### PR TITLE
jit: fix nested-loop TypeError crash (vstack TOS poisoning + non-flush bridge resume)

### DIFF
--- a/pyre/bench/synth/nested_for_varying_trip.py
+++ b/pyre/bench/synth/nested_for_varying_trip.py
@@ -1,0 +1,18 @@
+# A nested loop over a sliced list whose length varies between outer
+# iterations must preserve both iterators and the accumulator when a
+# compiled exhaustion guard resumes in the interpreter. The exact
+# aggregate makes corruption of either iterator or the accumulator
+# visible in the output.
+N = 5000
+
+
+def main():
+    total = 0
+    base = [1, 2]
+    for k in range(N):
+        for value in base[:(k % 2 + 1)]:
+            total += value
+    return total
+
+
+print(main())

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -4072,7 +4072,13 @@ fn getfield_vable_via_metainterp(
             write_int_reg(ctx, op.pc, dst, result, concrete_for_shadow)?;
         }
         'r' => {
+            // Scalar vable fields are frame bookkeeping, never Python
+            // operand-stack values, so they must not become the mirror's TOS
+            // candidate. `get_list_of_active_boxes` (pyjitpl.py:177-234)
+            // never names scalar fields as per-PC stack slots.
+            let vstack_last_ref = ctx.vstack_last_ref;
             write_ref_reg(ctx, op.pc, dst, result, concrete_for_shadow)?;
+            ctx.vstack_last_ref = vstack_last_ref;
         }
         'f' => {
             let len = ctx.registers_f.len();

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -2524,7 +2524,16 @@ pub fn trace_and_compile_from_bridge(
     // though the bridge compiled. The walk took the non-flush path, so it
     // committed no side effects; the blackhole re-running the resumed region
     // applies them exactly once.
-    let resume_via_blackhole = !adopted_walk_end_state && is_multiframe_resume;
+    // The non-flush path applies to single-frame guards too: without the
+    // committed walk-end state the live frame's last_instr / operand stack
+    // were never advanced through the guard's resume region (only the
+    // blackhole syncs them), so "continue running normally" resumes at the
+    // enclosing loop header and silently skips the region between the guard
+    // and the header — the deopt iteration's remaining inner-loop work.
+    // Complete this iteration through the blackhole exactly like the
+    // multi-frame case above; the compiled bridge stays attached for
+    // subsequent failures.
+    let resume_via_blackhole = !adopted_walk_end_state;
 
     // merge_point handles Finish/CloseLoop via bridge_info.
     if outcome.is_some() {


### PR DESCRIPTION
Fixes the hard `TypeError: not an iterator` crash on nested loops whose inner
trip count varies per outer iteration (the crash-variant of #177). Two stacked
defects:

1. **vstack TOS poisoning (crash).** `getfield_vable_via_metainterp`'s `'r'`
   dst-write stamped `vstack_last_ref`, so a `jit_merge_point`'s pycode green
   load between an opcode's residual result and the opcode boundary replaced the
   mirror's TOS candidate with the pycode box. The guard-capture stack overlay
   then wrote that box into the vable snapshot's iterator stack slot, and the
   deopt write-back put the code object where the interpreter expected an
   iterator — surfacing as `TypeError: not an iterator`. Scalar vable fields are
   frame bookkeeping, never operand-stack values (`get_list_of_active_boxes`,
   `pyjitpl.py:177-234`, never names them as per-PC stack slots); preserve
   `vstack_last_ref` across that one write.

2. **non-flush single-frame bridge resume.** `trace_and_compile_from_bridge`
   returned "bridge compiled, continue running normally" for single-frame walks
   that did not commit their end state, but only the blackhole syncs the live
   frame's `last_instr` / operand stack, so the interpreter resumed at the
   enclosing loop header and skipped the region between the guard and the header
   (the deopt iteration's remaining inner-loop work). Route the non-flush path
   through the blackhole for single-frame guards too, matching the multi-frame
   arm; the compiled bridge stays attached for subsequent failures.

Adds `synth/nested_for_varying_trip` (a varying-length list-slice inner loop) as
a regression gate.

## Verification

- `pyre/check.py --backend dynasm,cranelift`: **162/162 both backends** (incl.
  the new gate).
- `cargo test --features dynasm -p pyre-jit-trace -p pyre-jit`: 265 pass.
- Crash repro (for-loop helper called in a hot outer loop) no longer raises;
  `synth/nested_for_varying_trip`, `nested_foriter_call`, `loop_callee_return`,
  `nested_foriter_range` all pass on both backends.

## Interim relief; root-cause fix is epic #493

The narrow shape "a helper containing its own `FOR_ITER` inner loop, called from
a hot outer loop" still under-counts by a small one-time amount at bridge
compile — the nested-`FOR_ITER` in-flight-item residual, a symptom of the FBW
replay-from-entry adaptation. **Epic #493 (FBW always-commit protocol)** is the
root-cause fix: it retires replay-from-entry, so the walk's end state is adopted
instead of re-run, closing this residual *and* #467 wholesale. Its
position-accurate flush supersedes fix (2) above (once the walk always commits,
`resume_via_blackhole` is never taken for this path, so fix (2) goes inert — no
conflict).

This PR is interim crash relief so `main` stops raising `TypeError` on ordinary
varying-trip nested loops while #493 lands: it converts the crash into
completes-with-small-deficit for that one shape and fully fixes every other
varying-trip nested shape. Residual tracked by #177 / #493.
