### PR TITLE
jit: try/except/raise codewriter faithfulness + resume Ref-liveness

### DIFF
--- a/majit/majit-ir/src/forwarding.rs
+++ b/majit/majit-ir/src/forwarding.rs
@@ -30,7 +30,7 @@ use crate::value::{Const, InputArg};
 /// is a value-typed `Copy` payload with no `_forwarded` slot of its
 /// own, unlike `ResOp`/`InputArg`. Keeping it as a separate variant
 /// retires a dedicated const-as-chain-target carrier.
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub enum Forwarded {
     None,
 
@@ -85,6 +85,23 @@ pub enum Forwarded {
     // validation before landing. `Op.vecinfo` (resoperation.rs) is the SEPARATE
     // permanent `resoperation.py` VecOp datatype/bytesize/signed/count
     // store and stays.
+}
+
+impl std::fmt::Debug for Forwarded {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Compact by design: `Info(OpInfo)` carries the abstract-value graph
+        // (nested ops / virtual fields whose own `forwarded` slots reference
+        // back through non-`Weak` `Info` edges), so a derived Debug recurses
+        // without bound and overflows the stack when a `forwarded`-bearing
+        // `Op` / `InputArg` is printed. Render the variant shape only.
+        match self {
+            Forwarded::None => f.write_str("None"),
+            Forwarded::Op(_) => f.write_str("Op(Weak)"),
+            Forwarded::InputArg(_) => f.write_str("InputArg(Weak)"),
+            Forwarded::Const(c) => write!(f, "Const({c:?})"),
+            Forwarded::Info(_) => f.write_str("Info(..)"),
+        }
+    }
 }
 
 /// `resoperation.py AbstractResOpOrInputArg` — the shared `_forwarded`

--- a/majit/majit-metainterp/src/optimizeopt/optimizer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/optimizer.rs
@@ -3329,15 +3329,22 @@ impl Optimizer {
                     .collect();
                 if crate::majit_log_enabled() {
                     for entry in &ctx.exported_short_boxes {
+                        // Print args / same_as_source as OpRefs, not via the
+                        // Operands' derived Debug: a bound InputArg/Op carries a
+                        // `forwarded` slot whose Debug walks the whole abstract-value
+                        // graph (fields, descrs, nested ops), dumping tens of MB per
+                        // box and stalling the run.
+                        let arg_oprefs: Vec<OpRef> =
+                            entry.op.getarglist().iter().map(|a| a.to_opref()).collect();
                         eprintln!(
                             "[jit] exported_short_box: kind={:?} pos={:?} opcode={:?} args={:?} descr_idx={:?} invented={} same_as_source={:?}",
                             entry.kind,
                             entry.op.pos.get(),
                             entry.op.opcode,
-                            entry.op.getarglist(),
+                            arg_oprefs,
                             entry.op.getdescr().map(|d| d.index()),
                             entry.invented_name,
-                            entry.same_as_source,
+                            entry.same_as_source.as_ref().map(|o| o.to_opref()),
                         );
                     }
                 }

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -9084,29 +9084,16 @@ pub(crate) fn m73_encode_audit_enabled() -> bool {
     *ENABLED.get_or_init(|| std::env::var_os("PYRE_M73_ENCODE_AUDIT").is_some())
 }
 
-/// `PYRE_M73_LIVENESS_AUDIT` enables the assertion that querying the register
-/// liveness banks off the genuine jitcode `target`
-/// (`frame_liveness_reg_indices_by_bank_at_with_jitcode_pc(idx, py, target)`)
-/// reproduces the banks the ENCODE-side branch-arm readers compute via the
-/// `python_pc_for_jitcode_pc(target)` inversion + `skip_python_trivia_forward`.
-/// Certifies the precondition for re-sourcing the branch-arm Ref-liveness off
-/// the carried coordinate without the py_pc channel. Off in production.
+/// `PYRE_M73_LIVENESS_AUDIT` enables the assertion that the production
+/// branch-arm Ref-liveness banks — now sourced off the genuine jitcode
+/// `target` via `frame_liveness_reg_indices_by_bank_at_with_jitcode_pc(idx,
+/// py, target)` — still equal the banks the retired
+/// `python_pc_for_jitcode_pc(target)` inversion + `skip_python_trivia_forward`
+/// reader computes. Regression guard for the landed re-sourcing off the
+/// carried coordinate; off in production.
 pub(crate) fn m73_liveness_audit_enabled() -> bool {
     static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
     *ENABLED.get_or_init(|| std::env::var_os("PYRE_M73_LIVENESS_AUDIT").is_some())
-}
-
-/// `PYRE_M73_LIVENESS` (default OFF) flips the branch-arm Ref-liveness reader
-/// from the `python_pc_for_jitcode_pc` inversion to the jitcode-pc-keyed
-/// `frame_liveness_reg_indices_by_bank_at_with_jitcode_pc` twin, preferring the
-/// carried `target` coordinate. Behavioral flip (no byte-identity guarantee),
-/// certified by the always-available `PYRE_M73_LIVENESS_AUDIT` full-bank
-/// equality + `check.py`. When the carried coordinate is not `-live-`-decodable
-/// the twin falls back to the same `resolve_resume_pc` path as the raw reader,
-/// so unpopulated / portal-bridge installs are unaffected.
-pub(crate) fn m73_liveness_enabled() -> bool {
-    static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
-    *ENABLED.get_or_init(|| std::env::var_os("PYRE_M73_LIVENESS").is_some())
 }
 
 pub(crate) fn python_pc_for_jitcode_pc(metadata: &crate::PyJitCodeMetadata, jit_pc: usize) -> u32 {
@@ -9572,30 +9559,26 @@ fn branch_arm_resume_ref_liveness(
         let code = &*jc.payload.code_ptr;
         let py = python_pc_for_jitcode_pc(&jc.payload.metadata, target) as usize;
         let py = skip_python_trivia_forward(code, py);
-        let banks = crate::state::frame_liveness_reg_indices_by_bank_at(
+        // Source the branch-arm Ref-liveness banks off the genuine carried
+        // jitcode `target` via the jitcode-pc-keyed twin, bypassing the
+        // `python_pc_for_jitcode_pc` inversion + `pc_map` re-key. The twin
+        // falls back to the same `resolve_resume_pc` path (keyed on `py`) for
+        // unpopulated / portal-bridge installs, so those are unaffected.
+        let banks = crate::state::frame_liveness_reg_indices_by_bank_at_with_jitcode_pc(
             outer_jitcode_index as i32,
             py as i32,
+            target as i32,
         );
         if m73_liveness_audit_enabled() {
-            let twin = crate::state::frame_liveness_reg_indices_by_bank_at_with_jitcode_pc(
+            let via_inversion = crate::state::frame_liveness_reg_indices_by_bank_at(
                 outer_jitcode_index as i32,
                 py as i32,
-                target as i32,
             );
             assert_eq!(
-                twin, banks,
+                banks, via_inversion,
                 "liveness twin diverges from branch_arm_resume_ref_liveness at target={target} py={py}"
             );
         }
-        let banks = if m73_liveness_enabled() {
-            crate::state::frame_liveness_reg_indices_by_bank_at_with_jitcode_pc(
-                outer_jitcode_index as i32,
-                py as i32,
-                target as i32,
-            )
-        } else {
-            banks
-        };
         let live: std::collections::HashSet<u16> = banks.ref_.iter().map(|&c| c as u16).collect();
         let num_regs_r = jc.payload.jitcode.num_regs_r() as u16;
         Some((live, num_regs_r))

--- a/pyre/pyre-jit-trace/src/pyjitcode.rs
+++ b/pyre/pyre-jit-trace/src/pyjitcode.rs
@@ -154,9 +154,12 @@ pub struct PyJitCodeMetadata {
     /// `compute_nested_inline_caller_frame`) nulls the not-yet-produced result
     /// register before serializing the paused caller frame; that slot is not a
     /// live Variable at the return PC, so it carries no `pcdep_color_slots`
-    /// entry. This precomputed table (built in `finalize_jitcode` from the
-    /// compile-time stack coloring) supplies its color. Same length as
-    /// `depth_at_py_pc`; empty for non-compiled skeleton metadata.
+    /// entry — the same not-yet-defined call-result box that `_result_argcode`
+    /// (pyjitpl.py) clears in a non-topmost resumed frame (`registers_r[index]
+    /// = CONST_NULL` for the `'r'` argcode). This precomputed table (built in
+    /// `finalize_jitcode` from the compile-time stack coloring) supplies its
+    /// color. Same length as `depth_at_py_pc`; empty for non-compiled skeleton
+    /// metadata.
     pub result_color_at_pc: Vec<u16>,
     /// Post-regalloc Ref-bank color of the portal jitdriver's first red
     /// argument (`frame`).  RPython parity: `pypy/module/pypyjit/
@@ -204,7 +207,12 @@ pub struct PyJitCodeMetadata {
     /// `(bank, color, slot)`.
     ///
     /// Records each slot's TRUE per-program-point SSA color — the runtime
-    /// analog of RPython's compile-time baked register operands. Stack
+    /// analog of RPython's compile-time baked register operands, precomputed
+    /// per Python PC so a guard resume can invert color→slot without walking
+    /// the jitcode. It is the static form of the per-bank register enumeration
+    /// that `resume.py`'s `_prepare_next_section` → `enumerate_vars` dispatches
+    /// at resume time to seed `registers_i` / `registers_r` / `registers_f`
+    /// from the encoded section. Stack
     /// slots and body locals are freely chordal-colored (only the
     /// startblock inputargs are pinned by `enforce_input_args`,
     /// `flatten.py:88-100` parity), so there is no `color == slot`

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -5420,6 +5420,27 @@ pub(crate) fn p2_drain_enabled() -> bool {
     std::env::var_os("PYRE_P2_DRAIN").is_some()
 }
 
+/// Decode one suspended inline-callee frame's resume section into a
+/// [`ReconstructRecipe`], or `None` to decline the multi-frame inline rebuild.
+///
+/// `resume.py rebuild_from_resumedata` (`newframe(jitcode)` +
+/// `setup_resume_at_op` + `consume_boxes` per suspended frame) ALWAYS
+/// allocates and refills every inlined frame — its snapshot writer guarantees
+/// the liveness invariants the reader consumes. Pyre's per-function portal
+/// model + super-instruction bytecode cannot guarantee those invariants for
+/// every reconstructed callee, so this returns `None` exactly where a rebuild
+/// would be unsound: a no-snapshot pc, an unresolved jitcode, cell/free vars
+/// (cell contents live outside the resume stream → LOAD_DEREF NameError),
+/// unrecoverable callee globals, an `enumerate_vars` count that disagrees with
+/// the encoded section (`consume_boxes`), or an int/float-bank register with no
+/// boxed-Ref source.
+///
+/// The `None` fallback is semantically equivalent in program result: the caller
+/// declines the multi-frame inline reconstruction and routes to the
+/// conservative single-frame bridge / blackhole resume, which re-enters the
+/// interpreter and resumes correctly — only the inline-frame reconstruction
+/// optimization is forfeited, never correctness. The forward inline capture
+/// declines on the same conditions.
 fn reconstruct_inline_recipe(
     ctx: &mut majit_metainterp::TraceCtx,
     frame: &majit_ir::resumedata::RebuiltFrame,

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -319,8 +319,9 @@ impl FrameState {
             data.push(Some(w_type.clone()));
             data.push(Some(w_value.clone()));
         } else {
-            data.push(Some(super::flow::Constant::none().into()));
-            data.push(Some(super::flow::Constant::none().into()));
+            let (none_type, none_value) = last_exception_none_pair();
+            data.push(Some(none_type.into()));
+            data.push(Some(none_value.into()));
         }
         if let Some((frame, ec)) = &self.portal_extras {
             data.push(Some(frame.clone()));
@@ -506,30 +507,20 @@ impl FrameState {
                 union_flow_value(left_type, right_type, fresh_variable)?,
                 union_flow_value(left_value, right_value, fresh_variable)?,
             )),
-            (Some((left_type, left_value)), None) => Some((
-                union_flow_value(
-                    left_type,
-                    &super::flow::Constant::none().into(),
-                    fresh_variable,
-                )?,
-                union_flow_value(
-                    left_value,
-                    &super::flow::Constant::none().into(),
-                    fresh_variable,
-                )?,
-            )),
-            (None, Some((right_type, right_value))) => Some((
-                union_flow_value(
-                    &super::flow::Constant::none().into(),
-                    right_type,
-                    fresh_variable,
-                )?,
-                union_flow_value(
-                    &super::flow::Constant::none().into(),
-                    right_value,
-                    fresh_variable,
-                )?,
-            )),
+            (Some((left_type, left_value)), None) => {
+                let (none_type, none_value) = last_exception_none_pair();
+                Some((
+                    union_flow_value(left_type, &none_type.into(), fresh_variable)?,
+                    union_flow_value(left_value, &none_value.into(), fresh_variable)?,
+                ))
+            }
+            (None, Some((right_type, right_value))) => {
+                let (none_type, none_value) = last_exception_none_pair();
+                Some((
+                    union_flow_value(&none_type.into(), right_type, fresh_variable)?,
+                    union_flow_value(&none_value.into(), right_value, fresh_variable)?,
+                ))
+            }
         };
         // Portal extras carry graph-level identity; if the two sides
         // are both seeded they must reference the same `(frame, ec)`
@@ -643,6 +634,24 @@ where
 
 fn union_kind(left: Option<Kind>, right: Option<Kind>) -> Option<Kind> {
     if left == right { left } else { None }
+}
+
+/// The absent-`last_exception` sentinel pair, kind-matched per slot to
+/// the exception link types: `etype`/`>i` is `Kind::Int`, `evalue`/`>r`
+/// is `Kind::Ref` (`assembler.py:220`; exceptblock inputargs in flow.rs).
+/// A raising predecessor carries a typed `(Int, Ref)` pair, so an absent
+/// predecessor must pad each slot with the SAME kind, otherwise
+/// `union_flow_value`'s `union_kind(Int, Ref)` collapses to an untyped
+/// merged Variable that later defaults to `Ref` and mints a `ref_copy`
+/// over the real Int type source.  `framestate.py:66-71 _exc_args` pads
+/// both slots with one `Constant(None)` because flowspace Variables are
+/// untyped; the rtyper assigns the exception slots a uniform type
+/// afterwards, and pyre carries that uniform per-slot typing here.
+fn last_exception_none_pair() -> (super::flow::Constant, super::flow::Constant) {
+    (
+        super::flow::Constant::new(super::flow::ConstantValue::None, Some(Kind::Int)),
+        super::flow::Constant::new(super::flow::ConstantValue::None, Some(Kind::Ref)),
+    )
 }
 
 fn entry_frame_state(code: &CodeObject, frame_inputs: FrameInputs) -> FrameState {

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -6718,12 +6718,30 @@ impl CodeWriter {
                 // insert_switch_exits` ("switch link requires
                 // Signed/Bool llexitcase").  Force a block boundary
                 // here so the next PC's ops emit into a fresh egg.
-                let canraise_pending = matches!(
-                    current_block.block().borrow().exitswitch,
-                    Some(super::flow::ExitSwitch::Value(super::flow::FlowValue::Constant(
-                        ref c,
-                    ))) if matches!(c.value, super::flow::ConstantValue::Atom(super::flow::Atom::LastException))
-                );
+                // An explicit `raise X` covered by a try attaches its
+                // exception edge through `attach_catch_exception_edge`, which
+                // sets `exitswitch=LastException` — the same shape a canraise
+                // OP produces.  `canraise_pending` must NOT treat that as a
+                // half-closed canraise block: an explicit raise is an
+                // unconditional terminator with no normal continuation.
+                // Leaving it true drives `force_branch_boundary` at the next
+                // merge PC, so `mergeblock` appends a spurious normal exit onto
+                // the raise-terminated block (making it multi-exit); then
+                // `insert_exits` lowers the raise edge as a plain catch and
+                // drops the `raise` op, so the handler never runs.
+                let has_explicit_raise = current_block
+                    .block()
+                    .borrow()
+                    .exits
+                    .iter()
+                    .any(|e| e.borrow().explicit_raise_value.is_some());
+                let canraise_pending = !has_explicit_raise
+                    && matches!(
+                        current_block.block().borrow().exitswitch,
+                        Some(super::flow::ExitSwitch::Value(super::flow::FlowValue::Constant(
+                            ref c,
+                        ))) if matches!(c.value, super::flow::ConstantValue::Atom(super::flow::Atom::LastException))
+                    );
                 let force_branch_boundary = needs_fallthrough
                     && current_block
                         .framestate()
@@ -7545,16 +7563,36 @@ impl CodeWriter {
                     let block_closed_by_terminator = {
                         let block_rc = current_block.block();
                         let block = block_rc.borrow();
+                        // An explicit `raise X` covered by a try attaches its
+                        // exception edge through `attach_catch_exception_edge`,
+                        // which sets `exitswitch=LastException` — the same
+                        // canraise shape a real raising OP produces.  The
+                        // LastException exclusion below keeps a canraise OP's
+                        // block open so the walker keeps dispatching the op's
+                        // normal-flow result and the ops after it.  An explicit
+                        // raise has no normal continuation: it is an
+                        // unconditional terminator, so the block must close.
+                        // Left open, the walker serialises the following
+                        // fall-through / loop-back ops (and a `mergeblock`
+                        // appends a spurious normal exit) into the raise's
+                        // block; `insert_exits` then lowers the raise edge as a
+                        // plain catch and drops the `raise` op, so the handler
+                        // is never entered.
+                        let has_explicit_raise = block
+                            .exits
+                            .iter()
+                            .any(|e| e.borrow().explicit_raise_value.is_some());
                         !block.exits.is_empty()
-                            && !matches!(
-                                block.exitswitch,
-                                Some(super::flow::ExitSwitch::Value(super::flow::FlowValue::Constant(
-                                    ref c,
-                                ))) if matches!(
-                                    c.value,
-                                    super::flow::ConstantValue::Atom(super::flow::Atom::LastException)
-                                )
-                            )
+                            && (has_explicit_raise
+                                || !matches!(
+                                    block.exitswitch,
+                                    Some(super::flow::ExitSwitch::Value(super::flow::FlowValue::Constant(
+                                        ref c,
+                                    ))) if matches!(
+                                        c.value,
+                                        super::flow::ConstantValue::Atom(super::flow::Atom::LastException)
+                                    )
+                                ))
                     };
                     if block_closed_by_terminator {
                         current_state.next_offset = py_pc + 1;

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -7475,7 +7475,30 @@ impl CodeWriter {
                     //   op2 = -live- (for do_recursive_call / guard resume)
                     // The per-PC emit_live_placeholder!() after this block
                     // serves as op2; op3 is emitted inside the block below.
-                    if loop_header_pcs.contains(&py_pc) {
+                    // An explicit `raise X` covered by a try closes its block
+                    // with a single exception exit carrying `explicit_raise_value`
+                    // (`emit_raise!` set `needs_fallthrough = false`).  When that
+                    // block's fall-through PC is itself a loop header — the target
+                    // of the handler's back-edge — `emit_mark_label_pc!` cannot
+                    // switch away from the closed block until the joinpoint block
+                    // exists, so `current_block` is still the raise block here.
+                    // Emitting the loop-header `jit_merge_point` into it appends
+                    // the merge op AFTER the raise's operations; `insert_exits`
+                    // then serialises the block ops (including that merge) BEFORE
+                    // the `raise` op, so a blackhole guard-resume into this arm
+                    // reaches the merge and `ContinueRunningNormally`s (loops back)
+                    // before executing the `raise`, dropping the handler.  The
+                    // `jit_merge_point` belongs to the real loop-header block,
+                    // emitted when that PC is walked through its own joinpoint;
+                    // suppress it on a closed explicit-raise block (mirrors the
+                    // `block_closed_by_terminator` op-dispatch gate below).
+                    let closed_by_explicit_raise = current_block
+                        .block()
+                        .borrow()
+                        .exits
+                        .iter()
+                        .any(|e| e.borrow().explicit_raise_value.is_some());
+                    if loop_header_pcs.contains(&py_pc) && !closed_by_explicit_raise {
                         // jtransform.py:1710-1711 op3: -live- before
                         // jit_merge_point, "for inlined short preambles".
                         emit_live_placeholder!();

--- a/pyre/pyre-jit/src/jit/flatten.rs
+++ b/pyre/pyre-jit/src/jit/flatten.rs
@@ -2751,6 +2751,12 @@ impl RenameOperand {
 fn flatten_constant_operand(constant: &super::flow::Constant) -> Operand {
     match (&constant.value, constant.kind) {
         (ConstantValue::None, Some(Kind::Ref)) => Operand::ConstRef(0),
+        // Absent-`last_exception` TYPE-slot sentinel (`etype`/`>i` is
+        // Kind::Int).  Merged against a real `last_exception` pair, the
+        // absent side's type slot is `Constant(None, Int)`; it lowers to
+        // a null int the same way the value slot's `(None, Ref)` lowers
+        // to `ConstRef(0)`.
+        (ConstantValue::None, Some(Kind::Int)) => Operand::ConstInt(0),
         (ConstantValue::Bool(value), Some(Kind::Int)) => Operand::ConstInt(i64::from(*value)),
         (ConstantValue::Signed(value), Some(Kind::Int)) => Operand::ConstInt(*value),
         // RPython rtyper post-pass: a `Constant(ll_ptr, concretetype=


### PR DESCRIPTION
Six commits accumulated on `ssa-repr` since `main`, all in the JIT
try/except/raise codewriter and guard-resume paths.

## Bug fixes

- **`c3ee50ac3b5` — kind-match absent `last_exception` merge sentinel.**
  `FrameState::mergeable` and both `FrameState::union` asymmetric arms padded
  an absent `last_exception` slot with a single Ref-kind `Constant::none()` for
  both slots. Merged against a raising predecessor's typed `(etype: Int,
  evalue: Ref)` pair, `union_kind(Int, Ref)` collapsed to `None`, minting an
  untyped merged type slot that later defaulted to Ref and emitted a `ref_copy`
  over the Int type-source register — `expect_reg` then panicked on try/except
  patterns joining a raising predecessor with a non-raising one. Pad each absent
  slot with a kind-matched none (`etype` Int, `evalue` Ref) and lower the
  `(None, Int)` type-slot sentinel to `ConstInt(0)`. Matches `framestate.py`
  `union`, which merges the exception slots as untyped Variables the rtyper
  later types uniformly.

- **`a3a68a6fe2f` — skip loop-header `jit_merge_point` on a block closed by an
  explicit raise.** When an explicit-raise block's fall-through PC is also a
  loop header, the merge op was appended into the raise block ahead of `raise/r`,
  so a blackhole guard-resume reached the merge and looped back before executing
  the raise, skipping the handler. Gate the loop-header emission on the block not
  being closed by an explicit raise.

- **`10ef0610483` — close the codewriter block at an explicit raise covered by
  a try.** An explicit `raise X` under a try sets `exitswitch=LastException`
  (same shape as a canraise op); two walker sites treated the block as a
  half-closed canraise block with a normal continuation, appending a spurious
  normal exit that made `insert_exits` lower the raise edge as a plain catch and
  drop the raise op (skipping the handler). Exclude `explicit_raise_value` edges
  from both LastException canraise-continue checks so the block stays single-exit
  and `insert_exits` emits `raise/r`.

- **`f1caa034c25` — source branch-arm Ref-liveness from the jitcode-pc twin.**
  `branch_arm_resume_ref_liveness` read the resume snapshot's live Ref register
  colors by re-inverting the carried jitcode target back to a Python PC through
  `pc_map`. Read them off the carried coordinate directly via
  `frame_liveness_reg_indices_by_bank_at_with_jitcode_pc`. Drops the
  `PYRE_M73_LIVENESS` opt-in that gated the twin; the `_AUDIT` assertion now
  certifies the production twin against the retired inversion read.

## Logging / docs

- **`fd8b77b04cf` — render `Forwarded` Debug compactly to stop unbounded
  `MAJIT_LOG` recursion.** `Forwarded::Info(OpInfo)` carries the abstract-value
  graph by value with non-Weak back-edges, so derived Debug recursed without
  bound and overflowed the stack under `MAJIT_LOG`. Replace with a manual Debug
  that prints the variant shape only.

- **`f78e254e1f6` — cite upstream decision points for pcdep resume adaptations.**
  Doc-only citations on `result_color_at_pc`, `pcdep_color_slots`, and
  `reconstruct_inline_recipe`.

## Verification

- `pyre/check.py --backend cranelift`: 160/160.
- `pyre/check.py --backend dynasm`: 160/160 on a clean pass (`int_loop` /
  `nested_loop` are exception-free steady-state loops that oscillate around the
  2.0× wall-clock gate; the changes here are structural no-ops for them).
- `cargo test -p pyre-jit --features dynasm`: 301 + 6 pass, 0 fail.
- 24 try/except/raise/reraise repros diff-match `python3`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
