### PR TITLE
majit: loop-peel int-bound export/preservation, wasm raw-store lowering, aarch64 x21/x22

### DIFF
--- a/majit/majit-backend-dynasm/src/aarch64/arch.rs
+++ b/majit/majit-backend-dynasm/src/aarch64/arch.rs
@@ -21,8 +21,12 @@ pub const FRAME_FIXED_SIZE: usize = 0;
 pub const PASS_ON_MY_FRAME: usize = 0;
 
 /// aarch64/arch.py:13 — `JITFRAME_FIXED_SIZE = NUM_MANAGED_REGS +
-/// NUM_VFP_REGS`, i.e. 16 GPR + 8 VFP = 24.
-pub const JITFRAME_FIXED_SIZE: usize = 24;
+/// NUM_VFP_REGS`, i.e. 18 GPR + 8 VFP = 26.
+///
+/// `NUM_MANAGED_REGS` must equal `len(all_regs)` (runner.py:84 asserts
+/// this); enabling callee-saved x21, x22 grows `all_regs` from 16 to 18,
+/// so the managed-register area of the jitframe grows to match.
+pub const JITFRAME_FIXED_SIZE: usize = 26;
 
 /// aarch64/arch.py: thread-local data is reached via the system TLS
 /// register, not via a fixed slot in the JIT frame.

--- a/majit/majit-backend-dynasm/src/aarch64/assembler.rs
+++ b/majit/majit-backend-dynasm/src/aarch64/assembler.rs
@@ -31,7 +31,7 @@ use crate::regalloc::{RegAlloc, RegAllocOp};
 use crate::regloc::{Loc, RegLoc};
 use crate::runner::GuardGcTypeInfo;
 
-const AARCH64_GEN_REGS: [crate::regloc::RegLoc; 16] = crate::aarch64::registers::ALL_REGS;
+const AARCH64_GEN_REGS: [crate::regloc::RegLoc; 18] = crate::aarch64::registers::ALL_REGS;
 
 const AARCH64_FLOAT_REGS: [crate::regloc::RegLoc; 8] = crate::aarch64::registers::ALL_VFP_REGS;
 
@@ -1232,9 +1232,9 @@ impl<'a> AssemblerARM64<'a> {
     /// x64: System V AMD64 ABI — first arg (jf_ptr) in RDI.
     /// aarch64: AAPCS64 — first arg (jf_ptr) in X0.
     ///
-    /// Save slots: 32 bytes total (fp/lr at [sp,#0], x19/x20 at
-    /// [sp,#16]).  Mirrors aarch64/assembler.py:1117-1122 which
-    /// iterates `r.callee_saved_registers = [x19, x20]`.
+    /// Save slots: 48 bytes total (fp/lr at [sp,#0], x19/x20 at
+    /// [sp,#16], x21/x22 at [sp,#32]).  Mirrors aarch64/assembler.py:1117-1122
+    /// which iterates `r.callee_saved_registers = [x19, x20, x21, x22]`.
     ///
     /// aarch64/assembler.py:1092-1114 `_call_header_with_stack_check`:
     /// inline SP probe right after the frame pointer is captured,
@@ -1262,8 +1262,9 @@ impl<'a> AssemblerARM64<'a> {
     /// ```
     fn _call_header(&mut self, inputargs: &[InputArg]) {
         dynasm!(self.mc ; .arch aarch64
-            ; stp x29, x30, [sp, #-32]!
+            ; stp x29, x30, [sp, #-48]!
             ; stp x19, x20, [sp, #16]   // save callee-saved regs
+            ; stp x21, x22, [sp, #32]   // save callee-saved regs
             ; mov x29, x0
         );
         let propagate_descr = self.propagate_exception_descr_ptr();
@@ -1312,7 +1313,8 @@ impl<'a> AssemblerARM64<'a> {
                     // Overflow fallthrough: return x29 as jf_ptr.
                     ; mov x0, x29
                     ; ldp x19, x20, [sp, #16]
-                    ; ldp x29, x30, [sp], #32
+                    ; ldp x21, x22, [sp, #32]
+                    ; ldp x29, x30, [sp], #48
                     ; ret
                     ; =>continue_label
                 );
@@ -1334,7 +1336,8 @@ impl<'a> AssemblerARM64<'a> {
         dynasm!(self.mc ; .arch aarch64
             ; mov x0, x29
             ; ldp x19, x20, [sp, #16]   // restore callee-saved regs
-            ; ldp x29, x30, [sp], #32
+            ; ldp x21, x22, [sp, #32]   // restore callee-saved regs
+            ; ldp x29, x30, [sp], #48
             ; ret
         );
     }
@@ -5922,7 +5925,7 @@ impl<'a> AssemblerARM64<'a> {
         // live Ref into its canonical jitframe slot. `gcmap` identifies
         // those slots by the same register-index table that
         // `get_gcmap` writes bits from (`core_reg_index`:
-        //   x0..x13 → slots 0..13, x19 → 14, x20 → 15).
+        //   x0..x13 → slots 0..13, x19 → 14, x20 → 15, x21 → 16, x22 → 17).
         //
         // Without this spill the GC walks `jf_frame` slots 0..15 (per
         // gcmap bits), finds garbage, and returns with live Refs in CPU
@@ -5939,7 +5942,7 @@ impl<'a> AssemblerARM64<'a> {
         // the malloc site (see `MALLOC_NURSERY_CLOBBER`).
         dynasm!(self.mc ; .arch aarch64 ; =>slow_path);
         let base_ofs = crate::jitframe::FIRST_ITEM_OFFSET as i32;
-        // Save x2..x13 to slots 2..13 (x0/x1 excluded per ignored_regs).
+        // Save x2..x13, x19..x22 to their slots (x0/x1 excluded per ignored_regs).
         dynasm!(self.mc ; .arch aarch64
             ; stp x2, x3, [x29, base_ofs + 2 * 8]
             ; stp x4, x5, [x29, base_ofs + 4 * 8]
@@ -5948,6 +5951,7 @@ impl<'a> AssemblerARM64<'a> {
             ; stp x10, x11, [x29, base_ofs + 10 * 8]
             ; stp x12, x13, [x29, base_ofs + 12 * 8]
             ; stp x19, x20, [x29, base_ofs + 14 * 8]
+            ; stp x21, x22, [x29, base_ofs + 16 * 8]
         );
         // assembler.py:649-650: store gcmap to jf_gcmap so the collector
         // can trace live Refs pinned to frame slots during the slow-path
@@ -5969,7 +5973,7 @@ impl<'a> AssemblerARM64<'a> {
         // pop_gcmap: clear jf_gcmap after collecting call
         let gcmap_ofs = crate::jitframe::JF_GCMAP_OFS as u32;
         dynasm!(self.mc ; .arch aarch64 ; str xzr, [x29, gcmap_ofs]);
-        // Restore x2..x13, x19, x20 from jitframe slots (GC may have
+        // Restore x2..x13, x19..x22 from jitframe slots (GC may have
         // updated the stored pointers). x0 keeps the allocated payload ptr.
         let base_ofs_r = crate::jitframe::FIRST_ITEM_OFFSET as i32;
         dynasm!(self.mc ; .arch aarch64
@@ -5980,6 +5984,7 @@ impl<'a> AssemblerARM64<'a> {
             ; ldp x10, x11, [x29, base_ofs_r + 10 * 8]
             ; ldp x12, x13, [x29, base_ofs_r + 12 * 8]
             ; ldp x19, x20, [x29, base_ofs_r + 14 * 8]
+            ; ldp x21, x22, [x29, base_ofs_r + 16 * 8]
         );
         // `dynasm_nursery_slowpath` returns x0 = 0 on real host OOM
         // (calloc failure preserved as NULL per runner.rs).  Route

--- a/majit/majit-backend-dynasm/src/aarch64/regalloc.rs
+++ b/majit/majit-backend-dynasm/src/aarch64/regalloc.rs
@@ -32,7 +32,7 @@ fn check_imm_box(arg: OpRef) -> bool {
 }
 
 /// aarch64/registers.py:14
-///   `all_regs = registers[:14] + [x19, x20] #, x21, x22]`
+///   `all_regs = registers[:14] + [x19, x20, x21, x22]`
 pub fn all_core_regs() -> Vec<RegLoc> {
     registers::ALL_REGS.to_vec()
 }
@@ -74,12 +74,14 @@ pub fn call_result_fpr() -> RegLoc {
 /// `all_core_regs` list — used by gcmap and jitframe slot tables.
 ///
 /// aarch64 mapping (matches `all_core_regs`):
-///   x0..x13 → 0..13, x19 → 14, x20 → 15.
+///   x0..x13 → 0..13, x19 → 14, x20 → 15, x21 → 16, x22 → 17.
 pub fn core_reg_index(reg: RegLoc) -> Option<usize> {
     match reg.value {
         0..=13 => Some(reg.value as usize),
         19 => Some(14),
         20 => Some(15),
+        21 => Some(16),
+        22 => Some(17),
         _ => None,
     }
 }

--- a/majit/majit-backend-dynasm/src/aarch64/registers.rs
+++ b/majit/majit-backend-dynasm/src/aarch64/registers.rs
@@ -94,9 +94,14 @@ pub const VFPREGISTERS: [RegLoc; 32] = [
 /// registers.py:13 `all_vfp_regs = vfpregisters[:8]`
 pub const ALL_VFP_REGS: [RegLoc; 8] = [D0, D1, D2, D3, D4, D5, D6, D7];
 
-/// registers.py:14 `all_regs = registers[:14] + [x19, x20] #, x21, x22]`
-pub const ALL_REGS: [RegLoc; 16] = [
-    X0, X1, X2, X3, X4, X5, X6, X7, X8, X9, X10, X11, X12, X13, X19, X20,
+/// registers.py:14 `all_regs = registers[:14] + [x19, x20, x21, x22]`
+///
+/// Upstream leaves x21, x22 commented out as the contemplated
+/// extension (`registers[:14] + [x19, x20] #, x21, x22]`); pyre enables
+/// exactly that pair so loop-carried values survive residual calls
+/// without spilling to the jitframe.
+pub const ALL_REGS: [RegLoc; 18] = [
+    X0, X1, X2, X3, X4, X5, X6, X7, X8, X9, X10, X11, X12, X13, X19, X20, X21, X22,
 ];
 
 /// registers.py:16 `lr = x30`
@@ -117,8 +122,9 @@ pub const IP2: RegLoc = X15;
 /// registers.py:24 `ip3 = x14`
 pub const IP3: RegLoc = X14;
 
-/// registers.py:26 `callee_saved_registers = [x19, x20] # , x21, x22]`
-pub const CALLEE_SAVED_REGISTERS: [RegLoc; 2] = [X19, X20];
+/// registers.py:26 `callee_saved_registers = [x19, x20, x21, x22]`
+/// (upstream contemplates x21, x22 as a commented extension; enabled here).
+pub const CALLEE_SAVED_REGISTERS: [RegLoc; 4] = [X19, X20, X21, X22];
 
 /// registers.py:27 `vfp_argument_regs = caller_vfp_resp = all_vfp_regs[:8]`
 pub const VFP_ARGUMENT_REGS: [RegLoc; 8] = ALL_VFP_REGS;
@@ -130,8 +136,8 @@ pub const VFP_IP: RegLoc = D15;
 /// registers.py:34 `argument_regs = [x0, x1, x2, x3, x4, x5, x6, x7]`
 pub const ARGUMENT_REGS: [RegLoc; 8] = [X0, X1, X2, X3, X4, X5, X6, X7];
 
-/// registers.py:35 `callee_resp = [x19, x20] # ,x21, x22]`
-pub const CALLEE_RESP: [RegLoc; 2] = CALLEE_SAVED_REGISTERS;
+/// registers.py:35 `callee_resp = [x19, x20, x21, x22]`
+pub const CALLEE_RESP: [RegLoc; 4] = CALLEE_SAVED_REGISTERS;
 
 /// registers.py:36 `caller_resp = argument_regs + [x8, x9, x10, x11, x12, x13]`
 pub const CALLER_RESP: [RegLoc; 14] = [X0, X1, X2, X3, X4, X5, X6, X7, X8, X9, X10, X11, X12, X13];

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/lower_stmt.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/lower_stmt.rs
@@ -905,6 +905,13 @@ impl<'c> Lowerer<'c> {
         if let Some(()) = self.lower_ref_binding_setfield(expr) {
             return Some(());
         }
+        // Raw native-memory store: `majit_raw_store_i64(base, ea, val);` →
+        // raw_store_i (jtransform.py:1156-1163 rewrite_op_raw_store).  Runs
+        // before the residual-call path so the store lowers to an inline
+        // side-effecting IR op instead of an opaque helper call.
+        if let Some(()) = self.lower_raw_store_stmt(expr) {
+            return Some(());
+        }
         if let Some(()) = self.lower_state_array_write(expr) {
             return Some(());
         }
@@ -1704,6 +1711,55 @@ impl<'c> Lowerer<'c> {
                 quote! { let _ = __builder.live_placeholder(); },
             );
         }
+        Some(())
+    }
+
+    /// Lower a raw native-memory store intrinsic
+    /// `majit_raw_store_i64(base, ea, val)` to a `raw_store_i` op.
+    ///
+    /// RPython parity: an `rffi.raw_storage_setitem(base, offset, value)`
+    /// in the interpreter source is rewritten by
+    /// `jtransform.py:1156-1163 rewrite_op_raw_store` to
+    /// `raw_store_i(base, offset, value, arraydescrof(CArray(T)))`.  Here
+    /// the macro recognizes the kernel's `unsafe` intrinsic by name and
+    /// emits the same op with an 8-byte raw-int array descr
+    /// (`add_raw_int_array_descr`).  The three operands are all int-kind
+    /// (raw address, byte offset, stored value); the op has no result.
+    fn lower_raw_store_stmt(&mut self, expr: &Expr) -> Option<()> {
+        let Expr::Call(call) = expr else {
+            return None;
+        };
+        let segments = canonical_expr_segments(&call.func)?;
+        if segments.last().map(String::as_str) != Some("majit_raw_store_i64") {
+            return None;
+        }
+        if call.args.len() != 3 {
+            return None;
+        }
+        let base = self.lower_value_expr(&call.args[0])?;
+        let ea = self.lower_value_expr(&call.args[1])?;
+        let val = self.lower_value_expr(&call.args[2])?;
+        let (base_reg, ea_reg, val_reg) = (base.reg, ea.reg, val.reg);
+        self.emit_op(
+            OpMeta::linear(
+                OpKind::RawStore,
+                vec![
+                    Register::int(base_reg),
+                    Register::int(ea_reg),
+                    Register::int(val_reg),
+                ],
+                vec![],
+            ),
+            quote! {
+                let __raw_descr = __builder.add_raw_int_array_descr(8);
+                __builder.raw_store_i(
+                    #base_reg as u16,
+                    #ea_reg as u16,
+                    #val_reg as u16,
+                    __raw_descr,
+                );
+            },
+        );
         Some(())
     }
 

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/lower_value.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/lower_value.rs
@@ -159,12 +159,60 @@ impl<'c> Lowerer<'c> {
                 if let Some(binding) = self.lower_native_int_binop_call(call) {
                     return Some(binding);
                 }
+                // Raw native-memory load intrinsic `majit_raw_load_i64(base, ea)`
+                // → raw_load_i (jtransform.py:1165-1171 rewrite_op_raw_load).
+                if let Some(binding) = self.lower_raw_load_call(call) {
+                    return Some(binding);
+                }
                 self.lower_call_value(call)
             }
             Expr::MethodCall(call) => self.lower_method_call_value(call),
             Expr::Struct(s) => self.lower_struct_value(s),
             _ => None,
         }
+    }
+
+    /// Lower a raw native-memory load intrinsic
+    /// `majit_raw_load_i64(base, ea)` to a `raw_load_i` op (the read-side
+    /// analogue of `lower_raw_store_stmt`).  RPython parity:
+    /// `jtransform.py:1165-1171 rewrite_op_raw_load` lowers a
+    /// `rffi.raw_storage_getitem` to `raw_load_i(base, offset,
+    /// arraydescrof(CArray(T)))`.  Both operands are int-kind (raw address,
+    /// byte offset); the op writes an int result.
+    fn lower_raw_load_call(&mut self, call: &syn::ExprCall) -> Option<Binding> {
+        let segments = canonical_expr_segments(&call.func)?;
+        if segments.last().map(String::as_str) != Some("majit_raw_load_i64") {
+            return None;
+        }
+        if call.args.len() != 2 {
+            return None;
+        }
+        let base = self.lower_value_expr(&call.args[0])?;
+        let ea = self.lower_value_expr(&call.args[1])?;
+        let (base_reg, ea_reg) = (base.reg, ea.reg);
+        let dst = self.alloc_reg();
+        self.emit_op(
+            OpMeta::linear(
+                OpKind::RawLoad,
+                vec![Register::int(base_reg), Register::int(ea_reg)],
+                vec![Register::int(dst)],
+            ),
+            quote! {
+                let __raw_descr = __builder.add_raw_int_array_descr(8);
+                __builder.raw_load_i(
+                    #dst as u16,
+                    #base_reg as u16,
+                    #ea_reg as u16,
+                    __raw_descr,
+                );
+            },
+        );
+        Some(Binding {
+            reg: dst,
+            kind: BindingKind::Int,
+            depends_on_stack: base.depends_on_stack || ea.depends_on_stack,
+            struct_type: None,
+        })
     }
 
     /// Lower a struct literal `Path { f0: v0, f1: v1, .. }` to a JIT
@@ -1753,6 +1801,42 @@ mod tests {
         assert!(emitted.contains("setfield_gc_r"));
         assert!(emitted.contains("offset_of"));
         assert!(emitted.contains("size_of"));
+    }
+
+    #[test]
+    fn raw_store_intrinsic_lowers_to_raw_store_i() {
+        // `majit_raw_store_i64(base, ea, val)` lowers to a single RawStore
+        // op reading the three int operands (base, ea, val) and emitting a
+        // `raw_store_i` with an 8-byte raw-int array descr.
+        let mut lowerer = Lowerer::new(None);
+        lowerer
+            .bindings
+            .insert("base".to_string(), binding(3, BindingKind::Int));
+        lowerer
+            .bindings
+            .insert("ea".to_string(), binding(4, BindingKind::Int));
+        lowerer
+            .bindings
+            .insert("val".to_string(), binding(5, BindingKind::Int));
+        let stmt: syn::Stmt =
+            syn::parse_str("majit_raw_store_i64(base, ea, val);").expect("parse raw store");
+
+        lowerer.lower_stmt(&stmt).expect("raw store lowers");
+
+        let kinds: Vec<_> = lowerer.op_metadata.iter().map(|m| m.kind).collect();
+        assert_eq!(kinds, vec![OpKind::RawStore]);
+        assert_eq!(
+            lowerer.op_metadata[0].reads,
+            vec![Register::int(3), Register::int(4), Register::int(5)]
+        );
+        assert!(lowerer.op_metadata[0].writes.is_empty());
+        let emitted = lowerer
+            .statements
+            .iter()
+            .map(ToString::to_string)
+            .collect::<String>();
+        assert!(emitted.contains("raw_store_i"));
+        assert!(emitted.contains("add_raw_int_array_descr"));
     }
 
     #[test]

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/mod.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/mod.rs
@@ -1234,6 +1234,14 @@ pub(super) enum OpKind {
     /// `setfield_gc_{i,r,f}` — store a field through a struct ref.
     /// `reads` carries `[struct_reg, value_reg]`; no writes.
     SetfieldGc,
+    /// `raw_store_i` — store an int into raw native memory at a byte
+    /// offset. `reads` carries `[base_reg, ea_reg, value_reg]` (all int);
+    /// no writes. jtransform.py:1156-1163 `rewrite_op_raw_store`.
+    RawStore,
+    /// `raw_load_i` — load an int from raw native memory at a byte offset.
+    /// `reads` carries `[base_reg, ea_reg]` (int); `writes` carries the
+    /// result reg. jtransform.py:1165-1171 `rewrite_op_raw_load`.
+    RawLoad,
     /// `load_state_*` / `store_state_*` family.
     StateField,
     /// `int_guard_value` / `float_guard_value` / `ref_guard_value`.

--- a/majit/majit-metainterp/src/blackhole.rs
+++ b/majit/majit-metainterp/src/blackhole.rs
@@ -7183,6 +7183,24 @@ pub fn build_inline_call_only_bh_builder() -> BlackholeInterpBuilder {
         "getarrayitem_gc_f_pure/rid>f".to_string(),
         majit_translate::insns::BC_GETARRAYITEM_GC_F_PURE,
     );
+    // `raw_store_i/iiid` — emitted by the wasmi majit kernel's i64 memory
+    // store arms (`majit_raw_store_i64` → `raw_store_i`, the analogue of
+    // RPython `raw_storage_setitem`).  A store's bounds-guard failure (OOB
+    // access) deopts and resumes forward through the dispatch jitcode, so
+    // the blackhole must decode this op; without the map entry
+    // `wire_handler("raw_store_i/iiid", ...)` silently no-ops and the byte
+    // stays unwired, desyncing the blackhole decoder.
+    insns.insert(
+        "raw_store_i/iiid".to_string(),
+        majit_translate::insns::BC_RAW_STORE_I,
+    );
+    // `raw_load_i/iid>i` — the read-side companion the wasmi kernel emits for
+    // the store's out-of-bounds memory-preserving no-op readback.  Same
+    // resume-forward requirement as `raw_store_i` above.
+    insns.insert(
+        "raw_load_i/iid>i".to_string(),
+        majit_translate::insns::BC_RAW_LOAD_I,
+    );
     insns.insert(
         "setarrayitem_gc_i/riid".to_string(),
         majit_translate::insns::BC_SETARRAYITEM_GC_I,

--- a/majit/majit-metainterp/src/jitcode/assembler.rs
+++ b/majit/majit-metainterp/src/jitcode/assembler.rs
@@ -1409,6 +1409,72 @@ impl JitCodeBuilder {
         self.add_gc_int_array_descr(1, false)
     }
 
+    /// Add a descriptor for a `raw_store_i` / `raw_load_i` against raw
+    /// (non-GC-managed) native memory whose items are `item_size` bytes
+    /// wide.  Mirrors `jtransform.py:1160 rewrite_op_raw_store`'s
+    /// `self.cpu.arraydescrof(rffi.CArray(T))`: a flat C array with no
+    /// length header and no GC type tag.  `base_size = 0` and
+    /// `len_offset = None` because a raw address points directly at the
+    /// target byte (the effective address is passed as a byte offset, not
+    /// a scaled index); `is_gc_managed = false` so `make_guards` never
+    /// emits `GUARD_GC_TYPE` against a raw pointer that has no GC header.
+    /// Deduped structurally by `add_bh_descr`.
+    pub fn add_raw_int_array_descr(&mut self, item_size: usize) -> u16 {
+        self.add_bh_descr(CanonicalBhDescr::Array {
+            base_size: 0,
+            itemsize: item_size,
+            len_offset: None,
+            type_id: 0,
+            item_type: majit_ir::value::Type::Int,
+            is_array_of_pointers: false,
+            is_array_of_structs: false,
+            is_item_signed: false,
+            ei_index: u32::MAX,
+            array_type_id: None,
+            interior_fields: Vec::new(),
+            is_gc_managed: false,
+        })
+    }
+
+    /// Emit `raw_load_i/iid>i` (`blackhole.py:1512-1518 bhimpl_raw_load_i`):
+    /// read an int from raw memory at `registers_i[base_reg] +
+    /// registers_i[ea_reg]` (byte offset) into `dst`.  `jtransform.py:1165-1171
+    /// rewrite_op_raw_load` lowers a `raw_storage_getitem` to this op with an
+    /// `arraydescrof(rffi.CArray(T))` descr (`add_raw_int_array_descr`).
+    ///
+    /// Encoding: `[BC_RAW_LOAD_I][base_reg u8][ea_reg u8][descr_idx lo u8]
+    ///             [descr_idx hi u8][dst u8]`.
+    pub fn raw_load_i(&mut self, dst: u16, base_reg: u16, ea_reg: u16, descr_idx: u16) {
+        self.touch_reg(base_reg);
+        self.touch_reg(ea_reg);
+        self.touch_reg(dst);
+        self.write_insn("raw_load_i/iid>i");
+        self.push_reg_u8(base_reg, "raw_load_i base");
+        self.push_reg_u8(ea_reg, "raw_load_i ea");
+        self.push_u16(descr_idx);
+        self.push_reg_u8(dst, "raw_load_i dst");
+    }
+
+    /// Emit `raw_store_i/iiid` (`blackhole.py:1504-1506 bhimpl_raw_store_i`):
+    /// store the int in `value_reg` into raw memory at
+    /// `registers_i[base_reg] + registers_i[ea_reg]` (byte offset).
+    /// `jtransform.py:1156-1163 rewrite_op_raw_store` lowers a Python-level
+    /// `raw_storage_setitem` to this op with an `arraydescrof(rffi.CArray(T))`
+    /// descr (`add_raw_int_array_descr`, `item_size` bytes).
+    ///
+    /// Encoding: `[BC_RAW_STORE_I][base_reg u8][ea_reg u8][value_reg u8]
+    ///             [descr_idx lo u8][descr_idx hi u8]`.
+    pub fn raw_store_i(&mut self, base_reg: u16, ea_reg: u16, value_reg: u16, descr_idx: u16) {
+        self.touch_reg(base_reg);
+        self.touch_reg(ea_reg);
+        self.touch_reg(value_reg);
+        self.write_insn("raw_store_i/iiid");
+        self.push_reg_u8(base_reg, "raw_store_i base");
+        self.push_reg_u8(ea_reg, "raw_store_i ea");
+        self.push_reg_u8(value_reg, "raw_store_i value");
+        self.push_u16(descr_idx);
+    }
+
     /// Add a GC-array descriptor for an integer-element `env` array whose
     /// items are `item_size` bytes wide (`is_item_signed` selects sign- vs
     /// zero-extension on sub-word loads).  Generalizes

--- a/majit/majit-metainterp/src/optimizeopt/intbounds.rs
+++ b/majit/majit-metainterp/src/optimizeopt/intbounds.rs
@@ -2719,6 +2719,51 @@ mod tests {
         );
     }
 
+    /// wasm i32 address-mask sequence: masking an unbounded value with a
+    /// non-negative constant bounds the result to [0, mask], so the
+    /// subsequent IntGe(x, 0) / IntLe(x, mask) precheck guards must fold.
+    #[test]
+    fn test_int_and_mask_prechecks_fold() {
+        const MASK: i64 = 0xFFFF_FFFF; // 4294967295
+        // v9 (int_op 0) is an unbounded input; the mask and the comparison
+        // endpoints are literal Const operands, exactly as in the wasm trace.
+        let initial_bounds = vec![(OpRef::int_op(0), IntBound::unbounded())];
+        let ops = vec![
+            // v74 = IntAnd(v9, 0xFFFFFFFF)
+            make_op(
+                OpCode::IntAnd,
+                &[OpRef::int_op(0), OpRef::const_int(MASK)],
+                2,
+            ),
+            // v340 = IntGe(v74, 0); GuardTrue(v340)
+            make_op(OpCode::IntGe, &[OpRef::int_op(2), OpRef::const_int(0)], 3),
+            make_op(OpCode::GuardTrue, &[OpRef::int_op(3)], 5),
+            // v341 = IntLe(v74, 0xFFFFFFFF); GuardTrue(v341)
+            make_op(
+                OpCode::IntLe,
+                &[OpRef::int_op(2), OpRef::const_int(MASK)],
+                6,
+            ),
+            make_op(OpCode::GuardTrue, &[OpRef::int_op(6)], 8),
+        ];
+        let (result, mut ctx) = run_pass_with_bounds(&ops, &initial_bounds);
+        // The AND result must carry the [0, MASK] bound.
+        let b = {
+            let __mb = ctx.materialize_operand_at(OpRef::int_op(2));
+            ctx.getintbound_handle(&__mb).borrow().clone()
+        };
+        assert_eq!(b.lower, 0, "AND result lower should be 0");
+        assert_eq!(b.upper, MASK, "AND result upper should be MASK");
+        // Both precheck comparisons and their guards must be gone.
+        assert!(
+            result.iter().all(|op| op.opcode != OpCode::IntGe
+                && op.opcode != OpCode::IntLe
+                && op.opcode != OpCode::GuardTrue),
+            "precheck guards should fold away, got {:?}",
+            result.iter().map(|o| o.opcode).collect::<Vec<_>>()
+        );
+    }
+
     /// autogenintrules.py rule or_known_result: int_or(a, b) where the OR
     /// of bounds is a single constant => fold to that constant.
     #[test]

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -3540,11 +3540,15 @@ impl OptContext {
         //   * non-input non-Const with forwarded info → also append the
         //     arg op to `self.short` (handled by the builder's `use_box`
         //     dependency walk at shortpreamble.rs:1660-1688), emit
-        //     guards, AND clear the slot to prevent double-emission.
+        //     guards, AND clear the replay op's marker to prevent double-emission.
         //
-        // pyre's `take_preamble_forwarded_opinfo` is the take-clear
-        // primitive matching `arg.set_forwarded(None)`. We use it for the
-        // non-input branch only; input args use the read-only snapshot.
+        // RPython's non-input `arg` is the replay ResOperation object, while
+        // its live body Box keeps separate optimizer info. In pyre's flat-OpRef
+        // model the IntBound/PtrInfo lives in the canonical operand forwarding
+        // slot, so clearing that slot here would drop live body facts before
+        // loop-close virtualstate.py:491-492 can see them. The builder consumes
+        // the replay op's own marker (`Op.forwarded`) at shortpreamble.rs:2116
+        // to mirror `arg.set_forwarded(None)` without clearing optimizer info.
         enum ForwardedInfo {
             // shortpreamble.py:376-379 EmptyInfo / empty_info sentinel.
             // Its presence is meaningful for short-preamble dedup, but it
@@ -3600,8 +3604,8 @@ impl OptContext {
             is_input: bool,
         }
         let mut arg_entries: Vec<ArgEntry> = Vec::new();
-        for arg in preamble_op.getarglist().iter() {
-            let arg = arg.to_opref();
+        for arg_operand in preamble_op.getarglist().iter() {
+            let arg = arg_operand.to_opref();
             // Branch 1: shortpreamble.py:384 `isinstance(arg, Const): continue`.
             if arg.is_constant() || arg.is_none() {
                 continue;
@@ -3615,12 +3619,20 @@ impl OptContext {
                 arg,
                 OpRef::InputArgInt(_) | OpRef::InputArgFloat(_) | OpRef::InputArgRef(_)
             );
-            if let Some(info) = snapshot_forwarded(self, arg) {
-                arg_entries.push(ArgEntry {
-                    arg,
-                    info,
-                    is_input,
-                });
+            let has_replay_marker = arg_operand.bound_op().is_some_and(|op| {
+                !matches!(
+                    &*op.forwarded.borrow(),
+                    majit_ir::forwarding::Forwarded::None
+                )
+            });
+            if is_input || has_replay_marker {
+                if let Some(info) = snapshot_forwarded(self, arg) {
+                    arg_entries.push(ArgEntry {
+                        arg,
+                        info,
+                        is_input,
+                    });
+                }
             }
             // shortpreamble.py:391 `elif arg.get_forwarded() is None: pass`
             // is the no-info branch; falling out of `snapshot_forwarded`
@@ -3630,16 +3642,7 @@ impl OptContext {
             snapshot_forwarded(self, preamble_op.pos.get())
                 .map(|info| (preamble_op.pos.get(), info));
 
-        // Phase 2 (mutable): clear non-input arg slots — PyPy
-        // `arg.set_forwarded(None)` (shortpreamble.py:397). Branch 2 (input
-        // args) keeps its info; branch 3 (non-input) clears.
-        for entry in &arg_entries {
-            if !entry.is_input {
-                let _ = self.take_preamble_forwarded_opinfo(entry.arg);
-            }
-        }
-
-        // Phase 3: generate guards — `make_guards` takes `&mut self`
+        // Phase 2: generate guards — `make_guards` takes `&mut self`
         // directly. Constants seed via reserve_const_ref + seed_constant
         // (mirroring `ConstInt` / `ConstPtr` inline construction); producer
         // OpRefs come from `alloc_op_position_typed`.

--- a/majit/majit-metainterp/src/optimizeopt/unroll.rs
+++ b/majit/majit-metainterp/src/optimizeopt/unroll.rs
@@ -4235,7 +4235,27 @@ impl OptUnroll {
             // a snapshot. Matches PyPy `_forwarded` reference passing.
             return Some(OpInfo::Ptr(handle));
         }
-        // TODO: read from `exported_int_bounds`
+        // unroll.py:443-454 `_expand_info` calls `self.optimizer.getinfo(arg)`
+        // for EVERY exported value with no jump-arg restriction, so an int-typed
+        // value's bound is read straight off its `_forwarded` slot
+        // (`getintbound`). Read the live bound from the still-alive Phase-1
+        // optimizer context; this recovers the `[0, mask]` bound of a masked
+        // short-preamble / loop-invariant pure result that is not a jump arg and
+        // therefore never entered the `exported_int_bounds` side table. Mirror
+        // `export_arg_int_bounds` (intbounds.rs): skip Const/non-Int values and
+        // unbounded bounds.
+        if let Some(box_op) = resolved_box.as_ref() {
+            if !resolved.is_constant()
+                && matches!(ctx.opref_type(resolved), Some(majit_ir::Type::Int))
+            {
+                if let Some(bound) = ctx.peek_intbound_box(box_op) {
+                    if !bound.is_unbounded() {
+                        return Some(OpInfo::int_bound(bound));
+                    }
+                }
+            }
+        }
+        // Fallback: read from `exported_int_bounds`
         // side table.  RPython's `IntBound` flows through
         // `OptInfo.IntBound` on the Box itself
         // (`optimizeopt/info.py:580 IntBoundInfo`), so successive peeling
@@ -6572,6 +6592,59 @@ mod tests {
             ctx2.getintbound_handle(&__mb).borrow().clone()
         };
         assert_eq!((imported_bound.lower, imported_bound.upper), (10, 20));
+    }
+
+    #[test]
+    fn test_exported_state_reads_live_bound_for_non_jumparg() {
+        // unroll.py:443-454 `_expand_info` calls `self.optimizer.getinfo(arg)`
+        // for EVERY exported value with no jump-arg restriction. A masked pure
+        // result (`IntAnd(x, mask)`) that is a short-preamble / loop-invariant
+        // value is not a jump arg, so its `[0, mask]` IntBound never enters the
+        // `exported_int_bounds` side table (populated only from
+        // `jump.getarglist()`). The live bound must still be exported by reading
+        // it directly from the Phase-1 optimizer context.
+        let mut optimizer = crate::optimizeopt::optimizer::Optimizer::new();
+        use crate::optimizeopt::intutils::IntBound;
+        const MASK: i64 = 0xFFFF_FFFF;
+
+        let mut ctx = crate::optimizeopt::OptContext::with_num_inputs(4, 0);
+        // Bind the export-input position at its source (a forced end-arg is a
+        // bound box in production).
+        ctx.materialize_operand_at(OpRef::int_op(21));
+        let box21 = ctx
+            .get_box_replacement_operand_opt(OpRef::int_op(21))
+            .expect("int_op(21) bound to a box");
+        // The bound lives on the box's `_forwarded` slot (as it does after
+        // `IntAnd` narrows it), but it is NOT registered in the side table —
+        // exactly the state of a non-jump-arg short-box result.
+        ctx.setintbound(&box21, &IntBound::bounded(0, MASK));
+
+        // `None` side table → current code has no way to recover the bound and
+        // drops it; the live-bound read must surface it.
+        let exported = export_state(
+            &[OpRef::int_op(21)],
+            &[],
+            &mut optimizer,
+            &mut ctx,
+            None,
+        );
+
+        assert_eq!(
+            match exported
+                .exported_infos
+                .iter()
+                .find(|(k, _)| k.to_opref() == OpRef::int_op(21))
+                .map(|(_, v)| v)
+            {
+                Some(crate::optimizeopt::info::OpInfo::IntBound(b)) => {
+                    let b = b.borrow();
+                    Some((b.lower, b.upper))
+                }
+                _ => None,
+            },
+            Some((0, MASK)),
+            "live [0, MASK] bound on a non-jump-arg short-box result must be exported"
+        );
     }
 
     #[test]

--- a/majit/majit-metainterp/src/optimizeopt/unroll.rs
+++ b/majit/majit-metainterp/src/optimizeopt/unroll.rs
@@ -6621,13 +6621,7 @@ mod tests {
 
         // `None` side table → current code has no way to recover the bound and
         // drops it; the live-bound read must surface it.
-        let exported = export_state(
-            &[OpRef::int_op(21)],
-            &[],
-            &mut optimizer,
-            &mut ctx,
-            None,
-        );
+        let exported = export_state(&[OpRef::int_op(21)], &[], &mut optimizer, &mut ctx, None);
 
         assert_eq!(
             match exported

--- a/majit/majit-metainterp/src/optimizeopt/unroll.rs
+++ b/majit/majit-metainterp/src/optimizeopt/unroll.rs
@@ -6642,6 +6642,116 @@ mod tests {
     }
 
     #[test]
+    fn test_short_box_dependency_preserves_mask_bound_for_loop_close() {
+        // RPython keeps the replay op's `_forwarded` info separate from the
+        // body Box's optimizer info. A preamble-computed masked pure value can
+        // therefore be used by another short-box replay op without losing the
+        // live `[0, MASK]` IntBound needed by virtualstate.py:491-492 to avoid
+        // loop-close re-establishment guards.
+        use crate::optimizeopt::intutils::IntBound;
+        use crate::optimizeopt::shortpreamble::{
+            PreambleOpKind, ProducedShortOp, ShortPreambleBuilder,
+        };
+        use crate::optimizeopt::virtualstate::{VirtualState, VirtualStateInfo};
+        const MASK: i64 = 0xFFFF_FFFF;
+
+        let masked = OpRef::int_op(58);
+        let dependent = OpRef::int_op(59);
+        let mut ctx =
+            crate::optimizeopt::OptContext::with_inputarg_types(128, &vec![Type::Int; 128]);
+
+        let mask_op = {
+            let mut op = Op::new(
+                OpCode::IntAnd,
+                &[
+                    rooted_inputarg_operand(Type::Int, 8),
+                    Operand::from_opref(OpRef::const_int(MASK)),
+                ],
+            );
+            op.pos.set(masked);
+            std::rc::Rc::new(op)
+        };
+        let dep_op = {
+            let mut op = Op::new(
+                OpCode::IntAdd,
+                &[
+                    Operand::from_bound_op(&mask_op),
+                    Operand::from_opref(OpRef::const_int(2160)),
+                ],
+            );
+            op.pos.set(dependent);
+            std::rc::Rc::new(op)
+        };
+        let mask_box = ctx.materialize_operand_at(masked);
+        let dep_box = ctx.materialize_operand_at(dependent);
+        ctx.setintbound(&mask_box, &IntBound::bounded(0, MASK));
+        ctx.imported_short_preamble_builder = Some(ShortPreambleBuilder::new(
+            &[masked, dependent],
+            &[
+                (
+                    mask_box.clone(),
+                    ProducedShortOp {
+                        kind: PreambleOpKind::Pure,
+                        res: mask_box.clone(),
+                        preamble_op: mask_op.clone(),
+                        invented_name: false,
+                        same_as_source: None,
+                        label_arg_idx: Some(0),
+                    },
+                ),
+                (
+                    dep_box.clone(),
+                    ProducedShortOp {
+                        kind: PreambleOpKind::Pure,
+                        res: dep_box.clone(),
+                        preamble_op: dep_op.clone(),
+                        invented_name: false,
+                        same_as_source: None,
+                        label_arg_idx: Some(1),
+                    },
+                ),
+            ],
+            &[OpRef::input_arg_int(8)],
+        ));
+
+        let mask_pop = crate::optimizeopt::info::PreambleOp {
+            op: mask_box.clone(),
+            invented_name: false,
+            preamble_op: mask_op.clone(),
+            same_as_source: None,
+        };
+        let dep_pop = crate::optimizeopt::info::PreambleOp {
+            op: dep_box,
+            invented_name: false,
+            preamble_op: dep_op,
+            same_as_source: None,
+        };
+        assert_eq!(ctx.force_op_from_preamble_op(&mask_pop), masked);
+        assert_eq!(ctx.force_op_from_preamble_op(&dep_pop), dependent);
+
+        let target_vs = VirtualState::new(vec![VirtualStateInfo::IntBounded(IntBound::bounded(
+            0, MASK,
+        ))]);
+        let incoming_vs = crate::optimizeopt::virtualstate::export_state(&[masked], &ctx);
+        let runtime_box = ctx.make_constant_int(0);
+        let guard_reqs = target_vs
+            .generate_guards(&incoming_vs, &[masked], &[runtime_box], &mut ctx, false)
+            .expect("masked short-box state should match target loop state");
+        let mut emitted = Vec::new();
+        for req in &guard_reqs {
+            emitted.extend(req.to_ops(&[masked], &mut ctx));
+        }
+
+        assert!(
+            emitted
+                .iter()
+                .all(|op| !matches!(op.opcode, OpCode::IntGe | OpCode::IntLe | OpCode::GuardTrue)),
+            "loop close must not emit IntBound re-establishment guards for masked short-box arg: {:?}",
+            emitted.iter().map(|op| op.opcode).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
     fn test_export_state_uses_forced_end_args_snapshot() {
         let mut optimizer = crate::optimizeopt::optimizer::Optimizer::new();
         let mut ctx = crate::optimizeopt::OptContext::with_inputarg_types(4, &[Type::Ref]);

--- a/majit/majit-metainterp/src/pyjitpl/dispatch.rs
+++ b/majit/majit-metainterp/src/pyjitpl/dispatch.rs
@@ -2725,6 +2725,125 @@ where
                     unsafe { *((struct_ptr as *mut u8).add(offset) as *mut i64) = concrete };
                 }
             }
+            jitcode::insns::BC_RAW_STORE_I => {
+                // blackhole.py:1504-1506 bhimpl_raw_store_i: store an int
+                // into raw native memory at `base + ea` (byte offset).
+                // jtransform.py:1156-1163 rewrite_op_raw_store lowers a
+                // `raw_storage_setitem` to this op with an
+                // `arraydescrof(rffi.CArray(T))` descr. Record RawStore and
+                // perform the concrete store through the live raw address
+                // while tracing (metainterp executes as it records — the
+                // store side effect is the actual write for this iteration,
+                // mirroring BC_GETARRAYITEM_GC_I's concrete read).
+                //
+                // Encoding (`assembler.rs raw_store_i`):
+                //   [BC_RAW_STORE_I][base_reg u8][ea_reg u8][value_reg u8]
+                //   [descr_idx u16]
+                let (base_reg, ea_reg, value_reg, descr_idx) = {
+                    let frame = self.frames.current_mut();
+                    let base_reg = frame.next_u8() as usize;
+                    let ea_reg = frame.next_u8() as usize;
+                    let value_reg = frame.next_u8() as usize;
+                    let descr_idx = frame.next_u16() as usize;
+                    (base_reg, ea_reg, value_reg, descr_idx)
+                };
+                let Some(descr) = self.dispatch_array_descr_ref(ctx, descr_idx) else {
+                    return TraceAction::Abort;
+                };
+                let Some((_base_size, itemsize, _is_signed)) =
+                    self.dispatch_array_geometry(descr_idx)
+                else {
+                    return TraceAction::Abort;
+                };
+                let (base_opref, base_addr) = self.read_int_reg(base_reg);
+                let (ea_opref, ea_value) = self.read_int_reg(ea_reg);
+                let (value_opref, value) = self.read_int_reg(value_reg);
+                // pyjitpl.py:2693-2694 `_record_helper` invalidates the
+                // heapcache before recording a side-effecting op so a later
+                // `raw_load` at the same `(base, ea)` re-reads instead of
+                // folding a stale cached value.
+                ctx.heapcache_invalidate_caches_varargs(
+                    OpCode::RawStore,
+                    None,
+                    &[base_opref, ea_opref, value_opref],
+                );
+                ctx.record_op_with_descr(
+                    OpCode::RawStore,
+                    &[base_opref, ea_opref, value_opref],
+                    descr,
+                );
+                // Concrete eval: descriptor-sized store at `base + ea`
+                // (`ea` is already a byte offset — `emit_dynamic_offset_addr`
+                // in the backend adds it to `base` unscaled).
+                //
+                // SAFETY: `base_addr + ea_value` was bounds-checked by the
+                // guard that the JitCode's bounds-check `if` lowered to (this
+                // op is only reached on the in-bounds path); the address is
+                // within the outer interpreter's linear-memory allocation.
+                let item_addr = (base_addr as usize).wrapping_add(ea_value as usize);
+                unsafe {
+                    match itemsize {
+                        1 => *(item_addr as *mut u8) = value as u8,
+                        2 => *(item_addr as *mut u16) = value as u16,
+                        4 => *(item_addr as *mut u32) = value as u32,
+                        8 => *(item_addr as *mut i64) = value,
+                        other => {
+                            panic!("BC_RAW_STORE_I: unsupported itemsize {}", other)
+                        }
+                    }
+                }
+            }
+            jitcode::insns::BC_RAW_LOAD_I => {
+                // blackhole.py:1512-1518 bhimpl_raw_load_i: read an int from
+                // raw native memory at `base + ea` (byte offset). jtransform.py:
+                // 1165-1171 rewrite_op_raw_load lowers a `raw_storage_getitem`
+                // to this op with an `arraydescrof(rffi.CArray(T))` descr.
+                // Record RawLoadI and perform the concrete read while tracing.
+                //
+                // Encoding (`assembler.rs raw_load_i`):
+                //   [BC_RAW_LOAD_I][base_reg u8][ea_reg u8][descr_idx u16][dst u8]
+                let (base_reg, ea_reg, descr_idx, dst) = {
+                    let frame = self.frames.current_mut();
+                    let base_reg = frame.next_u8() as usize;
+                    let ea_reg = frame.next_u8() as usize;
+                    let descr_idx = frame.next_u16() as usize;
+                    let dst = frame.next_u8() as usize;
+                    (base_reg, ea_reg, descr_idx, dst)
+                };
+                let Some(descr) = self.dispatch_array_descr_ref(ctx, descr_idx) else {
+                    return TraceAction::Abort;
+                };
+                let Some((_base_size, itemsize, is_signed)) =
+                    self.dispatch_array_geometry(descr_idx)
+                else {
+                    return TraceAction::Abort;
+                };
+                let (base_opref, base_addr) = self.read_int_reg(base_reg);
+                let (ea_opref, ea_value) = self.read_int_reg(ea_reg);
+                let opref =
+                    ctx.record_op_with_descr(OpCode::RawLoadI, &[base_opref, ea_opref], descr);
+                // Concrete eval: descriptor-sized read at `base + ea`.
+                //
+                // SAFETY: the kernel clamps `ea` to an in-bounds byte offset
+                // (0 when the access would trap), so `base_addr + ea_value`
+                // is within the linear-memory allocation.
+                let item_addr = (base_addr as usize).wrapping_add(ea_value as usize);
+                let concrete = unsafe {
+                    match (itemsize, is_signed) {
+                        (1, true) => *(item_addr as *const i8) as i64,
+                        (1, false) => *(item_addr as *const u8) as i64,
+                        (2, true) => *(item_addr as *const i16) as i64,
+                        (2, false) => *(item_addr as *const u16) as i64,
+                        (4, true) => *(item_addr as *const i32) as i64,
+                        (4, false) => *(item_addr as *const u32) as i64,
+                        (8, _) => *(item_addr as *const i64),
+                        other => {
+                            panic!("BC_RAW_LOAD_I: unsupported (itemsize, signed) = {:?}", other)
+                        }
+                    }
+                };
+                self.set_int_reg(dst, Some(opref), Some(concrete));
+            }
             jitcode::insns::BC_GETFIELD_GC_I
             | jitcode::insns::BC_GETFIELD_GC_R
             | jitcode::insns::BC_GETFIELD_GC_I_PURE

--- a/majit/majit-metainterp/src/pyjitpl/dispatch.rs
+++ b/majit/majit-metainterp/src/pyjitpl/dispatch.rs
@@ -2838,7 +2838,10 @@ where
                         (4, false) => *(item_addr as *const u32) as i64,
                         (8, _) => *(item_addr as *const i64),
                         other => {
-                            panic!("BC_RAW_LOAD_I: unsupported (itemsize, signed) = {:?}", other)
+                            panic!(
+                                "BC_RAW_LOAD_I: unsupported (itemsize, signed) = {:?}",
+                                other
+                            )
                         }
                     }
                 };

--- a/majit/majit-translate/src/codewriter/insns.rs
+++ b/majit/majit-translate/src/codewriter/insns.rs
@@ -491,6 +491,13 @@ pub const BC_SETFIELD_GC_I_C: u8 = 222;
 // form.
 pub const BC_SETARRAYITEM_GC_I_C: u8 = 227;
 
+// `raw_store_i/iiid` — `blackhole.py:1504-1506 bhimpl_raw_store_i`
+// (`@arguments("cpu", "i", "i", "i", "d")`): raw address + byte offset +
+// int value + `arraydescrof(rffi.CArray(T))` (`jtransform.py:1156-1163
+// rewrite_op_raw_store`).  Sibling of the read-side `BC_RAW_LOAD_I` (20);
+// takes the next free byte.
+pub const BC_RAW_STORE_I: u8 = 228;
+
 // pyre-only `abort/>r` — Ref-result variant of `abort/` (BC_ABORT = 13)
 // emitted by `Assembler::encode_op`'s default branch when an `OpKind::
 // Abort { result_kind: Ref }` reaches the assembler.  Lives in
@@ -1053,6 +1060,12 @@ pub fn wellknown_bh_insns() -> IndexMap<&'static str, u8> {
     // returns="i"|"f")`): addr + offset + arraydescr.
     m.insert("raw_load_i/iid>i", BC_RAW_LOAD_I);
     m.insert("raw_load_f/iid>f", BC_RAW_LOAD_F);
+
+    // Raw memory store — `blackhole.py:1504-1509`
+    // `bhimpl_raw_store_{i,f}` (`@arguments("cpu", "i", "i", "i"|"f",
+    // "d")`): raw address + byte offset + value + arraydescr.  The
+    // handler is wired in `blackhole.rs` (`handler_raw_store_i`).
+    m.insert("raw_store_i/iiid", BC_RAW_STORE_I);
 
     // GC indexed load — `blackhole.py:1519-1525`
     // `bhimpl_gc_load_indexed_{i,f}` (`@arguments("cpu", "r", "i", "i",

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -1885,6 +1885,23 @@ pub fn lower_fun_decl_with_static_addrs(
 ///   removal to keep untouched graphs byte-identical.
 fn simplify_lowered_graph(graph: &mut FunctionGraph) {
     crate::model::eliminate_empty_blocks(graph);
+    // `eliminate_empty_blocks` (simplify.py:33-78) rewires each incoming
+    // link past an operation-less block and leaves the bypassed block
+    // orphaned, still carrying its exits.  Upstream every later consumer
+    // walks the graph through `iterblocks()` (flowspace/model.py:66), so
+    // the orphan and its stale links are invisible; the model-layer
+    // passes below scan `graph.blocks` directly, so the stale links stay
+    // in view — `prune_dead_phis` then trims a shared reachable target's
+    // dead inputargs without trimming the orphan's link
+    // (transform_dead_op_vars walks reachable blocks only), the
+    // arity-desynced link misaligns `remove_duplicate_inputargs`'s
+    // positional phi columns, and the legacy annotator's link fold
+    // (`follow_link`, annrpython.py binding propagation) unions the
+    // shifted kinds into live phi inputargs — surfacing as an
+    // assembler Int/Ref register-kind mismatch.  Empty the orphans
+    // eagerly so the direct-scan passes see the same surface
+    // `iterblocks()` exposes upstream.
+    crate::model::clear_unreachable_blocks(graph);
     // Lower the boxing-constructor idiom `malloc_typed(W_FloatObject{…})`
     // to a native `NewWithVtable` + payload store before the dead-aggregate
     // sweep, which then reclaims the orphaned construct-on-stack ctor and


### PR DESCRIPTION
Optimizer, codewriter, and backend groundwork developed while bringing the out-of-tree wasmi majit tier's `int_loop` steady-state trace to parity-tight form (loop body 44 → 40 ops, residual `CallI` count 0). Everything in this PR is engine-agnostic majit/front work verified on the regular pyre gate; the wasmi kernel itself lives in the separate wasmi repository and is not part of this PR.

## Commits

- **optimizeopt: regression-test IntAnd mask-precheck guard folding** — test-only. Asserts `IntBound::and_bound` already bounds `IntAnd(x, c)` to `[0, c]` so the wasm address-mask precheck guards (`IntGe`/`IntLe` + `GuardTrue`) const-fold away.
- **optimizeopt: export live int bounds for non-jump-arg values across loop label** — `collect_exported_info` recovered int bounds only from the `exported_int_bounds` side table (populated from `jump.getarglist()`), so a masked pure result that is a short-preamble value but not a jump arg lost its `[0, mask]` bound across the loop label. Now reads the live bound off the Phase-1 optimizer context, mirroring `_expand_info` (unroll.py:443-454) which calls `getinfo(arg)` for every exported value.
- **front: clear unreachable blocks after `eliminate_empty_blocks`** — upstream consumers traverse via `iterblocks()` (flowspace/model.py:66) so orphaned blocks are invisible; our model-layer passes scan `graph.blocks` directly and desynced a bypassed block's link arity, ultimately mistyping an Int phi as GcRef (census abort in `pyre-jit-trace` build.rs). Empties orphans eagerly so direct-scan passes see the same surface.
- **dynasm/aarch64: enable callee-saved x21/x22 in the register allocator** — enables exactly the pair upstream leaves commented out in `rpython/jit/backend/aarch64/registers.py` (`all_regs = registers[:14] + [x19, x20] #, x21, x22]`), so loop-carried values survive residual calls without jitframe spills. `NUM_MANAGED_REGS` 16 → 18, `JITFRAME_FIXED_SIZE` → 26, prologue/epilogue and malloc-slowpath save/restore updated.
- **majit: lower wasm memory store to inline raw-store in traces** — adds `raw_store_i` lowering/tracing/blackhole support (jtransform.py `rewrite_op_raw_store`, blackhole.py:1504-1506 `bhimpl_raw_store_i`) so a hot i64 memory store becomes an inline branchless bounds-check + `RawStore` instead of a residual `mem_store_i64_sf` `CallI`.
- **Preserve short-preamble IntBounds across dependency guards** — a dependent short-box replay cleared the canonical live forwarding slot (holding the IntBound) of its operand; RPython clears only the replay op's marker (shortpreamble.py:390-397). With the bound preserved, loop-close `generate_guards` takes the `contains_bound` early return (virtualstate.py:491-492) and stops emitting tautological re-establishment guard pairs in the loop body.
- two `fmt` commits (rustfmt).

## Verification

- `cargo fmt --check` clean.
- `cargo test --release` on `majit-metainterp` (`--features dynasm`), `majit-macros` (`--features dynasm`), `majit-backend-dynasm`, `majit-translate`: all green.
- `pyre/check.py`: ALL PASSED — dynasm 161/161, cranelift 161/161, wasm 161/161.
- On the wasmi tier (out-of-tree kernel): `int_loop` output correct (`19999999900000000`), steady-state loop body 40 ops with `RawStore=2`, `RawLoadI=2`, `CallI=0`; the loop-close `IntGe`/`IntLe` guard pairs are gone from the trace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
