### PR TITLE
Complex delegation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1106,6 +1106,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "icu_locale"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5a396343c7208121dc86e35623d3dfe19814a7613cfd14964994cdc9c9a2e26"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_locale_data",
+ "icu_provider",
+ "potential_utf",
+ "tinystr",
+ "zerovec",
+]
+
+[[package]]
 name = "icu_locale_core"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1118,6 +1133,12 @@ dependencies = [
  "writeable",
  "zerovec",
 ]
+
+[[package]]
+name = "icu_locale_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5fdcc9ac77c6d74ff5cf6e65ef3181d6af32003b16fce3a77fb451d2f695993"
 
 [[package]]
 name = "icu_normalizer"
@@ -2574,7 +2595,7 @@ dependencies = [
 [[package]]
 name = "rustpython-codegen"
 version = "0.5.0"
-source = "git+https://github.com/RustPython/RustPython.git?rev=a5eecb5ebfd48dc62fc05913d16a556d6b0ccd3a#a5eecb5ebfd48dc62fc05913d16a556d6b0ccd3a"
+source = "git+https://github.com/RustPython/RustPython.git?rev=238bed66fbb0102a83dd9b5c8244e0276fbe8eac#238bed66fbb0102a83dd9b5c8244e0276fbe8eac"
 dependencies = [
  "bitflags 2.11.1",
  "indexmap",
@@ -2597,7 +2618,7 @@ dependencies = [
 [[package]]
 name = "rustpython-common"
 version = "0.5.0"
-source = "git+https://github.com/RustPython/RustPython.git?rev=a5eecb5ebfd48dc62fc05913d16a556d6b0ccd3a#a5eecb5ebfd48dc62fc05913d16a556d6b0ccd3a"
+source = "git+https://github.com/RustPython/RustPython.git?rev=238bed66fbb0102a83dd9b5c8244e0276fbe8eac#238bed66fbb0102a83dd9b5c8244e0276fbe8eac"
 dependencies = [
  "ascii",
  "bitflags 2.11.1",
@@ -2620,7 +2641,7 @@ dependencies = [
 [[package]]
 name = "rustpython-compiler"
 version = "0.5.0"
-source = "git+https://github.com/RustPython/RustPython.git?rev=a5eecb5ebfd48dc62fc05913d16a556d6b0ccd3a#a5eecb5ebfd48dc62fc05913d16a556d6b0ccd3a"
+source = "git+https://github.com/RustPython/RustPython.git?rev=238bed66fbb0102a83dd9b5c8244e0276fbe8eac#238bed66fbb0102a83dd9b5c8244e0276fbe8eac"
 dependencies = [
  "rustpython-codegen",
  "rustpython-compiler-core",
@@ -2634,7 +2655,7 @@ dependencies = [
 [[package]]
 name = "rustpython-compiler-core"
 version = "0.5.0"
-source = "git+https://github.com/RustPython/RustPython.git?rev=a5eecb5ebfd48dc62fc05913d16a556d6b0ccd3a#a5eecb5ebfd48dc62fc05913d16a556d6b0ccd3a"
+source = "git+https://github.com/RustPython/RustPython.git?rev=238bed66fbb0102a83dd9b5c8244e0276fbe8eac#238bed66fbb0102a83dd9b5c8244e0276fbe8eac"
 dependencies = [
  "bitflags 2.11.1",
  "bitflagset",
@@ -2650,7 +2671,7 @@ dependencies = [
 [[package]]
 name = "rustpython-host_env"
 version = "0.5.0"
-source = "git+https://github.com/RustPython/RustPython.git?rev=a5eecb5ebfd48dc62fc05913d16a556d6b0ccd3a#a5eecb5ebfd48dc62fc05913d16a556d6b0ccd3a"
+source = "git+https://github.com/RustPython/RustPython.git?rev=238bed66fbb0102a83dd9b5c8244e0276fbe8eac#238bed66fbb0102a83dd9b5c8244e0276fbe8eac"
 dependencies = [
  "bitflags 2.11.1",
  "dns-lookup",
@@ -2682,7 +2703,7 @@ dependencies = [
 [[package]]
 name = "rustpython-literal"
 version = "0.5.0"
-source = "git+https://github.com/RustPython/RustPython.git?rev=a5eecb5ebfd48dc62fc05913d16a556d6b0ccd3a#a5eecb5ebfd48dc62fc05913d16a556d6b0ccd3a"
+source = "git+https://github.com/RustPython/RustPython.git?rev=238bed66fbb0102a83dd9b5c8244e0276fbe8eac#238bed66fbb0102a83dd9b5c8244e0276fbe8eac"
 dependencies = [
  "hexf-parse",
  "is-macro",
@@ -2761,7 +2782,7 @@ dependencies = [
 [[package]]
 name = "rustpython-sre_engine"
 version = "0.5.0"
-source = "git+https://github.com/RustPython/RustPython.git?rev=a5eecb5ebfd48dc62fc05913d16a556d6b0ccd3a#a5eecb5ebfd48dc62fc05913d16a556d6b0ccd3a"
+source = "git+https://github.com/RustPython/RustPython.git?rev=238bed66fbb0102a83dd9b5c8244e0276fbe8eac#238bed66fbb0102a83dd9b5c8244e0276fbe8eac"
 dependencies = [
  "bitflags 2.11.1",
  "num_enum",
@@ -2773,9 +2794,10 @@ dependencies = [
 [[package]]
 name = "rustpython-unicode"
 version = "0.5.0"
-source = "git+https://github.com/RustPython/RustPython.git?rev=a5eecb5ebfd48dc62fc05913d16a556d6b0ccd3a#a5eecb5ebfd48dc62fc05913d16a556d6b0ccd3a"
+source = "git+https://github.com/RustPython/RustPython.git?rev=238bed66fbb0102a83dd9b5c8244e0276fbe8eac#238bed66fbb0102a83dd9b5c8244e0276fbe8eac"
 dependencies = [
  "icu_casemap",
+ "icu_locale",
  "icu_normalizer",
  "icu_properties",
  "rustpython-wtf8",
@@ -2786,7 +2808,7 @@ dependencies = [
 [[package]]
 name = "rustpython-wtf8"
 version = "0.5.0"
-source = "git+https://github.com/RustPython/RustPython.git?rev=a5eecb5ebfd48dc62fc05913d16a556d6b0ccd3a#a5eecb5ebfd48dc62fc05913d16a556d6b0ccd3a"
+source = "git+https://github.com/RustPython/RustPython.git?rev=238bed66fbb0102a83dd9b5c8244e0276fbe8eac#238bed66fbb0102a83dd9b5c8244e0276fbe8eac"
 dependencies = [
  "ascii",
  "bstr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,16 +62,18 @@ pyre-wasm = { version = "0.0.2", path = "pyre/pyre-wasm" }
 pyrex = { version = "0.0.2", path = "pyre/pyrex" }
 
 # Pinned to upstream main, which now carries the rustpython-unicode crate,
-# the host_env mmap re-exports, and the round-half-even float_ops::from_hex
-# hex-float parser (#8234).
-rustpython-common = { git = "https://github.com/RustPython/RustPython.git", rev = "a5eecb5ebfd48dc62fc05913d16a556d6b0ccd3a" }
-rustpython-literal = { git = "https://github.com/RustPython/RustPython.git", rev = "a5eecb5ebfd48dc62fc05913d16a556d6b0ccd3a" }
-rustpython-compiler = { git = "https://github.com/RustPython/RustPython.git", rev = "a5eecb5ebfd48dc62fc05913d16a556d6b0ccd3a" }
-rustpython-compiler-core = { git = "https://github.com/RustPython/RustPython.git", rev = "a5eecb5ebfd48dc62fc05913d16a556d6b0ccd3a" }
-rustpython-host_env = { git = "https://github.com/RustPython/RustPython.git", rev = "a5eecb5ebfd48dc62fc05913d16a556d6b0ccd3a" }
-rustpython-wtf8 = { git = "https://github.com/RustPython/RustPython.git", rev = "a5eecb5ebfd48dc62fc05913d16a556d6b0ccd3a" }
-rustpython-unicode = { git = "https://github.com/RustPython/RustPython.git", rev = "a5eecb5ebfd48dc62fc05913d16a556d6b0ccd3a" }
-sre-engine = { package = "rustpython-sre_engine", git = "https://github.com/RustPython/RustPython.git", rev = "a5eecb5ebfd48dc62fc05913d16a556d6b0ccd3a" }
+# the host_env mmap re-exports, the round-half-even float_ops::from_hex
+# hex-float parser (#8234), the complex::parse_str internal-whitespace
+# rejection (#8242), and the round-half-even normal-range float/complex repr
+# tie (#8243).
+rustpython-common = { git = "https://github.com/RustPython/RustPython.git", rev = "238bed66fbb0102a83dd9b5c8244e0276fbe8eac" }
+rustpython-literal = { git = "https://github.com/RustPython/RustPython.git", rev = "238bed66fbb0102a83dd9b5c8244e0276fbe8eac" }
+rustpython-compiler = { git = "https://github.com/RustPython/RustPython.git", rev = "238bed66fbb0102a83dd9b5c8244e0276fbe8eac" }
+rustpython-compiler-core = { git = "https://github.com/RustPython/RustPython.git", rev = "238bed66fbb0102a83dd9b5c8244e0276fbe8eac" }
+rustpython-host_env = { git = "https://github.com/RustPython/RustPython.git", rev = "238bed66fbb0102a83dd9b5c8244e0276fbe8eac" }
+rustpython-wtf8 = { git = "https://github.com/RustPython/RustPython.git", rev = "238bed66fbb0102a83dd9b5c8244e0276fbe8eac" }
+rustpython-unicode = { git = "https://github.com/RustPython/RustPython.git", rev = "238bed66fbb0102a83dd9b5c8244e0276fbe8eac" }
+sre-engine = { package = "rustpython-sre_engine", git = "https://github.com/RustPython/RustPython.git", rev = "238bed66fbb0102a83dd9b5c8244e0276fbe8eac" }
 
 # majit JIT framework
 majit = { version = "0.0.2", path = "majit/majit" }

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -8784,59 +8784,10 @@ fn builtin_bin(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     Ok(w_str_new(&s))
 }
 
-/// Parse a complex literal string into `(real, imag)`.
-///
-/// `complexobject.c complex_from_string_inner`: optional surrounding
-/// parens, then `[real][+/-]imag[j]` with no internal whitespace.
+/// Parse a complex literal string into `(real, imag)`, delegated to
+/// `rustpython_literal::complex::parse_str`.
 fn parse_complex_str(raw: &str) -> Option<(f64, f64)> {
-    let mut s = raw.trim();
-    if s.starts_with('(') && s.ends_with(')') {
-        s = s[1..s.len() - 1].trim();
-    }
-    if s.is_empty() || s.contains(char::is_whitespace) {
-        return None;
-    }
-    let parse_part = |p: &str, is_imag: bool| -> Option<f64> {
-        // A bare/sign-only imaginary coefficient means ±1.
-        if is_imag {
-            match p {
-                "" | "+" => return Some(1.0),
-                "-" => return Some(-1.0),
-                _ => {}
-            }
-        }
-        p.parse::<f64>().ok()
-    };
-    let bytes = s.as_bytes();
-    // Boundary between real and imaginary parts: the last '+'/'-' that is
-    // not the leading sign and not part of an exponent (`e+`/`e-`).
-    let mut split = None;
-    for i in 1..bytes.len() {
-        let c = bytes[i];
-        if (c == b'+' || c == b'-') && bytes[i - 1] != b'e' && bytes[i - 1] != b'E' {
-            split = Some(i);
-        }
-    }
-    let ends_j = matches!(bytes.last(), Some(b'j') | Some(b'J'));
-    match split {
-        Some(i) => {
-            if !ends_j {
-                return None;
-            }
-            let real = parse_part(&s[..i], false)?;
-            let imag = parse_part(&s[i..s.len() - 1], true)?;
-            Some((real, imag))
-        }
-        None => {
-            if ends_j {
-                let imag = parse_part(&s[..s.len() - 1], true)?;
-                Some((0.0, imag))
-            } else {
-                let real = parse_part(s, false)?;
-                Some((real, 0.0))
-            }
-        }
-    }
+    rustpython_literal::complex::parse_str(raw)
 }
 
 /// Coerce a value to `(real, imag)` for `complex()` construction.

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -8489,43 +8489,10 @@ fn init_int_type(ns: &mut DictStorage) {
         ),
     );
 }
-/// Format one component of a complex repr: shortest float repr without
-/// the trailing `.0` that `float.__repr__` appends.
-fn complex_part_repr(val: f64) -> String {
-    if val.is_nan() {
-        return "nan".to_string();
-    }
-    if val.is_infinite() {
-        return if val < 0.0 {
-            "-inf".to_string()
-        } else {
-            "inf".to_string()
-        };
-    }
-    let s = crate::display::format_float_repr(val);
-    s.strip_suffix(".0").map(str::to_string).unwrap_or(s)
-}
-
-/// `complexobject.c complex_repr` — `Xj` for a pure-`+0` real part, else
-/// `(re±imj)`.
+/// Complex `repr` (`Xj` for a pure-`+0` real part, else `(re±imj)`),
+/// delegated to `rustpython_literal::complex::to_string`.
 pub(crate) fn complex_repr_string(re: f64, im: f64) -> String {
-    if re == 0.0 && re.is_sign_positive() {
-        format!("{}j", complex_part_repr(im))
-    } else {
-        // The sign follows the imaginary part's sign bit, so a negative
-        // zero prints as `-0j`; a NaN imaginary part prints with `+`.
-        let sign = if im.is_sign_negative() && !im.is_nan() {
-            "-"
-        } else {
-            "+"
-        };
-        format!(
-            "({}{}{}j)",
-            complex_part_repr(re),
-            sign,
-            complex_part_repr(im.abs())
-        )
-    }
+    rustpython_literal::complex::to_string(re, im)
 }
 
 fn init_complex_type(ns: &mut DictStorage) {


### PR DESCRIPTION
<!--
Thank you for contributing to Pyre.

Pyre is still a project that relies heavily on AI-assisted development.

For effective collaboration, please follow these rules.

1. The submitter is ultimately responsible for both the code and the discussion. Do not submit generated code or generated discussion without review.
2. Clearly separate the author's own judgment from generated suggestions. Do not submit generated discussion by itself without the author's own assessment.
-->

## Summary


## Self-review

<!--
Did you use AI to create this patch?
If the patch is not AI-generated, write: "This patch is not AI-generated."
Otherwise, please fill out this section.

Note: Do not run the review in the same session that generated the code.

If you are using Claude, a quick local review is `/parity to upstream/main`.

The currently recommended prompt for gpt-5.5 will be run automatically when this is ready for review.
The prompt is:

----
Assess by static analysis whether our changes in git diff main are equivalent
to the corresponding RPython/PyPy source code. The RPython and PyPy sources
are available locally.

If anything was ported incorrectly, report every instance in detail. After
collecting all differences, organize the report into separate sections:

1. Cases where our patch regressed PyPy parity compared to main
2. Other mismatches introduced by our patch
3. Mismatches that already existed before this patch
4. Structural adaptations

Exceptions: some differences cannot be ported 1:1 because of Python 3.11 vs
3.14 differences, opcode mismatches caused by using a CPython-compatible
compiler, GIL/free-threading differences, and fundamental implementation-
language differences between RPython and Rust. Mark those separately under
“Structural adaptations.”
-->

- [ ] I fully resolved all reasonable code review comments from Codex and CodeRabbit.
  - [ ] Auto-review section 1 is clear. This check is mandatory.
  - [ ] Auto-review section 2 is clear. If this is not checked, please add a comment explaining why.
- [ ] I did not use AI to write the code of this patch.
  - If this is not checked, commits must include `Assisted-by`
