### PR TITLE
jit: retire PYRE_FBW_BRIDGE_TERMINATE_NOREPLAY bisection gate

### DIFF
--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -7562,21 +7562,6 @@ pub(crate) fn fbw_no_replay_exit_enabled() -> bool {
     *ENABLED.get_or_init(|| std::env::var("PYRE_FBW_NO_REPLAY_EXIT").as_deref() != Ok("0"))
 }
 
-/// Whether a guard-failure BRIDGE walk that reached `Terminate` with a
-/// captured finish-concrete carries that result forward
-/// (`DoneWithThisFrame`) instead of rewinding to the guard pc and
-/// re-interpreting the region.  Without it the walk executes every residual
-/// once and then the `ContinueRunningNormally` re-entry re-executes the
-/// region a second time, double-applying any callee-internal side effect
-/// (e.g. `self.pos += 1` inside a residual `bump()`, #177).  Default ON;
-/// `PYRE_FBW_BRIDGE_TERMINATE_NOREPLAY=0` opts back into the legacy
-/// rewind-and-replay for bisection.
-pub fn fbw_bridge_terminate_noreplay_enabled() -> bool {
-    static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
-    *ENABLED
-        .get_or_init(|| std::env::var("PYRE_FBW_BRIDGE_TERMINATE_NOREPLAY").as_deref() != Ok("0"))
-}
-
 /// Arm/disarm the bridge `Terminate` no-replay shortcut for the next walk
 /// (see [`FBW_BRIDGE_NOREPLAY_ARMED`]).  The bridge tracer sets it before
 /// the walk and clears it after.

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -1633,8 +1633,8 @@ fn run_perfn_walk(
     // CALL_ASSEMBLER callback, which cannot consume a concrete result), so a
     // committed journal never strands into a blackhole re-run; the three
     // decisions (this predicate, the journal commit below, and the caller's
-    // consume-vs-rewind) stay in agreement.  `PYRE_FBW_BRIDGE_TERMINATE_NOREPLAY=0`
-    // (folded into the armed flag) restores the legacy rewind-and-replay.
+    // consume-vs-rewind) stay in agreement.  A multiframe resume is never
+    // armed, so it stays on the legacy rewind-and-replay path.
     let terminate_no_replay = crate::jitcode_dispatch::fbw_no_replay_exit_enabled()
         && (!is_bridge_trace || crate::jitcode_dispatch::fbw_bridge_noreplay_armed())
         && matches!(

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -2437,17 +2437,13 @@ pub fn trace_and_compile_from_bridge(
     let live_frame_addr = frame as *const PyFrame as usize;
     let mut adopted_walk_end_state = false;
     // Arm the bridge `Terminate` no-replay shortcut for this walk only when
-    // the gate is on, the caller can consume a concrete result, and the
-    // resume is single-frame.  The walk epilogue (`run_perfn_walk` in
-    // trace.rs) reads this flag: only when armed does a bridge `Terminate`
-    // walk keep its finish-concrete stash + commit the store journal, so the
-    // three decisions (epilogue predicate, journal commit, the
-    // consume-vs-rewind below) stay in agreement and a committed journal
-    // never strands into a blackhole re-run.
-    let bridge_noreplay_armed =
-        pyre_jit_trace::jitcode_dispatch::fbw_bridge_terminate_noreplay_enabled()
-            && allow_finish_direct_return
-            && !is_multiframe_resume;
+    // the caller can consume a concrete result and the resume is single-frame.
+    // The walk epilogue (`run_perfn_walk` in trace.rs) reads this flag: only
+    // when armed does a bridge `Terminate` walk keep its finish-concrete stash
+    // + commit the store journal, so the three decisions (epilogue predicate,
+    // journal commit, the consume-vs-rewind below) stay in agreement and a
+    // committed journal never strands into a blackhole re-run.
+    let bridge_noreplay_armed = allow_finish_direct_return && !is_multiframe_resume;
     pyre_jit_trace::jitcode_dispatch::fbw_bridge_noreplay_arm(bridge_noreplay_armed);
     let outcome = {
         let (driver, _) = crate::eval::driver_pair();


### PR DESCRIPTION
Follow-up cleanup for the #177 bridge-Terminate no-replay fix, which landed in
#472 (`a67d24956ae`) behind a default-on env gate `PYRE_FBW_BRIDGE_TERMINATE_NOREPLAY`
used only for bisection during that investigation. With #472 merged and CI green,
the gate is retired.

## What changes

- Delete `fbw_bridge_terminate_noreplay_enabled()` (the `OnceLock` env helper) in
  `jitcode_dispatch.rs`.
- Drop the gate conjunct from the bridge-arming expression in `call_jit.rs`; it now
  reads `allow_finish_direct_return && !is_multiframe_resume`.
- Update the two comments (`trace.rs`, `call_jit.rs`) that referenced the env var.

The multiframe correctness boundary (`!is_multiframe_resume`) and the
arm/armed mechanism (`fbw_bridge_noreplay_arm`/`fbw_bridge_noreplay_armed`) are
unchanged. The removed conjunct was default-true, so **default runtime behavior is
byte-identical** — single-frame bridge `Terminate` no-replay is now unconditional,
multiframe stays on the legacy rewind-and-replay path exactly as before.

## Verification

- `cargo check -p pyre-jit-trace` / `-p pyre-jit` (dynasm) ✓
- `#177` repro suite (repro/V1/V3/sweep/mf1/mf2) — all exact ✓
- `python3 pyre/check.py --backend dynasm` → **161/161 ✓**
- No residual references to the removed gate.

## Follow-up (not in this PR)

The multiframe bridge-`Terminate` double-mutation corner is an unreproducible
theoretical gap (every reachable #177/shlex/textwrap case resolves single-frame).
A real fix requires carrying the concrete result across a multiframe
`DoneWithThisFrame` (larger arch change). Leaving multiframe on the legacy path is
no regression versus pre-#177.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
