### PR TITLE
jit: FBW walker exception-state correctness fixes (#389c root #1 + adjacencies)

### DIFF
--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -16390,6 +16390,10 @@ impl majit_backend::Backend for CraneliftBackend {
         grab_exc_value_from_deadframe(frame).expect("grab_exc_value_from_deadframe failed")
     }
 
+    fn clear_stored_exception(&self) {
+        jit_exc_clear();
+    }
+
     fn invalidate_loop(&self, token: &JitCellToken) {
         token.invalidate();
     }

--- a/majit/majit-backend-dynasm/src/runner.rs
+++ b/majit/majit-backend-dynasm/src/runner.rs
@@ -2747,6 +2747,10 @@ impl Backend for DynasmBackend {
         frame.data.downcast_ref::<FrameData>().unwrap().exc_value
     }
 
+    fn clear_stored_exception(&self) {
+        crate::jit_exc_clear();
+    }
+
     /// `llmodel.py:252-268 free_loop_and_bridges` parity.  When the CLT
     /// drops, `asmmemmgr_gcreftracers` releases its strong refs to the
     /// baked `FailDescrCell` Arcs; subsequent recovery from a stale

--- a/majit/majit-backend-wasm/src/lib.rs
+++ b/majit/majit-backend-wasm/src/lib.rs
@@ -2390,6 +2390,10 @@ impl majit_backend::Backend for WasmBackend {
         GcRef(data.exc_value as usize)
     }
 
+    fn clear_stored_exception(&self) {
+        crate::jit_exc_clear();
+    }
+
     fn invalidate_loop(&self, _token: &JitCellToken) {
         // No native code to invalidate — wasm modules are immutable.
     }

--- a/majit/majit-backend/src/lib.rs
+++ b/majit/majit-backend/src/lib.rs
@@ -1990,6 +1990,15 @@ pub trait Backend: Send {
         GcRef::NULL
     }
 
+    /// `llmodel.py:194-199 _store_exception` counterpart — clear the backend
+    /// `_store_exception` cells (`jit_exc_value` / `jit_exc_type`).  A residual
+    /// `bh_call` that raised publishes into BOTH `BH_LAST_EXC_VALUE` and these
+    /// cells; when the blackhole catches it in-frame (`route_to_catch`) only
+    /// `BH_LAST_EXC_VALUE` is cleared, so the cell keeps the consumed exception
+    /// and a later `GUARD_NO_EXCEPTION` re-delivers it.  Draining on handler
+    /// entry keeps the cell coherent with the caught state.
+    fn clear_stored_exception(&self) {}
+
     /// Read the FailDescr from the last guard failure.
     fn get_latest_descr<'a>(&'a self, frame: &'a DeadFrame) -> &'a dyn FailDescr;
 

--- a/majit/majit-metainterp/src/blackhole.rs
+++ b/majit/majit-metainterp/src/blackhole.rs
@@ -1155,6 +1155,14 @@ impl BlackholeInterpreter {
         self.exception_last_value = exc_value;
         self.position = target;
         BH_LAST_EXC_VALUE.with(|c| c.set(0));
+        // A residual `bh_call` that raised published the exception into BOTH
+        // `BH_LAST_EXC_VALUE` and the backend `_store_exception` cells
+        // (`publish_residual_call_exception`).  Clearing only the former leaves
+        // the cell holding the now-caught exception; the next compiled re-entry
+        // (a nested call from this handler) would read it at its first
+        // `GUARD_NO_EXCEPTION` and re-deliver the already-handled exception.
+        // Drain the backend cells here so the handler runs with a pristine cell.
+        self.cpu().clear_stored_exception();
         true
     }
 

--- a/pyre/pyre-interpreter/src/call.rs
+++ b/pyre/pyre-interpreter/src/call.rs
@@ -2146,6 +2146,20 @@ pub fn install_dict_storage_hooks() {
             let ns = &*(ns_ptr as *const crate::DictStorage);
             ns.entries().map(|(k, v)| (k.to_string(), *v)).collect()
         });
+        pyre_object::dictmultiobject::register_dict_storage_walk_hook(|ns_ptr, forward| unsafe {
+            let ns = &mut *(ns_ptr as *mut crate::DictStorage);
+            let value_slots: Vec<*mut PyObjectRef> = ns
+                .values_mut()
+                .iter_mut()
+                .map(|value| value as *mut PyObjectRef)
+                .collect();
+            for slot in value_slots {
+                forward(&mut *slot);
+            }
+            if let Some(slot) = ns.mirror_target_slot_mut() {
+                forward(slot);
+            }
+        });
     });
 }
 

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -2565,6 +2565,17 @@ pub fn dispatch_via_miframe(
     // so `fbw_mode.snapshot_sym` is non-null on every default-JIT
     // run.  `PYRE_FULL_BODY_WALK=0` is the only opt-out
     // (the transitional trait leg), which leaves the pointer null.
+    // Recover the portal EC red off `sym.frame` before the first opcode is
+    // dispatched (thus before any guard is recorded), caching it into
+    // `sym.execution_context`.  A bridge-from-guard sym whose ec color collides
+    // with a real frame slot is left `OpRef::NONE` by `setup_bridge_sym`, which
+    // defers recovery to `ensure_execution_context`.  The walker's
+    // snapshot-capture path runs `collect_outer_active_boxes` AFTER the guard,
+    // so recovering there would record the getfield after the guard that
+    // references it (use-before-def).  Seed here — the trait's pre-guard
+    // cache-once analog — so every guard snapshot reads a real EC OpRef.
+    seed_execution_context_for_walk(sym, trace_ctx);
+
     // RPython parity: `metainterp.last_exc_value` (pyjitpl.py:1695)
     // is the standing exception OpRef. Walker's `WalkContext::last_exc_value`
     // mirrors this as `Option<OpRef>` — `None` means "no active
@@ -6906,7 +6917,7 @@ fn opref_is_null_const_ptr(op: OpRef) -> bool {
 
 fn collect_outer_active_boxes(
     sym: &crate::state::PyreSym,
-    trace_ctx: &TraceCtx,
+    trace_ctx: &mut TraceCtx,
     regs_i: &[OpRef],
     regs_r: &[OpRef],
     regs_f: &[OpRef],
@@ -7137,7 +7148,40 @@ fn collect_outer_active_boxes(
         let value = if is_portal_red_scratch {
             if color as u16 == portal_frame_reg {
                 sym.frame
+            } else if !sym.execution_context.is_none() {
+                // EC red already seeded on this snapshot path.
+                sym.execution_context
+            } else if !sym.frame.is_none() {
+                // Adapter / inline-caller snapshot path leaves
+                // `sym.execution_context` unseeded (`OpRef::NONE`).  This is the
+                // pre-guard inline-parent-frame collection (the paused caller's
+                // active boxes are built BEFORE the callee sub-walk records its
+                // guards), so recording the recovery getfield here is
+                // well-ordered.  Recover the EC from the frame the same way the
+                // trait encoder's `ensure_execution_context` does
+                // (trace_opcode.rs:1248): record `getfield
+                // frame.execution_context` and route that OpRef through as the
+                // portal EC red, so the resume snapshot never pushes NONE for
+                // `interp_jit.py:67 reds = ['frame', 'ec']`.  A NONE EC escapes
+                // as a null execution-context pointer and SIGSEGVs (rc=139) or
+                // trips the Ref-bank NONE guard (rc=101).
+                //
+                // The post-guard snapshot-capture path
+                // (`walker_capture_snapshot_for_last_guard`) reaches this fn with
+                // the outer full-body `sym`, whose EC is eagerly recovered at
+                // walk entry (`seed_execution_context_for_walk`) — so on that
+                // path `sym.execution_context` is already real above and this
+                // branch (which would record AFTER the guard, a use-before-def)
+                // is not taken.
+                trace_ctx.record_op_with_descr(
+                    OpCode::GetfieldGcR,
+                    &[sym.frame],
+                    crate::descr::pyframe_execution_context_descr(),
+                )
             } else {
+                // Neither EC nor frame is recoverable: keep the raw NONE so the
+                // downstream Ref-bank NONE guard surfaces the unrecoverable case
+                // instead of silently masking it.
                 sym.execution_context
             }
         } else if owns_vable {
@@ -16014,6 +16058,43 @@ fn walker_ensure_execution_context(ctx: &mut WalkContext<'_, '_>) -> Option<OpRe
         crate::descr::pyframe_execution_context_descr(),
     );
     Some(ec)
+}
+
+/// Eagerly recover the portal EC red before the full-body walk records its
+/// first guard, caching it into `sym.execution_context`.
+///
+/// The portal `[frame, ec]` reds (`interp_jit.py:67 reds = ['frame', 'ec']`)
+/// are force-alived in every `-live-` op's R-bank, so every guard's resume
+/// snapshot lists the EC color.  Loop / function-entry syms seed
+/// `sym.execution_context = InputArgRef(1)` at `create_sym`, but a
+/// bridge-from-guard sym whose ec color collides with a real frame slot is
+/// left `OpRef::NONE` by `setup_bridge_sym` (state.rs:8300-8326), which defers
+/// the recovery to `ensure_execution_context`.
+///
+/// The trait leg performs that recovery inside `get_list_of_active_boxes`,
+/// which runs BEFORE the guard is recorded, so its getfield is well-ordered.
+/// The walker's snapshot-capture path
+/// (`walker_capture_snapshot_for_last_guard` → `collect_outer_active_boxes`)
+/// runs AFTER the guard, so recording the recovery there would place the
+/// getfield after the guard that references it (a use-before-def; the resume
+/// position would also stamp onto the getfield rather than the guard, leaving
+/// the guard with `resume_pos = -1`).  Recover here instead — at walk entry,
+/// before any opcode is dispatched and thus before any guard — mirroring the
+/// trait's cache-once semantics.  When the EC is already seeded, or the frame
+/// itself is unset, this is a no-op.
+pub(crate) fn seed_execution_context_for_walk(
+    sym: &mut crate::state::PyreSym,
+    trace_ctx: &mut TraceCtx,
+) {
+    if !sym.execution_context.is_none() || sym.frame.is_none() {
+        return;
+    }
+    let ec = trace_ctx.record_op_with_descr(
+        OpCode::GetfieldGcR,
+        &[sym.frame],
+        crate::descr::pyframe_execution_context_descr(),
+    );
+    sym.execution_context = ec;
 }
 
 /// #124: walker-native truth specialization for the `truth_fn` residual

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -7933,6 +7933,27 @@ thread_local! {
     static FBW_CELL_STORE_JOURNAL: std::cell::RefCell<Vec<(pyre_object::PyObjectRef, i64)>> =
         const { std::cell::RefCell::new(Vec::new()) };
 
+    /// Undo log for the walked region's eagerly executed
+    /// `set_current_exception` stores against the LIVE per-thread
+    /// `ExecutionContext.sys_exc_value`.  The authoritative walk lowers
+    /// PUSH_EXC_INFO / POP_EXCEPT to `set_current_exception` residuals and
+    /// applies their concrete effect at walk time
+    /// ([`try_walker_lower_exc_info_residual`]) so a following
+    /// `get_current_exception` reads the right value.  Same rationale as
+    /// [`FBW_STORE_JOURNAL`]: on a non-commit exit the legacy replay re-runs
+    /// the walked region and must find the pre-walk `sys_exc_value`.  Without
+    /// this journal an exception that propagates OUT of an except-handler
+    /// (the handler body itself raises) aborts the walk BEFORE its paired
+    /// POP_EXCEPT restore runs, leaving the live EC holding the caught
+    /// exception; the next frame reads it as the active exception and chains
+    /// it as a spurious `__context__`.  Each entry is the displaced prior
+    /// value (`get_current_exception()` read just before the eager store);
+    /// the rollback re-applies them in reverse push order so the final write
+    /// restores the walk-entry value.  Entries are GC roots via
+    /// [`fbw_store_journal_root_walker`].
+    static FBW_SYS_EXC_JOURNAL: std::cell::RefCell<Vec<pyre_object::PyObjectRef>> =
+        const { std::cell::RefCell::new(Vec::new()) };
+
     /// In-flight FOR_ITER continuation (#57 Option C): `(consumed_item,
     /// body_pc)` stashed when the FOR_ITER `for_iter_next` residual
     /// ([`PyreHelperKind::ForIterNext`]) runs concretely on the
@@ -8114,6 +8135,7 @@ pub(crate) fn fbw_store_journal_reset() {
     FBW_STORE_JOURNAL.with(|j| j.borrow_mut().clear());
     FBW_APPEND_JOURNAL.with(|j| j.borrow_mut().clear());
     FBW_CELL_STORE_JOURNAL.with(|j| j.borrow_mut().clear());
+    FBW_SYS_EXC_JOURNAL.with(|j| j.borrow_mut().clear());
     FBW_UNJOURNALED_VALUE_UNAVAILABLE.with(|c| c.set(false));
     FBW_UNJOURNALED_SYMBOLIC.with(|c| c.set(false));
     FBW_EXECUTED_RESIDUAL_VOID.with(|c| c.set(0));
@@ -8184,12 +8206,24 @@ pub(crate) fn fbw_cell_store_journal_push(cell: pyre_object::PyObjectRef, intval
     fbw_bump_executed_effect();
 }
 
+/// Record the `sys_exc_value` a walked eager `set_current_exception`
+/// displaces, for the in-place restore when the walk does not commit its
+/// end state.  Pushed by [`try_walker_lower_exc_info_residual`] before it
+/// applies the concrete store.
+fn fbw_sys_exc_journal_push(displaced: pyre_object::PyObjectRef) {
+    FBW_SYS_EXC_JOURNAL.with(|j| j.borrow_mut().push(displaced));
+}
+
 /// Commit-path epilogue: the walk's eager stores and appends stand; drop
 /// the undo logs.
 pub(crate) fn fbw_store_journal_commit() {
     FBW_STORE_JOURNAL.with(|j| j.borrow_mut().clear());
     FBW_APPEND_JOURNAL.with(|j| j.borrow_mut().clear());
     FBW_CELL_STORE_JOURNAL.with(|j| j.borrow_mut().clear());
+    // A committed walk keeps its eager `sys_exc_value` store (the compiled
+    // trace or the adopted end state carries the same exception state), so
+    // drop the undo log without re-applying it.
+    FBW_SYS_EXC_JOURNAL.with(|j| j.borrow_mut().clear());
     // #57 Option C: a committed walk's end-flush adopts the advanced
     // iterator + the body that consumed it (counted once), so the in-flight
     // items must NOT also be delivered — drop the stash (and with it the
@@ -8543,6 +8577,19 @@ pub(crate) fn fbw_store_journal_rollback() {
             }
         }
     });
+    // Restore `sys_exc_value` to its pre-walk value.  Replaying in reverse
+    // push order makes the LAST write the value read at walk entry (the
+    // first eager store's displaced prior), so an aborted walk leaves the
+    // live per-thread EC exactly as the legacy replay-from-start expects —
+    // in particular an exception that propagated OUT of an except-handler
+    // (walk aborted before its POP_EXCEPT restore) no longer leaks the
+    // caught exception into the next frame's `__context__`.
+    FBW_SYS_EXC_JOURNAL.with(|j| {
+        let mut entries = j.borrow_mut();
+        while let Some(displaced) = entries.pop() {
+            pyre_interpreter::eval::set_current_exception(displaced);
+        }
+    });
 }
 
 /// Current journal length (commit-point diagnostics).
@@ -8798,6 +8845,17 @@ pub unsafe fn fbw_store_journal_root_walker_area(
     for (cell, _intvalue) in cell_stores.iter_mut() {
         visitor(unsafe { &mut *(cell as *mut pyre_object::PyObjectRef).cast() });
     }
+    // The displaced `sys_exc_value` entries are exception objects that may be
+    // nursery-resident and no longer referenced elsewhere once the eager store
+    // overwrote the EC slot; forward each so a minor collection during the rest
+    // of the walk cannot free/move the value the rollback restores.
+    FBW_SYS_EXC_JOURNAL.with(|j| {
+        for displaced in j.borrow_mut().iter_mut() {
+            // SAFETY: `PyObjectRef` and `GcRef` share the usize repr; the
+            // borrow keeps the Vec storage alive for the visit.
+            visitor(unsafe { &mut *(displaced as *mut pyre_object::PyObjectRef).cast() });
+        }
+    });
     // #57 Option C: each captured in-flight FOR_ITER item is nursery-resident
     // across the rest of the walk (subsequent residual calls allocate and a
     // minor collection moves nursery objects), so forward every entry's item
@@ -19579,7 +19637,13 @@ fn try_walker_lower_exc_info_residual(
     // The walk is authoritative: apply the concrete store the residual
     // executor would have performed, so the live EC tracks the symbolic
     // SETFIELD in lock-step (a following `get_current_exception` /
-    // POP_EXCEPT restore reads the right value).
+    // POP_EXCEPT restore reads the right value).  Journal the displaced
+    // prior value first: this store mutates the LIVE per-thread EC, so a
+    // non-commit walk exit must restore it (the store journal's discipline).
+    // Without the undo an exception propagating OUT of an except-handler
+    // aborts the walk before its POP_EXCEPT restore, leaking the caught
+    // exception into the next frame's `sys_exc_value`.
+    fbw_sys_exc_journal_push(pyre_interpreter::eval::get_current_exception());
     pyre_interpreter::eval::set_current_exception(store_concrete);
     Ok(Some(()))
 }

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -1733,16 +1733,36 @@ fn run_perfn_walk(
                 }
             } else if let Some(ref bridge_stack) = sym.bridge_stack_oprefs {
                 // Non-branch-guard / portal-bridge resume at the opcode-entry
-                // marker: in the semantic prefix the abstract-register color
-                // equals the semantic slot, so the `nlocals + depth` slot→color
-                // shortcut over the slot-indexed `bridge_stack_oprefs` holds.
+                // marker: the walk re-executes the opcode from the top, reading
+                // its operand-stack inputs POSITIONALLY — `registers_r[nlocals +
+                // stack_idx]` (trace_opcode.rs:628 `stack_slot_reg_idx`) — so
+                // the slot-indexed `bridge_stack` tail seeds color `nlocals + i`.
+                //
+                // The reserved-red skip is per-PC-wrong here.  `portal_frame_reg`
+                // / `portal_ec_reg` are a SINGLE global pair naming where the
+                // reds live at PORTAL ENTRY, not at an arbitrary interior resume
+                // PC; under free register coloring the reds sit at the
+                // operand-stack base `[nlocals, nlocals + 1]`, exactly the colors
+                // a shallow live operand stack occupies.  A live (non-NONE)
+                // `bridge_stack[i]` is the authoritative per-PC witness that slot
+                // `nlocals + i` holds a real operand-stack value at THIS PC — and
+                // a single color cannot simultaneously hold that value and the
+                // red, so the red is provably not live at color `nlocals + i`
+                // here (its identity is recovered through the frame field, e.g.
+                // `ensure_execution_context` / the standard-vable box, not this
+                // register).  Seeding the temp is therefore correct and the skip
+                // is what dropped it: on `re/_parser.py:append` (nlocals=2) the
+                // live callable at slot 2 = color 2 = `portal_frame_reg` was
+                // skipped, so `residual_call` read the stale entry frame/ec seed
+                // as its callable → SIGSEGV in dispatch_callable /
+                // `exception_is_valid_obj_as_class_w` (#389 with-gate probe).
+                //
+                // A NONE `bridge_stack[i]` (dead/empty slot) leaves the color's
+                // red seed intact — the red genuinely still owns the color there.
                 let nl = sym.nlocals;
                 for (i, &opref) in bridge_stack.iter().enumerate() {
                     if !opref.is_none() {
                         let color = (nl + i) as u8;
-                        if reserved_red_colors.contains(&color) {
-                            continue;
-                        }
                         seed(color, opref);
                     }
                 }

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -1533,6 +1533,26 @@ fn handler_entry_state_from_catch_sites(
     merged
 }
 
+/// True for a handler whose reconstructed entry stack carries both a
+/// `push_lasti` box and an exception slot (`handler_entry_state_from_catch_site`
+/// pushes the lasti box below a `fresh_ref_value` exception slot). That
+/// exception slot has no defining op, so under the inline splice regalloc —
+/// which sources interference only from per-PC resume snapshots — it never
+/// interferes with the lasti box and coalesces onto its register, making the
+/// cleanup RERAISE raise the stale lasti integer. The caller gives the slot a
+/// `last_exc_value` producer so it enters the snapshots and earns a distinct
+/// colour.
+fn handler_entry_has_lasti_exception_slots(
+    catch_sites: &[ExceptionCatchSite],
+    handler_py_pc: usize,
+) -> bool {
+    catch_sites.iter().any(|site| {
+        site.handler_py_pc == handler_py_pc
+            && site.push_lasti
+            && site.landing.framestate().is_some()
+    })
+}
+
 fn initialize_spam_block(
     code: &CodeObject,
     graph: &mut super::flow::FunctionGraph,
@@ -7288,6 +7308,19 @@ impl CodeWriter {
                     // current_block.
                     if block_switch_pending {
                         break;
+                    }
+                    if start_pc == py_pc
+                        && handler_entry_has_lasti_exception_slots(&catch_sites, py_pc)
+                    {
+                        if let Some(exc_value) = current_state.stack.last().cloned() {
+                            record_graph_op(
+                                &current_block.block(),
+                                "last_exc_value",
+                                Vec::new(),
+                                Some(exc_value),
+                                py_pc as i64,
+                            );
+                        }
                     }
                     // The walker emits one block-identity `Label(block)`
                     // at block entry (`flatten.py:116` parity).  Per-PC

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -7349,30 +7349,57 @@ impl CodeWriter {
                     //   op2 = -live- (for do_recursive_call / guard resume)
                     // The per-PC emit_live_placeholder!() after this block
                     // serves as op2; op3 is emitted inside the block below.
-                    // An explicit `raise X` covered by a try closes its block
-                    // with a single exception exit carrying `explicit_raise_value`
-                    // (`emit_raise!` set `needs_fallthrough = false`).  When that
-                    // block's fall-through PC is itself a loop header — the target
-                    // of the handler's back-edge — `emit_mark_label_pc!` cannot
-                    // switch away from the closed block until the joinpoint block
-                    // exists, so `current_block` is still the raise block here.
-                    // Emitting the loop-header `jit_merge_point` into it appends
-                    // the merge op AFTER the raise's operations; `insert_exits`
-                    // then serialises the block ops (including that merge) BEFORE
-                    // the `raise` op, so a blackhole guard-resume into this arm
-                    // reaches the merge and `ContinueRunningNormally`s (loops back)
-                    // before executing the `raise`, dropping the handler.  The
-                    // `jit_merge_point` belongs to the real loop-header block,
-                    // emitted when that PC is walked through its own joinpoint;
-                    // suppress it on a closed explicit-raise block (mirrors the
-                    // `block_closed_by_terminator` op-dispatch gate below).
-                    let closed_by_explicit_raise = current_block
-                        .block()
-                        .borrow()
-                        .exits
-                        .iter()
-                        .any(|e| e.borrow().explicit_raise_value.is_some());
-                    if loop_header_pcs.contains(&py_pc) && !closed_by_explicit_raise {
+                    //
+                    // The loop-header `jit_merge_point` belongs to the block that
+                    // legitimately STARTS at this PC — the one entered via its own
+                    // back-edge / pending-block pop (`flatten.py make_bytecode_block`
+                    // enters a block only via its own links).  Pyre's PC-sequential
+                    // walker can also reach a loop-header PC by sequentially
+                    // advancing off the PC-adjacent predecessor block AFTER that
+                    // predecessor was closed by an unconditional terminator
+                    // (`emit_goto!` / `emit_ref_return!` / `emit_raise!` cleared
+                    // `needs_fallthrough` so `emit_mark_label_pc!` could not switch
+                    // away, and no joinpoint is registered at the loop-header PC yet
+                    // because its back-edge lies at a higher, not-yet-walked PC).
+                    // In that case `current_block` is the terminator-closed
+                    // predecessor, NOT the loop-header block:
+                    //   - a JumpBackward block carrying `loop_header` + `goto`
+                    //     target whose PC-adjacent next PC is a DIFFERENT loop's
+                    //     header (the word-drop bug: the merge lands after the
+                    //     `goto`, so `insert_exits` serialises it BEFORE the goto
+                    //     target and a blackhole guard-resume reaches the
+                    //     `jit_merge_point` first, `ContinueRunningNormally`s at the
+                    //     loop-header PC without the predecessor's state reset →
+                    //     truncated / duplicated output);
+                    //   - an explicit `raise X` block whose fall-through PC is a
+                    //     loop header (merge serialised before the `raise`, dropping
+                    //     the handler).
+                    // In every terminator-closed case the merge belongs to the real
+                    // loop-header block, emitted when that PC is walked through its
+                    // own entry.  Suppress it here on any terminator-closed block —
+                    // the same guard the op-dispatch `block_closed_by_terminator`
+                    // gate applies below.  Computed once here and reused at that
+                    // gate.
+                    let block_closed_by_terminator = {
+                        let block_rc = current_block.block();
+                        let block = block_rc.borrow();
+                        let has_explicit_raise = block
+                            .exits
+                            .iter()
+                            .any(|e| e.borrow().explicit_raise_value.is_some());
+                        !block.exits.is_empty()
+                            && (has_explicit_raise
+                                || !matches!(
+                                    block.exitswitch,
+                                    Some(super::flow::ExitSwitch::Value(super::flow::FlowValue::Constant(
+                                        ref c,
+                                    ))) if matches!(
+                                        c.value,
+                                        super::flow::ConstantValue::Atom(super::flow::Atom::LastException)
+                                    )
+                                ))
+                    };
+                    if loop_header_pcs.contains(&py_pc) && !block_closed_by_terminator {
                         // jtransform.py:1710-1711 op3: -live- before
                         // jit_merge_point, "for inlined short preambles".
                         emit_live_placeholder!();
@@ -7457,40 +7484,11 @@ impl CodeWriter {
                     // the block, so subsequent ops still need dispatch for
                     // stack-depth parity (e.g. `Instruction::LoadName` +
                     // `Instruction::StoreName` patterns at module scope).
-                    let block_closed_by_terminator = {
-                        let block_rc = current_block.block();
-                        let block = block_rc.borrow();
-                        // An explicit `raise X` covered by a try attaches its
-                        // exception edge through `attach_catch_exception_edge`,
-                        // which sets `exitswitch=LastException` — the same
-                        // canraise shape a real raising OP produces.  The
-                        // LastException exclusion below keeps a canraise OP's
-                        // block open so the walker keeps dispatching the op's
-                        // normal-flow result and the ops after it.  An explicit
-                        // raise has no normal continuation: it is an
-                        // unconditional terminator, so the block must close.
-                        // Left open, the walker serialises the following
-                        // fall-through / loop-back ops (and a `mergeblock`
-                        // appends a spurious normal exit) into the raise's
-                        // block; `insert_exits` then lowers the raise edge as a
-                        // plain catch and drops the `raise` op, so the handler
-                        // is never entered.
-                        let has_explicit_raise = block
-                            .exits
-                            .iter()
-                            .any(|e| e.borrow().explicit_raise_value.is_some());
-                        !block.exits.is_empty()
-                            && (has_explicit_raise
-                                || !matches!(
-                                    block.exitswitch,
-                                    Some(super::flow::ExitSwitch::Value(super::flow::FlowValue::Constant(
-                                        ref c,
-                                    ))) if matches!(
-                                        c.value,
-                                        super::flow::ConstantValue::Atom(super::flow::Atom::LastException)
-                                    )
-                                ))
-                    };
+                    //
+                    // Reuses `block_closed_by_terminator` computed above the
+                    // loop-header `jit_merge_point` gate: the merge emission
+                    // only appends `operations` (never `exits` / `exitswitch`),
+                    // so the value is unchanged here.
                     if block_closed_by_terminator {
                         current_state.next_offset = py_pc + 1;
                         current_state.blocklist =

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -8820,7 +8820,7 @@ impl CodeWriter {
                             // for the analyzer-equivalent `EF_CANNOT_RAISE
                             // + empty raw frozensets + can_collect=false`
                             // shape (`effectinfo.py:281-283`).
-                            let _prev_var = residual_call!(
+                            let prev_var = residual_call!(
                                 get_current_exception_fn_idx,
                                 CallFlavor::PlainCannotRaiseNoHeap,
                                 majit_ir::PyreHelperKind::GetCurrentException,
@@ -8857,7 +8857,10 @@ impl CodeWriter {
                             // catch-landing `last_exc_value` pin, so
                             // `get_color` agrees with the runtime register.
                             let _prev_slot = stack_base + current_depth;
-                            let prev_value = fresh_ref_value(&mut graph);
+                            let prev_value: super::flow::FlowValue = match prev_var {
+                                Some(v) => v.into(),
+                                None => fresh_ref_value(&mut graph).into(),
+                            };
                             current_state.stack.push(prev_value.clone());
                             emit_pushvalue_ref!(
                                 current_depth,

--- a/pyre/pyre-object/src/dictmultiobject.rs
+++ b/pyre/pyre-object/src/dictmultiobject.rs
@@ -1443,16 +1443,19 @@ pub unsafe fn w_module_dict_getitem_str(obj: PyObjectRef, key: &str) -> Option<P
 ///
 /// A module dict's authoritative storage is reached only behind raw
 /// pointers — the `dstorage` cell map, the post-`switch_to_object_strategy`
-/// `object_storage`, and the `mstrategy.caches` cell registry — none of
-/// which are inline `gc_ptr_offsets`.  The W_ModuleDictObject is
-/// currently `malloc_typed` (Box-immortal), so its registered
-/// `module_dict_object_custom_trace` never fires; without an explicit
-/// walk, `LOAD_GLOBAL` (`w_module_dict_getitem_str`, which reads the
-/// authoritative `dstorage` cell map ahead of the proxy back-mirror)
-/// would observe relocated values through never-forwarded slots.
-/// `walk_pyframe_roots` calls this for every live frame's globals and
-/// builtins so the real storage stays forwarded across collection.
-/// No-op for non-module dicts.
+/// `object_storage`, the `mstrategy.caches` cell registry, and the
+/// `dict_storage_proxy` str-key back-mirror — none of which are inline
+/// `gc_ptr_offsets`.  The W_ModuleDictObject is currently `malloc_typed`
+/// (Box-immortal), so its registered `module_dict_object_custom_trace`
+/// never fires; without an explicit walk, `LOAD_GLOBAL`
+/// (`w_module_dict_getitem_str`, which reads the authoritative `dstorage`
+/// cell map ahead of the proxy back-mirror) would observe relocated values
+/// through never-forwarded slots.  The proxy independently caches aliased
+/// copies of the value pointers and is read *ahead* of `dstorage` by
+/// `w_module_dict_items_inner`, so it must be forwarded too or a relocation
+/// leaves it handing out a reclaimed slot.  `walk_pyframe_roots` calls this
+/// for every live frame's globals and builtins so the real storage stays
+/// forwarded across collection.  No-op for non-module dicts.
 ///
 /// `visitor` receives each movable value slot; `walk_module_value_slot`
 /// unwraps `MutableCell`s (themselves Box-immortal) to forward the inner
@@ -1489,6 +1492,12 @@ pub unsafe fn w_module_dict_walk_gc_cells(
     if !md.mstrategy.is_null() {
         (*md.mstrategy).walk_cache_cells(visitor);
     }
+    // The `dict_storage_proxy` caches aliased copies of the value pointers
+    // in an off-GC value block and is read ahead of `dstorage` by
+    // `w_module_dict_items_inner`.  Forward those copies too, or a minor
+    // collection that relocates a value leaves the proxy handing out a
+    // dangling pointer to a reclaimed slot.
+    maybe_walk_dict_storage(md.dict_storage_proxy, visitor);
 }
 
 /// `celldict.py:106-126 delitem` (str path).
@@ -2331,6 +2340,7 @@ type NamespaceStoreHook = unsafe fn(*mut u8, &str, PyObjectRef);
 type NamespaceDeleteHook = unsafe fn(*mut u8, &str);
 type NamespaceLookupHook = unsafe fn(*mut u8, &str) -> Option<PyObjectRef>;
 type NamespaceItemsHook = unsafe fn(*mut u8) -> Vec<(String, PyObjectRef)>;
+type NamespaceWalkHook = unsafe fn(*mut u8, &mut dyn FnMut(&mut PyObjectRef));
 
 struct AtomicHookPtr(std::sync::atomic::AtomicPtr<NamespaceStoreHook>);
 
@@ -2404,10 +2414,28 @@ impl AtomicItemsHookPtr {
     }
 }
 
+struct AtomicWalkHookPtr(std::sync::atomic::AtomicPtr<NamespaceWalkHook>);
+
+impl AtomicWalkHookPtr {
+    const fn new() -> Self {
+        Self(std::sync::atomic::AtomicPtr::new(std::ptr::null_mut()))
+    }
+
+    fn store(&self, hook: NamespaceWalkHook) {
+        let raw = crate::lltype::malloc_raw(hook);
+        self.0.store(raw, std::sync::atomic::Ordering::Release);
+    }
+
+    fn load(&self, order: std::sync::atomic::Ordering) -> *const NamespaceWalkHook {
+        self.0.load(order) as *const NamespaceWalkHook
+    }
+}
+
 static DICT_STORAGE_STORE_HOOK: AtomicHookPtr = AtomicHookPtr::new();
 static DICT_STORAGE_DELETE_HOOK: AtomicDeleteHookPtr = AtomicDeleteHookPtr::new();
 static DICT_STORAGE_LOOKUP_HOOK: AtomicLookupHookPtr = AtomicLookupHookPtr::new();
 static DICT_STORAGE_ITEMS_HOOK: AtomicItemsHookPtr = AtomicItemsHookPtr::new();
+static DICT_STORAGE_WALK_HOOK: AtomicWalkHookPtr = AtomicWalkHookPtr::new();
 
 /// Register the interpreter-level hook that writes (name, value) into a
 /// DictStorage. Called once during interpreter startup.
@@ -2439,6 +2467,32 @@ pub fn register_dict_storage_lookup_hook(hook: NamespaceLookupHook) {
 /// entry not yet mirrored into the W_DictObject.
 pub fn register_dict_storage_items_hook(hook: NamespaceItemsHook) {
     DICT_STORAGE_ITEMS_HOOK.store(hook);
+}
+
+/// Register the interpreter-level hook that forwards every movable
+/// `PyObjectRef` value slot held in a DictStorage's off-GC value block.
+/// Called once during interpreter startup so a module dict's
+/// `dict_storage_proxy` — which caches aliased copies of the value
+/// pointers and is read ahead of the authoritative `dstorage` cell map —
+/// keeps those copies forwarded across a minor collection instead of
+/// stranding them at a reclaimed pre-move address.
+pub fn register_dict_storage_walk_hook(hook: NamespaceWalkHook) {
+    DICT_STORAGE_WALK_HOOK.store(hook);
+}
+
+/// Forward the value slots of a `DictStorage` proxy through `visitor`.
+/// No-op when `ns_ptr` is null or the walk hook has not been registered
+/// (the hookless case fires for direct `w_module_new` callers and unit
+/// tests before `register_dict_storage_walk_hook` runs).
+unsafe fn maybe_walk_dict_storage(ns_ptr: *mut u8, visitor: &mut dyn FnMut(&mut PyObjectRef)) {
+    if ns_ptr.is_null() {
+        return;
+    }
+    let ptr = DICT_STORAGE_WALK_HOOK.load(std::sync::atomic::Ordering::Acquire);
+    if ptr.is_null() {
+        return;
+    }
+    (*ptr)(ns_ptr, visitor);
 }
 
 /// Read-side counterpart of `maybe_sync_dict_storage_store`: enumerate


### PR DESCRIPTION
Fixes a cluster of full-body-walk (FBW) tracer correctness bugs on the `with`/exception path, uncovered while investigating the #389(c) with-block JIT gate.

## Headline: `sys_exc_value` leak on exceptional `__exit__` exit (root #1)

The authoritative FBW walk lowers `PUSH_EXC_INFO`/`POP_EXCEPT` to `set_current_exception` residuals and applies their concrete effect against the live per-thread `ExecutionContext.sys_exc_value` during recording. When an exception propagates out of an `except`-handler whose body itself raises, the walk aborts before reaching the paired `POP_EXCEPT` restore, and the abort epilogue had no undo for the EC mutation — leaving the live EC holding the caught exception. The next frame read it as the active exception and chained it as a spurious `__context__`, growing the chain by one on every recording pass.

Fix: `FBW_SYS_EXC_JOURNAL`, an undo log symmetric to the existing list/append/cell store journals (push displaced prior value before the eager store; restore in reverse on a non-commit walk exit; drop on commit; GC-root the entries). An aborted walk now leaves the per-thread EC exactly as it was at walk entry.

Verified: a minimal single-`with` `try: raise inner / except: raise outer` repro went from 4187 divergences to 0; the nested-suppression (`test_exit_exception_chaining_reference`) shape is now byte-identical to the interpreter's `__context__` chain. `TestExitStack.test_exit_exception_chaining` now passes.

## Adjacent FBW/codewriter fixes in this branch
- Suppress the loop-header `jit_merge_point` on any terminator-closed predecessor block (dropped words in a JIT-compiled `textwrap._wrap_chunks`).
- Seed a live operand-stack temp at a portal-red color on opcode-entry bridge resume.
- Recover the portal EC red before it reaches the resume snapshot as NONE.

## Scope note
This clears the `__context__` correctness leak but is **correctness-only** — it does not clear the separate SIGSEGV cluster the `with`-gate still masks (a distinct GC/residual-state accumulation crash, tracked as #389(c) root #2). A before/after control confirmed the fix introduces zero crash regressions. The `with`-block gate therefore stays pinned until root #2 is fixed.

## Validation
- `check.py --backend dynasm`: **161/161 ALL PASSED** (gate on, shipping path).
- Before/after sweep control: gate-off crash codes identical, so no regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)