### PR TITLE
majit: single-pass close post-peel virt-array writeback + inline-portal ENTER/LEAVE balance

### DIFF
--- a/majit/examples/spcount/src/main.rs
+++ b/majit/examples/spcount/src/main.rs
@@ -59,24 +59,27 @@ const TOUCH: u8 = 30; // residual: side-effecting, result-neutral stack touch
 #[cfg(test)]
 static TOUCH_CALLS: core::sync::atomic::AtomicU32 = core::sync::atomic::AtomicU32::new(0);
 
+/// Number of loops the driver compiled/closed, observed by the tests. The
+/// residual-count canary only exercises the single-pass close if a trace
+/// actually compiled; this counter lets the test assert that it did, so a run
+/// that never starts tracing (or aborts before the `; state` close) fails
+/// loudly instead of passing vacuously. Mirrors tl's `SPIKE_COMPILES`.
+static SPCOUNT_COMPILES: core::sync::atomic::AtomicU32 = core::sync::atomic::AtomicU32::new(0);
+
 /// Side-effecting residual, `@dont_look_inside` — the JIT does not trace into
 /// it; it emits a residual CALL. `#[dont_look_inside]` is non-elidable and may
-/// raise, so the optimizer keeps the call. It reads and rewrites the live
-/// top-of-stack through the raw stack pointer: a genuine heap side effect that
-/// forces the virtualizable stack, yet leaves every value unchanged. The
-/// computed result is therefore independent of how many times `touch` runs, so
-/// the call count alone is the double-execution detector. Modelled on tl's
-/// `storage_roll`.
+/// raise, so the optimizer keeps the call. It is result-neutral (its only
+/// observable effect is the counted call), so the computed sum is independent
+/// of how many times `touch` runs and the call count alone is the
+/// double-execution detector. The argument is the scalar `stackpos` — a
+/// jit-lowerable value, so the TOUCH arm compiles into the trace (a virt-array
+/// base-pointer argument would degrade to a `BC_ABORT` stub and never compile).
+/// Modelled on tl's `storage_roll`.
 #[majit_macros::dont_look_inside]
-extern "C" fn touch(stack_ptr: usize, stackpos: i64) {
+extern "C" fn touch(stackpos: i64) {
     #[cfg(test)]
     TOUCH_CALLS.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
-    if stackpos > 0 {
-        let stack =
-            unsafe { std::slice::from_raw_parts_mut(stack_ptr as *mut i64, stackpos as usize) };
-        let top = stack[(stackpos - 1) as usize];
-        stack[(stackpos - 1) as usize] = top;
-    }
+    let _ = stackpos;
 }
 
 // ── State ──
@@ -103,6 +106,11 @@ struct StackState {
 pub fn mainloop(program: &Bytecode, inputarg: i64, threshold: u32) -> i64 {
     let mut driver: majit_metainterp::JitDriver<StackState> =
         majit_metainterp::JitDriver::new(threshold);
+    // Count compiled loops so the residual-count test can assert the
+    // single-pass close actually ran. Mirrors tl's SPIKE_COMPILES hook.
+    driver.set_on_compile_loop(|_gk, _b, _a| {
+        SPCOUNT_COMPILES.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
+    });
     let mut pc: usize = 0;
     let stacksize: i32 = 0;
     let mut state = StackState {
@@ -165,7 +173,7 @@ pub fn mainloop(program: &Bytecode, inputarg: i64, threshold: u32) -> i64 {
             }
             // Residual @dont_look_inside touch of the live stack.
             TOUCH => {
-                touch(state.stack.as_mut_ptr() as usize, state.stackpos);
+                touch(state.stackpos);
             }
             BR_COND => {
                 let offset = program[pc] as i8 as i64;
@@ -364,6 +372,20 @@ mod tests {
     /// times. Under single-pass tracing (the walk is the sole executor) the
     /// residual must run exactly the interpreter's count — a walk-vs-native
     /// double-execution during the trace-then-close would inflate it.
+    ///
+    /// The `SPCOUNT_COMPILES >= 1` canary below asserts the single-pass close
+    /// actually ran, so the residual count is not measured on a merely-
+    /// interpreted loop. This is the load-bearing guard: before the virt-array
+    /// write-back fix, the compiled loop resumed from the trace-start virt array
+    /// (the walk-final loop counter was never transferred into native `state`)
+    /// and re-executed the peeled iteration, firing `touch` N+1 times. The
+    /// write-back (`writeback_virt_array_state_fields`) makes native `state`
+    /// hold the walk-final (post-peel) counter before re-entry, so the compiled
+    /// loop advances instead of re-running the traced iteration — exactly N
+    /// firings. A residual whose argument is a virt-array base pointer instead
+    /// degrades to a `BC_ABORT` stub (no `#[jit_interp]` lowering) and never
+    /// compiles; using the scalar `stackpos` keeps the loop compilable so this
+    /// canary exercises the real single-pass close.
     #[test]
     fn jit_residual_not_double_executed() {
         let program = touch_loop_program();
@@ -371,8 +393,20 @@ mod tests {
 
         let expected = interp(&program, n);
         TOUCH_CALLS.store(0, Ordering::Relaxed);
+        SPCOUNT_COMPILES.store(0, Ordering::Relaxed);
         let got = mainloop(&program, n, 3);
         let jit_touches = TOUCH_CALLS.load(Ordering::Relaxed);
+
+        // The residual-count canary is only meaningful if a trace actually
+        // compiled and closed via the `; state` single-pass path. Without this
+        // guard the loop could merely interpret (no tracing, or an abort before
+        // the close), run `touch` exactly n× anyway, and leave the count green
+        // vacuously. A `>= 1` lower bound is robust under parallel tests: only
+        // this test resets the counter, and other tests can only raise it.
+        assert!(
+            SPCOUNT_COMPILES.load(Ordering::Relaxed) >= 1,
+            "single-pass trace never compiled — canary would pass vacuously"
+        );
 
         assert_eq!(got, expected, "JIT result diverged from interp");
         // One TOUCH per iteration; N iterations before the counter hits 0.

--- a/majit/majit-macros/src/jit_interp/codegen_state.rs
+++ b/majit/majit-macros/src/jit_interp/codegen_state.rs
@@ -922,6 +922,31 @@ fn generate_state_fields_jit_state(config: &JitInterpConfig, func: &ItemFn) -> T
             }
         })
         .collect();
+    // Single-pass close: write the walk-final virt-array element values
+    // (captured off the trace-ctx shadow) into native state, one array at a
+    // time in declaration order. Mirrors `restore_array_parts`'s per-element
+    // copy, but the source is the element-only flat vector
+    // (`collect_virtualizable_element_values`), so there are no ptr/len slots to
+    // skip. The user's Vec is fixed-capacity (see the reallocation note on
+    // `initialize_sym_virt_array_parts`), so the length matches the walk-final
+    // element count.
+    let writeback_virt_array_parts: Vec<TokenStream> = virt_arrays
+        .iter()
+        .map(|(_, f)| {
+            let fname = &f.name;
+            quote! {
+                let __len = self.#fname.len();
+                debug_assert!(
+                    values.len() >= __offset + __len,
+                    "writeback_virt_array: fewer element values than array length",
+                );
+                for i in 0..__len {
+                    self.#fname[i] = values[__offset + i];
+                }
+                __offset += __len;
+            }
+        })
+        .collect();
     let initialize_sym_scalar_parts: Vec<TokenStream> = scalars
         .iter()
         .map(|(_, f)| {
@@ -1227,6 +1252,19 @@ fn generate_state_fields_jit_state(config: &JitInterpConfig, func: &ItemFn) -> T
                 // 0-based ref index.
                 self.restore(meta, int_values);
                 #(#restore_ref_scalar_parts)*
+            }
+        }
+    } else {
+        quote! {}
+    };
+    // Emit the virt-array write-back override only for consumers that declare a
+    // `[.. ; virt]` array; 0-array interps (aheui, tlr, tinyframe, i64env) keep
+    // the trait default no-op, leaving their generated impl byte-identical.
+    let writeback_virt_array_override: TokenStream = if num_virt_arrays > 0 {
+        quote! {
+            fn writeback_virt_array_state_fields_from_values(&mut self, values: &[i64]) {
+                let mut __offset: usize = 0;
+                #(#writeback_virt_array_parts)*
             }
         }
     } else {
@@ -2075,6 +2113,8 @@ fn generate_state_fields_jit_state(config: &JitInterpConfig, func: &ItemFn) -> T
             fn writeback_scalar_state_fields_from_values(&mut self, values: &[i64]) {
                 #(#writeback_from_values_parts)*
             }
+
+            #writeback_virt_array_override
 
             fn state_field_layout(&self) -> majit_metainterp::blackhole::StateFieldLayout {
                 // Flat slot layout for blackhole resume: scalar count is

--- a/majit/majit-macros/src/jit_interp/mod.rs
+++ b/majit/majit-macros/src/jit_interp/mod.rs
@@ -2030,6 +2030,21 @@ fn rewrite_body(
                                     #driver.writeback_scalar_state_fields(
                                         &mut #state,
                                     );
+                                    // Push the walk-final loop-carried virt-array
+                                    // element values into native `state` too. The
+                                    // walk mutates the array on the trace-ctx
+                                    // shadow only; native `state`'s array is
+                                    // frozen at trace-start (synchronize_
+                                    // virtualizable skips the RustVec write-back
+                                    // during tracing). Without this the compiled-
+                                    // loop seed (extract_live reads native state)
+                                    // reflects the trace-start array and the loop
+                                    // re-executes the peeled iteration, double-
+                                    // firing any side-effecting residual. No-op
+                                    // when the state has no virtualizable array.
+                                    #driver.writeback_virt_array_state_fields(
+                                        &mut #state,
+                                    );
                                     // Transfer any loop-carried reds the walk
                                     // captured, then re-derive the
                                     // storage-backed cache fields (stacksize,

--- a/majit/majit-metainterp/src/jit_state.rs
+++ b/majit/majit-metainterp/src/jit_state.rs
@@ -386,6 +386,19 @@ pub trait JitState: Sized {
     /// no-op; the `#[jit_interp]` macro overrides it for state-field consumers.
     fn writeback_scalar_state_fields_from_values(&mut self, _values: &[i64]) {}
 
+    /// Whole-circuit single-pass: write the walk's loop-carried virtualizable
+    /// array element values (captured at close time by the trace ctx's
+    /// `collect_virtualizable_element_values`) into native state, the array
+    /// analog of `writeback_scalar_state_fields_from_values`. `values` is the
+    /// flat `[arr0_elem0.., arr1_elem0.., ..]` layout in state-field declaration
+    /// order (the same order `extract_live` / `collect_jump_args_with_boxes`
+    /// use). The walk mutates the array on the trace-ctx shadow only, so without
+    /// this native state's array stays frozen at trace-start and the compiled
+    /// loop re-executes the peeled iteration. Applied before
+    /// `recover_after_compiled_run`. Default no-op; the `#[jit_interp]` macro
+    /// overrides it only for consumers declaring a `[.. ; virt]` array.
+    fn writeback_virt_array_state_fields_from_values(&mut self, _values: &[i64]) {}
+
     /// blackhole.py:1679 `_exit_frame_with_exception` → warmspot.py:998-1005.
     ///
     /// The resumed blackhole frame chain raised an exception (`exc`, a GC ref

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -1400,6 +1400,24 @@ impl<S: JitState> JitDriver<S> {
         }
     }
 
+    /// Push the walk's loop-carried virtualizable-array element values into
+    /// native `state`, the array analog of `writeback_scalar_state_fields`. The
+    /// walk mutates the array on the trace-ctx shadow; native `state`'s array is
+    /// stale at the close because `synchronize_virtualizable` skips the RustVec
+    /// write-back during tracing. Without this, the compiled-loop seed
+    /// (`extract_live_values` reads native `state`) reflects the trace-start
+    /// array, so the loop re-executes the peeled iteration — double-firing any
+    /// side-effecting residual. Consumes (`take`s) the stash. No-op when the
+    /// state has no virtualizable array. Called from the whole-circuit
+    /// single-pass `jit_merge_point!` branch, after `writeback_scalar_state_fields`
+    /// and before `recover_after_compiled_run` / `try_resume_into_compiled_loop`.
+    #[inline]
+    pub fn writeback_virt_array_state_fields(&mut self, state: &mut S) {
+        if let Some(values) = self.meta.single_pass_virt_array_values.take() {
+            state.writeback_virt_array_state_fields_from_values(&values);
+        }
+    }
+
     /// Single-pass cross-loop-cut resume: directly enter the loop the
     /// CloseLoop arm just compiled (its key stashed in
     /// `single_pass_compiled_key`) with the walk-final native state, instead
@@ -1843,6 +1861,20 @@ impl<S: JitState> JitDriver<S> {
                 if let Some(sym) = self.sym.as_ref() {
                     let scalars = S::collect_scalar_state_field_values(sym);
                     self.meta.single_pass_scalar_values = Some(scalars);
+                }
+                // Capture the walk-final loop-carried virt-array element values
+                // off the still-live trace ctx (the walk mutated the ctx shadow,
+                // not native `state`), before `compile_loop` drains the ctx. The
+                // macro hook writes them into native `state` so the compiled loop
+                // resumes at S_{k+1} instead of re-executing the peeled iteration
+                // (pyjitpl.py:2982-2989 live_arg_boxes += virtualizable_boxes).
+                // `None` when the state has no virtualizable array.
+                let virt_elems = self
+                    .meta
+                    .trace_ctx()
+                    .and_then(|ctx| ctx.collect_virtualizable_element_values());
+                if let Some(elems) = virt_elems {
+                    self.meta.single_pass_virt_array_values = Some(elems);
                 }
                 // pyjitpl.py:2979-3036 reached_loop_header parity.
                 // Path 1: bridge — only if has_compiled_targets (line 2982).

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -1077,6 +1077,20 @@ pub struct MetaInterp<M: Clone> {
     /// via `writeback_scalar_state_fields_from_values`. `None` outside
     /// single-pass or when the state has no scalar fields.
     pub(crate) single_pass_scalar_values: Option<Vec<i64>>,
+    /// Single-pass tracing: the walk-final concrete values of the loop-carried
+    /// virtualizable ARRAY elements, captured off the active `TraceCtx`
+    /// (`collect_virtualizable_element_values`) at the CloseLoop point. The walk
+    /// mutates the array on the trace-ctx shadow only; native `state`'s array is
+    /// frozen at trace-start because `synchronize_virtualizable` skips the
+    /// write-back for `RustVec` storage during tracing (the native match body,
+    /// the usual writer, never runs under the single-pass walk). The macro hook
+    /// `take`s these and applies them to native `state` via
+    /// `writeback_virt_array_state_fields_from_values` before re-entering the
+    /// compiled loop, so it resumes at the post-peeled iteration (S_{k+1})
+    /// instead of re-executing the traced iteration — the analog of PyPy's
+    /// `live_arg_boxes += virtualizable_boxes` (pyjitpl.py:2982-2989). `None`
+    /// outside single-pass or when the state has no virtualizable array.
+    pub(crate) single_pass_virt_array_values: Option<Vec<i64>>,
     /// Single-pass tracing: the green key the CloseLoop arm compiled the
     /// (cross-loop-cut) inner loop under, captured after a `Compiled`
     /// outcome so the merge-point hook can DIRECTLY enter that freshly
@@ -2272,6 +2286,7 @@ impl<M: Clone> MetaInterp<M> {
             tracing: None,
             single_pass_outcome: None,
             single_pass_scalar_values: None,
+            single_pass_virt_array_values: None,
             single_pass_compiled_key: None,
             next_trace_id: 1,
             hooks: JitHooks::default(),

--- a/majit/majit-metainterp/src/pyjitpl/dispatch.rs
+++ b/majit/majit-metainterp/src/pyjitpl/dispatch.rs
@@ -1540,6 +1540,14 @@ where
             if frame.inline_frame {
                 ctx.pop_inline_frame();
             }
+            // pyjitpl.py:2556 finishframe_exception -> popframe(
+            // leave_portal_frame=True): a portal frame whose push recorded
+            // ENTER_PORTAL_FRAME unwinds through here, so record the matching
+            // LEAVE_PORTAL_FRAME just as the normal-return pop does.
+            if frame.portal_entered {
+                let jd_box = ctx.const_int(frame.portal_jd as i64);
+                ctx.record_op(OpCode::LeavePortalFrame, &[jd_box]);
+            }
             // [FR] A recursive-portal INLINE frame installed its callee's
             // fresh standard vable on push; restore the caller's on return.
             if frame.portal_vable_saved {
@@ -2130,6 +2138,14 @@ where
             let uid_box = ctx.const_int(green_pc as i64);
             ctx.record_op(OpCode::EnterPortalFrame, &[jd_box, uid_box]);
             portal_frame.inline_frame = true;
+            // pyjitpl.py:2461-2492 pairing: this push recorded ENTER_PORTAL_FRAME,
+            // so the frame's normal-return / exception-return pop records the
+            // matching LEAVE_PORTAL_FRAME (popframe leave_portal_frame default
+            // True). The merge-point cut path pops this frame itself and re-emits
+            // LEAVE (leave_portal_frame=False), so it never flows through those
+            // auto-LEAVE pops.
+            portal_frame.portal_entered = true;
+            portal_frame.portal_jd = jd_index;
             for (kind, caller_src, callee_dst) in arg_triples {
                 match kind {
                     JitArgKind::Int => {
@@ -2423,6 +2439,15 @@ where
             let finished_frame = self.frames.pop().expect("finished frame stack was empty");
             if finished_frame.inline_frame {
                 ctx.pop_inline_frame();
+            }
+            // pyjitpl.py:2506 finishframe -> popframe(leave_portal_frame=True):
+            // a portal frame whose push recorded ENTER_PORTAL_FRAME returns
+            // normally here, so record the matching LEAVE_PORTAL_FRAME. Ordinary
+            // BC_INLINE_CALL frames (inline_frame=true, portal_entered=false)
+            // recorded no ENTER and record no LEAVE.
+            if finished_frame.portal_entered {
+                let jd_box = ctx.const_int(finished_frame.portal_jd as i64);
+                ctx.record_op(OpCode::LeavePortalFrame, &[jd_box]);
             }
             // [FR] Restore the caller's sym scalar/fixed-array state that this
             // inline recursive-portal frame overwrote, and its nested vable.
@@ -7679,6 +7704,26 @@ mod tests {
         assert_eq!(finish_arg_types, vec![majit_ir::Type::Int]);
         assert_eq!(finish_args.len(), 1);
         assert_eq!(ctx.const_value(finish_args[0]), Some(42));
+
+        // The portal returns normally (int_return, no merge-point cut), so the
+        // ENTER_PORTAL_FRAME recorded at the inline-portal push pairs with a
+        // LEAVE_PORTAL_FRAME recorded by the normal-return pop
+        // (pyjitpl.py:2461-2492 enter/leave pairing on the finishframe path).
+        let recorder = ctx.into_recorder();
+        let ops = recorder.ops();
+        let enter_count = ops
+            .iter()
+            .filter(|o| o.opcode == OpCode::EnterPortalFrame)
+            .count();
+        let leave_count = ops
+            .iter()
+            .filter(|o| o.opcode == OpCode::LeavePortalFrame)
+            .count();
+        assert_eq!(enter_count, 1, "exactly one ENTER_PORTAL_FRAME");
+        assert_eq!(
+            leave_count, enter_count,
+            "normal-return path must balance ENTER_PORTAL_FRAME with LEAVE_PORTAL_FRAME",
+        );
     }
 
     thread_local! {

--- a/majit/majit-metainterp/src/pyjitpl/frame.rs
+++ b/majit/majit-metainterp/src/pyjitpl/frame.rs
@@ -92,6 +92,20 @@ pub struct MIFrame {
     /// INLINE frame; restored into the shared sym when the frame returns so the
     /// callee's in-place mutation of the single sym doesn't corrupt the caller.
     pub portal_scalar_state: Option<Vec<(OpRef, i64)>>,
+    /// [FR] True only for a frame whose push recorded `ENTER_PORTAL_FRAME`
+    /// (an inline-pushed portal, dispatch.rs). Its normal-return and
+    /// exception-return pops record the matching `LEAVE_PORTAL_FRAME`, so every
+    /// enter_portal_frame pairs with a leave_portal_frame (pyjitpl.py:2461-2492:
+    /// newframe→enter_portal_frame, popframe→leave_portal_frame default True on
+    /// both the finishframe and finishframe_exception paths). Distinct from
+    /// `inline_frame`, which is also true for ordinary `BC_INLINE_CALL` frames
+    /// that record no ENTER and must record no LEAVE. The merge-point cut is the
+    /// sole `leave_portal_frame=False` site and re-emits LEAVE itself.
+    pub portal_entered: bool,
+    /// [FR] The jd_index carried in this frame's `LEAVE_PORTAL_FRAME` op, set at
+    /// the same push that set `portal_entered`. Unused when `portal_entered` is
+    /// false.
+    pub portal_jd: usize,
     pub return_i: Option<usize>,
     pub return_r: Option<usize>,
     pub return_f: Option<usize>,
@@ -170,6 +184,8 @@ impl MIFrame {
             inline_frame: false,
             portal_vable_saved: false,
             portal_scalar_state: None,
+            portal_entered: false,
+            portal_jd: 0,
             return_i: None,
             return_r: None,
             return_f: None,

--- a/majit/majit-metainterp/src/trace_ctx.rs
+++ b/majit/majit-metainterp/src/trace_ctx.rs
@@ -1785,6 +1785,32 @@ impl TraceCtx {
         self.virtualizable_boxes.clone()
     }
 
+    /// The walk-final concrete values of the virtualizable's array elements, in
+    /// the flat `[arr0_elem0.., arr1_elem0.., ..]` layout — the array portion of
+    /// `virtualizable_values`, excluding the `num_static_extra_boxes` leading
+    /// static-field slots and the trailing identity slot
+    /// (`virtualizable_boxes[-1]`). `None` when no standard virtualizable is
+    /// active or its concrete shadow was disabled. Used by the single-pass close
+    /// to transfer walk-mutated loop-carried array state into native `state`
+    /// before re-entering the compiled loop (pyjitpl.py:2982-2989
+    /// `live_arg_boxes += virtualizable_boxes`).
+    pub fn collect_virtualizable_element_values(&self) -> Option<Vec<i64>> {
+        let values = self.virtualizable_values.as_ref()?;
+        let static_count = self
+            .virtualizable_info
+            .as_ref()
+            .map_or(0, |info| info.num_static_extra_boxes);
+        let end = values.len().saturating_sub(1); // drop the trailing identity slot
+        let start = static_count.min(end);
+        Some(
+            values[start..end]
+                .iter()
+                .copied()
+                .map(value_to_raw_bits)
+                .collect(),
+        )
+    }
+
     // (synchronize_virtualizable helper follows)
 
     /// Mirror of `MetaInterp::vable_ptr` used by `synchronize_virtualizable`.


### PR DESCRIPTION
Two follow-ups on the single-pass whole-circuit close path (`#344` Phase B, landed via #427/#434).

## 1. Transfer walk-final virt-array elements into native `state` before compiled-loop re-entry

The `; state` single-pass close re-entered the compiled loop seeded from native `state` **frozen at trace-start**, re-executing the peeled (traced) iteration. For a pure loop the recomputed values match, but a side-effecting `@dont_look_inside` residual fired one extra time (N+1) — observed as `touch` firing 51× for a 50-iteration loop, excess exactly +1 regardless of N/threshold.

**Root cause.** The walk mutates the loop-carried virtualizable array on the trace-ctx *shadow* only; native `state`'s array stays at trace-start because:
- the native match body (the usual writer) never runs under the single-pass walk;
- `synchronize_virtualizable` skips the `RustVec` write-back during tracing (the "heap is authoritative" assumption holds for the replay path where the native body writes every opcode, but is false for the `; state` path);
- `writeback_scalar_state_fields` transfers only scalar fields.

So `try_resume_into_compiled_loop` → `extract_live_values` seeds the compiled loop from the stale array and re-runs the already-peeled iteration.

**Fix.** Capture the walk-final virt-array element values off the trace ctx at CloseLoop (`collect_virtualizable_element_values`) and write them into native `state` in the `; state` merge-point hook (`writeback_virt_array_state_fields`), before `recover_after_compiled_run` / `try_resume_into_compiled_loop`. The compiled loop then resumes at the post-peeled iteration. This is the analog of `pyjitpl.py:2982-2989` `live_arg_boxes += virtualizable_boxes` → `raise_continue_running_normally`, which re-enters with the closing (post-peel) live values.

The macro emits the write-back override only when the interpreter declares a `[.. ; virt]` array, so 0-array interpreters keep the trait default no-op and their generated impl byte-identical. `writeback_virt_array_state_fields` has a single caller — the `; state` hook — so the shared replay path (`back_edge_internal`) is untouched.

`spcount`'s `jit_residual_not_double_executed` now uses a scalar-argument residual (compilable, unlike the virt-array base-pointer form) plus a `SPCOUNT_COMPILES` compile counter, so it exercises the single-pass close and guards this fix: the residual fires exactly N times (was N+1).

## 2. Balance ENTER_PORTAL_FRAME with LEAVE_PORTAL_FRAME on inline-portal frame pops

An inline-pushed portal frame recorded `ENTER_PORTAL_FRAME` at its push but its return pops recorded no matching `LEAVE_PORTAL_FRAME`, leaving the debug op stream unbalanced. Add `portal_entered`/`portal_jd` to `MIFrame` and record `LEAVE_PORTAL_FRAME` on both the normal-return pop (`finishframe`, `pyjitpl.py:2506`) and the exception-return pop (`finishframe_exception`, `pyjitpl.py:2556`). The merge-point cut path pops its frame directly and re-emits LEAVE itself, so it is unaffected. `portal_entered` is distinct from `inline_frame` (ordinary `BC_INLINE_CALL` frames set the latter but record no ENTER/LEAVE).

## Verification

- `spcount` 3/3 (`jit_residual_not_double_executed` 51→50, `jit_output_matches_interp`, `jit_no_loop`)
- `majit-metainterp` lib 1389/0/1ignored
- all example crates incl `dualtape` (2 virt arrays) and `tl` (replay-path residual)
- `pyre/check.py`: dynasm 159/159, cranelift 159/159 (wasm 4 = pre-existing, main-identical: `sre_pattern_methods` + 3 `inline*` portal cases; pyre proper uses no `; state` form so this fix's runtime path is untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)