### PR TITLE
jit: FBW bridge always-commit slices — CA adopted-frame completion, orphan stamp default-on, merge-point cut

### DIFF
--- a/majit/majit-ir/src/descr.rs
+++ b/majit/majit-ir/src/descr.rs
@@ -4782,21 +4782,48 @@ pub fn memcpy_fn_addr() -> i64 {
 /// "single instance per CPU" semantic; identity stability matters
 /// when downstream optimizer caches key on `descr_identity`.
 pub fn make_vtable_field_descr() -> DescrRef {
-    use std::sync::{Arc, OnceLock};
-    static VTABLE_FIELD_DESCR: OnceLock<DescrRef> = OnceLock::new();
-    VTABLE_FIELD_DESCR
+    static VTABLE_DESCR_GROUP: OnceLock<SimpleDescrGroup> = OnceLock::new();
+    VTABLE_DESCR_GROUP
         .get_or_init(|| {
-            // rclass.py / objectmodel.py: typeptr lives at object head
-            // with `Signed`-sized vtable pointer; is_immutable=true
-            // because the class identity does not change after malloc.
-            Arc::new(SimpleFieldDescr::new(
-                0x6000_0000,
-                0,                            // offset
-                std::mem::size_of::<usize>(), // field_size = WORD
-                crate::Type::Int,
-                true, // is_immutable — typeptr never reassigned
-            ))
+            let field_descr_cell = std::cell::RefCell::new(None);
+            let size_descr = Arc::new_cyclic(|weak_size: &Weak<SimpleSizeDescr>| {
+                let parent_descr: Weak<dyn Descr> = weak_size.clone();
+                // rclass.py / objectmodel.py: typeptr lives at object head
+                // with `Signed`-sized vtable pointer; is_immutable=true
+                // because the class identity does not change after malloc.
+                let field_descr = Arc::new(SimpleFieldDescr {
+                    index: AtomicU32::new(0x6000_0000),
+                    descr_index: AtomicI32::new(-1),
+                    ei_index: AtomicU32::new(u32::MAX),
+                    name: "object.typeptr".to_string(),
+                    offset: 0,
+                    field_size: std::mem::size_of::<usize>(),
+                    field_type: crate::Type::Int,
+                    is_immutable: true,
+                    is_quasi_immutable: false,
+                    flag: ArrayFlag::Signed,
+                    virtualizable: false,
+                    index_in_parent: 0,
+                    parent_descr: Some(parent_descr),
+                    vinfo: None,
+                });
+                *field_descr_cell.borrow_mut() = Some(field_descr.clone());
+                let all_fielddescrs = vec![field_descr as Arc<dyn FieldDescr>];
+                // descr.py:234-238: OBJECT gets a nullptr vtable, so
+                // its SizeDescr is not an object descriptor.
+                SimpleSizeDescr::new(u32::MAX, std::mem::size_of::<usize>(), 0)
+                    .with_all_fielddescrs(all_fielddescrs)
+            });
+            SimpleDescrGroup {
+                size_descr,
+                field_descrs: vec![
+                    field_descr_cell
+                        .into_inner()
+                        .expect("Arc::new_cyclic must initialize the typeptr field descriptor"),
+                ],
+            }
         })
+        .field_descrs[0]
         .clone()
 }
 

--- a/majit/majit-macros/src/jit_interp/mod.rs
+++ b/majit/majit-macros/src/jit_interp/mod.rs
@@ -672,24 +672,6 @@ impl Parse for JitInterpConfig {
     }
 }
 
-impl JitInterpConfig {
-    /// Whether any registered call uses an `InlinePipeline*` policy, which
-    /// requires the host to supply `__majit_pipeline_jitcode` in the dispatch
-    /// jitcode builder's scope.
-    pub fn uses_inline_pipeline(&self) -> bool {
-        self.calls.iter().any(|c| {
-            matches!(
-                c.policy,
-                Some(
-                    CallPolicyKind::InlinePipelineInt
-                        | CallPolicyKind::InlinePipelineRef
-                        | CallPolicyKind::InlinePipelineFloat
-                )
-            )
-        })
-    }
-}
-
 /// Parse `residual_writes = { <ref_scalar>.<field> => [helper, ...], ... }`.
 /// Each map key is a `state` ref-scalar field path (`selected_ref.size`) and
 /// the value is a bracketed list of residual helper function paths that mutate

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -5167,18 +5167,26 @@ impl<M: Clone> MetaInterp<M> {
         // (compile.py:443).
         let orig_vable_ptr_loop =
             self.orig_vable_ptr_from_trace_ctx(&ctx, driver_descriptor.as_ref());
-        let cross_loop_cut = if cut_inner_green_key.is_some() {
-            ctx.get_merge_point_at(green_key, ctx.header_pc)
-                .filter(|mp| mp.position._pos > 0)
-                .map(|mp| {
-                    (
-                        mp.green_boxes.clone(),
-                        crate::history::TreeLoopCutPosition::new(mp.position._pos),
-                    )
-                })
-        } else {
-            None
-        };
+        // pyjitpl.py:3018-3030: compile_loop(original_boxes, live_arg_boxes,
+        // start) always compiles from the merge point registered by the
+        // first header visit — `start` and `original_boxes` come from
+        // `current_merge_points[j]` regardless of where tracing began. A
+        // portal trace starts at its own header (position 0, no cut). A
+        // guard-origin trace that closes at its own key (a bridge walk
+        // whose target procedure has no jumpable label, e.g. a FINISH-only
+        // CALL_ASSEMBLER callee) registers the header mid-trace, so the
+        // prefix from the guard to the header must be cut off — otherwise
+        // the root entry contract pairs the guard's fail-arg inputargs
+        // with the merge point's full-shape JUMP and aborts on arity.
+        let cross_loop_cut = ctx
+            .get_merge_point_at(green_key, ctx.header_pc)
+            .filter(|mp| mp.position._pos > 0)
+            .map(|mp| {
+                (
+                    mp.green_boxes.clone(),
+                    crate::history::TreeLoopCutPosition::new(mp.position._pos),
+                )
+            });
 
         // compile.py:221: call_pure_results = metainterp.call_pure_results
         let call_pure_results = ctx.take_call_pure_results();

--- a/majit/majit-translate/src/annotator/bookkeeper.rs
+++ b/majit/majit-translate/src/annotator/bookkeeper.rs
@@ -443,6 +443,10 @@ pub(crate) enum EmulatedPbcCallKey {
     Sandboxing {
         callable_id: usize,
     },
+    /// RPython `annlowlevel.py:363` key `(llhelper, desc.pyobj)`.
+    LLHelper {
+        callable_id: usize,
+    },
 }
 
 /// RPython `Bookkeeper.pbc_call`'s `emulated` parameter

--- a/majit/majit-translate/src/translator/rtyper/annlowlevel.rs
+++ b/majit/majit-translate/src/translator/rtyper/annlowlevel.rs
@@ -25,34 +25,21 @@
 //!
 //! ## Status of this port
 //!
-//! **Skeleton landed; bodies deferred.** Every public function and
-//! method below surfaces as `TyperError::message("annlowlevel.py:N
-//! — <symbol> port pending")` so downstream consumers can call into
-//! the module in upstream shape without silently taking an adapted
-//! code path. Filling the bodies is the orthodox R4 work — the
-//! skeleton exists so each method can be swapped in against its
-//! upstream counterpart without call-site churn.
+//! **Skeleton partially filled.** Public functions and methods whose
+//! dependencies have landed are ported directly against their
+//! upstream counterparts; surfaces that still lack a required Rust
+//! carrier keep returning structured pending errors naming the
+//! missing primitive.
 //!
 //! The items whose callable bodies are still scheduled as follow-ups:
 //!
-//! * `PseudoHighLevelCallable` + `PseudoHighLevelCallableEntry`
-//!   (annlowlevel.py:286-320) — the type surface is present; call
-//!   specialization depends on
-//!   [`crate::translator::rtyper::extregistry::ExtRegistryEntry`] and
-//!   `hop.genop('direct_call', …)` wiring.
-//! * `LLHelperEntry` (annlowlevel.py:349-376) — the `llhelper` /
-//!   `llhelper_args` direct-running helper functions are present, but
-//!   annotation/rtyping specialization still depends on
-//!   `r.get_unique_llfn()` on `FunctionsPBCRepr` (unported).
 //! * The `hlstr` / `llstr` / `hlunicode` / `llunicode` and pointer-cast
 //!   helper surfaces are present below, but their bodies still return
 //!   structured pending errors until the corresponding `rstr`, `llmemory`,
 //!   and cast specialization paths land.
-//! * `placeholder_sigarg` / `typemeth_placeholder_sigarg` /
-//!   `ADTInterface` (annlowlevel.py:573-640) — the type surface is
-//!   present; signature expansion depends on
-//!   `rpython/annotator/signature.py::Sig` wiring and the `adtmeths`
-//!   attribute of low-level types.
+//! * `ADTInterface.__call__` (annlowlevel.py:632-640) — the type
+//!   surface is present; installing `_annenforceargs_` still lacks a
+//!   `ConstValue` carrier for method attributes.
 //! * `cachedtype` metaclass (annlowlevel.py:644-668) — metaclass
 //!   shape has no direct Rust counterpart; callers reach for
 //!   `once_cell::sync::Lazy` / `std::sync::LazyLock` + a manual cache
@@ -92,13 +79,14 @@ use std::rc::{Rc, Weak};
 use std::sync::Arc;
 
 use crate::annotator::annrpython::RPythonAnnotator;
+use crate::annotator::bookkeeper::{self, EmulatedPbcCallKey};
 use crate::annotator::description::{FunctionDesc, GraphCacheKey};
-use crate::annotator::model::{SomeObjectTrait, SomeValue, not_const};
+use crate::annotator::model::{SomeObjectTrait, SomePtr, SomeValue, not_const};
 use crate::annotator::policy::{
     AnnotatorPolicy, PolicyError, PolicyHandle, PolicyOps, Specializer,
     parse_specializer_directive, specializer_from_normalized,
 };
-use crate::annotator::signature::{Sig, SigArgType};
+use crate::annotator::signature::{AnnotationSpec, Sig, SigArgType, SignatureError};
 use crate::flowspace::model::{BlockKey, ConstValue, Constant, GraphKey, GraphRef, HostObject};
 use crate::flowspace::pygraph::PyGraph;
 
@@ -107,23 +95,151 @@ use super::llannotation::{annotation_to_lltype, lltype_to_annotation};
 use super::lltypesystem::lltype::{
     self, _ptr, DelayedPointer, ForwardReference, FuncType, LowLevelType, Ptr, PtrTarget,
 };
-use super::rmodel::RTypeResult;
 use super::rmodel::Repr;
-use super::rtyper::{HighLevelOp, RPythonTyper};
+use super::rmodel::{RTypeResult, inputconst_from_lltype};
+use super::rpbc::FunctionRepr;
+use super::rtyper::{GenopResult, HighLevelOp, RPythonTyper};
 
 use crate::tool::sourcetools::valid_identifier;
 
-fn annlowlevel_deferred(name: &str) -> TyperError {
-    TyperError::missing_rtype_operation(format!("annlowlevel.{name} helper surface deferred"))
+fn already_annotation_sigarg(s_value: SomeValue) -> SigArgType {
+    SigArgType::Spec(AnnotationSpec::Already(s_value))
+}
+
+fn signature_error(msg: impl Into<String>) -> SignatureError {
+    SignatureError::new(msg)
+}
+
+fn lowlevel_type_from_const_for_signature(
+    value: &ConstValue,
+    context: &str,
+) -> Result<LowLevelType, SignatureError> {
+    match value {
+        ConstValue::LowLevelType(t) => Ok((**t).clone()),
+        other => Err(signature_error(format!(
+            "{context}: expected a LowLevelType constant, got {other:?}"
+        ))),
+    }
+}
+
+fn lowlevel_ptr_type_from_const(value: &ConstValue, context: &str) -> Result<Ptr, TyperError> {
+    let ConstValue::LowLevelType(t) = value else {
+        return Err(TyperError::message(format!(
+            "{context}: expected a LowLevelType constant, got {value:?}"
+        )));
+    };
+    let LowLevelType::Ptr(ptr_t) = &**t else {
+        return Err(TyperError::message(format!(
+            "{context}: expected Ptr(FuncType), got {:?}",
+            t
+        )));
+    };
+    Ok((**ptr_t).clone())
+}
+
+fn ptr_to_annotation_sigarg(ptr: Ptr) -> SigArgType {
+    already_annotation_sigarg(lltype_to_annotation(LowLevelType::Ptr(Box::new(ptr))))
+}
+
+fn lowlevel_attr_from_struct(
+    struct_t: &lltype::Struct,
+    attr: &str,
+) -> Result<LowLevelType, String> {
+    if let Some(value) = struct_t._adtmeths.get(attr) {
+        return match value {
+            ConstValue::LowLevelType(t) => Ok((**t).clone()),
+            other => Err(format!(
+                "lltype Struct._adtmeths[{attr:?}] is not a LowLevelType: {other:?}"
+            )),
+        };
+    }
+    if let Some(field_t) = struct_t._flds.get(attr) {
+        return Ok(field_t.clone());
+    }
+    Err(struct_t._nofield(attr))
+}
+
+fn lowlevel_attr_from_type(t: &LowLevelType, attr: &str) -> Result<LowLevelType, String> {
+    match t {
+        LowLevelType::Struct(struct_t) => lowlevel_attr_from_struct(struct_t, attr),
+        LowLevelType::Array(array_t) => match attr {
+            "ITEM" | "OF" => Ok(array_t.OF.clone()),
+            _ => Err(format!("Array has no attribute {attr:?}")),
+        },
+        LowLevelType::FixedSizeArray(array_t) => match attr {
+            "ITEM" | "OF" => Ok(array_t.OF.clone()),
+            _ => Err(format!("FixedSizeArray has no attribute {attr:?}")),
+        },
+        LowLevelType::ForwardReference(forward_ref) => {
+            let resolved = forward_ref
+                .resolved()
+                .ok_or_else(|| format!("ForwardReference has no resolved attribute {attr:?}"))?;
+            lowlevel_attr_from_type(&resolved, attr)
+        }
+        LowLevelType::Ptr(ptr_t) => lowlevel_attr_from_ptrtarget(&ptr_t.TO, attr),
+        other => Err(format!("{other:?} has no low-level attribute {attr:?}")),
+    }
+}
+
+fn lowlevel_attr_from_ptrtarget(t: &PtrTarget, attr: &str) -> Result<LowLevelType, String> {
+    match t {
+        PtrTarget::Struct(struct_t) => lowlevel_attr_from_struct(struct_t, attr),
+        PtrTarget::Array(array_t) => match attr {
+            "ITEM" | "OF" => Ok(array_t.OF.clone()),
+            _ => Err(format!("Array has no attribute {attr:?}")),
+        },
+        PtrTarget::FixedSizeArray(array_t) => match attr {
+            "ITEM" | "OF" => Ok(array_t.OF.clone()),
+            _ => Err(format!("FixedSizeArray has no attribute {attr:?}")),
+        },
+        PtrTarget::ForwardReference(forward_ref) => {
+            let resolved = forward_ref
+                .resolved()
+                .ok_or_else(|| format!("ForwardReference has no resolved attribute {attr:?}"))?;
+            lowlevel_attr_from_type(&resolved, attr)
+        }
+        PtrTarget::Func(func_t) => match attr {
+            "RESULT" => Ok(func_t.result.clone()),
+            _ => Err(format!("FuncType has no low-level attribute {attr:?}")),
+        },
+        other => Err(format!("{other:?} has no low-level attribute {attr:?}")),
+    }
 }
 
 pub fn placeholder_sigarg(s: &str) -> Result<SigArgType, TyperError> {
     match s {
-        "self" => Ok(SigArgType::PassThrough),
-        "SELF" => Err(annlowlevel_deferred("placeholder_sigarg('SELF')")),
-        _ if s.chars().all(|c| c.is_ascii_lowercase()) => Err(annlowlevel_deferred(
-            format!("placeholder_sigarg({s:?})").as_str(),
+        "self" => Ok(SigArgType::DynamicCallable(Rc::new(|inputcells| {
+            let Some(s_self) = inputcells.first() else {
+                return Err(signature_error("placeholder_sigarg('self'): missing self"));
+            };
+            match s_self {
+                SomeValue::Ptr(_) => Ok(already_annotation_sigarg(s_self.clone())),
+                other => Err(signature_error(format!(
+                    "placeholder_sigarg('self') expected SomePtr, got {other:?}"
+                ))),
+            }
+        }))),
+        "SELF" => Err(TyperError::message(
+            "annlowlevel.placeholder_sigarg('SELF') raises NotImplementedError",
         )),
+        _ if s.chars().all(|c| c.is_ascii_lowercase()) => {
+            let attr = s.to_ascii_uppercase();
+            Ok(SigArgType::DynamicCallable(Rc::new(move |inputcells| {
+                let Some(s_self) = inputcells.first() else {
+                    return Err(signature_error(format!(
+                        "placeholder_sigarg({attr:?}): missing self"
+                    )));
+                };
+                let SomeValue::Ptr(s_self) = s_self else {
+                    return Err(signature_error(format!(
+                        "placeholder_sigarg({attr:?}) expected SomePtr, got {s_self:?}"
+                    )));
+                };
+                let t = lowlevel_attr_from_ptrtarget(&s_self.ll_ptrtype.TO, &attr)
+                    .map_err(signature_error)?;
+                Ok(already_annotation_sigarg(lltype_to_annotation(t)))
+            })))
+        }
         _ => Err(TyperError::message(format!(
             "placeholder_sigarg expected lowercase placeholder, got {s:?}"
         ))),
@@ -132,11 +248,60 @@ pub fn placeholder_sigarg(s: &str) -> Result<SigArgType, TyperError> {
 
 pub fn typemeth_placeholder_sigarg(s: &str) -> Result<SigArgType, TyperError> {
     match s {
-        "SELF" => Ok(SigArgType::PassThrough),
-        "self" => Err(annlowlevel_deferred("typemeth_placeholder_sigarg('self')")),
-        _ if s.chars().all(|c| c.is_ascii_lowercase()) => Err(annlowlevel_deferred(
-            format!("typemeth_placeholder_sigarg({s:?})").as_str(),
-        )),
+        "SELF" => Ok(SigArgType::DynamicCallable(Rc::new(|inputcells| {
+            let Some(s_type) = inputcells.first() else {
+                return Err(signature_error(
+                    "typemeth_placeholder_sigarg('SELF'): missing SELF",
+                ));
+            };
+            match s_type {
+                SomeValue::PBC(_) if s_type.is_constant() => {
+                    Ok(already_annotation_sigarg(s_type.clone()))
+                }
+                other => Err(signature_error(format!(
+                    "typemeth_placeholder_sigarg('SELF') expected constant SomePBC, got {other:?}"
+                ))),
+            }
+        }))),
+        "self" => Ok(SigArgType::DynamicCallable(Rc::new(|inputcells| {
+            let Some(s_type) = inputcells.first() else {
+                return Err(signature_error(
+                    "typemeth_placeholder_sigarg('self'): missing SELF",
+                ));
+            };
+            if !matches!(s_type, SomeValue::PBC(_)) || !s_type.is_constant() {
+                return Err(signature_error(format!(
+                    "typemeth_placeholder_sigarg('self') expected constant SomePBC, got {s_type:?}"
+                )));
+            }
+            let ty = lowlevel_type_from_const_for_signature(
+                s_type.const_().expect("is_constant checked"),
+                "typemeth_placeholder_sigarg('self')",
+            )?;
+            let ptr = Ptr::from_container_type(ty).map_err(signature_error)?;
+            Ok(ptr_to_annotation_sigarg(ptr))
+        }))),
+        _ if s.chars().all(|c| c.is_ascii_lowercase()) => {
+            let attr = s.to_ascii_uppercase();
+            Ok(SigArgType::DynamicCallable(Rc::new(move |inputcells| {
+                let Some(s_type) = inputcells.first() else {
+                    return Err(signature_error(format!(
+                        "typemeth_placeholder_sigarg({attr:?}): missing SELF"
+                    )));
+                };
+                if !matches!(s_type, SomeValue::PBC(_)) || !s_type.is_constant() {
+                    return Err(signature_error(format!(
+                        "typemeth_placeholder_sigarg({attr:?}) expected constant SomePBC, got {s_type:?}"
+                    )));
+                }
+                let ty = lowlevel_type_from_const_for_signature(
+                    s_type.const_().expect("is_constant checked"),
+                    &format!("typemeth_placeholder_sigarg({attr:?})"),
+                )?;
+                let item_t = lowlevel_attr_from_type(&ty, &attr).map_err(signature_error)?;
+                Ok(already_annotation_sigarg(lltype_to_annotation(item_t)))
+            })))
+        }
         _ => Err(TyperError::message(format!(
             "typemeth_placeholder_sigarg expected lowercase placeholder, got {s:?}"
         ))),
@@ -705,12 +870,55 @@ impl PseudoHighLevelCallableEntry {
     /// RPython `specialize_call(self, hop)` (annlowlevel.py:308-320).
     pub fn specialize_call(
         &self,
-        _instance: &PseudoHighLevelCallable,
-        _hop: &HighLevelOp,
+        instance: &PseudoHighLevelCallable,
+        hop: &HighLevelOp,
     ) -> RTypeResult {
-        Err(annlowlevel_deferred(
-            "PseudoHighLevelCallableEntry.specialize_call",
-        ))
+        let args_r = instance
+            .args_s
+            .iter()
+            .map(|s| {
+                let s = s.as_ref().ok_or_else(|| {
+                    TyperError::message(
+                        "PseudoHighLevelCallableEntry.specialize_call: missing argument annotation",
+                    )
+                })?;
+                hop.rtyper.getrepr(s)
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        let r_res = hop.rtyper.getrepr(&instance.s_result)?;
+        let vlist = hop.inputargs(args_r.iter().map(|r| r.into()).collect())?;
+        let p = instance.llfnptr.clone();
+        let func_ptr_type = lltype::typeOf(&p);
+        let c_func = inputconst_from_lltype(
+            &LowLevelType::Ptr(Box::new(func_ptr_type.clone())),
+            &ConstValue::LLPtr(Box::new(p)),
+        )?;
+        let PtrTarget::Func(functype) = &func_ptr_type.TO else {
+            return Err(TyperError::message(
+                "PseudoHighLevelCallableEntry.specialize_call: llfnptr is not Ptr(FuncType)",
+            ));
+        };
+        for (r_arg, argtype) in args_r.iter().zip(functype.args.iter()) {
+            if r_arg.lowleveltype() != argtype {
+                return Err(TyperError::message(format!(
+                    "PseudoHighLevelCallableEntry.specialize_call: argument lowleveltype mismatch: got {:?}, expected {:?}",
+                    r_arg.lowleveltype(),
+                    argtype
+                )));
+            }
+        }
+        if r_res.lowleveltype() != &functype.result {
+            return Err(TyperError::message(format!(
+                "PseudoHighLevelCallableEntry.specialize_call: result lowleveltype mismatch: got {:?}, expected {:?}",
+                r_res.lowleveltype(),
+                functype.result
+            )));
+        }
+        hop.exception_is_here()?;
+        let mut call_args = Vec::with_capacity(vlist.len() + 1);
+        call_args.push(crate::flowspace::model::Hlvalue::Constant(c_func));
+        call_args.extend(vlist);
+        Ok(hop.genop("direct_call", call_args, GenopResult::Repr(r_res)))
     }
 }
 
@@ -760,17 +968,128 @@ impl LLHelperEntry {
     /// (annlowlevel.py:352-368).
     pub fn compute_result_annotation(
         &self,
-        _s_f: &SomeValue,
-        _s_callable: &SomeValue,
+        s_f: &SomeValue,
+        s_callable: &SomeValue,
     ) -> Result<SomeValue, TyperError> {
-        Err(annlowlevel_deferred(
+        if !s_f.is_constant() {
+            return Err(TyperError::message(
+                "LLHelperEntry.compute_result_annotation: s_F must be constant",
+            ));
+        }
+        let SomeValue::PBC(pbc) = s_callable else {
+            return Err(TyperError::message(
+                "LLHelperEntry.compute_result_annotation: s_callable must be SomePBC",
+            ));
+        };
+        let f = lowlevel_ptr_type_from_const(
+            s_f.const_().expect("is_constant checked"),
             "LLHelperEntry.compute_result_annotation",
-        ))
+        )?;
+        let PtrTarget::Func(func) = &f.TO else {
+            return Err(TyperError::message(
+                "LLHelperEntry.compute_result_annotation: F must be Ptr(FuncType)",
+            ));
+        };
+        let args_s = func
+            .args
+            .iter()
+            .cloned()
+            .map(lltype_to_annotation)
+            .collect::<Vec<_>>();
+        let bookkeeper = bookkeeper::getbookkeeper().ok_or_else(|| {
+            TyperError::message(
+                "LLHelperEntry.compute_result_annotation missing annotator::bookkeeper::getbookkeeper",
+            )
+        })?;
+        for desc in pbc.descriptions.values() {
+            let _funcdesc: Rc<RefCell<FunctionDesc>> = desc.as_function().ok_or_else(|| {
+                TyperError::message(
+                    "LLHelperEntry.compute_result_annotation: description is not FunctionDesc",
+                )
+            })?;
+            let pyobj = desc.pyobj().ok_or_else(|| {
+                TyperError::message(
+                    "LLHelperEntry.compute_result_annotation: FunctionDesc.pyobj is missing",
+                )
+            })?;
+            if pbc.is_constant() {
+                let Some(ConstValue::HostObject(const_obj)) = s_callable.const_() else {
+                    return Err(TyperError::message(
+                        "LLHelperEntry.compute_result_annotation: constant SomePBC must carry HostObject",
+                    ));
+                };
+                if const_obj != &pyobj {
+                    return Err(TyperError::message(
+                        "LLHelperEntry.compute_result_annotation: constant SomePBC does not match desc.pyobj",
+                    ));
+                }
+            }
+            let key = EmulatedPbcCallKey::LLHelper {
+                callable_id: pyobj.identity_id(),
+            };
+            let s_res = bookkeeper
+                .emulate_pbc_call(key, s_callable, &args_s, &[], None)
+                .map_err(|e| TyperError::message(format!("{e:?}")))?;
+            if !lltype_to_annotation(func.result.clone()).contains(&s_res) {
+                return Err(TyperError::message(format!(
+                    "LLHelperEntry.compute_result_annotation: result {:?} is not contained in {:?}",
+                    s_res,
+                    lltype_to_annotation(func.result.clone())
+                )));
+            }
+        }
+        Ok(SomeValue::Ptr(SomePtr::new(f)))
     }
 
     /// RPython `specialize_call(self, hop)` (annlowlevel.py:370-376).
-    pub fn specialize_call(&self, _hop: &HighLevelOp) -> RTypeResult {
-        Err(annlowlevel_deferred("LLHelperEntry.specialize_call"))
+    pub fn specialize_call(&self, hop: &HighLevelOp) -> RTypeResult {
+        hop.exception_cannot_occur()?;
+        let callable_is_constant = {
+            let args_s = hop.args_s.borrow();
+            args_s
+                .get(1)
+                .ok_or_else(|| {
+                    TyperError::message("LLHelperEntry.specialize_call: missing callable argument")
+                })?
+                .is_constant()
+        };
+        let r_callable = {
+            let args_r = hop.args_r.borrow();
+            args_r.get(1).and_then(Clone::clone).ok_or_else(|| {
+                TyperError::message("LLHelperEntry.specialize_call: missing callable argument repr")
+            })?
+        };
+        if callable_is_constant {
+            let r_func = (r_callable.as_ref() as &dyn std::any::Any)
+                .downcast_ref::<FunctionRepr>()
+                .ok_or_else(|| {
+                    TyperError::message(
+                        "LLHelperEntry.specialize_call: callable repr is not FunctionRepr",
+                    )
+                })?;
+            return Ok(Some(r_func.get_unique_llfn()?));
+        }
+        let f = {
+            let args_s = hop.args_s.borrow();
+            let s_f = args_s.get(0).ok_or_else(|| {
+                TyperError::message("LLHelperEntry.specialize_call: missing F argument")
+            })?;
+            lowlevel_ptr_type_from_const(
+                s_f.const_().ok_or_else(|| {
+                    TyperError::message("LLHelperEntry.specialize_call: F must be constant")
+                })?,
+                "LLHelperEntry.specialize_call",
+            )?
+        };
+        let expected = LowLevelType::Ptr(Box::new(f));
+        if r_callable.lowleveltype() != &expected {
+            return Err(TyperError::message(format!(
+                "LLHelperEntry.specialize_call: callable lowleveltype mismatch: got {:?}, expected {:?}",
+                r_callable.lowleveltype(),
+                expected
+            )));
+        }
+        Ok(Some(hop.inputarg(&r_callable, 1)?))
     }
 }
 
@@ -846,7 +1165,10 @@ impl ADTInterface {
         &self,
         _adtmeths: HashMap<String, ConstValue>,
     ) -> Result<HashMap<String, ConstValue>, TyperError> {
-        Err(annlowlevel_deferred("ADTInterface.__call__"))
+        Err(TyperError::missing_rtype_operation(
+            "annlowlevel.ADTInterface.__call__ deferred: missing ConstValue::_annenforceargs_ carrier"
+                .to_string(),
+        ))
     }
 }
 
@@ -1713,10 +2035,43 @@ pub struct CastBasePtrToInstanceEntry;
 mod tests {
     use super::*;
     use crate::annotator::annrpython::RPythonAnnotator;
-    use crate::annotator::model::SomeInteger;
-    use crate::flowspace::model::{ConstValue, Constant, GraphFunc};
+    use crate::annotator::model::{SomeInteger, SomeObject, SomePBC};
+    use crate::flowspace::model::{
+        ConstValue, Constant, GraphFunc, Hlvalue, SpaceOperation, Variable,
+    };
+    use crate::translator::rtyper::rmodel::ReprState;
+    use crate::translator::rtyper::rtyper::LowLevelOpList;
     use rustpython_compiler::{Mode, compile as rp_compile};
     use rustpython_compiler_core::bytecode::ConstantData;
+
+    #[derive(Debug)]
+    struct TestRepr {
+        state: ReprState,
+        lowleveltype: LowLevelType,
+    }
+
+    impl TestRepr {
+        fn new(lowleveltype: LowLevelType) -> Self {
+            TestRepr {
+                state: ReprState::new(),
+                lowleveltype,
+            }
+        }
+    }
+
+    impl Repr for TestRepr {
+        fn lowleveltype(&self) -> &LowLevelType {
+            &self.lowleveltype
+        }
+
+        fn state(&self) -> &ReprState {
+            &self.state
+        }
+
+        fn class_name(&self) -> &'static str {
+            "TestRepr"
+        }
+    }
 
     fn make_rtyper() -> (Rc<RPythonAnnotator>, Rc<RPythonTyper>) {
         let annotator = RPythonAnnotator::new(None, None, None, false);
@@ -1744,6 +2099,37 @@ mod tests {
         HostObject::new_user_function(func)
     }
 
+    fn lowlevel_type_const_annotation(t: LowLevelType) -> SomeValue {
+        let mut s = SomeObject::default();
+        s.const_box = Some(Constant::new(ConstValue::LowLevelType(Box::new(t))));
+        SomeValue::Object(s)
+    }
+
+    fn lowlevel_type_pbc_annotation(annotator: &RPythonAnnotator, t: LowLevelType) -> SomeValue {
+        let f = compiled_host_function("def ll_marker():\n    return 1\n");
+        let entry = annotator
+            .bookkeeper
+            .getdesc(&f)
+            .expect("function desc for low-level type PBC");
+        let mut pbc = SomePBC::new([entry], false);
+        pbc.base.const_box = Some(Constant::new(ConstValue::LowLevelType(Box::new(t))));
+        SomeValue::PBC(pbc)
+    }
+
+    fn call_dynamic_sigarg(sigarg: &SigArgType, inputcells: &[SomeValue]) -> SigArgType {
+        let SigArgType::DynamicCallable(f) = sigarg else {
+            panic!("expected DynamicCallable");
+        };
+        f(inputcells).expect("dynamic signature argument should expand")
+    }
+
+    fn already_annotation(sigarg: SigArgType) -> SomeValue {
+        let SigArgType::Spec(AnnotationSpec::Already(s_value)) = sigarg else {
+            panic!("expected AnnotationSpec::Already");
+        };
+        s_value
+    }
+
     #[test]
     fn llhelper_args_builds_low_level_function_pointer() {
         let f = compiled_host_function("def ll_id(x):\n    return x\n");
@@ -1761,6 +2147,203 @@ mod tests {
             func._callable
                 .as_deref()
                 .is_some_and(|name| name.starts_with("ll_id#"))
+        );
+    }
+
+    #[test]
+    fn pseudo_high_level_callable_specialize_call_emits_direct_call() {
+        let (_annotator, rtyper) = make_rtyper();
+        let func_t = FuncType {
+            args: vec![LowLevelType::Signed],
+            result: LowLevelType::Signed,
+        };
+        let fnptr = lltype::functionptr(
+            func_t,
+            "ll_identity",
+            None,
+            Some("ll_identity#test".to_string()),
+        );
+        let instance = PseudoHighLevelCallable::new(
+            fnptr.clone(),
+            vec![Some(SomeValue::Integer(SomeInteger::default()))],
+            SomeValue::Integer(SomeInteger::default()),
+        );
+        let v_arg = Hlvalue::Constant(Constant::with_concretetype(
+            ConstValue::Int(3),
+            LowLevelType::Signed,
+        ));
+        let spaceop = SpaceOperation::new(
+            "simple_call".to_string(),
+            vec![v_arg.clone()],
+            Hlvalue::Variable(Variable::new()),
+        );
+        let llops = Rc::new(RefCell::new(LowLevelOpList::new(rtyper.clone(), None)));
+        let hop = HighLevelOp::new(rtyper.clone(), spaceop, Vec::new(), llops.clone());
+        let r_int = rtyper
+            .getrepr(&SomeValue::Integer(SomeInteger::default()))
+            .expect("int repr");
+        hop.args_v.borrow_mut().push(v_arg);
+        hop.args_s
+            .borrow_mut()
+            .push(SomeValue::Integer(SomeInteger::default()));
+        hop.args_r.borrow_mut().push(Some(r_int.clone()));
+        *hop.s_result.borrow_mut() = Some(SomeValue::Integer(SomeInteger::default()));
+        *hop.r_result.borrow_mut() = Some(r_int);
+
+        let result = PseudoHighLevelCallableEntry
+            .specialize_call(&instance, &hop)
+            .expect("specialize_call")
+            .expect("direct_call should produce a result");
+        assert!(matches!(result, Hlvalue::Variable(_)));
+        let ops = llops.borrow();
+        assert_eq!(ops.ops.len(), 1);
+        assert_eq!(ops.ops[0].opname, "direct_call");
+        let Hlvalue::Constant(c_func) = &ops.ops[0].args[0] else {
+            panic!("first direct_call arg should be function constant");
+        };
+        assert_eq!(
+            c_func.concretetype,
+            Some(LowLevelType::Ptr(Box::new(fnptr._TYPE)))
+        );
+        assert!(matches!(c_func.value, ConstValue::LLPtr(_)));
+        assert!(ops._called_exception_is_here_or_cannot_occur);
+    }
+
+    #[test]
+    fn llhelper_compute_result_annotation_emulates_pbc_call_and_returns_someptr() {
+        let (annotator, _rtyper) = make_rtyper();
+        let f = compiled_host_function("def ll_id(x):\n    return x\n");
+        let entry = annotator
+            .bookkeeper
+            .getdesc(&f)
+            .expect("function desc for llhelper");
+        let mut pbc = SomePBC::new([entry], false);
+        pbc.base.const_box = Some(Constant::new(ConstValue::HostObject(f)));
+        let s_callable = SomeValue::PBC(pbc);
+        let f_type = Ptr {
+            TO: PtrTarget::Func(FuncType {
+                args: vec![LowLevelType::Signed],
+                result: LowLevelType::Signed,
+            }),
+        };
+        let s_f = lowlevel_type_const_annotation(LowLevelType::Ptr(Box::new(f_type.clone())));
+        let _guard = annotator.bookkeeper.at_position(None);
+
+        let result = LLHelperEntry
+            .compute_result_annotation(&s_f, &s_callable)
+            .expect("compute_result_annotation");
+        let SomeValue::Ptr(s_ptr) = result else {
+            panic!("llhelper should return SomePtr(F)");
+        };
+        assert_eq!(s_ptr.ll_ptrtype, f_type);
+    }
+
+    #[test]
+    fn llhelper_specialize_call_nonconstant_callable_returns_inputarg() {
+        let (_annotator, rtyper) = make_rtyper();
+        let f_type = Ptr {
+            TO: PtrTarget::Func(FuncType {
+                args: vec![LowLevelType::Signed],
+                result: LowLevelType::Signed,
+            }),
+        };
+        let ptr_lltype = LowLevelType::Ptr(Box::new(f_type.clone()));
+        let s_f = lowlevel_type_const_annotation(ptr_lltype.clone());
+        let s_callable = SomeValue::Ptr(SomePtr::new(f_type));
+        let v_f = Hlvalue::Constant(Constant::with_concretetype(
+            ConstValue::LowLevelType(Box::new(ptr_lltype.clone())),
+            LowLevelType::Void,
+        ));
+        let v_callable = Variable::new();
+        v_callable.set_concretetype(Some(ptr_lltype.clone()));
+        let v_callable_h = Hlvalue::Variable(v_callable.clone());
+        let spaceop = SpaceOperation::new(
+            "simple_call".to_string(),
+            vec![v_f.clone(), v_callable_h.clone()],
+            Hlvalue::Variable(Variable::new()),
+        );
+        let llops = Rc::new(RefCell::new(LowLevelOpList::new(rtyper.clone(), None)));
+        let hop = HighLevelOp::new(rtyper, spaceop, Vec::new(), llops.clone());
+        let r_callable: Arc<dyn Repr> = Arc::new(TestRepr::new(ptr_lltype));
+        hop.args_v.borrow_mut().extend([v_f, v_callable_h]);
+        hop.args_s.borrow_mut().extend([s_f, s_callable]);
+        hop.args_r
+            .borrow_mut()
+            .extend([None, Some(r_callable.clone())]);
+
+        let result = LLHelperEntry
+            .specialize_call(&hop)
+            .expect("specialize_call")
+            .expect("non-constant callable should return inputarg");
+        let Hlvalue::Variable(result_var) = result else {
+            panic!("inputarg should preserve the callable variable");
+        };
+        assert_eq!(result_var, v_callable);
+        assert!(llops.borrow()._called_exception_is_here_or_cannot_occur);
+    }
+
+    #[test]
+    fn placeholder_sigarg_dynamic_branches_expand_from_pointer_type() {
+        let item = placeholder_sigarg("item").expect("item placeholder");
+        let self_arg = placeholder_sigarg("self").expect("self placeholder");
+        let ptr = Ptr {
+            TO: PtrTarget::Array(lltype::Array::gc(LowLevelType::Signed)),
+        };
+        let s_self = SomeValue::Ptr(SomePtr::new(ptr.clone()));
+
+        let expanded_item = already_annotation(call_dynamic_sigarg(&item, &[s_self.clone()]));
+        assert!(matches!(expanded_item, SomeValue::Integer(_)));
+        let expanded_self = already_annotation(call_dynamic_sigarg(&self_arg, &[s_self]));
+        let SomeValue::Ptr(expanded_self) = expanded_self else {
+            panic!("self placeholder should return SomePtr");
+        };
+        assert_eq!(expanded_self.ll_ptrtype, ptr);
+    }
+
+    #[test]
+    fn typemeth_placeholder_sigarg_dynamic_branches_expand_from_type_constant() {
+        let (annotator, _rtyper) = make_rtyper();
+        let list_type = LowLevelType::Array(Box::new(lltype::Array::gc(LowLevelType::Signed)));
+        let s_type = lowlevel_type_pbc_annotation(&annotator, list_type.clone());
+
+        let expanded_self = already_annotation(call_dynamic_sigarg(
+            &typemeth_placeholder_sigarg("self").expect("self typemeth placeholder"),
+            &[s_type.clone()],
+        ));
+        let SomeValue::Ptr(s_ptr) = expanded_self else {
+            panic!("typemeth self should return Ptr(TYPE)");
+        };
+        assert_eq!(
+            s_ptr.ll_ptrtype,
+            Ptr {
+                TO: PtrTarget::Array(lltype::Array::gc(LowLevelType::Signed))
+            }
+        );
+
+        let expanded_self_type = already_annotation(call_dynamic_sigarg(
+            &typemeth_placeholder_sigarg("SELF").expect("SELF typemeth placeholder"),
+            &[s_type.clone()],
+        ));
+        assert_eq!(expanded_self_type, s_type);
+
+        let expanded_item = already_annotation(call_dynamic_sigarg(
+            &typemeth_placeholder_sigarg("item").expect("item typemeth placeholder"),
+            &[lowlevel_type_pbc_annotation(&annotator, list_type)],
+        ));
+        assert!(matches!(expanded_item, SomeValue::Integer(_)));
+    }
+
+    #[test]
+    fn adtinterface_call_reports_missing_constvalue_annenforceargs_carrier() {
+        let interface = ADTInterface {
+            sigtemplates: HashMap::new(),
+            base: None,
+            sigs: HashMap::new(),
+        };
+        let err = interface.__call__(HashMap::new()).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("missing ConstValue::_annenforceargs_ carrier")
         );
     }
 

--- a/pyre/pyre-interpreter/src/host_seam.rs
+++ b/pyre/pyre-interpreter/src/host_seam.rs
@@ -58,6 +58,7 @@ pub mod sys {
     pub use ::libc::{WEXITSTATUS, WIFEXITED, WIFSIGNALED, WIFSTOPPED, WSTOPSIG, WTERMSIG};
     // Type-only re-exports for names that libc also defines as a function, so
     // the type resolves but the syscall call does not.
+    #[allow(non_camel_case_types)]
     pub type stat = ::libc::stat;
     pub use ::libc::winsize;
     // Constants (added as sandbox-reachable modules need them).

--- a/pyre/pyre-jit-trace/src/descr.rs
+++ b/pyre/pyre-jit-trace/src/descr.rs
@@ -1275,6 +1275,25 @@ static DICT_STORAGE_DESCR_GROUP: LazyLock<PyreObjectDescrGroup> = LazyLock::new(
     )
 });
 
+static ITEMS_BLOCK_DESCR_GROUP: LazyLock<PyreObjectDescrGroup> = LazyLock::new(|| {
+    build_object_descr_group_with_def_path(
+        pyre_object::object_array::ITEMS_BLOCK_ITEMS_OFFSET,
+        0,
+        0,
+        &[(
+            "ItemsBlock.capacity",
+            0,
+            8,
+            Type::Int,
+            false,
+            true,
+            false,
+        )],
+        "ItemsBlock",
+        "object_array::ItemsBlock",
+    )
+});
+
 // `pypy/objspace/std/sliceobject.py:13` `W_SliceObject._immutable_fields_ =
 // ['w_start', 'w_stop', 'w_step']` — all three Ref fields are immutable
 // once `__init__` runs.  The `space.newslice(w_start, w_end, w_step)` JIT
@@ -2027,8 +2046,10 @@ pub fn specialised_tuple_oo_w_class_descr() -> DescrRef {
 /// allocated the capacity is fixed; resize allocates a fresh block.
 /// Callers combine `list_items_descr()` / `tuple_wrappeditems_descr()`
 /// → `ItemsBlock*` with this descr to read the block's allocated size.
+/// The group parent lets sub-walk reads pass the optimizer's
+/// `ensure_ptr_info_arg0` parent lookup.
 pub fn items_block_capacity_descr() -> DescrRef {
-    make_immutable_field_descr(0, 8, Type::Int, false)
+    field_descr_from_group(&ITEMS_BLOCK_DESCR_GROUP, 0)
 }
 
 pub fn int_intval_descr() -> DescrRef {

--- a/pyre/pyre-jit-trace/src/descr.rs
+++ b/pyre/pyre-jit-trace/src/descr.rs
@@ -1280,15 +1280,7 @@ static ITEMS_BLOCK_DESCR_GROUP: LazyLock<PyreObjectDescrGroup> = LazyLock::new(|
         pyre_object::object_array::ITEMS_BLOCK_ITEMS_OFFSET,
         0,
         0,
-        &[(
-            "ItemsBlock.capacity",
-            0,
-            8,
-            Type::Int,
-            false,
-            true,
-            false,
-        )],
+        &[("ItemsBlock.capacity", 0, 8, Type::Int, false, true, false)],
         "ItemsBlock",
         "object_array::ItemsBlock",
     )

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -7596,9 +7596,10 @@ thread_local! {
     /// as `DoneWithThisFrame` instead of rewinding to the guard pc and
     /// re-interpreting the region (which would double every eagerly executed
     /// residual side effect, #177).  Only the bridge tracer sets it, and only
-    /// when the resume is single-frame and the caller can consume a concrete
-    /// result (the general guard path, not the CALL_ASSEMBLER callback), so a
-    /// committed journal never strands into a blackhole re-run.  Cleared after
+    /// when the resume is single-frame; the general guard path consumes the
+    /// kept stash as a terminal `BridgeResolution`, and the CALL_ASSEMBLER
+    /// callback hands it to its back-to-back blackhole hook, so a committed
+    /// journal never strands into a guard-state re-run.  Cleared after
     /// every bridge walk.
     static FBW_BRIDGE_NOREPLAY_ARMED: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
 }
@@ -7687,16 +7688,20 @@ pub(crate) fn fbw_finish_raise_set(value: ConcreteValue) {
 
 /// Peek at the stashed terminal disposition without consuming it (the
 /// `run_perfn_walk` epilogue uses this to decide whether to commit the
-/// store journal and keep the no-replay shortcut).
-pub(crate) fn fbw_finish_concrete_peek() -> Option<FinishConcrete> {
+/// store journal and keep the no-replay shortcut; the CALL_ASSEMBLER
+/// bridge callback uses it to leave a kept stash in its rooted cell for
+/// the back-to-back blackhole hook).
+pub fn fbw_finish_concrete_peek() -> Option<FinishConcrete> {
     FBW_FINISH_CONCRETE.with(|c| c.get())
 }
 
 /// Clear the stashed terminal disposition.  The `run_perfn_walk`
 /// epilogue calls this when the no-replay shortcut is declined (not a
 /// `Terminate` walk, or an unjournaled effect only the replay applies) so
-/// the portal degrades to `ContinueRunningNormally`.
-pub(crate) fn fbw_finish_concrete_reset() {
+/// the portal degrades to `ContinueRunningNormally`; the CALL_ASSEMBLER
+/// blackhole hook calls it so a kept stash that cannot be consumed does
+/// not leak into a later portal take.
+pub fn fbw_finish_concrete_reset() {
     FBW_FINISH_CONCRETE.with(|c| c.set(None));
 }
 

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -14438,6 +14438,14 @@ fn dispatch_residual_call_iRd_kind(
     ctx: &mut WalkContext<'_, '_>,
     dst_bank: char,
 ) -> Result<(DispatchOutcome, usize), DispatchError> {
+    // execute_varargs (pyjitpl.py:1940-1941) opens every residual call
+    // with metainterp.clear_exception(), so a caught exception's
+    // last_exc_value never survives past the next call — the
+    // opimpl_catch_exception assert (pyjitpl.py:504) relies on it.
+    // Clear at the arm entry so declined/folded paths uphold the same
+    // invariant as the concrete-execution success arm.
+    ctx.last_exc_value = None;
+    ctx.last_exc_value_concrete = ConcreteValue::Null;
     let funcptr = read_int_reg(code, op, 0, ctx)?;
     let (r_args, arg_width) = read_ref_var_list(code, op, 1, ctx)?;
     // #62: env-gated recognition probe (no-op unless PYRE_DIAG_INLINE_RECOG
@@ -19474,6 +19482,10 @@ fn dispatch_residual_call_iIRd_kind(
     ctx: &mut WalkContext<'_, '_>,
     dst_bank: char,
 ) -> Result<(DispatchOutcome, usize), DispatchError> {
+    // execute_varargs (pyjitpl.py:1940-1941) clear_exception at every
+    // residual-call entry; see dispatch_residual_call_iRd_kind.
+    ctx.last_exc_value = None;
+    ctx.last_exc_value_concrete = ConcreteValue::Null;
     let funcptr = read_int_reg(code, op, 0, ctx)?;
     let (i_args, i_width) = read_int_var_list(code, op, 1, ctx)?;
     let (r_args, r_width) = read_ref_var_list(code, op, 1 + i_width, ctx)?;
@@ -20051,6 +20063,10 @@ fn dispatch_residual_call_iIRFd_kind(
     ctx: &mut WalkContext<'_, '_>,
     dst_bank: char,
 ) -> Result<(DispatchOutcome, usize), DispatchError> {
+    // execute_varargs (pyjitpl.py:1940-1941) clear_exception at every
+    // residual-call entry; see dispatch_residual_call_iRd_kind.
+    ctx.last_exc_value = None;
+    ctx.last_exc_value_concrete = ConcreteValue::Null;
     let funcptr = read_int_reg(code, op, 0, ctx)?;
     let (i_args, i_width) = read_int_var_list(code, op, 1, ctx)?;
     let (r_args, r_width) = read_ref_var_list(code, op, 1 + i_width, ctx)?;

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -1625,6 +1625,11 @@ pub fn walk(
                     // last_exc_box)` records the outermost FINISH.
                     ctx.trace_ctx
                         .finish(&[exc], ctx.exit_frame_with_exception_descr_ref.clone());
+                    if let ConcreteValue::Ref(p) = exc_concrete {
+                        if !p.is_null() {
+                            fbw_finish_raise_set(exc_concrete);
+                        }
+                    }
                     return Ok((DispatchOutcome::Terminate, pc));
                 } else {
                     return Ok((DispatchOutcome::SubRaise { exc, exc_concrete }, pc));
@@ -7560,11 +7565,11 @@ thread_local! {
     static FBW_FINISH_PAYLOAD: std::cell::Cell<Option<(OpRef, Type)>> =
         const { std::cell::Cell::new(None) };
 
-    /// The CONCRETE return value a top-level `*_return` arm produced, set
-    /// alongside [`FBW_FINISH_PAYLOAD`] for a loop-free portal exit
-    /// (`DispatchOutcome::Terminate`).  Unlike `FBW_FINISH_PAYLOAD` (the
-    /// symbolic re-boxed `OpRef` the compile consumer records into the
-    /// trace), this holds the value the walk *concretely* computed.
+    /// The terminal disposition a top-level walk produced, set for a
+    /// loop-free portal exit (`DispatchOutcome::Terminate`).  Unlike
+    /// `FBW_FINISH_PAYLOAD` (the symbolic re-boxed `OpRef` the compile
+    /// consumer records into the trace), this holds the value the walk
+    /// *concretely* computed.
     ///
     /// A function trace that fully unrolls to `done_with_this_frame`
     /// executed every residual call concretely (consuming side-effecting
@@ -7580,7 +7585,7 @@ thread_local! {
     /// via [`fbw_finish_concrete_root_walker`].  `None` for ungated /
     /// loop-closing / float (no concrete float shadow bank) walks → the
     /// portal degrades to the legacy `ContinueRunningNormally` replay.
-    static FBW_FINISH_CONCRETE: std::cell::Cell<Option<ConcreteValue>> =
+    static FBW_FINISH_CONCRETE: std::cell::Cell<Option<FinishConcrete>> =
         const { std::cell::Cell::new(None) };
 
     /// Armed by the bridge tracer (`call_jit::trace_and_compile_from_bridge`)
@@ -7596,6 +7601,19 @@ thread_local! {
     /// committed journal never strands into a blackhole re-run.  Cleared after
     /// every bridge walk.
     static FBW_BRIDGE_NOREPLAY_ARMED: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+}
+
+/// Terminal disposition of a walk kept for the no-replay exit:
+/// the top-level frame's concrete return value, or the concrete
+/// exception object of the uncaught raise that ended the walk
+/// (`opimpl_raise` → `finishframe_exception` →
+/// `compile_exit_frame_with_exception`, pyjitpl.py:1688-1698 +
+/// 3238-3242; the caller consumes it as `ExitFrameWithExceptionRef`,
+/// jitexc.py:44).
+#[derive(Clone, Copy)]
+pub enum FinishConcrete {
+    Return(ConcreteValue),
+    Raise(ConcreteValue),
 }
 
 /// Whether the slice-b Finish-portal compile route is enabled.  Cached so
@@ -7659,17 +7677,22 @@ pub(crate) fn fbw_finish_payload_take() -> Option<(OpRef, Type)> {
 /// Stash the concrete return value of a top-level value-returning
 /// `*_return` arm (see [`FBW_FINISH_CONCRETE`]).
 pub(crate) fn fbw_finish_concrete_set(value: ConcreteValue) {
-    FBW_FINISH_CONCRETE.with(|c| c.set(Some(value)));
+    FBW_FINISH_CONCRETE.with(|c| c.set(Some(FinishConcrete::Return(value))));
 }
 
-/// Peek at the stashed concrete return value without consuming it (the
+/// Stash the concrete exception object of a top-level uncaught raise.
+pub(crate) fn fbw_finish_raise_set(value: ConcreteValue) {
+    FBW_FINISH_CONCRETE.with(|c| c.set(Some(FinishConcrete::Raise(value))));
+}
+
+/// Peek at the stashed terminal disposition without consuming it (the
 /// `run_perfn_walk` epilogue uses this to decide whether to commit the
 /// store journal and keep the no-replay shortcut).
-pub(crate) fn fbw_finish_concrete_peek() -> Option<ConcreteValue> {
+pub(crate) fn fbw_finish_concrete_peek() -> Option<FinishConcrete> {
     FBW_FINISH_CONCRETE.with(|c| c.get())
 }
 
-/// Clear the stashed concrete return value.  The `run_perfn_walk`
+/// Clear the stashed terminal disposition.  The `run_perfn_walk`
 /// epilogue calls this when the no-replay shortcut is declined (not a
 /// `Terminate` walk, or an unjournaled effect only the replay applies) so
 /// the portal degrades to `ContinueRunningNormally`.
@@ -7677,13 +7700,12 @@ pub(crate) fn fbw_finish_concrete_reset() {
     FBW_FINISH_CONCRETE.with(|c| c.set(None));
 }
 
-/// Consume the stashed concrete return value (the portal exit in
-/// `eval.rs` takes it to return the walk's result directly).
-pub fn fbw_finish_concrete_take() -> Option<ConcreteValue> {
+/// Consume the stashed terminal disposition at the portal exit.
+pub fn fbw_finish_concrete_take() -> Option<FinishConcrete> {
     FBW_FINISH_CONCRETE.with(|c| c.take())
 }
 
-/// `framework.py root_walker.walk_roots` parity for the concrete return
+/// `framework.py root_walker.walk_roots` parity for the concrete terminal
 /// value: a `Ref` payload holds a nursery-resident object across the
 /// post-walk compile (which allocates and may trigger a minor collection
 /// that moves nursery objects), so the slot is forwarded as a root.
@@ -7691,14 +7713,24 @@ pub fn fbw_finish_concrete_take() -> Option<ConcreteValue> {
 /// [`fbw_store_journal_root_walker`].
 pub fn fbw_finish_concrete_root_walker(visitor: &mut dyn FnMut(&mut majit_ir::GcRef)) {
     FBW_FINISH_CONCRETE.with(|c| {
-        if let Some(ConcreteValue::Ref(ptr)) = c.get() {
+        let Some(finish) = c.get() else {
+            return;
+        };
+        let (value, is_raise) = match finish {
+            FinishConcrete::Return(value) => (value, false),
+            FinishConcrete::Raise(value) => (value, true),
+        };
+        if let ConcreteValue::Ref(ptr) = value {
             let mut gcref = majit_ir::GcRef(ptr as usize);
             visitor(&mut gcref);
             // The visitor may forward (relocate) the ref; write it back so
             // the stashed value points at the moved object.
-            c.set(Some(ConcreteValue::Ref(
-                gcref.0 as pyre_object::PyObjectRef,
-            )));
+            let value = ConcreteValue::Ref(gcref.0 as pyre_object::PyObjectRef);
+            c.set(Some(if is_raise {
+                FinishConcrete::Raise(value)
+            } else {
+                FinishConcrete::Return(value)
+            }));
         }
     });
 }
@@ -22207,6 +22239,11 @@ fn handle(
             if ctx.is_top_level && !fbw_raise_enabled() {
                 ctx.trace_ctx
                     .finish(&[exc], ctx.exit_frame_with_exception_descr_ref.clone());
+                if let ConcreteValue::Ref(p) = concrete_exc {
+                    if !p.is_null() {
+                        fbw_finish_raise_set(concrete_exc);
+                    }
+                }
                 Ok((DispatchOutcome::Terminate, op.next_pc))
             } else {
                 Ok((
@@ -22338,6 +22375,11 @@ fn handle(
             if ctx.is_top_level && !fbw_raise_enabled() {
                 ctx.trace_ctx
                     .finish(&[exc], ctx.exit_frame_with_exception_descr_ref.clone());
+                if let ConcreteValue::Ref(p) = ctx.last_exc_value_concrete {
+                    if !p.is_null() {
+                        fbw_finish_raise_set(ctx.last_exc_value_concrete);
+                    }
+                }
                 Ok((DispatchOutcome::Terminate, op.next_pc))
             } else {
                 Ok((

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -609,7 +609,7 @@ pub struct WalkContext<'frame, 'static_a: 'frame> {
     /// ops — an effect declined at walk time still lands exactly once
     /// (see the void gate in
     /// [`try_execute_residual_call_via_executor`] and
-    /// [`FBW_UNJOURNALED_EFFECT`]).  A per-opcode arm walk has no
+    /// [`fbw_has_unjournaled_effect`]).  A per-opcode arm walk has no
     /// replay: the interpreter advances opcode by opcode during
     /// tracing and the compiled loop is entered at the NEXT iteration,
     /// so an effect the walker declines to execute is simply lost —
@@ -5809,14 +5809,14 @@ pub fn bool_box_truth_reset() {
 /// or corrupt the live heap under the discard-the-trace probe.
 ///
 /// **Return value**:
-/// * `Ok(Some(Ok(_)))` — helper executed normally, `recorded` OpRef
+/// * `Ok(ResidualExecOutcome::Executed(Ok(_)))` — helper executed normally, `recorded` OpRef
 ///   stamped with the concrete result.
-/// * `Ok(Some(Err(bh_exc)))` — helper raised; `bh_exc` is the wrapped
+/// * `Ok(ResidualExecOutcome::Executed(Err(bh_exc)))` — helper raised; `bh_exc` is the wrapped
 ///   `PyError` pointer (from `BH_LAST_EXC_VALUE`).  Caller is
 ///   responsible for routing into `WalkContext.last_exc_value` so the
 ///   downstream `GuardNoException` walker handler picks it up; the
 ///   `recorded` OpRef is NOT stamped (no concrete result).
-/// * `Ok(None)` — fold declined (preconditions not met: not the
+/// * `Ok(ResidualExecOutcome::Declined(_))` — fold declined (preconditions not met: not the
 ///   authoritative executor, opcode out of set, funcbox non-const, arity
 ///   exceeds [`MAX_HOST_CALL_ARITY`], any operand lacks a concrete
 ///   `box_value`, or any Ref arg is NULL), or the call's result is void
@@ -5835,6 +5835,18 @@ pub fn bool_box_truth_reset() {
 /// alongside [`try_fold_pure_call_via_executor`].  The may-force /
 /// can-raise path wires the `Err` exception through
 /// `WalkContext.last_exc_value`.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum ResidualDecline {
+    ValueUnavailable,
+    Symbolic,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum ResidualExecOutcome {
+    Executed(Result<i64, i64>),
+    Declined(ResidualDecline),
+}
+
 fn try_execute_residual_call_via_executor(
     ctx: &mut WalkContext<'_, '_>,
     call_opcode: OpCode,
@@ -5842,7 +5854,7 @@ fn try_execute_residual_call_via_executor(
     call_descr: &dyn majit_ir::descr::CallDescr,
     recorded: OpRef,
     op_pc: usize,
-) -> Result<Option<Result<i64, i64>>, DispatchError> {
+) -> Result<ResidualExecOutcome, DispatchError> {
     // Orthodox sub-jitcode walk safety (#171 wall-5d): a residual call whose
     // funcbox is a `symbolic_fnaddr` placeholder — a 64-bit `DefaultHasher`
     // hash of an in-body helper's `CallPath`/`CallTarget`, minted when
@@ -5869,7 +5881,7 @@ fn try_execute_residual_call_via_executor(
     // leave the flag `false` so the call is recorded symbolically
     // without re-running its side effects.
     if !ctx.is_authoritative_executor {
-        return Ok(None);
+        return Ok(ResidualExecOutcome::Declined(ResidualDecline::Symbolic));
     }
     let plain_or_loopinvariant = matches!(
         call_opcode,
@@ -5895,10 +5907,10 @@ fn try_execute_residual_call_via_executor(
             | OpCode::CallMayForceN
     );
     if !plain_or_loopinvariant && !is_may_force {
-        return Ok(None);
+        return Ok(ResidualExecOutcome::Declined(ResidualDecline::Symbolic));
     }
     if allboxes.is_empty() {
-        return Ok(None);
+        return Ok(ResidualExecOutcome::Declined(ResidualDecline::Symbolic));
     }
     // Same funcbox-must-be-const invariant as `try_fold_pure_call_via_executor`:
     // a non-const funcbox carries a stale stamp and dereferencing it as a
@@ -5907,7 +5919,7 @@ fn try_execute_residual_call_via_executor(
     // implicitly requires constness too (residual_call descrs always
     // carry a fixed funcptr at translation time).
     if !allboxes[0].is_constant() {
-        return Ok(None);
+        return Ok(ResidualExecOutcome::Declined(ResidualDecline::Symbolic));
     }
     // The LOAD_CONST helper (oopspec `LoadConst`) has a dedicated fold in the
     // residual_call dispatchers: when the const index AND the code pointer
@@ -5921,12 +5933,12 @@ fn try_execute_residual_call_via_executor(
     // `w_code_get_ptr` and faults.  Leave it symbolic, mirroring the fold's
     // "falls through to the generic record" contract.
     if call_descr.get_extra_info().pyre_helper == majit_ir::PyreHelperKind::LoadConst {
-        return Ok(None);
+        return Ok(ResidualExecOutcome::Declined(ResidualDecline::Symbolic));
     }
     let funcptr_val = ctx.trace_ctx.box_value(allboxes[0]);
     let func_ptr = match funcptr_val {
         Some(majit_ir::Value::Int(addr)) => addr,
-        _ => return Ok(None),
+        _ => return Ok(ResidualExecOutcome::Declined(ResidualDecline::Symbolic)),
     };
     // Sub-slice 4 safety gate — reject `symbolic_fnaddr_for_path`
     // placeholder values that escaped runtime patching.  Pyre's
@@ -5944,7 +5956,7 @@ fn try_execute_residual_call_via_executor(
     // non-fnptr value (e.g. an int constant mistakenly routed through
     // the funcbox slot).
     if (func_ptr as u64) >> 47 != 0 {
-        return Ok(None);
+        return Ok(ResidualExecOutcome::Declined(ResidualDecline::Symbolic));
     }
     // A residual whose funcptr is a `PyFrame` operand-stack accessor
     // (`pop`/`push`/`peek`/`peek_at`) reads or mutates the live frame's
@@ -5959,10 +5971,10 @@ fn try_execute_residual_call_via_executor(
     // frame whose operand stack the compiled trace's preceding pushes have
     // populated.
     if pyre_interpreter::is_pyframe_operand_stack_accessor(func_ptr as usize) {
-        return Ok(None);
+        return Ok(ResidualExecOutcome::Declined(ResidualDecline::Symbolic));
     }
     if allboxes.len() - 1 > majit_translate::codewriter::insns::MAX_HOST_CALL_ARITY {
-        return Ok(None);
+        return Ok(ResidualExecOutcome::Declined(ResidualDecline::Symbolic));
     }
     // A void residual (CALL_N family) is a side effect with no result box, so
     // `do_residual_call` executes it EAGERLY during the walk and resumes the
@@ -5994,7 +6006,9 @@ fn try_execute_residual_call_via_executor(
                             arg_index,
                         });
                     }
-                    return Ok(None);
+                    return Ok(ResidualExecOutcome::Declined(
+                        ResidualDecline::ValueUnavailable,
+                    ));
                 }
                 r.as_usize() as i64
             }
@@ -6007,7 +6021,9 @@ fn try_execute_residual_call_via_executor(
                         arg_index,
                     });
                 }
-                return Ok(None);
+                return Ok(ResidualExecOutcome::Declined(
+                    ResidualDecline::ValueUnavailable,
+                ));
             }
         };
         args.push(v);
@@ -6024,7 +6040,7 @@ fn try_execute_residual_call_via_executor(
     // prepends it as arg0 only when non-null), so a concrete-NULL there
     // is the normal plain-call shape.  These exemptions MUST match
     // `walker_abort_if_mayforce_null_ref_arg`'s — otherwise a normal
-    // no-receiver keyword/star call is declined here to `Ok(None)`
+    // no-receiver keyword/star call is declined as symbolic
     // (left symbolic), which drops the recording iteration's call
     // exactly once (`g(i, d=4)` in a hot loop summed to n-1, callee
     // ran n-1 times).
@@ -6056,7 +6072,7 @@ fn try_execute_residual_call_via_executor(
             continue;
         }
         if matches!(call_descr.arg_types().get(i), Some(majit_ir::Type::Ref)) && arg == 0 {
-            return Ok(None);
+            return Ok(ResidualExecOutcome::Declined(ResidualDecline::Symbolic));
         }
     }
     // #57 (Finding #1, in-place container mutation): an in-flight FOR_ITER
@@ -6366,6 +6382,7 @@ fn try_execute_residual_call_via_executor(
     }
     match exec_result {
         Ok(result_i64) => {
+            fbw_count_executed_residual(is_void, is_may_force);
             // `pyjitpl.py:1685-1690 _opimpl_residual_call*` finishes its
             // success arm with `metainterp.clear_exception()` (called
             // implicitly through `do_residual_call`'s no-raise tail).
@@ -6393,9 +6410,7 @@ fn try_execute_residual_call_via_executor(
             // pyjitpl.py:1392 `result_box.value = result` analogue — stamp
             // the recorded OpRef with the executed concrete so downstream
             // `concrete_of_opref` / `box_value` consumers see the folded
-            // value.  Full-body-walk Void results returned `None` above
-            // (recorded symbolically); a per-opcode arm walk reaches this
-            // arm for an executed void helper with nothing to stamp.
+            // value. An executed void helper has nothing to stamp.
             match call_descr.result_type() {
                 majit_ir::Type::Int => {
                     ctx.trace_ctx
@@ -6480,6 +6495,7 @@ fn try_execute_residual_call_via_executor(
             }
         }
         Err(bh_exc) => {
+            fbw_count_executed_residual(is_void, is_may_force);
             // pyjitpl.py:1690-1696 `metainterp.execute_raised(exception,
             // constant=False)` analogue — seed the standing exception
             // state so downstream walker chain (`reraise/`,
@@ -6514,7 +6530,7 @@ fn try_execute_residual_call_via_executor(
             }
         }
     }
-    Ok(Some(exec_result))
+    Ok(ResidualExecOutcome::Executed(exec_result))
 }
 
 /// `pyjitpl.py:3671-3681 MetaInterp.direct_call_release_gil` port.
@@ -7786,20 +7802,22 @@ thread_local! {
     static FBW_FORITER_INFLIGHT: std::cell::RefCell<Vec<InflightForiter>> =
         const { std::cell::RefCell::new(Vec::new()) };
 
-    /// Set when the walk records a side effect that was neither executed
-    /// at walk time nor undo-logged: a void residual call recorded
-    /// symbolically (the `try_execute_residual_call_via_executor` void
-    /// gate).  A flagged walk must not adopt its end state — the flush
-    /// site keeps the legacy replay, which is the only path that applies
-    /// the recorded effect.
-    static FBW_UNJOURNALED_EFFECT: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+    static FBW_UNJOURNALED_VALUE_UNAVAILABLE: std::cell::Cell<bool> =
+        const { std::cell::Cell::new(false) };
+    static FBW_UNJOURNALED_SYMBOLIC: std::cell::Cell<bool> =
+        const { std::cell::Cell::new(false) };
+
+    static FBW_EXECUTED_RESIDUAL_VOID: std::cell::Cell<u32> = const { std::cell::Cell::new(0) };
+    static FBW_EXECUTED_RESIDUAL_MAYFORCE: std::cell::Cell<u32> = const { std::cell::Cell::new(0) };
+    static FBW_EXECUTED_RESIDUAL_PLAIN: std::cell::Cell<u32> = const { std::cell::Cell::new(0) };
 
     /// gh#467 executed-effect odometer: bumped only when the walk concretely
     /// applies an effect — a store/append/cell journal push, a Void / mutator-
     /// tagged residual executed by [`try_execute_residual_call_via_executor`],
     /// or a residual whose concrete run entered a user Python frame (a value-
     /// returning dunder that may mutate).  A declined residual recorded only
-    /// symbolically sets [`FBW_UNJOURNALED_EFFECT`] but does NOT move this
+    /// symbolically sets an unjournaled flag ([`FBW_UNJOURNALED_VALUE_UNAVAILABLE`]
+    /// / [`FBW_UNJOURNALED_SYMBOLIC`]) but does NOT move this
     /// counter: no effect executed.  The inline abort-forward-flush gate
     /// (`try_walker_inline_user_call` / gh#467) snapshots both signals at the
     /// CALL.  A nonzero count delta means the callee attempt cannot be
@@ -7909,13 +7927,17 @@ fn fbw_built_exc_take(op: OpRef) -> bool {
     FBW_BUILT_EXC.with(|s| s.borrow_mut().remove(&op))
 }
 
-/// Clear the store journal and the unjournaled-effect flag before a walk
+/// Clear the store journal and residual-call census before a walk
 /// begins (mirrors [`bool_box_truth_reset`]).
 pub(crate) fn fbw_store_journal_reset() {
     FBW_STORE_JOURNAL.with(|j| j.borrow_mut().clear());
     FBW_APPEND_JOURNAL.with(|j| j.borrow_mut().clear());
     FBW_CELL_STORE_JOURNAL.with(|j| j.borrow_mut().clear());
-    FBW_UNJOURNALED_EFFECT.with(|c| c.set(false));
+    FBW_UNJOURNALED_VALUE_UNAVAILABLE.with(|c| c.set(false));
+    FBW_UNJOURNALED_SYMBOLIC.with(|c| c.set(false));
+    FBW_EXECUTED_RESIDUAL_VOID.with(|c| c.set(0));
+    FBW_EXECUTED_RESIDUAL_MAYFORCE.with(|c| c.set(0));
+    FBW_EXECUTED_RESIDUAL_PLAIN.with(|c| c.set(0));
     // gh#467: reset the executed-effect odometer and any stale
     // forward-flush carrier a prior aborted walk latched.
     FBW_EXECUTED_EFFECT_COUNT.with(|c| c.set(0));
@@ -8297,9 +8319,14 @@ pub(crate) fn fbw_store_journal_len() -> usize {
 }
 
 /// Mark the walk as carrying a recorded-but-unexecuted side effect only
-/// the legacy replay applies (see [`FBW_UNJOURNALED_EFFECT`]).
-pub(crate) fn fbw_mark_unjournaled_effect() {
-    FBW_UNJOURNALED_EFFECT.with(|c| c.set(true));
+/// the legacy replay applies.
+pub(crate) fn fbw_mark_unjournaled_effect(cause: ResidualDecline) {
+    match cause {
+        ResidualDecline::ValueUnavailable => {
+            FBW_UNJOURNALED_VALUE_UNAVAILABLE.with(|c| c.set(true));
+        }
+        ResidualDecline::Symbolic => FBW_UNJOURNALED_SYMBOLIC.with(|c| c.set(true)),
+    }
 }
 
 /// gh#467 executed-effect odometer read (see [`FBW_EXECUTED_EFFECT_COUNT`]).
@@ -8436,7 +8463,7 @@ pub(crate) fn fbw_abort_carrier_clear() {
     FBW_ABORT_CALL_RESUME.with(|c| *c.borrow_mut() = None);
 }
 
-/// An unexecutable residual call (`try_execute_residual_call_via_executor`
+/// A declined residual call (`try_execute_residual_call_via_executor`
 /// returned `None`) reached during a multiframe-inlined callee sub-walk
 /// (the framestack is non-empty) cannot fall back to the walk-end
 /// legacy replay.  The replay re-enters the freshly compiled loop from the
@@ -8469,7 +8496,34 @@ fn fbw_abort_nested_unjournaled_residual(
 
 /// Whether the walk recorded an effect outside the journal's reach.
 pub(crate) fn fbw_has_unjournaled_effect() -> bool {
-    FBW_UNJOURNALED_EFFECT.with(|c| c.get())
+    let (value_unavailable, symbolic) = fbw_unjournaled_kinds();
+    value_unavailable || symbolic
+}
+
+pub(crate) fn fbw_unjournaled_kinds() -> (bool, bool) {
+    (
+        FBW_UNJOURNALED_VALUE_UNAVAILABLE.with(|c| c.get()),
+        FBW_UNJOURNALED_SYMBOLIC.with(|c| c.get()),
+    )
+}
+
+fn fbw_count_executed_residual(is_void: bool, is_may_force: bool) {
+    let counter = if is_void {
+        &FBW_EXECUTED_RESIDUAL_VOID
+    } else if is_may_force {
+        &FBW_EXECUTED_RESIDUAL_MAYFORCE
+    } else {
+        &FBW_EXECUTED_RESIDUAL_PLAIN
+    };
+    counter.with(|c| c.set(c.get().wrapping_add(1)));
+}
+
+pub(crate) fn fbw_executed_residual_counts() -> (u32, u32, u32) {
+    (
+        FBW_EXECUTED_RESIDUAL_VOID.with(|c| c.get()),
+        FBW_EXECUTED_RESIDUAL_MAYFORCE.with(|c| c.get()),
+        FBW_EXECUTED_RESIDUAL_PLAIN.with(|c| c.get()),
+    )
 }
 
 /// `framework.py root_walker.walk_roots` parity for the store and append
@@ -12035,13 +12089,16 @@ fn direct_call_release_gil(
         recorded,
         pc,
     )?;
-    // A `None` leaves the call recorded symbolically WITHOUT running it, so
+    // A decline leaves the call recorded symbolically WITHOUT running it, so
     // the walk-end no-replay commit must stay off for this trace.
-    if resid_exec.is_none() {
-        fbw_abort_nested_unjournaled_residual(ctx, pc)?;
-        fbw_mark_unjournaled_effect();
-    }
-    let resid_raised = matches!(resid_exec, Some(Err(_)));
+    let resid_raised = match resid_exec {
+        ResidualExecOutcome::Executed(result) => result.is_err(),
+        ResidualExecOutcome::Declined(cause) => {
+            fbw_abort_nested_unjournaled_residual(ctx, pc)?;
+            fbw_mark_unjournaled_effect(cause);
+            false
+        }
+    };
     debug_assert!(
         !resid_raised || ei.check_can_raise(false),
         "{caller}: release-gil helper raised on a `!can_raise` EI — \
@@ -13089,11 +13146,14 @@ fn try_walker_call_assembler_self_recursive(
     // A decline leaves the CALL_ASSEMBLER recorded symbolically WITHOUT
     // running it — a side effect only the legacy replay applies, so the
     // walk-end no-replay commit must stay off for this trace (see
-    // `FBW_UNJOURNALED_EFFECT`).
-    if exec.is_none() {
-        fbw_mark_unjournaled_effect();
-    }
-    let exec_raised = matches!(exec, Some(Err(_)));
+    // `fbw_has_unjournaled_effect`).
+    let exec_raised = match exec {
+        ResidualExecOutcome::Executed(result) => result.is_err(),
+        ResidualExecOutcome::Declined(cause) => {
+            fbw_mark_unjournaled_effect(cause);
+            false
+        }
+    };
 
     // pyjitpl.py:2072: heapcache invalidation for the escaped frame.
     ctx.trace_ctx
@@ -13253,10 +13313,13 @@ fn emit_walker_loop_callee_call_assembler(
         ca_result,
         op.pc,
     )?;
-    if exec.is_none() {
-        fbw_mark_unjournaled_effect();
-    }
-    let exec_raised = matches!(exec, Some(Err(_)));
+    let exec_raised = match exec {
+        ResidualExecOutcome::Executed(result) => result.is_err(),
+        ResidualExecOutcome::Declined(cause) => {
+            fbw_mark_unjournaled_effect(cause);
+            false
+        }
+    };
 
     ctx.trace_ctx
         .heap_cache_mut()
@@ -14877,16 +14940,19 @@ fn dispatch_residual_call_iRd_kind(
             recorded,
             op.pc,
         )?;
-        // A `None` leaves the call recorded symbolically WITHOUT running
+        // A decline leaves the call recorded symbolically WITHOUT running
         // it — a side effect only the legacy replay applies, so the
         // walk-end no-replay commit must stay off for this trace (see
-        // `FBW_UNJOURNALED_EFFECT`).  Pure/elidable calls never reach
+        // `fbw_has_unjournaled_effect`).  Pure/elidable calls never reach
         // this dispatcher (they fold via the pure-call executor).
-        if resid_exec.is_none() {
-            fbw_abort_nested_unjournaled_residual(ctx, op.pc)?;
-            fbw_mark_unjournaled_effect();
-        }
-        let resid_raised = matches!(resid_exec, Some(Err(_)));
+        let resid_raised = match resid_exec {
+            ResidualExecOutcome::Executed(result) => result.is_err(),
+            ResidualExecOutcome::Declined(cause) => {
+                fbw_abort_nested_unjournaled_residual(ctx, op.pc)?;
+                fbw_mark_unjournaled_effect(cause);
+                false
+            }
+        };
         debug_assert!(
             !resid_raised || can_raise,
             "dispatch_residual_call_iRd_kind: helper raised on a \
@@ -19866,16 +19932,19 @@ fn dispatch_residual_call_iIRd_kind(
             recorded,
             op.pc,
         )?;
-        // A `None` leaves the call recorded symbolically WITHOUT running
+        // A decline leaves the call recorded symbolically WITHOUT running
         // it — a side effect only the legacy replay applies, so the
         // walk-end no-replay commit must stay off for this trace (see
-        // `FBW_UNJOURNALED_EFFECT`).  Pure/elidable calls never reach
+        // `fbw_has_unjournaled_effect`).  Pure/elidable calls never reach
         // this dispatcher (they fold via the pure-call executor).
-        if resid_exec.is_none() {
-            fbw_abort_nested_unjournaled_residual(ctx, op.pc)?;
-            fbw_mark_unjournaled_effect();
-        }
-        let resid_raised = matches!(resid_exec, Some(Err(_)));
+        let resid_raised = match resid_exec {
+            ResidualExecOutcome::Executed(result) => result.is_err(),
+            ResidualExecOutcome::Declined(cause) => {
+                fbw_abort_nested_unjournaled_residual(ctx, op.pc)?;
+                fbw_mark_unjournaled_effect(cause);
+                false
+            }
+        };
         debug_assert!(
             !resid_raised || can_raise,
             "dispatch_residual_call_iIRd_kind: helper raised on a \
@@ -20063,16 +20132,19 @@ fn dispatch_residual_call_iIRFd_kind(
             recorded,
             op.pc,
         )?;
-        // A `None` leaves the call recorded symbolically WITHOUT running
+        // A decline leaves the call recorded symbolically WITHOUT running
         // it — a side effect only the legacy replay applies, so the
         // walk-end no-replay commit must stay off for this trace (see
-        // `FBW_UNJOURNALED_EFFECT`).  Pure/elidable calls never reach
+        // `fbw_has_unjournaled_effect`).  Pure/elidable calls never reach
         // this dispatcher (they fold via the pure-call executor).
-        if resid_exec.is_none() {
-            fbw_abort_nested_unjournaled_residual(ctx, op.pc)?;
-            fbw_mark_unjournaled_effect();
-        }
-        let resid_raised = matches!(resid_exec, Some(Err(_)));
+        let resid_raised = match resid_exec {
+            ResidualExecOutcome::Executed(result) => result.is_err(),
+            ResidualExecOutcome::Declined(cause) => {
+                fbw_abort_nested_unjournaled_residual(ctx, op.pc)?;
+                fbw_mark_unjournaled_effect(cause);
+                false
+            }
+        };
         debug_assert!(
             !resid_raised || can_raise,
             "dispatch_residual_call_iIRFd_kind: helper raised on a \
@@ -28460,7 +28532,7 @@ mod tests {
         );
         drop(wc);
         assert!(
-            matches!(result, Ok(Some(Ok(_)))),
+            matches!(result, Ok(ResidualExecOutcome::Executed(Ok(_)))),
             "non-forcing may-force call with active vable must execute normally",
         );
         assert_eq!(

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -6011,6 +6011,13 @@ fn try_execute_residual_call_via_executor(
                             arg_index,
                         });
                     }
+                    if fbw_debug_abort_enabled() {
+                        eprintln!(
+                            "[fbw-resid-decline] NO_CONCRETE op_pc={op_pc} arg_index={arg_index} \
+                             helper={:?} opcode={call_opcode:?}",
+                            call_descr.get_extra_info().pyre_helper
+                        );
+                    }
                     return Ok(ResidualExecOutcome::Declined(
                         ResidualDecline::ValueUnavailable,
                     ));
@@ -6025,6 +6032,13 @@ fn try_execute_residual_call_via_executor(
                         pc: op_pc,
                         arg_index,
                     });
+                }
+                if fbw_debug_abort_enabled() {
+                    eprintln!(
+                        "[fbw-resid-decline] box_value=None op_pc={op_pc} arg_index={arg_index} \
+                         helper={:?} opcode={call_opcode:?}",
+                        call_descr.get_extra_info().pyre_helper
+                    );
                 }
                 return Ok(ResidualExecOutcome::Declined(
                     ResidualDecline::ValueUnavailable,

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -6282,6 +6282,16 @@ fn try_execute_residual_call_via_executor(
     // builtin FOR_ITER stays modeled.
     let foriter_frame_snapshot = (helper == majit_ir::PyreHelperKind::ForIterNext)
         .then(pyre_interpreter::call::frame_entry_count);
+    // #493: a NEW consume attempt for a FOR_ITER whose prior item is still in
+    // flight means that item's body ran to completion — mark the entry BEFORE
+    // the call so an attempt that aborts mid-way (a kept-stack guard on the
+    // exhaustion arm) still records the completion; a successful attempt
+    // replaces the entry with a fresh one anyway.
+    if helper == majit_ir::PyreHelperKind::ForIterNext {
+        let body_pc = fbw_foriter_body_pc_from_op_pc(ctx.fbw_mode.snapshot_sym, op_pc)
+            .unwrap_or(ctx.entry_py_pc as usize + 1);
+        fbw_foriter_inflight_mark_attempt(body_pc);
+    }
     // gh#467: sample the user-frame odometer UNCONDITIONALLY (not only under an
     // in-flight FOR_ITER) so the concrete-heap-write gate can detect a callee
     // sub-walk mutation committed through a value-returning dunder body — the
@@ -7758,6 +7768,12 @@ struct InflightForiter {
     item: pyre_object::PyObjectRef,
     body_pc: usize,
     body_effect_since_consume: bool,
+    /// The walk re-reached this FOR_ITER's consume after the item's body ran
+    /// (a NEW `for_iter_next` attempt was dispatched for the same `body_pc`).
+    /// A completed entry must never be re-delivered — its body already ran
+    /// during the walk — but a flush may still adopt the walk end state at
+    /// the header WITHOUT delivery (the interpreter re-attempts the consume).
+    body_completed: bool,
 }
 
 thread_local! {
@@ -8076,6 +8092,7 @@ pub(crate) fn fbw_foriter_inflight_capture(item: pyre_object::PyObjectRef, body_
             item,
             body_pc,
             body_effect_since_consume: false,
+            body_completed: false,
         };
         match stack.iter().position(|e| e.body_pc == body_pc) {
             Some(at) => {
@@ -8093,6 +8110,21 @@ pub(crate) fn fbw_foriter_inflight_capture(item: pyre_object::PyObjectRef, body_
 /// counts as a body effect committed after the consume (Finding #1).
 pub(crate) fn fbw_foriter_inflight_active() -> bool {
     FBW_FORITER_INFLIGHT.with(|c| !c.borrow().is_empty())
+}
+
+/// Mark the in-flight entry for `body_pc` body-completed: a NEW
+/// `for_iter_next` attempt is being dispatched for the same FOR_ITER, so the
+/// prior consumed item's body has run to completion (the walk is back at the
+/// header).  Called from the residual dispatch BEFORE the call executes so an
+/// attempt that aborts mid-way (a kept-stack guard on the exhaustion arm)
+/// still leaves the completion recorded; a successful attempt replaces the
+/// entry with a fresh one anyway ([`fbw_foriter_inflight_capture`]).
+pub(crate) fn fbw_foriter_inflight_mark_attempt(body_pc: usize) {
+    FBW_FORITER_INFLIGHT.with(|c| {
+        if let Some(entry) = c.borrow_mut().iter_mut().find(|e| e.body_pc == body_pc) {
+            entry.body_completed = true;
+        }
+    });
 }
 
 /// Flag that a non-elidable concrete residual committed an irreversible heap
@@ -8131,24 +8163,7 @@ pub fn fbw_foriter_inflight_take_for_resume(
     resume_py_pc: usize,
 ) -> Option<(pyre_object::PyObjectRef, usize)> {
     let body_pc = resume_py_pc + 1;
-    // The opcode at `resume_py_pc` must be a FOR_ITER (decoded from the live
-    // frame's code) — a non-FOR_ITER resume pc that merely happens to satisfy
-    // `body_pc == some entry.body_pc` is Shape B.
-    let frame_ptr = frame as *const u8;
-    let w_code =
-        unsafe { *(frame_ptr.add(crate::frame_layout::PYFRAME_PYCODE_OFFSET) as *const *const ()) };
-    if w_code.is_null() {
-        return None;
-    }
-    let raw_code = unsafe {
-        pyre_interpreter::w_code_get_ptr(w_code as pyre_object::PyObjectRef)
-            as *const pyre_interpreter::CodeObject
-    };
-    let is_foriter_header = matches!(
-        pyre_interpreter::decode_instruction_at(unsafe { &*raw_code }, resume_py_pc),
-        Some((pyre_interpreter::Instruction::ForIter { .. }, _))
-    );
-    if !is_foriter_header {
+    if !foriter_header_at(frame, resume_py_pc) {
         return None;
     }
     FBW_FORITER_INFLIGHT.with(|c| {
@@ -8156,10 +8171,14 @@ pub fn fbw_foriter_inflight_take_for_resume(
         let at = stack.iter().position(|e| e.body_pc == body_pc)?;
         // R1 never-double guard (cross-checks #33): an irreversible body effect
         // committed since this consume means re-running the body on delivery
-        // would double it — refuse delivery.  Also refuse if either journal is
-        // non-empty or an unjournaled effect stands (same signals as
-        // `fbw_foriter_inflight_take`).
+        // would double it — refuse delivery.  A body-COMPLETED entry (the walk
+        // re-reached the consume, so this item's body already ran) must never
+        // be delivered either — that is the header-flush-without-delivery
+        // shape ([`fbw_foriter_inflight_completed_at_resume`]).  Also refuse if
+        // either journal is non-empty or an unjournaled effect stands (same
+        // signals as `fbw_foriter_inflight_take`).
         if stack[at].body_effect_since_consume
+            || stack[at].body_completed
             || fbw_store_journal_len() != 0
             || FBW_APPEND_JOURNAL.with(|j| j.borrow().len()) != 0
             || fbw_has_unjournaled_effect()
@@ -8167,6 +8186,54 @@ pub fn fbw_foriter_inflight_take_for_resume(
             return None;
         }
         Some((stack[at].item, stack[at].body_pc))
+    })
+}
+
+/// Whether the opcode at `resume_py_pc` in the live frame's code is a
+/// FOR_ITER — a non-FOR_ITER resume pc that merely happens to satisfy
+/// `body_pc == some entry.body_pc` is Shape B.
+fn foriter_header_at(frame: usize, resume_py_pc: usize) -> bool {
+    let frame_ptr = frame as *const u8;
+    let w_code =
+        unsafe { *(frame_ptr.add(crate::frame_layout::PYFRAME_PYCODE_OFFSET) as *const *const ()) };
+    if w_code.is_null() {
+        return false;
+    }
+    let raw_code = unsafe {
+        pyre_interpreter::w_code_get_ptr(w_code as pyre_object::PyObjectRef)
+            as *const pyre_interpreter::CodeObject
+    };
+    matches!(
+        pyre_interpreter::decode_instruction_at(unsafe { &*raw_code }, resume_py_pc),
+        Some((pyre_interpreter::Instruction::ForIter { .. }, _))
+    )
+}
+
+/// #493 selector for the header-flush-without-delivery shape: `resume_py_pc`
+/// is a FOR_ITER header whose in-flight entry is body-COMPLETED — the abort
+/// fired during the NEXT consume attempt (a kept-stack guard on the FOR_ITER
+/// arms after the `for_iter_next` residual), so the consumed item's body
+/// already ran during the walk.  The walk end state at the header is then the
+/// complete post-body state: the flush adopts it WITHOUT delivering the item
+/// and the interpreter re-attempts the consume against the advanced iterator.
+/// Refuses when an effect committed since the consume (re-attempting the
+/// consume could re-apply the failed attempt's effect) — same signals as the
+/// delivery selector above.
+pub fn fbw_foriter_inflight_completed_at_resume(frame: usize, resume_py_pc: usize) -> bool {
+    let body_pc = resume_py_pc + 1;
+    if !foriter_header_at(frame, resume_py_pc) {
+        return false;
+    }
+    FBW_FORITER_INFLIGHT.with(|c| {
+        let stack = c.borrow();
+        let Some(at) = stack.iter().position(|e| e.body_pc == body_pc) else {
+            return false;
+        };
+        stack[at].body_completed
+            && !stack[at].body_effect_since_consume
+            && fbw_store_journal_len() == 0
+            && FBW_APPEND_JOURNAL.with(|j| j.borrow().len()) == 0
+            && !fbw_has_unjournaled_effect()
     })
 }
 
@@ -21391,6 +21458,10 @@ fn handle(
                             kept_stack_any_leg,
                         );
                     }
+                    // Stamp the abort coordinate at the raise point so the
+                    // walk-end branch-flush gate cannot flush the outer frame
+                    // from a callee-coordinate abort.
+                    ctx.session.borrow_mut().abort_in_subwalk = ctx.fbw_mode.inline_subwalk;
                     return Err(DispatchError::BranchGuardKeptStackUnsupported { pc: op.pc });
                 }
                 ctx.trace_ctx.record_guard(opcode, &[valuebox], 0);

--- a/pyre/pyre-jit-trace/src/liveness.rs
+++ b/pyre/pyre-jit-trace/src/liveness.rs
@@ -126,6 +126,7 @@ impl LiveVars {
                         Some(next + delta.get(op_arg).as_usize())
                     }
                     Instruction::ForIter { delta } => Some(next + delta.get(op_arg).as_usize()),
+                    Instruction::Send { delta } => Some(next + delta.get(op_arg).as_usize()),
                     _ => None,
                 };
                 if let Some(tgt) = target {
@@ -561,6 +562,12 @@ fn stack_effects(
         | Instruction::Cache
         | Instruction::NotTaken
         | Instruction::ExtendedArg => (d, d),
+        // SetupAnnotations/setup_annotations touches only the namespace: pop 0, push 0.
+        Instruction::SetupAnnotations => (d, d),
+        // MakeCell/make_cell replaces a localsplus slot: pop 0, push 0.
+        Instruction::MakeCell { .. } => (d, d),
+        // ExitInitCheck is a pyopcode.rs dispatch no-op in pyre: pop 0, push 0.
+        Instruction::ExitInitCheck => (d, d),
         // Push one
         Instruction::LoadConst { .. }
         | Instruction::LoadSmallInt { .. }
@@ -575,6 +582,12 @@ fn stack_effects(
         | Instruction::PushNull
         | Instruction::Copy { .. }
         | Instruction::PushExcInfo => (d + 1, d + 1),
+        // LoadCommonConstant/load_common_constant pops 0 and pushes the resolved constant.
+        Instruction::LoadCommonConstant { .. } => (d + 1, d + 1),
+        // ReturnGenerator/return_generator pops 0 and pushes the following POP_TOP placeholder.
+        Instruction::ReturnGenerator => (d + 1, d + 1),
+        // GetAnext's async-stub shape pops 1 and pushes 2, for net +1.
+        Instruction::GetAnext => (d + 1, d + 1),
         // LOAD_GLOBAL pushes 1 or 2 values depending on the low bit of namei.
         // When namei & 1 == 1, a NULL sentinel is pushed before the result (+2).
         // When namei & 1 == 0, only the result is pushed (+1).
@@ -607,6 +620,8 @@ fn stack_effects(
         | Instruction::PopIter => (d - 1, d - 1),
         // YieldValue: sends TOS to caller, receives new value back. Net 0.
         Instruction::YieldValue { .. } => (d, d),
+        // Send/send_value pops the sent value and pushes either next() or StopIteration.value.
+        Instruction::Send { .. } => (d, d),
         // PopExcept: codewriter pops the saved previous exception object
         // from the value stack and restores TLS from it. Net -1.
         Instruction::PopExcept => (d - 1, d - 1),
@@ -636,6 +651,18 @@ fn stack_effects(
         | Instruction::GetYieldFromIter
         | Instruction::GetAiter
         | Instruction::GetAwaitable { .. } => (d, d),
+        // ConvertValue/convert_value pops the input and pushes the converted value.
+        Instruction::ConvertValue { .. } => (d, d),
+        // FormatSimple/format_simple pops the value and pushes its formatted string.
+        Instruction::FormatSimple => (d, d),
+        // ToBool/to_bool pops the value and pushes its bool result.
+        Instruction::ToBool => (d, d),
+        // LoadFromDictOrGlobals/load_from_dict_or_globals pops the mapping and pushes the result.
+        Instruction::LoadFromDictOrGlobals { .. } => (d, d),
+        // LoadFromDictOrDeref/load_from_dict_or_deref pops the mapping and pushes the result.
+        Instruction::LoadFromDictOrDeref { .. } => (d, d),
+        // MakeFunction/opcode_make_function pops the code object and pushes the function.
+        Instruction::MakeFunction => (d, d),
         // LOAD_ATTR pushes 1 (attr) for the plain form, or 2 (attr,
         // self_or_null) for the method form — mirror of `execute_load_attr`
         // `attr.is_method()` → `load_method` (which pushes `[attr, NULL]`).
@@ -712,6 +739,8 @@ fn stack_effects(
         // through END_FOR until the following POP_ITER pops it, so the
         // branch-target depth still counts the iterator slot.
         Instruction::ForIter { .. } => (d + 1, d),
+        // WithExceptStart/with_except_start preserves five inputs and pushes the exit result.
+        Instruction::WithExceptStart => (d + 1, d + 1),
         // Return
         Instruction::ReturnValue => (d - 1, d - 1),
         // Build collections: pop count, push 1
@@ -735,16 +764,57 @@ fn stack_effects(
             let s = count.get(op_arg) as usize as i32;
             (d - s + 1, d - s + 1)
         }
+        // BuildTemplate/build_template_op pops strings+interpolations and pushes the template.
+        Instruction::BuildTemplate => (d - 1, d - 1),
+        // BuildInterpolation/build_interpolation_op pops value+expression(+spec) and pushes one.
+        Instruction::BuildInterpolation { format } => {
+            if u32::from(format.get(op_arg)) & 1 != 0 {
+                (d - 2, d - 2)
+            } else {
+                (d - 1, d - 1)
+            }
+        }
+        // BuildSlice/build_slice pops two or three components and pushes one slice.
+        Instruction::BuildSlice { argc } => {
+            use pyre_interpreter::bytecode::BuildSliceArgCount;
+            match argc.get(op_arg) {
+                BuildSliceArgCount::Two => (d - 1, d - 1),
+                BuildSliceArgCount::Three => (d - 2, d - 2),
+            }
+        }
         // CALL: pop callable + args, push result
         Instruction::Call { argc } => {
             let n = argc.get(op_arg) as usize as i32;
             (d - n - 1, d - n - 1)
         }
+        // CallFunctionEx/call_function_ex pops four call operands and pushes one result.
+        Instruction::CallFunctionEx => (d - 3, d - 3),
+        // CallKw/call_kw pops argc+3 call operands and pushes one result.
+        Instruction::CallKw { argc } => {
+            let n = argc.get(op_arg) as usize as i32;
+            (d - n - 2, d - n - 2)
+        }
+        // CallIntrinsic1/call_intrinsic_1 replaces one operand with one result.
+        Instruction::CallIntrinsic1 { .. } => (d, d),
+        // CallIntrinsic2/call_intrinsic_2 consumes one net slot for every intrinsic variant.
+        Instruction::CallIntrinsic2 { .. } => (d - 1, d - 1),
         // Unpack
         Instruction::UnpackSequence { count } => {
             let s = count.get(op_arg) as usize as i32;
             (d - 1 + s, d - 1 + s)
         }
+        // UnpackEx/unpack_ex pops one and pushes before+starred+after values.
+        Instruction::UnpackEx { counts } => {
+            let args = counts.get(op_arg);
+            let s = args.before as i32 + 1 + args.after as i32;
+            (d - 1 + s, d - 1 + s)
+        }
+        // FormatWithSpec/format_with_spec pops value+spec and pushes one string.
+        Instruction::FormatWithSpec => (d - 1, d - 1),
+        // EndAsyncFor's async-stub shape pops iterator+exception and pushes nothing.
+        Instruction::EndAsyncFor => (d - 2, d - 2),
+        // CleanupThrow's async-stub shape pops three exception items and pushes one result.
+        Instruction::CleanupThrow => (d - 2, d - 2),
         // MATCH_CLASS: pops subject, type, names (−3) and pushes the attrs
         // tuple or None (+1). Net −2.
         Instruction::MatchClass { .. } => (d - 2, d - 2),
@@ -797,6 +867,7 @@ fn target_pc(
         | Instruction::PopJumpIfNone { delta }
         | Instruction::PopJumpIfNotNone { delta } => Some(next + delta.get(op_arg).as_usize()),
         Instruction::ForIter { delta } => Some(next + delta.get(op_arg).as_usize()),
+        Instruction::Send { delta } => Some(next + delta.get(op_arg).as_usize()),
         _ => None,
     }
 }

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -8070,7 +8070,7 @@ impl JitState for PyreJitState {
         fail_values: &[i64],
         fail_types: &[Type],
     ) {
-        let bridge_stamp_enabled = std::env::var_os("PYRE_FBW_BRIDGE_STAMP").is_some();
+        let bridge_stamp_enabled = std::env::var("PYRE_FBW_BRIDGE_STAMP").as_deref() != Ok("0");
         if resume_data.frames.is_empty() {
             return;
         }

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -8070,6 +8070,7 @@ impl JitState for PyreJitState {
         fail_values: &[i64],
         fail_types: &[Type],
     ) {
+        let bridge_stamp_enabled = std::env::var_os("PYRE_FBW_BRIDGE_STAMP").is_some();
         if resume_data.frames.is_empty() {
             return;
         }
@@ -8257,6 +8258,8 @@ impl JitState for PyreJitState {
         // direction.  Defer seeding to the post-overlay stage where the
         // mirror is slot-indexed and values are authoritative.
         let seed_deferred_to_overlay = frame0.jitcode_pc != majit_ir::resumedata::NO_JITCODE_PC;
+        let mut bridge_stamp_orphans =
+            (bridge_stamp_enabled && seed_deferred_to_overlay).then(Vec::new);
         let mut value_cursor = 0usize;
         for &reg_idx in &reg_indices.int {
             let value = &frame0.values[value_cursor];
@@ -8305,6 +8308,9 @@ impl JitState for PyreJitState {
                 && !matches!(concrete_val, majit_ir::Value::Void)
             {
                 ctx.try_set_opref_concrete(resolved, concrete_val);
+            }
+            if let Some(orphan_stamps) = bridge_stamp_orphans.as_mut() {
+                orphan_stamps.push((resolved, concrete_val));
             }
             let reg_idx = reg_idx as usize;
             if reg_idx >= bridge_registers_r.len() {
@@ -8621,6 +8627,21 @@ impl JitState for PyreJitState {
                             ctx.try_set_opref_concrete(*opref, cv);
                         }
                     }
+                }
+            }
+        }
+        // Orphaned colors have decoded values but no semantic-mirror slot to
+        // re-stamp; seed them so bridge-walk residuals can resolve arguments.
+        if let Some(orphan_stamps) = bridge_stamp_orphans.as_ref() {
+            for (opref, cv) in orphan_stamps {
+                if opref.is_none() || semantic_mirror.contains(opref) {
+                    continue;
+                }
+                if !matches!(
+                    cv,
+                    majit_ir::Value::Void | majit_ir::Value::Ref(majit_ir::GcRef(0))
+                ) {
+                    ctx.try_set_opref_concrete(*opref, *cv);
                 }
             }
         }

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -2189,10 +2189,28 @@ fn run_perfn_walk(
             outcome_kind,
         );
     }
-    if WALK_END_FLUSH_COMMITTED.with(|c| c.get()) || terminate_no_replay {
+    let committed = WALK_END_FLUSH_COMMITTED.with(|c| c.get()) || terminate_no_replay;
+    let journal = crate::jitcode_dispatch::fbw_store_journal_len();
+    if committed {
         crate::jitcode_dispatch::fbw_store_journal_commit();
     } else {
         crate::jitcode_dispatch::fbw_store_journal_rollback();
+    }
+    if authoritative && std::env::var_os("PYRE_FBW_CENSUS").is_some() {
+        let mut end = match &walk_result {
+            Ok((outcome, _)) => format!("{outcome:?}"),
+            Err(error) => format!("{error:?}"),
+        };
+        if let Some(at) = end.find(|c: char| matches!(c, '(' | '{' | ' ')) {
+            end.truncate(at);
+        }
+        let (unj_val, unj_sym) = crate::jitcode_dispatch::fbw_unjournaled_kinds();
+        let (exec_v, exec_mf, exec_pl) = crate::jitcode_dispatch::fbw_executed_residual_counts();
+        eprintln!(
+            "[fbw-census] end={end} committed={committed} bridge={} unj_val={unj_val} \
+             unj_sym={unj_sym} exec_v={exec_v} exec_mf={exec_mf} exec_pl={exec_pl} journal={journal}",
+            ctx.is_bridge_trace,
+        );
     }
 
     Some((entry, code_len, walk_result))

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -2037,26 +2037,35 @@ fn run_perfn_walk(
         }
 
         // #32 S2: a kept-stack branch guard whose not-taken arm cannot be
-        // restored for the COMPILED trace aborts (`AbortPermanent`), but the
-        // authoritative walk's symbolic shadow IS complete at the abort pc (the
-        // hazard is about the JIT resume snapshot, not the interpreter-side
-        // shadow).  Flush that end state to the live frame so the interpreter
-        // resumes at the abort pc with the walked iterations already counted,
-        // instead of discarding the walk and dropping an in-flight FOR_ITER
-        // item via the conservative #30 header-guard drop.  Same
+        // restored for the COMPILED trace aborts (`AbortPermanent` for the
+        // unrestorable-Ref shape, decline + `Abort` for the depth>1
+        // invalid-mirror shape), but the authoritative walk's symbolic shadow
+        // IS complete at the abort pc (the hazard is about the JIT resume
+        // snapshot, not the interpreter-side shadow).  Flush that end state to
+        // the live frame so the interpreter resumes at the abort pc with the
+        // walked iterations already counted, instead of discarding the walk
+        // and dropping an in-flight FOR_ITER item via the conservative #30
+        // header-guard drop (or, for the `Unsupported` shape, re-executing the
+        // walk's residual effects from loop entry).  Same
         // no-unjournaled-effect / no-sub-walk predicate and same all-or-nothing
         // `flush_walk_end_state_to_frame` gate as the CloseLoop / marker legs;
         // when the flush declines (a slot the shadow cannot resolve) the legacy
         // drop stands (the residual S3 case).  `PYRE_FBW_BRANCH_FLUSH=0` opts
         // out.
         if std::env::var_os("PYRE_FBW_BRANCH_FLUSH").as_deref() != Some(std::ffi::OsStr::new("0")) {
-            if let Err(
-                crate::jitcode_dispatch::DispatchError::BranchGuardUnrestorableKeptStackPermanent {
+            let kept_stack_abort_pc = match &walk_result {
+                Err(
+                    crate::jitcode_dispatch::DispatchError::BranchGuardUnrestorableKeptStackPermanent {
+                        pc,
+                    },
+                ) => Some((*pc, false)),
+                Err(crate::jitcode_dispatch::DispatchError::BranchGuardKeptStackUnsupported {
                     pc,
-                },
-            ) = &walk_result
-            {
-                let abort_jit_pc = *pc;
+                }) => Some((*pc, true)),
+                _ => None,
+            };
+            if let Some((pc, is_unsupported)) = kept_stack_abort_pc {
+                let abort_jit_pc = pc;
                 if crate::jitcode_dispatch::fbw_has_unjournaled_effect()
                     || session.borrow().abort_in_subwalk
                 {
@@ -2090,7 +2099,24 @@ fn run_perfn_walk(
                     // and re-run the loop) keeps the legacy drop byte-identically
                     // (the residual S3 case).  So every other abort shape is
                     // untouched, including the entire flag-OFF path.
-                    let committed = push.is_some()
+                    // Shape A' (#493, `Unsupported` variant only) — the abort
+                    // resumes AT a FOR_ITER header whose in-flight entry is
+                    // body-COMPLETED: the abort fired during the NEXT consume
+                    // attempt (a kept-stack guard on the FOR_ITER arms after
+                    // the `for_iter_next` residual), so the item's body already
+                    // ran and delivery would double it.  The walk end state at
+                    // the header is the complete post-body state — adopt it
+                    // WITHOUT delivery; the interpreter re-attempts the consume
+                    // against the advanced iterator.  Replaces the legacy
+                    // replay-from-entry, which re-executes every residual the
+                    // walk already ran.
+                    let flush_completed_header = push.is_none()
+                        && is_unsupported
+                        && crate::jitcode_dispatch::fbw_foriter_inflight_completed_at_resume(
+                            cf_addr,
+                            resume_py_pc,
+                        );
+                    let committed = (push.is_some() || flush_completed_header)
                         && crate::state::flush_walk_end_state_to_frame_with_item(
                             ctx,
                             cf_addr,

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -2138,11 +2138,12 @@ fn run_perfn_walk(
     // rather than rewinding the live frame to the guard pc and re-running the
     // region through the `ContinueRunningNormally` re-entry — which would
     // execute every residual a second time and double-apply any
-    // callee-internal side effect (#177).  The tracer only arms it for a
-    // single-frame resume on the general guard path (never the
-    // CALL_ASSEMBLER callback, which cannot consume a concrete result), so a
-    // committed journal never strands into a blackhole re-run; the three
-    // decisions (this predicate, the journal commit below, and the caller's
+    // callee-internal side effect (#177).  The tracer arms it for any
+    // single-frame resume: the general guard path consumes the kept stash as
+    // a terminal `BridgeResolution`, and the CALL_ASSEMBLER callback hands it
+    // to its back-to-back blackhole hook, so a committed journal never
+    // strands into a guard-state re-run; the three decisions (this
+    // predicate, the journal commit below, and the caller's
     // consume-vs-rewind) stay in agreement.  A multiframe resume is never
     // armed, so it stays on the legacy rewind-and-replay path.
     let terminate_no_replay = crate::jitcode_dispatch::fbw_no_replay_exit_enabled()

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -57,6 +57,14 @@ thread_local! {
     /// FFI boundaries (compiled code → callback → exception).
     static LAST_CA_EXCEPTION: std::cell::RefCell<Option<pyre_interpreter::error::PyError>> =
         const { std::cell::RefCell::new(None) };
+    /// Callee PyFrame address whose CALL_ASSEMBLER bridge walk committed
+    /// and adopted its end-of-walk state (raise_continue_running_normally
+    /// analogue). The CA slow path calls the bridge hook and then the
+    /// blackhole hook back-to-back; the blackhole consumes this to
+    /// complete the callee from the adopted state instead of re-running
+    /// the guard-state resume over already-applied effects.
+    static CA_WALK_ADOPTED_FRAME: std::cell::Cell<usize> =
+        const { std::cell::Cell::new(0) };
     static SELF_RECURSIVE_DISPATCH_CACHE: UnsafeCell<Option<(u64, Option<u64>)>> =
         const { UnsafeCell::new(None) };
 }
@@ -1319,6 +1327,8 @@ fn jit_blackhole_resume_from_guard(
     num_raw_deadframe: usize,
     guard_exc: i64,
 ) -> Option<i64> {
+    let ca_adopted_frame = CA_WALK_ADOPTED_FRAME.with(|c| c.replace(0));
+
     // rstack.stack_check_slowpath → _StackOverflow parity: drain the
     // pending JIT-prologue overflow exception when the backend probe
     // tripped. The blackhole resume path is one of the three
@@ -1338,6 +1348,32 @@ fn jit_blackhole_resume_from_guard(
         return None;
     }
     let fail_values = unsafe { std::slice::from_raw_parts(fail_values_ptr, num_fail_values) };
+
+    // raise_continue_running_normally parity (pyjitpl.py:3048-3091 +
+    // warmspot.py:970-983): the CA bridge walk committed its end-of-walk
+    // state into the live callee frame and the frame adopted it. The walk
+    // already executed the resumed region's effects concretely, so the
+    // guard-state blackhole below would re-apply them over the advanced
+    // heap (double-execution / stale-value return). Complete the callee
+    // from its adopted state via the portal runner instead — the same
+    // portal_ptr(*args) completion the ContinueRunningNormally arm of
+    // handle_blackhole_result performs.
+    if ca_adopted_frame != 0 && ca_adopted_frame == fail_values[0] as usize {
+        let frame = unsafe { &mut *(ca_adopted_frame as *mut PyFrame) };
+        return match crate::eval::portal_runner_result(frame) {
+            Ok(result) => Some(result as i64),
+            Err(err) => {
+                let exc_obj = err.exc_object;
+                if exc_obj != pyre_object::PY_NULL {
+                    majit_metainterp::blackhole::BH_LAST_EXC_VALUE
+                        .with(|c| c.set(exc_obj as i64));
+                    store_jit_exception(exc_obj as i64);
+                }
+                Some(0)
+            }
+        };
+    }
+
     let raw_deadframe = if !raw_deadframe_ptr.is_null() && num_raw_deadframe > 0 {
         unsafe { std::slice::from_raw_parts(raw_deadframe_ptr, num_raw_deadframe) }
     } else {
@@ -2475,6 +2511,9 @@ pub fn trace_and_compile_from_bridge(
                 if pyre_jit_trace::trace::take_walk_end_flush_committed() {
                     frame.restore_resume_state_from(&executed);
                     adopted_walk_end_state = true;
+                    if !allow_finish_direct_return {
+                        CA_WALK_ADOPTED_FRAME.with(|c| c.set(live_frame_addr));
+                    }
                 }
                 action
             },

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -65,6 +65,17 @@ thread_local! {
     /// the guard-state resume over already-applied effects.
     static CA_WALK_ADOPTED_FRAME: std::cell::Cell<usize> =
         const { std::cell::Cell::new(0) };
+    /// Callee PyFrame address whose CALL_ASSEMBLER bridge walk terminated
+    /// with a kept finish-concrete stash (the walked callee ran to its
+    /// return/uncaught raise concretely).  The CA bridge hook returns a
+    /// bare bool and cannot carry the concrete result itself, so it sets
+    /// this handshake and the back-to-back blackhole hook consumes the
+    /// stash to complete the callee — the retrace-reaches-finishframe
+    /// `DoneWithThisFrame`/`ExitFrameWithExceptionRef` the assembler
+    /// caller catches (pyjitpl.py:1688-1698, jitexc.py) — instead of
+    /// re-running the resumed region over already-applied effects.
+    static CA_WALK_FINISHED_FRAME: std::cell::Cell<usize> =
+        const { std::cell::Cell::new(0) };
     static SELF_RECURSIVE_DISPATCH_CACHE: UnsafeCell<Option<(u64, Option<u64>)>> =
         const { UnsafeCell::new(None) };
 }
@@ -1328,6 +1339,7 @@ fn jit_blackhole_resume_from_guard(
     guard_exc: i64,
 ) -> Option<i64> {
     let ca_adopted_frame = CA_WALK_ADOPTED_FRAME.with(|c| c.replace(0));
+    let ca_finished_frame = CA_WALK_FINISHED_FRAME.with(|c| c.replace(0));
 
     // rstack.stack_check_slowpath → _StackOverflow parity: drain the
     // pending JIT-prologue overflow exception when the backend probe
@@ -1341,13 +1353,51 @@ fn jit_blackhole_resume_from_guard(
         // Stash for the eval loop to surface — same channel the
         // blackhole/force callbacks already use for cross-FFI errors.
         crate::call_jit::set_pending_ca_exception(exc);
+        pyre_jit_trace::jitcode_dispatch::fbw_finish_concrete_reset();
         return None;
     }
 
     if fail_values_ptr.is_null() || num_fail_values == 0 {
+        pyre_jit_trace::jitcode_dispatch::fbw_finish_concrete_reset();
         return None;
     }
     let fail_values = unsafe { std::slice::from_raw_parts(fail_values_ptr, num_fail_values) };
+
+    // The CA bridge walk ran the callee to its finishframe concretely and
+    // kept the finish-concrete stash (`CA_WALK_FINISHED_FRAME` handshake set
+    // by `trace_and_compile_from_bridge`); the guard-state blackhole below
+    // would re-run the resumed region over the already-applied effects.
+    // Complete the callee with the stashed concrete instead — the
+    // `DoneWithThisFrame` / `ExitFrameWithExceptionRef` the assembler caller
+    // catches when a retrace reaches finishframe (pyjitpl.py:1688-1698,
+    // jitexc.py).
+    if ca_finished_frame != 0 && ca_finished_frame == fail_values[0] as usize {
+        match pyre_jit_trace::jitcode_dispatch::fbw_finish_concrete_take() {
+            Some(pyre_jit_trace::jitcode_dispatch::FinishConcrete::Return(cv)) => {
+                let result = match cv {
+                    // A void return stashes `Null`, i.e. Python `None`.
+                    pyre_jit_trace::state::ConcreteValue::Null => pyre_object::w_none(),
+                    other => other.to_pyobj(),
+                };
+                return Some(result as i64);
+            }
+            Some(pyre_jit_trace::jitcode_dispatch::FinishConcrete::Raise(cv)) => {
+                let pyre_jit_trace::state::ConcreteValue::Ref(exc_ref) = cv else {
+                    unreachable!("FinishConcrete::Raise must hold a concrete Ref")
+                };
+                debug_assert!(!exc_ref.is_null());
+                publish_residual_call_exception(exc_ref as i64);
+                return Some(0);
+            }
+            // The epilogue reset the stash between the hook calls; fall
+            // through to the guard-state blackhole.
+            None => {}
+        }
+    } else {
+        // A kept stash without a matching frame must not leak into a later
+        // top-level portal `fbw_finish_concrete_take`.
+        pyre_jit_trace::jitcode_dispatch::fbw_finish_concrete_reset();
+    }
 
     // raise_continue_running_normally parity (pyjitpl.py:3048-3091 +
     // warmspot.py:970-983): the CA bridge walk committed its end-of-walk
@@ -2476,14 +2526,17 @@ pub fn trace_and_compile_from_bridge(
     let trace_frame = frame.snapshot_for_tracing();
     let live_frame_addr = frame as *const PyFrame as usize;
     let mut adopted_walk_end_state = false;
-    // Arm the bridge `Terminate` no-replay shortcut for this walk only when
-    // the caller can consume a concrete result and the resume is single-frame.
-    // The walk epilogue (`run_perfn_walk` in trace.rs) reads this flag: only
-    // when armed does a bridge `Terminate` walk keep its finish-concrete stash
-    // + commit the store journal, so the three decisions (epilogue predicate,
-    // journal commit, the consume-vs-rewind below) stay in agreement and a
-    // committed journal never strands into a blackhole re-run.
-    let bridge_noreplay_armed = allow_finish_direct_return && !is_multiframe_resume;
+    // Arm the bridge `Terminate` no-replay shortcut for this walk whenever
+    // the resume is single-frame.  The walk epilogue (`run_perfn_walk` in
+    // trace.rs) reads this flag: only when armed does a bridge `Terminate`
+    // walk keep its finish-concrete stash + commit the store journal, so the
+    // three decisions (epilogue predicate, journal commit, the
+    // consume-vs-rewind below) stay in agreement and a committed journal
+    // never strands into a blackhole re-run.  Both callers can consume the
+    // kept stash: the general guard path returns it as a terminal
+    // `BridgeResolution`, and the CALL_ASSEMBLER callback hands it to the
+    // back-to-back blackhole hook via `CA_WALK_FINISHED_FRAME`.
+    let bridge_noreplay_armed = !is_multiframe_resume;
     pyre_jit_trace::jitcode_dispatch::fbw_bridge_noreplay_arm(bridge_noreplay_armed);
     let outcome = {
         let (driver, _) = crate::eval::driver_pair();
@@ -2539,6 +2592,32 @@ pub fn trace_and_compile_from_bridge(
     // `pyjitpl.py:2841` `interpret()` raising `DoneWithThisFrame` from the
     // post-walk state.  Always take (not peek) so a kept stash cannot leak
     // into a later top-level portal `fbw_finish_concrete_take`.
+    //
+    // CALL_ASSEMBLER callback: this caller returns a bare bool and cannot
+    // carry the concrete result itself.  Leave the stash in its GC-rooted
+    // cell, record the callee frame in `CA_WALK_FINISHED_FRAME`, and let the
+    // CA slow path's back-to-back blackhole hook
+    // (`jit_blackhole_resume_from_guard`) take the stash and complete the
+    // callee with it — the finishframe `DoneWithThisFrame` /
+    // `ExitFrameWithExceptionRef` the assembler caller catches
+    // (pyjitpl.py:1688-1698, jitexc.py).
+    if !allow_finish_direct_return {
+        if pyre_jit_trace::jitcode_dispatch::fbw_finish_concrete_peek().is_some() {
+            debug_assert!(
+                !is_multiframe_resume,
+                "bridge Terminate no-replay stash kept for a multiframe resume \
+                 (frames={num_resume_frames})"
+            );
+            CA_WALK_FINISHED_FRAME.with(|c| c.set(live_frame_addr));
+            if majit_metainterp::majit_log_enabled() {
+                eprintln!(
+                    "[jit][bridge-trace] ca-finish-noreplay at resume_pc={} key={}",
+                    resume_pc, green_key
+                );
+            }
+            return BridgeResolution::ResumeBlackhole;
+        }
+    }
     match pyre_jit_trace::jitcode_dispatch::fbw_finish_concrete_take() {
         Some(pyre_jit_trace::jitcode_dispatch::FinishConcrete::Return(cv)) => {
             // `bridge_noreplay_armed` folds in `!is_multiframe_resume`, so a kept
@@ -2776,15 +2855,16 @@ fn jit_ca_handle_guard_failure(
         // blackhole leg, not here; pass 0 so the non-exception-guard
         // deferral keys only off the general guard path's `guard_exc`.
         // `allow_finish_direct_return = false`: this callback returns a bare
-        // bool to native code and has no channel for a concrete result, so
-        // it always takes the legacy rewind/blackhole path (the bridge
-        // `Terminate` no-replay shortcut stays off here).
+        // bool to native code and has no channel for a concrete result; a
+        // walk that terminates with a kept finish-concrete stash hands it to
+        // the back-to-back blackhole hook via `CA_WALK_FINISHED_FRAME`
+        // (returned as `ResumeBlackhole` here).
         match trace_and_compile_from_bridge(&descr_arc, frame, raw_values, &exit_layout, 0, false) {
             BridgeResolution::CompiledContinue => true,
             BridgeResolution::ResumeBlackhole => false,
-            // Unreachable: the shortcut is disarmed for this caller
-            // (`allow_finish_direct_return = false`), so the walk never keeps
-            // a finish-concrete stash and never returns a terminal variant.
+            // Unreachable: for this caller a kept stash takes the
+            // `CA_WALK_FINISHED_FRAME` handshake path, never a terminal
+            // variant.
             BridgeResolution::Finished(_) | BridgeResolution::FinishedException(_) => {
                 debug_assert!(
                     false,

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -2162,6 +2162,10 @@ pub enum BridgeResolution {
     /// post-walk state.  The caller returns this value directly instead of
     /// rewinding the live frame and re-running the region (#177).
     Finished(pyre_jit_trace::state::ConcreteValue),
+    /// The single-frame bridge walk ended in an uncaught raise; hand its
+    /// concrete exception to the guard's portal as
+    /// `ExitFrameWithExceptionRef` (jitexc.py:44).
+    FinishedException(pyre_jit_trace::state::ConcreteValue),
 }
 
 /// Map the legacy bool bridge outcome (`true` = continue in compiled code,
@@ -2535,23 +2539,36 @@ pub fn trace_and_compile_from_bridge(
     // `pyjitpl.py:2841` `interpret()` raising `DoneWithThisFrame` from the
     // post-walk state.  Always take (not peek) so a kept stash cannot leak
     // into a later top-level portal `fbw_finish_concrete_take`.
-    if let Some(cv) = pyre_jit_trace::jitcode_dispatch::fbw_finish_concrete_take() {
-        // `bridge_noreplay_armed` folds in `!is_multiframe_resume`, so a kept
-        // stash implies a single real live PyFrame: the `Terminate` is the
-        // live frame's function return, about to be popped by its caller with
-        // `cv`.  No rewind, no blackhole.
-        debug_assert!(
-            !is_multiframe_resume,
-            "bridge Terminate no-replay stash kept for a multiframe resume \
-             (frames={num_resume_frames})"
-        );
-        if majit_metainterp::majit_log_enabled() {
-            eprintln!(
-                "[jit][bridge-trace] finish-noreplay at resume_pc={} key={}",
-                resume_pc, green_key
+    match pyre_jit_trace::jitcode_dispatch::fbw_finish_concrete_take() {
+        Some(pyre_jit_trace::jitcode_dispatch::FinishConcrete::Return(cv)) => {
+            // `bridge_noreplay_armed` folds in `!is_multiframe_resume`, so a kept
+            // stash implies a single real live PyFrame: the `Terminate` is the
+            // live frame's function return, about to be popped by its caller with
+            // `cv`.  No rewind, no blackhole.
+            debug_assert!(
+                !is_multiframe_resume,
+                "bridge Terminate no-replay stash kept for a multiframe resume \
+                 (frames={num_resume_frames})"
             );
+            if majit_metainterp::majit_log_enabled() {
+                eprintln!(
+                    "[jit][bridge-trace] finish-noreplay at resume_pc={} key={}",
+                    resume_pc, green_key
+                );
+            }
+            return BridgeResolution::Finished(cv);
         }
-        return BridgeResolution::Finished(cv);
+        Some(pyre_jit_trace::jitcode_dispatch::FinishConcrete::Raise(cv)) => {
+            debug_assert!(
+                !is_multiframe_resume,
+                "bridge Terminate no-replay raise kept for a multiframe resume \
+                 (frames={num_resume_frames})"
+            );
+            // jitexc.py:44: hand the walk's uncaught exception to the
+            // guard's portal as ExitFrameWithExceptionRef.
+            return BridgeResolution::FinishedException(cv);
+        }
+        None => {}
     }
     if !adopted_walk_end_state {
         frame.restore_resume_state_from(&resume_state);
@@ -2767,11 +2784,11 @@ fn jit_ca_handle_guard_failure(
             BridgeResolution::ResumeBlackhole => false,
             // Unreachable: the shortcut is disarmed for this caller
             // (`allow_finish_direct_return = false`), so the walk never keeps
-            // a finish-concrete stash and never returns `Finished`.
-            BridgeResolution::Finished(_) => {
+            // a finish-concrete stash and never returns a terminal variant.
+            BridgeResolution::Finished(_) | BridgeResolution::FinishedException(_) => {
                 debug_assert!(
                     false,
-                    "CALL_ASSEMBLER bridge returned Finished despite disarm"
+                    "CALL_ASSEMBLER bridge returned a terminal no-replay result despite disarm"
                 );
                 false
             }

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -1365,8 +1365,7 @@ fn jit_blackhole_resume_from_guard(
             Err(err) => {
                 let exc_obj = err.exc_object;
                 if exc_obj != pyre_object::PY_NULL {
-                    majit_metainterp::blackhole::BH_LAST_EXC_VALUE
-                        .with(|c| c.set(exc_obj as i64));
+                    majit_metainterp::blackhole::BH_LAST_EXC_VALUE.with(|c| c.set(exc_obj as i64));
                     store_jit_exception(exc_obj as i64);
                 }
                 Some(0)

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -14,7 +14,7 @@ use pyre_interpreter::PyExecutionContext;
 use pyre_interpreter::executioncontext::ActionFlagOps;
 use pyre_interpreter::pyframe::PyFrame;
 use pyre_interpreter::{
-    PyResult, StepResult, decode_instruction_for_dispatch, execute_opcode_step,
+    PyError, PyResult, StepResult, decode_instruction_for_dispatch, execute_opcode_step,
 };
 use std::cell::{Cell, UnsafeCell};
 use std::collections::HashMap;
@@ -4728,14 +4728,20 @@ fn jit_merge_point_hook(
             // walk already consumed (a side-effecting residual ran once) and
             // deopt; the compiled trace serves only subsequent invocations.
             // No capture → the legacy ContinueRunningNormally replay.
-            if let Some(cv) = pyre_jit_trace::jitcode_dispatch::fbw_finish_concrete_take() {
-                let result = match cv {
-                    // A void return stashes `Null`, i.e. Python `None`
-                    // (`ConcreteValue::to_pyobj` would map it to PY_NULL).
-                    pyre_jit_trace::state::ConcreteValue::Null => w_none(),
-                    other => other.to_pyobj(),
-                };
-                return Some(LoopResult::Done(Ok(result)));
+            match pyre_jit_trace::jitcode_dispatch::fbw_finish_concrete_take() {
+                Some(pyre_jit_trace::jitcode_dispatch::FinishConcrete::Return(cv)) => {
+                    let result = match cv {
+                        // A void return stashes `Null`, i.e. Python `None`
+                        // (`ConcreteValue::to_pyobj` would map it to PY_NULL).
+                        pyre_jit_trace::state::ConcreteValue::Null => w_none(),
+                        other => other.to_pyobj(),
+                    };
+                    return Some(LoopResult::Done(Ok(result)));
+                }
+                Some(pyre_jit_trace::jitcode_dispatch::FinishConcrete::Raise(cv)) => {
+                    return Some(LoopResult::Done(Err(finish_concrete_raise_error(cv))));
+                }
+                None => {}
             }
             return Some(LoopResult::ContinueRunningNormally);
         }
@@ -4880,11 +4886,21 @@ impl Drop for GuardCompilingScope {
     }
 }
 
-/// compile.py:701-717 handle_fail outcome.
+/// Build the exception result the same way as blackhole.py:1679-1682
+/// `_exit_frame_with_exception`.
+fn finish_concrete_raise_error(value: pyre_jit_trace::state::ConcreteValue) -> PyError {
+    let pyre_jit_trace::state::ConcreteValue::Ref(exc_ref) = value else {
+        unreachable!("FinishConcrete::Raise must hold a concrete Ref")
+    };
+    debug_assert!(!exc_ref.is_null());
+    // blackhole.py:1679-1682 constructs ExitFrameWithExceptionRef directly
+    // from the uncaught exception object and leaves the exception latches as-is.
+    unsafe { PyError::from_exc_object(exc_ref) }
+}
+
 /// compile.py:701-717: handle_fail NEVER returns in RPython — it raises
 /// ContinueRunningNormally or DoneWithThisFrame. In pyre, we return the
 /// equivalent BlackholeResult.
-/// compile.py:701-717 handle_fail outcome.
 enum HandleFailOutcome {
     /// Bridge compiled successfully — continue in compiled code.
     BridgeCompiled,
@@ -4895,6 +4911,9 @@ enum HandleFailOutcome {
     /// raising `DoneWithThisFrame`).  Return it directly instead of
     /// rewinding + re-running the region (#177).
     BridgeFinished(pyre_object::PyObjectRef),
+    /// The bridge walk ended in an uncaught raise; propagate the same
+    /// `PyError` as `ExitFrameWithExceptionRef` (jitexc.py:44).
+    BridgeRaised(PyError),
 }
 
 /// compile.py:701-717 handle_fail.
@@ -4970,6 +4989,9 @@ fn handle_fail(
                         other => other.to_pyobj(),
                     };
                     return HandleFailOutcome::BridgeFinished(v);
+                }
+                crate::call_jit::BridgeResolution::FinishedException(cv) => {
+                    return HandleFailOutcome::BridgeRaised(finish_concrete_raise_error(cv));
                 }
                 crate::call_jit::BridgeResolution::ResumeBlackhole => {}
             }
@@ -5283,6 +5305,7 @@ fn execute_assembler(
                 HandleFailOutcome::BridgeCompiled => Some(LoopResult::ContinueRunningNormally),
                 // #177: single-frame bridge walk returned a concrete Finish.
                 HandleFailOutcome::BridgeFinished(v) => Some(LoopResult::Done(Ok(v))),
+                HandleFailOutcome::BridgeRaised(err) => Some(LoopResult::Done(Err(err))),
                 HandleFailOutcome::ResumeInBlackhole => {
                     // compile.py:710-716 / pyjitpl.py:2906 SwitchToBlackhole
                     let bh_result =
@@ -5529,13 +5552,19 @@ fn bound_reached(
                 // (the same continuation as the `jit_merge_point_hook`
                 // tracing site).
                 deliver_inflight_foriter_item(frame_root.frame());
-                if let Some(cv) = pyre_jit_trace::jitcode_dispatch::fbw_finish_concrete_take() {
-                    let result = match cv {
-                        // A void return stashes `Null`, i.e. Python `None`.
-                        pyre_jit_trace::state::ConcreteValue::Null => w_none(),
-                        other => other.to_pyobj(),
-                    };
-                    return Some(LoopResult::Done(Ok(result)));
+                match pyre_jit_trace::jitcode_dispatch::fbw_finish_concrete_take() {
+                    Some(pyre_jit_trace::jitcode_dispatch::FinishConcrete::Return(cv)) => {
+                        let result = match cv {
+                            // A void return stashes `Null`, i.e. Python `None`.
+                            pyre_jit_trace::state::ConcreteValue::Null => w_none(),
+                            other => other.to_pyobj(),
+                        };
+                        return Some(LoopResult::Done(Ok(result)));
+                    }
+                    Some(pyre_jit_trace::jitcode_dispatch::FinishConcrete::Raise(cv)) => {
+                        return Some(LoopResult::Done(Err(finish_concrete_raise_error(cv))));
+                    }
+                    None => {}
                 }
                 return Some(LoopResult::ContinueRunningNormally);
             }
@@ -5586,6 +5615,9 @@ fn bound_reached(
                 // #177: single-frame bridge walk returned a concrete Finish.
                 HandleFailOutcome::BridgeFinished(v) => {
                     return Some(LoopResult::Done(Ok(v)));
+                }
+                HandleFailOutcome::BridgeRaised(err) => {
+                    return Some(LoopResult::Done(Err(err)));
                 }
                 HandleFailOutcome::ResumeInBlackhole => {
                     let bh_result =
@@ -5774,6 +5806,9 @@ pub fn try_function_entry_jit(frame: &mut PyFrame) -> Option<PyResult> {
                 // This site returns `Option<PyResult>` (not `LoopResult`).
                 HandleFailOutcome::BridgeFinished(v) => {
                     return Some(Ok(v));
+                }
+                HandleFailOutcome::BridgeRaised(err) => {
+                    return Some(Err(err));
                 }
                 HandleFailOutcome::ResumeInBlackhole => {
                     let bh_result =


### PR DESCRIPTION
Epic #493 (FBW always-commit protocol) slice series, plus supporting descr/observability work. Rebased onto main (#509 WalkContext refactor).

## What's in here

- **jit: split residual decline causes, add walk-end census** — `ResidualExecOutcome` split (`ValueUnavailable` / `Symbolic`), executed-residual counters, `PYRE_FBW_CENSUS` walk-end line. Observability only.
- **jit: gated bridge-decode orphan stamping** — stamp decoded concrete values onto orphan-color OpRefs for divergent bridge resumes (initially behind `PYRE_FBW_BRIDGE_STAMP`).
- **majit: attach OBJECT parent SizeDescr to the typeptr field descr** / **jit: route items_block_capacity_descr through a descr group** — parentless-descr fixes (descr.py:218-239 cyclic OBJECT group; DictStorage-style group for the `ItemsBlock` capacity read), draining the `FieldDescrMissingParentDescr` walk-abort class.
- **jit: complete committed CA bridge walk from adopted frame** — the CALL_ASSEMBLER slow path ran the bridge hook and then unconditionally re-ran the guard-state blackhole, dropping a committed walk's end state (m4 repro returned a stale accumulator). The blackhole hook now completes the callee from the adopted frame via the portal runner (`raise_continue_running_normally` parity, pyjitpl.py:3048-3091 + warmspot.py:970-983).
- **jit: default bridge orphan stamp on** — with the CA fix in place, stamp-on matches stamp-off on every anchor and closes the e_min iteration deficit (9997 → 10000) by default; `PYRE_FBW_BRIDGE_STAMP=0` opts out.
- **jit: cut root-loop compile at the registered merge point** — upstream `compile_loop` always compiles from the registered merge point (pyjitpl.py:3018-3030). Pyre gated the cut on the cross-loop marker, so a guard-origin bridge closing at its own key never compiled. The cut is now unconditional; portal traces (position 0) are unaffected.
- **jit: clear last_exc_value at residual-call dispatch entry** — upstream `execute_varargs` clears the exception register at every residual-call entry (pyjitpl.py:1940-1941; catch_exception assert pyjitpl.py:504); pyre cleared it only on the concrete-exec success arm, so a stale exception declined the next residual call (`CatchExceptionWithActiveException` class, 9 → 0).
- **jit: no-replay finish for CALL_ASSEMBLER bridge Terminate walks** — the CA callback returns a bare bool and had no channel for a concrete finish result, so a CA bridge walk running the callee to finishframe concretely was rolled back and blackhole-re-run (double execution). The callback now records the finished frame in a thread-local handshake and the back-to-back blackhole consumes the kept stash (`DoneWithThisFrame`/`ExitFrameWithExceptionRef` parity, pyjitpl.py:1688-1698). Also closes the `PYRE_FBW_BRIDGE_STAMP=0` e_min deficit (9997 → 10000).
- **jit: model 24 missing opcode stack effects in liveness** — `stack_effects` default arm modeled 24 real stack-moving opcodes (CALL_FUNCTION_EX net −3, CALL_KW −(argc+2), UNPACK_EX, …) as net-0, inflating `depth_at_py_pc` past each occurrence; the walk-end flush then read phantom NULL stack slots and declined (CloseLoop non-commit class). All 24 modeled against the `eval.rs` implementations; `Send` registered as a branch instruction.
- **jit: flush kept-stack Unsupported abort at FOR_ITER header** — user-defined-iterator FOR_ITER walks executed their residuals then replayed from loop entry on the kept-stack abort. The in-flight entry at that abort is stale (entries are replaced on the next successful consume, never popped at body completion), so plain Shape-A delivery would re-run the last body. New `body_completed` tracking marked at every `for_iter_next` dispatch start; the delivery selector refuses completed entries; a new no-delivery flush arm (Unsupported variant only) adopts the walk end state at the header and lets the interpreter re-attempt the consume. The Permanent variant is byte-identical.
- **jit: log residual value-unavailable decline site under debug** — `PYRE_FBW_DEBUG_ABORT` prints op_pc/arg/helper when a residual declines with ValueUnavailable, attributing the remaining unj_val census walks without re-instrumenting.
- **rtyper: fill deferred annlowlevel mix-level helper bodies**, plus warning cleanups and rustfmt.

## Verification

- Post-rebase full gate: check.py dynasm + cranelift + wasm all 162/162, zero flakes; `cargo test --all --features dynasm` green.
- Corpus hazard census (`PYRE_FBW_CENSUS=1`): non-committed effectful walks **77 → 1** across the series (remaining: list_ops CompileTracePending+unj — box_value-None on residual args, the #493 P1 epic).
- Anchors: e_min 10000 (default), m4_300 2661 (stamp on == off at every probed N), gcd_kept_while 2663, repro_467 300000.

Full root-cause records: #493 comments 6-17.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
