### PR TITLE
dynasm: 16-byte-align loop back-edge targets

### DIFF
--- a/majit/majit-backend-dynasm/src/x86/assembler.rs
+++ b/majit/majit-backend-dynasm/src/x86/assembler.rs
@@ -4073,6 +4073,17 @@ impl<'a> Assembler386<'a> {
                 let label = self.mc.new_dynamic_label();
                 let descr_arc = op.getdescr();
                 let label_descr = descr_arc.as_ref().and_then(|d| d.as_loop_target_descr());
+                if label_descr.is_some() {
+                    // Align the loop back-edge target to 16 bytes. The buffer is
+                    // page-aligned, so aligning the offset aligns the address. A
+                    // head landing in the last few bytes of a 64-byte fetch line
+                    // costs a per-iteration front-end fetch bubble on the taken
+                    // back-edge; the pad (executed only on the first fall-through
+                    // entry) removes that sensitivity to frame-layout offset.
+                    while self.mc.offset().0 % 16 != 0 {
+                        dynasm!(self.mc ; .arch x64 ; nop);
+                    }
+                }
                 if majit_ir::debug::have_debug_prints() {
                     majit_ir::debug::log_one(
                         "jit-backend",


### PR DESCRIPTION
In the x86 assembler's OpCode::Label handler, pad with NOPs to a 16-byte boundary before binding a label that is a loop target. The code buffer is page-aligned, so aligning the offset aligns the address.

Without this, the loop head's byte offset depends on the frame size (e.g. the number of locals), and when it lands within ~8 bytes of a 64-byte instruction-fetch line the taken back-edge pays a per-iteration front-end fetch bubble (~0.2 ns/iter measured on Zen4 for a tight integer loop). The pad runs only on the first fall-through entry.

<!--
Thank you for contributing to Pyre.

Pyre is still a project that relies heavily on AI-assisted development.

For effective collaboration, please follow these rules.

1. The submitter is ultimately responsible for both the code and the discussion. Do not submit generated code or generated discussion without review.
2. Clearly separate the author's own judgment from generated suggestions. Do not submit generated discussion by itself without the author's own assessment.
-->

## Summary


## Self-review

<!--
Did you use AI to create this patch?
If the patch is not AI-generated, write: "This patch is not AI-generated."
Otherwise, please fill out this section.

Note: Do not run the review in the same session that generated the code.

If you are using Claude, a quick local review is `/parity to upstream/main`.

The currently recommended prompt for gpt-5.5 will be run automatically when this is ready for review.
The prompt is:

----
Assess by static analysis whether our changes in git diff main are equivalent
to the corresponding RPython/PyPy source code. The RPython and PyPy sources
are available locally.

If anything was ported incorrectly, report every instance in detail. After
collecting all differences, organize the report into separate sections:

1. Cases where our patch regressed PyPy parity compared to main
2. Other mismatches introduced by our patch
3. Mismatches that already existed before this patch
4. Structural adaptations

Exceptions: some differences cannot be ported 1:1 because of Python 3.11 vs
3.14 differences, opcode mismatches caused by using a CPython-compatible
compiler, GIL/free-threading differences, and fundamental implementation-
language differences between RPython and Rust. Mark those separately under
“Structural adaptations.”
-->

- [ ] I fully resolved all reasonable code review comments from Codex and CodeRabbit.
  - [ ] Auto-review section 1 is clear. This check is mandatory.
  - [ ] Auto-review section 2 is clear. If this is not checked, please add a comment explaining why.
- [ ] I did not use AI to write the code of this patch.
  - If this is not checked, commits must include `Assisted-by`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved loop alignment in generated code, which may help reduce slowdowns in tight loops on some systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->