### PR TITLE
importing IMPORT_NAME __import__ fixes + vable getarrayitem Option<Value>

### DIFF
--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -4122,7 +4122,7 @@ impl<S: JitState> JitDriver<S> {
         index_runtime_value: i64,
         fdescr: DescrRef,
         adescr: DescrRef,
-    ) -> (OpRef, Value) {
+    ) -> (OpRef, Option<Value>) {
         self.meta.opimpl_getarrayitem_vable_int(
             pc,
             vable_opref,
@@ -4141,7 +4141,7 @@ impl<S: JitState> JitDriver<S> {
         index_runtime_value: i64,
         fdescr: DescrRef,
         adescr: DescrRef,
-    ) -> (OpRef, Value) {
+    ) -> (OpRef, Option<Value>) {
         self.meta.opimpl_getarrayitem_vable_ref(
             pc,
             vable_opref,
@@ -4160,7 +4160,7 @@ impl<S: JitState> JitDriver<S> {
         index_runtime_value: i64,
         fdescr: DescrRef,
         adescr: DescrRef,
-    ) -> (OpRef, Value) {
+    ) -> (OpRef, Option<Value>) {
         self.meta.opimpl_getarrayitem_vable_float(
             pc,
             vable_opref,

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -4369,7 +4369,7 @@ impl<M: Clone> MetaInterp<M> {
         index_runtime_value: i64,
         fdescr: DescrRef,
         adescr: DescrRef,
-    ) -> (OpRef, Value) {
+    ) -> (OpRef, Option<Value>) {
         self.tracing
             .as_mut()
             .expect("opimpl_getarrayitem_vable_int requires active tracing")
@@ -4392,7 +4392,7 @@ impl<M: Clone> MetaInterp<M> {
         index_runtime_value: i64,
         fdescr: DescrRef,
         adescr: DescrRef,
-    ) -> (OpRef, Value) {
+    ) -> (OpRef, Option<Value>) {
         self.tracing
             .as_mut()
             .expect("opimpl_getarrayitem_vable_ref requires active tracing")
@@ -4415,7 +4415,7 @@ impl<M: Clone> MetaInterp<M> {
         index_runtime_value: i64,
         fdescr: DescrRef,
         adescr: DescrRef,
-    ) -> (OpRef, Value) {
+    ) -> (OpRef, Option<Value>) {
         self.tracing
             .as_mut()
             .expect("opimpl_getarrayitem_vable_float requires active tracing")

--- a/majit/majit-metainterp/src/pyjitpl/dispatch.rs
+++ b/majit/majit-metainterp/src/pyjitpl/dispatch.rs
@@ -3279,7 +3279,7 @@ where
                     fdescr,
                     adescr,
                 );
-                self.set_int_reg(dest, Some(opref), Some(value_as_int_bits(value)));
+                self.set_int_reg(dest, Some(opref), value.map(value_as_int_bits));
             }
             jitcode::insns::BC_GETARRAYITEM_VABLE_R => {
                 let (opcode_pc, vable_reg, array_idx, index_reg, dest) = {
@@ -3302,7 +3302,7 @@ where
                     fdescr,
                     adescr,
                 );
-                self.set_ref_reg(dest, Some(opref), Some(value_as_ref_bits(value)));
+                self.set_ref_reg(dest, Some(opref), value.map(value_as_ref_bits));
             }
             jitcode::insns::BC_GETARRAYITEM_VABLE_F => {
                 let (opcode_pc, vable_reg, array_idx, index_reg, dest) = {
@@ -3325,7 +3325,7 @@ where
                     fdescr,
                     adescr,
                 );
-                self.set_float_reg(dest, Some(opref), Some(value_as_float_bits(value)));
+                self.set_float_reg(dest, Some(opref), value.map(value_as_float_bits));
             }
             jitcode::insns::BC_SETARRAYITEM_VABLE_I => {
                 let (opcode_pc, vable_reg, array_idx, index_reg, src) = {

--- a/majit/majit-metainterp/src/trace_ctx.rs
+++ b/majit/majit-metainterp/src/trace_ctx.rs
@@ -3413,15 +3413,15 @@ impl TraceCtx {
         fdescr: &DescrRef,
         item_index: usize,
         adescr: DescrRef,
-    ) -> (OpRef, Value) {
+    ) -> (OpRef, Option<Value>) {
         if let Some(flat_idx) = self.vable_array_flat_index(fdescr, item_index) {
-            if let Some(entry) = self.virtualizable_entry_at(flat_idx) {
-                return entry;
+            if let Some((op, value)) = self.virtualizable_entry_at(flat_idx) {
+                return (op, concrete_shadow_value(value));
             }
         }
         let index = self.const_int(item_index as i64);
         let op = self.record_op_with_descr(OpCode::GetarrayitemGcI, &[array_opref, index], adescr);
-        (op, Value::Void)
+        (op, None)
     }
 
     /// pyjitpl.py:1201-1216 `_get_arrayitem_vable_index(pc, arrayfielddescr, indexbox)`.
@@ -3479,7 +3479,7 @@ impl TraceCtx {
         index_runtime_value: i64,
         fdescr: DescrRef,
         adescr: DescrRef,
-    ) -> (OpRef, Value) {
+    ) -> (OpRef, Option<Value>) {
         let concrete = self.concrete_of_opref(vable_opref);
         if self.is_nonstandard_virtualizable(pc, vable_opref, &fdescr, concrete) {
             // arraybox = self.opimpl_getfield_gc_r(box, fdescr)
@@ -3489,7 +3489,7 @@ impl TraceCtx {
                 self.record_op_with_descr(OpCode::GetfieldGcR, &[vable_opref], record_descr);
             return (
                 self.vable_getarrayitem_int_descr(array_opref, index, adescr),
-                Value::Void,
+                None,
             );
         }
         // index = self._get_arrayitem_vable_index(pc, fdescr, indexbox)
@@ -3497,8 +3497,8 @@ impl TraceCtx {
         if let Some(flat_idx) =
             self.get_arrayitem_vable_index(pc, index, index_runtime_value, &fdescr)
         {
-            if let Some(entry) = self.virtualizable_entry_at(flat_idx) {
-                return entry;
+            if let Some((op, value)) = self.virtualizable_entry_at(flat_idx) {
+                return (op, concrete_shadow_value(value));
             }
         }
         // Fallback: vable layout missing — go through getfield + arrayitem.
@@ -3509,7 +3509,7 @@ impl TraceCtx {
         } else {
             (
                 self.vable_getarrayitem_int_descr(array_opref, index, adescr),
-                Value::Void,
+                None,
             )
         }
     }
@@ -3521,15 +3521,15 @@ impl TraceCtx {
         fdescr: &DescrRef,
         item_index: usize,
         adescr: DescrRef,
-    ) -> (OpRef, Value) {
+    ) -> (OpRef, Option<Value>) {
         if let Some(flat_idx) = self.vable_array_flat_index(fdescr, item_index) {
-            if let Some(entry) = self.virtualizable_entry_at(flat_idx) {
-                return entry;
+            if let Some((op, value)) = self.virtualizable_entry_at(flat_idx) {
+                return (op, concrete_shadow_value(value));
             }
         }
         let index = self.const_int(item_index as i64);
         let op = self.record_op_with_descr(OpCode::GetarrayitemGcR, &[array_opref, index], adescr);
-        (op, Value::Void)
+        (op, None)
     }
 
     /// pyjitpl.py:1218-1234 `_opimpl_getarrayitem_vable` — ref variant.
@@ -3541,7 +3541,7 @@ impl TraceCtx {
         index_runtime_value: i64,
         fdescr: DescrRef,
         adescr: DescrRef,
-    ) -> (OpRef, Value) {
+    ) -> (OpRef, Option<Value>) {
         let concrete = self.concrete_of_opref(vable_opref);
         if self.is_nonstandard_virtualizable(pc, vable_opref, &fdescr, concrete) {
             let fwd = self.nonstandard_vable_element_concrete(
@@ -3556,15 +3556,15 @@ impl TraceCtx {
             let item = self.vable_getarrayitem_ref_descr(array_opref, index, adescr);
             if let Some(v) = fwd {
                 self.set_opref_concrete(item, v);
-                return (item, v);
+                return (item, Some(v));
             }
-            return (item, Value::Void);
+            return (item, None);
         }
         if let Some(flat_idx) =
             self.get_arrayitem_vable_index(pc, index, index_runtime_value, &fdescr)
         {
-            if let Some(entry) = self.virtualizable_entry_at(flat_idx) {
-                return entry;
+            if let Some((op, value)) = self.virtualizable_entry_at(flat_idx) {
+                return (op, concrete_shadow_value(value));
             }
         }
         let array_opref =
@@ -3574,7 +3574,7 @@ impl TraceCtx {
         } else {
             (
                 self.vable_getarrayitem_ref_descr(array_opref, index, adescr),
-                Value::Void,
+                None,
             )
         }
     }
@@ -3586,15 +3586,15 @@ impl TraceCtx {
         fdescr: &DescrRef,
         item_index: usize,
         adescr: DescrRef,
-    ) -> (OpRef, Value) {
+    ) -> (OpRef, Option<Value>) {
         if let Some(flat_idx) = self.vable_array_flat_index(fdescr, item_index) {
-            if let Some(entry) = self.virtualizable_entry_at(flat_idx) {
-                return entry;
+            if let Some((op, value)) = self.virtualizable_entry_at(flat_idx) {
+                return (op, concrete_shadow_value(value));
             }
         }
         let index = self.const_int(item_index as i64);
         let op = self.record_op_with_descr(OpCode::GetarrayitemGcF, &[array_opref, index], adescr);
-        (op, Value::Void)
+        (op, None)
     }
 
     /// pyjitpl.py:1218-1234 `_opimpl_getarrayitem_vable` — float variant.
@@ -3606,7 +3606,7 @@ impl TraceCtx {
         index_runtime_value: i64,
         fdescr: DescrRef,
         adescr: DescrRef,
-    ) -> (OpRef, Value) {
+    ) -> (OpRef, Option<Value>) {
         let concrete = self.concrete_of_opref(vable_opref);
         if self.is_nonstandard_virtualizable(pc, vable_opref, &fdescr, concrete) {
             let record_descr = self.vable_array_record_descr(&fdescr);
@@ -3614,14 +3614,14 @@ impl TraceCtx {
                 self.record_op_with_descr(OpCode::GetfieldGcR, &[vable_opref], record_descr);
             return (
                 self.vable_getarrayitem_float_descr(array_opref, index, adescr),
-                Value::Void,
+                None,
             );
         }
         if let Some(flat_idx) =
             self.get_arrayitem_vable_index(pc, index, index_runtime_value, &fdescr)
         {
-            if let Some(entry) = self.virtualizable_entry_at(flat_idx) {
-                return entry;
+            if let Some((op, value)) = self.virtualizable_entry_at(flat_idx) {
+                return (op, concrete_shadow_value(value));
             }
         }
         let array_opref =
@@ -3631,7 +3631,7 @@ impl TraceCtx {
         } else {
             (
                 self.vable_getarrayitem_float_descr(array_opref, index, adescr),
-                Value::Void,
+                None,
             )
         }
     }

--- a/pyre/pyre-interpreter/src/importing.rs
+++ b/pyre/pyre-interpreter/src/importing.rs
@@ -1868,7 +1868,7 @@ pub fn import_name(
     w_fromlist: PyObjectRef,
     w_flag: PyObjectRef,
 ) -> Result<PyObjectRef, crate::PyError> {
-    let w_builtin = frame.w_builtin;
+    let w_builtin = frame.get_builtin();
     let w_import = if !w_builtin.is_null() && unsafe { is_module(w_builtin) } {
         let w_dict = unsafe { pyre_object::w_module_get_w_dict(w_builtin) };
         if w_dict.is_null() {

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -4340,6 +4340,7 @@ fn getarrayitem_vable_via_metainterp(
         _ => unreachable!("dst_bank must be 'i', 'r' or 'f'"),
     };
     walker_capture_inline_nonstandard_vable_guard(ctx, op.pc, guards_before)?;
+    let shadow_value = shadow_value.unwrap_or(Value::Void);
     // When the read missed every concrete channel (`Void`) but we are inside
     // an inlined callee, fall back to the per-frame concrete-locals shadow —
     // a loop-carried local read after a may-force op in the loop body has no

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -4238,6 +4238,15 @@ pub extern "C" fn bh_import_name_fn(
     let frame = frame_ptr as *mut PyFrame;
     debug_assert!(!frame.is_null(), "IMPORT_NAME requires a live frame");
     if frame.is_null() {
+        // IMPORT_NAME produces a module or raises; it never yields a null
+        // result.  A null frame cannot honour that, so fail closed by
+        // publishing an exception for the trailing `GuardNoException`
+        // instead of returning a bare 0 the guard would accept.
+        let err = pyre_interpreter::PyError::new(
+            pyre_interpreter::PyErrorKind::SystemError,
+            "IMPORT_NAME residual received a null frame",
+        );
+        publish_residual_call_exception(err.to_exc_object() as i64);
         return 0;
     }
     match pyre_interpreter::importing::import_name(


### PR DESCRIPTION
Two follow-ups on the `box-pool` line: the post-merge Codex parity review of the IMPORT_NAME work (PR #470), and the next slice of the issue-#181 value model.

## importing: IMPORT_NAME via `get_builtin` + JIT null-frame fail-closed

Addresses the two section-1 regressions the Codex parity review flagged on the merged IMPORT_NAME patch.

- **`import_name` bypassed the execution-context builtin fallback.** It read `frame.w_builtin` directly; `pyopcode.py IMPORT_NAME` fetches `__import__` via `self.get_builtin()`, which pyre's `get_builtin()` implements with a fallback to the EC default when the frame's cached builtin is null. A frame with an unset cached builtin therefore wrongly raised `ImportError("__import__ not found")`. Now calls `frame.get_builtin()`.
- **`bh_import_name_fn` returned a bare `0` on a null residual frame** without publishing an exception, so the trailing `GuardNoException` accepted a null "module". IMPORT_NAME's contract is module-or-raise; the null-frame path now publishes a `SystemError` so the guard fails closed.

## trace_ctx: vable getarrayitem returns `Option<Value>` unknown

Extends the PR #465 field-getter value-model flip to the sibling array-item getters, fixing the same latent register-stamp bug for arrays.

The vable array-item getters returned `(OpRef, Value)` with `Value::Void` as the "unknown at trace time" sentinel. A residual / fallback array read produced `Value::Void`, and the dispatch consumer stamped it into a register as `Some(value_as_int_bits(Value::Void))` = `Some(0)` — recording a bogus concrete zero where the value is genuinely unknown, which can mislead downstream const-fold / guard decisions. (The FBW live tracer derives the concrete independently and never had the bug; only the metainterp trait path did.)

`vable_getarrayitem_{int,ref,float}_{vable,indexed}` — and the `MetaInterp` / `JitDriver` pass-throughs — now return `(OpRef, Option<Value>)`, mirroring `vable_getfield_*`: virtualizable-cache hits carry the value through `concrete_shadow_value`, residual/fallback reads return `None`, and the dispatch consumer uses `value.map(...)` so an unknown read leaves the register unstamped. The FBW `getarrayitem_vable_via_metainterp` path keeps its local `Value::Void` sentinel via `unwrap_or` at the boundary (logic unchanged). After the flip, `trace_ctx` has no remaining `(OpRef, Value)` Void-unknown getter.

## Verification

Both commits, both backends:

- `cargo test -p majit-metainterp --features dynasm --lib` — 1395 passed
- `cargo test -p majit-metainterp --features cranelift --lib` — 1393 passed
- `cargo test -p pyre-jit-trace --features dynasm --lib` — 265 passed
- `python ./pyre/check.py --backend dynasm` — 161/161
- `python ./pyre/check.py --backend cranelift` — 161/161
- `extra_tests/snippets/import.py` and a monkeypatched-`__import__` repro match CPython

Branch was rebased onto current `main` (incl. #494) after local verification; the PR CI gate re-confirms green on the rebased base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
