### PR TITLE
charon: f64 intrinsic MIR lowering + withdrawn struct-leaf classdef redirect

### DIFF
--- a/majit/majit-translate/src/annotator/bookkeeper.rs
+++ b/majit/majit-translate/src/annotator/bookkeeper.rs
@@ -1687,6 +1687,50 @@ impl Bookkeeper {
         self.classdefs.borrow().clone()
     }
 
+    /// Redirect a bare-leaf `root` whose field alias was withdrawn by
+    /// `harden_duplicate_leaf_metadata` (a cross-namespace leaf collision —
+    /// e.g. a struct leaf colliding with an enum variant of the same name) to
+    /// the unique surviving *qualified* struct key that carries that leaf.
+    /// A withdrawn bare leaf has no `fields` entry, so `project_struct_rows`
+    /// finds nothing and the classdef stays attrs-empty (every field getattr
+    /// on the cast result then blocks). The qualified key survives hardening
+    /// (only the bare alias is removed), so resolving through it projects the
+    /// struct's rows. Returns `None` — leaving the current bare-leaf behaviour
+    /// — unless there is exactly one surviving non-enum-variant qualified key
+    /// with this leaf: a genuinely ambiguous leaf (>=2 real struct keys) stays
+    /// unresolved, and an unwithdrawn leaf is untouched.
+    fn redirect_withdrawn_struct_leaf(self: &Rc<Self>, root: &str) -> Option<String> {
+        // Only a bare leaf can be a withdrawal victim; a qualified or
+        // per-instantiation spelling already survives hardening.
+        if root.contains("::") || root.contains('<') {
+            return None;
+        }
+        let guard = self.pyre_struct_fields.borrow();
+        let reg = guard.as_ref()?;
+        if reg.fields.contains_key(root) {
+            return None;
+        }
+        let mut hit: Option<&String> = None;
+        for k in reg.fields.keys() {
+            let Some((head, leaf)) = k.rsplit_once("::") else {
+                continue;
+            };
+            if leaf != root {
+                continue;
+            }
+            // An `{Enum}::{Variant}` key's tail is a variant name, not a
+            // struct leaf — the enum base carries the `__discriminant` row.
+            if reg.is_enum_base(head) {
+                continue;
+            }
+            if hit.is_some() {
+                return None;
+            }
+            hit = Some(k);
+        }
+        hit.cloned()
+    }
+
     /// Resolve a struct type-root name to its canonical, bookkeeper-
     /// REGISTERED `ClassDef`, with instance attributes projected from
     /// the threaded `StructFieldRegistry`.
@@ -1726,6 +1770,8 @@ impl Bookkeeper {
         self: &Rc<Self>,
         root: &str,
     ) -> Result<Rc<RefCell<ClassDef>>, AnnotatorError> {
+        let redirected = self.redirect_withdrawn_struct_leaf(root);
+        let root: &str = redirected.as_deref().unwrap_or(root);
         // Pass 1 — traverse the registry's struct-field graph from `root`,
         // registering an identity-keyed `ClassDef` in `descs` for every
         // reachable struct (via `intern_class_by_qualname` ->

--- a/majit/majit-translate/src/annotator/builtin.rs
+++ b/majit/majit-translate/src/annotator/builtin.rs
@@ -363,6 +363,7 @@ fn register_builtins() -> HashMap<String, BuiltinAnalyzer> {
     // `BigInt::from(i64)` — boxes a machine int into the foreign opaque
     // `BigInt` (Python `long`); returns the classdef-less GcRef shell.
     analyzer_for(&mut reg, "BigInt.from", bigint_from);
+    analyzer_for(&mut reg, "longlong2float.float2longlong", float2longlong_analyzer);
     // Foreign Rust container constructors — `Vec::new` /
     // `Vec::with_capacity` / `indexmap::IndexMap::new` / `Box::new`.
     // Each returns the classdef-less opaque `SomeInstance` shell (twin
@@ -1233,6 +1234,20 @@ pub fn rarith_longlongmask(
     _kwds: &HashMap<String, Option<SomeValue>>,
 ) -> Result<SomeValue, AnnotatorError> {
     // upstream: `SomeInteger(knowntype=rpython.rlib.rarithmetic.r_longlong)`.
+    Ok(SomeValue::Integer(SomeInteger::new_with_knowntype(
+        false,
+        crate::annotator::model::KnownType::LongLong,
+    )))
+}
+
+/// `longlong2float.float2longlong(floatval)` — upstream
+/// `Float2LongLongEntry.compute_result_annotation` returns
+/// `SomeInteger(knowntype=r_int64)` (== `r_longlong`).
+pub fn float2longlong_analyzer(
+    _bk: &Rc<Bookkeeper>,
+    _args_s: &[Option<SomeValue>],
+    _kwds: &HashMap<String, Option<SomeValue>>,
+) -> Result<SomeValue, AnnotatorError> {
     Ok(SomeValue::Integer(SomeInteger::new_with_knowntype(
         false,
         crate::annotator::model::KnownType::LongLong,

--- a/majit/majit-translate/src/annotator/builtin.rs
+++ b/majit/majit-translate/src/annotator/builtin.rs
@@ -363,7 +363,11 @@ fn register_builtins() -> HashMap<String, BuiltinAnalyzer> {
     // `BigInt::from(i64)` — boxes a machine int into the foreign opaque
     // `BigInt` (Python `long`); returns the classdef-less GcRef shell.
     analyzer_for(&mut reg, "BigInt.from", bigint_from);
-    analyzer_for(&mut reg, "longlong2float.float2longlong", float2longlong_analyzer);
+    analyzer_for(
+        &mut reg,
+        "longlong2float.float2longlong",
+        float2longlong_analyzer,
+    );
     // Foreign Rust container constructors — `Vec::new` /
     // `Vec::with_capacity` / `indexmap::IndexMap::new` / `Box::new`.
     // Each returns the classdef-less opaque `SomeInstance` shell (twin

--- a/majit/majit-translate/src/flowspace/model.rs
+++ b/majit/majit-translate/src/flowspace/model.rs
@@ -1969,6 +1969,18 @@ impl HostEnv {
         let bigint = HostObject::new_module("BigInt");
         bigint.module_set("from", HostObject::new_builtin_callable("BigInt.from"));
 
+        // `longlong2float.float2longlong(x)` reinterprets an f64 bit pattern as
+        // i64 (`convert_float_bytes_to_longlong` llop).  The front-end mints this
+        // callsite in the `f64::is_sign_negative` lowering; surface a module-shaped
+        // stub so Branch 3b in `flowspace_adapter::translate_op` resolves the
+        // 2-segment path, the annotator types it `SomeInteger(r_longlong)`, and the
+        // rtyper's `Float2LongLong` extregistry entry emits the genop.
+        let longlong2float = HostObject::new_module("longlong2float");
+        longlong2float.module_set(
+            "float2longlong",
+            HostObject::new_builtin_callable("longlong2float.float2longlong"),
+        );
+
         // Rust primitive type conversion impls (`u32::from`,
         // `i64::from`, `i64::try_from`, `usize::try_from`) — callsites
         // emit `[primitive, method]` 2-segment paths.  Each impl
@@ -2230,6 +2242,7 @@ impl HostEnv {
         mods.insert("std.alloc".into(), std_alloc);
         mods.insert("std.slice".into(), std_slice);
         mods.insert("BigInt".into(), bigint);
+        mods.insert("longlong2float".into(), longlong2float);
         mods.insert("majit_metainterp".into(), majit_metainterp);
         mods.insert("majit_metainterp.jit".into(), majit_metainterp_jit);
         mods.insert("u32".into(), primitive_u32);

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -5845,26 +5845,6 @@ impl<'a> Lowering<'a> {
                     self.graph.set_goto(bb_id, target_bb, link_args);
                     return Ok(());
                 }
-                // `f64::abs(x)` is the `float_abs` unary op (`FloatRepr::rtype_abs`) —
-                // emit it directly instead of leaving the graph-less intrinsic call.
-                if args.len() == 1 && self.is_f64_abs(&reg) {
-                    let res = self
-                        .graph
-                        .alloc_value_var_with_type(crate::model::ConcreteType::Unknown);
-                    self.graph.block_mut(bb_id).operations.push(SpaceOperation {
-                        result: Some(res.clone()),
-                        kind: OpKind::UnaryOp {
-                            op: "abs".to_string(),
-                            operand: args[0].clone(),
-                            result_ty: ValueType::Float,
-                        },
-                    });
-                    self.local_var[dest_local] = Some(res);
-                    let target_bb = self.block_id[target];
-                    let link_args = self.edge_args(mir_bb, target)?;
-                    self.graph.set_goto(bb_id, target_bb, link_args);
-                    return Ok(());
-                }
                 // The concrete container `IntoIterator::into_iter` impls
                 // (`&[T]`/`Vec`/`[T;N]`) construct a container iterator.
                 // Emit the `iter` operation on the container receiver — the
@@ -7593,20 +7573,6 @@ impl<'a> Lowering<'a> {
         self.llbc
             .fn_by_id(*id)
             .is_some_and(|fd| fd.item_meta.name_path() == "core::f64::<Impl>::is_sign_negative")
-    }
-
-    /// `f64::abs(self)` — `core` has no graph body (Opaque), so the callsite would
-    /// skip as an unregistered `FunctionPath`.  `abs` is the `float_abs` unary op
-    /// (`FloatRepr::rtype_abs`); the rtyper's `"abs"` dispatch and the annotator's
-    /// float `abs` (→ `SomeFloat`) already handle it, so emitting `UnaryOp("abs")`
-    /// is enough.
-    fn is_f64_abs(&self, reg: &RegularCall) -> bool {
-        let CallKind::Fun(FunId::Regular { id }) = &reg.kind else {
-            return false;
-        };
-        self.llbc
-            .fn_by_id(*id)
-            .is_some_and(|fd| fd.item_meta.name_path() == "core::f64::<Impl>::abs")
     }
 
     /// `majit_metainterp::jit::promote(x)` = `hint(x, promote=True)`

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -5761,6 +5761,46 @@ impl<'a> Lowering<'a> {
                     self.graph.set_goto(bb_id, target_bb, link_args);
                     return Ok(());
                 }
+                // `f64::is_finite(x)` is `(x - x) == 0.0` — emit the
+                // arithmetic directly instead of an unresolved call.
+                if args.len() == 1 && self.is_f64_is_finite(&reg) {
+                    let zero = self
+                        .graph
+                        .alloc_value_var_with_type(crate::model::ConcreteType::Unknown);
+                    self.graph.block_mut(bb_id).operations.push(SpaceOperation {
+                        result: Some(zero.clone()),
+                        kind: OpKind::ConstFloat(0),
+                    });
+                    let diff = self
+                        .graph
+                        .alloc_value_var_with_type(crate::model::ConcreteType::Unknown);
+                    self.graph.block_mut(bb_id).operations.push(SpaceOperation {
+                        result: Some(diff.clone()),
+                        kind: OpKind::BinOp {
+                            op: "sub".to_string(),
+                            lhs: args[0].clone(),
+                            rhs: args[0].clone(),
+                            result_ty: ValueType::Float,
+                        },
+                    });
+                    let res = self
+                        .graph
+                        .alloc_value_var_with_type(crate::model::ConcreteType::Unknown);
+                    self.graph.block_mut(bb_id).operations.push(SpaceOperation {
+                        result: Some(res.clone()),
+                        kind: OpKind::BinOp {
+                            op: "eq".to_string(),
+                            lhs: diff.clone(),
+                            rhs: zero.clone(),
+                            result_ty: ValueType::Int,
+                        },
+                    });
+                    self.local_var[dest_local] = Some(res);
+                    let target_bb = self.block_id[target];
+                    let link_args = self.edge_args(mir_bb, target)?;
+                    self.graph.set_goto(bb_id, target_bb, link_args);
+                    return Ok(());
+                }
                 // The concrete container `IntoIterator::into_iter` impls
                 // (`&[T]`/`Vec`/`[T;N]`) construct a container iterator.
                 // Emit the `iter` operation on the container receiver — the
@@ -7459,6 +7499,21 @@ impl<'a> Lowering<'a> {
         self.llbc
             .fn_by_id(*id)
             .is_some_and(|fd| fd.item_meta.name_path() == "core::f64::<Impl>::is_nan")
+    }
+
+    /// `f64::is_finite(self)` — `core` has no graph body (Opaque), so the
+    /// callsite would skip as an unregistered `FunctionPath`.  `is_finite`
+    /// is `(x - x) == 0.0`: finite `x` gives `0.0 == 0.0` = true, while ±inf
+    /// and NaN both make `x - x` NaN so the equality is false.  The float
+    /// `sub` carries no reflexive `sub(x, x) => 0` fold (unlike the integer
+    /// bank), preserving the inf/NaN truth value.
+    fn is_f64_is_finite(&self, reg: &RegularCall) -> bool {
+        let CallKind::Fun(FunId::Regular { id }) = &reg.kind else {
+            return false;
+        };
+        self.llbc
+            .fn_by_id(*id)
+            .is_some_and(|fd| fd.item_meta.name_path() == "core::f64::<Impl>::is_finite")
     }
 
     /// `majit_metainterp::jit::promote(x)` = `hint(x, promote=True)`

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -5801,6 +5801,70 @@ impl<'a> Lowering<'a> {
                     self.graph.set_goto(bb_id, target_bb, link_args);
                     return Ok(());
                 }
+                // `f64::is_sign_negative(x)` is `float2longlong(x) < 0` — reinterpret
+                // the f64 bits as i64 (sign bit = MSB) instead of an unresolved call.
+                if args.len() == 1 && self.is_f64_is_sign_negative(&reg) {
+                    let bits = self
+                        .graph
+                        .alloc_value_var_with_type(crate::model::ConcreteType::Unknown);
+                    self.graph.block_mut(bb_id).operations.push(SpaceOperation {
+                        result: Some(bits.clone()),
+                        kind: OpKind::Call {
+                            target: CallTarget::FunctionPath {
+                                segments: vec![
+                                    "longlong2float".to_string(),
+                                    "float2longlong".to_string(),
+                                ],
+                            },
+                            args: vec![args[0].clone()],
+                            result_ty: ValueType::Int,
+                        },
+                    });
+                    let zero = self
+                        .graph
+                        .alloc_value_var_with_type(crate::model::ConcreteType::Unknown);
+                    self.graph.block_mut(bb_id).operations.push(SpaceOperation {
+                        result: Some(zero.clone()),
+                        kind: OpKind::ConstInt(0),
+                    });
+                    let res = self
+                        .graph
+                        .alloc_value_var_with_type(crate::model::ConcreteType::Unknown);
+                    self.graph.block_mut(bb_id).operations.push(SpaceOperation {
+                        result: Some(res.clone()),
+                        kind: OpKind::BinOp {
+                            op: "lt".to_string(),
+                            lhs: bits.clone(),
+                            rhs: zero.clone(),
+                            result_ty: ValueType::Int,
+                        },
+                    });
+                    self.local_var[dest_local] = Some(res);
+                    let target_bb = self.block_id[target];
+                    let link_args = self.edge_args(mir_bb, target)?;
+                    self.graph.set_goto(bb_id, target_bb, link_args);
+                    return Ok(());
+                }
+                // `f64::abs(x)` is the `float_abs` unary op (`FloatRepr::rtype_abs`) —
+                // emit it directly instead of leaving the graph-less intrinsic call.
+                if args.len() == 1 && self.is_f64_abs(&reg) {
+                    let res = self
+                        .graph
+                        .alloc_value_var_with_type(crate::model::ConcreteType::Unknown);
+                    self.graph.block_mut(bb_id).operations.push(SpaceOperation {
+                        result: Some(res.clone()),
+                        kind: OpKind::UnaryOp {
+                            op: "abs".to_string(),
+                            operand: args[0].clone(),
+                            result_ty: ValueType::Float,
+                        },
+                    });
+                    self.local_var[dest_local] = Some(res);
+                    let target_bb = self.block_id[target];
+                    let link_args = self.edge_args(mir_bb, target)?;
+                    self.graph.set_goto(bb_id, target_bb, link_args);
+                    return Ok(());
+                }
                 // The concrete container `IntoIterator::into_iter` impls
                 // (`&[T]`/`Vec`/`[T;N]`) construct a container iterator.
                 // Emit the `iter` operation on the container receiver — the
@@ -7514,6 +7578,35 @@ impl<'a> Lowering<'a> {
         self.llbc
             .fn_by_id(*id)
             .is_some_and(|fd| fd.item_meta.name_path() == "core::f64::<Impl>::is_finite")
+    }
+
+    /// `f64::is_sign_negative(self)` — `core` has no graph body (Opaque), so the
+    /// callsite would skip as an unregistered `FunctionPath`.  `is_sign_negative`
+    /// is `float2longlong(x) < 0`: reinterpreting the f64 bits as `i64`, the sign
+    /// bit is the MSB, so a negative `i64` means the sign bit is set (true for
+    /// negatives, `-0.0`, and sign-bit-set NaN).  A pure `x < 0.0` would miss
+    /// `-0.0` and NaN, so it must be the bit reinterpret.
+    fn is_f64_is_sign_negative(&self, reg: &RegularCall) -> bool {
+        let CallKind::Fun(FunId::Regular { id }) = &reg.kind else {
+            return false;
+        };
+        self.llbc
+            .fn_by_id(*id)
+            .is_some_and(|fd| fd.item_meta.name_path() == "core::f64::<Impl>::is_sign_negative")
+    }
+
+    /// `f64::abs(self)` — `core` has no graph body (Opaque), so the callsite would
+    /// skip as an unregistered `FunctionPath`.  `abs` is the `float_abs` unary op
+    /// (`FloatRepr::rtype_abs`); the rtyper's `"abs"` dispatch and the annotator's
+    /// float `abs` (→ `SomeFloat`) already handle it, so emitting `UnaryOp("abs")`
+    /// is enough.
+    fn is_f64_abs(&self, reg: &RegularCall) -> bool {
+        let CallKind::Fun(FunId::Regular { id }) = &reg.kind else {
+            return false;
+        };
+        self.llbc
+            .fn_by_id(*id)
+            .is_some_and(|fd| fd.item_meta.name_path() == "core::f64::<Impl>::abs")
     }
 
     /// `majit_metainterp::jit::promote(x)` = `hint(x, promote=True)`

--- a/majit/majit-translate/src/translator/rtyper/annlowlevel.rs
+++ b/majit/majit-translate/src/translator/rtyper/annlowlevel.rs
@@ -1823,24 +1823,24 @@ impl MixLevelHelperAnnotator {
     ///     self.newgraphs.clear()
     /// ```
     ///
-    /// Port blocker: the body forwards into
-    /// `rpython/translator/backendopt/all.py:backend_optimizations`,
-    /// which itself chains the whole backend-opt pipeline (inlining,
-    /// mallocs-removal, constant folding, gc transform, stack check
-    /// insertion, …). None of that subsystem has been ported yet, and
-    /// the existing pyre graph pipeline (`translator/` passes like
-    /// `simplify`, `transform`, `unsimplify`) only covers a subset.
-    /// Until the backendopt.all port lands — which is a
-    /// cross-subsystem effort on its own — this surfaces as a typed
-    /// error so call sites (e.g. `rtyper_finish_helpers`) fail loudly
-    /// instead of silently running un-optimised helper graphs.
+    /// Unreachable in pyre. `backend_optimize` re-optimises the fresh helper
+    /// graphs a GC transformer builds, and its only upstream callers are the
+    /// translation-time GC passes (`rpython/memory/gctransform/`
+    /// {boehm,transform,refcounting,framework}). pyre does not run that
+    /// subsystem: it does not translate itself to C, so it needs no C-level GC
+    /// insertion; it manages memory with the `majit-gc` runtime collector; and
+    /// it inserts JIT GC operations with the backend `GcRewriterAssembler`
+    /// (`majit-gc/rewrite.rs`, the `jit/backend/llsupport/rewrite.py` analog),
+    /// exactly as upstream does for JIT traces rather than through the
+    /// translation-time gctransform. The callee `backend_optimizations` is
+    /// itself ported (`backendopt::all`) with a live caller (`driver`); this
+    /// method stays fail-loud so any future real caller surfaces instead of
+    /// silently running un-optimised helper graphs.
     pub fn backend_optimize(&self) -> Result<(), TyperError> {
-        // Line-by-line skeleton matching the upstream four-line body.
-        // The `backend_optimizations(translator, newgraphs, ...)` call
-        // is the load-bearing step that's blocked on the backendopt
-        // port; we capture the surrounding lines so the structure is
-        // visible at audit time and the convergence is mechanical
-        // once the call is implementable.
+        // Skeleton matching the upstream four-line body, kept so the shape is
+        // visible at audit time. `backend_optimizations` is reachable code
+        // (`backendopt::all`); this wrapper simply has no pyre caller — see the
+        // doc above.
 
         // upstream: translator = self.rtyper.annotator.translator
         let _translator = self
@@ -1854,13 +1854,13 @@ impl MixLevelHelperAnnotator {
         //                                  secondary=True,
         //                                  inline_graph_from_anywhere=True,
         //                                  **flags)
-        // Blocked on `rpython/translator/backendopt/all.py` port; surface
-        // the error before reaching `newgraphs.clear()` so the call
-        // chain fails loudly (rather than silently running un-optimised
-        // helper graphs).
+        // Fail before reaching `newgraphs.clear()`: pyre never runs the
+        // translation-time gctransform passes that call this, so reaching here
+        // means an unexpected caller appeared and should surface loudly.
         Err(TyperError::message(
-            "annlowlevel.py:277 MixLevelHelperAnnotator.backend_optimize port pending \
-             (blocked on rpython/translator/backendopt/all.py port)",
+            "annlowlevel.py:277 MixLevelHelperAnnotator.backend_optimize is unreachable in pyre \
+             (only translation-time gctransform passes call it; pyre uses the majit-gc runtime \
+             collector and the backend GcRewriterAssembler)",
         ))
         // upstream: self.newgraphs.clear() — only runs after a
         // successful backend_optimizations return; the stub never

--- a/majit/majit-translate/src/translator/rtyper/extregistry.rs
+++ b/majit/majit-translate/src/translator/rtyper/extregistry.rs
@@ -184,6 +184,15 @@ pub enum ExtRegistryEntry {
     /// [`Self::WeAreJitted`]); its `compute_annotation` is unreachable in
     /// practice and returns the same opaque shell to stay a faithful port.
     BigIntFrom,
+    /// `longlong2float.float2longlong(f64) -> i64` — RPython
+    /// `Float2LongLongEntry(ExtRegistryEntry)` (`rlib/longlong2float.py:76-86`).
+    /// Reinterprets the f64 bit pattern as a signed longlong via the
+    /// `convert_float_bytes_to_longlong` llop.  Same dual-registration shape as
+    /// [`Self::BigIntFrom`]: the annotation half is served by the
+    /// `longlong2float.float2longlong` `BUILTIN_ANALYZERS` entry
+    /// (`float2longlong_analyzer` → `SomeInteger(r_longlong)`); this entry fires on
+    /// the rtyper's `findbltintyper` → `specialize_call` path.
+    Float2LongLong,
 }
 
 /// Small Send-able annotation payload for static HostObject type
@@ -293,6 +302,7 @@ pub enum ExtRegistryEntryKey {
     /// per-instance identity — the variant tag alone supplies
     /// `self.__class__` and there is no `self.instance`.
     BigIntFrom,
+    Float2LongLong,
 }
 
 impl ExtRegistryEntry {
@@ -329,6 +339,7 @@ impl ExtRegistryEntry {
             },
             ExtRegistryEntry::WeAreJitted => ExtRegistryEntryKey::WeAreJitted,
             ExtRegistryEntry::BigIntFrom => ExtRegistryEntryKey::BigIntFrom,
+            ExtRegistryEntry::Float2LongLong => ExtRegistryEntryKey::Float2LongLong,
         }
     }
 
@@ -457,6 +468,12 @@ impl ExtRegistryEntry {
                     None,
                     false,
                     std::collections::BTreeMap::new(),
+                ),
+            )),
+            ExtRegistryEntry::Float2LongLong => Ok(SomeValue::Integer(
+                crate::annotator::model::SomeInteger::new_with_knowntype(
+                    false,
+                    crate::annotator::model::KnownType::LongLong,
                 ),
             )),
         }
@@ -596,6 +613,11 @@ impl ExtRegistryEntry {
             // is the opaque GcRef; `rtype_bigint_from` emits it.
             ExtRegistryEntry::BigIntFrom => {
                 Ok(super::rbuiltin::rtype_bigint_from as BuiltinTyperFn)
+            }
+            // `rlib/longlong2float.py:83-86` — `Float2LongLongEntry.specialize_call`
+            // emits `genop('convert_float_bytes_to_longlong', [v_float], SignedLongLong)`.
+            ExtRegistryEntry::Float2LongLong => {
+                Ok(super::rbuiltin::rtype_float2longlong as BuiltinTyperFn)
             }
         }
     }
@@ -841,6 +863,9 @@ fn lookup_host_object(host: &HostObject) -> Option<ExtRegistryEntry> {
     // host callable the annotator typed as `SomeBuiltin`.
     if host.qualname() == "BigInt.from" {
         return Some(ExtRegistryEntry::BigIntFrom);
+    }
+    if host.qualname() == "longlong2float.float2longlong" {
+        return Some(ExtRegistryEntry::Float2LongLong);
     }
     if let Some(entry) = host_value_registry().lock().unwrap().get(host).cloned() {
         return Some(entry);

--- a/majit/majit-translate/src/translator/rtyper/extregistry.rs
+++ b/majit/majit-translate/src/translator/rtyper/extregistry.rs
@@ -470,6 +470,14 @@ impl ExtRegistryEntry {
                     std::collections::BTreeMap::new(),
                 ),
             )),
+            // The annotation half is served by the
+            // `longlong2float.float2longlong` `BUILTIN_ANALYZERS` entry
+            // (`float2longlong_analyzer`), which `immutablevalue_hostobject`
+            // resolves before the `extregistry.is_registered` fall-through
+            // (bookkeeper.py:309-314). This entry only fires on the rtyper
+            // path; returning the same `SomeInteger(r_int64)` result that
+            // `Float2LongLongEntry.compute_result_annotation` produces keeps
+            // it a faithful port for any path that consults it.
             ExtRegistryEntry::Float2LongLong => Ok(SomeValue::Integer(
                 crate::annotator::model::SomeInteger::new_with_knowntype(
                     false,

--- a/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
+++ b/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
@@ -511,7 +511,7 @@ fn normalize_unary_op_name(pyre_name: &str) -> Result<String, TyperError> {
         other => Err(TyperError::missing_rtype_operation(format!(
             "normalize_unary_op_name: pyre UnaryOp `{other}` has no \
              flowspace counterpart (operation.py registers \
-             `pos` / `neg` / `invert` / `bool` and the ported `str` \
+             `pos` / `neg` / `abs` / `invert` / `bool` and the ported `str` \
              as unary ops; \
              `same_as` is rtyper's internal renaming op per \
              rtyper.py:478-481; all 13 typed cast names retired \

--- a/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
+++ b/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
@@ -501,17 +501,10 @@ fn normalize_unary_op_name(pyre_name: &str) -> Result<String, TyperError> {
         // string-build lowering (`str(arg)` ++ `ll_strconcat`) in place of
         // the graph-less `fmt::rt::Argument::new_display` chain.
         "str" => Ok("str".to_string()),
-        // `abs` — RPython `add_operator('abs', 1, .., pure=True)`
-        // (`operation.py`), dispatched through `RPythonTyper::translate_op`'s
-        // `"abs"` arm into the per-repr `rtype_abs` (`FloatRepr::rtype_abs` →
-        // `float_abs`; `IntegerRepr::rtype_abs` → `int_abs`).  `front::mir` emits
-        // `OpKind::UnaryOp { op: "abs", .. }` for the `f64::abs` intrinsic in place
-        // of the graph-less callee.
-        "abs" => Ok("abs".to_string()),
         other => Err(TyperError::missing_rtype_operation(format!(
             "normalize_unary_op_name: pyre UnaryOp `{other}` has no \
              flowspace counterpart (operation.py registers \
-             `pos` / `neg` / `abs` / `invert` / `bool` and the ported `str` \
+             `pos` / `neg` / `invert` / `bool` and the ported `str` \
              as unary ops; \
              `same_as` is rtyper's internal renaming op per \
              rtyper.py:478-481; all 13 typed cast names retired \

--- a/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
+++ b/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
@@ -501,6 +501,13 @@ fn normalize_unary_op_name(pyre_name: &str) -> Result<String, TyperError> {
         // string-build lowering (`str(arg)` ++ `ll_strconcat`) in place of
         // the graph-less `fmt::rt::Argument::new_display` chain.
         "str" => Ok("str".to_string()),
+        // `abs` — RPython `add_operator('abs', 1, .., pure=True)`
+        // (`operation.py`), dispatched through `RPythonTyper::translate_op`'s
+        // `"abs"` arm into the per-repr `rtype_abs` (`FloatRepr::rtype_abs` →
+        // `float_abs`; `IntegerRepr::rtype_abs` → `int_abs`).  `front::mir` emits
+        // `OpKind::UnaryOp { op: "abs", .. }` for the `f64::abs` intrinsic in place
+        // of the graph-less callee.
+        "abs" => Ok("abs".to_string()),
         other => Err(TyperError::missing_rtype_operation(format!(
             "normalize_unary_op_name: pyre UnaryOp `{other}` has no \
              flowspace counterpart (operation.py registers \

--- a/majit/majit-translate/src/translator/rtyper/rbuiltin.rs
+++ b/majit/majit-translate/src/translator/rtyper/rbuiltin.rs
@@ -1533,6 +1533,24 @@ pub fn rtype_bigint_from(hop: &HighLevelOp, _kwds_i: &HashMap<String, usize>) ->
     Ok(hop.genop("direct_call", vlist, GenopResult::Repr(r_result)))
 }
 
+/// `rlib/longlong2float.py:83-86` — `Float2LongLongEntry.specialize_call`:
+/// `hop.inputargs(lltype.Float)`, `hop.exception_cannot_occur()`,
+/// `return hop.genop("convert_float_bytes_to_longlong", [v_float], SignedLongLong)`.
+pub fn rtype_float2longlong(
+    hop: &HighLevelOp,
+    _kwds_i: &HashMap<String, usize>,
+) -> RTypeResult {
+    use crate::translator::rtyper::rtyper::GenopResult;
+
+    let vlist = hop.inputargs(vec![ConvertedTo::LowLevelType(&LowLevelType::Float)])?;
+    hop.exception_cannot_occur()?;
+    Ok(hop.genop(
+        "convert_float_bytes_to_longlong",
+        vlist,
+        GenopResult::LLType(LowLevelType::SignedLongLong),
+    ))
+}
+
 /// `@typer_for(pyre_object.lltype.malloc_raw)` — residual external
 /// lowering of the raw (non-GC) typed allocation intrinsic
 /// `malloc_raw::<T>(value: T) -> *mut T` (`malloc_raw_alloc` annotator

--- a/majit/majit-translate/src/translator/rtyper/rbuiltin.rs
+++ b/majit/majit-translate/src/translator/rtyper/rbuiltin.rs
@@ -1536,10 +1536,7 @@ pub fn rtype_bigint_from(hop: &HighLevelOp, _kwds_i: &HashMap<String, usize>) ->
 /// `rlib/longlong2float.py:83-86` — `Float2LongLongEntry.specialize_call`:
 /// `hop.inputargs(lltype.Float)`, `hop.exception_cannot_occur()`,
 /// `return hop.genop("convert_float_bytes_to_longlong", [v_float], SignedLongLong)`.
-pub fn rtype_float2longlong(
-    hop: &HighLevelOp,
-    _kwds_i: &HashMap<String, usize>,
-) -> RTypeResult {
+pub fn rtype_float2longlong(hop: &HighLevelOp, _kwds_i: &HashMap<String, usize>) -> RTypeResult {
     use crate::translator::rtyper::rtyper::GenopResult;
 
     let vlist = hop.inputargs(vec![ConvertedTo::LowLevelType(&LowLevelType::Float)])?;


### PR DESCRIPTION
Two rtyper-cutover coverage advances on the Charon frontend, both moving
build-time tracer graphs from the legacy-walker fallback onto the real
`RPythonTyper` in the dual-gate.

# Part 1 — f64 intrinsic MIR lowering

Lowers two Rust `f64` intrinsics recognized by the Charon frontend into MIR
so the build-time tracer codegen rtypes through the real `RPythonTyper` instead
of falling back to the legacy walker. Each was previously a Phase-A prepass skip.

- **`f64::is_finite` → `(x - x) == 0.0`** — the same JIT-path formula RPython's
  `ll_math.py` uses; the opaque Rust intrinsic is recognized in the MIR front and
  lowered to the arithmetic form (no new flow op).

- **`f64::is_sign_negative` → `float2longlong(x) < 0`** — has no PyPy flow
  operation, so it ports RPython's `Float2LongLongEntry` (`rlib/longlong2float.py`)
  end-to-end:
  - annotator `float2longlong` analyzer: `Float → SomeInteger(LongLong)`;
  - a synthetic `longlong2float` `HostObject` module + split
    builtin/extregistry registration (the `BigInt.from` host-callable pattern);
  - `extregistry` `Float2LongLong` entry whose `specialize_call` emits the
    `convert_float_bytes_to_longlong` genop.
  The sign-bit reinterpretation preserves `-0.0` and sign-bit-set NaNs, which a
  plain `x < 0.0` would miscompile.

- Corrects the `backend_optimize` stub rationale comment.

Newly Matched build-time graphs: `pack_half`, `format_with_spec`, `float_copysign`.

> **`f64::abs` lowering was attempted then reverted** (commit `front: drop f64::abs
> MIR lowering`). `abs`'s sole build-time caller is `complex_truediv`, which
> reaches codegen through the legacy walker (a downstream float `//` mislabel and
> a two-phase divergence keep it off the real rtyper). The legacy walker mis-kinds
> the float `abs` to an unwired `int_abs/f>f` opname, tripping the
> `default_bh_builder_unwired_set_matches_task_85` snapshot gate. The lowering
> matched zero rtyped graphs, so it was dropped; `is_finite` / `is_sign_negative`
> are unaffected.

# Part 2 — withdrawn struct-leaf classdef redirect

Fixes the largest coherent Phase-A bucket: field accessors whose receiver is a
`(*(obj as *const X)).field` cast (`function_get_code`, `w_method_get_class`, …)
annotated against an **attrs-empty** `SomeInstance(classdef=X)`, so every field
`getattr` blocked with "operation cannot succeed".

Root cause: `harden_duplicate_leaf_metadata` groups registry keys by their last
`::` segment across **both** struct keys and enum-variant keys, and withdraws the
bare-leaf field alias when a struct leaf collides with an enum variant of the same
name — e.g. struct `pyre_interpreter::function::Function` (16 fields) vs the
`ConstValue::Function` enum variant (1 field), and struct `Method` vs
`CallTarget::Method`. With the bare `Function`/`Method` alias removed,
`project_struct_rows` finds no rows and the classdef stays attrs-empty.

`getuniqueclassdef_for_struct_root` now redirects a bare-leaf `root` that has no
`fields` entry to the **unique surviving non-enum-base qualified struct key**
ending in that leaf, projecting its rows onto the classdef. An ambiguous leaf
(≥2 real struct keys) or an unwithdrawn leaf is left unchanged.

Instrumented build confirmed `Function` classdef attrs 0→16, `Method` 0→4; the
eight target accessor graphs leave the Phase-A fail set (aggregate 313→304).

## Verification

- `python pyre/check.py --backend dynasm`: **synthetic parity 169/169 ALL PASSED**;
  full suite 179 passed / 1 "failed" where the lone fail is the `nested_loop` ×2
  perf-ratio gate (pyre ~0.45s vs pypy ~0.21s). That gate is **proven
  pre-existing**, not introduced here: a same-load A/B (baseline rebuilt from
  `HEAD`, `nested_loop` measured back-to-back) gives **baseline median 0.45s ==
  fix median 0.45s** — pyre is inherently ~2× pypy on nested integer loops, right
  at the borderline gate. `raise_catch` confirmed a pure timing flake (FAIL ×1.5
  → PASS ×1.4 across runs).
- `python pyre/check.py --backend cranelift`: 163/163 green for the f64 part
  (backend-agnostic code path identical).
- Codex parity review clean on the f64 lowerings: documented structural
  adaptations with in-code citations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for `longlong2float.float2longlong` conversions.
  - Improved handling of floating-point operations including absolute value, finiteness checks, and sign detection.
  - Added support for the `abs` unary operation in translated code.

- **Bug Fixes**
  - Improved resolution of qualified struct definitions when metadata omits bare struct entries.
  - Updated unsupported backend optimization reporting with a clearer unreachable-path error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
