### PR TITLE
gc: incminimark parity — nursery zero-fill removal, ArenaCollection port, incremental sweep

### DIFF
--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -8149,11 +8149,11 @@ impl CraneliftBackend {
             // at the IR level), so the rewriter takes the single-LEA
             // path (rewrite.py:1083-1088).
             supports_load_effective_address: true,
-            // nursery.rs:68 `alloc_zeroed` + nursery.rs:105-110 `reset`
-            // memset-to-zero on recycle mean the nursery payload is
-            // always zero-filled at allocation time; `clear_gc_fields`
-            // thus short-circuits per rewrite.py:499-500.
-            malloc_zero_filled: true,
+            // incminimark.py:211 `malloc_zero_filled = False`:
+            // clear_gc_fields / clear_varsize_gc_fields emit only the
+            // per-object GC-pointer initialization required by
+            // rewrite.py:498-535.
+            malloc_zero_filled: false,
             // gc.py:39 `self.memcpy_fn = memcpy_fn` cast through
             // `cast_ptr_to_adr` + `cast_adr_to_int` (rewrite.py:1046-1047).
             memcpy_fn: majit_ir::memcpy_fn_addr(),
@@ -12104,6 +12104,16 @@ impl CraneliftBackend {
                     for (i, &(var_idx, _)) in live_refs.iter().enumerate() {
                         builder.def_var(var(var_idx), params[2 + i]);
                     }
+                    // jitframe.py:105-116: the custom tracer reads jf_gcmap
+                    // even though it is a raw Ptr(GCMAP), not one of the five
+                    // GCREF/forward fields explicitly cleared by
+                    // rewrite.py:641-650.  PyPy's unusual varsize-frame
+                    // allocation starts this pointer as NULL; recycled nursery
+                    // bytes do not.  Initialize it before publishing the frame.
+                    let zero_gcmap = builder.ins().iconst(cl_types::I64, 0);
+                    builder
+                        .ins()
+                        .store(MemFlags::trusted(), zero_gcmap, result, JF_GCMAP_OFS);
                     builder.def_var(var(vi), result);
                 }
 
@@ -16460,29 +16470,31 @@ impl majit_backend::Backend for CraneliftBackend {
     fn bh_new_with_vtable(&self, sizedescr: &majit_translate::jitcode::BhDescr) -> i64 {
         let size = sizedescr.as_size();
         let vtable = sizedescr.get_vtable();
-        let ptr = match with_cranelift_gc(|gc| {
-            // TODO: same cache-key/gc-tid conflation
-            // as `bh_new`; truncate `as u32` until gc_cache routing.
-            gc.alloc_nursery_typed(sizedescr.get_type_id() as u32, size)
-                .0 as i64
-        }) {
-            Some(p) => p,
-            None => {
-                let layout = std::alloc::Layout::from_size_align(size, 8)
-                    .unwrap_or(std::alloc::Layout::new::<u8>());
-                unsafe { std::alloc::alloc_zeroed(layout) as i64 }
-            }
+        let type_id = sizedescr.get_type_id() as u32;
+        // resume.py direct-reader materialization retains raw pointers across
+        // the forward blackhole run.  Match Dynasm's bh_new_with_vtable:
+        // typed virtuals are born zero-filled in non-moving oldgen.  The old
+        // Cranelift nursery path exposed recycled poison in omitted fields
+        // (W_LongObject.w_class and PyFrame's fixed fields) and could also
+        // stale the materialized pointer at the next minor collection.
+        let ptr = if type_id != 0 {
+            with_cranelift_gc(|gc| gc.alloc_oldgen_typed(type_id, size).0 as *mut u8)
+                .unwrap_or(std::ptr::null_mut())
+        } else {
+            let layout = std::alloc::Layout::from_size_align(size, 8)
+                .unwrap_or(std::alloc::Layout::new::<u8>());
+            unsafe { std::alloc::alloc_zeroed(layout) }
         };
         // llmodel.py:780-782: if self.vtable_offset is not None:
         //   self.write_int_at_mem(res, self.vtable_offset, WORD, sizedescr.get_vtable())
         if let Some(vt_off) = self.vtable_offset {
-            if vtable != 0 && ptr != 0 {
+            if vtable != 0 && !ptr.is_null() {
                 unsafe {
                     *((ptr as *mut u8).add(vt_off) as *mut usize) = vtable;
                 }
             }
         }
-        ptr
+        ptr as i64
     }
 
     /// llmodel.py:788-790 bh_new_array / bh_new_array_clear.

--- a/majit/majit-backend-dynasm/src/aarch64/assembler.rs
+++ b/majit/majit-backend-dynasm/src/aarch64/assembler.rs
@@ -3308,6 +3308,10 @@ impl<'a> AssemblerARM64<'a> {
             OpCode::CondCallGcWb | OpCode::CondCallGcWbArray => {
                 self.emit_write_barrier_fastpath(op, &arglocs);
             }
+            // aarch64/opassembler.py:755 emit_op_zero_array.  This is a
+            // result-less operation, but it is the initialization contract
+            // for NEW_ARRAY_CLEAR when malloc_zero_filled=false.
+            OpCode::ZeroArray => self.genop_discard_zero_array(op, arglocs),
             // ── Misc ──
             OpCode::ForceToken => {
                 if let Some(Loc::Reg(r)) = result_loc {
@@ -6858,37 +6862,123 @@ impl<'a> AssemblerARM64<'a> {
 
     /// ZERO_ARRAY: zero a range in an array.
     /// arg(0)=base, arg(1)=start, arg(2)=size, arg(3)=scale_start, arg(4)=scale_size.
-    fn genop_discard_zero_array(&mut self, op: &Op) {
-        let (base_size, _) = op
+    fn genop_discard_zero_array(&mut self, op: &Op, arglocs: &[Loc]) {
+        let [base_loc, start_loc, size_loc, ..] = arglocs else {
+            panic!("ZERO_ARRAY expects five regalloc locations, got {arglocs:?}");
+        };
+        if matches!(size_loc, Loc::Immed(i) if i.value == 0) {
+            return;
+        }
+        let (base_size, item_size) = op
             .with_array_descr(|ad| (ad.base_size() as i64, ad.item_size() as i64))
             .unwrap_or((8, 8));
 
         let scale_start = self.resolve_const_or(op.arg(3).to_opref(), 1);
         let scale_size = self.resolve_const_or(op.arg(4).to_opref(), 1);
-        let memset_ptr = libc::memset as *const () as i64;
 
-        // byte_offset = base_size + start * scale_start
-        // byte_length = size * scale_size
-        self.load_arg_to_rax(op.arg(0).to_opref()); // base
-        self.load_arg_to_rcx(op.arg(1).to_opref()); // start
-
-        if scale_start != 1 {
-            self.emit_mov_imm64(2, scale_start);
-            dynasm!(self.mc ; .arch aarch64 ; mul x1, x1, x2);
+        // aarch64/opassembler.py:755-839: first compute the byte destination
+        // in ip0/x16.  ip0/ip1 are never managed by regalloc.
+        self.regalloc_mov(base_loc, &Loc::Reg(crate::aarch64::registers::X16));
+        if let Loc::Immed(start) = start_loc {
+            let byte_offset = base_size + start.value * scale_start;
+            if byte_offset != 0 {
+                if (0..4096).contains(&byte_offset) {
+                    dynasm!(self.mc ; .arch aarch64 ; add x16, x16, byte_offset as u32);
+                } else {
+                    self.emit_mov_imm64(17, byte_offset);
+                    dynasm!(self.mc ; .arch aarch64 ; add x16, x16, x17);
+                }
+            }
+        } else {
+            self.regalloc_mov(start_loc, &Loc::Reg(crate::aarch64::registers::X17));
+            if scale_start != 1 {
+                self.emit_mov_imm64(2, scale_start);
+                dynasm!(self.mc ; .arch aarch64 ; mul x17, x17, x2);
+            }
+            if (0..4096).contains(&base_size) {
+                dynasm!(self.mc ; .arch aarch64
+                    ; add x16, x16, x17
+                    ; add x16, x16, base_size as u32
+                );
+            } else {
+                self.emit_mov_imm64(2, base_size);
+                dynasm!(self.mc ; .arch aarch64
+                    ; add x16, x16, x17
+                    ; add x16, x16, x2
+                );
+            }
         }
-        dynasm!(self.mc ; .arch aarch64
-            ; add x0, x0, base_size as u32
-            ; add x0, x0, x1
-            ; str x0, [sp, #-16]!               // save dest
-        );
-        self.load_arg_to_rax(op.arg(2).to_opref());
+
+        let natural_size = if item_size & 1 != 0 {
+            1
+        } else if item_size & 2 != 0 {
+            2
+        } else if item_size & 4 != 0 {
+            4
+        } else {
+            8
+        };
+        let constant_start = matches!(start_loc, Loc::Immed(_));
+        let limit = if natural_size < 8 && constant_start {
+            8
+        } else {
+            natural_size
+        };
+        let constant_bytes = match size_loc {
+            Loc::Immed(size) => Some(size.value * scale_size),
+            _ => None,
+        };
+
+        if let Some(total_size) = constant_bytes.filter(|size| *size >= 0 && *size <= 14 * limit) {
+            // aarch64/opassembler.py:796-835 — inline STRB/STRH/STRW/STR.
+            // For a constant byte start, group naturally aligned runs into
+            // eight-byte stores exactly as upstream does.
+            let start_byte = match start_loc {
+                Loc::Immed(start) => start.value * scale_start,
+                _ => -1,
+            };
+            let mut next_group = -1;
+            if natural_size < 8 && start_byte >= 0 {
+                next_group = (-start_byte) & 7;
+            }
+            let mut i = 0;
+            let mut dst_i = 0;
+            while i < total_size {
+                let mut size = natural_size;
+                if i == next_group {
+                    next_group += 8;
+                    if next_group <= total_size {
+                        size = 8;
+                        if dst_i % 8 != 0 {
+                            dynasm!(self.mc ; .arch aarch64 ; add x16, x16, dst_i as u32);
+                            dst_i = 0;
+                        }
+                    }
+                }
+                let offset = dst_i as u32;
+                match size {
+                    8 => dynasm!(self.mc ; .arch aarch64 ; str xzr, [x16, offset]),
+                    4 => dynasm!(self.mc ; .arch aarch64 ; str wzr, [x16, offset]),
+                    2 => dynasm!(self.mc ; .arch aarch64 ; strh wzr, [x16, offset]),
+                    _ => dynasm!(self.mc ; .arch aarch64 ; strb wzr, [x16, offset]),
+                }
+                i += size;
+                dst_i += size;
+            }
+            return;
+        }
+
+        // Residual non-collecting call.  Regalloc has already applied its
+        // normal `before_call(SAVE_DEFAULT_REGS)` policy, so no blanket
+        // jitframe save/restore is needed here.
+        let memset_ptr = libc::memset as *const () as i64;
+        self.regalloc_mov(size_loc, &Loc::Reg(crate::aarch64::registers::X2));
         if scale_size != 1 {
             self.emit_mov_imm64(1, scale_size);
-            dynasm!(self.mc ; .arch aarch64 ; mul x0, x0, x1);
+            dynasm!(self.mc ; .arch aarch64 ; mul x2, x2, x1);
         }
         dynasm!(self.mc ; .arch aarch64
-            ; mov x2, x0                         // byte_length
-            ; ldr x0, [sp], #16                  // dest
+            ; mov x0, x16                        // dest
             ; mov x1, 0
             ; stp x29, x30, [sp, #-16]!
         );

--- a/majit/majit-backend-dynasm/src/regalloc.rs
+++ b/majit/majit-backend-dynasm/src/regalloc.rs
@@ -3008,7 +3008,10 @@ impl<'a> RegAlloc<'a> {
             {
                 self.consider_setarrayitem_j2(args[0], args[1], args[2], i, output);
             }
-            OpCode::ZeroArray | OpCode::Strsetitem | OpCode::Unicodesetitem if args.len() >= 3 => {
+            OpCode::ZeroArray if args.len() >= 3 => {
+                self.consider_zero_array_j2(args, op, i, output);
+            }
+            OpCode::Strsetitem | OpCode::Unicodesetitem if args.len() >= 3 => {
                 self.consider_discard_3args_j2(args, i, output);
             }
             OpCode::Copystrcontent | OpCode::Copyunicodecontent => {
@@ -3267,9 +3270,7 @@ impl<'a> RegAlloc<'a> {
             OpCode::SetinteriorfieldGc | OpCode::SetinteriorfieldRaw => {
                 self.consider_setinteriorfield(op, i, output);
             }
-            OpCode::ZeroArray => {
-                self.consider_discard_3args(op, i, output);
-            }
+            OpCode::ZeroArray => self.consider_zero_array(op, i, output),
             OpCode::Strsetitem | OpCode::Unicodesetitem => {
                 self.consider_discard_3args(op, i, output);
             }
@@ -5936,6 +5937,108 @@ impl<'a> RegAlloc<'a> {
         for &arg in args {
             let tp = self.tp(arg);
             locs.push(self.make_sure_var_in_reg(arg, tp, args, None, false));
+        }
+        self.perform_discard(i, locs, output);
+    }
+
+    /// Select the inline-store or residual-memset ZERO_ARRAY path using the
+    /// same per-backend limits as upstream.  x86/regalloc.py:1436-1503 does
+    /// this split in regalloc; aarch64/opassembler.py:755-839 does it while
+    /// emitting, but the residual call still needs `before_call` here so only
+    /// live caller-saved registers are preserved.
+    fn zero_array_uses_memset(&self, op: &Op) -> bool {
+        let size = op.arg(2).to_opref();
+        if !size.is_constant() {
+            return true;
+        }
+        let mut size = self.const_value(size);
+        let scale = op.arg(4).to_opref();
+        if !scale.is_constant() {
+            return true;
+        }
+        size *= self.const_value(scale);
+
+        #[cfg(target_arch = "x86_64")]
+        {
+            // x86/regalloc.py:1451 — 16 eight-byte chunks.
+            !(0..=16 * 8).contains(&size)
+        }
+
+        #[cfg(target_arch = "aarch64")]
+        {
+            // aarch64/opassembler.py:796-812 — choose the natural STR width
+            // from the array item size.  A constant start permits aligned
+            // runs of eight-byte STRs even for byte/halfword/word arrays.
+            let item_size = op.with_array_descr(|ad| ad.item_size() as i64).unwrap_or(8);
+            let item_size = if item_size & 1 != 0 {
+                1
+            } else if item_size & 2 != 0 {
+                2
+            } else if item_size & 4 != 0 {
+                4
+            } else {
+                8
+            };
+            let start_is_constant = op.arg(1).to_opref().is_constant();
+            let limit = if item_size < 8 && start_is_constant {
+                8
+            } else {
+                item_size
+            };
+            size < 0 || size > 14 * limit
+        }
+    }
+
+    fn preserve_for_zero_array_memset(&mut self) {
+        let type_index = OpTypeIndex::from_parts(
+            self.inputargs,
+            self.operations,
+            &self.inputarg_pos,
+            &self.op_pos,
+        );
+        self.rm.before_call(
+            &[],
+            SAVE_DEFAULT_REGS,
+            &mut self.longevity,
+            &mut self.fm,
+            &mut self.pending_moves,
+            &type_index,
+        );
+        self.xrm.before_call(
+            &[],
+            SAVE_DEFAULT_REGS,
+            &mut self.longevity,
+            &mut self.fm,
+            &mut self.pending_moves,
+            &type_index,
+        );
+    }
+
+    fn consider_zero_array(&mut self, op: &Op, i: usize, output: &mut Vec<RegAllocOp>) {
+        let args: Vec<OpRef> = op.getarglist().iter().map(|a| a.to_opref()).collect();
+        let mut locs = Vec::with_capacity(args.len());
+        for &arg in &args {
+            locs.push(self.make_sure_var_in_reg(arg, self.tp(arg), &args, None, false));
+        }
+        if self.zero_array_uses_memset(op) {
+            self.preserve_for_zero_array_memset();
+        }
+        self.perform_discard(i, locs, output);
+    }
+
+    fn consider_zero_array_j2(
+        &mut self,
+        args: &[OpRef],
+        op: &Op,
+        i: usize,
+        output: &mut Vec<RegAllocOp>,
+    ) {
+        let mut locs = Vec::with_capacity(args.len());
+        for &arg in args {
+            locs.push(self.make_sure_var_in_reg(arg, self.tp(arg), args, None, false));
+        }
+        if self.zero_array_uses_memset(op) {
+            self.preserve_for_zero_array_memset();
         }
         self.perform_discard(i, locs, output);
     }

--- a/majit/majit-backend-dynasm/src/runner.rs
+++ b/majit/majit-backend-dynasm/src/runner.rs
@@ -1329,11 +1329,11 @@ impl DynasmBackend {
                 // even though the aarch64 backend has a native
                 // `genop_load_effective_address` lowering.
                 supports_load_effective_address: supports_load_effective_address(),
-                // nursery.rs:68 `alloc_zeroed` + nursery.rs:105-110
-                // `reset` memset-to-zero on recycle mean the nursery
-                // payload is always zero-filled at allocation time;
-                // `clear_gc_fields` short-circuits per rewrite.py:499-500.
-                malloc_zero_filled: true,
+                // incminimark.py:211 `malloc_zero_filled = False`:
+                // clear_gc_fields / clear_varsize_gc_fields emit only the
+                // per-object GC-pointer initialization required by
+                // rewrite.py:498-535.
+                malloc_zero_filled: false,
                 // gc.py:39 `self.memcpy_fn = memcpy_fn` cast through
                 // `cast_ptr_to_adr` + `cast_adr_to_int` (rewrite.py:1046-1047).
                 memcpy_fn: majit_ir::memcpy_fn_addr(),

--- a/majit/majit-backend-dynasm/src/x86/assembler.rs
+++ b/majit/majit-backend-dynasm/src/x86/assembler.rs
@@ -4359,6 +4359,11 @@ impl<'a> Assembler386<'a> {
             OpCode::CondCallGcWb | OpCode::CondCallGcWbArray => {
                 self.emit_write_barrier_fastpath(op, &arglocs);
             }
+            // x86/assembler.py:2694 genop_discard_zero_array.  The GC
+            // rewriter leaves ZERO_ARRAY in the stream and mutates its range
+            // after observing following SETARRAYITEM_GC stores; it must reach
+            // codegen even though it has no result.
+            OpCode::ZeroArray => self.genop_discard_zero_array(op, arglocs),
             // ── Misc ──
             OpCode::ForceToken => {
                 if let Some(Loc::Reg(r)) = result_loc {
@@ -8735,44 +8740,102 @@ impl<'a> Assembler386<'a> {
 
     /// ZERO_ARRAY: zero a range in an array.
     /// arg(0)=base, arg(1)=start, arg(2)=size, arg(3)=scale_start, arg(4)=scale_size.
-    fn genop_discard_zero_array(&mut self, op: &Op) {
+    fn genop_discard_zero_array(&mut self, op: &Op, arglocs: &[Loc]) {
+        let [base_loc, start_loc, size_loc, ..] = arglocs else {
+            panic!("ZERO_ARRAY expects five regalloc locations, got {arglocs:?}");
+        };
+        if matches!(size_loc, Loc::Immed(i) if i.value == 0) {
+            return;
+        }
         let (base_size, _) = op
             .with_array_descr(|ad| (ad.base_size() as i64, ad.item_size() as i64))
             .unwrap_or((8, 8));
 
         let scale_start = self.resolve_const_or(op.arg(3).to_opref(), 1);
         let scale_size = self.resolve_const_or(op.arg(4).to_opref(), 1);
-        let memset_ptr = libc::memset as *const () as i64;
 
-        // byte_offset = base_size + start * scale_start
-        // byte_length = size * scale_size
-        self.load_arg_to_rax(op.arg(0).to_opref()); // base
-        self.load_arg_to_rcx(op.arg(1).to_opref()); // start
-
-        if scale_start != 1 {
-            dynasm!(self.mc ; .arch x64 ; imul rcx, rcx, scale_start as i32);
+        // x86/regalloc.py:1436-1503 + assembler.py:2694-2725.  Materialize
+        // the effective address in r11, PyPy's reserved x86-64 scratch GPR.
+        let scratch = crate::regloc::X86_64_SCRATCH_REG.value;
+        self.regalloc_mov(base_loc, &Loc::Reg(crate::regloc::X86_64_SCRATCH_REG));
+        match start_loc {
+            Loc::Reg(start) => match scale_start {
+                1 => {
+                    dynasm!(self.mc ; .arch x64 ; lea Rq(scratch), [Rq(scratch) + Rq(start.value) + base_size as i32])
+                }
+                2 => {
+                    dynasm!(self.mc ; .arch x64 ; lea Rq(scratch), [Rq(scratch) + Rq(start.value) * 2 + base_size as i32])
+                }
+                4 => {
+                    dynasm!(self.mc ; .arch x64 ; lea Rq(scratch), [Rq(scratch) + Rq(start.value) * 4 + base_size as i32])
+                }
+                8 => {
+                    dynasm!(self.mc ; .arch x64 ; lea Rq(scratch), [Rq(scratch) + Rq(start.value) * 8 + base_size as i32])
+                }
+                _ => panic!("ZERO_ARRAY invalid start scale {scale_start}"),
+            },
+            Loc::Immed(start) => {
+                let offset = base_size + start.value * scale_start;
+                dynasm!(self.mc ; .arch x64 ; add Rq(scratch), offset as i32);
+            }
+            Loc::Frame(start) => {
+                let offset = start.ebp_loc.value;
+                dynasm!(self.mc ; .arch x64
+                    ; imul rax, [rbp + offset], scale_start as i32
+                    ; add Rq(scratch), rax
+                    ; add Rq(scratch), base_size as i32
+                );
+            }
+            other => panic!("ZERO_ARRAY expected GPR/frame/immediate start, got {other:?}"),
         }
-        dynasm!(self.mc ; .arch x64
-            ; add rax, DWORD base_size as i32
-            ; add rax, rcx
-            ; push rax                           // save dest
-        );
-        self.load_arg_to_rax(op.arg(2).to_opref()); // size
+
+        if let Loc::Immed(bytes) = size_loc {
+            let nbytes = bytes.value * scale_size;
+            if (0..=16 * 8).contains(&nbytes) {
+                let xmm = crate::regloc::X86_64_XMM_SCRATCH_REG.value;
+                let mut cleared = false;
+                let mut offset = 0;
+                while offset < nbytes {
+                    let remaining = nbytes - offset;
+                    let current = if remaining >= 16 {
+                        if !cleared {
+                            dynasm!(self.mc ; .arch x64 ; xorps Rx(xmm), Rx(xmm));
+                            cleared = true;
+                        }
+                        dynasm!(self.mc ; .arch x64 ; movups [Rq(scratch) + offset as i32], Rx(xmm));
+                        16
+                    } else if remaining >= 8 {
+                        dynasm!(self.mc ; .arch x64 ; mov QWORD [Rq(scratch) + offset as i32], 0);
+                        8
+                    } else if remaining >= 4 {
+                        dynasm!(self.mc ; .arch x64 ; mov DWORD [Rq(scratch) + offset as i32], 0);
+                        4
+                    } else if remaining >= 2 {
+                        dynasm!(self.mc ; .arch x64 ; mov WORD [Rq(scratch) + offset as i32], 0);
+                        2
+                    } else {
+                        dynasm!(self.mc ; .arch x64 ; mov BYTE [Rq(scratch) + offset as i32], 0);
+                        1
+                    };
+                    offset += current;
+                }
+                return;
+            }
+        }
+
+        // Large/non-constant residual call.  Regalloc has already run the
+        // backend's ordinary non-collecting `before_call` preservation.
+        let memset_ptr = libc::memset as *const () as i64;
+        self.regalloc_mov(size_loc, &Loc::Reg(crate::regloc::EDX));
         if scale_size != 1 {
-            dynasm!(self.mc ; .arch x64 ; imul rax, rax, scale_size as i32);
+            dynasm!(self.mc ; .arch x64 ; imul rdx, rdx, scale_size as i32);
         }
         // memset(dest, 0, byte_length)
-        dynasm!(self.mc ; .arch x64
-            ; mov rdx, rax                       // byte_length
-            ; pop rax                            // dest
-            ; push rbp
-        );
         self.emit_abi_int_arg_from_reg(2, 2);
         self.emit_abi_int_arg_from_imm(1, 0);
-        self.emit_abi_int_arg_from_reg(0, 0);
+        self.emit_abi_int_arg_from_reg(0, scratch);
         dynasm!(self.mc ; .arch x64 ; mov rax, QWORD memset_ptr);
-        self.emit_abi_call_rax_after_one_push();
-        dynasm!(self.mc ; .arch x64 ; pop rbp);
+        self.emit_abi_call_rax();
     }
 
     // ================================================================

--- a/majit/majit-backend-wasm/src/lib.rs
+++ b/majit/majit-backend-wasm/src/lib.rs
@@ -2344,7 +2344,15 @@ impl majit_backend::Backend for WasmBackend {
                     .collect();
 
                 // Done reading the frame; release it from the jf shadow stack
-                // (it becomes collectible) and free the gcmap.
+                // (it becomes collectible) and free the gcmap. Null the frame's
+                // jf_gcmap before dropping the gcmap Box: the old-gen frame can
+                // outlive this call still marked VISITED (grayed while it was a
+                // root at a major-cycle start), reachable through the major
+                // gray stack or the remembered set. A later collection would
+                // then custom-trace it and read the freed gcmap. A null gcmap
+                // makes jitframe_trace forward nothing (jitframe.py:115-116),
+                // which is correct here: the outputs were already read out.
+                unsafe { (*jf).jf_gcmap = std::ptr::null() };
                 majit_gc::shadow_stack::pop_jf_to(saved);
                 drop(gcmap);
 

--- a/majit/majit-gc/src/collector.rs
+++ b/majit/majit-gc/src/collector.rs
@@ -1595,6 +1595,33 @@ impl MiniMarkGC {
         GcRef(new_obj_addr)
     }
 
+    /// llarena debug-fill parity: a GC-visible slot containing the nursery
+    /// poison is an uninitialized reference, not an unmanaged pointer to skip.
+    /// Check before nursery-range filtering so poison mode fails closed at the
+    /// trace site and identifies the exact holder and slot.
+    #[inline]
+    fn assert_traced_slot_initialized(
+        &self,
+        field_ref: GcRef,
+        slot_addr: usize,
+        holder_addr: usize,
+        site: &str,
+    ) {
+        const NURSERY_POISON_WORD: usize = (usize::MAX / 0xff) * 0xaa;
+        if self.nursery.poison_enabled() && field_ref.0 == NURSERY_POISON_WORD {
+            let holder_type_id = if holder_addr == 0 {
+                None
+            } else {
+                Some(unsafe { (*header_of(holder_addr)).type_id() })
+            };
+            let holder_offset = slot_addr.checked_sub(holder_addr);
+            panic!(
+                "GC BUG: traced slot contains nursery poison at slot_addr={:#x} holder_addr={:#x} holder_type_id={:?} holder_offset={:?} site={}",
+                slot_addr, holder_addr, holder_type_id, holder_offset, site,
+            );
+        }
+    }
+
     /// incminimark.py:2145-2263 `_trace_drag_out` + :2128-2143
     /// `_trace_drag_out1_marking_phase`, for a nursery object reached
     /// through a *root* slot during minor collection.
@@ -1611,6 +1638,7 @@ impl MiniMarkGC {
     /// here (matching `_trace_drag_out1` vs `_trace_drag_out1_marking_phase`).
     #[inline]
     fn drag_out_root(&mut self, gcref: &mut GcRef) {
+        self.assert_traced_slot_initialized(*gcref, gcref as *mut GcRef as usize, 0, "minor_root");
         if !self.is_nursery_object_start(gcref.0) || self.pinned_objects.contains(&gcref.0) {
             return;
         }
@@ -1641,6 +1669,12 @@ impl MiniMarkGC {
             unsafe {
                 trace_fn(obj_addr, &mut |slot_ptr: *mut GcRef| {
                     let field_ref = *slot_ptr;
+                    self.assert_traced_slot_initialized(
+                        field_ref,
+                        slot_ptr as usize,
+                        obj_addr,
+                        "minor_custom_trace",
+                    );
                     if self.is_nursery_object_start(field_ref.0) {
                         let new_ref = self.copy_nursery_object(field_ref.0);
                         *slot_ptr = new_ref;
@@ -1661,6 +1695,12 @@ impl MiniMarkGC {
         for &offset in &gc_ptr_offsets {
             let slot = (obj_addr + offset) as *mut GcRef;
             let field_ref = unsafe { *slot };
+            self.assert_traced_slot_initialized(
+                field_ref,
+                slot as usize,
+                obj_addr,
+                "minor_fixed_field",
+            );
             if self.is_nursery_object_start(field_ref.0) {
                 let new_ref = self.copy_nursery_object(field_ref.0);
                 unsafe {
@@ -1676,6 +1716,12 @@ impl MiniMarkGC {
             for i in 0..length {
                 let slot = (items_start + i * item_size) as *mut GcRef;
                 let field_ref = unsafe { *slot };
+                self.assert_traced_slot_initialized(
+                    field_ref,
+                    slot as usize,
+                    obj_addr,
+                    "minor_varsize_item",
+                );
                 if self.is_nursery_object_start(field_ref.0) {
                     let new_ref = self.copy_nursery_object(field_ref.0);
                     unsafe {
@@ -2704,6 +2750,12 @@ impl MiniMarkGC {
                             for i in interval_start..interval_stop {
                                 let slot = (items_start + i * item_size) as *mut GcRef;
                                 let field_ref = unsafe { *slot };
+                                self.assert_traced_slot_initialized(
+                                    field_ref,
+                                    slot as usize,
+                                    obj,
+                                    "minor_dirty_card_item",
+                                );
                                 if self.is_nursery_object_start(field_ref.0) {
                                     let new_ref = self.copy_nursery_object(field_ref.0);
                                     unsafe {

--- a/majit/majit-gc/src/collector.rs
+++ b/majit/majit-gc/src/collector.rs
@@ -1634,28 +1634,23 @@ impl MiniMarkGC {
     fn trace_and_update_object(&mut self, obj_addr: usize) {
         let type_id = unsafe { (*header_of(obj_addr)).type_id() };
         self.validate_type_id(type_id, obj_addr, "trace_and_update_object");
-        let type_info = self.types.get(type_id);
+        let custom_trace = self.types.get(type_id).custom_trace;
 
         // custom_trace_hook parity: use custom trace function if registered.
-        if let Some(trace_fn) = type_info.custom_trace {
-            let mut slots: Vec<*mut GcRef> = Vec::new();
+        if let Some(trace_fn) = custom_trace {
             unsafe {
                 trace_fn(obj_addr, &mut |slot_ptr: *mut GcRef| {
-                    slots.push(slot_ptr);
-                });
-            }
-            for slot_ptr in slots {
-                let field_ref = unsafe { *slot_ptr };
-                if self.is_nursery_object_start(field_ref.0) {
-                    let new_ref = self.copy_nursery_object(field_ref.0);
-                    unsafe {
+                    let field_ref = *slot_ptr;
+                    if self.is_nursery_object_start(field_ref.0) {
+                        let new_ref = self.copy_nursery_object(field_ref.0);
                         *slot_ptr = new_ref;
                     }
-                }
+                });
             }
             return;
         }
 
+        let type_info = self.types.get(type_id);
         let gc_ptr_offsets: Vec<usize> = type_info.gc_ptr_offsets.clone();
         let items_have_gc_ptrs = type_info.items_have_gc_ptrs;
         let item_size = type_info.item_size;

--- a/majit/majit-gc/src/collector.rs
+++ b/majit/majit-gc/src/collector.rs
@@ -2,7 +2,7 @@
 ///
 /// A generational copying collector with:
 /// - Bump-pointer nursery for young objects
-/// - System-allocator old gen with mark-sweep for major collection
+/// - ArenaCollection old gen plus rawmalloc fallback, with incremental major sweep
 /// - Write barrier with remembered set for old-to-young pointers
 ///
 /// Modeled after incminimark's minor/major collection.
@@ -301,7 +301,20 @@ impl Default for RootSet {
 /// Default card page shift: each card covers 2^7 = 128 array elements.
 pub const DEFAULT_CARD_PAGE_SHIFT: u32 = 7;
 
-/// State for incremental major collection.
+/// incminimark.py:2390-2634 major-collection state machine.
+///
+/// incminimark's `STATE_FINALIZING` is intentionally absent.  Pyre exposes
+/// explicit FinalizerQueue death deques and trigger callbacks, but has no
+/// collector-run `execute_finalizers`; incminimark.py:2623-2631 therefore
+/// reduces to setting `Scanning` before firing those triggers in the same step.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum GcState {
+    Scanning,
+    Marking,
+    Sweeping,
+}
+
+/// State for incremental major marking.
 ///
 /// Instead of doing a full mark-sweep in one pause, the marking work
 /// is spread across multiple minor collections. Each minor collection
@@ -310,8 +323,6 @@ pub const DEFAULT_CARD_PAGE_SHIFT: u32 = 7;
 struct IncrementalMarkState {
     /// Objects still to be scanned (gray set).
     gray_stack: Vec<usize>,
-    /// Whether an incremental cycle is in progress.
-    marking_in_progress: bool,
     /// Number of objects marked so far in this cycle.
     objects_marked: usize,
     /// Target number of bytes to trace per increment.
@@ -333,7 +344,6 @@ impl IncrementalMarkState {
     fn new(nursery_size: usize) -> Self {
         IncrementalMarkState {
             gray_stack: Vec::new(),
-            marking_in_progress: false,
             objects_marked: 0,
             mark_budget_per_step: (nursery_size.saturating_mul(2)).max(1),
             mark_offsets: Vec::new(),
@@ -438,6 +448,8 @@ pub struct MiniMarkGC {
     pub minor_collections: usize,
     /// Count of major collections performed.
     pub major_collections: usize,
+    /// incminimark.py:2390-2634 `gc_state`.
+    gc_state: GcState,
     /// State for incremental major collection.
     incr_state: IncrementalMarkState,
     /// incminimark.py:304 `self.major_collection_threshold`. After a major
@@ -603,6 +615,7 @@ impl MiniMarkGC {
             config,
             minor_collections: 0,
             major_collections: 0,
+            gc_state: GcState::Scanning,
             incr_state: IncrementalMarkState::new(nursery_size),
             major_collection_threshold,
             growth_rate_max,
@@ -919,7 +932,7 @@ impl MiniMarkGC {
     /// `obj_addr` must point at a live (not-yet-freed) object payload
     /// whose header still names a registered type id — true for a dead
     /// nursery object before `nursery.reset()` and a dying old-gen object
-    /// before `oldgen.sweep()`.
+    /// before the first incremental old-gen sweep step.
     fn run_destructor(&self, obj_addr: usize) {
         let type_id = unsafe { (*header_of(obj_addr)).type_id() };
         if (type_id as usize) >= self.types.len() {
@@ -941,19 +954,17 @@ impl MiniMarkGC {
     /// Flags for an object born directly into the old generation, adding
     /// `flags::VISITED` while a major marking cycle is in progress.
     ///
-    /// pyre's [`OldGen::sweep`] is a flat mark-sweep that frees every object
-    /// lacking `flags::VISITED` — a deliberate simplification of incminimark's
-    /// incremental, position-based arena sweep. Under that flat sweep, an object
-    /// allocated straight into the old generation during marking (a large object
-    /// or a nursery-full fallback) would be white at cycle end and freed while
-    /// still reachable: the one-shot major root scan (`seed_major_roots`) already
-    /// ran, and no minor-collection drag-out re-reaches a non-promoted object.
-    /// Allocating it black preserves the snapshot-at-the-beginning invariant that
-    /// incminimark upholds structurally. Any young pointer later stored into it
-    /// re-enters marking through the write barrier's remembered-set rescan.
+    /// An object allocated straight into the old generation during MARKING (a
+    /// large object or nursery-full fallback) enters the still-active page/raw
+    /// lists that will be frozen at the MARKING->SWEEPING seam. The root scan has
+    /// already happened, so allocate it black; allocations during SWEEPING need
+    /// no VISITED workaround because incminimark.py:2513-2514 and :2688-2694's
+    /// list swaps keep them outside this cycle's candidates. Any young pointer
+    /// later stored into a born-black object re-enters marking through the write
+    /// barrier's remembered-set rescan.
     #[inline]
     fn oldgen_birth_flags(&self, base: u64) -> u64 {
-        if self.incr_state.marking_in_progress {
+        if self.gc_state == GcState::Marking {
             base | flags::VISITED
         } else {
             base
@@ -1159,7 +1170,7 @@ impl MiniMarkGC {
         // remembered by the write barrier may already be black. Requeue
         // those black objects so the major collector rescans their new
         // outgoing references before sweep.
-        if self.incr_state.marking_in_progress {
+        if self.gc_state == GcState::Marking {
             let remembered_now: Vec<usize> = self.remembered_set.iter().copied().collect();
             for obj_addr in remembered_now {
                 let hdr = unsafe { header_of(obj_addr) };
@@ -1249,7 +1260,7 @@ impl MiniMarkGC {
                 self.nursery_objects_shadows.clear();
             } else {
                 let pinned = &self.pinned_objects;
-                let marking = self.incr_state.marking_in_progress;
+                let marking = self.gc_state == GcState::Marking;
                 self.nursery_objects_shadows
                     .retain(|obj_addr, shadow_addr| {
                         let keep = pinned.contains(obj_addr);
@@ -1435,11 +1446,11 @@ impl MiniMarkGC {
             // which does not carry it.)
             (*(shadow_hdr_ptr as *mut GcHeader)).set_flag(flags::TRACK_YOUNG_PTRS);
             // A shadow reserved during marking is an old-gen object subject to
-            // the flat sweep; keep it black so the in-progress cycle does not
+            // this cycle's future sweep; keep it black so marking does not
             // reclaim the reserved identity home before the object is copied in
             // (incminimark.py:1747 record_pinned_object_with_shadow). See
             // `oldgen_birth_flags`.
-            if self.incr_state.marking_in_progress {
+            if self.gc_state == GcState::Marking {
                 (*(shadow_hdr_ptr as *mut GcHeader)).set_flag(flags::VISITED);
             }
             if type_info.item_size > 0 {
@@ -1660,7 +1671,7 @@ impl MiniMarkGC {
         // incminimark.py:2140-2143: append iff (VISITED | PINNED) == 0. pyre's
         // marking convention sets VISITED at push time (see `seed_major_root`
         // / `mark_object`), so set it here rather than at pop.
-        if self.incr_state.marking_in_progress {
+        if self.gc_state == GcState::Marking {
             let hdr = unsafe { header_of(new_ref.0) };
             if unsafe { !(*hdr).has_flag(flags::VISITED) } {
                 unsafe { (*hdr).set_flag(flags::VISITED) };
@@ -1794,11 +1805,12 @@ impl MiniMarkGC {
     ///
     /// Seeds the gray stack with all root-reachable old-gen objects.
     pub fn start_incremental_cycle(&mut self) {
-        self.incr_state.marking_in_progress = true;
+        debug_assert_eq!(self.gc_state, GcState::Scanning);
         self.incr_state.gray_stack.clear();
         self.incr_state.objects_marked = 0;
 
         self.seed_major_roots();
+        self.gc_state = GcState::Marking;
     }
 
     fn seed_major_root(&mut self, gcref: GcRef) {
@@ -1817,6 +1829,21 @@ impl MiniMarkGC {
             if newly_marked {
                 self.incr_state.gray_stack.push(gcref.0);
                 self.note_nonmoving_nursery_mark(gcref.0);
+
+                // incminimark.py:1322-1340 requires marking worklists to
+                // contain no nursery objects after a minor. Pyre JITFRAME
+                // gcmap spills are collector metadata, not SETFIELD_GC
+                // writes: a frame first grayed in STATE_SCANNING can leave
+                // the active shadow stack before the next minor without a
+                // mutator barrier. Arm this newly seeded old root in the
+                // existing old_objects_pointing_to_young shape once, so that
+                // minor forwards any such spill before resetting nursery.
+                if !self.is_in_nursery(gcref.0)
+                    && unsafe { (*hdr).has_flag(flags::TRACK_YOUNG_PTRS) }
+                {
+                    unsafe { (*hdr).clear_flag(flags::TRACK_YOUNG_PTRS) };
+                    self.remembered_set.push(gcref.0);
+                }
             }
         }
     }
@@ -1938,30 +1965,61 @@ impl MiniMarkGC {
         if !self.enabled {
             return;
         }
-        if !self.incr_state.marking_in_progress && !self.threshold_reached(0) {
+        if self.gc_state == GcState::Scanning && !self.threshold_reached(0) {
             return;
         }
 
         loop {
-            self.threshold_bytes_made_old = self
-                .threshold_bytes_made_old
-                .saturating_add(self.config.nursery_size / 2);
+            self.major_collection_step();
 
-            if !self.incr_state.marking_in_progress {
+            // incminimark.py:849-855 target (A1), with FINALIZING collapsed.
+            if self.gc_state == GcState::Scanning {
+                break;
+            }
+
+            // incminimark.py:849-860 target (A2). Keep pyre's existing
+            // consecutive-step credit loop: the enclosing call has already
+            // completed the minor collection that supplied these promotions.
+            if self.bytes_made_old_since_cycle <= self.threshold_bytes_made_old {
+                break;
+            }
+        }
+    }
+
+    /// incminimark.py:2390-2634 `major_collection_step`.
+    fn major_collection_step(&mut self) {
+        self.debug_check_consistency();
+
+        // incminimark.py:2406-2436: each state-machine step grants half a
+        // nursery of promotion credit.
+        self.threshold_bytes_made_old = self
+            .threshold_bytes_made_old
+            .saturating_add(self.config.nursery_size / 2);
+
+        match self.gc_state {
+            GcState::Scanning => {
+                // incminimark.py:2439-2448 STATE_SCANNING.
                 self.bytes_made_old_since_cycle = 0;
                 self.threshold_bytes_made_old = self.config.nursery_size / 2;
                 self.start_incremental_cycle();
             }
-
-            let done = self.incremental_mark_step();
-            if done {
-                self.finish_incremental_cycle();
-                break;
+            GcState::Marking => {
+                // `incremental_mark_step` performs the MARKING->SWEEPING seam
+                // itself when the gray stack is exhausted.
+                self.incremental_mark_step();
             }
+            GcState::Sweeping => self.incremental_sweep_step(),
+        }
+    }
 
-            if self.bytes_made_old_since_cycle <= self.threshold_bytes_made_old {
-                break;
-            }
+    /// incminimark.py:1316-1319 debug invariant.
+    fn debug_check_consistency(&self) {
+        if self.oldgen.rawmalloc_sweep_pending() {
+            debug_assert_eq!(
+                self.gc_state,
+                GcState::Sweeping,
+                "raw_malloc_might_sweep must be empty outside SWEEPING"
+            );
         }
     }
 
@@ -1972,11 +2030,12 @@ impl MiniMarkGC {
     /// one object so very small budgets still make forward progress.
     /// Returns `true` if marking is complete (gray stack exhausted).
     pub fn incremental_mark_step(&mut self) -> bool {
+        debug_assert_eq!(self.gc_state, GcState::Marking);
         let mut budget = self.incr_state.mark_budget_per_step;
         let mut processed_any = false;
         while budget > 0 || !processed_any {
             let Some(obj_addr) = self.incr_state.gray_stack.pop() else {
-                self.incr_state.marking_in_progress = false;
+                self.finish_incremental_marking();
                 return true; // marking complete
             };
             let obj_size = self.object_total_size(obj_addr);
@@ -1990,6 +2049,7 @@ impl MiniMarkGC {
 
     fn object_total_size(&self, obj_addr: usize) -> usize {
         let type_id = unsafe { (*header_of(obj_addr)).type_id() };
+        self.validate_type_id(type_id, obj_addr, "object_total_size");
         let type_info = self.types.get(type_id);
         let payload_size = if type_info.item_size > 0 {
             let length = unsafe { *((obj_addr + type_info.length_offset) as *const usize) };
@@ -2111,8 +2171,8 @@ impl MiniMarkGC {
     /// edge to a still-white object. The per-minor black re-grey in
     /// `do_collect_nursery` only re-scans modifications up to the last minor; a
     /// cycle finished at a safepoint *between* minors (`do_collect_oldgen_nonmoving`
-    /// branch A, `gc_step`) leaves the trailing delta unscanned. Under pyre's flat
-    /// [`OldGen::sweep`], those white-but-reachable children would then be freed.
+    /// branch A, `gc_step`) leaves the trailing delta unscanned. The later
+    /// incremental sweep would otherwise free those white-but-reachable children.
     /// Re-grey every already-marked modified object and trace transitively so the
     /// delta is marked before the retain/sweep below. (pyre's marking convention
     /// sets VISITED at push time, so a black object is simply re-pushed; white
@@ -2129,9 +2189,11 @@ impl MiniMarkGC {
         }
     }
 
-    /// Complete the sweep phase after incremental marking finishes.
-    fn finish_incremental_cycle(&mut self) {
-        self.major_collections += 1;
+    /// incminimark.py:2473-2533: finish MARKING and freeze this cycle's sweep
+    /// candidates.  Every VISITED-dependent consumer runs before either raw or
+    /// arena memory is freed.
+    fn finish_incremental_marking(&mut self) {
+        debug_assert_eq!(self.gc_state, GcState::Marking);
         // Re-scan the trailing snapshot-at-the-beginning delta (old objects
         // modified since the last minor) before the sweep, or a cycle finished
         // between minors frees reachable old->old targets.
@@ -2166,9 +2228,68 @@ impl MiniMarkGC {
         // Reset the live off-heap footprint exactly from the survivors (the
         // dying objects' destructors just ran, freeing their limb Vecs), so the
         // promotion-time running total cannot drift and the next-major threshold
-        // taken from get_total_memory_used below reflects the post-sweep truth.
+        // later taken from get_total_memory_used reflects the post-sweep truth.
         self.recompute_oldgen_external_bytes();
-        self.oldgen.sweep();
+
+        // incminimark.py:2512-2514. ArenaCollection's prepare moves active
+        // pages to old_* lists, and OldGen swaps old_rawmalloced_objects into
+        // raw_malloc_might_sweep. Promotions between sweep steps therefore
+        // allocate into fresh lists and are not candidates in this cycle.
+        self.oldgen.sweep_prepare();
+
+        // incminimark.py:2516-2526 maintains an
+        // `old_objects_pointing_to_pinned` stack. Pyre's explicit pin contract
+        // keeps pinned objects nursery-resident and records their old-gen
+        // identity shadows directly, so it has no equivalent stack to filter.
+        // incminimark.py:2528-2529 rawrefcount integration is likewise absent.
+        self.gc_state = GcState::Sweeping;
+    }
+
+    /// incminimark.py:2535-2621 STATE_SWEEPING.
+    fn incremental_sweep_step(&mut self) {
+        debug_assert_eq!(self.gc_state, GcState::Sweeping);
+        let done = if self.oldgen.rawmalloc_sweep_pending() {
+            // incminimark.py:2537-2547: process a bounded number of rawmalloc
+            // objects first. Even if this drains the stack, the arena half is
+            // deliberately deferred to the next state-machine step.
+            let limit = 3 * self.config.nursery_size / self.oldgen.small_request_threshold();
+            // Upstream production geometry makes this non-zero. Pyre unit
+            // tests use nurseries smaller than one rawmalloc threshold, so one
+            // candidate is the minimum needed for forward progress while
+            // retaining the incminimark.py:2543 upper-bound formula otherwise.
+            self.oldgen.sweep_rawmalloc_step(limit.max(1));
+            false
+        } else {
+            // incminimark.py:2549-2555: visit at most three nursery sizes of
+            // frozen arena pages.
+            let limit = 3 * self.config.nursery_size / self.oldgen.page_size();
+            // As above, tiny test nurseries need one-page forward progress;
+            // normal configurations use the literal incminimark.py:2553 value.
+            self.oldgen.sweep_arenas_step(limit.max(1))
+        };
+
+        if done {
+            self.finish_incremental_cycle();
+        }
+    }
+
+    /// incminimark.py:2560-2631: complete SWEEPING, compute the next threshold
+    /// from post-sweep accounting, then collapse FINALIZING back to SCANNING.
+    fn finish_incremental_cycle(&mut self) {
+        debug_assert_eq!(self.gc_state, GcState::Sweeping);
+        debug_assert!(!self.oldgen.rawmalloc_sweep_pending());
+        self.major_collections += 1;
+        if std::env::var_os("MAJIT_LOG").is_some() {
+            eprintln!(
+                "[gc][major] complete count={} oldgen_bytes={}",
+                self.major_collections,
+                self.get_total_memory_used(),
+            );
+        }
+
+        // incminimark.py:2563-2564 resets VISITED on translated prebuilt root
+        // objects. Pyre creates all GC objects at runtime and has no immortal
+        // prebuilt-root list, so there is no corresponding reset pass.
         // incminimark.py:2566-2577 — set the threshold for the next major
         // collection to `major_collection_threshold` times the surviving
         // size, but no more than `max_delta` above it, floored at
@@ -2188,6 +2309,11 @@ impl MiniMarkGC {
         );
         self.bytes_made_old_since_cycle = 0;
         self.threshold_bytes_made_old = 0;
+
+        // incminimark.py:2617-2631: pyre has explicit death deques but no
+        // collector-run execute_finalizers phase. Make recursive collections
+        // see SCANNING first, then fire the queue-notification triggers now.
+        self.gc_state = GcState::Scanning;
         self.execute_finalizer_triggers();
     }
 
@@ -2200,11 +2326,9 @@ impl MiniMarkGC {
     ///     bit. Live target → keep the weakref in a fresh list.
     ///     Dying target → null the slot and drop the weakref.
     ///
-    /// RPython's extra GCFLAG_FINALIZATION_ORDERING handling
-    /// (incminimark.py:3120-3121 — treats objects queued for finalize
-    /// as "dying for weakref purposes" even though they're still
-    /// reachable) is deferred until the finalizer queue itself lands;
-    /// the rule reduces to a plain VISITED check until then.
+    /// incminimark.py:3120-3121 also treats FINALIZATION_ORDERING targets as
+    /// dying for weakref purposes even though finalizer-queue reachability has
+    /// marked them VISITED; the check below preserves that ordering.
     fn invalidate_old_weakrefs(&mut self) {
         let entries = std::mem::take(&mut self.old_objects_with_weakrefs);
         let mut new_with_weakref = Vec::with_capacity(entries.len());
@@ -2376,7 +2500,7 @@ impl MiniMarkGC {
     /// Walk the old-destructor list: a VISITED (surviving) object is kept
     /// in a fresh list; a dying (not-VISITED) object's destructor runs
     /// before the imminent sweep frees its memory. Must run while VISITED
-    /// bits are still meaningful — i.e. before `oldgen.sweep()` clears
+    /// bits are still meaningful — i.e. before incremental sweep steps clear
     /// them.
     fn deal_with_old_objects_with_destructors(&mut self) {
         let entries = std::mem::take(&mut self.old_objects_with_destructors);
@@ -2412,7 +2536,7 @@ impl MiniMarkGC {
 
     /// Whether an incremental marking cycle is currently in progress.
     pub fn is_incremental_marking(&self) -> bool {
-        self.incr_state.marking_in_progress
+        self.gc_state == GcState::Marking
     }
 
     /// Number of objects marked so far in the current incremental cycle.
@@ -2462,30 +2586,13 @@ impl MiniMarkGC {
         // cycle, but we need a complete mark-sweep here regardless.
         self.do_collect_nursery();
 
-        if self.incr_state.marking_in_progress {
-            // An incremental cycle is in progress. Finish it by draining
-            // the gray stack without budget limits.
-            while !self.incr_state.gray_stack.is_empty() {
-                let obj_addr = self.incr_state.gray_stack.pop().unwrap();
-                self.mark_object(obj_addr);
-                self.incr_state.objects_marked += 1;
-            }
-            self.incr_state.marking_in_progress = false;
-            self.finish_incremental_cycle();
-        } else {
-            // No incremental cycle in progress. Do a full stop-the-world
-            // mark-sweep using the same mark_object infrastructure.
-            self.incr_state.gray_stack.clear();
-
-            self.seed_major_roots();
-
-            // Drain gray stack completely.
-            while let Some(obj_addr) = self.incr_state.gray_stack.pop() {
-                self.mark_object(obj_addr);
-            }
-
-            self.finish_incremental_cycle();
+        if self.gc_state == GcState::Scanning {
+            self.start_incremental_cycle();
         }
+        // incminimark.py:2366-2378 `gc_step_until(STATE_SCANNING)`: bounded
+        // state-machine steps are still looped to completion inside this one
+        // stop-the-world call.
+        self.gc_step_until_scanning();
     }
 
     /// Reclaim dead old-gen objects WITHOUT moving the nursery.
@@ -2505,7 +2612,7 @@ impl MiniMarkGC {
     /// survive into the next minor's promoted copy (`copy_nursery_object`
     /// memcpys the header verbatim). The strictly-last step clears VISITED on
     /// exactly the nursery objects greyed this cycle — after
-    /// `finish_incremental_cycle`, hence after `invalidate_old_weakrefs`,
+    /// sweep completion, hence after `invalidate_old_weakrefs`,
     /// which reads a nursery target's VISITED to decide weakref survival. The
     /// remembered set is left untouched: a non-moving major does not consume
     /// `old -> young` edges, so the next minor still finds them.
@@ -2518,24 +2625,12 @@ impl MiniMarkGC {
         self.oldgen_nonmoving_active = true;
         self.oldgen_nonmoving_nursery_marks.clear();
 
-        if self.incr_state.marking_in_progress {
-            // A cycle started by a prior minor's `run_major_progress_after_minor`
-            // is mid-flight; drain it rather than re-seed (the `do_collect_full`
-            // incremental arm, minus the leading minor).
-            while let Some(obj_addr) = self.incr_state.gray_stack.pop() {
-                self.mark_object(obj_addr);
-                self.incr_state.objects_marked += 1;
-            }
-            self.incr_state.marking_in_progress = false;
-            self.finish_incremental_cycle();
-        } else {
-            self.incr_state.gray_stack.clear();
-            self.seed_major_roots();
-            while let Some(obj_addr) = self.incr_state.gray_stack.pop() {
-                self.mark_object(obj_addr);
-            }
-            self.finish_incremental_cycle();
+        if self.gc_state == GcState::Scanning {
+            self.start_incremental_cycle();
         }
+        // Keep this oldgen-only entry stop-the-world: it may enter while
+        // MARKING or SWEEPING, but always returns after the complete cycle.
+        self.gc_step_until_scanning();
 
         // Strictly-last: clear VISITED on every nursery object greyed this
         // cycle (the oldgen sweep already cleared it on old-gen survivors).
@@ -2549,6 +2644,12 @@ impl MiniMarkGC {
             }
         }
         self.oldgen_nonmoving_active = false;
+    }
+
+    fn gc_step_until_scanning(&mut self) {
+        while self.gc_state != GcState::Scanning {
+            self.major_collection_step();
+        }
     }
 
     /// incminimark.py:1489-1493 write_barrier(addr_struct):
@@ -2591,6 +2692,12 @@ impl MiniMarkGC {
     /// at runtime and never sets GCFLAG_NO_HEAP_PTRS (there are no immortal
     /// prebuilt objects from translation), so no object ever reaches that arm.
     fn remember_young_pointer(&mut self, obj: GcRef) {
+        // incminimark.py does not special-case STATE_SWEEPING in its barrier.
+        // After the seam, every retained entry names a VISITED survivor. A new
+        // barrier entry can only name an object the mutator can reach: an old
+        // candidate already known live, a candidate already swept, or a new
+        // object on the fresh lists. An unreachable white candidate cannot be
+        // mutated and therefore cannot be re-added between sweep steps.
         self.remembered_set.push(obj.0);
         let hdr = unsafe { header_of(obj.0) };
         unsafe { (*hdr).clear_flag(flags::TRACK_YOUNG_PTRS) };
@@ -2815,9 +2922,9 @@ impl MiniMarkGC {
             // on the popped object (the marking convention sets it at *push*
             // time — see `seed_major_root` and the remembered-set rescan above),
             // so keep the object black across the re-push. Clearing it would
-            // leave the still-reachable card object white and let `OldGen::sweep`
-            // reclaim it.
-            if self.incr_state.marking_in_progress {
+            // leave the still-reachable card object white for the incremental
+            // sweep to reclaim.
+            if self.gc_state == GcState::Marking {
                 unsafe { (*hdr).set_flag(flags::VISITED) };
                 self.incr_state.gray_stack.push(obj);
             }
@@ -2875,29 +2982,18 @@ impl MiniMarkGC {
 
     /// Perform one incremental GC step. Called from JIT safepoints.
     ///
-    /// If an incremental marking cycle should start, it is initiated.
-    /// If a cycle is already in progress, one bounded marking step is
+    /// If an incremental major cycle should start, it is initiated. If a cycle
+    /// is already in progress, one bounded MARKING or SWEEPING step is
     /// performed. Returns true if any GC work was done.
     pub fn gc_step(&mut self) -> bool {
         if !self.enabled {
             return false;
         }
-        if self.threshold_reached(0) && !self.incr_state.marking_in_progress {
-            self.start_incremental_cycle();
-            let done = self.incremental_mark_step();
-            if done {
-                self.finish_incremental_cycle();
-            }
-            true
-        } else if self.incr_state.marking_in_progress {
-            let done = self.incremental_mark_step();
-            if done {
-                self.finish_incremental_cycle();
-            }
-            true
-        } else {
-            false
+        if self.gc_state == GcState::Scanning && !self.threshold_reached(0) {
+            return false;
         }
+        self.major_collection_step();
+        true
     }
 
     /// Reset the nursery while preserving pinned objects.
@@ -5045,6 +5141,43 @@ mod tests {
     }
 
     #[test]
+    fn minor_forwards_nursery_references_held_by_gray_objects() {
+        let ptr_size = std::mem::size_of::<GcRef>();
+        let mut gc = test_gc(4096);
+        let holder_tid = gc.register_type(TypeInfo::with_gc_ptrs(ptr_size, vec![0]));
+        let leaf_tid = gc.register_type(TypeInfo::simple(16));
+
+        let holder = gc.alloc_with_type(holder_tid, ptr_size);
+        unsafe { *(holder.0 as *mut GcRef) = GcRef::NULL };
+        let mut root = holder;
+        unsafe { gc.roots.add(&mut root) };
+        gc.do_collect_nursery();
+
+        gc.set_mark_budget(1);
+        gc.start_incremental_cycle();
+        assert_eq!(gc.incr_state.gray_stack, vec![root.0]);
+
+        let young = gc.alloc_with_type(leaf_tid, 16);
+        unsafe {
+            *(young.0 as *mut u64) = 0xC011_EC70;
+            // Model a collector-owned JITFRAME gcmap spill: it does not pass
+            // through the ordinary mutator write barrier.
+            *(root.0 as *mut GcRef) = young;
+        }
+        assert!(gc.remembered_set.contains(&root.0));
+
+        gc.disable();
+        gc.do_collect_nursery();
+        gc.enable();
+
+        let forwarded = unsafe { *(root.0 as *const GcRef) };
+        assert!(!gc.is_in_nursery(forwarded.0));
+        assert_eq!(unsafe { *(forwarded.0 as *const u64) }, 0xC011_EC70);
+        gc.do_collect_full();
+        gc.roots.clear();
+    }
+
+    #[test]
     fn test_minor_collection_can_take_multiple_major_steps_when_promotions_outpace_credit() {
         let ptr_size = std::mem::size_of::<GcRef>();
         let mut gc = test_gc(1024);
@@ -5180,12 +5313,88 @@ mod tests {
         }
 
         // Finish: sweep unreachable objects.
-        gc.finish_incremental_cycle();
+        gc.gc_step_until_scanning();
 
         // Only the reachable object should survive.
         assert_eq!(gc.oldgen.object_count(), 1);
         assert!(!root.is_null());
 
+        gc.roots.clear();
+    }
+
+    #[test]
+    fn incremental_sweep_spans_steps_and_preserves_interleaved_promotion() {
+        let mut gc = test_gc(4096);
+        let tid = gc.register_type(TypeInfo::simple(16));
+        let total_size = GcHeader::SIZE + 16;
+
+        // More than two arena pages of white old objects ensure that the
+        // one-page budget used by this tiny test nursery cannot finish sweep.
+        for _ in 0..900 {
+            gc.alloc_in_oldgen(tid, total_size);
+        }
+
+        gc.start_incremental_cycle();
+        assert!(gc.incremental_mark_step());
+        assert_eq!(gc.gc_state, GcState::Sweeping);
+        gc.major_collection_step();
+        assert_eq!(gc.gc_state, GcState::Sweeping);
+
+        // Disable automatic major progress only while this minor promotes its
+        // survivor. The promotion allocates on ArenaCollection's fresh active
+        // page lists created by mass_free_prepare, not the frozen old_* lists.
+        let young = gc.alloc_with_type(tid, 16);
+        unsafe { *(young.0 as *mut u64) = 0x51_7E_A5E };
+        let mut root = young;
+        unsafe { gc.roots.add(&mut root) };
+        gc.disable();
+        gc.do_collect_nursery();
+        gc.enable();
+        assert!(!gc.is_in_nursery(root.0));
+
+        gc.gc_step_until_scanning();
+        assert_eq!(gc.gc_state, GcState::Scanning);
+        assert_eq!(gc.major_collections, 1);
+        assert_eq!(gc.oldgen.object_count(), 1);
+        assert_eq!(unsafe { *(root.0 as *const u64) }, 0x51_7E_A5E);
+        gc.roots.clear();
+    }
+
+    #[test]
+    #[cfg(debug_assertions)]
+    #[should_panic(expected = "raw_malloc_might_sweep must be empty outside SWEEPING")]
+    fn rawmalloc_sweep_candidates_require_sweeping_state() {
+        let mut gc = test_gc(4096);
+        let tid = gc.register_type(TypeInfo::simple(16));
+        let raw_size = gc.oldgen.small_request_threshold() + std::mem::size_of::<usize>();
+        gc.alloc_in_oldgen(tid, raw_size);
+        gc.oldgen.sweep_prepare();
+        assert!(gc.oldgen.rawmalloc_sweep_pending());
+        assert_eq!(gc.gc_state, GcState::Scanning);
+        gc.debug_check_consistency();
+    }
+
+    #[test]
+    fn stop_the_world_full_collection_drains_marking_and_sweeping() {
+        let mut gc = test_gc(4096);
+        let tid = gc.register_type(TypeInfo::simple(16));
+        let live = gc.alloc_in_oldgen(tid, GcHeader::SIZE + 16);
+        let mut root = live;
+        unsafe { gc.roots.add(&mut root) };
+
+        let raw_size = gc.oldgen.small_request_threshold() + std::mem::size_of::<usize>();
+        for _ in 0..20 {
+            gc.alloc_in_oldgen(tid, raw_size);
+        }
+        let majors_before = gc.major_collections;
+
+        gc.do_collect_full();
+
+        assert_eq!(gc.gc_state, GcState::Scanning);
+        assert!(!gc.oldgen.rawmalloc_sweep_pending());
+        assert_eq!(gc.major_collections, majors_before + 1);
+        assert_eq!(gc.oldgen.object_count(), 1);
+        assert_eq!(root.0, live.0);
         gc.roots.clear();
     }
 
@@ -5403,7 +5612,7 @@ mod tests {
         }
 
         // Complete the cycle.
-        gc.finish_incremental_cycle();
+        gc.gc_step_until_scanning();
         assert!(gc.major_collections > 0);
 
         // Walk the list from the head and verify all data values.
@@ -5628,6 +5837,17 @@ mod tests {
         gc.set_mark_budget(1);
         gc.start_incremental_cycle();
         assert!(gc.is_incremental_marking());
+
+        // `seed_major_root` arms all newly gray roots for the next minor so
+        // collector-owned JITFRAME spills cannot strand nursery references.
+        // Reset that one-time collector setup here to isolate the ordinary
+        // mutator write-barrier behavior this test covers.
+        gc.remembered_set.clear();
+        unsafe {
+            (*header_of(root_a.0)).set_flag(flags::TRACK_YOUNG_PTRS);
+            (*header_of(root_b.0)).set_flag(flags::TRACK_YOUNG_PTRS);
+            (*header_of(root_c.0)).set_flag(flags::TRACK_YOUNG_PTRS);
+        }
 
         // During marking, perform write barriers on A and B.
         gc.do_write_barrier(root_a);
@@ -5971,7 +6191,7 @@ mod tests {
 
         gc.disable();
         assert!(!gc.gc_step());
-        assert!(!gc.incr_state.marking_in_progress);
+        assert_eq!(gc.gc_state, GcState::Scanning);
 
         gc.enable();
         assert!(gc.gc_step());
@@ -6284,7 +6504,7 @@ mod tests {
         assert!(gc.oldgen.contains(rooted.0));
 
         gc.start_incremental_cycle();
-        gc.finish_incremental_cycle();
+        gc.gc_step_until_scanning();
 
         assert!(gc.oldgen.contains(rooted.0));
         crate::shadow_stack::pop_jf_to(depth);
@@ -6655,6 +6875,9 @@ mod tests {
 
         // Popping removes the queue root; the following major reclaims it.
         gc.do_collect_oldgen_nonmoving();
-        assert!(!gc.oldgen.contains(obj.0));
+        // ArenaCollection::contains is intentionally an arena-range query and
+        // can stay true for a freed block while the current arena is retained.
+        // The allocator's exact live count verifies reclamation here.
+        assert_eq!(gc.oldgen.object_count(), 0);
     }
 }

--- a/majit/majit-gc/src/collector.rs
+++ b/majit/majit-gc/src/collector.rs
@@ -963,6 +963,19 @@ impl MiniMarkGC {
     /// Allocate directly in old gen (for large objects or post-collection fallback).
     fn alloc_in_oldgen(&mut self, type_id: u32, total_size: usize) -> GcRef {
         let ptr = self.oldgen.alloc(total_size);
+        // `do_malloc_fixedsize_clear` and the resume.py direct reader both
+        // require a zero-filled payload.  In particular, resume
+        // materialization writes only fields present in resumedata; omitted
+        // PyFrame owned-content fields must remain null for its destructor.
+        // Keep this rare born-old contract here: ArenaCollection.malloc and
+        // nursery promotion's alloc-and-copy path stay uninitialized.
+        unsafe {
+            std::ptr::write_bytes(
+                ptr.add(GcHeader::SIZE),
+                0,
+                total_size.saturating_sub(GcHeader::SIZE),
+            );
+        }
         let hdr = unsafe { &mut *(ptr as *mut GcHeader) };
         // Old objects start with TRACK_YOUNG_PTRS set (they need write barrier).
         // An object born into the old generation while a major marking cycle is
@@ -2020,6 +2033,22 @@ impl MiniMarkGC {
         // retains the live children); only the bounded fixed-field offsets are
         // copied into the reused `mark_offsets` buffer.
         let type_id = unsafe { (*header_of(obj_addr)).type_id() };
+        // A non-moving major can trace a live nursery object without first
+        // copying it into its reserved old-gen shadow.  Keep that unoccupied
+        // shadow black, but do not push/trace it: only its header (and varsize
+        // length) is initialized until copy_nursery_object overwrites the full
+        // block.  Upstream normally reaches the shadow through
+        // GCFLAG_HAS_SHADOW during the leading minor; this is the equivalent
+        // for pyre's oldgen-only non-moving major.
+        if self.is_in_nursery(obj_addr)
+            && unsafe { (*header_of(obj_addr)).has_flag(flags::HAS_SHADOW) }
+        {
+            let shadow_obj = *self
+                .nursery_objects_shadows
+                .get(&obj_addr)
+                .expect("GCFLAG_HAS_SHADOW but no shadow found");
+            unsafe { (*header_of(shadow_obj)).set_flag(flags::VISITED) };
+        }
         let custom_trace;
         let (item_size, length_offset, fixed_size, items_have_gc_ptrs);
         let mut offsets = std::mem::take(&mut self.incr_state.mark_offsets);
@@ -4016,6 +4045,37 @@ mod tests {
     }
 
     #[test]
+    fn born_old_typed_payload_is_zero_filled() {
+        let mut gc = test_gc(4096);
+        let tid = gc.register_type(TypeInfo::simple(24));
+        let obj = gc.alloc_in_oldgen(tid, GcHeader::SIZE + 24);
+        let payload = unsafe { std::slice::from_raw_parts(obj.0 as *const u8, 24) };
+        assert!(payload.iter().all(|&byte| byte == 0));
+    }
+
+    #[test]
+    fn nonmoving_major_keeps_unoccupied_shadow_until_minor_copy() {
+        let mut gc = test_gc(4096);
+        let tid = gc.register_type(TypeInfo::simple(16));
+        let obj = gc.alloc_with_type(tid, 16);
+        let shadow = gc.allocate_shadow(obj.0);
+        let mut root = obj;
+        unsafe { gc.roots.add(&mut root) };
+
+        // The shadow payload has not been copied yet.  A non-moving major must
+        // retain the reserved block without tracing its uninitialized fields.
+        gc.do_collect_oldgen_nonmoving();
+        assert_eq!(gc.oldgen.object_count(), 1);
+        assert!(gc.oldgen.contains(shadow));
+        assert!(!unsafe { (*header_of(shadow)).has_flag(flags::VISITED) });
+
+        // The following minor occupies exactly that reserved identity home.
+        gc.do_collect_nursery();
+        assert_eq!(root.0, shadow);
+        gc.roots.clear();
+    }
+
+    #[test]
     fn write_barrier_skips_object_without_track_young_ptrs() {
         let mut gc = test_gc(1024);
         gc.register_type(TypeInfo::simple(16));
@@ -4602,9 +4662,20 @@ mod tests {
     #[test]
     fn test_card_marking_clear_after_collection() {
         let mut gc = test_gc(4096);
-        let (obj, _) = alloc_card_array(&mut gc, 512);
+        let (obj, array_length) = alloc_card_array(&mut gc, 512);
         let hdr = unsafe { header_of(obj.0) };
         assert!(unsafe { (*hdr).has_flag(flags::HAS_CARDS) });
+
+        // external_malloc is not zero-filled.  Initialize every item that
+        // dirty-card tracing is allowed to read, as production allocation
+        // rewrites do before publishing the array.
+        let ptr_size = std::mem::size_of::<GcRef>();
+        let items_start = obj.0 + 8;
+        for i in 0..array_length {
+            unsafe {
+                *((items_start + i * ptr_size) as *mut GcRef) = GcRef::NULL;
+            }
+        }
 
         // Mark some cards.
         gc.do_write_barrier_card(obj, 0, DEFAULT_CARD_PAGE_SHIFT);

--- a/majit/majit-gc/src/lib.rs
+++ b/majit/majit-gc/src/lib.rs
@@ -16,6 +16,7 @@ pub mod gc_sync;
 pub mod gcreftracer;
 pub mod header;
 pub mod hook_cell;
+pub mod minimarkpage;
 pub mod nursery;
 pub mod oldgen;
 pub mod rewrite;

--- a/majit/majit-gc/src/minimarkpage.rs
+++ b/majit/majit-gc/src/minimarkpage.rs
@@ -240,7 +240,7 @@ impl ArenaCollection {
     }
 
     /// `ArenaCollection.mass_free_prepare`.
-    fn mass_free_prepare(&mut self) {
+    pub(crate) fn mass_free_prepare(&mut self) {
         self.peak_memory_used = self.peak_memory_used.max(self.total_memory_used);
         let mut size_class = self.small_request_threshold / WORD;
         self.size_class_with_old_pages = size_class as isize;
@@ -254,7 +254,7 @@ impl ArenaCollection {
     }
 
     /// `ArenaCollection.mass_free_incremental`.
-    fn mass_free_incremental(
+    pub(crate) fn mass_free_incremental(
         &mut self,
         ok_to_free_func: &mut impl FnMut(*mut u8) -> bool,
         mut max_pages: usize,

--- a/majit/majit-gc/src/minimarkpage.rs
+++ b/majit/majit-gc/src/minimarkpage.rs
@@ -1,0 +1,582 @@
+//! Size-class arena allocator for old-generation objects.
+//!
+//! Structural port of `rpython/memory/gc/minimarkpage.py`.  Memory is split
+//! into arenas, pages, and same-sized blocks.  Free blocks and free pages are
+//! chained through their first machine word, exactly like upstream's
+//! `llarena` representation; allocations are deliberately not zero-filled.
+
+use std::alloc::{self, Layout};
+use std::ptr;
+
+const WORD: usize = std::mem::size_of::<usize>();
+
+#[repr(C)]
+struct ArenaReference {
+    base: *mut u8,
+    layout: Layout,
+    nfreepages: usize,
+    totalpages: usize,
+    freepages: *mut u8,
+    nextarena: *mut ArenaReference,
+}
+
+#[repr(C)]
+struct PageHeader {
+    nextpage: *mut PageHeader,
+    arena: *mut ArenaReference,
+    nfree: usize,
+    freeblock: *mut u8,
+}
+
+/// `minimarkpage.py:ArenaCollection`.
+pub struct ArenaCollection {
+    pub arena_size: usize,
+    pub page_size: usize,
+    pub small_request_threshold: usize,
+    pub arenas_count: usize,
+    page_for_size: Vec<*mut PageHeader>,
+    full_page_for_size: Vec<*mut PageHeader>,
+    old_page_for_size: Vec<*mut PageHeader>,
+    old_full_page_for_size: Vec<*mut PageHeader>,
+    nblocks_for_size: Vec<usize>,
+    hdrsize: usize,
+    max_pages_per_arena: usize,
+    arenas_lists: Vec<*mut ArenaReference>,
+    old_arenas_lists: Vec<*mut ArenaReference>,
+    current_arena: *mut ArenaReference,
+    /// pyre-local old-generation membership support.  The arena lists above
+    /// retain minimarkpage.py's allocator shape; this flat range index avoids
+    /// pointer-chasing every bucket for arbitrary-word validity checks.
+    /// It changes only when an arena is allocated or freed.
+    arena_ranges: Vec<(usize, usize)>,
+    min_empty_nfreepages: usize,
+    pub num_uninitialized_pages: usize,
+    pub total_memory_used: usize,
+    pub peak_memory_used: usize,
+    pub total_memory_alloced: usize,
+    pub peak_memory_alloced: usize,
+    live_objects: usize,
+    size_class_with_old_pages: isize,
+}
+
+// ArenaCollection owns its arena allocations and is only mutated through
+// `&mut self`; the collector itself provides single-threaded access.
+unsafe impl Send for ArenaCollection {}
+
+impl ArenaCollection {
+    pub fn new(arena_size: usize, page_size: usize, small_request_threshold: usize) -> Self {
+        assert_eq!(arena_size % WORD, 0);
+        assert_eq!(page_size % WORD, 0);
+        assert_eq!(small_request_threshold % WORD, 0);
+        let length = small_request_threshold / WORD + 1;
+        let hdrsize = std::mem::size_of::<PageHeader>();
+        assert!(page_size > hdrsize);
+        let mut nblocks_for_size = vec![0; length];
+        for (i, nblocks) in nblocks_for_size.iter_mut().enumerate().skip(1) {
+            *nblocks = (page_size - hdrsize) / (WORD * i);
+            assert!(*nblocks > 0);
+        }
+        let max_pages_per_arena = arena_size / page_size;
+        assert!(max_pages_per_arena > 0);
+        Self {
+            arena_size,
+            page_size,
+            small_request_threshold,
+            arenas_count: 0,
+            page_for_size: vec![ptr::null_mut(); length],
+            full_page_for_size: vec![ptr::null_mut(); length],
+            old_page_for_size: vec![ptr::null_mut(); length],
+            old_full_page_for_size: vec![ptr::null_mut(); length],
+            nblocks_for_size,
+            hdrsize,
+            max_pages_per_arena,
+            arenas_lists: vec![ptr::null_mut(); max_pages_per_arena],
+            old_arenas_lists: vec![ptr::null_mut(); max_pages_per_arena],
+            current_arena: ptr::null_mut(),
+            arena_ranges: Vec::new(),
+            min_empty_nfreepages: max_pages_per_arena,
+            num_uninitialized_pages: 0,
+            total_memory_used: 0,
+            peak_memory_used: 0,
+            total_memory_alloced: 0,
+            peak_memory_alloced: 0,
+            live_objects: 0,
+            size_class_with_old_pages: -1,
+        }
+    }
+
+    /// `ArenaCollection.malloc`: allocate an uninitialized arena block.
+    pub fn malloc(&mut self, size: usize) -> *mut u8 {
+        let nsize = size;
+        assert!(nsize > 0, "malloc: size is null");
+        assert!(
+            nsize <= self.small_request_threshold,
+            "malloc: size too big"
+        );
+        assert_eq!(nsize & (WORD - 1), 0, "malloc: size is not aligned");
+        self.total_memory_used += nsize;
+        self.live_objects += 1;
+        let size_class = nsize / WORD;
+        let mut page = self.page_for_size[size_class];
+        if page.is_null() {
+            page = self.allocate_new_page(size_class);
+        }
+        unsafe {
+            let result = (*page).freeblock;
+            let freeblock = if (*page).nfree > 0 {
+                (*page).nfree -= 1;
+                *(result as *mut *mut u8)
+            } else {
+                result.add(nsize)
+            };
+            (*page).freeblock = freeblock;
+            let pageaddr = page as *mut u8;
+            if freeblock.offset_from(pageaddr) as usize > self.page_size - nsize {
+                self.page_for_size[size_class] = (*page).nextpage;
+                (*page).nextpage = self.full_page_for_size[size_class];
+                self.full_page_for_size[size_class] = page;
+            }
+            result
+        }
+    }
+
+    /// `ArenaCollection.allocate_new_page`.
+    fn allocate_new_page(&mut self, size_class: usize) -> *mut PageHeader {
+        if self.current_arena.is_null() {
+            self.allocate_new_arena();
+        }
+        unsafe {
+            let arena = self.current_arena;
+            let result = (*arena).freepages;
+            let freepages = if (*arena).nfreepages > 0 {
+                (*arena).nfreepages -= 1;
+                *(result as *mut *mut u8)
+            } else {
+                assert!(self.num_uninitialized_pages > 0);
+                self.num_uninitialized_pages -= 1;
+                if self.num_uninitialized_pages > 0 {
+                    result.add(self.page_size)
+                } else {
+                    ptr::null_mut()
+                }
+            };
+            (*arena).freepages = freepages;
+            if freepages.is_null() {
+                assert_eq!((*arena).nfreepages, 0);
+                (*arena).nextarena = self.arenas_lists[0];
+                self.arenas_lists[0] = arena;
+                self.current_arena = ptr::null_mut();
+            }
+            let page = result as *mut PageHeader;
+            ptr::write(
+                page,
+                PageHeader {
+                    nextpage: ptr::null_mut(),
+                    arena,
+                    nfree: 0,
+                    freeblock: result.add(self.hdrsize),
+                },
+            );
+            assert!(self.page_for_size[size_class].is_null());
+            self.page_for_size[size_class] = page;
+            page
+        }
+    }
+
+    /// `ArenaCollection._pick_next_arena`.
+    fn _pick_next_arena(&mut self) -> bool {
+        let mut i = self.min_empty_nfreepages;
+        while i < self.max_pages_per_arena {
+            if !self.arenas_lists[i].is_null() {
+                self.current_arena = self.arenas_lists[i];
+                unsafe {
+                    self.arenas_lists[i] = (*self.current_arena).nextarena;
+                }
+                return true;
+            }
+            i += 1;
+            self.min_empty_nfreepages = i;
+        }
+        false
+    }
+
+    /// `ArenaCollection.allocate_new_arena`.
+    fn allocate_new_arena(&mut self) {
+        if self._pick_next_arena() {
+            return;
+        }
+        self._rehash_arenas_lists();
+        if self._pick_next_arena() {
+            return;
+        }
+        let layout = Layout::from_size_align(self.arena_size, WORD).expect("invalid arena layout");
+        let arena_base = unsafe { alloc::alloc(layout) };
+        if arena_base.is_null() {
+            alloc::handle_alloc_error(layout);
+        }
+        self.total_memory_alloced += self.arena_size;
+        self.peak_memory_alloced = self.peak_memory_alloced.max(self.total_memory_alloced);
+        let arena_end = unsafe { arena_base.add(self.arena_size) } as usize;
+        let firstpage = start_of_page(arena_base as usize + self.page_size - 1, self.page_size);
+        let npages = (arena_end - firstpage) / self.page_size;
+        assert!(npages > 0);
+        let arena = Box::into_raw(Box::new(ArenaReference {
+            base: arena_base,
+            layout,
+            nfreepages: 0,
+            totalpages: npages,
+            freepages: firstpage as *mut u8,
+            nextarena: ptr::null_mut(),
+        }));
+        self.num_uninitialized_pages = npages;
+        self.current_arena = arena;
+        self.arenas_count += 1;
+        let range = (arena_base as usize, arena_end);
+        let index = self
+            .arena_ranges
+            .binary_search_by_key(&range.0, |&(start, _)| start)
+            .unwrap_err();
+        self.arena_ranges.insert(index, range);
+    }
+
+    /// `ArenaCollection.mass_free_prepare`.
+    fn mass_free_prepare(&mut self) {
+        self.peak_memory_used = self.peak_memory_used.max(self.total_memory_used);
+        let mut size_class = self.small_request_threshold / WORD;
+        self.size_class_with_old_pages = size_class as isize;
+        while size_class >= 1 {
+            self.old_page_for_size[size_class] = self.page_for_size[size_class];
+            self.old_full_page_for_size[size_class] = self.full_page_for_size[size_class];
+            self.page_for_size[size_class] = ptr::null_mut();
+            self.full_page_for_size[size_class] = ptr::null_mut();
+            size_class -= 1;
+        }
+    }
+
+    /// `ArenaCollection.mass_free_incremental`.
+    fn mass_free_incremental(
+        &mut self,
+        ok_to_free_func: &mut impl FnMut(*mut u8) -> bool,
+        mut max_pages: usize,
+    ) -> bool {
+        let mut size_class = self.size_class_with_old_pages;
+        while size_class >= 1 {
+            max_pages = self.mass_free_in_pages(size_class as usize, ok_to_free_func, max_pages);
+            if max_pages == 0 {
+                self.size_class_with_old_pages = size_class;
+                return false;
+            }
+            size_class -= 1;
+        }
+        if size_class >= 0 {
+            self._rehash_arenas_lists();
+            self.size_class_with_old_pages = -1;
+        }
+        true
+    }
+
+    /// `ArenaCollection.mass_free`, the non-incremental STW entry point.
+    pub fn mass_free(&mut self, mut ok_to_free_func: impl FnMut(*mut u8) -> bool) {
+        self.mass_free_prepare();
+        let complete = self.mass_free_incremental(&mut ok_to_free_func, usize::MAX);
+        assert!(
+            complete,
+            "non-incremental mass_free_in_pages returned false"
+        );
+    }
+
+    /// `ArenaCollection._rehash_arenas_lists`.
+    fn _rehash_arenas_lists(&mut self) {
+        std::mem::swap(&mut self.old_arenas_lists, &mut self.arenas_lists);
+        self.arenas_lists.fill(ptr::null_mut());
+        for i in 0..self.max_pages_per_arena {
+            let mut arena = self.old_arenas_lists[i];
+            self.old_arenas_lists[i] = ptr::null_mut();
+            while !arena.is_null() {
+                unsafe {
+                    let nextarena = (*arena).nextarena;
+                    if (*arena).nfreepages == (*arena).totalpages {
+                        self.free_arena(arena);
+                    } else {
+                        let n = (*arena).nfreepages;
+                        assert!(n < self.max_pages_per_arena);
+                        (*arena).nextarena = self.arenas_lists[n];
+                        self.arenas_lists[n] = arena;
+                    }
+                    arena = nextarena;
+                }
+            }
+        }
+        self.min_empty_nfreepages = 1;
+    }
+
+    fn mass_free_in_pages(
+        &mut self,
+        size_class: usize,
+        ok_to_free_func: &mut impl FnMut(*mut u8) -> bool,
+        mut max_pages: usize,
+    ) -> usize {
+        let nblocks = self.nblocks_for_size[size_class];
+        let block_size = size_class * WORD;
+        let mut remaining_partial_pages = self.page_for_size[size_class];
+        let mut remaining_full_pages = self.full_page_for_size[size_class];
+        for step in 0..2 {
+            let mut page = if step == 0 {
+                std::mem::replace(
+                    &mut self.old_full_page_for_size[size_class],
+                    ptr::null_mut(),
+                )
+            } else {
+                std::mem::replace(&mut self.old_page_for_size[size_class], ptr::null_mut())
+            };
+            while !page.is_null() {
+                let surviving = self.walk_page(page, block_size, ok_to_free_func);
+                let nextpage = unsafe { (*page).nextpage };
+                if surviving == nblocks {
+                    assert_eq!(step, 0, "a non-full page became full while freeing");
+                    unsafe { (*page).nextpage = remaining_full_pages };
+                    remaining_full_pages = page;
+                } else if surviving > 0 {
+                    unsafe { (*page).nextpage = remaining_partial_pages };
+                    remaining_partial_pages = page;
+                } else {
+                    self.free_page(page);
+                }
+                max_pages -= 1;
+                if max_pages == 0 {
+                    if step == 0 {
+                        self.old_full_page_for_size[size_class] = nextpage;
+                    } else {
+                        self.old_page_for_size[size_class] = nextpage;
+                    }
+                    self.page_for_size[size_class] = remaining_partial_pages;
+                    self.full_page_for_size[size_class] = remaining_full_pages;
+                    return 0;
+                }
+                page = nextpage;
+            }
+        }
+        self.page_for_size[size_class] = remaining_partial_pages;
+        self.full_page_for_size[size_class] = remaining_full_pages;
+        max_pages
+    }
+
+    /// `ArenaCollection.free_page`.
+    fn free_page(&mut self, page: *mut PageHeader) {
+        unsafe {
+            let arena = (*page).arena;
+            (*arena).nfreepages += 1;
+            let pageaddr = page as *mut u8;
+            *(pageaddr as *mut *mut u8) = (*arena).freepages;
+            (*arena).freepages = pageaddr;
+        }
+    }
+
+    /// `ArenaCollection.walk_page`.
+    fn walk_page(
+        &mut self,
+        page: *mut PageHeader,
+        block_size: usize,
+        ok_to_free_func: &mut impl FnMut(*mut u8) -> bool,
+    ) -> usize {
+        unsafe {
+            let mut freeblock = (*page).freeblock;
+            let mut prevfreeblockat: *mut *mut u8 = ptr::addr_of_mut!((*page).freeblock);
+            let mut obj = (page as *mut u8).add(self.hdrsize);
+            let mut surviving = 0;
+            let mut freed = 0;
+            let mut skip_free_blocks = (*page).nfree;
+            loop {
+                if obj == freeblock {
+                    if skip_free_blocks == 0 {
+                        break;
+                    }
+                    skip_free_blocks -= 1;
+                    prevfreeblockat = obj as *mut *mut u8;
+                    freeblock = *prevfreeblockat;
+                } else {
+                    assert!(
+                        (freeblock as usize) > obj as usize,
+                        "freeblocks are not ordered"
+                    );
+                    if ok_to_free_func(obj) {
+                        *prevfreeblockat = obj;
+                        prevfreeblockat = obj as *mut *mut u8;
+                        *prevfreeblockat = freeblock;
+                        (*page).nfree += 1;
+                        freed += 1;
+                    } else {
+                        surviving += 1;
+                    }
+                }
+                obj = obj.add(block_size);
+            }
+            self.total_memory_used -= freed * block_size;
+            self.live_objects -= freed;
+            surviving
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn object_count(&self) -> usize {
+        self.live_objects
+    }
+
+    /// Arena-owned address-range membership, matching the answer available to
+    /// incminimark from its arena pages.  It intentionally does not distinguish
+    /// live blocks from free/uninitialized bytes inside a live arena.  The
+    /// allocator's bucketed arena lists remain the source of allocation state;
+    /// this sorted flat index serves pyre's arbitrary-word membership query.
+    pub fn contains(&self, addr: usize) -> bool {
+        let index = self
+            .arena_ranges
+            .partition_point(|&(start, _)| start <= addr);
+        index > 0 && addr < self.arena_ranges[index - 1].1
+    }
+
+    unsafe fn free_arena(&mut self, arena: *mut ArenaReference) {
+        unsafe {
+            let base = (*arena).base as usize;
+            let index = self
+                .arena_ranges
+                .binary_search_by_key(&base, |&(start, _)| start)
+                .expect("freed arena missing from range index");
+            self.arena_ranges.remove(index);
+            alloc::dealloc((*arena).base, (*arena).layout);
+            self.total_memory_alloced -= self.arena_size;
+            self.arenas_count -= 1;
+            drop(Box::from_raw(arena));
+        }
+    }
+}
+
+impl Drop for ArenaCollection {
+    fn drop(&mut self) {
+        unsafe {
+            if !self.current_arena.is_null() {
+                self.free_arena(self.current_arena);
+                self.current_arena = ptr::null_mut();
+            }
+            for i in 0..self.arenas_lists.len() {
+                let mut arena = self.arenas_lists[i];
+                self.arenas_lists[i] = ptr::null_mut();
+                while !arena.is_null() {
+                    let next = (*arena).nextarena;
+                    self.free_arena(arena);
+                    arena = next;
+                }
+            }
+        }
+    }
+}
+
+/// `minimarkpage.py:start_of_page` (translated path).
+pub fn start_of_page(addr: usize, page_size: usize) -> usize {
+    addr - addr % page_size
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const PAGE_SIZE: usize = 256;
+    const ARENA_SIZE: usize = PAGE_SIZE * 8;
+    const THRESHOLD: usize = 9 * WORD;
+
+    #[test]
+    fn allocate_and_malloc_mixed_sizes() {
+        let mut ac = ArenaCollection::new(ARENA_SIZE, PAGE_SIZE, THRESHOLD);
+        let a = ac.malloc(2 * WORD);
+        let b = ac.malloc(3 * WORD);
+        let c = ac.malloc(2 * WORD);
+        assert_ne!(a, c);
+        assert!(ac.contains(a as usize));
+        assert!(ac.contains(b as usize));
+        assert_eq!(ac.total_memory_used, 7 * WORD);
+        assert_eq!((a as usize) % WORD, 0);
+    }
+
+    #[test]
+    fn malloc_reuses_ordered_free_blocks() {
+        let mut ac = ArenaCollection::new(ARENA_SIZE, PAGE_SIZE, THRESHOLD);
+        let objects: Vec<_> = (0..5).map(|_| ac.malloc(2 * WORD)).collect();
+        ac.mass_free(|obj| obj == objects[1] || obj == objects[3]);
+        assert_eq!(ac.total_memory_used, 3 * 2 * WORD);
+        assert_eq!(ac.malloc(2 * WORD), objects[1]);
+        assert_eq!(ac.malloc(2 * WORD), objects[3]);
+    }
+
+    #[test]
+    fn mass_free_partial_and_emptied_pages() {
+        let mut ac = ArenaCollection::new(ARENA_SIZE, PAGE_SIZE, THRESHOLD);
+        let block_size = 2 * WORD;
+        let per_page = (PAGE_SIZE - std::mem::size_of::<PageHeader>()) / block_size;
+        let objects: Vec<_> = (0..per_page + 2).map(|_| ac.malloc(block_size)).collect();
+        let survivor = objects[0];
+        ac.mass_free(|obj| obj != survivor);
+        assert_eq!(ac.total_memory_used, block_size);
+        assert!(ac.contains(survivor as usize));
+        let reused = ac.malloc(block_size);
+        assert_ne!(reused, survivor);
+    }
+
+    #[test]
+    fn whole_arena_is_returned_after_mass_free() {
+        let mut ac = ArenaCollection::new(ARENA_SIZE, PAGE_SIZE, THRESHOLD);
+        let first = ac.malloc(WORD) as usize;
+        while !ac.current_arena.is_null() {
+            ac.malloc(WORD);
+        }
+        assert_eq!(ac.arenas_count, 1);
+        ac.mass_free(|_| true);
+        assert_eq!(ac.total_memory_used, 0);
+        assert_eq!(ac.arenas_count, 0);
+        assert_eq!(ac.total_memory_alloced, 0);
+        assert!(!ac.contains(first));
+    }
+
+    #[test]
+    fn randomized_mass_free_matches_live_set() {
+        let mut ac = ArenaCollection::new(ARENA_SIZE, PAGE_SIZE, THRESHOLD);
+        let mut live = Vec::new();
+        let mut state = 0x1234_5678_u64;
+        for _round in 0..50 {
+            for _ in 0..37 {
+                state = state.wrapping_mul(6364136223846793005).wrapping_add(1);
+                let size = ((state as usize % 6) + 1) * WORD;
+                live.push((ac.malloc(size), size));
+            }
+            let before = ac.total_memory_used;
+            let mut decisions: Vec<_> = live
+                .iter()
+                .map(|&(ptr, size)| {
+                    state = state.wrapping_mul(6364136223846793005).wrapping_add(1);
+                    (ptr, size, (state >> 63) != 0, false)
+                })
+                .collect();
+            ac.mass_free(|obj| {
+                let entry = decisions.iter_mut().find(|entry| entry.0 == obj).unwrap();
+                assert!(!entry.3);
+                entry.3 = true;
+                entry.2
+            });
+            assert!(decisions.iter().all(|entry| entry.3));
+            let freed_bytes: usize = decisions
+                .iter()
+                .filter(|entry| entry.2)
+                .map(|entry| entry.1)
+                .sum();
+            assert_eq!(ac.total_memory_used, before - freed_bytes);
+            live = decisions
+                .into_iter()
+                .filter(|entry| !entry.2)
+                .map(|entry| (entry.0, entry.1))
+                .collect();
+        }
+    }
+
+    #[test]
+    fn start_of_page_rounds_down() {
+        assert_eq!(start_of_page(0x12345, 0x1000), 0x12000);
+    }
+}

--- a/majit/majit-gc/src/nursery.rs
+++ b/majit/majit-gc/src/nursery.rs
@@ -66,6 +66,9 @@ pub struct Nursery {
     /// Heap-allocated free/top pointers. The Box ensures stable addresses
     /// that the JIT can hardcode into compiled code.
     ptrs: Box<NurseryPtrs>,
+    /// llarena.py mode-3 parity: poison recycled nursery bytes so tests
+    /// expose allocation paths that incorrectly rely on zero-filled memory.
+    poison_on_reset: bool,
 }
 
 // Safety: The nursery owns its memory exclusively and only one thread accesses it.
@@ -83,7 +86,13 @@ impl Nursery {
         }
         let top = unsafe { start.add(size) };
         let ptrs = Box::new(NurseryPtrs { free: start, top });
-        Nursery { start, size, ptrs }
+        let poison_on_reset = std::env::var_os("MAJIT_GC_NURSERY_POISON").is_some();
+        Nursery {
+            start,
+            size,
+            ptrs,
+            poison_on_reset,
+        }
     }
 
     /// incminimark.py:676-680 malloc_fixedsize parity:
@@ -115,22 +124,15 @@ impl Nursery {
     /// incminimark.py:1946 parity: reset nursery after minor collection.
     ///   self.nursery_free = self.nursery
     ///
-    /// PRE-EXISTING-ADAPTATION: the full-nursery zeroing below has no
-    /// upstream counterpart — incminimark's reset is `arena_reset(prev,
-    /// ..., 0)` (incminimark.py:1938; llarena.py:334 mode 0 = "don't fill
-    /// with zeroes") with `malloc_zero_filled = False` (incminimark.py:211),
-    /// each allocation initializing its own fields ("fully initialized,
-    /// but not zero-filled", incminimark.py:960).  pyre allocation paths
-    /// (Rust constructors and JIT inline New*) currently assume
-    /// zero-filled nursery memory for fields they do not write, i.e. the
-    /// system behaves as `malloc_zero_filled = True`.  Convergence path:
-    /// audit every alloc site for assumed-zero fields (add explicit field
-    /// init / `zero_gc_pointers_inside` equivalents), then drop this
-    /// `write_bytes` — it costs one full-nursery memset per minor
-    /// collection (~4.5% of nbody).
+    /// incminimark.py:211/1938 parity: `malloc_zero_filled = False` and
+    /// `arena_reset(..., 0)` leave recycled bytes untouched; allocation
+    /// sites initialize their own GC-pointer fields.  Poison mode mirrors
+    /// llarena.py mode 3 for detecting violations of that contract.
     pub fn reset(&mut self) {
-        unsafe {
-            ptr::write_bytes(self.start, 0, self.size);
+        if self.poison_on_reset {
+            unsafe {
+                ptr::write_bytes(self.start, 0xAA, self.size);
+            }
         }
         self.ptrs.free = self.start;
     }
@@ -207,6 +209,14 @@ impl Nursery {
     #[inline]
     pub fn contains(&self, addr: usize) -> bool {
         addr >= self.start as usize && addr < (self.start as usize + self.size)
+    }
+
+    /// Whether recycled nursery bytes are filled with the llarena-style
+    /// uninitialized-memory poison.  This is cached at nursery construction so
+    /// traced-slot checks do not consult the environment during collection.
+    #[inline]
+    pub(crate) fn poison_enabled(&self) -> bool {
+        self.poison_on_reset
     }
 }
 

--- a/majit/majit-gc/src/nursery.rs
+++ b/majit/majit-gc/src/nursery.rs
@@ -128,10 +128,23 @@ impl Nursery {
     /// `arena_reset(..., 0)` leave recycled bytes untouched; allocation
     /// sites initialize their own GC-pointer fields.  Poison mode mirrors
     /// llarena.py mode 3 for detecting violations of that contract.
+    ///
+    /// WASM-ONLY ADAPTATION: majit-backend-wasm/src/codegen.rs:2592-2599
+    /// documents that wasm skips the GC rewrite, so its JIT code has no
+    /// `clear_gc_fields` stores and still requires recycled nursery bytes to
+    /// be zero-filled.  Delete this target branch once wasm runs the rewrite
+    /// or its inline allocation paths explicitly initialize GC fields.
     pub fn reset(&mut self) {
-        if self.poison_on_reset {
-            unsafe {
-                ptr::write_bytes(self.start, 0xAA, self.size);
+        #[cfg(target_arch = "wasm32")]
+        unsafe {
+            ptr::write_bytes(self.start, 0, self.size);
+        }
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            if self.poison_on_reset {
+                unsafe {
+                    ptr::write_bytes(self.start, 0xAA, self.size);
+                }
             }
         }
         self.ptrs.free = self.start;

--- a/majit/majit-gc/src/oldgen.rs
+++ b/majit/majit-gc/src/oldgen.rs
@@ -1,189 +1,170 @@
-/// Old-generation allocator.
-///
-/// Objects that survive nursery collection are copied here. For Phase 0,
-/// this is a simple allocation scheme using the system allocator. Each
-/// allocation is tracked in a list so we can iterate all old-gen objects
-/// during major (mark-sweep) collection.
+//! Old-generation allocation on `minimarkpage.py:ArenaCollection`.
+
 use std::alloc::{self, Layout};
+use std::collections::HashSet;
 use std::ptr;
 
 use crate::flags;
 use crate::header::{GcHeader, header_of};
+use crate::minimarkpage::ArenaCollection;
 
-/// A single old-generation allocation record.
-struct OldObject {
-    /// Start of the raw allocation (for dealloc).
-    /// For objects with card marking, this is before the card header bytes.
-    /// incminimark.py:1046-1067: allocsize includes cardheadersize.
+const WORD: usize = std::mem::size_of::<usize>();
+const DEFAULT_PAGE_SIZE: usize = 1024 * WORD;
+const DEFAULT_ARENA_SIZE: usize = 65536 * WORD;
+const SMALL_REQUEST_THRESHOLD: usize = 35 * WORD;
+
+/// incminimark.py `old_rawmalloced_objects` entry.  The list shape is kept
+/// because upstream individually frees objects above the small threshold.
+struct RawMallocedObject {
     alloc_start: usize,
-    /// Address of the GcHeader.
-    /// = alloc_start + card_header_bytes for card-marked objects,
-    /// = alloc_start for regular objects.
     header_addr: usize,
-    /// Layout used for deallocation.
     layout: Layout,
 }
 
-/// Simple old-generation allocator backed by the system allocator.
-///
-/// Tracks all allocations for mark-sweep collection.
 pub struct OldGen {
-    /// All live old-gen objects.
-    objects: Vec<OldObject>,
-    /// O(1) membership index: payload addresses (`header_addr +
-    /// GcHeader::SIZE`) of every live old-gen object.
-    ///
-    /// PRE-EXISTING-ADAPTATION (data-structure parity, AGENTS.md). incminimark's
-    /// `ArenaCollection` answers "is this an old object?" in O(1) from arena
-    /// page bounds — a pure range check, exactly like `Nursery::contains`. pyre
-    /// allocates each old object individually through the system allocator (see
-    /// the struct doc — no contiguous arena), so there is no range to test and
-    /// this `HashSet` stands in, kept in sync with `objects` on alloc/sweep.
-    ///
-    /// Convergence path (blocked, multi-session): port `minimarkpage.py`'s
-    /// size-class free-list `ArenaCollection` so old objects live in contiguous
-    /// arena pages and `contains` becomes a bounds check. The blocker is sweep:
-    /// the nursery is copying (survivors are evacuated, then the whole arena is
-    /// reset, so it never frees individually), but the old gen is mark-sweep and
-    /// must free dead objects in place — which under an arena requires the
-    /// per-size-class free lists `mass_free` rebuilds, a self-contained but
-    /// multi-file allocator port. Until then the `HashSet` is load-bearing for a
-    /// second reason: `is_managed_heap_object` tests arbitrary field addresses
-    /// that may transiently point outside the GC heap (the L1/L2 stepping-stone
-    /// state, collector.rs `mark_object`), so a header-flag check is unsafe
-    /// until every `gc_ptr_offsets` target is a real GC allocation; a bounds
-    /// check over arena pages would correctly answer false for those, which is
-    /// the other half of why the arena port is the right fix.
-    ///
-    /// Without this index `contains` is a linear scan that becomes a hot O(n²)
-    /// under the parity-correct major-collection threshold once the old gen is
-    /// large (issue 215: minor-collection `walk_jf_roots` calls `contains` per
-    /// root).
-    payloads: std::collections::HashSet<usize>,
-    /// Total bytes allocated in old gen.
-    total_bytes: usize,
+    ac: ArenaCollection,
+    old_rawmalloced_objects: Vec<RawMallocedObject>,
+    /// Exact payload membership for objects routed to individual rawmalloc
+    /// (oversized or card-header allocations).  This is the same address-dict
+    /// shape upstream uses when it needs exact rawmalloc membership:
+    /// incminimark.py:1219-1221 and 2153-2158.  Unlike the removed F2-era
+    /// payload side table, it has no entry for ordinary arena survivors.
+    rawmalloced_payloads: HashSet<usize>,
+    rawmalloced_total_size: usize,
+    /// llarena debug-fill parity for old-generation allocations.  The same
+    /// opt-in detector covers both recycled arena blocks and rawmalloc blocks.
+    poison_on_alloc: bool,
 }
 
-// Safety: OldGen owns all its allocations, single-threaded access.
 unsafe impl Send for OldGen {}
 
 impl OldGen {
     pub fn new() -> Self {
-        OldGen {
-            objects: Vec::new(),
-            payloads: std::collections::HashSet::new(),
-            total_bytes: 0,
+        Self {
+            ac: ArenaCollection::new(
+                DEFAULT_ARENA_SIZE,
+                DEFAULT_PAGE_SIZE,
+                SMALL_REQUEST_THRESHOLD,
+            ),
+            old_rawmalloced_objects: Vec::new(),
+            rawmalloced_payloads: HashSet::new(),
+            rawmalloced_total_size: 0,
+            poison_on_alloc: std::env::var_os("MAJIT_GC_NURSERY_POISON").is_some(),
         }
     }
 
-    /// Allocate space for an object of `total_size` bytes (header + payload).
-    /// Returns a pointer to the header location. Memory is zero-filled.
+    /// Allocate header + payload.  Like incminimark.py:999-1009, the arena
+    /// path is not cleared; callers initialize the object explicitly.
     pub fn alloc(&mut self, total_size: usize) -> *mut u8 {
         self.alloc_with_card_header(total_size, 0)
     }
 
-    /// incminimark.py:1046-1067: allocate with card header bytes prepended.
-    ///
-    /// Layout: `[card_bytes (card_header_bytes)] [GcHeader] [payload]`
-    /// Returns pointer to the GcHeader (NOT the card bytes).
-    /// Card bytes are zero-filled.
+    /// incminimark.py:1012-1080: card headers occur in the rawmalloc branch,
+    /// are prepended to the allocation, and only the card bytes are cleared.
     pub fn alloc_with_card_header(
         &mut self,
         total_size: usize,
         card_header_bytes: usize,
     ) -> *mut u8 {
-        let obj_size = total_size.max(GcHeader::MIN_NURSERY_OBJ_SIZE);
-        let alloc_size = card_header_bytes + obj_size;
-        let layout = Layout::from_size_align(alloc_size, 8).expect("invalid layout");
-        let ptr = unsafe { alloc::alloc_zeroed(layout) };
-        if ptr.is_null() {
-            alloc::handle_alloc_error(layout);
-        }
-        let header_ptr = unsafe { ptr.add(card_header_bytes) };
-        let obj_record = OldObject {
-            alloc_start: ptr as usize,
-            header_addr: header_ptr as usize,
-            layout,
+        let obj_size = round_up(total_size.max(GcHeader::MIN_NURSERY_OBJ_SIZE));
+        let alloc_size = round_up(card_header_bytes + obj_size);
+        let header_ptr = if card_header_bytes == 0 && alloc_size <= SMALL_REQUEST_THRESHOLD {
+            self.ac.malloc(alloc_size)
+        } else {
+            let layout = Layout::from_size_align(alloc_size, WORD).expect("invalid layout");
+            let raw = unsafe { alloc::alloc(layout) };
+            if raw.is_null() {
+                alloc::handle_alloc_error(layout);
+            }
+            if card_header_bytes > 0 {
+                unsafe { ptr::write_bytes(raw, 0, card_header_bytes) };
+            }
+            let header_ptr = unsafe { raw.add(card_header_bytes) };
+            self.old_rawmalloced_objects.push(RawMallocedObject {
+                alloc_start: raw as usize,
+                header_addr: header_ptr as usize,
+                layout,
+            });
+            self.rawmalloced_payloads
+                .insert(header_ptr as usize + GcHeader::SIZE);
+            self.rawmalloced_total_size += alloc_size;
+            header_ptr
         };
-        self.objects.push(obj_record);
-        self.payloads.insert(header_ptr as usize + GcHeader::SIZE);
-        self.total_bytes += alloc_size;
+        if self.poison_on_alloc {
+            // ArenaCollection.malloc intentionally returns uninitialized
+            // memory.  In detector mode make that contract observable for
+            // both fresh/recycled arena blocks and rawmalloced objects.
+            unsafe { ptr::write_bytes(header_ptr, 0xAA, obj_size) };
+        }
         header_ptr
     }
 
-    /// Allocate and copy data from a source address.
-    /// `total_size` is the total size including header.
-    /// Returns a pointer to the header of the new copy.
-    ///
-    /// # Safety
-    /// `src` must point to at least `total_size` bytes of readable memory.
+    /// Allocate uninitialized space and overwrite the complete object from
+    /// `src`, as nursery promotion does.
     pub unsafe fn alloc_and_copy(&mut self, src: *const u8, total_size: usize) -> *mut u8 {
         let dst = self.alloc(total_size);
         unsafe { ptr::copy_nonoverlapping(src, dst, total_size) };
         dst
     }
 
-    /// Total bytes currently allocated in old gen.
+    /// incminimark.py:1268: arena live bytes plus rawmalloced live bytes.
     pub fn total_bytes(&self) -> usize {
-        self.total_bytes
+        self.ac.total_memory_used + self.rawmalloced_total_size
     }
 
-    /// Number of objects in old gen.
-    pub fn object_count(&self) -> usize {
-        self.objects.len()
+    #[cfg(test)]
+    pub(crate) fn object_count(&self) -> usize {
+        self.ac.object_count() + self.old_rawmalloced_objects.len()
     }
 
-    /// Perform mark-sweep collection.
-    /// Before calling this, the caller must have set VISITED on all reachable objects.
-    /// This frees all objects that do NOT have the VISITED flag, and clears
-    /// VISITED on surviving objects.
+    /// Non-incremental major sweep: `ArenaCollection.mass_free` for small
+    /// objects and individual freeing of unvisited rawmalloced objects.
     pub fn sweep(&mut self) {
-        let mut surviving = Vec::new();
-        let mut freed_bytes = 0usize;
-
-        for obj_record in self.objects.drain(..) {
-            let hdr = unsafe { &mut *(obj_record.header_addr as *mut GcHeader) };
+        self.ac.mass_free(|header_ptr| unsafe {
+            let hdr = &mut *(header_ptr as *mut GcHeader);
             if hdr.has_flag(flags::VISITED) {
-                // Survived: clear VISITED for next cycle.
                 hdr.clear_flag(flags::VISITED);
-                surviving.push(obj_record);
+                false
             } else {
-                // Dead: free it. Dealloc from alloc_start (includes card header).
-                freed_bytes += obj_record.layout.size();
-                self.payloads
-                    .remove(&(obj_record.header_addr + GcHeader::SIZE));
-                unsafe {
-                    alloc::dealloc(obj_record.alloc_start as *mut u8, obj_record.layout);
-                }
+                true
+            }
+        });
+
+        let mut surviving = Vec::new();
+        let mut freed_bytes = 0;
+        for object in self.old_rawmalloced_objects.drain(..) {
+            let hdr = unsafe { &mut *(object.header_addr as *mut GcHeader) };
+            if hdr.has_flag(flags::VISITED) {
+                hdr.clear_flag(flags::VISITED);
+                surviving.push(object);
+            } else {
+                freed_bytes += object.layout.size();
+                let removed = self
+                    .rawmalloced_payloads
+                    .remove(&(object.header_addr + GcHeader::SIZE));
+                debug_assert!(removed);
+                unsafe { alloc::dealloc(object.alloc_start as *mut u8, object.layout) };
             }
         }
-
-        self.total_bytes -= freed_bytes;
-        self.objects = surviving;
+        self.rawmalloced_total_size -= freed_bytes;
+        self.old_rawmalloced_objects = surviving;
     }
 
-    /// Iterate all old-gen object addresses (payload address, after header).
-    /// The callback receives the object payload address.
-    pub fn for_each_object(&self, mut f: impl FnMut(usize)) {
-        for obj_record in &self.objects {
-            f(obj_record.header_addr + GcHeader::SIZE);
-        }
-    }
-
-    /// Check whether `obj_addr` is the payload address of a tracked old-gen
-    /// object. O(1) via the `payloads` index (see its field doc). Called per
-    /// root in minor collection (`walk_jf_roots`) and per traced field in
-    /// `is_managed_heap_object`, so it must not be a linear scan.
+    /// Arena membership is intentionally an address-range answer, not a live
+    /// block answer.  Rawmalloced objects retain exact payload membership.
     pub fn contains(&self, obj_addr: usize) -> bool {
-        self.payloads.contains(&obj_addr)
+        self.ac.contains(obj_addr) || self.rawmalloced_payloads.contains(&obj_addr)
     }
 
-    /// Mark an old-gen object as visited (for major collection).
     pub fn mark_visited(obj_addr: usize) {
-        unsafe {
-            (*header_of(obj_addr)).set_flag(flags::VISITED);
-        }
+        unsafe { (*header_of(obj_addr)).set_flag(flags::VISITED) };
     }
+}
+
+fn round_up(size: usize) -> usize {
+    size.checked_add(WORD - 1)
+        .expect("allocation size overflow")
+        & !(WORD - 1)
 }
 
 impl Default for OldGen {
@@ -194,10 +175,8 @@ impl Default for OldGen {
 
 impl Drop for OldGen {
     fn drop(&mut self) {
-        for obj_record in self.objects.drain(..) {
-            unsafe {
-                alloc::dealloc(obj_record.alloc_start as *mut u8, obj_record.layout);
-            }
+        for object in self.old_rawmalloced_objects.drain(..) {
+            unsafe { alloc::dealloc(object.alloc_start as *mut u8, object.layout) };
         }
     }
 }
@@ -207,97 +186,50 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_oldgen_alloc() {
+    fn small_alloc_and_copy() {
         let mut oldgen = OldGen::new();
-        let ptr = oldgen.alloc(32);
-        assert!(!ptr.is_null());
-        assert_eq!(oldgen.object_count(), 1);
-        assert!(oldgen.total_bytes() >= 32);
+        let src = [1u8; 32];
+        let dst = unsafe { oldgen.alloc_and_copy(src.as_ptr(), src.len()) };
+        assert_eq!(unsafe { *dst.add(17) }, 1);
+        assert!(oldgen.contains(dst as usize + GcHeader::SIZE));
     }
 
     #[test]
-    fn test_oldgen_alloc_and_copy() {
+    fn sweep_reuses_small_blocks_and_clears_visited() {
         let mut oldgen = OldGen::new();
-        let src = [1u8, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16];
-        let dst = unsafe { oldgen.alloc_and_copy(src.as_ptr(), 16) };
-        assert!(!dst.is_null());
-        for i in 0..16 {
-            assert_eq!(unsafe { *dst.add(i) }, src[i]);
-        }
-    }
-
-    #[test]
-    fn test_oldgen_sweep() {
-        let mut oldgen = OldGen::new();
-
-        // Allocate 3 objects
         let p1 = oldgen.alloc(GcHeader::SIZE + 16);
         let p2 = oldgen.alloc(GcHeader::SIZE + 16);
-        let p3 = oldgen.alloc(GcHeader::SIZE + 16);
-        assert_eq!(oldgen.object_count(), 3);
-
-        // Mark p1 and p3 as visited (reachable), leave p2 unmarked (dead)
-        let hdr1 = unsafe { &mut *(p1 as *mut GcHeader) };
-        *hdr1 = GcHeader::new(0);
-        hdr1.set_flag(flags::VISITED);
-
-        let hdr2 = unsafe { &mut *(p2 as *mut GcHeader) };
-        *hdr2 = GcHeader::new(0);
-        // Not visited -> dead
-
-        let hdr3 = unsafe { &mut *(p3 as *mut GcHeader) };
-        *hdr3 = GcHeader::new(0);
-        hdr3.set_flag(flags::VISITED);
-
-        oldgen.sweep();
-
-        assert_eq!(oldgen.object_count(), 2);
-
-        // Verify VISITED is cleared on survivors
-        let hdr1 = unsafe { &mut *(p1 as *mut GcHeader) };
-        assert!(!hdr1.has_flag(flags::VISITED));
-        let hdr3 = unsafe { &mut *(p3 as *mut GcHeader) };
-        assert!(!hdr3.has_flag(flags::VISITED));
-    }
-
-    #[test]
-    fn test_oldgen_contains_after_sweep() {
-        let mut oldgen = OldGen::new();
-
-        let p1 = oldgen.alloc(GcHeader::SIZE + 16);
-        let p2 = oldgen.alloc(GcHeader::SIZE + 16);
-        let p3 = oldgen.alloc(GcHeader::SIZE + 16);
-        let o1 = p1 as usize + GcHeader::SIZE;
-        let o2 = p2 as usize + GcHeader::SIZE;
-        let o3 = p3 as usize + GcHeader::SIZE;
-
-        assert!(oldgen.contains(o1));
-        assert!(oldgen.contains(o2));
-        assert!(oldgen.contains(o3));
-
         unsafe {
-            *(p1 as *mut GcHeader) = GcHeader::new(0);
-            *(p2 as *mut GcHeader) = GcHeader::new(0);
-            *(p3 as *mut GcHeader) = GcHeader::new(0);
-            (*(p1 as *mut GcHeader)).set_flag(flags::VISITED);
-            (*(p3 as *mut GcHeader)).set_flag(flags::VISITED);
+            *p1.cast::<GcHeader>() = GcHeader::new(0);
+            *p2.cast::<GcHeader>() = GcHeader::new(0);
+            (*p1.cast::<GcHeader>()).set_flag(flags::VISITED);
         }
-
         oldgen.sweep();
-
-        assert!(oldgen.contains(o1));
-        assert!(!oldgen.contains(o2));
-        assert!(oldgen.contains(o3));
+        assert!(!unsafe { (*p1.cast::<GcHeader>()).has_flag(flags::VISITED) });
+        let p3 = oldgen.alloc(GcHeader::SIZE + 16);
+        assert_eq!(p3, p2);
     }
 
     #[test]
-    fn test_oldgen_for_each() {
+    fn large_and_card_allocations_use_rawmalloc_accounting() {
         let mut oldgen = OldGen::new();
-        oldgen.alloc(GcHeader::SIZE + 8);
-        oldgen.alloc(GcHeader::SIZE + 8);
+        let size = SMALL_REQUEST_THRESHOLD + WORD;
+        let ptr = oldgen.alloc_with_card_header(size, 2 * WORD);
+        assert_eq!(unsafe { *ptr.sub(1) }, 0);
+        unsafe {
+            *ptr.cast::<GcHeader>() = GcHeader::new(0);
+            (*ptr.cast::<GcHeader>()).set_flag(flags::VISITED);
+        }
+        assert!(oldgen.contains(ptr as usize + GcHeader::SIZE));
+        assert_eq!(oldgen.total_bytes(), round_up(size + 2 * WORD));
+        oldgen.sweep();
+        assert!(oldgen.contains(ptr as usize + GcHeader::SIZE));
 
-        let mut count = 0;
-        oldgen.for_each_object(|_addr| count += 1);
-        assert_eq!(count, 2);
+        let dead = oldgen.alloc(size);
+        let dead_payload = dead as usize + GcHeader::SIZE;
+        unsafe { *dead.cast::<GcHeader>() = GcHeader::new(0) };
+        assert!(oldgen.contains(dead_payload));
+        oldgen.sweep();
+        assert!(!oldgen.contains(dead_payload));
     }
 }

--- a/majit/majit-gc/src/oldgen.rs
+++ b/majit/majit-gc/src/oldgen.rs
@@ -24,6 +24,10 @@ struct RawMallocedObject {
 pub struct OldGen {
     ac: ArenaCollection,
     old_rawmalloced_objects: Vec<RawMallocedObject>,
+    /// incminimark.py:2688-2694 `raw_malloc_might_sweep`.  At sweep
+    /// preparation the old rawmalloc stack is swapped into this one, isolating
+    /// it from rawmalloc allocations made by minors between sweep steps.
+    raw_malloc_might_sweep: Vec<RawMallocedObject>,
     /// Exact payload membership for objects routed to individual rawmalloc
     /// (oversized or card-header allocations).  This is the same address-dict
     /// shape upstream uses when it needs exact rawmalloc membership:
@@ -47,6 +51,7 @@ impl OldGen {
                 SMALL_REQUEST_THRESHOLD,
             ),
             old_rawmalloced_objects: Vec::new(),
+            raw_malloc_might_sweep: Vec::new(),
             rawmalloced_payloads: HashSet::new(),
             rawmalloced_total_size: 0,
             poison_on_alloc: std::env::var_os("MAJIT_GC_NURSERY_POISON").is_some(),
@@ -114,40 +119,99 @@ impl OldGen {
 
     #[cfg(test)]
     pub(crate) fn object_count(&self) -> usize {
-        self.ac.object_count() + self.old_rawmalloced_objects.len()
+        self.ac.object_count()
+            + self.old_rawmalloced_objects.len()
+            + self.raw_malloc_might_sweep.len()
     }
 
-    /// Non-incremental major sweep: `ArenaCollection.mass_free` for small
-    /// objects and individual freeing of unvisited rawmalloced objects.
-    pub fn sweep(&mut self) {
-        self.ac.mass_free(|header_ptr| unsafe {
-            let hdr = &mut *(header_ptr as *mut GcHeader);
-            if hdr.has_flag(flags::VISITED) {
-                hdr.clear_flag(flags::VISITED);
-                false
-            } else {
-                true
-            }
-        });
+    /// incminimark.py:2512-2514 and :2688-2694: freeze the arena pages and
+    /// rawmalloc stack belonging to this major cycle.  Allocations made while
+    /// sweeping go to the fresh active page lists and
+    /// `old_rawmalloced_objects`, so this cycle never visits them.
+    pub fn sweep_prepare(&mut self) {
+        self.ac.mass_free_prepare();
+        debug_assert!(
+            self.raw_malloc_might_sweep.is_empty(),
+            "raw_malloc_might_sweep must be empty"
+        );
+        std::mem::swap(
+            &mut self.raw_malloc_might_sweep,
+            &mut self.old_rawmalloced_objects,
+        );
+    }
 
-        let mut surviving = Vec::new();
-        let mut freed_bytes = 0;
-        for object in self.old_rawmalloced_objects.drain(..) {
+    /// incminimark.py:2695-2702 `free_unvisited_rawmalloc_objects_step`.
+    /// Process at most `nobjects` candidates and return the unused part of the
+    /// budget, exactly like the upstream routine.
+    pub fn sweep_rawmalloc_step(&mut self, mut nobjects: usize) -> usize {
+        while !self.raw_malloc_might_sweep.is_empty() && nobjects > 0 {
+            let object = self.raw_malloc_might_sweep.pop().unwrap();
             let hdr = unsafe { &mut *(object.header_addr as *mut GcHeader) };
             if hdr.has_flag(flags::VISITED) {
                 hdr.clear_flag(flags::VISITED);
-                surviving.push(object);
+                self.old_rawmalloced_objects.push(object);
             } else {
-                freed_bytes += object.layout.size();
+                self.rawmalloced_total_size -= object.layout.size();
                 let removed = self
                     .rawmalloced_payloads
                     .remove(&(object.header_addr + GcHeader::SIZE));
                 debug_assert!(removed);
                 unsafe { alloc::dealloc(object.alloc_start as *mut u8, object.layout) };
             }
+            nobjects -= 1;
         }
-        self.rawmalloced_total_size -= freed_bytes;
-        self.old_rawmalloced_objects = surviving;
+        nobjects
+    }
+
+    /// Whether the rawmalloc half of the current incremental sweep remains.
+    pub fn rawmalloc_sweep_pending(&self) -> bool {
+        !self.raw_malloc_might_sweep.is_empty()
+    }
+
+    /// incminimark.py:2549-2555: sweep at most `max_pages` frozen arena pages.
+    pub fn sweep_arenas_step(&mut self, max_pages: usize) -> bool {
+        self.ac.mass_free_incremental(
+            &mut |header_ptr| unsafe {
+                let hdr = &mut *(header_ptr as *mut GcHeader);
+                if hdr.has_flag(flags::VISITED) {
+                    hdr.clear_flag(flags::VISITED);
+                    false
+                } else {
+                    true
+                }
+            },
+            max_pages,
+        )
+    }
+
+    pub fn page_size(&self) -> usize {
+        DEFAULT_PAGE_SIZE
+    }
+
+    pub fn small_request_threshold(&self) -> usize {
+        SMALL_REQUEST_THRESHOLD
+    }
+
+    /// Non-incremental compatibility entry point, expressed as prepare plus
+    /// draining steps just like minimarkpage.py:376-383 `mass_free`.
+    #[allow(dead_code)]
+    pub fn sweep(&mut self) {
+        self.sweep_prepare();
+        while self.rawmalloc_sweep_pending() {
+            self.sweep_rawmalloc_step(usize::MAX);
+        }
+        let complete = self.sweep_arenas_step(usize::MAX);
+        assert!(complete, "non-incremental oldgen sweep returned false");
+    }
+
+    #[cfg(test)]
+    pub(crate) fn rawmalloc_sweep_candidate_count(&self) -> usize {
+        self.raw_malloc_might_sweep.len()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn active_rawmalloc_count(&self) -> usize {
+        self.old_rawmalloced_objects.len()
     }
 
     /// Arena membership is intentionally an address-range answer, not a live
@@ -176,6 +240,9 @@ impl Default for OldGen {
 impl Drop for OldGen {
     fn drop(&mut self) {
         for object in self.old_rawmalloced_objects.drain(..) {
+            unsafe { alloc::dealloc(object.alloc_start as *mut u8, object.layout) };
+        }
+        for object in self.raw_malloc_might_sweep.drain(..) {
             unsafe { alloc::dealloc(object.alloc_start as *mut u8, object.layout) };
         }
     }
@@ -231,5 +298,39 @@ mod tests {
         assert!(oldgen.contains(dead_payload));
         oldgen.sweep();
         assert!(!oldgen.contains(dead_payload));
+    }
+
+    #[test]
+    fn rawmalloc_sweep_step_is_bounded_and_isolates_new_allocations() {
+        let mut oldgen = OldGen::new();
+        let size = SMALL_REQUEST_THRESHOLD + WORD;
+        for _ in 0..3 {
+            let ptr = oldgen.alloc(size);
+            unsafe { *ptr.cast::<GcHeader>() = GcHeader::new(0) };
+        }
+
+        oldgen.sweep_prepare();
+        assert_eq!(oldgen.rawmalloc_sweep_candidate_count(), 3);
+        assert_eq!(oldgen.active_rawmalloc_count(), 0);
+
+        // incminimark.py:2688-2694: allocations made after the swap land in
+        // the fresh active stack and are not swept in this cycle.
+        let fresh = oldgen.alloc(size);
+        let fresh_payload = fresh as usize + GcHeader::SIZE;
+        unsafe { *fresh.cast::<GcHeader>() = GcHeader::new(0) };
+        assert_eq!(oldgen.active_rawmalloc_count(), 1);
+
+        let bytes_before = oldgen.total_bytes();
+        assert_eq!(oldgen.sweep_rawmalloc_step(1), 0);
+        assert_eq!(oldgen.rawmalloc_sweep_candidate_count(), 2);
+        assert_eq!(oldgen.total_bytes(), bytes_before - round_up(size));
+
+        while oldgen.rawmalloc_sweep_pending() {
+            oldgen.sweep_rawmalloc_step(1);
+        }
+        assert_eq!(oldgen.active_rawmalloc_count(), 1);
+        assert_eq!(oldgen.total_bytes(), round_up(size));
+        assert!(oldgen.contains(fresh_payload));
+        assert!(oldgen.sweep_arenas_step(1));
     }
 }

--- a/majit/majit-gc/src/rewrite.rs
+++ b/majit/majit-gc/src/rewrite.rs
@@ -2520,6 +2520,22 @@ impl GcRewriterImpl {
                     &[st.last_malloced_ref.clone(), prev_size_ref],
                 );
                 let r = st.emit_result(incr_op, result_pos);
+                // rewrite.py:914-918 initializes every batched object's
+                // Signed-sized HDR.tid word.  pyre splits that word into a
+                // 32-bit type id and 32-bit flags, so gen_initialize_tid's
+                // narrow store cannot clear poison/stale flags.  The first
+                // object is cleared by CallMallocNursery's backend fast path;
+                // clear the flags half of each interior header here.  This
+                // must stay specific to NurseryPtrIncrement: the first result
+                // can come from an old-gen slow path whose TRACK_YOUNG_PTRS
+                // flag gen_initialize_tid intentionally preserves.
+                let flags_ofs = st.const_int(-(std::mem::size_of::<u32>() as i64));
+                let zero = st.const_int(0);
+                let word32 = st.const_int(std::mem::size_of::<u32>() as i64);
+                st.emit(mk_op(
+                    OpCode::GcStore,
+                    &[r.clone(), flags_ofs, zero, word32],
+                ));
                 st.previous_size = size;
                 st.last_malloced_ref = r.clone();
                 st.remember_wb(&r);
@@ -3797,12 +3813,14 @@ mod tests {
             round_up(24 + header) as i64
         );
 
-        // Both should have tid initialisation.
+        // Both have tid initialisation; the interior allocation also clears
+        // the flags half of its header because NurseryPtrIncrement bypasses
+        // the backend's CallMallocNursery header clear.
         let tid_stores: Vec<_> = result
             .iter()
             .filter(|o| o.opcode == OpCode::GcStore)
             .collect();
-        assert_eq!(tid_stores.len(), 2);
+        assert_eq!(tid_stores.len(), 3);
         assert_eq!(
             tid_stores[0]
                 .arg(2)
@@ -3812,13 +3830,29 @@ mod tests {
             1
         ); // first type_id
         assert_eq!(
-            tid_stores[1]
+            tid_stores[2]
                 .arg(2)
                 .to_opref()
                 .inline_const_bits()
                 .expect("inline ConstInt"),
             2
         ); // second type_id
+        assert_eq!(
+            tid_stores[1]
+                .arg(1)
+                .to_opref()
+                .inline_const_bits()
+                .expect("inline ConstInt"),
+            -(std::mem::size_of::<u32>() as i64)
+        );
+        assert_eq!(
+            tid_stores[1]
+                .arg(2)
+                .to_opref()
+                .inline_const_bits()
+                .expect("inline ConstInt"),
+            0
+        );
     }
 
     // ── Test 7: A collecting operation between two NEWs prevents batching ──

--- a/pyre/pyre-jit-trace/src/descr.rs
+++ b/pyre/pyre-jit-trace/src/descr.rs
@@ -703,11 +703,25 @@ fn build_object_descr_group_with_def_path(
             .collect();
         // descr.py:123-126 precompute both lists; `gc_fielddescrs` is
         // `all_fielddescrs(only_gc=True)` per heaptracker.py:94-95.
-        let gc_fielddescrs: Vec<Arc<dyn FieldDescr>> = all_fielddescrs
+        let mut gc_fielddescrs: Vec<Arc<dyn FieldDescr>> = all_fielddescrs
             .iter()
             .filter(|fd| fd.is_pointer_field())
             .cloned()
             .collect();
+        // descr.py:121-126 + heaptracker.py:94-95: gc_fielddescrs walks
+        // the complete GC struct, including inherited fields.  Every
+        // runtime object group built here embeds PyObject, whose `w_class`
+        // is a GC reference even when the leaf field list only names the
+        // concrete payload (for example W_IntObject.intval).  Keep the
+        // leaf-only all_fielddescrs indexing used by OptVirtualize, but add
+        // the inherited header edge to the allocation-clear census unless
+        // a group already declared that offset explicitly.
+        if !gc_fielddescrs
+            .iter()
+            .any(|fd| fd.offset() == pyre_object::pyobject::W_CLASS_OFFSET)
+        {
+            gc_fielddescrs.push(new_w_class_field_descr());
+        }
         // `descr.py:108-118 get_size_descr` cache key — `path_hash`로
         // 만들어진 lltype-object identity.  Prefer the canonical
         // *def-path* qualifier (PyPy's `lltype.Struct` identity has
@@ -1700,7 +1714,12 @@ use pyre_object::functional::{
     RANGE_ITER_CURRENT_OFFSET, RANGE_ITER_REMAINING_OFFSET, RANGE_ITER_STEP_OFFSET,
 };
 use pyre_object::interp_exceptions::{
-    EXC_ARGS_W_OFFSET, EXC_KIND_COUNT, EXC_KIND_OFFSET, EXC_W_CONTEXT_OFFSET, ExcKind,
+    EXC_ARGS_W_OFFSET, EXC_KIND_COUNT, EXC_KIND_OFFSET, EXC_W_ATTR_OBJ_OFFSET, EXC_W_CAUSE_OFFSET,
+    EXC_W_CODE_OFFSET, EXC_W_CONTEXT_OFFSET, EXC_W_DICT_OFFSET, EXC_W_ENCODING_OFFSET,
+    EXC_W_END_OFFSET, EXC_W_ERRNO_OFFSET, EXC_W_FILENAME_OFFSET, EXC_W_FILENAME2_OFFSET,
+    EXC_W_IMPORT_MSG_OFFSET, EXC_W_IMPORT_NAME_FROM_OFFSET, EXC_W_IMPORT_PATH_OFFSET,
+    EXC_W_NAME_OFFSET, EXC_W_OBJECT_OFFSET, EXC_W_REASON_OFFSET, EXC_W_START_OFFSET,
+    EXC_W_STRERROR_OFFSET, EXC_W_TRACEBACK_OFFSET, ExcKind, W_BASE_EXCEPTION_GC_PTR_OFFSETS,
     W_BASE_EXCEPTION_SIZE, exc_kind_to_pytype,
 };
 use pyre_object::intobject::W_IntObject;
@@ -1723,7 +1742,7 @@ use pyre_object::{FLOAT_TYPE, INT_TYPE};
 /// field read on the common PyObject header.
 ///
 /// Mutable because __class__ assignment can change it.
-pub fn w_class_descr() -> DescrRef {
+fn new_w_class_field_descr() -> Arc<dyn FieldDescr> {
     // Named "w_class" so `FieldDescr::is_w_class()` recognises the
     // header field; OptVirtualize must resolve it from the object's
     // class identity rather than indexing it against a virtual's value
@@ -1741,6 +1760,10 @@ pub fn w_class_descr() -> DescrRef {
         parent_descr: None,
         ei_index: AtomicU32::new(u32::MAX),
     })
+}
+
+pub fn w_class_descr() -> DescrRef {
+    new_w_class_field_descr()
 }
 
 /// Alias for backward compatibility — same as w_class_descr().
@@ -2211,6 +2234,174 @@ fn build_w_exception_group(kind: ExcKind) -> PyreObjectDescrGroup {
                 false,
                 false,
             ),
+            // The runtime flattens the subclass-specific exception fields
+            // onto W_BaseException and its TypeInfo traces every one of them.
+            // Keep them in gc_fielddescrs so rewrite.py:498-504 emits the
+            // delayed NULL stores required by malloc_zero_filled=false.  They
+            // follow the four optimizer-visible fields above so the stable
+            // kind/w_class/args_w/w_context indices do not change.
+            (
+                "W_BaseException.w_cause",
+                EXC_W_CAUSE_OFFSET,
+                8,
+                Type::Ref,
+                false,
+                false,
+                false,
+            ),
+            (
+                "W_BaseException.w_traceback",
+                EXC_W_TRACEBACK_OFFSET,
+                8,
+                Type::Ref,
+                false,
+                false,
+                false,
+            ),
+            (
+                "W_BaseException.w_object",
+                EXC_W_OBJECT_OFFSET,
+                8,
+                Type::Ref,
+                false,
+                false,
+                false,
+            ),
+            (
+                "W_BaseException.w_start",
+                EXC_W_START_OFFSET,
+                8,
+                Type::Ref,
+                false,
+                false,
+                false,
+            ),
+            (
+                "W_BaseException.w_end",
+                EXC_W_END_OFFSET,
+                8,
+                Type::Ref,
+                false,
+                false,
+                false,
+            ),
+            (
+                "W_BaseException.w_reason",
+                EXC_W_REASON_OFFSET,
+                8,
+                Type::Ref,
+                false,
+                false,
+                false,
+            ),
+            (
+                "W_BaseException.w_encoding",
+                EXC_W_ENCODING_OFFSET,
+                8,
+                Type::Ref,
+                false,
+                false,
+                false,
+            ),
+            (
+                "W_BaseException.w_errno",
+                EXC_W_ERRNO_OFFSET,
+                8,
+                Type::Ref,
+                false,
+                false,
+                false,
+            ),
+            (
+                "W_BaseException.w_strerror",
+                EXC_W_STRERROR_OFFSET,
+                8,
+                Type::Ref,
+                false,
+                false,
+                false,
+            ),
+            (
+                "W_BaseException.w_filename",
+                EXC_W_FILENAME_OFFSET,
+                8,
+                Type::Ref,
+                false,
+                false,
+                false,
+            ),
+            (
+                "W_BaseException.w_filename2",
+                EXC_W_FILENAME2_OFFSET,
+                8,
+                Type::Ref,
+                false,
+                false,
+                false,
+            ),
+            (
+                "W_BaseException.w_code",
+                EXC_W_CODE_OFFSET,
+                8,
+                Type::Ref,
+                false,
+                false,
+                false,
+            ),
+            (
+                "W_BaseException.w_exc_name",
+                EXC_W_NAME_OFFSET,
+                8,
+                Type::Ref,
+                false,
+                false,
+                false,
+            ),
+            (
+                "W_BaseException.w_attr_obj",
+                EXC_W_ATTR_OBJ_OFFSET,
+                8,
+                Type::Ref,
+                false,
+                false,
+                false,
+            ),
+            (
+                "W_BaseException.w_import_path",
+                EXC_W_IMPORT_PATH_OFFSET,
+                8,
+                Type::Ref,
+                false,
+                false,
+                false,
+            ),
+            (
+                "W_BaseException.w_import_name_from",
+                EXC_W_IMPORT_NAME_FROM_OFFSET,
+                8,
+                Type::Ref,
+                false,
+                false,
+                false,
+            ),
+            (
+                "W_BaseException.w_import_msg",
+                EXC_W_IMPORT_MSG_OFFSET,
+                8,
+                Type::Ref,
+                false,
+                false,
+                false,
+            ),
+            (
+                "W_BaseException.w_dict",
+                EXC_W_DICT_OFFSET,
+                8,
+                Type::Ref,
+                false,
+                false,
+                false,
+            ),
         ],
         // Empty name: the per-kind vtable means a shared "W_BaseException"
         // name-registry slot would be first-write-wins and lose the other
@@ -2414,6 +2605,33 @@ pub fn pyframe_f_backref_descr() -> DescrRef {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn pyobject_size_descrs_include_inherited_w_class_gc_field() {
+        let descr = w_int_size_descr();
+        let size = descr.as_size_descr().expect("W_IntObject SizeDescr");
+        assert!(
+            size.gc_fielddescrs()
+                .iter()
+                .any(|fd| fd.offset() == W_CLASS_OFFSET),
+            "malloc_zero_filled=False requires the inherited PyObject.w_class edge"
+        );
+    }
+
+    #[test]
+    fn exception_size_descr_clears_every_runtime_traced_gc_field() {
+        let (descr, _, _, _) = w_exception_descrs(ExcKind::ValueError);
+        let size = descr.as_size_descr().expect("W_BaseException SizeDescr");
+        let mut actual: Vec<usize> = size.gc_fielddescrs().iter().map(|fd| fd.offset()).collect();
+        actual.sort_unstable();
+        actual.dedup();
+
+        let mut expected = W_BASE_EXCEPTION_GC_PTR_OFFSETS.to_vec();
+        expected.push(W_CLASS_OFFSET);
+        expected.sort_unstable();
+        expected.dedup();
+        assert_eq!(actual, expected);
+    }
 
     #[test]
     fn test_field_descr_indices_are_stable_and_distinct() {

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -761,11 +761,21 @@ unsafe fn pyframe_object_custom_trace(obj_addr: usize, f: &mut dyn FnMut(*mut ma
     // RPython's phase-agnostic precedent is jitframe.py:104 `jitframe_trace`.
     let array = frame.locals_cells_stack_w;
     if !array.is_null() {
-        let walk_items = if pyre_object::gc_hook::try_gc_owns_object(array as *mut u8) {
+        let managed = pyre_object::gc_hook::try_gc_owns_object(array as *mut u8);
+        if managed {
             f(
                 &mut frame.locals_cells_stack_w as *mut *mut pyre_object::FixedObjectArray
                     as *mut majit_ir::GcRef,
             );
+        }
+        // The visitor forwards a promoted nursery array in place, so
+        // `frame.locals_cells_stack_w` now holds the old-gen copy. Re-read it:
+        // the local `array` read above still points at the pre-copy location,
+        // whose header is a forwarding marker (arraylen there is the
+        // forwarding address). `walk_items` and the item walk must use the
+        // live destination.
+        let array = frame.locals_cells_stack_w;
+        let walk_items = if managed {
             !majit_gc::gc_is_nursery_object(array as usize)
         } else {
             true


### PR DESCRIPTION
Removes the three GC constant-factor NEW-DEVIATIONs identified by the fib GC RCA and converges the collector on incminimark's allocation and sweep contracts. The series also carries a wasm-only CI fix and the incremental STATE_SWEEPING port that the PR's own codex parity review requested.

## Commits

1. **`8c222d83903` — stream custom_trace slots inline** (F4): `trace_and_update_object` no longer allocates a fresh `Vec` per traced jitframe/pyframe object; slots stream to the visitor inline, matching incminimark's inline trace.
2. **`2763fee11eb` — stop zero-filling the nursery on reset** (F1): `Nursery::reset` becomes a pure bump reset (`malloc_zero_filled=False` + `arena_reset(..., 0)` parity, incminimark.py:211,1938). Every allocation path now initializes explicitly:
   - both backends report `malloc_zero_filled=false`, so the GC rewriter emits delayed null stores for `gc_fielddescrs` (rewrite.py:498-528);
   - ZERO_ARRAY now reaches codegen on x86-64/AArch64 (it previously fell through to a catch-all no-op, so NEW_ARRAY_CLEAR never cleared); small constant sizes emit inline zero stores per the upstream limits (x86 regalloc.py:1436-1503, aarch64 opassembler.py:755-839), larger sizes call memset under `before_call` preservation;
   - `gc_fielddescrs` now include inherited `PyObject.w_class` and all traced `W_BaseException` reference fields (descr.py:121-126, heaptracker.py:94-95);
   - cranelift nulls `jf_gcmap` on varsize JitFrame allocation (jitframe.py:105-116) and materializes typed resume virtuals with zero-filled non-moving allocations, matching dynasm;
   - `MAJIT_GC_NURSERY_POISON=1` fills 0xAA and the poison-mode collector panics when any traced slot reads `0xAA..AA` (llarena debug-fill spirit) — this detector surfaced every fix above.
3. **`6282ec894b8` — minimarkpage ArenaCollection port** (F2/F3): old-gen survivors allocate from a line-by-line `rpython/memory/gc/minimarkpage.py` port (size-class pages, ordered free lists, `mass_free` sweep) instead of one system malloc per object; the per-survivor `payloads: HashSet` is deleted. Oversized/card objects stay individually rawmalloced (`old_rawmalloced_objects` shape) with an exact membership set mirroring `young_rawmalloced_objects` (incminimark.py:1219-1221). Also fixes a latent shadow bug: a non-moving major could sweep a live nursery object's unoccupied shadow as white.
4. **`fede99ece0f` — keep zero-filling the nursery on reset for wasm32** (CI fix): the wasm backend does not run the GC rewrite pass (majit-backend-wasm/src/codegen.rs) and emits inline nursery-bump allocations without clear-fields stores, so the F1 flip broke it wasm-only (26 ubuntu CI failures, `GC BUG: invalid type_id` at `copy_nursery_object`). The zero-fill reset is retained under `#[cfg(target_arch = "wasm32")]` with the convergence path documented; wasm check.py returns to all-pass.
5. **`2d07487d465` — sweep the old generation incrementally across major steps** (STATE_SWEEPING port, requested by this PR's codex parity review §3): `GcState { Scanning, Marking, Sweeping }` replaces the boolean marking flag (incminimark.py:2390-2634). Exhausting the gray stack freezes this cycle's sweep candidates (`mass_free_prepare` + `raw_malloc_might_sweep` swap, incminimark.py:2512-2514, :2688-2694) and each subsequent major step frees at most `3*nursery_size/small_request_threshold` rawmalloc candidates or `3*nursery_size/page_size` arena pages (incminimark.py:2537-2555). Promotions between sweep steps allocate into fresh lists and are excluded from the active cycle. The completed-major counter and next-major threshold move to sweep completion (post-sweep accounting, incminimark.py:2566-2577); STW entry points loop steps to completion (`gc_step_until` parity).
6. **`3bc0f321568` — null the wasm entry frame's `jf_gcmap` before releasing it** (fix exposed by commit 5): the orthodox `PYRE_WASM_CA` `execute_token` frame is an old-gen GC-managed `JitFrame` whose `jf_gcmap` points at a per-loop gcmap Box held only for `glue::execute`. After reading outputs it dropped that Box but left `jf_gcmap` dangling. Once major sweeping became incremental the major cycle spans later `execute_token` calls, so the still-`VISITED` (grayed) frame is custom-traced in a later collection and reads the freed gcmap, asserting `bogus frame field get: index >= frame_lgt` in `jitframe_trace`. Nulling `jf_gcmap` before the drop makes the trace forward nothing (jitframe.py:115-116), correct because the frame is already released; wasm check.py returns to 162/162.

## Validation

- `check.py` 163/163 on dynasm and cranelift, in default and poison modes (each slice, both backends), re-verified after rebasing onto the current base.
- wasm backend: 162/162, re-verified after the incremental-sweep dangling-gcmap fix (commit 6); the F1 flip's 26 failures and the sweep's 7 `bogus frame field get` failures are both resolved, with JIT confirmed active.
- cargo test matrix (majit-gc, pyre-jit-trace, pyre-jit) in default and poison modes; `gc_stress` integration run serialized (its parallel failure is the known process-global GC singleton test race, reproduced on clean HEAD).
- fib(40) minor/major collection cadence unchanged by the sweep split (54,954/14; fib35 baseline 4,954/1 for the first three slices).
- fib_profile (fib(40)) interleaved A/B, 6 pairs per slice, wins every pair: F1 −7.1% user time, F2/F3 −3.9% on top, incremental sweep −1.0% on top.

Remaining deferred follow-up from the parity review: the bounded-heap OOM policy (`PYPY_GC_MAX` `raise MemoryError`, incminimark.py:2603-2615) — blocked on a MemoryError propagation channel from the GC entry points.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
