### PR TITLE
#346: retire rtyper legacy walker — census slices (17 residuals→ ~15 leaf clusters closed)

### DIFF
--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -13150,21 +13150,31 @@ fn block_reachable(graph: &FunctionGraph, target: BlockId) -> bool {
 /// Grammar (verified against the real LLBC for several handler graphs):
 /// - literal segment: a length byte `L` with `L < 0x80`, then `L` bytes
 ///   of UTF-8 text appended to the current piece;
-/// - placeholder: the single byte `0xC0` — closes the current piece and
-///   begins the next (the Display-vs-Debug choice lives in the parallel
-///   args array, not in this template, so a placeholder carries no kind);
+/// - sequential placeholder: the single byte `0xC0` — closes the current
+///   piece, begins the next, and renders the next argument in order (the
+///   Display-vs-Debug choice lives in the parallel args array, not in this
+///   template, so a placeholder carries no kind);
+/// - explicit / reused placeholder: `0xC8` followed by a little-endian
+///   `u16` argument index — a 3-byte token that renders `args[index]`, so
+///   a `{0}…{0}` template that names one argument twice packs two `0xC8`
+///   tokens pointing at index `0`;
 /// - terminator: a `0x00` byte (only at a segment boundary; `0`/`0xC0`
 ///   bytes inside a literal are consumed by its length prefix).
 ///
-/// Returns `(pieces, placeholder_count)` with `pieces.len() ==
-/// placeholder_count + 1`.  Returns `None` (bail, leaving the graph
-/// untouched) on any high-bit control byte other than `0xC0` — i.e. a
-/// format spec with width/precision/fill or an explicit positional/named
-/// argument — and on non-UTF-8 literal bytes.
-fn decode_packed_format_pieces(bytes: &[u8]) -> Option<(Vec<String>, usize)> {
+/// Returns `(pieces, arg_indices)` where `arg_indices` holds the argument
+/// index each placeholder renders (one per placeholder, so `pieces.len() ==
+/// arg_indices.len() + 1`).  A sequential `0xC0` auto-increments; a reused
+/// `0xC8` index points back at an already-seen argument, so the distinct
+/// argument count is `max(arg_indices) + 1`, which can be less than the
+/// placeholder count.  Returns `None` (bail, leaving the graph untouched)
+/// on any high-bit control byte other than `0xC0`/`0xC8` — a format spec
+/// with width/precision/fill or a named argument — and on non-UTF-8
+/// literal bytes.
+fn decode_packed_format_pieces(bytes: &[u8]) -> Option<(Vec<String>, Vec<usize>)> {
     let mut pieces: Vec<String> = Vec::new();
     let mut current = String::new();
-    let mut placeholders = 0usize;
+    let mut indices: Vec<usize> = Vec::new();
+    let mut auto = 0usize; // next sequential argument index
     let mut i = 0;
     let mut terminated = false;
     while i < bytes.len() {
@@ -13177,10 +13187,18 @@ fn decode_packed_format_pieces(bytes: &[u8]) -> Option<(Vec<String>, usize)> {
             terminated = true;
             break;
         } else if b == 0xC0 {
-            // plain sequential placeholder
+            // sequential placeholder: renders the next argument in order
             pieces.push(std::mem::take(&mut current));
-            placeholders += 1;
+            indices.push(auto);
+            auto += 1;
             i += 1;
+        } else if b == 0xC8 {
+            // explicit / reused placeholder: `0xC8` + little-endian u16 index
+            let lo = *bytes.get(i + 1)? as usize;
+            let hi = *bytes.get(i + 2)? as usize;
+            pieces.push(std::mem::take(&mut current));
+            indices.push(lo | (hi << 8));
+            i += 3;
         } else if b < 0x80 {
             // literal segment of length `b`
             let start = i + 1;
@@ -13189,7 +13207,7 @@ fn decode_packed_format_pieces(bytes: &[u8]) -> Option<(Vec<String>, usize)> {
             current.push_str(std::str::from_utf8(seg).ok()?);
             i = end;
         } else {
-            // any other control byte = format spec / positional arg: bail
+            // any other control byte = format spec / named arg: bail
             return None;
         }
     }
@@ -13200,7 +13218,7 @@ fn decode_packed_format_pieces(bytes: &[u8]) -> Option<(Vec<String>, usize)> {
         return None;
     }
     pieces.push(current);
-    Some((pieces, placeholders))
+    Some((pieces, indices))
 }
 
 /// Read an `Array` aggregate literal: given the Variable holding a
@@ -13285,12 +13303,18 @@ struct FmtArg {
 }
 
 /// The decoded contents of a `format_args!` chain — the literal string
-/// pieces interleaved with the rendered placeholder arguments
-/// (`pieces.len() == args.len() + 1`).
+/// pieces interleaved with the placeholder arguments.  `args` holds one
+/// entry per *distinct* argument (the args-array elements), while
+/// `arg_indices` holds the argument index each *placeholder* renders in
+/// template order (`pieces.len() == arg_indices.len() + 1`).  A `{0}…{0}`
+/// template that reuses one argument has `arg_indices == [0, …, 0]` with a
+/// single `args` entry, so `arg_indices.len()` (placeholders) can exceed
+/// `args.len()` (distinct arguments).
 #[derive(Debug, Clone)]
 struct FmtChain {
     pieces: Vec<String>,
     args: Vec<FmtArg>,
+    arg_indices: Vec<usize>,
 }
 
 /// Match a `FunctionPath`'s trailing segments against `tail`, so a
@@ -13441,18 +13465,29 @@ fn extract_fmt_chain(
     for v in &piece_byte_vars {
         bytes.push(u8::try_from(resolve_const_int(graph, v)?).ok()?);
     }
-    let (pieces, placeholder_count) = decode_packed_format_pieces(&bytes)?;
+    let (pieces, arg_indices) = decode_packed_format_pieces(&bytes)?;
     // Args: an `Array` of `Argument::new_display|new_debug(&v)` ctors, one
-    // per placeholder.
+    // per *distinct* argument.  The args array holds the distinct arguments;
+    // reused placeholders (`0xC8`) point back at an earlier index, so the
+    // distinct count is `max(arg_indices) + 1` — bail unless it matches the
+    // args array, and every placeholder index must be in range.
     let arg_elems = read_array_literal_elements(graph, &args_var)?;
-    if arg_elems.len() != placeholder_count {
+    let distinct = arg_indices.iter().map(|i| i + 1).max().unwrap_or(0);
+    if arg_elems.len() != distinct {
+        return None;
+    }
+    if arg_indices.iter().any(|&i| i >= arg_elems.len()) {
         return None;
     }
     let mut args = Vec::with_capacity(arg_elems.len());
     for elem in &arg_elems {
         args.push(extract_fmt_arg(graph, elem)?);
     }
-    Some(FmtChain { pieces, args })
+    Some(FmtChain {
+        pieces,
+        args,
+        arg_indices,
+    })
 }
 
 /// Emit a `__str_const` constant of `text` into `bb_id` and return its
@@ -13518,8 +13553,11 @@ fn emit_str_add(
 /// rejected before emission.
 fn emit_fmt_concat(graph: &mut FunctionGraph, bb_id: BlockId, chain: &FmtChain) -> Variable {
     let mut acc = emit_str_const(graph, bb_id, &chain.pieces[0]);
-    for (i, arg) in chain.args.iter().enumerate() {
-        acc = emit_str_add(graph, bb_id, &acc, &arg.value);
+    // Walk placeholders in template order via `arg_indices`; a reused
+    // argument re-renders the same recovered value (`str(&str)` is pure, so
+    // referencing the value var twice is sound).
+    for (i, &ai) in chain.arg_indices.iter().enumerate() {
+        acc = emit_str_add(graph, bb_id, &acc, &chain.args[ai].value);
         let next_piece = emit_str_const(graph, bb_id, &chain.pieces[i + 1]);
         acc = emit_str_add(graph, bb_id, &acc, &next_piece);
     }
@@ -13677,8 +13715,13 @@ fn collect_fmt_collapse(graph: &FunctionGraph, bf: BlockId, fi: usize) -> Option
         _ => return None,
     };
     let chain = extract_fmt_chain(graph, &fmt_args)?;
-    if chain.args.len() != 1 {
-        return None; // scope: single-argument chains
+    if chain.args.len() != 1 || chain.arg_indices.len() != 1 {
+        // scope: exactly one argument rendered by exactly one placeholder.
+        // A single argument reused across several placeholders (`{0}…{0}`)
+        // has `arg_indices.len() > 1` and stays residual here (none of the
+        // census walls), rather than mis-driving the single-placeholder
+        // expansion below.
+        return None;
     }
     if chain.args[0].kind != FmtArgKind::Display {
         // `str(value)` renders Display; `{:?}` Debug has no native rstr
@@ -13887,9 +13930,12 @@ struct FmtCollapseMulti {
     /// `Arguments::new` result var id (re-threaded to the folded String,
     /// then deleted).
     arguments_var: u64,
-    /// The rendered-value vars in placeholder order (the args-array
+    /// The rendered-value vars, one per *distinct* argument (the args-array
     /// elements, live as inputargs of `args_block`).
     arg_elem_vars: Vec<Variable>,
+    /// The distinct-argument index each placeholder renders, in template
+    /// order (`0xC8` reuse points several placeholders at one `arg_elem_var`).
+    arg_indices: Vec<usize>,
     pieces: Vec<String>,
     /// `(block, op_index, inner)` per `Argument::new_display` ctor to
     /// rewrite into `str(inner)` in place.
@@ -14315,6 +14361,7 @@ fn collect_fmt_collapse_multi(
         args_block,
         arguments_var,
         arg_elem_vars,
+        arg_indices: chain.arg_indices,
         pieces,
         new_display_ops,
         format_block: bf,
@@ -14411,6 +14458,7 @@ fn collapse_fmt_chains_multi(graph: &mut FunctionGraph) -> usize {
                     kind: FmtArgKind::Display,
                 })
                 .collect(),
+            arg_indices: site.arg_indices.clone(),
         };
         let folded = emit_fmt_concat(graph, site.args_block, &fold_chain);
         // 4. Re-thread the folded String onto the link that forwarded the
@@ -14779,13 +14827,13 @@ mod tests {
     fn decode_packed_format_pieces_matches_real_llbc_templates() {
         use super::decode_packed_format_pieces;
 
-        // The four fixtures below are the verbatim `[u8; N]` pieces buffers
+        // The fixtures below are the verbatim `[u8; N]` pieces buffers
         // charon lowers for these handler graphs (captured from the real
         // pyre-interpreter.ullbc). Each asserts the reconstructed pieces +
-        // placeholder count, i.e. the original format string.
+        // per-placeholder argument indices, i.e. the original format string.
 
         // `format!("stack underflow during {}", context)`
-        let (pieces, n) = decode_packed_format_pieces(&[
+        let (pieces, indices) = decode_packed_format_pieces(&[
             23, 115, 116, 97, 99, 107, 32, 117, 110, 100, 101, 114, 102, 108, 111, 119, 32, 100,
             117, 114, 105, 110, 103, 32, 192, 0,
         ])
@@ -14794,10 +14842,10 @@ mod tests {
             pieces,
             vec!["stack underflow during ".to_string(), String::new()]
         );
-        assert_eq!(n, 1);
+        assert_eq!(indices, vec![0]);
 
         // `format!("{} indices must be integers or slices, not {}", ..)`
-        let (pieces, n) = decode_packed_format_pieces(&[
+        let (pieces, indices) = decode_packed_format_pieces(&[
             192, 41, 32, 105, 110, 100, 105, 99, 101, 115, 32, 109, 117, 115, 116, 32, 98, 101, 32,
             105, 110, 116, 101, 103, 101, 114, 115, 32, 111, 114, 32, 115, 108, 105, 99, 101, 115,
             44, 32, 110, 111, 116, 32, 192, 0,
@@ -14811,10 +14859,10 @@ mod tests {
                 String::new(),
             ]
         );
-        assert_eq!(n, 2);
+        assert_eq!(indices, vec![0, 1]);
 
         // `format!("'{}' object does not support item assignment", ..)`
-        let (pieces, n) = decode_packed_format_pieces(&[
+        let (pieces, indices) = decode_packed_format_pieces(&[
             1, 39, 192, 41, 39, 32, 111, 98, 106, 101, 99, 116, 32, 100, 111, 101, 115, 32, 110,
             111, 116, 32, 115, 117, 112, 112, 111, 114, 116, 32, 105, 116, 101, 109, 32, 97, 115,
             115, 105, 103, 110, 109, 101, 110, 116, 0,
@@ -14827,10 +14875,10 @@ mod tests {
                 "' object does not support item assignment".to_string(),
             ]
         );
-        assert_eq!(n, 1);
+        assert_eq!(indices, vec![0]);
 
         // `format!("__init__() should return None, not '{}'", ..)`
-        let (pieces, n) = decode_packed_format_pieces(&[
+        let (pieces, indices) = decode_packed_format_pieces(&[
             36, 95, 95, 105, 110, 105, 116, 95, 95, 40, 41, 32, 115, 104, 111, 117, 108, 100, 32,
             114, 101, 116, 117, 114, 110, 32, 78, 111, 110, 101, 44, 32, 110, 111, 116, 32, 39,
             192, 1, 39, 0,
@@ -14843,15 +14891,44 @@ mod tests {
                 "'".to_string(),
             ]
         );
-        assert_eq!(n, 1);
+        assert_eq!(indices, vec![0]);
+
+        // `format!("can only concatenate {a} (not \"{b}\") to {a}", ..)` —
+        // the `add`-operand error tail (descroperation.rs), where the first
+        // argument is reused by the trailing placeholder.  The reuse packs a
+        // `0xC8` + little-endian u16 index (`200, 0, 0`) pointing back at
+        // argument 0, so `indices == [0, 1, 0]` with two distinct arguments.
+        let (pieces, indices) = decode_packed_format_pieces(&[
+            21, 99, 97, 110, 32, 111, 110, 108, 121, 32, 99, 111, 110, 99, 97, 116, 101, 110, 97,
+            116, 101, 32, 192, 7, 32, 40, 110, 111, 116, 32, 34, 192, 6, 34, 41, 32, 116, 111, 32,
+            200, 0, 0, 0,
+        ])
+        .unwrap();
+        assert_eq!(
+            pieces,
+            vec![
+                "can only concatenate ".to_string(),
+                " (not \"".to_string(),
+                "\") to ".to_string(),
+                String::new(),
+            ]
+        );
+        assert_eq!(indices, vec![0, 1, 0]);
+
+        // A template naming arguments 1 and 3 explicitly (`0xC8` + u16 index
+        // each): three sequential `0xC0` then two explicit reuses.
+        let (pieces, indices) =
+            decode_packed_format_pieces(&[192, 192, 192, 200, 1, 0, 200, 3, 0, 0]).unwrap();
+        assert_eq!(pieces.len(), 6);
+        assert_eq!(indices, vec![0, 1, 2, 1, 3]);
     }
 
     #[test]
     fn decode_packed_format_pieces_bails_and_handles_edges() {
         use super::decode_packed_format_pieces;
 
-        // A control byte other than 0xC0 (e.g. a format-spec / positional
-        // placeholder) must bail so the recognizer leaves the graph alone.
+        // A control byte other than 0xC0 / 0xC8 (e.g. a width/precision
+        // format-spec) must bail so the recognizer leaves the graph alone.
         assert_eq!(decode_packed_format_pieces(&[0xC1, 0]), None);
         assert_eq!(decode_packed_format_pieces(&[0x80, 0]), None);
 
@@ -14866,16 +14943,21 @@ mod tests {
         assert_eq!(decode_packed_format_pieces(&[2, 104, 105]), None);
         assert_eq!(decode_packed_format_pieces(&[2, 104, 105, 192]), None);
 
-        // Literal-only template (no placeholders) → single piece.
-        let (pieces, n) = decode_packed_format_pieces(&[2, 104, 105, 0]).unwrap();
+        // A `0xC8` reuse token whose 2-byte little-endian index runs past
+        // the buffer end bails rather than reading out of bounds.
+        assert_eq!(decode_packed_format_pieces(&[0xC8, 0]), None);
+        assert_eq!(decode_packed_format_pieces(&[0xC8, 0, 0]), None);
+
+        // Literal-only template (no placeholders) → single piece, no args.
+        let (pieces, indices) = decode_packed_format_pieces(&[2, 104, 105, 0]).unwrap();
         assert_eq!(pieces, vec!["hi".to_string()]);
-        assert_eq!(n, 0);
+        assert_eq!(indices, Vec::<usize>::new());
 
         // Two consecutive literal segments accumulate into one piece
         // (how a >127-byte literal is split); one placeholder follows.
-        let (pieces, n) = decode_packed_format_pieces(&[1, 97, 1, 98, 192, 0]).unwrap();
+        let (pieces, indices) = decode_packed_format_pieces(&[1, 97, 1, 98, 192, 0]).unwrap();
         assert_eq!(pieces, vec!["ab".to_string(), String::new()]);
-        assert_eq!(n, 1);
+        assert_eq!(indices, vec![0]);
     }
 
     #[test]
@@ -14929,9 +15011,9 @@ mod tests {
             .map(|v| resolve_const_int(&graph, v).expect("const int") as u8)
             .collect();
         assert_eq!(decoded, vec![2, 104, 105, 0xC0, 0]);
-        let (pieces, n) = decode_packed_format_pieces(&decoded).unwrap();
+        let (pieces, indices) = decode_packed_format_pieces(&decoded).unwrap();
         assert_eq!(pieces, vec!["hi".to_string(), String::new()]);
-        assert_eq!(n, 1);
+        assert_eq!(indices, vec![0]);
 
         // A non-Array producer (plain ConstInt) is rejected.
         assert_eq!(read_array_literal_elements(&graph, &elements[0]), None);
@@ -15866,6 +15948,7 @@ mod tests {
                     kind: FmtArgKind::Display,
                 },
             ],
+            arg_indices: vec![0, 1],
         };
         let result = emit_fmt_concat(&mut graph, bb, &chain);
 

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -4398,6 +4398,7 @@ impl<'a> Lowering<'a> {
                     .or_else(|| self.fold_size_const_global(id))
                     .or_else(|| self.fold_named_const_int_array_global(id))
                     .or_else(|| primitive_float_const(&segments))
+                    .or_else(|| code_flags_const(&segments))
                     .unwrap_or_else(|| OpKind::Call {
                         target: CallTarget::FunctionPath { segments },
                         args: vec![],
@@ -12545,6 +12546,51 @@ fn primitive_float_const(segments: &[String]) -> Option<OpKind> {
         _ => return None,
     };
     Some(OpKind::ConstFloat(bits))
+}
+
+/// Supply the value of a `CodeFlags` associated constant. `bitflags!`
+/// generates each flag as an `impl CodeFlags { const NAME: Self }` whose
+/// initializer Charon records as an `Opaque` body (the `<Impl>` segment
+/// anonymizes to `_`), so [`Lowering::const_eval_global`] finds no
+/// in-LLBC init to evaluate and the read stays a `not registered` Call.
+/// The value is a fixed compile-time `u32` bitmask, so emit it by-value
+/// as the same `ConstInt` an inline integer literal lowers to — a
+/// `flags.contains(CodeFlags::VARARGS)` test then folds to the
+/// integer bit-and the `bitflags` `.contains` inlines to. Mirrors
+/// [`primitive_float_const`] for `f64::INFINITY`.
+fn code_flags_const(segments: &[String]) -> Option<OpKind> {
+    let [first, second, .., impl_seg, leaf] = segments else {
+        return None;
+    };
+    if first.as_str() != "rustpython_compiler_core"
+        || second.as_str() != "bytecode"
+        || impl_seg.as_str() != "<Impl>"
+    {
+        return None;
+    }
+    let bits: u32 = match leaf.as_str() {
+        "OPTIMIZED" => 0x0001,
+        "NEWLOCALS" => 0x0002,
+        "VARARGS" => 0x0004,
+        "VARKEYWORDS" => 0x0008,
+        "NESTED" => 0x0010,
+        "GENERATOR" => 0x0020,
+        "COROUTINE" => 0x0080,
+        "ITERABLE_COROUTINE" => 0x0100,
+        "ASYNC_GENERATOR" => 0x0200,
+        "FUTURE_DIVISION" => 0x20000,
+        "FUTURE_ABSOLUTE_IMPORT" => 0x40000,
+        "FUTURE_WITH_STATEMENT" => 0x80000,
+        "FUTURE_PRINT_FUNCTION" => 0x100000,
+        "FUTURE_UNICODE_LITERALS" => 0x200000,
+        "FUTURE_BARRY_AS_BDFL" => 0x400000,
+        "FUTURE_GENERATOR_STOP" => 0x800000,
+        "FUTURE_ANNOTATIONS" => 0x1000000,
+        "HAS_DOCSTRING" => 0x4000000,
+        "METHOD" => 0x8000000,
+        _ => return None,
+    };
+    Some(OpKind::ConstInt(bits as i64))
 }
 
 fn place_kind_label(k: &PlaceKind) -> &'static str {

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -6892,21 +6892,30 @@ impl<'a> Lowering<'a> {
     /// Restricted to the integer-index impl (`Index<usize>`, the element
     /// load).  `Vec`'s `Index<Range<…>>` impls share the `index` leaf but
     /// return a sub-`&[T]` slice, not an element — lowering those to a
-    /// scalar `ArrayRead` would mis-index, so the index argument
-    /// (`inputs[1]`) must type as an integer.
+    /// scalar `ArrayRead` would mis-index, so the index type must be an
+    /// integer.  Charon runs `monomorphize:false`, so the `index`
+    /// signature keeps the generic index param `I` (a `TypeVar` typing as
+    /// `Ref`); the concrete index type is the callsite substitution
+    /// `types[1]` of the impl generics `[T, I, A]`.  `Index<usize>` types
+    /// as `Int`; `Index<Range<…>>` resolves to a `Range*` Adt (`Ref`) and
+    /// stays foreign.
     fn is_vec_index_call(&self, reg: &RegularCall) -> bool {
         let CallKind::Fun(FunId::Regular { id }) = &reg.kind else {
             return false;
         };
-        self.llbc.fn_by_id(*id).is_some_and(|fd| {
+        let owner_leaf_ok = self.llbc.fn_by_id(*id).is_some_and(|fd| {
             impl_method_owner_for_fundecl(self.llbc, fd)
                 .is_some_and(|(owner, leaf)| owner == "vec::Vec" && leaf == "index")
-                && fd
-                    .signature
-                    .inputs
-                    .get(1)
-                    .is_some_and(|t| matches!(tyref_to_value_type(t, self.llbc), ValueType::Int))
-        })
+        });
+        if !owner_leaf_ok {
+            return false;
+        }
+        reg.generics
+            .get("types")
+            .and_then(serde_json::Value::as_array)
+            .and_then(|tys| tys.get(1))
+            .and_then(|t| serde_json::from_value::<TyRef>(t.clone()).ok())
+            .is_some_and(|t| matches!(tyref_to_value_type(&t, self.llbc), ValueType::Int))
     }
 
     /// `<[T]>::swap(s, a, b)` (`core::slice::<Impl>::swap`) — an

--- a/pyre/pyre-interpreter/src/_pypy_generic_alias.rs
+++ b/pyre/pyre-interpreter/src/_pypy_generic_alias.rs
@@ -32,7 +32,23 @@ pub(crate) const ATTR_EXCEPTIONS: &[&str] = &[
 /// `name in _ATTR_EXCEPTIONS` — used by `getattr` to decide whether to
 /// delegate to `__origin__`.
 pub(crate) fn is_attr_exception(name: &str) -> bool {
-    ATTR_EXCEPTIONS.contains(&name)
+    // `name in _ATTR_EXCEPTIONS` membership, spelled as direct string
+    // equality so it lowers to a chain of `ll_streq` rather than a
+    // scan over the `&[&str]` const backing (whose body is opaque).
+    matches!(
+        name,
+        "__args__"
+            | "__class__"
+            | "__copy__"
+            | "__deepcopy__"
+            | "__mro_entries__"
+            | "__origin__"
+            | "__parameters__"
+            | "__reduce__"
+            | "__reduce_ex__"
+            | "__typing_unpacked_tuple_args__"
+            | "__unpacked__"
+    )
 }
 
 /// `generic_alias_class_getitem(space, w_cls, w_item)` (util.py:99).

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -6705,19 +6705,11 @@ pub unsafe fn isinstance_w(w_obj: PyObjectRef, w_cls: PyObjectRef) -> bool {
     if w_obj_type.is_null() {
         return false;
     }
-    if std::ptr::eq(w_obj_type, w_cls) {
-        return true;
-    }
-    // Walk MRO
-    let mro_ptr = w_type_get_mro(w_obj_type);
-    if !mro_ptr.is_null() {
-        for &t in &*mro_ptr {
-            if std::ptr::eq(t, w_cls) {
-                return true;
-            }
-        }
-    }
-    false
+    // `type(w_inst).issubtype(w_type)` (objspace.py:808 _type_isinstance).
+    // The MRO membership scan is the single home `w_type_issubtype`
+    // (self-identity is mro[0], so the `w_obj_type is w_cls` fast path is
+    // subsumed); the null-mro case walks find_best_base there.
+    w_type_issubtype(w_obj_type, w_cls)
 }
 
 /// pypy/interpreter/baseobjspace.py:419-420 DescrMismatch.

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -1593,14 +1593,14 @@ unsafe fn range_compute_slice(obj: PyObjectRef, slice: PyObjectRef) -> PyResult 
 /// `range.count(value)` — `functional.py W_Range.descr_count`.
 fn range_count_method(args: &[PyObjectRef]) -> PyResult {
     let obj = args[0];
-    let needle = args.get(1).copied().unwrap_or(PY_NULL);
+    let needle = if args.len() > 1 { args[1] } else { PY_NULL };
     Ok(w_int_new(if contains(obj, needle)? { 1 } else { 0 }))
 }
 
 /// `range.index(value)` — `functional.py W_Range.descr_index`.
 fn range_index_method(args: &[PyObjectRef]) -> PyResult {
     let obj = args[0];
-    let needle = args.get(1).copied().unwrap_or(PY_NULL);
+    let needle = if args.len() > 1 { args[1] } else { PY_NULL };
     unsafe {
         // int / bool / long needle → O(1) `(value - start) // step`.
         if is_int(needle) || is_long(needle) {
@@ -10477,7 +10477,8 @@ unsafe fn property_no_accessor(prop: PyObjectRef, obj: PyObjectRef, kind: &str) 
 fn property_set_name_impl(args: &[PyObjectRef]) -> PyResult {
     // descriptor.py:274-276 `set_name(self, w_type, w_name)` — the bound
     // method receives `[property, owner, name]`.
-    if let Some(&w_name) = args.get(2) {
+    if args.len() > 2 {
+        let w_name = args[2];
         unsafe { pyre_object::descriptor::w_property_set_name(args[0], w_name) };
     }
     Ok(pyre_object::w_none())
@@ -10485,17 +10486,20 @@ fn property_set_name_impl(args: &[PyObjectRef]) -> PyResult {
 
 fn property_setter_impl(args: &[PyObjectRef]) -> PyResult {
     // descriptor.py:243-244 `setter` → `_copy(space, w_setter=w_setter)`
-    unsafe { property_copy(args[0], None, args.get(1).copied(), None) }
+    let w_setter = if args.len() > 1 { Some(args[1]) } else { None };
+    unsafe { property_copy(args[0], None, w_setter, None) }
 }
 
 fn property_getter_impl(args: &[PyObjectRef]) -> PyResult {
     // descriptor.py:240-241 `getter` → `_copy(space, w_getter=w_getter)`
-    unsafe { property_copy(args[0], args.get(1).copied(), None, None) }
+    let w_getter = if args.len() > 1 { Some(args[1]) } else { None };
+    unsafe { property_copy(args[0], w_getter, None, None) }
 }
 
 fn property_deleter_impl(args: &[PyObjectRef]) -> PyResult {
     // descriptor.py:246-247 `deleter` → `_copy(space, w_deleter=w_deleter)`
-    unsafe { property_copy(args[0], None, None, args.get(1).copied()) }
+    let w_deleter = if args.len() > 1 { Some(args[1]) } else { None };
+    unsafe { property_copy(args[0], None, None, w_deleter) }
 }
 
 /// `descriptor.py W_Property.get` as the type-dict `__get__` entry — args
@@ -10506,7 +10510,11 @@ fn property_deleter_impl(args: &[PyObjectRef]) -> PyResult {
 pub(crate) fn property_descr_get_impl(args: &[PyObjectRef]) -> PyResult {
     unsafe {
         let prop = args[0];
-        let obj = args.get(1).copied().unwrap_or(pyre_object::PY_NULL);
+        let obj = if args.len() > 1 {
+            args[1]
+        } else {
+            pyre_object::PY_NULL
+        };
         // `if space.is_w(w_obj, space.w_None): return self`
         if obj.is_null() || is_none(obj) {
             return Ok(prop);
@@ -10524,7 +10532,11 @@ pub(crate) fn property_descr_set_impl(args: &[PyObjectRef]) -> PyResult {
     unsafe {
         let prop = args[0];
         let obj = args[1];
-        let value = args.get(2).copied().unwrap_or(pyre_object::PY_NULL);
+        let value = if args.len() > 2 {
+            args[2]
+        } else {
+            pyre_object::PY_NULL
+        };
         let fset = w_property_get_fset(prop);
         if fset.is_null() || is_none(fset) {
             return Err(property_no_accessor(prop, obj, "setter"));
@@ -10733,7 +10745,7 @@ fn takewhile_reduce_method(args: &[PyObjectRef]) -> PyResult {
 /// state just as `bool_w` does).
 fn takewhile_setstate_method(args: &[PyObjectRef]) -> PyResult {
     let it = unsafe { &mut *(args[0] as *mut pyre_object::interp_itertools::W_TakeWhile) };
-    it.stopped = int_w(args.get(1).copied().unwrap_or(w_none()))? != 0;
+    it.stopped = int_w(if args.len() > 1 { args[1] } else { w_none() })? != 0;
     Ok(w_none())
 }
 
@@ -10751,7 +10763,7 @@ fn dropwhile_reduce_method(args: &[PyObjectRef]) -> PyResult {
 /// `takewhile_setstate_method` for the `int_w(...)? != 0` equivalence).
 fn dropwhile_setstate_method(args: &[PyObjectRef]) -> PyResult {
     let it = unsafe { &mut *(args[0] as *mut pyre_object::interp_itertools::W_DropWhile) };
-    it.started = int_w(args.get(1).copied().unwrap_or(w_none()))? != 0;
+    it.started = int_w(if args.len() > 1 { args[1] } else { w_none() })? != 0;
     Ok(w_none())
 }
 
@@ -10851,7 +10863,7 @@ fn cycle_setstate_method(args: &[PyObjectRef]) -> PyResult {
     // list reached through the tuple) survive each iteration.
     let _roots = pyre_object::gc_roots::push_roots();
     let w_self = args[0];
-    let w_state = args.get(1).copied().unwrap_or(w_none());
+    let w_state = if args.len() > 1 { args[1] } else { w_none() };
     pyre_object::gc_roots::pin_root(w_self);
     pyre_object::gc_roots::pin_root(w_state);
     let state_w = unpackiterable(w_state, 2)?;
@@ -10903,7 +10915,7 @@ fn chain_setstate_method(args: &[PyObjectRef]) -> PyResult {
     // elements) survive each iteration.
     let _roots = pyre_object::gc_roots::push_roots();
     let w_self = args[0];
-    let w_state = args.get(1).copied().unwrap_or(w_none());
+    let w_state = if args.len() > 1 { args[1] } else { w_none() };
     pyre_object::gc_roots::pin_root(w_self);
     pyre_object::gc_roots::pin_root(w_state);
     let state = unpackiterable(w_state, -1)?;

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -3856,38 +3856,39 @@ fn getattr_str_impl(obj: PyObjectRef, name: &str, call_getattr: bool) -> PyResul
         }
     }
 
-    let result = object_getattr_miss(obj, name, call_getattr);
+    let err = match object_getattr_miss(obj, name, call_getattr) {
+        Ok(value) => return Ok(value),
+        Err(e) => e,
+    };
     // module.py:130-142 `Module.descr_getattribute` — PEP 562: after the
     // normal lookup misses with AttributeError, a module-level `__getattr__`
     // stored in the module's own dict gets the final say, called with just the
     // attribute name.  Only `space.getattr` consults it.
-    if let Err(ref e) = result {
-        if call_getattr && e.kind == PyErrorKind::AttributeError && unsafe { is_module(obj) } {
-            let w_dict = unsafe { pyre_object::w_module_get_w_dict(obj) };
-            if !w_dict.is_null() {
-                if let Some(mod_getattr) = finditem_str(w_dict, "__getattr__")? {
-                    if !mod_getattr.is_null() {
-                        let name_obj = w_str_new(name);
-                        return crate::call::call_function_impl_result(mod_getattr, &[name_obj]);
-                    }
+    if call_getattr && err.kind == PyErrorKind::AttributeError && unsafe { is_module(obj) } {
+        let w_dict = unsafe { pyre_object::w_module_get_w_dict(obj) };
+        if !w_dict.is_null() {
+            if let Some(mod_getattr) = finditem_str(w_dict, "__getattr__")? {
+                if !mod_getattr.is_null() {
+                    let name_obj = w_str_new(name);
+                    return crate::call::call_function_impl_result(mod_getattr, &[name_obj]);
                 }
-                // No module `__getattr__`: phrase the miss with the module's
-                // `__name__` (`module '<name>' has no attribute '<attr>'`, the
-                // `'%U'` form), which requires a str `__name__` and falls back
-                // to the bare form otherwise.  (The `__spec__`-based
-                // circular-import diagnostics are not ported.)
-                let msg = match finditem_str(w_dict, "__name__")? {
-                    Some(w) if !w.is_null() && unsafe { pyre_object::is_str(w) } => {
-                        let nm = unsafe { pyre_object::w_str_get_wtf8(w) };
-                        format!("module '{nm}' has no attribute '{name}'")
-                    }
-                    _ => format!("module has no attribute '{name}'"),
-                };
-                return Err(PyError::new(PyErrorKind::AttributeError, msg));
             }
+            // No module `__getattr__`: phrase the miss with the module's
+            // `__name__` (`module '<name>' has no attribute '<attr>'`, the
+            // `'%U'` form), which requires a str `__name__` and falls back
+            // to the bare form otherwise.  (The `__spec__`-based
+            // circular-import diagnostics are not ported.)
+            let msg = match finditem_str(w_dict, "__name__")? {
+                Some(w) if !w.is_null() && unsafe { pyre_object::is_str(w) } => {
+                    let nm = unsafe { pyre_object::w_str_get_wtf8(w) };
+                    format!("module '{nm}' has no attribute '{name}'")
+                }
+                _ => format!("module has no attribute '{name}'"),
+            };
+            return Err(PyError::new(PyErrorKind::AttributeError, msg));
         }
     }
-    result
+    Err(err)
 }
 
 // ─── `w_name`-taking attribute API ───

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -190,7 +190,7 @@ pub(crate) unsafe fn issubtype_w(w_type: PyObjectRef, cls: PyObjectRef) -> bool 
     }
     let mro_ptr = w_type_get_mro(w_type);
     if !mro_ptr.is_null() {
-        return (*mro_ptr).iter().any(|&t| std::ptr::eq(t, cls));
+        return (*mro_ptr).as_slice().iter().any(|&t| std::ptr::eq(t, cls));
     }
     compute_default_mro(w_type)
         .iter()
@@ -2803,7 +2803,7 @@ pub fn exception_match(exc_type: PyObjectRef, check_class: PyObjectRef) -> bool 
         return false;
     }
 
-    let mro = unsafe { &*mro_ptr };
+    let mro = unsafe { (*mro_ptr).as_slice() };
     mro.iter().any(|&klass| is_w(klass, check_class))
 }
 
@@ -3303,8 +3303,10 @@ fn getattr_str_impl(obj: PyObjectRef, name: &str, call_getattr: bool) -> PyResul
             let mro_ptr = w_type_get_mro(w_obj_type);
             if !mro_ptr.is_null() {
                 let mro = &*mro_ptr;
+                let mro_len = mro.len();
                 let mut past_super = false;
-                for &t in mro {
+                for i in 0..mro_len {
+                    let t = mro[i];
                     if std::ptr::eq(t, super_type) {
                         past_super = true;
                         continue;
@@ -4499,7 +4501,7 @@ fn object_getattr_miss(obj: PyObjectRef, name: &str, call_getattr: bool) -> PyRe
             if name == "__mro__" {
                 let mro_ptr = w_type_get_mro(obj);
                 if !mro_ptr.is_null() {
-                    return Ok(w_tuple_new((*mro_ptr).clone()));
+                    return Ok(w_tuple_new((*mro_ptr).to_vec()));
                 }
             }
             if name == "__flags__" {
@@ -5786,7 +5788,7 @@ pub unsafe fn compares_by_identity(w_type: PyObjectRef) -> bool {
     let cached_mro = pyre_object::typeobject::w_type_get_mro(w_type);
     let mro_owned;
     let mro: &[PyObjectRef] = if !cached_mro.is_null() {
-        &*cached_mro
+        (*cached_mro).as_slice()
     } else {
         mro_owned = compute_mro(w_type);
         &mro_owned
@@ -5900,11 +5902,11 @@ pub(crate) unsafe fn lookup_where(
     if w_type.is_null() || !is_type(w_type) {
         return None;
     }
-    // Use cached MRO if available (PyPy: W_TypeObject.mro_w)
+    // Use cached MRO if available (W_TypeObject.mro_w)
     let cached = w_type_get_mro(w_type);
     let mro_owned;
     let mro: &[PyObjectRef] = if !cached.is_null() {
-        &*cached
+        (*cached).as_slice()
     } else {
         mro_owned = compute_mro(w_type);
         &mro_owned
@@ -6004,7 +6006,7 @@ pub(crate) unsafe fn lookup_in_type_wtf8(w_type: PyObjectRef, name: &Wtf8) -> Op
     let cached = w_type_get_mro(w_type);
     let mro_owned;
     let mro: &[PyObjectRef] = if !cached.is_null() {
-        &*cached
+        (*cached).as_slice()
     } else {
         mro_owned = compute_mro(w_type);
         &mro_owned
@@ -6560,7 +6562,7 @@ pub unsafe fn super_lookup_binding(
     };
     let mro_ptr = w_type_get_mro(w_obj_type);
     if !mro_ptr.is_null() {
-        let mro = &*mro_ptr;
+        let mro = (*mro_ptr).as_slice();
         let mut past_super = false;
         for &t in mro {
             if std::ptr::eq(t, super_type) {
@@ -10685,20 +10687,33 @@ fn generator_next(gen_obj: PyObjectRef) -> PyResult {
 
 /// __next__ method wrapper
 fn generator_next_method(args: &[PyObjectRef]) -> PyResult {
-    let gen_obj = args.first().copied().unwrap_or(pyre_object::PY_NULL);
+    let gen_obj = if args.is_empty() {
+        pyre_object::PY_NULL
+    } else {
+        args[0]
+    };
     generator_next(gen_obj)
 }
 
 /// Generic __next__ wrapper for iterators that delegate to `next()`.
 /// Used for itertools count/repeat etc.
 fn iter_next_method(args: &[PyObjectRef]) -> PyResult {
-    let obj = args.first().copied().unwrap_or(pyre_object::PY_NULL);
+    let obj = if args.is_empty() {
+        pyre_object::PY_NULL
+    } else {
+        args[0]
+    };
     next(obj)
 }
 
 /// `__iter__` for an iterator — returns the iterator itself.
 fn iter_self_method(args: &[PyObjectRef]) -> PyResult {
-    Ok(args.first().copied().unwrap_or(pyre_object::PY_NULL))
+    let obj = if args.is_empty() {
+        pyre_object::PY_NULL
+    } else {
+        args[0]
+    };
+    Ok(obj)
 }
 
 /// `takewhile.__reduce__` — `interp_itertools.py W_TakeWhile.descr_reduce`:
@@ -10916,16 +10931,32 @@ fn chain_setstate_method(args: &[PyObjectRef]) -> PyResult {
 
 /// PyPy: GeneratorIterator.descr_send(w_arg)
 fn generator_send_method(args: &[PyObjectRef]) -> PyResult {
-    let gen_obj = args.first().copied().unwrap_or(pyre_object::PY_NULL);
-    let value = args.get(1).copied().unwrap_or(w_none());
+    let gen_obj = if args.is_empty() {
+        pyre_object::PY_NULL
+    } else {
+        args[0]
+    };
+    let value = if args.len() > 1 { args[1] } else { w_none() };
     generator_send_ex(gen_obj, value, None)
 }
 
 /// PyPy: GeneratorIterator.descr_throw(w_type, w_val=None, w_tb=None)
 fn generator_throw_method(args: &[PyObjectRef]) -> PyResult {
-    let gen_obj = args.first().copied().unwrap_or(pyre_object::PY_NULL);
-    let w_type = args.get(1).copied().unwrap_or(pyre_object::PY_NULL);
-    let w_val = args.get(2).copied().unwrap_or(pyre_object::PY_NULL);
+    let gen_obj = if args.is_empty() {
+        pyre_object::PY_NULL
+    } else {
+        args[0]
+    };
+    let w_type = if args.len() > 1 {
+        args[1]
+    } else {
+        pyre_object::PY_NULL
+    };
+    let w_val = if args.len() > 2 {
+        args[2]
+    } else {
+        pyre_object::PY_NULL
+    };
     // w_tb (args[3]) ignored for now — traceback not yet supported
 
     let err = normalize_throw_args(w_type, w_val);
@@ -10934,7 +10965,11 @@ fn generator_throw_method(args: &[PyObjectRef]) -> PyResult {
 
 /// PyPy: GeneratorIterator.descr_close()
 fn generator_close_method(args: &[PyObjectRef]) -> PyResult {
-    let gen_obj = args.first().copied().unwrap_or(pyre_object::PY_NULL);
+    let gen_obj = if args.is_empty() {
+        pyre_object::PY_NULL
+    } else {
+        args[0]
+    };
     unsafe {
         use pyre_object::generator::*;
         if w_generator_is_exhausted(gen_obj) {

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -1276,7 +1276,7 @@ unsafe fn getitem_list(obj: PyObjectRef, index: PyObjectRef) -> PyResult {
             if let Some(v) = w_list_getitem(obj, i) {
                 items.push(v);
             }
-            i = i.saturating_add(step);
+            i += step;
         }
         return Ok(w_list_new(items));
     }
@@ -1305,7 +1305,7 @@ unsafe fn getitem_tuple(obj: PyObjectRef, index: PyObjectRef) -> PyResult {
             if let Some(v) = w_tuple_getitem(obj, i) {
                 items.push(v);
             }
-            i = i.saturating_add(step);
+            i += step;
         }
         return Ok(w_tuple_new(items));
     }
@@ -1341,7 +1341,7 @@ unsafe fn getitem_str(obj: PyObjectRef, index: PyObjectRef) -> PyResult {
             if i >= 0 && (i as usize) < cps.len() {
                 result.push(cps[i as usize]);
             }
-            i = i.saturating_add(step);
+            i += step;
         }
         return Ok(w_str_from_wtf8(result));
     }
@@ -1392,14 +1392,14 @@ unsafe fn getitem_bytes_like(obj: PyObjectRef, index: PyObjectRef) -> PyResult {
                 result.push(pyre_object::bytesobject::bytes_like_getitem(
                     obj, i as usize,
                 ));
-                i = i.saturating_add(step);
+                i += step;
             }
         } else {
             while i > stop {
                 result.push(pyre_object::bytesobject::bytes_like_getitem(
                     obj, i as usize,
                 ));
-                i = i.saturating_add(step);
+                i += step;
             }
         }
         return Ok(if is_bytes {
@@ -2143,7 +2143,7 @@ unsafe fn getitem_range_iter(obj: PyObjectRef, index: PyObjectRef) -> PyResult {
         let mut i = start;
         while (step > 0 && i < stop) || (step < 0 && i > stop) {
             items.push(w_int_new(r.current + i * r.step));
-            i = i.saturating_add(step);
+            i += step;
         }
         return Ok(w_list_new(items));
     }
@@ -2297,7 +2297,7 @@ unsafe fn setitem_list_slice(obj: PyObjectRef, index: PyObjectRef, value: PyObje
         if i >= 0 && i < len {
             indices.push(i);
         }
-        i = i.saturating_add(step);
+        i += step;
     }
     let other_len = pyre_object::w_list_len(w_other);
     if other_len != indices.len() {
@@ -2540,7 +2540,7 @@ unsafe fn setitem_bytearray_slice(
         if i >= 0 && i < len {
             indices.push(i as usize);
         }
-        i = i.saturating_add(step);
+        i += step;
     }
     if sequence2.len() != indices.len() {
         return Err(PyError::new(
@@ -11822,12 +11822,12 @@ pub(crate) fn delitem_slot(obj: PyObjectRef, index: PyObjectRef) -> Result<(), P
                 if step > 0 {
                     while i < stop {
                         indices.push(i);
-                        i = i.saturating_add(step);
+                        i += step;
                     }
                 } else {
                     while i > stop {
                         indices.push(i);
-                        i = i.saturating_add(step);
+                        i += step;
                     }
                 }
                 indices.sort_unstable_by(|a, b| b.cmp(a));
@@ -11873,12 +11873,12 @@ pub(crate) fn delitem_slot(obj: PyObjectRef, index: PyObjectRef) -> Result<(), P
                 if step > 0 {
                     while i < stop {
                         indices.push(i);
-                        i = i.saturating_add(step);
+                        i += step;
                     }
                 } else {
                     while i > stop {
                         indices.push(i);
-                        i = i.saturating_add(step);
+                        i += step;
                     }
                 }
                 indices.sort_unstable_by(|a, b| b.cmp(a));

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -247,6 +247,14 @@ unsafe fn w_memoryview_new_plain(
 ///
 /// # Safety
 /// `mv` must point to a valid `W_MemoryView` with a live backing.
+///
+/// The gather walks the exporter's backing storage through pointer
+/// arithmetic and grows a `Vec<u8>` (`buffer.py:117-127 _copy_base`, an
+/// rstring `StringBuilder` append the tracer does not model element by
+/// element); the sub-slice `&full[b..b+isz]` is a windowed copy, not a
+/// value-model view.  Residualize the whole geometry/copy subtree behind
+/// this single `.gather()` call surface (`@jit.dont_look_inside`).
+#[majit_macros::dont_look_inside]
 pub(crate) unsafe fn memoryview_gather_bytes(mv: PyObjectRef) -> Vec<u8> {
     unsafe { pyre_object::memoryview::w_memoryview_view(mv).gather() }
 }

--- a/pyre/pyre-interpreter/src/call.rs
+++ b/pyre/pyre-interpreter/src/call.rs
@@ -620,6 +620,14 @@ fn set_orig_class(result: PyObjectRef, alias: PyObjectRef) -> Result<(), crate::
     }
 }
 
+// `dont_look_inside`: a builtin is invoked through a runtime `BuiltinCodeFn`
+// value (`func(args)`), a call through a fn-pointer the tracer has no lowering
+// for (only static `CallPath`s lower). The builtin body is the residual
+// boundary — the JIT residualizes the whole dispatch (signature-aware kwarg
+// packing + the C-level call) instead of tracing into it, mirroring
+// `cpu.bh_call_*`. This also keeps `builtin_code_get_signature`'s raw-ptr
+// `as_ref` read out of any traced graph.
+#[majit_macros::dont_look_inside]
 fn call_builtin_code_positional(code: PyObjectRef, args: &[PyObjectRef]) -> PyResult {
     let func = unsafe { builtin_code_get(code) };
     if let Some(sig) = unsafe { crate::builtin_code_get_signature(code) } {
@@ -2187,16 +2195,26 @@ pub fn call_function_impl_raw(callable: PyObjectRef, args: &[PyObjectRef]) -> Py
     match call_function_impl_result(callable, args) {
         Ok(result) => result,
         Err(e) => {
-            // Debug diagnostic reads the real process env + writes real stderr;
-            // keep it out of the sandbox build (host access must go the seam).
-            #[cfg(not(feature = "sandbox"))]
-            if pyre_debug_call_enabled() {
-                eprintln!("[call_function_impl] error: {}", e.message);
-            }
+            log_call_error(&e.message);
             set_call_error(e);
             PY_NULL
         }
     }
+}
+
+/// Cold debug-diagnostic sink for `call_function_impl_raw`. Residualized so
+/// the `eprintln!` formatting machinery (`fmt::rt::Argument`) stays out of the
+/// traced graph — the whole body is a host-stderr write behind the env probe,
+/// which the tracer cannot model. No-op under `sandbox` (host access must go
+/// through the seam).
+#[majit_macros::dont_look_inside]
+fn log_call_error(message: &str) {
+    #[cfg(not(feature = "sandbox"))]
+    if pyre_debug_call_enabled() {
+        eprintln!("[call_function_impl] error: {message}");
+    }
+    #[cfg(feature = "sandbox")]
+    let _ = message;
 }
 
 pub(crate) fn call_function_impl(callable: PyObjectRef, args: &[PyObjectRef]) -> PyObjectRef {

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -1707,14 +1707,26 @@ impl NamespaceOpcodeHandler for PyFrame {
         // is not the one being executed.  Identity is `pycode.w_globals
         // is self.get_w_globals_storage()` — the wrapped dict OBJECT on both
         // sides (`w_code_get_w_globals` vs the frame's `w_globals`).
-        let pycode_matches_frame: bool = unsafe {
-            let cwo = crate::pycode::w_code_get_w_globals(self.pycode as PyObjectRef);
-            !cwo.is_null() && std::ptr::eq(cwo, w_globals)
+        // `celldict.py:287-291 _LOAD_GLOBAL_cached`: under the JIT the
+        // whole `GlobalCache` chase is bypassed via `_load_global_fallback`
+        // → `_load_global` (`pyopcode.py:958-967 space.finditem_str`), so
+        // only the builtin `finditem_str` fallback below runs.  Positive
+        // form (`load_attr_cached` eval.rs:3586) keeps the annotator off
+        // the bare-`!` hazard; `we_are_jitted()` folds to `ConstBool(true)`
+        // so the cache arm and its `Rc<RefCell<GlobalCache>>` chase are
+        // dead-code-eliminated on the lifted graph.
+        let use_cache = if majit_metainterp::jit::we_are_jitted() {
+            false
+        } else {
+            unsafe {
+                let cwo = crate::pycode::w_code_get_w_globals(self.pycode as PyObjectRef);
+                !cwo.is_null()
+                    && std::ptr::eq(cwo, w_globals)
+                    && !w_globals.is_null()
+                    && pyre_object::dictmultiobject::is_module_dict(w_globals)
+            }
         };
-        if pycode_matches_frame
-            && !w_globals.is_null()
-            && unsafe { pyre_object::dictmultiobject::is_module_dict(w_globals) }
-        {
+        if use_cache {
             let cache_hit: Option<PyObjectRef> = unsafe {
                 load_global_via_cache(
                     w_globals,
@@ -1800,6 +1812,16 @@ pub unsafe fn load_global_via_cache_extern(
 /// `Ok(None)` on full miss, `Err(_)` when `space.finditem_str` raises
 /// during the builtins fallback (`baseobjspace.py:45-49
 /// W_Root.getdictvalue` → `space.finditem_str`).
+///
+/// The `GlobalCache` chase walks an `Rc<RefCell<GlobalCache>>` cache
+/// structure the tracer cannot model (its `deref` reads past the
+/// refcount / borrow-flag header, not a value-model identity).
+/// `celldict.py:287-291 _LOAD_GLOBAL_cached` bypasses the whole cache
+/// under `jit.we_are_jitted()`, resolving the builtin through
+/// `space.finditem_str` instead, so the cache is off-trace plumbing;
+/// residualize it (`@jit.dont_look_inside`) like the sibling
+/// `load_attr_caching`.
+#[majit_macros::dont_look_inside]
 unsafe fn load_global_via_cache(
     w_module_dict: PyObjectRef,
     w_builtin: PyObjectRef,

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -414,6 +414,20 @@ unsafe fn walk_builtin_type_dicts_gc(forward: &mut dyn FnMut(&mut PyObjectRef)) 
                         );
                     }
                 }
+                // `mro_w` is a stable type-9 GcArray block (`alloc_mro_block_gc`)
+                // whose only strong root is this immortal type. The custom
+                // trace `type_object_custom_trace` never fires for a Box-immortal
+                // owner, so forward the block field slot here: the collector
+                // marks the tid-9 block and its varsize walker forwards
+                // items[0..len]. Omitting this lets the first major collection
+                // sweep the block — a UAF on the next MRO read. Guard on GC
+                // ownership so the `std::alloc` bootstrap fallback (not owned)
+                // is left in place.
+                if !t.mro_w.is_null()
+                    && pyre_object::gc_hook::try_gc_owns_object(t.mro_w as *mut u8)
+                {
+                    forward(&mut *(std::ptr::addr_of_mut!(t.mro_w) as *mut PyObjectRef));
+                }
             }
         }
     }

--- a/pyre/pyre-interpreter/src/jit_fnaddr.rs
+++ b/pyre/pyre-interpreter/src/jit_fnaddr.rs
@@ -450,10 +450,8 @@ pub fn jit_trace_fnaddrs() -> Vec<(&'static str, i64)> {
     // (`@elidable_promote`, typeobject.py:1657).  Its `#[dont_look_inside]`
     // residualises the call; bind the `-> bool` Rust `fn` directly by
     // qualified path (2-pointer args, JIT-representable, no C-ABI bridge).
-    let w_type_issubtype: unsafe fn(
-        pyre_object::PyObjectRef,
-        pyre_object::PyObjectRef,
-    ) -> bool = pyre_object::w_type_issubtype;
+    let w_type_issubtype: unsafe fn(pyre_object::PyObjectRef, pyre_object::PyObjectRef) -> bool =
+        pyre_object::w_type_issubtype;
     push_alias_pair(
         &mut entries,
         "pyre_object::typeobject::w_type_issubtype",
@@ -634,6 +632,19 @@ pub fn jit_trace_fnaddrs() -> Vec<(&'static str, i64)> {
         "pyre_interpreter::baseobjspace::compute_default_mro",
         "pyre_interpreter::compute_default_mro",
         compute_default_mro as *const (),
+    );
+    // #346: `memoryview_gather_bytes` is the sole `.gather()` call surface —
+    // the buffer-protocol copy leaf whose geometry walk + `Vec<u8>` growth
+    // + `Range`-indexed sub-slices are opaque host plumbing. Residualized
+    // (`#[dont_look_inside]`), it is a `Vec`-returning residual like
+    // `compute_mro`; bind its `fn` directly by qualified path.
+    let memoryview_gather_bytes: unsafe fn(pyre_object::PyObjectRef) -> Vec<u8> =
+        crate::builtins::memoryview_gather_bytes;
+    push_alias_pair(
+        &mut entries,
+        "pyre_interpreter::builtins::memoryview_gather_bytes",
+        "pyre_interpreter::memoryview_gather_bytes",
+        memoryview_gather_bytes as *const (),
     );
     // #346: `lookup_in_type_where_uncached` is the scalar-`Option` residual
     // boundary over the cold uncached MRO walk. With `compute_mro` opaque,

--- a/pyre/pyre-interpreter/src/jit_fnaddr.rs
+++ b/pyre/pyre-interpreter/src/jit_fnaddr.rs
@@ -1022,6 +1022,12 @@ pub fn jit_trace_fnaddrs() -> Vec<(&'static str, i64)> {
     );
     push_alias_pair(
         &mut entries,
+        "pyre_object::dict_eq_hook::eq_error_pending",
+        "pyre_object::eq_error_pending",
+        pyre_object::dict_eq_hook::eq_error_pending as *const (),
+    );
+    push_alias_pair(
+        &mut entries,
         "pyre_interpreter::stack_check::stack_almost_full",
         "pyre_interpreter::stack_almost_full",
         crate::stack_check::stack_almost_full as *const (),
@@ -2112,6 +2118,21 @@ pub fn jit_static_int_values() -> Vec<(&'static str, i64)> {
         // overflow clamp. Charon leaves the associated const as a global
         // accessor path, so bake the native signed max value.
         ("core::num::<Impl>::MAX", i64::MAX),
+        // `compares_by_identity_status` tri-state markers, read as opaque
+        // global accessor paths in `mutated` / the `__eq__`/`__hash__`
+        // fast paths. Bake the build-time `u8` values.
+        (
+            "typeobject::COMPARES_BY_IDENTITY_UNKNOWN",
+            pyre_object::typeobject::COMPARES_BY_IDENTITY_UNKNOWN as i64,
+        ),
+        (
+            "typeobject::COMPARES_BY_IDENTITY_YES",
+            pyre_object::typeobject::COMPARES_BY_IDENTITY_YES as i64,
+        ),
+        (
+            "typeobject::COMPARES_BY_IDENTITY_NO",
+            pyre_object::typeobject::COMPARES_BY_IDENTITY_NO as i64,
+        ),
     ]
 }
 

--- a/pyre/pyre-interpreter/src/jit_fnaddr.rs
+++ b/pyre/pyre-interpreter/src/jit_fnaddr.rs
@@ -445,6 +445,21 @@ pub fn jit_trace_fnaddrs() -> Vec<(&'static str, i64)> {
         "pyre_object::w_type_set_uses_object_setattr",
         crate::opcode_ops::bh_w_type_set_uses_object_setattr as *const (),
     );
+    // `w_type_issubtype` is the MRO membership scan (`_issubtype`,
+    // typeobject.py:1640), run under the JIT inside `_pure_issubtype`
+    // (`@elidable_promote`, typeobject.py:1657).  Its `#[dont_look_inside]`
+    // residualises the call; bind the `-> bool` Rust `fn` directly by
+    // qualified path (2-pointer args, JIT-representable, no C-ABI bridge).
+    let w_type_issubtype: unsafe fn(
+        pyre_object::PyObjectRef,
+        pyre_object::PyObjectRef,
+    ) -> bool = pyre_object::w_type_issubtype;
+    push_alias_pair(
+        &mut entries,
+        "pyre_object::typeobject::w_type_issubtype",
+        "pyre_object::w_type_issubtype",
+        w_type_issubtype as *const (),
+    );
     // `lookup_exc_class_for_kind` reads the TLS `EXC_CLASS_BY_KIND`
     // registry the tracer cannot model; its residual call rides a C-ABI
     // bridge that reconstructs the `ExcKind` from the integer arg slot.

--- a/pyre/pyre-interpreter/src/jit_fnaddr.rs
+++ b/pyre/pyre-interpreter/src/jit_fnaddr.rs
@@ -932,6 +932,12 @@ pub fn jit_trace_fnaddrs() -> Vec<(&'static str, i64)> {
     );
     push_alias_pair(
         &mut entries,
+        "pyre_object::gc_hook::try_gc_owns_object",
+        "pyre_object::try_gc_owns_object",
+        pyre_object::gc_hook::try_gc_owns_object as *const (),
+    );
+    push_alias_pair(
+        &mut entries,
         "pyre_object::dict_eq_hook::has_hash_w_hook",
         "pyre_object::has_hash_w_hook",
         pyre_object::dict_eq_hook::has_hash_w_hook as *const (),

--- a/pyre/pyre-interpreter/src/jit_fnaddr.rs
+++ b/pyre/pyre-interpreter/src/jit_fnaddr.rs
@@ -938,6 +938,12 @@ pub fn jit_trace_fnaddrs() -> Vec<(&'static str, i64)> {
     );
     push_alias_pair(
         &mut entries,
+        "pyre_object::gc_hook::maybe_register_finalizer",
+        "pyre_object::maybe_register_finalizer",
+        pyre_object::gc_hook::maybe_register_finalizer as *const (),
+    );
+    push_alias_pair(
+        &mut entries,
         "pyre_object::dict_eq_hook::has_hash_w_hook",
         "pyre_object::has_hash_w_hook",
         pyre_object::dict_eq_hook::has_hash_w_hook as *const (),

--- a/pyre/pyre-interpreter/src/jit_fnaddr.rs
+++ b/pyre/pyre-interpreter/src/jit_fnaddr.rs
@@ -1894,6 +1894,8 @@ pub fn jit_static_pytype_addrs() -> Vec<(&'static str, i64)> {
             "interp_itertools::PAIRWISE_TYPE",
             interp_itertools::PAIRWISE_TYPE
         ),
+        pytype_addr!("interp_itertools::CYCLE_TYPE", interp_itertools::CYCLE_TYPE),
+        pytype_addr!("interp_itertools::CHAIN_TYPE", interp_itertools::CHAIN_TYPE),
         pytype_addr!("interp_sre::SRE_SCANNER_TYPE", interp_sre::SRE_SCANNER_TYPE),
         pytype_addr!(
             "functional::LONG_RANGE_ITER_TYPE",
@@ -1937,6 +1939,10 @@ pub fn jit_static_pytype_addrs() -> Vec<(&'static str, i64)> {
         (
             "pytraceback::PYTRACEBACK_TYPE",
             &crate::pytraceback::PYTRACEBACK_TYPE as *const _ as i64,
+        ),
+        (
+            "interp_buffer::PICKLEBUFFER_TYPE",
+            &crate::module::__pypy__::interp_buffer::PICKLEBUFFER_TYPE as *const _ as i64,
         ),
     ]
 }

--- a/pyre/pyre-interpreter/src/module/_abc/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_abc/mod.rs
@@ -110,7 +110,7 @@ fn subclass_of(cls: PyObjectRef, subclass: PyObjectRef) -> Result<bool, crate::P
     unsafe {
         let mro_ptr = w_type_get_mro(subclass);
         if !mro_ptr.is_null() {
-            for &t in &*mro_ptr {
+            for &t in (*mro_ptr).as_slice() {
                 if std::ptr::eq(t, cls) {
                     return Ok(true);
                 }

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -1155,7 +1155,7 @@ fn new_typeobject_with_base_and_layout(
     let base_mro = unsafe { w_type_get_mro(base) };
     let mut mro = vec![type_obj];
     if !base_mro.is_null() {
-        mro.extend_from_slice(unsafe { &*base_mro });
+        mro.extend_from_slice(unsafe { (*base_mro).as_slice() });
     } else {
         mro.push(base);
     }
@@ -1864,8 +1864,13 @@ fn check_user_subclass(w_self: PyObjectRef, w_subtype: PyObjectRef) -> Result<()
         return Ok(());
     }
     let mro_ptr = unsafe { pyre_object::w_type_get_mro(w_subtype) };
-    let is_sub =
-        !mro_ptr.is_null() && unsafe { (*mro_ptr).iter().any(|&t| std::ptr::eq(t, w_self)) };
+    let is_sub = !mro_ptr.is_null()
+        && unsafe {
+            (*mro_ptr)
+                .as_slice()
+                .iter()
+                .any(|&t| std::ptr::eq(t, w_self))
+        };
     if !is_sub {
         let self_name = unsafe { pyre_object::w_type_get_name(w_self) };
         let sub_name = unsafe { pyre_object::w_type_get_name(w_subtype) };
@@ -6101,7 +6106,7 @@ fn init_type_type(ns: &mut DictStorage) {
                 if mro_ptr.is_null() {
                     return Ok(pyre_object::w_tuple_new(vec![]));
                 }
-                Ok(pyre_object::w_tuple_new((*mro_ptr).clone()))
+                Ok(pyre_object::w_tuple_new((*mro_ptr).to_vec()))
             }
         },
         2,
@@ -6130,7 +6135,7 @@ fn init_type_type(ns: &mut DictStorage) {
             if mro_ptr.is_null() {
                 return Ok(pyre_object::w_list_new(vec![]));
             }
-            Ok(pyre_object::w_list_new((*mro_ptr).clone()))
+            Ok(pyre_object::w_list_new((*mro_ptr).to_vec()))
         }
     });
     dict_storage_store(ns, "mro", mro_method);

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -334,9 +334,21 @@ unsafe fn type_object_custom_trace(obj_addr: usize, f: &mut dyn FnMut(*mut majit
     f(&mut t.ob_header.w_class as *mut pyre_object::PyObjectRef as *mut majit_ir::GcRef);
     f(&mut t.bases as *mut pyre_object::PyObjectRef as *mut majit_ir::GcRef);
     if !t.mro_w.is_null() {
-        let mro = unsafe { &mut *t.mro_w };
-        for slot in mro.iter_mut() {
-            f(slot as *mut pyre_object::PyObjectRef as *mut majit_ir::GcRef);
+        if pyre_object::gc_hook::try_gc_owns_object(t.mro_w as *mut u8) {
+            // GC-owned type-9 block: forward the `mro_w` field slot; the
+            // varsize walker forwards items[0..len]. Forwarding each element
+            // instead would mark the elements but leave the block itself
+            // unmarked, so a major collection would sweep it (UAF). Mirrors
+            // `list_object_custom_trace`'s GC-owned branch.
+            let mro_slot = std::ptr::addr_of_mut!(t.mro_w);
+            f(mro_slot as *mut majit_ir::GcRef);
+        } else {
+            // std::alloc fallback block (no GC hook): forward each element in
+            // place — the block is stationary and the collector does not own it.
+            let mro = unsafe { &mut *t.mro_w };
+            for slot in mro.as_mut_slice().iter_mut() {
+                f(slot as *mut pyre_object::PyObjectRef as *mut majit_ir::GcRef);
+            }
         }
     }
     if !t.weak_subclasses.is_null() {

--- a/pyre/pyre-object/src/dict_eq_hook.rs
+++ b/pyre/pyre-object/src/dict_eq_hook.rs
@@ -138,8 +138,10 @@ pub extern "C" fn take_eq_error() -> bool {
 /// user `__eq__` calls means no extra comparison runs and the FIRST
 /// exception is the one retained — matching `r_dict(space.eq_w, ...)`
 /// which raises at the first comparison (`dictmultiobject.py:1209`).
-#[inline]
-pub(crate) fn eq_error_pending() -> bool {
+/// `dont_look_inside`: thread-local read, residualizes via the
+/// registered fnaddr (the `take_eq_error` twin).
+#[majit_macros::dont_look_inside]
+pub extern "C" fn eq_error_pending() -> bool {
     EQ_W_ERROR.with(|cell| !cell.get().is_null())
 }
 

--- a/pyre/pyre-object/src/gc_hook.rs
+++ b/pyre/pyre-object/src/gc_hook.rs
@@ -441,8 +441,12 @@ pub fn clear_gc_current_object_address_hook() {
 /// "no GC owns this pointer" and fall through to their non-GC
 /// dealloc path. This is the host-side mirror of
 /// `majit_gc::gc_owns_object`.
-#[inline]
-pub fn try_gc_owns_object(addr: *mut u8) -> bool {
+// `dont_look_inside`: host hook dispatch (a process-global
+// atomic fn-pointer cell) stays opaque to the JIT — traces never look inside a
+// GC ownership check (the backend GC rewrite owns that concern); calls
+// residualize via the registered fnaddr. The `try_gc_write_barrier` twin.
+#[majit_macros::dont_look_inside]
+pub extern "C" fn try_gc_owns_object(addr: *mut u8) -> bool {
     match GC_OWNS_OBJECT_HOOK.get() {
         Some(f) => f(addr as usize),
         None => false,

--- a/pyre/pyre-object/src/gc_hook.rs
+++ b/pyre/pyre-object/src/gc_hook.rs
@@ -302,7 +302,13 @@ pub fn register_maybe_finalizer_hook(hook: MaybeRegisterFinalizerHookFn) {
     MAYBE_REGISTER_FINALIZER_HOOK.set(Some(hook));
 }
 
-pub fn maybe_register_finalizer(obj: PyObjectRef) {
+// `dont_look_inside`: the host finalizer-registration hook is a
+// process-global fn-pointer cell (`MAYBE_REGISTER_FINALIZER_HOOK`) whose
+// dispatch stays opaque to the JIT; calls residualize via the registered
+// fnaddr. The `try_gc_owns_object` twin.
+#[majit_macros::dont_look_inside]
+#[allow(improper_ctypes_definitions)]
+pub extern "C" fn maybe_register_finalizer(obj: PyObjectRef) {
     if let Some(hook) = MAYBE_REGISTER_FINALIZER_HOOK.get() {
         hook(obj);
     }

--- a/pyre/pyre-object/src/object_array.rs
+++ b/pyre/pyre-object/src/object_array.rs
@@ -763,6 +763,58 @@ impl IndexMut<usize> for FixedObjectArray {
     }
 }
 
+/// Allocate a fixed-length `FixedObjectArray` GcArray pre-filled from
+/// `values`, for `W_TypeObject.mro_w` (typeobject.py:179 `mro_w?[*]`, an
+/// immutable `[W_Root]`). The block is `PY_OBJECT_ARRAY_GC_TYPE_ID`
+/// (`Ptr(GcArray(OBJECTPTR))`), so the collector reads its length from the
+/// offset-0 header and forwards items[0..len]; the prepass types
+/// `w_type_get_mro`'s result as `SomeList(SomeInstance(PyObjectRef))`.
+///
+/// Allocated on the **stable** (non-moving old-gen) path via
+/// [`crate::gc_hook::try_gc_alloc_stable_raw`] — the owning `W_TypeObject`
+/// is a `malloc_typed` Box-immortal whose custom trace never fires, so the
+/// MRO block cannot be marked through its owner; keeping it old-gen means
+/// the major collector always scans it from the prebuilt-root set (the
+/// `walk_type_dicts_gc` mro forwarding), never minor-relocates it, and the
+/// caller's `values` slice stays valid because the stable allocator does
+/// not collect. Falls back to a header-prefixed `std::alloc` block when no
+/// GC hook is installed (bootstrap / pure interpreter). A young MRO element
+/// (a metaclass `mro()` returning fresh types) is registered on the
+/// remembered set via the old→young write barrier.
+pub unsafe fn alloc_mro_block_gc(values: &[PyObjectRef]) -> *mut FixedObjectArray {
+    let len = values.len();
+    let payload = FIXED_ARRAY_ITEMS_OFFSET + len * std::mem::size_of::<PyObjectRef>();
+    let raw = crate::gc_hook::try_gc_alloc_stable_raw(PY_OBJECT_ARRAY_GC_TYPE_ID, payload);
+    let block = if !raw.is_null() {
+        raw as *mut FixedObjectArray
+    } else {
+        // Bootstrap / no-hook fallback: a plain `std::alloc` block. It carries
+        // no GcHeader (the collector never observes it — `try_gc_owns_object`
+        // reports false), matching the mapdict-storage fallback contract.
+        let layout = Layout::from_size_align(payload, std::mem::align_of::<FixedObjectArray>())
+            .expect("mro block layout");
+        let mem = unsafe { alloc(layout) };
+        if mem.is_null() {
+            std::alloc::handle_alloc_error(layout);
+        }
+        mem as *mut FixedObjectArray
+    };
+    unsafe {
+        (*block).len = len;
+        let items = (*block).items_mut_ptr();
+        for (i, &v) in values.iter().enumerate() {
+            items.add(i).write(v);
+        }
+        // Old→young barrier if the block landed in old-gen and any element is a
+        // young object: registers the block on the remembered set so a later
+        // minor collection forwards the young MRO entries.
+        if crate::gc_hook::try_gc_owns_object(block as *mut u8) {
+            crate::gc_hook::try_gc_write_barrier(block as *mut u8);
+        }
+    }
+    block
+}
+
 // ─── GcTypedArray: typed array helper for resume / blackhole ─────────
 //
 // llmodel.py:788-789: bh_new_array / bh_new_array_clear

--- a/pyre/pyre-object/src/typeobject.rs
+++ b/pyre/pyre-object/src/typeobject.rs
@@ -724,6 +724,13 @@ pub unsafe fn w_type_get_mro(obj: PyObjectRef) -> *mut Vec<PyObjectRef> {
 /// (typeobject.py:603/1640).  The single home for the MRO subtype check;
 /// interpreter-level subtype guards and reflected-binop dispatch delegate
 /// here rather than each re-scanning the MRO.
+///
+/// Under the JIT `issubtype` runs this scan inside `_pure_issubtype`
+/// (`@elidable_promote`, typeobject.py:1657), so the MRO membership walk
+/// is not traced — its result is promoted.  The `dont_look_inside` marker
+/// is the equivalent boundary: the JIT residualises the call instead of
+/// tracing the per-type MRO read the tracer cannot model.
+#[majit_macros::dont_look_inside]
 pub unsafe fn w_type_issubtype(w_type: PyObjectRef, cls: PyObjectRef) -> bool {
     let mro_ptr = w_type_get_mro(w_type);
     if mro_ptr.is_null() {

--- a/pyre/pyre-object/src/typeobject.rs
+++ b/pyre/pyre-object/src/typeobject.rs
@@ -105,8 +105,12 @@ pub struct W_TypeObject {
     pub bases: PyObjectRef,
     /// Raw pointer to the class dict backing storage (`dict_w` analogue).
     pub dict: *mut u8,
-    /// Cached C3 MRO — W_TypeObject.mro_w.
-    pub mro_w: *mut Vec<PyObjectRef>,
+    /// Cached C3 MRO — W_TypeObject.mro_w (typeobject.py:179 `mro_w?[*]`,
+    /// an immutable `[W_Root]`). Stored as a stable `Ptr(GcArray(OBJECTPTR))`
+    /// block (`alloc_mro_block_gc`) so the length-prefixed inline layout
+    /// matches upstream and a JIT-prepass read types as
+    /// `SomeList(SomeInstance(PyObjectRef))`.
+    pub mro_w: *mut crate::object_array::FixedObjectArray,
     /// typeobject.py:184 `flag_heaptype` — immutable after creation.
     pub flag_heaptype: bool,
     /// typeobject.py:195 `layout` — pointer to shared Layout object.
@@ -714,8 +718,8 @@ pub unsafe fn w_type_get_dict_ptr(obj: PyObjectRef) -> *mut u8 {
     (*(obj as *const W_TypeObject)).dict
 }
 
-/// Get the cached MRO, or null if not yet set.
-pub unsafe fn w_type_get_mro(obj: PyObjectRef) -> *mut Vec<PyObjectRef> {
+/// Get the cached MRO block, or null if not yet set.
+pub unsafe fn w_type_get_mro(obj: PyObjectRef) -> *mut crate::object_array::FixedObjectArray {
     (*(obj as *const W_TypeObject)).mro_w
 }
 
@@ -747,7 +751,7 @@ pub unsafe fn w_type_issubtype(w_type: PyObjectRef, cls: PyObjectRef) -> bool {
         }
         return false;
     }
-    (*mro_ptr).iter().any(|&t| std::ptr::eq(t, cls))
+    (*mro_ptr).as_slice().iter().any(|&t| std::ptr::eq(t, cls))
 }
 
 /// typeobject.py:1335-1354 find_best_base — the type base whose instance
@@ -790,7 +794,7 @@ unsafe fn find_best_base(w_type: PyObjectRef) -> PyObjectRef {
 /// uncacheable) — `mutated()` then never refreshes it.
 pub unsafe fn w_type_set_mro(obj: PyObjectRef, mro: Vec<PyObjectRef>) {
     let purely_of_types = is_mro_purely_of_types(&mro);
-    (*(obj as *mut W_TypeObject)).mro_w = crate::lltype::malloc_raw(mro);
+    (*(obj as *mut W_TypeObject)).mro_w = crate::object_array::alloc_mro_block_gc(&mro);
     crate::gc_hook::try_gc_write_barrier(obj as *mut u8);
     if !purely_of_types {
         w_type_set_version_tag(obj, 0);


### PR DESCRIPTION
Advances gh#346 (retire the legacy rtyper walker) by closing several JIT-prepass census residual clusters so more production graphs lift through the two-phase (annotate→rtype) CodeWriter path. Each slice was census-verified (the targeted foreign-leaf cluster disappears; newly-exposed leaves are all known-deeper foreign clusters, per the domino structure) and passes `pyre/check.py` on all three backends (dynasm / cranelift / wasm 162/162).

## Slices

- **jit_fnaddr: register CYCLE/CHAIN/PICKLEBUFFER static PyType addrs** — the three `#[pyre_class]` static PyType singletons missing from `jit_static_pytype_addrs()`, so a `Global` read of their `_TYPE` lowers to the typed `__pyre_cast_instance` narrow instead of an unregistered 0-arg FunctionPath call.

- **isinstance_w: delegate MRO scan to w_type_issubtype** — `isinstance_w` reimplemented the MRO membership walk inline (`for &t in &*mro_ptr`), lowering to a foreign `slice::iter::Iter::next` that blocked six graphs. Delegate to the single `w_type_issubtype` home and mark it `#[dont_look_inside]`, mirroring PyPy `_pure_issubtype` `@elidable_promote` (`typeobject.py:1657`) — the MRO scan is not traced.

- **baseobjspace: slice loops step with `+=`** — the `saturating_add(step)` slice-loop index bump lowered to a foreign `saturating_add`; `normalize_slice` already clamps the bounds, so a plain `+=` is parity-equivalent (matches PyPy `start += step`).

- **mir: is_vec_index_call reads index type from callsite generics** — the gate typed the index on `fd.signature.inputs[1]`, dead under Charon `monomorphize:false` (the `index` signature keeps the generic param `I` as a `TypeVar`→`Ref`). Read the concrete index from the callsite substitution `reg.generics.types[1]`: `Index<usize>` lowers to a scalar `ArrayRead`; `Index<Range<…>>` stays foreign.

- **mir: recognize reused-argument placeholders in packed fmt templates** — the `format_args!` packed-template decoder handled only the sequential `0xC0` placeholder. `descroperation::add`'s `"can only concatenate {a} (not \"{b}\") to {a}"` tail reuses an argument, packed as a `0xC8` explicit-index placeholder (a 3-byte token: `0xC8` + little-endian u16 index). Decode it and thread a per-placeholder argument-index list through `FmtChain` and both collapsers so a reused argument re-renders its recovered value.

- **eval: residualize load_global_via_cache, gate the cache off-trace** — `load_global_via_cache` chases an `Rc<RefCell<GlobalCache>>` whose `deref` reads past the refcount header (not a value-model identity). Mark it `#[dont_look_inside]` and gate the interpreter cache arm behind `we_are_jitted()` in positive form, matching PyPy `celldict.py:287-291` (bypass the cache under the JIT → `space.finditem_str`).

- **builtins: residualize memoryview_gather_bytes** — the sole `.gather()` call surface; the gather walks the exporter backing through pointer arithmetic and grows a `Vec<u8>` (a `StringBuilder`-style copy, `buffer.py:117-127`), and its sub-slice is a windowed copy, not a view. Mark the wrapper `#[dont_look_inside]` and register its fnaddr (a `Vec`-returning residual, like `compute_mro`).

## Verification

- Census: each targeted leaf cluster vanishes; distinct `.cachedgraph` residuals fall from 18 → 15. Newly-exposed leaves are all known-deeper foreign clusters, not pyre-local regressions.
- `pyre/check.py`: dynasm 162/162, cranelift 162/162, wasm 162/162.

🤖 Generated with [Claude Code](https://claude.com/claude-code)