### PR TITLE
majit: #25 de-conflate frame-input shape from true-portal; always-portal flip (default ON)

### DIFF
--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -4246,6 +4246,42 @@ fn getarrayitem_vable_via_metainterp(
     ctx: &mut WalkContext<'_, '_>,
     dst_bank: char,
 ) -> Result<(DispatchOutcome, usize), DispatchError> {
+    // Strict fresh-frame fold: when this op reads the current inline level's
+    // own (unseeded) portal frame, resolve it register-to-register through the
+    // per-slot OpRef shadow and emit NO GC op — the `fresh_virtualizable` case
+    // (jtransform.py:990-993 `is_virtualizable_getset` returns `False`).  The
+    // param-store seed dominates every read of a branchless leaf's own frame,
+    // so the slot is present; a genuinely-unbound read falls through to the
+    // `VableBoxNotSeeded` abort below (never the 16 GiB metainterp path).
+    let fold_frame_reg = fbw_strict_fold_frame_reg();
+    if fold_frame_reg != u16::MAX && code[op.pc + 1] as u16 == fold_frame_reg {
+        let index = read_int_reg(code, op, 1, ctx)?;
+        if let Some(majit_ir::Value::Int(slot)) = ctx.trace_ctx.concrete_of_opref(index) {
+            if let Some(result) = fbw_callee_local_get_opref(slot) {
+                let dst = code[op.pc + 7] as usize;
+                let concrete = concrete_from_recorded_opref(ctx, result);
+                match dst_bank {
+                    'i' => write_int_reg(ctx, op.pc, dst, result, concrete)?,
+                    'r' => write_ref_reg(ctx, op.pc, dst, result, concrete)?,
+                    'f' => {
+                        let len = ctx.registers_f.len();
+                        let slot_ref =
+                            ctx.registers_f
+                                .get_mut(dst)
+                                .ok_or(DispatchError::RegisterOutOfRange {
+                                    pc: op.pc,
+                                    reg: dst,
+                                    len,
+                                    bank: "f",
+                                })?;
+                        *slot_ref = result;
+                    }
+                    _ => unreachable!("dst_bank must be 'i', 'r' or 'f'"),
+                }
+                return Ok((DispatchOutcome::Continue, op.next_pc));
+            }
+        }
+    }
     let vable = read_ref_reg(code, op, 0, ctx)?;
     // An unseeded walker Ref register holds `OpRef::None` (`raw() ==
     // u32::MAX`); feeding it into the metainterp vable path would resize
@@ -4350,6 +4386,31 @@ fn setarrayitem_vable_via_metainterp(
     ctx: &mut WalkContext<'_, '_>,
     value_bank: char,
 ) -> Result<(DispatchOutcome, usize), DispatchError> {
+    // Strict fresh-frame fold (twin of `getarrayitem_vable_via_metainterp`): a
+    // write to the current inline level's own (unseeded) portal frame updates
+    // the per-slot OpRef + concrete shadow and emits NO SETARRAYITEM_GC.  Both
+    // local stores (`index < nlocals`) and operand-stack pushes (`index >=
+    // nlocals`) on the fresh frame are pure mirror writes here — the value
+    // lives in an SSA register; the vable array is folded away.
+    let fold_frame_reg = fbw_strict_fold_frame_reg();
+    if fold_frame_reg != u16::MAX && code[op.pc + 1] as u16 == fold_frame_reg {
+        let index = read_int_reg(code, op, 1, ctx)?;
+        if let Some(majit_ir::Value::Int(slot)) = ctx.trace_ctx.concrete_of_opref(index) {
+            let value = match value_bank {
+                'i' => read_int_reg(code, op, 2, ctx)?,
+                'r' => read_ref_reg(code, op, 2, ctx)?,
+                'f' => read_float_reg(code, op, 2, ctx)?,
+                _ => unreachable!("value_bank must be 'i', 'r' or 'f'"),
+            };
+            let concrete = ctx
+                .trace_ctx
+                .concrete_of_opref(value)
+                .unwrap_or(majit_ir::Value::Void);
+            fbw_callee_local_set_opref(slot, value);
+            fbw_callee_local_set_concrete(slot, concrete);
+            return Ok((DispatchOutcome::Continue, op.next_pc));
+        }
+    }
     let vable = read_ref_reg(code, op, 0, ctx)?;
     // See `getarrayitem_vable_via_metainterp`: an unseeded `OpRef::None`
     // vable would resize the heapcache flag vector to 16 GiB; bail instead.
@@ -7112,6 +7173,78 @@ thread_local! {
     static FBW_CALLEE_LOCALS_CONCRETE:
         std::cell::RefCell<Vec<std::collections::HashMap<i64, majit_ir::Value>>> =
         const { std::cell::RefCell::new(Vec::new()) };
+
+    /// FBW strict fresh-frame OpRef shadow: a twin of
+    /// `FBW_CALLEE_LOCALS_CONCRETE` carrying the SSA `OpRef` each `localsplus`
+    /// slot currently holds, innermost frame last.  Used only on the strict
+    /// straight-line inline path (a branchless leaf) when the callee body
+    /// carries the portal frame-vable prologue: the callee's own
+    /// `getarrayitem_vable_r` / `setarrayitem_vable_r` on its own (unseeded)
+    /// frame fold register-to-register through this map, emitting NO GC op.
+    /// This is the `fresh_virtualizable` case: a freshly-built callee frame's
+    /// local accesses lower direct, not vable — `is_virtualizable_getset`
+    /// returns `False` when `'fresh_virtualizable' in flags`
+    /// (rpython/jit/codewriter/jtransform.py:990-993,
+    /// pypy/interpreter/pycode.py:275 `fresh_frame = jit.hint(frame,
+    /// access_directly=True, fresh_virtualizable=True)`).
+    static FBW_CALLEE_LOCALS_OPREF:
+        std::cell::RefCell<Vec<std::collections::HashMap<i64, OpRef>>> =
+        const { std::cell::RefCell::new(Vec::new()) };
+
+    /// The callee portal frame register a strict fresh-frame fold resolves
+    /// own-frame vable ops against, innermost frame last.  `u16::MAX` = this
+    /// inline level is NOT a strict fold (plain strict leaf with no vable
+    /// prologue, or the multiframe path that seeds a real virtual frame), so
+    /// the fold short-circuits stay inert and the ordinary metainterp vable
+    /// path runs.
+    static FBW_STRICT_FOLD_FRAME_REG: std::cell::RefCell<Vec<u16>> =
+        const { std::cell::RefCell::new(Vec::new()) };
+}
+
+/// Whether the always-portal frame-input flip is active (`PYRE_ALWAYS_PORTAL`).
+/// When set, every drained per-code jitcode is built with the portal
+/// `[frame, ec]` input shape + frame-vable locals prologue, and the strict
+/// inline path activates the fresh-frame fold to keep a branchless leaf
+/// register-to-register.  Process-constant: the codewriter reads the same env
+/// at build time so a jitcode's shape and its walk-time fold agree.
+fn fbw_always_portal_enabled() -> bool {
+    std::env::var_os("PYRE_ALWAYS_PORTAL").is_some()
+}
+
+/// Activate the strict fresh-frame fold for the innermost inline level,
+/// binding it to the callee's portal frame register.
+fn fbw_strict_fold_activate(frame_reg: u16) {
+    FBW_STRICT_FOLD_FRAME_REG.with(|s| {
+        if let Some(top) = s.borrow_mut().last_mut() {
+            *top = frame_reg;
+        }
+    });
+}
+
+/// The innermost inline level's strict-fold frame register (`u16::MAX` when
+/// inactive / no inline level).
+fn fbw_strict_fold_frame_reg() -> u16 {
+    FBW_STRICT_FOLD_FRAME_REG.with(|s| s.borrow().last().copied().unwrap_or(u16::MAX))
+}
+
+/// Record a callee local slot's live `OpRef` in the innermost fresh-frame
+/// shadow (no-op when the stack is empty).  A `NONE` value clears the slot.
+fn fbw_callee_local_set_opref(slot: i64, value: OpRef) {
+    FBW_CALLEE_LOCALS_OPREF.with(|s| {
+        if let Some(top) = s.borrow_mut().last_mut() {
+            if value.is_none() {
+                top.remove(&slot);
+            } else {
+                top.insert(slot, value);
+            }
+        }
+    });
+}
+
+/// Read a callee local slot's live `OpRef` from the innermost fresh-frame
+/// shadow.
+fn fbw_callee_local_get_opref(slot: i64) -> Option<OpRef> {
+    FBW_CALLEE_LOCALS_OPREF.with(|s| s.borrow().last().and_then(|top| top.get(&slot).copied()))
 }
 
 /// Record a callee local slot's concrete in the innermost inline shadow
@@ -7142,6 +7275,10 @@ impl InlineRecursionGuard {
     fn enter(w_code: usize) -> Self {
         FBW_INLINE_CODE_STACK.with(|s| s.borrow_mut().push(w_code));
         FBW_CALLEE_LOCALS_CONCRETE.with(|s| s.borrow_mut().push(std::collections::HashMap::new()));
+        FBW_CALLEE_LOCALS_OPREF.with(|s| s.borrow_mut().push(std::collections::HashMap::new()));
+        // Push inactive by default: only the strict straight-line path
+        // activates the fold via `fbw_strict_fold_activate`.
+        FBW_STRICT_FOLD_FRAME_REG.with(|s| s.borrow_mut().push(u16::MAX));
         InlineRecursionGuard
     }
 }
@@ -7152,6 +7289,12 @@ impl Drop for InlineRecursionGuard {
             s.borrow_mut().pop();
         });
         FBW_CALLEE_LOCALS_CONCRETE.with(|s| {
+            s.borrow_mut().pop();
+        });
+        FBW_CALLEE_LOCALS_OPREF.with(|s| {
+            s.borrow_mut().pop();
+        });
+        FBW_STRICT_FOLD_FRAME_REG.with(|s| {
             s.borrow_mut().pop();
         });
     }
@@ -12200,6 +12343,7 @@ fn callee_fast_path_inlinable(
     body_code: &[u8],
     callee_descr_refs: &[DescrRef],
     ctx: &WalkContext<'_, '_>,
+    callee_frame_reg: u16,
 ) -> bool {
     let mut pc = 0usize;
     while pc < body_code.len() {
@@ -12213,8 +12357,21 @@ fn callee_fast_path_inlinable(
             }
             return false;
         }
+        // A vable op is inlinable on the strict straight-line path when it is
+        // either a static const-field read (`pycode` / `w_globals`, resolved
+        // frame-free) OR a read/write off the callee's OWN portal frame
+        // register — the latter is the `fresh_virtualizable` case, folded
+        // register-to-register through the per-slot OpRef shadow by the two
+        // `*_vable_via_metainterp` short-circuits (no GC op emitted).  Under
+        // the always-portal flip, LOAD_FAST / STORE_FAST lower to
+        // `getarrayitem_vable_r` / `setarrayitem_vable_r(frame, slot)`, so a
+        // branchless leaf's locals prologue must not decline the fast path.
+        // `callee_frame_reg == u16::MAX` (flag OFF) makes
+        // `inline_resolvable_seeded_frame_op` return false, so this is inert
+        // in the default build.
         if d.opname.contains("vable")
             && !inline_resolvable_static_vable_read(body_code, &d, callee_descr_refs, ctx)
+            && !inline_resolvable_seeded_frame_op(body_code, &d, callee_frame_reg)
         {
             if std::env::var_os("PYRE_FBW_STRICT_DIAG").is_some() {
                 eprintln!(
@@ -13102,7 +13259,23 @@ fn try_walker_inline_user_call(
     // The trait leg inlines such callees via `push_inline_frame` +
     // `recursive-call-assembler`, so route the enclosing key there
     // (`FBW_DECLINED_KEYS`) instead of recording the slow residual.
-    let strict_inlinable = callee_fast_path_inlinable(body.code, callee_descr_refs, ctx);
+    // Resolve the callee's own portal frame register up-front so both the
+    // strict predicate (own-frame vable acceptance) and the multiframe gate
+    // share one `ensure_jitcode_index` + `portal_red_regs_at` lookup.  Under
+    // the always-portal flip the strict straight-line leaf's LOAD_FAST /
+    // STORE_FAST carry the frame-vable locals prologue, folded register-to-
+    // register against this frame reg (see the `*_vable_via_metainterp`
+    // short-circuits).  `u16::MAX` when the flip is OFF keeps the strict
+    // predicate byte-identical (`inline_resolvable_seeded_frame_op` declines).
+    let callee_portal_frame_reg = if fbw_always_portal_enabled() {
+        crate::state::ensure_jitcode_index(callee_code_key as *const ())
+            .map(|jc| crate::state::portal_red_regs_at(jc).0)
+            .unwrap_or(u16::MAX)
+    } else {
+        u16::MAX
+    };
+    let strict_inlinable =
+        callee_fast_path_inlinable(body.code, callee_descr_refs, ctx, callee_portal_frame_reg);
 
     // #62: a self-recursive single-int callee (`fib`'s shape) routes to the
     // direct `CALL_ASSEMBLER` arm (`try_walker_call_assembler_self_recursive`,
@@ -13596,6 +13769,27 @@ fn try_walker_inline_user_call(
         // Track this callee on the FBW inline stack for the lifetime of the
         // sub-walk so a nested self-call sees the correct recursion depth.
         let _recursion_frame = InlineRecursionGuard::enter(callee_code_key);
+        // Strict fresh-frame fold: a branchless leaf inlined without a virtual
+        // frame (not `try_multiframe`) whose body carries the always-portal
+        // frame-vable locals prologue resolves its own `getarrayitem_vable_r` /
+        // `setarrayitem_vable_r` register-to-register through the per-slot
+        // shadow.  Seed each param into slot `i` (`local_to_vable_slot` is
+        // identity) and activate the fold so the callee's first LOAD_FAST of a
+        // param folds to the arg OpRef instead of reading its unseeded frame
+        // box.  Inert when `callee_portal_frame_reg == u16::MAX` (flip OFF /
+        // frame reg unresolved) or `try_multiframe` (real virtual frame seeded).
+        if !try_multiframe && callee_portal_frame_reg != u16::MAX {
+            fbw_strict_fold_activate(callee_portal_frame_reg);
+            for i in 0..nparams {
+                let slot = i as i64;
+                fbw_callee_local_set_opref(slot, r_args[2 + i]);
+                let concrete = sub_wc
+                    .trace_ctx
+                    .concrete_of_opref(r_args[2 + i])
+                    .unwrap_or(majit_ir::Value::Void);
+                fbw_callee_local_set_concrete(slot, concrete);
+            }
+        }
         // Path-1: resolve scalar static-field reads off this callee's own
         // unseeded portal frame to its compile-time constants for the
         // lifetime of the sub-walk.

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -4123,6 +4123,15 @@ fn setfield_vable_via_metainterp(
     ctx: &mut WalkContext<'_, '_>,
     value_bank: char,
 ) -> Result<(DispatchOutcome, usize), DispatchError> {
+    // Strict fresh-frame fold: a scalar setfield to the current inline level's
+    // own (unseeded) portal frame is a virtual-field write — `valuestackdepth`
+    // / `last_instr` sync on a branchless leaf that resumes at the caller
+    // boundary — so it folds to a no-op, emitting no SETFIELD_GC.  The
+    // `fresh_virtualizable` OptVirtualize elision (jtransform.py:990-993).
+    let fold_frame_reg = fbw_strict_fold_frame_reg();
+    if fold_frame_reg != u16::MAX && code[op.pc + 1] as u16 == fold_frame_reg {
+        return Ok((DispatchOutcome::Continue, op.next_pc));
+    }
     let obj = read_ref_reg(code, op, 0, ctx)?;
     // Same unseeded-register guard as `getfield_vable_via_metainterp`:
     // a `None` box would resize the heapcache flag vector to 16 GiB.
@@ -4265,15 +4274,14 @@ fn getarrayitem_vable_via_metainterp(
                     'r' => write_ref_reg(ctx, op.pc, dst, result, concrete)?,
                     'f' => {
                         let len = ctx.registers_f.len();
-                        let slot_ref =
-                            ctx.registers_f
-                                .get_mut(dst)
-                                .ok_or(DispatchError::RegisterOutOfRange {
-                                    pc: op.pc,
-                                    reg: dst,
-                                    len,
-                                    bank: "f",
-                                })?;
+                        let slot_ref = ctx.registers_f.get_mut(dst).ok_or(
+                            DispatchError::RegisterOutOfRange {
+                                pc: op.pc,
+                                reg: dst,
+                                len,
+                                bank: "f",
+                            },
+                        )?;
                         *slot_ref = result;
                     }
                     _ => unreachable!("dst_bank must be 'i', 'r' or 'f'"),
@@ -7201,14 +7209,16 @@ thread_local! {
         const { std::cell::RefCell::new(Vec::new()) };
 }
 
-/// Whether the always-portal frame-input flip is active (`PYRE_ALWAYS_PORTAL`).
-/// When set, every drained per-code jitcode is built with the portal
-/// `[frame, ec]` input shape + frame-vable locals prologue, and the strict
-/// inline path activates the fresh-frame fold to keep a branchless leaf
-/// register-to-register.  Process-constant: the codewriter reads the same env
-/// at build time so a jitcode's shape and its walk-time fold agree.
+/// Whether the always-portal frame-input flip is active.  DEFAULT ON: every
+/// drained per-code jitcode is built with the portal `[frame, ec]` input shape
+/// + frame-vable locals prologue, and the strict inline path activates the
+/// fresh-frame fold to keep a branchless leaf register-to-register.  Set
+/// `PYRE_ALWAYS_PORTAL=0` to roll back to the old fused shape (non-portal
+/// callees carry frame only, no vable prologue) for bisection.  Process-
+/// constant: the codewriter reads the same env at build time so a jitcode's
+/// shape and its walk-time fold agree.
 fn fbw_always_portal_enabled() -> bool {
-    std::env::var_os("PYRE_ALWAYS_PORTAL").is_some()
+    std::env::var_os("PYRE_ALWAYS_PORTAL").as_deref() != Some(std::ffi::OsStr::new("0"))
 }
 
 /// Activate the strict fresh-frame fold for the innermost inline level,

--- a/pyre/pyre-jit-trace/src/pyjitcode.rs
+++ b/pyre/pyre-jit-trace/src/pyjitcode.rs
@@ -190,16 +190,16 @@ pub struct PyJitCodeMetadata {
     /// argument (`ec`, `pypy/module/pypyjit/interp_jit.py:67`).
     /// Snapshot serializer maps this color to `sym.execution_context`.
     pub portal_ec_reg: u16,
-    /// Whether the body was compiled with the PORTAL entry shape
-    /// (`FrameInputs::Portal`: `[frame, ec]` red inputs + frame-vable
-    /// locals prologue) — `jitdriver_sd_from_portal_graph(code)` was
-    /// `Some` at compile time.  A body first compiled as a plain CALLEE
-    /// (`FrameInputs::Frame`, discovered through another function's
-    /// call) reads its params from caller-seeded registers and stays
-    /// frozen once installed trace-side (resume data captured against
-    /// it must stay consistent), so a later portal trace of the same
-    /// code must NOT walk it: `run_perfn_walk` declines on
-    /// `!built_as_portal` and the trait tracer compiles the function.
+    /// Whether the body carries the PORTAL entry INPUT SHAPE
+    /// (`FrameInputs::Portal`: `[frame, ec]` red inputs + frame-vable locals
+    /// prologue) — the default for every drained per-code jitcode under the
+    /// always-portal flip, so a later portal walk of ANY body is admitted.
+    /// This records the input shape, NOT true-portal-ness (the
+    /// `jit_merge_point` marker stays gated separately on
+    /// `jitdriver_sd_from_portal_graph`).  `false` only for shapeless
+    /// skeletons (`PyJitCodeMetadata::skeleton`), which `run_perfn_walk`
+    /// declines to walk.  When the flip is OFF a plain callee
+    /// (`FrameInputs::Frame`) is also shapeless here and declines the same way.
     pub built_as_portal: bool,
     /// Absolute start index of the operand stack in PyFrame.locals_cells_stack_w.
     pub stack_base: usize,

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -1222,26 +1222,22 @@ fn run_perfn_walk(
     // (recolored / already consumed) at the guard, which the guard's resume
     // data never preserved. See the field doc on `PyreSym::bridge_walk_entry_pc`.
     let entry = sym.bridge_walk_entry_pc.unwrap_or(pc_map_entry);
-    // The full-body walk drives a PORTAL trace, so the body must carry
-    // the portal entry shape (`FrameInputs::Portal`: `[frame, ec]` red
-    // inputs + the frame-vable locals prologue).  A body first compiled
-    // as a plain CALLEE (`FrameInputs::Frame` — `get_jitcode` builds the
-    // shape from `jitdriver_sd_from_portal_graph` at compile time, and a
-    // function discovered through another function's call compiles
-    // before it becomes a portal) reads its params from caller-seeded
-    // registers; the portal red seeding below would land `ec_box` in a
-    // PARAMETER color and the walk would record the ExecutionContext
-    // const as the function's argument — garbage baked into the trace
-    // (previously masked only when the unseeded color happened to stay
-    // `OpRef::NONE` and aborted as `ResidualCallArgUnbound`).  The
-    // installed body is frozen once trace-side resume data references
-    // it, so it cannot be swapped for a portal rebuild here; decline
-    // permanently like the other structural `FBW_DECLINED_KEYS` classes
-    // and let the trait tracer compile this function.
+    // The full-body walk drives a PORTAL trace, so the body must carry the
+    // portal entry INPUT SHAPE (`FrameInputs::Portal`: `[frame, ec]` red inputs
+    // + the frame-vable locals prologue).  Under the always-portal flip every
+    // drained per-code jitcode is Portal-shaped (`built_as_portal` records the
+    // input shape, independent of true-portal-ness), so this decline narrows to
+    // the only remaining shapeless case: a skeleton jitcode with no portal
+    // input shape (pyjitcode.rs `skeleton`).  When the flip is OFF, a body
+    // first compiled as a plain callee (`FrameInputs::Frame`) is still
+    // shapeless here — its portal red seeding would land `ec_box` in a
+    // PARAMETER color and record the ExecutionContext const as the function's
+    // argument — so decline permanently like the other structural
+    // `FBW_DECLINED_KEYS` classes and let the trait tracer compile it.
     if !pjc.metadata.built_as_portal {
         if crate::jitcode_dispatch::fbw_debug_abort_enabled() {
             eprintln!(
-                "[fbw-abort] start_pc={start_pc} jitcode body compiled as plain callee \
+                "[fbw-abort] start_pc={start_pc} jitcode has no portal input shape \
                  (built_as_portal=false); declining walk"
             );
         }

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -8001,12 +8001,8 @@ fn extract_interior_field_info(descr: &majit_ir::DescrRef) -> (usize, usize, u8)
 pub(crate) struct PyreBlackholeAllocator;
 
 /// `resume.py:1509-1518 setfield(struct, fieldnum, descr)` byte-write
-/// helper.  Pyre's three `bh_setfield_gc_{i,r,f}` impls share the same
-/// size-aware byte-write because pyre objects are raw Rust structs;
-/// the type-keyed dispatch in the trait keeps RPython's call-site
-/// shape (`cpu.bh_setfield_gc_i/r/f`). Offset 0 is valid for plain
-/// RPython structs; callers that materialize PyObject headers must avoid
-/// replaying a header-field descr instead of hiding it here.
+/// helper for integer and float fields. Ref fields use a pointer-width
+/// store in `bh_setfield_gc_r`, matching `llmodel.py:723`.
 fn bh_setfield_gc_byte_write(struct_ptr: i64, value: i64, descr_info: &majit_ir::FieldDescrInfo) {
     let field_offset = descr_info.offset;
     if struct_ptr == 0 {
@@ -8215,7 +8211,12 @@ impl majit_metainterp::resume::BlackholeAllocator for PyreBlackholeAllocator {
     }
 
     fn bh_setfield_gc_r(&self, struct_ptr: i64, value: i64, descr_info: &majit_ir::FieldDescrInfo) {
-        bh_setfield_gc_byte_write(struct_ptr, value, descr_info);
+        if struct_ptr == 0 {
+            return;
+        }
+        unsafe {
+            ((struct_ptr as *mut u8).add(descr_info.offset) as *mut usize).write(value as usize);
+        }
     }
 
     fn bh_setfield_gc_f(&self, struct_ptr: i64, value: i64, descr_info: &majit_ir::FieldDescrInfo) {

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -5755,15 +5755,37 @@ impl CodeWriter {
         let portal_jd_index = self
             .callcontrol()
             .jitdriver_sd_from_portal_graph(code as *const CodeObject);
-        let is_portal = portal_jd_index.is_some();
-        // Every per-code jitcode threads the universal `self` red frame;
-        // the portal additionally threads `ec` (`jitdriver_sd.reds =
-        // [frame, ec]`).  Non-portal callees carry frame only.
-        let frame_inputs = if is_portal {
+        // #25 step1-2: de-conflate the fused `is_portal` bool into its two
+        // independent RPython concepts.  TRUE-PORTAL is the `jit_merge_point`
+        // marker + jitdriver stamp (`portal_jd is not None`, jtransform.py:65).
+        // FRAME INPUT SHAPE is the `[frame, ec]` red inputs + the frame-vable
+        // locals prologue (`reds = ['frame', 'ec']`, interp_jit.py:67).  A
+        // function first compiled as a plain callee (`FrameInputs::Frame`, no
+        // vable prologue) can never later be walked as a portal; the
+        // always-portal flip makes every body walkable by giving it the Portal
+        // input shape, while the marker stays gated on TRUE-PORTAL.
+        let is_true_portal = portal_jd_index.is_some();
+        // Every per-code jitcode threads the universal `self` red frame; the
+        // portal additionally threads `ec`.  DEFAULT ON: every drained per-code
+        // jitcode carries the Portal shape (its whole body is walkable; the
+        // leaf frame-vable prologue folds via `fresh_virtualizable`).  Set
+        // `PYRE_ALWAYS_PORTAL=0` to roll back to non-portal callees at
+        // `FrameInputs::Frame` (byte-identical to the fused bool) for bisection.
+        let always_portal =
+            std::env::var_os("PYRE_ALWAYS_PORTAL").as_deref() != Some(std::ffi::OsStr::new("0"));
+        let frame_inputs = if is_true_portal || always_portal {
             FrameInputs::Portal
         } else {
             FrameInputs::Frame
         };
+        // The frame-vable locals/stack prologue is emitted iff the frame is
+        // virtualizable-shaped (Portal).  This is `matches!(Portal)`, NOT
+        // `has_frame()`: a `Frame` callee carries the frame inputarg but no
+        // vable ops (it reads params from caller-seeded registers), so gating
+        // on `has_frame()` would inject the prologue into flag-OFF callees.
+        // When OFF, `frame_is_portal == is_true_portal`, so every dual-write
+        // site behaves exactly as the old fused `is_portal`.
+        let frame_is_portal = matches!(frame_inputs, FrameInputs::Portal);
 
         // Populate `cpu.lowering_ctx` with the four retired-family fn
         // indices so the canonical `flatten.rs::flatten_graph(graph,
@@ -6089,7 +6111,7 @@ impl CodeWriter {
         // scratch's liverange.
         macro_rules! emit_vsd {
             ($depth:expr, $py_pc:expr) => {
-                if is_portal {
+                if frame_is_portal {
                     let depth_value = (stack_base_absolute + $depth as usize) as i64;
                     // Graph-side shadow: produce a fresh Int Variable
                     // from a constant-source `int_copy` op and consume it
@@ -6347,7 +6369,7 @@ impl CodeWriter {
                 // underflow.  Store `py_pc - 1` (the `set_last_instr_from_next_instr`
                 // convention: `next_instr = last_instr + 1`) so the
                 // interpreter resumes at this unsupported opcode and runs it.
-                if is_portal {
+                if frame_is_portal {
                     let v_li: super::flow::FlowValue =
                         super::flow::Constant::signed(($py_pc) as i64 - 1).into();
                     record_graph_op(
@@ -7002,7 +7024,7 @@ impl CodeWriter {
                 // identity for downstream dual-writes can thread the
                 // same Variable; non-portal callees skip the graph emit
                 // and return `None`.
-                if is_portal {
+                if frame_is_portal {
                     let result = emit_graph_op_with_result(
                         &mut graph,
                         &current_block.block(),
@@ -7035,7 +7057,7 @@ impl CodeWriter {
                 let _ = $src;
                 let src_value: super::flow::FlowValue = $src_value;
                 let pushvalue_ref_py_pc: i64 = ($py_pc) as i64;
-                if is_portal {
+                if frame_is_portal {
                     let depth_value = (stack_base_absolute + $depth as usize) as i64;
                     // `pyframe.py:389 pushvalue` lowers to
                     // `setarrayitem_vable_r(locals_cells_stack_w,
@@ -7091,7 +7113,7 @@ impl CodeWriter {
                     "emit_pushvalue_ref_const: only PY_NULL is supported today; \
                      graph shadow uses Constant::none() per assembler.py:109",
                 );
-                if is_portal {
+                if frame_is_portal {
                     let depth_value = (stack_base_absolute + $depth as usize) as i64;
                     let v_idx: super::flow::FlowValue =
                         super::flow::Constant::signed(depth_value).into();
@@ -7145,7 +7167,7 @@ impl CodeWriter {
                 let popvalue_ref_py_pc: i64 = ($py_pc) as i64;
                 $depth = $depth.saturating_sub(1);
                 let popped_reg = stack_base + $depth;
-                if is_portal {
+                if frame_is_portal {
                     let depth_value = (stack_base_absolute + $depth as usize) as i64;
                     let v_idx: super::flow::FlowValue =
                         super::flow::Constant::signed(depth_value).into();
@@ -7177,7 +7199,7 @@ impl CodeWriter {
             ($depth:ident, $reg:expr, $py_pc:expr) => {{
                 let reg = $reg;
                 let load_fast_py_pc: i64 = ($py_pc) as i64;
-                if is_portal {
+                if frame_is_portal {
                     let local_slot = local_to_vable_slot(reg as usize) as i64;
                     let stack_slot = (stack_base_absolute + $depth as usize) as i64;
                     // Graph-side dual-write of BOTH halves of the
@@ -7430,7 +7452,7 @@ impl CodeWriter {
                         // jtransform.py:1710-1711 op3: -live- before
                         // jit_merge_point, "for inlined short preambles".
                         emit_live_placeholder!();
-                        if is_portal {
+                        if is_true_portal {
                             let jdindex = portal_jd_index
                                 .expect("portal jit_merge_point requires a registered jitdriver");
                             let scratch_pycode_reg =
@@ -7441,7 +7463,7 @@ impl CodeWriter {
                                 VABLE_CODE_FIELD_IDX
                             )
                             .expect(
-                                "portal jit_merge_point requires is_portal=true; \
+                                "portal jit_merge_point requires is_true_portal=true; \
                              emit_vable_getfield_ref! must return a per-SpaceOp \
                              Variable for the `pycode` green arg",
                             );
@@ -7615,7 +7637,7 @@ impl CodeWriter {
                             let reg = var_num.get(op_arg).as_usize() as u16;
                             emit_popvalue_ref!(current_depth, py_pc);
                             let stored = pop_ref_or_fresh(&mut current_state, &mut graph);
-                            if is_portal {
+                            if frame_is_portal {
                                 // Graph dual-write of jtransform.py:1898
                                 // `do_fixed_list_setitem` — STORE_FAST →
                                 // `setarrayitem_vable_r(locals_cells_stack_w,
@@ -7661,7 +7683,7 @@ impl CodeWriter {
                             // takes only a literal Int as input, so no
                             // frame_var or other portal-only Variable is
                             // threaded — the graph op is well-formed for
-                            // every CodeWriter regardless of is_portal.
+                            // every CodeWriter regardless of frame shape.
                             let boxed = residual_call!(
                                 box_int_fn_idx,
                                 CallFlavor::Plain,
@@ -7716,7 +7738,7 @@ impl CodeWriter {
                             let load_reg = u32::from(pair.idx_2()) as u16;
                             emit_popvalue_ref!(current_depth, py_pc);
                             let stored = pop_ref_or_fresh(&mut current_state, &mut graph);
-                            if is_portal {
+                            if frame_is_portal {
                                 // STORE_FAST half graph dual-write
                                 // (jtransform.py:1898 `do_fixed_list_setitem`).
                                 let store_slot = local_to_vable_slot(store_reg as usize) as i64;
@@ -7738,7 +7760,7 @@ impl CodeWriter {
                             // The local binding is carried by the graph `FrameState`
                             // (`store_local_value` below), which the canonical splice
                             // lowers to the register movements via `insert_renamings`.
-                            if is_portal {
+                            if frame_is_portal {
                                 let load_slot = local_to_vable_slot(load_reg as usize) as i64;
                                 let stack_slot =
                                     (stack_base_absolute + current_depth as usize) as i64;
@@ -8143,7 +8165,7 @@ impl CodeWriter {
                             // `[callable, null_or_self]` order (eval.rs:3141,
                             // shared_opcode.rs opcode_call).
                             let loaded_dst_reg = stack_base + current_depth;
-                            if is_portal {
+                            if is_true_portal {
                                 let _ = ssarepr.fresh_var(Kind::Ref, scratch_ref_base).0;
                             }
                             // #336: in the PORTAL jitcode, load the global at
@@ -8192,7 +8214,7 @@ impl CodeWriter {
                             // are created at module load and promoted to the
                             // non-moving oldgen before any jitcode build, so
                             // const-folding them stays GC-safe.
-                            let result_value: super::flow::FlowValue = if is_portal {
+                            let result_value: super::flow::FlowValue = if is_true_portal {
                                 let ns_var = emit_graph_op_with_result(
                                     &mut graph,
                                     &current_block.block(),
@@ -8377,7 +8399,7 @@ impl CodeWriter {
                             // leaves the register unbound for any execution that
                             // is not rd_numb-seeded (walker full-body walk,
                             // blackhole entry upstream of the push).
-                            let null_or_self_needs_read = is_portal
+                            let null_or_self_needs_read = frame_is_portal
                                 && !matches!(
                                     current_state.stack.last(),
                                     Some(super::flow::FlowValue::Variable(_))
@@ -9394,7 +9416,7 @@ impl CodeWriter {
                             for reg in [reg_a, reg_b] {
                                 emit_popvalue_ref!(current_depth, py_pc);
                                 let stored = pop_ref_or_fresh(&mut current_state, &mut graph);
-                                if is_portal {
+                                if frame_is_portal {
                                     // Graph-side dual-write — same shape as
                                     // the StoreFast handler.  The SSARepr is
                                     // produced by the canonical splice from
@@ -9559,7 +9581,7 @@ impl CodeWriter {
                             // (jitcode_dispatch.rs), porting
                             // `get_list_of_active_boxes` (pyjitpl.py:177-234).
                             let iter_slot_depth = current_depth.saturating_sub(1);
-                            let iter_value: super::flow::FlowValue = if is_portal {
+                            let iter_value: super::flow::FlowValue = if frame_is_portal {
                                 let iter_abs_slot =
                                     (stack_base_absolute + iter_slot_depth as usize) as i64;
                                 let v_iter_idx: super::flow::FlowValue =
@@ -9851,7 +9873,7 @@ impl CodeWriter {
                                 let tos_idx = stack_len - 1;
                                 let other_idx = stack_len - depth;
                                 current_state.stack.swap(tos_idx, other_idx);
-                                if is_portal && tos_idx != other_idx {
+                                if frame_is_portal && tos_idx != other_idx {
                                     let tos_value = current_state.stack[tos_idx].clone();
                                     let other_value = current_state.stack[other_idx].clone();
                                     let tos_slot: super::flow::FlowValue =
@@ -9903,7 +9925,7 @@ impl CodeWriter {
                         Instruction::LoadFastAndClear { var_num } => {
                             let reg = var_num.get(op_arg).as_usize() as u16;
                             emit_load_fast_ref!(current_depth, reg, py_pc);
-                            if is_portal {
+                            if frame_is_portal {
                                 // Clear the LOCAL slot to NULL:
                                 // `setarrayitem_vable_r(locals_cells_stack_w,
                                 // local_slot, ConstRef(0))`, the same
@@ -11270,7 +11292,7 @@ impl CodeWriter {
                                 Kind::Ref,
                                 py_pc as i64,
                             );
-                            if is_portal {
+                            if frame_is_portal {
                                 let local_slot = local_to_vable_slot(idx as usize) as i64;
                                 let v_idx: super::flow::FlowValue =
                                     super::flow::Constant::signed(local_slot).into();
@@ -11313,7 +11335,7 @@ impl CodeWriter {
                                 Kind::Ref,
                                 py_pc as i64,
                             );
-                            if is_portal {
+                            if frame_is_portal {
                                 let local_slot = local_to_vable_slot(idx as usize) as i64;
                                 let v_idx: super::flow::FlowValue =
                                     super::flow::Constant::signed(local_slot).into();
@@ -11598,7 +11620,7 @@ impl CodeWriter {
                     .get(site.lasti_py_pc)
                     .copied()
                     .unwrap_or(site.stack_depth);
-                if is_portal {
+                if frame_is_portal {
                     let mut unwind_depth = raising_depth;
                     while unwind_depth > site.stack_depth {
                         unwind_depth -= 1;
@@ -11642,7 +11664,7 @@ impl CodeWriter {
                     // (`flowcontext.py:135-139` recorder pattern,
                     // `jtransform.py:1898 do_fixed_list_setitem` for the
                     // array write).
-                    if is_portal {
+                    if frame_is_portal {
                         let boxed_lasti = residual_call!(
                             box_int_fn_idx,
                             CallFlavor::Plain,
@@ -11691,7 +11713,7 @@ impl CodeWriter {
                 // from the copy list.  `exc_value` is colored by the graph
                 // regalloc and its handler-entry slot is reconstructed from the
                 // per-PC pcdep resume map, so no walker slot pin is needed.
-                if is_portal {
+                if frame_is_portal {
                     let depth_value = (stack_base_absolute + depth as usize) as i64;
                     // pyframe.py:378-387 `pushvalue` semantics — graph
                     // dual-write of the stack mirror.
@@ -12412,7 +12434,7 @@ impl CodeWriter {
             depth_at_pc,
             portal_frame_reg,
             portal_ec_reg,
-            is_portal,
+            frame_is_portal,
             has_abort,
             num_regs,
             result_color_at_pc,
@@ -12452,7 +12474,7 @@ impl CodeWriter {
         depth_at_pc: Vec<u16>,
         portal_frame_reg: u16,
         portal_ec_reg: u16,
-        is_portal: bool,
+        frame_is_portal: bool,
         has_abort: bool,
         num_regs: super::assembler::NumRegs,
         result_color_at_pc: Vec<u16>,
@@ -12537,7 +12559,7 @@ impl CodeWriter {
             for (py, &off) in pc_map_bytes.iter().enumerate() {
                 if seen.insert(off) {
                     let rewound = block_head_python_pc(&first_jit_pc_by_py_pc, py);
-                    let block_py = if !is_portal && branch_targets.contains(&rewound) {
+                    let block_py = if !frame_is_portal && branch_targets.contains(&rewound) {
                         rewound
                     } else {
                         py
@@ -12751,7 +12773,12 @@ impl CodeWriter {
             result_color_at_pc,
             portal_frame_reg,
             portal_ec_reg,
-            built_as_portal: is_portal,
+            // Records the INPUT SHAPE (Portal `[frame, ec]` + frame-vable
+            // prologue), NOT true-portal-ness: every drained per-code jitcode
+            // is Portal-shaped under the always-portal flip, so a later portal
+            // walk of any body is admitted (`run_perfn_walk` no longer declines
+            // on `!built_as_portal`).  Only shapeless skeletons carry `false`.
+            built_as_portal: frame_is_portal,
             stack_base: frame_stack_base,
             max_stackdepth: code.max_stackdepth as usize,
             pcdep_color_slots,
@@ -13011,22 +13038,24 @@ pub fn register_portal_jitdriver(code: &pyre_interpreter::CodeObject) {
 /// # Non-portal callee status (TODO, partial fix in flight)
 ///
 /// Drained graphs whose `code` is NOT registered as a portal go through the
-/// same `transform_graph_to_jitcode` body. `is_portal=false` already gates
-/// the graph-side dual-writes (vable getfield/setfield → `frame_var` would
-/// be an undefined inputarg), and per-helper walker emit sites are being
-/// migrated to feed compile-time-known operands directly per
+/// same `transform_graph_to_jitcode` body.  With the frame-input shape
+/// de-conflated from true-portal-ness, the graph-side frame-vable dual-writes
+/// gate on `frame_is_portal` (the Portal input shape, default ON so every body
+/// is walkable), while the `jit_merge_point` marker and the LOAD_GLOBAL /
+/// LOAD_CONST namespace split gate on `is_true_portal`.  Per-helper walker
+/// emit sites feed compile-time-known operands directly per
 /// `pyframe.py:509-510 getcode(): hint(self.pycode, promote=True)`.
 ///
 /// Per-helper migration status:
 ///   * `bh_load_const_fn(w_code_ptr, consti)` — **migrated**.  Walker emit
-///     in the `Instruction::LoadConst` arm splits on `is_portal`: portal
+///     in the `Instruction::LoadConst` arm splits on `is_true_portal`: portal
 ///     keeps the `getfield_vable_r(portal_frame_reg, code_field)` +
 ///     register-operand call shape; non-portal skips the vable getfield
 ///     and emits `build_load_const_fn_residual_call_ir_r_insn_with_const_pycode`
 ///     with the callee's own `w_code` pointer as `Operand::ConstRef`.
 ///   * `bh_load_global_fn(namespace_ptr, w_code_ptr, frame_ptr, namei)` —
 ///     **pycode operand migrated**.  Walker emit in the
-///     `Instruction::LoadGlobal` arm splits on `is_portal`: portal keeps
+///     `Instruction::LoadGlobal` arm splits on `is_true_portal`: portal keeps
 ///     the `getfield_vable_r(portal_frame_reg, code_field)` + register
 ///     operand; non-portal skips that vable getfield and emits
 ///     `build_load_global_fn_residual_call_ir_r_insn_with_const_pycode`


### PR DESCRIPTION
Splits the fused per-CodeObject `is_portal` bool into its two independent concepts and flips to always-portal input shape (default ON, `PYRE_ALWAYS_PORTAL=0` to roll back).

## What it does

- **`is_true_portal`** (`portal_jd is not None`): keeps the `jit_merge_point` marker + jitdriver stamp + LOAD_GLOBAL/LOAD_CONST namespace const-fold split.
- **`frame_inputs` / `frame_is_portal`** (`reds=['frame','ec']` + frame-vable locals prologue): the INPUT SHAPE, now `Portal` for every drained jitcode under the flip.

Every drained per-code jitcode becomes Portal-shaped, so its whole body is walkable as a portal and the `trace.rs` `!built_as_portal` decline narrows to shapeless skeletons only.

## The blocker it resolves

The prior always-portal attempt regressed `inline_helper` 22x: forcing the frame-vable prologue into leaf callees made `callee_fast_path_inlinable` reject them as non-static vable → strict-leaf declines → main loop stops compiling.

**Fix = the fresh-frame register-to-register fold** (`f202ec29e57`): a branchless leaf's own-frame `getarrayitem_vable_r`/`setarrayitem_vable_r` resolve through a per-slot `OpRef` shadow (`FBW_CALLEE_LOCALS_OPREF`) instead of the metainterp vable path, emitting no GC op — the runtime realization of the `fresh_virtualizable` translate-time elision (`is_virtualizable_getset` returns False when `'fresh_virtualizable' in flags`). The `1fbd3ecdf48` commit adds the scalar `setfield_vable` no-op fold that completes it.

## Commits

- `f202ec29e57` — strict fresh-frame vable fold machinery (inert until the flip; byte-identical 159×2).
- `1fbd3ecdf48` — de-conflate frame-input shape; always-portal flip (default ON).

## Verification

- `inline_helper` `985375007` @ 0.18s (was TIMEOUT on the prior blocked attempt).
- `short_circuit_side_effects` `built_as_portal` 3→0, stdout byte-identical.
- `check.py`: **dynasm 160/160, cranelift 160/160, wasm 159/160** (the 1 wasm fail `synth/calls_closures` is pre-existing — byte-identical wrong output under both `PYRE_ALWAYS_PORTAL=1` and `=0`).
- `cargo test -p pyre-jit-trace -p pyre-jit`: 0 failed.

Composes with the orthodox strict-multiframe snapshot routing (#440/#453) that this branch is rebased onto.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
