### PR TITLE
interp: sequence repeat overflow error parity

### DIFF
--- a/pyre/pyre-interpreter/src/objspace/descroperation.rs
+++ b/pyre/pyre-interpreter/src/objspace/descroperation.rs
@@ -1030,15 +1030,17 @@ pub(crate) unsafe fn str_concat(a: PyObjectRef, b: PyObjectRef) -> PyResult {
     Ok(w_str_from_wtf8(result))
 }
 
-/// Extract a non-negative repeat count from an int or long, raising
-/// OverflowError with `msg` for positive bigints that exceed usize.
-unsafe fn repeat_count(n: PyObjectRef, msg: &str) -> Result<usize, PyError> {
+/// Extract a non-negative repeat count from an int or long.
+unsafe fn repeat_count(n: PyObjectRef) -> Result<usize, PyError> {
     if is_long(n) {
         let big = as_bigint(n);
         match big.to_usize() {
             Some(v) => Ok(v),
             None if bigint_lt(big, BigInt::from(0)) => Ok(0),
-            None => Err(PyError::new(PyErrorKind::OverflowError, msg)),
+            None => Err(PyError::new(
+                PyErrorKind::OverflowError,
+                "cannot fit 'int' into an index-sized integer",
+            )),
         }
     } else {
         let nv = w_int_get_value(n);
@@ -1052,14 +1054,20 @@ pub(crate) unsafe fn str_repeat(s: PyObjectRef, n: PyObjectRef) -> PyResult {
     // WTF-8 — so a surrogate-bearing string repeats without going through
     // `w_str_get_value`.
     let bytes = w_str_get_wtf8(s).as_bytes();
-    let count = repeat_count(n, "new string is too long")?;
+    let count = repeat_count(n)?;
     if count == 1 {
         return Ok(crate::type_methods::str_result_unchanged(s));
     }
     let total = bytes
         .len()
         .checked_mul(count)
-        .ok_or_else(|| PyError::new(PyErrorKind::OverflowError, "new string is too long"))?;
+        .ok_or_else(|| PyError::new(PyErrorKind::OverflowError, "repeated string is too long"))?;
+    if total > isize::MAX as usize {
+        return Err(PyError::new(
+            PyErrorKind::OverflowError,
+            "repeated string is too long",
+        ));
+    }
     let mut out: Vec<u8> = Vec::new();
     out.try_reserve_exact(total)
         .map_err(|_| PyError::new(PyErrorKind::MemoryError, ""))?;
@@ -1091,11 +1099,17 @@ pub(crate) unsafe fn bytes_concat(a: PyObjectRef, b: PyObjectRef) -> PyResult {
 
 pub(crate) unsafe fn bytes_repeat(s: PyObjectRef, n: PyObjectRef) -> PyResult {
     let data = pyre_object::bytesobject::bytes_like_data(s);
-    let count = repeat_count(n, "repeated bytes are too long")?;
+    let count = repeat_count(n)?;
     let cap = data
         .len()
         .checked_mul(count)
         .ok_or_else(|| PyError::new(PyErrorKind::OverflowError, "repeated bytes are too long"))?;
+    if cap > isize::MAX as usize {
+        return Err(PyError::new(
+            PyErrorKind::OverflowError,
+            "repeated bytes are too long",
+        ));
+    }
     let mut buf: Vec<u8> = Vec::new();
     buf.try_reserve_exact(cap)
         .map_err(|_| PyError::new(PyErrorKind::MemoryError, ""))?;
@@ -1145,7 +1159,7 @@ pub(crate) unsafe fn tuple_concat(a: PyObjectRef, b: PyObjectRef) -> PyResult {
 
 /// listobject.py:638-641 descr_mul
 pub(crate) unsafe fn list_repeat(list: PyObjectRef, n: PyObjectRef) -> PyResult {
-    let count = repeat_count(n, "list is too large")?;
+    let count = repeat_count(n)?;
     let len = w_list_len(list);
     let cap = len
         .checked_mul(count)
@@ -1169,7 +1183,7 @@ pub(crate) unsafe fn list_repeat(list: PyObjectRef, n: PyObjectRef) -> PyResult 
 /// `list_repeat`, but the extra copies are appended into the existing
 /// storage instead of building a fresh list.
 pub(crate) unsafe fn list_inplace_repeat(list: PyObjectRef, n: PyObjectRef) -> Result<(), PyError> {
-    let count = repeat_count(n, "list is too large")?;
+    let count = repeat_count(n)?;
     if count == 0 {
         w_list_clear(list);
         return Ok(());
@@ -1949,7 +1963,7 @@ pub fn mul(a: PyObjectRef, b: PyObjectRef) -> PyResult {
         }
         // tupleobject.py descr_mul
         if is_tuple(a) && is_int_or_long(b) {
-            let n = repeat_count(b, "tuple is too large")?;
+            let n = repeat_count(b)?;
             let len = w_tuple_len(a);
             let cap = len
                 .checked_mul(n)

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -2365,7 +2365,21 @@ fn init_list_type(ns: &mut DictStorage) {
 /// non-int" message; any other coercion error propagates.
 fn list_repeat_index(w_obj: PyObjectRef) -> Result<Option<PyObjectRef>, crate::PyError> {
     match crate::baseobjspace::space_index(w_obj) {
-        Ok(w_count) => Ok(Some(w_count)),
+        Ok(w_count) => {
+            // getindex_w(w_obj, OverflowError): an out-of-index-range value
+            // reports the original operand's type, not the __index__ result.
+            match crate::baseobjspace::int_w(w_count) {
+                Ok(_) => Ok(Some(w_count)),
+                Err(e) if e.kind == crate::PyErrorKind::OverflowError => Err(crate::PyError::new(
+                    crate::PyErrorKind::OverflowError,
+                    format!(
+                        "cannot fit '{}' into an index-sized integer",
+                        crate::baseobjspace::object_functionstr_type_name(w_obj)
+                    ),
+                )),
+                Err(e) => Err(e),
+            }
+        }
         Err(e) if e.kind == crate::PyErrorKind::TypeError => Ok(None),
         Err(e) => Err(e),
     }


### PR DESCRIPTION
`seq * n` raised the wrong error for oversized repeats across bytes, bytearray, list, tuple, and str. Matches CPython 3.14.2 / PyPy.

## Count doesn't fit an index-sized integer
`b'ab' * (10**100)`, `[1] * (10**100)`, `(1,) * (10**100)`, `'ab' * (10**100)`, etc. surfaced a per-type "too large" message via `repeat_count`. Both `PyNumber_AsSsize_t(n, OverflowError)` and PyPy `getindex_w(w_n, OverflowError)` raise `OverflowError: cannot fit '<type>' into an index-sized integer` here. `repeat_count` now raises that; `list_repeat_index` (the `__index__` dunder path) names the **original** operand's type, so `b'ab' * X()` with a custom `X.__index__` reports `'X'`, not `'int'`.

## Result exceeds an index-sized integer
`b'ab' * (2**62)` / `'ab' * (2**62)` gave `MemoryError`; CPython raises `OverflowError: repeated bytes are too long` / `repeated string is too long` before allocating. Added an `isize::MAX` guard to `bytes_repeat`/`str_repeat` (and corrected str's message from "new string is too long"). `list`/`tuple` keep `MemoryError` for oversized results, matching CPython.

This is the `*`-operator sibling of the `bytearray.__imul__` overflow handling in #507.

## Verification
- `check.py --backend dynasm` 162/162, `--backend cranelift` 162/162
- A 12-case repeat probe (bytes/bytearray/list/tuple/str × count-overflow / result-too-large / custom `__index__` / normal) diffed against CPython 3.14.2 — fully identical

🤖 Generated with [Claude Code](https://claude.com/claude-code)