### PR TITLE
jit: #177 bridge-Terminate no-replay — carry Finish result forward instead of rewind + re-interpret

### DIFF
--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -7526,6 +7526,20 @@ thread_local! {
     /// portal degrades to the legacy `ContinueRunningNormally` replay.
     static FBW_FINISH_CONCRETE: std::cell::Cell<Option<ConcreteValue>> =
         const { std::cell::Cell::new(None) };
+
+    /// Armed by the bridge tracer (`call_jit::trace_and_compile_from_bridge`)
+    /// before a single-frame, direct-return-capable guard-failure walk.  When
+    /// set, the `run_perfn_walk` epilogue lets a bridge `Terminate` walk keep
+    /// the no-replay shortcut — commit the store journal and keep the
+    /// finish-concrete stash — so the caller hands the captured result forward
+    /// as `DoneWithThisFrame` instead of rewinding to the guard pc and
+    /// re-interpreting the region (which would double every eagerly executed
+    /// residual side effect, #177).  Only the bridge tracer sets it, and only
+    /// when the resume is single-frame and the caller can consume a concrete
+    /// result (the general guard path, not the CALL_ASSEMBLER callback), so a
+    /// committed journal never strands into a blackhole re-run.  Cleared after
+    /// every bridge walk.
+    static FBW_BRIDGE_NOREPLAY_ARMED: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
 }
 
 /// Whether the slice-b Finish-portal compile route is enabled.  Cached so
@@ -7546,6 +7560,34 @@ pub(crate) fn fbw_call_assembler_enabled() -> bool {
 pub(crate) fn fbw_no_replay_exit_enabled() -> bool {
     static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
     *ENABLED.get_or_init(|| std::env::var("PYRE_FBW_NO_REPLAY_EXIT").as_deref() != Ok("0"))
+}
+
+/// Whether a guard-failure BRIDGE walk that reached `Terminate` with a
+/// captured finish-concrete carries that result forward
+/// (`DoneWithThisFrame`) instead of rewinding to the guard pc and
+/// re-interpreting the region.  Without it the walk executes every residual
+/// once and then the `ContinueRunningNormally` re-entry re-executes the
+/// region a second time, double-applying any callee-internal side effect
+/// (e.g. `self.pos += 1` inside a residual `bump()`, #177).  Default ON;
+/// `PYRE_FBW_BRIDGE_TERMINATE_NOREPLAY=0` opts back into the legacy
+/// rewind-and-replay for bisection.
+pub fn fbw_bridge_terminate_noreplay_enabled() -> bool {
+    static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ENABLED
+        .get_or_init(|| std::env::var("PYRE_FBW_BRIDGE_TERMINATE_NOREPLAY").as_deref() != Ok("0"))
+}
+
+/// Arm/disarm the bridge `Terminate` no-replay shortcut for the next walk
+/// (see [`FBW_BRIDGE_NOREPLAY_ARMED`]).  The bridge tracer sets it before
+/// the walk and clears it after.
+pub fn fbw_bridge_noreplay_arm(armed: bool) {
+    FBW_BRIDGE_NOREPLAY_ARMED.with(|c| c.set(armed));
+}
+
+/// Whether the bridge `Terminate` no-replay shortcut is armed for the
+/// current walk (read by the `run_perfn_walk` epilogue predicate).
+pub(crate) fn fbw_bridge_noreplay_armed() -> bool {
+    FBW_BRIDGE_NOREPLAY_ARMED.with(|c| c.get())
 }
 
 /// Whether `PYRE_FBW_DEBUG_ABORT` is set.  When on, `full_body_walk_trace`

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -1561,12 +1561,21 @@ fn run_perfn_walk(
     // to `ContinueRunningNormally`.  This shares its predicate with the
     // store-journal commit below so the two decisions never disagree.
     //
-    // Bridge walks are excluded: only the loop-free function portal consumes
-    // the finish stash without replaying.  A bridge `Terminate` walk's caller
-    // resumes the region through the blackhole, so keeping the stores here
-    // would double-apply them (once eagerly, once in the blackhole replay).
+    // A guard-failure BRIDGE `Terminate` walk takes the same shortcut when
+    // the bridge tracer armed it (`fbw_bridge_noreplay_armed`): the caller
+    // hands the captured concrete result forward as `DoneWithThisFrame`
+    // rather than rewinding the live frame to the guard pc and re-running the
+    // region through the `ContinueRunningNormally` re-entry — which would
+    // execute every residual a second time and double-apply any
+    // callee-internal side effect (#177).  The tracer only arms it for a
+    // single-frame resume on the general guard path (never the
+    // CALL_ASSEMBLER callback, which cannot consume a concrete result), so a
+    // committed journal never strands into a blackhole re-run; the three
+    // decisions (this predicate, the journal commit below, and the caller's
+    // consume-vs-rewind) stay in agreement.  `PYRE_FBW_BRIDGE_TERMINATE_NOREPLAY=0`
+    // (folded into the armed flag) restores the legacy rewind-and-replay.
     let terminate_no_replay = crate::jitcode_dispatch::fbw_no_replay_exit_enabled()
-        && !is_bridge_trace
+        && (!is_bridge_trace || crate::jitcode_dispatch::fbw_bridge_noreplay_armed())
         && matches!(
             &walk_result,
             Ok((crate::jitcode_dispatch::DispatchOutcome::Terminate, _))

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -2106,6 +2106,38 @@ fn bridge_source_identity_from_descr(
     Some((green_key, trace_id, fail_index))
 }
 
+/// Outcome of `trace_and_compile_from_bridge`.
+///
+/// `pyjitpl.py:2884 handle_guard_failure` never returns — it raises
+/// `ContinueRunningNormally` (bridge attached, resume in compiled code),
+/// switches to the blackhole, or raises `DoneWithThisFrame` when
+/// `interpret()` runs the resumed frames forward to a `Finish`.  Pyre
+/// reifies those three exits so the caller can act on each.
+pub enum BridgeResolution {
+    /// Bridge attached — caller re-enters compiled code
+    /// (`ContinueRunningNormally`).  The legacy `true` return.
+    CompiledContinue,
+    /// Resume the region in the blackhole interpreter
+    /// (`SwitchToBlackhole`).  The legacy `false` return.
+    ResumeBlackhole,
+    /// The single-frame bridge walk ran the resumed frame forward to a
+    /// `Finish` (`Terminate`) and captured its concrete return value —
+    /// `pyjitpl.py` `interpret()` raising `DoneWithThisFrame` from the
+    /// post-walk state.  The caller returns this value directly instead of
+    /// rewinding the live frame and re-running the region (#177).
+    Finished(pyre_jit_trace::state::ConcreteValue),
+}
+
+/// Map the legacy bool bridge outcome (`true` = continue in compiled code,
+/// `false` = resume in the blackhole) onto [`BridgeResolution`].
+fn bridge_resolution_from_bool(compiled_continue: bool) -> BridgeResolution {
+    if compiled_continue {
+        BridgeResolution::CompiledContinue
+    } else {
+        BridgeResolution::ResumeBlackhole
+    }
+}
+
 /// compile.py:714 (_trace_and_compile_from_bridge):
 /// Called when a guard failure reaches the trace_eagerness threshold.
 /// Traces the alternative path from the guard failure point and compiles
@@ -2121,10 +2153,17 @@ fn bridge_source_identity_from_descr(
 /// (back-edge to loop header) is reached.
 /// compile.py:714 _trace_and_compile_from_bridge parity.
 ///
-/// Returns true if the bridge was successfully compiled and attached.
-/// On failure (trace abort, start failure), returns false so the caller
-/// falls through to resume_in_blackhole (RPython pyjitpl.py:2906-2907
-/// SwitchToBlackhole → run_blackhole_interp_to_cancel_tracing).
+/// Returns [`BridgeResolution`]: `CompiledContinue` when the bridge was
+/// compiled and attached, `ResumeBlackhole` on a trace abort / start
+/// failure so the caller falls through to resume_in_blackhole (RPython
+/// pyjitpl.py:2906-2907 SwitchToBlackhole → run_blackhole_interp_to_cancel_tracing),
+/// or `Finished(cv)` when a single-frame walk ran forward to a `Finish`
+/// (`interpret()` raising `DoneWithThisFrame`).
+///
+/// `allow_finish_direct_return` gates the `Finished` shortcut: only the
+/// general guard path (`eval::handle_fail`) can consume a concrete result,
+/// so the CALL_ASSEMBLER callback passes `false` and always takes the
+/// legacy rewind/blackhole path.
 // dont_look_inside: bridge-compile machinery the tracer must not enter.
 #[cfg_attr(target_arch = "wasm32", allow(unreachable_code))]
 #[majit_macros::dont_look_inside]
@@ -2154,7 +2193,13 @@ pub fn trace_and_compile_from_bridge(
     // tracer can decline a pending-exception resume at a non-exception
     // guard (see the deferral below).
     guard_exc: i64,
-) -> bool {
+    // Whether the caller can consume a `Finished(cv)` direct return (the
+    // general guard path can; the CALL_ASSEMBLER callback, which returns a
+    // bare bool to native code, cannot).  Gates the bridge `Terminate`
+    // no-replay shortcut so a committed store journal never strands into a
+    // blackhole re-run on a path that would ignore the concrete result.
+    allow_finish_direct_return: bool,
+) -> BridgeResolution {
     use crate::eval::build_jit_state;
     use crate::jit::state::PyreEnv;
 
@@ -2164,7 +2209,7 @@ pub fn trace_and_compile_from_bridge(
         // `compile.giveup()` when `loop_token` is None (memmgr-evicted).
         // Pyre signals the same outcome by returning `false`, dropping
         // the caller into `resume_in_blackhole` (pyjitpl.py:711).
-        return false;
+        return BridgeResolution::ResumeBlackhole;
     };
 
     let info = {
@@ -2203,7 +2248,7 @@ pub fn trace_and_compile_from_bridge(
         (0, 0)
     };
     if resume_pc == 0 {
-        return false;
+        return BridgeResolution::ResumeBlackhole;
     }
     let is_multiframe_resume = num_resume_frames > 1;
     frame.set_last_instr_from_next_instr(resume_pc);
@@ -2239,7 +2284,7 @@ pub fn trace_and_compile_from_bridge(
                 green_key, trace_id, fail_index
             );
         }
-        return false;
+        return BridgeResolution::ResumeBlackhole;
     }
     // RPython pyjitpl.py:3101 _prepare_exception_resumption +
     // pyjitpl.py:3132 prepare_resume_from_failure parity:
@@ -2364,7 +2409,7 @@ pub fn trace_and_compile_from_bridge(
         if driver.is_tracing() {
             driver.meta_interp_mut().abort_trace(false);
         }
-        return false;
+        return BridgeResolution::ResumeBlackhole;
     }
 
     // pyjitpl.py:2841 interpret(): after start_retrace_from_guard, RPython
@@ -2391,6 +2436,19 @@ pub fn trace_and_compile_from_bridge(
     let trace_frame = frame.snapshot_for_tracing();
     let live_frame_addr = frame as *const PyFrame as usize;
     let mut adopted_walk_end_state = false;
+    // Arm the bridge `Terminate` no-replay shortcut for this walk only when
+    // the gate is on, the caller can consume a concrete result, and the
+    // resume is single-frame.  The walk epilogue (`run_perfn_walk` in
+    // trace.rs) reads this flag: only when armed does a bridge `Terminate`
+    // walk keep its finish-concrete stash + commit the store journal, so the
+    // three decisions (epilogue predicate, journal commit, the
+    // consume-vs-rewind below) stay in agreement and a committed journal
+    // never strands into a blackhole re-run.
+    let bridge_noreplay_armed =
+        pyre_jit_trace::jitcode_dispatch::fbw_bridge_terminate_noreplay_enabled()
+            && allow_finish_direct_return
+            && !is_multiframe_resume;
+    pyre_jit_trace::jitcode_dispatch::fbw_bridge_noreplay_arm(bridge_noreplay_armed);
     let outcome = {
         let (driver, _) = crate::eval::driver_pair();
         driver.jit_merge_point_keyed(
@@ -2418,6 +2476,41 @@ pub fn trace_and_compile_from_bridge(
             },
         )
     };
+    // Disarm so the flag cannot leak into a later (non-bridge) walk on this
+    // thread; the epilogue has already consumed it.
+    pyre_jit_trace::jitcode_dispatch::fbw_bridge_noreplay_arm(false);
+
+    // #177 bridge `Terminate` no-replay: consume any finish-concrete the walk
+    // kept.  A stash survives the epilogue only when `bridge_noreplay_armed`
+    // held AND the walk reached `Terminate` with a materialized concrete and
+    // no unjournaled effect — the epilogue then committed the store journal,
+    // so the walked region's eager side effects (including callee-internal
+    // `SetfieldGc`s like `self.pos += 1`) stand exactly once.  Rewinding the
+    // live frame to the guard pc and re-running the region — via the
+    // `ContinueRunningNormally` re-entry — would apply them a second time.
+    // Hand the concrete result forward as `DoneWithThisFrame` instead,
+    // mirroring the top-level portal (eval.rs `maybe_compile_and_run`) and
+    // `pyjitpl.py:2841` `interpret()` raising `DoneWithThisFrame` from the
+    // post-walk state.  Always take (not peek) so a kept stash cannot leak
+    // into a later top-level portal `fbw_finish_concrete_take`.
+    if let Some(cv) = pyre_jit_trace::jitcode_dispatch::fbw_finish_concrete_take() {
+        // `bridge_noreplay_armed` folds in `!is_multiframe_resume`, so a kept
+        // stash implies a single real live PyFrame: the `Terminate` is the
+        // live frame's function return, about to be popped by its caller with
+        // `cv`.  No rewind, no blackhole.
+        debug_assert!(
+            !is_multiframe_resume,
+            "bridge Terminate no-replay stash kept for a multiframe resume \
+             (frames={num_resume_frames})"
+        );
+        if majit_metainterp::majit_log_enabled() {
+            eprintln!(
+                "[jit][bridge-trace] finish-noreplay at resume_pc={} key={}",
+                resume_pc, green_key
+            );
+        }
+        return BridgeResolution::Finished(cv);
+    }
     if !adopted_walk_end_state {
         frame.restore_resume_state_from(&resume_state);
     }
@@ -2445,7 +2538,7 @@ pub fn trace_and_compile_from_bridge(
                 resume_pc, green_key, resume_via_blackhole
             );
         }
-        return !resume_via_blackhole;
+        return bridge_resolution_from_bool(!resume_via_blackhole);
     }
 
     // pyjitpl.py:2982-2983 / 3095-3099 parity:
@@ -2470,7 +2563,7 @@ pub fn trace_and_compile_from_bridge(
                 resume_pc, green_key, resume_via_blackhole
             );
         }
-        return !resume_via_blackhole;
+        return bridge_resolution_from_bool(!resume_via_blackhole);
     }
 
     // If the driver is no longer tracing, the bridge was compiled
@@ -2497,7 +2590,7 @@ pub fn trace_and_compile_from_bridge(
                 resume_pc, green_key, compiled, adopted_walk_end_state
             );
         }
-        return compiled || adopted_walk_end_state;
+        return bridge_resolution_from_bool(compiled || adopted_walk_end_state);
     }
 
     // Trace did not converge into a bridge. Abort like RPython's
@@ -2514,7 +2607,7 @@ pub fn trace_and_compile_from_bridge(
     }
     // A committed walk has already executed the region into the live
     // frame; the blackhole replay must not run even on this abort path.
-    adopted_walk_end_state
+    bridge_resolution_from_bool(adopted_walk_end_state)
 }
 
 /// compile.py:701-717 handle_fail for call_assembler guard failures.
@@ -2614,7 +2707,24 @@ fn jit_ca_handle_guard_failure(
         // CALL_ASSEMBLER guard failures grab their callee exception on the
         // blackhole leg, not here; pass 0 so the non-exception-guard
         // deferral keys only off the general guard path's `guard_exc`.
-        trace_and_compile_from_bridge(&descr_arc, frame, raw_values, &exit_layout, 0)
+        // `allow_finish_direct_return = false`: this callback returns a bare
+        // bool to native code and has no channel for a concrete result, so
+        // it always takes the legacy rewind/blackhole path (the bridge
+        // `Terminate` no-replay shortcut stays off here).
+        match trace_and_compile_from_bridge(&descr_arc, frame, raw_values, &exit_layout, 0, false) {
+            BridgeResolution::CompiledContinue => true,
+            BridgeResolution::ResumeBlackhole => false,
+            // Unreachable: the shortcut is disarmed for this caller
+            // (`allow_finish_direct_return = false`), so the walk never keeps
+            // a finish-concrete stash and never returns `Finished`.
+            BridgeResolution::Finished(_) => {
+                debug_assert!(
+                    false,
+                    "CALL_ASSEMBLER bridge returned Finished despite disarm"
+                );
+                false
+            }
+        }
     };
 
     if majit_metainterp::majit_log_enabled() {

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -4787,6 +4787,11 @@ enum HandleFailOutcome {
     BridgeCompiled,
     /// Resume in blackhole interpreter.
     ResumeInBlackhole,
+    /// The single-frame bridge walk ran the resumed frame forward to a
+    /// `Finish` and captured its concrete return value (`interpret()`
+    /// raising `DoneWithThisFrame`).  Return it directly instead of
+    /// rewinding + re-running the region (#177).
+    BridgeFinished(pyre_object::PyObjectRef),
 }
 
 /// compile.py:701-717 handle_fail.
@@ -4827,24 +4832,43 @@ fn handle_fail(
             // `done_compiling` so a panic inside
             // `trace_and_compile_from_bridge` cannot latch
             // `ST_BUSY_FLAG`.
-            let compiled = {
+            let resolution = {
                 let _guard = GuardCompilingScope::new(descr_arc);
                 // force_plain_eval prevents concrete calls during bridge
                 // tracing from re-entering compiled code.
                 let _plain = pyre_interpreter::call::force_plain_eval();
+                // `allow_finish_direct_return = true`: the general guard path
+                // can hand a concrete `Finish` result back to its portal.
                 crate::call_jit::trace_and_compile_from_bridge(
                     descr_arc,
                     frame,
                     raw_values,
                     exit_layout,
                     guard_exc,
+                    true,
                 )
             };
-            if compiled {
-                // compile.py:708: bridge compiled → ContinueRunningNormally.
-                // RPython: the bridge is attached to the guard descr;
-                // re-entering compiled code will follow the bridge.
-                return HandleFailOutcome::BridgeCompiled;
+            match resolution {
+                crate::call_jit::BridgeResolution::CompiledContinue => {
+                    // compile.py:708: bridge compiled → ContinueRunningNormally.
+                    // RPython: the bridge is attached to the guard descr;
+                    // re-entering compiled code will follow the bridge.
+                    return HandleFailOutcome::BridgeCompiled;
+                }
+                crate::call_jit::BridgeResolution::Finished(cv) => {
+                    // #177: the walk ran the resumed frame forward to its
+                    // return and captured the concrete result; hand it back
+                    // as `DoneWithThisFrame` (`interpret()` raising it from
+                    // the post-walk state) rather than rewinding + re-running.
+                    // The bridge stays attached for subsequent guard failures.
+                    let v = match cv {
+                        // A void return stashes `Null`, i.e. Python `None`.
+                        pyre_jit_trace::state::ConcreteValue::Null => w_none(),
+                        other => other.to_pyobj(),
+                    };
+                    return HandleFailOutcome::BridgeFinished(v);
+                }
+                crate::call_jit::BridgeResolution::ResumeBlackhole => {}
             }
         }
     }
@@ -5153,6 +5177,8 @@ fn execute_assembler(
                 info,
             ) {
                 HandleFailOutcome::BridgeCompiled => Some(LoopResult::ContinueRunningNormally),
+                // #177: single-frame bridge walk returned a concrete Finish.
+                HandleFailOutcome::BridgeFinished(v) => Some(LoopResult::Done(Ok(v))),
                 HandleFailOutcome::ResumeInBlackhole => {
                     // compile.py:710-716 / pyjitpl.py:2906 SwitchToBlackhole
                     let bh_result =
@@ -5439,6 +5465,10 @@ fn bound_reached(
                 HandleFailOutcome::BridgeCompiled => {
                     return Some(LoopResult::ContinueRunningNormally);
                 }
+                // #177: single-frame bridge walk returned a concrete Finish.
+                HandleFailOutcome::BridgeFinished(v) => {
+                    return Some(LoopResult::Done(Ok(v)));
+                }
                 HandleFailOutcome::ResumeInBlackhole => {
                     let bh_result =
                         resume_in_blackhole_from_exit_layout(raw_values, exit_layout, guard_exc);
@@ -5618,6 +5648,11 @@ pub fn try_function_entry_jit(frame: &mut PyFrame) -> Option<PyResult> {
                     // Bridge compiled → ContinueRunningNormally → re-enter
                     // compiled code which will follow the new bridge.
                     // Fall through to eval_loop_jit below.
+                }
+                // #177: single-frame bridge walk returned a concrete Finish.
+                // This site returns `Option<PyResult>` (not `LoopResult`).
+                HandleFailOutcome::BridgeFinished(v) => {
+                    return Some(Ok(v));
                 }
                 HandleFailOutcome::ResumeInBlackhole => {
                     let bh_result =


### PR DESCRIPTION
## Summary

Fixes the one-time `+1` heap double-mutation (#177) that appears the first time the
JIT compiles a hot nested loop whose inner iteration calls a heap-mutating method.

A guard-failure bridge full-body-walk that reaches the callee's `RETURN`
(`DispatchOutcome::Terminate`) executes its side-effecting residual once, then
rewinds the live frame to the guard pc and re-interprets the region via the
`ContinueRunningNormally` re-entry — applying the callee-internal side effect
(e.g. a residual method's `self.pos += 1`, a `SetfieldGc` invisible to the
full-body-walk store journal) a second time.

## Fix

Candidate (ii) **advance-past**: a single-frame bridge whose walk reached `Finish`
carries its captured concrete result forward as `DoneWithThisFrame` instead of
rewinding and re-running — the analog of RPython `interpret()` raising
`DoneWithThisFrame` from the post-walk state, and of pyre's own top-level portal
no-replay exit.

Implemented as an armed-flag single source of truth: `trace_and_compile_from_bridge`
computes `armed = gate && allow_finish_direct_return && !is_multiframe_resume`
before the walk; the walk-end predicate (`terminate_no_replay`) admits the bridge
`Terminate` case only when armed (committing the store journal + keeping the
finish-concrete stash); the caller returns the result via a new
`BridgeResolution::Finished` / `HandleFailOutcome::BridgeFinished`. This makes the
multiframe corner structurally impossible (multiframe ⇒ not armed ⇒ legacy
rewind/blackhole), and the `CALL_ASSEMBLER` callback (bool-only channel) stays on
the legacy path. Gated `PYRE_FBW_BRIDGE_TERMINATE_NOREPLAY` (default on; `=0`
restores the legacy rewind-and-replay for bisection).

Touches `pyre/pyre-jit-trace/src/{trace.rs,jitcode_dispatch.rs}` and
`pyre/pyre-jit/src/{call_jit.rs,eval.rs}`.

## Verification

- Reproducer prints `30000` (was `30001`) on both dynasm and cranelift; the sweep
  50/100/1000/3000 is exact; the flat V1 case stays `3000`;
  `PYRE_FBW_BRIDGE_TERMINATE_NOREPLAY=0` reproduces `30001`.
- `pyre/check.py` green on both backends (160/160).
- Codex parity review: no regression or new mismatch (sections 1 & 2 empty; the
  pre-existing multiframe-bridge blackhole gap it flags predates and is avoided by
  this patch).

Addresses #177.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
