### PR TITLE
Fix #498 inlined-closure freevar+branch miscompile; bytearray repeat/seq dunders

### DIFF
--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -1791,8 +1791,7 @@ impl OptContext {
         // (`seed_boxes_canonical` fixtures populate `inputarg_refs` directly).
         // Void slots are skipped: `InputArg{Int,Ref,Float}` has no Void
         // encoding (resoperation.py:719/727/739), so a Void sentinel in
-        // `inputargs` is not a real input-arg host (mirrors the retired
-        // box_pool scan's `!b.is_inputarg()` skip).
+        // `inputargs` is not a real input-arg host and carries no binding.
         for op in self.inputargs.clone() {
             match op.ty() {
                 Some(tp) if tp != majit_ir::Type::Void => {
@@ -2135,8 +2134,7 @@ impl OptContext {
     /// `inputarg_refs`) from a list of already-bound operands, mirroring
     /// what the production recorder→optimizer handoff populates. Each box
     /// is distributed by its bound identity: InputArg boxes land in
-    /// `inputarg_refs[index]`, ResOp boxes in `resop_refs[pos]`. This
-    /// replaces the retired `ctx.box_pool = vec![..]` fixture pattern so
+    /// `inputarg_refs[index]`, ResOp boxes in `resop_refs[pos]`, so that
     /// `resolve_to_operand` / `materialize_operand_at` / `find_producer_op` resolve each
     /// OpRef through the same canonical hosts production uses, returning a
     /// fresh operand bound to the seeded `Op` / `InputArg`.
@@ -2640,8 +2638,7 @@ impl OptContext {
     /// Whether the canonical `_forwarded` host for raw position `raw`
     /// (any `resop_refs` entry whose `OpRef` shares this raw, or
     /// `inputarg_refs[raw]` for an InputArg slot) carries `Forwarded::Const`.
-    /// The position-keyed replacement for the retired
-    /// `box_pool.get_at_position(raw)` const probe in `allocate_next_pos_raw`.
+    /// The position-keyed const probe used by `allocate_next_pos_raw`.
     fn position_is_const_forwarded(&self, raw: u32) -> bool {
         use majit_ir::forwarding::Forwarded;
         let idx = raw as usize;

--- a/majit/majit-metainterp/src/optimizeopt/optimizer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/optimizer.rs
@@ -551,13 +551,12 @@ pub(crate) fn merge_backend_constants_from_ctx(
     let live_positions = live_runtime_positions(ctx.new_operations.iter().map(|rc| rc.as_ref()));
 
     // Iterate every bound ResOp across the canonical `_forwarded` hosts
-    // (`new_operations` ∪ `phase1_emit_ops` ∪ `resop_refs`) rather than the
-    // `box_pool` side-table. The forwarded-write's bound-precondition
-    // forbids a forwarded write to an unbound box, so every
-    // position carrying `Forwarded::Const` has a bound producer `Op`
-    // reachable through one of these stores. Body-namespace producers are
-    // never `InputArg`, so the original `b.is_inputarg()` skip
-    // (make_constant excludes InputArg positions, mod.rs:3946) is automatic.
+    // (`new_operations` ∪ `phase1_emit_ops` ∪ `resop_refs`). The
+    // forwarded-write's bound-precondition forbids a forwarded write to an
+    // unbound box, so every position carrying `Forwarded::Const` has a bound
+    // producer `Op` reachable through one of these stores. Body-namespace
+    // producers are never `InputArg`, so the `b.is_inputarg()` skip
+    // (make_constant excludes InputArg positions) is automatic.
     // `entry_or_insert_with` dedups positions appearing in more than one
     // store.
     let mut consider = |op: &majit_ir::OpRc| {
@@ -2914,10 +2913,10 @@ impl Optimizer {
         // `Weak<Op>` upgrade succeeds.
         // `live_synthetics` is the incrementally-maintained set of synthetic
         // stand-ins (mint_synthetic_resop / bind_input_resops) whose position
-        // was never superseded by an `emit` — exactly the box-bound-to-synthetic
-        // boxes the old `box_pool.iter_indexed()` walk pushed. The unbound
-        // branch of that walk only ever hit Void boxes (no synthesis), so this
-        // drain reproduces it without reading `box_pool`.
+        // was never superseded by an `emit` — the box-bound-to-synthetic
+        // producers that must travel into `phase1_emit_ops`. Positions that
+        // were never synthesized carry no producer, so nothing else needs
+        // draining here.
         self.phase1_emit_ops
             .extend(ctx.live_synthetics.iter().cloned());
         // Transfer exported virtual state from context to optimizer
@@ -3590,8 +3589,7 @@ impl Optimizer {
             // pre-compact value. Readers off the canonical `Op.pos`
             // (`merge_backend_constants`) need the post-compact position.
             // Non-const synthetics never entered `remap`, so they keep their
-            // position — matching the prior `box_pool` walk's `remap.get`
-            // guard. Replaces that walk's production `Op.pos` write.
+            // position; only const-folded producers are repositioned here.
             for (op, new_pos) in &const_remaps {
                 op.pos.set(op.pos.get().with_raw(*new_pos));
             }
@@ -4595,8 +4593,8 @@ impl Optimizer {
                 None => ctx.materialize_operand_at(forced),
             };
             // The forced value is a chain terminal, so its canonical box's
-            // OpRef identity equals `forced`; OpRef-keyed consumers (backend,
-            // box_pool) see the same key, only the _forwarded info is added.
+            // OpRef identity equals `forced`; OpRef-keyed consumers (the
+            // backend) see the same key, only the _forwarded info is added.
             debug_assert_eq!(
                 resolved.to_opref(),
                 forced,

--- a/majit/majit-metainterp/src/optimizeopt/unroll.rs
+++ b/majit/majit-metainterp/src/optimizeopt/unroll.rs
@@ -2982,14 +2982,11 @@ impl OptUnroll {
                         return rc;
                     }
                 }
-                // S-0.C: `box_pool[*ia_opref].bound_inputarg()` resolves
-                // to the same `InputArgRc` as `inputarg_refs[idx]` after
-                // `ensure_inputarg_bindings` / `materialize_operand_at`'s InputArg
-                // placeholder arm have run (both write the canonical
-                // `InputArgRc` matching the OpRef's type). Drop the
-                // box_pool fallback — fall through to a fresh `InputArg`
-                // allocation, matching the original last-resort behaviour
-                // for the type-mismatch edge case.
+                // `inputarg_refs[idx]` is the canonical `InputArgRc` for this
+                // OpRef once `ensure_inputarg_bindings` / `materialize_operand_at`'s
+                // InputArg placeholder arm have run (both write the canonical
+                // `InputArgRc` matching the OpRef's type). Fall through to a
+                // fresh `InputArg` allocation for the type-mismatch edge case.
                 //
                 // Reaching here means the slot was either absent or
                 // type-mismatched. In production every canonical inputarg

--- a/pyre/pyre-interpreter/src/objspace/descroperation.rs
+++ b/pyre/pyre-interpreter/src/objspace/descroperation.rs
@@ -1206,6 +1206,44 @@ pub(crate) unsafe fn list_inplace_repeat(list: PyObjectRef, n: PyObjectRef) -> R
     Ok(())
 }
 
+/// bytearrayobject.py descr_inplace_mul — repeat the bytearray in place,
+/// preserving object identity.  A resize while the buffer is exported raises
+/// BufferError, mirroring the `__iadd__` export guard; a count of 1 leaves the
+/// length unchanged and needs no resize.
+pub(crate) unsafe fn bytearray_inplace_repeat(
+    ba: PyObjectRef,
+    n: PyObjectRef,
+) -> Result<(), PyError> {
+    let count = repeat_count(n, "repeated bytes are too long")?;
+    let len = pyre_object::bytearrayobject::w_bytearray_len(ba);
+    if count == 1 {
+        return Ok(());
+    }
+    let new_size = len
+        .checked_mul(count)
+        .ok_or_else(|| PyError::new(PyErrorKind::OverflowError, "repeated bytes are too long"))?;
+    // Only an actual length change touches the buffer size; an exported buffer
+    // blocks it.
+    if new_size != len {
+        crate::builtins::bytearray_check_exports(ba)?;
+    }
+    if count == 0 {
+        pyre_object::bytearrayobject::w_bytearray_vec_mut(ba).clear();
+        return Ok(());
+    }
+    if len == 0 {
+        return Ok(());
+    }
+    let snapshot = pyre_object::bytearrayobject::w_bytearray_data(ba).to_vec();
+    let vec = pyre_object::bytearrayobject::w_bytearray_vec_mut(ba);
+    vec.try_reserve_exact(new_size - len)
+        .map_err(|_| PyError::new(PyErrorKind::MemoryError, ""))?;
+    for _ in 1..count {
+        vec.extend_from_slice(&snapshot);
+    }
+    Ok(())
+}
+
 // ── Comparison operations ─────────────────────────────────────────────
 
 unsafe fn int_lt(a: PyObjectRef, b: PyObjectRef) -> PyResult {

--- a/pyre/pyre-interpreter/src/objspace/descroperation.rs
+++ b/pyre/pyre-interpreter/src/objspace/descroperation.rs
@@ -1214,7 +1214,7 @@ pub(crate) unsafe fn bytearray_inplace_repeat(
     ba: PyObjectRef,
     n: PyObjectRef,
 ) -> Result<(), PyError> {
-    let count = repeat_count(n, "repeated bytes are too long")?;
+    let count = repeat_count(n)?;
     let len = pyre_object::bytearrayobject::w_bytearray_len(ba);
     if count == 1 {
         return Ok(());

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -13113,6 +13113,76 @@ fn init_bytearray_type(ns: &mut DictStorage) {
             2,
         ),
     );
+    // `bytes_descr_repeat` builds its result via `bytes_repeat`, which yields a
+    // bytearray for a bytearray receiver, so the repeat dunders are shared.
+    dict_storage_store(
+        ns,
+        "__mul__",
+        make_builtin_function_with_arity("__mul__", |args| bytes_descr_repeat(args), 2),
+    );
+    dict_storage_store(
+        ns,
+        "__rmul__",
+        make_builtin_function_with_arity("__rmul__", |args| bytes_descr_repeat(args), 2),
+    );
+    dict_storage_store(
+        ns,
+        "__imul__",
+        make_builtin_function_with_arity(
+            "__imul__",
+            |args| {
+                // descr_inplace_mul: the count goes through `__index__`; a
+                // non-index operand becomes NotImplemented.
+                crate::type_methods::arity_slot(args, 1)?;
+                let Some(w_count) = list_repeat_index(args[1])? else {
+                    return Ok(pyre_object::w_not_implemented());
+                };
+                unsafe {
+                    crate::objspace::descroperation::bytearray_inplace_repeat(args[0], w_count)?
+                };
+                Ok(args[0])
+            },
+            2,
+        ),
+    );
+    dict_storage_store(
+        ns,
+        "__contains__",
+        make_builtin_function_with_arity(
+            "__contains__",
+            |args| {
+                crate::type_methods::arity_slot(args, 1)?;
+                Ok(pyre_object::w_bool_from(
+                    crate::baseobjspace::contains_slot(args[0], args[1])?,
+                ))
+            },
+            2,
+        ),
+    );
+    dict_storage_store(
+        ns,
+        "__len__",
+        make_builtin_function_with_arity(
+            "__len__",
+            |args| {
+                crate::type_methods::arity_slot(args, 0)?;
+                crate::baseobjspace::len_slot(args[0])
+            },
+            1,
+        ),
+    );
+    dict_storage_store(
+        ns,
+        "__iter__",
+        make_builtin_function_with_arity(
+            "__iter__",
+            |args| {
+                crate::type_methods::arity_slot(args, 0)?;
+                crate::baseobjspace::iter(args[0])
+            },
+            1,
+        ),
+    );
     for (name, func) in [
         ("__eq__", bytearray_dunder_eq as DunderFn),
         ("__ne__", bytearray_dunder_ne),

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -7085,12 +7085,20 @@ fn collect_outer_active_boxes(
                             }
                         }
                     } else {
-                        // Local slot.  Written to the shadow on every
-                        // `STORE_FAST`, so the shadow is authoritative; fall
-                        // back to the walk register bank only when the shadow
-                        // slot is unset / NULL and the bank holds a real value.
+                        // At a branch guard the walk register is the live
+                        // `MIFrame.registers_r[index]` binding captured by
+                        // `_get_list_of_active_boxes`.  The virtualizable
+                        // shadow can still hold the loop-entry value for a
+                        // local overwritten earlier in this arm, so prefer the
+                        // guard-state register and retain the shadow as the
+                        // fallback.  Non-branch captures keep the shadow-first
+                        // portal-local path.
+                        let walk_is_real = walk_box
+                            .is_some_and(|b| b != OpRef::NONE && !opref_is_null_const_ptr(b));
                         let shadow_is_real = vbox.is_some_and(|b| !opref_is_null_const_ptr(b));
-                        if shadow_is_real {
+                        if guard_py_pc.is_some() && walk_is_real {
+                            walk_box.unwrap_or_else(fallback)
+                        } else if shadow_is_real {
                             vbox.unwrap_or_else(fallback)
                         } else {
                             match walk_box {

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -5573,12 +5573,12 @@ fn try_fold_pure_call_via_executor(
         // pure shapes — skip the stamp for void.
         majit_ir::Type::Void => return,
     };
-    // Stamp only when the recorded result has a live BoxPool slot.  A deeper
-    // inlined / recursive frame's residual result may be recorded in a
-    // context whose Box is not allocated in the active recorder; stamping it
-    // would violate the `*FrontendOp(pos, value)` invariant.  Skipping leaves
-    // the result symbolic so the downstream branch aborts the trace into the
-    // trait fallback instead of crashing.
+    // Stamp only when the recorded result has a live slot in the active
+    // recorder.  A deeper inlined / recursive frame's residual result may be
+    // recorded in a context whose position is not allocated in the active
+    // recorder; stamping it would violate the `*FrontendOp(pos, value)`
+    // invariant.  Skipping leaves the result symbolic so the downstream branch
+    // aborts the trace into the trait fallback instead of crashing.
     ctx.trace_ctx.try_set_opref_concrete(recorded, result_value);
 }
 


### PR DESCRIPTION
Two commits on `box-pool`.

## jitcode_dispatch: guard-resume local ref capture prefers walk register

Fixes #498 — an inlined closure that reads a freevar (`LOAD_DEREF`) and then branches installed a miscompiled trace (wrong return value; or a `TypeError: 'int' object is not iterable` when the aliasing reversed and the returned int was written into the cell slot).

Root cause: `collect_outer_active_boxes` (the pyre port of RPython `_get_list_of_active_boxes`) captured a local Ref slot from the `virtualizable_boxes` shadow, which can still hold the loop-entry value for a local overwritten earlier in a branch arm. At a branch-guard resume this embedded the stale/aliased value into the snapshot.

Fix: at a branch guard, prefer the live walk register (`registers_r[index]`, the source `_get_list_of_active_boxes` reads directly) when it holds a real value, retaining the shadow as the fallback for retired-mirror slots that sit at `OpRef::NONE`. Non-branch captures keep the shadow-first portal-local path. This restores the RPython register-first read where the register is valid; the shadow-first policy was the divergence.

Minimal repros (oracle = `PYRE_JIT=0`), all now match on both backends:
- int freevar read-only + branch → `1600000` (was `210`)
- list freevar `append` + branch → `(1600000, 40000)` (was `TypeError`)
- `nonlocal` store + branch → `(1600000, 40000)` (was `(40198, 40000)`)

## bytearray: expose `__mul__`/`__rmul__`/`__imul__`/`__contains__`/`__len__`/`__iter__`

Exposes the repeat / membership / length / iteration dunders on `bytearray` via `descroperation` + `typedef`.

## Verification

- three #498 repros match oracle on dynasm and cranelift
- `python ./pyre/check.py --backend cranelift` — 162/162 ALL PASSED
- `python ./pyre/check.py --backend dynasm` — correctness-clean (only `nested_loop`/`raise_catch` perf-ratio timing flakes under load)
- `cargo test -p pyre-jit-trace --features dynasm --lib` — 270 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for repeating `bytearray` values in place with `*=`.
  - Improved `bytearray` repetition behavior for multiplication and reverse multiplication.
  - Added correct handling for empty results, repeated content, and buffer-size changes.

- **Bug Fixes**
  - Improved runtime handling of branch guards to select the correct execution state during JIT tracing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->