### PR TITLE
jit: multi-param self-recursive CALL_ASSEMBLER fold + dynamic double-apply gate

### DIFF
--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -5983,9 +5983,8 @@ fn residual_callee_is_walk_self_recursive(
         if sym.jitcode.is_null() {
             return false;
         }
-        let caller_code = pyre_interpreter::live_code_wrapper(
-            (*sym.jitcode).raw_code() as *const (),
-        ) as *const ();
+        let caller_code = pyre_interpreter::live_code_wrapper((*sym.jitcode).raw_code() as *const ())
+            as *const ();
         w_code as usize == caller_code as usize
     }
 }

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -5945,6 +5945,51 @@ fn probe_resid_decline_ctx(
     );
 }
 
+/// Whether a residual call is a self-recursive call to the walk's own code —
+/// the `CALL_ASSEMBLER` fold target running as a plain residual because the
+/// fold declined (no compiled token yet, a non-concrete argument during a
+/// bridge resume, etc.).  Mirrors the callee/self resolution in
+/// `try_walker_call_assembler_self_recursive`.  Keeps the recursion itself out
+/// of the foreign-body-residual latch so pure recursion (`fib`) still folds.
+fn residual_callee_is_walk_self_recursive(
+    ctx: &WalkContext<'_, '_>,
+    allboxes: &[OpRef],
+    helper: majit_ir::PyreHelperKind,
+) -> bool {
+    if helper != majit_ir::PyreHelperKind::CallFn {
+        return false;
+    }
+    let sym_ptr = ctx.fbw_mode.snapshot_sym;
+    if sym_ptr.is_null() {
+        return false;
+    }
+    // A `bh_call_fn` residual is `[funcptr, callable, null_or_self, arg0, ...]`;
+    // the Python callable is `allboxes[1]`.
+    let Some(&callable_box) = allboxes.get(1) else {
+        return false;
+    };
+    let Some(majit_ir::Value::Ref(callable_ref)) = ctx.trace_ctx.box_value(callable_box) else {
+        return false;
+    };
+    if callable_ref == majit_ir::GcRef::NO_CONCRETE || callable_ref.as_usize() == 0 {
+        return false;
+    }
+    let callable = callable_ref.as_usize() as pyre_object::PyObjectRef;
+    unsafe {
+        let Some((w_code, _nparams, _has_closure)) = resolve_inlinable_callee(callable) else {
+            return false;
+        };
+        let sym = &*sym_ptr;
+        if sym.jitcode.is_null() {
+            return false;
+        }
+        let caller_code = pyre_interpreter::live_code_wrapper(
+            (*sym.jitcode).raw_code() as *const (),
+        ) as *const ();
+        w_code as usize == caller_code as usize
+    }
+}
+
 fn try_execute_residual_call_via_executor(
     ctx: &mut WalkContext<'_, '_>,
     call_opcode: OpCode,
@@ -6433,6 +6478,11 @@ fn try_execute_residual_call_via_executor(
     };
     if !provably_side_effect_free {
         fbw_mark_executed_nonpure_residual();
+        // Count only a FOREIGN non-pure residual: a self-recursive call is the
+        // fold target running because its fold declined, not a body side effect.
+        if !residual_callee_is_walk_self_recursive(ctx, allboxes, helper) {
+            fbw_mark_executed_body_residual();
+        }
     }
     ctx.trace_ctx
         .set_virtualizable_heap_ptr(saved_vable_heap_ptr.unwrap_or(std::ptr::null()));
@@ -7893,6 +7943,14 @@ thread_local! {
     /// effect outside the FBW journals; later exit handling must not replay it.
     static FBW_EXECUTED_NONPURE_RESIDUAL: std::cell::Cell<bool> =
         const { std::cell::Cell::new(false) };
+
+    /// Set when this walk concretely executed a non-provably-pure residual that
+    /// is NOT the self-recursive `CALL_ASSEMBLER` fold target — a foreign body
+    /// write (`events.append(n)`).  A self-recursive fold ahead of which such a
+    /// residual ran declines, since folding would leave the walk uncommittable
+    /// and the interpreter would replay the executed mutation.
+    static FBW_EXECUTED_BODY_RESIDUAL: std::cell::Cell<bool> =
+        const { std::cell::Cell::new(false) };
 }
 
 /// Terminal disposition of a walk kept for the no-replay exit:
@@ -7956,6 +8014,21 @@ pub(crate) fn fbw_executed_nonpure_residual() -> bool {
 /// Clear the executed-residual latch at a walk boundary.
 pub(crate) fn fbw_executed_nonpure_residual_reset() {
     FBW_EXECUTED_NONPURE_RESIDUAL.with(|c| c.set(false));
+}
+
+/// Record a foreign (non self-recursive) non-pure residual concrete execution.
+pub(crate) fn fbw_mark_executed_body_residual() {
+    FBW_EXECUTED_BODY_RESIDUAL.with(|c| c.set(true));
+}
+
+/// Whether a foreign non-pure residual has concretely executed this walk.
+pub(crate) fn fbw_executed_body_residual() -> bool {
+    FBW_EXECUTED_BODY_RESIDUAL.with(|c| c.get())
+}
+
+/// Clear the foreign-body-residual latch at a walk boundary.
+pub(crate) fn fbw_executed_body_residual_reset() {
+    FBW_EXECUTED_BODY_RESIDUAL.with(|c| c.set(false));
 }
 
 /// Whether `PYRE_FBW_DEBUG_ABORT` is set.  When on, `full_body_walk_trace`
@@ -13618,6 +13691,15 @@ fn try_walker_call_assembler_self_recursive(
         pyre_interpreter::live_code_wrapper((*sym.jitcode).raw_code() as *const ()) as *const ()
     };
     if w_code as usize != caller_code as usize {
+        return Ok(None);
+    }
+    // A foreign (non self-recursive) non-pure residual already executed
+    // concretely earlier in this walk (e.g. `events.append(n)` ahead of the
+    // self-call).  Folding to CALL_ASSEMBLER terminates the walk symbolically;
+    // a later value-unavailable decline then leaves it uncommittable, so the
+    // interpreter replays the region and double-applies that mutation.  Decline
+    // to the plain residual path, which eagerly executes and commits the call.
+    if fbw_executed_body_residual() {
         return Ok(None);
     }
     // Branch A frame shape only: `ncells == 0`, non-global-storing callee.

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -7550,6 +7550,11 @@ const FBW_MAX_INLINE_RECURSION: usize = 7;
 /// bound is now a performance, not a soundness, question.)
 const FBW_MAX_MULTIFRAME_DEPTH: usize = 1;
 
+/// Upper bound on the parameter count the self-recursive `CALL_ASSEMBLER` fold
+/// accepts. Accumulator/linear recursion is low-arity; the cap keeps a
+/// pathological signature off the fold path.
+const FBW_REC_CA_MAX_PARAMS: usize = 8;
+
 /// Recursion depth of `w_code` on the walk's framestack.
 fn fbw_inline_recursion_count(ctx: &WalkContext<'_, '_>, w_code: usize) -> usize {
     ctx.session
@@ -13615,13 +13620,12 @@ fn try_walker_call_assembler_self_recursive(
     if pyre_helper != majit_ir::PyreHelperKind::CallFn {
         return Ok(None);
     }
-    // Single positional argument (`r_args = [callable, null_or_self,
-    // arg0]`); Ref dst only (`residual_call_r_r`, the boxed PyObject
-    // consumed by a following BINARY_OP).  The only `residual_call_r_i`
-    // helper is the 1-arg `truth_fn`, which can never pass the
-    // `r_args.len() != 3` bail — an Int dst is structurally unreachable
-    // here, so don't accept one.
-    if dst_bank != 'r' || r_args.len() != 3 {
+    // Positional args only (`r_args = [callable, null_or_self, arg0, ..]`);
+    // Ref dst only (`residual_call_r_r`, the boxed PyObject consumed by a
+    // following BINARY_OP).  The only `residual_call_r_i` helper is the
+    // 1-arg `truth_fn`, so an Int dst is structurally unreachable here —
+    // don't accept one.  At least one positional argument is required.
+    if dst_bank != 'r' || r_args.len() < 3 {
         return Ok(None);
     }
     // A self-recursive CALL_ASSEMBLER raising inside a `try` body must
@@ -13649,26 +13653,36 @@ fn try_walker_call_assembler_self_recursive(
     if !null_or_self.is_null() {
         return Ok(None);
     }
-    // The callable must be a plain Python function with exactly one
-    // positional parameter and no closure.  Unlike the inline path this
-    // does NOT require a leaf body: the callee runs as its own compiled
-    // loop reached through `CALL_ASSEMBLER`, not traced through — so a
-    // branchy self-recursive body (`fib`'s `if n < 2`) is eligible here
-    // even though `callee_fast_path_inlinable` declines it for inlining.
+    // The callable must be a plain Python function with N positional
+    // parameters and no closure.  Unlike the inline path this does NOT
+    // require a leaf body: the callee runs as its own compiled loop reached
+    // through `CALL_ASSEMBLER`, not traced through — so a branchy
+    // self-recursive body (`fib`'s `if n < 2`) is eligible here even though
+    // `callee_fast_path_inlinable` declines it for inlining.
     let Some((w_code, nparams, has_closure)) = (unsafe { resolve_inlinable_callee(callable) })
     else {
         return Ok(None);
     };
-    if has_closure || nparams != 1 {
+    // Dense positional fill only: the call must pass exactly `nparams`
+    // positional args (`r_args = [callable, null_or_self, arg0..arg{n-1}]`),
+    // so the built frame's `locals[0..nparams]` come straight from the args.
+    // A default/vararg/kwarg mismatch would leave a hole the frame build
+    // cannot fill — decline to the residual.
+    if has_closure || nparams < 1 || nparams != r_args.len() - 2 || nparams > FBW_REC_CA_MAX_PARAMS
+    {
         return Ok(None);
     }
-    // The single positional argument must be a boxed int at trace time
-    // (`concrete_arg0 is_int`, `trace_opcode.rs:6148`).
-    let ConcreteValue::Ref(arg_obj) = arg_concretes[2] else {
-        return Ok(None);
-    };
-    if arg_obj.is_null() || !unsafe { pyre_object::is_int(arg_obj) } {
-        return Ok(None);
+    // Every positional argument must be a boxed int at trace time
+    // (`concrete_arg is_int`): the callee was traced against int locals whose
+    // speculative low-bit guard would deopt on a non-int box.  A non-int
+    // argument declines to the residual call.
+    for i in 0..nparams {
+        let ConcreteValue::Ref(arg_obj) = arg_concretes[2 + i] else {
+            return Ok(None);
+        };
+        if arg_obj.is_null() || !unsafe { pyre_object::is_int(arg_obj) } {
+            return Ok(None);
+        }
     }
     // The outer portal sym (the only materialized frame across sub-walks)
     // via the FBW thread-local — the same read mechanism
@@ -13752,17 +13766,18 @@ fn try_walker_call_assembler_self_recursive(
     let nlocals = callee_code.varnames.len();
     let max_stack = callee_code.max_stackdepth as usize;
 
-    // Unbox the boxed int argument -> raw payload, then re-box it into the
-    // callee's `locals[0]` through `walker_box_int` so the local carries the
-    // same representation the callee was traced against.  Under
-    // `CAN_BE_TAGGED` a small `int` becomes a tagged immediate (`ll_int_box`);
-    // a heap-only re-box (`emit_box_int_inline`) would force a `W_IntObject`
-    // and the callee's speculative low-bit guard on the local would deopt on
-    // every recursion.  Under `!CAN_BE_TAGGED` `walker_box_int` falls back to
-    // `wrapint` (= `emit_box_int_inline`), so the emitted ops are unchanged.
-    // Mirror of `trace_guarded_int_payload(args[0])`.
-    let raw_arg = walker_unbox_int(ctx, op.pc, r_args[2], int_type_addr)?;
-    let arg_box = crate::state::wrapint(ctx.trace_ctx, raw_arg);
+    // Unbox each boxed int argument -> raw payload, then re-box it into the
+    // callee's `locals[i]` through `wrapint` so the local carries the same
+    // representation the callee was traced against.  Under `CAN_BE_TAGGED` a
+    // small `int` becomes a tagged immediate (`ll_int_box`); a heap-only
+    // re-box would force a `W_IntObject` and the callee's speculative low-bit
+    // guard on the local would deopt on every recursion.  Mirror of
+    // `trace_guarded_int_payload(args[i])`.
+    let mut param_boxes: Vec<OpRef> = Vec::with_capacity(nparams);
+    for i in 0..nparams {
+        let raw_arg = walker_unbox_int(ctx, op.pc, r_args[2 + i], int_type_addr)?;
+        param_boxes.push(crate::state::wrapint(ctx.trace_ctx, raw_arg));
+    }
 
     // Execution-context red: recover it fresh off the materialized caller
     // portal frame via `GETFIELD_GC_R(frame, execution_context_descr)` rather
@@ -13785,9 +13800,9 @@ fn try_walker_call_assembler_self_recursive(
     // local, no cells, constant code / globals.
     let pycode_const = ctx.trace_ctx.const_ref(w_code as i64);
     let w_globals_obj_const = ctx.trace_ctx.const_ref(callee_globals_obj as i64);
-    let callee_frame = crate::helpers::emit_new_pyframe_inline_self_recursive(
+    let callee_frame = crate::helpers::emit_new_pyframe_inline_with_params(
         ctx.trace_ctx,
-        arg_box,
+        &param_boxes,
         nlocals + max_stack,
         nlocals,
         pycode_const,
@@ -14256,20 +14271,19 @@ fn try_walker_inline_user_call(
     let strict_inlinable =
         callee_fast_path_inlinable(body.code, callee_descr_refs, ctx, callee_portal_frame_reg);
 
-    // #62: a self-recursive single-int callee (`fib`'s shape) routes to the
-    // direct `CALL_ASSEMBLER` arm (`try_walker_call_assembler_self_recursive`,
-    // reached when this inline attempt returns `Ok(None)`) — NOT the multiframe
-    // inline path.  Detected here, BEFORE the multiframe gate: a forward-branch
-    // self-recursive callee is `try_multiframe`-eligible, but unbounded
-    // self-recursion bottoms out the multiframe inline at the depth cap and
-    // aborts (`LoopBearingCalleeInlineUnsupported`) → trait leg.  The CA arm
-    // instead folds the recursion into a recursive-portal `CALL_ASSEMBLER`.
-    // A strict-inlinable callee is a straight-line leaf (no self-recursion), so
-    // this never preempts the strict path.  Gated on `PYRE_FBW_REC_CA` (the
-    // same flag the CA arm honours): when off, keep the multiframe/trait route.
+    // A self-recursive callee routes to the direct `CALL_ASSEMBLER` arm
+    // (`try_walker_call_assembler_self_recursive`, reached when this inline
+    // attempt returns `Ok(None)`) rather than the multiframe inline path.
+    // Multi-parameter all-int calls fold there; other self-recursive shapes
+    // decline from the fold to the plain residual call instead of aborting.
+    // Detected before the multiframe gate: a forward-branch self-recursive
+    // callee is `try_multiframe`-eligible, but unbounded self-recursion bottoms
+    // out the multiframe inline at the depth cap.  A strict-inlinable callee is
+    // a straight-line leaf (no self-recursion), so this never preempts the
+    // strict path.  Gated on `PYRE_FBW_REC_CA`, matching the fold.
     if !strict_inlinable
         && std::env::var_os("PYRE_FBW_REC_CA").as_deref() != Some(std::ffi::OsStr::new("0"))
-        && nparams == 1
+        && nparams >= 1
     {
         let sym_ptr = ctx.fbw_mode.snapshot_sym;
         let self_recursive = !sym_ptr.is_null()
@@ -14278,18 +14292,14 @@ fn try_walker_inline_user_call(
                     as *const ()
             } as usize
                 == w_code as usize;
-        let arg_is_int = matches!(
-            arg_concretes.get(2),
-            Some(ConcreteValue::Ref(a)) if !a.is_null() && unsafe { pyre_object::is_int(*a) }
-        );
         if ctx.fbw_mode.carrier_resume && std::env::var_os("PYRE_P2_DIAG").is_some() {
             eprintln!(
-                "[p2-diag] nested call pc={} self_recursive={self_recursive} arg_is_int={arg_is_int} strict_inlinable={strict_inlinable} recursion_count={}",
+                "[p2-diag] nested call pc={} self_recursive={self_recursive} strict_inlinable={strict_inlinable} recursion_count={}",
                 op.pc,
                 fbw_inline_recursion_count(ctx, callee_code_key)
             );
         }
-        if self_recursive && arg_is_int {
+        if self_recursive {
             // A bridge-carrier resume is the deopt continuation of an
             // already-compiled recursive portal, so a nested self-recursive
             // call folds straight to the recursive-portal `CALL_ASSEMBLER`
@@ -14298,9 +14308,9 @@ fn try_walker_inline_user_call(
             if ctx.fbw_mode.carrier_resume {
                 return Ok(None);
             }
-            // A self-recursive single-int callee folds to the recursive-portal
-            // `CALL_ASSEMBLER` tail (`try_walker_call_assembler_self_recursive`),
-            // reached by returning `Ok(None)` here.
+            // A self-recursive all-int callee folds to the recursive-portal
+            // `CALL_ASSEMBLER` tail.  Other self-recursive shapes decline from
+            // that fold to the plain residual call.
             return Ok(None);
         }
     }
@@ -14336,8 +14346,8 @@ fn try_walker_inline_user_call(
     if !strict_inlinable && !try_multiframe {
         // A non-self-recursive loop/branch callee that neither the strict nor
         // the multiframe fast path can serve declines to the trait leg
-        // (`FBW_DECLINED_KEYS`).  The self-recursive single-int shape was
-        // already routed to the `CALL_ASSEMBLER` arm above (`Ok(None)`).
+        // (`FBW_DECLINED_KEYS`).  Self-recursive calls were already routed to
+        // the `CALL_ASSEMBLER` fold or plain residual path above (`Ok(None)`).
         return Err(DispatchError::LoopBearingCalleeInlineUnsupported { pc: op.pc });
     }
 

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -13672,15 +13672,20 @@ fn try_walker_call_assembler_self_recursive(
     {
         return Ok(None);
     }
-    // Every positional argument must be a boxed int at trace time
+    // Every positional argument must be an exact boxed int at trace time
     // (`concrete_arg is_int`): the callee was traced against int locals whose
-    // speculative low-bit guard would deopt on a non-int box.  A non-int
-    // argument declines to the residual call.
+    // speculative low-bit guard would deopt on a non-int box.  `is_int` also
+    // accepts `bool`, whose payload reads through a different accessor than the
+    // int one the unbox below uses, so a `bool` argument must decline too.  A
+    // non-int (or bool) argument declines to the residual call.
     for i in 0..nparams {
         let ConcreteValue::Ref(arg_obj) = arg_concretes[2 + i] else {
             return Ok(None);
         };
-        if arg_obj.is_null() || !unsafe { pyre_object::is_int(arg_obj) } {
+        if arg_obj.is_null()
+            || !unsafe { pyre_object::is_int(arg_obj) }
+            || unsafe { pyre_object::is_bool(arg_obj) }
+        {
             return Ok(None);
         }
     }

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -2614,6 +2614,7 @@ fn full_body_walk_trace(
     // value cannot leak into this walk's `Terminate` handling.
     crate::jitcode_dispatch::fbw_finish_payload_reset();
     crate::jitcode_dispatch::fbw_executed_nonpure_residual_reset();
+    crate::jitcode_dispatch::fbw_executed_body_residual_reset();
     crate::jitcode_dispatch::fbw_abort_outer_resume_py_pc_reset();
     // Clear the prior walk's store journal + unjournaled-effect flag so
     // dropped (aborted) entries cannot be applied by this walk's commit.

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -324,55 +324,6 @@ fn try_commit_midbody_abort(
     }
 }
 
-/// True when the full-body walker must NOT trace this callee as its own origin,
-/// decided statically before the first walk.
-///
-/// A self-recursive callee with `arg_count != 1` cannot be served by the walker:
-/// the single-int self-recursive `CALL_ASSEMBLER` arm
-/// (`jitcode_dispatch.rs` `try_walker_call_assembler_self_recursive`) is
-/// `nparams == 1` only, so a 2+-param self-recursive callee always bottoms out
-/// at the inline-depth cap and aborts `LoopBearingCalleeInlineUnsupported`.
-/// That abort happens AFTER the walk has concretely executed the body's leading
-/// side effects (e.g. an unjournaled residual `list.append`), which the abort
-/// rollback cannot rewind and the interpreter then replays from entry — a silent
-/// double.  Declining the walker here routes the callee to a clean re-interpret
-/// (the trace-start gate's `else` arm) BEFORE any side effect runs.  These
-/// callees never compile under the walker anyway (verified: 2-param
-/// self-recursion is always `loops_compiled=0`), so the decline costs no
-/// compilation.  `arg_count == 1` is exempt so `fib`'s recursive-portal
-/// `CALL_ASSEMBLER` compile is preserved.
-///
-/// The predicate is a pure function of the code's bytecode and is recomputed on
-/// each call: the scan is a single pass over a short callee body, the gate is
-/// hit only at a compile attempt (not per opcode), and after the first decline
-/// the `fbw_decline` path absorbs the repeat cost — so no cache is warranted.
-/// A thread-local memo would also be wrong under free-threading (this result is
-/// thread-invariant, but a per-thread memo cannot share a hit across threads).
-fn static_walker_should_decline(w_code: *const (), start_pc: usize) -> bool {
-    let raw = unsafe {
-        pyre_interpreter::w_code_get_ptr(w_code as pyre_object::PyObjectRef)
-            as *const pyre_interpreter::CodeObject
-    };
-    if raw.is_null() {
-        return false;
-    }
-    let code = unsafe { &*raw };
-    // The unsafe double-append happens only when the recursive function is
-    // traced as its OWN callee from function-entry: the walk executes the
-    // pre-recursion body concretely, reaches the self-call, and aborts, so the
-    // interpreter replays the concrete mutation.  A `start_pc` that is a
-    // loop-header (a backward-jump target) is a distinct trace origin — an
-    // independent hot loop inside the same function — whose compile has nothing
-    // to do with the recursive-callee resume; declining it only strands that
-    // loop out of the JIT.  Restrict the decline to non-loop-header origins.
-    if start_pc_is_loop_header(code, start_pc) {
-        return false;
-    }
-    // `arg_count == 1` keeps the single-int self-recursive `CALL_ASSEMBLER` arm
-    // (fib) reachable — never decline it.
-    code.arg_count != 1 && code_is_self_recursive(code)
-}
-
 /// True when `start_pc` is the target of a `JumpBackward` in `code` — i.e. a
 /// loop header, the origin of a loop-header trace rather than a function-entry
 /// trace.
@@ -390,43 +341,6 @@ fn start_pc_is_loop_header(code: &pyre_interpreter::CodeObject, start_pc: usize)
         }
     }
     false
-}
-
-/// Heuristic static test: does `code` load its own name (`co_name`) feeding a
-/// `CALL`?  That is the self-recursion shape in bytecode.  A module-level
-/// function loads itself with `LOAD_GLOBAL <own-name>` (the name-index low bit
-/// is the `push_null` flag, so the real `co_names` index is `namei >> 1`); a
-/// nested/closure function loads itself with `LOAD_DEREF`/`LOAD_FROM_DICT_OR_DEREF`
-/// of the cell/free var whose name is its own.  A shadowed same-name binding is
-/// a false positive, but the only cost is declining a walker trace that would
-/// abort anyway.
-fn code_is_self_recursive(code: &pyre_interpreter::CodeObject) -> bool {
-    use pyre_interpreter::Instruction as I;
-    let own_name: &str = code.obj_name.as_ref();
-    let mut arg_state = pyre_interpreter::OpArgState::default();
-    let mut self_name_loaded = false;
-    let mut has_call = false;
-    for unit in code.instructions.iter().copied() {
-        let (instr, op_arg) = arg_state.get(unit);
-        match instr {
-            I::LoadGlobal { namei } => {
-                let idx = (namei.get(op_arg) as usize) >> 1;
-                if code.names.get(idx).map(|n| -> &str { n.as_ref() }) == Some(own_name) {
-                    self_name_loaded = true;
-                }
-            }
-            I::LoadDeref { i } | I::LoadFromDictOrDeref { i } => {
-                let idx = i.get(op_arg).as_usize();
-                let (name, _is_free) = pyre_interpreter::deref_name_and_kind(code, idx);
-                if name == own_name {
-                    self_name_loaded = true;
-                }
-            }
-            I::Call { .. } | I::CallKw { .. } => has_call = true,
-            _ => {}
-        }
-    }
-    self_name_loaded && has_call
 }
 
 /// Trace an entire loop body starting at `start_pc`.
@@ -583,22 +497,13 @@ pub fn trace_bytecode(
     // blackhole switch); the trait leg is pyre's transitional stand-in
     // until the walker covers those shapes (deleted with the trait in
     // Phase 6).
-    let static_decline = carrier.is_none() && static_walker_should_decline(w_code, start_pc);
     if carrier.is_none()
         && std::env::var_os("PYRE_FULL_BODY_WALK").as_deref() != Some(std::ffi::OsStr::new("0"))
         && !fbw_declined(crate::driver::make_green_key(w_code, start_pc))
-        && !static_decline
     {
         let action = full_body_walk_trace(ctx, sym, w_code, start_pc, cf_addr);
         finish_trace_namespace_dependency(meta);
         return (action, concrete_frame);
-    }
-    // A self-recursive `arg_count != 1` callee is declined by
-    // `static_walker_should_decline` above (BEFORE any concrete side effect),
-    // not by the lazy post-abort `fbw_decline`.  Record it so the decline is
-    // visible in the `PYRE_FBW_DEBUG_ABORT` corpus instead of vanishing.
-    if static_decline {
-        crate::jitcode_dispatch::census_record("Static::SelfRecursiveMultiParam");
     }
     // gap-10: the trait tracer (`PyreMetaInterp` / `owned_concrete_frame`
     // interpret loop) is retired.  Any path the walker did not trace above — an
@@ -2969,106 +2874,9 @@ mod tests {
     }
 
     #[test]
-    fn code_is_self_recursive_detects_self_call() {
-        // A function that calls its own global name feeding a CALL.
-        let code = named_function_code(
-            "def rec_append(xs, n):\n    xs.append(n)\n    if n > 0:\n        return rec_append(xs, n - 1) + 1\n    return 1\n",
-            "rec_append",
-        );
-        assert!(super::code_is_self_recursive(&code));
-        // arg_count == 2 and self-recursive → the walker must decline.
-        assert_eq!(code.arg_count, 2);
-    }
-
-    #[test]
-    fn code_is_self_recursive_rejects_non_recursive_loop() {
-        // A loop-bearing function with a CALL but no self-referential LOAD_GLOBAL.
-        let code = named_function_code(
-            "def fill(dst, n):\n    i = 0\n    while i < n:\n        dst.append(i)\n        i = i + 1\n    return len(dst)\n",
-            "fill",
-        );
-        assert!(!super::code_is_self_recursive(&code));
-    }
-
-    #[test]
-    fn code_is_self_recursive_detects_closure_self_call() {
-        // A nested function loads its own name via LOAD_DEREF (closure cell),
-        // not LOAD_GLOBAL — the scanner must still recognize the self-call.
-        let code = named_function_code(
-            "def outer():\n    def rec(xs, n):\n        xs.append(n)\n        if n > 0:\n            return rec(xs, n - 1) + 1\n        return 1\n    return rec\n",
-            "rec",
-        );
-        assert!(
-            super::code_is_self_recursive(&code),
-            "closure self-recursion (LOAD_DEREF) must be detected"
-        );
-        assert_eq!(code.arg_count, 2);
-        // 2-arg closure self-recursion traced from entry must decline.
-        assert!(
-            decline_predicate(&code, 0),
-            "2-arg closure self-recursion must be declined"
-        );
-    }
-
-    /// Mirror of the `static_walker_should_decline` predicate on a raw
-    /// `CodeObject` (the pointer-resolution wrapper needs a live GC-boxed code
-    /// object, unavailable in a bare unit test — the boxing round-trip SIGSEGVs
-    /// without interpreter init).  The decline logic itself is
-    /// `!start_pc_is_loop_header && arg_count != 1 && code_is_self_recursive`.
-    fn decline_predicate(code: &pyre_interpreter::CodeObject, start_pc: usize) -> bool {
-        !super::start_pc_is_loop_header(code, start_pc)
-            && code.arg_count != 1
-            && super::code_is_self_recursive(code)
-    }
-
-    #[test]
-    fn walker_decline_only_multi_param_self_recursive() {
-        // 1-param self-recursion (fib shape): self-recursive but arg_count == 1,
-        // so the walker must NOT decline it (the CALL_ASSEMBLER arm compiles it).
-        let fib = named_function_code(
-            "def fib(n):\n    if n < 2:\n        return n\n    return fib(n - 1) + fib(n - 2)\n",
-            "fib",
-        );
-        assert!(super::code_is_self_recursive(&fib));
-        assert_eq!(fib.arg_count, 1);
-        assert!(
-            !decline_predicate(&fib, 0),
-            "1-param self-recursion must stay walker-eligible (fib CA arm)"
-        );
-
-        // 2-param self-recursion (rec_append shape) traced from function-entry:
-        // must decline.  rec_append is loop-free, so its entry-trace start_pc
-        // (0) is not a loop header.
-        let rec = named_function_code(
-            "def rec_append(xs, n):\n    xs.append(n)\n    if n > 0:\n        return rec_append(xs, n - 1) + 1\n    return 1\n",
-            "rec_append",
-        );
-        assert!(
-            decline_predicate(&rec, 0),
-            "2-param self-recursion must be declined by the walker"
-        );
-
-        // Non-recursive loop callee: must stay eligible.
-        let fill = named_function_code(
-            "def fill(dst, n):\n    i = 0\n    while i < n:\n        dst.append(i)\n        i = i + 1\n    return len(dst)\n",
-            "fill",
-        );
-        assert!(
-            !decline_predicate(&fill, 0),
-            "non-self-recursive loop callee must stay walker-eligible"
-        );
-    }
-
-    #[test]
-    fn walker_decline_spares_unrelated_loop_in_recursive_fn() {
-        // A 2-param self-recursive function that ALSO has an unrelated hot
-        // `while` loop.  The recursive-callee decline must not strand that
-        // loop: a loop-header trace (start_pc at the JumpBackward target) is a
-        // distinct origin from the function-entry recursive trace.
+    fn start_pc_is_loop_header_detects_while_target() {
         let src = "def f(a, b):\n    if a <= 0:\n        total = 0\n        i = 0\n        while i < b:\n            total = total + i\n            i = i + 1\n        return total\n    return f(a - 1, b)\n";
         let code = named_function_code(src, "f");
-        assert!(super::code_is_self_recursive(&code));
-        assert_eq!(code.arg_count, 2);
 
         // Locate the loop header (the JumpBackward target).
         let mut arg_state = pyre_interpreter::OpArgState::default();
@@ -3092,17 +2900,9 @@ mod tests {
             super::start_pc_is_loop_header(&code, loop_header),
             "the JumpBackward target must be recognized as a loop header"
         );
-
-        // Entry-origin trace (start_pc 0): declined (the recursive callee).
         assert!(
-            decline_predicate(&code, 0),
-            "the recursive callee traced from entry must decline"
-        );
-        // Loop-header-origin trace: must stay eligible so the unrelated hot
-        // loop still gets a JIT token.
-        assert!(
-            !decline_predicate(&code, loop_header),
-            "an unrelated hot loop in a recursive function must stay walker-eligible"
+            !super::start_pc_is_loop_header(&code, 0),
+            "function entry must not be recognized as the loop header"
         );
     }
 


### PR DESCRIPTION
Three commits extending the self-recursive `CALL_ASSEMBLER` fold in the full-body walker.

### `decline self-recursive fold after a foreign body write`
A non-pure residual (e.g. `events.append(n)`) executed concretely before a self-recursive call could double-apply on replay: folding terminates the walk symbolically, a later value-unavailable decline leaves it uncommittable, and the interpreter replays the region. A dynamic per-walk latch `FBW_EXECUTED_BODY_RESIDUAL` declines the fold when a foreign (non self-recursive) non-pure residual has already run. The self-recursive call itself runs as a residual during warmup and is excluded via a callee-code == walk-code check at the executor, so pure recursion (`fib`) still folds.

The decline is dynamic, not static: a body write *before* the self-call must decline, but a write *after* the self-call is fine to fold, so an order-insensitive "body has a non-pure call" gate would be wrong.

### `generalize self-recursive fold to N int params`
`try_walker_call_assembler_self_recursive` now accepts N dense all-int positional parameters (capped at 8) instead of exactly one, building the callee frame through `emit_new_pyframe_inline_with_params`. Every self-recursive call routes to the fold, or to the plain residual call when the fold declines. Removes `static_walker_should_decline` / `code_is_self_recursive`; the multi-param body double-apply they statically guarded is now covered by the dynamic gate above.

Multi-param accumulator/linear recursion (`rs(n, acc)`, `fib2(n, a, b)`, `gcd`) compiles instead of falling back to the interpreter — `mp_perf` 11.08s → 1.96s (dynasm), ~5.6×. `fib` fold and speed are preserved.

### `decline self-recursive fold on bool arguments`
The per-parameter `is_int` check also accepted `bool`, whose payload reads through a different accessor than the int unbox path, corrupting the box and crashing (SIGSEGV) once the multi-parameter fold could carry a bool through a separate parameter. Excludes `is_bool` so a bool argument declines to the plain residual call.

### Verification
- `check.py` dynasm 180/180 + cranelift 180/180
- multi-param probes and 8 double-apply / edge repros: oracle == JIT on both backends
- corpus Terminate-leak scan: 0/169
- fold engagement preserved: `mp_perf` EMIT=1, `fib` EMIT=2

A session-close codex parity review flagged six findings; the bool crash was the one real bug (fixed here), and the other five were empirically refuted against oracle output (non-foldable recursion routes to the residual by design; `*args`/keyword-only signatures already decline the fold; the callable/globals resolution is per-function and correct under reassignment; the body-residual latch scenario does not reproduce).

— *commented by Claude*
