### PR TITLE
gc: route dynasm and wasm finalizer trampolines through the gc_sync fallback

### DIFF
--- a/majit/majit-backend-dynasm/src/runner.rs
+++ b/majit/majit-backend-dynasm/src/runner.rs
@@ -485,22 +485,11 @@ fn dynasm_collect_oldgen_nonmoving() {
 }
 
 fn dynasm_register_finalizer(fq_index: usize, obj: GcRef, trigger: majit_gc::FinalizerTriggerFn) {
-    DYNASM_ACTIVE_GC.with(|cell| {
-        let mut guard = cell.borrow_mut();
-        if let Some(gc) = guard.as_deref_mut() {
-            gc.register_finalizer(fq_index, obj, trigger);
-        }
-    });
+    with_dynasm_active_gc_mut(|gc| gc.register_finalizer(fq_index, obj, trigger));
 }
 
 fn dynasm_finalizer_next_dead(fq_index: usize) -> Option<GcRef> {
-    DYNASM_ACTIVE_GC.with(|cell| {
-        let mut guard = cell.borrow_mut();
-        match guard.as_deref_mut() {
-            Some(gc) => gc.finalizer_next_dead(fq_index),
-            None => None,
-        }
-    })
+    with_dynasm_active_gc_mut(|gc| gc.finalizer_next_dead(fq_index)).flatten()
 }
 
 /// Report `(oldgen_total, nursery_used)` for the interpreter GC safepoint.

--- a/majit/majit-backend-wasm/src/lib.rs
+++ b/majit/majit-backend-wasm/src/lib.rs
@@ -389,18 +389,11 @@ fn wasm_collect_oldgen_nonmoving() {
 }
 
 fn wasm_register_finalizer(fq_index: usize, obj: GcRef, trigger: majit_gc::FinalizerTriggerFn) {
-    WASM_ACTIVE_GC.with(|cell| {
-        if let Some(gc) = cell.borrow_mut().as_deref_mut() {
-            gc.register_finalizer(fq_index, obj, trigger);
-        }
-    });
+    with_wasm_active_gc_mut(|gc| gc.register_finalizer(fq_index, obj, trigger));
 }
 
 fn wasm_finalizer_next_dead(fq_index: usize) -> Option<GcRef> {
-    WASM_ACTIVE_GC.with(|cell| match cell.borrow_mut().as_deref_mut() {
-        Some(gc) => gc.finalizer_next_dead(fq_index),
-        None => None,
-    })
+    with_wasm_active_gc_mut(|gc| gc.finalizer_next_dead(fq_index)).flatten()
 }
 
 /// `majit_gc::CheckIsObjectFn` installed by `set_gc_allocator`.


### PR DESCRIPTION
## Problem

Follow-up to #447 (merged). Two codex P2 review comments landed on that PR after the final push and were not included in the merge:

- `majit/majit-backend-dynasm/src/runner.rs` — `dynasm_register_finalizer` / `dynasm_finalizer_next_dead` read the `DYNASM_ACTIVE_GC` TLS box directly.
- `majit/majit-backend-wasm/src/lib.rs` — `wasm_register_finalizer` / `wasm_finalizer_next_dead`, same pattern.

After #447's box demotion, production installs no backend TLS GC box, so these trampolines silently dropped `register_finalizer` and always returned `None` from `next_dead`: objects relying on the RPython FinalizerQueue (`__del__`) were never registered or drained on dynasm and wasm production builds. Cranelift was already correct — its trampolines route through `with_cranelift_gc`, which falls back to the `gc_sync` singleton.

## Fix

Route the four trampolines through the existing three-way helpers (`with_dynasm_active_gc_mut` / `with_wasm_active_gc_mut`: test box → box; no box + `gc_sync` initialized → `gc_op`; no GC → no-op/None), the same shape as the other demoted trampolines.

## Verification

- `cargo fmt --all -- --check` clean
- `cargo check -p majit-backend-dynasm` and `cargo check -p majit-backend-wasm --target wasm32-unknown-unknown` clean
- `pyre/check.py --backend wasm --synthetic-only --synthetic-pattern calls_closures.py` PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)
