### PR TITLE
str: PyPy codecs and finalizer support

### DIFF
--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -384,6 +384,10 @@ fn install_gc_box(mut gc: Box<dyn GcAllocator>) {
     majit_gc::set_active_gc_owns_object(Some(gc_owns_object_via_active_runtime));
     majit_gc::set_active_gc_id_or_identityhash(Some(id_or_identityhash_via_active_runtime));
     majit_gc::set_active_write_barrier(Some(gc_write_barrier_via_active_runtime));
+    majit_gc::set_active_finalizer_hooks(
+        Some(register_finalizer_via_active_runtime),
+        Some(finalizer_next_dead_via_active_runtime),
+    );
 }
 
 /// Production path: install a `GcHandle` forwarding to the global singleton.
@@ -1552,6 +1556,18 @@ fn collect_full_via_active_runtime() {
 /// it runs no minor, so a Rust-stack nursery PyObjectRef cannot dangle.
 fn collect_oldgen_nonmoving_via_active_runtime() {
     with_cranelift_gc(|gc| gc.collect_oldgen_nonmoving());
+}
+
+fn register_finalizer_via_active_runtime(
+    fq_index: usize,
+    obj: GcRef,
+    trigger: majit_gc::FinalizerTriggerFn,
+) {
+    with_cranelift_gc(|gc| gc.register_finalizer(fq_index, obj, trigger));
+}
+
+fn finalizer_next_dead_via_active_runtime(fq_index: usize) -> Option<GcRef> {
+    with_cranelift_gc(|gc| gc.finalizer_next_dead(fq_index)).flatten()
 }
 
 /// Report `(oldgen_total, nursery_used)` for the interpreter GC safepoint.

--- a/majit/majit-backend-dynasm/src/runner.rs
+++ b/majit/majit-backend-dynasm/src/runner.rs
@@ -162,6 +162,10 @@ fn install_gc_box(gc: Box<dyn majit_gc::GcAllocator>) {
     majit_gc::set_active_gc_owns_object(Some(dynasm_gc_owns_object));
     majit_gc::set_active_gc_id_or_identityhash(Some(dynasm_id_or_identityhash));
     majit_gc::set_active_write_barrier(Some(dynasm_gc_write_barrier));
+    majit_gc::set_active_finalizer_hooks(
+        Some(dynasm_register_finalizer),
+        Some(dynasm_finalizer_next_dead),
+    );
 }
 
 /// Production path: install a `GcHandle` (zero-size, routes through
@@ -392,6 +396,29 @@ fn dynasm_collect_oldgen_nonmoving() {
             gc.collect_oldgen_nonmoving();
         }
     });
+}
+
+fn dynasm_register_finalizer(
+    fq_index: usize,
+    obj: GcRef,
+    trigger: majit_gc::FinalizerTriggerFn,
+) {
+    DYNASM_ACTIVE_GC.with(|cell| {
+        let mut guard = cell.borrow_mut();
+        if let Some(gc) = guard.as_deref_mut() {
+            gc.register_finalizer(fq_index, obj, trigger);
+        }
+    });
+}
+
+fn dynasm_finalizer_next_dead(fq_index: usize) -> Option<GcRef> {
+    DYNASM_ACTIVE_GC.with(|cell| {
+        let mut guard = cell.borrow_mut();
+        match guard.as_deref_mut() {
+            Some(gc) => gc.finalizer_next_dead(fq_index),
+            None => None,
+        }
+    })
 }
 
 /// Report `(oldgen_total, nursery_used)` for the interpreter GC safepoint.

--- a/majit/majit-backend-dynasm/src/runner.rs
+++ b/majit/majit-backend-dynasm/src/runner.rs
@@ -398,11 +398,7 @@ fn dynasm_collect_oldgen_nonmoving() {
     });
 }
 
-fn dynasm_register_finalizer(
-    fq_index: usize,
-    obj: GcRef,
-    trigger: majit_gc::FinalizerTriggerFn,
-) {
+fn dynasm_register_finalizer(fq_index: usize, obj: GcRef, trigger: majit_gc::FinalizerTriggerFn) {
     DYNASM_ACTIVE_GC.with(|cell| {
         let mut guard = cell.borrow_mut();
         if let Some(gc) = guard.as_deref_mut() {

--- a/majit/majit-backend-wasm/src/lib.rs
+++ b/majit/majit-backend-wasm/src/lib.rs
@@ -331,11 +331,7 @@ fn wasm_collect_oldgen_nonmoving() {
     });
 }
 
-fn wasm_register_finalizer(
-    fq_index: usize,
-    obj: GcRef,
-    trigger: majit_gc::FinalizerTriggerFn,
-) {
+fn wasm_register_finalizer(fq_index: usize, obj: GcRef, trigger: majit_gc::FinalizerTriggerFn) {
     WASM_ACTIVE_GC.with(|cell| {
         if let Some(gc) = cell.borrow_mut().as_deref_mut() {
             gc.register_finalizer(fq_index, obj, trigger);

--- a/majit/majit-backend-wasm/src/lib.rs
+++ b/majit/majit-backend-wasm/src/lib.rs
@@ -244,6 +244,10 @@ fn install_gc_box(gc: Box<dyn majit_gc::GcAllocator>) {
     majit_gc::set_active_write_barrier(Some(wasm_active_gc_write_barrier));
     majit_gc::set_active_collect_oldgen(Some(wasm_collect_oldgen_nonmoving));
     majit_gc::set_active_heap_stats(Some(active_gc_heap_stats));
+    majit_gc::set_active_finalizer_hooks(
+        Some(wasm_register_finalizer),
+        Some(wasm_finalizer_next_dead),
+    );
 }
 
 /// Production path: install a `GcHandle` forwarding to the global singleton.
@@ -325,6 +329,25 @@ fn wasm_collect_oldgen_nonmoving() {
             gc.collect_oldgen_nonmoving();
         }
     });
+}
+
+fn wasm_register_finalizer(
+    fq_index: usize,
+    obj: GcRef,
+    trigger: majit_gc::FinalizerTriggerFn,
+) {
+    WASM_ACTIVE_GC.with(|cell| {
+        if let Some(gc) = cell.borrow_mut().as_deref_mut() {
+            gc.register_finalizer(fq_index, obj, trigger);
+        }
+    });
+}
+
+fn wasm_finalizer_next_dead(fq_index: usize) -> Option<GcRef> {
+    WASM_ACTIVE_GC.with(|cell| match cell.borrow_mut().as_deref_mut() {
+        Some(gc) => gc.finalizer_next_dead(fq_index),
+        None => None,
+    })
 }
 
 /// `majit_gc::CheckIsObjectFn` installed by `set_gc_allocator`.

--- a/majit/majit-gc/src/collector.rs
+++ b/majit/majit-gc/src/collector.rs
@@ -406,6 +406,8 @@ pub struct MiniMarkGC {
     /// gc/base.py finalizer handlers: one death deque and trigger per queue.
     finalizer_handlers: Vec<FinalizerHandler>,
     finalizer_lock: bool,
+    /// incminimark.py:394 `self.enabled = True`.
+    enabled: bool,
     /// True while [`do_collect_oldgen_nonmoving`](MiniMarkGC::do_collect_oldgen_nonmoving)
     /// is running. A non-moving major skips the leading minor, so unlike
     /// `do_collect_full` it marks through a *populated* nursery: `mark_object`
@@ -581,6 +583,7 @@ impl MiniMarkGC {
             old_objects_with_finalizers: VecDeque::new(),
             finalizer_handlers: Vec::new(),
             finalizer_lock: false,
+            enabled: true,
             oldgen_nonmoving_active: false,
             oldgen_nonmoving_nursery_marks: Vec::new(),
             config,
@@ -1782,6 +1785,12 @@ impl MiniMarkGC {
     /// minors may need multiple consecutive steps so old-gen growth does not
     /// outrun marking.
     fn run_major_progress_after_minor(&mut self) {
+        // incminimark.py:832 — automatic major progress after a minor stops
+        // while disabled; explicit collect() passes force_enabled and stays
+        // ungated (collect_full / collect_oldgen_nonmoving here).
+        if !self.enabled {
+            return;
+        }
         if !self.incr_state.marking_in_progress && !self.threshold_reached(0) {
             return;
         }
@@ -2248,6 +2257,19 @@ impl MiniMarkGC {
         self.incr_state.objects_marked
     }
 
+    /// incminimark.py:530-537 `enable` / `disable` / `isenabled`.
+    pub fn enable(&mut self) {
+        self.enabled = true;
+    }
+
+    pub fn disable(&mut self) {
+        self.enabled = false;
+    }
+
+    pub fn isenabled(&self) -> bool {
+        self.enabled
+    }
+
     /// Set the per-step marking budget in bytes.
     pub fn set_mark_budget(&mut self, budget: usize) {
         self.incr_state.mark_budget_per_step = budget;
@@ -2678,6 +2700,9 @@ impl MiniMarkGC {
     /// If a cycle is already in progress, one bounded marking step is
     /// performed. Returns true if any GC work was done.
     pub fn gc_step(&mut self) -> bool {
+        if !self.enabled {
+            return false;
+        }
         if self.threshold_reached(0) && !self.incr_state.marking_in_progress {
             self.start_incremental_cycle();
             let done = self.incremental_mark_step();
@@ -3104,6 +3129,18 @@ impl GcAllocator for MiniMarkGC {
 
     fn collect_oldgen_nonmoving(&mut self) {
         self.do_collect_oldgen_nonmoving();
+    }
+
+    fn enable(&mut self) {
+        self.enable();
+    }
+
+    fn disable(&mut self) {
+        self.disable();
+    }
+
+    fn isenabled(&self) -> bool {
+        self.isenabled()
     }
 
     fn register_finalizer(&mut self, fq_index: usize, obj: GcRef, trigger: FinalizerTriggerFn) {
@@ -5631,6 +5668,22 @@ mod tests {
         // With an almost-empty old gen, gc_step should do nothing.
         assert!(!gc.gc_step());
         assert!(!gc.is_incremental_marking());
+    }
+
+    #[test]
+    fn test_gc_step_respects_enabled_flag() {
+        let mut gc = test_gc(4096);
+        gc.register_type(TypeInfo::simple(16));
+        gc.alloc_in_oldgen(0, GcHeader::SIZE + 16);
+        gc.next_major_collection_threshold = 0.0;
+        assert!(gc.threshold_reached(0));
+
+        gc.disable();
+        assert!(!gc.gc_step());
+        assert!(!gc.incr_state.marking_in_progress);
+
+        gc.enable();
+        assert!(gc.gc_step());
     }
 
     #[test]

--- a/majit/majit-gc/src/collector.rs
+++ b/majit/majit-gc/src/collector.rs
@@ -8,13 +8,14 @@
 /// Modeled after incminimark's minor/major collection.
 use indexmap::{IndexMap, IndexSet};
 use majit_ir::GcRef;
+use std::collections::VecDeque;
 
-use crate::GcAllocator;
 use crate::flags;
 use crate::header::{GcHeader, header_of};
 use crate::nursery::{DEFAULT_NURSERY_SIZE, Nursery};
 use crate::oldgen::OldGen;
 use crate::trace::{ClassTypeLayout, TypeEntry, TypeInfo, TypeInfoLayout, TypeRegistry};
+use crate::{FinalizerTriggerFn, GcAllocator};
 
 /// Configuration for the MiniMarkGC.
 pub struct GcConfig {
@@ -339,6 +340,11 @@ impl IncrementalMarkState {
     }
 }
 
+struct FinalizerHandler {
+    deque: VecDeque<usize>,
+    trigger: FinalizerTriggerFn,
+}
+
 /// The MiniMark generational GC.
 #[allow(non_snake_case)] // _T_IS_RPYTHON_INSTANCE_BYTE keeps the RPython spelling
 pub struct MiniMarkGC {
@@ -390,6 +396,16 @@ pub struct MiniMarkGC {
     /// (incminimark.py:2510-2511, :2897-2912) before the major sweep:
     /// a VISITED object survives, a dying one's destructor runs.
     old_objects_with_destructors: Vec<usize>,
+    /// incminimark.py:388-390.  Registrations first enter the probably-young
+    /// deque as `(object, finalizer-handler-index)` pairs and are promoted by
+    /// the next minor collection.
+    probably_young_objects_with_finalizers: VecDeque<(usize, usize)>,
+    /// incminimark.py:392-393.  Old objects still waiting to become
+    /// unreachable, paired with their translated FinalizerQueue handler.
+    old_objects_with_finalizers: VecDeque<(usize, usize)>,
+    /// gc/base.py finalizer handlers: one death deque and trigger per queue.
+    finalizer_handlers: Vec<FinalizerHandler>,
+    finalizer_lock: bool,
     /// True while [`do_collect_oldgen_nonmoving`](MiniMarkGC::do_collect_oldgen_nonmoving)
     /// is running. A non-moving major skips the leading minor, so unlike
     /// `do_collect_full` it marks through a *populated* nursery: `mark_object`
@@ -561,6 +577,10 @@ impl MiniMarkGC {
             old_objects_with_weakrefs: Vec::new(),
             young_objects_with_destructors: Vec::new(),
             old_objects_with_destructors: Vec::new(),
+            probably_young_objects_with_finalizers: VecDeque::new(),
+            old_objects_with_finalizers: VecDeque::new(),
+            finalizer_handlers: Vec::new(),
+            finalizer_lock: false,
             oldgen_nonmoving_active: false,
             oldgen_nonmoving_nursery_marks: Vec::new(),
             config,
@@ -1071,6 +1091,12 @@ impl MiniMarkGC {
             }
         }
 
+        // incminimark.py:1838-1841: registered young finalizers all survive
+        // this minor and move to the old-registration deque.
+        if !self.probably_young_objects_with_finalizers.is_empty() {
+            self.deal_with_young_objects_with_finalizers();
+        }
+
         // incminimark.py:1843-1862: while True loop —
         // collect_cardrefs_to_nursery, then collect_oldrefs_to_nursery.
         // collect_oldrefs_to_nursery may cause new card-marked objects to
@@ -1240,6 +1266,34 @@ impl MiniMarkGC {
             if self.oldgen.contains(pointing_to) {
                 self.old_objects_with_weakrefs.push(new_obj);
             }
+        }
+    }
+
+    /// incminimark.py:2914-2926 `deal_with_young_objects_with_finalizers`.
+    fn deal_with_young_objects_with_finalizers(&mut self) {
+        while let Some((obj_addr, fq_index)) =
+            self.probably_young_objects_with_finalizers.pop_front()
+        {
+            let current = if self.is_nursery_object_start(obj_addr) {
+                let hdr = unsafe { header_of(obj_addr) };
+                if unsafe { (*hdr).has_flag(flags::IGNORE_FINALIZER) } {
+                    continue;
+                }
+                let mut root = GcRef(obj_addr);
+                self.drag_out_root(&mut root);
+                root.0
+            } else {
+                if !self.is_managed_heap_object(obj_addr) {
+                    continue;
+                }
+                let hdr = unsafe { header_of(obj_addr) };
+                if unsafe { (*hdr).has_flag(flags::IGNORE_FINALIZER) } {
+                    continue;
+                }
+                obj_addr
+            };
+            self.old_objects_with_finalizers
+                .push_back((current, fq_index));
         }
     }
 
@@ -1708,6 +1762,17 @@ impl MiniMarkGC {
         crate::shadow_stack::walk_extra_roots(|gcref| {
             self.seed_major_root(*gcref);
         });
+
+        // gc/base.py `enum_pending_finalizers`: objects already moved to a
+        // death queue remain GC roots until app-level code pops them.
+        let pending: Vec<usize> = self
+            .finalizer_handlers
+            .iter()
+            .flat_map(|handler| handler.deque.iter().copied())
+            .collect();
+        for addr in pending {
+            self.seed_major_root(GcRef(addr));
+        }
     }
 
     /// Drive incremental major-collection progress after a minor collection.
@@ -1904,7 +1969,9 @@ impl MiniMarkGC {
         // VISITED bit on every old-gen object is still meaningful at
         // this point; sweep below tears down `VISITED` per object as
         // it walks oldgen.
-        if !self.old_objects_with_weakrefs.is_empty() {
+        if !self.old_objects_with_finalizers.is_empty() {
+            self.deal_with_objects_with_finalizers();
+        } else if !self.old_objects_with_weakrefs.is_empty() {
             self.invalidate_old_weakrefs();
         }
         // A non-moving major (do_collect_oldgen_nonmoving) runs with a live
@@ -1949,6 +2016,7 @@ impl MiniMarkGC {
         );
         self.bytes_made_old_since_cycle = 0;
         self.threshold_bytes_made_old = 0;
+        self.execute_finalizer_triggers();
     }
 
     /// incminimark.py:3105-3126 `invalidate_old_weakrefs(self)`.
@@ -1991,15 +2059,144 @@ impl MiniMarkGC {
                 new_with_weakref.push(obj_addr);
                 continue;
             }
-            // The target's header reports VISITED → the weakref survives.
+            // incminimark.py:3120-3121: queued finalizers carry VISITED so
+            // they survive this cycle, but FINALIZATION_ORDERING still makes
+            // their weakrefs observe death before `__del__` runs.
             let target_hdr = (pointing_to - GcHeader::SIZE) as *const GcHeader;
-            if unsafe { (*target_hdr).has_flag(flags::VISITED) } {
+            if unsafe {
+                (*target_hdr).has_flag(flags::VISITED)
+                    && !(*target_hdr).has_flag(flags::FINALIZATION_ORDERING)
+            } {
                 new_with_weakref.push(obj_addr);
             } else {
                 unsafe { (*weakptr_slot).0 = 0 };
             }
         }
         self.old_objects_with_weakrefs = new_with_weakref;
+    }
+
+    fn finalization_state(&self, obj_addr: usize) -> u8 {
+        let hdr = unsafe { header_of(obj_addr) };
+        let visited = unsafe { (*hdr).has_flag(flags::VISITED) };
+        let ordering = unsafe { (*hdr).has_flag(flags::FINALIZATION_ORDERING) };
+        match (visited, ordering) {
+            (false, false) => 0,
+            (false, true) => 1,
+            (true, true) => 2,
+            (true, false) => 3,
+        }
+    }
+
+    /// Return the GC-managed outgoing references of one object.  This is the
+    /// collector `trace()` callback shape used by incminimark's finalization
+    /// ordering walk, kept separate from normal VISITED marking.
+    fn finalizer_children(&self, obj_addr: usize) -> Vec<usize> {
+        let type_id = unsafe { (*header_of(obj_addr)).type_id() };
+        let info = self.types.get(type_id);
+        let mut children = Vec::new();
+        if let Some(trace_fn) = info.custom_trace {
+            unsafe {
+                trace_fn(obj_addr, &mut |slot_ptr: *mut GcRef| {
+                    let child = *slot_ptr;
+                    if !child.is_null() && self.is_managed_heap_object(child.0) {
+                        children.push(child.0);
+                    }
+                });
+            }
+            return children;
+        }
+        for &offset in &info.gc_ptr_offsets {
+            let child = unsafe { *((obj_addr + offset) as *const GcRef) };
+            if !child.is_null() && self.is_managed_heap_object(child.0) {
+                children.push(child.0);
+            }
+        }
+        if info.items_have_gc_ptrs && info.item_size > 0 {
+            let length = unsafe { *((obj_addr + info.length_offset) as *const usize) };
+            let items_start = obj_addr + info.size;
+            for i in 0..length {
+                let child = unsafe { *((items_start + i * info.item_size) as *const GcRef) };
+                if !child.is_null() && self.is_managed_heap_object(child.0) {
+                    children.push(child.0);
+                }
+            }
+        }
+        children
+    }
+
+    fn recursively_clear_finalization_ordering(&mut self, obj_addr: usize) {
+        let mut pending = vec![obj_addr];
+        while let Some(addr) = pending.pop() {
+            if self.finalization_state(addr) == 2 {
+                unsafe { (*header_of(addr)).clear_flag(flags::FINALIZATION_ORDERING) };
+                pending.extend(self.finalizer_children(addr));
+            }
+        }
+    }
+
+    /// incminimark.py:2928-2983 `deal_with_objects_with_finalizers`.
+    fn deal_with_objects_with_finalizers(&mut self) {
+        let mut new_with_finalizer = VecDeque::new();
+        let mut marked = VecDeque::new();
+
+        while let Some((obj_addr, fq_index)) = self.old_objects_with_finalizers.pop_front() {
+            let hdr = unsafe { header_of(obj_addr) };
+            if unsafe { (*hdr).has_flag(flags::IGNORE_FINALIZER) } {
+                continue;
+            }
+            if unsafe { (*hdr).has_flag(flags::VISITED) } {
+                new_with_finalizer.push_back((obj_addr, fq_index));
+                continue;
+            }
+
+            marked.push_back((obj_addr, fq_index));
+            let mut pending = vec![obj_addr];
+            while let Some(addr) = pending.pop() {
+                match self.finalization_state(addr) {
+                    0 => {
+                        unsafe { (*header_of(addr)).set_flag(flags::FINALIZATION_ORDERING) };
+                        pending.extend(self.finalizer_children(addr));
+                    }
+                    2 => self.recursively_clear_finalization_ordering(addr),
+                    _ => {}
+                }
+            }
+
+            // `_recursively_bump_finalization_state_from_1_to_2`: enqueue the
+            // root in normal marking and visit its complete object graph.
+            self.seed_major_root(GcRef(obj_addr));
+            while let Some(addr) = self.incr_state.gray_stack.pop() {
+                self.mark_object(addr);
+            }
+        }
+
+        // PyPy clears weakrefs while queued objects are in state 2.
+        if !self.old_objects_with_weakrefs.is_empty() {
+            self.invalidate_old_weakrefs();
+        }
+
+        while let Some((obj_addr, fq_index)) = marked.pop_front() {
+            if self.finalization_state(obj_addr) == 2 {
+                self.finalizer_handlers[fq_index].deque.push_back(obj_addr);
+                self.recursively_clear_finalization_ordering(obj_addr);
+            } else {
+                new_with_finalizer.push_back((obj_addr, fq_index));
+            }
+        }
+        self.old_objects_with_finalizers = new_with_finalizer;
+    }
+
+    fn execute_finalizer_triggers(&mut self) {
+        if self.finalizer_lock {
+            return;
+        }
+        self.finalizer_lock = true;
+        for handler in &self.finalizer_handlers {
+            if !handler.deque.is_empty() {
+                (handler.trigger)();
+            }
+        }
+        self.finalizer_lock = false;
     }
 
     /// incminimark.py:2897-2912 `deal_with_old_objects_with_destructors`.
@@ -2907,6 +3104,37 @@ impl GcAllocator for MiniMarkGC {
 
     fn collect_oldgen_nonmoving(&mut self) {
         self.do_collect_oldgen_nonmoving();
+    }
+
+    fn register_finalizer(&mut self, fq_index: usize, obj: GcRef, trigger: FinalizerTriggerFn) {
+        if obj.is_null() || !self.is_managed_heap_object(obj.0) {
+            return;
+        }
+        assert!(fq_index <= self.finalizer_handlers.len());
+        if fq_index == self.finalizer_handlers.len() {
+            self.finalizer_handlers.push(FinalizerHandler {
+                deque: VecDeque::new(),
+                trigger,
+            });
+        }
+        if self.oldgen.contains(obj.0) {
+            // Pyre's host allocations can be born directly in old-gen and an
+            // explicit non-moving major intentionally skips the leading minor.
+            // This is the post-`_trace_drag_out1` destination of PyPy's
+            // probably-young deque, reached immediately for an already-old obj.
+            self.old_objects_with_finalizers
+                .push_back((obj.0, fq_index));
+        } else {
+            self.probably_young_objects_with_finalizers
+                .push_back((obj.0, fq_index));
+        }
+    }
+
+    fn finalizer_next_dead(&mut self, fq_index: usize) -> Option<GcRef> {
+        self.finalizer_handlers
+            .get_mut(fq_index)
+            .and_then(|handler| handler.deque.pop_front())
+            .map(GcRef)
     }
 
     fn id_or_identityhash(&mut self, obj_addr: usize) -> usize {
@@ -6049,5 +6277,40 @@ mod tests {
 
         assert!(gc.old_objects_with_weakrefs.is_empty());
         gc.roots.clear();
+    }
+
+    #[test]
+    fn finalizer_queue_keeps_dead_object_until_it_is_popped() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        static TRIGGERS: AtomicUsize = AtomicUsize::new(0);
+        fn trigger() {
+            TRIGGERS.fetch_add(1, Ordering::Relaxed);
+        }
+
+        TRIGGERS.store(0, Ordering::Relaxed);
+        let mut gc = test_gc(4096);
+        let tid = gc.register_type(TypeInfo::simple(16));
+        let obj = gc.alloc_in_oldgen(tid, GcHeader::SIZE + 16);
+        let mut root = obj;
+        unsafe { gc.roots.add(&mut root) };
+        GcAllocator::register_finalizer(&mut gc, 0, obj, trigger);
+
+        // A live registered object stays on the registration deque.
+        gc.do_collect_oldgen_nonmoving();
+        assert!(GcAllocator::finalizer_next_dead(&mut gc, 0).is_none());
+        assert!(gc.oldgen.contains(obj.0));
+
+        // Once unreachable it moves to the death queue and is kept alive for
+        // app-level `__del__` execution.
+        gc.roots.remove(&mut root);
+        gc.do_collect_oldgen_nonmoving();
+        assert_eq!(TRIGGERS.load(Ordering::Relaxed), 1);
+        assert!(gc.oldgen.contains(obj.0));
+        assert_eq!(GcAllocator::finalizer_next_dead(&mut gc, 0), Some(obj));
+
+        // Popping removes the queue root; the following major reclaims it.
+        gc.do_collect_oldgen_nonmoving();
+        assert!(!gc.oldgen.contains(obj.0));
     }
 }

--- a/majit/majit-gc/src/gc_sync.rs
+++ b/majit/majit-gc/src/gc_sync.rs
@@ -71,6 +71,29 @@ static GC_SYNC: GcSync = GcSync {
     stw_generation: AtomicUsize::new(0),
 };
 
+thread_local! {
+    /// > 0 while this thread already holds exclusive GC access via a
+    /// slow-path `gc_op_slow` or a `request_stw` collection. Nested
+    /// `gc_op`/`gc_query` on the same thread then run directly on the
+    /// singleton instead of re-locking the non-reentrant `gc_mutex`.
+    static GATE_HELD_DEPTH: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+}
+
+struct GateHeldGuard;
+
+impl GateHeldGuard {
+    fn enter() -> Self {
+        GATE_HELD_DEPTH.with(|c| c.set(c.get() + 1));
+        GateHeldGuard
+    }
+}
+
+impl Drop for GateHeldGuard {
+    fn drop(&mut self) {
+        GATE_HELD_DEPTH.with(|c| c.set(c.get() - 1));
+    }
+}
+
 // ──────────────────────────────────────────────────────────────
 // Singleton management
 // ──────────────────────────────────────────────────────────────
@@ -88,6 +111,28 @@ pub fn store_singleton(gc: Box<dyn GcAllocator>) {
     }
     // SAFETY: gc_mutex held, no concurrent access.
     unsafe {
+        *GC_STORE.0.get() = Some(gc);
+    }
+    GC_INITIALIZED.store(true, Ordering::Release);
+}
+
+/// Test-support: install a fresh GC singleton, LEAKING the previous one.
+///
+/// The prior GC's objects must NOT be freed; process-global immortal builtins
+/// (a builtin type's `weak_subclasses`, etc.) may still reference them, so
+/// dropping the old `OldGen` would leave those references dangling. Forgetting
+/// the old singleton keeps them valid. Used by the `gc_stress` harness to give
+/// each per-worker test a pristine heap and empty root set, so a prior test's
+/// oldgen residue or stale registered roots cannot corrupt this test's
+/// collections.
+pub fn replace_singleton_leaking_old(gc: Box<dyn GcAllocator>) {
+    let _guard = GC_SYNC.gc_mutex.lock().unwrap();
+    // SAFETY: gc_mutex held; the gc_stress harness runs tests serially, so no
+    // concurrent gc_op is in flight during the swap.
+    unsafe {
+        if let Some(old) = (*GC_STORE.0.get()).take() {
+            std::mem::forget(old);
+        }
         *GC_STORE.0.get() = Some(gc);
     }
     GC_INITIALIZED.store(true, Ordering::Release);
@@ -153,6 +198,13 @@ pub fn unregister_thread() {
 /// Single-threaded production always takes the fast path.
 #[inline]
 pub fn gc_op<R>(f: impl FnOnce(&mut dyn GcAllocator) -> R) -> R {
+    if GATE_HELD_DEPTH.with(|c| c.get()) > 0 {
+        // This thread already holds exclusive GC access during collection.
+        // SAFETY: gc_mutex is held by this thread, so there is no concurrent
+        // access to the singleton.
+        return f(unsafe { singleton_mut() });
+    }
+
     // Fast path: single thread, no STW.
     if REGISTERED_THREADS.load(Ordering::Acquire) <= 1
         && !GC_SYNC.stw_requested.load(Ordering::Acquire)
@@ -184,8 +236,10 @@ fn gc_op_slow<R>(f: impl FnOnce(&mut dyn GcAllocator) -> R) -> R {
         drop(_guard);
         park_until_stw_done();
         let _guard = GC_SYNC.gc_mutex.lock().unwrap();
+        let _held = GateHeldGuard::enter();
         return f(unsafe { singleton_mut() });
     }
+    let _held = GateHeldGuard::enter();
     f(unsafe { singleton_mut() })
 }
 
@@ -219,7 +273,10 @@ pub fn request_stw(collect_fn: impl FnOnce(&mut dyn GcAllocator)) {
 
     // SAFETY: gc_mutex held + fast path blocked by stw_requested +
     // IN_FAST_PATH drained. No concurrent singleton access.
-    collect_fn(unsafe { singleton_mut() });
+    {
+        let _held = GateHeldGuard::enter();
+        collect_fn(unsafe { singleton_mut() });
+    }
 
     // Resume all parked threads.
     GC_SYNC.stw_requested.store(false, Ordering::Release);
@@ -271,6 +328,16 @@ mod tests {
         ensure_gc();
         let result = gc_op(|gc| gc.nursery_free());
         assert!(!result.is_null());
+    }
+
+    #[test]
+    fn nested_gc_query_inside_slow_path_gc_op_does_not_deadlock() {
+        ensure_gc();
+        register_thread();
+        // Outer gc_op holds gc_mutex; the nested gc_query must not re-lock it.
+        let ok = gc_op(|_outer| gc_query(|gc| !gc.nursery_free().is_null()));
+        assert!(ok);
+        unregister_thread();
     }
 
     #[test]

--- a/majit/majit-gc/src/lib.rs
+++ b/majit/majit-gc/src/lib.rs
@@ -1481,14 +1481,39 @@ pub fn gc_remove_root(slot: *mut GcRef) {
     });
 }
 
-/// Register an object with an RPython-style finalizer queue on the process GC.
-pub fn gc_register_finalizer(fq_index: usize, obj: GcRef, trigger: FinalizerTriggerFn) {
-    gc_sync::gc_op(|gc| gc.register_finalizer(fq_index, obj, trigger));
+/// rgc.py `FinalizerQueue.register_finalizer` - routed to the active backend GC.
+pub type RegisterFinalizerFn = fn(fq_index: usize, obj: GcRef, trigger: FinalizerTriggerFn);
+/// rgc.py `FinalizerQueue.next_dead` - routed to the active backend GC.
+pub type FinalizerNextDeadFn = fn(fq_index: usize) -> Option<GcRef>;
+
+thread_local! {
+    static ACTIVE_REGISTER_FINALIZER: Cell<Option<RegisterFinalizerFn>> = const { Cell::new(None) };
+    static ACTIVE_FINALIZER_NEXT_DEAD: Cell<Option<FinalizerNextDeadFn>> = const { Cell::new(None) };
 }
 
-/// Pop one object from an RPython-style finalizer death queue.
+/// Install the active backend's finalizer trampolines. Pass `None` to clear.
+pub fn set_active_finalizer_hooks(
+    register: Option<RegisterFinalizerFn>,
+    next_dead: Option<FinalizerNextDeadFn>,
+) {
+    ACTIVE_REGISTER_FINALIZER.with(|c| c.set(register));
+    ACTIVE_FINALIZER_NEXT_DEAD.with(|c| c.set(next_dead));
+}
+
+/// Register an object with an RPython-style finalizer queue on the active GC.
+pub fn gc_register_finalizer(fq_index: usize, obj: GcRef, trigger: FinalizerTriggerFn) {
+    ACTIVE_REGISTER_FINALIZER.with(|c| match c.get() {
+        Some(f) => f(fq_index, obj, trigger),
+        None => gc_sync::gc_op(|gc| gc.register_finalizer(fq_index, obj, trigger)),
+    });
+}
+
+/// Pop one object from the active GC's RPython-style finalizer death queue.
 pub fn gc_fq_next_dead(fq_index: usize) -> Option<GcRef> {
-    gc_sync::gc_op(|gc| gc.finalizer_next_dead(fq_index))
+    ACTIVE_FINALIZER_NEXT_DEAD.with(|c| match c.get() {
+        Some(f) => f(fq_index),
+        None => gc_sync::gc_op(|gc| gc.finalizer_next_dead(fq_index)),
+    })
 }
 
 /// rgc.enable / rgc.disable — toggle automatic major-collection progress

--- a/majit/majit-gc/src/lib.rs
+++ b/majit/majit-gc/src/lib.rs
@@ -264,6 +264,16 @@ pub trait GcAllocator: Send {
     /// with no incremental old-gen lacks no method; `MiniMarkGC` overrides it.
     fn collect_oldgen_nonmoving(&mut self) {}
 
+    /// Toggle automatic major-collection progress. Backends without
+    /// incremental major collection ignore it.
+    fn enable(&mut self) {}
+
+    fn disable(&mut self) {}
+
+    fn isenabled(&self) -> bool {
+        true
+    }
+
     /// rgc.py `FinalizerQueue.register_finalizer` /
     /// framework.py `gc_fq_register`: register `obj` with one translated
     /// finalizer handler.  Backends without finalizer queues ignore it.
@@ -684,6 +694,15 @@ impl GcAllocator for GcHandle {
     }
     fn collect_oldgen_nonmoving(&mut self) {
         gc_sync::gc_op(|gc| gc.collect_oldgen_nonmoving())
+    }
+    fn enable(&mut self) {
+        gc_sync::gc_op(|gc| gc.enable())
+    }
+    fn disable(&mut self) {
+        gc_sync::gc_op(|gc| gc.disable())
+    }
+    fn isenabled(&self) -> bool {
+        gc_sync::gc_query(|gc| gc.isenabled())
     }
     fn register_finalizer(&mut self, fq_index: usize, obj: GcRef, trigger: FinalizerTriggerFn) {
         gc_sync::gc_op(|gc| gc.register_finalizer(fq_index, obj, trigger))
@@ -1470,6 +1489,18 @@ pub fn gc_register_finalizer(fq_index: usize, obj: GcRef, trigger: FinalizerTrig
 /// Pop one object from an RPython-style finalizer death queue.
 pub fn gc_fq_next_dead(fq_index: usize) -> Option<GcRef> {
     gc_sync::gc_op(|gc| gc.finalizer_next_dead(fq_index))
+}
+
+/// rgc.enable / rgc.disable — toggle automatic major-collection progress
+/// on the process-global GC.
+pub fn gc_set_enabled(enabled: bool) {
+    gc_sync::gc_op(|gc| {
+        if enabled {
+            gc.enable()
+        } else {
+            gc.disable()
+        }
+    })
 }
 
 /// Thread-local callback that performs a host-side write barrier through

--- a/majit/majit-gc/src/lib.rs
+++ b/majit/majit-gc/src/lib.rs
@@ -58,6 +58,10 @@ pub mod flags {
     pub const DUMMY: u64 = 1 << 12;
 }
 
+/// Low-level trigger stored in an RPython finalizer handler.  It must only
+/// schedule app-level work; finalizers themselves run after collection.
+pub type FinalizerTriggerFn = fn();
+
 /// True when the `gc_stress` test feature is compiled in: every allocation
 /// may then run a full collection inside `alloc_with_type`, so JIT fast
 /// paths that bypass it (inline nursery bump) must stay disabled or the
@@ -259,6 +263,16 @@ pub trait GcAllocator: Send {
     /// objects without moving the nursery). The default no-ops so a backend
     /// with no incremental old-gen lacks no method; `MiniMarkGC` overrides it.
     fn collect_oldgen_nonmoving(&mut self) {}
+
+    /// rgc.py `FinalizerQueue.register_finalizer` /
+    /// framework.py `gc_fq_register`: register `obj` with one translated
+    /// finalizer handler.  Backends without finalizer queues ignore it.
+    fn register_finalizer(&mut self, _fq_index: usize, _obj: GcRef, _trigger: FinalizerTriggerFn) {}
+
+    /// rgc.py `FinalizerQueue.next_dead` / framework.py `gc_fq_next_dead`.
+    fn finalizer_next_dead(&mut self, _fq_index: usize) -> Option<GcRef> {
+        None
+    }
 
     /// minimark.py:1900-1915 `id_or_identityhash(gcobj)`.
     /// Return a stable address for the object that does not change
@@ -670,6 +684,12 @@ impl GcAllocator for GcHandle {
     }
     fn collect_oldgen_nonmoving(&mut self) {
         gc_sync::gc_op(|gc| gc.collect_oldgen_nonmoving())
+    }
+    fn register_finalizer(&mut self, fq_index: usize, obj: GcRef, trigger: FinalizerTriggerFn) {
+        gc_sync::gc_op(|gc| gc.register_finalizer(fq_index, obj, trigger))
+    }
+    fn finalizer_next_dead(&mut self, fq_index: usize) -> Option<GcRef> {
+        gc_sync::gc_op(|gc| gc.finalizer_next_dead(fq_index))
     }
     fn id_or_identityhash(&mut self, obj_addr: usize) -> usize {
         gc_sync::gc_op(|gc| gc.id_or_identityhash(obj_addr))
@@ -1440,6 +1460,16 @@ pub fn gc_remove_root(slot: *mut GcRef) {
             f(slot)
         }
     });
+}
+
+/// Register an object with an RPython-style finalizer queue on the process GC.
+pub fn gc_register_finalizer(fq_index: usize, obj: GcRef, trigger: FinalizerTriggerFn) {
+    gc_sync::gc_op(|gc| gc.register_finalizer(fq_index, obj, trigger));
+}
+
+/// Pop one object from an RPython-style finalizer death queue.
+pub fn gc_fq_next_dead(fq_index: usize) -> Option<GcRef> {
+    gc_sync::gc_op(|gc| gc.finalizer_next_dead(fq_index))
 }
 
 /// Thread-local callback that performs a host-side write barrier through

--- a/majit/majit-gc/src/lib.rs
+++ b/majit/majit-gc/src/lib.rs
@@ -1494,13 +1494,7 @@ pub fn gc_fq_next_dead(fq_index: usize) -> Option<GcRef> {
 /// rgc.enable / rgc.disable — toggle automatic major-collection progress
 /// on the process-global GC.
 pub fn gc_set_enabled(enabled: bool) {
-    gc_sync::gc_op(|gc| {
-        if enabled {
-            gc.enable()
-        } else {
-            gc.disable()
-        }
-    })
+    gc_sync::gc_op(|gc| if enabled { gc.enable() } else { gc.disable() })
 }
 
 /// Thread-local callback that performs a host-side write barrier through

--- a/pyre/cpython_tests/run.py
+++ b/pyre/cpython_tests/run.py
@@ -97,6 +97,7 @@ KNOWN_SKIPS = {
     "test.test_largefile": "demands too many resources",
     "test.test_embed": "needs embedded CPython",
     "test.test_xpickle": "spawns per-version pythonX.Y subprocesses (PATH-dependent, can deadlock)",
+    "test.test_c_locale_coercion": "asserts child stderr is empty, but MAJIT_STATS=1 prints a [jit-stats] line to every process's stderr",
 }
 
 # ── classification ───────────────────────────────────────────────────

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -5869,6 +5869,14 @@ pub unsafe fn mutated(w_type: PyObjectRef, key: Option<&str>) {
             pyre_object::typeobject::new_version_tag(),
         );
     }
+    // typeobject.py:1475 computes `hasuserdel` only at creation; pyre's
+    // allocation path reads the flag (objspace.py:486), so a post-creation
+    // `__del__` assignment must set it too. Sticky like upstream — a later
+    // deletion leaves it set; registration on a type without `__del__` is
+    // a harmless no-op in _call_finalizer.
+    if key == Some("__del__") {
+        pyre_object::w_type_set_hasuserdel(w_type, true);
+    }
     // typeobject.py:288-291 — walk direct subclasses recursively.
     let subs = pyre_object::typeobject::w_type_get_subclasses(w_type);
     for w_sub in subs {

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -5021,8 +5021,7 @@ pub fn builtin_int(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> 
         // intobject.py:1047 — unicode is normalized through
         // `unicode_to_decimal_w` so non-ASCII decimal digits parse.
         if unsafe { is_str(obj) } {
-            let s = unsafe { w_str_get_value(obj) };
-            return parse_int_from_str(&unicode_to_decimal(s), 10);
+            return parse_int_from_str(&unicode_to_decimal_w(obj)?, 10);
         }
         // intobject.py:1056-1070 — bytes / bytearray, then any object
         // exposing a readable buffer (`space.charbuf_w`).
@@ -5042,7 +5041,7 @@ pub fn builtin_int(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> 
     unsafe {
         // intobject.py:1079 — unicode normalized through `unicode_to_decimal_w`.
         if is_str(obj) {
-            return parse_int_from_str(&unicode_to_decimal(w_str_get_value(obj)), base);
+            return parse_int_from_str(&unicode_to_decimal_w(obj)?, base);
         }
         // With an explicit base only str / bytes / bytearray are accepted.
         if pyre_object::bytesobject::is_bytes_like(obj) {
@@ -5145,25 +5144,54 @@ pub(crate) fn getindex_w(w_obj: PyObjectRef) -> Result<i64, crate::PyError> {
 /// becomes its ASCII digit and non-ASCII whitespace becomes a space, so
 /// `int("４２")` and `float("١٫٥")`-style inputs parse.  An all-ASCII string
 /// is returned untouched.
-fn unicode_to_decimal(s: &str) -> std::borrow::Cow<'_, str> {
-    if s.is_ascii() {
-        return std::borrow::Cow::Borrowed(s);
+fn unicode_to_decimal_w(
+    w_unistr: PyObjectRef,
+) -> Result<std::borrow::Cow<'static, str>, crate::PyError> {
+    let utf8 = unsafe { w_str_get_wtf8(w_unistr) };
+    if let Ok(s) = utf8.as_str()
+        && s.is_ascii()
+    {
+        return Ok(std::borrow::Cow::Borrowed(s));
     }
-    let mut out = String::with_capacity(s.len());
-    for c in s.chars() {
-        if c as u32 > 127 {
-            if c.is_whitespace() {
+
+    // unicodeobject.py `_unicode_to_decimal_w`: iterate the internal UTF-8
+    // representation by code point, translate Unicode decimal digits and
+    // whitespace, then encode each result as strict UTF-8.  WTF-8 exposes the
+    // same surrogate-bearing representation as RPython's rutf8 iterator.
+    let ucd = rustpython_unicode::Ucd::new(true);
+    let mut out = String::with_capacity(utf8.len());
+    for (pos, cp) in utf8.code_points().enumerate() {
+        let mut c = cp;
+        if c.to_u32() > 127 {
+            let Some(ch) = c.to_char() else {
+                return Err(crate::typedef::unicode_encode_error(
+                    "utf-8",
+                    w_unistr,
+                    pos,
+                    pos + 1,
+                    "surrogates not allowed",
+                ));
+            };
+            if ch.is_whitespace() {
                 out.push(' ');
                 continue;
             }
-            if let Some(v) = rustpython_unicode::Ucd::new(true).decimal(CodePoint::from(c)) {
-                out.push((b'0' + v as u8) as char);
-                continue;
+            if let Some(v) = ucd.decimal(c) {
+                c = CodePoint::from((b'0' + v as u8) as char);
             }
         }
-        out.push(c);
+        let Some(ch) = c.to_char() else {
+            return Err(crate::typedef::unicode_encode_error(
+                "utf-8",
+                w_unistr,
+                pos,
+                pos + 1,
+                "surrogates not allowed",
+            ));
+        };
+        out.push(ch);
     }
-    std::borrow::Cow::Owned(out)
+    Ok(std::borrow::Cow::Owned(out))
 }
 
 /// Parse an integer from a string with the given base.
@@ -5311,11 +5339,13 @@ pub(crate) fn builtin_float(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::
             return Ok(floatobject::w_float_new(v));
         }
         if is_str(obj) {
-            let raw = w_str_get_value(obj);
             // floatobject.py:242 — unicode is normalized through
             // `unicode_to_decimal_w` before `_string_to_float`, so non-ASCII
             // decimal digits parse.
-            let s = unicode_to_decimal(raw);
+            let s = unicode_to_decimal_w(obj)?;
+            // The strict conversion above rejected any surrogate, so the
+            // original object now has a valid UTF-8 view for the error text.
+            let raw = w_str_get_value(obj);
             // `float_from_string` strips PEP 515 underscore separators
             // (between digits only) before parsing; the numeric conversion
             // uses the Python-literal float grammar.
@@ -9422,8 +9452,11 @@ pub(crate) fn builtin_complex(args: &[PyObjectRef]) -> Result<PyObjectRef, crate
                     "complex() can't take second arg if first is a string",
                 ));
             }
-            let s = unsafe { w_str_get_value(a) };
-            let (r, i) = parse_complex_str(s).ok_or_else(|| {
+            // complexobject.py:342 applies `unicode_to_decimal_w` before
+            // underscore removal and parsing, including strict surrogate
+            // rejection.
+            let s = unicode_to_decimal_w(a)?;
+            let (r, i) = parse_complex_str(&s).ok_or_else(|| {
                 crate::PyError::new(
                     crate::PyErrorKind::ValueError,
                     format!("complex() arg is a malformed string"),

--- a/pyre/pyre-interpreter/src/call.rs
+++ b/pyre/pyre-interpreter/src/call.rs
@@ -3758,6 +3758,7 @@ fn mangle(name: &str, klass: &str) -> String {
 /// typeobject.py:1131-1140 copy_flags_from_bases:
 ///   w_self.hasdict |= w_base.hasdict
 ///   w_self.weakrefable |= w_base.weakrefable
+///   typeobject.py:1406 w_self.hasuserdel |= w_base.hasuserdel
 unsafe fn copy_flags_from_bases(
     w_type: pyre_object::PyObjectRef,
     w_bases: pyre_object::PyObjectRef,
@@ -3775,6 +3776,9 @@ unsafe fn copy_flags_from_bases(
                     }
                     if pyre_object::w_type_get_weakrefable(base) {
                         pyre_object::w_type_set_weakrefable(w_type, true);
+                    }
+                    if pyre_object::w_type_get_hasuserdel(base) {
+                        pyre_object::w_type_set_hasuserdel(w_type, true);
                     }
                 }
             }
@@ -3819,7 +3823,7 @@ pub unsafe fn create_all_slots(
             }
         }
 
-        // typeobject.py:1510: copy_flags_from_bases — inherit hasdict/weakrefable
+        // typeobject.py:1510: copy_flags_from_bases — inherit hasdict/weakrefable/hasuserdel
         copy_flags_from_bases(w_type, w_bases);
 
         // typeobject.py:1146: base_layout = w_bestbase.layout
@@ -3909,6 +3913,9 @@ pub unsafe fn create_all_slots(
         }
         if wantweakref {
             create_weakref_slot(w_type);
+        }
+        if ns.get("__del__").is_some() {
+            pyre_object::w_type_set_hasuserdel(w_type, true);
         }
 
         // typeobject.py:1199-1204: layout computation

--- a/pyre/pyre-interpreter/src/error.rs
+++ b/pyre/pyre-interpreter/src/error.rs
@@ -793,6 +793,24 @@ impl PyError {
         Self::write_unraisable_default(space, w_type, w_value, w_tb, &first_line, w_object, "");
     }
 
+    fn write_unraisable_to_sys_stderr(buf: &[u8]) -> bool {
+        let Some(sys_mod) = crate::importing::get_sys_module("sys") else {
+            return false;
+        };
+        let stderr = match crate::baseobjspace::getattr_str(sys_mod, "stderr") {
+            Ok(w) if !w.is_null() && !unsafe { pyre_object::is_none(w) } => w,
+            _ => return false,
+        };
+        let text = String::from_utf8_lossy(buf).into_owned();
+        let w_text = pyre_object::w_str_new(&text);
+        let result = crate::baseobjspace::call_method(stderr, "write", &[w_text]);
+        if result.is_null() {
+            let _ = crate::call::take_call_error();
+            return false;
+        }
+        true
+    }
+
     /// pypy/interpreter/error.py:318-347 `write_unraisable_default`.
     pub fn write_unraisable_default(
         space: PyObjectRef,
@@ -831,7 +849,9 @@ impl PyError {
             let err = unsafe { PyError::from_exc_object(w_value) };
             let _ = write_exception(&mut buf, &err, true);
         }
-        crate::host_seam::emit_stderr(&buf);
+        if !Self::write_unraisable_to_sys_stderr(&buf) {
+            crate::host_seam::emit_stderr(&buf);
+        }
     }
 
     fn to_exc_kind(&self) -> ExcKind {

--- a/pyre/pyre-interpreter/src/error.rs
+++ b/pyre/pyre-interpreter/src/error.rs
@@ -984,7 +984,13 @@ fn unraisable_hook_args_type() -> PyObjectRef {
         *cell.get_or_init(|| {
             crate::_structseq::make_struct_seq(
                 "sys.UnraisableHookArgs",
-                &["exc_type", "exc_value", "exc_traceback", "err_msg", "object"],
+                &[
+                    "exc_type",
+                    "exc_value",
+                    "exc_traceback",
+                    "err_msg",
+                    "object",
+                ],
             )
         })
     })

--- a/pyre/pyre-interpreter/src/error.rs
+++ b/pyre/pyre-interpreter/src/error.rs
@@ -1,6 +1,7 @@
 use pyre_object::PyObjectRef;
 use pyre_object::interp_exceptions::{ExcKind, exc_kind_name, w_exception_new};
 use std::io::Write;
+use std::sync::OnceLock;
 
 #[derive(Debug, Clone)]
 pub struct OperationError {
@@ -686,6 +687,153 @@ impl PyError {
         exc
     }
 
+    pub fn normalize_exception(&mut self, _space: PyObjectRef) -> Result<PyObjectRef, PyError> {
+        let w_value = self.to_exc_object();
+        if w_value.is_null() || !unsafe { pyre_object::is_exception(w_value) } {
+            return Err(PyError::type_error("exception is not a BaseException"));
+        }
+        self.exc_object = w_value;
+        Ok(w_value)
+    }
+
+    /// pypy/interpreter/error.py:263-317 `write_unraisable`, with the
+    /// `with_traceback=False` first-line shape.
+    pub fn write_unraisable(
+        &mut self,
+        space: PyObjectRef,
+        where_desc: &str,
+        w_object: PyObjectRef,
+    ) {
+        let w_value = self
+            .normalize_exception(space)
+            .unwrap_or_else(|_| self.to_exc_object());
+        let mut w_type = crate::baseobjspace::exception_getclass(w_value);
+        if w_type.is_null() {
+            w_type = pyre_object::w_none();
+        }
+        let mut w_tb = if !w_value.is_null() && unsafe { pyre_object::is_exception(w_value) } {
+            unsafe { pyre_object::interp_exceptions::w_exception_get_traceback(w_value) }
+        } else {
+            pyre_object::PY_NULL
+        };
+        if w_tb.is_null() {
+            w_tb = pyre_object::w_none();
+        }
+        let mut w_object = if w_object.is_null() {
+            pyre_object::w_none()
+        } else {
+            w_object
+        };
+        let mut first_line = if where_desc.is_empty() {
+            String::new()
+        } else {
+            format!("Exception ignored in: {where_desc}")
+        };
+        // vm.py:19-25 also carries `extra_line`; pyre's hook-args
+        // structseq targets the 5-field shape, so only the default printer
+        // receives the Rust-side extra line.
+        let hook_args = crate::_structseq::new_instance(
+            unraisable_hook_args_type(),
+            vec![
+                w_type,
+                w_value,
+                w_tb,
+                if first_line.is_empty() {
+                    pyre_object::w_none()
+                } else {
+                    pyre_object::w_str_new(&first_line)
+                },
+                w_object,
+            ],
+        );
+        if let Some(sys_mod) = crate::importing::get_sys_module("sys") {
+            if let Ok(w_hook) = crate::baseobjspace::getattr_str(sys_mod, "unraisablehook") {
+                if !w_hook.is_null() && !unsafe { pyre_object::is_none(w_hook) } {
+                    match crate::call::call_function_impl_result(w_hook, &[hook_args]) {
+                        Ok(_) => return,
+                        Err(mut hook_err) => {
+                            first_line = "Exception ignored in sys.unraisablehook".to_string();
+                            w_object = w_hook;
+                            let hook_value = hook_err
+                                .normalize_exception(space)
+                                .unwrap_or_else(|_| hook_err.to_exc_object());
+                            w_type = crate::baseobjspace::exception_getclass(hook_value);
+                            if w_type.is_null() {
+                                w_type = pyre_object::w_none();
+                            }
+                            w_tb = if !hook_value.is_null()
+                                && unsafe { pyre_object::is_exception(hook_value) }
+                            {
+                                unsafe {
+                                    pyre_object::interp_exceptions::w_exception_get_traceback(
+                                        hook_value,
+                                    )
+                                }
+                            } else {
+                                pyre_object::PY_NULL
+                            };
+                            if w_tb.is_null() {
+                                w_tb = pyre_object::w_none();
+                            }
+                            Self::write_unraisable_default(
+                                space,
+                                w_type,
+                                hook_value,
+                                w_tb,
+                                &first_line,
+                                w_object,
+                                "",
+                            );
+                            return;
+                        }
+                    }
+                }
+            }
+        }
+        Self::write_unraisable_default(space, w_type, w_value, w_tb, &first_line, w_object, "");
+    }
+
+    /// pypy/interpreter/error.py:318-347 `write_unraisable_default`.
+    pub fn write_unraisable_default(
+        space: PyObjectRef,
+        w_type: PyObjectRef,
+        w_value: PyObjectRef,
+        w_tb: PyObjectRef,
+        first_line: &str,
+        w_object: PyObjectRef,
+        extra_line: &str,
+    ) {
+        let _ = (space, w_type);
+        let mut first_line = if first_line.is_empty() {
+            "Exception ignored in:".to_string()
+        } else {
+            first_line.to_string()
+        };
+        if !w_object.is_null() && !unsafe { pyre_object::is_none(w_object) } {
+            let objrepr = unsafe { crate::display::py_repr(w_object) }
+                .unwrap_or_else(|_| "<object repr() failed>".to_string());
+            first_line = format!("{first_line} {objrepr}");
+        }
+        let extra_line = if extra_line.is_empty() {
+            "\n".to_string()
+        } else {
+            format!("{extra_line}:\n")
+        };
+        let mut buf = Vec::new();
+        let _ = write!(&mut buf, "{first_line}");
+        if !extra_line.is_empty() {
+            let _ = write!(&mut buf, "{extra_line}");
+        }
+        if !w_value.is_null() && unsafe { pyre_object::is_exception(w_value) } {
+            if !w_tb.is_null() && !unsafe { pyre_object::is_none(w_tb) } {
+                unsafe { pyre_object::interp_exceptions::w_exception_set_traceback(w_value, w_tb) };
+            }
+            let err = unsafe { PyError::from_exc_object(w_value) };
+            let _ = write_exception(&mut buf, &err, true);
+        }
+        crate::host_seam::emit_stderr(&buf);
+    }
+
     fn to_exc_kind(&self) -> ExcKind {
         match self.kind {
             PyErrorKind::TypeError => ExcKind::TypeError,
@@ -826,6 +974,20 @@ impl PyError {
             format!("{name}: {message}")
         }
     }
+}
+
+fn unraisable_hook_args_type() -> PyObjectRef {
+    thread_local! {
+        static TYPE: OnceLock<PyObjectRef> = const { OnceLock::new() };
+    }
+    TYPE.with(|cell| {
+        *cell.get_or_init(|| {
+            crate::_structseq::make_struct_seq(
+                "sys.UnraisableHookArgs",
+                &["exc_type", "exc_value", "exc_traceback", "err_msg", "object"],
+            )
+        })
+    })
 }
 
 /// Resolve an exception instance's actual Python class name for display.

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -493,6 +493,17 @@ fn walk_pyframe_roots(visitor: &mut dyn FnMut(&mut majit_ir::GcRef)) {
             // copy alone is not authoritative for later EC reads).
             let exc_slot = unsafe { &mut (*ec).sys_exc_value as *mut PyObjectRef };
             visitor(unsafe { &mut *(exc_slot as *mut majit_ir::GcRef) });
+            // pending_with_disabled_del is a GC-visible list upstream
+            // (executioncontext.py:652); pyre's Vec lives in the boxed
+            // UserDelAction, so its element slots are visited here.
+            let action = unsafe { (*ec).user_del_action };
+            if !action.is_null() {
+                if let Some(list) = unsafe { (*action).pending_with_disabled_del.as_mut() } {
+                    for slot in list.iter_mut() {
+                        visitor(unsafe { &mut *(slot as *mut PyObjectRef as *mut majit_ir::GcRef) });
+                    }
+                }
+            }
         };
         visit_ec_slots(frame_ec);
         if ambient_ec != frame_ec {

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -500,7 +500,9 @@ fn walk_pyframe_roots(visitor: &mut dyn FnMut(&mut majit_ir::GcRef)) {
             if !action.is_null() {
                 if let Some(list) = unsafe { (*action).pending_with_disabled_del.as_mut() } {
                     for slot in list.iter_mut() {
-                        visitor(unsafe { &mut *(slot as *mut PyObjectRef as *mut majit_ir::GcRef) });
+                        visitor(unsafe {
+                            &mut *(slot as *mut PyObjectRef as *mut majit_ir::GcRef)
+                        });
                     }
                 }
             }

--- a/pyre/pyre-interpreter/src/executioncontext.rs
+++ b/pyre/pyre-interpreter/src/executioncontext.rs
@@ -2357,7 +2357,12 @@ impl UserDelAction {
             let w_obj = self.finalizer_queue.next_dead();
             match w_obj {
                 None => break,
-                Some(w) => self._call_finalizer(w),
+                Some(w) => {
+                    // The deque entry was the object's only root; pin it across the __del__ call.
+                    let _roots = pyre_object::gc_roots::push_roots();
+                    pyre_object::gc_roots::pin_root(w);
+                    self._call_finalizer(w);
+                }
             }
         }
     }

--- a/pyre/pyre-interpreter/src/executioncontext.rs
+++ b/pyre/pyre-interpreter/src/executioncontext.rs
@@ -538,7 +538,9 @@ pub const TICK_COUNTER_STEP: usize = 100;
 pub struct WRootFinalizerQueue;
 
 impl WRootFinalizerQueue {
-    pub fn finalizer_trigger(&mut self) {}
+    pub fn finalizer_trigger(&mut self) {
+        finalizer_queue_trigger();
+    }
 
     /// `pypy/interpreter/executioncontext.py:640` —
     /// `self.space.finalizer_queue.next_dead()`.
@@ -546,14 +548,32 @@ impl WRootFinalizerQueue {
     /// Returns the next `w_obj` whose finalizer should run, or `None`
     /// when the death queue is empty.
     ///
-    /// TODO: the real death queue requires GC
-    /// integration to land a
-    /// `WRootFinalizerQueue` instance backed by `rgc.FinalizerQueue`.
-    /// Until then this is a constant-`None` stub so callers
-    /// (`UserDelAction::_run_finalizers`) can mirror PyPy's loop shape
-    /// line-by-line.
     pub fn next_dead(&mut self) -> Option<PyObjectRef> {
-        None
+        let obj = pyre_object::gc_hook::try_gc_finalizer_next_dead(0);
+        (!obj.is_null()).then_some(obj)
+    }
+}
+
+fn finalizer_queue_trigger() {
+    let ec = crate::call::getexecutioncontext() as *mut ExecutionContext;
+    if ec.is_null() {
+        return;
+    }
+    unsafe {
+        let action = (*ec).user_del_action;
+        if !action.is_null() {
+            (*action).fire();
+        }
+    }
+}
+
+/// objspace.py `allocate_instance` finalizer registration callback.
+pub fn maybe_register_user_finalizer(obj: PyObjectRef) {
+    let Some(w_type) = crate::typedef::r#type(obj) else {
+        return;
+    };
+    if unsafe { crate::baseobjspace::lookup_in_type(w_type, "__del__") }.is_some() {
+        pyre_object::gc_hook::try_gc_register_finalizer(0, obj, finalizer_queue_trigger);
     }
 }
 
@@ -578,6 +598,9 @@ pub struct ExecutionContext {
     pub thread_disappeared: bool,
     pub w_async_exception_type: PyObjectRef,
     pub actionflag: ActionFlag,
+    /// `space.user_del_action`, allocated after the ExecutionContext reaches
+    /// its stable process-lifetime address.
+    pub user_del_action: *mut UserDelAction,
     /// `pypy/objspace/std/dictmultiobject.py:60-69
     /// allocate_and_init_instance(module=True)` parity — the builtins
     /// module's `w_dict` is a `W_ModuleDictObject` backed by
@@ -663,6 +686,7 @@ impl ExecutionContext {
             thread_disappeared: false,
             w_async_exception_type: pyre_object::PY_NULL,
             actionflag: ActionFlag::new(),
+            user_del_action: std::ptr::null_mut(),
             builtins_module,
             builtin_dict_cache: std::cell::Cell::new(pyre_object::PY_NULL),
             check_signal_action: None,
@@ -673,6 +697,14 @@ impl ExecutionContext {
     pub fn __init__(&mut self, space: PyObjectRef) {
         self.space = space;
         self.compiler = pyre_object::w_none();
+    }
+
+    pub fn install_user_del_action(&mut self) {
+        if self.user_del_action.is_null() {
+            let action = UserDelAction::new(self.space, &mut self.actionflag);
+            self.user_del_action = Box::into_raw(action);
+        }
+        pyre_object::gc_hook::register_maybe_finalizer_hook(maybe_register_user_finalizer);
     }
 
     #[inline]
@@ -950,7 +982,9 @@ impl ExecutionContext {
     }
 
     pub fn _run_finalizers_now(&mut self) {
-        let _ = self;
+        if !self.user_del_action.is_null() {
+            unsafe { (*self.user_del_action)._run_finalizers() };
+        }
     }
 
     /// pypy/interpreter/executioncontext.py:185-200 `run_trace_func`.
@@ -2338,8 +2372,22 @@ impl UserDelAction {
         }
     }
 
-    pub fn _call_finalizer(&mut self, _w_obj: PyObjectRef) {
-        let _ = _w_obj;
+    pub fn _call_finalizer(&mut self, w_obj: PyObjectRef) {
+        let Some(w_type) = crate::typedef::r#type(w_obj) else {
+            return;
+        };
+        let Some(w_del) = (unsafe { crate::baseobjspace::lookup_in_type(w_type, "__del__") })
+        else {
+            return;
+        };
+        if self.gc_disabled(w_obj) {
+            return;
+        }
+        if let Err(error) =
+            unsafe { crate::baseobjspace::get_and_call_function(w_del, w_obj, w_type, &[]) }
+        {
+            report_error(self.base.space, &error, "", w_del);
+        }
     }
 }
 
@@ -2365,8 +2413,15 @@ impl AsyncActionOps for UserDelAction {
     }
 }
 
-pub fn report_error(_space: PyObjectRef, _e: PyObjectRef, _where_desc: &str, _w_obj: PyObjectRef) {
-    let _ = (_space, _e, _where_desc, _w_obj);
+pub fn report_error(
+    _space: PyObjectRef,
+    error: &crate::PyError,
+    where_desc: &str,
+    _w_obj: PyObjectRef,
+) {
+    crate::host_seam::emit_stderr(
+        format!("Exception ignored in {where_desc}__del__: {error}\n").as_bytes(),
+    );
 }
 
 pub fn make_finalizer_queue<WRoot>(w_root: WRoot, _space: PyObjectRef) -> WRootFinalizerQueue {

--- a/pyre/pyre-interpreter/src/executioncontext.rs
+++ b/pyre/pyre-interpreter/src/executioncontext.rs
@@ -567,12 +567,12 @@ fn finalizer_queue_trigger() {
     }
 }
 
-/// objspace.py `allocate_instance` finalizer registration callback.
+/// objspace.py:486 `allocate_instance` finalizer registration callback.
 pub fn maybe_register_user_finalizer(obj: PyObjectRef) {
     let Some(w_type) = crate::typedef::r#type(obj) else {
         return;
     };
-    if unsafe { crate::baseobjspace::lookup_in_type(w_type, "__del__") }.is_some() {
+    if unsafe { pyre_object::w_type_get_hasuserdel(w_type) } {
         pyre_object::gc_hook::try_gc_register_finalizer(0, obj, finalizer_queue_trigger);
     }
 }

--- a/pyre/pyre-interpreter/src/executioncontext.rs
+++ b/pyre/pyre-interpreter/src/executioncontext.rs
@@ -2388,6 +2388,8 @@ impl UserDelAction {
         if self.gc_disabled(w_obj) {
             return;
         }
+        // pyre's combined helper cannot distinguish get-vs-call errors;
+        // report through the call arm (executioncontext.py:680-690).
         if let Err(error) =
             unsafe { crate::baseobjspace::get_and_call_function(w_del, w_obj, w_type, &[]) }
         {
@@ -2419,14 +2421,13 @@ impl AsyncActionOps for UserDelAction {
 }
 
 pub fn report_error(
-    _space: PyObjectRef,
+    space: PyObjectRef,
     error: &crate::PyError,
     where_desc: &str,
-    _w_obj: PyObjectRef,
+    w_obj: PyObjectRef,
 ) {
-    crate::host_seam::emit_stderr(
-        format!("Exception ignored in {where_desc}__del__: {error}\n").as_bytes(),
-    );
+    let mut error = error.clone();
+    error.write_unraisable(space, where_desc, w_obj);
 }
 
 pub fn make_finalizer_queue<WRoot>(w_root: WRoot, _space: PyObjectRef) -> WRootFinalizerQueue {

--- a/pyre/pyre-interpreter/src/importing.rs
+++ b/pyre/pyre-interpreter/src/importing.rs
@@ -871,23 +871,25 @@ pub fn init_sys_path(script_dir: &Path) {
     SYS_PATH.with(|p| {
         let mut path = p.borrow_mut();
         path.clear();
-        // Script directory first (PyPy: first entry in sys.path)
-        path.push(script_dir.to_path_buf());
-        // Current working directory as fallback. Under sandbox read it through
-        // the seam so it resolves to the controller's virtual cwd (`/tmp`)
-        // rather than leaking the trusted parent's real working directory.
-        #[cfg(feature = "sandbox")]
-        let cwd = {
-            use std::os::unix::ffi::OsStrExt;
-            crate::host_seam::ops::getcwd()
-                .ok()
-                .map(|b| PathBuf::from(std::ffi::OsStr::from_bytes(&b)))
-        };
-        #[cfg(not(feature = "sandbox"))]
-        let cwd = host_os::current_dir().ok();
-        if let Some(cwd) = cwd {
-            if cwd != script_dir {
-                path.push(cwd);
+        if !safe_path_flag() {
+            // Script directory first.
+            path.push(script_dir.to_path_buf());
+            // Current working directory as fallback. Under sandbox read it through
+            // the seam so it resolves to the controller's virtual cwd (`/tmp`)
+            // rather than leaking the trusted parent's real working directory.
+            #[cfg(feature = "sandbox")]
+            let cwd = {
+                use std::os::unix::ffi::OsStrExt;
+                crate::host_seam::ops::getcwd()
+                    .ok()
+                    .map(|b| PathBuf::from(std::ffi::OsStr::from_bytes(&b)))
+            };
+            #[cfg(not(feature = "sandbox"))]
+            let cwd = host_os::current_dir().ok();
+            if let Some(cwd) = cwd {
+                if cwd != script_dir {
+                    path.push(cwd);
+                }
             }
         }
         // CPython stdlib path is detected lazily on first stdlib import

--- a/pyre/pyre-interpreter/src/importing.rs
+++ b/pyre/pyre-interpreter/src/importing.rs
@@ -1161,6 +1161,12 @@ thread_local! {
     static SYS_ARGV_PENDING: std::cell::Cell<pyre_object::PyObjectRef> =
         const { std::cell::Cell::new(pyre_object::PY_NULL) };
     static SYS_NO_SITE: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+    static SYS_NO_USER_SITE: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+    static SYS_IGNORE_ENVIRONMENT: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+    static SYS_ISOLATED: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+    static SYS_DEV_MODE: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+    static SYS_UTF8_MODE: std::cell::Cell<i64> = const { std::cell::Cell::new(1) };
+    static SYS_SAFE_PATH: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
 }
 
 /// Record whether the launcher was given `-S` (no `site` import), so the
@@ -1173,6 +1179,49 @@ pub fn set_no_site(no_site: bool) {
 /// Read the `-S` flag for `sys.flags.no_site`.
 pub fn no_site_flag() -> bool {
     SYS_NO_SITE.with(|p| p.get())
+}
+
+/// Record the command-line flags consumed by `app_main.py` before `sys` is
+/// initialized.  The codec paths also read `dev_mode` directly, matching
+/// `space.sys.get_flag('dev_mode')` in `unicodeobject.py`.
+pub fn set_runtime_flags(
+    no_user_site: bool,
+    ignore_environment: bool,
+    isolated: bool,
+    dev_mode: bool,
+    utf8_mode: i64,
+    safe_path: bool,
+) {
+    SYS_NO_USER_SITE.with(|p| p.set(no_user_site));
+    SYS_IGNORE_ENVIRONMENT.with(|p| p.set(ignore_environment));
+    SYS_ISOLATED.with(|p| p.set(isolated));
+    SYS_DEV_MODE.with(|p| p.set(dev_mode));
+    SYS_UTF8_MODE.with(|p| p.set(utf8_mode));
+    SYS_SAFE_PATH.with(|p| p.set(safe_path));
+}
+
+pub fn no_user_site_flag() -> bool {
+    SYS_NO_USER_SITE.with(|p| p.get())
+}
+
+pub fn ignore_environment_flag() -> bool {
+    SYS_IGNORE_ENVIRONMENT.with(|p| p.get())
+}
+
+pub fn isolated_flag() -> bool {
+    SYS_ISOLATED.with(|p| p.get())
+}
+
+pub fn dev_mode_flag() -> bool {
+    SYS_DEV_MODE.with(|p| p.get())
+}
+
+pub fn utf8_mode_flag() -> i64 {
+    SYS_UTF8_MODE.with(|p| p.get())
+}
+
+pub fn safe_path_flag() -> bool {
+    SYS_SAFE_PATH.with(|p| p.get())
 }
 
 /// Called from sys module init to pick up any pending argv.

--- a/pyre/pyre-interpreter/src/module/_codecs/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_codecs/mod.rs
@@ -105,35 +105,43 @@ struct CodecException {
     w_end: PyObjectRef,
     start: usize,
     end: usize,
-    kind: pyre_object::interp_exceptions::ExcKind,
+    kind: Option<pyre_object::interp_exceptions::ExcKind>,
 }
 
 fn check_exception(w_exc: PyObjectRef) -> Result<CodecException, crate::PyError> {
-    let w_start = crate::baseobjspace::getattr_str(w_exc, "start")
-        .map_err(|_| crate::PyError::type_error("wrong exception"))?;
-    let w_end = crate::baseobjspace::getattr_str(w_exc, "end")
-        .map_err(|_| crate::PyError::type_error("wrong exception"))?;
-    let w_obj = crate::baseobjspace::getattr_str(w_exc, "object")
-        .map_err(|_| crate::PyError::type_error("wrong exception"))?;
-    let start = crate::baseobjspace::int_w(w_start)
-        .map_err(|_| crate::PyError::type_error("wrong exception"))?;
-    let end = crate::baseobjspace::int_w(w_end)
-        .map_err(|_| crate::PyError::type_error("wrong exception"))?;
-    if start < 0
-        || end < start
+    let map_attr_error = |err: crate::PyError| {
+        if err.kind == crate::PyErrorKind::AttributeError {
+            crate::PyError::type_error("wrong exception")
+        } else {
+            err
+        }
+    };
+    let w_start = crate::baseobjspace::getattr_str(w_exc, "start").map_err(map_attr_error)?;
+    let w_end = crate::baseobjspace::getattr_str(w_exc, "end").map_err(map_attr_error)?;
+    let w_obj = crate::baseobjspace::getattr_str(w_exc, "object").map_err(map_attr_error)?;
+    let start_i64 = crate::baseobjspace::int_w(w_start)?;
+    let end_i64 = crate::baseobjspace::int_w(w_end)?;
+    if end_i64 - start_i64 < 0
         || !(unsafe { crate::baseobjspace::isinstance_str_w(w_obj) }
             || unsafe { crate::baseobjspace::isinstance_bytes_w(w_obj) })
-        || !unsafe { pyre_object::is_exception(w_exc) }
     {
         return Err(crate::PyError::type_error("wrong exception"));
     }
+    let kind = if unsafe { pyre_object::is_exception(w_exc) } {
+        Some(unsafe { pyre_object::interp_exceptions::w_exception_get_kind(w_exc) })
+    } else {
+        None
+    };
+    // Bounds are clamped like the C accessors so Rust slicing stays in range.
+    let start = start_i64.max(0) as usize;
+    let end = end_i64.max(start_i64.max(0)) as usize;
     Ok(CodecException {
         w_exc,
         w_obj,
         w_end,
-        start: start as usize,
-        end: end as usize,
-        kind: unsafe { pyre_object::interp_exceptions::w_exception_get_kind(w_exc) },
+        start,
+        end,
+        kind,
     })
 }
 
@@ -150,7 +158,13 @@ fn codec_result(replacement: PyObjectRef, position: PyObjectRef) -> PyObjectRef 
 
 fn strict_errors(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     let exc = codec_error_arg(args)?;
-    Err(unsafe { crate::PyError::from_exc_object(exc.w_exc) })
+    if unsafe { pyre_object::is_exception(exc.w_exc) } {
+        Err(unsafe { crate::PyError::from_exc_object(exc.w_exc) })
+    } else {
+        Err(crate::PyError::type_error(
+            "codec must pass exception instance",
+        ))
+    }
 }
 
 fn ignore_errors(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
@@ -186,9 +200,13 @@ fn replace_errors(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     let exc = codec_error_arg(args)?;
     let size = exc.end - exc.start;
     let replacement = match exc.kind {
-        pyre_object::interp_exceptions::ExcKind::UnicodeEncodeError => "?".repeat(size),
-        pyre_object::interp_exceptions::ExcKind::UnicodeDecodeError => "\u{fffd}".to_string(),
-        pyre_object::interp_exceptions::ExcKind::UnicodeTranslateError => "\u{fffd}".repeat(size),
+        Some(pyre_object::interp_exceptions::ExcKind::UnicodeEncodeError) => "?".repeat(size),
+        Some(pyre_object::interp_exceptions::ExcKind::UnicodeDecodeError) => {
+            "\u{fffd}".to_string()
+        }
+        Some(pyre_object::interp_exceptions::ExcKind::UnicodeTranslateError) => {
+            "\u{fffd}".repeat(size)
+        }
         _ => {
             return Err(crate::PyError::type_error(
                 "don't know how to handle exception in error callback",
@@ -200,7 +218,7 @@ fn replace_errors(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
 
 fn xmlcharrefreplace_errors(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     let exc = codec_error_arg(args)?;
-    if exc.kind != pyre_object::interp_exceptions::ExcKind::UnicodeEncodeError {
+    if exc.kind != Some(pyre_object::interp_exceptions::ExcKind::UnicodeEncodeError) {
         return Err(crate::PyError::type_error(
             "don't know how to handle exception in error callback",
         ));
@@ -215,17 +233,21 @@ fn xmlcharrefreplace_errors(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::
 fn backslashreplace_errors(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     let exc = codec_error_arg(args)?;
     let replacement = match exc.kind {
-        pyre_object::interp_exceptions::ExcKind::UnicodeEncodeError
-        | pyre_object::interp_exceptions::ExcKind::UnicodeTranslateError => error_codepoints(&exc)?
-            .into_iter()
-            .map(raw_unicode_escape)
-            .collect::<String>(),
-        pyre_object::interp_exceptions::ExcKind::UnicodeDecodeError => {
+        Some(pyre_object::interp_exceptions::ExcKind::UnicodeEncodeError)
+        | Some(pyre_object::interp_exceptions::ExcKind::UnicodeTranslateError) => {
+            error_codepoints(&exc)?
+                .into_iter()
+                .map(raw_unicode_escape)
+                .collect::<String>()
+        }
+        Some(pyre_object::interp_exceptions::ExcKind::UnicodeDecodeError) => {
             if !unsafe { pyre_object::is_bytes(exc.w_obj) } {
                 return Err(crate::PyError::type_error("wrong exception"));
             }
             let data = unsafe { w_bytes_data(exc.w_obj) };
-            data[exc.start..exc.end]
+            let end = exc.end.min(data.len());
+            let start = exc.start.min(end);
+            data[start..end]
                 .iter()
                 .map(|&byte| raw_unicode_escape(byte as u32))
                 .collect::<String>()
@@ -241,7 +263,7 @@ fn backslashreplace_errors(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::P
 
 fn namereplace_errors(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     let exc = codec_error_arg(args)?;
-    if exc.kind != pyre_object::interp_exceptions::ExcKind::UnicodeEncodeError {
+    if exc.kind != Some(pyre_object::interp_exceptions::ExcKind::UnicodeEncodeError) {
         return Err(crate::PyError::type_error(
             "don't know how to handle exception in error callback",
         ));
@@ -301,9 +323,9 @@ fn exception_encoding(exc: &CodecException) -> Result<(usize, StandardEncoding),
 
 fn surrogatepass_errors(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     let exc = codec_error_arg(args)?;
-    let (byte_len, encoding) = exception_encoding(&exc)?;
     match exc.kind {
-        pyre_object::interp_exceptions::ExcKind::UnicodeEncodeError => {
+        Some(pyre_object::interp_exceptions::ExcKind::UnicodeEncodeError) => {
+            let (_byte_len, encoding) = exception_encoding(&exc)?;
             let mut replacement = Vec::new();
             for code in error_codepoints(&exc)? {
                 if !(0xD800..=0xDFFF).contains(&code) {
@@ -327,7 +349,8 @@ fn surrogatepass_errors(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyEr
             }
             Ok(codec_result(w_bytes_from_bytes(&replacement), exc.w_end))
         }
-        pyre_object::interp_exceptions::ExcKind::UnicodeDecodeError => {
+        Some(pyre_object::interp_exceptions::ExcKind::UnicodeDecodeError) => {
+            let (byte_len, encoding) = exception_encoding(&exc)?;
             if !unsafe { pyre_object::is_bytes(exc.w_obj) } {
                 return Err(crate::PyError::type_error("wrong exception"));
             }
@@ -371,7 +394,7 @@ fn surrogatepass_errors(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyEr
 fn surrogateescape_errors(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     let exc = codec_error_arg(args)?;
     match exc.kind {
-        pyre_object::interp_exceptions::ExcKind::UnicodeEncodeError => {
+        Some(pyre_object::interp_exceptions::ExcKind::UnicodeEncodeError) => {
             let mut replacement = Vec::new();
             for code in error_codepoints(&exc)? {
                 if !(0xDC80..=0xDCFF).contains(&code) {
@@ -381,14 +404,15 @@ fn surrogateescape_errors(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::Py
             }
             Ok(codec_result(w_bytes_from_bytes(&replacement), exc.w_end))
         }
-        pyre_object::interp_exceptions::ExcKind::UnicodeDecodeError => {
+        Some(pyre_object::interp_exceptions::ExcKind::UnicodeDecodeError) => {
             if !unsafe { pyre_object::is_bytes(exc.w_obj) } {
                 return Err(crate::PyError::type_error("wrong exception"));
             }
             let data = unsafe { w_bytes_data(exc.w_obj) };
             let mut replacement = Wtf8Buf::new();
             let mut consumed = 0usize;
-            while consumed < 4 && exc.start + consumed < exc.end {
+            while consumed < 4 && exc.start + consumed < exc.end && exc.start + consumed < data.len()
+            {
                 let byte = data[exc.start + consumed];
                 if byte < 128 {
                     break;

--- a/pyre/pyre-interpreter/src/module/_codecs/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_codecs/mod.rs
@@ -8,6 +8,7 @@
 use std::cell::Cell;
 
 use pyre_object::*;
+use rustpython_wtf8::{CodePoint, Wtf8Buf};
 
 struct CodecState {
     codec_search_path: PyObjectRef,
@@ -18,12 +19,14 @@ struct CodecState {
 
 impl CodecState {
     fn new() -> Self {
-        Self {
+        let mut state = Self {
             codec_search_path: w_list_new(Vec::new()),
             codec_search_cache: w_dict_new(),
             codec_error_registry: w_dict_new(),
             codec_need_encodings: true,
-        }
+        };
+        register_builtin_error_handlers(&mut state);
+        state
     }
 }
 
@@ -96,15 +99,406 @@ fn is_callable(obj: PyObjectRef) -> bool {
     false
 }
 
-// `lookup_error(name)` returns a pass-through handler that never fires
-// because the pure-Python stdlib paths pyre exercises do not encounter
-// encoding errors yet.
-fn lookup_error(_args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    Ok(crate::make_builtin_function_with_arity(
-        "error_handler",
-        |args| Ok(args.first().copied().unwrap_or(w_none())),
-        1,
+struct CodecException {
+    w_exc: PyObjectRef,
+    w_obj: PyObjectRef,
+    w_end: PyObjectRef,
+    start: usize,
+    end: usize,
+    kind: pyre_object::interp_exceptions::ExcKind,
+}
+
+fn check_exception(w_exc: PyObjectRef) -> Result<CodecException, crate::PyError> {
+    let w_start = crate::baseobjspace::getattr_str(w_exc, "start")
+        .map_err(|_| crate::PyError::type_error("wrong exception"))?;
+    let w_end = crate::baseobjspace::getattr_str(w_exc, "end")
+        .map_err(|_| crate::PyError::type_error("wrong exception"))?;
+    let w_obj = crate::baseobjspace::getattr_str(w_exc, "object")
+        .map_err(|_| crate::PyError::type_error("wrong exception"))?;
+    let start = crate::baseobjspace::int_w(w_start)
+        .map_err(|_| crate::PyError::type_error("wrong exception"))?;
+    let end = crate::baseobjspace::int_w(w_end)
+        .map_err(|_| crate::PyError::type_error("wrong exception"))?;
+    if start < 0
+        || end < start
+        || !(unsafe { crate::baseobjspace::isinstance_str_w(w_obj) }
+            || unsafe { crate::baseobjspace::isinstance_bytes_w(w_obj) })
+        || !unsafe { pyre_object::is_exception(w_exc) }
+    {
+        return Err(crate::PyError::type_error("wrong exception"));
+    }
+    Ok(CodecException {
+        w_exc,
+        w_obj,
+        w_end,
+        start: start as usize,
+        end: end as usize,
+        kind: unsafe { pyre_object::interp_exceptions::w_exception_get_kind(w_exc) },
+    })
+}
+
+fn codec_error_arg(args: &[PyObjectRef]) -> Result<CodecException, crate::PyError> {
+    args.first()
+        .copied()
+        .ok_or_else(|| crate::PyError::type_error("error handler requires an exception"))
+        .and_then(check_exception)
+}
+
+fn codec_result(replacement: PyObjectRef, position: PyObjectRef) -> PyObjectRef {
+    w_tuple_new(vec![replacement, position])
+}
+
+fn strict_errors(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    let exc = codec_error_arg(args)?;
+    Err(unsafe { crate::PyError::from_exc_object(exc.w_exc) })
+}
+
+fn ignore_errors(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    let exc = codec_error_arg(args)?;
+    Ok(codec_result(w_str_new(""), exc.w_end))
+}
+
+fn error_codepoints(exc: &CodecException) -> Result<Vec<u32>, crate::PyError> {
+    if !unsafe { crate::baseobjspace::isinstance_str_w(exc.w_obj) } {
+        return Err(crate::PyError::type_error(
+            "don't know how to handle exception in error callback",
+        ));
+    }
+    Ok(unsafe { w_str_get_wtf8(exc.w_obj) }
+        .code_points()
+        .skip(exc.start)
+        .take(exc.end.saturating_sub(exc.start))
+        .map(|cp| cp.to_u32())
+        .collect())
+}
+
+fn raw_unicode_escape(code: u32) -> String {
+    if code >= 0x10000 {
+        format!("\\U{code:08x}")
+    } else if code >= 0x100 {
+        format!("\\u{code:04x}")
+    } else {
+        format!("\\x{code:02x}")
+    }
+}
+
+fn replace_errors(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    let exc = codec_error_arg(args)?;
+    let size = exc.end - exc.start;
+    let replacement = match exc.kind {
+        pyre_object::interp_exceptions::ExcKind::UnicodeEncodeError => "?".repeat(size),
+        pyre_object::interp_exceptions::ExcKind::UnicodeDecodeError => "\u{fffd}".to_string(),
+        pyre_object::interp_exceptions::ExcKind::UnicodeTranslateError => "\u{fffd}".repeat(size),
+        _ => {
+            return Err(crate::PyError::type_error(
+                "don't know how to handle exception in error callback",
+            ));
+        }
+    };
+    Ok(codec_result(w_str_new(&replacement), exc.w_end))
+}
+
+fn xmlcharrefreplace_errors(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    let exc = codec_error_arg(args)?;
+    if exc.kind != pyre_object::interp_exceptions::ExcKind::UnicodeEncodeError {
+        return Err(crate::PyError::type_error(
+            "don't know how to handle exception in error callback",
+        ));
+    }
+    let replacement: String = error_codepoints(&exc)?
+        .into_iter()
+        .map(|code| format!("&#{code};"))
+        .collect();
+    Ok(codec_result(w_str_new(&replacement), exc.w_end))
+}
+
+fn backslashreplace_errors(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    let exc = codec_error_arg(args)?;
+    let replacement = match exc.kind {
+        pyre_object::interp_exceptions::ExcKind::UnicodeEncodeError
+        | pyre_object::interp_exceptions::ExcKind::UnicodeTranslateError => error_codepoints(&exc)?
+            .into_iter()
+            .map(raw_unicode_escape)
+            .collect::<String>(),
+        pyre_object::interp_exceptions::ExcKind::UnicodeDecodeError => {
+            if !unsafe { pyre_object::is_bytes(exc.w_obj) } {
+                return Err(crate::PyError::type_error("wrong exception"));
+            }
+            let data = unsafe { w_bytes_data(exc.w_obj) };
+            data[exc.start..exc.end]
+                .iter()
+                .map(|&byte| raw_unicode_escape(byte as u32))
+                .collect::<String>()
+        }
+        _ => {
+            return Err(crate::PyError::type_error(
+                "don't know how to handle exception in error callback",
+            ));
+        }
+    };
+    Ok(codec_result(w_str_new(&replacement), exc.w_end))
+}
+
+fn namereplace_errors(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    let exc = codec_error_arg(args)?;
+    if exc.kind != pyre_object::interp_exceptions::ExcKind::UnicodeEncodeError {
+        return Err(crate::PyError::type_error(
+            "don't know how to handle exception in error callback",
+        ));
+    }
+    let mut replacement = String::new();
+    for code in error_codepoints(&exc)? {
+        if let Some(name) =
+            char::from_u32(code).and_then(crate::module::unicodedata::character_name)
+        {
+            replacement.push_str("\\N{");
+            replacement.push_str(&name);
+            replacement.push('}');
+        } else {
+            replacement.push_str(&raw_unicode_escape(code));
+        }
+    }
+    Ok(codec_result(w_str_new(&replacement), exc.w_end))
+}
+
+#[derive(Clone, Copy)]
+enum StandardEncoding {
+    Utf8,
+    Utf16Le,
+    Utf16Be,
+    Utf32Le,
+    Utf32Be,
+}
+
+fn standard_encoding(name: &str) -> Option<(usize, StandardEncoding)> {
+    let compact: String = name
+        .chars()
+        .filter(|c| !matches!(c, '-' | '_' | ' '))
+        .flat_map(char::to_lowercase)
+        .collect();
+    match compact.as_str() {
+        "utf8" | "cputf8" => Some((3, StandardEncoding::Utf8)),
+        "utf16le" => Some((2, StandardEncoding::Utf16Le)),
+        "utf16be" => Some((2, StandardEncoding::Utf16Be)),
+        "utf16" if cfg!(target_endian = "little") => Some((2, StandardEncoding::Utf16Le)),
+        "utf16" => Some((2, StandardEncoding::Utf16Be)),
+        "utf32le" => Some((4, StandardEncoding::Utf32Le)),
+        "utf32be" => Some((4, StandardEncoding::Utf32Be)),
+        "utf32" if cfg!(target_endian = "little") => Some((4, StandardEncoding::Utf32Le)),
+        "utf32" => Some((4, StandardEncoding::Utf32Be)),
+        _ => None,
+    }
+}
+
+fn exception_encoding(exc: &CodecException) -> Result<(usize, StandardEncoding), crate::PyError> {
+    let w_encoding = crate::baseobjspace::getattr_str(exc.w_exc, "encoding")?;
+    if !unsafe { is_str(w_encoding) } {
+        return Err(unsafe { crate::PyError::from_exc_object(exc.w_exc) });
+    }
+    standard_encoding(unsafe { w_str_get_value(w_encoding) })
+        .ok_or_else(|| unsafe { crate::PyError::from_exc_object(exc.w_exc) })
+}
+
+fn surrogatepass_errors(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    let exc = codec_error_arg(args)?;
+    let (byte_len, encoding) = exception_encoding(&exc)?;
+    match exc.kind {
+        pyre_object::interp_exceptions::ExcKind::UnicodeEncodeError => {
+            let mut replacement = Vec::new();
+            for code in error_codepoints(&exc)? {
+                if !(0xD800..=0xDFFF).contains(&code) {
+                    return Err(unsafe { crate::PyError::from_exc_object(exc.w_exc) });
+                }
+                match encoding {
+                    StandardEncoding::Utf8 => replacement.extend_from_slice(&[
+                        0xe0 | (code >> 12) as u8,
+                        0x80 | ((code >> 6) & 0x3f) as u8,
+                        0x80 | (code & 0x3f) as u8,
+                    ]),
+                    StandardEncoding::Utf16Le => {
+                        replacement.extend_from_slice(&(code as u16).to_le_bytes())
+                    }
+                    StandardEncoding::Utf16Be => {
+                        replacement.extend_from_slice(&(code as u16).to_be_bytes())
+                    }
+                    StandardEncoding::Utf32Le => replacement.extend_from_slice(&code.to_le_bytes()),
+                    StandardEncoding::Utf32Be => replacement.extend_from_slice(&code.to_be_bytes()),
+                }
+            }
+            Ok(codec_result(w_bytes_from_bytes(&replacement), exc.w_end))
+        }
+        pyre_object::interp_exceptions::ExcKind::UnicodeDecodeError => {
+            if !unsafe { pyre_object::is_bytes(exc.w_obj) } {
+                return Err(crate::PyError::type_error("wrong exception"));
+            }
+            let data = unsafe { w_bytes_data(exc.w_obj) };
+            if exc.start + byte_len > data.len() {
+                return Err(unsafe { crate::PyError::from_exc_object(exc.w_exc) });
+            }
+            let bytes = &data[exc.start..exc.start + byte_len];
+            let code = match encoding {
+                StandardEncoding::Utf8 => {
+                    if bytes[0] & 0xf0 != 0xe0 || bytes[1] & 0xc0 != 0x80 || bytes[2] & 0xc0 != 0x80
+                    {
+                        0
+                    } else {
+                        (((bytes[0] & 0x0f) as u32) << 12)
+                            | (((bytes[1] & 0x3f) as u32) << 6)
+                            | (bytes[2] & 0x3f) as u32
+                    }
+                }
+                StandardEncoding::Utf16Le => u16::from_le_bytes(bytes.try_into().unwrap()) as u32,
+                StandardEncoding::Utf16Be => u16::from_be_bytes(bytes.try_into().unwrap()) as u32,
+                StandardEncoding::Utf32Le => u32::from_le_bytes(bytes.try_into().unwrap()),
+                StandardEncoding::Utf32Be => u32::from_be_bytes(bytes.try_into().unwrap()),
+            };
+            if !(0xD800..=0xDFFF).contains(&code) {
+                return Err(unsafe { crate::PyError::from_exc_object(exc.w_exc) });
+            }
+            let mut replacement = Wtf8Buf::new();
+            replacement.push(CodePoint::from_u32(code).unwrap());
+            Ok(codec_result(
+                w_str_from_wtf8(replacement),
+                w_int_new((exc.start + byte_len) as i64),
+            ))
+        }
+        _ => Err(crate::PyError::type_error(
+            "don't know how to handle exception in error callback",
+        )),
+    }
+}
+
+fn surrogateescape_errors(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    let exc = codec_error_arg(args)?;
+    match exc.kind {
+        pyre_object::interp_exceptions::ExcKind::UnicodeEncodeError => {
+            let mut replacement = Vec::new();
+            for code in error_codepoints(&exc)? {
+                if !(0xDC80..=0xDCFF).contains(&code) {
+                    return Err(unsafe { crate::PyError::from_exc_object(exc.w_exc) });
+                }
+                replacement.push((code - 0xDC00) as u8);
+            }
+            Ok(codec_result(w_bytes_from_bytes(&replacement), exc.w_end))
+        }
+        pyre_object::interp_exceptions::ExcKind::UnicodeDecodeError => {
+            if !unsafe { pyre_object::is_bytes(exc.w_obj) } {
+                return Err(crate::PyError::type_error("wrong exception"));
+            }
+            let data = unsafe { w_bytes_data(exc.w_obj) };
+            let mut replacement = Wtf8Buf::new();
+            let mut consumed = 0usize;
+            while consumed < 4 && exc.start + consumed < exc.end {
+                let byte = data[exc.start + consumed];
+                if byte < 128 {
+                    break;
+                }
+                replacement.push(CodePoint::from_u32(0xDC00 + byte as u32).unwrap());
+                consumed += 1;
+            }
+            if consumed == 0 {
+                return Err(unsafe { crate::PyError::from_exc_object(exc.w_exc) });
+            }
+            Ok(codec_result(
+                w_str_from_wtf8(replacement),
+                w_int_new((exc.start + consumed) as i64),
+            ))
+        }
+        _ => Err(crate::PyError::type_error(
+            "don't know how to handle exception in error callback",
+        )),
+    }
+}
+
+fn register_builtin_error_handlers(state: &mut CodecState) {
+    let handlers: [(
+        &str,
+        fn(&[PyObjectRef]) -> Result<PyObjectRef, crate::PyError>,
+    ); 8] = [
+        ("strict", strict_errors),
+        ("ignore", ignore_errors),
+        ("replace", replace_errors),
+        ("xmlcharrefreplace", xmlcharrefreplace_errors),
+        ("backslashreplace", backslashreplace_errors),
+        ("surrogateescape", surrogateescape_errors),
+        ("surrogatepass", surrogatepass_errors),
+        ("namereplace", namereplace_errors),
+    ];
+    for (name, handler) in handlers {
+        let w_handler = crate::make_builtin_function_with_arity(name, handler, 1);
+        unsafe {
+            pyre_object::dictmultiobject::w_dict_setitem_str(
+                state.codec_error_registry,
+                name,
+                w_handler,
+            );
+        }
+    }
+}
+
+/// `interp_codecs.py:602-610 lookup_error`.  The direct codec loops implement
+/// the eight built-ins themselves; custom handlers live in the same registry
+/// dict PyPy uses and are returned verbatim.
+pub(crate) fn validate_error_handler(errors: &str) -> Result<(), crate::PyError> {
+    let found = with_codec_state(|state| unsafe {
+        pyre_object::dictmultiobject::w_dict_getitem_str(state.codec_error_registry, errors)
+    });
+    if found.is_some() {
+        Ok(())
+    } else {
+        Err(crate::PyError::new(
+            crate::PyErrorKind::LookupError,
+            format!("unknown error handler name {errors}"),
+        ))
+    }
+}
+
+fn lookup_error(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    let Some(w_errors) = args.first().copied() else {
+        return Err(crate::PyError::type_error(
+            "lookup_error() missing argument",
+        ));
+    };
+    if !unsafe { is_str(w_errors) } {
+        return Err(crate::PyError::type_error(
+            "lookup_error() argument must be str",
+        ));
+    }
+    let errors = unsafe { w_str_get_value(w_errors) };
+    if let Some(w_handler) = with_codec_state(|state| unsafe {
+        pyre_object::dictmultiobject::w_dict_getitem_str(state.codec_error_registry, errors)
+    }) {
+        return Ok(w_handler);
+    }
+    Err(crate::PyError::new(
+        crate::PyErrorKind::LookupError,
+        format!("unknown error handler name {errors}"),
     ))
+}
+
+fn register_error(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    let (Some(w_errors), Some(w_handler)) = (args.first().copied(), args.get(1).copied()) else {
+        return Err(crate::PyError::type_error(
+            "register_error() requires name and handler",
+        ));
+    };
+    if !unsafe { is_str(w_errors) } {
+        return Err(crate::PyError::type_error(
+            "register_error() argument 1 must be str",
+        ));
+    }
+    if !is_callable(w_handler) {
+        return Err(crate::PyError::type_error("argument must be callable"));
+    }
+    let errors = unsafe { w_str_get_value(w_errors) };
+    with_codec_state(|state| unsafe {
+        pyre_object::dictmultiobject::w_dict_setitem_str(
+            state.codec_error_registry,
+            errors,
+            w_handler,
+        );
+    });
+    Ok(w_none())
 }
 
 fn register_codec(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
@@ -265,6 +659,9 @@ pub(crate) fn encode_text_codec(
     errors: &str,
 ) -> Result<PyObjectRef, crate::PyError> {
     let w_codec_info = lookup_text_codec("encode", encoding)?;
+    if crate::importing::dev_mode_flag() {
+        validate_error_handler(errors)?;
+    }
     let w_encfunc = unsafe { pyre_object::w_tuple_getitem(w_codec_info, 0).unwrap_or_else(w_none) };
     let w_retval = call_codec(w_encfunc, w_obj, "encoding", Some(errors))?;
     if !unsafe { pyre_object::bytesobject::is_bytes_like(w_retval) } {
@@ -282,6 +679,9 @@ pub(crate) fn decode_text_codec(
     errors: &str,
 ) -> Result<PyObjectRef, crate::PyError> {
     let w_codec_info = lookup_text_codec("decode", encoding)?;
+    if crate::importing::dev_mode_flag() {
+        validate_error_handler(errors)?;
+    }
     let w_decfunc = unsafe { pyre_object::w_tuple_getitem(w_codec_info, 1).unwrap_or_else(w_none) };
     let w_retval = call_codec(w_decfunc, w_obj, "decoding", Some(errors))?;
     if !unsafe { pyre_object::is_str(w_retval) } {
@@ -1245,7 +1645,7 @@ crate::py_module! {
     },
     functions: {
         "lookup_error"     / 1 = lookup_error,
-        "register_error"   / 2 = |_| Ok(w_none()),
+        "register_error"   / 2 = register_error,
         "_unregister_error" / 1 = |_| Ok(w_bool_from(false)),
         "register"       / 1 = register_codec,
         "unregister"     / 1 = unregister,

--- a/pyre/pyre-interpreter/src/module/_codecs/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_codecs/mod.rs
@@ -201,9 +201,7 @@ fn replace_errors(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     let size = exc.end - exc.start;
     let replacement = match exc.kind {
         Some(pyre_object::interp_exceptions::ExcKind::UnicodeEncodeError) => "?".repeat(size),
-        Some(pyre_object::interp_exceptions::ExcKind::UnicodeDecodeError) => {
-            "\u{fffd}".to_string()
-        }
+        Some(pyre_object::interp_exceptions::ExcKind::UnicodeDecodeError) => "\u{fffd}".to_string(),
         Some(pyre_object::interp_exceptions::ExcKind::UnicodeTranslateError) => {
             "\u{fffd}".repeat(size)
         }
@@ -411,7 +409,9 @@ fn surrogateescape_errors(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::Py
             let data = unsafe { w_bytes_data(exc.w_obj) };
             let mut replacement = Wtf8Buf::new();
             let mut consumed = 0usize;
-            while consumed < 4 && exc.start + consumed < exc.end && exc.start + consumed < data.len()
+            while consumed < 4
+                && exc.start + consumed < exc.end
+                && exc.start + consumed < data.len()
             {
                 let byte = data[exc.start + consumed];
                 if byte < 128 {

--- a/pyre/pyre-interpreter/src/module/_codecs/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_codecs/mod.rs
@@ -477,6 +477,12 @@ pub(crate) fn validate_error_handler(errors: &str) -> Result<(), crate::PyError>
     }
 }
 
+pub(crate) fn lookup_registered_error(errors: &str) -> Option<PyObjectRef> {
+    with_codec_state(|state| unsafe {
+        pyre_object::dictmultiobject::w_dict_getitem_str(state.codec_error_registry, errors)
+    })
+}
+
 fn lookup_error(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     let Some(w_errors) = args.first().copied() else {
         return Err(crate::PyError::type_error(

--- a/pyre/pyre-interpreter/src/module/gc/mod.rs
+++ b/pyre/pyre-interpreter/src/module/gc/mod.rs
@@ -31,8 +31,15 @@ fn enable_finalizers(action: &mut crate::executioncontext::UserDelAction) {
     }
     action.finalizers_lock_count -= 1;
     if action.finalizers_lock_count == 0 {
-        if let Some(mut pending) = action.pending_with_disabled_del.take() {
-            for obj in pending.drain(..) {
+        if let Some(pending) = action.pending_with_disabled_del.take() {
+            // The list just left its GC-visible UserDelAction slot; keep every
+            // entry rooted while the finalizers run (upstream clears the
+            // GC-visible list as it progresses, interp_gc.py:80-84).
+            let _roots = pyre_object::gc_roots::push_roots();
+            for &obj in pending.iter() {
+                pyre_object::gc_roots::pin_root(obj);
+            }
+            for obj in pending {
                 action._call_finalizer(obj);
             }
         }
@@ -76,6 +83,7 @@ crate::py_module! {
             Ok(w_int_new(0))
         },
         "disable"       / 0 = |_| {
+            pyre_object::gc_hook::try_gc_set_enabled(false);
             GC_ENABLED.store(false, Ordering::Relaxed);
             if let Some(action) = user_del_action() {
                 if action.enabled_at_app_level {
@@ -86,6 +94,7 @@ crate::py_module! {
             Ok(w_none())
         },
         "enable"        / 0 = |_| {
+            pyre_object::gc_hook::try_gc_set_enabled(true);
             GC_ENABLED.store(true, Ordering::Relaxed);
             if let Some(action) = user_del_action() {
                 if !action.enabled_at_app_level {
@@ -95,7 +104,13 @@ crate::py_module! {
             }
             Ok(w_none())
         },
-        "isenabled"     / 0 = |_| Ok(w_bool_from(GC_ENABLED.load(Ordering::Relaxed))),
+        "isenabled"     / 0 = |_| {
+            let enabled = match user_del_action() {
+                Some(action) => action.enabled_at_app_level,
+                None => GC_ENABLED.load(Ordering::Relaxed),
+            };
+            Ok(w_bool_from(enabled))
+        },
         "get_objects"   / 1 = |_| Ok(w_list_new(vec![])),
         "get_referrers" / * = |_| Ok(w_list_new(vec![])),
         "get_referents" / * = |_| Ok(w_list_new(vec![])),

--- a/pyre/pyre-interpreter/src/module/gc/mod.rs
+++ b/pyre/pyre-interpreter/src/module/gc/mod.rs
@@ -1,10 +1,7 @@
 //! gc module — PyPy: `pypy/module/gc/`.
 //!
-//! Partial port of `interp_gc.py`.  `collect` is currently a no-op because
-//! collection at arbitrary interpreter depth needs shadowstack coverage for
-//! Rust-stack-only `PyObjectRef`s; `enable` / `disable` / `isenabled` accept
-//! calls but pyre has no generational threshold knob; `get_referrers` /
-//! `get_referents` return empty lists; the DEBUG_* constants are stubbed.
+//! Partial port of `interp_gc.py`. Explicit collection uses pyre's non-moving
+//! old-gen major, then drains the RPython finalizer queue synchronously.
 
 use pyre_object::*;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -14,6 +11,40 @@ use std::sync::atomic::{AtomicBool, Ordering};
 /// `gc.isenabled()` should reflect the most recent `enable`/`disable`
 /// call so callers that toggle and re-read the state stay consistent.
 static GC_ENABLED: AtomicBool = AtomicBool::new(true);
+
+fn user_del_action() -> Option<&'static mut crate::executioncontext::UserDelAction> {
+    let ec = crate::call::getexecutioncontext() as *mut crate::PyExecutionContext;
+    if ec.is_null() {
+        return None;
+    }
+    let action = unsafe { (*ec).user_del_action };
+    if action.is_null() {
+        None
+    } else {
+        Some(unsafe { &mut *action })
+    }
+}
+
+fn enable_finalizers(action: &mut crate::executioncontext::UserDelAction) {
+    if action.finalizers_lock_count == 0 {
+        return;
+    }
+    action.finalizers_lock_count -= 1;
+    if action.finalizers_lock_count == 0 {
+        if let Some(mut pending) = action.pending_with_disabled_del.take() {
+            for obj in pending.drain(..) {
+                action._call_finalizer(obj);
+            }
+        }
+    }
+}
+
+fn disable_finalizers(action: &mut crate::executioncontext::UserDelAction) {
+    action.finalizers_lock_count += 1;
+    if action.pending_with_disabled_del.is_none() {
+        action.pending_with_disabled_del = Some(Vec::new());
+    }
+}
 
 crate::py_module! {
     "gc",
@@ -31,18 +62,39 @@ crate::py_module! {
         // upstream.  MethodCache / MapAttrCache clears (`:14-17`) skipped
         // because pyre has no equivalent caches.
         "collect"       / 1 = |_| {
-            // A real collection here needs a shadowstack pass over interpreter
-            // Rust-stack `PyObjectRef`s; see the full-collect trampoline doc in
-            // `pyre-jit/src/eval.rs`. Even the non-moving old-gen major is
-            // unsound at arbitrary interpreter depth because marking cannot see
-            // Rust-stack-only references. Until that shadowstack pass exists,
-            // `collect` is a no-op and collections happen only at the JIT's own
-            // safepoints / the gated interpreter safepoint
-            // (`pyre-object/src/gc_interp.rs`).
+            pyre_object::gc_hook::try_gc_collect_oldgen();
+            if let Some(action) = user_del_action() {
+                let temp_reenable = !action.enabled_at_app_level;
+                if temp_reenable {
+                    enable_finalizers(action);
+                }
+                action._run_finalizers();
+                if temp_reenable {
+                    disable_finalizers(action);
+                }
+            }
             Ok(w_int_new(0))
         },
-        "disable"       / 0 = |_| { GC_ENABLED.store(false, Ordering::Relaxed); Ok(w_none()) },
-        "enable"        / 0 = |_| { GC_ENABLED.store(true, Ordering::Relaxed); Ok(w_none()) },
+        "disable"       / 0 = |_| {
+            GC_ENABLED.store(false, Ordering::Relaxed);
+            if let Some(action) = user_del_action() {
+                if action.enabled_at_app_level {
+                    action.enabled_at_app_level = false;
+                    disable_finalizers(action);
+                }
+            }
+            Ok(w_none())
+        },
+        "enable"        / 0 = |_| {
+            GC_ENABLED.store(true, Ordering::Relaxed);
+            if let Some(action) = user_del_action() {
+                if !action.enabled_at_app_level {
+                    action.enabled_at_app_level = true;
+                    enable_finalizers(action);
+                }
+            }
+            Ok(w_none())
+        },
         "isenabled"     / 0 = |_| Ok(w_bool_from(GC_ENABLED.load(Ordering::Relaxed))),
         "get_objects"   / 1 = |_| Ok(w_list_new(vec![])),
         "get_referrers" / * = |_| Ok(w_list_new(vec![])),

--- a/pyre/pyre-interpreter/src/module/sys/vm.rs
+++ b/pyre/pyre-interpreter/src/module/sys/vm.rs
@@ -136,6 +136,36 @@ fn sys_setprofile_impl(args: &[PyObjectRef]) -> crate::PyResult {
     Ok(w_none())
 }
 
+fn sys_unraisablehook(args: &[PyObjectRef]) -> crate::PyResult {
+    let Some(&w_hookargs) = args.first() else {
+        return Err(crate::PyError::type_error(
+            "unraisablehook() missing 1 required positional argument",
+        ));
+    };
+    let w_type = crate::baseobjspace::getattr_str(w_hookargs, "exc_type")?;
+    let w_value = crate::baseobjspace::getattr_str(w_hookargs, "exc_value")?;
+    let w_tb = crate::baseobjspace::getattr_str(w_hookargs, "exc_traceback")?;
+    let w_err_msg = crate::baseobjspace::getattr_str(w_hookargs, "err_msg")?;
+    let err_msg = if unsafe { pyre_object::is_none(w_err_msg) } {
+        String::new()
+    } else if unsafe { pyre_object::is_str(w_err_msg) } {
+        unsafe { pyre_object::w_str_get_value(w_err_msg) }.to_string()
+    } else {
+        unsafe { crate::display::py_str(w_err_msg)? }
+    };
+    let w_object = crate::baseobjspace::getattr_str(w_hookargs, "object")?;
+    crate::PyError::write_unraisable_default(
+        w_none(),
+        w_type,
+        w_value,
+        w_tb,
+        &err_msg,
+        w_object,
+        "",
+    );
+    Ok(w_none())
+}
+
 /// pypy/module/sys/vm.py `exc_info_direct` — return the active exception
 /// as a `(type, value, traceback)` tuple.
 ///
@@ -919,16 +949,10 @@ pub fn register_module(ns: &mut DictStorage) {
     // sys.unraisablehook(unraisable) — handles exceptions raised where they
     // cannot propagate (e.g. __del__).  Stored alongside the read-only
     // `__unraisablehook__` original so code can save and restore it.
-    dict_storage_store(
-        ns,
-        "unraisablehook",
-        make_builtin_function_with_arity("unraisablehook", |_| Ok(w_none()), 1),
-    );
-    dict_storage_store(
-        ns,
-        "__unraisablehook__",
-        make_builtin_function_with_arity("unraisablehook", |_| Ok(w_none()), 1),
-    );
+    let unraisablehook_fn =
+        make_builtin_function_with_arity("unraisablehook", sys_unraisablehook, 1);
+    dict_storage_store(ns, "unraisablehook", unraisablehook_fn);
+    dict_storage_store(ns, "__unraisablehook__", unraisablehook_fn);
     // sys.path_hooks / path_importer_cache
     dict_storage_store(ns, "path_hooks", w_list_new(vec![]));
     dict_storage_store(ns, "path_importer_cache", w_dict_new());

--- a/pyre/pyre-interpreter/src/module/sys/vm.rs
+++ b/pyre/pyre-interpreter/src/module/sys/vm.rs
@@ -359,23 +359,47 @@ pub fn register_module(ns: &mut DictStorage) {
             dict_storage_store(fns, "interactive", w_int_new(0));
             dict_storage_store(fns, "optimize", w_int_new(0));
             dict_storage_store(fns, "dont_write_bytecode", w_int_new(0));
-            dict_storage_store(fns, "no_user_site", w_int_new(0));
+            dict_storage_store(
+                fns,
+                "no_user_site",
+                w_int_new(i64::from(crate::importing::no_user_site_flag())),
+            );
             // `-S` (skip `import site`) is recorded by the launcher.
             dict_storage_store(
                 fns,
                 "no_site",
                 w_int_new(i64::from(crate::importing::no_site_flag())),
             );
-            dict_storage_store(fns, "ignore_environment", w_int_new(0));
+            dict_storage_store(
+                fns,
+                "ignore_environment",
+                w_int_new(i64::from(crate::importing::ignore_environment_flag())),
+            );
             dict_storage_store(fns, "verbose", w_int_new(0));
             dict_storage_store(fns, "bytes_warning", w_int_new(0));
             dict_storage_store(fns, "quiet", w_int_new(0));
             dict_storage_store(fns, "hash_randomization", w_int_new(0));
-            dict_storage_store(fns, "isolated", w_int_new(0));
-            dict_storage_store(fns, "dev_mode", w_bool_from(false));
-            dict_storage_store(fns, "utf8_mode", w_int_new(1));
+            dict_storage_store(
+                fns,
+                "isolated",
+                w_int_new(i64::from(crate::importing::isolated_flag())),
+            );
+            dict_storage_store(
+                fns,
+                "dev_mode",
+                w_bool_from(crate::importing::dev_mode_flag()),
+            );
+            dict_storage_store(
+                fns,
+                "utf8_mode",
+                w_int_new(crate::importing::utf8_mode_flag()),
+            );
             dict_storage_store(fns, "warn_default_encoding", w_int_new(0));
-            dict_storage_store(fns, "safe_path", w_bool_from(false));
+            dict_storage_store(
+                fns,
+                "safe_path",
+                w_bool_from(crate::importing::safe_path_flag()),
+            );
             dict_storage_store(fns, "int_max_str_digits", w_int_new(4300));
             dict_storage_store(fns, "context_aware_warnings", w_bool_from(false));
             dict_storage_store(fns, "thread_inherit_context", w_int_new(0));
@@ -794,19 +818,25 @@ pub fn register_module(ns: &mut DictStorage) {
         "copyright",
         w_str_new("Copyright (c) 2001-2024 Python Software Foundation.\nAll Rights Reserved."),
     );
-    // sys.getsizeof(obj[, default]) — pyre has no per-object size accounting
-    // (vm.py getsizeof): return the caller-supplied `default`, and raise
-    // TypeError when it is omitted.
+    // sys.getsizeof(obj[, default]) — PyPy vm.py returns the supplied default
+    // for untracked objects.  str additionally exposes its PEP 393-compatible
+    // `__sizeof__`, needed by the shared CPython test_str overflow check.
     dict_storage_store(
         ns,
         "getsizeof",
         make_builtin_function_with_arity(
             "getsizeof",
-            |args| match args.get(1).copied() {
-                Some(w_default) => Ok(w_default),
-                None => Err(crate::PyError::type_error(
-                    "getsizeof(object, default) -> int: object size is not tracked; supply a default",
-                )),
+            |args| {
+                if unsafe { pyre_object::is_str(args[0]) } {
+                    let method = crate::baseobjspace::getattr_str(args[0], "__sizeof__")?;
+                    return crate::call::call_function_impl_result(method, &[]);
+                }
+                match args.get(1).copied() {
+                    Some(w_default) => Ok(w_default),
+                    None => Err(crate::PyError::type_error(
+                        "getsizeof(object, default) -> int: object size is not tracked; supply a default",
+                    )),
+                }
             },
             1,
         ),

--- a/pyre/pyre-interpreter/src/module/unicodedata/mod.rs
+++ b/pyre/pyre-interpreter/src/module/unicodedata/mod.rs
@@ -24,6 +24,10 @@ use rustpython_wtf8::{CodePoint, Wtf8};
 
 use crate::{PyError, PyErrorKind};
 
+pub(crate) fn character_name(ch: char) -> Option<String> {
+    ucd_core::character_name(ch)
+}
+
 type PyResult = Result<PyObjectRef, PyError>;
 
 /// Latest bundled database view — the module-level functions.

--- a/pyre/pyre-interpreter/src/type_methods.rs
+++ b/pyre/pyre-interpreter/src/type_methods.rs
@@ -2479,7 +2479,11 @@ pub fn decode_raw_unicode_escape(data: &[u8], errors: &str) -> Result<Wtf8Buf, c
                 i = available_end;
                 continue;
             }
-            let error_end = if numeric.is_some() { available_end } else { hex_end };
+            let error_end = if numeric.is_some() {
+                available_end
+            } else {
+                hex_end
+            };
             let reason = if numeric.is_some() {
                 "illegal Unicode character"
             } else if want == 4 {
@@ -2885,9 +2889,7 @@ pub(crate) fn call_registered_decode_error_handler(
             .unwrap_or_else(|| crate::PyError::type_error("error handler failed")));
     }
 
-    if !unsafe { pyre_object::is_tuple(w_res) }
-        || unsafe { pyre_object::w_tuple_len(w_res) } != 2
-    {
+    if !unsafe { pyre_object::is_tuple(w_res) } || unsafe { pyre_object::w_tuple_len(w_res) } != 2 {
         return Err(crate::PyError::type_error(
             "decoding error handler must return (str, int) tuple",
         ));
@@ -3081,9 +3083,7 @@ fn utf16_32_decode_error(
             }
             Ok(start + consumed)
         }
-        _ => call_registered_decode_error_handler(
-            err_mode, codec, data, start, end, reason, out,
-        ),
+        _ => call_registered_decode_error_handler(err_mode, codec, data, start, end, reason, out),
     }
 }
 

--- a/pyre/pyre-interpreter/src/type_methods.rs
+++ b/pyre/pyre-interpreter/src/type_methods.rs
@@ -1096,8 +1096,7 @@ fn format_render(
     depth: u32,
 ) -> Result<Wtf8Buf, crate::PyError> {
     use rustpython_common::format::{
-        FieldName, FieldNamePart, FieldType, FormatParseError, FormatPart, FormatString,
-        FromTemplate,
+        FieldName, FieldNamePart, FieldType, FormatParseError, FromTemplate,
     };
     let lookup_kwarg = |name: &str| -> Result<Option<PyObjectRef>, crate::PyError> {
         if let Some(m) = mapping {
@@ -1118,15 +1117,15 @@ fn format_render(
     if depth == 0 {
         return Err(crate::PyError::value_error("Max string recursion exceeded"));
     }
-    let parsed = FormatString::from_str(fmt).map_err(|e| format_parse_err(e, fmt))?;
+    let parsed = parse_format_parts(fmt)?;
     let mut result = Wtf8Buf::new();
-    for part in &parsed.format_parts {
+    for part in &parsed {
         let (field_name, conversion_spec, format_spec) = match part {
-            FormatPart::Literal(literal) => {
+            PyPyFormatPart::Literal(literal) => {
                 result.push_wtf8(literal);
                 continue;
             }
-            FormatPart::Field {
+            PyPyFormatPart::Field {
                 field_name,
                 conversion_spec,
                 format_spec,
@@ -1266,6 +1265,146 @@ fn format_render(
         result.push_wtf8(&formatted);
     }
     Ok(result)
+}
+
+enum PyPyFormatPart {
+    Literal(Wtf8Buf),
+    Field {
+        field_name: Wtf8Buf,
+        conversion_spec: Option<CodePoint>,
+        format_spec: Wtf8Buf,
+    },
+}
+
+fn codepoint_slice(codepoints: &[CodePoint], start: usize, end: usize) -> Wtf8Buf {
+    let mut out = Wtf8Buf::new();
+    for &cp in &codepoints[start..end] {
+        out.push(cp);
+    }
+    out
+}
+
+/// `newformat.py:TemplateFormatter._do_build_string/_parse_field`.
+/// Braces inside the first-part item lookup (`{[{]}`) are ordinary key text;
+/// braces after `:`/`!` are recursive format markup.
+fn parse_format_parts(fmt: &Wtf8) -> Result<Vec<PyPyFormatPart>, crate::PyError> {
+    let s: Vec<CodePoint> = fmt.code_points().collect();
+    let end = s.len();
+    let mut parts = Vec::new();
+    let mut literal = Wtf8Buf::new();
+    let mut i = 0usize;
+    while i < end {
+        let c = s[i];
+        if c != '{' && c != '}' {
+            literal.push(c);
+            i += 1;
+            continue;
+        }
+        if c == '}' {
+            if i + 1 == end || s[i + 1] != '}' {
+                return Err(crate::PyError::value_error(
+                    "Single '}' encountered in format string",
+                ));
+            }
+            literal.push(c);
+            i += 2;
+            continue;
+        }
+        if i + 1 == end {
+            return Err(crate::PyError::value_error(
+                "Single '{' encountered in format string",
+            ));
+        }
+        if s[i + 1] == '{' {
+            literal.push(c);
+            i += 2;
+            continue;
+        }
+        if !literal.is_empty() {
+            parts.push(PyPyFormatPart::Literal(std::mem::take(&mut literal)));
+        }
+
+        i += 1;
+        let field_start = i;
+        let mut nested = 1usize;
+        let mut in_second_part = false;
+        while i < end {
+            let c = s[i];
+            if c == '{' {
+                nested += 1;
+            } else if c == '}' {
+                nested -= 1;
+                if nested == 0 {
+                    break;
+                }
+            } else if c == '[' && !in_second_part {
+                i += 1;
+                while i < end && s[i] != ']' {
+                    i += 1;
+                }
+                continue;
+            } else if c == ':' || c == '!' {
+                in_second_part = true;
+            }
+            i += 1;
+        }
+        if nested != 0 {
+            return Err(crate::PyError::value_error(
+                "expected '}' before end of string",
+            ));
+        }
+        let field_end = i;
+
+        let mut cursor = field_start;
+        let mut field_name_end = field_end;
+        let mut conversion_spec = None;
+        let mut spec_start = field_end;
+        while cursor < field_end {
+            let c = s[cursor];
+            if c == ':' || c == '!' {
+                field_name_end = cursor;
+                if c == '!' {
+                    cursor += 1;
+                    if cursor == field_end {
+                        return Err(crate::PyError::value_error(
+                            "end of string while looking for conversion specifier",
+                        ));
+                    }
+                    conversion_spec = Some(s[cursor]);
+                    cursor += 1;
+                    if cursor < field_end {
+                        if s[cursor] != ':' {
+                            return Err(crate::PyError::value_error(
+                                "expected ':' after conversion specifier",
+                            ));
+                        }
+                        cursor += 1;
+                    }
+                } else {
+                    cursor += 1;
+                }
+                spec_start = cursor;
+                break;
+            } else if c == '[' {
+                while cursor + 1 < field_end && s[cursor + 1] != ']' {
+                    cursor += 1;
+                }
+            } else if c == '{' {
+                return Err(crate::PyError::value_error("unexpected '{' in field name"));
+            }
+            cursor += 1;
+        }
+        parts.push(PyPyFormatPart::Field {
+            field_name: codepoint_slice(&s, field_start, field_name_end),
+            conversion_spec,
+            format_spec: codepoint_slice(&s, spec_start, field_end),
+        });
+        i += 1;
+    }
+    if !literal.is_empty() {
+        parts.push(PyPyFormatPart::Literal(literal));
+    }
+    Ok(parts)
 }
 
 /// Fetch positional argument `idx`, raising the `str.format` IndexError for
@@ -2187,6 +2326,30 @@ pub fn encode_object(
     errors: &str,
 ) -> Result<Vec<u8>, crate::PyError> {
     let enc_lower = encoding.to_ascii_lowercase().replace('_', "-");
+    if crate::importing::dev_mode_flag()
+        && matches!(
+            enc_lower.as_str(),
+            "utf-8"
+                | "utf8"
+                | "u8"
+                | "ascii"
+                | "us-ascii"
+                | "646"
+                | "latin-1"
+                | "latin1"
+                | "iso-8859-1"
+                | "8859"
+                | "raw-unicode-escape"
+                | "utf-16"
+                | "utf-16-le"
+                | "utf-16-be"
+                | "utf-32"
+                | "utf-32-le"
+                | "utf-32-be"
+        )
+    {
+        crate::module::_codecs::validate_error_handler(errors)?;
+    }
     if matches!(enc_lower.as_str(), "utf-8" | "utf8" | "u8") {
         return encode_utf8_with_errors(w_object, errors);
     }
@@ -2244,7 +2407,7 @@ pub fn encode_raw_unicode_escape(s: &Wtf8) -> Vec<u8> {
 /// [`encode_raw_unicode_escape`].  A backslash starts a `\uXXXX` /
 /// `\UXXXXXXXX` escape; any other byte (including a lone backslash or a
 /// malformed escape) is taken as a Latin-1 code point.
-pub fn decode_raw_unicode_escape(data: &[u8]) -> Result<Wtf8Buf, crate::PyError> {
+pub fn decode_raw_unicode_escape(data: &[u8], errors: &str) -> Result<Wtf8Buf, crate::PyError> {
     let mut out = Wtf8Buf::new();
     let mut i = 0usize;
     while i < data.len() {
@@ -2265,17 +2428,59 @@ pub fn decode_raw_unicode_escape(data: &[u8]) -> Result<Wtf8Buf, crate::PyError>
             Some(b'U') => 8usize,
             _ => 0,
         };
-        if want != 0 && i + 2 + want <= data.len() {
-            let hex = &data[i + 2..i + 2 + want];
-            if let Ok(hs) = std::str::from_utf8(hex) {
-                if let Ok(v) = u32::from_str_radix(hs, 16) {
-                    if let Some(c) = CodePoint::from_u32(v) {
-                        out.push(c);
-                        i += 2 + want;
-                        continue;
+        if want != 0 {
+            let escape_start = i;
+            let digits_start = i + 2;
+            let available_end = (digits_start + want).min(data.len());
+            let mut hex_end = digits_start;
+            while hex_end < available_end && data[hex_end].is_ascii_hexdigit() {
+                hex_end += 1;
+            }
+            let numeric = if available_end == digits_start + want && hex_end == available_end {
+                std::str::from_utf8(&data[digits_start..available_end])
+                    .ok()
+                    .and_then(|s| u32::from_str_radix(s, 16).ok())
+            } else {
+                None
+            };
+            let parsed = numeric.and_then(CodePoint::from_u32);
+            if let Some(c) = parsed {
+                out.push(c);
+                i = available_end;
+                continue;
+            }
+            let error_end = if available_end < digits_start + want {
+                hex_end
+            } else {
+                available_end
+            };
+            let reason = if numeric.is_some() {
+                "illegal Unicode character"
+            } else if want == 4 {
+                "truncated \\uXXXX escape"
+            } else {
+                "truncated \\UXXXXXXXX escape"
+            };
+            match errors {
+                "ignore" => {}
+                "replace" => out.push_char('\u{FFFD}'),
+                "backslashreplace" => {
+                    for &byte in &data[escape_start..error_end] {
+                        out.push_str(&format!("\\x{byte:02x}"));
                     }
                 }
+                _ => {
+                    return Err(crate::typedef::unicode_decode_error(
+                        "rawunicodeescape",
+                        data,
+                        escape_start,
+                        error_end,
+                        reason,
+                    ));
+                }
             }
+            i = error_end;
+            continue;
         }
         // Not a valid escape — emit the backslash literally as Latin-1.
         out.push_char(b as char);

--- a/pyre/pyre-interpreter/src/type_methods.rs
+++ b/pyre/pyre-interpreter/src/type_methods.rs
@@ -2213,12 +2213,17 @@ fn encode_utf8_with_errors(
     }
     let mut out = Vec::with_capacity(s.len());
     let mut buf = [0u8; 4];
-    for (index, cp) in s.code_points().enumerate() {
+    let cps: Vec<CodePoint> = s.code_points().collect();
+    let mut i = 0usize;
+    while i < cps.len() {
+        let cp = cps[i];
         if let Some(c) = cp.to_char() {
             out.extend_from_slice(c.encode_utf8(&mut buf).as_bytes());
+            i += 1;
             continue;
         }
         let code = cp.to_u32();
+        let index = i;
         match err_mode {
             // surrogatepass_errors encode branch (interp_codecs.py:455-458):
             // emit the three-byte sequence for the surrogate code point.
@@ -2257,12 +2262,37 @@ fn encode_utf8_with_errors(
             "backslashreplace" => out.extend_from_slice(format!("\\u{code:04x}").as_bytes()),
             "xmlcharrefreplace" => out.extend_from_slice(format!("&#{code};").as_bytes()),
             _ => {
-                return Err(crate::PyError::new(
-                    crate::PyErrorKind::LookupError,
-                    format!("unknown error handler name '{err_mode}'"),
-                ));
+                let (rep, newpos) = call_registered_encode_error_handler(
+                    err_mode,
+                    "utf-8",
+                    w_object,
+                    cps.len(),
+                    index,
+                    index + 1,
+                    "surrogates not allowed",
+                )?;
+                match rep {
+                    EncodeReplacement::Str(rcps) => {
+                        for rc in rcps {
+                            if rc >= 0x80 {
+                                return Err(crate::typedef::unicode_encode_error(
+                                    "utf-8",
+                                    w_object,
+                                    index,
+                                    index + 1,
+                                    "surrogates not allowed",
+                                ));
+                            }
+                            out.push(rc as u8);
+                        }
+                    }
+                    EncodeReplacement::Bytes(b) => out.extend_from_slice(&b),
+                }
+                i = newpos;
+                continue;
             }
         }
+        i += 1;
     }
     Ok(out)
 }
@@ -2560,10 +2590,30 @@ fn encode_narrow(
                 }
             }
             _ => {
-                return Err(crate::PyError::new(
-                    crate::PyErrorKind::LookupError,
-                    format!("unknown error handler name '{errors}'"),
-                ));
+                let (rep, newpos) = call_registered_encode_error_handler(
+                    errors,
+                    enc_name,
+                    source,
+                    cps.len(),
+                    start,
+                    end,
+                    range_msg,
+                )?;
+                match rep {
+                    EncodeReplacement::Str(rcps) => {
+                        for rc in rcps {
+                            if rc > max_cp {
+                                return Err(crate::typedef::unicode_encode_error(
+                                    enc_name, source, start, end, range_msg,
+                                ));
+                            }
+                            out.push(rc as u8);
+                        }
+                    }
+                    EncodeReplacement::Bytes(b) => out.extend_from_slice(&b),
+                }
+                i = newpos;
+                continue;
             }
         }
         i = end;
@@ -2653,12 +2703,16 @@ fn encode_utf16_32_impl(
     if bom {
         emit_scalar(&mut out, 0xFEFF, is32, big_endian);
     }
-    for (index, cp) in s.code_points().enumerate() {
-        let code = cp.to_u32();
+    let cps: Vec<u32> = s.code_points().map(|c| c.to_u32()).collect();
+    let mut i = 0usize;
+    while i < cps.len() {
+        let code = cps[i];
         if !(0xD800..=0xDFFF).contains(&code) {
             emit_scalar(&mut out, code, is32, big_endian);
+            i += 1;
             continue;
         }
+        let index = i;
         // Lone surrogate — only the utf-8/16/32 surrogatepass branch may
         // emit it, as a raw code unit (interp_codecs.py surrogatepass).
         match errors {
@@ -2696,12 +2750,49 @@ fn encode_utf16_32_impl(
                 ));
             }
             _ => {
-                return Err(crate::PyError::new(
-                    crate::PyErrorKind::LookupError,
-                    format!("unknown error handler name '{errors}'"),
-                ));
+                let (rep, newpos) = call_registered_encode_error_handler(
+                    errors,
+                    codec,
+                    w_object,
+                    cps.len(),
+                    index,
+                    index + 1,
+                    "surrogates not allowed",
+                )?;
+                match rep {
+                    EncodeReplacement::Str(rcps) => {
+                        for rc in rcps {
+                            if rc >= 0x80 {
+                                return Err(crate::typedef::unicode_encode_error(
+                                    codec,
+                                    w_object,
+                                    index,
+                                    index + 1,
+                                    "surrogates not allowed",
+                                ));
+                            }
+                            emit_scalar(&mut out, rc, is32, big_endian);
+                        }
+                    }
+                    EncodeReplacement::Bytes(b) => {
+                        let unit = if is32 { 4 } else { 2 };
+                        if b.len() % unit != 0 {
+                            return Err(crate::typedef::unicode_encode_error(
+                                codec,
+                                w_object,
+                                index,
+                                index + 1,
+                                "surrogates not allowed",
+                            ));
+                        }
+                        out.extend_from_slice(&b);
+                    }
+                }
+                i = newpos;
+                continue;
             }
         }
+        i += 1;
     }
     Ok(out)
 }
@@ -2834,6 +2925,96 @@ pub(crate) fn call_registered_decode_error_handler(
 
     out.push_wtf8(unsafe { pyre_object::w_str_get_wtf8(w_replace) });
     Ok(newpos as usize)
+}
+
+/// Replacement returned by a custom encode error handler: either a str
+/// (its code points, re-encoded by the codec) or raw bytes (copied
+/// verbatim). interp_codecs.py:69-72 rettype 'u' vs 'b'.
+enum EncodeReplacement {
+    Str(Vec<u32>),
+    Bytes(Vec<u8>),
+}
+
+/// interp_codecs.py:33-108 `call_errorhandler` (encode branch): invoke a
+/// custom handler registered through `_codecs.register_error` for an
+/// encode error span. `start`/`end`/`char_len` are CHARACTER (code-point)
+/// indices into the source; the returned position is a character index to
+/// resume at. The caller re-encodes an `EncodeReplacement::Str` through
+/// its own codec (raising the ORIGINAL error if a replacement code point
+/// is not encodable) and copies `EncodeReplacement::Bytes` verbatim.
+fn call_registered_encode_error_handler(
+    err_mode: &str,
+    codec: &str,
+    source: PyObjectRef,
+    char_len: usize,
+    start: usize,
+    end: usize,
+    reason: &str,
+) -> Result<(EncodeReplacement, usize), crate::PyError> {
+    let w_handler = crate::module::_codecs::lookup_registered_error(err_mode).ok_or_else(|| {
+        crate::PyError::new(
+            crate::PyErrorKind::LookupError,
+            format!("unknown error handler name '{err_mode}'"),
+        )
+    })?;
+
+    let w_exc =
+        crate::typedef::unicode_encode_error(codec, source, start, end, reason).to_exc_object();
+    let w_res = crate::baseobjspace::call_function(w_handler, &[w_exc]);
+    if w_res.is_null() {
+        return Err(crate::call::take_call_error()
+            .unwrap_or_else(|| crate::PyError::type_error("error handler failed")));
+    }
+
+    if !unsafe { pyre_object::is_tuple(w_res) } || unsafe { pyre_object::w_tuple_len(w_res) } != 2 {
+        return Err(crate::PyError::type_error(
+            "encoding error handler must return (str/bytes, int) tuple",
+        ));
+    }
+    let w_replace = unsafe { pyre_object::w_tuple_getitem(w_res, 0).unwrap() };
+    let w_newpos = unsafe { pyre_object::w_tuple_getitem(w_res, 1).unwrap() };
+
+    let replacement = if unsafe { pyre_object::is_str(w_replace) } {
+        EncodeReplacement::Str(
+            unsafe { pyre_object::w_str_get_wtf8(w_replace) }
+                .code_points()
+                .map(|c| c.to_u32())
+                .collect(),
+        )
+    } else if unsafe { pyre_object::bytesobject::is_bytes(w_replace) } {
+        EncodeReplacement::Bytes(
+            unsafe { pyre_object::bytesobject::bytes_like_data(w_replace) }.to_vec(),
+        )
+    } else {
+        return Err(crate::PyError::type_error(
+            "encoding error handler must return (str/bytes, int) tuple",
+        ));
+    };
+
+    // newpos folds against the source CHARACTER length and resumes into the
+    // original code-point sequence.
+    let length = char_len as i64;
+    let mut newpos = match crate::baseobjspace::int_w(w_newpos) {
+        Ok(n) => n,
+        Err(e) => {
+            if e.kind == crate::PyErrorKind::OverflowError {
+                -1
+            } else {
+                return Err(e);
+            }
+        }
+    };
+    if newpos < 0 {
+        newpos += length;
+    }
+    if newpos < 0 || newpos > length {
+        return Err(crate::PyError::new(
+            crate::PyErrorKind::IndexError,
+            format!("position {newpos} from error handler out of bounds"),
+        ));
+    }
+
+    Ok((replacement, newpos as usize))
 }
 
 /// Decode error-handler dispatch for utf-16 / utf-32 (interp_codecs.py

--- a/pyre/pyre-interpreter/src/type_methods.rs
+++ b/pyre/pyre-interpreter/src/type_methods.rs
@@ -2764,6 +2764,75 @@ fn read_code_unit(data: &[u8], pos: usize, unit: usize, big_endian: bool) -> u32
     }
 }
 
+/// interp_codecs.py:33-108 `call_errorhandler` (decode branch): invoke a
+/// custom handler registered through `_codecs.register_error` for a decode
+/// error position.
+pub(crate) fn call_registered_decode_error_handler(
+    err_mode: &str,
+    codec: &str,
+    data: &[u8],
+    start: usize,
+    end: usize,
+    reason: &str,
+    out: &mut Wtf8Buf,
+) -> Result<usize, crate::PyError> {
+    let w_handler = crate::module::_codecs::lookup_registered_error(err_mode).ok_or_else(|| {
+        crate::PyError::new(
+            crate::PyErrorKind::LookupError,
+            format!("unknown error handler name '{err_mode}'"),
+        )
+    })?;
+
+    let w_exc =
+        crate::typedef::unicode_decode_error(codec, data, start, end, reason).to_exc_object();
+    let w_res = crate::baseobjspace::call_function(w_handler, &[w_exc]);
+    if w_res.is_null() {
+        return Err(crate::call::take_call_error()
+            .unwrap_or_else(|| crate::PyError::type_error("error handler failed")));
+    }
+
+    if !unsafe { pyre_object::is_tuple(w_res) }
+        || unsafe { pyre_object::w_tuple_len(w_res) } != 2
+    {
+        return Err(crate::PyError::type_error(
+            "decoding error handler must return (str, int) tuple",
+        ));
+    }
+    let w_replace = unsafe { pyre_object::w_tuple_getitem(w_res, 0).unwrap() };
+    let w_newpos = unsafe { pyre_object::w_tuple_getitem(w_res, 1).unwrap() };
+    if !unsafe { pyre_object::is_str(w_replace) } {
+        return Err(crate::PyError::type_error(
+            "decoding error handler must return (str, int) tuple",
+        ));
+    }
+
+    // Bounds stay against original data; these loops resume into the
+    // original byte slice.
+    let length = data.len() as i64;
+    let mut newpos = match crate::baseobjspace::int_w(w_newpos) {
+        Ok(n) => n,
+        Err(e) => {
+            if e.kind == crate::PyErrorKind::OverflowError {
+                -1
+            } else {
+                return Err(e);
+            }
+        }
+    };
+    if newpos < 0 {
+        newpos += length;
+    }
+    if newpos < 0 || newpos > length {
+        return Err(crate::PyError::new(
+            crate::PyErrorKind::IndexError,
+            format!("position {newpos} from error handler out of bounds"),
+        ));
+    }
+
+    out.push_wtf8(unsafe { pyre_object::w_str_get_wtf8(w_replace) });
+    Ok(newpos as usize)
+}
+
 /// Decode error-handler dispatch for utf-16 / utf-32 (interp_codecs.py
 /// surrogatepass/surrogateescape branches plus the generic handlers).
 /// Appends the replacement to `out` and returns the byte position to
@@ -2828,10 +2897,9 @@ fn utf16_32_decode_error(
             }
             Ok(start + consumed)
         }
-        _ => Err(crate::PyError::new(
-            crate::PyErrorKind::LookupError,
-            format!("unknown error handler name '{err_mode}'"),
-        )),
+        _ => call_registered_decode_error_handler(
+            err_mode, codec, data, start, end, reason, out,
+        ),
     }
 }
 

--- a/pyre/pyre-interpreter/src/type_methods.rs
+++ b/pyre/pyre-interpreter/src/type_methods.rs
@@ -2466,13 +2466,16 @@ pub fn decode_raw_unicode_escape(data: &[u8], errors: &str) -> Result<Wtf8Buf, c
                     }
                 }
                 _ => {
-                    return Err(crate::typedef::unicode_decode_error(
+                    i = call_registered_decode_error_handler(
+                        errors,
                         "rawunicodeescape",
                         data,
                         escape_start,
                         error_end,
                         reason,
-                    ));
+                        &mut out,
+                    )?;
+                    continue;
                 }
             }
             i = error_end;

--- a/pyre/pyre-interpreter/src/type_methods.rs
+++ b/pyre/pyre-interpreter/src/type_methods.rs
@@ -2449,11 +2449,7 @@ pub fn decode_raw_unicode_escape(data: &[u8], errors: &str) -> Result<Wtf8Buf, c
                 i = available_end;
                 continue;
             }
-            let error_end = if available_end < digits_start + want {
-                hex_end
-            } else {
-                available_end
-            };
+            let error_end = if numeric.is_some() { available_end } else { hex_end };
             let reason = if numeric.is_some() {
                 "illegal Unicode character"
             } else if want == 4 {
@@ -2482,9 +2478,14 @@ pub fn decode_raw_unicode_escape(data: &[u8], errors: &str) -> Result<Wtf8Buf, c
             i = error_end;
             continue;
         }
-        // Not a valid escape — emit the backslash literally as Latin-1.
+        // Not a valid escape — emit both bytes literally as Latin-1.
         out.push_char(b as char);
-        i += 1;
+        if let Some(next) = kind {
+            out.push_char(next as char);
+            i += 2;
+        } else {
+            i += 1;
+        }
     }
     Ok(out)
 }

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -12372,7 +12372,9 @@ pub(crate) fn decode_bytes_to_wtf8(
         "utf-8" | "utf8" | "u8" => decode_utf8_with_errors(data, err_mode)?,
         "ascii" | "us-ascii" | "646" => {
             let mut out = Wtf8Buf::new();
-            for (i, &b) in data.iter().enumerate() {
+            let mut i = 0;
+            while i < data.len() {
+                let b = data[i];
                 if b >= 0x80 {
                     match err_mode {
                         "strict" => {
@@ -12384,15 +12386,20 @@ pub(crate) fn decode_bytes_to_wtf8(
                                 "ordinal not in range(128)",
                             ));
                         }
-                        "ignore" => continue,
+                        "ignore" => {
+                            i += 1;
+                            continue;
+                        }
                         "replace" => {
                             out.push_char('\u{FFFD}');
+                            i += 1;
                             continue;
                         }
                         // surrogateescape escapes the non-ASCII byte as a lone
                         // surrogate 0xdc00+b (interp_codecs.py:536-555).
                         "surrogateescape" => {
                             out.push(CodePoint::from_u32(0xDC00 + b as u32).unwrap());
+                            i += 1;
                             continue;
                         }
                         // surrogatepass only decodes three-byte UTF-8 surrogate
@@ -12409,20 +12416,28 @@ pub(crate) fn decode_bytes_to_wtf8(
                         }
                         "backslashreplace" => {
                             out.push_str(&format!("\\x{:02x}", b));
+                            i += 1;
                             continue;
                         }
                         "xmlcharrefreplace" | "namereplace" => {
                             return Err(decode_error_encode_only_handler());
                         }
                         _ => {
-                            return Err(crate::PyError::new(
-                                crate::PyErrorKind::LookupError,
-                                format!("unknown error handler name '{err_mode}'"),
-                            ));
+                            i = crate::type_methods::call_registered_decode_error_handler(
+                                err_mode,
+                                "ascii",
+                                data,
+                                i,
+                                i + 1,
+                                "ordinal not in range(128)",
+                                &mut out,
+                            )?;
+                            continue;
                         }
                     }
                 }
                 out.push_char(b as char);
+                i += 1;
             }
             out
         }

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -1535,12 +1535,25 @@ fn str_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
         args[0]
     };
     let value = crate::builtins::builtin_str(&args[1..])?;
-    if cls.is_null() || !unsafe { pyre_object::is_type(cls) } {
+    if cls.is_null() {
         return Ok(value);
     }
     let str_typeobj = gettypefor(&pyre_object::STR_TYPE);
     if str_typeobj.map_or(false, |t| std::ptr::eq(cls, t)) {
         return Ok(value);
+    }
+    if !unsafe { pyre_object::is_type(cls) } {
+        return Err(crate::PyError::type_error(
+            "str.__new__(X): X is not a subtype of str",
+        ));
+    }
+    if let Some(w_str) = str_typeobj {
+        if !unsafe { crate::baseobjspace::issubtype_w(cls, w_str) } {
+            let cls_name = unsafe { pyre_object::w_type_get_name(cls) };
+            return Err(crate::PyError::type_error(format!(
+                "str.__new__({cls_name}): {cls_name} is not a subtype of str"
+            )));
+        }
     }
     let contents = unsafe { pyre_object::w_str_get_wtf8(value) }.to_wtf8_buf();
     Ok(pyre_object::w_str_subclass_from_wtf8(contents, cls))

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -1542,13 +1542,8 @@ fn str_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     if str_typeobj.map_or(false, |t| std::ptr::eq(cls, t)) {
         return Ok(value);
     }
-    let s_owned = unsafe { pyre_object::w_str_get_value(value) }.to_string();
-    let obj = pyre_object::w_str_new(&s_owned);
-    // Tag with subclass type so type(obj) returns cls.
-    unsafe {
-        (*(obj as *mut pyre_object::PyObject)).w_class = cls;
-    }
-    Ok(obj)
+    let contents = unsafe { pyre_object::w_str_get_wtf8(value) }.to_wtf8_buf();
+    Ok(pyre_object::w_str_subclass_from_wtf8(contents, cls))
 }
 
 /// dict.__new__(cls, *args) — if cls is a dict subclass, create an instance
@@ -2400,6 +2395,73 @@ fn list_descr_mul(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
 
 fn init_str_type(ns: &mut DictStorage) {
     dict_storage_store(ns, "__new__", make_new_descr(str_descr_new));
+    // unicodeobject.py:330-338 descr_repr / descr_str.  descr_str returns an
+    // exact base str for a subtype, which is required by enum.StrEnum's
+    // inherited `str.__str__`.
+    dict_storage_store(
+        ns,
+        "__repr__",
+        make_builtin_function_with_arity(
+            "__repr__",
+            |args| {
+                Ok(pyre_object::w_str_new(&crate::display::format_wtf8_repr(
+                    unsafe { pyre_object::w_str_get_wtf8(args[0]) },
+                )))
+            },
+            1,
+        ),
+    );
+    dict_storage_store(
+        ns,
+        "__str__",
+        make_builtin_function_with_arity(
+            "__str__",
+            |args| {
+                let obj = args[0];
+                if unsafe { pyre_object::pyobject::is_exact_type(obj, &pyre_object::STR_TYPE) } {
+                    Ok(obj)
+                } else {
+                    Ok(pyre_object::w_str_from_wtf8(
+                        unsafe { pyre_object::w_str_get_wtf8(obj) }.to_wtf8_buf(),
+                    ))
+                }
+            },
+            1,
+        ),
+    );
+    dict_storage_store(
+        ns,
+        "__sizeof__",
+        make_builtin_function_with_arity(
+            "__sizeof__",
+            |args| {
+                let s = unsafe { pyre_object::w_str_get_wtf8(args[0]) };
+                let mut maxchar = 0u32;
+                let mut length = 0usize;
+                for cp in s.code_points() {
+                    maxchar = maxchar.max(cp.to_u32());
+                    length += 1;
+                }
+                // CPython's compact PEP 393 layout, exposed for compatibility
+                // with test_str.test_raiseMemError.  PyPy documents
+                // `__sizeof__` on str but sys.getsizeof itself remains a
+                // default-returning operation for other objects.
+                let word = std::mem::size_of::<usize>();
+                let struct_size = if maxchar < 0x80 { 5 * word } else { 7 * word };
+                let char_size = if maxchar < 0x100 {
+                    1
+                } else if maxchar < 0x10000 {
+                    2
+                } else {
+                    4
+                };
+                Ok(pyre_object::w_int_new(
+                    (struct_size + char_size * (length + 1)) as i64,
+                ))
+            },
+            1,
+        ),
+    );
     dict_storage_store(
         ns,
         "__format__",
@@ -8243,6 +8305,24 @@ type DunderFn = fn(&[PyObjectRef]) -> Result<PyObjectRef, crate::PyError>;
 
 fn init_int_type(ns: &mut DictStorage) {
     dict_storage_store(ns, "__new__", make_new_descr(int_descr_new));
+    // intobject.py descr_repr / descr_str.  IntEnum binds its __str__ to this
+    // descriptor, so it must exist in int's TypeDef rather than falling back
+    // to object.__str__.
+    let int_to_text = |args: &[PyObjectRef]| {
+        Ok(pyre_object::w_str_new(
+            &unsafe { crate::builtins::obj_to_bigint(args[0]) }.to_string(),
+        ))
+    };
+    dict_storage_store(
+        ns,
+        "__repr__",
+        make_builtin_function_with_arity("__repr__", int_to_text, 1),
+    );
+    dict_storage_store(
+        ns,
+        "__str__",
+        make_builtin_function_with_arity("__str__", int_to_text, 1),
+    );
     dict_storage_store(
         ns,
         "bit_length",
@@ -12252,6 +12332,30 @@ pub(crate) fn decode_bytes_to_wtf8(
 ) -> Result<Wtf8Buf, crate::PyError> {
     let err_mode = errors;
     let enc_lower = encoding.to_ascii_lowercase().replace('_', "-");
+    if crate::importing::dev_mode_flag()
+        && matches!(
+            enc_lower.as_str(),
+            "utf-8"
+                | "utf8"
+                | "u8"
+                | "ascii"
+                | "us-ascii"
+                | "646"
+                | "latin-1"
+                | "latin1"
+                | "iso-8859-1"
+                | "8859"
+                | "raw-unicode-escape"
+                | "utf-16"
+                | "utf-16-le"
+                | "utf-16-be"
+                | "utf-32"
+                | "utf-32-le"
+                | "utf-32-be"
+        )
+    {
+        crate::module::_codecs::validate_error_handler(errors)?;
+    }
     let s = match enc_lower.as_str() {
         "utf-8" | "utf8" | "u8" => decode_utf8_with_errors(data, err_mode)?,
         "ascii" | "us-ascii" | "646" => {
@@ -12313,7 +12417,7 @@ pub(crate) fn decode_bytes_to_wtf8(
         "latin-1" | "latin1" | "iso-8859-1" | "8859" => {
             Wtf8Buf::from_string(data.iter().map(|&b| b as char).collect::<String>())
         }
-        "raw-unicode-escape" => crate::type_methods::decode_raw_unicode_escape(data)?,
+        "raw-unicode-escape" => crate::type_methods::decode_raw_unicode_escape(data, err_mode)?,
         _ => {
             if let Some(result) = crate::type_methods::decode_utf16_32(data, &enc_lower, err_mode) {
                 result?

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -12013,10 +12013,9 @@ fn utf8_error_handler(
             Ok(end)
         }
         "xmlcharrefreplace" | "namereplace" => Err(decode_error_encode_only_handler()),
-        _ => Err(crate::PyError::new(
-            crate::PyErrorKind::LookupError,
-            format!("unknown error handler name '{err_mode}'"),
-        )),
+        _ => crate::type_methods::call_registered_decode_error_handler(
+            err_mode, "utf-8", data, start, end, reason, out,
+        ),
     }
 }
 

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -116,6 +116,20 @@ fn pyre_object_gc_collect_oldgen_trampoline() {
     majit_gc::collect_oldgen_nonmoving();
 }
 
+fn pyre_object_gc_register_finalizer_trampoline(
+    fq_index: usize,
+    obj: pyre_object::PyObjectRef,
+    trigger: pyre_object::gc_hook::GcFinalizerTriggerFn,
+) {
+    majit_gc::gc_register_finalizer(fq_index, majit_ir::GcRef(obj as usize), trigger);
+}
+
+fn pyre_object_gc_finalizer_next_dead_trampoline(fq_index: usize) -> pyre_object::PyObjectRef {
+    majit_gc::gc_fq_next_dead(fq_index)
+        .map(|obj| obj.0 as pyre_object::PyObjectRef)
+        .unwrap_or(pyre_object::PY_NULL)
+}
+
 /// Heap-stats trampoline for the interpreter GC safepoint
 /// (`pyre_object::gc_interp`). Bridges pyre-object's heap-stats hook to
 /// `majit_gc::active_heap_stats`, so the safepoint can gate its
@@ -1507,14 +1521,17 @@ fn build_gc() -> Box<dyn majit_gc::GcAllocator> {
         w_type_tid,
     );
     pytype_to_tid.insert(&pyre_object::TYPE_TYPE as *const _ as usize, w_type_tid);
-    // W_UnicodeObject carries a `*mut String` (raw heap) plus a
-    // `usize` length. No direct `PyObjectRef` field. Pre-registered
-    // so the foreign-pytype loop's `sizeof(PyObject)` approximation
-    // does not under-count the payload.
-    let w_str_tid = gc.register_type(TypeInfo::object_subclass(
-        std::mem::size_of::<pyre_object::unicodeobject::W_UnicodeObject>(),
-        object_tid,
-    ));
+    // W_UnicodeObject carries an off-heap WTF-8 buffer. Managed subclass
+    // instances additionally need the header's `w_class` traced, matching
+    // W_ObjectObject's instance-class edge; exact strings remain immortal.
+    let w_str_tid = gc.register_type(
+        TypeInfo::object_subclass_with_gc_ptrs(
+            std::mem::size_of::<pyre_object::unicodeobject::W_UnicodeObject>(),
+            object_tid,
+            vec![pyre_object::pyobject::W_CLASS_OFFSET],
+        )
+        .with_destructor_fn(pyre_object::unicodeobject::unicode_object_destructor),
+    );
     debug_assert_eq!(w_str_tid, W_UNICODE_GC_TYPE_ID);
     majit_gc::GcAllocator::register_vtable_for_type(
         &mut gc,
@@ -2408,6 +2425,10 @@ fn install_pyre_object_hooks() {
     );
     pyre_object::register_gc_collect_hook(pyre_object_gc_collect_trampoline);
     pyre_object::gc_hook::register_gc_collect_oldgen_hook(pyre_object_gc_collect_oldgen_trampoline);
+    pyre_object::gc_hook::register_gc_finalizer_hooks(
+        pyre_object_gc_register_finalizer_trampoline,
+        pyre_object_gc_finalizer_next_dead_trampoline,
+    );
     pyre_object::gc_hook::register_gc_heap_stats_hook(pyre_object_gc_heap_stats_trampoline);
     pyre_object::gc_hook::register_gc_jitframe_empty_hook(pyre_object_gc_jitframe_empty_trampoline);
     pyre_object::register_gc_root_hooks(

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -116,6 +116,10 @@ fn pyre_object_gc_collect_oldgen_trampoline() {
     majit_gc::collect_oldgen_nonmoving();
 }
 
+fn pyre_object_gc_set_enabled_trampoline(enabled: bool) {
+    majit_gc::gc_set_enabled(enabled);
+}
+
 fn pyre_object_gc_register_finalizer_trampoline(
     fq_index: usize,
     obj: pyre_object::PyObjectRef,
@@ -2425,6 +2429,7 @@ fn install_pyre_object_hooks() {
     );
     pyre_object::register_gc_collect_hook(pyre_object_gc_collect_trampoline);
     pyre_object::gc_hook::register_gc_collect_oldgen_hook(pyre_object_gc_collect_oldgen_trampoline);
+    pyre_object::gc_hook::register_gc_set_enabled_hook(pyre_object_gc_set_enabled_trampoline);
     pyre_object::gc_hook::register_gc_finalizer_hooks(
         pyre_object_gc_register_finalizer_trampoline,
         pyre_object_gc_finalizer_next_dead_trampoline,

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -2459,6 +2459,17 @@ fn build_gc_global() {
     majit_gc::gc_sync::store_singleton(gc);
 }
 
+/// Test-support: give the calling `gc_stress` worker a pristine GC heap by
+/// installing a fresh GC and leaking the shared singleton. The per-test worker
+/// threads share the process-global GC singleton; without this, a
+/// class-defining test leaves oldgen residue or stale roots that a later
+/// test's collection, run on a different worker thread with a different
+/// thread-local root set, can mishandle and corrupt immortal state.
+pub fn reset_gc_fresh_for_test() {
+    let gc = build_gc();
+    majit_gc::gc_sync::replace_singleton_leaking_old(gc);
+}
+
 /// Initialize the GC subsystem independently of the JIT driver.
 ///
 /// Phase 1 (process-global, once): build MiniMarkGC, type registry,

--- a/pyre/pyre-jit/tests/gc_stress.rs
+++ b/pyre/pyre-jit/tests/gc_stress.rs
@@ -6,26 +6,23 @@
 //! stack in CI.
 //!
 //! Every `#[test]` runs one end-to-end Python program through the shared
-//! `run_harness`, on its own freshly spawned 256 MiB worker thread. All mutable
-//! JIT / GC / interpreter state is thread-local, so each test gets a clean
-//! per-thread world — that isolation is what keeps the six programs independent
-//! inside this one shared process. The programs are therefore NOT run on the
-//! same thread and are NOT flattened into a single test.
+//! `run_harness`, on its own freshly spawned 256 MiB worker thread. The
+//! per-worker thread keeps stack-heavy interpreter / tracer recursion off the
+//! default test stack. These tests also share process-global GC and builtin
+//! type state, so `run_on_worker` serializes them and `run_harness` installs a
+//! fresh GC heap for each worker.
 //!
 //! The harness mirrors the `pyrex` launcher (`pyrex/src/lib.rs` `real_main` +
-//! `run_source`) exactly: it does NOT build the GC up front. Each program's
-//! module body and functions use `while` loops (no `FOR_ITER`), so eval reaches
-//! a JIT-eligible frame and builds the GC lazily — matching production, where
-//! builtins already exist as immortal objects before the GC comes up.
-//! `gc.collect()` then forces deterministic collections through the collect
-//! hook (`interp_gc.py:7-26 collect`).
+//! `run_source`) startup shape, then swaps in a per-worker fresh GC before the
+//! program allocates. Each program's module body and functions use `while`
+//! loops (no `FOR_ITER`), so eval reaches a JIT-eligible frame. `gc.collect()`
+//! then forces deterministic collections through the collect hook
+//! (`interp_gc.py:7-26 collect`).
 //!
 //! Non-vacuity is asserted AFTER eval: the stable instance allocator hook
-//! (installed by the `JIT_DRIVER` initializer, `driver_pair` -> `set_gc_allocator`)
-//! must be live, proving the GC was actually built during the run and objects
-//! were routed through the real managed heap rather than the leaking
-//! `lltype::malloc` Box fallback (which would make the survival checks
-//! meaningless).
+//! must be live, proving the program's objects routed through the real managed
+//! heap rather than the leaking `lltype::malloc` Box fallback (which would make
+//! the survival checks meaningless).
 
 use std::rc::Rc;
 
@@ -33,19 +30,24 @@ use pyre_interpreter::call::{register_build_class, set_build_class_exec_ctx, set
 use pyre_interpreter::importing;
 use pyre_interpreter::pyframe::PyFrame;
 use pyre_interpreter::{Mode, PyExecutionContext, compile_source_with_filename};
-use pyre_jit::eval::{eval_with_jit, init_jit_hooks};
+use pyre_jit::eval::{eval_with_jit, init_jit_hooks, reset_gc_fresh_for_test};
+
+static GC_STRESS_SERIAL: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
 /// Shared harness body for every GC-stress program. Compiles and runs `program`
 /// (using `name` as its `sys.argv[0]` / filename) exactly as the `pyrex`
-/// launcher would, letting the GC build lazily during eval. An uncaught
-/// `assert` in the program surfaces here as `Err`, so a successful return means
-/// every read-back assertion held. `vacuity_label` names the survival checks
-/// for the post-eval non-vacuity error.
+/// launcher would, after installing a fresh per-worker GC heap. An uncaught
+/// `assert` in the program surfaces here as `Err`, so a successful return
+/// means every read-back assertion held. `vacuity_label` names the survival
+/// checks for the post-eval non-vacuity error.
 fn run_harness(program: &str, name: &str, vacuity_label: &str) -> Result<(), String> {
     // Mirror `pyrex::real_main` startup, then `pyrex::run_source`.
     pyre_interpreter::stack_check::set_recursion_limit(5000)
         .map_err(|_| "set_recursion_limit failed".to_string())?;
     init_jit_hooks();
+    // Per-worker fresh GC heap: these tests share the process-global GC
+    // singleton, so hide any prior test's residue before this one allocates.
+    reset_gc_fresh_for_test();
 
     let cwd = std::env::current_dir().map_err(|e| e.to_string())?;
     importing::init_sys_path(&cwd);
@@ -75,21 +77,18 @@ fn run_harness(program: &str, name: &str, vacuity_label: &str) -> Result<(), Str
     importing::set_sys_module("__main__", main_module);
 
     // An uncaught `assert` in the program surfaces here as `Err`, so a
-    // successful return means every read-back assertion held. The GC is
-    // built lazily inside this call (the module frame and its functions are
-    // `FOR_ITER`-free), exactly as in the launcher.
+    // successful return means every read-back assertion held.
     eval_with_jit(&mut frame).map_err(|e| format!("execution error: {}", e.message))?;
 
     // Non-vacuity: the stable instance allocator hook is installed by the
     // `JIT_DRIVER` initializer (`driver_pair` -> `set_gc_allocator`). If it is
-    // live now, the GC was built during eval, so the objects above routed
-    // through it rather than the leaking Box fallback — the survival checks
-    // were meaningful.
+    // live now, allocations routed through the managed heap rather than the
+    // leaking Box fallback, so the survival checks were meaningful.
     let probe = pyre_object::try_gc_alloc_stable(
         pyre_object::W_OBJECT_OBJECT_GC_TYPE_ID,
         pyre_object::W_OBJECT_OBJECT_SIZE,
     )
-    .ok_or_else(|| format!("GC was not built during eval; {vacuity_label} would be vacuous"))?;
+    .ok_or_else(|| format!("stable GC alloc hook was not live; {vacuity_label} would be vacuous"))?;
     if probe.is_null() {
         return Err("stable GC alloc hook returned null for an instance-sized block".to_string());
     }
@@ -103,16 +102,23 @@ fn run_harness(program: &str, name: &str, vacuity_label: &str) -> Result<(), Str
 
 /// Run `run_harness` on its own freshly spawned 256 MiB worker thread and
 /// unwrap the result. Mirrors the launcher's worker stack so deep tracer /
-/// interpreter recursion does not overflow the default test stack. GC / JIT
-/// hooks are thread-local, so each test's whole harness runs on this fresh
-/// thread — that per-thread spawn is what isolates the tests inside one shared
-/// process.
+/// interpreter recursion does not overflow the default test stack. The tests
+/// mutate process-global GC and builtin type state, so each worker run is
+/// serialized even when cargo schedules tests in parallel.
 fn run_on_worker(
     program: &'static str,
     name: &'static str,
     vacuity_label: &'static str,
     fail_msg: &'static str,
 ) {
+    // These tests share the process-global GC singleton and process-global
+    // builtin type state (`object.weak_subclasses`, version tags), which are
+    // not thread-safe, so run them one at a time regardless of cargo's
+    // parallel test scheduling. Poison-tolerant: one worker panicking must not
+    // wedge the rest.
+    let _serial = GC_STRESS_SERIAL
+        .lock()
+        .unwrap_or_else(|e| e.into_inner());
     let handle = std::thread::Builder::new()
         .stack_size(256 * 1024 * 1024)
         .spawn(move || run_harness(program, name, vacuity_label))

--- a/pyre/pyre-jit/tests/gc_stress.rs
+++ b/pyre/pyre-jit/tests/gc_stress.rs
@@ -88,7 +88,9 @@ fn run_harness(program: &str, name: &str, vacuity_label: &str) -> Result<(), Str
         pyre_object::W_OBJECT_OBJECT_GC_TYPE_ID,
         pyre_object::W_OBJECT_OBJECT_SIZE,
     )
-    .ok_or_else(|| format!("stable GC alloc hook was not live; {vacuity_label} would be vacuous"))?;
+    .ok_or_else(|| {
+        format!("stable GC alloc hook was not live; {vacuity_label} would be vacuous")
+    })?;
     if probe.is_null() {
         return Err("stable GC alloc hook returned null for an instance-sized block".to_string());
     }
@@ -116,9 +118,7 @@ fn run_on_worker(
     // not thread-safe, so run them one at a time regardless of cargo's
     // parallel test scheduling. Poison-tolerant: one worker panicking must not
     // wedge the rest.
-    let _serial = GC_STRESS_SERIAL
-        .lock()
-        .unwrap_or_else(|e| e.into_inner());
+    let _serial = GC_STRESS_SERIAL.lock().unwrap_or_else(|e| e.into_inner());
     let handle = std::thread::Builder::new()
         .stack_size(256 * 1024 * 1024)
         .spawn(move || run_harness(program, name, vacuity_label))

--- a/pyre/pyre-object/src/gc_hook.rs
+++ b/pyre/pyre-object/src/gc_hook.rs
@@ -18,6 +18,8 @@
 
 use std::cell::Cell;
 
+use crate::PyObjectRef;
+
 /// Signature of the host-side GC allocation callback.
 ///
 /// `type_id` is the backend-registered GC type id (same id used by
@@ -249,6 +251,64 @@ pub fn try_gc_collect_oldgen() {
     GC_COLLECT_OLDGEN_HOOK.with(|cell| {
         if let Some(f) = cell.get() {
             f();
+        }
+    });
+}
+
+/// RPython `gc_fq_register` / `gc_fq_next_dead` hooks.  The trigger is the
+/// translated FinalizerQueue handler and only schedules interpreter work.
+pub type GcFinalizerTriggerFn = fn();
+pub type GcRegisterFinalizerHookFn = fn(usize, PyObjectRef, GcFinalizerTriggerFn);
+pub type GcFinalizerNextDeadHookFn = fn(usize) -> PyObjectRef;
+
+thread_local! {
+    static GC_REGISTER_FINALIZER_HOOK: Cell<Option<GcRegisterFinalizerHookFn>> =
+        const { Cell::new(None) };
+    static GC_FINALIZER_NEXT_DEAD_HOOK: Cell<Option<GcFinalizerNextDeadHookFn>> =
+        const { Cell::new(None) };
+}
+
+pub fn register_gc_finalizer_hooks(
+    register: GcRegisterFinalizerHookFn,
+    next_dead: GcFinalizerNextDeadHookFn,
+) {
+    GC_REGISTER_FINALIZER_HOOK.with(|cell| cell.set(Some(register)));
+    GC_FINALIZER_NEXT_DEAD_HOOK.with(|cell| cell.set(Some(next_dead)));
+}
+
+pub fn try_gc_register_finalizer(fq_index: usize, obj: PyObjectRef, trigger: GcFinalizerTriggerFn) {
+    GC_REGISTER_FINALIZER_HOOK.with(|cell| {
+        if let Some(register) = cell.get() {
+            register(fq_index, obj, trigger);
+        }
+    });
+}
+
+pub fn try_gc_finalizer_next_dead(fq_index: usize) -> PyObjectRef {
+    GC_FINALIZER_NEXT_DEAD_HOOK.with(|cell| {
+        cell.get()
+            .map(|next_dead| next_dead(fq_index))
+            .unwrap_or(crate::PY_NULL)
+    })
+}
+
+/// `ObjSpace.allocate_instance`-level hook.  pyre-object owns allocation but
+/// pyre-interpreter owns MRO lookup and can therefore decide `hasuserdel`.
+pub type MaybeRegisterFinalizerHookFn = fn(PyObjectRef);
+
+thread_local! {
+    static MAYBE_REGISTER_FINALIZER_HOOK: Cell<Option<MaybeRegisterFinalizerHookFn>> =
+        const { Cell::new(None) };
+}
+
+pub fn register_maybe_finalizer_hook(hook: MaybeRegisterFinalizerHookFn) {
+    MAYBE_REGISTER_FINALIZER_HOOK.with(|cell| cell.set(Some(hook)));
+}
+
+pub fn maybe_register_finalizer(obj: PyObjectRef) {
+    MAYBE_REGISTER_FINALIZER_HOOK.with(|cell| {
+        if let Some(hook) = cell.get() {
+            hook(obj);
         }
     });
 }

--- a/pyre/pyre-object/src/gc_hook.rs
+++ b/pyre/pyre-object/src/gc_hook.rs
@@ -255,6 +255,34 @@ pub fn try_gc_collect_oldgen() {
     });
 }
 
+/// Signature of the host-side automatic major-progress toggle callback.
+pub type GcSetEnabledHookFn = fn(bool);
+
+thread_local! {
+    static GC_SET_ENABLED_HOOK: Cell<Option<GcSetEnabledHookFn>> = const { Cell::new(None) };
+}
+
+/// Install the automatic major-progress toggle callback for this thread.
+pub fn register_gc_set_enabled_hook(hook: GcSetEnabledHookFn) {
+    GC_SET_ENABLED_HOOK.with(|cell| cell.set(Some(hook)));
+}
+
+/// Remove the automatic major-progress toggle callback on this thread.
+pub fn clear_gc_set_enabled_hook() {
+    GC_SET_ENABLED_HOOK.with(|cell| cell.set(None));
+}
+
+/// Toggle automatic major-collection progress via the installed hook. No-op
+/// when no hook is installed on this thread.
+#[inline]
+pub fn try_gc_set_enabled(enabled: bool) {
+    GC_SET_ENABLED_HOOK.with(|cell| {
+        if let Some(f) = cell.get() {
+            f(enabled);
+        }
+    });
+}
+
 /// RPython `gc_fq_register` / `gc_fq_next_dead` hooks.  The trigger is the
 /// translated FinalizerQueue handler and only schedules interpreter work.
 pub type GcFinalizerTriggerFn = fn();

--- a/pyre/pyre-object/src/objectobject.rs
+++ b/pyre/pyre-object/src/objectobject.rs
@@ -79,7 +79,7 @@ pub fn w_instance_new(w_type: PyObjectRef) -> PyObjectRef {
     let _roots = crate::gc_roots::push_roots();
     crate::gc_roots::pin_root(w_type);
 
-    alloc_instance_object(W_ObjectObject {
+    let obj = alloc_instance_object(W_ObjectObject {
         ob_header: PyObject {
             ob_type: &INSTANCE_TYPE as *const PyType,
             w_class: w_type,
@@ -90,7 +90,11 @@ pub fn w_instance_new(w_type: PyObjectRef) -> PyObjectRef {
         // map is the not-yet-initialized empty state.
         map: std::ptr::null(),
         storage: std::ptr::null_mut(),
-    })
+    });
+    // objspace.py `allocate_instance`: types with `hasuserdel` register the
+    // fresh instance on `space.finalizer_queue` immediately after allocation.
+    crate::gc_hook::maybe_register_finalizer(obj);
+    obj
 }
 
 /// Allocate a `W_ObjectObject` through the GC. The header is stamped

--- a/pyre/pyre-object/src/typeobject.rs
+++ b/pyre/pyre-object/src/typeobject.rs
@@ -115,6 +115,10 @@ pub struct W_TypeObject {
     pub hasdict: bool,
     /// typeobject.py:181 `weakrefable` — True when instances support weakrefs.
     pub weakrefable: bool,
+    /// typeobject.py:210 `hasuserdel` — True when instances have a user
+    /// `__del__` (computed at type creation, typeobject.py:1406/1475, and
+    /// kept fresh by `mutated`).
+    pub hasuserdel: bool,
     /// typeobject.py:169 `flag_map_or_seq` (`'?'`, `'M'`, `'S'`).
     ///
     /// Default `'?'` per typeobject.py:216.  Inherited from base
@@ -288,6 +292,7 @@ pub fn w_type_new(name: &str, bases: PyObjectRef, dict_ptr: *mut u8) -> PyObject
         layout: std::ptr::null(),
         hasdict: false,
         weakrefable: false,
+        hasuserdel: false,
         flag_map_or_seq: std::sync::atomic::AtomicU8::new(b'?'),
         compares_by_identity_status: std::sync::atomic::AtomicU8::new(COMPARES_BY_IDENTITY_UNKNOWN),
         weak_subclasses: std::ptr::null_mut(),
@@ -376,6 +381,7 @@ pub fn w_type_new_builtin(
         layout: std::ptr::null(),
         hasdict: false,
         weakrefable: false,
+        hasuserdel: false,
         // typeobject.py:216 default; built-in dict/list/tuple
         // override via `w_type_set_flag_map_or_seq` at typedef
         // registration time (see `typedef.rs`).
@@ -656,6 +662,14 @@ pub unsafe fn w_type_get_weakrefable(obj: PyObjectRef) -> bool {
 }
 pub unsafe fn w_type_set_weakrefable(obj: PyObjectRef, v: bool) {
     (*(obj as *mut W_TypeObject)).weakrefable = v;
+}
+
+/// typeobject.py:210 `hasuserdel` getter/setter.
+pub unsafe fn w_type_get_hasuserdel(obj: PyObjectRef) -> bool {
+    (*(obj as *const W_TypeObject)).hasuserdel
+}
+pub unsafe fn w_type_set_hasuserdel(obj: PyObjectRef, v: bool) {
+    (*(obj as *mut W_TypeObject)).hasuserdel = v;
 }
 
 // ── Other accessors ──────────────────────────────────────────────────

--- a/pyre/pyre-object/src/unicodeobject.rs
+++ b/pyre/pyre-object/src/unicodeobject.rs
@@ -103,6 +103,46 @@ pub fn w_str_from_wtf8(value: Wtf8Buf) -> PyObjectRef {
     }) as PyObjectRef
 }
 
+/// Allocate a `str` subclass instance through the stable GC allocator.
+/// PyPy's `W_UnicodeObject` subclass is an ordinary GC object; exact strings
+/// remain on pyre's existing immortal/interned path, while subclass identity
+/// and app-level finalization require collector ownership.
+pub fn w_str_subclass_from_wtf8(value: Wtf8Buf, w_class: PyObjectRef) -> PyObjectRef {
+    let byte_len = value.len();
+    let char_len = value.code_points().count();
+    let value = crate::lltype::malloc_raw(value);
+    let unicode = W_UnicodeObject {
+        ob_header: PyObject {
+            ob_type: &STR_TYPE as *const PyType,
+            w_class,
+        },
+        value,
+        byte_len,
+        len: char_len,
+    };
+    let raw = crate::gc_hook::try_gc_alloc_stable_raw(W_UNICODE_GC_TYPE_ID, W_UNICODE_OBJECT_SIZE);
+    let obj = if raw.is_null() {
+        crate::lltype::malloc_typed(unicode) as PyObjectRef
+    } else {
+        unsafe {
+            std::ptr::write(raw as *mut W_UnicodeObject, unicode);
+            raw as PyObjectRef
+        }
+    };
+    crate::gc_hook::maybe_register_finalizer(obj);
+    obj
+}
+
+/// Lightweight GC destructor for the off-heap WTF-8 buffer owned by a
+/// managed `W_UnicodeObject`.
+pub unsafe fn unicode_object_destructor(obj_addr: usize) {
+    let obj = unsafe { &mut *(obj_addr as *mut W_UnicodeObject) };
+    if !obj.value.is_null() {
+        unsafe { drop(Box::from_raw(obj.value)) };
+        obj.value = std::ptr::null_mut();
+    }
+}
+
 thread_local! {
     /// String constant interning cache — single-threaded, no lock needed.
     /// RPython has no equivalent lock; string interning is handled by the

--- a/pyre/pyrex/src/lib.rs
+++ b/pyre/pyrex/src/lib.rs
@@ -36,6 +36,35 @@ enum RunMode {
     },
 }
 
+#[derive(Clone, Copy)]
+struct LaunchFlags {
+    inspect: bool,
+    quiet: bool,
+    no_site: bool,
+    no_user_site: bool,
+    ignore_environment: bool,
+    isolated: bool,
+    dev_mode: bool,
+    utf8_mode: i64,
+    safe_path: bool,
+}
+
+impl Default for LaunchFlags {
+    fn default() -> Self {
+        Self {
+            inspect: false,
+            quiet: false,
+            no_site: false,
+            no_user_site: false,
+            ignore_environment: false,
+            isolated: false,
+            dev_mode: false,
+            utf8_mode: 1,
+            safe_path: false,
+        }
+    }
+}
+
 fn usage(binary_name: &str) -> String {
     format!(
         "\
@@ -45,10 +74,13 @@ Options:
 -m mod : run library module as a script (terminates option list)
 -h     : print this help message and exit (also --help)
 -i     : inspect interactively after running script
+-E     : ignore PYTHON* environment variables
+-I     : isolate Python from the user's environment
 -O     : optimize (no-op, reserved for compatibility)
 -q     : don't print version on interactive startup
 -S     : don't imply 'import site' on initialization
 -V     : print the Python version number and exit (also --version)
+-X opt : set implementation-specific option
 file   : program read from script file
 -      : program read from stdin (default; interactive mode if a tty)
 arg ...: arguments passed to program in sys.argv[1:]
@@ -71,34 +103,48 @@ fn drain_args(parser: &mut lexopt::Parser) -> Result<Vec<String>, lexopt::Error>
     Ok(rest)
 }
 
-fn parse_args(
-    binary_name: &str,
-) -> Result<(RunMode, bool, bool, bool, Vec<String>), lexopt::Error> {
+fn parse_args(binary_name: &str) -> Result<(RunMode, LaunchFlags, Vec<String>), lexopt::Error> {
     let mut parser = lexopt::Parser::from_env();
-    let mut inspect = false;
-    let mut quiet = false;
-    let mut no_site = false;
+    let mut flags = LaunchFlags::default();
 
     while let Some(arg) = parser.next()? {
         match arg {
             Short('c') => {
                 let cmd = parser.value()?.string()?;
                 let rest = drain_args(&mut parser)?;
-                return Ok((RunMode::Command(cmd), inspect, quiet, no_site, rest));
+                return Ok((RunMode::Command(cmd), flags, rest));
             }
             Short('m') => {
                 let module = parser.value()?.string()?;
                 let rest = drain_args(&mut parser)?;
-                return Ok((RunMode::Module(module), inspect, quiet, no_site, rest));
+                return Ok((RunMode::Module(module), flags, rest));
             }
             Short('h') | Long("help") => {
                 print!("{}", usage(binary_name));
                 std::process::exit(0);
             }
-            Short('i') => inspect = true,
+            Short('i') => flags.inspect = true,
+            // app_main.py `cmdline_options['E']` / `X_option`.
+            Short('E') => flags.ignore_environment = true,
+            // app_main.py `isolated_option`: -I implies -E, -s and -P.
+            Short('I') => {
+                flags.isolated = true;
+                flags.ignore_environment = true;
+                flags.no_user_site = true;
+                flags.safe_path = true;
+            }
+            Short('X') => {
+                let option = parser.value()?.string()?;
+                match option.as_str() {
+                    "dev" => flags.dev_mode = true,
+                    "utf8" | "utf8=1" => flags.utf8_mode = 1,
+                    "utf8=0" => flags.utf8_mode = 0,
+                    _ => {}
+                }
+            }
             Short('O') => {} // no-op
-            Short('q') => quiet = true,
-            Short('S') => no_site = true,
+            Short('q') => flags.quiet = true,
+            Short('S') => flags.no_site = true,
             Short('V') | Long("version") => {
                 println!("{binary_name} 0.0.1");
                 std::process::exit(0);
@@ -107,18 +153,18 @@ fn parse_args(
                 let script = script.string()?;
                 if script == "interact" {
                     let mode = parse_interact(&mut parser)?;
-                    return Ok((mode, inspect, quiet, no_site, vec![]));
+                    return Ok((mode, flags, vec![]));
                 }
                 if script == "-" {
-                    return Ok((RunMode::Repl, inspect, quiet, no_site, vec![]));
+                    return Ok((RunMode::Repl, flags, vec![]));
                 }
                 let rest = drain_args(&mut parser)?;
-                return Ok((RunMode::Script(script), inspect, quiet, no_site, rest));
+                return Ok((RunMode::Script(script), flags, rest));
             }
             _ => return Err(arg.unexpected()),
         }
     }
-    Ok((RunMode::Repl, inspect, quiet, no_site, vec![]))
+    Ok((RunMode::Repl, flags, vec![]))
 }
 
 /// Parse a `--heapsize` value (`pypy_interact.py:88-102`): a byte count with an
@@ -294,13 +340,24 @@ fn real_main(binary_name: &str) {
             default_hook(info);
         }
     }));
-    let (mode, inspect, quiet, no_site, args) = match parse_args(binary_name) {
+    let (mode, flags, args) = match parse_args(binary_name) {
         Ok(v) => v,
         Err(e) => {
             eprintln!("{binary_name}: {e}");
             std::process::exit(2);
         }
     };
+    let LaunchFlags {
+        inspect,
+        quiet,
+        no_site,
+        no_user_site,
+        ignore_environment,
+        isolated,
+        dev_mode,
+        utf8_mode,
+        safe_path,
+    } = flags;
 
     // The `interact` controller does not run the embedded interpreter; it only
     // spawns and relays for an untrusted child, so it skips the interpreter
@@ -334,6 +391,14 @@ fn real_main(binary_name: &str) {
     // Record `-S` before the first `import sys` so `sys.flags.no_site`
     // reflects whether site initialization was skipped.
     importing::set_no_site(no_site);
+    importing::set_runtime_flags(
+        no_user_site,
+        ignore_environment,
+        isolated,
+        dev_mode,
+        utf8_mode,
+        safe_path,
+    );
 
     // OS-level hardening (default-on in any Linux `sandbox` build): lock the
     // sandboxed child to a host-neutral syscall allowlist so any un-mediated
@@ -542,6 +607,7 @@ fn setup_exec_context() -> Rc<PyExecutionContext> {
     set_last_exec_ctx(Rc::as_ptr(&execution_context));
     unsafe {
         let ec_ptr = Rc::as_ptr(&execution_context) as *mut PyExecutionContext;
+        (*ec_ptr).install_user_del_action();
         pyre_interpreter::module::signal::interp_signal::install_signal_handling(&mut *ec_ptr);
     }
     execution_context

--- a/pyre/pyrex/src/lib.rs
+++ b/pyre/pyrex/src/lib.rs
@@ -78,7 +78,9 @@ Options:
 -I     : isolate Python from the user's environment
 -O     : optimize (no-op, reserved for compatibility)
 -q     : don't print version on interactive startup
+-s     : don't add user site directory to sys.path
 -S     : don't imply 'import site' on initialization
+-P     : don't prepend a potentially unsafe path to sys.path
 -V     : print the Python version number and exit (also --version)
 -X opt : set implementation-specific option
 file   : program read from script file
@@ -144,7 +146,9 @@ fn parse_args(binary_name: &str) -> Result<(RunMode, LaunchFlags, Vec<String>), 
             }
             Short('O') => {} // no-op
             Short('q') => flags.quiet = true,
+            Short('s') => flags.no_user_site = true,
             Short('S') => flags.no_site = true,
+            Short('P') => flags.safe_path = true,
             Short('V') | Long("version") => {
                 println!("{binary_name} 0.0.1");
                 std::process::exit(0);

--- a/pyre/pyrex/src/repl.rs
+++ b/pyre/pyrex/src/repl.rs
@@ -54,6 +54,8 @@ pub fn run_repl(quiet: bool, no_site: bool) {
     // process, and register the periodic signal-check action.
     unsafe {
         let ec_ptr = Rc::as_ptr(&execution_context) as *mut PyExecutionContext;
+        pyre_interpreter::call::set_last_exec_ctx(ec_ptr);
+        (*ec_ptr).install_user_del_action();
         pyre_interpreter::module::signal::interp_signal::install_signal_handling(&mut *ec_ptr);
     }
 


### PR DESCRIPTION
Port of PyPy's `_codecs` error-handler registry and incminimark FinalizerQueue, plus str-subclass allocation and CLI flags. Squashed continuation of #438.

## Main commit (`3219fa35445`)
- `_codecs`: codec error registry with the 8 builtin handlers (strict/ignore/replace/xmlcharrefreplace/backslashreplace/surrogateescape/surrogatepass/namereplace), `check_exception` (interp_codecs.py shape), `register_error`/`lookup_error`.
- majit-gc: FinalizerQueue port from incminimark — `probably_young`/`old_objects_with_finalizers` deques, finalization-ordering state machine (`deal_with_objects_with_finalizers`, incminimark.py:2928-2990), weakrefs to FINALIZATION_ORDERING objects cleared before `__del__` runs (incminimark.py:3105-3126), death-queue objects seeded as major roots.
- Interpreter wiring: `maybe_register_user_finalizer` at allocation (allocate_instance hasuserdel), `UserDelAction` deferred execution, `gc.collect()` drains finalizers synchronously with enable/disable lock-count.
- str subclasses: stable GC allocation owning a fresh WTF-8 buffer + destructor for the off-heap buffer.
- Local `parse_format_parts` (newformat.py shape) replacing the pinned-crate FormatString (fixes `{[{]}` bracket-content parsing).
- `unicode_to_decimal_w` rewrite with surrogate rejection; `sys.flags` populated from real launch flags; `-E`/`-I`/`-X` CLI options.

## Review-fix commit (`99887adc51a`)
Codex parity review findings: `check_exception` only converts AttributeError to TypeError; OOB clamps in backslashreplace/surrogateescape against crafted exceptions; raw-unicode-escape error span = hex-digit-run end + backslash pairs consumed literally (unicodehelper.py:541/791); `_run_finalizers` pins the popped object across `__del__`; `str.__new__` validates cls is a str subtype; standalone `-s`/`-P` options.

## Verification
- `test_str` fully green: run=138 SUCCESS (first fully green run).
- `cargo test -p majit-gc`: 170 passed, incl. new finalizer_queue test.

## Follow-up parity commits (codex-review dispositions)

Six commits on top of the base address the deferred findings from the codex parity review; each keeps `check.py --backend dynasm` at 161/161.

- `gc: rgc.enable/disable parity and pending_with_disabled_del rooting` — `enabled` flag on the collector gates `run_major_progress_after_minor` + `gc_step` (incminimark.py:530-537); `gc_set_enabled` hook chain majit-gc → gc_hook → pyre-jit; `walk_pyframe_roots` visits the previously GC-invisible `pending_with_disabled_del` Vec; `enable_finalizers` pins entries during the drain.
- `executioncontext: route finalizer errors through write_unraisable` — `report_error` → `PyError::write_unraisable` + `UnraisableHookArgs` structseq + real `sys.unraisablehook` (default / custom / raising-hook fallback).
- `typeobject: cache hasuserdel; register finalizers from the flag` — `hasuserdel` cached on `W_TypeObject` (copy_flags_from_bases OR + `__del__` slot check + `mutated` refresh); `maybe_register_user_finalizer` reads the flag instead of a per-allocation MRO scan, closing the JIT-allocation finalizer-registration gap.
- `_codecs: route decode error positions through registered custom handlers` — utf-8 / utf-16 / utf-32 decode error arms invoke a handler registered via `_codecs.register_error` (interp_codecs.py:33-108 decode branch).
- `_codecs: route raw-unicode-escape decode errors through custom handlers` — same routing for the raw-unicode-escape decode path.
- `_codecs: route encode error positions through registered custom handlers` — encode side: `UnicodeEncodeError` construction, `(str/bytes, int)` return validation, newpos folded against source character length; the utf-8 and utf-16/32 loops become resumable while-index loops; a str replacement is re-encoded per codec (utf-8/ascii/utf-16/utf-32 accept `< 0x80`, latin-1 `< 0x100`, else the original error re-raises), a bytes replacement copied verbatim with even/multiple-of-4 length checks for utf-16/32. Cross-checked byte-for-byte against CPython.

Won't-fix (documented): a `weakref` to an object with `__del__` derefs non-`None` inside `__del__`, matching CPython 3.14 (PEP 442 / `tp_finalize` clears weakrefs after `__del__`); clearing before `__del__` is the PyPy behavior and was reverted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added enable/disable/isenabled controls for major GC progress, plus improved finalizer scheduling/draining.
  * Implemented real `sys.unraisablehook` with richer unraisable exception reporting.
  * Added runtime flag plumbing (including safe-path behavior), codec error-handler registry, and `_codecs.register_error`.
* **Bug Fixes**
  * Improved `__del__`/finalizer tracking across inheritance and post-creation assignments.
  * Stricter Unicode digit/whitespace normalization for numeric parsing; consistent codec error handling.
  * Enhanced formatting parsing and corrected `sys.getsizeof(str)` to use `__sizeof__`.
* **Tests**
  * Updated GC-stress harness to reset heap per worker and reduce concurrency issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
