### PR TITLE
objspace: pypy-parity for operator errors, __index__ coercion, 3-arg pow

### DIFF
--- a/pyre/bench/synth/list_insert_pop_index.py
+++ b/pyre/bench/synth/list_insert_pop_index.py
@@ -1,0 +1,55 @@
+# list.insert(index, x) and list.pop(index) coerce the index through
+# `__index__` (`getindex_w(index, OverflowError)`): a small custom index
+# inserts/pops at the resolved position, an out-of-range pop reports "pop index
+# out of range", and a non-index key surfaces the "cannot be interpreted as an
+# integer" TypeError.  A plain-int warmup loop exercises the working fast paths
+# first.  Only cpython==pypy outputs are asserted (an overflowing index raises
+# OverflowError with text that diverges between the oracles).  Deterministic.
+class Idx:
+    def __init__(self, v):
+        self.v = v
+
+    def __index__(self):
+        return self.v
+
+
+def warm(n):
+    acc = 0
+    data = []
+    for i in range(n):
+        data.insert(0, i)
+        if len(data) > 4:
+            acc += data.pop()
+    return acc
+
+
+def m(label, fn):
+    try:
+        print(label, "->", repr(fn()))
+    except BaseException as e:
+        print(label, "!!", type(e).__name__, repr(str(e)))
+
+
+def ins(i):
+    l = [0, 1, 2]
+    l.insert(i, 9)
+    return l
+
+
+def pop(i):
+    l = [10, 11, 12]
+    return (l.pop(i), l)
+
+
+def main():
+    print("warm", warm(15000))
+    m("ins_idx", lambda: ins(Idx(1)))
+    m("ins_neg", lambda: ins(Idx(-1)))
+    m("ins_float", lambda: ins(1.5))
+    m("pop_idx", lambda: pop(Idx(1)))
+    m("pop_neg", lambda: pop(Idx(-1)))
+    m("pop_oob", lambda: pop(Idx(9)))
+    m("pop_float", lambda: pop(1.5))
+
+
+main()

--- a/pyre/bench/synth/list_subscript_index.py
+++ b/pyre/bench/synth/list_subscript_index.py
@@ -1,0 +1,67 @@
+# A list subscript, assignment, and deletion coerce a non-int key through
+# `__index__` (`getindex_w`); an index too large for a machine word raises
+# IndexError naming the key's real type ("cannot fit '<type>' ..."), and an
+# out-of-range index raises "list index out of range".  A plain-int warmup
+# loop exercises the working integer fast paths first.  Only cpython==pypy
+# outputs are asserted (the "indices must be integers" TypeError text and the
+# assignment out-of-range message diverge between the oracles).  Deterministic.
+class Idx:
+    def __init__(self, v):
+        self.v = v
+
+    def __index__(self):
+        return self.v
+
+
+class Big:
+    def __index__(self):
+        return 10 ** 40
+
+
+def warm(n):
+    acc = 0
+    data = [0, 1, 2, 3, 4]
+    for i in range(n):
+        j = i % 5
+        data[j] = data[j] + 1
+        acc += data[j]
+    return acc
+
+
+def m(label, fn):
+    try:
+        print(label, "->", repr(fn()))
+    except BaseException as e:
+        print(label, "!!", type(e).__name__, repr(str(e)))
+
+
+def read(i):
+    return [10, 20, 30][i]
+
+
+def setv(i):
+    l = [0, 0, 0]
+    l[i] = 9
+    return l
+
+
+def delv(i):
+    l = [0, 1, 2]
+    del l[i]
+    return l
+
+
+def main():
+    print("warm", warm(15000))
+    m("read_idx", lambda: read(Idx(1)))
+    m("read_neg", lambda: read(Idx(-1)))
+    m("read_oob", lambda: read(Idx(9)))
+    m("read_big", lambda: read(Big()))
+    m("set_idx", lambda: setv(Idx(1)))
+    m("set_neg", lambda: setv(Idx(-1)))
+    m("del_idx", lambda: delv(Idx(1)))
+    m("del_neg", lambda: delv(Idx(-1)))
+    m("del_big", lambda: delv(Big()))
+
+
+main()

--- a/pyre/bench/synth/operator_error_typename.py
+++ b/pyre/bench/synth/operator_error_typename.py
@@ -1,0 +1,50 @@
+# Binary-operator and comparison TypeError messages name the operand's real
+# class (not the placeholder 'object'), and the `**`/pow() message reads
+# 'for ** or pow():'. A custom class with no numeric dunders drives every
+# operator to its error path; a plain-int warmup loop first exercises the
+# working fast paths. (Unary +/-/~/abs messages also carry the real class name
+# but their text diverges between the oracles, so they are not asserted here.)
+# Deterministic.
+class Foo:
+    pass
+
+
+def warm(n):
+    acc = 0
+    for i in range(n):
+        acc += (i << 1) + (i & 3) - (i % 5)
+    return acc
+
+
+def m(label, fn):
+    try:
+        fn()
+        print(label, "no-error")
+    except TypeError as e:
+        print(label, type(e).__name__, e)
+
+
+def main():
+    print("warm", warm(15000))
+    f = Foo()
+    m("add", lambda: 1 + f)
+    m("sub", lambda: 1 - f)
+    m("mul", lambda: 3 * f)
+    m("truediv", lambda: 1 / f)
+    m("floordiv", lambda: 1 // f)
+    m("mod", lambda: 1 % f)
+    m("lshift", lambda: 1 << f)
+    m("rshift", lambda: 256 >> f)
+    m("and", lambda: 255 & f)
+    m("or", lambda: 1 | f)
+    m("xor", lambda: 1 ^ f)
+    m("add_l", lambda: f + 1)
+    m("both", lambda: f << f)
+    m("lt", lambda: 1 < f)
+    m("gt_l", lambda: f > 1)
+    m("pow_op", lambda: f ** 2)
+    m("pow_builtin", lambda: pow(f, 2))
+    m("pow_str", lambda: "a" ** 2)
+
+
+main()

--- a/pyre/bench/synth/pow3_arg_types.py
+++ b/pyre/bench/synth/pow3_arg_types.py
@@ -1,0 +1,48 @@
+# Three-argument `pow(base, exp, mod)` requires all operands to be integers.
+# A float base rejects the modulus with a TypeError, a complex base with a
+# ValueError ("complex modulo"), and the all-integer forms compute the modular
+# power. A warmup loop exercises the working integer path first. Only cpython==
+# pypy outputs are asserted (the mixed int/float operand errors name the three
+# operand types, which the two oracles word differently). Deterministic.
+def m(label, fn):
+    try:
+        print(label, "->", repr(fn()))
+    except BaseException as e:
+        print(label, "!!", type(e).__name__, repr(str(e)))
+
+
+def warm(n):
+    acc = 0
+    for i in range(n):
+        acc = (acc + pow(i % 7, 13, 1000)) % 1000
+    return acc
+
+
+class MyInt(int):
+    def __pow__(self, exp, mod=None):
+        return ("MyInt.pow", int(self), exp, mod)
+
+
+def main():
+    print("warm", warm(15000))
+    # All-integer 3-arg forms compute the modular power.
+    m("i_i_i", lambda: pow(2, 10, 100))
+    # A base whose type overrides __pow__ is honoured for 3-arg pow (the
+    # integer fast path must not shadow the override).
+    m("sub_i_i", lambda: pow(MyInt(2), 3, 5))
+    m("sub_i_2", lambda: pow(MyInt(2), 3))
+    m("b_i_i", lambda: pow(True, 10, 100))
+    m("i_neg_i", lambda: pow(3, -1, 7))
+    m("i_i_N", lambda: pow(2, 10, None))
+    # 2-arg forms are unaffected.
+    m("f_i_2", lambda: pow(2.0, 10))
+    m("i_i_2", lambda: pow(2, 10))
+    # A float base rejects a real modulus.
+    m("f_i_i", lambda: pow(2.0, 10, 100))
+    m("f_f_i", lambda: pow(2.0, 10.0, 100))
+    m("f_i_N", lambda: pow(2.0, 10, None))
+    # A complex base rejects a modulus with a ValueError.
+    m("c_i_i", lambda: pow(2j, 10, 100))
+
+
+main()

--- a/pyre/bench/synth/set_remove_ord_errors.py
+++ b/pyre/bench/synth/set_remove_ord_errors.py
@@ -1,0 +1,32 @@
+# set.remove(missing) raises KeyError carrying the missing key itself (so its
+# repr shows), matching dict[missing]; ord() on a non-string names the argument's
+# real type. A warmup loop exercises the working set-membership and ord fast
+# paths first. Deterministic.
+def warm(n):
+    acc = 0
+    s = {1, 2, 3}
+    for i in range(n):
+        acc += ord("a") + (i % 3 in s)
+    return acc
+
+
+def m(label, fn):
+    try:
+        fn()
+        print(label, "no-error")
+    except BaseException as e:
+        print(label, type(e).__name__, repr(str(e)), e.args)
+
+
+def main():
+    print("warm", warm(15000))
+    m("remove_int", lambda: {1, 2}.remove(9))
+    m("remove_str", lambda: {1, 2}.remove("x"))
+    m("remove_tuple", lambda: {(1, 2)}.remove((3, 4)))
+    m("ord_int", lambda: ord(65))
+    m("ord_none", lambda: ord(None))
+    m("ord_list", lambda: ord([1]))
+    m("ord_float", lambda: ord(1.5))
+
+
+main()

--- a/pyre/bench/synth/tuple_str_bytes_subscript_index.py
+++ b/pyre/bench/synth/tuple_str_bytes_subscript_index.py
@@ -1,0 +1,58 @@
+# tuple, str, and bytes subscripts coerce a non-int, non-slice key through
+# `__index__` (`getindex_w`): a small custom index reads the resolved position,
+# an out-of-range index raises the type's "index out of range", and an index
+# too large for a machine word raises IndexError naming the key's real type
+# ("cannot fit '<type>' ..."). Plain-int warmup loops exercise the working fast
+# paths first. Only cpython==pypy outputs are asserted (the "indices must be"
+# TypeError text and the bytes out-of-range wording diverge between the
+# oracles). Deterministic.
+class Idx:
+    def __init__(self, v):
+        self.v = v
+
+    def __index__(self):
+        return self.v
+
+
+class Big:
+    def __index__(self):
+        return 10 ** 40
+
+
+def warm(n):
+    acc = 0
+    t = (1, 2, 3, 4, 5)
+    s = "abcde"
+    b = b"abcde"
+    for i in range(n):
+        j = i % 5
+        acc += t[j] + (s[j] == "c") + b[j]
+    return acc
+
+
+def m(label, fn):
+    try:
+        print(label, "->", repr(fn()))
+    except BaseException as e:
+        print(label, "!!", type(e).__name__, repr(str(e)))
+
+
+def main():
+    print("warm", warm(15000))
+    t = (10, 20, 30)
+    m("t_idx", lambda: t[Idx(1)])
+    m("t_neg", lambda: t[Idx(-1)])
+    m("t_oob", lambda: t[Idx(9)])
+    m("t_big", lambda: t[Big()])
+    s = "abcde"
+    m("s_idx", lambda: s[Idx(1)])
+    m("s_neg", lambda: s[Idx(-1)])
+    m("s_oob", lambda: s[Idx(9)])
+    m("s_big", lambda: s[Big()])
+    b = b"abcde"
+    m("b_idx", lambda: b[Idx(1)])
+    m("b_neg", lambda: b[Idx(-1)])
+    m("b_big", lambda: b[Big()])
+
+
+main()

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -1334,10 +1334,31 @@ unsafe fn getitem_tuple(obj: PyObjectRef, index: PyObjectRef) -> PyResult {
         }
         return Ok(w_tuple_new(items));
     }
-    if !is_int(index) {
+    // `descr_getitem`: getindex_w(index, IndexError, "tuple") — coercion
+    // inlined for the same rtyper reason as `getitem_list`.
+    let idx = if is_int(index) {
+        w_int_get_value(index)
+    } else if pyre_object::pyobject::is_int_or_long(index) || lookup(index, "__index__").is_some() {
+        let indexed = space_index(index)?;
+        if is_int(indexed) {
+            w_int_get_value(indexed)
+        } else {
+            match i64::try_from(w_long_get_value(indexed)) {
+                Ok(i) => i,
+                Err(_) => {
+                    return Err(PyError::new(
+                        PyErrorKind::IndexError,
+                        format!(
+                            "cannot fit '{}' into an index-sized integer",
+                            object_functionstr_type_name(index)
+                        ),
+                    ));
+                }
+            }
+        }
+    } else {
         return Err(index_type_error("tuple", index));
-    }
-    let idx = w_int_get_value(index);
+    };
     match w_tuple_getitem(obj, idx) {
         Some(val) => Ok(val),
         None => Err(PyError::new(
@@ -1370,43 +1391,46 @@ unsafe fn getitem_str(obj: PyObjectRef, index: PyObjectRef) -> PyResult {
         }
         return Ok(w_str_from_wtf8(result));
     }
-    if is_int(index) {
-        let idx = w_int_get_value(index);
-        let actual_idx = if idx < 0 { cps.len() as i64 + idx } else { idx } as usize;
-        if actual_idx < cps.len() {
-            let mut one = Wtf8Buf::new();
-            one.push(cps[actual_idx]);
-            return Ok(w_str_from_wtf8(one));
+    // `descr_getitem`: getindex_w(index, IndexError, "string") — coercion
+    // inlined for the same rtyper reason as `getitem_list`.
+    let idx = if is_int(index) {
+        w_int_get_value(index)
+    } else if pyre_object::pyobject::is_int_or_long(index) || lookup(index, "__index__").is_some() {
+        let indexed = space_index(index)?;
+        if is_int(indexed) {
+            w_int_get_value(indexed)
+        } else {
+            match i64::try_from(w_long_get_value(indexed)) {
+                Ok(i) => i,
+                Err(_) => {
+                    return Err(PyError::new(
+                        PyErrorKind::IndexError,
+                        format!(
+                            "cannot fit '{}' into an index-sized integer",
+                            object_functionstr_type_name(index)
+                        ),
+                    ));
+                }
+            }
         }
-        return Err(PyError::new(
-            PyErrorKind::IndexError,
-            "string index out of range",
-        ));
+    } else {
+        return Err(index_type_error("string", index));
+    };
+    let actual_idx = if idx < 0 { cps.len() as i64 + idx } else { idx } as usize;
+    if actual_idx < cps.len() {
+        let mut one = Wtf8Buf::new();
+        one.push(cps[actual_idx]);
+        return Ok(w_str_from_wtf8(one));
     }
-    Err(PyError::type_error(format!(
-        "string indices must be integers, not '{}'",
-        crate::type_methods::arg_type_name(index)
-    )))
+    Err(PyError::new(
+        PyErrorKind::IndexError,
+        "string index out of range",
+    ))
 }
 
 #[inline(never)]
 unsafe fn getitem_bytes_like(obj: PyObjectRef, index: PyObjectRef) -> PyResult {
     let is_bytes = pyre_object::bytesobject::is_bytes(obj);
-    if is_int(index) {
-        let idx = w_int_get_value(index);
-        let len = pyre_object::bytesobject::bytes_like_len(obj) as i64;
-        let actual = if idx < 0 { len + idx } else { idx };
-        if actual >= 0 && actual < len {
-            return Ok(w_int_new(
-                pyre_object::bytesobject::bytes_like_getitem(obj, actual as usize) as i64,
-            ));
-        }
-        let name = if is_bytes { "bytes" } else { "bytearray" };
-        return Err(PyError::new(
-            PyErrorKind::IndexError,
-            format!("{name} index out of range"),
-        ));
-    }
     if is_slice(index) {
         let len = pyre_object::bytesobject::bytes_like_len(obj) as i64;
         let (start, stop, step) = normalize_slice(index, len)?;
@@ -1433,8 +1457,44 @@ unsafe fn getitem_bytes_like(obj: PyObjectRef, index: PyObjectRef) -> PyResult {
             pyre_object::bytearrayobject::w_bytearray_from_bytes(&result)
         });
     }
-    let descr = if is_bytes { "byte" } else { "bytearray" };
-    Err(index_type_error(descr, index))
+    // `descr_getitem`: getindex_w(index, IndexError, "byte") — coercion
+    // inlined for the same rtyper reason as `getitem_list`.
+    let idx = if is_int(index) {
+        w_int_get_value(index)
+    } else if pyre_object::pyobject::is_int_or_long(index) || lookup(index, "__index__").is_some() {
+        let indexed = space_index(index)?;
+        if is_int(indexed) {
+            w_int_get_value(indexed)
+        } else {
+            match i64::try_from(w_long_get_value(indexed)) {
+                Ok(i) => i,
+                Err(_) => {
+                    return Err(PyError::new(
+                        PyErrorKind::IndexError,
+                        format!(
+                            "cannot fit '{}' into an index-sized integer",
+                            object_functionstr_type_name(index)
+                        ),
+                    ));
+                }
+            }
+        }
+    } else {
+        let descr = if is_bytes { "byte" } else { "bytearray" };
+        return Err(index_type_error(descr, index));
+    };
+    let len = pyre_object::bytesobject::bytes_like_len(obj) as i64;
+    let actual = if idx < 0 { len + idx } else { idx };
+    if actual >= 0 && actual < len {
+        return Ok(w_int_new(
+            pyre_object::bytesobject::bytes_like_getitem(obj, actual as usize) as i64,
+        ));
+    }
+    let name = if is_bytes { "byte" } else { "bytearray" };
+    Err(PyError::new(
+        PyErrorKind::IndexError,
+        format!("{name} index out of range"),
+    ))
 }
 
 #[inline(never)]

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -1251,17 +1251,16 @@ pub(crate) fn getitem_slot(obj: PyObjectRef, index: PyObjectRef) -> PyResult {
 
 /// `pypy/interpreter/baseobjspace.py:1574 getindex_w` — the `TypeError`
 /// raised when a sequence subscript is neither an integer nor a slice:
-/// `"<descr> indices must be integers or slices, not <type>"`.
+/// `"<descr> indices must be integers or slices, not '<type>'"` (the `%T`
+/// operand names the key's own class).
 fn index_type_error(descr: &str, index: PyObjectRef) -> PyError {
-    let tp = unsafe {
-        if index.is_null() {
-            "NULL"
-        } else {
-            (*(*index).ob_type).name
-        }
+    let tp = if index.is_null() {
+        "NULL".to_string()
+    } else {
+        object_functionstr_type_name(index)
     };
     PyError::type_error(format!(
-        "{descr} indices must be integers or slices, not {tp}"
+        "{descr} indices must be integers or slices, not '{tp}'"
     ))
 }
 
@@ -1280,10 +1279,36 @@ unsafe fn getitem_list(obj: PyObjectRef, index: PyObjectRef) -> PyResult {
         }
         return Ok(w_list_new(items));
     }
-    if !is_int(index) {
+    // `descr_getitem`: getindex_w(index, IndexError, "list") coerces a
+    // non-slice key through `__index__`.  The coercion is inlined rather
+    // than routed through the `Result<i64>` `subscript_index_w` helper,
+    // whose payload fails to bind a concrete Int repr in the rtyper
+    // (concretetype None → the codewriter mis-colors it Ref), so the hot
+    // integer subscript keeps its Int repr concrete.
+    let idx = if is_int(index) {
+        w_int_get_value(index)
+    } else if pyre_object::pyobject::is_int_or_long(index) || lookup(index, "__index__").is_some() {
+        let indexed = space_index(index)?;
+        if is_int(indexed) {
+            w_int_get_value(indexed)
+        } else {
+            match i64::try_from(w_long_get_value(indexed)) {
+                Ok(i) => i,
+                // `getindex_w` overflow reports the source type, not the coerced int.
+                Err(_) => {
+                    return Err(PyError::new(
+                        PyErrorKind::IndexError,
+                        format!(
+                            "cannot fit '{}' into an index-sized integer",
+                            object_functionstr_type_name(index)
+                        ),
+                    ));
+                }
+            }
+        }
+    } else {
         return Err(index_type_error("list", index));
-    }
-    let idx = w_int_get_value(index);
+    };
     match w_list_getitem(obj, idx) {
         Some(val) => Ok(val),
         None => Err(PyError::new(
@@ -2251,16 +2276,37 @@ unsafe fn setitem_list(obj: PyObjectRef, index: PyObjectRef, value: PyObjectRef)
     if is_slice(index) {
         return setitem_list_slice(obj, index, value);
     }
-    if !is_int(index) {
+    // `descr_setitem`: getindex_w(index, IndexError, "list") — coercion
+    // inlined for the same rtyper reason as `getitem_list`.
+    let idx = if is_int(index) {
+        w_int_get_value(index)
+    } else if pyre_object::pyobject::is_int_or_long(index) || lookup(index, "__index__").is_some() {
+        let indexed = space_index(index)?;
+        if is_int(indexed) {
+            w_int_get_value(indexed)
+        } else {
+            match i64::try_from(w_long_get_value(indexed)) {
+                Ok(i) => i,
+                Err(_) => {
+                    return Err(PyError::new(
+                        PyErrorKind::IndexError,
+                        format!(
+                            "cannot fit '{}' into an index-sized integer",
+                            object_functionstr_type_name(index)
+                        ),
+                    ));
+                }
+            }
+        }
+    } else {
         return Err(index_type_error("list", index));
-    }
-    let idx = w_int_get_value(index);
+    };
     if w_list_setitem(obj, idx, value) {
         Ok(w_none())
     } else {
         Err(PyError::new(
             PyErrorKind::IndexError,
-            "list assignment index out of range",
+            "list index out of range",
         ))
     }
 }
@@ -2323,13 +2369,15 @@ unsafe fn setitem_list_slice(obj: PyObjectRef, index: PyObjectRef, value: PyObje
     Ok(w_none())
 }
 
-/// Resolve a `bytearray` subscript index (`bytearray_ass_subscript`): honor
-/// `__index__`, raise the "indices must be integers or slices" TypeError for a
-/// non-index, non-slice key, and raise IndexError for a value too large to fit
-/// an index (`PyNumber_AsSsize_t(index, IndexError)`).
-unsafe fn bytearray_index(index: PyObjectRef) -> Result<i64, PyError> {
+/// Resolve a sequence subscript index (`getindex_w(index, IndexError, descr)`):
+/// honor `__index__`, raise the "indices must be integers or slices" TypeError
+/// for a non-index, non-slice key, and raise IndexError for a value too large
+/// to fit an index (`PyNumber_AsSsize_t(index, IndexError)`).  Used on cold
+/// deletion paths; hot read/write paths inline the same coercion so their Int
+/// repr stays concrete in the rtyper.
+unsafe fn subscript_index_w(descr: &str, index: PyObjectRef) -> Result<i64, PyError> {
     if !pyre_object::pyobject::is_int_or_long(index) && lookup(index, "__index__").is_none() {
-        return Err(index_type_error("bytearray", index));
+        return Err(index_type_error(descr, index));
     }
     match int_w(space_index(index)?) {
         Ok(i) => Ok(i),
@@ -2347,6 +2395,27 @@ unsafe fn bytearray_index(index: PyObjectRef) -> Result<i64, PyError> {
     }
 }
 
+/// `getindex_w(index, OverflowError)` with `objdescr=None` — the variant
+/// reached through the `@unwrap_spec(index='index')` of `list.insert` /
+/// `list.pop`.  With no `objdescr`, `space.index`'s own error for a non-index
+/// key surfaces verbatim ("'<type>' object cannot be interpreted as an
+/// integer" / "__index__ returned non-int (type X)"); an index too large for a
+/// machine word raises OverflowError "cannot fit '<type>' into an index-sized
+/// integer" (distinct from the subscript path's IndexError).
+pub(crate) unsafe fn getindex_w_index(index: PyObjectRef) -> Result<i64, PyError> {
+    match int_w(space_index(index)?) {
+        Ok(i) => Ok(i),
+        Err(e) if e.kind == PyErrorKind::OverflowError => Err(PyError::new(
+            PyErrorKind::OverflowError,
+            format!(
+                "cannot fit '{}' into an index-sized integer",
+                object_functionstr_type_name(index)
+            ),
+        )),
+        Err(e) => Err(e),
+    }
+}
+
 #[inline(never)]
 unsafe fn setitem_bytearray(obj: PyObjectRef, index: PyObjectRef, value: PyObjectRef) -> PyResult {
     if is_slice(index) {
@@ -2354,7 +2423,7 @@ unsafe fn setitem_bytearray(obj: PyObjectRef, index: PyObjectRef, value: PyObjec
     }
     // `descr_setitem`: getindex_w(index) → byte_w(value) → _fixindex(idx) store.
     // Both coercions are inlined rather than routed through the shared
-    // `bytearray_index`/`byte_w`, whose `Result<int>` payload fails to bind a
+    // `subscript_index_w`/`byte_w`, whose `Result<int>` payload fails to bind a
     // concrete Int repr in the rtyper (concretetype None) so the codewriter
     // mis-colors it Ref against its Int provenance; the inline `space_index`
     // pattern keeps the Int repr concrete.  The value is coerced before the
@@ -11790,16 +11859,6 @@ pub(crate) fn delitem_slot(obj: PyObjectRef, index: PyObjectRef) -> Result<(), P
     use pyre_object::*;
     unsafe {
         if is_list(obj) {
-            if is_int(index) {
-                let i = w_int_get_value(index);
-                let len = w_list_len(obj) as i64;
-                let idx = if i < 0 { len + i } else { i };
-                if idx >= 0 && idx < len {
-                    w_list_pop(obj, idx);
-                    return Ok(());
-                }
-                return Err(PyError::type_error("list index out of range"));
-            }
             if is_slice(index) {
                 let len = w_list_len(obj) as i64;
                 let (start, stop, step) = normalize_slice(index, len)?;
@@ -11831,6 +11890,27 @@ pub(crate) fn delitem_slot(obj: PyObjectRef, index: PyObjectRef) -> Result<(), P
                 }
                 return Ok(());
             }
+            // `descr_delitem`: getindex_w(idx, IndexError, "list") coerces a
+            // non-slice key through `__index__` before the length is read.  A
+            // key that is neither an index nor a slice raises the "indices must
+            // be integers" TypeError here rather than falling through to the
+            // generic `__delitem__` slot, which is bound to `delitem_slot` and
+            // would recurse.
+            let i = if is_int(index) {
+                w_int_get_value(index)
+            } else {
+                subscript_index_w("list", index)?
+            };
+            let len = w_list_len(obj) as i64;
+            let idx = if i < 0 { len + i } else { i };
+            if idx >= 0 && idx < len {
+                w_list_pop(obj, idx);
+                return Ok(());
+            }
+            return Err(PyError::new(
+                PyErrorKind::IndexError,
+                "list index out of range",
+            ));
         }
         if is_dict(obj) {
             return dict_delitem(obj, index);
@@ -11882,7 +11962,7 @@ pub(crate) fn delitem_slot(obj: PyObjectRef, index: PyObjectRef) -> Result<(), P
                 }
                 return Ok(());
             }
-            let i = bytearray_index(index)?;
+            let i = subscript_index_w("bytearray", index)?;
             let len = pyre_object::bytearrayobject::w_bytearray_len(obj) as i64;
             let idx = if i < 0 { len + i } else { i };
             if idx >= 0 && idx < len {

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -3394,8 +3394,7 @@ fn builtin_issubclass(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyErro
     )?))
 }
 
-// Descroperation helpers (lookup_type_special, should_try_reverse_first,
-// try_dispatch_binary_special, try_dispatch_ternary_special,
+// Descroperation helpers (lookup_type_special, try_dispatch_binary_special,
 // try_int_long_pow_with_modulo, binary_builtin_type_error,
 // box_bigint_result, issubtype_w) live in `crate::baseobjspace` because
 // they are space-level semantics shared between the builtin module,

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -2586,8 +2586,8 @@ pub fn builtin_abs(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> 
         }
     }
     Err(crate::PyError::type_error(format!(
-        "bad operand type for abs(): '{}'",
-        unsafe { (*(*obj).ob_type).name }
+        "unsupported operand type for unary abs: '{}'",
+        crate::baseobjspace::object_functionstr_type_name(obj)
     )))
 }
 

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -7266,9 +7266,10 @@ fn builtin_ord(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
             return Ok(w_int_new(data[0] as i64));
         }
     }
-    Err(crate::PyError::type_error(
-        "ord() expected string of length 1, but other type found",
-    ))
+    Err(crate::PyError::type_error(format!(
+        "ord() expected string of length 1, but {} found",
+        crate::baseobjspace::object_functionstr_type_name(obj)
+    )))
 }
 
 /// `chr(i)` — PyPy: operation.py chr

--- a/pyre/pyre-interpreter/src/module/_weakref/interp__weakref.rs
+++ b/pyre/pyre-interpreter/src/module/_weakref/interp__weakref.rs
@@ -1092,10 +1092,10 @@ proxy_binary_reflected!(proxy_rmod, crate::baseobjspace::mod_);
 // pow / rpow — interp__weakref.py:363 generates a 3-arg wrapper because
 // `('pow', '**', 3, ['__pow__', '__rpow__'])` has arity=3 but
 // `forcing_count = len(special_methods) = 2`, so the optional modulo
-// operand passes through unforced. The wrapper hands the result to
-// `space.pow(w_obj0, w_obj1, w_obj2)` (descroperation.py:399), so
-// NotImplemented from forward `__pow__` properly falls through to the
-// reflected `__rpow__` and vice versa.
+// operand passes through unforced. The two-arg form hands off to
+// `space.pow`, whose forward/reverse dance lets `__rpow__` answer; the
+// three-arg form hands off to `space.pow3`, which consults only the
+// forward `__pow__` (descroperation.py:450) and never the reflected slot.
 pub fn proxy_pow(args: &[PyObjectRef]) -> Result<PyObjectRef, PyError> {
     let w_obj0 = force(args[0])?;
     let w_obj1 = force(args[1])?;
@@ -1967,12 +1967,13 @@ mod tests {
         assert_eq!(unsafe { pyre_object::w_int_get_value(result) }, 7777);
     }
 
-    /// 3-arg `pow(proxy, b, c)` must end up in
-    /// `space.pow3 → try_dispatch_ternary_special`, so a forward
-    /// `__pow__` returning NotImplemented falls through to the
-    /// reflected `__rpow__`.
+    /// 3-arg `pow(proxy, b, c)` reaches `space.pow3`, which consults only the
+    /// forward `__pow__` on the base — the reflected `__rpow__` is not tried
+    /// for ternary power (descroperation.py:450). A forward `NotImplemented`
+    /// therefore raises the three-operand type error rather than falling
+    /// through to the right operand's `__rpow__`.
     #[test]
-    fn test_proxy_pow_three_arg_falls_through_to_rpow() {
+    fn test_proxy_pow_three_arg_does_not_use_rpow() {
         crate::typedef::init_typeobjects();
         let lhs_type = crate::typedef::make_builtin_type("Pow3Lhs", |ns| {
             crate::dict_storage_store(
@@ -1987,18 +1988,18 @@ mod tests {
             crate::dict_storage_store(
                 ns,
                 "__rpow__",
-                crate::make_builtin_function("__rpow__", |args| {
-                    // Echo the modulus operand so we can confirm it
-                    // threaded through to the reflected wrapper.
-                    Ok(args[2])
-                }),
+                crate::make_builtin_function("__rpow__", |args| Ok(args[2])),
             );
         });
         let lhs = pyre_object::objectobject::w_instance_new(lhs_type);
         let rhs = pyre_object::objectobject::w_instance_new(rhs_type);
         let proxy_lhs = W_Proxy_new(lhs, PY_NULL);
-        let result = proxy_pow(&[proxy_lhs, rhs, pyre_object::w_int_new(99)]).unwrap();
-        assert_eq!(unsafe { pyre_object::w_int_get_value(result) }, 99);
+        let err = proxy_pow(&[proxy_lhs, rhs, pyre_object::w_int_new(99)]).unwrap_err();
+        assert_eq!(err.kind, crate::PyErrorKind::TypeError);
+        assert_eq!(
+            err.message,
+            "unsupported operand type(s) for pow(): 'Pow3Lhs', 'Pow3Rhs', 'int'"
+        );
     }
 
     /// `divmod(proxy, rhs)` where `lhs.__divmod__` returns NotImplemented

--- a/pyre/pyre-interpreter/src/objspace/descroperation.rs
+++ b/pyre/pyre-interpreter/src/objspace/descroperation.rs
@@ -1893,8 +1893,8 @@ pub fn add(a: PyObjectRef, b: PyObjectRef) -> PyResult {
         if let Some(result) = try_instance_binop(a, b, "__add__") {
             return result;
         }
-        let a_name = (*ll_type(a)).name;
-        let b_name = (*ll_type(b)).name;
+        let a_name = crate::baseobjspace::object_functionstr_type_name(a);
+        let b_name = crate::baseobjspace::object_functionstr_type_name(b);
         // Sequence concatenation slot (sq_concat) reports a distinct
         // message when the left operand is a sequence — `unicode_concatenate`
         // / `list_concat` / `tuple_concat`.
@@ -1958,8 +1958,8 @@ pub fn sub(a: PyObjectRef, b: PyObjectRef) -> PyResult {
         if let Some(result) = try_typedef_binop(a, b, "__sub__") {
             return result;
         }
-        let a_name = (*ll_type(a)).name;
-        let b_name = (*ll_type(b)).name;
+        let a_name = crate::baseobjspace::object_functionstr_type_name(a);
+        let b_name = crate::baseobjspace::object_functionstr_type_name(b);
         Err(PyError::type_error(format!(
             "unsupported operand type(s) for -: '{a_name}' and '{b_name}'"
         )))
@@ -2035,8 +2035,8 @@ pub fn mul(a: PyObjectRef, b: PyObjectRef) -> PyResult {
         if let Some(result) = try_instance_binop(a, b, "__mul__") {
             return result;
         }
-        let a_name = (*ll_type(a)).name;
-        let b_name = (*ll_type(b)).name;
+        let a_name = crate::baseobjspace::object_functionstr_type_name(a);
+        let b_name = crate::baseobjspace::object_functionstr_type_name(b);
         // Sequence repetition slot (sq_repeat): a sequence on either side
         // with a non-int multiplier reports the non-int's type.
         let a_seq =
@@ -2085,8 +2085,8 @@ pub fn floordiv(a: PyObjectRef, b: PyObjectRef) -> PyResult {
         if let Some(result) = try_instance_binop(a, b, "__floordiv__") {
             return result;
         }
-        let a_name = (*ll_type(a)).name;
-        let b_name = (*ll_type(b)).name;
+        let a_name = crate::baseobjspace::object_functionstr_type_name(a);
+        let b_name = crate::baseobjspace::object_functionstr_type_name(b);
         Err(PyError::type_error(format!(
             "unsupported operand type(s) for //: '{a_name}' and '{b_name}'"
         )))
@@ -2143,8 +2143,8 @@ pub fn mod_(a: PyObjectRef, b: PyObjectRef) -> PyResult {
         if let Some(result) = try_instance_binop(a, b, "__mod__") {
             return result;
         }
-        let a_name = (*ll_type(a)).name;
-        let b_name = (*ll_type(b)).name;
+        let a_name = crate::baseobjspace::object_functionstr_type_name(a);
+        let b_name = crate::baseobjspace::object_functionstr_type_name(b);
         Err(PyError::type_error(format!(
             "unsupported operand type(s) for %: '{a_name}' and '{b_name}'"
         )))
@@ -2193,8 +2193,8 @@ pub fn truediv(a: PyObjectRef, b: PyObjectRef) -> PyResult {
         if let Some(result) = try_instance_binop(a, b, "__truediv__") {
             return result;
         }
-        let a_name = (*ll_type(a)).name;
-        let b_name = (*ll_type(b)).name;
+        let a_name = crate::baseobjspace::object_functionstr_type_name(a);
+        let b_name = crate::baseobjspace::object_functionstr_type_name(b);
         Err(PyError::type_error(format!(
             "unsupported operand type(s) for /: '{a_name}' and '{b_name}'"
         )))
@@ -2230,10 +2230,10 @@ pub fn pow(a: PyObjectRef, b: PyObjectRef) -> PyResult {
         if let Some(result) = try_instance_binop(a, b, "__pow__") {
             return result;
         }
-        let a_name = (*ll_type(a)).name;
-        let b_name = (*ll_type(b)).name;
+        let a_name = crate::baseobjspace::object_functionstr_type_name(a);
+        let b_name = crate::baseobjspace::object_functionstr_type_name(b);
         Err(PyError::type_error(format!(
-            "unsupported operand type(s) for **: '{a_name}' and '{b_name}'"
+            "unsupported operand type(s) for ** or pow(): '{a_name}' and '{b_name}'"
         )))
     }
 }
@@ -2954,8 +2954,8 @@ pub fn lshift(a: PyObjectRef, b: PyObjectRef) -> PyResult {
         if let Some(result) = try_instance_binop(a, b, "__lshift__") {
             return result;
         }
-        let a_name = (*ll_type(a)).name;
-        let b_name = (*ll_type(b)).name;
+        let a_name = crate::baseobjspace::object_functionstr_type_name(a);
+        let b_name = crate::baseobjspace::object_functionstr_type_name(b);
         Err(PyError::type_error(format!(
             "unsupported operand type(s) for <<: '{a_name}' and '{b_name}'"
         )))
@@ -2985,8 +2985,8 @@ pub fn rshift(a: PyObjectRef, b: PyObjectRef) -> PyResult {
         if let Some(result) = try_instance_binop(a, b, "__rshift__") {
             return result;
         }
-        let a_name = (*ll_type(a)).name;
-        let b_name = (*ll_type(b)).name;
+        let a_name = crate::baseobjspace::object_functionstr_type_name(a);
+        let b_name = crate::baseobjspace::object_functionstr_type_name(b);
         Err(PyError::type_error(format!(
             "unsupported operand type(s) for >>: '{a_name}' and '{b_name}'"
         )))
@@ -3044,8 +3044,8 @@ pub fn and_(a: PyObjectRef, b: PyObjectRef) -> PyResult {
         if let Some(result) = try_typedef_binop(a, b, "__and__") {
             return result;
         }
-        let a_name = (*ll_type(a)).name;
-        let b_name = (*ll_type(b)).name;
+        let a_name = crate::baseobjspace::object_functionstr_type_name(a);
+        let b_name = crate::baseobjspace::object_functionstr_type_name(b);
         Err(PyError::type_error(format!(
             "unsupported operand type(s) for &: '{a_name}' and '{b_name}'"
         )))
@@ -3152,8 +3152,8 @@ pub fn or_(a: PyObjectRef, b: PyObjectRef) -> PyResult {
         if let Some(result) = try_typedef_binop(a, b, "__or__") {
             return result;
         }
-        let a_name = (*ll_type(a)).name;
-        let b_name = (*ll_type(b)).name;
+        let a_name = crate::baseobjspace::object_functionstr_type_name(a);
+        let b_name = crate::baseobjspace::object_functionstr_type_name(b);
         Err(PyError::type_error(format!(
             "unsupported operand type(s) for |: '{a_name}' and '{b_name}'"
         )))
@@ -3212,8 +3212,8 @@ pub fn xor(a: PyObjectRef, b: PyObjectRef) -> PyResult {
         if let Some(result) = try_typedef_binop(a, b, "__xor__") {
             return result;
         }
-        let a_name = (*ll_type(a)).name;
-        let b_name = (*ll_type(b)).name;
+        let a_name = crate::baseobjspace::object_functionstr_type_name(a);
+        let b_name = crate::baseobjspace::object_functionstr_type_name(b);
         Err(PyError::type_error(format!(
             "unsupported operand type(s) for ^: '{a_name}' and '{b_name}'"
         )))
@@ -3546,8 +3546,8 @@ pub fn compare_slot(a: PyObjectRef, b: PyObjectRef, op: CompareOp) -> PyResult {
         if matches!(op, CompareOp::Ne) {
             return Ok(w_bool_from(!std::ptr::eq(a, b)));
         }
-        let a_name = (*ll_type(a)).name;
-        let b_name = (*ll_type(b)).name;
+        let a_name = crate::baseobjspace::object_functionstr_type_name(a);
+        let b_name = crate::baseobjspace::object_functionstr_type_name(b);
         let op_symbol = op.symbol();
         Err(PyError::type_error(format!(
             "'{op_symbol}' not supported between instances of '{a_name}' and '{b_name}'"
@@ -3607,12 +3607,12 @@ pub fn pos(a: PyObjectRef) -> PyResult {
         }
         if a.is_null() {
             return Err(PyError::type_error(
-                "bad operand type for unary +: 'NoneType'",
+                "unsupported operand type for unary pos: 'NoneType'",
             ));
         }
         Err(PyError::type_error(format!(
-            "bad operand type for unary +: '{}'",
-            (*ll_type(a)).name,
+            "unsupported operand type for unary pos: '{}'",
+            crate::baseobjspace::object_functionstr_type_name(a),
         )))
     }
 }
@@ -3647,12 +3647,12 @@ pub fn neg(a: PyObjectRef) -> PyResult {
         }
         if a.is_null() {
             return Err(PyError::type_error(
-                "bad operand type for unary -: 'NoneType'",
+                "unsupported operand type for unary neg: 'NoneType'",
             ));
         }
         Err(PyError::type_error(format!(
-            "bad operand type for unary -: '{}'",
-            (*ll_type(a)).name,
+            "unsupported operand type for unary neg: '{}'",
+            crate::baseobjspace::object_functionstr_type_name(a),
         )))
     }
 }
@@ -3675,8 +3675,8 @@ pub fn invert(a: PyObjectRef) -> PyResult {
             return result;
         }
         Err(PyError::type_error(format!(
-            "bad operand type for unary ~: '{}'",
-            (*ll_type(a)).name,
+            "unsupported operand type for unary ~: '{}'",
+            crate::baseobjspace::object_functionstr_type_name(a),
         )))
     }
 }

--- a/pyre/pyre-interpreter/src/objspace/descroperation.rs
+++ b/pyre/pyre-interpreter/src/objspace/descroperation.rs
@@ -2495,25 +2495,6 @@ pub(crate) unsafe fn lookup_type_special(obj: PyObjectRef, dunder: &str) -> Opti
     crate::typedef::r#type(obj).and_then(|tp| lookup_in_type(tp, dunder))
 }
 
-/// descroperation.py `_binop_impl` — when `type(rhs)` is a proper
-/// subtype of `type(lhs)` and defines the reflected dunder, the
-/// reflected operand is tried first.
-pub(crate) unsafe fn should_try_reverse_first(
-    lhs: PyObjectRef,
-    rhs: PyObjectRef,
-    rdunder: &str,
-) -> bool {
-    let Some(lhs_type) = crate::typedef::r#type(lhs) else {
-        return false;
-    };
-    let Some(rhs_type) = crate::typedef::r#type(rhs) else {
-        return false;
-    };
-    !std::ptr::eq(lhs_type, rhs_type)
-        && issubtype_w(rhs_type, lhs_type)
-        && lookup_in_type(rhs_type, rdunder).is_some()
-}
-
 /// Call a special method and treat NotImplemented as "no result", per
 /// descroperation.py `_check_notimplemented`.
 pub(crate) fn try_call_special(
@@ -2648,39 +2629,6 @@ pub(crate) fn try_inplace_special(
     Ok(None)
 }
 
-/// descroperation.py:399 `def pow(space, w_obj1, w_obj2, w_obj3)` —
-/// the same forward/reverse dance as the binary version but threading
-/// the third (modulo) operand through to both arms.
-pub(crate) fn try_dispatch_ternary_special(
-    lhs: PyObjectRef,
-    rhs: PyObjectRef,
-    third: PyObjectRef,
-    dunder: &str,
-    rdunder: &str,
-) -> Result<Option<PyObjectRef>, PyError> {
-    let try_reverse_first = unsafe { should_try_reverse_first(lhs, rhs, rdunder) };
-    if try_reverse_first {
-        if let Some(method) = unsafe { lookup_type_special(rhs, rdunder) } {
-            if let Some(result) = try_call_special(method, &[rhs, lhs, third])? {
-                return Ok(Some(result));
-            }
-        }
-    }
-    if let Some(method) = unsafe { lookup_type_special(lhs, dunder) } {
-        if let Some(result) = try_call_special(method, &[lhs, rhs, third])? {
-            return Ok(Some(result));
-        }
-    }
-    if !try_reverse_first {
-        if let Some(method) = unsafe { lookup_type_special(rhs, rdunder) } {
-            if let Some(result) = try_call_special(method, &[rhs, lhs, third])? {
-                return Ok(Some(result));
-            }
-        }
-    }
-    Ok(None)
-}
-
 /// `(int|long) ** (int|long) % (int|long)` fast path used by `space.pow`
 /// when a modulus is supplied — longobject.py `int_pow`.
 pub(crate) fn try_int_long_pow_with_modulo(
@@ -2755,34 +2703,51 @@ pub(crate) fn box_bigint_result(value: BigInt) -> PyObjectRef {
     }
 }
 
+/// `%T` — the runtime type name of `obj` (`space.type(obj).name`), falling
+/// back to the layout-level type for objects without a Python type.
+fn operand_type_name(obj: PyObjectRef) -> String {
+    unsafe {
+        match crate::typedef::r#type(obj) {
+            Some(tp) => pyre_object::w_type_get_name(tp).to_string(),
+            None => (*ll_type(obj)).name.to_string(),
+        }
+    }
+}
+
 pub(crate) fn binary_builtin_type_error(
     opname: &str,
     lhs: PyObjectRef,
     rhs: PyObjectRef,
 ) -> PyError {
-    let lhs_name = unsafe {
-        match crate::typedef::r#type(lhs) {
-            Some(tp) => pyre_object::w_type_get_name(tp).to_string(),
-            None => (*ll_type(lhs)).name.to_string(),
-        }
-    };
-    let rhs_name = unsafe {
-        match crate::typedef::r#type(rhs) {
-            Some(tp) => pyre_object::w_type_get_name(tp).to_string(),
-            None => (*ll_type(rhs)).name.to_string(),
-        }
-    };
+    let lhs_name = operand_type_name(lhs);
+    let rhs_name = operand_type_name(rhs);
     PyError::type_error(format!(
         "unsupported operand type(s) for {opname}: '{lhs_name}' and '{rhs_name}'"
     ))
 }
 
-/// 3-arg `pow(a, b, c)` dispatch — pypy/objspace/descroperation.py:399
+/// The three-operand form of [`binary_builtin_type_error`] for `pow(a, b, c)`
+/// — descroperation.py:469 `unsupported operand type(s) for pow(): T, T, T`.
+pub(crate) fn ternary_builtin_type_error(
+    opname: &str,
+    a: PyObjectRef,
+    b: PyObjectRef,
+    c: PyObjectRef,
+) -> PyError {
+    let a_name = operand_type_name(a);
+    let b_name = operand_type_name(b);
+    let c_name = operand_type_name(c);
+    PyError::type_error(format!(
+        "unsupported operand type(s) for {opname}: '{a_name}', '{b_name}', '{c_name}'"
+    ))
+}
+
+/// 3-arg `pow(a, b, c)` dispatch — pypy/objspace/descroperation.py:441
 /// `def pow(space, w_obj1, w_obj2, w_obj3)`. Tries the int/long modulus
-/// fast path, then forward `__pow__` and reverse `__rpow__` with the
-/// usual NotImplemented fallback. PyPy's MethodTable lists `pow` with
-/// arity=3 (`('pow', '**', 3, ['__pow__', '__rpow__'])`) so a 3-arg
-/// space op exists for the proxy wrapper to call.
+/// fast path, then only the forward `__pow__` on the base; the reflected
+/// `__rpow__` is not consulted for three-arg power (unlike two-arg), so a
+/// forward `NotImplemented` raises the three-operand type error rather than
+/// falling through to the right operand.
 pub fn pow3(base: PyObjectRef, exp: PyObjectRef, modulus: PyObjectRef) -> PyResult {
     let base = unwrap_cell(base);
     let exp = unwrap_cell(exp);
@@ -2790,13 +2755,16 @@ pub fn pow3(base: PyObjectRef, exp: PyObjectRef, modulus: PyObjectRef) -> PyResu
     if unsafe { is_none(modulus) } {
         return pow(base, exp);
     }
-    if let Some(result) = try_int_long_pow_with_modulo(base, exp, modulus)? {
-        return Ok(result);
+    // descroperation.py:459 — three-arg power looks up only the forward
+    // `__pow__` on the base (so a subclass override is honoured) and never
+    // the reflected `__rpow__`. The integer modular-power computation lives
+    // in `int.__pow__`, reached through this lookup.
+    if let Some(method) = unsafe { lookup_type_special(base, "__pow__") } {
+        if let Some(result) = try_call_special(method, &[base, exp, modulus])? {
+            return Ok(result);
+        }
     }
-    if let Some(result) = try_dispatch_ternary_special(base, exp, modulus, "__pow__", "__rpow__")? {
-        return Ok(result);
-    }
-    Err(binary_builtin_type_error("pow()", base, exp))
+    Err(ternary_builtin_type_error("pow()", base, exp, modulus))
 }
 
 /// `divmod(a, b)` dispatch — pypy/interpreter/baseobjspace.py:2159

--- a/pyre/pyre-interpreter/src/type_methods.rs
+++ b/pyre/pyre-interpreter/src/type_methods.rs
@@ -253,7 +253,10 @@ pub fn list_method_extend(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::Py
 /// PyPy: listobject.py descr_insert — list.insert(index, item)
 pub fn list_method_insert(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     arity_exact_unpack(args, "insert", 2)?;
-    let index = unsafe { w_int_get_value(args[1]) };
+    // `@unwrap_spec(index='index')` → getindex_w(index, OverflowError): coerce
+    // through `__index__`; `get_positive_index` then clamps to `[0, len]`
+    // inside `w_list_insert`.
+    let index = unsafe { crate::baseobjspace::getindex_w_index(args[1])? };
     unsafe { pyre_object::listobject::w_list_insert(args[0], index, args[2]) };
     Ok(w_none())
 }
@@ -266,8 +269,10 @@ pub fn list_method_pop(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyErr
     // `descr_pop` checks arity before touching the list, so `pop(1, 2)` on an
     // empty list reports the surplus argument rather than "pop from empty list".
     arity_at_most(args, "pop", 1)?;
+    // `@unwrap_spec(index='index')` → getindex_w(index, OverflowError): coerce
+    // through `__index__`.
     let index = if args.len() > 1 {
-        unsafe { w_int_get_value(args[1]) }
+        unsafe { crate::baseobjspace::getindex_w_index(args[1])? }
     } else {
         -1
     };

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -13854,10 +13854,7 @@ fn init_set_type(ns: &mut DictStorage) {
                 }
                 let removed = unsafe { pyre_object::w_set_discard(args[0], args[1]) };
                 if !removed {
-                    return Err(crate::PyError::new(
-                        crate::PyErrorKind::KeyError,
-                        "set.remove(x): x not in set",
-                    ));
+                    return Err(crate::PyError::key_error_with_key(args[1]));
                 }
                 Ok(pyre_object::w_none())
             },

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -8036,19 +8036,30 @@ int_binop_rev!(
 /// three-argument modular power.
 fn int_dunder_pow(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     crate::type_methods::arity_pow(args)?;
-    if unsafe { pyre_object::pyobject::is_int_or_long(args[1]) } {
-        if args.len() >= 3 {
-            if unsafe { pyre_object::pyobject::is_none(args[2]) } {
-                crate::objspace::descroperation::pow_builtin(args[0], args[1])
-            } else {
-                crate::objspace::descroperation::pow3(args[0], args[1], args[2])
-            }
-        } else {
-            crate::objspace::descroperation::pow_builtin(args[0], args[1])
-        }
-    } else {
-        Ok(pyre_object::w_not_implemented())
+    // intobject.py:674 descr_pow — a non-int exponent defers to the other
+    // operand's reflected slot.
+    if !unsafe { pyre_object::pyobject::is_int_or_long(args[1]) } {
+        return Ok(pyre_object::w_not_implemented());
     }
+    if args.len() >= 3 && !unsafe { pyre_object::pyobject::is_none(args[2]) } {
+        // Only an integer modulus routes through the modular-power path.
+        // The object protocol has no ternary reflected slot, so an int base
+        // with a non-int modulus yields NotImplemented and the caller raises
+        // the three-operand type error.
+        if !unsafe { pyre_object::pyobject::is_int_or_long(args[2]) } {
+            return Ok(pyre_object::w_not_implemented());
+        }
+        // intobject.py:686 — self, exponent and modulus are all integers, so
+        // compute the modular power here rather than re-entering the ternary
+        // dispatch (which would recurse back into this slot).
+        return match crate::objspace::descroperation::try_int_long_pow_with_modulo(
+            args[0], args[1], args[2],
+        )? {
+            Some(result) => Ok(result),
+            None => Ok(pyre_object::w_not_implemented()),
+        };
+    }
+    crate::objspace::descroperation::pow_builtin(args[0], args[1])
 }
 
 float_binop_fwd!(
@@ -8107,12 +8118,24 @@ float_binop_rev!(
     float_dunder_rdivmod,
     crate::objspace::descroperation::divmod_builtin
 );
+/// floatobject.py:588 — a float `__pow__`/`__rpow__` rejects a ternary
+/// modulus argument, which is meaningful only for integer power.
+fn float_pow_reject_modulus(args: &[PyObjectRef]) -> Result<(), crate::PyError> {
+    if args.len() >= 3 && !unsafe { pyre_object::pyobject::is_none(args[2]) } {
+        return Err(crate::PyError::type_error(
+            "pow() 3rd argument not allowed unless all arguments are integers",
+        ));
+    }
+    Ok(())
+}
+
 /// `float.__pow__` / `__rpow__` — the ternary-power slot accepts an
 /// optional modulus argument, so arity is validated as one-or-two.
 fn float_dunder_pow(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     crate::type_methods::arity_pow(args)?;
     let b = args[1];
     if unsafe { pyre_object::pyobject::is_float(b) || pyre_object::pyobject::is_int_or_long(b) } {
+        float_pow_reject_modulus(args)?;
         crate::objspace::descroperation::pow_builtin(args[0], b)
     } else {
         Ok(pyre_object::w_not_implemented())
@@ -8122,6 +8145,7 @@ fn float_dunder_rpow(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError
     crate::type_methods::arity_pow(args)?;
     let b = args[1];
     if unsafe { pyre_object::pyobject::is_float(b) || pyre_object::pyobject::is_int_or_long(b) } {
+        float_pow_reject_modulus(args)?;
         crate::objspace::descroperation::pow_builtin(b, args[0])
     } else {
         Ok(pyre_object::w_not_implemented())
@@ -8160,11 +8184,21 @@ complex_binop_rev!(
     complex_dunder_rtruediv,
     crate::objspace::descroperation::truediv_builtin
 );
+/// complexobject.py:525 — a complex `__pow__`/`__rpow__` rejects a ternary
+/// modulus argument with `ValueError: complex modulo`.
+fn complex_pow_reject_modulus(args: &[PyObjectRef]) -> Result<(), crate::PyError> {
+    if args.len() >= 3 && !unsafe { pyre_object::pyobject::is_none(args[2]) } {
+        return Err(crate::PyError::value_error("complex modulo"));
+    }
+    Ok(())
+}
+
 /// `complex.__pow__` / `__rpow__` — the ternary-power slot accepts an
 /// optional modulus argument, so arity is validated as one-or-two.
 fn complex_dunder_pow(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     crate::type_methods::arity_pow(args)?;
     if complex_binop_operand(args[1]) {
+        complex_pow_reject_modulus(args)?;
         crate::objspace::descroperation::pow_builtin(args[0], args[1])
     } else {
         Ok(pyre_object::w_not_implemented())
@@ -8173,6 +8207,7 @@ fn complex_dunder_pow(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyErro
 fn complex_dunder_rpow(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     crate::type_methods::arity_pow(args)?;
     if complex_binop_operand(args[1]) {
+        complex_pow_reject_modulus(args)?;
         crate::objspace::descroperation::pow_builtin(args[1], args[0])
     } else {
         Ok(pyre_object::w_not_implemented())


### PR DESCRIPTION
Five interpreter object-space slices bringing error/coercion behavior in line
with PyPy (`rpython/`/`pypy/` upstream). Each is independently verified against
`pypy3` and, where cpython==pypy, guarded by a synthetic regression test.

## Slices

**Operator TypeError messages: name real class, pypy text** (`b15f509af26`)
Binary (`+ - * / // % << >> & | ^`) and comparison error messages take the
operand name from `object_functionstr_type_name` (the `__class__` name) instead
of `(*ll_type(x)).name` — a user class now reads `'Foo'`, not `'object'`. The
`**` operator / 2-arg `pow` message reads `for ** or pow():`, and unary
`+ - ~`/`abs` on an unsupported operand read `unsupported operand type for
unary pos|neg|~|abs:` (`_make_unaryop_impl`). Synth `operator_error_typename`
guards the binop/comparison/`**` cases (cpython==pypy); unary/abs match pypy but
diverge from cpython, so are verified out of band.

**set.remove KeyError carries key; ord() names arg type** (`0d8e2973b0d`)
`set.remove(x)` on a missing element now raises `key_error_with_key(x)` (the
KeyError carries `x`, matching `dict[missing]`) instead of a fixed string.
`ord()` on a non-string names the argument's type via
`object_functionstr_type_name` (e.g. `but int found`). Synth
`set_remove_ord_errors`.

**list: coerce subscript/insert/pop index through `__index__`** (`c2e91f3e481`)
`getitem_list`/`setitem_list`/`delitem_slot` and `list.insert`/`list.pop` run a
non-int, non-slice index through `__index__` (`getindex_w`). Hot get/set inline
the coercion (is_int fast path + `__index__` slow path) to keep a concrete Int
repr in the rtyper; cold del/insert/pop route through
`subscript_index_w`/`getindex_w_index`. Fixes a RecursionError where a non-int
`del list[k]` fell through to the generic `__delitem__` slot and recursed.
Overflow raises `cannot fit '<type>' into an index-sized integer`; a non-index
key raises `<descr> indices must be integers or slices, not '<type>'`; out-of-range
raises `list index out of range`. Synth `list_subscript_index`,
`list_insert_pop_index`.

**seq: coerce tuple/str/bytes subscript index through `__index__`** (`3b08028f82f`)
`getitem_tuple`/`getitem_str`/`getitem_bytes_like` coerce a non-int, non-slice
key through `__index__`, mirroring `getitem_list`. `getitem_str` routes its
non-index TypeError through `index_type_error`, adding the missing `or slices`
clause; a bytes index-out-of-range reads `byte index out of range`. Synth
`tuple_str_bytes_subscript_index`.

**pow: 3-arg power tries only forward `__pow__`, not `__rpow__`** (`00eccce001d`)
3-arg `pow(base, exp, mod)` consults only the forward `__pow__` on the base
(`descroperation.py:459`) and raises the three-operand `unsupported operand
type(s) for pow(): T, T, T` on NotImplemented — matching PyPy, not cpython. The
integer modular-power fast path moves from `pow3` into `int.__pow__`, so a base
whose type overrides `__pow__` is honoured (`pow(MyInt(2), 3, 5)` calls the
override). `int.__pow__` returns NotImplemented for a non-integer modulus and
computes the modular power directly rather than re-entering `pow3`, fixing an
infinite recursion that crashed `pow(2, 10, 100.0)` / `pow(2, 10, 100j)` with
RecursionError. A float base rejects a non-None modulus with TypeError
`pow() 3rd argument not allowed unless all arguments are integers`, a complex
base with ValueError `complex modulo`. Removes the now-unused
`try_dispatch_ternary_special`/`should_try_reverse_first`. Synth
`pow3_arg_types`.

## Verification

- `pyre==pypy` matrices for each slice; pow 11/11 + subscript value/oob/big cases.
- `python ./pyre/check.py`: cranelift 187/187, wasm 186/186 green; the sole
  dynasm miss is the pre-existing `nested_loop` perf-boundary flake (output
  byte-identical to pypy, passes in isolation, uses none of this code).
- codex parity review: 0 Section-1 regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
