### PR TITLE
jit: rewind block-head inverse over no-JitCode block prefixes

### DIFF
--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -9331,9 +9331,12 @@ pub(crate) fn python_pc_for_jitcode_pc(metadata: &crate::PyJitCodeMetadata, jit_
     // heads.
     //
     // The `block_head_py_by_jit_pc` table is the precomputed inverse of this
-    // block-head case (marker byte offset → smallest resuming py_pc), built
-    // from the same block-head marker bytes at compile time.  Drained installs
-    // carry it; skeleton / portal-bridge / fixture installs leave it empty.
+    // block-head case (marker byte offset → Python block entry), built from
+    // the same block-head marker bytes at compile time. A no-JitCode prefix is
+    // included in the entry coordinate, so a CACHE / NOT_TAKEN run followed by
+    // constant-folded loads cannot move the inverse into the middle of an arm.
+    // Drained installs carry it; skeleton / portal-bridge / fixture installs
+    // leave it empty.
     if !metadata.block_head_py_by_jit_pc.is_empty() {
         if let Ok(i) = metadata
             .block_head_py_by_jit_pc

--- a/pyre/pyre-jit-trace/src/pyjitcode.rs
+++ b/pyre/pyre-jit-trace/src/pyjitcode.rs
@@ -94,15 +94,17 @@ pub struct PyJitCodeMetadata {
     /// as `after_residual_call_resume_pc`.
     pub first_jit_pc_by_py_pc: Vec<usize>,
     /// Inverse of the derived marker resolution's block-head case: each distinct
-    /// `-live-` marker byte offset that some PC resolves to → the SMALLEST py_pc
-    /// that resolves there (the start of that marker's carry-forward run).
+    /// `-live-` marker byte offset that some PC resolves to → the Python block
+    /// entry. For plain-callee control-flow entries, the dense map's smallest
+    /// resolving PC is rewound over a contiguous no-JitCode prefix so a block
+    /// beginning with trivia / constant-folded ops does not invert to the first
+    /// later opcode that emits JitCode. Other markers keep their dense owner.
     /// Sorted ascending by jitcode offset for binary search.  Replaces the
-    /// former `pc_map.iter().position(|&m| m == jit_pc)` block-head scan in
+    /// former dense-map block-head scan in
     /// `python_pc_for_jitcode_pc` (a coordinate landing exactly on a marker is
     /// a block head — branch/catch target — and belongs to the first opcode
-    /// resuming there).  Equal to `position()` by construction; empty for
-    /// skeleton / portal-bridge / fixture metadata, where the legacy scan
-    /// remains the fallback.
+    /// resuming there). Empty for skeleton / portal-bridge / fixture metadata,
+    /// where the legacy scan remains the fallback.
     pub block_head_py_by_jit_pc: Vec<(usize, u32)>,
     /// task#50 sparse carry-forward sidecar: the `-live-` marker byte offset
     /// for each py_pc whose dense marker the on-demand [`derive_resume_marker`]

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -1070,6 +1070,21 @@ fn derive_after_call_indices_from_sparse(
     out
 }
 
+/// Recover a candidate Python block entry for an exact JitCode `-live-`
+/// marker. `pc_map` names the first Python PC that resolves to the marker, but
+/// a block can start with a run of opcodes that emit no JitCode of their own
+/// (trivia, constant-folded loads, fused local loads). In that case the first
+/// resolving PC is the later emitting opcode, while the marker belongs to the
+/// start of the preceding no-emission run. The metadata builder accepts this
+/// candidate only for control-flow entries in plain-callee JitCodes; portal and
+/// non-entry marker ownership stays unchanged.
+fn block_head_python_pc(first_jit_pc_by_py_pc: &[usize], mut py: usize) -> usize {
+    while py > 0 && first_jit_pc_by_py_pc[py - 1] == usize::MAX {
+        py -= 1;
+    }
+    py
+}
+
 fn fresh_variable_for_state(
     graph: &mut super::flow::FunctionGraph,
     kind: Option<Kind>,
@@ -12506,16 +12521,28 @@ impl CodeWriter {
             first_jit_pc_by_py_pc[*py_pc] = combined_bytes[first_insn_base + k];
         }
 
-        // Block-head inverse: for each distinct marker byte offset, record the
-        // FIRST (smallest) py_pc that resolves to it.  Ascending `py` iteration
-        // with first-write-wins reproduces `pc_map.iter().position(|&m| m == off)`
-        // exactly, indexed for binary search.
+        // Block-head inverse: for each distinct marker byte offset, start from
+        // the FIRST py_pc that resolves to it. For a control-flow entry in a
+        // plain-callee JitCode, rewind over the contiguous no-JitCode prefix
+        // immediately before that PC. Such a block can begin with CACHE /
+        // NOT_TAKEN plus constant-folded or fused loads; those PCs do not occur
+        // in `first_jit_pc_by_py_pc`, so the first dense `pc_map` hit otherwise
+        // names a later mid-arm opcode. Portal JitCodes emit live frame/global
+        // reads at these entries and already invert correctly; non-entry markers
+        // keep their dense-map owner as well.
         let mut block_head_py_by_jit_pc: Vec<(usize, u32)> = Vec::new();
         {
+            let branch_targets = find_branch_target_pcs(code);
             let mut seen: std::collections::HashSet<usize> = std::collections::HashSet::new();
             for (py, &off) in pc_map_bytes.iter().enumerate() {
                 if seen.insert(off) {
-                    block_head_py_by_jit_pc.push((off, py as u32));
+                    let rewound = block_head_python_pc(&first_jit_pc_by_py_pc, py);
+                    let block_py = if !is_portal && branch_targets.contains(&rewound) {
+                        rewound
+                    } else {
+                        py
+                    };
+                    block_head_py_by_jit_pc.push((off, block_py as u32));
                 }
             }
             block_head_py_by_jit_pc.sort_unstable_by_key(|&(off, _)| off);
@@ -12605,12 +12632,8 @@ impl CodeWriter {
                     by_off.insert(pos, py);
                 }
             }
-            let mut marker_seen: std::collections::HashSet<usize> =
-                std::collections::HashSet::new();
-            for (py, &off) in pc_map_bytes.iter().enumerate() {
-                if marker_seen.insert(off) {
-                    by_off.insert(off, py);
-                }
+            for &(off, py) in &block_head_py_by_jit_pc {
+                by_off.insert(off, py as usize);
             }
             // Compile-time twin of `skip_python_trivia_forward`
             // (jitcode_dispatch.rs:9126): advance past Python trivia opcodes to
@@ -12647,13 +12670,12 @@ impl CodeWriter {
                 depth_pred_by_jit_pc.push((off, depth));
                 const_ref_slots_by_jit_pc.push((off, const_slots));
             }
-            // Marker tier: exact-match, block-head precedence (first-seen dedup
-            // gives the smallest py resolving at the marker offset).
-            for (py, &off) in pc_map_bytes.iter().enumerate() {
-                if marker_seen.remove(&off) {
-                    let depth_trivia = static_depth.get(skip_trivia(py)).copied();
-                    depth_trivia_marker_by_jit_pc.push((off, depth_trivia));
-                }
+            // Marker tier: exact-match, block-head precedence. Source the
+            // corrected block-entry PC from the inversion table so the direct
+            // depth twin and `python_pc_for_jitcode_pc` cannot diverge.
+            for &(off, py) in &block_head_py_by_jit_pc {
+                let depth_trivia = static_depth.get(skip_trivia(py as usize)).copied();
+                depth_trivia_marker_by_jit_pc.push((off, depth_trivia));
             }
             depth_trivia_marker_by_jit_pc.sort_unstable_by_key(|&(off, _)| off);
             // Op-start tier: predecessor scan, markers EXCLUDED.
@@ -13280,6 +13302,15 @@ mod tests {
     use pyre_interpreter::bytecode::{CodeObject, ConstantData};
     use pyre_interpreter::compile_exec;
     use std::sync::Arc;
+
+    #[test]
+    fn block_head_python_pc_rewinds_unemitted_prefix() {
+        let first = vec![3, 11, usize::MAX, usize::MAX, usize::MAX, 27];
+
+        assert_eq!(block_head_python_pc(&first, 5), 2);
+        assert_eq!(block_head_python_pc(&first, 1), 1);
+        assert_eq!(block_head_python_pc(&first, 0), 0);
+    }
 
     /// A coalesce candidate whose two endpoints hold distinct canonical
     /// CPython slots — including the disjoint-live inline-callee case that is


### PR DESCRIPTION
## Summary

The block-head inverse table (`block_head_py_by_jit_pc`) recorded, for each distinct `-live-` marker byte offset, the first Python PC that resolves to it in the dense `pc_map`. A branch-target block can begin with a run of opcodes that emit no JitCode of their own (CACHE / NOT_TAKEN, constant-folded or fused loads); those PCs never appear in `first_jit_pc_by_py_pc`, so the recorded owner was the first LATER opcode that emits JitCode — a mid-arm coordinate.

For a branch guard in an inlined callee (#68 multiframe path) this made `python_pc_for_jitcode_pc(other_target)` + `depth_at_py_pc` report the mid-arm operand-stack depth (e.g. 4 where the true not-taken-arm entry has depth 0, per `dis.stack_effect` ground truth), producing a spurious kept-stack classification and a spurious `BranchGuardUnrestorableKeptStackPermanent` decline (`calls_closures` in the synth corpus — the last PERMANENT kept-stack decliner).

The fix rewinds the recorded owner over the contiguous no-JitCode prefix (`block_head_python_pc`), applied to control-flow entries in plain-callee JitCodes; portal JitCodes emit live frame/global reads at these entries and already invert correctly, and non-entry markers keep their dense-map owner. The `depth_trivia` marker tier now sources the same corrected table so the direct depth twin and `python_pc_for_jitcode_pc` cannot diverge.

This is the prerequisite fix identified while closing the kept-stack decline frontier (#462): sound relaxation of the sub-walk kept-stack decline and per-callee-frame resume liveness (PyPy `opencoder.py` per-frame `jitcode.index` parity) are gated on these coordinates being correct.

## Verification

- `calls_closures`: the callee branch guard now compiles (spurious decline gone), byte-exact vs `PYRE_NO_JIT=1`
- Former decliners (`exec_defined_global_read`, `loops_comprehension`) byte-exact; user-iterator FOR_ITER pair (`iteration_protocol`, `seqiter_getitem_lazy`) still correctly declines (proven load-bearing) and stays byte-exact
- 30 adversarial kept-stack / short-circuit / user-iterator / callee-shape repros byte-exact
- Full synth sweep 151/151 JIT==NOJIT
- `check.py` cranelift **161/161**, dynasm **161/161** (no perf flakes this run)
- New unit test `block_head_python_pc_rewinds_unemitted_prefix`

Code authored by Codex (gpt-5.6-sol) under Claude orchestration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)