### PR TITLE
#205 DictStorage-elim (1/3): converge module globals to the proxy-free W_ModuleDictObject

### DIFF
--- a/pyre/bench/synth/exec_defined_global_read.py
+++ b/pyre/bench/synth/exec_defined_global_read.py
@@ -4,9 +4,8 @@ N = 200
 def main():
     # A function defined inside `exec(src, fresh_dict)` captures the fresh
     # dict as its `__globals__`.  Calling it enough to JIT-compile a trace
-    # must keep resolving its module globals (LOAD_GLOBAL `ADDEND`) — the
-    # frame's globals object is the exec dict, and its backing storage must
-    # stay live after `exec` returns.
+    # must keep resolving its module globals (LOAD_GLOBAL `ADDEND`) through
+    # that dict object; no separate backing storage is involved.
     ns = {}
     exec(
         "ADDEND = 3\n"

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -8728,46 +8728,12 @@ pub fn pick_builtin(
     w_globals: *mut crate::DictStorage,
     exec_ctx: *const crate::PyExecutionContext,
 ) -> PyObjectRef {
-    if !w_globals.is_null() {
-        if let Some(w_builtin) = crate::dict_storage_get(unsafe { &*w_globals }, "__builtins__") {
-            if !w_builtin.is_null() {
-                // moduledef.py:100-101 `if w_builtin is space.builtin: return
-                // space.builtin` — Module identity short-circuit.
-                if !exec_ctx.is_null() {
-                    let space_builtin = unsafe { (*exec_ctx).get_builtin() };
-                    if !space_builtin.is_null() && std::ptr::eq(w_builtin, space_builtin) {
-                        return w_builtin;
-                    }
-                }
-                // moduledef.py:104 `isinstance(w_builtin, module.Module)`.
-                if unsafe { pyre_object::is_module(w_builtin) } {
-                    return w_builtin;
-                }
-                // moduledef.py:102-103 `space.isinstance_w(w_builtin, w_dict)`.
-                // PyPy: `return module.Module(space, None, w_builtin)` —
-                // a Module wrapping the caller's dict.  `LOAD_GLOBAL`
-                // falls through to `space.finditem_str(w_module.w_dict,
-                // name)`, dispatching through any dict subclass
-                // `__getitem__` override.
-                let backing = crate::type_methods::resolve_dict_backing(w_builtin);
-                if !backing.is_null() {
-                    return pyre_object::w_module_new_aliasing_dict(
-                        "",
-                        std::ptr::null_mut(),
-                        w_builtin,
-                    );
-                }
-                // Fall through — `__builtins__` is not Module/dict (e.g.
-                // `42`, a list, ...).  PyPy moduledef.py:106-108 builds
-                // the default empty Module here.
-            }
-        }
-    }
-    // moduledef.py:106-108 default — anonymous Module with only
-    // `None=w_None`.  This is reached when (a) `w_globals` is null,
-    // (b) `__builtins__` is absent from globals, or (c) `__builtins__`
-    // is not Module/dict.
-    build_default_pick_builtin_module()
+    let w_globals = if w_globals.is_null() {
+        pyre_object::PY_NULL
+    } else {
+        dict_storage_to_dict(w_globals)
+    };
+    pick_builtin_obj(w_globals, exec_ctx)
 }
 
 /// Object-based `pick_builtin` for call frames whose globals came from

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -6206,66 +6206,6 @@ fn exec_or_eval(
         }
     }
 
-    /// Ensure the globals dict OBJECT carries the shadow `DictStorage`
-    /// required by the transitional back-mirror bridge.
-    ///
-    /// `pypy/interpreter/pyopcode.py:771-776` runs the frame on the user
-    /// dict directly. Module dicts and dicts returned by `globals()` already
-    /// carry a proxy — reused as-is, so a second `exec(src, g)` allocates
-    /// nothing (heap-stable).
-    ///
-    /// A fresh dict (`exec(src, {})`) gets one storage allocated,
-    /// pre-populated from its str-keyed entries (LOAD_GLOBAL must see
-    /// bindings the dict already held), back-mirrored (`set_mirror_target`,
-    /// so STORE_GLOBAL / DELETE_GLOBAL through the storage propagate into
-    /// the dict's entries), and attached as the proxy (so the dict's own
-    /// `__setitem__` fans str-keyed writes back into the storage via
-    /// `maybe_sync_dict_storage_store`).  The two halves stand in for
-    /// PyPy's single `W_DictMultiObject`.
-    ///
-    /// The storage is owned by the dict for its lifetime — functions
-    /// defined during the run capture the dict OBJECT as `__globals__`, so it
-    /// is intentionally leaked alongside the dict rather than freed. Retires
-    /// with the `dict_storage_proxy` bridge when the dict becomes the single
-    /// store.
-    fn ensure_globals_storage_proxy(w_globals: pyre_object::PyObjectRef) {
-        if w_globals.is_null() {
-            return;
-        }
-        // Dispatch storage on `resolve_dict_backing` (a dict subclass
-        // resolves to itself; a dict-proxy / mapping to its inner dict),
-        // mirroring PyPy's storage-vs-original split.
-        let backing = unsafe { crate::type_methods::resolve_dict_backing(w_globals) };
-        if backing.is_null() {
-            return;
-        }
-        if !unsafe { pyre_object::w_dict_get_dict_storage_proxy(backing) }.is_null() {
-            // module.__dict__ / globals() / a dict reused across exec —
-            // already storage-backed, nothing to allocate.
-            return;
-        }
-        let mut ns = Box::new(crate::DictStorage::new());
-        unsafe {
-            for (key, value) in pyre_object::w_dict_items(backing) {
-                if !value.is_null() && pyre_object::is_str(key) {
-                    let name = pyre_object::w_str_get_value(key).to_string();
-                    crate::dict_storage_store(&mut ns, &name, value);
-                }
-            }
-            ns.set_mirror_target(backing);
-        }
-        // The fresh immortal storage now holds refs copied out of a GC
-        // dict (possibly young); rescan on the next minor collection.
-        pyre_object::gc_roots::mark_prebuilt_roots_dirty();
-        ns.fix_ptr();
-        let storage_ptr: *mut crate::DictStorage = ns.as_mut() as *mut _;
-        unsafe {
-            pyre_object::w_dict_set_dict_storage_proxy(backing, storage_ptr as *mut u8);
-        }
-        // Owned by the dict for its lifetime; leaked rather than freed.
-        let _ = Box::into_raw(ns);
-    }
-
     fn ensure_eval_builtins(
         w_globals: pyre_object::PyObjectRef,
         exec_ctx: *const crate::PyExecutionContext,
@@ -6412,15 +6352,10 @@ fn exec_or_eval(
     } else {
         pyre_object::w_dict_new()
     };
-    // Seed the str-keyed storage proxy that the LOAD_GLOBAL / STORE_GLOBAL
-    // bytecode fastpath reads, mirroring the dict's str entries.  A dict
-    // already backing a frame (module.__dict__ / globals()) keeps its proxy.
-    ensure_globals_storage_proxy(w_globals);
     // pyopcode.py:773-774 `space.call_method(w_globals, 'setdefault', ...)`
     // (exec) and compiling.py:109-110 `space.setitem_str(w_globals, ...)`
     // (eval) dispatch on the ORIGINAL `w_globals` object so a dict-subclass
-    // `setdefault` / `__contains__` / `__setitem__` override fires; the
-    // str-keyed write fans into the storage proxy seeded above.
+    // `setdefault` / `__contains__` / `__setitem__` override fires.
     if is_eval {
         ensure_eval_builtins(w_globals, exec_ctx)?;
     } else {

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -6206,15 +6206,13 @@ fn exec_or_eval(
         }
     }
 
-    /// Ensure the globals dict OBJECT carries a str-keyed `DictStorage`
-    /// proxy for the bytecode globals fastpath (LOAD_GLOBAL /
-    /// STORE_GLOBAL / DELETE_GLOBAL).
+    /// Ensure the globals dict OBJECT carries the shadow `DictStorage`
+    /// required by the transitional back-mirror bridge.
     ///
     /// `pypy/interpreter/pyopcode.py:771-776` runs the frame on the user
-    /// dict directly; pyre's bytecode handlers still read a `*mut
-    /// DictStorage`, so the dict needs a storage proxy attached.  Module
-    /// dicts and dicts returned by `globals()` already carry one — reused
-    /// as-is, so a second `exec(src, g)` allocates nothing (heap-stable).
+    /// dict directly. Module dicts and dicts returned by `globals()` already
+    /// carry a proxy — reused as-is, so a second `exec(src, g)` allocates
+    /// nothing (heap-stable).
     ///
     /// A fresh dict (`exec(src, {})`) gets one storage allocated,
     /// pre-populated from its str-keyed entries (LOAD_GLOBAL must see
@@ -6226,10 +6224,10 @@ fn exec_or_eval(
     /// PyPy's single `W_DictMultiObject`.
     ///
     /// The storage is owned by the dict for its lifetime — functions
-    /// defined during the run capture the dict OBJECT as `__globals__` and
-    /// recover this storage via `get_w_globals_storage()` — so it is intentionally
-    /// leaked alongside the dict rather than freed.  Retires with the
-    /// `dict_storage_proxy` bridge when the dict becomes the single store.
+    /// defined during the run capture the dict OBJECT as `__globals__`, so it
+    /// is intentionally leaked alongside the dict rather than freed. Retires
+    /// with the `dict_storage_proxy` bridge when the dict becomes the single
+    /// store.
     fn ensure_globals_storage_proxy(w_globals: pyre_object::PyObjectRef) {
         if w_globals.is_null() {
             return;

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -3465,12 +3465,8 @@ impl OpcodeStepExecutor for PyFrame {
     // `maybe_sync_dict_storage_delete`.
     fn delete_global(&mut self, name: &str) -> Result<(), PyError> {
         let w_globals = self.get_w_globals();
-        let found: bool = if w_globals.is_null() {
-            let ns = self.get_w_globals_storage();
-            unsafe { crate::dict_storage_delete(&mut *ns, name) }
-        } else {
-            unsafe { pyre_object::w_dict_delitem_str(w_globals, name) }
-        };
+        let found =
+            !w_globals.is_null() && unsafe { pyre_object::w_dict_delitem_str(w_globals, name) };
         if !found {
             return Err(PyError::key_error(format!("'{name}'")));
         }

--- a/pyre/pyre-interpreter/src/importing.rs
+++ b/pyre/pyre-interpreter/src/importing.rs
@@ -1495,6 +1495,7 @@ fn exec_code_module(
     pathname: Option<&str>,
     cpathname: Option<&str>,
 ) -> Result<PyObjectRef, crate::PyError> {
+    let w_globals = crate::baseobjspace::dict_storage_to_dict(namespace);
     // importing.py:272-274 — setdefault('__builtins__', space.builtin).
     // `fresh_dict_storage` already seeds `__builtins__` for module-shape
     // namespaces; the explicit setdefault here mirrors PyPy's defensive
@@ -1503,7 +1504,7 @@ fn exec_code_module(
     // pointer with no surprises.
     {
         let ns = unsafe { &mut *namespace };
-        if crate::dict_storage_get(ns, "__builtins__").is_none() {
+        if unsafe { pyre_object::w_dict_getitem_str(w_globals, "__builtins__") }.is_none() {
             let ctx = unsafe { &*execution_context };
             let w_builtin = ctx.get_builtin();
             if !w_builtin.is_null() {
@@ -1541,10 +1542,10 @@ fn exec_code_module(
         // (_bootstrap_external.py:1732, 1739).  When the importlib
         // app-level layer lands, the `None` arms will collapse onto the
         // mechanical PyPy port.
-        if crate::dict_storage_get(ns, "__loader__").is_none() {
+        if unsafe { pyre_object::w_dict_getitem_str(w_globals, "__loader__") }.is_none() {
             crate::dict_storage_store(ns, "__loader__", pyre_object::w_none());
         }
-        if crate::dict_storage_get(ns, "__spec__").is_none() {
+        if unsafe { pyre_object::w_dict_getitem_str(w_globals, "__spec__") }.is_none() {
             crate::dict_storage_store(ns, "__spec__", pyre_object::w_none());
         }
     }
@@ -1596,9 +1597,9 @@ pub fn appleveldef_install(ns: &mut DictStorage, source: &str, filename: &str, n
     if let Err(e) = frame.run_with_jit() {
         panic!("appleveldef `{filename}`: exec — {e:?}");
     }
-    let app_ns_ref = unsafe { &*app_ns_ptr };
+    let w_app_globals = frame.get_w_globals();
     for &name in names {
-        match crate::dict_storage_get(app_ns_ref, name) {
+        match unsafe { pyre_object::w_dict_getitem_str(w_app_globals, name) } {
             Some(val) => crate::dict_storage_store(ns, name, val),
             None => panic!("appleveldef `{filename}`: name `{name}` not bound by source"),
         }

--- a/pyre/pyre-interpreter/src/importing.rs
+++ b/pyre/pyre-interpreter/src/importing.rs
@@ -1490,25 +1490,23 @@ fn parse_source_module(pathname: &str, source: &str) -> Result<CodeObject, Strin
 
 fn exec_code_module(
     code: CodeObject,
-    namespace: *mut DictStorage,
+    w_globals: pyre_object::PyObjectRef,
     execution_context: *const PyExecutionContext,
     pathname: Option<&str>,
     cpathname: Option<&str>,
 ) -> Result<PyObjectRef, crate::PyError> {
-    let w_globals = crate::baseobjspace::dict_storage_to_dict(namespace);
     // importing.py:272-274 — setdefault('__builtins__', space.builtin).
-    // `fresh_dict_storage` already seeds `__builtins__` for module-shape
+    // `fresh_module_globals` already seeds `__builtins__` for module-shape
     // namespaces; the explicit setdefault here mirrors PyPy's defensive
-    // call so callers that hand in a pre-built storage (future
+    // call so callers that hand in a pre-built globals object (future
     // `_imp.exec_dynamic`-style entry) still inherit the builtins
     // pointer with no surprises.
-    {
-        let ns = unsafe { &mut *namespace };
-        if unsafe { pyre_object::w_dict_getitem_str(w_globals, "__builtins__") }.is_none() {
-            let ctx = unsafe { &*execution_context };
-            let w_builtin = ctx.get_builtin();
-            if !w_builtin.is_null() {
-                crate::dict_storage_store(ns, "__builtins__", w_builtin);
+    if unsafe { pyre_object::w_dict_getitem_str(w_globals, "__builtins__") }.is_none() {
+        let ctx = unsafe { &*execution_context };
+        let w_builtin = ctx.get_builtin();
+        if !w_builtin.is_null() {
+            unsafe {
+                pyre_object::w_dict_setitem_str(w_globals, "__builtins__", w_builtin);
             }
         }
     }
@@ -1516,10 +1514,11 @@ fn exec_code_module(
     // `Some(pathname)` for source-file imports and `None` for the
     // `write_paths=False` shape (REPL, builtin bootstrap).
     if let Some(p) = pathname {
-        let ns = unsafe { &mut *namespace };
         // importing.py:284 setitem('__file__', w_pathname).
         let w_pathname = pyre_object::w_str_new(p);
-        crate::dict_storage_store(ns, "__file__", w_pathname);
+        unsafe {
+            pyre_object::w_dict_setitem_str(w_globals, "__file__", w_pathname);
+        }
         // importing.py:285 setitem('__cached__', w_cpathname).  PyPy
         // surfaces `space.w_None` when `cpathname is None`, i.e. the
         // import was not satisfied from a `.pyc`.  Pyre has no .pyc
@@ -1528,7 +1527,9 @@ fn exec_code_module(
             Some(c) => pyre_object::w_str_new(c),
             None => pyre_object::w_none(),
         };
-        crate::dict_storage_store(ns, "__cached__", w_cpathname);
+        unsafe {
+            pyre_object::w_dict_setitem_str(w_globals, "__cached__", w_cpathname);
+        }
         // importing.py:286-298 — `_fix_up_module(d, name, pathname,
         // cpathname)`.  PyPy's `_fix_up_module`
         // (`lib-python/3/importlib/_bootstrap_external.py:1728`) sets
@@ -1543,10 +1544,14 @@ fn exec_code_module(
         // app-level layer lands, the `None` arms will collapse onto the
         // mechanical PyPy port.
         if unsafe { pyre_object::w_dict_getitem_str(w_globals, "__loader__") }.is_none() {
-            crate::dict_storage_store(ns, "__loader__", pyre_object::w_none());
+            unsafe {
+                pyre_object::w_dict_setitem_str(w_globals, "__loader__", pyre_object::w_none());
+            }
         }
         if unsafe { pyre_object::w_dict_getitem_str(w_globals, "__spec__") }.is_none() {
-            crate::dict_storage_store(ns, "__spec__", pyre_object::w_none());
+            unsafe {
+                pyre_object::w_dict_setitem_str(w_globals, "__spec__", pyre_object::w_none());
+            }
         }
     }
     let code_ptr = Box::into_raw(Box::new(code));
@@ -1559,7 +1564,8 @@ fn exec_code_module(
     // GENERATOR / COROUTINE / ASYNC_GENERATOR dispatch in
     // pyframe.py:268-273 holds for the import path too, and so an imported
     // module's top-level hot loop reaches the JIT portal.
-    let mut frame = crate::createframe(w_code as *const (), namespace, execution_context, None)?;
+    let mut frame =
+        crate::pyframe::createframe_obj(w_code as *const (), w_globals, execution_context, None)?;
     frame.run_with_jit()
 }
 
@@ -1637,14 +1643,14 @@ fn load_source_module(
     // PyPy equivalent: Module.__init__ creates w_dict = space.newdict()
     // then exec_code_module sets __builtins__ and runs code in w_dict.
     let ctx = unsafe { &*execution_context };
-    let mut namespace = Box::new(ctx.fresh_dict_storage());
-    namespace.fix_ptr();
+    let w_globals = ctx.fresh_module_globals();
+    let _root = pyre_object::gc_roots::push_roots();
+    pyre_object::gc_roots::pin_root(w_globals);
 
     // PyPy `interpreter/module.py:Module.__init__` seeds `__name__` on
-    // the module's w_dict.  `w_module_new(modulename, ns_ptr)` below
-    // does that via `w_dict_setitem_str("__name__", ...)` which the
-    // storage proxy mirrors back into `namespace`, so an explicit
-    // dict_storage_store here would be redundant.
+    // the module's w_dict.  `w_module_new_aliasing_dict` below does that
+    // via `w_dict_setitem_str("__name__", ...)`, so an explicit store
+    // here would be redundant.
     //
     // `__file__`/`__cached__` setting moved into `exec_code_module`
     // (`importing.py:284-285`) so the per-module attribute seeding
@@ -1663,7 +1669,9 @@ fn load_source_module(
     } else {
         modulename
     };
-    crate::dict_storage_store(&mut namespace, "__package__", pyre_object::w_str_new(pkg));
+    unsafe {
+        pyre_object::w_dict_setitem_str(w_globals, "__package__", pyre_object::w_str_new(pkg));
+    }
 
     // Seed `__path__` BEFORE executing the package body so relative imports
     // inside `__init__.py` (`from .sub import *`) resolve against the package
@@ -1672,32 +1680,21 @@ fn load_source_module(
     // sys.path and pick up a same-leaf module from an unrelated package.
     if let Some(dir) = package_dir {
         let path_str = pyre_object::w_str_new(&dir.to_string_lossy());
-        crate::dict_storage_store(
-            &mut namespace,
-            "__path__",
-            pyre_object::w_list_new(vec![path_str]),
-        );
+        unsafe {
+            pyre_object::w_dict_setitem_str(
+                w_globals,
+                "__path__",
+                pyre_object::w_list_new(vec![path_str]),
+            );
+        }
     }
-
-    let ns_ptr = Box::into_raw(namespace);
 
     // Create the module object BEFORE execution and register in sys.modules.
     // PyPy: load_source_module → set_sys_modules BEFORE exec_code_module.
     // This prevents infinite recursion on circular imports.
-    //
-    // `dict_storage_to_dict(ns_ptr)` now constructs a W_ModuleDictObject
-    // (PyPy `dictmultiobject.py:60-69 allocate_and_init_instance(
-    // module=True)` shape) with `dict_storage_proxy = ns_ptr` and
-    // registers it as `DictStorage.mirror_target`, so `module.w_dict`,
-    // `function.__globals__`, and `globals()` all converge on the same
-    // W_ModuleDictObject identity.  Forward writes via the module dict
-    // fan out to the DictStorage; back-mirror updates the strategy
-    // storage in step — the frame-side `*mut DictStorage` carrier
-    // stays valid until `PyFrame.w_globals` migrates to
-    // `PyObjectRef`.  The simpler builtin module loader path (no
-    // frame globals dependency) already uses `W_ModuleDictObject`.
-    let canonical = crate::baseobjspace::dict_storage_to_dict(ns_ptr);
-    let module = pyre_object::w_module_new_aliasing_dict(modulename, ns_ptr as *mut u8, canonical);
+    let canonical = w_globals;
+    let module =
+        pyre_object::w_module_new_aliasing_dict(modulename, std::ptr::null_mut(), canonical);
     set_sys_module(modulename, module);
 
     // PyPy `importing.py:300` passes `pathname`/`cpathname` to
@@ -1708,7 +1705,13 @@ fn load_source_module(
     // On exec failure drop the pre-registered module from sys.modules
     // (`_bootstrap._load`) so a retried import re-runs the body instead of
     // observing a half-built module.
-    if let Err(e) = exec_code_module(code, ns_ptr, execution_context, Some(&pathname_str), None) {
+    if let Err(e) = exec_code_module(
+        code,
+        w_globals,
+        execution_context,
+        Some(&pathname_str),
+        None,
+    ) {
         remove_sys_module(modulename);
         return Err(e);
     }
@@ -1757,28 +1760,28 @@ fn load_namespace_package(
     // Submodule imports resolve against `__path__` exactly as for a regular
     // package.
     let ctx = unsafe { &*execution_context };
-    let mut namespace = Box::new(ctx.fresh_dict_storage());
-    namespace.fix_ptr();
+    let w_globals = ctx.fresh_module_globals();
+    let _root = pyre_object::gc_roots::push_roots();
+    pyre_object::gc_roots::pin_root(w_globals);
 
-    crate::dict_storage_store(
-        &mut namespace,
-        "__package__",
-        pyre_object::w_str_new(modulename),
-    );
+    unsafe {
+        pyre_object::w_dict_setitem_str(
+            w_globals,
+            "__package__",
+            pyre_object::w_str_new(modulename),
+        );
+    }
 
     let path_items: Vec<PyObjectRef> = dirs
         .iter()
         .map(|d| pyre_object::w_str_new(&d.to_string_lossy()))
         .collect();
-    crate::dict_storage_store(
-        &mut namespace,
-        "__path__",
-        pyre_object::w_list_new(path_items),
-    );
+    unsafe {
+        pyre_object::w_dict_setitem_str(w_globals, "__path__", pyre_object::w_list_new(path_items));
+    }
 
-    let ns_ptr = Box::into_raw(namespace);
-    let canonical = crate::baseobjspace::dict_storage_to_dict(ns_ptr);
-    let module = pyre_object::w_module_new_aliasing_dict(modulename, ns_ptr as *mut u8, canonical);
+    let module =
+        pyre_object::w_module_new_aliasing_dict(modulename, std::ptr::null_mut(), w_globals);
     set_sys_module(modulename, module);
     Ok(module)
 }

--- a/pyre/pyre-interpreter/src/importing.rs
+++ b/pyre/pyre-interpreter/src/importing.rs
@@ -1582,10 +1582,9 @@ fn exec_code_module(
 /// each binding in `names` into the caller's module dict `ns`.
 ///
 /// `filename` is used as the source path for tracebacks / co_filename
-/// only.  The intermediate namespace is intentionally leaked: every
-/// function defined in `source` retains it as its `__globals__`, so the
-/// box must outlive the bound names — which, for module-init artifacts,
-/// is "forever".
+/// only.  Every function defined in `source` retains the intermediate
+/// namespace as its `__globals__`; once copied into the caller's module,
+/// those functions keep the namespace transitively reachable.
 pub fn appleveldef_install(ns: &mut DictStorage, source: &str, filename: &str, names: &[&str]) {
     let code = compile_source_with_filename(source, Mode::Exec, filename)
         .unwrap_or_else(|e| panic!("appleveldef `{filename}`: compile failed — {e}"));
@@ -1593,17 +1592,16 @@ pub fn appleveldef_install(ns: &mut DictStorage, source: &str, filename: &str, n
     if ctx.is_null() {
         panic!("appleveldef `{filename}`: no execution context at module init");
     }
-    let mut app_ns = Box::new(unsafe { (*ctx).fresh_dict_storage() });
-    app_ns.fix_ptr();
-    let app_ns_ptr: *mut DictStorage = Box::leak(app_ns);
+    let w_app_globals = unsafe { (*ctx).fresh_module_globals() };
+    let _root = pyre_object::gc_roots::push_roots();
+    pyre_object::gc_roots::pin_root(w_app_globals);
     let code_ptr = Box::into_raw(Box::new(code));
     let w_code = crate::w_code_new(code_ptr as *const ());
-    let mut frame = crate::createframe(w_code as *const (), app_ns_ptr, ctx, None)
+    let mut frame = crate::pyframe::createframe_obj(w_code as *const (), w_app_globals, ctx, None)
         .unwrap_or_else(|e| panic!("appleveldef `{filename}`: createframe — {e:?}"));
     if let Err(e) = frame.run_with_jit() {
         panic!("appleveldef `{filename}`: exec — {e:?}");
     }
-    let w_app_globals = frame.get_w_globals();
     for &name in names {
         match unsafe { pyre_object::w_dict_getitem_str(w_app_globals, name) } {
             Some(val) => crate::dict_storage_store(ns, name, val),

--- a/pyre/pyre-interpreter/src/pyframe.rs
+++ b/pyre/pyre-interpreter/src/pyframe.rs
@@ -144,10 +144,9 @@ pub struct PyFrame {
     /// constructor (or threaded through directly by the obj-taking
     /// constructors), so every reader after construction observes the same
     /// W_DictObject across the frame's lifetime.  This is the source of
-    /// truth: `get_w_globals()` returns it directly and
-    /// `get_w_globals_storage()` recovers the raw storage from it via
-    /// `w_dict_get_dict_storage_proxy`.  Synthetic test stubs that
-    /// hand-build PyFrame without a real globals leave it `PY_NULL`.
+    /// truth: `get_w_globals()` and `get_w_globals_storage()` both return it
+    /// directly.  Synthetic test stubs that hand-build PyFrame without a real
+    /// globals leave it `PY_NULL`.
     pub w_globals: PyObjectRef,
 }
 
@@ -1533,15 +1532,12 @@ impl PyFrame {
         self.code()
     }
 
-    /// pyframe.py:129-133 get_w_globals_storage — the raw `*mut DictStorage`
-    /// backing this frame's globals.  `pyframe.py:49 self.w_globals =
-    /// w_globals` keeps the canonical W_DictObject as the single field;
-    /// pyre's split layout makes `w_globals` that source of truth and
-    /// recovers the raw storage from it via `w_dict_get_dict_storage_proxy`
-    /// (the inverse of `dict_storage_to_dict`).
+    /// pyframe.py:129-133 get_w_globals_storage — return the frame's canonical
+    /// W_DictObject.  `pyframe.py:49 self.w_globals = w_globals` keeps that
+    /// object as the single globals field.
     #[inline]
-    pub fn get_w_globals_storage(&self) -> *mut DictStorage {
-        w_globals_storage(self.w_globals)
+    pub fn get_w_globals_storage(&self) -> PyObjectRef {
+        self.w_globals
     }
 
     /// The canonical W_DictObject for this frame's globals
@@ -1638,13 +1634,13 @@ impl PyFrame {
         // slots, resolved eagerly here exactly as `new_minimal` does, so a
         // frame built through this hook is left in the same state as one
         // built by `createframe`.
-        self.w_builtin =
-            crate::baseobjspace::frame_builtin(w_globals_storage, self.execution_context);
-        self.w_globals = if w_globals_storage.is_null() {
+        let w_globals = if w_globals_storage.is_null() {
             PY_NULL
         } else {
             crate::baseobjspace::dict_storage_to_dict(w_globals_storage)
         };
+        self.w_builtin = crate::baseobjspace::frame_builtin_obj(w_globals, self.execution_context);
+        self.w_globals = w_globals;
         // pyframe.py:103 — stamp `pycode.w_globals` (the first-globals cache
         // the LOAD_GLOBAL fast path keys on); side effect only, since the
         // gated debugdata snapshot retired in favour of `w_globals`.
@@ -1675,7 +1671,7 @@ impl PyFrame {
 
     /// PyPy-compatible `fget_w_globals_storage`.
     #[inline]
-    pub fn fget_w_globals_storage(&self) -> *mut DictStorage {
+    pub fn fget_w_globals_storage(&self) -> PyObjectRef {
         self.get_w_globals_storage()
     }
 
@@ -1821,7 +1817,6 @@ impl PyFrame {
         let nlocals = unsafe { (&*raw).varnames.len() };
         let ncells = unsafe { ncells(&*raw) };
         let size = nlocals + ncells + 16; // small stack
-        let w_builtin = crate::baseobjspace::frame_builtin(w_globals_storage, execution_context);
         // `pyframe.py:98 __init__(self, space, code, w_globals, ...)`
         // stores `w_globals` as the canonical W_DictObject directly.
         // Pyre carries both the raw storage pointer (`w_globals_storage`) and
@@ -1833,6 +1828,7 @@ impl PyFrame {
         } else {
             crate::baseobjspace::dict_storage_to_dict(w_globals_storage)
         };
+        let w_builtin = crate::baseobjspace::frame_builtin_obj(w_globals, execution_context);
         // pyframe.py:103 — stamp `pycode.w_globals`; side effect only (the
         // gated debugdata snapshot retired in favour of `w_globals`).
         unsafe {
@@ -1944,7 +1940,6 @@ impl PyFrame {
         let num_cells = ncells(code_ref);
         let max_stack = code_ref.max_stackdepth as usize;
 
-        let w_builtin = crate::baseobjspace::frame_builtin(w_globals_storage, execution_context);
         // `pyframe.py:98 __init__` — `self.w_globals = w_globals` stores
         // the W_DictObject directly; eager `dict_storage_to_dict`
         // mirrors the identity invariant on pyre's split layout.
@@ -1953,6 +1948,7 @@ impl PyFrame {
         } else {
             crate::baseobjspace::dict_storage_to_dict(w_globals_storage)
         };
+        let w_builtin = crate::baseobjspace::frame_builtin_obj(w_globals, execution_context);
         // pyframe.py:103 — stamp `pycode.w_globals`; side effect only (the
         // gated debugdata snapshot retired in favour of `w_globals`).
         unsafe {
@@ -3211,11 +3207,13 @@ impl PyFrame {
         closure: PyObjectRef,
         allocation: FrameLocalsArrayAllocation,
     ) -> Result<Self, crate::PyError> {
-        let w_builtin = if w_globals.is_null() {
-            crate::baseobjspace::frame_builtin(globals, execution_context)
+        let w_globals = if w_globals.is_null() && !globals.is_null() {
+            crate::baseobjspace::dict_storage_to_dict(globals)
         } else {
-            crate::baseobjspace::frame_builtin_obj_checked(w_globals, execution_context)?
+            w_globals
         };
+        let w_builtin =
+            crate::baseobjspace::frame_builtin_obj_checked(w_globals, execution_context)?;
         Ok(Self::finish_for_call_with_globals_obj(
             code,
             args,
@@ -3247,11 +3245,12 @@ impl PyFrame {
         closure: PyObjectRef,
         allocation: FrameLocalsArrayAllocation,
     ) -> Self {
-        let w_builtin = if w_globals.is_null() {
-            crate::baseobjspace::frame_builtin(globals, execution_context)
+        let w_globals = if w_globals.is_null() && !globals.is_null() {
+            crate::baseobjspace::dict_storage_to_dict(globals)
         } else {
-            crate::baseobjspace::frame_builtin_obj(w_globals, execution_context)
+            w_globals
         };
+        let w_builtin = crate::baseobjspace::frame_builtin_obj(w_globals, execution_context);
         Self::finish_for_call_with_globals_obj(
             code,
             args,
@@ -3590,9 +3589,6 @@ pub fn createframe(
 
 /// `baseobjspace.py:796 createframe` with the globals passed as the dict
 /// OBJECT (`pyframe.py:49 self.w_globals = w_globals` stores the object).
-/// The legacy raw `*mut DictStorage` is recovered from the object via the
-/// proxy back-link only for the `frame_stores_global` check and the
-/// FrameDebugData.w_globals snapshot, both of which retire in later steps.
 pub fn createframe_obj(
     code: *const (),
     w_globals: PyObjectRef,
@@ -3615,12 +3611,11 @@ pub fn createframe_obj(
     // Normalize a dict-subclass globals (`exec(src, G())`) to its inner
     // `__dict_data__` dict.  The storage proxy that LOAD_GLOBAL reads lives
     // on the `W_DictObject`, and downstream readers key off this object —
-    // `get_w_globals_storage`, MAKE_FUNCTION's `function.__globals__`, and the JIT
-    // inline / callee globals readers — so the frame must hold the
+    // `get_w_globals_storage`, MAKE_FUNCTION's `function.__globals__`, and the
+    // JIT inline / callee globals readers — so the frame must hold the
     // `W_DictObject`, not the subclass instance whose layout has no proxy
     // slot.  No-op for a plain dict / module dict (`resolve_dict_backing`
-    // returns the argument).  Converges to holding the object directly when
-    // the raw `DictStorage` proxy retires.
+    // returns the argument).
     let w_globals = if w_globals.is_null() {
         w_globals
     } else {
@@ -3682,21 +3677,6 @@ pub fn createframe_obj(
     remember_frame_locals_array(frame.locals_cells_stack_w);
 
     Ok(frame)
-}
-
-/// Recover the str-keyed storage proxy backing a globals OBJECT.  Resolves
-/// a dict subclass to its inner `__dict_data__` dict first: the proxy lives
-/// on the `W_DictObject`, so reading it straight off the subclass instance
-/// would dereference an unrelated offset.
-pub(crate) fn w_globals_storage(w_globals: PyObjectRef) -> *mut DictStorage {
-    if w_globals.is_null() {
-        return std::ptr::null_mut();
-    }
-    let backing = crate::type_methods::resolve_dict_backing(w_globals);
-    if backing.is_null() {
-        return std::ptr::null_mut();
-    }
-    unsafe { pyre_object::w_dict_get_dict_storage_proxy(backing) as *mut DictStorage }
 }
 
 /// `space.finditem_str(w_obj, key)` — `space.getitem` with KeyError

--- a/pyre/pyre-interpreter/src/reduce_protocol.rs
+++ b/pyre/pyre-interpreter/src/reduce_protocol.rs
@@ -47,15 +47,15 @@ fn handle(which: usize) -> PyObjectRef {
             let mut app_ns = Box::new(unsafe { (*ctx).fresh_dict_storage() });
             app_ns.fix_ptr();
             let app_ns_ptr: *mut crate::DictStorage = Box::leak(app_ns);
+            let w_app_globals = crate::baseobjspace::dict_storage_to_dict(app_ns_ptr);
             crate::importing::appleveldef_install(
                 unsafe { &mut *app_ns_ptr },
                 include_str!("reduce_protocol_app.py"),
                 "reduce_protocol_app.py",
                 &["reduce_1", "reduce_2", "get_slotvalues"],
             );
-            let ns = unsafe { &*app_ns_ptr };
             let get = |name: &str| {
-                crate::dict_storage_get(ns, name)
+                unsafe { pyre_object::w_dict_getitem_str(w_app_globals, name) }
                     .unwrap_or_else(|| panic!("reduce_protocol: `{name}` not bound"))
             };
             [get("reduce_1"), get("reduce_2"), get("get_slotvalues")]

--- a/pyre/pyre-jit-trace/src/descr.rs
+++ b/pyre/pyre-jit-trace/src/descr.rs
@@ -2543,32 +2543,14 @@ pub fn pyframe_code_descr() -> DescrRef {
     field_descr_from_group(&PYFRAME_DESCR_GROUP, 3)
 }
 
-pub fn pyframe_dict_storage_descr() -> DescrRef {
-    field_descr_from_group(&PYFRAME_DESCR_GROUP, 4)
-}
-
 /// R3.3b prep: canonical `PyFrame.w_globals` slot
 /// (PYFRAME_W_GLOBALS_OFFSET).  Used by
 /// `emit_new_pyframe_inline_self_recursive` to populate the
 /// W_DictObject sibling so trace-time chases observe a non-null
-/// PyObjectRef.  R3.3 cutover will fold `pyframe_dict_storage_descr`
-/// into this entry after retiring the adjacent raw slot.
+/// PyObjectRef.  `PyFrame.w_globals` is the single globals slot;
+/// the raw dict-storage accessor has been retired.
 pub fn pyframe_w_globals_obj_descr() -> DescrRef {
     field_descr_from_group(&PYFRAME_DESCR_GROUP, 12)
-}
-
-/// R3.3-b: `W_ModuleDictObject.dict_storage_proxy` field — a raw
-/// `*mut DictStorage` pointer set during module init and stable
-/// for the object's lifetime.  Used by `frame_get_namespace` to
-/// chase from `w_globals` (a W_ModuleDictObject) to the
-/// DictStorage that `load/store_namespace_value` reads.
-pub fn module_dict_storage_proxy_descr() -> DescrRef {
-    make_immutable_field_descr(
-        pyre_object::dictmultiobject::W_MODULE_DICT_STORAGE_PROXY_OFFSET,
-        8,
-        Type::Ref,
-        false,
-    )
 }
 
 /// rewrite.py:665-695 handle_call_assembler scalar field read for the

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -4177,11 +4177,11 @@ fn eval_with_jit_inner(frame: &mut PyFrame) -> PyResult {
 
 fn log_named_global_result(frame: &PyFrame, label: &str) {
     unsafe {
-        let ns = frame.get_w_globals_storage();
-        if ns.is_null() {
+        let w_globals = frame.get_w_globals();
+        if w_globals.is_null() {
             return;
         }
-        let Some(&value) = (*ns).get("result") else {
+        let Some(value) = pyre_object::w_dict_getitem_str(w_globals, "result") else {
             return;
         };
         if value.is_null() {

--- a/pyre/pyrex/src/lib.rs
+++ b/pyre/pyrex/src/lib.rs
@@ -717,21 +717,19 @@ fn run_module(module: &str, no_site: bool) {
 
     // `_run_module_as_main` reads `sys.modules["__main__"].__dict__` and runs
     // the module's code in it, so a `__main__` module backed by a fresh dict
-    // must exist before runpy is imported. Reuse the canonical W_DictObject
-    // paired with the storage so `__main__.__dict__` and `globals()` share one
-    // identity (module.py:77 Module.getdict()).
-    let mut namespace = Box::new(execution_context.fresh_dict_storage());
-    namespace.fix_ptr();
-    pyre_interpreter::dict_storage_store(
-        &mut namespace,
-        "__name__",
-        pyre_object::w_str_new("__main__"),
-    );
-    let namespace = Box::into_raw(namespace);
-    let canonical = pyre_interpreter::baseobjspace::dict_storage_to_dict(namespace);
+    // must exist before runpy is imported. Use the canonical W_DictObject so
+    // `__main__.__dict__` and `globals()` share one identity (module.py:77
+    // Module.getdict()).
+    let w_globals = execution_context.fresh_module_globals();
+    let _root = pyre_object::gc_roots::push_roots();
+    pyre_object::gc_roots::pin_root(w_globals);
+    unsafe {
+        pyre_object::w_dict_setitem_str(w_globals, "__name__", pyre_object::w_str_new("__main__"))
+    };
+    let canonical = w_globals;
     let main_module = pyre_object::module::w_module_new_aliasing_dict(
         "__main__",
-        namespace as *mut u8,
+        std::ptr::null_mut(),
         canonical,
     );
     importing::set_sys_module("__main__", main_module);

--- a/pyre/pyrex/src/repl.rs
+++ b/pyre/pyrex/src/repl.rs
@@ -8,7 +8,7 @@ use rustpython_compiler::{
 
 use pyre_interpreter::call::{register_build_class, set_build_class_exec_ctx};
 use pyre_interpreter::importing;
-use pyre_interpreter::{DictStorage, PyDisplay, PyError, PyExecutionContext, dict_storage_store};
+use pyre_interpreter::{PyDisplay, PyError, PyExecutionContext};
 use pyre_jit::eval::eval_with_jit;
 
 use crate::repl_readline::{Readline, ReadlineResult};
@@ -34,7 +34,7 @@ enum ShellExecResult {
 
 struct ReplRuntime {
     ctx_ptr: *const PyExecutionContext,
-    namespace: *mut DictStorage,
+    w_globals: pyre_object::PyObjectRef,
     sys_module: pyre_object::PyObjectRef,
 }
 
@@ -59,23 +59,20 @@ pub fn run_repl(quiet: bool, no_site: bool) {
         pyre_interpreter::module::signal::interp_signal::install_signal_handling(&mut *ec_ptr);
     }
 
-    let mut namespace = Box::new(execution_context.fresh_dict_storage());
-    namespace.fix_ptr();
-    dict_storage_store(
-        &mut namespace,
-        "__name__",
-        pyre_object::w_str_new("__main__"),
-    );
-    let namespace = Box::into_raw(namespace);
+    let w_globals = execution_context.fresh_module_globals();
+    let _root = pyre_object::gc_roots::push_roots();
+    pyre_object::gc_roots::pin_root(w_globals);
+    unsafe {
+        pyre_object::w_dict_setitem_str(w_globals, "__name__", pyre_object::w_str_new("__main__"))
+    };
 
-    // PyPy `module.py:77 Module.getdict()` parity: reuse the canonical
-    // W_DictObject paired with this storage so REPL STORE_NAME writes,
-    // `globals()`, `f.__globals__`, and `__main__.__dict__` all share
-    // one identity.
-    let canonical = pyre_interpreter::baseobjspace::dict_storage_to_dict(namespace);
+    // PyPy `module.py:77 Module.getdict()` parity: use the canonical
+    // W_DictObject so REPL STORE_NAME writes, `globals()`, `f.__globals__`,
+    // and `__main__.__dict__` all share one identity.
+    let canonical = w_globals;
     let main_module = pyre_object::module::w_module_new_aliasing_dict(
         "__main__",
-        namespace as *mut u8,
+        std::ptr::null_mut(),
         canonical,
     );
     importing::set_sys_module("__main__", main_module);
@@ -103,7 +100,7 @@ pub fn run_repl(quiet: bool, no_site: bool) {
 
     let runtime = ReplRuntime {
         ctx_ptr: Rc::into_raw(Rc::clone(&execution_context)),
-        namespace,
+        w_globals,
         sys_module,
     };
 
@@ -246,9 +243,9 @@ fn shell_exec(
         ShellCompileAction::Execute(code) => {
             let code_ptr = Box::into_raw(Box::new(code));
             let w_code = pyre_interpreter::pycode::w_code_new(code_ptr as *const ());
-            let mut frame = match pyre_interpreter::createframe(
+            let mut frame = match pyre_interpreter::pyframe::createframe_obj(
                 w_code as *const (),
-                runtime.namespace,
+                runtime.w_globals,
                 runtime.ctx_ptr,
                 None,
             ) {


### PR DESCRIPTION
## Summary

#205 **DictStorage-elimination, increment 1 of 3 (module globals)**. A module/global namespace used to be carried in **two** parallel representations kept in sync by a "back-mirror bridge": the canonical dict object `W_ModuleDictObject` (celldict) **and** a legacy flat `struct DictStorage` shadow, linked by `W_ModuleDictObject.dict_storage_proxy` ↔ `DictStorage.mirror_target`. The flat shadow is a pyre-local workaround; PyPy carries a module namespace as one `W_ModuleDictObject`.

This increment converges **every module-globals producer** onto the proxy-free celldict shape, so no module-globals namespace allocates or reads a `DictStorage` shadow anymore. The bridge machinery itself **stays** — it is still used by type `__dict__` and instance `__dict__`, which are increments 2 and 3.

## Slices

1. **Reads → object API** (`pyframe.rs`): `get_w_globals_storage` / `fget_w_globals_storage` now return the `w_globals` **object** (`PyObjectRef`), not `*mut DictStorage`; the `w_globals_storage` proxy-chasing helper is removed; `DELETE_GLOBAL`, `pick_builtin`, import defaulting, reduce-protocol, and the JIT global diagnostic read through `w_dict_getitem_str` / `w_dict_delitem_str`.
2. **Source-module import** (`importing.rs`): `load_source_module` / `load_namespace_package` / `exec_code_module` build globals with `fresh_module_globals()` + `createframe_obj`, passing a null storage pointer to `w_module_new_aliasing_dict`.
3. **appleveldef** (`importing.rs`): the app-level-def namespace goes proxy-free the same way.
4. **Embedders** (`pyrex`): `run_module` (`-m`) and `run_repl` build `__main__` proxy-free; `ReplRuntime` carries the dict object; the globals is pinned for the whole session (replaces the old immortal `Box::leak`).
5. **exec/eval** (`builtins.rs`): remove `ensure_globals_storage_proxy` — the exec/eval frame is already object-based and the two direct proxy readers no-op on a null proxy, so the exec dict is the single store.
6. **JIT descriptors** (`descr.rs`): delete the now-dead `pyframe_dict_storage_descr` / `module_dict_storage_proxy_descr` vable accessors.

## Soundness

Each freshly created proxy-free globals object is GC-pinned (`gc_roots::push_roots` + `pin_root`) across the window between creation and the point it becomes reachably rooted (`sys.modules` / the frame / a captured `__globals__`), since seeding and module-object allocation can trigger a collection. The embedder `__main__` globals is pinned for the whole `-m` / REPL session.

## Verification

- `gc_stress` 6/6 and `check.py` **dynasm/cranelift/wasm 180 / 180 / 179** on every slice.
- Embedder smokes: REPL (globals persistence across lines, function `__globals__` capture, post-assignment mutation visible), `-m this` / `-m calendar`.
- exec/eval smokes: fresh-dict `exec` with a JIT-compiled hot global reader, `eval`, dict-subclass globals, post-exec global mutation.
- Adversarial multi-dimension review (GC-rooting, missed proxy readers, exec/eval + dict-subclass semantics, signature-change fallout, PyPy parity) + Codex parity review.

Part of #205. Increment 2 (type dicts, unblocks #528) and increment 3 (instance dicts, then delete `struct DictStorage`) follow.

— *opened by Claude*
