### PR TITLE
ruleopt: document proof-gate skip and 64-bit LONG_BIT inline

### DIFF
--- a/majit/majit-metainterp/src/ruleopt/generate.rs
+++ b/majit/majit-metainterp/src/ruleopt/generate.rs
@@ -85,6 +85,13 @@ pub fn generate_rust_mixin(ast: &parse::File) -> String {
 }
 
 /// Parse rule source and generate the complete Rust mixin source.
+///
+/// PyPy's `generate.py` calls `proof.prove_source(content)` (a Z3 equivalence
+/// check over every non-`SORRY_Z3` rule) before codegen. The Rust `proof`
+/// module has no solver bound (`Prover::check_rule` reports
+/// `SolverUnavailable`), so — like the Python-emitting [`generate_source`] — this
+/// wrapper generates over the typed AST from `parse` without the proof gate.
+/// Wiring the gate in is a separate parity item (porting the Z3 harness).
 pub fn generate_rust_source(content: &str) -> Result<String, parse::RuleParseError> {
     let ast = parse::parse(content)?;
     Ok(format!(

--- a/majit/majit-metainterp/src/ruleopt/rust_codegen.rs
+++ b/majit/majit-metainterp/src/ruleopt/rust_codegen.rs
@@ -105,6 +105,10 @@ impl RustCodegen {
         opname.to_ascii_uppercase()
     }
 
+    // `LONG_BIT` lowers to the literal `64`, and `MININT`/`MAXINT` to the
+    // `i64` bounds: the JIT is native and pyre targets a 64-bit machine word
+    // exclusively, so these fold to the same values the runtime shift/range ops
+    // use. A 32-bit target would need the word size threaded through here.
     fn rust_constant(value: &str) -> String {
         match value {
             "LONG_BIT" => "64".to_string(),


### PR DESCRIPTION
Follow-up to #489 addressing the Codex parity review on that PR. Comment-only —
the generated `autogenintrules.rs` is unchanged.

- **§2 (proof gate):** `generate_rust_source` now documents that it skips PyPy's
  `proof.prove_source` gate because the Rust `proof` module has no solver bound
  (`Prover::check_rule` returns `SolverUnavailable`), matching the existing
  Python-emitting `generate_source`. Wiring the real gate in is a separate item
  (porting the Z3 harness); it cannot be called today as it would fail every
  non-`SORRY_Z3` rule.
- **§3 (LONG_BIT):** `rust_codegen::rust_constant` now documents that
  `LONG_BIT`/`MININT`/`MAXINT` fold to the 64-bit machine-word literals because
  the JIT targets 64-bit exclusively (a pre-existing, deliberate adaptation the
  generator preserves).

Verification: `cargo test -p majit-metainterp --lib ruleopt::` — 26 passed
(drift + coverage green; generator output byte-identical).

— *opened by Claude*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified how Rust source generation processes typed rules and documented the current absence of an automated equivalence-proof check.
  * Documented 64-bit machine-word assumptions, including the handling of word-size constants and integer bounds.
  * No functional behavior or public interfaces changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->