### PR TITLE
#205 DictStorage-elim (2/3): migrate heap type dicts to a GC-managed W_DictObject

### DIFF
--- a/pyre/pyre-interpreter/src/_structseq.rs
+++ b/pyre/pyre-interpreter/src/_structseq.rs
@@ -206,15 +206,7 @@ fn structseq_setattr(args: &[PyObjectRef]) -> Result<PyObjectRef, PyError> {
     let attr = unsafe { pyre_object::w_str_get_value(attr_obj) };
     let cls = unsafe { (*inst).w_class };
     // `attr not in type(self).__dict__` — own-dict membership, not MRO.
-    let in_type_dict = {
-        let dict_ptr = unsafe { pyre_object::typeobject::w_type_get_dict_ptr(cls) }
-            as *const crate::DictStorage;
-        if dict_ptr.is_null() {
-            false
-        } else {
-            crate::dict_storage_get(unsafe { &*dict_ptr }, &attr).is_some()
-        }
-    };
+    let in_type_dict = crate::type_dict_contains(cls, &attr);
     if !in_type_dict {
         let cls_name = unsafe { pyre_object::w_type_get_name(cls) };
         return Err(PyError::attribute_error(format!(

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -3317,12 +3317,7 @@ fn getattr_str_impl(obj: PyObjectRef, name: &str, call_getattr: bool) -> PyResul
                     if is_type(t) {
                         // Look in this class's own dict only (not its MRO),
                         // since we are already iterating the full MRO ourselves.
-                        let ns_ptr = w_type_get_dict_ptr(t) as *mut crate::DictStorage;
-                        let found = if !ns_ptr.is_null() {
-                            (*ns_ptr).get(name).copied()
-                        } else {
-                            None
-                        };
+                        let found = crate::type_dict_lookup(t, name);
                         if let Some(attr) = found {
                             // descriptor.py W_Super.getattribute:
                             // Invoke descriptor __get__ protocol.
@@ -4168,9 +4163,7 @@ pub(crate) unsafe fn object_setattr_surrogate(
                     w_type_get_name(obj)
                 )));
             }
-            let dict_ptr = w_type_get_dict_ptr(obj) as *mut crate::DictStorage;
-            if !dict_ptr.is_null() {
-                crate::dict_storage_store_wtf8(&mut *dict_ptr, name, value);
+            if crate::type_dict_store_wtf8(obj, name, value) {
                 pyre_object::gc_hook::try_gc_write_barrier(obj as *mut u8);
                 mutated(obj, name.as_str().ok());
                 return Ok(w_none());
@@ -4252,8 +4245,7 @@ pub(crate) unsafe fn object_delattr_surrogate(
                     w_type_get_name(obj)
                 )));
             }
-            let dict_ptr = w_type_get_dict_ptr(obj) as *mut crate::DictStorage;
-            if !dict_ptr.is_null() && crate::dict_storage_delete_wtf8(&mut *dict_ptr, name) {
+            if crate::type_dict_delete_wtf8(obj, name) {
                 // A lone surrogate has no `&str` form, so `mutated` falls
                 // back to the conservative whole-cache reset (correct: a
                 // surrogate can never name `__eq__`/`__hash__`).
@@ -5801,22 +5793,13 @@ pub unsafe fn compares_by_identity(w_type: PyObjectRef) -> bool {
         if *cls == object_type {
             break;
         }
-        let ns_ptr = pyre_object::typeobject::w_type_get_dict_ptr(*cls) as *mut crate::DictStorage;
-        if ns_ptr.is_null() {
-            continue;
+        if crate::type_dict_lookup(*cls, "__eq__").is_some() {
+            compares_by_identity = false;
+            break;
         }
-        let ns = &*ns_ptr;
-        if let Some(&v) = ns.get("__eq__") {
-            if !v.is_null() {
-                compares_by_identity = false;
-                break;
-            }
-        }
-        if let Some(&v) = ns.get("__hash__") {
-            if !v.is_null() {
-                compares_by_identity = false;
-                break;
-            }
+        if crate::type_dict_lookup(*cls, "__hash__").is_some() {
+            compares_by_identity = false;
+            break;
         }
     }
     let result = if compares_by_identity {
@@ -5915,14 +5898,8 @@ pub(crate) unsafe fn lookup_where(
         if (*cls).is_null() || !is_type(*cls) {
             continue;
         }
-        let ns_ptr = w_type_get_dict_ptr(*cls) as *mut crate::DictStorage;
-        if !ns_ptr.is_null() {
-            let ns = &*ns_ptr;
-            if let Some(&value) = ns.get(name) {
-                if !value.is_null() {
-                    return Some((*cls, value));
-                }
-            }
+        if let Some(value) = crate::type_dict_lookup(*cls, name) {
+            return Some((*cls, value));
         }
     }
     None
@@ -6015,14 +5992,8 @@ pub(crate) unsafe fn lookup_in_type_wtf8(w_type: PyObjectRef, name: &Wtf8) -> Op
         if (*cls).is_null() || !is_type(*cls) {
             continue;
         }
-        let ns_ptr = w_type_get_dict_ptr(*cls) as *mut crate::DictStorage;
-        if !ns_ptr.is_null() {
-            let ns = &*ns_ptr;
-            if let Some(&value) = ns.get_wtf8(name) {
-                if !value.is_null() {
-                    return Some(value);
-                }
-            }
+        if let Some(value) = crate::type_dict_lookup_wtf8(*cls, name) {
+            return Some(value);
         }
     }
     None
@@ -7277,8 +7248,7 @@ pub fn object_setattr(obj: PyObjectRef, name: &str, value: PyObjectRef) -> PyRes
                     w_type_get_name(obj)
                 )));
             }
-            let dict_ptr = w_type_get_dict_ptr(obj) as *mut crate::DictStorage;
-            if !dict_ptr.is_null() {
+            if crate::type_dict_has_storage(obj) {
                 // typeobject.py:1258-1261 descr_set___abstractmethods__ —
                 // evaluate truthiness BEFORE mutating the dict so a raising
                 // `__bool__` leaves the type unchanged (CPython
@@ -7288,7 +7258,7 @@ pub fn object_setattr(obj: PyObjectRef, name: &str, value: PyObjectRef) -> PyRes
                 } else {
                     None
                 };
-                crate::dict_storage_store(&mut *dict_ptr, name, value);
+                crate::type_dict_store(obj, name, value);
                 pyre_object::gc_hook::try_gc_write_barrier(obj as *mut u8);
                 if let Some(a) = abstract_flag {
                     pyre_object::w_type_set_abstract(obj, a);
@@ -7841,9 +7811,8 @@ pub fn object_delattr(obj: PyObjectRef, name: &str) -> PyResult {
                     w_type_get_name(obj)
                 )));
             }
-            let dict_ptr = w_type_get_dict_ptr(obj) as *mut crate::DictStorage;
-            if !dict_ptr.is_null() {
-                if crate::dict_storage_delete(&mut *dict_ptr, name) {
+            if crate::type_dict_has_storage(obj) {
+                if crate::type_dict_delete(obj, name) {
                     // typeobject.py:1263-1267 descr_del___abstractmethods__.
                     if name == "__abstractmethods__" {
                         pyre_object::w_type_set_abstract(obj, false);
@@ -11288,13 +11257,7 @@ mod tests {
             // closure capture is fine — make_builtin_type runs init eagerly.
         });
         // Stash __bases__ on outer's type dict pointing at the inner instance.
-        crate::dict_storage_store(
-            unsafe {
-                &mut *(pyre_object::w_type_get_dict_ptr(outer_type) as *mut crate::DictStorage)
-            },
-            "__bases__",
-            w_tuple_new(vec![inner]),
-        );
+        crate::type_dict_store(outer_type, "__bases__", w_tuple_new(vec![inner]));
         let outer = pyre_object::objectobject::w_instance_new(outer_type);
         let yes = super::issubclass(outer, inner).expect("issubclass should succeed");
         assert!(yes);

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -4509,20 +4509,21 @@ fn object_getattr_miss(obj: PyObjectRef, name: &str, call_getattr: bool) -> PyRe
                 // returns `W_DictProxyObject(w_dict)` — a read-only
                 // **live** view of the type's namespace.  The proxy's
                 // identity is fresh per call (a new wrapper) but its
-                // `w_mapping` is the type's canonical W_DictObject, so
-                // a subsequent `cls.x = 1; d['x']` resolves through the
-                // dict_storage_proxy and surfaces the live binding.
-                let dict_ptr = w_type_get_dict_ptr(obj) as *const crate::DictStorage;
+                // `w_mapping` is the type's canonical W_DictObject.
+                let dict_ptr = w_type_get_dict_ptr(obj);
                 if dict_ptr.is_null() {
                     return Ok(pyre_object::w_dict_proxy_new(pyre_object::w_dict_new()));
                 }
-                // `pypy/objspace/std/typeobject.py:1277 descr_get_dict`
-                // wraps the type's regular W_DictObject — not a
-                // module-strategy dict — into the proxy.  Pass
-                // `Instance` kind so the type's namespace lives on
-                // the EmptyDictStrategy/typed-strategy ladder rather
-                // than ModuleDictStrategy's GlobalCache machinery.
-                let canonical = dict_storage_to_dict_kind(dict_ptr, DictWrapKind::Instance);
+                let canonical = if w_type_is_heaptype(obj) {
+                    dict_ptr as PyObjectRef
+                } else {
+                    // Static builtin types keep their raw namespace and lazily
+                    // materialize the canonical regular dict mirror.
+                    dict_storage_to_dict_kind(
+                        dict_ptr as *const crate::DictStorage,
+                        DictWrapKind::Instance,
+                    )
+                };
                 return Ok(pyre_object::w_dict_proxy_new(canonical));
             }
             if name == "__bases__" {

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -3260,12 +3260,27 @@ fn type_descr_new_with_metaclass(
         }
         let w_metaclass = w_winner;
 
-        let w_type = pyre_object::w_type_new(name, w_effective_bases, ns_ptr as *mut u8);
-        // typeobject.py:1143-1204 create_all_slots parity.
-        unsafe {
-            let ns = &*ns_ptr;
-            crate::call::create_all_slots(w_type, ns, w_effective_bases)?;
+        let _dict_root = pyre_object::gc_roots::push_roots();
+        let dict_root = pyre_object::gc_roots::shadow_stack_len();
+        let dict_obj = pyre_object::w_dict_new();
+        pyre_object::gc_roots::pin_root(dict_obj);
+        for (key, &value) in unsafe { (*ns_ptr).entries_wtf8() } {
+            if value.is_null() {
+                continue;
+            }
+            let dict_obj = pyre_object::gc_roots::shadow_stack_get(dict_root);
+            match key.as_str() {
+                Ok(s) => unsafe { pyre_object::w_dict_setitem_str_no_proxy(dict_obj, s, value) },
+                Err(_) => unsafe {
+                    pyre_object::w_dict_setitem_wtf8_no_proxy(dict_obj, key, value)
+                },
+            }
         }
+        let dict_obj = pyre_object::gc_roots::shadow_stack_get(dict_root);
+        drop(unsafe { Box::from_raw(ns_ptr) });
+        let w_type = pyre_object::w_type_new(name, w_effective_bases, dict_obj as *mut u8);
+        // typeobject.py:1143-1204 create_all_slots parity.
+        unsafe { crate::call::create_all_slots(w_type, w_effective_bases)? };
         // rclass.py:739-743 — set w_class (typeptr) at allocation time.
         // For type objects, w_class is the metaclass (type(C) → Meta).
         // baseobjspace.py:76 getclass() returns the metatype.
@@ -3292,15 +3307,12 @@ fn type_descr_new_with_metaclass(
         // already removed, not the original backing.  Collect the entries
         // first so the storage borrow is released before the call, which may
         // re-enter the type's dict.
-        let set_name_entries: Vec<(Wtf8Buf, PyObjectRef)> = unsafe {
-            (*ns_ptr)
-                .entries_wtf8()
-                .map(|(k, v)| (k.to_owned(), *v))
-                .collect()
-        };
+        let dict_obj = pyre_object::gc_roots::shadow_stack_get(dict_root);
+        let set_name_entries = unsafe { pyre_object::w_dict_items(dict_obj) };
         for (key, v) in set_name_entries {
-            let k = pyre_object::w_str_from_wtf8(key);
-            unsafe { crate::baseobjspace::set_name(w_type, k, v) }?;
+            if unsafe { pyre_object::is_str(key) } {
+                unsafe { crate::baseobjspace::set_name(w_type, key, v) }?;
+            }
         }
 
         // type_new_init_subclass — fire __init_subclass__ with the

--- a/pyre/pyre-interpreter/src/call.rs
+++ b/pyre/pyre-interpreter/src/call.rs
@@ -3357,6 +3357,13 @@ fn build_class_inner(
     };
     // Create class via metaclass or default type()
     // PyPy: typeobject.py — metaclass(name, bases, dict_w) or type.__new__
+    // Keep the default path's fresh managed namespace rooted until slot
+    // creation, __set_name__, and classcell binding have all completed.
+    let _dict_root = if w_metaclass.is_none() {
+        Some(pyre_object::gc_roots::push_roots())
+    } else {
+        None
+    };
     let w_type = if let Some(w_metaclass) = w_metaclass {
         // Convert class namespace to a dict for metaclass call.
         // If __prepare__ returned a custom dict, replay stores into it
@@ -3463,12 +3470,26 @@ fn build_class_inner(
             class_ns.remove("__classdictcell__");
             crate::builtins::type_new_wrap_special_methods(class_ns);
         }
-        let w = pyre_object::w_type_new(name, w_effective_bases, class_ns_ptr as *mut u8);
-        // typeobject.py:1143-1204 create_all_slots parity.
-        unsafe {
-            let ns = &*class_ns_ptr;
-            create_all_slots(w, ns, w_effective_bases)?;
+        let dict_root = pyre_object::gc_roots::shadow_stack_len();
+        let dict_obj = pyre_object::w_dict_new();
+        pyre_object::gc_roots::pin_root(dict_obj);
+        for (key, &value) in unsafe { (*class_ns_ptr).entries_wtf8() } {
+            if value.is_null() {
+                continue;
+            }
+            let dict_obj = pyre_object::gc_roots::shadow_stack_get(dict_root);
+            match key.as_str() {
+                Ok(s) => unsafe { pyre_object::w_dict_setitem_str_no_proxy(dict_obj, s, value) },
+                Err(_) => unsafe {
+                    pyre_object::w_dict_setitem_wtf8_no_proxy(dict_obj, key, value)
+                },
+            }
         }
+        let dict_obj = pyre_object::gc_roots::shadow_stack_get(dict_root);
+        drop(unsafe { Box::from_raw(class_ns_ptr) });
+        let w = pyre_object::w_type_new(name, w_effective_bases, dict_obj as *mut u8);
+        // typeobject.py:1143-1204 create_all_slots parity.
+        unsafe { create_all_slots(w, w_effective_bases)? };
         // baseobjspace.py:76 — set w_class to 'type' (default metaclass)
         unsafe {
             (*w).w_class = crate::typedef::w_type();
@@ -3486,12 +3507,10 @@ fn build_class_inner(
         // which handles __set_name__ in builtins.rs, so we must NOT call it
         // again there to avoid double invocation.
         if unsafe { pyre_object::is_type(w) } {
-            let ns = unsafe { &*class_ns_ptr };
-            let entries: Vec<(String, PyObjectRef)> =
-                ns.entries().map(|(k, &v)| (k.to_string(), v)).collect();
-            for (attr_name, value) in entries {
-                if !value.is_null() {
-                    let w_name = pyre_object::w_str_new(&attr_name);
+            let dict_obj = pyre_object::gc_roots::shadow_stack_get(dict_root);
+            let entries = unsafe { pyre_object::w_dict_items(dict_obj) };
+            for (w_name, value) in entries {
+                if !value.is_null() && unsafe { pyre_object::is_str(w_name) } {
                     unsafe { crate::baseobjspace::set_name(w, w_name, value) }?;
                 }
             }
@@ -3846,7 +3865,6 @@ unsafe fn copy_flags_from_bases(
 /// `w_type` must be a valid W_TypeObject pointer.
 pub unsafe fn create_all_slots(
     w_type: pyre_object::PyObjectRef,
-    ns: &crate::DictStorage,
     w_bases: pyre_object::PyObjectRef,
 ) -> Result<(), crate::PyError> {
     unsafe {
@@ -3864,7 +3882,7 @@ pub unsafe fn create_all_slots(
         // `abc.Mapping` / `abc.Sequence` match `case {..}` / `case [..]`. The
         // bit lives only in the defining body's namespace, so subclasses pick
         // it up through `inherit_flag_map_or_seq` above rather than re-reading.
-        if let Some(&w_flags) = ns.get("__abc_tpflags__") {
+        if let Some(w_flags) = crate::type_dict_lookup(w_type, "__abc_tpflags__") {
             if pyre_object::is_int(w_flags) {
                 let flags = pyre_object::w_int_get_value(w_flags);
                 if flags & (1 << 6) != 0 {
@@ -3893,7 +3911,7 @@ pub unsafe fn create_all_slots(
         // typeobject.py:1150-1204 create_all_slots
         let mut newslotnames = Vec::new();
         let (mut wantdict, mut wantweakref);
-        if let Some(&w_slots) = ns.get("__slots__") {
+        if let Some(w_slots) = crate::type_dict_lookup(w_type, "__slots__") {
             // typeobject.py:1154-1176: has __slots__
             wantdict = false;
             wantweakref = false;
@@ -3965,7 +3983,7 @@ pub unsafe fn create_all_slots(
         if wantweakref {
             create_weakref_slot(w_type);
         }
-        if ns.get("__del__").is_some() {
+        if crate::type_dict_contains(w_type, "__del__") {
             pyre_object::w_type_set_hasuserdel(w_type, true);
         }
 

--- a/pyre/pyre-interpreter/src/call.rs
+++ b/pyre/pyre-interpreter/src/call.rs
@@ -3926,7 +3926,6 @@ pub unsafe fn create_all_slots(
             newslotnames.sort();
 
             // typeobject.py:1183-1189: create_slot loop
-            let type_ns = pyre_object::w_type_get_dict_ptr(w_type) as *mut crate::DictStorage;
             let type_name = pyre_object::w_type_get_name(w_type);
             let mut slot_index = base_nslots;
             let mut i = 0;
@@ -3939,15 +3938,15 @@ pub unsafe fn create_all_slots(
                 }
                 // typeobject.py:1211: slot_name = mangle(slot_name, w_self.name)
                 let mangled = mangle(&newslotnames[i], type_name);
-                if !type_ns.is_null() && (*type_ns).get(mangled.as_str()).is_some() {
+                if crate::type_dict_contains(w_type, mangled.as_str()) {
                     // typeobject.py:1219-1220: name conflict → skip this slot
                     newslotnames.remove(i);
                 } else {
                     // typeobject.py:1216-1217: create_slot
                     newslotnames[i] = mangled.clone();
-                    if !type_ns.is_null() {
+                    if crate::type_dict_has_storage(w_type) {
                         let member = pyre_object::w_member_new(slot_index, mangled.clone(), w_type);
-                        (*type_ns).insert(mangled, member);
+                        crate::type_dict_store(w_type, &mangled, member);
                     }
                     slot_index += 1;
                     i += 1;
@@ -4014,9 +4013,8 @@ unsafe fn create_dict_slot(w_type: pyre_object::PyObjectRef) {
         if !pyre_object::w_type_get_hasdict(w_type) {
             let descr =
                 crate::typedef::copy_descriptor_for_type(crate::typedef::dict_descr(), w_type);
-            let type_ns = pyre_object::w_type_get_dict_ptr(w_type) as *mut crate::DictStorage;
-            if !type_ns.is_null() && (*type_ns).get("__dict__").is_none() {
-                (*type_ns).insert("__dict__".to_string(), descr);
+            if !crate::type_dict_contains(w_type, "__dict__") {
+                crate::type_dict_store(w_type, "__dict__", descr);
             }
             pyre_object::w_type_set_hasdict(w_type, true);
         }
@@ -4037,9 +4035,8 @@ unsafe fn create_weakref_slot(w_type: pyre_object::PyObjectRef) {
         if !pyre_object::w_type_get_weakrefable(w_type) {
             let descr =
                 crate::typedef::copy_descriptor_for_type(crate::typedef::weakref_descr(), w_type);
-            let type_ns = pyre_object::w_type_get_dict_ptr(w_type) as *mut crate::DictStorage;
-            if !type_ns.is_null() && (*type_ns).get("__weakref__").is_none() {
-                (*type_ns).insert("__weakref__".to_string(), descr);
+            if !crate::type_dict_contains(w_type, "__weakref__") {
+                crate::type_dict_store(w_type, "__weakref__", descr);
             }
             pyre_object::w_type_set_weakrefable(w_type, true);
         }

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -324,9 +324,8 @@ unsafe fn walk_raw_getset_roots(value: PyObjectRef, visitor: &mut dyn FnMut(&mut
 /// per-type `__dict__`/`__weakref__` getset descriptor copies.  Keys are
 /// Rust `String`s (not GC objects); only the `PyObjectRef` values relocate.
 /// Snapshot the value slots first (same shape as the globals proxy walk)
-/// so `forward` cannot re-borrow the storage.  Shared by
-/// `walk_builtin_type_dicts_gc` for Box-immortal builtin types and the
-/// `W_TYPE_GC_TYPE_ID` custom trace for GC-managed heap types.
+/// so `forward` cannot re-borrow the storage.  This is the static builtin
+/// namespace path; heap types forward their managed dict object instead.
 pub unsafe fn type_walk_namespace_values(
     w_type: PyObjectRef,
     forward: &mut dyn FnMut(&mut PyObjectRef),
@@ -370,8 +369,8 @@ pub unsafe fn type_walk_namespace_values(
 /// trace fired, but their namespaces, `bases`, and `weak_subclasses` can hold
 /// young GC objects after startup.  Walk every registered builtin type (and
 /// the rare pre-GC heap-type fallback) as pinned roots so those children stay
-/// live and their slots are forwarded.  Heap types are GC-managed and reach
-/// the same fields through their own `W_TYPE_GC_TYPE_ID` custom trace.
+/// live and their slots are forwarded.  GC-managed heap types reach the same
+/// fields through their own `W_TYPE_GC_TYPE_ID` custom trace.
 unsafe fn walk_builtin_type_dicts_gc(forward: &mut dyn FnMut(&mut PyObjectRef)) {
     unsafe {
         for addr in pyre_object::typeobject::snapshot_builtin_type_roots() {
@@ -388,10 +387,17 @@ unsafe fn walk_builtin_type_dicts_gc(forward: &mut dyn FnMut(&mut PyObjectRef)) 
                 let bases_slot =
                     &mut (*(w_type as *mut pyre_object::typeobject::W_TypeObject)).bases;
                 forward(bases_slot);
-                // Namespace `dict_w` values: the class attributes, methods,
-                // and getset descriptor copies — the same walk the
-                // `W_TYPE_GC_TYPE_ID` custom trace performs for a heap type.
-                type_walk_namespace_values(w_type, forward);
+                let t = &mut *(w_type as *mut pyre_object::typeobject::W_TypeObject);
+                if pyre_object::w_type_is_heaptype(w_type) {
+                    // A pre-GC heap-type fallback has the managed-dict field
+                    // shape even though its type object itself is Box-immortal.
+                    let dict_slot = &mut t.dict as *mut *mut u8 as *mut PyObjectRef;
+                    forward(&mut *dict_slot);
+                } else {
+                    // Static builtin namespace values remain in raw
+                    // DictStorage and retain their mirror-target edge.
+                    type_walk_namespace_values(w_type, forward);
+                }
                 // `weak_subclasses` holds `w_weakref_new` (`try_gc_alloc`)
                 // young WEAKREF GcStructs whose only strong root is this
                 // off-GC list; forward each slot in place so the WEAKREF
@@ -402,7 +408,6 @@ unsafe fn walk_builtin_type_dicts_gc(forward: &mut dyn FnMut(&mut PyObjectRef)) 
                 // `mutated()` / `w_type_get_subclasses` deref.  The
                 // `W_TYPE_GC_TYPE_ID` custom trace performs the same walk for
                 // a heap type.
-                let t = &mut *(w_type as *mut pyre_object::typeobject::W_TypeObject);
                 if t.weak_subclasses.is_null() {
                     // No subclasses recorded.
                 } else {

--- a/pyre/pyre-interpreter/src/module/_io/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_io/mod.rs
@@ -61,7 +61,7 @@ crate::py_module! {
             let t = pyre_object::w_type_new(
                 name,
                 pyre_object::w_tuple_new(vec![obj_type]),
-                std::ptr::null_mut(),
+                pyre_object::w_dict_new() as *mut u8,
             );
             unsafe { pyre_object::w_type_set_mro(t, vec![t, obj_type]) };
             unsafe { pyre_object::typeobject::w_type_ready(t) };

--- a/pyre/pyre-interpreter/src/runtime_ops.rs
+++ b/pyre/pyre-interpreter/src/runtime_ops.rs
@@ -1047,63 +1047,100 @@ pub fn dict_storage_delete_wtf8(namespace: &mut DictStorage, name: &Wtf8) -> boo
     namespace.remove_wtf8(name).is_some()
 }
 
-fn type_dict_storage_ptr(cls: PyObjectRef) -> *mut DictStorage {
-    unsafe { pyre_object::w_type_get_dict_ptr(cls) as *mut DictStorage }
+fn type_dict_ptr(cls: PyObjectRef) -> *mut u8 {
+    unsafe { pyre_object::w_type_get_dict_ptr(cls) }
 }
 
 pub fn type_dict_has_storage(cls: PyObjectRef) -> bool {
-    !type_dict_storage_ptr(cls).is_null()
+    !type_dict_ptr(cls).is_null()
 }
 
 pub fn type_dict_lookup(cls: PyObjectRef, name: &str) -> Option<PyObjectRef> {
-    let namespace = type_dict_storage_ptr(cls);
-    if namespace.is_null() {
+    let dict = type_dict_ptr(cls);
+    if dict.is_null() {
         return None;
     }
-    let value = unsafe { (*namespace).get(name).copied()? };
+    let value = if unsafe { pyre_object::w_type_is_heaptype(cls) } {
+        unsafe { pyre_object::w_dict_getitem_str(dict as PyObjectRef, name)? }
+    } else {
+        unsafe { (*(dict as *mut DictStorage)).get(name).copied()? }
+    };
     if value.is_null() { None } else { Some(value) }
 }
 
 pub fn type_dict_lookup_wtf8(cls: PyObjectRef, name: &Wtf8) -> Option<PyObjectRef> {
-    let namespace = type_dict_storage_ptr(cls);
-    if namespace.is_null() {
+    let dict = type_dict_ptr(cls);
+    if dict.is_null() {
         return None;
     }
-    let value = unsafe { (*namespace).get_wtf8(name).copied()? };
+    let value = if unsafe { pyre_object::w_type_is_heaptype(cls) } {
+        unsafe { pyre_object::w_dict_getitem_wtf8(dict as PyObjectRef, name)? }
+    } else {
+        unsafe { (*(dict as *mut DictStorage)).get_wtf8(name).copied()? }
+    };
     if value.is_null() { None } else { Some(value) }
 }
 
 pub fn type_dict_contains(cls: PyObjectRef, name: &str) -> bool {
-    let namespace = type_dict_storage_ptr(cls);
-    !namespace.is_null() && unsafe { (*namespace).get(name).is_some() }
+    let dict = type_dict_ptr(cls);
+    if dict.is_null() {
+        return false;
+    }
+    if unsafe { pyre_object::w_type_is_heaptype(cls) } {
+        unsafe { pyre_object::w_dict_getitem_str(dict as PyObjectRef, name).is_some() }
+    } else {
+        unsafe { (*(dict as *mut DictStorage)).get(name).is_some() }
+    }
 }
 
 pub fn type_dict_store(cls: PyObjectRef, name: &str, value: PyObjectRef) -> bool {
-    let namespace = type_dict_storage_ptr(cls);
-    if namespace.is_null() {
+    let dict = type_dict_ptr(cls);
+    if dict.is_null() {
         return false;
     }
-    unsafe { dict_storage_store(&mut *namespace, name, value) };
+    if unsafe { pyre_object::w_type_is_heaptype(cls) } {
+        unsafe { pyre_object::w_dict_setitem_str_no_proxy(dict as PyObjectRef, name, value) };
+    } else {
+        unsafe { dict_storage_store(&mut *(dict as *mut DictStorage), name, value) };
+    }
     true
 }
 
 pub fn type_dict_store_wtf8(cls: PyObjectRef, name: &Wtf8, value: PyObjectRef) -> bool {
-    let namespace = type_dict_storage_ptr(cls);
-    if namespace.is_null() {
+    let dict = type_dict_ptr(cls);
+    if dict.is_null() {
         return false;
     }
-    unsafe { dict_storage_store_wtf8(&mut *namespace, name, value) };
+    if unsafe { pyre_object::w_type_is_heaptype(cls) } {
+        unsafe { pyre_object::w_dict_setitem_wtf8_no_proxy(dict as PyObjectRef, name, value) };
+    } else {
+        unsafe { dict_storage_store_wtf8(&mut *(dict as *mut DictStorage), name, value) };
+    }
     true
 }
 
 pub fn type_dict_delete(cls: PyObjectRef, name: &str) -> bool {
-    let namespace = type_dict_storage_ptr(cls);
-    !namespace.is_null() && unsafe { dict_storage_delete(&mut *namespace, name) }
+    let dict = type_dict_ptr(cls);
+    if dict.is_null() {
+        return false;
+    }
+    if unsafe { pyre_object::w_type_is_heaptype(cls) } {
+        unsafe { pyre_object::w_dict_delitem_str_no_proxy(dict as PyObjectRef, name) }
+    } else {
+        unsafe { dict_storage_delete(&mut *(dict as *mut DictStorage), name) }
+    }
 }
 
 pub fn type_dict_delete_wtf8(cls: PyObjectRef, name: &Wtf8) -> bool {
-    let namespace = type_dict_storage_ptr(cls);
-    !namespace.is_null() && unsafe { dict_storage_delete_wtf8(&mut *namespace, name) }
+    let dict = type_dict_ptr(cls);
+    if dict.is_null() {
+        return false;
+    }
+    if unsafe { pyre_object::w_type_is_heaptype(cls) } {
+        unsafe { pyre_object::w_dict_delitem_wtf8_no_proxy(dict as PyObjectRef, name) }
+    } else {
+        unsafe { dict_storage_delete_wtf8(&mut *(dict as *mut DictStorage), name) }
+    }
 }
 
 pub fn sequence_len(seq: PyObjectRef) -> Result<usize, PyError> {

--- a/pyre/pyre-interpreter/src/runtime_ops.rs
+++ b/pyre/pyre-interpreter/src/runtime_ops.rs
@@ -1047,6 +1047,65 @@ pub fn dict_storage_delete_wtf8(namespace: &mut DictStorage, name: &Wtf8) -> boo
     namespace.remove_wtf8(name).is_some()
 }
 
+fn type_dict_storage_ptr(cls: PyObjectRef) -> *mut DictStorage {
+    unsafe { pyre_object::w_type_get_dict_ptr(cls) as *mut DictStorage }
+}
+
+pub fn type_dict_has_storage(cls: PyObjectRef) -> bool {
+    !type_dict_storage_ptr(cls).is_null()
+}
+
+pub fn type_dict_lookup(cls: PyObjectRef, name: &str) -> Option<PyObjectRef> {
+    let namespace = type_dict_storage_ptr(cls);
+    if namespace.is_null() {
+        return None;
+    }
+    let value = unsafe { (*namespace).get(name).copied()? };
+    if value.is_null() { None } else { Some(value) }
+}
+
+pub fn type_dict_lookup_wtf8(cls: PyObjectRef, name: &Wtf8) -> Option<PyObjectRef> {
+    let namespace = type_dict_storage_ptr(cls);
+    if namespace.is_null() {
+        return None;
+    }
+    let value = unsafe { (*namespace).get_wtf8(name).copied()? };
+    if value.is_null() { None } else { Some(value) }
+}
+
+pub fn type_dict_contains(cls: PyObjectRef, name: &str) -> bool {
+    let namespace = type_dict_storage_ptr(cls);
+    !namespace.is_null() && unsafe { (*namespace).get(name).is_some() }
+}
+
+pub fn type_dict_store(cls: PyObjectRef, name: &str, value: PyObjectRef) -> bool {
+    let namespace = type_dict_storage_ptr(cls);
+    if namespace.is_null() {
+        return false;
+    }
+    unsafe { dict_storage_store(&mut *namespace, name, value) };
+    true
+}
+
+pub fn type_dict_store_wtf8(cls: PyObjectRef, name: &Wtf8, value: PyObjectRef) -> bool {
+    let namespace = type_dict_storage_ptr(cls);
+    if namespace.is_null() {
+        return false;
+    }
+    unsafe { dict_storage_store_wtf8(&mut *namespace, name, value) };
+    true
+}
+
+pub fn type_dict_delete(cls: PyObjectRef, name: &str) -> bool {
+    let namespace = type_dict_storage_ptr(cls);
+    !namespace.is_null() && unsafe { dict_storage_delete(&mut *namespace, name) }
+}
+
+pub fn type_dict_delete_wtf8(cls: PyObjectRef, name: &Wtf8) -> bool {
+    let namespace = type_dict_storage_ptr(cls);
+    !namespace.is_null() && unsafe { dict_storage_delete_wtf8(&mut *namespace, name) }
+}
+
 pub fn sequence_len(seq: PyObjectRef) -> Result<usize, PyError> {
     unsafe {
         if is_tuple(seq) {

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -5779,14 +5779,12 @@ fn patch_getset_descriptor_metadata() {
     if tp.is_null() {
         return;
     }
-    let dict_ptr = unsafe { pyre_object::w_type_get_dict_ptr(tp) } as *mut DictStorage;
-    if dict_ptr.is_null() {
+    if !crate::type_dict_has_storage(tp) {
         return;
     }
-    let ns = unsafe { &mut *dict_ptr };
     // typedef.py:470 __name__
-    dict_storage_store(
-        ns,
+    crate::type_dict_store(
+        tp,
         "__name__",
         make_getset_descriptor(make_builtin_function_with_arity(
             "__name__",
@@ -5822,8 +5820,8 @@ fn patch_getset_descriptor_metadata() {
     //     qualname = "%s.%s" % (type_qualname, self.name)
     //     return space.newtext(qualname)
     // ```
-    dict_storage_store(
-        ns,
+    crate::type_dict_store(
+        tp,
         "__qualname__",
         make_getset_descriptor(make_builtin_function_with_arity(
             "__qualname__",
@@ -5892,8 +5890,8 @@ fn patch_getset_descriptor_metadata() {
     //     raise oefmt(space.w_AttributeError,
     //                 "generic self has no __objclass__")
     // ```
-    dict_storage_store(
-        ns,
+    crate::type_dict_store(
+        tp,
         "__objclass__",
         make_getset_descriptor(make_builtin_function_with_arity(
             "__objclass__",
@@ -5922,8 +5920,8 @@ fn patch_getset_descriptor_metadata() {
         )),
     );
     // typedef.py:473 __doc__ = interp_attrproperty('doc', ...)
-    dict_storage_store(
-        ns,
+    crate::type_dict_store(
+        tp,
         "__doc__",
         make_getset_descriptor(make_builtin_function_with_arity(
             "__doc__",
@@ -6227,10 +6225,7 @@ fn init_type_type(ns: &mut DictStorage) {
             let value = args[2];
             unsafe {
                 if pyre_object::is_type(cls) {
-                    let dict_ptr = pyre_object::w_type_get_dict_ptr(cls) as *mut crate::DictStorage;
-                    if !dict_ptr.is_null() {
-                        crate::dict_storage_store(&mut *dict_ptr, "__module__", value);
-                    }
+                    crate::type_dict_store(cls, "__module__", value);
                 }
             }
             Ok(pyre_object::w_none())
@@ -6947,13 +6942,11 @@ fn patch_builtin_function_descriptors() {
     if bf_type.is_null() {
         return;
     }
-    let dict_ptr = unsafe { pyre_object::w_type_get_dict_ptr(bf_type) } as *mut DictStorage;
-    if dict_ptr.is_null() {
+    if !crate::type_dict_has_storage(bf_type) {
         return;
     }
-    let ns = unsafe { &*dict_ptr };
     for name in ["__self__", "__doc__"] {
-        if let Some(&descr) = ns.get(name) {
+        if let Some(descr) = crate::type_dict_lookup(bf_type, name) {
             if unsafe { pyre_object::typedef::is_getset_property(descr) } {
                 // typedef.py:818 `cls=BuiltinFunction` — patch the
                 // `reqcls` slot in place now that the BuiltinFunction

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -6253,16 +6253,16 @@ fn init_type_type(ns: &mut DictStorage) {
                     return Ok(pyre_object::w_dict_proxy_new(pyre_object::w_dict_new()));
                 }
                 // `pypy/objspace/std/typeobject.py:1277 descr_get_dict`
-                // returns `W_DictProxyObject(w_dict)` — read-only **live**
-                // view.  Wrap the type's canonical W_DictObject so
-                // subsequent `cls.x = 1` setattrs flow through the
-                // dict_storage_proxy and become visible on the proxy.
-                // Instance flavor: a type's namespace is a regular
-                // W_DictObject, not a module-strategy dict.
-                let canonical = crate::baseobjspace::dict_storage_to_dict_kind(
-                    ns_ptr as *const DictStorage,
-                    crate::baseobjspace::DictWrapKind::Instance,
-                );
+                // returns a read-only live view over the type's canonical
+                // regular dict object.
+                let canonical = if pyre_object::w_type_is_heaptype(cls) {
+                    ns_ptr as PyObjectRef
+                } else {
+                    crate::baseobjspace::dict_storage_to_dict_kind(
+                        ns_ptr as *const DictStorage,
+                        crate::baseobjspace::DictWrapKind::Instance,
+                    )
+                };
                 Ok(pyre_object::w_dict_proxy_new(canonical))
             }
         },

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -322,9 +322,8 @@ unsafe fn pyre_object_compares_by_identity_trampoline(w_type: pyre_object::PyObj
 ///     collector's `invalidate_young_weakrefs` / `invalidate_old_weakrefs`
 ///     (incminimark.py:3058-3126), so passing the slot to `f` keeps the
 ///     WEAKREF alive without forcing the target alive.
-///   * the off-GC namespace `DictStorage` values (methods, class
-///     attributes, getset descriptor copies) via the interpreter helper,
-///     mirroring `object_object_custom_trace`'s off-GC storage walk.
+///   * the managed namespace object for heap types, or the off-GC
+///     `DictStorage` values for static builtin types.
 ///
 /// Heap types are stable old-gen GC objects, so this trace keeps their owned
 /// GC edges live and forwards their slots.  The separate builtin-type walk
@@ -357,12 +356,16 @@ unsafe fn type_object_custom_trace(obj_addr: usize, f: &mut dyn FnMut(*mut majit
             f(slot as *mut *mut pyre_object::weakref::Weakref as *mut majit_ir::GcRef);
         }
     }
-    pyre_interpreter::eval::type_walk_namespace_values(
-        obj_addr as pyre_object::PyObjectRef,
-        &mut |slot: &mut pyre_object::PyObjectRef| {
-            f(slot as *mut pyre_object::PyObjectRef as *mut majit_ir::GcRef);
-        },
-    );
+    if unsafe { pyre_object::w_type_is_heaptype(obj_addr as pyre_object::PyObjectRef) } {
+        f(&mut t.dict as *mut *mut u8 as *mut pyre_object::PyObjectRef as *mut majit_ir::GcRef);
+    } else {
+        pyre_interpreter::eval::type_walk_namespace_values(
+            obj_addr as pyre_object::PyObjectRef,
+            &mut |slot: &mut pyre_object::PyObjectRef| {
+                f(slot as *mut pyre_object::PyObjectRef as *mut majit_ir::GcRef);
+            },
+        );
+    }
 }
 
 /// Custom trace for `GeneratorIterator` (generator.py GeneratorIterator).

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -368,6 +368,23 @@ unsafe fn type_object_custom_trace(obj_addr: usize, f: &mut dyn FnMut(*mut majit
     }
 }
 
+/// Reclaim the two Rust-owned, out-of-line containers of a swept heap type.
+/// `mro_w` is a GC-managed `FixedObjectArray` reclaimed by the collector and
+/// must not be freed here. The managed namespace object is also reclaimed by
+/// the collector, while the shared/uncertain `terminator` ownership remains
+/// deferred by #528.
+unsafe fn type_object_destructor(obj_addr: usize) {
+    let t = obj_addr as *const pyre_object::typeobject::W_TypeObject;
+    let name = unsafe { (*t).name };
+    if !name.is_null() {
+        drop(unsafe { Box::from_raw(name) });
+    }
+    let weak_subclasses = unsafe { (*t).weak_subclasses };
+    if !weak_subclasses.is_null() {
+        drop(unsafe { Box::from_raw(weak_subclasses) });
+    }
+}
+
 /// Custom trace for `GeneratorIterator` (generator.py GeneratorIterator).
 ///
 /// The suspended frame is held behind an opaque `frame_ptr`
@@ -1569,11 +1586,14 @@ fn build_gc() -> Box<dyn majit_gc::GcAllocator> {
     // `TYPE_TYPE` is in `all_foreign_pytypes()` and the
     // loop's `sizeof(PyObject)` approximation drastically
     // under-counts the W_TypeObject payload.
-    let w_type_tid = gc.register_type(TypeInfo::object_subclass_with_custom_trace(
-        std::mem::size_of::<pyre_object::typeobject::W_TypeObject>(),
-        object_tid,
-        type_object_custom_trace,
-    ));
+    let w_type_tid = gc.register_type(
+        TypeInfo::object_subclass_with_custom_trace(
+            std::mem::size_of::<pyre_object::typeobject::W_TypeObject>(),
+            object_tid,
+            type_object_custom_trace,
+        )
+        .with_destructor_fn(type_object_destructor),
+    );
     debug_assert_eq!(w_type_tid, W_TYPE_GC_TYPE_ID);
     majit_gc::GcAllocator::register_vtable_for_type(
         &mut gc,

--- a/pyre/pyre-object/src/typeobject.rs
+++ b/pyre/pyre-object/src/typeobject.rs
@@ -275,8 +275,15 @@ pub fn w_type_new(name: &str, bases: PyObjectRef, dict_ptr: *mut u8) -> PyObject
     let name = crate::lltype::malloc_raw(name.to_string());
     // `gct_fv_gc_malloc` bracket pattern (`framework.py:853-856`).
     let _roots = crate::gc_roots::push_roots();
+    let save_point = crate::gc_roots::shadow_stack_len();
     crate::gc_roots::pin_root(bases);
-
+    crate::gc_roots::pin_root(dict_ptr as PyObjectRef);
+    let raw = crate::gc_hook::try_gc_alloc_stable_raw(W_TYPE_GC_TYPE_ID, W_TYPE_OBJECT_SIZE);
+    // The stable allocation may collect the nursery, so install the forwarded
+    // bases and managed namespace addresses rather than the pre-collection
+    // arguments.
+    let bases = crate::gc_roots::shadow_stack_get(save_point);
+    let dict_ptr = crate::gc_roots::shadow_stack_get(save_point + 1) as *mut u8;
     let value = W_TypeObject {
         ob_header: PyObject {
             ob_type: &TYPE_TYPE as *const PyType,
@@ -314,7 +321,6 @@ pub fn w_type_new(name: &str, bases: PyObjectRef, dict_ptr: *mut u8) -> PyObject
         flag_disallow_instantiation: std::sync::atomic::AtomicBool::new(false),
         flag_abstract: std::sync::atomic::AtomicBool::new(false),
     };
-    let raw = crate::gc_hook::try_gc_alloc_stable_raw(W_TYPE_GC_TYPE_ID, W_TYPE_OBJECT_SIZE);
     let (w_type, gc_managed) = if !raw.is_null() {
         unsafe { std::ptr::write(raw as *mut W_TypeObject, value) };
         (raw as PyObjectRef, true)


### PR DESCRIPTION
Increment 2 of 3 of #205 (retire `struct DictStorage`). Stacked on inc1 (#539, merged) and rebased onto current `main`.

## What

Migrate **heap type** namespaces off the raw `DictStorage` box onto a GC-managed `W_DictObject`, so a `type.__dict__` mappingproxy keeps the namespace alive on its own and swept heap types reclaim their Rust-owned sidecars. Static builtin types keep their Box-immortal `DictStorage` (dual-mode, discriminated by `w_type_is_heaptype`).

Advances #528 (reclaim swept heap-type sidecars): the mappingproxy-holds-a-dangling-value-ptr blocker is resolved, and `name` / `weak_subclasses` are now freed on sweep.

## Slices

1. `type-dict: funnel …` — route all type-namespace value access through `type_dict_*` helpers (behavior-neutral).
2. `type-dict: store … GC-managed dict object` — a heap type's `.dict` becomes a GC `W_DictObject` (dual-mode via `w_type_is_heaptype`); the type's custom trace forwards `.dict`; `cls.__dict__` builds a proxy over the GC dict directly; class construction folds the namespace into `w_dict_new()` and frees the transient `class_ns`.
3. `gc: free a swept heap type's name and weak-subclasses sidecars` — register `type_object_destructor` to drop the `name` `String` and the `weak_subclasses` `Vec` on sweep. `mro_w` (a GC-managed `FixedObjectArray`) and `dict` (a GC `W_DictObject`) are reclaimed by the collector; `terminator` stays deferred (#528).

## Verification

- `python3 pyre/check.py` — dynasm 181/181, cranelift 181/181, wasm 180/180 (ALL PASSED).
- `cargo test -p pyre-jit --features dynasm --test gc_stress` — 6/6.
- #528 smokes: bounded managed-heap plateau across 200k define-and-drop classes; a retained `cls.__dict__` proxy survives 20× `gc.collect()` and still reads correctly.
- Adversarial multi-agent GC-soundness review of slice 2: 0 confirmed defects.

## Notes

- Rebasing onto current `main` surfaced a latent cross-branch incompatibility: `main` GC-ified `mro_w` (`alloc_mro_block_gc`), so slice 3's destructor freeing `mro_w` as a `Box` double-freed a GC object (SIGABRT on `synth/sre_pattern_methods`, wasm dlmalloc abort on `synth/type_name_surrogate_reject`). Folded into slice 3: the destructor no longer touches `mro_w`.
- Remaining #528 residual (separate, general dict-lifecycle): a swept `W_DictObject` still leaks its raw `dstorage` container (no `W_DICT` destructor yet). Tracked as a follow-up.

— *opened by Claude*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved class creation and type dictionary handling for more reliable attribute lookup, assignment, and deletion.
  * Improved garbage-collection safety when creating and tracing types.
  * Ensured built-in I/O base types initialize with usable namespaces.
  * Improved descriptor metadata and class initialization behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->