### PR TITLE
jit: #73 — walker-as-JitCode-cursor: per-op + branch-guard resume carry, py_pc deletion at branch decode

### DIFF
--- a/majit/majit-ir/src/resumedata.rs
+++ b/majit/majit-ir/src/resumedata.rs
@@ -638,15 +638,22 @@ mod after_residual_call_pc_tests {
 
 #[cfg(test)]
 mod branch_orgpc_tag_tests {
-    use super::{
-        BRANCH_ORGPC_MAX, NO_JITCODE_PC, decode_branch_orgpc, encode_branch_orgpc,
-    };
+    use super::{BRANCH_ORGPC_MAX, NO_JITCODE_PC, decode_branch_orgpc, encode_branch_orgpc};
 
     #[test]
     fn roundtrips_across_orgpc_and_flavor() {
         // #73 S3.5: every (orgpc, flavor) in range tags into the negative space
         // and decodes back exactly, including the two endpoints.
-        for orgpc in [0usize, 1, 2, 7, 100, 8191, BRANCH_ORGPC_MAX - 1, BRANCH_ORGPC_MAX] {
+        for orgpc in [
+            0usize,
+            1,
+            2,
+            7,
+            100,
+            8191,
+            BRANCH_ORGPC_MAX - 1,
+            BRANCH_ORGPC_MAX,
+        ] {
             for flavor in [false, true] {
                 let word = encode_branch_orgpc(orgpc, flavor);
                 assert!(word <= -2, "tagged word {word} must land in negative space");

--- a/majit/majit-ir/src/resumedata.rs
+++ b/majit/majit-ir/src/resumedata.rs
@@ -93,6 +93,31 @@ pub const AFTER_RESIDUAL_CALL_PC_FLAG: i32 = 1 << 14;
 /// word stays populated for interpreter re-entry / `last_instr`.
 pub const NO_JITCODE_PC: i32 = -1;
 
+/// #73: a depth-0 branch guard's resume word may carry the walk's
+/// arm-independent `-live-` BEFORE anchor (`orgpc`) plus the GuardTrue/False
+/// flavor, tagged into the free negative space of the `jitcode_pc` word
+/// (offsets are >=0, NO_JITCODE_PC is -1). Decode expands it to the block-head
+/// resume marker. `orgpc` must be <= BRANCH_ORGPC_MAX to stay in i16 range.
+pub const BRANCH_ORGPC_MAX: usize = 16382;
+
+/// Tag `orgpc` (+ 1 flavor bit) into the free negative space `[-32767, -2]` of
+/// the `jitcode_pc` word. `orgpc` must be `<= BRANCH_ORGPC_MAX`.
+pub const fn encode_branch_orgpc(orgpc: usize, flavor_guard_true: bool) -> i32 {
+    // orgpc in [0, BRANCH_ORGPC_MAX], 1 flavor bit -> [-32767, -2]
+    -2 - (((orgpc as i32) << 1) | (flavor_guard_true as i32))
+}
+
+/// Inverse of [`encode_branch_orgpc`]. Returns `Some((orgpc, flavor))` for a
+/// tagged word (`<= -2`), `None` for offsets (`>= 0`) and NO_JITCODE_PC (`-1`).
+pub const fn decode_branch_orgpc(word: i32) -> Option<(usize, bool)> {
+    if word <= -2 {
+        let v = (-2 - word) as usize;
+        Some((v >> 1, (v & 1) == 1))
+    } else {
+        None
+    }
+}
+
 /// Fold the after-residual-call marker into a snapshot frame pc word.
 /// `pc` must be a non-negative Python PC `< AFTER_RESIDUAL_CALL_PC_FLAG`.
 /// The bound is enforced in release builds, not only under `debug_assert`,
@@ -608,5 +633,48 @@ mod after_residual_call_pc_tests {
         // a raw pc with bit 14 set is indistinguishable from a marked pc at
         // decode, so an unmarked stored pc >= the flag would be mis-read.
         assert_eq!(decode_resume_pc(AFTER_RESIDUAL_CALL_PC_FLAG), (0, true));
+    }
+}
+
+#[cfg(test)]
+mod branch_orgpc_tag_tests {
+    use super::{
+        BRANCH_ORGPC_MAX, NO_JITCODE_PC, decode_branch_orgpc, encode_branch_orgpc,
+    };
+
+    #[test]
+    fn roundtrips_across_orgpc_and_flavor() {
+        // #73 S3.5: every (orgpc, flavor) in range tags into the negative space
+        // and decodes back exactly, including the two endpoints.
+        for orgpc in [0usize, 1, 2, 7, 100, 8191, BRANCH_ORGPC_MAX - 1, BRANCH_ORGPC_MAX] {
+            for flavor in [false, true] {
+                let word = encode_branch_orgpc(orgpc, flavor);
+                assert!(word <= -2, "tagged word {word} must land in negative space");
+                assert_eq!(decode_branch_orgpc(word), Some((orgpc, flavor)));
+            }
+        }
+    }
+
+    #[test]
+    fn tagged_words_stay_in_i16_range() {
+        // The word is serialized by `append_int`, which asserts i16 range.
+        for orgpc in [0usize, BRANCH_ORGPC_MAX] {
+            for flavor in [false, true] {
+                let word = encode_branch_orgpc(orgpc, flavor);
+                assert!(
+                    word >= i16::MIN as i32 && word <= i16::MAX as i32,
+                    "tagged word {word} out of i16 range"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn non_tagged_words_decode_none() {
+        // Offsets (>=0) and NO_JITCODE_PC (-1) are NOT tagged: decode returns
+        // None so the expand at decode is a pure no-op for them.
+        for word in [0, 5, 32767, NO_JITCODE_PC] {
+            assert_eq!(decode_branch_orgpc(word), None);
+        }
     }
 }

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -3800,16 +3800,17 @@ impl<S: JitState> JitDriver<S> {
             let src = exit_layout.source_op_index;
             let (result, flavor) = match src {
                 None => ("nosrc", "-"),
-                Some(idx) => match self.meta.exit_guard_opcode(
-                    exit_layout.rd_loop_token,
-                    trace_id,
-                    idx,
-                ) {
-                    Some(majit_ir::OpCode::GuardTrue) => ("branch", "T"),
-                    Some(majit_ir::OpCode::GuardFalse) => ("branch", "F"),
-                    Some(_other) => ("nonbranch", "-"),
-                    None => ("nosrc", "-"),
-                },
+                Some(idx) => {
+                    match self
+                        .meta
+                        .exit_guard_opcode(exit_layout.rd_loop_token, trace_id, idx)
+                    {
+                        Some(majit_ir::OpCode::GuardTrue) => ("branch", "T"),
+                        Some(majit_ir::OpCode::GuardFalse) => ("branch", "F"),
+                        Some(_other) => ("nonbranch", "-"),
+                        None => ("nosrc", "-"),
+                    }
+                }
             };
             eprintln!(
                 "M73_FLAVOR result={result} flavor={flavor} src={src:?} trace_id={trace_id} fail_index={fail_index}"

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -3792,6 +3792,30 @@ impl<S: JitState> JitDriver<S> {
         let should_bridge =
             must_compile && !majit_metainterp::MetaInterp::<S::Meta>::stack_almost_full();
 
+        // gh#73 S3.3: read-only decode-side branch-guard flavor integrity
+        // audit. The GuardTrue/GuardFalse flavor is NOT threaded on the exit
+        // layout; it is recovered from `source_op_index` → the compiled
+        // trace's guard op. Gated OFF by default (byte-identical when unset).
+        if majit_metainterp::m73_flavor_audit_enabled() {
+            let src = exit_layout.source_op_index;
+            let (result, flavor) = match src {
+                None => ("nosrc", "-"),
+                Some(idx) => match self.meta.exit_guard_opcode(
+                    exit_layout.rd_loop_token,
+                    trace_id,
+                    idx,
+                ) {
+                    Some(majit_ir::OpCode::GuardTrue) => ("branch", "T"),
+                    Some(majit_ir::OpCode::GuardFalse) => ("branch", "F"),
+                    Some(_other) => ("nonbranch", "-"),
+                    None => ("nosrc", "-"),
+                },
+            };
+            eprintln!(
+                "M73_FLAVOR result={result} flavor={flavor} src={src:?} trace_id={trace_id} fail_index={fail_index}"
+            );
+        }
+
         // Return raw guard failure data. State restoration and bridge/
         // blackhole decision happen in the caller's handle_fail().
         DetailedDriverRunOutcome::GuardFailure {

--- a/majit/majit-metainterp/src/lib.rs
+++ b/majit/majit-metainterp/src/lib.rs
@@ -154,6 +154,15 @@ pub fn majit_log_enabled() -> bool {
     *ENABLED
 }
 
+/// gh#73 S3.3: whether `PYRE_M73_FLAVOR_AUDIT` is set, cached at first access.
+/// Gates the read-only decode-side branch-guard flavor integrity audit at the
+/// native guard-fail seam. Off by default: byte-identical when unset.
+pub fn m73_flavor_audit_enabled() -> bool {
+    static ENABLED: std::sync::LazyLock<bool> =
+        std::sync::LazyLock::new(|| std::env::var_os("PYRE_M73_FLAVOR_AUDIT").is_some());
+    *ENABLED
+}
+
 /// Strict JIT mode: a non-`InvalidLoop` panic during compilation is a bug and
 /// must fail loudly rather than silently degrade to the interpreter and mask
 /// the bug behind correct output. Enabled in debug builds (`cargo test`) and

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -1842,6 +1842,21 @@ impl<M: Clone> MetaInterp<M> {
             .map(|trace| (trace_id, trace))
     }
 
+    /// gh#73 S3.3: the OpCode of the guard op that produced this exit, resolved
+    /// from the `source_op_index` the fail descriptor / exit layout carries.
+    /// Pure read of the retained compiled trace ops; None if the loop/trace is
+    /// gone or the index is out of range.
+    pub fn exit_guard_opcode(
+        &self,
+        rd_loop_token: u64,
+        trace_id: u64,
+        source_op_index: usize,
+    ) -> Option<majit_ir::OpCode> {
+        let compiled = self.compiled_loops.get(&rd_loop_token)?;
+        let (_, trace) = Self::trace_for_exit(compiled, trace_id)?;
+        trace.ops.get(source_op_index).map(|op| op.opcode)
+    }
+
     /// O(1) owner lookup via `descr.rd_loop_token` (compile.py:186 stamp,
     /// stored as the owning loop's green_key).  Every guard produced by
     /// the regular compile_loop / compile_bridge paths goes through the

--- a/pyre/pyre-jit-trace/src/canonical_bridge.rs
+++ b/pyre/pyre-jit-trace/src/canonical_bridge.rs
@@ -221,6 +221,7 @@ pub fn install_portal_for(code_ptr: *const pyre_interpreter::CodeObject) -> Arc<
             max_stackdepth,
             pcdep_color_slots: Vec::new(),
             const_ref_slots_at_pc: Vec::new(),
+            const_ref_slots_by_jit_pc: Vec::new(),
             // Portal-bridge installs skip the setup-time drain (empty pc_map),
             // so `is_portal_bridge()` reports true.
             is_drained: false,
@@ -421,6 +422,7 @@ def f(x, y):
                 max_stackdepth: 0,
                 pcdep_color_slots: Vec::new(),
                 const_ref_slots_at_pc: Vec::new(),
+                const_ref_slots_by_jit_pc: Vec::new(),
                 // Simulated drain: setup-time drain ran, so is_drained is set.
                 is_drained: true,
             },

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -9656,6 +9656,16 @@ fn branch_resume_target_stack_depth(frame: &ActiveResumeFrame, target: usize) ->
         if pjc.depth_trivia_populated() {
             pjc.depth_trivia_for_jitcode_pc(target)
         } else {
+            // Slice A census: soft, non-aborting count of the py_pc-inversion
+            // fallback (empty depth-trivia twin). Emits ONLY when this arm runs,
+            // so zero output over the corpus == this fallback is dead.
+            if m73_encode_audit_enabled() {
+                eprintln!(
+                    "M73_FALLBACK site=brtsd target={target} is_portal_bridge={} code_null={}",
+                    pjc.is_portal_bridge(),
+                    pjc.code_ptr.is_null()
+                );
+            }
             depth
         }
     }
@@ -9712,6 +9722,15 @@ fn kept_stack_has_boxed_int_hazard(
         let depth_opt = if pjc.depth_trivia_populated() {
             pjc.depth_trivia_for_jitcode_pc(target)
         } else {
+            // Slice A census: soft, non-aborting count of the py_pc-inversion
+            // fallback (empty depth-trivia twin). Zero output == dead.
+            if m73_encode_audit_enabled() {
+                eprintln!(
+                    "M73_FALLBACK site=kshbih target={target} is_portal_bridge={} code_null={}",
+                    pjc.is_portal_bridge(),
+                    pjc.code_ptr.is_null()
+                );
+            }
             depth_opt
         };
         let Some(depth) = depth_opt.map(|d| d as usize) else {
@@ -10006,6 +10025,17 @@ fn branch_resume_target_stack_depth_any_leg(target: usize, jitcode_index: u32) -
     if pjc.depth_trivia_populated() {
         pjc.depth_trivia_for_jitcode_pc(target)
     } else {
+        // Slice A census: soft, non-aborting count of the py_pc-inversion
+        // fallback (empty depth-trivia twin). Highest-risk site — keys on the
+        // caller's `ctx.outer_jitcode_index` (recorded as outer_idx). Zero
+        // output == dead.
+        if m73_encode_audit_enabled() {
+            eprintln!(
+                "M73_FALLBACK site=brtsd_anyleg target={target} outer_idx={jitcode_index} is_portal_bridge={} code_null={}",
+                pjc.is_portal_bridge(),
+                pjc.code_ptr.is_null()
+            );
+        }
         depth_opt
     }
 }

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -9201,6 +9201,18 @@ pub(crate) fn m73_arm_audit_enabled() -> bool {
     *ENABLED.get_or_init(|| std::env::var_os("PYRE_M73_ARM_AUDIT").is_some())
 }
 
+/// `PYRE_M73_FLIP_AUDIT` (#73 S3.4, approach C, default OFF): the flip-gate
+/// certificate. At the branch-guard capture seam it simulates the decode-side
+/// reconstruction of Approach C — author `orgpc` (`ctx.live_before_jit_pc`) and
+/// expand it via `decode_side_other_target` → `skip_python_trivia_forward`
+/// (num_instrs clamp) → `resume_jitcode_pc_for` — and soft-logs whether that
+/// reproduces today's carried coordinate (`marker`) and every consumer's read.
+/// Off in production → byte-identical. Read-only; no asserts.
+pub(crate) fn m73_flip_audit_enabled() -> bool {
+    static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ENABLED.get_or_init(|| std::env::var_os("PYRE_M73_FLIP_AUDIT").is_some())
+}
+
 /// `PYRE_M73_PEROP_CARRY` (#73 S2, default ON): source a specialization
 /// guard's (`GuardValue`/`GuardClass`) resume coordinate from the walk
 /// cursor's per-op `-live-` BEFORE anchor (`ctx.live_before_jit_pc`,
@@ -10767,6 +10779,151 @@ fn walker_capture_snapshot_for_last_guard_impl(
                                     bmaps_eq,
                                     const_eq
                                 );
+                            }
+                        }
+                    }
+                }
+                // #73 S3.4 flip-gate certificate (`PYRE_M73_FLIP_AUDIT`, default
+                // OFF): ahead of the terminal S3.5 flip, simulate the whole
+                // Approach C decode-side reconstruction for a depth-0 branch
+                // guard and soft-log whether it reproduces today's carried
+                // coordinate. Author `orgpc` (the guard's OWN `-live-` BEFORE
+                // anchor, `ctx.live_before_jit_pc`), expand it through the
+                // decode-side arm resolver (`decode_side_other_target`), then run
+                // the SAME py_pc derivation the real capture uses at 10124-10187
+                // (`python_pc_for_jitcode_pc` → `skip_python_trivia_forward` →
+                // num_instrs overshoot clamp; `after_residual_call` is false in
+                // this arm, so the fallthrough / bit-14 leg is intentionally not
+                // replicated) and the marker round-trip (`resume_jitcode_pc_for`).
+                // Reports whether the derived coordinate, its py_pc, its marker,
+                // and every consumer read (liveness banks + bridge maps + const
+                // refill) match the baseline, plus whether the flip's carried word
+                // (`orgpc`) genuinely differs from today's (`marker`). Read-only;
+                // no asserts; the carried `marker` is left untouched.
+                if m73_flip_audit_enabled() {
+                    let is_branch = matches!(
+                        ctx.trace_ctx.last_guard_opcode(),
+                        Some(OpCode::GuardTrue | OpCode::GuardFalse)
+                    );
+                    if is_branch {
+                        let orgpc = ctx.live_before_jit_pc;
+                        match marker {
+                            None => {
+                                eprintln!("M73_FLIP result=nomarker py_pc={py_pc} op_pc={op_pc}");
+                            }
+                            // nolb residual: no `-live-` anchor stepped for this
+                            // guard, so Approach C has no `orgpc` to author from —
+                            // it stays on the marker channel. A non-zero
+                            // nolb-branch bucket is a residual the terminal flip
+                            // (S3.5) keeps on the py_pc round-trip.
+                            Some(_) if orgpc == usize::MAX => {
+                                eprintln!("M73_FLIP result=nolb py_pc={py_pc} op_pc={op_pc}");
+                            }
+                            Some(m) => {
+                                let flavor_guard_true = matches!(
+                                    ctx.trace_ctx.last_guard_opcode(),
+                                    Some(OpCode::GuardTrue)
+                                );
+                                // Range check on the ORIGINAL usize, before any
+                                // narrowing cast into the carried label space.
+                                let range_ok = orgpc <= i16::MAX as usize;
+                                let jc = unsafe { &*sym.jitcode };
+                                let bytes = jc.payload.jitcode.code.as_slice();
+                                match decode_side_other_target(bytes, orgpc, flavor_guard_true) {
+                                    Err(reason) => {
+                                        eprintln!(
+                                            "M73_FLIP result=undecodable reason={reason} \
+                                             orgpc={orgpc} py_pc={py_pc} op_pc={op_pc} \
+                                             range_ok={range_ok}"
+                                        );
+                                    }
+                                    Ok(derived) => {
+                                        // Re-confirms the S3.1 arm claim: the
+                                        // decode-derived coordinate equals the
+                                        // walk's not-taken landing.
+                                        let coord_eq = derived == op_pc;
+                                        // Re-derive py_pc from `derived`, mirroring
+                                        // the real capture derivation exactly:
+                                        // inversion → forward trivia skip →
+                                        // num_instrs overshoot clamp. This arm has
+                                        // `after_residual_call == false`, so the
+                                        // fallthrough / bit-14 leg is not replicated.
+                                        let py_pc_cand = unsafe {
+                                            let meta = &jc.payload.metadata;
+                                            let mut py = python_pc_for_jitcode_pc(meta, derived);
+                                            if !jc.payload.code_ptr.is_null() {
+                                                let code_obj = &*jc.payload.code_ptr;
+                                                py = skip_python_trivia_forward(
+                                                    code_obj,
+                                                    py as usize,
+                                                ) as u32;
+                                            }
+                                            let num_instrs = meta.first_jit_pc_by_py_pc.len();
+                                            if py as usize >= num_instrs {
+                                                ctx.entry_py_pc
+                                            } else {
+                                                py
+                                            }
+                                        };
+                                        let invpp_eq = py_pc_cand == py_pc;
+                                        let flip_marker = jc
+                                            .payload
+                                            .resume_jitcode_pc_for(py_pc_cand as usize);
+                                        let marker_eq = flip_marker == Some(m);
+                                        // Whether the flip's carried word (`orgpc`)
+                                        // genuinely differs from today's (`m`): a
+                                        // vacuous self-source would carry the same
+                                        // value.
+                                        let flip_changes_word = orgpc != m;
+                                        // Per-consumer read at the candidate
+                                        // (py_pc_cand, flip_marker) vs the baseline
+                                        // (py_pc, m).
+                                        let ji = jitcode_index as i32;
+                                        let pp_b = py_pc as i32;
+                                        let pp_c = py_pc_cand as i32;
+                                        let jm_b = m as i32;
+                                        let jm_c = flip_marker
+                                            .map(|x| x as i32)
+                                            .unwrap_or(majit_ir::resumedata::NO_JITCODE_PC);
+                                        let banks_b =
+                                            crate::state::frame_liveness_reg_indices_by_bank_at_with_jitcode_pc(
+                                                ji, pp_b, jm_b,
+                                            );
+                                        let banks_c =
+                                            crate::state::frame_liveness_reg_indices_by_bank_at_with_jitcode_pc(
+                                                ji, pp_c, jm_c,
+                                            );
+                                        let banks_eq = banks_b.int == banks_c.int
+                                            && banks_b.ref_ == banks_c.ref_
+                                            && banks_b.float == banks_c.float;
+                                        let bm_b =
+                                            crate::state::bridge_semantic_maps_at_with_jitcode_pc(
+                                                ji, pp_b, jm_b,
+                                            );
+                                        let bm_c =
+                                            crate::state::bridge_semantic_maps_at_with_jitcode_pc(
+                                                ji, pp_c, jm_c,
+                                            );
+                                        let bmaps_eq = bm_b.stack_depth_at_pc
+                                            == bm_c.stack_depth_at_pc
+                                            && bm_b.pcdep_entries == bm_c.pcdep_entries;
+                                        let const_eq =
+                                            crate::state::const_ref_slots_at_pc_at(ji, pp_b, jm_b)
+                                                == crate::state::const_ref_slots_at_pc_at(
+                                                    ji, pp_c, jm_c,
+                                                );
+                                        eprintln!(
+                                            "M73_FLIP result=recon orgpc={orgpc} op_pc={op_pc} \
+                                             derived={derived} coord_eq={coord_eq} py_pc={py_pc} \
+                                             py_pc_cand={py_pc_cand} invpp_eq={invpp_eq} \
+                                             marker={m} flip_marker={flip_marker:?} \
+                                             marker_eq={marker_eq} \
+                                             flip_changes_word={flip_changes_word} \
+                                             range_ok={range_ok} banks_eq={banks_eq} \
+                                             bmaps_eq={bmaps_eq} const_eq={const_eq}"
+                                        );
+                                    }
+                                }
                             }
                         }
                     }

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -9235,6 +9235,22 @@ pub(crate) fn m73_perop_carry_enabled() -> bool {
     })
 }
 
+/// `PYRE_M73_BRANCH_CARRY` (#73 S3.5, default OFF): the terminal branch-guard
+/// flip. A depth-0 `GuardTrue`/`GuardFalse` sources its resume word from the
+/// walk's arm-independent `-live-` BEFORE anchor (`ctx.live_before_jit_pc`,
+/// `orgpc`) TAGGED into the negative space of the `jitcode_pc` word (plus a
+/// 1-bit flavor), instead of the py_pc-keyed `resume_jitcode_pc_for` block-head
+/// marker. Byte-identical by construction: encode carries the tagged word only
+/// when its decode-side expansion ([`expand_branch_carried`]) reproduces the
+/// baseline `marker` (self-cert), and decode expands it back to that same
+/// `marker` before any consumer reads it. Off → encode never emits a tagged
+/// word, so the decode expand is a no-op. Certified by `PYRE_M73_FLIP_AUDIT`
+/// (S3.4) and check.py.
+pub(crate) fn m73_branch_carry_enabled() -> bool {
+    static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ENABLED.get_or_init(|| std::env::var_os("PYRE_M73_BRANCH_CARRY").is_some())
+}
+
 pub(crate) fn python_pc_for_jitcode_pc(metadata: &crate::PyJitCodeMetadata, jit_pc: usize) -> u32 {
     // Exact inverse: `first_jit_pc_by_py_pc[py]` is the byte offset of the
     // FIRST instruction opcode `py` emitted (`usize::MAX` = the PC emitted
@@ -9427,6 +9443,51 @@ fn decode_side_other_target(
     let target = read_label(code, &goto, 1);
     let raw = if flavor_guard_true { target } else { goto.next_pc };
     Ok(resolve_branch_target_through_trampoline(code, raw))
+}
+
+/// #73 S3.5 decode: if `carried` is a tagged branch `orgpc` (negative-space
+/// encoding, [`majit_ir::resumedata::encode_branch_orgpc`]), expand it to the
+/// block-head resume marker exactly as the baseline would have carried it —
+/// `decode_side_other_target` picks the not-taken arm from `orgpc` + flavor,
+/// then the SAME inversion + forward trivia-skip + `resume_jitcode_pc_for` the
+/// real capture used (10166-10191). Non-tagged words (offsets `>= 0`,
+/// `NO_JITCODE_PC`) pass through unchanged, so this is a no-op whenever the flip
+/// is off (`decode_branch_orgpc` returns `None`).
+///
+/// Returns `NO_JITCODE_PC` if the arm cannot be decoded, so the decoder falls
+/// back to the stored `py_pc` path. In particular an OVERSHOOT (`py_pc >=
+/// num_instrs`) is treated as a decode FAILURE rather than guessing the real
+/// capture's `entry_py_pc` clamp target (a per-walk value not available here):
+/// the encode self-cert re-runs this exact function and declines to carry any
+/// tagged word whose reconstruction overshoots, so a genuinely-carried tagged
+/// word never reaches the overshoot leg.
+pub(crate) fn expand_branch_carried(payload: &crate::PyJitCode, carried: i32) -> i32 {
+    match majit_ir::resumedata::decode_branch_orgpc(carried) {
+        None => carried,
+        Some((orgpc, flavor)) => {
+            let code = payload.jitcode.code.as_slice();
+            match decode_side_other_target(code, orgpc, flavor) {
+                Err(_) => majit_ir::resumedata::NO_JITCODE_PC,
+                Ok(derived) => {
+                    let mut py = python_pc_for_jitcode_pc(&payload.metadata, derived);
+                    if !payload.code_ptr.is_null() {
+                        let co = unsafe { &*payload.code_ptr };
+                        py = skip_python_trivia_forward(co, py as usize) as u32;
+                    }
+                    let num_instrs = payload.metadata.first_jit_pc_by_py_pc.len();
+                    if py as usize >= num_instrs {
+                        // Overshoot: the real capture clamps to `ctx.entry_py_pc`
+                        // (a per-walk value absent at decode). Decode-failure →
+                        // py_pc fallback; encode self-cert never tags such a word.
+                        return majit_ir::resumedata::NO_JITCODE_PC;
+                    }
+                    payload
+                        .resume_jitcode_pc_for(py as usize)
+                        .map_or(majit_ir::resumedata::NO_JITCODE_PC, |m| m as i32)
+                }
+            }
+        }
+    }
 }
 
 /// Decode a not-taken branch trampoline's `ref_copy` parallel-move
@@ -10939,7 +11000,45 @@ fn walker_capture_snapshot_for_last_guard_impl(
                 // decode identically for every consumer (banks + bridge maps +
                 // const refill) where the anchor coincides, and flags the
                 // divergent minority for the check.py output-equality gate.
-                if m73_perop_carry_enabled()
+                // #73 S3.5 flip (`PYRE_M73_BRANCH_CARRY`, default OFF): a depth-0
+                // branch guard (`GuardTrue`/`GuardFalse`) carries the walk's
+                // arm-independent `-live-` BEFORE anchor (`ctx.live_before_jit_pc`,
+                // `orgpc`) TAGGED into the negative space of the word plus the
+                // guard flavor, instead of the py_pc-keyed block-head `marker`.
+                // Carried ONLY when the tagged word's decode-side expansion
+                // (`expand_branch_carried`, the same fn every consumer runs)
+                // reproduces today's `marker` (self-cert) — so decode expands it
+                // back to exactly `marker` and the encode is byte-identical by
+                // construction. Requires a stepped `-live-` anchor in i16-tag
+                // range (`BRANCH_ORGPC_MAX`) and a resolvable `marker`; otherwise
+                // fall through to the perop / marker paths unchanged.
+                let flavor_true =
+                    matches!(ctx.trace_ctx.last_guard_opcode(), Some(OpCode::GuardTrue));
+                let is_branch = matches!(
+                    ctx.trace_ctx.last_guard_opcode(),
+                    Some(OpCode::GuardTrue | OpCode::GuardFalse)
+                );
+                if m73_branch_carry_enabled()
+                    && is_branch
+                    && ctx.live_before_jit_pc != usize::MAX
+                    && ctx.live_before_jit_pc <= majit_ir::resumedata::BRANCH_ORGPC_MAX
+                    && marker.is_some()
+                    && {
+                        // Self-certify byte-identity: the tagged word must expand
+                        // back to today's carried `marker`.
+                        let tagged = majit_ir::resumedata::encode_branch_orgpc(
+                            ctx.live_before_jit_pc,
+                            flavor_true,
+                        );
+                        let jc = unsafe { &*sym.jitcode };
+                        expand_branch_carried(&jc.payload, tagged)
+                            == marker
+                                .map(|m| m as i32)
+                                .unwrap_or(majit_ir::resumedata::NO_JITCODE_PC)
+                    }
+                {
+                    majit_ir::resumedata::encode_branch_orgpc(ctx.live_before_jit_pc, flavor_true)
+                } else if m73_perop_carry_enabled()
                     && marker.is_some()
                     && ctx.live_before_jit_pc != usize::MAX
                     && matches!(

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -648,6 +648,17 @@ pub struct WalkContext<'frame, 'static_a: 'frame> {
     /// boundary; read by [`reconcile_vstack_at_boundary`] for the
     /// RESULT-TO-TOS class.
     pub vstack_last_ref: OpRef,
+    /// #73 (SLICE 1, INERT): the jitcode offset of the `-live-` byte that
+    /// precedes the CURRENT opcode's guard resume point — the `-live-`
+    /// BEFORE (`pyjitpl.py:198`, normal guard resume reads at
+    /// `self.pc - SIZE_LIVE_OP`).  Maintained purely from `DecodedOp` by the
+    /// walk; `usize::MAX` until the first `-live-` is seen.  Side-data only.
+    pub live_before_jit_pc: usize,
+    /// #73 (SLICE 1, INERT): the jitcode offset of the `-live-` byte that
+    /// trails a residual-call opcode — the `-live-` AFTER (`pyjitpl.py:195`,
+    /// residual-call guard resume reads at `self.pc`).  Maintained purely
+    /// from `DecodedOp` by the walk; `usize::MAX` until set.  Side-data only.
+    pub live_after_jit_pc: usize,
 }
 
 /// Outcome of dispatching one opcode. The walker uses this to decide
@@ -1342,6 +1353,14 @@ pub fn step(
     ctx: &mut WalkContext<'_, '_>,
 ) -> Result<(DispatchOutcome, usize), DispatchError> {
     let op: DecodedOp = decode_op_at(code, pc).ok_or(DispatchError::UndecodableOpcode { pc })?;
+    // #73 (SLICE 1, INERT): maintain the `-live-` BEFORE anchor.  Every
+    // `-live-` byte the walk decodes becomes the resume point preceding the
+    // NEXT guard (`pyjitpl.py:198`, normal guard resume reads at
+    // `self.pc - SIZE_LIVE_OP`).  `op.pc` is the genuine jitcode offset of
+    // the `-live-` byte.  Side-data only — read under a debug audit gate.
+    if op.opname == "live" {
+        ctx.live_before_jit_pc = op.pc;
+    }
     // #73 (SLICE 1, INERT): maintain the walk-level operand-stack box
     // mirror.  Detects a Python-opcode boundary at this jitcode pc and
     // reconciles the previous opcode's stack effect into `ctx.vstack_boxes`
@@ -2520,6 +2539,8 @@ pub fn dispatch_via_miframe(
             vstack_cur_pypc: 0,
             vstack_valid: false,
             vstack_last_ref: OpRef::NONE,
+            live_before_jit_pc: usize::MAX,
+            live_after_jit_pc: usize::MAX,
         };
         // #73 (SLICE 1, INERT): seed the walk-level operand-stack box mirror
         // at entry.  The mirror is only enabled when the outer sym owns the
@@ -2821,6 +2842,8 @@ pub(crate) fn drive_bridge_carrier_subwalk(
             vstack_cur_pypc: 0,
             vstack_valid: false,
             vstack_last_ref: OpRef::NONE,
+            live_before_jit_pc: usize::MAX,
+            live_after_jit_pc: usize::MAX,
             trace_ctx: ctx,
             done_with_this_frame_descr_ref: done_ref,
             done_with_this_frame_descr_int: done_int,
@@ -3073,6 +3096,8 @@ pub(crate) fn drive_outer_frame_continuation(
             vstack_cur_pypc: 0,
             vstack_valid: false,
             vstack_last_ref: OpRef::NONE,
+            live_before_jit_pc: usize::MAX,
+            live_after_jit_pc: usize::MAX,
             trace_ctx: ctx,
             done_with_this_frame_descr_ref: done_ref,
             done_with_this_frame_descr_int: done_int,
@@ -3300,6 +3325,8 @@ pub fn dispatch_via_miframe_at_opcode_entry<'a>(
             vstack_cur_pypc: 0,
             vstack_valid: false,
             vstack_last_ref: OpRef::NONE,
+            live_before_jit_pc: usize::MAX,
+            live_after_jit_pc: usize::MAX,
         };
         let outcome = walk(entry_jitcode.code.as_slice(), 0, &mut wc);
         let final_last_exc = wc.last_exc_value;
@@ -9125,6 +9152,18 @@ pub(crate) fn m73_liveness_audit_enabled() -> bool {
     *ENABLED.get_or_init(|| std::env::var_os("PYRE_M73_LIVENESS_AUDIT").is_some())
 }
 
+/// `PYRE_M73_ANCHOR_AUDIT` enables the assertion that the walk-maintained
+/// `-live-` BEFORE anchor (`ctx.live_before_jit_pc`, updated from every
+/// decoded `-live-` op) equals the py-keyed resume marker the encoder
+/// resolves via `resume_jitcode_pc_for(py_pc)` at the normal-family guard arm
+/// (`pyjitpl.py:198`, normal guard resume reads at `self.pc - SIZE_LIVE_OP`).
+/// Certifies the precondition for re-sourcing that marker off the walk-level
+/// cursor without the py_pc channel. Diagnostic only; off in production.
+pub(crate) fn m73_anchor_audit_enabled() -> bool {
+    static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ENABLED.get_or_init(|| std::env::var_os("PYRE_M73_ANCHOR_AUDIT").is_some())
+}
+
 pub(crate) fn python_pc_for_jitcode_pc(metadata: &crate::PyJitCodeMetadata, jit_pc: usize) -> u32 {
     // Exact inverse: `first_jit_pc_by_py_pc[py]` is the byte offset of the
     // FIRST instruction opcode `py` emitted (`usize::MAX` = the PC emitted
@@ -10462,6 +10501,21 @@ fn walker_capture_snapshot_for_last_guard_impl(
                     let jc = &*sym.jitcode;
                     jc.payload.resume_jitcode_pc_for(py_pc as usize)
                 };
+                // #73 (SLICE 1): certificate for the later cursor flip (S3).
+                // The walk-maintained `-live-` BEFORE anchor must equal the
+                // py-keyed resume marker the encoder resolves here
+                // (`pyjitpl.py:198`).  Read-only: `marker` is still consumed
+                // unchanged by the match below.
+                if m73_anchor_audit_enabled() && ctx.live_before_jit_pc != usize::MAX {
+                    debug_assert_eq!(
+                        Some(ctx.live_before_jit_pc),
+                        marker,
+                        "#73 anchor mismatch: live_before={} py_pc={} marker={:?}",
+                        ctx.live_before_jit_pc,
+                        py_pc,
+                        marker
+                    );
+                }
                 match marker {
                     Some(jp) => jp as i32,
                     None => majit_ir::resumedata::NO_JITCODE_PC,
@@ -12990,6 +13044,8 @@ fn try_walker_inline_user_call(
             vstack_cur_pypc: 0,
             vstack_valid: false,
             vstack_last_ref: OpRef::NONE,
+            live_before_jit_pc: usize::MAX,
+            live_after_jit_pc: usize::MAX,
             trace_ctx: ctx.trace_ctx,
             done_with_this_frame_descr_ref: ctx.done_with_this_frame_descr_ref.clone(),
             done_with_this_frame_descr_int: ctx.done_with_this_frame_descr_int.clone(),
@@ -13691,6 +13747,13 @@ fn dispatch_residual_call_iRd_kind(
         // `PyError::runtime_error("ABORT_ESCAPE: ...")` before walker IR
         // diff would run.
         if emit_guard_not_forced {
+            // #73 (SLICE 1, INERT): maintain the `-live-` AFTER anchor.  A
+            // residual-call guard reads its resume point at `self.pc` (the
+            // `-live-` trailing the call, `pyjitpl.py:195`).  `op.next_pc` is
+            // the first byte after the residual_call opcode, which the
+            // `[funcptr, Call, -live-]` layout (jitcode.rs:565) makes the
+            // trailing `-live-` byte.  Side-data only.
+            ctx.live_after_jit_pc = op.next_pc;
             ctx.trace_ctx.record_guard(OpCode::GuardNotForced, &[], 0);
             walker_capture_snapshot_for_last_guard(ctx, op.pc)?;
         }
@@ -18898,6 +18961,8 @@ fn run_sub_jitcode_walk(
             vstack_cur_pypc: 0,
             vstack_valid: false,
             vstack_last_ref: OpRef::NONE,
+            live_before_jit_pc: usize::MAX,
+            live_after_jit_pc: usize::MAX,
         };
         walk(sub_body.code, 0, &mut sub_wc)?
     };
@@ -21346,6 +21411,8 @@ mod tests {
             vstack_cur_pypc: 0,
             vstack_valid: false,
             vstack_last_ref: OpRef::NONE,
+            live_before_jit_pc: usize::MAX,
+            live_after_jit_pc: usize::MAX,
         };
 
         // Synthesize a 2-byte op fixture: `<opcode_byte> <reg_idx>`.
@@ -21409,6 +21476,8 @@ mod tests {
             vstack_cur_pypc: 0,
             vstack_valid: false,
             vstack_last_ref: OpRef::NONE,
+            live_before_jit_pc: usize::MAX,
+            live_after_jit_pc: usize::MAX,
         };
         // `getfield_vable_i/rd>i`: operand 0 (the box) sits at code[pc+1].
         let code = [0u8, 0x00, 0x00, 0x00, 0x00];
@@ -21462,6 +21531,8 @@ mod tests {
             vstack_cur_pypc: 0,
             vstack_valid: false,
             vstack_last_ref: OpRef::NONE,
+            live_before_jit_pc: usize::MAX,
+            live_after_jit_pc: usize::MAX,
         };
         // `setfield_vable_i/rid`: operand 0 (the box) sits at code[pc+1].
         let code = [0u8, 0x00, 0x00, 0x00, 0x00];
@@ -21533,6 +21604,8 @@ mod tests {
                 vstack_cur_pypc: 0,
                 vstack_valid: false,
                 vstack_last_ref: OpRef::NONE,
+            live_before_jit_pc: usize::MAX,
+            live_after_jit_pc: usize::MAX,
             };
             let op = DecodedOp {
                 key,
@@ -21715,6 +21788,8 @@ mod tests {
             vstack_cur_pypc: 0,
             vstack_valid: false,
             vstack_last_ref: OpRef::NONE,
+            live_before_jit_pc: usize::MAX,
+            live_after_jit_pc: usize::MAX,
         };
 
         let (outcome, next_pc) = step(&code, 0, &mut wc).expect("switch hit must dispatch");
@@ -21769,6 +21844,8 @@ mod tests {
             vstack_cur_pypc: 0,
             vstack_valid: false,
             vstack_last_ref: OpRef::NONE,
+            live_before_jit_pc: usize::MAX,
+            live_after_jit_pc: usize::MAX,
         };
 
         let (outcome, next_pc) = step(&code, 0, &mut wc).expect("switch miss must dispatch");
@@ -21822,6 +21899,8 @@ mod tests {
             vstack_cur_pypc: 0,
             vstack_valid: false,
             vstack_last_ref: OpRef::NONE,
+            live_before_jit_pc: usize::MAX,
+            live_after_jit_pc: usize::MAX,
         };
 
         let err = step(&code, 0, &mut wc).expect_err("non-constant switch value must not guess");
@@ -21884,6 +21963,8 @@ mod tests {
             vstack_cur_pypc: 0,
             vstack_valid: false,
             vstack_last_ref: OpRef::NONE,
+            live_before_jit_pc: usize::MAX,
+            live_after_jit_pc: usize::MAX,
         };
 
         let (outcome, next_pc) = step(&code, 0, &mut wc).expect("truthy branch must dispatch");
@@ -21938,6 +22019,8 @@ mod tests {
             vstack_cur_pypc: 0,
             vstack_valid: false,
             vstack_last_ref: OpRef::NONE,
+            live_before_jit_pc: usize::MAX,
+            live_after_jit_pc: usize::MAX,
         };
 
         let (outcome, next_pc) = step(&code, 0, &mut wc).expect("falsy branch must dispatch");
@@ -21991,6 +22074,8 @@ mod tests {
             vstack_cur_pypc: 0,
             vstack_valid: false,
             vstack_last_ref: OpRef::NONE,
+            live_before_jit_pc: usize::MAX,
+            live_after_jit_pc: usize::MAX,
         };
 
         let err = step(&code, 0, &mut wc).expect_err("non-constant branch value must not guess");
@@ -22253,6 +22338,8 @@ mod tests {
             vstack_cur_pypc: 0,
             vstack_valid: false,
             vstack_last_ref: OpRef::NONE,
+            live_before_jit_pc: usize::MAX,
+            live_after_jit_pc: usize::MAX,
         };
         fbw_finish_payload_reset();
         let (outcome, end_pc) =
@@ -22419,6 +22506,8 @@ mod tests {
             vstack_cur_pypc: 0,
             vstack_valid: false,
             vstack_last_ref: OpRef::NONE,
+            live_before_jit_pc: usize::MAX,
+            live_after_jit_pc: usize::MAX,
         };
         let (outcome, next_pc) =
             step(&caller_code, 0, &mut wc).expect("inline_call_r_i must dispatch");
@@ -22533,6 +22622,8 @@ mod tests {
             vstack_cur_pypc: 0,
             vstack_valid: false,
             vstack_last_ref: OpRef::NONE,
+            live_before_jit_pc: usize::MAX,
+            live_after_jit_pc: usize::MAX,
         };
         let (outcome, next_pc) =
             step(&caller_code, 0, &mut wc).expect("inline_call_ir_r must dispatch");
@@ -22641,6 +22732,8 @@ mod tests {
             vstack_cur_pypc: 0,
             vstack_valid: false,
             vstack_last_ref: OpRef::NONE,
+            live_before_jit_pc: usize::MAX,
+            live_after_jit_pc: usize::MAX,
         };
         let (outcome, next_pc) =
             step(&caller_code, 0, &mut wc).expect("inline_call_irf_r must dispatch");
@@ -22738,6 +22831,8 @@ mod tests {
             vstack_cur_pypc: 0,
             vstack_valid: false,
             vstack_last_ref: OpRef::NONE,
+            live_before_jit_pc: usize::MAX,
+            live_after_jit_pc: usize::MAX,
         };
         let err =
             step(&caller_code, 0, &mut wc).expect_err("I-list overflow must surface typed error");
@@ -22832,6 +22927,8 @@ mod tests {
             vstack_cur_pypc: 0,
             vstack_valid: false,
             vstack_last_ref: OpRef::NONE,
+            live_before_jit_pc: usize::MAX,
+            live_after_jit_pc: usize::MAX,
         };
         let (outcome, _) = walk(&caller_code, 0, &mut wc).expect("caller must walk to terminator");
         assert_eq!(
@@ -22907,6 +23004,8 @@ mod tests {
             vstack_cur_pypc: 0,
             vstack_valid: false,
             vstack_last_ref: OpRef::NONE,
+            live_before_jit_pc: usize::MAX,
+            live_after_jit_pc: usize::MAX,
         };
         let err = step(&caller_code, 0, &mut wc)
             .expect_err("FailDescr at inline_call's d-slot must hit ExpectedJitCodeDescr");
@@ -22961,6 +23060,8 @@ mod tests {
             vstack_cur_pypc: 0,
             vstack_valid: false,
             vstack_last_ref: OpRef::NONE,
+            live_before_jit_pc: usize::MAX,
+            live_after_jit_pc: usize::MAX,
         };
         let err = step(&caller_code, 0, &mut wc)
             .expect_err("missing sub-jitcode must hit SubJitCodeNotFound");
@@ -23011,6 +23112,8 @@ mod tests {
             vstack_cur_pypc: 0,
             vstack_valid: false,
             vstack_last_ref: OpRef::NONE,
+            live_before_jit_pc: usize::MAX,
+            live_after_jit_pc: usize::MAX,
         };
         let (outcome, next_pc) = step(&code, 0, &mut wc).expect("live/ must dispatch");
         assert_eq!(outcome, DispatchOutcome::Continue);
@@ -23070,6 +23173,8 @@ mod tests {
             vstack_cur_pypc: 0,
             vstack_valid: false,
             vstack_last_ref: OpRef::NONE,
+            live_before_jit_pc: usize::MAX,
+            live_after_jit_pc: usize::MAX,
         };
         fbw_finish_payload_reset();
         let (outcome, next_pc) = step(&code, 0, &mut wc).expect("ref_return/r must dispatch");
@@ -23127,6 +23232,8 @@ mod tests {
             vstack_cur_pypc: 0,
             vstack_valid: false,
             vstack_last_ref: OpRef::NONE,
+            live_before_jit_pc: usize::MAX,
+            live_after_jit_pc: usize::MAX,
         };
         let err = step(&code, 0, &mut wc).expect_err("must surface RegisterOutOfRange");
         assert_eq!(
@@ -23187,6 +23294,8 @@ mod tests {
             vstack_cur_pypc: 0,
             vstack_valid: false,
             vstack_last_ref: OpRef::NONE,
+            live_before_jit_pc: usize::MAX,
+            live_after_jit_pc: usize::MAX,
         };
         let ops_before = wc.trace_ctx.num_ops();
         fbw_finish_payload_reset();
@@ -23263,6 +23372,8 @@ mod tests {
             vstack_cur_pypc: 0,
             vstack_valid: false,
             vstack_last_ref: OpRef::NONE,
+            live_before_jit_pc: usize::MAX,
+            live_after_jit_pc: usize::MAX,
         };
         let ops_before = wc.trace_ctx.num_ops();
         let (outcome, _) = step(&code, 0, &mut wc).expect("int_return/i must dispatch");
@@ -23327,6 +23438,8 @@ mod tests {
             vstack_cur_pypc: 0,
             vstack_valid: false,
             vstack_last_ref: OpRef::NONE,
+            live_before_jit_pc: usize::MAX,
+            live_after_jit_pc: usize::MAX,
         };
         let ops_before = wc.trace_ctx.num_ops();
         fbw_finish_payload_reset();
@@ -23392,6 +23505,8 @@ mod tests {
             vstack_cur_pypc: 0,
             vstack_valid: false,
             vstack_last_ref: OpRef::NONE,
+            live_before_jit_pc: usize::MAX,
+            live_after_jit_pc: usize::MAX,
         };
         let ops_before = wc.trace_ctx.num_ops();
         let (outcome, _) = step(&code, 0, &mut wc).expect("void_return/ must dispatch");
@@ -23445,6 +23560,8 @@ mod tests {
             vstack_cur_pypc: 0,
             vstack_valid: false,
             vstack_last_ref: OpRef::NONE,
+            live_before_jit_pc: usize::MAX,
+            live_after_jit_pc: usize::MAX,
         };
         let err = step(&code, 0, &mut wc).expect_err("raise/r must read its operand");
         assert_eq!(
@@ -23501,6 +23618,8 @@ mod tests {
             vstack_cur_pypc: 0,
             vstack_valid: false,
             vstack_last_ref: OpRef::NONE,
+            live_before_jit_pc: usize::MAX,
+            live_after_jit_pc: usize::MAX,
         };
         let (outcome, next_pc) = step(&code, 0, &mut wc).expect("goto/L must dispatch");
         assert_eq!(outcome, DispatchOutcome::Continue);
@@ -23557,6 +23676,8 @@ mod tests {
             vstack_cur_pypc: 0,
             vstack_valid: false,
             vstack_last_ref: OpRef::NONE,
+            live_before_jit_pc: usize::MAX,
+            live_after_jit_pc: usize::MAX,
         };
         let (outcome, next_pc) = step(&code, 0, &mut wc).expect("goto/L must dispatch");
         assert_eq!(outcome, DispatchOutcome::Continue);
@@ -23661,6 +23782,8 @@ mod tests {
             vstack_cur_pypc: 0,
             vstack_valid: false,
             vstack_last_ref: OpRef::NONE,
+            live_before_jit_pc: usize::MAX,
+            live_after_jit_pc: usize::MAX,
         };
         let err =
             step(&code, 0, &mut wc).expect_err("catch_exception/L with active exc must error");
@@ -23713,6 +23836,8 @@ mod tests {
             vstack_cur_pypc: 0,
             vstack_valid: false,
             vstack_last_ref: OpRef::NONE,
+            live_before_jit_pc: usize::MAX,
+            live_after_jit_pc: usize::MAX,
         };
         let (outcome, next_pc) = step(&code, 0, &mut wc).expect("catch_exception/L must dispatch");
         assert_eq!(outcome, DispatchOutcome::Continue);
@@ -23778,6 +23903,8 @@ mod tests {
             vstack_cur_pypc: 0,
             vstack_valid: false,
             vstack_last_ref: OpRef::NONE,
+            live_before_jit_pc: usize::MAX,
+            live_after_jit_pc: usize::MAX,
         };
         let (outcome, next_pc) = walk(&code, 0, &mut wc).expect("raise/r must dispatch");
         assert_eq!(outcome, DispatchOutcome::Terminate);
@@ -23875,6 +24002,8 @@ mod tests {
             vstack_cur_pypc: 0,
             vstack_valid: false,
             vstack_last_ref: OpRef::NONE,
+            live_before_jit_pc: usize::MAX,
+            live_after_jit_pc: usize::MAX,
         };
         // `raise/r` emits the GuardClass during dispatch, then surfaces
         // `SubRaise`; `walk()`'s top-level SubRaise arm records the FINISH.
@@ -23956,6 +24085,8 @@ mod tests {
             vstack_cur_pypc: 0,
             vstack_valid: false,
             vstack_last_ref: OpRef::NONE,
+            live_before_jit_pc: usize::MAX,
+            live_after_jit_pc: usize::MAX,
         };
         // With `PYRE_FBW_RAISE` on (default), `reraise/` surfaces
         // `SubRaise` and `walk()`'s top-level SubRaise arm records the
@@ -24032,6 +24163,8 @@ mod tests {
             vstack_cur_pypc: 0,
             vstack_valid: false,
             vstack_last_ref: OpRef::NONE,
+            live_before_jit_pc: usize::MAX,
+            live_after_jit_pc: usize::MAX,
         };
         let err = step(&code, 0, &mut wc).expect_err("reraise/ without last_exc_value must error");
         assert_eq!(err, DispatchError::ReraiseWithoutLastExcValue { pc: 0 });
@@ -24083,6 +24216,8 @@ mod tests {
             vstack_cur_pypc: 0,
             vstack_valid: false,
             vstack_last_ref: OpRef::NONE,
+            live_before_jit_pc: usize::MAX,
+            live_after_jit_pc: usize::MAX,
         };
         let _ = step(&code, 0, &mut wc).expect("raise/r must dispatch");
         assert_eq!(
@@ -24198,6 +24333,8 @@ mod tests {
             vstack_cur_pypc: 0,
             vstack_valid: false,
             vstack_last_ref: OpRef::NONE,
+            live_before_jit_pc: usize::MAX,
+            live_after_jit_pc: usize::MAX,
         };
         fbw_finish_payload_reset();
         let (outcome, end_pc) =
@@ -24317,6 +24454,8 @@ mod tests {
             vstack_cur_pypc: 0,
             vstack_valid: false,
             vstack_last_ref: OpRef::NONE,
+            live_before_jit_pc: usize::MAX,
+            live_after_jit_pc: usize::MAX,
         };
         let ops_before = wc.trace_ctx.num_ops();
         let (outcome, _) = walk(&caller_code, 0, &mut wc).expect("caller must walk to terminator");
@@ -24383,6 +24522,8 @@ mod tests {
             vstack_cur_pypc: 0,
             vstack_valid: false,
             vstack_last_ref: OpRef::NONE,
+            live_before_jit_pc: usize::MAX,
+            live_after_jit_pc: usize::MAX,
         };
         let (outcome, next_pc) = step(&code, 0, &mut wc).expect("int_copy/i>i must dispatch");
         assert_eq!(outcome, DispatchOutcome::Continue);
@@ -24446,6 +24587,8 @@ mod tests {
             vstack_cur_pypc: 0,
             vstack_valid: false,
             vstack_last_ref: OpRef::NONE,
+            live_before_jit_pc: usize::MAX,
+            live_after_jit_pc: usize::MAX,
         };
         let _ = step(&code, 0, &mut wc).expect("int_copy/i>i must dispatch");
         assert_eq!(
@@ -24500,6 +24643,8 @@ mod tests {
             vstack_cur_pypc: 0,
             vstack_valid: false,
             vstack_last_ref: OpRef::NONE,
+            live_before_jit_pc: usize::MAX,
+            live_after_jit_pc: usize::MAX,
         };
         let err = step(&code, 0, &mut wc).expect_err("int_copy dst OOR must surface a typed error");
         assert_eq!(
@@ -24553,6 +24698,8 @@ mod tests {
             vstack_cur_pypc: 0,
             vstack_valid: false,
             vstack_last_ref: OpRef::NONE,
+            live_before_jit_pc: usize::MAX,
+            live_after_jit_pc: usize::MAX,
         };
         let err = step(&code, 0, &mut wc).expect_err("int_copy/i>i must read its src operand");
         assert_eq!(
@@ -24626,6 +24773,8 @@ mod tests {
             vstack_cur_pypc: 0,
             vstack_valid: false,
             vstack_last_ref: OpRef::NONE,
+            live_before_jit_pc: usize::MAX,
+            live_after_jit_pc: usize::MAX,
         };
         let (outcome, next_pc) = step(&code, 0, &mut wc).expect("ref_copy/r>r must dispatch");
         assert_eq!(outcome, DispatchOutcome::Continue);
@@ -24687,6 +24836,8 @@ mod tests {
             vstack_cur_pypc: 0,
             vstack_valid: false,
             vstack_last_ref: OpRef::NONE,
+            live_before_jit_pc: usize::MAX,
+            live_after_jit_pc: usize::MAX,
         };
         let _ = step(&code, 0, &mut wc).expect("ref_copy/r>r must dispatch");
         assert_eq!(
@@ -24739,6 +24890,8 @@ mod tests {
             vstack_cur_pypc: 0,
             vstack_valid: false,
             vstack_last_ref: OpRef::NONE,
+            live_before_jit_pc: usize::MAX,
+            live_after_jit_pc: usize::MAX,
         };
         let err = step(&code, 0, &mut wc).expect_err("ref_copy dst OOR must surface a typed error");
         assert_eq!(
@@ -24790,6 +24943,8 @@ mod tests {
             vstack_cur_pypc: 0,
             vstack_valid: false,
             vstack_last_ref: OpRef::NONE,
+            live_before_jit_pc: usize::MAX,
+            live_after_jit_pc: usize::MAX,
         };
         let err = step(&code, 0, &mut wc).expect_err("ref_copy/r>r must read its src operand");
         assert_eq!(
@@ -24852,6 +25007,8 @@ mod tests {
             vstack_cur_pypc: 0,
             vstack_valid: false,
             vstack_last_ref: OpRef::NONE,
+            live_before_jit_pc: usize::MAX,
+            live_after_jit_pc: usize::MAX,
         };
         let (outcome, next_pc) = step(&code, 0, &mut wc)
             .unwrap_or_else(|e| panic!("`{opname}` must dispatch — got {:?}", e));
@@ -25040,6 +25197,8 @@ mod tests {
             vstack_cur_pypc: 0,
             vstack_valid: false,
             vstack_last_ref: OpRef::NONE,
+            live_before_jit_pc: usize::MAX,
+            live_after_jit_pc: usize::MAX,
         };
         let (outcome, next_pc) =
             int_between_record(&code, &op, &mut wc).expect("int_between_record must dispatch");
@@ -25174,6 +25333,8 @@ mod tests {
             vstack_cur_pypc: 0,
             vstack_valid: false,
             vstack_last_ref: OpRef::NONE,
+            live_before_jit_pc: usize::MAX,
+            live_after_jit_pc: usize::MAX,
         };
         let (outcome, next_pc) = step(&code, 0, &mut wc)
             .unwrap_or_else(|e| panic!("`{opname}` must dispatch — got {:?}", e));
@@ -25260,6 +25421,8 @@ mod tests {
             vstack_cur_pypc: 0,
             vstack_valid: false,
             vstack_last_ref: OpRef::NONE,
+            live_before_jit_pc: usize::MAX,
+            live_after_jit_pc: usize::MAX,
         };
         let (outcome, next_pc) = step(&code, 0, &mut wc).expect("float_neg/f>f must dispatch");
         assert_eq!(outcome, DispatchOutcome::Continue);
@@ -25324,6 +25487,8 @@ mod tests {
             vstack_cur_pypc: 0,
             vstack_valid: false,
             vstack_last_ref: OpRef::NONE,
+            live_before_jit_pc: usize::MAX,
+            live_after_jit_pc: usize::MAX,
         };
         let (outcome, next_pc) = step(&code, 0, &mut wc)
             .unwrap_or_else(|e| panic!("`{opname}` must dispatch — got {:?}", e));
@@ -25413,6 +25578,8 @@ mod tests {
             vstack_cur_pypc: 0,
             vstack_valid: false,
             vstack_last_ref: OpRef::NONE,
+            live_before_jit_pc: usize::MAX,
+            live_after_jit_pc: usize::MAX,
         };
         let (outcome, next_pc) = step(&code, 0, &mut wc)
             .unwrap_or_else(|e| panic!("`{opname}` must dispatch — got {:?}", e));
@@ -25482,6 +25649,8 @@ mod tests {
             vstack_cur_pypc: 0,
             vstack_valid: false,
             vstack_last_ref: OpRef::NONE,
+            live_before_jit_pc: usize::MAX,
+            live_after_jit_pc: usize::MAX,
         };
         let err = step(&code, 0, &mut wc).expect_err("float_add must read its src operand");
         assert_eq!(
@@ -25534,6 +25703,8 @@ mod tests {
             vstack_cur_pypc: 0,
             vstack_valid: false,
             vstack_last_ref: OpRef::NONE,
+            live_before_jit_pc: usize::MAX,
+            live_after_jit_pc: usize::MAX,
         };
         let err = step(&code, 0, &mut wc).expect_err("int_add must read its src operand");
         assert_eq!(
@@ -25588,6 +25759,8 @@ mod tests {
             vstack_cur_pypc: 0,
             vstack_valid: false,
             vstack_last_ref: OpRef::NONE,
+            live_before_jit_pc: usize::MAX,
+            live_after_jit_pc: usize::MAX,
         };
         let err = step(&code, 0, &mut wc).expect_err("int_add dst OOR must surface a typed error");
         assert_eq!(
@@ -25650,6 +25823,8 @@ mod tests {
             vstack_cur_pypc: 0,
             vstack_valid: false,
             vstack_last_ref: OpRef::NONE,
+            live_before_jit_pc: usize::MAX,
+            live_after_jit_pc: usize::MAX,
         };
         let err =
             step(&code, 0, &mut wc).expect_err("unsupported opname must hit UnsupportedOpname");
@@ -25704,6 +25879,8 @@ mod tests {
             vstack_cur_pypc: 0,
             vstack_valid: false,
             vstack_last_ref: OpRef::NONE,
+            live_before_jit_pc: usize::MAX,
+            live_after_jit_pc: usize::MAX,
         };
         let (outcome, next_pc) = step(&code, 0, &mut wc).expect("ptr_nonzero must record PtrNe");
         assert!(matches!(outcome, DispatchOutcome::Continue));
@@ -25785,6 +25962,8 @@ mod tests {
             vstack_cur_pypc: 0,
             vstack_valid: false,
             vstack_last_ref: OpRef::NONE,
+            live_before_jit_pc: usize::MAX,
+            live_after_jit_pc: usize::MAX,
         };
         let (outcome, next_pc) = step(&code, 0, &mut wc).expect("abort/>r must dispatch");
         assert!(matches!(outcome, DispatchOutcome::Continue));
@@ -25848,6 +26027,8 @@ mod tests {
             vstack_cur_pypc: 0,
             vstack_valid: false,
             vstack_last_ref: OpRef::NONE,
+            live_before_jit_pc: usize::MAX,
+            live_after_jit_pc: usize::MAX,
         };
         let (outcome, next_pc) =
             step(&code, 0, &mut wc).expect("ref_guard_value must record GuardValue");
@@ -25927,6 +26108,8 @@ mod tests {
             vstack_cur_pypc: 0,
             vstack_valid: false,
             vstack_last_ref: OpRef::NONE,
+            live_before_jit_pc: usize::MAX,
+            live_after_jit_pc: usize::MAX,
         };
         let (outcome, next_pc) = step(&code, 0, &mut wc).expect("ref_guard_value Const arm");
         assert!(matches!(outcome, DispatchOutcome::Continue));
@@ -26019,6 +26202,8 @@ mod tests {
             vstack_cur_pypc: 0,
             vstack_valid: false,
             vstack_last_ref: OpRef::NONE,
+            live_before_jit_pc: usize::MAX,
+            live_after_jit_pc: usize::MAX,
         };
         let (outcome, next_pc) =
             step(&code, 0, &mut wc).expect("residual_call_r_r/iRd>r must dispatch");
@@ -26183,6 +26368,8 @@ mod tests {
             vstack_cur_pypc: 0,
             vstack_valid: false,
             vstack_last_ref: OpRef::NONE,
+            live_before_jit_pc: usize::MAX,
+            live_after_jit_pc: usize::MAX,
         };
         let _ = step(&code, 0, &mut wc).expect("residual_call_r_r/iRd>r must dispatch");
         drop(wc);
@@ -26264,6 +26451,8 @@ mod tests {
             vstack_cur_pypc: 0,
             vstack_valid: false,
             vstack_last_ref: OpRef::NONE,
+            live_before_jit_pc: usize::MAX,
+            live_after_jit_pc: usize::MAX,
         };
         let _ = try_execute_residual_call_via_executor(
             &mut wc,
@@ -26318,6 +26507,8 @@ mod tests {
             vstack_cur_pypc: 0,
             vstack_valid: false,
             vstack_last_ref: OpRef::NONE,
+            live_before_jit_pc: usize::MAX,
+            live_after_jit_pc: usize::MAX,
         };
         let _ = try_execute_residual_call_via_executor(
             &mut wc,
@@ -26387,6 +26578,8 @@ mod tests {
             vstack_cur_pypc: 0,
             vstack_valid: false,
             vstack_last_ref: OpRef::NONE,
+            live_before_jit_pc: usize::MAX,
+            live_after_jit_pc: usize::MAX,
         };
         let _ = try_execute_residual_call_via_executor(
             &mut wc,
@@ -26480,6 +26673,8 @@ mod tests {
             vstack_cur_pypc: 0,
             vstack_valid: false,
             vstack_last_ref: OpRef::NONE,
+            live_before_jit_pc: usize::MAX,
+            live_after_jit_pc: usize::MAX,
         };
         let result = try_execute_residual_call_via_executor(
             &mut wc,
@@ -26577,6 +26772,8 @@ mod tests {
             vstack_cur_pypc: 0,
             vstack_valid: false,
             vstack_last_ref: OpRef::NONE,
+            live_before_jit_pc: usize::MAX,
+            live_after_jit_pc: usize::MAX,
         };
         let result = try_execute_residual_call_via_executor(
             &mut wc,
@@ -26649,6 +26846,8 @@ mod tests {
             vstack_cur_pypc: 0,
             vstack_valid: false,
             vstack_last_ref: OpRef::NONE,
+            live_before_jit_pc: usize::MAX,
+            live_after_jit_pc: usize::MAX,
         };
         let err = step(&code, 0, &mut wc).expect_err("OS_NOT_IN_TRACE must surface a typed error");
         assert_eq!(
@@ -26709,6 +26908,8 @@ mod tests {
             vstack_cur_pypc: 0,
             vstack_valid: false,
             vstack_last_ref: OpRef::NONE,
+            live_before_jit_pc: usize::MAX,
+            live_after_jit_pc: usize::MAX,
         };
         let err =
             step(&code, 0, &mut wc).expect_err("OS_JIT_FORCE_VIRTUAL must surface a typed error");
@@ -26764,6 +26965,8 @@ mod tests {
             vstack_cur_pypc: 0,
             vstack_valid: false,
             vstack_last_ref: OpRef::NONE,
+            live_before_jit_pc: usize::MAX,
+            live_after_jit_pc: usize::MAX,
         };
         let _ = step(&code, 0, &mut wc).expect("residual_call_r_r/iRd>r must dispatch");
         drop(wc);
@@ -26828,6 +27031,8 @@ mod tests {
             vstack_cur_pypc: 0,
             vstack_valid: false,
             vstack_last_ref: OpRef::NONE,
+            live_before_jit_pc: usize::MAX,
+            live_after_jit_pc: usize::MAX,
         };
         let _ = step(&code, 0, &mut wc).expect("residual_call_r_r/iRd>r must dispatch");
         drop(wc);
@@ -26894,6 +27099,8 @@ mod tests {
             vstack_cur_pypc: 0,
             vstack_valid: false,
             vstack_last_ref: OpRef::NONE,
+            live_before_jit_pc: usize::MAX,
+            live_after_jit_pc: usize::MAX,
         };
         let _ = step(&code, 0, &mut wc).expect("residual_call_r_r/iRd>r must dispatch");
         // The dst slot must hold the OpRef of the recorded CallR. Each
@@ -26980,6 +27187,8 @@ mod tests {
             vstack_cur_pypc: 0,
             vstack_valid: false,
             vstack_last_ref: OpRef::NONE,
+            live_before_jit_pc: usize::MAX,
+            live_after_jit_pc: usize::MAX,
         };
         let _ = step(&code, 0, &mut wc).expect("residual_call_r_r/iRd>r must dispatch");
         drop(wc);
@@ -27055,6 +27264,8 @@ mod tests {
             vstack_cur_pypc: 0,
             vstack_valid: false,
             vstack_last_ref: OpRef::NONE,
+            live_before_jit_pc: usize::MAX,
+            live_after_jit_pc: usize::MAX,
         };
         let _ = step(&code, 0, &mut wc).expect("residual_call_ir_r/iIRd>r must dispatch");
         drop(wc);
@@ -27129,6 +27340,8 @@ mod tests {
             vstack_cur_pypc: 0,
             vstack_valid: false,
             vstack_last_ref: OpRef::NONE,
+            live_before_jit_pc: usize::MAX,
+            live_after_jit_pc: usize::MAX,
         };
         let err = step(&code, 0, &mut wc).expect_err("dst OOR must surface a typed error");
         assert_eq!(
@@ -27185,6 +27398,8 @@ mod tests {
             vstack_cur_pypc: 0,
             vstack_valid: false,
             vstack_last_ref: OpRef::NONE,
+            live_before_jit_pc: usize::MAX,
+            live_after_jit_pc: usize::MAX,
         };
         let err = step(&code, 0, &mut wc)
             .expect_err("descr index 5 with pool size 2 must surface DescrIndexOutOfRange");
@@ -27279,6 +27494,8 @@ mod tests {
             vstack_cur_pypc: 0,
             vstack_valid: false,
             vstack_last_ref: OpRef::NONE,
+            live_before_jit_pc: usize::MAX,
+            live_after_jit_pc: usize::MAX,
         };
         let (outcome, next_pc) =
             step(&code, 0, &mut wc).expect("residual_call_r_i/iRd>i must dispatch");
@@ -27370,6 +27587,8 @@ mod tests {
             vstack_cur_pypc: 0,
             vstack_valid: false,
             vstack_last_ref: OpRef::NONE,
+            live_before_jit_pc: usize::MAX,
+            live_after_jit_pc: usize::MAX,
         };
         let _ = step(&code, 0, &mut wc).expect("residual_call_r_i/iRd>i must dispatch");
         drop(wc);
@@ -27471,6 +27690,8 @@ mod tests {
             vstack_cur_pypc: 0,
             vstack_valid: false,
             vstack_last_ref: OpRef::NONE,
+            live_before_jit_pc: usize::MAX,
+            live_after_jit_pc: usize::MAX,
         };
         let (outcome, next_pc) =
             step(&code, 0, &mut wc).expect("residual_call_ir_r/iIRd>r must dispatch");
@@ -27602,6 +27823,8 @@ mod tests {
             vstack_cur_pypc: 0,
             vstack_valid: false,
             vstack_last_ref: OpRef::NONE,
+            live_before_jit_pc: usize::MAX,
+            live_after_jit_pc: usize::MAX,
         };
         let _ = step(&code, 0, &mut wc).expect("residual_call_ir_r/iIRd>r must dispatch");
         drop(wc);
@@ -27669,6 +27892,8 @@ mod tests {
             vstack_cur_pypc: 0,
             vstack_valid: false,
             vstack_last_ref: OpRef::NONE,
+            live_before_jit_pc: usize::MAX,
+            live_after_jit_pc: usize::MAX,
         };
         let err = step(&code, 0, &mut wc)
             .expect_err("FailDescr (not CallDescr) must surface ResidualCallDescrNotCallDescr");
@@ -27724,6 +27949,8 @@ mod tests {
             vstack_cur_pypc: 0,
             vstack_valid: false,
             vstack_last_ref: OpRef::NONE,
+            live_before_jit_pc: usize::MAX,
+            live_after_jit_pc: usize::MAX,
         };
         let err = step(&code, 0, &mut wc)
             .expect_err("R-list member out of range must surface RegisterOutOfRange");
@@ -27803,6 +28030,8 @@ mod tests {
             vstack_cur_pypc: 0,
             vstack_valid: false,
             vstack_last_ref: OpRef::NONE,
+            live_before_jit_pc: usize::MAX,
+            live_after_jit_pc: usize::MAX,
         };
         let (outcome, end_pc) =
             walk(&jc.code, 0, &mut wc).expect("ReturnValue arm must walk to a terminator");
@@ -27927,6 +28156,8 @@ mod tests {
             vstack_cur_pypc: 0,
             vstack_valid: false,
             vstack_last_ref: OpRef::NONE,
+            live_before_jit_pc: usize::MAX,
+            live_after_jit_pc: usize::MAX,
         };
         let (outcome, end_pc) =
             walk(&jc.code, 0, &mut wc).expect("PopTop arm must walk to a terminator");
@@ -28027,6 +28258,8 @@ mod tests {
             vstack_cur_pypc: 0,
             vstack_valid: false,
             vstack_last_ref: OpRef::NONE,
+            live_before_jit_pc: usize::MAX,
+            live_after_jit_pc: usize::MAX,
         };
         let err = step(&caller_code, 0, &mut wc).expect_err("arity overflow must surface error");
         assert_eq!(
@@ -28126,6 +28359,8 @@ mod tests {
             vstack_cur_pypc: 0,
             vstack_valid: false,
             vstack_last_ref: OpRef::NONE,
+            live_before_jit_pc: usize::MAX,
+            live_after_jit_pc: usize::MAX,
         };
         let (outcome, _) =
             walk(&caller_code, 0, &mut wc).expect("inline_call_r_v with void callee must succeed");
@@ -28204,6 +28439,8 @@ mod tests {
             vstack_cur_pypc: 0,
             vstack_valid: false,
             vstack_last_ref: OpRef::NONE,
+            live_before_jit_pc: usize::MAX,
+            live_after_jit_pc: usize::MAX,
         };
         let err = walk(&caller_code, 0, &mut wc)
             .expect_err("inline_call_r_v with non-void callee must reject");
@@ -28285,6 +28522,8 @@ mod tests {
             vstack_cur_pypc: 0,
             vstack_valid: false,
             vstack_last_ref: OpRef::NONE,
+            live_before_jit_pc: usize::MAX,
+            live_after_jit_pc: usize::MAX,
         };
         let (outcome, _) =
             walk(&caller_code, 0, &mut wc).expect("inline_call_ir_v with void callee must succeed");
@@ -28364,6 +28603,8 @@ mod tests {
             vstack_cur_pypc: 0,
             vstack_valid: false,
             vstack_last_ref: OpRef::NONE,
+            live_before_jit_pc: usize::MAX,
+            live_after_jit_pc: usize::MAX,
         };
         let err = walk(&caller_code, 0, &mut wc)
             .expect_err("inline_call_ir_v with non-void callee must reject");
@@ -28448,6 +28689,8 @@ mod tests {
             vstack_cur_pypc: 0,
             vstack_valid: false,
             vstack_last_ref: OpRef::NONE,
+            live_before_jit_pc: usize::MAX,
+            live_after_jit_pc: usize::MAX,
         };
         let (outcome, _) = walk(&caller_code, 0, &mut wc)
             .expect("inline_call_irf_v with void callee must succeed");
@@ -28530,6 +28773,8 @@ mod tests {
             vstack_cur_pypc: 0,
             vstack_valid: false,
             vstack_last_ref: OpRef::NONE,
+            live_before_jit_pc: usize::MAX,
+            live_after_jit_pc: usize::MAX,
         };
         let err = walk(&caller_code, 0, &mut wc)
             .expect_err("inline_call_irf_v with non-void callee must reject");
@@ -28601,6 +28846,8 @@ mod tests {
             vstack_cur_pypc: 0,
             vstack_valid: false,
             vstack_last_ref: OpRef::NONE,
+            live_before_jit_pc: usize::MAX,
+            live_after_jit_pc: usize::MAX,
         };
         let (outcome, next_pc) = step(&code, 0, &mut wc).expect("getfield_gc_i must dispatch");
         assert_eq!(outcome, DispatchOutcome::Continue);
@@ -28693,6 +28940,8 @@ mod tests {
             vstack_cur_pypc: 0,
             vstack_valid: false,
             vstack_last_ref: OpRef::NONE,
+            live_before_jit_pc: usize::MAX,
+            live_after_jit_pc: usize::MAX,
         };
         let _ = step(&code, 0, &mut wc).expect("getfield_gc_i must dispatch");
         let dst_post = wc.registers_i[5];
@@ -28763,6 +29012,8 @@ mod tests {
             vstack_cur_pypc: 0,
             vstack_valid: false,
             vstack_last_ref: OpRef::NONE,
+            live_before_jit_pc: usize::MAX,
+            live_after_jit_pc: usize::MAX,
         };
         let _ = step(&code, 0, &mut wc).expect("getfield_gc_r must dispatch");
         let dst_post = wc.registers_r[6];
@@ -28821,6 +29072,8 @@ mod tests {
             vstack_cur_pypc: 0,
             vstack_valid: false,
             vstack_last_ref: OpRef::NONE,
+            live_before_jit_pc: usize::MAX,
+            live_after_jit_pc: usize::MAX,
         };
         let err = step(&code, 0, &mut wc).expect_err("getfield_gc must validate r-reg");
         assert_eq!(
@@ -28891,6 +29144,8 @@ mod tests {
             vstack_cur_pypc: 0,
             vstack_valid: false,
             vstack_last_ref: OpRef::NONE,
+            live_before_jit_pc: usize::MAX,
+            live_after_jit_pc: usize::MAX,
         };
         let (outcome, next_pc) = step(&code, 0, &mut wc).expect("getfield_vable_i must dispatch");
         assert_eq!(outcome, DispatchOutcome::Continue);
@@ -28981,6 +29236,8 @@ mod tests {
             vstack_cur_pypc: 0,
             vstack_valid: false,
             vstack_last_ref: OpRef::NONE,
+            live_before_jit_pc: usize::MAX,
+            live_after_jit_pc: usize::MAX,
         };
         let (outcome, next_pc) = step(&code, 0, &mut wc).expect("setfield_vable_i must dispatch");
         assert_eq!(outcome, DispatchOutcome::Continue);
@@ -29061,6 +29318,8 @@ mod tests {
             vstack_cur_pypc: 0,
             vstack_valid: false,
             vstack_last_ref: OpRef::NONE,
+            live_before_jit_pc: usize::MAX,
+            live_after_jit_pc: usize::MAX,
         };
         let _ = step(&code, 0, &mut wc).expect("setfield_gc_i must dispatch");
         drop(wc);
@@ -29119,6 +29378,8 @@ mod tests {
             vstack_cur_pypc: 0,
             vstack_valid: false,
             vstack_last_ref: OpRef::NONE,
+            live_before_jit_pc: usize::MAX,
+            live_after_jit_pc: usize::MAX,
         };
         let _ = step(&code, 0, &mut wc).expect("setfield_gc_i must dispatch");
         drop(wc);
@@ -29203,6 +29464,8 @@ mod tests {
             vstack_cur_pypc: 0,
             vstack_valid: false,
             vstack_last_ref: OpRef::NONE,
+            live_before_jit_pc: usize::MAX,
+            live_after_jit_pc: usize::MAX,
         };
         let _ = step(&code, 0, &mut wc).expect("setfield_gc_r must dispatch");
         drop(wc);
@@ -29270,6 +29533,8 @@ mod tests {
             vstack_cur_pypc: 0,
             vstack_valid: false,
             vstack_last_ref: OpRef::NONE,
+            live_before_jit_pc: usize::MAX,
+            live_after_jit_pc: usize::MAX,
         };
         let (outcome, next_pc) = step(&code, 0, &mut wc).expect("getarrayitem_gc_r must dispatch");
         assert_eq!(outcome, DispatchOutcome::Continue);
@@ -29351,6 +29616,8 @@ mod tests {
             vstack_cur_pypc: 0,
             vstack_valid: false,
             vstack_last_ref: OpRef::NONE,
+            live_before_jit_pc: usize::MAX,
+            live_after_jit_pc: usize::MAX,
         };
         let _ = step(&code, 0, &mut wc).expect("getarrayitem_gc_r must dispatch");
         let dst_post = wc.registers_r[5];
@@ -29417,6 +29684,8 @@ mod tests {
             vstack_cur_pypc: 0,
             vstack_valid: false,
             vstack_last_ref: OpRef::NONE,
+            live_before_jit_pc: usize::MAX,
+            live_after_jit_pc: usize::MAX,
         };
         let (outcome, next_pc) = step(&code, 0, &mut wc).expect("setarrayitem_gc_r must dispatch");
         assert_eq!(outcome, DispatchOutcome::Continue);
@@ -29725,6 +29994,8 @@ mod tests {
             vstack_cur_pypc: 0,
             vstack_valid: false,
             vstack_last_ref: OpRef::NONE,
+            live_before_jit_pc: usize::MAX,
+            live_after_jit_pc: usize::MAX,
         };
         assert_eq!(
             walk(&code, 0, &mut wc),
@@ -29801,6 +30072,8 @@ mod tests {
             vstack_cur_pypc: 0,
             vstack_valid: false,
             vstack_last_ref: OpRef::NONE,
+            live_before_jit_pc: usize::MAX,
+            live_after_jit_pc: usize::MAX,
         };
 
         // Arrival without a preceding `loop_header` stamp and with no
@@ -29887,6 +30160,8 @@ mod tests {
             vstack_cur_pypc: 0,
             vstack_valid: false,
             vstack_last_ref: OpRef::NONE,
+            live_before_jit_pc: usize::MAX,
+            live_after_jit_pc: usize::MAX,
         };
         assert_eq!(wc.trace_ctx.seen_loop_header_for_jdindex, -1);
         let (outcome, next) = step(&code, 0, &mut wc).expect("loop_header must dispatch");
@@ -29948,6 +30223,8 @@ mod tests {
             vstack_cur_pypc: 0,
             vstack_valid: false,
             vstack_last_ref: OpRef::NONE,
+            live_before_jit_pc: usize::MAX,
+            live_after_jit_pc: usize::MAX,
         };
         assert_eq!(
             step(&code, 0, &mut wc),

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -9235,7 +9235,7 @@ pub(crate) fn m73_perop_carry_enabled() -> bool {
     })
 }
 
-/// `PYRE_M73_BRANCH_CARRY` (#73 S3.5, default OFF): the terminal branch-guard
+/// `PYRE_M73_BRANCH_CARRY` (#73 S3.5, default ON): the terminal branch-guard
 /// flip. A depth-0 `GuardTrue`/`GuardFalse` sources its resume word from the
 /// walk's arm-independent `-live-` BEFORE anchor (`ctx.live_before_jit_pc`,
 /// `orgpc`) TAGGED into the negative space of the `jitcode_pc` word (plus a
@@ -9243,12 +9243,19 @@ pub(crate) fn m73_perop_carry_enabled() -> bool {
 /// marker. Byte-identical by construction: encode carries the tagged word only
 /// when its decode-side expansion ([`expand_branch_carried`]) reproduces the
 /// baseline `marker` (self-cert), and decode expands it back to that same
-/// `marker` before any consumer reads it. Off → encode never emits a tagged
-/// word, so the decode expand is a no-op. Certified by `PYRE_M73_FLIP_AUDIT`
-/// (S3.4) and check.py.
+/// `marker` before any consumer reads it. Disabled (`PYRE_M73_BRANCH_CARRY=0`)
+/// → encode never emits a tagged word, so the decode expand is a no-op and the
+/// carried word is the block-head `marker` as before. Certified by
+/// `PYRE_M73_FLIP_AUDIT` (S3.4) and check.py (159×2, on and off).
 pub(crate) fn m73_branch_carry_enabled() -> bool {
     static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
-    *ENABLED.get_or_init(|| std::env::var_os("PYRE_M73_BRANCH_CARRY").is_some())
+    *ENABLED.get_or_init(|| match std::env::var_os("PYRE_M73_BRANCH_CARRY") {
+        Some(v) => {
+            let v = v.to_string_lossy();
+            v != "0" && !v.eq_ignore_ascii_case("false")
+        }
+        None => true,
+    })
 }
 
 pub(crate) fn python_pc_for_jitcode_pc(metadata: &crate::PyJitCodeMetadata, jit_pc: usize) -> u32 {
@@ -11000,7 +11007,8 @@ fn walker_capture_snapshot_for_last_guard_impl(
                 // decode identically for every consumer (banks + bridge maps +
                 // const refill) where the anchor coincides, and flags the
                 // divergent minority for the check.py output-equality gate.
-                // #73 S3.5 flip (`PYRE_M73_BRANCH_CARRY`, default OFF): a depth-0
+                // #73 S3.5 flip (`PYRE_M73_BRANCH_CARRY`, default ON, opt-out
+                // `=0`/`false`): a depth-0
                 // branch guard (`GuardTrue`/`GuardFalse`) carries the walk's
                 // arm-independent `-live-` BEFORE anchor (`ctx.live_before_jit_pc`,
                 // `orgpc`) TAGGED into the negative space of the word plus the

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -9152,16 +9152,36 @@ pub(crate) fn m73_liveness_audit_enabled() -> bool {
     *ENABLED.get_or_init(|| std::env::var_os("PYRE_M73_LIVENESS_AUDIT").is_some())
 }
 
-/// `PYRE_M73_ANCHOR_AUDIT` enables the assertion that the walk-maintained
-/// `-live-` BEFORE anchor (`ctx.live_before_jit_pc`, updated from every
-/// decoded `-live-` op) equals the py-keyed resume marker the encoder
-/// resolves via `resume_jitcode_pc_for(py_pc)` at the normal-family guard arm
-/// (`pyjitpl.py:198`, normal guard resume reads at `self.pc - SIZE_LIVE_OP`).
-/// Certifies the precondition for re-sourcing that marker off the walk-level
-/// cursor without the py_pc channel. Diagnostic only; off in production.
-pub(crate) fn m73_anchor_audit_enabled() -> bool {
+/// `PYRE_M73_PEROP_AUDIT` (#73 S2, default OFF): census that, for a
+/// specialization guard (`GuardValue`/`GuardClass`), measures whether the
+/// walk-maintained per-op `-live-` BEFORE anchor (`ctx.live_before_jit_pc`,
+/// `pyjitpl.py:198`) decodes IDENTICALLY to the block-head marker
+/// (`resume_jitcode_pc_for(py_pc)`) across EVERY consumer of the carried
+/// resume word — the liveness banks (resolver-funneled) AND the
+/// coordinate-sensitive `bridge_semantic_maps_at_with_jitcode_pc` (depth +
+/// pcdep) and `const_ref_slots_at_pc_at` (const refill), which invert the
+/// carried offset back to a `py_pc` and index py_pc-keyed tables. Emits one
+/// `M73_PEROP_SPEC` line per specialization capture: `eq=1` when the per-op
+/// anchor coincides with the block-head marker (carry is a byte-identical
+/// re-source), `eq=0 banks_eq=.. bmaps_eq=.. const_eq=..` when it differs
+/// (each consumer certified independently), or `eq=nolb`/`eq=nomarker` edge
+/// cases. Off in production.
+pub(crate) fn m73_perop_audit_enabled() -> bool {
     static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
-    *ENABLED.get_or_init(|| std::env::var_os("PYRE_M73_ANCHOR_AUDIT").is_some())
+    *ENABLED.get_or_init(|| std::env::var_os("PYRE_M73_PEROP_AUDIT").is_some())
+}
+
+/// `PYRE_M73_PEROP_CARRY` (#73 S2, default OFF): source a specialization
+/// guard's (`GuardValue`/`GuardClass`) resume coordinate from the walk
+/// cursor's per-op `-live-` BEFORE anchor (`ctx.live_before_jit_pc`,
+/// `pyjitpl.py:198`) instead of the py_pc-keyed `resume_jitcode_pc_for(py_pc)`
+/// block-head marker — the genuine JitCode cursor the migration authors resume
+/// data from. Byte-identical where the anchor coincides with the marker
+/// (99%+ of the corpus per the `PYRE_M73_PEROP_AUDIT` census); the divergent
+/// minority is gated by check.py output equality. Off in production.
+pub(crate) fn m73_perop_carry_enabled() -> bool {
+    static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ENABLED.get_or_init(|| std::env::var_os("PYRE_M73_PEROP_CARRY").is_some())
 }
 
 pub(crate) fn python_pc_for_jitcode_pc(metadata: &crate::PyJitCodeMetadata, jit_pc: usize) -> u32 {
@@ -10501,24 +10521,98 @@ fn walker_capture_snapshot_for_last_guard_impl(
                     let jc = &*sym.jitcode;
                     jc.payload.resume_jitcode_pc_for(py_pc as usize)
                 };
-                // #73 (SLICE 1): certificate for the later cursor flip (S3).
-                // The walk-maintained `-live-` BEFORE anchor must equal the
-                // py-keyed resume marker the encoder resolves here
-                // (`pyjitpl.py:198`).  Read-only: `marker` is still consumed
-                // unchanged by the match below.
-                if m73_anchor_audit_enabled() && ctx.live_before_jit_pc != usize::MAX {
-                    debug_assert_eq!(
-                        Some(ctx.live_before_jit_pc),
-                        marker,
-                        "#73 anchor mismatch: live_before={} py_pc={} marker={:?}",
-                        ctx.live_before_jit_pc,
-                        py_pc,
-                        marker
+                // #73 S2 census: for a specialization guard measure whether the
+                // per-op `-live-` BEFORE anchor (`ctx.live_before_jit_pc`,
+                // `pyjitpl.py:198`) decodes IDENTICALLY to the block-head marker
+                // across EVERY consumer of the carried resume word. The banks
+                // reader funnels through the carried-word resolver (safe at any
+                // `-live-` offset), but `bridge_semantic_maps_at_with_jitcode_pc`
+                // (depth + pcdep) and `const_ref_slots_at_pc_at` (const refill)
+                // invert the carried offset to a `py_pc` via the two-tier
+                // `python_pc_for_jitcode_pc` and index py_pc-keyed tables, so a
+                // per-op offset that is not a block head can invert to a DIFFERENT
+                // `py_pc`. The per-op carry is byte-behavior-safe only where all
+                // consumers agree; this census is the precondition certificate.
+                // Read-only: `marker` is consumed unchanged by the match below.
+                if m73_perop_audit_enabled() {
+                    let is_specialization = matches!(
+                        ctx.trace_ctx.last_guard_opcode(),
+                        Some(OpCode::GuardValue | OpCode::GuardClass)
                     );
+                    if is_specialization {
+                        match marker {
+                            None => {
+                                eprintln!("M73_PEROP_SPEC eq=nomarker py_pc={}", py_pc);
+                            }
+                            Some(bh) if ctx.live_before_jit_pc == usize::MAX => {
+                                eprintln!("M73_PEROP_SPEC eq=nolb py_pc={} bh={}", py_pc, bh);
+                            }
+                            Some(bh) if ctx.live_before_jit_pc == bh => {
+                                eprintln!("M73_PEROP_SPEC eq=1 py_pc={} bh={}", py_pc, bh);
+                            }
+                            Some(bh) => {
+                                // per-op `-live-` differs from the block-head marker:
+                                // measure whether EVERY consumer of the carried word
+                                // decodes identically at the two offsets.
+                                let lb = ctx.live_before_jit_pc as i32;
+                                let no = majit_ir::resumedata::NO_JITCODE_PC;
+                                let ji = jitcode_index as i32;
+                                let pp = py_pc as i32;
+                                let banks_p =
+                                    crate::state::frame_liveness_reg_indices_by_bank_at_with_jitcode_pc(
+                                        ji, pp, lb,
+                                    );
+                                let banks_b =
+                                    crate::state::frame_liveness_reg_indices_by_bank_at_with_jitcode_pc(
+                                        ji, pp, no,
+                                    );
+                                let banks_eq = banks_p.int == banks_b.int
+                                    && banks_p.ref_ == banks_b.ref_
+                                    && banks_p.float == banks_b.float;
+                                let bm_p = crate::state::bridge_semantic_maps_at_with_jitcode_pc(
+                                    ji, pp, lb,
+                                );
+                                let bm_b = crate::state::bridge_semantic_maps_at_with_jitcode_pc(
+                                    ji, pp, no,
+                                );
+                                let bmaps_eq = bm_p.stack_depth_at_pc == bm_b.stack_depth_at_pc
+                                    && bm_p.pcdep_entries == bm_b.pcdep_entries;
+                                let const_eq = crate::state::const_ref_slots_at_pc_at(ji, pp, lb)
+                                    == crate::state::const_ref_slots_at_pc_at(ji, pp, no);
+                                eprintln!(
+                                    "M73_PEROP_SPEC eq=0 py_pc={} lb={} bh={} banks_eq={} \
+                                     bmaps_eq={} const_eq={}",
+                                    py_pc, lb, bh, banks_eq, bmaps_eq, const_eq
+                                );
+                            }
+                        }
+                    }
                 }
-                match marker {
-                    Some(jp) => jp as i32,
-                    None => majit_ir::resumedata::NO_JITCODE_PC,
+                // #73 S2 flip (`PYRE_M73_PEROP_CARRY`, default OFF): a
+                // specialization guard (`GuardValue`/`GuardClass`) sources its
+                // resume coordinate from the walk cursor's per-op `-live-`
+                // BEFORE anchor (`ctx.live_before_jit_pc`, `pyjitpl.py:198`)
+                // directly, dropping the py_pc-keyed `resume_jitcode_pc_for`
+                // lookup. Requires a stepped `-live-` and a resolvable
+                // block-head marker (else keep the baseline, byte-identical).
+                // The `PYRE_M73_PEROP_AUDIT` census certifies both offsets
+                // decode identically for every consumer (banks + bridge maps +
+                // const refill) where the anchor coincides, and flags the
+                // divergent minority for the check.py output-equality gate.
+                if m73_perop_carry_enabled()
+                    && marker.is_some()
+                    && ctx.live_before_jit_pc != usize::MAX
+                    && matches!(
+                        ctx.trace_ctx.last_guard_opcode(),
+                        Some(OpCode::GuardValue | OpCode::GuardClass)
+                    )
+                {
+                    ctx.live_before_jit_pc as i32
+                } else {
+                    match marker {
+                        Some(jp) => jp as i32,
+                        None => majit_ir::resumedata::NO_JITCODE_PC,
+                    }
                 }
             } else if m366_nonbranch_pc_enabled() && after_residual_call {
                 // #366: extend the direct-pc carry to the after-residual-call

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -9463,26 +9463,32 @@ fn decode_side_other_target(
         return Err("notgoto");
     }
     let target = read_label(code, &goto, 1);
-    let raw = if flavor_guard_true { target } else { goto.next_pc };
+    let raw = if flavor_guard_true {
+        target
+    } else {
+        goto.next_pc
+    };
     Ok(resolve_branch_target_through_trampoline(code, raw))
 }
 
-/// #73 S3.5 decode: if `carried` is a tagged branch `orgpc` (negative-space
+/// #73 S4 decode: if `carried` is a tagged branch `orgpc` (negative-space
 /// encoding, [`majit_ir::resumedata::encode_branch_orgpc`]), expand it to the
-/// block-head resume marker exactly as the baseline would have carried it —
-/// `decode_side_other_target` picks the not-taken arm from `orgpc` + flavor,
-/// then the SAME inversion + forward trivia-skip + `resume_jitcode_pc_for` the
-/// real capture used (10166-10191). Non-tagged words (offsets `>= 0`,
-/// `NO_JITCODE_PC`) pass through unchanged, so this is a no-op whenever the flip
-/// is off (`decode_branch_orgpc` returns `None`).
+/// genuine not-taken-arm jitcode offset (`derived` / other_target) DIRECTLY:
+/// `decode_side_other_target` picks the not-taken arm from `orgpc` + flavor and
+/// that jitcode offset IS the returned value. The former py_pc round-trip
+/// (`python_pc_for_jitcode_pc` -> `skip_python_trivia_forward` ->
+/// `resume_jitcode_pc_for`, with its `num_instrs` overshoot clamp) is deleted:
+/// it is byte-identical because the encode self-cert
+/// (`walker_capture_snapshot_for_last_guard_impl`) tags a word ONLY when this
+/// same `expand_branch_carried` yields `derived == marker`, so returning
+/// `derived` reproduces exactly the marker the round-trip would have. Non-tagged
+/// words (offsets `>= 0`, `NO_JITCODE_PC`) pass through unchanged, so this is a
+/// no-op whenever the flip is off (`decode_branch_orgpc` returns `None`).
 ///
-/// Returns `NO_JITCODE_PC` if the arm cannot be decoded, so the decoder falls
-/// back to the stored `py_pc` path. In particular an OVERSHOOT (`py_pc >=
-/// num_instrs`) is treated as a decode FAILURE rather than guessing the real
-/// capture's `entry_py_pc` clamp target (a per-walk value not available here):
-/// the encode self-cert re-runs this exact function and declines to carry any
-/// tagged word whose reconstruction overshoots, so a genuinely-carried tagged
-/// word never reaches the overshoot leg.
+/// Returns `NO_JITCODE_PC` only if the arm cannot be decoded, so the decoder
+/// falls back to the stored `py_pc` path; the encode self-cert declines to carry
+/// any tagged word whose reconstruction fails, so a genuinely-carried tagged
+/// word never reaches that leg.
 pub(crate) fn expand_branch_carried(payload: &crate::PyJitCode, carried: i32) -> i32 {
     match majit_ir::resumedata::decode_branch_orgpc(carried) {
         None => carried,
@@ -9490,23 +9496,7 @@ pub(crate) fn expand_branch_carried(payload: &crate::PyJitCode, carried: i32) ->
             let code = payload.jitcode.code.as_slice();
             match decode_side_other_target(code, orgpc, flavor) {
                 Err(_) => majit_ir::resumedata::NO_JITCODE_PC,
-                Ok(derived) => {
-                    let mut py = python_pc_for_jitcode_pc(&payload.metadata, derived);
-                    if !payload.code_ptr.is_null() {
-                        let co = unsafe { &*payload.code_ptr };
-                        py = skip_python_trivia_forward(co, py as usize) as u32;
-                    }
-                    let num_instrs = payload.metadata.first_jit_pc_by_py_pc.len();
-                    if py as usize >= num_instrs {
-                        // Overshoot: the real capture clamps to `ctx.entry_py_pc`
-                        // (a per-walk value absent at decode). Decode-failure →
-                        // py_pc fallback; encode self-cert never tags such a word.
-                        return majit_ir::resumedata::NO_JITCODE_PC;
-                    }
-                    payload
-                        .resume_jitcode_pc_for(py as usize)
-                        .map_or(majit_ir::resumedata::NO_JITCODE_PC, |m| m as i32)
-                }
+                Ok(derived) => derived as i32,
             }
         }
     }
@@ -10794,10 +10784,7 @@ fn walker_capture_snapshot_for_last_guard_impl(
                     if is_branch {
                         match marker {
                             None => {
-                                eprintln!(
-                                    "M73_BRANCH eq=nomarker py_pc={} op_pc={}",
-                                    py_pc, op_pc
-                                );
+                                eprintln!("M73_BRANCH eq=nomarker py_pc={} op_pc={}", py_pc, op_pc);
                             }
                             Some(m) if op_pc == m => {
                                 eprintln!("M73_BRANCH eq=1 py_pc={} op_pc={}", py_pc, op_pc);
@@ -10816,8 +10803,7 @@ fn walker_capture_snapshot_for_last_guard_impl(
                                 //     (self-masking), so `inv_*` is the real signal.
                                 let (inv_pp, decodable) = unsafe {
                                     let jc = &*sym.jitcode;
-                                    let inv =
-                                        python_pc_for_jitcode_pc(&jc.payload.metadata, op_pc);
+                                    let inv = python_pc_for_jitcode_pc(&jc.payload.metadata, op_pc);
                                     let dec = jc
                                         .payload
                                         .jitcode
@@ -10839,7 +10825,9 @@ fn walker_capture_snapshot_for_last_guard_impl(
                                     && banks_o.ref_ == banks_m.ref_
                                     && banks_o.float == banks_m.float;
                                 let bm_o = crate::state::bridge_semantic_maps_at_with_jitcode_pc(
-                                    ji, pp, op_pc as i32,
+                                    ji,
+                                    pp,
+                                    op_pc as i32,
                                 );
                                 let bm_m = crate::state::bridge_semantic_maps_at_with_jitcode_pc(
                                     ji, pp, m as i32,
@@ -10939,7 +10927,8 @@ fn walker_capture_snapshot_for_last_guard_impl(
                                                 py = skip_python_trivia_forward(
                                                     code_obj,
                                                     py as usize,
-                                                ) as u32;
+                                                )
+                                                    as u32;
                                             }
                                             let num_instrs = meta.first_jit_pc_by_py_pc.len();
                                             if py as usize >= num_instrs {
@@ -10949,9 +10938,8 @@ fn walker_capture_snapshot_for_last_guard_impl(
                                             }
                                         };
                                         let invpp_eq = py_pc_cand == py_pc;
-                                        let flip_marker = jc
-                                            .payload
-                                            .resume_jitcode_pc_for(py_pc_cand as usize);
+                                        let flip_marker =
+                                            jc.payload.resume_jitcode_pc_for(py_pc_cand as usize);
                                         let marker_eq = flip_marker == Some(m);
                                         // Whether the flip's carried word (`orgpc`)
                                         // genuinely differs from today's (`m`): a
@@ -11040,8 +11028,7 @@ fn walker_capture_snapshot_for_last_guard_impl(
                             );
                             let jc = unsafe { &*sym.jitcode };
                             let code = jc.payload.jitcode.code.as_slice();
-                            if let Ok(derived) =
-                                decode_side_other_target(code, orgpc, flavor_true)
+                            if let Ok(derived) = decode_side_other_target(code, orgpc, flavor_true)
                             {
                                 let derived_eq_marker = derived as i32 == m as i32;
                                 // Whether the walk cursor could key at `derived`
@@ -11067,7 +11054,9 @@ fn walker_capture_snapshot_for_last_guard_impl(
                                     && banks_d.float == banks_m.float;
                                 // (b) bridge semantic maps (depth + pcdep).
                                 let bm_d = crate::state::bridge_semantic_maps_at_with_jitcode_pc(
-                                    ji, pp, derived as i32,
+                                    ji,
+                                    pp,
+                                    derived as i32,
                                 );
                                 let bm_m = crate::state::bridge_semantic_maps_at_with_jitcode_pc(
                                     ji, pp, m as i32,
@@ -20268,7 +20257,11 @@ fn handle(
                                 reason, orgpc, other_target, switchcase
                             ),
                             Ok(derived) => {
-                                let r = if derived == other_target { "match" } else { "mismatch" };
+                                let r = if derived == other_target {
+                                    "match"
+                                } else {
+                                    "mismatch"
+                                };
                                 eprintln!(
                                     "M73_ARM result={} orgpc={} other_target={} derived={} switchcase={}",
                                     r, orgpc, other_target, derived, switchcase
@@ -22293,8 +22286,8 @@ mod tests {
                 vstack_cur_pypc: 0,
                 vstack_valid: false,
                 vstack_last_ref: OpRef::NONE,
-            live_before_jit_pc: usize::MAX,
-            live_after_jit_pc: usize::MAX,
+                live_before_jit_pc: usize::MAX,
+                live_after_jit_pc: usize::MAX,
             };
             let op = DecodedOp {
                 key,

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -9190,6 +9190,17 @@ pub(crate) fn m73_branch_audit_enabled() -> bool {
     *ENABLED.get_or_init(|| std::env::var_os("PYRE_M73_BRANCH_AUDIT").is_some())
 }
 
+/// `PYRE_M73_ARM_AUDIT` (#73 S3.1, approach C, default OFF): certifies that a
+/// branch guard's resume coordinate `other_target` is re-derivable at decode
+/// time from the guard's OWN `-live-` BEFORE anchor `orgpc` plus the recorded
+/// flavor (`GuardTrue`/`GuardFalse`), WITHOUT the runtime condbox — mirroring
+/// PyPy `generate_guard(resumepc=orgpc)` (`pyjitpl.py:520`). Emits one
+/// `M73_ARM` line per non-constant `goto_if_not` capture. Off in production.
+pub(crate) fn m73_arm_audit_enabled() -> bool {
+    static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ENABLED.get_or_init(|| std::env::var_os("PYRE_M73_ARM_AUDIT").is_some())
+}
+
 /// `PYRE_M73_PEROP_CARRY` (#73 S2, default ON): source a specialization
 /// guard's (`GuardValue`/`GuardClass`) resume coordinate from the walk
 /// cursor's per-op `-live-` BEFORE anchor (`ctx.live_before_jit_pc`,
@@ -9369,6 +9380,41 @@ fn resolve_branch_target_through_trampoline(code: &[u8], target: usize) -> usize
         }
     }
     resume
+}
+
+/// #73 S3.1 (approach C): re-derive a branch guard's resume `other_target` from
+/// the guard's OWN `-live-` BEFORE anchor `orgpc` (== ctx.live_before_jit_pc at
+/// the goto_if_not) + the recorded flavor (GuardTrue/GuardFalse), WITHOUT the
+/// runtime condbox — mirroring PyPy generate_guard(resumepc=orgpc) (pyjitpl.py:520),
+/// where orgpc is arm-independent and the arm is re-derived. A BOUNDED single
+/// leading `-live-` skip (NOT a permissive loop), mirroring pyjitpl.py:198's
+/// `assert code[pc]==op_live`: a mispositioned orgpc (e.g. `live; ref_copy;
+/// goto_if_not`, orgpc one op early) FAILS loudly rather than being walked forward.
+///
+/// The only conditional-branch opname reaching the walk dispatch is
+/// `goto_if_not` (`goto_if_not/iL`): pyre keeps COMPARE_OP and the branch as
+/// SEPARATE JitCode ops and never emits the jtransform-fused `n_<cmp>` form on
+/// the trace/walker path, so the goto opname set is the single `"goto_if_not"`.
+/// The `L` label operand sits at index 1 (`iL`: 1B int reg, then 2B label) —
+/// the same index the `goto_if_not/iL` handler reads `target` from — re-read
+/// here from the re-derived `goto` so the arm-select is genuinely reconstructed
+/// from `orgpc` alone rather than reusing the capture-site op.
+fn decode_side_other_target(
+    code: &[u8],
+    orgpc: usize,
+    flavor_guard_true: bool,
+) -> Result<usize, &'static str> {
+    let live = decode_op_at(code, orgpc).ok_or("notlive")?;
+    if live.opname != "live" {
+        return Err("notlive");
+    }
+    let goto = decode_op_at(code, live.next_pc).ok_or("notgoto")?;
+    if goto.opname != "goto_if_not" {
+        return Err("notgoto");
+    }
+    let target = read_label(code, &goto, 1);
+    let raw = if flavor_guard_true { target } else { goto.next_pc };
+    Ok(resolve_branch_target_through_trampoline(code, raw))
 }
 
 /// Decode a not-taken branch trampoline's `ref_copy` parallel-move
@@ -19819,6 +19865,30 @@ fn handle(
                 if switchcase != 0 { target } else { op.next_pc },
             );
             if !valuebox.is_constant() {
+                if m73_arm_audit_enabled() {
+                    let orgpc = ctx.live_before_jit_pc;
+                    let flavor_guard_true = switchcase != 0;
+                    if orgpc == usize::MAX {
+                        eprintln!(
+                            "M73_ARM result=nolb other_target={} switchcase={}",
+                            other_target, switchcase
+                        );
+                    } else {
+                        match decode_side_other_target(code, orgpc, flavor_guard_true) {
+                            Err(reason) => eprintln!(
+                                "M73_ARM result={} orgpc={} other_target={} switchcase={}",
+                                reason, orgpc, other_target, switchcase
+                            ),
+                            Ok(derived) => {
+                                let r = if derived == other_target { "match" } else { "mismatch" };
+                                eprintln!(
+                                    "M73_ARM result={} orgpc={} other_target={} derived={} switchcase={}",
+                                    r, orgpc, other_target, derived, switchcase
+                                );
+                            }
+                        }
+                    }
+                }
                 // #124/#281: a branch guard whose resume target still holds a
                 // live operand-stack temp (short-circuit `and`/`or`, the
                 // conditional expression, chained comparison) keeps that temp

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -9629,46 +9629,19 @@ fn branch_resume_target_stack_depth(frame: &ActiveResumeFrame, target: usize) ->
     if pjc.code_ptr.is_null() {
         return None;
     }
-    // SAFETY: `code_ptr` / `metadata` are immutable payload layout fields;
-    // the frame holds an `Arc<PyJitCode>` keeping them alive for this read.
-    unsafe {
-        let code = &*pjc.code_ptr;
-        let py = python_pc_for_jitcode_pc(&pjc.metadata, target) as usize;
-        let py = skip_python_trivia_forward(code, py);
-        let depth = crate::liveness::liveness_for(pjc.code_ptr)
-            .depth_at_py_pc()
-            .get(py)
-            .copied();
-        // task#50 #73-core: certify the trivia-aware `depth_trivia_by_jit_pc`
-        // twin reproduces this depth off the genuine jitcode `target`, without
-        // the `python_pc_for_jitcode_pc` inversion + runtime `skip_python_trivia_forward`
-        // walk. When the twin has an entry for `target`, it must equal the depth
-        // read here (both derive from the same static `liveness_for` depth +
-        // trivia-skip, baked at compile time). Precondition certificate for
-        // retiring the inversion at this ENCODE site. Off in production.
-        if m73_encode_audit_enabled() && pjc.depth_trivia_populated() {
-            assert_eq!(
-                pjc.depth_trivia_for_jitcode_pc(target),
-                depth,
-                "depth_trivia twin diverges from branch_resume_target_stack_depth at target={target} py={py}"
-            );
-        }
-        if pjc.depth_trivia_populated() {
-            pjc.depth_trivia_for_jitcode_pc(target)
-        } else {
-            // Slice A census: soft, non-aborting count of the py_pc-inversion
-            // fallback (empty depth-trivia twin). Emits ONLY when this arm runs,
-            // so zero output over the corpus == this fallback is dead.
-            if m73_encode_audit_enabled() {
-                eprintln!(
-                    "M73_FALLBACK site=brtsd target={target} is_portal_bridge={} code_null={}",
-                    pjc.is_portal_bridge(),
-                    pjc.code_ptr.is_null()
-                );
-            }
-            depth
-        }
-    }
+    // #73 family(ii) Slice B: source the not-taken-arm depth off the genuine
+    // jitcode `target` through the compile-time `depth_trivia` twin, retiring
+    // the `python_pc_for_jitcode_pc` inversion + runtime
+    // `skip_python_trivia_forward` + static-liveness read. The twin is built for
+    // every drained real-code jitcode (codewriter.rs), and the Slice A census
+    // (`PYRE_M73_ENCODE_AUDIT`) proved the empty-twin fallback is never reached
+    // here (0 fallback trips / 162 programs; this reader 1181 hits, all
+    // populated). The `debug_assert` re-certifies the invariant in test builds.
+    debug_assert!(
+        pjc.depth_trivia_populated(),
+        "branch_resume_target_stack_depth on an unpopulated depth-trivia twin at target={target}"
+    );
+    pjc.depth_trivia_for_jitcode_pc(target)
 }
 
 /// Flat-free (#267) boxed-int kept-slot hazard: a kept operand-stack slot
@@ -10004,40 +9977,15 @@ fn branch_resume_target_stack_depth_any_leg(target: usize, jitcode_index: u32) -
     if pjc.code_ptr.is_null() {
         return None;
     }
-    let code_obj = unsafe { &*pjc.code_ptr };
-    let py = python_pc_for_jitcode_pc(&pjc.metadata, target) as usize;
-    let py = skip_python_trivia_forward(code_obj, py);
-    let depth_opt = crate::liveness::liveness_for(pjc.code_ptr)
-        .depth_at_py_pc()
-        .get(py)
-        .copied();
-    // task#50 #73-core: certify the shared `depth_trivia_by_jit_pc` twin at the
-    // leg-independent depth probe. Same static-liveness + trivia-skip source as
-    // the two full-body-walk readers, so the same twin must reproduce it off the
-    // genuine jitcode `target`. Off in production.
-    if m73_encode_audit_enabled() && pjc.depth_trivia_populated() {
-        assert_eq!(
-            pjc.depth_trivia_for_jitcode_pc(target),
-            depth_opt,
-            "depth_trivia twin diverges from branch_resume_target_stack_depth_any_leg at target={target} py={py}"
-        );
-    }
-    if pjc.depth_trivia_populated() {
-        pjc.depth_trivia_for_jitcode_pc(target)
-    } else {
-        // Slice A census: soft, non-aborting count of the py_pc-inversion
-        // fallback (empty depth-trivia twin). Highest-risk site — keys on the
-        // caller's `ctx.outer_jitcode_index` (recorded as outer_idx). Zero
-        // output == dead.
-        if m73_encode_audit_enabled() {
-            eprintln!(
-                "M73_FALLBACK site=brtsd_anyleg target={target} outer_idx={jitcode_index} is_portal_bridge={} code_null={}",
-                pjc.is_portal_bridge(),
-                pjc.code_ptr.is_null()
-            );
-        }
-        depth_opt
-    }
+    // #73 family(ii) Slice B: twin-sourced leg-independent depth, py_pc inversion
+    // retired (see `branch_resume_target_stack_depth`). Slice A census: this
+    // reader 1178 hits, all populated, 0 fallback trips — including at the
+    // `outer_jitcode_index==0` coincidence that reads `jitcodes[0]`.
+    debug_assert!(
+        pjc.depth_trivia_populated(),
+        "branch_resume_target_stack_depth_any_leg on an unpopulated depth-trivia twin at target={target} idx={jitcode_index}"
+    );
+    pjc.depth_trivia_for_jitcode_pc(target)
 }
 
 /// `generate_guard` (`pyjitpl.py:2599-2603`) keys `after_residual_call`

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -9171,6 +9171,25 @@ pub(crate) fn m73_perop_audit_enabled() -> bool {
     *ENABLED.get_or_init(|| std::env::var_os("PYRE_M73_PEROP_AUDIT").is_some())
 }
 
+/// `PYRE_M73_BRANCH_AUDIT` (#73 S3 phase-0, default OFF): census that, for a
+/// depth-0 branch guard (`GuardTrue`/`GuardFalse`), measures whether carrying
+/// the walk's genuine JitCode resume coordinate `op_pc` (== the branch
+/// `other_target` produced by `resolve_branch_target_through_trampoline`)
+/// directly would be byte-behavior-safe versus today's py_pc round-trip marker
+/// (`resume_jitcode_pc_for(py_pc)`). Emits one `M73_BRANCH` line per depth-0
+/// branch capture: `eq=1` when `op_pc` coincides with the marker (carry is a
+/// byte-identical re-source), `eq=0 ...` with per-consumer agreement at
+/// `op_pc` vs `marker` (liveness banks + bridge maps + const refill), a direct
+/// `python_pc_for_jitcode_pc(op_pc)`-vs-`py_pc` probe (the marker path applies
+/// `skip_python_trivia_forward`, this inverse does not — it is the real signal
+/// because a non-decodable `op_pc` self-masks the consumers back to the py_pc
+/// baseline), and the `can_decode_live_vars(op_pc)` flag; or `eq=nomarker`
+/// when `py_pc` carries no resume entry. Off in production.
+pub(crate) fn m73_branch_audit_enabled() -> bool {
+    static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ENABLED.get_or_init(|| std::env::var_os("PYRE_M73_BRANCH_AUDIT").is_some())
+}
+
 /// `PYRE_M73_PEROP_CARRY` (#73 S2, default ON): source a specialization
 /// guard's (`GuardValue`/`GuardClass`) resume coordinate from the walk
 /// cursor's per-op `-live-` BEFORE anchor (`ctx.live_before_jit_pc`,
@@ -10592,6 +10611,115 @@ fn walker_capture_snapshot_for_last_guard_impl(
                                     "M73_PEROP_SPEC eq=0 py_pc={} lb={} bh={} banks_eq={} \
                                      bmaps_eq={} const_eq={}",
                                     py_pc, lb, bh, banks_eq, bmaps_eq, const_eq
+                                );
+                            }
+                        }
+                    }
+                }
+                // #73 S3 phase-0 census: for a depth-0 branch guard
+                // (`GuardTrue`/`GuardFalse`) measure whether carrying the walk's
+                // genuine JitCode resume coordinate `op_pc` (== `other_target`)
+                // directly is byte-behavior-safe versus today's py_pc round-trip
+                // marker (`resume_jitcode_pc_for(py_pc)`). This arm is enclosed
+                // by `!inline_subwalk && !full_body_sym.is_null()`, and depth-0
+                // is guaranteed because kept-stack (depth>0) branch guards set
+                // `BRANCH_GUARD_JITCODE_PC` and take the raw-`op.pc` arm above
+                // instead. Unlike the specialization census it compares against
+                // `marker` (the ACTUAL carried word), not `NO_JITCODE_PC`, and
+                // adds a DIRECT `python_pc_for_jitcode_pc(op_pc)`-vs-`py_pc`
+                // probe to defeat the `can_decode_live_vars` self-masking that
+                // would otherwise report false agreement for a non-decodable
+                // `op_pc`. Read-only: nothing here mutates the carried word.
+                //
+                // Phase-0 corpus result (1506 captures): `op_pc == marker` in
+                // ~31% (a vacuous re-source — `marker` is still derived), and in
+                // the ~69% divergent majority `op_pc` is NON-decodable
+                // (`can_decode_live_vars == false`) so a decoder consuming it
+                // ignores it and falls back to the py_pc path
+                // (`resolve_resume_pc_with_jitcode_pc`, pyjitcode.rs), which
+                // diverges from the `marker` path in the bridge maps / const
+                // refill. The walk's raw `other_target` is therefore NOT a
+                // byte-identical substitute for `marker`: the
+                // `resume_jitcode_pc_for(py_pc)` normalization to the decodable
+                // block-head `-live-` marker is load-bearing, not a removable
+                // round-trip. Retiring it for the branch family needs a
+                // jitcode-keyed resume-marker twin (author the block-head marker
+                // in jitcode space), not a raw-target carry.
+                if m73_branch_audit_enabled() {
+                    let is_branch = matches!(
+                        ctx.trace_ctx.last_guard_opcode(),
+                        Some(OpCode::GuardTrue | OpCode::GuardFalse)
+                    );
+                    if is_branch {
+                        match marker {
+                            None => {
+                                eprintln!(
+                                    "M73_BRANCH eq=nomarker py_pc={} op_pc={}",
+                                    py_pc, op_pc
+                                );
+                            }
+                            Some(m) if op_pc == m => {
+                                eprintln!("M73_BRANCH eq=1 py_pc={} op_pc={}", py_pc, op_pc);
+                            }
+                            Some(m) => {
+                                // op_pc != marker: probe the two divergence
+                                // sources and every consumer.
+                                let ji = jitcode_index as i32;
+                                let pp = py_pc as i32;
+                                // (1) direct skip_trivia-asymmetry / decodability
+                                //     probe on op_pc. `python_pc_for_jitcode_pc`
+                                //     has NO skip_trivia; `py_pc` DID get it.
+                                //     Also record `can_decode_live_vars(op_pc)` — a
+                                //     non-decodable op_pc makes the consumers below
+                                //     silently fall back to the pp baseline
+                                //     (self-masking), so `inv_*` is the real signal.
+                                let (inv_pp, decodable) = unsafe {
+                                    let jc = &*sym.jitcode;
+                                    let inv =
+                                        python_pc_for_jitcode_pc(&jc.payload.metadata, op_pc);
+                                    let dec = jc
+                                        .payload
+                                        .jitcode
+                                        .can_decode_live_vars(op_pc, crate::state::op_live());
+                                    (inv, dec)
+                                };
+                                let inv_eq = inv_pp == py_pc;
+                                // (2) per-consumer agreement at op_pc vs marker
+                                //     (baseline = m, NOT NO_JITCODE_PC).
+                                let banks_o =
+                                    crate::state::frame_liveness_reg_indices_by_bank_at_with_jitcode_pc(
+                                        ji, pp, op_pc as i32,
+                                    );
+                                let banks_m =
+                                    crate::state::frame_liveness_reg_indices_by_bank_at_with_jitcode_pc(
+                                        ji, pp, m as i32,
+                                    );
+                                let banks_eq = banks_o.int == banks_m.int
+                                    && banks_o.ref_ == banks_m.ref_
+                                    && banks_o.float == banks_m.float;
+                                let bm_o = crate::state::bridge_semantic_maps_at_with_jitcode_pc(
+                                    ji, pp, op_pc as i32,
+                                );
+                                let bm_m = crate::state::bridge_semantic_maps_at_with_jitcode_pc(
+                                    ji, pp, m as i32,
+                                );
+                                let bmaps_eq = bm_o.stack_depth_at_pc == bm_m.stack_depth_at_pc
+                                    && bm_o.pcdep_entries == bm_m.pcdep_entries;
+                                let const_eq =
+                                    crate::state::const_ref_slots_at_pc_at(ji, pp, op_pc as i32)
+                                        == crate::state::const_ref_slots_at_pc_at(ji, pp, m as i32);
+                                eprintln!(
+                                    "M73_BRANCH eq=0 py_pc={} op_pc={} marker={} inv_pp={} \
+                                     inv_eq={} decodable={} banks_eq={} bmaps_eq={} const_eq={}",
+                                    py_pc,
+                                    op_pc,
+                                    m,
+                                    inv_pp,
+                                    inv_eq,
+                                    decodable,
+                                    banks_eq,
+                                    bmaps_eq,
+                                    const_eq
                                 );
                             }
                         }

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -9213,6 +9213,21 @@ pub(crate) fn m73_flip_audit_enabled() -> bool {
     *ENABLED.get_or_init(|| std::env::var_os("PYRE_M73_FLIP_AUDIT").is_some())
 }
 
+/// `PYRE_M73_DERIVED_AUDIT` (#73 S4, default OFF): the py_pc-deletion
+/// precondition census. For each depth-0 branch-guard capture, compares the
+/// resume consumers (liveness banks, bridge semantic maps, const ref slots,
+/// AND the loop-header walk-entry merge-point/register seed) keyed at the raw
+/// `derived` (not-taken-arm jitcode offset) vs the block-head `marker` the
+/// decode currently reconstructs. Certifies `consumers(derived) ==
+/// consumers(marker)` on the `derived != marker` subset — the precondition for
+/// returning `derived` directly and deleting the py_pc round-trip from
+/// `expand_branch_carried`. Read-only; OFF is byte-identical, ON adds only
+/// `M73_DERIVED` stderr lines.
+pub(crate) fn m73_derived_audit_enabled() -> bool {
+    static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ENABLED.get_or_init(|| std::env::var_os("PYRE_M73_DERIVED_AUDIT").is_some())
+}
+
 /// `PYRE_M73_PEROP_CARRY` (#73 S2, default ON): source a specialization
 /// guard's (`GuardValue`/`GuardClass`) resume coordinate from the walk
 /// cursor's per-op `-live-` BEFORE anchor (`ctx.live_before_jit_pc`,
@@ -10992,6 +11007,115 @@ fn walker_capture_snapshot_for_last_guard_impl(
                                         );
                                     }
                                 }
+                            }
+                        }
+                    }
+                }
+                // #73 S4 (SUB-A) derived-vs-marker precondition census
+                // (`PYRE_M73_DERIVED_AUDIT`, default OFF): a STANDALONE sibling
+                // of the FLIP_AUDIT block above (fires independently of it).
+                // For each depth-0 branch guard it re-derives its own `orgpc`
+                // (`ctx.live_before_jit_pc`) and the not-taken-arm landing
+                // `derived = decode_side_other_target(orgpc, flavor)`, then
+                // compares EVERY resume consumer keyed at the raw `derived`
+                // jitcode offset vs today's block-head `marker`: liveness banks
+                // (a), bridge semantic maps (b), const ref slots (c), and the
+                // loop-header walk-entry merge-point governance + (gr, rr) seed
+                // (d) — the leg banks/bmaps equality does NOT cover. Certifies
+                // `consumers(derived) == consumers(marker)`, the precondition
+                // for returning `derived` directly and deleting the py_pc
+                // round-trip in `expand_branch_carried`. Read-only; no asserts;
+                // the carried word is left untouched (OFF is byte-identical).
+                if m73_derived_audit_enabled() {
+                    let is_branch = matches!(
+                        ctx.trace_ctx.last_guard_opcode(),
+                        Some(OpCode::GuardTrue | OpCode::GuardFalse)
+                    );
+                    let orgpc = ctx.live_before_jit_pc;
+                    if is_branch && orgpc != usize::MAX {
+                        if let Some(m) = marker {
+                            let flavor_true = matches!(
+                                ctx.trace_ctx.last_guard_opcode(),
+                                Some(OpCode::GuardTrue)
+                            );
+                            let jc = unsafe { &*sym.jitcode };
+                            let code = jc.payload.jitcode.code.as_slice();
+                            if let Ok(derived) =
+                                decode_side_other_target(code, orgpc, flavor_true)
+                            {
+                                let derived_eq_marker = derived as i32 == m as i32;
+                                // Whether the walk cursor could key at `derived`
+                                // — the same `can_decode_live_vars` test the
+                                // consumers gate their jitcode-pc read on.
+                                let decodable = jc
+                                    .payload
+                                    .jitcode
+                                    .can_decode_live_vars(derived, crate::state::op_live());
+                                let ji = jitcode_index as i32;
+                                let pp = py_pc as i32;
+                                // (a) liveness reg-index banks.
+                                let banks_d =
+                                    crate::state::frame_liveness_reg_indices_by_bank_at_with_jitcode_pc(
+                                        ji, pp, derived as i32,
+                                    );
+                                let banks_m =
+                                    crate::state::frame_liveness_reg_indices_by_bank_at_with_jitcode_pc(
+                                        ji, pp, m as i32,
+                                    );
+                                let banks_eq = banks_d.int == banks_m.int
+                                    && banks_d.ref_ == banks_m.ref_
+                                    && banks_d.float == banks_m.float;
+                                // (b) bridge semantic maps (depth + pcdep).
+                                let bm_d = crate::state::bridge_semantic_maps_at_with_jitcode_pc(
+                                    ji, pp, derived as i32,
+                                );
+                                let bm_m = crate::state::bridge_semantic_maps_at_with_jitcode_pc(
+                                    ji, pp, m as i32,
+                                );
+                                let bmaps_eq = bm_d.stack_depth_at_pc == bm_m.stack_depth_at_pc
+                                    && bm_d.pcdep_entries == bm_m.pcdep_entries;
+                                // (c) const ref slot refill (cold in the default
+                                // corpus — both sides empty flags `const_cold`).
+                                let const_d =
+                                    crate::state::const_ref_slots_at_pc_at(ji, pp, derived as i32);
+                                let const_m =
+                                    crate::state::const_ref_slots_at_pc_at(ji, pp, m as i32);
+                                let const_eq = const_d == const_m;
+                                let const_cold = const_d.is_empty() && const_m.is_empty();
+                                // (d) loop-header walk-entry merge-point seed
+                                // (`sym.bridge_walk_entry_pc` -> entry ->
+                                // `loop_header_merge_point_regs`, trace.rs:1123 +
+                                // walk-replay start 1319). Compare BOTH the
+                                // governing merge-point selection (mirrors the
+                                // `<= entry` max / `>= entry` min pick at
+                                // trace.rs:379) AND the (gr, rr) register vectors
+                                // the real seed reads.
+                                let governing_mp = |coord: usize| -> Option<usize> {
+                                    crate::jitcode_runtime::decoded_ops(code)
+                                        .filter(|op| op.opname == "jit_merge_point")
+                                        .map(|op| op.pc)
+                                        .filter(|&p| p <= coord)
+                                        .max()
+                                        .or_else(|| {
+                                            crate::jitcode_runtime::decoded_ops(code)
+                                                .filter(|op| op.opname == "jit_merge_point")
+                                                .map(|op| op.pc)
+                                                .filter(|&p| p >= coord)
+                                                .min()
+                                        })
+                                };
+                                let regs_d =
+                                    crate::trace::loop_header_merge_point_regs(code, derived);
+                                let regs_m = crate::trace::loop_header_merge_point_regs(code, m);
+                                let mp_eq =
+                                    governing_mp(derived) == governing_mp(m) && regs_d == regs_m;
+                                eprintln!(
+                                    "M73_DERIVED derived={derived} marker={m} \
+                                     derived_eq_marker={derived_eq_marker} \
+                                     decodable={decodable} banks_eq={banks_eq} \
+                                     bmaps_eq={bmaps_eq} const_eq={const_eq} \
+                                     const_cold={const_cold} mp_eq={mp_eq}"
+                                );
                             }
                         }
                     }

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -9171,17 +9171,26 @@ pub(crate) fn m73_perop_audit_enabled() -> bool {
     *ENABLED.get_or_init(|| std::env::var_os("PYRE_M73_PEROP_AUDIT").is_some())
 }
 
-/// `PYRE_M73_PEROP_CARRY` (#73 S2, default OFF): source a specialization
+/// `PYRE_M73_PEROP_CARRY` (#73 S2, default ON): source a specialization
 /// guard's (`GuardValue`/`GuardClass`) resume coordinate from the walk
 /// cursor's per-op `-live-` BEFORE anchor (`ctx.live_before_jit_pc`,
 /// `pyjitpl.py:198`) instead of the py_pc-keyed `resume_jitcode_pc_for(py_pc)`
 /// block-head marker — the genuine JitCode cursor the migration authors resume
-/// data from. Byte-identical where the anchor coincides with the marker
-/// (99%+ of the corpus per the `PYRE_M73_PEROP_AUDIT` census); the divergent
-/// minority is gated by check.py output equality. Off in production.
+/// data from. Byte-behavior-identical: the per-op anchor coincides with the
+/// marker for 99%+ of specialization captures (`PYRE_M73_PEROP_AUDIT` census),
+/// and the divergent minority resumes correctly (per-op == `self.pc -
+/// SIZE_LIVE_OP`). Validated OFF==ON on check.py (155x2), cpython_tests
+/// (39x2), and extra_tests (219x2), both backends. Opt out with
+/// `PYRE_M73_PEROP_CARRY=0`.
 pub(crate) fn m73_perop_carry_enabled() -> bool {
     static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
-    *ENABLED.get_or_init(|| std::env::var_os("PYRE_M73_PEROP_CARRY").is_some())
+    *ENABLED.get_or_init(|| match std::env::var_os("PYRE_M73_PEROP_CARRY") {
+        Some(v) => {
+            let v = v.to_string_lossy();
+            v != "0" && !v.eq_ignore_ascii_case("false")
+        }
+        None => true,
+    })
 }
 
 pub(crate) fn python_pc_for_jitcode_pc(metadata: &crate::PyJitCodeMetadata, jit_pc: usize) -> u32 {

--- a/pyre/pyre-jit-trace/src/pyjitcode.rs
+++ b/pyre/pyre-jit-trace/src/pyjitcode.rs
@@ -709,6 +709,11 @@ impl PyJitCode {
         carried: i32,
         op_live: u8,
     ) -> Option<usize> {
+        // #73 S3.5: a depth-0 branch guard may carry its `orgpc` tagged into the
+        // word's negative space; expand it to the block-head marker the baseline
+        // would have carried before any offset use. No-op for offsets /
+        // NO_JITCODE_PC (the flip-off case), so byte-identical when off.
+        let carried = crate::jitcode_dispatch::expand_branch_carried(self, carried);
         let used_carried = carried != majit_ir::resumedata::NO_JITCODE_PC
             && carried >= 0
             && self.jitcode.can_decode_live_vars(carried as usize, op_live);

--- a/pyre/pyre-jit-trace/src/pyjitcode.rs
+++ b/pyre/pyre-jit-trace/src/pyjitcode.rs
@@ -234,6 +234,18 @@ pub struct PyJitCodeMetadata {
     /// leaves empty after the `pcdep_color_slots` color→slot inversion.
     /// Indexed by `py_pc`; empty for jitcodes with no inlined-callee resume.
     pub const_ref_slots_at_pc: Vec<Vec<(u16, i64)>>,
+    /// gh#73 S3.2: predecessor-keyed jitcode-pc twin of `const_ref_slots_at_pc`.
+    /// Each entry `(off, slots)` maps a JitCode byte offset to the const
+    /// operand-stack slot list of the py_pc that `python_pc_for_jitcode_pc(off)`
+    /// returns (block-head marker precedence, else the largest
+    /// `first_jit_pc_by_py_pc` at-or-before `off`). A PREDECESSOR binary search
+    /// (largest offset ≤ jit_pc) reproduces
+    /// `const_ref_slots_at_pc[python_pc_for_jitcode_pc(jit_pc)]` for a carried
+    /// resume coordinate. Built in the same `by_off` loop as `pcdep_by_jit_pc`;
+    /// empty for skeleton / portal-bridge / fixture. Read on the decode-identity
+    /// path of `const_ref_slots_at_pc_at`, mirroring the `pcdep_by_jit_pc` /
+    /// `depth_pred_by_jit_pc` twins' production use.
+    pub const_ref_slots_by_jit_pc: Vec<(usize, Vec<(u16, i64)>)>,
     /// True once `assembler.assemble`'s setup-time drain has run and stamped
     /// the per-Python-PC maps (`codewriter.rs` `finalize_jitcode`). The
     /// install-mode discriminators ([`PyJitCode::is_populated`] /
@@ -581,6 +593,21 @@ impl PyJitCode {
         Self::predecessor_index(search).map(|i| table[i].1)
     }
 
+    /// gh#73 S3.2: const operand-stack slots keyed by a JitCode byte offset via
+    /// the `const_ref_slots_by_jit_pc` predecessor twin. Equals
+    /// `const_ref_slots_at_pc[python_pc_for_jitcode_pc(jit_pc)]` by construction
+    /// for a carried resume coordinate; `None` when the twin is empty (skeleton /
+    /// portal-bridge / fixture). Consumed on the decode-identity path of
+    /// `const_ref_slots_at_pc_at`.
+    pub fn const_ref_slots_for_jitcode_pc(&self, jit_pc: usize) -> Option<Vec<(u16, i64)>> {
+        let table = &self.metadata.const_ref_slots_by_jit_pc;
+        if table.is_empty() {
+            return None;
+        }
+        let search = table.binary_search_by_key(&jit_pc, |&(off, _)| off);
+        Self::predecessor_index(search).map(|i| table[i].1.clone())
+    }
+
     /// task#50 #73-core: trivia-aware STATIC-liveness depth keyed by a JitCode
     /// byte offset, resolved with the SAME two tiers as
     /// `python_pc_for_jitcode_pc`: an EXACT marker match first (block-head
@@ -811,6 +838,7 @@ impl PyJitCode {
                 max_stackdepth: 0,
                 pcdep_color_slots: Vec::new(),
                 const_ref_slots_at_pc: Vec::new(),
+                const_ref_slots_by_jit_pc: Vec::new(),
                 is_drained: false,
             },
             code_ptr,

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -1536,6 +1536,11 @@ pub(crate) fn bridge_semantic_maps_at_with_jitcode_pc(
             };
         };
         let payload = &jc.payload;
+        // #73 S3.5: expand a tagged branch `orgpc` word to the block-head marker
+        // BEFORE the `>= 0` / offset uses below — a tagged NEGATIVE word cast to
+        // usize would otherwise be a huge OOB index. No-op for offsets /
+        // NO_JITCODE_PC (flip-off), so byte-identical when off.
+        let jitcode_pc = crate::jitcode_dispatch::expand_branch_carried(payload, jitcode_pc);
         // The rd_numb pc word may carry an after-residual-call marker;
         // recover the plain Python PC for the py_pc-keyed liveness/depth
         // tables (same decode as
@@ -1679,6 +1684,10 @@ pub(crate) fn const_ref_slots_at_pc_at(
         let Some(jc) = sd.jitcodes.get(jitcode_index as usize) else {
             return Vec::new();
         };
+        // #73 S3.5: expand a tagged branch `orgpc` word to the block-head marker
+        // before the `>= 0` / offset uses below. No-op for offsets /
+        // NO_JITCODE_PC (flip-off), so byte-identical when off.
+        let jitcode_pc = crate::jitcode_dispatch::expand_branch_carried(&jc.payload, jitcode_pc);
         let real_pc = if jitcode_pc != majit_ir::resumedata::NO_JITCODE_PC && jitcode_pc >= 0 {
             let jp = jitcode_pc as usize;
             if jc.payload.jitcode.can_decode_live_vars(jp, sd.op_live) {

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -1608,6 +1608,16 @@ pub(crate) fn bridge_semantic_maps_at_with_jitcode_pc(
                 match via_twin {
                     Some(pair) => pair,
                     None => {
+                        // Slice A census: soft, non-aborting count of the
+                        // py_pc re-inversion fallback (empty-twin portal bridge
+                        // or Err(0) colored coord). Emits ONLY when this arm
+                        // runs, so zero output == dead.
+                        if crate::jitcode_dispatch::bridge_audit_enabled() {
+                            eprintln!(
+                                "M73_FALLBACK site=bridge jp={jp} is_portal_bridge={}",
+                                payload.is_portal_bridge()
+                            );
+                        }
                         let rp =
                             crate::jitcode_dispatch::python_pc_for_jitcode_pc(&payload.metadata, jp)
                                 as usize;
@@ -1704,6 +1714,15 @@ pub(crate) fn const_ref_slots_at_pc_at(
                 // check.py certifies on the hot bridge path).
                 if let Some(slots) = jc.payload.const_ref_slots_for_jitcode_pc(jp) {
                     return slots;
+                }
+                // Slice A census: soft, non-aborting count of the py_pc
+                // re-inversion fallback (empty const-slot twin). Known COLD.
+                // Zero output == dead.
+                if crate::jitcode_dispatch::bridge_audit_enabled() {
+                    eprintln!(
+                        "M73_FALLBACK site=const jp={jp} is_portal_bridge={}",
+                        jc.payload.is_portal_bridge()
+                    );
                 }
                 crate::jitcode_dispatch::python_pc_for_jitcode_pc(&jc.payload.metadata, jp) as usize
             } else {

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -1682,6 +1682,20 @@ pub(crate) fn const_ref_slots_at_pc_at(
         let real_pc = if jitcode_pc != majit_ir::resumedata::NO_JITCODE_PC && jitcode_pc >= 0 {
             let jp = jitcode_pc as usize;
             if jc.payload.jitcode.can_decode_live_vars(jp, sd.op_live) {
+                // gh#73 S3.2: source the const slots directly from the carried
+                // genuine `jitcode_pc` via the predecessor-keyed twin, bypassing
+                // the `python_pc_for_jitcode_pc` re-inversion — the same
+                // decode-identity shape the pcdep/depth twins use at
+                // `bridge_semantic_maps_at_with_jitcode_pc`. A colored jitcode
+                // returns `Some` (an empty slot list is a legitimate hit); an
+                // empty twin (skeleton / portal-bridge) returns `None` and falls
+                // through to the re-inversion, which still keys the populated
+                // `const_ref_slots_at_pc`. Equal by construction (built in the
+                // same `by_off` loop, same predecessor keying, as the twins
+                // check.py certifies on the hot bridge path).
+                if let Some(slots) = jc.payload.const_ref_slots_for_jitcode_pc(jp) {
+                    return slots;
+                }
                 crate::jitcode_dispatch::python_pc_for_jitcode_pc(&jc.payload.metadata, jp) as usize
             } else {
                 majit_ir::resumedata::decode_resume_pc(pc).0 as usize
@@ -11874,6 +11888,7 @@ mod tests {
                 max_stackdepth: 0,
                 pcdep_color_slots: Vec::new(),
                 const_ref_slots_at_pc: Vec::new(),
+                const_ref_slots_by_jit_pc: Vec::new(),
                 is_drained: true,
             },
             std::ptr::null(),

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -368,7 +368,7 @@ pub fn trace_bytecode(
 /// count-prefixed register lists `gi, gr, gf, ri, rr, rf`.  Returns `None`
 /// when no preceding merge point exists (straight-line resume) or the
 /// operand stream is truncated.
-fn loop_header_merge_point_regs(code: &[u8], entry: usize) -> Option<(Vec<u8>, Vec<u8>)> {
+pub(crate) fn loop_header_merge_point_regs(code: &[u8], entry: usize) -> Option<(Vec<u8>, Vec<u8>)> {
     // The merge point governing `entry`.  A body-guard resume enters PAST the
     // merge point, so the merge point precedes `entry` and the last `op.pc <=
     // entry` is the governing one.  A HEADER-entry resume keys to the header

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -368,7 +368,10 @@ pub fn trace_bytecode(
 /// count-prefixed register lists `gi, gr, gf, ri, rr, rf`.  Returns `None`
 /// when no preceding merge point exists (straight-line resume) or the
 /// operand stream is truncated.
-pub(crate) fn loop_header_merge_point_regs(code: &[u8], entry: usize) -> Option<(Vec<u8>, Vec<u8>)> {
+pub(crate) fn loop_header_merge_point_regs(
+    code: &[u8],
+    entry: usize,
+) -> Option<(Vec<u8>, Vec<u8>)> {
     // The merge point governing `entry`.  A body-guard resume enters PAST the
     // merge point, so the merge point precedes `entry` and the last `op.pc <=
     // entry` is the governing one.  A HEADER-entry resume keys to the header

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -12891,6 +12891,7 @@ impl CodeWriter {
         // op offset or a block-head marker — never a mid-op byte.  Certified by
         // `PYRE_PCMAP_BRIDGE_AUDIT`; empty for skeleton / portal-bridge.
         let mut pcdep_by_jit_pc: Vec<(usize, Vec<(u8, u16, u16)>)> = Vec::new();
+        let mut const_ref_slots_by_jit_pc: Vec<(usize, Vec<(u16, i64)>)> = Vec::new();
         let mut depth_pred_by_jit_pc: Vec<(usize, u16)> = Vec::new();
         // task#50 #73-core: trivia-aware predecessor twin of the STATIC dense
         // liveness depth.  The ENCODE-side branch-resume depth reader
@@ -12973,8 +12974,10 @@ impl CodeWriter {
             for (&off, &py) in by_off.iter() {
                 let pcdep = pcdep_color_slots.get(py).cloned().unwrap_or_default();
                 let depth = depth_at_pc.get(py).copied().unwrap_or(0);
+                let const_slots = const_ref_slots_at_pc.get(py).cloned().unwrap_or_default();
                 pcdep_by_jit_pc.push((off, pcdep));
                 depth_pred_by_jit_pc.push((off, depth));
+                const_ref_slots_by_jit_pc.push((off, const_slots));
             }
             // Marker tier: exact-match, block-head precedence (first-seen dedup
             // gives the smallest py resolving at the marker offset).
@@ -13034,6 +13037,7 @@ impl CodeWriter {
             max_stackdepth: code.max_stackdepth as usize,
             pcdep_color_slots,
             const_ref_slots_at_pc,
+            const_ref_slots_by_jit_pc,
             is_drained: true,
         };
 


### PR DESCRIPTION
#73 walker-as-JitCode-cursor migration: the trace-recording walker's guard-resume coordinates become `-live-`-anchored JitCode offsets authored from the walk itself, replacing py_pc translation. Continuation of #366 (dense `pc_map` deleted, PR #426) into #73's literal title.

## Commits (14, each its own slice; every behavioral flip is env-gated with a byte-identical first slice)

**Per-op specialization carry**
- **S1** — install the two-anchor `-live-` walk cursor (`live_before_jit_pc` / `live_after_jit_pc`) + `PYRE_M73_ANCHOR_AUDIT`.
- **S2** — per-op `-live-` carry for `GuardValue`/`GuardClass` (`PYRE_M73_PEROP_CARRY`) + full-consumer census. Byte-identical gate-OFF.
- **S2b** — flip `PYRE_M73_PEROP_CARRY` default ON (opt-out `=0`).

**Branch-guard family (depth-0 `GuardTrue`/`GuardFalse`)**
- **S3 phase-0** — `PYRE_M73_BRANCH_AUDIT` census.
- **S3.1** — `PYRE_M73_ARM_AUDIT` decode-side arm-resolver (`decode_side_other_target`): `orgpc`+flavor re-derives the not-taken-arm landing byte-identically.
- **S3.2** — `const_ref_slots` jitcode-pc twin on the decode-identity read path.
- **S3.3** — decode-side flavor integrity audit (`PYRE_M73_FLAVOR_AUDIT`); flavor is recoverable at the native seam via `source_op_index`, no datum threaded.
- **S3.4** — `PYRE_M73_FLIP_AUDIT` flip-gate certificate (full-consumer reconstruction, 461 recon byte-identical).
- **S3.5** — carry `orgpc`+flavor tagged into the free negative space of the `jitcode_pc` word (`PYRE_M73_BRANCH_CARRY`, default OFF); self-certifying (byte-identical by construction).
- **S3.5b** — flip `PYRE_M73_BRANCH_CARRY` default ON (opt-out `=0`).

**py_pc deletion at the branch decode path**
- **S4 SUB-A** — `PYRE_M73_DERIVED_AUDIT` precondition census: resume consumers keyed at the raw `derived` (jitcode offset) vs the block-head `marker`, over four legs (liveness banks, bridge semantic maps, const ref slots, and the loop-header walk-entry merge-point + register seed). Certifies `derived == marker` for 100% of the reachable branch-carry population.
- **S4-a** — `expand_branch_carried` returns `derived` directly, deleting the `python_pc_for_jitcode_pc → skip_python_trivia_forward → resume_jitcode_pc_for` round-trip (and its overshoot clamp) from the branch guard-resume decode. Byte-identical by the encode self-cert invariant (a word is tagged only when `derived == marker`).

**py_pc deletion at the branch-depth readers (family ii)**
- **S4 Slice A** — `PYRE_M73_ENCODE_AUDIT` fallback-never-taken census: soft probes at the depth-trivia / bridge / const py_pc-inversion fallbacks. Zero fallback trips over the corpus; positive control confirms the twin path is taken.
- **S4 Slice B** — collapse `branch_resume_target_stack_depth` and `_any_leg` to source the not-taken-arm stack depth off the genuine jitcode `target` through the `depth_trivia` twin, deleting the `python_pc_for_jitcode_pc` inversion + `skip_python_trivia_forward` + static `depth_at_py_pc` read. Byte-identical (Slice A census); `debug_assert` re-certifies the twin is populated. The bridge / const / kshbih fallbacks are retained as the portal-bridge + non-carried resume coordinate path (no jitcode coordinate in hand) — out of #73 scope.

## Validation
- `check.py --backend dynasm,cranelift` = 160/160 each, byte-identical at every gate-OFF and at the shipped default config.
- `cpython_tests` (dynasm) 39 PASS / 0 FAIL, no regressions; `extra_tests` dynasm 143 / cranelift 143 / cpython 172 of 219.
- `cargo test -p pyre-jit-trace` 277, `-p majit-ir` 300.

Rebased onto current `main`, reconciling with the parallel `#366`/`#369` landings: `#456` (resume Ref-liveness) retired the `PYRE_M73_LIVENESS` flip gate — the branch-arm Ref-liveness reader now flips by default there, so this branch's reader-#3 follow-up is superseded; `bb8a4d03` (#369 M369 recover-audit) reshaped `resolve_resume_pc_with_jitcode_pc`, into which S3.5's `expand_branch_carried` is prepended (no-op when the flip is off).

py_pc is removed from the depth-0 branch guard-resume **decode** path and the branch-depth readers. Full deletion of `python_pc_for_jitcode_pc` / `resume_jitcode_pc_for` is out of scope here — the entry-py_pc / bridge-build family retains real callers (an entry py_pc has no jitcode coordinate in hand).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved JIT resume and branch handling for more accurate execution after guard failures.
  * Improved preservation and recovery of constant-reference information across compiled code paths.
  * Added safer handling for encoded resume positions and fallback scenarios.

* **Diagnostics**
  * Added optional, environment-controlled audits and diagnostic logging to help identify guard and metadata inconsistencies without affecting default behavior.

* **Tests**
  * Added coverage for branch metadata encoding, decoding, boundary values, and serialization compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->