### PR TITLE
majit-cranelift: demote loop-invariant deopt-only ref LABEL args out of the SSA loop phi

### DIFF
--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -4982,6 +4982,70 @@ fn compute_loop_phi_keep(ops: &[Op], label_indices: &[usize]) -> IndexMap<usize,
                 any = true;
             }
         }
+
+        // A kept back-edge position (and every arg of an in-body JUMP to a
+        // local LABEL) is resolved through SSA `use_var` at the JUMP, and the
+        // loop-body reload skip leaves a demoted var's SSA value stale after an
+        // in-loop collecting call.  Un-demote any position whose OpRef also
+        // flows through such a use.  Iterate: un-demoting a position re-adds
+        // its own OpRef to the kept back-edge args (a duplicated LABEL arg can
+        // then escape).
+        if any {
+            let local_label_descrs: IndexSet<u32> = label_indices
+                .iter()
+                .filter_map(|&li| ops[li].getdescr().map(|d| d.index()))
+                .collect();
+            loop {
+                let mut escapes: IndexSet<u32> = IndexSet::new();
+                for (idx, op) in ops.iter().enumerate() {
+                    if idx <= label_idx || op.opcode != OpCode::Jump {
+                        continue;
+                    }
+                    let is_back_jump = back_jumps.contains(&idx);
+                    let is_local_jump = is_back_jump
+                        || op
+                            .getdescr()
+                            .map(|d| local_label_descrs.contains(&d.index()))
+                            .unwrap_or(false);
+                    if !is_local_jump {
+                        // External JUMP: lowered via the guard-exit path, whose
+                        // failarg resolution is demotion-aware.
+                        continue;
+                    }
+                    for (i, a) in op.getarglist().iter().enumerate() {
+                        if is_back_jump && !keep.get(i).copied().unwrap_or(true) {
+                            // Demoted position: dropped from the back-edge args.
+                            continue;
+                        }
+                        if !a.is_none() && !a.is_constant() {
+                            let o = a.to_opref();
+                            if o.inline_const_bits().is_none() {
+                                escapes.insert(o.raw());
+                            }
+                        }
+                    }
+                }
+                let mut changed = false;
+                for i in 0..arity {
+                    if keep[i] {
+                        continue;
+                    }
+                    let escaped = label_args
+                        .get(i)
+                        .map(|a| escapes.contains(&a.to_opref().raw()))
+                        .unwrap_or(false);
+                    if escaped {
+                        keep[i] = true;
+                        changed = true;
+                    }
+                }
+                if !changed {
+                    break;
+                }
+            }
+            any = keep.iter().any(|k| !*k);
+        }
+
         if any {
             keep_by_label.insert(label_idx, keep);
         }
@@ -5226,8 +5290,8 @@ fn resolve_failarg_opref(
         return builder.ins().iconst(cl_types::I64, c);
     }
     // A loop-invariant deopt-only arg demoted out of the loop phi has no SSA
-    // Variable in the loop body; its value lives only in its dense jitframe
-    // slot (seeded once in the preamble, unchanged by the loop). Reload it from
+    // Variable in the loop body; its value lives in its ref-root slot (seeded
+    // on the preamble fall-through, GC-forwarded in place). Reload it from
     // there rather than `use_var`-ing an undefined Variable.
     if let Some(offset) = demoted_failarg_offset(demoted_failarg_slots, opref.raw()) {
         return builder
@@ -5624,9 +5688,11 @@ fn reload_ref_roots(
             continue;
         }
         // Demoted refs are read on demand from their ref-root slot by guard
-        // exits (`resolve_failarg_opref`); the loop body never `use_var`s them,
-        // so there is no SSA definition to reload — and defining one would be
-        // dead. The GC already updated the slot in place across the call.
+        // exits (`resolve_failarg_opref`); the loop body never `use_var`s them
+        // (`compute_loop_phi_keep` un-demotes any arg that escapes through a
+        // kept back-edge position or an in-body local JUMP), so there is no
+        // SSA definition to reload — and defining one would be dead. The GC
+        // already updated the slot in place across the call.
         if is_demoted_failarg(demoted_failarg_slots, var_idx) {
             continue;
         }
@@ -9295,6 +9361,7 @@ impl CraneliftBackend {
                 // the body's guard exits read from.  Reading the ref-root slot
                 // directly would be stale: a bridge does not repopulate it.
                 let loop_phi_keep = loop_phi_keep_by_label.get(&label_idx);
+                let mut demoted_root_syncs: Vec<(CValue, i32)> = Vec::new();
                 if let Some(positions) = demoted_ref_positions_by_label.get(&label_idx) {
                     for &(i, raw, root_ofs) in positions {
                         let v = builder.ins().load(
@@ -9304,7 +9371,7 @@ impl CraneliftBackend {
                             JF_FRAME_ITEM0_OFS + (i as i32) * 8,
                         );
                         builder.def_var(var(raw), v);
-                        builder.ins().store(MemFlags::new(), v, cur_jf, root_ofs);
+                        demoted_root_syncs.push((v, root_ofs));
                     }
                 }
                 let vals: Vec<CValue> = (0..arity)
@@ -9316,6 +9383,15 @@ impl CraneliftBackend {
                             .load(cl_types::I64, MemFlags::trusted(), cur_jf, offset)
                     })
                     .collect();
+                // Ref-root re-syncs go after every dense carried-slot load:
+                // when `max_output_slots < arity` the ref-root region aliases
+                // the tail of the dense slots, and a store emitted before the
+                // loads would clobber a carried value the loader has yet to
+                // read (same hazard `deferred_entry_root_syncs` defers past
+                // the dispatch above).
+                for &(v, root_ofs) in &demoted_root_syncs {
+                    builder.ins().store(MemFlags::new(), v, cur_jf, root_ofs);
+                }
                 let args = block_args_to(&mut builder, label_block, &vals);
                 builder.ins().jump(label_block, &args);
             }
@@ -17831,6 +17907,36 @@ mod tests {
         let moved = backend.get_ref_value(&frame, 0);
         assert_ne!(moved, root);
         assert_eq!(unsafe { *(moved.0 as *const u64) }, 0xD30F_0004);
+    }
+
+    #[test]
+    fn loop_phi_keeps_ref_escaping_via_kept_backedge_position() {
+        // A deopt-only invariant ref that also flows through a *kept* back-edge
+        // position is `use_var`-resolved at the JUMP, so demoting it would feed
+        // a stale (pre-collection) SSA value into the kept phi. It must stay a
+        // phi. Without the escape refinement the label maps to `[true, false]`;
+        // the refinement un-demotes position 1, leaving no demotion so the
+        // label is absent from the per-label map.
+        let inv = OpRef::ref_op(1);
+        let other = OpRef::ref_op(3);
+        let guard = mk_op(OpCode::GuardTrue, &[OpRef::int_op(2)], OpRef::NONE.raw());
+        guard.setfailargs(smallvec::smallvec![rb(inv)]);
+        let ops = vec![
+            mk_op(OpCode::SameAsR, &[OpRef::input_arg_ref(0)], inv.raw()),
+            mk_op(OpCode::SameAsR, &[OpRef::input_arg_ref(1)], other.raw()),
+            mk_op(OpCode::Label, &[other, inv], OpRef::NONE.raw()),
+            guard,
+            // Back-edge passes `inv` at the kept position 0 as well as its own
+            // demotable position 1.
+            mk_op(OpCode::Jump, &[inv, inv], OpRef::NONE.raw()),
+        ];
+
+        let ops: Vec<Op> = ops.iter().map(|op| (**op).clone()).collect();
+        assert_eq!(
+            compute_loop_phi_keep(&ops, &[2]).get(&2),
+            None,
+            "ref escaping through a kept back-edge position must not be demoted"
+        );
     }
 
     #[test]

--- a/majit/majit-metainterp/src/trace_ctx.rs
+++ b/majit/majit-metainterp/src/trace_ctx.rs
@@ -310,6 +310,13 @@ pub struct TraceCtx {
     /// skip when no compiled targets exist for the current
     /// greenkey) gate on this flag instead of fn presence.
     pub is_bridge_trace: bool,
+    /// Set true during the walk when a LOAD_GLOBAL / LOAD_NAME resolves through
+    /// the frame's module globals dict.  Read by
+    /// `finish_trace_namespace_dependency` at walk end and by the entry-bridge
+    /// fold mid-walk; drives `PyreMeta.namespace_dependent` (the re-entry
+    /// namespace-length gate).  Per-trace: a fresh ctx starts `false`, so no
+    /// manual reset is needed.
+    pub reads_module_global: bool,
     /// For a bridge trace (`is_bridge_trace`), the loop-header bytecode pc of
     /// the parent loop the bridge will JUMP into. The bridge closes when it
     /// reaches this pc (a real compiled-loop header), NOT when it transiently
@@ -1199,6 +1206,7 @@ impl TraceCtx {
             forced_virtualizable: None,
             has_compiled_targets_fn: None,
             is_bridge_trace: false,
+            reads_module_global: false,
             bridge_target_header_pc: None,
             portal_call_depth_fn: None,
             seen_loop_header_for_jdindex: -1,
@@ -1273,6 +1281,7 @@ impl TraceCtx {
             forced_virtualizable: None,
             has_compiled_targets_fn: None,
             is_bridge_trace: false,
+            reads_module_global: false,
             bridge_target_header_pc: None,
             portal_call_depth_fn: None,
             seen_loop_header_for_jdindex: -1,

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -20534,14 +20534,19 @@ fn try_walker_load_global_cell_fold(
     Ok(true)
 }
 
-fn mark_trace_reads_module_global(w_globals: pyre_object::PyObjectRef, name: &str) {
+fn mark_trace_reads_module_global(
+    tc: &mut TraceCtx,
+    w_globals: pyre_object::PyObjectRef,
+    name: &str,
+) {
     if !w_globals.is_null() && crate::state::module_dict_cell_slot_direct(w_globals, name).is_some()
     {
-        crate::trace::set_trace_reads_module_global(true);
+        tc.reads_module_global = true;
     }
 }
 
 fn mark_trace_reads_module_global_from_code(
+    tc: &mut TraceCtx,
     w_globals: pyre_object::PyObjectRef,
     w_code_ptr: usize,
     name_idx: usize,
@@ -20563,11 +20568,15 @@ fn mark_trace_reads_module_global_from_code(
     }) else {
         return false;
     };
-    mark_trace_reads_module_global(w_globals, &name);
+    mark_trace_reads_module_global(tc, w_globals, &name);
     true
 }
 
-fn mark_trace_reads_module_global_from_frame_name(frame_ptr: usize, w_name_ptr: usize) -> bool {
+fn mark_trace_reads_module_global_from_frame_name(
+    tc: &mut TraceCtx,
+    frame_ptr: usize,
+    w_name_ptr: usize,
+) -> bool {
     if frame_ptr == 0 || w_name_ptr == 0 {
         return false;
     }
@@ -20579,7 +20588,7 @@ fn mark_trace_reads_module_global_from_frame_name(frame_ptr: usize, w_name_ptr: 
     let name = unsafe {
         pyre_object::unicodeobject::w_str_get_value(w_name_ptr as pyre_object::PyObjectRef)
     };
-    mark_trace_reads_module_global(w_globals, name);
+    mark_trace_reads_module_global(tc, w_globals, name);
     true
 }
 
@@ -21059,17 +21068,18 @@ fn dispatch_residual_call_iIRd_kind(
             ) {
                 let name_idx = (namei as usize) >> 1;
                 if !mark_trace_reads_module_global_from_code(
+                    ctx.trace_ctx,
                     ns_ptr as pyre_object::PyObjectRef,
                     w_code_ptr,
                     name_idx,
                 ) {
-                    crate::trace::set_trace_reads_module_global(true);
+                    ctx.trace_ctx.reads_module_global = true;
                 }
             } else {
-                crate::trace::set_trace_reads_module_global(true);
+                ctx.trace_ctx.reads_module_global = true;
             }
         } else {
-            crate::trace::set_trace_reads_module_global(true);
+            ctx.trace_ctx.reads_module_global = true;
         }
     }
     if ctx.is_authoritative_executor
@@ -21129,14 +21139,18 @@ fn dispatch_residual_call_iIRd_kind(
                 ctx.trace_ctx.box_value(frame_opref),
                 ctx.trace_ctx.box_value(name_opref),
             ) {
-                if !mark_trace_reads_module_global_from_frame_name(frame_ptr, w_name_ptr) {
-                    crate::trace::set_trace_reads_module_global(true);
+                if !mark_trace_reads_module_global_from_frame_name(
+                    ctx.trace_ctx,
+                    frame_ptr,
+                    w_name_ptr,
+                ) {
+                    ctx.trace_ctx.reads_module_global = true;
                 }
             } else {
-                crate::trace::set_trace_reads_module_global(true);
+                ctx.trace_ctx.reads_module_global = true;
             }
         } else {
-            crate::trace::set_trace_reads_module_global(true);
+            ctx.trace_ctx.reads_module_global = true;
         }
     }
     if ctx.is_authoritative_executor
@@ -24193,8 +24207,7 @@ fn handle(
                                 // re-entered after later namespace growth. Fold in
                                 // the live per-trace flag so the bridge keeps the
                                 // conservative namespace gate.
-                                entry_meta.namespace_dependent |=
-                                    crate::trace::trace_reads_module_global();
+                                entry_meta.namespace_dependent |= ctx.trace_ctx.reads_module_global;
                                 driver.meta_interp_mut().compile_trace_from_interp(
                                     key,
                                     &live_args,

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -7891,7 +7891,14 @@ impl JitState for PyreJitState {
         PyreMeta {
             num_locals,
             ns_len: self.namespace_len(),
-            namespace_dependent: crate::trace::trace_reads_module_global(),
+            // Provisional seed only.  build_meta runs at trace START, before the
+            // walk records any LOAD_GLOBAL/LOAD_NAME, so the true value does not
+            // exist yet.  finish_trace_namespace_dependency overwrites this from
+            // TraceCtx.reads_module_global on every trace_bytecode return path,
+            // and the entry-bridge fold ORs the live flag mid-walk (`false` is
+            // the OR identity).  Both invariants must hold for this seed to stay
+            // safe to drop.
+            namespace_dependent: false,
             valuestackdepth: vsd,
             array_capacity: capacity,
             // virtualizable_gen.rs:24-31 wires `extra_reds = { ec: Ref }` per

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -51,10 +51,6 @@ thread_local! {
     /// `WALK_END_PROPAGATED_EXCEPTION`. Bridge tracing leaves this false and
     /// conservatively retains its legacy preflight.
     static WALK_END_PROPAGATE_ALLOWED: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
-    /// Set during one trace when a LOAD_GLOBAL / LOAD_NAME resolves through the
-    /// frame's module globals dict.  Such traces still depend on the globals
-    /// namespace length because same-key value rebinds are not guarded yet.
-    static TRACE_READS_MODULE_GLOBAL: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
 }
 
 /// Take-and-reset the walk-end flush flag for the trace that just
@@ -67,20 +63,22 @@ pub fn take_walk_end_propagated_exception() -> Option<pyre_interpreter::PyError>
     WALK_END_PROPAGATED_EXCEPTION.with(|c| c.borrow_mut().take())
 }
 
-pub(crate) fn set_trace_reads_module_global(value: bool) {
-    TRACE_READS_MODULE_GLOBAL.with(|c| c.set(value));
-}
-
-pub(crate) fn trace_reads_module_global() -> bool {
-    TRACE_READS_MODULE_GLOBAL.with(|c| c.get())
-}
-
+/// Copy the walk-accumulated `TraceCtx.reads_module_global` flag into the
+/// trace's `PyreMeta.namespace_dependent` at every `trace_bytecode` return
+/// path.  This is the sole authority for the finalized value; `build_meta`
+/// seeds it `false` at trace start (the walk hasn't run yet) and the
+/// entry-bridge fold ORs the live flag mid-walk, so `false` there is the OR
+/// identity.  On mid-walk-compile close paths the tracing ctx was already
+/// taken, so `trace_ctx()` is `None` and this no-ops exactly as before — the
+/// value was folded into the entry bridge's meta by then.
 fn finish_trace_namespace_dependency(meta: &mut MetaInterp<PyreMeta>) {
-    let namespace_dependent = trace_reads_module_global();
+    let namespace_dependent = meta
+        .trace_ctx()
+        .map(|ctx| ctx.reads_module_global)
+        .unwrap_or(false);
     if let Some(trace_meta) = meta.trace_meta_mut() {
         trace_meta.namespace_dependent = namespace_dependent;
     }
-    set_trace_reads_module_global(false);
 }
 
 thread_local! {
@@ -458,7 +456,8 @@ pub fn trace_bytecode(
     WALK_END_FLUSH_COMMITTED.with(|c| c.set(false));
     WALK_END_PROPAGATED_EXCEPTION.with(|c| *c.borrow_mut() = None);
     WALK_END_PROPAGATE_ALLOWED.with(|c| c.set(allow_propagate_out));
-    set_trace_reads_module_global(false);
+    // `TraceCtx.reads_module_global` needs no reset here: a fresh TraceCtx is
+    // built per trace (zero-init `false`), unlike the walk-end TLS flags above.
     // Likewise clear any no-replay finish payload a prior trace left
     // unconsumed.  The FBW walk re-clears this in `run_perfn_walk`; the
     // trait leg (`trace_step_result_to_action`) has no such epilogue, so

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -996,26 +996,6 @@ pub(crate) fn swap_stack_slots(
 }
 
 impl MIFrame {
-    fn mark_trace_reads_module_global_if_present(&self, name: &str) {
-        if self.concrete_frame_addr == 0 {
-            crate::trace::set_trace_reads_module_global(true);
-            return;
-        }
-        let frame =
-            unsafe { &*(self.concrete_frame_addr as *const pyre_interpreter::pyframe::PyFrame) };
-        let w_globals = frame.get_w_globals();
-        if w_globals.is_null() {
-            // Cannot probe a null globals dict for membership; classify
-            // conservatively as a module-global read, like the
-            // `concrete_frame_addr == 0` path above.
-            crate::trace::set_trace_reads_module_global(true);
-            return;
-        }
-        if crate::state::module_dict_cell_slot_direct(w_globals, name).is_some() {
-            crate::trace::set_trace_reads_module_global(true);
-        }
-    }
-
     #[allow(dead_code)]
     fn active_execution_context(&self) -> *const pyre_interpreter::PyExecutionContext {
         let exec_ctx = self.sym().concrete_execution_context;
@@ -7702,7 +7682,6 @@ impl MIFrame {
             use pyre_interpreter::OpcodeStepExecutor;
             let idx = namei.get(op_arg) as usize;
             let name = code.names[idx].as_ref();
-            self.mark_trace_reads_module_global_if_present(name);
             OpcodeStepExecutor::load_name(self, name, idx)?;
             return Ok(Some(pyre_interpreter::StepResult::Continue));
         }
@@ -7733,7 +7712,6 @@ impl MIFrame {
             let name_idx = raw >> 1;
             let push_null = (raw & 1) != 0;
             let name = code.names[name_idx].as_ref();
-            self.mark_trace_reads_module_global_if_present(name);
             OpcodeStepExecutor::load_global(self, name, name_idx, push_null)?;
             return Ok(Some(pyre_interpreter::StepResult::Continue));
         }


### PR DESCRIPTION
## Summary

The cranelift loop-block LABEL carries every back-edge-live value as a Cranelift
block param (an SSA loop phi). Loop-invariant args that are needed only to
reconstruct the Python frame on a guard deopt never have to occupy a register
across the loop; threading them as phis only wastes registers and forces the
allocator to spill the hot induction variables. The x86 backend's
`consider_label` already force-spills exactly this class into frame slots, which
is why its loop body is byte-identical regardless of dead-local count.

This change teaches the cranelift backend to demote such args out of the loop
phi into frame-resident slots.

## Mechanism

`compute_loop_phi_keep_last` classifies the last LABEL's args. An arg is demoted
when it is all of:

* **loop-invariant** — every back-edge JUMP re-passes the LABEL's own OpRef at
  that position, unchanged;
* **deopt-only** — never read by an in-loop computation op (guard failargs live
  in `getfailargs`, not `getarglist`);
* **not redefined** — no op after the LABEL writes that OpRef.

A demoted arg gets no Cranelift block param and is dropped from every back-edge
JUMP's arg list. Its value is seeded once into its slot on the preamble
fall-through, re-defined from the carried slot (`ITEM0 + i*8`) on loader
re-entry, and reloaded from the slot by `resolve_failarg_opref` during
guard-exit frame reconstruction (via the `DEMOTED_FAILARG_SLOTS` thread-local,
armed only once emission reaches the last LABEL's body). The loop body is then
byte-identical to the dynasm backend regardless of dead-local count.

## Correctness constraints

Each of these was a real crash / wrong output found in exception / nested / GC
re-entry paths that the synthetic parity suite alone did not catch:

1. **Arm the failarg hook only at the last-LABEL body**, not whole-compile — else
   a guard in an outer/preamble region of a nested trace reads an unseeded slot.
2. **The loader must `def_var` a demoted ref from `ITEM0 + i*8`** (the slot every
   re-entry contract populates) and re-sync it to the ref-root slot. Reading the
   ref-root slot directly is stale — an exception-resume bridge does not
   repopulate it.
3. **Never demote INPUTARGs** — "invariant per the inner back-edge" can still be
   mutated by an enclosing loop across a re-entry the inner back-edge never sees;
   inputargs also carry special entry-block establishment.
4. **Demote GC ref-roots only.** A demoted non-ref would home at `ITEM0 + i*8`,
   inside the dense deadframe scratch region `[0, max_output_slots)` that guard
   failargs and before-call spills (`CallMayForce` / `CallReleaseGil` /
   `GuardNotForced2`) overwrite densely by failarg index → persistent clobber →
   a later guard rebuilds a garbage frame. A ref's home is its ref-root slot
   (`ref_root_base_ofs + slot*8`), disjoint from the scratch region and
   GC-forwarded in place. The measured win is entirely ref dead locals (heap
   int/float/str are all boxed refs), so refs-only costs nothing.

## Performance

Dead-local loop microbenchmark (ns/iter, cranelift): 8 dead locals
**0.73 vs 3.3 (~4.5x)**, 12 dead locals ~3.3x, 0 dead locals unchanged.

## Verification

* Full 149-case synthetic parity suite: ALL PASSED.
* Targeted re-entry / GC battery (dead locals across an in-loop forcing call,
  break-bridge re-entry with nursery GC moves, deopt frame reconstruction, GC
  stress): ALL PASS.

Opt out with `PYRE_CL_NO_LOOP_PHI_ELIM=1`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved loop optimization and deoptimization correctness, preventing certain values from being incorrectly demoted.
  * Prevented stale or overwritten reference values during optimized execution.
  * Improved tracking of module-global dependencies for compiled traces, helping ensure optimized code remains valid when module state is accessed.
* **Performance**
  * Refined trace dependency handling to improve reliability and reduce unnecessary global state tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->