### PR TITLE
gc: #396 globalize per-thread GC hook fn-ptr cells

### DIFF
--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -1652,10 +1652,22 @@ fn gc_owns_object_via_active_runtime(addr: usize) -> bool {
             .map(|g| g.as_deref().map(|gc| gc.is_managed_heap_object(addr)))
     }) {
         Ok(Some(r)) => r,
-        Ok(None) => majit_gc::gc_sync::gc_query_reentrant(|g| g.is_managed_heap_object(addr)),
+        Ok(None) => {
+            if majit_gc::gc_sync::is_initialized() {
+                majit_gc::gc_sync::gc_query_reentrant(|g| g.is_managed_heap_object(addr))
+            } else {
+                false
+            }
+        }
         Err(_) => CRANELIFT_ACTIVE_GC_RAW.with(|raw| match raw.get() {
             Some(ptr) => unsafe { (&*ptr).is_managed_heap_object(addr) },
-            None => majit_gc::gc_sync::gc_query_reentrant(|g| g.is_managed_heap_object(addr)),
+            None => {
+                if majit_gc::gc_sync::is_initialized() {
+                    majit_gc::gc_sync::gc_query_reentrant(|g| g.is_managed_heap_object(addr))
+                } else {
+                    false
+                }
+            }
         }),
     }
 }

--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -1647,9 +1647,10 @@ fn gc_owns_object_via_active_runtime(addr: usize) -> bool {
     // `gc_sync` read only for this immutable ownership query, matching the
     // read-only nature of RPython's descriptor call, instead of panicking
     // across the extern slowpath.
-    match CRANELIFT_ACTIVE_GC
-        .with(|cell| cell.try_borrow().map(|g| g.as_deref().map(|gc| gc.is_managed_heap_object(addr))))
-    {
+    match CRANELIFT_ACTIVE_GC.with(|cell| {
+        cell.try_borrow()
+            .map(|g| g.as_deref().map(|gc| gc.is_managed_heap_object(addr)))
+    }) {
         Ok(Some(r)) => r,
         Ok(None) => majit_gc::gc_sync::gc_query_reentrant(|g| g.is_managed_heap_object(addr)),
         Err(_) => CRANELIFT_ACTIVE_GC_RAW.with(|raw| match raw.get() {

--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -357,6 +357,14 @@ fn install_gc_box(mut gc: Box<dyn GcAllocator>) {
     let supports_guard_gc_type = gc.supports_guard_gc_type();
     set_cranelift_active_gc(Some(gc));
     set_cranelift_jitframe_type_id(jitframe_type_id);
+    register_active_hooks(supports_guard_gc_type);
+}
+
+/// Register all backend-agnostic `majit_gc::set_active_*` hooks to the
+/// cranelift trampolines. Shared by `install_gc_box` (test: also stores a
+/// box) and `install_gc_standalone` (production: hooks only, no box — the
+/// trampolines then route to the `gc_sync` singleton).
+fn register_active_hooks(supports_guard_gc_type: bool) {
     majit_gc::set_active_gc_guard_hooks(majit_gc::ActiveGcGuardHooks {
         check_is_object: Some(check_is_object_via_active_runtime),
         is_tagged_immediate: Some(is_tagged_immediate_via_active_runtime),
@@ -390,10 +398,19 @@ fn install_gc_box(mut gc: Box<dyn GcAllocator>) {
     );
 }
 
-/// Production path: install a `GcHandle` forwarding to the global singleton.
+/// Production path: register the `set_active_*` hooks WITHOUT storing a
+/// box. `CRANELIFT_ACTIVE_GC` stays `None`, so every trampoline routes to
+/// the process-global `gc_sync` singleton (the per-thread GC box is the
+/// free-threading gap R4 removes).
 pub fn install_gc_standalone() {
-    let handle: Box<dyn GcAllocator> = Box::new(majit_gc::GcHandle);
-    install_gc_box(handle);
+    let jitframe_type_id = majit_gc::gc_sync::gc_op(|gc| {
+        let id = ensure_jitframe_type_registered(gc);
+        gc.freeze_types();
+        id
+    });
+    let supports_guard_gc_type = majit_gc::gc_sync::gc_query(|gc| gc.supports_guard_gc_type());
+    set_cranelift_jitframe_type_id(jitframe_type_id);
+    register_active_hooks(supports_guard_gc_type);
 }
 
 /// Follow jf_forward chain to get the final jitframe address.
@@ -1392,21 +1409,24 @@ thread_local! {
 }
 
 fn with_cranelift_gc<R>(f: impl FnOnce(&mut dyn GcAllocator) -> R) -> Option<R> {
-    CRANELIFT_ACTIVE_GC.with(|cell| {
-        let mut guard = cell.borrow_mut();
-        match guard.as_deref_mut() {
-            Some(gc) => Some(f(gc)),
-            None => None,
-        }
-    })
+    if CRANELIFT_ACTIVE_GC.with(|cell| cell.borrow().is_some()) {
+        return CRANELIFT_ACTIVE_GC.with(|cell| {
+            let mut guard = cell.borrow_mut();
+            let raw: *mut dyn GcAllocator = guard.as_deref_mut()?;
+            // SAFETY: `guard` holds the borrow for the whole `f` call and
+            // these are non-reentrant top-level trampolines, so the
+            // reborrow is exclusive and outlives `f`.
+            Some(f(unsafe { &mut *raw }))
+        });
+    }
+    if majit_gc::gc_sync::is_initialized() {
+        return Some(majit_gc::gc_sync::gc_op(f));
+    }
+    None
 }
 
 fn with_cranelift_gc_required<R>(f: impl FnOnce(&mut dyn GcAllocator) -> R) -> R {
-    CRANELIFT_ACTIVE_GC.with(|cell| {
-        let mut guard = cell.borrow_mut();
-        let gc = guard.as_deref_mut().expect("missing active GC runtime");
-        f(gc)
-    })
+    with_cranelift_gc(f).expect("missing active GC runtime")
 }
 
 fn set_cranelift_active_gc(gc: Option<Box<dyn GcAllocator>>) {
@@ -1437,7 +1457,7 @@ fn set_cranelift_jitframe_type_id(type_id: Option<u32>) {
 }
 
 fn cranelift_gc_active() -> bool {
-    CRANELIFT_ACTIVE_GC.with(|cell| cell.borrow().is_some())
+    CRANELIFT_ACTIVE_GC.with(|cell| cell.borrow().is_some()) || majit_gc::gc_sync::is_initialized()
 }
 
 /// `majit_gc::CheckIsObjectFn` installed by `set_gc_allocator`. Dispatches
@@ -1602,43 +1622,41 @@ fn gc_write_barrier_via_active_runtime(obj: GcRef) {
 /// `try_gc_alloc_stable`-allocated blocks from `std::alloc`-backed
 /// fallback blocks during the L1/L2 stepping-stone window.
 fn id_or_identityhash_via_active_runtime(addr: usize) -> usize {
-    CRANELIFT_ACTIVE_GC.with(|cell| {
+    let via_box = CRANELIFT_ACTIVE_GC.with(|cell| {
         let mut guard = match cell.try_borrow_mut() {
             Ok(guard) => guard,
-            Err(_) => return addr,
+            Err(_) => return Some(addr),
         };
-        match guard.as_deref_mut() {
-            Some(gc) => gc.id_or_identityhash(addr),
-            None => addr,
-        }
-    })
+        guard.as_deref_mut().map(|gc| gc.id_or_identityhash(addr))
+    });
+    if let Some(r) = via_box {
+        return r;
+    }
+    if majit_gc::gc_sync::is_initialized() {
+        return majit_gc::gc_sync::gc_op(|gc| gc.id_or_identityhash(addr));
+    }
+    addr
 }
 
 fn gc_owns_object_via_active_runtime(addr: usize) -> bool {
-    CRANELIFT_ACTIVE_GC.with(|cell| {
-        let mut guard = match cell.try_borrow_mut() {
-            Ok(guard) => guard,
-            Err(_) => {
-                // Structural adaptation: RPython's GC descriptor can be
-                // queried reentrantly while a collection is walking extra
-                // roots. Pyre stores the active cranelift GC in a Rust
-                // `RefCell`; allocation slowpaths hold the mutable borrow
-                // while those root walkers may call
-                // `gc_current_object_address`. Use the raw pointer only
-                // for this immutable ownership query, matching the
-                // read-only nature of RPython's descriptor call, instead
-                // of panicking across the extern slowpath.
-                return CRANELIFT_ACTIVE_GC_RAW.with(|raw| match raw.get() {
-                    Some(ptr) => unsafe { (&*ptr).is_managed_heap_object(addr) },
-                    None => false,
-                });
-            }
-        };
-        guard
-            .as_deref_mut()
-            .map(|gc| gc.is_managed_heap_object(addr))
-            .unwrap_or(false)
-    })
+    // Structural adaptation: RPython's GC descriptor can be queried
+    // reentrantly while a collection is walking extra roots. Pyre stores
+    // the active cranelift GC in a Rust `RefCell`; allocation slowpaths
+    // hold the mutable borrow while those root walkers may call
+    // `gc_current_object_address`. Use the raw pointer / reentrant
+    // `gc_sync` read only for this immutable ownership query, matching the
+    // read-only nature of RPython's descriptor call, instead of panicking
+    // across the extern slowpath.
+    match CRANELIFT_ACTIVE_GC
+        .with(|cell| cell.try_borrow().map(|g| g.as_deref().map(|gc| gc.is_managed_heap_object(addr))))
+    {
+        Ok(Some(r)) => r,
+        Ok(None) => majit_gc::gc_sync::gc_query_reentrant(|g| g.is_managed_heap_object(addr)),
+        Err(_) => CRANELIFT_ACTIVE_GC_RAW.with(|raw| match raw.get() {
+            Some(ptr) => unsafe { (&*ptr).is_managed_heap_object(addr) },
+            None => majit_gc::gc_sync::gc_query_reentrant(|g| g.is_managed_heap_object(addr)),
+        }),
+    }
 }
 
 /// Returns true when the active GC was present and roots were

--- a/majit/majit-backend-dynasm/src/aarch64/assembler.rs
+++ b/majit/majit-backend-dynasm/src/aarch64/assembler.rs
@@ -5781,11 +5781,7 @@ impl<'a> AssemblerARM64<'a> {
         is_array: bool,
         loc_index: Option<crate::regloc::RegLoc>,
     ) {
-        let wb = match crate::runner::DYNASM_ACTIVE_GC.with(|cell| {
-            cell.borrow()
-                .as_ref()
-                .map(|gc| gc.get_write_barrier_descr())
-        }) {
+        let wb = match crate::runner::with_dynasm_active_gc(|gc| gc.get_write_barrier_descr()) {
             Some(Some(wb)) => wb,
             _ => return,
         };

--- a/majit/majit-backend-dynasm/src/runner.rs
+++ b/majit/majit-backend-dynasm/src/runner.rs
@@ -113,11 +113,57 @@ thread_local! {
         const { std::cell::Cell::new(None) };
 }
 
-fn with_dynasm_active_gc<R>(f: impl FnOnce(&dyn majit_gc::GcAllocator) -> R) -> Option<R> {
-    DYNASM_ACTIVE_GC.with(|cell| {
-        let guard = cell.borrow();
-        guard.as_deref().map(f)
-    })
+/// Read-only GC query for the guard hooks and codegen helpers.
+///
+/// - **Test box present** (`DYNASM_ACTIVE_GC` is `Some`): a test owns the
+///   GC directly — apply `f` to the boxed allocator.
+/// - **No box, `gc_sync` initialized** (production): route to the
+///   process-global singleton via `gc_query_reentrant`. These hooks can
+///   fire during a collection's guard evaluation / extra-root walk, so
+///   the reentrant read-only path (no second `gc_mutex`, no second
+///   `&mut`) is required.
+/// - **No box, `gc_sync` uninitialized** (no GC at all — unit tests):
+///   returns `None` so callers keep their existing `.unwrap_or(default)`
+///   / `.flatten()` behaviour.
+pub(crate) fn with_dynasm_active_gc<R>(f: impl Fn(&dyn majit_gc::GcAllocator) -> R) -> Option<R> {
+    if let Some(r) = DYNASM_ACTIVE_GC.with(|cell| cell.borrow().as_deref().map(&f)) {
+        return Some(r);
+    }
+    if majit_gc::gc_sync::is_initialized() {
+        return Some(majit_gc::gc_sync::gc_query_reentrant(f));
+    }
+    None
+}
+
+/// `&mut` counterpart of [`with_dynasm_active_gc`] for GC mutations
+/// (allocation, write barriers). Same three-way routing: test box →
+/// box; production (no box, `gc_sync` initialized) → `gc_sync::gc_op`;
+/// no GC at all → `None` so callers keep their non-GC fallback.
+///
+/// These callers run at the top level of a JIT/blackhole trampoline
+/// (mutator context), never inside a collection, so the non-reentrant
+/// `gc_op` is correct here.
+pub(crate) fn with_dynasm_active_gc_mut<R>(
+    f: impl FnOnce(&mut dyn majit_gc::GcAllocator) -> R,
+) -> Option<R> {
+    if DYNASM_ACTIVE_GC.with(|cell| cell.borrow().is_some()) {
+        return DYNASM_ACTIVE_GC.with(|cell| {
+            let mut guard = cell.borrow_mut();
+            let raw: *mut dyn majit_gc::GcAllocator = guard.as_deref_mut()?;
+            // SAFETY: `guard` holds the `RefCell` borrow for the whole
+            // `f` call, and these callers are non-reentrant top-level
+            // mutator trampolines, so the reborrow is exclusive and
+            // outlives `f`. The raw round-trip is what lets the boxed
+            // `dyn + 'static` allocator satisfy the `FnOnce(&mut dyn
+            // GcAllocator)` HRTB bound (same shape `gc_op` gets from its
+            // `&'static mut` singleton).
+            Some(f(unsafe { &mut *raw }))
+        });
+    }
+    if majit_gc::gc_sync::is_initialized() {
+        return Some(majit_gc::gc_sync::gc_op(f));
+    }
+    None
 }
 
 /// Store a GC allocator in the dynasm backend thread-local and register
@@ -125,19 +171,11 @@ fn with_dynasm_active_gc<R>(f: impl FnOnce(&dyn majit_gc::GcAllocator) -> R) -> 
 /// requiring a `DynasmBackend` instance.  This allows the GC subsystem
 /// to be installed at boot (via `init_gc_subsystem`) before the JIT
 /// driver is constructed.
-/// Install a GC handle into TLS and register all `set_active_*` hooks.
-/// Shared by both `install_gc_standalone` (production: GcHandle to global
-/// singleton) and `set_gc_allocator` (tests: direct Box ownership).
-fn install_gc_box(gc: Box<dyn majit_gc::GcAllocator>) {
-    let supports_guard_gc_type = gc.supports_guard_gc_type();
-    DYNASM_ACTIVE_GC.with(|cell| {
-        let mut guard = cell.borrow_mut();
-        *guard = Some(gc);
-        let raw = guard
-            .as_deref_mut()
-            .map(|g| g as *mut dyn majit_gc::GcAllocator);
-        DYNASM_ACTIVE_GC_RAW.with(|raw_cell| raw_cell.set(raw));
-    });
+/// Register all backend-agnostic `majit_gc::set_active_*` hooks to the
+/// dynasm trampolines. Shared by `install_gc_box` (test path: also stores
+/// a box in TLS) and `install_gc_standalone` (production: hooks only, no
+/// box — the trampolines then route to the `gc_sync` singleton).
+fn register_active_hooks(supports_guard_gc_type: bool) {
     majit_gc::set_active_gc_guard_hooks(majit_gc::ActiveGcGuardHooks {
         check_is_object: Some(dynasm_check_is_object),
         is_tagged_immediate: Some(dynasm_is_tagged_immediate),
@@ -168,12 +206,32 @@ fn install_gc_box(gc: Box<dyn majit_gc::GcAllocator>) {
     );
 }
 
-/// Production path: install a `GcHandle` (zero-size, routes through
-/// `gc_sync`) into TLS and register all `set_active_*` hooks.
+/// Install a GC allocator box into TLS and register all `set_active_*`
+/// hooks. Test path only — `set_gc_allocator` hands ownership of a real
+/// allocator to the backend thread. Production uses
+/// [`install_gc_standalone`], which registers the same hooks WITHOUT a
+/// box so the trampolines fall through to `gc_sync`.
+fn install_gc_box(gc: Box<dyn majit_gc::GcAllocator>) {
+    let supports_guard_gc_type = gc.supports_guard_gc_type();
+    DYNASM_ACTIVE_GC.with(|cell| {
+        let mut guard = cell.borrow_mut();
+        *guard = Some(gc);
+        let raw = guard
+            .as_deref_mut()
+            .map(|g| g as *mut dyn majit_gc::GcAllocator);
+        DYNASM_ACTIVE_GC_RAW.with(|raw_cell| raw_cell.set(raw));
+    });
+    register_active_hooks(supports_guard_gc_type);
+}
+
+/// Production path: register all `set_active_*` hooks WITHOUT storing a
+/// box. `DYNASM_ACTIVE_GC` stays `None`, so every trampoline routes to
+/// the process-global `gc_sync` singleton (the per-thread GC box is the
+/// free-threading gap R4 removes).
 pub fn install_gc_standalone() {
-    let mut handle: Box<dyn majit_gc::GcAllocator> = Box::new(majit_gc::GcHandle);
-    handle.freeze_types();
-    install_gc_box(handle);
+    majit_gc::gc_sync::gc_op(|gc| gc.freeze_types());
+    let supports_guard_gc_type = majit_gc::gc_sync::gc_query(|gc| gc.supports_guard_gc_type());
+    register_active_hooks(supports_guard_gc_type);
 }
 
 /// Clear both `DYNASM_ACTIVE_GC` and `DYNASM_ACTIVE_GC_RAW`. Callers
@@ -307,13 +365,14 @@ fn dynasm_alloc_nursery_typed(type_id: u32, size: usize) -> GcRef {
     // falls back to old-gen on nursery full — stable across minor
     // collections that fire between here and the caller's store into
     // a tracked slot.
-    DYNASM_ACTIVE_GC.with(|cell| {
-        let mut guard = cell.borrow_mut();
-        match guard.as_deref_mut() {
-            Some(gc) => gc.alloc_nursery_no_collect_typed(type_id, size),
-            None => GcRef(0),
-        }
-    })
+    if let Some(r) = DYNASM_ACTIVE_GC.with(|c| {
+        c.borrow_mut()
+            .as_deref_mut()
+            .map(|g| g.alloc_nursery_no_collect_typed(type_id, size))
+    }) {
+        return r;
+    }
+    majit_gc::gc_sync::gc_op(|g| g.alloc_nursery_no_collect_typed(type_id, size))
 }
 
 /// Host-side *collecting* nursery allocation trampoline. Unlike
@@ -324,13 +383,14 @@ fn dynasm_alloc_nursery_typed(type_id: u32, size: usize) -> GcRef {
 /// allocation — so the embedded minor cycle is safe and dead bigints are
 /// reclaimed instead of accumulating in old-gen.
 fn dynasm_alloc_nursery_collecting_typed(type_id: u32, size: usize) -> GcRef {
-    DYNASM_ACTIVE_GC.with(|cell| {
-        let mut guard = cell.borrow_mut();
-        match guard.as_deref_mut() {
-            Some(gc) => gc.alloc_nursery_typed(type_id, size),
-            None => GcRef(0),
-        }
-    })
+    if let Some(r) = DYNASM_ACTIVE_GC.with(|c| {
+        c.borrow_mut()
+            .as_deref_mut()
+            .map(|g| g.alloc_nursery_typed(type_id, size))
+    }) {
+        return r;
+    }
+    majit_gc::gc_sync::gc_op(|g| g.alloc_nursery_typed(type_id, size))
 }
 
 /// Host-side old-gen external-byte trampoline — charges off-heap
@@ -338,19 +398,31 @@ fn dynasm_alloc_nursery_collecting_typed(type_id: u32, size: usize) -> GcRef {
 /// active GC when the initialized object landed in old-gen. Never forces a
 /// minor collection.
 fn dynasm_charge_oldgen_external(obj_addr: usize, bytes: usize) {
-    DYNASM_ACTIVE_GC.with(|cell| {
-        if let Some(gc) = cell.borrow_mut().as_deref_mut() {
-            gc.charge_oldgen_external(obj_addr, bytes);
-        }
-    })
+    if DYNASM_ACTIVE_GC
+        .with(|c| {
+            c.borrow_mut()
+                .as_deref_mut()
+                .map(|g| g.charge_oldgen_external(obj_addr, bytes))
+        })
+        .is_some()
+    {
+        return;
+    }
+    majit_gc::gc_sync::gc_op(|g| g.charge_oldgen_external(obj_addr, bytes));
 }
 
 fn dynasm_charge_memory_pressure(bytes: usize) {
-    DYNASM_ACTIVE_GC.with(|cell| {
-        if let Some(gc) = cell.borrow_mut().as_deref_mut() {
-            gc.charge_memory_pressure(bytes);
-        }
-    })
+    if DYNASM_ACTIVE_GC
+        .with(|c| {
+            c.borrow_mut()
+                .as_deref_mut()
+                .map(|g| g.charge_memory_pressure(bytes))
+        })
+        .is_some()
+    {
+        return;
+    }
+    majit_gc::gc_sync::gc_op(|g| g.charge_memory_pressure(bytes));
 }
 
 /// Host-side old-gen allocation trampoline. Used by
@@ -360,13 +432,14 @@ fn dynasm_charge_memory_pressure(bytes: usize) {
 /// (non-moving), so the returned pointer is stable across minor and
 /// major collections.
 fn dynasm_alloc_oldgen_typed(type_id: u32, size: usize) -> GcRef {
-    DYNASM_ACTIVE_GC.with(|cell| {
-        let mut guard = cell.borrow_mut();
-        match guard.as_deref_mut() {
-            Some(gc) => gc.alloc_oldgen_typed(type_id, size),
-            None => GcRef(0),
-        }
-    })
+    if let Some(r) = DYNASM_ACTIVE_GC.with(|c| {
+        c.borrow_mut()
+            .as_deref_mut()
+            .map(|g| g.alloc_oldgen_typed(type_id, size))
+    }) {
+        return r;
+    }
+    majit_gc::gc_sync::gc_op(|g| g.alloc_oldgen_typed(type_id, size))
 }
 
 /// User-level `gc.collect()` trampoline — drives `GcAllocator::collect_full`
@@ -377,12 +450,13 @@ fn dynasm_alloc_oldgen_typed(type_id: u32, size: usize) -> GcRef {
 /// Python value stack, or on the shadow stack — Rust-stack PyObjectRef
 /// in nursery would dangle after the embedded minor cycle.
 fn dynasm_collect_full() {
-    DYNASM_ACTIVE_GC.with(|cell| {
-        let mut guard = cell.borrow_mut();
-        if let Some(gc) = guard.as_deref_mut() {
-            gc.collect_full();
-        }
-    });
+    if DYNASM_ACTIVE_GC
+        .with(|c| c.borrow_mut().as_deref_mut().map(|g| g.collect_full()))
+        .is_some()
+    {
+        return;
+    }
+    majit_gc::gc_sync::gc_op(|g| g.collect_full());
 }
 
 /// Non-moving old-gen-only major. Reclaims stable-allocated interp int/float
@@ -390,12 +464,17 @@ fn dynasm_collect_full() {
 /// an active JIT (nursery non-empty) — unlike [`dynasm_collect_full`], whose
 /// embedded minor would relocate a Rust-stack nursery PyObjectRef.
 fn dynasm_collect_oldgen_nonmoving() {
-    DYNASM_ACTIVE_GC.with(|cell| {
-        let mut guard = cell.borrow_mut();
-        if let Some(gc) = guard.as_deref_mut() {
-            gc.collect_oldgen_nonmoving();
-        }
-    });
+    if DYNASM_ACTIVE_GC
+        .with(|c| {
+            c.borrow_mut()
+                .as_deref_mut()
+                .map(|g| g.collect_oldgen_nonmoving())
+        })
+        .is_some()
+    {
+        return;
+    }
+    majit_gc::gc_sync::gc_op(|g| g.collect_oldgen_nonmoving());
 }
 
 fn dynasm_register_finalizer(fq_index: usize, obj: GcRef, trigger: majit_gc::FinalizerTriggerFn) {
@@ -419,13 +498,12 @@ fn dynasm_finalizer_next_dead(fq_index: usize) -> Option<GcRef> {
 
 /// Report `(oldgen_total, nursery_used)` for the interpreter GC safepoint.
 fn dynasm_heap_stats() -> (usize, usize) {
-    DYNASM_ACTIVE_GC.with(|cell| {
-        let mut guard = cell.borrow_mut();
-        match guard.as_deref_mut() {
-            Some(gc) => gc.heap_byte_stats(),
-            None => (0, 0),
-        }
-    })
+    if let Some(r) =
+        DYNASM_ACTIVE_GC.with(|c| c.borrow_mut().as_deref_mut().map(|g| g.heap_byte_stats()))
+    {
+        return r;
+    }
+    majit_gc::gc_sync::gc_op(|g| g.heap_byte_stats())
 }
 
 /// Host-side root-register trampoline. Bridges
@@ -435,46 +513,57 @@ fn dynasm_heap_stats() -> (usize, usize) {
 /// Caller must keep `slot` valid until [`dynasm_gc_remove_root`] is
 /// called with the same pointer.
 unsafe fn dynasm_gc_add_root(slot: *mut GcRef) {
-    DYNASM_ACTIVE_GC.with(|cell| {
-        let mut guard = cell.borrow_mut();
-        if let Some(gc) = guard.as_deref_mut() {
-            unsafe { gc.add_root(slot) };
-        }
-    });
+    if DYNASM_ACTIVE_GC
+        .with(|c| {
+            c.borrow_mut()
+                .as_deref_mut()
+                .map(|g| unsafe { g.add_root(slot) })
+        })
+        .is_some()
+    {
+        return;
+    }
+    majit_gc::gc_sync::gc_op(|g| unsafe { g.add_root(slot) });
 }
 
 /// Companion to [`dynasm_gc_add_root`].
 fn dynasm_gc_remove_root(slot: *mut GcRef) {
-    DYNASM_ACTIVE_GC.with(|cell| {
-        let mut guard = cell.borrow_mut();
-        if let Some(gc) = guard.as_deref_mut() {
-            gc.remove_root(slot);
-        }
-    });
+    if DYNASM_ACTIVE_GC
+        .with(|c| c.borrow_mut().as_deref_mut().map(|g| g.remove_root(slot)))
+        .is_some()
+    {
+        return;
+    }
+    majit_gc::gc_sync::gc_op(|g| g.remove_root(slot));
 }
 
 /// Host-side write-barrier trampoline for GC-managed objects updated
 /// outside compiled code.
 fn dynasm_gc_write_barrier(obj: GcRef) {
-    DYNASM_ACTIVE_GC.with(|cell| {
-        let mut guard = cell.borrow_mut();
-        if let Some(gc) = guard.as_deref_mut() {
-            gc.write_barrier(obj);
-        }
-    });
+    if DYNASM_ACTIVE_GC
+        .with(|c| c.borrow_mut().as_deref_mut().map(|g| g.write_barrier(obj)))
+        .is_some()
+    {
+        return;
+    }
+    majit_gc::gc_sync::gc_op(|g| g.write_barrier(obj));
 }
 
 fn dynasm_id_or_identityhash(addr: usize) -> usize {
-    DYNASM_ACTIVE_GC.with(|cell| {
+    // Keep the defensive `try_borrow_mut`: a borrow already held by an
+    // in-progress alloc means the test box is busy, so fall back to the
+    // raw `addr` (this is a top-level op, never reentrant).
+    let via_box = DYNASM_ACTIVE_GC.with(|cell| {
         let mut guard = match cell.try_borrow_mut() {
             Ok(guard) => guard,
-            Err(_) => return addr,
+            Err(_) => return Some(addr),
         };
-        match guard.as_deref_mut() {
-            Some(gc) => gc.id_or_identityhash(addr),
-            None => addr,
-        }
-    })
+        guard.as_deref_mut().map(|gc| gc.id_or_identityhash(addr))
+    });
+    if let Some(r) = via_box {
+        return r;
+    }
+    majit_gc::gc_sync::gc_op(|g| g.id_or_identityhash(addr))
 }
 
 /// Host-side `is_managed_heap_object` trampoline. Lets host-side
@@ -484,31 +573,27 @@ fn dynasm_id_or_identityhash(addr: usize) -> usize {
 /// `false` when no GC is installed (caller falls through to
 /// `std::alloc::dealloc`).
 fn dynasm_gc_owns_object(addr: usize) -> bool {
-    DYNASM_ACTIVE_GC.with(|cell| {
-        let guard = match cell.try_borrow() {
-            Ok(guard) => guard,
-            Err(_) => {
-                // Structural adaptation: RPython's GC descriptor is a
-                // normal object reference and `gc_current_object_address`
-                // can query ownership while a collection is already in
-                // progress. Pyre stores the active dynasm GC behind a
-                // Rust `RefCell`; during `alloc_nursery` the mutable
-                // borrow is held while extra-root walkers may ask whether
-                // a mapdict key is GC-managed. Use the raw pointer only
-                // for this immutable ownership query, matching the
-                // read-only nature of RPython's descriptor call, instead
-                // of panicking across the extern "C" slowpath.
-                return DYNASM_ACTIVE_GC_RAW.with(|raw| match raw.get() {
-                    Some(ptr) => unsafe { (&*ptr).is_managed_heap_object(addr) },
-                    None => false,
-                });
-            }
-        };
-        match guard.as_deref() {
-            Some(gc) => gc.is_managed_heap_object(addr),
-            None => false,
-        }
-    })
+    // Structural adaptation: RPython's GC descriptor is a normal object
+    // reference and `gc_current_object_address` can query ownership while
+    // a collection is already in progress. Pyre stores the active dynasm
+    // GC behind a Rust `RefCell` (test box) or in the process-global
+    // `gc_sync` singleton (production). This read-only ownership query can
+    // fire reentrantly from an extra-root walker mid-collection, so:
+    //   - `Ok(Some)`: a test box is present and free-borrowable → use it.
+    //   - `Ok(None)`: no box (production) → route to `gc_sync` reentrantly.
+    //   - `Err`: the test box's mutable borrow is held by an in-progress
+    //     alloc → reach it through the raw mirror (read-only), or fall
+    //     back to `gc_sync` if there is no box at all.
+    match DYNASM_ACTIVE_GC
+        .with(|c| c.try_borrow().map(|g| g.as_deref().map(|gc| gc.is_managed_heap_object(addr))))
+    {
+        Ok(Some(r)) => r,
+        Ok(None) => majit_gc::gc_sync::gc_query_reentrant(|g| g.is_managed_heap_object(addr)),
+        Err(_) => DYNASM_ACTIVE_GC_RAW.with(|raw| match raw.get() {
+            Some(p) => unsafe { (&*p).is_managed_heap_object(addr) },
+            None => majit_gc::gc_sync::gc_query_reentrant(|g| g.is_managed_heap_object(addr)),
+        }),
+    }
 }
 
 /// `gc.py:51` malloc-helper OOM signaling.
@@ -546,12 +631,8 @@ fn oom_signal_if_zero(result: u64) -> u64 {
 /// Returns payload pointer (after GcHeader), matching fast-path semantics.
 pub extern "C" fn dynasm_nursery_slowpath(total_size: u64) -> u64 {
     let gc_hdr = majit_gc::header::GcHeader::SIZE;
-    let result = DYNASM_ACTIVE_GC.with(|cell| {
-        let mut guard = cell.borrow_mut();
-        guard
-            .as_mut()
-            .map(|gc| gc.alloc_nursery(total_size as usize - gc_hdr).0 as u64)
-    });
+    let result =
+        with_dynasm_active_gc_mut(|gc| gc.alloc_nursery(total_size as usize - gc_hdr).0 as u64);
     let ptr = result.unwrap_or_else(|| unsafe {
         // `libc::calloc` returns NULL on real host OOM; preserve that
         // NULL through to the trampoline's `TEST rax, rax; JZ propagate`
@@ -576,18 +657,14 @@ pub extern "C" fn dynasm_nursery_slowpath(total_size: u64) -> u64 {
 /// through the trailing array, i.e. it excludes the GC header that the
 /// allocator prepends internally.
 pub extern "C" fn dynasm_nursery_slowpath_jitframe(frame_size: u64) -> u64 {
-    DYNASM_ACTIVE_GC.with(|cell| {
-        let mut guard = cell.borrow_mut();
-        if let Some(gc) = guard.as_mut() {
-            if let Some(type_id) = crate::jitframe_gc_type_id() {
-                gc.alloc_nursery_typed(type_id, frame_size as usize).0 as u64
-            } else {
-                gc.alloc_nursery(frame_size as usize).0 as u64
-            }
+    with_dynasm_active_gc_mut(|gc| {
+        if let Some(type_id) = crate::jitframe_gc_type_id() {
+            gc.alloc_nursery_typed(type_id, frame_size as usize).0 as u64
         } else {
-            unsafe { libc::calloc(1, frame_size as usize) as u64 }
+            gc.alloc_nursery(frame_size as usize).0 as u64
         }
     })
+    .unwrap_or_else(|| unsafe { libc::calloc(1, frame_size as usize) as u64 })
 }
 
 /// `_build_malloc_slowpath(kind='var')` parity: varsize nursery
@@ -621,12 +698,9 @@ pub extern "C" fn dynasm_nursery_slowpath_varsize(
     length: u64,
 ) -> u64 {
     let gc_hdr = majit_gc::header::GcHeader::SIZE;
-    let result = DYNASM_ACTIVE_GC.with(|cell| {
-        let mut guard = cell.borrow_mut();
-        guard.as_mut().map(|gc| {
-            gc.alloc_varsize(base_size as usize, item_size as usize, length as usize)
-                .0 as u64
-        })
+    let result = with_dynasm_active_gc_mut(|gc| {
+        gc.alloc_varsize(base_size as usize, item_size as usize, length as usize)
+            .0 as u64
     });
     result.unwrap_or_else(|| {
         let total = base_size as usize + item_size as usize * length as usize + gc_hdr;
@@ -678,19 +752,16 @@ fn dynasm_alloc_varsize_typed_and_set_len(
     length_ofs: usize,
     length: usize,
 ) -> u64 {
-    let result = DYNASM_ACTIVE_GC.with(|cell| {
-        let mut guard = cell.borrow_mut();
-        guard.as_mut().map(|gc| {
-            let obj = gc.alloc_varsize_typed(type_id, base_size, item_size, length);
-            if obj.is_null() {
-                0
-            } else {
-                unsafe {
-                    *((obj.0 as *mut u8).add(length_ofs) as *mut usize) = length;
-                }
-                obj.0 as u64
+    let result = with_dynasm_active_gc_mut(|gc| {
+        let obj = gc.alloc_varsize_typed(type_id, base_size, item_size, length);
+        if obj.is_null() {
+            0
+        } else {
+            unsafe {
+                *((obj.0 as *mut u8).add(length_ofs) as *mut usize) = length;
             }
-        })
+            obj.0 as u64
+        }
     });
     result.unwrap_or_else(|| {
         dynasm_raw_varsize_alloc_typed_and_set_len(
@@ -759,12 +830,9 @@ fn dynasm_alloc_oldgen_varsize_typed_and_set_len(
 }
 
 fn dynasm_alloc_oldgen_typed_or_raw(type_id: u32, payload_size: usize) -> u64 {
-    let result = DYNASM_ACTIVE_GC.with(|cell| {
-        let mut guard = cell.borrow_mut();
-        guard.as_mut().map(|gc| {
-            let obj = gc.alloc_oldgen_typed(type_id, payload_size);
-            if obj.is_null() { 0 } else { obj.0 as u64 }
-        })
+    let result = with_dynasm_active_gc_mut(|gc| {
+        let obj = gc.alloc_oldgen_typed(type_id, payload_size);
+        if obj.is_null() { 0 } else { obj.0 as u64 }
     });
     // gc.py:51 contract: helper returns NULL on OOM so
     // CHECK_MEMORY_ERROR can convert it into a MemoryError.  Only
@@ -824,23 +892,15 @@ pub extern "C" fn dynasm_malloc_unicode(type_id: u64, length: u64) -> u64 {
 /// opassembler.py:956-976: non-array write barrier slow path.
 /// Calls gc.write_barrier(obj) which is the generic barrier.
 pub extern "C" fn dynasm_write_barrier(obj_ptr: u64) {
-    DYNASM_ACTIVE_GC.with(|cell| {
-        let mut guard = cell.borrow_mut();
-        if let Some(gc) = guard.as_mut() {
-            gc.write_barrier(majit_ir::GcRef(obj_ptr as usize));
-        }
-    });
+    with_dynasm_active_gc_mut(|gc| gc.write_barrier(majit_ir::GcRef(obj_ptr as usize)));
 }
 
 /// opassembler.py:953-960: array write barrier slow path.
 /// Calls jit_remember_young_pointer_from_array(obj) which handles
 /// the CARDS_SET transition for HAS_CARDS arrays.
 pub extern "C" fn dynasm_write_barrier_from_array(obj_ptr: u64) {
-    DYNASM_ACTIVE_GC.with(|cell| {
-        let mut guard = cell.borrow_mut();
-        if let Some(gc) = guard.as_mut() {
-            gc.jit_remember_young_pointer_from_array(majit_ir::GcRef(obj_ptr as usize));
-        }
+    with_dynasm_active_gc_mut(|gc| {
+        gc.jit_remember_young_pointer_from_array(majit_ir::GcRef(obj_ptr as usize))
     });
 }
 
@@ -857,13 +917,10 @@ fn dynasm_write_barrier_if_managed(obj_ptr: u64) {
     if obj_ptr == 0 {
         return;
     }
-    DYNASM_ACTIVE_GC.with(|cell| {
-        let mut guard = cell.borrow_mut();
-        if let Some(gc) = guard.as_mut() {
-            let obj = majit_ir::GcRef(obj_ptr as usize);
-            if gc.is_managed_heap_object(obj.0) {
-                gc.write_barrier(obj);
-            }
+    with_dynasm_active_gc_mut(|gc| {
+        let obj = majit_ir::GcRef(obj_ptr as usize);
+        if gc.is_managed_heap_object(obj.0) {
+            gc.write_barrier(obj);
         }
     });
 }
@@ -1420,7 +1477,7 @@ impl DynasmBackend {
         const_pool: &majit_ir::ConstMap<majit_ir::Const>,
     ) -> indexmap::IndexMap<i64, u32> {
         let mut table = indexmap::IndexMap::new();
-        if self.vtable_offset.is_some() || DYNASM_ACTIVE_GC.with(|cell| cell.borrow().is_none()) {
+        if self.vtable_offset.is_some() || with_dynasm_active_gc(|_| ()).is_none() {
             // vtable_offset path doesn't need typeid lookups; without a
             // gc_ll_descr there is nothing to resolve anyway.
             return table;
@@ -1463,7 +1520,7 @@ impl DynasmBackend {
         ops: &[Op],
     ) -> indexmap::IndexMap<i64, (i64, i64)> {
         let mut table = indexmap::IndexMap::new();
-        if DYNASM_ACTIVE_GC.with(|cell| cell.borrow().is_none()) {
+        if with_dynasm_active_gc(|_| ()).is_none() {
             return table;
         }
         for op in ops {

--- a/majit/majit-backend-dynasm/src/runner.rs
+++ b/majit/majit-backend-dynasm/src/runner.rs
@@ -343,11 +343,18 @@ pub(crate) fn new_via_gc_enabled() -> bool {
 /// Compiled-code `New` allocation trampoline. Called from the machine code
 /// emitted by `genop_new` / `genop_new_with_vtable` when `new_via_gc_enabled`.
 /// Routes through the active GC's nursery allocator (mirroring cranelift's
-/// `gc_alloc_nursery_shim`); falls back to `malloc` when no GC is installed.
+/// `gc_alloc_nursery_shim`), including the process-global singleton; falls back
+/// to `malloc` when no GC is installed.
 pub(crate) extern "C" fn dynasm_new_alloc(size: usize) -> *mut u8 {
     DYNASM_ACTIVE_GC.with(|cell| match cell.borrow_mut().as_deref_mut() {
         Some(gc) => gc.alloc_nursery(size).0 as *mut u8,
-        None => unsafe { libc::malloc(size) as *mut u8 },
+        None => {
+            if majit_gc::gc_sync::is_initialized() {
+                majit_gc::gc_sync::gc_op(|g| g.alloc_nursery(size).0 as *mut u8)
+            } else {
+                unsafe { libc::malloc(size) as *mut u8 }
+            }
+        }
     })
 }
 

--- a/majit/majit-backend-dynasm/src/runner.rs
+++ b/majit/majit-backend-dynasm/src/runner.rs
@@ -584,9 +584,10 @@ fn dynasm_gc_owns_object(addr: usize) -> bool {
     //   - `Err`: the test box's mutable borrow is held by an in-progress
     //     alloc → reach it through the raw mirror (read-only), or fall
     //     back to `gc_sync` if there is no box at all.
-    match DYNASM_ACTIVE_GC
-        .with(|c| c.try_borrow().map(|g| g.as_deref().map(|gc| gc.is_managed_heap_object(addr))))
-    {
+    match DYNASM_ACTIVE_GC.with(|c| {
+        c.try_borrow()
+            .map(|g| g.as_deref().map(|gc| gc.is_managed_heap_object(addr)))
+    }) {
         Ok(Some(r)) => r,
         Ok(None) => majit_gc::gc_sync::gc_query_reentrant(|g| g.is_managed_heap_object(addr)),
         Err(_) => DYNASM_ACTIVE_GC_RAW.with(|raw| match raw.get() {

--- a/majit/majit-backend-dynasm/src/runner.rs
+++ b/majit/majit-backend-dynasm/src/runner.rs
@@ -596,10 +596,22 @@ fn dynasm_gc_owns_object(addr: usize) -> bool {
             .map(|g| g.as_deref().map(|gc| gc.is_managed_heap_object(addr)))
     }) {
         Ok(Some(r)) => r,
-        Ok(None) => majit_gc::gc_sync::gc_query_reentrant(|g| g.is_managed_heap_object(addr)),
+        Ok(None) => {
+            if majit_gc::gc_sync::is_initialized() {
+                majit_gc::gc_sync::gc_query_reentrant(|g| g.is_managed_heap_object(addr))
+            } else {
+                false
+            }
+        }
         Err(_) => DYNASM_ACTIVE_GC_RAW.with(|raw| match raw.get() {
             Some(p) => unsafe { (&*p).is_managed_heap_object(addr) },
-            None => majit_gc::gc_sync::gc_query_reentrant(|g| g.is_managed_heap_object(addr)),
+            None => {
+                if majit_gc::gc_sync::is_initialized() {
+                    majit_gc::gc_sync::gc_query_reentrant(|g| g.is_managed_heap_object(addr))
+                } else {
+                    false
+                }
+            }
         }),
     }
 }

--- a/majit/majit-backend-dynasm/src/x86/assembler.rs
+++ b/majit/majit-backend-dynasm/src/x86/assembler.rs
@@ -7648,11 +7648,10 @@ impl<'a> Assembler386<'a> {
     /// barrier when card marking exists; otherwise it falls back to the generic
     /// write barrier.
     fn emit_setarrayitem_gc_write_barrier(&mut self, arglocs: &[Loc]) {
-        let use_array_barrier = crate::runner::with_dynasm_active_gc(|gc| {
-            gc.get_write_barrier_descr()
-        })
-        .flatten()
-        .is_some_and(|wb| wb.jit_wb_cards_set != 0);
+        let use_array_barrier =
+            crate::runner::with_dynasm_active_gc(|gc| gc.get_write_barrier_descr())
+                .flatten()
+                .is_some_and(|wb| wb.jit_wb_cards_set != 0);
         self.emit_write_barrier_fastpath_kind(arglocs, use_array_barrier);
     }
 

--- a/majit/majit-backend-dynasm/src/x86/assembler.rs
+++ b/majit/majit-backend-dynasm/src/x86/assembler.rs
@@ -395,11 +395,8 @@ fn build_malloc_slowpath_body(asm: &mut Assembler, slowpath_fn: i64, propagate_p
     // share): non-array write barrier on the reloaded jf so subsequent
     // Ref writes into frame slots are tracked by minor GC.  The barrier
     // body is conditional on the GC exposing a write-barrier descr.
-    let wb_descr = crate::runner::DYNASM_ACTIVE_GC.with(|cell| {
-        cell.borrow()
-            .as_ref()
-            .and_then(|gc| gc.get_write_barrier_descr())
-    });
+    let wb_descr =
+        crate::runner::with_dynasm_active_gc(|gc| gc.get_write_barrier_descr()).flatten();
     if let Some(wb) = wb_descr {
         let byteofs = wb.jit_wb_if_flag_byteofs;
         let mask = wb.jit_wb_if_flag_singlebyte as i8;
@@ -2320,12 +2317,10 @@ impl<'a> Assembler386<'a> {
         // (assembler.py:2401 `if array and jit_wb_cards_set` gate); the
         // `helper_num=4` XMM-skip optimization is a perf adaptation not
         // a correctness gap and is not yet implemented.
-        if crate::runner::DYNASM_ACTIVE_GC.with(|cell| {
-            cell.borrow()
-                .as_ref()
-                .and_then(|gc| gc.get_write_barrier_descr())
-                .is_some()
-        }) {
+        if crate::runner::with_dynasm_active_gc(|gc| gc.get_write_barrier_descr())
+            .flatten()
+            .is_some()
+        {
             let rbp_loc = Loc::Reg(crate::regloc::EBP);
             self.emit_write_barrier_fastpath_kind(&[rbp_loc], false);
         }
@@ -7653,12 +7648,11 @@ impl<'a> Assembler386<'a> {
     /// barrier when card marking exists; otherwise it falls back to the generic
     /// write barrier.
     fn emit_setarrayitem_gc_write_barrier(&mut self, arglocs: &[Loc]) {
-        let use_array_barrier = crate::runner::DYNASM_ACTIVE_GC.with(|cell| {
-            cell.borrow()
-                .as_ref()
-                .and_then(|gc| gc.get_write_barrier_descr())
-                .is_some_and(|wb| wb.jit_wb_cards_set != 0)
-        });
+        let use_array_barrier = crate::runner::with_dynasm_active_gc(|gc| {
+            gc.get_write_barrier_descr()
+        })
+        .flatten()
+        .is_some_and(|wb| wb.jit_wb_cards_set != 0);
         self.emit_write_barrier_fastpath_kind(arglocs, use_array_barrier);
     }
 
@@ -7669,11 +7663,7 @@ impl<'a> Assembler386<'a> {
     }
 
     fn emit_write_barrier_fastpath_kind(&mut self, arglocs: &[Loc], is_array: bool) {
-        let wb = match crate::runner::DYNASM_ACTIVE_GC.with(|cell| {
-            cell.borrow()
-                .as_ref()
-                .map(|gc| gc.get_write_barrier_descr())
-        }) {
+        let wb = match crate::runner::with_dynasm_active_gc(|gc| gc.get_write_barrier_descr()) {
             Some(Some(wb)) => wb,
             _ => return,
         };

--- a/majit/majit-backend-wasm/src/lib.rs
+++ b/majit/majit-backend-wasm/src/lib.rs
@@ -220,9 +220,18 @@ thread_local! {
 /// - **No box, `gc_sync` uninitialized** (no GC at all — unit tests):
 ///   returns `None` so callers keep their existing `.unwrap_or(default)`
 ///   / `.flatten()` behaviour.
-fn with_wasm_active_gc<R>(f: impl FnOnce(&dyn GcAllocator) -> R) -> Option<R> {
-    if WASM_ACTIVE_GC.with(|cell| cell.borrow().is_some()) {
-        return WASM_ACTIVE_GC.with(|cell| cell.borrow().as_deref().map(f));
+fn with_wasm_active_gc<R>(f: impl Fn(&dyn GcAllocator) -> R) -> Option<R> {
+    match WASM_ACTIVE_GC.with(|cell| cell.try_borrow().map(|g| g.as_deref().map(|gc| f(gc)))) {
+        Ok(Some(r)) => return Some(r),
+        Ok(None) => {}
+        Err(_) => {
+            if let Some(ptr) = WASM_ACTIVE_GC_RAW.with(|raw| raw.get()) {
+                // SAFETY: the raw mirror points at the same live test box whose
+                // mutable borrow is held by the in-progress mutation. This is a
+                // read-only reentrant query, so it does not create a second &mut.
+                return Some(f(unsafe { &*ptr }));
+            }
+        }
     }
     if majit_gc::gc_sync::is_initialized() {
         return Some(majit_gc::gc_sync::gc_query_reentrant(f));

--- a/majit/majit-backend-wasm/src/lib.rs
+++ b/majit/majit-backend-wasm/src/lib.rs
@@ -208,25 +208,55 @@ thread_local! {
         const { std::cell::Cell::new(None) };
 }
 
+/// Read-only GC query for the guard hooks and codegen helpers.
+///
+/// - **Test box present** (`WASM_ACTIVE_GC` is `Some`): a test owns the
+///   GC directly — apply `f` to the boxed allocator.
+/// - **No box, `gc_sync` initialized** (production): route to the
+///   process-global singleton via `gc_query_reentrant`. Some of these
+///   callers can fire during a collection's guard evaluation / extra-root
+///   walk, so the reentrant read-only path (no second `gc_mutex`, no
+///   second `&mut`) is required.
+/// - **No box, `gc_sync` uninitialized** (no GC at all — unit tests):
+///   returns `None` so callers keep their existing `.unwrap_or(default)`
+///   / `.flatten()` behaviour.
 fn with_wasm_active_gc<R>(f: impl FnOnce(&dyn GcAllocator) -> R) -> Option<R> {
-    WASM_ACTIVE_GC.with(|cell| {
-        let guard = cell.borrow();
-        guard.as_deref().map(f)
-    })
+    if WASM_ACTIVE_GC.with(|cell| cell.borrow().is_some()) {
+        return WASM_ACTIVE_GC.with(|cell| cell.borrow().as_deref().map(f));
+    }
+    if majit_gc::gc_sync::is_initialized() {
+        return Some(majit_gc::gc_sync::gc_query_reentrant(f));
+    }
+    None
 }
 
-/// Store a GC allocator in the wasm backend thread-local and register
-/// the `majit_gc::set_active_*` function-pointer hooks, without
-/// requiring a `WasmBackend` instance.
-/// Install a GC box into TLS and register all `set_active_*` hooks.
-fn install_gc_box(gc: Box<dyn majit_gc::GcAllocator>) {
-    let supports_guard_gc_type = gc.supports_guard_gc_type();
-    WASM_ACTIVE_GC.with(|cell| {
-        let mut guard = cell.borrow_mut();
-        *guard = Some(gc);
-        let raw = guard.as_deref_mut().map(|gc| gc as *mut dyn GcAllocator);
-        WASM_ACTIVE_GC_RAW.with(|raw_cell| raw_cell.set(raw));
-    });
+/// `&mut` counterpart of `with_wasm_active_gc` for GC mutations
+/// (allocation, write barriers, collection). Test box → box; production
+/// (no box, `gc_sync` initialized) → `gc_sync::gc_op`; no GC at all →
+/// `None` so callers keep their non-GC fallback. Top-level mutator/
+/// blackhole trampolines, never inside a collection, so `gc_op` is correct.
+fn with_wasm_active_gc_mut<R>(f: impl FnOnce(&mut dyn GcAllocator) -> R) -> Option<R> {
+    if WASM_ACTIVE_GC.with(|cell| cell.borrow().is_some()) {
+        return WASM_ACTIVE_GC.with(|cell| {
+            let mut guard = cell.borrow_mut();
+            let raw: *mut dyn GcAllocator = guard.as_deref_mut()?;
+            // SAFETY: `guard` holds the borrow for the whole `f` call and
+            // these are non-reentrant top-level trampolines, so the
+            // reborrow is exclusive and outlives `f`.
+            Some(f(unsafe { &mut *raw }))
+        });
+    }
+    if majit_gc::gc_sync::is_initialized() {
+        return Some(majit_gc::gc_sync::gc_op(f));
+    }
+    None
+}
+
+/// Register all backend-agnostic `majit_gc::set_active_*` hooks to the
+/// wasm trampolines. Shared by `install_gc_box` (test path: also stores a
+/// box in TLS) and `install_gc_standalone` (production: hooks only, no box
+/// — the trampolines then route to the `gc_sync` singleton).
+fn register_active_hooks(supports_guard_gc_type: bool) {
     majit_gc::set_active_gc_guard_hooks(majit_gc::ActiveGcGuardHooks {
         check_is_object: Some(wasm_check_is_object),
         is_tagged_immediate: Some(wasm_is_tagged_immediate),
@@ -250,11 +280,33 @@ fn install_gc_box(gc: Box<dyn majit_gc::GcAllocator>) {
     );
 }
 
-/// Production path: install a `GcHandle` forwarding to the global singleton.
+/// Store a GC allocator in the wasm backend thread-local and register
+/// the `majit_gc::set_active_*` function-pointer hooks, without
+/// requiring a `WasmBackend` instance.
+/// Install a GC box into TLS and register all `set_active_*` hooks. Test
+/// path only — `set_gc_allocator` hands ownership of a real allocator to
+/// the backend thread. Production uses [`install_gc_standalone`], which
+/// registers the same hooks WITHOUT a box so the trampolines fall through
+/// to `gc_sync`.
+fn install_gc_box(gc: Box<dyn majit_gc::GcAllocator>) {
+    let supports_guard_gc_type = gc.supports_guard_gc_type();
+    WASM_ACTIVE_GC.with(|cell| {
+        let mut guard = cell.borrow_mut();
+        *guard = Some(gc);
+        let raw = guard.as_deref_mut().map(|gc| gc as *mut dyn GcAllocator);
+        WASM_ACTIVE_GC_RAW.with(|raw_cell| raw_cell.set(raw));
+    });
+    register_active_hooks(supports_guard_gc_type);
+}
+
+/// Production path: register all `set_active_*` hooks WITHOUT storing a
+/// box. `WASM_ACTIVE_GC` stays `None`, so every trampoline routes to the
+/// process-global `gc_sync` singleton (the per-thread GC box is the
+/// free-threading gap R4 removes).
 pub fn install_gc_standalone() {
-    let mut handle: Box<dyn majit_gc::GcAllocator> = Box::new(majit_gc::GcHandle);
-    handle.freeze_types();
-    install_gc_box(handle);
+    majit_gc::gc_sync::gc_op(|gc| gc.freeze_types());
+    let supports_guard_gc_type = majit_gc::gc_sync::gc_query(|gc| gc.supports_guard_gc_type());
+    register_active_hooks(supports_guard_gc_type);
 }
 
 /// Diagnostic only: `(oldgen_total_bytes, nursery_used_bytes)` of the GC owned
@@ -319,16 +371,12 @@ fn nursery_alloc_params(ops: &[Op]) -> Option<codegen::NurseryAllocParams> {
 
 /// `majit_gc::CollectOldgenFn` installed by `set_gc_allocator`. Drives the
 /// interpreter-safepoint non-moving old-gen major (`gc_interp::safepoint`,
-/// default-on on wasm) through the wasm-thread-local GC. Needs mutable access,
-/// so it borrows `WASM_ACTIVE_GC` directly rather than via `with_wasm_active_gc`.
-/// Mirrors dynasm's `dynasm_collect_oldgen_nonmoving` and cranelift's
-/// `collect_oldgen_nonmoving_via_active_runtime`.
+/// default-on on wasm) through the active GC. Needs mutable access, so it
+/// routes via `with_wasm_active_gc_mut` (test box → box; production → the
+/// `gc_sync` singleton). Mirrors dynasm's `dynasm_collect_oldgen_nonmoving`
+/// and cranelift's `collect_oldgen_nonmoving_via_active_runtime`.
 fn wasm_collect_oldgen_nonmoving() {
-    WASM_ACTIVE_GC.with(|cell| {
-        if let Some(gc) = cell.borrow_mut().as_deref_mut() {
-            gc.collect_oldgen_nonmoving();
-        }
-    });
+    with_wasm_active_gc_mut(|gc| gc.collect_oldgen_nonmoving());
 }
 
 fn wasm_register_finalizer(fq_index: usize, obj: GcRef, trigger: majit_gc::FinalizerTriggerFn) {
@@ -381,25 +429,14 @@ fn wasm_alloc_nursery_typed(type_id: u32, size: usize) -> GcRef {
     // See cranelift/dynasm counterparts: host-side allocation must not
     // trigger collection because the caller holds a raw pointer that
     // is not a registered GC root.
-    WASM_ACTIVE_GC.with(|cell| {
-        let mut guard = cell.borrow_mut();
-        match guard.as_deref_mut() {
-            Some(gc) => gc.alloc_nursery_no_collect_typed(type_id, size),
-            None => GcRef(0),
-        }
-    })
+    with_wasm_active_gc_mut(|gc| gc.alloc_nursery_no_collect_typed(type_id, size))
+        .unwrap_or(GcRef(0))
 }
 
 /// Host-side old-gen allocation trampoline. Stable
 /// across minor/major collections — see dynasm counterpart.
 fn wasm_alloc_oldgen_typed(type_id: u32, size: usize) -> GcRef {
-    WASM_ACTIVE_GC.with(|cell| {
-        let mut guard = cell.borrow_mut();
-        match guard.as_deref_mut() {
-            Some(gc) => gc.alloc_oldgen_typed(type_id, size),
-            None => GcRef(0),
-        }
-    })
+    with_wasm_active_gc_mut(|gc| gc.alloc_oldgen_typed(type_id, size)).unwrap_or(GcRef(0))
 }
 
 /// JIT-trace allocation trampoline target for `New` / `NewWithVtable`.
@@ -419,10 +456,8 @@ fn wasm_alloc_oldgen_typed(type_id: u32, size: usize) -> GcRef {
 /// allocation. So it uses the *collecting* `alloc_nursery_typed`, which
 /// triggers a minor collection on nursery-full instead of leaking to old-gen.
 pub extern "C" fn wasm_jit_alloc(type_id: i64, size: i64) -> i64 {
-    WASM_ACTIVE_GC.with(|cell| match cell.borrow_mut().as_deref_mut() {
-        Some(gc) => gc.alloc_nursery_typed(type_id as u32, size as usize).0 as i64,
-        None => 0,
-    })
+    with_wasm_active_gc_mut(|gc| gc.alloc_nursery_typed(type_id as u32, size as usize).0 as i64)
+        .unwrap_or(0)
 }
 
 /// JIT-trace variable-size allocation trampoline target for `NewArray` /
@@ -438,25 +473,23 @@ pub extern "C" fn wasm_jit_alloc_array(
     let Ok(length) = usize::try_from(length) else {
         return 0;
     };
-    WASM_ACTIVE_GC.with(|cell| match cell.borrow_mut().as_deref_mut() {
-        Some(gc) => {
-            let obj = gc.alloc_varsize_typed(
-                type_id as u32,
-                base_size as usize,
-                item_size as usize,
-                length,
-            );
-            if obj.is_null() {
-                0
-            } else {
-                unsafe {
-                    *((obj.0 as *mut u8).add(len_offset as usize) as *mut usize) = length;
-                }
-                obj.0 as i64
+    with_wasm_active_gc_mut(|gc| {
+        let obj = gc.alloc_varsize_typed(
+            type_id as u32,
+            base_size as usize,
+            item_size as usize,
+            length,
+        );
+        if obj.is_null() {
+            0
+        } else {
+            unsafe {
+                *((obj.0 as *mut u8).add(len_offset as usize) as *mut usize) = length;
             }
+            obj.0 as i64
         }
-        None => 0,
     })
+    .unwrap_or(0)
 }
 
 /// JIT-trace write-barrier trampoline target for ref-storing `SetfieldGc` /
@@ -467,11 +500,7 @@ pub extern "C" fn wasm_jit_alloc_array(
 /// skips the native GC rewrite pass, so the trace emits this barrier directly
 /// instead of `COND_CALL_GC_WB`. Returns 0 — the store codegen ignores it.
 pub extern "C" fn wasm_jit_write_barrier(obj: i64) -> i64 {
-    WASM_ACTIVE_GC.with(|cell| {
-        if let Some(gc) = cell.borrow_mut().as_deref_mut() {
-            gc.write_barrier(GcRef(obj as usize));
-        }
-    });
+    with_wasm_active_gc_mut(|gc| gc.write_barrier(GcRef(obj as usize)));
     0
 }
 
@@ -585,22 +614,12 @@ fn build_callee_gcmap(
 /// Caller must keep `slot` valid until [`wasm_gc_remove_root`] is
 /// called with the same pointer.
 unsafe fn wasm_gc_add_root(slot: *mut GcRef) {
-    WASM_ACTIVE_GC.with(|cell| {
-        let mut guard = cell.borrow_mut();
-        if let Some(gc) = guard.as_deref_mut() {
-            unsafe { gc.add_root(slot) };
-        }
-    });
+    with_wasm_active_gc_mut(|gc| unsafe { gc.add_root(slot) });
 }
 
 /// Companion to [`wasm_gc_add_root`].
 fn wasm_gc_remove_root(slot: *mut GcRef) {
-    WASM_ACTIVE_GC.with(|cell| {
-        let mut guard = cell.borrow_mut();
-        if let Some(gc) = guard.as_deref_mut() {
-            gc.remove_root(slot);
-        }
-    });
+    with_wasm_active_gc_mut(|gc| gc.remove_root(slot));
 }
 
 /// Host-side write-barrier trampoline for the interpreter (mapdict / list /
@@ -608,35 +627,32 @@ fn wasm_gc_remove_root(slot: *mut GcRef) {
 /// `dynasm_gc_write_barrier`; without it every interpreter ref-store is a
 /// silent no-op, so a collecting nursery loses old→young pointers.
 fn wasm_active_gc_write_barrier(obj: GcRef) {
-    WASM_ACTIVE_GC.with(|cell| {
-        let mut guard = cell.borrow_mut();
-        if let Some(gc) = guard.as_deref_mut() {
-            gc.write_barrier(obj);
-        }
-    });
+    with_wasm_active_gc_mut(|gc| gc.write_barrier(obj));
 }
 
 /// Host-side `is_managed_heap_object` trampoline.
+///
+/// This read-only ownership query can fire reentrantly from an extra-root
+/// walker mid-collection (the interpreter-safepoint major holds the
+/// `WASM_ACTIVE_GC` mutable borrow while asking whether a slot is
+/// GC-managed), so:
+///   - `Ok(Some)`: a test box is present and free-borrowable → use it.
+///   - `Ok(None)`: no box (production) → route to `gc_sync` reentrantly.
+///   - `Err`: the test box's mutable borrow is held by an in-progress
+///     mutation → reach it through the raw mirror (read-only), or fall
+///     back to `gc_sync` if there is no box at all.
 fn wasm_gc_owns_object(addr: usize) -> bool {
-    WASM_ACTIVE_GC.with(|cell| {
-        let guard = match cell.try_borrow() {
-            Ok(guard) => guard,
-            Err(_) => {
-                // The interpreter-safepoint major holds the mutable borrow
-                // while its extra-root walker asks whether a slot is
-                // GC-managed. Answer the read-only ownership query through the
-                // raw mirror rather than panicking on the second borrow.
-                return WASM_ACTIVE_GC_RAW.with(|raw| match raw.get() {
-                    Some(ptr) => unsafe { (*ptr).is_managed_heap_object(addr) },
-                    None => false,
-                });
-            }
-        };
-        match guard.as_deref() {
-            Some(gc) => gc.is_managed_heap_object(addr),
-            None => false,
-        }
-    })
+    match WASM_ACTIVE_GC.with(|cell| {
+        cell.try_borrow()
+            .map(|g| g.as_deref().map(|gc| gc.is_managed_heap_object(addr)))
+    }) {
+        Ok(Some(r)) => r,
+        Ok(None) => majit_gc::gc_sync::gc_query_reentrant(|g| g.is_managed_heap_object(addr)),
+        Err(_) => WASM_ACTIVE_GC_RAW.with(|raw| match raw.get() {
+            Some(ptr) => unsafe { (*ptr).is_managed_heap_object(addr) },
+            None => majit_gc::gc_sync::gc_query_reentrant(|g| g.is_managed_heap_object(addr)),
+        }),
+    }
 }
 
 pub struct WasmBackend {
@@ -820,7 +836,7 @@ impl WasmBackend {
         if self.vtable_offset.is_some() {
             return table;
         }
-        if WASM_ACTIVE_GC.with(|cell| cell.borrow().is_none()) {
+        if with_wasm_active_gc(|_| ()).is_none() {
             return table;
         }
         for op in ops {
@@ -1066,10 +1082,8 @@ impl majit_backend::Backend for WasmBackend {
         // TODO: get_type_id() returns the u64 path_hash cache key; the GC tid
         // is its low 32 bits until gc_cache routing resolves the real tid.
         let type_id = sizedescr.get_type_id() as u32;
-        WASM_ACTIVE_GC.with(|cell| match cell.borrow_mut().as_deref_mut() {
-            Some(gc) => gc.alloc_nursery_no_collect_typed(type_id, size).0 as i64,
-            None => 0,
-        })
+        with_wasm_active_gc_mut(|gc| gc.alloc_nursery_no_collect_typed(type_id, size).0 as i64)
+            .unwrap_or(0)
     }
 
     /// llmodel.py:778-782 bh_new_with_vtable(sizedescr): allocate, then write
@@ -1078,10 +1092,9 @@ impl majit_backend::Backend for WasmBackend {
         let size = sizedescr.as_size();
         let vtable = sizedescr.get_vtable();
         let type_id = sizedescr.get_type_id() as u32;
-        let ptr = WASM_ACTIVE_GC.with(|cell| match cell.borrow_mut().as_deref_mut() {
-            Some(gc) => gc.alloc_nursery_no_collect_typed(type_id, size).0 as i64,
-            None => 0,
-        });
+        let ptr =
+            with_wasm_active_gc_mut(|gc| gc.alloc_nursery_no_collect_typed(type_id, size).0 as i64)
+                .unwrap_or(0);
         if ptr != 0 && vtable != 0 {
             if let Some(vt_off) = self.vtable_offset {
                 unsafe {
@@ -1100,20 +1113,18 @@ impl majit_backend::Backend for WasmBackend {
             .array_len_offset()
             .expect("bh_new_array requires ArrayDescr.lendescr");
         let type_id = arraydescr.get_type_id() as u32;
-        WASM_ACTIVE_GC.with(|cell| match cell.borrow_mut().as_deref_mut() {
-            Some(gc) => {
-                let obj = gc.alloc_varsize_typed(type_id, base_size, itemsize, length);
-                if obj.is_null() {
-                    0
-                } else {
-                    unsafe {
-                        *((obj.0 as *mut u8).add(len_offset) as *mut usize) = length;
-                    }
-                    obj.0 as i64
+        with_wasm_active_gc_mut(|gc| {
+            let obj = gc.alloc_varsize_typed(type_id, base_size, itemsize, length);
+            if obj.is_null() {
+                0
+            } else {
+                unsafe {
+                    *((obj.0 as *mut u8).add(len_offset) as *mut usize) = length;
                 }
+                obj.0 as i64
             }
-            None => 0,
         })
+        .unwrap_or(0)
     }
 
     /// llmodel.py:790 bh_new_array_clear = bh_new_array (allocator zeroes).

--- a/majit/majit-backend-wasm/src/lib.rs
+++ b/majit/majit-backend-wasm/src/lib.rs
@@ -529,10 +529,10 @@ pub extern "C" fn wasm_jit_ca_alloc_frame(frame_bytes: i64, gcmap_ptr: i64) -> i
     // own execution. Steady recursive frames die young; only frames that live
     // through a collection are promoted instead of inflating the old-gen major
     // collection threshold on every call.
-    let jf_ref = WASM_ACTIVE_GC.with(|cell| match cell.borrow_mut().as_deref_mut() {
-        Some(gc) => gc.alloc_nursery_typed(wasm_jitframe_tid(), JitFrame::alloc_size(depth)),
-        None => GcRef(0),
-    });
+    let jf_ref = with_wasm_active_gc_mut(|gc| {
+        gc.alloc_nursery_typed(wasm_jitframe_tid(), JitFrame::alloc_size(depth))
+    })
+    .unwrap_or(GcRef(0));
     if jf_ref.0 == 0 {
         return 0;
     }

--- a/majit/majit-backend-wasm/src/lib.rs
+++ b/majit/majit-backend-wasm/src/lib.rs
@@ -647,10 +647,22 @@ fn wasm_gc_owns_object(addr: usize) -> bool {
             .map(|g| g.as_deref().map(|gc| gc.is_managed_heap_object(addr)))
     }) {
         Ok(Some(r)) => r,
-        Ok(None) => majit_gc::gc_sync::gc_query_reentrant(|g| g.is_managed_heap_object(addr)),
+        Ok(None) => {
+            if majit_gc::gc_sync::is_initialized() {
+                majit_gc::gc_sync::gc_query_reentrant(|g| g.is_managed_heap_object(addr))
+            } else {
+                false
+            }
+        }
         Err(_) => WASM_ACTIVE_GC_RAW.with(|raw| match raw.get() {
             Some(ptr) => unsafe { (*ptr).is_managed_heap_object(addr) },
-            None => majit_gc::gc_sync::gc_query_reentrant(|g| g.is_managed_heap_object(addr)),
+            None => {
+                if majit_gc::gc_sync::is_initialized() {
+                    majit_gc::gc_sync::gc_query_reentrant(|g| g.is_managed_heap_object(addr))
+                } else {
+                    false
+                }
+            }
         }),
     }
 }

--- a/majit/majit-gc/src/collector.rs
+++ b/majit/majit-gc/src/collector.rs
@@ -971,6 +971,12 @@ impl MiniMarkGC {
     /// 3. Iteratively process newly discovered references until stable.
     /// 4. Reset nursery.
     pub fn do_collect_nursery(&mut self) {
+        let _stw = if crate::gc_sync::registered_threads() > 1 {
+            Some(crate::gc_sync::quiesce_mutators())
+        } else {
+            None
+        };
+        let walk_all_mutators = crate::gc_sync::mutators_quiesced();
         if std::env::var_os("MAJIT_LOG").is_some() {
             eprintln!(
                 "[gc][minor] start count={} remembered={} cards_set={}",
@@ -999,9 +1005,14 @@ impl MiniMarkGC {
         // Phase 1b: Process shadow stack roots.
         // RPython gc.py: GcRootMap_shadowstack — walk the thread-local
         // shadow stack to find GC refs pushed by compiled JIT code.
-        crate::shadow_stack::walk_roots(|gcref| {
+        let mut visit_shadow_root = |gcref: &mut GcRef| {
             self.drag_out_root(gcref);
-        });
+        };
+        if walk_all_mutators {
+            crate::shadow_stack::walk_all_roots(&mut visit_shadow_root);
+        } else {
+            crate::shadow_stack::walk_roots(&mut visit_shadow_root);
+        }
 
         // Phase 1c: Process jitframe shadow stack roots.
         // RPython root_walker.walk_roots with jitframe entries —
@@ -1012,7 +1023,7 @@ impl MiniMarkGC {
         // after the walk finishes without reborrowing `self` inside the
         // tracer callback.
         let mut libc_jf_slots: Vec<*mut majit_ir::GcRef> = Vec::new();
-        crate::shadow_stack::walk_jf_roots(|gcref| {
+        let mut visit_jf_root = |gcref: &mut GcRef| {
             if self.is_nursery_object_start(gcref.0) {
                 self.drag_out_root(gcref);
             } else if !gcref.is_null() && self.oldgen.contains(gcref.0) {
@@ -1029,7 +1040,12 @@ impl MiniMarkGC {
                     libc_jf_slots.push(slot_ptr);
                 });
             }
-        });
+        };
+        if walk_all_mutators {
+            crate::shadow_stack::walk_all_jf_roots(&mut visit_jf_root);
+        } else {
+            crate::shadow_stack::walk_jf_roots(&mut visit_jf_root);
+        }
         for slot_ptr in libc_jf_slots {
             let field_ref = unsafe { &mut *slot_ptr };
             self.drag_out_root(field_ref);
@@ -1041,18 +1057,28 @@ impl MiniMarkGC {
         // root set. RPython traces these via the RPython object graph
         // (Box arrays); pyre stores raw i64 in Vec<i64> so we walk the
         // explicit thread-local stack of register banks.
-        crate::shadow_stack::walk_bh_regs(|gcref| {
+        let mut visit_bh_root = |gcref: &mut GcRef| {
             self.drag_out_root(gcref);
-        });
+        };
+        if walk_all_mutators {
+            crate::shadow_stack::walk_all_bh_regs(&mut visit_bh_root);
+        } else {
+            crate::shadow_stack::walk_bh_regs(&mut visit_bh_root);
+        }
 
         // blackhole resume construction roots (`resume.py:1312`): the
         // virtuals_cache + each frame's registers_r are filled by lazily
         // materializing virtuals before `run()` re-roots them via
         // `push_bh_regs`; forward any already-materialized nursery refs so a
         // later materialization's collection does not strand them.
-        crate::shadow_stack::walk_resume_ref_roots(|gcref| {
+        let mut visit_resume_root = |gcref: &mut GcRef| {
             self.drag_out_root(gcref);
-        });
+        };
+        if walk_all_mutators {
+            crate::shadow_stack::walk_all_resume_ref_roots(&mut visit_resume_root);
+        } else {
+            crate::shadow_stack::walk_resume_ref_roots(&mut visit_resume_root);
+        }
 
         // Phase 1e: framework.py `root_walker.walk_roots` parity — the
         // embedding runtime plugs a walker that visits
@@ -1726,12 +1752,18 @@ impl MiniMarkGC {
             self.seed_major_root(gcref);
         }
 
-        crate::shadow_stack::walk_roots(|gcref| {
+        let walk_all_mutators = crate::gc_sync::mutators_quiesced();
+        let mut visit_shadow_root = |gcref: &mut GcRef| {
             self.seed_major_root(*gcref);
-        });
+        };
+        if walk_all_mutators {
+            crate::shadow_stack::walk_all_roots(&mut visit_shadow_root);
+        } else {
+            crate::shadow_stack::walk_roots(&mut visit_shadow_root);
+        }
 
         let mut libc_jf_refs: Vec<GcRef> = Vec::new();
-        crate::shadow_stack::walk_jf_roots(|gcref| {
+        let mut visit_jf_root = |gcref: &mut GcRef| {
             if !gcref.is_null() && crate::shadow_stack::is_libc_jitframe(gcref.0) {
                 crate::shadow_stack::trace_libc_jitframe(gcref.0, &mut |slot_ptr| {
                     let field_ref = unsafe { *slot_ptr };
@@ -1742,21 +1774,36 @@ impl MiniMarkGC {
             } else {
                 self.seed_major_root(*gcref);
             }
-        });
+        };
+        if walk_all_mutators {
+            crate::shadow_stack::walk_all_jf_roots(&mut visit_jf_root);
+        } else {
+            crate::shadow_stack::walk_jf_roots(&mut visit_jf_root);
+        }
         for gcref in libc_jf_refs {
             self.seed_major_root(gcref);
         }
 
-        crate::shadow_stack::walk_bh_regs(|gcref| {
+        let mut visit_bh_root = |gcref: &mut GcRef| {
             self.seed_major_root(*gcref);
-        });
+        };
+        if walk_all_mutators {
+            crate::shadow_stack::walk_all_bh_regs(&mut visit_bh_root);
+        } else {
+            crate::shadow_stack::walk_bh_regs(&mut visit_bh_root);
+        }
 
         // blackhole resume construction roots (`resume.py:1312`): see the
         // minor-collection path for why the in-flight virtuals_cache /
         // registers_r slices must be seeded as roots.
-        crate::shadow_stack::walk_resume_ref_roots(|gcref| {
+        let mut visit_resume_root = |gcref: &mut GcRef| {
             self.seed_major_root(*gcref);
-        });
+        };
+        if walk_all_mutators {
+            crate::shadow_stack::walk_all_resume_ref_roots(&mut visit_resume_root);
+        } else {
+            crate::shadow_stack::walk_resume_ref_roots(&mut visit_resume_root);
+        }
 
         crate::walk_active_extra_roots(&mut |gcref| {
             self.seed_major_root(*gcref);
@@ -2289,6 +2336,11 @@ impl MiniMarkGC {
     /// 2. Mark phase: trace all roots and transitively mark reachable objects.
     /// 3. Sweep phase: free all unmarked old-gen objects.
     pub fn do_collect_full(&mut self) {
+        let _stw = if crate::gc_sync::registered_threads() > 1 {
+            Some(crate::gc_sync::quiesce_mutators())
+        } else {
+            None
+        };
         // Minor collection first to empty the nursery.
         // Note: do_collect_nursery may itself start/advance an incremental
         // cycle, but we need a complete mark-sweep here regardless.

--- a/majit/majit-gc/src/collector.rs
+++ b/majit/majit-gc/src/collector.rs
@@ -9,6 +9,7 @@
 use indexmap::{IndexMap, IndexSet};
 use majit_ir::GcRef;
 use std::collections::VecDeque;
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 use crate::flags;
 use crate::header::{GcHeader, header_of};
@@ -353,9 +354,10 @@ pub struct MiniMarkGC {
     /// gc.py:525-531 published nursery-top slot read by generated inline
     /// allocation paths. Kept separately from the real top so free-threaded
     /// execution can pin the published limit to zero without changing the
-    /// Rust allocator's nursery bounds. The Box keeps its baked address stable
-    /// even if the containing GC value moves.
-    published_nursery_top: Box<usize>,
+    /// Rust allocator's nursery bounds. The atomic publishes limit changes to
+    /// generated code and Rust-side readers. The Box keeps its baked address
+    /// stable even if the containing GC value moves.
+    published_nursery_top: Box<AtomicUsize>,
     /// Whether generated code may use the shared nursery bump fast path.
     inline_alloc_enabled: bool,
     /// The old generation.
@@ -577,7 +579,7 @@ impl MiniMarkGC {
         min_heap_size = min_heap_size.max(nursery_size as f64 * major_collection_threshold);
 
         let nursery = Nursery::new(config.nursery_size);
-        let published_nursery_top = Box::new(nursery.top_ptr() as usize);
+        let published_nursery_top = Box::new(AtomicUsize::new(nursery.top_ptr() as usize));
         let mut gc = MiniMarkGC {
             nursery,
             published_nursery_top,
@@ -646,11 +648,14 @@ impl MiniMarkGC {
     /// allocator bound, unless free-threading has disabled the non-atomic
     /// shared bump fast path.
     fn refresh_published_nursery_top(&mut self) {
-        *self.published_nursery_top = if self.inline_alloc_enabled {
-            self.nursery.top_ptr() as usize
-        } else {
-            0
-        };
+        self.published_nursery_top.store(
+            if self.inline_alloc_enabled {
+                self.nursery.top_ptr() as usize
+            } else {
+                0
+            },
+            Ordering::Release,
+        );
     }
 
     // ── incminimark.py:1292-1308 card marking geometry ──
@@ -3297,7 +3302,7 @@ impl GcAllocator for MiniMarkGC {
     }
 
     fn nursery_top_addr(&self) -> usize {
-        std::ptr::addr_of!(*self.published_nursery_top) as usize
+        self.published_nursery_top.as_ptr() as usize
     }
 
     fn set_inline_alloc_enabled(&mut self, enabled: bool) {
@@ -3591,14 +3596,20 @@ mod tests {
 
         let published_addr = gc.nursery_top_addr();
         let real_top = gc.nursery_top() as usize;
-        assert_eq!(unsafe { *(published_addr as *const usize) }, real_top);
+        assert_eq!(
+            unsafe { &*(published_addr as *const AtomicUsize) }.load(Ordering::Acquire),
+            real_top
+        );
 
         // Prove the collection reset republishes the real limit instead of
         // merely leaving the construction-time value untouched.
-        unsafe { *(published_addr as *mut usize) = 0 };
+        unsafe { &*(published_addr as *const AtomicUsize) }.store(0, Ordering::Release);
         gc.collect_nursery();
         assert_eq!(gc.nursery_top_addr(), published_addr);
-        assert_eq!(unsafe { *(published_addr as *const usize) }, real_top);
+        assert_eq!(
+            unsafe { &*(published_addr as *const AtomicUsize) }.load(Ordering::Acquire),
+            real_top
+        );
 
         let obj = gc.alloc_nursery(16);
         assert!(!obj.is_null());
@@ -3612,17 +3623,23 @@ mod tests {
         let published_addr = gc.nursery_top_addr();
 
         gc.set_inline_alloc_enabled(false);
-        assert_eq!(unsafe { *(published_addr as *const usize) }, 0);
+        assert_eq!(
+            unsafe { &*(published_addr as *const AtomicUsize) }.load(Ordering::Acquire),
+            0
+        );
         assert!(!gc.alloc_nursery(16).is_null());
         assert!(!gc.alloc_with_type(0, 16).is_null());
 
         gc.collect_nursery();
-        assert_eq!(unsafe { *(published_addr as *const usize) }, 0);
+        assert_eq!(
+            unsafe { &*(published_addr as *const AtomicUsize) }.load(Ordering::Acquire),
+            0
+        );
         assert!(!gc.alloc_nursery(16).is_null());
 
         gc.set_inline_alloc_enabled(true);
         assert_eq!(
-            unsafe { *(published_addr as *const usize) },
+            unsafe { &*(published_addr as *const AtomicUsize) }.load(Ordering::Acquire),
             gc.nursery_top() as usize
         );
     }

--- a/majit/majit-gc/src/collector.rs
+++ b/majit/majit-gc/src/collector.rs
@@ -350,6 +350,14 @@ struct FinalizerHandler {
 pub struct MiniMarkGC {
     /// The nursery (young generation).
     nursery: Nursery,
+    /// gc.py:525-531 published nursery-top slot read by generated inline
+    /// allocation paths. Kept separately from the real top so free-threaded
+    /// execution can pin the published limit to zero without changing the
+    /// Rust allocator's nursery bounds. The Box keeps its baked address stable
+    /// even if the containing GC value moves.
+    published_nursery_top: Box<usize>,
+    /// Whether generated code may use the shared nursery bump fast path.
+    inline_alloc_enabled: bool,
     /// The old generation.
     oldgen: OldGen,
     /// Type registry for tracing objects.
@@ -568,8 +576,12 @@ impl MiniMarkGC {
         // nursery_size * major_collection_threshold.
         min_heap_size = min_heap_size.max(nursery_size as f64 * major_collection_threshold);
 
+        let nursery = Nursery::new(config.nursery_size);
+        let published_nursery_top = Box::new(nursery.top_ptr() as usize);
         let mut gc = MiniMarkGC {
-            nursery: Nursery::new(config.nursery_size),
+            nursery,
+            published_nursery_top,
+            inline_alloc_enabled: true,
             oldgen: OldGen::new(),
             types: TypeRegistry::new(),
             roots: RootSet::new(),
@@ -628,6 +640,17 @@ impl MiniMarkGC {
         gc.set_major_threshold_from(0.0, 0.0);
         gc._setup_guard_is_object();
         gc
+    }
+
+    /// Refresh the gc.py:525-531 published nursery-top slot from the real
+    /// allocator bound, unless free-threading has disabled the non-atomic
+    /// shared bump fast path.
+    fn refresh_published_nursery_top(&mut self) {
+        *self.published_nursery_top = if self.inline_alloc_enabled {
+            self.nursery.top_ptr() as usize
+        } else {
+            0
+        };
     }
 
     // ── incminimark.py:1292-1308 card marking geometry ──
@@ -1094,6 +1117,14 @@ impl MiniMarkGC {
         crate::shadow_stack::set_extra_root_walk_kind(
             crate::shadow_stack::ExtraRootWalkKind::Minor,
         );
+        let mut visit_extra_area = |gcref: &mut GcRef| {
+            self.drag_out_root(gcref);
+        };
+        if walk_all_mutators {
+            crate::shadow_stack::walk_all_extra_areas(&mut visit_extra_area);
+        } else {
+            crate::shadow_stack::walk_my_extra_areas(&mut visit_extra_area);
+        }
         crate::walk_active_extra_roots(&mut |gcref| {
             self.drag_out_root(gcref);
         });
@@ -1227,6 +1258,7 @@ impl MiniMarkGC {
         } else {
             self.reset_nursery_with_pinned();
         }
+        self.refresh_published_nursery_top();
 
         // Minor collections must also drive incremental major-collection
         // progress. Like incminimark, take one or more major steps until
@@ -1803,6 +1835,15 @@ impl MiniMarkGC {
             crate::shadow_stack::walk_all_resume_ref_roots(&mut visit_resume_root);
         } else {
             crate::shadow_stack::walk_resume_ref_roots(&mut visit_resume_root);
+        }
+
+        let mut visit_extra_area = |gcref: &mut GcRef| {
+            self.seed_major_root(*gcref);
+        };
+        if walk_all_mutators {
+            crate::shadow_stack::walk_all_extra_areas(&mut visit_extra_area);
+        } else {
+            crate::shadow_stack::walk_my_extra_areas(&mut visit_extra_area);
         }
 
         crate::walk_active_extra_roots(&mut |gcref| {
@@ -3251,7 +3292,12 @@ impl GcAllocator for MiniMarkGC {
     }
 
     fn nursery_top_addr(&self) -> usize {
-        self.nursery.top_addr()
+        std::ptr::addr_of!(*self.published_nursery_top) as usize
+    }
+
+    fn set_inline_alloc_enabled(&mut self, enabled: bool) {
+        self.inline_alloc_enabled = enabled;
+        self.refresh_published_nursery_top();
     }
 
     fn max_nursery_object_size(&self) -> usize {
@@ -3531,6 +3577,49 @@ mod tests {
         let obj = gc.alloc_with_type(0, 16);
         assert!(!obj.is_null());
         assert!(gc.is_in_nursery(obj.0));
+    }
+
+    #[test]
+    fn published_nursery_top_tracks_real_top_across_minor_collection() {
+        let mut gc = test_gc(4096);
+        gc.register_type(TypeInfo::simple(16));
+
+        let published_addr = gc.nursery_top_addr();
+        let real_top = gc.nursery_top() as usize;
+        assert_eq!(unsafe { *(published_addr as *const usize) }, real_top);
+
+        // Prove the collection reset republishes the real limit instead of
+        // merely leaving the construction-time value untouched.
+        unsafe { *(published_addr as *mut usize) = 0 };
+        gc.collect_nursery();
+        assert_eq!(gc.nursery_top_addr(), published_addr);
+        assert_eq!(unsafe { *(published_addr as *const usize) }, real_top);
+
+        let obj = gc.alloc_nursery(16);
+        assert!(!obj.is_null());
+        assert!(gc.is_in_nursery(obj.0));
+    }
+
+    #[test]
+    fn disabled_inline_alloc_keeps_published_top_zero_without_disabling_allocator() {
+        let mut gc = test_gc(4096);
+        gc.register_type(TypeInfo::simple(16));
+        let published_addr = gc.nursery_top_addr();
+
+        gc.set_inline_alloc_enabled(false);
+        assert_eq!(unsafe { *(published_addr as *const usize) }, 0);
+        assert!(!gc.alloc_nursery(16).is_null());
+        assert!(!gc.alloc_with_type(0, 16).is_null());
+
+        gc.collect_nursery();
+        assert_eq!(unsafe { *(published_addr as *const usize) }, 0);
+        assert!(!gc.alloc_nursery(16).is_null());
+
+        gc.set_inline_alloc_enabled(true);
+        assert_eq!(
+            unsafe { *(published_addr as *const usize) },
+            gc.nursery_top() as usize
+        );
     }
 
     #[test]

--- a/majit/majit-gc/src/collector.rs
+++ b/majit/majit-gc/src/collector.rs
@@ -2435,6 +2435,11 @@ impl MiniMarkGC {
     /// remembered set is left untouched: a non-moving major does not consume
     /// `old -> young` edges, so the next minor still finds them.
     pub fn do_collect_oldgen_nonmoving(&mut self) {
+        let _stw = if crate::gc_sync::stw_required() {
+            Some(crate::gc_sync::quiesce_mutators())
+        } else {
+            None
+        };
         self.oldgen_nonmoving_active = true;
         self.oldgen_nonmoving_nursery_marks.clear();
 

--- a/majit/majit-gc/src/collector.rs
+++ b/majit/majit-gc/src/collector.rs
@@ -994,7 +994,7 @@ impl MiniMarkGC {
     /// 3. Iteratively process newly discovered references until stable.
     /// 4. Reset nursery.
     pub fn do_collect_nursery(&mut self) {
-        let _stw = if crate::gc_sync::registered_threads() > 1 {
+        let _stw = if crate::gc_sync::stw_required() {
             Some(crate::gc_sync::quiesce_mutators())
         } else {
             None
@@ -2377,7 +2377,7 @@ impl MiniMarkGC {
     /// 2. Mark phase: trace all roots and transitively mark reachable objects.
     /// 3. Sweep phase: free all unmarked old-gen objects.
     pub fn do_collect_full(&mut self) {
-        let _stw = if crate::gc_sync::registered_threads() > 1 {
+        let _stw = if crate::gc_sync::stw_required() {
             Some(crate::gc_sync::quiesce_mutators())
         } else {
             None

--- a/majit/majit-gc/src/gc_sync.rs
+++ b/majit/majit-gc/src/gc_sync.rs
@@ -21,7 +21,7 @@
 //! thread requests STW, all other mutators park at their next poll point
 //! (which is every GC operation in P0), collection runs, then all resume.
 
-use std::cell::UnsafeCell;
+use std::cell::{Cell, UnsafeCell};
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Condvar, Mutex};
 
@@ -153,6 +153,78 @@ unsafe fn singleton_mut() -> &'static mut dyn GcAllocator {
 }
 
 // ──────────────────────────────────────────────────────────────
+// Reentrancy guard — collection-time read-only queries
+// ──────────────────────────────────────────────────────────────
+
+thread_local! {
+    /// `> 0` while this thread holds an exclusive `&mut` to the singleton
+    /// (inside a `gc_op` / `request_stw` closure). A collection fires *inside*
+    /// one of those closures, and its extra-root walkers re-enter the GC with
+    /// read-only ownership queries (`gc_owns_object` → `is_managed_heap_object`).
+    /// `gc_query_reentrant` consults this so such a query reaches the singleton
+    /// via a shared read instead of a second `gc_mutex` lock (deadlock) or a
+    /// second `&mut` (aliasing).
+    static GC_OP_DEPTH: Cell<u32> = const { Cell::new(0) };
+}
+
+/// RAII marker: raises `GC_OP_DEPTH` for the exact span of a closure that holds
+/// the exclusive `&mut dyn GcAllocator`. Wraps every `singleton_mut()` call.
+struct OpGuard;
+impl OpGuard {
+    #[inline]
+    fn enter() -> Self {
+        GC_OP_DEPTH.with(|d| d.set(d.get() + 1));
+        OpGuard
+    }
+}
+impl Drop for OpGuard {
+    #[inline]
+    fn drop(&mut self) {
+        GC_OP_DEPTH.with(|d| d.set(d.get() - 1));
+    }
+}
+
+/// Whether this thread is already inside a `gc_op` / `request_stw` closure
+/// (i.e. a collection is running on this thread and holds the `&mut`).
+#[inline]
+pub fn in_gc_op() -> bool {
+    GC_OP_DEPTH.with(|d| d.get() != 0)
+}
+
+/// Shared reference to the singleton, re-derived from the static `UnsafeCell`.
+///
+/// SAFETY: only sound when [`in_gc_op`] holds on this thread — the collector
+/// already owns the exclusive `&mut`, all other mutators are parked (STW) or
+/// spinning (single-thread fast path), and the returned `&dyn` is used only for
+/// a read-only query whose lifetime ends before control returns to the
+/// collector. Re-derives from `GC_STORE.0.get()` each call (a pre-`&mut`-cached
+/// raw pointer would be invalidated by `singleton_mut`'s reborrow).
+#[inline]
+unsafe fn singleton_ref_reentrant() -> &'static dyn GcAllocator {
+    unsafe { &*GC_STORE.0.get() }
+        .as_deref()
+        .expect("GC singleton not initialized — call store_singleton() first")
+}
+
+/// Read-only query that is safe both at top level and reentrantly from inside a
+/// collection (an extra-root walker's `gc_owns_object` / ownership query).
+///
+/// Top level (`!in_gc_op()`): takes the fully-synchronised [`gc_query`] path.
+/// Reentrant (`in_gc_op()`): reads the singleton directly, without re-locking
+/// `gc_mutex` (which would deadlock — the lock is non-recursive and, under STW,
+/// held by this very collector) or forming a second `&mut`.
+#[inline]
+pub fn gc_query_reentrant<R>(f: impl FnOnce(&dyn GcAllocator) -> R) -> R {
+    if in_gc_op() {
+        // SAFETY: in_gc_op() ⇒ this thread holds the &mut and is the sole
+        // running mutator (parked/spinning invariant); read-only, bounded to `f`.
+        f(unsafe { singleton_ref_reentrant() })
+    } else {
+        gc_query(f)
+    }
+}
+
+// ──────────────────────────────────────────────────────────────
 // Mutator registry — single-thread fast path
 // ──────────────────────────────────────────────────────────────
 
@@ -205,6 +277,10 @@ pub fn gc_op<R>(f: impl FnOnce(&mut dyn GcAllocator) -> R) -> R {
         return f(unsafe { singleton_mut() });
     }
 
+    debug_assert!(
+        !in_gc_op(),
+        "reentrant &mut gc_op — a collection-time query must use gc_query_reentrant"
+    );
     // Fast path: single thread, no STW.
     if REGISTERED_THREADS.load(Ordering::Acquire) <= 1
         && !GC_SYNC.stw_requested.load(Ordering::Acquire)
@@ -216,7 +292,10 @@ pub fn gc_op<R>(f: impl FnOnce(&mut dyn GcAllocator) -> R) -> R {
             && !GC_SYNC.stw_requested.load(Ordering::Acquire)
         {
             // SAFETY: single thread, no concurrent access possible.
-            let r = f(unsafe { singleton_mut() });
+            let r = {
+                let _op = OpGuard::enter();
+                f(unsafe { singleton_mut() })
+            };
             IN_FAST_PATH.store(false, Ordering::Release);
             return r;
         }
@@ -237,9 +316,11 @@ fn gc_op_slow<R>(f: impl FnOnce(&mut dyn GcAllocator) -> R) -> R {
         park_until_stw_done();
         let _guard = GC_SYNC.gc_mutex.lock().unwrap();
         let _held = GateHeldGuard::enter();
+        let _op = OpGuard::enter();
         return f(unsafe { singleton_mut() });
     }
     let _held = GateHeldGuard::enter();
+    let _op = OpGuard::enter();
     f(unsafe { singleton_mut() })
 }
 
@@ -275,6 +356,7 @@ pub fn request_stw(collect_fn: impl FnOnce(&mut dyn GcAllocator)) {
     // IN_FAST_PATH drained. No concurrent singleton access.
     {
         let _held = GateHeldGuard::enter();
+        let _op = OpGuard::enter();
         collect_fn(unsafe { singleton_mut() });
     }
 

--- a/majit/majit-gc/src/gc_sync.rs
+++ b/majit/majit-gc/src/gc_sync.rs
@@ -937,4 +937,81 @@ mod tests {
         unregister_test_mutator();
         assert!(minor_collections >= THREADS * ROUNDS);
     }
+
+    #[test]
+    #[ignore = "requires exclusive process — conflicts with other majit-gc tests' local GCs"]
+    fn oldgen_nonmoving_preserves_other_mutators_roots() {
+        if !is_initialized() {
+            let mut gc = MiniMarkGC::with_config(GcConfig {
+                nursery_size: 64 * 1024,
+                large_object_threshold: 32 * 1024,
+                ..GcConfig::default()
+            });
+            let type_id = gc.register_type(TypeInfo::simple(16));
+            assert_eq!(type_id, 0);
+            store_singleton(Box::new(gc));
+        }
+
+        const EXPECTED: u64 = 0xCAFE_D00D_F00D_BAAD;
+        let ready = Arc::new(AtomicBool::new(false));
+        let done = Arc::new(AtomicBool::new(false));
+
+        register_test_mutator();
+        let worker = {
+            let ready = ready.clone();
+            let done = done.clone();
+            std::thread::spawn(move || {
+                register_test_mutator();
+                let root_depth = gc_op(|gc| {
+                    let object = gc.alloc_nursery_typed(0, 16);
+                    unsafe { *(object.0 as *mut u64) = EXPECTED };
+                    crate::shadow_stack::push(object)
+                });
+                ready.store(true, Ordering::Release);
+
+                for _ in 0..64 {
+                    gc_op(|_gc| {
+                        let object = crate::shadow_stack::get(root_depth);
+                        assert_eq!(unsafe { *(object.0 as *const u64) }, EXPECTED);
+                    });
+                    std::thread::yield_now();
+                }
+                while !done.load(Ordering::Acquire) {
+                    gc_op(|_gc| {
+                        let object = crate::shadow_stack::get(root_depth);
+                        assert_eq!(unsafe { *(object.0 as *const u64) }, EXPECTED);
+                    });
+                    std::thread::yield_now();
+                }
+                gc_op(|_gc| {
+                    let object = crate::shadow_stack::get(root_depth);
+                    assert_eq!(unsafe { *(object.0 as *const u64) }, EXPECTED);
+                });
+
+                crate::shadow_stack::pop_to(root_depth);
+                unregister_test_mutator();
+            })
+        };
+
+        while !ready.load(Ordering::Acquire) {
+            std::thread::yield_now();
+        }
+        for _ in 0..3 {
+            gc_op(|gc| {
+                for _ in 0..40 {
+                    let junk = gc.alloc_nursery_typed(0, 2048);
+                    unsafe { *(junk.0 as *mut u64) = 0xBAD0_BAD0_BAD0_BAD0 };
+                }
+                gc.collect_nursery();
+            });
+        }
+        for _ in 0..3 {
+            gc_op(|gc| gc.collect_oldgen_nonmoving());
+        }
+
+        done.store(true, Ordering::Release);
+        worker.join().unwrap();
+        unregister_test_mutator();
+        assert_eq!(registered_threads(), 0);
+    }
 }

--- a/majit/majit-gc/src/gc_sync.rs
+++ b/majit/majit-gc/src/gc_sync.rs
@@ -206,11 +206,22 @@ impl OpGuard {
     #[inline]
     fn enter() -> Self {
         let prev = GC_OP_OWNER.swap(my_ident(), Ordering::SeqCst);
-        debug_assert!(
+        assert!(
             prev == 0,
             "GC singleton exclusivity invariant violated: concurrent &mut access"
         );
         OpGuard { prev }
+    }
+}
+
+/// Releases an acquired fast-path gate on both normal return and unwind.
+struct FastPathGate {
+    restore: usize,
+}
+impl Drop for FastPathGate {
+    #[inline]
+    fn drop(&mut self) {
+        IN_FAST_PATH.store(self.restore, Ordering::Release);
     }
 }
 impl Drop for OpGuard {
@@ -384,6 +395,7 @@ pub fn gc_op<R>(f: impl FnOnce(&mut dyn GcAllocator) -> R) -> R {
             .compare_exchange(0, ident, Ordering::Acquire, Ordering::Relaxed)
             .is_ok()
     {
+        let _fast_path_gate = FastPathGate { restore: 0 };
         // Recheck after acquiring the fast-path lock: another thread may have
         // registered or requested STW after the eligibility loads above.
         if REGISTERED_THREADS.load(Ordering::Acquire) <= 1
@@ -395,10 +407,8 @@ pub fn gc_op<R>(f: impl FnOnce(&mut dyn GcAllocator) -> R) -> R {
                 let _op = OpGuard::enter();
                 f(unsafe { singleton_mut() })
             };
-            IN_FAST_PATH.store(0, Ordering::Release);
             return r;
         }
-        IN_FAST_PATH.store(0, Ordering::Release);
     }
     gc_op_slow(f)
 }
@@ -442,6 +452,7 @@ fn gc_op_slow<R>(f: impl FnOnce(&mut dyn GcAllocator) -> R) -> R {
             std::hint::spin_loop();
         }
     }
+    let _fast_path_gate = (!self_holds_fast_path).then_some(FastPathGate { restore: 0 });
 
     if registered {
         let mut state = GC_SYNC.quiesce.lock().unwrap();
@@ -466,9 +477,6 @@ fn gc_op_slow<R>(f: impl FnOnce(&mut dyn GcAllocator) -> R) -> R {
         // single-thread allocation discipline.
         f(unsafe { singleton_mut() })
     };
-    if !self_holds_fast_path {
-        IN_FAST_PATH.store(0, Ordering::Release);
-    }
     result
 }
 

--- a/majit/majit-gc/src/gc_sync.rs
+++ b/majit/majit-gc/src/gc_sync.rs
@@ -704,7 +704,10 @@ mod tests {
         ensure_gc();
         register_test_mutator();
         assert_ne!(
-            gc_query(|gc| unsafe { *(gc.nursery_top_addr() as *const usize) }),
+            gc_query(
+                |gc| unsafe { &*(gc.nursery_top_addr() as *const AtomicUsize) }
+                    .load(Ordering::Acquire)
+            ),
             0
         );
 
@@ -716,7 +719,10 @@ mod tests {
         .unwrap();
 
         assert_eq!(
-            gc_query(|gc| unsafe { *(gc.nursery_top_addr() as *const usize) }),
+            gc_query(
+                |gc| unsafe { &*(gc.nursery_top_addr() as *const AtomicUsize) }
+                    .load(Ordering::Acquire)
+            ),
             0
         );
         unregister_test_mutator();

--- a/majit/majit-gc/src/gc_sync.rs
+++ b/majit/majit-gc/src/gc_sync.rs
@@ -17,9 +17,12 @@
 //!
 //! This is NOT a GIL — mutators do not hold a lock during Python execution.
 //! The lock is held only for the duration of each individual GC operation.
-//! The STW protocol is for collection: when nursery is full, the collecting
-//! thread requests STW, all other mutators park at their next poll point
-//! (which is every GC operation in P0), collection runs, then all resume.
+//! Collection begins only when every other registered thread is at an
+//! entry-style safepoint where all of its live GC references are rooted.
+//! A slow `gc_op` leaves RUNNING before blocking on `gc_mutex`, then rejoins
+//! RUNNING before its closure executes. A dispatch poll parks directly. There
+//! is no exit safepoint: a returned reference remains protected until the
+//! caller roots it before its next collection-capable call.
 
 use std::cell::{Cell, UnsafeCell};
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
@@ -42,13 +45,15 @@ pub struct GcSync {
     /// Mutex serialising all GC operations. Held briefly per alloc/barrier
     /// (P0). Held for full STW duration during collection.
     gc_mutex: Mutex<()>,
-    /// Set to true when a thread wants to collect. Other threads park
-    /// at their next gc_op or runtime dispatch poll.
+    /// Set while a collector is draining other mutators to entry-style
+    /// safepoints. Cleared before the collector releases `gc_mutex`.
     stw_requested: AtomicBool,
-    /// RUNNING mutator count. A registered thread is removed before it waits
-    /// on gc_mutex, so a collector holding gc_mutex can drain this to zero.
+    /// RUNNING registered-mutator count. A slow `gc_op` removes itself before
+    /// waiting on `gc_mutex`, so a mutex-holding collector can drain every
+    /// other mutator while remaining counted itself.
     quiesce: Mutex<QuiesceState>,
-    /// Signalled whenever RUNNING decreases, including the transition to zero.
+    /// Signalled whenever RUNNING decreases toward the collector-inclusive
+    /// drain target (one when the collector is counted, otherwise zero).
     quiesced: Condvar,
     /// Signalled when STW ends and parked mutators may become RUNNING again.
     resumed: Condvar,
@@ -170,13 +175,22 @@ thread_local! {
     static THREAD_REGISTERED: Cell<bool> = const { Cell::new(false) };
 
     /// Registered mutators are normally RUNNING. Outermost slow gc_op regions
-    /// and safepoint parks flip this to false until they resume.
+    /// waiting on gc_mutex and dispatch safepoint parks flip this to false.
     static THREAD_RUNNING: Cell<bool> = const { Cell::new(false) };
+
+    /// True while this thread owns the singleton through the lock-free
+    /// single-thread fast path. The slow-path drain uses this to avoid waiting
+    /// on the current thread's own process-global `IN_FAST_PATH` lock.
+    static THREAD_HOLDS_FAST_PATH: Cell<bool> = const { Cell::new(false) };
 
     /// Reentrancy depth for collector-side quiescence. do_collect_full calls
     /// do_collect_nursery, so only the outer guard owns the STW transition.
     static STW_DEPTH: Cell<u32> = const { Cell::new(0) };
 }
+
+/// Debug-build owner flag for the exclusive singleton borrow invariant.
+#[cfg(debug_assertions)]
+static MUT_ACTIVE: AtomicBool = AtomicBool::new(false);
 
 /// RAII marker: raises `GC_OP_DEPTH` for the exact span of a closure that holds
 /// the exclusive `&mut dyn GcAllocator`. Wraps every `singleton_mut()` call.
@@ -185,6 +199,10 @@ impl OpGuard {
     #[inline]
     fn enter() -> Self {
         GC_OP_DEPTH.with(|d| d.set(d.get() + 1));
+        #[cfg(debug_assertions)]
+        if GC_OP_DEPTH.with(|d| d.get()) == 1 && MUT_ACTIVE.swap(true, Ordering::SeqCst) {
+            panic!("GC singleton exclusivity invariant violated: concurrent &mut access");
+        }
         OpGuard
     }
 }
@@ -192,6 +210,10 @@ impl Drop for OpGuard {
     #[inline]
     fn drop(&mut self) {
         GC_OP_DEPTH.with(|d| d.set(d.get() - 1));
+        #[cfg(debug_assertions)]
+        if GC_OP_DEPTH.with(|d| d.get()) == 0 {
+            MUT_ACTIVE.store(false, Ordering::SeqCst);
+        }
     }
 }
 
@@ -243,13 +265,14 @@ pub fn gc_query_reentrant<R>(f: impl FnOnce(&dyn GcAllocator) -> R) -> R {
 /// `unregister_thread`.  When ≤ 1, `gc_op` skips the Mutex entirely.
 static REGISTERED_THREADS: AtomicUsize = AtomicUsize::new(0);
 
-/// Set by the single-thread fast path while inside `singleton_mut()`.
-/// `register_thread` spins on this to prevent the 1→2 transition from
-/// racing with a concurrent fast-path gc_op.
+/// Fast-path lock held while the single-thread path accesses `singleton_mut()`.
+/// CAS acquisition serialises all eligible callers, including unregistered
+/// callers, and slow paths drain its owner before accessing the singleton.
 static IN_FAST_PATH: AtomicBool = AtomicBool::new(false);
 
-/// Register the current thread as a GC mutator.  Must be called before
-/// any `gc_op` on this thread.  Paired with `unregister_thread`.
+/// Register the current thread as a GC mutator. Paired with
+/// `unregister_thread`. An unregistered thread may still call `gc_op`; it is
+/// not counted for STW, but serialises through the same operation gate.
 pub fn register_thread() {
     assert!(
         !THREAD_REGISTERED.with(|registered| registered.get()),
@@ -257,9 +280,9 @@ pub fn register_thread() {
     );
     let old = REGISTERED_THREADS.fetch_add(1, Ordering::SeqCst);
     if old > 0 {
-        // A second thread is arriving.  Spin until any in-progress
-        // fast-path gc_op completes — after this, the first thread
-        // will see REGISTERED_THREADS > 1 and take the Mutex path.
+        // A second thread is arriving. Spin until the operation gate is free;
+        // after this, existing callers see REGISTERED_THREADS > 1 and take the
+        // Mutex path. CAS acquisition makes this stricter than the old marker.
         while IN_FAST_PATH.load(Ordering::Acquire) {
             std::hint::spin_loop();
         }
@@ -273,10 +296,19 @@ pub fn register_thread() {
     state.running += 1;
     THREAD_RUNNING.with(|running| running.set(true));
     THREAD_REGISTERED.with(|registered| registered.set(true));
+    drop(state);
+
+    if old > 0 && is_initialized() {
+        // gc.py:525-531 publishes the nursery slots used by generated inline
+        // allocation. A shared free-threaded nursery cannot safely use its
+        // non-atomic bump sequence, so the 1→2 transition pins that path off.
+        // This is sticky: unregistering threads never republishes the top.
+        gc_op(|gc| gc.set_inline_alloc_enabled(false));
+    }
 }
 
-/// Unregister the current thread.  After this, gc_op must not be
-/// called from this thread.
+/// Unregister the current thread. Subsequent `gc_op` calls remain serialised,
+/// but this thread no longer participates in STW quiescence.
 pub fn unregister_thread() {
     assert!(
         THREAD_REGISTERED.with(|registered| registered.get()),
@@ -307,64 +339,10 @@ pub fn registered_threads() -> usize {
 // GC operation gate — fast path when single-threaded
 // ──────────────────────────────────────────────────────────────
 
-/// A registered mutator's outermost slow gc_op is a safe region for its
-/// complete duration, including time blocked on gc_mutex.
-struct SafeRegionGuard {
-    active: bool,
-}
-
-impl SafeRegionGuard {
-    fn enter() -> Self {
-        let registered = THREAD_REGISTERED.with(|registered| registered.get());
-        let needs_safe_region = registered
-            && (REGISTERED_THREADS.load(Ordering::Acquire) > 1
-                || GC_SYNC.stw_requested.load(Ordering::Acquire));
-        if !needs_safe_region || in_gc_op() {
-            return Self { active: false };
-        }
-
-        let mut state = GC_SYNC.quiesce.lock().unwrap();
-        assert!(
-            THREAD_RUNNING.with(|running| running.replace(false)),
-            "GC mutator entered a safe region twice"
-        );
-        state.running = state
-            .running
-            .checked_sub(1)
-            .expect("RUNNING underflow entering gc_op safe region");
-        GC_SYNC.quiesced.notify_all();
-
-        state = GC_SYNC
-            .resumed
-            .wait_while(state, |_| GC_SYNC.stw_requested.load(Ordering::Acquire))
-            .unwrap();
-        drop(state);
-        Self { active: true }
-    }
-}
-
-impl Drop for SafeRegionGuard {
-    fn drop(&mut self) {
-        if !self.active {
-            return;
-        }
-        let mut state = GC_SYNC.quiesce.lock().unwrap();
-        state = GC_SYNC
-            .resumed
-            .wait_while(state, |_| GC_SYNC.stw_requested.load(Ordering::Acquire))
-            .unwrap();
-        state.running += 1;
-        assert!(
-            !THREAD_RUNNING.with(|running| running.replace(true)),
-            "GC mutator left a safe region twice"
-        );
-    }
-}
-
 /// Execute a closure with exclusive `&mut dyn GcAllocator` access.
 ///
-/// **Fast path** (single registered thread, no STW): direct access,
-/// no Mutex.  Cost: 2 atomic loads + 2 atomic stores (~4ns x86).
+/// **Fast path** (single registered thread, no STW): direct access after
+/// acquiring `IN_FAST_PATH`, without taking the Mutex.
 ///
 /// **Slow path** (multiple threads or STW): acquires `gc_mutex`.
 /// Single-threaded production always takes the fast path.
@@ -384,18 +362,29 @@ pub fn gc_op<R>(f: impl FnOnce(&mut dyn GcAllocator) -> R) -> R {
     // Fast path: single thread, no STW.
     if REGISTERED_THREADS.load(Ordering::Acquire) <= 1
         && !GC_SYNC.stw_requested.load(Ordering::Acquire)
+        && IN_FAST_PATH
+            .compare_exchange(false, true, Ordering::Acquire, Ordering::Relaxed)
+            .is_ok()
     {
-        IN_FAST_PATH.store(true, Ordering::Release);
-        // Double-check: another thread may have registered between
-        // our load and the flag set.
+        // Recheck after acquiring the fast-path lock: another thread may have
+        // registered or requested STW after the eligibility loads above.
         if REGISTERED_THREADS.load(Ordering::Acquire) <= 1
             && !GC_SYNC.stw_requested.load(Ordering::Acquire)
         {
-            // SAFETY: single thread, no concurrent access possible.
+            // SAFETY: the fast-path lock excludes other fast operations, and
+            // slow operations drain it before accessing the singleton.
+            assert!(
+                !THREAD_HOLDS_FAST_PATH.with(|held| held.replace(true)),
+                "nested single-thread GC fast path"
+            );
             let r = {
                 let _op = OpGuard::enter();
                 f(unsafe { singleton_mut() })
             };
+            assert!(
+                THREAD_HOLDS_FAST_PATH.with(|held| held.replace(false)),
+                "single-thread GC fast path marker cleared twice"
+            );
             IN_FAST_PATH.store(false, Ordering::Release);
             return r;
         }
@@ -407,14 +396,69 @@ pub fn gc_op<R>(f: impl FnOnce(&mut dyn GcAllocator) -> R) -> R {
 /// Slow path: Mutex-guarded access with STW parking.
 #[cold]
 fn gc_op_slow<R>(f: impl FnOnce(&mut dyn GcAllocator) -> R) -> R {
-    // Enter the safe region before acquiring gc_mutex. A thread blocked on
-    // the mutex is therefore already excluded from RUNNING, which lets the
-    // collector hold gc_mutex while waiting for RUNNING == 0.
-    let _safe = SafeRegionGuard::enter();
+    let registered = THREAD_REGISTERED.with(|registered| registered.get());
+    if registered {
+        let mut state = GC_SYNC.quiesce.lock().unwrap();
+        assert!(
+            THREAD_RUNNING.with(|running| running.replace(false)),
+            "GC mutator entered a gc_op safepoint twice"
+        );
+        state.running = state
+            .running
+            .checked_sub(1)
+            .expect("RUNNING underflow entering gc_op safepoint");
+        GC_SYNC.quiesced.notify_all();
+    }
+
+    // Blocking on gc_mutex is the park: this thread is already excluded from
+    // RUNNING, so a collector can hold the mutex while draining other threads.
     let _guard = GC_SYNC.gc_mutex.lock().unwrap();
-    let _held = GateHeldGuard::enter();
-    let _op = OpGuard::enter();
-    f(unsafe { singleton_mut() })
+
+    // Drain a fast operation before borrowing the singleton. A fast holder
+    // never waits on gc_mutex, so this terminates. Together with CAS acquisition
+    // this makes fast and slow singleton accesses mutually exclusive.
+    let self_holds_fast_path = THREAD_HOLDS_FAST_PATH.with(|held| held.get());
+    while IN_FAST_PATH.load(Ordering::Acquire) && !self_holds_fast_path {
+        std::hint::spin_loop();
+    }
+    if !self_holds_fast_path {
+        // Claim the gate after draining so a new fast operation cannot start
+        // between the final observation above and the singleton borrow.
+        while IN_FAST_PATH
+            .compare_exchange(false, true, Ordering::Acquire, Ordering::Relaxed)
+            .is_err()
+        {
+            std::hint::spin_loop();
+        }
+    }
+
+    if registered {
+        let mut state = GC_SYNC.quiesce.lock().unwrap();
+        // An STW requester holds gc_mutex and clears its request before
+        // releasing it, so a thread that acquired gc_mutex cannot need to wait.
+        debug_assert!(
+            !GC_SYNC.stw_requested.load(Ordering::Acquire),
+            "gc_mutex holder observed an active STW request"
+        );
+        state.running += 1;
+        assert!(
+            !THREAD_RUNNING.with(|running| running.replace(true)),
+            "GC mutator re-entered RUNNING twice"
+        );
+    }
+
+    let result = {
+        let _held = GateHeldGuard::enter();
+        let _op = OpGuard::enter();
+        // There is deliberately no exit park. A returned reference is rooted
+        // by the caller before its next entry-style safepoint, matching the
+        // single-thread allocation discipline.
+        f(unsafe { singleton_mut() })
+    };
+    if !self_holds_fast_path {
+        IN_FAST_PATH.store(false, Ordering::Release);
+    }
+    result
 }
 
 /// Execute a closure with `&dyn GcAllocator` access (read-only query).
@@ -435,12 +479,10 @@ pub fn gc_query<R>(f: impl FnOnce(&dyn GcAllocator) -> R) -> R {
 pub struct StwGuard {
     active: bool,
     owner: bool,
-    restore_fast_collector: bool,
 }
 
-/// Quiesce every registered mutator when the process-global GC is shared.
-/// The collecting thread is normally already safe because collection runs
-/// inside an outermost slow gc_op.
+/// Quiesce every other registered mutator when the process-global GC is shared.
+/// A registered collecting thread stays in RUNNING while collection executes.
 pub fn quiesce_mutators() -> StwGuard {
     let nested = STW_DEPTH.with(|depth| {
         let old = depth.get();
@@ -455,7 +497,6 @@ pub fn quiesce_mutators() -> StwGuard {
         return StwGuard {
             active: true,
             owner: false,
-            restore_fast_collector: false,
         };
     }
 
@@ -463,40 +504,18 @@ pub fn quiesce_mutators() -> StwGuard {
         return StwGuard {
             active: false,
             owner: false,
-            restore_fast_collector: false,
         };
     }
 
     let mut state = GC_SYNC.quiesce.lock().unwrap();
     GC_SYNC.stw_requested.store(true, Ordering::Release);
 
-    // The 1→2 registration transition publishes REGISTERED_THREADS before it
-    // waits for the old single-thread fast operation to finish. If that very
-    // operation fills the nursery, make its collecting thread safe and release
-    // the transition waiter; stw_requested prevents any new fast operation.
-    let restore_fast_collector = IN_FAST_PATH.load(Ordering::Acquire)
-        && in_gc_op()
-        && THREAD_REGISTERED.with(|registered| registered.get())
+    let collector_is_running = THREAD_REGISTERED.with(|registered| registered.get())
         && THREAD_RUNNING.with(|running| running.get());
-    if restore_fast_collector {
-        THREAD_RUNNING.with(|running| running.set(false));
-        state.running = state
-            .running
-            .checked_sub(1)
-            .expect("RUNNING underflow quiescing fast-path collector");
-        IN_FAST_PATH.store(false, Ordering::Release);
-        GC_SYNC.quiesced.notify_all();
-    }
-
-    // Any other fast operation began before the multi-thread transition and
-    // will finish without consulting the quiesce mutex.
-    while IN_FAST_PATH.load(Ordering::Acquire) {
-        std::hint::spin_loop();
-    }
-
+    let drain_target = usize::from(collector_is_running);
     state = GC_SYNC
         .quiesced
-        .wait_while(state, |state| state.running != 0)
+        .wait_while(state, |state| state.running != drain_target)
         .unwrap();
     drop(state);
     STW_DEPTH.with(|depth| depth.set(1));
@@ -504,7 +523,6 @@ pub fn quiesce_mutators() -> StwGuard {
     StwGuard {
         active: true,
         owner: true,
-        restore_fast_collector,
     }
 }
 
@@ -530,14 +548,7 @@ impl Drop for StwGuard {
         }
         assert_eq!(remaining, 0, "outer STW guard dropped before nested guard");
 
-        let mut state = GC_SYNC.quiesce.lock().unwrap();
-        if self.restore_fast_collector {
-            state.running += 1;
-            assert!(
-                !THREAD_RUNNING.with(|running| running.replace(true)),
-                "fast-path collector resumed twice"
-            );
-        }
+        let _state = GC_SYNC.quiesce.lock().unwrap();
         GC_SYNC.stw_requested.store(false, Ordering::Release);
         GC_SYNC.stw_generation.fetch_add(1, Ordering::Release);
         GC_SYNC.resumed.notify_all();
@@ -559,8 +570,35 @@ pub fn request_stw(collect_fn: impl FnOnce(&mut dyn GcAllocator)) {
 
 /// Park the current thread until the ongoing STW finishes.
 fn park_until_stw_done() {
-    let safe = SafeRegionGuard::enter();
-    drop(safe);
+    if !THREAD_REGISTERED.with(|registered| registered.get())
+        || !THREAD_RUNNING.with(|running| running.get())
+    {
+        return;
+    }
+
+    let mut state = GC_SYNC.quiesce.lock().unwrap();
+    if !GC_SYNC.stw_requested.load(Ordering::Acquire) {
+        return;
+    }
+    assert!(
+        THREAD_RUNNING.with(|running| running.replace(false)),
+        "GC mutator entered a dispatch safepoint twice"
+    );
+    state.running = state
+        .running
+        .checked_sub(1)
+        .expect("RUNNING underflow entering dispatch safepoint");
+    GC_SYNC.quiesced.notify_all();
+
+    state = GC_SYNC
+        .resumed
+        .wait_while(state, |_| GC_SYNC.stw_requested.load(Ordering::Acquire))
+        .unwrap();
+    state.running += 1;
+    assert!(
+        !THREAD_RUNNING.with(|running| running.replace(true)),
+        "GC mutator left a dispatch safepoint twice"
+    );
 }
 
 /// Poll for a collector request at a runtime dispatch safepoint.
@@ -581,8 +619,15 @@ mod tests {
     use super::*;
     use crate::collector::{GcConfig, MiniMarkGC};
     use crate::trace::TypeInfo;
+    use std::cell::UnsafeCell;
     use std::sync::atomic::AtomicUsize;
     use std::sync::{Arc, Barrier};
+
+    struct GcOpCounter(UnsafeCell<usize>);
+
+    // SAFETY: tests access the cell only inside gc_op, whose singleton gate
+    // must provide the same exclusive serialization as it does for the GC.
+    unsafe impl Sync for GcOpCounter {}
 
     fn ensure_gc() {
         if !is_initialized() {
@@ -618,6 +663,62 @@ mod tests {
         let ok = gc_op(|_outer| gc_query(|gc| !gc.nursery_free().is_null()));
         assert!(ok);
         unregister_thread();
+    }
+
+    #[test]
+    #[ignore = "requires exclusive process — exercises process-global registration state"]
+    fn registered_and_unregistered_gc_ops_are_mutually_exclusive() {
+        ensure_gc();
+        register_test_mutator();
+
+        const OPS_PER_THREAD: usize = 100_000;
+        let counter = Arc::new(GcOpCounter(UnsafeCell::new(0)));
+        let start = Arc::new(Barrier::new(2));
+        let worker = {
+            let counter = counter.clone();
+            let start = start.clone();
+            std::thread::spawn(move || {
+                // An unregistered thread's gc_op is legal and must serialize
+                // through the same fast-path lock as a registered caller.
+                start.wait();
+                for _ in 0..OPS_PER_THREAD {
+                    gc_op(|_| unsafe { *counter.0.get() += 1 });
+                }
+            })
+        };
+
+        start.wait();
+        for _ in 0..OPS_PER_THREAD {
+            gc_op(|_| unsafe { *counter.0.get() += 1 });
+        }
+        worker.join().unwrap();
+
+        assert_eq!(unsafe { *counter.0.get() }, OPS_PER_THREAD * 2);
+        unregister_test_mutator();
+    }
+
+    #[test]
+    #[ignore = "requires exclusive process — mutates the sticky singleton inline-allocation state"]
+    fn second_registered_thread_pins_published_nursery_top() {
+        ensure_gc();
+        register_test_mutator();
+        assert_ne!(
+            gc_query(|gc| unsafe { *(gc.nursery_top_addr() as *const usize) }),
+            0
+        );
+
+        std::thread::spawn(|| {
+            register_test_mutator();
+            unregister_test_mutator();
+        })
+        .join()
+        .unwrap();
+
+        assert_eq!(
+            gc_query(|gc| unsafe { *(gc.nursery_top_addr() as *const usize) }),
+            0
+        );
+        unregister_test_mutator();
     }
 
     #[test]
@@ -695,6 +796,79 @@ mod tests {
 
         worker.join().unwrap();
         unregister_test_mutator();
+    }
+
+    #[test]
+    #[ignore = "requires exclusive process — conflicts with other majit-gc tests' local GCs"]
+    fn entry_only_safepoint_preserves_fresh_gc_op_return() {
+        if !is_initialized() {
+            let mut gc = MiniMarkGC::with_config(GcConfig {
+                nursery_size: 64 * 1024,
+                large_object_threshold: 32 * 1024,
+                ..GcConfig::default()
+            });
+            let type_id = gc.register_type(TypeInfo::simple(16));
+            assert_eq!(type_id, 0);
+            store_singleton(Box::new(gc));
+        }
+
+        const MUTATORS: usize = 4;
+        const ROUNDS: usize = 128;
+        let start = Arc::new(Barrier::new(MUTATORS + 1));
+        let finished = Arc::new(AtomicUsize::new(0));
+
+        let collector = {
+            let start = start.clone();
+            let finished = finished.clone();
+            std::thread::spawn(move || {
+                register_test_mutator();
+                start.wait();
+                while finished.load(Ordering::Acquire) != MUTATORS {
+                    gc_op(|gc| gc.collect_nursery());
+                    std::thread::yield_now();
+                }
+                unregister_test_mutator();
+            })
+        };
+
+        let mutators: Vec<_> = (0..MUTATORS)
+            .map(|thread_index| {
+                let start = start.clone();
+                let finished = finished.clone();
+                std::thread::spawn(move || {
+                    register_test_mutator();
+                    start.wait();
+
+                    for round in 0..ROUNDS {
+                        let expected =
+                            0xA110_C000_0000_0000u64 | ((thread_index as u64) << 32) | round as u64;
+                        let fresh = gc_op(|gc| gc.alloc_nursery_typed(0, 16));
+                        unsafe { *(fresh.0 as *mut u64) = expected };
+
+                        // Widen the allocation-return window. Collection must
+                        // wait for the next entry safepoint, after this fresh
+                        // reference has been installed in the shadow stack.
+                        std::thread::yield_now();
+                        let root_depth = crate::shadow_stack::push(fresh);
+                        gc_op(|gc| {
+                            gc.collect_nursery();
+                            let rooted = crate::shadow_stack::get(root_depth);
+                            assert_eq!(unsafe { *(rooted.0 as *const u64) }, expected);
+                        });
+                        crate::shadow_stack::pop_to(root_depth);
+                    }
+
+                    finished.fetch_add(1, Ordering::Release);
+                    unregister_test_mutator();
+                })
+            })
+            .collect();
+
+        for mutator in mutators {
+            mutator.join().unwrap();
+        }
+        collector.join().unwrap();
+        assert_eq!(registered_threads(), 0);
     }
 
     #[test]

--- a/majit/majit-gc/src/gc_sync.rs
+++ b/majit/majit-gc/src/gc_sync.rs
@@ -160,68 +160,72 @@ unsafe fn singleton_mut() -> &'static mut dyn GcAllocator {
 // Reentrancy guard — collection-time read-only queries
 // ──────────────────────────────────────────────────────────────
 
-thread_local! {
-    /// `> 0` while this thread holds an exclusive `&mut` to the singleton
-    /// (inside a `gc_op` / `request_stw` closure). A collection fires *inside*
-    /// one of those closures, and its extra-root walkers re-enter the GC with
-    /// read-only ownership queries (`gc_owns_object` → `is_managed_heap_object`).
-    /// `gc_query_reentrant` consults this so such a query reaches the singleton
-    /// via a shared read instead of a second `gc_mutex` lock (deadlock) or a
-    /// second `&mut` (aliasing).
-    static GC_OP_DEPTH: Cell<u32> = const { Cell::new(0) };
-
-    /// Whether this thread has completed `register_thread` and is represented
-    /// in the RUNNING count.
-    static THREAD_REGISTERED: Cell<bool> = const { Cell::new(false) };
-
-    /// Registered mutators are normally RUNNING. Outermost slow gc_op regions
-    /// waiting on gc_mutex and dispatch safepoint parks flip this to false.
-    static THREAD_RUNNING: Cell<bool> = const { Cell::new(false) };
-
-    /// True while this thread owns the singleton through the lock-free
-    /// single-thread fast path. The slow-path drain uses this to avoid waiting
-    /// on the current thread's own process-global `IN_FAST_PATH` lock.
-    static THREAD_HOLDS_FAST_PATH: Cell<bool> = const { Cell::new(false) };
-
-    /// Reentrancy depth for collector-side quiescence. do_collect_full calls
-    /// do_collect_nursery, so only the outer guard owns the STW transition.
-    static STW_DEPTH: Cell<u32> = const { Cell::new(0) };
+/// Per-thread GC-sync facts, kept in one struct like pypy_threadlocal_s
+/// (threadlocal.c:46-97). Its address doubles as this thread's ident for the
+/// global owner words below, mirroring how _rpygil_get_my_ident reads the
+/// ident out of the threadlocal struct (threadlocal.h:143-146).
+struct GcThreadState {
+    /// Completed `register_thread`, represented in the RUNNING count.
+    registered: Cell<bool>,
+    /// Registered mutators are normally RUNNING. Outermost slow gc_op
+    /// regions waiting on gc_mutex and dispatch safepoint parks flip this
+    /// to false.
+    running: Cell<bool>,
 }
 
-/// Debug-build owner flag for the exclusive singleton borrow invariant.
-#[cfg(debug_assertions)]
-static MUT_ACTIVE: AtomicBool = AtomicBool::new(false);
+thread_local! {
+    static GC_THREAD: GcThreadState = const {
+        GcThreadState { registered: Cell::new(false), running: Cell::new(false) }
+    };
+}
 
-/// RAII marker: raises `GC_OP_DEPTH` for the exact span of a closure that holds
+/// Stable nonzero ident of the current thread: the address of its
+/// `GC_THREAD` struct.
+#[inline]
+fn my_ident() -> usize {
+    GC_THREAD.with(|t| t as *const GcThreadState as usize)
+}
+
+/// Ident of the thread currently holding the exclusive `&mut dyn GcAllocator`
+/// (inside a `gc_op` closure); 0 when none. `in_gc_op` compares against
+/// `my_ident()`, the `rpy_fastgil == get_ident()` idiom (thread_gil.c:21).
+static GC_OP_OWNER: AtomicUsize = AtomicUsize::new(0);
+
+/// Ident of the STW-owning collector thread; 0 when no STW. Only the owner
+/// nests (do_collect_full drives do_collect_nursery), so a global owner word
+/// plus depth replaces per-thread state.
+static STW_OWNER: AtomicUsize = AtomicUsize::new(0);
+static STW_DEPTH: AtomicUsize = AtomicUsize::new(0);
+
+/// RAII marker: sets `GC_OP_OWNER` for the exact span of a closure that holds
 /// the exclusive `&mut dyn GcAllocator`. Wraps every `singleton_mut()` call.
-struct OpGuard;
+struct OpGuard {
+    prev: usize,
+}
 impl OpGuard {
     #[inline]
     fn enter() -> Self {
-        GC_OP_DEPTH.with(|d| d.set(d.get() + 1));
-        #[cfg(debug_assertions)]
-        if GC_OP_DEPTH.with(|d| d.get()) == 1 && MUT_ACTIVE.swap(true, Ordering::SeqCst) {
-            panic!("GC singleton exclusivity invariant violated: concurrent &mut access");
-        }
-        OpGuard
+        let prev = GC_OP_OWNER.swap(my_ident(), Ordering::SeqCst);
+        debug_assert!(
+            prev == 0,
+            "GC singleton exclusivity invariant violated: concurrent &mut access"
+        );
+        OpGuard { prev }
     }
 }
 impl Drop for OpGuard {
     #[inline]
     fn drop(&mut self) {
-        GC_OP_DEPTH.with(|d| d.set(d.get() - 1));
-        #[cfg(debug_assertions)]
-        if GC_OP_DEPTH.with(|d| d.get()) == 0 {
-            MUT_ACTIVE.store(false, Ordering::SeqCst);
-        }
+        GC_OP_OWNER.store(self.prev, Ordering::SeqCst);
     }
 }
 
 /// Whether this thread is already inside a `gc_op` / `request_stw` closure
-/// (i.e. a collection is running on this thread and holds the `&mut`).
+/// (i.e. a collection is running on this thread and holds the `&mut`). Uses an
+/// owner-word comparison against this thread's ident.
 #[inline]
 pub fn in_gc_op() -> bool {
-    GC_OP_DEPTH.with(|d| d.get() != 0)
+    GC_OP_OWNER.load(Ordering::Relaxed) == my_ident()
 }
 
 /// Shared reference to the singleton, re-derived from the static `UnsafeCell`.
@@ -265,17 +269,17 @@ pub fn gc_query_reentrant<R>(f: impl FnOnce(&dyn GcAllocator) -> R) -> R {
 /// `unregister_thread`.  When ≤ 1, `gc_op` skips the Mutex entirely.
 static REGISTERED_THREADS: AtomicUsize = AtomicUsize::new(0);
 
-/// Fast-path lock held while the single-thread path accesses `singleton_mut()`.
-/// CAS acquisition serialises all eligible callers, including unregistered
-/// callers, and slow paths drain its owner before accessing the singleton.
-static IN_FAST_PATH: AtomicBool = AtomicBool::new(false);
+/// Fast-path lock word: 0 when free, otherwise the holder thread's ident
+/// (`my_ident`), following rpy_fastgil (thread_gil.c:7-31). Self-ownership
+/// is checked by comparing against `my_ident()`.
+static IN_FAST_PATH: AtomicUsize = AtomicUsize::new(0);
 
 /// Register the current thread as a GC mutator. Paired with
 /// `unregister_thread`. An unregistered thread may still call `gc_op`; it is
 /// not counted for STW, but serialises through the same operation gate.
 pub fn register_thread() {
     assert!(
-        !THREAD_REGISTERED.with(|registered| registered.get()),
+        !GC_THREAD.with(|t| t.registered.get()),
         "GC mutator thread registered twice"
     );
     let old = REGISTERED_THREADS.fetch_add(1, Ordering::SeqCst);
@@ -283,7 +287,7 @@ pub fn register_thread() {
         // A second thread is arriving. Spin until the operation gate is free;
         // after this, existing callers see REGISTERED_THREADS > 1 and take the
         // Mutex path. CAS acquisition makes this stricter than the old marker.
-        while IN_FAST_PATH.load(Ordering::Acquire) {
+        while IN_FAST_PATH.load(Ordering::Acquire) != 0 {
             std::hint::spin_loop();
         }
     }
@@ -294,8 +298,8 @@ pub fn register_thread() {
         .wait_while(state, |_| GC_SYNC.stw_requested.load(Ordering::Acquire))
         .unwrap();
     state.running += 1;
-    THREAD_RUNNING.with(|running| running.set(true));
-    THREAD_REGISTERED.with(|registered| registered.set(true));
+    GC_THREAD.with(|t| t.running.set(true));
+    GC_THREAD.with(|t| t.registered.set(true));
     drop(state);
 
     if old > 0 && is_initialized() {
@@ -311,19 +315,19 @@ pub fn register_thread() {
 /// but this thread no longer participates in STW quiescence.
 pub fn unregister_thread() {
     assert!(
-        THREAD_REGISTERED.with(|registered| registered.get()),
+        GC_THREAD.with(|t| t.registered.get()),
         "unregistering an unregistered GC mutator thread"
     );
     let mut state = GC_SYNC.quiesce.lock().unwrap();
     assert!(
-        THREAD_RUNNING.with(|running| running.replace(false)),
+        GC_THREAD.with(|t| t.running.replace(false)),
         "unregistering a parked GC mutator thread"
     );
     state.running = state
         .running
         .checked_sub(1)
         .expect("RUNNING underflow during unregister_thread");
-    THREAD_REGISTERED.with(|registered| registered.set(false));
+    GC_THREAD.with(|t| t.registered.set(false));
     let old = REGISTERED_THREADS.fetch_sub(1, Ordering::SeqCst);
     assert!(old > 0, "REGISTERED_THREADS underflow");
     GC_SYNC.quiesced.notify_all();
@@ -344,7 +348,7 @@ pub fn registered_threads() -> usize {
 #[inline]
 pub fn stw_required() -> bool {
     let registered = REGISTERED_THREADS.load(Ordering::Acquire);
-    let self_registered = usize::from(THREAD_REGISTERED.with(|registered| registered.get()));
+    let self_registered = usize::from(GC_THREAD.with(|t| t.registered.get()));
     registered.saturating_sub(self_registered) > 0
 }
 
@@ -368,6 +372,7 @@ pub fn gc_op<R>(f: impl FnOnce(&mut dyn GcAllocator) -> R) -> R {
         return f(unsafe { singleton_mut() });
     }
 
+    let ident = my_ident();
     debug_assert!(
         !in_gc_op(),
         "reentrant &mut gc_op — a collection-time query must use gc_query_reentrant"
@@ -376,7 +381,7 @@ pub fn gc_op<R>(f: impl FnOnce(&mut dyn GcAllocator) -> R) -> R {
     if REGISTERED_THREADS.load(Ordering::Acquire) <= 1
         && !GC_SYNC.stw_requested.load(Ordering::Acquire)
         && IN_FAST_PATH
-            .compare_exchange(false, true, Ordering::Acquire, Ordering::Relaxed)
+            .compare_exchange(0, ident, Ordering::Acquire, Ordering::Relaxed)
             .is_ok()
     {
         // Recheck after acquiring the fast-path lock: another thread may have
@@ -386,22 +391,14 @@ pub fn gc_op<R>(f: impl FnOnce(&mut dyn GcAllocator) -> R) -> R {
         {
             // SAFETY: the fast-path lock excludes other fast operations, and
             // slow operations drain it before accessing the singleton.
-            assert!(
-                !THREAD_HOLDS_FAST_PATH.with(|held| held.replace(true)),
-                "nested single-thread GC fast path"
-            );
             let r = {
                 let _op = OpGuard::enter();
                 f(unsafe { singleton_mut() })
             };
-            assert!(
-                THREAD_HOLDS_FAST_PATH.with(|held| held.replace(false)),
-                "single-thread GC fast path marker cleared twice"
-            );
-            IN_FAST_PATH.store(false, Ordering::Release);
+            IN_FAST_PATH.store(0, Ordering::Release);
             return r;
         }
-        IN_FAST_PATH.store(false, Ordering::Release);
+        IN_FAST_PATH.store(0, Ordering::Release);
     }
     gc_op_slow(f)
 }
@@ -409,11 +406,12 @@ pub fn gc_op<R>(f: impl FnOnce(&mut dyn GcAllocator) -> R) -> R {
 /// Slow path: Mutex-guarded access with STW parking.
 #[cold]
 fn gc_op_slow<R>(f: impl FnOnce(&mut dyn GcAllocator) -> R) -> R {
-    let registered = THREAD_REGISTERED.with(|registered| registered.get());
+    let ident = my_ident();
+    let registered = GC_THREAD.with(|t| t.registered.get());
     if registered {
         let mut state = GC_SYNC.quiesce.lock().unwrap();
         assert!(
-            THREAD_RUNNING.with(|running| running.replace(false)),
+            GC_THREAD.with(|t| t.running.replace(false)),
             "GC mutator entered a gc_op safepoint twice"
         );
         state.running = state
@@ -430,15 +428,15 @@ fn gc_op_slow<R>(f: impl FnOnce(&mut dyn GcAllocator) -> R) -> R {
     // Drain a fast operation before borrowing the singleton. A fast holder
     // never waits on gc_mutex, so this terminates. Together with CAS acquisition
     // this makes fast and slow singleton accesses mutually exclusive.
-    let self_holds_fast_path = THREAD_HOLDS_FAST_PATH.with(|held| held.get());
-    while IN_FAST_PATH.load(Ordering::Acquire) && !self_holds_fast_path {
+    let self_holds_fast_path = IN_FAST_PATH.load(Ordering::Acquire) == ident;
+    while IN_FAST_PATH.load(Ordering::Acquire) != 0 && !self_holds_fast_path {
         std::hint::spin_loop();
     }
     if !self_holds_fast_path {
         // Claim the gate after draining so a new fast operation cannot start
         // between the final observation above and the singleton borrow.
         while IN_FAST_PATH
-            .compare_exchange(false, true, Ordering::Acquire, Ordering::Relaxed)
+            .compare_exchange(0, ident, Ordering::Acquire, Ordering::Relaxed)
             .is_err()
         {
             std::hint::spin_loop();
@@ -455,7 +453,7 @@ fn gc_op_slow<R>(f: impl FnOnce(&mut dyn GcAllocator) -> R) -> R {
         );
         state.running += 1;
         assert!(
-            !THREAD_RUNNING.with(|running| running.replace(true)),
+            !GC_THREAD.with(|t| t.running.replace(true)),
             "GC mutator re-entered RUNNING twice"
         );
     }
@@ -469,7 +467,7 @@ fn gc_op_slow<R>(f: impl FnOnce(&mut dyn GcAllocator) -> R) -> R {
         f(unsafe { singleton_mut() })
     };
     if !self_holds_fast_path {
-        IN_FAST_PATH.store(false, Ordering::Release);
+        IN_FAST_PATH.store(0, Ordering::Release);
     }
     result
 }
@@ -497,16 +495,9 @@ pub struct StwGuard {
 /// Quiesce every other registered mutator when the process-global GC is shared.
 /// A registered collecting thread stays in RUNNING while collection executes.
 pub fn quiesce_mutators() -> StwGuard {
-    let nested = STW_DEPTH.with(|depth| {
-        let old = depth.get();
-        if old != 0 {
-            depth.set(old + 1);
-            true
-        } else {
-            false
-        }
-    });
-    if nested {
+    let ident = my_ident();
+    if STW_OWNER.load(Ordering::Acquire) == ident {
+        STW_DEPTH.fetch_add(1, Ordering::Relaxed);
         return StwGuard {
             active: true,
             owner: false,
@@ -523,15 +514,16 @@ pub fn quiesce_mutators() -> StwGuard {
     let mut state = GC_SYNC.quiesce.lock().unwrap();
     GC_SYNC.stw_requested.store(true, Ordering::Release);
 
-    let collector_is_running = THREAD_REGISTERED.with(|registered| registered.get())
-        && THREAD_RUNNING.with(|running| running.get());
+    let collector_is_running =
+        GC_THREAD.with(|t| t.registered.get()) && GC_THREAD.with(|t| t.running.get());
     let drain_target = usize::from(collector_is_running);
     state = GC_SYNC
         .quiesced
         .wait_while(state, |state| state.running != drain_target)
         .unwrap();
     drop(state);
-    STW_DEPTH.with(|depth| depth.set(1));
+    STW_OWNER.store(ident, Ordering::Release);
+    STW_DEPTH.store(1, Ordering::Relaxed);
 
     StwGuard {
         active: true,
@@ -542,7 +534,7 @@ pub fn quiesce_mutators() -> StwGuard {
 /// Whether this thread currently owns or is nested inside collector-side STW.
 #[inline]
 pub fn mutators_quiesced() -> bool {
-    STW_DEPTH.with(|depth| depth.get() != 0)
+    STW_OWNER.load(Ordering::Acquire) == my_ident()
 }
 
 impl Drop for StwGuard {
@@ -550,16 +542,14 @@ impl Drop for StwGuard {
         if !self.active {
             return;
         }
-        let remaining = STW_DEPTH.with(|depth| {
-            let old = depth.get();
-            assert!(old > 0, "STW_DEPTH underflow");
-            depth.set(old - 1);
-            old - 1
-        });
+        let old = STW_DEPTH.fetch_sub(1, Ordering::Relaxed);
+        assert!(old > 0, "STW_DEPTH underflow");
+        let remaining = old - 1;
         if !self.owner {
             return;
         }
         assert_eq!(remaining, 0, "outer STW guard dropped before nested guard");
+        STW_OWNER.store(0, Ordering::Release);
 
         let _state = GC_SYNC.quiesce.lock().unwrap();
         GC_SYNC.stw_requested.store(false, Ordering::Release);
@@ -583,9 +573,7 @@ pub fn request_stw(collect_fn: impl FnOnce(&mut dyn GcAllocator)) {
 
 /// Park the current thread until the ongoing STW finishes.
 fn park_until_stw_done() {
-    if !THREAD_REGISTERED.with(|registered| registered.get())
-        || !THREAD_RUNNING.with(|running| running.get())
-    {
+    if !GC_THREAD.with(|t| t.registered.get()) || !GC_THREAD.with(|t| t.running.get()) {
         return;
     }
 
@@ -594,7 +582,7 @@ fn park_until_stw_done() {
         return;
     }
     assert!(
-        THREAD_RUNNING.with(|running| running.replace(false)),
+        GC_THREAD.with(|t| t.running.replace(false)),
         "GC mutator entered a dispatch safepoint twice"
     );
     state.running = state
@@ -609,7 +597,7 @@ fn park_until_stw_done() {
         .unwrap();
     state.running += 1;
     assert!(
-        !THREAD_RUNNING.with(|running| running.replace(true)),
+        !GC_THREAD.with(|t| t.running.replace(true)),
         "GC mutator left a dispatch safepoint twice"
     );
 }

--- a/majit/majit-gc/src/gc_sync.rs
+++ b/majit/majit-gc/src/gc_sync.rs
@@ -43,31 +43,30 @@ pub struct GcSync {
     /// (P0). Held for full STW duration during collection.
     gc_mutex: Mutex<()>,
     /// Set to true when a thread wants to collect. Other threads park
-    /// at their next poll point (= every gc_op call in P0).
+    /// at their next gc_op or runtime dispatch poll.
     stw_requested: AtomicBool,
-    /// Number of threads currently inside a gc_op (between gc_mutex lock
-    /// and unlock). The collector waits for this to reach 0.
-    /// Note: in P0, a thread inside gc_op holds gc_mutex, so at most 1
-    /// thread is inside at a time. This counter exists for P1 (TLAB)
-    /// where alloc won't hold the mutex.
-    #[allow(dead_code)] // reserved for P1 (TLAB): unread until alloc stops holding gc_mutex
-    active_in_gc_op: AtomicUsize,
-    /// Signalled when the last active thread exits gc_op during STW.
-    #[allow(dead_code)] // reserved for P1 (TLAB): pairs with active_in_gc_op
-    all_parked: Condvar,
-    /// Signalled when STW ends (collector finished, mutators can resume).
-    stw_done: Condvar,
+    /// RUNNING mutator count. A registered thread is removed before it waits
+    /// on gc_mutex, so a collector holding gc_mutex can drain this to zero.
+    quiesce: Mutex<QuiesceState>,
+    /// Signalled whenever RUNNING decreases, including the transition to zero.
+    quiesced: Condvar,
+    /// Signalled when STW ends and parked mutators may become RUNNING again.
+    resumed: Condvar,
     /// Generation counter incremented after each STW. Prevents spurious
     /// wake: a thread checks that generation changed before proceeding.
     stw_generation: AtomicUsize,
 }
 
+struct QuiesceState {
+    running: usize,
+}
+
 static GC_SYNC: GcSync = GcSync {
     gc_mutex: Mutex::new(()),
     stw_requested: AtomicBool::new(false),
-    active_in_gc_op: AtomicUsize::new(0),
-    all_parked: Condvar::new(),
-    stw_done: Condvar::new(),
+    quiesce: Mutex::new(QuiesceState { running: 0 }),
+    quiesced: Condvar::new(),
+    resumed: Condvar::new(),
     stw_generation: AtomicUsize::new(0),
 };
 
@@ -165,6 +164,18 @@ thread_local! {
     /// via a shared read instead of a second `gc_mutex` lock (deadlock) or a
     /// second `&mut` (aliasing).
     static GC_OP_DEPTH: Cell<u32> = const { Cell::new(0) };
+
+    /// Whether this thread has completed `register_thread` and is represented
+    /// in the RUNNING count.
+    static THREAD_REGISTERED: Cell<bool> = const { Cell::new(false) };
+
+    /// Registered mutators are normally RUNNING. Outermost slow gc_op regions
+    /// and safepoint parks flip this to false until they resume.
+    static THREAD_RUNNING: Cell<bool> = const { Cell::new(false) };
+
+    /// Reentrancy depth for collector-side quiescence. do_collect_full calls
+    /// do_collect_nursery, so only the outer guard owns the STW transition.
+    static STW_DEPTH: Cell<u32> = const { Cell::new(0) };
 }
 
 /// RAII marker: raises `GC_OP_DEPTH` for the exact span of a closure that holds
@@ -240,6 +251,10 @@ static IN_FAST_PATH: AtomicBool = AtomicBool::new(false);
 /// Register the current thread as a GC mutator.  Must be called before
 /// any `gc_op` on this thread.  Paired with `unregister_thread`.
 pub fn register_thread() {
+    assert!(
+        !THREAD_REGISTERED.with(|registered| registered.get()),
+        "GC mutator thread registered twice"
+    );
     let old = REGISTERED_THREADS.fetch_add(1, Ordering::SeqCst);
     if old > 0 {
         // A second thread is arriving.  Spin until any in-progress
@@ -249,17 +264,102 @@ pub fn register_thread() {
             std::hint::spin_loop();
         }
     }
+
+    let mut state = GC_SYNC.quiesce.lock().unwrap();
+    state = GC_SYNC
+        .resumed
+        .wait_while(state, |_| GC_SYNC.stw_requested.load(Ordering::Acquire))
+        .unwrap();
+    state.running += 1;
+    THREAD_RUNNING.with(|running| running.set(true));
+    THREAD_REGISTERED.with(|registered| registered.set(true));
 }
 
 /// Unregister the current thread.  After this, gc_op must not be
 /// called from this thread.
 pub fn unregister_thread() {
-    REGISTERED_THREADS.fetch_sub(1, Ordering::SeqCst);
+    assert!(
+        THREAD_REGISTERED.with(|registered| registered.get()),
+        "unregistering an unregistered GC mutator thread"
+    );
+    let mut state = GC_SYNC.quiesce.lock().unwrap();
+    assert!(
+        THREAD_RUNNING.with(|running| running.replace(false)),
+        "unregistering a parked GC mutator thread"
+    );
+    state.running = state
+        .running
+        .checked_sub(1)
+        .expect("RUNNING underflow during unregister_thread");
+    THREAD_REGISTERED.with(|registered| registered.set(false));
+    let old = REGISTERED_THREADS.fetch_sub(1, Ordering::SeqCst);
+    assert!(old > 0, "REGISTERED_THREADS underflow");
+    GC_SYNC.quiesced.notify_all();
+}
+
+/// Number of registered GC mutators.
+#[inline]
+pub fn registered_threads() -> usize {
+    REGISTERED_THREADS.load(Ordering::Acquire)
 }
 
 // ──────────────────────────────────────────────────────────────
 // GC operation gate — fast path when single-threaded
 // ──────────────────────────────────────────────────────────────
+
+/// A registered mutator's outermost slow gc_op is a safe region for its
+/// complete duration, including time blocked on gc_mutex.
+struct SafeRegionGuard {
+    active: bool,
+}
+
+impl SafeRegionGuard {
+    fn enter() -> Self {
+        let registered = THREAD_REGISTERED.with(|registered| registered.get());
+        let needs_safe_region = registered
+            && (REGISTERED_THREADS.load(Ordering::Acquire) > 1
+                || GC_SYNC.stw_requested.load(Ordering::Acquire));
+        if !needs_safe_region || in_gc_op() {
+            return Self { active: false };
+        }
+
+        let mut state = GC_SYNC.quiesce.lock().unwrap();
+        assert!(
+            THREAD_RUNNING.with(|running| running.replace(false)),
+            "GC mutator entered a safe region twice"
+        );
+        state.running = state
+            .running
+            .checked_sub(1)
+            .expect("RUNNING underflow entering gc_op safe region");
+        GC_SYNC.quiesced.notify_all();
+
+        state = GC_SYNC
+            .resumed
+            .wait_while(state, |_| GC_SYNC.stw_requested.load(Ordering::Acquire))
+            .unwrap();
+        drop(state);
+        Self { active: true }
+    }
+}
+
+impl Drop for SafeRegionGuard {
+    fn drop(&mut self) {
+        if !self.active {
+            return;
+        }
+        let mut state = GC_SYNC.quiesce.lock().unwrap();
+        state = GC_SYNC
+            .resumed
+            .wait_while(state, |_| GC_SYNC.stw_requested.load(Ordering::Acquire))
+            .unwrap();
+        state.running += 1;
+        assert!(
+            !THREAD_RUNNING.with(|running| running.replace(true)),
+            "GC mutator left a safe region twice"
+        );
+    }
+}
 
 /// Execute a closure with exclusive `&mut dyn GcAllocator` access.
 ///
@@ -307,18 +407,11 @@ pub fn gc_op<R>(f: impl FnOnce(&mut dyn GcAllocator) -> R) -> R {
 /// Slow path: Mutex-guarded access with STW parking.
 #[cold]
 fn gc_op_slow<R>(f: impl FnOnce(&mut dyn GcAllocator) -> R) -> R {
-    if GC_SYNC.stw_requested.load(Ordering::Acquire) {
-        park_until_stw_done();
-    }
+    // Enter the safe region before acquiring gc_mutex. A thread blocked on
+    // the mutex is therefore already excluded from RUNNING, which lets the
+    // collector hold gc_mutex while waiting for RUNNING == 0.
+    let _safe = SafeRegionGuard::enter();
     let _guard = GC_SYNC.gc_mutex.lock().unwrap();
-    if GC_SYNC.stw_requested.load(Ordering::Acquire) {
-        drop(_guard);
-        park_until_stw_done();
-        let _guard = GC_SYNC.gc_mutex.lock().unwrap();
-        let _held = GateHeldGuard::enter();
-        let _op = OpGuard::enter();
-        return f(unsafe { singleton_mut() });
-    }
     let _held = GateHeldGuard::enter();
     let _op = OpGuard::enter();
     f(unsafe { singleton_mut() })
@@ -335,6 +428,122 @@ pub fn gc_query<R>(f: impl FnOnce(&dyn GcAllocator) -> R) -> R {
 // STW protocol
 // ──────────────────────────────────────────────────────────────
 
+/// RAII stop-the-world guard used by collection drivers.
+///
+/// Nested guards only raise STW_DEPTH; the outer guard owns the request,
+/// RUNNING drain, and resume broadcast.
+pub struct StwGuard {
+    active: bool,
+    owner: bool,
+    restore_fast_collector: bool,
+}
+
+/// Quiesce every registered mutator when the process-global GC is shared.
+/// The collecting thread is normally already safe because collection runs
+/// inside an outermost slow gc_op.
+pub fn quiesce_mutators() -> StwGuard {
+    let nested = STW_DEPTH.with(|depth| {
+        let old = depth.get();
+        if old != 0 {
+            depth.set(old + 1);
+            true
+        } else {
+            false
+        }
+    });
+    if nested {
+        return StwGuard {
+            active: true,
+            owner: false,
+            restore_fast_collector: false,
+        };
+    }
+
+    if REGISTERED_THREADS.load(Ordering::Acquire) <= 1 {
+        return StwGuard {
+            active: false,
+            owner: false,
+            restore_fast_collector: false,
+        };
+    }
+
+    let mut state = GC_SYNC.quiesce.lock().unwrap();
+    GC_SYNC.stw_requested.store(true, Ordering::Release);
+
+    // The 1→2 registration transition publishes REGISTERED_THREADS before it
+    // waits for the old single-thread fast operation to finish. If that very
+    // operation fills the nursery, make its collecting thread safe and release
+    // the transition waiter; stw_requested prevents any new fast operation.
+    let restore_fast_collector = IN_FAST_PATH.load(Ordering::Acquire)
+        && in_gc_op()
+        && THREAD_REGISTERED.with(|registered| registered.get())
+        && THREAD_RUNNING.with(|running| running.get());
+    if restore_fast_collector {
+        THREAD_RUNNING.with(|running| running.set(false));
+        state.running = state
+            .running
+            .checked_sub(1)
+            .expect("RUNNING underflow quiescing fast-path collector");
+        IN_FAST_PATH.store(false, Ordering::Release);
+        GC_SYNC.quiesced.notify_all();
+    }
+
+    // Any other fast operation began before the multi-thread transition and
+    // will finish without consulting the quiesce mutex.
+    while IN_FAST_PATH.load(Ordering::Acquire) {
+        std::hint::spin_loop();
+    }
+
+    state = GC_SYNC
+        .quiesced
+        .wait_while(state, |state| state.running != 0)
+        .unwrap();
+    drop(state);
+    STW_DEPTH.with(|depth| depth.set(1));
+
+    StwGuard {
+        active: true,
+        owner: true,
+        restore_fast_collector,
+    }
+}
+
+/// Whether this thread currently owns or is nested inside collector-side STW.
+#[inline]
+pub fn mutators_quiesced() -> bool {
+    STW_DEPTH.with(|depth| depth.get() != 0)
+}
+
+impl Drop for StwGuard {
+    fn drop(&mut self) {
+        if !self.active {
+            return;
+        }
+        let remaining = STW_DEPTH.with(|depth| {
+            let old = depth.get();
+            assert!(old > 0, "STW_DEPTH underflow");
+            depth.set(old - 1);
+            old - 1
+        });
+        if !self.owner {
+            return;
+        }
+        assert_eq!(remaining, 0, "outer STW guard dropped before nested guard");
+
+        let mut state = GC_SYNC.quiesce.lock().unwrap();
+        if self.restore_fast_collector {
+            state.running += 1;
+            assert!(
+                !THREAD_RUNNING.with(|running| running.replace(true)),
+                "fast-path collector resumed twice"
+            );
+        }
+        GC_SYNC.stw_requested.store(false, Ordering::Release);
+        GC_SYNC.stw_generation.fetch_add(1, Ordering::Release);
+        GC_SYNC.resumed.notify_all();
+    }
+}
+
 /// Request stop-the-world collection. The calling thread becomes the
 /// collector: it waits for all other threads to park, runs `collect_fn`
 /// with exclusive GC access, then resumes everyone.
@@ -342,48 +551,25 @@ pub fn gc_query<R>(f: impl FnOnce(&dyn GcAllocator) -> R) -> R {
 /// `collect_fn` receives `&mut dyn GcAllocator` — it can call
 /// `collect_nursery`, `collect_full`, etc.
 pub fn request_stw(collect_fn: impl FnOnce(&mut dyn GcAllocator)) {
-    GC_SYNC.stw_requested.store(true, Ordering::Release);
-
-    // Wait for any in-progress fast-path gc_op to finish.
-    while IN_FAST_PATH.load(Ordering::Acquire) {
-        std::hint::spin_loop();
-    }
-
-    // Acquire gc_mutex — ensures no thread is mid-slow-path gc_op.
-    let guard = GC_SYNC.gc_mutex.lock().unwrap();
-
-    // SAFETY: gc_mutex held + fast path blocked by stw_requested +
-    // IN_FAST_PATH drained. No concurrent singleton access.
-    {
-        let _held = GateHeldGuard::enter();
-        let _op = OpGuard::enter();
-        collect_fn(unsafe { singleton_mut() });
-    }
-
-    // Resume all parked threads.
-    GC_SYNC.stw_requested.store(false, Ordering::Release);
-    GC_SYNC.stw_generation.fetch_add(1, Ordering::Release);
-    GC_SYNC.stw_done.notify_all();
-    drop(guard);
+    gc_op(|gc| {
+        let _stw = quiesce_mutators();
+        collect_fn(gc);
+    });
 }
 
 /// Park the current thread until the ongoing STW finishes.
 fn park_until_stw_done() {
-    let gen_before = GC_SYNC.stw_generation.load(Ordering::Acquire);
-    let guard = GC_SYNC.gc_mutex.lock().unwrap();
-    // Re-check: STW may have finished between our check and lock.
-    if !GC_SYNC.stw_requested.load(Ordering::Acquire) {
-        drop(guard);
-        return;
+    let safe = SafeRegionGuard::enter();
+    drop(safe);
+}
+
+/// Poll for a collector request at a runtime dispatch safepoint.
+/// Steady state is one relaxed atomic load.
+#[inline]
+pub fn safepoint_poll() {
+    if GC_SYNC.stw_requested.load(Ordering::Relaxed) {
+        park_until_stw_done();
     }
-    // Wait until generation advances (STW completed).
-    let _guard = GC_SYNC
-        .stw_done
-        .wait_while(guard, |_| {
-            GC_SYNC.stw_generation.load(Ordering::Acquire) == gen_before
-                && GC_SYNC.stw_requested.load(Ordering::Acquire)
-        })
-        .unwrap();
 }
 
 // ──────────────────────────────────────────────────────────────
@@ -393,7 +579,8 @@ fn park_until_stw_done() {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::collector::MiniMarkGC;
+    use crate::collector::{GcConfig, MiniMarkGC};
+    use crate::trace::TypeInfo;
     use std::sync::atomic::AtomicUsize;
     use std::sync::{Arc, Barrier};
 
@@ -402,14 +589,25 @@ mod tests {
             let gc = Box::new(MiniMarkGC::new());
             store_singleton(gc);
         }
+    }
+
+    fn register_test_mutator() {
+        crate::shadow_stack::register_mutator();
         register_thread();
+    }
+
+    fn unregister_test_mutator() {
+        crate::shadow_stack::unregister_mutator();
+        unregister_thread();
     }
 
     #[test]
     fn gc_op_basic() {
         ensure_gc();
+        register_test_mutator();
         let result = gc_op(|gc| gc.nursery_free());
         assert!(!result.is_null());
+        unregister_test_mutator();
     }
 
     #[test]
@@ -426,6 +624,7 @@ mod tests {
     #[ignore = "requires exclusive process — conflicts with other majit-gc tests' local GCs"]
     fn two_threads_alloc_no_race() {
         ensure_gc();
+        register_test_mutator();
 
         let counter = Arc::new(AtomicUsize::new(0));
         let barrier = Arc::new(Barrier::new(2));
@@ -435,7 +634,7 @@ mod tests {
                 let c = counter.clone();
                 let b = barrier.clone();
                 std::thread::spawn(move || {
-                    register_thread();
+                    register_test_mutator();
                     b.wait();
                     for _ in 0..100 {
                         gc_op(|_gc| {
@@ -444,7 +643,7 @@ mod tests {
                             c.store(v + 1, Ordering::Relaxed);
                         });
                     }
-                    unregister_thread();
+                    unregister_test_mutator();
                 })
             })
             .collect();
@@ -455,12 +654,14 @@ mod tests {
 
         // With gc_mutex serialisation, counter should be exactly 200.
         assert_eq!(counter.load(Ordering::Relaxed), 200);
+        unregister_test_mutator();
     }
 
     #[test]
     #[ignore = "requires exclusive process — conflicts with other majit-gc tests' local GCs"]
     fn stw_blocks_concurrent_gc_ops() {
         ensure_gc();
+        register_test_mutator();
 
         let stw_ran = Arc::new(AtomicBool::new(false));
         let stw_ran2 = stw_ran.clone();
@@ -470,7 +671,11 @@ mod tests {
         let b2 = barrier.clone();
 
         let worker = std::thread::spawn(move || {
+            register_test_mutator();
             b2.wait();
+            while !GC_SYNC.stw_requested.load(Ordering::Acquire) {
+                std::hint::spin_loop();
+            }
             // This gc_op should block until STW finishes.
             gc_op(|_gc| {
                 assert!(
@@ -478,12 +683,10 @@ mod tests {
                     "gc_op should only run after STW completes"
                 );
             });
+            unregister_test_mutator();
         });
 
         barrier.wait();
-        // Small delay to let worker reach gc_op.
-        std::thread::sleep(std::time::Duration::from_millis(10));
-
         request_stw(|_gc| {
             stw_ran.store(true, Ordering::Release);
             // Simulate collection work.
@@ -491,5 +694,72 @@ mod tests {
         });
 
         worker.join().unwrap();
+        unregister_test_mutator();
+    }
+
+    #[test]
+    #[ignore = "requires exclusive process — conflicts with other majit-gc tests' local GCs"]
+    fn multithreaded_collections_preserve_each_mutators_roots() {
+        if !is_initialized() {
+            let mut gc = MiniMarkGC::with_config(GcConfig {
+                nursery_size: 64 * 1024,
+                large_object_threshold: 32 * 1024,
+                ..GcConfig::default()
+            });
+            let type_id = gc.register_type(TypeInfo::simple(16));
+            assert_eq!(type_id, 0);
+            store_singleton(Box::new(gc));
+        }
+
+        const THREADS: usize = 4;
+        const ROUNDS: usize = 32;
+        const ALLOCS_PER_ROUND: usize = 40;
+        let start = Arc::new(Barrier::new(THREADS));
+        let handles: Vec<_> = (0..THREADS)
+            .map(|thread_index| {
+                let start = start.clone();
+                std::thread::spawn(move || {
+                    register_test_mutator();
+                    start.wait();
+
+                    let expected = 0xCAFE_0000_0000_0000u64 | thread_index as u64;
+                    let root_depth = gc_op(|gc| {
+                        let object = gc.alloc_nursery_typed(0, 16);
+                        unsafe { *(object.0 as *mut u64) = expected };
+                        crate::shadow_stack::push(object)
+                    });
+
+                    for _ in 0..ROUNDS {
+                        gc_op(|gc| {
+                            let object = crate::shadow_stack::get(root_depth);
+                            assert_eq!(unsafe { *(object.0 as *const u64) }, expected);
+                            for _ in 0..ALLOCS_PER_ROUND {
+                                let junk = gc.alloc_nursery_typed(0, 2048);
+                                unsafe { *(junk.0 as *mut u64) = 0xBAD0_BAD0_BAD0_BAD0 };
+                            }
+                            gc.collect_nursery();
+                        });
+
+                        gc_op(|_gc| {
+                            let object = crate::shadow_stack::get(root_depth);
+                            assert_eq!(unsafe { *(object.0 as *const u64) }, expected);
+                        });
+                    }
+
+                    crate::shadow_stack::pop_to(root_depth);
+                    unregister_test_mutator();
+                })
+            })
+            .collect();
+
+        for handle in handles {
+            handle.join().unwrap();
+        }
+        assert_eq!(registered_threads(), 0);
+
+        register_test_mutator();
+        let minor_collections = gc_op(|gc| gc.collection_counts().0);
+        unregister_test_mutator();
+        assert!(minor_collections >= THREADS * ROUNDS);
     }
 }

--- a/majit/majit-gc/src/gc_sync.rs
+++ b/majit/majit-gc/src/gc_sync.rs
@@ -75,29 +75,6 @@ static GC_SYNC: GcSync = GcSync {
     stw_generation: AtomicUsize::new(0),
 };
 
-thread_local! {
-    /// > 0 while this thread already holds exclusive GC access via a
-    /// slow-path `gc_op_slow` or a `request_stw` collection. Nested
-    /// `gc_op`/`gc_query` on the same thread then run directly on the
-    /// singleton instead of re-locking the non-reentrant `gc_mutex`.
-    static GATE_HELD_DEPTH: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
-}
-
-struct GateHeldGuard;
-
-impl GateHeldGuard {
-    fn enter() -> Self {
-        GATE_HELD_DEPTH.with(|c| c.set(c.get() + 1));
-        GateHeldGuard
-    }
-}
-
-impl Drop for GateHeldGuard {
-    fn drop(&mut self) {
-        GATE_HELD_DEPTH.with(|c| c.set(c.get() - 1));
-    }
-}
-
 // ──────────────────────────────────────────────────────────────
 // Singleton management
 // ──────────────────────────────────────────────────────────────
@@ -376,13 +353,6 @@ pub fn stw_required() -> bool {
 /// Single-threaded production always takes the fast path.
 #[inline]
 pub fn gc_op<R>(f: impl FnOnce(&mut dyn GcAllocator) -> R) -> R {
-    if GATE_HELD_DEPTH.with(|c| c.get()) > 0 {
-        // This thread already holds exclusive GC access during collection.
-        // SAFETY: gc_mutex is held by this thread, so there is no concurrent
-        // access to the singleton.
-        return f(unsafe { singleton_mut() });
-    }
-
     let ident = my_ident();
     debug_assert!(
         !in_gc_op(),
@@ -470,7 +440,6 @@ fn gc_op_slow<R>(f: impl FnOnce(&mut dyn GcAllocator) -> R) -> R {
     }
 
     let result = {
-        let _held = GateHeldGuard::enter();
         let _op = OpGuard::enter();
         // There is deliberately no exit park. A returned reference is rooted
         // by the caller before its next entry-style safepoint, matching the
@@ -665,11 +634,12 @@ mod tests {
     }
 
     #[test]
-    fn nested_gc_query_inside_slow_path_gc_op_does_not_deadlock() {
+    fn nested_reentrant_query_inside_gc_op_reads_singleton() {
         ensure_gc();
         register_thread();
-        // Outer gc_op holds gc_mutex; the nested gc_query must not re-lock it.
-        let ok = gc_op(|_outer| gc_query(|gc| !gc.nursery_free().is_null()));
+        // The reentrant query reads the singleton directly instead of
+        // re-entering the operation gate.
+        let ok = gc_op(|_outer| gc_query_reentrant(|gc| !gc.nursery_free().is_null()));
         assert!(ok);
         unregister_thread();
     }

--- a/majit/majit-gc/src/gc_sync.rs
+++ b/majit/majit-gc/src/gc_sync.rs
@@ -335,6 +335,19 @@ pub fn registered_threads() -> usize {
     REGISTERED_THREADS.load(Ordering::Acquire)
 }
 
+/// Whether a stop-the-world pause is required for a collection driven by the
+/// current thread: true iff at least one *other* thread is a registered mutator.
+/// The current thread is excluded because the collector walks its own roots
+/// directly (`walk_my_*`); the danger is an unwaited, unscanned OTHER mutator.
+/// An unregistered collector with one registered mutator elsewhere still needs
+/// STW, which the bare count `> 1` check misses.
+#[inline]
+pub fn stw_required() -> bool {
+    let registered = REGISTERED_THREADS.load(Ordering::Acquire);
+    let self_registered = usize::from(THREAD_REGISTERED.with(|registered| registered.get()));
+    registered.saturating_sub(self_registered) > 0
+}
+
 // ──────────────────────────────────────────────────────────────
 // GC operation gate — fast path when single-threaded
 // ──────────────────────────────────────────────────────────────
@@ -500,7 +513,7 @@ pub fn quiesce_mutators() -> StwGuard {
         };
     }
 
-    if REGISTERED_THREADS.load(Ordering::Acquire) <= 1 {
+    if !stw_required() {
         return StwGuard {
             active: false,
             owner: false,

--- a/majit/majit-gc/src/hook_cell.rs
+++ b/majit/majit-gc/src/hook_cell.rs
@@ -1,0 +1,167 @@
+//! Process-global fn-pointer hook cells.
+//!
+//! [`FnPtrCell`] is the free-threading replacement for a
+//! `thread_local! { static X: Cell<Option<fn(..)>> }` GC hook. Before the GC
+//! became a process-global singleton (`gc_sync`), each thread could own a
+//! distinct GC and installed its own hook fn pointers; now every thread
+//! installs the *same* pointer, so the per-thread copy is redundant and — for
+//! a collector that may run on an arbitrary thread — unsound (a thread that
+//! never ran the install path would collect with the hook unset).
+//!
+//! The value is a bare `fn(..)` pointer, which is thin and pointer-sized, so
+//! it is stored bit-for-bit in an [`AtomicPtr<()>`] with the null pointer
+//! standing in for `None`. This keeps the read side a single acquire atomic
+//! load plus a null check — no lock, no heap — matching the cost of the TLS
+//! access it replaces on the allocation hot path.
+//!
+//! Registration mirrors [`crate::shadow_stack::register_extra_root_walker`]:
+//! the hooks are process-global constants fixed once at boot (the runtime
+//! substitute for RPython's translation-time weaving against a global
+//! `gcdata`). Overwrite and clear (`None`) remain supported because the test
+//! harness installs mock hooks and resets them; production installs each hook
+//! exactly once under a `Once`.
+
+use std::marker::PhantomData;
+use std::sync::atomic::{AtomicPtr, Ordering};
+
+/// A process-global cell holding an optional bare `fn` pointer of type `F`.
+///
+/// `F` must be a bare function-pointer type (`fn(..) -> ..`), which is
+/// pointer-sized and thin; this is enforced by a size `debug_assert` on every
+/// access and would be a compile-time-visible mismatch for any wider `F`.
+pub struct FnPtrCell<F: Copy> {
+    ptr: AtomicPtr<()>,
+    _marker: PhantomData<F>,
+}
+
+// SAFETY: the stored value is a code address (a bare fn pointer), which is
+// itself `Send + Sync`; all access is through the `AtomicPtr`, which provides
+// the synchronization. `PhantomData<F>` carries no runtime state.
+unsafe impl<F: Copy> Sync for FnPtrCell<F> {}
+
+impl<F: Copy> FnPtrCell<F> {
+    /// Compile-time guard: `F` must be pointer-sized, i.e. a bare `fn(..)`
+    /// pointer. `transmute_copy` does not check sizes, so a wider `F` would
+    /// read out of bounds in `get`/`set`; forcing this associated const in
+    /// both turns that into a build error instead of release-only UB.
+    const SIZE_OK: () = assert!(
+        std::mem::size_of::<F>() == std::mem::size_of::<*mut ()>(),
+        "FnPtrCell<F>: F must be a pointer-sized bare fn pointer",
+    );
+
+    /// A cell with no hook installed (`None`).
+    pub const fn new() -> Self {
+        Self {
+            ptr: AtomicPtr::new(std::ptr::null_mut()),
+            _marker: PhantomData,
+        }
+    }
+
+    /// Read the installed hook, or `None` if unset/cleared.
+    ///
+    /// `Acquire` pairs with the `Release` store in [`Self::set`] so a reader
+    /// that observes the pointer also observes everything the installer
+    /// published before it. On x86-64/aarch64 an acquire load is a plain load,
+    /// so this is no more expensive than the thread-local read it replaces.
+    #[inline]
+    pub fn get(&self) -> Option<F> {
+        let () = Self::SIZE_OK;
+        let p = self.ptr.load(Ordering::Acquire);
+        if p.is_null() {
+            None
+        } else {
+            // SAFETY: `p` is non-null and was produced by `set` from a value of
+            // type `F` (a pointer-sized fn pointer, per SIZE_OK); reinterpreting
+            // its bits back to `F` round-trips the original pointer.
+            Some(unsafe { std::mem::transmute_copy::<*mut (), F>(&p) })
+        }
+    }
+
+    /// Install (`Some`) or clear (`None`) the hook.
+    ///
+    /// Production installs each hook once at boot; the setter tolerates being
+    /// called again with the same value (idempotent) and supports clearing so
+    /// the `#[cfg(test)]` isolation seam can reset between tests.
+    pub fn set(&self, f: Option<F>) {
+        let () = Self::SIZE_OK;
+        let raw: *mut () = match f {
+            None => std::ptr::null_mut(),
+            Some(f) => {
+                // SAFETY: `F` is a pointer-sized bare fn pointer (per SIZE_OK);
+                // reinterpret its bits as an erased data pointer for storage.
+                // `set(None)` stores null, which `get` reads back as `None`.
+                unsafe { std::mem::transmute_copy::<F, *mut ()>(&f) }
+            }
+        };
+        self.ptr.store(raw, Ordering::Release);
+    }
+}
+
+impl<F: Copy> Default for FnPtrCell<F> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Declare a process-global fn-pointer hook cell backed by [`FnPtrCell`].
+///
+/// Replaces a `thread_local! { static NAME: Cell<Option<Fn>> = .. }` hook with
+/// a process-global `static NAME: FnPtrCell<Fn>`. The accessor functions
+/// (`set_*` / `try_*` / getters) stay hand-written so their attributes
+/// (`#[dont_look_inside]`, `extern "C"`) and per-hook fallback values are
+/// preserved; they just read/write `NAME` via [`FnPtrCell::get`] /
+/// [`FnPtrCell::set`] instead of `NAME.with(..)`.
+///
+/// ```ignore
+/// majit_gc::global_hook!(static ACTIVE_CAN_MOVE: CanMoveFn);
+/// ```
+#[macro_export]
+macro_rules! global_hook {
+    ($(#[$attr:meta])* $vis:vis static $name:ident : $fnty:ty) => {
+        $(#[$attr])*
+        $vis static $name: $crate::hook_cell::FnPtrCell<$fnty> =
+            $crate::hook_cell::FnPtrCell::new();
+    };
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    type UnaryFn = fn(usize) -> usize;
+
+    static CELL: FnPtrCell<UnaryFn> = FnPtrCell::new();
+
+    fn double(x: usize) -> usize {
+        x * 2
+    }
+    fn triple(x: usize) -> usize {
+        x * 3
+    }
+
+    #[test]
+    fn none_when_unset() {
+        let cell: FnPtrCell<UnaryFn> = FnPtrCell::new();
+        assert!(cell.get().is_none());
+    }
+
+    #[test]
+    fn roundtrips_install_overwrite_clear() {
+        let cell: FnPtrCell<UnaryFn> = FnPtrCell::new();
+        cell.set(Some(double));
+        assert_eq!(cell.get().unwrap()(21), 42);
+        // overwrite with a different value
+        cell.set(Some(triple));
+        assert_eq!(cell.get().unwrap()(2), 6);
+        // clear
+        cell.set(None);
+        assert!(cell.get().is_none());
+    }
+
+    #[test]
+    fn static_cell_usable() {
+        CELL.set(Some(double));
+        assert_eq!(CELL.get().unwrap()(5), 10);
+        CELL.set(None);
+    }
+}

--- a/majit/majit-gc/src/lib.rs
+++ b/majit/majit-gc/src/lib.rs
@@ -614,11 +614,12 @@ pub trait GcAllocator: Send {
 
 /// Forwarding handle to the process-global GC singleton via `gc_sync`.
 ///
-/// Every method routes through `gc_sync::gc_op` (mutex-guarded) or
-/// `gc_sync::gc_query`. No raw pointer — synchronisation is structural.
-/// Per-thread backend TLS stores `Box<GcHandle>` as `Box<dyn GcAllocator>`,
-/// so the ~45 trampoline functions per backend keep their existing
-/// `RefCell<Option<Box<dyn GcAllocator>>>` access pattern unchanged.
+/// `&mut self` methods route through `gc_sync::gc_op` (mutex-guarded);
+/// `&self` read-only queries route through `gc_sync::gc_query_reentrant` so
+/// they stay correct when a collection-time extra-root walker re-enters the GC
+/// (ownership / type queries) while this thread already holds the `&mut` — a
+/// plain `gc_query` would re-lock the non-recursive `gc_mutex` (deadlock) or, on
+/// the fast path, form a second `&mut`. No raw pointer at this layer.
 ///
 /// # Thread safety
 ///
@@ -715,7 +716,7 @@ impl GcAllocator for GcHandle {
         gc_sync::gc_op(|gc| gc.id_or_identityhash(obj_addr))
     }
     fn get_write_barrier_descr(&self) -> Option<WriteBarrierDescr> {
-        gc_sync::gc_query(|gc| gc.get_write_barrier_descr())
+        gc_sync::gc_query_reentrant(|gc| gc.get_write_barrier_descr())
     }
     unsafe fn add_root(&mut self, root: *mut GcRef) {
         gc_sync::gc_op(|gc| unsafe { gc.add_root(root) })
@@ -724,31 +725,31 @@ impl GcAllocator for GcHandle {
         gc_sync::gc_op(|gc| gc.remove_root(root))
     }
     fn is_managed_heap_object(&self, addr: usize) -> bool {
-        gc_sync::gc_query(|gc| gc.is_managed_heap_object(addr))
+        gc_sync::gc_query_reentrant(|gc| gc.is_managed_heap_object(addr))
     }
     fn nursery_free(&self) -> *mut u8 {
-        gc_sync::gc_query(|gc| gc.nursery_free())
+        gc_sync::gc_query_reentrant(|gc| gc.nursery_free())
     }
     fn nursery_free_addr(&self) -> usize {
-        gc_sync::gc_query(|gc| gc.nursery_free_addr())
+        gc_sync::gc_query_reentrant(|gc| gc.nursery_free_addr())
     }
     fn nursery_top(&self) -> *const u8 {
-        gc_sync::gc_query(|gc| gc.nursery_top())
+        gc_sync::gc_query_reentrant(|gc| gc.nursery_top())
     }
     fn nursery_top_addr(&self) -> usize {
-        gc_sync::gc_query(|gc| gc.nursery_top_addr())
+        gc_sync::gc_query_reentrant(|gc| gc.nursery_top_addr())
     }
     fn max_nursery_object_size(&self) -> usize {
-        gc_sync::gc_query(|gc| gc.max_nursery_object_size())
+        gc_sync::gc_query_reentrant(|gc| gc.max_nursery_object_size())
     }
     fn card_page_shift(&self) -> u32 {
-        gc_sync::gc_query(|gc| gc.card_page_shift())
+        gc_sync::gc_query_reentrant(|gc| gc.card_page_shift())
     }
     fn jit_remember_young_pointer(&mut self, obj: GcRef) {
         gc_sync::gc_op(|gc| gc.jit_remember_young_pointer(obj))
     }
     fn can_optimize_cond_call(&self) -> bool {
-        gc_sync::gc_query(|gc| gc.can_optimize_cond_call())
+        gc_sync::gc_query_reentrant(|gc| gc.can_optimize_cond_call())
     }
     fn gc_step(&mut self) -> bool {
         gc_sync::gc_op(|gc| gc.gc_step())
@@ -763,28 +764,28 @@ impl GcAllocator for GcHandle {
         gc_sync::gc_op(|gc| gc.unpin(obj))
     }
     fn is_pinned(&self, obj: GcRef) -> bool {
-        gc_sync::gc_query(|gc| gc.is_pinned(obj))
+        gc_sync::gc_query_reentrant(|gc| gc.is_pinned(obj))
     }
     fn register_type(&mut self, info: trace::TypeInfo) -> u32 {
         gc_sync::gc_op(|gc| gc.register_type(info))
     }
     fn type_count(&self) -> usize {
-        gc_sync::gc_query(|gc| gc.type_count())
+        gc_sync::gc_query_reentrant(|gc| gc.type_count())
     }
     fn heap_byte_stats(&self) -> (usize, usize) {
-        gc_sync::gc_query(|gc| gc.heap_byte_stats())
+        gc_sync::gc_query_reentrant(|gc| gc.heap_byte_stats())
     }
     fn collection_counts(&self) -> (usize, usize) {
-        gc_sync::gc_query(|gc| gc.collection_counts())
+        gc_sync::gc_query_reentrant(|gc| gc.collection_counts())
     }
     fn type_alloc_is_plain(&self, type_id: u32) -> bool {
-        gc_sync::gc_query(|gc| gc.type_alloc_is_plain(type_id))
+        gc_sync::gc_query_reentrant(|gc| gc.type_alloc_is_plain(type_id))
     }
     fn type_size(&self, type_id: u32) -> Option<usize> {
-        gc_sync::gc_query(|gc| gc.type_size(type_id))
+        gc_sync::gc_query_reentrant(|gc| gc.type_size(type_id))
     }
     fn get_typeid_from_classptr_if_gcremovetypeptr(&self, classptr: usize) -> Option<u32> {
-        gc_sync::gc_query(|gc| gc.get_typeid_from_classptr_if_gcremovetypeptr(classptr))
+        gc_sync::gc_query_reentrant(|gc| gc.get_typeid_from_classptr_if_gcremovetypeptr(classptr))
     }
     fn register_vtable_for_type(&mut self, vtable: usize, type_id: u32) {
         gc_sync::gc_op(|gc| gc.register_vtable_for_type(vtable, type_id))
@@ -793,37 +794,37 @@ impl GcAllocator for GcHandle {
         gc_sync::gc_op(|gc| gc.freeze_types())
     }
     fn supports_guard_gc_type(&self) -> bool {
-        gc_sync::gc_query(|gc| gc.supports_guard_gc_type())
+        gc_sync::gc_query_reentrant(|gc| gc.supports_guard_gc_type())
     }
     fn check_is_object(&self, gcref: GcRef) -> bool {
-        gc_sync::gc_query(|gc| gc.check_is_object(gcref))
+        gc_sync::gc_query_reentrant(|gc| gc.check_is_object(gcref))
     }
     fn is_tagged_immediate(&self, addr: usize) -> bool {
-        gc_sync::gc_query(|gc| gc.is_tagged_immediate(addr))
+        gc_sync::gc_query_reentrant(|gc| gc.is_tagged_immediate(addr))
     }
     fn can_move(&self, gcref: GcRef) -> bool {
-        gc_sync::gc_query(|gc| gc.can_move(gcref))
+        gc_sync::gc_query_reentrant(|gc| gc.can_move(gcref))
     }
     fn get_translated_info_for_typeinfo(&self) -> (usize, u8, usize) {
-        gc_sync::gc_query(|gc| gc.get_translated_info_for_typeinfo())
+        gc_sync::gc_query_reentrant(|gc| gc.get_translated_info_for_typeinfo())
     }
     fn get_translated_info_for_guard_is_object(&self) -> (usize, u8) {
-        gc_sync::gc_query(|gc| gc.get_translated_info_for_guard_is_object())
+        gc_sync::gc_query_reentrant(|gc| gc.get_translated_info_for_guard_is_object())
     }
     fn subclassrange_min_offset(&self) -> usize {
-        gc_sync::gc_query(|gc| gc.subclassrange_min_offset())
+        gc_sync::gc_query_reentrant(|gc| gc.subclassrange_min_offset())
     }
     fn subclass_range(&self, classptr: usize) -> Option<(i64, i64)> {
-        gc_sync::gc_query(|gc| gc.subclass_range(classptr))
+        gc_sync::gc_query_reentrant(|gc| gc.subclass_range(classptr))
     }
     fn typeid_subclass_range(&self, typeid: u32) -> Option<(i64, i64)> {
-        gc_sync::gc_query(|gc| gc.typeid_subclass_range(typeid))
+        gc_sync::gc_query_reentrant(|gc| gc.typeid_subclass_range(typeid))
     }
     fn get_actual_typeid(&self, gcref: GcRef) -> Option<u32> {
-        gc_sync::gc_query(|gc| gc.get_actual_typeid(gcref))
+        gc_sync::gc_query_reentrant(|gc| gc.get_actual_typeid(gcref))
     }
     fn typeid_is_object(&self, typeid: u32) -> Option<bool> {
-        gc_sync::gc_query(|gc| gc.typeid_is_object(typeid))
+        gc_sync::gc_query_reentrant(|gc| gc.typeid_is_object(typeid))
     }
 }
 

--- a/majit/majit-gc/src/lib.rs
+++ b/majit/majit-gc/src/lib.rs
@@ -15,6 +15,7 @@ pub mod collector;
 pub mod gc_sync;
 pub mod gcreftracer;
 pub mod header;
+pub mod hook_cell;
 pub mod nursery;
 pub mod oldgen;
 pub mod rewrite;
@@ -901,7 +902,7 @@ impl Default for GcMap {
 }
 
 // ─────────────────────────────────────────────────────────────────────
-// Thread-local active GC allocator hook
+// Process-global active GC allocator hooks
 // ─────────────────────────────────────────────────────────────────────
 //
 // The metainterp / optimizer layer needs a backend-agnostic way to query
@@ -912,15 +913,13 @@ impl Default for GcMap {
 // a callback here that the metainterp can invoke without taking a
 // backend dependency.
 
-use std::cell::Cell;
-
-/// Thread-local callback that answers `cpu.check_is_object(gcptr)` for
+/// Process-global callback that answers `cpu.check_is_object(gcptr)` for
 /// the currently active backend. Set by the backend when it installs a
-/// GC runtime for the executing thread; cleared when the runtime is
+/// GC runtime; cleared when the runtime is
 /// unregistered.
 pub type CheckIsObjectFn = fn(GcRef) -> bool;
 
-/// Thread-local callback that answers the collector's tagged-immediate
+/// Process-global callback that answers the collector's tagged-immediate
 /// test (gc/base.py:380-383 `is_valid_gc_object`) for the currently
 /// active backend's GC: `config.taggedpointers && (addr & 1 == 1)`.
 /// Lets a backend-agnostic caller decide that an odd-valued constant
@@ -928,7 +927,7 @@ pub type CheckIsObjectFn = fn(GcRef) -> bool;
 /// reading an object header at offset 0.
 pub type IsTaggedImmediateFn = fn(usize) -> bool;
 
-/// Thread-local callback that answers `gc_ll_descr.get_actual_typeid`
+/// Process-global callback that answers `gc_ll_descr.get_actual_typeid`
 /// (gc.py:624-629) for the currently active backend. Returns the
 /// `rffi.cast(HDRPTR, gcptr).tid` half-word for managed objects and
 /// `vtable_to_type_id` for the foreign-object seam pyre uses. Paired
@@ -937,13 +936,13 @@ pub type IsTaggedImmediateFn = fn(usize) -> bool;
 /// runtime layout assumptions.
 pub type GetActualTypeidFn = fn(GcRef) -> Option<u32>;
 
-/// Thread-local callback that answers the codegen-time bounds lookup
+/// Process-global callback that answers the codegen-time bounds lookup
 /// `rffi.cast(rclass.CLASSTYPE, vtable_ptr).subclassrange_{min,max}`
 /// from x86/assembler.py:1971-1974. Used by the executor's
 /// `GuardSubclass` arm to evaluate bridges interpretively.
 pub type SubclassRangeFn = fn(classptr: usize) -> Option<(i64, i64)>;
 
-/// Thread-local callback that answers the `value.typeptr
+/// Process-global callback that answers the `value.typeptr
 /// .subclassrange_min/max` lookup from llgraph/runner.py:1271-1281
 /// directly by typeid. The backend installs this alongside
 /// `subclass_range` so the executor can recover the object side of
@@ -953,7 +952,7 @@ pub type SubclassRangeFn = fn(classptr: usize) -> Option<(i64, i64)>;
 /// `CLASSTYPE` entry (gctypelayout.py:359-374).
 pub type TypeidSubclassRangeFn = fn(typeid: u32) -> Option<(i64, i64)>;
 
-/// Thread-local callback that answers `rclass.OBJECT`-layout queries
+/// Process-global callback that answers `rclass.OBJECT`-layout queries
 /// by typeid — "does this typeid carry `T_IS_RPYTHON_INSTANCE` in its
 /// TYPE_INFO entry" (gctypelayout.py:642). The executor's
 /// `GuardIsObject` arm calls this after resolving the object's typeid
@@ -962,26 +961,25 @@ pub type TypeidSubclassRangeFn = fn(typeid: u32) -> Option<(i64, i64)>;
 pub type TypeidIsObjectFn = fn(typeid: u32) -> Option<bool>;
 pub type ExtraRootWalkerFn = fn(&mut dyn FnMut(&mut GcRef));
 
-/// Thread-local callback that answers `rgc.can_move(gcref)`
+/// Process-global callback that answers `rgc.can_move(gcref)`
 /// (rpython/rlib/rgc.py:229) for the currently active backend's GC. The
 /// const-baking site (`x86/regalloc.py:58-61 convert_to_imm`) consults
 /// this before baking a `ConstPtr` immediate.
 pub type CanMoveFn = fn(GcRef) -> bool;
 
-thread_local! {
-    static ACTIVE_CHECK_IS_OBJECT: Cell<Option<CheckIsObjectFn>> = const { Cell::new(None) };
-    static ACTIVE_IS_TAGGED_IMMEDIATE: Cell<Option<IsTaggedImmediateFn>> = const { Cell::new(None) };
-    static ACTIVE_GET_ACTUAL_TYPEID: Cell<Option<GetActualTypeidFn>> = const { Cell::new(None) };
-    static ACTIVE_SUBCLASS_RANGE: Cell<Option<SubclassRangeFn>> = const { Cell::new(None) };
-    static ACTIVE_TYPEID_SUBCLASS_RANGE: Cell<Option<TypeidSubclassRangeFn>> = const { Cell::new(None) };
-    static ACTIVE_TYPEID_IS_OBJECT: Cell<Option<TypeidIsObjectFn>> = const { Cell::new(None) };
-    static ACTIVE_CAN_MOVE: Cell<Option<CanMoveFn>> = const { Cell::new(None) };
-    static ACTIVE_SUPPORTS_GUARD_GC_TYPE: Cell<bool> = const { Cell::new(false) };
-    static ACTIVE_EXTRA_ROOT_WALKER: Cell<Option<ExtraRootWalkerFn>> = const { Cell::new(None) };
-}
+global_hook!(static ACTIVE_CHECK_IS_OBJECT: CheckIsObjectFn);
+global_hook!(static ACTIVE_IS_TAGGED_IMMEDIATE: IsTaggedImmediateFn);
+global_hook!(static ACTIVE_GET_ACTUAL_TYPEID: GetActualTypeidFn);
+global_hook!(static ACTIVE_SUBCLASS_RANGE: SubclassRangeFn);
+global_hook!(static ACTIVE_TYPEID_SUBCLASS_RANGE: TypeidSubclassRangeFn);
+global_hook!(static ACTIVE_TYPEID_IS_OBJECT: TypeidIsObjectFn);
+global_hook!(static ACTIVE_CAN_MOVE: CanMoveFn);
+static ACTIVE_SUPPORTS_GUARD_GC_TYPE: std::sync::atomic::AtomicBool =
+    std::sync::atomic::AtomicBool::new(false);
+global_hook!(static ACTIVE_EXTRA_ROOT_WALKER: ExtraRootWalkerFn);
 
 /// Bundle of callbacks the metainterp / executor can reach through
-/// thread-locals. Mirrors the fan-out of methods RPython's optimizer
+/// process-global cells. Mirrors the fan-out of methods RPython's optimizer
 /// and blackhole reach via `self.cpu` / `self.cpu.gc_ll_descr`; majit
 /// installs them together so a backend swap is a single call.
 #[derive(Clone, Copy, Default)]
@@ -996,7 +994,7 @@ pub struct ActiveGcGuardHooks {
     pub supports_guard_gc_type: bool,
 }
 
-/// Install the active backend's GC-guard callbacks on this thread.
+/// Install the active backend's GC-guard callbacks.
 /// Called by backends when they enter a JIT region. Pass a default
 /// `ActiveGcGuardHooks` with every field set to `None` / `false` to
 /// clear. Mirrors how RPython's `cpu` field lets the optimizer and
@@ -1004,42 +1002,82 @@ pub struct ActiveGcGuardHooks {
 /// .get_actual_typeid`, and the codegen-time bounds lookup; majit
 /// bundles them here so a backend install is a single call.
 pub fn set_active_gc_guard_hooks(hooks: ActiveGcGuardHooks) {
-    ACTIVE_CHECK_IS_OBJECT.with(|c| c.set(hooks.check_is_object));
-    ACTIVE_IS_TAGGED_IMMEDIATE.with(|c| c.set(hooks.is_tagged_immediate));
-    ACTIVE_GET_ACTUAL_TYPEID.with(|c| c.set(hooks.get_actual_typeid));
-    ACTIVE_SUBCLASS_RANGE.with(|c| c.set(hooks.subclass_range));
-    ACTIVE_TYPEID_SUBCLASS_RANGE.with(|c| c.set(hooks.typeid_subclass_range));
-    ACTIVE_TYPEID_IS_OBJECT.with(|c| c.set(hooks.typeid_is_object));
-    ACTIVE_CAN_MOVE.with(|c| c.set(hooks.can_move));
-    ACTIVE_SUPPORTS_GUARD_GC_TYPE.with(|c| c.set(hooks.supports_guard_gc_type));
+    ACTIVE_CHECK_IS_OBJECT.set(hooks.check_is_object);
+    ACTIVE_IS_TAGGED_IMMEDIATE.set(hooks.is_tagged_immediate);
+    ACTIVE_GET_ACTUAL_TYPEID.set(hooks.get_actual_typeid);
+    ACTIVE_SUBCLASS_RANGE.set(hooks.subclass_range);
+    ACTIVE_TYPEID_SUBCLASS_RANGE.set(hooks.typeid_subclass_range);
+    ACTIVE_TYPEID_IS_OBJECT.set(hooks.typeid_is_object);
+    ACTIVE_CAN_MOVE.set(hooks.can_move);
+    ACTIVE_SUPPORTS_GUARD_GC_TYPE.store(
+        hooks.supports_guard_gc_type,
+        std::sync::atomic::Ordering::Release,
+    );
 }
 
-/// Install a thread-local callback that exposes non-shadow-stack roots
+/// Snapshot of the current guard-hook cells (test-only helper).
+#[allow(dead_code)]
+fn current_gc_guard_hooks() -> ActiveGcGuardHooks {
+    ActiveGcGuardHooks {
+        check_is_object: ACTIVE_CHECK_IS_OBJECT.get(),
+        is_tagged_immediate: ACTIVE_IS_TAGGED_IMMEDIATE.get(),
+        get_actual_typeid: ACTIVE_GET_ACTUAL_TYPEID.get(),
+        subclass_range: ACTIVE_SUBCLASS_RANGE.get(),
+        typeid_subclass_range: ACTIVE_TYPEID_SUBCLASS_RANGE.get(),
+        typeid_is_object: ACTIVE_TYPEID_IS_OBJECT.get(),
+        can_move: ACTIVE_CAN_MOVE.get(),
+        supports_guard_gc_type: supports_guard_gc_type(),
+    }
+}
+
+static GUARD_HOOKS_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+/// Test-only: install `hooks` while holding a process-global lock, restoring
+/// the previous guard-hook values when the returned guard drops. Serializes
+/// hook-overriding tests so the now-global cells do not race. `pub` because
+/// the sole caller lives in the `majit-metainterp` crate's tests.
+pub struct GuardHooksTestGuard {
+    prev: ActiveGcGuardHooks,
+    _lock: std::sync::MutexGuard<'static, ()>,
+}
+impl Drop for GuardHooksTestGuard {
+    fn drop(&mut self) {
+        set_active_gc_guard_hooks(self.prev);
+    }
+}
+pub fn override_gc_guard_hooks_for_test(hooks: ActiveGcGuardHooks) -> GuardHooksTestGuard {
+    let lock = GUARD_HOOKS_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|e| e.into_inner());
+    let prev = current_gc_guard_hooks();
+    set_active_gc_guard_hooks(hooks);
+    GuardHooksTestGuard { prev, _lock: lock }
+}
+
+/// Install a process-global callback that exposes non-shadow-stack roots
 /// owned by the embedding runtime.
 pub fn set_active_extra_root_walker(walker: Option<ExtraRootWalkerFn>) {
-    ACTIVE_EXTRA_ROOT_WALKER.with(|c| c.set(walker));
+    ACTIVE_EXTRA_ROOT_WALKER.set(walker);
 }
 
 /// Walk the active runtime's extra GC roots.
 pub fn walk_active_extra_roots(visitor: &mut dyn FnMut(&mut GcRef)) {
-    ACTIVE_EXTRA_ROOT_WALKER.with(|c| {
-        if let Some(f) = c.get() {
-            f(visitor);
-        }
-    });
+    if let Some(f) = ACTIVE_EXTRA_ROOT_WALKER.get() {
+        f(visitor);
+    }
 }
 
 /// llmodel.py:541-546 `cpu.check_is_object(gcptr)` shim. Returns whether
 /// `gcref` is a `T_IS_RPYTHON_INSTANCE` (has `typeptr` at offset 0). When
-/// no backend has installed a callback on this thread, returns `false`.
+/// no backend has installed a callback, returns `false`.
 pub fn check_is_object(gcref: GcRef) -> bool {
     if gcref.is_null() {
         return false;
     }
-    ACTIVE_CHECK_IS_OBJECT.with(|c| match c.get() {
+    match ACTIVE_CHECK_IS_OBJECT.get() {
         Some(f) => f(gcref),
         None => false,
-    })
+    }
 }
 
 /// gc/base.py:380-383 `is_valid_gc_object` tagged-immediate test shim.
@@ -1048,10 +1086,10 @@ pub fn check_is_object(gcref: GcRef) -> bool {
 /// backend is installed — same absent-backend semantics as
 /// `check_is_object`, so flag-off / no-GC paths are unaffected.
 pub fn is_tagged_immediate(addr: usize) -> bool {
-    ACTIVE_IS_TAGGED_IMMEDIATE.with(|c| match c.get() {
+    match ACTIVE_IS_TAGGED_IMMEDIATE.get() {
         Some(f) => f(addr),
         None => false,
-    })
+    }
 }
 
 /// Whether the active backend's GC has `config.taggedpointers` enabled
@@ -1073,10 +1111,10 @@ pub fn get_actual_typeid(gcref: GcRef) -> Option<u32> {
     if gcref.is_null() {
         return None;
     }
-    ACTIVE_GET_ACTUAL_TYPEID.with(|c| match c.get() {
+    match ACTIVE_GET_ACTUAL_TYPEID.get() {
         Some(f) => f(gcref),
         None => None,
-    })
+    }
 }
 
 /// `rgc.can_move(gcref)` shim (rpython/rlib/rgc.py:229). Delegates to the
@@ -1088,10 +1126,10 @@ pub fn can_move(gcref: GcRef) -> bool {
     if gcref.is_null() {
         return false;
     }
-    ACTIVE_CAN_MOVE.with(|c| match c.get() {
+    match ACTIVE_CAN_MOVE.get() {
         Some(f) => f(gcref),
         None => false,
-    })
+    }
 }
 
 /// x86/assembler.py:1971-1974 codegen-time bounds lookup shim used by
@@ -1099,7 +1137,7 @@ pub fn can_move(gcref: GcRef) -> bool {
 /// `(subclassrange_min, subclassrange_max)` for the class whose vtable
 /// pointer is given, or `None` when no backend is installed.
 pub fn subclass_range(classptr: usize) -> Option<(i64, i64)> {
-    ACTIVE_SUBCLASS_RANGE.with(|c| c.get().and_then(|f| f(classptr)))
+    ACTIVE_SUBCLASS_RANGE.get().and_then(|f| f(classptr))
 }
 
 /// Companion to `subclass_range` keyed by typeid instead of classptr.
@@ -1109,7 +1147,7 @@ pub fn subclass_range(classptr: usize) -> Option<(i64, i64)> {
 /// classptr is known only to the GC). Returns `None` when no backend
 /// is installed.
 pub fn typeid_subclass_range(typeid: u32) -> Option<(i64, i64)> {
-    ACTIVE_TYPEID_SUBCLASS_RANGE.with(|c| c.get().and_then(|f| f(typeid)))
+    ACTIVE_TYPEID_SUBCLASS_RANGE.get().and_then(|f| f(typeid))
 }
 
 /// Companion to `check_is_object` keyed by typeid. Called by the
@@ -1117,13 +1155,13 @@ pub fn typeid_subclass_range(typeid: u32) -> Option<(i64, i64)> {
 /// typeid via `get_actual_typeid`. Returns `None` when no backend is
 /// installed.
 pub fn typeid_is_object(typeid: u32) -> Option<bool> {
-    ACTIVE_TYPEID_IS_OBJECT.with(|c| c.get().and_then(|f| f(typeid)))
+    ACTIVE_TYPEID_IS_OBJECT.get().and_then(|f| f(typeid))
 }
 
 /// llmodel.py:63 `supports_guard_gc_type` shim. Mirrors the active
 /// backend's capability flag. `false` when no backend has been installed.
 pub fn supports_guard_gc_type() -> bool {
-    ACTIVE_SUPPORTS_GUARD_GC_TYPE.with(|c| c.get())
+    ACTIVE_SUPPORTS_GUARD_GC_TYPE.load(std::sync::atomic::Ordering::Acquire)
 }
 
 // ── Host-side nursery allocation hook ───────────────────────────────
@@ -1135,34 +1173,31 @@ pub fn supports_guard_gc_type() -> bool {
 // dependency. Mirrors how RPython host code reaches `gc.malloc(TYPE)`
 // through the global GC instance.
 
-/// Thread-local callback that performs a nursery allocation for the
+/// Process-global callback that performs a nursery allocation for the
 /// currently active backend. The callback returns `GcRef(0)` (i.e.
 /// null) on allocation failure so callers can fall back to a
 /// non-GC allocator.
 pub type AllocNurseryTypedFn = fn(type_id: u32, payload_size: usize) -> GcRef;
 
-thread_local! {
-    static ACTIVE_ALLOC_NURSERY_TYPED: Cell<Option<AllocNurseryTypedFn>> =
-        const { Cell::new(None) };
-}
+global_hook!(static ACTIVE_ALLOC_NURSERY_TYPED: AllocNurseryTypedFn);
 
 /// Install the active backend's nursery allocator callback. Pass
 /// `None` to clear.
 pub fn set_active_alloc_nursery_typed(hook: Option<AllocNurseryTypedFn>) {
-    ACTIVE_ALLOC_NURSERY_TYPED.with(|c| c.set(hook));
+    ACTIVE_ALLOC_NURSERY_TYPED.set(hook);
 }
 
 /// Allocate through the active backend's GC. Returns `GcRef(0)` when
-/// no backend is installed on this thread (callers treat this as a
+/// no backend has installed a hook (callers treat this as a
 /// null pointer and fall back to their non-GC path).
 pub fn alloc_nursery_typed(type_id: u32, payload_size: usize) -> GcRef {
-    ACTIVE_ALLOC_NURSERY_TYPED.with(|c| match c.get() {
+    match ACTIVE_ALLOC_NURSERY_TYPED.get() {
         Some(f) => f(type_id, payload_size),
         None => GcRef(0),
-    })
+    }
 }
 
-/// Thread-local callback that performs a stable-address old-gen
+/// Process-global callback that performs a stable-address old-gen
 /// allocation for the currently active backend. Used by host-side
 /// allocators whose callers hold the returned pointer on the Rust
 /// stack without registering it as a GC root. MiniMark's
@@ -1171,28 +1206,24 @@ pub fn alloc_nursery_typed(type_id: u32, payload_size: usize) -> GcRef {
 /// `GcRef(0)` on allocation failure.
 pub type AllocOldgenTypedFn = fn(type_id: u32, payload_size: usize) -> GcRef;
 
-thread_local! {
-    static ACTIVE_ALLOC_OLDGEN_TYPED: Cell<Option<AllocOldgenTypedFn>> =
-        const { Cell::new(None) };
-}
+global_hook!(static ACTIVE_ALLOC_OLDGEN_TYPED: AllocOldgenTypedFn);
 
 /// Install the active backend's old-gen allocator callback. Pass
 /// `None` to clear.
 pub fn set_active_alloc_oldgen_typed(hook: Option<AllocOldgenTypedFn>) {
-    ACTIVE_ALLOC_OLDGEN_TYPED.with(|c| c.set(hook));
+    ACTIVE_ALLOC_OLDGEN_TYPED.set(hook);
 }
 
 /// Allocate a stable-address (old-gen) object through the active
-/// backend's GC. Returns `GcRef(0)` when no backend is installed on
-/// this thread.
+/// backend's GC. Returns `GcRef(0)` when no backend has installed a hook.
 pub fn alloc_oldgen_typed(type_id: u32, payload_size: usize) -> GcRef {
-    ACTIVE_ALLOC_OLDGEN_TYPED.with(|c| match c.get() {
+    match ACTIVE_ALLOC_OLDGEN_TYPED.get() {
         Some(f) => f(type_id, payload_size),
         None => GcRef(0),
-    })
+    }
 }
 
-/// Thread-local callback for a *collecting* nursery allocation — unlike
+/// Process-global callback for a *collecting* nursery allocation — unlike
 /// [`alloc_nursery_typed`] (which the backends install as the no-collect
 /// variant), this one runs a minor collection when the nursery is full instead
 /// of spilling to old-gen. Only safe for callers that hold no unrooted GC
@@ -1201,159 +1232,136 @@ pub fn alloc_oldgen_typed(type_id: u32, payload_size: usize) -> GcRef {
 /// gcmap-carrying residual CallR). Returns `GcRef(0)` when no backend installed.
 pub type AllocNurseryCollectingTypedFn = fn(type_id: u32, payload_size: usize) -> GcRef;
 
-thread_local! {
-    static ACTIVE_ALLOC_NURSERY_COLLECTING_TYPED: Cell<Option<AllocNurseryCollectingTypedFn>> =
-        const { Cell::new(None) };
-}
+global_hook!(static ACTIVE_ALLOC_NURSERY_COLLECTING_TYPED: AllocNurseryCollectingTypedFn);
 
 /// Install the active backend's collecting-nursery allocator callback. Pass
 /// `None` to clear. Backends that do not install one leave callers to fall back
 /// to the no-collect path.
 pub fn set_active_alloc_nursery_collecting_typed(hook: Option<AllocNurseryCollectingTypedFn>) {
-    ACTIVE_ALLOC_NURSERY_COLLECTING_TYPED.with(|c| c.set(hook));
+    ACTIVE_ALLOC_NURSERY_COLLECTING_TYPED.set(hook);
 }
 
 /// Allocate through the active backend's collecting nursery allocator. Returns
-/// `GcRef(0)` when no backend (or no collecting hook) is installed on this
-/// thread (callers treat this as null and fall back to the no-collect path).
+/// `GcRef(0)` when no backend (or no collecting hook) is installed (callers
+/// treat this as null and fall back to the no-collect path).
 pub fn alloc_nursery_collecting_typed(type_id: u32, payload_size: usize) -> GcRef {
-    ACTIVE_ALLOC_NURSERY_COLLECTING_TYPED.with(|c| match c.get() {
+    match ACTIVE_ALLOC_NURSERY_COLLECTING_TYPED.get() {
         Some(f) => f(type_id, payload_size),
         None => GcRef(0),
-    })
+    }
 }
 
-/// Thread-local callback that charges off-heap memory pressure on the active
+/// Process-global callback that charges off-heap memory pressure on the active
 /// backend's GC (`GcAllocator::charge_memory_pressure`). Used by host-side
 /// allocators of GC objects whose payload includes external, GC-invisible memory
 /// (the bignum limb `Vec`). Returns silently when no backend is installed.
 pub type ChargeMemoryPressureFn = fn(bytes: usize);
 
-thread_local! {
-    static ACTIVE_CHARGE_MEMORY_PRESSURE: Cell<Option<ChargeMemoryPressureFn>> =
-        const { Cell::new(None) };
-}
+global_hook!(static ACTIVE_CHARGE_MEMORY_PRESSURE: ChargeMemoryPressureFn);
 
 /// Install the active backend's memory-pressure callback. Pass `None` to clear.
 pub fn set_active_charge_memory_pressure(hook: Option<ChargeMemoryPressureFn>) {
-    ACTIVE_CHARGE_MEMORY_PRESSURE.with(|c| c.set(hook));
+    ACTIVE_CHARGE_MEMORY_PRESSURE.set(hook);
 }
 
 /// Charge `bytes` of off-heap memory pressure on the active backend's GC. No-op
-/// when no backend is installed on this thread.
+/// when no backend has installed a hook.
 pub fn charge_memory_pressure(bytes: usize) {
-    ACTIVE_CHARGE_MEMORY_PRESSURE.with(|c| {
-        if let Some(f) = c.get() {
-            f(bytes);
-        }
-    })
+    if let Some(f) = ACTIVE_CHARGE_MEMORY_PRESSURE.get() {
+        f(bytes);
+    }
 }
 
-/// Thread-local callback that charges an object's off-heap payload against the
+/// Process-global callback that charges an object's off-heap payload against the
 /// active backend's major threshold (`GcAllocator::charge_oldgen_external`) when
 /// the object is old-gen, without forcing a minor. Used after initializing GC
 /// objects whose payload includes external, GC-invisible memory (the bignum limb
 /// `Vec`). Returns silently when no backend is installed.
 pub type ChargeOldgenExternalFn = fn(obj_addr: usize, bytes: usize);
 
-thread_local! {
-    static ACTIVE_CHARGE_OLDGEN_EXTERNAL: Cell<Option<ChargeOldgenExternalFn>> =
-        const { Cell::new(None) };
-}
+global_hook!(static ACTIVE_CHARGE_OLDGEN_EXTERNAL: ChargeOldgenExternalFn);
 
 /// Install the active backend's old-gen external-byte callback. Pass `None` to clear.
 pub fn set_active_charge_oldgen_external(hook: Option<ChargeOldgenExternalFn>) {
-    ACTIVE_CHARGE_OLDGEN_EXTERNAL.with(|c| c.set(hook));
+    ACTIVE_CHARGE_OLDGEN_EXTERNAL.set(hook);
 }
 
 /// Charge `bytes` of `obj_addr`'s off-heap payload on the active backend's GC
-/// when the object is old-gen. No-op when no backend is installed on this thread.
+/// when the object is old-gen. No-op when no backend has installed a hook.
 pub fn charge_oldgen_external(obj_addr: usize, bytes: usize) {
-    ACTIVE_CHARGE_OLDGEN_EXTERNAL.with(|c| {
-        if let Some(f) = c.get() {
-            f(obj_addr, bytes);
-        }
-    })
+    if let Some(f) = ACTIVE_CHARGE_OLDGEN_EXTERNAL.get() {
+        f(obj_addr, bytes);
+    }
 }
 
-/// Thread-local callback that runs a full mark-sweep collection cycle
+/// Process-global callback that runs a full mark-sweep collection cycle
 /// on the active backend's GC (`GcAllocator::collect_full`). Used by
 /// `pypy/module/gc/interp_gc.py:7-26 collect` ports — i.e. user-level
 /// `gc.collect()` reaches the live GC through this trampoline. Returns
-/// silently when no backend is installed on this thread (callers treat
+/// silently when no backend has installed a hook (callers treat
 /// it as a no-op).
 pub type CollectFullFn = fn();
 
-thread_local! {
-    static ACTIVE_COLLECT_FULL: Cell<Option<CollectFullFn>> = const { Cell::new(None) };
-}
+global_hook!(static ACTIVE_COLLECT_FULL: CollectFullFn);
 
 /// Install the active backend's full-collection trampoline. Pass
 /// `None` to clear.
 pub fn set_active_collect_full(hook: Option<CollectFullFn>) {
-    ACTIVE_COLLECT_FULL.with(|c| c.set(hook));
+    ACTIVE_COLLECT_FULL.set(hook);
 }
 
 /// Trigger a full mark-sweep collection on the active backend's GC.
-/// No-op when no backend is installed on this thread.
+/// No-op when no backend has installed a hook.
 pub fn collect_full() {
-    ACTIVE_COLLECT_FULL.with(|c| {
-        if let Some(f) = c.get() {
-            f();
-        }
-    });
+    if let Some(f) = ACTIVE_COLLECT_FULL.get() {
+        f();
+    }
 }
 
-/// Thread-local callback running a non-moving old-gen-only major collection
+/// Process-global callback running a non-moving old-gen-only major collection
 /// (`GcAllocator::collect_oldgen_nonmoving`). The interpreter GC safepoint
 /// reaches it to reclaim stable-allocated interp int/float without moving the
 /// nursery — so it can fire under an active JIT (nursery non-empty), unlike
 /// the moving `collect_full`. No-op when no backend is installed.
 pub type CollectOldgenFn = fn();
 
-thread_local! {
-    static ACTIVE_COLLECT_OLDGEN: Cell<Option<CollectOldgenFn>> = const { Cell::new(None) };
-}
+global_hook!(static ACTIVE_COLLECT_OLDGEN: CollectOldgenFn);
 
 /// Install the active backend's non-moving-major trampoline. Pass `None` to
 /// clear.
 pub fn set_active_collect_oldgen(hook: Option<CollectOldgenFn>) {
-    ACTIVE_COLLECT_OLDGEN.with(|c| c.set(hook));
+    ACTIVE_COLLECT_OLDGEN.set(hook);
 }
 
 /// Trigger a non-moving old-gen-only major collection on the active backend's
-/// GC. No-op when no backend is installed on this thread.
+/// GC. No-op when no backend has installed a hook.
 pub fn collect_oldgen_nonmoving() {
-    ACTIVE_COLLECT_OLDGEN.with(|c| {
-        if let Some(f) = c.get() {
-            f();
-        }
-    });
+    if let Some(f) = ACTIVE_COLLECT_OLDGEN.get() {
+        f();
+    }
 }
 
-/// Thread-local callback reporting the active GC's `heap_byte_stats`
+/// Process-global callback reporting the active GC's `heap_byte_stats`
 /// (`(oldgen_total, nursery_used)`). Lets the interpreter safepoint
 /// (`pyre_object::gc_interp`) gate a collection on an empty nursery,
 /// where the embedded minor cycle moves nothing and is therefore safe
 /// even without a shadowstack pass over Rust-stack temporaries.
 pub type HeapStatsFn = fn() -> (usize, usize);
 
-thread_local! {
-    static ACTIVE_HEAP_STATS: Cell<Option<HeapStatsFn>> = const { Cell::new(None) };
-}
+global_hook!(static ACTIVE_HEAP_STATS: HeapStatsFn);
 
 /// Install the active backend's `heap_byte_stats` trampoline.
 pub fn set_active_heap_stats(hook: Option<HeapStatsFn>) {
-    ACTIVE_HEAP_STATS.with(|c| c.set(hook));
+    ACTIVE_HEAP_STATS.set(hook);
 }
 
 /// Report `(oldgen_total, nursery_used)` from the active backend's GC.
-/// `(0, 0)` when no backend is installed on this thread.
+/// `(0, 0)` when no backend has installed a hook.
 pub fn active_heap_stats() -> (usize, usize) {
-    ACTIVE_HEAP_STATS.with(|c| match c.get() {
+    match ACTIVE_HEAP_STATS.get() {
         Some(f) => f(),
         None => (0, 0),
-    })
+    }
 }
 
 /// Whether the JIT-frame shadow stack is empty — i.e. no compiled trace
@@ -1367,7 +1375,7 @@ pub fn jitframe_shadow_stack_empty() -> bool {
     shadow_stack::jf_top_ptr().is_null()
 }
 
-/// Thread-local callback that reports whether a raw address is owned
+/// Process-global callback that reports whether a raw address is owned
 /// by the active backend's GC heap. Used by host-side allocators
 /// (`pyre-object`'s `dealloc_items_block`) to discriminate
 /// `try_gc_alloc_stable`-allocated blocks from `std::alloc`-backed
@@ -1377,44 +1385,40 @@ pub fn jitframe_shadow_stack_empty() -> bool {
 /// `std::alloc`-allocated ones.
 pub type GcOwnsObjectFn = fn(addr: usize) -> bool;
 
-thread_local! {
-    static ACTIVE_GC_OWNS_OBJECT: Cell<Option<GcOwnsObjectFn>> = const { Cell::new(None) };
-}
+global_hook!(static ACTIVE_GC_OWNS_OBJECT: GcOwnsObjectFn);
 
 /// Install the active backend's `is_managed_heap_object` trampoline.
 pub fn set_active_gc_owns_object(hook: Option<GcOwnsObjectFn>) {
-    ACTIVE_GC_OWNS_OBJECT.with(|c| c.set(hook));
+    ACTIVE_GC_OWNS_OBJECT.set(hook);
 }
 
-/// minimark.py:1900-1915 `id_or_identityhash` TLS hook.
+/// minimark.py:1900-1915 `id_or_identityhash` hook.
 pub type GcIdOrIdentityHashFn = fn(addr: usize) -> usize;
 
-thread_local! {
-    static ACTIVE_GC_ID_OR_IDENTITYHASH: Cell<Option<GcIdOrIdentityHashFn>> = const { Cell::new(None) };
-}
+global_hook!(static ACTIVE_GC_ID_OR_IDENTITYHASH: GcIdOrIdentityHashFn);
 
 pub fn set_active_gc_id_or_identityhash(hook: Option<GcIdOrIdentityHashFn>) {
-    ACTIVE_GC_ID_OR_IDENTITYHASH.with(|c| c.set(hook));
+    ACTIVE_GC_ID_OR_IDENTITYHASH.set(hook);
 }
 
 /// Return a GC-move-stable address for identity hashing.
 /// Falls back to `addr` when no backend is installed.
 pub fn gc_id_or_identityhash(addr: usize) -> usize {
-    ACTIVE_GC_ID_OR_IDENTITYHASH.with(|c| match c.get() {
+    match ACTIVE_GC_ID_OR_IDENTITYHASH.get() {
         Some(f) => f(addr),
         None => addr,
-    })
+    }
 }
 
 /// Whether `addr` lies inside the active backend's managed GC heap.
-/// Returns `false` when no backend is installed on this thread —
+/// Returns `false` when no backend has installed a hook —
 /// callers treat that as "no GC owns this pointer" and fall through
 /// to their non-GC dealloc path.
 pub fn gc_owns_object(addr: usize) -> bool {
-    ACTIVE_GC_OWNS_OBJECT.with(|c| match c.get() {
+    match ACTIVE_GC_OWNS_OBJECT.get() {
         Some(f) => f(addr),
         None => false,
-    })
+    }
 }
 
 /// Return the current address for a managed object without treating it as a
@@ -1432,7 +1436,7 @@ pub fn gc_current_object_address(addr: usize) -> usize {
     }
 }
 
-/// Thread-local callbacks for registering/removing a Rust-stack slot
+/// Process-global callbacks for registering/removing a Rust-stack slot
 /// as a GC root with the currently active backend. Used by host-side
 /// allocators whose callers need to keep a
 /// just-allocated nursery pointer alive across a subsequent
@@ -1445,40 +1449,34 @@ pub fn gc_current_object_address(addr: usize) -> usize {
 pub type AddRootFn = unsafe fn(slot: *mut GcRef);
 pub type RemoveRootFn = fn(slot: *mut GcRef);
 
-thread_local! {
-    static ACTIVE_ADD_ROOT: Cell<Option<AddRootFn>> = const { Cell::new(None) };
-    static ACTIVE_REMOVE_ROOT: Cell<Option<RemoveRootFn>> = const { Cell::new(None) };
-}
+global_hook!(static ACTIVE_ADD_ROOT: AddRootFn);
+global_hook!(static ACTIVE_REMOVE_ROOT: RemoveRootFn);
 
 /// Install the active backend's root-register callbacks. Pass `None`
 /// to clear.
 pub fn set_active_root_hooks(add: Option<AddRootFn>, remove: Option<RemoveRootFn>) {
-    ACTIVE_ADD_ROOT.with(|c| c.set(add));
-    ACTIVE_REMOVE_ROOT.with(|c| c.set(remove));
+    ACTIVE_ADD_ROOT.set(add);
+    ACTIVE_REMOVE_ROOT.set(remove);
 }
 
 /// Register a stack slot as a GC root with the active backend. No-op
-/// when no backend is installed on this thread.
+/// when no backend has installed a hook.
 ///
 /// # Safety
 /// The caller must ensure the slot remains valid until
 /// [`gc_remove_root`] is called with the same pointer.
 pub unsafe fn gc_add_root(slot: *mut GcRef) {
-    ACTIVE_ADD_ROOT.with(|c| {
-        if let Some(f) = c.get() {
-            unsafe { f(slot) }
-        }
-    });
+    if let Some(f) = ACTIVE_ADD_ROOT.get() {
+        unsafe { f(slot) }
+    }
 }
 
 /// Remove a previously-registered root slot from the active backend.
-/// No-op when no backend is installed on this thread.
+/// No-op when no backend has installed a hook.
 pub fn gc_remove_root(slot: *mut GcRef) {
-    ACTIVE_REMOVE_ROOT.with(|c| {
-        if let Some(f) = c.get() {
-            f(slot)
-        }
-    });
+    if let Some(f) = ACTIVE_REMOVE_ROOT.get() {
+        f(slot)
+    }
 }
 
 /// rgc.py `FinalizerQueue.register_finalizer` - routed to the active backend GC.
@@ -1486,34 +1484,32 @@ pub type RegisterFinalizerFn = fn(fq_index: usize, obj: GcRef, trigger: Finalize
 /// rgc.py `FinalizerQueue.next_dead` - routed to the active backend GC.
 pub type FinalizerNextDeadFn = fn(fq_index: usize) -> Option<GcRef>;
 
-thread_local! {
-    static ACTIVE_REGISTER_FINALIZER: Cell<Option<RegisterFinalizerFn>> = const { Cell::new(None) };
-    static ACTIVE_FINALIZER_NEXT_DEAD: Cell<Option<FinalizerNextDeadFn>> = const { Cell::new(None) };
-}
+global_hook!(static ACTIVE_REGISTER_FINALIZER: RegisterFinalizerFn);
+global_hook!(static ACTIVE_FINALIZER_NEXT_DEAD: FinalizerNextDeadFn);
 
 /// Install the active backend's finalizer trampolines. Pass `None` to clear.
 pub fn set_active_finalizer_hooks(
     register: Option<RegisterFinalizerFn>,
     next_dead: Option<FinalizerNextDeadFn>,
 ) {
-    ACTIVE_REGISTER_FINALIZER.with(|c| c.set(register));
-    ACTIVE_FINALIZER_NEXT_DEAD.with(|c| c.set(next_dead));
+    ACTIVE_REGISTER_FINALIZER.set(register);
+    ACTIVE_FINALIZER_NEXT_DEAD.set(next_dead);
 }
 
 /// Register an object with an RPython-style finalizer queue on the active GC.
 pub fn gc_register_finalizer(fq_index: usize, obj: GcRef, trigger: FinalizerTriggerFn) {
-    ACTIVE_REGISTER_FINALIZER.with(|c| match c.get() {
+    match ACTIVE_REGISTER_FINALIZER.get() {
         Some(f) => f(fq_index, obj, trigger),
         None => gc_sync::gc_op(|gc| gc.register_finalizer(fq_index, obj, trigger)),
-    });
+    }
 }
 
 /// Pop one object from the active GC's RPython-style finalizer death queue.
 pub fn gc_fq_next_dead(fq_index: usize) -> Option<GcRef> {
-    ACTIVE_FINALIZER_NEXT_DEAD.with(|c| match c.get() {
+    match ACTIVE_FINALIZER_NEXT_DEAD.get() {
         Some(f) => f(fq_index),
         None => gc_sync::gc_op(|gc| gc.finalizer_next_dead(fq_index)),
-    })
+    }
 }
 
 /// rgc.enable / rgc.disable — toggle automatic major-collection progress
@@ -1522,30 +1518,25 @@ pub fn gc_set_enabled(enabled: bool) {
     gc_sync::gc_op(|gc| if enabled { gc.enable() } else { gc.disable() })
 }
 
-/// Thread-local callback that performs a host-side write barrier through
+/// Process-global callback that performs a host-side write barrier through
 /// the currently active backend GC.
 pub type WriteBarrierFn = fn(obj: GcRef);
 
-thread_local! {
-    static ACTIVE_WRITE_BARRIER: Cell<Option<WriteBarrierFn>> = const { Cell::new(None) };
-}
+global_hook!(static ACTIVE_WRITE_BARRIER: WriteBarrierFn);
 
 /// Install the active backend's write-barrier callback. Pass `None` to clear.
 pub fn set_active_write_barrier(hook: Option<WriteBarrierFn>) {
-    ACTIVE_WRITE_BARRIER.with(|c| c.set(hook));
+    ACTIVE_WRITE_BARRIER.set(hook);
 }
 
 /// Perform a write barrier through the active backend.
 ///
 /// Calling convention: callers must invoke this before storing a GC reference
 /// into `obj`, matching [`GcAllocator::write_barrier`]. The active callback is
-/// thread-local and installed with [`set_active_write_barrier`] as a
-/// [`WriteBarrierFn`]; this is a no-op when no barrier is installed on the
-/// current thread.
+/// a process-global cell installed with [`set_active_write_barrier`] as a
+/// [`WriteBarrierFn`]; this is a no-op when no barrier is installed.
 pub fn gc_write_barrier(obj: GcRef) {
-    ACTIVE_WRITE_BARRIER.with(|c| {
-        if let Some(f) = c.get() {
-            f(obj)
-        }
-    });
+    if let Some(f) = ACTIVE_WRITE_BARRIER.get() {
+        f(obj)
+    }
 }

--- a/majit/majit-gc/src/lib.rs
+++ b/majit/majit-gc/src/lib.rs
@@ -1466,8 +1466,15 @@ global_hook!(static ACTIVE_REMOVE_ROOT: RemoveRootFn);
 /// Install the active backend's root-register callbacks. Pass `None`
 /// to clear.
 pub fn set_active_root_hooks(add: Option<AddRootFn>, remove: Option<RemoveRootFn>) {
-    ACTIVE_ADD_ROOT.set(add);
-    ACTIVE_REMOVE_ROOT.set(remove);
+    if add.is_some() {
+        // Publish remove before add so every newly registered root can be removed.
+        ACTIVE_REMOVE_ROOT.set(remove);
+        ACTIVE_ADD_ROOT.set(add);
+    } else {
+        // Withdraw add before remove so no root can be registered without removal.
+        ACTIVE_ADD_ROOT.set(add);
+        ACTIVE_REMOVE_ROOT.set(remove);
+    }
 }
 
 /// Register a stack slot as a GC root with the active backend. No-op

--- a/majit/majit-gc/src/lib.rs
+++ b/majit/majit-gc/src/lib.rs
@@ -334,8 +334,15 @@ pub trait GcAllocator: Send {
     fn nursery_top(&self) -> *const u8;
 
     /// gc.py:525-531 get_nursery_top_addr parity.
-    /// Address of the mutable nursery_top field that JIT code reads.
+    /// Address of the published nursery_top slot that JIT code reads.
     fn nursery_top_addr(&self) -> usize;
+
+    /// Enable or disable JIT inline nursery allocation.
+    ///
+    /// Collectors without a published nursery fast path need no action.
+    fn set_inline_alloc_enabled(&mut self, enabled: bool) {
+        let _ = enabled;
+    }
 
     /// Maximum size for nursery allocation (larger objects go to old gen directly).
     fn max_nursery_object_size(&self) -> usize;
@@ -738,6 +745,9 @@ impl GcAllocator for GcHandle {
     }
     fn nursery_top_addr(&self) -> usize {
         gc_sync::gc_query_reentrant(|gc| gc.nursery_top_addr())
+    }
+    fn set_inline_alloc_enabled(&mut self, enabled: bool) {
+        gc_sync::gc_op(|gc| gc.set_inline_alloc_enabled(enabled))
     }
     fn max_nursery_object_size(&self) -> usize {
         gc_sync::gc_query_reentrant(|gc| gc.max_nursery_object_size())

--- a/majit/majit-gc/src/shadow_stack.rs
+++ b/majit/majit-gc/src/shadow_stack.rs
@@ -18,6 +18,7 @@
 /// load/store instructions (no function calls), exactly as in
 /// assembler.py:1122-1136.
 use std::cell::{Cell, RefCell};
+use std::sync::{Mutex, OnceLock, RwLock};
 
 use majit_ir::GcRef;
 
@@ -139,30 +140,27 @@ pub fn register_libc_jitframe_tracer(tracer: LibcJitframeTracer) {
 // visitor can safely dispatch to the registered tracer. Without this
 // set the visitor cannot tell a libc-alloc'd jitframe from an
 // unrelated foreign pointer that happens to sit on the shadow stack.
-thread_local! {
-    static LIBC_JF_REGISTRY: RefCell<indexmap::IndexSet<usize>> =
-        RefCell::new(indexmap::IndexSet::new());
+static LIBC_JF_REGISTRY: OnceLock<RwLock<indexmap::IndexSet<usize>>> = OnceLock::new();
+
+fn libc_jf_registry() -> &'static RwLock<indexmap::IndexSet<usize>> {
+    LIBC_JF_REGISTRY.get_or_init(|| RwLock::new(indexmap::IndexSet::new()))
 }
 
 /// Register a libc-allocated jitframe payload address. Must be called
 /// before pushing the jitframe onto the JF shadow stack.
 pub fn register_libc_jitframe(addr: usize) {
-    LIBC_JF_REGISTRY.with(|r| {
-        r.borrow_mut().insert(addr);
-    });
+    libc_jf_registry().write().unwrap().insert(addr);
 }
 
 /// Unregister a libc-allocated jitframe address. Call once the
 /// jitframe memory is about to be freed.
 pub fn unregister_libc_jitframe(addr: usize) {
-    LIBC_JF_REGISTRY.with(|r| {
-        r.borrow_mut().swap_remove(&addr);
-    });
+    libc_jf_registry().write().unwrap().swap_remove(&addr);
 }
 
 /// Check whether an address was registered as a libc-allocated jitframe.
 pub fn is_libc_jitframe(addr: usize) -> bool {
-    LIBC_JF_REGISTRY.with(|r| r.borrow().contains(&addr))
+    libc_jf_registry().read().unwrap().contains(&addr)
 }
 
 /// Invoke the registered tracer if any. Returns true if tracer ran.
@@ -221,6 +219,64 @@ thread_local! {
     /// construction window and popped when it ends.
     static RESUME_REF_ROOTS_STACK: RefCell<Vec<(*mut i64, usize)>> =
         RefCell::new(Vec::with_capacity(16));
+}
+
+/// Root structures owned by one registered mutator thread.
+///
+/// The pointers remain valid until `unregister_mutator` runs on the owning
+/// thread. Foreign access is only permitted while gc_sync has quiesced every
+/// registered mutator, so none of the underlying TLS structures can move or
+/// be mutably accessed by its owner during a walk.
+struct MutatorEntry {
+    thread_id: std::thread::ThreadId,
+    shadow_stack: *const RefCell<ShadowStack>,
+    jf_root_stack: *const RefCell<JitFrameShadowStack>,
+    bh_regs_stack: *const RefCell<Vec<BhRegsEntry>>,
+    resume_ref_roots_stack: *const RefCell<Vec<(*mut i64, usize)>>,
+}
+
+// The raw pointers refer to TLS owned by `thread_id`. The registry only moves
+// pointer values between threads; dereferencing them requires the STW
+// quiescence established by gc_sync.
+unsafe impl Send for MutatorEntry {}
+
+static MUTATOR_REGISTRY: Mutex<Vec<MutatorEntry>> = Mutex::new(Vec::new());
+
+/// Register the current thread's four TLS root structures for STW root walks.
+pub fn register_mutator() {
+    let thread_id = std::thread::current().id();
+    let shadow_stack = SHADOW_STACK.with(|stack| stack as *const _);
+    let jf_root_stack = JF_ROOT_STACK.with(|stack| stack as *const _);
+    let bh_regs_stack = BH_REGS_STACK.with(|stack| stack as *const _);
+    let resume_ref_roots_stack = RESUME_REF_ROOTS_STACK.with(|stack| stack as *const _);
+
+    let mut registry = MUTATOR_REGISTRY.lock().unwrap();
+    assert!(
+        !registry.iter().any(|entry| entry.thread_id == thread_id),
+        "mutator thread registered twice"
+    );
+    registry.push(MutatorEntry {
+        thread_id,
+        shadow_stack,
+        jf_root_stack,
+        bh_regs_stack,
+        resume_ref_roots_stack,
+    });
+}
+
+/// Remove the current thread from the all-thread root registry.
+///
+/// Call this before gc_sync::unregister_thread so RUNNING cannot reach zero
+/// while an entry whose TLS is being destroyed remains visible to the
+/// collector.
+pub fn unregister_mutator() {
+    let thread_id = std::thread::current().id();
+    let mut registry = MUTATOR_REGISTRY.lock().unwrap();
+    let index = registry
+        .iter()
+        .position(|entry| entry.thread_id == thread_id)
+        .expect("unregistering an unregistered mutator thread");
+    registry.swap_remove(index);
 }
 
 /// The shadow stack itself.
@@ -297,6 +353,26 @@ pub fn walk_roots(mut visitor: impl FnMut(&mut GcRef)) {
             }
         }
     });
+}
+
+/// Walk every registered mutator's GcRef shadow stack during STW.
+///
+/// This deliberately bypasses `RefCell::borrow_mut`: a RefCell borrow is a
+/// same-thread runtime check and must not be used as the synchronization
+/// mechanism for foreign TLS. gc_sync's quiescence is what makes the raw
+/// dereferences and in-place forwarding sound.
+pub fn walk_all_roots(mut visitor: impl FnMut(&mut GcRef)) {
+    let registry = MUTATOR_REGISTRY.lock().unwrap();
+    for mutator in registry.iter() {
+        // SAFETY: every registered mutator is quiesced, and registry removal
+        // precedes the owner's RUNNING decrement and TLS destruction.
+        let ss = unsafe { &mut *(*mutator.shadow_stack).as_ptr() };
+        for entry in ss.entries.iter_mut() {
+            if !entry.is_null() {
+                visitor(entry);
+            }
+        }
+    }
 }
 
 /// Current depth of the GcRef shadow stack.
@@ -474,6 +550,29 @@ pub fn walk_jf_roots(mut visitor: impl FnMut(&mut GcRef)) {
     });
 }
 
+/// Walk every registered mutator's jitframe shadow stack during STW.
+pub fn walk_all_jf_roots(mut visitor: impl FnMut(&mut GcRef)) {
+    let registry = MUTATOR_REGISTRY.lock().unwrap();
+    for mutator in registry.iter() {
+        // SAFETY: the owning mutator is quiesced and cannot change the stack
+        // or its backing allocation until the STW guard resumes it.
+        let stack = unsafe { &mut *(*mutator.jf_root_stack).as_ptr() };
+        stack.ensure_init();
+        unsafe {
+            let base = stack.base as *mut usize;
+            let top = stack.top.get() as *mut usize;
+            let mut ptr = base;
+            while ptr < top {
+                let jf_ref = &mut *(ptr.add(1) as *mut GcRef);
+                if !jf_ref.is_null() {
+                    visitor(jf_ref);
+                }
+                ptr = ptr.add(2);
+            }
+        }
+    }
+}
+
 /// Read the jf_ptr of the top shadow stack entry.
 ///
 /// assembler.py:1369-1377 _reload_frame_if_necessary:
@@ -610,6 +709,25 @@ pub fn walk_bh_regs(mut visitor: impl FnMut(&mut GcRef)) {
     });
 }
 
+/// Walk every registered mutator's blackhole register roots during STW.
+pub fn walk_all_bh_regs(mut visitor: impl FnMut(&mut GcRef)) {
+    let registry = MUTATOR_REGISTRY.lock().unwrap();
+    for mutator in registry.iter() {
+        // SAFETY: all owners are quiesced, and each registered slice remains
+        // pinned until its owning blackhole frame pops the entry after resume.
+        let entries = unsafe { &*(*mutator.bh_regs_stack).as_ptr() };
+        for entry in entries.iter() {
+            let slots = unsafe { std::slice::from_raw_parts_mut(entry.regs_ptr, entry.regs_len) };
+            for slot in slots.iter_mut() {
+                let gcref = unsafe { &mut *(slot as *mut i64 as *mut GcRef) };
+                visitor(gcref);
+            }
+            let tmp = unsafe { &mut *(entry.tmpreg_ptr as *mut GcRef) };
+            visitor(tmp);
+        }
+    }
+}
+
 /// Current depth of the blackhole register bank stack.
 pub fn bh_regs_depth() -> usize {
     BH_REGS_STACK.with(|ss| ss.borrow().len())
@@ -657,6 +775,23 @@ pub fn walk_resume_ref_roots(mut visitor: impl FnMut(&mut GcRef)) {
             }
         }
     });
+}
+
+/// Walk every registered mutator's resume-construction roots during STW.
+pub fn walk_all_resume_ref_roots(mut visitor: impl FnMut(&mut GcRef)) {
+    let registry = MUTATOR_REGISTRY.lock().unwrap();
+    for mutator in registry.iter() {
+        // SAFETY: the owner is quiesced and the registered slices stay pinned
+        // for the complete resume-construction window.
+        let entries = unsafe { &*(*mutator.resume_ref_roots_stack).as_ptr() };
+        for &(ptr, len) in entries.iter() {
+            let slots = unsafe { std::slice::from_raw_parts_mut(ptr, len) };
+            for slot in slots.iter_mut() {
+                let gcref = unsafe { &mut *(slot as *mut i64 as *mut GcRef) };
+                visitor(gcref);
+            }
+        }
+    }
 }
 
 // ── Extra root walkers registered by the embedder ───────────────

--- a/majit/majit-gc/src/shadow_stack.rs
+++ b/majit/majit-gc/src/shadow_stack.rs
@@ -233,6 +233,19 @@ struct MutatorEntry {
     jf_root_stack: *const RefCell<JitFrameShadowStack>,
     bh_regs_stack: *const RefCell<Vec<BhRegsEntry>>,
     resume_ref_roots_stack: *const RefCell<Vec<(*mut i64, usize)>>,
+    extra_areas: Vec<MutatorExtraArea>,
+}
+
+/// Walker for one opaque root area owned by a registered mutator.
+///
+/// The callback runs on the collecting thread. It must derive every
+/// thread-specific address from `data` and must not consult caller TLS.
+pub type MutatorExtraWalkFn = unsafe fn(*const (), &mut dyn FnMut(&mut GcRef));
+
+#[derive(Clone, Copy)]
+struct MutatorExtraArea {
+    walk: MutatorExtraWalkFn,
+    data: *const (),
 }
 
 // The raw pointers refer to TLS owned by `thread_id`. The registry only moves
@@ -261,7 +274,50 @@ pub fn register_mutator() {
         jf_root_stack,
         bh_regs_stack,
         resume_ref_roots_stack,
+        extra_areas: Vec::new(),
     });
+}
+
+/// Append an opaque root area to the current registered mutator.
+///
+/// The owning thread must keep `data` valid until [`unregister_mutator`].
+/// Foreign-thread invocation is restricted to the STW walk.
+pub fn register_mutator_extra_area(walk: MutatorExtraWalkFn, data: *const ()) {
+    let thread_id = std::thread::current().id();
+    let mut registry = MUTATOR_REGISTRY.lock().unwrap();
+    let entry = registry
+        .iter_mut()
+        .find(|entry| entry.thread_id == thread_id)
+        .expect("register_mutator_extra_area called before register_mutator");
+    entry.extra_areas.push(MutatorExtraArea { walk, data });
+}
+
+/// Walk every registered mutator's opaque extra root areas during STW.
+pub fn walk_all_extra_areas(mut visitor: impl FnMut(&mut GcRef)) {
+    let registry = MUTATOR_REGISTRY.lock().unwrap();
+    for mutator in registry.iter() {
+        for area in mutator.extra_areas.iter() {
+            // SAFETY: gc_sync has quiesced every registered owner, and each
+            // area remains valid until its MutatorEntry is removed.
+            unsafe { (area.walk)(area.data, &mut visitor) };
+        }
+    }
+}
+
+/// Walk the current mutator's opaque extra root areas.
+///
+/// This is the single-thread collection path; callers without a registered
+/// mutator have no per-thread areas and are a no-op.
+pub fn walk_my_extra_areas(mut visitor: impl FnMut(&mut GcRef)) {
+    let thread_id = std::thread::current().id();
+    let registry = MUTATOR_REGISTRY.lock().unwrap();
+    let Some(mutator) = registry.iter().find(|entry| entry.thread_id == thread_id) else {
+        return;
+    };
+    for area in mutator.extra_areas.iter() {
+        // SAFETY: this is the owning thread's synchronous collection path.
+        unsafe { (area.walk)(area.data, &mut visitor) };
+    }
 }
 
 /// Remove the current thread from the all-thread root registry.
@@ -1024,6 +1080,22 @@ mod tests {
         assert_eq!(get(0), GcRef(0x1100));
         assert_eq!(get(1), GcRef(0x2100));
         clear();
+    }
+
+    #[test]
+    fn test_mutator_extra_area_walks_current_thread() {
+        unsafe fn walk_cell(data: *const (), visitor: &mut dyn FnMut(&mut GcRef)) {
+            let slot = unsafe { &mut *(data as *mut GcRef) };
+            visitor(slot);
+        }
+
+        let _lock = TEST_MUTEX.lock().unwrap_or_else(|p| p.into_inner());
+        let mut root = GcRef(0x1000);
+        register_mutator();
+        register_mutator_extra_area(walk_cell, &mut root as *mut GcRef as *const ());
+        walk_my_extra_areas(|gcref| gcref.0 += 0x100);
+        unregister_mutator();
+        assert_eq!(root, GcRef(0x1100));
     }
 
     #[test]

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -18565,15 +18565,7 @@ mod tests {
 
     #[test]
     fn default_issubclass_uses_active_gc_subclass_ranges() {
-        struct ResetGcHooks;
-        impl Drop for ResetGcHooks {
-            fn drop(&mut self) {
-                majit_gc::set_active_gc_guard_hooks(majit_gc::ActiveGcGuardHooks::default());
-            }
-        }
-
-        let _reset = ResetGcHooks;
-        majit_gc::set_active_gc_guard_hooks(majit_gc::ActiveGcGuardHooks {
+        let _guard = majit_gc::override_gc_guard_hooks_for_test(majit_gc::ActiveGcGuardHooks {
             subclass_range: Some(test_subclass_range),
             ..Default::default()
         });

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -6230,6 +6230,28 @@ pub(crate) unsafe fn walk_method_cache_gc(forward: &mut dyn FnMut(&mut PyObjectR
     });
 }
 
+pub(crate) fn capture_method_cache_root_area() -> *const () {
+    METHOD_CACHE.with(|cache| cache as *const _ as *const ())
+}
+
+/// # Safety
+/// `data` must come from [`capture_method_cache_root_area`], and the owning
+/// thread must be quiesced.
+pub(crate) unsafe fn walk_method_cache_root_area(
+    data: *const (),
+    forward: &mut dyn FnMut(&mut PyObjectRef),
+) {
+    let cache = unsafe { &mut *(*(data as *const std::cell::RefCell<MethodCache>)).as_ptr() };
+    for (w_class, w_value) in cache.lookup_where.iter_mut() {
+        if !w_class.is_null() {
+            forward(w_class);
+        }
+        if !w_value.is_null() {
+            forward(w_value);
+        }
+    }
+}
+
 /// `typeobject.py:503-514 lookup_where_with_method_cache` — the method
 /// cache front door.  One path for interpreter and JIT (PyPy branches
 /// only on `version_tag is None`, never on `we_are_jitted()`): promote

--- a/pyre/pyre-interpreter/src/call.rs
+++ b/pyre/pyre-interpreter/src/call.rs
@@ -244,6 +244,10 @@ pub fn take_last_exec_ctx() -> *const crate::PyExecutionContext {
     LAST_EXEC_CTX.with(|c| c.get())
 }
 
+pub(crate) fn capture_last_exec_ctx_cell() -> *const () {
+    LAST_EXEC_CTX.with(|cell| cell as *const _ as *const ())
+}
+
 /// `pypy/objspace/std/objspace.py space.getexecutioncontext()` analogue.
 ///
 /// PyPy walks thread state and returns the live `ExecutionContext`,

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -751,8 +751,8 @@ fn walk_pyframe_roots(visitor: &mut dyn FnMut(&mut majit_ir::GcRef)) {
 /// Install the PyFrame GC root walker with the majit-gc collector.
 ///
 /// Called once at process startup from the JIT driver / pyrex main.
-/// Stored in a per-thread slot; calling again with the same fn pointer
-/// is idempotent.
+/// Stored in a process-global fn-pointer cell (#396); calling again with
+/// the same fn pointer is idempotent.
 pub fn register_pyframe_root_walker() {
     majit_gc::set_active_extra_root_walker(Some(walk_pyframe_roots));
 }

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -43,6 +43,24 @@ impl Code {
 // `get_current_exception` / `set_current_exception`; see those.
 thread_local! {
     pub(crate) static CURRENT_FRAME: Cell<*mut PyFrame> = const { Cell::new(std::ptr::null_mut()) };
+
+    static PYFRAME_ROOT_AREA: PyFrameRootArea = PyFrameRootArea {
+        current_frame: CURRENT_FRAME.with(|frame| frame as *const _),
+        last_exec_ctx: crate::call::capture_last_exec_ctx_cell(),
+        import_roots: crate::importing::capture_import_root_area(),
+        method_cache: crate::baseobjspace::capture_method_cache_root_area(),
+        mapdict_method_cache: crate::pycode::capture_mapdict_method_cache_root_area(),
+        codec_state: crate::module::_codecs::capture_codec_state_root_area(),
+    };
+}
+
+struct PyFrameRootArea {
+    current_frame: *const Cell<*mut PyFrame>,
+    last_exec_ctx: *const (),
+    import_roots: *const (),
+    method_cache: *const (),
+    mapdict_method_cache: *const (),
+    codec_state: *const (),
 }
 use crate::pyframe::PyFrame;
 
@@ -429,7 +447,20 @@ fn gc_prebuilt_remember_enabled() -> bool {
     })
 }
 
-fn walk_pyframe_roots(visitor: &mut dyn FnMut(&mut majit_ir::GcRef)) {
+pub fn capture_pyframe_root_area() -> *const () {
+    PYFRAME_ROOT_AREA.with(|area| area as *const _ as *const ())
+}
+
+/// Walk one captured thread's active frame and interpreter root state.
+///
+/// # Safety
+/// `data` must come from [`capture_pyframe_root_area`], and the owning thread
+/// must be quiesced.
+pub unsafe fn walk_pyframe_roots_area(
+    data: *const (),
+    visitor: &mut dyn FnMut(&mut majit_ir::GcRef),
+) {
+    let area = unsafe { &*(data as *const PyFrameRootArea) };
     // incminimark.py:339-355 prebuilt-object scanning parity: a minor
     // collection scans an old/prebuilt object only when the write barrier
     // recorded a store into it since the previous minor collection
@@ -445,7 +476,8 @@ fn walk_pyframe_roots(visitor: &mut dyn FnMut(&mut majit_ir::GcRef)) {
     let scan_prebuilt = !is_minor
         || pyre_object::gc_roots::prebuilt_roots_dirty()
         || !gc_prebuilt_remember_enabled();
-    CURRENT_FRAME.with(|cf| {
+    let cf = unsafe { &*area.current_frame };
+    {
         // Forward `CURRENT_FRAME` itself: when the top frame is a
         // nursery-allocated `PyFrame`
         // (`emit_new_pyframe_inline_self_recursive`) the visitor copies
@@ -480,7 +512,10 @@ fn walk_pyframe_roots(visitor: &mut dyn FnMut(&mut majit_ir::GcRef)) {
         // nursery exception.  PyPy reaches the ExecutionContext
         // unconditionally through `space.threadlocals`, independent of
         // any frame.
-        let ambient_ec = crate::call::take_last_exec_ctx() as *mut PyExecutionContext;
+        let ambient_ec = unsafe {
+            (&*(area.last_exec_ctx as *const Cell<*const PyExecutionContext>)).get()
+                as *mut PyExecutionContext
+        };
         let mut visit_ec_slots = |ec: *mut PyExecutionContext| {
             if ec.is_null() {
                 return;
@@ -710,42 +745,27 @@ fn walk_pyframe_roots(visitor: &mut dyn FnMut(&mut majit_ir::GcRef)) {
                     // dangles after a collection.
                     walk_raw_getset_roots(*slot, visitor);
                 };
-                crate::importing::walk_module_dicts_gc(&mut forward);
-                // The `sys.modules` dict is cached in a fast-path cell
-                // (`importing::SYS_MODULES_DICT`) that is independent of the
-                // `sys.__dict__["modules"]` slot the walk above forwards; forward
-                // the cell too so a relocated modules dict is not read back stale
-                // on the next import / `check_sys_modules` lookup.
-                crate::importing::walk_sys_modules_dict_gc(&mut forward);
-                // Box-immortal heap types' namespace dicts hold movable
-                // methods / class attributes / descriptor copies that no
-                // custom trace reaches; root them the same way.
-                walk_type_dicts_gc(&mut forward);
+                crate::importing::walk_import_roots_area(area.import_roots, &mut forward);
                 // The interpreter method cache (`baseobjspace::MethodCache`)
                 // keeps a second pointer to each looked-up method that the
                 // namespace-dict walk above does not reach; forward those so
                 // a cache hit after a moving collection is not stale.
-                crate::baseobjspace::walk_method_cache_gc(&mut forward);
+                crate::baseobjspace::walk_method_cache_root_area(area.method_cache, &mut forward);
                 // The per-pycode `_mapdict_caches` LOAD_METHOD slots hold a
                 // `w_method` pointer (mapdict.py:1418) that no custom trace
                 // reaches — code objects are Box-immortal — so forward those
                 // the same way.
-                crate::pycode::walk_mapdict_method_cache_gc(&mut forward);
+                crate::pycode::walk_mapdict_method_cache_root_area(
+                    area.mapdict_method_cache,
+                    &mut forward,
+                );
                 // _codecs.CodecState is a space-cache object in PyPy; pyre
                 // keeps the same list/dict state in module-local storage, so
                 // its Python objects must be forwarded explicitly.
-                crate::module::_codecs::walk_codec_state_gc(&mut forward);
-            }
-            // The minor walk above promoted every young value reachable
-            // from the prebuilt family; re-arm the write-tracking bit
-            // (incminimark: the minor collection empties
-            // `old_objects_pointing_to_young`).  A major seeding walk does
-            // not promote, so the bit is left untouched there.
-            if is_minor {
-                pyre_object::gc_roots::clear_prebuilt_roots_dirty();
+                crate::module::_codecs::walk_codec_state_root_area(area.codec_state, &mut forward);
             }
         }
-    });
+    }
 }
 
 /// Install the PyFrame GC root walker with the majit-gc collector.
@@ -754,7 +774,29 @@ fn walk_pyframe_roots(visitor: &mut dyn FnMut(&mut majit_ir::GcRef)) {
 /// Stored in a process-global fn-pointer cell (#396); calling again with
 /// the same fn pointer is idempotent.
 pub fn register_pyframe_root_walker() {
-    majit_gc::set_active_extra_root_walker(Some(walk_pyframe_roots));
+    majit_gc::shadow_stack::register_extra_root_walker(walk_global_prebuilt_roots);
+}
+
+fn walk_global_prebuilt_roots(visitor: &mut dyn FnMut(&mut majit_ir::GcRef)) {
+    let is_minor = majit_gc::shadow_stack::extra_root_walk_kind()
+        == majit_gc::shadow_stack::ExtraRootWalkKind::Minor;
+    let scan_prebuilt = !is_minor
+        || pyre_object::gc_roots::prebuilt_roots_dirty()
+        || !gc_prebuilt_remember_enabled();
+    if !scan_prebuilt {
+        return;
+    }
+    unsafe {
+        let mut forward = |slot: &mut PyObjectRef| {
+            visitor(&mut *(slot as *mut PyObjectRef as *mut majit_ir::GcRef));
+            walk_raw_function_roots(*slot, visitor);
+            walk_raw_getset_roots(*slot, visitor);
+        };
+        walk_type_dicts_gc(&mut forward);
+    }
+    if is_minor {
+        pyre_object::gc_roots::clear_prebuilt_roots_dirty();
+    }
 }
 
 /// Forward the GC slots a SUSPENDED generator's frame owns.

--- a/pyre/pyre-interpreter/src/importing.rs
+++ b/pyre/pyre-interpreter/src/importing.rs
@@ -371,12 +371,16 @@ thread_local! {
     static IMPORT_ROOT_AREA: ImportRootArea = ImportRootArea {
         modules: SYS_MODULES.with(|modules| modules as *const _),
         modules_dict: SYS_MODULES_DICT.with(|dict| dict as *const _),
+        argv_pending: SYS_ARGV_PENDING.with(|p| p as *const _),
     };
 }
 
 struct ImportRootArea {
     modules: *const RefCell<HashMap<String, PyObjectRef>>,
     modules_dict: *const std::cell::Cell<PyObjectRef>,
+    /// The pending `sys.argv` list is reachable only from this cell between
+    /// `set_sys_argv` and `take_pending_sys_argv`.
+    argv_pending: *const std::cell::Cell<PyObjectRef>,
 }
 
 // ── builtin module registry ──────────────────────────────────────────
@@ -1183,6 +1187,12 @@ pub(crate) unsafe fn walk_import_roots_area(
     if !dict.is_null() {
         visitor(&mut dict);
         modules_dict.set(dict);
+    }
+    let argv_pending = unsafe { &*area.argv_pending };
+    let mut argv = argv_pending.get();
+    if !argv.is_null() {
+        visitor(&mut argv);
+        argv_pending.set(argv);
     }
 }
 

--- a/pyre/pyre-interpreter/src/importing.rs
+++ b/pyre/pyre-interpreter/src/importing.rs
@@ -1172,8 +1172,10 @@ pub(crate) unsafe fn walk_import_roots_area(
     visitor: &mut dyn FnMut(&mut PyObjectRef),
 ) {
     let area = unsafe { &*(data as *const ImportRootArea) };
-    let modules = unsafe { &*area.modules };
-    for &module in modules.borrow().values() {
+    // SAFETY: the owning thread is quiesced for this foreign root walk, so the
+    // modules map is stable even if it parked with the RefCell borrow flag set.
+    let modules = unsafe { &*(*area.modules).as_ptr() };
+    for &module in modules.values() {
         if module.is_null() || !unsafe { pyre_object::is_module(module) } {
             continue;
         }

--- a/pyre/pyre-interpreter/src/importing.rs
+++ b/pyre/pyre-interpreter/src/importing.rs
@@ -367,6 +367,16 @@ thread_local! {
     /// Each builtin module is lazily created on first import.
     pub(crate) static BUILTIN_MODULES: RefCell<HashMap<&'static str, fn(&mut DictStorage)>> =
         RefCell::new(HashMap::new());
+
+    static IMPORT_ROOT_AREA: ImportRootArea = ImportRootArea {
+        modules: SYS_MODULES.with(|modules| modules as *const _),
+        modules_dict: SYS_MODULES_DICT.with(|dict| dict as *const _),
+    };
+}
+
+struct ImportRootArea {
+    modules: *const RefCell<HashMap<String, PyObjectRef>>,
+    modules_dict: *const std::cell::Cell<PyObjectRef>,
 }
 
 // ── builtin module registry ──────────────────────────────────────────
@@ -1144,6 +1154,36 @@ pub unsafe fn walk_sys_modules_dict_gc(visitor: &mut dyn FnMut(&mut PyObjectRef)
         visitor(&mut dict);
         d.set(dict);
     });
+}
+
+pub(crate) fn capture_import_root_area() -> *const () {
+    IMPORT_ROOT_AREA.with(|area| area as *const _ as *const ())
+}
+
+/// # Safety
+/// `data` must come from [`capture_import_root_area`], and the owning thread
+/// must be quiesced.
+pub(crate) unsafe fn walk_import_roots_area(
+    data: *const (),
+    visitor: &mut dyn FnMut(&mut PyObjectRef),
+) {
+    let area = unsafe { &*(data as *const ImportRootArea) };
+    let modules = unsafe { &*area.modules };
+    for &module in modules.borrow().values() {
+        if module.is_null() || !unsafe { pyre_object::is_module(module) } {
+            continue;
+        }
+        unsafe {
+            let w_dict = pyre_object::w_module_get_w_dict(module);
+            pyre_object::dictmultiobject::w_module_dict_walk_gc_cells(w_dict, visitor);
+        }
+    }
+    let modules_dict = unsafe { &*area.modules_dict };
+    let mut dict = modules_dict.get();
+    if !dict.is_null() {
+        visitor(&mut dict);
+        modules_dict.set(dict);
+    }
 }
 
 /// Set the Python-visible sys.modules dict reference. Called during sys

--- a/pyre/pyre-interpreter/src/module/_codecs/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_codecs/mod.rs
@@ -58,6 +58,28 @@ pub(crate) unsafe fn walk_codec_state_gc(visitor: &mut dyn FnMut(&mut PyObjectRe
     });
 }
 
+pub(crate) fn capture_codec_state_root_area() -> *const () {
+    CODEC_STATE.with(|state| state as *const _ as *const ())
+}
+
+/// # Safety
+/// `data` must come from [`capture_codec_state_root_area`], and the owning
+/// thread must be quiesced.
+pub(crate) unsafe fn walk_codec_state_root_area(
+    data: *const (),
+    visitor: &mut dyn FnMut(&mut PyObjectRef),
+) {
+    let state = unsafe { &*(data as *const Cell<*mut CodecState>) };
+    let ptr = state.get();
+    if ptr.is_null() {
+        return;
+    }
+    let state = unsafe { &mut *ptr };
+    visitor(&mut state.codec_search_path);
+    visitor(&mut state.codec_search_cache);
+    visitor(&mut state.codec_error_registry);
+}
+
 // PyPy `interp_codecs.py:166-190 normalize`.
 fn normalize(encoding: &str) -> String {
     let mut chars = String::new();

--- a/pyre/pyre-interpreter/src/module/signal/interp_signal.rs
+++ b/pyre/pyre-interpreter/src/module/signal/interp_signal.rs
@@ -148,6 +148,32 @@ pub fn walk_signal_handler_roots(mut visitor: impl FnMut(&mut PyObjectRef)) {
     });
 }
 
+pub fn capture_signal_handler_root_area() -> *const () {
+    HANDLERS.with(|handlers| handlers as *const _ as *const ())
+}
+
+/// # Safety
+/// `data` must come from [`capture_signal_handler_root_area`], and the owning
+/// thread must be quiesced.
+pub unsafe fn walk_signal_handler_roots_area(
+    data: *const (),
+    mut visitor: impl FnMut(&mut PyObjectRef),
+) {
+    let handlers = unsafe { &*(data as *const std::cell::Cell<PyObjectRef>) };
+    let mut dict = handlers.get();
+    if dict.is_null() {
+        return;
+    }
+    visitor(&mut dict);
+    handlers.set(dict);
+    unsafe {
+        let strategy = pyre_object::dictmultiobject::w_dict_get_strategy(dict);
+        strategy.walk_gc_refs(dict, &mut |slot: *mut PyObjectRef| {
+            visitor(&mut *slot);
+        });
+    }
+}
+
 /// `@unwrap_spec(signum=int)` — coerce the signal-number argument to an
 /// `i32`.  The gateway `int` converter is `space.gateway_int_w`
 /// (`gateway.py:646-665` → `int_w(allow_conversion=True)`), which runs

--- a/pyre/pyre-interpreter/src/objspace/std/mapdict.rs
+++ b/pyre/pyre-interpreter/src/objspace/std/mapdict.rs
@@ -2542,6 +2542,16 @@ thread_local! {
     /// this is the same per-instance lifeline storage.
     pub static WEAKREF_TABLE: RefCell<HashMap<usize, PyObjectRef>> =
         RefCell::new(HashMap::new());
+
+    static MAPDICT_ROOT_AREA: MapdictRootArea = MapdictRootArea {
+        instance_dict: INSTANCE_DICT.with(|table| table as *const _),
+        weakref_table: WEAKREF_TABLE.with(|table| table as *const _),
+    };
+}
+
+struct MapdictRootArea {
+    instance_dict: *const RefCell<HashMap<usize, PyObjectRef>>,
+    weakref_table: *const RefCell<HashMap<usize, PyObjectRef>>,
 }
 
 // ── MapdictDictSupport ────────────────────────────────────────────────
@@ -3040,19 +3050,36 @@ pub unsafe fn instance_walk_boxed_storage(obj: PyObjectRef, f: &mut dyn FnMut(*m
 /// those value slots here so the backend GC can update them when nursery objects
 /// move.
 pub fn walk_mapdict_roots(mut visitor: impl FnMut(&mut PyObjectRef)) {
-    let dict_values = INSTANCE_DICT.with(|table| {
+    let data = capture_mapdict_root_area();
+    unsafe { walk_mapdict_roots_area(data, &mut visitor) };
+}
+
+pub fn capture_mapdict_root_area() -> *const () {
+    MAPDICT_ROOT_AREA.with(|area| area as *const _ as *const ())
+}
+
+/// # Safety
+/// `data` must come from [`capture_mapdict_root_area`], and the owning thread
+/// must be quiesced.
+pub unsafe fn walk_mapdict_roots_area(data: *const (), mut visitor: impl FnMut(&mut PyObjectRef)) {
+    let area = unsafe { &*(data as *const MapdictRootArea) };
+    let instance_dict = unsafe { &*area.instance_dict };
+    let weakref_table = unsafe { &*area.weakref_table };
+    let dict_values = {
+        let table = instance_dict;
         table
             .borrow()
             .iter()
             .map(|(&key, &dict)| (key, dict))
             .collect::<Vec<_>>()
-    });
+    };
     // SAFETY: do not hold the RefCell borrow while invoking callbacks. The
     // visitor and w_dict_walk_entries_mut may re-enter mapdict/dict APIs.
     for (key, mut dict) in dict_values {
         visitor(&mut dict);
         let new_key = current_owner_key(key);
-        INSTANCE_DICT.with(|table| {
+        {
+            let table = instance_dict;
             let mut table = table.borrow_mut();
             if new_key == key {
                 if let Some(slot) = table.get_mut(&key) {
@@ -3061,7 +3088,7 @@ pub fn walk_mapdict_roots(mut visitor: impl FnMut(&mut PyObjectRef)) {
             } else if table.remove(&key).is_some() {
                 table.insert(new_key, dict);
             }
-        });
+        }
         // Trace the dict's own r_dict entries. INSTANCE_DICT now holds only
         // non-instance hasdict wrappers (property/member) — never a
         // MapDictStrategy view, since an instance's `__dict__` wrapper lives in
@@ -3091,17 +3118,19 @@ pub fn walk_mapdict_roots(mut visitor: impl FnMut(&mut PyObjectRef)) {
         // via the instance/wrapper write barriers that enter the remembered set.
         // So no instance is walked here.
     }
-    let weakref_values = WEAKREF_TABLE.with(|table| {
+    let weakref_values = {
+        let table = weakref_table;
         table
             .borrow()
             .iter()
             .map(|(&key, &value)| (key, value))
             .collect::<Vec<_>>()
-    });
+    };
     for (key, mut value) in weakref_values {
         visitor(&mut value);
         let new_key = current_owner_key(key);
-        WEAKREF_TABLE.with(|table| {
+        {
+            let table = weakref_table;
             let mut table = table.borrow_mut();
             if new_key == key {
                 if let Some(slot) = table.get_mut(&key) {
@@ -3110,7 +3139,7 @@ pub fn walk_mapdict_roots(mut visitor: impl FnMut(&mut PyObjectRef)) {
             } else if table.remove(&key).is_some() {
                 table.insert(new_key, value);
             }
-        });
+        }
     }
 }
 

--- a/pyre/pyre-interpreter/src/pycode.rs
+++ b/pyre/pyre-interpreter/src/pycode.rs
@@ -1180,6 +1180,36 @@ pub(crate) unsafe fn walk_mapdict_method_cache_gc(forward: &mut dyn FnMut(&mut P
     });
 }
 
+pub(crate) fn capture_mapdict_method_cache_root_area() -> *const () {
+    MAPDICT_METHOD_CACHE_CODES.with(|codes| codes as *const _ as *const ())
+}
+
+/// # Safety
+/// `data` must come from [`capture_mapdict_method_cache_root_area`], and the
+/// owning thread must be quiesced.
+pub(crate) unsafe fn walk_mapdict_method_cache_root_area(
+    data: *const (),
+    forward: &mut dyn FnMut(&mut PyObjectRef),
+) {
+    let codes = unsafe {
+        &*(*(data as *const std::cell::RefCell<std::collections::HashSet<usize>>)).as_ptr()
+    };
+    for &code in codes.iter() {
+        let code = unsafe { &*(code as *const PyCode) };
+        if code.mapdict_caches.is_null() {
+            continue;
+        }
+        let vec = unsafe { &mut *code.mapdict_caches };
+        for slot in vec.iter_mut() {
+            if let Some(entry) = slot.as_mut() {
+                if !entry.w_method.is_null() {
+                    forward(&mut entry.w_method);
+                }
+            }
+        }
+    }
+}
+
 /// Number of `_mapdict_caches` slots — equals `len(co_names_w)` at construction
 /// time.  Returns 0 for code objects built from null or unaligned `code_ptr`.
 ///

--- a/pyre/pyre-interpreter/src/stack_check.rs
+++ b/pyre/pyre-interpreter/src/stack_check.rs
@@ -129,6 +129,11 @@ thread_local! {
     /// (stack.c:63-64).
     static TL_STACK_END: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
 
+    /// stack.c:18 `report_error`, mirrored per thread for free-threaded
+    /// critical-code suppression. The global struct field remains the
+    /// stable backend-visible cache; the slow path reads this source of truth.
+    static TL_REPORT_ERROR: std::cell::Cell<u8> = const { std::cell::Cell::new(1) };
+
     /// Pending Python exception produced by a JIT prologue stack check
     /// in the current OS thread. This follows the same ownership model
     /// as `pypy_threadlocal_s::stack_end`: backend code may enter from
@@ -258,9 +263,9 @@ pub extern "C" fn pyre_stack_set_length_fraction(frac: f64) {
 ///   * `-max_stack_size <= diff < 0` — stack underflowed; revise the
 ///     base upward via the shared "update base to current" epilogue
 ///     (stack.c:52-55), return `0`.
-///   * else — real stack overflow (stack.c:56-58), return
-///     `PYRE_STACKTOOBIG.report_error` (which is cleared during
-///     critical-code sections by [`pyre_stack_criticalcode_start`]).
+///   * else — real stack overflow (stack.c:56-58), return the current
+///     thread's `report_error` mirror (which is cleared during critical-code
+///     sections by [`pyre_stack_criticalcode_start`]).
 ///
 /// The TLS mirror [`TL_STACK_END`] is the source of truth
 /// (stack.c:40 `baseptr = tl1->stack_end;`); the global
@@ -300,7 +305,7 @@ pub extern "C" fn pyre_stack_too_big_slowpath(current: usize) -> u8 {
             // "update base to current" epilogue below.
         } else {
             // stack.c:56-58 real stack overflow.
-            return PYRE_STACKTOOBIG.report_error.load(Ordering::Relaxed);
+            return TL_REPORT_ERROR.with(|c| c.get());
         }
     }
 
@@ -402,19 +407,19 @@ pub fn is_jit_overflow_pending() -> bool {
 }
 
 /// rpython/translator/c/src/stack.h:42 `LL_stack_criticalcode_start`.
-/// Clears the `report_error` flag so the slowpath will not signal a
-/// stack overflow during short critical-code sections.
+/// Clears this thread's `report_error` mirror so its slowpath will not signal
+/// a stack overflow during short critical-code sections.
 #[unsafe(no_mangle)]
 pub extern "C" fn pyre_stack_criticalcode_start() {
-    PYRE_STACKTOOBIG.report_error.store(0, Ordering::Relaxed);
+    TL_REPORT_ERROR.with(|c| c.set(0));
 }
 
 /// rpython/translator/c/src/stack.h:43 `LL_stack_criticalcode_stop`.
-/// Re-enables the `report_error` flag so subsequent real overflows
-/// raise `RecursionError` again.
+/// Re-enables this thread's `report_error` mirror so subsequent real
+/// overflows raise `RecursionError` again.
 #[unsafe(no_mangle)]
 pub extern "C" fn pyre_stack_criticalcode_stop() {
-    PYRE_STACKTOOBIG.report_error.store(1, Ordering::Relaxed);
+    TL_REPORT_ERROR.with(|c| c.set(1));
 }
 
 /// pypy/module/sys/vm.py:63 `setrecursionlimit` parity. Tentatively
@@ -544,6 +549,7 @@ mod tests {
             .stack_length
             .store(MAX_STACK_SIZE, Ordering::Relaxed);
         PYRE_STACKTOOBIG.report_error.store(1, Ordering::Relaxed);
+        TL_REPORT_ERROR.with(|c| c.set(1));
         crate::module::sys::state::reset_recursion_limit_for_tests();
         clear_jit_pending_exception();
     }
@@ -821,6 +827,35 @@ mod tests {
         pyre_stack_criticalcode_stop();
         let overflow = pyre_stack_too_big_slowpath(sp);
         assert_eq!(overflow, 1, "stop must re-enable overflow signalling");
+        reset_all();
+    }
+
+    #[test]
+    fn criticalcode_suppression_is_thread_local() {
+        let _g = lock_tests();
+        reset_all();
+        let entered = std::sync::Arc::new(std::sync::Barrier::new(2));
+        let release = std::sync::Arc::new(std::sync::Barrier::new(2));
+        let worker_entered = entered.clone();
+        let worker_release = release.clone();
+        let worker = std::thread::spawn(move || {
+            pyre_stack_criticalcode_start();
+            worker_entered.wait();
+            worker_release.wait();
+            pyre_stack_criticalcode_stop();
+        });
+        entered.wait();
+
+        let sp = current_sp();
+        plant_stack_end(sp.saturating_add(2 * MAX_STACK_SIZE));
+        assert_eq!(
+            pyre_stack_too_big_slowpath(sp),
+            1,
+            "another thread's criticalcode must not suppress this thread"
+        );
+
+        release.wait();
+        worker.join().unwrap();
         reset_all();
     }
 

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -7779,27 +7779,41 @@ pub fn fbw_finish_concrete_take() -> Option<FinishConcrete> {
 /// Registered once via `register_extra_root_walker` at JIT init, mirroring
 /// [`fbw_store_journal_root_walker`].
 pub fn fbw_finish_concrete_root_walker(visitor: &mut dyn FnMut(&mut majit_ir::GcRef)) {
-    FBW_FINISH_CONCRETE.with(|c| {
-        let Some(finish) = c.get() else {
-            return;
-        };
-        let (value, is_raise) = match finish {
-            FinishConcrete::Return(value) => (value, false),
-            FinishConcrete::Raise(value) => (value, true),
-        };
-        if let ConcreteValue::Ref(ptr) = value {
-            let mut gcref = majit_ir::GcRef(ptr as usize);
-            visitor(&mut gcref);
-            // The visitor may forward (relocate) the ref; write it back so
-            // the stashed value points at the moved object.
-            let value = ConcreteValue::Ref(gcref.0 as pyre_object::PyObjectRef);
-            c.set(Some(if is_raise {
-                FinishConcrete::Raise(value)
-            } else {
-                FinishConcrete::Return(value)
-            }));
-        }
-    });
+    let data = capture_fbw_finish_concrete_root_area();
+    unsafe { fbw_finish_concrete_root_walker_area(data, visitor) };
+}
+
+pub fn capture_fbw_finish_concrete_root_area() -> *const () {
+    FBW_FINISH_CONCRETE.with(|value| value as *const _ as *const ())
+}
+
+/// # Safety
+/// `data` must come from [`capture_fbw_finish_concrete_root_area`], and the
+/// owning thread must be quiesced.
+pub unsafe fn fbw_finish_concrete_root_walker_area(
+    data: *const (),
+    visitor: &mut dyn FnMut(&mut majit_ir::GcRef),
+) {
+    let cell = unsafe { &*(data as *const std::cell::Cell<Option<FinishConcrete>>) };
+    let Some(finish) = cell.get() else {
+        return;
+    };
+    let (value, is_raise) = match finish {
+        FinishConcrete::Return(value) => (value, false),
+        FinishConcrete::Raise(value) => (value, true),
+    };
+    if let ConcreteValue::Ref(ptr) = value {
+        let mut gcref = majit_ir::GcRef(ptr as usize);
+        visitor(&mut gcref);
+        // The visitor may forward (relocate) the ref; write it back so
+        // the stashed value points at the moved object.
+        let value = ConcreteValue::Ref(gcref.0 as pyre_object::PyObjectRef);
+        cell.set(Some(if is_raise {
+            FinishConcrete::Raise(value)
+        } else {
+            FinishConcrete::Return(value)
+        }));
+    }
 }
 
 /// One in-flight FOR_ITER continuation entry (#57 Option C): the item the
@@ -8013,6 +8027,24 @@ pub(crate) struct MidBodyPayload {
     pub live_locals: Vec<Option<ConcreteValue>>,
     pub live_stack: Vec<ConcreteValue>,
     pub return_value: pyre_object::PyObjectRef,
+}
+
+struct FbwStoreJournalRootArea {
+    stores: *const std::cell::RefCell<Vec<[pyre_object::PyObjectRef; 3]>>,
+    appends: *const std::cell::RefCell<Vec<(pyre_object::PyObjectRef, usize)>>,
+    cell_stores: *const std::cell::RefCell<Vec<(pyre_object::PyObjectRef, i64)>>,
+    foriter: *const std::cell::RefCell<Vec<InflightForiter>>,
+    abort_resume: *const std::cell::RefCell<Option<InlineAbortCarrier>>,
+}
+
+thread_local! {
+    static FBW_STORE_JOURNAL_ROOT_AREA: FbwStoreJournalRootArea = FbwStoreJournalRootArea {
+        stores: FBW_STORE_JOURNAL.with(|value| value as *const _),
+        appends: FBW_APPEND_JOURNAL.with(|value| value as *const _),
+        cell_stores: FBW_CELL_STORE_JOURNAL.with(|value| value as *const _),
+        foriter: FBW_FORITER_INFLIGHT.with(|value| value as *const _),
+        abort_resume: FBW_ABORT_CALL_RESUME.with(|value| value as *const _),
+    };
 }
 
 /// Record that `op` is a walker-built inline exception (B3 construct fold).
@@ -8688,91 +8720,90 @@ pub(crate) fn fbw_executed_residual_counts() -> (u32, u32, u32) {
 /// objects), so every ref slot is forwarded as a root.  Registered once via
 /// `majit_gc::shadow_stack::register_extra_root_walker` at JIT init.
 pub fn fbw_store_journal_root_walker(visitor: &mut dyn FnMut(&mut majit_ir::GcRef)) {
-    FBW_STORE_JOURNAL.with(|j| {
-        for triple in j.borrow_mut().iter_mut() {
-            for slot in triple.iter_mut() {
-                // SAFETY: `PyObjectRef` and `GcRef` share the usize repr
-                // (`GcRef` is `#[repr(transparent)]`); the borrow keeps
-                // the Vec storage alive for the visit.
-                visitor(unsafe { &mut *(slot as *mut pyre_object::PyObjectRef).cast() });
-            }
+    let data = capture_fbw_store_journal_root_area();
+    unsafe { fbw_store_journal_root_walker_area(data, visitor) };
+}
+
+pub fn capture_fbw_store_journal_root_area() -> *const () {
+    FBW_STORE_JOURNAL_ROOT_AREA.with(|area| area as *const _ as *const ())
+}
+
+/// # Safety
+/// `data` must come from [`capture_fbw_store_journal_root_area`], and the
+/// owning thread must be quiesced.
+pub unsafe fn fbw_store_journal_root_walker_area(
+    data: *const (),
+    visitor: &mut dyn FnMut(&mut majit_ir::GcRef),
+) {
+    let area = unsafe { &*(data as *const FbwStoreJournalRootArea) };
+    let stores = unsafe { &mut *(*area.stores).as_ptr() };
+    for triple in stores.iter_mut() {
+        for slot in triple.iter_mut() {
+            visitor(unsafe { &mut *(slot as *mut pyre_object::PyObjectRef).cast() });
         }
-    });
-    FBW_APPEND_JOURNAL.with(|j| {
-        for (list, _len) in j.borrow_mut().iter_mut() {
-            // SAFETY: as above — only the `PyObjectRef` slot is a root; the
-            // `usize` length is a plain scalar.
-            visitor(unsafe { &mut *(list as *mut pyre_object::PyObjectRef).cast() });
-        }
-    });
+    }
+    let appends = unsafe { &mut *(*area.appends).as_ptr() };
+    for (list, _len) in appends.iter_mut() {
+        visitor(unsafe { &mut *(list as *mut pyre_object::PyObjectRef).cast() });
+    }
     // Cell-store journal: the cell is immovable (`malloc_typed`) so no
     // forwarding happens, but a mid-walk rebind can drop the module dict's
     // only reference — rooting it keeps the rollback's `intvalue` restore
     // from writing into a freed block.
-    FBW_CELL_STORE_JOURNAL.with(|j| {
-        for (cell, _intvalue) in j.borrow_mut().iter_mut() {
-            // SAFETY: as above — only the `PyObjectRef` slot is a root; the
-            // `i64` payload is a plain scalar.
-            visitor(unsafe { &mut *(cell as *mut pyre_object::PyObjectRef).cast() });
-        }
-    });
+    let cell_stores = unsafe { &mut *(*area.cell_stores).as_ptr() };
+    for (cell, _intvalue) in cell_stores.iter_mut() {
+        visitor(unsafe { &mut *(cell as *mut pyre_object::PyObjectRef).cast() });
+    }
     // #57 Option C: each captured in-flight FOR_ITER item is nursery-resident
     // across the rest of the walk (subsequent residual calls allocate and a
     // minor collection moves nursery objects), so forward every entry's item
     // as a root.
-    FBW_FORITER_INFLIGHT.with(|c| {
-        for entry in c.borrow_mut().iter_mut() {
-            // SAFETY: as above — only the `PyObjectRef` slot is a root; the
-            // `usize` body pc and the bool flag are plain scalars.
-            visitor(unsafe { &mut *(&mut entry.item as *mut pyre_object::PyObjectRef).cast() });
-        }
-    });
+    let foriter = unsafe { &mut *(*area.foriter).as_ptr() };
+    for entry in foriter.iter_mut() {
+        // SAFETY: as above — only the `PyObjectRef` slot is a root; the
+        // `usize` body pc and the bool flag are plain scalars.
+        visitor(unsafe { &mut *(&mut entry.item as *mut pyre_object::PyObjectRef).cast() });
+    }
     // gh#467: the latched forward-flush operand stack (callable + args) is
     // nursery-resident across the abort unwind — the flush boxes Int/Float
     // locals, which can trigger a minor collection that moves these refs before
     // they are written into the frame array — so forward every slot as a root.
-    FBW_ABORT_CALL_RESUME.with(|c| {
-        if let Some(carrier) = c.borrow_mut().as_mut() {
-            match carrier {
-                InlineAbortCarrier::Entry { call_stack, .. } => {
-                    for slot in call_stack {
-                        visitor(unsafe { &mut *(slot as *mut pyre_object::PyObjectRef).cast() });
+    let abort_resume = unsafe { &mut *(*area.abort_resume).as_ptr() };
+    if let Some(carrier) = abort_resume.as_mut() {
+        match carrier {
+            InlineAbortCarrier::Entry { call_stack, .. } => {
+                for slot in call_stack {
+                    visitor(unsafe { &mut *(slot as *mut pyre_object::PyObjectRef).cast() });
+                }
+            }
+            InlineAbortCarrier::MidBody(payload) => {
+                visitor(unsafe {
+                    &mut *(&mut payload.w_code as *mut pyre_object::PyObjectRef).cast()
+                });
+                visitor(unsafe {
+                    &mut *(&mut payload.w_globals as *mut pyre_object::PyObjectRef).cast()
+                });
+                visitor(unsafe {
+                    &mut *(&mut payload.x_arg as *mut pyre_object::PyObjectRef).cast()
+                });
+                if !payload.return_value.is_null() {
+                    visitor(unsafe {
+                        &mut *(&mut payload.return_value as *mut pyre_object::PyObjectRef).cast()
+                    });
+                }
+                for slot in payload.live_locals.iter_mut().flatten() {
+                    if let ConcreteValue::Ref(value) = slot {
+                        visitor(unsafe { &mut *(value as *mut pyre_object::PyObjectRef).cast() });
                     }
                 }
-                InlineAbortCarrier::MidBody(payload) => {
-                    visitor(unsafe {
-                        &mut *(&mut payload.w_code as *mut pyre_object::PyObjectRef).cast()
-                    });
-                    visitor(unsafe {
-                        &mut *(&mut payload.w_globals as *mut pyre_object::PyObjectRef).cast()
-                    });
-                    visitor(unsafe {
-                        &mut *(&mut payload.x_arg as *mut pyre_object::PyObjectRef).cast()
-                    });
-                    if !payload.return_value.is_null() {
-                        visitor(unsafe {
-                            &mut *(&mut payload.return_value as *mut pyre_object::PyObjectRef)
-                                .cast()
-                        });
-                    }
-                    for slot in payload.live_locals.iter_mut().flatten() {
-                        if let ConcreteValue::Ref(value) = slot {
-                            visitor(unsafe {
-                                &mut *(value as *mut pyre_object::PyObjectRef).cast()
-                            });
-                        }
-                    }
-                    for slot in &mut payload.live_stack {
-                        if let ConcreteValue::Ref(value) = slot {
-                            visitor(unsafe {
-                                &mut *(value as *mut pyre_object::PyObjectRef).cast()
-                            });
-                        }
+                for slot in &mut payload.live_stack {
+                    if let ConcreteValue::Ref(value) = slot {
+                        visitor(unsafe { &mut *(value as *mut pyre_object::PyObjectRef).cast() });
                     }
                 }
             }
         }
-    });
+    }
 }
 
 /// FBW-native port of [`crate::state::ensure_boxed_for_ca`] that operates

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -822,21 +822,33 @@ pub fn pyjitcode_for_jitcode_index(jitcode_index: i32) -> Option<std::sync::Arc<
 /// the non-moving old-gen, build-time consts are `malloc_typed`-immortal —
 /// so the slots are marked in place without forwarding.
 pub fn walk_jitcode_constants_refs(visitor: &mut dyn FnMut(&mut majit_ir::GcRef)) {
-    METAINTERP_SD.with(|r| {
-        // A collection can fire while another reader holds a shared borrow;
-        // only a concurrent `borrow_mut` (jitcode install/refill, which runs
-        // outside an old-gen sweep) conflicts, and those freshly built consts
-        // are still reachable from the builder, so skipping is safe there.
-        let Ok(sd) = r.try_borrow() else {
-            return;
-        };
-        for jc in sd.jitcodes.iter() {
-            for &slot in jc.payload.jitcode.constants_r.iter() {
-                let mut gcref = majit_ir::GcRef(slot as usize);
-                visitor(&mut gcref);
-            }
+    let data = capture_jitcode_constants_root_area();
+    unsafe { walk_jitcode_constants_refs_area(data, visitor) };
+}
+
+pub fn capture_jitcode_constants_root_area() -> *const () {
+    METAINTERP_SD.with(|state| state as *const _ as *const ())
+}
+
+/// # Safety
+/// `data` must come from [`capture_jitcode_constants_root_area`], and the
+/// owning thread must be quiesced.
+pub unsafe fn walk_jitcode_constants_refs_area(
+    data: *const (),
+    visitor: &mut dyn FnMut(&mut majit_ir::GcRef),
+) {
+    let state = unsafe { &*(data as *const RefCell<MetaInterpStaticData>) };
+    // A collection can fire while the owner holds a shared borrow. Preserve
+    // the existing skip for that re-entrant single-thread case.
+    let Ok(sd) = state.try_borrow() else {
+        return;
+    };
+    for jc in sd.jitcodes.iter() {
+        for &slot in jc.payload.jitcode.constants_r.iter() {
+            let mut gcref = majit_ir::GcRef(slot as usize);
+            visitor(&mut gcref);
         }
-    });
+    }
 }
 
 /// Resolve by PyCode wrapper through the trace-side

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -406,6 +406,16 @@ impl FrameArena {
 
 thread_local! {
     static FRAME_ARENA: UnsafeCell<FrameArena> = UnsafeCell::new(FrameArena::new());
+
+    static JIT_CALLEE_FRAME_ROOT_AREA: JitCalleeFrameRootArea = JitCalleeFrameRootArea {
+        arena: FRAME_ARENA.with(|cell| cell as *const _),
+        heap_frames: HEAP_CALLEE_FRAMES.with(|cell| cell as *const _),
+    };
+}
+
+struct JitCalleeFrameRootArea {
+    arena: *const UnsafeCell<FrameArena>,
+    heap_frames: *const UnsafeCell<Vec<*mut PyFrame>>,
 }
 
 #[inline]
@@ -442,17 +452,32 @@ unsafe fn visit_callee_frame_roots(frame: *mut PyFrame, visitor: &mut dyn FnMut(
 /// framework.py `root_walker.walk_roots` seam the collector already
 /// uses for the other host-side root sources.
 pub fn walk_jit_callee_frame_roots(visitor: &mut dyn FnMut(&mut GcRef)) {
-    let arena = arena_ref();
+    let data = capture_jit_callee_frame_root_area();
+    unsafe { walk_jit_callee_frame_roots_area(data, visitor) };
+}
+
+pub fn capture_jit_callee_frame_root_area() -> *const () {
+    JIT_CALLEE_FRAME_ROOT_AREA.with(|area| area as *const _ as *const ())
+}
+
+/// # Safety
+/// `data` must come from [`capture_jit_callee_frame_root_area`], and the
+/// owning thread must be quiesced.
+pub unsafe fn walk_jit_callee_frame_roots_area(
+    data: *const (),
+    visitor: &mut dyn FnMut(&mut GcRef),
+) {
+    let area = unsafe { &*(data as *const JitCalleeFrameRootArea) };
+    let arena = unsafe { &mut *(*area.arena).get() };
     for idx in 0..ARENA_CAP {
         if arena.armed[idx] {
             unsafe { visit_callee_frame_roots(arena.buf[idx].frame.as_mut_ptr(), visitor) };
         }
     }
-    HEAP_CALLEE_FRAMES.with(|cell| {
-        for &ptr in unsafe { &*cell.get() }.iter() {
-            unsafe { visit_callee_frame_roots(ptr, visitor) };
-        }
-    });
+    let heap_frames = unsafe { &*(*area.heap_frames).get() };
+    for &ptr in heap_frames.iter() {
+        unsafe { visit_callee_frame_roots(ptr, visitor) };
+    }
 }
 
 // ── JIT call callbacks ───────────────────────────────────────────

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -2352,62 +2352,56 @@ fn install_gc_into_backend() {
 /// interpreter is initialized.
 fn install_gc_root_walkers() {
     pyre_interpreter::eval::register_pyframe_root_walker();
-    // framework.py `root_walker.walk_roots` parity for the boxed `Ref`
-    // constants in every live jitcode's `constants_r` pool. RPython
-    // traces these through the `JitCode` GC object; pyre's jitcodes
-    // live in Rust `Arc` memory, so a constant boxed object reachable
-    // only from `jitcode.constants_r` (copied into the blackhole
-    // register file at `init_register_files_from_runtime_jitcode`) is
-    // swept by a major collection unless walked here, and the next
-    // guard-failure resume dereferences the freed pointer. See
-    // `pyre_jit_trace::state::walk_jitcode_constants_refs`.
-    majit_gc::shadow_stack::register_extra_root_walker(
-        pyre_jit_trace::state::walk_jitcode_constants_refs,
+}
+
+fn register_thread_root_areas() {
+    let register = majit_gc::shadow_stack::register_mutator_extra_area;
+    register(
+        pyframe_root_walker_area,
+        pyre_interpreter::eval::capture_pyframe_root_area(),
     );
-    // framework.py `root_walker.walk_roots` parity for the full-body
-    // walk's store-undo journal: the `(list, key, displaced)` triples
-    // hold nursery refs across the rest of the walk (residual calls
-    // allocate, and a minor collection moves nursery objects). See
-    // `pyre_jit_trace::jitcode_dispatch::fbw_store_journal_root_walker`.
-    majit_gc::shadow_stack::register_extra_root_walker(
-        pyre_jit_trace::jitcode_dispatch::fbw_store_journal_root_walker,
+    register(
+        pyre_object_root_walker_area,
+        pyre_object::gc_roots::capture_shadow_stack_area(),
     );
-    // The no-replay portal exit stashes a `Ref` return value (the
-    // walk's concrete result) that must survive the post-walk compile's
-    // allocations until the portal consumes it. See
-    // `pyre_jit_trace::jitcode_dispatch::fbw_finish_concrete_root_walker`.
-    majit_gc::shadow_stack::register_extra_root_walker(
-        pyre_jit_trace::jitcode_dispatch::fbw_finish_concrete_root_walker,
+    register(
+        jitcode_constants_root_walker_area,
+        pyre_jit_trace::state::capture_jitcode_constants_root_area(),
     );
-    // pyre's temporary mapdict side table mirrors PyPy fields that are
-    // normally traced by the translated GC. Walk its value slots
-    // explicitly until the table is folded into the object layout.
-    majit_gc::shadow_stack::register_extra_root_walker(pyre_interpreter_side_table_root_walker);
-    // Signal handler dict walker — the dict may not exist yet (null-check
-    // in walk_signal_handler_roots guards this), but the walker must be
-    // registered here so PYRE_JIT=0 paths also get it.
+    register(
+        fbw_store_journal_root_walker_area,
+        pyre_jit_trace::jitcode_dispatch::capture_fbw_store_journal_root_area(),
+    );
+    register(
+        fbw_finish_concrete_root_walker_area,
+        pyre_jit_trace::jitcode_dispatch::capture_fbw_finish_concrete_root_area(),
+    );
+    register(
+        mapdict_root_walker_area,
+        pyre_interpreter::objspace::std::mapdict::capture_mapdict_root_area(),
+    );
     #[cfg(not(target_arch = "wasm32"))]
-    majit_gc::shadow_stack::register_extra_root_walker(signal_handler_root_walker);
-    // `GcWeakrefBox` instances are immortal, so the collector never
-    // relocates / retains their inline `inner` Weakref pointer. Walk
-    // those slots as roots so a cached weakref's boxed Weakref stays
-    // coherent across collections (otherwise `get_or_make_weakref`'s
-    // cache returns a dangling pointer after a minor cycle).
-    majit_gc::shadow_stack::register_extra_root_walker(weakref_box_inner_root_walker);
-    // `W_SRE_Pattern` instances are immortal, so the collector never
-    // traces their GC-heap `w_pattern` / `w_groupindex` / `w_indexgroup`
-    // slots. Walk them as roots so a compiled pattern's named-group dict
-    // stays live (otherwise `groupdict()` iterates a reclaimed dict).
-    majit_gc::shadow_stack::register_extra_root_walker(sre_pattern_root_walker);
-    // JIT-created callee frames (frame arena + heap fallbacks) hold
-    // GC refs in their locals arrays but sit on no
-    // `CURRENT_FRAME`/`f_backref` chain while compiled code runs,
-    // so `walk_pyframe_roots` never reaches them. See
-    // `call_jit::walk_jit_callee_frame_roots`.
-    majit_gc::shadow_stack::register_extra_root_walker(
-        crate::call_jit::walk_jit_callee_frame_roots,
+    register(
+        signal_handler_root_walker_area,
+        pyre_interpreter::module::signal::interp_signal::capture_signal_handler_root_area(),
     );
-    majit_gc::shadow_stack::register_extra_root_walker(pyre_object_root_walker);
+    register(
+        weakref_box_inner_root_walker_area,
+        pyre_object::weakref::capture_gc_weakref_box_root_area(),
+    );
+    register(
+        sre_pattern_root_walker_area,
+        pyre_object::interp_sre::capture_sre_pattern_root_area(),
+    );
+    register(
+        jit_callee_frame_root_walker_area,
+        crate::call_jit::capture_jit_callee_frame_root_area(),
+    );
+    let jit_driver = JIT_DRIVER.with(|cell| cell as *const _ as *const ());
+    register(rd_consts_root_walker_area, jit_driver);
+    register(partial_trace_root_walker_area, jit_driver);
+    register(active_trace_root_walker_area, jit_driver);
+    register(compile_snapshot_root_walker_area, jit_driver);
 }
 
 /// pyre-object GC hook trampolines — safe to install at boot because
@@ -2486,6 +2480,7 @@ pub fn init_gc_subsystem() {
     build_gc_global();
     if !GC_TLS_INSTALLED.with(|c| c.get()) {
         majit_gc::shadow_stack::register_mutator();
+        register_thread_root_areas();
         majit_gc::gc_sync::register_thread();
         GC_MUTATOR_REGISTRATION.with(|_| {});
         install_gc_into_backend();
@@ -2514,42 +2509,46 @@ pub fn init_gc_root_walkers() {
 }
 
 thread_local! {
-    static JIT_DRIVER: UnsafeCell<JitDriverPair> = UnsafeCell::new({
-        let info = build_pyframe_virtualizable_info();
-        let mut d = JitDriver::new(JIT_THRESHOLD);
-        d.set_virtualizable_info(info.clone());
-        d.meta_interp_mut().num_scalar_inputargs =
-            pyre_jit_trace::virtualizable_gen::NUM_SCALAR_INPUTARGS;
-        // info.py:810-822 `ConstPtrInfo.getstrlen1(mode)` — install pyre's
-        // `W_UnicodeObject` length reader so constant STRLEN / UNICODELEN ops
-        // fold to `IntBound::from_constant(len)` during intbounds
-        // postprocessing.
-        //
-        // PyPy returns the exact length for both modes:
-        //
-        //     def getstrlen1(self, mode):
-        //         from rpython.jit.metainterp.optimizeopt import vstring
-        //         if mode is vstring.mode_string:
-        //             s = self._unpack_str(vstring.mode_string)
-        //             ...
-        //             return len(s)
-        //         elif mode is vstring.mode_unicode:
-        //             s = self._unpack_str(vstring.mode_unicode)
-        //             ...
-        //             return len(s)
-        //
-        // Pyre's `W_UnicodeObject.value` is a Rust `String` whose
-        // `len()` returns the UTF-8 BYTE length and whose
-        // `chars().count()` returns the codepoint count, so the resolver
-        // needs different reads per mode:
-        //
-        //   * mode == 0 (`vstring.mode_string`, byte string) — return the
-        //     UTF-8 byte length, which is what PyPy's `str.len()` would
-        //     produce for an RPython byte string.
-        //   * mode == 1 (`vstring.mode_unicode`, unicode string) — return
-        //     the codepoint count, which is what Python 3's
-        //     `len(str_object)` produces.
-        d.meta_interp_mut().set_string_length_resolver(std::sync::Arc::new(
+    static JIT_DRIVER: UnsafeCell<Option<JitDriverPair>> = const { UnsafeCell::new(None) };
+}
+
+fn build_jit_driver_pair() -> JitDriverPair {
+    let info = build_pyframe_virtualizable_info();
+    let mut d = JitDriver::new(JIT_THRESHOLD);
+    d.set_virtualizable_info(info.clone());
+    d.meta_interp_mut().num_scalar_inputargs =
+        pyre_jit_trace::virtualizable_gen::NUM_SCALAR_INPUTARGS;
+    // info.py:810-822 `ConstPtrInfo.getstrlen1(mode)` — install pyre's
+    // `W_UnicodeObject` length reader so constant STRLEN / UNICODELEN ops
+    // fold to `IntBound::from_constant(len)` during intbounds
+    // postprocessing.
+    //
+    // PyPy returns the exact length for both modes:
+    //
+    //     def getstrlen1(self, mode):
+    //         from rpython.jit.metainterp.optimizeopt import vstring
+    //         if mode is vstring.mode_string:
+    //             s = self._unpack_str(vstring.mode_string)
+    //             ...
+    //             return len(s)
+    //         elif mode is vstring.mode_unicode:
+    //             s = self._unpack_str(vstring.mode_unicode)
+    //             ...
+    //             return len(s)
+    //
+    // Pyre's `W_UnicodeObject.value` is a Rust `String` whose
+    // `len()` returns the UTF-8 BYTE length and whose
+    // `chars().count()` returns the codepoint count, so the resolver
+    // needs different reads per mode:
+    //
+    //   * mode == 0 (`vstring.mode_string`, byte string) — return the
+    //     UTF-8 byte length, which is what PyPy's `str.len()` would
+    //     produce for an RPython byte string.
+    //   * mode == 1 (`vstring.mode_unicode`, unicode string) — return
+    //     the codepoint count, which is what Python 3's
+    //     `len(str_object)` produces.
+    d.meta_interp_mut()
+        .set_string_length_resolver(std::sync::Arc::new(
             |gcref: majit_ir::GcRef, mode: u8| -> Option<i64> {
                 if gcref.is_null() {
                     return None;
@@ -2574,85 +2573,59 @@ thread_local! {
                 }
             },
         ));
-        init_gc_subsystem();
-
-        // framework.py `root_walker.walk_roots` parity for JIT-side const
-        // pools: every compiled guard's `rd_consts` (resume.py:451) may
-        // hold nursery-resident GC refs for TAGCONST-encoded Ref values.
-        // Without this walker, minor collection would leave stale
-        // pointers in `rd_consts` and the next guard failure would
-        // dereference freed memory. See
-        // `majit_metainterp::MetaInterp::walk_rd_consts_refs`.
-        majit_gc::shadow_stack::register_extra_root_walker(rd_consts_root_walker);
-        // framework.py `root_walker.walk_roots` parity for the stashed
-        // retrace state: `MetaInterp.partial_trace.ops` carries the
-        // recorded `Op`s between a failed bridge compile and the
-        // subsequent `compile_retrace`. Any `OpRef::ConstPtr(GcRef)`
-        // in `op.args[j]` / `op.fail_args[j]` (history.py:314
-        // `ConstPtr.value`) holds a nursery-resident Ref that must
-        // survive minor collection in that window. RPython traces these
-        // through the `TreeLoop.operations` Python object graph; pyre's
-        // `Vec<Op>` storage needs the explicit walker. See
-        // `majit_metainterp::MetaInterp::walk_partial_trace_refs`.
-        majit_gc::shadow_stack::register_extra_root_walker(partial_trace_root_walker);
-        // framework.py `root_walker.walk_roots` parity for the active
-        // recorder's op-graph: any `OpRef::ConstPtr(GcRef)` stored
-        // in `op.args[j]` or `op.fail_args[j]` (history.py:314
-        // `ConstPtr.value`) holds a nursery-resident Ref that must
-        // survive minor collection during tracing. RPython traces these
-        // through the `MetaInterp.history` Python object graph
-        // automatically; pyre's recorder is in Rust storage so the
-        // embedder registers the walker. See
-        // `majit_metainterp::MetaInterp::walk_active_trace_refs`.
-        majit_gc::shadow_stack::register_extra_root_walker(active_trace_root_walker);
-        majit_gc::shadow_stack::register_extra_root_walker(compile_snapshot_root_walker);
-        d.set_vtable_offset(Some(pyre_object::pyobject::OB_TYPE_OFFSET));
-        // resume.py:1367 — BlackholeAllocator for virtual materialization.
-        d.register_blackhole_allocator(PyreBlackholeAllocator);
-        // warmspot.py:1039 handle_jitexception_from_blackhole parity:
-        // portal_runner is called when ContinueRunningNormally is raised
-        // at a recursive portal level during blackhole execution.
-        d.register_portal_runner(pyre_portal_runner);
-        // pypy/module/pypyjit/interp_jit.py:72-78 PyPyJitDriver(..., is_recursive=True).
-        // Drives MetaInterp.is_main_jitcode() / is_portal_jitcode dispatch
-        // — without this flag the recursive-portal bookkeeping stays
-        // disabled while is_main_jitcode() callers still assume it was
-        // set, leaving the metadata internally inconsistent.
-        d.set_is_recursive(true);
-        // warmspot.py:449 — jd.result_type = getkind(portal.getreturnvar().concretetype)[0]
-        // PyPy dispatch() returns W_Root → Ref.
-        d.set_result_type(majit_ir::Type::Ref);
-        // rlib/jit.py:842 set_user_param — the translation-time `--jit STR`
-        // option's analog. `PYRE_JIT="vec_all=1"` opts vectorization in the
-        // PyPy way (parameter; the defaults stay off). `PYRE_JIT=0` keeps its
-        // existing disable meaning (handled on the can_enter_jit gate), so it
-        // is skipped here.
-        if let Ok(text) = std::env::var("PYRE_JIT") {
-            let text = text.trim();
-            if !text.is_empty() && text != "0" {
-                let ws = d.meta_interp_mut().warm_state_mut();
-                let _ = apply_jit_param_string(ws, text);
-            }
+    d.set_vtable_offset(Some(pyre_object::pyobject::OB_TYPE_OFFSET));
+    // resume.py:1367 — BlackholeAllocator for virtual materialization.
+    d.register_blackhole_allocator(PyreBlackholeAllocator);
+    // warmspot.py:1039 handle_jitexception_from_blackhole parity:
+    // portal_runner is called when ContinueRunningNormally is raised
+    // at a recursive portal level during blackhole execution.
+    d.register_portal_runner(pyre_portal_runner);
+    // pypy/module/pypyjit/interp_jit.py:72-78 PyPyJitDriver(..., is_recursive=True).
+    // Drives MetaInterp.is_main_jitcode() / is_portal_jitcode dispatch
+    // — without this flag the recursive-portal bookkeeping stays
+    // disabled while is_main_jitcode() callers still assume it was
+    // set, leaving the metadata internally inconsistent.
+    d.set_is_recursive(true);
+    // warmspot.py:449 — jd.result_type = getkind(portal.getreturnvar().concretetype)[0]
+    // PyPy dispatch() returns W_Root → Ref.
+    d.set_result_type(majit_ir::Type::Ref);
+    // rlib/jit.py:842 set_user_param — the translation-time `--jit STR`
+    // option's analog. `PYRE_JIT="vec_all=1"` opts vectorization in the
+    // PyPy way (parameter; the defaults stay off). `PYRE_JIT=0` keeps its
+    // existing disable meaning (handled on the can_enter_jit gate), so it
+    // is skipped here.
+    if let Ok(text) = std::env::var("PYRE_JIT") {
+        let text = text.trim();
+        if !text.is_empty() && text != "0" {
+            let ws = d.meta_interp_mut().warm_state_mut();
+            let _ = apply_jit_param_string(ws, text);
         }
-        // Publish the wasm CA deopt-helper's `__indirect_function_table` slot so
-        // `compile_bridge` can lift a self-recursive CALL_ASSEMBLER bridge: the
-        // CA arm `call_indirect`s it to blackhole-resume a callee that left its
-        // trace through a guard. Taking the function's address keeps it in the
-        // table; on wasm32 the address IS the table index. Done here (not only in
-        // `init_jit_hooks`) because the wasm entry path reaches `driver_pair`
-        // without `init_jit_hooks`.
-        #[cfg(target_arch = "wasm32")]
-        majit_backend_wasm::set_ca_deopt_helper_slot(
-            crate::call_jit::wasm_ca_resume_deopt as *const () as usize as u32,
-        );
-        (d, info)
-    });
+    }
+    // Publish the wasm CA deopt-helper's `__indirect_function_table` slot so
+    // `compile_bridge` can lift a self-recursive CALL_ASSEMBLER bridge: the
+    // CA arm `call_indirect`s it to blackhole-resume a callee that left its
+    // trace through a guard. Taking the function's address keeps it in the
+    // table; on wasm32 the address IS the table index. Done here (not only in
+    // `init_jit_hooks`) because the wasm entry path reaches `driver_pair`
+    // without `init_jit_hooks`.
+    #[cfg(target_arch = "wasm32")]
+    majit_backend_wasm::set_ca_deopt_helper_slot(
+        crate::call_jit::wasm_ca_resume_deopt as *const () as usize as u32,
+    );
+    (d, info)
 }
 
 // dont_look_inside: JIT-driver global accessor (JIT_DRIVER TLS).
 #[majit_macros::dont_look_inside]
 pub fn driver_pair() -> &'static mut JitDriverPair {
-    JIT_DRIVER.with(|cell| unsafe { &mut *cell.get() })
+    init_gc_subsystem();
+    JIT_DRIVER.with(|cell| unsafe {
+        let slot = &mut *cell.get();
+        if slot.is_none() {
+            *slot = Some(build_jit_driver_pair());
+        }
+        slot.as_mut().unwrap()
+    })
 }
 
 /// framework.py `root_walker.walk_roots` hook for
@@ -2673,6 +2646,15 @@ fn rd_consts_root_walker(visitor: &mut dyn FnMut(&mut majit_ir::GcRef)) {
     pair.0.walk_rd_consts_refs(visitor);
 }
 
+unsafe fn rd_consts_root_walker_area(
+    data: *const (),
+    visitor: &mut dyn FnMut(&mut majit_ir::GcRef),
+) {
+    if let Some(pair) = unsafe { jit_driver_pair_from_root_area(data) } {
+        pair.0.walk_rd_consts_refs(visitor);
+    }
+}
+
 /// framework.py `root_walker.walk_roots` hook for the inline-Const
 /// `ConstPtr` slots inside `MetaInterp.partial_trace.ops` —
 /// history.py:314 `ConstPtr.value` lives on the OpRef itself, so the
@@ -2685,6 +2667,15 @@ fn partial_trace_root_walker(visitor: &mut dyn FnMut(&mut majit_ir::GcRef)) {
     // thread-local invariant.
     let pair = driver_pair();
     pair.0.walk_partial_trace_refs(visitor);
+}
+
+unsafe fn partial_trace_root_walker_area(
+    data: *const (),
+    visitor: &mut dyn FnMut(&mut majit_ir::GcRef),
+) {
+    if let Some(pair) = unsafe { jit_driver_pair_from_root_area(data) } {
+        pair.0.walk_partial_trace_refs(visitor);
+    }
 }
 
 /// framework.py `root_walker.walk_roots` hook for the active recorder's
@@ -2700,6 +2691,15 @@ fn active_trace_root_walker(visitor: &mut dyn FnMut(&mut majit_ir::GcRef)) {
     pair.0.walk_active_trace_refs(visitor);
 }
 
+unsafe fn active_trace_root_walker_area(
+    data: *const (),
+    visitor: &mut dyn FnMut(&mut majit_ir::GcRef),
+) {
+    if let Some(pair) = unsafe { jit_driver_pair_from_root_area(data) } {
+        pair.0.walk_active_trace_refs(visitor);
+    }
+}
+
 /// GC walker for ConstPtr GcRefs extracted from snapshot maps
 /// during compilation. history.py:314 ConstPtr.value is traced through
 /// the Python object graph; pyre's SnapshotBox.opref slots in Rust Vecs
@@ -2707,6 +2707,20 @@ fn active_trace_root_walker(visitor: &mut dyn FnMut(&mut majit_ir::GcRef)) {
 fn compile_snapshot_root_walker(visitor: &mut dyn FnMut(&mut majit_ir::GcRef)) {
     let pair = driver_pair();
     pair.0.walk_compile_snapshot_refs(visitor);
+}
+
+unsafe fn compile_snapshot_root_walker_area(
+    data: *const (),
+    visitor: &mut dyn FnMut(&mut majit_ir::GcRef),
+) {
+    if let Some(pair) = unsafe { jit_driver_pair_from_root_area(data) } {
+        pair.0.walk_compile_snapshot_refs(visitor);
+    }
+}
+
+unsafe fn jit_driver_pair_from_root_area(data: *const ()) -> Option<&'static mut JitDriverPair> {
+    let cell = unsafe { &*(data as *const UnsafeCell<Option<JitDriverPair>>) };
+    unsafe { (&mut *cell.get()).as_mut() }
 }
 
 /// `framework.shadowstack walk_stack_root` adapter — walk every
@@ -2728,6 +2742,94 @@ fn pyre_object_root_walker(visitor: &mut dyn FnMut(&mut majit_ir::GcRef)) {
             unsafe { &mut *(slot as *mut pyre_object::PyObjectRef as *mut majit_ir::GcRef) };
         visitor(gcref);
     });
+}
+
+unsafe fn pyre_object_root_walker_area(
+    data: *const (),
+    visitor: &mut dyn FnMut(&mut majit_ir::GcRef),
+) {
+    unsafe {
+        pyre_object::gc_roots::walk_shadow_stack_area(data, |slot| {
+            visit_pyobject_root(slot, visitor);
+        });
+    }
+}
+
+unsafe fn pyframe_root_walker_area(data: *const (), visitor: &mut dyn FnMut(&mut majit_ir::GcRef)) {
+    unsafe { pyre_interpreter::eval::walk_pyframe_roots_area(data, visitor) };
+}
+
+unsafe fn jitcode_constants_root_walker_area(
+    data: *const (),
+    visitor: &mut dyn FnMut(&mut majit_ir::GcRef),
+) {
+    unsafe { pyre_jit_trace::state::walk_jitcode_constants_refs_area(data, visitor) };
+}
+
+unsafe fn fbw_store_journal_root_walker_area(
+    data: *const (),
+    visitor: &mut dyn FnMut(&mut majit_ir::GcRef),
+) {
+    unsafe { pyre_jit_trace::jitcode_dispatch::fbw_store_journal_root_walker_area(data, visitor) };
+}
+
+unsafe fn fbw_finish_concrete_root_walker_area(
+    data: *const (),
+    visitor: &mut dyn FnMut(&mut majit_ir::GcRef),
+) {
+    unsafe {
+        pyre_jit_trace::jitcode_dispatch::fbw_finish_concrete_root_walker_area(data, visitor)
+    };
+}
+
+unsafe fn mapdict_root_walker_area(data: *const (), visitor: &mut dyn FnMut(&mut majit_ir::GcRef)) {
+    unsafe {
+        pyre_interpreter::objspace::std::mapdict::walk_mapdict_roots_area(data, |slot| {
+            visit_pyobject_root(slot, visitor);
+        });
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+unsafe fn signal_handler_root_walker_area(
+    data: *const (),
+    visitor: &mut dyn FnMut(&mut majit_ir::GcRef),
+) {
+    unsafe {
+        pyre_interpreter::module::signal::interp_signal::walk_signal_handler_roots_area(
+            data,
+            |slot| visit_pyobject_root(slot, visitor),
+        );
+    }
+}
+
+unsafe fn weakref_box_inner_root_walker_area(
+    data: *const (),
+    visitor: &mut dyn FnMut(&mut majit_ir::GcRef),
+) {
+    unsafe {
+        pyre_object::weakref::walk_gc_weakref_box_inner_roots_area(data, |slot| {
+            visit_pyobject_root(slot, visitor);
+        });
+    }
+}
+
+unsafe fn sre_pattern_root_walker_area(
+    data: *const (),
+    visitor: &mut dyn FnMut(&mut majit_ir::GcRef),
+) {
+    unsafe {
+        pyre_object::interp_sre::walk_sre_pattern_roots_area(data, |slot| {
+            visit_pyobject_root(slot, visitor);
+        });
+    }
+}
+
+unsafe fn jit_callee_frame_root_walker_area(
+    data: *const (),
+    visitor: &mut dyn FnMut(&mut majit_ir::GcRef),
+) {
+    unsafe { crate::call_jit::walk_jit_callee_frame_roots_area(data, visitor) };
 }
 
 fn visit_pyobject_root(
@@ -3470,7 +3572,7 @@ fn init_callbacks() {
                     crate::call_jit::jit_create_self_recursive_callee_frame_1 as *const (),
                 jit_create_self_recursive_callee_frame_1_raw_int:
                     crate::call_jit::jit_create_self_recursive_callee_frame_1_raw_int as *const (),
-                driver_pair: || JIT_DRIVER.with(|cell| cell.get() as *mut u8),
+                driver_pair: || driver_pair() as *mut JitDriverPair as *mut u8,
                 ensure_majit_jitcode: |code, w_code| {
                     if !code.is_null() {
                         let _ =

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -134,15 +134,6 @@ fn pyre_object_gc_finalizer_next_dead_trampoline(fq_index: usize) -> pyre_object
         .unwrap_or(pyre_object::PY_NULL)
 }
 
-/// Heap-stats trampoline for the interpreter GC safepoint
-/// (`pyre_object::gc_interp`). Bridges pyre-object's heap-stats hook to
-/// `majit_gc::active_heap_stats`, so the safepoint can gate its
-/// collection on an empty nursery (where the embedded minor cycle moves
-/// nothing and is safe without a shadowstack pass).
-fn pyre_object_gc_heap_stats_trampoline() -> (usize, usize) {
-    majit_gc::active_heap_stats()
-}
-
 /// Jitframe-empty trampoline for the interpreter GC safepoint. Bridges
 /// pyre-object's hook to `majit_gc::jitframe_shadow_stack_empty`, so the
 /// safepoint can skip collecting while a compiled trace is suspended.
@@ -863,9 +854,12 @@ type JitDriverPair = (
 );
 
 thread_local! {
-    /// Per-thread flag: TLS hooks (backend GC handle, majit_gc
-    /// set_active_* fn-ptrs, pyre_object gc_hook cells) installed.
-    /// Each thread must install its own hooks because they are TLS cells.
+    /// Per-thread flag: this thread has registered with the gc_sync
+    /// mutator registry and installed the backend GC handle into the
+    /// backend's per-thread TLS box. The majit_gc set_active_* fn-ptrs and
+    /// pyre_object gc_hook cells are now process-global (#396), so they are
+    /// installed once (not gated by this flag); only the per-thread backend
+    /// box and mutator registration remain per-thread here.
     static GC_TLS_INSTALLED: Cell<bool> = const { Cell::new(false) };
 }
 
@@ -2339,16 +2333,6 @@ fn install_gc_into_backend() {
     majit_backend_dynasm::runner::install_gc_standalone();
 }
 
-/// Install TLS hooks: backend GC handle + pyre-object hook trampolines.
-///
-/// The 4 JIT-only root walkers (`rd_consts`, `partial_trace`,
-/// `active_trace`, `compile_snapshot`) are NOT registered here — they
-/// call `driver_pair()` which would trigger recursive `JIT_DRIVER` init.
-fn install_gc_hooks() {
-    install_gc_into_backend();
-    install_pyre_object_hooks();
-}
-
 /// Phase B: root walkers that reference interpreter state (immortal dicts,
 /// mapdict side table, etc.).  Called on first eval entry, after the
 /// interpreter is initialized.
@@ -2434,7 +2418,6 @@ fn install_pyre_object_hooks() {
         pyre_object_gc_register_finalizer_trampoline,
         pyre_object_gc_finalizer_next_dead_trampoline,
     );
-    pyre_object::gc_hook::register_gc_heap_stats_hook(pyre_object_gc_heap_stats_trampoline);
     pyre_object::gc_hook::register_gc_jitframe_empty_hook(pyre_object_gc_jitframe_empty_trampoline);
     pyre_object::register_gc_root_hooks(
         pyre_object_gc_add_root_trampoline,
@@ -2474,17 +2457,29 @@ pub fn reset_gc_fresh_for_test() {
 ///
 /// Phase 1 (process-global, once): build MiniMarkGC, type registry,
 /// subclass ranges, store in gc_sync singleton.
-/// Phase 2 (per-thread, idempotent): install TLS hooks so the backend
-/// trampolines and pyre_object hooks reach the global GC via gc_sync.
+/// Phase 2a (per-thread): register this thread with the gc_sync mutator
+/// registry and install the backend GC handle. `install_gc_into_backend`
+/// also registers the `majit_gc::set_active_*` fn-pointer cells (add_root,
+/// write_barrier, guard hooks, …). The backend still keeps a per-thread TLS
+/// box (removed by #396 R4), so this part stays per-thread.
+/// Phase 2b (process-global, once): install the pyre-object hook
+/// trampolines. These are process-global fn-pointer cells (#396), so a
+/// single install is visible to every thread. They route pyre-object
+/// through the `set_active_*` cells from phase 2a, so phase 2a runs first —
+/// a thread never publishes the pyre-object hooks before its own backend
+/// `set_active_*` install.
 pub fn init_gc_subsystem() {
     build_gc_global();
-    if GC_TLS_INSTALLED.with(|c| c.get()) {
-        return;
+    if !GC_TLS_INSTALLED.with(|c| c.get()) {
+        majit_gc::gc_sync::register_thread();
+        install_gc_into_backend();
+        GC_TLS_INSTALLED.with(|c| c.set(true));
     }
-    majit_gc::gc_sync::register_thread();
-    install_gc_hooks();
-    GC_TLS_INSTALLED.with(|c| c.set(true));
+    PYRE_OBJECT_HOOKS_INSTALLED.call_once(install_pyre_object_hooks);
 }
+
+/// Guards the one-time install of the process-global pyre-object GC hooks.
+static PYRE_OBJECT_HOOKS_INSTALLED: std::sync::Once = std::sync::Once::new();
 
 thread_local! {
     static GC_ROOT_WALKERS_INSTALLED: Cell<bool> = const { Cell::new(false) };

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -861,6 +861,20 @@ thread_local! {
     /// installed once (not gated by this flag); only the per-thread backend
     /// box and mutator registration remain per-thread here.
     static GC_TLS_INSTALLED: Cell<bool> = const { Cell::new(false) };
+
+    /// Initialized after shadow_stack::register_mutator has captured all four
+    /// root TLS slots. Its destructor therefore removes the registry entry
+    /// before those slots are destroyed, then removes the thread from RUNNING.
+    static GC_MUTATOR_REGISTRATION: GcMutatorRegistration = const { GcMutatorRegistration };
+}
+
+struct GcMutatorRegistration;
+
+impl Drop for GcMutatorRegistration {
+    fn drop(&mut self) {
+        majit_gc::shadow_stack::unregister_mutator();
+        majit_gc::gc_sync::unregister_thread();
+    }
 }
 
 /// Build and configure the MiniMarkGC with all type registrations,
@@ -2471,7 +2485,9 @@ pub fn reset_gc_fresh_for_test() {
 pub fn init_gc_subsystem() {
     build_gc_global();
     if !GC_TLS_INSTALLED.with(|c| c.get()) {
+        majit_gc::shadow_stack::register_mutator();
         majit_gc::gc_sync::register_thread();
+        GC_MUTATOR_REGISTRATION.with(|_| {});
         install_gc_into_backend();
         GC_TLS_INSTALLED.with(|c| c.set(true));
     }
@@ -2915,6 +2931,7 @@ impl __extend__ {
         next_instr: usize,
         _ec: *const PyExecutionContext,
     ) -> PyResult {
+        majit_gc::gc_sync::safepoint_poll();
         frame.set_last_instr_from_next_instr(next_instr);
         // interp_jit.py:79-96 dispatch: the while-True loop runs until
         // Yield or ExitFrame. ContinueRunningNormally means portal

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -2479,9 +2479,9 @@ pub fn reset_gc_fresh_for_test() {
 pub fn init_gc_subsystem() {
     build_gc_global();
     if !GC_TLS_INSTALLED.with(|c| c.get()) {
+        majit_gc::gc_sync::register_thread();
         majit_gc::shadow_stack::register_mutator();
         register_thread_root_areas();
-        majit_gc::gc_sync::register_thread();
         GC_MUTATOR_REGISTRATION.with(|_| {});
         install_gc_into_backend();
         GC_TLS_INSTALLED.with(|c| c.set(true));

--- a/pyre/pyre-object/src/gc_hook.rs
+++ b/pyre/pyre-object/src/gc_hook.rs
@@ -358,8 +358,8 @@ majit_gc::global_hook!(static GC_REMOVE_ROOT_HOOK: GcRemoveRootHookFn);
 
 /// Install the root-register / remove callbacks.
 pub fn register_gc_root_hooks(add: GcAddRootHookFn, remove: GcRemoveRootHookFn) {
-    GC_ADD_ROOT_HOOK.set(Some(add));
     GC_REMOVE_ROOT_HOOK.set(Some(remove));
+    GC_ADD_ROOT_HOOK.set(Some(add));
 }
 
 /// Remove the root-register callbacks.

--- a/pyre/pyre-object/src/gc_hook.rs
+++ b/pyre/pyre-object/src/gc_hook.rs
@@ -1,11 +1,17 @@
-//! Thread-local GC allocation hook for host-side Python object allocators.
+//! Process-global GC allocation hook for host-side Python object allocators.
 //!
 //! `pyre-object` sits below `majit-gc` in the dependency graph and must
-//! not depend on it. Host-side allocators (`w_int_new`, `w_float_new`,
-//! …) that want to route through the real GC instead of `Box::into_raw`
-//! go through the callback registered here. `pyre-jit::eval` installs
-//! the concrete trampoline on `JitDriver` init so the callback reaches
-//! the backend-owned GC allocator via `majit_gc` TLS hooks.
+//! not depend on it for the GC itself. Host-side allocators (`w_int_new`,
+//! `w_float_new`, …) that want to route through the real GC instead of
+//! `Box::into_raw` go through the callback registered here. `pyre-jit::eval`
+//! installs the concrete trampoline on `JitDriver` init so the callback
+//! reaches the backend-owned GC allocator via `majit_gc` hooks.
+//!
+//! The GC is a process-global singleton (`gc_sync`), so these hooks are
+//! process-global fn-pointer cells ([`majit_gc::hook_cell::FnPtrCell`] via
+//! [`majit_gc::global_hook`]) rather than per-thread: every thread installs
+//! the same pointer, and a collector running on an arbitrary thread must see
+//! it even if that thread never ran the install path.
 //!
 //! Callers use [`try_gc_alloc`] which returns `None` when no hook is
 //! installed — they fall back to the `Box::into_raw` path in
@@ -13,10 +19,8 @@
 //! fallback at each call site as the hook's reliability is verified
 //! under the full bench suite.
 //!
-//! Layering: this module has no external dependencies. It defines the
-//! function-pointer slot only. Wire-up lives in `pyre-jit`.
-
-use std::cell::Cell;
+//! Layering: this module defines the function-pointer slots only. Wire-up
+//! lives in `pyre-jit`.
 
 use crate::PyObjectRef;
 
@@ -30,29 +34,26 @@ use crate::PyObjectRef;
 /// `std::ptr::null_mut()`.
 pub type GcAllocHookFn = fn(type_id: u32, payload_size: usize) -> *mut u8;
 
-thread_local! {
-    static GC_ALLOC_HOOK: Cell<Option<GcAllocHookFn>> = const { Cell::new(None) };
-    static GC_ALLOC_STABLE_HOOK: Cell<Option<GcAllocHookFn>> = const { Cell::new(None) };
-}
+majit_gc::global_hook!(static GC_ALLOC_HOOK: GcAllocHookFn);
+majit_gc::global_hook!(static GC_ALLOC_STABLE_HOOK: GcAllocHookFn);
 
-/// Install the allocation callback for this thread. Overwrites any
-/// previously-installed hook.
+/// Install the allocation callback. Overwrites any previously-installed hook.
 pub fn register_gc_alloc_hook(hook: GcAllocHookFn) {
-    GC_ALLOC_HOOK.with(|cell| cell.set(Some(hook)));
+    GC_ALLOC_HOOK.set(Some(hook));
 }
 
-/// Remove the callback on this thread. Subsequent [`try_gc_alloc`]
-/// returns `None` until a new hook is registered.
+/// Remove the callback. Subsequent [`try_gc_alloc`] returns `None` until a
+/// new hook is registered.
 pub fn clear_gc_alloc_hook() {
-    GC_ALLOC_HOOK.with(|cell| cell.set(None));
+    GC_ALLOC_HOOK.set(None);
 }
 
 /// Attempt a GC allocation via the installed hook. Returns `None`
-/// when no hook is installed on this thread, or `Some(null)` when the
-/// hook itself returned null.
+/// when no hook is installed, or `Some(null)` when the hook itself
+/// returned null.
 #[inline]
 pub fn try_gc_alloc(type_id: u32, payload_size: usize) -> Option<*mut u8> {
-    GC_ALLOC_HOOK.with(|cell| cell.get().map(|f| f(type_id, payload_size)))
+    GC_ALLOC_HOOK.get().map(|f| f(type_id, payload_size))
 }
 
 /// Install the stable (old-gen) allocation callback for this thread.
@@ -64,20 +65,20 @@ pub fn try_gc_alloc(type_id: u32, payload_size: usize) -> Option<*mut u8> {
 /// whose returned pointer is stable across minor and major
 /// collections (MiniMark mark-sweep does not move old-gen objects).
 pub fn register_gc_alloc_stable_hook(hook: GcAllocHookFn) {
-    GC_ALLOC_STABLE_HOOK.with(|cell| cell.set(Some(hook)));
+    GC_ALLOC_STABLE_HOOK.set(Some(hook));
 }
 
-/// Remove the stable-allocation callback on this thread.
+/// Remove the stable-allocation callback.
 pub fn clear_gc_alloc_stable_hook() {
-    GC_ALLOC_STABLE_HOOK.with(|cell| cell.set(None));
+    GC_ALLOC_STABLE_HOOK.set(None);
 }
 
 /// Attempt a stable-address GC allocation via the installed hook.
 /// See [`register_gc_alloc_stable_hook`] for semantics. Returns
-/// `None` when no hook is installed on this thread.
+/// `None` when no hook is installed.
 #[inline]
 pub fn try_gc_alloc_stable(type_id: u32, payload_size: usize) -> Option<*mut u8> {
-    GC_ALLOC_STABLE_HOOK.with(|cell| cell.get().map(|f| f(type_id, payload_size)))
+    GC_ALLOC_STABLE_HOOK.get().map(|f| f(type_id, payload_size))
 }
 
 /// Null-collapsing view of [`try_gc_alloc_stable`] for JIT-traced callers.
@@ -86,7 +87,7 @@ pub fn try_gc_alloc_stable(type_id: u32, payload_size: usize) -> Option<*mut u8>
 /// returned `null`; every traced caller already treats those two cases
 /// identically (fall back to `malloc_typed`), so the `Option` discriminant
 /// carries no information the caller reads.  Residualising this primitive
-/// (`@dont_look_inside`, `rlib/jit.py:139`) keeps the thread-local hook
+/// (`@dont_look_inside`, `rlib/jit.py:139`) keeps the process-global hook
 /// dispatch out of the trace — a `*mut u8` return has no discriminant to
 /// erase, unlike the `Option<*mut u8>` accessor.
 #[majit_macros::dont_look_inside]
@@ -94,23 +95,21 @@ pub fn try_gc_alloc_stable_raw(type_id: u32, payload_size: usize) -> *mut u8 {
     try_gc_alloc_stable(type_id, payload_size).unwrap_or(core::ptr::null_mut())
 }
 
-thread_local! {
-    static GC_ALLOC_COLLECTING_HOOK: Cell<Option<GcAllocHookFn>> = const { Cell::new(None) };
-}
+majit_gc::global_hook!(static GC_ALLOC_COLLECTING_HOOK: GcAllocHookFn);
 
-/// Install the *collecting* nursery allocation callback for this thread.
+/// Install the *collecting* nursery allocation callback.
 ///
 /// Unlike [`register_gc_alloc_hook`] (no-collect), the backend routes this to a
 /// nursery allocator that runs a minor collection when the nursery is full. Only
 /// for callers that hold no unrooted GC pointer across the allocation and run at
 /// a JIT safepoint (gcmap-rooted) — i.e. the elidable bigint payload helpers.
 pub fn register_gc_alloc_collecting_hook(hook: GcAllocHookFn) {
-    GC_ALLOC_COLLECTING_HOOK.with(|cell| cell.set(Some(hook)));
+    GC_ALLOC_COLLECTING_HOOK.set(Some(hook));
 }
 
-/// Remove the collecting-allocation callback on this thread.
+/// Remove the collecting-allocation callback.
 pub fn clear_gc_alloc_collecting_hook() {
-    GC_ALLOC_COLLECTING_HOOK.with(|cell| cell.set(None));
+    GC_ALLOC_COLLECTING_HOOK.set(None);
 }
 
 /// Attempt a collecting GC nursery allocation via the installed hook. Returns
@@ -118,26 +117,23 @@ pub fn clear_gc_alloc_collecting_hook() {
 /// no-collect [`try_gc_alloc`]).
 #[inline]
 pub fn try_gc_alloc_collecting(type_id: u32, payload_size: usize) -> Option<*mut u8> {
-    GC_ALLOC_COLLECTING_HOOK.with(|cell| cell.get().map(|f| f(type_id, payload_size)))
+    GC_ALLOC_COLLECTING_HOOK.get().map(|f| f(type_id, payload_size))
 }
 
 /// Signature of the host-side memory-pressure callback: charge `bytes` of
 /// off-heap, GC-invisible payload (a bignum's external limb `Vec`).
 pub type GcChargeMemoryPressureFn = fn(bytes: usize);
 
-thread_local! {
-    static GC_CHARGE_MEMORY_PRESSURE_HOOK: Cell<Option<GcChargeMemoryPressureFn>> =
-        const { Cell::new(None) };
-}
+majit_gc::global_hook!(static GC_CHARGE_MEMORY_PRESSURE_HOOK: GcChargeMemoryPressureFn);
 
-/// Install the memory-pressure callback for this thread.
+/// Install the memory-pressure callback.
 pub fn register_gc_charge_memory_pressure_hook(hook: GcChargeMemoryPressureFn) {
-    GC_CHARGE_MEMORY_PRESSURE_HOOK.with(|cell| cell.set(Some(hook)));
+    GC_CHARGE_MEMORY_PRESSURE_HOOK.set(Some(hook));
 }
 
-/// Remove the memory-pressure callback on this thread.
+/// Remove the memory-pressure callback.
 pub fn clear_gc_charge_memory_pressure_hook() {
-    GC_CHARGE_MEMORY_PRESSURE_HOOK.with(|cell| cell.set(None));
+    GC_CHARGE_MEMORY_PRESSURE_HOOK.set(None);
 }
 
 /// Charge `bytes` of off-heap memory pressure via the installed hook (no-op when
@@ -146,11 +142,9 @@ pub fn clear_gc_charge_memory_pressure_hook() {
 /// call where a forced minor is safe.
 #[inline]
 pub fn try_gc_charge_memory_pressure(bytes: usize) {
-    GC_CHARGE_MEMORY_PRESSURE_HOOK.with(|cell| {
-        if let Some(f) = cell.get() {
-            f(bytes);
-        }
-    })
+    if let Some(f) = GC_CHARGE_MEMORY_PRESSURE_HOOK.get() {
+        f(bytes);
+    }
 }
 
 /// Signature of the host-side old-gen external-byte callback: add `bytes` of
@@ -158,19 +152,16 @@ pub fn try_gc_charge_memory_pressure(bytes: usize) {
 /// total when the object is old-gen.
 pub type GcChargeOldgenExternalFn = fn(obj_addr: usize, bytes: usize);
 
-thread_local! {
-    static GC_CHARGE_OLDGEN_EXTERNAL_HOOK: Cell<Option<GcChargeOldgenExternalFn>> =
-        const { Cell::new(None) };
-}
+majit_gc::global_hook!(static GC_CHARGE_OLDGEN_EXTERNAL_HOOK: GcChargeOldgenExternalFn);
 
-/// Install the old-gen external-byte callback for this thread.
+/// Install the old-gen external-byte callback.
 pub fn register_gc_charge_oldgen_external_hook(hook: GcChargeOldgenExternalFn) {
-    GC_CHARGE_OLDGEN_EXTERNAL_HOOK.with(|cell| cell.set(Some(hook)));
+    GC_CHARGE_OLDGEN_EXTERNAL_HOOK.set(Some(hook));
 }
 
-/// Remove the old-gen external-byte callback on this thread.
+/// Remove the old-gen external-byte callback.
 pub fn clear_gc_charge_oldgen_external_hook() {
-    GC_CHARGE_OLDGEN_EXTERNAL_HOOK.with(|cell| cell.set(None));
+    GC_CHARGE_OLDGEN_EXTERNAL_HOOK.set(None);
 }
 
 /// Charge `bytes` of `obj_addr`'s off-heap payload against the major threshold
@@ -179,17 +170,15 @@ pub fn clear_gc_charge_oldgen_external_hook() {
 /// minor, so it is safe after allocating an unrooted payload: a directly-old-gen
 /// bignum's limb `Vec` would otherwise stay invisible to the threshold until
 /// the next major's `recompute_oldgen_external_bytes`.
-// `dont_look_inside`: host hook dispatch (`thread_local!` `Cell` indirection)
+// `dont_look_inside`: host hook dispatch (a process-global atomic fn-pointer cell)
 // stays opaque to the JIT — the `try_gc_add_root` / `try_gc_remove_root` /
 // `try_gc_write_barrier` twins; calls residualize via the registered fnaddr
 // (`rlib/jit.py:139`). A `()` return has no discriminant to erase.
 #[majit_macros::dont_look_inside]
 pub fn try_gc_charge_oldgen_external(obj_addr: usize, bytes: usize) {
-    GC_CHARGE_OLDGEN_EXTERNAL_HOOK.with(|cell| {
-        if let Some(f) = cell.get() {
-            f(obj_addr, bytes);
-        }
-    })
+    if let Some(f) = GC_CHARGE_OLDGEN_EXTERNAL_HOOK.get() {
+        f(obj_addr, bytes);
+    }
 }
 
 /// Signature of the host-side full-collection callback. Used by
@@ -197,30 +186,26 @@ pub fn try_gc_charge_oldgen_external(obj_addr: usize, bytes: usize) {
 /// `gc.collect()` reaches the live GC through this hook.
 pub type GcCollectHookFn = fn();
 
-thread_local! {
-    static GC_COLLECT_HOOK: Cell<Option<GcCollectHookFn>> = const { Cell::new(None) };
-}
+majit_gc::global_hook!(static GC_COLLECT_HOOK: GcCollectHookFn);
 
-/// Install the full-collection callback for this thread. Overwrites
-/// any previously-installed hook.
+/// Install the full-collection callback. Overwrites any previously-installed
+/// hook.
 pub fn register_gc_collect_hook(hook: GcCollectHookFn) {
-    GC_COLLECT_HOOK.with(|cell| cell.set(Some(hook)));
+    GC_COLLECT_HOOK.set(Some(hook));
 }
 
-/// Remove the full-collection callback on this thread.
+/// Remove the full-collection callback.
 pub fn clear_gc_collect_hook() {
-    GC_COLLECT_HOOK.with(|cell| cell.set(None));
+    GC_COLLECT_HOOK.set(None);
 }
 
 /// Trigger a full mark-sweep collection via the installed hook. No-op
-/// when no hook is installed on this thread.
+/// when no hook is installed.
 #[inline]
 pub fn try_gc_collect() {
-    GC_COLLECT_HOOK.with(|cell| {
-        if let Some(f) = cell.get() {
-            f();
-        }
-    });
+    if let Some(f) = GC_COLLECT_HOOK.get() {
+        f();
+    }
 }
 
 /// Signature of the host-side non-moving old-gen-only major callback.
@@ -230,57 +215,49 @@ pub fn try_gc_collect() {
 /// Rust-stack nursery `PyObjectRef` that has no shadowstack root.
 pub type GcCollectOldgenHookFn = fn();
 
-thread_local! {
-    static GC_COLLECT_OLDGEN_HOOK: Cell<Option<GcCollectOldgenHookFn>> = const { Cell::new(None) };
-}
+majit_gc::global_hook!(static GC_COLLECT_OLDGEN_HOOK: GcCollectOldgenHookFn);
 
-/// Install the non-moving-major callback for this thread.
+/// Install the non-moving-major callback.
 pub fn register_gc_collect_oldgen_hook(hook: GcCollectOldgenHookFn) {
-    GC_COLLECT_OLDGEN_HOOK.with(|cell| cell.set(Some(hook)));
+    GC_COLLECT_OLDGEN_HOOK.set(Some(hook));
 }
 
-/// Remove the non-moving-major callback on this thread.
+/// Remove the non-moving-major callback.
 pub fn clear_gc_collect_oldgen_hook() {
-    GC_COLLECT_OLDGEN_HOOK.with(|cell| cell.set(None));
+    GC_COLLECT_OLDGEN_HOOK.set(None);
 }
 
 /// Trigger a non-moving old-gen-only major collection via the installed hook.
-/// No-op when no hook is installed on this thread.
+/// No-op when no hook is installed.
 #[inline]
 pub fn try_gc_collect_oldgen() {
-    GC_COLLECT_OLDGEN_HOOK.with(|cell| {
-        if let Some(f) = cell.get() {
-            f();
-        }
-    });
+    if let Some(f) = GC_COLLECT_OLDGEN_HOOK.get() {
+        f();
+    }
 }
 
 /// Signature of the host-side automatic major-progress toggle callback.
 pub type GcSetEnabledHookFn = fn(bool);
 
-thread_local! {
-    static GC_SET_ENABLED_HOOK: Cell<Option<GcSetEnabledHookFn>> = const { Cell::new(None) };
-}
+majit_gc::global_hook!(static GC_SET_ENABLED_HOOK: GcSetEnabledHookFn);
 
-/// Install the automatic major-progress toggle callback for this thread.
+/// Install the automatic major-progress toggle callback.
 pub fn register_gc_set_enabled_hook(hook: GcSetEnabledHookFn) {
-    GC_SET_ENABLED_HOOK.with(|cell| cell.set(Some(hook)));
+    GC_SET_ENABLED_HOOK.set(Some(hook));
 }
 
-/// Remove the automatic major-progress toggle callback on this thread.
+/// Remove the automatic major-progress toggle callback.
 pub fn clear_gc_set_enabled_hook() {
-    GC_SET_ENABLED_HOOK.with(|cell| cell.set(None));
+    GC_SET_ENABLED_HOOK.set(None);
 }
 
 /// Toggle automatic major-collection progress via the installed hook. No-op
-/// when no hook is installed on this thread.
+/// when no hook is installed.
 #[inline]
 pub fn try_gc_set_enabled(enabled: bool) {
-    GC_SET_ENABLED_HOOK.with(|cell| {
-        if let Some(f) = cell.get() {
-            f(enabled);
-        }
-    });
+    if let Some(f) = GC_SET_ENABLED_HOOK.get() {
+        f(enabled);
+    }
 }
 
 /// RPython `gc_fq_register` / `gc_fq_next_dead` hooks.  The trigger is the
@@ -289,96 +266,44 @@ pub type GcFinalizerTriggerFn = fn();
 pub type GcRegisterFinalizerHookFn = fn(usize, PyObjectRef, GcFinalizerTriggerFn);
 pub type GcFinalizerNextDeadHookFn = fn(usize) -> PyObjectRef;
 
-thread_local! {
-    static GC_REGISTER_FINALIZER_HOOK: Cell<Option<GcRegisterFinalizerHookFn>> =
-        const { Cell::new(None) };
-    static GC_FINALIZER_NEXT_DEAD_HOOK: Cell<Option<GcFinalizerNextDeadHookFn>> =
-        const { Cell::new(None) };
-}
+majit_gc::global_hook!(static GC_REGISTER_FINALIZER_HOOK: GcRegisterFinalizerHookFn);
+majit_gc::global_hook!(static GC_FINALIZER_NEXT_DEAD_HOOK: GcFinalizerNextDeadHookFn);
 
 pub fn register_gc_finalizer_hooks(
     register: GcRegisterFinalizerHookFn,
     next_dead: GcFinalizerNextDeadHookFn,
 ) {
-    GC_REGISTER_FINALIZER_HOOK.with(|cell| cell.set(Some(register)));
-    GC_FINALIZER_NEXT_DEAD_HOOK.with(|cell| cell.set(Some(next_dead)));
+    GC_REGISTER_FINALIZER_HOOK.set(Some(register));
+    GC_FINALIZER_NEXT_DEAD_HOOK.set(Some(next_dead));
 }
 
 pub fn try_gc_register_finalizer(fq_index: usize, obj: PyObjectRef, trigger: GcFinalizerTriggerFn) {
-    GC_REGISTER_FINALIZER_HOOK.with(|cell| {
-        if let Some(register) = cell.get() {
-            register(fq_index, obj, trigger);
-        }
-    });
+    if let Some(register) = GC_REGISTER_FINALIZER_HOOK.get() {
+        register(fq_index, obj, trigger);
+    }
 }
 
 pub fn try_gc_finalizer_next_dead(fq_index: usize) -> PyObjectRef {
-    GC_FINALIZER_NEXT_DEAD_HOOK.with(|cell| {
-        cell.get()
-            .map(|next_dead| next_dead(fq_index))
-            .unwrap_or(crate::PY_NULL)
-    })
+    GC_FINALIZER_NEXT_DEAD_HOOK
+        .get()
+        .map(|next_dead| next_dead(fq_index))
+        .unwrap_or(crate::PY_NULL)
 }
 
 /// `ObjSpace.allocate_instance`-level hook.  pyre-object owns allocation but
 /// pyre-interpreter owns MRO lookup and can therefore decide `hasuserdel`.
 pub type MaybeRegisterFinalizerHookFn = fn(PyObjectRef);
 
-thread_local! {
-    static MAYBE_REGISTER_FINALIZER_HOOK: Cell<Option<MaybeRegisterFinalizerHookFn>> =
-        const { Cell::new(None) };
-}
+majit_gc::global_hook!(static MAYBE_REGISTER_FINALIZER_HOOK: MaybeRegisterFinalizerHookFn);
 
 pub fn register_maybe_finalizer_hook(hook: MaybeRegisterFinalizerHookFn) {
-    MAYBE_REGISTER_FINALIZER_HOOK.with(|cell| cell.set(Some(hook)));
+    MAYBE_REGISTER_FINALIZER_HOOK.set(Some(hook));
 }
 
 pub fn maybe_register_finalizer(obj: PyObjectRef) {
-    MAYBE_REGISTER_FINALIZER_HOOK.with(|cell| {
-        if let Some(hook) = cell.get() {
-            hook(obj);
-        }
-    });
-}
-
-/// Signature of the host-side heap-stats callback returning
-/// `(oldgen_total, nursery_used)`. Used by the interpreter GC safepoint
-/// (`crate::gc_interp`) to gate a collection on an empty nursery.
-pub type GcHeapStatsHookFn = fn() -> (usize, usize);
-
-thread_local! {
-    static GC_HEAP_STATS_HOOK: Cell<Option<GcHeapStatsHookFn>> = const { Cell::new(None) };
-}
-
-/// Install the heap-stats callback for this thread.
-pub fn register_gc_heap_stats_hook(hook: GcHeapStatsHookFn) {
-    GC_HEAP_STATS_HOOK.with(|cell| cell.set(Some(hook)));
-}
-
-/// Remove the heap-stats callback on this thread.
-pub fn clear_gc_heap_stats_hook() {
-    GC_HEAP_STATS_HOOK.with(|cell| cell.set(None));
-}
-
-/// Bytes currently used in the active GC's nursery, via the installed
-/// hook. `0` when no hook is installed (treated as "nursery empty").
-#[inline]
-pub fn try_gc_nursery_used() -> usize {
-    GC_HEAP_STATS_HOOK.with(|cell| match cell.get() {
-        Some(f) => f().1,
-        None => 0,
-    })
-}
-
-/// Bytes currently held in the active GC's old generation, via the installed
-/// heap-stats hook. `0` when no hook is installed. The interpreter safepoint
-/// reads this to gate a non-moving major on old-gen growth.
-#[inline]
-pub fn try_gc_oldgen_total() -> usize {
-    GC_HEAP_STATS_HOOK.with(|cell| match cell.get() {
-        Some(f) => f().0,
-        None => 0,
-    })
+    if let Some(hook) = MAYBE_REGISTER_FINALIZER_HOOK.get() {
+        hook(obj);
+    }
 }
 
 /// Signature of the host-side "is the JIT-frame shadow stack empty"
@@ -387,18 +312,16 @@ pub fn try_gc_oldgen_total() -> usize {
 /// mis-mapped from a nested interpreter collection).
 pub type GcJitframeEmptyHookFn = fn() -> bool;
 
-thread_local! {
-    static GC_JITFRAME_EMPTY_HOOK: Cell<Option<GcJitframeEmptyHookFn>> = const { Cell::new(None) };
-}
+majit_gc::global_hook!(static GC_JITFRAME_EMPTY_HOOK: GcJitframeEmptyHookFn);
 
-/// Install the jitframe-shadow-stack-empty callback for this thread.
+/// Install the jitframe-shadow-stack-empty callback.
 pub fn register_gc_jitframe_empty_hook(hook: GcJitframeEmptyHookFn) {
-    GC_JITFRAME_EMPTY_HOOK.with(|cell| cell.set(Some(hook)));
+    GC_JITFRAME_EMPTY_HOOK.set(Some(hook));
 }
 
-/// Remove the jitframe-shadow-stack-empty callback on this thread.
+/// Remove the jitframe-shadow-stack-empty callback.
 pub fn clear_gc_jitframe_empty_hook() {
-    GC_JITFRAME_EMPTY_HOOK.with(|cell| cell.set(None));
+    GC_JITFRAME_EMPTY_HOOK.set(None);
 }
 
 /// Whether no compiled trace is suspended (jitframe shadow stack empty),
@@ -406,10 +329,10 @@ pub fn clear_gc_jitframe_empty_hook() {
 /// no jitframes).
 #[inline]
 pub fn try_gc_jitframe_empty() -> bool {
-    GC_JITFRAME_EMPTY_HOOK.with(|cell| match cell.get() {
+    match GC_JITFRAME_EMPTY_HOOK.get() {
         Some(f) => f(),
         None => true,
-    })
+    }
 }
 
 /// Signature of the host-side root-register callbacks.
@@ -428,21 +351,19 @@ pub fn try_gc_jitframe_empty() -> bool {
 pub type GcAddRootHookFn = unsafe fn(slot: *mut *mut u8);
 pub type GcRemoveRootHookFn = fn(slot: *mut *mut u8);
 
-thread_local! {
-    static GC_ADD_ROOT_HOOK: Cell<Option<GcAddRootHookFn>> = const { Cell::new(None) };
-    static GC_REMOVE_ROOT_HOOK: Cell<Option<GcRemoveRootHookFn>> = const { Cell::new(None) };
-}
+majit_gc::global_hook!(static GC_ADD_ROOT_HOOK: GcAddRootHookFn);
+majit_gc::global_hook!(static GC_REMOVE_ROOT_HOOK: GcRemoveRootHookFn);
 
-/// Install the root-register / remove callbacks for this thread.
+/// Install the root-register / remove callbacks.
 pub fn register_gc_root_hooks(add: GcAddRootHookFn, remove: GcRemoveRootHookFn) {
-    GC_ADD_ROOT_HOOK.with(|cell| cell.set(Some(add)));
-    GC_REMOVE_ROOT_HOOK.with(|cell| cell.set(Some(remove)));
+    GC_ADD_ROOT_HOOK.set(Some(add));
+    GC_REMOVE_ROOT_HOOK.set(Some(remove));
 }
 
-/// Remove the root-register callbacks on this thread.
+/// Remove the root-register callbacks.
 pub fn clear_gc_root_hooks() {
-    GC_ADD_ROOT_HOOK.with(|cell| cell.set(None));
-    GC_REMOVE_ROOT_HOOK.with(|cell| cell.set(None));
+    GC_ADD_ROOT_HOOK.set(None);
+    GC_REMOVE_ROOT_HOOK.set(None);
 }
 
 /// Register `slot` as a live GC root via the installed callback.
@@ -451,34 +372,34 @@ pub fn clear_gc_root_hooks() {
 /// # Safety
 /// Caller must keep `slot` valid until [`try_gc_remove_root`] is
 /// called with the same pointer.
-// `dont_look_inside`: host hook dispatch (`thread_local!` `Cell`
-// indirection) stays opaque to the JIT — the `try_gc_write_barrier`
+// `dont_look_inside`: host hook dispatch (a process-global
+// atomic fn-pointer cell) stays opaque to the JIT — the `try_gc_write_barrier`
 // twin; calls residualize via the registered fnaddr (`rlib/jit.py:139`).
 #[majit_macros::dont_look_inside]
 pub unsafe fn try_gc_add_root(slot: *mut *mut u8) -> bool {
-    GC_ADD_ROOT_HOOK.with(|cell| match cell.get() {
+    match GC_ADD_ROOT_HOOK.get() {
         Some(f) => {
             unsafe { f(slot) };
             true
         }
         None => false,
-    })
+    }
 }
 
 /// Remove a previously-registered root via the installed callback.
 /// Returns `true` when the callback was invoked.
-// `dont_look_inside`: host hook dispatch (`thread_local!` `Cell`
-// indirection) stays opaque to the JIT — the `try_gc_add_root` twin;
+// `dont_look_inside`: host hook dispatch (a process-global
+// atomic fn-pointer cell) stays opaque to the JIT — the `try_gc_add_root` twin;
 // calls residualize via the registered fnaddr (`rlib/jit.py:139`).
 #[majit_macros::dont_look_inside]
 pub fn try_gc_remove_root(slot: *mut *mut u8) -> bool {
-    GC_REMOVE_ROOT_HOOK.with(|cell| match cell.get() {
+    match GC_REMOVE_ROOT_HOOK.get() {
         Some(f) => {
             f(slot);
             true
         }
         None => false,
-    })
+    }
 }
 
 /// Signature of the host-side "is GC-managed" predicate. Callers
@@ -489,31 +410,28 @@ pub fn try_gc_remove_root(slot: *mut *mut u8) -> bool {
 pub type GcOwnsObjectHookFn = fn(addr: usize) -> bool;
 pub type GcCurrentObjectAddressHookFn = fn(addr: usize) -> usize;
 
-thread_local! {
-    static GC_OWNS_OBJECT_HOOK: Cell<Option<GcOwnsObjectHookFn>> = const { Cell::new(None) };
-    static GC_CURRENT_OBJECT_ADDRESS_HOOK: Cell<Option<GcCurrentObjectAddressHookFn>> =
-        const { Cell::new(None) };
-}
+majit_gc::global_hook!(static GC_OWNS_OBJECT_HOOK: GcOwnsObjectHookFn);
+majit_gc::global_hook!(static GC_CURRENT_OBJECT_ADDRESS_HOOK: GcCurrentObjectAddressHookFn);
 
 /// Install the GC-ownership predicate. Overwrites any previously-
 /// installed hook.
 pub fn register_gc_owns_object_hook(hook: GcOwnsObjectHookFn) {
-    GC_OWNS_OBJECT_HOOK.with(|cell| cell.set(Some(hook)));
+    GC_OWNS_OBJECT_HOOK.set(Some(hook));
 }
 
-/// Remove the GC-ownership predicate on this thread.
+/// Remove the GC-ownership predicate.
 pub fn clear_gc_owns_object_hook() {
-    GC_OWNS_OBJECT_HOOK.with(|cell| cell.set(None));
+    GC_OWNS_OBJECT_HOOK.set(None);
 }
 
 /// Install the non-rooting current-address lookup hook.
 pub fn register_gc_current_object_address_hook(hook: GcCurrentObjectAddressHookFn) {
-    GC_CURRENT_OBJECT_ADDRESS_HOOK.with(|cell| cell.set(Some(hook)));
+    GC_CURRENT_OBJECT_ADDRESS_HOOK.set(Some(hook));
 }
 
-/// Remove the current-address lookup hook on this thread.
+/// Remove the current-address lookup hook.
 pub fn clear_gc_current_object_address_hook() {
-    GC_CURRENT_OBJECT_ADDRESS_HOOK.with(|cell| cell.set(None));
+    GC_CURRENT_OBJECT_ADDRESS_HOOK.set(None);
 }
 
 /// Whether `addr` lies inside the active backend's managed GC heap.
@@ -523,10 +441,10 @@ pub fn clear_gc_current_object_address_hook() {
 /// `majit_gc::gc_owns_object`.
 #[inline]
 pub fn try_gc_owns_object(addr: *mut u8) -> bool {
-    GC_OWNS_OBJECT_HOOK.with(|cell| match cell.get() {
+    match GC_OWNS_OBJECT_HOOK.get() {
         Some(f) => f(addr as usize),
         None => false,
-    })
+    }
 }
 
 /// Return the current address for `addr` without registering it as a root.
@@ -534,26 +452,24 @@ pub fn try_gc_owns_object(addr: *mut u8) -> bool {
 /// address is unchanged.
 #[inline]
 pub fn try_gc_current_object_address(addr: *mut u8) -> *mut u8 {
-    GC_CURRENT_OBJECT_ADDRESS_HOOK.with(|cell| match cell.get() {
+    match GC_CURRENT_OBJECT_ADDRESS_HOOK.get() {
         Some(f) => f(addr as usize) as *mut u8,
         None => addr,
-    })
+    }
 }
 
 /// minimark.py:1900-1915 `identityhash` hook.
 /// Returns a GC-move-stable address for the given object.
 pub type GcIdentityHashHookFn = fn(obj_addr: usize) -> usize;
 
-thread_local! {
-    static GC_IDENTITY_HASH_HOOK: Cell<Option<GcIdentityHashHookFn>> = const { Cell::new(None) };
-}
+majit_gc::global_hook!(static GC_IDENTITY_HASH_HOOK: GcIdentityHashHookFn);
 
 pub fn register_gc_identity_hash_hook(hook: GcIdentityHashHookFn) {
-    GC_IDENTITY_HASH_HOOK.with(|cell| cell.set(Some(hook)));
+    GC_IDENTITY_HASH_HOOK.set(Some(hook));
 }
 
 pub fn clear_gc_identity_hash_hook() {
-    GC_IDENTITY_HASH_HOOK.with(|cell| cell.set(None));
+    GC_IDENTITY_HASH_HOOK.set(None);
 }
 
 /// Return a stable identity hash for `obj_addr`.  When the hook is
@@ -562,10 +478,10 @@ pub fn clear_gc_identity_hash_hook() {
 /// installed, returns `obj_addr` unchanged (pre-GC fallback).
 #[inline]
 pub fn gc_identity_hash(obj_addr: usize) -> usize {
-    GC_IDENTITY_HASH_HOOK.with(|cell| match cell.get() {
+    match GC_IDENTITY_HASH_HOOK.get() {
         Some(f) => f(obj_addr),
         None => obj_addr,
-    })
+    }
 }
 
 /// Signature of the host-side write barrier callback. `obj` is the
@@ -574,40 +490,56 @@ pub fn gc_identity_hash(obj_addr: usize) -> usize {
 /// remembering.
 pub type GcWriteBarrierHookFn = fn(obj: *mut u8);
 
-thread_local! {
-    static GC_WRITE_BARRIER_HOOK: Cell<Option<GcWriteBarrierHookFn>> = const { Cell::new(None) };
-}
+majit_gc::global_hook!(static GC_WRITE_BARRIER_HOOK: GcWriteBarrierHookFn);
 
-/// Install the write-barrier callback for this thread.
+/// Install the write-barrier callback.
 pub fn register_gc_write_barrier_hook(hook: GcWriteBarrierHookFn) {
-    GC_WRITE_BARRIER_HOOK.with(|cell| cell.set(Some(hook)));
+    GC_WRITE_BARRIER_HOOK.set(Some(hook));
 }
 
-/// Remove the write-barrier callback on this thread.
+/// Remove the write-barrier callback.
 pub fn clear_gc_write_barrier_hook() {
-    GC_WRITE_BARRIER_HOOK.with(|cell| cell.set(None));
+    GC_WRITE_BARRIER_HOOK.set(None);
 }
 
 /// Run the active GC write barrier for `obj` when one is installed.
-// `dont_look_inside`: host hook dispatch (`thread_local!` `Cell`
-// indirection) stays opaque to the JIT — traces never look inside a
+// `dont_look_inside`: host hook dispatch (a process-global
+// atomic fn-pointer cell) stays opaque to the JIT — traces never look inside a
 // write barrier (the backend GC rewrite owns that concern); calls
 // residualize via the registered fnaddr.
 #[majit_macros::dont_look_inside]
 pub extern "C" fn try_gc_write_barrier(obj: *mut u8) -> bool {
-    GC_WRITE_BARRIER_HOOK.with(|cell| match cell.get() {
+    match GC_WRITE_BARRIER_HOOK.get() {
         Some(f) => {
             f(obj);
             true
         }
         None => false,
-    })
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use std::sync::atomic::{AtomicUsize, Ordering};
+
+    // The hook cells are process-global. These tests are the only hook
+    // *installers* in this binary, so they take this lock first to serialize
+    // against each other — that keeps every "unregistered/cleared -> None/false"
+    // assertion sound (no other test installs a hook concurrently).
+    //
+    // Assertions on a mock's *invocation* are a separate concern: the alloc and
+    // root hooks are read only behind `gc_interp::enabled()` / a registered
+    // backend type id, both off by default in this binary, so no concurrent
+    // production path invokes those mocks — their arg-recording statics are safe
+    // under `cargo test`. (They are NOT safe under `PYRE_GC_INTERP=1`, which is
+    // never set for a pyre-object test run.) The write-barrier hook has ungated
+    // production callers, so its test asserts on the `try_*` return value rather
+    // than a shared counter.
+    static HOOK_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+    fn hook_test_guard() -> std::sync::MutexGuard<'static, ()> {
+        HOOK_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner())
+    }
 
     static LAST_TYPE_ID: AtomicUsize = AtomicUsize::new(0);
     static LAST_SIZE: AtomicUsize = AtomicUsize::new(0);
@@ -625,12 +557,14 @@ mod tests {
 
     #[test]
     fn returns_none_when_unregistered() {
+        let _hook_lock = hook_test_guard();
         clear_gc_alloc_hook();
         assert!(try_gc_alloc(1, 16).is_none());
     }
 
     #[test]
     fn invokes_registered_hook_with_args() {
+        let _hook_lock = hook_test_guard();
         register_gc_alloc_hook(mock_hook);
         let ptr = try_gc_alloc(7, 24);
         assert!(ptr.is_some());
@@ -642,6 +576,7 @@ mod tests {
 
     #[test]
     fn clear_removes_hook() {
+        let _hook_lock = hook_test_guard();
         register_gc_alloc_hook(mock_hook);
         assert!(try_gc_alloc(1, 8).is_some());
         clear_gc_alloc_hook();
@@ -650,6 +585,7 @@ mod tests {
 
     #[test]
     fn hook_returning_null_propagates_some_null() {
+        let _hook_lock = hook_test_guard();
         register_gc_alloc_hook(null_hook);
         let ptr = try_gc_alloc(1, 8);
         assert!(ptr.is_some());
@@ -659,7 +595,6 @@ mod tests {
 
     static LAST_ROOT_PTR: AtomicUsize = AtomicUsize::new(0);
     static REMOVE_CALLS: AtomicUsize = AtomicUsize::new(0);
-    static WRITE_BARRIER_CALLS: AtomicUsize = AtomicUsize::new(0);
 
     unsafe fn mock_add_root(slot: *mut *mut u8) {
         LAST_ROOT_PTR.store(slot as usize, Ordering::Relaxed);
@@ -669,13 +604,11 @@ mod tests {
         REMOVE_CALLS.fetch_add(1, Ordering::Relaxed);
     }
 
-    fn mock_write_barrier(obj: *mut u8) {
-        let _ = obj;
-        WRITE_BARRIER_CALLS.fetch_add(1, Ordering::Relaxed);
-    }
+    fn mock_write_barrier(_obj: *mut u8) {}
 
     #[test]
     fn root_hooks_register_and_remove_round_trip() {
+        let _hook_lock = hook_test_guard();
         clear_gc_root_hooks();
         let mut slot: *mut u8 = std::ptr::null_mut();
         assert!(!unsafe { try_gc_add_root(&mut slot as *mut *mut u8) });
@@ -698,6 +631,7 @@ mod tests {
 
     #[test]
     fn stable_hook_is_independent_from_nursery_hook() {
+        let _hook_lock = hook_test_guard();
         clear_gc_alloc_hook();
         clear_gc_alloc_stable_hook();
         assert!(try_gc_alloc(1, 8).is_none());
@@ -721,14 +655,19 @@ mod tests {
 
     #[test]
     fn write_barrier_hook_registers_invokes_and_clears() {
+        let _hook_lock = hook_test_guard();
         clear_gc_write_barrier_hook();
         let obj = 0x1000usize as *mut u8;
         assert!(!try_gc_write_barrier(obj));
 
-        WRITE_BARRIER_CALLS.store(0, Ordering::Relaxed);
         register_gc_write_barrier_hook(mock_write_barrier);
+        // `try_gc_write_barrier` returns true iff it dispatched to the installed
+        // hook, so the return value alone proves invocation. We deliberately do
+        // NOT assert on a shared call counter: the write-barrier hook cell is
+        // process-global and its many ungated production callers (list / tuple /
+        // dict / descriptor / …) fire the same hook from concurrent tests, which
+        // would perturb any global counter and reintroduce a parallel-test flake.
         assert!(try_gc_write_barrier(obj));
-        assert_eq!(WRITE_BARRIER_CALLS.load(Ordering::Relaxed), 1);
 
         clear_gc_write_barrier_hook();
         assert!(!try_gc_write_barrier(obj));

--- a/pyre/pyre-object/src/gc_hook.rs
+++ b/pyre/pyre-object/src/gc_hook.rs
@@ -9,9 +9,9 @@
 //!
 //! The GC is a process-global singleton (`gc_sync`), so these hooks are
 //! process-global fn-pointer cells ([`majit_gc::hook_cell::FnPtrCell`] via
-//! [`majit_gc::global_hook`]) rather than per-thread: every thread installs
-//! the same pointer, and a collector running on an arbitrary thread must see
-//! it even if that thread never ran the install path.
+//! [`majit_gc::global_hook`]) rather than per-thread: one install publishes
+//! the same pointer to every thread, and a collector running on an arbitrary
+//! thread must see it even if that thread never ran the install path.
 //!
 //! Callers use [`try_gc_alloc`] which returns `None` when no hook is
 //! installed — they fall back to the `Box::into_raw` path in

--- a/pyre/pyre-object/src/gc_hook.rs
+++ b/pyre/pyre-object/src/gc_hook.rs
@@ -117,7 +117,9 @@ pub fn clear_gc_alloc_collecting_hook() {
 /// no-collect [`try_gc_alloc`]).
 #[inline]
 pub fn try_gc_alloc_collecting(type_id: u32, payload_size: usize) -> Option<*mut u8> {
-    GC_ALLOC_COLLECTING_HOOK.get().map(|f| f(type_id, payload_size))
+    GC_ALLOC_COLLECTING_HOOK
+        .get()
+        .map(|f| f(type_id, payload_size))
 }
 
 /// Signature of the host-side memory-pressure callback: charge `bytes` of

--- a/pyre/pyre-object/src/gc_roots.rs
+++ b/pyre/pyre-object/src/gc_roots.rs
@@ -183,6 +183,23 @@ pub fn walk_shadow_stack(mut visitor: impl FnMut(&mut PyObjectRef)) {
     });
 }
 
+/// Capture the current thread's pinned-root stack for a foreign STW walk.
+pub fn capture_shadow_stack_area() -> *const () {
+    SHADOW_STACK.with(|s| s as *const _ as *const ())
+}
+
+/// Visit a captured thread's pinned-root stack without consulting caller TLS.
+///
+/// # Safety
+/// `data` must come from [`capture_shadow_stack_area`], and the owning thread
+/// must be quiesced for the duration of the walk.
+pub unsafe fn walk_shadow_stack_area(data: *const (), mut visitor: impl FnMut(&mut PyObjectRef)) {
+    let stack = unsafe { &mut *(*(data as *const RefCell<Vec<PyObjectRef>>)).as_ptr() };
+    for slot in stack.iter_mut() {
+        visitor(slot);
+    }
+}
+
 // ── Prebuilt-root write tracking ────────────────────────────────────
 //
 // incminimark.py:106-114 `GCFLAG_TRACK_YOUNG_PTRS` / 339-344

--- a/pyre/pyre-object/src/interp_sre.rs
+++ b/pyre/pyre-object/src/interp_sre.rs
@@ -57,6 +57,29 @@ pub fn walk_sre_pattern_roots(mut visitor: impl FnMut(&mut PyObjectRef)) {
     });
 }
 
+pub fn capture_sre_pattern_root_area() -> *const () {
+    SRE_PATTERNS.with(|patterns| patterns as *const _ as *const ())
+}
+
+/// # Safety
+/// `data` must come from [`capture_sre_pattern_root_area`], and its owning
+/// thread must be quiesced.
+pub unsafe fn walk_sre_pattern_roots_area(
+    data: *const (),
+    mut visitor: impl FnMut(&mut PyObjectRef),
+) {
+    let patterns =
+        unsafe { &*(*(data as *const std::cell::RefCell<Vec<*mut W_SRE_Pattern>>)).as_ptr() };
+    for &pattern in patterns.iter() {
+        if pattern.is_null() {
+            continue;
+        }
+        visitor(unsafe { &mut (*pattern).w_pattern });
+        visitor(unsafe { &mut (*pattern).w_groupindex });
+        visitor(unsafe { &mut (*pattern).w_indexgroup });
+    }
+}
+
 /// Allocate a `W_SRE_Pattern` — `SRE_Pattern__new__` field stamping
 /// (interp_sre.py:624-639).
 pub fn w_sre_pattern_new(

--- a/pyre/pyre-object/src/weakref.rs
+++ b/pyre/pyre-object/src/weakref.rs
@@ -181,6 +181,28 @@ pub fn walk_gc_weakref_box_inner_roots(mut visitor: impl FnMut(&mut PyObjectRef)
     });
 }
 
+pub fn capture_gc_weakref_box_root_area() -> *const () {
+    WEAKREF_BOXES.with(|b| b as *const _ as *const ())
+}
+
+/// # Safety
+/// `data` must be the current value returned by
+/// [`capture_gc_weakref_box_root_area`] for a quiesced owning thread.
+pub unsafe fn walk_gc_weakref_box_inner_roots_area(
+    data: *const (),
+    mut visitor: impl FnMut(&mut PyObjectRef),
+) {
+    let boxes =
+        unsafe { &*(*(data as *const std::cell::RefCell<Vec<*mut GcWeakrefBox>>)).as_ptr() };
+    for &boxed in boxes.iter() {
+        if boxed.is_null() {
+            continue;
+        }
+        let inner_slot = unsafe { std::ptr::addr_of_mut!((*boxed).inner) } as *mut PyObjectRef;
+        visitor(unsafe { &mut *inner_slot });
+    }
+}
+
 /// `isinstance(obj, GcWeakrefBox)` predicate.
 ///
 /// # Safety


### PR DESCRIPTION
Addresses #396 (R1+R2+R3, plus R4 slices 1–4: reentrancy-safe `gc_sync` + backend box demotion on all three backends — dynasm, cranelift, wasm).

After the GC became a process-global singleton (`gc_sync`, #388), the ~47 per-thread `thread_local! Cell<Option<fn>>` GC hook cells installed identical values on every thread. A collector running on an arbitrary thread would see an unset hook on any thread that never ran the install path — a free-threading correctness gap (P0), not just cleanup.

## Changes

- **majit-gc**: new `FnPtrCell` (AtomicPtr-backed, null = `None`, Acquire/Release, pointer-size `const`-assert) + `global_hook!` macro (kept in majit-gc so pyre-object need not depend on it). Convert the `ACTIVE_*` GC-guard / alloc / collect / root / write-barrier / heap-stats fn-ptr cells to process-global statics; `ACTIVE_SUPPORTS_GUARD_GC_TYPE` → `AtomicBool`. Add `override_gc_guard_hooks_for_test` (RAII guard under a process-global lock) for the metainterp mock-guard-hook test. De-thread-local the hook doc comments.
- **pyre-object**: convert the 14 `gc_hook` fn-ptr cells to `global_hook!`. Delete the write-only-dead `GC_HEAP_STATS_HOOK` path (the interpreter safepoint dropped its `nursery_used == 0` gate at the `collect_oldgen` switch). Add `HOOK_TEST_LOCK` serializing the hook-installer tests now that the cells are shared.
- **pyre-jit**: split `init_gc_subsystem` — per-thread `gc_sync` mutator registration + backend GC handle install stay per-thread; the process-global pyre-object hooks install once under a `Once`, after the backend `set_active_*` install they route through (backend-first ordering). Remove the dead heap-stats trampoline.
- **pyre-interpreter**: `register_pyframe_root_walker` doc — now a process-global cell.

## R4 — reentrancy-safe `gc_sync` + backend box demotion

Backend `*_ACTIVE_GC` TLS is not a pure ZST vestige: it is the test GC-ownership mechanism (`set_gc_allocator`, ~30 tests install a real `Box<MiniMarkGC>`), and the `_RAW` mirror answered reentrant collection-time ownership queries because `gc_sync` was not reentrant. R4 makes production stop relying on the box.

- **Slice 1 (keystone) — `gc_sync` reentrant read-only query.** A thread-local `GC_OP_DEPTH` + `OpGuard` wraps every `&mut` singleton access (`gc_op` fast/slow, `request_stw`); `gc_query_reentrant` takes a fresh `&*GC_STORE` shared read when already inside a `gc_op` (the collection-time root-walk case), avoiding the double-`&mut` alias / non-recursive-mutex deadlock. `debug_assert!(!in_gc_op())` catches an accidental reentrant `&mut`. `GcHandle`'s `&self` methods now route through `gc_query_reentrant`.
- **Slices 2 (dynasm) / 3 (cranelift) / 4 (wasm) — box demotion.** `install_gc_standalone` registers the `set_active_*` hooks WITHOUT a box, so production reaches the GC through `gc_sync`; tests still install a real box. Because a `None` box no longer means "no GC", every site that treated box-absent as GC-absent (alloc/write-barrier slowpaths called from JIT code, codegen-time guard-table / write-barrier-descr reads, the `is_none()` gates) now consults `gc_sync` before its non-GC fallback. Missing that on dynasm first surfaced as omitted write barriers → remembered-set corruption → SIGSEGV/SIGBUS in `fib_recursive`/`nbody`/`calls_closures`; all three backends are now clean under repeated GC-stress. (wasm is single-threaded, so its box was never a free-threading hazard — it is demoted for consistency.)

The P1 free-threading work (STW safepoint + TLAB atop the now-reentrant `gc_sync`) is tracked separately in #452.

## Verification

- cargo test (per-crate): majit-gc 172 / pyre-object 206 / majit-metainterp 1389; majit-backend-dynasm 56+12; majit-backend-cranelift 126+35+1; majit-backend-wasm 2+14
- check.py **dynasm 160/160**, **cranelift 159/159**, **wasm 160/160** on this base, each rebuilt after box demotion; `fib_recursive`/`nbody`/`calls_closures` pass 5×5 with no crash under production `gc_sync` routing + a debug GC-stress run (debug_assert live) with all root-walkers registered.
- Note: the full-workspace `cargo test` job exercises the pre-existing #396 parallel-GC-test race (many libtest threads share the one `gc_sync` GC → nondeterministic SIGABRT); that is the condition this epic exists to remove (P1, #452), not a regression from these commits — the same suite passes `--test-threads=1` and passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GC reliability during multithreaded and stop-the-world collections.
  * Prevented re-entrant GC queries from causing deadlocks or incorrect behavior.
  * Corrected thread-local stack-overflow/critical-code suppression so effects don’t leak across threads.
  * Improved root tracking across interpreter, JIT, method caches, mapdict, weak references, signals, codecs, and frames.
* **Performance**
  * Improved JIT allocation and write-barrier fastpaths.
  * Added safer support for inline nursery allocation and production GC integration.
* **Stability**
  * Improved active GC ownership/identity/type queries across runtime backends.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
