### PR TITLE
M369: default-off resume-path audit gates for #369

### DIFF
--- a/majit/majit-metainterp/src/lib.rs
+++ b/majit/majit-metainterp/src/lib.rs
@@ -237,6 +237,19 @@ pub fn no_unroll_enabled() -> bool {
     *FLAG.get_or_init(|| std::env::var_os("PYRE_NO_UNROLL").is_some())
 }
 
+/// `PYRE_M369_RESUME_PC_AUDIT`: instrument the resume-data encoder to report
+/// every per-frame `jitcode_pc` word that carries a non-sentinel value. Those
+/// are the kept-stack branch-guard frames where the Python `pc` word alone
+/// cannot describe the resume coordinate, so the extra `jitcode_pc` word is
+/// still load-bearing. Default off (a pure `eprintln!` behind the flag; the
+/// emitted `rd_numb` bytes are unchanged). When a corpus run reports zero
+/// residuals, the word is redundant and the frame chain can collapse to the
+/// 2-word `(jitcode_index, pc)` shape (resume.py:249-253).
+pub fn m369_resume_pc_audit_enabled() -> bool {
+    static FLAG: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *FLAG.get_or_init(|| std::env::var_os("PYRE_M369_RESUME_PC_AUDIT").is_some())
+}
+
 /// `PYRE_ORIGINAL_BOXES`: default true, only disabled by `0` or `false`.
 pub fn original_boxes_enabled() -> bool {
     static FLAG: std::sync::OnceLock<bool> = std::sync::OnceLock::new();

--- a/majit/majit-metainterp/src/resume.rs
+++ b/majit/majit-metainterp/src/resume.rs
@@ -3968,6 +3968,29 @@ impl ResumeDataLoopMemo {
             // Per-frame `jitcode_pc` word (after `pc`); see
             // `majit_ir::resumedata::NO_JITCODE_PC`.
             numb_state.append_int(frame.jitcode_pc as i64);
+            // `PYRE_M369_RESUME_PC_AUDIT`: report frames whose `jitcode_pc` is
+            // non-sentinel — the residual kept-stack cases that still block
+            // collapsing this frame chain to the 2-word `(jitcode_index, pc)`
+            // shape (resume.py:249-253).  `pc_substitutes` reports whether the
+            // (flag-stripped) `pc` word already equals `jitcode_pc`, i.e.
+            // whether `pc` alone would suffice at this frame.
+            if crate::m369_resume_pc_audit_enabled()
+                && frame.jitcode_pc != majit_ir::resumedata::NO_JITCODE_PC
+            {
+                let (py_pc, after_residual_call) =
+                    majit_ir::resumedata::decode_resume_pc(frame.pc);
+                eprintln!(
+                    "[m369-audit] residual jitcode_pc frame: jitcode_index={} \
+                     pc_raw={} pc={} after_residual_call={} jitcode_pc={} \
+                     pc_substitutes={}",
+                    frame.jitcode_index,
+                    frame.pc,
+                    py_pc,
+                    after_residual_call,
+                    frame.jitcode_pc,
+                    py_pc == frame.jitcode_pc,
+                );
+            }
             self._number_boxes(&frame.boxes, &mut numb_state, env)?;
         }
 

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -9073,6 +9073,22 @@ pub(crate) fn bridge_audit_enabled() -> bool {
     *ENABLED.get_or_init(|| std::env::var_os("PYRE_PCMAP_BRIDGE_AUDIT").is_some())
 }
 
+/// `PYRE_M369_RECOVER_AUDIT` (default OFF): decode-side round-trip audit for the
+/// #369 record-side flip (make the rd_numb `pc` word hold the JitCode offset and
+/// drop the separate `jitcode_pc` word). At the `resolve_resume_pc_with_jitcode_pc`
+/// funnel it checks whether the ORIGINAL Python pc is recoverable from the JitCode
+/// offset the flip would store: `python_pc_for_jitcode_pc(flip_offset) ==
+/// decode_resume_pc(raw_pc).0`, bucketed by frame class (branch_guard /
+/// portal_bridge / after_residual_call / sentinel_plain). Zero divergence across
+/// the corpus is the precondition for dropping the py_pc word. Orthogonal to the
+/// task#50 twin-table audits, which are gated by `can_decode_live_vars` and so
+/// never reach the portal-bridge / sentinel / after-residual-call frames.
+/// Diagnostic only; off in production.
+pub(crate) fn m369_recover_audit_enabled() -> bool {
+    static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ENABLED.get_or_init(|| std::env::var_os("PYRE_M369_RECOVER_AUDIT").is_some())
+}
+
 /// `PYRE_M73_ENCODE_AUDIT` enables the assertion that the trivia-aware
 /// `depth_trivia_by_jit_pc` twin reproduces the ENCODE-side branch-resume depth
 /// that `branch_resume_target_stack_depth` computes via

--- a/pyre/pyre-jit-trace/src/pyjitcode.rs
+++ b/pyre/pyre-jit-trace/src/pyjitcode.rs
@@ -674,13 +674,53 @@ impl PyJitCode {
         carried: i32,
         op_live: u8,
     ) -> Option<usize> {
-        if carried != majit_ir::resumedata::NO_JITCODE_PC && carried >= 0 {
-            let jp = carried as usize;
-            if self.jitcode.can_decode_live_vars(jp, op_live) {
-                return Some(jp);
+        let used_carried = carried != majit_ir::resumedata::NO_JITCODE_PC
+            && carried >= 0
+            && self.jitcode.can_decode_live_vars(carried as usize, op_live);
+        let resolved = if used_carried {
+            Some(carried as usize)
+        } else {
+            self.resolve_resume_pc(raw_pc)
+        };
+        if crate::jitcode_dispatch::m369_recover_audit_enabled() {
+            self.m369_recover_audit(raw_pc, used_carried, resolved);
+        }
+        resolved
+    }
+
+    /// `PYRE_M369_RECOVER_AUDIT` probe: for the JitCode offset the #369 flip would
+    /// store in the `pc` word (`resolved`), report whether the original Python pc
+    /// (`decode_resume_pc(raw_pc).0`) is recovered by
+    /// `python_pc_for_jitcode_pc(resolved)`, bucketed by frame class. Off in
+    /// production; pure `eprintln!`, no behavioral effect.
+    fn m369_recover_audit(&self, raw_pc: i32, used_carried: bool, resolved: Option<usize>) {
+        let (py_pc, after_residual_call) = majit_ir::resumedata::decode_resume_pc(raw_pc);
+        if py_pc < 0 {
+            return;
+        }
+        let bucket = if used_carried {
+            "branch_guard"
+        } else if self.metadata.block_head_py_by_jit_pc.is_empty() {
+            "portal_bridge"
+        } else if after_residual_call {
+            "after_residual_call"
+        } else {
+            "sentinel_plain"
+        };
+        match resolved {
+            None => {
+                eprintln!("[m369-recover] bucket={bucket} match=unresolved raw_pc={raw_pc} py_pc={py_pc}");
+            }
+            Some(flip_offset) => {
+                let recovered =
+                    crate::jitcode_dispatch::python_pc_for_jitcode_pc(&self.metadata, flip_offset);
+                let matched = recovered as i64 == py_pc as i64;
+                eprintln!(
+                    "[m369-recover] bucket={bucket} match={matched} raw_pc={raw_pc} \
+                     py_pc={py_pc} flip_offset={flip_offset} recovered={recovered}"
+                );
             }
         }
-        self.resolve_resume_pc(raw_pc)
     }
 
     /// Skeleton slot inserted by [`Self::skeleton`] — neither `code`

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -4795,6 +4795,19 @@ pub(crate) fn m369_route_audit_enabled() -> bool {
     *ENABLED.get_or_init(|| std::env::var_os("PYRE_M369_ROUTE_AUDIT").is_some())
 }
 
+thread_local! {
+    /// `PYRE_M369_ROUTE_AUDIT` scratch: the innermost resume frame's
+    /// recoverability, captured while `build_resumed_frames` still has the raw
+    /// rd_numb header (`jitcode_index`, carried `jitcode_pc`) in scope, read by
+    /// the `bridge_decode` census line in `decode_and_restore_guard_failure`.
+    /// `(carried, portal)`: `carried` = a JitCode offset is stored (`jitcode_pc`
+    /// != NO_JITCODE_PC) so the #369 flip could re-derive py_pc by re-execution
+    /// (Option-B feasible); `portal` = a portal-bridge frame (empty block_head
+    /// map) whose py_pc is not offset-resolvable — a HARD blocker if !carried.
+    static M369_INNERMOST_RECOVERY: std::cell::Cell<Option<(bool, bool)>> =
+        const { std::cell::Cell::new(None) };
+}
+
 /// compile.py:710-716 resume_in_blackhole parity.
 ///
 /// RPython: resume_in_blackhole → blackhole_from_resumedata →
@@ -6955,11 +6968,19 @@ pub(crate) fn decode_and_restore_guard_failure(
             // blackhole instead (path-A).  `divergent_vs_ni` is true when the
             // stored py_pc differs from the vable-restored `next_instr` -> the
             // py_pc word is the only source, i.e. NOT droppable in favour of ni.
+            // `innermost_carried` (a JitCode offset is stored) => a #369 flip can
+            // re-derive py_pc by re-execution (Option-B feasible); `portal` with
+            // no carried offset is a HARD blocker (py_pc not offset-resolvable).
+            let (innermost_carried, innermost_portal) =
+                M369_INNERMOST_RECOVERY.with(|c| c.get()).unwrap_or((false, false));
             eprintln!(
-                "[m369-route] source=bridge_decode frames={} single={} divergent_vs_ni={} resume_pc={} ni={}",
+                "[m369-route] source=bridge_decode frames={} single={} divergent_vs_ni={} \
+                 innermost_carried={} innermost_portal={} resume_pc={} ni={}",
                 resumed_frames.len(),
                 resumed_frames.len() == 1,
                 resume_pc != ni,
+                innermost_carried,
+                innermost_portal,
                 resume_pc,
                 ni
             );
@@ -7490,8 +7511,24 @@ fn build_resumed_frames(
         }
     }
 
+    let nframes = frames.len();
+    if m369_route_audit_enabled() {
+        M369_INNERMOST_RECOVERY.with(|c| c.set(None));
+    }
     let mut result = Vec::with_capacity(frames.len());
     for (idx, (frame, values)) in frames.iter().zip(all_values.into_iter()).enumerate() {
+        // The innermost frame's stored py_pc is the one that reaches the live
+        // frame `last_instr` on the single-frame bridge-trace path (path-B); its
+        // carried jitcode_pc / portal-bridge status decides whether a #369 flip
+        // could re-derive that py_pc from the offset. Capture it here while the
+        // raw rd_numb header is in scope.
+        if m369_route_audit_enabled() && idx + 1 == nframes {
+            let carried = frame.jitcode_pc != majit_ir::resumedata::NO_JITCODE_PC;
+            let portal = pyre_jit_trace::state::pyjitcode_for_jitcode_index(frame.jitcode_index)
+                .map(|p| p.metadata.block_head_py_by_jit_pc.is_empty())
+                .unwrap_or(false);
+            M369_INNERMOST_RECOVERY.with(|c| c.set(Some((carried, portal))));
+        }
         // resume.py:1338 read_jitcode_pos_pc parity:
         // py_pc comes from rd_numb frame header (frame.pc = orgpc).
         // pc=0 is valid (function start). pc=-1 = no-snapshot sentinel.

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -4781,6 +4781,20 @@ fn blackhole_result_tag(r: &crate::call_jit::BlackholeResult) -> &'static str {
     }
 }
 
+/// `PYRE_M369_ROUTE_AUDIT` (default OFF): resume-path routing census for the
+/// #369 record-side flip.  Emits one `[m369-route]` line per guard-failure
+/// resume so the benign path-A population (blackhole re-execution, which
+/// re-derives `last_instr` from the JitCode offset and never reads the stored
+/// py_pc word) can be split from the load-bearing path-B population
+/// (bridge-trace forward re-entry, which installs the stored py_pc as the live
+/// frame `last_instr` at the `set_last_instr_from_next_instr(resume_pc)` site).
+/// Pure `eprintln!`, no behavioral effect.  Complements the decode-side
+/// `PYRE_M369_RECOVER_AUDIT` (which measures the offset-derivation funnel).
+pub(crate) fn m369_route_audit_enabled() -> bool {
+    static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ENABLED.get_or_init(|| std::env::var_os("PYRE_M369_ROUTE_AUDIT").is_some())
+}
+
 /// compile.py:710-716 resume_in_blackhole parity.
 ///
 /// RPython: resume_in_blackhole → blackhole_from_resumedata →
@@ -4793,6 +4807,16 @@ pub(crate) fn resume_in_blackhole_from_exit_layout(
     exit_layout: &CompiledExitLayout,
     guard_exc: i64,
 ) -> crate::call_jit::BlackholeResult {
+    if m369_route_audit_enabled() {
+        // Every entry here is a blackhole resume (path-A): a cold/declined
+        // guard, or a multi-frame bridge falling back via `resume_via_blackhole`.
+        // The JitCode is re-executed forward; the stored py_pc is not read as
+        // `last_instr`, so any stored-py_pc divergence is benign here.
+        eprintln!(
+            "[m369-route] source=blackhole_entry trace={} fail={}",
+            exit_layout.trace_id, exit_layout.fail_index
+        );
+    }
     if majit_metainterp::majit_log_enabled() {
         eprintln!(
             "[dynasm-debug] resume_in_blackhole: raw_values.len={} exit_types.len={} rd_numb={:?}",
@@ -6922,6 +6946,23 @@ pub(crate) fn decode_and_restore_guard_failure(
                     jit_state.clear_stack_above(corrected_vsd);
                 }
             }
+        }
+        if m369_route_audit_enabled() {
+            // The stored innermost py_pc becomes `resume_pc` -> the live frame
+            // `last_instr` at the caller's `set_last_instr_from_next_instr`.
+            // A SINGLE-frame guard traces the bridge forward from it (path-B,
+            // stored py_pc load-bearing); a MULTI-frame guard routes to the
+            // blackhole instead (path-A).  `divergent_vs_ni` is true when the
+            // stored py_pc differs from the vable-restored `next_instr` -> the
+            // py_pc word is the only source, i.e. NOT droppable in favour of ni.
+            eprintln!(
+                "[m369-route] source=bridge_decode frames={} single={} divergent_vs_ni={} resume_pc={} ni={}",
+                resumed_frames.len(),
+                resumed_frames.len() == 1,
+                resume_pc != ni,
+                resume_pc,
+                ni
+            );
         }
         Some((typed, resume_pc, resumed_frames.len()))
     } else {


### PR DESCRIPTION
Stacked on #435 (base branch `box-pool`). Adds four **default-OFF** diagnostic gates instrumenting the guard-failure resume path, to bound the #369 word-drop (retire the carried `jitcode_pc` / `py_pc` resume side-channel).

## Commits
- `resume: add PYRE_M369_RESUME_PC_AUDIT jitcode_pc gate` — logs the resolved resume pc / jitcode_pc at the resume-pc funnel.
- `pyjitcode: add PYRE_M369_RECOVER_AUDIT decode-side gate` — decode-side py_pc recoverability.
- `eval: add PYRE_M369_ROUTE_AUDIT resume-path gate` — path-A (blackhole) vs path-B (bridge-trace) routing split.
- `eval: extend M369_ROUTE_AUDIT with innermost recoverability` — adds innermost `carried` / `portal` classification.

Every gate is guarded by a `PYRE_M369_*` env var via `OnceLock`; with the vars unset the code is inert (no behavioral change, no resume-data byte change).

## Finding (census over the synth corpus, deterministic run1 == run2)
- path-A blackhole re-entry: 99.5% — never reads the stored py_pc; re-executes JitCode forward from the offset.
- path-B bridge-trace, single-frame & divergent: the only frames that read the stored py_pc.
- **All path-B blocking frames carry the JitCode offset (`carried=T`, `portal=F`) → the py_pc word is 100% reconstructible from the offset in the observed corpus. 0 hard-blockers, 0 portal blockers.**

This bounds #369: the flip surface is a small single-frame bridge-trace residue, all offset-recoverable. The actual word-drop is a separate correctness-critical slice (needs GC-stress verification) and is not part of this PR — this PR is diagnostics only.

## Verification
`cargo test -p pyre-jit --lib --features dynasm` → 301 passed / 0 failed. Gates inert when their env vars are unset.

Refs #369.

— *commented by Claude*
