### PR TITLE
memoryview native view geometry; census union-ADT bucket

### DIFF
--- a/majit/majit-translate/src/translator/rtyper/cutover.rs
+++ b/majit/majit-translate/src/translator/rtyper/cutover.rs
@@ -2736,6 +2736,15 @@ fn classify_unported_reason(reason: &str) -> &'static str {
     // ── annotator-stage catch-alls ──
     else if reason.contains("UnionError") {
         "UNION-ERROR (generic-ADT phi / pair)"
+    } else if reason.contains("setbinding: new value does not contain old") {
+        // A binding moved backwards in the lattice: a variable's
+        // `SomeInteger.knowntypedata` (or instance) annotation refined from
+        // a generic to a per-instantiation classdef between fixpoint passes
+        // (`Option` -> `Option<Result<*mut PyObject,PyError>>`), so
+        // `contains` (union == self) is false. Same per-instantiation
+        // classdef monotonicity as the mergeinputargs `UnionError` bucket —
+        // fixed by the same generic-ADT union work, so it shares the label.
+        "UNION-ERROR (generic-ADT phi / pair)"
     } else if reason.contains("Blocked block -- operation cannot succeed") {
         "BLOCKED-BLOCK (annotation dead-end downstream)"
     } else if reason.contains("compute_at_fixpoint failed")
@@ -3325,6 +3334,25 @@ mod tests {
         assert!(
             is_known_unported(msg),
             "noneify-on-ptr merge must skip/fallback on the typed-null-pointer-lowering gap"
+        );
+    }
+
+    #[test]
+    fn setbinding_backwards_binding_classifies_as_union_adt() {
+        // `unary_invert`/`unary_negative`/`descroperation::{invert,neg}` fail
+        // when a `SomeInteger.knowntypedata` inner annotation refines from a
+        // generic `Option` to a per-instantiation `Option<Result<..>>`
+        // classdef between passes — the same generic-ADT union gap that the
+        // mergeinputargs `UnionError` failures carry, one lattice step later.
+        let msg = "setbinding: new value does not contain old (Integer(SomeInteger { \
+                   knowntypedata: Some({Int(1): {v: Instance(Option<Result<*mut \
+                   PyObject,PyError>>::Some)}}) }) ⊄ Integer(SomeInteger { \
+                   knowntypedata: Some({Int(1): {v: Instance(Option::Some)}}) }))";
+        assert_eq!(
+            classify_unported_reason(msg),
+            "UNION-ERROR (generic-ADT phi / pair)",
+            "backwards setbinding on per-instantiation classdef knowntypedata \
+             shares the generic-ADT union disposition, not UNCLASSIFIED"
         );
     }
 

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -68,12 +68,21 @@ unsafe fn memoryview_backing_bytes_mut(backing: PyObjectRef) -> Option<&'static 
     }
 }
 
-/// Read element `i` of a memoryview shape/strides tuple as an `i64`.
-unsafe fn memoryview_dim_value(tuple: PyObjectRef, i: i64) -> i64 {
+/// Wrap native per-dimension extents (a `shape` or `strides`) into a fresh
+/// `tuple[int]` for the `descr` getters.  Each int is pinned as built, so a
+/// later element's allocation cannot strand an earlier one before
+/// `w_tuple_new` roots the whole set.
+unsafe fn memoryview_wrap_dims(dims: &[i64]) -> PyObjectRef {
     unsafe {
-        pyre_object::tupleobject::w_tuple_getitem(tuple, i)
-            .map(|w| pyre_object::w_int_get_value(w))
-            .unwrap_or(0)
+        let _roots = pyre_object::gc_roots::push_roots();
+        let sp = pyre_object::gc_roots::shadow_stack_len();
+        for &d in dims {
+            pyre_object::gc_roots::pin_root(w_int_new(d));
+        }
+        let items: Vec<PyObjectRef> = (0..dims.len())
+            .map(|i| pyre_object::gc_roots::shadow_stack_get(sp + i))
+            .collect();
+        pyre_object::w_tuple_new(items)
     }
 }
 
@@ -136,6 +145,57 @@ unsafe fn w_memoryview_alloc(
             offset,
             length,
             readonly,
+        };
+        let view_ptr = pyre_object::memoryview::bufferview_alloc(view);
+        pyre_object::memoryview::w_memoryview_set_view(mv, view_ptr);
+        mv
+    }
+}
+
+/// Build a `memoryview` over a plain contiguous 1-D exporter — a `SimpleView`
+/// (`bytes` / `bytearray`, derived format `'B'`) or a `RawBufferView`
+/// (`array.array`, explicit format).  The exporter's `Buffer` variant picks
+/// which, and both derive shape / strides / ndim / offset, so — unlike the
+/// `Strided` builder — no geometry Python objects are constructed; only a
+/// `Raw` view keeps a format object.  Pins the exporter (and, for `Raw`, the
+/// format) across the header allocation (the sole collection point), then
+/// re-reads them relocated before building the off-heap box.
+unsafe fn w_memoryview_new_plain(
+    w_obj: PyObjectRef,
+    fmt: &str,
+    itemsize: i64,
+    length: i64,
+) -> PyObjectRef {
+    use pyre_object::bufferview::BufferView;
+    unsafe {
+        let array_ty = crate::typedef::gettypeobject(&pyre_object::interp_array::ARRAY_TYPE);
+        let is_array = pyre_object::interp_array::is_array(w_obj)
+            || crate::baseobjspace::isinstance_w(w_obj, array_ty);
+        let _roots = pyre_object::gc_roots::push_roots();
+        let sp = pyre_object::gc_roots::shadow_stack_len();
+        pyre_object::gc_roots::pin_root(w_obj);
+        // A Raw view keeps its explicit format object; a Simple view derives 'B'.
+        if is_array {
+            pyre_object::gc_roots::pin_root(w_str_new(fmt));
+        }
+        let mv = pyre_object::memoryview::w_memoryview_alloc_header(false);
+        let r_obj = pyre_object::gc_roots::shadow_stack_get(sp);
+        let backing = memoryview_backing_buffer(r_obj);
+        let view = if is_array {
+            let r_fmt = pyre_object::gc_roots::shadow_stack_get(sp + 1);
+            BufferView::Raw {
+                backing,
+                w_obj: r_obj,
+                w_fmt: r_fmt,
+                itemsize,
+                length,
+            }
+        } else {
+            BufferView::Simple {
+                backing,
+                w_obj: r_obj,
+                length,
+            }
         };
         let view_ptr = pyre_object::memoryview::bufferview_alloc(view);
         pyre_object::memoryview::w_memoryview_set_view(mv, view_ptr);
@@ -226,7 +286,7 @@ pub(crate) fn w_memoryview_new(w_obj: PyObjectRef) -> Result<PyObjectRef, crate:
                 false,
             ));
         }
-        let (fmt, itemsize, readonly, byte_len) = match memoryview_buffer_params(w_obj) {
+        let (fmt, itemsize, _readonly, byte_len) = match memoryview_buffer_params(w_obj) {
             Some(p) => p,
             None => {
                 let tname = crate::typedef::r#type(w_obj)
@@ -237,23 +297,14 @@ pub(crate) fn w_memoryview_new(w_obj: PyObjectRef) -> Result<PyObjectRef, crate:
                 )));
             }
         };
-        let count = if itemsize > 0 {
-            byte_len as i64 / itemsize
-        } else {
-            0
-        };
-        Ok(w_memoryview_alloc(
-            w_obj,
+        // A plain view derives its geometry: a bytes / bytearray backing builds
+        // a `SimpleView`, an array.array a `RawBufferView` (readonly follows the
+        // backing kind).
+        Ok(w_memoryview_new_plain(
             w_obj,
             &fmt,
-            &[count],
-            &[itemsize],
             itemsize,
-            1,
-            0,
             byte_len as i64,
-            readonly,
-            false,
         ))
     }
 }
@@ -428,7 +479,7 @@ fn memoryview_pack_value(
 unsafe fn memoryview_values(mv: PyObjectRef) -> Vec<PyObjectRef> {
     unsafe {
         let itemsize = pyre_object::memoryview::w_memoryview_itemsize(mv) as usize;
-        let fmt = pyre_object::w_str_get_value(pyre_object::memoryview::w_memoryview_format(mv));
+        let fmt = pyre_object::memoryview::w_memoryview_format_str(mv);
         let data = memoryview_gather_bytes(mv);
         let mut items = Vec::new();
         let mut base = 0;
@@ -454,15 +505,15 @@ unsafe fn memoryview_slice_view(
     unsafe {
         let itemsize = w_memoryview_itemsize(mv);
         let ndim = w_memoryview_ndim(mv);
-        let parent_shape = w_memoryview_shape(mv);
-        let parent_strides = w_memoryview_strides(mv);
+        let parent_shape = w_memoryview_native_shape(mv);
+        let parent_strides = w_memoryview_native_strides(mv);
         let count = if ndim >= 1 {
-            memoryview_dim_value(parent_shape, 0)
+            parent_shape.first().copied().unwrap_or(0)
         } else {
             0
         };
         let stride_p = if ndim >= 1 {
-            memoryview_dim_value(parent_strides, 0)
+            parent_strides.first().copied().unwrap_or(0)
         } else {
             itemsize
         };
@@ -486,8 +537,8 @@ unsafe fn memoryview_slice_view(
         let mut shape_v = vec![slicelength];
         let mut strides_v = vec![new_stride];
         for d in 1..ndim {
-            shape_v.push(memoryview_dim_value(parent_shape, d));
-            strides_v.push(memoryview_dim_value(parent_strides, d));
+            shape_v.push(parent_shape.get(d as usize).copied().unwrap_or(0));
+            strides_v.push(parent_strides.get(d as usize).copied().unwrap_or(0));
         }
         let new_length = shape_v.iter().product::<i64>() * itemsize;
         let fmt = w_memoryview_format_str(mv).to_owned();
@@ -556,12 +607,9 @@ unsafe fn memoryview_get_offset(
 ) -> Result<i64, crate::PyError> {
     use pyre_object::memoryview::*;
     unsafe {
-        let read = |t: PyObjectRef, i: i64| {
-            pyre_object::tupleobject::w_tuple_getitem(t, i)
-                .map(|w| pyre_object::w_int_get_value(w))
-                .unwrap_or(0)
-        };
-        let nitems = read(w_memoryview_shape(mv), dim);
+        let shape = w_memoryview_native_shape(mv);
+        let strides = w_memoryview_native_strides(mv);
+        let nitems = shape.get(dim as usize).copied().unwrap_or(0);
         let mut idx = index;
         if idx < 0 {
             idx += nitems;
@@ -572,7 +620,7 @@ unsafe fn memoryview_get_offset(
                 dim + 1
             )));
         }
-        Ok(read(w_memoryview_strides(mv), dim) * idx)
+        Ok(strides.get(dim as usize).copied().unwrap_or(0) * idx)
     }
 }
 
@@ -659,7 +707,7 @@ fn memoryview_getitem(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyErro
             }
             let base = (w_memoryview_offset(mv) + i * w_memoryview_stride0(mv)) as usize;
             let full = memoryview_backing_slice(w_memoryview_backing(mv));
-            let fmt = pyre_object::w_str_get_value(w_memoryview_format(mv));
+            let fmt = w_memoryview_format_str(mv);
             return Ok(memoryview_unpack_element(
                 fmt,
                 full,
@@ -685,7 +733,7 @@ fn memoryview_getitem(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyErro
                 let itemsize = w_memoryview_itemsize(mv);
                 let base = (w_memoryview_offset(mv) + start) as usize;
                 let full = memoryview_backing_slice(w_memoryview_backing(mv));
-                let fmt = pyre_object::w_str_get_value(w_memoryview_format(mv));
+                let fmt = w_memoryview_format_str(mv);
                 return Ok(memoryview_unpack_element(
                     fmt,
                     full,
@@ -727,7 +775,7 @@ fn memoryview_setitem(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyErro
         }
         let itemsize = w_memoryview_itemsize(mv);
         let isz = itemsize.max(0) as usize;
-        let fmt = pyre_object::w_str_get_value(w_memoryview_format(mv)).to_owned();
+        let fmt = w_memoryview_format_str(mv).to_owned();
         let count = if itemsize > 0 {
             w_memoryview_length(mv) / itemsize
         } else {
@@ -892,7 +940,9 @@ fn memoryview_format(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError
     let mv = args.first().copied().unwrap_or(w_none());
     unsafe {
         memoryview_check_released(mv)?;
-        Ok(pyre_object::memoryview::w_memoryview_format(mv))
+        Ok(w_str_new(pyre_object::memoryview::w_memoryview_format_str(
+            mv,
+        )))
     }
 }
 
@@ -930,7 +980,9 @@ fn memoryview_shape(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError>
     let mv = args.first().copied().unwrap_or(w_none());
     unsafe {
         memoryview_check_released(mv)?;
-        Ok(pyre_object::memoryview::w_memoryview_shape(mv))
+        Ok(memoryview_wrap_dims(
+            &pyre_object::memoryview::w_memoryview_native_shape(mv),
+        ))
     }
 }
 
@@ -939,7 +991,9 @@ fn memoryview_strides(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyErro
     let mv = args.first().copied().unwrap_or(w_none());
     unsafe {
         memoryview_check_released(mv)?;
-        Ok(pyre_object::memoryview::w_memoryview_strides(mv))
+        Ok(memoryview_wrap_dims(
+            &pyre_object::memoryview::w_memoryview_native_strides(mv),
+        ))
     }
 }
 
@@ -952,11 +1006,8 @@ fn memoryview_len(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
         if dim == 0 {
             return Ok(w_int_new(1));
         }
-        match pyre_object::tupleobject::w_tuple_getitem(
-            pyre_object::memoryview::w_memoryview_shape(mv),
-            0,
-        ) {
-            Some(s) => Ok(w_int_new(pyre_object::w_int_get_value(s))),
+        match pyre_object::memoryview::w_memoryview_native_shape(mv).first() {
+            Some(&s) => Ok(w_int_new(s)),
             None => Ok(w_int_new(0)),
         }
     }
@@ -978,8 +1029,14 @@ unsafe fn memoryview_tolist_rec(
 ) -> PyObjectRef {
     use pyre_object::memoryview::*;
     unsafe {
-        let dimshape = memoryview_dim_value(w_memoryview_shape(mv), idim);
-        let dimstride = memoryview_dim_value(w_memoryview_strides(mv), idim);
+        let dimshape = w_memoryview_native_shape(mv)
+            .get(idim as usize)
+            .copied()
+            .unwrap_or(0);
+        let dimstride = w_memoryview_native_strides(mv)
+            .get(idim as usize)
+            .copied()
+            .unwrap_or(0);
         let mut items = Vec::with_capacity(dimshape.max(0) as usize);
         let mut pos = start;
         if idim == ndim - 1 {
@@ -1020,7 +1077,7 @@ fn memoryview_tolist(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError
             return Ok(w_list_new(memoryview_values(mv)));
         }
         let isz = pyre_object::memoryview::w_memoryview_itemsize(mv) as usize;
-        let fmt = pyre_object::w_str_get_value(pyre_object::memoryview::w_memoryview_format(mv));
+        let fmt = pyre_object::memoryview::w_memoryview_format_str(mv);
         let full = memoryview_backing_slice(pyre_object::memoryview::w_memoryview_backing(mv));
         let start = pyre_object::memoryview::w_memoryview_offset(mv);
         Ok(memoryview_tolist_rec(mv, fmt, full, isz, ndim, 0, start))
@@ -1059,13 +1116,8 @@ fn memoryview_cast(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> 
         // A reshape, or reinterpreting a multi-dim view, rejects an empty
         // dimension (`_zero_in_shape`).
         if has_shape || orig_ndim != 1 {
-            let shape_t = w_memoryview_shape(mv);
-            let has_zero = (0..orig_ndim).any(|i| {
-                pyre_object::tupleobject::w_tuple_getitem(shape_t, i)
-                    .map(|w| pyre_object::w_int_get_value(w))
-                    .unwrap_or(0)
-                    == 0
-            });
+            let shape_v = w_memoryview_native_shape(mv);
+            let has_zero = shape_v.iter().take(orig_ndim as usize).any(|&x| x == 0);
             if has_zero {
                 return Err(crate::PyError::type_error(
                     "memoryview: cannot casts view with zeros in shape or strides",
@@ -1109,7 +1161,7 @@ fn memoryview_cast(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> 
                  character format prefixed with an optional '@'",
             ));
         };
-        let orig_fmt = pyre_object::w_str_get_value(w_memoryview_format(mv));
+        let orig_fmt = w_memoryview_format_str(mv);
         if (memoryview_native_fmtchar(orig_fmt).is_none() || !memoryview_is_byte_format(orig_fmt))
             && !memoryview_is_byte_format(&fmt)
         {
@@ -1418,15 +1470,8 @@ pub(crate) unsafe fn memoryview_contiguity(mv: PyObjectRef) -> (bool, bool) {
             return (true, true);
         }
         let itemsize = w_memoryview_itemsize(mv);
-        let shape_t = w_memoryview_shape(mv);
-        let strides_t = w_memoryview_strides(mv);
-        let read = |t: PyObjectRef, i: i64| {
-            pyre_object::tupleobject::w_tuple_getitem(t, i)
-                .map(|w| pyre_object::w_int_get_value(w))
-                .unwrap_or(0)
-        };
-        let shape: Vec<i64> = (0..ndim).map(|i| read(shape_t, i)).collect();
-        let strides: Vec<i64> = (0..ndim).map(|i| read(strides_t, i)).collect();
+        let shape = w_memoryview_native_shape(mv);
+        let strides = w_memoryview_native_strides(mv);
         (
             memoryview_is_c_contiguous(&shape, &strides, itemsize),
             memoryview_is_f_contiguous(&shape, &strides, itemsize),

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -79,16 +79,20 @@ unsafe fn memoryview_dim_value(tuple: PyObjectRef, i: i64) -> i64 {
 
 /// Allocate a `W_MemoryView` over a freshly built off-heap `BufferView`.
 /// Selects the backing `Buffer` variant (needs `isinstance_w`, hence here and
-/// not in pyre-object) and pins every ref across the allocation — building the
-/// box and allocating the object can trigger a collection before the new
-/// memoryview roots them.
+/// not in pyre-object) and builds the geometry's Python objects (`format` /
+/// `shape` / `strides`) *inside* the rooted region, pinning every ref across
+/// the allocations — building the boxes and allocating the header can trigger a
+/// collection before the new memoryview roots them.  Geometry arrives as native
+/// values so no caller has to hold an unrooted `format` / `shape` / `strides`
+/// object across the call; `fmt` must borrow non-GC storage (e.g. a Rust
+/// `String`) since it is read after the pin.
 #[allow(clippy::too_many_arguments)]
 unsafe fn w_memoryview_alloc(
     w_obj: PyObjectRef,
     w_backing: PyObjectRef,
-    w_format: PyObjectRef,
-    w_shape: PyObjectRef,
-    w_strides: PyObjectRef,
+    fmt: &str,
+    shape: &[i64],
+    strides: &[i64],
     itemsize: i64,
     ndim: i64,
     offset: i64,
@@ -101,13 +105,20 @@ unsafe fn w_memoryview_alloc(
         let sp = pyre_object::gc_roots::shadow_stack_len();
         pyre_object::gc_roots::pin_root(w_obj);
         pyre_object::gc_roots::pin_root(w_backing);
-        pyre_object::gc_roots::pin_root(w_format);
-        pyre_object::gc_roots::pin_root(w_shape);
-        pyre_object::gc_roots::pin_root(w_strides);
-        // Allocate the managed header first; old-gen allocation may trigger a
-        // moving collection, so read the relocated refs back from the shadow
-        // stack before building the off-heap view (mirrors `W_TupleObject`
-        // filling its items block from the `pop_roots`-relocated slots).
+        // Build each geometry object and pin it as produced: a later allocation
+        // may relocate an earlier one, so the pinned shadow slot (re-read below)
+        // is the source of truth, not the stale local.
+        pyre_object::gc_roots::pin_root(w_str_new(fmt));
+        pyre_object::gc_roots::pin_root(pyre_object::w_tuple_new(
+            shape.iter().map(|&x| w_int_new(x)).collect(),
+        ));
+        pyre_object::gc_roots::pin_root(pyre_object::w_tuple_new(
+            strides.iter().map(|&x| w_int_new(x)).collect(),
+        ));
+        // Allocate the managed header last of the ref-bearing allocations; a
+        // moving collection here relocates the pinned refs, so read every one
+        // back from the shadow stack before building the off-heap view (mirrors
+        // `W_TupleObject` filling its items block from the relocated slots).
         let mv = pyre_object::memoryview::w_memoryview_alloc_header(released);
         let r_obj = pyre_object::gc_roots::shadow_stack_get(sp);
         let r_backing = pyre_object::gc_roots::shadow_stack_get(sp + 1);
@@ -198,12 +209,15 @@ pub(crate) fn w_memoryview_new(w_obj: PyObjectRef) -> Result<PyObjectRef, crate:
         if is_w_memoryview(w_obj) {
             memoryview_check_released(w_obj)?;
             let backing = w_memoryview_backing(w_obj);
+            let fmt = w_memoryview_format_str(w_obj).to_owned();
+            let shape = w_memoryview_native_shape(w_obj);
+            let strides = w_memoryview_native_strides(w_obj);
             return Ok(w_memoryview_alloc(
                 w_memoryview_obj(w_obj),
                 backing,
-                w_memoryview_format(w_obj),
-                w_memoryview_shape(w_obj),
-                w_memoryview_strides(w_obj),
+                &fmt,
+                &shape,
+                &strides,
                 w_memoryview_itemsize(w_obj),
                 w_memoryview_ndim(w_obj),
                 w_memoryview_offset(w_obj),
@@ -228,14 +242,12 @@ pub(crate) fn w_memoryview_new(w_obj: PyObjectRef) -> Result<PyObjectRef, crate:
         } else {
             0
         };
-        let shape = pyre_object::w_tuple_new(vec![w_int_new(count)]);
-        let strides = pyre_object::w_tuple_new(vec![w_int_new(itemsize)]);
         Ok(w_memoryview_alloc(
             w_obj,
             w_obj,
-            w_str_new(&fmt),
-            shape,
-            strides,
+            &fmt,
+            &[count],
+            &[itemsize],
             itemsize,
             1,
             0,
@@ -478,14 +490,13 @@ unsafe fn memoryview_slice_view(
             strides_v.push(memoryview_dim_value(parent_strides, d));
         }
         let new_length = shape_v.iter().product::<i64>() * itemsize;
-        let shape = pyre_object::w_tuple_new(shape_v.iter().map(|&x| w_int_new(x)).collect());
-        let strides = pyre_object::w_tuple_new(strides_v.iter().map(|&x| w_int_new(x)).collect());
+        let fmt = w_memoryview_format_str(mv).to_owned();
         Ok(w_memoryview_alloc(
             w_memoryview_obj(mv),
             w_memoryview_backing(mv),
-            w_memoryview_format(mv),
-            shape,
-            strides,
+            &fmt,
+            &shape_v,
+            &strides_v,
             itemsize,
             ndim.max(1),
             new_offset,
@@ -1116,17 +1127,14 @@ fn memoryview_cast(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> 
         let backing = w_memoryview_backing(mv);
         let obj = w_memoryview_obj(mv);
         let readonly = w_memoryview_readonly(mv);
-        let w_fmt = w_str_new(&fmt);
         if !has_shape {
             let count = total / new_itemsize;
-            let shape = pyre_object::w_tuple_new(vec![w_int_new(count)]);
-            let strides = pyre_object::w_tuple_new(vec![w_int_new(new_itemsize)]);
             return Ok(w_memoryview_alloc(
                 obj,
                 backing,
-                w_fmt,
-                shape,
-                strides,
+                &fmt,
+                &[count],
+                &[new_itemsize],
                 new_itemsize,
                 1,
                 offset,
@@ -1158,14 +1166,12 @@ fn memoryview_cast(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> 
             ));
         }
         let strides_v = memoryview_strides_from_shape(&dims, new_itemsize);
-        let shape = pyre_object::w_tuple_new(dims.iter().map(|&d| w_int_new(d)).collect());
-        let strides = pyre_object::w_tuple_new(strides_v.iter().map(|&s| w_int_new(s)).collect());
         Ok(w_memoryview_alloc(
             obj,
             backing,
-            w_fmt,
-            shape,
-            strides,
+            &fmt,
+            &dims,
+            &strides_v,
             new_itemsize,
             ndim,
             offset,
@@ -1182,12 +1188,15 @@ fn memoryview_toreadonly(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyE
     unsafe {
         use pyre_object::memoryview::*;
         memoryview_check_released(mv)?;
+        let fmt = w_memoryview_format_str(mv).to_owned();
+        let shape = w_memoryview_native_shape(mv);
+        let strides = w_memoryview_native_strides(mv);
         Ok(w_memoryview_alloc(
             w_memoryview_obj(mv),
             w_memoryview_backing(mv),
-            w_memoryview_format(mv),
-            w_memoryview_shape(mv),
-            w_memoryview_strides(mv),
+            &fmt,
+            &shape,
+            &strides,
             w_memoryview_itemsize(mv),
             w_memoryview_ndim(mv),
             w_memoryview_offset(mv),

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -616,6 +616,23 @@ unsafe fn memoryview_object_custom_trace(obj_addr: usize, f: &mut dyn FnMut(*mut
             f(w_strides as *mut pyre_object::PyObjectRef as *mut majit_ir::GcRef);
             trace_buffer_exporter(backing, f);
         }
+        // Simple / Raw derive their shape / strides (and Simple its format),
+        // so only the `.obj` exporter, the backing, and — for Raw — the
+        // explicit format object are ref slots to forward.
+        pyre_object::bufferview::BufferView::Simple { backing, w_obj, .. } => {
+            f(w_obj as *mut pyre_object::PyObjectRef as *mut majit_ir::GcRef);
+            trace_buffer_exporter(backing, f);
+        }
+        pyre_object::bufferview::BufferView::Raw {
+            backing,
+            w_obj,
+            w_fmt,
+            ..
+        } => {
+            f(w_obj as *mut pyre_object::PyObjectRef as *mut majit_ir::GcRef);
+            f(w_fmt as *mut pyre_object::PyObjectRef as *mut majit_ir::GcRef);
+            trace_buffer_exporter(backing, f);
+        }
     }
 }
 

--- a/pyre/pyre-object/src/buffer.rs
+++ b/pyre/pyre-object/src/buffer.rs
@@ -73,6 +73,18 @@ impl Buffer {
         }
     }
 
+    /// Whether the exporter's storage is read-only (`Buffer.readonly`,
+    /// `rpython/rlib/buffer.py:53`).  `bytes` is immutable; `bytearray` /
+    /// `array` are writable; a `Sub` inherits its parent's mutability.
+    #[inline]
+    pub fn readonly(&self) -> bool {
+        match self {
+            Buffer::String { .. } => true,
+            Buffer::Byte { .. } | Buffer::Array { .. } => false,
+            Buffer::Sub { parent, .. } => parent.readonly(),
+        }
+    }
+
     /// The root exporter object whose storage this buffer reads/writes; a
     /// `Sub` reports its parent's exporter (`SubBuffer` has no `.obj` of its
     /// own).

--- a/pyre/pyre-object/src/bufferview.rs
+++ b/pyre/pyre-object/src/bufferview.rs
@@ -106,6 +106,27 @@ pub enum BufferView {
         length: i64,
         readonly: bool,
     },
+    /// `SimpleView` (`pypy/interpreter/buffer.py:270`) — a plain contiguous
+    /// 1-D byte view (`bytes` / `bytearray`).  Format `'B'`, itemsize 1,
+    /// ndim 1, offset 0, shape `[length]`, strides `[1]` are all derived;
+    /// `readonly` comes from the backing, so nothing but the exporter refs is
+    /// stored.
+    Simple {
+        backing: Buffer,
+        w_obj: PyObjectRef,
+        length: i64,
+    },
+    /// `RawBufferView` (`buffer.py:231`) — a typed contiguous 1-D view
+    /// (`array.array`).  Format / itemsize are explicit; ndim 1, offset 0,
+    /// shape `[length / itemsize]` (`[0]` when empty), strides `[itemsize]`
+    /// derive; `readonly` comes from the backing.
+    Raw {
+        backing: Buffer,
+        w_obj: PyObjectRef,
+        w_fmt: PyObjectRef,
+        itemsize: i64,
+        length: i64,
+    },
 }
 
 impl BufferView {
@@ -113,65 +134,132 @@ impl BufferView {
     #[inline]
     pub fn backing(&self) -> &Buffer {
         match self {
-            BufferView::Strided { backing, .. } => backing,
+            BufferView::Strided { backing, .. }
+            | BufferView::Simple { backing, .. }
+            | BufferView::Raw { backing, .. } => backing,
         }
     }
     /// The exporter reported by `memoryview.obj`.
     #[inline]
     pub fn w_obj(&self) -> PyObjectRef {
         match self {
-            BufferView::Strided { w_obj, .. } => *w_obj,
+            BufferView::Strided { w_obj, .. }
+            | BufferView::Simple { w_obj, .. }
+            | BufferView::Raw { w_obj, .. } => *w_obj,
         }
     }
-    /// Format string object (`memoryview.format`).
+    /// The element format string (`getformat`), read natively — the callers
+    /// that need a Python `str` wrap a fresh one at the `descr` boundary.  A
+    /// `Simple` view derives `'B'`; a `Raw` view reads its explicit format.
+    ///
+    /// # Safety
+    /// The view's stored format object must be a live `str`.
     #[inline]
-    pub fn w_format(&self) -> PyObjectRef {
-        match self {
-            BufferView::Strided { w_format, .. } => *w_format,
+    pub unsafe fn format_str(&self) -> &'static str {
+        unsafe {
+            match self {
+                BufferView::Strided { w_format, .. } => crate::w_str_get_value(*w_format),
+                BufferView::Simple { .. } => "B",
+                BufferView::Raw { w_fmt, .. } => crate::w_str_get_value(*w_fmt),
+            }
         }
     }
-    /// Shape tuple (`memoryview.shape`).
+    /// The per-dimension element counts (`getshape`) as native extents.  A
+    /// `Simple` view is `[length]`; a `Raw` view is `[length / itemsize]`
+    /// (`[0]` when empty, `buffer.py:254`).
+    ///
+    /// # Safety
+    /// The view's stored shape object must be a live tuple of ints.
     #[inline]
-    pub fn w_shape(&self) -> PyObjectRef {
-        match self {
-            BufferView::Strided { w_shape, .. } => *w_shape,
+    pub unsafe fn native_shape(&self) -> Vec<i64> {
+        unsafe {
+            match self {
+                BufferView::Strided { w_shape, .. } => read_dims(*w_shape),
+                BufferView::Simple { length, .. } => vec![*length],
+                BufferView::Raw {
+                    itemsize, length, ..
+                } => {
+                    if *length == 0 {
+                        vec![0]
+                    } else {
+                        vec![*length / *itemsize]
+                    }
+                }
+            }
         }
     }
-    /// Strides tuple (`memoryview.strides`).
+    /// The per-dimension byte steps (`getstrides`) as native extents.  A
+    /// `Simple` view is `[1]`; a `Raw` view is `[itemsize]`.
+    ///
+    /// # Safety
+    /// The view's stored strides object must be a live tuple of ints.
     #[inline]
-    pub fn w_strides(&self) -> PyObjectRef {
-        match self {
-            BufferView::Strided { w_strides, .. } => *w_strides,
+    pub unsafe fn native_strides(&self) -> Vec<i64> {
+        unsafe {
+            match self {
+                BufferView::Strided { w_strides, .. } => read_dims(*w_strides),
+                BufferView::Simple { .. } => vec![1],
+                BufferView::Raw { itemsize, .. } => vec![*itemsize],
+            }
+        }
+    }
+    /// `strides[0]` — the signed byte step between consecutive elements of a
+    /// 1-D view, falling back to `itemsize` when the strides are empty.
+    ///
+    /// # Safety
+    /// The view's stored strides object must be a live tuple of ints.
+    #[inline]
+    pub unsafe fn stride0(&self) -> i64 {
+        unsafe {
+            match self {
+                BufferView::Strided {
+                    w_strides,
+                    itemsize,
+                    ..
+                } => crate::tupleobject::w_tuple_getitem(*w_strides, 0)
+                    .map(|s| crate::intobject::w_int_get_value(s))
+                    .unwrap_or(*itemsize),
+                BufferView::Simple { .. } => 1,
+                BufferView::Raw { itemsize, .. } => *itemsize,
+            }
         }
     }
     #[inline]
     pub fn itemsize(&self) -> i64 {
         match self {
-            BufferView::Strided { itemsize, .. } => *itemsize,
+            BufferView::Strided { itemsize, .. } | BufferView::Raw { itemsize, .. } => *itemsize,
+            BufferView::Simple { .. } => 1,
         }
     }
     #[inline]
     pub fn ndim(&self) -> i64 {
         match self {
             BufferView::Strided { ndim, .. } => *ndim,
+            BufferView::Simple { .. } | BufferView::Raw { .. } => 1,
         }
     }
     #[inline]
     pub fn offset(&self) -> i64 {
         match self {
             BufferView::Strided { offset, .. } => *offset,
+            BufferView::Simple { .. } | BufferView::Raw { .. } => 0,
         }
     }
     #[inline]
     pub fn length(&self) -> i64 {
         match self {
-            BufferView::Strided { length, .. } => *length,
+            BufferView::Strided { length, .. }
+            | BufferView::Simple { length, .. }
+            | BufferView::Raw { length, .. } => *length,
         }
     }
     #[inline]
     pub fn readonly(&self) -> bool {
         match self {
             BufferView::Strided { readonly, .. } => *readonly,
+            BufferView::Simple { backing, .. } | BufferView::Raw { backing, .. } => {
+                backing.readonly()
+            }
         }
     }
 
@@ -186,32 +274,25 @@ impl BufferView {
     /// tagged kind.
     pub unsafe fn gather(&self) -> Vec<u8> {
         unsafe {
-            let BufferView::Strided {
-                backing,
-                w_shape,
-                w_strides,
-                itemsize,
-                ndim,
-                offset,
-                length,
-                ..
-            } = self;
-            let full = backing.as_bytes();
-            let isz = (*itemsize).max(0) as usize;
-            if *ndim == 0 {
+            let itemsize = self.itemsize();
+            let ndim = self.ndim();
+            let offset = self.offset();
+            let full = self.backing().as_bytes();
+            let isz = itemsize.max(0) as usize;
+            if ndim == 0 {
                 let mut out = Vec::with_capacity(isz);
-                copy_base(full, *offset, isz, &mut out);
+                copy_base(full, offset, isz, &mut out);
                 return out;
             }
-            let shape = read_dims(*w_shape);
-            let strides = read_dims(*w_strides);
-            let count = if *itemsize > 0 {
-                *length / *itemsize
+            let shape = self.native_shape();
+            let strides = self.native_strides();
+            let count = if itemsize > 0 {
+                self.length() / itemsize
             } else {
                 0
             };
             let mut out = Vec::with_capacity(count.max(0) as usize * isz);
-            copy_rec(full, &shape, &strides, *ndim, 0, *offset, isz, &mut out);
+            copy_rec(full, &shape, &strides, ndim, 0, offset, isz, &mut out);
             out
         }
     }

--- a/pyre/pyre-object/src/memoryview.rs
+++ b/pyre/pyre-object/src/memoryview.rs
@@ -198,3 +198,51 @@ pub unsafe fn w_memoryview_stride0(obj: PyObjectRef) -> i64 {
         }
     }
 }
+
+/// Read a shape / strides tuple into native `i64` extents.
+///
+/// # Safety
+/// `t` must point to a valid tuple of ints.
+unsafe fn read_tuple_ints(t: PyObjectRef) -> Vec<i64> {
+    unsafe {
+        let n = crate::tupleobject::w_tuple_len(t);
+        (0..n)
+            .map(|i| {
+                crate::tupleobject::w_tuple_getitem(t, i as i64)
+                    .map(|w| crate::intobject::w_int_get_value(w))
+                    .unwrap_or(0)
+            })
+            .collect()
+    }
+}
+
+/// The view's format string content (`memoryview.format`) read without
+/// allocating a fresh string object — the native counterpart of
+/// [`w_memoryview_format`] for callers that only need the bytes.
+///
+/// # Safety
+/// `obj` must point to a valid `W_MemoryView`.
+#[inline]
+pub unsafe fn w_memoryview_format_str(obj: PyObjectRef) -> &'static str {
+    unsafe { crate::w_str_get_value(w_memoryview_view(obj).w_format()) }
+}
+
+/// The view's shape as native `i64` extents (the native counterpart of
+/// [`w_memoryview_shape`]).
+///
+/// # Safety
+/// `obj` must point to a valid `W_MemoryView`.
+#[inline]
+pub unsafe fn w_memoryview_native_shape(obj: PyObjectRef) -> Vec<i64> {
+    unsafe { read_tuple_ints(w_memoryview_view(obj).w_shape()) }
+}
+
+/// The view's strides as native `i64` byte steps (the native counterpart of
+/// [`w_memoryview_strides`]).
+///
+/// # Safety
+/// `obj` must point to a valid `W_MemoryView`.
+#[inline]
+pub unsafe fn w_memoryview_native_strides(obj: PyObjectRef) -> Vec<i64> {
+    unsafe { read_tuple_ints(w_memoryview_view(obj).w_strides()) }
+}

--- a/pyre/pyre-object/src/memoryview.rs
+++ b/pyre/pyre-object/src/memoryview.rs
@@ -141,9 +141,6 @@ pub unsafe fn w_memoryview_backing(obj: PyObjectRef) -> PyObjectRef {
 }
 
 mv_view_obj!(w_memoryview_obj, w_obj);
-mv_view_obj!(w_memoryview_format, w_format);
-mv_view_obj!(w_memoryview_shape, w_shape);
-mv_view_obj!(w_memoryview_strides, w_strides);
 mv_view_scalar!(w_memoryview_itemsize, itemsize, i64);
 mv_view_scalar!(w_memoryview_ndim, ndim, i64);
 mv_view_scalar!(w_memoryview_offset, offset, i64);
@@ -190,59 +187,33 @@ pub unsafe fn w_memoryview_set_released(obj: PyObjectRef) {
 /// `obj` must point to a valid `W_MemoryView`.
 #[inline]
 pub unsafe fn w_memoryview_stride0(obj: PyObjectRef) -> i64 {
-    unsafe {
-        let view = w_memoryview_view(obj);
-        match crate::tupleobject::w_tuple_getitem(view.w_strides(), 0) {
-            Some(s) => crate::intobject::w_int_get_value(s),
-            None => view.itemsize(),
-        }
-    }
-}
-
-/// Read a shape / strides tuple into native `i64` extents.
-///
-/// # Safety
-/// `t` must point to a valid tuple of ints.
-unsafe fn read_tuple_ints(t: PyObjectRef) -> Vec<i64> {
-    unsafe {
-        let n = crate::tupleobject::w_tuple_len(t);
-        (0..n)
-            .map(|i| {
-                crate::tupleobject::w_tuple_getitem(t, i as i64)
-                    .map(|w| crate::intobject::w_int_get_value(w))
-                    .unwrap_or(0)
-            })
-            .collect()
-    }
+    unsafe { w_memoryview_view(obj).stride0() }
 }
 
 /// The view's format string content (`memoryview.format`) read without
-/// allocating a fresh string object — the native counterpart of
-/// [`w_memoryview_format`] for callers that only need the bytes.
+/// wrapping a fresh string object — for callers that only need the bytes.
 ///
 /// # Safety
 /// `obj` must point to a valid `W_MemoryView`.
 #[inline]
 pub unsafe fn w_memoryview_format_str(obj: PyObjectRef) -> &'static str {
-    unsafe { crate::w_str_get_value(w_memoryview_view(obj).w_format()) }
+    unsafe { w_memoryview_view(obj).format_str() }
 }
 
-/// The view's shape as native `i64` extents (the native counterpart of
-/// [`w_memoryview_shape`]).
+/// The view's shape as native `i64` extents (`memoryview.shape`).
 ///
 /// # Safety
 /// `obj` must point to a valid `W_MemoryView`.
 #[inline]
 pub unsafe fn w_memoryview_native_shape(obj: PyObjectRef) -> Vec<i64> {
-    unsafe { read_tuple_ints(w_memoryview_view(obj).w_shape()) }
+    unsafe { w_memoryview_view(obj).native_shape() }
 }
 
-/// The view's strides as native `i64` byte steps (the native counterpart of
-/// [`w_memoryview_strides`]).
+/// The view's strides as native `i64` byte steps (`memoryview.strides`).
 ///
 /// # Safety
 /// `obj` must point to a valid `W_MemoryView`.
 #[inline]
 pub unsafe fn w_memoryview_native_strides(obj: PyObjectRef) -> Vec<i64> {
-    unsafe { read_tuple_ints(w_memoryview_view(obj).w_strides()) }
+    unsafe { w_memoryview_view(obj).native_strides() }
 }


### PR DESCRIPTION
Two independent, self-contained changes on `charon`.

## 1. memoryview: native geometry for view construction (#264)

Foundation for the next `BufferView` de-flatten step (Simple/Raw peel). `w_memoryview_alloc` now takes native geometry (`fmt: &str`, `shape`/`strides: &[i64]`) and builds the format/shape/strides Python objects **inside** the rooted region — each is pinned, then re-read from the shadow stack after the header allocation. Callers no longer hold an unrooted format/shape/strides object across the construction call, removing a latent build-then-pass GC hazard at the plain/slice/cast sites.

All six construction sites (plain / copy / slice / cast-1D / cast-ND / toreadonly) pass native values; eager pre-call tuple/str builds are removed. `copy` and `toreadonly` read the source view's geometry through three new native accessors (`w_memoryview_format_str` / `w_memoryview_native_shape` / `w_memoryview_native_strides`).

Behavior-preserving — the view stays `Strided`.

## 2. rtyper: bucket setbinding-backwards fails as union-ADT (#346)

Diagnostic classification only, no runtime effect. `classify_unported_reason` (census histogram) had no arm for the `setbinding: new value does not contain old` failure, so `unary_invert` / `unary_negative` / `descroperation::{invert,neg}` fell into UNCLASSIFIED. Their `SomeInteger.knowntypedata` inner annotation refines from a generic `Option` to a per-instantiation `Option<Result<*mut PyObject, PyError>>` classdef between fixpoint passes — the same per-instantiation classdef monotonicity carried by the `mergeinputargs` UnionError failures, one lattice step later. Routed to the same UNION-ERROR bucket.

## Verification

| Gate | Result |
|---|---|
| `check.py` cranelift | 159/159 |
| `check.py` wasm | 159/159 |
| `check.py` dynasm | 158/159 (sole miss = `nested_loop` perf-gate flake, memoryview-unrelated, load-sensitive; persists at timeout-scale 3) |
| 6-path memoryview GC-stress probe (nursery churn + `gc.collect()`) | byte-exact on dynasm + cranelift |
| `builtin_memoryview.py` acceptance | exit 0 on dynasm + cranelift |
| `cargo test -p pyre-object` | 206/206 |

— *commented by Claude*
