### PR TITLE
interp: time.asctime year format parity

### DIFF
--- a/pyre/pyre-interpreter/src/host_seam.rs
+++ b/pyre/pyre-interpreter/src/host_seam.rs
@@ -49,11 +49,10 @@ pub mod sys {
         c_char, c_int, c_long, c_uint, c_void, clockid_t, gid_t, mode_t, off_t, pid_t, rusage,
         size_t, time_t, timespec, timeval, tm, uid_t,
     };
-    // Calendar/formatting on a caller-supplied value: `asctime_r` is pure, and
-    // `gmtime_r` reads only glibc's timezone cache — which the seccomp backstop
-    // primes before lockdown (see `pyre_sandbox::seccomp`), so at runtime neither
-    // opens a host file.
-    pub use ::libc::{asctime_r, gmtime_r};
+    // Calendar/formatting on a caller-supplied value: `gmtime_r` reads only glibc's
+    // timezone cache — which the seccomp backstop primes before lockdown
+    // (see `pyre_sandbox::seccomp`), so at runtime it doesn't open a host file.
+    pub use ::libc::gmtime_r;
     // Pure functions: wait-status decoders are bit-twiddling on a caller-supplied
     // integer; they make no syscall and read no host state.
     pub use ::libc::{WEXITSTATUS, WIFEXITED, WIFSIGNALED, WIFSTOPPED, WSTOPSIG, WTERMSIG};

--- a/pyre/pyre-interpreter/src/module/time/interp_time.rs
+++ b/pyre/pyre-interpreter/src/module/time/interp_time.rs
@@ -1020,39 +1020,20 @@ pub fn asctime(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
 }
 
 fn _asctime_from_tm(tm: &c_tm) -> Result<PyObjectRef, crate::PyError> {
-    #[cfg(target_arch = "wasm32")]
-    {
-        let _ = tm;
-        Err(crate::PyError::not_implemented(
-            "time.asctime is unavailable on wasm32",
-        ))
-    }
-    #[cfg(unix)]
-    {
-        let libc_tm = c_tm_to_libc_tm(&tm);
-        let mut buf = [0 as libc::c_char; 26];
-        let p = unsafe { libc::asctime_r(&libc_tm, buf.as_mut_ptr()) };
-        if p.is_null() {
-            return Err(crate::PyError::value_error("unconvertible time"));
-        }
-        let lossy = unsafe { std::ffi::CStr::from_ptr(p as *const libc::c_char) }.to_string_lossy();
-        let s = lossy.trim_end_matches('\n');
-        Ok(w_str_new(s))
-    }
-    #[cfg(windows)]
-    {
-        unsafe extern "C" {
-            fn asctime(timeptr: *const MsvcTm) -> *const libc::c_char;
-        }
-        let msvc_tm = c_tm_to_msvc_tm(&tm);
-        let p = unsafe { asctime(&msvc_tm) };
-        if p.is_null() {
-            return Err(crate::PyError::value_error("unconvertible time"));
-        }
-        let lossy = unsafe { std::ffi::CStr::from_ptr(p) }.to_string_lossy();
-        let s = lossy.trim_end_matches('\n');
-        Ok(w_str_new(s))
-    }
+    const WDAY_NAME: [&str; 7] = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+    const MON_NAME: [&str; 12] = [
+        "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
+    ];
+    Ok(w_str_new(&format!(
+        "{} {}{:>3} {:02}:{:02}:{:02} {}",
+        WDAY_NAME[tm.tm_wday as usize],
+        MON_NAME[tm.tm_mon as usize],
+        tm.tm_mday,
+        tm.tm_hour,
+        tm.tm_min,
+        tm.tm_sec,
+        tm.tm_year + 1900
+    )))
 }
 
 /// time.ctime([seconds]) — interp_time.ctime


### PR DESCRIPTION
<!--
Thank you for contributing to Pyre.

Pyre is still a project that relies heavily on AI-assisted development.

For effective collaboration, please follow these rules.

1. The submitter is ultimately responsible for both the code and the discussion. Do not submit generated code or generated discussion without review.
2. Clearly separate the author's own judgment from generated suggestions. Do not submit generated discussion by itself without the author's own assessment.
-->

## Summary

Replace the existing `libc`-based `time.asctime` implementation with a pure Rust implementation to achieve format parity between Pyre and CPython.

This fixes all `test_time.TestAsctime4dyear` test cases.

## Self-review

<!--
Did you use AI to create this patch?
If the patch is not AI-generated, write: "This patch is not AI-generated."
Otherwise, please fill out this section.

Note: Do not run the review in the same session that generated the code.

If you are using Claude, a quick local review is `/parity to upstream/main`.

The currently recommended prompt for gpt-5.5 will be run automatically when this is ready for review.
The prompt is:

----
Assess by static analysis whether our changes in git diff main are equivalent
to the corresponding RPython/PyPy source code. The RPython and PyPy sources
are available locally.

If anything was ported incorrectly, report every instance in detail. After
collecting all differences, organize the report into separate sections:

1. Cases where our patch regressed PyPy parity compared to main
2. Other mismatches introduced by our patch
3. Mismatches that already existed before this patch
4. Structural adaptations

Exceptions: some differences cannot be ported 1:1 because of Python 3.11 vs
3.14 differences, opcode mismatches caused by using a CPython-compatible
compiler, GIL/free-threading differences, and fundamental implementation-
language differences between RPython and Rust. Mark those separately under
“Structural adaptations.”
-->

This patch is not AI-generated.

- [x] I fully resolved all reasonable code review comments from Codex and CodeRabbit.
  - [ ] Auto-review section 1 is clear. This check is mandatory.
  - [ ] Auto-review section 2 is clear. If this is not checked, please add a comment explaining why.
- [x] I did not use AI to write the code of this patch.
  - If this is not checked, commits must include `Assisted-by`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `time.asctime` consistency across platforms, including WebAssembly.
  * Standardized formatting of weekday, month, and time values.
  * Removed unexpected platform-specific behavior and trailing newline handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->