### PR TITLE
majit-translate: deterministic annotator ordering (IndexMap + monotonic DescKey)

### DIFF
--- a/majit/majit-translate/src/annotator/bookkeeper.rs
+++ b/majit/majit-translate/src/annotator/bookkeeper.rs
@@ -25,8 +25,8 @@
 //!   mirrored on the Rust bookkeeper; reachable only from rtyper-phase
 //!   consumers.
 
-use std::cell::RefCell;
 use indexmap::{IndexMap, IndexSet};
+use std::cell::RefCell;
 use std::collections::{HashMap, HashSet};
 use std::rc::{Rc, Weak};
 

--- a/majit/majit-translate/src/annotator/bookkeeper.rs
+++ b/majit/majit-translate/src/annotator/bookkeeper.rs
@@ -26,6 +26,7 @@
 //!   consumers.
 
 use std::cell::RefCell;
+use indexmap::{IndexMap, IndexSet};
 use std::collections::{HashMap, HashSet};
 use std::rc::{Rc, Weak};
 
@@ -205,7 +206,12 @@ pub struct Bookkeeper {
     /// MethodDesc / MethodOfFrozenDesc per bookkeeper.py:353-409. The
     /// Rust port keys directly on [`HostObject`] (which already has
     /// `Arc::ptr_eq` identity) via [`DescEntry`].
-    pub(crate) descs: RefCell<HashMap<HostObject, DescEntry>>,
+    /// `IndexMap`, not `HashMap`: `normalize_class_pbcs` iterates
+    /// `descs.values()` to resolve DescKeys back to `ClassDesc`s and folds
+    /// them into a `commonbase`, feeding classdef numbering.  The key is a
+    /// pointer identity, so only insertion order (IndexMap) is
+    /// reproducible — a `HashMap` would number classdefs run-varyingly.
+    pub(crate) descs: RefCell<IndexMap<HostObject, DescEntry>>,
     /// RPython `self.classdefs = []` (bookkeeper.py:68). Populated by
     /// `ClassDesc._init_classdef` (classdesc.py:672-697). ClassDef
     /// identity is Rc pointer equality — matches upstream's Python
@@ -222,13 +228,20 @@ pub struct Bookkeeper {
     /// RPython `self.classpbc_attr_families = {}` (bookkeeper.py:62) —
     /// lazy `attrname -> UnionFind(ClassAttrFamily)` map materialised by
     /// `get_classpbc_attr_families(attrname)` (bookkeeper.py:447-456).
+    /// `IndexMap`: `normalize_class_pbcs` iterates this map to build the
+    /// commonbase/access-set numbering; upstream is a Python dict.
     pub(crate) classpbc_attr_families:
-        RefCell<HashMap<String, UnionFind<DescKey, Rc<RefCell<ClassAttrFamily>>>>>,
+        RefCell<IndexMap<String, UnionFind<DescKey, Rc<RefCell<ClassAttrFamily>>>>>,
     /// RPython `self.pbc_maximal_call_families = UnionFind(CallFamily)`
     /// (bookkeeper.py:64).
     pub(crate) pbc_maximal_call_families: RefCell<UnionFind<DescKey, Rc<RefCell<CallFamily>>>>,
     /// RPython `self.emulated_pbc_calls = {}` (bookkeeper.py:66).
-    pub(crate) emulated_pbc_calls: RefCell<HashMap<EmulatedPbcCallKey, (SomePBC, Vec<SomeValue>)>>,
+    /// `IndexMap`, not `HashMap`: `compute_at_fixpoint` iterates
+    /// `.values()` to drive `consider_call_site`, and upstream walks
+    /// `emulated_pbc_calls.itervalues()` in dict insertion order.  A
+    /// `HashMap` would consider the emulated calls in a run-varying order,
+    /// perturbing union-seed order and which callee fails first.
+    pub(crate) emulated_pbc_calls: RefCell<IndexMap<EmulatedPbcCallKey, (SomePBC, Vec<SomeValue>)>>,
     /// RPython `bookkeeper._jit_annotation_cache = {}`
     /// (rlib/jit.py:903-914), populated lazily by
     /// `ExtEnterLeaveMarker.compute_result_annotation`.
@@ -527,17 +540,17 @@ impl Bookkeeper {
             position_key: RefCell::new(None),
             listdefs: RefCell::new(HashMap::new()),
             dictdefs: RefCell::new(HashMap::new()),
-            descs: RefCell::new(HashMap::new()),
+            descs: RefCell::new(IndexMap::new()),
             classdefs: RefCell::new(Vec::new()),
             methoddescs: RefCell::new(HashMap::new()),
             frozenpbc_attr_families: RefCell::new(UnionFind::new(|desc: &DescKey| {
                 Rc::new(RefCell::new(FrozenAttrFamily::new(*desc)))
             })),
-            classpbc_attr_families: RefCell::new(HashMap::new()),
+            classpbc_attr_families: RefCell::new(IndexMap::new()),
             pbc_maximal_call_families: RefCell::new(UnionFind::new(|desc: &DescKey| {
                 Rc::new(RefCell::new(CallFamily::new(*desc)))
             })),
-            emulated_pbc_calls: RefCell::new(HashMap::new()),
+            emulated_pbc_calls: RefCell::new(IndexMap::new()),
             _jit_annotation_cache: RefCell::new(HashMap::new()),
             immutable_cache: RefCell::new(HashMap::new()),
             pending_specializations: RefCell::new(Vec::new()),
@@ -600,11 +613,22 @@ impl Bookkeeper {
     /// registry is set (unit-test fixtures), degrading the pass to a
     /// no-op over whatever classdefs already exist.
     pub fn pyre_struct_root_names(&self) -> Vec<String> {
-        self.pyre_struct_fields
+        let mut roots: Vec<String> = self
+            .pyre_struct_fields
             .borrow()
             .as_ref()
             .map(|reg| reg.fields.keys().cloned().collect())
-            .unwrap_or_default()
+            .unwrap_or_default();
+        // `reg.fields` is a `HashMap`, so its `keys()` order varies
+        // run-to-run.  This Vec drives `getuniqueclassdef_for_struct_root`
+        // in `ensure_session`, whose first-touch order assigns the global
+        // `NEXT_CLASSDEF_ID` counter (`get_unique_cdef_id`), and those ids
+        // are the sort witness for the inheritance-id markers.  An unsorted
+        // order therefore makes classdef numbering — and the downstream
+        // annotate/rtype classification — nondeterministic.  Sort for a
+        // stable mint order, matching `pre_register_enum_variant_classes`.
+        roots.sort();
+        roots
     }
 
     /// True when `leaf` is the trait-leaf of a registered dispatch family
@@ -1055,7 +1079,7 @@ impl Bookkeeper {
         &self,
         classdesc: &Rc<RefCell<ClassDesc>>,
         attrname: &str,
-    ) -> Result<HashSet<PositionKey>, AnnotatorError> {
+    ) -> Result<IndexSet<PositionKey>, AnnotatorError> {
         // upstream: `attrdef = clsdesc.classdef.find_attribute(attrname)`
         let classdef = classdesc
             .borrow()
@@ -2994,9 +3018,12 @@ impl Bookkeeper {
             //            for other_key in prev:
             //                if other_key in emulated_pbc_calls:
             //                    del emulated_pbc_calls[other_key]`.
-            emulated_map.remove(&unique_key);
+            // `shift_remove`, not `remove`/`swap_remove`: preserve the
+            // insertion order of the surviving entries so the fixpoint
+            // `values()` walk stays deterministic.
+            emulated_map.shift_remove(&unique_key);
             for key in replace {
-                emulated_map.remove(key);
+                emulated_map.shift_remove(key);
             }
             // upstream: `emulated_pbc_calls[unique_key] = pbc, args_s`.
             emulated_map.insert(unique_key, (pbc.clone(), args_s.to_vec()));

--- a/majit/majit-translate/src/annotator/classdesc.rs
+++ b/majit/majit-translate/src/annotator/classdesc.rs
@@ -694,6 +694,14 @@ impl Attribute {
 /// and exception-class predicates.
 #[derive(Debug)]
 pub struct ClassDesc {
+    /// Stable identity handle, minted once at construction from the
+    /// monotonic `alloc_desc_key()` counter.  Unlike the other Desc
+    /// kinds, `ClassDesc` does not embed a `Desc` base, so it carries
+    /// its own copy.  Keys every family/PBC table entry for this
+    /// classdesc; used instead of `Rc::as_ptr` so the ordering of those
+    /// tables (and the classdef numbering derived from them) is
+    /// reproducible across runs.
+    pub(crate) identity: super::description::DescKey,
     /// RPython `self.pyobj` — the live Python class object.
     pub pyobj: HostObject,
     /// RPython `self.name` — upstream `cls.__module__ + '.' + cls.__name__`.
@@ -735,6 +743,7 @@ impl ClassDesc {
     /// callers use [`Self::new`].
     pub fn new_shell(bookkeeper: &Rc<Bookkeeper>, pyobj: HostObject, name: String) -> Self {
         ClassDesc {
+            identity: super::description::alloc_desc_key(),
             pyobj,
             name,
             basedesc: None,
@@ -907,6 +916,7 @@ impl ClassDesc {
 
         // Build `self` — subsequent mutation flows through interior mutability.
         let me = Rc::new(RefCell::new(ClassDesc {
+            identity: super::description::alloc_desc_key(),
             pyobj: cls.clone(),
             name,
             basedesc,
@@ -1597,8 +1607,7 @@ impl ClassDesc {
         this: &Rc<RefCell<Self>>,
         attrname: &str,
     ) -> Option<Rc<RefCell<super::description::ClassAttrFamily>>> {
-        use super::description::DescKey;
-        let key = DescKey::from_rc(this);
+        let key = this.borrow().identity;
         let bk = this.borrow().bookkeeper.upgrade()?;
         Some(bk.with_classpbc_attr_families(attrname, |uf| {
             let rep = uf.find_rep(key);
@@ -1623,8 +1632,7 @@ impl ClassDesc {
         this: &Rc<RefCell<Self>>,
         attrname: &str,
     ) -> Option<Rc<RefCell<super::description::ClassAttrFamily>>> {
-        use super::description::DescKey;
-        let key = DescKey::from_rc(this);
+        let key = this.borrow().identity;
         let bk = this.borrow().bookkeeper.upgrade()?;
         bk.with_classpbc_attr_families(attrname, |uf| {
             if !uf.contains(&key) {
@@ -1651,16 +1659,15 @@ impl ClassDesc {
         others: &[Rc<RefCell<Self>>],
         attrname: &str,
     ) -> bool {
-        use super::description::DescKey;
         let Some(bk) = this.borrow().bookkeeper.upgrade() else {
             return false;
         };
-        let head_key = DescKey::from_rc(this);
+        let head_key = this.borrow().identity;
         bk.with_classpbc_attr_families(attrname, |uf| {
             let mut rep = uf.find_rep(head_key);
             let mut changed = false;
             for desc in others {
-                let other_key = DescKey::from_rc(desc);
+                let other_key = desc.borrow().identity;
                 let (c, new_rep) = uf.union(rep, other_key);
                 changed |= c;
                 rep = new_rep;
@@ -1948,7 +1955,6 @@ impl ClassDesc {
         s_result: &super::model::SomeValue,
         op_key: Option<super::bookkeeper::PositionKey>,
     ) -> Result<(), super::model::AnnotatorError> {
-        use super::description::DescKey;
         use super::model::SomeValue;
         if descs.is_empty() {
             return Ok(());
@@ -1957,12 +1963,12 @@ impl ClassDesc {
         // `class ClassDesc(Desc)` inheritance collapses into a bare
         // struct here), so `getcallfamily` / `mergecallfamilies` are
         // re-derived against the bookkeeper's pbc_maximal_call_families
-        // UnionFind keyed by `DescKey::from_rc(&classdesc)` — the same
-        // pointer identity upstream `id(desc)` provides.
+        // UnionFind keyed by the classdesc's stored `identity` — the same
+        // stable id upstream `id(desc)` provides.
         let Some(bk) = descs[0].borrow().bookkeeper.upgrade() else {
             return Ok(());
         };
-        let head_key = DescKey::from_rc(&descs[0]);
+        let head_key = descs[0].borrow().identity;
         // upstream: `descs[0].getcallfamily()` — force the family slot
         // to exist so merge has a representative.
         {
@@ -1974,7 +1980,7 @@ impl ClassDesc {
             let mut families = bk.pbc_maximal_call_families.borrow_mut();
             let mut rep = families.find_rep(head_key);
             for other in descs.iter().skip(1) {
-                let other_key = DescKey::from_rc(other);
+                let other_key = other.borrow().identity;
                 let (_changed, new_rep) = families.union(rep, other_key);
                 rep = new_rep;
             }
@@ -3887,8 +3893,8 @@ mod tests {
         a.borrow_mut().basedesc = Some(common.clone());
         let b = make_classdesc(&bk, "pkg.B");
         b.borrow_mut().basedesc = Some(common.clone());
-        let a_key = DescKey::from_rc(&a);
-        let b_key = DescKey::from_rc(&b);
+        let a_key = a.borrow().identity;
+        let b_key = b.borrow().identity;
         // Pre-condition: A and B belong to distinct CallFamilies.
         {
             let mut families = bk.pbc_maximal_call_families.borrow_mut();

--- a/majit/majit-translate/src/annotator/classdesc.rs
+++ b/majit/majit-translate/src/annotator/classdesc.rs
@@ -53,6 +53,7 @@
 //! `__NOT_RPYTHON__`, and `_annspecialcase_`.
 
 use std::cell::RefCell;
+use indexmap::{IndexMap, IndexSet};
 use std::collections::{HashMap, HashSet};
 use std::rc::{Rc, Weak};
 use std::sync::Arc;
@@ -525,8 +526,9 @@ pub struct Attribute {
     ///
     /// Upstream stores positions as tuples of `(FunctionGraph, Block,
     /// op_index)`; the Rust port uses the ported [`PositionKey`]
-    /// identity.
-    pub(crate) read_locations: HashSet<PositionKey>,
+    /// identity.  `IndexSet`: these positions drive `reflowfromposition`
+    /// order during the fixpoint; upstream is a Python dict/set.
+    pub(crate) read_locations: IndexSet<PositionKey>,
 }
 
 impl Attribute {
@@ -542,7 +544,7 @@ impl Attribute {
             s_value: SomeValue::Impossible,
             readonly: true,
             attr_allowed: true,
-            read_locations: HashSet::new(),
+            read_locations: IndexSet::new(),
         }
     }
 
@@ -2206,7 +2208,8 @@ pub struct ClassDef {
     /// RPython `self.attr_sources = {}` — `{name: list-of-sources}`.
     attr_sources: HashMap<String, Vec<AttrSource>>,
     /// RPython `self.read_locations_of__class__ = {}`.
-    pub(crate) read_locations_of_class: HashMap<PositionKey, bool>,
+    /// `IndexMap`: iterated to drive `reflowfromposition`; upstream dict.
+    pub(crate) read_locations_of_class: IndexMap<PositionKey, bool>,
     /// RPython `self.repr = None`. Populated by `rclass.getclassrepr()`
     /// with the cached `ClassRepr` for this classdef.
     pub repr: Option<Arc<ClassRepr>>,
@@ -2303,7 +2306,7 @@ impl ClassDef {
             shortname,
             subdefs: Vec::new(),
             attr_sources: HashMap::new(),
-            read_locations_of_class: HashMap::new(),
+            read_locations_of_class: IndexMap::new(),
             repr: None,
             extra_access_sets: HashMap::new(),
             instances_seen: HashSet::new(),

--- a/majit/majit-translate/src/annotator/classdesc.rs
+++ b/majit/majit-translate/src/annotator/classdesc.rs
@@ -52,8 +52,8 @@
 //! `_mixin_`, `_immutable_fields_`, `__slots__`, `_attrs_`,
 //! `__NOT_RPYTHON__`, and `_annspecialcase_`.
 
-use std::cell::RefCell;
 use indexmap::{IndexMap, IndexSet};
+use std::cell::RefCell;
 use std::collections::{HashMap, HashSet};
 use std::rc::{Rc, Weak};
 use std::sync::Arc;

--- a/majit/majit-translate/src/annotator/description.rs
+++ b/majit/majit-translate/src/annotator/description.rs
@@ -62,21 +62,14 @@ pub type GraphBuilder<'a> = Box<
 pub struct DescKey(pub(crate) usize);
 
 impl DescKey {
-    /// Turn a raw pointer identity into a [`DescKey`]. Used by tests
-    /// and (soon) the Desc constructor in commit 2.
+    /// Turn a raw id into a [`DescKey`]. Test-only.
     #[cfg(test)]
     pub(crate) fn from_raw(id: usize) -> Self {
         DescKey(id)
     }
-
-    /// Compute a DescKey from the identity of an `Rc<T>` pointer — the
-    /// Rust equivalent of Python dict-by-identity keying.
-    pub(crate) fn from_rc<T: ?Sized>(rc: &Rc<T>) -> Self {
-        DescKey(Rc::as_ptr(rc) as *const () as usize)
-    }
 }
 
-fn alloc_desc_key() -> DescKey {
+pub(crate) fn alloc_desc_key() -> DescKey {
     static NEXT_DESC_KEY: AtomicUsize = AtomicUsize::new(1);
     DescKey(NEXT_DESC_KEY.fetch_add(1, Ordering::Relaxed))
 }
@@ -623,17 +616,14 @@ impl FuncDescEntry {
     /// Upstream `MemoDesc(FunctionDesc)` (description.py:395) is one
     /// object with one identity. The Rust port decomposes it into this
     /// wrapper plus a *private* inner base `FunctionDesc` (minted only
-    /// inside `newfuncdesc` and never registered on its own), so the two
-    /// would otherwise carry two identities: `desc_key()` reports the
-    /// MemoDesc (`from_rc`), while `rowkey()` / `getcallfamily()` read
-    /// the inner base's `Desc.identity`. Slave the inner base's identity
-    /// to the MemoDesc here so both coincide — then the PBC set, the
-    /// methoddesc cache key, the call family and the call table all key
-    /// on a single identity, matching upstream where the MemoDesc *is*
-    /// the FunctionDesc (`rowkey()` returns `self`, description.py:365).
+    /// inside `newfuncdesc` and never registered on its own).  Both
+    /// `desc_key()` and
+    /// `rowkey()` now read that inner `base.identity`, so the PBC set,
+    /// the methoddesc cache key, the call family and the call table all
+    /// key on the FunctionDesc's single stable identity — matching
+    /// upstream where the MemoDesc *is* the FunctionDesc (`rowkey()`
+    /// returns `self`, description.py:365).  No slaving needed.
     pub(crate) fn memo(rc: Rc<RefCell<MemoDesc>>) -> Self {
-        let base = rc.borrow().base.clone();
-        base.borrow_mut().base.identity = DescKey::from_rc(&rc);
         FuncDescEntry {
             inner: FuncDescInner::Memo(rc),
         }
@@ -674,11 +664,15 @@ impl FuncDescEntry {
     }
 
     /// `id(desc)` — the identity of the actual desc object (the
-    /// `MemoDesc` itself for a memo, not its base).
+    /// `MemoDesc` itself for a memo, not its base).  Reads the stored
+    /// monotonic `base.identity` rather than `Rc::as_ptr`, so the key —
+    /// and the ordering of every table keyed on it — is reproducible.
+    /// For a memo, `memo()` slaves the inner base's identity to the
+    /// MemoDesc, so both views coincide on one stable id.
     pub(crate) fn desc_key(&self) -> DescKey {
         match &self.inner {
-            FuncDescInner::Plain(rc) => DescKey::from_rc(rc),
-            FuncDescInner::Memo(rc) => DescKey::from_rc(rc),
+            FuncDescInner::Plain(rc) => rc.borrow().base.identity,
+            FuncDescInner::Memo(rc) => rc.borrow().base.borrow().base.identity,
         }
     }
 
@@ -702,16 +696,18 @@ impl DescEntry {
         DescEntry::Func(FuncDescEntry::memo(rc))
     }
 
-    /// RPython `id(desc)` — pointer-identity handle. Used as the dict
-    /// key by `CallFamily.descs`, `FrozenAttrFamily.descs`, and
-    /// `ClassAttrFamily.descs`.
+    /// RPython `id(desc)` — identity handle.  Used as the dict key by
+    /// `CallFamily.descs`, `FrozenAttrFamily.descs`,
+    /// `ClassAttrFamily.descs`, and the `SomePBC.descriptions` set.
+    /// Reads each desc's stored monotonic identity rather than
+    /// `Rc::as_ptr`, so those tables order reproducibly across runs.
     pub(crate) fn desc_key(&self) -> DescKey {
         match self {
             DescEntry::Func(fe) => fe.desc_key(),
-            DescEntry::Method(rc) => DescKey::from_rc(rc),
-            DescEntry::Frozen(rc) => DescKey::from_rc(rc),
-            DescEntry::MethodOfFrozen(rc) => DescKey::from_rc(rc),
-            DescEntry::Class(rc) => DescKey::from_rc(rc),
+            DescEntry::Method(rc) => rc.borrow().base.identity,
+            DescEntry::Frozen(rc) => rc.borrow().base.identity,
+            DescEntry::MethodOfFrozen(rc) => rc.borrow().base.identity,
+            DescEntry::Class(rc) => rc.borrow().identity,
         }
     }
 
@@ -2817,7 +2813,7 @@ impl MethodDesc {
                     &borrowed.name,
                     commonflags.clone(),
                 );
-                replacements.push((DescKey::from_rc(desc), DescEntry::Method(newdesc)));
+                replacements.push((borrowed.base.identity, DescEntry::Method(newdesc)));
             }
         }
         for (old_key, new_entry) in replacements {
@@ -2872,7 +2868,7 @@ impl MethodDesc {
                         continue;
                     };
                     if classdef1.borrow().issubclass(&classdef2) {
-                        remove.push(DescKey::from_rc(desc1));
+                        remove.push(borrowed1.base.identity);
                         break;
                     }
                 }
@@ -4389,8 +4385,10 @@ mod tests {
         );
 
         let mut descs = std::collections::BTreeMap::new();
-        descs.insert(DescKey::from_rc(&base_md), DescEntry::Method(base_md));
-        descs.insert(DescKey::from_rc(&child_md), DescEntry::Method(child_md));
+        let base_key = base_md.borrow().base.identity;
+        let child_key = child_md.borrow().base.identity;
+        descs.insert(base_key, DescEntry::Method(base_md));
+        descs.insert(child_key, DescEntry::Method(child_md));
 
         MethodDesc::simplify_desc_set(&mut descs);
 

--- a/majit/majit-translate/src/annotator/description.rs
+++ b/majit/majit-translate/src/annotator/description.rs
@@ -24,6 +24,7 @@
 //! `Rc::as_ptr` per variant.
 
 use std::cell::RefCell;
+use indexmap::IndexMap;
 use std::collections::HashMap;
 use std::rc::Rc;
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -160,9 +161,12 @@ impl From<String> for GraphCacheKey {
 #[derive(Debug)]
 pub struct CallFamily {
     /// RPython `self.descs = {desc: True}` (description.py:21).
-    pub(crate) descs: HashMap<DescKey, ()>,
+    /// `IndexMap`: `update`/`absorb` fold these in iteration order and
+    /// upstream is a Python dict (insertion order); a `HashMap` would
+    /// seed the phi-merge union in a run-varying order.
+    pub(crate) descs: IndexMap<DescKey, ()>,
     /// RPython `self.calltables = {}` (description.py:22).
-    pub(crate) calltables: HashMap<CallShape, Vec<CallTableRow>>,
+    pub(crate) calltables: IndexMap<CallShape, Vec<CallTableRow>>,
     /// RPython `self.total_calltable_size = 0` (description.py:23).
     pub(crate) total_calltable_size: usize,
     /// RPython `CallFamily.normalized = False` class-level default
@@ -176,11 +180,11 @@ pub struct CallFamily {
 impl CallFamily {
     /// RPython `CallFamily.__init__(desc)` (description.py:20-23).
     pub(crate) fn new(desc: DescKey) -> Self {
-        let mut descs = HashMap::new();
+        let mut descs = IndexMap::new();
         descs.insert(desc, ());
         CallFamily {
             descs,
-            calltables: HashMap::new(),
+            calltables: IndexMap::new(),
             total_calltable_size: 0,
             normalized: false,
             modified: true,
@@ -271,22 +275,23 @@ impl UnionFindInfo for Rc<RefCell<CallFamily>> {
 #[derive(Debug)]
 pub struct FrozenAttrFamily {
     /// RPython `self.descs = {desc: True}` (description.py:79).
-    pub(crate) descs: HashMap<DescKey, ()>,
+    /// `IndexMap`: iteration order feeds `update`/`absorb`; upstream dict.
+    pub(crate) descs: IndexMap<DescKey, ()>,
     /// RPython `self.read_locations = {}` (description.py:80).
-    pub(crate) read_locations: HashMap<super::bookkeeper::PositionKey, ()>,
+    pub(crate) read_locations: IndexMap<super::bookkeeper::PositionKey, ()>,
     /// RPython `self.attrs = {}` (description.py:81).
-    pub(crate) attrs: HashMap<String, SomeValue>,
+    pub(crate) attrs: IndexMap<String, SomeValue>,
 }
 
 impl FrozenAttrFamily {
     /// RPython `FrozenAttrFamily.__init__(desc)` (description.py:78-81).
     pub(crate) fn new(desc: DescKey) -> Self {
-        let mut descs = HashMap::new();
+        let mut descs = IndexMap::new();
         descs.insert(desc, ());
         FrozenAttrFamily {
             descs,
-            read_locations: HashMap::new(),
-            attrs: HashMap::new(),
+            read_locations: IndexMap::new(),
+            attrs: IndexMap::new(),
         }
     }
 
@@ -337,9 +342,11 @@ impl UnionFindInfo for Rc<RefCell<FrozenAttrFamily>> {
 #[derive(Debug)]
 pub struct ClassAttrFamily {
     /// RPython `self.descs = {desc: True}` (description.py:114).
-    pub(crate) descs: HashMap<DescKey, ()>,
+    /// `IndexMap`: iteration order feeds `update`/`absorb` s_value union;
+    /// upstream dict.
+    pub(crate) descs: IndexMap<DescKey, ()>,
     /// RPython `self.read_locations = {}` (description.py:115).
-    pub(crate) read_locations: HashMap<super::bookkeeper::PositionKey, ()>,
+    pub(crate) read_locations: IndexMap<super::bookkeeper::PositionKey, ()>,
     /// RPython `self.s_value = s_ImpossibleValue` (description.py:116).
     pub(crate) s_value: SomeValue,
     /// Upstream sets this dynamically in
@@ -357,11 +364,11 @@ pub struct ClassAttrFamily {
 impl ClassAttrFamily {
     /// RPython `ClassAttrFamily.__init__(desc)` (description.py:113-116).
     pub(crate) fn new(desc: DescKey) -> Self {
-        let mut descs = HashMap::new();
+        let mut descs = IndexMap::new();
         descs.insert(desc, ());
         ClassAttrFamily {
             descs,
-            read_locations: HashMap::new(),
+            read_locations: IndexMap::new(),
             s_value: s_impossible_value(),
             commonbase: None,
         }

--- a/majit/majit-translate/src/annotator/description.rs
+++ b/majit/majit-translate/src/annotator/description.rs
@@ -23,8 +23,8 @@
 //! [`DescEntry`]). [`DescEntry::desc_key`] derives the key from
 //! `Rc::as_ptr` per variant.
 
-use std::cell::RefCell;
 use indexmap::IndexMap;
+use std::cell::RefCell;
 use std::collections::HashMap;
 use std::rc::Rc;
 use std::sync::atomic::{AtomicUsize, Ordering};

--- a/majit/majit-translate/src/tool/algo/unionfind.rs
+++ b/majit/majit-translate/src/tool/algo/unionfind.rs
@@ -31,7 +31,7 @@
 //! `|_| ()`, relying on the no-op `impl UnionFindInfo for ()` to
 //! preserve the upstream absorb-skip semantics.
 
-use std::collections::HashMap;
+use indexmap::IndexMap;
 use std::hash::Hash;
 
 /// RPython `info1.absorb(info2)` (unionfind.py:76) — called by
@@ -54,11 +54,15 @@ where
     K: Eq + Hash + Clone,
 {
     /// RPython `self.link_to_parent` (unionfind.py:8).
-    link_to_parent: HashMap<K, K>,
+    /// `IndexMap`, not `HashMap`: `keys()`/`infos()` iterate these to
+    /// drive commonbase folding and access-set numbering downstream, and
+    /// upstream stores Python dicts (insertion order).  A `HashMap` would
+    /// make that order — and the resulting classification — run-varying.
+    link_to_parent: IndexMap<K, K>,
     /// RPython `self.weight` (unionfind.py:9).
-    weight: HashMap<K, usize>,
+    weight: IndexMap<K, usize>,
     /// RPython `self.root_info` (unionfind.py:11).
-    root_info: HashMap<K, V>,
+    root_info: IndexMap<K, V>,
     /// RPython `self.info_factory` (unionfind.py:10). See module doc
     /// for why the Rust port makes this mandatory.
     info_factory: Box<dyn Fn(&K) -> V>,
@@ -76,9 +80,9 @@ where
         F: Fn(&K) -> V + 'static,
     {
         UnionFind {
-            link_to_parent: HashMap::new(),
-            weight: HashMap::new(),
-            root_info: HashMap::new(),
+            link_to_parent: IndexMap::new(),
+            weight: IndexMap::new(),
+            root_info: IndexMap::new(),
             info_factory: Box::new(info_factory),
         }
     }
@@ -185,13 +189,15 @@ where
         // take both infos out, absorb, and re-insert the merged one
         // onto the chosen new root below. `()` infos no-op via the
         // trait impl, matching the upstream None branch.
-        let mut info1 = self.root_info.remove(&rep1).expect("rep1 info");
-        let info2 = self.root_info.remove(&rep2).expect("rep2 info");
+        // `shift_remove`, not `swap_remove` (IndexMap's `remove`): keep the
+        // insertion order of surviving entries stable for the `infos()` walk.
+        let mut info1 = self.root_info.shift_remove(&rep1).expect("rep1 info");
+        let info2 = self.root_info.shift_remove(&rep2).expect("rep2 info");
         info1.absorb(info2);
 
         // upstream: weighted union, smaller tree under larger.
-        let w1 = self.weight.remove(&rep1).expect("rep1 weight");
-        let w2 = self.weight.remove(&rep2).expect("rep2 weight");
+        let w1 = self.weight.shift_remove(&rep1).expect("rep1 weight");
+        let w2 = self.weight.shift_remove(&rep2).expect("rep2 weight");
         let w = w1 + w2;
 
         let (new_rep1, new_rep2) = if w1 < w2 { (rep2, rep1) } else { (rep1, rep2) };

--- a/majit/majit-translate/src/translator/rtyper/normalizecalls.rs
+++ b/majit/majit-translate/src/translator/rtyper/normalizecalls.rs
@@ -301,7 +301,7 @@ pub fn merge_classpbc_getattr_into_classdef(
             let mut out = Vec::new();
             for entry in descs_map.values() {
                 if let DescEntry::Class(rc) = entry {
-                    let key = crate::annotator::description::DescKey::from_rc(rc);
+                    let key = rc.borrow().identity;
                     if desc_keys.contains(&key) {
                         out.push(rc.clone());
                     }
@@ -1738,8 +1738,8 @@ mod tests {
 
         // Build a single ClassAttrFamily containing both descs by
         // unioning them under the "shared" attr name.
-        let root_key = DescKey::from_rc(&root_desc);
-        let leaf_key = DescKey::from_rc(&leaf_desc);
+        let root_key = root_desc.borrow().identity;
+        let leaf_key = leaf_desc.borrow().identity;
         ann.bookkeeper.with_classpbc_attr_families("shared", |uf| {
             uf.find(root_key);
             uf.union(root_key, leaf_key);
@@ -1795,7 +1795,7 @@ mod tests {
             let pyobj = only_desc.borrow().pyobj.clone();
             descs.insert(pyobj, DE::Class(only_desc.clone()));
         }
-        let only_key = DescKey::from_rc(&only_desc);
+        let only_key = only_desc.borrow().identity;
         ann.bookkeeper.with_classpbc_attr_families("alone", |uf| {
             uf.find(only_key);
             Some(())

--- a/majit/majit-translate/src/translator/rtyper/rclass.rs
+++ b/majit/majit-translate/src/translator/rtyper/rclass.rs
@@ -954,7 +954,7 @@ impl ClassRepr {
         r_parentcls: &Arc<ClassRepr>,
     ) -> Result<(), TyperError> {
         let classdesc = self.classdef.borrow().classdesc.clone();
-        let classdesc_key = crate::annotator::description::DescKey::from_rc(&classdesc);
+        let classdesc_key = classdesc.borrow().identity;
 
         // upstream: `for fldname in r_parentcls.clsfields`.
         let clsfields_snapshot: Vec<(String, (String, Arc<dyn Repr>))> = r_parentcls
@@ -6039,9 +6039,9 @@ mod tests {
 
         let rtyper = fresh_rtyper();
         let classdef = ClassDef::new_standalone("pkg.C", None);
-        let access_set = Rc::new(RefCell::new(ClassAttrFamily::new(DescKey::from_rc(
-            &classdef.borrow().classdesc,
-        ))));
+        let access_set = Rc::new(RefCell::new(ClassAttrFamily::new(
+            classdef.borrow().classdesc.borrow().identity,
+        )));
         access_set.borrow_mut().s_value = SomeValue::Bool(crate::annotator::model::SomeBool::new());
         let access_key = class_attr_family_key(&access_set);
         classdef

--- a/majit/majit-translate/src/translator/rtyper/rpbc.rs
+++ b/majit/majit-translate/src/translator/rtyper/rpbc.rs
@@ -8602,8 +8602,8 @@ mod pbc_repr_tests {
         let _leaf_cd = ClassDesc::getuniqueclassdef(&leaf_desc).unwrap();
 
         // Wire the ClassAttrFamily for "x" via UnionFind union.
-        let root_key = DescKey::from_rc(&root_desc);
-        let leaf_key = DescKey::from_rc(&leaf_desc);
+        let root_key = root_desc.borrow().identity;
+        let leaf_key = leaf_desc.borrow().identity;
         ann.bookkeeper.with_classpbc_attr_families("x", |uf| {
             uf.find(root_key);
             uf.union(root_key, leaf_key);


### PR DESCRIPTION
Two RPython-orthodoxy corrections to the annotator's ordering, both scoped to the two-phase rtyper prepass. Neither changes what graphs lift (total phaseA fail count is unchanged at ~302); they replace run-varying iteration/keying with the insertion-ordered / stable-identity shapes upstream uses.

## 1. IndexMap for annotator PBC/attr-family and struct-root maps (`8e6e751`)

The default-hasher `HashMap`s on the annotate/rtype numbering and phi-merge-union path iterated in `RandomState` order, which upstream stores as insertion-ordered Python dicts:

- `bookkeeper.rs`: `emulated_pbc_calls`, `descs`, `classpbc_attr_families`. Also sort `pyre_struct_root_names` so the struct-root classdef mint order (which seeds the global `NEXT_CLASSDEF_ID` counter) is stable — matching the already-sorted `pre_register_enum_variant_classes` sibling.
- `description.rs`: `CallFamily`/`FrozenAttrFamily`/`ClassAttrFamily` `descs`, `read_locations`, `calltables`, `attrs`.
- `unionfind.rs`: `link_to_parent`, `weight`, `root_info`; `shift_remove` in `union()` to preserve insertion order of surviving entries.
- `classdesc.rs`: `ClassDesc.read_locations`, `ClassDef.read_locations_of_class`.

## 2. Key desc identity on the monotonic id, not `Rc::as_ptr` (`740bd9c`)

`SomePBC.descriptions` is a `BTreeMap<DescKey, _>` and several sites pick `descriptions.values().next()` as "the first desc". `DescKey` was derived from `Rc::as_ptr`, so that selection — and every family/PBC table ordered by `DescKey` — varied with the address the allocator handed out.

`DescEntry::desc_key()` and the 28 direct `DescKey::from_rc` call sites now read each desc's stored monotonic identity (`Desc::identity`, minted from `alloc_desc_key`):

- `ClassDesc` gains an `identity` field (it does not embed the `Desc` base the other desc kinds share); both constructors mint it via `alloc_desc_key`.
- `FuncDescEntry::memo` no longer slaves the inner base identity to the MemoDesc pointer; `desc_key()` and `rowkey()` already both read the inner `FunctionDesc` `base.identity`.
- Remove the now-unused `DescKey::from_rc`.

## Verification

- `cargo test -p majit-translate`: 2977 + all integration tests pass.
- `check.py`: dynasm 161/161, cranelift 161/161, wasm 161/161 (3/3 backend runs) on the rebased tree.

## Note

These remove the `RandomState` and ASLR-pointer ordering sources but do not fully determinize the `compute_at_fixpoint`-failed ("cat2") census count — the residual wobble is poison-order sensitivity in the shared-callee prepass, tracked separately. The stable census gate (total phaseA fail count) is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)