### PR TITLE
jit: close the FBW inline sub-walk double-apply class (gh#495) + branch-resume local binding fix (gh#498)

### DIFF
--- a/pyre/bench/synth/closure_freevar_branch_list_cell.py
+++ b/pyre/bench/synth/closure_freevar_branch_list_cell.py
@@ -1,0 +1,25 @@
+# gh#498 guard: branch resume keeps local result across list-cell mutation.
+N = 40000
+
+
+def run():
+    buf = []
+    acc = 0
+
+    def step(k):
+        buf.append(k)
+        if k < 0:
+            return 0
+        if k == 2:
+            return 200
+        return -1
+
+    i = 0
+    while i < N:
+        v = step(i % 5)
+        acc += v if v != -1 else 0
+        i += 1
+    return acc, len(buf)
+
+
+print(run())

--- a/pyre/bench/synth/closure_freevar_branch_nonlocal.py
+++ b/pyre/bench/synth/closure_freevar_branch_nonlocal.py
@@ -1,0 +1,27 @@
+# gh#498 guard: branch resume keeps local result across nonlocal mutation.
+N = 40000
+
+
+def run():
+    n = 0
+    acc = 0
+
+    def step(k):
+        nonlocal n
+        n = n + 1
+        if k < 0:
+            return 0
+        if k == 2:
+            return 200
+        return -1
+
+    i = 0
+    while i < N:
+        k = i % 5
+        v = step(k)
+        acc += v if v != -1 else 0
+        i += 1
+    return acc, n
+
+
+print(run())

--- a/pyre/bench/synth/closure_freevar_branch_readonly.py
+++ b/pyre/bench/synth/closure_freevar_branch_readonly.py
@@ -1,0 +1,22 @@
+# gh#498 guard: branch resume keeps the current closure-call result local.
+N = 40000
+
+
+def run():
+    base = 10
+    acc = 0
+
+    def step(k):
+        if k == 2:
+            return base + 190
+        return -1
+
+    i = 0
+    while i < N:
+        v = step(i % 5)
+        acc += v if v != -1 else 0
+        i += 1
+    return acc
+
+
+print(run())

--- a/pyre/bench/synth/const_int_return_side_effect.py
+++ b/pyre/bench/synth/const_int_return_side_effect.py
@@ -1,0 +1,13 @@
+# gh#495 guard: constant-int-returning callee mutation must not be replayed or dropped.
+N = 30000
+class C:
+    def __init__(self): self.pos = 0
+def step(c):
+    c.pos = c.pos + 1
+    return 7
+def run():
+    c = C(); acc = 0; i = 0
+    while i < N:
+        acc = acc + step(c); i = i + 1
+    return acc, c.pos
+print(run())

--- a/pyre/bench/synth/float_return_side_effect.py
+++ b/pyre/bench/synth/float_return_side_effect.py
@@ -1,0 +1,13 @@
+# gh#495 guard: float-returning callee mutation must not be replayed or dropped.
+N = 30000
+class C:
+    def __init__(self): self.pos = 0
+def step(c):
+    c.pos = c.pos + 1
+    return 1.5
+def run():
+    c = C(); acc = 0.0; i = 0
+    while i < N:
+        acc = acc + step(c); i = i + 1
+    return acc, c.pos
+print(run())

--- a/pyre/bench/synth/foriter_exempt_nested_foriter.py
+++ b/pyre/bench/synth/foriter_exempt_nested_foriter.py
@@ -1,0 +1,64 @@
+# gh#495 guard: ForIterNext exemption double-advance is masked by fbw_abort_nested_unjournaled_residual; +1 reproduces under PYRE_FBW_NESTED_RESID_ABORT=0
+# branch-bearing callee with a SECOND FOR_ITER (nested), not the loop header.
+# Two shared generators; inner FOR_ITER advance is a non-header foriter (Finding #2).
+# Post-inner declining residual forces abort while inner item in-flight.
+N = 20000
+
+
+class Shared:
+    def __init__(self):
+        self.a = 0
+        self.b = 0
+        self.t = 0
+
+
+def gouter(sh, m):
+    j = 0
+    while j < m:
+        sh.a += 1
+        yield j
+        j += 1
+
+
+def ginner(sh, m):
+    j = 0
+    while j < m:
+        sh.b += 1
+        yield j * 10
+        j += 1
+
+
+def tail(sh):
+    sh.t += 1
+    return sh.t
+
+
+def step(go, gi, sh, k):
+    if k < 0:
+        return 0
+    s = 0
+    for x in go:
+        s += x
+        for y in gi:
+            s += y
+            break
+        t = tail(sh)
+        s += t & 0
+        break
+    return s
+
+
+def run(N):
+    sh = Shared()
+    go = gouter(sh, N * 10)
+    gi = ginner(sh, N * 10)
+    acc = 0
+    i = 0
+    while i < N:
+        k = i % 5
+        acc += step(go, gi, sh, k)
+        i += 1
+    return acc, sh.a, sh.b, sh.t
+
+
+print(run(N))

--- a/pyre/bench/synth/foriter_exempt_shared_generator.py
+++ b/pyre/bench/synth/foriter_exempt_shared_generator.py
@@ -1,0 +1,52 @@
+# gh#495 guard: ForIterNext exemption double-advance is masked by fbw_abort_nested_unjournaled_residual; +1 reproduces under PYRE_FBW_NESTED_RESID_ABORT=0
+# SHARED long generator consumed incrementally. step consumes ONE item (for..break),
+# FOR_ITER advance mutates shared counter (exempt). Then a declining nested-residual CALL.
+# If the inline sub-walk aborts AFTER the exempt advance and the trait leg re-runs step,
+# the SHARED generator is advanced AGAIN -> double advance / dropped item / counter skew.
+N = 20000
+
+
+class Shared:
+    def __init__(self):
+        self.pos = 0
+        self.tail = 0
+
+
+def biggen(sh, m):
+    j = 0
+    while j < m:
+        sh.pos += 1
+        yield j
+        j += 1
+
+
+def tailhelper(sh):
+    sh.tail += 1
+    return sh.tail
+
+
+def step(g, sh, k):
+    if k < 0:
+        return 0
+    got = -1
+    for x in g:
+        got = x
+        break
+    t = tailhelper(sh)
+    return got + (t & 0)
+
+
+def run(N):
+    sh = Shared()
+    g = biggen(sh, N * 10)
+    acc = 0
+    i = 0
+    while i < N:
+        k = i % 5
+        v = step(g, sh, k)
+        acc += v
+        i += 1
+    return acc, sh.pos, sh.tail
+
+
+print(run(N))

--- a/pyre/bench/synth/inline_subwalk_mutating_residual_abort.py
+++ b/pyre/bench/synth/inline_subwalk_mutating_residual_abort.py
@@ -1,0 +1,39 @@
+# gh#495 guard: inlined subwalk with mutating residual call and local abort path.
+N = 60000
+
+
+class Counter:
+    def __init__(self):
+        self.pos = 0
+
+    def bump(self):
+        self.pos = self.pos + 1
+
+
+def step(c, d, k):
+    c.bump()                 # unjournaled SetfieldGc via nested residual CALL
+    if k < 0:                # branch to force branch-bearing (multiframe) shape
+        return 0
+    try:
+        return d[k]          # residual dict-lookup; raises KeyError for misses
+    except KeyError:
+        return -1            # caught LOCALLY in the callee frame
+
+
+def run():
+    d = {1: 100, 2: 200, 3: 300}
+    acc = 0
+    c = Counter()
+    i = 0
+    while i < N:
+        k = i % 5            # 0 and 4 miss -> KeyError caught -> -1
+        v = step(c, d, k)
+        if v == -1:
+            acc -= 1
+        else:
+            acc += v
+        i = i + 1
+    return acc, c.pos
+
+
+print(run())

--- a/pyre/bench/synth/inline_subwalk_mutating_residual_noexc.py
+++ b/pyre/bench/synth/inline_subwalk_mutating_residual_noexc.py
@@ -1,0 +1,39 @@
+# gh#495 guard: inlined subwalk with mutating residual call and no exception replay.
+# same as adv_3_a but NO exception: the miss branch avoids KeyError entirely
+N = 60000
+
+
+class Counter:
+    def __init__(self):
+        self.pos = 0
+
+    def bump(self):
+        self.pos = self.pos + 1
+
+
+def step(c, d, k):
+    c.bump()
+    if k < 0:
+        return 0
+    if k in d:
+        return d[k]
+    return -1
+
+
+def run():
+    d = {1: 100, 2: 200, 3: 300}
+    acc = 0
+    c = Counter()
+    i = 0
+    while i < N:
+        k = i % 5
+        v = step(c, d, k)
+        if v == -1:
+            acc -= 1
+        else:
+            acc += v
+        i = i + 1
+    return acc, c.pos
+
+
+print(run())

--- a/pyre/bench/synth/inline_subwalk_property_mutates.py
+++ b/pyre/bench/synth/inline_subwalk_property_mutates.py
@@ -1,0 +1,26 @@
+# gh#495 guard: inlined property residual mutates before branch and caught miss.
+# @property value-returning mutating + try/except-inside-callee raising branch
+N = 60000
+class C:
+    def __init__(self): self.pos = 0
+    @property
+    def tick(self):
+        self.pos = self.pos + 1
+        return self.pos
+def step(c, d, k):
+    t = c.tick
+    if k < 0: return 0
+    try:
+        return d[k]
+    except KeyError:
+        return -1
+def run():
+    d = {1:100,2:200,3:300}; acc=0; c=C(); i=0
+    while i < N:
+        k = i % 5
+        v = step(c, d, k)
+        if v == -1: acc -= 1
+        else: acc += v
+        i += 1
+    return acc, c.pos
+print(run())

--- a/pyre/bench/synth/inline_subwalk_radd_consumed.py
+++ b/pyre/bench/synth/inline_subwalk_radd_consumed.py
@@ -1,0 +1,21 @@
+# gh#495 guard: reflected-add residual mutation feeds the inlined branch result.
+# radd result feeds the branch condition; branch varies each iter -> sub-walk churn
+N = 40000
+class Acc:
+    def __init__(self): self.pos = 0
+    def __radd__(self, o):
+        self.pos = self.pos + 1
+        return self.pos + o
+def step(c, k):
+    t = k + c                 # c.__radd__ residual, returns int depending on pos
+    if t & 1: return 1        # branch depends on mutating residual result
+    if k < 0: return 0
+    return -1
+def run():
+    acc=0; c=Acc(); i=0
+    while i < N:
+        v = step(c, i % 7)
+        acc += v
+        i += 1
+    return acc, c.pos
+print(run())

--- a/pyre/bench/synth/inline_subwalk_user_iterator.py
+++ b/pyre/bench/synth/inline_subwalk_user_iterator.py
@@ -1,0 +1,32 @@
+# gh#495 guard: inlined callee consumes user iterator whose next mutates state.
+# FOR loop over user iterator INSIDE branch-bearing inlined callee; __next__ mutates shared counter
+N = 30000
+class It:
+    def __init__(self): self.pos = 0; self.lim = 3
+    def __iter__(self):
+        self.n = 0
+        return self
+    def __next__(self):
+        self.n = self.n + 1
+        if self.n > self.lim:
+            raise StopIteration
+        self.pos = self.pos + 1
+        return self.n
+def step(it, d, k):
+    if k < 0:
+        return 0
+    if k in d:
+        s = 0
+        for x in it:          # FOR_ITER over user iterator inside inlined callee branch
+            s += x
+        return s
+    return -1
+def run():
+    d = {1:100,2:200,3:300}; acc=0; it=It(); i=0
+    while i < N:
+        k = i % 5
+        v = step(it, d, k)
+        acc += v
+        i += 1
+    return acc, it.pos
+print(run())

--- a/pyre/bench/synth/mutate_then_raise_caught.py
+++ b/pyre/bench/synth/mutate_then_raise_caught.py
@@ -1,0 +1,28 @@
+# gh#495 guard: mutating residual raises and is caught inside the inlined callee.
+# V2: mutate-then-RAISE, caught inside callee. Tests fixed path under exc churn.
+N = 30000
+class C:
+    def __init__(self):
+        self.pos = 0
+    def tick(self):
+        self.pos = self.pos + 1
+        raise ValueError
+def step(c, d, k):
+    try:
+        c.tick()             # void residual mutating then raising
+    except ValueError:
+        pass
+    if k < 0:
+        return 0
+    if k in d:
+        return d[k]
+    return -1
+def run():
+    d = {1:100,2:200,3:300}; acc=0; c=C(); i=0
+    while i < N:
+        k = i % 5
+        v = step(c, d, k)
+        acc += (v if v != -1 else 0)
+        i += 1
+    return acc, c.pos
+print(run())

--- a/pyre/bench/synth/mutate_uncaught_raise_delivery.py
+++ b/pyre/bench/synth/mutate_uncaught_raise_delivery.py
@@ -1,0 +1,15 @@
+# gh#495 guard: mutating call that raises uncaught must deliver the exception once.
+N = 30000
+class C:
+    def __init__(self): self.pos = 0
+    def tick(self):
+        self.pos = self.pos + 1
+        if self.pos == N: raise ValueError(self.pos)
+def run():
+    c = C(); i = 0
+    try:
+        while i < N + 10:
+            c.tick(); i += 1
+    except ValueError as e:
+        return c.pos, i, str(e)
+print(run())

--- a/pyre/bench/synth/nested_callee_chain_mutation_abort.py
+++ b/pyre/bench/synth/nested_callee_chain_mutation_abort.py
@@ -1,0 +1,53 @@
+# gh#495 guard: nested inlined callees mutate through a branch-bearing abort path.
+# 3-level nested branch-bearing mutating callees. outer while -> A -> B -> C, each mutates.
+N = 40000
+
+
+class Counter:
+    def __init__(self):
+        self.pos = 0
+
+    def bump(self):
+        self.pos = self.pos + 1
+
+
+def levelC(c, d, k):
+    c.bump()
+    if k < 0:
+        return 0
+    if k in d:
+        return d[k]
+    return -1
+
+
+def levelB(c, d, k):
+    c.bump()
+    if k == 4:
+        return 7
+    return levelC(c, d, k)
+
+
+def levelA(c, d, k):
+    c.bump()
+    if k < 0:
+        return -3
+    return levelB(c, d, k)
+
+
+def run():
+    d = {1: 100, 2: 200, 3: 300}
+    acc = 0
+    c = Counter()
+    i = 0
+    while i < N:
+        k = i % 5
+        v = levelA(c, d, k)
+        if v == -1:
+            acc -= 1
+        else:
+            acc += v
+        i = i + 1
+    return acc, c.pos
+
+
+print(run())

--- a/pyre/bench/synth/or_chain_fresh_alloc_arg.py
+++ b/pyre/bench/synth/or_chain_fresh_alloc_arg.py
@@ -1,0 +1,24 @@
+N = 30000
+
+
+class Box:
+    def __init__(self, v):
+        self.v = v
+
+
+def pick(a, b, c):
+    return a.v or b.v or c.v
+
+
+def run():
+    z = Box(0)
+    two = Box(2)
+    acc = 0
+    i = 0
+    while i < N:
+        acc += pick(z, Box(i % 3), two)
+        i += 1
+    return acc
+
+
+print(run())

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -8246,18 +8246,22 @@ pub(crate) struct MidBodyPayload {
 struct FbwStoreJournalRootArea {
     stores: *const std::cell::RefCell<Vec<[pyre_object::PyObjectRef; 3]>>,
     appends: *const std::cell::RefCell<Vec<(pyre_object::PyObjectRef, usize)>>,
+    abort_overrides: *const std::cell::RefCell<Vec<(usize, pyre_object::PyObjectRef)>>,
     cell_stores: *const std::cell::RefCell<Vec<(pyre_object::PyObjectRef, i64)>>,
     foriter: *const std::cell::RefCell<Vec<InflightForiter>>,
     abort_resume: *const std::cell::RefCell<Option<InlineAbortCarrier>>,
+    active_session: *const std::cell::Cell<*const std::cell::RefCell<WalkSession>>,
 }
 
 thread_local! {
     static FBW_STORE_JOURNAL_ROOT_AREA: FbwStoreJournalRootArea = FbwStoreJournalRootArea {
         stores: FBW_STORE_JOURNAL.with(|value| value as *const _),
         appends: FBW_APPEND_JOURNAL.with(|value| value as *const _),
+        abort_overrides: FBW_ABORT_OUTER_STACK_OVERRIDES.with(|value| value as *const _),
         cell_stores: FBW_CELL_STORE_JOURNAL.with(|value| value as *const _),
         foriter: FBW_FORITER_INFLIGHT.with(|value| value as *const _),
         abort_resume: FBW_ABORT_CALL_RESUME.with(|value| value as *const _),
+        active_session: ACTIVE_WALK_SESSION.with(|value| value as *const _),
     };
 }
 
@@ -9015,6 +9019,29 @@ pub unsafe fn fbw_store_journal_root_walker_area(
     for (list, _len) in appends.iter_mut() {
         visitor(unsafe { &mut *(list as *mut pyre_object::PyObjectRef).cast() });
     }
+    // Nested-inline abort outer-frame stash: PyObjectRef slots kept across the
+    // rest of the walk; only the ref slot is a root.
+    let abort_overrides = unsafe { &mut *(*area.abort_overrides).as_ptr() };
+    for (_slot, value) in abort_overrides.iter_mut() {
+        visitor(unsafe { &mut *(value as *mut pyre_object::PyObjectRef).cast() });
+    }
+    // Inline parent-frame stack overrides on the active walk session's
+    // framestack. The session lives on the walk driver's Rust stack (which the
+    // GC cannot scan) and each override slot holds a nursery-resident ref.
+    let session_ptr = unsafe { (*area.active_session).get() };
+    if !session_ptr.is_null() {
+        // SAFETY: `ACTIVE_WALK_SESSION` is set by `InlineFrameGuard::enter` and
+        // cleared when the last frame pops, so a non-null pointer refers to a
+        // session that is live for the duration of this quiesced walk.
+        let session = unsafe { &mut *(*session_ptr).as_ptr() };
+        for frame in session.framestack.iter_mut() {
+            if let Some(parent) = frame.parent.as_mut() {
+                for (_slot, value) in parent.call_stack_overrides.iter_mut() {
+                    visitor(unsafe { &mut *(value as *mut pyre_object::PyObjectRef).cast() });
+                }
+            }
+        }
+    }
     // Cell-store journal: the cell is immovable (`malloc_typed`) so no
     // forwarding happens, but a mid-walk rebind can drop the module dict's
     // only reference — rooting it keeps the rollback's `intvalue` restore
@@ -9747,8 +9774,7 @@ fn step_vstack_mirror(ctx: &mut WalkContext<'_, '_>, jit_pc: usize) {
             ctx.vstack_valid = false;
             return;
         }
-        let Some(frame) = ActiveResumeFrame::current(ctx.session, ctx.fbw_mode.snapshot_sym)
-        else {
+        let Some(frame) = ActiveResumeFrame::current(ctx.session, ctx.fbw_mode.snapshot_sym) else {
             ctx.vstack_valid = false;
             return;
         };

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -2871,6 +2871,8 @@ fn compute_bridge_root_parent_frame(
     );
     Some(InlineParentFrame {
         jitcode_index,
+        call_py_pc: None,
+        call_stack_overrides: Vec::new(),
         resume_py_pc,
         // Parent-frame words are never branch-tagged; negative tags belong to
         // a branch guard's own top-frame word.
@@ -6314,9 +6316,9 @@ fn try_execute_residual_call_via_executor(
     // provably side-effect-free.  Ref-result getters/dunders/user `__next__`
     // can mutate live heap through user frames while `writes_live_heap` is
     // false, and rollback would miss that concrete mutation.  The helper no-ops
-    // outside `FBW_INLINE_CODE_STACK`, so top-level depth-1 behavior is unchanged.
+    // on an empty session framestack, so top-level depth-1 behavior is unchanged.
     if !provably_side_effect_free {
-        fbw_abort_nested_unjournaled_residual(op_pc)?;
+        fbw_abort_nested_unjournaled_residual(ctx, op_pc)?;
     }
     let body_effect_candidate =
         !provably_side_effect_free && writes_live_heap && fbw_foriter_inflight_active();
@@ -7420,6 +7422,12 @@ fn fbw_strict_fold_frame_reg(ctx: &WalkContext<'_, '_>) -> u16 {
 struct InlineParentFrame {
     /// The caller's jitcode index (`(*JitCode).index`).
     jitcode_index: u32,
+    /// The caller CALL opcode's Python pc. A nested inline-capture abort
+    /// resumes the top-level frame here so the declined callee executes once.
+    call_py_pc: Option<u32>,
+    /// Concrete operand-stack slots at `call_py_pc`, keyed by absolute
+    /// `locals_cells_stack_w` index. Used only by the abort-point flush.
+    call_stack_overrides: Vec<(usize, pyre_object::PyObjectRef)>,
     /// The caller's resume Python pc: the CALL's return point (fallthrough),
     /// where the next opcode pops the call result.  First slice keeps this a
     /// plain py_pc (`< AFTER_RESIDUAL_CALL_PC_FLAG`); a CALL inside a
@@ -7438,6 +7446,17 @@ struct InlineParentFrame {
 /// RAII guard for one framestack level. Pop on drop so `?` and nested
 /// sub-walks unwind to the caller's level.
 struct InlineFrameGuard<'a>(&'a std::cell::RefCell<WalkSession>);
+
+thread_local! {
+    /// Top-level caller CALL pc and its concrete operand-stack slots stashed
+    /// by [`fbw_abort_nested_unjournaled_residual`] at the nested-inline
+    /// decline, read back by the trace loop after the walk unwinds
+    /// ([`fbw_abort_outer_resume_take`]) to drive the abort-point flush.
+    static FBW_ABORT_OUTER_RESUME_PY_PC: std::cell::Cell<Option<usize>> =
+        const { std::cell::Cell::new(None) };
+    static FBW_ABORT_OUTER_STACK_OVERRIDES: std::cell::RefCell<Vec<(usize, pyre_object::PyObjectRef)>> =
+        const { std::cell::RefCell::new(Vec::new()) };
+}
 
 impl<'a> InlineFrameGuard<'a> {
     fn enter(
@@ -8802,9 +8821,38 @@ fn fbw_abort_nested_unjournaled_residual(
             != Some(std::ffi::OsStr::new("0"))
     });
     if enabled && !ctx.session.borrow().framestack.is_empty() {
+        let (outer_resume_py_pc, stack_overrides) = {
+            let session = ctx.session.borrow();
+            match session.framestack.first().and_then(|f| f.parent.as_ref()) {
+                Some(frame) => (frame.call_py_pc, frame.call_stack_overrides.clone()),
+                None => (None, Vec::new()),
+            }
+        };
+        FBW_ABORT_OUTER_RESUME_PY_PC.with(|c| c.set(outer_resume_py_pc.map(|pc| pc as usize)));
+        FBW_ABORT_OUTER_STACK_OVERRIDES.with(|c| {
+            *c.borrow_mut() = stack_overrides;
+        });
         return Err(DispatchError::LoopBearingCalleeInlineUnsupported { pc });
     }
     Ok(())
+}
+
+/// Take the top-level caller CALL pc and stack slots stashed by
+/// [`fbw_abort_nested_unjournaled_residual`].
+pub(crate) fn fbw_abort_outer_resume_take()
+-> Option<(usize, Vec<(usize, pyre_object::PyObjectRef)>)> {
+    let pc = FBW_ABORT_OUTER_RESUME_PY_PC.with(|c| c.replace(None))?;
+    let stack_overrides = FBW_ABORT_OUTER_STACK_OVERRIDES.with(|c| {
+        let mut slots = c.borrow_mut();
+        std::mem::take(&mut *slots)
+    });
+    Some((pc, stack_overrides))
+}
+
+/// Clear the nested inline abort resume latch at a walk boundary.
+pub(crate) fn fbw_abort_outer_resume_py_pc_reset() {
+    FBW_ABORT_OUTER_RESUME_PY_PC.with(|c| c.set(None));
+    FBW_ABORT_OUTER_STACK_OVERRIDES.with(|c| c.borrow_mut().clear());
 }
 
 /// Whether the walk recorded an effect outside the journal's reach.
@@ -12329,6 +12377,113 @@ fn decline_inline_caller_frame_for_catch_marker(
     }
 }
 
+fn concrete_ref_for_color(
+    ctx: &WalkContext<'_, '_>,
+    color: usize,
+) -> Option<pyre_object::PyObjectRef> {
+    if let Some(ConcreteValue::Ref(ptr)) = ctx.concrete_registers_r.get(color) {
+        if !ptr.is_null() {
+            return Some(*ptr);
+        }
+    }
+    let opref = ctx.registers_r.get(color).copied()?;
+    match ctx.trace_ctx.concrete_of_opref(opref) {
+        Some(Value::Ref(r)) if !r.is_null() => Some(r.as_usize() as pyre_object::PyObjectRef),
+        _ => None,
+    }
+}
+
+fn concrete_ref_for_opref(
+    ctx: &WalkContext<'_, '_>,
+    opref: OpRef,
+) -> Option<pyre_object::PyObjectRef> {
+    match ctx.trace_ctx.concrete_of_opref(opref) {
+        Some(Value::Ref(r)) => Some(r.as_usize() as pyre_object::PyObjectRef),
+        _ => None,
+    }
+}
+
+fn collect_call_stack_overrides(
+    caller_sym: &crate::state::PyreSym,
+    ctx: &WalkContext<'_, '_>,
+    call_py_pc: usize,
+) -> Vec<(usize, pyre_object::PyObjectRef)> {
+    if caller_sym.jitcode.is_null() {
+        return Vec::new();
+    }
+    let (nlocals, depth, pcdep_entries) = unsafe {
+        let jc = &*caller_sym.jitcode;
+        if jc.payload.code_ptr.is_null() {
+            return Vec::new();
+        }
+        let depth = crate::liveness::liveness_for(jc.payload.code_ptr)
+            .depth_at_py_pc()
+            .get(call_py_pc)
+            .copied()
+            .unwrap_or(0) as usize;
+        let pcdep = jc
+            .payload
+            .metadata
+            .pcdep_color_slots
+            .get(call_py_pc)
+            .cloned()
+            .unwrap_or_default();
+        (caller_sym.nlocals, depth, pcdep)
+    };
+    let stack_end = nlocals + depth;
+    if depth == 0 {
+        return Vec::new();
+    }
+    let mut overrides = Vec::new();
+    if ctx.vstack_valid && ctx.vstack_depth == depth && ctx.vstack_boxes.len() >= depth {
+        for d in 0..depth {
+            let slot = nlocals + d;
+            if let Some(value) = concrete_ref_for_opref(ctx, ctx.vstack_boxes[d]) {
+                overrides.push((slot, value));
+            }
+        }
+    }
+    let base = ctx
+        .trace_ctx
+        .virtualizable_info()
+        .map(|info| info.num_static_extra_boxes)
+        .unwrap_or(0);
+    for slot in nlocals..stack_end {
+        if overrides.iter().any(|&(present, _)| present == slot) {
+            continue;
+        }
+        if let Some((_opref, Value::Ref(value))) = ctx.trace_ctx.virtualizable_entry_at(base + slot)
+        {
+            if !value.is_null() {
+                overrides.push((slot, value.as_usize() as pyre_object::PyObjectRef));
+            }
+        }
+    }
+    if pcdep_entries.is_empty() {
+        for slot in nlocals..stack_end {
+            if overrides.iter().any(|&(present, _)| present == slot) {
+                continue;
+            }
+            if let Some(value) = concrete_ref_for_color(ctx, slot) {
+                overrides.push((slot, value));
+            }
+        }
+    } else {
+        for &(bank, color, slot) in &pcdep_entries {
+            let slot = slot as usize;
+            if bank == 1 && slot >= nlocals && slot < stack_end {
+                if overrides.iter().any(|&(present, _)| present == slot) {
+                    continue;
+                }
+                if let Some(value) = concrete_ref_for_color(ctx, color as usize) {
+                    overrides.push((slot, value));
+                }
+            }
+        }
+    }
+    overrides
+}
+
 fn compute_inline_caller_frame(
     ctx: &mut WalkContext<'_, '_>,
     call_jit_pc: usize,
@@ -12361,7 +12516,7 @@ fn compute_inline_caller_frame(
     if caller_sym.jitcode.is_null() {
         return Err(InlineCallerFrameDecline::Unavailable);
     }
-    let (jitcode_index, fallthrough_py_pc, resume_marker_jit_pc, code_ptr) = unsafe {
+    let (jitcode_index, call_py_pc, fallthrough_py_pc, resume_marker_jit_pc, code_ptr) = unsafe {
         let jc = &*caller_sym.jitcode;
         if jc.payload.code_ptr.is_null() || !jc.payload.is_populated() {
             return Err(InlineCallerFrameDecline::Unavailable);
@@ -12377,6 +12532,7 @@ fn compute_inline_caller_frame(
         let fallthrough = crate::pyjitpl::semantic_fallthrough_pc(code, call_py) as u32;
         (
             jc.index as u32,
+            call_py as u32,
             fallthrough,
             jc.payload.after_residual_marker_for_jitcode_pc(call_jit_pc),
             jc.payload.code_ptr,
@@ -12393,6 +12549,7 @@ fn compute_inline_caller_frame(
     if depth == 0 {
         return Err(InlineCallerFrameDecline::Unavailable);
     }
+    let call_stack_overrides = collect_call_stack_overrides(caller_sym, ctx, call_py_pc as usize);
     // #73: the result slot's color comes from the codewriter-precomputed
     // `result_color_at_pc` (top-of-stack color at the return pc), not the flat
     // `stack_slot_color_map` — the result is not a live Variable here, so it
@@ -12458,6 +12615,8 @@ fn compute_inline_caller_frame(
     }
     Ok(InlineParentFrame {
         jitcode_index,
+        call_py_pc: Some(call_py_pc),
+        call_stack_overrides,
         resume_py_pc: fallthrough_py_pc,
         resume_marker_jit_pc,
         boxes,
@@ -12568,6 +12727,8 @@ fn compute_nested_inline_caller_frame(
     };
     Ok(InlineParentFrame {
         jitcode_index,
+        call_py_pc: Some(call_py as u32),
+        call_stack_overrides: Vec::new(),
         resume_py_pc: fallthrough_py_pc,
         resume_marker_jit_pc,
         boxes,

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -6217,14 +6217,12 @@ fn try_execute_residual_call_via_executor(
     // None ref, so it is not a void call yet still mutates) — eager-everything +
     // commit is the single consistent rule, matching `do_residual_call`.
     //
-    // pyjitpl.py:3329-3330 `vinfo.tracing_before_residual_call(virtualizable)`
-    // heap half: every decline gate has passed, so the helper WILL execute —
-    // set TOKEN_TRACING_RESCALL on the active virtualizable so a force
-    // inside the callee is observable afterwards.  Trait mirror:
-    // `MIFrame::vable_and_vrefs_before_residual_call` (trace_opcode.rs:2602).
-    // Skipped for non-forces opcodes and when no live vable exists (the
-    // jitdriver has no standard virtualizable, or unit-test init disabled
-    // the heap pointer) — nothing the callee could force.
+    // The standard virtualizable box pointer for a MayForce residual — a
+    // force inside the callee could escape the frame.  None for non-forces
+    // opcodes and when no live vable exists (the jitdriver has no standard
+    // virtualizable, or unit-test init disabled the heap pointer) — nothing
+    // the callee could force.  The token is armed further below, past every
+    // decline gate.
     let vable_obj_ptr = if is_may_force {
         ctx.trace_ctx
             .standard_virtualizable_box()
@@ -6234,10 +6232,6 @@ fn try_execute_residual_call_via_executor(
     } else {
         None
     };
-    if let Some(obj_ptr) = vable_obj_ptr {
-        let info = crate::frame_layout::build_pyframe_virtualizable_info();
-        unsafe { info.tracing_before_residual_call(obj_ptr) };
-    }
     // A Python-level callee (e.g. a recursive `fib`) re-enters the
     // interpreter (`eval_loop_jit` → `jit_merge_point`) while this walk still
     // holds the driver in the tracing state.  Suspend re-entrant trace
@@ -6326,6 +6320,20 @@ fn try_execute_residual_call_via_executor(
     // on an empty session framestack, so top-level depth-1 behavior is unchanged.
     if !provably_side_effect_free {
         fbw_abort_nested_unjournaled_residual(ctx, op_pc)?;
+    }
+    // pyjitpl.py:3329-3330 `vinfo.tracing_before_residual_call(virtualizable)`
+    // heap half: every decline gate has now passed, so the helper WILL
+    // execute — set TOKEN_TRACING_RESCALL on the active virtualizable so a
+    // force inside the callee is observable afterwards.  Armed AFTER the
+    // inline-subwalk decline so a declined residual never strands the token:
+    // tracing_before pairs with the tracing_after clear below only for
+    // residuals that proceed, mirroring `do_residual_call` where
+    // `vable_and_vrefs_before_residual_call` (pyjitpl.py:2017) runs only past
+    // the OS_NOT_IN_TRACE / force-virtual short-circuits.  Trait mirror:
+    // `MIFrame::vable_and_vrefs_before_residual_call` (trace_opcode.rs:2602).
+    if let Some(obj_ptr) = vable_obj_ptr {
+        let info = crate::frame_layout::build_pyframe_virtualizable_info();
+        unsafe { info.tracing_before_residual_call(obj_ptr) };
     }
     let body_effect_candidate =
         !provably_side_effect_free && writes_live_heap && fbw_foriter_inflight_active();
@@ -8937,16 +8945,28 @@ fn fbw_abort_nested_unjournaled_residual(
     Ok(())
 }
 
-/// Take the top-level caller CALL pc and stack slots stashed by
-/// [`fbw_abort_nested_unjournaled_residual`].
-pub(crate) fn fbw_abort_outer_resume_take()
--> Option<(usize, Vec<(usize, pyre_object::PyObjectRef)>)> {
-    let pc = FBW_ABORT_OUTER_RESUME_PY_PC.with(|c| c.replace(None))?;
-    let stack_overrides = FBW_ABORT_OUTER_STACK_OVERRIDES.with(|c| {
-        let mut slots = c.borrow_mut();
-        std::mem::take(&mut *slots)
-    });
-    Some((pc, stack_overrides))
+/// Take the outer-caller resume pc stashed by
+/// [`fbw_abort_nested_unjournaled_residual`].  The stack overrides stay in
+/// `FBW_ABORT_OUTER_STACK_OVERRIDES` (rooted by the #447 area walker,
+/// `abort_overrides`) until [`fbw_abort_outer_stack_overrides_clear`]; the
+/// flush reads them in place from the rooted cell so a minor collection while
+/// boxing Int/Float locals forwards the very refs it writes.
+pub(crate) fn fbw_abort_outer_resume_take() -> Option<usize> {
+    FBW_ABORT_OUTER_RESUME_PY_PC.with(|c| c.replace(None))
+}
+
+/// Run `f` with the rooted outer-frame stack overrides borrowed in place.
+/// A GC during `f` forwards the cell's ref slots via the area walker's
+/// `as_ptr` access, so the borrowed slice observes the forwarded values.
+pub(crate) fn fbw_abort_outer_stack_overrides_with<R>(
+    f: impl FnOnce(&[(usize, pyre_object::PyObjectRef)]) -> R,
+) -> R {
+    FBW_ABORT_OUTER_STACK_OVERRIDES.with(|c| f(&c.borrow()))
+}
+
+/// Clear the outer-frame stack overrides after the flush consumed them.
+pub(crate) fn fbw_abort_outer_stack_overrides_clear() {
+    FBW_ABORT_OUTER_STACK_OVERRIDES.with(|c| c.borrow_mut().clear());
 }
 
 /// Clear the nested inline abort resume latch at a walk boundary.

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -6369,6 +6369,9 @@ fn try_execute_residual_call_via_executor(
         let _suspend = majit_metainterp::TraceContinuationSuspendGuard::enter();
         majit_metainterp::executor::execute_residual_call(call_descr, func_ptr, &args)
     };
+    if !provably_side_effect_free {
+        fbw_mark_executed_nonpure_residual();
+    }
     ctx.trace_ctx
         .set_virtualizable_heap_ptr(saved_vable_heap_ptr.unwrap_or(std::ptr::null()));
     // pyjitpl.py:3349-3353 `vinfo.tracing_after_residual_call(virtualizable)`
@@ -7716,6 +7719,12 @@ thread_local! {
     /// journal never strands into a guard-state re-run.  Cleared after
     /// every bridge walk.
     static FBW_BRIDGE_NOREPLAY_ARMED: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+
+    /// Set when this walk concretely executed a residual call that is not
+    /// provably side-effect-free. Such a residual may have committed a heap
+    /// effect outside the FBW journals; later exit handling must not replay it.
+    static FBW_EXECUTED_NONPURE_RESIDUAL: std::cell::Cell<bool> =
+        const { std::cell::Cell::new(false) };
 }
 
 /// Terminal disposition of a walk kept for the no-replay exit:
@@ -7762,6 +7771,23 @@ pub fn fbw_bridge_noreplay_arm(armed: bool) {
 /// current walk (read by the `run_perfn_walk` epilogue predicate).
 pub(crate) fn fbw_bridge_noreplay_armed() -> bool {
     FBW_BRIDGE_NOREPLAY_ARMED.with(|c| c.get())
+}
+
+/// Record that the current walk concretely executed a residual which could
+/// have committed non-journaled heap state.
+pub(crate) fn fbw_mark_executed_nonpure_residual() {
+    FBW_EXECUTED_NONPURE_RESIDUAL.with(|c| c.set(true));
+}
+
+/// Whether the current walk has concretely executed a non-provably-pure
+/// residual.
+pub(crate) fn fbw_executed_nonpure_residual() -> bool {
+    FBW_EXECUTED_NONPURE_RESIDUAL.with(|c| c.get())
+}
+
+/// Clear the executed-residual latch at a walk boundary.
+pub(crate) fn fbw_executed_nonpure_residual_reset() {
+    FBW_EXECUTED_NONPURE_RESIDUAL.with(|c| c.set(false));
 }
 
 /// Whether `PYRE_FBW_DEBUG_ABORT` is set.  When on, `full_body_walk_trace`

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -6310,6 +6310,9 @@ fn try_execute_residual_call_via_executor(
                 | majit_ir::PyreHelperKind::SetCurrentException
                 | majit_ir::PyreHelperKind::StoreDeref
         );
+    if writes_live_heap && !provably_side_effect_free {
+        fbw_abort_nested_unjournaled_residual(op_pc)?;
+    }
     let body_effect_candidate =
         !provably_side_effect_free && writes_live_heap && fbw_foriter_inflight_active();
     // #57 Option C (Finding #1, user-frame signal): the Void/helper-tag write

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -7449,6 +7449,15 @@ thread_local! {
         const { std::cell::Cell::new(None) };
     static FBW_ABORT_OUTER_STACK_OVERRIDES: std::cell::RefCell<Vec<(usize, pyre_object::PyObjectRef)>> =
         const { std::cell::RefCell::new(Vec::new()) };
+    /// Raw pointer to the walk session whose framestack currently holds
+    /// inline frames, for [`fbw_store_journal_root_walker`]: the session
+    /// lives on the walk driver's Rust stack, which the GC cannot scan, and
+    /// each `InlineParentFrame::call_stack_overrides` slot holds a
+    /// nursery-resident ref across residual-call allocations.  Set by
+    /// [`InlineFrameGuard::enter`] and restored on drop; null outside any
+    /// inline sub-walk.
+    static ACTIVE_WALK_SESSION: std::cell::Cell<*const std::cell::RefCell<WalkSession>> =
+        const { std::cell::Cell::new(std::ptr::null()) };
 }
 
 impl<'a> InlineFrameGuard<'a> {
@@ -7461,13 +7470,18 @@ impl<'a> InlineFrameGuard<'a> {
             .borrow_mut()
             .framestack
             .push(InlineFrame { w_code, parent });
+        ACTIVE_WALK_SESSION.with(|c| c.set(session as *const _));
         InlineFrameGuard(session)
     }
 }
 
 impl Drop for InlineFrameGuard<'_> {
     fn drop(&mut self) {
-        self.0.borrow_mut().framestack.pop();
+        let mut session = self.0.borrow_mut();
+        session.framestack.pop();
+        if session.framestack.is_empty() {
+            ACTIVE_WALK_SESSION.with(|c| c.set(std::ptr::null()));
+        }
     }
 }
 
@@ -7677,6 +7691,21 @@ pub(crate) fn fbw_inline_nsfold_enabled() -> bool {
             v != "0" && !v.eq_ignore_ascii_case("false")
         }
         None => true,
+    })
+}
+
+/// `PYRE_FBW_CALLEE_VSTACK` (default OFF) — maintain a callee-local
+/// operand-stack mirror while walking an inline sub-call.  The callee enters
+/// with an empty operand stack; subsequent boundaries must use the active
+/// callee jitcode metadata rather than the outer full-body tables.
+fn fbw_callee_vstack_enabled() -> bool {
+    static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ENABLED.get_or_init(|| match std::env::var_os("PYRE_FBW_CALLEE_VSTACK") {
+        Some(v) => {
+            let v = v.to_string_lossy();
+            v != "0" && !v.eq_ignore_ascii_case("false")
+        }
+        None => false,
     })
 }
 
@@ -9464,12 +9493,13 @@ fn reconcile_vstack_at_boundary(
     // with the NONE slot left in place; `stack_sync` (USE) defers any NONE
     // mirror slot to the legacy read.
     if ctx.vstack_valid {
+        let skip_shadow_fill = ctx.fbw_mode.inline_subwalk && fbw_callee_vstack_enabled();
         let hole = ctx
             .vstack_boxes
             .get(..new_depth)
             .map(|s| s.iter().any(|&b| b == OpRef::NONE))
             .unwrap_or(true);
-        if hole {
+        if hole && !skip_shadow_fill {
             // Best-effort fill from the shadow; leave un-fillable slots NONE.
             let _ = reseed_vstack_from_shadow(ctx, new_depth);
         }
@@ -9634,47 +9664,70 @@ fn step_vstack_mirror(ctx: &mut WalkContext<'_, '_>, jit_pc: usize) {
     }
     // Inside an inline sub-walk the `jit_pc` is a CALLEE coordinate that
     // does not exist in the outer (`fbw_mode.snapshot_sym`) jitcode's
-    // py_pc→jitcode tables, so `python_pc_for_jitcode_pc` would return garbage
-    // and a
-    // callee `write_ref_reg` would clobber `vstack_last_ref`.  Decline the
-    // whole mirror for any walk that inlines a Python call — the benches
-    // this targets (short-circuit `or`/`and` chains) are call-free, and
-    // declining is a clean fallback to the legacy read.
-    if ctx.fbw_mode.inline_subwalk {
-        ctx.vstack_valid = false;
-        return;
-    }
-    let full_body_sym = ctx.fbw_mode.snapshot_sym;
-    if full_body_sym.is_null() {
-        return;
-    }
-    // SAFETY: the pointer is live for the lifetime of the full-body walk
-    // (set in `dispatch_via_miframe`); read-only access to immutable
-    // layout fields (jitcode / code_ptr / metadata).
-    let sym = unsafe { &*full_body_sym };
-    if sym.jitcode.is_null() {
-        return;
-    }
-    let (new_pypc, code_ptr) = unsafe {
-        let jc = &*sym.jitcode;
-        if jc.payload.code_ptr.is_null() {
+    // py_pc→jitcode tables.  Without the `PYRE_FBW_CALLEE_VSTACK` gate the
+    // mirror declines (a callee `write_ref_reg` would clobber
+    // `vstack_last_ref`); with it, the coordinate is resolved through the
+    // active callee jitcode metadata instead.
+    let (new_pypc, code_ptr, new_depth) = if ctx.fbw_mode.inline_subwalk {
+        if !fbw_callee_vstack_enabled() {
+            ctx.vstack_valid = false;
             return;
         }
-        (
-            vstack_containing_py_pc(&jc.payload.metadata, jit_pc),
-            jc.payload.code_ptr,
-        )
+        let Some(frame) = ActiveResumeFrame::current(ctx.session, ctx.fbw_mode.snapshot_sym)
+        else {
+            ctx.vstack_valid = false;
+            return;
+        };
+        let Some(coord) = frame.vstack_coordinate_for_jitcode_pc(jit_pc) else {
+            ctx.vstack_valid = false;
+            return;
+        };
+        coord
+    } else {
+        let full_body_sym = ctx.fbw_mode.snapshot_sym;
+        if full_body_sym.is_null() {
+            return;
+        }
+        // SAFETY: the pointer is live for the lifetime of the full-body walk
+        // (set in `dispatch_via_miframe`); read-only access to immutable
+        // layout fields (jitcode / code_ptr / metadata).
+        let sym = unsafe { &*full_body_sym };
+        if sym.jitcode.is_null() {
+            return;
+        }
+        unsafe {
+            let jc = &*sym.jitcode;
+            if jc.payload.code_ptr.is_null() {
+                return;
+            }
+            let py_pc = vstack_containing_py_pc(&jc.payload.metadata, jit_pc);
+            let depth = crate::liveness::liveness_for(jc.payload.code_ptr)
+                .depth_at_py_pc()
+                .get(py_pc as usize)
+                .copied()
+                .unwrap_or(0) as usize;
+            (py_pc, jc.payload.code_ptr, depth)
+        }
     };
     if new_pypc == ctx.vstack_cur_pypc {
         return;
     }
     let code = unsafe { &*code_ptr };
-    let new_depth = crate::liveness::liveness_for(code_ptr)
-        .depth_at_py_pc()
-        .get(new_pypc as usize)
-        .copied()
-        .unwrap_or(0) as usize;
     reconcile_vstack_at_boundary(ctx, code, new_pypc, new_depth);
+}
+
+fn seed_callee_vstack_mirror(ctx: &mut WalkContext<'_, '_>, frame: &ActiveResumeFrame) {
+    if !fbw_callee_vstack_enabled() {
+        return;
+    }
+    let Some((first_pypc, _code_ptr, _depth)) = frame.vstack_coordinate_for_jitcode_pc(0) else {
+        return;
+    };
+    ctx.vstack_boxes.clear();
+    ctx.vstack_depth = 0;
+    ctx.vstack_cur_pypc = first_pypc;
+    ctx.vstack_last_ref = OpRef::NONE;
+    ctx.vstack_valid = true;
 }
 
 /// #73 (SLICE 1, INERT): seed the walk-level operand-stack box mirror
@@ -10597,6 +10650,28 @@ impl ActiveResumeFrame {
             }
             None => Self::outer(snapshot_sym),
         }
+    }
+
+    fn vstack_coordinate_for_jitcode_pc(
+        &self,
+        jit_pc: usize,
+    ) -> Option<(u32, *const pyre_interpreter::CodeObject, usize)> {
+        let pjc = &self.0;
+        if pjc.code_ptr.is_null() {
+            return None;
+        }
+        let py_pc = vstack_containing_py_pc(&pjc.metadata, jit_pc);
+        let depth = crate::liveness::liveness_for(pjc.code_ptr)
+            .depth_at_py_pc()
+            .get(py_pc as usize)
+            .copied()
+            .unwrap_or(0) as usize;
+        Some((py_pc, pjc.code_ptr, depth))
+    }
+
+    fn body_matches(&self, sub_body: &SubJitCodeBody) -> bool {
+        let code = self.0.jitcode.code.as_slice();
+        code.len() == sub_body.code.len() && code.as_ptr() == sub_body.code.as_ptr()
     }
 }
 
@@ -15195,6 +15270,11 @@ fn try_walker_inline_user_call(
         // Track this callee for the lifetime of the sub-walk so nested
         // self-calls see the correct recursion depth.
         let _inline_frame = InlineFrameGuard::enter(ctx.session, callee_code_key, parent_frame);
+        if let Some(frame) = ActiveResumeFrame::current(ctx.session, ctx.fbw_mode.snapshot_sym) {
+            if frame.body_matches(&body) {
+                seed_callee_vstack_mirror(&mut sub_wc, &frame);
+            }
+        }
         // Strict fresh-frame fold: a branchless leaf inlined without a virtual
         // frame (not `try_multiframe`) whose body carries the Portal
         // frame-vable locals prologue resolves its own `getarrayitem_vable_r` /
@@ -21646,6 +21726,11 @@ fn run_sub_jitcode_walk(
             live_before_jit_pc: usize::MAX,
             live_after_jit_pc: usize::MAX,
         };
+        if let Some(frame) = ActiveResumeFrame::current(ctx.session, ctx.fbw_mode.snapshot_sym) {
+            if frame.body_matches(sub_body) {
+                seed_callee_vstack_mirror(&mut sub_wc, &frame);
+            }
+        }
         walk(sub_body.code, 0, &mut sub_wc)?
     };
     Ok(callee_outcome)

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -7170,22 +7170,30 @@ fn collect_outer_active_boxes(
         );
         // Portal-red routing applies only to the force-alived SCRATCH case
         // (`filter_liveness_in_place` keeps `portal_frame_reg`/`portal_ec_reg`
-        // in every `-live-` R-bank even where the color carries no value).
-        // The jitcode register allocator ALSO assigns these colors to real
-        // frame slots at other PCs (e.g. a call-result register live across a
-        // later call), where `pcdep_color_slots` maps the color to a semantic
-        // slot.  Routing such a colliding color to `sym.frame`/
-        // `sym.execution_context` encodes the wrong box: the blackhole then
-        // resumes the slot's register with the EC and feeds it to the slot's
-        // consumer (`fib(n-1) + fib(n-2)` resumed the left operand as the EC
-        // → SIGSEGV).  A color that names a live semantic slot takes the
-        // normal slot-value paths below; the EC stays recoverable from the
-        // frame (`ensure_execution_context` getfield).
+        // in every `-live-` R-bank even where the color names no frame slot).
+        // If the walk's live register bank already carries a real box, snapshot
+        // that box first: it is the direct `get_list_of_active_boxes`
+        // (`pyjitpl.py:222`) source for this live color, and bridge resume uses
+        // the same color-indexed bank to recover the EC red (`state.rs:1748`).
+        // Fall back to the named red field only when the bank is empty.  If both
+        // are empty, the force-alived red is dead at this capture point, so encode
+        // `CONST_NULL` (history.py:361), matching the union-liveness arm below.
+        //
+        // The jitcode register allocator ALSO assigns these colors to real frame
+        // slots at other PCs (e.g. a call-result register live across a later
+        // call), where `pcdep_color_slots` maps the color to a semantic slot.
+        // Routing such a colliding color to `sym.frame`/`sym.execution_context`
+        // encodes the wrong box; a color that names a live semantic slot therefore
+        // takes the normal slot-value paths below.
         let is_portal_red_scratch = semantic_idx.is_none()
             && ((color as u16 == portal_frame_reg && portal_frame_reg != u16::MAX)
                 || (color as u16 == portal_ec_reg && portal_ec_reg != u16::MAX));
         let value = if is_portal_red_scratch {
-            if color as u16 == portal_frame_reg {
+            let live_reg = regs_r
+                .get(color)
+                .copied()
+                .filter(|&v| v != OpRef::NONE && !opref_is_null_const_ptr(v));
+            let red_field = if color as u16 == portal_frame_reg {
                 sym.frame
             } else if !sym.execution_context.is_none() {
                 // EC red already seeded on this snapshot path.
@@ -7222,7 +7230,13 @@ fn collect_outer_active_boxes(
                 // downstream Ref-bank NONE guard surfaces the unrecoverable case
                 // instead of silently masking it.
                 sym.execution_context
-            }
+            };
+            live_reg
+                .or_else(|| {
+                    (red_field != OpRef::NONE && !opref_is_null_const_ptr(red_field))
+                        .then_some(red_field)
+                })
+                .unwrap_or_else(|| OpRef::const_ptr(majit_ir::GcRef(0)))
         } else if owns_vable {
             match semantic_idx {
                 Some(s_idx) if s_idx < nlocals + valid_stack_only => {

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -5907,6 +5907,13 @@ fn try_execute_residual_call_via_executor(
     recorded: OpRef,
     op_pc: usize,
 ) -> Result<ResidualExecOutcome, DispatchError> {
+    // `execute_varargs` clears the metainterp exception slot at residual-call
+    // entry, before the helper can either run or leave the call recorded
+    // symbolically. A handled exception from an earlier opcode must not survive
+    // across the back edge and make a later linear `catch_exception/L` look like
+    // it is handling a fresh raise.
+    clear_walk_exception(ctx);
+
     // Orthodox sub-jitcode walk safety (#171 wall-5d): a residual call whose
     // funcbox is a `symbolic_fnaddr` placeholder — a 64-bit `DefaultHasher`
     // hash of an in-body helper's `CallPath`/`CallTarget`, minted when
@@ -6470,20 +6477,6 @@ fn try_execute_residual_call_via_executor(
     match exec_result {
         Ok(result_i64) => {
             fbw_count_executed_residual(is_void, is_may_force);
-            // `pyjitpl.py:1685-1690 _opimpl_residual_call*` finishes its
-            // success arm with `metainterp.clear_exception()` (called
-            // implicitly through `do_residual_call`'s no-raise tail).
-            // Pyre's `ctx.last_exc_value` carries a sticky `OpRef` /
-            // concrete pointer from any prior raising helper in the
-            // same walk; if a later non-raising residual call did not
-            // clear it, downstream consumers (`last_exc_value/>r`,
-            // `reraise/`, `catch_exception/L`) would read the stale
-            // value as if a fresh exception had just landed.  Mirror
-            // `clear_exception()` here so the success arm only
-            // surfaces an active exception when the *current* call
-            // raised.
-            ctx.last_exc_value = None;
-            ctx.last_exc_value_concrete = ConcreteValue::Null;
             // #57 (Finding #1): the in-place int-list extend committed; journal
             // its pre-extend length so an aborting walk's rollback rewinds it and
             // the deliver re-applies it exactly once.  `result_i64 == lhs`
@@ -13054,6 +13047,11 @@ fn walker_record_guard_exception(ctx: &mut WalkContext<'_, '_>, pc: usize) {
     let _ = walker_capture_snapshot_for_last_guard(ctx, pc);
 }
 
+fn clear_walk_exception(ctx: &mut WalkContext<'_, '_>) {
+    ctx.last_exc_value = None;
+    ctx.last_exc_value_concrete = ConcreteValue::Null;
+}
+
 fn direct_call_release_gil(
     ctx: &mut WalkContext<'_, '_>,
     ei: &majit_ir::EffectInfo,
@@ -15531,6 +15529,11 @@ fn dispatch_residual_call_iRd_kind(
     };
 
     let ei = call_descr.get_extra_info();
+    // Residual-call entry mirrors `execute_varargs`: even when the walker
+    // folds the call or leaves it recorded symbolically, stale handled
+    // exceptions from earlier opcodes are not visible to the following
+    // linear `catch_exception/L`.
+    clear_walk_exception(ctx);
 
     // #62 slice (3c): attempt full-body-walk inline of a user-function call
     // (dev-gated PYRE_FBW_INLINE).  Eligible exact-positional closure-free
@@ -20756,6 +20759,7 @@ fn dispatch_residual_call_iIRd_kind(
     let allboxes = build_allboxes(funcptr, &argboxes, &argbox_types, call_descr.arg_types());
 
     let ei = call_descr.get_extra_info();
+    clear_walk_exception(ctx);
     // pyjitpl.py:2003-2005 OS_NOT_IN_TRACE guard — see helper docstring
     // for the convergence rationale.
     if let Some(outcome) = do_not_in_trace_call_result(ei, op.pc)? {
@@ -21338,6 +21342,7 @@ fn dispatch_residual_call_iIRFd_kind(
     ensure_residual_call_args_bound(&allboxes, op.pc)?;
 
     let ei = call_descr.get_extra_info();
+    clear_walk_exception(ctx);
     if let Some(outcome) = do_not_in_trace_call_result(ei, op.pc)? {
         return Ok((outcome, op.next_pc));
     }

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -7235,12 +7235,15 @@ fn collect_outer_active_boxes(
                         // `write_ref_reg` mirror was retired: outside a
                         // branch guard's own per-PC color map, the walk
                         // register may hold a stale value from a prior SSA def
-                        // that shared the color.  Keep the shadow-first order
-                        // by default.  Under `PYRE_FBW_STACK_LIVEREG`, prefer
-                        // the live register only when the guard PC's
+                        // that shared the color.  Prefer the live register
+                        // (the upstream source) when the guard PC's
                         // `pcdep_color_slots` proves this color owns the same
-                        // stack slot at the guard capture point; otherwise the
-                        // virtualizable shadow remains authoritative.
+                        // stack slot at the guard capture point — there the
+                        // register read means exactly `registers_r[index]`;
+                        // where ownership is unprovable the virtualizable
+                        // shadow remains authoritative
+                        // (`PYRE_FBW_STACK_LIVEREG=0` restores shadow-first
+                        // everywhere).
                         let shadow_is_real = vbox.is_some_and(|b| !opref_is_null_const_ptr(b));
                         let walk_real =
                             walk_box.filter(|&v| v != OpRef::NONE && !opref_is_null_const_ptr(v));
@@ -7750,9 +7753,11 @@ fn fbw_callee_vstack_enabled() -> bool {
     })
 }
 
-/// `PYRE_FBW_STACK_LIVEREG` (default OFF) — for branch-guard operand-stack
-/// snapshot slots, prefer the live Ref register when the guard PC's per-PC
-/// color map proves that color owns the same stack slot.
+/// `PYRE_FBW_STACK_LIVEREG` (default ON) — for branch-guard operand-stack
+/// snapshot slots, prefer the live Ref register (`pyjitpl.py:222`
+/// `get_list_of_active_boxes` reads `self.registers_r[index]`) when the
+/// guard PC's per-PC color map proves that color owns the same stack slot.
+/// `=0` restores the shadow-first pyre-local order everywhere.
 fn fbw_stack_livereg_enabled() -> bool {
     static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
     *ENABLED.get_or_init(|| match std::env::var_os("PYRE_FBW_STACK_LIVEREG") {
@@ -7760,7 +7765,7 @@ fn fbw_stack_livereg_enabled() -> bool {
             let v = v.to_string_lossy();
             v != "0" && !v.eq_ignore_ascii_case("false")
         }
-        None => false,
+        None => true,
     })
 }
 

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -6266,7 +6266,7 @@ fn try_execute_residual_call_via_executor(
     // concretely, succeed, and carry `PyreHelperKind::None` (`store_attr_fn` /
     // `delete_subscr_fn` / `delete_attr_fn` / `list_extend_fn` / `store_name_fn`
     // / `store_global` / `store_slice` …): a missed mutator is a silent double
-    // on a body re-run (correctness-FATAL).  Flag any residual that WRITES live
+    // on a body re-run (correctness-FATAL).  Track residuals that WRITE live
     // heap state outside the journals.
     //
     // The write discriminator is the residual's RESULT TYPE plus the
@@ -6310,7 +6310,12 @@ fn try_execute_residual_call_via_executor(
                 | majit_ir::PyreHelperKind::SetCurrentException
                 | majit_ir::PyreHelperKind::StoreDeref
         );
-    if writes_live_heap && !provably_side_effect_free {
+    // Inside an inline sub-walk, decline before any residual that is not
+    // provably side-effect-free.  Ref-result getters/dunders/user `__next__`
+    // can mutate live heap through user frames while `writes_live_heap` is
+    // false, and rollback would miss that concrete mutation.  The helper no-ops
+    // outside `FBW_INLINE_CODE_STACK`, so top-level depth-1 behavior is unchanged.
+    if !provably_side_effect_free {
         fbw_abort_nested_unjournaled_residual(op_pc)?;
     }
     let body_effect_candidate =

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -23172,6 +23172,7 @@ fn handle(
             let result = OpRef::ConstInt(value);
             if ctx.is_top_level {
                 if fbw_call_assembler_enabled() {
+                    fbw_finish_concrete_set(ConcreteValue::Int(value));
                     fbw_terminate_with_finish(ctx, result, op.pc)?;
                 } else {
                     ctx.trace_ctx
@@ -23202,6 +23203,9 @@ fn handle(
                     // Slice b: portal-exit FINISH carries Type::Ref;
                     // `fbw_ensure_boxed_for_ca` re-boxes the float via
                     // wrapfloat.
+                    if let Some(majit_ir::Value::Float(v)) = ctx.trace_ctx.box_value(result) {
+                        fbw_finish_concrete_set(ConcreteValue::Float(v));
+                    }
                     fbw_terminate_with_finish(ctx, result, op.pc)?;
                 } else {
                     ctx.trace_ctx

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -7026,6 +7026,39 @@ fn collect_outer_active_boxes(
     };
     let pcdep_opt: Option<&[(u8, u16, u16)]> =
         (!pcdep_entries.is_empty()).then(|| pcdep_entries.as_slice());
+    let stack_livereg_gate = fbw_stack_livereg_enabled();
+    let (guard_pcdep_entries, guard_stack_only) = if stack_livereg_gate {
+        if let Some(gpc) = guard_py_pc {
+            if sym.jitcode.is_null() {
+                (Vec::new(), 0usize)
+            } else {
+                unsafe {
+                    let jc = &*sym.jitcode;
+                    let entries = jc
+                        .payload
+                        .metadata
+                        .pcdep_color_slots
+                        .get(gpc as usize)
+                        .cloned()
+                        .unwrap_or_default();
+                    let depth = if jc.payload.code_ptr.is_null() {
+                        0usize
+                    } else {
+                        crate::liveness::liveness_for(jc.payload.code_ptr)
+                            .depth_at_py_pc()
+                            .get(gpc as usize)
+                            .copied()
+                            .unwrap_or(0) as usize
+                    };
+                    (entries, depth)
+                }
+            }
+        } else {
+            (Vec::new(), 0usize)
+        }
+    } else {
+        (Vec::new(), 0usize)
+    };
     // Int / Float bank diagnostic panic: pyre's banks are sized to the
     // jitcode's `num_regs_X`, which the codewriter co-publishes with the
     // liveness side-table, so every liveness index is in range by
@@ -7197,26 +7230,34 @@ fn collect_outer_active_boxes(
                     let vbox = trace_ctx.virtualizable_box_at(nvs + s_idx);
                     let walk_box = regs_r.get(color).copied();
                     if s_idx >= nlocals {
-                        // Operand-stack slot.  The authoritative source is the
-                        // virtualizable shadow (`setarrayitem_vable_r` keeps it
-                        // current on every push/store).  The walk register file
-                        // (`registers_r[color]`) is NOT authoritative for stack
-                        // slots: stack-slot `write_ref_reg` was retired, so the
+                        // Operand-stack slot.  `pyjitpl.py:222` snapshots
+                        // `self.registers_r[index]`, but pyre's stack
+                        // `write_ref_reg` mirror was retired: outside a
+                        // branch guard's own per-PC color map, the walk
                         // register may hold a stale value from a prior SSA def
-                        // that shared the same color (e.g. a green scratch ref
-                        // like `pycode_var` whose tiny live range lets the
-                        // chordal coloring assign it the same color as an
-                        // iterator).  Read the shadow first; fall back to the
-                        // walk register only when the shadow slot is NULL
-                        // (a mid-opcode transient the portal never wrote).
+                        // that shared the color.  Keep the shadow-first order
+                        // by default.  Under `PYRE_FBW_STACK_LIVEREG`, prefer
+                        // the live register only when the guard PC's
+                        // `pcdep_color_slots` proves this color owns the same
+                        // stack slot at the guard capture point; otherwise the
+                        // virtualizable shadow remains authoritative.
                         let shadow_is_real = vbox.is_some_and(|b| !opref_is_null_const_ptr(b));
-                        if shadow_is_real {
+                        let walk_real =
+                            walk_box.filter(|&v| v != OpRef::NONE && !opref_is_null_const_ptr(v));
+                        let guard_pc_proves_slot = stack_livereg_gate
+                            && guard_py_pc.is_some()
+                            && crate::state::semantic_ref_slot_for_reg_color(
+                                nlocals,
+                                guard_stack_only,
+                                &guard_pcdep_entries,
+                                color,
+                            ) == Some(s_idx);
+                        if guard_pc_proves_slot {
+                            walk_real.or(vbox).unwrap_or_else(fallback)
+                        } else if shadow_is_real {
                             vbox.unwrap_or_else(fallback)
                         } else {
-                            match walk_box {
-                                Some(v) if v != OpRef::NONE && !opref_is_null_const_ptr(v) => v,
-                                _ => vbox.unwrap_or_else(fallback),
-                            }
+                            walk_real.unwrap_or_else(|| vbox.unwrap_or_else(fallback))
                         }
                     } else {
                         // At a branch guard the walk register is the live
@@ -7701,6 +7742,20 @@ pub(crate) fn fbw_inline_nsfold_enabled() -> bool {
 fn fbw_callee_vstack_enabled() -> bool {
     static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
     *ENABLED.get_or_init(|| match std::env::var_os("PYRE_FBW_CALLEE_VSTACK") {
+        Some(v) => {
+            let v = v.to_string_lossy();
+            v != "0" && !v.eq_ignore_ascii_case("false")
+        }
+        None => false,
+    })
+}
+
+/// `PYRE_FBW_STACK_LIVEREG` (default OFF) — for branch-guard operand-stack
+/// snapshot slots, prefer the live Ref register when the guard PC's per-PC
+/// color map proves that color owns the same stack slot.
+fn fbw_stack_livereg_enabled() -> bool {
+    static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ENABLED.get_or_init(|| match std::env::var_os("PYRE_FBW_STACK_LIVEREG") {
         Some(v) => {
             let v = v.to_string_lossy();
             v != "0" && !v.eq_ignore_ascii_case("false")

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -3754,7 +3754,7 @@ pub(crate) fn flush_walk_end_state_to_frame(
     frame: usize,
     resume_py_pc: usize,
 ) -> bool {
-    flush_walk_end_state_to_frame_with_item(ctx, frame, resume_py_pc, None)
+    flush_walk_end_state_to_frame_inner(ctx, frame, resume_py_pc, None, &[])
 }
 
 /// `flush_walk_end_state_to_frame` plus an optional in-flight FOR_ITER item
@@ -3769,6 +3769,25 @@ pub(crate) fn flush_walk_end_state_to_frame_with_item(
     frame: usize,
     resume_py_pc: usize,
     push: Option<(PyObjectRef, usize)>,
+) -> bool {
+    flush_walk_end_state_to_frame_inner(ctx, frame, resume_py_pc, push, &[])
+}
+
+pub(crate) fn flush_walk_end_state_to_frame_with_stack_overrides(
+    ctx: &TraceCtx,
+    frame: usize,
+    resume_py_pc: usize,
+    stack_overrides: &[(usize, PyObjectRef)],
+) -> bool {
+    flush_walk_end_state_to_frame_inner(ctx, frame, resume_py_pc, None, stack_overrides)
+}
+
+fn flush_walk_end_state_to_frame_inner(
+    ctx: &TraceCtx,
+    frame: usize,
+    resume_py_pc: usize,
+    push: Option<(PyObjectRef, usize)>,
+    stack_overrides: &[(usize, PyObjectRef)],
 ) -> bool {
     if frame == 0 {
         return false;
@@ -3828,10 +3847,21 @@ pub(crate) fn flush_walk_end_state_to_frame_with_item(
     }
     // Validation pass first: it allocates nothing, so entry presence
     // cannot change under it.  Commit only when every live slot resolves.
+    let stack_override_at = |abs: usize| -> Option<PyObjectRef> {
+        stack_overrides
+            .iter()
+            .find_map(|&(slot, value)| (slot == abs).then_some(value))
+    };
     for abs in 0..live {
         let Some((_opref, value)) = ctx.virtualizable_entry_at(base + abs) else {
             return false;
         };
+        if abs >= nlocals && !stack_overrides.is_empty() {
+            if stack_override_at(abs).is_none() {
+                return false;
+            }
+            continue;
+        }
         // An operand-STACK slot (`abs >= nlocals`) that resolves to a NULL Ref
         // is an UNPOPULATED shadow slot, not a live value: the virtualizable
         // shadow tracks locals/cells faithfully but its stack region is only
@@ -3870,7 +3900,11 @@ pub(crate) fn flush_walk_end_state_to_frame_with_item(
         let Some((_opref, value)) = ctx.virtualizable_entry_at(base + abs) else {
             return false;
         };
-        let boxed = boxed_slot_value_for_type(Type::Ref, &value);
+        let boxed = if abs >= nlocals {
+            stack_override_at(abs).unwrap_or_else(|| boxed_slot_value_for_type(Type::Ref, &value))
+        } else {
+            boxed_slot_value_for_type(Type::Ref, &value)
+        };
         unsafe {
             (*arr_ptr).as_mut_slice()[abs] = boxed;
         }

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -2629,6 +2629,7 @@ fn full_body_walk_trace(
     // aborted walk's top-level `*_return` arm may have stashed, so a stale
     // value cannot leak into this walk's `Terminate` handling.
     crate::jitcode_dispatch::fbw_finish_payload_reset();
+    crate::jitcode_dispatch::fbw_executed_nonpure_residual_reset();
     // Clear the prior walk's store journal + unjournaled-effect flag so
     // dropped (aborted) entries cannot be applied by this walk's commit.
     crate::jitcode_dispatch::fbw_store_journal_reset();

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -2162,51 +2162,44 @@ fn run_perfn_walk(
                 } else if let Some(resume_py_pc) =
                     crate::jitcode_dispatch::fbw_abort_resume_py_pc(sym, abort_jit_pc)
                 {
-                    // Shape A — the abort resumes AT a FOR_ITER header whose
-                    // consumed item is in flight (`body_pc == resume_py_pc + 1`,
-                    // and the opcode there really is a FOR_ITER): the walk
-                    // advanced the iterator but the item is not yet on the
-                    // flushed (header) stack, so deliver it (push + reposition to
-                    // the body) so the body runs once.
-                    let push = crate::jitcode_dispatch::fbw_foriter_inflight_take_for_resume(
-                        cf_addr,
-                        resume_py_pc,
-                    );
-                    // Commit ONLY for Shape A — the abort resumes at an
-                    // in-flight FOR_ITER header and an item is delivered.  This
-                    // keeps the leg strictly a FOR_ITER-continuation delivery: a
-                    // `BranchGuardUnrestorableKeptStackPermanent` that is not at
-                    // such a header (a non-FOR_ITER trace, or an in-flight item
-                    // whose header is not the resume pc — the consumed item then
-                    // sits between the header and the resume pc but is not on the
-                    // shadow stack, so adopting it would resume with a stale TOS
-                    // and re-run the loop) keeps the legacy drop byte-identically
-                    // (the residual S3 case).  So every other abort shape is
-                    // untouched, including the entire flag-OFF path.
-                    // Shape A' (#493, `Unsupported` variant only) — the abort
-                    // resumes AT a FOR_ITER header whose in-flight entry is
-                    // body-COMPLETED: the abort fired during the NEXT consume
-                    // attempt (a kept-stack guard on the FOR_ITER arms after
-                    // the `for_iter_next` residual), so the item's body already
-                    // ran and delivery would double it.  The walk end state at
-                    // the header is the complete post-body state — adopt it
-                    // WITHOUT delivery; the interpreter re-attempts the consume
-                    // against the advanced iterator.  Replaces the legacy
-                    // replay-from-entry, which re-executes every residual the
-                    // walk already ran.
-                    let flush_completed_header = push.is_none()
-                        && is_unsupported
-                        && crate::jitcode_dispatch::fbw_foriter_inflight_completed_at_resume(
+                    // Two kept-stack branch aborts reach this leg (`is_unsupported`
+                    // came from the `kept_stack_abort_pc` match).  Both resume at a
+                    // FOR_ITER header whose walk already advanced the iterator; they
+                    // differ in whether the consumed item's body ran.
+                    let committed = if is_unsupported {
+                        // `BranchGuardKeptStackUnsupported` aborts AFTER the body
+                        // ran for the consumed item (the depth>1 kept operand stack
+                        // the COMPILED trace could not restore); the walk's
+                        // symbolic shadow already counted that iteration.  Resume
+                        // at the FOR_ITER header on the flushed end state WITHOUT
+                        // re-delivering the in-flight item — delivering it would
+                        // re-run the body and double-count the value.  A plain
+                        // end-state flush, gated the same as the marker leg.
+                        crate::state::flush_walk_end_state_to_frame(ctx, cf_addr, resume_py_pc)
+                    } else {
+                        // Shape A — a `BranchGuardUnrestorableKeptStackPermanent`
+                        // abort resumes AT a FOR_ITER header whose consumed item is
+                        // in flight (`body_pc == resume_py_pc + 1`, the opcode
+                        // there really is a FOR_ITER): the walk advanced the
+                        // iterator but the item is not yet on the flushed (header)
+                        // stack, so deliver it (push + reposition to the body) so
+                        // the body runs once.  Commit ONLY when an item is
+                        // delivered — a Permanent abort not at such a header keeps
+                        // the legacy drop byte-identically (the residual S3 case),
+                        // so every other abort shape (and the whole flag-OFF path)
+                        // is untouched.
+                        let push = crate::jitcode_dispatch::fbw_foriter_inflight_take_for_resume(
                             cf_addr,
                             resume_py_pc,
                         );
-                    let committed = (push.is_some() || flush_completed_header)
-                        && crate::state::flush_walk_end_state_to_frame_with_item(
-                            ctx,
-                            cf_addr,
-                            resume_py_pc,
-                            push,
-                        );
+                        push.is_some()
+                            && crate::state::flush_walk_end_state_to_frame_with_item(
+                                ctx,
+                                cf_addr,
+                                resume_py_pc,
+                                push,
+                            )
+                    };
                     if committed {
                         // The flush owns the iteration count; drop any remaining
                         // in-flight items so the legacy deliver cannot re-apply

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -2089,15 +2089,26 @@ fn run_perfn_walk(
                              (unjournaled effect) — legacy replay kept"
                         );
                     }
-                } else if let Some((resume_py_pc, stack_overrides)) =
+                } else if let Some(resume_py_pc) =
                     crate::jitcode_dispatch::fbw_abort_outer_resume_take()
                 {
-                    if crate::state::flush_walk_end_state_to_frame_with_stack_overrides(
-                        ctx,
-                        cf_addr,
-                        resume_py_pc,
-                        &stack_overrides,
-                    ) {
+                    // Flush while the overrides stay rooted in
+                    // FBW_ABORT_OUTER_STACK_OVERRIDES (the flush boxes Int/Float
+                    // locals — an allocation that can move the nursery-resident
+                    // override refs; the area walker forwards them in place),
+                    // then clear the cell.
+                    let committed = crate::jitcode_dispatch::fbw_abort_outer_stack_overrides_with(
+                        |stack_overrides| {
+                            crate::state::flush_walk_end_state_to_frame_with_stack_overrides(
+                                ctx,
+                                cf_addr,
+                                resume_py_pc,
+                                stack_overrides,
+                            )
+                        },
+                    );
+                    crate::jitcode_dispatch::fbw_abort_outer_stack_overrides_clear();
+                    if committed {
                         if crate::jitcode_dispatch::fbw_debug_abort_enabled() {
                             eprintln!(
                                 "[fbw-abort-flush] COMMIT abort_jit_pc={abort_jit_pc} \

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -2070,6 +2070,54 @@ fn run_perfn_walk(
                     crate::jitcode_dispatch::fbw_abort_carrier_clear();
                 }
             }
+            if let Err(
+                crate::jitcode_dispatch::DispatchError::LoopBearingCalleeInlineUnsupported { pc },
+            ) = &walk_result
+            {
+                let abort_jit_pc = *pc;
+                if !crate::jitcode_dispatch::fbw_executed_nonpure_residual() {
+                    if crate::jitcode_dispatch::fbw_debug_abort_enabled() {
+                        eprintln!(
+                            "[fbw-abort-flush] declined at abort_jit_pc={abort_jit_pc} \
+                             (no executed non-pure residual) — legacy replay kept"
+                        );
+                    }
+                } else if crate::jitcode_dispatch::fbw_has_unjournaled_effect() {
+                    if crate::jitcode_dispatch::fbw_debug_abort_enabled() {
+                        eprintln!(
+                            "[fbw-abort-flush] declined at abort_jit_pc={abort_jit_pc} \
+                             (unjournaled effect) — legacy replay kept"
+                        );
+                    }
+                } else if let Some((resume_py_pc, stack_overrides)) =
+                    crate::jitcode_dispatch::fbw_abort_outer_resume_take()
+                {
+                    if crate::state::flush_walk_end_state_to_frame_with_stack_overrides(
+                        ctx,
+                        cf_addr,
+                        resume_py_pc,
+                        &stack_overrides,
+                    ) {
+                        if crate::jitcode_dispatch::fbw_debug_abort_enabled() {
+                            eprintln!(
+                                "[fbw-abort-flush] COMMIT abort_jit_pc={abort_jit_pc} \
+                                 resume_py_pc={resume_py_pc} (nested inline decline)"
+                            );
+                        }
+                        WALK_END_FLUSH_COMMITTED.with(|c| c.set(true));
+                    } else if crate::jitcode_dispatch::fbw_debug_abort_enabled() {
+                        eprintln!(
+                            "[fbw-abort-flush] declined at resume_py_pc={resume_py_pc} \
+                             (shadow slot without concrete / depth / lastblock) — legacy replay kept"
+                        );
+                    }
+                } else if crate::jitcode_dispatch::fbw_debug_abort_enabled() {
+                    eprintln!(
+                        "[fbw-abort-flush] declined at abort_jit_pc={abort_jit_pc} \
+                         (no outer caller resume pc) — legacy replay kept"
+                    );
+                }
+            }
         }
 
         // #32 S2: a kept-stack branch guard whose not-taken arm cannot be
@@ -2630,6 +2678,7 @@ fn full_body_walk_trace(
     // value cannot leak into this walk's `Terminate` handling.
     crate::jitcode_dispatch::fbw_finish_payload_reset();
     crate::jitcode_dispatch::fbw_executed_nonpure_residual_reset();
+    crate::jitcode_dispatch::fbw_abort_outer_resume_py_pc_reset();
     // Clear the prior walk's store journal + unjournaled-effect flag so
     // dropped (aborted) entries cannot be applied by this walk's commit.
     crate::jitcode_dispatch::fbw_store_journal_reset();


### PR DESCRIPTION
Closes the gh#495 double-apply epic and gh#498, plus regression guards and gated Slice-A infra. 16 commits on `main`.

## gh#495 — FBW inline sub-walk concrete-residual double-apply class
- **Phase 0 floor**: decline any non-provably-pure residual executed inside an inline sub-walk (`fbw_abort_nested_unjournaled_residual`), so concrete heap effects outside the FBW journals can never be re-applied by entry replay.
- **B1 forward-commit chain**: `FBW_EXECUTED_NONPURE_RESIDUAL` latch; const-int/float finish stashes; exception forward-delivery (`exit_frame_with_exception`, pyjitpl.py:2557 parity); abort-flush of executed-effect nested aborts with caller-CALL-pc + concrete stack overrides (rebuild_from_resumedata resume.py:1042 parity); GC-rooting for the stashes.
- **Parity fixes**: clear residual-call exception at ENTRY (execute_varargs pyjitpl.py:1942), drop the decline-mode raise finish stash.
- **10 synth regression guards** (`pyre/bench/synth/inline_subwalk_*` et al., each `# gh#495 guard:`).

## gh#498 — inlined-closure freevar + branch miscompile
- Root cause: branch-guard snapshots sourced local Ref slots from the virtualizable shadow first, picking up a stale loop-entry binding for a local overwritten just before the guard (`get_list_of_active_boxes` reads `registers_r[index]` — the live color). Fix: prefer the live walk register when the snapshot carries a guard pc.
- Soundness floor kept: decline bridge reconstruction when a pcdep-declared color is missing from decoded resume liveness (never fill a pcdep-live slot from the vable image).
- **3 synth guards** (`closure_freevar_branch_{readonly,nonlocal,list_cell}`).

## Task #1 (codex-review §3) — ForIterNext exemption audit
- Disposition: latent, masked — 11 shapes swept with zero default-flag divergence; the exemption's double-advance was reachable only under `PYRE_FBW_NESTED_RESID_ABORT=0` on older bases. **2 synth guards** (`foriter_exempt_*`) pin the masking machinery.

## Slice A0 (gated OFF)
- Callee operand-stack mirror for inline sub-walks behind `PYRE_FBW_CALLEE_VSTACK` (default OFF). A corpus-wide decline census found no reachable target for the flip on the current base, so it stays inert re-evaluation infra (177/177 in both modes).

## Verification
- `pyre/check.py --backend dynasm`: **ALL PASSED 177/177** at tip (also with `PYRE_FBW_CALLEE_VSTACK=1`); gh#495/#498 repro batteries oracle-equal, including `PYPY_GC_NURSERY` stress.
- Side find while probing: pre-existing FBW capture panic filed as #511 (not introduced by this branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved correctness and recovery for optimized and full-body walk execution across nested calls, mutations, exceptions, generators/iterators, closures, and branch scenarios.
  - Enhanced end-of-walk state resumption for inline-decline paths, including more reliable operand-stack flushing with targeted slot overrides.
  - Strengthened completion handling for mixed integer/float results and added tracking to prevent unsafe non-pure residual execution.

- **Tests**
  - Added new benchmark/regression modules covering closure branching, `nonlocal` behavior, mutation/raise flows, and additional inline sub-walk edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->