### PR TITLE
str: JIT quasi-immut retrace + DELETE_FAST walker lowering; utf8_mode flag

### DIFF
--- a/majit/majit-backend-wasm/src/lib.rs
+++ b/majit/majit-backend-wasm/src/lib.rs
@@ -1046,6 +1046,41 @@ fn wasm_unsupported_trace_reason(ops: &[Op], is_loop: bool, allow_ca: bool) -> O
                 "wasm backend: loop trace with cross-loop terminal JUMP (no local LABEL)".into(),
             );
         }
+        // The loop lowering assumes the closing back-edge JUMP targets the LAST
+        // label: `build_function` picks the loop-back label with
+        // `ops.rposition(Label)`, `find_label_args` returns that label's args,
+        // and the JUMP arm maps the jump args onto it positionally then `br`s to
+        // it. A loop re-traced after a quasi-immutable invalidation can instead
+        // close with a JUMP back to its wider preamble entry label while a
+        // narrower peeled header sits last; mapping the wide jump's args onto the
+        // narrow last label's params leaks preamble constants into loop-carried
+        // slots. The JUMP and the label it targets share the loop-target descr
+        // Arc, so a differing descr identity marks a non-last target — decline it
+        // (`compile_bridge` declines the analogous loop-closing JUMP). The
+        // interpreter runs the invalidated loop correctly.
+        let last_label_descr = ops
+            .iter()
+            .rev()
+            .find(|op| op.opcode == majit_ir::OpCode::Label)
+            .and_then(|op| {
+                op.getdescr()
+                    .map(|d| std::sync::Arc::as_ptr(&d) as *const () as usize)
+            });
+        let closing_jump_descr = ops
+            .iter()
+            .rev()
+            .find(|op| op.opcode == majit_ir::OpCode::Jump)
+            .and_then(|op| {
+                op.getdescr()
+                    .map(|d| std::sync::Arc::as_ptr(&d) as *const () as usize)
+            });
+        if matches!((last_label_descr, closing_jump_descr), (Some(label), Some(jump)) if label != jump)
+        {
+            return Some(
+                "wasm backend: loop back-edge JUMP targets a non-last label (re-traced/unpeeled loop shape)"
+                    .into(),
+            );
+        }
     }
     // A JUMP with no local LABEL inside a bridge (a loop-closing bridge) is
     // lowered to a `return_call_indirect` into the source loop's table slot — a

--- a/majit/majit-ir/src/effectinfo.rs
+++ b/majit/majit-ir/src/effectinfo.rs
@@ -674,6 +674,15 @@ pub enum PyreHelperKind {
     /// virtualized New), so the following `selected_ref.head = new_node`
     /// remains a normal committed setfield. has_oopspec stays false.
     NurseryAlloc,
+    /// `bh_load_method_self_fn(obj, attr, code, name_idx)` — the LOAD_METHOD
+    /// binding half (`callmethod.py:25-85`).  The full-body walker recognises
+    /// this tag to fold the pure `compute_load_method_bound` decision once the
+    /// paired [`LoadAttr`] method-cache fold has made `attr` concrete.
+    ///
+    /// Keep this at the enum tail: [`PyreHelperKind`] is `repr(u8)`, and
+    /// inserting a helper in the middle changes existing discriminants consumed
+    /// by serialized/stable helper metadata.
+    LoadMethodSelf,
 }
 
 impl EffectInfo {

--- a/majit/majit-metainterp/src/optimizeopt/unroll.rs
+++ b/majit/majit-metainterp/src/optimizeopt/unroll.rs
@@ -299,6 +299,9 @@ pub struct UnrollOptimizer {
     /// pyjitpl.py:2289 all_descrs: dense list indexed by descr_index.
     /// Threaded through inner Optimizer instances for inline registration.
     pub all_descrs: Vec<majit_ir::descr::DescrRef>,
+    /// compile.py:204-207 / heap.py:807-808 quasi-immutable deps collected
+    /// by the phase optimizers for post-compile watcher registration.
+    pub quasi_immutable_deps: Vec<(u64, u32)>,
     /// RPython Box type parity: trace inputarg types from recorder.
     /// Each RPython Box carries its type; in majit OpRef is untyped u32.
     /// Propagated to Phase 1 and Phase 2 Optimizer.trace_inputargs
@@ -383,6 +386,7 @@ impl UnrollOptimizer {
             snapshot_vref_boxes: Vec::new(),
             snapshot_frame_pcs: Vec::new(),
             all_descrs: Vec::new(),
+            quasi_immutable_deps: Vec::new(),
             trace_inputargs: Vec::new(),
             phase1_emit_ops: Vec::new(),
             phase1_patchguardop: None,
@@ -722,6 +726,10 @@ impl UnrollOptimizer {
             }
             let p1_ops =
                 opt_p1.run_optimize_from_inputs(&p1_ops_in, &mut consts_p1, num_inputs, false)?;
+            merge_quasi_immutable_deps(
+                &mut self.quasi_immutable_deps,
+                &opt_p1.quasi_immutable_deps,
+            );
             // RPython parity: Phase 1 optimizer may discover new constants
             // via make_constant (e.g., constant-folded heap reads, guard
             // class pointers). These live on the operand's forwarded chain
@@ -1137,6 +1145,10 @@ impl UnrollOptimizer {
                 false,
             )
         })?;
+        merge_quasi_immutable_deps(
+            &mut self.quasi_immutable_deps,
+            &opt_p2.quasi_immutable_deps,
+        );
         self.clear_compile_snapshot_roots();
         // RPython optimizer.py:614-625 freezes op arguments during
         // `_emit_operation`; optimizer.py:598-612 may then install a Const
@@ -2004,6 +2016,14 @@ fn closing_loop_contract_arity<T: AsRef<Op>>(ops: &[T], fallback: usize) -> usiz
 impl Default for UnrollOptimizer {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+fn merge_quasi_immutable_deps(dst: &mut Vec<(u64, u32)>, src: &[(u64, u32)]) {
+    for dep in src {
+        if !dst.contains(dep) {
+            dst.push(*dep);
+        }
     }
 }
 

--- a/majit/majit-metainterp/src/optimizeopt/unroll.rs
+++ b/majit/majit-metainterp/src/optimizeopt/unroll.rs
@@ -1145,10 +1145,7 @@ impl UnrollOptimizer {
                 false,
             )
         })?;
-        merge_quasi_immutable_deps(
-            &mut self.quasi_immutable_deps,
-            &opt_p2.quasi_immutable_deps,
-        );
+        merge_quasi_immutable_deps(&mut self.quasi_immutable_deps, &opt_p2.quasi_immutable_deps);
         self.clear_compile_snapshot_roots();
         // RPython optimizer.py:614-625 freezes op arguments during
         // `_emit_operation`; optimizer.py:598-612 may then install a Const

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -5458,8 +5458,11 @@ impl<M: Clone> MetaInterp<M> {
             )
         };
         let mut retried_without_unroll = false;
-        let (optimized_ops, final_num_inputs) = match optimize_result {
-            Ok(result) => result,
+        let (optimized_ops, final_num_inputs, quasi_immutable_deps) = match optimize_result {
+            Ok(result) => {
+                let deps = std::mem::take(&mut unroll_opt.quasi_immutable_deps);
+                (result.0, result.1, deps)
+            }
             // unroll.py:119-123 `except (InvalidLoop, SpeculativeError)`: a
             // guard proven to always fail, or a speculative heap access proven
             // ill-typed (now a deferred `InvalidLoop` signal rather than a
@@ -5565,10 +5568,11 @@ impl<M: Clone> MetaInterp<M> {
                                 retried_without_unroll = true;
                                 constants = retry_constants;
                                 let ni = simple_opt.final_num_inputs();
+                                let deps = std::mem::take(&mut simple_opt.quasi_immutable_deps);
                                 // Return descrs to unroll_opt so take_back_all_descrs
                                 // at the end of compile_loop picks them up.
                                 unroll_opt.all_descrs = std::mem::take(&mut simple_opt.all_descrs);
-                                (retry_ops, ni)
+                                (retry_ops, ni, deps)
                             }
                             Ok(Err(_invalid_loop)) => {
                                 // The unroll-free retry also abandoned the trace.
@@ -5597,6 +5601,7 @@ impl<M: Clone> MetaInterp<M> {
                 }
             }
         };
+        self.last_quasi_immutable_deps = quasi_immutable_deps;
 
         // compile.py:302-308: vectorization post-pass. Condition is
         // `((warmstate.vec and jitdriver_sd.vec) or warmstate.vec_all) and
@@ -6271,10 +6276,13 @@ impl<M: Clone> MetaInterp<M> {
     /// compile.py: has_compiled_targets — check if a green key has
     /// compiled target tokens that a bridge can jump to.
     pub fn has_compiled_targets(&self, green_key: u64) -> bool {
-        // Consistent with has_compiled_loop: direct key only, no alias.
-        // Both functions must see the same view — otherwise tracing sees
-        // "targets exist" while execution sees "no compiled loop", causing
-        // wasted compile/trace churn in nested loops.
+        // Consistent with has_compiled_loop: direct key only, no alias, and
+        // the warmstate token must still be live. warmstate.py:483-500 removes
+        // invalidated/dead cells before retracing; pyre's compiled_loops
+        // side-table must not make such a dead token look jumpable.
+        if !self.has_compiled_loop(green_key) {
+            return false;
+        }
         self.compiled_loops
             .get(&green_key)
             .map_or(false, |c| !c.front_target_tokens.is_empty())

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -7080,6 +7080,8 @@ impl<M: Clone> MetaInterp<M> {
                 if let Some(ref hook) = self.hooks.on_compile_loop {
                     hook(green_key, 0, num_combined_ops);
                 }
+                self.last_quasi_immutable_deps =
+                    std::mem::take(&mut unroll_opt.quasi_immutable_deps);
                 true
             }
             Err(e) => {

--- a/majit/majit-metainterp/src/warmstate.rs
+++ b/majit/majit-metainterp/src/warmstate.rs
@@ -537,6 +537,7 @@ impl WarmEnterState {
     }
 
     pub fn counter_tick_checked(&mut self, green_key_hash: u64) -> bool {
+        let mut cleanup_dead_token_cell = false;
         if let Some(cell) = self.cells.get(&green_key_hash) {
             if cell.is_compiled() || cell.is_tracing() {
                 return true;
@@ -544,12 +545,23 @@ impl WarmEnterState {
             if cell.flags & jc_flags::DONT_TRACE_HERE != 0 && cell.has_seen_a_procedure_token() {
                 return false;
             }
+            if cell.has_seen_a_procedure_token() && cell.get_procedure_token().is_none() {
+                cleanup_dead_token_cell = true;
+            }
+        }
+        if cleanup_dead_token_cell {
+            // warmstate.py:483-500 — loop-header counter entry must also
+            // remove invalidated token cells before it starts counting again.
+            self.cleanup_chain(green_key_hash);
+            return false;
         }
         self.counter.tick(green_key_hash, self.increment_threshold)
     }
 
     pub fn maybe_compile(&mut self, green_key_hash: u64) -> HotResult {
+        let mut cleanup_dead_token_cell = false;
         if let Some(cell) = self.cells.get(&green_key_hash) {
+            let has_procedure_token = cell.get_procedure_token().is_some();
             let is_compiled = cell.is_compiled();
             let is_tracing = cell.is_tracing();
             let flags = cell.flags;
@@ -570,6 +582,16 @@ impl WarmEnterState {
             if flags & jc_flags::DONT_TRACE_HERE != 0 {
                 return HotResult::NotHot;
             }
+            if has_seen_a_procedure_token && !has_procedure_token {
+                cleanup_dead_token_cell = true;
+            }
+        }
+
+        if cleanup_dead_token_cell {
+            // warmstate.py:483-500 — an invalidated/dead procedure token is
+            // removed from the chain, resetting the hot counter so it re-arms.
+            self.cleanup_chain(green_key_hash);
+            return HotResult::NotHot;
         }
 
         if !self.counter.tick(green_key_hash, self.increment_threshold) {
@@ -605,7 +627,9 @@ impl WarmEnterState {
     /// typed-greenkey threading work.
     pub fn maybe_compile_with_key(&mut self, key: &GreenKey) -> HotResult {
         let hash = key.get_uhash();
+        let mut cleanup_dead_token_cell = false;
         if let Some(cell) = self.lookup_chain_with_key(key) {
+            let has_procedure_token = cell.get_procedure_token().is_some();
             let is_compiled = cell.is_compiled();
             let is_tracing = cell.is_tracing();
             let flags = cell.flags;
@@ -622,6 +646,16 @@ impl WarmEnterState {
             if flags & jc_flags::DONT_TRACE_HERE != 0 {
                 return HotResult::NotHot;
             }
+            if has_seen_a_procedure_token && !has_procedure_token {
+                cleanup_dead_token_cell = true;
+            }
+        }
+
+        if cleanup_dead_token_cell {
+            // warmstate.py:483-500 — an invalidated/dead procedure token is
+            // removed from the chain, resetting the hot counter so it re-arms.
+            self.cleanup_chain(hash);
+            return HotResult::NotHot;
         }
 
         if !self.counter.tick(hash, self.increment_threshold) {
@@ -1354,6 +1388,7 @@ impl WarmEnterState {
     ///
     /// warmstate.py:256-257: jitcounter.tick(hash, increment_function_threshold).
     pub fn should_trace_function_entry(&mut self, green_key_hash: u64) -> bool {
+        let mut cleanup_dead_token_cell = false;
         if let Some(cell) = self.cells.get(&green_key_hash) {
             if cell.is_compiled() || cell.is_tracing() {
                 return false;
@@ -1366,6 +1401,15 @@ impl WarmEnterState {
                     return true;
                 }
             }
+            if cell.has_seen_a_procedure_token() && cell.get_procedure_token().is_none() {
+                cleanup_dead_token_cell = true;
+            }
+        }
+        if cleanup_dead_token_cell {
+            // warmstate.py:483-500 — function-entry warmup must see an
+            // invalidated token as a removed cell and re-count from cold.
+            self.cleanup_chain(green_key_hash);
+            return false;
         }
         self.counter
             .tick(green_key_hash, self.increment_function_threshold)
@@ -3030,6 +3074,77 @@ mod tests {
 
         // Loop should now be invalidated state
         assert_eq!(ws.get_cell_state(key), BaseJitCellState::Invalidated);
+    }
+
+    #[test]
+    fn test_quasiimmut_invalidated_cell_rearms_hot_counter() {
+        let mut ws = WarmEnterState::new(2);
+        let key = 0xD00D;
+        let qmut = 0xFA11;
+
+        assert!(matches!(ws.maybe_compile(key), HotResult::NotHot));
+        assert!(matches!(ws.maybe_compile(key), HotResult::StartTracing));
+        ws.finish_tracing(key);
+        let token = JitCellToken::new(ws.alloc_token_number());
+        ws.attach_procedure_to_interp(key, token);
+        ws.register_quasiimmut_dependency(qmut, key);
+
+        assert_eq!(ws.invalidate_quasiimmut(qmut), 1);
+        assert_eq!(ws.get_cell_state(key), BaseJitCellState::Invalidated);
+
+        // warmstate.py:483-500: the next entry removes the invalidated
+        // token cell and resets the counter; following entries count fresh.
+        assert!(matches!(ws.maybe_compile(key), HotResult::NotHot));
+        assert!(ws.get_cell(key).is_none());
+        assert!(matches!(ws.maybe_compile(key), HotResult::NotHot));
+        assert!(matches!(ws.maybe_compile(key), HotResult::StartTracing));
+    }
+
+    #[test]
+    fn test_counter_tick_checked_rearms_after_quasiimmut_invalidation() {
+        let mut ws = WarmEnterState::new(2);
+        let key = 0xD00E;
+        let qmut = 0xFA12;
+
+        assert!(!ws.counter_tick_checked(key));
+        assert!(ws.counter_tick_checked(key));
+        ws.force_start_tracing(key);
+        ws.finish_tracing(key);
+        let token = JitCellToken::new(ws.alloc_token_number());
+        ws.attach_procedure_to_interp(key, token);
+        ws.register_quasiimmut_dependency(qmut, key);
+
+        assert_eq!(ws.invalidate_quasiimmut(qmut), 1);
+        assert_eq!(ws.get_cell_state(key), BaseJitCellState::Invalidated);
+
+        assert!(!ws.counter_tick_checked(key));
+        assert!(ws.get_cell(key).is_none());
+        assert!(!ws.counter_tick_checked(key));
+        assert!(ws.counter_tick_checked(key));
+    }
+
+    #[test]
+    fn test_function_entry_rearms_after_quasiimmut_invalidation() {
+        let mut ws = WarmEnterState::new(2);
+        ws.set_function_threshold(2);
+        let key = 0xD00F;
+        let qmut = 0xFA13;
+
+        assert!(!ws.should_trace_function_entry(key));
+        assert!(ws.should_trace_function_entry(key));
+        ws.force_start_tracing(key);
+        ws.finish_tracing(key);
+        let token = JitCellToken::new(ws.alloc_token_number());
+        ws.attach_procedure_to_interp(key, token);
+        ws.register_quasiimmut_dependency(qmut, key);
+
+        assert_eq!(ws.invalidate_quasiimmut(qmut), 1);
+        assert_eq!(ws.get_cell_state(key), BaseJitCellState::Invalidated);
+
+        assert!(!ws.should_trace_function_entry(key));
+        assert!(ws.get_cell(key).is_none());
+        assert!(!ws.should_trace_function_entry(key));
+        assert!(ws.should_trace_function_entry(key));
     }
 
     #[test]

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -1268,14 +1268,22 @@ fn index_type_error(descr: &str, index: PyObjectRef) -> PyError {
 unsafe fn getitem_list(obj: PyObjectRef, index: PyObjectRef) -> PyResult {
     if is_slice(index) {
         let len = w_list_len(obj) as i64;
-        let (start, stop, step) = normalize_slice(index, len)?;
+        let (rs, rp, st) = crate::sliceobject::slice_unpack(
+            w_slice_get_start(index),
+            w_slice_get_stop(index),
+            w_slice_get_step(index),
+        )?;
+        let (start, _stop, step, slicelength) =
+            crate::sliceobject::slice_adjust_indices(rs, rp, st, len);
         let mut items = Vec::new();
         let mut i = start;
-        while (step > 0 && i < stop) || (step < 0 && i > stop) {
+        for n in 0..slicelength {
             if let Some(v) = w_list_getitem(obj, i) {
                 items.push(v);
             }
-            i += step;
+            if n + 1 < slicelength {
+                i += step;
+            }
         }
         return Ok(w_list_new(items));
     }
@@ -1323,14 +1331,22 @@ unsafe fn getitem_tuple(obj: PyObjectRef, index: PyObjectRef) -> PyResult {
     if is_slice(index) {
         // tupleobject.py descr_getslice → slice.indices.
         let len = w_tuple_len(obj) as i64;
-        let (start, stop, step) = normalize_slice(index, len)?;
+        let (rs, rp, st) = crate::sliceobject::slice_unpack(
+            w_slice_get_start(index),
+            w_slice_get_stop(index),
+            w_slice_get_step(index),
+        )?;
+        let (start, _stop, step, slicelength) =
+            crate::sliceobject::slice_adjust_indices(rs, rp, st, len);
         let mut items = Vec::new();
         let mut i = start;
-        while (step > 0 && i < stop) || (step < 0 && i > stop) {
+        for n in 0..slicelength {
             if let Some(v) = w_tuple_getitem(obj, i) {
                 items.push(v);
             }
-            i += step;
+            if n + 1 < slicelength {
+                i += step;
+            }
         }
         return Ok(w_tuple_new(items));
     }
@@ -1377,17 +1393,25 @@ unsafe fn getitem_str(obj: PyObjectRef, index: PyObjectRef) -> PyResult {
     if is_slice(index) {
         // `pypy/objspace/std/unicodeobject.py W_UnicodeObject._getitem_slice`
         // → `slice.indices(len)` (`pypy/objspace/std/sliceobject.py`).
-        // Reuse the shared `normalize_slice` helper so negative-step
-        // defaults (`s[::-1]`, `s[5::-1]`) match list/tuple semantics.
+        // Use the shared adjusted slice count so very large steps do not
+        // overflow the index loop.
         let len = cps.len() as i64;
-        let (start, stop, step) = normalize_slice(index, len)?;
+        let (rs, rp, st) = crate::sliceobject::slice_unpack(
+            w_slice_get_start(index),
+            w_slice_get_stop(index),
+            w_slice_get_step(index),
+        )?;
+        let (start, _stop, step, slicelength) =
+            crate::sliceobject::slice_adjust_indices(rs, rp, st, len);
         let mut result = Wtf8Buf::new();
         let mut i = start;
-        while (step > 0 && i < stop) || (step < 0 && i > stop) {
+        for n in 0..slicelength {
             if i >= 0 && (i as usize) < cps.len() {
                 result.push(cps[i as usize]);
             }
-            i += step;
+            if n + 1 < slicelength {
+                i += step;
+            }
         }
         return Ok(w_str_from_wtf8(result));
     }

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -541,16 +541,12 @@ unsafe fn memoryview_slice_view(
             0
         };
         let (start, stop, step) = crate::baseobjspace::normalize_slice(index, count)?;
-        let slicelength = if step > 0 {
-            if stop > start {
-                (stop - start + step - 1) / step
-            } else {
-                0
-            }
-        } else if start > stop {
-            (start - stop - step - 1) / -step
-        } else {
+        let slicelength = if (step < 0 && stop >= start) || (step > 0 && start >= stop) {
             0
+        } else if step < 0 {
+            (stop - start + 1) / step + 1
+        } else {
+            (stop - start - 1) / step + 1
         };
         Ok(w_memoryview_new_derived(mv, |v| unsafe {
             v.new_slice(start, step, slicelength)

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -1856,9 +1856,7 @@ pub fn install_default_builtins(namespace: &mut DictStorage) {
         exception,
     );
     crate::dict_storage_store(namespace, "NameError", name_error);
-    // `exceptions.c` — `UnboundLocalError(NameError)`.  pyre raises a plain
-    // NameError for unbound locals, but the builtin name must exist for
-    // `except UnboundLocalError` clauses in copyreg / pickle.
+    // `exceptions.c` — `UnboundLocalError(NameError)`.
     crate::dict_storage_store(
         namespace,
         "UnboundLocalError",

--- a/pyre/pyre-interpreter/src/error.rs
+++ b/pyre/pyre-interpreter/src/error.rs
@@ -346,6 +346,7 @@ pub enum PyErrorKind {
     ValueError,
     ZeroDivisionError,
     NameError,
+    UnboundLocalError,
     IndexError,
     KeyError,
     AttributeError,
@@ -499,12 +500,18 @@ impl PyError {
         Self::new(PyErrorKind::NotImplementedError, msg)
     }
 
-    /// `_PyEval_FormatExcCheckArg` parity — a NameError (or
-    /// UnboundLocalError, which pyre maps to NameError) carrying the
+    /// `_PyEval_FormatExcCheckArg` parity — a NameError carrying the
     /// undefined `name` so `e.name` reads back once the instance is
     /// materialised (Python 3.10+).
     pub fn name_error_with_name(msg: impl Into<String>, name: &str) -> Self {
         let mut err = Self::new(PyErrorKind::NameError, msg);
+        err.w_name_context = pyre_object::w_str_new(name);
+        err
+    }
+
+    /// UnboundLocalError(NameError) carrying the undefined local name.
+    pub fn unbound_local_error_with_name(msg: impl Into<String>, name: &str) -> Self {
+        let mut err = Self::new(PyErrorKind::UnboundLocalError, msg);
         err.w_name_context = pyre_object::w_str_new(name);
         err
     }
@@ -860,6 +867,7 @@ impl PyError {
             PyErrorKind::ValueError => ExcKind::ValueError,
             PyErrorKind::ZeroDivisionError => ExcKind::ZeroDivisionError,
             PyErrorKind::NameError => ExcKind::NameError,
+            PyErrorKind::UnboundLocalError => ExcKind::UnboundLocalError,
             PyErrorKind::IndexError => ExcKind::IndexError,
             PyErrorKind::KeyError => ExcKind::KeyError,
             PyErrorKind::AttributeError => ExcKind::AttributeError,
@@ -929,6 +937,7 @@ impl PyError {
             ExcKind::ValueError => PyErrorKind::ValueError,
             ExcKind::ZeroDivisionError => PyErrorKind::ZeroDivisionError,
             ExcKind::NameError => PyErrorKind::NameError,
+            ExcKind::UnboundLocalError => PyErrorKind::UnboundLocalError,
             ExcKind::IndexError => PyErrorKind::IndexError,
             ExcKind::KeyError => PyErrorKind::KeyError,
             ExcKind::AttributeError => PyErrorKind::AttributeError,

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -2921,6 +2921,14 @@ impl OpcodeStepExecutor for PyFrame {
     // ── DeleteFast ──
 
     fn delete_fast(&mut self, idx: usize) -> Result<(), PyError> {
+        if self.locals_w()[idx].is_null() {
+            let code = unsafe { &*crate::pyframe_get_pycode(self) };
+            let name = code.varnames.get(idx).map(String::as_str).unwrap_or("");
+            return Err(PyError::unbound_local_error_with_name(
+                format!("local variable '{name}' referenced before assignment"),
+                name,
+            ));
+        }
         self.locals_w_mut()[idx] = PY_NULL;
         Ok(())
     }

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -1577,7 +1577,7 @@ impl LocalOpcodeHandler for PyFrame {
     fn load_local_checked_value(&mut self, idx: usize, name: &str) -> Result<Self::Value, PyError> {
         let value = self.locals_w()[idx];
         if value.is_null() {
-            return Err(PyError::name_error_with_name(
+            return Err(PyError::unbound_local_error_with_name(
                 format!("local variable '{name}' referenced before assignment"),
                 name,
             ));

--- a/pyre/pyre-interpreter/src/importing.rs
+++ b/pyre/pyre-interpreter/src/importing.rs
@@ -1219,7 +1219,7 @@ thread_local! {
     static SYS_IGNORE_ENVIRONMENT: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
     static SYS_ISOLATED: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
     static SYS_DEV_MODE: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
-    static SYS_UTF8_MODE: std::cell::Cell<i64> = const { std::cell::Cell::new(1) };
+    static SYS_UTF8_MODE: std::cell::Cell<i64> = const { std::cell::Cell::new(0) };
     static SYS_SAFE_PATH: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
 }
 

--- a/pyre/pyre-interpreter/src/objspace/descroperation.rs
+++ b/pyre/pyre-interpreter/src/objspace/descroperation.rs
@@ -1058,16 +1058,21 @@ pub(crate) unsafe fn str_repeat(s: PyObjectRef, n: PyObjectRef) -> PyResult {
     if count == 1 {
         return Ok(crate::type_methods::str_result_unchanged(s));
     }
-    let total = bytes
-        .len()
-        .checked_mul(count)
-        .ok_or_else(|| PyError::new(PyErrorKind::OverflowError, "repeated string is too long"))?;
-    if total > isize::MAX as usize {
+    // unicode_repeat: overflow is judged on the character count
+    // (length * nchars), not the WTF-8 byte length. A non-ASCII character
+    // is wider in WTF-8 than its Py_UCS storage, so the byte product may
+    // exceed isize::MAX while the character product does not. That case is
+    // a MemoryError from the allocation, not an OverflowError.
+    let char_len = w_str_len(s);
+    if char_len != 0 && count > isize::MAX as usize / char_len {
         return Err(PyError::new(
             PyErrorKind::OverflowError,
             "repeated string is too long",
         ));
     }
+    let Some(total) = bytes.len().checked_mul(count) else {
+        return Err(PyError::new(PyErrorKind::MemoryError, ""));
+    };
     let mut out: Vec<u8> = Vec::new();
     out.try_reserve_exact(total)
         .map_err(|_| PyError::new(PyErrorKind::MemoryError, ""))?;

--- a/pyre/pyre-interpreter/src/pyframe.rs
+++ b/pyre/pyre-interpreter/src/pyframe.rs
@@ -1411,9 +1411,6 @@ pub fn hidden_local(code: &CodeObject, idx: usize) -> bool {
 /// in the `[nvarnames, nvarnames + npure_cellvars)` band) reports "local
 /// variable '{name}' referenced before assignment"; a free variable reports
 /// "free variable '{name}' referenced before assignment in enclosing scope".
-/// pyre has no `UnboundLocalError`, so — like `load_local_checked_value` —
-/// both use `NameError`.
-///
 /// `idx` follows the `npure_cellvars` slot layout: `varnames` occupy
 /// `[0, nvarnames)`, pure cellvars (those not also varnames) the next
 /// `npure_cellvars` slots, then freevars.
@@ -1460,7 +1457,11 @@ pub fn deref_unbound_error(code: &CodeObject, idx: usize) -> crate::PyError {
     } else {
         format!("local variable '{name}' referenced before assignment")
     };
-    crate::PyError::name_error_with_name(message, name)
+    if is_free {
+        crate::PyError::name_error_with_name(message, name)
+    } else {
+        crate::PyError::unbound_local_error_with_name(message, name)
+    }
 }
 
 /// Whether calling a code object with these flags produces a suspended

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -15356,7 +15356,13 @@ fn dispatch_residual_call_iRd_kind(
                 ctx.trace_ctx.box_value(frame_opref),
                 ctx.trace_ctx.box_value(name_opref),
             ) {
-                if try_walker_store_name_cell_fold(ctx, frame_ptr, w_name_ptr, value_opref)? {
+                if try_walker_store_name_cell_fold(
+                    ctx,
+                    op.pc,
+                    frame_ptr,
+                    w_name_ptr,
+                    value_opref,
+                )? {
                     return Ok((DispatchOutcome::Continue, op.next_pc));
                 }
             }
@@ -16373,6 +16379,17 @@ fn walker_emit_fold_guard_with_snapshot(
 ) -> Result<(), DispatchError> {
     ctx.trace_ctx.record_guard(opcode, args, 0);
     walker_capture_snapshot_for_last_guard(ctx, op_pc)
+}
+
+fn walker_flush_guard_not_invalidated(
+    ctx: &mut WalkContext<'_, '_>,
+    op_pc: usize,
+) -> Result<(), DispatchError> {
+    if ctx.trace_ctx.pending_guard_not_invalidated_pc().is_some() {
+        ctx.trace_ctx.set_pending_guard_not_invalidated(None);
+        walker_emit_fold_guard_with_snapshot(ctx, op_pc, OpCode::GuardNotInvalidated, &[])?;
+    }
+    Ok(())
 }
 
 /// Record `int_eq(raw, const k)` and stamp its already-known concrete
@@ -19949,10 +19966,13 @@ fn try_walker_load_global_cell_fold(
     // a DIFFERENT present name on the same module dict.
     let abs_ns_const = ctx.trace_ctx.const_ref(w_globals as i64);
     let abs_slot_const = ctx.trace_ctx.const_int(usize::MAX as i64);
-    ctx.trace_ctx.record_op(
-        majit_ir::OpCode::QuasiimmutField,
-        &[abs_ns_const, abs_slot_const],
+    crate::state::record_namespace_quasiimmut_field(
+        ctx.trace_ctx,
+        abs_ns_const,
+        abs_slot_const,
+        u32::MAX,
     );
+    walker_flush_guard_not_invalidated(ctx, op_pc)?;
     // Guard (b): the builtins value for `name` must be unchanged.  The
     // `emit_namespace_cell_fold` below records a `QUASIIMMUT_FIELD` on the
     // builtins dict + the elidable cell lookup, so a rebind/del of the
@@ -20089,8 +20109,13 @@ fn emit_namespace_cell_fold(
 
     let ns_const = ctx.trace_ctx.const_ref(ns as i64);
     let slot_const = ctx.trace_ctx.const_int(slot as i64);
-    ctx.trace_ctx
-        .record_op(majit_ir::OpCode::QuasiimmutField, &[ns_const, slot_const]);
+    crate::state::record_namespace_quasiimmut_field(
+        ctx.trace_ctx,
+        ns_const,
+        slot_const,
+        slot as u32,
+    );
+    walker_flush_guard_not_invalidated(ctx, op_pc)?;
     // Bake the immovable cell as a `ConstPtr` (pypy `ConstPtr(cell)`).  The
     // `QuasiimmutField(ns, slot)` guard above invalidates the loop on a
     // rebind / strategy-version bump (`optimize_QUASIIMMUT_FIELD` watches the
@@ -20208,6 +20233,7 @@ fn try_walker_load_name_cell_fold(
 /// invalidating this loop.
 fn emit_namespace_cell_store_fold(
     ctx: &mut WalkContext<'_, '_>,
+    op_pc: usize,
     ns: pyre_object::PyObjectRef,
     slot: usize,
     stored: pyre_object::PyObjectRef,
@@ -20216,8 +20242,13 @@ fn emit_namespace_cell_store_fold(
 ) -> Result<(), DispatchError> {
     let ns_const = ctx.trace_ctx.const_ref(ns as i64);
     let slot_const = ctx.trace_ctx.const_int(slot as i64);
-    ctx.trace_ctx
-        .record_op(majit_ir::OpCode::QuasiimmutField, &[ns_const, slot_const]);
+    crate::state::record_namespace_quasiimmut_field(
+        ctx.trace_ctx,
+        ns_const,
+        slot_const,
+        slot as u32,
+    );
+    walker_flush_guard_not_invalidated(ctx, op_pc)?;
     // Bake the immovable cell as a `ConstPtr`, identical to the LOAD fold
     // (`emit_namespace_cell_fold`), so this `setfield_gc_i` and the LOAD's
     // `getfield_gc_i` canonicalise onto one trace-heapcache slot via
@@ -20284,6 +20315,7 @@ fn emit_namespace_cell_store_fold(
 /// cell + bumps the version for those, which the setfield fast path must not).
 fn try_walker_store_name_cell_fold(
     ctx: &mut WalkContext<'_, '_>,
+    op_pc: usize,
     frame_ptr: usize,
     w_name_ptr: usize,
     value_opref: OpRef,
@@ -20346,7 +20378,7 @@ fn try_walker_store_name_cell_fold(
     let Some(majit_ir::Value::Int(new_int)) = ctx.trace_ctx.box_value(raw_int) else {
         return Ok(false);
     };
-    emit_namespace_cell_store_fold(ctx, w_globals, slot, stored, raw_int, new_int)?;
+    emit_namespace_cell_store_fold(ctx, op_pc, w_globals, slot, stored, raw_int, new_int)?;
     Ok(true)
 }
 

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -7848,6 +7848,22 @@ fn fbw_loadattr_fold_enabled() -> bool {
     })
 }
 
+/// `PYRE_FBW_LOADMETHOD_FOLD` — gate the full-body-walker method-cache fold.
+/// When on, a monomorphic `obj.method(...)` dispatch folds the LOAD_ATTR
+/// method lookup to a constant descriptor plus guards, and folds the paired
+/// `load_method_self` residual to its constant binding decision.  Default ON;
+/// `0`/`false` opts out as the kill switch.
+fn fbw_loadmethod_fold_enabled() -> bool {
+    static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ENABLED.get_or_init(|| match std::env::var_os("PYRE_FBW_LOADMETHOD_FOLD") {
+        Some(v) => {
+            let v = v.to_string_lossy();
+            v != "0" && !v.eq_ignore_ascii_case("false")
+        }
+        None => true,
+    })
+}
+
 /// `PYRE_FBW_DELETE_FAST` — gate the full-body-walker DELETE_FAST lowering.
 /// Default ON; `0`/`false` opts back into the existing `abort_permanent`
 /// marker fallback for unsupported shapes.
@@ -13499,6 +13515,49 @@ fn inline_resolvable_seeded_frame_op(
     }
 }
 
+fn residual_call_helper_kind_in_body(
+    body_code: &[u8],
+    d: &DecodedOp,
+    callee_descr_refs: &[DescrRef],
+) -> Option<majit_ir::PyreHelperKind> {
+    let descr_offset = match d.key {
+        "residual_call_r_r/iRd>r" | "residual_call_r_i/iRd>i" | "residual_call_r_v/iRd" => {
+            let r_len_pc = d.pc + 2;
+            let r_len = *body_code.get(r_len_pc)? as usize;
+            1 + 1 + r_len
+        }
+        "residual_call_ir_r/iIRd>r" | "residual_call_ir_i/iIRd>i" | "residual_call_ir_v/iIRd" => {
+            let i_len_pc = d.pc + 2;
+            let i_width = 1 + *body_code.get(i_len_pc)? as usize;
+            let r_len_pc = d.pc + 1 + 1 + i_width;
+            let r_width = 1 + *body_code.get(r_len_pc)? as usize;
+            1 + i_width + r_width
+        }
+        _ => return None,
+    };
+    let descr_index = decode_descr_index(body_code, d, descr_offset);
+    callee_descr_refs
+        .get(descr_index)
+        .and_then(|descr| descr.as_call_descr())
+        .map(|cd| cd.get_extra_info().pyre_helper)
+}
+
+fn method_form_callee_body_supported(body_code: &[u8], callee_descr_refs: &[DescrRef]) -> bool {
+    let mut pc = 0usize;
+    while pc < body_code.len() {
+        let Some(d) = crate::jitcode_runtime::decode_op_at(body_code, pc) else {
+            return false;
+        };
+        if residual_call_helper_kind_in_body(body_code, &d, callee_descr_refs)
+            == Some(majit_ir::PyreHelperKind::LoadAttr)
+        {
+            return false;
+        }
+        pc = d.next_pc;
+    }
+    true
+}
+
 /// Active boxes for an inlined callee's OWN frame in a multi-frame snapshot
 /// (#68).  The fast-path inline predicate guarantees the callee does not own a
 /// virtualizable (any vable op declines the inline), so the owns_vable /
@@ -14116,11 +14175,10 @@ fn emit_loop_callee_ca_vable_scalar(
 ///   propagated as a trace abort (sound — aborts to the interpreter rather
 ///   than mixing inlined + residual emission).
 ///
-/// Arg layout: `r_args = [callable@0, null_or_self@1, positional@2..]`
-/// (the `call_fn` family carries no frame argument; the parent frame is
-/// resolved from the execution context inside `bh_call_fn_impl`, which
-/// prepends a non-null `null_or_self` as arg0).  Only the plain-call
-/// shape (concretely-NULL `null_or_self`) is inlined.
+/// Arg layout: `r_args = [callable@0, null_or_self@1, positional@2..]`.
+/// `bh_call_fn_impl` prepends a non-null `null_or_self` as arg0, so the
+/// inlined callee's positional locals are either `positional` for plain calls
+/// or `[null_or_self, positional...]` for method-form calls.
 /// Only exact-positional, closure-free callees are inlined.  Guards inside a
 /// pure-leaf callee resume to the caller's CALL boundary via the inherited
 /// single-frame snapshot (`entry_py_pc` / `outer_active_boxes`), which is
@@ -14148,6 +14206,7 @@ fn try_walker_inline_user_call(
     ctx: &mut WalkContext<'_, '_>,
     op: &DecodedOp,
     code: &[u8],
+    ref_operand_offset: usize,
     funcptr: OpRef,
     r_args: &[OpRef],
     call_descr: &dyn majit_ir::descr::CallDescr,
@@ -14190,9 +14249,16 @@ fn try_walker_inline_user_call(
     if r_args.is_empty() {
         return Ok(None);
     }
-    let arg_concretes = read_ref_var_list_concrete(code, op, 1, ctx);
+    let mut arg_concretes = read_ref_var_list_concrete(code, op, ref_operand_offset, ctx);
     if r_args.len() < 2 {
         return Ok(None);
+    }
+    for i in 0..2 {
+        if matches!(arg_concretes.get(i), Some(ConcreteValue::Null)) {
+            if let Some(majit_ir::Value::Ref(r)) = ctx.trace_ctx.box_value(r_args[i]) {
+                arg_concretes[i] = ConcreteValue::Ref(r.as_usize() as pyre_object::PyObjectRef);
+            }
+        }
     }
     let ConcreteValue::Ref(callable) = arg_concretes[0] else {
         return Ok(None);
@@ -14200,24 +14266,25 @@ fn try_walker_inline_user_call(
     if callable.is_null() {
         return Ok(None);
     }
-    // Plain-call shape only: a non-null `null_or_self` is a method
-    // receiver `bh_call_fn_impl` would prepend as arg0; an unknown
-    // concrete cannot be proven plain.  Either way, decline to the
-    // residual call.
     let ConcreteValue::Ref(null_or_self) = arg_concretes[1] else {
         return Ok(None);
     };
-    if !null_or_self.is_null() {
-        return Ok(None);
+    let method_form = !null_or_self.is_null();
+    let mut callee_args = Vec::with_capacity(r_args.len().saturating_sub(1));
+    let mut callee_arg_concretes = Vec::with_capacity(arg_concretes.len().saturating_sub(1));
+    if method_form {
+        callee_args.push(r_args[1]);
+        callee_arg_concretes.push(arg_concretes[1]);
     }
+    callee_args.extend_from_slice(&r_args[2..]);
+    callee_arg_concretes.extend_from_slice(&arg_concretes[2..]);
     let Some((w_code, nparams, has_closure)) = (unsafe { resolve_inlinable_callee(callable) })
     else {
         return Ok(None);
     };
-    let nargs_passed = r_args.len() - 2;
     // Only exact-positional, closure-free calls: every callee local [0..nparams]
     // is bound from a passed arg, none from defaults/varargs/cells.
-    if has_closure || nargs_passed != nparams {
+    if has_closure || callee_args.len() != nparams {
         return Ok(None);
     }
     // Bound recursive inlining at `max_unroll_recursion`: a callee already
@@ -14245,6 +14312,9 @@ fn try_walker_inline_user_call(
     else {
         return Ok(None);
     };
+    if method_form && !method_form_callee_body_supported(body.code, callee_descr_refs) {
+        return Ok(None);
+    }
     if std::env::var("PYRE_FBW_INLINE_DIAG").is_ok() {
         let mut pc = 0usize;
         let mut shown = 0;
@@ -14377,6 +14447,14 @@ fn try_walker_inline_user_call(
         // the multiframe fast path can serve declines to the trait leg
         // (`FBW_DECLINED_KEYS`).  Self-recursive calls were already routed to
         // the `CALL_ASSEMBLER` fold or plain residual path above (`Ok(None)`).
+        //
+        // For method-form calls reached through the LOAD_METHOD fold, decline
+        // locally instead.  The fold's first-order win is the guarded method
+        // cache; making an uninlineable method body blacklist the whole outer
+        // loop turns a correct specialization into a compile regression.
+        if method_form {
+            return Ok(None);
+        }
         return Err(DispatchError::LoopBearingCalleeInlineUnsupported { pc: op.pc });
     }
 
@@ -14439,8 +14517,8 @@ fn try_walker_inline_user_call(
         if reg >= callee_regs_r.len() {
             return Ok(None);
         }
-        callee_regs_r[reg] = r_args[2 + i];
-        callee_concrete_r[reg] = arg_concretes[2 + i];
+        callee_regs_r[reg] = callee_args[i];
+        callee_concrete_r[reg] = callee_arg_concretes[i];
     }
 
     // #68: seed the callee's `frame` / `ec` reds that the codewriter
@@ -14585,7 +14663,7 @@ fn try_walker_inline_user_call(
 
             let pycode_const = ctx.trace_ctx.const_ref(w_code as i64);
             let w_globals_obj_const = ctx.trace_ctx.const_ref(inline_consts.w_globals as i64);
-            let param_boxes: Vec<OpRef> = (0..nparams).map(|i| r_args[2 + i]).collect();
+            let param_boxes: Vec<OpRef> = (0..nparams).map(|i| callee_args[i]).collect();
             let callee_frame = crate::helpers::emit_new_pyframe_inline_with_params(
                 ctx.trace_ctx,
                 &param_boxes,
@@ -14880,10 +14958,10 @@ fn try_walker_inline_user_call(
             sub_wc.callee_shadow.as_mut().unwrap().fold_frame_reg = callee_portal_frame_reg;
             for i in 0..nparams {
                 let slot = i as i64;
-                let value = r_args[2 + i];
+                let value = callee_args[i];
                 let concrete = sub_wc
                     .trace_ctx
-                    .concrete_of_opref(r_args[2 + i])
+                    .concrete_of_opref(callee_args[i])
                     .unwrap_or(majit_ir::Value::Void);
                 let shadow = sub_wc.callee_shadow.as_mut().unwrap();
                 shadow.set_opref(slot, value);
@@ -15003,7 +15081,7 @@ fn try_walker_inline_user_call(
                                 Value::Float(v) => Some(ConcreteValue::Float(v)),
                                 Value::Void => None,
                             })
-                            .or_else(|| arg_concretes.get(2 + slot).copied())?;
+                            .or_else(|| callee_arg_concretes.get(slot).copied())?;
                         if matches!(value, ConcreteValue::Null | ConcreteValue::Bool(_)) {
                             return None;
                         }
@@ -15021,7 +15099,8 @@ fn try_walker_inline_user_call(
                         unsafe { &*outer_jc.payload.code_ptr },
                         call_py_pc + 1,
                     );
-                    let Some(ConcreteValue::Ref(x_arg)) = arg_concretes.get(2).copied() else {
+                    let Some(ConcreteValue::Ref(x_arg)) = callee_arg_concretes.first().copied()
+                    else {
                         return None;
                     };
                     Some(MidBodyPayload {
@@ -15216,6 +15295,7 @@ fn dispatch_residual_call_iRd_kind(
         ctx,
         op,
         code,
+        1,
         funcptr,
         &r_args,
         call_descr,
@@ -15370,13 +15450,8 @@ fn dispatch_residual_call_iRd_kind(
                 ctx.trace_ctx.box_value(frame_opref),
                 ctx.trace_ctx.box_value(name_opref),
             ) {
-                if try_walker_store_name_cell_fold(
-                    ctx,
-                    op.pc,
-                    frame_ptr,
-                    w_name_ptr,
-                    value_opref,
-                )? {
+                if try_walker_store_name_cell_fold(ctx, op.pc, frame_ptr, w_name_ptr, value_opref)?
+                {
                     return Ok((DispatchOutcome::Continue, op.next_pc));
                 }
             }
@@ -17288,16 +17363,8 @@ fn try_walker_specialize_load_attr(
     };
     // Resolve the attribute name from the jitcode's own PyCode `co_names`
     // (mirrors `bh_load_attr_fn`; the codewriter passes the raw co_names index).
-    let name = unsafe {
-        let code_ptr = pyre_interpreter::w_code_get_ptr(w_code_ptr as pyre_object::PyObjectRef);
-        if code_ptr.is_null() {
-            return Ok(None);
-        }
-        let code = &*(code_ptr as *const pyre_interpreter::CodeObject);
-        match pyre_interpreter::pyframe::load_name_from_code(code, name_idx) {
-            Some(n) => n.to_string(),
-            None => return Ok(None),
-        }
+    let Some(name) = walker_load_name_from_code(w_code_ptr, name_idx) else {
+        return Ok(None);
     };
     // `mapdict.py:1495-1533` resolution, returning the fold ingredients (the
     // read is left to the caller so it can be folded to a guarded inline read).
@@ -17344,6 +17411,242 @@ fn try_walker_specialize_load_attr(
     let idx_const = ctx.trace_ctx.const_int(storageindex as i64);
     let value = crate::state::trace_items_block_getitem_value(ctx.trace_ctx, block, idx_const);
     write_residual_call_result_to_dst(ctx, op_pc, dst, dst_bank, value)?;
+    Ok(Some(()))
+}
+
+fn walker_load_name_from_code(w_code_ptr: usize, name_idx: usize) -> Option<String> {
+    unsafe {
+        let code_ptr = pyre_interpreter::w_code_get_ptr(w_code_ptr as pyre_object::PyObjectRef);
+        if code_ptr.is_null() {
+            return None;
+        }
+        let code = &*(code_ptr as *const pyre_interpreter::CodeObject);
+        pyre_interpreter::pyframe::load_name_from_code(code, name_idx).map(ToString::to_string)
+    }
+}
+
+fn walker_record_getfield_gc_i_uncached(
+    ctx: &mut WalkContext<'_, '_>,
+    obj: OpRef,
+    descr: DescrRef,
+) -> OpRef {
+    let opcode = if descr.is_always_pure() {
+        OpCode::GetfieldGcPureI
+    } else {
+        OpCode::GetfieldGcI
+    };
+    ctx.trace_ctx.record_op_with_descr(opcode, &[obj], descr)
+}
+
+fn walker_record_getfield_gc_r_uncached(
+    ctx: &mut WalkContext<'_, '_>,
+    obj: OpRef,
+    descr: DescrRef,
+) -> OpRef {
+    let opcode = if descr.is_always_pure() {
+        OpCode::GetfieldGcPureR
+    } else {
+        OpCode::GetfieldGcR
+    };
+    ctx.trace_ctx.record_op_with_descr(opcode, &[obj], descr)
+}
+
+/// True only when this `LoadAttr` residual is immediately consumed by the
+/// paired `load_method_self(obj, attr, code, name_idx)` residual emitted for
+/// `LOAD_METHOD`.  Plain `LOAD_ATTR` of a function descriptor must keep the
+/// normal bound-method semantics and cannot be rewritten to the raw function.
+fn next_op_is_load_method_self_for_attr(
+    code: &[u8],
+    op: &DecodedOp,
+    ctx: &WalkContext<'_, '_>,
+    attr_dst_reg: usize,
+) -> bool {
+    let Some(mut next) = crate::jitcode_runtime::decode_op_at(code, op.next_pc) else {
+        return false;
+    };
+    while next.opname == "live"
+        || next.opname.starts_with("setarrayitem_vable")
+        || next.opname.starts_with("setfield_vable")
+    {
+        let Some(after_live) = crate::jitcode_runtime::decode_op_at(code, next.next_pc) else {
+            return false;
+        };
+        next = after_live;
+    }
+    if next.key != "residual_call_ir_r/iIRd>r" {
+        return false;
+    }
+    let i_len_pc = next.pc + 2;
+    let Some(&i_len_byte) = code.get(i_len_pc) else {
+        return false;
+    };
+    let i_width = 1 + i_len_byte as usize;
+    let r_len_pc = next.pc + 1 + 1 + i_width;
+    let Some(&r_len_byte) = code.get(r_len_pc) else {
+        return false;
+    };
+    let r_len = r_len_byte as usize;
+    if r_len < 2 {
+        return false;
+    }
+    let Some(&attr_reg_byte) = code.get(r_len_pc + 1 + 1) else {
+        return false;
+    };
+    if attr_reg_byte as usize != attr_dst_reg {
+        return false;
+    }
+    let r_width = 1 + r_len;
+    let descr_offset = 1 + i_width + r_width;
+    let descr_index = decode_descr_index(code, &next, descr_offset);
+    ctx.descr_refs
+        .get(descr_index)
+        .and_then(|descr| descr.as_call_descr())
+        .is_some_and(|cd| {
+            cd.get_extra_info().pyre_helper == majit_ir::PyreHelperKind::LoadMethodSelf
+        })
+}
+
+/// `callmethod.py:25-85 LOAD_METHOD` method-cache fold for the
+/// codewriter's method-form `LOAD_ATTR` residual.  The safety oracle is the
+/// interpreter's `load_method_fast_path`: it declines custom
+/// `__getattribute__`, uncacheable types, non-function descriptors,
+/// shadowing instance attributes, and non-instance receivers.  On success the
+/// walker emits the guards that keep that decision stable, then writes
+/// `w_descr` as a green constant so the following `CALL` can use the existing
+/// constant-callee inline path.
+#[allow(clippy::too_many_arguments)]
+fn try_walker_specialize_load_method_attr(
+    ctx: &mut WalkContext<'_, '_>,
+    op_pc: usize,
+    obj: OpRef,
+    w_code_ptr: usize,
+    name_idx: usize,
+    dst: usize,
+    dst_bank: char,
+) -> Result<Option<()>, DispatchError> {
+    if !ctx.is_authoritative_executor || !ctx.is_full_body_walk || dst_bank != 'r' {
+        return Ok(None);
+    }
+    let Some(concrete_obj) = walker_concrete_ref_object(ctx, obj) else {
+        return Ok(None);
+    };
+    let Some(name) = walker_load_name_from_code(w_code_ptr, name_idx) else {
+        return Ok(None);
+    };
+    if name.contains("__") {
+        return Ok(None);
+    }
+    let Some((w_type, version_tag, w_descr)) =
+        (unsafe { pyre_interpreter::load_method_fast_path(concrete_obj, &name) })
+    else {
+        return Ok(None);
+    };
+    if unsafe { resolve_inlinable_callee(w_descr) }.is_none() {
+        return Ok(None);
+    }
+    let map = unsafe {
+        let inst = &*(concrete_obj as *const pyre_object::W_ObjectObject);
+        inst.map
+    };
+    if map.is_null() {
+        return Ok(None);
+    }
+
+    // guard_class(obj, &INSTANCE_TYPE): receiver is a user instance, so the
+    // `w_class` and map fields read below are valid.
+    let instance_type_addr = &pyre_object::pyobject::INSTANCE_TYPE as *const _ as i64;
+    if !ctx.trace_ctx.heap_cache().is_class_known(obj) {
+        let type_const = ctx.trace_ctx.const_int(instance_type_addr);
+        walker_emit_fold_guard_with_snapshot(ctx, op_pc, OpCode::GuardClass, &[obj, type_const])?;
+        ctx.trace_ctx
+            .heap_cache_mut()
+            .class_now_known(obj, instance_type_addr);
+    }
+
+    // Pin the Python-level receiver class (`w_class`) exactly.  This is the
+    // per-frame method namespace anchor: a subclass with the same instance
+    // payload vtable side-exits instead of reusing the caller's method.
+    let w_class_op = walker_record_getfield_gc_r_uncached(ctx, obj, crate::descr::w_class_descr());
+    let w_type_const = ctx.trace_ctx.const_ref(w_type as i64);
+    walker_emit_fold_guard_with_snapshot(
+        ctx,
+        op_pc,
+        OpCode::GuardValue,
+        &[w_class_op, w_type_const],
+    )?;
+    ctx.trace_ctx
+        .heap_cache_mut()
+        .replace_box(w_class_op, w_type_const);
+
+    // typeobject.py:506 `promote(self.version_tag())`: class mutation or method
+    // reassignment bumps `_version_tag`, so the old `w_descr` side-exits.
+    let vt_op = walker_record_getfield_gc_i_uncached(
+        ctx,
+        w_type_const,
+        crate::descr::type_version_tag_descr(),
+    );
+    let vt_const = ctx.trace_ctx.const_int(version_tag as i64);
+    walker_emit_fold_guard_with_snapshot(ctx, op_pc, OpCode::GuardValue, &[vt_op, vt_const])?;
+    ctx.trace_ctx.heap_cache_mut().replace_box(vt_op, vt_const);
+
+    // mapdict.py LOAD_ATTR caching: guard the instance map so adding a
+    // shadowing `obj.method` attribute changes shape and side-exits before the
+    // constant descriptor is reused.
+    let map_op = walker_record_getfield_gc_i_uncached(ctx, obj, crate::descr::object_map_descr());
+    let map_const = ctx.trace_ctx.const_int(map as i64);
+    walker_emit_fold_guard_with_snapshot(ctx, op_pc, OpCode::GuardValue, &[map_op, map_const])?;
+    ctx.trace_ctx
+        .heap_cache_mut()
+        .replace_box(map_op, map_const);
+
+    let method_const = ctx.trace_ctx.const_ref(w_descr as i64);
+    write_residual_call_result_to_dst(ctx, op_pc, dst, dst_bank, method_const)?;
+    Ok(Some(()))
+}
+
+/// Fold `bh_load_method_self_fn(obj, attr, code, name_idx)` once both the
+/// receiver and the attribute are concrete.  The method-attribute fold above
+/// already guards class, type version, and instance map; this second residual
+/// is only the pure `compute_load_method_bound` binding decision.  A plain
+/// instance-method bind writes the original red receiver box, not a baked
+/// `ConstRef`, matching `callmethod.py:68 f.pushvalue(w_obj)`.
+#[allow(clippy::too_many_arguments)]
+fn try_walker_fold_load_method_self(
+    ctx: &mut WalkContext<'_, '_>,
+    op_pc: usize,
+    obj: OpRef,
+    attr: OpRef,
+    _attr_reg: usize,
+    w_code_ptr: usize,
+    name_idx: usize,
+    dst: usize,
+    dst_bank: char,
+) -> Result<Option<()>, DispatchError> {
+    if !ctx.is_authoritative_executor || !ctx.is_full_body_walk || dst_bank != 'r' {
+        return Ok(None);
+    }
+    let Some(concrete_obj) = walker_concrete_ref_object(ctx, obj) else {
+        return Ok(None);
+    };
+    let Some(concrete_attr) = walker_concrete_ref_object(ctx, attr) else {
+        return Ok(None);
+    };
+    if unsafe { pyre_object::is_method(concrete_attr) } {
+        return Ok(None);
+    };
+    let Some(name) = walker_load_name_from_code(w_code_ptr, name_idx) else {
+        return Ok(None);
+    };
+    let bound =
+        pyre_interpreter::eval::compute_load_method_bound(concrete_obj, concrete_attr, &name);
+    let bound_op = if std::ptr::eq(bound, concrete_obj) {
+        obj
+    } else if bound == pyre_object::PY_NULL {
+        ctx.trace_ctx.const_ref(pyre_object::PY_NULL as i64)
+    } else {
+        return Ok(None);
+    };
+    write_residual_call_result_to_dst(ctx, op_pc, dst, dst_bank, bound_op)?;
     Ok(Some(()))
 }
 
@@ -20451,6 +20754,26 @@ fn dispatch_residual_call_iIRd_kind(
     // `dispatch_residual_call_iRd_kind` for the rationale.
     do_jit_force_virtual_guard(ei, op.pc)?;
 
+    // Method-form `CALL` helpers lower through the mixed int/ref residual
+    // shape (`bh_call_fn_N(callable, null_or_self, args...)` carries the call
+    // arity in the Int list).  Share the same user-function inline gate as the
+    // plain Ref-only residual, but read the concrete Ref shadows from the
+    // shifted R-list offset.
+    if let Some(inlined) = try_walker_inline_user_call(
+        ctx,
+        op,
+        code,
+        1 + i_width,
+        funcptr,
+        &r_args,
+        call_descr,
+        ei.pyre_helper,
+        dst_bank,
+        dst,
+    )? {
+        return Ok(inlined);
+    }
+
     // LoadConst fold: the LOAD_CONST helper (oopspec `LoadConst`, set
     // codewriter-side at flatten.rs
     // `build_residual_call_ir_r_single_ref_plain_insn_from_operands`)
@@ -20676,6 +20999,77 @@ fn dispatch_residual_call_iIRd_kind(
                     ctx,
                     op.pc,
                     obj_opref,
+                    w_code_ptr,
+                    namei as usize,
+                    dst,
+                    dst_bank,
+                )?
+                .is_some()
+                {
+                    return Ok((DispatchOutcome::Continue, op.next_pc));
+                }
+            }
+        }
+    }
+    if ctx.is_authoritative_executor
+        && ctx.is_full_body_walk
+        && ei.pyre_helper == majit_ir::PyreHelperKind::LoadAttr
+        && fbw_loadmethod_fold_enabled()
+        && next_op_is_load_method_self_for_attr(code, op, ctx, dst)
+    {
+        if let (Some(&obj_opref), Some(&code_opref), Some(&namei_opref)) =
+            (r_args.first(), r_args.get(1), i_args.first())
+        {
+            if let (
+                Some(majit_ir::Value::Ref(majit_ir::GcRef(w_code_ptr))),
+                Some(majit_ir::Value::Int(namei)),
+            ) = (
+                ctx.trace_ctx.box_value(code_opref),
+                ctx.trace_ctx.box_value(namei_opref),
+            ) {
+                if try_walker_specialize_load_method_attr(
+                    ctx,
+                    op.pc,
+                    obj_opref,
+                    w_code_ptr,
+                    namei as usize,
+                    dst,
+                    dst_bank,
+                )?
+                .is_some()
+                {
+                    return Ok((DispatchOutcome::Continue, op.next_pc));
+                }
+            }
+        }
+    }
+    if ctx.is_authoritative_executor
+        && ctx.is_full_body_walk
+        && ei.pyre_helper == majit_ir::PyreHelperKind::LoadMethodSelf
+        && fbw_loadmethod_fold_enabled()
+    {
+        if let (Some(&namei_opref), Some(&obj_opref), Some(&attr_opref), Some(&code_opref)) =
+            (i_args.first(), r_args.first(), r_args.get(1), r_args.get(2))
+        {
+            let r_len_pc = op.pc + 1 + 1 + i_width;
+            let attr_reg = code
+                .get(r_len_pc + 1 + 1)
+                .copied()
+                .map(usize::from)
+                .unwrap_or(usize::MAX);
+            if let (
+                Some(majit_ir::Value::Int(namei)),
+                Some(majit_ir::Value::Ref(majit_ir::GcRef(w_code_ptr))),
+            ) = (
+                ctx.trace_ctx.box_value(namei_opref),
+                ctx.trace_ctx.box_value(code_opref),
+            ) {
+                if try_walker_fold_load_method_self(
+                    ctx,
+                    op.pc,
+                    obj_opref,
+                    attr_opref,
+                    attr_reg,
                     w_code_ptr,
                     namei as usize,
                     dst,

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -14257,8 +14257,7 @@ fn try_walker_inline_user_call(
         if matches!(arg_concretes.get(i), Some(ConcreteValue::Null)) {
             if let Some(majit_ir::Value::Ref(r)) = ctx.trace_ctx.box_value(r_args[i]) {
                 if r != majit_ir::GcRef::NO_CONCRETE && r.as_usize() != 0 {
-                    arg_concretes[i] =
-                        ConcreteValue::Ref(r.as_usize() as pyre_object::PyObjectRef);
+                    arg_concretes[i] = ConcreteValue::Ref(r.as_usize() as pyre_object::PyObjectRef);
                 }
             }
         }

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -7848,6 +7848,20 @@ fn fbw_loadattr_fold_enabled() -> bool {
     })
 }
 
+/// `PYRE_FBW_DELETE_FAST` — gate the full-body-walker DELETE_FAST lowering.
+/// Default ON; `0`/`false` opts back into the existing `abort_permanent`
+/// marker fallback for unsupported shapes.
+pub(crate) fn fbw_delete_fast_enabled() -> bool {
+    static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ENABLED.get_or_init(|| match std::env::var_os("PYRE_FBW_DELETE_FAST") {
+        Some(v) => {
+            let v = v.to_string_lossy();
+            v != "0" && !v.eq_ignore_ascii_case("false")
+        }
+        None => true,
+    })
+}
+
 /// `PYRE_FBW_INLINE_NSFOLD` (default ON) — gates resolving an inlined callee's
 /// `getfield_vable_r` namespace(idx5)/pycode(idx1) read from the callee's
 /// compile-time [`InlineCalleeConsts`] on the MULTIFRAME path (seeded virtual

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -14256,7 +14256,10 @@ fn try_walker_inline_user_call(
     for i in 0..2 {
         if matches!(arg_concretes.get(i), Some(ConcreteValue::Null)) {
             if let Some(majit_ir::Value::Ref(r)) = ctx.trace_ctx.box_value(r_args[i]) {
-                arg_concretes[i] = ConcreteValue::Ref(r.as_usize() as pyre_object::PyObjectRef);
+                if r != majit_ir::GcRef::NO_CONCRETE && r.as_usize() != 0 {
+                    arg_concretes[i] =
+                        ConcreteValue::Ref(r.as_usize() as pyre_object::PyObjectRef);
+                }
             }
         }
     }

--- a/pyre/pyre-jit-trace/src/opcode_handler_impls.rs
+++ b/pyre/pyre-jit-trace/src/opcode_handler_impls.rs
@@ -828,12 +828,7 @@ impl pyre_interpreter::NamespaceOpcodeHandler for crate::state::MIFrame {
             //    trace-time cell fold into call_pure_results.
             // 3. CALL_PURE_R(helper, ns, slot) — elidable cell lookup folds
             //    to the constant cell (or raw value) pointer.
-            crate::state::record_namespace_quasiimmut_field(
-                ctx,
-                ns_const,
-                slot_const,
-                slot as u32,
-            );
+            crate::state::record_namespace_quasiimmut_field(ctx, ns_const, slot_const, slot as u32);
             crate::state::MIFrame::flush_guard_not_invalidated(_this, ctx);
             let lookup_fn = crate::helpers::jit_namespace_cell_lookup as *const ();
             let lookup_args = [ns_const, slot_const];

--- a/pyre/pyre-jit-trace/src/opcode_handler_impls.rs
+++ b/pyre/pyre-jit-trace/src/opcode_handler_impls.rs
@@ -828,7 +828,13 @@ impl pyre_interpreter::NamespaceOpcodeHandler for crate::state::MIFrame {
             //    trace-time cell fold into call_pure_results.
             // 3. CALL_PURE_R(helper, ns, slot) — elidable cell lookup folds
             //    to the constant cell (or raw value) pointer.
-            ctx.record_op(majit_ir::OpCode::QuasiimmutField, &[ns_const, slot_const]);
+            crate::state::record_namespace_quasiimmut_field(
+                ctx,
+                ns_const,
+                slot_const,
+                slot as u32,
+            );
+            crate::state::MIFrame::flush_guard_not_invalidated(_this, ctx);
             let lookup_fn = crate::helpers::jit_namespace_cell_lookup as *const ();
             let lookup_args = [ns_const, slot_const];
             let lookup_arg_types = [majit_ir::Type::Ref, majit_ir::Type::Int];

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -3665,6 +3665,27 @@ pub(crate) fn module_dict_cell_value_direct(obj: PyObjectRef, slot: usize) -> Op
     unsafe { pyre_object::dictmultiobject::module_dict_cell_at(obj, slot) }
 }
 
+/// pyjitpl.py:1074-1089 `opimpl_record_quasiimmut_field` for namespace
+/// slot folds: record the dependency marker and arm the pending
+/// GUARD_NOT_INVALIDATED once per heapcache epoch.
+pub(crate) fn record_namespace_quasiimmut_field(
+    ctx: &mut TraceCtx,
+    obj: OpRef,
+    slot: OpRef,
+    slot_index: u32,
+) {
+    if ctx.heap_cache().is_quasi_immut_known(obj, slot_index) {
+        ctx.profiler()
+            .count_ops(OpCode::QuasiimmutField, majit_metainterp::counters::HEAPCACHED_OPS);
+        return;
+    }
+    ctx.heap_cache_mut().quasi_immut_now_known(obj, slot_index);
+    ctx.record_op(OpCode::QuasiimmutField, &[obj, slot]);
+    if ctx.heap_cache_mut().check_and_clear_guard_not_invalidated() {
+        ctx.set_pending_guard_not_invalidated(Some(ctx.last_traced_pc));
+    }
+}
+
 /// virtualizable.py:44 + interp_jit.py:25-31 —
 /// `locals_cells_stack_w[*]` is declared as a W_Root array, so every
 /// item's JIT type is GCREF (Type::Ref). W_IntObject/W_FloatObject are

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -1939,6 +1939,15 @@ pub(crate) fn concrete_value_from_slot(obj: PyObjectRef) -> ConcreteValue {
     ConcreteValue::from_pyobj(obj)
 }
 
+fn concrete_value_from_ir_value(value: majit_ir::Value) -> ConcreteValue {
+    match value {
+        Value::Ref(gc_ref) => concrete_value_from_slot(gc_ref.0 as PyObjectRef),
+        Value::Int(n) => ConcreteValue::Int(n),
+        Value::Float(n) => ConcreteValue::Float(n),
+        Value::Void => ConcreteValue::Null,
+    }
+}
+
 impl ConcreteValue {
     /// Convert from PyObjectRef (unbox if possible).
     /// Null pointers become ConcreteValue::Null ("untracked").
@@ -8842,6 +8851,24 @@ impl JitState for PyreJitState {
             bridge_array_len,
             &vable_array_values,
         );
+        sym.concrete_locals = (0..nlocals)
+            .map(|i| {
+                live_array_values
+                    .get(i)
+                    .copied()
+                    .map(concrete_value_from_ir_value)
+                    .unwrap_or(ConcreteValue::Ref(pyre_object::PY_NULL))
+            })
+            .collect();
+        sym.concrete_stack = (0..stack_only)
+            .map(|i| {
+                live_array_values
+                    .get(nlocals + i)
+                    .copied()
+                    .map(concrete_value_from_ir_value)
+                    .unwrap_or(ConcreteValue::Ref(pyre_object::PY_NULL))
+            })
+            .collect();
         let mut concrete_values = Vec::with_capacity(vable_scalar_values.len() + bridge_array_len);
         concrete_values.extend_from_slice(&vable_scalar_values);
         let taken_concrete = live_array_values.len().min(bridge_array_len);
@@ -12837,13 +12864,14 @@ pub(crate) fn assemble_bridge_inline_pending(
     // locals_cells_stack_w is a W_Root array — every live slot is Ref.
     sym.symbolic_local_types = vec![Type::Ref; nlocals];
     sym.symbolic_stack_types = vec![Type::Ref; valuestackdepth - nlocals];
-    // Box-identity shadow: unbox per the FAST branch (`ConcreteValue::
-    // from_pyobj`), so a boxed int/float local tracks as Int/Float.
+    // Box-identity shadow: unbox per the FAST branch, preserving PY_NULL
+    // frame slots as Ref(PY_NULL) so uninitialized locals stay distinct from
+    // untracked values.
     sym.concrete_locals = (0..nlocals)
-        .map(|k| ConcreteValue::from_pyobj(recipe_slot_to_pyobj(recipe.concrete_r[k])))
+        .map(|k| concrete_value_from_slot(recipe_slot_to_pyobj(recipe.concrete_r[k])))
         .collect();
     sym.concrete_stack = (nlocals..valuestackdepth)
-        .map(|k| ConcreteValue::from_pyobj(recipe_slot_to_pyobj(recipe.concrete_r[k])))
+        .map(|k| concrete_value_from_slot(recipe_slot_to_pyobj(recipe.concrete_r[k])))
         .collect();
     sym.concrete_namespace = w_globals;
     sym.concrete_execution_context = execution_context;

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -3675,8 +3675,10 @@ pub(crate) fn record_namespace_quasiimmut_field(
     slot_index: u32,
 ) {
     if ctx.heap_cache().is_quasi_immut_known(obj, slot_index) {
-        ctx.profiler()
-            .count_ops(OpCode::QuasiimmutField, majit_metainterp::counters::HEAPCACHED_OPS);
+        ctx.profiler().count_ops(
+            OpCode::QuasiimmutField,
+            majit_metainterp::counters::HEAPCACHED_OPS,
+        );
         return;
     }
     ctx.heap_cache_mut().quasi_immut_now_known(obj, slot_index);

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -2427,6 +2427,10 @@ impl MIFrame {
         // reaches store_local_value through `setarrayitem_vable_r`; use the
         // same virtualizable/local-slot writer with the unbound sentinel.
         let null = ctx.const_ref(pyre_object::PY_NULL as i64);
+        if idx < self.sym().concrete_locals.len() {
+            self.sym_mut().concrete_locals[idx] =
+                crate::state::ConcreteValue::Ref(pyre_object::PY_NULL);
+        }
         self.store_local_value(ctx, idx, null, ConcreteValue::Ref(pyre_object::PY_NULL))
     }
 
@@ -7551,8 +7555,37 @@ impl MIFrame {
         // falls through to the codewriter's `abort_permanent` fallback.
         if let Instruction::DeleteFast { var_num } = instruction {
             if crate::jitcode_dispatch::fbw_delete_fast_enabled() {
+                let idx = var_num.get(op_arg).as_usize();
+                let name = if idx < pyre_interpreter::code_varnames_len(code) {
+                    code.varnames[idx].as_ref()
+                } else {
+                    "<cell>"
+                };
+                let concrete_unbound = self
+                    .sym()
+                    .concrete_locals
+                    .get(idx)
+                    .copied()
+                    .is_some_and(|v| v == crate::state::ConcreteValue::Ref(pyre_object::PY_NULL));
+                let traced_unbound = self.with_ctx(|this, ctx| {
+                    let value = this.load_local_value(ctx, idx)?;
+                    Ok::<_, PyError>(
+                        ctx.box_value(value)
+                            == Some(Value::Ref(GcRef(pyre_object::PY_NULL as usize))),
+                    )
+                })?;
+                if concrete_unbound || traced_unbound {
+                    return Err(PyError::unbound_local_error_with_name(
+                        format!("local variable '{name}' referenced before assignment"),
+                        name,
+                    ));
+                }
                 self.with_ctx(|this, ctx| {
-                    this.delete_local_value(ctx, var_num.get(op_arg).as_usize())
+                    let opref = crate::state::MIFrame::load_local_value(this, ctx, idx)?;
+                    if this.value_type(opref) == majit_ir::Type::Ref {
+                        crate::state::MIFrame::guard_nonnull(this, ctx, opref);
+                    }
+                    this.delete_local_value(ctx, idx)
                 })?;
                 return Ok(Some(pyre_interpreter::StepResult::Continue));
             }

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -2427,12 +2427,7 @@ impl MIFrame {
         // reaches store_local_value through `setarrayitem_vable_r`; use the
         // same virtualizable/local-slot writer with the unbound sentinel.
         let null = ctx.const_ref(pyre_object::PY_NULL as i64);
-        self.store_local_value(
-            ctx,
-            idx,
-            null,
-            ConcreteValue::Ref(pyre_object::PY_NULL),
-        )
+        self.store_local_value(ctx, idx, null, ConcreteValue::Ref(pyre_object::PY_NULL))
     }
 
     pub(crate) fn set_next_instr(&mut self, _ctx: &mut TraceCtx, target: usize) {
@@ -7387,8 +7382,7 @@ impl MIFrame {
             let is_unbound = self.with_ctx(|this, ctx| {
                 let value = this.load_local_value(ctx, idx)?;
                 Ok::<_, PyError>(
-                    ctx.box_value(value)
-                        == Some(Value::Ref(GcRef(pyre_object::PY_NULL as usize))),
+                    ctx.box_value(value) == Some(Value::Ref(GcRef(pyre_object::PY_NULL as usize))),
                 )
             })?;
             if is_unbound {

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -2418,6 +2418,23 @@ impl MIFrame {
         Ok(())
     }
 
+    pub(crate) fn delete_local_value(
+        &mut self,
+        ctx: &mut TraceCtx,
+        idx: usize,
+    ) -> Result<(), PyError> {
+        // eval.rs:delete_fast writes PY_NULL into locals_w[idx].  STORE_FAST
+        // reaches store_local_value through `setarrayitem_vable_r`; use the
+        // same virtualizable/local-slot writer with the unbound sentinel.
+        let null = ctx.const_ref(pyre_object::PY_NULL as i64);
+        self.store_local_value(
+            ctx,
+            idx,
+            null,
+            ConcreteValue::Ref(pyre_object::PY_NULL),
+        )
+    }
+
     pub(crate) fn set_next_instr(&mut self, _ctx: &mut TraceCtx, target: usize) {
         self.sym_mut().pending_next_instr = Some(target);
     }
@@ -7367,6 +7384,19 @@ impl MIFrame {
             } else {
                 "<cell>"
             };
+            let is_unbound = self.with_ctx(|this, ctx| {
+                let value = this.load_local_value(ctx, idx)?;
+                Ok::<_, PyError>(
+                    ctx.box_value(value)
+                        == Some(Value::Ref(GcRef(pyre_object::PY_NULL as usize))),
+                )
+            })?;
+            if is_unbound {
+                return Err(PyError::unbound_local_error_with_name(
+                    format!("local variable '{name}' referenced before assignment"),
+                    name,
+                ));
+            }
             OpcodeStepExecutor::load_fast_checked(self, idx, name)?;
             return Ok(Some(pyre_interpreter::StepResult::Continue));
         }
@@ -7403,6 +7433,21 @@ impl MIFrame {
             } else {
                 "<cell>"
             };
+            for (idx, name) in [(idx1, name1), (idx2, name2)] {
+                let is_unbound = self.with_ctx(|this, ctx| {
+                    let value = this.load_local_value(ctx, idx)?;
+                    Ok::<_, PyError>(
+                        ctx.box_value(value)
+                            == Some(Value::Ref(GcRef(pyre_object::PY_NULL as usize))),
+                    )
+                })?;
+                if is_unbound {
+                    return Err(PyError::unbound_local_error_with_name(
+                        format!("local variable '{name}' referenced before assignment"),
+                        name,
+                    ));
+                }
+            }
             OpcodeStepExecutor::load_fast_pair_checked(self, idx1, name1, idx2, name2)?;
             return Ok(Some(pyre_interpreter::StepResult::Continue));
         }
@@ -7505,6 +7550,18 @@ impl MIFrame {
             use pyre_interpreter::OpcodeStepExecutor;
             OpcodeStepExecutor::store_fast(self, var_num.get(op_arg).as_usize())?;
             return Ok(Some(pyre_interpreter::StepResult::Continue));
+        }
+
+        // DELETE_FAST walker activation via the same local-slot writer as
+        // STORE_FAST, but with PY_NULL as the value.  `PYRE_FBW_DELETE_FAST=0`
+        // falls through to the codewriter's `abort_permanent` fallback.
+        if let Instruction::DeleteFast { var_num } = instruction {
+            if crate::jitcode_dispatch::fbw_delete_fast_enabled() {
+                self.with_ctx(|this, ctx| {
+                    this.delete_local_value(ctx, var_num.get(op_arg).as_usize())
+                })?;
+                return Ok(Some(pyre_interpreter::StepResult::Continue));
+            }
         }
 
         // BINARY_OP walker activation via `OpcodeStepExecutor` delegation.

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -5427,12 +5427,12 @@ pub extern "C" fn bh_unary_not_fn(value: i64) -> i64 {
 /// LOAD_FAST_CHECK residual (`load_fast_check` HLOp → `residual_call_ir_r`).
 /// The local slot is read from the vable exactly like LOAD_FAST and handed in
 /// as `value` (possibly `PY_NULL` for an unbound local).  Returns `value`
-/// unchanged when bound; on an unbound local raises `NameError`, resolving the
-/// variable name from the resume frame's code object via the `co_varnames`
-/// index baked in by the codewriter.  Reads no heap and runs no user code
-/// (`CallFlavor::Plain`); the exception is published through
-/// `BH_LAST_EXC_VALUE` for the trailing `GuardNoException` and the call
-/// returns 0.
+/// unchanged when bound; on an unbound local raises `UnboundLocalError`,
+/// resolving the variable name from the resume frame's code object via the
+/// `co_varnames` index baked in by the codewriter.  Reads no heap and runs no
+/// user code (`CallFlavor::Plain`); the exception is published through
+/// `BH_LAST_EXC_VALUE` for the trailing `GuardNoException` and the call returns
+/// 0.
 pub extern "C" fn bh_load_fast_check_fn(value: i64, w_code_ptr: i64, name_idx: i64) -> i64 {
     if value as pyre_object::PyObjectRef != pyre_object::PY_NULL {
         return value;
@@ -5452,9 +5452,9 @@ pub extern "C" fn bh_load_fast_check_fn(value: i64, w_code_ptr: i64, name_idx: i
     } else {
         "<cell>"
     };
-    let exc_obj = pyre_interpreter::PyError::new(
-        pyre_interpreter::PyErrorKind::NameError,
+    let exc_obj = pyre_interpreter::PyError::unbound_local_error_with_name(
         format!("local variable '{name}' referenced before assignment"),
+        name,
     )
     .to_exc_object();
     publish_residual_call_exception(exc_obj as i64);

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -2497,6 +2497,20 @@ pub fn trace_and_compile_from_bridge(
     // always-correct blackhole resume handles it.  (Routing the bridge walk
     // to the handler is the orthodox follow-up, gated on the in-try
     // residual-call resume-PC epic; declining is correctness-first.)
+    //
+    // The escaping case — an exception guard whose raising op is NOT caught in
+    // this frame, so the exception unwinds OUT to the caller — has the same
+    // fallthrough-not-catch resume gap: the guard's resume_pc is the
+    // no-exception fallthrough, so the bridge walk records the RETURN of the
+    // NULL raised-call result and the compiled bridge hands a NULL up to the
+    // caller (the "call failed" crash).  The
+    // `emit_exception_bridge_prologue` GUARD_EXCEPTION path that would trace
+    // the propagate-out continuation needs resume-data replay pyre does not yet
+    // have (its synthetic guard carries no rd_resume_position), so decline the
+    // escaping case too and let the blackhole propagate the exception out of
+    // the frame to the caller's handler.  Compiling a real raising bridge
+    // (`Finish(exc, exit_frame_with_exception_descr_ref)`) is the orthodox
+    // follow-up, gated on the same exception-edge bridge epic.
     let caught_in_frame = pending_exc && last_bridge_is_exception_guard && {
         if is_multiframe_resume {
             // `resume_pc` (and thus `frame.last_instr`, set above) addresses the
@@ -2518,7 +2532,7 @@ pub fn trace_and_compile_from_bridge(
             pyre_interpreter::pycode::lookup_exceptiontable(&code.exceptiontable, off).is_some()
         }
     };
-    if pending_exc && (!last_bridge_is_exception_guard || caught_in_frame) {
+    if pending_exc {
         if majit_metainterp::majit_log_enabled() {
             eprintln!(
                 "[jit][bridge-trace] decline (pending exc, caught_in_frame={caught_in_frame}) key={} trace={} fail={} resume_pc={}",

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -1525,10 +1525,10 @@ fn build_gc() -> Box<dyn majit_gc::GcAllocator> {
     // `pytype_to_tid`, so this pre-registration wins over its
     // generic `object_subclass(sizeof(PyObject), parent_tid)`
     // default which would underallocate `W_BaseException`.
-    for kind_idx in 0u8..=(pyre_object::interp_exceptions::ExcKind::BufferError as u8) {
+    for kind_idx in 0u8..=(pyre_object::interp_exceptions::ExcKind::UnboundLocalError as u8) {
         // Round-trip the byte through the enum so we don't depend
-        // on unsafe transmute; every value in [0, BufferError] is
-        // a valid `ExcKind` variant by construction.
+        // on unsafe transmute; every value in [0, UnboundLocalError]
+        // is a valid `ExcKind` variant by construction.
         let kind = match kind_idx {
             0 => pyre_object::interp_exceptions::ExcKind::BaseException,
             1 => pyre_object::interp_exceptions::ExcKind::Exception,
@@ -1562,6 +1562,7 @@ fn build_gc() -> Box<dyn majit_gc::GcAllocator> {
             29 => pyre_object::interp_exceptions::ExcKind::ModuleNotFoundError,
             30 => pyre_object::interp_exceptions::ExcKind::SyntaxError,
             31 => pyre_object::interp_exceptions::ExcKind::BufferError,
+            32 => pyre_object::interp_exceptions::ExcKind::UnboundLocalError,
             _ => unreachable!(),
         };
         let pytype_ptr =

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -11318,10 +11318,8 @@ impl CodeWriter {
                                     None,
                                     py_pc as i64,
                                 );
-                                current_state.store_local_value(
-                                    idx,
-                                    super::flow::Constant::none().into(),
-                                );
+                                current_state
+                                    .store_local_value(idx, super::flow::Constant::none().into());
                             } else {
                                 emit_abort_permanent!(py_pc);
                             }

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -11300,9 +11300,121 @@ impl CodeWriter {
                         Instruction::DeleteFast { var_num } => {
                             if fbw_delete_fast_enabled() {
                                 let idx = var_num.get(op_arg).as_usize();
+                                if current_state.local_value_at(idx).is_none() {
+                                    emit_abort_permanent!(py_pc);
+                                    continue;
+                                }
+                                let idx_u16 = idx as u16;
                                 let local_slot = local_to_vable_slot(idx) as i64;
                                 let v_idx: super::flow::FlowValue =
                                     super::flow::Constant::signed(local_slot).into();
+                                let code_const: super::flow::FlowValue =
+                                    super::flow::Constant::new(
+                                        super::flow::ConstantValue::Signed(w_code as i64),
+                                        Some(Kind::Ref),
+                                    )
+                                    .into();
+                                let name_idx_const: super::flow::FlowValue =
+                                    super::flow::Constant::signed(idx as i64).into();
+                                emit_load_fast_ref!(current_depth, idx_u16, py_pc);
+                                let _value_reg = emit_popvalue_ref!(current_depth, py_pc);
+                                let value_value = pop_ref_or_fresh(&mut current_state, &mut graph);
+                                let checked_value = emit_graph_op_with_result(
+                                    &mut graph,
+                                    &current_block.block(),
+                                    "load_fast_check",
+                                    vec![
+                                        value_value.into(),
+                                        code_const.into(),
+                                        name_idx_const.into(),
+                                    ],
+                                    Kind::Ref,
+                                    py_pc as i64,
+                                );
+                                let checked_flow: super::flow::FlowValue = checked_value.into();
+                                let is_null = emit_graph_op_with_result(
+                                    &mut graph,
+                                    &current_block.block(),
+                                    "ptr_iszero",
+                                    vec![checked_flow.clone().into()],
+                                    Kind::Int,
+                                    py_pc as i64,
+                                );
+                                current_block.block().borrow_mut().exitswitch =
+                                    Some(super::flow::ExitSwitch::Value(is_null.into()));
+                                let abort_state = current_state.clone();
+                                let abort_block = SpamBlockRef::new(
+                                    graph.new_block(Vec::new()),
+                                    Some(abort_state.clone()),
+                                );
+                                abort_block.block().borrow_mut().inputargs =
+                                    abort_state.getvariables();
+                                all_walker_blocks.push(abort_block.clone());
+                                append_exit(
+                                    &current_block.block(),
+                                    output_link(&current_state, &abort_state, abort_block.block()),
+                                );
+                                set_last_bool_exitcase(&current_block.block(), true);
+                                {
+                                    let v_li: super::flow::FlowValue =
+                                        super::flow::Constant::signed(py_pc as i64 - 1).into();
+                                    record_graph_op(
+                                        &abort_block.block(),
+                                        "setfield_vable_i",
+                                        vable_setfield_int_graph_args(
+                                            frame_var.into(),
+                                            v_li.into(),
+                                            VABLE_LAST_INSTR_FIELD_IDX,
+                                        ),
+                                        None,
+                                        py_pc as i64,
+                                    );
+                                    record_graph_op(
+                                        &abort_block.block(),
+                                        "abort_permanent",
+                                        Vec::new(),
+                                        None,
+                                        py_pc as i64,
+                                    );
+                                    append_exit(
+                                        &abort_block.block(),
+                                        super::flow::Link::new(
+                                            vec![super::flow::Constant::none().into()],
+                                            Some(graph.returnblock.clone()),
+                                            None,
+                                        )
+                                        .into_ref(),
+                                    );
+                                }
+                                let continue_state = current_state.clone();
+                                let continue_block = SpamBlockRef::new(
+                                    graph.new_block(Vec::new()),
+                                    Some(continue_state.clone()),
+                                );
+                                continue_block.block().borrow_mut().inputargs =
+                                    continue_state.getvariables();
+                                all_walker_blocks.push(continue_block.clone());
+                                append_exit(
+                                    &current_block.block(),
+                                    output_link(
+                                        &current_state,
+                                        &continue_state,
+                                        continue_block.block(),
+                                    ),
+                                );
+                                set_last_bool_exitcase(&current_block.block(), false);
+                                current_block = continue_block;
+                                record_graph_op(
+                                    &current_block.block(),
+                                    "setarrayitem_vable_r",
+                                    vable_setarrayitem_ref_graph_args(
+                                        frame_var.into(),
+                                        v_idx.clone().into(),
+                                        checked_flow.into(),
+                                    ),
+                                    None,
+                                    py_pc as i64,
+                                );
                                 // eval.rs:delete_fast writes PY_NULL into the
                                 // locals slot. Mirror STORE_FAST's
                                 // `setarrayitem_vable_r` local write with the

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -11018,6 +11018,25 @@ impl CodeWriter {
                         // resolves the variable name with.
                         Instruction::LoadFastCheck { var_num } => {
                             let idx = var_num.get(op_arg).as_usize() as u16;
+                            // A local proven unbound at compile time (a
+                            // `ConstantValue::None` slot, e.g. after a preceding
+                            // DELETE_FAST) makes LOAD_FAST_CHECK unconditionally
+                            // raise UnboundLocalError.  Emitting the
+                            // `load_fast_check` residual + `GuardNoException` +
+                            // push leaves a normal-return `Finish` continuation;
+                            // a later guard-failure bridge resolves into that
+                            // return and silently swallows the raise.  Bail to
+                            // the interpreter so it raises, mirroring the
+                            // constant-folded `if w_value is None` failure arm
+                            // (matches the DeleteFast known-unbound handling).
+                            if matches!(
+                                current_state.local_value_at(idx as usize),
+                                Some(super::flow::FlowValue::Constant(c))
+                                    if c.value == super::flow::ConstantValue::None
+                            ) {
+                                emit_abort_permanent!(py_pc);
+                                continue;
+                            }
                             let code_const: super::flow::FlowValue = super::flow::Constant::new(
                                 super::flow::ConstantValue::Signed(w_code as i64),
                                 Some(Kind::Ref),

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -54,6 +54,15 @@ fn local_to_vable_slot(var_num: usize) -> usize {
     var_num
 }
 
+/// `PYRE_FBW_DELETE_FAST` gates the walker-native DELETE_FAST lowering.
+/// Default ON; `0`/`false` restores the permanent-abort marker.
+#[inline]
+fn fbw_delete_fast_enabled() -> bool {
+    std::env::var("PYRE_FBW_DELETE_FAST")
+        .map(|v| v != "0" && !v.eq_ignore_ascii_case("false"))
+        .unwrap_or(true)
+}
+
 /// Re-export of `pyre_jit_trace::pyjitcode::portal_red_pre_regalloc_slots`
 /// so the codewriter pipeline shares the same formula with the
 /// portal-bridge install path in `canonical_bridge.rs`.  See the
@@ -3697,9 +3706,9 @@ fn register_helper_fn_pointers(
         cpu.unary_not_fn as *const (),
         CallFlavor::MayForce,
     );
-    // `bh_load_fast_check_fn` only null-checks the local and raises NameError;
-    // it reads no heap and runs no user code → `Plain`.  Appended last to
-    // preserve fn_ptr indices.
+    // `bh_load_fast_check_fn` only null-checks the local and raises
+    // UnboundLocalError; it reads no heap and runs no user code → `Plain`.
+    // Appended last to preserve fn_ptr indices.
     let load_fast_check_fn = bind(
         assembler,
         cpu.load_fast_check_fn as *const (),
@@ -10996,14 +11005,14 @@ impl CodeWriter {
                         }
 
                         // LOAD_FAST_CHECK: reads a local that may be unbound,
-                        // pushes it, and raises NameError when the slot is
+                        // pushes it, and raises UnboundLocalError when the slot is
                         // PY_NULL.  The local is read from the vable exactly
                         // like LOAD_FAST (`emit_load_fast_ref!`, inlining-safe
                         // via `frame_var`); the `load_fast_check(value, code,
                         // name_idx)` HLOp → `residual_call_ir_r(
                         // load_fast_check_fn, ListR[value, code],
                         // ListI[name_idx])` returns the value when bound or
-                        // raises the unbound NameError (`bh_load_fast_check_fn`,
+                        // raises the unbound UnboundLocalError (`bh_load_fast_check_fn`,
                         // CallFlavor::Plain — reads no heap, runs no user code).
                         // `name_idx` is the `co_varnames` index the residual
                         // resolves the variable name with.
@@ -11288,20 +11297,38 @@ impl CodeWriter {
                             current_state.store_local_value(idx as usize, result_value.into());
                         }
 
+                        Instruction::DeleteFast { var_num } => {
+                            if fbw_delete_fast_enabled() {
+                                let idx = var_num.get(op_arg).as_usize();
+                                let local_slot = local_to_vable_slot(idx) as i64;
+                                let v_idx: super::flow::FlowValue =
+                                    super::flow::Constant::signed(local_slot).into();
+                                // eval.rs:delete_fast writes PY_NULL into the
+                                // locals slot. Mirror STORE_FAST's
+                                // `setarrayitem_vable_r` local write with the
+                                // unbound sentinel as the value.
+                                record_graph_op(
+                                    &current_block.block(),
+                                    "setarrayitem_vable_r",
+                                    vable_setarrayitem_ref_graph_args(
+                                        frame_var.into(),
+                                        v_idx.into(),
+                                        super::flow::Constant::none().into(),
+                                    ),
+                                    None,
+                                    py_pc as i64,
+                                );
+                                current_state.store_local_value(
+                                    idx,
+                                    super::flow::Constant::none().into(),
+                                );
+                            } else {
+                                emit_abort_permanent!(py_pc);
+                            }
+                        }
+
                         // Instructions that don't touch the operand stack (locals/cells only).
-                        // DELETE_FAST aborts rather than lowering a localsplus-slot
-                        // clear: making it traceable lets `del`-bearing regions compile
-                        // (notably the implicit `del e` an `except E as e:` handler
-                        // emits), which surfaces latent miscompiles there — exception
-                        // `__context__` chaining and raising LOAD_FAST_CHECK side-exits.
-                        // The abort's resume coordinate (`last_instr = py_pc - 1`,
-                        // stored below by `emit_abort_permanent`) is honored by the
-                        // full-body walk's abort-point flush (`run_perfn_walk`), so a
-                        // `del`-bearing hot method resumes AT the del instead of
-                        // replaying the walked region's already-executed residual side
-                        // effects.
-                        Instruction::DeleteFast { .. }
-                        | Instruction::DeleteDeref { .. }
+                        Instruction::DeleteDeref { .. }
                         | Instruction::DeleteGlobal { .. }
                         | Instruction::DeleteName { .. }
                         | Instruction::SetupAnnotations => {

--- a/pyre/pyre-jit/src/jit/flatten.rs
+++ b/pyre/pyre-jit/src/jit/flatten.rs
@@ -4008,7 +4008,8 @@ pub fn build_load_method_self_fn_residual_call_ir_r_insn(
     code_operand: Operand,
     dst_reg: u16,
 ) -> Insn {
-    let effect_info = effect_info_for_call_flavor(CallFlavor::PlainCannotRaise);
+    let mut effect_info = effect_info_for_call_flavor(CallFlavor::PlainCannotRaise);
+    effect_info.pyre_helper = majit_ir::PyreHelperKind::LoadMethodSelf;
     let descr_operand = Operand::descr(DescrOperand::CallDescrStub(CallDescrStub {
         effect_info,
         arg_kinds: vec![Kind::Ref, Kind::Ref, Kind::Ref, Kind::Int],
@@ -6412,7 +6413,8 @@ where
         Some(super::flow::FlowValue::Variable(var)) => get_register(*var),
         _ => return None,
     };
-    let effect_info = effect_info_for_call_flavor(CallFlavor::PlainCannotRaise);
+    let mut effect_info = effect_info_for_call_flavor(CallFlavor::PlainCannotRaise);
+    effect_info.pyre_helper = majit_ir::PyreHelperKind::LoadMethodSelf;
     let descr_operand = Operand::descr(DescrOperand::CallDescrStub(CallDescrStub {
         effect_info,
         arg_kinds: vec![Kind::Ref, Kind::Ref, Kind::Ref, Kind::Int],

--- a/pyre/pyre-object/src/interp_exceptions.rs
+++ b/pyre/pyre-object/src/interp_exceptions.rs
@@ -22,6 +22,8 @@ pub static EXC_ZERO_DIVISION_ERROR_TYPE: PyType = crate::pyobject::new_pytype("Z
 pub static EXC_TYPE_ERROR_TYPE: PyType = crate::pyobject::new_pytype("TypeError");
 pub static EXC_VALUE_ERROR_TYPE: PyType = crate::pyobject::new_pytype("ValueError");
 pub static EXC_NAME_ERROR_TYPE: PyType = crate::pyobject::new_pytype("NameError");
+pub static EXC_UNBOUND_LOCAL_ERROR_TYPE: PyType =
+    crate::pyobject::new_pytype("UnboundLocalError");
 pub static EXC_INDEX_ERROR_TYPE: PyType = crate::pyobject::new_pytype("IndexError");
 pub static EXC_KEY_ERROR_TYPE: PyType = crate::pyobject::new_pytype("KeyError");
 pub static EXC_ATTRIBUTE_ERROR_TYPE: PyType = crate::pyobject::new_pytype("AttributeError");
@@ -87,6 +89,7 @@ pub fn exc_kind_to_pytype(kind: ExcKind) -> &'static PyType {
         ExcKind::TypeError => &EXC_TYPE_ERROR_TYPE,
         ExcKind::ValueError => &EXC_VALUE_ERROR_TYPE,
         ExcKind::NameError => &EXC_NAME_ERROR_TYPE,
+        ExcKind::UnboundLocalError => &EXC_UNBOUND_LOCAL_ERROR_TYPE,
         ExcKind::IndexError => &EXC_INDEX_ERROR_TYPE,
         ExcKind::KeyError => &EXC_KEY_ERROR_TYPE,
         ExcKind::AttributeError => &EXC_ATTRIBUTE_ERROR_TYPE,
@@ -206,6 +209,8 @@ pub enum ExcKind {
     /// (`PyByteArray_Resize`: "Existing exports of data: object cannot
     /// be re-sized").  Direct subclass of Exception.
     BufferError = 31,
+    /// Subclass of NameError raised when a fast local is read while unbound.
+    UnboundLocalError = 32,
 }
 
 impl ExcKind {
@@ -571,7 +576,7 @@ pub fn w_exception_new_empty(kind: ExcKind) -> PyObjectRef {
 /// arrays against the same authoritative bound.  Anchored on the
 /// highest-numbered variant so adding new ExcKinds at the end of the
 /// enum extends the bound automatically.
-pub const EXC_KIND_COUNT: usize = (ExcKind::BufferError as u8 as usize) + 1;
+pub const EXC_KIND_COUNT: usize = (ExcKind::UnboundLocalError as u8 as usize) + 1;
 
 thread_local! {
     static EXC_CLASS_BY_KIND: std::cell::Cell<[PyObjectRef; EXC_KIND_COUNT]> =
@@ -1268,6 +1273,7 @@ pub fn exc_kind_name(kind: ExcKind) -> &'static str {
         ExcKind::ValueError => "ValueError",
         ExcKind::ZeroDivisionError => "ZeroDivisionError",
         ExcKind::NameError => "NameError",
+        ExcKind::UnboundLocalError => "UnboundLocalError",
         ExcKind::IndexError => "IndexError",
         ExcKind::KeyError => "KeyError",
         ExcKind::AttributeError => "AttributeError",
@@ -1318,6 +1324,9 @@ pub fn exc_kind_matches(kind: ExcKind, type_name: &str) -> bool {
     }
     if type_name == "RuntimeError" {
         return matches!(kind, ExcKind::RuntimeError | ExcKind::RecursionError);
+    }
+    if type_name == "NameError" {
+        return matches!(kind, ExcKind::NameError | ExcKind::UnboundLocalError);
     }
     // ImportError hierarchy — ModuleNotFoundError is-a ImportError.
     if type_name == "ImportError" {
@@ -1370,6 +1379,7 @@ pub fn exc_kind_from_name(name: &str) -> Option<ExcKind> {
         "ValueError" => Some(ExcKind::ValueError),
         "ZeroDivisionError" => Some(ExcKind::ZeroDivisionError),
         "NameError" => Some(ExcKind::NameError),
+        "UnboundLocalError" => Some(ExcKind::UnboundLocalError),
         "IndexError" => Some(ExcKind::IndexError),
         "KeyError" => Some(ExcKind::KeyError),
         "AttributeError" => Some(ExcKind::AttributeError),
@@ -1470,6 +1480,7 @@ mod tests {
             ExcKind::ValueError,
             ExcKind::ZeroDivisionError,
             ExcKind::NameError,
+            ExcKind::UnboundLocalError,
             ExcKind::IndexError,
             ExcKind::KeyError,
             ExcKind::AttributeError,

--- a/pyre/pyre-object/src/interp_exceptions.rs
+++ b/pyre/pyre-object/src/interp_exceptions.rs
@@ -22,8 +22,7 @@ pub static EXC_ZERO_DIVISION_ERROR_TYPE: PyType = crate::pyobject::new_pytype("Z
 pub static EXC_TYPE_ERROR_TYPE: PyType = crate::pyobject::new_pytype("TypeError");
 pub static EXC_VALUE_ERROR_TYPE: PyType = crate::pyobject::new_pytype("ValueError");
 pub static EXC_NAME_ERROR_TYPE: PyType = crate::pyobject::new_pytype("NameError");
-pub static EXC_UNBOUND_LOCAL_ERROR_TYPE: PyType =
-    crate::pyobject::new_pytype("UnboundLocalError");
+pub static EXC_UNBOUND_LOCAL_ERROR_TYPE: PyType = crate::pyobject::new_pytype("UnboundLocalError");
 pub static EXC_INDEX_ERROR_TYPE: PyType = crate::pyobject::new_pytype("IndexError");
 pub static EXC_KEY_ERROR_TYPE: PyType = crate::pyobject::new_pytype("KeyError");
 pub static EXC_ATTRIBUTE_ERROR_TYPE: PyType = crate::pyobject::new_pytype("AttributeError");

--- a/pyre/pyre-object/src/interp_exceptions.rs
+++ b/pyre/pyre-object/src/interp_exceptions.rs
@@ -1459,6 +1459,16 @@ mod tests {
             "BaseException"
         ));
         assert!(!exc_kind_matches(ExcKind::ZeroDivisionError, "ValueError"));
+        assert!(exc_kind_matches(
+            ExcKind::UnboundLocalError,
+            "UnboundLocalError"
+        ));
+        assert!(exc_kind_matches(ExcKind::UnboundLocalError, "NameError"));
+        assert!(exc_kind_matches(ExcKind::UnboundLocalError, "Exception"));
+        assert!(exc_kind_matches(
+            ExcKind::UnboundLocalError,
+            "BaseException"
+        ));
     }
 
     #[test]

--- a/pyre/pyre-object/src/pyobject.rs
+++ b/pyre/pyre-object/src/pyobject.rs
@@ -644,6 +644,17 @@ pub fn all_foreign_pytypes() -> &'static [(&'static PyType, &'static PyType)] {
             &crate::interp_exceptions::EXC_NAME_ERROR_TYPE,
             &crate::interp_exceptions::EXC_EXCEPTION_TYPE,
         ),
+        // UnboundLocalError subclasses NameError; listed after it so the
+        // topological-order constraint of the foreign-pytype loop holds.
+        // Its GC tid is pre-registered to the shared `W_BaseException`
+        // tid by the per-ExcKind loop in `pyre-jit/src/eval.rs`, so that
+        // loop skips this entry; without the pre-registration it would
+        // assign an undersized standalone `sizeof(PyObject)` tid and shift
+        // every hardcoded post-loop GC tid.
+        (
+            &crate::interp_exceptions::EXC_UNBOUND_LOCAL_ERROR_TYPE,
+            &crate::interp_exceptions::EXC_NAME_ERROR_TYPE,
+        ),
         // LookupError is the intermediate parent of IndexError and
         // KeyError per `pypy/module/exceptions/interp_exceptions.py:474
         // W_LookupError = _new_exception('LookupError', W_Exception,

--- a/pyre/pyrex/src/lib.rs
+++ b/pyre/pyrex/src/lib.rs
@@ -105,15 +105,27 @@ fn drain_args(parser: &mut lexopt::Parser) -> Result<Vec<String>, lexopt::Error>
     Ok(rest)
 }
 
+/// Emit the `preconfig_init_utf8_mode` fatal error for an invalid PYTHONUTF8 /
+/// `-X utf8` value and exit; the value is validated during pre-init config.
+fn fatal_utf8_config_error(detail: &str) -> ! {
+    eprintln!("Fatal Python error: preconfig_init_utf8_mode: {detail}");
+    eprintln!("Python runtime state: preinitializing");
+    eprintln!();
+    std::process::exit(1);
+}
+
 fn locale_implies_utf8_mode() -> bool {
     let locale = std::env::var("LC_ALL")
         .ok()
         .or_else(|| std::env::var("LC_CTYPE").ok())
         .or_else(|| std::env::var("LANG").ok());
-    match locale.as_deref() {
-        None | Some("") | Some("C") | Some("POSIX") => true,
-        Some(value) => !value.contains('.'),
-    }
+    // Only the legacy C/POSIX locale — or an unset/empty locale, which resolves
+    // to C — coerces utf8_mode to 1; every named locale (en_US, C.UTF-8, …)
+    // leaves it 0.
+    matches!(
+        locale.as_deref(),
+        None | Some("") | Some("C") | Some("POSIX")
+    )
 }
 
 fn resolve_utf8_mode(flags: &LaunchFlags) -> i64 {
@@ -123,7 +135,11 @@ fn resolve_utf8_mode(flags: &LaunchFlags) -> i64 {
     if !flags.ignore_environment {
         if let Ok(value) = std::env::var("PYTHONUTF8") {
             if !value.is_empty() {
-                return if value == "0" { 0 } else { 1 };
+                return match value.as_str() {
+                    "0" => 0,
+                    "1" => 1,
+                    _ => fatal_utf8_config_error("invalid PYTHONUTF8 environment variable value"),
+                };
             }
         }
     }
@@ -171,6 +187,9 @@ fn parse_args(binary_name: &str) -> Result<(RunMode, LaunchFlags, Vec<String>), 
                     "dev" => flags.dev_mode = true,
                     "utf8" | "utf8=1" => flags.utf8_mode = Some(1),
                     "utf8=0" => flags.utf8_mode = Some(0),
+                    _ if option.starts_with("utf8=") => {
+                        fatal_utf8_config_error("invalid -X utf8 option value")
+                    }
                     _ => {}
                 }
             }

--- a/pyre/pyrex/src/lib.rs
+++ b/pyre/pyrex/src/lib.rs
@@ -45,7 +45,7 @@ struct LaunchFlags {
     ignore_environment: bool,
     isolated: bool,
     dev_mode: bool,
-    utf8_mode: i64,
+    utf8_mode: Option<i64>,
     safe_path: bool,
 }
 
@@ -59,7 +59,7 @@ impl Default for LaunchFlags {
             ignore_environment: false,
             isolated: false,
             dev_mode: false,
-            utf8_mode: 1,
+            utf8_mode: None,
             safe_path: false,
         }
     }
@@ -105,6 +105,36 @@ fn drain_args(parser: &mut lexopt::Parser) -> Result<Vec<String>, lexopt::Error>
     Ok(rest)
 }
 
+fn locale_implies_utf8_mode() -> bool {
+    let locale = std::env::var("LC_ALL")
+        .ok()
+        .or_else(|| std::env::var("LC_CTYPE").ok())
+        .or_else(|| std::env::var("LANG").ok());
+    match locale.as_deref() {
+        None | Some("") | Some("C") | Some("POSIX") => true,
+        Some(value) => !value.contains('.'),
+    }
+}
+
+fn resolve_utf8_mode(flags: &LaunchFlags) -> i64 {
+    if let Some(value) = flags.utf8_mode {
+        return value;
+    }
+    if !flags.ignore_environment {
+        if let Ok(value) = std::env::var("PYTHONUTF8") {
+            if !value.is_empty() {
+                return if value == "0" { 0 } else { 1 };
+            }
+        }
+    }
+    if locale_implies_utf8_mode() { 1 } else { 0 }
+}
+
+fn finalize_flags(mut flags: LaunchFlags) -> LaunchFlags {
+    flags.utf8_mode = Some(resolve_utf8_mode(&flags));
+    flags
+}
+
 fn parse_args(binary_name: &str) -> Result<(RunMode, LaunchFlags, Vec<String>), lexopt::Error> {
     let mut parser = lexopt::Parser::from_env();
     let mut flags = LaunchFlags::default();
@@ -114,12 +144,12 @@ fn parse_args(binary_name: &str) -> Result<(RunMode, LaunchFlags, Vec<String>), 
             Short('c') => {
                 let cmd = parser.value()?.string()?;
                 let rest = drain_args(&mut parser)?;
-                return Ok((RunMode::Command(cmd), flags, rest));
+                return Ok((RunMode::Command(cmd), finalize_flags(flags), rest));
             }
             Short('m') => {
                 let module = parser.value()?.string()?;
                 let rest = drain_args(&mut parser)?;
-                return Ok((RunMode::Module(module), flags, rest));
+                return Ok((RunMode::Module(module), finalize_flags(flags), rest));
             }
             Short('h') | Long("help") => {
                 print!("{}", usage(binary_name));
@@ -139,8 +169,8 @@ fn parse_args(binary_name: &str) -> Result<(RunMode, LaunchFlags, Vec<String>), 
                 let option = parser.value()?.string()?;
                 match option.as_str() {
                     "dev" => flags.dev_mode = true,
-                    "utf8" | "utf8=1" => flags.utf8_mode = 1,
-                    "utf8=0" => flags.utf8_mode = 0,
+                    "utf8" | "utf8=1" => flags.utf8_mode = Some(1),
+                    "utf8=0" => flags.utf8_mode = Some(0),
                     _ => {}
                 }
             }
@@ -157,18 +187,18 @@ fn parse_args(binary_name: &str) -> Result<(RunMode, LaunchFlags, Vec<String>), 
                 let script = script.string()?;
                 if script == "interact" {
                     let mode = parse_interact(&mut parser)?;
-                    return Ok((mode, flags, vec![]));
+                    return Ok((mode, finalize_flags(flags), vec![]));
                 }
                 if script == "-" {
-                    return Ok((RunMode::Repl, flags, vec![]));
+                    return Ok((RunMode::Repl, finalize_flags(flags), vec![]));
                 }
                 let rest = drain_args(&mut parser)?;
-                return Ok((RunMode::Script(script), flags, rest));
+                return Ok((RunMode::Script(script), finalize_flags(flags), rest));
             }
             _ => return Err(arg.unexpected()),
         }
     }
-    Ok((RunMode::Repl, flags, vec![]))
+    Ok((RunMode::Repl, finalize_flags(flags), vec![]))
 }
 
 /// Parse a `--heapsize` value (`pypy_interact.py:88-102`): a byte count with an
@@ -400,7 +430,7 @@ fn real_main(binary_name: &str) {
         ignore_environment,
         isolated,
         dev_mode,
-        utf8_mode,
+        utf8_mode.unwrap_or(0),
         safe_path,
     );
 


### PR DESCRIPTION
Branch `str` over `main` — three independent changes, all verified `164/164` on `pyre/check.py --backend dynasm`.

## Commits

- **`pyrex/importing`: resolve `sys.flags.utf8_mode`** from `-X utf8` / `PYTHONUTF8` / locale (default `-1` locale-selected), matching launcher parity.

- **`majit`: re-trace quasi-immutable-invalidated loops instead of interpreting them.** When a module-dict version bump invalidates a compiled loop's baked quasi-immutable cell (e.g. reassigning a global), the loop's procedure token becomes non-jumpable; the warmstate entry points now detect `has_seen_a_procedure_token() && get_procedure_token().is_none()`, clean the cell chain, and re-arm the counter so the loop re-traces against the fresh value (warmstate.py:483-500) rather than falling back to the interpreter. Adds paired `QuasiimmutField` + `GUARD_NOT_INVALIDATED` recording for namespace cells. Fixes `global_reassign` (14× → 1.0× CPython).

- **`majit`: lower `DELETE_FAST` in the walker and add `UnboundLocalError`.** `DELETE_FAST` was lowered to an `abort_permanent` marker, so any hot loop whose body contained a `del` — including the implicit `del e` an `except E as e:` handler emits — ran fully interpreted. It now has a walker-native lowering that writes `PY_NULL` into the local slot (mirroring `delete_fast` / STORE_FAST's `setarrayitem_vable_r`), gated by `PYRE_FBW_DELETE_FAST` (default on). `UnboundLocalError` is added as a proper `NameError` subclass so unbound fast-local reads raise it and `except NameError` still catches it (unbound freevars keep raising `NameError`).

## Verification

- `pyre/check.py --backend dynasm`: **164/164**.
- Same-binary A/B (kill-switch) for `DELETE_FAST`: `swap_except_return_resume` −97% (38×), `finally_bare_raise` −94% (16×), `binary_slice_index` −39%, `build_set_hashability` −37%, `exception_oserror_fields` −34%; the rest within ±4% noise. **Zero regressions.**
- `UnboundLocalError` semantics match CPython 3.14 (MRO, `issubclass(UnboundLocalError, NameError)`, `except NameError` catch).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Uninitialized local variables now consistently raise `UnboundLocalError`, including in optimized and traced execution paths.
  - Invalidated optimized code is cleaned up correctly, allowing affected code to become hot and retrace.
  - UTF-8 mode now follows explicit options, environment settings, and locale defaults more accurately.

- **Performance**
  - Improved optimization of method calls, local-variable deletion, and namespace invalidation tracking.
  - Enhanced loop optimization dependency tracking for more reliable recompilation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->