### PR TITLE
eval/importing parity: IMPORT_STAR sync, SETUP_ANNOTATIONS probe, IMPORT_NAME __import__

### DIFF
--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -2705,21 +2705,9 @@ impl OpcodeStepExecutor for PyFrame {
 
     fn import_name(&mut self, name: &str) -> Result<(), PyError> {
         let w_fromlist = self.pop();
-        let w_level = self.pop();
-        let level = if unsafe { pyre_object::is_int(w_level) } {
-            unsafe { pyre_object::w_int_get_value(w_level) }
-        } else {
-            0
-        };
-
-        let module = crate::importing::importhook(
-            name,
-            self.get_w_globals(), // for relative imports: __name__/__package__
-            w_fromlist,
-            level,
-            self.execution_context,
-        )?;
-        self.push(module);
+        let w_flag = self.pop();
+        let w_obj = crate::importing::import_name(self, name, w_fromlist, w_flag)?;
+        self.push(w_obj);
         Ok(())
     }
 

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -2382,11 +2382,12 @@ impl OpcodeStepExecutor for PyFrame {
     /// pyre-equivalent flow runs the bytecode opcode and writes into
     /// the class_locals namespace just like CPython).
     fn setup_annotations(&mut self) -> Result<(), PyError> {
-        // Route the `__annotations__` ensure through `space.contains` /
-        // `space.setitem` on the locals mapping object, mirroring STORE_NAME.
+        // `if not self.space.finditem_str(w_locals, '__annotations__')`:
+        // probe by item lookup, not membership — a custom mapping's
+        // `__contains__` can disagree with `__getitem__`/KeyError.
         let w_locals = self.get_or_create_w_locals();
-        let key = unsafe { pyre_object::w_str_new("__annotations__") };
-        if !crate::baseobjspace::contains(w_locals, key)? {
+        if crate::baseobjspace::finditem_str(w_locals, "__annotations__")?.is_none() {
+            let key = unsafe { pyre_object::w_str_new("__annotations__") };
             crate::baseobjspace::setitem(w_locals, key, pyre_object::w_dict_new())?;
         }
         Ok(())
@@ -3405,18 +3406,21 @@ impl OpcodeStepExecutor for PyFrame {
     }
 
     // ── import_star ──
-    // pypy/interpreter/pyopcode.py:1076 IMPORT_STAR — merge module's public names into
-    // the locals mapping (class body / exec-with-locals), not globals.
-    //
-    // Non-dict mapping locals route through `import_all_from_w` so each
-    // `from module import *` entry lands via `space.setitem(w_locals,
-    // name, value)` rather than the `*mut DictStorage` fast path,
-    // matching `pyopcode.py:1078 self.getdictscope()` returning a
-    // generic `w_obj`.
+    // IMPORT_STAR — merge the module's public names into the locals
+    // mapping (class body / exec-with-locals), not globals:
+    //     w_locals = self.getdictscope()
+    //     import_all_from(self.space, w_module, w_locals)
+    //     self.setdictscope(w_locals)
+    // `getdictscope` runs fast2locals so the mapping reflects the live
+    // fast locals; `import_all_from_w` lands each `from module import *`
+    // entry via `space.setitem(w_locals, name, value)` rather than the
+    // `*mut DictStorage` fast path; `setdictscope` runs locals2fast to
+    // write the merged mapping back into the frame's fast locals.
     fn import_star(&mut self) -> Result<(), PyError> {
         let module = self.pop();
-        let w_locals = self.get_or_create_w_locals();
+        let w_locals = self.getdictscope()?;
         crate::importing::import_all_from_w(module, w_locals)?;
+        self.setdictscope(w_locals)?;
         Ok(())
     }
 

--- a/pyre/pyre-interpreter/src/function.rs
+++ b/pyre/pyre-interpreter/src/function.rs
@@ -159,6 +159,9 @@ fn function_write_barrier(obj: PyObjectRef) {
     // A Box-immortal function's children are reached only through
     // `walk_raw_function_roots`, which clean minor collections skip;
     // record every field store (gc_roots.rs prebuilt-root tracking).
+    // RPython's GC transform inserts the old-to-young `write_barrier`
+    // (minimark.py:1065) after such post-alloc field stores; pyre has no
+    // transform pass, so callers run it by hand through this helper.
     pyre_object::gc_roots::mark_prebuilt_roots_dirty();
 }
 

--- a/pyre/pyre-interpreter/src/importing.rs
+++ b/pyre/pyre-interpreter/src/importing.rs
@@ -18,7 +18,7 @@ use std::path::PathBuf;
 #[cfg(feature = "host_env")]
 use std::path::Path;
 
-use crate::{CodeObject, Mode, compile_source_with_filename};
+use crate::{CodeObject, Mode, PyFrame, compile_source_with_filename};
 use crate::{DictStorage, PyExecutionContext, dict_storage_store};
 use pyre_object::*;
 
@@ -1757,11 +1757,44 @@ fn absolute_import(
     })
 }
 
+// ── IMPORT_NAME ──────────────────────────────────────────────────────
+
+/// PyPy equivalent: pyopcode.py `IMPORT_NAME`.
+pub fn import_name(
+    frame: &mut PyFrame,
+    name: &str,
+    w_fromlist: PyObjectRef,
+    w_flag: PyObjectRef,
+) -> Result<PyObjectRef, crate::PyError> {
+    let w_builtin = frame.w_builtin;
+    let w_import = if !w_builtin.is_null() && unsafe { is_module(w_builtin) } {
+        let w_dict = unsafe { pyre_object::w_module_get_w_dict(w_builtin) };
+        if w_dict.is_null() {
+            None
+        } else {
+            crate::baseobjspace::finditem_str(w_dict, "__import__")?
+        }
+    } else {
+        None
+    }
+    .ok_or_else(|| crate::PyError::new(crate::PyErrorKind::ImportError, "__import__ not found"))?;
+
+    let w_locals = match frame.getdebug() {
+        Some(d) if !d.w_locals.is_null() => d.w_locals,
+        _ => pyre_object::w_none(),
+    };
+    let w_globals = frame.get_w_globals();
+    let w_modulename = pyre_object::w_str_new(name);
+
+    crate::call::call_callable(
+        frame,
+        w_import,
+        &[w_modulename, w_globals, w_locals, w_fromlist, w_flag],
+    )
+}
+
 // ── importhook ───────────────────────────────────────────────────────
 // PyPy equivalent: importing.py `importhook()`
-//
-// Main entry point called by the IMPORT_NAME opcode.
-// Stack: [level, fromlist] → [module]
 
 pub fn importhook(
     name: &str,

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -4101,10 +4101,9 @@ pub extern "C" fn bh_delete_attr_fn(obj: i64, w_code_ptr: i64, name_idx: i64) ->
 
 /// IMPORT_NAME residual (`import_name` HLOp → `residual_call_ir_r`).
 /// Resolves the module name from the jitcode's own code object via
-/// `name_idx` (same `co_names` invariant as `bh_load_attr_fn`), reads the
-/// importing frame's `__name__`/`__package__` (for relative imports) from the
-/// threaded `frame_ptr`, and runs `importhook` with the TLS-pinned execution
-/// context the eval loop stamps on entry.  Importing a module may run its
+/// `name_idx` (same `co_names` invariant as `bh_load_attr_fn`), fetches
+/// `__import__` from the threaded frame's builtins, and calls it with the
+/// frame's globals and locals. Importing a module may run its
 /// top-level Python (`MayForce`); on error the exception is published
 /// through `BH_LAST_EXC_VALUE` for the trailing `GuardNoException` and the
 /// call returns 0.  `fromlist` and `level` are the two popped operands
@@ -4130,33 +4129,16 @@ pub extern "C" fn bh_import_name_fn(
         return 0;
     }
     let name = code.names[idx].as_ref();
-    // `import_name` reads the importing frame's globals for relative-import
-    // package resolution (`__name__` / `__package__`).  Read them from the
-    // live red frame passed as an explicit Ref argument — mirroring
-    // `bh_load_global_fn` — rather than `getexecutioncontext().gettopframe()`,
-    // which collapses to the wrong frame for an inlined non-portal callee.
-    // `w_globals` must be the wrapped dict object `resolve_package_name` does
-    // `finditem_str` against (not the raw DictStorage), so resolve it through
-    // `get_w_globals`.
     let frame = frame_ptr as *mut PyFrame;
-    let w_globals = if frame.is_null() {
-        pyre_object::PY_NULL
-    } else {
-        unsafe { (*frame).get_w_globals() }
-    };
-    let ec = pyre_interpreter::call::getexecutioncontext();
-    let w_level = level as pyre_object::PyObjectRef;
-    let level = if unsafe { pyre_object::is_int(w_level) } {
-        unsafe { pyre_object::w_int_get_value(w_level) }
-    } else {
-        0
-    };
-    match pyre_interpreter::importing::importhook(
+    debug_assert!(!frame.is_null(), "IMPORT_NAME requires a live frame");
+    if frame.is_null() {
+        return 0;
+    }
+    match pyre_interpreter::importing::import_name(
+        unsafe { &mut *frame },
         name,
-        w_globals,
         fromlist as pyre_object::PyObjectRef,
-        level,
-        ec,
+        level as pyre_object::PyObjectRef,
     ) {
         Ok(module) => module as i64,
         Err(err) => {

--- a/pyre/pyre-object/src/listobject.rs
+++ b/pyre/pyre-object/src/listobject.rs
@@ -446,7 +446,10 @@ pub fn list_strategy_for(items: &[PyObjectRef]) -> ListStrategy {
 }
 
 /// Fire the GC write barrier for an Object-strategy list whose `items`
-/// block just gained a possibly-young element. `list_object_custom_trace`
+/// block just gained a possibly-young element. RPython's GC transform
+/// emits `ll_writebarrier` (rgc.py:1196) automatically after a pointer
+/// store into a structure behind a custom tracer; pyre has no transform
+/// pass, so the barrier runs here by hand. `list_object_custom_trace`
 /// only forwards the off-GC `ItemsBlock` slots when the list is reached by
 /// a collection; an old-gen list that stored a young element is reached on
 /// a minor GC only if it sits in the remembered set, so the barrier must


### PR DESCRIPTION
Two follow-up slices from the same sub-agent batch as #465.

## eval: IMPORT_STAR dictscope sync, annotations item probe

Ports two `pyopcode.py` shapes in `pyre-interpreter/src/eval.rs`:

- **IMPORT_STAR** fetched the locals mapping via `get_or_create_w_locals`, skipping both the `fast2locals` pre-sync and the `locals2fast` writeback. Now follows pyopcode.py `IMPORT_STAR`: `getdictscope()` → `import_all_from_w` → `setdictscope(w_locals)`, so the mapping reflects live fast locals before the merge and the merged names are written back into the frame's fast locals.
- **SETUP_ANNOTATIONS** probed for `__annotations__` with a membership check (`contains`); pyopcode.py uses `finditem_str` item lookup, which a custom mapping's `__contains__` can disagree with. The store keeps `setitem` with a `w_str_new` key since pyre has no `setitem_str`.

Parity spot checks (pyre vs CPython, identical output/exit): `from module import *` with local writeback, and class-level annotations including re-annotation.

## gc: cite upstream write-barrier decision points

Comment-only: the hand-run write barriers (`function_write_barrier`, Object-strategy list barrier) now cite the GC-transform insertions they stand in for (`minimark.py` `write_barrier`, `rgc.py` `ll_writebarrier`); pyre has no transform pass, so callers run them by hand.

## Verification

- `cargo test -p pyre-interpreter --features dynasm --lib` — 375 passed, 0 failed
- `python ./pyre/check.py --backend cranelift` — 161/161 ALL PASSED
- `python ./pyre/check.py --backend dynasm` — 160/161: the one failure is the `nested_loop` perf-ratio gate (0.47s vs pypy 0.22s, stable across direct reruns), **pre-existing on the current main base**: `nested_loop.py` contains no `import *` / annotations, so this diff's opcode bodies never execute there. It first appears with the base advance that brought in #424 (dynasm regalloc walker-slot coalesce filter retirement); cranelift is unaffected. Worth a separate look.

## importing: IMPORT_NAME calls builtins __import__

Found while verifying the above: `IMPORT_NAME` ignored a monkeypatched `builtins.__import__` and always performed a real import (`extra_tests/snippets/import.py` failed its `__import__`-override assertions). Ported the pyopcode.py `IMPORT_NAME` shape into `importing::import_name` — fetch `__import__` from the frame's builtins (`ImportError "__import__ not found"` when missing), `w_locals` from the frame debug slot or `None`, call it with `(w_modulename, w_globals, w_locals, w_fromlist, w_flag)`. Both the eval-loop opcode and the JIT residual `bh_import_name_fn` route through the helper. With this commit the full gate is green on both backends: dynasm 161/161, cranelift 161/161 (including `nested_loop`, confirming the earlier perf-gate failure was borderline load sensitivity).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of module imports, including import levels, from-lists, and custom import hooks.
  * Fixed wildcard imports so imported names are correctly reflected in the current local scope.
  * Improved creation of `__annotations__` for custom local mappings, ensuring consistent lookup behavior.
* **Documentation**
  * Clarified internal memory-management behavior for improved maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->