### PR TITLE
memoryview: zero-copy slicing, cast wrappers, hash cache — complete the BufferView peel

### DIFF
--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -1317,21 +1317,34 @@ fn memoryview_hex(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     crate::typedef::bytes_method_hex(&fwd)
 }
 
-/// `memoryview.__hash__` — `descr_hash`: a writable view is unhashable;
-/// a read-only view hashes its raw bytes (so `hash(mv) == hash(bytes)`).
+/// `descr_hash` (memoryobject.py:476) — a writable view is unhashable; a
+/// read-only view hashes its raw bytes (so `hash(mv) == hash(bytes)`),
+/// cached in `self._hash` with the `-1` sentinel (`_hash_str` never returns
+/// `-1`) — the release / readonly checks run only on the first call, and a
+/// view hashed before `release()` keeps hashing afterwards.
+unsafe fn memoryview_hash_value(mv: PyObjectRef) -> Result<i64, crate::PyError> {
+    unsafe {
+        let mut hash = pyre_object::memoryview::w_memoryview_hash(mv);
+        if hash == -1 {
+            memoryview_check_released(mv)?;
+            if !pyre_object::memoryview::w_memoryview_readonly(mv) {
+                return Err(crate::PyError::value_error(
+                    "cannot hash writable memoryview object",
+                ));
+            }
+            // `compute_hash(self.view.as_str())` — the same content digest the
+            // bytes path uses, so `hash(memoryview(b)) == hash(b)`.
+            hash = hash_str_bytes(&memoryview_gather_bytes(mv));
+            pyre_object::memoryview::w_memoryview_set_hash(mv, hash);
+        }
+        Ok(hash)
+    }
+}
+
+/// `memoryview.__hash__` — see [`memoryview_hash_value`].
 fn memoryview_hash(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     let mv = args.first().copied().unwrap_or(w_none());
-    unsafe {
-        memoryview_check_released(mv)?;
-        if !pyre_object::memoryview::w_memoryview_readonly(mv) {
-            return Err(crate::PyError::value_error(
-                "cannot hash writable memoryview object",
-            ));
-        }
-        // `compute_hash(self.view.as_str())` — the same content digest the
-        // bytes path uses, so `hash(memoryview(b)) == hash(b)`.
-        Ok(w_int_new(hash_str_bytes(&memoryview_gather_bytes(mv))))
-    }
+    unsafe { Ok(w_int_new(memoryview_hash_value(mv)?)) }
 }
 
 /// `memoryview.__delitem__` — memoryview does not support item deletion.
@@ -6801,15 +6814,9 @@ pub fn try_hash_value(obj: PyObjectRef) -> Result<i64, crate::PyError> {
             )));
         }
         if pyre_object::memoryview::is_w_memoryview(obj) {
-            // `descr_hash` — released views and writable views are
-            // unhashable; a read-only view hashes its raw bytes.
-            memoryview_check_released(obj)?;
-            if !pyre_object::memoryview::w_memoryview_readonly(obj) {
-                return Err(crate::PyError::value_error(
-                    "cannot hash writable memoryview object",
-                ));
-            }
-            return Ok(_hash_str(&memoryview_gather_bytes(obj)));
+            // `descr_hash` — released and writable views are unhashable; a
+            // read-only view hashes its raw bytes, cached in `_hash`.
+            return memoryview_hash_value(obj);
         }
         if is_tuple(obj) {
             let n = w_tuple_len(obj);

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -83,25 +83,43 @@ unsafe fn w_memoryview_new_derived(
     }
 }
 
-/// Allocate a `W_MemoryView` over a fresh `Strided` view carrying explicit
-/// native geometry on the SOURCE view's storage — the cast / toreadonly
-/// constructors, which recompute geometry rather than derive it.  The
-/// geometry's Python objects (`format` / `shape` / `strides`) are built and
-/// pinned inside the rooted region; the source memoryview is pinned too, so
-/// after the header allocation (the sole remaining collection point) its
-/// backing `Buffer` — including any `Sub` window a zero-copy slice installed
-/// — clones over with live refs.  `offset` is relative to that backing.
-#[allow(clippy::too_many_arguments)]
-unsafe fn w_memoryview_alloc_strided_from(
+/// `_cast_to_1D` (`memoryobject.py:635`) — a `View1D` reinterpreting the
+/// source view's bytes under a new 1-D element format.  The source
+/// memoryview and the fresh format object are pinned across the header
+/// allocation (the sole collection point); the source view then clones over
+/// as the boxed parent with post-collection refs.
+unsafe fn w_memoryview_cast_1d(mv_src: PyObjectRef, fmt: &str, itemsize: i64) -> PyObjectRef {
+    unsafe {
+        let _roots = pyre_object::gc_roots::push_roots();
+        let sp = pyre_object::gc_roots::shadow_stack_len();
+        pyre_object::gc_roots::pin_root(mv_src);
+        pyre_object::gc_roots::pin_root(w_str_new(fmt));
+        let mv = pyre_object::memoryview::w_memoryview_alloc_header(false);
+        let r_src = pyre_object::gc_roots::shadow_stack_get(sp);
+        let r_fmt = pyre_object::gc_roots::shadow_stack_get(sp + 1);
+        let src_view = pyre_object::memoryview::w_memoryview_view(r_src);
+        let view = pyre_object::bufferview::BufferView::View1D {
+            parent: Box::new(src_view.clone()),
+            w_obj: src_view.w_obj(),
+            w_fmt: r_fmt,
+            itemsize,
+        };
+        let view_ptr = pyre_object::memoryview::bufferview_alloc(view);
+        pyre_object::memoryview::w_memoryview_set_view(mv, view_ptr);
+        mv
+    }
+}
+
+/// `descr_cast` with a shape — `_cast_to_1D` then `_cast_to_ND`
+/// (`memoryobject.py:599-603`): a `ViewND` reshaping a fresh `View1D` over
+/// the source view.  The shape / strides tuples are built and pinned inside
+/// the rooted region alongside the source memoryview and format object.
+unsafe fn w_memoryview_cast_nd(
     mv_src: PyObjectRef,
     fmt: &str,
+    itemsize: i64,
     shape: &[i64],
     strides: &[i64],
-    itemsize: i64,
-    ndim: i64,
-    offset: i64,
-    length: i64,
-    readonly: bool,
 ) -> PyObjectRef {
     unsafe {
         let _roots = pyre_object::gc_roots::push_roots();
@@ -113,27 +131,23 @@ unsafe fn w_memoryview_alloc_strided_from(
         pyre_object::gc_roots::pin_root(w_str_new(fmt));
         pyre_object::gc_roots::pin_root(memoryview_wrap_dims(shape));
         pyre_object::gc_roots::pin_root(memoryview_wrap_dims(strides));
-        // Allocate the managed header last of the ref-bearing allocations; a
-        // moving collection here relocates the pinned refs, so read every one
-        // back from the shadow stack before building the off-heap view (mirrors
-        // `W_TupleObject` filling its items block from the relocated slots).
         let mv = pyre_object::memoryview::w_memoryview_alloc_header(false);
         let r_src = pyre_object::gc_roots::shadow_stack_get(sp);
-        let r_format = pyre_object::gc_roots::shadow_stack_get(sp + 1);
+        let r_fmt = pyre_object::gc_roots::shadow_stack_get(sp + 1);
         let r_shape = pyre_object::gc_roots::shadow_stack_get(sp + 2);
         let r_strides = pyre_object::gc_roots::shadow_stack_get(sp + 3);
         let src_view = pyre_object::memoryview::w_memoryview_view(r_src);
-        let view = pyre_object::bufferview::BufferView::Strided {
-            backing: src_view.backing().clone(),
+        let view = pyre_object::bufferview::BufferView::ViewND {
+            parent: Box::new(pyre_object::bufferview::BufferView::View1D {
+                parent: Box::new(src_view.clone()),
+                w_obj: src_view.w_obj(),
+                w_fmt: r_fmt,
+                itemsize,
+            }),
             w_obj: src_view.w_obj(),
-            w_format: r_format,
+            ndim: shape.len() as i64,
             w_shape: r_shape,
             w_strides: r_strides,
-            itemsize,
-            ndim,
-            offset,
-            length,
-            readonly,
         };
         let view_ptr = pyre_object::memoryview::bufferview_alloc(view);
         pyre_object::memoryview::w_memoryview_set_view(mv, view_ptr);
@@ -144,8 +158,8 @@ unsafe fn w_memoryview_alloc_strided_from(
 /// Build a `memoryview` over a plain contiguous 1-D exporter — a `SimpleView`
 /// (`bytes` / `bytearray`, derived format `'B'`) or a `RawBufferView`
 /// (`array.array`, explicit format).  The exporter's `Buffer` variant picks
-/// which, and both derive shape / strides / ndim / offset, so — unlike the
-/// `Strided` builder — no geometry Python objects are constructed; only a
+/// which, and both derive shape / strides / ndim / offset, so no geometry
+/// Python objects are constructed; only a
 /// `Raw` view keeps a format object.  Pins the exporter (and, for `Raw`, the
 /// format) across the header allocation (the sole collection point), then
 /// re-reads them relocated before building the off-heap box.
@@ -1128,21 +1142,8 @@ fn memoryview_cast(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> 
                 "memoryview: length is not a multiple of itemsize",
             ));
         }
-        let offset = w_memoryview_offset(mv);
-        let readonly = w_memoryview_readonly(mv);
         if !has_shape {
-            let count = total / new_itemsize;
-            return Ok(w_memoryview_alloc_strided_from(
-                mv,
-                &fmt,
-                &[count],
-                &[new_itemsize],
-                new_itemsize,
-                1,
-                offset,
-                total,
-                readonly,
-            ));
+            return Ok(w_memoryview_cast_1d(mv, &fmt, new_itemsize));
         }
         // _cast_to_ND: `length = itemsize; for d in shape: length *= d`, then
         // `length != view.getlength()` rejects.  A negative dimension makes the
@@ -1167,16 +1168,12 @@ fn memoryview_cast(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> 
             ));
         }
         let strides_v = memoryview_strides_from_shape(&dims, new_itemsize);
-        Ok(w_memoryview_alloc_strided_from(
+        Ok(w_memoryview_cast_nd(
             mv,
             &fmt,
+            new_itemsize,
             &dims,
             &strides_v,
-            new_itemsize,
-            ndim,
-            offset,
-            total,
-            readonly,
         ))
     }
 }
@@ -1187,20 +1184,13 @@ fn memoryview_toreadonly(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyE
     unsafe {
         use pyre_object::memoryview::*;
         memoryview_check_released(mv)?;
-        let fmt = w_memoryview_format_str(mv).to_owned();
-        let shape = w_memoryview_native_shape(mv);
-        let strides = w_memoryview_native_strides(mv);
-        Ok(w_memoryview_alloc_strided_from(
-            mv,
-            &fmt,
-            &shape,
-            &strides,
-            w_memoryview_itemsize(mv),
-            w_memoryview_ndim(mv),
-            w_memoryview_offset(mv),
-            w_memoryview_length(mv),
-            true,
-        ))
+        // `ReadonlyWrapper(self.view)` (memoryobject.py:256).
+        Ok(w_memoryview_new_derived(mv, |v| {
+            pyre_object::bufferview::BufferView::Readonly {
+                view: Box::new(v.clone()),
+                w_obj: v.w_obj(),
+            }
+        }))
     }
 }
 

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -39,35 +39,6 @@ unsafe fn memoryview_backing_buffer(backing: PyObjectRef) -> pyre_object::buffer
     }
 }
 
-/// The full byte storage of a memoryview backing, read through its tagged
-/// `Buffer` variant.
-unsafe fn memoryview_backing_slice(backing: PyObjectRef) -> &'static [u8] {
-    unsafe { memoryview_backing_buffer(backing).as_bytes() }
-}
-
-/// Mutable raw byte storage of a writable memoryview backing — `bytearray`
-/// or `array.array`, the two mutable buffer exporters.  `None` for a
-/// read-only exporter (`bytes`) or one without in-place byte storage, so a
-/// write assignment reports "cannot modify read-only memory".
-unsafe fn memoryview_backing_bytes_mut(backing: PyObjectRef) -> Option<&'static mut [u8]> {
-    unsafe {
-        let bytearray_ty =
-            crate::typedef::gettypeobject(&pyre_object::bytearrayobject::BYTEARRAY_TYPE);
-        if pyre_object::bytearrayobject::is_bytearray(backing)
-            || crate::baseobjspace::isinstance_w(backing, bytearray_ty)
-        {
-            return Some(pyre_object::bytearrayobject::w_bytearray_data_mut(backing));
-        }
-        let array_ty = crate::typedef::gettypeobject(&pyre_object::interp_array::ARRAY_TYPE);
-        if pyre_object::interp_array::is_array(backing)
-            || crate::baseobjspace::isinstance_w(backing, array_ty)
-        {
-            return Some(pyre_object::interp_array::w_array_vec_mut(backing).as_mut_slice());
-        }
-        None
-    }
-}
-
 /// Wrap native per-dimension extents (a `shape` or `strides`) into a fresh
 /// `tuple[int]` for the `descr` getters.  Each int is pinned as built, so a
 /// later element's allocation cannot strand an earlier one before
@@ -86,19 +57,43 @@ unsafe fn memoryview_wrap_dims(dims: &[i64]) -> PyObjectRef {
     }
 }
 
-/// Allocate a `W_MemoryView` over a freshly built off-heap `BufferView`.
-/// Selects the backing `Buffer` variant (needs `isinstance_w`, hence here and
-/// not in pyre-object) and builds the geometry's Python objects (`format` /
-/// `shape` / `strides`) *inside* the rooted region, pinning every ref across
-/// the allocations — building the boxes and allocating the header can trigger a
-/// collection before the new memoryview roots them.  Geometry arrives as native
-/// values so no caller has to hold an unrooted `format` / `shape` / `strides`
-/// object across the call; `fmt` must borrow non-GC storage (e.g. a Rust
-/// `String`) since it is read after the pin.
+/// Allocate a `W_MemoryView` whose view DERIVES from an existing view — the
+/// copy (`W_MemoryView.copy`) and zero-copy slice (`new_slice`) constructors.
+/// PyPy hands the same immutable view object to the derived memoryview; pyre
+/// clones it into the new owner's box via `derive`.
+///
+/// GC-safety: the source memoryview is pinned across the header allocation
+/// (the sole collection point).  Its custom trace keeps every ref inside its
+/// off-heap box alive and updated in place, so `derive` — which must not
+/// allocate on the GC heap — runs on post-collection refs.
+unsafe fn w_memoryview_new_derived(
+    mv_src: PyObjectRef,
+    derive: impl FnOnce(&pyre_object::bufferview::BufferView) -> pyre_object::bufferview::BufferView,
+) -> PyObjectRef {
+    unsafe {
+        let _roots = pyre_object::gc_roots::push_roots();
+        let sp = pyre_object::gc_roots::shadow_stack_len();
+        pyre_object::gc_roots::pin_root(mv_src);
+        let mv = pyre_object::memoryview::w_memoryview_alloc_header(false);
+        let r_src = pyre_object::gc_roots::shadow_stack_get(sp);
+        let view = derive(pyre_object::memoryview::w_memoryview_view(r_src));
+        let view_ptr = pyre_object::memoryview::bufferview_alloc(view);
+        pyre_object::memoryview::w_memoryview_set_view(mv, view_ptr);
+        mv
+    }
+}
+
+/// Allocate a `W_MemoryView` over a fresh `Strided` view carrying explicit
+/// native geometry on the SOURCE view's storage — the cast / toreadonly
+/// constructors, which recompute geometry rather than derive it.  The
+/// geometry's Python objects (`format` / `shape` / `strides`) are built and
+/// pinned inside the rooted region; the source memoryview is pinned too, so
+/// after the header allocation (the sole remaining collection point) its
+/// backing `Buffer` — including any `Sub` window a zero-copy slice installed
+/// — clones over with live refs.  `offset` is relative to that backing.
 #[allow(clippy::too_many_arguments)]
-unsafe fn w_memoryview_alloc(
-    w_obj: PyObjectRef,
-    w_backing: PyObjectRef,
+unsafe fn w_memoryview_alloc_strided_from(
+    mv_src: PyObjectRef,
     fmt: &str,
     shape: &[i64],
     strides: &[i64],
@@ -107,36 +102,30 @@ unsafe fn w_memoryview_alloc(
     offset: i64,
     length: i64,
     readonly: bool,
-    released: bool,
 ) -> PyObjectRef {
     unsafe {
         let _roots = pyre_object::gc_roots::push_roots();
         let sp = pyre_object::gc_roots::shadow_stack_len();
-        pyre_object::gc_roots::pin_root(w_obj);
-        pyre_object::gc_roots::pin_root(w_backing);
+        pyre_object::gc_roots::pin_root(mv_src);
         // Build each geometry object and pin it as produced: a later allocation
         // may relocate an earlier one, so the pinned shadow slot (re-read below)
         // is the source of truth, not the stale local.
         pyre_object::gc_roots::pin_root(w_str_new(fmt));
-        pyre_object::gc_roots::pin_root(pyre_object::w_tuple_new(
-            shape.iter().map(|&x| w_int_new(x)).collect(),
-        ));
-        pyre_object::gc_roots::pin_root(pyre_object::w_tuple_new(
-            strides.iter().map(|&x| w_int_new(x)).collect(),
-        ));
+        pyre_object::gc_roots::pin_root(memoryview_wrap_dims(shape));
+        pyre_object::gc_roots::pin_root(memoryview_wrap_dims(strides));
         // Allocate the managed header last of the ref-bearing allocations; a
         // moving collection here relocates the pinned refs, so read every one
         // back from the shadow stack before building the off-heap view (mirrors
         // `W_TupleObject` filling its items block from the relocated slots).
-        let mv = pyre_object::memoryview::w_memoryview_alloc_header(released);
-        let r_obj = pyre_object::gc_roots::shadow_stack_get(sp);
-        let r_backing = pyre_object::gc_roots::shadow_stack_get(sp + 1);
-        let r_format = pyre_object::gc_roots::shadow_stack_get(sp + 2);
-        let r_shape = pyre_object::gc_roots::shadow_stack_get(sp + 3);
-        let r_strides = pyre_object::gc_roots::shadow_stack_get(sp + 4);
+        let mv = pyre_object::memoryview::w_memoryview_alloc_header(false);
+        let r_src = pyre_object::gc_roots::shadow_stack_get(sp);
+        let r_format = pyre_object::gc_roots::shadow_stack_get(sp + 1);
+        let r_shape = pyre_object::gc_roots::shadow_stack_get(sp + 2);
+        let r_strides = pyre_object::gc_roots::shadow_stack_get(sp + 3);
+        let src_view = pyre_object::memoryview::w_memoryview_view(r_src);
         let view = pyre_object::bufferview::BufferView::Strided {
-            backing: memoryview_backing_buffer(r_backing),
-            w_obj: r_obj,
+            backing: src_view.backing().clone(),
+            w_obj: src_view.w_obj(),
             w_format: r_format,
             w_shape: r_shape,
             w_strides: r_strides,
@@ -268,23 +257,10 @@ pub(crate) fn w_memoryview_new(w_obj: PyObjectRef) -> Result<PyObjectRef, crate:
     unsafe {
         if is_w_memoryview(w_obj) {
             memoryview_check_released(w_obj)?;
-            let backing = w_memoryview_backing(w_obj);
-            let fmt = w_memoryview_format_str(w_obj).to_owned();
-            let shape = w_memoryview_native_shape(w_obj);
-            let strides = w_memoryview_native_strides(w_obj);
-            return Ok(w_memoryview_alloc(
-                w_memoryview_obj(w_obj),
-                backing,
-                &fmt,
-                &shape,
-                &strides,
-                w_memoryview_itemsize(w_obj),
-                w_memoryview_ndim(w_obj),
-                w_memoryview_offset(w_obj),
-                w_memoryview_length(w_obj),
-                w_memoryview_readonly(w_obj),
-                false,
-            ));
+            // `W_MemoryView.copy` shares the source's (immutable) view; the
+            // clone preserves the variant, so copying a sliced / plain view
+            // keeps its zero-copy window and derived geometry.
+            return Ok(w_memoryview_new_derived(w_obj, |v| v.clone()));
         }
         let (fmt, itemsize, _readonly, byte_len) = match memoryview_buffer_params(w_obj) {
             Some(p) => p,
@@ -491,33 +467,24 @@ unsafe fn memoryview_values(mv: PyObjectRef) -> Vec<PyObjectRef> {
     }
 }
 
-/// A live strided sub-view `m[start:stop:step]`, sharing the same backing.
-/// Slicing operates on dimension 0 (`buffer.py BufferSlice`): the element
-/// count is `shape[0]`, the step rides `strides[0]`, and dimensions `1..ndim`
-/// are preserved, so slicing an N-D view keeps its dimensionality.  The byte
-/// `offset += start*strides[0]` and `strides[0] *= step` make the result read
-/// through to the original storage.
+/// A live sub-view `m[start:stop:step]` sharing the same storage
+/// (`descr_getitem` slice arm → `view.new_slice(start, step, slicelength)`).
+/// A step==1 slice of a plain view stays a `Simple` / `Raw` view over a
+/// `Buffer::Sub` window; a strided slice wraps the view in a
+/// `BufferView::Slice`, whose dimension-0 shape / stride derive from the
+/// parent's, so slicing an N-D view keeps its dimensionality.
 unsafe fn memoryview_slice_view(
     mv: PyObjectRef,
     index: PyObjectRef,
 ) -> Result<PyObjectRef, crate::PyError> {
     use pyre_object::memoryview::*;
     unsafe {
-        let itemsize = w_memoryview_itemsize(mv);
         let ndim = w_memoryview_ndim(mv);
-        let parent_shape = w_memoryview_native_shape(mv);
-        let parent_strides = w_memoryview_native_strides(mv);
         let count = if ndim >= 1 {
-            parent_shape.first().copied().unwrap_or(0)
+            w_memoryview_native_shape(mv).first().copied().unwrap_or(0)
         } else {
             0
         };
-        let stride_p = if ndim >= 1 {
-            parent_strides.first().copied().unwrap_or(0)
-        } else {
-            itemsize
-        };
-        let offset_p = w_memoryview_offset(mv);
         let (start, stop, step) = crate::baseobjspace::normalize_slice(index, count)?;
         let slicelength = if step > 0 {
             if stop > start {
@@ -530,31 +497,9 @@ unsafe fn memoryview_slice_view(
         } else {
             0
         };
-        let new_offset = offset_p + start * stride_p;
-        let new_stride = stride_p * step;
-        // Dimension 0 takes the slice's shape/stride; later dimensions ride
-        // along unchanged.
-        let mut shape_v = vec![slicelength];
-        let mut strides_v = vec![new_stride];
-        for d in 1..ndim {
-            shape_v.push(parent_shape.get(d as usize).copied().unwrap_or(0));
-            strides_v.push(parent_strides.get(d as usize).copied().unwrap_or(0));
-        }
-        let new_length = shape_v.iter().product::<i64>() * itemsize;
-        let fmt = w_memoryview_format_str(mv).to_owned();
-        Ok(w_memoryview_alloc(
-            w_memoryview_obj(mv),
-            w_memoryview_backing(mv),
-            &fmt,
-            &shape_v,
-            &strides_v,
-            itemsize,
-            ndim.max(1),
-            new_offset,
-            new_length,
-            w_memoryview_readonly(mv),
-            false,
-        ))
+        Ok(w_memoryview_new_derived(mv, |v| unsafe {
+            v.new_slice(start, step, slicelength)
+        }))
     }
 }
 
@@ -706,7 +651,7 @@ fn memoryview_getitem(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyErro
                 return Err(crate::PyError::index_error("index out of bounds"));
             }
             let base = (w_memoryview_offset(mv) + i * w_memoryview_stride0(mv)) as usize;
-            let full = memoryview_backing_slice(w_memoryview_backing(mv));
+            let full = w_memoryview_view(mv).backing().as_bytes();
             let fmt = w_memoryview_format_str(mv);
             return Ok(memoryview_unpack_element(
                 fmt,
@@ -732,7 +677,7 @@ fn memoryview_getitem(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyErro
                 let start = memoryview_start_from_tuple(mv, index)?;
                 let itemsize = w_memoryview_itemsize(mv);
                 let base = (w_memoryview_offset(mv) + start) as usize;
-                let full = memoryview_backing_slice(w_memoryview_backing(mv));
+                let full = w_memoryview_view(mv).backing().as_bytes();
                 let fmt = w_memoryview_format_str(mv);
                 return Ok(memoryview_unpack_element(
                     fmt,
@@ -769,8 +714,7 @@ fn memoryview_setitem(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyErro
         if w_memoryview_readonly(mv) {
             return Err(crate::PyError::type_error("cannot modify read-only memory"));
         }
-        let backing = w_memoryview_backing(mv);
-        if memoryview_backing_bytes_mut(backing).is_none() {
+        if w_memoryview_view(mv).backing().as_bytes_mut().is_none() {
             return Err(crate::PyError::type_error("cannot modify read-only memory"));
         }
         let itemsize = w_memoryview_itemsize(mv);
@@ -811,8 +755,10 @@ fn memoryview_setitem(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyErro
                     "cannot modify size of memoryview object",
                 ));
             }
-            let full =
-                memoryview_backing_bytes_mut(backing).expect("writable backing checked above");
+            let full = w_memoryview_view(mv)
+                .backing()
+                .as_bytes_mut()
+                .expect("writable backing checked above");
             for (k, &idx) in indices.iter().enumerate() {
                 let dst = (offset + idx * stride0) as usize;
                 full[dst..dst + isz].copy_from_slice(&src[k * isz..k * isz + isz]);
@@ -851,8 +797,10 @@ fn memoryview_setitem(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyErro
             memoryview_check_released(mv)?;
             let start = memoryview_start_from_tuple(mv, index)?;
             let addr = (offset + start) as usize;
-            let full =
-                memoryview_backing_bytes_mut(backing).expect("writable backing checked above");
+            let full = w_memoryview_view(mv)
+                .backing()
+                .as_bytes_mut()
+                .expect("writable backing checked above");
             full[addr..addr + isz].copy_from_slice(&packed);
             return Ok(w_none());
         }
@@ -872,7 +820,10 @@ fn memoryview_setitem(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyErro
         // Re-check release after value coercion (see tuple path above).
         memoryview_check_released(mv)?;
         let addr = (offset + i * stride0) as usize;
-        let full = memoryview_backing_bytes_mut(backing).expect("writable backing checked above");
+        let full = w_memoryview_view(mv)
+            .backing()
+            .as_bytes_mut()
+            .expect("writable backing checked above");
         full[addr..addr + isz].copy_from_slice(&packed);
         Ok(w_none())
     }
@@ -928,9 +879,9 @@ fn memoryview_raw_address(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::Py
     let mv = args.first().copied().unwrap_or(w_none());
     unsafe {
         memoryview_check_released(mv)?;
-        let backing = pyre_object::memoryview::w_memoryview_backing(mv);
-        let base = memoryview_backing_slice(backing).as_ptr() as usize;
-        let offset = pyre_object::memoryview::w_memoryview_offset(mv) as usize;
+        let view = pyre_object::memoryview::w_memoryview_view(mv);
+        let base = view.backing().as_bytes().as_ptr() as usize;
+        let offset = view.offset() as usize;
         Ok(w_int_new((base + offset) as i64))
     }
 }
@@ -1078,7 +1029,9 @@ fn memoryview_tolist(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError
         }
         let isz = pyre_object::memoryview::w_memoryview_itemsize(mv) as usize;
         let fmt = pyre_object::memoryview::w_memoryview_format_str(mv);
-        let full = memoryview_backing_slice(pyre_object::memoryview::w_memoryview_backing(mv));
+        let full = pyre_object::memoryview::w_memoryview_view(mv)
+            .backing()
+            .as_bytes();
         let start = pyre_object::memoryview::w_memoryview_offset(mv);
         Ok(memoryview_tolist_rec(mv, fmt, full, isz, ndim, 0, start))
     }
@@ -1176,14 +1129,11 @@ fn memoryview_cast(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> 
             ));
         }
         let offset = w_memoryview_offset(mv);
-        let backing = w_memoryview_backing(mv);
-        let obj = w_memoryview_obj(mv);
         let readonly = w_memoryview_readonly(mv);
         if !has_shape {
             let count = total / new_itemsize;
-            return Ok(w_memoryview_alloc(
-                obj,
-                backing,
+            return Ok(w_memoryview_alloc_strided_from(
+                mv,
                 &fmt,
                 &[count],
                 &[new_itemsize],
@@ -1192,7 +1142,6 @@ fn memoryview_cast(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> 
                 offset,
                 total,
                 readonly,
-                false,
             ));
         }
         // _cast_to_ND: `length = itemsize; for d in shape: length *= d`, then
@@ -1218,9 +1167,8 @@ fn memoryview_cast(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> 
             ));
         }
         let strides_v = memoryview_strides_from_shape(&dims, new_itemsize);
-        Ok(w_memoryview_alloc(
-            obj,
-            backing,
+        Ok(w_memoryview_alloc_strided_from(
+            mv,
             &fmt,
             &dims,
             &strides_v,
@@ -1229,7 +1177,6 @@ fn memoryview_cast(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> 
             offset,
             total,
             readonly,
-            false,
         ))
     }
 }
@@ -1243,9 +1190,8 @@ fn memoryview_toreadonly(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyE
         let fmt = w_memoryview_format_str(mv).to_owned();
         let shape = w_memoryview_native_shape(mv);
         let strides = w_memoryview_native_strides(mv);
-        Ok(w_memoryview_alloc(
-            w_memoryview_obj(mv),
-            w_memoryview_backing(mv),
+        Ok(w_memoryview_alloc_strided_from(
+            mv,
             &fmt,
             &shape,
             &strides,
@@ -1254,7 +1200,6 @@ fn memoryview_toreadonly(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyE
             w_memoryview_offset(mv),
             w_memoryview_length(mv),
             true,
-            false,
         ))
     }
 }

--- a/pyre/pyre-interpreter/src/module/_socket/interp_socket.rs
+++ b/pyre/pyre-interpreter/src/module/_socket/interp_socket.rs
@@ -207,18 +207,15 @@ fn socket_writebuf(obj: pyre_object::PyObjectRef) -> Result<&'static mut [u8], c
                 "a read-write bytes-like object is required, not 'memoryview'",
             ));
         }
-        let backing = unsafe { pyre_object::memoryview::w_memoryview_backing(obj) };
+        let view = unsafe { pyre_object::memoryview::w_memoryview_view(obj) };
         // A writable view's backing is a `bytearray` or an `array.array`; both
         // expose a mutable byte store.  Honour the view window: write only into
-        // `[offset, offset+length)` of the backing, not the whole buffer.
-        let full: &mut [u8] = if unsafe { pyre_object::bytearrayobject::is_bytearray(backing) } {
-            unsafe { pyre_object::bytearrayobject::w_bytearray_data_mut(backing) }
-        } else if unsafe { pyre_object::interp_array::is_array(backing) } {
-            unsafe { pyre_object::interp_array::w_array_vec_mut(backing).as_mut_slice() }
-        } else {
+        // `[offset, offset+length)` of the backing storage (itself already the
+        // `Buffer::Sub` window for a zero-copy slice), not the whole buffer.
+        let Some(full) = (unsafe { view.backing().as_bytes_mut() }) else {
             return Err(crate::PyError::type_error("cannot modify read-only memory"));
         };
-        let off = unsafe { pyre_object::memoryview::w_memoryview_offset(obj) } as usize;
+        let off = unsafe { view.offset() } as usize;
         let len = unsafe { pyre_object::memoryview::w_memoryview_length(obj) } as usize;
         // The backing may have been resized after the view was taken; reject a
         // window that no longer fits rather than panic.

--- a/pyre/pyre-interpreter/src/module/struct/mod.rs
+++ b/pyre/pyre-interpreter/src/module/struct/mod.rs
@@ -620,14 +620,17 @@ unsafe fn writebuf<'a>(obj: PyObjectRef) -> Result<&'a mut [u8], crate::PyError>
                     "a read-write bytes-like object is required",
                 ));
             }
-            let backing = memoryview::w_memoryview_backing(obj);
-            if bytearrayobject::is_bytearray(backing)
+            let view = memoryview::w_memoryview_view(obj);
+            if bytearrayobject::is_bytearray(view.backing().w_obj())
                 && memoryview::w_memoryview_stride0(obj) == memoryview::w_memoryview_itemsize(obj)
             {
-                let off = memoryview::w_memoryview_offset(obj) as usize;
+                let off = view.offset() as usize;
                 let len = memoryview::w_memoryview_length(obj) as usize;
-                let full = bytearrayobject::w_bytearray_data_mut(backing);
-                return Ok(&mut full[off..off + len]);
+                // The backing storage is already the view's `Buffer::Sub`
+                // window for a zero-copy slice.
+                if let Some(full) = view.backing().as_bytes_mut() {
+                    return Ok(&mut full[off..off + len]);
+                }
             }
         }
         Err(crate::PyError::type_error(

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -590,17 +590,15 @@ fn trace_buffer_exporter(
     }
 }
 
-/// Forward, in place, every `PyObjectRef` the view owns — the `.obj`
-/// exporter, the format / shape / strides objects, and the backing exporter
-/// inside its `Buffer` — exactly as `W_ListObject` walks its off-block
-/// elements.  The box is `std::alloc` stationary, so `view` never moves.
-unsafe fn memoryview_object_custom_trace(obj_addr: usize, f: &mut dyn FnMut(*mut majit_ir::GcRef)) {
-    let mv = obj_addr as *const pyre_object::memoryview::W_MemoryView;
-    let view_ptr = unsafe { (*mv).view } as *mut pyre_object::bufferview::BufferView;
-    if view_ptr.is_null() {
-        return;
-    }
-    let view = unsafe { &mut *view_ptr };
+/// Forward, in place, every `PyObjectRef` a view tree owns — the `.obj`
+/// exporter, any stored format / shape / strides objects, the backing
+/// exporter inside its `Buffer`, and (for a `Slice` wrapper) everything the
+/// boxed parent view owns — exactly as `W_ListObject` walks its off-block
+/// elements.  The boxes are `std::alloc` stationary, so nothing here moves.
+fn trace_bufferview(
+    view: &mut pyre_object::bufferview::BufferView,
+    f: &mut dyn FnMut(*mut majit_ir::GcRef),
+) {
     match view {
         pyre_object::bufferview::BufferView::Strided {
             backing,
@@ -633,7 +631,20 @@ unsafe fn memoryview_object_custom_trace(obj_addr: usize, f: &mut dyn FnMut(*mut
             f(w_fmt as *mut pyre_object::PyObjectRef as *mut majit_ir::GcRef);
             trace_buffer_exporter(backing, f);
         }
+        pyre_object::bufferview::BufferView::Slice { parent, w_obj, .. } => {
+            f(w_obj as *mut pyre_object::PyObjectRef as *mut majit_ir::GcRef);
+            trace_bufferview(parent, f);
+        }
     }
+}
+
+unsafe fn memoryview_object_custom_trace(obj_addr: usize, f: &mut dyn FnMut(*mut majit_ir::GcRef)) {
+    let mv = obj_addr as *const pyre_object::memoryview::W_MemoryView;
+    let view_ptr = unsafe { (*mv).view } as *mut pyre_object::bufferview::BufferView;
+    if view_ptr.is_null() {
+        return;
+    }
+    trace_bufferview(unsafe { &mut *view_ptr }, f);
 }
 
 /// Reclaim the off-heap `BufferView` box (and any nested `Buffer::Sub`
@@ -641,9 +652,9 @@ unsafe fn memoryview_object_custom_trace(obj_addr: usize, f: &mut dyn FnMut(*mut
 /// `W_MemoryView` header is swept.  The custom trace only keeps the box's
 /// `PyObjectRef`s alive while the header lives; without this the
 /// `std::alloc` box would leak on every memoryview / slice / cast that
-/// dies.  `release()` only flips the `released` flag (it does not null
-/// `view`), so the box is always freed here at header death; the null
-/// guard covers the brief header-allocated-before-`set_view` window.
+/// dies.  `release()` drops the box and nulls `view` eagerly, so the null
+/// guard covers both a released view and the brief
+/// header-allocated-before-`set_view` window.
 unsafe fn memoryview_object_destructor(obj_addr: usize) {
     let mv = obj_addr as *const pyre_object::memoryview::W_MemoryView;
     let view_ptr = unsafe { (*mv).view } as *mut pyre_object::bufferview::BufferView;

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -600,20 +600,6 @@ fn trace_bufferview(
     f: &mut dyn FnMut(*mut majit_ir::GcRef),
 ) {
     match view {
-        pyre_object::bufferview::BufferView::Strided {
-            backing,
-            w_obj,
-            w_format,
-            w_shape,
-            w_strides,
-            ..
-        } => {
-            f(w_obj as *mut pyre_object::PyObjectRef as *mut majit_ir::GcRef);
-            f(w_format as *mut pyre_object::PyObjectRef as *mut majit_ir::GcRef);
-            f(w_shape as *mut pyre_object::PyObjectRef as *mut majit_ir::GcRef);
-            f(w_strides as *mut pyre_object::PyObjectRef as *mut majit_ir::GcRef);
-            trace_buffer_exporter(backing, f);
-        }
         // Simple / Raw derive their shape / strides (and Simple its format),
         // so only the `.obj` exporter, the backing, and — for Raw — the
         // explicit format object are ref slots to forward.
@@ -634,6 +620,32 @@ fn trace_bufferview(
         pyre_object::bufferview::BufferView::Slice { parent, w_obj, .. } => {
             f(w_obj as *mut pyre_object::PyObjectRef as *mut majit_ir::GcRef);
             trace_bufferview(parent, f);
+        }
+        pyre_object::bufferview::BufferView::View1D {
+            parent,
+            w_obj,
+            w_fmt,
+            ..
+        } => {
+            f(w_obj as *mut pyre_object::PyObjectRef as *mut majit_ir::GcRef);
+            f(w_fmt as *mut pyre_object::PyObjectRef as *mut majit_ir::GcRef);
+            trace_bufferview(parent, f);
+        }
+        pyre_object::bufferview::BufferView::ViewND {
+            parent,
+            w_obj,
+            w_shape,
+            w_strides,
+            ..
+        } => {
+            f(w_obj as *mut pyre_object::PyObjectRef as *mut majit_ir::GcRef);
+            f(w_shape as *mut pyre_object::PyObjectRef as *mut majit_ir::GcRef);
+            f(w_strides as *mut pyre_object::PyObjectRef as *mut majit_ir::GcRef);
+            trace_bufferview(parent, f);
+        }
+        pyre_object::bufferview::BufferView::Readonly { view, w_obj } => {
+            f(w_obj as *mut pyre_object::PyObjectRef as *mut majit_ir::GcRef);
+            trace_bufferview(view, f);
         }
     }
 }

--- a/pyre/pyre-object/src/buffer.rs
+++ b/pyre/pyre-object/src/buffer.rs
@@ -12,6 +12,12 @@
 use crate::pyobject::PyObjectRef;
 
 /// Flat byte storage behind a buffer-protocol exporter.
+///
+/// `Clone` shares the storage, not the bytes: a variant holds only the
+/// exporter ref (plus window scalars for `Sub`), so a clone is another
+/// window onto the same live storage — how PyPy shares one immutable
+/// `Buffer` object between views.
+#[derive(Clone)]
 pub enum Buffer {
     /// `bytes` — read-only (`StringBuffer`).
     String { w_obj: PyObjectRef },
@@ -126,6 +132,44 @@ impl Buffer {
                         at_most
                     };
                     &full[off..off + length]
+                }
+            }
+        }
+    }
+
+    /// Mutable byte storage of a writable buffer, or `None` when the
+    /// exporter is read-only (`bytes`).  The variant tag already encodes the
+    /// concrete exporter kind (including a subclass, tagged at construction),
+    /// so dispatch needs no isinstance.  A `Sub` yields its window of the
+    /// parent's storage with the same clamp as [`as_bytes`](Buffer::as_bytes).
+    ///
+    /// # Safety
+    /// The variant's `w_obj` must point to a live object of the tagged kind.
+    #[inline]
+    pub unsafe fn as_bytes_mut(&self) -> Option<&'static mut [u8]> {
+        unsafe {
+            match self {
+                Buffer::String { .. } => None,
+                Buffer::Byte { w_obj } => {
+                    Some(crate::bytearrayobject::w_bytearray_data_mut(*w_obj))
+                }
+                Buffer::Array { w_obj } => {
+                    Some(crate::interp_array::w_array_vec_mut(*w_obj).as_mut_slice())
+                }
+                Buffer::Sub {
+                    parent,
+                    offset,
+                    size,
+                } => {
+                    let full = parent.as_bytes_mut()?;
+                    let off = (*offset).min(full.len());
+                    let at_most = full.len() - off;
+                    let length = if *size >= 0 && (*size as usize) <= at_most {
+                        *size as usize
+                    } else {
+                        at_most
+                    };
+                    Some(&mut full[off..off + length])
                 }
             }
         }

--- a/pyre/pyre-object/src/bufferview.rs
+++ b/pyre/pyre-object/src/bufferview.rs
@@ -76,41 +76,16 @@ unsafe fn read_dims(t: PyObjectRef) -> Vec<i64> {
 /// A view of a [`Buffer`]'s bytes with offset / shape / stride geometry and a
 /// buffer-protocol format.
 ///
-/// PyPy splits this into a class hierarchy — `SimpleView` / `RawBufferView`
-/// (1-D), `BufferSlice` (strided), `BufferView1D` / `BufferViewND` (cast) —
-/// each carrying only the state it needs and deriving the rest.  The single
-/// [`Strided`](BufferView::Strided) variant is the general case that holds
-/// every geometry field explicitly; the specialised variants peel off in
-/// later slices, each routing its own constructor and deriving geometry
-/// GC-safely.
+/// One variant per class of PyPy's view hierarchy — `SimpleView` /
+/// `RawBufferView` (plain 1-D), `BufferSlice` (strided slice),
+/// `BufferView1D` / `BufferViewND` (cast), `ReadonlyWrapper` — each carrying
+/// only the state its class stores and deriving the rest.
 ///
 /// Views are immutable once built (`_immutable_ = True`), so `Clone` shares
 /// semantics: PyPy hands the same view object to a wrapper / copy, pyre
 /// clones it into the new owner's box.
 #[derive(Clone)]
 pub enum BufferView {
-    /// General strided / N-dimensional view over the root [`Buffer`], carrying
-    /// absolute `offset` / `shape` / `strides` geometry.
-    Strided {
-        /// Byte storage actually read / written (the root exporter's buffer).
-        backing: Buffer,
-        /// The exporter reported by `memoryview.obj` — coincides with the
-        /// backing for a plain view, but a chained cast / slice keeps the root
-        /// storage in `backing` while `w_obj` still reports the original
-        /// exporter.
-        w_obj: PyObjectRef,
-        /// Format string object (`memoryview.format`).
-        w_format: PyObjectRef,
-        /// Shape tuple (`memoryview.shape`).
-        w_shape: PyObjectRef,
-        /// Strides tuple (`memoryview.strides`).
-        w_strides: PyObjectRef,
-        itemsize: i64,
-        ndim: i64,
-        offset: i64,
-        length: i64,
-        readonly: bool,
-    },
     /// `SimpleView` (`pypy/interpreter/buffer.py:270`) — a plain contiguous
     /// 1-D byte view (`bytes` / `bytearray`).  Format `'B'`, itemsize 1,
     /// ndim 1, offset 0, shape `[length]`, strides `[1]` are all derived;
@@ -147,6 +122,33 @@ pub enum BufferView {
         step: i64,
         length: i64,
     },
+    /// `BufferView1D` (`memoryobject.py:867`) — a cast to a new 1-D element
+    /// format over the parent's bytes (`_cast_to_1D`).  Format / itemsize are
+    /// explicit; ndim 1, shape `[parent_length / itemsize]`, strides
+    /// `[itemsize]` derive; byte access delegates to the parent
+    /// (`IndirectView`).
+    View1D {
+        parent: Box<BufferView>,
+        w_obj: PyObjectRef,
+        w_fmt: PyObjectRef,
+        itemsize: i64,
+    },
+    /// `BufferViewND` (`memoryobject.py:893`) — a cast to an N-dimensional
+    /// shape over a 1-D parent (`_cast_to_ND`).  `shape` / `strides` ride as
+    /// their tuple objects; format / itemsize come from the parent.
+    ViewND {
+        parent: Box<BufferView>,
+        w_obj: PyObjectRef,
+        ndim: i64,
+        w_shape: PyObjectRef,
+        w_strides: PyObjectRef,
+    },
+    /// `ReadonlyWrapper` (`buffer.py:415`) — `toreadonly`'s wrapper: every
+    /// read delegates to the wrapped view, `readonly` is forced true.
+    Readonly {
+        view: Box<BufferView>,
+        w_obj: PyObjectRef,
+    },
 }
 
 impl BufferView {
@@ -154,20 +156,23 @@ impl BufferView {
     #[inline]
     pub fn backing(&self) -> &Buffer {
         match self {
-            BufferView::Strided { backing, .. }
-            | BufferView::Simple { backing, .. }
-            | BufferView::Raw { backing, .. } => backing,
-            BufferView::Slice { parent, .. } => parent.backing(),
+            BufferView::Simple { backing, .. } | BufferView::Raw { backing, .. } => backing,
+            BufferView::Slice { parent, .. }
+            | BufferView::View1D { parent, .. }
+            | BufferView::ViewND { parent, .. } => parent.backing(),
+            BufferView::Readonly { view, .. } => view.backing(),
         }
     }
     /// The exporter reported by `memoryview.obj`.
     #[inline]
     pub fn w_obj(&self) -> PyObjectRef {
         match self {
-            BufferView::Strided { w_obj, .. }
-            | BufferView::Simple { w_obj, .. }
+            BufferView::Simple { w_obj, .. }
             | BufferView::Raw { w_obj, .. }
-            | BufferView::Slice { w_obj, .. } => *w_obj,
+            | BufferView::Slice { w_obj, .. }
+            | BufferView::View1D { w_obj, .. }
+            | BufferView::ViewND { w_obj, .. }
+            | BufferView::Readonly { w_obj, .. } => *w_obj,
         }
     }
     /// The element format string (`getformat`), read natively — the callers
@@ -180,10 +185,14 @@ impl BufferView {
     pub unsafe fn format_str(&self) -> &'static str {
         unsafe {
             match self {
-                BufferView::Strided { w_format, .. } => crate::w_str_get_value(*w_format),
                 BufferView::Simple { .. } => "B",
-                BufferView::Raw { w_fmt, .. } => crate::w_str_get_value(*w_fmt),
-                BufferView::Slice { parent, .. } => parent.format_str(),
+                BufferView::Raw { w_fmt, .. } | BufferView::View1D { w_fmt, .. } => {
+                    crate::w_str_get_value(*w_fmt)
+                }
+                BufferView::Slice { parent, .. } | BufferView::ViewND { parent, .. } => {
+                    parent.format_str()
+                }
+                BufferView::Readonly { view, .. } => view.format_str(),
             }
         }
     }
@@ -197,7 +206,6 @@ impl BufferView {
     pub unsafe fn native_shape(&self) -> Vec<i64> {
         unsafe {
             match self {
-                BufferView::Strided { w_shape, .. } => read_dims(*w_shape),
                 BufferView::Simple { length, .. } => vec![*length],
                 BufferView::Raw {
                     itemsize, length, ..
@@ -217,6 +225,12 @@ impl BufferView {
                     }
                     shape
                 }
+                // `[getlength() // itemsize]` (memoryobject.py:888).
+                BufferView::View1D {
+                    parent, itemsize, ..
+                } => vec![parent.length() / *itemsize],
+                BufferView::ViewND { w_shape, .. } => read_dims(*w_shape),
+                BufferView::Readonly { view, .. } => view.native_shape(),
             }
         }
     }
@@ -229,9 +243,10 @@ impl BufferView {
     pub unsafe fn native_strides(&self) -> Vec<i64> {
         unsafe {
             match self {
-                BufferView::Strided { w_strides, .. } => read_dims(*w_strides),
                 BufferView::Simple { .. } => vec![1],
-                BufferView::Raw { itemsize, .. } => vec![*itemsize],
+                BufferView::Raw { itemsize, .. } | BufferView::View1D { itemsize, .. } => {
+                    vec![*itemsize]
+                }
                 // Dimension 0 steps by the parent's stride times the slice
                 // step (`strides[0] *= step`, buffer.py:332).
                 BufferView::Slice { parent, step, .. } => {
@@ -241,6 +256,8 @@ impl BufferView {
                     }
                     strides
                 }
+                BufferView::ViewND { w_strides, .. } => read_dims(*w_strides),
+                BufferView::Readonly { view, .. } => view.native_strides(),
             }
         }
     }
@@ -253,33 +270,38 @@ impl BufferView {
     pub unsafe fn stride0(&self) -> i64 {
         unsafe {
             match self {
-                BufferView::Strided {
-                    w_strides,
-                    itemsize,
-                    ..
+                BufferView::Simple { .. } => 1,
+                BufferView::Raw { itemsize, .. } | BufferView::View1D { itemsize, .. } => {
+                    *itemsize
+                }
+                BufferView::Slice { parent, step, .. } => parent.stride0() * *step,
+                BufferView::ViewND {
+                    parent, w_strides, ..
                 } => crate::tupleobject::w_tuple_getitem(*w_strides, 0)
                     .map(|s| crate::intobject::w_int_get_value(s))
-                    .unwrap_or(*itemsize),
-                BufferView::Simple { .. } => 1,
-                BufferView::Raw { itemsize, .. } => *itemsize,
-                BufferView::Slice { parent, step, .. } => parent.stride0() * *step,
+                    .unwrap_or_else(|| parent.itemsize()),
+                BufferView::Readonly { view, .. } => view.stride0(),
             }
         }
     }
     #[inline]
     pub fn itemsize(&self) -> i64 {
         match self {
-            BufferView::Strided { itemsize, .. } | BufferView::Raw { itemsize, .. } => *itemsize,
+            BufferView::Raw { itemsize, .. } | BufferView::View1D { itemsize, .. } => *itemsize,
             BufferView::Simple { .. } => 1,
-            BufferView::Slice { parent, .. } => parent.itemsize(),
+            BufferView::Slice { parent, .. } | BufferView::ViewND { parent, .. } => {
+                parent.itemsize()
+            }
+            BufferView::Readonly { view, .. } => view.itemsize(),
         }
     }
     #[inline]
     pub fn ndim(&self) -> i64 {
         match self {
-            BufferView::Strided { ndim, .. } => *ndim,
-            BufferView::Simple { .. } | BufferView::Raw { .. } => 1,
+            BufferView::Simple { .. } | BufferView::Raw { .. } | BufferView::View1D { .. } => 1,
             BufferView::Slice { parent, .. } => parent.ndim(),
+            BufferView::ViewND { ndim, .. } => *ndim,
+            BufferView::Readonly { view, .. } => view.ndim(),
         }
     }
     /// Byte offset of the view's first element within the backing storage.
@@ -291,33 +313,50 @@ impl BufferView {
     /// A `Slice` parent's stored strides object must be live.
     #[inline]
     pub unsafe fn offset(&self) -> i64 {
-        match self {
-            BufferView::Strided { offset, .. } => *offset,
-            BufferView::Simple { .. } | BufferView::Raw { .. } => 0,
-            BufferView::Slice { parent, start, .. } => unsafe {
-                parent.offset() + *start * parent.stride0()
-            },
+        unsafe {
+            match self {
+                BufferView::Simple { .. } | BufferView::Raw { .. } => 0,
+                BufferView::Slice { parent, start, .. } => {
+                    parent.offset() + *start * parent.stride0()
+                }
+                // IndirectView delegates byte access to the parent unshifted.
+                BufferView::View1D { parent, .. } | BufferView::ViewND { parent, .. } => {
+                    parent.offset()
+                }
+                BufferView::Readonly { view, .. } => view.offset(),
+            }
         }
     }
     /// `getlength` — the view's byte count.  A `Slice` spans `shape[0]`
-    /// elements (`buffer.py:336`).
+    /// elements (`buffer.py:336`); a `ViewND` spans `product(shape)` elements
+    /// (`memoryobject.py:922`).
+    ///
+    /// # Safety
+    /// A `ViewND`'s stored shape object must be a live tuple of ints.
     #[inline]
-    pub fn length(&self) -> i64 {
-        match self {
-            BufferView::Strided { length, .. }
-            | BufferView::Simple { length, .. }
-            | BufferView::Raw { length, .. } => *length,
-            BufferView::Slice { parent, length, .. } => *length * parent.itemsize(),
+    pub unsafe fn length(&self) -> i64 {
+        unsafe {
+            match self {
+                BufferView::Simple { length, .. } | BufferView::Raw { length, .. } => *length,
+                BufferView::Slice { parent, length, .. } => *length * parent.itemsize(),
+                BufferView::View1D { parent, .. } => parent.length(),
+                BufferView::ViewND {
+                    parent, w_shape, ..
+                } => read_dims(*w_shape).iter().product::<i64>() * parent.itemsize(),
+                BufferView::Readonly { view, .. } => view.length(),
+            }
         }
     }
     #[inline]
     pub fn readonly(&self) -> bool {
         match self {
-            BufferView::Strided { readonly, .. } => *readonly,
             BufferView::Simple { backing, .. } | BufferView::Raw { backing, .. } => {
                 backing.readonly()
             }
-            BufferView::Slice { parent, .. } => parent.readonly(),
+            BufferView::Slice { parent, .. }
+            | BufferView::View1D { parent, .. }
+            | BufferView::ViewND { parent, .. } => parent.readonly(),
+            BufferView::Readonly { .. } => true,
         }
     }
 
@@ -379,6 +418,11 @@ impl BufferView {
                 start: pstart + pstep * start,
                 step: pstep * step,
                 length: slicelength,
+            },
+            // A slice of a read-only wrapper stays wrapped (buffer.py:462).
+            BufferView::Readonly { w_obj, .. } => BufferView::Readonly {
+                view: Box::new(wrap(self)),
+                w_obj: *w_obj,
             },
             other => wrap(other),
         }
@@ -503,7 +547,7 @@ mod tests {
         }
         assert_eq!(s.itemsize(), 1);
         assert_eq!(s.ndim(), 1);
-        assert_eq!(s.length(), 5);
+        assert_eq!(unsafe { s.length() }, 5);
     }
 
     #[test]

--- a/pyre/pyre-object/src/bufferview.rs
+++ b/pyre/pyre-object/src/bufferview.rs
@@ -6,11 +6,11 @@
 //!
 //! `memoryview`'s `W_MemoryView` holds one of these off the GC heap; the GC
 //! reaches the refs inside (the backing exporter, the `.obj` exporter, and
-//! the format / shape / strides objects) through `W_MemoryView`'s custom
-//! trace.  The format / shape / strides ride as their Python objects so the
-//! `W_MemoryView` accessors stay pure reads; lowering them to native Rust
-//! `str` / `Vec` (the `SimpleView` / `RawBufferView` subclass split) is a
-//! later slice.
+//! any stored format / shape / strides objects) through `W_MemoryView`'s
+//! custom trace.  The specialised variants (`Simple` / `Raw` / `Slice`)
+//! derive their geometry natively and store only exporter refs plus scalars;
+//! callers that need a Python `str` / `tuple` wrap a fresh one at the `descr`
+//! boundary.
 
 use crate::buffer::Buffer;
 use crate::pyobject::PyObjectRef;
@@ -83,6 +83,11 @@ unsafe fn read_dims(t: PyObjectRef) -> Vec<i64> {
 /// every geometry field explicitly; the specialised variants peel off in
 /// later slices, each routing its own constructor and deriving geometry
 /// GC-safely.
+///
+/// Views are immutable once built (`_immutable_ = True`), so `Clone` shares
+/// semantics: PyPy hands the same view object to a wrapper / copy, pyre
+/// clones it into the new owner's box.
+#[derive(Clone)]
 pub enum BufferView {
     /// General strided / N-dimensional view over the root [`Buffer`], carrying
     /// absolute `offset` / `shape` / `strides` geometry.
@@ -127,6 +132,21 @@ pub enum BufferView {
         itemsize: i64,
         length: i64,
     },
+    /// `BufferSlice` (`buffer.py:321`) — a strided dimension-0 window over a
+    /// parent view, produced by a step≠1 slice (a step==1 slice of a
+    /// `Simple` / `Raw` view re-specialises over a [`Buffer::Sub`] window
+    /// instead).  `start` / `step` are in parent dimension-0 element units
+    /// and `length` is the element count (`shape[0]`); shape / strides /
+    /// format / itemsize derive from the parent with dimension 0 replaced,
+    /// so no geometry objects are stored.  A slice of a slice composes into
+    /// the parent's coordinates, keeping the wrapper depth at 1.
+    Slice {
+        parent: Box<BufferView>,
+        w_obj: PyObjectRef,
+        start: i64,
+        step: i64,
+        length: i64,
+    },
 }
 
 impl BufferView {
@@ -137,6 +157,7 @@ impl BufferView {
             BufferView::Strided { backing, .. }
             | BufferView::Simple { backing, .. }
             | BufferView::Raw { backing, .. } => backing,
+            BufferView::Slice { parent, .. } => parent.backing(),
         }
     }
     /// The exporter reported by `memoryview.obj`.
@@ -145,7 +166,8 @@ impl BufferView {
         match self {
             BufferView::Strided { w_obj, .. }
             | BufferView::Simple { w_obj, .. }
-            | BufferView::Raw { w_obj, .. } => *w_obj,
+            | BufferView::Raw { w_obj, .. }
+            | BufferView::Slice { w_obj, .. } => *w_obj,
         }
     }
     /// The element format string (`getformat`), read natively — the callers
@@ -161,6 +183,7 @@ impl BufferView {
                 BufferView::Strided { w_format, .. } => crate::w_str_get_value(*w_format),
                 BufferView::Simple { .. } => "B",
                 BufferView::Raw { w_fmt, .. } => crate::w_str_get_value(*w_fmt),
+                BufferView::Slice { parent, .. } => parent.format_str(),
             }
         }
     }
@@ -185,6 +208,15 @@ impl BufferView {
                         vec![*length / *itemsize]
                     }
                 }
+                // Dimension 0 takes the slice's element count; later
+                // dimensions ride along (`shape[0] = length`, buffer.py:334).
+                BufferView::Slice { parent, length, .. } => {
+                    let mut shape = parent.native_shape();
+                    if let Some(s0) = shape.first_mut() {
+                        *s0 = *length;
+                    }
+                    shape
+                }
             }
         }
     }
@@ -200,6 +232,15 @@ impl BufferView {
                 BufferView::Strided { w_strides, .. } => read_dims(*w_strides),
                 BufferView::Simple { .. } => vec![1],
                 BufferView::Raw { itemsize, .. } => vec![*itemsize],
+                // Dimension 0 steps by the parent's stride times the slice
+                // step (`strides[0] *= step`, buffer.py:332).
+                BufferView::Slice { parent, step, .. } => {
+                    let mut strides = parent.native_strides();
+                    if let Some(s0) = strides.first_mut() {
+                        *s0 *= *step;
+                    }
+                    strides
+                }
             }
         }
     }
@@ -221,6 +262,7 @@ impl BufferView {
                     .unwrap_or(*itemsize),
                 BufferView::Simple { .. } => 1,
                 BufferView::Raw { itemsize, .. } => *itemsize,
+                BufferView::Slice { parent, step, .. } => parent.stride0() * *step,
             }
         }
     }
@@ -229,6 +271,7 @@ impl BufferView {
         match self {
             BufferView::Strided { itemsize, .. } | BufferView::Raw { itemsize, .. } => *itemsize,
             BufferView::Simple { .. } => 1,
+            BufferView::Slice { parent, .. } => parent.itemsize(),
         }
     }
     #[inline]
@@ -236,21 +279,35 @@ impl BufferView {
         match self {
             BufferView::Strided { ndim, .. } => *ndim,
             BufferView::Simple { .. } | BufferView::Raw { .. } => 1,
+            BufferView::Slice { parent, .. } => parent.ndim(),
         }
     }
+    /// Byte offset of the view's first element within the backing storage.
+    /// A `Slice` starts `start` parent elements past the parent's own offset
+    /// (`getbytes` adds `self.start * self.parent.getstrides()[0]`,
+    /// buffer.py:340).
+    ///
+    /// # Safety
+    /// A `Slice` parent's stored strides object must be live.
     #[inline]
-    pub fn offset(&self) -> i64 {
+    pub unsafe fn offset(&self) -> i64 {
         match self {
             BufferView::Strided { offset, .. } => *offset,
             BufferView::Simple { .. } | BufferView::Raw { .. } => 0,
+            BufferView::Slice { parent, start, .. } => unsafe {
+                parent.offset() + *start * parent.stride0()
+            },
         }
     }
+    /// `getlength` — the view's byte count.  A `Slice` spans `shape[0]`
+    /// elements (`buffer.py:336`).
     #[inline]
     pub fn length(&self) -> i64 {
         match self {
             BufferView::Strided { length, .. }
             | BufferView::Simple { length, .. }
             | BufferView::Raw { length, .. } => *length,
+            BufferView::Slice { parent, length, .. } => *length * parent.itemsize(),
         }
     }
     #[inline]
@@ -260,6 +317,70 @@ impl BufferView {
             BufferView::Simple { backing, .. } | BufferView::Raw { backing, .. } => {
                 backing.readonly()
             }
+            BufferView::Slice { parent, .. } => parent.readonly(),
+        }
+    }
+
+    /// `new_slice(start, step, slicelength)` — a live dimension-0 sub-view
+    /// sharing the parent's storage (`buffer.py:149,261,310,403`).  `start` /
+    /// `slicelength` are in dimension-0 element units.
+    ///
+    /// A step==1 slice of a `Simple` / `Raw` view re-specialises over a
+    /// [`Buffer::Sub`] window of the same storage, so the result stays a
+    /// plain contiguous view; every other case wraps the parent in a
+    /// [`Slice`](BufferView::Slice).  Slicing a `Slice` composes into its
+    /// parent's coordinates — `start` maps through `parent_index`
+    /// (`self.start + self.step * idx`, buffer.py:386) so a re-slice of a
+    /// strided slice lands on the elements the composed stride selects.
+    ///
+    /// # Safety
+    /// The view's stored geometry objects must be live.
+    pub unsafe fn new_slice(&self, start: i64, step: i64, slicelength: i64) -> BufferView {
+        let wrap = |view: &BufferView| BufferView::Slice {
+            parent: Box::new(view.clone()),
+            w_obj: view.w_obj(),
+            start,
+            step,
+            length: slicelength,
+        };
+        match self {
+            BufferView::Simple {
+                backing, w_obj, ..
+            } if step == 1 => BufferView::Simple {
+                backing: Buffer::sub(backing.clone(), start as usize, slicelength),
+                w_obj: *w_obj,
+                length: slicelength,
+            },
+            BufferView::Raw {
+                backing,
+                w_obj,
+                w_fmt,
+                itemsize,
+                ..
+            } if step == 1 => {
+                let n = *itemsize;
+                BufferView::Raw {
+                    backing: Buffer::sub(backing.clone(), (start * n) as usize, slicelength * n),
+                    w_obj: *w_obj,
+                    w_fmt: *w_fmt,
+                    itemsize: n,
+                    length: slicelength * n,
+                }
+            }
+            BufferView::Slice {
+                parent,
+                w_obj,
+                start: pstart,
+                step: pstep,
+                ..
+            } => BufferView::Slice {
+                parent: parent.clone(),
+                w_obj: *w_obj,
+                start: pstart + pstep * start,
+                step: pstep * step,
+                length: slicelength,
+            },
+            other => wrap(other),
         }
     }
 
@@ -295,5 +416,129 @@ impl BufferView {
             copy_rec(full, &shape, &strides, ndim, 0, offset, isz, &mut out);
             out
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Geometry-only tests: `Simple` / `Raw` derive everything from scalars,
+    // so a fake exporter address is never dereferenced.
+    fn fake(addr: usize) -> PyObjectRef {
+        addr as PyObjectRef
+    }
+
+    fn simple(len: i64) -> BufferView {
+        BufferView::Simple {
+            backing: Buffer::String {
+                w_obj: fake(0x1000),
+            },
+            w_obj: fake(0x1000),
+            length: len,
+        }
+    }
+
+    #[test]
+    fn simple_step1_slice_respecializes_over_sub_window() {
+        // SimpleView.new_slice step==1 (buffer.py:312): the result is another
+        // SimpleView over a SubBuffer window, not a BufferSlice wrapper.
+        let s = unsafe { simple(10).new_slice(2, 1, 5) };
+        match &s {
+            BufferView::Simple {
+                backing: Buffer::Sub { offset, size, .. },
+                length,
+                ..
+            } => {
+                assert_eq!((*offset, *size, *length), (2, 5, 5));
+            }
+            _ => panic!("expected Simple over Sub"),
+        }
+        unsafe {
+            assert_eq!(s.native_shape(), vec![5]);
+            assert_eq!(s.native_strides(), vec![1]);
+            assert_eq!(s.offset(), 0);
+        }
+    }
+
+    #[test]
+    fn raw_step1_slice_scales_the_window_by_itemsize() {
+        // RawBufferView.new_slice step==1 (buffer.py:262-265): the SubBuffer
+        // window is `start * itemsize .. + slicelength * itemsize`.
+        let raw = BufferView::Raw {
+            backing: Buffer::Array {
+                w_obj: fake(0x2000),
+            },
+            w_obj: fake(0x2000),
+            w_fmt: fake(0x2004),
+            itemsize: 4,
+            length: 40,
+        };
+        let s = unsafe { raw.new_slice(1, 1, 3) };
+        match &s {
+            BufferView::Raw {
+                backing: Buffer::Sub { offset, size, .. },
+                itemsize,
+                length,
+                ..
+            } => {
+                assert_eq!((*offset, *size, *itemsize, *length), (4, 12, 4, 12));
+            }
+            _ => panic!("expected Raw over Sub"),
+        }
+        unsafe {
+            assert_eq!(s.native_shape(), vec![3]);
+            assert_eq!(s.native_strides(), vec![4]);
+        }
+    }
+
+    #[test]
+    fn strided_step_wraps_in_a_slice_with_derived_geometry() {
+        let s = unsafe { simple(10).new_slice(0, 2, 5) };
+        assert!(matches!(s, BufferView::Slice { .. }));
+        unsafe {
+            assert_eq!(s.native_shape(), vec![5]);
+            assert_eq!(s.native_strides(), vec![2]);
+            assert_eq!(s.offset(), 0);
+        }
+        assert_eq!(s.itemsize(), 1);
+        assert_eq!(s.ndim(), 1);
+        assert_eq!(s.length(), 5);
+    }
+
+    #[test]
+    fn slice_of_slice_composes_through_the_parent_step() {
+        // Re-slicing a strided slice maps `start` through `parent_index`
+        // (buffer.py:386) and multiplies the steps, collapsing to one
+        // wrapper over the original parent.
+        let s2 = unsafe { simple(10).new_slice(0, 2, 5).new_slice(1, 1, 2) };
+        match &s2 {
+            BufferView::Slice {
+                parent,
+                start,
+                step,
+                length,
+                ..
+            } => {
+                assert_eq!((*start, *step, *length), (2, 2, 2));
+                assert!(matches!(**parent, BufferView::Simple { .. }));
+            }
+            _ => panic!("expected collapsed Slice"),
+        }
+        unsafe {
+            assert_eq!(s2.offset(), 2);
+            assert_eq!(s2.native_strides(), vec![2]);
+        }
+    }
+
+    #[test]
+    fn reversed_slice_starts_at_the_high_end() {
+        let s = unsafe { simple(10).new_slice(9, -1, 10) };
+        unsafe {
+            assert_eq!(s.offset(), 9);
+            assert_eq!(s.native_strides(), vec![-1]);
+            assert_eq!(s.native_shape(), vec![10]);
+        }
+        assert!(s.readonly()); // String backing stays readonly through the wrapper
     }
 }

--- a/pyre/pyre-object/src/bufferview.rs
+++ b/pyre/pyre-object/src/bufferview.rs
@@ -271,9 +271,7 @@ impl BufferView {
         unsafe {
             match self {
                 BufferView::Simple { .. } => 1,
-                BufferView::Raw { itemsize, .. } | BufferView::View1D { itemsize, .. } => {
-                    *itemsize
-                }
+                BufferView::Raw { itemsize, .. } | BufferView::View1D { itemsize, .. } => *itemsize,
                 BufferView::Slice { parent, step, .. } => parent.stride0() * *step,
                 BufferView::ViewND {
                     parent, w_strides, ..
@@ -383,9 +381,7 @@ impl BufferView {
             length: slicelength,
         };
         match self {
-            BufferView::Simple {
-                backing, w_obj, ..
-            } if step == 1 => BufferView::Simple {
+            BufferView::Simple { backing, w_obj, .. } if step == 1 => BufferView::Simple {
                 backing: Buffer::sub(backing.clone(), start as usize, slicelength),
                 w_obj: *w_obj,
                 length: slicelength,

--- a/pyre/pyre-object/src/memoryview.rs
+++ b/pyre/pyre-object/src/memoryview.rs
@@ -28,6 +28,9 @@ pub struct W_MemoryView {
     /// geometry and backing live here, off the GC heap, reached by the custom
     /// trace.
     pub view: *const BufferView,
+    /// `self._hash` — the cached content hash, `-1` until computed
+    /// (`memoryobject.py:92`).
+    pub w_hash: i64,
     /// Flips on `release()` / context-manager exit.
     pub released: bool,
 }
@@ -59,6 +62,7 @@ pub fn w_memoryview_alloc_header(released: bool) -> PyObjectRef {
             w_class: crate::pyobject::get_instantiate(&MEMORYVIEW_TYPE),
         },
         view: std::ptr::null(),
+        w_hash: -1,
         released,
     };
     let raw = crate::gc_hook::try_gc_alloc_stable_raw(
@@ -152,6 +156,27 @@ mv_view_scalar!(w_memoryview_readonly, readonly, bool);
 #[inline]
 pub unsafe fn w_memoryview_released(obj: PyObjectRef) -> bool {
     unsafe { (*(obj as *const W_MemoryView)).released }
+}
+
+/// The cached content hash (`self._hash`), `-1` until computed.
+///
+/// # Safety
+/// `obj` must point to a valid `W_MemoryView`.
+#[inline]
+pub unsafe fn w_memoryview_hash(obj: PyObjectRef) -> i64 {
+    unsafe { (*(obj as *const W_MemoryView)).w_hash }
+}
+
+/// Store the computed content hash.  A plain scalar store — no write
+/// barrier (a barrier guards `PyObjectRef` stores only).
+///
+/// # Safety
+/// `obj` must point to a valid `W_MemoryView`.
+#[inline]
+pub unsafe fn w_memoryview_set_hash(obj: PyObjectRef, hash: i64) {
+    unsafe {
+        (*(obj as *mut W_MemoryView)).w_hash = hash;
+    }
 }
 
 /// Release the view: drop the off-heap `BufferView` box (reclaiming any


### PR DESCRIPTION
Completes the memoryview de-flatten epic (#264 lineage): the `BufferView` enum now matches PyPy's view classes one-to-one — `SimpleView`, `RawBufferView`, `BufferSlice`, `BufferView1D`, `BufferViewND`, `ReadonlyWrapper` — and the pyre-only `Strided` stand-in is gone.

## Commits

1. **zero-copy slicing via `Buffer::Sub` and `Slice` view** — `new_slice` (buffer.py:149,261,310,403): a step==1 slice of a plain view re-specialises over a `SubBuffer` window; a strided slice wraps the parent in `BufferView::Slice` with derived dim-0 geometry; slicing a slice composes into the parent's coordinates. Deliberate coordinate fix vs upstream: buffer.py:404's `real_start = start + self.start` mis-places a nonzero start on a step≠1 slice (untested in PyPy); pyre maps start through `parent_index`, matching CPython (`m[::2][1:3]` → elements 2,4). `memoryview(mv)` clones the whole immutable view (variant-preserving copy); all byte access — getitem/setitem/tolist/raw_address, `_socket` recv_into, `struct` pack_into — reads through the view's `Buffer` (new `as_bytes_mut` with the `SubBuffer.getlength` clamp), so a window is never widened back to full storage.
2. **`View1D`/`ViewND` cast + `Readonly` wrapper; drop `Strided`** — `_cast_to_1D` / `_cast_to_ND` (memoryobject.py:635,686) and `ReadonlyWrapper` (buffer.py:415) ported as variants delegating byte access to their boxed parent, so a cast of a zero-copy slice keeps its window; the GC custom trace recurses the view tree.
3. **hash cache in `w_hash`** — `_hash` with the `-1` sentinel (memoryobject.py:92,476): checks run only on the first call, a view hashed before `release()` keeps hashing; the `hash()` builtin's duplicated uncached arm now routes through the same shared helper.

## Verification

- check.py on the final rebased tree: cranelift 161/161, wasm 161/161, dynasm 160/161 (sole miss = `raise_catch` x1.5 perf gate under parallel-build load; pre-existing rotating flake, ratio unchanged from before these commits).
- 46-check slice probe (live windows, parent-mutation visibility, write-through, slice-of-slice composition both orders, slice→cast, empty/edge/ND slices, GC churn over deep slice chains) byte-exact vs CPython 3.14 on both native backends; hash probe matches CPython except the known PyPy divergence (PyPy does not require the exporter itself to be hashable).
- `cargo test -p pyre-object` 211/211; LLBC re-extracted per change and after the base rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `memoryview` slicing, casting, read-only conversion, and nested-view behavior.
  * Fixed writable buffer access for socket and struct operations, preserving zero-copy updates where supported.
  * Improved garbage collection handling for complex and nested memoryviews.
  * Added reliable caching for hash values and maintained correct restrictions on hashing writable views.
  * Preserved shared storage when duplicating views without copying underlying bytes.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->