### PR TITLE
#346: retire rtyper legacy walker — vec!→NewList, GC-safepoint residuals, f64::abs lowering

### DIFF
--- a/pyre/pyre-interpreter/src/call.rs
+++ b/pyre/pyre-interpreter/src/call.rs
@@ -152,7 +152,12 @@ pub fn frame_entry_count() -> u64 {
 /// ([`FRAME_ENTRY_COUNT`]).  Called once at every `eval_loop` /
 /// `eval_loop_jit` entry, i.e. each time a user Python frame begins
 /// executing bytecode.
-#[inline(always)]
+///
+/// Touches the runtime-mutable `FRAME_ENTRY_COUNT` thread-local, not a
+/// build-time constant, so the JIT residualizes the call instead of tracing
+/// into it (`@dont_look_inside`, the `note_alloc` sibling). A `()` return has
+/// no discriminant to erase and it cannot raise.
+#[majit_macros::dont_look_inside]
 pub fn bump_frame_entry_count() {
     FRAME_ENTRY_COUNT.with(|c| c.set(c.get().wrapping_add(1)));
 }

--- a/pyre/pyre-interpreter/src/jit_fnaddr.rs
+++ b/pyre/pyre-interpreter/src/jit_fnaddr.rs
@@ -721,6 +721,28 @@ pub fn jit_trace_fnaddrs() -> Vec<(&'static str, i64)> {
         "pyre_interpreter::call::bump_frame_entry_count",
         crate::call::bump_frame_entry_count as *const (),
     );
+    // The dispatch-loop safepoint entry itself reads `ALLOC_SINCE_GC` inline and
+    // dispatches to the collection hook, and `maybe_sync_dict_storage_store`
+    // stores through the `DICT_STORAGE_STORE_HOOK` fn-pointer cell — both
+    // runtime-mutable, `()`-returning, cannot-raise, word-argument residuals
+    // (`#[dont_look_inside]`), bound by qualified path.
+    push_alias_pair(
+        &mut entries,
+        "pyre_object::gc_interp::safepoint",
+        "pyre_object::safepoint",
+        pyre_object::gc_interp::safepoint as *const (),
+    );
+    let maybe_sync_dict_storage_store: unsafe fn(
+        *mut u8,
+        pyre_object::PyObjectRef,
+        pyre_object::PyObjectRef,
+    ) = pyre_object::dictmultiobject::maybe_sync_dict_storage_store;
+    push_alias_pair(
+        &mut entries,
+        "pyre_object::dictmultiobject::maybe_sync_dict_storage_store",
+        "pyre_object::maybe_sync_dict_storage_store",
+        maybe_sync_dict_storage_store as *const (),
+    );
     // `jit_bigint_div` / `jit_bigint_rem` residualize the `div_rem()` tuple
     // synth (`front::bigint_div_rem`): the foreign malachite `div_rem` returns
     // a `(BigInt, BigInt)` the tracer models as a `__pos_0`/`__pos_1` tuple
@@ -2366,6 +2388,22 @@ mod tests {
         assert_eq!(
             bindings["pyre_interpreter::call::bump_frame_entry_count"],
             bump
+        );
+
+        let safepoint = pyre_object::gc_interp::safepoint as *const () as usize as i64;
+        assert_eq!(bindings["pyre_object::gc_interp::safepoint"], safepoint);
+        assert_eq!(bindings["pyre_object::safepoint"], safepoint);
+
+        let store_sync: unsafe fn(*mut u8, pyre_object::PyObjectRef, pyre_object::PyObjectRef) =
+            pyre_object::dictmultiobject::maybe_sync_dict_storage_store;
+        let store_sync = store_sync as *const () as usize as i64;
+        assert_eq!(
+            bindings["pyre_object::dictmultiobject::maybe_sync_dict_storage_store"],
+            store_sync
+        );
+        assert_eq!(
+            bindings["pyre_object::maybe_sync_dict_storage_store"],
+            store_sync
         );
     }
 

--- a/pyre/pyre-interpreter/src/jit_fnaddr.rs
+++ b/pyre/pyre-interpreter/src/jit_fnaddr.rs
@@ -679,6 +679,48 @@ pub fn jit_trace_fnaddrs() -> Vec<(&'static str, i64)> {
         "pyre_object::bigint_gc_type_id",
         pyre_object::longobject::bigint_gc_type_id as *const (),
     );
+    // The dispatch-loop safepoint's four toucher residuals plus the frame-entry
+    // odometer bump and the items-block strategy gate: each reads a
+    // runtime-mutable global (`COLLECT_STATE` / `EVAL_NESTING` atomics, the two
+    // GC hook fn-pointer cells, `FRAME_ENTRY_COUNT` TLS, the `PYRE_GC_ITEMSBLOCK`
+    // `OnceLock`) — none a build-time constant — so all carry
+    // `#[dont_look_inside]` and bind their `-> bool` / `()` Rust `fn` directly by
+    // qualified path (siblings of `gc_interp::enabled` / `note_alloc`).
+    push_alias_pair(
+        &mut entries,
+        "pyre_object::gc_interp::collect_enabled",
+        "pyre_object::collect_enabled",
+        pyre_object::gc_interp::collect_enabled as *const (),
+    );
+    push_alias_pair(
+        &mut entries,
+        "pyre_object::gc_interp::at_outermost_activation",
+        "pyre_object::at_outermost_activation",
+        pyre_object::gc_interp::at_outermost_activation as *const (),
+    );
+    push_alias_pair(
+        &mut entries,
+        "pyre_object::gc_hook::try_gc_collect_oldgen",
+        "pyre_object::try_gc_collect_oldgen",
+        pyre_object::gc_hook::try_gc_collect_oldgen as *const (),
+    );
+    push_alias_pair(
+        &mut entries,
+        "pyre_object::gc_hook::try_gc_jitframe_empty",
+        "pyre_object::try_gc_jitframe_empty",
+        pyre_object::gc_hook::try_gc_jitframe_empty as *const (),
+    );
+    push_alias_pair(
+        &mut entries,
+        "pyre_object::object_array::itemsblock_gc_enabled",
+        "pyre_object::itemsblock_gc_enabled",
+        pyre_object::object_array::itemsblock_gc_enabled as *const (),
+    );
+    push_fnaddr(
+        &mut entries,
+        "pyre_interpreter::call::bump_frame_entry_count",
+        crate::call::bump_frame_entry_count as *const (),
+    );
     // `jit_bigint_div` / `jit_bigint_rem` residualize the `div_rem()` tuple
     // synth (`front::bigint_div_rem`): the foreign malachite `div_rem` returns
     // a `(BigInt, BigInt)` the tracer models as a `__pos_0`/`__pos_1` tuple
@@ -2260,6 +2302,70 @@ mod tests {
         assert_eq!(
             bindings["pyre_interpreter::var_nums_to_second_index"],
             second
+        );
+    }
+
+    /// The dispatch-loop safepoint's global-state readers residualize by
+    /// qualified path; a typo in either the module-qualified or root alias
+    /// silently regresses the `#[dont_look_inside]` call to a symbolic hash,
+    /// so pin both spellings against the live fnaddr (siblings of the
+    /// `gc_interp::enabled` / `note_alloc` registrations).
+    #[test]
+    fn jit_trace_fnaddrs_covers_interp_gc_safepoint_readers() {
+        let bindings: HashMap<&'static str, i64> = jit_trace_fnaddrs().into_iter().collect();
+
+        let collect_enabled = pyre_object::gc_interp::collect_enabled as *const () as usize as i64;
+        assert_eq!(
+            bindings["pyre_object::gc_interp::collect_enabled"],
+            collect_enabled
+        );
+        assert_eq!(bindings["pyre_object::collect_enabled"], collect_enabled);
+
+        let at_outermost =
+            pyre_object::gc_interp::at_outermost_activation as *const () as usize as i64;
+        assert_eq!(
+            bindings["pyre_object::gc_interp::at_outermost_activation"],
+            at_outermost
+        );
+        assert_eq!(
+            bindings["pyre_object::at_outermost_activation"],
+            at_outermost
+        );
+
+        let collect_oldgen =
+            pyre_object::gc_hook::try_gc_collect_oldgen as *const () as usize as i64;
+        assert_eq!(
+            bindings["pyre_object::gc_hook::try_gc_collect_oldgen"],
+            collect_oldgen
+        );
+        assert_eq!(
+            bindings["pyre_object::try_gc_collect_oldgen"],
+            collect_oldgen
+        );
+
+        let jitframe_empty =
+            pyre_object::gc_hook::try_gc_jitframe_empty as *const () as usize as i64;
+        assert_eq!(
+            bindings["pyre_object::gc_hook::try_gc_jitframe_empty"],
+            jitframe_empty
+        );
+        assert_eq!(
+            bindings["pyre_object::try_gc_jitframe_empty"],
+            jitframe_empty
+        );
+
+        let itemsblock =
+            pyre_object::object_array::itemsblock_gc_enabled as *const () as usize as i64;
+        assert_eq!(
+            bindings["pyre_object::object_array::itemsblock_gc_enabled"],
+            itemsblock
+        );
+        assert_eq!(bindings["pyre_object::itemsblock_gc_enabled"], itemsblock);
+
+        let bump = crate::call::bump_frame_entry_count as *const () as usize as i64;
+        assert_eq!(
+            bindings["pyre_interpreter::call::bump_frame_entry_count"],
+            bump
         );
     }
 

--- a/pyre/pyre-object/src/dictmultiobject.rs
+++ b/pyre/pyre-object/src/dictmultiobject.rs
@@ -2283,7 +2283,13 @@ pub unsafe fn w_module_dict_store_inner_checked(
 /// Write a str-keyed assignment back to the dict's backing DictStorage,
 /// if any. Declared in pyre-interpreter and re-exported via an `extern`
 /// hook registered at startup to avoid a circular dependency.
-unsafe fn maybe_sync_dict_storage_store(ns_ptr: *mut u8, key: PyObjectRef, value: PyObjectRef) {
+// `dont_look_inside`: the store-through target is a process-global atomic
+// fn-pointer cell (`DICT_STORAGE_STORE_HOOK`) whose dispatch stays opaque to
+// the JIT; calls residualize via the registered fnaddr. All three args are
+// word-sized (`*mut u8` + two refs) and the `()` return cannot raise — the
+// `try_gc_owns_object` / `maybe_register_finalizer` twin.
+#[majit_macros::dont_look_inside]
+pub unsafe fn maybe_sync_dict_storage_store(ns_ptr: *mut u8, key: PyObjectRef, value: PyObjectRef) {
     if ns_ptr.is_null() {
         return;
     }

--- a/pyre/pyre-object/src/gc_hook.rs
+++ b/pyre/pyre-object/src/gc_hook.rs
@@ -231,7 +231,12 @@ pub fn clear_gc_collect_oldgen_hook() {
 
 /// Trigger a non-moving old-gen-only major collection via the installed hook.
 /// No-op when no hook is installed.
-#[inline]
+///
+/// Reads the runtime-mutable `GC_COLLECT_OLDGEN_HOOK` fn-pointer cell, not a
+/// build-time constant, so the JIT residualizes the call instead of tracing
+/// into it (`@dont_look_inside`, the [`try_gc_owns_object`] twin). A `()`
+/// return has no discriminant to erase and it cannot raise.
+#[majit_macros::dont_look_inside]
 pub fn try_gc_collect_oldgen() {
     if let Some(f) = GC_COLLECT_OLDGEN_HOOK.get() {
         f();
@@ -335,7 +340,12 @@ pub fn clear_gc_jitframe_empty_hook() {
 /// Whether no compiled trace is suspended (jitframe shadow stack empty),
 /// via the installed hook. `true` when no hook is installed (no JIT →
 /// no jitframes).
-#[inline]
+///
+/// Reads the runtime-mutable `GC_JITFRAME_EMPTY_HOOK` fn-pointer cell, not a
+/// build-time constant, so the JIT residualizes the call instead of tracing
+/// into it (`@dont_look_inside`, the [`try_gc_collect_oldgen`] twin). The
+/// `-> bool` return fits a single word and it cannot raise.
+#[majit_macros::dont_look_inside]
 pub fn try_gc_jitframe_empty() -> bool {
     match GC_JITFRAME_EMPTY_HOOK.get() {
         Some(f) => f(),

--- a/pyre/pyre-object/src/gc_interp.rs
+++ b/pyre/pyre-object/src/gc_interp.rs
@@ -86,8 +86,13 @@ impl Drop for EvalActivationGuard {
 /// `sorted` key). The outer handler holds live `PyObjectRef`s on the
 /// Rust stack that the walker cannot reach — a collection would free
 /// still-reachable old-gen objects. Block the safepoint there.
-#[inline]
-fn at_outermost_activation() -> bool {
+///
+/// Reads the runtime-mutable `EVAL_NESTING` thread-local, not a build-time
+/// constant, so the JIT residualizes the call instead of tracing into it
+/// (`@dont_look_inside`, the [`enabled`] sibling). The `-> bool` return fits
+/// a single word and it cannot raise.
+#[majit_macros::dont_look_inside]
+pub fn at_outermost_activation() -> bool {
     EVAL_NESTING.with(|d| d.get() <= 2)
 }
 
@@ -172,8 +177,13 @@ pub fn safepoint() {
 
 /// Whether the safepoint actually collects. Off via `PYRE_GC_INTERP_COLLECT=0`
 /// to isolate the allocation routing from the collection while diagnosing.
-#[inline]
-fn collect_enabled() -> bool {
+///
+/// Reads (and lazily initialises) the runtime-mutable `COLLECT_STATE` atomic,
+/// not a build-time constant, so the JIT residualizes the call instead of
+/// tracing into it (`@dont_look_inside`, the [`enabled`] sibling). The
+/// `-> bool` return fits a single word and it cannot raise.
+#[majit_macros::dont_look_inside]
+pub fn collect_enabled() -> bool {
     match COLLECT_STATE.load(Ordering::Relaxed) {
         1 => false,
         2 => true,

--- a/pyre/pyre-object/src/gc_interp.rs
+++ b/pyre/pyre-object/src/gc_interp.rs
@@ -160,7 +160,15 @@ pub fn note_alloc() {
 /// ([`at_outermost_activation`]) so a Python callback nested inside native
 /// module code — whose Rust-stack roots the pyframe walker cannot see — never
 /// triggers it.
-#[inline]
+///
+/// Reads the runtime-mutable `ALLOC_SINCE_GC` atomic and dispatches to the
+/// installed collection hook, neither a build-time constant, so the JIT
+/// residualizes the call instead of tracing into it (`@dont_look_inside`, the
+/// [`enabled`] sibling). A `()` return has no discriminant to erase and it
+/// cannot raise. On the cold interpreter dispatch loop its first act is
+/// already the non-inlined `enabled()` early-return; the residual adds no
+/// hot-path cost the un-residualized form did not already pay.
+#[majit_macros::dont_look_inside]
 pub fn safepoint() {
     if !enabled() {
         return;

--- a/pyre/pyre-object/src/object_array.rs
+++ b/pyre/pyre-object/src/object_array.rs
@@ -266,7 +266,13 @@ unsafe fn alloc_mapdict_storage_block(cap: usize) -> *mut ItemsBlock {
 /// fannkuch/nbody/spectral_norm timings unchanged). `PYRE_GC_ITEMSBLOCK=0`
 /// (or `off`/`false`) restores the `std::alloc` fallback to bisect a
 /// suspected block-GC regression.
-fn itemsblock_gc_enabled() -> bool {
+///
+/// Reads (and lazily initialises) the runtime-mutable `ENABLED` `OnceLock`,
+/// not a build-time constant, so the JIT residualizes the call instead of
+/// tracing into it (`@dont_look_inside`, the `gc_interp::enabled` sibling).
+/// The `-> bool` return fits a single word and it cannot raise.
+#[majit_macros::dont_look_inside]
+pub fn itemsblock_gc_enabled() -> bool {
     use std::sync::OnceLock;
     static ENABLED: OnceLock<bool> = OnceLock::new();
     *ENABLED.get_or_init(|| {


### PR DESCRIPTION
## Summary

#346 rtyper-legacy retirement — four census slices on top of `main`, each lifting JIT-prepass graphs that previously fell back to the legacy walker. The metric is the distinct `[PREPASS phaseA fail] CallPath` count (what `cutover::is_known_unported` counts); every slice was verified with a census delta + `check.py` gate.

## Commits

1. **`vec![..]` → `OpKind::NewList` with cross-block box sweep** — recognizes the `box_assume_init_into_vec_unsafe(box [e0..eN])` form the `vec!` macro lowers to, emits `NewList`, and sweeps the dead cross-block `Box::new_uninit` remnant via `prune_dead_boxing_remnants` (dependency-flow liveness).

2. **GC-safepoint global-state readers residual** — six zero-arg void/bool cannot-raise readers of runtime-mutable process globals (`try_gc_collect_oldgen`, `try_gc_jitframe_empty`, `at_outermost_activation`, `collect_enabled`, `bump_frame_entry_count`, `itemsblock_gc_enabled`) marked `#[dont_look_inside]` and registered in `jit_trace_fnaddrs`, mirroring the `gc_interp::enabled` / `note_alloc` precedent.

3. **safepoint entry + dict store-through hook residual** — `gc_interp::safepoint` (reads `ALLOC_SINCE_GC` inline + dispatches the collection hook) and `dictmultiobject::maybe_sync_dict_storage_store` (stores through `DICT_STORAGE_STORE_HOOK`); dominoes `typing_intrinsic_1/2`.

4. **f64::abs → `float_abs`, float `/` → truediv** — recognizes `core::f64::<Impl>::abs` and emits an abstract `abs` `UnaryOp` (rtyper lowers via `FloatRepr::rtype_abs` → `float_abs`, `rfloat.py:44-46`), teaches the closed `normalize_unary_op_name` allowlist the `"abs"` opname, and relabels a float-result `floordiv` to `truediv` (the type-blind `canonical_binop_label` maps every `Div` to the integer `floordiv`, but `FloatRepr` has only `rtype_truediv`). Lifts `complex_truediv`.

## Verification

`python3 ./pyre/check.py` — **dynasm 181/181, cranelift 181/181, wasm 180/180** at the branch tip.
Each slice's census delta was confirmed with no path regression (set-diff of the PREPASS-fail path set before/after).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
