### PR TITLE
trace: box_value unknown as explicit Option; inputarg_type doc reword

### DIFF
--- a/majit/majit-metainterp/src/box_trace.rs
+++ b/majit/majit-metainterp/src/box_trace.rs
@@ -31,9 +31,8 @@ fn getfield_gc_i_pureornot(
         // covering const pool, standard-virtualizable shadow, and
         // the frontend object's `value` field (RPython
         // `currfieldbox.getint()` dispatch parity).
-        let cached_value = ctx.box_value(cached).unwrap_or(Value::Void);
-        let expected_int = match cached_value {
-            Value::Int(n) => Some(n),
+        let expected_int = match ctx.box_value(cached) {
+            Some(Value::Int(n)) => Some(n),
             _ => None,
         };
         if let Some(cached_int) = expected_int {
@@ -75,17 +74,16 @@ fn getfield_gc_i_pureornot(
         let struct_ptr = struct_ref.0 as i64;
         if struct_ptr != usize::MAX as i64 && struct_ptr != 0 {
             ctx.field_sanity_load(struct_ptr, &descr, majit_ir::Type::Int)
-                .unwrap_or(Value::Void)
         } else {
-            Value::Void
+            None
         }
     } else {
-        Value::Void
+        None
     };
     // RPython `Box(value)` constructor analog — stamp the recorded
     // OpRef so subsequent `box_value(result)` consumers see the
     // runtime concrete instead of the GcRef(usize::MAX) sentinel.
-    if !matches!(live_value, Value::Void) {
+    if let Some(live_value) = live_value {
         ctx.set_opref_concrete(result, live_value);
     }
     ctx.heapcache_getfield_now_known(obj, field_index, result);
@@ -305,9 +303,8 @@ fn getfield_gc_f_pureornot(
         // covering const pool, standard-virtualizable shadow, and
         // the frontend object's `value` field (RPython
         // `currfieldbox.getfloat_storage()` dispatch parity).
-        let cached_value = ctx.box_value(cached).unwrap_or(majit_ir::Value::Void);
-        let expected_float = match cached_value {
-            Value::Float(f) => Some(f),
+        let expected_float = match ctx.box_value(cached) {
+            Some(Value::Float(f)) => Some(f),
             _ => None,
         };
         if let Some(cached_float) = expected_float {
@@ -349,14 +346,13 @@ fn getfield_gc_f_pureornot(
         let struct_ptr = struct_ref.0 as i64;
         if struct_ptr != usize::MAX as i64 && struct_ptr != 0 {
             ctx.field_sanity_load(struct_ptr, &descr, majit_ir::Type::Float)
-                .unwrap_or(Value::Void)
         } else {
-            Value::Void
+            None
         }
     } else {
-        Value::Void
+        None
     };
-    if !matches!(live_value, Value::Void) {
+    if let Some(live_value) = live_value {
         ctx.set_opref_concrete(result, live_value);
     }
     ctx.heapcache_getfield_now_known(obj, field_index, result);

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -4026,7 +4026,7 @@ impl<S: JitState> JitDriver<S> {
         vable_opref: OpRef,
         vable_struct_ptr: i64,
         fielddescr: DescrRef,
-    ) -> (OpRef, Value) {
+    ) -> (OpRef, Option<Value>) {
         self.meta
             .opimpl_getfield_vable_int(pc, vable_opref, vable_struct_ptr, fielddescr)
     }
@@ -4037,7 +4037,7 @@ impl<S: JitState> JitDriver<S> {
         vable_opref: OpRef,
         vable_struct_ptr: i64,
         fielddescr: DescrRef,
-    ) -> (OpRef, Value) {
+    ) -> (OpRef, Option<Value>) {
         self.meta
             .opimpl_getfield_vable_ref(pc, vable_opref, vable_struct_ptr, fielddescr)
     }
@@ -4048,7 +4048,7 @@ impl<S: JitState> JitDriver<S> {
         vable_opref: OpRef,
         vable_struct_ptr: i64,
         fielddescr: DescrRef,
-    ) -> (OpRef, Value) {
+    ) -> (OpRef, Option<Value>) {
         self.meta
             .opimpl_getfield_vable_float(pc, vable_opref, vable_struct_ptr, fielddescr)
     }

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -6928,9 +6928,9 @@ impl OptContext {
     /// read on an existing producer is sufficient.  Until then this lookup
     /// is the read-only counterpart of `resoperation.py:719/727/739
     /// InputArg{Int,Ref,Float}.type` — it must not materialize a fresh
-    /// Box, because the materialization path keys the new Box's type
-    /// off the OpRef variant tag (mod.rs:3791) and a Phase 2 context
-    /// referencing a Phase 1 low slot can mismatch that tag against
+    /// operand, because the materialization path (`materialize_operand_at`)
+    /// keys the new operand's type off the OpRef variant tag and a Phase 2
+    /// context referencing a Phase 1 low slot can mismatch that tag against
     /// the canonical `inputarg_types[idx]`.
     pub fn inputarg_type(&self, opref: OpRef) -> Option<majit_ir::Type> {
         if opref.is_none() || opref.is_constant() {

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -4265,7 +4265,7 @@ impl<M: Clone> MetaInterp<M> {
         vable_opref: OpRef,
         vable_struct_ptr: i64,
         fielddescr: DescrRef,
-    ) -> (OpRef, Value) {
+    ) -> (OpRef, Option<Value>) {
         self.tracing
             .as_mut()
             .expect("opimpl_getfield_vable_int requires active tracing")
@@ -4279,7 +4279,7 @@ impl<M: Clone> MetaInterp<M> {
         vable_opref: OpRef,
         vable_struct_ptr: i64,
         fielddescr: DescrRef,
-    ) -> (OpRef, Value) {
+    ) -> (OpRef, Option<Value>) {
         self.tracing
             .as_mut()
             .expect("opimpl_getfield_vable_ref requires active tracing")
@@ -4293,7 +4293,7 @@ impl<M: Clone> MetaInterp<M> {
         vable_opref: OpRef,
         vable_struct_ptr: i64,
         fielddescr: DescrRef,
-    ) -> (OpRef, Value) {
+    ) -> (OpRef, Option<Value>) {
         self.tracing
             .as_mut()
             .expect("opimpl_getfield_vable_float requires active tracing")

--- a/majit/majit-metainterp/src/pyjitpl/dispatch.rs
+++ b/majit/majit-metainterp/src/pyjitpl/dispatch.rs
@@ -2611,7 +2611,7 @@ where
                 let vable_struct_ptr = self.read_ref_reg(vable_reg).1;
                 let (opref, value) =
                     ctx.vable_getfield_int(opcode_pc, vable_opref, vable_struct_ptr, fielddescr);
-                self.set_int_reg(dest, Some(opref), Some(value_as_int_bits(value)));
+                self.set_int_reg(dest, Some(opref), value.map(value_as_int_bits));
             }
             jitcode::insns::BC_GETFIELD_VABLE_R => {
                 let (opcode_pc, vable_reg, field_idx, dest) = {
@@ -2628,7 +2628,7 @@ where
                 let vable_struct_ptr = self.read_ref_reg(vable_reg).1;
                 let (opref, value) =
                     ctx.vable_getfield_ref(opcode_pc, vable_opref, vable_struct_ptr, fielddescr);
-                self.set_ref_reg(dest, Some(opref), Some(value_as_ref_bits(value)));
+                self.set_ref_reg(dest, Some(opref), value.map(value_as_ref_bits));
             }
             jitcode::insns::BC_GETFIELD_VABLE_F => {
                 let (opcode_pc, vable_reg, field_idx, dest) = {
@@ -2645,7 +2645,7 @@ where
                 let vable_struct_ptr = self.read_ref_reg(vable_reg).1;
                 let (opref, value) =
                     ctx.vable_getfield_float(opcode_pc, vable_opref, vable_struct_ptr, fielddescr);
-                self.set_float_reg(dest, Some(opref), Some(value_as_float_bits(value)));
+                self.set_float_reg(dest, Some(opref), value.map(value_as_float_bits));
             }
             jitcode::insns::BC_NEW | jitcode::insns::BC_NEW_WITH_VTABLE => {
                 // blackhole.py:1301-1310 bhimpl_new / bhimpl_new_with_vtable.
@@ -3004,9 +3004,8 @@ where
                         // `currfieldbox.getint()` dispatch parity).
                         // `None` payload (entry seeded without a live
                         // concrete) skips the check.
-                        let cached_value = ctx.box_value(cached).unwrap_or(majit_ir::Value::Void);
-                        let expected = match cached_value {
-                            majit_ir::Value::Int(n) => Some(n),
+                        let expected = match ctx.box_value(cached) {
+                            Some(majit_ir::Value::Int(n)) => Some(n),
                             _ => None,
                         };
                         // Cache hit propagates the stale `tobox.getint()`

--- a/majit/majit-metainterp/src/trace_ctx.rs
+++ b/majit/majit-metainterp/src/trace_ctx.rs
@@ -126,6 +126,17 @@ fn concrete_ptrs_eq(a: Option<&Value>, b: Option<&Value>) -> bool {
     }
 }
 
+/// Reinterpret a `virtualizable_values` shadow slot as an optional concrete.
+/// The shadow stores `Value::Void` in slots whose runtime concrete is not
+/// recorded; surface those as `None` so the vable-field read channel carries
+/// the "unknown" marker explicitly rather than a synthesized `Void`.
+fn concrete_shadow_value(value: Value) -> Option<Value> {
+    match value {
+        Value::Void => None,
+        v => Some(v),
+    }
+}
+
 /// pyjitpl.py:2989 box-with-type pair.
 ///
 /// RPython's `Box` carries type implicitly via Python class identity
@@ -2924,7 +2935,7 @@ impl TraceCtx {
         vable_opref: OpRef,
         vable_struct_ptr: i64,
         fielddescr: DescrRef,
-    ) -> (OpRef, Value) {
+    ) -> (OpRef, Option<Value>) {
         let concrete = self.concrete_of_opref(vable_opref);
         if self.is_nonstandard_virtualizable(pc, vable_opref, &fielddescr, concrete) {
             // self.opimpl_getfield_gc_i(box, fielddescr) →
@@ -2939,9 +2950,9 @@ impl TraceCtx {
                 // const pool, standard-virtualizable shadow, and
                 // the frontend object's `value` field (RPython
                 // `currfieldbox.getXXX()` dispatch parity).
-                let cached_value = self.box_value(cached).unwrap_or(Value::Void);
+                let cached_value = self.box_value(cached);
                 let expected_int = match cached_value {
-                    Value::Int(n) => Some(n),
+                    Some(Value::Int(n)) => Some(n),
                     _ => None,
                 };
                 if let Some(cached_int) = expected_int {
@@ -2980,12 +2991,11 @@ impl TraceCtx {
             } else {
                 None
             };
-            let live_value = live.unwrap_or(Value::Void);
-            if !matches!(live_value, Value::Void) {
+            if let Some(live_value) = live {
                 self.set_opref_concrete(op, live_value);
             }
             self.heapcache_getfield_now_known(vable_opref, field_index, op);
-            return (op, live_value);
+            return (op, live);
         }
         // self.metainterp.check_synchronized_virtualizable() — no-op in pyre.
         // index = self._get_virtualizable_field_index(fielddescr)
@@ -2995,13 +3005,13 @@ impl TraceCtx {
             .as_ref()
             .and_then(|info| info.static_field_by_descr(&fielddescr));
         if let Some(idx) = index {
-            if let Some(entry) = self.virtualizable_entry_at(idx) {
-                return entry;
+            if let Some((op, value)) = self.virtualizable_entry_at(idx) {
+                return (op, concrete_shadow_value(value));
             }
         }
         // Fallback for tests/missing layout
         let op = self.record_op_with_descr(OpCode::GetfieldGcI, &[vable_opref], fielddescr);
-        (op, Value::Void)
+        (op, None)
     }
 
     /// Record a virtualizable field read with an explicit field descriptor.
@@ -3224,7 +3234,7 @@ impl TraceCtx {
         vable_opref: OpRef,
         vable_struct_ptr: i64,
         fielddescr: DescrRef,
-    ) -> (OpRef, Value) {
+    ) -> (OpRef, Option<Value>) {
         let concrete = self.concrete_of_opref(vable_opref);
         if self.is_nonstandard_virtualizable(pc, vable_opref, &fielddescr, concrete) {
             // self.opimpl_getfield_gc_r(box, fielddescr) →
@@ -3238,9 +3248,9 @@ impl TraceCtx {
                 // `currfieldbox.getref_base()` payload through the
                 // full chain (const pool, standard-virtualizable
                 // shadow, the frontend object's `value` field).
-                let cached_value = self.box_value(cached).unwrap_or(Value::Void);
+                let cached_value = self.box_value(cached);
                 let expected_ref = match cached_value {
-                    Value::Ref(r) => Some(r),
+                    Some(Value::Ref(r)) => Some(r),
                     _ => None,
                 };
                 if let Some(cached_ref) = expected_ref {
@@ -3276,24 +3286,23 @@ impl TraceCtx {
             } else {
                 None
             };
-            let live_value = live.unwrap_or(Value::Void);
-            if !matches!(live_value, Value::Void) {
+            if let Some(live_value) = live {
                 self.set_opref_concrete(op, live_value);
             }
             self.heapcache_getfield_now_known(vable_opref, field_index, op);
-            return (op, live_value);
+            return (op, live);
         }
         let index = self
             .virtualizable_info
             .as_ref()
             .and_then(|info| info.static_field_by_descr(&fielddescr));
         if let Some(idx) = index {
-            if let Some(entry) = self.virtualizable_entry_at(idx) {
-                return entry;
+            if let Some((op, value)) = self.virtualizable_entry_at(idx) {
+                return (op, concrete_shadow_value(value));
             }
         }
         let op = self.record_op_with_descr(OpCode::GetfieldGcR, &[vable_opref], fielddescr);
-        (op, Value::Void)
+        (op, None)
     }
 
     /// Record a virtualizable ref field read with an explicit field descriptor.
@@ -3317,7 +3326,7 @@ impl TraceCtx {
         vable_opref: OpRef,
         vable_struct_ptr: i64,
         fielddescr: DescrRef,
-    ) -> (OpRef, Value) {
+    ) -> (OpRef, Option<Value>) {
         let concrete = self.concrete_of_opref(vable_opref);
         if self.is_nonstandard_virtualizable(pc, vable_opref, &fielddescr, concrete) {
             // self.opimpl_getfield_gc_f(box, fielddescr) →
@@ -3333,9 +3342,9 @@ impl TraceCtx {
                 // Value::Eq for Float uses to_bits — bit-identical.
                 // `box_value(cached)` resolves the upstream
                 // `currfieldbox.constbox()` payload.
-                let cached_value = self.box_value(cached).unwrap_or(Value::Void);
+                let cached_value = self.box_value(cached);
                 let expected_float = match cached_value {
-                    Value::Float(f) => Some(f),
+                    Some(Value::Float(f)) => Some(f),
                     _ => None,
                 };
                 if let Some(cached_float) = expected_float {
@@ -3370,24 +3379,23 @@ impl TraceCtx {
             } else {
                 None
             };
-            let live_value = live.unwrap_or(Value::Void);
-            if !matches!(live_value, Value::Void) {
+            if let Some(live_value) = live {
                 self.set_opref_concrete(op, live_value);
             }
             self.heapcache_getfield_now_known(vable_opref, field_index, op);
-            return (op, live_value);
+            return (op, live);
         }
         let index = self
             .virtualizable_info
             .as_ref()
             .and_then(|info| info.static_field_by_descr(&fielddescr));
         if let Some(idx) = index {
-            if let Some(entry) = self.virtualizable_entry_at(idx) {
-                return entry;
+            if let Some((op, value)) = self.virtualizable_entry_at(idx) {
+                return (op, concrete_shadow_value(value));
             }
         }
         let op = self.record_op_with_descr(OpCode::GetfieldGcF, &[vable_opref], fielddescr);
-        (op, Value::Void)
+        (op, None)
     }
 
     /// Standard virtualizable array item read (int).
@@ -3712,9 +3720,8 @@ impl TraceCtx {
                 // `currfieldbox.getref_base()` payload through the
                 // full chain (const pool, standard-virtualizable
                 // shadow, the frontend object's `value` field).
-                let cached_value = self.box_value(cached).unwrap_or(Value::Void);
-                let expected_ref = match cached_value {
-                    Value::Ref(r) => Some(r),
+                let expected_ref = match self.box_value(cached) {
+                    Some(Value::Ref(r)) => Some(r),
                     _ => None,
                 };
                 if let Some(cached_ref) = expected_ref {
@@ -3747,8 +3754,7 @@ impl TraceCtx {
                 } else {
                     None
                 };
-                let live_value = live.unwrap_or(Value::Void);
-                if !matches!(live_value, Value::Void) {
+                if let Some(live_value) = live {
                     self.set_opref_concrete(op, live_value);
                 }
                 self.heapcache_getfield_now_known(vable_opref, f_index, op);

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -3387,18 +3387,17 @@ fn getarrayitem_gc_via_heapcache(
             if array_ptr != usize::MAX as i64 && array_ptr != 0 {
                 ctx.trace_ctx
                     .array_sanity_load(array_ptr, index_value, &descr, ty)
-                    .unwrap_or(majit_ir::Value::Void)
             } else {
-                majit_ir::Value::Void
+                None
             }
         } else {
-            majit_ir::Value::Void
+            None
         };
         // Stamp the loaded value as Box.value of the recorded result
         // (RPython `Box(value)` constructor analog) so subsequent
         // consumers see the runtime concrete instead of the
         // GcRef(usize::MAX) sentinel.
-        if !matches!(live_value, majit_ir::Value::Void) {
+        if let Some(live_value) = live_value {
             ctx.trace_ctx.set_opref_concrete(resbox, live_value);
         }
         ctx.trace_ctx
@@ -3812,20 +3811,18 @@ fn getfield_gc_via_heapcache(
         {
             let struct_ptr = struct_ref.0 as i64;
             if struct_ptr != usize::MAX as i64 && struct_ptr != 0 {
-                ctx.trace_ctx
-                    .field_sanity_load(struct_ptr, &descr, ty)
-                    .unwrap_or(majit_ir::Value::Void)
+                ctx.trace_ctx.field_sanity_load(struct_ptr, &descr, ty)
             } else {
-                majit_ir::Value::Void
+                None
             }
         } else {
-            majit_ir::Value::Void
+            None
         };
         // Stamp the loaded value as the Box.value of the recorded
         // result so subsequent reads (cache hits + non-Const
         // `concrete_of_opref` consumers) see the real runtime
         // concrete instead of the GcRef(usize::MAX) sentinel.
-        if !matches!(live_value, majit_ir::Value::Void) {
+        if let Some(live_value) = live_value {
             ctx.trace_ctx.set_opref_concrete(resbox, live_value);
         }
         ctx.trace_ctx
@@ -4028,12 +4025,11 @@ fn getfield_vable_via_metainterp(
     // `opref_concrete` so `concrete_of_opref(result)` honors the same
     // contract for downstream consumers (`goto_if_not/iL`,
     // `switch/id`, `int_*` arithmetic).  The non-standard heapcache
-    // path inside `vable_getfield_int` already does the same stamp
-    // (trace_ctx.rs:2384); the standard path returns the cached
-    // `(opref, value)` pair without stamping.  `Value::Void` means no
-    // live concrete is available for this slot — skip to match the
-    // heapcache path's gating.
-    if !matches!(shadow_value, Value::Void) {
+    // path inside `vable_getfield_int` already does the same stamp;
+    // the standard path returns the cached `(opref, value)` pair
+    // without stamping.  `None` means no live concrete is available
+    // for this slot — skip to match the heapcache path's gating.
+    if let Some(shadow_value) = shadow_value {
         ctx.trace_ctx.set_opref_concrete(result, shadow_value);
     }
     let dst = code[op.pc + 4] as usize;
@@ -29316,9 +29312,6 @@ mod tests {
         let descr_pool: Vec<DescrRef> = vec![make_fail_descr(0), descr];
         let frame_done = done_descr_ref_for_tests();
         let cached = tc.const_ref(0xCAFE_F00D);
-        let cached_payload = tc
-            .constants_get_value(cached)
-            .unwrap_or(majit_ir::Value::Void);
         tc.heapcache_getarrayitem_now_known(array, index, 1, cached);
         let ops_before = tc.num_ops();
         let mut wc = WalkContext {

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -2777,9 +2777,8 @@ pub(crate) fn opimpl_getfield_gc_i(ctx: &mut TraceCtx, obj: OpRef, descr: DescrR
         // pool, standard-virtualizable shadow, and the frontend
         // object's `value` field (RPython `currfieldbox.getint()`
         // dispatch parity).
-        let cached_value = ctx.box_value(cached).unwrap_or(Value::Void);
-        let expected_int = match cached_value {
-            majit_ir::Value::Int(n) => Some(n),
+        let expected_int = match ctx.box_value(cached) {
+            Some(majit_ir::Value::Int(n)) => Some(n),
             _ => None,
         };
         if let Some(cached_int) = expected_int {
@@ -2859,14 +2858,13 @@ pub(crate) fn opimpl_getfield_gc_i(ctx: &mut TraceCtx, obj: OpRef, descr: DescrR
         let struct_ptr = struct_ref.0 as i64;
         if struct_ptr != usize::MAX as i64 && struct_ptr != 0 {
             ctx.field_sanity_load(struct_ptr, &descr, majit_ir::Type::Int)
-                .unwrap_or(majit_ir::Value::Void)
         } else {
-            majit_ir::Value::Void
+            None
         }
     } else {
-        majit_ir::Value::Void
+        None
     };
-    if !matches!(live_value, majit_ir::Value::Void) {
+    if let Some(live_value) = live_value {
         ctx.set_opref_concrete(result, live_value);
     }
     ctx.heapcache_getfield_now_known(obj, field_index, result);
@@ -2885,9 +2883,8 @@ pub(crate) fn opimpl_getfield_gc_r(ctx: &mut TraceCtx, obj: OpRef, descr: DescrR
         // `currfieldbox.getref_base()` payload through the full chain
         // (const pool, standard-virtualizable shadow, the frontend
         // object's `value` field).
-        let cached_value = ctx.box_value(cached).unwrap_or(Value::Void);
-        let expected_ref = match cached_value {
-            majit_ir::Value::Ref(r) => Some(r),
+        let expected_ref = match ctx.box_value(cached) {
+            Some(majit_ir::Value::Ref(r)) => Some(r),
             _ => None,
         };
         if let Some(cached_ref) = expected_ref {
@@ -2945,14 +2942,13 @@ pub(crate) fn opimpl_getfield_gc_r(ctx: &mut TraceCtx, obj: OpRef, descr: DescrR
         let struct_ptr = struct_ref.0 as i64;
         if struct_ptr != usize::MAX as i64 && struct_ptr != 0 {
             ctx.field_sanity_load(struct_ptr, &descr, majit_ir::Type::Ref)
-                .unwrap_or(majit_ir::Value::Void)
         } else {
-            majit_ir::Value::Void
+            None
         }
     } else {
-        majit_ir::Value::Void
+        None
     };
-    if !matches!(live_value, majit_ir::Value::Void) {
+    if let Some(live_value) = live_value {
         ctx.set_opref_concrete(result, live_value);
     }
     ctx.heapcache_getfield_now_known(obj, field_index, result);
@@ -3250,8 +3246,7 @@ pub(crate) fn trace_array_getitem_value(ctx: &mut TraceCtx, array: OpRef, index:
         return cached;
     }
     let result = ctx.record_op_with_descr(OpCode::GetarrayitemGcR, &[array, index], descr.clone());
-    let live_value = array_load_for_cache(ctx, array, index, &descr, majit_ir::Type::Ref);
-    if !matches!(live_value, majit_ir::Value::Void) {
+    if let Some(live_value) = array_load_for_cache(ctx, array, index, &descr, majit_ir::Type::Ref) {
         ctx.set_opref_concrete(result, live_value);
     }
     ctx.heapcache_getarrayitem_now_known(array, index, descr_idx, result);
@@ -3273,19 +3268,18 @@ fn array_load_for_cache(
     index: OpRef,
     descr: &DescrRef,
     kind: majit_ir::Type,
-) -> majit_ir::Value {
+) -> Option<majit_ir::Value> {
     let Some(majit_ir::Value::Ref(array_ref)) = ctx.box_value(array) else {
-        return majit_ir::Value::Void;
+        return None;
     };
     let array_ptr = array_ref.0 as i64;
     if array_ptr == usize::MAX as i64 || array_ptr == 0 {
-        return majit_ir::Value::Void;
+        return None;
     }
     let Some(majit_ir::Value::Int(index_value)) = ctx.box_value(index) else {
-        return majit_ir::Value::Void;
+        return None;
     };
     ctx.array_sanity_load(array_ptr, index_value, descr, kind)
-        .unwrap_or(majit_ir::Value::Void)
 }
 
 /// Read from frame's locals_cells_stack_w — namespace access path.
@@ -3300,8 +3294,7 @@ pub(crate) fn trace_raw_array_getitem_value(
         return cached;
     }
     let result = ctx.record_op_with_descr(OpCode::GetarrayitemGcR, &[array, index], descr.clone());
-    let live_value = array_load_for_cache(ctx, array, index, &descr, majit_ir::Type::Ref);
-    if !matches!(live_value, majit_ir::Value::Void) {
+    if let Some(live_value) = array_load_for_cache(ctx, array, index, &descr, majit_ir::Type::Ref) {
         ctx.set_opref_concrete(result, live_value);
     }
     ctx.heapcache_getarrayitem_now_known(array, index, descr_idx, result);
@@ -3332,8 +3325,7 @@ pub(crate) fn trace_items_block_getitem_value(
         return cached;
     }
     let result = ctx.record_op_with_descr(OpCode::GetarrayitemGcR, &[block, index], descr.clone());
-    let live_value = array_load_for_cache(ctx, block, index, &descr, majit_ir::Type::Ref);
-    if !matches!(live_value, majit_ir::Value::Void) {
+    if let Some(live_value) = array_load_for_cache(ctx, block, index, &descr, majit_ir::Type::Ref) {
         ctx.set_opref_concrete(result, live_value);
     }
     ctx.heapcache_getarrayitem_now_known(block, index, descr_idx, result);
@@ -3365,8 +3357,7 @@ pub(crate) fn trace_items_block_getitem_value_pure(
     let descr = pyobject_gcarray_descr();
     let result =
         ctx.record_op_with_descr(OpCode::GetarrayitemGcPureR, &[block, index], descr.clone());
-    let live_value = array_load_for_cache(ctx, block, index, &descr, majit_ir::Type::Ref);
-    if !matches!(live_value, majit_ir::Value::Void) {
+    if let Some(live_value) = array_load_for_cache(ctx, block, index, &descr, majit_ir::Type::Ref) {
         ctx.set_opref_concrete(result, live_value);
     }
     result
@@ -3422,8 +3413,7 @@ pub(crate) fn trace_int_block_getitem_value(
         return cached;
     }
     let result = ctx.record_op_with_descr(OpCode::GetarrayitemGcI, &[block, index], descr.clone());
-    let live_value = array_load_for_cache(ctx, block, index, &descr, majit_ir::Type::Int);
-    if !matches!(live_value, majit_ir::Value::Void) {
+    if let Some(live_value) = array_load_for_cache(ctx, block, index, &descr, majit_ir::Type::Int) {
         ctx.set_opref_concrete(result, live_value);
     }
     ctx.heapcache_getarrayitem_now_known(block, index, descr_idx, result);
@@ -3459,8 +3449,7 @@ pub(crate) fn trace_float_block_getitem_value(
         return cached;
     }
     let result = ctx.record_op_with_descr(OpCode::GetarrayitemGcF, &[block, index], descr.clone());
-    let live_value = array_load_for_cache(ctx, block, index, &descr, majit_ir::Type::Float);
-    if !matches!(live_value, majit_ir::Value::Void) {
+    if let Some(live_value) = array_load_for_cache(ctx, block, index, &descr, majit_ir::Type::Float) {
         ctx.set_opref_concrete(result, live_value);
     }
     ctx.heapcache_getarrayitem_now_known(block, index, descr_idx, result);

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -3449,7 +3449,8 @@ pub(crate) fn trace_float_block_getitem_value(
         return cached;
     }
     let result = ctx.record_op_with_descr(OpCode::GetarrayitemGcF, &[block, index], descr.clone());
-    if let Some(live_value) = array_load_for_cache(ctx, block, index, &descr, majit_ir::Type::Float) {
+    if let Some(live_value) = array_load_for_cache(ctx, block, index, &descr, majit_ir::Type::Float)
+    {
         ctx.set_opref_concrete(result, live_value);
     }
     ctx.heapcache_getarrayitem_now_known(block, index, descr_idx, result);

--- a/pyre/pyre-jit-trace/src/trace_helpers/typed_trace.rs
+++ b/pyre/pyre-jit-trace/src/trace_helpers/typed_trace.rs
@@ -329,14 +329,13 @@ pub fn generated_binary_float_value(
                     let struct_ptr = struct_ref.0 as i64;
                     if struct_ptr != usize::MAX as i64 && struct_ptr != 0 {
                         ctx.field_sanity_load(struct_ptr, &ff_descr, majit_ir::Type::Float)
-                            .unwrap_or(majit_ir::Value::Void)
                     } else {
-                        majit_ir::Value::Void
+                        None
                     }
                 } else {
-                    majit_ir::Value::Void
+                    None
                 };
-                if !matches!(live_value, majit_ir::Value::Void) {
+                if let Some(live_value) = live_value {
                     ctx.set_opref_concrete(r, live_value);
                 }
                 ctx.heapcache_getfield_now_known(obj, ff_idx, r);


### PR DESCRIPTION
Two box-adjacent slices (refs #181).

## trace: box_value unknown flows as Option, not Void

`box_value` / `field_sanity_load` / `array_sanity_load` consumers collapsed the `Option<Value>` with `.unwrap_or(Value::Void)`, and at the vable-field read sites the synthesized `Void` escaped through a `(OpRef, Value)` return channel as if it were the real field value.

- Local collapse sites now match on the `Option<Value>` directly (pure shape change; the sanity checks keep their skip-when-unknown behavior).
- `TraceCtx::vable_getfield_{int,ref,float}` + their `MetaInterp`/`JitDriver` opimpl wrappers return `(OpRef, Option<Value>)`; `virtualizable_values` shadow slots surface their in-band `Void` sentinel as `None` (`concrete_shadow_value`). `state.rs::array_load_for_cache` returns `Option<Value>`.
- Fixes a latent stamp: `BC_GETFIELD_VABLE_{I,R,F}` converted the leaked `Void` with `value_as_*_bits` (== 0) and stamped the destination register concrete as `Some(0)` when the vable field's runtime value was unknown; it now stamps `None`. The FBW mirror (`getfield_vable_via_metainterp`) derived its concrete independently and did not have the bug.

Left unchanged with justification: `virtualizable_values: Vec<Value>` keeps `Void` as its native in-band unknown sentinel (flipping that representation ripples into vable storage); two `jitcode_dispatch.rs` sites re-collapse into that representation without escaping.

Not in scope (issue #181 remainder): populating load-op values where knowable — the value-model endpoint stays option (i) (RPython-faithful payload threading); `Option::None` is the interim first-class "unknown".

## optimizeopt: reword stale Box terms in inputarg_type doc

Comment-only: the `inputarg_type` TODO still described materialization in the deleted `Box` vocabulary and cited an in-repo line number; reworded to the `materialize_operand_at`/operand reality. The TODO's convergence path (stamp the type onto the `InputArg` producer) is still real and kept.

## Verification

- `cargo test -p majit-metainterp --features dynasm --lib` — 1389 passed, 0 failed
- `cargo test -p majit-metainterp --features cranelift --lib` — 1387 passed, 0 failed
- `cargo test -p pyre-jit --lib --features dynasm` — 304 passed, 0 failed
- `python ./pyre/check.py` — dynasm 160/160, cranelift 160/160

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of unavailable or unknown values during virtualizable field reads.
  * Prevented invalid concrete values from being recorded during boxed value and array access checks.
  * Improved tracing reliability when cached values or object pointers are unavailable.

* **Documentation**
  * Clarified operand materialization behavior in optimizer documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->