### PR TITLE
jit: branch-arm hazard scoping to invalid mirror + inlined-callee abort_permanent decline (gh#467)

### DIFF
--- a/majit/majit-backend-dynasm/src/aarch64/assembler.rs
+++ b/majit/majit-backend-dynasm/src/aarch64/assembler.rs
@@ -5300,17 +5300,42 @@ impl<'a> AssemblerARM64<'a> {
             _ => false,
         };
 
-        // aarch64/callbuilder.py:29-41 — build arg plan.
-        // ABI regs x0..x7 for core, d0..d7 for float.
+        // aarch64/callbuilder.py:29-41 — build arg plan.  Core and float
+        // arguments have independent x0..x7 / d0..d7 banks; overflow from
+        // either bank is written to the outgoing stack area in source order.
         let mut non_float_src: Vec<Loc> = Vec::new();
         let mut non_float_dst: Vec<Loc> = Vec::new();
         let mut float_src: Vec<Loc> = Vec::new();
         let mut float_dst: Vec<Loc> = Vec::new();
         let mut immed_args: Vec<(u8, i64, bool)> = Vec::new(); // (abi_idx, value, is_float)
+        let mut stack_args: Vec<Loc> = Vec::new();
+        let mut next_core = 0u8;
+        let mut next_float = 0u8;
 
-        for i in (func_index + 1)..arg_count.min(func_index + 9) {
-            let abi_idx = (i - func_index - 1) as u8;
-            let arg = arglocs[i];
+        for &arg in &arglocs[(func_index + 1)..arg_count] {
+            let is_float = match arg {
+                Loc::Frame(f) => f.ebp_loc.is_float,
+                Loc::Reg(r) => r.is_xmm,
+                Loc::Immed(im) => im.is_float,
+                _ => false,
+            };
+            let abi_idx = if is_float {
+                if next_float == 8 {
+                    stack_args.push(arg);
+                    continue;
+                }
+                let idx = next_float;
+                next_float += 1;
+                idx
+            } else {
+                if next_core == 8 {
+                    stack_args.push(arg);
+                    continue;
+                }
+                let idx = next_core;
+                next_core += 1;
+                idx
+            };
             match arg {
                 Loc::Frame(f) if f.ebp_loc.is_float => {
                     float_src.push(arg);
@@ -5332,6 +5357,38 @@ impl<'a> AssemblerARM64<'a> {
                     immed_args.push((abi_idx, im.value, im.is_float));
                 }
                 _ => {}
+            }
+        }
+
+        // aarch64/callbuilder.py:42-50: reserve a 16-byte-aligned outgoing
+        // stack area and copy every register-bank overflow argument before
+        // remapping the register arguments (whose moves may clobber sources).
+        let stack_bytes = (stack_args.len() * WORD + 15) & !15;
+        if stack_bytes != 0 {
+            dynasm!(self.mc ; .arch aarch64 ; sub sp, sp, stack_bytes as u32);
+            for (slot, arg) in stack_args.into_iter().enumerate() {
+                let offset = (slot * WORD) as u32;
+                match arg {
+                    Loc::Reg(r) if r.is_xmm => {
+                        dynasm!(self.mc ; .arch aarch64 ; str D(r.value), [sp, offset]);
+                    }
+                    Loc::Reg(r) => {
+                        dynasm!(self.mc ; .arch aarch64 ; str X(r.value), [sp, offset]);
+                    }
+                    Loc::Frame(f) if f.ebp_loc.is_float => {
+                        self.emit_ldr_fp_d(15, f.ebp_loc.value);
+                        dynasm!(self.mc ; .arch aarch64 ; str d15, [sp, offset]);
+                    }
+                    Loc::Frame(f) => {
+                        self.emit_ldr_fp(16, f.ebp_loc.value);
+                        dynasm!(self.mc ; .arch aarch64 ; str x16, [sp, offset]);
+                    }
+                    Loc::Immed(im) => {
+                        self.emit_mov_imm64(16, im.value);
+                        dynasm!(self.mc ; .arch aarch64 ; str x16, [sp, offset]);
+                    }
+                    other => panic!("unsupported AArch64 stack call argument {other:?}"),
+                }
             }
         }
 
@@ -5365,6 +5422,9 @@ impl<'a> AssemblerARM64<'a> {
             }
         }
 
+        if stack_bytes != 0 {
+            dynasm!(self.mc ; .arch aarch64 ; add sp, sp, stack_bytes as u32);
+        }
         dynasm!(self.mc ; .arch aarch64 ; ldp x29, x30, [sp], #16);
     }
 

--- a/pyre/pyre-interpreter/src/pyframe.rs
+++ b/pyre/pyre-interpreter/src/pyframe.rs
@@ -388,7 +388,7 @@ impl FrameBox {
         // its own stack — so root that slot across the allocation. The frame
         // block is non-moving (old-gen when GC-managed, `std::alloc`
         // otherwise), so only the locals array needs protecting.
-        let _root = LocalsRoot::new(frame_ptr);
+        let _root = FrameLocalsRoot::new(frame_ptr);
         let generator = pyre_object::generator::w_generator_new(frame_ptr as *mut u8);
         unsafe {
             (*frame_ptr).f_generator_nowref = generator;
@@ -437,13 +437,13 @@ impl Drop for FrameBox {
 /// root the eval path holds in `call.rs`: during setup the freshly-installed
 /// locals/cells live only in that array, so an intervening collection would
 /// drop or mis-forward them unless the slot is rooted.
-struct LocalsRoot {
+pub struct FrameLocalsRoot {
     slot: *mut *mut u8,
     registered: bool,
 }
 
-impl LocalsRoot {
-    fn new(frame_ptr: *mut PyFrame) -> Self {
+impl FrameLocalsRoot {
+    pub fn new(frame_ptr: *mut PyFrame) -> Self {
         let slot =
             unsafe { std::ptr::addr_of_mut!((*frame_ptr).locals_cells_stack_w) as *mut *mut u8 };
         let registered = unsafe { pyre_object::gc_hook::try_gc_add_root(slot) };
@@ -451,7 +451,7 @@ impl LocalsRoot {
     }
 }
 
-impl Drop for LocalsRoot {
+impl Drop for FrameLocalsRoot {
     fn drop(&mut self) {
         if self.registered {
             pyre_object::gc_hook::try_gc_remove_root(self.slot);
@@ -3444,7 +3444,7 @@ pub fn createframe_obj(
     // cells) and stores the cells into `locals_cells_stack_w`; root the slot so
     // a collection mid-init can't drop the cells already written there.
     {
-        let _root = LocalsRoot::new(frame.as_mut_ptr());
+        let _root = FrameLocalsRoot::new(frame.as_mut_ptr());
         frame.initialize_frame_scopes(outer_ref, code)?;
     }
 

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -20515,18 +20515,32 @@ fn handle(
                     // Hazard (1): the not-taken arm reads a regular Ref register
                     // the blackhole resumes as NULL (the conditional-expression
                     // boxed-int NULL-deref crash).
-                    let reads_null_ref = match &liveness {
-                        Some((live_ref, num_regs_r)) => branch_arm_reads_unrestorable_ref(
-                            code,
-                            other_target,
-                            live_ref,
-                            *num_regs_r,
-                        ),
-                        // Liveness unavailable (the trait leg, where
-                        // `FULL_BODY_SNAPSHOT_SYM` is null, or an unresolved
-                        // coordinate) — cannot prove restorable, so decline.
-                        None => true,
-                    };
+                    //
+                    // Scoped to the undermodeled invalid-mirror walk
+                    // (`!ctx.vstack_valid`), exactly like Hazards (2)/(3) below.
+                    // A VALID walk mirror sources every on-stack kept slot from
+                    // `ctx.vstack_boxes` and every kept local from the vable
+                    // shadow (`collect_outer_active_boxes`), so on resume the
+                    // not-taken arm's Ref reads are reconstructed per-slot even
+                    // when the guard's snapshot liveness (`live_ref`) does not
+                    // name that register color — the same per-slot recovery that
+                    // makes the short-circuit / conditional-expression kept-stack
+                    // reads (#416/#420) restorable for Hazards (2)/(3).  The
+                    // register-file scan only proves a hazard for the INVALID
+                    // mirror, where those per-slot sources are unavailable.
+                    let reads_null_ref = !ctx.vstack_valid
+                        && match &liveness {
+                            Some((live_ref, num_regs_r)) => branch_arm_reads_unrestorable_ref(
+                                code,
+                                other_target,
+                                live_ref,
+                                *num_regs_r,
+                            ),
+                            // Liveness unavailable (the trait leg, where
+                            // `FULL_BODY_SNAPSHOT_SYM` is null, or an unresolved
+                            // coordinate) — cannot prove restorable, so decline.
+                            None => true,
+                        };
                     // Hazard (2): the not-taken edge carries `ref_copy` renames
                     // (`kept_recovered` non-empty) — the #416/#420 short-circuit
                     // / chained-comparison kept-stack recovery.  Historically the

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -8465,7 +8465,7 @@ enum VstackOpClass {
     /// new TOS with `vstack_last_ref`.  Covers value producers whose
     /// result is the topmost stack slot: LOAD_FAST / LOAD_CONST /
     /// LOAD_GLOBAL(result) / LOAD_NAME / LOAD_ATTR / BINARY_OP /
-    /// BINARY_SUBSCR / COMPARE_OP / unary ops / TO_BOOL / CALL /
+    /// BINARY_SUBSCR / COMPARE_OP / unary ops / CALL /
     /// IS_OP / CONTAINS_OP / single-result BUILD_*.
     ResultToTos,
     /// The opcode only pops (and/or stores to a local/global/attr/subscr,
@@ -8699,8 +8699,10 @@ fn classify_vstack_opcode(
         // effect there.
         Instruction::ForIter { .. } => VstackOpClass::ResultToTos,
 
-        // Everything else (TO_BOOL if present as a distinct variant, …) is
-        // not modeled — decline and fall back to the legacy read.
+        // Everything else is not modeled — decline and fall back to the
+        // legacy read.  TO_BOOL emits no JitCode (codewriter.rs:8598
+        // `Instruction::ToBool => {}`) so it never reaches this classifier;
+        // the py-pc boundary mapping skips it.
         _ => VstackOpClass::Unmodeled,
     }
 }

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -11471,7 +11471,7 @@ fn walker_capture_snapshot_for_last_guard_impl(
 /// Build the paused caller frame for a multi-frame inline snapshot (#68),
 /// computed at the inline CALL site where the caller's live register banks
 /// (`ctx.registers_*`) are still in scope.  `call_jit_pc` is the CALL op's
-/// jitcode pc in the caller.  Returns `None` (→ caller declines the inline)
+/// jitcode pc in the caller.  Returns a named decline reason
 /// when the caller frame is not snapshot-able for this first slice: missing
 /// liveness / resume tables, a CALL inside a try-block (catch marker resume pc
 /// is not
@@ -11483,10 +11483,26 @@ fn walker_capture_snapshot_for_last_guard_impl(
 /// in_a_call=true)` parity (`trace_opcode.rs:1779`).  Reuses
 /// [`collect_outer_active_boxes`] (the caller owns the portal virtualizable)
 /// after temporarily nulling the result slot's register.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum InlineCallerFrameDecline {
+    TryBlockCatchMarker,
+    Unavailable,
+}
+
+fn decline_inline_caller_frame_for_catch_marker(
+    after_residual_call_resume_pc: Option<usize>,
+) -> Result<(), InlineCallerFrameDecline> {
+    if after_residual_call_resume_pc.is_some() {
+        Err(InlineCallerFrameDecline::TryBlockCatchMarker)
+    } else {
+        Ok(())
+    }
+}
+
 fn compute_inline_caller_frame(
     ctx: &mut WalkContext<'_, '_>,
     call_jit_pc: usize,
-) -> Option<InlineParentFrame> {
+) -> Result<InlineParentFrame, InlineCallerFrameDecline> {
     // #68 nested multiframe: when an inlined callee is already active
     // (`FBW_INLINE_CODE_STACK.last()` is Some), the immediate caller of THIS
     // call is that intermediate callee (a sym-less sub-jitcode), not the
@@ -11501,30 +11517,26 @@ fn compute_inline_caller_frame(
     }
     let caller_sym_ptr = FULL_BODY_SNAPSHOT_SYM.with(|c| c.get());
     if caller_sym_ptr.is_null() {
-        return None;
+        return Err(InlineCallerFrameDecline::Unavailable);
     }
     // SAFETY: set for the lifetime of the top-level `dispatch_via_miframe`;
     // read-only access to immutable layout fields.
     let caller_sym = unsafe { &*caller_sym_ptr };
     if caller_sym.jitcode.is_null() {
-        return None;
+        return Err(InlineCallerFrameDecline::Unavailable);
     }
     let (jitcode_index, fallthrough_py_pc, code_ptr) = unsafe {
         let jc = &*caller_sym.jitcode;
         if jc.payload.code_ptr.is_null() || !jc.payload.is_populated() {
-            return None;
+            return Err(InlineCallerFrameDecline::Unavailable);
         }
         let call_py = python_pc_for_jitcode_pc(&jc.payload.metadata, call_jit_pc) as usize;
         // A CALL inside a try-block resumes at its own catch via a bit-14
         // marker pc, which the multi-frame capture's `py_pc < FLAG` assert
         // rejects — decline this slice.
-        if jc
-            .payload
-            .after_residual_call_resume_pc_for(call_py)
-            .is_some()
-        {
-            return None;
-        }
+        decline_inline_caller_frame_for_catch_marker(
+            jc.payload.after_residual_call_resume_pc_for(call_py),
+        )?;
         let code = &*jc.payload.code_ptr;
         let fallthrough = crate::pyjitpl::semantic_fallthrough_pc(code, call_py) as u32;
         (jc.index as u32, fallthrough, jc.payload.code_ptr)
@@ -11538,14 +11550,15 @@ fn compute_inline_caller_frame(
             .unwrap_or(0) as usize
     };
     if depth == 0 {
-        return None;
+        return Err(InlineCallerFrameDecline::Unavailable);
     }
     // #73: the result slot's color comes from the codewriter-precomputed
     // `result_color_at_pc` (top-of-stack color at the return pc), not the flat
     // `stack_slot_color_map` — the result is not a live Variable here, so it
     // carries no pcdep entry.
     let result_color =
-        crate::state::result_color_at_pc_at(jitcode_index as i32, fallthrough_py_pc as usize)?;
+        crate::state::result_color_at_pc_at(jitcode_index as i32, fallthrough_py_pc as usize)
+            .ok_or(InlineCallerFrameDecline::Unavailable)?;
     // Null the not-yet-produced result slot, build the box list, then restore
     // the caller's register (the inlined callee, not the walk, produces the
     // result; the inner frame supplies it on resume).
@@ -11569,7 +11582,7 @@ fn compute_inline_caller_frame(
     if let (Some(saved), true) = (saved, result_color < ctx.registers_r.len()) {
         ctx.registers_r[result_color] = saved;
     }
-    Some(InlineParentFrame {
+    Ok(InlineParentFrame {
         jitcode_index,
         resume_py_pc: fallthrough_py_pc,
         boxes,
@@ -11587,18 +11600,18 @@ fn compute_nested_inline_caller_frame(
     ctx: &mut WalkContext<'_, '_>,
     call_jit_pc: usize,
     caller_code: usize,
-) -> Option<InlineParentFrame> {
-    let jitcode_index = crate::state::ensure_jitcode_index(caller_code as *const ())? as u32;
-    let pjc = crate::state::pyjitcode_for_jitcode_index(jitcode_index as i32)?;
+) -> Result<InlineParentFrame, InlineCallerFrameDecline> {
+    let jitcode_index = crate::state::ensure_jitcode_index(caller_code as *const ())
+        .ok_or(InlineCallerFrameDecline::Unavailable)? as u32;
+    let pjc = crate::state::pyjitcode_for_jitcode_index(jitcode_index as i32)
+        .ok_or(InlineCallerFrameDecline::Unavailable)?;
     if !pjc.is_populated() || pjc.code_ptr.is_null() {
-        return None;
+        return Err(InlineCallerFrameDecline::Unavailable);
     }
     let call_py = python_pc_for_jitcode_pc(&pjc.metadata, call_jit_pc) as usize;
     // A CALL inside a try-block resumes at its own catch via a bit-14 marker
     // pc, which the multi-frame capture's `py_pc < FLAG` assert rejects.
-    if pjc.after_residual_call_resume_pc_for(call_py).is_some() {
-        return None;
-    }
+    decline_inline_caller_frame_for_catch_marker(pjc.after_residual_call_resume_pc_for(call_py))?;
     let fallthrough_py_pc = unsafe {
         let code = &*pjc.code_ptr;
         crate::pyjitpl::semantic_fallthrough_pc(code, call_py) as u32
@@ -11612,12 +11625,13 @@ fn compute_nested_inline_caller_frame(
             .unwrap_or(0) as usize
     };
     if depth == 0 {
-        return None;
+        return Err(InlineCallerFrameDecline::Unavailable);
     }
     // #73: result slot color from the precomputed `result_color_at_pc`, not
     // the flat `stack_slot_color_map` (see `compute_inline_caller_frame`).
     let result_color =
-        crate::state::result_color_at_pc_at(jitcode_index as i32, fallthrough_py_pc as usize)?;
+        crate::state::result_color_at_pc_at(jitcode_index as i32, fallthrough_py_pc as usize)
+            .ok_or(InlineCallerFrameDecline::Unavailable)?;
     // Null the not-yet-produced result slot, build the box list, then restore
     // the caller's register (the inlined callee, not the walk, produces the
     // result; the inner frame supplies it on resume) — same as the top-level
@@ -11646,9 +11660,9 @@ fn compute_nested_inline_caller_frame(
     }
     let boxes = match boxes {
         Ok(b) => b,
-        Err(_) => return None,
+        Err(_) => return Err(InlineCallerFrameDecline::Unavailable),
     };
-    Some(InlineParentFrame {
+    Ok(InlineParentFrame {
         jitcode_index,
         resume_py_pc: fallthrough_py_pc,
         boxes,
@@ -13282,6 +13296,25 @@ fn emit_loop_callee_ca_vable_scalar(
 /// pure-leaf callee resume to the caller's CALL boundary via the inherited
 /// single-frame snapshot (`entry_py_pc` / `outer_active_boxes`), which is
 /// sound for side-effect-free leaves (re-execute the whole call on deopt).
+fn reconstructed_all_ref_call_stack(
+    code: &[u8],
+    op: &DecodedOp,
+    ctx: &WalkContext<'_, '_>,
+) -> Option<Vec<pyre_object::PyObjectRef>> {
+    let fresh = read_ref_var_list_concrete(code, op, 1, ctx);
+    let mut stack = Vec::with_capacity(fresh.len());
+    if fresh.is_empty() {
+        return None;
+    }
+    for c in fresh {
+        match c {
+            ConcreteValue::Ref(r) => stack.push(r),
+            _ => return None,
+        }
+    }
+    stack.first().is_some_and(|c| !c.is_null()).then_some(stack)
+}
+
 fn try_walker_inline_user_call(
     ctx: &mut WalkContext<'_, '_>,
     op: &DecodedOp,
@@ -13753,72 +13786,13 @@ fn try_walker_inline_user_call(
         }
     }
 
-    // #68: a forward-branch callee inlined under the multi-frame path needs a
-    // paused caller frame on `FBW_INLINE_PARENT_FRAMES` so its in-callee guards
-    // snapshot both frames.  Compute it here, while the caller's live register
-    // banks (`ctx.registers_*`) are still in scope — at guard-capture time the
-    // walk context is the callee's.  A caller frame that is not snapshot-able
-    // (try-block catch marker / missing liveness) declines to the trait leg.
-    let parent_frame = if try_multiframe {
-        match compute_inline_caller_frame(ctx, op.pc) {
-            Some(pf) => Some(pf),
-            None => return Err(DispatchError::LoopBearingCalleeInlineUnsupported { pc: op.pc }),
-        }
-    } else if callee_frame_seeded {
-        // A strict straight-line callee seeded at the top inline level (the
-        // `try_multiframe` arm above already handled the branch path).  Push the
-        // paused caller frame so its in-callee guards resume through the
-        // multi-frame snapshot (`walker_capture_multi_frame_inline_snapshot`) at
-        // the callee's OWN coordinate, with the caller paused at the CALL return
-        // point (`get_list_of_active_boxes(in_a_call=true)` parity,
-        // `trace_opcode.rs:1779`).  With the callee frame red now seeded,
-        // `collect_callee_active_boxes` sources the callee's live boxes and the
-        // snapshot succeeds, producing the full RPython `Snapshot.frames` chain
-        // (`opencoder.py:767 create_top_snapshot`, resumed by
-        // `resume.py rebuild_from_resumedata`).  This replaces the single-frame
-        // collapse, whose caller-boundary re-execute both mis-sizes the resumed
-        // frame (a decode / `LOAD_FAST` overrun) and re-applies the callee's
-        // committed side effect on deopt.
-        //
-        // Best effort: `compute_inline_caller_frame` returns `None` for a caller
-        // shape it cannot build yet (a CALL inside a try-block, or no result on
-        // the operand stack at the return point).  Fall back to the single-frame
-        // collapse there (do NOT decline the inline — that shape is served
-        // correctly today), so this never removes a working inline.
-        compute_inline_caller_frame(ctx, op.pc)
-    } else {
-        // Single-frame collapse (resume at the CALL boundary, re-execute the
-        // whole call on deopt): a nested strict callee
-        // (`inline_depth >= FBW_MAX_MULTIFRAME_DEPTH`, task #126), an un-seedable
-        // strict callee, or a callee neither seed served.  Sound for a pure
-        // value-returning leaf (idempotent re-execute) and for a nested
-        // straight-line callee (its pre-multiframe behavior).
-        None
-    };
-
-    // CODEX1 parity: snapshot the heap-effect state before the callee
-    // sub-walk.  If the prologue (callee pc 0 → its loop header) mutates the
-    // heap, the `SubLoopCalleeCallAssembler` arm below would re-run the WHOLE
-    // call through the residual executor to stamp `ca_result`, applying the
-    // prologue's side effects a second time at trace time.  RPython's
-    // `do_residual_call` runs the call exactly once (`pyjitpl.py:2019`), so a
-    // side-effecting prologue must decline the CA inline (see the arm).
-    let prologue_journal_before = fbw_store_journal_len();
+    // gh#467 forward-flush inputs are captured AT the CALL, after this
+    // iteration's pre-CALL effects and before any callee sub-walk.  Hoisting
+    // them above the paused-caller-frame gate lets its try-block decline use
+    // the same Entry-carrier predicates as a zero-effect sub-walk abort.
     let unjournaled_before_subwalk = fbw_has_unjournaled_effect();
-    // gh#467 forward-flush gate snapshots AT the CALL, after this iteration's
-    // pre-CALL effects and before the callee sub-walk.  A sub-walk that aborts
-    // without moving the executed-effect odometer applied nothing concrete;
-    // an unjournaled mark raised inside that discarded attempt describes only
-    // a declined residual and may be discarded with it.  A mark already set at
-    // entry belongs outside the callee and blocks the flush.  Latched only at
-    // the TOP inline level: the flushed frame is the top-level `cf_addr`, whose
-    // operand stack is THIS call's `[callable, null_or_self, args...]`.
     let executed_effects_before = fbw_executed_effect_count();
     let is_top_inline = !INLINE_SUBWALK_CAPTURE_BOUNDARY.with(|c| c.get());
-    // The outer CALL's python pc in the TOP-level frame's code, derived from the
-    // FBW snapshot sym at this residual_call's jitcode pc (`op.pc`) — the same
-    // coordinate `call_site_py_pc` below computes.  `None` outside the FBW
-    // top-inline path (no forward flush there).
     let abort_flush_call_py_pc: Option<usize> = if ctx.is_full_body_walk && is_top_inline {
         let sym_ptr = FULL_BODY_SNAPSHOT_SYM.with(|c| c.get());
         if sym_ptr.is_null() {
@@ -13842,6 +13816,78 @@ fn try_walker_inline_user_call(
     } else {
         None
     };
+
+    // #68: a forward-branch callee inlined under the multi-frame path needs a
+    // paused caller frame on `FBW_INLINE_PARENT_FRAMES` so its in-callee guards
+    // snapshot both frames.  Compute it here, while the caller's live register
+    // banks (`ctx.registers_*`) are still in scope — at guard-capture time the
+    // walk context is the callee's.  A caller frame that is not snapshot-able
+    // (try-block catch marker / missing liveness) declines to the trait leg.
+    let parent_frame = if try_multiframe {
+        match compute_inline_caller_frame(ctx, op.pc) {
+            Ok(pf) => Some(pf),
+            Err(InlineCallerFrameDecline::TryBlockCatchMarker) => {
+                // An un-entered multiframe-inline CALL declined at its
+                // try-block catch marker is re-run whole and forward, exactly
+                // as if it had never been inlined (`pyjitpl.py:2949`).  The
+                // multi-frame guard snapshot itself remains declined.
+                if is_top_inline
+                    && !unjournaled_before_subwalk
+                    && fbw_executed_effect_count() == executed_effects_before
+                {
+                    if let (Some(call_pc), Some(stack)) = (
+                        abort_flush_call_py_pc,
+                        reconstructed_all_ref_call_stack(code, op, ctx),
+                    ) {
+                        fbw_set_abort_call_resume(call_pc, stack);
+                    }
+                }
+                return Err(DispatchError::LoopBearingCalleeInlineUnsupported { pc: op.pc });
+            }
+            Err(InlineCallerFrameDecline::Unavailable) => {
+                return Err(DispatchError::LoopBearingCalleeInlineUnsupported { pc: op.pc });
+            }
+        }
+    } else if callee_frame_seeded {
+        // A strict straight-line callee seeded at the top inline level (the
+        // `try_multiframe` arm above already handled the branch path).  Push the
+        // paused caller frame so its in-callee guards resume through the
+        // multi-frame snapshot (`walker_capture_multi_frame_inline_snapshot`) at
+        // the callee's OWN coordinate, with the caller paused at the CALL return
+        // point (`get_list_of_active_boxes(in_a_call=true)` parity,
+        // `trace_opcode.rs:1779`).  With the callee frame red now seeded,
+        // `collect_callee_active_boxes` sources the callee's live boxes and the
+        // snapshot succeeds, producing the full RPython `Snapshot.frames` chain
+        // (`opencoder.py:767 create_top_snapshot`, resumed by
+        // `resume.py rebuild_from_resumedata`).  This replaces the single-frame
+        // collapse, whose caller-boundary re-execute both mis-sizes the resumed
+        // frame (a decode / `LOAD_FAST` overrun) and re-applies the callee's
+        // committed side effect on deopt.
+        //
+        // Best effort: `compute_inline_caller_frame` returns `Unavailable` for a caller
+        // shape it cannot build yet (a CALL inside a try-block, or no result on
+        // the operand stack at the return point).  Fall back to the single-frame
+        // collapse there (do NOT decline the inline — that shape is served
+        // correctly today), so this never removes a working inline.
+        compute_inline_caller_frame(ctx, op.pc).ok()
+    } else {
+        // Single-frame collapse (resume at the CALL boundary, re-execute the
+        // whole call on deopt): a nested strict callee
+        // (`inline_depth >= FBW_MAX_MULTIFRAME_DEPTH`, task #126), an un-seedable
+        // strict callee, or a callee neither seed served.  Sound for a pure
+        // value-returning leaf (idempotent re-execute) and for a nested
+        // straight-line callee (its pre-multiframe behavior).
+        None
+    };
+
+    // CODEX1 parity: snapshot the heap-effect state before the callee
+    // sub-walk.  If the prologue (callee pc 0 → its loop header) mutates the
+    // heap, the `SubLoopCalleeCallAssembler` arm below would re-run the WHOLE
+    // call through the residual executor to stamp `ca_result`, applying the
+    // prologue's side effects a second time at trace time.  RPython's
+    // `do_residual_call` runs the call exactly once (`pyjitpl.py:2019`), so a
+    // side-effecting prologue must decline the CA inline (see the arm).
+    let prologue_journal_before = fbw_store_journal_len();
     // Compute fresh outer_active_boxes for the inline sub-walk when the
     // parent FBW walk carries an empty set (`dispatch_via_miframe`
     // initializes `outer_active_boxes: Vec::new()`; it is computed
@@ -14151,22 +14197,7 @@ fn try_walker_inline_user_call(
                 && fbw_executed_effect_count() == executed_effects_before
             {
                 if let Some(call_pc) = abort_flush_call_py_pc {
-                    let fresh = read_ref_var_list_concrete(code, op, 1, ctx);
-                    let mut stack = Vec::with_capacity(fresh.len());
-                    let mut all_ref = !fresh.is_empty();
-                    for c in &fresh {
-                        match c {
-                            ConcreteValue::Ref(r) => stack.push(*r),
-                            _ => {
-                                all_ref = false;
-                                break;
-                            }
-                        }
-                    }
-                    // The top-of-stack callable slot must be a real object; a
-                    // non-Ref anywhere means the reconstruction is unreliable, so
-                    // decline (the legacy replay is always sound).
-                    if all_ref && stack.first().is_some_and(|c| !c.is_null()) {
+                    if let Some(stack) = reconstructed_all_ref_call_stack(code, op, ctx) {
                         fbw_set_abort_call_resume(call_pc, stack);
                     }
                 }
@@ -22490,6 +22521,15 @@ mod tests {
     /// when the staticdata singleton was never attached.
     fn done_descr_ref_for_tests() -> DescrRef {
         make_fail_descr(1)
+    }
+
+    #[test]
+    fn inline_caller_frame_distinguishes_try_block_catch_marker_decline() {
+        assert_eq!(
+            decline_inline_caller_frame_for_catch_marker(Some(42)),
+            Err(InlineCallerFrameDecline::TryBlockCatchMarker),
+        );
+        assert_eq!(decline_inline_caller_frame_for_catch_marker(None), Ok(()));
     }
 
     /// `ensure_residual_call_args_bound` backs the unbound-arg abort path

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -12332,7 +12332,7 @@ fn diagnose_inline_recognition(arg_concretes: &[ConcreteValue], op_pc: usize) {
 ///
 /// # Safety
 /// `callable` must be a non-null pointer obtained from a `ConcreteValue::Ref`.
-unsafe fn resolve_inlinable_callee(
+pub(crate) unsafe fn resolve_inlinable_callee(
     callable: pyre_object::PyObjectRef,
 ) -> Option<(*const (), usize, bool)> {
     unsafe {

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -7896,7 +7896,7 @@ thread_local! {
     /// forward (re-executing the callee from scratch) instead of rolling back
     /// and replaying the loop body from entry.  The `PyObjectRef`s are rooted by
     /// [`fbw_store_journal_root_walker`] across the abort unwind's allocations.
-    static FBW_ABORT_CALL_RESUME: std::cell::RefCell<Option<(usize, Vec<pyre_object::PyObjectRef>)>> =
+    static FBW_ABORT_CALL_RESUME: std::cell::RefCell<Option<InlineAbortCarrier>> =
         const { std::cell::RefCell::new(None) };
 
     /// B3 (`PYRE_FBW_RAISE`): the set of OpRefs the walker built inline via
@@ -7931,6 +7931,29 @@ thread_local! {
     /// [`FBW_EXC_PREV`]) rather than a `POP_EXCEPT` restore (which pops it).
     /// The two `SetCurrentException` shapes are otherwise identical.
     static FBW_EXC_PENDING_PUSH_SET: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+}
+
+#[derive(Clone, Debug)]
+pub(crate) enum InlineAbortCarrier {
+    Entry {
+        call_py_pc: usize,
+        call_stack: Vec<pyre_object::PyObjectRef>,
+    },
+    MidBody(MidBodyPayload),
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct MidBodyPayload {
+    pub call_py_pc: usize,
+    pub post_call_py_pc: usize,
+    pub call_stack_len: usize,
+    pub callee_py_pc: usize,
+    pub w_code: pyre_object::PyObjectRef,
+    pub w_globals: pyre_object::PyObjectRef,
+    pub x_arg: pyre_object::PyObjectRef,
+    pub live_locals: Vec<Option<ConcreteValue>>,
+    pub live_stack: Vec<ConcreteValue>,
+    pub return_value: pyre_object::PyObjectRef,
 }
 
 /// Record that `op` is a walker-built inline exception (B3 construct fold).
@@ -8354,13 +8377,32 @@ pub(crate) fn fbw_bump_executed_effect() {
 
 /// gh#467 latch the inline-abort forward-flush carrier (see [`FBW_ABORT_CALL_RESUME`]).
 pub(crate) fn fbw_set_abort_call_resume(call_pc: usize, stack: Vec<pyre_object::PyObjectRef>) {
-    FBW_ABORT_CALL_RESUME.with(|c| *c.borrow_mut() = Some((call_pc, stack)));
+    FBW_ABORT_CALL_RESUME.with(|c| {
+        *c.borrow_mut() = Some(InlineAbortCarrier::Entry {
+            call_py_pc: call_pc,
+            call_stack: stack,
+        })
+    });
 }
 
-/// gh#467 take the inline-abort forward-flush carrier, clearing it (see
-/// [`FBW_ABORT_CALL_RESUME`]).
-pub(crate) fn fbw_take_abort_call_resume() -> Option<(usize, Vec<pyre_object::PyObjectRef>)> {
-    FBW_ABORT_CALL_RESUME.with(|c| c.borrow_mut().take())
+pub(crate) fn fbw_set_midbody_abort_resume(payload: MidBodyPayload) {
+    FBW_ABORT_CALL_RESUME.with(|c| *c.borrow_mut() = Some(InlineAbortCarrier::MidBody(payload)));
+}
+
+pub(crate) fn fbw_abort_carrier_clone() -> Option<InlineAbortCarrier> {
+    FBW_ABORT_CALL_RESUME.with(|c| c.borrow().clone())
+}
+
+pub(crate) fn fbw_abort_carrier_set_return(value: pyre_object::PyObjectRef) {
+    FBW_ABORT_CALL_RESUME.with(|c| {
+        if let Some(InlineAbortCarrier::MidBody(payload)) = c.borrow_mut().as_mut() {
+            payload.return_value = value;
+        }
+    });
+}
+
+pub(crate) fn fbw_abort_carrier_clear() {
+    FBW_ABORT_CALL_RESUME.with(|c| *c.borrow_mut() = None);
 }
 
 /// An unexecutable residual call (`try_execute_residual_call_via_executor`
@@ -8446,11 +8488,44 @@ pub fn fbw_store_journal_root_walker(visitor: &mut dyn FnMut(&mut majit_ir::GcRe
     // locals, which can trigger a minor collection that moves these refs before
     // they are written into the frame array — so forward every slot as a root.
     FBW_ABORT_CALL_RESUME.with(|c| {
-        if let Some((_call_pc, stack)) = c.borrow_mut().as_mut() {
-            for slot in stack.iter_mut() {
-                // SAFETY: `PyObjectRef` and `GcRef` share the usize repr; the
-                // borrow keeps the Vec storage alive for the visit.
-                visitor(unsafe { &mut *(slot as *mut pyre_object::PyObjectRef).cast() });
+        if let Some(carrier) = c.borrow_mut().as_mut() {
+            match carrier {
+                InlineAbortCarrier::Entry { call_stack, .. } => {
+                    for slot in call_stack {
+                        visitor(unsafe { &mut *(slot as *mut pyre_object::PyObjectRef).cast() });
+                    }
+                }
+                InlineAbortCarrier::MidBody(payload) => {
+                    visitor(unsafe {
+                        &mut *(&mut payload.w_code as *mut pyre_object::PyObjectRef).cast()
+                    });
+                    visitor(unsafe {
+                        &mut *(&mut payload.w_globals as *mut pyre_object::PyObjectRef).cast()
+                    });
+                    visitor(unsafe {
+                        &mut *(&mut payload.x_arg as *mut pyre_object::PyObjectRef).cast()
+                    });
+                    if !payload.return_value.is_null() {
+                        visitor(unsafe {
+                            &mut *(&mut payload.return_value as *mut pyre_object::PyObjectRef)
+                                .cast()
+                        });
+                    }
+                    for slot in payload.live_locals.iter_mut().flatten() {
+                        if let ConcreteValue::Ref(value) = slot {
+                            visitor(unsafe {
+                                &mut *(value as *mut pyre_object::PyObjectRef).cast()
+                            });
+                        }
+                    }
+                    for slot in &mut payload.live_stack {
+                        if let ConcreteValue::Ref(value) = slot {
+                            visitor(unsafe {
+                                &mut *(value as *mut pyre_object::PyObjectRef).cast()
+                            });
+                        }
+                    }
+                }
             }
         }
     });
@@ -13886,10 +13961,111 @@ fn try_walker_inline_user_call(
         // callee sub-walk so its branch guards capture both frames (no-op when
         // `parent_frame` is None — the strict straight-line inline path).
         let _parent_frame_guard = parent_frame.map(InlineParentFrameGuard::enter);
-        // Yield the walk Result; `sub_wc` (and the RAII guards) drop at the
-        // block end so the outer `ctx` is borrowable again for the gh#467
-        // forward-flush re-read below.
-        walk(body.code, 0, &mut sub_wc)
+        // Capture a depth-1 live callee before these guards drop. This is the
+        // two-frame specialization of `run_blackhole_interp_to_cancel_tracing`:
+        // `_copy_data_from_miframe` preserves the callee's own position and
+        // live registers instead of collapsing it onto the caller frame.
+        let result = walk(body.code, 0, &mut sub_wc);
+        if let Err(DispatchError::AbortPermanentMarkerReached { pc: abort_pc }) = &result {
+            if is_top_inline
+                && !unjournaled_before_subwalk
+                && fbw_executed_effect_count() != executed_effects_before
+            {
+                let payload = (|| {
+                    let call_py_pc = abort_flush_call_py_pc?;
+                    let callee_pjc = crate::state::pyjitcode_for_code(w_code)?;
+                    let metadata = &callee_pjc.metadata;
+                    let callee_py_pc = python_pc_for_jitcode_pc(metadata, *abort_pc) as usize;
+                    if metadata.first_jit_pc_by_py_pc.get(callee_py_pc).copied() != Some(*abort_pc)
+                    {
+                        return None;
+                    }
+                    let raw = unsafe {
+                        pyre_interpreter::w_code_get_ptr(w_code as pyre_object::PyObjectRef)
+                            as *const pyre_interpreter::CodeObject
+                    };
+                    if raw.is_null() {
+                        return None;
+                    }
+                    let callee_code = unsafe { &*raw };
+                    if pyre_interpreter::pyframe::code_flags_make_generator(callee_code.flags)
+                        || !callee_code.cellvars.is_empty()
+                        || !callee_code.freevars.is_empty()
+                        || !unsafe { pyre_interpreter::function_get_closure(callable) }.is_null()
+                    {
+                        return None;
+                    }
+                    let depth = metadata.depth_at_py_pc.get(callee_py_pc).copied()? as usize;
+                    let nlocals = callee_code.varnames.len();
+                    let entries = metadata.pcdep_color_slots.get(callee_py_pc)?;
+                    let mut live_stack = Vec::with_capacity(depth);
+                    for rel in 0..depth {
+                        let color =
+                            crate::state::semantic_slot_color_for_ref_slot(entries, nlocals + rel)?;
+                        let value = *sub_wc.concrete_registers_r.get(color)?;
+                        if !matches!(value, ConcreteValue::Ref(r) if !r.is_null()) {
+                            return None;
+                        }
+                        live_stack.push(value);
+                    }
+                    if live_stack.len() != depth {
+                        return None;
+                    }
+                    let lv = crate::state::liveness_for(raw);
+                    let mut live_locals = vec![None; nlocals];
+                    for (slot, dst) in live_locals.iter_mut().enumerate() {
+                        if !lv.is_local_live(callee_py_pc, slot) {
+                            continue;
+                        }
+                        let value = fbw_callee_local_get_concrete(slot as i64)
+                            .and_then(|value| match value {
+                                Value::Ref(r) => Some(ConcreteValue::Ref(
+                                    r.as_usize() as pyre_object::PyObjectRef
+                                )),
+                                Value::Int(v) => Some(ConcreteValue::Int(v)),
+                                Value::Float(v) => Some(ConcreteValue::Float(v)),
+                                Value::Void => None,
+                            })
+                            .or_else(|| arg_concretes.get(2 + slot).copied())?;
+                        if matches!(value, ConcreteValue::Null | ConcreteValue::Bool(_)) {
+                            return None;
+                        }
+                        *dst = Some(value);
+                    }
+                    let sym_ptr = FULL_BODY_SNAPSHOT_SYM.with(|c| c.get());
+                    if sym_ptr.is_null() {
+                        return None;
+                    }
+                    let outer_jc = unsafe { &*(*sym_ptr).jitcode };
+                    if outer_jc.payload.code_ptr.is_null() {
+                        return None;
+                    }
+                    let post_call_py_pc = skip_python_trivia_forward(
+                        unsafe { &*outer_jc.payload.code_ptr },
+                        call_py_pc + 1,
+                    );
+                    let Some(ConcreteValue::Ref(x_arg)) = live_stack.first().copied() else {
+                        return None;
+                    };
+                    Some(MidBodyPayload {
+                        call_py_pc,
+                        post_call_py_pc,
+                        call_stack_len: arg_concretes.len(),
+                        callee_py_pc,
+                        w_code: w_code as pyre_object::PyObjectRef,
+                        w_globals: unsafe { pyre_interpreter::function_get_globals_obj(callable) },
+                        x_arg,
+                        live_locals,
+                        live_stack,
+                        return_value: pyre_object::PY_NULL,
+                    })
+                })();
+                if let Some(payload) = payload {
+                    fbw_set_midbody_abort_resume(payload);
+                }
+            }
+        }
+        result
     };
     let (outcome, _end_pc) = match callee_outcome {
         Ok(v) => v,

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -9075,8 +9075,9 @@ fn pc_map_marker_for(metadata: &crate::PyJitCodeMetadata, py: usize) -> Option<u
 
 /// Map an `abort_permanent` marker's jitcode pc back to the Python opcode
 /// the interpreter must resume at.  `emit_abort_permanent` (codewriter)
-/// anchors that resume coordinate (`last_instr = py_pc - 1`); the full-body
-/// walk reads it here to flush the abort-point frame instead of replaying
+/// anchors the graph marker at `py_pc` and additionally stores
+/// `last_instr = py_pc - 1` for portal frames; the full-body walk reads the
+/// marker coordinate here to flush the abort-point frame instead of replaying
 /// the walked region.  Returns None when the sym's jitcode / `code_ptr` is
 /// unavailable (no resume coordinate derivable → legacy replay).
 pub(crate) fn fbw_abort_resume_py_pc(

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -6222,7 +6222,7 @@ fn try_execute_residual_call_via_executor(
             || heap_write_odometer_before
                 .is_some_and(|before| pyre_interpreter::call::frame_entry_count() != before))
     {
-        fbw_bump_concrete_heap_write();
+        fbw_bump_executed_effect();
     }
     // #73/#267: a user-defined iterator's FOR_ITER runs its item producer
     // (`__next__`/`__getitem__`) as an inline sub-walk whose operand-stack
@@ -7874,25 +7874,22 @@ thread_local! {
     /// the recorded effect.
     static FBW_UNJOURNALED_EFFECT: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
 
-    /// gh#467 concrete-heap-write odometer: bumped whenever the walk applies a
-    /// heap mutation the store/append/cell journals do NOT cover — a Void /
-    /// mutator-tagged residual executed concretely by
-    /// [`try_execute_residual_call_via_executor`], a residual whose concrete
-    /// run entered a user Python frame (a value-returning dunder that may
-    /// mutate), or an unexecutable residual flagged via
-    /// [`fbw_mark_unjournaled_effect`].  Unlike [`FBW_UNJOURNALED_EFFECT`] (a
-    /// monotone bool) this is a COUNT, so a callee sub-walk's OWN concrete
-    /// effect is detectable even when a prior (pre-CALL) effect already tripped
-    /// the bool.  Read only by the inline abort-forward-flush gate
-    /// (`try_walker_inline_user_call` / gh#467): snapshot at the CALL, compare
-    /// after the sub-walk aborts — a nonzero delta means the callee committed
-    /// an irreversible effect, so re-executing the CALL would double it.
-    static FBW_CONCRETE_HEAP_WRITE_COUNT: std::cell::Cell<usize> =
+    /// gh#467 executed-effect odometer: bumped only when the walk concretely
+    /// applies an effect — a store/append/cell journal push, a Void / mutator-
+    /// tagged residual executed by [`try_execute_residual_call_via_executor`],
+    /// or a residual whose concrete run entered a user Python frame (a value-
+    /// returning dunder that may mutate).  A declined residual recorded only
+    /// symbolically sets [`FBW_UNJOURNALED_EFFECT`] but does NOT move this
+    /// counter: no effect executed.  The inline abort-forward-flush gate
+    /// (`try_walker_inline_user_call` / gh#467) snapshots both signals at the
+    /// CALL.  A nonzero count delta means the callee attempt cannot be
+    /// discarded and re-executed without risking a double.
+    static FBW_EXECUTED_EFFECT_COUNT: std::cell::Cell<usize> =
         const { std::cell::Cell::new(0) };
 
     /// gh#467 inline-abort forward-flush carrier: latched by
-    /// [`try_walker_inline_user_call`] when an `abort_permanent` marker fires
-    /// inside a TOP-level inline sub-walk whose callee committed no heap effect.
+    /// [`try_walker_inline_user_call`] when a supported abort fires inside a
+    /// TOP-level inline sub-walk whose callee executed no concrete effect.
     /// Holds `(outer CALL python pc, [callable, null_or_self, args...])` — the
     /// exact operand stack the interpreter's CALL opcode expects — so the walk
     /// driver can flush the outer frame AT that CALL and resume the interpreter
@@ -7960,9 +7957,9 @@ pub(crate) fn fbw_store_journal_reset() {
     FBW_APPEND_JOURNAL.with(|j| j.borrow_mut().clear());
     FBW_CELL_STORE_JOURNAL.with(|j| j.borrow_mut().clear());
     FBW_UNJOURNALED_EFFECT.with(|c| c.set(false));
-    // gh#467: reset the concrete-heap-write odometer and any stale
+    // gh#467: reset the executed-effect odometer and any stale
     // forward-flush carrier a prior aborted walk latched.
-    FBW_CONCRETE_HEAP_WRITE_COUNT.with(|c| c.set(0));
+    FBW_EXECUTED_EFFECT_COUNT.with(|c| c.set(0));
     FBW_ABORT_CALL_RESUME.with(|c| *c.borrow_mut() = None);
     // #57 Option C: drop any in-flight FOR_ITER items a prior aborted walk
     // left undelivered (its live frame already consumed the delivery), so a
@@ -7993,7 +7990,7 @@ pub(crate) fn fbw_store_journal_push(
     // gh#467: a journaled store still mutated the heap this iteration; the
     // forward-flush gate counts it so a callee sub-walk that appends/setitems
     // cannot be committed-then-re-executed (a double).
-    fbw_bump_concrete_heap_write();
+    fbw_bump_executed_effect();
 }
 
 /// Record the live length a walked eager list append grew past, for the
@@ -8005,7 +8002,7 @@ pub(crate) fn fbw_store_journal_push(
 pub(crate) fn fbw_append_journal_push(list: pyre_object::PyObjectRef, length_before: usize) {
     FBW_APPEND_JOURNAL.with(|j| j.borrow_mut().push((list, length_before)));
     // gh#467: see `fbw_store_journal_push`.
-    fbw_bump_concrete_heap_write();
+    fbw_bump_executed_effect();
 }
 
 /// Record the `intvalue` a walked eager `IntMutableCell` store displaces,
@@ -8021,7 +8018,7 @@ pub(crate) fn fbw_cell_store_journal_push(cell: pyre_object::PyObjectRef, intval
     }
     FBW_CELL_STORE_JOURNAL.with(|j| j.borrow_mut().push((cell, intvalue_before)));
     // gh#467: see `fbw_store_journal_push`.
-    fbw_bump_concrete_heap_write();
+    fbw_bump_executed_effect();
 }
 
 /// Commit-path epilogue: the walk's eager stores and appends stand; drop
@@ -8343,20 +8340,16 @@ pub(crate) fn fbw_store_journal_len() -> usize {
 /// the legacy replay applies (see [`FBW_UNJOURNALED_EFFECT`]).
 pub(crate) fn fbw_mark_unjournaled_effect() {
     FBW_UNJOURNALED_EFFECT.with(|c| c.set(true));
-    // gh#467: an unexecutable residual is also a non-journaled effect the
-    // forward-flush gate must count, so a callee that hits one is detected even
-    // when the monotone bool was already set by a pre-CALL effect.
-    fbw_bump_concrete_heap_write();
 }
 
-/// gh#467 concrete-heap-write odometer read (see [`FBW_CONCRETE_HEAP_WRITE_COUNT`]).
-pub(crate) fn fbw_concrete_heap_write_count() -> usize {
-    FBW_CONCRETE_HEAP_WRITE_COUNT.with(|c| c.get())
+/// gh#467 executed-effect odometer read (see [`FBW_EXECUTED_EFFECT_COUNT`]).
+pub(crate) fn fbw_executed_effect_count() -> usize {
+    FBW_EXECUTED_EFFECT_COUNT.with(|c| c.get())
 }
 
-/// gh#467 bump the concrete-heap-write odometer (see [`FBW_CONCRETE_HEAP_WRITE_COUNT`]).
-pub(crate) fn fbw_bump_concrete_heap_write() {
-    FBW_CONCRETE_HEAP_WRITE_COUNT.with(|c| c.set(c.get() + 1));
+/// gh#467 bump the executed-effect odometer (see [`FBW_EXECUTED_EFFECT_COUNT`]).
+pub(crate) fn fbw_bump_executed_effect() {
+    FBW_EXECUTED_EFFECT_COUNT.with(|c| c.set(c.get() + 1));
 }
 
 /// gh#467 latch the inline-abort forward-flush carrier (see [`FBW_ABORT_CALL_RESUME`]).
@@ -13697,19 +13690,16 @@ fn try_walker_inline_user_call(
     // `do_residual_call` runs the call exactly once (`pyjitpl.py:2019`), so a
     // side-effecting prologue must decline the CA inline (see the arm).
     let prologue_journal_before = fbw_store_journal_len();
-    let prologue_effect_before = fbw_has_unjournaled_effect();
-    // gh#467 forward-flush gate snapshot: the concrete-heap-write odometer AT
-    // the CALL (after this iteration's pre-CALL effects, before the callee
-    // sub-walk).  If the sub-walk aborts on an `abort_permanent` marker WITHOUT
-    // moving this odometer, the callee committed nothing irreversible, so the
-    // walk driver may flush the outer frame at this CALL and re-execute the call
-    // forward instead of replaying the loop from entry (which double-applies the
-    // non-journaled pre-CALL store).  Latched only at the TOP inline level: the
-    // flushed frame is the top-level `cf_addr`, whose operand stack is THIS
-    // call's `[callable, null_or_self, args...]`.  Mirrors the convergence of
-    // `run_blackhole_interp_to_cancel_tracing` (`pyjitpl.py:2949`), minus the
-    // inner-frame rebuild (#126/#215).
-    let concrete_writes_before = fbw_concrete_heap_write_count();
+    let unjournaled_before_subwalk = fbw_has_unjournaled_effect();
+    // gh#467 forward-flush gate snapshots AT the CALL, after this iteration's
+    // pre-CALL effects and before the callee sub-walk.  A sub-walk that aborts
+    // without moving the executed-effect odometer applied nothing concrete;
+    // an unjournaled mark raised inside that discarded attempt describes only
+    // a declined residual and may be discarded with it.  A mark already set at
+    // entry belongs outside the callee and blocks the flush.  Latched only at
+    // the TOP inline level: the flushed frame is the top-level `cf_addr`, whose
+    // operand stack is THIS call's `[callable, null_or_self, args...]`.
+    let executed_effects_before = fbw_executed_effect_count();
     let is_top_inline = !INLINE_SUBWALK_CAPTURE_BOUNDARY.with(|c| c.get());
     // The outer CALL's python pc in the TOP-level frame's code, derived from the
     // FBW snapshot sym at this residual_call's jitcode pc (`op.pc`) — the same
@@ -13906,25 +13896,29 @@ fn try_walker_inline_user_call(
             if std::env::var("PYRE_FBW_INLINE_DIAG").is_ok() {
                 eprintln!("[inline-abort] callee sub-walk err: {e:?}");
             }
-            // gh#467: an `abort_permanent` marker fired inside this top-level
-            // inline sub-walk.  If the callee committed NO irreversible heap
-            // effect (the concrete-heap-write odometer is unmoved since the
-            // CALL), latch the outer CALL boundary so the walk driver flushes
-            // the outer frame there and re-executes the call FORWARD — running
-            // the callee from scratch in the interpreter — instead of rolling
-            // back and replaying the loop from entry, which double-applies the
-            // non-journaled pre-CALL store (the gh#467 defect).  The operand
+            // gh#467: a supported abort fired inside this top-level inline
+            // sub-walk.  If the callee executed NO concrete effect and no
+            // unjournaled effect existed before the attempt, latch the outer
+            // CALL boundary so the walk driver flushes the outer frame there
+            // and re-executes the call FORWARD — running the callee from scratch
+            // in the interpreter — instead of rolling back and replaying the
+            // loop from entry, which double-applies the non-journaled pre-CALL
+            // store.  Discarding a zero-executed-effect callee attempt and
+            // re-running its CALL is observationally identical to upstream
+            // never having inlined it: tracing aborts and `switch_to_blackhole`
+            // re-runs the call (`pyjitpl.py:2949`; gh#467).  The operand
             // stack the CALL opcode expects (`[callable, null_or_self,
             // args...]`) is re-read from the (now GC-forwarded) outer registers,
             // not the pre-sub-walk `arg_concretes`, so it is current after the
-            // sub-walk's allocations.  A callee that DID commit an effect
-            // (odometer moved) keeps the legacy replay — the honest residual
-            // (the inner-frame rebuild is #126/#215).  This is the intermediate
-            // convergence of `run_blackhole_interp_to_cancel_tracing`
-            // (`pyjitpl.py:2949`), minus the inner-frame reconstruction.
-            if matches!(e, DispatchError::AbortPermanentMarkerReached { .. })
-                && is_top_inline
-                && fbw_concrete_heap_write_count() == concrete_writes_before
+            // sub-walk's allocations.  Any doubt keeps the legacy replay — the
+            // honest residual (the inner-frame rebuild is #126/#215).
+            if matches!(
+                e,
+                DispatchError::AbortPermanentMarkerReached { .. }
+                    | DispatchError::LoopBearingCalleeInlineUnsupported { .. }
+            ) && is_top_inline
+                && !unjournaled_before_subwalk
+                && fbw_executed_effect_count() == executed_effects_before
             {
                 if let Some(call_pc) = abort_flush_call_py_pc {
                     let fresh = read_ref_var_list_concrete(code, op, 1, ctx);
@@ -13994,7 +13988,7 @@ fn try_walker_inline_user_call(
             // those side effects twice at trace time.  A side-effect-free
             // prologue (the common loop-setup-only case) still inlines.
             if fbw_store_journal_len() > prologue_journal_before
-                || (!prologue_effect_before && fbw_has_unjournaled_effect())
+                || (!unjournaled_before_subwalk && fbw_has_unjournaled_effect())
             {
                 return Err(DispatchError::LoopBearingCalleeInlineUnsupported { pc: op.pc });
             }

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -332,6 +332,17 @@ impl<'a> RawDescrPool<'a> {
     }
 }
 
+/// A callee local slot's recording-time concrete, tagged with the frame
+/// register it was written through. Own-frame reads (`getarrayitem_vable`) and
+/// the mid-body live-value recovery only honor an entry whose `frame_reg`
+/// matches the frame they resolve against, so a value stored to another frame's
+/// same-indexed slot never leaks across a frame identity.
+#[derive(Clone, Copy)]
+pub struct CalleeLocalConcrete {
+    pub frame_reg: u16,
+    pub value: majit_ir::Value,
+}
+
 /// Per-inline-level callee locals shadow owned by the walking frame
 /// (`MIFrame.registers_i/r/f`, `pyjitpl.py:177-234`).
 ///
@@ -351,8 +362,10 @@ pub struct CalleeLocalsShadow {
     /// `pypy/interpreter/pycode.py:275`).
     pub opref: std::collections::HashMap<i64, OpRef>,
     /// Recording-time concrete held by each local slot, including across
-    /// may-force operations that clear the heapcache.
-    pub concrete: std::collections::HashMap<i64, majit_ir::Value>,
+    /// may-force operations that clear the heapcache. Each entry records the
+    /// frame register it was written through so a slot read resolves against
+    /// its own frame only.
+    pub concrete: std::collections::HashMap<i64, CalleeLocalConcrete>,
     /// Portal frame register used to resolve own-frame vable operations.
     /// `u16::MAX` means that the strict fresh-frame fold is inactive.
     pub fold_frame_reg: u16,
@@ -379,12 +392,13 @@ impl CalleeLocalsShadow {
     }
 
     /// A `Void` value clears the slot so a later read does not resurrect a
-    /// stale concrete.
-    fn set_concrete(&mut self, slot: i64, value: majit_ir::Value) {
+    /// stale concrete. `frame_reg` is the frame register the write targeted.
+    fn set_concrete(&mut self, frame_reg: u16, slot: i64, value: majit_ir::Value) {
         if matches!(value, majit_ir::Value::Void) {
             self.concrete.remove(&slot);
         } else {
-            self.concrete.insert(slot, value);
+            self.concrete
+                .insert(slot, CalleeLocalConcrete { frame_reg, value });
         }
     }
 }
@@ -2950,11 +2964,11 @@ pub(crate) fn drive_bridge_carrier_subwalk(
         // self-recursive call's int arg is known (`arg_is_int`) and the call
         // folds to `CALL_ASSEMBLER` instead of declining.
         for (slot, &v) in local_concretes.iter().enumerate() {
-            sub_wc
-                .callee_shadow
-                .as_mut()
-                .unwrap()
-                .set_concrete(slot as i64, v);
+            sub_wc.callee_shadow.as_mut().unwrap().set_concrete(
+                callee_pjc.metadata.portal_frame_reg,
+                slot as i64,
+                v,
+            );
         }
         walk(callee_code, entry, &mut sub_wc)
     };
@@ -4432,6 +4446,8 @@ fn getarrayitem_vable_via_metainterp(
         ctx.callee_shadow
             .as_ref()
             .and_then(|shadow| shadow.concrete.get(&index_value).copied())
+            .filter(|entry| entry.frame_reg == code[op.pc + 1] as u16)
+            .map(|entry| entry.value)
             .unwrap_or(Value::Void)
     } else {
         shadow_value
@@ -4503,7 +4519,7 @@ fn setarrayitem_vable_via_metainterp(
                 .unwrap_or(majit_ir::Value::Void);
             if let Some(shadow) = ctx.callee_shadow.as_mut() {
                 shadow.set_opref(slot, value);
-                shadow.set_concrete(slot, concrete);
+                shadow.set_concrete(fold_frame_reg, slot, concrete);
             }
             return Ok((DispatchOutcome::Continue, op.next_pc));
         }
@@ -4549,7 +4565,7 @@ fn setarrayitem_vable_via_metainterp(
     // Keep the inline concrete-locals shadow current so a later read of this
     // slot (after a may-force op clears the heapcache) recovers the concrete.
     if let Some(shadow) = ctx.callee_shadow.as_mut() {
-        shadow.set_concrete(index_value, concrete);
+        shadow.set_concrete(code[op.pc + 1] as u16, index_value, concrete);
     }
     walker_capture_inline_nonstandard_vable_guard(ctx, op.pc, guards_before)?;
     // #73 (SLICE 1, INERT): a Ref stored to the operand-stack region of the
@@ -8406,6 +8422,92 @@ fn fbw_structural_abort_opcode_is_effect_free(pc: usize) -> bool {
 
 fn exact_first_jit_anchor(first_jit_pc_by_py_pc: &[usize], py_pc: usize, jit_pc: usize) -> bool {
     first_jit_pc_by_py_pc.get(py_pc).copied() == Some(jit_pc)
+}
+
+/// Admit a marker at the semantic head of a portal-shaped Python opcode.
+/// `serialize_op` keeps the first op for a Python pc, so the
+/// `setfield_vable_i(last_instr)` emitted immediately before
+/// `abort_permanent` owns the exact anchor slot. The write is entry
+/// bookkeeping: forward interpretation repeats it before executing the
+/// unsupported opcode. Anything except that same-pc write to this portal
+/// frame declines.
+fn portal_marker_first_jit_anchor(
+    first_jit_pc_by_py_pc: &[usize],
+    built_as_portal: bool,
+    portal_frame_reg: u16,
+    perfn_descrs: &[majit_metainterp::jitcode::RuntimeBhDescr],
+    code: &[u8],
+    py_pc: usize,
+    jit_pc: usize,
+    mut python_pc_for_op: impl FnMut(usize) -> usize,
+) -> bool {
+    if exact_first_jit_anchor(first_jit_pc_by_py_pc, py_pc, jit_pc) {
+        return true;
+    }
+    if !built_as_portal || portal_frame_reg > u8::MAX as u16 {
+        return false;
+    }
+    let Some(mut pc) = first_jit_pc_by_py_pc.get(py_pc).copied() else {
+        return false;
+    };
+    if pc == usize::MAX || pc >= jit_pc {
+        return false;
+    }
+    while pc < jit_pc {
+        let Some(op) = crate::jitcode_runtime::decode_op_at(code, pc) else {
+            return false;
+        };
+        if op.next_pc > jit_pc
+            || python_pc_for_op(op.pc) != py_pc
+            || op.key != "setfield_vable_i/rid"
+            || code.get(op.pc + 1).copied() != Some(portal_frame_reg as u8)
+        {
+            return false;
+        }
+        // `rid`: opcode, frame reg, value reg, little-endian descr index.
+        let Some((&lo, &hi)) = code.get(op.pc + 3).zip(code.get(op.pc + 4)) else {
+            return false;
+        };
+        let descr_index = lo as usize | ((hi as usize) << 8);
+        if !matches!(
+            perfn_descrs.get(descr_index),
+            Some(majit_metainterp::jitcode::RuntimeBhDescr::Descr(
+                majit_translate::jitcode::BhDescr::VableField { index: 0 }
+            ))
+        ) {
+            return false;
+        }
+        pc = op.next_pc;
+    }
+    pc == jit_pc
+}
+
+/// Read one exact Ref slot from a callee sub-walk's fresh-frame virtualizable
+/// shadow. The shadow's `fold_frame_reg` witnesses the strict-fold shape; an
+/// entry whose recorded `frame_reg` matches witnesses the live multi-frame
+/// inline shape. A foreign frame, missing, non-Ref, or null value is ambiguous
+/// and declines.
+fn callee_vable_ref_at(
+    shadow: Option<&CalleeLocalsShadow>,
+    frame_reg: u16,
+    slot: usize,
+) -> Option<ConcreteValue> {
+    if frame_reg == u16::MAX {
+        return None;
+    }
+    let shadow = shadow?;
+    let entry = shadow.concrete.get(&(slot as i64)).copied()?;
+    let strict_fold_witness = shadow.fold_frame_reg == frame_reg;
+    let inline_scope_witness = entry.frame_reg == frame_reg;
+    if !strict_fold_witness && !inline_scope_witness {
+        return None;
+    }
+    match entry.value {
+        Value::Ref(r) if r.as_usize() != 0 => {
+            Some(ConcreteValue::Ref(r.as_usize() as pyre_object::PyObjectRef))
+        }
+        Value::Int(_) | Value::Float(_) | Value::Ref(_) | Value::Void => None,
+    }
 }
 
 /// gh#467 bump the executed-effect odometer (see [`FBW_EXECUTED_EFFECT_COUNT`]).
@@ -14034,7 +14136,7 @@ fn try_walker_inline_user_call(
                     .unwrap_or(majit_ir::Value::Void);
                 let shadow = sub_wc.callee_shadow.as_mut().unwrap();
                 shadow.set_opref(slot, value);
-                shadow.set_concrete(slot, concrete);
+                shadow.set_concrete(callee_portal_frame_reg, slot, concrete);
             }
         }
         // Path-1: resolve scalar static-field reads off this callee's own
@@ -14071,11 +14173,24 @@ fn try_walker_inline_user_call(
                     let callee_pjc = crate::state::pyjitcode_for_code(w_code)?;
                     let metadata = &callee_pjc.metadata;
                     let callee_py_pc = python_pc_for_jitcode_pc(metadata, abort_pc) as usize;
-                    if !exact_first_jit_anchor(
-                        &metadata.first_jit_pc_by_py_pc,
-                        callee_py_pc,
-                        abort_pc,
-                    ) {
+                    let anchor_ok = match abort_kind {
+                        MidBodyAbortKind::Structural => exact_first_jit_anchor(
+                            &metadata.first_jit_pc_by_py_pc,
+                            callee_py_pc,
+                            abort_pc,
+                        ),
+                        MidBodyAbortKind::Marker => portal_marker_first_jit_anchor(
+                            &metadata.first_jit_pc_by_py_pc,
+                            metadata.built_as_portal,
+                            metadata.portal_frame_reg,
+                            callee_perfn_descrs,
+                            body.code,
+                            callee_py_pc,
+                            abort_pc,
+                            |op_pc| python_pc_for_jitcode_pc(metadata, op_pc) as usize,
+                        ),
+                    };
+                    if !anchor_ok {
                         return None;
                     }
                     let raw = unsafe {
@@ -14093,14 +14208,31 @@ fn try_walker_inline_user_call(
                     {
                         return None;
                     }
-                    let depth = metadata.depth_at_py_pc.get(callee_py_pc).copied()? as usize;
+                    let Some(depth) = metadata.depth_at_py_pc.get(callee_py_pc).copied() else {
+                        return None;
+                    };
+                    let depth = depth as usize;
                     let nlocals = callee_code.varnames.len();
-                    let entries = metadata.pcdep_color_slots.get(callee_py_pc)?;
+                    let Some(entries) = metadata.pcdep_color_slots.get(callee_py_pc) else {
+                        return None;
+                    };
                     let mut live_stack = Vec::with_capacity(depth);
                     for rel in 0..depth {
-                        let color =
-                            crate::state::semantic_slot_color_for_ref_slot(entries, nlocals + rel)?;
-                        let value = *sub_wc.concrete_registers_r.get(color)?;
+                        let semantic_slot = nlocals + rel;
+                        let register_value =
+                            crate::state::semantic_slot_color_for_ref_slot(entries, semantic_slot)
+                                .and_then(|color| sub_wc.concrete_registers_r.get(color).copied());
+                        let value = register_value.or_else(|| {
+                            (metadata.built_as_portal && abort_kind == MidBodyAbortKind::Marker)
+                                .then(|| {
+                                    callee_vable_ref_at(
+                                        sub_wc.callee_shadow.as_ref(),
+                                        metadata.portal_frame_reg,
+                                        semantic_slot,
+                                    )
+                                })
+                                .flatten()
+                        })?;
                         if !matches!(value, ConcreteValue::Ref(r) if !r.is_null()) {
                             return None;
                         }
@@ -14115,8 +14247,12 @@ fn try_walker_inline_user_call(
                         if !lv.is_local_live(callee_py_pc, slot) {
                             continue;
                         }
-                        let value = fbw_callee_local_get_concrete(slot as i64)
-                            .and_then(|value| match value {
+                        let value = sub_wc
+                            .callee_shadow
+                            .as_ref()
+                            .and_then(|shadow| shadow.concrete.get(&(slot as i64)).copied())
+                            .filter(|entry| entry.frame_reg == metadata.portal_frame_reg)
+                            .and_then(|entry| match entry.value {
                                 Value::Ref(r) => Some(ConcreteValue::Ref(
                                     r.as_usize() as pyre_object::PyObjectRef
                                 )),
@@ -31582,5 +31718,100 @@ mod tests {
         assert!(super::exact_first_jit_anchor(&first, 28, 101));
         assert!(!super::exact_first_jit_anchor(&first, 28, 102));
         assert!(!super::exact_first_jit_anchor(&first, 27, 101));
+    }
+
+    #[test]
+    fn portal_marker_anchor_accepts_only_same_pc_last_instr_bookkeeping() {
+        use majit_metainterp::jitcode::RuntimeBhDescr;
+        use majit_translate::jitcode::BhDescr;
+
+        let setfield = *insns_opname_to_byte()
+            .get("setfield_vable_i/rid")
+            .expect("setfield_vable_i must exist");
+        let abort = *insns_opname_to_byte()
+            .get("abort_permanent/")
+            .expect("abort_permanent must exist");
+        let int_copy = *insns_opname_to_byte()
+            .get("int_copy/c>i")
+            .expect("int_copy/c>i must exist");
+        let descrs = [RuntimeBhDescr::Descr(BhDescr::VableField { index: 0 })];
+        let mut first = vec![usize::MAX; 30];
+        first[29] = 0;
+        let portal_gap = [setfield, 1, 7, 0, 0, abort];
+
+        assert!(super::portal_marker_first_jit_anchor(
+            &first,
+            true,
+            1,
+            &descrs,
+            &portal_gap,
+            29,
+            5,
+            |_| 29,
+        ));
+        assert!(!super::portal_marker_first_jit_anchor(
+            &first,
+            true,
+            1,
+            &descrs,
+            &portal_gap,
+            29,
+            5,
+            |_| 28,
+        ));
+
+        let computation_gap = [int_copy, 1, 7, abort];
+        assert!(!super::portal_marker_first_jit_anchor(
+            &first,
+            true,
+            1,
+            &descrs,
+            &computation_gap,
+            29,
+            3,
+            |_| 29,
+        ));
+
+        first[29] = 5;
+        assert!(super::portal_marker_first_jit_anchor(
+            &first,
+            false,
+            u16::MAX,
+            &[],
+            &portal_gap,
+            29,
+            5,
+            |_| 29,
+        ));
+    }
+
+    #[test]
+    fn callee_vable_ref_gates_on_frame_register_identity() {
+        use majit_ir::{GcRef, Value};
+
+        let ref_value = Value::Ref(GcRef(0x1000));
+        let mut shadow = super::CalleeLocalsShadow::default();
+        shadow.set_concrete(1, 3, ref_value);
+
+        // An entry recorded through frame reg 1 resolves for that frame only.
+        assert!(matches!(
+            super::callee_vable_ref_at(Some(&shadow), 1, 3),
+            Some(ConcreteValue::Ref(value)) if value as usize == 0x1000
+        ));
+        // A foreign frame register declines (no strict-fold witness either).
+        assert_eq!(super::callee_vable_ref_at(Some(&shadow), 2, 3), None);
+
+        // The strict-fold witness admits the slot even when the recorded writer
+        // frame differs from the queried frame.
+        shadow.fold_frame_reg = 2;
+        assert!(matches!(
+            super::callee_vable_ref_at(Some(&shadow), 2, 3),
+            Some(ConcreteValue::Ref(value)) if value as usize == 0x1000
+        ));
+
+        // A missing slot, the `u16::MAX` sentinel, and an absent shadow decline.
+        assert_eq!(super::callee_vable_ref_at(Some(&shadow), 1, 4), None);
+        assert_eq!(super::callee_vable_ref_at(Some(&shadow), u16::MAX, 3), None);
+        assert_eq!(super::callee_vable_ref_at(None, 1, 3), None);
     }
 }

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -6134,6 +6134,12 @@ fn try_execute_residual_call_via_executor(
     // builtin FOR_ITER stays modeled.
     let foriter_frame_snapshot = (helper == majit_ir::PyreHelperKind::ForIterNext)
         .then(pyre_interpreter::call::frame_entry_count);
+    // gh#467: sample the user-frame odometer UNCONDITIONALLY (not only under an
+    // in-flight FOR_ITER) so the concrete-heap-write gate can detect a callee
+    // sub-walk mutation committed through a value-returning dunder body — the
+    // same user-frame signal Finding #1 uses, generalized past FOR_ITER.
+    let heap_write_odometer_before =
+        (!provably_side_effect_free).then(pyre_interpreter::call::frame_entry_count);
     let exec_result = {
         let _suspend = majit_metainterp::TraceContinuationSuspendGuard::enter();
         majit_metainterp::executor::execute_residual_call(call_descr, func_ptr, &args)
@@ -6203,6 +6209,20 @@ fn try_execute_residual_call_via_executor(
             );
         }
         fbw_mark_foriter_body_effect_since_consume();
+    }
+    // gh#467: bump the concrete-heap-write odometer for any residual that is not
+    // provably side-effect-free and either writes live heap (a Void / mutator-
+    // tagged store the store/append journals do not cover) or entered a user
+    // Python frame (a value-returning getter/dunder body that may have mutated).
+    // The inline abort-forward-flush gate snapshots this at the CALL and refuses
+    // the forward flush if a callee sub-walk moved it — re-executing the CALL
+    // would double the effect.
+    if !provably_side_effect_free
+        && (writes_live_heap
+            || heap_write_odometer_before
+                .is_some_and(|before| pyre_interpreter::call::frame_entry_count() != before))
+    {
+        fbw_bump_concrete_heap_write();
     }
     // #73/#267: a user-defined iterator's FOR_ITER runs its item producer
     // (`__next__`/`__getitem__`) as an inline sub-walk whose operand-stack
@@ -7854,6 +7874,34 @@ thread_local! {
     /// the recorded effect.
     static FBW_UNJOURNALED_EFFECT: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
 
+    /// gh#467 concrete-heap-write odometer: bumped whenever the walk applies a
+    /// heap mutation the store/append/cell journals do NOT cover — a Void /
+    /// mutator-tagged residual executed concretely by
+    /// [`try_execute_residual_call_via_executor`], a residual whose concrete
+    /// run entered a user Python frame (a value-returning dunder that may
+    /// mutate), or an unexecutable residual flagged via
+    /// [`fbw_mark_unjournaled_effect`].  Unlike [`FBW_UNJOURNALED_EFFECT`] (a
+    /// monotone bool) this is a COUNT, so a callee sub-walk's OWN concrete
+    /// effect is detectable even when a prior (pre-CALL) effect already tripped
+    /// the bool.  Read only by the inline abort-forward-flush gate
+    /// (`try_walker_inline_user_call` / gh#467): snapshot at the CALL, compare
+    /// after the sub-walk aborts — a nonzero delta means the callee committed
+    /// an irreversible effect, so re-executing the CALL would double it.
+    static FBW_CONCRETE_HEAP_WRITE_COUNT: std::cell::Cell<usize> =
+        const { std::cell::Cell::new(0) };
+
+    /// gh#467 inline-abort forward-flush carrier: latched by
+    /// [`try_walker_inline_user_call`] when an `abort_permanent` marker fires
+    /// inside a TOP-level inline sub-walk whose callee committed no heap effect.
+    /// Holds `(outer CALL python pc, [callable, null_or_self, args...])` — the
+    /// exact operand stack the interpreter's CALL opcode expects — so the walk
+    /// driver can flush the outer frame AT that CALL and resume the interpreter
+    /// forward (re-executing the callee from scratch) instead of rolling back
+    /// and replaying the loop body from entry.  The `PyObjectRef`s are rooted by
+    /// [`fbw_store_journal_root_walker`] across the abort unwind's allocations.
+    static FBW_ABORT_CALL_RESUME: std::cell::RefCell<Option<(usize, Vec<pyre_object::PyObjectRef>)>> =
+        const { std::cell::RefCell::new(None) };
+
     /// B3 (`PYRE_FBW_RAISE`): the set of OpRefs the walker built inline via
     /// [`try_walker_trace_exception_new`] (the virtualizable `NewWithVtable`
     /// exception).  Mirrors the trait's `sym.trace_built_exc`
@@ -7912,6 +7960,10 @@ pub(crate) fn fbw_store_journal_reset() {
     FBW_APPEND_JOURNAL.with(|j| j.borrow_mut().clear());
     FBW_CELL_STORE_JOURNAL.with(|j| j.borrow_mut().clear());
     FBW_UNJOURNALED_EFFECT.with(|c| c.set(false));
+    // gh#467: reset the concrete-heap-write odometer and any stale
+    // forward-flush carrier a prior aborted walk latched.
+    FBW_CONCRETE_HEAP_WRITE_COUNT.with(|c| c.set(0));
+    FBW_ABORT_CALL_RESUME.with(|c| *c.borrow_mut() = None);
     // #57 Option C: drop any in-flight FOR_ITER items a prior aborted walk
     // left undelivered (its live frame already consumed the delivery), so a
     // stale item cannot be re-delivered by this walk's abort.  This also
@@ -7938,6 +7990,10 @@ pub(crate) fn fbw_store_journal_push(
     displaced: pyre_object::PyObjectRef,
 ) {
     FBW_STORE_JOURNAL.with(|j| j.borrow_mut().push([list, key, displaced]));
+    // gh#467: a journaled store still mutated the heap this iteration; the
+    // forward-flush gate counts it so a callee sub-walk that appends/setitems
+    // cannot be committed-then-re-executed (a double).
+    fbw_bump_concrete_heap_write();
 }
 
 /// Record the live length a walked eager list append grew past, for the
@@ -7948,6 +8004,8 @@ pub(crate) fn fbw_store_journal_push(
 // (`try_walker_orthodox_list_append`).
 pub(crate) fn fbw_append_journal_push(list: pyre_object::PyObjectRef, length_before: usize) {
     FBW_APPEND_JOURNAL.with(|j| j.borrow_mut().push((list, length_before)));
+    // gh#467: see `fbw_store_journal_push`.
+    fbw_bump_concrete_heap_write();
 }
 
 /// Record the `intvalue` a walked eager `IntMutableCell` store displaces,
@@ -7962,6 +8020,8 @@ pub(crate) fn fbw_cell_store_journal_push(cell: pyre_object::PyObjectRef, intval
         );
     }
     FBW_CELL_STORE_JOURNAL.with(|j| j.borrow_mut().push((cell, intvalue_before)));
+    // gh#467: see `fbw_store_journal_push`.
+    fbw_bump_concrete_heap_write();
 }
 
 /// Commit-path epilogue: the walk's eager stores and appends stand; drop
@@ -8283,6 +8343,31 @@ pub(crate) fn fbw_store_journal_len() -> usize {
 /// the legacy replay applies (see [`FBW_UNJOURNALED_EFFECT`]).
 pub(crate) fn fbw_mark_unjournaled_effect() {
     FBW_UNJOURNALED_EFFECT.with(|c| c.set(true));
+    // gh#467: an unexecutable residual is also a non-journaled effect the
+    // forward-flush gate must count, so a callee that hits one is detected even
+    // when the monotone bool was already set by a pre-CALL effect.
+    fbw_bump_concrete_heap_write();
+}
+
+/// gh#467 concrete-heap-write odometer read (see [`FBW_CONCRETE_HEAP_WRITE_COUNT`]).
+pub(crate) fn fbw_concrete_heap_write_count() -> usize {
+    FBW_CONCRETE_HEAP_WRITE_COUNT.with(|c| c.get())
+}
+
+/// gh#467 bump the concrete-heap-write odometer (see [`FBW_CONCRETE_HEAP_WRITE_COUNT`]).
+pub(crate) fn fbw_bump_concrete_heap_write() {
+    FBW_CONCRETE_HEAP_WRITE_COUNT.with(|c| c.set(c.get() + 1));
+}
+
+/// gh#467 latch the inline-abort forward-flush carrier (see [`FBW_ABORT_CALL_RESUME`]).
+pub(crate) fn fbw_set_abort_call_resume(call_pc: usize, stack: Vec<pyre_object::PyObjectRef>) {
+    FBW_ABORT_CALL_RESUME.with(|c| *c.borrow_mut() = Some((call_pc, stack)));
+}
+
+/// gh#467 take the inline-abort forward-flush carrier, clearing it (see
+/// [`FBW_ABORT_CALL_RESUME`]).
+pub(crate) fn fbw_take_abort_call_resume() -> Option<(usize, Vec<pyre_object::PyObjectRef>)> {
+    FBW_ABORT_CALL_RESUME.with(|c| c.borrow_mut().take())
 }
 
 /// An unexecutable residual call (`try_execute_residual_call_via_executor`
@@ -8361,6 +8446,19 @@ pub fn fbw_store_journal_root_walker(visitor: &mut dyn FnMut(&mut majit_ir::GcRe
             // SAFETY: as above — only the `PyObjectRef` slot is a root; the
             // `usize` body pc and the bool flag are plain scalars.
             visitor(unsafe { &mut *(&mut entry.item as *mut pyre_object::PyObjectRef).cast() });
+        }
+    });
+    // gh#467: the latched forward-flush operand stack (callable + args) is
+    // nursery-resident across the abort unwind — the flush boxes Int/Float
+    // locals, which can trigger a minor collection that moves these refs before
+    // they are written into the frame array — so forward every slot as a root.
+    FBW_ABORT_CALL_RESUME.with(|c| {
+        if let Some((_call_pc, stack)) = c.borrow_mut().as_mut() {
+            for slot in stack.iter_mut() {
+                // SAFETY: `PyObjectRef` and `GcRef` share the usize repr; the
+                // borrow keeps the Vec storage alive for the visit.
+                visitor(unsafe { &mut *(slot as *mut pyre_object::PyObjectRef).cast() });
+            }
         }
     });
 }
@@ -13600,6 +13698,46 @@ fn try_walker_inline_user_call(
     // side-effecting prologue must decline the CA inline (see the arm).
     let prologue_journal_before = fbw_store_journal_len();
     let prologue_effect_before = fbw_has_unjournaled_effect();
+    // gh#467 forward-flush gate snapshot: the concrete-heap-write odometer AT
+    // the CALL (after this iteration's pre-CALL effects, before the callee
+    // sub-walk).  If the sub-walk aborts on an `abort_permanent` marker WITHOUT
+    // moving this odometer, the callee committed nothing irreversible, so the
+    // walk driver may flush the outer frame at this CALL and re-execute the call
+    // forward instead of replaying the loop from entry (which double-applies the
+    // non-journaled pre-CALL store).  Latched only at the TOP inline level: the
+    // flushed frame is the top-level `cf_addr`, whose operand stack is THIS
+    // call's `[callable, null_or_self, args...]`.  Mirrors the convergence of
+    // `run_blackhole_interp_to_cancel_tracing` (`pyjitpl.py:2949`), minus the
+    // inner-frame rebuild (#126/#215).
+    let concrete_writes_before = fbw_concrete_heap_write_count();
+    let is_top_inline = !INLINE_SUBWALK_CAPTURE_BOUNDARY.with(|c| c.get());
+    // The outer CALL's python pc in the TOP-level frame's code, derived from the
+    // FBW snapshot sym at this residual_call's jitcode pc (`op.pc`) — the same
+    // coordinate `call_site_py_pc` below computes.  `None` outside the FBW
+    // top-inline path (no forward flush there).
+    let abort_flush_call_py_pc: Option<usize> = if ctx.is_full_body_walk && is_top_inline {
+        let sym_ptr = FULL_BODY_SNAPSHOT_SYM.with(|c| c.get());
+        if sym_ptr.is_null() {
+            None
+        } else {
+            let sym = unsafe { &*sym_ptr };
+            if sym.jitcode.is_null() {
+                None
+            } else {
+                unsafe {
+                    let jc = &*sym.jitcode;
+                    let mut py = python_pc_for_jitcode_pc(&jc.payload.metadata, op.pc);
+                    if !jc.payload.code_ptr.is_null() {
+                        let codeobj = &*jc.payload.code_ptr;
+                        py = skip_python_trivia_forward(codeobj, py as usize) as u32;
+                    }
+                    Some(py as usize)
+                }
+            }
+        }
+    } else {
+        None
+    };
     // Compute fresh outer_active_boxes for the inline sub-walk when the
     // parent FBW walk carries an empty set (`dispatch_via_miframe`
     // initializes `outer_active_boxes: Vec::new()`; it is computed
@@ -13757,19 +13895,63 @@ fn try_walker_inline_user_call(
         // callee sub-walk so its branch guards capture both frames (no-op when
         // `parent_frame` is None — the strict straight-line inline path).
         let _parent_frame_guard = parent_frame.map(InlineParentFrameGuard::enter);
-        let (outcome, _end_pc) = match walk(body.code, 0, &mut sub_wc) {
-            Ok(v) => v,
-            Err(e) => {
-                if std::env::var("PYRE_FBW_INLINE_DIAG").is_ok() {
-                    eprintln!("[inline-abort] callee sub-walk err: {e:?}");
-                }
-                return Err(e);
+        // Yield the walk Result; `sub_wc` (and the RAII guards) drop at the
+        // block end so the outer `ctx` is borrowable again for the gh#467
+        // forward-flush re-read below.
+        walk(body.code, 0, &mut sub_wc)
+    };
+    let (outcome, _end_pc) = match callee_outcome {
+        Ok(v) => v,
+        Err(e) => {
+            if std::env::var("PYRE_FBW_INLINE_DIAG").is_ok() {
+                eprintln!("[inline-abort] callee sub-walk err: {e:?}");
             }
-        };
-        outcome
+            // gh#467: an `abort_permanent` marker fired inside this top-level
+            // inline sub-walk.  If the callee committed NO irreversible heap
+            // effect (the concrete-heap-write odometer is unmoved since the
+            // CALL), latch the outer CALL boundary so the walk driver flushes
+            // the outer frame there and re-executes the call FORWARD — running
+            // the callee from scratch in the interpreter — instead of rolling
+            // back and replaying the loop from entry, which double-applies the
+            // non-journaled pre-CALL store (the gh#467 defect).  The operand
+            // stack the CALL opcode expects (`[callable, null_or_self,
+            // args...]`) is re-read from the (now GC-forwarded) outer registers,
+            // not the pre-sub-walk `arg_concretes`, so it is current after the
+            // sub-walk's allocations.  A callee that DID commit an effect
+            // (odometer moved) keeps the legacy replay — the honest residual
+            // (the inner-frame rebuild is #126/#215).  This is the intermediate
+            // convergence of `run_blackhole_interp_to_cancel_tracing`
+            // (`pyjitpl.py:2949`), minus the inner-frame reconstruction.
+            if matches!(e, DispatchError::AbortPermanentMarkerReached { .. })
+                && is_top_inline
+                && fbw_concrete_heap_write_count() == concrete_writes_before
+            {
+                if let Some(call_pc) = abort_flush_call_py_pc {
+                    let fresh = read_ref_var_list_concrete(code, op, 1, ctx);
+                    let mut stack = Vec::with_capacity(fresh.len());
+                    let mut all_ref = !fresh.is_empty();
+                    for c in &fresh {
+                        match c {
+                            ConcreteValue::Ref(r) => stack.push(*r),
+                            _ => {
+                                all_ref = false;
+                                break;
+                            }
+                        }
+                    }
+                    // The top-of-stack callable slot must be a real object; a
+                    // non-Ref anywhere means the reconstruction is unreliable, so
+                    // decline (the legacy replay is always sound).
+                    if all_ref && stack.first().is_some_and(|c| !c.is_null()) {
+                        fbw_set_abort_call_resume(call_pc, stack);
+                    }
+                }
+            }
+            return Err(e);
+        }
     };
 
-    match callee_outcome {
+    match outcome {
         DispatchOutcome::SubReturn {
             result: Some(value),
         } => {

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -1430,7 +1430,20 @@ pub fn step(
     // unless the full-body walk owns the virtualizable shadow and the
     // mirror is still valid.
     step_vstack_mirror(ctx, pc);
-    handle(&op, code, ctx)
+    let effects_before = fbw_executed_effect_count();
+    let result = handle(&op, code, ctx);
+    if matches!(
+        result,
+        Err(DispatchError::LoopBearingCalleeInlineUnsupported { .. })
+    ) {
+        FBW_STRUCTURAL_ABORT_OPCODE_EFFECTS.with(|c| {
+            c.set(Some((
+                op.pc,
+                fbw_executed_effect_count().saturating_sub(effects_before),
+            )))
+        });
+    }
+    result
 }
 
 /// Walk the code from `start_pc` until a terminating opcode fires.
@@ -7887,6 +7900,15 @@ thread_local! {
     static FBW_EXECUTED_EFFECT_COUNT: std::cell::Cell<usize> =
         const { std::cell::Cell::new(0) };
 
+    /// Effect-count delta of the exact JitCode opcode that most recently
+    /// returned `LoopBearingCalleeInlineUnsupported`.  The structural
+    /// mid-body carrier accepts only a zero delta: pyre re-runs the enclosing
+    /// Python opcode boundary, unlike byte-exact `blackhole_from_resumedata`
+    /// (`pyjitpl.py:2949`), so any already-applied effect in that opcode must
+    /// keep the legacy path.
+    static FBW_STRUCTURAL_ABORT_OPCODE_EFFECTS: std::cell::Cell<Option<(usize, usize)>> =
+        const { std::cell::Cell::new(None) };
+
     /// gh#467 inline-abort forward-flush carrier: latched by
     /// [`try_walker_inline_user_call`] when a supported abort fires inside a
     /// TOP-level inline sub-walk whose callee executed no concrete effect.
@@ -7942,8 +7964,15 @@ pub(crate) enum InlineAbortCarrier {
     MidBody(MidBodyPayload),
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum MidBodyAbortKind {
+    Marker,
+    Structural,
+}
+
 #[derive(Clone, Debug)]
 pub(crate) struct MidBodyPayload {
+    pub abort_kind: MidBodyAbortKind,
     pub call_py_pc: usize,
     pub post_call_py_pc: usize,
     pub call_stack_len: usize,
@@ -7983,6 +8012,7 @@ pub(crate) fn fbw_store_journal_reset() {
     // gh#467: reset the executed-effect odometer and any stale
     // forward-flush carrier a prior aborted walk latched.
     FBW_EXECUTED_EFFECT_COUNT.with(|c| c.set(0));
+    FBW_STRUCTURAL_ABORT_OPCODE_EFFECTS.with(|c| c.set(None));
     FBW_ABORT_CALL_RESUME.with(|c| *c.borrow_mut() = None);
     // #57 Option C: drop any in-flight FOR_ITER items a prior aborted walk
     // left undelivered (its live frame already consumed the delivery), so a
@@ -8368,6 +8398,14 @@ pub(crate) fn fbw_mark_unjournaled_effect() {
 /// gh#467 executed-effect odometer read (see [`FBW_EXECUTED_EFFECT_COUNT`]).
 pub(crate) fn fbw_executed_effect_count() -> usize {
     FBW_EXECUTED_EFFECT_COUNT.with(|c| c.get())
+}
+
+fn fbw_structural_abort_opcode_is_effect_free(pc: usize) -> bool {
+    FBW_STRUCTURAL_ABORT_OPCODE_EFFECTS.with(|c| c.get() == Some((pc, 0)))
+}
+
+fn exact_first_jit_anchor(first_jit_pc_by_py_pc: &[usize], py_pc: usize, jit_pc: usize) -> bool {
+    first_jit_pc_by_py_pc.get(py_pc).copied() == Some(jit_pc)
 }
 
 /// gh#467 bump the executed-effect odometer (see [`FBW_EXECUTED_EFFECT_COUNT`]).
@@ -13966,7 +14004,18 @@ fn try_walker_inline_user_call(
         // `_copy_data_from_miframe` preserves the callee's own position and
         // live registers instead of collapsing it onto the caller frame.
         let result = walk(body.code, 0, &mut sub_wc);
-        if let Err(DispatchError::AbortPermanentMarkerReached { pc: abort_pc }) = &result {
+        let midbody_abort = match &result {
+            Err(DispatchError::AbortPermanentMarkerReached { pc }) => {
+                Some((*pc, MidBodyAbortKind::Marker))
+            }
+            Err(DispatchError::LoopBearingCalleeInlineUnsupported { pc })
+                if fbw_structural_abort_opcode_is_effect_free(*pc) =>
+            {
+                Some((*pc, MidBodyAbortKind::Structural))
+            }
+            _ => None,
+        };
+        if let Some((abort_pc, abort_kind)) = midbody_abort {
             if is_top_inline
                 && !unjournaled_before_subwalk
                 && fbw_executed_effect_count() != executed_effects_before
@@ -13975,9 +14024,12 @@ fn try_walker_inline_user_call(
                     let call_py_pc = abort_flush_call_py_pc?;
                     let callee_pjc = crate::state::pyjitcode_for_code(w_code)?;
                     let metadata = &callee_pjc.metadata;
-                    let callee_py_pc = python_pc_for_jitcode_pc(metadata, *abort_pc) as usize;
-                    if metadata.first_jit_pc_by_py_pc.get(callee_py_pc).copied() != Some(*abort_pc)
-                    {
+                    let callee_py_pc = python_pc_for_jitcode_pc(metadata, abort_pc) as usize;
+                    if !exact_first_jit_anchor(
+                        &metadata.first_jit_pc_by_py_pc,
+                        callee_py_pc,
+                        abort_pc,
+                    ) {
                         return None;
                     }
                     let raw = unsafe {
@@ -14044,10 +14096,11 @@ fn try_walker_inline_user_call(
                         unsafe { &*outer_jc.payload.code_ptr },
                         call_py_pc + 1,
                     );
-                    let Some(ConcreteValue::Ref(x_arg)) = live_stack.first().copied() else {
+                    let Some(ConcreteValue::Ref(x_arg)) = arg_concretes.get(2).copied() else {
                         return None;
                     };
                     Some(MidBodyPayload {
+                        abort_kind,
                         call_py_pc,
                         post_call_py_pc,
                         call_stack_len: arg_concretes.len(),
@@ -31479,5 +31532,15 @@ mod tests {
             step(&code, 0, &mut wc),
             Err(DispatchError::JitMergePointGreenKeyUnresolved { pc: 0 })
         );
+    }
+
+    #[test]
+    fn structural_midbody_anchor_requires_exact_first_jit_pc() {
+        let mut first = vec![usize::MAX; 30];
+        first[28] = 101;
+        first[29] = 115;
+        assert!(super::exact_first_jit_anchor(&first, 28, 101));
+        assert!(!super::exact_first_jit_anchor(&first, 28, 102));
+        assert!(!super::exact_first_jit_anchor(&first, 27, 101));
     }
 }

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -3869,6 +3869,139 @@ pub(crate) fn flush_walk_end_state_to_frame_with_item(
     true
 }
 
+/// gh#467 forward-flush AT an inlined-callee CALL boundary.  When an
+/// `abort_permanent` marker fires inside an inline sub-walk whose callee
+/// committed no heap effect, the outer frame is flushed as of the CALL that
+/// entered the callee: the locals/cells region from the vable shadow (exactly
+/// like [`flush_walk_end_state_to_frame`]), the operand-stack region rebuilt
+/// from the concrete `call_stack` (`[callable, null_or_self, args...]` the
+/// walker holds), `valuestackdepth` set to cover both, and
+/// `last_instr = call_py_pc - 1` so `next_instr()` re-executes the CALL in the
+/// interpreter — running the callee from scratch.  Everything the walk applied
+/// BEFORE the CALL stands (the caller commits the store journals), so the
+/// non-journaled pre-CALL store applies exactly once.  This is the frame-level
+/// analogue of `run_blackhole_interp_to_cancel_tracing` (`pyjitpl.py:2949`)
+/// continuing forward from the abort, without the inner-frame reconstruction
+/// (#126/#215): the outer frame re-runs the whole call.
+///
+/// Unlike the merge-point flush, the operand stack does NOT come from the vable
+/// shadow (whose stack region is only valid at a merge point — at a mid-
+/// statement CALL those slots read NULL); it is the caller-provided
+/// `call_stack`, whose height MUST match the forward analysis's `depth_at_py_pc`
+/// at `call_py_pc` (a mismatch means the reconstruction disagrees with the
+/// encoded stack shape → decline).  All-or-nothing: returns false (frame
+/// untouched) on any depth mismatch, an unresolved live local, a net block-chain
+/// change, or insufficient array capacity; the caller then keeps the legacy
+/// replay.
+pub(crate) fn flush_walk_end_state_at_outer_call(
+    ctx: &TraceCtx,
+    frame: usize,
+    call_py_pc: usize,
+    call_stack: &[PyObjectRef],
+) -> bool {
+    if frame == 0 {
+        return false;
+    }
+    let Some(nlocals) = concrete_nlocals(frame) else {
+        return false;
+    };
+    let Some(info) = ctx.virtualizable_info() else {
+        return false;
+    };
+    let frame_ptr = frame as *const u8;
+    let w_code =
+        unsafe { *(frame_ptr.add(crate::frame_layout::PYFRAME_PYCODE_OFFSET) as *const *const ()) };
+    if w_code.is_null() {
+        return false;
+    }
+    let raw_code = unsafe {
+        pyre_interpreter::w_code_get_ptr(w_code as PyObjectRef)
+            as *const pyre_interpreter::CodeObject
+    };
+    // The analysis depth at the CALL pc is the live operand-stack height there
+    // (`callable + null_or_self + args`).  The reconstructed `call_stack` must
+    // match it exactly — a disagreement means the residual_call operand list
+    // does not model the interpreter's CALL stack for this call shape, so the
+    // resumed frame would be mis-sized.  Decline.
+    let Some(depth) = crate::liveness::liveness_for(raw_code)
+        .depth_at_py_pc()
+        .get(call_py_pc)
+        .copied()
+    else {
+        return false;
+    };
+    if depth as usize != call_stack.len() {
+        return false;
+    }
+    let end_vsd = nlocals + call_stack.len();
+    let base = info.num_static_extra_boxes;
+    // Block-chain net-change check (identical to `flush_walk_end_state_to_frame`):
+    // the flush writes only locals/stack/vsd/last_instr, so a push/pop inside the
+    // walked region would leave the adopted frame's chain inconsistent with its
+    // resumed pc.
+    let Some(lastblock_idx) = info
+        .static_fields
+        .iter()
+        .position(|f| f.name == "lastblock")
+    else {
+        return false;
+    };
+    let Some((_opref, shadow_lastblock)) = ctx.virtualizable_entry_at(lastblock_idx) else {
+        return false;
+    };
+    let frame_lastblock = unsafe { *(frame_ptr.add(PYFRAME_LASTBLOCK_OFFSET) as *const usize) };
+    match shadow_lastblock {
+        Value::Ref(r) => {
+            if r.0 != frame_lastblock {
+                return false;
+            }
+        }
+        _ => return false,
+    }
+    // Validation pass first (allocates nothing): every LOCAL slot must resolve
+    // in the shadow.  The stack region is supplied by `call_stack`, not the
+    // shadow, so it is not validated here.
+    for abs in 0..nlocals {
+        if ctx.virtualizable_entry_at(base + abs).is_none() {
+            return false;
+        }
+    }
+    let arr_ptr = unsafe {
+        *(frame_ptr.add(PYFRAME_LOCALS_CELLS_STACK_OFFSET)
+            as *const *mut pyre_object::FixedObjectArray)
+    };
+    if arr_ptr.is_null() || unsafe { &*arr_ptr }.as_slice().len() < end_vsd {
+        return false;
+    }
+    // Commit the operand stack FIRST: `call_stack` holds live nursery-resident
+    // refs, and boxing an Int/Float local below can trigger a minor collection.
+    // Once written into the (rooted) frame array they are forwarded with it, so
+    // landing them before any allocation keeps them current.
+    for (i, &value) in call_stack.iter().enumerate() {
+        unsafe {
+            (*arr_ptr).as_mut_slice()[nlocals + i] = value;
+        }
+    }
+    // Commit the locals from the shadow (re-reading per slot: boxing may move
+    // nursery objects, but each written slot is frame-reachable and the
+    // trace-ctx forwarding hook keeps the shadow current).
+    for abs in 0..nlocals {
+        let Some((_opref, value)) = ctx.virtualizable_entry_at(base + abs) else {
+            return false;
+        };
+        let boxed = boxed_slot_value_for_type(Type::Ref, &value);
+        unsafe {
+            (*arr_ptr).as_mut_slice()[abs] = boxed;
+        }
+    }
+    unsafe {
+        let pf = &mut *(frame as *mut PyFrame);
+        pf.valuestackdepth = end_vsd;
+        pf.last_instr = call_py_pc as isize - 1;
+    }
+    true
+}
+
 pub(crate) fn looks_like_heap_ref(value: PyObjectRef) -> bool {
     let addr = value as usize;
     let word_align = std::mem::align_of::<usize>() - 1;

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -4066,6 +4066,40 @@ pub(crate) fn can_flush_walk_end_state_after_outer_call(
     !arr_ptr.is_null() && unsafe { &*arr_ptr }.as_slice().len() >= nlocals + 1
 }
 
+/// Materialize the outer frame's locals from the virtualizable shadow.
+/// Callers must run their complete preflight before executing a rebuilt
+/// callee; after that point a failure would make replay unsafe.
+pub(crate) fn write_back_outer_locals(ctx: &TraceCtx, frame: usize) -> bool {
+    if frame == 0 {
+        return false;
+    }
+    let Some(nlocals) = concrete_nlocals(frame) else {
+        return false;
+    };
+    let Some(info) = ctx.virtualizable_info() else {
+        return false;
+    };
+    let frame_ptr = frame as *mut u8;
+    let arr_ptr = unsafe {
+        *(frame_ptr.add(PYFRAME_LOCALS_CELLS_STACK_OFFSET)
+            as *const *mut pyre_object::FixedObjectArray)
+    };
+    if arr_ptr.is_null() || unsafe { &*arr_ptr }.as_slice().len() < nlocals {
+        return false;
+    }
+    let base = info.num_static_extra_boxes;
+    for abs in 0..nlocals {
+        let Some((_opref, value)) = ctx.virtualizable_entry_at(base + abs) else {
+            return false;
+        };
+        let boxed = boxed_slot_value_for_type(Type::Ref, &value);
+        unsafe {
+            (*arr_ptr).as_mut_slice()[abs] = boxed;
+        }
+    }
+    true
+}
+
 /// `_setup_return_value_r` parity for the outer half of a two-frame abort:
 /// install the rebuilt callee's return value and resume after the CALL.
 pub(crate) fn flush_walk_end_state_after_outer_call(
@@ -4088,9 +4122,6 @@ pub(crate) fn flush_walk_end_state_after_outer_call(
     let Some(nlocals) = concrete_nlocals(frame) else {
         return false;
     };
-    let Some(info) = ctx.virtualizable_info() else {
-        return false;
-    };
     let frame_ptr = frame as *mut u8;
     let arr_ptr = unsafe {
         *(frame_ptr.add(PYFRAME_LOCALS_CELLS_STACK_OFFSET)
@@ -4100,15 +4131,8 @@ pub(crate) fn flush_walk_end_state_after_outer_call(
     unsafe {
         (*arr_ptr).as_mut_slice()[nlocals] = retval;
     }
-    let base = info.num_static_extra_boxes;
-    for abs in 0..nlocals {
-        let Some((_opref, value)) = ctx.virtualizable_entry_at(base + abs) else {
-            return false;
-        };
-        let boxed = boxed_slot_value_for_type(Type::Ref, &value);
-        unsafe {
-            (*arr_ptr).as_mut_slice()[abs] = boxed;
-        }
+    if !write_back_outer_locals(ctx, frame) {
+        return false;
     }
     unsafe {
         let pf = &mut *(frame as *mut PyFrame);

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -4002,6 +4002,122 @@ pub(crate) fn flush_walk_end_state_at_outer_call(
     true
 }
 
+/// Allocation-free preflight for the depth-1 post-CALL delivery. Every gate
+/// is checked before the rebuilt callee runs, so a later decline cannot replay
+/// effects the plain interpreter already committed.
+pub(crate) fn can_flush_walk_end_state_after_outer_call(
+    ctx: &TraceCtx,
+    frame: usize,
+    call_py_pc: usize,
+    post_call_py_pc: usize,
+    call_stack_len: usize,
+) -> bool {
+    if frame == 0 {
+        return false;
+    }
+    let Some(nlocals) = concrete_nlocals(frame) else {
+        return false;
+    };
+    let Some(info) = ctx.virtualizable_info() else {
+        return false;
+    };
+    let frame_ptr = frame as *const u8;
+    let w_code =
+        unsafe { *(frame_ptr.add(crate::frame_layout::PYFRAME_PYCODE_OFFSET) as *const *const ()) };
+    if w_code.is_null() {
+        return false;
+    }
+    let raw_code = unsafe {
+        pyre_interpreter::w_code_get_ptr(w_code as PyObjectRef)
+            as *const pyre_interpreter::CodeObject
+    };
+    if raw_code.is_null() {
+        return false;
+    }
+    let depths = crate::liveness::liveness_for(raw_code).depth_at_py_pc();
+    if depths.get(call_py_pc).copied().map(usize::from) != Some(call_stack_len)
+        || depths.get(post_call_py_pc).copied() != Some(1)
+    {
+        return false;
+    }
+    let Some(lastblock_idx) = info
+        .static_fields
+        .iter()
+        .position(|f| f.name == "lastblock")
+    else {
+        return false;
+    };
+    let Some((_opref, Value::Ref(shadow_lastblock))) = ctx.virtualizable_entry_at(lastblock_idx)
+    else {
+        return false;
+    };
+    let frame_lastblock = unsafe { *(frame_ptr.add(PYFRAME_LASTBLOCK_OFFSET) as *const usize) };
+    if shadow_lastblock.0 != frame_lastblock {
+        return false;
+    }
+    let base = info.num_static_extra_boxes;
+    if (0..nlocals).any(|abs| ctx.virtualizable_entry_at(base + abs).is_none()) {
+        return false;
+    }
+    let arr_ptr = unsafe {
+        *(frame_ptr.add(PYFRAME_LOCALS_CELLS_STACK_OFFSET)
+            as *const *mut pyre_object::FixedObjectArray)
+    };
+    !arr_ptr.is_null() && unsafe { &*arr_ptr }.as_slice().len() >= nlocals + 1
+}
+
+/// `_setup_return_value_r` parity for the outer half of a two-frame abort:
+/// install the rebuilt callee's return value and resume after the CALL.
+pub(crate) fn flush_walk_end_state_after_outer_call(
+    ctx: &TraceCtx,
+    frame: usize,
+    call_py_pc: usize,
+    post_call_py_pc: usize,
+    call_stack_len: usize,
+    retval: PyObjectRef,
+) -> bool {
+    if !can_flush_walk_end_state_after_outer_call(
+        ctx,
+        frame,
+        call_py_pc,
+        post_call_py_pc,
+        call_stack_len,
+    ) {
+        return false;
+    }
+    let Some(nlocals) = concrete_nlocals(frame) else {
+        return false;
+    };
+    let Some(info) = ctx.virtualizable_info() else {
+        return false;
+    };
+    let frame_ptr = frame as *mut u8;
+    let arr_ptr = unsafe {
+        *(frame_ptr.add(PYFRAME_LOCALS_CELLS_STACK_OFFSET)
+            as *const *mut pyre_object::FixedObjectArray)
+    };
+    // Land the nursery-resident result before boxing locals can collect.
+    unsafe {
+        (*arr_ptr).as_mut_slice()[nlocals] = retval;
+    }
+    let base = info.num_static_extra_boxes;
+    for abs in 0..nlocals {
+        let Some((_opref, value)) = ctx.virtualizable_entry_at(base + abs) else {
+            return false;
+        };
+        let boxed = boxed_slot_value_for_type(Type::Ref, &value);
+        unsafe {
+            (*arr_ptr).as_mut_slice()[abs] = boxed;
+        }
+    }
+    unsafe {
+        let pf = &mut *(frame as *mut PyFrame);
+        pf.valuestackdepth = nlocals + 1;
+        pf.last_instr = post_call_py_pc as isize - 1;
+    }
+    true
+}
+
 pub(crate) fn looks_like_heap_ref(value: PyObjectRef) -> bool {
     let addr = value as usize;
     let word_align = std::mem::align_of::<usize>() - 1;

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -3870,8 +3870,8 @@ pub(crate) fn flush_walk_end_state_to_frame_with_item(
 }
 
 /// gh#467 forward-flush AT an inlined-callee CALL boundary.  When an
-/// `abort_permanent` marker fires inside an inline sub-walk whose callee
-/// committed no heap effect, the outer frame is flushed as of the CALL that
+/// supported abort fires inside an inline sub-walk whose callee executed no
+/// concrete effect, the outer frame is flushed as of the CALL that
 /// entered the callee: the locals/cells region from the vable shadow (exactly
 /// like [`flush_walk_end_state_to_frame`]), the operand-stack region rebuilt
 /// from the concrete `call_stack` (`[callable, null_or_self, args...]` the

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -1597,8 +1597,9 @@ fn run_perfn_walk(
             }
         }
 
-        // `abort_permanent` marker abort (DELETE_FAST and the other
-        // emit_abort_permanent opcodes): the marker's contract is "resume
+        // Inline-callee forward abort, or an `abort_permanent` marker abort
+        // (DELETE_FAST and the other emit_abort_permanent opcodes).  The
+        // marker's contract is "resume
         // the interpreter AT this unsupported opcode and run it" — codewriter
         // stores `last_instr = py_pc - 1` for the blackhole.  On the
         // full-body walk that recorded write is discarded with the aborted
@@ -1607,24 +1608,36 @@ fn run_perfn_walk(
         // them from entry → double-execution (e.g. a `del`-bearing method
         // whose prior STORE_ATTR ran once during the walk, then again on
         // replay).  Flush the abort-point frame (locals + last_instr) so the
-        // portal resumes at the unsupported opcode instead of replaying —
-        // same mechanism and same no-unjournaled-effect predicate as the
-        // CloseLoop end-flush above.  `PYRE_FBW_ABORT_FLUSH=0` opts out.
+        // portal resumes at the unsupported opcode instead of replaying.
+        // The marker-only fallback uses the same no-unjournaled-effect
+        // predicate as the CloseLoop end-flush above.  A latched inline-callee
+        // forward abort has already distinguished an outside mark from a mark
+        // inside its discarded attempt.  `PYRE_FBW_ABORT_FLUSH=0` opts out.
         if std::env::var_os("PYRE_FBW_ABORT_FLUSH").as_deref() != Some(std::ffi::OsStr::new("0")) {
-            if let Err(crate::jitcode_dispatch::DispatchError::AbortPermanentMarkerReached { pc }) =
-                &walk_result
-            {
-                let abort_jit_pc = *pc;
-                // gh#467: the marker fired inside a TOP-level inline sub-walk
-                // whose callee committed no heap effect
+            let call_forward_abort = match &walk_result {
+                Err(crate::jitcode_dispatch::DispatchError::AbortPermanentMarkerReached { pc }) => {
+                    Some((*pc, true))
+                }
+                Err(
+                    crate::jitcode_dispatch::DispatchError::LoopBearingCalleeInlineUnsupported {
+                        pc,
+                    },
+                ) => Some((*pc, false)),
+                _ => None,
+            };
+            if let Some((abort_jit_pc, is_marker_abort)) = call_forward_abort {
+                // gh#467: a supported abort fired inside a TOP-level inline
+                // sub-walk whose callee executed no concrete effect
                 // (`try_walker_inline_user_call` latched the carrier only under
-                // that gate).  Flush the OUTER frame at the CALL that entered the
-                // callee and resume the interpreter forward — re-executing the
-                // whole call from scratch — instead of the legacy replay from
-                // loop entry, which double-applies the non-journaled pre-CALL
-                // store.  The abort's `abort_jit_pc` is a CALLEE coordinate with
-                // no meaning in the outer py_pc tables, so the outer CALL py_pc
-                // and operand stack come from the latch, not `abort_jit_pc`.
+                // that gate).  The nested-unjournaled-decline class means the
+                // residual did not execute; its callee attempt can be discarded
+                // with any inside-only unjournaled mark.  Flush the OUTER frame
+                // at the CALL that entered the callee and resume the interpreter
+                // forward — re-executing the whole call from scratch — instead
+                // of the legacy replay from loop entry, which double-applies the
+                // non-journaled pre-CALL store.  The abort's `abort_jit_pc` is a
+                // CALLEE coordinate with no meaning in the outer py_pc tables,
+                // so the outer CALL py_pc and operand stack come from the latch.
                 // Convergence of `run_blackhole_interp_to_cancel_tracing`
                 // (`pyjitpl.py:2949`), minus the inner-frame rebuild (#126/#215).
                 if let Some((call_py_pc, call_stack)) =
@@ -1652,32 +1665,44 @@ fn run_perfn_walk(
                              lastblock) — legacy replay kept"
                         );
                     }
-                } else if crate::jitcode_dispatch::fbw_has_unjournaled_effect()
-                    || crate::jitcode_dispatch::fbw_abort_in_subwalk()
-                {
-                    if crate::jitcode_dispatch::fbw_debug_abort_enabled() {
-                        eprintln!(
-                            "[fbw-abort-flush] declined at abort_jit_pc={abort_jit_pc} \
-                             (unjournaled effect or inline sub-walk) — legacy replay kept"
-                        );
-                    }
-                } else if let Some(resume_py_pc) =
-                    crate::jitcode_dispatch::fbw_abort_resume_py_pc(sym, abort_jit_pc)
-                {
-                    if crate::state::flush_walk_end_state_to_frame(ctx, cf_addr, resume_py_pc) {
+                } else if is_marker_abort {
+                    if crate::jitcode_dispatch::fbw_has_unjournaled_effect()
+                        || crate::jitcode_dispatch::fbw_abort_in_subwalk()
+                    {
                         if crate::jitcode_dispatch::fbw_debug_abort_enabled() {
                             eprintln!(
-                                "[fbw-abort-flush] COMMIT abort_jit_pc={abort_jit_pc} \
-                                 resume_py_pc={resume_py_pc}"
+                                "[fbw-abort-flush] declined at abort_jit_pc={abort_jit_pc} \
+                                 (unjournaled effect or inline sub-walk) — legacy replay kept"
                             );
                         }
-                        WALK_END_FLUSH_COMMITTED.with(|c| c.set(true));
-                    } else if crate::jitcode_dispatch::fbw_debug_abort_enabled() {
-                        eprintln!(
-                            "[fbw-abort-flush] declined at resume_py_pc={resume_py_pc} \
-                             (shadow slot without concrete / depth / lastblock) — legacy replay kept"
-                        );
+                    } else if let Some(resume_py_pc) =
+                        crate::jitcode_dispatch::fbw_abort_resume_py_pc(sym, abort_jit_pc)
+                    {
+                        if crate::state::flush_walk_end_state_to_frame(ctx, cf_addr, resume_py_pc) {
+                            if crate::jitcode_dispatch::fbw_debug_abort_enabled() {
+                                eprintln!(
+                                    "[fbw-abort-flush] COMMIT abort_jit_pc={abort_jit_pc} \
+                                     resume_py_pc={resume_py_pc}"
+                                );
+                            }
+                            WALK_END_FLUSH_COMMITTED.with(|c| c.set(true));
+                        } else if crate::jitcode_dispatch::fbw_debug_abort_enabled() {
+                            eprintln!(
+                                "[fbw-abort-flush] declined at resume_py_pc={resume_py_pc} \
+                                 (shadow slot without concrete / depth / lastblock) — legacy replay kept"
+                            );
+                        }
                     }
+                } else if crate::jitcode_dispatch::fbw_debug_abort_enabled() {
+                    // A nested-unjournaled decline without a latch failed at
+                    // least one all-or-nothing gate (nested inline, executed
+                    // effect, outside unjournaled mark, or CALL reconstruction).
+                    // It has no exact outer resume pc, so preserve the legacy
+                    // replay without consulting the marker-only inverse map.
+                    eprintln!(
+                        "[fbw-abort-flush] gh#467 CALL-forward declined at \
+                         abort_jit_pc={abort_jit_pc} (no carrier) — legacy replay kept"
+                    );
                 }
             }
         }

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -1882,6 +1882,179 @@ fn loop_body_has_abort_permanent(w_code: *const ()) -> bool {
     false
 }
 
+/// True when the hot loop body in `w_code` inline-calls — transitively — a
+/// user function whose per-fn jitcode body carries an `abort_permanent`
+/// marker.
+///
+/// [`loop_body_has_abort_permanent`] only scans the top-level per-CodeObject
+/// jitcode, so an `abort_permanent` reached through an inlined callee slips
+/// past it.  That gap causes a walk-time double-apply: a non-journaled
+/// concrete heap store (dict/attr/set item, list `extend`, …) in the loop
+/// body executes concretely, then an inline-eligible user CALL later in the
+/// same body is inline-attempted; the callee sub-walk hits `abort_permanent`
+/// and routes the whole walk to abort; the epilogue rolls back the store
+/// journal and REPLAYS FROM LOOP ENTRY, so the non-journaled store — which
+/// the journal never captured — re-executes and the loop over-counts (e.g.
+/// `300001` instead of `300000`).  Declining the walk up front, before it
+/// executes anything, avoids the double-apply: the location re-interprets
+/// without JIT (correct, at interpreter speed).
+///
+/// This is an OVER-DECLINING stopgap, and static: it can decline on a
+/// function merely referenced by the loop (present in `co_names`/locals),
+/// not just one the executed path actually calls.  A hot loop that calls any
+/// helper whose body contains an unported op (`match`, `async`,
+/// chained-compare `SWAP`, …) — even on a rarely taken path — now runs
+/// interpreted in full, not just the aborting call.  The orthodox mechanism
+/// has no up-front scan at all: an unsupported op raises `SwitchToBlackhole`
+/// mid-trace and `run_blackhole_interp_to_cancel_tracing`
+/// (pyjitpl.py:2949) converts the live framestack and continues FORWARD in
+/// the blackhole interpreter, so nothing replays and nothing double-applies.
+/// This decline holds until that forward-resume convergence (#126/#215) lets
+/// an inlined-callee abort resume the outer walk in place instead of rolling
+/// back to loop entry.
+///
+/// The scan resolves candidate callees CONCRETELY from the live frame (the
+/// walk has not run yet, so no store has executed).  Two seed sources:
+/// - the frame's module globals — every referenced name in the CodeObject's
+///   `co_names` is looked up in `w_globals`;
+/// - the ROOT frame's fastlocals + closure cells — a helper passed as an
+///   argument/local (`h([i, i])`) or held in a closure cell resolves here.
+///
+/// Each plain-function value's per-fn jitcode body is scanned end-to-end for
+/// `abort_permanent` (the marker can sit at any pc, ahead of the callee's own
+/// merge point).  Non-aborting callees are enqueued and their own referenced
+/// functions scanned transitively through THEIR globals, guarded by a
+/// scan-local visited set.  The root `w_code` is pre-marked visited — its own
+/// loop-body marker is already handled by [`loop_body_has_abort_permanent`].
+///
+/// Frame-local seeding is ROOT-frame only; a deeper (not-yet-pushed) callee's
+/// locals are not available up front.  Callees reached via attribute access,
+/// container elements, or another call's return value, and callees local to a
+/// deeper frame, stay unresolvable before the walk — those rely on the
+/// deferred #126/#215 forward-resume convergence rather than this stopgap.
+fn loop_inlines_abort_permanent_callee(w_code: *const (), cf_addr: usize) -> bool {
+    // Gate: only scan when the top-level loop body (ops after the first
+    // `jit_merge_point`) contains a `residual_call*` op.  Every inline-eligible
+    // user call lowers to a residual_call, so a call-free loop cannot
+    // inline-abort — skipping it avoids resolving globals for the common case.
+    let Some(pjc) = crate::state::pyjitcode_for_code(w_code) else {
+        return false;
+    };
+    let mut seen_merge_point = false;
+    let mut has_residual_call = false;
+    for op in crate::jitcode_runtime::decoded_ops(pjc.jitcode.code.as_slice()) {
+        if op.opname == "jit_merge_point" {
+            seen_merge_point = true;
+        } else if seen_merge_point && op.opname.starts_with("residual_call") {
+            has_residual_call = true;
+            break;
+        }
+    }
+    if !has_residual_call || cf_addr == 0 {
+        return false;
+    }
+
+    // Process one concrete candidate value shared by both seed paths (globals
+    // and frame slots): gate it to a plain user function, scan its whole
+    // jitcode body for `abort_permanent`, and otherwise enqueue it for
+    // transitive resolution through its own globals.  Returns `true` iff the
+    // candidate's body carries the marker.
+    //
+    // SAFETY: `cand` is a live concrete `PyObjectRef` read from the frame or a
+    // module dict before the walk mutates anything.
+    unsafe fn consider_candidate(
+        cand: pyre_object::PyObjectRef,
+        function_type_addr: usize,
+        visited: &mut std::collections::HashSet<*const ()>,
+        queue: &mut std::collections::VecDeque<(*const (), pyre_object::PyObjectRef)>,
+    ) -> bool {
+        // Only plain user functions inline (mirrors the inline path's exact
+        // FUNCTION_TYPE gate); builtins carry no CodeObject.
+        if cand.is_null() || (*cand).ob_type as *const () as usize != function_type_addr {
+            return false;
+        }
+        let callee_w_code = pyre_interpreter::function_get_code(cand);
+        if callee_w_code.is_null() || !visited.insert(callee_w_code) {
+            return false;
+        }
+        if let Some(body) = crate::state::sub_jitcode_body_for_code(callee_w_code) {
+            for op in crate::jitcode_runtime::decoded_ops(body.code) {
+                if op.opname == "abort_permanent" {
+                    return true;
+                }
+            }
+        }
+        // Transitive: resolve this callee's own referenced functions in its own
+        // globals.
+        let callee_globals = pyre_interpreter::function_get_globals_obj(cand);
+        if !callee_globals.is_null() {
+            queue.push_back((callee_w_code, callee_globals));
+        }
+        false
+    }
+
+    // SAFETY: `cf_addr` is the live `PyFrame` pointer the portal passed to the
+    // walk; its `w_globals` is the module dict and its locals/cells region is
+    // initialised.  All callee resolution reads live concrete objects before
+    // the walk mutates anything.
+    unsafe {
+        let cf = &*(cf_addr as *const pyre_interpreter::pyframe::PyFrame);
+        let root_globals = cf.w_globals;
+        if root_globals.is_null() {
+            return false;
+        }
+        let function_type_addr = &pyre_interpreter::FUNCTION_TYPE as *const _ as usize;
+        let mut visited: std::collections::HashSet<*const ()> = std::collections::HashSet::new();
+        // The root's own loop-body `abort_permanent` is handled upstream.
+        visited.insert(w_code);
+        // BFS over (code wrapper ptr, globals in which its `co_names` resolve).
+        let mut queue: std::collections::VecDeque<(*const (), pyre_object::PyObjectRef)> =
+            std::collections::VecDeque::new();
+        queue.push_back((w_code, root_globals));
+
+        // Seed from the root frame's fastlocals + closure cells: a helper
+        // passed as an argument/local or held in a cell is not in `co_names`,
+        // so resolve it directly from the frame's initialised locals/cells
+        // region.  Stop at `stack_base()` — operand-stack slots beyond it are
+        // uninitialised.
+        let slots = cf.locals_w().as_slice();
+        let bound = cf.stack_base().min(slots.len());
+        for &slot in &slots[..bound] {
+            if slot.is_null() {
+                continue;
+            }
+            // A closure cell holds the function indirectly; unwrap it.
+            let value = if pyre_object::is_cell(slot) {
+                pyre_object::w_cell_get(slot)
+            } else {
+                slot
+            };
+            if consider_candidate(value, function_type_addr, &mut visited, &mut queue) {
+                return true;
+            }
+        }
+
+        while let Some((code_ptr, globals)) = queue.pop_front() {
+            let raw = pyre_interpreter::w_code_get_ptr(code_ptr as pyre_object::PyObjectRef)
+                as *const CodeObject;
+            if raw.is_null() {
+                continue;
+            }
+            for name in (*raw).names.iter() {
+                let Some(cand) =
+                    pyre_object::dictmultiobject::w_dict_getitem_str(globals, name.as_str())
+                else {
+                    continue;
+                };
+                if consider_candidate(cand, function_type_addr, &mut visited, &mut queue) {
+                    return true;
+                }
+            }
+        }
+    }
+    false
+}
+
 /// Issue #73 production full-body tracer (Phase 5 flip, gated).
 ///
 /// `PYRE_FULL_BODY_WALK=1` drives the per-CodeObject JitCode body via
@@ -1917,6 +2090,17 @@ fn full_body_walk_trace(
         // (`Trait::DeclinedAbort`).  Without this the real declining class is
         // invisible to the census.
         crate::jitcode_dispatch::census_record("FullBodyWalk::LoopBodyAbortPermanent");
+        fbw_decline(crate::driver::make_green_key(w_code, start_pc));
+        return TraceAction::Abort;
+    }
+    // Sibling defense to the above, transitively through inlined callees: a
+    // non-journaled concrete store in the loop body followed by an
+    // inline-eligible CALL whose callee body carries `abort_permanent` would
+    // abort the walk, roll back the store journal, and replay from loop entry
+    // — re-executing the non-journaled store.  Decline up front, before the
+    // walk runs anything.  (See `loop_inlines_abort_permanent_callee`.)
+    if loop_inlines_abort_permanent_callee(w_code, cf_addr) {
+        crate::jitcode_dispatch::census_record("FullBodyWalk::CalleeAbortPermanent");
         fbw_decline(crate::driver::make_green_key(w_code, start_pc));
         return TraceAction::Abort;
     }

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -2014,6 +2014,15 @@ fn loop_inlines_abort_permanent_callee(w_code: *const (), cf_addr: usize) -> boo
         if callee_w_code.is_null() || !visited.insert(callee_w_code) {
             return false;
         }
+        // A FUNCTION_TYPE object can wrap a BuiltinCode, not a CodeObject:
+        // `make_builtin_function*` (gateway.rs:701) puts such a function into
+        // module globals (e.g. `from sys import getsizeof`).  Feeding its
+        // BuiltinCode to `sub_jitcode_body_for_code` / `w_code_get_ptr` casts it
+        // as a PyCode and derefs garbage, so reject it before the scan — a
+        // builtin carries no traceable body and never inlines.
+        if pyre_interpreter::is_builtin_code(callee_w_code as pyre_object::PyObjectRef) {
+            return false;
+        }
         if let Some(body) = crate::state::sub_jitcode_body_for_code(callee_w_code) {
             for op in crate::jitcode_runtime::decoded_ops(body.code) {
                 if op.opname == "abort_permanent" {

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -1615,7 +1615,44 @@ fn run_perfn_walk(
                 &walk_result
             {
                 let abort_jit_pc = *pc;
-                if crate::jitcode_dispatch::fbw_has_unjournaled_effect()
+                // gh#467: the marker fired inside a TOP-level inline sub-walk
+                // whose callee committed no heap effect
+                // (`try_walker_inline_user_call` latched the carrier only under
+                // that gate).  Flush the OUTER frame at the CALL that entered the
+                // callee and resume the interpreter forward — re-executing the
+                // whole call from scratch — instead of the legacy replay from
+                // loop entry, which double-applies the non-journaled pre-CALL
+                // store.  The abort's `abort_jit_pc` is a CALLEE coordinate with
+                // no meaning in the outer py_pc tables, so the outer CALL py_pc
+                // and operand stack come from the latch, not `abort_jit_pc`.
+                // Convergence of `run_blackhole_interp_to_cancel_tracing`
+                // (`pyjitpl.py:2949`), minus the inner-frame rebuild (#126/#215).
+                if let Some((call_py_pc, call_stack)) =
+                    crate::jitcode_dispatch::fbw_take_abort_call_resume()
+                {
+                    if crate::state::flush_walk_end_state_at_outer_call(
+                        ctx,
+                        cf_addr,
+                        call_py_pc,
+                        &call_stack,
+                    ) {
+                        if crate::jitcode_dispatch::fbw_debug_abort_enabled() {
+                            eprintln!(
+                                "[fbw-abort-flush] gh#467 CALL-forward COMMIT \
+                                 abort_jit_pc={abort_jit_pc} call_py_pc={call_py_pc} \
+                                 stack_depth={}",
+                                call_stack.len()
+                            );
+                        }
+                        WALK_END_FLUSH_COMMITTED.with(|c| c.set(true));
+                    } else if crate::jitcode_dispatch::fbw_debug_abort_enabled() {
+                        eprintln!(
+                            "[fbw-abort-flush] gh#467 CALL-forward declined at \
+                             call_py_pc={call_py_pc} (depth mismatch / unresolved local / \
+                             lastblock) — legacy replay kept"
+                        );
+                    }
+                } else if crate::jitcode_dispatch::fbw_has_unjournaled_effect()
                     || crate::jitcode_dispatch::fbw_abort_in_subwalk()
                 {
                     if crate::jitcode_dispatch::fbw_debug_abort_enabled() {

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -42,12 +42,25 @@ thread_local! {
     /// returned `FrameBox` carries adoptable end state for the LIVE
     /// frame (no-replay) or still holds the entry state (legacy replay).
     static WALK_END_FLUSH_COMMITTED: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+    /// A no-handler exception produced by a committed rebuilt callee.  The
+    /// portal consumes it as `LoopResult::Done(Err(..))`; keeping it separate
+    /// from `ContinueRunningNormally` mirrors `_exit_frame_with_exception`.
+    static WALK_END_PROPAGATED_EXCEPTION: std::cell::RefCell<Option<pyre_interpreter::PyError>> =
+        const { std::cell::RefCell::new(None) };
+    /// True at portal trace sites that can consume
+    /// `WALK_END_PROPAGATED_EXCEPTION`. Bridge tracing leaves this false and
+    /// conservatively retains its legacy preflight.
+    static WALK_END_PROPAGATE_ALLOWED: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
 }
 
 /// Take-and-reset the walk-end flush flag for the trace that just
 /// returned from [`trace_bytecode`].
 pub fn take_walk_end_flush_committed() -> bool {
     WALK_END_FLUSH_COMMITTED.with(|c| c.replace(false))
+}
+
+pub fn take_walk_end_propagated_exception() -> Option<pyre_interpreter::PyError> {
+    WALK_END_PROPAGATED_EXCEPTION.with(|c| c.borrow_mut().take())
 }
 
 thread_local! {
@@ -119,6 +132,14 @@ fn midbody_post_marker_is_effect_free(code: &CodeObject, start_pc: usize) -> boo
     })
 }
 
+fn exception_delivery_stack_is_sourceable(
+    handler_depth: u32,
+    array_len: usize,
+    stack_base: usize,
+) -> bool {
+    handler_depth == 0 && array_len >= stack_base + 1
+}
+
 fn try_commit_midbody_abort(
     ctx: &TraceCtx,
     cf_addr: usize,
@@ -140,23 +161,51 @@ fn try_commit_midbody_abort(
         return false;
     }
     let code = unsafe { &*raw };
-    // G6 is fail-closed: after the marker, only instructions proven to avoid
-    // heap/global/nonlocal mutation and user calls may reach `execute_frame`.
-    // It may then either return normally or raise without committing an
-    // observable effect, so Err -> legacy replay is exactly status quo and
-    // cannot double-apply an effect. General forward exception delivery stays
-    // deferred to #126/#215 (or a later slice).
-    if !code.exceptiontable.is_empty()
-        || !midbody_post_marker_is_effect_free(code, payload.callee_py_pc)
+    // Only portal trace sites currently carry `_exit_frame_with_exception`
+    // out of the walk. Bridge sites keep the former effect-free preflight;
+    // this is checked before running the rebuilt callee, so they never strand
+    // an effectful Err into replay.
+    if !WALK_END_PROPAGATE_ALLOWED.with(|c| c.get())
+        && (!code.exceptiontable.is_empty()
+            || !midbody_post_marker_is_effect_free(code, payload.callee_py_pc))
     {
         return false;
     }
     if cf_addr == 0 {
         return false;
     }
-    let ec = unsafe { (*(cf_addr as *const pyre_interpreter::PyFrame)).execution_context };
+    let ec = unsafe { (*(cf_addr as *const pyre_interpreter::PyFrame)).execution_context }
+        as *mut pyre_interpreter::PyExecutionContext;
     if ec.is_null() {
         return false;
+    }
+    let propagate_allowed = WALK_END_PROPAGATE_ALLOWED.with(|c| c.get());
+    let outer = unsafe { &mut *(cf_addr as *mut pyre_interpreter::PyFrame) };
+    let outer_stack_base = outer.nlocals() + outer.ncells();
+    let outer_code = unsafe { &*pyre_interpreter::pyframe_get_pycode(outer) };
+    let outer_handler = pyre_interpreter::pycode::lookup_exceptiontable(
+        &outer_code.exceptiontable,
+        (payload.call_py_pc as u32) * 2,
+    );
+    if propagate_allowed {
+        // E-G2: this specialization reconstructs only the exact empty
+        // operand-stack level used by statement-position calls. A handler
+        // preserving any operand below the call remains on legacy replay.
+        if let Some((_target, depth, _lasti)) = outer_handler {
+            if !exception_delivery_stack_is_sourceable(
+                depth,
+                outer.locals_w().as_slice().len(),
+                outer_stack_base,
+            ) {
+                return false;
+            }
+        }
+        // G7: materialize every outer local before the rebuilt callee can run.
+        // `can_flush_walk_end_state_after_outer_call` already proved all
+        // shadow entries sourceable, so no post-effect decline remains.
+        if !crate::state::write_back_outer_locals(ctx, cf_addr) {
+            return false;
+        }
     }
     let mut w_code = payload.w_code;
     let mut w_globals = payload.w_globals;
@@ -184,7 +233,7 @@ fn try_commit_midbody_abort(
     else {
         return false;
     };
-    if current.live_locals.len() != code.varnames.len() || current.live_stack.is_empty() {
+    if current.live_locals.len() != code.varnames.len() {
         return false;
     }
     for slot in &mut frame.locals_w_mut().as_mut_slice()[..code.varnames.len()] {
@@ -219,19 +268,41 @@ fn try_commit_midbody_abort(
     }
     frame.valuestackdepth = stack_base + current.live_stack.len();
     frame.last_instr = current.callee_py_pc as isize - 1;
-    let Ok(mut retval) = frame.execute_frame(None, None) else {
-        return false;
-    };
-    crate::jitcode_dispatch::fbw_abort_carrier_set_return(retval);
-    let _retval_root = ObjectSlotRoot::new(&mut retval);
-    crate::state::flush_walk_end_state_after_outer_call(
-        ctx,
-        cf_addr,
-        current.call_py_pc,
-        current.post_call_py_pc,
-        current.call_stack_len,
-        retval,
-    )
+    let sys_exc_value_pre = unsafe { (*ec).sys_exc_value };
+    match frame.execute_frame(None, None) {
+        Ok(mut retval) => {
+            crate::jitcode_dispatch::fbw_abort_carrier_set_return(retval);
+            let _retval_root = ObjectSlotRoot::new(&mut retval);
+            crate::state::flush_walk_end_state_after_outer_call(
+                ctx,
+                cf_addr,
+                current.call_py_pc,
+                current.post_call_py_pc,
+                current.call_stack_len,
+                retval,
+            )
+        }
+        Err(mut operr) => {
+            // `_resume_mainloop(current_exc)` returns the exception to the
+            // caller frame. Restore the caller's pre-CALL handled-exception
+            // state first; PUSH_EXC_INFO/POP_EXCEPT will manage it from the
+            // selected handler onward.
+            unsafe { (*ec).sys_exc_value = sys_exc_value_pre };
+            if !propagate_allowed {
+                return false;
+            }
+            let outer = unsafe { &mut *(cf_addr as *mut pyre_interpreter::PyFrame) };
+            outer.last_instr = current.call_py_pc as isize;
+            outer.valuestackdepth = outer_stack_base;
+            let mut next_instr = current.call_py_pc;
+            if pyre_interpreter::eval::handle_exception(outer, &mut operr, &mut next_instr) {
+                outer.last_instr = next_instr as isize - 1;
+            } else {
+                WALK_END_PROPAGATED_EXCEPTION.with(|c| *c.borrow_mut() = Some(operr));
+            }
+            true
+        }
+    }
 }
 
 /// True when the full-body walker must NOT trace this callee as its own origin,
@@ -353,6 +424,7 @@ pub fn trace_bytecode(
     start_pc: usize,
     mut concrete_frame: pyre_interpreter::pyframe::FrameBox,
     live_frame_addr: usize,
+    allow_propagate_out: bool,
 ) -> (TraceAction, pyre_interpreter::pyframe::FrameBox) {
     // `llmodel.py:557` parity — install pyre's `Cpu` impl so the
     // optimizer's `protect_speculative_string` / `bh_strlen` /
@@ -363,6 +435,8 @@ pub fn trace_bytecode(
     // A stale flag from a prior trace on this thread must not leak into
     // this trace's adoption decision.
     WALK_END_FLUSH_COMMITTED.with(|c| c.set(false));
+    WALK_END_PROPAGATED_EXCEPTION.with(|c| *c.borrow_mut() = None);
+    WALK_END_PROPAGATE_ALLOWED.with(|c| c.set(allow_propagate_out));
     // Likewise clear any no-replay finish payload a prior trace left
     // unconsumed.  The FBW walk re-clears this in `run_perfn_walk`; the
     // trait leg (`trace_step_result_to_action`) has no such epilogue, so
@@ -1851,7 +1925,12 @@ fn run_perfn_walk(
                         }
                     }
                     Some(crate::jitcode_dispatch::InlineAbortCarrier::MidBody(payload))
-                        if is_marker_abort =>
+                        if (is_marker_abort
+                            && payload.abort_kind
+                                == crate::jitcode_dispatch::MidBodyAbortKind::Marker)
+                            || (!is_marker_abort
+                                && payload.abort_kind
+                                    == crate::jitcode_dispatch::MidBodyAbortKind::Structural) =>
                     {
                         if try_commit_midbody_abort(ctx, cf_addr, payload) {
                             if crate::jitcode_dispatch::fbw_debug_abort_enabled() {
@@ -2905,5 +2984,12 @@ mod tests {
             !decline_predicate(&code, loop_header),
             "an unrelated hot loop in a recursive function must stay walker-eligible"
         );
+    }
+
+    #[test]
+    fn forward_exception_delivery_requires_exact_empty_handler_stack() {
+        assert!(super::exception_delivery_stack_is_sourceable(0, 8, 7));
+        assert!(!super::exception_delivery_stack_is_sourceable(1, 9, 7));
+        assert!(!super::exception_delivery_stack_is_sourceable(0, 7, 7));
     }
 }

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -1961,19 +1961,22 @@ fn loop_body_has_abort_permanent(w_code: *const ()) -> bool {
 /// executes anything, avoids the double-apply: the location re-interprets
 /// without JIT (correct, at interpreter speed).
 ///
-/// This is an OVER-DECLINING stopgap, and static: it can decline on a
-/// function merely referenced by the loop (present in `co_names`/locals),
-/// not just one the executed path actually calls.  A hot loop that calls any
-/// helper whose body contains an unported op (`match`, `async`,
-/// chained-compare `SWAP`, …) — even on a rarely taken path — now runs
-/// interpreted in full, not just the aborting call.  The orthodox mechanism
-/// has no up-front scan at all: an unsupported op raises `SwitchToBlackhole`
-/// mid-trace and `run_blackhole_interp_to_cancel_tracing`
-/// (pyjitpl.py:2949) converts the live framestack and continues FORWARD in
-/// the blackhole interpreter, so nothing replays and nothing double-applies.
-/// This decline holds until that forward-resume convergence (#126/#215) lets
-/// an inlined-callee abort resume the outer walk in place instead of rolling
-/// back to loop entry.
+/// This is an OVER-DECLINING stopgap, and static: it mirrors the inline path's
+/// static eligibility gates, but can still decline on a function merely
+/// referenced by the loop (present in `co_names`/locals), not just one the
+/// executed path actually calls.  Call-site-dependent gates such as the
+/// passed-argument count and recursion depth cannot be resolved by this scan,
+/// so a callee that would fail one of those gates can also over-decline.  A hot
+/// loop that calls an otherwise inline-eligible helper whose body contains an
+/// unported op (`match`, `async`, chained-compare `SWAP`, …) — even on a rarely
+/// taken path — now runs interpreted in full, not just the aborting call.  The
+/// orthodox mechanism has no up-front scan at all: an unsupported op raises
+/// `SwitchToBlackhole` mid-trace and
+/// `run_blackhole_interp_to_cancel_tracing` (pyjitpl.py:2949) converts the live
+/// framestack and continues FORWARD in the blackhole interpreter, so nothing
+/// replays and nothing double-applies.  This decline holds until that
+/// forward-resume convergence (#126/#215) lets an inlined-callee abort resume
+/// the outer walk in place instead of rolling back to loop entry.
 ///
 /// The scan resolves candidate callees CONCRETELY from the live frame (the
 /// walk has not run yet, so no store has executed).  Two seed sources:
@@ -1982,9 +1985,11 @@ fn loop_body_has_abort_permanent(w_code: *const ()) -> bool {
 /// - the ROOT frame's fastlocals + closure cells — a helper passed as an
 ///   argument/local (`h([i, i])`) or held in a closure cell resolves here.
 ///
-/// Each plain-function value's per-fn jitcode body is scanned end-to-end for
-/// `abort_permanent` (the marker can sit at any pc, ahead of the callee's own
-/// merge point).  Non-aborting callees are enqueued and their own referenced
+/// Each plain-function value first passes the inline path's static closure,
+/// positional-parameter, jitcode-body, and Ref-register-capacity gates.  Its
+/// per-fn jitcode body is then scanned end-to-end for `abort_permanent` (the
+/// marker can sit at any pc, ahead of the callee's own merge point).
+/// Non-aborting eligible callees are enqueued and their own referenced
 /// functions scanned transitively through THEIR globals, guarded by a
 /// scan-local visited set.  The root `w_code` is pre-marked visited — its own
 /// loop-body marker is already handled by [`loop_body_has_abort_permanent`].
@@ -2036,7 +2041,7 @@ fn loop_inlines_abort_permanent_callee(w_code: *const (), cf_addr: usize) -> boo
             return false;
         }
         let callee_w_code = pyre_interpreter::function_get_code(cand);
-        if callee_w_code.is_null() || !visited.insert(callee_w_code) {
+        if callee_w_code.is_null() {
             return false;
         }
         // A FUNCTION_TYPE object can wrap a BuiltinCode, not a CodeObject:
@@ -2048,11 +2053,23 @@ fn loop_inlines_abort_permanent_callee(w_code: *const (), cf_addr: usize) -> boo
         if pyre_interpreter::is_builtin_code(callee_w_code as pyre_object::PyObjectRef) {
             return false;
         }
-        if let Some(body) = crate::state::sub_jitcode_body_for_code(callee_w_code) {
-            for op in crate::jitcode_runtime::decoded_ops(body.code) {
-                if op.opname == "abort_permanent" {
-                    return true;
-                }
+        let Some((callee_w_code, nparams, has_closure)) =
+            crate::jitcode_dispatch::resolve_inlinable_callee(cand)
+        else {
+            return false;
+        };
+        if has_closure || nparams == 0 {
+            return false;
+        }
+        let Some(body) = crate::state::sub_jitcode_body_for_code(callee_w_code) else {
+            return false;
+        };
+        if nparams > body.num_regs_r || !visited.insert(callee_w_code) {
+            return false;
+        }
+        for op in crate::jitcode_runtime::decoded_ops(body.code) {
+            if op.opname == "abort_permanent" {
+                return true;
             }
         }
         // Transitive: resolve this callee's own referenced functions in its own

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -12,6 +12,27 @@ use pyre_interpreter::CodeObject;
 
 use crate::state::{PyreMeta, PyreSym};
 
+struct ObjectSlotRoot {
+    slot: *mut *mut u8,
+    registered: bool,
+}
+
+impl ObjectSlotRoot {
+    fn new(value: &mut pyre_object::PyObjectRef) -> Self {
+        let slot = value as *mut pyre_object::PyObjectRef as *mut *mut u8;
+        let registered = unsafe { pyre_object::gc_hook::try_gc_add_root(slot) };
+        Self { slot, registered }
+    }
+}
+
+impl Drop for ObjectSlotRoot {
+    fn drop(&mut self) {
+        if self.registered {
+            pyre_object::gc_hook::try_gc_remove_root(self.slot);
+        }
+    }
+}
+
 thread_local! {
     /// pyjitpl.py:3048-3091 `raise_continue_running_normally` seam: set
     /// when the authoritative full-body walk committed its end-of-walk
@@ -51,6 +72,166 @@ fn fbw_decline(key: u64) {
     FBW_DECLINED_KEYS.with(|s| {
         s.borrow_mut().insert(key);
     });
+}
+
+fn midbody_post_marker_is_effect_free(code: &CodeObject, start_pc: usize) -> bool {
+    (start_pc..code.instructions.len()).all(|pc| {
+        let Some((instruction, _)) = pyre_interpreter::decode_instruction_at(code, pc) else {
+            return false;
+        };
+        matches!(
+            instruction,
+            pyre_interpreter::Instruction::Cache
+                | pyre_interpreter::Instruction::ExtendedArg
+                | pyre_interpreter::Instruction::Resume { .. }
+                | pyre_interpreter::Instruction::Nop
+                | pyre_interpreter::Instruction::NotTaken
+                | pyre_interpreter::Instruction::LoadConst { .. }
+                | pyre_interpreter::Instruction::LoadCommonConstant { .. }
+                | pyre_interpreter::Instruction::LoadSmallInt { .. }
+                | pyre_interpreter::Instruction::LoadFast { .. }
+                | pyre_interpreter::Instruction::LoadFastBorrow { .. }
+                | pyre_interpreter::Instruction::LoadFastCheck { .. }
+                | pyre_interpreter::Instruction::LoadFastBorrowLoadFastBorrow { .. }
+                | pyre_interpreter::Instruction::LoadFastLoadFast { .. }
+                | pyre_interpreter::Instruction::StoreFast { .. }
+                | pyre_interpreter::Instruction::StoreFastLoadFast { .. }
+                | pyre_interpreter::Instruction::StoreFastStoreFast { .. }
+                | pyre_interpreter::Instruction::PopTop
+                | pyre_interpreter::Instruction::Copy { .. }
+                | pyre_interpreter::Instruction::Swap { .. }
+                | pyre_interpreter::Instruction::BinaryOp { .. }
+                | pyre_interpreter::Instruction::CompareOp { .. }
+                | pyre_interpreter::Instruction::IsOp { .. }
+                | pyre_interpreter::Instruction::JumpForward { .. }
+                | pyre_interpreter::Instruction::JumpBackward { .. }
+                | pyre_interpreter::Instruction::JumpBackwardNoInterrupt { .. }
+                | pyre_interpreter::Instruction::PopJumpIfFalse { .. }
+                | pyre_interpreter::Instruction::PopJumpIfTrue { .. }
+                | pyre_interpreter::Instruction::PopJumpIfNone { .. }
+                | pyre_interpreter::Instruction::PopJumpIfNotNone { .. }
+                | pyre_interpreter::Instruction::MatchMapping
+                | pyre_interpreter::Instruction::MatchSequence
+                | pyre_interpreter::Instruction::GetLen
+                | pyre_interpreter::Instruction::UnpackSequence { .. }
+                | pyre_interpreter::Instruction::ReturnValue
+        )
+    })
+}
+
+fn try_commit_midbody_abort(
+    ctx: &TraceCtx,
+    cf_addr: usize,
+    payload: &crate::jitcode_dispatch::MidBodyPayload,
+) -> bool {
+    if !crate::state::can_flush_walk_end_state_after_outer_call(
+        ctx,
+        cf_addr,
+        payload.call_py_pc,
+        payload.post_call_py_pc,
+        payload.call_stack_len,
+    ) {
+        return false;
+    }
+    let raw = unsafe {
+        pyre_interpreter::w_code_get_ptr(payload.w_code) as *const pyre_interpreter::CodeObject
+    };
+    if raw.is_null() {
+        return false;
+    }
+    let code = unsafe { &*raw };
+    // G6 is fail-closed: after the marker, only instructions proven to avoid
+    // heap/global/nonlocal mutation and user calls may reach `execute_frame`.
+    // It may then either return normally or raise without committing an
+    // observable effect, so Err -> legacy replay is exactly status quo and
+    // cannot double-apply an effect. General forward exception delivery stays
+    // deferred to #126/#215 (or a later slice).
+    if !code.exceptiontable.is_empty()
+        || !midbody_post_marker_is_effect_free(code, payload.callee_py_pc)
+    {
+        return false;
+    }
+    if cf_addr == 0 {
+        return false;
+    }
+    let ec = unsafe { (*(cf_addr as *const pyre_interpreter::PyFrame)).execution_context };
+    if ec.is_null() {
+        return false;
+    }
+    let mut w_code = payload.w_code;
+    let mut w_globals = payload.w_globals;
+    let mut x_arg = payload.x_arg;
+    let _w_code_root = ObjectSlotRoot::new(&mut w_code);
+    let _w_globals_root = ObjectSlotRoot::new(&mut w_globals);
+    let _x_arg_root = ObjectSlotRoot::new(&mut x_arg);
+    let frame = match pyre_interpreter::PyFrame::try_new_for_call_with_closure_and_globals_obj(
+        w_code as *const (),
+        &[x_arg],
+        std::ptr::null_mut(),
+        w_globals,
+        ec,
+        pyre_object::PY_NULL,
+    ) {
+        Ok(frame) => frame,
+        Err(_) => return false,
+    };
+    let mut frame = pyre_interpreter::pyframe::FrameBox::new(frame);
+    frame.fix_array_ptrs();
+    let _frame_locals_root = pyre_interpreter::pyframe::FrameLocalsRoot::new(frame.as_mut_ptr());
+
+    let Some(crate::jitcode_dispatch::InlineAbortCarrier::MidBody(current)) =
+        crate::jitcode_dispatch::fbw_abort_carrier_clone()
+    else {
+        return false;
+    };
+    if current.live_locals.len() != code.varnames.len() || current.live_stack.is_empty() {
+        return false;
+    }
+    for slot in &mut frame.locals_w_mut().as_mut_slice()[..code.varnames.len()] {
+        *slot = pyre_object::PY_NULL;
+    }
+    // `_copy_data_from_miframe` restores Ref registers before any scalar
+    // boxing allocation; once installed, the rooted frame array owns them.
+    for (slot, value) in current.live_locals.iter().enumerate() {
+        if let Some(crate::state::ConcreteValue::Ref(value)) = value {
+            frame.locals_w_mut().as_mut_slice()[slot] = *value;
+        }
+    }
+    let stack_base = code.varnames.len();
+    for (rel, value) in current.live_stack.iter().enumerate() {
+        let crate::state::ConcreteValue::Ref(value) = value else {
+            return false;
+        };
+        frame.locals_w_mut().as_mut_slice()[stack_base + rel] = *value;
+    }
+    for (slot, value) in current.live_locals.iter().enumerate() {
+        frame.locals_w_mut().as_mut_slice()[slot] = match value {
+            None => pyre_object::PY_NULL,
+            Some(crate::state::ConcreteValue::Ref(value)) => *value,
+            Some(crate::state::ConcreteValue::Int(value)) => pyre_object::w_int_new(*value),
+            Some(crate::state::ConcreteValue::Float(value)) => {
+                pyre_object::floatobject::w_float_new(*value)
+            }
+            Some(crate::state::ConcreteValue::Null | crate::state::ConcreteValue::Bool(_)) => {
+                return false;
+            }
+        };
+    }
+    frame.valuestackdepth = stack_base + current.live_stack.len();
+    frame.last_instr = current.callee_py_pc as isize - 1;
+    let Ok(mut retval) = frame.execute_frame(None, None) else {
+        return false;
+    };
+    crate::jitcode_dispatch::fbw_abort_carrier_set_return(retval);
+    let _retval_root = ObjectSlotRoot::new(&mut retval);
+    crate::state::flush_walk_end_state_after_outer_call(
+        ctx,
+        cf_addr,
+        current.call_py_pc,
+        current.post_call_py_pc,
+        current.call_stack_len,
+        retval,
+    )
 }
 
 /// True when the full-body walker must NOT trace this callee as its own origin,
@@ -1640,69 +1821,101 @@ fn run_perfn_walk(
                 // so the outer CALL py_pc and operand stack come from the latch.
                 // Convergence of `run_blackhole_interp_to_cancel_tracing`
                 // (`pyjitpl.py:2949`), minus the inner-frame rebuild (#126/#215).
-                if let Some((call_py_pc, call_stack)) =
-                    crate::jitcode_dispatch::fbw_take_abort_call_resume()
-                {
-                    if crate::state::flush_walk_end_state_at_outer_call(
-                        ctx,
-                        cf_addr,
+                let carrier = crate::jitcode_dispatch::fbw_abort_carrier_clone();
+                match carrier.as_ref() {
+                    Some(crate::jitcode_dispatch::InlineAbortCarrier::Entry {
                         call_py_pc,
-                        &call_stack,
-                    ) {
-                        if crate::jitcode_dispatch::fbw_debug_abort_enabled() {
-                            eprintln!(
-                                "[fbw-abort-flush] gh#467 CALL-forward COMMIT \
-                                 abort_jit_pc={abort_jit_pc} call_py_pc={call_py_pc} \
-                                 stack_depth={}",
-                                call_stack.len()
-                            );
-                        }
-                        WALK_END_FLUSH_COMMITTED.with(|c| c.set(true));
-                    } else if crate::jitcode_dispatch::fbw_debug_abort_enabled() {
-                        eprintln!(
-                            "[fbw-abort-flush] gh#467 CALL-forward declined at \
-                             call_py_pc={call_py_pc} (depth mismatch / unresolved local / \
-                             lastblock) — legacy replay kept"
-                        );
-                    }
-                } else if is_marker_abort {
-                    if crate::jitcode_dispatch::fbw_has_unjournaled_effect()
-                        || crate::jitcode_dispatch::fbw_abort_in_subwalk()
-                    {
-                        if crate::jitcode_dispatch::fbw_debug_abort_enabled() {
-                            eprintln!(
-                                "[fbw-abort-flush] declined at abort_jit_pc={abort_jit_pc} \
-                                 (unjournaled effect or inline sub-walk) — legacy replay kept"
-                            );
-                        }
-                    } else if let Some(resume_py_pc) =
-                        crate::jitcode_dispatch::fbw_abort_resume_py_pc(sym, abort_jit_pc)
-                    {
-                        if crate::state::flush_walk_end_state_to_frame(ctx, cf_addr, resume_py_pc) {
+                        call_stack,
+                    }) => {
+                        if crate::state::flush_walk_end_state_at_outer_call(
+                            ctx,
+                            cf_addr,
+                            *call_py_pc,
+                            call_stack,
+                        ) {
                             if crate::jitcode_dispatch::fbw_debug_abort_enabled() {
                                 eprintln!(
-                                    "[fbw-abort-flush] COMMIT abort_jit_pc={abort_jit_pc} \
-                                     resume_py_pc={resume_py_pc}"
+                                    "[fbw-abort-flush] gh#467 CALL-forward COMMIT \
+                                     abort_jit_pc={abort_jit_pc} call_py_pc={call_py_pc} \
+                                     stack_depth={}",
+                                    call_stack.len()
                                 );
                             }
                             WALK_END_FLUSH_COMMITTED.with(|c| c.set(true));
                         } else if crate::jitcode_dispatch::fbw_debug_abort_enabled() {
                             eprintln!(
-                                "[fbw-abort-flush] declined at resume_py_pc={resume_py_pc} \
-                                 (shadow slot without concrete / depth / lastblock) — legacy replay kept"
+                                "[fbw-abort-flush] gh#467 CALL-forward declined at \
+                                 call_py_pc={call_py_pc} (depth mismatch / unresolved local / \
+                                 lastblock) — legacy replay kept"
                             );
                         }
                     }
-                } else if crate::jitcode_dispatch::fbw_debug_abort_enabled() {
-                    // A nested-unjournaled decline without a latch failed at
-                    // least one all-or-nothing gate (nested inline, executed
-                    // effect, outside unjournaled mark, or CALL reconstruction).
-                    // It has no exact outer resume pc, so preserve the legacy
-                    // replay without consulting the marker-only inverse map.
-                    eprintln!(
-                        "[fbw-abort-flush] gh#467 CALL-forward declined at \
-                         abort_jit_pc={abort_jit_pc} (no carrier) — legacy replay kept"
-                    );
+                    Some(crate::jitcode_dispatch::InlineAbortCarrier::MidBody(payload))
+                        if is_marker_abort =>
+                    {
+                        if try_commit_midbody_abort(ctx, cf_addr, payload) {
+                            if crate::jitcode_dispatch::fbw_debug_abort_enabled() {
+                                eprintln!(
+                                    "[fbw-abort-flush] gh#467 callee-rebuild COMMIT \
+                                     abort_jit_pc={abort_jit_pc} callee_py_pc={} \
+                                     call_py_pc={} post_call_py_pc={}",
+                                    payload.callee_py_pc,
+                                    payload.call_py_pc,
+                                    payload.post_call_py_pc,
+                                );
+                            }
+                            WALK_END_FLUSH_COMMITTED.with(|c| c.set(true));
+                        } else if crate::jitcode_dispatch::fbw_debug_abort_enabled() {
+                            eprintln!(
+                                "[fbw-abort-flush] gh#467 callee-rebuild declined at \
+                                 callee_py_pc={} — legacy replay kept",
+                                payload.callee_py_pc,
+                            );
+                        }
+                    }
+                    None if is_marker_abort => {
+                        if crate::jitcode_dispatch::fbw_has_unjournaled_effect()
+                            || crate::jitcode_dispatch::fbw_abort_in_subwalk()
+                        {
+                            if crate::jitcode_dispatch::fbw_debug_abort_enabled() {
+                                eprintln!(
+                                    "[fbw-abort-flush] declined at abort_jit_pc={abort_jit_pc} \
+                                     (unjournaled effect or inline sub-walk) — legacy replay kept"
+                                );
+                            }
+                        } else if let Some(resume_py_pc) =
+                            crate::jitcode_dispatch::fbw_abort_resume_py_pc(sym, abort_jit_pc)
+                        {
+                            if crate::state::flush_walk_end_state_to_frame(
+                                ctx,
+                                cf_addr,
+                                resume_py_pc,
+                            ) {
+                                if crate::jitcode_dispatch::fbw_debug_abort_enabled() {
+                                    eprintln!(
+                                        "[fbw-abort-flush] COMMIT abort_jit_pc={abort_jit_pc} \
+                                         resume_py_pc={resume_py_pc}"
+                                    );
+                                }
+                                WALK_END_FLUSH_COMMITTED.with(|c| c.set(true));
+                            } else if crate::jitcode_dispatch::fbw_debug_abort_enabled() {
+                                eprintln!(
+                                    "[fbw-abort-flush] declined at resume_py_pc={resume_py_pc} \
+                                     (shadow slot without concrete / depth / lastblock) — legacy replay kept"
+                                );
+                            }
+                        }
+                    }
+                    _ if crate::jitcode_dispatch::fbw_debug_abort_enabled() => {
+                        eprintln!(
+                            "[fbw-abort-flush] gh#467 CALL-forward declined at \
+                             abort_jit_pc={abort_jit_pc} (no carrier) — legacy replay kept"
+                        );
+                    }
+                    _ => {}
+                }
+                if carrier.is_some() {
+                    crate::jitcode_dispatch::fbw_abort_carrier_clear();
                 }
             }
         }

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -2454,8 +2454,15 @@ pub fn trace_and_compile_from_bridge(
             &env,
             || {},
             |meta, sym| {
-                let (action, executed) =
-                    trace_bytecode(meta, sym, code, resume_pc, trace_frame, live_frame_addr);
+                let (action, executed) = trace_bytecode(
+                    meta,
+                    sym,
+                    code,
+                    resume_pc,
+                    trace_frame,
+                    live_frame_addr,
+                    false,
+                );
                 // pyjitpl.py:3048-3091 raise_continue_running_normally:
                 // a bridge walk that closed at a merge point and committed
                 // its end-of-walk state into the trace snapshot

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -4647,7 +4647,8 @@ fn jit_merge_point_hook(
     // `green_key` when we are mid-trace and the current merge point's
     // key is not the tracing origin.
     let starting_tracing_key = driver.starting_green_key();
-    if let Some(outcome) = driver.jit_merge_point_keyed(
+    let mut propagated_exception = None;
+    let driver_outcome = driver.jit_merge_point_keyed(
         green_key,
         pc,
         &mut jit_state,
@@ -4664,7 +4665,7 @@ fn jit_merge_point_hook(
             let _ = concrete_frame;
             let live_frame_addr = &*frame as *const PyFrame as usize;
             let (action, executed_frame) =
-                trace_bytecode(meta, sym, code, pc, snapshot, live_frame_addr);
+                trace_bytecode(meta, sym, code, pc, snapshot, live_frame_addr, true);
             // pyjitpl.py:3048-3091 raise_continue_running_normally: tracing
             // IS execution — a walk that committed its end-of-walk state
             // into the snapshot (CloseLoop / CompileTracePending flush)
@@ -4676,9 +4677,14 @@ fn jit_merge_point_hook(
             if pyre_jit_trace::trace::take_walk_end_flush_committed() {
                 frame.restore_resume_state_from(&executed_frame);
             }
+            propagated_exception = pyre_jit_trace::trace::take_walk_end_propagated_exception();
             action
         },
-    ) {
+    );
+    if let Some(err) = propagated_exception {
+        return Some(LoopResult::Done(Err(err)));
+    }
+    if let Some(outcome) = driver_outcome {
         match handle_jit_outcome(outcome, &jit_state, frame, info, green_key) {
             JitAction::Return(result) => return Some(LoopResult::Done(result)),
             JitAction::ContinueRunningNormally => return Some(LoopResult::ContinueRunningNormally),
@@ -5436,6 +5442,7 @@ fn bound_reached(
             // run their own eval_loop_jit) don't trigger jit_merge_point_hook.
             driver.meta_interp_mut().tracing_call_depth = Some(call_depth());
             let code = unsafe { &*pyre_interpreter::pyframe_get_pycode(frame_root.frame()) };
+            let mut propagated_exception = None;
             let outcome = driver.jit_merge_point_keyed(
                 green_key,
                 loop_header_pc,
@@ -5454,6 +5461,7 @@ fn bound_reached(
                         loop_header_pc,
                         concrete_frame,
                         live_frame_addr,
+                        true,
                     );
                     // raise_continue_running_normally seam — see the
                     // jit_merge_point_hook tracing site for the contract.
@@ -5462,10 +5470,15 @@ fn bound_reached(
                             .frame()
                             .restore_resume_state_from(&executed_frame);
                     }
+                    propagated_exception =
+                        pyre_jit_trace::trace::take_walk_end_propagated_exception();
                     action
                 },
             );
             driver.meta_interp_mut().tracing_call_depth = None;
+            if let Some(err) = propagated_exception {
+                return Some(LoopResult::Done(Err(err)));
+            }
             let compiled_key = driver.last_compiled_key().unwrap_or(green_key);
             if !had_compiled && driver.has_compiled_loop(compiled_key) {
                 register_quasi_immutable_deps(compiled_key);

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -6392,16 +6392,16 @@ impl CodeWriter {
                 // compiled trace would continue past unsupported
                 // opcodes instead of falling back to the interpreter).
                 // `abort_permanent` is pyre-specific (no upstream
-                // RPython counterpart); use `offset = -1` matching
-                // `emit_vsd!`'s synthetic-op convention since
-                // `abort_permanent` is an emission-time bail-out
-                // marker, not tied to a single Python bytecode PC.
+                // RPython counterpart), but it must retain the Python
+                // opcode where interpretation resumes. In a non-portal
+                // callee there is no last_instr vable write to anchor that
+                // coordinate for the inverse map.
                 record_graph_op(
                     &current_block.block(),
                     "abort_permanent",
                     Vec::new(),
                     None,
-                    -1,
+                    ($py_pc) as i64,
                 );
                 // pyre-only dead-end: the block has no successor in
                 // the shadow graph. Leaving `needs_fallthrough = false`


### PR DESCRIPTION
## What

Three JIT tracing fixes, census-driven:

1. **Scope the branch-arm unrestorable-Ref hazard to the invalid walk mirror**
   (`jitcode_dispatch.rs`). Hazard (1) of the branch-guard resume decline
   (`reads_null_ref`) ran the `branch_arm_reads_unrestorable_ref` register scan
   regardless of walk-mirror validity, while Hazards (2)/(3) were already scoped
   to `!vstack_valid`. A valid #73 walk mirror sources kept operand-stack slots
   from `vstack_boxes` and kept locals from the vable shadow per-slot on resume,
   so the register scan only proves a hazard for the invalid mirror.
   `capture_resumedata` (pyjitpl.py:2610-2624) appends `virtualizable_boxes` and
   the framestack to every guard's resume data, so these reads are always
   restorable upstream. Soundness was force-verified: with the decline force-
   disabled, the two affected guards re-executed their not-taken arms across
   594+404 real guard failures with output byte-identical to the interpreter.
   `exec_defined_global_read` and `loops_comprehension` each gain one compiled
   loop.

2. **Decline the walk when an inlined callee body carries `abort_permanent`**
   (`trace.rs`, gh#467 stopgap). `loop_body_has_abort_permanent` scans only the
   top-level jitcode, so an `abort_permanent` inside an inlined callee slipped
   past it: a non-journaled concrete heap store executed during the walk, the
   callee sub-walk aborted, and the epilogue replayed from loop entry —
   re-executing the store (`d[0] = d[0] + 1` over-counted 300001 vs 300000,
   deterministic). The new `loop_inlines_abort_permanent_callee` resolves callee
   candidates concretely before the walk (module globals via `co_names`,
   root-frame fastlocals, closure cells), scans their jitcode bodies
   transitively, and declines up front so the loop re-interprets (correct, at
   interpreter speed). This is a documented over-declining adaptation: upstream
   has no up-front scan — an unsupported op raises `SwitchToBlackhole` and
   `run_blackhole_interp_to_cancel_tracing` (pyjitpl.py:2949) continues forward
   in the blackhole interpreter, so nothing ever replays. Callees unresolvable
   before the walk (attributes, container elements, call results) remain the
   residual tracked in gh#467; the convergence is the #126/#215 forward-resume
   work.

3. **Correct stale TO_BOOL references in the vstack classifier docs**
   (`jitcode_dispatch.rs`, doc-only). TO_BOOL emits no JitCode
   (`Instruction::ToBool => {}` in the codewriter) and never reaches
   `classify_vstack_opcode`.

## Validation

- `check.py` dynasm **160/160** + cranelift **160/160**.
- `cargo test -p pyre-jit-trace` and `-p pyre-jit` (dynasm): all green.
- gh#467 repros (global helper, `extend` variant, arg-passed helper) flip to
  interpreter-identical output; a clean-helper control loop still JIT-compiles
  (~7.6×).
- Over-decline census for the stopgap: **0 of 201** corpus programs newly
  declined.

## Codex parity review

Sections 1/2: the two findings are the stopgap's own over-declining/static
nature — accepted as a deliberate, documented adaptation (the in-code comment
cites `run_blackhole_interp_to_cancel_tracing` as the orthodox mechanism and
gh#467/#126/#215 as the convergence). Sections 3/4: pre-existing #125-family
and #215 P2 items, unchanged here; this diff narrows the
`jitcode_dispatch.rs` kept-stack decline mismatch rather than widening it.

Closes nothing; tracks gh#467.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved AArch64 function calls with more reliable handling of mixed integer and floating-point arguments, including overflow arguments passed on the stack.
  - Improved JIT recovery when optimized calls are interrupted, helping prevent duplicated side effects and ensuring interpreter state is restored safely.
  - Added safeguards to avoid tracing hot loops that contain unsupported permanent-abort paths.
  - Refined handling of object state, frame restoration, and garbage collection during JIT fallback scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->