### PR TITLE
interp: bytearray extend + __imul__ parity follow-ups

### DIFF
--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -12547,8 +12547,12 @@ fn bytearray_method_imul(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyE
     let count = match crate::baseobjspace::int_w(w_index) {
         Ok(v) => v,
         Err(e) if e.kind == crate::PyErrorKind::OverflowError => {
-            return Err(crate::PyError::overflow_error(
-                "cannot fit 'int' into an index-sized integer",
+            return Err(crate::PyError::new(
+                crate::PyErrorKind::OverflowError,
+                format!(
+                    "cannot fit '{}' into an index-sized integer",
+                    crate::baseobjspace::object_functionstr_type_name(args[1])
+                ),
             ));
         }
         Err(e) => return Err(e),

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -12594,10 +12594,38 @@ fn bytearray_method_extend(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::P
         if pyre_object::bytesobject::is_bytes_like(other) {
             pyre_object::bytesobject::bytes_like_data(other).to_vec()
         } else {
-            crate::builtins::collect_iterable(other)?
-                .into_iter()
-                .map(bytearray_byte_arg)
-                .collect::<Result<_, _>>()?
+            // `PyObject_GetIter` — a non-iterable operand is the "can't extend" case.
+            let it = crate::baseobjspace::iter(other).map_err(|e| {
+                if e.kind == crate::PyErrorKind::TypeError {
+                    crate::PyError::type_error(format!(
+                        "can't extend bytearray with {}",
+                        crate::baseobjspace::object_functionstr_type_name(other)
+                    ))
+                } else {
+                    e
+                }
+            })?;
+            let is_str = pyre_object::is_str(other);
+            let mut appended = Vec::new();
+            loop {
+                match crate::baseobjspace::next(it) {
+                    Ok(v) => {
+                        let b = bytearray_byte_arg(v).map_err(|e| {
+                            if is_str && e.kind == crate::PyErrorKind::TypeError {
+                                crate::PyError::type_error(
+                                    "expected iterable of integers; got: 'str'",
+                                )
+                            } else {
+                                e
+                            }
+                        })?;
+                        appended.push(b);
+                    }
+                    Err(e) if e.kind == crate::PyErrorKind::StopIteration => break,
+                    Err(e) => return Err(e),
+                }
+            }
+            appended
         }
     };
     unsafe {


### PR DESCRIPTION
Two bytearray parity follow-ups continuing #488, both matching CPython 3.14.2.

## `interp: bytearray extend error-message parity`
`descr_extend` lumped the get-iterator and drain steps through `collect_iterable`, so a non-iterable operand surfaced a generic `"'X' object is not iterable"` and a `str` operand surfaced a generic `"'str' object cannot be interpreted as an integer"`. Splitting the two steps (`bytearray_extend_impl`):

- non-iterable operand → `can't extend bytearray with <type>` (names the operand type)
- byte-conversion failure while extending a `str` → `expected iterable of integers; got: 'str'`

Out-of-range `ValueError`s, a `str` element inside a non-`str` container, and errors raised mid-iteration propagate unchanged; the bytes-like fast path is untouched.

## `interp: bytearray __imul__ overflow names operand type`
The `__imul__` oversized-count `OverflowError` hardcoded the type as `'int'`, but `getindex_w`/`PyNumber_AsSsize_t` name the original operand's type, so an object whose `__index__` returns an out-of-range value must report its own type. This restores the fix that was not part of the #488 merge (it lived in an un-pushed amend).

## Verification
- `check.py --backend dynasm` 161/161, `--backend cranelift` 161/161
- Probes diffed against CPython 3.14.2: extend (16 cases incl. discriminators), `__imul__` type-name (`int` vs custom `X`), prior `__imul__`/bytearray regressions, `builtin_memoryview.py` — all identical

🤖 Generated with [Claude Code](https://claude.com/claude-code)