### PR TITLE
jit(wasm): Ref-home liveness filtering, runtime-length varsize inline, live-across-collect home shrink

### DIFF
--- a/majit/majit-backend-wasm/src/codegen.rs
+++ b/majit/majit-backend-wasm/src/codegen.rs
@@ -48,13 +48,13 @@ const CALL_ARGS_OFS: u64 = 2024;
 /// Minimum frame allocation size in bytes to accommodate the call area.
 pub const MIN_FRAME_BYTES: usize = 2024 + 16 * 8; // 16 max call args
 
-/// Byte offset of the Ref-home region within the frame. Each Ref-typed value
-/// (input arg or op result) is given a dedicated home slot here: it is
+/// Byte offset of the Ref-home region within the frame. Each Ref value that is
+/// live across a collecting call is given a dedicated home slot here: it is
 /// null-initialized at trace entry and written on every definition
 /// (store-on-def), so a home slot only ever holds null or a valid GcRef.
-/// A (future) collecting allocation registers these slots as GC roots and
-/// forwards them, then the trace reloads the live Ref locals from their homes
-/// — making object movement transparent without precise liveness.
+/// A collecting allocation registers these slots as GC roots and forwards them,
+/// then the trace reloads the live Ref locals from their homes — making object
+/// movement transparent without rooting Refs that never cross a collection.
 ///
 /// Placed past the call area so it never overlaps the fail-index / input /
 /// output slots (which sit below the call area at offset 2000) or the call
@@ -188,10 +188,57 @@ fn array_item_size_sign_from_descr(op: &Op) -> (usize, bool) {
         .unwrap_or((8, true))
 }
 
-/// Maps each Ref-typed value (input arg / op result) to a compact home-slot
-/// index `0..len`, where its current `GcRef` is mirrored into the frame's
-/// GC-root region (`HOME_SLOT_BASE + home * 8`) so a collecting allocation
-/// inside the trace can forward it.
+/// Dense census of every non-constant Ref-typed value (input arg / op result),
+/// independent of whether it needs a home slot. Write-barrier selection still
+/// needs the full Ref type set after homes are shrunk to only values live across
+/// collecting calls.
+struct RefValues {
+    /// `Vec<bool>` is a wasteful container in general, but justified here: the
+    /// set is built and dropped within one `build_wasm_module` call, sized to
+    /// the trace's value count (tens to low hundreds), and only ever
+    /// point-queried. At that size a direct byte index beats a bitset's
+    /// shift/mask, and the workspace pulls in no bitset crate; it matches the
+    /// backend's other id-indexed flag vectors (`label_resume_safety`,
+    /// `failguard`).
+    by_id: Vec<bool>,
+}
+
+impl RefValues {
+    fn mark(by_id: &mut Vec<bool>, id: u32) {
+        let i = id as usize;
+        if i >= by_id.len() {
+            by_id.resize(i + 1, false);
+        }
+        by_id[i] = true;
+    }
+
+    fn collect(inputargs: &[InputArg], ops: &[Op]) -> Self {
+        let mut by_id = Vec::new();
+        for ia in inputargs {
+            if ia.tp == Type::Ref {
+                Self::mark(&mut by_id, ia.index);
+            }
+        }
+        for op in ops {
+            let r = op.pos.get();
+            if r != OpRef::NONE && !r.is_constant() && op.result_type() == Type::Ref {
+                Self::mark(&mut by_id, r.raw());
+            }
+        }
+        Self { by_id }
+    }
+
+    fn contains(&self, v: OpRef) -> bool {
+        v != OpRef::NONE
+            && !v.is_constant()
+            && self.by_id.get(v.raw() as usize).copied().unwrap_or(false)
+    }
+}
+
+/// Maps each homed Ref-typed value (input arg / op result) to a compact
+/// home-slot index `0..len`, where its current `GcRef` is mirrored into the
+/// frame's GC-root region (`HOME_SLOT_BASE + home * 8`) so a collecting
+/// allocation inside the trace can forward it.
 ///
 /// Keyed by value id (`OpRef::raw()` / input `index`), which is the dense
 /// `[0, num_vars)` space the wasm value locals already use (`1 + raw`); a flat
@@ -220,17 +267,23 @@ impl RefHomes {
         }
     }
 
-    fn collect(inputargs: &[InputArg], ops: &[Op]) -> Self {
+    fn collect(inputargs: &[InputArg], ops: &[Op], include_ca_collects: bool) -> Self {
+        let liveness = HomeLiveness::collect(inputargs, ops);
+        let collect_positions = collecting_call_positions(ops, include_ca_collects);
         let mut by_id = Vec::new();
         let mut next = 0u32;
         for ia in inputargs {
-            if ia.tp == Type::Ref {
+            if ia.tp == Type::Ref && liveness.live_across_any(ia.index, &collect_positions) {
                 Self::assign(&mut by_id, &mut next, ia.index);
             }
         }
         for op in ops {
             let r = op.pos.get();
-            if r != OpRef::NONE && !r.is_constant() && op.result_type() == Type::Ref {
+            if r != OpRef::NONE
+                && !r.is_constant()
+                && op.result_type() == Type::Ref
+                && liveness.live_across_any(r.raw(), &collect_positions)
+            {
                 Self::assign(&mut by_id, &mut next, r.raw());
             }
         }
@@ -277,7 +330,9 @@ impl RefHomes {
 /// caller size the callee frame and the GC walker for a (wider) bridge's home
 /// region before codegen runs.
 pub fn count_ref_homes(inputargs: &[InputArg], ops: &[Op]) -> usize {
-    RefHomes::collect(inputargs, ops).len()
+    // This pre-sizing query is used for CA bridges before `CaParams` exists, so
+    // count `CallAssemblerR` as a collecting position to match CA codegen.
+    RefHomes::collect(inputargs, ops, true).len()
 }
 
 /// Argument index of the stored value for a GC ref-storing op. `SetfieldRaw` /
@@ -299,18 +354,17 @@ fn ref_store_value_arg(op: &Op) -> Option<usize> {
 /// `handle_write_barrier_setfield` gate `v.type == 'r' and not ConstPtr`: a
 /// constant reference is an immortal/old object whose store never makes the base
 /// point to young, so it needs no barrier (rewrite.py:930-931).
-fn write_barrier_base(op: &Op, ref_homes: &RefHomes) -> Option<OpRef> {
+fn write_barrier_base(op: &Op, ref_values: &RefValues) -> Option<OpRef> {
     let val = op.arg(ref_store_value_arg(op)?).to_opref();
-    // `home` returns `None` for a constant value, matching the gate's
-    // `not ConstPtr`.
-    ref_homes.home(val).map(|_| op.arg(0).to_opref())
+    // `contains` returns false for constants, matching the gate's `not ConstPtr`.
+    ref_values.contains(val).then(|| op.arg(0).to_opref())
 }
 
 /// Whether any op in the trace needs a write-barrier trampoline call, which
 /// requires the `jit_call` import to be present.
-fn has_ref_store_op(ops: &[Op], ref_homes: &RefHomes) -> bool {
+fn has_ref_store_op(ops: &[Op], ref_values: &RefValues) -> bool {
     ops.iter()
-        .any(|op| write_barrier_base(op, ref_homes).is_some())
+        .any(|op| write_barrier_base(op, ref_values).is_some())
 }
 
 /// Emit a write-barrier check on `base_ref` before a ref-storing field/array
@@ -400,7 +454,11 @@ struct HomeLiveness {
 
 impl HomeLiveness {
     fn collect(inputargs: &[InputArg], ops: &[Op]) -> Self {
-        let mut n = inputargs.iter().map(|ia| ia.index as usize + 1).max().unwrap_or(0);
+        let mut n = inputargs
+            .iter()
+            .map(|ia| ia.index as usize + 1)
+            .max()
+            .unwrap_or(0);
         for op in ops {
             let r = op.pos.get();
             if r != OpRef::NONE && !r.is_constant() {
@@ -445,10 +503,32 @@ impl HomeLiveness {
     /// local holds a value a collection at op `at` could invalidate.
     fn live_across(&self, raw: u32, at: usize) -> bool {
         let raw = raw as usize;
-        raw < self.def_pos.len()
-            && self.def_pos[raw] < at as i32
-            && self.last_use[raw] > at as i32
+        raw < self.def_pos.len() && self.def_pos[raw] < at as i32 && self.last_use[raw] > at as i32
     }
+
+    fn live_across_any(&self, raw: u32, positions: &[usize]) -> bool {
+        positions.iter().any(|&at| self.live_across(raw, at))
+    }
+}
+
+/// Static collecting-call positions whose gcmap-visible homes may be forwarded.
+/// These are exactly the sites that emit post-call reloads from homes:
+/// `New`/`NewWithVtable`, `NewArray`/`NewArrayClear`, and the CA
+/// `CallAssemblerR` arm when enabled. General residual calls deliberately stay
+/// out of this set because their host-side allocations use the no-collect hook
+/// and the codegen emits no reload for them.
+fn collecting_call_positions(ops: &[Op], include_ca_collects: bool) -> Vec<usize> {
+    ops.iter()
+        .enumerate()
+        .filter_map(|(i, op)| {
+            matches!(
+                op.opcode,
+                OpCode::New | OpCode::NewWithVtable | OpCode::NewArray | OpCode::NewArrayClear
+            )
+            .then_some(i)
+            .or_else(|| (include_ca_collects && op.opcode == OpCode::CallAssemblerR).then_some(i))
+        })
+        .collect()
 }
 
 /// Reload the live Ref locals from their home slots after a collecting call
@@ -631,7 +711,7 @@ fn residual_call_void_word_arity(op: &Op) -> Option<usize> {
 /// `extern "C" fn(i64×n) -> i64` table entries), or a ref-storing store
 /// (its `wasm_jit_write_barrier` helper takes 1 arg). All of these share
 /// the residual-call type family, so one max covers them.
-fn direct_helper_i64_arity(op: &Op, ref_homes: &RefHomes) -> Option<usize> {
+fn direct_helper_i64_arity(op: &Op, ref_values: &RefValues) -> Option<usize> {
     if let Some(n) = residual_call_i64_arity(op) {
         return Some(n);
     }
@@ -644,7 +724,7 @@ fn direct_helper_i64_arity(op: &Op, ref_homes: &RefHomes) -> Option<usize> {
         // wasm_jit_alloc_array(type_id, base_size, item_size, length, len_offset)
         OpCode::NewArray | OpCode::NewArrayClear => Some(5),
         // wasm_jit_write_barrier(base)
-        _ => write_barrier_base(op, ref_homes).map(|_| 1),
+        _ => write_barrier_base(op, ref_values).map(|_| 1),
     }
 }
 
@@ -896,7 +976,8 @@ pub fn build_wasm_module(
         )));
     }
 
-    let ref_homes = RefHomes::collect(inputargs, ops);
+    let ref_values = RefValues::collect(inputargs, ops);
+    let ref_homes = RefHomes::collect(inputargs, ops, ca.emit_ca);
     let num_ref_homes = ref_homes.len();
 
     // Self-recursive CALL_ASSEMBLER arm (`PYRE_WASM_CA`): `bridge_finish_fi` is
@@ -927,7 +1008,7 @@ pub fn build_wasm_module(
     // for the callee-frame GC-alloc / shadow-stack-pop trampolines (an emit_ca
     // bridge always materializes its callee frame via NewWithVtable, so this is
     // already true in practice — stated explicitly for robustness).
-    let needs_call = has_call_ops(ops) || has_ref_store_op(ops, &ref_homes) || ca.emit_ca;
+    let needs_call = has_call_ops(ops) || has_ref_store_op(ops, &ref_values) || ca.emit_ca;
     // The shared indirect-function table is imported for `jit_call`'s residual
     // dispatch, the epilogue's bridge `call_indirect`, and the CA arm's
     // self-recursive `call_indirect`.
@@ -942,7 +1023,7 @@ pub fn build_wasm_module(
     let residual_max_arity = if WASM_DIRECT_RESIDUAL_CALL {
         let scanned = ops
             .iter()
-            .filter_map(|op| direct_helper_i64_arity(op, &ref_homes))
+            .filter_map(|op| direct_helper_i64_arity(op, &ref_values))
             .max();
         if ca.emit_ca {
             // The CA arm's frame helpers (`wasm_jit_ca_alloc_frame(frame_bytes,
@@ -1054,6 +1135,7 @@ pub fn build_wasm_module(
         alloc_array_fn_ptr,
         wb_fn_ptr,
         nursery,
+        &ref_values,
         &ref_homes,
         cells_base,
         bridge_dispatch,
@@ -1091,6 +1173,7 @@ fn build_function(
     alloc_array_fn_ptr: i64,
     wb_fn_ptr: i64,
     nursery: Option<&NurseryAllocParams>,
+    ref_values: &RefValues,
     ref_homes: &RefHomes,
     cells_base: u32,
     bridge_dispatch: bool,
@@ -1138,7 +1221,10 @@ fn build_function(
     let alloc_size_local = alloc_scratch_local + 1;
     let mut func = Function::new(vec![
         (num_vars + UMULHI_SCRATCH, ValType::I64),
-        (base_i32_locals + if nursery.is_some() { 2 } else { 0 }, ValType::I32),
+        (
+            base_i32_locals + if nursery.is_some() { 2 } else { 0 },
+            ValType::I32,
+        ),
     ]);
     let mut sink = func.instructions();
 
@@ -1778,7 +1864,7 @@ fn build_function(
                 }
             }
             OpCode::SetfieldGc | OpCode::SetfieldRaw => {
-                if let Some(base) = write_barrier_base(op, ref_homes) {
+                if let Some(base) = write_barrier_base(op, ref_values) {
                     emit_write_barrier(
                         &mut sink,
                         constants,
@@ -1867,7 +1953,7 @@ fn build_function(
                 }
             }
             OpCode::SetarrayitemGc | OpCode::SetarrayitemRaw => {
-                if let Some(base) = write_barrier_base(op, ref_homes) {
+                if let Some(base) = write_barrier_base(op, ref_values) {
                     emit_write_barrier(
                         &mut sink,
                         constants,
@@ -1917,7 +2003,7 @@ fn build_function(
                 }
             }
             OpCode::SetinteriorfieldGc => {
-                if let Some(base) = write_barrier_base(op, ref_homes) {
+                if let Some(base) = write_barrier_base(op, ref_values) {
                     emit_write_barrier(
                         &mut sink,
                         constants,
@@ -2791,8 +2877,8 @@ fn build_function(
                 let inline_nursery_total = length_const.and_then(|len| {
                     use majit_gc::header::GcHeader;
                     let len = usize::try_from(len).ok()?;
-                    let payload = (base_size as usize)
-                        .checked_add((item_size as usize).checked_mul(len)?)?;
+                    let payload =
+                        (base_size as usize).checked_add((item_size as usize).checked_mul(len)?)?;
                     let total =
                         ((GcHeader::SIZE + payload).max(GcHeader::MIN_NURSERY_OBJ_SIZE) + 7) & !7;
                     let na = nursery.filter(|na| {

--- a/majit/majit-backend-wasm/src/codegen.rs
+++ b/majit/majit-backend-wasm/src/codegen.rs
@@ -380,21 +380,97 @@ fn emit_write_barrier(
     sink.call(jit_call);
 }
 
-/// Reload every live Ref local from its home slot, optionally skipping one
-/// value id (`skip_raw` — the freshly-allocated result, whose home is not yet
-/// written). Emitted after a collecting allocation: the collection forwarded
-/// the home slots (registered as GC roots), so reloading the locals makes
-/// object movement transparent to the trace without precise per-safepoint
-/// liveness. Over-reloading a dead Ref is harmless (it is never read again).
+/// Per-value def / last-use op positions over the trace, used to filter the
+/// post-collection Ref reloads ([`emit_reload_refs_from_homes`]) down to
+/// values that are both already defined and still read — the wasm-shaped
+/// analog of the native regalloc reloading a spilled box on its next use
+/// (llsupport/regalloc.py `longevity`) instead of eagerly rebinding every
+/// home.
+///
+/// Positions: inputs are defined at `-1`; an op result at its op index; a
+/// LABEL's args additionally at the label's index (a loop-carried value
+/// re-enters the body there — a def index past a reload site must not hide
+/// the stale local from the reload on the next iteration). Uses are op args
+/// plus guard fail args; the loop-closing JUMP's args are op args, so
+/// loop-carried values stay live through the backedge.
+struct HomeLiveness {
+    def_pos: Vec<i32>,
+    last_use: Vec<i32>,
+}
+
+impl HomeLiveness {
+    fn collect(inputargs: &[InputArg], ops: &[Op]) -> Self {
+        let mut n = inputargs.iter().map(|ia| ia.index as usize + 1).max().unwrap_or(0);
+        for op in ops {
+            let r = op.pos.get();
+            if r != OpRef::NONE && !r.is_constant() {
+                n = n.max(r.raw() as usize + 1);
+            }
+        }
+        let mut def_pos = vec![i32::MAX; n];
+        let mut last_use = vec![-1i32; n];
+        for ia in inputargs {
+            def_pos[ia.index as usize] = -1;
+        }
+        for (i, op) in ops.iter().enumerate() {
+            let r = op.pos.get();
+            if r != OpRef::NONE && !r.is_constant() && (r.raw() as usize) < n {
+                let d = &mut def_pos[r.raw() as usize];
+                *d = (*d).min(i as i32);
+            }
+            for a in op.getarglist().iter() {
+                let a = a.to_opref();
+                if a == OpRef::NONE || a.is_constant() || (a.raw() as usize) >= n {
+                    continue;
+                }
+                last_use[a.raw() as usize] = i as i32;
+                if op.opcode == OpCode::Label {
+                    let d = &mut def_pos[a.raw() as usize];
+                    *d = (*d).min(i as i32);
+                }
+            }
+            if let Some(fa) = op.getfailargs() {
+                for a in fa.iter() {
+                    let a = a.to_opref();
+                    if a != OpRef::NONE && !a.is_constant() && (a.raw() as usize) < n {
+                        last_use[a.raw() as usize] = i as i32;
+                    }
+                }
+            }
+        }
+        Self { def_pos, last_use }
+    }
+
+    /// Value `raw` is defined before op `at` and read after it — i.e. its
+    /// local holds a value a collection at op `at` could invalidate.
+    fn live_across(&self, raw: u32, at: usize) -> bool {
+        let raw = raw as usize;
+        raw < self.def_pos.len()
+            && self.def_pos[raw] < at as i32
+            && self.last_use[raw] > at as i32
+    }
+}
+
+/// Reload the live Ref locals from their home slots after a collecting call
+/// at op index `at_op`, optionally skipping one value id (`skip_raw` — the
+/// freshly-allocated result, whose home is not yet written). The collection
+/// forwarded the home slots (registered as GC roots), so reloading the
+/// locals makes object movement transparent to the trace. Only values live
+/// across `at_op` ([`HomeLiveness::live_across`]) are reloaded: a value not
+/// yet defined has a null home and its local is written at its def, and a
+/// value never read after `at_op` has no consumer for the reload — the
+/// native regalloc likewise reloads a spilled box only on its next use.
 fn emit_reload_refs_from_homes(
     sink: &mut InstructionSink<'_>,
     ref_homes: &RefHomes,
+    liveness: &HomeLiveness,
+    at_op: usize,
     skip_raw: Option<u32>,
 ) {
     // `iter` yields id order, so the emitted module is reproducible without a
     // sort; each reload is independent (home and local storage are disjoint).
     for (raw, h) in ref_homes.iter() {
-        if Some(raw) == skip_raw {
+        if Some(raw) == skip_raw || !liveness.live_across(raw, at_op) {
             continue;
         }
         sink.local_get(0);
@@ -1080,6 +1156,9 @@ fn build_function(
     // inner loop header).
     let loop_label_idx = ops.iter().rposition(|op| op.opcode == OpCode::Label);
     let has_loop = loop_label_idx.is_some();
+
+    // Def / last-use positions for the post-collection Ref reload filter.
+    let liveness = HomeLiveness::collect(inputargs, ops);
 
     // A Label-less trace with bridge dispatch — a `PYRE_WASM_CA` recursion
     // loop, or (chaining on) a bridge whose own guards chain nested
@@ -2392,7 +2471,7 @@ fn build_function(
                 // and its home is not written until the store-on-def below, so a
                 // reload would clobber it with the home's pre-call (stale) value.
                 let skip = (!OpRef::raw_is_constant(vi)).then_some(vi);
-                emit_reload_refs_from_homes(&mut sink, ref_homes, skip);
+                emit_reload_refs_from_homes(&mut sink, ref_homes, &liveness, op_idx, skip);
             }
 
             // ── CALL operations (via trampoline) ──
@@ -2577,6 +2656,8 @@ fn build_function(
                     emit_reload_refs_from_homes(
                         &mut sink,
                         ref_homes,
+                        &liveness,
+                        op_idx,
                         (!OpRef::raw_is_constant(vi)).then_some(vi),
                     );
                     sink.else_();
@@ -2681,7 +2762,7 @@ fn build_function(
                 // nothing).
                 if residual_type_base.is_none() || inline_nursery.is_none() {
                     let skip = (!OpRef::raw_is_constant(vi)).then_some(vi);
-                    emit_reload_refs_from_homes(&mut sink, ref_homes, skip);
+                    emit_reload_refs_from_homes(&mut sink, ref_homes, &liveness, op_idx, skip);
                 }
             }
             OpCode::NewArray | OpCode::NewArrayClear => {
@@ -2752,6 +2833,8 @@ fn build_function(
                     emit_reload_refs_from_homes(
                         &mut sink,
                         ref_homes,
+                        &liveness,
+                        op_idx,
                         (!OpRef::raw_is_constant(vi)).then_some(vi),
                     );
                     sink.else_();
@@ -2854,7 +2937,7 @@ fn build_function(
                 // inline-bump path already emitted this inside its slow arm.
                 if residual_type_base.is_none() || inline_nursery_total.is_none() {
                     let skip = (!OpRef::raw_is_constant(vi)).then_some(vi);
-                    emit_reload_refs_from_homes(&mut sink, ref_homes, skip);
+                    emit_reload_refs_from_homes(&mut sink, ref_homes, &liveness, op_idx, skip);
                 }
             }
 

--- a/majit/majit-backend-wasm/src/codegen.rs
+++ b/majit/majit-backend-wasm/src/codegen.rs
@@ -1129,13 +1129,16 @@ fn build_function(
     // flag-off module keeps exactly one i32 local (byte-identical).
     let ca_cfp_local = num_vars + UMULHI_SCRATCH + 2;
     let ca_fi_local = num_vars + UMULHI_SCRATCH + 3;
-    // One more i32 scratch when the inline nursery-bump fast path is armed:
-    // it holds the loaded `nursery_free` across the bump/commit sequence.
+    // Extra i32 scratches when the inline nursery-bump fast path is armed:
+    // one holds the loaded `nursery_free` across the bump/commit sequence;
+    // runtime varsize array allocation also needs one for the computed
+    // total/new-free word.
     let base_i32_locals: u32 = if ca.emit_ca { 3 } else { 1 };
     let alloc_scratch_local = num_vars + UMULHI_SCRATCH + 1 + base_i32_locals;
+    let alloc_size_local = alloc_scratch_local + 1;
     let mut func = Function::new(vec![
         (num_vars + UMULHI_SCRATCH, ValType::I64),
-        (base_i32_locals + nursery.is_some() as u32, ValType::I32),
+        (base_i32_locals + if nursery.is_some() { 2 } else { 0 }, ValType::I32),
     ]);
     let mut sink = func.instructions();
 
@@ -2777,28 +2780,56 @@ fn build_function(
                     .map_or(0i64, |ld| ld.offset() as i64);
                 let type_id = ad.map_or(0i64, |ad| ad.type_id() as i64);
 
-                // Inline nursery bump for a CONSTANT-length array of a plain
-                // type under the large-object threshold (same fast path as the
-                // `New` arm — the total is a compile-time constant, and the
-                // nursery is bulk-zeroed on reset so `NewArrayClear`'s cleared
-                // items come for free, exactly like the helper). Writes the
-                // header word and the length field inline. A runtime-length
-                // array keeps the helper call.
-                let inline_nursery_total = const_operand_value(constants, op.arg(0).to_opref())
-                    .and_then(|len| {
+                // Inline nursery bump for arrays of a plain type under the
+                // large-object threshold (same fast path as the `New` arm).
+                // Constant lengths keep the existing compile-time total; a
+                // runtime length uses malloc_cond_varsize's precheck against a
+                // compile-time maxlength before computing the bump size.
+                // The nursery is bulk-zeroed on reset so `NewArrayClear`'s
+                // cleared items come for free, exactly like the helper.
+                let length_const = const_operand_value(constants, op.arg(0).to_opref());
+                let inline_nursery_total = length_const.and_then(|len| {
+                    use majit_gc::header::GcHeader;
+                    let len = usize::try_from(len).ok()?;
+                    let payload = (base_size as usize)
+                        .checked_add((item_size as usize).checked_mul(len)?)?;
+                    let total =
+                        ((GcHeader::SIZE + payload).max(GcHeader::MIN_NURSERY_OBJ_SIZE) + 7) & !7;
+                    let na = nursery.filter(|na| {
+                        total <= na.large_threshold
+                            && u32::try_from(type_id).is_ok_and(|t| na.plain_tids.contains(&t))
+                    })?;
+                    Some((total, len, na))
+                });
+                let inline_nursery_varsize = if length_const.is_none() {
+                    (|| {
                         use majit_gc::header::GcHeader;
-                        let len = usize::try_from(len).ok()?;
-                        let payload = (base_size as usize)
-                            .checked_add((item_size as usize).checked_mul(len)?)?;
-                        let total =
-                            ((GcHeader::SIZE + payload).max(GcHeader::MIN_NURSERY_OBJ_SIZE) + 7)
-                                & !7;
+                        let base_size_usize = usize::try_from(base_size).ok()?;
+                        let item_size_usize = usize::try_from(item_size).ok()?;
+                        let base_total = GcHeader::SIZE.checked_add(base_size_usize)?;
                         let na = nursery.filter(|na| {
-                            total <= na.large_threshold
-                                && u32::try_from(type_id).is_ok_and(|t| na.plain_tids.contains(&t))
+                            u32::try_from(type_id).is_ok_and(|t| na.plain_tids.contains(&t))
                         })?;
-                        Some((total, len, na))
-                    });
+                        // malloc_cond_varsize checks the length before doing
+                        // the scaled size calculation.  Use the largest length
+                        // whose rounded total still fits under the nursery
+                        // large-object threshold, capped to wasm32's usize
+                        // length field.
+                        let threshold = na.large_threshold.min(u32::MAX as usize) & !7;
+                        if threshold < GcHeader::MIN_NURSERY_OBJ_SIZE || base_total > threshold {
+                            return None;
+                        }
+                        let max_len = if item_size_usize == 0 {
+                            u32::MAX as usize
+                        } else {
+                            ((threshold - base_total) / item_size_usize).min(u32::MAX as usize)
+                        };
+                        let max_len = i64::try_from(max_len).ok()?;
+                        Some((max_len, base_total as i64, item_size_usize as i64, na))
+                    })()
+                } else {
+                    None
+                };
                 if let (Some(base), Some((total_size, length, na))) =
                     (residual_type_base, inline_nursery_total)
                 {
@@ -2876,6 +2907,125 @@ fn build_function(
                     } else {
                         sink.drop();
                     }
+                } else if let (Some(base), Some((max_len, base_total, item_size, na))) =
+                    (residual_type_base, inline_nursery_varsize)
+                {
+                    // malloc_cond_varsize: negative lengths compare greater in
+                    // the unsigned precheck and go to the collecting slow path.
+                    emit_resolve(&mut sink, constants, op.arg(0).to_opref());
+                    sink.i64_const(max_len);
+                    sink.i64_gt_u();
+                    sink.if_(BlockType::Result(ValType::I64));
+                    sink.i64_const(type_id);
+                    sink.i64_const(base_size);
+                    sink.i64_const(item_size);
+                    emit_resolve(&mut sink, constants, op.arg(0).to_opref());
+                    sink.i64_const(len_offset);
+                    sink.i32_const(alloc_array_fn_ptr as i32);
+                    sink.call_indirect(0, base + 5);
+                    emit_reload_refs_from_homes(
+                        &mut sink,
+                        ref_homes,
+                        &liveness,
+                        op_idx,
+                        (!OpRef::raw_is_constant(vi)).then_some(vi),
+                    );
+                    sink.else_();
+                    // total = round_up_8(max(header + base + item * length,
+                    // MIN_NURSERY_OBJ_SIZE)).
+                    emit_resolve(&mut sink, constants, op.arg(0).to_opref());
+                    sink.i64_const(item_size);
+                    sink.i64_mul();
+                    sink.i64_const(base_total);
+                    sink.i64_add();
+                    sink.i32_wrap_i64();
+                    sink.local_set(alloc_size_local);
+                    sink.local_get(alloc_size_local);
+                    sink.i32_const(majit_gc::header::GcHeader::MIN_NURSERY_OBJ_SIZE as i32);
+                    sink.i32_lt_u();
+                    sink.if_(BlockType::Result(ValType::I32));
+                    sink.i32_const(majit_gc::header::GcHeader::MIN_NURSERY_OBJ_SIZE as i32);
+                    sink.else_();
+                    sink.local_get(alloc_size_local);
+                    sink.end();
+                    sink.i32_const(7);
+                    sink.i32_add();
+                    sink.i32_const(-8);
+                    sink.i32_and();
+                    sink.local_set(alloc_size_local);
+
+                    // free = *nursery_free; new_free = free + total
+                    sink.i32_const(na.free_addr as i32);
+                    sink.i32_load(MemArg {
+                        offset: 0,
+                        align: 2,
+                        memory_index: 0,
+                    });
+                    sink.local_tee(alloc_scratch_local);
+                    sink.local_get(alloc_size_local);
+                    sink.i32_add();
+                    sink.local_tee(alloc_size_local);
+                    sink.i32_const(na.top_addr as i32);
+                    sink.i32_load(MemArg {
+                        offset: 0,
+                        align: 2,
+                        memory_index: 0,
+                    });
+                    sink.i32_gt_u();
+                    sink.if_(BlockType::Result(ValType::I64));
+                    sink.i64_const(type_id);
+                    sink.i64_const(base_size);
+                    sink.i64_const(item_size);
+                    emit_resolve(&mut sink, constants, op.arg(0).to_opref());
+                    sink.i64_const(len_offset);
+                    sink.i32_const(alloc_array_fn_ptr as i32);
+                    sink.call_indirect(0, base + 5);
+                    emit_reload_refs_from_homes(
+                        &mut sink,
+                        ref_homes,
+                        &liveness,
+                        op_idx,
+                        (!OpRef::raw_is_constant(vi)).then_some(vi),
+                    );
+                    sink.else_();
+                    // Commit: *nursery_free = new_free.
+                    sink.i32_const(na.free_addr as i32);
+                    sink.local_get(alloc_size_local);
+                    sink.i32_store(MemArg {
+                        offset: 0,
+                        align: 2,
+                        memory_index: 0,
+                    });
+                    // Header word: `GcHeader::new(tid)` — flags 0.
+                    sink.local_get(alloc_scratch_local);
+                    sink.i64_const(type_id);
+                    sink.i64_store(MemArg {
+                        offset: 0,
+                        align: 3,
+                        memory_index: 0,
+                    });
+                    // Length field (usize, 4 bytes on wasm32) at
+                    // `payload + len_offset`.
+                    sink.local_get(alloc_scratch_local);
+                    emit_resolve(&mut sink, constants, op.arg(0).to_opref());
+                    sink.i32_wrap_i64();
+                    sink.i32_store(MemArg {
+                        offset: majit_gc::header::GcHeader::SIZE as u64 + len_offset as u64,
+                        align: 2,
+                        memory_index: 0,
+                    });
+                    // Result payload pointer = free + header size.
+                    sink.local_get(alloc_scratch_local);
+                    sink.i32_const(majit_gc::header::GcHeader::SIZE as i32);
+                    sink.i32_add();
+                    sink.i64_extend_i32_u();
+                    sink.end();
+                    sink.end();
+                    if !OpRef::raw_is_constant(vi) {
+                        sink.local_set(1 + vi);
+                    } else {
+                        sink.drop();
+                    }
                 } else if let Some(base) = residual_type_base {
                     // Direct in-module allocation, like the `New` arm:
                     // `wasm_jit_alloc_array(type_id, base_size, item_size,
@@ -2934,8 +3084,10 @@ fn build_function(
                     }
                 }
                 // `wasm_jit_alloc_array` collects; reload other live Refs. The
-                // inline-bump path already emitted this inside its slow arm.
-                if residual_type_base.is_none() || inline_nursery_total.is_none() {
+                // inline-bump paths already emitted this inside their slow arms.
+                if residual_type_base.is_none()
+                    || (inline_nursery_total.is_none() && inline_nursery_varsize.is_none())
+                {
                     let skip = (!OpRef::raw_is_constant(vi)).then_some(vi);
                     emit_reload_refs_from_homes(&mut sink, ref_homes, &liveness, op_idx, skip);
                 }

--- a/majit/majit-backend-wasm/src/lib.rs
+++ b/majit/majit-backend-wasm/src/lib.rs
@@ -653,12 +653,12 @@ pub extern "C" fn wasm_jit_ca_pop_frame(_frame_base: i64) -> i64 {
 }
 
 /// Build the per-frame `jf_gcmap` for a CA callee frame: mark the CA input slots
-/// (`v64` + `ec`, at `FRAME_SLOT_BASE`) AND the home slots (live SSA Refs), in
-/// the `JitFrame`'s Signed-granular item indexing (see [`build_home_gcmap`] for
-/// the wasm32 layout). Unlike the host-entry frame F0 (homes only), a callee
-/// frame keeps its virtualizable `v64` in an input slot (never homed by the
-/// loop), so the input slots are roots too. Returned buffer is leaked by the
-/// caller (one per bridge) and lives for the program's life.
+/// (`v64` + `ec`, at `FRAME_SLOT_BASE`) AND the surviving home slots (Refs live
+/// across collecting calls), in the `JitFrame`'s Signed-granular item indexing
+/// (see [`build_home_gcmap`] for the wasm32 layout). Unlike the host-entry frame
+/// F0 (homes only), a callee frame keeps its virtualizable `v64` in an input slot
+/// (never homed by the loop), so the input slots are roots too. Returned buffer
+/// is leaked by the caller (one per bridge) and lives for the program's life.
 fn build_callee_gcmap(input_count: usize, home_count: usize) -> Box<[usize]> {
     let sign = std::mem::size_of::<isize>();
     let bits_per_word = std::mem::size_of::<usize>() * 8;
@@ -774,8 +774,8 @@ fn wasm_jitframe_tid() -> u32 {
     WASM_JITFRAME_TID.load(std::sync::atomic::Ordering::Relaxed)
 }
 
-/// Build a `jf_gcmap` bitmap marking the Ref-home region as the frame's traced
-/// GC roots, in the `JitFrame`'s Signed-granular item indexing.
+/// Build a `jf_gcmap` bitmap marking the surviving Ref-home region as the
+/// frame's traced GC roots, in the `JitFrame`'s Signed-granular item indexing.
 ///
 /// On wasm32 `isize` is 4 bytes, so `jf_frame` items are 4-byte Signed slots and
 /// each 8-byte data slot spans two items — the orthodox PyPy 32-bit layout where
@@ -1872,18 +1872,20 @@ impl majit_backend::Backend for WasmBackend {
         // Self-recursive CALL_ASSEMBLER (PYRE_WASM_CA): the CA arm bump-allocates
         // a fresh callee frame per recursive `call_indirect` into the source
         // loop. Size it for the source loop's frame layout (base_slots + the
-        // dispatch-key slot + ref-home region, mirroring `execute_token`);
+        // dispatch-key slot + surviving ref-home region, mirroring
+        // `execute_token`);
         // `build_wasm_module` widens it to also fit THIS bridge, which reuses the
         // same frame when the loop's guard-exit chains back into it.
-        // This bridge materializes the recursive callee frame and homes it (plus
-        // its other live Refs) in the SAME arena frame the source loop runs on,
-        // store-on-def'ing at its OWN home indices. A self-recursive fib bridge
-        // reserves more homes than the source loop, so the arena frame and the GC
-        // walker must cover the WIDER of the two: otherwise the callee `v64`'s
-        // home (index >= `source_num_ref_homes`) lands past the frame's walked
-        // region and a minor collection mid-recursion reclaims it, leaving a later
-        // deopt to read zeroed nursery memory. `count_ref_homes` matches the
-        // `num_ref_homes` `build_wasm_module` returns below.
+        // This bridge materializes the recursive callee frame and homes any
+        // bridge Refs live across collecting calls in the SAME arena frame the
+        // source loop runs on, store-on-def'ing at its OWN dense home indices. A
+        // self-recursive fib bridge may reserve more surviving homes than the
+        // source loop, so the arena frame and the GC walker must cover the WIDER
+        // of the two: otherwise a bridge home (index >= `source_num_ref_homes`)
+        // lands past the frame's walked region and a minor collection
+        // mid-recursion reclaims it, leaving a later deopt to read zeroed nursery
+        // memory. `count_ref_homes` matches the CA-enabled `num_ref_homes`
+        // `build_wasm_module` returns below.
         //
         // The recursion can also chain into NESTED bridges (and sibling loops via
         // loop-closing tail calls) while running ON a CA callee frame — and those
@@ -2286,7 +2288,8 @@ impl majit_backend::Backend for WasmBackend {
         // Allocate frame area large enough for slots + call trampoline area +
         // the Ref-home region. MIN_FRAME_BYTES accommodates the call area at
         // offset 2000+; the Ref-home region (`codegen::HOME_SLOT_BASE`) follows
-        // it, one slot per Ref-typed value (`num_ref_homes`).
+        // it, one slot per Ref value live across a collecting call
+        // (`num_ref_homes`).
         let min_slots = codegen::MIN_FRAME_BYTES / 8;
         let base_slots = min_slots.max(1 + compiled.max_output_slots.max(compiled.num_inputs));
         // +1 for the resume-at-LABEL dispatch-key slot (codegen::DISPATCH_KEY_OFS
@@ -2295,9 +2298,9 @@ impl majit_backend::Backend for WasmBackend {
         // `vec![0i64]` zeroes it, so a fresh host entry reads key 0 (preamble).
         //
         // A self-recursive CALL_ASSEMBLER bridge runs its outermost call in this
-        // frame and may home more Refs than the loop, so size for the LARGER of
-        // the two (`ca_bridge_ref_homes`); the extra slots are zeroed and
-        // GC-rooted below exactly like the loop's own homes.
+        // frame and may home more collection-live Refs than the loop, so size
+        // for the LARGER of the two (`ca_bridge_ref_homes`); the extra slots are
+        // zeroed and GC-rooted below exactly like the loop's own homes.
         // A cross-trace tail call can land in a loop or bridge homing more Refs
         // than this one, so also size at least `FRAME_REF_HOME_FLOOR` — the bound
         // `compile_bridge`'s frame-fit accept checks rely on.
@@ -2345,9 +2348,9 @@ impl majit_backend::Backend for WasmBackend {
                 let jf = jf_ref.0 as *mut JitFrame;
                 unsafe { JitFrame::init(jf, std::ptr::null(), depth) };
 
-                // Conservative per-loop gcmap over the Ref-home region. Held in
-                // this stack frame (jf_gcmap points at it) until the outputs are
-                // read after the trace returns.
+                // Per-loop gcmap over the surviving Ref-home region. Held in this
+                // stack frame (jf_gcmap points at it) until the outputs are read
+                // after the trace returns.
                 let gcmap = build_home_gcmap(eff_ref_homes);
                 unsafe { (*jf).jf_gcmap = gcmap.as_ptr() as *const u8 };
 
@@ -2392,11 +2395,11 @@ impl majit_backend::Backend for WasmBackend {
                 };
             }
 
-            // Legacy host-Vec frame path (default, PYRE_WASM_CA off) — byte-
-            // identical to before: fail_index at frame[0], inputs/outputs at
-            // frame[1 + i], Ref homes manually rooted across the trace. A home
-            // slot only ever holds null (entry init) or a valid GcRef (store-on-
-            // def), so forwarding is safe without precise liveness. The path to
+            // Legacy host-Vec frame path (default, PYRE_WASM_CA off): fail_index
+            // at frame[0], inputs/outputs at frame[1 + i], surviving Ref homes
+            // manually rooted across the trace. A home slot only ever holds null
+            // (entry init) or a valid GcRef (store-on-def), so forwarding is
+            // safe. The path to
             // `wasm_gc_remove_root` is straight-line and the wasm32 build is
             // `panic=abort`, so `glue::execute` cannot unwind and leak roots.
             let mut frame = vec![0i64; frame_size];


### PR DESCRIPTION
Three wasm-backend slices from the #466 cost-floor work (context/analysis in #466 — the issue stays open for the architectural levers). Each is a convergence toward the RPython backend mechanism; all three are timing-neutral by interleaved A/B (the removed waste was hidden by L1-hot loads and wasmtime DCE) and landed on the parity-faithful framing rather than a perf claim.

## 1. `jit(wasm): filter post-collection Ref home reloads by liveness`

`emit_reload_refs_from_homes` reloaded **all** Ref homes unconditionally after every collecting call — including homes whose value was not yet defined and homes never read again. The reference regalloc (`llsupport/regalloc.py` `longevity`) reloads a spilled box only on its next use; eager reload-all has no analog. A `HomeLiveness` pass (def position / last use, with LABEL-arg defs clamped to the LABEL so loop-carried values stay hot across the backedge, and guard fail args counted as uses) filters each reload site to homes defined-before ∧ read-after.

fib bridge: home reloads 180 → 72, memory ops 411 → 303, emitted module 3542 → 2678 bytes; loop module byte-identical.

## 2. `jit(wasm): inline the nursery bump for runtime-length arrays`

The `NewArray`/`NewArrayClear` arm inline-bumped only constant-length arrays; a runtime-length array always took the residual `alloc_array` helper — a collecting call, which also forced a Ref home reload at each site. This ports the `malloc_cond_varsize` shape (`rewrite.py` `gen_malloc_nursery_varsize`; the dynasm backend already carries this port in `aarch64/assembler.rs`): guard the length against a compile-time maxlength (unsigned compare, so negative lengths go slow), compute the rounded total at runtime, bump inline, and keep the residual helper + home reload only in the slow arm.

The fib bridge loses its two unconditional `alloc_array` `call_indirect`s; bench outputs byte-identical.

## 3. `jit(wasm): assign Ref homes only to values live across a collecting call`

Every non-constant Ref-typed op got a frame home, a null-init store at entry, and a store on def — regardless of whether the value ever needed GC rooting. Homes are now assigned only to Refs whose liveness range crosses a collecting position (`New`/`NewWithVtable`/`NewArray`/`NewArrayClear` sites and `CallAssemblerR`), matching the reference regalloc giving a jitframe location only to values actually spilled at a call. Homes renumber densely; gcmap construction, CA frame sizing and the CA reuse zero-runs consume the shrunk set; a separate `RefValues` census keeps write-barrier detection covering all Ref values. Guard-fail/resume reads use the fail/output slot region, not homes.

fib bridge: homes 21 → 15, null-init stores −6, memory ops 236 → 224.

## Verification

Each commit was gated individually:

| gate | result |
|---|---|
| full `pyre/check.py --backend dynasm,wasm` (benches included) | **dynasm 161/161, wasm 161/161** ×3 runs |
| `pyre/check.py --synthetic-only` | 151/151 both |
| `cargo test -p majit-backend-wasm` (and `-p majit-gc` where touched) | green |
| fib(32) output | 2178309, bench outputs byte-identical across A/B |
| dynasm | unaffected (wasm-backend-only files) |

Codex parity review of the full diff: §1 (parity regressions) **None**, §2 (new mismatches) **None**; the two new structural adaptations (wasm-local liveness census, wasm32 varsize bounds/rounding) carry their reference citations in-code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
