### PR TITLE
interp+jit: batch of semantic and crash defect fixes (generators, sort/extend rooting, class protocol, in-place op JIT drop)

### DIFF
--- a/majit/majit-metainterp/src/optimizeopt/heap.rs
+++ b/majit/majit-metainterp/src/optimizeopt/heap.rs
@@ -1742,7 +1742,13 @@ impl OptHeap {
                 if flush_owners.contains(&owner) {
                     return;
                 }
-                let allocated_here = self.seen_allocation.contains(owner.raw() as usize);
+                // `seen_allocation` is keyed by real SSA-op positions.  A
+                // forwarded lazy-store owner may instead be an inline Const
+                // (`ConstPtr` after a raising/non-raising path merge); like
+                // RPython's Const box it cannot be a trace allocation, and
+                // it has no raw position to query.
+                let allocated_here =
+                    !owner.is_constant() && self.seen_allocation.contains(owner.raw() as usize);
                 let escaped = ctx
                     .get_box_replacement_operand_opt(owner)
                     .as_ref()

--- a/pyre/extra_tests/snippets/builtin_all.py
+++ b/pyre/extra_tests/snippets/builtin_all.py
@@ -5,5 +5,13 @@ assert not all([False])
 assert all([])
 assert not all([False, TestFailingBool()])
 
+
+def all_stops_after_false():
+    yield 0
+    raise RuntimeError("unreachable")
+
+
+assert not all(all_stops_after_false())
+
 assert_raises(RuntimeError, all, TestFailingIter())
 assert_raises(RuntimeError, all, [TestFailingBool()])

--- a/pyre/extra_tests/snippets/builtin_any.py
+++ b/pyre/extra_tests/snippets/builtin_any.py
@@ -5,5 +5,13 @@ assert not any([False])
 assert not any([])
 assert any([True, TestFailingBool()])
 
+
+def any_stops_after_true():
+    yield 1
+    raise RuntimeError("unreachable")
+
+
+assert any(any_stops_after_true())
+
 assert_raises(RuntimeError, lambda: any(TestFailingIter()))
 assert_raises(RuntimeError, lambda: any([TestFailingBool()]))

--- a/pyre/extra_tests/snippets/jit_inplace_user_loop.py
+++ b/pyre/extra_tests/snippets/jit_inplace_user_loop.py
@@ -1,0 +1,56 @@
+"""Hot user ``__i*__`` dispatch must not drop the tracing-boundary item."""
+
+
+class HotInPlace:
+    def __init__(self, val):
+        self.val = val
+        self.calls = 0
+
+    def __iadd__(self, other):
+        self.calls += 1
+        self.val += other
+        return self
+
+    def __isub__(self, other):
+        self.calls += 1
+        self.val -= other
+        return self
+
+    def __imul__(self, other):
+        self.calls += 1
+        self.val *= other
+        return self
+
+
+add = HotInPlace(0)
+for n in range(1000):
+    add += n
+assert add.calls == 1000
+assert add.val == 499500
+
+sub = HotInPlace(499500)
+for n in range(1000):
+    sub -= n
+assert sub.calls == 1000
+assert sub.val == 0
+
+mul = HotInPlace(1)
+for n in range(1000):
+    mul *= n
+assert mul.calls == 1000
+
+
+class HotInPlaceFresh:
+    def __init__(self, val, calls=0):
+        self.val = val
+        self.calls = calls
+
+    def __iadd__(self, other):
+        return HotInPlaceFresh(self.val + other, self.calls + 1)
+
+
+fresh = HotInPlaceFresh(0)
+for n in range(1000):
+    fresh += n
+assert fresh.calls == 1000
+assert fresh.val == 499500

--- a/pyre/extra_tests/snippets/stdlib_functools_cmp_to_key.py
+++ b/pyre/extra_tests/snippets/stdlib_functools_cmp_to_key.py
@@ -1,0 +1,14 @@
+from functools import cmp_to_key
+
+
+descending = cmp_to_key(lambda a, b: b - a)
+ascending = cmp_to_key(lambda a, b: a - b)
+
+assert sorted([3, 1, 2], key=descending) == [3, 2, 1]
+assert sorted([3, 1, 2], key=ascending) == [1, 2, 3]
+assert min([3, 1, 2], key=descending) == 3
+assert max([3, 1, 2], key=descending) == 1
+assert sorted(
+    [(1, "first"), (1, "second"), (0, "third")],
+    key=cmp_to_key(lambda a, b: a[0] - b[0]),
+) == [(0, "third"), (1, "first"), (1, "second")]

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -10590,13 +10590,30 @@ fn generator_send_ex(gen_obj: PyObjectRef, w_arg: PyObjectRef, operr: Option<PyE
         w_generator_set_started(gen_obj);
         w_generator_set_running(gen_obj, true);
 
+        // A suspended `yield from` owns the next resume operation.  Keep the
+        // outer frame parked until its delegate either yields again or is
+        // exhausted, so a value or exception never takes the bytecode path
+        // intended for an awaitable resume.
+        let mut pending_operr = operr;
+        let mut delegated_completion = false;
+        if already_started && !frame.w_yielding_from.is_null() {
+            match resume_yield_from(frame, w_arg, pending_operr.take()) {
+                Ok(Some(value)) => {
+                    w_generator_set_running(gen_obj, false);
+                    return Ok(value);
+                }
+                Ok(None) => delegated_completion = true,
+                Err(err) => pending_operr = Some(err),
+            }
+        }
+
         // generator.py:104 — w_result = frame.execute_frame(w_arg, operr)
-        let w_inputvalue = if already_started && operr.is_none() {
+        let w_inputvalue = if already_started && pending_operr.is_none() && !delegated_completion {
             Some(w_arg)
         } else {
             None
         };
-        let result = frame.execute_frame(w_inputvalue, operr);
+        let result = frame.execute_frame(w_inputvalue, pending_operr);
 
         w_generator_set_running(gen_obj, false);
 
@@ -10632,6 +10649,123 @@ fn generator_send_ex(gen_obj: PyObjectRef, w_arg: PyObjectRef, operr: Option<PyE
             }
         }
     }
+}
+
+/// Resume the iterator recorded by a suspended `yield from`.
+///
+/// `Some` is a value yielded by the delegate and is therefore also the
+/// outer generator's result.  `None` means the delegate completed and the
+/// outer frame has been positioned at the completion path.
+fn resume_yield_from(
+    frame: &mut crate::pyframe::PyFrame,
+    w_arg: PyObjectRef,
+    operr: Option<PyError>,
+) -> Result<Option<PyObjectRef>, PyError> {
+    let w_yf = frame.w_yielding_from;
+    debug_assert!(!w_yf.is_null());
+
+    let result = match operr {
+        Some(err) if err.kind == PyErrorKind::GeneratorExit => {
+            close_yield_from(w_yf)?;
+            frame.w_yielding_from = pyre_object::PY_NULL;
+            return Err(err);
+        }
+        Some(err) => throw_yield_from(w_yf, err),
+        None if unsafe { pyre_object::is_none(w_arg) } => next(w_yf),
+        None => {
+            let send = getattr_str(w_yf, "send")?;
+            crate::call::call_function_impl_result(send, &[w_arg])
+        }
+    };
+
+    match result {
+        Ok(value) => Ok(Some(value)),
+        Err(err) if err.kind == PyErrorKind::StopIteration => {
+            frame.w_yielding_from = pyre_object::PY_NULL;
+            finish_yield_from(frame, err)?;
+            Ok(None)
+        }
+        Err(err) => {
+            frame.w_yielding_from = pyre_object::PY_NULL;
+            Err(err)
+        }
+    }
+}
+
+/// Delegate a thrown exception, preserving the original exception when the
+/// iterator has no `throw` method.
+fn throw_yield_from(w_yf: PyObjectRef, err: PyError) -> PyResult {
+    unsafe {
+        if pyre_object::generator::is_generator(w_yf) {
+            return generator_send_ex(w_yf, w_none(), Some(err));
+        }
+    }
+    let throw = match getattr_str(w_yf, "throw") {
+        Ok(method) => method,
+        Err(attr_err) if attr_err.kind == PyErrorKind::AttributeError => return Err(err),
+        Err(attr_err) => return Err(attr_err),
+    };
+    let w_exc = err.to_exc_object();
+    let w_type = crate::typedef::r#type(w_exc).unwrap_or(pyre_object::PY_NULL);
+    crate::call::call_function_impl_result(throw, &[w_type, w_exc])
+}
+
+/// Run a delegated iterator's close operation.  A generator close is kept
+/// in the same resume path so nested delegation unwinds one frame at a time.
+fn close_yield_from(w_yf: PyObjectRef) -> PyResult {
+    unsafe {
+        if pyre_object::generator::is_generator(w_yf) {
+            let exit = PyError::new(PyErrorKind::GeneratorExit, String::new());
+            return match generator_send_ex(w_yf, w_none(), Some(exit)) {
+                Ok(_) => Err(PyError::runtime_error("generator ignored GeneratorExit")),
+                Err(err)
+                    if err.kind == PyErrorKind::StopIteration
+                        || err.kind == PyErrorKind::GeneratorExit =>
+                {
+                    Ok(w_none())
+                }
+                Err(err) => Err(err),
+            };
+        }
+    }
+    let close = match getattr_str(w_yf, "close") {
+        Ok(method) => method,
+        Err(err) if err.kind == PyErrorKind::AttributeError => return Ok(w_none()),
+        Err(err) => return Err(err),
+    };
+    crate::call::call_function_impl_result(close, &[])
+}
+
+/// Put the stopped delegate's return value through the `SEND` completion
+/// edge.  The iterator remains on the operand stack until `END_SEND` removes
+/// it, exactly as it does when exhaustion happens during bytecode dispatch.
+fn finish_yield_from(frame: &mut crate::pyframe::PyFrame, err: PyError) -> Result<(), PyError> {
+    use crate::bytecode::Instruction;
+
+    let value = if !err.exc_object.is_null() && unsafe { pyre_object::is_exception(err.exc_object) }
+    {
+        getattr_str(err.exc_object, "value").unwrap_or_else(|_| w_none())
+    } else {
+        w_none()
+    };
+    frame.pushvalue(value);
+
+    let code = frame.code();
+    let last_instr = frame.last_instr.max(0) as usize;
+    let mut completion_target = None;
+    for pc in 0..=last_instr {
+        let Some((instruction, op_arg)) = crate::pyopcode::decode_instruction_at(code, pc) else {
+            continue;
+        };
+        if let Instruction::Send { delta } = instruction {
+            let next = pc + instruction.cache_entries() + 1;
+            completion_target = Some(next + delta.get(op_arg).as_usize());
+        }
+    }
+    let target = completion_target
+        .ok_or_else(|| PyError::runtime_error("yield from completion has no SEND instruction"))?;
+    frame.set_last_instr_from_next_instr(target);
+    Ok(())
 }
 
 /// Build a `StopIteration` carrying `value` on `.value` / `args[0]`.

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -11141,7 +11141,7 @@ fn generator_throw_method(args: &[PyObjectRef]) -> PyResult {
     };
     // w_tb (args[3]) ignored for now — traceback not yet supported
 
-    let err = normalize_throw_args(w_type, w_val);
+    let err = normalize_throw_args(w_type, w_val)?;
     generator_send_ex(gen_obj, w_none(), Some(err))
 }
 
@@ -11183,30 +11183,30 @@ fn generator_close_method(args: &[PyObjectRef]) -> PyResult {
 ///   throw(TypeError)         — type → creates instance
 ///   throw(TypeError("msg"))  — instance → derives type
 ///   throw(TypeError, "msg")  — type + value → creates instance
-fn normalize_throw_args(w_type: PyObjectRef, w_val: PyObjectRef) -> PyError {
+fn normalize_throw_args(w_type: PyObjectRef, w_val: PyObjectRef) -> Result<PyError, PyError> {
     unsafe {
         // If w_type is an exception instance, use it directly
         if !w_type.is_null() && pyre_object::interp_exceptions::is_exception(w_type) {
-            return PyError::from_exc_object(w_type);
+            return Ok(PyError::from_exc_object(w_type));
         }
 
-        // If w_type is a type (class), try to create exception from it
-        if !w_type.is_null() && pyre_object::is_type(w_type) {
-            let type_name = pyre_object::w_type_get_name(w_type);
-            if let Some(kind) = pyre_object::interp_exceptions::exc_kind_from_name(type_name) {
-                let msg = if w_val.is_null() || pyre_object::is_none(w_val) {
-                    String::new()
-                } else if pyre_object::is_str(w_val) {
-                    pyre_object::w_str_get_value(w_val).to_string()
-                } else {
-                    String::new()
-                };
-                return PyError::new(PyError::kind_from_exc(kind), msg);
+        // generator.py throw(): a valid exception class is called to make
+        // the exception instance, including user-defined subclasses.
+        if !w_type.is_null() && exception_is_valid_obj_as_class_w(w_type) {
+            let w_exc = if w_val.is_null() || pyre_object::is_none(w_val) {
+                crate::call::call_function_impl_result(w_type, &[])?
+            } else {
+                crate::call::call_function_impl_result(w_type, &[w_val])?
+            };
+            if pyre_object::interp_exceptions::is_exception(w_exc) {
+                return Ok(PyError::from_exc_object(w_exc));
             }
         }
 
         // Fallback: TypeError
-        PyError::type_error("exceptions must be classes or instances deriving from BaseException")
+        Err(PyError::type_error(
+            "exceptions must be classes or instances deriving from BaseException",
+        ))
     }
 }
 

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -3324,23 +3324,11 @@ fn getattr_str_impl(obj: PyObjectRef, name: &str, call_getattr: bool) -> PyResul
                             None
                         };
                         if let Some(attr) = found {
-                            // descriptor.py W_Super.getattribute:
-                            // Invoke descriptor __get__ protocol.
-                            // classmethod.__get__(obj, type) binds the class
-                            // (`w_obj_type`); staticmethod.__get__ unwraps to
-                            // the plain function; a plain function binds `obj`.
-                            // `__new__` is implicitly static — never bind.
-                            if pyre_object::is_classmethod(attr) {
-                                let func = pyre_object::w_classmethod_get_func(attr);
-                                return Ok(pyre_object::w_method_new(func, w_obj_type, w_obj_type));
-                            }
-                            if pyre_object::is_staticmethod(attr) {
-                                return Ok(pyre_object::w_staticmethod_get_func(attr));
-                            }
-                            if name != "__new__" && crate::is_function(attr) {
-                                return Ok(pyre_object::w_method_new(attr, bound_obj, w_obj_type));
-                            }
-                            return Ok(attr);
+                            // W_Super.getattribute binds every descriptor,
+                            // rather than only the three builtin method
+                            // wrapper shapes.  This also covers property,
+                            // getset, member, and user-defined descriptors.
+                            return Ok(get(attr, bound_obj, w_obj_type)?.unwrap_or(attr));
                         }
                     }
                 }
@@ -6603,6 +6591,70 @@ pub unsafe fn compute_default_mro(w_type: PyObjectRef) -> Vec<PyObjectRef> {
     compute_mro(w_type)
 }
 
+/// Reject a base tuple whose C3 merge has no valid next head.
+///
+/// Type construction calls this before allocating the new type or running
+/// descriptor/class-subclass hooks, so an invalid hierarchy cannot escape as
+/// a later and unrelated lookup failure.
+pub unsafe fn validate_c3_mro(bases: PyObjectRef) -> Result<(), crate::PyError> {
+    if bases.is_null() || !is_tuple(bases) {
+        return Ok(());
+    }
+    let n = w_tuple_len(bases);
+    let mut lists: Vec<Vec<PyObjectRef>> = Vec::with_capacity(n + 1);
+    let mut bases_list = Vec::with_capacity(n);
+    for i in 0..n {
+        let Some(base) = w_tuple_getitem(bases, i as i64) else {
+            continue;
+        };
+        if is_type_like_w(base) {
+            let mro = w_type_get_mro(base);
+            lists.push(if mro.is_null() {
+                compute_mro(base)
+            } else {
+                (*mro).to_vec()
+            });
+        }
+        bases_list.push(base);
+    }
+    lists.push(bases_list);
+
+    loop {
+        lists.retain(|list| !list.is_empty());
+        if lists.is_empty() {
+            return Ok(());
+        }
+        let next = lists.iter().find_map(|list| {
+            let candidate = list[0];
+            (!lists.iter().any(|other| {
+                other.len() > 1 && other[1..].iter().any(|&item| std::ptr::eq(item, candidate))
+            }))
+            .then_some(candidate)
+        });
+        let Some(next) = next else {
+            let names = (0..n)
+                .filter_map(|i| w_tuple_getitem(bases, i as i64))
+                .map(|base| {
+                    if is_type_like_w(base) {
+                        w_type_get_name(base).to_string()
+                    } else {
+                        "?".to_string()
+                    }
+                })
+                .collect::<Vec<_>>()
+                .join(", ");
+            return Err(crate::PyError::type_error(format!(
+                "Cannot create a consistent method resolution\norder (MRO) for bases {names}"
+            )));
+        };
+        for list in &mut lists {
+            if !list.is_empty() && std::ptr::eq(list[0], next) {
+                list.remove(0);
+            }
+        }
+    }
+}
+
 /// C3 linearization core (typeobject.py:1687 `compute_C3_mro`).
 ///
 /// `dont_look_inside` — MRO computation is opaque, MRO iteration stays traced.
@@ -7194,6 +7246,9 @@ fn descr_set___class__(w_obj: PyObjectRef, w_newcls: PyObjectRef) -> PyResult {
 pub fn setattr_str(obj: PyObjectRef, name: &str, value: PyObjectRef) -> PyResult {
     let value = unwrap_cell(value);
     let obj = crate::module::_weakref::interp__weakref::force(obj)?;
+    // `super` proxies only `__getattribute__` (descriptor.py W_Super); it has
+    // no `__setattr__`, so `super().name = value` uses the object default and
+    // raises AttributeError rather than resolving a descriptor setter.
     // descroperation.py:247 — space.lookup for __setattr__ through MRO,
     // then get_and_call_function which applies descriptor binding.
     unsafe {

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -7624,21 +7624,48 @@ pub(crate) fn builtin_sorted(args: &[PyObjectRef]) -> Result<PyObjectRef, crate:
         .map(|v| crate::baseobjspace::is_true(v))
         .transpose()?
         .unwrap_or(false);
-    let mut items = collect_iterable(iterable)?;
-    // `pypy/objspace/std/listobject.py W_ListObject.descr_sort` →
-    // build (key, item) pairs, sort by key, optionally reverse.
-    let keyed: Vec<(PyObjectRef, PyObjectRef)> = if let Some(kf) = key_fn {
-        items
-            .iter()
-            .map(|&item| {
-                let k = crate::call_function(kf, &[item]);
-                (k, item)
-            })
-            .collect()
-    } else {
-        items.iter().map(|&item| (item, item)).collect()
-    };
-    let mut keyed = keyed;
+    let items = collect_iterable(iterable)?;
+    let _roots = pyre_object::gc_roots::push_roots();
+    let item_base = pyre_object::gc_roots::shadow_stack_len();
+    for item in items {
+        pyre_object::gc_roots::pin_root(item);
+    }
+    let item_len = pyre_object::gc_roots::shadow_stack_len() - item_base;
+    let order = sort_rooted_items(item_base, item_len, key_fn, reverse)?;
+    let result = order
+        .into_iter()
+        .map(|index| pyre_object::gc_roots::shadow_stack_get(item_base + index))
+        .collect();
+    Ok(w_list_new(result))
+}
+
+/// Sort rooted item slots and return the resulting permutation.  All object
+/// references that survive a Python call live in the shadow stack; the sort
+/// itself only moves integer indices.
+pub(crate) fn sort_rooted_items(
+    item_base: usize,
+    item_len: usize,
+    key_fn: Option<PyObjectRef>,
+    reverse: bool,
+) -> Result<Vec<usize>, crate::PyError> {
+    let _key_roots = pyre_object::gc_roots::push_roots();
+    let key_base = pyre_object::gc_roots::shadow_stack_len();
+    let key_fn_slot = key_fn.map(|key| {
+        pyre_object::gc_roots::pin_root(key);
+        key_base
+    });
+    let key_base = key_base + usize::from(key_fn_slot.is_some());
+    if let Some(key_fn_slot) = key_fn_slot {
+        for index in 0..item_len {
+            let key = crate::call::call_function_impl_result(
+                pyre_object::gc_roots::shadow_stack_get(key_fn_slot),
+                &[pyre_object::gc_roots::shadow_stack_get(item_base + index)],
+            )?;
+            pyre_object::gc_roots::pin_root(key);
+        }
+    }
+
+    let mut order: Vec<usize> = (0..item_len).collect();
     // `rpython/rlib/listsort.py listsort.lt` defers to
     // `space.lt(a, b)` and propagates exceptions; if the user's
     // `__lt__` raises, sort halts with that error.  Rust's
@@ -7649,10 +7676,10 @@ pub(crate) fn builtin_sorted(args: &[PyObjectRef]) -> Result<PyObjectRef, crate:
     // original relative order (a stable descending sort). A single
     // post-sort reverse would instead flip ties.
     if reverse {
-        keyed.reverse();
+        order.reverse();
     }
     let sort_error: std::cell::Cell<Option<crate::PyError>> = std::cell::Cell::new(None);
-    let sort_lt = |ka: PyObjectRef, kb: PyObjectRef| -> bool {
+    let sort_lt = |left: usize, right: usize| -> bool {
         if sort_error
             .take()
             .map(|e| {
@@ -7663,7 +7690,17 @@ pub(crate) fn builtin_sorted(args: &[PyObjectRef]) -> Result<PyObjectRef, crate:
         {
             return false;
         }
-        match crate::baseobjspace::compare(ka, kb, crate::baseobjspace::CompareOp::Lt) {
+        let left = pyre_object::gc_roots::shadow_stack_get(if key_fn_slot.is_some() {
+            key_base + left
+        } else {
+            item_base + left
+        });
+        let right = pyre_object::gc_roots::shadow_stack_get(if key_fn_slot.is_some() {
+            key_base + right
+        } else {
+            item_base + right
+        });
+        match crate::baseobjspace::compare(left, right, crate::baseobjspace::CompareOp::Lt) {
             Ok(r) => crate::baseobjspace::is_true(r).unwrap_or_else(|e| {
                 sort_error.set(Some(e));
                 false
@@ -7674,12 +7711,12 @@ pub(crate) fn builtin_sorted(args: &[PyObjectRef]) -> Result<PyObjectRef, crate:
             }
         }
     };
-    keyed.sort_by(|(ka, _), (kb, _)| {
-        let ab = sort_lt(*ka, *kb);
+    order.sort_by(|left, right| {
+        let ab = sort_lt(*left, *right);
         if ab {
             return std::cmp::Ordering::Less;
         }
-        let ba = sort_lt(*kb, *ka);
+        let ba = sort_lt(*right, *left);
         if ba {
             return std::cmp::Ordering::Greater;
         }
@@ -7687,15 +7724,25 @@ pub(crate) fn builtin_sorted(args: &[PyObjectRef]) -> Result<PyObjectRef, crate:
         // `False` for both directions (legacy unhashable / unorderable
         // pairs that pyre still has) — preserves prior behaviour.
         unsafe {
-            if is_int(*ka) && is_int(*kb) {
-                return w_int_get_value(*ka).cmp(&w_int_get_value(*kb));
+            let left = pyre_object::gc_roots::shadow_stack_get(if key_fn_slot.is_some() {
+                key_base + *left
+            } else {
+                item_base + *left
+            });
+            let right = pyre_object::gc_roots::shadow_stack_get(if key_fn_slot.is_some() {
+                key_base + *right
+            } else {
+                item_base + *right
+            });
+            if is_int(left) && is_int(right) {
+                return w_int_get_value(left).cmp(&w_int_get_value(right));
             }
-            if is_str(*ka) && is_str(*kb) {
-                return w_str_get_value(*ka).cmp(w_str_get_value(*kb));
+            if is_str(left) && is_str(right) {
+                return w_str_get_value(left).cmp(w_str_get_value(right));
             }
-            if is_float(*ka) && is_float(*kb) {
-                return pyre_object::w_float_get_value(*ka)
-                    .partial_cmp(&pyre_object::w_float_get_value(*kb))
+            if is_float(left) && is_float(right) {
+                return pyre_object::w_float_get_value(left)
+                    .partial_cmp(&pyre_object::w_float_get_value(right))
                     .unwrap_or(std::cmp::Ordering::Equal);
             }
             std::cmp::Ordering::Equal
@@ -7706,10 +7753,9 @@ pub(crate) fn builtin_sorted(args: &[PyObjectRef]) -> Result<PyObjectRef, crate:
     }
     // Second half of the `reverse=True` double-reverse (see above).
     if reverse {
-        keyed.reverse();
+        order.reverse();
     }
-    items = keyed.into_iter().map(|(_, v)| v).collect();
-    Ok(w_list_new(items))
+    Ok(order)
 }
 
 /// `any(iterable)` — PyPy: operation.py any

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -5221,35 +5221,52 @@ fn parse_int_from_str(s: &str, base: u32) -> Result<PyObjectRef, crate::PyError>
     } else {
         (1i64, s)
     };
-    let (radix, digits) = if base == 0 {
+    let (radix, digits, had_base_prefix) = if base == 0 {
         if let Some(r) = rest.strip_prefix("0x").or(rest.strip_prefix("0X")) {
-            (16u32, r)
+            (16u32, r, true)
         } else if let Some(r) = rest.strip_prefix("0b").or(rest.strip_prefix("0B")) {
-            (2u32, r)
+            (2u32, r, true)
         } else if let Some(r) = rest.strip_prefix("0o").or(rest.strip_prefix("0O")) {
-            (8u32, r)
+            (8u32, r, true)
         } else {
-            (10u32, rest)
+            (10u32, rest, false)
         }
     } else {
-        let stripped = match base {
-            16 => rest
-                .strip_prefix("0x")
-                .or(rest.strip_prefix("0X"))
-                .unwrap_or(rest),
-            2 => rest
-                .strip_prefix("0b")
-                .or(rest.strip_prefix("0B"))
-                .unwrap_or(rest),
-            8 => rest
-                .strip_prefix("0o")
-                .or(rest.strip_prefix("0O"))
-                .unwrap_or(rest),
-            _ => rest,
+        let (stripped, had_base_prefix) = match base {
+            16 => match rest.strip_prefix("0x").or(rest.strip_prefix("0X")) {
+                Some(r) => (r, true),
+                None => (rest, false),
+            },
+            2 => match rest.strip_prefix("0b").or(rest.strip_prefix("0B")) {
+                Some(r) => (r, true),
+                None => (rest, false),
+            },
+            8 => match rest.strip_prefix("0o").or(rest.strip_prefix("0O")) {
+                Some(r) => (r, true),
+                None => (rest, false),
+            },
+            _ => (rest, false),
         };
-        (base, stripped)
+        (base, stripped, had_base_prefix)
     };
-    let cleaned: String = digits.chars().filter(|&c| c != '_').collect();
+    let is_digit = |c: char| c.to_digit(radix).is_some();
+    let digit_chars: Vec<char> = digits.chars().collect();
+    let mut cleaned = String::with_capacity(digits.len());
+    for (i, &c) in digit_chars.iter().enumerate() {
+        if c == '_' {
+            let after_prefix = had_base_prefix && i == 0;
+            let prev_is_digit = i > 0 && is_digit(digit_chars[i - 1]);
+            let next_is_digit = i + 1 < digit_chars.len() && is_digit(digit_chars[i + 1]);
+            if next_is_digit && (prev_is_digit || after_prefix) {
+                continue;
+            }
+            return Err(crate::PyError::new(
+                crate::PyErrorKind::ValueError,
+                format!("invalid literal for int() with base {base}: '{s}'"),
+            ));
+        }
+        cleaned.push(c);
+    }
     if let Ok(v) = i64::from_str_radix(&cleaned, radix) {
         return Ok(w_int_new(sign * v));
     }

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -7724,13 +7724,15 @@ fn builtin_any(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
             args.len()
         )));
     }
-    let items = collect_iterable(args[0])?;
-    for item in items {
-        if crate::baseobjspace::is_true(item)? {
-            return Ok(w_bool_from(true));
+    let it = crate::baseobjspace::iter(args[0])?;
+    loop {
+        match crate::baseobjspace::next(it) {
+            Ok(item) if crate::baseobjspace::is_true(item)? => return Ok(w_bool_from(true)),
+            Ok(_) => {}
+            Err(e) if e.kind == crate::PyErrorKind::StopIteration => return Ok(w_bool_from(false)),
+            Err(e) => return Err(e),
         }
     }
-    Ok(w_bool_from(false))
 }
 
 /// `all(iterable)` — PyPy: operation.py all
@@ -9002,13 +9004,15 @@ fn builtin_all(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
             args.len()
         )));
     }
-    let items = collect_iterable(args[0])?;
-    for item in items {
-        if !crate::baseobjspace::is_true(item)? {
-            return Ok(w_bool_from(false));
+    let it = crate::baseobjspace::iter(args[0])?;
+    loop {
+        match crate::baseobjspace::next(it) {
+            Ok(item) if !crate::baseobjspace::is_true(item)? => return Ok(w_bool_from(false)),
+            Ok(_) => {}
+            Err(e) if e.kind == crate::PyErrorKind::StopIteration => return Ok(w_bool_from(true)),
+            Err(e) => return Err(e),
         }
     }
-    Ok(w_bool_from(true))
 }
 
 /// `sum(sequence, start=0)` — PyPy `__builtin__/app_functional.py sum`.

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -3120,6 +3120,13 @@ pub(crate) fn type_new_wrap_special_methods(ns: &mut crate::DictStorage) {
     }
 }
 
+/// A class that supplies equality but no hash is explicitly unhashable.
+pub(crate) fn type_new_set_hash_if_eq(ns: &mut crate::DictStorage) {
+    if ns.get("__eq__").is_some() && ns.get("__hash__").is_none() {
+        crate::dict_storage_store(ns, "__hash__", pyre_object::w_none());
+    }
+}
+
 fn type_descr_new_with_metaclass(
     args: &[PyObjectRef],
     w_metaclass: PyObjectRef,
@@ -3212,6 +3219,7 @@ fn type_descr_new_with_metaclass(
             }
         }
         let ns_ptr = Box::into_raw(class_ns);
+        unsafe { type_new_set_hash_if_eq(&mut *ns_ptr) };
         unsafe { type_new_wrap_special_methods(&mut *ns_ptr) };
 
         // Default bases to (object,) if empty
@@ -3227,6 +3235,7 @@ fn type_descr_new_with_metaclass(
             } else {
                 bases
             };
+        unsafe { crate::baseobjspace::validate_c3_mro(w_effective_bases)? };
 
         // CPython: calculate_metaclass — delegate to winner if different
         let default_meta = if w_metaclass.is_null() {

--- a/pyre/pyre-interpreter/src/call.rs
+++ b/pyre/pyre-interpreter/src/call.rs
@@ -2366,13 +2366,17 @@ pub(crate) fn calculate_metaclass(
 /// `typeobject.c type_call` — a type whose `tp_new` is NULL
 /// (`Py_TPFLAGS_DISALLOW_INSTANTIATION`, e.g. generator) refuses
 /// `Type()` with `cannot create 'X' instances`.
-fn check_type_instantiable(w_type: PyObjectRef) -> Result<(), PyError> {
+pub(crate) fn check_type_instantiable(w_type: PyObjectRef) -> Result<(), PyError> {
     if unsafe { pyre_object::w_type_disallows_instantiation(w_type) } {
         let name = unsafe { pyre_object::w_type_get_name(w_type) };
         return Err(PyError::type_error(format!(
             "cannot create '{name}' instances"
         )));
     }
+    // Abstract-class rejection lives in `object.__new__` (objectobject.py:131
+    // descr__new__ → `w_type_is_abstract`), the single enforcement point, so
+    // the error names the missing methods.  A duplicate check here would fire
+    // first with a less specific message.
     Ok(())
 }
 
@@ -3355,6 +3359,7 @@ fn build_class_inner(
     } else {
         bases
     };
+    unsafe { crate::baseobjspace::validate_c3_mro(w_effective_bases)? };
     // Create class via metaclass or default type()
     // PyPy: typeobject.py — metaclass(name, bases, dict_w) or type.__new__
     let w_type = if let Some(w_metaclass) = w_metaclass {
@@ -3461,6 +3466,7 @@ fn build_class_inner(
             let class_ns = &mut *class_ns_ptr;
             class_ns.remove("__classcell__");
             class_ns.remove("__classdictcell__");
+            crate::builtins::type_new_set_hash_if_eq(class_ns);
             crate::builtins::type_new_wrap_special_methods(class_ns);
         }
         let w = pyre_object::w_type_new(name, w_effective_bases, class_ns_ptr as *mut u8);

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -2513,6 +2513,26 @@ impl OpcodeStepExecutor for PyFrame {
         Ok(())
     }
 
+    fn cleanup_throw(&mut self) -> Result<(), PyError> {
+        let w_exc = self.pop_value()?;
+        let err = unsafe { PyError::from_exc_object(w_exc) };
+        if err.kind != PyErrorKind::StopIteration {
+            return Err(err);
+        }
+
+        self.pop_value()?;
+        self.pop_value()?;
+        let value =
+            if !err.exc_object.is_null() && unsafe { pyre_object::is_exception(err.exc_object) } {
+                crate::baseobjspace::getattr_str(err.exc_object, "value")
+                    .unwrap_or_else(|_| pyre_object::w_none())
+            } else {
+                pyre_object::w_none()
+            };
+        self.push(value);
+        Ok(())
+    }
+
     /// WITH_EXCEPT_START — call __exit__ for the exceptional `with` exit.
     ///
     /// Stack layout the bytecode emits (bottom → top):
@@ -3545,14 +3565,27 @@ impl OpcodeStepExecutor for PyFrame {
     }
 
     fn send_value(&mut self, target: usize) -> Result<(), PyError> {
-        let _value = self.pop(); // sent value
+        let value = self.pop();
         let iter = self.peek();
-        match crate::baseobjspace::next(iter) {
+        let result = if unsafe { pyre_object::is_none(value) } {
+            crate::baseobjspace::next(iter)
+        } else {
+            let send = crate::baseobjspace::getattr_str(iter, "send")?;
+            crate::call::call_function_impl_result(send, &[value])
+        };
+        match result {
             Ok(result) => {
+                self.w_yielding_from = iter;
+                if pyre_object::gc_hook::try_gc_owns_object(self as *mut PyFrame as *mut u8) {
+                    pyre_object::gc_hook::try_gc_write_barrier(self as *mut PyFrame as *mut u8);
+                }
                 self.push(result);
                 Ok(())
             }
             Err(e) if e.kind == crate::PyErrorKind::StopIteration => {
+                if std::ptr::eq(self.w_yielding_from, iter) {
+                    self.w_yielding_from = pyre_object::PY_NULL;
+                }
                 // `pypy/interpreter/pyopcode.py:1158-1166 next_yield_from`:
                 //     try:
                 //         w_stop_value = space.getattr(e.get_w_value(space),

--- a/pyre/pyre-interpreter/src/module/_abc/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_abc/mod.rs
@@ -27,6 +27,40 @@ fn abc_init(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     if let Some(&cls) = args.first() {
         let fresh = w_list_new(vec![]);
         crate::baseobjspace::setattr_str(cls, "_abc_registry", fresh)?;
+        let mut abstract_names = Vec::new();
+        let bases = unsafe { w_type_get_bases(cls) };
+        if !bases.is_null() && unsafe { is_tuple(bases) } {
+            for i in 0..unsafe { w_tuple_len(bases) } {
+                let Some(base) = (unsafe { w_tuple_getitem(bases, i as i64) }) else {
+                    continue;
+                };
+                let Ok(names) = crate::baseobjspace::getattr_str(base, "__abstractmethods__")
+                else {
+                    continue;
+                };
+                if !unsafe { is_set_or_frozenset(names) } {
+                    continue;
+                }
+                for name in unsafe { w_set_items(names) } {
+                    if let Some(value) = unsafe {
+                        crate::baseobjspace::lookup_in_type(cls, pyre_object::w_str_get_value(name))
+                    } && crate::baseobjspace::isabstractmethod_w(value)?
+                    {
+                        abstract_names.push(name);
+                    }
+                }
+            }
+        }
+        let namespace = unsafe { w_type_get_dict_ptr(cls) as *mut crate::DictStorage };
+        if !namespace.is_null() {
+            for (name, &value) in unsafe { (*namespace).entries() } {
+                if crate::baseobjspace::isabstractmethod_w(value)? {
+                    abstract_names.push(w_str_new(name));
+                }
+            }
+        }
+        let methods = w_frozenset_from_items(&abstract_names);
+        crate::baseobjspace::setattr_str(cls, "__abstractmethods__", methods)?;
     }
     Ok(w_none())
 }

--- a/pyre/pyre-interpreter/src/module/_functools/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_functools/mod.rs
@@ -1,23 +1,90 @@
 //! _functools module — CPython accelerator imported by
 //! `lib-python/3/functools.py`.
 //!
-//! Stub surface — `reduce` raises TypeError (callers should use the
-//! pure-Python equivalent); `cmp_to_key` returns an identity wrapper
-//! that gives correct ordering for any operands already in their natural
-//! sort order (str / int / tuple of those — pyre's stdlib doesn't
-//! exercise other shapes).
-
 use pyre_object::*;
 
-// `functools.cmp_to_key(cmp)` — pyre's identity wrapper covers the
-// str / int / tuple sort key cases the stdlib actually uses; arbitrary
-// cmp callables are not honoured.
-fn cmp_to_key(_args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    Ok(crate::make_builtin_function_with_arity(
-        "cmp_to_key.K",
-        |args| Ok(args.first().copied().unwrap_or(w_none())),
-        1,
+const ATTR_CMP: &str = "cmp";
+const ATTR_OBJ: &str = "obj";
+
+fn key_wrapper_init(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    crate::baseobjspace::setattr_str(args[0], ATTR_OBJ, args[1])?;
+    Ok(w_none())
+}
+
+fn key_wrapper_compare(
+    args: &[PyObjectRef],
+    op: crate::objspace::descroperation::CompareOp,
+) -> Result<PyObjectRef, crate::PyError> {
+    let self_type = crate::typedef::r#type(args[0]).expect("key wrapper has a type");
+    if crate::typedef::r#type(args[1]) != Some(self_type) {
+        return Ok(w_not_implemented());
+    }
+    let cmp = unsafe {
+        crate::baseobjspace::lookup_in_type(self_type, ATTR_CMP)
+            .expect("key wrapper type has its comparator")
+    };
+    let lhs = crate::baseobjspace::getattr_str(args[0], ATTR_OBJ)?;
+    let rhs = crate::baseobjspace::getattr_str(args[1], ATTR_OBJ)?;
+    let result = crate::call::call_function_impl_result(cmp, &[lhs, rhs])?;
+    crate::objspace::descroperation::compare(result, w_int_new(0), op)
+}
+
+fn key_wrapper_lt(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    key_wrapper_compare(args, crate::objspace::descroperation::CompareOp::Lt)
+}
+
+fn key_wrapper_le(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    key_wrapper_compare(args, crate::objspace::descroperation::CompareOp::Le)
+}
+
+fn key_wrapper_eq(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    key_wrapper_compare(args, crate::objspace::descroperation::CompareOp::Eq)
+}
+
+fn key_wrapper_gt(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    key_wrapper_compare(args, crate::objspace::descroperation::CompareOp::Gt)
+}
+
+fn key_wrapper_ge(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    key_wrapper_compare(args, crate::objspace::descroperation::CompareOp::Ge)
+}
+
+fn key_wrapper_hash(_args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    Err(crate::PyError::type_error(
+        "unhashable type: 'functools.KeyWrapper'",
     ))
+}
+
+fn cmp_to_key(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    let cmp = args[0];
+    let key_type = crate::typedef::make_builtin_type("functools.KeyWrapper", |ns| {
+        crate::dict_storage_store(ns, ATTR_CMP, cmp);
+        crate::dict_storage_store(
+            ns,
+            "__init__",
+            crate::make_builtin_function_with_arity("__init__", key_wrapper_init, 2),
+        );
+        for (name, func) in [
+            ("__lt__", key_wrapper_lt as fn(&[PyObjectRef]) -> _),
+            ("__le__", key_wrapper_le as fn(&[PyObjectRef]) -> _),
+            ("__eq__", key_wrapper_eq as fn(&[PyObjectRef]) -> _),
+            ("__gt__", key_wrapper_gt as fn(&[PyObjectRef]) -> _),
+            ("__ge__", key_wrapper_ge as fn(&[PyObjectRef]) -> _),
+        ] {
+            crate::dict_storage_store(
+                ns,
+                name,
+                crate::make_builtin_function_with_arity(name, func, 2),
+            );
+        }
+        crate::dict_storage_store(
+            ns,
+            "__hash__",
+            crate::make_builtin_function_with_arity("__hash__", key_wrapper_hash, 1),
+        );
+    });
+    unsafe { pyre_object::w_type_set_hasdict(key_type, true) };
+    Ok(key_type)
 }
 
 crate::py_module! {

--- a/pyre/pyre-interpreter/src/module/operator/mod.rs
+++ b/pyre/pyre-interpreter/src/module/operator/mod.rs
@@ -94,7 +94,7 @@ fn op_compare_digest(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError
 // Inline closures below preserve the per-name `assert!` checks.
 use crate::baseobjspace::{
     self, CompareOp, add, and_, contains, delitem, floordiv, getitem, invert, is_true, lshift,
-    mod_, mul, neg, or_, pos, pow, rshift, setitem, sub, truediv, xor,
+    matmul, mod_, mul, neg, or_, pos, pow, rshift, setitem, sub, truediv, xor,
 };
 
 crate::py_module! {
@@ -110,6 +110,7 @@ crate::py_module! {
         "add"      / 2 = |args| op_binary(args, "add", add),
         "sub"      / 2 = |args| op_binary(args, "sub", sub),
         "mul"      / 2 = |args| op_binary(args, "mul", mul),
+        "matmul"   / 2 = |args| op_binary(args, "matmul", matmul),
         "truediv"  / 2 = |args| truediv(args[0], args[1]),
         "floordiv" / 2 = |args| floordiv(args[0], args[1]),
         "mod"      / 2 = |args| mod_(args[0], args[1]),
@@ -123,6 +124,7 @@ crate::py_module! {
         "and_"     / 2 = |args| and_(args[0], args[1]),
         "or_"      / 2 = |args| or_(args[0], args[1]),
         "xor"      / 2 = |args| xor(args[0], args[1]),
+        "imatmul"  / 2 = |args| op_binary(args, "imatmul", |a, b| crate::opcode_ops::binary_value(a, b, crate::bytecode::BinaryOperator::InplaceMatrixMultiply)),
         "not_"     / 1 = |args| Ok(w_bool_from(!is_true(args[0])?)),
         // interp_operator.py:138
         "truth"    / 1 = |args| Ok(w_bool_from(is_true(args[0])?)),

--- a/pyre/pyre-interpreter/src/module/operator/mod.rs
+++ b/pyre/pyre-interpreter/src/module/operator/mod.rs
@@ -9,16 +9,8 @@ fn op_index(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
             args.len()
         )));
     }
-    let obj = args[0];
-    unsafe {
-        if is_int(obj) {
-            return Ok(obj);
-        }
-        if is_bool(obj) {
-            return Ok(w_int_new(if w_bool_get_value(obj) { 1 } else { 0 }));
-        }
-    }
-    Ok(crate::call_function_or_identity(obj, "__index__"))
+    let indexed = crate::baseobjspace::space_index(args[0])?;
+    unsafe { Ok(range_bigint_to_obj(range_obj_to_bigint(indexed))) }
 }
 
 /// Shared body for the binary-arithmetic thunks (`add`/`sub`/`mul`): a

--- a/pyre/pyre-interpreter/src/objspace/descroperation.rs
+++ b/pyre/pyre-interpreter/src/objspace/descroperation.rs
@@ -1357,6 +1357,34 @@ unsafe fn complex_truediv(a: PyObjectRef, b: PyObjectRef) -> PyResult {
     Ok(w_complex_new(real, imag))
 }
 
+unsafe fn complex_powi(a: PyObjectRef, exponent: i64) -> PyResult {
+    let (mut base_real, mut base_imag) = complex_val(a).unwrap();
+    let mut result_real = 1.0;
+    let mut result_imag = 0.0;
+    let mut n = exponent.unsigned_abs();
+    while n != 0 {
+        if n & 1 != 0 {
+            let real = result_real * base_real - result_imag * base_imag;
+            result_imag = result_real * base_imag + result_imag * base_real;
+            result_real = real;
+        }
+        n >>= 1;
+        if n != 0 {
+            let real = base_real * base_real - base_imag * base_imag;
+            base_imag = base_real * base_imag + base_imag * base_real;
+            base_real = real;
+        }
+    }
+    if exponent < 0 {
+        complex_truediv(
+            w_complex_new(1.0, 0.0),
+            w_complex_new(result_real, result_imag),
+        )
+    } else {
+        Ok(w_complex_new(result_real, result_imag))
+    }
+}
+
 /// `complexobject.c _Py_c_pow`.
 unsafe fn complex_pow(a: PyObjectRef, b: PyObjectRef) -> PyResult {
     let (ar, ai) = complex_val(a).unwrap();
@@ -1368,6 +1396,8 @@ unsafe fn complex_pow(a: PyObjectRef, b: PyObjectRef) -> PyResult {
             return Err(PyError::zero_division("0.0 to a negative or complex power"));
         }
         (0.0, 0.0)
+    } else if bi == 0.0 && (-100.0..=100.0).contains(&br) && br == br.trunc() {
+        return complex_powi(a, br as i64);
     } else {
         let vabs = ar.hypot(ai);
         let mut len = vabs.powf(br);

--- a/pyre/pyre-interpreter/src/objspace/descroperation.rs
+++ b/pyre/pyre-interpreter/src/objspace/descroperation.rs
@@ -1636,6 +1636,7 @@ fn reverse_dunder(dunder: &str) -> Option<&'static str> {
         "__truediv__" => "__rtruediv__",
         "__floordiv__" => "__rfloordiv__",
         "__mod__" => "__rmod__",
+        "__matmul__" => "__rmatmul__",
         "__pow__" => "__rpow__",
         "__lshift__" => "__rlshift__",
         "__rshift__" => "__rrshift__",
@@ -1936,6 +1937,21 @@ pub fn add(a: PyObjectRef, b: PyObjectRef) -> PyResult {
         Err(PyError::type_error(format!(
             "unsupported operand type(s) for +: '{}' and '{}'",
             a_name, b_name,
+        )))
+    }
+}
+
+pub fn matmul(a: PyObjectRef, b: PyObjectRef) -> PyResult {
+    let a = unwrap_cell(a);
+    let b = unwrap_cell(b);
+    unsafe {
+        if let Some(result) = try_dispatch_binary_special(a, b, "__matmul__", "__rmatmul__")? {
+            return Ok(result);
+        }
+        let a_name = (*ll_type(a)).name;
+        let b_name = (*ll_type(b)).name;
+        Err(PyError::type_error(format!(
+            "unsupported operand type(s) for @: '{a_name}' and '{b_name}'"
         )))
     }
 }

--- a/pyre/pyre-interpreter/src/opcode_ops.rs
+++ b/pyre/pyre-interpreter/src/opcode_ops.rs
@@ -3,8 +3,8 @@ use crate::bytecode::{BinaryOperator, ComparisonOperator};
 use pyre_object::{PyObjectRef, w_bool_from};
 
 use crate::{
-    CompareOp, add, and_, compare, floordiv, getitem, invert, is_true, lshift, mod_, mul, neg, or_,
-    pow, rshift, sub, truediv, xor,
+    CompareOp, add, and_, compare, floordiv, getitem, invert, is_true, lshift, matmul, mod_, mul,
+    neg, or_, pow, rshift, sub, truediv, xor,
 };
 
 /// Maps an in-place `BinaryOperator` to its special-method name
@@ -19,6 +19,7 @@ fn inplace_dunder_name(op: BinaryOperator) -> Option<&'static str> {
         BinaryOperator::InplaceTrueDivide => "__itruediv__",
         BinaryOperator::InplacePower => "__ipow__",
         BinaryOperator::InplaceLshift => "__ilshift__",
+        BinaryOperator::InplaceMatrixMultiply => "__imatmul__",
         BinaryOperator::InplaceRshift => "__irshift__",
         BinaryOperator::InplaceAnd => "__iand__",
         BinaryOperator::InplaceOr => "__ior__",
@@ -64,6 +65,7 @@ pub fn binary_value(
         BinaryOperator::TrueDivide | BinaryOperator::InplaceTrueDivide => truediv(a, b),
         BinaryOperator::Power | BinaryOperator::InplacePower => pow(a, b),
         BinaryOperator::Lshift | BinaryOperator::InplaceLshift => lshift(a, b),
+        BinaryOperator::MatrixMultiply | BinaryOperator::InplaceMatrixMultiply => matmul(a, b),
         BinaryOperator::Rshift | BinaryOperator::InplaceRshift => rshift(a, b),
         BinaryOperator::And | BinaryOperator::InplaceAnd => and_(a, b),
         // mappingproxy `__ior__` (read-only) raises TypeError, handled
@@ -71,9 +73,6 @@ pub fn binary_value(
         BinaryOperator::Or | BinaryOperator::InplaceOr => or_(a, b),
         BinaryOperator::Xor | BinaryOperator::InplaceXor => xor(a, b),
         BinaryOperator::Subscr => getitem(a, b),
-        _ => Err(PyError::type_error(format!(
-            "binary operation {op:?} not yet implemented"
-        ))),
     }
 }
 

--- a/pyre/pyre-interpreter/src/pyframe.rs
+++ b/pyre/pyre-interpreter/src/pyframe.rs
@@ -2457,23 +2457,14 @@ impl PyFrame {
 
     /// pyframe.py:300 resume_execute_frame (send-path only).
     ///
-    /// pyre does not emit YIELD_FROM/SEND yet, so `w_yielding_from` is
-    /// expected to remain null; asserting makes the gap visible instead of
-    /// silently dropping the delegate. The SApplicationException branch
-    /// (pyframe.py:320) is handled by the caller in `execute_frame`: if
-    /// `operr.is_some()`, resume_execute_frame is skipped and
-    /// `eval_frame_plain_with_operr` routes the error through
-    /// `handle_exception` at `last_instr + 1`, matching PyPy's
-    /// `handle_generator_error`.
+    /// A suspended delegate is resumed by `generator_send_ex` before this
+    /// method runs.  Once that delegate completes, this path receives the
+    /// normal outer-frame input again.
     #[inline]
     pub fn resume_execute_frame(
         &mut self,
         w_arg_or_err: PyObjectRef,
     ) -> Result<usize, crate::PyError> {
-        debug_assert!(
-            self.w_yielding_from.is_null(),
-            "YIELD_FROM delegation not yet ported; see pyframe.py:305-318",
-        );
         if self.last_instr != -1 {
             self.pushvalue(w_arg_or_err);
             Ok(self.last_instr as usize + 1)

--- a/pyre/pyre-interpreter/src/pyopcode.rs
+++ b/pyre/pyre-interpreter/src/pyopcode.rs
@@ -1258,6 +1258,9 @@ pub trait OpcodeStepExecutor: SharedOpcodeHandler {
     fn end_send(&mut self) -> Result<(), PyError> {
         Err(crate::PyError::type_error("end_send not implemented").into())
     }
+    fn cleanup_throw(&mut self) -> Result<(), PyError> {
+        Err(crate::PyError::type_error("cleanup throw not implemented").into())
+    }
     /// GET_AWAITABLE — replace TOS with its awaitable iterator (`__await__`).
     /// Overridden by the interpreter; the trace path declines (await suspends
     /// the frame and is never JIT-traced).
@@ -2060,6 +2063,13 @@ pub fn execute_send<E: OpcodeStepExecutor>(
 ) -> Result<StepResult<<E as SharedOpcodeHandler>::Value>, PyError> {
     let target = jump_target_forward_from_oparg(code, next_instr, op_arg);
     executor.send_value(target)?;
+    Ok(StepResult::Continue)
+}
+
+pub fn execute_cleanup_throw<E: OpcodeStepExecutor>(
+    executor: &mut E,
+) -> Result<StepResult<<E as SharedOpcodeHandler>::Value>, PyError> {
+    executor.cleanup_throw()?;
     Ok(StepResult::Continue)
 }
 
@@ -3476,10 +3486,7 @@ where
         Instruction::GetAwaitable { .. } => execute_get_awaitable(executor, instruction, op_arg),
 
         // ── Async stubs ──
-        Instruction::GetAiter
-        | Instruction::GetAnext
-        | Instruction::EndAsyncFor
-        | Instruction::CleanupThrow => {
+        Instruction::GetAiter | Instruction::GetAnext | Instruction::EndAsyncFor => {
             Err(crate::PyError::type_error("async not yet implemented").into())
         }
 
@@ -3489,6 +3496,8 @@ where
         Instruction::Send { .. } => execute_send(executor, code, op_arg, next_instr),
 
         Instruction::EndSend => execute_end_send(executor),
+
+        Instruction::CleanupThrow => execute_cleanup_throw(executor),
 
         // ── Misc stubs ──
         // Pops obj, pushes (callable, self_or_null).

--- a/pyre/pyre-interpreter/src/runtime_ops.rs
+++ b/pyre/pyre-interpreter/src/runtime_ops.rs
@@ -458,7 +458,8 @@ pub fn binary_op_tag(op: BinaryOperator) -> Option<i64> {
         BinaryOperator::InplaceAnd => 22,
         BinaryOperator::InplaceOr => 23,
         BinaryOperator::InplaceXor => 24,
-        _ => return None,
+        BinaryOperator::MatrixMultiply => 25,
+        BinaryOperator::InplaceMatrixMultiply => 26,
     })
 }
 
@@ -492,6 +493,8 @@ pub fn binary_op_from_tag(tag: i64) -> Option<BinaryOperator> {
         22 => BinaryOperator::InplaceAnd,
         23 => BinaryOperator::InplaceOr,
         24 => BinaryOperator::InplaceXor,
+        25 => BinaryOperator::MatrixMultiply,
+        26 => BinaryOperator::InplaceMatrixMultiply,
         _ => return None,
     })
 }

--- a/pyre/pyre-interpreter/src/type_methods.rs
+++ b/pyre/pyre-interpreter/src/type_methods.rs
@@ -240,10 +240,32 @@ pub fn list_method_extend(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::Py
                 }
             }
         } else {
-            // listobject.py:1019 _extend_from_iterable
-            let items = crate::builtins::collect_iterable(other)?;
-            for item in items {
-                w_list_append(list, item);
+            // listobject.py:1019 _extend_from_iterable: append each yielded
+            // value before asking the iterator for the next one.  In
+            // particular, an exception from a later `next()` must not roll
+            // back the prefix already appended to the receiver.
+            let _roots = pyre_object::gc_roots::push_roots();
+            let root_base = pyre_object::gc_roots::shadow_stack_len();
+            pyre_object::gc_roots::pin_root(list);
+            pyre_object::gc_roots::pin_root(other);
+            let iterator =
+                crate::baseobjspace::iter(pyre_object::gc_roots::shadow_stack_get(root_base + 1))?;
+            pyre_object::gc_roots::pin_root(iterator);
+            loop {
+                let item = match crate::baseobjspace::next(pyre_object::gc_roots::shadow_stack_get(
+                    root_base + 2,
+                )) {
+                    Ok(item) => item,
+                    Err(err) if err.kind == crate::PyErrorKind::StopIteration => break,
+                    Err(err) => return Err(err),
+                };
+                let _item_roots = pyre_object::gc_roots::push_roots();
+                let item_slot = pyre_object::gc_roots::shadow_stack_len();
+                pyre_object::gc_roots::pin_root(item);
+                w_list_append(
+                    pyre_object::gc_roots::shadow_stack_get(root_base),
+                    pyre_object::gc_roots::shadow_stack_get(item_slot),
+                );
             }
         }
     }
@@ -321,20 +343,68 @@ pub fn list_method_reverse(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::P
 pub fn list_method_sort(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     require_receiver(args, "sort")?;
     let list = args[0];
-    // listobject.py `descr_sort` shares `rpython/rlib/listsort.py`'s comparison
-    // machinery (general `space.lt`, `key=`, `reverse=`) with `sorted()`.
-    // The flat builtin ABI hands us `[self, kwargs?]`, exactly the shape
-    // `sorted()` expects, so produce the sorted sequence through the same
-    // path and copy it back into the list in place.
-    let sorted_list = crate::builtins::builtin_sorted(args)?;
+    // Keep the argument decoding shared with `sorted()` before changing the
+    // receiver's visible storage.
+    let (positional, kwargs) = crate::builtins::split_builtin_kwargs(args);
+    if positional.len() > 1 {
+        return Err(crate::PyError::type_error(format!(
+            "sorted() takes at most 1 positional argument ({} given)",
+            positional.len()
+        )));
+    }
+    crate::builtins::kwarg_reject_unknown(kwargs, &["key", "reverse"], "sorted")?;
+    let key_fn = crate::builtins::kwarg_get(kwargs, "key")
+        .filter(|key| unsafe { !pyre_object::is_none(*key) });
+    let reverse = crate::builtins::kwarg_get(kwargs, "reverse")
+        .map(|value| crate::baseobjspace::is_true(value))
+        .transpose()?
+        .unwrap_or(false);
+
     unsafe {
-        let n = w_list_len(sorted_list);
-        let items: Vec<PyObjectRef> = (0..n)
-            .filter_map(|i| w_list_getitem(sorted_list, i as i64))
-            .collect();
+        // Hold the detached values in shadow-stack slots, not a bare Rust
+        // Vec, while key and comparison calls can collect.  The receiver is
+        // empty for the whole operation, so user code cannot alter this
+        // sorting slice through the visible list.
+        let saved = pyre_object::w_list_items_copy_as_vec(list);
+        let _roots = pyre_object::gc_roots::push_roots();
+        let item_base = pyre_object::gc_roots::shadow_stack_len();
+        for item in saved {
+            pyre_object::gc_roots::pin_root(item);
+        }
+        let saved_len = pyre_object::gc_roots::shadow_stack_len() - item_base;
         pyre_object::listobject::w_list_clear(list);
-        for item in items {
-            w_list_append(list, item);
+
+        let sorted = crate::builtins::sort_rooted_items(item_base, saved_len, key_fn, reverse);
+        let modified = w_list_len(list) != 0;
+
+        // Discard any visible mutations and always restore the detached
+        // values.  On an error from the key function this restores the input
+        // order; after a successful sort it installs the sorted permutation.
+        pyre_object::listobject::w_list_clear(list);
+        match sorted {
+            Ok(order) => {
+                for index in order {
+                    w_list_append(
+                        list,
+                        pyre_object::gc_roots::shadow_stack_get(item_base + index),
+                    );
+                }
+                if modified {
+                    return Err(crate::PyError::new(
+                        crate::PyErrorKind::ValueError,
+                        "list modified during sort",
+                    ));
+                }
+            }
+            Err(err) => {
+                for index in 0..saved_len {
+                    w_list_append(
+                        list,
+                        pyre_object::gc_roots::shadow_stack_get(item_base + index),
+                    );
+                }
+                return Err(err);
+            }
         }
     }
     Ok(w_none())

--- a/pyre/pyre-interpreter/src/type_methods.rs
+++ b/pyre/pyre-interpreter/src/type_methods.rs
@@ -493,7 +493,7 @@ fn cps_to_str(cps: &[CodePoint]) -> PyObjectRef {
 /// A lone surrogate is not whitespace.
 fn cp_is_whitespace(cp: CodePoint) -> bool {
     match cp.to_char() {
-        Some(c) => c.is_whitespace(),
+        Some(c) => classify::is_space(c),
         None => false,
     }
 }
@@ -712,7 +712,7 @@ pub fn str_method_format_map(args: &[PyObjectRef]) -> Result<PyObjectRef, crate:
 
 /// `pypy/objspace/std/unicodeobject.py W_UnicodeObject._strip` —
 /// `s.strip([chars])`.  When `chars` is missing or None, defaults to
-/// ASCII whitespace (the `str::trim` set).  When provided, removes
+/// the same Unicode whitespace predicate as `str.isspace()`.  When provided, removes
 /// any character contained in `chars` from each end (NOT a substring
 /// match — `'aabaa'.strip('a') == 'b'`).
 fn strip_chars(s: &Wtf8, chars: Option<&Wtf8>, left: bool, right: bool) -> Wtf8Buf {
@@ -721,13 +721,13 @@ fn strip_chars(s: &Wtf8, chars: Option<&Wtf8>, left: bool, right: bool) -> Wtf8B
     if left {
         current = match chars_set.as_ref() {
             Some(set) => current.trim_start_matches(|cp: CodePoint| set.contains(&cp)),
-            None => current.trim_start(),
+            None => current.trim_start_matches(cp_is_whitespace),
         };
     }
     if right {
         current = match chars_set.as_ref() {
             Some(set) => current.trim_end_matches(|cp: CodePoint| set.contains(&cp)),
-            None => current.trim_end(),
+            None => current.trim_end_matches(cp_is_whitespace),
         };
     }
     current.to_wtf8_buf()
@@ -4381,10 +4381,27 @@ pub fn str_method_rpartition(args: &[PyObjectRef]) -> Result<PyObjectRef, crate:
 }
 
 /// PyPy: unicodeobject.py descr_splitlines.
-/// Walks `\n`, `\r`, and `\r\n` boundaries explicitly so that
+/// Walks the Unicode line-boundary set explicitly so that
 /// `keepends=True` retains the terminator on each emitted line and a
 /// trailing `\n` does NOT produce an extra empty entry — matching
 /// `'a\nb\n'.splitlines() == ['a', 'b']`.
+fn cp_is_linebreak(cp: CodePoint) -> bool {
+    matches!(
+        cp.to_char(),
+        Some(
+            '\n' | '\r'
+                | '\u{000b}'
+                | '\u{000c}'
+                | '\u{001c}'
+                | '\u{001d}'
+                | '\u{001e}'
+                | '\u{0085}'
+                | '\u{2028}'
+                | '\u{2029}'
+        )
+    )
+}
+
 pub fn str_method_splitlines(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     require_receiver(args, "splitlines")?;
     let (pos, kwargs) = crate::builtins::split_builtin_kwargs(args);
@@ -4401,10 +4418,7 @@ pub fn str_method_splitlines(args: &[PyObjectRef]) -> Result<PyObjectRef, crate:
         "keepends",
         pos.get(1).is_some(),
     )?;
-    // `\n` / `\r` are single bytes that cannot occur inside a multi-byte
-    // WTF-8 sequence, so the line boundaries are found by walking bytes;
-    // each emitted slice cuts on a code-point boundary.
-    let bytes = unsafe { w_str_get_wtf8(pos[0]) }.as_bytes();
+    let cps: Vec<CodePoint> = unsafe { w_str_get_wtf8(pos[0]) }.code_points().collect();
     // keepends is positional-or-keyword.
     let keepends = crate::builtins::kwarg_get(kwargs, "keepends")
         .or_else(|| pos.get(1).copied())
@@ -4414,22 +4428,25 @@ pub fn str_method_splitlines(args: &[PyObjectRef]) -> Result<PyObjectRef, crate:
     let mut parts: Vec<PyObjectRef> = Vec::new();
     let mut start = 0usize;
     let mut i = 0usize;
-    while i < bytes.len() {
-        if bytes[i] == b'\n' || bytes[i] == b'\r' {
+    while i < cps.len() {
+        if cp_is_linebreak(cps[i]) {
             let mut term_end = i + 1;
-            if bytes[i] == b'\r' && term_end < bytes.len() && bytes[term_end] == b'\n' {
+            if cps[i].to_char() == Some('\r')
+                && term_end < cps.len()
+                && cps[term_end].to_char() == Some('\n')
+            {
                 term_end += 1;
             }
             let end = if keepends { term_end } else { i };
-            parts.push(wtf8_slice_str(&bytes[start..end]));
+            parts.push(cps_to_str(&cps[start..end]));
             start = term_end;
             i = term_end;
         } else {
             i += 1;
         }
     }
-    if start < bytes.len() {
-        parts.push(wtf8_slice_str(&bytes[start..]));
+    if start < cps.len() {
+        parts.push(cps_to_str(&cps[start..]));
     }
     Ok(w_list_new(parts))
 }

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -1697,10 +1697,8 @@ fn subclass_to_tag(
     Ok(Some(cls))
 }
 
-/// `list.__new__(cls, *args)` — `listobject.py:descr__new__` allocates a
-/// `W_ListObject` of `w_listtype`.  `builtin_list_ctor` always returns a
-/// fresh list, so a subclass instance is the same object with `w_class`
-/// retagged.
+/// `list.__new__(cls, *args)` allocates an empty list.  Population belongs to
+/// `list.__init__`, including for subclasses which inherit that initializer.
 fn list_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     let (params, kwargs) = crate::builtins::split_builtin_kwargs(args);
     let cls = params.first().copied().unwrap_or(pyre_object::PY_NULL);
@@ -1711,13 +1709,41 @@ fn list_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
         params.len().saturating_sub(2),
         crate::builtins::has_real_kwargs(kwargs),
     )?;
-    let value = crate::builtins::builtin_list_ctor(params.get(1..).unwrap_or(&[]))?;
+    let value = pyre_object::w_list_new(Vec::new());
     if let Some(sub) = subclass_to_tag(cls, &pyre_object::LIST_TYPE)? {
         unsafe {
             (*value).w_class = sub;
         }
     }
     Ok(value)
+}
+
+fn list_descr_init(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    let (params, kwargs) = crate::builtins::split_builtin_kwargs(args);
+    let list = params.first().copied().unwrap_or(pyre_object::PY_NULL);
+    if list.is_null() || !unsafe { pyre_object::is_list(list) } {
+        return Err(crate::PyError::type_error(
+            "descriptor '__init__' requires a 'list' object",
+        ));
+    }
+    if crate::builtins::has_real_kwargs(kwargs) {
+        return Err(crate::PyError::type_error(
+            "list() takes no keyword arguments",
+        ));
+    }
+    if params.len() > 2 {
+        return Err(crate::PyError::type_error(format!(
+            "list expected at most 1 argument, got {}",
+            params.len() - 1
+        )));
+    }
+    unsafe { pyre_object::w_list_clear(list) };
+    if let Some(&iterable) = params.get(1) {
+        for item in crate::builtins::collect_iterable(iterable)? {
+            unsafe { pyre_object::w_list_append(list, item) };
+        }
+    }
+    Ok(pyre_object::w_none())
 }
 
 /// `tuple.__new__(cls, *args)` — `tupleobject.py:descr__new__` allocates
@@ -2123,6 +2149,11 @@ fn arg_type_name(obj: PyObjectRef) -> String {
 
 fn init_list_type(ns: &mut DictStorage) {
     dict_storage_store(ns, "__new__", make_new_descr(list_descr_new));
+    dict_storage_store(
+        ns,
+        "__init__",
+        make_builtin_function("__init__", list_descr_init),
+    );
     // listobject.py:2486 __class_getitem__ = interp2app(
     //     generic_alias_class_getitem, as_classmethod=True)
     dict_storage_store(

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -7850,13 +7850,20 @@ fn init_property_type(ns: &mut DictStorage) {
 }
 
 /// `self` as a plain int — `int.real` / `numerator` / `conjugate` /
-/// `as_integer_ratio` return the integer value, so a `bool` receiver
-/// yields `1` / `0` rather than itself.
+/// `as_integer_ratio` and the integer conversion dunders return the
+/// integer value, so a non-exact receiver is down-converted.
 fn int_as_plain_int(args: &[PyObjectRef]) -> PyObjectRef {
     let obj = args.first().copied().unwrap_or(pyre_object::w_int_new(0));
     unsafe {
         if pyre_object::is_bool(obj) {
             return pyre_object::w_int_new(pyre_object::w_bool_get_value(obj) as i64);
+        }
+        if pyre_object::is_int(obj)
+            && !(pyre_object::tagged_int::CAN_BE_TAGGED
+                && pyre_object::tagged_int::is_tagged_int(obj))
+            && (*obj).w_class != pyre_object::get_instantiate(&pyre_object::INT_TYPE)
+        {
+            return pyre_object::w_int_new(pyre_object::w_int_get_value(obj));
         }
     }
     obj
@@ -8533,16 +8540,13 @@ fn init_int_type(ns: &mut DictStorage) {
             int_from_bytes,
         )),
     );
-    // int.__index__ / __int__ / __trunc__ — identity
+    // int.__index__ / __int__ / __trunc__ — exact ints preserve identity;
+    // subclasses and bools are normalized by `int_as_plain_int`.
     for method in ["__index__", "__int__", "__trunc__"] {
         dict_storage_store(
             ns,
             method,
-            make_builtin_function_with_arity(
-                method,
-                |args| Ok(args.first().copied().unwrap_or(pyre_object::w_int_new(0))),
-                1,
-            ),
+            make_builtin_function_with_arity(method, |args| Ok(int_as_plain_int(args)), 1),
         );
     }
     // int.conjugate — identity (bool → int)

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -6211,11 +6211,18 @@ fn try_execute_residual_call_via_executor(
     //    FRESH object and rebinds the journaled local, so a plain deliver re-run
     //    is exact with no journaling.
     //
-    // Any OTHER receiver — an object-/float-strategy list, `bytearray`, `set`,
-    // `dict`, `array`, a mixed `int-list += non-ints` that would change strategy,
-    // … — commits a mutation the rollback cannot rewind, so decline the walk
-    // here and let this loop run interpreted (exact), like the gate refusing an
-    // unsupported body op.
+    // Any OTHER *exact builtin* receiver — an object-/float-strategy list,
+    // `bytearray`, `set`, `dict`, `array`, a mixed `int-list += non-ints` that
+    // would change strategy, … — may commit a mutation the rollback cannot
+    // rewind, so decline the walk here and let this loop run interpreted
+    // (exact), like the gate refusing an unsupported body op.  A user instance
+    // must not take that decline: its `__iadd__`/`__isub__`/… has not run yet,
+    // while the in-flight `FOR_ITER` item has already been consumed.  The
+    // permanent-abort path then drops that item (the conservative delivery
+    // gate sees the loop's preceding `STORE_NAME`), silently skipping one
+    // augmented-assignment iteration at the trace-entry boundary.  Let the
+    // normal residual dispatch execute user special methods; its existing
+    // user-frame effect accounting handles any later abort.
     let inplace_list_journal: Option<(pyre_object::PyObjectRef, usize)> =
         if call_descr.get_extra_info().pyre_helper == majit_ir::PyreHelperKind::BinaryOp
             && args.len() >= 3
@@ -6237,8 +6244,10 @@ fn try_execute_residual_call_via_executor(
                     || pyre_object::pyobject::is_tuple(lhs)
                 {
                     None
-                } else {
+                } else if pyre_object::pyobject::is_exact_builtin_instance(lhs) {
                     return Err(DispatchError::InplaceContainerMutationUnsupported { pc: op_pc });
+                } else {
+                    None
                 }
             }
         } else {


### PR DESCRIPTION
Fixes a batch of interpreter- and JIT-level semantic/crash defects surfaced by a
discovery sweep, rebased linear on top of `main`. Each commit is one cluster;
`python3 pyre/check.py` is green on both backends (dynasm 181/181, wasm 180/180).

### Interpreter semantics
- **String/numeric builtins** — `int(str)` underscore placement (PEP 515 parity with `float`), `str.splitlines` full Unicode line boundaries (VT/FF/FS/GS/RS/NEL/LS/PS), `str.strip`/`split` treat FS/GS/RS as whitespace, `bool.__index__`/`__int__`/`__trunc__` normalize to `int`, `complex ** int` via `c_powi`.
- **Generator delegation** — `send()`/`throw()`/`close()` on a generator suspended at `yield from` route into the delegate (recursively); `CLEANUP_THROW` implemented; `StopIteration.value` preserved.
- **Short-circuiting** — `any()`/`all()` pull one item at a time (terminate on infinite generators); `functools.cmp_to_key` binds a `KeyWrapper` comparator.
- **Sort/extend rooting** — `list.sort`/`sorted` pin items and computed keys in the shadow stack (a raising key previously **SIGSEGV**'d); `list.sort` mutation guard (`ValueError "list modified during sort"`); `list.extend`/`+=` appends incrementally so items before an iterator raise survive.
- **Class protocol** — `super` attribute access runs the descriptor `__get__` path; `list.__new__`/`__init__` split so subclasses can `super().__init__(...)`; a class defining `__eq__` without `__hash__` gets `__hash__ = None`; `ABCMeta` records `__abstractmethods__` and instance construction rejects a non-empty set; C3 MRO validated before allocation (`TypeError` "Cannot create a consistent method resolution order (MRO) for bases …").
- **throw/matmul** — `generator.throw()` constructs any `BaseException` subclass; `@`/`@=`/`operator.matmul` dispatch `__matmul__`/`__rmatmul__`/`__imatmul__`.

### JIT
- **User in-place ops** — the residual-call walker permanently declined any in-place binary-op receiver, dropping the in-flight `FOR_ITER` item for user objects whose `__iadd__`/`__isub__`/`__imul__` had not yet run. Restrict the decline to exact builtin instances so user objects go through normal residual dispatch. (The exact-builtin decline case remains a separate FOR_ITER-midbody exact-resume item, gh#467.)
- **heap lazy-set owner guard** — `force_call_argument_lazy_sets` looked up the lazy-store owner via `OpRef::raw()`, which panics when the forwarded owner is an inline `Const` on a merged raising/non-raising path; a `Const` cannot be a trace allocation, so skip the `seen_allocation` lookup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
