### PR TITLE
majit: inline headerless nursery bump for aheui node allocation

### DIFF
--- a/majit/majit-backend-dynasm/src/aarch64/assembler.rs
+++ b/majit/majit-backend-dynasm/src/aarch64/assembler.rs
@@ -3069,7 +3069,6 @@ impl<'a> AssemblerARM64<'a> {
             // before the call, use the existing frame-slot genop_call, then
             // mark the result in the allocated register.
             OpCode::CallI
-            | OpCode::CallR
             | OpCode::CallF
             | OpCode::CallN
             | OpCode::CallPureI
@@ -3088,6 +3087,15 @@ impl<'a> AssemblerARM64<'a> {
             | OpCode::CallReleaseGilF
             | OpCode::CallReleaseGilN => {
                 self.genop_call_with_arglocs(op, arglocs);
+            }
+            OpCode::CallR => {
+                let is_nursery_alloc = op.with_call_descr(|cd| cd.get_extra_info().pyre_helper)
+                    == Some(majit_ir::PyreHelperKind::NurseryAlloc);
+                if is_nursery_alloc {
+                    self.genop_nursery_alloc_inline(op, arglocs);
+                } else {
+                    self.genop_call_with_arglocs(op, arglocs);
+                }
             }
             OpCode::CallAssemblerI
             | OpCode::CallAssemblerR
@@ -5448,6 +5456,69 @@ impl<'a> AssemblerARM64<'a> {
                 self.store_rax_to_result(op.pos.get());
             }
         }
+    }
+
+    /// Inline aheui's headerless `jit_alloc_node(value, next)` nursery bump.
+    ///
+    /// The fast path only advances `nursery_free` and initializes the
+    /// 16-byte Node payload, so it cannot collect and emits no gcmap. The
+    /// slow path is the ordinary residual call wrapper, which may collect
+    /// inside `jit_alloc_node` / `Nursery::alloc` and passes `next` (the old
+    /// head) as the keep-root. This is sound because the op is still a call:
+    /// the optimizer's residual-call emission fences pending head/size
+    /// setfields before this allocation, matching the storage collector's
+    /// root-currentness requirement.
+    fn genop_nursery_alloc_inline(&mut self, op: &Op, arglocs: &[Loc]) {
+        const NURSERY_ALLOC_NODE_SIZE: u32 = 16; // aheui headerless Node = 16B (value@0,next@8)
+
+        let (nf_addr, nt_addr) = crate::runner::dynasm_nursery_addrs();
+        if nf_addr == 0 || nt_addr == 0 {
+            self.genop_call_with_arglocs(op, arglocs);
+            return;
+        }
+
+        let func_index = 3 + usize::from(op.opcode.is_call_release_gil());
+        let (Some(&value_loc), Some(&next_loc)) =
+            (arglocs.get(func_index + 1), arglocs.get(func_index + 2))
+        else {
+            self.genop_call_with_arglocs(op, arglocs);
+            return;
+        };
+
+        let slow_path = self.mc.new_dynamic_label();
+        let done = self.mc.new_dynamic_label();
+
+        // Fast path uses ONLY reserved IP regs (x14/x15/x16/x17); never touches a
+        // regalloc-managed register, so the slow path's original arglocs stay
+        // intact. x16=nf_addr->base, x17=base, x14=newf(temp), x15=nt_addr->top.
+        self.emit_mov_imm64(16, nf_addr as i64); // x16 = &nursery_free
+        dynasm!(self.mc ; .arch aarch64
+            ; ldr x17, [x16]                        // x17 = base = *nursery_free
+            ; add x14, x17, NURSERY_ALLOC_NODE_SIZE // x14 = newf = base + 16
+        );
+        self.emit_mov_imm64(15, nt_addr as i64); // x15 = &nursery_top
+        dynasm!(self.mc ; .arch aarch64
+            ; ldr x15, [x15]                        // x15 = top = *nursery_top
+            ; cmp x14, x15                          // newf vs top
+            ; b.hi =>slow_path                      // newf > top -> exhausted
+            ; str x14, [x16]                        // *nursery_free = newf
+        );
+        // Init node fields; value/next loaded from ORIGINAL arglocs (no pre-clobber).
+        // load_loc_to_reg returns a managed reg untouched, or loads Frame/Immed into
+        // the IP scratch we pass (x15 and x14 are free here: top consumed, newf stored).
+        let vreg = self.load_loc_to_reg(&value_loc, 15);
+        dynasm!(self.mc ; .arch aarch64 ; str X(vreg), [x17]); // value @ base+0
+        let nreg = self.load_loc_to_reg(&next_loc, 14);
+        dynasm!(self.mc ; .arch aarch64 ; str X(nreg), [x17, 8]); // next @ base+8
+        dynasm!(self.mc ; .arch aarch64 ; mov x0, x17); // result = base
+        if !op.pos.get().is_none() {
+            self.store_rax_to_result(op.pos.get());
+        }
+        dynasm!(self.mc ; .arch aarch64 ; b =>done);
+
+        dynasm!(self.mc ; .arch aarch64 ; =>slow_path);
+        self.genop_call_with_arglocs(op, arglocs);
+        dynasm!(self.mc ; .arch aarch64 ; =>done);
     }
 
     /// assembler.py:295-360 call_assembler: invoke a compiled JIT loop.

--- a/majit/majit-backend-dynasm/src/x86/assembler.rs
+++ b/majit/majit-backend-dynasm/src/x86/assembler.rs
@@ -4118,7 +4118,6 @@ impl<'a> Assembler386<'a> {
             // before the call, use the existing frame-slot genop_call, then
             // mark the result in the allocated register.
             OpCode::CallI
-            | OpCode::CallR
             | OpCode::CallF
             | OpCode::CallN
             | OpCode::CallPureI
@@ -4137,6 +4136,15 @@ impl<'a> Assembler386<'a> {
             | OpCode::CallReleaseGilF
             | OpCode::CallReleaseGilN => {
                 self.genop_call_with_arglocs(op, arglocs);
+            }
+            OpCode::CallR => {
+                let is_nursery_alloc = op.with_call_descr(|cd| cd.get_extra_info().pyre_helper)
+                    == Some(majit_ir::PyreHelperKind::NurseryAlloc);
+                if is_nursery_alloc {
+                    self.genop_nursery_alloc_inline_x86(op, arglocs);
+                } else {
+                    self.genop_call_with_arglocs(op, arglocs);
+                }
             }
             OpCode::CallAssemblerI
             | OpCode::CallAssemblerR
@@ -7074,6 +7082,101 @@ impl<'a> Assembler386<'a> {
         if !op.pos.get().is_none() {
             self.store_rax_to_result(op.pos.get());
         }
+    }
+
+    /// Inline aheui's headerless `jit_alloc_node(value, next)` nursery bump.
+    ///
+    /// The fast path only advances `nursery_free` and initializes the
+    /// 16-byte Node payload, so it cannot collect and emits no gcmap. The
+    /// slow path is the ordinary residual call wrapper, which may collect
+    /// inside `jit_alloc_node` / `Nursery::alloc` and passes `next` (the old
+    /// head) as the keep-root. This is sound because the op is still a call:
+    /// the optimizer's residual-call emission fences pending head/size
+    /// setfields before this allocation, matching the storage collector's
+    /// root-currentness requirement.
+    fn genop_nursery_alloc_inline_x86(&mut self, op: &Op, arglocs: &[Loc]) {
+        const NURSERY_ALLOC_NODE_SIZE: i32 = 16; // aheui headerless Node = 16B (value@0,next@8)
+
+        let (nf_addr, nt_addr) = crate::runner::dynasm_nursery_addrs();
+        if nf_addr == 0 || nt_addr == 0 {
+            self.genop_call_with_arglocs(op, arglocs);
+            return;
+        }
+
+        let func_index = 3 + usize::from(op.opcode.is_call_release_gil());
+        let (Some(&value_loc), Some(&next_loc)) =
+            (arglocs.get(func_index + 1), arglocs.get(func_index + 2))
+        else {
+            self.genop_call_with_arglocs(op, arglocs);
+            return;
+        };
+
+        let fn_loc = arglocs.get(func_index).copied();
+        let source_regs = [
+            fn_loc.and_then(|loc| loc.as_reg()),
+            value_loc.as_reg(),
+            next_loc.as_reg(),
+        ];
+        let caller_save_scratch = crate::x86::regalloc::SAVE_AROUND_CALL_CORE_REGS;
+        let mut picked = Vec::new();
+        for &reg in caller_save_scratch {
+            if source_regs
+                .iter()
+                .flatten()
+                .any(|source| source.is_core_reg() && source.value == reg.value)
+            {
+                continue;
+            }
+            picked.push(reg);
+            if picked.len() == 4 {
+                break;
+            }
+        }
+        if picked.len() < 4 {
+            self.genop_call_with_arglocs(op, arglocs);
+            return;
+        }
+        let value_reg = picked[0].value;
+        let next_reg = picked[1].value;
+        let base_reg = picked[2].value;
+        let new_free_reg = picked[3].value;
+        let scratch = crate::regloc::X86_64_SCRATCH_REG.value;
+        let nf = nf_addr as i64;
+        let nt = nt_addr as i64;
+
+        let value_dst = Loc::Reg(crate::regloc::RegLoc::new(value_reg, false));
+        let next_dst = Loc::Reg(crate::regloc::RegLoc::new(next_reg, false));
+        self.regalloc_mov(&value_loc, &value_dst);
+        self.regalloc_mov(&next_loc, &next_dst);
+
+        let slow_path = self.mc.new_dynamic_label();
+        let done = self.mc.new_dynamic_label();
+
+        // CallR regalloc has already spilled/moved caller-save registers via
+        // before_call(). Use only those freed registers plus R11, and load
+        // value/next before staging nursery slot addresses so their original
+        // argloc source registers stay intact for the slow residual call.
+        dynasm!(self.mc ; .arch x64
+            ; mov Rq(scratch), QWORD nf
+            ; mov Rq(base_reg), [Rq(scratch)]                       // base = *nursery_free
+            ; lea Rq(new_free_reg), [Rq(base_reg) + NURSERY_ALLOC_NODE_SIZE]
+            ; mov Rq(scratch), QWORD nt
+            ; cmp Rq(new_free_reg), [Rq(scratch)]
+            ; ja =>slow_path
+            ; mov Rq(scratch), QWORD nf
+            ; mov [Rq(scratch)], Rq(new_free_reg)                   // *nursery_free = base + 16
+            ; mov [Rq(base_reg)], Rq(value_reg)                     // value @ base+0
+            ; mov [Rq(base_reg) + 8], Rq(next_reg)                  // next @ base+8
+            ; mov rax, Rq(base_reg)                                 // result = base
+        );
+        if !op.pos.get().is_none() {
+            self.store_rax_to_result(op.pos.get());
+        }
+        dynasm!(self.mc ; .arch x64 ; jmp =>done);
+
+        dynasm!(self.mc ; .arch x64 ; =>slow_path);
+        self.genop_call_with_arglocs(op, arglocs);
+        dynasm!(self.mc ; .arch x64 ; =>done);
     }
 
     /// assembler.py:295-360 call_assembler: invoke a compiled JIT loop.

--- a/majit/majit-ir/src/effectinfo.rs
+++ b/majit/majit-ir/src/effectinfo.rs
@@ -667,6 +667,13 @@ pub enum PyreHelperKind {
     /// `__getattribute__`, data descriptor, unboxed slot, attribute absent from
     /// this instance's map).
     LoadAttr,
+    /// aheui headerless-Node nursery allocation (`jit_alloc_node(value,next)`).
+    /// The dynasm backend recognises this tag on the CallR descr to emit an
+    /// inline nursery bump (RPython malloc_cond shape) instead of a full
+    /// residual `blr`; the node stays a real escaping alloc result (NOT a
+    /// virtualized New), so the following `selected_ref.head = new_node`
+    /// remains a normal committed setfield. has_oopspec stays false.
+    NurseryAlloc,
 }
 
 impl EffectInfo {

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/lower_stmt.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/lower_stmt.rs
@@ -1429,6 +1429,20 @@ impl<'c> Lowerer<'c> {
                         },
                     );
                 }
+                crate::jit_interp::CallPolicyKind::NurseryAllocRef => {
+                    let typed_args = typed_call_arg_tokens(&arg_bindings);
+                    let throwaway_reg = self.alloc_reg();
+                    let __arg_regs: Vec<Register> =
+                        arg_bindings.iter().map(Register::from_binding).collect();
+                    self.emit_op(
+                        OpMeta::linear(OpKind::Call, __arg_regs, vec![Register::ref_(throwaway_reg)]),
+                        quote! {
+                            let __fn_idx = __builder.add_fn_ptr(#func as *const ());
+                            let __typed_args = #typed_args;
+                            __builder.residual_call_ref_canonical_via_target_with_effect_info(__fn_idx, __typed_args, #throwaway_reg, majit_metainterp::nursery_alloc_effect_info());
+                        },
+                    );
+                }
                 // Wrapped Int / Ref / Float statement-form: result discarded,
                 // but the residual_call must still execute the side effect on
                 // the compiled trace.  RPython jtransform.py:456

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/lower_value.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/lower_value.rs
@@ -756,6 +756,45 @@ impl<'c> Lowerer<'c> {
                         struct_type,
                     });
                 }
+                crate::jit_interp::CallPolicyKind::NurseryAllocRef => {
+                    let typed_args = typed_call_arg_tokens(&arg_bindings);
+                    let reg = self.alloc_reg();
+                    let __arg_regs: Vec<Register> =
+                        arg_bindings.iter().map(Register::from_binding).collect();
+                    self.emit_op(
+                        OpMeta::linear(OpKind::Call, __arg_regs, vec![Register::ref_(reg)]),
+                        quote! {
+                            let __fn_idx = __builder.add_fn_ptr(#func as *const ());
+                            let __typed_args = #typed_args;
+                            __builder.residual_call_ref_canonical_via_target_with_effect_info(__fn_idx, __typed_args, #reg, majit_metainterp::nursery_alloc_effect_info());
+                        },
+                    );
+                    // jtransform.py:467-470 — a residual ref call can raise, so
+                    // the trailing `-live-` follows it exactly as the shared
+                    // path below emits for the other explicit residual arms.
+                    // This arm returns early (to attach `struct_type`), so it
+                    // cannot fall through to that shared emission and must emit
+                    // the marker itself.
+                    if post_live_after_call {
+                        self.emit_op(
+                            OpMeta::live_marker(),
+                            quote! { let _ = __builder.live_placeholder(); },
+                        );
+                    }
+                    // Check `call_returns` config for a declared return
+                    // struct type, enabling subsequent `result.field`
+                    // access to resolve through `ref_fields`.
+                    let func_segments = canonical_expr_segments(func);
+                    let struct_type = func_segments.and_then(|segs| {
+                        self.config.and_then(|c| c.call_returns.get(&segs).cloned())
+                    });
+                    return Some(Binding {
+                        reg,
+                        kind: BindingKind::Ref,
+                        depends_on_stack: false,
+                        struct_type,
+                    });
+                }
                 crate::jit_interp::CallPolicyKind::ResidualIntWrapped
                 | crate::jit_interp::CallPolicyKind::ResidualIntCannotRaiseWrapped
                 | crate::jit_interp::CallPolicyKind::MayForceIntWrapped

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/mod.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/mod.rs
@@ -432,6 +432,7 @@ pub(super) fn call_policy_effect_slot(
         | K::ResidualInt
         | K::ResidualIntWrapped
         | K::ResidualRef
+        | K::NurseryAllocRef
         | K::ResidualRefWrapped
         | K::ResidualFloatWrapped => Some(CondCallEffectSlot::CanRaise),
 
@@ -540,6 +541,7 @@ pub(super) fn call_policy_result_kind(
         | K::InlinePipelineInt => Some(CallResultKind::Int),
 
         K::ResidualRef
+        | K::NurseryAllocRef
         | K::ResidualRefWrapped
         | K::ResidualRefCannotRaiseWrapped
         | K::MayForceRefWrapped

--- a/majit/majit-macros/src/jit_interp/mod.rs
+++ b/majit/majit-macros/src/jit_interp/mod.rs
@@ -414,6 +414,10 @@ pub(crate) enum CallPolicyKind {
     ElidableIntOrMemerror,
     ElidableIntOrMemerrorWrapped,
     ResidualRef,
+    /// Like `ResidualRef` but stamps the descr EffectInfo with
+    /// `PyreHelperKind::NurseryAlloc` (aheui inline nursery bump). Result is a
+    /// real escaping Ref — no virtualization.
+    NurseryAllocRef,
     ResidualRefWrapped,
     /// `EF_CANNOT_RAISE` for ref-returning residual helpers.
     /// Mirrors `ResidualIntCannotRaiseWrapped`; the unwrapped variant
@@ -493,6 +497,7 @@ pub(crate) fn parse_call_policy_kind(kind: &Ident) -> Option<CallPolicyKind> {
         "elidable_int_or_memerror" => CallPolicyKind::ElidableIntOrMemerror,
         "elidable_int_or_memerror_wrapped" => CallPolicyKind::ElidableIntOrMemerrorWrapped,
         "residual_ref" => CallPolicyKind::ResidualRef,
+        "nursery_alloc_ref" => CallPolicyKind::NurseryAllocRef,
         "residual_ref_wrapped" => CallPolicyKind::ResidualRefWrapped,
         "residual_ref_cannot_raise_wrapped" => CallPolicyKind::ResidualRefCannotRaiseWrapped,
         "may_force_ref_wrapped" => CallPolicyKind::MayForceRefWrapped,

--- a/majit/majit-metainterp/src/call_descr.rs
+++ b/majit/majit-metainterp/src/call_descr.rs
@@ -186,6 +186,17 @@ pub fn default_effect_info() -> EffectInfo {
     EffectInfo::const_new(ExtraEffect::CanRaise, OopSpecIndex::None)
 }
 
+/// aheui nursery-alloc residual: identical optimizer treatment to
+/// [`default_effect_info`] (CanRaise, empty write-sets, can_collect=true)
+/// but stamped with [`PyreHelperKind::NurseryAlloc`] so the dynasm CallR
+/// genop emits an inline nursery bump. The tag does not change effect
+/// analysis — the op is forced/fenced exactly like the current residual.
+pub fn nursery_alloc_effect_info() -> EffectInfo {
+    let mut ei = default_effect_info();
+    ei.pyre_helper = PyreHelperKind::NurseryAlloc;
+    ei
+}
+
 /// `EF_CANNOT_RAISE` analyzer-absent fallback — the `call.py:303
 /// else:` row of `call.py:282-303 getcalldescr` selected when
 /// `self._canraise(op) == False`, fed through

--- a/majit/majit-metainterp/src/lib.rs
+++ b/majit/majit-metainterp/src/lib.rs
@@ -90,6 +90,7 @@ pub use call_descr::{
     make_call_assembler_descr, make_call_assembler_descr_by_number,
     make_call_assembler_descr_with_vable, make_call_assembler_descr_with_vable_by_number,
     make_call_descr, make_call_descr_from_target_slot, make_call_descr_with_effect,
+    nursery_alloc_effect_info,
 };
 pub use compile::{make_fail_descr, make_fail_descr_typed, make_finish_fail_descr_typed};
 pub use io_buffer::{


### PR DESCRIPTION
follow-up #345

## Summary

aheui JIT node allocation (`OP_PUSH`/`DUP`/`PUSHNUM`/`PUSHCHAR`) currently lowers each push to a residual ref-returning call into `jit_alloc_node` — a full `blr` with argument marshalling, frame save/reload, and gcmap. rpaheui's orthodox shape (RPython `malloc_cond` / `CALL_MALLOC_NURSERY`) is an inline nursery bump: load `nursery_free`, add the node size, compare against `nursery_top`, cond-call the slowpath only on exhaustion, store back the bumped free.

This PR emits that inline bump in compiled code for the aheui node allocator, driven by an IR-level tag (no backend layering violation, no virtualization of the escaping node).

## Design

Classification is via a new `EffectInfo.pyre_helper` tag, `PyreHelperKind::NurseryAlloc` — **not** a callee-address sniff and **not** a conversion to `OpCode::New`. The op stays `OpCode::CallR` with a real `Ref` result register, so `selected_ref.head = new_node` remains a normal committed `setfield_gc_r` (avoids the partial-virtualization SIGSEGV where a deferred `SetfieldGc(head)` desyncs from a force-committed `SetfieldGc(size)`). The dynasm backend branches on the descr's `pyre_helper`; every other backend lowers the tagged op as an ordinary indirect call.

aheui `Node` is **headerless** (`#[repr(C)] { value: i64 @0, next: *mut Node @8 }`, 16 bytes), so the stock `genop_call_malloc_nursery` (which reserves an 8-byte `GcHeader`, zeroes it, and returns `base+8`) does not apply. The emitters bump by 16, return `base`, and initialize `value@0` / `next@8` inline. The slowpath is the original `genop_call_with_arglocs` (the residual `jit_alloc_node` call with gcmap), reused as the cond-call target — the free-list, `collect`, and `grow` all stay on that path.

## Changes

- **majit-ir / metainterp / macros**: `PyreHelperKind::NurseryAlloc`, `nursery_alloc_effect_info()`, and a `nursery_alloc_ref` call policy that lowers identically to `residual_ref` but tags the descr's `EffectInfo`.
- **majit-backend-dynasm (aarch64)**: `genop_nursery_alloc_inline` using only the reserved IP scratch registers (x14–x17), loading `value`/`next` from their original arglocs after the overflow branch so the slowpath can re-marshal from unclobbered sources.
- **majit-backend-dynasm (x86_64)**: `genop_nursery_alloc_inline_x86` picking caller-save scratch registers that exclude the fnptr, value, and next argloc source registers.

The aheui side (address exposure via `nursery_bump_addrs()` and the `jit_alloc_node => nursery_alloc_ref` policy flip) lives in the aheui-rust repo.

## Verification

- aarch64 logo byte-identical: 996310 bytes / exit 42 / md5 `7fcdbfff0af449c4283c008e3ca317ce`, `jit == naive`, both fast and slow paths exercised.
- `cargo fmt` clean, workspace `cargo check` green.
- x86_64: `cargo check --target x86_64-apple-darwin` only — runtime byte-id verification pending the x86 CI leg (this host is aarch64).

Perf: A/B on logo is neutral (residual `jit_alloc_node` was already an `#[inline(always)]` leaf bump). Landed as an RPython-orthodox structural-parity change (inline bump is the orthodox shape; the residual call was the deviation), not for a wall-clock win.