### PR TITLE
interp: bytearray buffer-export lock on size mutation

### DIFF
--- a/pyre/extra_tests/snippets/builtin_memoryview.py
+++ b/pyre/extra_tests/snippets/builtin_memoryview.py
@@ -73,25 +73,35 @@ test_compare_buffer_exporters()
 
 
 def test_resizable():
-    # PyPy has no export lock: descr_releasebuffer is a no-op and bytearray
-    # mutators never check exports, so resizing a bytearray while a memoryview
-    # over it is alive succeeds (no BufferError).
+    # A live buffer export (memoryview) locks the bytearray against every
+    # size-changing mutation; in-place item writes stay legal.  Releasing the
+    # export lifts the lock.
     b = bytearray(b"123")
-    b.append(4)
+    b.append(4)  # no export yet: legal
     m = memoryview(b)
-    b.append(5)
+    assert_raises(BufferError, lambda: b.append(5))
+    assert_raises(BufferError, lambda: b.extend(b"xy"))
+    assert_raises(BufferError, lambda: b.insert(0, 1))
+    assert_raises(BufferError, lambda: b.pop())
+    assert_raises(BufferError, lambda: b.remove(ord("1")))
+    assert_raises(BufferError, lambda: b.clear())
+    assert_raises(BufferError, lambda: b.__iadd__(b"z"))
+    assert_raises(BufferError, lambda: b.__setitem__(slice(0, 1), b"ZZZ"))
+    assert_raises(BufferError, lambda: b.__delitem__(0))
+    assert_raises(BufferError, lambda: b.__delitem__(slice(0, 1)))
+    # In-place, size-preserving writes remain legal while exported.
+    b[0] = ord("9")
+    b[0:2] = b"88"
+    assert b[:2] == b"88"
     m.release()
+    # Export released: size-changing mutation succeeds again.
+    b.append(5)
+    assert len(b) == 5
+    # A context-managed view re-locks for its lifetime.
+    with memoryview(b):
+        assert_raises(BufferError, lambda: b.append(6))
     b.append(6)
-    m2 = memoryview(b)
-    m4 = memoryview(m2)
-    b.append(5)
-    m3 = memoryview(m2)
-    b.append(5)
-    m2.release()
-    b.append(5)
-    m3.release()
-    m4.release()
-    b.append(7)
+    assert len(b) == 6
 
 
 test_resizable()

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -2516,7 +2516,14 @@ unsafe fn setitem_bytearray_slice(
         w_slice_get_step(index),
     )?;
     let len = pyre_object::bytearrayobject::w_bytearray_len(obj) as i64;
-    let (start, stop, step, _) = crate::sliceobject::slice_adjust_indices(rs, rp, st, len);
+    let (start, stop, step, slicelength) =
+        crate::sliceobject::slice_adjust_indices(rs, rp, st, len);
+    // `descr_setitem`: only a length-changing assignment is a resize —
+    // `_check_exports` is skipped for an equal-length write, so `m[0:2] = b'ZZ'`
+    // remains legal while a buffer is exported but `m[0:1] = b'ZZZ'` is not.
+    if sequence2.len() as i64 != slicelength {
+        crate::builtins::bytearray_check_exports(obj)?;
+    }
     let vec = pyre_object::bytearrayobject::w_bytearray_vec_mut(obj);
     if step == 1 {
         let cur = vec.len();
@@ -11791,6 +11798,9 @@ pub(crate) fn delitem_slot(obj: PyObjectRef, index: PyObjectRef) -> Result<(), P
         // length is read, so a mutation during index evaluation is reflected in
         // the bounds.
         if pyre_object::bytearrayobject::is_bytearray(obj) {
+            // `descr_delitem` refuses any deletion (single or slice — every
+            // delete shrinks the buffer) while an export is outstanding.
+            crate::builtins::bytearray_check_exports(obj)?;
             if is_slice(index) {
                 let (rs, rp, st) = crate::sliceobject::slice_unpack(
                     w_slice_get_start(index),

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -1263,6 +1263,15 @@ fn memoryview_release(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyErro
     Ok(w_none())
 }
 
+/// `memoryview.__release_buffer__` — a no-op (`descr_release_buffer`): a
+/// consumer releasing a buffer it obtained from this memoryview has nothing
+/// to undo, because acquiring a buffer from a memoryview does not increment
+/// the underlying exporter's export count.  It must NOT release the view
+/// itself.
+fn memoryview_release_buffer(_args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    Ok(w_none())
+}
+
 /// `memoryview.__enter__` — check-released, then return the view itself.
 fn memoryview_enter(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     let mv = args.first().copied().unwrap_or(w_none());
@@ -1553,7 +1562,7 @@ pub(crate) fn init_memoryview_type(ns: &mut DictStorage) {
     // so they register as plain (non-arity-pinned) builtins.
     for (name, f) in [
         ("__exit__", memoryview_exit as MvFn),
-        ("__release_buffer__", memoryview_release),
+        ("__release_buffer__", memoryview_release_buffer),
         ("__delitem__", memoryview_delitem),
         ("hex", memoryview_hex),
         ("cast", memoryview_cast),

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -1247,17 +1247,21 @@ fn memoryview_release(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyErro
     let mv = args.first().copied().unwrap_or(w_none());
     unsafe {
         if !pyre_object::memoryview::w_memoryview_released(mv) {
-            // `_release_underlying`: an owning view drops the one buffer export
-            // it holds on its backing.  Read the backing before `set_released`
+            // `_release_underlying`: read the backing before `set_released`
             // drops the view box.  A slice / copy (`owns_export == false`)
-            // shares the export and must not decrement it.
+            // shares the export and must not release it.
             if pyre_object::memoryview::w_memoryview_owns_export(mv) {
                 let backing = pyre_object::memoryview::w_memoryview_backing(mv);
-                if backing_is_bytearray(backing) {
-                    pyre_object::bytearrayobject::w_bytearray_exports_decref(backing);
+                // Clear the view before invoking the exporter hook so a
+                // re-entrant release is a no-op.
+                pyre_object::memoryview::w_memoryview_set_released(mv);
+                if let Some(release_fn) = crate::baseobjspace::lookup(backing, "__release_buffer__")
+                {
+                    crate::call::call_function_impl_result(release_fn, &[backing, mv])?;
                 }
+            } else {
+                pyre_object::memoryview::w_memoryview_set_released(mv);
             }
-            pyre_object::memoryview::w_memoryview_set_released(mv);
         }
     }
     Ok(w_none())

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -39,6 +39,31 @@ unsafe fn memoryview_backing_buffer(backing: PyObjectRef) -> pyre_object::buffer
     }
 }
 
+/// True when `obj` is a `bytearray` (exact or subclass — a subclass shares the
+/// primitive layout).  The `_exports` lock only tracks bytearray sources: the
+/// sole resizable exporter carrying the lock (`array.array` has none).
+unsafe fn backing_is_bytearray(obj: PyObjectRef) -> bool {
+    unsafe {
+        pyre_object::bytearrayobject::is_bytearray(obj)
+            || crate::baseobjspace::isinstance_w(
+                obj,
+                crate::typedef::gettypeobject(&pyre_object::bytearrayobject::BYTEARRAY_TYPE),
+            )
+    }
+}
+
+/// `_check_exports` — reject a size-changing mutation of a bytearray while a
+/// buffer export (a live memoryview) is outstanding.
+pub(crate) unsafe fn bytearray_check_exports(obj: PyObjectRef) -> Result<(), crate::PyError> {
+    if unsafe { pyre_object::bytearrayobject::w_bytearray_exports(obj) } > 0 {
+        return Err(crate::PyError::new(
+            crate::PyErrorKind::BufferError,
+            "Existing exports of data: object cannot be re-sized",
+        ));
+    }
+    Ok(())
+}
+
 /// Wrap native per-dimension extents (a `shape` or `strides`) into a fresh
 /// `tuple[int]` for the `descr` getters.  Each int is pinned as built, so a
 /// later element's allocation cannot strand an earlier one before
@@ -74,7 +99,9 @@ unsafe fn w_memoryview_new_derived(
         let _roots = pyre_object::gc_roots::push_roots();
         let sp = pyre_object::gc_roots::shadow_stack_len();
         pyre_object::gc_roots::pin_root(mv_src);
-        let mv = pyre_object::memoryview::w_memoryview_alloc_header(false);
+        // A derived view (copy / slice / cast) shares — never owns — the
+        // backing's export.
+        let mv = pyre_object::memoryview::w_memoryview_alloc_header(false, false);
         let r_src = pyre_object::gc_roots::shadow_stack_get(sp);
         let view = derive(pyre_object::memoryview::w_memoryview_view(r_src));
         let view_ptr = pyre_object::memoryview::bufferview_alloc(view);
@@ -94,7 +121,7 @@ unsafe fn w_memoryview_cast_1d(mv_src: PyObjectRef, fmt: &str, itemsize: i64) ->
         let sp = pyre_object::gc_roots::shadow_stack_len();
         pyre_object::gc_roots::pin_root(mv_src);
         pyre_object::gc_roots::pin_root(w_str_new(fmt));
-        let mv = pyre_object::memoryview::w_memoryview_alloc_header(false);
+        let mv = pyre_object::memoryview::w_memoryview_alloc_header(false, false);
         let r_src = pyre_object::gc_roots::shadow_stack_get(sp);
         let r_fmt = pyre_object::gc_roots::shadow_stack_get(sp + 1);
         let src_view = pyre_object::memoryview::w_memoryview_view(r_src);
@@ -131,7 +158,7 @@ unsafe fn w_memoryview_cast_nd(
         pyre_object::gc_roots::pin_root(w_str_new(fmt));
         pyre_object::gc_roots::pin_root(memoryview_wrap_dims(shape));
         pyre_object::gc_roots::pin_root(memoryview_wrap_dims(strides));
-        let mv = pyre_object::memoryview::w_memoryview_alloc_header(false);
+        let mv = pyre_object::memoryview::w_memoryview_alloc_header(false, false);
         let r_src = pyre_object::gc_roots::shadow_stack_get(sp);
         let r_fmt = pyre_object::gc_roots::shadow_stack_get(sp + 1);
         let r_shape = pyre_object::gc_roots::shadow_stack_get(sp + 2);
@@ -181,8 +208,14 @@ unsafe fn w_memoryview_new_plain(
         if is_array {
             pyre_object::gc_roots::pin_root(w_str_new(fmt));
         }
-        let mv = pyre_object::memoryview::w_memoryview_alloc_header(false);
+        // Root view over an exporter: it owns the backing's buffer export.
+        let mv = pyre_object::memoryview::w_memoryview_alloc_header(false, true);
         let r_obj = pyre_object::gc_roots::shadow_stack_get(sp);
+        // `buffer_w`: record the export on a bytearray backing so a
+        // size-changing mutation is refused while this view is live.
+        if backing_is_bytearray(r_obj) {
+            pyre_object::bytearrayobject::w_bytearray_exports_incref(r_obj);
+        }
         let backing = memoryview_backing_buffer(r_obj);
         let view = if is_array {
             let r_fmt = pyre_object::gc_roots::shadow_stack_get(sp + 1);
@@ -1214,6 +1247,16 @@ fn memoryview_release(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyErro
     let mv = args.first().copied().unwrap_or(w_none());
     unsafe {
         if !pyre_object::memoryview::w_memoryview_released(mv) {
+            // `_release_underlying`: an owning view drops the one buffer export
+            // it holds on its backing.  Read the backing before `set_released`
+            // drops the view box.  A slice / copy (`owns_export == false`)
+            // shares the export and must not decrement it.
+            if pyre_object::memoryview::w_memoryview_owns_export(mv) {
+                let backing = pyre_object::memoryview::w_memoryview_backing(mv);
+                if backing_is_bytearray(backing) {
+                    pyre_object::bytearrayobject::w_bytearray_exports_decref(backing);
+                }
+            }
             pyre_object::memoryview::w_memoryview_set_released(mv);
         }
     }

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -12528,9 +12528,21 @@ fn bytearray_method_copy(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyE
     Ok(pyre_object::bytearrayobject::w_bytearray_from_bytes(data))
 }
 
+/// `bytearrayobject.py descr_releasebuffer` — the Python 3.12
+/// `__release_buffer__` protocol entry for a released bytearray export.
+fn bytearray_method_release_buffer(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    unsafe { pyre_object::bytearrayobject::w_bytearray_exports_decref(args[0]) };
+    Ok(pyre_object::w_none())
+}
+
 /// PyPy: bytearrayobject.py W_BytearrayObject.typedef
 fn init_bytearray_type(ns: &mut DictStorage) {
     dict_storage_store(ns, "__new__", make_new_descr(bytearray_descr_new));
+    dict_storage_store(
+        ns,
+        "__release_buffer__",
+        make_builtin_function_with_arity("__release_buffer__", bytearray_method_release_buffer, 2),
+    );
     // `bytearrayobject.py W_BytearrayObject.descr_decode` shares the
     // bytes decode machinery — `bytes_method_decode` already pulls the
     // payload via `bytes_like_data`, which handles both kinds.

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -12409,6 +12409,7 @@ fn bytearray_byte_arg(obj: PyObjectRef) -> Result<u8, crate::PyError> {
 /// `bytearrayobject.py:descr_append` — append one byte in place.
 fn bytearray_method_append(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     crate::type_methods::arity_at_least(args, "append", 1)?;
+    unsafe { crate::builtins::bytearray_check_exports(args[0])? };
     let b = bytearray_byte_arg(args[1])?;
     unsafe { pyre_object::bytearrayobject::w_bytearray_vec_mut(args[0]).push(b) };
     Ok(pyre_object::w_none())
@@ -12418,6 +12419,7 @@ fn bytearray_method_append(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::P
 /// bytes, or each integer yielded by an iterable.
 fn bytearray_method_extend(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     crate::type_methods::arity_at_least(args, "extend", 1)?;
+    unsafe { crate::builtins::bytearray_check_exports(args[0])? };
     let other = args[1];
     // Materialize the new bytes before mutating so `x.extend(x)` is safe.
     let appended: Vec<u8> = unsafe {
@@ -12440,6 +12442,7 @@ fn bytearray_method_extend(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::P
 /// clamping out-of-range indices (negative counts from the end).
 fn bytearray_method_insert(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     crate::type_methods::arity_at_least(args, "insert", 2)?;
+    unsafe { crate::builtins::bytearray_check_exports(args[0])? };
     let index = crate::builtins::space_index_w(args[1])?;
     let b = bytearray_byte_arg(args[2])?;
     unsafe {
@@ -12455,6 +12458,7 @@ fn bytearray_method_insert(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::P
 /// `value`; ValueError when absent.
 fn bytearray_method_remove(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     crate::type_methods::arity_at_least(args, "remove", 1)?;
+    unsafe { crate::builtins::bytearray_check_exports(args[0])? };
     let b = bytearray_byte_arg(args[1])?;
     unsafe {
         let vec = pyre_object::bytearrayobject::w_bytearray_vec_mut(args[0]);
@@ -12473,6 +12477,7 @@ fn bytearray_method_remove(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::P
 fn bytearray_method_pop(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     crate::type_methods::require_receiver(args, "pop")?;
     unsafe {
+        crate::builtins::bytearray_check_exports(args[0])?;
         let vec = pyre_object::bytearrayobject::w_bytearray_vec_mut(args[0]);
         let len = vec.len() as i64;
         if len == 0 {
@@ -12508,7 +12513,10 @@ fn bytearray_method_reverse(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::
 /// `bytearrayobject.py:descr_clear` — empty the bytearray in place.
 fn bytearray_method_clear(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     crate::type_methods::require_receiver(args, "clear")?;
-    unsafe { pyre_object::bytearrayobject::w_bytearray_vec_mut(args[0]).clear() };
+    unsafe {
+        crate::builtins::bytearray_check_exports(args[0])?;
+        pyre_object::bytearrayobject::w_bytearray_vec_mut(args[0]).clear();
+    };
     Ok(pyre_object::w_none())
 }
 
@@ -12640,6 +12648,7 @@ fn init_bytearray_type(ns: &mut DictStorage) {
                 let ba = args[0];
                 let other = args[1];
                 unsafe {
+                    crate::builtins::bytearray_check_exports(ba)?;
                     if let Some(src) = buffer_as_bytes_like(other)? {
                         let data = pyre_object::bytesobject::bytes_like_data(src).to_vec();
                         pyre_object::bytearrayobject::w_bytearray_extend(ba, &data);

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -12624,10 +12624,18 @@ fn init_bytearray_type(ns: &mut DictStorage) {
                 let b = args[1];
                 unsafe {
                     let a_data = pyre_object::bytesobject::bytes_like_data(a);
-                    let b_data = match buffer_as_bytes_like(b)? {
-                        Some(src) => pyre_object::bytesobject::bytes_like_data(src).to_vec(),
-                        None => vec![],
+                    // descr_add: a non-buffer operand raises rather than
+                    // concatenating as empty.
+                    let Some(src) = buffer_as_bytes_like(b)? else {
+                        return Err(crate::PyError::new(
+                            crate::PyErrorKind::TypeError,
+                            format!(
+                                "can't concat {} to bytearray",
+                                crate::type_methods::arg_type_name(b)
+                            ),
+                        ));
                     };
+                    let b_data = pyre_object::bytesobject::bytes_like_data(src).to_vec();
                     let mut result = a_data.to_vec();
                     result.extend_from_slice(&b_data);
                     Ok(pyre_object::bytearrayobject::w_bytearray_from_bytes(
@@ -12649,10 +12657,19 @@ fn init_bytearray_type(ns: &mut DictStorage) {
                 let other = args[1];
                 unsafe {
                     crate::builtins::bytearray_check_exports(ba)?;
-                    if let Some(src) = buffer_as_bytes_like(other)? {
-                        let data = pyre_object::bytesobject::bytes_like_data(src).to_vec();
-                        pyre_object::bytearrayobject::w_bytearray_extend(ba, &data);
-                    }
+                    // descr_inplace_add: a non-buffer operand raises rather
+                    // than silently leaving the bytearray unchanged.
+                    let Some(src) = buffer_as_bytes_like(other)? else {
+                        return Err(crate::PyError::new(
+                            crate::PyErrorKind::TypeError,
+                            format!(
+                                "can't concat {} to bytearray",
+                                crate::type_methods::arg_type_name(other)
+                            ),
+                        ));
+                    };
+                    let data = pyre_object::bytesobject::bytes_like_data(src).to_vec();
+                    pyre_object::bytearrayobject::w_bytearray_extend(ba, &data);
                 }
                 Ok(ba)
             },

--- a/pyre/pyre-object/src/bytearrayobject.rs
+++ b/pyre/pyre-object/src/bytearrayobject.rs
@@ -8,11 +8,14 @@ pub static BYTEARRAY_TYPE: PyType = crate::pyobject::new_pytype("bytearray");
 
 /// Python bytearray object.
 ///
-/// Layout: `[ob_type | data]`
+/// Layout: `[ob_type | data | exports]`
 #[repr(C)]
 pub struct W_BytearrayObject {
     pub ob_header: PyObject,
     pub data: *mut Vec<u8>,
+    /// `_exports` — count of active buffer exports.  Size-changing mutators
+    /// are refused while this is positive (`_check_exports`).
+    pub exports: i64,
 }
 
 /// GC type id assigned to `W_BytearrayObject` at JitDriver init time.
@@ -37,6 +40,7 @@ pub fn w_bytearray_new(size: usize) -> PyObjectRef {
             w_class: get_instantiate(&BYTEARRAY_TYPE),
         },
         data,
+        exports: 0,
     }) as PyObjectRef
 }
 
@@ -49,6 +53,7 @@ pub fn w_bytearray_from_bytes(bytes: &[u8]) -> PyObjectRef {
             w_class: get_instantiate(&BYTEARRAY_TYPE),
         },
         data,
+        exports: 0,
     }) as PyObjectRef
 }
 
@@ -123,6 +128,27 @@ pub unsafe fn w_bytearray_vec_mut(obj: PyObjectRef) -> &'static mut Vec<u8> {
     unsafe {
         let ba = &*(obj as *const W_BytearrayObject);
         &mut *ba.data
+    }
+}
+
+/// `_exports` — number of live buffer exports over this bytearray.
+pub unsafe fn w_bytearray_exports(obj: PyObjectRef) -> i64 {
+    unsafe { (*(obj as *const W_BytearrayObject)).exports }
+}
+
+/// `buffer_w` — record a new live buffer export.
+pub unsafe fn w_bytearray_exports_incref(obj: PyObjectRef) {
+    unsafe {
+        let ba = &mut *(obj as *mut W_BytearrayObject);
+        ba.exports += 1;
+    }
+}
+
+/// `bf_releasebuffer` — a consumer released its buffer export.
+pub unsafe fn w_bytearray_exports_decref(obj: PyObjectRef) {
+    unsafe {
+        let ba = &mut *(obj as *mut W_BytearrayObject);
+        ba.exports -= 1;
     }
 }
 

--- a/pyre/pyre-object/src/bytearrayobject.rs
+++ b/pyre/pyre-object/src/bytearrayobject.rs
@@ -144,10 +144,18 @@ pub unsafe fn w_bytearray_exports_incref(obj: PyObjectRef) {
     }
 }
 
-/// `bf_releasebuffer` — a consumer released its buffer export.
+/// `bf_releasebuffer` — a consumer released its buffer export.  A release
+/// without a matching acquisition is a fatal accounting bug
+/// (`_exports_underflow`).
 pub unsafe fn w_bytearray_exports_decref(obj: PyObjectRef) {
     unsafe {
         let ba = &mut *(obj as *mut W_BytearrayObject);
+        if ba.exports <= 0 {
+            panic!(
+                "bytearray bf_releasebuffer: _exports underflow: id={obj:?} exports={}",
+                ba.exports
+            );
+        }
         ba.exports -= 1;
     }
 }

--- a/pyre/pyre-object/src/memoryview.rs
+++ b/pyre/pyre-object/src/memoryview.rs
@@ -33,6 +33,11 @@ pub struct W_MemoryView {
     pub w_hash: i64,
     /// Flips on `release()` / context-manager exit.
     pub released: bool,
+    /// `owns_export` (`memoryobject.py`).  True for a view built directly over
+    /// an exporter (holds one `_exports` count on the backing); false for a
+    /// slice or a copy that shares the original's export.  Only an owning view
+    /// releases the underlying export.
+    pub owns_export: bool,
 }
 
 /// Allocate a [`BufferView`] off the GC heap (a stationary `Box`, like a
@@ -55,7 +60,7 @@ pub fn bufferview_alloc(view: BufferView) -> *const BufferView {
 /// from the shadow stack (post-relocation) and attaches the box with
 /// [`w_memoryview_set_view`].  Falls back to `malloc_typed` when no GC hook
 /// is installed (unit tests).
-pub fn w_memoryview_alloc_header(released: bool) -> PyObjectRef {
+pub fn w_memoryview_alloc_header(released: bool, owns_export: bool) -> PyObjectRef {
     let payload = W_MemoryView {
         ob: PyObject {
             ob_type: &MEMORYVIEW_TYPE as *const PyType,
@@ -64,6 +69,7 @@ pub fn w_memoryview_alloc_header(released: bool) -> PyObjectRef {
         view: std::ptr::null(),
         w_hash: -1,
         released,
+        owns_export,
     };
     let raw = crate::gc_hook::try_gc_alloc_stable_raw(
         <W_MemoryView as crate::lltype::GcType>::type_id(),
@@ -177,6 +183,16 @@ pub unsafe fn w_memoryview_set_hash(obj: PyObjectRef, hash: i64) {
     unsafe {
         (*(obj as *mut W_MemoryView)).w_hash = hash;
     }
+}
+
+/// `owns_export` — whether this view holds an `_exports` count on its backing
+/// (true for a root view over an exporter, false for a slice / copy).
+///
+/// # Safety
+/// `obj` must point to a valid `W_MemoryView`.
+#[inline]
+pub unsafe fn w_memoryview_owns_export(obj: PyObjectRef) -> bool {
+    unsafe { (*(obj as *const W_MemoryView)).owns_export }
 }
 
 /// Release the view: drop the off-heap `BufferView` box (reclaiming any


### PR DESCRIPTION
## Summary

Ports the bytearray buffer-export lock: size-changing bytearray mutations raise `BufferError: Existing exports of data: object cannot be re-sized` while a memoryview is exported. In-place item writes and equal-length slice-assign stay legal; releasing the export lifts the lock.

- `W_BytearrayObject.exports` counts live buffer exports (`_exports`, bytearrayobject.py); `W_MemoryView.owns_export` marks a root view built directly over an exporter (`owns_export`/`_release_underlying`, memoryobject.py).
- A root view over a bytearray increments the count; slices, copies and casts share the original's export (non-owning); only an owning view's release decrements.
- `_check_exports` guards append / extend / insert / remove / pop / clear / `__iadd__` / `__delitem__` and length-changing slice-assign.
- `builtin_memoryview.py` `test_resizable` rewritten to assert the lock (its old body asserted the pre-lock behavior; an earlier lock was removed in 866914e9523 when vendored PyPy had no `_exports` — vendored PyPy has since gained it via 938bc206612, so this converges to current upstream).

Kept PyPy-faithful where PyPy and CPython diverge: releasing the root view unlocks even while derived views are alive (CPython counts every view), and `remove` of an absent value while exported raises BufferError before ValueError. pyre has no memoryview finalizer, so a view collected without an explicit release keeps its export held.

## Verification

- check.py dynasm 161/161 + cranelift 161/161 (one `raise_catch` wall-clock perf flake cleared on re-run)
- `cargo test -p pyre-object` 206, `-p pyre-interpreter --features dynasm` 375, all green
- `builtin_memoryview.py` exit 0 on both interpreters; export-lock probe output identical to CPython on all PyPy/CPython-agreeing cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)