### PR TITLE
jit: tagged-int JIT box/unbox boundary + correctness fixes 

### DIFF
--- a/majit/majit-ir/src/value.rs
+++ b/majit/majit-ir/src/value.rs
@@ -48,6 +48,16 @@ pub struct GcRef(pub usize);
 impl GcRef {
     pub const NULL: GcRef = GcRef(0);
 
+    /// Tracer sentinel for "no concrete runtime value is known for this
+    /// OpRef" (distinct from `NULL`, which is a genuine null reference).
+    ///
+    /// The value must never alias a real `PyObjectRef`: a tagged small int is
+    /// always odd (`(v << 1) | 1`) and a heap object is 8-aligned, so an even,
+    /// non-8-aligned, non-null address is unrepresentable as either. `usize::MAX`
+    /// itself is unsound once ints are tagged — it equals `tag_int(-1)` — so the
+    /// sentinel clears the low bit to stay off every tagged value.
+    pub const NO_CONCRETE: GcRef = GcRef(usize::MAX - 1);
+
     pub fn is_null(self) -> bool {
         self.0 == 0
     }

--- a/majit/majit-metainterp/src/trace_ctx.rs
+++ b/majit/majit-metainterp/src/trace_ctx.rs
@@ -3187,9 +3187,9 @@ impl TraceCtx {
         // `virtualizable_values` is a dense `Vec<Value>`, so an unknown
         // concrete still needs a placeholder slot.  This is the lone
         // remaining materialization of the "no concrete" marker; the
-        // role-2 shadow store keeps a `Value::Ref(GcRef(usize::MAX))`
+        // role-2 shadow store keeps a `Value::Ref(GcRef::NO_CONCRETE)`
         // until that store is itself moved to `Vec<Option<Value>>`.
-        let stored = concrete.unwrap_or(Value::Ref(majit_ir::GcRef(usize::MAX)));
+        let stored = concrete.unwrap_or(Value::Ref(majit_ir::GcRef::NO_CONCRETE));
         self.set_virtualizable_entry_at(index, value, stored);
         // Keep the heapcache consistent: if a prior nonstandard getfield
         // cached a value for this field (e.g., before a replace_box made

--- a/pyre/pyre-jit-trace/src/helpers.rs
+++ b/pyre/pyre-jit-trace/src/helpers.rs
@@ -1249,7 +1249,7 @@ pub fn emit_new_pyframe_inline_with_params(
 
 pub fn emit_new_pyframe_inline_self_recursive(
     ctx: &mut TraceCtx,
-    raw_int_arg: OpRef,
+    arg_box: OpRef,
     array_size: usize,
     valuestackdepth: usize,
     pycode: OpRef,
@@ -1257,15 +1257,21 @@ pub fn emit_new_pyframe_inline_self_recursive(
     ec: OpRef,
 ) -> OpRef {
     use crate::descr::{
-        int_intval_descr, pyframe_code_descr, pyframe_execution_context_descr,
-        pyframe_locals_cells_stack_descr, pyframe_next_instr_descr, pyframe_size_descr,
-        pyframe_stack_depth_descr, pyframe_w_globals_obj_descr, w_int_size_descr,
+        pyframe_code_descr, pyframe_execution_context_descr, pyframe_locals_cells_stack_descr,
+        pyframe_next_instr_descr, pyframe_size_descr, pyframe_stack_depth_descr,
+        pyframe_w_globals_obj_descr,
     };
     use crate::state::pyobject_gcarray_descr;
 
-    // Step 1 — box the raw int into a fresh W_IntObject. Mirrors the
-    // `w_int_new(raw_int_arg)` call inside the opaque helper.
-    let boxed = emit_box_int_inline(ctx, raw_int_arg, w_int_size_descr(), int_intval_descr());
+    // Step 1 — `locals[0]` receives the caller's already-boxed positional
+    // argument box.  The caller supplies the shape-correct box so the callee
+    // reads back the same representation it was traced against: under
+    // `CAN_BE_TAGGED` a small `int` stays a tagged immediate (`ll_int_box`),
+    // otherwise a heap `W_IntObject` (`w_int_new` fallback).  Re-boxing a raw
+    // payload heap-side here would force a heap box even when the value fits
+    // the tagged range, and the callee's speculative low-bit guard on the
+    // local would then deopt on every recursion.
+    let boxed = arg_box;
 
     // Step 2 — allocate the locals_cells_stack_w array. `NewArrayClear`
     // zeros every slot so any future LOAD_FAST on an unbound local

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -8222,17 +8222,30 @@ pub fn fbw_store_journal_root_walker(visitor: &mut dyn FnMut(&mut majit_ir::GcRe
 /// (`wrapint` / `wrapfloat` = `NewWithVtable` + `SetfieldGc`).  `value_type`
 /// here is `ctx.get_opref_type(value).unwrap_or(Type::Ref)`, the exact body
 /// of `MIFrame::value_type` minus the borrow.
-fn fbw_ensure_boxed_for_ca(ctx: &mut TraceCtx, value: OpRef) -> OpRef {
+fn fbw_ensure_boxed_for_ca(
+    ctx: &mut WalkContext<'_, '_>,
+    op_pc: usize,
+    value: OpRef,
+) -> Result<OpRef, DispatchError> {
     let ty = if value.is_none() {
         Type::Ref
     } else {
-        ctx.get_opref_type(value).unwrap_or(Type::Ref)
+        ctx.trace_ctx.get_opref_type(value).unwrap_or(Type::Ref)
     };
-    match ty {
-        Type::Int => crate::state::wrapint(ctx, value),
-        Type::Float => crate::state::wrapfloat(ctx, value),
+    let boxed = match ty {
+        Type::Int => {
+            // The concrete int is stamped on `value` by the `int_return`
+            // callers (or carried by a `ConstInt`), so route the box through
+            // the tagged-immediate path when it fits.
+            match ctx.trace_ctx.box_value(value) {
+                Some(majit_ir::Value::Int(v)) => walker_box_int(ctx, op_pc, value, v)?,
+                _ => crate::state::wrapint(ctx.trace_ctx, value),
+            }
+        }
+        Type::Float => crate::state::wrapfloat(ctx.trace_ctx, value),
         Type::Ref | Type::Void => value,
-    }
+    };
+    Ok(boxed)
 }
 
 /// FBW-native port of `MIFrame::store_token_in_vable` (`pyjitpl.py:3222`).
@@ -8266,7 +8279,7 @@ fn fbw_terminate_with_finish(
     result: OpRef,
     op_pc: usize,
 ) -> Result<(), DispatchError> {
-    let finish_value = fbw_ensure_boxed_for_ca(ctx.trace_ctx, result);
+    let finish_value = fbw_ensure_boxed_for_ca(ctx, op_pc, result)?;
     fbw_store_token_in_vable(ctx, op_pc)?;
     FBW_FINISH_PAYLOAD.with(|c| c.set(Some((finish_value, Type::Ref))));
     Ok(())
@@ -14988,7 +15001,9 @@ fn try_walker_specialize_unpack(
                 crate::descr::specialised_tuple_ii_value1_descr()
             };
             let raw = crate::state::opimpl_getfield_gc_i(ctx.trace_ctx, seq, descr);
-            let boxed = crate::state::wrapint(ctx.trace_ctx, raw);
+            let elem =
+                unsafe { pyre_object::w_int_get_value(elem_ptr as pyre_object::PyObjectRef) };
+            let boxed = walker_box_int(ctx, op_pc, raw, elem)?;
             ctx.trace_ctx.set_opref_concrete(
                 boxed,
                 majit_ir::Value::Ref(majit_ir::GcRef(elem_ptr as usize)),
@@ -16092,7 +16107,7 @@ fn try_walker_specialize_subscr(
             let elem = unsafe { pyre_object::w_int_get_value(result_obj) };
             ctx.trace_ctx
                 .set_opref_concrete(raw, majit_ir::Value::Int(elem));
-            crate::state::wrapint(ctx.trace_ctx, raw)
+            walker_box_int(ctx, op_pc, raw, elem)?
         }
         _ => {
             let block = crate::state::opimpl_getfield_gc_r(
@@ -16378,7 +16393,7 @@ fn try_walker_specialize_builtin_len(
     let raw_len = crate::state::opimpl_getfield_gc_i(ctx.trace_ctx, list_op, len_descr);
     ctx.trace_ctx
         .set_opref_concrete(raw_len, majit_ir::Value::Int(concrete_len as i64));
-    let boxed = crate::state::wrapint(ctx.trace_ctx, raw_len);
+    let boxed = walker_box_int(ctx, op.pc, raw_len, concrete_len as i64)?;
     ctx.trace_ctx.set_opref_concrete(
         boxed,
         majit_ir::Value::Ref(majit_ir::GcRef(boxed_result as usize)),
@@ -17777,7 +17792,8 @@ fn emit_namespace_cell_fold(
             cell_opref,
             crate::descr::int_mutable_cell_value_descr(),
         );
-        crate::state::wrapint(ctx.trace_ctx, raw_int)
+        let intval = unsafe { pyre_object::w_int_get_value(result_obj) };
+        walker_box_int(ctx, op_pc, raw_int, intval)?
     } else {
         cell_opref
     };
@@ -18251,7 +18267,9 @@ fn dispatch_residual_call_iIRd_kind(
     if ei.pyre_helper == majit_ir::PyreHelperKind::BoxInt && dst_bank == 'r' {
         if let Some(&raw_arg) = i_args.first() {
             if let Some(boxed_ptr) = walker_execute_may_force_boxed(ctx, &allboxes, call_descr) {
-                let boxed = crate::state::wrapint(ctx.trace_ctx, raw_arg);
+                let intval =
+                    unsafe { pyre_object::w_int_get_value(boxed_ptr as pyre_object::PyObjectRef) };
+                let boxed = walker_box_int(ctx, op.pc, raw_arg, intval)?;
                 ctx.trace_ctx.set_opref_concrete(
                     boxed,
                     majit_ir::Value::Ref(majit_ir::GcRef(boxed_ptr as usize)),

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -1904,7 +1904,7 @@ fn concrete_from_recorded_opref(ctx: &WalkContext<'_, '_>, opref: OpRef) -> Conc
     match ctx.trace_ctx.concrete_of_opref(opref) {
         Some(Value::Int(v)) => ConcreteValue::Int(v),
         Some(Value::Float(v)) => ConcreteValue::Float(v),
-        Some(Value::Ref(r)) if r != majit_ir::GcRef(usize::MAX) => {
+        Some(Value::Ref(r)) if r != majit_ir::GcRef::NO_CONCRETE => {
             ConcreteValue::Ref(r.as_usize() as pyre_object::PyObjectRef)
         }
         _ => ConcreteValue::Null,
@@ -3518,7 +3518,7 @@ fn walker_fill_materialized_array(
         return;
     }
     let block = match ctx.trace_ctx.box_value(array) {
-        Some(majit_ir::Value::Ref(r)) if r != majit_ir::GcRef(usize::MAX) && r.as_usize() != 0 => {
+        Some(majit_ir::Value::Ref(r)) if r != majit_ir::GcRef::NO_CONCRETE && r.as_usize() != 0 => {
             r.as_usize() as *mut pyre_object::object_array::ItemsBlock
         }
         // No stamped concrete → not materialized (gate off / non-ref / non-const).
@@ -3532,23 +3532,23 @@ fn walker_fill_materialized_array(
         Some(majit_ir::Value::Int(i)) if i >= 0 => i as usize,
         _ => {
             ctx.trace_ctx
-                .try_set_opref_concrete(array, majit_ir::Value::Ref(majit_ir::GcRef(usize::MAX)));
+                .try_set_opref_concrete(array, majit_ir::Value::Ref(majit_ir::GcRef::NO_CONCRETE));
             return;
         }
     };
     let cap = unsafe { pyre_object::object_array::items_block_capacity(block) };
     if idx >= cap {
         ctx.trace_ctx
-            .try_set_opref_concrete(array, majit_ir::Value::Ref(majit_ir::GcRef(usize::MAX)));
+            .try_set_opref_concrete(array, majit_ir::Value::Ref(majit_ir::GcRef::NO_CONCRETE));
         return;
     }
     let elem = match ctx.trace_ctx.box_value(value) {
-        Some(majit_ir::Value::Ref(r)) if r != majit_ir::GcRef(usize::MAX) => {
+        Some(majit_ir::Value::Ref(r)) if r != majit_ir::GcRef::NO_CONCRETE => {
             r.as_usize() as pyre_object::PyObjectRef
         }
         _ => {
             ctx.trace_ctx
-                .try_set_opref_concrete(array, majit_ir::Value::Ref(majit_ir::GcRef(usize::MAX)));
+                .try_set_opref_concrete(array, majit_ir::Value::Ref(majit_ir::GcRef::NO_CONCRETE));
             return;
         }
     };
@@ -5236,7 +5236,7 @@ fn try_fold_pure_call_via_executor(
                 // "no concrete known" — never reach this path because
                 // `box_value` returns `None` for un-stamped OpRefs, but
                 // belt-and-suspenders against future plumbing.
-                if r == majit_ir::GcRef(usize::MAX) {
+                if r == majit_ir::GcRef::NO_CONCRETE {
                     return;
                 }
                 r.as_usize() as i64
@@ -5690,7 +5690,7 @@ fn try_execute_residual_call_via_executor(
         let v = match ctx.trace_ctx.box_value(arg) {
             Some(majit_ir::Value::Int(n)) => n,
             Some(majit_ir::Value::Ref(r)) => {
-                if r == majit_ir::GcRef(usize::MAX) {
+                if r == majit_ir::GcRef::NO_CONCRETE {
                     if is_void {
                         return Err(DispatchError::ResidualCallArgUnbound {
                             pc: op_pc,
@@ -13836,7 +13836,7 @@ fn walker_execute_may_force_boxed(
         let v = match ctx.trace_ctx.box_value(arg) {
             Some(majit_ir::Value::Int(n)) => n,
             Some(majit_ir::Value::Ref(r)) => {
-                if r == majit_ir::GcRef(usize::MAX) {
+                if r == majit_ir::GcRef::NO_CONCRETE {
                     return None;
                 }
                 r.as_usize() as i64
@@ -13866,7 +13866,7 @@ fn walker_concrete_ref_object(
     opref: OpRef,
 ) -> Option<pyre_object::PyObjectRef> {
     match ctx.trace_ctx.concrete_of_opref(opref) {
-        Some(majit_ir::Value::Ref(r)) if r != majit_ir::GcRef(usize::MAX) => {
+        Some(majit_ir::Value::Ref(r)) if r != majit_ir::GcRef::NO_CONCRETE => {
             let obj = r.as_usize() as pyre_object::PyObjectRef;
             if obj.is_null() { None } else { Some(obj) }
         }
@@ -14661,6 +14661,21 @@ fn walker_guard_class(
     type_addr: i64,
 ) -> Result<(), DispatchError> {
     if !ctx.trace_ctx.heap_cache().is_class_known(obj) {
+        // `GuardClass` reads `ob_type` off `obj` (rpython/jit/backend/x86/
+        // assembler.py:1885 `_cmp_guard_class` derefs the pointer with no tag
+        // test), so the frontend must not hand it a tagged immediate. `obj`
+        // here is a concrete heap box at record time (callers gate on
+        // `is_long`), but the trace is reused for operands that arrive tagged
+        // on a later entry. Emit the low-bit `GuardFalse` first — mirroring
+        // `walker_unbox_int_typed`'s boxed leg — so a tagged arrival deopts
+        // instead of faulting on the class deref.
+        if pyre_object::tagged_int::CAN_BE_TAGGED
+            && walker_concrete_ref_object(ctx, obj)
+                .is_some_and(|o| !pyre_object::tagged_int::is_tagged_int(o))
+        {
+            let lowbit = crate::helpers::emit_tag_lowbit_test(ctx.trace_ctx, obj, false);
+            walker_emit_guard_with_snapshot(ctx, op_pc, OpCode::GuardFalse, &[lowbit])?;
+        }
         let type_const = ctx.trace_ctx.const_int(type_addr);
         ctx.trace_ctx
             .record_guard(OpCode::GuardClass, &[obj, type_const], 0);

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -12057,9 +12057,20 @@ fn try_walker_call_assembler_self_recursive(
     let nlocals = callee_code.varnames.len();
     let max_stack = callee_code.max_stackdepth as usize;
 
-    // Unbox the boxed int argument -> raw payload, re-boxed inside the new
-    // callee frame.  Mirror of `trace_guarded_int_payload(args[0])`.
+    // Unbox the boxed int argument -> raw payload, then re-box it into the
+    // callee's `locals[0]` through `walker_box_int` so the local carries the
+    // same representation the callee was traced against.  Under
+    // `CAN_BE_TAGGED` a small `int` becomes a tagged immediate (`ll_int_box`);
+    // a heap-only re-box (`emit_box_int_inline`) would force a `W_IntObject`
+    // and the callee's speculative low-bit guard on the local would deopt on
+    // every recursion.  Under `!CAN_BE_TAGGED` `walker_box_int` falls back to
+    // `wrapint` (= `emit_box_int_inline`), so the emitted ops are unchanged.
+    // Mirror of `trace_guarded_int_payload(args[0])`.
     let raw_arg = walker_unbox_int(ctx, op.pc, r_args[2], int_type_addr)?;
+    let arg_box = match ctx.trace_ctx.box_value(raw_arg) {
+        Some(majit_ir::Value::Int(v)) => walker_box_int(ctx, op.pc, raw_arg, v)?,
+        _ => crate::state::wrapint(ctx.trace_ctx, raw_arg),
+    };
 
     // Execution-context red: recover it fresh off the materialized caller
     // portal frame via `GETFIELD_GC_R(frame, execution_context_descr)` rather
@@ -12084,7 +12095,7 @@ fn try_walker_call_assembler_self_recursive(
     let w_globals_obj_const = ctx.trace_ctx.const_ref(callee_globals_obj as i64);
     let callee_frame = crate::helpers::emit_new_pyframe_inline_self_recursive(
         ctx.trace_ctx,
-        raw_arg,
+        arg_box,
         nlocals + max_stack,
         nlocals,
         pycode_const,

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -3073,6 +3073,20 @@ pub(crate) fn trace_unbox_int_with_resume_descr<F: crate::walker_frame_ops::Walk
 ///    `W_LongObject.toint()` (`longobject.py:138`) → `rbigint.toint()`
 ///    (`rbigint.py:465`, elidable). OverflowError is statically
 ///    unreachable post-fits-int GUARD_TRUE.
+///
+/// Unlike the int arms (`trace_unbox_int_with_resume_descr`,
+/// `trace_guarded_int_payload`), step 1's `GUARD_CLASS` carries no
+/// `is_tagged_int` pre-check before its `ob_type` deref, and needs none: a
+/// tagged immediate can never select this arm. Both call sites gate it on
+/// `is_long(concrete)` — `trace_plain_int_payload` (`trace_opcode.rs` `if
+/// is_long(concrete_item)`) and `unbox_int_or_long_for_int_strategy` (fed by
+/// `unbox_long = is_long(concrete_value)` in `detect_list_setitem_strategy`).
+/// `is_long` routes through `py_type_check`, which short-circuits a tagged
+/// immediate to `ptr::eq(tp, &INT_TYPE)` — false for `LONG_TYPE` — before any
+/// `ob_type` deref. A `W_LongObject` is a distinct 8-aligned heap struct and is
+/// never tagged, so `is_long` is definitionally false for an odd pointer. The
+/// `GUARD_CLASS` deref therefore only ever sees an aligned heap pointer. Both
+/// call sites also early-return `value_type == Int` operands before this arm.
 pub(crate) fn trace_unbox_long_with_resume<F: crate::walker_frame_ops::WalkerFrameOps>(
     frame: &mut F,
     obj: OpRef,

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -3016,7 +3016,7 @@ pub(crate) fn trace_unbox_int_with_resume_descr<F: crate::walker_frame_ops::Walk
 ) -> OpRef {
     if pyre_object::tagged_int::CAN_BE_TAGGED {
         if let Some(majit_ir::Value::Ref(r)) = frame.ctx().concrete_of_opref(obj) {
-            if r != majit_ir::GcRef(usize::MAX) {
+            if r != majit_ir::GcRef::NO_CONCRETE {
                 let o = r.as_usize() as pyre_object::PyObjectRef;
                 if !o.is_null() {
                     if pyre_object::tagged_int::is_tagged_int(o) {

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -5123,7 +5123,7 @@ impl MIFrame {
     fn guard_int_object_value(&mut self, ctx: &mut TraceCtx, int_obj: OpRef, expected: i64) {
         if pyre_object::tagged_int::CAN_BE_TAGGED {
             if let Some(Value::Ref(r)) = ctx.concrete_of_opref(int_obj) {
-                if r != GcRef(usize::MAX) {
+                if r != GcRef::NO_CONCRETE {
                     let o = r.as_usize() as PyObjectRef;
                     if !o.is_null() {
                         if pyre_object::tagged_int::is_tagged_int(o) {
@@ -5213,7 +5213,7 @@ impl MIFrame {
         }
         if pyre_object::tagged_int::CAN_BE_TAGGED {
             if let Some(Value::Ref(r)) = ctx.concrete_of_opref(int_obj) {
-                if r != GcRef(usize::MAX) {
+                if r != GcRef::NO_CONCRETE {
                     let o = r.as_usize() as PyObjectRef;
                     if !o.is_null() {
                         if pyre_object::tagged_int::is_tagged_int(o) {

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -538,9 +538,16 @@ fn emit_call_assembler_callee_frame(
                 let pycode_const = ctx.const_ref(w_callee_code as i64);
                 let w_globals_obj_const = ctx.const_ref(callee_globals_obj as i64);
                 let ec = this.ensure_execution_context(ctx);
+                // Re-box the unboxed raw arg into `locals[0]` tag-aware so the
+                // callee reads the same representation it was traced against;
+                // heap-only boxing here forces a `W_IntObject` even when the
+                // value fits the tagged range, deopting the callee's low-bit
+                // guard every recursion.  `box_int_payload` = `wrapint` under
+                // `!CAN_BE_TAGGED`, so the emission is unchanged by default.
+                let arg_box = this.box_int_payload(ctx, raw_arg);
                 let frame = crate::helpers::emit_new_pyframe_inline_self_recursive(
                     ctx,
-                    raw_arg,
+                    arg_box,
                     nlocals + ncells + max_stack,
                     nlocals + ncells,
                     pycode_const,
@@ -5227,6 +5234,31 @@ impl MIFrame {
         }
         self.guard_class(ctx, int_obj, &INT_TYPE as *const PyType);
         opimpl_getfield_gc_i(ctx, int_obj, int_intval_descr())
+    }
+
+    /// Box a raw `Type::Int` payload back into a `Ref`, taking the tagged
+    /// immediate path when `CAN_BE_TAGGED` and the concrete value fits
+    /// (`ll_int_box`, mirror of `walker_box_int`).  The `IntAddOvf(raw,raw)`
+    /// doubling is the `fits_tagged` overflow check; a runtime value that does
+    /// not fit deopts on the `GuardNoOverflow` rather than producing a wrong
+    /// box.  Falls back to `wrapint` (heap `W_IntObject`) when the flag is off
+    /// or the value is not a concrete `Int`, so the emission is unchanged in
+    /// the default configuration.
+    pub(crate) fn box_int_payload(&mut self, ctx: &mut TraceCtx, raw: OpRef) -> OpRef {
+        if pyre_object::tagged_int::CAN_BE_TAGGED {
+            if let Some(Value::Int(value)) = ctx.box_value(raw) {
+                if pyre_object::tagged_int::fits_tagged(value) {
+                    let doubled = ctx.record_op(OpCode::IntAddOvf, &[raw, raw]);
+                    ctx.set_opref_concrete(doubled, Value::Int(value << 1));
+                    self.generate_guard(ctx, OpCode::GuardNoOverflow, &[]);
+                    let one = ctx.const_int(1);
+                    let tagged = ctx.record_op(OpCode::IntOr, &[doubled, one]);
+                    ctx.set_opref_concrete(tagged, Value::Int((value << 1) | 1));
+                    return ctx.record_op(OpCode::CastIntToPtr, &[tagged]);
+                }
+            }
+        }
+        crate::state::wrapint(ctx, raw)
     }
 
     pub(crate) fn guard_len_gt_index(&mut self, ctx: &mut TraceCtx, len: OpRef, index: usize) {

--- a/pyre/pyre-jit-trace/src/walker_frame_ops.rs
+++ b/pyre/pyre-jit-trace/src/walker_frame_ops.rs
@@ -147,7 +147,7 @@ pub trait WalkerFrameOps {
     fn guard_int_object_value(&mut self, int_obj: OpRef, expected: i64) {
         if pyre_object::tagged_int::CAN_BE_TAGGED {
             if let Some(majit_ir::Value::Ref(r)) = self.ctx().concrete_of_opref(int_obj) {
-                if r != majit_ir::GcRef(usize::MAX) {
+                if r != majit_ir::GcRef::NO_CONCRETE {
                     let o = r.as_usize() as pyre_object::PyObjectRef;
                     if !o.is_null() {
                         if pyre_object::tagged_int::is_tagged_int(o) {


### PR DESCRIPTION
## Summary

Tagged-int enablement epic (#22) JIT boundary work. Small ints can be represented as immediate `(v<<1)|1` values instead of heap `W_IntObject`, gated behind `CAN_BE_TAGGED` (default **false** — this PR is inert at runtime; the enablement flip is a separate future commit).

These commits land the JIT trace-time box/unbox tag path and two correctness fixes surfaced during flip validation:

- **box in-trace ints via the tagged path** (`walker_box_int`/`box_int_payload`), gated `CAN_BE_TAGGED`.
- **self-recursive CALL_ASSEMBLER frame arg** boxed tag-aware.
- **`trace_unbox_long_with_resume`** tag-unreachability invariant documented.
- **no-concrete sentinel de-collision**: `tag_int(-1) == usize::MAX` aliased the tracer's "no concrete value known" sentinel `GcRef(usize::MAX)`. Introduced `GcRef::NO_CONCRETE = usize::MAX-1` (even, cannot alias any tagged/odd immediate or 8-aligned heap ptr) across all sites.
- **`walker_guard_class` tag pre-check**: emit a low-bit `GuardFalse` before `GuardClass` on a possibly-tagged operand (mirrors `walker_unbox_int_typed`'s boxed leg), so a tagged arrival deopts instead of faulting on the class deref.

## Status

- Flag **false** (default): byte-identical to prior behavior; inert.
- Flag **true** (local validation only): correctness clean (dynasm 156/159, zero correctness fails). The remaining flip blocker is **perf** — hot integer loops are 2.6–3.3× slower than PyPy because in-trace tagging defeats loop virtualization (the tagged Ref is carried literally across the back-edge and re-untagged each iteration, instead of the box being virtualized away as in flag-false). Root-caused; the fix (reconciling the int representation at the loop merge point: resume-numbering + unbox folding) is tracked as follow-up and does not block this gated groundwork.

## Verification

- `check.py` dynasm + cranelift green with flag **false** (this PR's shipping config).
- Flag-true validation (local): 6 correctness repros green (fib_loop, exc_caught, etc.); JIT-on == JIT-off == py3.14 bit-exact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)