### PR TITLE
jit: store-loop header merge-point forward-select + list-subscript exact-type guards + int-subclass BigInt

### DIFF
--- a/majit/majit-backend-wasm/src/lib.rs
+++ b/majit/majit-backend-wasm/src/lib.rs
@@ -491,8 +491,10 @@ static CA_GCMAP_ZERO_RUNS: GuestCell<Vec<(usize, &'static [(usize, usize)])>> =
 /// static once and steady-state recursion performs no allocator calls at
 /// all. Entries stay registered as libc jitframes and are never freed
 /// (bounded by peak recursion depth).
-static CA_FRAMES: GuestCell<CaFrames> =
-    GuestCell::new(CaFrames { entries: Vec::new(), live: 0 });
+static CA_FRAMES: GuestCell<CaFrames> = GuestCell::new(CaFrames {
+    entries: Vec::new(),
+    live: 0,
+});
 
 /// Backing store for [`CA_FRAMES`]: `entries[..live]` live, `entries[live..]`
 /// pooled (top at `entries[live]`).

--- a/pyre/pyre-interpreter/src/opcode_ops.rs
+++ b/pyre/pyre-interpreter/src/opcode_ops.rs
@@ -658,13 +658,18 @@ pub extern "C" fn bh_execute_store_subscr(executor_ptr: i64) -> i64 {
 /// already depends on pyre-interpreter for the normal recording-time
 /// helpers (`jit_setitem`, `jit_getitem`, ...).
 ///
-/// `BH_LAST_EXC_VALUE`); the 1/0 polarity parallels
-/// `bh_execute_store_subscr` above and matches the executor's
-/// raise-vs-success ABI for void residual_calls.  The trait-side void
-/// `jit_setitem` instead publishes the raise into the backend
-/// pos_exception cells (the recorded GuardNoException re-raises through
-/// the blackhole resume) — `bh_store_subscr_fn` is the residual-call
-/// leg, which signals the raise to the dispatcher via the 0 return.
+/// `setitem` may enter a user `__setitem__` (MayForce), so a raise is
+/// published into BOTH the backend `_store_exception` cells (via
+/// `jit_publish_exception`, so a compiled trace's trailing
+/// `GuardNoException` side-exits) AND `BH_LAST_EXC_VALUE` (so the
+/// blackhole / full-body walk sees a non-null standing exception). This
+/// dual-publish mirrors `bh_store_attr_fn`
+/// (`call_jit::publish_residual_call_exception`) and `jit_next`; writing
+/// only `BH_LAST_EXC_VALUE` would leave `GuardNoException` reading a
+/// stale 0 and silently swallow the raise. The 1/0 return signals
+/// raise-vs-success to the walker's residual executor. The walker drains
+/// the backend cells after an Err (`jitcode_dispatch.rs` execute-raised
+/// arm), so the extra publish does not leak into tracing.
 #[allow(improper_ctypes_definitions)]
 pub extern "C" fn bh_store_subscr_fn(obj: i64, key: i64, value: i64) -> i64 {
     let obj = obj as pyre_object::PyObjectRef;
@@ -673,6 +678,7 @@ pub extern "C" fn bh_store_subscr_fn(obj: i64, key: i64, value: i64) -> i64 {
     if let Err(err) = crate::baseobjspace::setitem(obj, key, value) {
         let exc_obj = err.to_exc_object();
         majit_metainterp::blackhole::BH_LAST_EXC_VALUE.with(|c| c.set(exc_obj as i64));
+        crate::runtime_ops::jit_publish_exception(exc_obj);
         return 0;
     }
     1

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -1285,12 +1285,19 @@ fn int_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     if int_typeobj.map_or(false, |t| std::ptr::eq(cls, t)) {
         return Ok(value);
     }
-    // cls is a subclass of int. Create a unique W_IntObject (bypassing
-    // the small-int cache so each instance has its own identity).
-    // Set w_class = cls so type()/isinstance() see the subclass while
-    // preserving W_IntObject layout for arithmetic.
-    let int_val = unsafe { pyre_object::w_int_get_value(value) };
-    let obj = pyre_object::w_int_new_unique(int_val);
+    // cls is a subclass of int. Create a unique instance (bypassing the
+    // small-int cache so each has its own identity). Set w_class = cls so
+    // type()/isinstance() see the subclass while preserving the underlying
+    // int/long storage layout for arithmetic. A magnitude that overflows
+    // i64 is a W_LongObject; cloning its BigInt keeps the value intact
+    // (w_int_get_value would truncate it to a garbage machine word).
+    let obj = if unsafe { pyre_object::is_long(value) } {
+        let big = unsafe { pyre_object::w_long_get_value(value) }.clone();
+        pyre_object::w_long_new(big)
+    } else {
+        let int_val = unsafe { pyre_object::w_int_get_value(value) };
+        pyre_object::w_int_new_unique(int_val)
+    };
     unsafe {
         (*obj).w_class = cls;
     }

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -16762,11 +16762,15 @@ fn try_walker_specialize_subscr(
         );
     }
 
-    // Gate: list[int], non-negative index in bounds, int- or float-storage.
-    // A bool index (`is_int` accepts `W_BoolObject`) is fine: bool shares
-    // int's `intval`, so it unboxes through its own &BOOL_TYPE guard below.
+    // Gate: EXACT list[int], non-negative index in bounds, int- or
+    // float-storage.  A bool index (`is_int` accepts `W_BoolObject`) is fine:
+    // bool shares int's `intval`, so it unboxes through its own &BOOL_TYPE
+    // guard below.  A list SUBCLASS instance shares `ob_type == &LIST_TYPE`
+    // but retags `w_class` and may override `__getitem__`; `is_exact_list`
+    // excludes it so it falls to the generic residual (which honours the
+    // override) instead of this direct-storage load.
     let (sid, index, concrete_len) = unsafe {
-        if !pyre_object::pyobject::is_list(list_obj) || !pyre_object::is_int(key_obj) {
+        if !pyre_object::is_exact_list(list_obj) || !pyre_object::is_int(key_obj) {
             return Ok(None);
         }
         let index = pyre_object::w_int_get_value(key_obj);
@@ -16807,6 +16811,18 @@ fn try_walker_specialize_subscr(
     ctx.trace_ctx
         .heap_cache_mut()
         .class_now_known(list_op, list_type_addr);
+
+    // A list SUBCLASS instance shares `ob_type == &LIST_TYPE` (so it passes
+    // the GuardClass above) but retags `w_class` and may override
+    // `__getitem__`; guard the exact canonical `w_class` so such an instance
+    // side-exits to the generic residual (which honours the override) rather
+    // than taking this direct-storage load.
+    walker_guard_exact_w_class(
+        ctx,
+        op_pc,
+        list_op,
+        pyre_object::pyobject::get_instantiate(&pyre_object::pyobject::LIST_TYPE),
+    )?;
 
     // guard_value(strategy == sid): getfield strategy + GuardValue + replace_box.
     let strategy = crate::state::opimpl_getfield_gc_i(
@@ -18111,7 +18127,11 @@ fn try_walker_specialize_store_subscr(
         // route through the generic path — PyPy's IntegerListStrategy rejects a
         // W_BoolObject (`is_correct_type` is exact-type), switching the list to
         // object storage, so the int-storage fast path would drop the bool type.
-        if !pyre_object::pyobject::is_list(list_obj) || !pyre_object::is_int(key_obj) {
+        // EXACT list only: a list SUBCLASS instance shares `ob_type ==
+        // &LIST_TYPE` but retags `w_class` and may override `__setitem__`;
+        // `is_exact_list` excludes it so it falls to the generic residual
+        // (which honours the override) instead of this direct-storage store.
+        if !pyre_object::is_exact_list(list_obj) || !pyre_object::is_int(key_obj) {
             return Ok(None);
         }
         let index = pyre_object::w_int_get_value(key_obj);
@@ -18149,6 +18169,18 @@ fn try_walker_specialize_store_subscr(
     ctx.trace_ctx
         .heap_cache_mut()
         .class_now_known(list_op, list_type_addr);
+
+    // A list SUBCLASS instance shares `ob_type == &LIST_TYPE` (so it passes
+    // the GuardClass above) but retags `w_class` and may override
+    // `__setitem__`; guard the exact canonical `w_class` so such an instance
+    // side-exits to the generic residual (which honours the override) rather
+    // than taking this direct-storage store.
+    walker_guard_exact_w_class(
+        ctx,
+        op_pc,
+        list_op,
+        pyre_object::pyobject::get_instantiate(&pyre_object::pyobject::LIST_TYPE),
+    )?;
 
     // guard_value(strategy == sid): getfield strategy + GuardValue + replace_box.
     let strategy = crate::state::opimpl_getfield_gc_i(

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -1540,7 +1540,7 @@ fn read_float_reg(
 /// writes the resolved target as `chr(target & 0xFF)` +
 /// `chr((target >> 8) & 0xFF)`, matching `bhimpl_goto`'s
 /// `code[pc] | (code[pc+1] << 8)` decode.
-fn read_label(code: &[u8], op: &DecodedOp, operand_offset: usize) -> usize {
+pub(crate) fn read_label(code: &[u8], op: &DecodedOp, operand_offset: usize) -> usize {
     let lo = code[op.pc + 1 + operand_offset] as usize;
     let hi = code[op.pc + 1 + operand_offset + 1] as usize;
     lo | (hi << 8)
@@ -11124,9 +11124,14 @@ fn walker_capture_snapshot_for_last_guard_impl(
                                                 .min()
                                         })
                                 };
+                                // `governing_mp` above mirrors the `<= coord`
+                                // max-first pick, i.e. the body-resume branch;
+                                // pass `body_resume=true` to keep this audit's
+                                // seed identical to that comparison.
                                 let regs_d =
-                                    crate::trace::loop_header_merge_point_regs(code, derived);
-                                let regs_m = crate::trace::loop_header_merge_point_regs(code, m);
+                                    crate::trace::loop_header_merge_point_regs(code, derived, true);
+                                let regs_m =
+                                    crate::trace::loop_header_merge_point_regs(code, m, true);
                                 let mp_eq =
                                     governing_mp(derived) == governing_mp(m) && regs_d == regs_m;
                                 eprintln!(

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -355,9 +355,41 @@ pub fn trace_bytecode(
 /// seeded, e.g. a `goto_if_not` over a non-concrete Int produced by an
 /// unfolded `residual_call`).  See
 /// `project_issue73_architecture_walker_as_tracer_2026_05_28`.
+///
+/// Whether the loop whose header merge point is `header_mp_pc` (the loop a
+/// header entry at `entry` is about to trace) is NESTED inside another loop
+/// still active at `entry`.
+///
+/// A backward `goto/L` (target `< pc`) is a loop back-edge spanning
+/// `[target, goto_pc]`.  The loop being traced is nested iff some back-edge
+/// `[t, g]` ENCLOSES it: it starts before the entry (`t < entry`) and closes
+/// AFTER the whole inner loop (`g > header_mp_pc`).  A PRECEDING sibling
+/// loop's back-edge closes before `entry` (`g < header_mp_pc`) so it does not
+/// match; the inner loop's OWN back-edge is excluded because its target lands
+/// at its own header (the first merge point at or after `t` is `header_mp_pc`
+/// itself, not an earlier loop).
+fn header_entry_is_nested(code: &[u8], entry: usize, header_mp_pc: usize) -> bool {
+    let first_mp_at_or_after = |t: usize| {
+        crate::jitcode_runtime::decoded_ops(code)
+            .filter(|op| op.opname == "jit_merge_point")
+            .map(|op| op.pc)
+            .filter(|&pc| pc >= t)
+            .min()
+    };
+    crate::jitcode_runtime::decoded_ops(code)
+        .filter(|op| op.opname == "goto")
+        .any(|op| {
+            let target = crate::jitcode_dispatch::read_label(code, &op, 0);
+            target < op.pc // backward branch = loop back-edge
+                && target < entry
+                && op.pc > header_mp_pc
+                && first_mp_at_or_after(target).is_some_and(|mp| mp < header_mp_pc)
+        })
+}
+
 /// Decode the loop-header `jit_merge_point` that governs the resume
-/// coordinate `entry` (the nearest one with `pc < entry`) and return its
-/// green-ref (`gr`) and red (`rr`) register lists.
+/// coordinate `entry` and return its green-ref (`gr`) and red (`rr`)
+/// register lists.
 ///
 /// These name the jitcode register colors the loop body reads its
 /// loop-invariant pycode (`gr`) and frame/ec (`rr`) from.  A mid-loop walk
@@ -368,29 +400,58 @@ pub fn trace_bytecode(
 /// count-prefixed register lists `gi, gr, gf, ri, rr, rf`.  Returns `None`
 /// when no preceding merge point exists (straight-line resume) or the
 /// operand stream is truncated.
+///
+/// `body_resume` selects which merge point governs `entry`.  RPython binds
+/// each merge point's greenboxes 1:1 from the op it is ABOUT TO execute
+/// (pyjitpl.py:1537 `opimpl_jit_merge_point(greenboxes, ...)`), because the
+/// MIFrame walks every op forward.  pyre resumes PAST that op at a resume
+/// marker, so it must reconstruct the same op's register colors:
+///  - A HEADER entry (`body_resume=false`, a fresh loop trace) sits at the
+///    loop header's leading `-live-` marker, immediately BEFORE the merge
+///    point the walk is about to reach — so the governing op is the FIRST
+///    merge point at or after `entry`.  Picking the largest one BEFORE
+///    `entry` would select a PRECEDING sibling loop's merge point (a
+///    function with two loops), seeding that loop's pycode/frame/ec colors
+///    and leaving this loop's distinct colors `OpRef::NONE` — the
+///    born-between-loops abort.
+///  - A body-guard bridge resume (`body_resume=true`) enters PAST its loop's
+///    merge point, so the governing op is the LAST merge point at or before
+///    `entry`.
+///
+/// EXCEPTION: a header entry into a loop that is NESTED inside another loop
+/// still active at `entry` (a `for` inside a `while`) keeps the pre-fix
+/// behavior — the enclosing loop's (earlier) merge point is selected, which
+/// leaves the inner loop's own green color `OpRef::NONE` so the inner-loop
+/// trace declines at its merge point instead of compiling.  pyre's walker
+/// miscompiles the bridges an inner nested loop closes into (wrong result),
+/// so declining (and running the inner loop interpreted) is the safe shape
+/// until that separate nested-loop limitation is fixed.  Only the top-level
+/// sibling-loop case is newly enabled by the forward selection.
 pub(crate) fn loop_header_merge_point_regs(
     code: &[u8],
     entry: usize,
+    body_resume: bool,
 ) -> Option<(Vec<u8>, Vec<u8>)> {
-    // The merge point governing `entry`.  A body-guard resume enters PAST the
-    // merge point, so the merge point precedes `entry` and the last `op.pc <=
-    // entry` is the governing one.  A HEADER-entry resume keys to the header
-    // PC's own leading `-live-` marker, inserted immediately before the
-    // header's first insn, which sits just BEFORE the `jit_merge_point` op;
-    // there `entry < mp_pc`, so fall back to the first merge point at or after
-    // `entry`.  A straight-line function has no merge point and returns `None`.
-    let mp_pc = crate::jitcode_runtime::decoded_ops(code)
-        .filter(|op| op.opname == "jit_merge_point")
-        .map(|op| op.pc)
-        .filter(|&pc| pc <= entry)
-        .max()
-        .or_else(|| {
-            crate::jitcode_runtime::decoded_ops(code)
-                .filter(|op| op.opname == "jit_merge_point")
-                .map(|op| op.pc)
-                .filter(|&pc| pc >= entry)
-                .min()
-        })?;
+    let merge_point_pcs = || {
+        crate::jitcode_runtime::decoded_ops(code)
+            .filter(|op| op.opname == "jit_merge_point")
+            .map(|op| op.pc)
+    };
+    let mp_pc = if body_resume {
+        merge_point_pcs()
+            .filter(|&pc| pc <= entry)
+            .max()
+            .or_else(|| merge_point_pcs().filter(|&pc| pc >= entry).min())
+    } else {
+        let forward = merge_point_pcs().filter(|&pc| pc >= entry).min();
+        match forward {
+            Some(f) if !header_entry_is_nested(code, entry, f) => Some(f),
+            _ => merge_point_pcs()
+                .filter(|&pc| pc <= entry)
+                .max()
+                .or(forward),
+        }
+    }?;
     let mut cursor = mp_pc + 1 + 1; // opcode byte + jdindex (`c`)
     let mut lists: [Vec<u8>; 6] = Default::default();
     for slot in lists.iter_mut() {
@@ -1123,7 +1184,7 @@ fn run_perfn_walk(
         // standard virtualizable. The #124 operand-stack override below must
         // not overwrite these (a kept temp never lives in a red-input color).
         let mut reserved_red_colors: Vec<u8> = Vec::new();
-        match loop_header_merge_point_regs(pjc.jitcode.code.as_slice(), entry) {
+        match loop_header_merge_point_regs(pjc.jitcode.code.as_slice(), entry, is_bridge_trace) {
             Some((gr, rr)) => {
                 if let Some(&r) = gr.first() {
                     seed(r, pycode_box);

--- a/pyre/pyre-jit-trace/src/trace_helpers/typed_trace.rs
+++ b/pyre/pyre-jit-trace/src/trace_helpers/typed_trace.rs
@@ -1869,7 +1869,13 @@ pub fn generated_binary_subscr_value(
         }
         let index = pyre_object::w_int_get_value(concrete_key);
 
-        if pyre_object::pyobject::is_tuple(concrete_obj) {
+        // EXACT tuple/list only: a subclass instance shares the builtin
+        // `ob_type` but retags `w_class` and may override `__getitem__`;
+        // exclude it so the read falls to the generic residual (which honours
+        // the override) instead of a direct backing-storage load.  The
+        // arity-2 specialised tuples stay admitted — `is_exact_tuple` reports
+        // them exact (they carry the canonical `tuple` `w_class`).
+        if pyre_object::is_exact_tuple(concrete_obj) {
             let concrete_len = pyre_object::w_tuple_len(concrete_obj);
             if check_index_in_bounds(index, concrete_len) {
                 return Some(generated_tuple_getitem(
@@ -1882,7 +1888,7 @@ pub fn generated_binary_subscr_value(
                     concrete_len,
                 ));
             }
-        } else if pyre_object::pyobject::is_list(concrete_obj) {
+        } else if pyre_object::is_exact_list(concrete_obj) {
             if let Some(sid) = detect_list_getitem_strategy(concrete_obj) {
                 let concrete_len = pyre_object::w_list_len(concrete_obj);
                 if check_index_in_bounds(index, concrete_len) {
@@ -1917,9 +1923,11 @@ pub fn generated_store_subscr_value<F: pyre_jit_trace::walker_frame_ops::WalkerF
         return false;
     }
     unsafe {
-        if pyre_object::pyobject::is_list(concrete_obj)
-            && pyre_object::pyobject::is_int(concrete_key)
-        {
+        // EXACT list only: a list SUBCLASS instance shares `ob_type ==
+        // &LIST_TYPE` but retags `w_class` and may override `__setitem__`;
+        // exclude it so the store falls to the generic residual (which honours
+        // the override) instead of a direct backing-storage write.
+        if pyre_object::is_exact_list(concrete_obj) && pyre_object::pyobject::is_int(concrete_key) {
             if let Some((sid, unbox_long)) =
                 detect_list_setitem_strategy(concrete_obj, concrete_value)
             {

--- a/pyre/pyre-jit-trace/src/trace_helpers/typed_trace.rs
+++ b/pyre/pyre-jit-trace/src/trace_helpers/typed_trace.rs
@@ -686,6 +686,10 @@ pub fn generated_list_setitem_by_strategy<F: pyre_jit_trace::walker_frame_ops::W
         obj,
         &pyre_object::pyobject::LIST_TYPE as *const _ as *const pyre_object::PyType,
     );
+    frame.guard_exact_w_class(
+        obj,
+        pyre_object::pyobject::get_instantiate(&pyre_object::pyobject::LIST_TYPE),
+    );
     frame.guard_list_strategy(obj, strategy_id);
     let len_descr = match strategy_id {
         0 => crate::descr::list_length_descr(),
@@ -1794,6 +1798,12 @@ pub fn generated_dynamic_list_index(
 ///
 /// Combined with guard_class + guard_strategy + opimpl_check_resizable_neg_index
 /// as emitted by jtransform do_resizable_list_getitem.
+///
+/// The runtime exact-`w_class` subclass guard for the LIVE getitem path is
+/// enforced by walker-native `try_walker_specialize_subscr`
+/// (jitcode_dispatch.rs, guard at the `walker_guard_exact_w_class` call);
+/// this typed-trace helper is reached only by the retired executor-trait
+/// path (trace_opcode.rs), so it carries no separate exact-w_class guard.
 ///
 /// strategy_id: 0 = object, 1 = int, 2 = float.
 #[inline]

--- a/pyre/pyre-jit-trace/src/walker_frame_ops.rs
+++ b/pyre/pyre-jit-trace/src/walker_frame_ops.rs
@@ -206,11 +206,8 @@ pub trait WalkerFrameOps {
         if expected_typeobj.is_null() || self.ctx().heap_cache().is_unescaped(obj) {
             return;
         }
-        let actual = crate::state::opimpl_getfield_gc_r(
-            self.ctx_mut(),
-            obj,
-            crate::descr::w_class_descr(),
-        );
+        let actual =
+            crate::state::opimpl_getfield_gc_r(self.ctx_mut(), obj, crate::descr::w_class_descr());
         let expected = self.ctx_mut().const_ref(expected_typeobj as i64);
         let eq = self.ctx_mut().record_op(OpCode::PtrEq, &[actual, expected]);
         self.generate_guard(OpCode::GuardTrue, &[eq]);

--- a/pyre/pyre-jit-trace/src/walker_frame_ops.rs
+++ b/pyre/pyre-jit-trace/src/walker_frame_ops.rs
@@ -193,6 +193,28 @@ pub trait WalkerFrameOps {
         );
         self.implement_guard_value(strategy, expected);
     }
+
+    /// `baseobjspace` subclass-override guard — a builtin SUBCLASS instance
+    /// shares the payload `ob_type` (so it passes `guard_class`) but retags
+    /// `w_class` and may override the dunder; guard the exact canonical
+    /// `w_class` so such an instance side-exits to the generic residual
+    /// (which honours the override) rather than a direct backing-storage
+    /// access.  Skipped when `obj` is a freshly-allocated unescaped virtual
+    /// (cannot be an external subclass instance) or the expected typeobj is
+    /// null.  Walker-native counterpart: `walker_guard_exact_w_class`.
+    fn guard_exact_w_class(&mut self, obj: OpRef, expected_typeobj: pyre_object::PyObjectRef) {
+        if expected_typeobj.is_null() || self.ctx().heap_cache().is_unescaped(obj) {
+            return;
+        }
+        let actual = crate::state::opimpl_getfield_gc_r(
+            self.ctx_mut(),
+            obj,
+            crate::descr::w_class_descr(),
+        );
+        let expected = self.ctx_mut().const_ref(expected_typeobj as i64);
+        let eq = self.ctx_mut().record_op(OpCode::PtrEq, &[actual, expected]);
+        self.generate_guard(OpCode::GuardTrue, &[eq]);
+    }
 }
 
 // `MIFrame` impl — delegates `generate_guard` to the existing


### PR DESCRIPTION
Six commits on top of `main` (the FOR_ITER abort-free heap-store admission from this line already landed via #448 and was dropped during rebase).

## Commits
- **jit: publish STORE_SUBSCR residual exception to backend cells** — `bh_store_subscr_fn` publishes a raise into both `BH_LAST_EXC_VALUE` and the backend `_store_exception` cells, so a compiled trace's trailing `GuardNoException` side-exits instead of reading a stale 0 and swallowing the raise. Mirrors `bh_store_attr_fn` / `jit_next`.
- **jit: guard exact list type in subscript read/store specializations** — walker-native list get/setitem gate on `is_exact_list` and emit a runtime `walker_guard_exact_w_class` (PtrEq on the canonical `w_class`) so a list subclass that shares `ob_type == &LIST_TYPE` but overrides `__getitem__`/`__setitem__` side-exits to the generic residual rather than taking the direct-storage path.
- **jit: forward-select loop-header merge point for header-entry traces** — a header entry selects the FIRST merge point at/after `entry` (`min{mp_pc >= entry}`) instead of the last one before it; the old `max{<= entry}` picked a preceding sibling loop's merge point, seeding that loop's green colors and leaving this loop's pycode color `OpRef::NONE` (the "born-between-loops" `JitMergePointGreenKeyUnresolved` abort). Body-guard bridge resumes keep `max{<= entry}`. `header_entry_is_nested` scopes the change out for a loop nested inside another still-active loop, keeping nested inner loops on the interpreted path (their bridges are separately miscompiled — see #36).
- **jit-trace: exact-w_class guard on residual/trait list setitem path** — adds a default `WalkerFrameOps::guard_exact_w_class` and calls it in `generated_list_setitem_by_strategy`, extending the exact-type guard to the residual/trait store helper (defense-in-depth; the live getitem helper is retired-path only and documented in place).
- **interpreter: preserve BigInt magnitude for int-subclass instances** — `int_descr_new` branches on `is_long`, cloning the `BigInt` into `w_long_new` for magnitudes that overflow i64 (the i64 fast path truncated them to a garbage machine word).
- **style: apply rustfmt to walker_frame_ops exact-w_class guard.**

## Verification
- `cargo build --release` (dynasm) clean; `python pyre/check.py --backend dynasm` → **ALL PASSED: dynasm 161/161**.
- Store-loop benches (prefix / histo / matfill / sieve / copy_scale): 0.78–0.95x regressions → **5–13x**, driven by the merge-point fix letting the second sibling loop compile.
- Nested adversarial shapes (for-in-while / for-in-for / while-in-for / triple / mixed siblings) byte-identical JIT vs `PYRE_NO_JIT=1`.

## Codex parity review
Ran against the true fork point: **Section 1 & 2 = None** (no new parity regressions or mismatches). Section 3/4 findings are all documented adaptations or accurately-documented unreachable pre-existing items (dispositions recorded in `.claude/codex-review-report.md`). Follow-ups filed: #36 (nested-loop bridge exact-resume), #35 (rvmprof port).

— *commented by Claude*
