### PR TITLE
jit: remove dead loop-trace operand-stack seed from run_perfn_walk

### DIFF
--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -1646,6 +1646,11 @@ fn run_perfn_walk(
                 reserved_red_colors.push(ec_color);
             }
         }
+        // Loop-trace entry seeds no operand-stack colors.  The codewriter's
+        // `Instruction::ForIter` handler emits `getarrayitem_vable_r` to reload
+        // the iterator from the virtualizable on every iteration, so the
+        // residual consumes that in-loop read rather than an entry register.
+        //
         // #124: a bridge enters mid-body, where the loop-header merge-point
         // colors seeded above (the loop's green pycode / red frame+ec) are
         // reused for live operand-stack temps — the kept conditional-
@@ -1697,67 +1702,6 @@ fn run_perfn_walk(
                             continue;
                         }
                         seed(color, opref);
-                    }
-                }
-            }
-        } else {
-            // Loop trace: seed operand-stack loop-input registers from
-            // sym.registers_r.  RPython's MIFrame registers are populated
-            // by executing every opcode (including jit_merge_point, which
-            // binds the reds); pyre's walker enters PAST the merge point,
-            // so loop-carried operand-stack variables (e.g. the FOR_ITER
-            // iterator on TOS) are left OpRef::NONE without this seed.
-            // The vable shadow (virtualizable_boxes) holds the correct
-            // InputArgRef for each slot, but vable_getarrayitem_ref routes
-            // through is_nonstandard_virtualizable when the reader OpRef's
-            // concrete is the usize::MAX sentinel (= NONE), so the
-            // standard fast path is never reached.  Seed the operand-stack
-            // colors (nlocals .. nlocals+stack_depth) from sym.registers_r
-            // — the same InputArgRef values init_symbolic placed there.
-            // Clamp to the jitcode's num_regs_r so the argboxes vector
-            // never exceeds the callee register bank size.
-            //
-            // Also stamp each seeded InputArgRef with its concrete pointer
-            // from the live frame's `locals_cells_stack_w` so downstream
-            // `box_value`/`concrete_of_opref` consumers (e.g. residual-call
-            // arg resolution in `try_execute_residual_call_via_executor`)
-            // can resolve loop-input operand-stack values.  Without this,
-            // a `ForIterNext(iterator)` residual declines execution because
-            // the iterator arg's `box_value` returns `None`, leaving the
-            // `ptr_nonzero` result unstemped → `GotoIfNotValueNotConcrete`.
-            let nl = sym.nlocals;
-            let num_regs_r = pjc.jitcode.num_regs_r() as usize;
-            let stack_depth = sym.registers_r.len().saturating_sub(nl);
-            // Read the live frame's locals_cells_stack_w for concrete ptrs.
-            let frame_ref = unsafe { &*(cf_addr as *const pyre_interpreter::pyframe::PyFrame) };
-            let frame_slots: &[pyre_object::PyObjectRef] = unsafe {
-                if !frame_ref.locals_cells_stack_w.is_null() {
-                    (*frame_ref.locals_cells_stack_w).as_slice()
-                } else {
-                    &[]
-                }
-            };
-            for i in 0..stack_depth {
-                let color = nl + i;
-                if color >= num_regs_r {
-                    break;
-                }
-                let opref = sym.registers_r[nl + i];
-                if !opref.is_none() {
-                    if reserved_red_colors.contains(&(color as u8)) {
-                        continue;
-                    }
-                    seed(color as u8, opref);
-                    // Stamp the concrete pointer from the live frame slot.
-                    let frame_idx = nl + i;
-                    if frame_idx < frame_slots.len() {
-                        let ptr = frame_slots[frame_idx];
-                        if !ptr.is_null() {
-                            mi.ctx().set_opref_concrete(
-                                opref,
-                                majit_ir::Value::Ref(majit_ir::GcRef(ptr as usize)),
-                            );
-                        }
                     }
                 }
             }


### PR DESCRIPTION
Design cleanup following the gh#152 per-iteration FOR_ITER reload (#436): the walk-side loop-trace operand-stack seed no longer has a consumer.

## Change

`run_perfn_walk`'s argboxes seeding had a non-bridge arm that copied `sym.registers_r` operand-stack colors (`nlocals..nlocals+depth`) into the walk register file and stamped their concrete pointers from the live frame's `locals_cells_stack_w`. Its stated justification — "without this, a `ForIterNext(iterator)` residual declines execution" — predates #436: since the codewriter's `Instruction::ForIter` handler reloads the iterator through `getarrayitem_vable_r` on every iteration (the `peekvalue()` port, pyopcode.py:1303-1304 / jtransform.py:760-767), the residual consumes that in-loop read instead of an entry register. The `nlocals+depth` slot→color shortcut in this seed is also the mechanism class that produced the original color mis-seed the reload eliminated.

Both bridge seed arms (`bridge_registers_r` color seeding, `bridge_stack_oprefs` slot seeding) are unchanged — they serve bridge-resume paths, not loop entry.

## Evidence (A/B, arm neutralized vs baseline)

Over `kept_stack_deep_var_{condexpr,nested_call,shortcircuit,shortcircuit_mutate}`, `foriter_call_body`, `foriter_loadglobal_body`, `while_is_none`, `int_loop`, `nested_loop`, `fib_loop`: identical stdout, identical `PYRE_FBW_DEBUG_ABORT` census (zero new aborts/declines), identical `MAJIT_STATS` compile stats (`loops_compiled`/`bridges_compiled`/`loops_aborted`/`guard_failures`).

## Verification

- `python3 pyre/check.py`: dynasm 163/163, cranelift 163/163, wasm 162/162 (re-run after rebase onto #512)
- JIT vs `PYRE_NO_JIT` bit-exact on the 7 synth benches above at the rebased HEAD
- `cargo test -p pyre-jit-trace`: 284 passed / 0 failed; `cargo test -p pyre-jit`: 314 passed / 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)