### PR TITLE
collections.deque: migrate to typed-payload #[pyre_class]

### DIFF
--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -9655,6 +9655,32 @@ pub fn iter(obj: PyObjectRef) -> PyResult {
                 }
             }
         }
+        // descroperation.py `def iter` — a typed-payload builtin
+        // (e.g. `deque`) whose typedef registers `__iter__` is not an
+        // `INSTANCE_TYPE` layout, so the `is_instance` fast path above skips
+        // it.  Mirror the generic MRO dunder dispatch `getitem_slot` uses:
+        // resolve the user type, dispatch `__iter__`, else fall back to
+        // `__getitem__` sequence iteration for a non-mapping type.  Gated on
+        // `!is_instance` so the instance path above is untouched.
+        if !is_instance(obj) {
+            if let Some(w_type) = crate::typedef::r#type(obj) {
+                if let Some(method) = lookup_in_type_where(w_type, "__iter__") {
+                    if is_none(method) {
+                        return Err(PyError::type_error(format!(
+                            "'{}' object is not iterable",
+                            (*(*obj).ob_type).name
+                        )));
+                    }
+                    let w_iter = crate::call::call_function_impl_result(method, &[obj])?;
+                    return iter_check_is_iterator(w_iter);
+                }
+                let is_mapping =
+                    pyre_object::typeobject::w_type_get_flag_map_or_seq(w_type) == b'M';
+                if !is_mapping && lookup_in_type_where(w_type, "__getitem__").is_some() {
+                    return Ok(pyre_object::w_seq_iter_new(obj, 0));
+                }
+            }
+        }
     }
     Err(PyError::type_error(format!(
         "'{}' object is not iterable",
@@ -11866,6 +11892,16 @@ pub(crate) fn delitem_slot(obj: PyObjectRef, index: PyObjectRef) -> Result<(), P
             if let Some(method) =
                 lookup_in_type_where(pyre_object::w_instance_get_type(obj), "__delitem__")
             {
+                crate::builtins::call_and_check(method, &[obj, index])?;
+                return Ok(());
+            }
+        }
+        // descroperation.py delitem — any object whose type registers a
+        // `__delitem__` on its MRO supports deletion; the arms above are fast
+        // paths for the builtin sequence/mapping layouts.  Covers typed-payload
+        // types like `deque` whose typedef binds `__delitem__`.
+        if let Some(w_type) = crate::typedef::r#type(obj) {
+            if let Some(method) = lookup_in_type_where(w_type, "__delitem__") {
                 crate::builtins::call_and_check(method, &[obj, index])?;
                 return Ok(());
             }

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -6936,6 +6936,18 @@ pub fn try_hash_value(obj: PyObjectRef) -> Result<i64, crate::PyError> {
                 return Ok(if h == -1 { -2 } else { h });
             }
         }
+        // A type may declare itself unhashable via `__hash__ = None`
+        // (a typed-payload `#[pyre_methods(unhashable)]` layout such as
+        // `deque`); the `is_instance` arm above covers user classes, this
+        // covers the builtin/typed-payload layouts before the identity-hash
+        // fallback.
+        if let Some(w_type) = crate::typedef::r#type(obj) {
+            if let Some(method) = crate::baseobjspace::lookup_in_type(w_type, "__hash__") {
+                if pyre_object::is_none(method) {
+                    return Err(unhashable_type_error(obj));
+                }
+            }
+        }
     }
     Ok(hash_value(obj))
 }

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -2003,11 +2003,18 @@ impl IterOpcodeHandler for PyFrame {
                 self.locals_w_mut()[tos] = seq_iter;
                 return Ok(());
             }
-            // User-defined __iter__ — PyPy: space.iter → __iter__()
-            // Delegates to baseobjspace::iter which handles type MRO
-            // and __getitem__ fallback (PyPy: space.iter →
-            // PyObject_GetIter → tp_iter or PySeqIter_New).
-            if pyre_object::is_instance(iter) {
+            // User-defined __iter__ — PyPy: space.iter → __iter__().
+            // Instances, plus typed-payload builtins (e.g. deque) whose
+            // type registers `__iter__` on its MRO.  Delegates to
+            // baseobjspace::iter which handles type MRO and __getitem__
+            // fallback (PyPy: space.iter → PyObject_GetIter → tp_iter or
+            // PySeqIter_New).  Already-iterator payloads returned above, so
+            // this only sees non-iterator containers.
+            if pyre_object::is_instance(iter)
+                || crate::typedef::r#type(iter).is_some_and(|t| {
+                    crate::baseobjspace::lookup_in_type_where(t, "__iter__").is_some()
+                })
+            {
                 let result = crate::baseobjspace::iter(iter)?;
                 let tos = self.valuestackdepth - 1;
                 self.locals_w_mut()[tos] = result;

--- a/pyre/pyre-interpreter/src/module/_collections/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_collections/mod.rs
@@ -1,11 +1,11 @@
 //! _collections module — PyPy: `pypy/module/_collections/`.
 //!
 //! Provides the C-accelerated `deque` / `defaultdict` / `OrderedDict`
-//! types.  `deque` is the interp-level `py_class!` stub below, backed by
-//! an attribute-dict list (`__data__`); semantically correct for
+//! types.  `deque` is an interp-level typed-payload `#[pyre_class]`, backed
+//! by a list payload field; semantically correct for
 //! `collections.py`'s `MutableSequence` consumers but not performant
 //! (PyPy's `W_Deque` is a doubly-linked block list — porting that needs
-//! typed payload backing on top of `py_class!`).  `defaultdict` is the
+//! a separate algorithm migration).  `defaultdict` is the
 //! app-level `dict` subclass in `app_defaultdict.py`, mirroring PyPy's
 //! `app_defaultdict.py` (neither runtime can subclass the app-level
 //! `dict` from interp-level).
@@ -16,546 +16,618 @@ use pyre_object::*;
 /// (append / appendleft / pop / popleft / clear / extend / extendleft /
 /// rotate / count / remove / reverse / index / copy + container and repr
 /// protocols, with `maxlen` bounding) backed by an inner list at
-/// `self.__data__`.  The bound is kept in the private `self.__maxlen__`
-/// slot and surfaced read-only via the `maxlen` property.
-mod deque_class {
-    use super::*;
+/// `self.data`.  The bound is kept in `self.maxlen` and surfaced read-only
+/// via the `maxlen` property.
+#[crate::pyre_class("collections.deque")]
+pub struct W_Deque {
+    /// Backing list object (a real `list`); always a valid list after `__new__`.
+    data: PyObjectRef,
+    /// Bound: `-1` = unbounded, `>= 0` = the maxlen. Validated non-negative at `__init__`.
+    maxlen: i64,
+    /// Lightweight iteration-lock counter (`interp_deque.py` `state`); bumped on every mutation.
+    state: i64,
+}
 
-    fn data(self_obj: PyObjectRef) -> Option<PyObjectRef> {
-        crate::baseobjspace::getattr_str(self_obj, "__data__").ok()
+fn data(self_obj: PyObjectRef) -> PyObjectRef {
+    W_Deque::from_obj(self_obj)
+        .map(|d| d.data)
+        .unwrap_or_else(w_none)
+}
+
+/// Snapshot the backing list into a `Vec`.
+fn snapshot(self_obj: PyObjectRef) -> Vec<PyObjectRef> {
+    let d = data(self_obj);
+    unsafe {
+        (0..w_list_len(d))
+            .filter_map(|i| w_list_getitem(d, i as i64))
+            .collect()
     }
+}
 
-    /// Snapshot the backing list into a `Vec`.
-    fn snapshot(self_obj: PyObjectRef) -> Vec<PyObjectRef> {
-        match data(self_obj) {
-            Some(d) => unsafe {
-                (0..w_list_len(d))
-                    .filter_map(|i| w_list_getitem(d, i as i64))
-                    .collect()
+/// Replace the backing list with `items`.
+fn store(self_obj: PyObjectRef, items: Vec<PyObjectRef>) {
+    W_Deque::from_obj(self_obj).unwrap().data = w_list_new(items);
+    modified(self_obj);
+}
+
+/// `interp_deque.py modified` — lightweight iteration lock.  Any
+/// mutation invalidates the outstanding lock so an in-progress
+/// `count` / `index` / `remove` / `__contains__` / comparison detects
+/// it.  PyPy invalidates a `Lock` object identity; pyre realizes the
+/// same as a monotonic `state` counter: every mutation bumps it, and
+/// `checklock` raises when the snapshot no longer matches.
+fn lock_state(self_obj: PyObjectRef) -> i64 {
+    // Volatile read: a `checklock` re-read must observe a `state` bump made
+    // by a re-entrant mutation from an intervening user callback (`eq_w`).
+    // A plain field read is cached across that callback because the payload
+    // escaped and is mutated through a non-receiver pointer, which the
+    // `&self`/`&mut self` receiver's aliasing guarantee forbids the compiler
+    // from expecting.
+    let base = self_obj as *const W_Deque;
+    if base.is_null() {
+        return 0;
+    }
+    unsafe { std::ptr::read_volatile(std::ptr::addr_of!((*base).state)) }
+}
+
+fn modified(self_obj: PyObjectRef) {
+    // Volatile bump paired with `lock_state`'s volatile read (see there).
+    let base = self_obj as *mut W_Deque;
+    if base.is_null() {
+        return;
+    }
+    unsafe {
+        let p = std::ptr::addr_of_mut!((*base).state);
+        std::ptr::write_volatile(p, std::ptr::read_volatile(p).wrapping_add(1));
+    }
+}
+
+/// `interp_deque.py getlock` — snapshot the current lock token.
+fn getlock(self_obj: PyObjectRef) -> i64 {
+    lock_state(self_obj)
+}
+
+/// `interp_deque.py checklock` — raise `RuntimeError` if the deque
+/// was mutated since `lock` was taken.
+fn checklock(self_obj: PyObjectRef, lock: i64) -> Result<(), crate::PyError> {
+    if lock_state(self_obj) != lock {
+        return Err(crate::PyError::runtime_error(
+            "deque mutated during iteration",
+        ));
+    }
+    Ok(())
+}
+
+/// `self.maxlen`: `None` (unbounded) or a non-negative bound.  The
+/// bound is validated non-negative at construction, so the stored
+/// value is read back directly.
+fn maxlen_bound(self_obj: PyObjectRef) -> Option<usize> {
+    let m = W_Deque::from_obj(self_obj)?.maxlen;
+    if m < 0 { None } else { Some(m as usize) }
+}
+
+fn maxlen_obj(self_obj: PyObjectRef) -> PyObjectRef {
+    match W_Deque::from_obj(self_obj) {
+        Some(d) if d.maxlen >= 0 => w_int_new(d.maxlen),
+        _ => w_none(),
+    }
+}
+
+/// `W_Deque.append` + `trimleft`: drop from the left once over the bound.
+fn do_append(self_obj: PyObjectRef, item: PyObjectRef) {
+    let d = data(self_obj);
+    unsafe { w_list_append(d, item) };
+    modified(self_obj);
+    if let Some(m) = maxlen_bound(self_obj) {
+        let mut items = snapshot(self_obj);
+        if items.len() > m {
+            items.drain(0..items.len() - m);
+            store(self_obj, items);
+        }
+    }
+}
+
+/// `space.decode_index4` index-only case — reject a slice with a
+/// `TypeError`, route any `__index__`-able object through
+/// `getindex_w`, apply the negative-index wrap and the in-range
+/// check, and return the resolved element position.
+fn deque_index(index: PyObjectRef, len: i64) -> Result<usize, crate::PyError> {
+    if unsafe { pyre_object::is_slice(index) } {
+        return Err(crate::PyError::type_error("deque[:] is not supported"));
+    }
+    let mut idx = crate::builtins::getindex_w(index)?;
+    if idx < 0 {
+        idx += len;
+    }
+    if idx < 0 || idx >= len {
+        return Err(crate::PyError::index_error("index out of range"));
+    }
+    Ok(idx as usize)
+}
+
+/// `W_Deque.compare` — element-wise (`compare_by_iteration`) ordering
+/// against another deque, ignoring `maxlen`; `NotImplemented` when the
+/// other operand is not a deque.  Delegates to list comparison over
+/// snapshots of both backings.
+fn deque_compare(
+    self_obj: PyObjectRef,
+    other: PyObjectRef,
+    op: crate::baseobjspace::CompareOp,
+) -> Result<PyObjectRef, crate::PyError> {
+    if !crate::baseobjspace::isinstance(other, type_object())? {
+        return Ok(pyre_object::w_not_implemented());
+    }
+    // `compare_by_iteration` walks both deques
+    // through their iterators; each `W_DequeIter.next` checks the lock
+    // before yielding, so a mutation is detected
+    // up to — but not past — the element that decides the result.  pyre
+    // snapshots, so check each deque's lock before consuming its element
+    // and stop as soon as the result is determined.
+    use crate::baseobjspace::CompareOp;
+    let lock_a = getlock(self_obj);
+    let lock_b = getlock(other);
+    let snap_a = snapshot(self_obj);
+    let snap_b = snapshot(other);
+    let mut i = 0usize;
+    loop {
+        // next(w_it1): lock-check precedes the element.
+        checklock(self_obj, lock_a)?;
+        let x1 = snap_a.get(i).copied();
+        // next(w_it2): lock-check precedes the element.
+        checklock(other, lock_b)?;
+        let x2 = snap_b.get(i).copied();
+        match (x1, x2) {
+            (Some(a), Some(b)) => {
+                if !crate::baseobjspace::eq_w(a, b)? {
+                    // First differing pair decides the result; no further
+                    // `next`, so no further lock check.
+                    return match op {
+                        CompareOp::Eq => Ok(pyre_object::w_bool_from(false)),
+                        CompareOp::Ne => Ok(pyre_object::w_bool_from(true)),
+                        _ => crate::baseobjspace::compare(a, b, op),
+                    };
+                }
+            }
+            // One or both deques exhausted — decide by length.
+            _ => {
+                let res = match op {
+                    CompareOp::Eq => x1.is_none() && x2.is_none(),
+                    CompareOp::Ne => !(x1.is_none() && x2.is_none()),
+                    CompareOp::Lt => x2.is_some(),
+                    CompareOp::Le => x1.is_none(),
+                    CompareOp::Gt => x1.is_some(),
+                    CompareOp::Ge => x2.is_none(),
+                };
+                return Ok(pyre_object::w_bool_from(res));
+            }
+        }
+        i += 1;
+    }
+}
+
+/// `W_Deque.mul` — repeat the elements `num` times, then re-bound by
+/// `maxlen` by routing through the constructor (which trims).
+fn deque_repeat(self_obj: PyObjectRef, n: PyObjectRef) -> Result<PyObjectRef, crate::PyError> {
+    if !unsafe { is_int(n) } {
+        return Ok(pyre_object::w_not_implemented());
+    }
+    let num = unsafe { w_int_get_value(n) }.max(0);
+    let base = snapshot(self_obj);
+    let mut items = Vec::with_capacity(base.len().saturating_mul(num as usize));
+    for _ in 0..num {
+        items.extend_from_slice(&base);
+    }
+    let ty = unsafe { w_instance_get_type(self_obj) };
+    let list = w_list_new(items);
+    let m = maxlen_obj(self_obj);
+    if unsafe { is_none(m) } {
+        crate::call::call_function_impl_result(ty, &[list])
+    } else {
+        crate::call::call_function_impl_result(ty, &[list, m])
+    }
+}
+
+/// `W_Deque.appendleft` + `trimright`: drop from the right once over the bound.
+fn do_appendleft(self_obj: PyObjectRef, item: PyObjectRef) {
+    let mut items = snapshot(self_obj);
+    items.insert(0, item);
+    if let Some(m) = maxlen_bound(self_obj) {
+        items.truncate(m);
+    }
+    store(self_obj, items);
+}
+
+#[crate::pyre_methods(weakrefable, unhashable)]
+impl W_Deque {
+    // `deque_new` allocates an empty unbounded payload; the construction
+    // arguments (`iterable`, `maxlen`) are consumed by `__init__`, so they
+    // are accepted and ignored here — the type-call protocol forwards them
+    // (and any keywords) to `__new__` as well.
+    #[staticmethod]
+    fn __new__(_cls: PyObjectRef, _args: &[PyObjectRef]) -> PyObjectRef {
+        // Construction arguments are consumed/validated by `__init__`; accept
+        // (and ignore) any positional or keyword args here via the whole-slice
+        // catch-all so a subclass with its own `__init__` keyword parameters
+        // does not trip an unknown-keyword error in `__new__`.
+        let _ = _args;
+        // Stable (non-moving) allocation: the mutators re-derive `self`
+        // from a raw `PyObjectRef` across list-allocating calls (`store`),
+        // so the payload must not relocate under them.
+        W_Deque::allocate_stable(W_Deque {
+            ob: pyre_object::PyObject {
+                ob_type: std::ptr::null(),
+                w_class: std::ptr::null_mut(),
             },
-            None => Vec::new(),
-        }
+            data: w_list_new(vec![]),
+            maxlen: -1,
+            state: 0,
+        })
     }
 
-    /// Replace the backing list with `items`.
-    fn store(self_obj: PyObjectRef, items: Vec<PyObjectRef>) {
-        // Private storage slot on a hasdict deque (no custom `__setattr__`,
-        // `__data__` is not a descriptor): the infallible instance-dict
-        // store `W_Root.setdictvalue` (baseobjspace.py:51).
-        crate::baseobjspace::setdictvalue(self_obj, "__data__", w_list_new(items));
-        modified(self_obj);
-    }
-
-    /// `interp_deque.py:107 modified` — lightweight iteration lock.  Any
-    /// mutation invalidates the outstanding lock so an in-progress
-    /// `count` / `index` / `remove` / `__contains__` / comparison detects
-    /// it.  PyPy invalidates a `Lock` object identity; pyre realizes the
-    /// same as a monotonic `__state__` counter (as CPython does via
-    /// `deque->state`): every mutation bumps it, and `checklock` raises when
-    /// the snapshot no longer matches.
-    fn lock_state(self_obj: PyObjectRef) -> i64 {
-        match crate::baseobjspace::getattr_str(self_obj, "__state__") {
-            Ok(w) if !w.is_null() && unsafe { is_int(w) } => unsafe { w_int_get_value(w) },
-            _ => 0,
-        }
-    }
-
-    fn modified(self_obj: PyObjectRef) {
-        let next = lock_state(self_obj).wrapping_add(1);
-        // Private lock-counter slot on a hasdict deque (no custom
-        // `__setattr__`, `__state__` is not a descriptor): the infallible
-        // instance-dict store `W_Root.setdictvalue` (baseobjspace.py:51).
-        crate::baseobjspace::setdictvalue(self_obj, "__state__", w_int_new(next));
-    }
-
-    /// `interp_deque.py:110 getlock` — snapshot the current lock token.
-    fn getlock(self_obj: PyObjectRef) -> i64 {
-        lock_state(self_obj)
-    }
-
-    /// `interp_deque.py:115 checklock` — raise `RuntimeError` if the deque
-    /// was mutated since `lock` was taken.
-    fn checklock(self_obj: PyObjectRef, lock: i64) -> Result<(), crate::PyError> {
-        if lock_state(self_obj) != lock {
-            return Err(crate::PyError::runtime_error(
-                "deque mutated during iteration",
-            ));
+    // `init(iterable=None, maxlen=None)` — remember maxlen, then
+    // extend so the bound is enforced while filling.
+    fn __init__(
+        &mut self,
+        #[default(None)] iterable: Option<PyObjectRef>,
+        #[default(None)] maxlen: Option<PyObjectRef>,
+    ) -> Result<(), crate::PyError> {
+        self.data = w_list_new(vec![]);
+        self.state = 0;
+        // gateway_nonnegint_w(w_maxlen): None unbounded; non-int → TypeError; negative → ValueError.
+        self.maxlen = match maxlen {
+            Some(m) if !unsafe { is_none(m) } => {
+                if !unsafe { is_int(m) } {
+                    return Err(crate::PyError::type_error("an integer is required"));
+                }
+                let v = unsafe { w_int_get_value(m) };
+                if v < 0 {
+                    return Err(crate::PyError::value_error("maxlen must be non-negative"));
+                }
+                v
+            }
+            _ => -1,
+        };
+        let self_obj = self as *mut W_Deque as PyObjectRef;
+        if let Some(it) = iterable {
+            for item in crate::builtins::collect_iterable(it)? {
+                do_append(self_obj, item);
+            }
         }
         Ok(())
     }
-
-    /// `self.maxlen`: `None` (unbounded) or a non-negative bound.  The
-    /// bound is validated non-negative at construction, so the stored
-    /// value is read back directly.
-    fn maxlen_bound(self_obj: PyObjectRef) -> Option<usize> {
-        let w = crate::baseobjspace::getattr_str(self_obj, "__maxlen__").ok()?;
-        if w.is_null() || unsafe { is_none(w) } {
-            None
-        } else {
-            Some(unsafe { w_int_get_value(w) } as usize)
-        }
+    fn append(&mut self, item: PyObjectRef) {
+        let self_obj = self as *mut W_Deque as PyObjectRef;
+        do_append(self_obj, item);
     }
-
-    /// `W_Deque.append` + `trimleft`: drop from the left once over the bound.
-    fn do_append(self_obj: PyObjectRef, item: PyObjectRef) {
-        let Some(d) = data(self_obj) else { return };
-        unsafe { w_list_append(d, item) };
-        modified(self_obj);
-        if let Some(m) = maxlen_bound(self_obj) {
-            let mut items = snapshot(self_obj);
-            if items.len() > m {
-                items.drain(0..items.len() - m);
-                store(self_obj, items);
+    fn appendleft(&mut self, item: PyObjectRef) {
+        let self_obj = self as *mut W_Deque as PyObjectRef;
+        do_appendleft(self_obj, item);
+    }
+    fn pop(&mut self) -> Result<PyObjectRef, crate::PyError> {
+        let self_obj = self as *mut W_Deque as PyObjectRef;
+        // `W_Deque.pop` — empty raises IndexError.
+        let mut items = snapshot(self_obj);
+        let item = items
+            .pop()
+            .ok_or_else(|| crate::PyError::index_error("pop from an empty deque"))?;
+        store(self_obj, items);
+        Ok(item)
+    }
+    fn popleft(&mut self) -> Result<PyObjectRef, crate::PyError> {
+        let self_obj = self as *mut W_Deque as PyObjectRef;
+        // `W_Deque.popleft` — empty raises IndexError.
+        let mut items = snapshot(self_obj);
+        if items.is_empty() {
+            return Err(crate::PyError::index_error("pop from an empty deque"));
+        }
+        let item = items.remove(0);
+        store(self_obj, items);
+        Ok(item)
+    }
+    fn clear(&mut self) {
+        let self_obj = self as *mut W_Deque as PyObjectRef;
+        store(self_obj, vec![]);
+    }
+    fn extend(&mut self, iterable: PyObjectRef) -> Result<(), crate::PyError> {
+        let self_obj = self as *mut W_Deque as PyObjectRef;
+        for item in crate::builtins::collect_iterable(iterable)? {
+            do_append(self_obj, item);
+        }
+        Ok(())
+    }
+    fn extendleft(&mut self, iterable: PyObjectRef) -> Result<(), crate::PyError> {
+        let self_obj = self as *mut W_Deque as PyObjectRef;
+        // Each element is appended on the left, so the result is
+        // the reverse of `iterable`.
+        for item in crate::builtins::collect_iterable(iterable)? {
+            do_appendleft(self_obj, item);
+        }
+        Ok(())
+    }
+    fn count(&self, x: PyObjectRef) -> Result<i64, crate::PyError> {
+        let self_obj = self as *const W_Deque as PyObjectRef;
+        let lock = getlock(self_obj);
+        let mut n = 0i64;
+        for it in snapshot(self_obj) {
+            let equal = crate::baseobjspace::eq_w(it, x)?;
+            checklock(self_obj, lock)?;
+            if equal {
+                n += 1;
             }
         }
+        Ok(n)
     }
-
-    /// `space.decode_index4` index-only case — reject a slice with a
-    /// `TypeError`, route any `__index__`-able object through
-    /// `getindex_w`, apply the negative-index wrap and the in-range
-    /// check, and return the resolved element position.
-    fn deque_index(index: PyObjectRef, len: i64) -> Result<usize, crate::PyError> {
-        if unsafe { pyre_object::is_slice(index) } {
-            return Err(crate::PyError::type_error("deque[:] is not supported"));
+    fn remove(&mut self, x: PyObjectRef) -> Result<(), crate::PyError> {
+        let self_obj = self as *mut W_Deque as PyObjectRef;
+        let mut items = snapshot(self_obj);
+        let lock = getlock(self_obj);
+        let mut pos = None;
+        for (i, &it) in items.iter().enumerate() {
+            let equal = crate::baseobjspace::eq_w(it, x)?;
+            checklock(self_obj, lock)?;
+            if equal {
+                pos = Some(i);
+                break;
+            }
         }
-        let mut idx = crate::builtins::getindex_w(index)?;
-        if idx < 0 {
-            idx += len;
+        match pos {
+            Some(pos) => {
+                items.remove(pos);
+                store(self_obj, items);
+                Ok(())
+            }
+            None => Err(crate::PyError::value_error(
+                "deque.remove(x): x not in deque",
+            )),
         }
-        if idx < 0 || idx >= len {
-            return Err(crate::PyError::index_error("index out of range"));
-        }
-        Ok(idx as usize)
     }
-
-    /// `W_Deque.compare` — element-wise (`compare_by_iteration`) ordering
-    /// against another deque, ignoring `maxlen`; `NotImplemented` when the
-    /// other operand is not a deque.  Delegates to list comparison over
-    /// snapshots of both backings.
-    fn deque_compare(
-        self_obj: PyObjectRef,
-        other: PyObjectRef,
-        op: crate::baseobjspace::CompareOp,
-    ) -> Result<PyObjectRef, crate::PyError> {
-        if !crate::baseobjspace::isinstance(other, type_object())? {
-            return Ok(pyre_object::w_not_implemented());
+    fn __contains__(&self, x: PyObjectRef) -> Result<bool, crate::PyError> {
+        let self_obj = self as *const W_Deque as PyObjectRef;
+        let lock = getlock(self_obj);
+        for it in snapshot(self_obj) {
+            let equal = crate::baseobjspace::eq_w(it, x)?;
+            checklock(self_obj, lock)?;
+            if equal {
+                return Ok(true);
+            }
         }
-        // `compare_by_iteration` (baseobjspace.py:1491) walks both deques
-        // through their iterators; each `W_DequeIter.next` checks the lock
-        // before yielding (interp_deque.py:650-652), so a mutation is detected
-        // up to — but not past — the element that decides the result.  pyre
-        // snapshots, so check each deque's lock before consuming its element
-        // and stop as soon as the result is determined.
-        use crate::baseobjspace::CompareOp;
-        let lock_a = getlock(self_obj);
-        let lock_b = getlock(other);
-        let snap_a = snapshot(self_obj);
-        let snap_b = snapshot(other);
-        let mut i = 0usize;
-        loop {
-            // next(w_it1): lock-check precedes the element.
-            checklock(self_obj, lock_a)?;
-            let x1 = snap_a.get(i).copied();
-            // next(w_it2): lock-check precedes the element.
-            checklock(other, lock_b)?;
-            let x2 = snap_b.get(i).copied();
-            match (x1, x2) {
-                (Some(a), Some(b)) => {
-                    if !crate::baseobjspace::eq_w(a, b)? {
-                        // First differing pair decides the result; no further
-                        // `next`, so no further lock check.
-                        return match op {
-                            CompareOp::Eq => Ok(pyre_object::w_bool_from(false)),
-                            CompareOp::Ne => Ok(pyre_object::w_bool_from(true)),
-                            _ => crate::baseobjspace::compare(a, b, op),
-                        };
-                    }
+        Ok(false)
+    }
+    fn reverse(&mut self) {
+        let self_obj = self as *mut W_Deque as PyObjectRef;
+        let mut items = snapshot(self_obj);
+        items.reverse();
+        store(self_obj, items);
+    }
+    fn rotate(&mut self, n: Option<PyObjectRef>) -> Result<(), crate::PyError> {
+        let self_obj = self as *mut W_Deque as PyObjectRef;
+        // Rotate right by n (negative rotates left).  The count goes
+        // through `__index__` so non-integers raise `TypeError`.
+        let n = match n {
+            Some(v) => crate::builtins::getindex_w(v)?,
+            None => 1,
+        };
+        let mut items = snapshot(self_obj);
+        let len = items.len() as i64;
+        if len <= 1 {
+            return Ok(());
+        }
+        let shift = ((n % len) + len) % len;
+        if shift != 0 {
+            items.rotate_right(shift as usize);
+            store(self_obj, items);
+        }
+        Ok(())
+    }
+    fn index(
+        &self,
+        x: PyObjectRef,
+        start: Option<PyObjectRef>,
+        stop: Option<PyObjectRef>,
+    ) -> Result<i64, crate::PyError> {
+        let self_obj = self as *const W_Deque as PyObjectRef;
+        let items = snapshot(self_obj);
+        let len = items.len() as i64;
+        // `space.iter(self)` takes the lock before `unwrap_start_stop`,
+        // so a `__index__` on start/stop that mutates the deque is caught
+        // by the first `checklock`.
+        let lock = getlock(self_obj);
+        let clamp = |i: i64| if i < 0 { (i + len).max(0) } else { i.min(len) };
+        let start = clamp(
+            start
+                .map(|v| crate::builtins::getindex_w(v))
+                .transpose()?
+                .unwrap_or(0),
+        );
+        let stop = clamp(
+            stop.map(|v| crate::builtins::getindex_w(v))
+                .transpose()?
+                .unwrap_or(len),
+        );
+        let upper = stop.min(len);
+        let mut i = 0i64;
+        while i < upper {
+            // `space.next(w_iter)` checks the lock before each element.
+            checklock(self_obj, lock)?;
+            if i >= start {
+                if crate::baseobjspace::eq_w(items[i as usize], x)? {
+                    // Match returns immediately, before the post-match
+                    // `checklock`.
+                    return Ok(i);
                 }
-                // One or both deques exhausted — decide by length.
-                _ => {
-                    let res = match op {
-                        CompareOp::Eq => x1.is_none() && x2.is_none(),
-                        CompareOp::Ne => !(x1.is_none() && x2.is_none()),
-                        CompareOp::Lt => x2.is_some(),
-                        CompareOp::Le => x1.is_none(),
-                        CompareOp::Gt => x1.is_some(),
-                        CompareOp::Ge => x2.is_none(),
-                    };
-                    return Ok(pyre_object::w_bool_from(res));
-                }
+                // Re-check the lock after a non-match.
+                checklock(self_obj, lock)?;
             }
             i += 1;
         }
+        Err(crate::PyError::value_error(format!(
+            "{} is not in deque",
+            unsafe { crate::py_repr(x)? }
+        )))
     }
-
-    /// `W_Deque.mul` — repeat the elements `num` times, then re-bound by
-    /// `maxlen` by routing through the constructor (which trims).
-    fn deque_repeat(self_obj: PyObjectRef, n: PyObjectRef) -> Result<PyObjectRef, crate::PyError> {
+    fn copy(&self) -> Result<PyObjectRef, crate::PyError> {
+        let self_obj = self as *const W_Deque as PyObjectRef;
+        // `type(self)(self)` or `type(self)(self, maxlen)`.
+        let ty = unsafe { w_instance_get_type(self_obj) };
+        let list = w_list_new(snapshot(self_obj));
+        let m = maxlen_obj(self_obj);
+        if unsafe { is_none(m) } {
+            crate::call::call_function_impl_result(ty, &[list])
+        } else {
+            crate::call::call_function_impl_result(ty, &[list, m])
+        }
+    }
+    fn __reduce__(&self) -> Result<PyObjectRef, crate::PyError> {
+        let self_obj = self as *const W_Deque as PyObjectRef;
+        // `_collectionsmodule.c deque_reduce` —
+        // `(type(self), args, state, iter(self))`.  `args` is
+        // `((), maxlen)` when the deque is bounded so the bound
+        // survives the round-trip, else `()`.  `state` is the generic
+        // instance state; the items ride the listitems iterator (the
+        // 4th element).
+        //
+        // The instance payload lives in typed fields, leaving a deque
+        // subclass's `__dict__` free to round-trip its instance
+        // attributes through `object_getstate_default`.
+        let ty = unsafe { w_instance_get_type(self_obj) };
+        let m = maxlen_obj(self_obj);
+        let args = if unsafe { is_none(m) } {
+            w_tuple_new(vec![])
+        } else {
+            w_tuple_new(vec![w_tuple_new(vec![]), m])
+        };
+        let state = crate::reduce_protocol::object_getstate_default(self_obj)?;
+        let items = crate::baseobjspace::iter(w_list_new(snapshot(self_obj)))?;
+        Ok(w_tuple_new(vec![ty, args, state, items]))
+    }
+    fn __len__(&self) -> i64 {
+        let self_obj = self as *const W_Deque as PyObjectRef;
+        (unsafe { w_list_len(data(self_obj)) }) as i64
+    }
+    fn __iter__(&self) -> Result<PyObjectRef, crate::PyError> {
+        let self_obj = self as *const W_Deque as PyObjectRef;
+        crate::baseobjspace::iter(data(self_obj))
+    }
+    fn __getitem__(&self, index: PyObjectRef) -> Result<PyObjectRef, crate::PyError> {
+        let self_obj = self as *const W_Deque as PyObjectRef;
+        let items = snapshot(self_obj);
+        let idx = deque_index(index, items.len() as i64)?;
+        Ok(items[idx])
+    }
+    fn __setitem__(
+        &mut self,
+        index: PyObjectRef,
+        value: PyObjectRef,
+    ) -> Result<(), crate::PyError> {
+        let self_obj = self as *mut W_Deque as PyObjectRef;
+        let mut items = snapshot(self_obj);
+        let idx = deque_index(index, items.len() as i64)?;
+        items[idx] = value;
+        store(self_obj, items);
+        Ok(())
+    }
+    fn __delitem__(&mut self, index: PyObjectRef) -> Result<(), crate::PyError> {
+        let self_obj = self as *mut W_Deque as PyObjectRef;
+        let mut items = snapshot(self_obj);
+        let idx = deque_index(index, items.len() as i64)?;
+        items.remove(idx);
+        store(self_obj, items);
+        Ok(())
+    }
+    fn __eq__(&self, other: PyObjectRef) -> Result<PyObjectRef, crate::PyError> {
+        let self_obj = self as *const W_Deque as PyObjectRef;
+        deque_compare(self_obj, other, crate::baseobjspace::CompareOp::Eq)
+    }
+    fn __ne__(&self, other: PyObjectRef) -> Result<PyObjectRef, crate::PyError> {
+        let self_obj = self as *const W_Deque as PyObjectRef;
+        deque_compare(self_obj, other, crate::baseobjspace::CompareOp::Ne)
+    }
+    fn __lt__(&self, other: PyObjectRef) -> Result<PyObjectRef, crate::PyError> {
+        let self_obj = self as *const W_Deque as PyObjectRef;
+        deque_compare(self_obj, other, crate::baseobjspace::CompareOp::Lt)
+    }
+    fn __le__(&self, other: PyObjectRef) -> Result<PyObjectRef, crate::PyError> {
+        let self_obj = self as *const W_Deque as PyObjectRef;
+        deque_compare(self_obj, other, crate::baseobjspace::CompareOp::Le)
+    }
+    fn __gt__(&self, other: PyObjectRef) -> Result<PyObjectRef, crate::PyError> {
+        let self_obj = self as *const W_Deque as PyObjectRef;
+        deque_compare(self_obj, other, crate::baseobjspace::CompareOp::Gt)
+    }
+    fn __ge__(&self, other: PyObjectRef) -> Result<PyObjectRef, crate::PyError> {
+        let self_obj = self as *const W_Deque as PyObjectRef;
+        deque_compare(self_obj, other, crate::baseobjspace::CompareOp::Ge)
+    }
+    fn __mul__(&self, n: PyObjectRef) -> Result<PyObjectRef, crate::PyError> {
+        let self_obj = self as *const W_Deque as PyObjectRef;
+        deque_repeat(self_obj, n)
+    }
+    fn __rmul__(&self, n: PyObjectRef) -> Result<PyObjectRef, crate::PyError> {
+        let self_obj = self as *const W_Deque as PyObjectRef;
+        deque_repeat(self_obj, n)
+    }
+    fn __imul__(&mut self, n: PyObjectRef) -> Result<PyObjectRef, crate::PyError> {
+        let self_obj = self as *mut W_Deque as PyObjectRef;
+        // `W_Deque.imul` — empty or *1 is self; *<=0 clears; else
+        // repeat in place, trimmed by maxlen.
         if !unsafe { is_int(n) } {
             return Ok(pyre_object::w_not_implemented());
         }
-        let num = unsafe { w_int_get_value(n) }.max(0);
+        let num = unsafe { w_int_get_value(n) };
         let base = snapshot(self_obj);
+        if base.is_empty() || num == 1 {
+            return Ok(self_obj);
+        }
+        if num <= 0 {
+            store(self_obj, vec![]);
+            return Ok(self_obj);
+        }
         let mut items = Vec::with_capacity(base.len().saturating_mul(num as usize));
         for _ in 0..num {
             items.extend_from_slice(&base);
         }
-        let ty = unsafe { w_instance_get_type(self_obj) };
-        let list = w_list_new(items);
-        match crate::baseobjspace::getattr_str(self_obj, "__maxlen__") {
-            Ok(m) if !(m.is_null() || unsafe { is_none(m) }) => {
-                crate::call::call_function_impl_result(ty, &[list, m])
-            }
-            _ => crate::call::call_function_impl_result(ty, &[list]),
-        }
-    }
-
-    /// `W_Deque.appendleft` + `trimright`: drop from the right once over the bound.
-    fn do_appendleft(self_obj: PyObjectRef, item: PyObjectRef) {
-        let mut items = snapshot(self_obj);
-        items.insert(0, item);
         if let Some(m) = maxlen_bound(self_obj) {
-            items.truncate(m);
+            if items.len() > m {
+                items.drain(0..items.len() - m);
+            }
         }
         store(self_obj, items);
+        Ok(self_obj)
+    }
+    fn __repr__(&self) -> Result<String, crate::PyError> {
+        let self_obj = self as *const W_Deque as PyObjectRef;
+        // `dequerepr` — a deque reachable from its own items renders
+        // the inner reference as `[...]` instead of recursing.
+        let Some(_guard) = crate::display::ReprGuard::enter(self_obj) else {
+            return Ok("[...]".to_string());
+        };
+        // The repr uses the short class name, so strip any dotted
+        // module prefix from the builtin tp_name (`collections.deque`
+        // → `deque`); a user subclass name has no dot.
+        let full = unsafe { w_type_get_name(w_instance_get_type(self_obj)) };
+        let name = full.rsplit('.').next().unwrap_or(full);
+        let listrepr = snapshot(self_obj)
+            .into_iter()
+            .map(|it| unsafe { crate::py_repr(it) })
+            .collect::<Result<Vec<_>, _>>()?
+            .join(", ");
+        Ok(match maxlen_bound(self_obj) {
+            Some(m) => format!("{name}([{listrepr}], maxlen={m})"),
+            None => format!("{name}([{listrepr}])"),
+        })
     }
 
-    crate::py_class! {
-        // Dotted name so the builtin `__module__` resolves to `collections`
-        // (the name dot-split fallback), matching CPython's
-        // `collections.deque`; `__name__` / `__qualname__` strip to `deque`.
-        "collections.deque",
-        methods: {
-            // `init(iterable=None, maxlen=None)` — remember maxlen, then
-            // extend so the bound is enforced while filling.
-            fn __init__(self_obj: PyObjectRef, #[default(None)] iterable: Option<PyObjectRef>, #[default(None)] maxlen: Option<PyObjectRef>) -> Result<(), crate::PyError> {
-                store(self_obj, vec![]);
-                // `gateway_nonnegint_w(w_maxlen)` — None is unbounded; a
-                // non-integer is a TypeError and a negative bound is a
-                // ValueError, both raised here at construction rather than
-                // silently clamped when the bound is later read.
-                let w_maxlen = match maxlen {
-                    Some(m) if !unsafe { is_none(m) } => {
-                        if !unsafe { is_int(m) } {
-                            return Err(crate::PyError::type_error(
-                                "an integer is required"));
-                        }
-                        if unsafe { w_int_get_value(m) } < 0 {
-                            return Err(crate::PyError::value_error(
-                                "maxlen must be non-negative"));
-                        }
-                        m
-                    }
-                    _ => w_none(),
-                };
-                let _ = crate::baseobjspace::setattr_str(self_obj, "__maxlen__", w_maxlen);
-                if let Some(it) = iterable {
-                    for item in crate::builtins::collect_iterable(it)? {
-                        do_append(self_obj, item);
-                    }
-                }
-                Ok(())
-            }
-            fn append(self_obj: PyObjectRef, item: PyObjectRef) {
-                do_append(self_obj, item);
-            }
-            fn appendleft(self_obj: PyObjectRef, item: PyObjectRef) {
-                do_appendleft(self_obj, item);
-            }
-            fn pop(self_obj: PyObjectRef) -> Result<PyObjectRef, crate::PyError> {
-                // `W_Deque.pop` — empty raises IndexError.
-                let mut items = snapshot(self_obj);
-                let item = items.pop().ok_or_else(||
-                    crate::PyError::index_error("pop from an empty deque"))?;
-                store(self_obj, items);
-                Ok(item)
-            }
-            fn popleft(self_obj: PyObjectRef) -> Result<PyObjectRef, crate::PyError> {
-                // `W_Deque.popleft` — empty raises IndexError.
-                let mut items = snapshot(self_obj);
-                if items.is_empty() {
-                    return Err(crate::PyError::index_error("pop from an empty deque"));
-                }
-                let item = items.remove(0);
-                store(self_obj, items);
-                Ok(item)
-            }
-            fn clear(self_obj: PyObjectRef) {
-                store(self_obj, vec![]);
-            }
-            fn extend(self_obj: PyObjectRef, iterable: PyObjectRef) -> Result<(), crate::PyError> {
-                for item in crate::builtins::collect_iterable(iterable)? {
-                    do_append(self_obj, item);
-                }
-                Ok(())
-            }
-            fn extendleft(self_obj: PyObjectRef, iterable: PyObjectRef) -> Result<(), crate::PyError> {
-                // Each element is appended on the left, so the result is
-                // the reverse of `iterable`.
-                for item in crate::builtins::collect_iterable(iterable)? {
-                    do_appendleft(self_obj, item);
-                }
-                Ok(())
-            }
-            fn count(self_obj: PyObjectRef, x: PyObjectRef) -> Result<i64, crate::PyError> {
-                let lock = getlock(self_obj);
-                let mut n = 0i64;
-                for it in snapshot(self_obj) {
-                    let equal = crate::baseobjspace::eq_w(it, x)?;
-                    checklock(self_obj, lock)?;
-                    if equal {
-                        n += 1;
-                    }
-                }
-                Ok(n)
-            }
-            fn remove(self_obj: PyObjectRef, x: PyObjectRef) -> Result<(), crate::PyError> {
-                let mut items = snapshot(self_obj);
-                let lock = getlock(self_obj);
-                let mut pos = None;
-                for (i, &it) in items.iter().enumerate() {
-                    let equal = crate::baseobjspace::eq_w(it, x)?;
-                    checklock(self_obj, lock)?;
-                    if equal {
-                        pos = Some(i);
-                        break;
-                    }
-                }
-                match pos {
-                    Some(pos) => {
-                        items.remove(pos);
-                        store(self_obj, items);
-                        Ok(())
-                    }
-                    None => Err(crate::PyError::value_error(
-                        "deque.remove(x): x not in deque")),
-                }
-            }
-            fn __contains__(self_obj: PyObjectRef, x: PyObjectRef) -> Result<bool, crate::PyError> {
-                let lock = getlock(self_obj);
-                for it in snapshot(self_obj) {
-                    let equal = crate::baseobjspace::eq_w(it, x)?;
-                    checklock(self_obj, lock)?;
-                    if equal {
-                        return Ok(true);
-                    }
-                }
-                Ok(false)
-            }
-            fn reverse(self_obj: PyObjectRef) {
-                let mut items = snapshot(self_obj);
-                items.reverse();
-                store(self_obj, items);
-            }
-            fn rotate(self_obj: PyObjectRef, n: Option<PyObjectRef>) -> Result<(), crate::PyError> {
-                // Rotate right by n (negative rotates left).  The count goes
-                // through `__index__` so non-integers raise `TypeError`.
-                let n = match n {
-                    Some(v) => crate::builtins::getindex_w(v)?,
-                    None => 1,
-                };
-                let mut items = snapshot(self_obj);
-                let len = items.len() as i64;
-                if len <= 1 {
-                    return Ok(());
-                }
-                let shift = ((n % len) + len) % len;
-                if shift != 0 {
-                    items.rotate_right(shift as usize);
-                    store(self_obj, items);
-                }
-                Ok(())
-            }
-            fn index(self_obj: PyObjectRef, x: PyObjectRef, start: Option<PyObjectRef>, stop: Option<PyObjectRef>) -> Result<i64, crate::PyError> {
-                let items = snapshot(self_obj);
-                let len = items.len() as i64;
-                // `space.iter(self)` takes the lock before `unwrap_start_stop`
-                // (interp_deque.py:393-396), so a `__index__` on start/stop
-                // that mutates the deque is caught by the first `checklock`.
-                let lock = getlock(self_obj);
-                let clamp = |i: i64| if i < 0 { (i + len).max(0) } else { i.min(len) };
-                let start = clamp(
-                    start.map(|v| crate::builtins::getindex_w(v)).transpose()?.unwrap_or(0),
-                );
-                let stop = clamp(
-                    stop.map(|v| crate::builtins::getindex_w(v)).transpose()?.unwrap_or(len),
-                );
-                let upper = stop.min(len);
-                let mut i = 0i64;
-                while i < upper {
-                    // `space.next(w_iter)` checks the lock before each element.
-                    checklock(self_obj, lock)?;
-                    if i >= start {
-                        if crate::baseobjspace::eq_w(items[i as usize], x)? {
-                            // Match returns immediately, before the post-match
-                            // `checklock` (interp_deque.py:402-403).
-                            return Ok(i);
-                        }
-                        // interp_deque.py:406 — re-check after a non-match.
-                        checklock(self_obj, lock)?;
-                    }
-                    i += 1;
-                }
-                Err(crate::PyError::value_error(
-                    format!("{} is not in deque", unsafe { crate::py_repr(x)? })))
-            }
-            fn copy(self_obj: PyObjectRef) -> Result<PyObjectRef, crate::PyError> {
-                // `type(self)(self)` or `type(self)(self, maxlen)`.
-                let ty = unsafe { w_instance_get_type(self_obj) };
-                let list = w_list_new(snapshot(self_obj));
-                match crate::baseobjspace::getattr_str(self_obj, "__maxlen__") {
-                    Ok(m) if !(m.is_null() || unsafe { is_none(m) }) =>
-                        crate::call::call_function_impl_result(ty, &[list, m]),
-                    _ => crate::call::call_function_impl_result(ty, &[list]),
-                }
-            }
-            fn __reduce__(self_obj: PyObjectRef) -> Result<PyObjectRef, crate::PyError> {
-                // `_collectionsmodule.c deque_reduce` —
-                // `(type(self), args, state, iter(self))`.  `args` is
-                // `((), maxlen)` when the deque is bounded so the bound
-                // survives the round-trip, else `()`.  `state` is the generic
-                // instance state; the items ride the listitems iterator (the
-                // 4th element).
-                //
-                // The instance payload (`__data__`/`__maxlen__`/`__state__`)
-                // lives in the attribute side-dict (this type is hasdict so the
-                // attribute backing has somewhere to go), and a subclass keeps
-                // user attributes in that same dict with no separate `__dict__`
-                // descriptor exposed, so `object_getstate_default` reports
-                // `None` here and a deque subclass round-trips its type, items
-                // and bound but not extra instance attributes. Preserving those
-                // needs the typed-payload deque backing noted in the module
-                // header (the payload would then leave the attribute dict free
-                // to be a real instance `__dict__`).
-                let ty = unsafe { w_instance_get_type(self_obj) };
-                let w_maxlen = crate::baseobjspace::getattr_str(self_obj, "__maxlen__")
-                    .unwrap_or_else(|_| w_none());
-                let args = if w_maxlen.is_null() || unsafe { is_none(w_maxlen) } {
-                    w_tuple_new(vec![])
-                } else {
-                    w_tuple_new(vec![w_tuple_new(vec![]), w_maxlen])
-                };
-                let state = crate::reduce_protocol::object_getstate_default(self_obj)?;
-                let items = crate::baseobjspace::iter(w_list_new(snapshot(self_obj)))?;
-                Ok(w_tuple_new(vec![ty, args, state, items]))
-            }
-            fn __len__(self_obj: PyObjectRef) -> i64 {
-                data(self_obj)
-                    .map(|d| unsafe { w_list_len(d) } as i64)
-                    .unwrap_or(0)
-            }
-            fn __iter__(self_obj: PyObjectRef) -> Result<PyObjectRef, crate::PyError> {
-                match data(self_obj) {
-                    Some(d) => crate::baseobjspace::iter(d),
-                    None => Ok(w_seq_iter_new(w_list_new(vec![]), 0)),
-                }
-            }
-            fn __getitem__(self_obj: PyObjectRef, index: PyObjectRef) -> Result<PyObjectRef, crate::PyError> {
-                let items = snapshot(self_obj);
-                let idx = deque_index(index, items.len() as i64)?;
-                Ok(items[idx])
-            }
-            fn __setitem__(self_obj: PyObjectRef, index: PyObjectRef, value: PyObjectRef) -> Result<(), crate::PyError> {
-                let mut items = snapshot(self_obj);
-                let idx = deque_index(index, items.len() as i64)?;
-                items[idx] = value;
-                store(self_obj, items);
-                Ok(())
-            }
-            fn __delitem__(self_obj: PyObjectRef, index: PyObjectRef) -> Result<(), crate::PyError> {
-                let mut items = snapshot(self_obj);
-                let idx = deque_index(index, items.len() as i64)?;
-                items.remove(idx);
-                store(self_obj, items);
-                Ok(())
-            }
-            fn __eq__(self_obj: PyObjectRef, other: PyObjectRef) -> Result<PyObjectRef, crate::PyError> {
-                deque_compare(self_obj, other, crate::baseobjspace::CompareOp::Eq)
-            }
-            fn __ne__(self_obj: PyObjectRef, other: PyObjectRef) -> Result<PyObjectRef, crate::PyError> {
-                deque_compare(self_obj, other, crate::baseobjspace::CompareOp::Ne)
-            }
-            fn __lt__(self_obj: PyObjectRef, other: PyObjectRef) -> Result<PyObjectRef, crate::PyError> {
-                deque_compare(self_obj, other, crate::baseobjspace::CompareOp::Lt)
-            }
-            fn __le__(self_obj: PyObjectRef, other: PyObjectRef) -> Result<PyObjectRef, crate::PyError> {
-                deque_compare(self_obj, other, crate::baseobjspace::CompareOp::Le)
-            }
-            fn __gt__(self_obj: PyObjectRef, other: PyObjectRef) -> Result<PyObjectRef, crate::PyError> {
-                deque_compare(self_obj, other, crate::baseobjspace::CompareOp::Gt)
-            }
-            fn __ge__(self_obj: PyObjectRef, other: PyObjectRef) -> Result<PyObjectRef, crate::PyError> {
-                deque_compare(self_obj, other, crate::baseobjspace::CompareOp::Ge)
-            }
-            fn __mul__(self_obj: PyObjectRef, n: PyObjectRef) -> Result<PyObjectRef, crate::PyError> {
-                deque_repeat(self_obj, n)
-            }
-            fn __rmul__(self_obj: PyObjectRef, n: PyObjectRef) -> Result<PyObjectRef, crate::PyError> {
-                deque_repeat(self_obj, n)
-            }
-            fn __imul__(self_obj: PyObjectRef, n: PyObjectRef) -> Result<PyObjectRef, crate::PyError> {
-                // `W_Deque.imul` — empty or *1 is self; *<=0 clears; else
-                // repeat in place, trimmed by maxlen.
-                if !unsafe { is_int(n) } {
-                    return Ok(pyre_object::w_not_implemented());
-                }
-                let num = unsafe { w_int_get_value(n) };
-                let base = snapshot(self_obj);
-                if base.is_empty() || num == 1 {
-                    return Ok(self_obj);
-                }
-                if num <= 0 {
-                    store(self_obj, vec![]);
-                    return Ok(self_obj);
-                }
-                let mut items = Vec::with_capacity(base.len().saturating_mul(num as usize));
-                for _ in 0..num {
-                    items.extend_from_slice(&base);
-                }
-                if let Some(m) = maxlen_bound(self_obj) {
-                    if items.len() > m {
-                        items.drain(0..items.len() - m);
-                    }
-                }
-                store(self_obj, items);
-                Ok(self_obj)
-            }
-            fn __repr__(self_obj: PyObjectRef) -> Result<String, crate::PyError> {
-                // `dequerepr` — a deque reachable from its own items renders
-                // the inner reference as `[...]` instead of recursing.
-                let Some(_guard) = crate::display::ReprGuard::enter(self_obj) else {
-                    return Ok("[...]".to_string());
-                };
-                // The repr uses the short class name, so strip any dotted
-                // module prefix from the builtin tp_name (`collections.deque`
-                // → `deque`); a user subclass name has no dot.
-                let full = unsafe { w_type_get_name(w_instance_get_type(self_obj)) };
-                let name = full.rsplit('.').next().unwrap_or(full);
-                let listrepr = snapshot(self_obj)
-                    .into_iter()
-                    .map(|it| unsafe { crate::py_repr(it) })
-                    .collect::<Result<Vec<_>, _>>()?
-                    .join(", ");
-                Ok(match maxlen_bound(self_obj) {
-                    Some(m) => format!("{name}([{listrepr}], maxlen={m})"),
-                    None => format!("{name}([{listrepr}])"),
-                })
-            }
-        },
-        properties: {
-            // GetSetProperty fget is invoked as `fget(descriptor, instance)`.
-            fn maxlen(_descr: PyObjectRef, self_obj: PyObjectRef) -> PyObjectRef {
-                crate::baseobjspace::getattr_str(self_obj, "__maxlen__")
-                    .unwrap_or_else(|_| w_none())
-            }
-        }
+    #[getter]
+    fn maxlen(&self) -> PyObjectRef {
+        let self_obj = self as *const W_Deque as PyObjectRef;
+        maxlen_obj(self_obj)
     }
 }
 
 crate::py_module! {
     "_collections",
     interpleveldefs: {
-        "deque"           => deque_class::type_object(),
+        "deque"           => type_object(),
         "_deque_iterator" => crate::typedef::w_object(),
         // `OrderedDict` is a dict subclass; alias to the dict type
         // object so `isinstance(d, OrderedDict)` matches dict instances.

--- a/pyre/pyre-macros/src/lib.rs
+++ b/pyre/pyre-macros/src/lib.rs
@@ -1186,6 +1186,24 @@ fn expand_pyre_class(
                 };
                 ::pyre_object::lltype::malloc_typed(full) as ::pyre_object::PyObjectRef
             }
+
+            /// Stable-address variant of [`Self::allocate`]: allocates via
+            /// the non-moving `malloc_typed_stable`, so the object never
+            /// relocates.  Required for a self-mutating payload whose methods
+            /// re-derive `self` from a raw `PyObjectRef` across an allocating
+            /// call — a movable object would leave that raw pointer stale.
+            #[allow(dead_code)]
+            pub fn allocate_stable(payload: Self) -> ::pyre_object::PyObjectRef {
+                let _roots = ::pyre_object::gc_roots::push_roots();
+                let full = Self {
+                    ob: ::pyre_object::PyObject {
+                        ob_type: &#pytype_static as *const ::pyre_object::PyType,
+                        w_class: ::pyre_object::pyobject::get_instantiate(&#pytype_static),
+                    },
+                    ..payload
+                };
+                ::pyre_object::lltype::malloc_typed_stable(full) as ::pyre_object::PyObjectRef
+            }
         }
     })
 }

--- a/pyre/pyre-object/src/lltype.rs
+++ b/pyre/pyre-object/src/lltype.rs
@@ -222,6 +222,38 @@ pub fn malloc_typed<T: GcType>(value: T) -> *mut T {
     majit_gc::header::alloc_with_gc_header(value, type_id)
 }
 
+/// Stable-address variant of [`malloc_typed`]: routes through the
+/// non-moving old-gen allocator (`try_gc_alloc_stable_raw`) so the object
+/// never relocates across a later collection.  A self-mutating typed payload
+/// whose methods re-derive `self` from a raw `PyObjectRef` across an
+/// allocating call needs this: under the movable [`malloc_typed`] a
+/// collection triggered mid-method (e.g. by allocating a fresh backing list)
+/// relocates the object, leaving that raw `self` pointer stale — the same
+/// rationale as `alloc_instance_object`.  Falls back to the movable
+/// [`malloc_typed`] when no stable hook is installed (single-crate tests /
+/// pre-init snapshot tools).
+#[inline]
+pub fn malloc_typed_stable<T: GcType>(value: T) -> *mut T {
+    debug_assert_eq!(
+        std::mem::size_of::<T>(),
+        T::SIZE,
+        "GcType::SIZE drift from std::mem::size_of"
+    );
+    let type_id = match T::type_id() {
+        TypeIdCell::UNASSIGNED => 0,
+        id => id,
+    };
+    let raw = crate::gc_hook::try_gc_alloc_stable_raw(type_id, T::SIZE);
+    if raw.is_null() {
+        malloc_typed(value)
+    } else {
+        unsafe {
+            std::ptr::write(raw as *mut T, value);
+            raw as *mut T
+        }
+    }
+}
+
 /// `lltype.malloc(T, flavor='raw')` parity. Non-GC heap allocation;
 /// caller manages lifetime via `Box::from_raw` later.
 ///


### PR DESCRIPTION
Migrate `collections.deque` from the untyped `py_class!` (`hasdict=true`) to a
typed `#[pyre_class]` payload (`data`/`maxlen`/`state`). The base type now
rejects stray attributes (`deque().foo = 1` → `AttributeError`) and a subclass
carries its own `__dict__` (subclass attributes survive pickle/copy). #232 M1.

## Storage migration

- Payload struct `W_Deque { data, maxlen, state }`, list-backed (M1).
- Mutating methods take `&mut self`; the `state` iteration-lock field is
  read/written via volatile access so a re-entrant mutation from a user
  `__eq__` during `count`/`remove` is observed by `checklock`.
- `__new__` allocates via `allocate_stable` (non-moving) and takes a
  whole-slice catch-all so a subclass `__init__`'s keyword parameters do not
  trip an unknown-keyword error; construction args are validated by `__init__`.
- deque marked `unhashable` + `weakrefable`.

## Typed-payload dunder dispatch

Several dispatchers gated the generic MRO dunder lookup on
`is_instance(obj)` (INSTANCE_TYPE only), silently skipping typed-payload
builtins. Add a `typedef::r#type` + `lookup_in_type_where` fallback (mirroring
`getitem_slot`) at four sites:

- baseobjspace `iter` (`__iter__`, else `__getitem__` sequence iteration)
- baseobjspace `delitem_slot` (`__delitem__`)
- eval `GET_ITER` (delegates to `space.iter`)
- builtins `try_hash_value` (`__hash__ = None` → unhashable `TypeError`)

## Infrastructure

- `lltype::malloc_typed_stable` + a `#[pyre_class]`-generated `allocate_stable`
  mirroring `alloc_instance_object` (`try_gc_alloc_stable_raw` + `ptr::write`,
  fallback to movable).

## Verification

- `check.py`: cranelift **161/161**, dynasm correctness **161/161** (2
  pre-existing perf flakes: `nested_loop`, `raise_catch` — both pass on
  cranelift, unrelated to deque).
- Custom acceptance suite: **43/43** both JIT and NO_JIT.
- Method set is identical old-vs-new (migration preserved every method +
  algorithm), so no storage-migration regressions. Remaining `test_deque.py`
  failures are pre-existing/M2 (block-list lock-aware iterator, O(1) ops,
  never-existed `__add__`/`insert`/`__copy__`, framework-wide arity laxity).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
