### PR TITLE
cranelift: reload and re-pin the JITFRAME after CALL_RELEASE_GIL

### DIFF
--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -11758,6 +11758,14 @@ impl CraneliftBackend {
                         None,
                     );
 
+                    // The GIL-released window is the most likely point for a
+                    // moving collection by another mutator, so reload the frame
+                    // from the shadow stack and re-pin it before touching the
+                    // frame again — `_reload_frame_if_necessary` runs after every
+                    // call, and every other collecting-call arm does the same.
+                    jf_ptr = emit_reload_frame_if_necessary(&mut builder, ptr_type, call_conv);
+                    builder.ins().set_pinned_reg(jf_ptr);
+
                     emit_pop_gcmap(&mut builder, jf_ptr, per_call_gcmap);
                     // Reload roots (may have been updated by GC during call)
                     reload_ref_roots(


### PR DESCRIPTION
## What

After a `CALL_RELEASE_GIL`, reload the JITFRAME pointer from the shadow stack and re-pin it before the frame is touched again.

## Why

The GIL-released window is a likely point for another mutator to trigger a moving collection, which can relocate the frame object. Without reloading, the pinned frame register holds a stale address and subsequent frame accesses dereference freed/moved memory. This mirrors what every other collecting-call arm already does after a call, and is the same class of fix as the loop entry-prologue frame-depth check (#530).

## Scope / impact

The GIL release/acquire shims are currently no-op, so this reload has no observable runtime effect yet — it is preventive GC-safety hardening that becomes load-bearing once no-GIL wiring drives real GIL release. `_reload_frame_if_necessary` runs after every call; this brings the `CALL_RELEASE_GIL` arm in line.

## Verification

- `python3 pyre/check.py --backend cranelift`: 181/181 ALL PASSED.
- dynasm is unaffected (cranelift-only change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)