### PR TITLE
majit/wasm: GC-lifetime fixes + dict/set O(N²) and module-scope JIT resume defects

### DIFF
--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -1674,15 +1674,19 @@ fn gc_owns_object_via_active_runtime(addr: usize) -> bool {
 }
 
 fn gc_is_nursery_object_via_active_runtime(addr: usize) -> bool {
-    CRANELIFT_ACTIVE_GC.with(|cell| match cell.try_borrow_mut() {
-        Ok(mut guard) => guard
-            .as_deref_mut()
-            .map(|gc| gc.is_nursery_object(addr))
-            .unwrap_or(false),
-        Err(_) => CRANELIFT_ACTIVE_GC_RAW.with(|raw| match raw.get() {
-            Some(ptr) => unsafe { (&*ptr).is_nursery_object(addr) },
-            None => false,
+    let via_box = CRANELIFT_ACTIVE_GC.with(|cell| match cell.try_borrow() {
+        Ok(guard) => guard.as_deref().map(|gc| gc.is_nursery_object(addr)),
+        Err(_) => CRANELIFT_ACTIVE_GC_RAW.with(|raw| {
+            raw.get()
+                .map(|ptr| unsafe { (&*ptr).is_nursery_object(addr) })
         }),
+    });
+    via_box.unwrap_or_else(|| {
+        if majit_gc::gc_sync::is_initialized() {
+            majit_gc::gc_sync::gc_query_reentrant(|g| g.is_nursery_object(addr))
+        } else {
+            false
+        }
     })
 }
 

--- a/majit/majit-backend-dynasm/src/runner.rs
+++ b/majit/majit-backend-dynasm/src/runner.rs
@@ -607,15 +607,19 @@ fn dynasm_gc_owns_object(addr: usize) -> bool {
 }
 
 fn dynasm_gc_is_nursery_object(addr: usize) -> bool {
-    DYNASM_ACTIVE_GC.with(|cell| match cell.try_borrow() {
-        Ok(guard) => guard
-            .as_deref()
-            .map(|gc| gc.is_nursery_object(addr))
-            .unwrap_or(false),
-        Err(_) => DYNASM_ACTIVE_GC_RAW.with(|raw| match raw.get() {
-            Some(ptr) => unsafe { (&*ptr).is_nursery_object(addr) },
-            None => false,
+    let via_box = DYNASM_ACTIVE_GC.with(|cell| match cell.try_borrow() {
+        Ok(guard) => guard.as_deref().map(|gc| gc.is_nursery_object(addr)),
+        Err(_) => DYNASM_ACTIVE_GC_RAW.with(|raw| {
+            raw.get()
+                .map(|ptr| unsafe { (&*ptr).is_nursery_object(addr) })
         }),
+    });
+    via_box.unwrap_or_else(|| {
+        if majit_gc::gc_sync::is_initialized() {
+            majit_gc::gc_sync::gc_query_reentrant(|g| g.is_nursery_object(addr))
+        } else {
+            false
+        }
     })
 }
 

--- a/majit/majit-backend-wasm/src/codegen.rs
+++ b/majit/majit-backend-wasm/src/codegen.rs
@@ -3181,6 +3181,21 @@ fn build_function(
                         sink.i64_load(mem64(frame.call_result_ofs));
                         sink.local_set(1 + vi);
                     }
+                    // Mirror the direct path: a trampoline residual call may force and collect.
+                    emit_reload_frame_if_necessary(
+                        &mut sink,
+                        residual_type_base,
+                        ca.ca_reload_fn_ptr,
+                        ca.jf_top_addr,
+                    );
+                    emit_reload_refs_from_homes(
+                        &mut sink,
+                        ref_homes,
+                        &liveness,
+                        op_idx,
+                        (!is_void && !OpRef::raw_is_constant(vi)).then_some(vi),
+                        frame,
+                    );
                 }
             }
 

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -9648,29 +9648,18 @@ impl<M: Clone> MetaInterp<M> {
 impl<M: Clone> MetaInterp<M> {
     fn recovery_slot_types_from_exit_types_and_layout(
         exit_types: &[Type],
-        recovery_layout: Option<&majit_backend::ExitRecoveryLayout>,
+        _recovery_layout: Option<&majit_backend::ExitRecoveryLayout>,
     ) -> Vec<Type> {
-        let Some(recovery) = recovery_layout else {
-            return exit_types.to_vec();
-        };
-        let mut types = Vec::new();
-        for frame in recovery.frames.iter().rev() {
-            let Some(slot_types) = frame.slot_types.as_ref() else {
-                return exit_types.to_vec();
-            };
-            types.extend_from_slice(slot_types);
-        }
-        if types.len() == exit_types.len() {
-            types
-        } else {
-            exit_types.to_vec()
-        }
+        exit_types.to_vec()
     }
 
-    /// Return the full recovery slot types for a guard exit, concatenated
-    /// from all frames in callee-first order (matching the blackhole
-    /// consumer's section convention). Falls back to exit_types when
-    /// recovery_layout is absent.
+    /// Return the compact fail-argument types for a guard exit.
+    ///
+    /// `ResumeDataDirectReader` indexes `deadframe` with TAGBOX numbers, so
+    /// this vector must stay parallel to the guard's compact fail arguments.
+    /// `ExitFrameLayout::slot_types` describes semantic frame slots in frame
+    /// order and is not interchangeable, even when the two vectors happen to
+    /// have the same length.
     pub fn get_recovery_slot_types(
         &self,
         green_key: u64,
@@ -19204,7 +19193,7 @@ mod tests {
     }
 
     #[test]
-    fn test_recovery_slot_types_use_single_frame_slot_types_when_available() {
+    fn test_recovery_slot_types_keep_compact_failarg_types() {
         let recovery_layout = majit_backend::ExitRecoveryLayout {
             vable_array: vec![],
             vref_array: vec![],
@@ -19226,7 +19215,7 @@ mod tests {
                 &[Type::Ref],
                 Some(&recovery_layout),
             ),
-            vec![Type::Int]
+            vec![Type::Ref]
         );
     }
 
@@ -19258,7 +19247,7 @@ mod tests {
     }
 
     #[test]
-    fn test_recovery_slot_types_concatenate_frames_in_callee_first_order() {
+    fn test_recovery_slot_types_do_not_substitute_frame_slot_order() {
         let recovery_layout = majit_backend::ExitRecoveryLayout {
             vable_array: vec![],
             vref_array: vec![],
@@ -19297,7 +19286,39 @@ mod tests {
                 &[Type::Ref, Type::Int, Type::Float, Type::Ref],
                 Some(&recovery_layout),
             ),
-            vec![Type::Float, Type::Ref, Type::Ref, Type::Int]
+            vec![Type::Ref, Type::Int, Type::Float, Type::Ref]
+        );
+    }
+
+    #[test]
+    fn test_module_frame_slot_types_do_not_retype_vable_identity() {
+        let recovery_layout = majit_backend::ExitRecoveryLayout {
+            vable_array: vec![],
+            vref_array: vec![],
+            frames: vec![majit_backend::ExitFrameLayout {
+                trace_id: None,
+                header_pc: Some(9),
+                source_guard: None,
+                pc: 9,
+                jitcode_index: 0,
+                slots: vec![
+                    majit_backend::ExitValueSourceLayout::ExitValue(0),
+                    majit_backend::ExitValueSourceLayout::ExitValue(1),
+                    majit_backend::ExitValueSourceLayout::ExitValue(2),
+                    majit_backend::ExitValueSourceLayout::ExitValue(3),
+                ],
+                slot_types: Some(vec![Type::Int, Type::Ref, Type::Int, Type::Ref]),
+            }],
+            virtual_layouts: vec![],
+            pending_field_layouts: vec![],
+        };
+
+        assert_eq!(
+            MetaInterp::<()>::recovery_slot_types_from_exit_types_and_layout(
+                &[Type::Ref, Type::Ref, Type::Int, Type::Ref],
+                Some(&recovery_layout),
+            ),
+            vec![Type::Ref, Type::Ref, Type::Int, Type::Ref]
         );
     }
 
@@ -19388,7 +19409,7 @@ mod tests {
         );
         assert_eq!(
             meta.get_recovery_slot_types(green_key, trace_id, fail_index),
-            Some(vec![Type::Int])
+            Some(vec![Type::Ref])
         );
         assert_eq!(
             meta.get_rd_virtuals(green_key, trace_id, fail_index),

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -10183,11 +10183,10 @@ pub fn next(obj: PyObjectRef) -> PyResult {
                 ));
             }
             let index = dv::w_dict_view_iterator_get_index(obj);
-            let items = pyre_object::dictmultiobject::w_dict_items(dict);
-            if index >= items.len() {
+            let Some((k, mut v)) = pyre_object::dictmultiobject::w_dict_nth_item(dict, index)
+            else {
                 return Err(PyError::stop_iteration());
-            }
-            let (k, mut v) = items[index];
+            };
             dv::w_dict_view_iterator_set_index(obj, index + 1);
             // `:829-841` strategy-transition handling.
             let start_strategy_id = dv::w_dict_view_iterator_get_start_strategy_id(obj);

--- a/pyre/pyre-interpreter/src/pyframe.rs
+++ b/pyre/pyre-interpreter/src/pyframe.rs
@@ -2051,6 +2051,11 @@ impl PyFrame {
     /// long as the generator object reaches it (`generator.py` holds the
     /// frame), and the generator's custom trace greys the frame block.
     pub fn snapshot_for_generator(&self) -> FrameBox {
+        // `build_snapshot_frame` finishes by cloning `lastblock`; no later
+        // field construction allocates. `FrameBox::new` then uses the
+        // non-collecting `alloc_in_oldgen` path and write-barriers the frame
+        // before this returns, so any nursery block chain is reached from the
+        // remembered set on the next minor collection.
         let mut frame =
             FrameBox::new(self.build_snapshot_frame(FrameLocalsArrayAllocation::OldGenGc));
         frame.fix_array_ptrs();

--- a/pyre/pyre-interpreter/src/pyframe.rs
+++ b/pyre/pyre-interpreter/src/pyframe.rs
@@ -600,14 +600,21 @@ unsafe fn alloc_frame_block(
     pyre_object::lltype::malloc_raw(block)
 }
 
+#[inline]
+fn remember_frame_block_node(node: *mut FrameBlock) {
+    if pyre_object::gc_hook::try_gc_owns_object(node as *mut u8) {
+        pyre_object::gc_hook::try_gc_write_barrier(node as *mut u8);
+    }
+}
+
 unsafe fn clone_block_chain(
     ptr: *mut FrameBlock,
     allocation: FrameLocalsArrayAllocation,
 ) -> *mut FrameBlock {
     // `previous` is assigned only while a node is constructed and points to
-    // a strictly older node.  Rebuild oldest-to-newest for the GC regime, so
-    // a node allocated in old-gen can never acquire a younger predecessor and
-    // no write barrier is needed for `previous`.
+    // a strictly older node. Rebuild oldest-to-newest, but barrier each store:
+    // a nursery-full allocation fallback can make a node old while its
+    // predecessor is still young.
     let mut source = Vec::new();
     let mut current = ptr;
     while !current.is_null() {
@@ -627,6 +634,7 @@ unsafe fn clone_block_chain(
         block.previous = std::ptr::null_mut();
         let node = unsafe { alloc_frame_block(block, allocation) };
         unsafe { (*node).previous = cloned };
+        remember_frame_block_node(node);
         cloned = node;
     }
     cloned
@@ -1495,12 +1503,11 @@ impl PyFrame {
             } else {
                 pyre_object::lltype::malloc_raw(value)
             };
-            // The allocation starts null-filled, but callers commonly seed
-            // it immediately with w_globals or a freshly allocated mapping.
-            // Remembering the completed object is harmless for Box fallback
-            // and keeps the old-gen debug payload visible to the next minor.
-            remember_frame_debug_data(self.debugdata);
         }
+        // Callers mutate the returned payload directly. Remember the container
+        // immediately before exposing it so old debugdata keeps any young refs
+        // written by the caller visible to the next minor collection.
+        remember_frame_debug_data(self.debugdata);
         unsafe { &mut *self.debugdata }
     }
 
@@ -1513,12 +1520,7 @@ impl PyFrame {
     /// PyPy-compatible `getorcreatedebug()`.
     #[inline]
     pub fn getorcreatedebug(&mut self, init_lineno: isize) -> &mut FrameDebugData {
-        self.getorcreate_debug_data(init_lineno);
-        // Callers mutate the returned payload directly (notably w_f_trace)
-        // without their own barrier. Keep the old-gen payload remembered
-        // before exposing it for that mutation.
-        remember_frame_debug_data(self.debugdata);
-        unsafe { &mut *self.debugdata }
+        self.getorcreate_debug_data(init_lineno)
     }
 
     /// PyPy-compatible alias for `code()`.
@@ -1591,7 +1593,6 @@ impl PyFrame {
         // observable instead of faulting.
         let w_locals = unsafe { pyre_object::w_dict_new() };
         self.getorcreate_debug_data(-1).w_locals = w_locals;
-        remember_frame_debug_data(self.debugdata);
         w_locals
     }
 
@@ -2305,11 +2306,15 @@ impl PyFrame {
         let _root = unsafe { FrameBlockRoot::new(&mut previous) };
         block.previous = std::ptr::null_mut();
         let node = unsafe { alloc_frame_block(block, allocation) };
-        // `previous` is written only here (and in clone/unpickle construction)
-        // and always targets the strictly older node.  Thus an old-gen block
-        // never points to a younger block and needs no write barrier.
+        // Both links need barriers: a nursery-full allocation fallback can
+        // make `node` old while `previous` is young, and this old frame usually
+        // receives a young `node`.
         unsafe { (*node).previous = previous };
+        remember_frame_block_node(node);
         self.lastblock = node;
+        if pyre_object::gc_hook::try_gc_owns_object(self as *mut PyFrame as *mut u8) {
+            pyre_object::gc_hook::try_gc_write_barrier(self as *mut PyFrame as *mut u8);
+        }
     }
 
     /// pyframe.py:190 pop_block
@@ -2635,10 +2640,12 @@ impl PyFrame {
 
         if let Some(debug) = self.getdebug() {
             let had_locals = !debug.w_locals.is_null();
+            // Allocate before remembering debugdata: a minor can happen here.
+            let w_locals = had_locals.then(|| unsafe { pyre_object::w_dict_new() });
             let d = self.getorcreate_debug_data(-1);
             d.w_f_trace = pyre_object::PY_NULL;
-            if had_locals {
-                d.w_locals = unsafe { pyre_object::w_dict_new() };
+            if let Some(w_locals) = w_locals {
+                d.w_locals = w_locals;
             }
         }
 

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -13634,11 +13634,8 @@ fn set_method_intersection(
     let mut result: Vec<pyre_object::PyObjectRef> = self_items;
     for other in &args[1..] {
         let other_items = crate::builtins::collect_iterable(*other)?;
-        result.retain(|&item| unsafe {
-            other_items
-                .iter()
-                .any(|&o| pyre_object::w_set_contains(pyre_object::w_set_from_items(&[o]), item))
-        });
+        let probe = pyre_object::w_set_from_items(&other_items);
+        result.retain(|&item| unsafe { pyre_object::w_set_contains(probe, item) });
     }
     unsafe {
         if pyre_object::is_frozenset(args[0]) {

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -524,9 +524,17 @@ unsafe fn module_dict_object_custom_trace(
 
 unsafe fn set_object_custom_trace(obj_addr: usize, f: &mut dyn FnMut(*mut majit_ir::GcRef)) {
     let set = unsafe { &mut *(obj_addr as *mut pyre_object::setobject::W_SetObject) };
-    let items = unsafe { &mut *set.items };
-    for item in items.iter_mut() {
-        f(item as *mut pyre_object::PyObjectRef as *mut majit_ir::GcRef);
+    let entries = unsafe { &mut *set.items };
+    for (key, _) in entries.iter_mut() {
+        // ObjectKey.hash is identity-stable across GC moves, so writing the
+        // relocated pointer through the key's `obj` slot keeps the bucket
+        // index valid — mirrors `dict_object_custom_trace`.
+        let key_ptr = key as *const pyre_object::dictmultiobject::ObjectKey
+            as *mut pyre_object::dictmultiobject::ObjectKey;
+        f(
+            std::ptr::addr_of_mut!((*key_ptr).obj) as *mut pyre_object::PyObjectRef
+                as *mut majit_ir::GcRef,
+        );
     }
 }
 
@@ -1422,8 +1430,8 @@ fn build_gc() -> Box<dyn majit_gc::GcAllocator> {
         w_dict_tid,
     );
     pytype_to_tid.insert(&pyre_object::DICT_TYPE as *const _ as usize, w_dict_tid);
-    // W_SetObject carries `items: *mut Vec<PyObjectRef>`. Register a
-    // custom trace hook so GC forwarding updates indirect element slots.
+    // W_SetObject carries `items: *mut IndexMap<ObjectKey, ()>`. Register a
+    // custom trace hook so GC forwarding updates indirect key object slots.
     // Both `set` and `frozenset` PyTypes share this Rust struct/tid.
     let w_set_tid = gc.register_type(TypeInfo::object_subclass_with_custom_trace(
         std::mem::size_of::<pyre_object::setobject::W_SetObject>(),

--- a/pyre/pyre-object/src/dictmultiobject.rs
+++ b/pyre/pyre-object/src/dictmultiobject.rs
@@ -3235,6 +3235,18 @@ pub unsafe fn w_dict_items(obj: PyObjectRef) -> Vec<(PyObjectRef, PyObjectRef)> 
     w_dict_get_strategy(obj).items(obj)
 }
 
+/// `w_dict_get_strategy(obj).nth_item(obj, index)` — single-entry
+/// dispatch backing the dict view iterator's per-step fetch.
+///
+/// # Safety
+/// `obj` must be a valid `W_DictObject` PyObjectRef.
+pub unsafe fn w_dict_nth_item(
+    obj: PyObjectRef,
+    index: usize,
+) -> Option<(PyObjectRef, PyObjectRef)> {
+    w_dict_get_strategy(obj).nth_item(obj, index)
+}
+
 /// `dictmultiobject.py:585-587 W_DictMultiObject.descr_copy` —
 /// `w_dict.copy()` delegates to `strategy.copy(w_dict)` so typed
 /// strategies preserve their backing shape (`:1152
@@ -3337,6 +3349,24 @@ pub unsafe fn w_dict_items_int_strategy(obj: PyObjectRef) -> Vec<(PyObjectRef, P
         .collect()
 }
 
+/// Internal helper: single-entry accessor for `IntDictStrategy` —
+/// the `index`-th `(newint(key), value)` pair in insertion order,
+/// O(1) via `IndexMap::get_index`.  Backs the dict view iterator's
+/// per-step fetch (`baseobjspace.rs` `next()`), replacing a full
+/// `w_dict_items_int_strategy` re-materialisation per step.
+///
+/// # Safety
+/// Same as [`w_dict_items_int_strategy`].
+pub unsafe fn w_dict_nth_item_int_strategy(
+    obj: PyObjectRef,
+    index: usize,
+) -> Option<(PyObjectRef, PyObjectRef)> {
+    let (k, v) = w_dict_int_storage(obj)
+        .get_index(index)
+        .map(|(&k, &v)| (k, v))?;
+    Some((crate::w_int_new(k), v))
+}
+
 /// Internal helper: `IntDictStrategy::clear` body —
 /// `dictmultiobject.py:1141 self.unerase(w_dict.dstorage).clear()`.
 ///
@@ -3416,6 +3446,21 @@ pub unsafe fn w_dict_items_bytes_strategy(obj: PyObjectRef) -> Vec<(PyObjectRef,
         .collect()
 }
 
+/// Internal helper: single-entry accessor for `BytesDictStrategy`.
+///
+/// # Safety
+/// Same as [`w_dict_items_bytes_strategy`].
+pub unsafe fn w_dict_nth_item_bytes_strategy(
+    obj: PyObjectRef,
+    index: usize,
+) -> Option<(PyObjectRef, PyObjectRef)> {
+    let entries = w_dict_bytes_storage(obj);
+    let (k, v) = entries.get_index(index)?;
+    let key_bytes = k.clone();
+    let value = *v;
+    Some((crate::w_bytes_from_bytes(key_bytes.as_slice()), value))
+}
+
 /// Internal helper: `BytesDictStrategy::clear` body.
 ///
 /// # Safety
@@ -3459,6 +3504,26 @@ pub unsafe fn w_dict_items_object_strategy(obj: PyObjectRef) -> Vec<(PyObjectRef
         }
     }
     out
+}
+
+/// Internal helper: single-entry accessor for `ObjectDictStrategy` /
+/// `UnicodeDictStrategy`.  O(1) `get_index` when no `dict_storage_proxy`
+/// is attached; falls back to the full `w_dict_items_object_strategy`
+/// materialisation for the proxy-merged ordering (proxy dicts are
+/// namespace-sized, not the O(N²) hot path).
+///
+/// # Safety
+/// `obj` must point to a valid `W_DictObject`.
+pub unsafe fn w_dict_nth_item_object_strategy(
+    obj: PyObjectRef,
+    index: usize,
+) -> Option<(PyObjectRef, PyObjectRef)> {
+    let dict = &*(obj as *const W_DictObject);
+    if dict.dict_storage_proxy.is_null() {
+        let entries = &*(dict.dstorage as *const indexmap::IndexMap<ObjectKey, PyObjectRef>);
+        return entries.get_index(index).map(|(k, &v)| (k.obj, v));
+    }
+    w_dict_items_object_strategy(obj).into_iter().nth(index)
 }
 
 /// Internal helper: `ModuleDictStrategy::items` body for pyre's
@@ -3979,6 +4044,28 @@ pub trait DictStrategy {
     /// # Safety
     /// `w_dict` must be a valid PyObjectRef.
     unsafe fn items(&self, w_dict: PyObjectRef) -> Vec<(PyObjectRef, PyObjectRef)>;
+
+    /// Fetch the single `(key, value)` entry at iteration position
+    /// `index` (insertion order), wrapping only that one key — O(1)
+    /// per step for the typed strategies via `IndexMap::get_index`.
+    /// Returns `None` once `index` is past the end.
+    ///
+    /// Stands in for PyPy's `next_*_entry` pulling one entry from the
+    /// strategy cursor (`dictmultiobject.py:904-937`); the dict view
+    /// iterator's integer `index` field replaces the live iterator the
+    /// GC-object layout cannot hold.  The default materialises the full
+    /// list (fine for the tiny empty strategies); typed strategies
+    /// override for O(1).
+    ///
+    /// # Safety
+    /// `w_dict` must be a valid PyObjectRef.
+    unsafe fn nth_item(
+        &self,
+        w_dict: PyObjectRef,
+        index: usize,
+    ) -> Option<(PyObjectRef, PyObjectRef)> {
+        self.items(w_dict).into_iter().nth(index)
+    }
 
     /// `dictmultiobject.py:624-634 DictStrategy.pop` — remove and
     /// return the value for `w_key`.  Returns `Ok(value)` on hit,
@@ -4822,6 +4909,14 @@ impl DictStrategy for ObjectDictStrategy {
         crate::dictmultiobject::w_dict_items_object_strategy(w_dict)
     }
 
+    unsafe fn nth_item(
+        &self,
+        w_dict: PyObjectRef,
+        index: usize,
+    ) -> Option<(PyObjectRef, PyObjectRef)> {
+        crate::dictmultiobject::w_dict_nth_item_object_strategy(w_dict, index)
+    }
+
     /// `dictmultiobject.py:1227-1228 clear` — `self.unerase
     /// (w_dict.dstorage).clear()`.  Direct dstorage truncation +
     /// JIT length-cache reset; `w_dict_clear` (the public wrapper)
@@ -4980,6 +5075,14 @@ impl DictStrategy for BytesDictStrategy {
         crate::dictmultiobject::w_dict_items_bytes_strategy(w_dict)
     }
 
+    unsafe fn nth_item(
+        &self,
+        w_dict: PyObjectRef,
+        index: usize,
+    ) -> Option<(PyObjectRef, PyObjectRef)> {
+        crate::dictmultiobject::w_dict_nth_item_bytes_strategy(w_dict, index)
+    }
+
     unsafe fn clear(&self, w_dict: PyObjectRef) {
         crate::dictmultiobject::w_dict_clear_bytes_strategy(w_dict);
     }
@@ -5134,6 +5237,14 @@ impl DictStrategy for UnicodeDictStrategy {
 
     unsafe fn items(&self, w_dict: PyObjectRef) -> Vec<(PyObjectRef, PyObjectRef)> {
         crate::dictmultiobject::w_dict_items_object_strategy(w_dict)
+    }
+
+    unsafe fn nth_item(
+        &self,
+        w_dict: PyObjectRef,
+        index: usize,
+    ) -> Option<(PyObjectRef, PyObjectRef)> {
+        crate::dictmultiobject::w_dict_nth_item_object_strategy(w_dict, index)
     }
 
     unsafe fn clear(&self, w_dict: PyObjectRef) {
@@ -5328,6 +5439,14 @@ impl DictStrategy for IntDictStrategy {
 
     unsafe fn items(&self, w_dict: PyObjectRef) -> Vec<(PyObjectRef, PyObjectRef)> {
         crate::dictmultiobject::w_dict_items_int_strategy(w_dict)
+    }
+
+    unsafe fn nth_item(
+        &self,
+        w_dict: PyObjectRef,
+        index: usize,
+    ) -> Option<(PyObjectRef, PyObjectRef)> {
+        crate::dictmultiobject::w_dict_nth_item_int_strategy(w_dict, index)
     }
 
     unsafe fn clear(&self, w_dict: PyObjectRef) {

--- a/pyre/pyre-object/src/setobject.rs
+++ b/pyre/pyre-object/src/setobject.rs
@@ -2,10 +2,10 @@
 //!
 //! PyPy equivalent: pypy/objspace/std/setobject.py
 //!
-//! Stores arbitrary PyObjectRef elements with element equality
-//! reusing dict_keys_equal semantics. PyPy carries multiple set
-//! strategies (EmptySet, IntegerSet, etc.); pyre starts with a single
-//! Vec to keep parity tractable while bringing the type online.
+//! Stores arbitrary PyObjectRef elements in a hashed IndexMap of ObjectKey,
+//! reusing the dict object strategy's hashing and equality semantics. PyPy
+//! carries multiple set strategies (EmptySet, IntegerSet, etc.); pyre starts
+//! with a single strategy while bringing the type online.
 
 #![allow(unsafe_op_in_unsafe_fn)]
 
@@ -16,13 +16,13 @@ pub static FROZENSET_TYPE: PyType = crate::pyobject::new_pytype("frozenset");
 
 /// Python set object.
 ///
-/// Layout: `[ob_type | items | len]`. `items` is heap-owned via
-/// `Box::into_raw` to keep the struct trivially `Copy`-friendly for the
-/// JIT raw-pointer model.
+/// Layout: `[ob_type | items | len]`. `items` is a heap-owned hashed
+/// `IndexMap<ObjectKey, ()>`, mirroring the dict object strategy while
+/// keeping the struct trivially `Copy`-friendly for the JIT raw-pointer model.
 #[repr(C)]
 pub struct W_SetObject {
     pub ob_header: PyObject,
-    pub items: *mut Vec<PyObjectRef>,
+    pub items: *mut indexmap::IndexMap<crate::dictmultiobject::ObjectKey, ()>,
     pub len: usize,
 }
 
@@ -54,13 +54,6 @@ pub unsafe fn is_set_or_frozenset(obj: PyObjectRef) -> bool {
     unsafe { is_set(obj) || is_frozenset(obj) }
 }
 
-/// Element equality. Delegates to dict_keys_equal so that set membership
-/// follows the same rules as dict key equality (int / bool / str / tuple
-/// / frozenset, with pointer identity as a fallback for everything else).
-unsafe fn set_keys_equal(a: PyObjectRef, b: PyObjectRef) -> bool {
-    crate::dictmultiobject::dict_keys_equal(a, b)
-}
-
 /// Fire the GC write barrier for a set whose element storage just gained
 /// a possibly-young element. `set_object_custom_trace` only forwards the
 /// `items` slots when the set is reached by a collection; an old-gen set
@@ -73,7 +66,10 @@ fn set_write_barrier(obj: PyObjectRef) {
 }
 
 fn alloc_set_with_type(tp: &'static PyType) -> PyObjectRef {
-    let items = crate::lltype::malloc_raw(Vec::new());
+    let items = crate::lltype::malloc_raw(indexmap::IndexMap::<
+        crate::dictmultiobject::ObjectKey,
+        (),
+    >::new());
     let header = PyObject {
         ob_type: tp as *const PyType,
         w_class: get_instantiate(tp),
@@ -143,14 +139,11 @@ pub fn w_frozenset_from_items(items: &[PyObjectRef]) -> PyObjectRef {
 pub unsafe fn w_set_add(obj: PyObjectRef, item: PyObjectRef) {
     let s = &mut *(obj as *mut W_SetObject);
     let entries = &mut *s.items;
-    for &existing in entries.iter() {
-        if set_keys_equal(existing, item) {
-            return;
-        }
+    let key = crate::dictmultiobject::object_key_for(item);
+    if entries.insert(key, ()).is_none() {
+        s.len += 1;
+        set_write_barrier(obj);
     }
-    entries.push(item);
-    s.len += 1;
-    set_write_barrier(obj);
 }
 
 /// Membership test.
@@ -160,7 +153,7 @@ pub unsafe fn w_set_add(obj: PyObjectRef, item: PyObjectRef) {
 pub unsafe fn w_set_contains(obj: PyObjectRef, item: PyObjectRef) -> bool {
     let s = &*(obj as *const W_SetObject);
     let entries = &*s.items;
-    entries.iter().any(|&e| set_keys_equal(e, item))
+    entries.contains_key(&crate::dictmultiobject::object_key_for(item))
 }
 
 /// Remove an element if present. Returns true when removed.
@@ -170,8 +163,10 @@ pub unsafe fn w_set_contains(obj: PyObjectRef, item: PyObjectRef) -> bool {
 pub unsafe fn w_set_discard(obj: PyObjectRef, item: PyObjectRef) -> bool {
     let s = &mut *(obj as *mut W_SetObject);
     let entries = &mut *s.items;
-    if let Some(idx) = entries.iter().position(|&e| set_keys_equal(e, item)) {
-        entries.remove(idx);
+    if entries
+        .shift_remove(&crate::dictmultiobject::object_key_for(item))
+        .is_some()
+    {
         s.len -= 1;
         true
     } else {
@@ -193,7 +188,7 @@ pub unsafe fn w_set_len(obj: PyObjectRef) -> usize {
 /// `obj` must point to a valid `W_SetObject`.
 pub unsafe fn w_set_items(obj: PyObjectRef) -> Vec<PyObjectRef> {
     let s = &*(obj as *const W_SetObject);
-    (*s.items).clone()
+    (*s.items).keys().map(|key| key.obj).collect()
 }
 
 #[cfg(test)]
@@ -201,8 +196,22 @@ mod tests {
     use super::*;
     use crate::intobject::w_int_new;
 
+    fn install_test_hash_hook() {
+        unsafe fn hash_int(obj: PyObjectRef) -> i64 {
+            crate::w_int_get_value(obj)
+        }
+
+        unsafe fn hash_str(_ptr: *const u8, _len: usize) -> i64 {
+            0
+        }
+
+        crate::dict_eq_hook::register_hash_w_hook(hash_int);
+        crate::dict_eq_hook::register_hash_str_hook(hash_str);
+    }
+
     #[test]
     fn add_dedupes() {
+        install_test_hash_hook();
         let s = w_set_new();
         unsafe {
             w_set_add(s, w_int_new(1));
@@ -217,6 +226,7 @@ mod tests {
 
     #[test]
     fn discard_removes() {
+        install_test_hash_hook();
         let s = w_set_new();
         unsafe {
             w_set_add(s, w_int_new(1));

--- a/pyre/pyre-wasm-runner/src/main.rs
+++ b/pyre/pyre-wasm-runner/src/main.rs
@@ -305,10 +305,16 @@ fn run(module_path: &PathBuf, source: &str) -> Result<i32> {
     }
     if let Some(path) = &guest_profile_out {
         if let Some(p) = store.data_mut().guest_profiler.take() {
-            let f = std::fs::File::create(path).context("create guest profile output")?;
-            p.finish(std::io::BufWriter::new(f))
-                .context("write guest profile")?;
-            eprintln!("[guest-profile] wrote {path}");
+            match std::fs::File::create(path).context("create guest profile output") {
+                Ok(f) => match p
+                    .finish(std::io::BufWriter::new(f))
+                    .context("write guest profile")
+                {
+                    Ok(()) => eprintln!("[guest-profile] wrote {path}"),
+                    Err(err) => eprintln!("[guest-profile] failed to write {path}: {err:#}"),
+                },
+                Err(err) => eprintln!("[guest-profile] failed to create {path}: {err:#}"),
+            }
         }
     }
     if std::env::var_os("PYRE_WASM_JIT_STATS").is_some() {


### PR DESCRIPTION
Six commits on top of `main` (merge-base `e3f8c390a2e` / #535): three GC/wasm-lifetime fixes and three defects found and fixed during a large-collection + module-scope stress sweep.

## Defect fixes (this sweep)

- **`dict` view iterator was O(N²)** (`abb36de5206`) — `dict.keys()/.values()/.items()` iteration re-materialized the whole items `Vec` on every `next()`. Fixed with an O(1) `nth_item` via `IndexMap::get_index`; a 40k-entry dynasm bench dropped 21.5s → 0.036s and the wasm capacity-overflow crash is gone.
- **`set`/`frozenset` were O(N²)** (`e8fa344fa40`) — the store was a linear `Vec<PyObjectRef>`; add/contains/discard all linear-scanned. Re-backed with a hashed `IndexMap<ObjectKey, ()>` reusing the dict object-strategy hashing (+ GC-trace mirror, intersection rewrite). `set(range(40k))` 3.07s → 0.02s; full union/inter/diff 31.5s → 0.05s (dynasm), 66s → 0.92s (wasm).
- **Module-scope JIT loops crashed (SIGSEGV/panic)** (`6e063d62422`) — any module-level (`nlocals=0` portal frame) hot loop that compiled a trace with a collecting call (e.g. `for i in range(500): t = t + i`) crashed at guard resume. `recovery_slot_types_from_exit_types_and_layout` substituted frames-only `slot_types` for the compact `exit_types` on a length match, retyping the virtualizable-identity `TAGBOX(0)` from `Ref` to `Int`; `decode_ref` then `box_int`'d the frame pointer into a fresh `W_IntObject` that `consume_vable_info` read as a null-array `PyFrame`. Fixed by keeping `deadframe` types parallel to the compact fail arguments. Function-scoped loops (`nlocals ≥ 1`) were immune. (Cherry-picked from the equivalent module-frame fix authored on another branch.)

## GC / wasm lifetime (pre-sweep)

- `591a26a4ce1` write-barrier GC-managed frame block and debug-data stores
- `9849e9153a3` fall back to `gc_sync` for backend nursery-membership queries
- `343b9f03393` reload live `Ref` homes after the `jit_call` trampoline's residual calls

## Verification

`python3 pyre/check.py --backend dynasm,wasm` → **dynasm 180/180, wasm 179/179** (zero regression). `cargo test -p majit-metainterp recovery_slot_types` and `cargo test -p pyre-object` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
