### PR TITLE
jit: drop the WITH_EXCEPT_START gate + with-frame exception-correctness fixes (#389)

### DIFF
--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -417,7 +417,6 @@ pub struct InlineFrame {
 /// Per-trace-attempt walk session, owned by the walk driver and threaded
 /// through [`WalkContext`] — `MetaInterp.framestack` (`pyjitpl.py:2475`,
 /// `:2487`; depth scan `:1390`). Innermost level last.
-#[derive(Default)]
 pub struct WalkSession {
     /// Inlined callee levels. Parent snapshots are outermost-first, matching
     /// `Snapshot.frames`; a caller is pushed at its inline CALL and popped
@@ -428,6 +427,30 @@ pub struct WalkSession {
     /// the outer snapshot root's py_pc→jitcode translation, so abort-point
     /// flushing must decline after the sub-walk unwinds.
     pub abort_in_subwalk: bool,
+    /// Blackhole `tmpreg_r`/`tmpreg_i`/`tmpreg_f` (`blackhole.py:661-679`):
+    /// the single-slot scratch that `insert_renamings` (`flatten.py:154`)
+    /// routes a cyclic parallel move through via `*_push`/`*_pop` pairs.
+    /// `ref_push/r` writes the source Ref (+ its concrete shadow) here;
+    /// `ref_pop/>r` reads it back into a dst register.  Persisted on the
+    /// per-walk session because a push and its matching pop straddle
+    /// intervening `*_copy` ops within one trampoline.
+    pub tmpreg_r: OpRef,
+    pub tmpreg_r_concrete: ConcreteValue,
+    pub tmpreg_i: OpRef,
+    pub tmpreg_f: OpRef,
+}
+
+impl Default for WalkSession {
+    fn default() -> Self {
+        Self {
+            framestack: Vec::new(),
+            abort_in_subwalk: false,
+            tmpreg_r: OpRef::NONE,
+            tmpreg_r_concrete: ConcreteValue::Null,
+            tmpreg_i: OpRef::NONE,
+            tmpreg_f: OpRef::NONE,
+        }
+    }
 }
 
 /// Compile-time-constant frame fields of an inlined callee.
@@ -23251,6 +23274,88 @@ fn handle(
                     bank: "f",
                 })?;
             *slot = src_val;
+            Ok((DispatchOutcome::Continue, op.next_pc))
+        }
+        "ref_push/r" => {
+            // Blackhole `bhimpl_ref_push` (`blackhole.py:664-666`):
+            // `self.tmpreg_r = a`.  `insert_renamings` (`flatten.py:154`)
+            // emits `*_push`/`*_pop` around a cyclic parallel move — the
+            // swap `r_a <-> r_b` lowers to `push r_b; copy r_b<-r_a;
+            // pop r_a` so the overwritten value survives in the tmpreg.
+            // Pure SSA-level scratch move, no IR op recorded.  Operand
+            // layout `r`: 1B src.
+            let src_val = read_ref_reg(code, op, 0, ctx)?;
+            let src_concrete = read_ref_reg_concrete(code, op, 0, ctx);
+            {
+                let mut sess = ctx.session.borrow_mut();
+                sess.tmpreg_r = src_val;
+                sess.tmpreg_r_concrete = src_concrete;
+            }
+            Ok((DispatchOutcome::Continue, op.next_pc))
+        }
+        "ref_pop/>r" => {
+            // Blackhole `bhimpl_ref_pop` (`blackhole.py:674-676`):
+            // `return self.get_tmpreg_r()`.  Reads the value stashed by
+            // the matching `ref_push/r` back into a dst register, in
+            // lock-step with its concrete shadow.  Operand layout `>r`:
+            // 1B dst.
+            let (val, concrete) = {
+                let sess = ctx.session.borrow();
+                (sess.tmpreg_r, sess.tmpreg_r_concrete)
+            };
+            let dst = code[op.pc + 1] as usize;
+            write_ref_reg(ctx, op.pc, dst, val, concrete)?;
+            Ok((DispatchOutcome::Continue, op.next_pc))
+        }
+        "int_push/i" => {
+            // Blackhole `bhimpl_int_push` (`blackhole.py:661-663`):
+            // `self.tmpreg_i = a`.  Int-bank sibling of `ref_push/r`.
+            // Operand layout `i`: 1B src.
+            let src_val = read_int_reg(code, op, 0, ctx)?;
+            ctx.session.borrow_mut().tmpreg_i = src_val;
+            Ok((DispatchOutcome::Continue, op.next_pc))
+        }
+        "int_pop/>i" => {
+            // Blackhole `bhimpl_int_pop` (`blackhole.py:671-673`).
+            // Operand layout `>i`: 1B dst.
+            let val = ctx.session.borrow().tmpreg_i;
+            let dst = code[op.pc + 1] as usize;
+            let len = ctx.registers_i.len();
+            let slot = ctx
+                .registers_i
+                .get_mut(dst)
+                .ok_or(DispatchError::RegisterOutOfRange {
+                    pc: op.pc,
+                    reg: dst,
+                    len,
+                    bank: "i",
+                })?;
+            *slot = val;
+            Ok((DispatchOutcome::Continue, op.next_pc))
+        }
+        "float_push/f" => {
+            // Blackhole `bhimpl_float_push` (`blackhole.py:667-669`).
+            // Operand layout `f`: 1B src.
+            let src_val = read_float_reg(code, op, 0, ctx)?;
+            ctx.session.borrow_mut().tmpreg_f = src_val;
+            Ok((DispatchOutcome::Continue, op.next_pc))
+        }
+        "float_pop/>f" => {
+            // Blackhole `bhimpl_float_pop` (`blackhole.py:677-679`).
+            // Operand layout `>f`: 1B dst.
+            let val = ctx.session.borrow().tmpreg_f;
+            let dst = code[op.pc + 1] as usize;
+            let len = ctx.registers_f.len();
+            let slot = ctx
+                .registers_f
+                .get_mut(dst)
+                .ok_or(DispatchError::RegisterOutOfRange {
+                    pc: op.pc,
+                    reg: dst,
+                    len,
+                    bank: "f",
+                })?;
+            *slot = val;
             Ok((DispatchOutcome::Continue, op.next_pc))
         }
         "ref_copy/r>r" => {

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -8419,6 +8419,7 @@ struct FbwStoreJournalRootArea {
     appends: *const std::cell::RefCell<Vec<(pyre_object::PyObjectRef, usize)>>,
     abort_overrides: *const std::cell::RefCell<Vec<(usize, pyre_object::PyObjectRef)>>,
     cell_stores: *const std::cell::RefCell<Vec<(pyre_object::PyObjectRef, i64)>>,
+    sys_exc: *const std::cell::RefCell<Vec<pyre_object::PyObjectRef>>,
     foriter: *const std::cell::RefCell<Vec<InflightForiter>>,
     abort_resume: *const std::cell::RefCell<Option<InlineAbortCarrier>>,
     active_session: *const std::cell::Cell<*const std::cell::RefCell<WalkSession>>,
@@ -8430,6 +8431,7 @@ thread_local! {
         appends: FBW_APPEND_JOURNAL.with(|value| value as *const _),
         abort_overrides: FBW_ABORT_OUTER_STACK_OVERRIDES.with(|value| value as *const _),
         cell_stores: FBW_CELL_STORE_JOURNAL.with(|value| value as *const _),
+        sys_exc: FBW_SYS_EXC_JOURNAL.with(|value| value as *const _),
         foriter: FBW_FORITER_INFLIGHT.with(|value| value as *const _),
         abort_resume: FBW_ABORT_CALL_RESUME.with(|value| value as *const _),
         active_session: ACTIVE_WALK_SESSION.with(|value| value as *const _),
@@ -9237,13 +9239,12 @@ pub unsafe fn fbw_store_journal_root_walker_area(
     // nursery-resident and no longer referenced elsewhere once the eager store
     // overwrote the EC slot; forward each so a minor collection during the rest
     // of the walk cannot free/move the value the rollback restores.
-    FBW_SYS_EXC_JOURNAL.with(|j| {
-        for displaced in j.borrow_mut().iter_mut() {
-            // SAFETY: `PyObjectRef` and `GcRef` share the usize repr; the
-            // borrow keeps the Vec storage alive for the visit.
-            visitor(unsafe { &mut *(displaced as *mut pyre_object::PyObjectRef).cast() });
-        }
-    });
+    let sys_exc = unsafe { &mut *(*area.sys_exc).as_ptr() };
+    for displaced in sys_exc.iter_mut() {
+        // SAFETY: `PyObjectRef` and `GcRef` share the usize repr; the
+        // borrowed area keeps the Vec storage alive for the visit.
+        visitor(unsafe { &mut *(displaced as *mut pyre_object::PyObjectRef).cast() });
+    }
     // #57 Option C: each captured in-flight FOR_ITER item is nursery-resident
     // across the rest of the walk (subsequent residual calls allocate and a
     // minor collection moves nursery objects), so forward every entry's item

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -17416,13 +17416,28 @@ fn try_walker_specialize_load_attr(
     // guard_value(getfield_gc_i(obj, map), C_map): `jit.promote(self.map)`
     // (`mapdict.py:905-906`).  The map nodes are interned + immortal, so the
     // pointer is a stable identity guarded as an opaque word (object_map_descr
-    // is Int-typed).  Skipped when the field read already const-folds to the map
-    // (heapcache hit).
+    // is Int-typed).
+    //
+    // The guard may only be elided when the map read is ALREADY a compile-time
+    // constant — i.e. a prior promotion in this trace pinned it via
+    // `replace_box`.  It must NOT be elided merely because `box_value(map_op)`
+    // reports the concrete map: every traced getfield op carries its live value
+    // (`opimpl_getfield_gc_i` → `set_opref_concrete`, `history.py:803`
+    // FrontendOp), so `box_value == map` holds for the very first read and
+    // would drop the guard on the trace's entry.  A trace whose map guard is
+    // dropped reads `storage[storageindex]` off any same-class receiver whose
+    // map differs (GuardClass alone does not pin the layout), returning a wild
+    // slot value.  Pin the map with `replace_box` after guarding so a later
+    // fold on the same receiver correctly elides (matching the trait
+    // `implement_guard_value`, `trace_opcode.rs:4631-4633`).
     let map_op =
         crate::state::opimpl_getfield_gc_i(ctx.trace_ctx, obj, crate::descr::object_map_descr());
-    if ctx.trace_ctx.box_value(map_op) != Some(majit_ir::Value::Int(map as i64)) {
+    if !map_op.is_constant() {
         let map_const = ctx.trace_ctx.const_int(map as i64);
         walker_emit_fold_guard_with_snapshot(ctx, op_pc, OpCode::GuardValue, &[map_op, map_const])?;
+        ctx.trace_ctx
+            .heap_cache_mut()
+            .replace_box(map_op, map_const);
     }
 
     // getfield_gc_r(obj, storage) + getarrayitem_gc_r(block, C_storageindex):

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -1621,7 +1621,7 @@ fn run_perfn_walk(
                                 reserved_red_colors.first().copied() == Some(color);
                             let bridge_names_operand =
                                 !is_frame_color && opref != ec_box && opref != frame_box;
-                            if pyre_object::tagged_int::CAN_BE_TAGGED && bridge_names_operand {
+                            if bridge_names_operand {
                                 seed(color, opref);
                             }
                             continue;

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -1822,6 +1822,7 @@ fn run_perfn_walk(
                 ) => Some((*pc, false)),
                 _ => None,
             };
+            let mut entry_carrier_call_py_pc = None;
             if let Some((abort_jit_pc, is_marker_abort)) = call_forward_abort {
                 // gh#467: a supported abort fired inside a TOP-level inline
                 // sub-walk whose callee executed no concrete effect
@@ -1843,6 +1844,7 @@ fn run_perfn_walk(
                         call_py_pc,
                         call_stack,
                     }) => {
+                        entry_carrier_call_py_pc = Some(*call_py_pc);
                         if crate::state::flush_walk_end_state_at_outer_call(
                             ctx,
                             cf_addr,
@@ -1961,35 +1963,46 @@ fn run_perfn_walk(
                 } else if let Some(resume_py_pc) =
                     crate::jitcode_dispatch::fbw_abort_outer_resume_take()
                 {
-                    // Flush while the overrides stay rooted in
-                    // FBW_ABORT_OUTER_STACK_OVERRIDES (the flush boxes Int/Float
-                    // locals — an allocation that can move the nursery-resident
-                    // override refs; the area walker forwards them in place),
-                    // then clear the cell.
-                    let committed = crate::jitcode_dispatch::fbw_abort_outer_stack_overrides_with(
-                        |stack_overrides| {
-                            crate::state::flush_walk_end_state_to_frame_with_stack_overrides(
-                                ctx,
-                                cf_addr,
-                                resume_py_pc,
-                                stack_overrides,
-                            )
-                        },
-                    );
-                    crate::jitcode_dispatch::fbw_abort_outer_stack_overrides_clear();
-                    if committed {
+                    if entry_carrier_call_py_pc == Some(resume_py_pc) {
+                        crate::jitcode_dispatch::fbw_abort_outer_stack_overrides_clear();
                         if crate::jitcode_dispatch::fbw_debug_abort_enabled() {
                             eprintln!(
-                                "[fbw-abort-flush] COMMIT abort_jit_pc={abort_jit_pc} \
-                                 resume_py_pc={resume_py_pc} (nested inline decline)"
+                                "[fbw-abort-flush] skipped at resume_py_pc={resume_py_pc} \
+                                 (entry carrier already handled same resume)"
                             );
                         }
-                        WALK_END_FLUSH_COMMITTED.with(|c| c.set(true));
-                    } else if crate::jitcode_dispatch::fbw_debug_abort_enabled() {
-                        eprintln!(
-                            "[fbw-abort-flush] declined at resume_py_pc={resume_py_pc} \
-                             (shadow slot without concrete / depth / lastblock) — legacy replay kept"
-                        );
+                    } else {
+                        // Flush while the overrides stay rooted in
+                        // FBW_ABORT_OUTER_STACK_OVERRIDES (the flush boxes Int/Float
+                        // locals — an allocation that can move the nursery-resident
+                        // override refs; the area walker forwards them in place),
+                        // then clear the cell.
+                        let committed =
+                            crate::jitcode_dispatch::fbw_abort_outer_stack_overrides_with(
+                                |stack_overrides| {
+                                    crate::state::flush_walk_end_state_to_frame_with_stack_overrides(
+                                        ctx,
+                                        cf_addr,
+                                        resume_py_pc,
+                                        stack_overrides,
+                                    )
+                                },
+                            );
+                        crate::jitcode_dispatch::fbw_abort_outer_stack_overrides_clear();
+                        if committed {
+                            if crate::jitcode_dispatch::fbw_debug_abort_enabled() {
+                                eprintln!(
+                                    "[fbw-abort-flush] COMMIT abort_jit_pc={abort_jit_pc} \
+                                     resume_py_pc={resume_py_pc} (nested inline decline)"
+                                );
+                            }
+                            WALK_END_FLUSH_COMMITTED.with(|c| c.set(true));
+                        } else if crate::jitcode_dispatch::fbw_debug_abort_enabled() {
+                            eprintln!(
+                                "[fbw-abort-flush] declined at resume_py_pc={resume_py_pc} \
+                                 (shadow slot without concrete / depth / lastblock) — legacy replay kept"
+                            );
+                        }
                     }
                 } else if crate::jitcode_dispatch::fbw_debug_abort_enabled() {
                     eprintln!(

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -8946,9 +8946,12 @@ mod tests {
         // A `with` block compiles to `WITH_EXCEPT_START` for its exception link,
         // lowered as a residual with the exception disposition preserved across
         // the guard-failure bridge. The frame is admitted for tracing.
+        // The body is kept free of `FOR_ITER` so the only classification axis
+        // is the `WITH_EXCEPT_START` shape; a `for` loop whose body is not
+        // allow-listed declines independently via `for_iter_bodies_all_jit_safe`.
         use pyre_interpreter::compile_exec;
         let module = compile_exec(
-            "def wf(cm):\n    total = 0\n    for _ in range(3):\n        with cm:\n            total += 1\n    return total\n",
+            "def wf(cm):\n    total = 0\n    with cm:\n        total += 1\n    return total\n",
         )
         .expect("test code should compile");
         let code = function_code_from_module(&module, "wf");

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -4108,12 +4108,8 @@ fn unsupported_jit_shape(code: &pyre_interpreter::CodeObject) -> UnsupportedJitS
     let mut arg_state = pyre_interpreter::OpArgState::default();
     let mut has_for_iter = false;
     for unit in code.instructions.iter().copied() {
-        match arg_state.get(unit).0 {
-            pyre_interpreter::Instruction::WithExceptStart => {
-                return UnsupportedJitShape::StructuralRegion;
-            }
-            pyre_interpreter::Instruction::ForIter { .. } => has_for_iter = true,
-            _ => {}
+        if let pyre_interpreter::Instruction::ForIter { .. } = arg_state.get(unit).0 {
+            has_for_iter = true;
         }
     }
     if has_for_iter {
@@ -8946,24 +8942,17 @@ mod tests {
     }
 
     #[test]
-    fn with_block_frame_is_structural_region() {
-        // A `with` block compiles to `WITH_EXCEPT_START` for its exception link.
-        // The codewriter still residualizes that lowering, so tracing the frame
-        // (or its nested callees) miscompiles — a raw SIGSEGV in the exception
-        // path plus guard-failure storms (test_strftime/test_shlex/test_textwrap,
-        // #389). The frame must classify as `StructuralRegion` so it and its
-        // callees stay interpreted; dropping this gate regressed the CPython
-        // suite (commit 4daa5c517e, reverted).
+    fn with_block_frame_is_admitted() {
+        // A `with` block compiles to `WITH_EXCEPT_START` for its exception link,
+        // lowered as a residual with the exception disposition preserved across
+        // the guard-failure bridge. The frame is admitted for tracing.
         use pyre_interpreter::compile_exec;
         let module = compile_exec(
             "def wf(cm):\n    total = 0\n    for _ in range(3):\n        with cm:\n            total += 1\n    return total\n",
         )
         .expect("test code should compile");
         let code = function_code_from_module(&module, "wf");
-        assert_eq!(
-            unsupported_jit_shape(&code),
-            UnsupportedJitShape::StructuralRegion
-        );
+        assert_eq!(unsupported_jit_shape(&code), UnsupportedJitShape::None);
     }
 
     fn ensure_test_jit_callbacks() {

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -9092,13 +9092,6 @@ impl CodeWriter {
                             // on top. Preserve the net `+1` stack effect in the
                             // shadow graph and fall back to the interpreter for
                             // the actual helper call semantics.
-                            //
-                            // Portable (flowspace records a `direct_call` /
-                            // `indirect_call`) but latent: a `with` block's
-                            // exception table prevents the enclosing loop/callee
-                            // from ever reaching a JIT token, so this abort is
-                            // never reached in practice — no residual yet.
-                            emit_abort_permanent!(py_pc);
                             push_fresh_ref(&mut current_state, &mut graph);
                             current_depth += 1;
                             emit_vsd!(current_depth, py_pc);


### PR DESCRIPTION
Removes the `WITH_EXCEPT_START` JIT gate so hot loops inside a `with`-block are admitted for tracing, and lands the exception-correctness and resume fixes that the gate previously masked.

## Commits (rebased onto current `main`)

- **`0c527d51591` jit: read the FBW sys_exc journal through the captured root area** — the walker read `FBW_SYS_EXC_JOURNAL` via TLS on the store-journal path; on abort rollback this could diverge from the captured root area. Now threads the journal cell through the captured root area so the walker and the rollback see the same store.
- **`5e03d05dfc7` jit: preserve exception disposition on an uncaught exception-guard bridge** (#389c root #6) — a loop-free `with`-callee trace reaching the no-replay portal exit swallowed an exception-guard bridge's raise, so e.g. `re.compile('\\')` intermittently did not raise. The bridge resolver now returns the exception continuation for an uncaught exception-guard bridge instead of the captured concrete return.
- **`4f84553d51b` jit: admit with-block frames for tracing (drop the WITH_EXCEPT_START gate)** — deletes the `emit_abort_permanent!` at the `WithExceptStart` codewriter arm and the `StructuralRegion` decline in `unsupported_jit_shape`. `with`-frames now trace as plain residual regions.
- **`948c40dca36` jit: skip the executed-nonpure abort-flush when the entry carrier owns the same outer resume** (test_fnmatch) — a double abort-flush at the same outer resume pc corrupted a bound-method local in a nested `FOR_ITER`. The executed-nonpure arm now declines when the Entry-carrier arm already owns that resume.
- **`15ea5baec63` jit: seed a bridge-named operand in a reserved red color regardless of tagged-int support** (test_strftime) — the bridge red-color seeding was gated on `CAN_BE_TAGGED`, leaving a stale `ConstPtr(ec)` callable on no-token and a SIGSEGV. The seeding now runs unconditionally.

## Status

Every baseline-gated regression the gate drop exposed is fixed and green:

- [x] test_fnmatch — wrong result at `test_range` (baseline-gated) — `948c40dca36`
- [x] test_strftime — SIGSEGV (baseline-gated) — `15ea5baec63`
- [x] test_strtod — rust panic at `pyframe.rs:2098` (baseline-gated) — no longer reproduces after the rebase onto current `main`; the super-instruction resume defect it hit is subsumed by the upstream resume-frame rework (#536 / #543). The dedicated resume commit that previously fixed it was dropped as redundant — against the new resume-frame shape it miscompiled the `gh#498` branch-resume guard (`synth/closure_freevar_branch_list_cell`).
- [ ] test_re — ~20 JIT-only errors: an expected exception (`re.PatternError`/`OverflowError`) escapes a `with assertRaises(...)` block instead of being suppressed (non-gated; `test_re` baseline is already FAIL, no CI impact) — #389c root #4-alt, tracked as a follow-up. RCA is still open: the escape route traces as `CompareOp -> PopJumpIfFalse -> RaiseVarargs` (not the with-cleanup opcodes); the `WITH_EXCEPT_START` result-slot hypothesis was investigated and refuted.

`check.py --backend dynasm`: **181/181** (rebased onto `main` at `928139e6d95`).

All exposed miscompiles reproduce only with the JIT on (`PYRE_NO_JIT=1` is clean), confirming they are trace-path bugs, not interpreter regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
