### PR TITLE
#205 A5: GC-manage heap types via stable old-gen alloc; retire the HEAP_TYPE_REGISTRY heap-type band-aid

### DIFF
--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -7285,6 +7285,7 @@ pub fn object_setattr(obj: PyObjectRef, name: &str, value: PyObjectRef) -> PyRes
             let dict_ptr = w_type_get_dict_ptr(obj) as *mut crate::DictStorage;
             if !dict_ptr.is_null() {
                 crate::dict_storage_store(&mut *dict_ptr, name, value);
+                pyre_object::gc_hook::try_gc_write_barrier(obj as *mut u8);
                 // typeobject.py:430 — `self.mutated(name)` after the
                 // dict_w write so cached `compares_by_identity_status`
                 // (and future per-type caches) reset on this type and

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -4168,6 +4168,7 @@ pub(crate) unsafe fn object_setattr_surrogate(
             let dict_ptr = w_type_get_dict_ptr(obj) as *mut crate::DictStorage;
             if !dict_ptr.is_null() {
                 crate::dict_storage_store_wtf8(&mut *dict_ptr, name, value);
+                pyre_object::gc_hook::try_gc_write_barrier(obj as *mut u8);
                 mutated(obj, name.as_str().ok());
                 return Ok(w_none());
             }
@@ -6208,8 +6209,9 @@ unsafe fn _cached_lookup_where(
 ///
 /// Every cached value is an MRO type's namespace-dict resident (or a
 /// Box-immortal builtin descriptor), so it is already kept *reachable* by
-/// `walk_type_dicts_gc` — this walk is therefore not load-bearing for
-/// reclamation in the current model, and old-gen residents are not
+/// `walk_builtin_type_dicts_gc` or the heap type's custom trace — this walk is
+/// therefore not load-bearing for reclamation in the current model, and
+/// old-gen residents are not
 /// relocated by a collection, so it forwards no slot in practice today.
 /// It becomes load-bearing once those values become movable (the
 /// movable-object GC phases): `version_tag` is bumped only by `mutated()`,

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -319,15 +319,14 @@ unsafe fn walk_raw_getset_roots(value: PyObjectRef, visitor: &mut dyn FnMut(&mut
     }
 }
 
-/// Forward every `PyObjectRef` value bound in a heap type's namespace
+/// Forward every `PyObjectRef` value bound in a type's namespace
 /// `DictStorage` in place — the class attributes, methods, and the
 /// per-type `__dict__`/`__weakref__` getset descriptor copies.  Keys are
 /// Rust `String`s (not GC objects); only the `PyObjectRef` values relocate.
 /// Snapshot the value slots first (same shape as the globals proxy walk)
-/// so `forward` cannot re-borrow the storage.  Shared by `walk_type_dicts_gc`
-/// (the Box-immortal-type band-aid root walk) and the `W_TYPE_GC_TYPE_ID`
-/// custom trace, so a GC-managed heap type reaches its own namespace values
-/// directly once its trace fires.
+/// so `forward` cannot re-borrow the storage.  Shared by
+/// `walk_builtin_type_dicts_gc` for Box-immortal builtin types and the
+/// `W_TYPE_GC_TYPE_ID` custom trace for GC-managed heap types.
 pub unsafe fn type_walk_namespace_values(
     w_type: PyObjectRef,
     forward: &mut dyn FnMut(&mut PyObjectRef),
@@ -367,22 +366,15 @@ pub unsafe fn type_walk_namespace_values(
     }
 }
 
-/// Box-immortal heap types (`w_type_new`) never have their
-/// `W_TYPE_GC_TYPE_ID` custom trace fired, so the movable values bound in
-/// each type's namespace `DictStorage` (methods, class attributes, the
-/// per-type `__dict__`/`__weakref__` getset copies), the `bases` tuple, and
-/// the `weak_subclasses` WEAKREF list are unreachable by the collector.
-/// Walk every registered heap type's namespace values + `bases` +
-/// `weak_subclasses` as pinned roots so a relocated class attribute /
-/// method / descriptor — or a reclaimed subclass weakref — is not read back
-/// stale after a collection; the same shape `walk_module_dicts_gc` uses for
-/// module dicts.  PRE-EXISTING-ADAPTATION: PyPy GC-manages type objects and
-/// traces `dict_w`/`bases`/`weak_subclasses` for free; convergence is to
-/// GC-manage `W_TypeObject` (then its custom trace fires and this walk is
-/// deleted), mirroring the deferred instance Path-B keystone.
-unsafe fn walk_type_dicts_gc(forward: &mut dyn FnMut(&mut PyObjectRef)) {
+/// Box-immortal builtin types never have their `W_TYPE_GC_TYPE_ID` custom
+/// trace fired, but their namespaces, `bases`, and `weak_subclasses` can hold
+/// young GC objects after startup.  Walk every registered builtin type (and
+/// the rare pre-GC heap-type fallback) as pinned roots so those children stay
+/// live and their slots are forwarded.  Heap types are GC-managed and reach
+/// the same fields through their own `W_TYPE_GC_TYPE_ID` custom trace.
+unsafe fn walk_builtin_type_dicts_gc(forward: &mut dyn FnMut(&mut PyObjectRef)) {
     unsafe {
-        for addr in pyre_object::typeobject::snapshot_heap_types() {
+        for addr in pyre_object::typeobject::snapshot_builtin_type_roots() {
             let w_type = addr as PyObjectRef;
             if w_type.is_null() {
                 continue;
@@ -398,8 +390,7 @@ unsafe fn walk_type_dicts_gc(forward: &mut dyn FnMut(&mut PyObjectRef)) {
                 forward(bases_slot);
                 // Namespace `dict_w` values: the class attributes, methods,
                 // and getset descriptor copies — the same walk the
-                // `W_TYPE_GC_TYPE_ID` custom trace performs once a heap type
-                // is GC-managed.
+                // `W_TYPE_GC_TYPE_ID` custom trace performs for a heap type.
                 type_walk_namespace_values(w_type, forward);
                 // `weak_subclasses` holds `w_weakref_new` (`try_gc_alloc`)
                 // young WEAKREF GcStructs whose only strong root is this
@@ -409,8 +400,8 @@ unsafe fn walk_type_dicts_gc(forward: &mut dyn FnMut(&mut PyObjectRef)) {
                 // the first collection reclaims the weakref and the base's
                 // `weak_subclasses[i]` dangles — a UAF on the next
                 // `mutated()` / `w_type_get_subclasses` deref.  The
-                // `W_TYPE_GC_TYPE_ID` custom trace performs the same walk once
-                // a heap type is GC-managed.
+                // `W_TYPE_GC_TYPE_ID` custom trace performs the same walk for
+                // a heap type.
                 let t = &mut *(w_type as *mut pyre_object::typeobject::W_TypeObject);
                 if t.weak_subclasses.is_null() {
                     // No subclasses recorded.
@@ -806,7 +797,7 @@ fn walk_global_prebuilt_roots(visitor: &mut dyn FnMut(&mut majit_ir::GcRef)) {
             walk_raw_function_roots(*slot, visitor);
             walk_raw_getset_roots(*slot, visitor);
         };
-        walk_type_dicts_gc(&mut forward);
+        walk_builtin_type_dicts_gc(&mut forward);
     }
     if is_minor {
         pyre_object::gc_roots::clear_prebuilt_roots_dirty();

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -326,11 +326,9 @@ unsafe fn pyre_object_compares_by_identity_trampoline(w_type: pyre_object::PyObj
 ///     attributes, getset descriptor copies) via the interpreter helper,
 ///     mirroring `object_object_custom_trace`'s off-GC storage walk.
 ///
-/// Inert while heap types remain `malloc_typed` Box-immortal (the
-/// collector never fires this trace for an immortal object, and the
-/// visitor's `is_in_nursery` / `is_managed_heap_object` guard skips
-/// non-managed children); it replaces the `walk_type_dicts_gc` band-aid
-/// root walk once `w_type_new` is GC-managed.
+/// Heap types are stable old-gen GC objects, so this trace keeps their owned
+/// GC edges live and forwards their slots.  The separate builtin-type walk
+/// covers Box-immortal builtin types, whose custom trace never fires.
 unsafe fn type_object_custom_trace(obj_addr: usize, f: &mut dyn FnMut(*mut majit_ir::GcRef)) {
     let t = unsafe { &mut *(obj_addr as *mut pyre_object::typeobject::W_TypeObject) };
     f(&mut t.ob_header.w_class as *mut pyre_object::PyObjectRef as *mut majit_ir::GcRef);

--- a/pyre/pyre-jit/tests/gc_stress.rs
+++ b/pyre/pyre-jit/tests/gc_stress.rs
@@ -395,11 +395,10 @@ assert result == 3430, result
 /// class attribute (a movable list), and the per-type `__dict__` getset
 /// descriptor (whose `fget` is a collectable function) all survive repeated
 /// full collections, even when first reached *fresh* after the collections.
-/// Heap type objects (`w_type_new`) are Box-immortal, so the collector never
-/// fires their `W_TYPE_GC_TYPE_ID` custom trace and never reaches the movable
-/// values bound in the type's namespace `DictStorage`. Before the
-/// `HEAP_TYPE_REGISTRY` / `walk_type_dicts_gc` / `walk_raw_getset_roots` root
-/// walk, this program SIGSEGV'd.
+/// Heap type objects (`w_type_new`) are GC-managed, so their
+/// `W_TYPE_GC_TYPE_ID` custom trace reaches the movable values bound in the
+/// type's namespace `DictStorage`. The `BUILTIN_TYPE_NAMESPACE_ROOTS` /
+/// `walk_builtin_type_dicts_gc` walk covers immortal builtin types instead.
 ///
 /// `C`'s namespace dict holds a method (`method`), a class attribute
 /// (`KLASS_ATTR`), and — once `c.__dict__` is first read — the copied
@@ -445,7 +444,7 @@ assert result == 33, result
 /// base's `weak_subclasses` survives repeated full collections so the base's
 /// `mutated()` walk still reaches it. `w_type_add_subclass` stores
 /// `w_weakref_new(subclass)` — a `try_gc_alloc` young WEAKREF GcStruct — in the
-/// base's off-GC `weak_subclasses`. Before this fix `walk_type_dicts_gc`
+/// base's off-GC `weak_subclasses`. Before this fix the type root walk
 /// forwarded `bases` and namespace values but NOT `weak_subclasses`, so the
 /// first collection reclaimed the WEAKREF and `type.__setattr__`'s `mutated()`
 /// walk ran over the freed slot (a UAF that dropped cache invalidation).

--- a/pyre/pyre-object/src/objectobject.rs
+++ b/pyre/pyre-object/src/objectobject.rs
@@ -72,10 +72,10 @@ pub fn w_instance_new(w_type: PyObjectRef) -> PyObjectRef {
     // `gct_fv_gc_malloc` bracket pattern (`framework.py:853-856`) for
     // the allocation below. `w_type` is a `W_TypeObject`
     // (`pyre-object::typeobject` GC type id 33) — user-defined types
-    // are allocated through `malloc_typed`, so the typeptr is a live
-    // GC reference across the instance allocation. The `is_in_nursery`
-    // filter in the walker (`majit-gc/src/collector.rs:764`) keeps the
-    // built-in static `PyType` case (e.g. `INT_TYPE`) untouched.
+    // are stable old-gen GC objects, so the pinned typeptr remains a live,
+    // non-moving GC reference across the instance allocation. The
+    // `is_in_nursery` filter in the walker (`majit-gc/src/collector.rs:764`)
+    // keeps the built-in static `PyType` case (e.g. `INT_TYPE`) untouched.
     let _roots = crate::gc_roots::push_roots();
     crate::gc_roots::pin_root(w_type);
 

--- a/pyre/pyre-object/src/typeobject.rs
+++ b/pyre/pyre-object/src/typeobject.rs
@@ -232,40 +232,31 @@ pub fn leak_layout(layout: Layout) -> *const Layout {
 }
 
 thread_local! {
-    /// Heap type objects (`w_type_new` — user `class` statements and
-    /// `type(name, bases, dict)`) are `malloc_typed` Box-immortal, so the
-    /// collector never fires their `W_TYPE_GC_TYPE_ID` custom trace and
-    /// therefore never reaches the movable values bound in a type's
-    /// namespace dict (methods, class attributes, the per-type
-    /// `__dict__`/`__weakref__` getset copies) nor the `bases` tuple.
-    /// This registry lets the interpreter root every heap type's namespace
-    /// as a pinned root source on each collection — the same shape
-    /// `walk_module_dicts_gc` uses for Box-immortal module dicts.
-    ///
     /// Builtin types (`w_type_new_builtin`) are created before the GC is
-    /// built and only ever hold Box-immortal values, so they are not
-    /// registered.  Append-only interim: heap types are themselves immortal,
-    /// so a recorded address stays valid for the process lifetime (unlike a
-    /// GC-managed object, an immortal type is never freed, so no stale-address
-    /// pruning is needed).  Convergence path: GC-manage `W_TypeObject` so its
-    /// custom trace fires and this walk is deleted.
-    static HEAP_TYPE_REGISTRY: std::cell::RefCell<Vec<usize>> =
+    /// built and remain `malloc_typed` Box-immortal, so the collector never
+    /// fires their `W_TYPE_GC_TYPE_ID` custom trace.  Their namespaces can
+    /// still acquire young GC children after boot, including the cached
+    /// `type.__dict__` `mirror_target` and subclass weakrefs.  This registry
+    /// roots those children on each collection.  It also covers the rare
+    /// pre-GC immortal fallback from `w_type_new` when no GC hook is installed.
+    /// Heap types allocated after GC startup are GC-managed instead and are
+    /// rooted through their own `W_TYPE_GC_TYPE_ID` custom trace.
+    static BUILTIN_TYPE_NAMESPACE_ROOTS: std::cell::RefCell<Vec<usize>> =
         std::cell::RefCell::new(Vec::new());
 }
 
-/// Record a heap type for the collection-time namespace root walk.
-fn register_heap_type(addr: usize) {
-    // A fresh heap type carries young namespace values / bases; record the
-    // prebuilt-family store so the next minor collection scans it
+/// Record an immortal type for the collection-time namespace root walk.
+fn register_builtin_type_roots(addr: usize) {
+    // Record the prebuilt-family store so the next minor collection scans it
     // (gc_roots.rs prebuilt-root write tracking).
     crate::gc_roots::mark_prebuilt_roots_dirty();
-    HEAP_TYPE_REGISTRY.with(|reg| reg.borrow_mut().push(addr));
+    BUILTIN_TYPE_NAMESPACE_ROOTS.with(|reg| reg.borrow_mut().push(addr));
 }
 
-/// Snapshot the registered heap-type addresses for the root walker
-/// (`pyre_interpreter::eval::walk_type_dicts_gc`).
-pub fn snapshot_heap_types() -> Vec<usize> {
-    HEAP_TYPE_REGISTRY.with(|reg| reg.borrow().clone())
+/// Snapshot the registered immortal-type addresses for the root walker
+/// (`pyre_interpreter::eval::walk_builtin_type_dicts_gc`).
+pub fn snapshot_builtin_type_roots() -> Vec<usize> {
+    BUILTIN_TYPE_NAMESPACE_ROOTS.with(|reg| reg.borrow().clone())
 }
 
 /// Allocate a new W_TypeObject with `flag_heaptype = true`.
@@ -279,7 +270,7 @@ pub fn w_type_new(name: &str, bases: PyObjectRef, dict_ptr: *mut u8) -> PyObject
     let _roots = crate::gc_roots::push_roots();
     crate::gc_roots::pin_root(bases);
 
-    let w_type = crate::lltype::malloc_typed(W_TypeObject {
+    let value = W_TypeObject {
         ob_header: PyObject {
             ob_type: &TYPE_TYPE as *const PyType,
             w_class: std::ptr::null_mut(),
@@ -314,8 +305,25 @@ pub fn w_type_new(name: &str, bases: PyObjectRef, dict_ptr: *mut u8) -> PyObject
         // Heap subclasses are always instantiable (their `tp_new` is the
         // slot wrapper); only builtin disallow-types flip this.
         flag_disallow_instantiation: std::sync::atomic::AtomicBool::new(false),
-    }) as PyObjectRef;
-    register_heap_type(w_type as usize);
+    };
+    let raw = crate::gc_hook::try_gc_alloc_stable_raw(W_TYPE_GC_TYPE_ID, W_TYPE_OBJECT_SIZE);
+    let (w_type, gc_managed) = if !raw.is_null() {
+        unsafe { std::ptr::write(raw as *mut W_TypeObject, value) };
+        (raw as PyObjectRef, true)
+    } else {
+        // No GC hook yet (pre-init / snapshot tools): fall back to an immortal box.
+        (crate::lltype::malloc_typed(value) as PyObjectRef, false)
+    };
+    if gc_managed {
+        // Fresh old-gen type stores young `bases`/namespace into an old object;
+        // remember it so the next minor collection scans it and its custom trace
+        // (`W_TYPE_GC_TYPE_ID`) forwards those young children.
+        crate::gc_hook::try_gc_write_barrier(w_type as *mut u8);
+    } else {
+        // Immortal fallback type (pre-GC): its trace never fires, so root its
+        // namespace the same way builtin types are rooted.
+        register_builtin_type_roots(w_type as usize);
+    }
     w_type
 }
 
@@ -405,13 +413,13 @@ pub fn w_type_new_builtin(
         // `w_type_set_disallow_instantiation`.
         flag_disallow_instantiation: std::sync::atomic::AtomicBool::new(false),
     }) as PyObjectRef;
-    // A builtin type is Box-immortal just like a heap type, so its namespace
-    // values, `bases`, and the lazily-cached `type.__dict__` `mirror_target`
-    // are reachable only through `walk_type_dicts_gc` (`pyre_interpreter
-    // ::eval`).  Register it so that walk forwards them; without this a
+    // A builtin type is Box-immortal, so its namespace values, `bases`, and
+    // the lazily-cached `type.__dict__` `mirror_target` are reachable only
+    // through `walk_builtin_type_dicts_gc` (`pyre_interpreter::eval`).
+    // Register it so that walk forwards them; without this a
     // collection reclaims the cached `__dict__` wrapper and the next
     // `cls.__dict__` access reads a dangling pointer.
-    register_heap_type(w_type as usize);
+    register_builtin_type_roots(w_type as usize);
     w_type
 }
 
@@ -696,10 +704,9 @@ pub unsafe fn w_type_get_bases(obj: PyObjectRef) -> PyObjectRef {
 /// responsible for validating layout compatibility and recomputing the MRO.
 pub unsafe fn w_type_set_bases(obj: PyObjectRef, bases: PyObjectRef) {
     crate::gc_roots::pin_root(bases);
-    // Prebuilt-family store: `bases` lives on the Box-immortal type and is
-    // reached only by the `walk_type_dicts_gc` root walk.
     crate::gc_roots::mark_prebuilt_roots_dirty();
     (*(obj as *mut W_TypeObject)).bases = bases;
+    crate::gc_hook::try_gc_write_barrier(obj as *mut u8);
 }
 
 /// Get the class namespace pointer (as *mut u8).
@@ -777,6 +784,7 @@ unsafe fn find_best_base(w_type: PyObjectRef) -> PyObjectRef {
 pub unsafe fn w_type_set_mro(obj: PyObjectRef, mro: Vec<PyObjectRef>) {
     let purely_of_types = is_mro_purely_of_types(&mro);
     (*(obj as *mut W_TypeObject)).mro_w = crate::lltype::malloc_raw(mro);
+    crate::gc_hook::try_gc_write_barrier(obj as *mut u8);
     if !purely_of_types {
         w_type_set_version_tag(obj, 0);
     }
@@ -896,9 +904,8 @@ pub unsafe fn w_type_set_acceptable_as_base_class(obj: PyObjectRef, v: bool) {
 /// `w_weakref_new` so subclass GC isn't blocked (`:642-650`); each
 /// entry is a `try_gc_alloc` WEAKREF GcStruct, so the off-GC
 /// `weak_subclasses` list is the WEAKREF's only strong root and must
-/// be walked by the collector (`walk_type_dicts_gc` while heap types
-/// stay Box-immortal, the `W_TYPE_GC_TYPE_ID` custom trace once they
-/// are GC-managed).
+/// be walked by the collector (`walk_builtin_type_dicts_gc` for builtin
+/// types, the `W_TYPE_GC_TYPE_ID` custom trace for heap types).
 ///
 /// # Safety
 /// `w_parent` must point at a valid `W_TypeObject`.  `w_subclass`
@@ -912,8 +919,8 @@ pub unsafe fn w_type_add_subclass(w_parent: PyObjectRef, w_subclass: PyObjectRef
         return;
     }
     let parent = &mut *(w_parent as *mut W_TypeObject);
-    // Prebuilt-family store: the weak_subclasses list is reached only by the
-    // `walk_type_dicts_gc` root walk.
+    // Builtin parents need the prebuilt root walk; this is harmless for a
+    // GC-managed heap parent.
     crate::gc_roots::mark_prebuilt_roots_dirty();
     if parent.weak_subclasses.is_null() {
         parent.weak_subclasses = Box::into_raw(Box::new(Vec::new()));
@@ -931,10 +938,12 @@ pub unsafe fn w_type_add_subclass(w_parent: PyObjectRef, w_subclass: PyObjectRef
         }
         if existing.is_null() {
             subs[i] = newref;
+            crate::gc_hook::try_gc_write_barrier(w_parent as *mut u8);
             return;
         }
     }
     subs.push(newref);
+    crate::gc_hook::try_gc_write_barrier(w_parent as *mut u8);
 }
 
 /// `typeobject.py:664-670 W_TypeObject.remove_subclass`.


### PR DESCRIPTION
## Summary

#205 item **A5**: GC-manage heap types so a collectable class is rooted by its own custom trace, retiring the `HEAP_TYPE_REGISTRY` heap-type band-aid.

- `w_type_new` allocates heap types via `try_gc_alloc_stable_raw(W_TYPE_GC_TYPE_ID)` into the **non-moving old generation** (mirroring the A4 instance recipe), falling back to `malloc_typed` only when no GC hook is installed. The already-written `type_object_custom_trace` now fires, forwarding `w_class`/`bases`/`mro_w`/`weak_subclasses`/namespace values; the instance trace already forwards `ob_header.w_class`, so a live instance keeps its type alive (no `ob_type` UAF).
- **Write barriers** on the old→young stores a GC-managed heap type takes after creation: the fresh type in `w_type_new`, both `type.__setattr__` class-dict stores (surrogate + non-surrogate), `w_type_set_bases`, `w_type_set_mro`, and the `weak_subclasses` push in `w_type_add_subclass` (which keeps `mark_prebuilt_roots_dirty` for immortal builtin parents).
- `HEAP_TYPE_REGISTRY` / `walk_type_dicts_gc` are renamed to `BUILTIN_TYPE_NAMESPACE_ROOTS` / `walk_builtin_type_dicts_gc`: heap types are rooted by their own trace, so only **builtin (immortal)** types — whose trace never fires but whose namespaces still acquire young children after boot (the cached `type.__dict__` `mirror_target`, subclass weakrefs) — and the rare pre-GC fallback type stay registered for the walk. This matches the issue's "only built-in roots remain".

## Soundness note

A fresh heap type is unrooted on the Rust stack across `create_all_slots` / `compute_default_mro` / `w_type_set_mro` / `w_type_ready` before it is bound. That is safe **by safepoint placement** — those host allocations are non-collecting and the interp collecting safepoint runs only at the outermost dispatch-loop activation — **not by allocator construction**, so a collecting operation must not be introduced into that window without a `pin_root` bracket.

## Follow-up

Reclaiming the type's Rust-owned sidecars (`name`/`dict`/`mro_w`/`weak_subclasses`) on collection is deferred to #528 — freeing the `DictStorage` is blocked on the `cls.__dict__` mappingproxy aliasing that #205 **A1** resolves.

## Verification

- `gc_stress` 30× repeat: **30/30**
- `check.py` dynasm/cranelift/wasm: **164 / 164 / 163**
- Codex parity review: no PyPy-parity regressions; the one introduced mismatch (sidecar leak) → #528; one pre-existing missing write barrier that this change promotes from latent to live → fixed here (the non-surrogate `type.__setattr__` store).

Part of #205 (item A5).

— *opened by Claude*
