### PR TITLE
interp: reject instantiation of abstract classes in object.__new__

### DIFF
--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -7284,8 +7284,20 @@ pub fn object_setattr(obj: PyObjectRef, name: &str, value: PyObjectRef) -> PyRes
             }
             let dict_ptr = w_type_get_dict_ptr(obj) as *mut crate::DictStorage;
             if !dict_ptr.is_null() {
+                // typeobject.py:1258-1261 descr_set___abstractmethods__ —
+                // evaluate truthiness BEFORE mutating the dict so a raising
+                // `__bool__` leaves the type unchanged (CPython
+                // type_set_abstractmethods).
+                let abstract_flag = if name == "__abstractmethods__" {
+                    Some(is_true(value)?)
+                } else {
+                    None
+                };
                 crate::dict_storage_store(&mut *dict_ptr, name, value);
                 pyre_object::gc_hook::try_gc_write_barrier(obj as *mut u8);
+                if let Some(a) = abstract_flag {
+                    pyre_object::w_type_set_abstract(obj, a);
+                }
                 // typeobject.py:430 — `self.mutated(name)` after the
                 // dict_w write so cached `compares_by_identity_status`
                 // (and future per-type caches) reset on this type and
@@ -7837,6 +7849,10 @@ pub fn object_delattr(obj: PyObjectRef, name: &str) -> PyResult {
             let dict_ptr = w_type_get_dict_ptr(obj) as *mut crate::DictStorage;
             if !dict_ptr.is_null() {
                 if crate::dict_storage_delete(&mut *dict_ptr, name) {
+                    // typeobject.py:1263-1267 descr_del___abstractmethods__.
+                    if name == "__abstractmethods__" {
+                        pyre_object::w_type_set_abstract(obj, false);
+                    }
                     // typeobject.py:445 — `self.mutated(key)` mirrors the
                     // setattr branch's invalidation across the subclass
                     // tree.

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -9500,6 +9500,36 @@ fn init_bool_type(ns: &mut DictStorage) {
 /// `object.__new__(cls)` — allocate a bare instance of cls.
 ///
 /// PyPy: objectobject.py descr__new__
+/// objectobject.py:17-21 _abstract_method_error (CPython 3.12+ message form).
+fn abstract_instantiation_error(cls: PyObjectRef) -> crate::PyError {
+    let type_name = unsafe { pyre_object::w_type_get_name(cls) };
+    let mut methods: Vec<String> = Vec::new();
+    if let Ok(w_abstracts) = crate::baseobjspace::getattr_str(cls, "__abstractmethods__") {
+        // The setter marks any truthy value abstract without enforcing a set,
+        // so guard the unchecked casts: only iterate a genuine set of strings.
+        if unsafe { pyre_object::is_set_or_frozenset(w_abstracts) } {
+            for item in unsafe { pyre_object::w_set_items(w_abstracts) } {
+                if unsafe { pyre_object::is_str(item) } {
+                    if let Ok(s) = unsafe { pyre_object::w_str_get_wtf8(item) }.as_str() {
+                        methods.push(s.to_string());
+                    }
+                }
+            }
+        }
+    }
+    methods.sort();
+    let plural = if methods.len() == 1 { "" } else { "s" };
+    let joined = methods
+        .iter()
+        .map(|m| format!("'{m}'"))
+        .collect::<Vec<_>>()
+        .join(", ");
+    crate::PyError::type_error(format!(
+        "Can't instantiate abstract class {type_name} without an implementation \
+         for abstract method{plural} {joined}"
+    ))
+}
+
 fn object_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     assert!(
         !args.is_empty(),
@@ -9508,6 +9538,10 @@ fn object_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError>
     let cls = crate::baseobjspace::unwrap_cell(args[0]);
     // cls should be a W_TypeObject — create instance of it
     if unsafe { is_type(cls) } {
+        // objectobject.py:131 descr__new__ — abstract classes refuse instantiation.
+        if unsafe { pyre_object::w_type_is_abstract(cls) } {
+            return Err(abstract_instantiation_error(cls));
+        }
         return Ok(w_instance_new(cls));
     }
     // Fallback: create bare instance with no type

--- a/pyre/pyre-object/src/typeobject.rs
+++ b/pyre/pyre-object/src/typeobject.rs
@@ -201,6 +201,9 @@ pub struct W_TypeObject {
     /// once after construction via `w_type_set_disallow_instantiation`;
     /// never inherited by heap subclasses (the default is `false`).
     pub flag_disallow_instantiation: std::sync::atomic::AtomicBool,
+    /// typeobject.py:166/216 `flag_abstract?` — set from the
+    /// `__abstractmethods__` setattr hook; gates `object.__new__`.
+    pub flag_abstract: std::sync::atomic::AtomicBool,
 }
 
 /// Source of fresh `version_tag` identities (`VersionTag()`, typeobject.py:73).
@@ -305,6 +308,7 @@ pub fn w_type_new(name: &str, bases: PyObjectRef, dict_ptr: *mut u8) -> PyObject
         // Heap subclasses are always instantiable (their `tp_new` is the
         // slot wrapper); only builtin disallow-types flip this.
         flag_disallow_instantiation: std::sync::atomic::AtomicBool::new(false),
+        flag_abstract: std::sync::atomic::AtomicBool::new(false),
     };
     let raw = crate::gc_hook::try_gc_alloc_stable_raw(W_TYPE_GC_TYPE_ID, W_TYPE_OBJECT_SIZE);
     let (w_type, gc_managed) = if !raw.is_null() {
@@ -412,6 +416,7 @@ pub fn w_type_new_builtin(
         // generator / coroutine / frame typedefs flip it via
         // `w_type_set_disallow_instantiation`.
         flag_disallow_instantiation: std::sync::atomic::AtomicBool::new(false),
+        flag_abstract: std::sync::atomic::AtomicBool::new(false),
     }) as PyObjectRef;
     // A builtin type is Box-immortal, so its namespace values, `bases`, and
     // the lazily-cached `type.__dict__` `mirror_target` are reachable only
@@ -515,6 +520,31 @@ pub unsafe fn w_type_set_disallow_instantiation(w_type: PyObjectRef) {
     let t = &*(w_type as *const W_TypeObject);
     t.flag_disallow_instantiation
         .store(true, std::sync::atomic::Ordering::Release);
+}
+
+/// `W_TypeObject.is_abstract` (typeobject.py:597-598).
+///
+/// # Safety
+/// `w_type` must point at a `W_TypeObject`.
+pub unsafe fn w_type_is_abstract(w_type: PyObjectRef) -> bool {
+    if w_type.is_null() || !is_type(w_type) {
+        return false;
+    }
+    let t = &*(w_type as *const W_TypeObject);
+    t.flag_abstract.load(std::sync::atomic::Ordering::Acquire)
+}
+
+/// `W_TypeObject.set_abstract` (typeobject.py:600-601).
+///
+/// # Safety
+/// `w_type` must point at a `W_TypeObject`.
+pub unsafe fn w_type_set_abstract(w_type: PyObjectRef, abstract_: bool) {
+    if w_type.is_null() || !is_type(w_type) {
+        return;
+    }
+    let t = &*(w_type as *const W_TypeObject);
+    t.flag_abstract
+        .store(abstract_, std::sync::atomic::Ordering::Release);
 }
 
 // ── Layout accessors ─────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Pyre had no abstract-type mechanism at all: assigning a non-empty `__abstractmethods__` never marked the type abstract, and `object.__new__` never checked it. So `C()` on an ABC with unimplemented abstract methods silently produced an instance instead of raising `TypeError` — and even a plain class with a manually-set `__abstractmethods__` instantiated freely.

This ports PyPy's `flag_abstract` faithfully:

- **`pyre-object` `W_TypeObject`** gains a `flag_abstract: AtomicBool` with `w_type_is_abstract` / `w_type_set_abstract` accessors (`typeobject.py` `is_abstract` / `set_abstract`), initialized `false` in both constructors.
- **`pyre-interpreter` setattr/delattr** mirror `descr_set/del___abstractmethods__`: assigning `__abstractmethods__` sets the flag to the value's truthiness (empty `frozenset` → concrete, non-empty → abstract); deleting it clears the flag.
- **`object.__new__` (`object_descr_new`)** raises `TypeError` for an abstract class, using the CPython 3.12+ message form: `Can't instantiate abstract class C without an implementation for abstract method 'foo'`.

## Test results

- `test_abc`: failures **33 → 24** (the pure-Python `_py_abc` path is now fully fixed; no new failures).
- `test_enum`: **154 before and after** (no regression; verified against a `git stash` baseline rebuild).
- Verified inheritance semantics (abstract base / still-abstract subclass rejected, concrete subclass instantiable), `del __abstractmethods__` clearing the flag, and that normal / builtin-subclass instantiation is unaffected.

## Out of scope (tracked separately)

The remaining `test_abc` failures are two independent defects:
1. The C `_abc` path — `_abc_init` does not compute `__abstractmethods__` (missing `compute_abstract_methods`).
2. `classmethod` / `staticmethod` subclass type collapse — `abstractclassmethod` / `abstractstaticmethod` lose their `__isabstractmethod__`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Abstract classes can no longer be instantiated.
  * Abstract status now updates correctly when `__abstractmethods__` is set or deleted.
  * Instantiation now raises a clearer error naming the abstract class and listing the missing method implementations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->