### PR TITLE
majit: address #535 review — gate LABEL dispatch-key entry, fix virtual LABEL sources

### DIFF
--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -16044,6 +16044,10 @@ impl majit_backend::Backend for CraneliftBackend {
         Self::execute_with_inputs_at_dispatch_key(compiled, &inputs, dispatch_key)
     }
 
+    fn supports_dispatch_key_entry(&self) -> bool {
+        true
+    }
+
     fn execute_token_ints(&self, token: &JitCellToken, args: &[i64]) -> DeadFrame {
         let compiled = token
             .compiled

--- a/majit/majit-backend/src/lib.rs
+++ b/majit/majit-backend/src/lib.rs
@@ -1807,6 +1807,16 @@ pub trait Backend: Send {
         self.execute_token(token, args)
     }
 
+    /// Whether [`Backend::execute_token_with_dispatch_key`] honors non-zero
+    /// dispatch keys as alternate compiled-loop entry points.
+    ///
+    /// Backends that use the default `execute_token_with_dispatch_key`
+    /// implementation enter the ordinary token entry regardless of the key, so
+    /// metainterp direct-LABEL handoffs must stay disabled for them.
+    fn supports_dispatch_key_entry(&self) -> bool {
+        false
+    }
+
     /// Execute compiled code with integer-only arguments.
     ///
     /// Avoids the `Value::Int` wrapping/unwrapping overhead when all

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -1553,7 +1553,8 @@ impl<S: JitState> JitDriver<S> {
             return;
         }
         self.meta.single_pass_label_entry_key = self.meta.single_pass_compiled_key.filter(|&key| {
-            self.meta.has_compiled_loop(key)
+            self.meta.backend_supports_dispatch_key_entry()
+                && self.meta.has_compiled_loop(key)
                 && self.meta.loop_header_pc_for(key) != Some(0)
                 && self.meta.front_target_dispatch_key(key).is_some()
         });
@@ -1625,6 +1626,9 @@ impl<S: JitState> JitDriver<S> {
             return None;
         }
         if self.meta.loop_header_pc_for(key) == Some(0) {
+            return None;
+        }
+        if !self.meta.backend_supports_dispatch_key_entry() {
             return None;
         }
         let dispatch_key = self.meta.front_target_dispatch_key(key)?;

--- a/majit/majit-metainterp/src/optimizeopt/unroll.rs
+++ b/majit/majit-metainterp/src/optimizeopt/unroll.rs
@@ -2890,14 +2890,9 @@ impl OptUnroll {
         }
         // unroll.py:462-463 `label_args, virtuals =
         //   virtual_state.make_inputargs_and_virtuals(end_args, self.optimizer)`.
-        let (label_args, virtuals) = virtual_state
-            .make_inputargs_and_virtuals(&end_args, optimizer, ctx, false)
+        let (label_args, virtuals, label_source_positions) = virtual_state
+            .make_inputargs_and_virtuals_with_source_positions(&end_args, optimizer, ctx, false)
             .expect("export_state make_inputargs_and_virtuals failed");
-        let label_source_positions = end_args
-            .iter()
-            .enumerate()
-            .filter_map(|(index, arg)| (!arg.is_constant()).then_some(index))
-            .collect::<Vec<_>>();
         if crate::callee_rca_enabled() {
             eprintln!(
                 "[callee-rca][export-state] original_label_args={:?} end_args={:?} \

--- a/majit/majit-metainterp/src/optimizeopt/virtualstate.rs
+++ b/majit/majit-metainterp/src/optimizeopt/virtualstate.rs
@@ -784,6 +784,59 @@ impl VirtualState {
         Ok((inputargs, virtuals))
     }
 
+    /// Return `make_inputargs_and_virtuals` plus the close-loop live-value
+    /// source positions for each emitted non-virtual LABEL arg.
+    ///
+    /// The positions follow the `make_inputargs` output order from
+    /// virtualstate.py:655-683, not a separate top-level `end_args` filter.
+    /// Top-level virtual entries are skipped, so a LABEL arg produced by a
+    /// virtual field maps to that field's concrete live-value slot when it is
+    /// present in `concrete_refs`.
+    pub fn make_inputargs_and_virtuals_with_source_positions(
+        &self,
+        concrete_refs: &[OpRef],
+        optimizer: &mut crate::optimizeopt::optimizer::Optimizer,
+        ctx: &mut OptContext,
+        force_boxes: bool,
+    ) -> Result<(Vec<OpRef>, Vec<OpRef>, Vec<usize>), ()> {
+        let (inputargs, virtuals) =
+            self.make_inputargs_and_virtuals(concrete_refs, optimizer, ctx, force_boxes)?;
+        let label_source_positions = self
+            .label_source_positions_for_inputargs(concrete_refs, &inputargs, ctx)
+            // No corresponding close-loop live slot: direct LABEL packing
+            // is unavailable for this trace, so leave metadata empty and
+            // let pack_front_target_live_values decline.
+            .unwrap_or_default();
+        Ok((inputargs, virtuals, label_source_positions))
+    }
+
+    fn label_source_positions_for_inputargs(
+        &self,
+        concrete_refs: &[OpRef],
+        inputargs: &[OpRef],
+        ctx: &mut OptContext,
+    ) -> Option<Vec<usize>> {
+        if concrete_refs.len() != self.state.len() {
+            return None;
+        }
+        inputargs
+            .iter()
+            .map(|&inputarg| {
+                let resolved_inputarg = ctx.get_replacement_opref(inputarg);
+                concrete_refs
+                    .iter()
+                    .enumerate()
+                    .find_map(|(index, &candidate)| {
+                        if self.state[index].is_virtual() || candidate.is_constant() {
+                            return None;
+                        }
+                        (ctx.get_replacement_opref(candidate) == resolved_inputarg).then_some(index)
+                    })
+                    .or_else(|| inputarg.is_input_arg().then_some(inputarg.raw() as usize))
+            })
+            .collect()
+    }
+
     /// Walk the virtual state tree the way RPython's `enum_forced_boxes`
     /// does (virtualstate.py:182-198 AbstractVirtualStructStateInfo,
     /// 263-275 VArrayStateInfo, 333-354 VArrayStructStateInfo,
@@ -3157,6 +3210,49 @@ mod tests {
             .expect("make_inputargs_and_virtuals");
         assert_eq!(inputargs, vec![OpRef::int_op(20), OpRef::ref_op(22)]);
         assert_eq!(virtuals, vec![OpRef::ref_op(21)]);
+    }
+
+    #[test]
+    fn test_label_source_positions_follow_make_inputargs_for_virtual_field() {
+        let descr = test_descr(10);
+        let mut ctx = OptContext::new(32);
+        let object = OpRef::ref_op(10);
+        let field = OpRef::int_op(11);
+        let scalar = OpRef::int_op(12);
+        ctx.materialize_operand_at(object);
+        ctx.materialize_operand_at(field);
+        ctx.materialize_operand_at(scalar);
+
+        let object_box = ctx
+            .get_box_replacement_operand_opt(object)
+            .expect("object box is bound");
+        let mut info = PtrInfo::virtual_obj(descr, None);
+        info.setfield(
+            0,
+            crate::history::test_support::rooted_resop_operand(Type::Int, field.raw()),
+        );
+        ctx.set_ptr_info(&object_box, info);
+
+        let state = export_state(&[object, field, scalar], &ctx);
+        let mut optimizer = crate::optimizeopt::optimizer::Optimizer::new();
+        let (inputargs, virtuals, source_positions) = state
+            .make_inputargs_and_virtuals_with_source_positions(
+                &[object, field, scalar],
+                &mut optimizer,
+                &mut ctx,
+                false,
+            )
+            .expect("make_inputargs_and_virtuals_with_source_positions");
+
+        assert_eq!(inputargs, vec![field, scalar]);
+        assert_eq!(virtuals, vec![object]);
+        assert_eq!(
+            source_positions,
+            vec![1, 2],
+            "virtualstate.py:655-683 make_inputargs skips the top-level virtual; \
+             unroll.py:462-465 LABEL packing must source the field slot, not \
+             the virtual object slot"
+        );
     }
 
     /// virtualstate.py:196 / 274 / 352 — `state.position > self.position`

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -14245,6 +14245,10 @@ impl<M: Clone> MetaInterp<M> {
         &mut self.backend
     }
 
+    pub fn backend_supports_dispatch_key_entry(&self) -> bool {
+        self.backend.supports_dispatch_key_entry()
+    }
+
     /// Register a helper that boxes a raw integer into an interpreter object.
     /// PyPy warmspot.py set_param_max_unroll_recursion().
     pub fn set_max_unroll_recursion(&mut self, value: usize) {


### PR DESCRIPTION
Follow-up to the merged #535, addressing the two remaining P1 Codex review comments (the third, "clear stale label-entry handoffs", was already fixed within #535 before merge).

## Gate LABEL dispatch-key entry to supporting backends (#535 review P1)
Only the Cranelift backend overrides `execute_token_with_dispatch_key`; the default impl discards the key and enters the single token entry (peeled preamble). The single-pass LABEL arm was gated only by `front_target_dispatch_key(key).is_some()` (metainterp-level, backend-agnostic), so dynasm/wasm armed a LABEL handoff whose dispatch key they then ignored — entering the preamble with compact LABEL args (preamble replay / wrong arg layout).

Adds `Backend::supports_dispatch_key_entry` (default `false`, Cranelift `true`) and gates both `arm_single_pass_label_entry_on_next_back_edge` and the direct resume-into-compiled-loop helper on it. On dynasm/wasm the handoff is no longer armed and the pre-existing correct back-edge path is used — verified no double-count regression via `check.py` on all three backends.

## Derive single-pass LABEL source positions from make_inputargs order (#535 review P1)
`label_source_positions` was an independent "all non-constant `end_args`" filter, which diverges from `make_inputargs_and_virtuals` output when `end_args` carries a loop-carried virtual: `make_inputargs` skips top-level virtual entries and emits forced fields, so `pack_front_target_live_values` mapped the first LABEL arg to the virtual object slot (or length-mismatched/aborted).

Adds `make_inputargs_and_virtuals_with_source_positions`, deriving the positions from the `make_inputargs` enumeration (virtualstate.py:655-683, unroll.py:462-465). When a LABEL arg has no close-loop live slot, the positions are left empty so `pack_front_target_live_values` declines instead of mispacking. Regression test covers `[virtual_object, field_slot, scalar] -> [1, 2]`.

## Verification
- `cargo test -p majit-metainterp` — 1397 passed, 0 failed.
- `python3 ./pyre/check.py` — dynasm 180/180, cranelift 180/180, wasm 179/179, 3/3 backend runs.

— *PR prepared by Claude*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added runtime capability detection for dispatch-key entry support.
  * Enabled compatible execution backends to use dispatch-key-based entry handling.

* **Bug Fixes**
  * Prevented unsupported execution paths from attempting dispatch-key entry, improving compatibility and reliability.
  * Improved tracking of live values during optimized loop transitions, including nested virtual values.

* **Tests**
  * Added coverage verifying accurate live-value source tracking during exported-state handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->