### PR TITLE
mapdict: route __class__ store through setattr, not the attr cache

### DIFF
--- a/pyre/bench/synth/class_reassign_hot.py
+++ b/pyre/bench/synth/class_reassign_hot.py
@@ -1,0 +1,31 @@
+# Reassigning obj.__class__ inside a hot loop must actually re-root the
+# instance's type, so method lookup and type() follow the new class.  The
+# STORE_ATTR mapdict inline cache (store_attr_slowpath) used to classify
+# `__class__` as an ordinary instance-dict attribute (its data-descriptor role
+# is modelled by object_setattr's special-case, not a getset, so it never
+# surfaces for classify_attr) and stored it into the instance dict, leaving the
+# real type unchanged: obj.kind() kept dispatching through the old class.  The
+# exact aggregate over the loop makes that silent miscompile observable.
+N = 200000
+
+
+class A:
+    def kind(self):
+        return 1
+
+
+class B:
+    def kind(self):
+        return 2
+
+
+def main():
+    total = 0
+    obj = A()
+    for _ in range(N):
+        total += obj.kind()
+        obj.__class__ = B if obj.__class__ is A else A
+    print(total)
+
+
+main()

--- a/pyre/pyre-interpreter/src/objspace/std/mapdict.rs
+++ b/pyre/pyre-interpreter/src/objspace/std/mapdict.rs
@@ -1289,6 +1289,18 @@ unsafe fn store_attr_slowpath(
     w_value: PyObjectRef,
     entry: Option<MapdictCacheEntry>,
 ) -> Result<(), PyError> {
+    // `object.__class__` is a getset data descriptor in PyPy, so `_classify_attr`
+    // (classify_attr) marks it INVALID and the store falls through to
+    // `space.setattr` (mapdict.py:1653) — the assignment re-roots the instance
+    // type via `descr_set___class__`, not the instance dict.  pyre models
+    // `__class__` through `object_setattr`'s special-case rather than a getset,
+    // so it never surfaces as a data descriptor for classify_attr to reject;
+    // exclude it from the store cache here so `obj.__class__ = NewCls` reaches
+    // that special-case instead of being mis-stored as an ordinary instance-dict
+    // attribute (which leaves the real type unchanged).
+    if name == "__class__" {
+        return crate::baseobjspace::setattr_str(w_obj, name, w_value).map(|_| ());
+    }
     // mapdict.py:1591 `if map is not None:`.
     if !map.is_null() {
         // mapdict.py:1592 `w_type = map.terminator.w_cls`.


### PR DESCRIPTION
`store_attr_slowpath` (the STORE_ATTR mapdict inline-cache path) classified
`__class__` as an ordinary instance-dict attribute and stored
`obj.__class__ = NewCls` into the instance dict, leaving `ob_type` unchanged —
so `type(obj)` and method lookup kept resolving through the old class (a silent
type-freeze, reproducible cold on all backends).

pyre models `object.__class__` through `object_setattr`'s special-case rather
than a getset data descriptor, so `classify_attr` never sees a descriptor to
mark INVALID; the mapdict cache path was the one store path missing the
special-case. This delegates `__class__` to `setattr_str` at the top of
`store_attr_slowpath`, so the assignment reaches `descr_set___class__` and
re-roots the instance type — mirroring PyPy where `object.__class__` is a getset
data descriptor that `_classify_attr` marks INVALID and the store falls through
to `space.setattr` (mapdict.py:1653).

Adds `pyre/bench/synth/class_reassign_hot.py`: a `__class__` reassignment inside
a hot loop whose exact aggregate makes the silent type-freeze observable.

This is the remaining patch on top of `main` after #443 merged.

Verified: `python pyre/check.py` — dynasm 161/161, cranelift 161/161, wasm 161/161
(3/3 backends).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a benchmark covering runtime class reassignment and method lookup behavior.

* **Bug Fixes**
  * Improved handling of `__class__` reassignment so objects correctly reflect their updated type and associated methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->