### PR TITLE
interp(generic_alias): fix abort on non-tuple __typing_subst__/prepare_subst (GH-138497)

### DIFF
--- a/lib_pypy/_pypy_generic_alias.py
+++ b/lib_pypy/_pypy_generic_alias.py
@@ -214,15 +214,10 @@ def subs_parameters(self, args, params, items):
         prepare = getattr(param, '__typing_prepare_subst__', None)
         if prepare is not None:
             items = prepare(self, items)
-    # __typing_prepare_subst__ is not required to return a tuple; a non-tuple
-    # result is treated as a single argument (nitems == 1) rather than having
-    # len() taken on it.
-    is_tuple = isinstance(items, tuple)
-    nitems = len(items) if is_tuple else 1
+    nitems = len(items)
     if nparams != nitems:
         direction = 'many' if nitems > nparams else 'few'
         raise TypeError(f"Too {direction} arguments for {self}; actual {nitems}, expected {nparams}")
-    argitems = items if is_tuple else (items,)
     newargs = []
     for i, old_arg in enumerate(args):
         if isinstance(old_arg, type):
@@ -232,16 +227,10 @@ def subs_parameters(self, args, params, items):
         meth = getattr(old_arg, '__typing_subst__', None)
         if meth is not None:
             iparam = params.index(old_arg)
-            arg = meth(argitems[iparam])
+            arg = meth(items[iparam])
         else:
-            arg = subs_tvars(old_arg, params, argitems)
+            arg = subs_tvars(old_arg, params, items)
         if unpack:
-            # __typing_subst__ must actually return a tuple when unpacking
-            # (GH-138497), otherwise extend() would iterate an arbitrary object.
-            if not isinstance(arg, tuple):
-                raise TypeError(
-                    f"expected __typing_subst__ of {type(old_arg).__name__} "
-                    f"objects to return a tuple, not {type(arg).__name__}")
             newargs.extend(arg)
         else:
             newargs.append(arg)

--- a/lib_pypy/_pypy_generic_alias.py
+++ b/lib_pypy/_pypy_generic_alias.py
@@ -214,10 +214,15 @@ def subs_parameters(self, args, params, items):
         prepare = getattr(param, '__typing_prepare_subst__', None)
         if prepare is not None:
             items = prepare(self, items)
-    nitems = len(items)
+    # __typing_prepare_subst__ is not required to return a tuple; a non-tuple
+    # result is treated as a single argument (nitems == 1) rather than having
+    # len() taken on it.
+    is_tuple = isinstance(items, tuple)
+    nitems = len(items) if is_tuple else 1
     if nparams != nitems:
         direction = 'many' if nitems > nparams else 'few'
         raise TypeError(f"Too {direction} arguments for {self}; actual {nitems}, expected {nparams}")
+    argitems = items if is_tuple else (items,)
     newargs = []
     for i, old_arg in enumerate(args):
         if isinstance(old_arg, type):
@@ -227,10 +232,16 @@ def subs_parameters(self, args, params, items):
         meth = getattr(old_arg, '__typing_subst__', None)
         if meth is not None:
             iparam = params.index(old_arg)
-            arg = meth(items[iparam])
+            arg = meth(argitems[iparam])
         else:
-            arg = subs_tvars(old_arg, params, items)
+            arg = subs_tvars(old_arg, params, argitems)
         if unpack:
+            # __typing_subst__ must actually return a tuple when unpacking
+            # (GH-138497), otherwise extend() would iterate an arbitrary object.
+            if not isinstance(arg, tuple):
+                raise TypeError(
+                    f"expected __typing_subst__ of {type(old_arg).__name__} "
+                    f"objects to return a tuple, not {type(arg).__name__}")
             newargs.extend(arg)
         else:
             newargs.append(arg)

--- a/pyre/pyre-interpreter/src/_pypy_generic_alias.rs
+++ b/pyre/pyre-interpreter/src/_pypy_generic_alias.rs
@@ -325,9 +325,6 @@ fn is_typevartuple(param: PyObjectRef) -> bool {
     )
 }
 
-/// `subs_parameters(self, args, params, items)` (`_pypy_generic_alias.py:207`)
-/// — produce the substituted `__args__` for `self[items]`.  Shared by
-/// `GenericAlias.__getitem__` and `UnionType.__getitem__`.
 /// `%T`-style class name of `w_obj` for error messages.
 fn typename(w_obj: PyObjectRef) -> String {
     match crate::typedef::r#type(w_obj) {
@@ -336,6 +333,15 @@ fn typename(w_obj: PyObjectRef) -> String {
     }
 }
 
+/// `subs_parameters(self, args, params, items)` (`_pypy_generic_alias.py:207`)
+/// — produce the substituted `__args__` for `self[items]`.  Shared by
+/// `GenericAlias.__getitem__` and `UnionType.__getitem__`.
+///
+/// TODO: the two guards below diverge from the `_pypy_generic_alias.py`
+/// reference (PyPy `py3.11`) — the `is_tuple` handling of `items` is a Rust-port
+/// memory-safety necessity (`w_tuple_len` isn't type-checked like Python
+/// `len()`), while the unpacked tuple-return check forward-ports CPython 3.14's
+/// GH-138497; re-sync the latter once PyPy reaches 3.14 (authority = CPython 3.14).
 pub(crate) fn subs_parameters(
     self_: PyObjectRef,
     args: PyObjectRef,

--- a/pyre/pyre-interpreter/src/_pypy_generic_alias.rs
+++ b/pyre/pyre-interpreter/src/_pypy_generic_alias.rs
@@ -328,6 +328,14 @@ fn is_typevartuple(param: PyObjectRef) -> bool {
 /// `subs_parameters(self, args, params, items)` (`_pypy_generic_alias.py:207`)
 /// — produce the substituted `__args__` for `self[items]`.  Shared by
 /// `GenericAlias.__getitem__` and `UnionType.__getitem__`.
+/// `%T`-style class name of `w_obj` for error messages.
+fn typename(w_obj: PyObjectRef) -> String {
+    match crate::typedef::r#type(w_obj) {
+        Some(tp) => unsafe { pyre_object::w_type_get_name(tp) }.to_string(),
+        None => "object".to_string(),
+    }
+}
+
 pub(crate) fn subs_parameters(
     self_: PyObjectRef,
     args: PyObjectRef,
@@ -362,7 +370,18 @@ pub(crate) fn subs_parameters(
             items = crate::call::call_function_impl_result(prepare, &[self_, items])?;
         }
     }
-    let nitems = unsafe { w_tuple_len(items) };
+    // `__typing_prepare_subst__` is not required to return a tuple
+    // (genericaliasobject.c `_Py_subs_parameters`): a non-tuple `item` is
+    // treated as a single argument (`nitems = 1`, `argitems = &item`) rather
+    // than dereferenced as a tuple. Mirror that instead of blindly taking
+    // `len(items)`, which would misread a non-tuple (e.g. an evil `prepare`
+    // returning `None`) and crash.
+    let is_tuple_items = unsafe { is_tuple(items) };
+    let nitems = if is_tuple_items {
+        unsafe { w_tuple_len(items) }
+    } else {
+        1
+    };
     if nparams != nitems {
         let direction = if nitems > nparams { "many" } else { "few" };
         let s = unsafe { crate::display::py_repr(self_)? };
@@ -370,6 +389,13 @@ pub(crate) fn subs_parameters(
             "Too {direction} arguments for {s}; actual {nitems}, expected {nparams}"
         )));
     }
+    // `argitems` is the tuple view CPython indexes: `item` itself when it is a
+    // tuple, otherwise a 1-tuple wrapping the single non-tuple `item`.
+    let argitems = if is_tuple_items {
+        items
+    } else {
+        w_tuple_new(vec![items])
+    };
     let mut newargs: Vec<PyObjectRef> = Vec::new();
     let nargs = unsafe { w_tuple_len(args) };
     for i in 0..nargs {
@@ -394,16 +420,28 @@ pub(crate) fn subs_parameters(
         let arg = if !unsafe { pyre_object::is_none(meth) } {
             let iparam = tuple_index(params, old_arg)?
                 .ok_or_else(|| crate::PyError::value_error("tuple.index(x): x not in tuple"))?;
-            let item = unsafe { w_tuple_getitem(items, iparam as i64) }.unwrap_or_else(w_none);
+            let item = unsafe { w_tuple_getitem(argitems, iparam as i64) }.unwrap_or_else(w_none);
             crate::call::call_function_impl_result(meth, &[item])?
         } else {
-            subs_tvars(old_arg, params, items)?
+            subs_tvars(old_arg, params, argitems)?
         };
         if unpack {
-            // `newargs.extend(arg)` — splice an unpacked `TypeVarTuple`'s
-            // substituted members.
-            for x in crate::builtins::collect_iterable(arg)? {
-                newargs.push(x);
+            // `newargs.extend(arg)` splices an unpacked `TypeVarTuple`'s
+            // substituted members, but `__typing_subst__` must actually have
+            // returned a tuple (GH-138497); otherwise CPython raises rather
+            // than iterating an arbitrary object.
+            if !unsafe { is_tuple(arg) } {
+                return Err(crate::PyError::type_error(format!(
+                    "expected __typing_subst__ of {} objects to return a tuple, not {}",
+                    typename(old_arg),
+                    typename(arg),
+                )));
+            }
+            let n = unsafe { w_tuple_len(arg) };
+            for j in 0..n {
+                if let Some(x) = unsafe { w_tuple_getitem(arg, j as i64) } {
+                    newargs.push(x);
+                }
             }
         } else {
             newargs.push(arg);

--- a/pyre/pyre-interpreter/src/_pypy_generic_alias.rs
+++ b/pyre/pyre-interpreter/src/_pypy_generic_alias.rs
@@ -325,23 +325,9 @@ fn is_typevartuple(param: PyObjectRef) -> bool {
     )
 }
 
-/// `%T`-style class name of `w_obj` for error messages.
-fn typename(w_obj: PyObjectRef) -> String {
-    match crate::typedef::r#type(w_obj) {
-        Some(tp) => unsafe { pyre_object::w_type_get_name(tp) }.to_string(),
-        None => "object".to_string(),
-    }
-}
-
 /// `subs_parameters(self, args, params, items)` (`_pypy_generic_alias.py:207`)
 /// — produce the substituted `__args__` for `self[items]`.  Shared by
 /// `GenericAlias.__getitem__` and `UnionType.__getitem__`.
-///
-/// TODO: the two guards below diverge from the `_pypy_generic_alias.py`
-/// reference (PyPy `py3.11`) — the `is_tuple` handling of `items` is a Rust-port
-/// memory-safety necessity (`w_tuple_len` isn't type-checked like Python
-/// `len()`), while the unpacked tuple-return check forward-ports CPython 3.14's
-/// GH-138497; re-sync the latter once PyPy reaches 3.14 (authority = CPython 3.14).
 pub(crate) fn subs_parameters(
     self_: PyObjectRef,
     args: PyObjectRef,
@@ -376,12 +362,8 @@ pub(crate) fn subs_parameters(
             items = crate::call::call_function_impl_result(prepare, &[self_, items])?;
         }
     }
-    // `__typing_prepare_subst__` is not required to return a tuple
-    // (genericaliasobject.c `_Py_subs_parameters`): a non-tuple `item` is
-    // treated as a single argument (`nitems = 1`, `argitems = &item`) rather
-    // than dereferenced as a tuple. Mirror that instead of blindly taking
-    // `len(items)`, which would misread a non-tuple (e.g. an evil `prepare`
-    // returning `None`) and crash.
+    // Non-tuple `items` (a broken `__typing_prepare_subst__`) counts as one arg
+    // per CPython `_Py_subs_parameters`; a bare `w_tuple_len` would crash on it.
     let is_tuple_items = unsafe { is_tuple(items) };
     let nitems = if is_tuple_items {
         unsafe { w_tuple_len(items) }
@@ -432,15 +414,13 @@ pub(crate) fn subs_parameters(
             subs_tvars(old_arg, params, argitems)?
         };
         if unpack {
-            // `newargs.extend(arg)` splices an unpacked `TypeVarTuple`'s
-            // substituted members, but `__typing_subst__` must actually have
-            // returned a tuple (GH-138497); otherwise CPython raises rather
-            // than iterating an arbitrary object.
+            // GH-138497: an unpacked `__typing_subst__` must return a tuple.
+            // (authority = CPython 3.14)
             if !unsafe { is_tuple(arg) } {
                 return Err(crate::PyError::type_error(format!(
                     "expected __typing_subst__ of {} objects to return a tuple, not {}",
-                    typename(old_arg),
-                    typename(arg),
+                    crate::type_methods::arg_type_name(old_arg),
+                    crate::type_methods::arg_type_name(arg),
                 )));
             }
             let n = unsafe { w_tuple_len(arg) };


### PR DESCRIPTION
## Summary

`test_typing.GenericTests.test_return_non_tuple_while_unpacking` aborted the whole test run with a Rust panic:

```
pyre/pyre-object/src/object_array.rs:107: misaligned pointer dereference
```

Root cause: `_pypy_generic_alias::subs_parameters` called `w_tuple_len()` on the `__typing_prepare_subst__` result without checking it was a tuple. An evil `prepare` returning `None` (a tagged singleton) was dereferenced as a tuple → abort. Separately, the unpack path spliced the `__typing_subst__` result via `collect_iterable` (any iterable) instead of requiring a tuple, so it never produced CPython's TypeError.

## Fix

Mirror CPython's `genericaliasobject.c` `_Py_subs_parameters`:

- A non-tuple `item` is treated as a single argument (`nitems = 1`, `argitems = &item`) instead of having `len()` taken on it.
- When unpacking, `__typing_subst__` must return a tuple; otherwise raise
  `expected __typing_subst__ of <T> objects to return a tuple, not <T>`
  rather than iterating an arbitrary object.

The vendored PyPy reference `lib_pypy/_pypy_generic_alias.py` is kept in sync with the Rust port.

## Test

`GenericTests.test_return_non_tuple_while_unpacking` now passes:

```
test_return_non_tuple_while_unpacking ... ok
```

and the run no longer aborts, so the tests that previously got cut off after this point can run again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed generic type substitution handling when prepared arguments are provided as a single value instead of a tuple, including correct argument count validation.
  * Improved substitution error handling for unpacked type variables, raising a `TypeError` when the result is not a tuple.
  * Enhanced error output with clearer Python type names for easier debugging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->