### PR TITLE
interp: bytearray parity follow-ups (__index__ byte arg, __imul__)

### DIFF
--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -12516,24 +12516,15 @@ fn bytes_descr_new_impl(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyEr
     }
 }
 
-/// `space.byte_w` — extract a single byte (`0 <= v < 256`) from an int
-/// argument; a non-int raises the CPython "object cannot be interpreted
-/// as an integer" TypeError, an out-of-range int the ValueError.
+/// `space.byte_w` — extract a single byte (`0 <= v < 256`) from an index
+/// argument; an invalid index raises TypeError, an out-of-range value ValueError.
 fn bytearray_byte_arg(obj: PyObjectRef) -> Result<u8, crate::PyError> {
-    unsafe {
-        if pyre_object::is_int(obj) {
-            let v = pyre_object::w_int_get_value(obj);
-            if !(0..=255).contains(&v) {
-                return Err(crate::PyError::value_error("byte must be in range(0, 256)"));
-            }
-            Ok(v as u8)
-        } else {
-            Err(crate::PyError::type_error(format!(
-                "'{}' object cannot be interpreted as an integer",
-                (*(*obj).ob_type).name
-            )))
-        }
+    // byte_w: getindex_w then range-check to [0, 256).
+    let value = crate::baseobjspace::getindex_w(obj)?;
+    if !(0..=255).contains(&value) {
+        return Err(crate::PyError::value_error("byte must be in range(0, 256)"));
     }
+    Ok(value as u8)
 }
 
 /// `bytearrayobject.py:descr_append` — append one byte in place.

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -12527,6 +12527,44 @@ fn bytearray_byte_arg(obj: PyObjectRef) -> Result<u8, crate::PyError> {
     Ok(value as u8)
 }
 
+/// `pypy/objspace/std/bytearrayobject.py descr_inplace_mul` — repeat the
+/// bytearray in place while preserving its identity.
+fn bytearray_method_imul(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    crate::type_methods::arity_at_least(args, "__imul__", 1)?;
+    let ba = args[0];
+    // Follow CPython here: a non-index TypeError propagates rather than
+    // returning NotImplemented.
+    let w_index = crate::baseobjspace::space_index(args[1])?;
+    let count = match crate::baseobjspace::int_w(w_index) {
+        Ok(v) => v,
+        Err(e) if e.kind == crate::PyErrorKind::OverflowError => {
+            return Err(crate::PyError::overflow_error(
+                "cannot fit 'int' into an index-sized integer",
+            ));
+        }
+        Err(e) => return Err(e),
+    };
+    unsafe {
+        crate::builtins::bytearray_check_exports(ba)?;
+        let vec = pyre_object::bytearrayobject::w_bytearray_vec_mut(ba);
+        if count <= 0 {
+            vec.clear();
+        } else if count != 1 && !vec.is_empty() {
+            vec.len().checked_mul(count as usize).ok_or_else(|| {
+                crate::PyError::new(
+                    crate::PyErrorKind::OverflowError,
+                    "repeated bytes are too long",
+                )
+            })?;
+            let orig = vec.clone();
+            for _ in 1..count {
+                vec.extend_from_slice(&orig);
+            }
+        }
+    }
+    Ok(ba)
+}
+
 /// `bytearrayobject.py:descr_append` — append one byte in place.
 fn bytearray_method_append(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     crate::type_methods::arity_at_least(args, "append", 1)?;
@@ -12808,6 +12846,11 @@ fn init_bytearray_type(ns: &mut DictStorage) {
             },
             2,
         ),
+    );
+    dict_storage_store(
+        ns,
+        "__imul__",
+        make_builtin_function_with_arity("__imul__", bytearray_method_imul, 2),
     );
     // The transform methods read via `bytes_like_data` and build their
     // result with `new_bytes_like`, which yields a bytearray for a


### PR DESCRIPTION
Two bytearray-method parity fixes surfaced while re-checking the PR #469 parity review (both were flagged as pre-existing §3 mismatches; each is small and adjacent to the just-merged export-lock work).

## 1. `bytearray_byte_arg` accepts any `__index__` (`4f44786f572`)

`bytearray_byte_arg` accepted only an exact `int`, so `append`/`insert`/`remove`/per-element `extend` rejected an `__index__` provider with a `TypeError`. CPython accepts it. Delegate to `getindex_w` then range-check to `[0, 256)`, matching `byte_w` (baseobjspace.py:1882-1891): an `__index__` object is accepted; an out-of-range value (int or `__index__` result, including overflow) raises `ValueError "byte must be in range(0, 256)"`; a non-index raises the same `TypeError` as before. `b[0] = x` and `b *= n` already accepted `__index__` and are untouched.

## 2. `bytearray.__imul__` repeats in place (`498e67a808f`)

bytearray had no `__imul__`, so `b *= n` built a **new** object via `__mul__` (identity not preserved), skipped the buffer-export lock, and `bytearray.__imul__` was `AttributeError`. Register `__imul__` (descr_inplace_mul, bytearrayobject.py:426-440): convert the count with `getindex_w`, refuse a size change while a buffer is exported (`_check_exports`), then repeat the byte storage in place. A non-index operand propagates `TypeError` (CPython-wins over PyPy's `NotImplemented`).

## Verification

- Probes vs CPython 3.14 — identical on every case: `__index__` byte args (append/insert/remove/extend), out-of-range → ValueError, non-index → TypeError; `b *= 3` in-place (id preserved), `__imul__` by `__index__`/0/negative, `b *= 2` while exported → BufferError, after release → succeeds, `b * n` / `n * b` unchanged.
- check.py dynasm 161/161 + cranelift 161/161
- `builtin_memoryview.py` clean; export-lock / concat probes unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added in-place repetition support for byte arrays using the `*=` operator.
  * Byte array values now accept a wider range of index-compatible inputs.

* **Bug Fixes**
  * Added validation to ensure converted byte values remain within the valid 0–255 range.
  * Handles zero, negative, and excessively large repetition counts safely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->