### PR TITLE
jit: preserve compiled-loop re-entry across module namespace growth

### DIFF
--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -2572,6 +2572,14 @@ impl<M: Clone> MetaInterp<M> {
         self.active_trace_session.as_ref().map(|s| &s.trace_meta)
     }
 
+    /// Mutable access to the active frontend trace metadata for per-trace
+    /// facts that are only known after the frontend has walked the body.
+    pub fn trace_meta_mut(&mut self) -> Option<&mut M> {
+        self.active_trace_session
+            .as_mut()
+            .map(|s| &mut s.trace_meta)
+    }
+
     /// Drain the frontend trace metadata, leaving the session slot
     /// empty.  Used by the finish-compile helpers that consume `M`
     /// before calling `recorder.finish()` + backend compile.

--- a/pyre/bench/loop_reentry_regression.py
+++ b/pyre/bench/loop_reentry_regression.py
@@ -1,0 +1,56 @@
+# Regression guard: a compiled hot loop must be re-entered on every call of its
+# enclosing function, not only on the call that compiled it.
+#
+# KNOWN-FAILING on the single-pass walker JIT as of this commit. Not wired into
+# check.py's run list precisely because it currently fails; run it directly:
+#
+#     python pyre/bench/loop_reentry_regression.py                 # PASS (CPython)
+#     target/release/pyre-cranelift pyre/bench/loop_reentry_regression.py   # FAIL
+#
+# Root cause: the only path that enters a compiled loop is
+# JitDriver::try_resume_into_compiled_loop (majit/majit-metainterp/src/
+# jitdriver.rs), gated on single_pass_compiled_key, which is set once at
+# CloseLoop compile and consumed by .take(). The #[jit_interp] merge-point
+# expansion (majit/majit-macros/src/jit_interp/mod.rs) calls it only inside
+# `if driver.is_tracing()` on the post-compile snapshot, and its own comment
+# notes "the native back-edges never key the walk's merge-point header, so the
+# compiled inner loop is otherwise unreachable". So the loop is entered exactly
+# once (right after it compiles) and a fresh activation of the same function
+# runs it fully interpreted. back_edge_internal / can_enter_jit_keyed already
+# implement compiled-loop entry but are not wired to the native hot back-edge.
+#
+# Symptom the check detects: call 1 runs the loop compiled (~sub-ns/iter), calls
+# 2+ run it interpreted (~1000 ns/iter). The margin is ~1000x, so the 20x gate
+# is not timing-flaky.
+
+import time
+
+N = 3_000_000
+SLOWDOWN_LIMIT = 20.0  # calls 2+ may be at most 20x slower than call 1
+
+
+def loop(n):
+    i = 0
+    total = 0
+    while i < n:
+        total = total + i
+        i = i + 1
+    return total
+
+
+def per_call_ns():
+    t0 = time.perf_counter()
+    loop(N)
+    return (time.perf_counter() - t0) / N * 1e9
+
+
+first = per_call_ns()          # compiles mid-call, then runs compiled
+rest = [per_call_ns() for _ in range(3)]
+worst = max(rest)
+ratio = worst / first if first > 0 else float("inf")
+
+print(f"call1={first:.2f}ns rest={[round(x, 2) for x in rest]} worst_ratio={ratio:.1f}x")
+if ratio > SLOWDOWN_LIMIT:
+    print(f"FAIL re-entry broken: later calls {ratio:.0f}x slower than the compiling call")
+    raise SystemExit(1)
+print("PASS re-entry preserved")

--- a/pyre/bench/loop_reentry_regression.py
+++ b/pyre/bench/loop_reentry_regression.py
@@ -1,27 +1,17 @@
 # Regression guard: a compiled hot loop must be re-entered on every call of its
 # enclosing function, not only on the call that compiled it.
 #
-# KNOWN-FAILING on the single-pass walker JIT as of this commit. Not wired into
-# check.py's run list precisely because it currently fails; run it directly:
+# Wired into check.py via run_selfcheck on dynasm + cranelift; skipped on wasm,
+# whose guest has no `time` module. Run it directly:
 #
-#     python pyre/bench/loop_reentry_regression.py                 # PASS (CPython)
-#     target/release/pyre-cranelift pyre/bench/loop_reentry_regression.py   # FAIL
+#     python pyre/bench/loop_reentry_regression.py               # PASS (interpreter)
+#     target/release/pyre-cranelift pyre/bench/loop_reentry_regression.py
 #
-# Root cause: the only path that enters a compiled loop is
-# JitDriver::try_resume_into_compiled_loop (majit/majit-metainterp/src/
-# jitdriver.rs), gated on single_pass_compiled_key, which is set once at
-# CloseLoop compile and consumed by .take(). The #[jit_interp] merge-point
-# expansion (majit/majit-macros/src/jit_interp/mod.rs) calls it only inside
-# `if driver.is_tracing()` on the post-compile snapshot, and its own comment
-# notes "the native back-edges never key the walk's merge-point header, so the
-# compiled inner loop is otherwise unreachable". So the loop is entered exactly
-# once (right after it compiles) and a fresh activation of the same function
-# runs it fully interpreted. back_edge_internal / can_enter_jit_keyed already
-# implement compiled-loop entry but are not wired to the native hot back-edge.
-#
-# Symptom the check detects: call 1 runs the loop compiled (~sub-ns/iter), calls
-# 2+ run it interpreted (~1000 ns/iter). The margin is ~1000x, so the 20x gate
-# is not timing-flaky.
+# The regression it guards: is_compatible refused re-entry once the enclosing
+# module bound a new top-level name and its globals dict grew, so call 1 ran the
+# loop compiled (~sub-ns/iter) while calls 2+ ran it interpreted (~1000 ns/iter)
+# with a per-iteration compiled-entry abort. The ~1000x margin makes the 20x gate
+# below not timing-flaky.
 
 import time
 

--- a/pyre/check.py
+++ b/pyre/check.py
@@ -947,17 +947,26 @@ class Check:
 
     # ── self-checking regression guard ──
 
-    def run_selfcheck(self, name, script, timeout, expect="PASS"):
+    def run_selfcheck(self, name, script, timeout, expect="PASS", skip_backends=()):
         """Run a self-checking regression script on each enabled backend.
 
         The script asserts its own invariant (exit 0 AND prints *expect*);
         check.py only honors the exit code and the required marker. Used for
         guards whose signal is a timing ratio, not byte-identical output, so
         they cannot go through `run_bench` or the synthetic suite.
+
+        *skip_backends* names backends the guard does not apply to (e.g. a
+        `time`-module timing guard cannot run on the wasm guest, which has no
+        `time` module).
         """
         print(f"  {name}")
         for backend in ALL_BACKENDS:
             if not self.enabled(backend):
+                continue
+            if backend in skip_backends:
+                sys.stdout.write(f"    {backend:<10s}")
+                print(dim("skip"))
+                self._append_comparison(backend, name, "-", "-", "skip")
                 continue
             effective_timeout = scaled_timeout(timeout, self._timeout_scale(backend))
             sys.stdout.write(f"    {backend:<10s}")
@@ -1321,10 +1330,14 @@ def main():
         chk.run_bench("spectral_norm",  f"{B}/spectral_norm.py",        5,       2,       7,       2,       7)
         chk.run_bench("nbody",          f"{B}/nbody.py",               10,       3,       None,    3,       None,    wasm_float_tol=True)
         chk.run_bench("fannkuch",       f"{B}/fannkuch.py",            30,       1,       5,       2,       None)
+        # Skipped on wasm: the guard times calls with `time.perf_counter()`, and
+        # the wasm guest has no `time` module (import fails before any output),
+        # so the guard is native-JIT-backend only.
         chk.run_selfcheck(
             "loop_reentry",
             f"{B}/loop_reentry_regression.py",
             15,
+            skip_backends=("wasm",),
         )
 
     if not args.no_synthetic:

--- a/pyre/check.py
+++ b/pyre/check.py
@@ -945,6 +945,52 @@ class Check:
                 wasm_float_tol=wasm_float_tol,
             )
 
+    # ── self-checking regression guard ──
+
+    def run_selfcheck(self, name, script, timeout, expect="PASS"):
+        """Run a self-checking regression script on each enabled backend.
+
+        The script asserts its own invariant (exit 0 AND prints *expect*);
+        check.py only honors the exit code and the required marker. Used for
+        guards whose signal is a timing ratio, not byte-identical output, so
+        they cannot go through `run_bench` or the synthetic suite.
+        """
+        print(f"  {name}")
+        for backend in ALL_BACKENDS:
+            if not self.enabled(backend):
+                continue
+            effective_timeout = scaled_timeout(timeout, self._timeout_scale(backend))
+            sys.stdout.write(f"    {backend:<10s}")
+            sys.stdout.flush()
+            output, elapsed, code, stderr = run_timed(
+                [self._pyre(backend), script],
+                timeout_s=effective_timeout,
+                env=pyre_env(),
+            )
+            panic_reason = _jit_panic_reason(stderr)
+            if panic_reason:
+                self._record(backend, False, name, panic_reason)
+                print(f"{red('JIT-PANIC')}  {panic_reason}")
+                self._append_comparison(backend, name, "-", "-", "FAIL")
+                continue
+            if code != 0:
+                detail = (
+                    f"timeout (>{effective_timeout}s)" if code == 124
+                    else f"exit {code}"
+                )
+                self._record(backend, False, name, detail)
+                print(f"{red('FAIL')}  {detail}")
+                self._append_comparison(backend, name, "-", "-", "FAIL")
+                continue
+            if expect not in output:
+                self._record(backend, False, name, f"missing '{expect}'")
+                print(f"{red('FAIL')}  missing '{expect}'")
+                self._append_comparison(backend, name, "-", "-", "FAIL")
+                continue
+            self._record(backend, True, name, "")
+            print(f"{green('PASS')}  {elapsed:.2f}s")
+            self._append_comparison(backend, name, "-", "-", f"{elapsed:.2f}s")
+
     # ── synthetic parity suite ──
 
     def run_synthetic_bench(self, path, timeout):
@@ -1275,6 +1321,11 @@ def main():
         chk.run_bench("spectral_norm",  f"{B}/spectral_norm.py",        5,       2,       7,       2,       7)
         chk.run_bench("nbody",          f"{B}/nbody.py",               10,       3,       None,    3,       None,    wasm_float_tol=True)
         chk.run_bench("fannkuch",       f"{B}/fannkuch.py",            30,       1,       5,       2,       None)
+        chk.run_selfcheck(
+            "loop_reentry",
+            f"{B}/loop_reentry_regression.py",
+            15,
+        )
 
     if not args.no_synthetic:
         print()

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -19079,6 +19079,12 @@ fn mark_trace_reads_module_global_from_code(
     w_code_ptr: usize,
     name_idx: usize,
 ) -> bool {
+    // A null globals dict cannot be probed for membership; report unresolved so
+    // the caller takes the conservative fallback, matching
+    // `mark_trace_reads_module_global_from_frame_name`.
+    if w_globals.is_null() {
+        return false;
+    }
     let Some(name) = (unsafe {
         let raw = pyre_interpreter::w_code_get_ptr(w_code_ptr as pyre_object::PyObjectRef)
             as *const pyre_interpreter::CodeObject;
@@ -22639,7 +22645,20 @@ fn handle(
                         // a trace rooted at a *loop header* falls back to
                         // the plain bridge shape.
                         None => match driver.compile_trace_entry_data() {
-                            Some((original_green_key, entry_meta)) => {
+                            Some((original_green_key, mut entry_meta)) => {
+                                // `compile_trace_entry_data` clones the active
+                                // trace metadata, whose `namespace_dependent` is
+                                // only finalized by `finish_trace_namespace_dependency`
+                                // after the walk returns. An entry bridge is
+                                // compiled mid-walk, before that finalize, so a
+                                // trace that has already read a module global
+                                // would otherwise install the bridge with a stale
+                                // `namespace_dependent = false` and let it be
+                                // re-entered after later namespace growth. Fold in
+                                // the live per-trace flag so the bridge keeps the
+                                // conservative namespace gate.
+                                entry_meta.namespace_dependent |=
+                                    crate::trace::trace_reads_module_global();
                                 driver.meta_interp_mut().compile_trace_from_interp(
                                     key,
                                     &live_args,

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -19067,6 +19067,49 @@ fn try_walker_load_global_cell_fold(
     Ok(true)
 }
 
+fn mark_trace_reads_module_global(w_globals: pyre_object::PyObjectRef, name: &str) {
+    if !w_globals.is_null() && crate::state::module_dict_cell_slot_direct(w_globals, name).is_some()
+    {
+        crate::trace::set_trace_reads_module_global(true);
+    }
+}
+
+fn mark_trace_reads_module_global_from_code(
+    w_globals: pyre_object::PyObjectRef,
+    w_code_ptr: usize,
+    name_idx: usize,
+) -> bool {
+    let Some(name) = (unsafe {
+        let raw = pyre_interpreter::w_code_get_ptr(w_code_ptr as pyre_object::PyObjectRef)
+            as *const pyre_interpreter::CodeObject;
+        if raw.is_null() {
+            None
+        } else {
+            pyre_interpreter::pyframe::load_name_from_code(&*raw, name_idx).map(|n| n.to_string())
+        }
+    }) else {
+        return false;
+    };
+    mark_trace_reads_module_global(w_globals, &name);
+    true
+}
+
+fn mark_trace_reads_module_global_from_frame_name(frame_ptr: usize, w_name_ptr: usize) -> bool {
+    if frame_ptr == 0 || w_name_ptr == 0 {
+        return false;
+    }
+    let frame = unsafe { &*(frame_ptr as *const pyre_interpreter::pyframe::PyFrame) };
+    let w_globals = frame.get_w_globals();
+    if w_globals.is_null() {
+        return false;
+    }
+    let name = unsafe {
+        pyre_object::unicodeobject::w_str_get_value(w_name_ptr as pyre_object::PyObjectRef)
+    };
+    mark_trace_reads_module_global(w_globals, name);
+    true
+}
+
 /// Shared module-dict cell fast path for the LOAD_GLOBAL / LOAD_NAME folds:
 /// const-fold a module-global name read to a `QuasiimmutField` version guard
 /// + elidable `jit_namespace_cell_lookup`, reading an `ObjectMutableCell`'s
@@ -19518,6 +19561,37 @@ fn dispatch_residual_call_iIRd_kind(
     if ctx.is_authoritative_executor
         && ctx.is_full_body_walk
         && ei.pyre_helper == majit_ir::PyreHelperKind::LoadGlobal
+    {
+        if let (Some(&namei_opref), Some(&ns_opref), Some(&code_opref)) =
+            (i_args.first(), r_args.first(), r_args.get(1))
+        {
+            if let (
+                Some(majit_ir::Value::Int(namei)),
+                Some(majit_ir::Value::Ref(majit_ir::GcRef(ns_ptr))),
+                Some(majit_ir::Value::Ref(majit_ir::GcRef(w_code_ptr))),
+            ) = (
+                ctx.trace_ctx.box_value(namei_opref),
+                ctx.trace_ctx.box_value(ns_opref),
+                ctx.trace_ctx.box_value(code_opref),
+            ) {
+                let name_idx = (namei as usize) >> 1;
+                if !mark_trace_reads_module_global_from_code(
+                    ns_ptr as pyre_object::PyObjectRef,
+                    w_code_ptr,
+                    name_idx,
+                ) {
+                    crate::trace::set_trace_reads_module_global(true);
+                }
+            } else {
+                crate::trace::set_trace_reads_module_global(true);
+            }
+        } else {
+            crate::trace::set_trace_reads_module_global(true);
+        }
+    }
+    if ctx.is_authoritative_executor
+        && ctx.is_full_body_walk
+        && ei.pyre_helper == majit_ir::PyreHelperKind::LoadGlobal
         && std::env::var("PYRE_FBW_LOADGLOBAL_FOLD").as_deref() != Ok("0")
         && (!jitcode_has_exception_handler(code) || fbw_builtin_fold_enabled())
     {
@@ -19560,6 +19634,28 @@ fn dispatch_residual_call_iIRd_kind(
     // CanRaise residual a `catch_exception` could otherwise resume into);
     // `try_walker_load_name_cell_fold` gates module scope at runtime and
     // routes non-module frames back to this residual.
+    if ctx.is_authoritative_executor
+        && ctx.is_full_body_walk
+        && ei.pyre_helper == majit_ir::PyreHelperKind::LoadName
+    {
+        if let (Some(&frame_opref), Some(&name_opref)) = (r_args.first(), r_args.get(1)) {
+            if let (
+                Some(majit_ir::Value::Ref(majit_ir::GcRef(frame_ptr))),
+                Some(majit_ir::Value::Ref(majit_ir::GcRef(w_name_ptr))),
+            ) = (
+                ctx.trace_ctx.box_value(frame_opref),
+                ctx.trace_ctx.box_value(name_opref),
+            ) {
+                if !mark_trace_reads_module_global_from_frame_name(frame_ptr, w_name_ptr) {
+                    crate::trace::set_trace_reads_module_global(true);
+                }
+            } else {
+                crate::trace::set_trace_reads_module_global(true);
+            }
+        } else {
+            crate::trace::set_trace_reads_module_global(true);
+        }
+    }
     if ctx.is_authoritative_executor
         && ctx.is_full_body_walk
         && ei.pyre_helper == majit_ir::PyreHelperKind::LoadName

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -10122,6 +10122,32 @@ mod tests {
     }
 
     #[test]
+    fn is_compatible_ignores_namespace_length_when_not_namespace_dependent() {
+        // A pure-compute / builtin-only trace does not fold a module global, so
+        // its compiled code is independent of the globals dict: a later
+        // top-level bind (namespace growth) must not refuse re-entry.
+        let state = empty_state();
+        let mut meta = empty_meta();
+        meta.num_locals = state.local_count();
+        meta.namespace_dependent = false;
+        meta.ns_len = state.namespace_len() + 5;
+        assert!(<PyreJitState as JitState>::is_compatible(&state, &meta));
+    }
+
+    #[test]
+    fn is_compatible_enforces_namespace_length_when_namespace_dependent() {
+        // A trace that read a module global keeps the conservative length gate,
+        // since same-key value rebinds are not value-guarded: a namespace-length
+        // mismatch must refuse re-entry.
+        let state = empty_state();
+        let mut meta = empty_meta();
+        meta.num_locals = state.local_count();
+        meta.namespace_dependent = true;
+        meta.ns_len = state.namespace_len() + 5;
+        assert!(!<PyreJitState as JitState>::is_compatible(&state, &meta));
+    }
+
+    #[test]
     fn test_pre_opcode_snapshot_gate_skips_peek_only_and_no_guard_opcodes() {
         let iter_code =
             compile_function_body("def f(xs):\n    for x in xs:\n        return len(xs)\n");

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -2134,6 +2134,7 @@ pub struct PyreMeta {
     #[vable(num_locals)]
     pub num_locals: usize,
     pub ns_len: usize,
+    pub namespace_dependent: bool,
     #[vable(valuestackdepth)]
     pub valuestackdepth: usize,
     /// Full `locals_cells_stack_w` length on the heap object
@@ -7804,6 +7805,7 @@ impl JitState for PyreJitState {
         PyreMeta {
             num_locals,
             ns_len: self.namespace_len(),
+            namespace_dependent: crate::trace::trace_reads_module_global(),
             valuestackdepth: vsd,
             array_capacity: capacity,
             // virtualizable_gen.rs:24-31 wires `extra_reds = { ec: Ref }` per
@@ -8051,8 +8053,13 @@ impl JitState for PyreJitState {
         // warmstate.py:503-511: RPython enters assembler unconditionally
         // when procedure_token exists. No next_instr check —
         // the compiled code's preamble handles entry from any PC.
-        // Shape checks (nlocals, namespace) ensure frame layout matches.
-        self.local_count() == meta.num_locals && self.namespace_len() == meta.ns_len
+        // Shape checks ensure the frame layout matches.  Namespace length is
+        // load-bearing only for traces that read module globals: pure-compute
+        // and builtin-only loops do not depend on later top-level binds, while
+        // module-global reads still need this conservative gate because
+        // same-key value rebinds are not value-guarded yet.
+        self.local_count() == meta.num_locals
+            && (!meta.namespace_dependent || self.namespace_len() == meta.ns_len)
     }
 
     fn setup_bridge_sym(
@@ -9106,6 +9113,7 @@ impl JitState for PyreJitState {
         PyreMeta {
             num_locals: provisional.num_locals,
             ns_len: provisional.ns_len,
+            namespace_dependent: provisional.namespace_dependent,
             valuestackdepth: provisional.valuestackdepth,
             array_capacity,
             trace_extra_reds: provisional.trace_extra_reds,
@@ -10077,6 +10085,7 @@ mod tests {
         PyreMeta {
             num_locals: 0,
             ns_len: 0,
+            namespace_dependent: false,
             valuestackdepth: 0,
             array_capacity: 0,
             trace_extra_reds: 0,
@@ -10931,6 +10940,7 @@ mod tests {
         let meta = PyreMeta {
             num_locals: 2,
             ns_len: 0,
+            namespace_dependent: false,
             valuestackdepth: 3,
             array_capacity: 4,
             trace_extra_reds: 1,
@@ -10989,6 +10999,7 @@ mod tests {
         let meta = PyreMeta {
             num_locals: 2,
             ns_len: 0,
+            namespace_dependent: false,
             valuestackdepth: 4,
             array_capacity: 5,
             trace_extra_reds: 1,
@@ -11048,6 +11059,7 @@ mod tests {
         let meta = PyreMeta {
             num_locals: 4,
             ns_len: 0,
+            namespace_dependent: false,
             valuestackdepth: 4,
             array_capacity: 4,
             trace_extra_reds: 1,

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -51,6 +51,10 @@ thread_local! {
     /// `WALK_END_PROPAGATED_EXCEPTION`. Bridge tracing leaves this false and
     /// conservatively retains its legacy preflight.
     static WALK_END_PROPAGATE_ALLOWED: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+    /// Set during one trace when a LOAD_GLOBAL / LOAD_NAME resolves through the
+    /// frame's module globals dict.  Such traces still depend on the globals
+    /// namespace length because same-key value rebinds are not guarded yet.
+    static TRACE_READS_MODULE_GLOBAL: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
 }
 
 /// Take-and-reset the walk-end flush flag for the trace that just
@@ -61,6 +65,22 @@ pub fn take_walk_end_flush_committed() -> bool {
 
 pub fn take_walk_end_propagated_exception() -> Option<pyre_interpreter::PyError> {
     WALK_END_PROPAGATED_EXCEPTION.with(|c| c.borrow_mut().take())
+}
+
+pub(crate) fn set_trace_reads_module_global(value: bool) {
+    TRACE_READS_MODULE_GLOBAL.with(|c| c.set(value));
+}
+
+pub(crate) fn trace_reads_module_global() -> bool {
+    TRACE_READS_MODULE_GLOBAL.with(|c| c.get())
+}
+
+fn finish_trace_namespace_dependency(meta: &mut MetaInterp<PyreMeta>) {
+    let namespace_dependent = trace_reads_module_global();
+    if let Some(trace_meta) = meta.trace_meta_mut() {
+        trace_meta.namespace_dependent = namespace_dependent;
+    }
+    set_trace_reads_module_global(false);
 }
 
 thread_local! {
@@ -437,6 +457,7 @@ pub fn trace_bytecode(
     WALK_END_FLUSH_COMMITTED.with(|c| c.set(false));
     WALK_END_PROPAGATED_EXCEPTION.with(|c| *c.borrow_mut() = None);
     WALK_END_PROPAGATE_ALLOWED.with(|c| c.set(allow_propagate_out));
+    set_trace_reads_module_global(false);
     // Likewise clear any no-replay finish payload a prior trace left
     // unconsumed.  The FBW walk re-clears this in `run_perfn_walk`; the
     // trait leg (`trace_step_result_to_action`) has no such epilogue, so
@@ -517,9 +538,11 @@ pub fn trace_bytecode(
         // sub-walk+inject shape is a separate unsound deviation, kept gated off.
         if crate::state::p2_drain_enabled() {
             let action = drive_bridge_carrier_walk(ctx, sym, w_code, start_pc, cf_addr, carrier);
+            finish_trace_namespace_dependency(meta);
             return (action, concrete_frame);
         }
         let action = drive_bridge_framestack_walk(ctx, sym, w_code, start_pc, cf_addr, carrier);
+        finish_trace_namespace_dependency(meta);
         return (action, concrete_frame);
     }
     // Issue #73 walker-as-tracer foundation probe (slice #1, gated).
@@ -540,6 +563,7 @@ pub fn trace_bytecode(
     // frame at `root_pc` instead of the deepest resumed callee.
     if carrier.is_none() && std::env::var_os("PYRE_WALK_PERFN_JITCODE").is_some() {
         probe_walk_perfn_jitcode(ctx, sym, w_code, start_pc, cf_addr);
+        finish_trace_namespace_dependency(meta);
         return (TraceAction::Abort, concrete_frame);
     }
     // Issue #73 Phase 5 production flip: the per-CodeObject JitCode body is
@@ -566,6 +590,7 @@ pub fn trace_bytecode(
         && !static_decline
     {
         let action = full_body_walk_trace(ctx, sym, w_code, start_pc, cf_addr);
+        finish_trace_namespace_dependency(meta);
         return (action, concrete_frame);
     }
     // A self-recursive `arg_count != 1` callee is declined by
@@ -587,6 +612,7 @@ pub fn trace_bytecode(
     } else {
         "Trait::DeclinedAbort"
     });
+    finish_trace_namespace_dependency(meta);
     (TraceAction::Abort, concrete_frame)
 }
 

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -1005,6 +1005,10 @@ impl MIFrame {
             unsafe { &*(self.concrete_frame_addr as *const pyre_interpreter::pyframe::PyFrame) };
         let w_globals = frame.get_w_globals();
         if w_globals.is_null() {
+            // Cannot probe a null globals dict for membership; classify
+            // conservatively as a module-global read, like the
+            // `concrete_frame_addr == 0` path above.
+            crate::trace::set_trace_reads_module_global(true);
             return;
         }
         if crate::state::module_dict_cell_slot_direct(w_globals, name).is_some() {

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -996,6 +996,22 @@ pub(crate) fn swap_stack_slots(
 }
 
 impl MIFrame {
+    fn mark_trace_reads_module_global_if_present(&self, name: &str) {
+        if self.concrete_frame_addr == 0 {
+            crate::trace::set_trace_reads_module_global(true);
+            return;
+        }
+        let frame =
+            unsafe { &*(self.concrete_frame_addr as *const pyre_interpreter::pyframe::PyFrame) };
+        let w_globals = frame.get_w_globals();
+        if w_globals.is_null() {
+            return;
+        }
+        if crate::state::module_dict_cell_slot_direct(w_globals, name).is_some() {
+            crate::trace::set_trace_reads_module_global(true);
+        }
+    }
+
     #[allow(dead_code)]
     fn active_execution_context(&self) -> *const pyre_interpreter::PyExecutionContext {
         let exec_ctx = self.sym().concrete_execution_context;
@@ -7627,7 +7643,9 @@ impl MIFrame {
         if let Instruction::LoadName { namei } = instruction {
             use pyre_interpreter::OpcodeStepExecutor;
             let idx = namei.get(op_arg) as usize;
-            OpcodeStepExecutor::load_name(self, code.names[idx].as_ref(), idx)?;
+            let name = code.names[idx].as_ref();
+            self.mark_trace_reads_module_global_if_present(name);
+            OpcodeStepExecutor::load_name(self, name, idx)?;
             return Ok(Some(pyre_interpreter::StepResult::Continue));
         }
         if let Instruction::StoreName { namei } = instruction {
@@ -7656,12 +7674,9 @@ impl MIFrame {
             let raw = namei.get(op_arg) as usize;
             let name_idx = raw >> 1;
             let push_null = (raw & 1) != 0;
-            OpcodeStepExecutor::load_global(
-                self,
-                code.names[name_idx].as_ref(),
-                name_idx,
-                push_null,
-            )?;
+            let name = code.names[name_idx].as_ref();
+            self.mark_trace_reads_module_global_if_present(name);
+            OpcodeStepExecutor::load_global(self, name, name_idx, push_null)?;
             return Ok(Some(pyre_interpreter::StepResult::Continue));
         }
 

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -9007,6 +9007,7 @@ mod tests {
         let meta = PyreMeta {
             num_locals: 4,
             ns_len: 0,
+            namespace_dependent: false,
             valuestackdepth: 4,
             array_capacity: 4,
             trace_extra_reds: 1,


### PR DESCRIPTION
## Problem

A hot loop compiled early in a module was never re-entered on later activations
once the module bound any new top-level name. `PyreJitState::is_compatible`
required `namespace_len() == meta.ns_len` unconditionally; `namespace_len()` is
the module globals-dict length, which grows as a module binds top-level names.
Once it no longer matched the length captured at compile time, every re-entry was
refused (`Abort { reason: incompatible-state }`) and the loop ran fully
interpreted with a per-iteration compiled-entry abort — far slower than plain
interpretation. Fixes #152.

## Fix

The namespace-length term is load-bearing only for correctness of traces that
read a module global: such reads fold the value into the trace, and the emitted
`QuasiimmutField` version guard fires on module-dict key-set changes but not on a
same-key value rebind, so re-entering after a rebind could read a stale baked
value.

This gates the term on that dependence:

- `PyreMeta` gains a `namespace_dependent` flag.
- A per-trace thread-local is raised whenever a traced `LOAD_GLOBAL` / `LOAD_NAME`
  resolves a name present in the frame's module globals dict, hooked in both the
  full-body-walker leg (`jitcode_dispatch.rs`, covering inlined callees) and the
  trait leg (`trace_opcode.rs`). Name-resolution failures conservatively raise the
  flag.
- `is_compatible` applies the length gate only for namespace-dependent traces:

  ```rust
  self.local_count() == meta.num_locals
      && (!meta.namespace_dependent || self.namespace_len() == meta.ns_len)
  ```

Pure-compute (`while`) and builtin-only (`range`) loops re-enter across namespace
growth. Module-global-reading loops keep the conservative gate (no correctness
regression; a value-rebind-safe fold that would drop the gate entirely is a
follow-up).

## Regression guard

`pyre/bench/loop_reentry_regression.py` runs a hot `while` loop across several
activations and fails if a later call runs >20x slower than the first. It is
wired into `check.py` via a new `run_selfcheck` runner (honors the script's exit
code + `PASS` marker instead of a vs-pypy time comparison).

## Verification

- `python pyre/check.py --backend dynasm,cranelift`: **correctness green on both
  backends** — every synthetic parity test byte-identical to pypy, no wrong
  output / crash / panic.
- `loop_reentry` PASS on both backends (later calls ~0.3-0.4x the first, i.e. not
  slower).
- Global-rebind re-entry correctness (direct read, read via inlined callee,
  module-level `LOAD_NAME`, and the `global_reassign` / `global_reassign_obj`
  synthetic tests) byte-identical to CPython on both backends.
- No perf regression: an A/B build of this branch vs its origin/main base times
  `int_loop`/`nested_loop` within <1% (median 170.5 vs 169.4 ms, 382.8 vs
  382.5 ms). The `int_loop`/`nested_loop` vs-pypy perf-gate flakiness seen on some
  runs reproduces identically on the unmodified base and is unrelated to this
  change (the affected loops read no module globals, so `namespace_dependent` is
  false and their compiled code and entry decisions are unchanged).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved JIT handling for code that reads module-level names.
  * Prevented unnecessary recompilation when namespace size changes without affecting traced dependencies.
  * Improved trace metadata handling across early exits and resumed execution.

* **Tests**
  * Added a regression benchmark that detects significant slowdowns when re-entering compiled loops.
  * Integrated the regression check into pre-merge validation across supported backends.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->