### PR TITLE
comparison slots: eq/ne arity guards, mappingproxy unwrap, exception propagation, dict __eq__ guard

### DIFF
--- a/pyre/pyre-interpreter/src/objspace/descroperation.rs
+++ b/pyre/pyre-interpreter/src/objspace/descroperation.rs
@@ -3469,20 +3469,20 @@ pub fn compare_slot(a: PyObjectRef, b: PyObjectRef, op: CompareOp) -> PyResult {
         // path is the one that succeeds for `set == d.keys()`.
         if let Some(a_type) = crate::typedef::r#type(a) {
             if let Some(method) = lookup_in_type_where(a_type, dunder) {
-                if let Ok(result) = crate::call::call_function_impl_result(method, &[a, b]) {
-                    if !is_not_implemented(result) {
-                        return Ok(result);
-                    }
+                // A raised exception (not NotImplemented) propagates; only
+                // NotImplemented falls through to the reflected comparison.
+                let result = crate::call::call_function_impl_result(method, &[a, b])?;
+                if !is_not_implemented(result) {
+                    return Ok(result);
                 }
             }
         }
         if let Some(rdunder) = reverse_dunder(dunder) {
             if let Some(b_type) = crate::typedef::r#type(b) {
                 if let Some(method) = lookup_in_type_where(b_type, rdunder) {
-                    if let Ok(result) = crate::call::call_function_impl_result(method, &[b, a]) {
-                        if !is_not_implemented(result) {
-                            return Ok(result);
-                        }
+                    let result = crate::call::call_function_impl_result(method, &[b, a])?;
+                    if !is_not_implemented(result) {
+                        return Ok(result);
                     }
                 }
             }

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -3180,11 +3180,16 @@ fn init_dict_type(ns: &mut DictStorage) {
                     let backing = crate::type_methods::resolve_dict_backing(o);
                     if backing.is_null() { o } else { backing }
                 };
-                crate::baseobjspace::compare(
-                    resolve(args[0]),
-                    resolve(args[1]),
-                    crate::baseobjspace::CompareOp::Eq,
-                )
+                let a = resolve(args[0]);
+                let b = resolve(args[1]);
+                // `dictmultiobject.py descr_eq`: a non-dict operand yields
+                // NotImplemented. Handing it to `compare` would re-dispatch
+                // to this `__eq__` (the operand is not a dict for compare's
+                // fast path) and recurse.
+                if !unsafe { pyre_object::is_dict(b) } {
+                    return Ok(pyre_object::w_not_implemented());
+                }
+                crate::baseobjspace::compare(a, b, crate::baseobjspace::CompareOp::Eq)
             },
             2,
         ),

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -4750,10 +4750,17 @@ fn init_mappingproxy_type(ns: &mut DictStorage) {
         args: &[PyObjectRef],
         op: crate::baseobjspace::CompareOp,
     ) -> Result<PyObjectRef, crate::PyError> {
-        if args.len() < 2 {
-            return Ok(pyre_object::w_bool_from(false));
-        }
-        crate::baseobjspace::compare(args[0], args[1], op)
+        crate::type_methods::arity_slot(args, 1)?;
+        // descr_op → getattr(space, op)(self.w_mapping, w_other): the
+        // comparison runs on the wrapped mapping, not the proxy itself.
+        let self_mapping = unsafe {
+            if pyre_object::is_dict_proxy(args[0]) {
+                pyre_object::w_dict_proxy_get_mapping(args[0])
+            } else {
+                args[0]
+            }
+        };
+        crate::baseobjspace::compare(self_mapping, args[1], op)
     }
     fn proxy_eq(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
         cmp_helper(args, crate::baseobjspace::CompareOp::Eq)
@@ -9414,9 +9421,8 @@ fn init_object_type(ns: &mut DictStorage) {
         make_builtin_function_with_arity(
             "__eq__",
             |args| {
-                Ok(pyre_object::w_bool_from(
-                    args.len() >= 2 && std::ptr::eq(args[0], args[1]),
-                ))
+                crate::type_methods::arity_slot(args, 1)?;
+                Ok(pyre_object::w_bool_from(std::ptr::eq(args[0], args[1])))
             },
             2,
         ),
@@ -9431,9 +9437,7 @@ fn init_object_type(ns: &mut DictStorage) {
         make_builtin_function_with_arity(
             "__ne__",
             |args| {
-                if args.len() < 2 {
-                    return Ok(pyre_object::w_bool_from(true));
-                }
+                crate::type_methods::arity_slot(args, 1)?;
                 let eq = crate::baseobjspace::compare(
                     args[0],
                     args[1],


### PR DESCRIPTION
Comparison-slot correctness fixes across `object`/`mappingproxy`/`dict`.

## `3df8cead57f` object/mappingproxy eq/ne: arity guards; mappingproxy self unwrap

- `object.__eq__` / `object.__ne__` slots now enforce exact arity via `arity_slot(args, 1)?`, raising `expected 1 argument, got N` for wrong argc instead of silently accepting extra args. Dead `if args.len() < 2` early-return in `__ne__` removed; the `is_not_implemented(eq)` passthrough + negation logic is preserved.
- `mappingproxy` comparison helper unwraps the wrapped mapping before comparing (`descr_op` runs on `self.w_mapping`, not the proxy), and enforces the same arity guard.

## `3687f128628` comparison: propagate builtin comparison-slot exceptions; dict `__eq__` non-dict guard

Two coupled fixes uncovered while investigating the `mp < {..}` error message:

1. **Swallowed exceptions (`compare_slot`).** The MRO-driven dunder dispatch wrapped both the forward and reflected calls in `if let Ok(result) = call(...)`, silently swallowing any exception a comparison slot raised and falling through to the generic `not supported between instances of A and B` formatter. `do_richcompare` propagates a raised exception immediately and only falls through on `NotImplemented`; both dispatch sites changed to `let result = call(...)?`.

2. **Latent dict `__eq__` self-recursion (unmasked by #1).** `dict.__eq__` called `compare()` for a non-dict rhs, which re-dispatched back into `dict.__eq__` — an infinite self-loop. The old swallow was catching the per-level `RecursionError` and terminating via the identity fallback (`{} == 5` → `False`), so the bug never surfaced until exceptions began propagating. `dict.__eq__` now returns `NotImplemented` for a non-dict resolved rhs, matching `dictmultiobject.py descr_eq`. Blast radius is narrow: `list`/`tuple`/`str`/`int` are already guarded by the `cmp_dunder!` `$guard`.

## Verification

- Probe suites (operator paths + 33 comprehensive cases: `dict` × `{int, set, list, str, None, subclass}`, cross-type, dict-view ordering raise, user-class raise propagation, `mp <`) byte-identical to CPython 3.14.2 on **both** backends.
- `pyre/check.py`: **cranelift 161/161 + dynasm 161/161** all passed.
- `cargo fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
