### PR TITLE
majit: aheui compile-path perf (get_gcmap, ShortBoxes O(n²), FxHash) + native_tag_small tag lowering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1530,6 +1530,7 @@ dependencies = [
  "majit-ir",
  "majit-trace",
  "majit-translate",
+ "rustc-hash",
 ]
 
 [[package]]
@@ -1600,6 +1601,7 @@ dependencies = [
  "majit-macros",
  "majit-trace",
  "majit-translate",
+ "rustc-hash",
  "smallvec",
  "vecset",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -148,6 +148,7 @@ stacker = "0.1"
 
 # string / hash
 siphasher = "1.0"
+rustc-hash = "2.1.3"
 md-5 = "0.10"
 sha1 = "0.10"
 sha2 = "0.10"

--- a/majit/majit-backend-dynasm/Cargo.toml
+++ b/majit/majit-backend-dynasm/Cargo.toml
@@ -15,6 +15,7 @@ dynasm = { workspace = true }
 dynasmrt = { workspace = true }
 libc = { workspace = true }
 indexmap = { workspace = true }
+rustc-hash = { workspace = true }
 
 [dev-dependencies]
 majit-ir = { workspace = true, features = ["test-support"] }

--- a/majit/majit-backend-dynasm/src/regalloc.rs
+++ b/majit/majit-backend-dynasm/src/regalloc.rs
@@ -2339,15 +2339,24 @@ impl<'a> RegAlloc<'a> {
                 gcmap_set_bit(gcmap, val);
             }
         }
-        for (v, lifetime) in self.longevity.lifetimes_iter() {
-            if self.opref_type(*v) != Some(Type::Ref)
-                || !self.rm.is_still_alive(*v, &self.longevity)
-            {
+        // regalloc.py:36 BindingsIterItems; regalloc.py:178 bindings_iteritems.
+        let mut index = 0;
+        while index < self.fm.current_frame_depth {
+            let Some(v) = self.fm.boxes_in_frame[index] else {
+                index += 1;
                 continue;
-            }
-            if let Some(loc) = lifetime.current_frame_loc {
+            };
+            let loc = self
+                .longevity
+                .get(v)
+                .and_then(|lifetime| lifetime.current_frame_loc)
+                .expect("gcmap frame binding without current_frame_loc");
+            debug_assert_eq!(FrameManager::get_loc_index(&loc), index);
+            let size = FrameManager::frame_size(self.tp(v));
+            if self.opref_type(v) == Some(Type::Ref) && self.rm.is_still_alive(v, &self.longevity) {
                 gcmap_set_bit(gcmap, loc.position + JITFRAME_FIXED_SIZE);
             }
+            index += size;
         }
         gcmap
     }

--- a/majit/majit-backend-dynasm/src/regalloc.rs
+++ b/majit/majit-backend-dynasm/src/regalloc.rs
@@ -14,6 +14,7 @@
 ///   get_scale              — regalloc.py:1239
 use indexmap::IndexMap;
 use majit_ir::IndexMapExt;
+use rustc_hash::FxBuildHasher;
 
 use crate::arch::*;
 use crate::gcmap::{allocate_gcmap, gcmap_set_bit};
@@ -261,7 +262,7 @@ pub struct LifetimeManager {
     // ~all its backend time in `IndexMap::get_index_of` here). regalloc.py:1054
     // keys longevity by a dict (O(1)); `IndexMap` restores that O(1) lookup
     // while keeping the insertion-ordered iteration `IndexMap` provided.
-    lifetimes: indexmap::IndexMap<OpRef, Lifetime>,
+    lifetimes: indexmap::IndexMap<OpRef, Lifetime, FxBuildHasher>,
     /// regalloc.py:1064 maps register → FixedRegisterPositions
     pub fixed_register_use: IndexMap<RegLoc, FixedRegisterPositions>,
 }
@@ -269,7 +270,7 @@ pub struct LifetimeManager {
 impl LifetimeManager {
     pub fn new() -> Self {
         LifetimeManager {
-            lifetimes: indexmap::IndexMap::new(),
+            lifetimes: indexmap::IndexMap::default(),
             fixed_register_use: IndexMap::new(),
         }
     }

--- a/majit/majit-macros/src/jit_interp/codegen_trace.rs
+++ b/majit/majit-macros/src/jit_interp/codegen_trace.rs
@@ -38,6 +38,7 @@ pub fn generate_trace_fn(config: &JitInterpConfig, func: &ItemFn) -> TokenStream
         &config.ref_fields,
         &config.call_returns,
         &config.native_int_binops,
+        &config.native_tag_small,
         config.split_dispatch,
         config.switch_dispatch,
     );

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/lower_value.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/lower_value.rs
@@ -159,6 +159,9 @@ impl<'c> Lowerer<'c> {
                 if let Some(binding) = self.lower_native_int_binop_call(call) {
                     return Some(binding);
                 }
+                if let Some(binding) = self.lower_native_tag_small_call(call) {
+                    return Some(binding);
+                }
                 // Raw native-memory load intrinsic `majit_raw_load_i64(base, ea)`
                 // → raw_load_i (jtransform.py:1165-1171 rewrite_op_raw_load).
                 if let Some(binding) = self.lower_raw_load_call(call) {
@@ -1591,6 +1594,64 @@ impl<'c> Lowerer<'c> {
             reg,
             kind: BindingKind::Int,
             depends_on_stack: lhs.depends_on_stack || rhs.depends_on_stack,
+            struct_type: None,
+        })
+    }
+
+    /// Recognize a unary function call registered in `native_tag_small` and
+    /// emit native `(x << 1) | 1` IR (IntLshift then IntOr) instead of a CallI.
+    /// The concrete/naive path calls the original fn normally.
+    fn lower_native_tag_small_call(&mut self, call: &ExprCall) -> Option<Binding> {
+        let config = self.config?;
+        let func_segments = canonical_expr_segments(&call.func)?;
+        if !config
+            .native_tag_small
+            .iter()
+            .any(|path| *path == func_segments)
+        {
+            return None;
+        }
+        if call.args.len() != 1 {
+            return None;
+        }
+
+        let inner = self.lower_value_expr(&call.args[0])?;
+        if !matches!(inner.kind, BindingKind::Int) {
+            return None;
+        }
+
+        let x_reg = inner.reg;
+        let one_reg = self.alloc_reg();
+        self.emit_op(
+            OpMeta::linear(OpKind::LoadConstI, vec![], vec![Register::int(one_reg)]),
+            quote! { __builder.load_const_i_value(#one_reg, 1i64); },
+        );
+
+        let shl_reg = self.alloc_reg();
+        let lshift = syn::Ident::new("IntLshift", proc_macro2::Span::call_site());
+        self.emit_op(
+            OpMeta::linear(
+                OpKind::BinopI,
+                Register::ints(&[x_reg, one_reg]),
+                vec![Register::int(shl_reg)],
+            ),
+            binop_i_emit_tokens(shl_reg, &lshift, x_reg, one_reg),
+        );
+
+        let res_reg = self.alloc_reg();
+        let or = syn::Ident::new("IntOr", proc_macro2::Span::call_site());
+        self.emit_op(
+            OpMeta::linear(
+                OpKind::BinopI,
+                Register::ints(&[shl_reg, one_reg]),
+                vec![Register::int(res_reg)],
+            ),
+            binop_i_emit_tokens(res_reg, &or, shl_reg, one_reg),
+        );
+        Some(Binding {
+            reg: res_reg,
+            kind: BindingKind::Int,
+            depends_on_stack: inner.depends_on_stack,
             struct_type: None,
         })
     }

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/mod.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/mod.rs
@@ -202,6 +202,9 @@ pub struct LowererConfig {
     /// key, it emits the named IR opcode directly — bypassing the call-policy
     /// machinery.  jtransform.py:2030 `_handle_int_special()` parity.
     pub(super) native_int_binops: Vec<(Vec<String>, String)>,
+    /// Pure unary tag-small helpers.  Key = canonical func path segments.
+    /// `lower_native_tag_small_call` emits `(x << 1) | 1` directly.
+    pub(super) native_tag_small: Vec<Vec<String>>,
     /// Source: `JitInterpConfig.split_dispatch`.  When set, the dispatch lowerer
     /// routes pure forward-advancing green-pc arms through the per-arm
     /// sub-JitCode path with a pc-returning `inline_call_<types>_i` instead of
@@ -826,6 +829,7 @@ impl LowererConfig {
         ref_fields: &[crate::jit_interp::RefFieldEntry],
         call_returns: &[(Path, Path)],
         native_int_binops: &[(Path, Ident)],
+        native_tag_small: &[Path],
         split_dispatch: bool,
         switch_dispatch: bool,
     ) -> Self {
@@ -1023,6 +1027,10 @@ impl LowererConfig {
             native_int_binops: native_int_binops
                 .iter()
                 .map(|(path, op)| (canonical_path_segments(path), op.to_string()))
+                .collect(),
+            native_tag_small: native_tag_small
+                .iter()
+                .map(canonical_path_segments)
                 .collect(),
             split_dispatch,
             switch_dispatch,

--- a/majit/majit-macros/src/jit_interp/mod.rs
+++ b/majit/majit-macros/src/jit_interp/mod.rs
@@ -159,6 +159,8 @@ pub struct JitInterpConfig {
     /// (e.g. `val_add`) is still visible, so this config rewrites it to a
     /// native IR binop at codewriter time.
     pub native_int_binops: Vec<(Path, Ident)>,
+    /// native_tag_small = { jit_retag_small } — unary fns lowered to (x<<1)|1 native IR.
+    pub native_tag_small: Vec<Path>,
     /// Opt-in: route pure forward-advancing dispatch arms (those whose body
     /// only does work then `pc += N`, with no back-edge / `can_enter_jit!` /
     /// early return) through the per-arm sub-JitCode path with a pc-returning
@@ -545,6 +547,7 @@ impl Parse for JitInterpConfig {
         let mut call_returns: Vec<(Path, Path)> = Vec::new();
         let mut struct_allocs: Vec<(Path, Path)> = Vec::new();
         let mut native_int_binops: Vec<(Path, Ident)> = Vec::new();
+        let mut native_tag_small: Vec<Path> = Vec::new();
         let mut split_dispatch = false;
         let mut switch_dispatch = false;
 
@@ -611,6 +614,9 @@ impl Parse for JitInterpConfig {
                 "native_int_binops" => {
                     native_int_binops = parse_native_int_binops_map(input)?;
                 }
+                "native_tag_small" => {
+                    native_tag_small = parse_native_tag_small_list(input)?;
+                }
                 "split_dispatch" => {
                     split_dispatch = input.parse::<LitBool>()?.value;
                 }
@@ -666,6 +672,7 @@ impl Parse for JitInterpConfig {
             call_returns,
             struct_allocs,
             native_int_binops,
+            native_tag_small,
             split_dispatch,
             switch_dispatch,
         })
@@ -744,6 +751,18 @@ fn parse_native_int_binops_map(input: ParseStream) -> syn::Result<Vec<(Path, Ide
         content.parse::<Token![=>]>()?;
         let opcode: Ident = content.parse()?;
         entries.push((func_path, opcode));
+        let _ = content.parse::<Token![,]>();
+    }
+    Ok(entries)
+}
+
+fn parse_native_tag_small_list(input: ParseStream) -> syn::Result<Vec<Path>> {
+    let content;
+    braced!(content in input);
+    let mut entries = Vec::new();
+    while !content.is_empty() {
+        let func_path: Path = content.parse()?;
+        entries.push(func_path);
         let _ = content.parse::<Token![,]>();
     }
     Ok(entries)

--- a/majit/majit-metainterp/Cargo.toml
+++ b/majit/majit-metainterp/Cargo.toml
@@ -26,6 +26,7 @@ bit-set = { workspace = true }
 smallvec = { workspace = true }
 vecset = { workspace = true }
 indexmap = { workspace = true }
+rustc-hash = { workspace = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 # Native backends never build for wasm32; on wasm32 the backend is

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -40,11 +40,13 @@ use indexmap::{IndexMap, IndexSet};
 use info::{EnsuredPtrInfo, PtrInfo};
 use majit_ir::operand::Operand;
 use majit_ir::{DescrRef, GcRef, Op, OpCode, OpRef, Type, Value};
+use rustc_hash::{FxBuildHasher, FxHashMap};
 use std::collections::VecDeque;
 
 pub type SnapshotBoxes = Vec<Option<Vec<SnapshotBox>>>;
 pub type SnapshotFrameSizes = Vec<Option<Vec<usize>>>;
 pub type SnapshotFramePcs = Vec<Option<Vec<(i32, i32, i32)>>>;
+type OpRefFxIndexMap<V> = indexmap::IndexMap<OpRef, V, FxBuildHasher>;
 
 pub(crate) fn snapshot_get<T>(store: &[Option<T>], pos: i32) -> Option<&T> {
     if pos < 0 {
@@ -536,7 +538,7 @@ pub struct OptContext {
     /// so the last push at a position wins, matching the `rfind`
     /// last-occurrence semantics); rebuilt by `rebuild_new_operations_index`
     /// after the rare structural mutations, and cleared with the context.
-    pub(crate) new_operations_index: std::collections::HashMap<OpRef, majit_ir::OpRc>,
+    pub(crate) new_operations_index: FxHashMap<OpRef, majit_ir::OpRc>,
     /// optimizer.py:246 `self._emittedoperations = {}` — the result boxes
     /// of ops emitted by THIS optimizer run, keyed by box identity
     /// (`Rc::ptr_eq`) to mirror the upstream dict keyed by the `op` object.
@@ -793,7 +795,7 @@ pub struct OptContext {
     // earlier container guaranteed but resolves `get` in O(1).  Same O(1)
     // acceleration rationale as `input_ops_index`; no PyPy counterpart
     // (upstream keys producers on `box._forwarded`, not a positional map).
-    pub(crate) resop_refs: indexmap::IndexMap<OpRef, majit_ir::resoperation::OpRc>,
+    pub(crate) resop_refs: OpRefFxIndexMap<majit_ir::resoperation::OpRc>,
     /// Live synthetic stand-ins (mint_synthetic_resop / bind_input_resops
     /// products) that have NOT been superseded by an `emit` at their
     /// position. The end-of-Phase-1 orphan-binding pass drains this into
@@ -814,7 +816,7 @@ pub struct OptContext {
     /// `live_synthetics_swap_remove_pos`; without it the scan is O(n^2) over a
     /// vector that grows to the whole trace length (~44k on aheui's logo loop),
     /// the same producer-resolution cost `phase1_emit_ops_index` removes.
-    pub(crate) live_synthetics_index: std::collections::HashMap<OpRef, usize>,
+    pub(crate) live_synthetics_index: FxHashMap<OpRef, usize>,
     /// Phase 1 emit ops carried into Phase 2's lookup surface.
     ///
     /// In RPython, a Box referenced cross-phase keeps its `.type` attribute
@@ -836,7 +838,7 @@ pub struct OptContext {
     /// box of every Phase 2 guard, the dominant O(n^2) compile cost. Same
     /// derived-index rationale as `input_ops_index` (no PyPy counterpart:
     /// upstream keys producers on `box._forwarded`, not a positional map).
-    pub(crate) phase1_emit_ops_index: std::collections::HashMap<OpRef, majit_ir::OpRc>,
+    pub(crate) phase1_emit_ops_index: FxHashMap<OpRef, majit_ir::OpRc>,
     /// Recorder trace ops that carry the input operands' producer `Op`
     /// (e.g. the `IntLt`/`GetfieldGcPureI` operands of a recorded loop),
     /// shared by `Rc` with the canonical stores but absent from
@@ -867,7 +869,7 @@ pub struct OptContext {
     /// (last occurrence wins), enforced by rebuilding forward (a later
     /// `insert` at the same key overwrites the earlier) and covered by
     /// `input_ops_index_last_occurrence_wins`.
-    pub(crate) input_ops_index: std::collections::HashMap<OpRef, majit_ir::OpRc>,
+    pub(crate) input_ops_index: FxHashMap<OpRef, majit_ir::OpRc>,
     /// optimizer.py:644,679 _last_guard_op — index of the last guard in
     /// new_operations that had full resume data built. Consecutive guards
     /// share resume data via _copy_resume_data_from (ResumeGuardCopiedDescr).
@@ -1641,7 +1643,10 @@ impl OptContext {
     pub fn new(estimated_ops: usize) -> Self {
         OptContext {
             new_operations: Vec::with_capacity(estimated_ops),
-            new_operations_index: std::collections::HashMap::with_capacity(estimated_ops),
+            new_operations_index: FxHashMap::with_capacity_and_hasher(
+                estimated_ops,
+                Default::default(),
+            ),
             emitted_operations: indexmap::IndexSet::new(),
             num_inputs: 0,
             inputarg_base: 0,
@@ -1690,13 +1695,13 @@ impl OptContext {
 
             inputargs: Vec::new(),
             inputarg_refs: Vec::new(),
-            resop_refs: indexmap::IndexMap::new(),
+            resop_refs: indexmap::IndexMap::default(),
             live_synthetics: Vec::new(),
-            live_synthetics_index: std::collections::HashMap::new(),
+            live_synthetics_index: FxHashMap::default(),
             phase1_emit_ops: Vec::new(),
-            phase1_emit_ops_index: std::collections::HashMap::new(),
+            phase1_emit_ops_index: FxHashMap::default(),
             input_ops: Vec::new(),
-            input_ops_index: std::collections::HashMap::new(),
+            input_ops_index: FxHashMap::default(),
             last_guard_idx: None,
             last_seen_snapshot_pos: None,
             cpu: crate::cpu::default_cpu(),
@@ -2223,7 +2228,10 @@ impl OptContext {
     ) -> Self {
         OptContext {
             new_operations: Vec::with_capacity(estimated_ops),
-            new_operations_index: std::collections::HashMap::with_capacity(estimated_ops),
+            new_operations_index: FxHashMap::with_capacity_and_hasher(
+                estimated_ops,
+                Default::default(),
+            ),
             emitted_operations: indexmap::IndexSet::new(),
             num_inputs: num_inputs as u32,
             inputarg_base,
@@ -2272,13 +2280,13 @@ impl OptContext {
 
             inputargs: Vec::new(),
             inputarg_refs: Vec::new(),
-            resop_refs: indexmap::IndexMap::new(),
+            resop_refs: indexmap::IndexMap::default(),
             live_synthetics: Vec::new(),
-            live_synthetics_index: std::collections::HashMap::new(),
+            live_synthetics_index: FxHashMap::default(),
             phase1_emit_ops: Vec::new(),
-            phase1_emit_ops_index: std::collections::HashMap::new(),
+            phase1_emit_ops_index: FxHashMap::default(),
             input_ops: Vec::new(),
-            input_ops_index: std::collections::HashMap::new(),
+            input_ops_index: FxHashMap::default(),
             last_guard_idx: None,
             last_seen_snapshot_pos: None,
             cpu: crate::cpu::default_cpu(),

--- a/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
+++ b/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
@@ -457,6 +457,12 @@ pub struct ShortBoxes {
     /// per producer, so the same position yields the same object. Const
     /// results never key this map (they route to `const_short_boxes`).
     potential_ops: IndexMap<majit_ir::operand::Operand, PotentialShortOp>,
+    /// Mirrors `to_opref()` for every key ever inserted into `potential_ops`
+    /// (which is insert-only; same-key overwrites keep the same opref), so
+    /// membership equals the old linear scan `any(k.to_opref() == opref)`.
+    /// Parity anchor: shortpreamble.py:290 `op in self.potential_ops` is
+    /// dict membership.
+    potential_op_oprefs: IndexSet<OpRef>,
     /// shortpreamble.py:250 self.produced_short_boxes = {}
     /// (insertion order preserved by IndexMap for deterministic export.)
     /// Keyed by the result Box (`shortop.res`), compared by object
@@ -583,6 +589,7 @@ impl ShortBoxes {
     pub fn new(num_label_args: usize) -> Self {
         ShortBoxes {
             potential_ops: IndexMap::new(),
+            potential_op_oprefs: IndexSet::new(),
             produced_short_boxes: IndexMap::new(),
             const_short_boxes: Vec::new(),
             known_constants: IndexSet::new(),
@@ -621,10 +628,7 @@ impl ShortBoxes {
     pub fn is_reachable(&self, opref: OpRef) -> bool {
         self.label_args.iter().any(|&a| a == opref)
             || opref.is_constant()
-            || self
-                .potential_ops
-                .iter()
-                .any(|(k, _)| k.to_opref() == opref)
+            || self.potential_op_oprefs.contains(&opref)
     }
 
     pub fn note_known_constant(&mut self, opref: OpRef) {
@@ -636,6 +640,7 @@ impl ShortBoxes {
     }
 
     fn add_op(&mut self, key: majit_ir::operand::Operand, pop: PotentialShortOp) {
+        self.potential_op_oprefs.insert(key.to_opref());
         self.potential_ops.insert(key, pop);
     }
 
@@ -756,6 +761,7 @@ impl ShortBoxes {
         // shortpreamble.py:259 `self.potential_ops[box] = ShortInputArg(...)`
         // — keyed by the label-arg Box itself; `arg_res` is its canonical
         // (producer-bound) operand, shared with `res`.
+        self.potential_op_oprefs.insert(arg_res.to_opref());
         self.potential_ops.insert(
             arg_res.clone(),
             PotentialShortOp::Preamble(PreambleOp {
@@ -828,11 +834,7 @@ impl ShortBoxes {
         if self.known_constants.contains(&opref) {
             return Some(ctx.materialize_operand_at(opref));
         }
-        if self
-            .potential_ops
-            .iter()
-            .any(|(k, _)| k.to_opref() == opref)
-        {
+        if self.potential_op_oprefs.contains(&opref) {
             // shortpreamble.py:291-294 `r = self.add_op_to_short(...);
             // return r.preamble_op`. ShortInputArg: renamed short_inputargs
             // box, see the produced arm above.

--- a/majit/majit-metainterp/src/resume.rs
+++ b/majit/majit-metainterp/src/resume.rs
@@ -7,6 +7,7 @@
 //! This is the RPython equivalent of `rpython/jit/metainterp/resume.py`.
 
 use indexmap::{IndexMap, IndexSet};
+use rustc_hash::FxBuildHasher;
 use std::cell::UnsafeCell;
 use std::sync::Arc;
 
@@ -14,6 +15,8 @@ use majit_backend::{
     ExitFrameLayout, ExitPendingFieldLayout, ExitRecoveryLayout, ExitVirtualLayout,
 };
 use majit_ir::{Const, GcRef, OpRef, Type};
+
+pub type LiveboxTypeMap = indexmap::IndexMap<majit_ir::OpRef, majit_ir::Type, FxBuildHasher>;
 
 /// resume.py:656-670: element kind from arraydescr.
 /// 0=ref (is_array_of_pointers), 1=int, 2=float (is_array_of_floats).
@@ -167,7 +170,7 @@ pub struct NumberingState {
     /// raw u32 — pyre's flat-OpRef stand-in for PyPy's `box is box`
     /// identity. See `LiveboxMap` (resume.rs:98) for the matching
     /// typed-key convention.
-    pub livebox_types: indexmap::IndexMap<majit_ir::OpRef, majit_ir::Type>,
+    pub livebox_types: LiveboxTypeMap,
 }
 
 impl NumberingState {
@@ -177,7 +180,7 @@ impl NumberingState {
             liveboxes: LiveboxMap::new(),
             num_boxes: 0,
             num_virtuals: 0,
-            livebox_types: indexmap::IndexMap::new(),
+            livebox_types: indexmap::IndexMap::default(),
         }
     }
     pub fn append_short(&mut self, item: i16) {
@@ -4048,7 +4051,7 @@ impl ResumeDataLoopMemo {
         Vec<majit_ir::Const>,
         Vec<std::rc::Rc<majit_ir::RdVirtualInfo>>,
         Vec<majit_ir::OpRef>,
-        indexmap::IndexMap<majit_ir::OpRef, majit_ir::Type>,
+        LiveboxTypeMap,
     ) {
         let num_env_virtuals = numb_state.num_virtuals;
 


### PR DESCRIPTION
majit compile-path performance for the aheui tracing-JIT workload, plus a macro
feature backing aheui's native smallint tag lowering. All four commits preserve
the logo byte-id gate (996310 bytes / exit 42 / md5 7fcdbfff…, jit == naive).

## Commits
- **`a3d0a7d` get_gcmap: walk frame bindings, not all lifetimes** — regalloc.rs
  iterated every lifetime (~40K) at each of ~1500 call sites; walk the occupied
  `boxes_in_frame` slots instead (llsupport/regalloc.py BindingsIterItems parity).
  Compile bucket 223→124 ms on the single 44K-op logo trace.
- **`bfc6592` ShortBoxes: index potential_ops opref membership** — `is_reachable`
  / `produce_arg` did `.iter().any(|(k,_)| k.to_opref()==opref)` over all
  potential_ops per query = O(n²) (~104 ms). Add a companion `IndexSet<OpRef>`
  for O(1) membership (shortpreamble.py dict-membership parity).
- **`1531801` FxHash for hot OpRef-keyed compile-path maps** — replace SipHash
  (std default) on OptContext new_operations_index / phase1_emit_ops_index /
  input_ops_index / live_synthetics_index (verified never iterated) and
  resop_refs / regalloc lifetimes / resume livebox_types (IndexMap→FxBuildHasher,
  iteration order unaffected). Was ~150 ms SipHash, ~98 ms under find_producer_op.
- **`6b38cd0` native_tag_small config for unary (x<<1)|1 tag lowering** — a new
  `native_tag_small` list on `#[jit_interp]`; a unary call to a listed fn lowers
  to native `IntLshift(x,1)` + `IntOr(_,1)` IR instead of a CallI, parallel to
  `native_int_binops`. Backs aheui's `jit_retag_small` smallint fast-path retag.

Verification: majit-metainterp + majit-backend-dynasm test suites green; logo
byte-id preserved at every commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
