### PR TITLE
jit: residual-decline diagnostics + str/tuple __mul__ getindex_w parity

### DIFF
--- a/pyre/bench/synth/sequence_repeat_index.py
+++ b/pyre/bench/synth/sequence_repeat_index.py
@@ -1,0 +1,41 @@
+# str/tuple `*` route the repeat count through getindex_w: a custom __index__
+# repeats the sequence just like list/bytes, and an out-of-index-range __index__
+# raises OverflowError naming the original operand. A hot loop first warms
+# str/tuple `__mul__` with plain ints so the trace JIT compiles the repeat path,
+# then a deterministic tail exercises the custom-__index__ cases and catches the
+# overflows. Deterministic.
+class Three:
+    def __index__(self):
+        return 3
+
+
+class BigIndex:
+    def __index__(self):
+        return 1 << 70
+
+
+def warm(n):
+    acc = 0
+    for i in range(n):
+        k = i % 5 + 1
+        acc += len("ab" * k)
+        acc += len((7,) * k)
+    return acc
+
+
+def repeat(w_seq, w_count):
+    try:
+        return repr(w_seq * w_count)
+    except (OverflowError, TypeError) as e:
+        return f"{type(e).__name__} {e}"
+
+
+def main():
+    print("warm", warm(15000))
+    print("tuple three", repeat((7,), Three()))
+    print("str three", repeat("ab", Three()))
+    print("tuple big", repeat((7,), BigIndex()))
+    print("str big", repeat("ab", BigIndex()))
+
+
+main()

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -2366,28 +2366,36 @@ fn init_list_type(ns: &mut DictStorage) {
     }
 }
 
-/// Coerce a `list * n` / `list *= n` repeat count through `__index__`
-/// (`space.getindex_w`).  An operand without `__index__` yields `None`, which
-/// the caller maps to NotImplemented so the `*`/`*=` operator can try a
-/// reflected `__rmul__` and otherwise emit the "can't multiply sequence by
-/// non-int" message; any other coercion error propagates.
+/// `space.getindex_w(w_obj, space.w_OverflowError)`: run `w_obj.__index__()`
+/// and return the resulting int/long object, converting an out-of-index-range
+/// value to an `OverflowError` that names the ORIGINAL operand (not the
+/// `__index__` result). A non-`__index__` operand raises the `TypeError` from
+/// `space.index`. Callers that repeat a sequence share this so `str`/`tuple`
+/// honour a custom `__index__` exactly like `list`/`bytes`.
+fn getindex_repeat(w_obj: PyObjectRef) -> Result<PyObjectRef, crate::PyError> {
+    let w_count = crate::baseobjspace::space_index(w_obj)?;
+    match crate::baseobjspace::int_w(w_count) {
+        Ok(_) => Ok(w_count),
+        Err(e) if e.kind == crate::PyErrorKind::OverflowError => Err(crate::PyError::new(
+            crate::PyErrorKind::OverflowError,
+            format!(
+                "cannot fit '{}' into an index-sized integer",
+                crate::baseobjspace::object_functionstr_type_name(w_obj)
+            ),
+        )),
+        Err(e) => Err(e),
+    }
+}
+
+/// Coerce a `list`/`tuple` `* n` / `*= n` repeat count through `getindex_repeat`
+/// (`getindex_w`). An operand without `__index__` yields `None`, which the
+/// caller maps to NotImplemented so the `*`/`*=` operator can try a reflected
+/// `__rmul__` and otherwise emit the "can't multiply sequence by non-int"
+/// message; any other coercion error propagates. This is `descr_mul`'s
+/// `try/except TypeError -> NotImplemented` wrapper (`listobject.py`).
 fn list_repeat_index(w_obj: PyObjectRef) -> Result<Option<PyObjectRef>, crate::PyError> {
-    match crate::baseobjspace::space_index(w_obj) {
-        Ok(w_count) => {
-            // getindex_w(w_obj, OverflowError): an out-of-index-range value
-            // reports the original operand's type, not the __index__ result.
-            match crate::baseobjspace::int_w(w_count) {
-                Ok(_) => Ok(Some(w_count)),
-                Err(e) if e.kind == crate::PyErrorKind::OverflowError => Err(crate::PyError::new(
-                    crate::PyErrorKind::OverflowError,
-                    format!(
-                        "cannot fit '{}' into an index-sized integer",
-                        crate::baseobjspace::object_functionstr_type_name(w_obj)
-                    ),
-                )),
-                Err(e) => Err(e),
-            }
-        }
+    match getindex_repeat(w_obj) {
+        Ok(w_count) => Ok(Some(w_count)),
         Err(e) if e.kind == crate::PyErrorKind::TypeError => Ok(None),
         Err(e) => Err(e),
     }
@@ -2852,14 +2860,15 @@ fn init_str_type(ns: &mut DictStorage) {
             "__mul__",
             |args| {
                 crate::type_methods::arity_slot(args, 1)?;
-                if unsafe { pyre_object::pyobject::is_int_or_long(args[1]) } {
-                    unsafe { crate::objspace::descroperation::str_repeat(args[0], args[1]) }
+                // unicodeobject descr_mul = getindex_w (no NotImplemented
+                // wrapper), so a non-__index__ operand raises and a custom
+                // __index__ (incl. an out-of-range one) is honoured.
+                let w_count = if unsafe { pyre_object::pyobject::is_int_or_long(args[1]) } {
+                    args[1]
                 } else {
-                    let count = crate::builtins::space_index_w(args[1])?;
-                    unsafe {
-                        crate::objspace::descroperation::str_repeat(args[0], w_int_new(count))
-                    }
-                }
+                    getindex_repeat(args[1])?
+                };
+                unsafe { crate::objspace::descroperation::str_repeat(args[0], w_count) }
             },
             2,
         ),
@@ -5031,14 +5040,15 @@ fn init_tuple_type(ns: &mut DictStorage) {
 /// raises the `__index__` TypeError.
 fn tuple_descr_mul(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     crate::type_methods::arity_slot(args, 1)?;
-    if unsafe { pyre_object::pyobject::is_int_or_long(args[1]) } {
-        crate::objspace::descroperation::mul(args[0], args[1])
-    } else {
-        // NotImplemented lets the `*` operator try a reflected `__rmul__`
-        // and otherwise emit the "can't multiply sequence by non-int"
-        // message, instead of this method's own slot error.
-        Ok(pyre_object::w_not_implemented())
-    }
+    // tupleobject descr_mul routes the count through getindex_w, so a custom
+    // __index__ repeats the tuple (and an out-of-range one overflows).
+    // A non-__index__ operand yields NotImplemented, letting the `*` operator
+    // try a reflected `__rmul__` and otherwise emit "can't multiply sequence by
+    // non-int", instead of this method's own slot error.
+    let Some(w_count) = list_repeat_index(args[1])? else {
+        return Ok(pyre_object::w_not_implemented());
+    };
+    crate::objspace::descroperation::mul(args[0], w_count)
 }
 
 // ── Int/Float/Bool TypeDef (minimal) ─────────────────────────────────

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -5899,6 +5899,52 @@ pub(crate) enum ResidualExecOutcome {
     Declined(ResidualDecline),
 }
 
+/// Diagnostic (`PYRE_FBW_DEBUG_ABORT`): dump the Python coordinate and per-arg
+/// provenance behind a ValueUnavailable residual decline — the resume py_pc,
+/// the decoded Python opcode, the declined arg's OpRef and whether it is a
+/// constant, and its `box_value`.  Attributes an unj_val census walk to a
+/// knowable-but-unpopulated value versus a genuinely-symbolic heap object
+/// without re-instrumenting.
+fn probe_resid_decline_ctx(
+    ctx: &WalkContext<'_, '_>,
+    why: &str,
+    op_pc: usize,
+    arg_index: usize,
+    arg: OpRef,
+    allboxes: &[OpRef],
+) {
+    let sym = ctx.fbw_mode.snapshot_sym;
+    let (py_pc, opcode) = if !sym.is_null() {
+        let s = unsafe { &*sym };
+        if !s.jitcode.is_null() {
+            let jc = unsafe { &*s.jitcode };
+            let pc = python_pc_for_jitcode_pc(&jc.payload.metadata, op_pc) as usize;
+            let op = if !jc.payload.code_ptr.is_null() {
+                pyre_interpreter::decode_instruction_at(unsafe { &*jc.payload.code_ptr }, pc)
+                    .map(|(i, _)| format!("{i:?}"))
+            } else {
+                None
+            };
+            (Some(pc), op)
+        } else {
+            (None, None)
+        }
+    } else {
+        (None, None)
+    };
+    let box_v = ctx.trace_ctx.box_value(arg);
+    let arg_id = if arg.is_constant() || arg.is_none() {
+        "const".to_string()
+    } else {
+        format!("r{}", arg.raw())
+    };
+    eprintln!(
+        "[fbw-resid-decline] {why} op_pc={op_pc} py_pc={py_pc:?} py_op={opcode:?} \
+         arg_index={arg_index} arg={arg_id} box_value={box_v:?} nargs={}",
+        allboxes.len() - 1,
+    );
+}
+
 fn try_execute_residual_call_via_executor(
     ctx: &mut WalkContext<'_, '_>,
     call_opcode: OpCode,
@@ -6066,10 +6112,13 @@ fn try_execute_residual_call_via_executor(
                         });
                     }
                     if fbw_debug_abort_enabled() {
-                        eprintln!(
-                            "[fbw-resid-decline] NO_CONCRETE op_pc={op_pc} arg_index={arg_index} \
-                             helper={:?} opcode={call_opcode:?}",
-                            call_descr.get_extra_info().pyre_helper
+                        probe_resid_decline_ctx(
+                            ctx,
+                            "NO_CONCRETE",
+                            op_pc,
+                            arg_index,
+                            arg,
+                            allboxes,
                         );
                     }
                     return Ok(ResidualExecOutcome::Declined(
@@ -6088,11 +6137,7 @@ fn try_execute_residual_call_via_executor(
                     });
                 }
                 if fbw_debug_abort_enabled() {
-                    eprintln!(
-                        "[fbw-resid-decline] box_value=None op_pc={op_pc} arg_index={arg_index} \
-                         helper={:?} opcode={call_opcode:?}",
-                        call_descr.get_extra_info().pyre_helper
-                    );
+                    probe_resid_decline_ctx(ctx, "box_value=None", op_pc, arg_index, arg, allboxes);
                 }
                 return Ok(ResidualExecOutcome::Declined(
                     ResidualDecline::ValueUnavailable,

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -5938,9 +5938,15 @@ fn probe_resid_decline_ctx(
     } else {
         format!("r{}", arg.raw())
     };
+    // The declined arg's semantic register slot and its index-keyed concrete
+    // shadow (`concrete_registers_r`): a `Null` shadow at a found slot with a
+    // `None` box_value is the bridge-resume seed gap (neither store populated).
+    let reg_slot = ctx.registers_r.iter().position(|&r| r == arg);
+    let shadow = reg_slot.and_then(|s| ctx.concrete_registers_r.get(s));
     eprintln!(
         "[fbw-resid-decline] {why} op_pc={op_pc} py_pc={py_pc:?} py_op={opcode:?} \
-         arg_index={arg_index} arg={arg_id} box_value={box_v:?} nargs={}",
+         arg_index={arg_index} arg={arg_id} box_value={box_v:?} reg_slot={reg_slot:?} \
+         reg_shadow={shadow:?} nargs={}",
         allboxes.len() - 1,
     );
 }


### PR DESCRIPTION
Three commits on this branch.

## JIT residual-decline diagnostics (diagnostic-logging only, no behavior change)
- `jit: enrich residual value-unavailable decline log` — expands the residual value-unavailable decline diagnostic in `jitcode_dispatch.rs` with per-value availability detail.
- `jit: report register-shadow state in residual decline log` — adds register-shadow state to the same decline log.

## str/tuple `__mul__` route repeat count via getindex_w
`str *` used `space_index_w` (i64-truncating) and `tuple *` declined any non-int with `NotImplemented`, so a custom `__index__` returning an out-of-index-range value raised a wrong `TypeError` and `tuple` ignored a custom `__index__` entirely.

Extract `getindex_repeat` (`getindex_w` with `w_OverflowError`) shared by `list`/`str`/`tuple` `descr_mul`:
- a custom `__index__` repeats the sequence,
- an out-of-range one raises `OverflowError` naming the original operand,
- a non-`__index__` operand raises (`str`) or declines to `NotImplemented` (`list`, `tuple`).

Matches `unicodeobject`/`tupleobject`/`listobject` `descr_mul`. Adds `pyre/bench/synth/sequence_repeat_index.py` regression test (cpython==pypy baseline, exercises `(7,)*Three()`→`(7,7,7)`, `'ab'*Three()`→`'ababab'`, and out-of-range `__index__`→`OverflowError`).

## Verification
Branch-level `pyre/check.py`: cranelift 180/180, wasm 179/179, dynasm 179 passed (the one `raise_catch` miss is a timing-only perf-gate flake — passes on isolated re-run). New synth test PASS on dynasm/cranelift/wasm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)