### PR TITLE
interp: raise TypeError from object.__new__() with no arguments

### DIFF
--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -9501,10 +9501,12 @@ fn init_bool_type(ns: &mut DictStorage) {
 ///
 /// PyPy: objectobject.py descr__new__
 fn object_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    assert!(
-        !args.is_empty(),
-        "object.__new__() requires a type argument"
-    );
+    // objectobject.py:118 descr__new__ — `w_type` is a mandatory argument.
+    if args.is_empty() {
+        return Err(crate::PyError::type_error(
+            "object.__new__(): not enough arguments",
+        ));
+    }
     let cls = crate::baseobjspace::unwrap_cell(args[0]);
     // cls should be a W_TypeObject — create instance of it
     if unsafe { is_type(cls) } {


### PR DESCRIPTION
## Summary

`object.__new__` (`object_descr_new`) asserted `!args.is_empty()`, so a zero-argument call — `object.__new__()`, as in test_descr's `assertRaises(TypeError, object.__new__)` — aborted the **whole interpreter with a Rust panic** instead of raising a catchable exception.

PyPy's `objectobject.py:118 descr__new__(space, w_type, __args__)` makes `w_type` a mandatory argument, so its interp2app unwrap raises `TypeError` when it is missing. pyre receives the raw arg slice, so this guards the empty case explicitly and returns CPython's `tp_new_wrapper` message: `object.__new__(): not enough arguments`.

## Test results

- `object.__new__()` (no args) → **`TypeError`** (was a process-killing panic).
- `test_descr::test_bad_new` (`@expectedFailure`) → now reports its expected failure cleanly instead of crashing.
- `object.__new__(A)` and normal instantiation are unaffected.
- The pre-existing `test_isinstance` Bus error reproduces identically on `main` without this change (verified against a `git stash` baseline rebuild) — not a regression.

## Out of scope

The excess-argument path (`object.__new__(A, 5)` in `test_object_new`) is a separate PyPy `_excess_args` gap and is **not** addressed here; it is tracked as follow-up work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for `object.__new__()` when called without the required type argument.
  * Returns a clear `TypeError` instead of triggering an internal assertion failure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->