### PR TITLE
interp: compute __abstractmethods__ in _abc_init and propagate __isabstractmethod__

### DIFF
--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -8420,12 +8420,25 @@ fn init_staticmethod_type(ns: PyObjectRef) {
             "__new__",
             make_builtin_function("__new__", |args| {
                 // staticmethod(func) — args[0] is cls (staticmethod type), args[1] is func
+                let cls = args.first().copied().unwrap_or(pyre_object::PY_NULL);
                 let func = if args.len() > 1 {
                     args[1]
                 } else {
                     pyre_object::w_none()
                 };
-                Ok(pyre_object::function::w_staticmethod_new(func))
+                let sm = pyre_object::function::w_staticmethod_new(func);
+                // function.py `allocate_instance(StaticMethod, w_subtype)` —
+                // honour the subtype so `abstractstaticmethod(func)` yields an
+                // `abstractstaticmethod` instance, not a bare `staticmethod`.
+                let staticmethod_type =
+                    crate::typedef::gettypeobject(&pyre_object::function::STATICMETHOD_TYPE);
+                if !cls.is_null() && !std::ptr::eq(cls, staticmethod_type) {
+                    check_user_subclass(staticmethod_type, cls)?;
+                    unsafe {
+                        (*sm).w_class = cls;
+                    }
+                }
+                Ok(sm)
             }),
         )
     };
@@ -8540,12 +8553,25 @@ fn init_classmethod_type(ns: PyObjectRef) {
             ns,
             "__new__",
             make_builtin_function("__new__", |args| {
+                let cls = args.first().copied().unwrap_or(pyre_object::PY_NULL);
                 let func = if args.len() > 1 {
                     args[1]
                 } else {
                     pyre_object::w_none()
                 };
-                Ok(pyre_object::function::w_classmethod_new(func))
+                let cm = pyre_object::function::w_classmethod_new(func);
+                // function.py `allocate_instance(ClassMethod, w_subtype)` —
+                // honour the subtype so `abstractclassmethod(func)` yields an
+                // `abstractclassmethod` instance, not a bare `classmethod`.
+                let classmethod_type =
+                    crate::typedef::gettypeobject(&pyre_object::function::CLASSMETHOD_TYPE);
+                if !cls.is_null() && !std::ptr::eq(cls, classmethod_type) {
+                    check_user_subclass(classmethod_type, cls)?;
+                    unsafe {
+                        (*cm).w_class = cls;
+                    }
+                }
+                Ok(cm)
             }),
         )
     };
@@ -8747,6 +8773,41 @@ fn init_property_type(ns: PyObjectRef) {
                 "__delete__",
                 crate::baseobjspace::property_descr_delete_impl,
             ),
+        )
+    };
+    // descriptor.py `__isabstractmethod__` — `isabstract(fget) or
+    // isabstract(fset) or isabstract(fdel)`.
+    unsafe {
+        pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
+            ns,
+            "__isabstractmethod__",
+            make_getset_descriptor(make_builtin_function_with_arity(
+                "__isabstractmethod__",
+                |args| {
+                    let prop = args.get(1).copied().unwrap_or(pyre_object::PY_NULL);
+                    if !unsafe { pyre_object::descriptor::is_property(prop) } {
+                        return Ok(pyre_object::w_bool_from(false));
+                    }
+                    // A missing accessor is `PY_NULL`; treat it as not-abstract.
+                    let is_abstract = |f: PyObjectRef| -> Result<bool, crate::PyError> {
+                        if f.is_null() {
+                            Ok(false)
+                        } else {
+                            crate::baseobjspace::isabstractmethod_w(f)
+                        }
+                    };
+                    let result =
+                        is_abstract(unsafe { pyre_object::descriptor::w_property_get_fget(prop) })?
+                            || is_abstract(unsafe {
+                                pyre_object::descriptor::w_property_get_fset(prop)
+                            })?
+                            || is_abstract(unsafe {
+                                pyre_object::descriptor::w_property_get_fdel(prop)
+                            })?;
+                    Ok(pyre_object::w_bool_from(result))
+                },
+                2,
+            )),
         )
     };
 }

--- a/pyre/pyre-object/src/typeobject.rs
+++ b/pyre/pyre-object/src/typeobject.rs
@@ -866,10 +866,11 @@ pub unsafe fn w_type_is_heaptype(obj: PyObjectRef) -> bool {
 ///
 /// `_HEAPTYPE = 1<<9`, `_CPYTYPE = 1` (non-heap builtin types),
 /// `PATMA_SEQUENCE = 1<<5`, `PATMA_MAPPING = 1<<6`,
-/// `DISALLOW_INSTANTIATION = 1<<7`.  pyre tracks `flag_heaptype`,
-/// `flag_map_or_seq` and `flag_disallow_instantiation`; the cpytype bit
-/// follows `!flag_heaptype` (every non-heap type is a builtin C type).
-/// The abstract / method-descriptor bits have no pyre flag yet.
+/// `DISALLOW_INSTANTIATION = 1<<7`, `IS_ABSTRACT = 1<<20`.  pyre tracks
+/// `flag_heaptype`, `flag_map_or_seq`, `flag_disallow_instantiation` and
+/// `flag_abstract`; the cpytype bit follows `!flag_heaptype` (every
+/// non-heap type is a builtin C type).  The method-descriptor bits have no
+/// pyre flag yet.
 pub unsafe fn w_type_get_flags(obj: PyObjectRef) -> i64 {
     if obj.is_null() || !is_type(obj) {
         return 0;
@@ -879,12 +880,17 @@ pub unsafe fn w_type_get_flags(obj: PyObjectRef) -> i64 {
     const DISALLOW_INSTANTIATION: i64 = 1 << 7;
     const PATMA_SEQUENCE: i64 = 1 << 5;
     const PATMA_MAPPING: i64 = 1 << 6;
+    // `Py_TPFLAGS_IS_ABSTRACT` — read by `inspect.isabstract`.
+    const IS_ABSTRACT: i64 = 1 << 20;
     let t = &*(obj as *const W_TypeObject);
     let mut flags = 0i64;
     if t.flag_heaptype {
         flags |= HEAPTYPE;
     } else {
         flags |= CPYTYPE;
+    }
+    if t.flag_abstract.load(std::sync::atomic::Ordering::Acquire) {
+        flags |= IS_ABSTRACT;
     }
     if t.flag_disallow_instantiation
         .load(std::sync::atomic::Ordering::Acquire)


### PR DESCRIPTION
## Summary

`_abc_init` only set up `_abc_registry` and never computed `__abstractmethods__`, so ABCs were freely instantiable and `inspect.isabstract` always returned False. This PR completes the ABC abstract-method machinery.

- **`_abc_init` computes `__abstractmethods__`** — new `compute_abstract_methods` (mirrors `_abcmodule.c` / `app_abc.py`): the abstract members in `cls.__dict__` plus those inherited from bases and not overridden with a concrete member.
- **`property.__isabstractmethod__`** getset descriptor (`isabstract(fget) or fset or fdel`).
- **`staticmethod`/`classmethod` `__new__` honour the subtype**, so the legacy `abstractstaticmethod`/`abstractclassmethod` subclasses behave correctly (subtype instance returned, `__init__` runs, class-level `__isabstractmethod__ = True` is visible).
- **`w_type_get_flags` reports `Py_TPFLAGS_IS_ABSTRACT`** from the existing `flag_abstract`, which `inspect.isabstract` reads.

## Test

`python -m test test_abc`: **24 failures + 8 errors → 11 failures, 0 errors.**

Remaining `test_abc` failures are unrelated to this change:
- `test_abstractproperty_basics` / `test_descriptors_with_abstractmethod` are blocked by a separate `super().<property>` bug (property `__get__` is not invoked through `super`), reproducible independently of `abc`.
- `test_issubclass_bad_arguments` is a pre-existing `issubclass()` argument-validation gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved subclass behavior for `staticmethod` and `classmethod`, ensuring type checks correctly reflect custom subtypes.
  * Added support for identifying abstract properties based on their accessors.
  * Updated type flags so abstract classes are correctly recognized by runtime checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->