### PR TITLE
majit: node virtualization for aheui linked-list nodes (~1.9x logo)

### DIFF
--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -11900,6 +11900,9 @@ impl CraneliftBackend {
                 }
 
                 // ── GC allocation calls ──
+                OpCode::CallMallocNurseryHeaderless => {
+                    unreachable!("headerless nursery alloc is aheui-dynasm-only");
+                }
                 OpCode::CallMallocNursery => {
                     // x86/assembler.py:2556-2565 malloc_cond parity.
                     // RPython: inline nursery bump alloc for BOTH loops and

--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -3782,6 +3782,46 @@ extern "C" fn gc_alloc_nursery_shim(size: u64) -> u64 {
     with_cranelift_gc_required(|gc| gc.alloc_nursery(size as usize).0 as u64)
 }
 
+fn try_headerless_nursery_bump(gc: &mut dyn GcAllocator, size: usize) -> Option<u64> {
+    let nf_addr = gc.nursery_free_addr();
+    let nt_addr = gc.nursery_top_addr();
+    if nf_addr == 0 || nt_addr == 0 {
+        return None;
+    }
+
+    unsafe {
+        let nf = nf_addr as *mut usize;
+        let nt = nt_addr as *const usize;
+        let free = nf.read();
+        let top = nt.read();
+        let new_free = free.checked_add(size)?;
+        if new_free > top {
+            return None;
+        }
+        nf.write(new_free);
+        Some(free as u64)
+    }
+}
+
+/// Headerless nursery overflow helper.  Returns the raw allocation base with
+/// no GC header, matching the dynasm headerless fast-path contract.
+extern "C" fn gc_alloc_nursery_headerless_shim(size: u64) -> u64 {
+    with_cranelift_gc_required(|gc| {
+        let size = size as usize;
+        if let Some(base) = try_headerless_nursery_bump(gc, size) {
+            return base;
+        }
+        gc.collect_nursery();
+        if let Some(base) = try_headerless_nursery_bump(gc, size) {
+            return base;
+        }
+
+        let layout = std::alloc::Layout::from_size_align(size, 8)
+            .unwrap_or_else(|_| std::alloc::Layout::new::<u8>());
+        unsafe { std::alloc::alloc_zeroed(layout) as u64 }
+    })
+}
+
 /// Plain malloc fallback for New() when no GC runtime is configured.
 extern "C" fn plain_malloc_zeroed_shim(size: u64) -> u64 {
     let layout = std::alloc::Layout::from_size_align(size as usize, 8)
@@ -11901,7 +11941,34 @@ impl CraneliftBackend {
 
                 // ── GC allocation calls ──
                 OpCode::CallMallocNurseryHeaderless => {
-                    unreachable!("headerless nursery alloc is aheui-dynasm-only");
+                    if !cranelift_gc_active() {
+                        return Err(missing_gc_runtime(op.opcode));
+                    }
+                    let size = resolve_opref_or_imm(
+                        &mut builder,
+                        &constants,
+                        &known_values,
+                        op.arg(0).to_opref(),
+                    );
+                    let result = emit_collecting_gc_call(
+                        &mut builder,
+                        ptr_type,
+                        call_conv,
+                        jf_ptr,
+                        &ref_root_slots,
+                        &defined_ref_vars,
+                        &stale_ref_vars,
+                        &demoted_failarg_slots,
+                        ref_root_base_ofs,
+                        per_call_gcmap,
+                        gc_alloc_nursery_headerless_shim as *const () as usize,
+                        &[size],
+                        Some(cl_types::I64),
+                    )
+                    .expect("headerless nursery allocation helper must return a value");
+                    jf_ptr = emit_reload_frame_if_necessary(&mut builder, ptr_type, call_conv);
+                    builder.ins().set_pinned_reg(jf_ptr);
+                    builder.def_var(var(vi), result);
                 }
                 OpCode::CallMallocNursery => {
                     // x86/assembler.py:2556-2565 malloc_cond parity.

--- a/majit/majit-backend-dynasm/src/aarch64/assembler.rs
+++ b/majit/majit-backend-dynasm/src/aarch64/assembler.rs
@@ -6153,6 +6153,16 @@ impl<'a> AssemblerARM64<'a> {
 
     /// Headerless fixed-size nursery allocation.  `size` excludes any GC
     /// header; result is the old nursery base.
+    ///
+    /// The fast path raw-bumps `dynasm_nursery_addrs()`, so it is correct only
+    /// when the active dynasm GC is headerless-aware — its nursery must yield a
+    /// raw base carrying no `GcHeader` (aheui's `NurseryGcAllocator`, whose
+    /// nursery is the aheui node arena collected by aheui's own copying node
+    /// GC).  A headered collector such as MiniMarkGC must never back this op:
+    /// its nursery walk reads a `GcHeader` at `base - GcHeader::SIZE`, which a
+    /// raw base lacks.  The overflow slowpath enforces this via
+    /// `alloc_nursery_headerless`'s panicking default; the fast path relies on
+    /// the same invariant being upheld by whoever declares `headerless_structs`.
     fn genop_call_malloc_nursery_headerless(&mut self, op: &Op) {
         let size_ref = op.arg(0).to_opref();
         let size = size_ref.inline_const_bits().unwrap_or_else(|| {

--- a/majit/majit-backend-dynasm/src/aarch64/assembler.rs
+++ b/majit/majit-backend-dynasm/src/aarch64/assembler.rs
@@ -3145,6 +3145,18 @@ impl<'a> AssemblerARM64<'a> {
                     self.store_rax_to_result(op.pos.get());
                 }
             }
+            OpCode::CallMallocNurseryHeaderless => {
+                self.genop_call_malloc_nursery_headerless(op);
+                if let Some(Loc::Reg(r)) = result_loc {
+                    if r.value != 0 {
+                        let rv = r.value;
+                        dynasm!(self.mc ; .arch aarch64 ; mov X(rv), x0);
+                    }
+                }
+                if !op.pos.get().is_none() {
+                    self.store_rax_to_result(op.pos.get());
+                }
+            }
             // aarch64/assembler.py:715 malloc_cond_varsize_frame
             OpCode::CallMallocNurseryVarsizeFrame => {
                 let sizeloc = match arglocs.first() {
@@ -6134,6 +6146,96 @@ impl<'a> AssemblerARM64<'a> {
         // (calloc failure preserved as NULL per runner.rs).  Route
         // through the propagate path before the fast-path join so the
         // null pointer never reaches subsequent typed stores.
+        self.emit_propagate_memory_error_if_null(0);
+
+        dynasm!(self.mc ; .arch aarch64 ; =>done);
+    }
+
+    /// Headerless fixed-size nursery allocation.  `size` excludes any GC
+    /// header; result is the old nursery base.
+    fn genop_call_malloc_nursery_headerless(&mut self, op: &Op) {
+        let size_ref = op.arg(0).to_opref();
+        let size = size_ref.inline_const_bits().unwrap_or_else(|| {
+            self.constants
+                .get(&size_ref.raw())
+                .map(|c| c.as_raw_i64())
+                .unwrap_or(size_ref.raw() as i64)
+        });
+        let (nf_addr, nt_addr) = crate::runner::dynasm_nursery_addrs();
+        if nf_addr == 0 || nt_addr == 0 {
+            self.emit_mov_imm64(0, size);
+            self.emit_mov_imm64(
+                2,
+                crate::runner::dynasm_nursery_slowpath_headerless as *const () as i64,
+            );
+            self.emit_malloc_slowpath_helper_call(2);
+            self.reload_frame_if_necessary();
+            return;
+        }
+
+        self.emit_mov_imm64(2, nf_addr as i64);
+        dynasm!(self.mc ; .arch aarch64 ; ldr x0, [x2]);
+
+        if size < 4096 {
+            let sz = size as u32;
+            dynasm!(self.mc ; .arch aarch64 ; add x1, x0, sz);
+        } else {
+            self.emit_mov_imm64(1, size);
+            dynasm!(self.mc ; .arch aarch64 ; add x1, x0, x1);
+        }
+
+        self.emit_mov_imm64(3, nt_addr as i64);
+        dynasm!(self.mc ; .arch aarch64 ; ldr x3, [x3]);
+        dynasm!(self.mc ; .arch aarch64 ; cmp x1, x3);
+
+        let slow_path = self.mc.new_dynamic_label();
+        let done = self.mc.new_dynamic_label();
+        dynasm!(self.mc ; .arch aarch64 ; b.hi =>slow_path);
+
+        self.emit_mov_imm64(2, nf_addr as i64);
+        dynasm!(self.mc ; .arch aarch64
+            ; str x1, [x2]       // *nursery_free = new_free
+            ; b =>done
+        );
+
+        dynasm!(self.mc ; .arch aarch64 ; =>slow_path);
+        let base_ofs = crate::jitframe::FIRST_ITEM_OFFSET as i32;
+        dynasm!(self.mc ; .arch aarch64
+            ; stp x2, x3, [x29, base_ofs + 2 * 8]
+            ; stp x4, x5, [x29, base_ofs + 4 * 8]
+            ; stp x6, x7, [x29, base_ofs + 6 * 8]
+            ; stp x8, x9, [x29, base_ofs + 8 * 8]
+            ; stp x10, x11, [x29, base_ofs + 10 * 8]
+            ; stp x12, x13, [x29, base_ofs + 12 * 8]
+            ; stp x19, x20, [x29, base_ofs + 14 * 8]
+            ; stp x21, x22, [x29, base_ofs + 16 * 8]
+        );
+        if let Some(gcmap) = self.pending_malloc_nursery_gcmap {
+            self.push_gcmap(gcmap as *mut usize);
+        } else {
+            let gcmap_ofs = crate::jitframe::JF_GCMAP_OFS as u32;
+            dynasm!(self.mc ; .arch aarch64 ; str xzr, [x29, gcmap_ofs]);
+        }
+        self.emit_mov_imm64(0, size);
+        self.emit_mov_imm64(
+            2,
+            crate::runner::dynasm_nursery_slowpath_headerless as *const () as i64,
+        );
+        self.emit_malloc_slowpath_helper_call(2);
+        self.reload_frame_if_necessary();
+        let gcmap_ofs = crate::jitframe::JF_GCMAP_OFS as u32;
+        dynasm!(self.mc ; .arch aarch64 ; str xzr, [x29, gcmap_ofs]);
+        let base_ofs_r = crate::jitframe::FIRST_ITEM_OFFSET as i32;
+        dynasm!(self.mc ; .arch aarch64
+            ; ldp x2, x3, [x29, base_ofs_r + 2 * 8]
+            ; ldp x4, x5, [x29, base_ofs_r + 4 * 8]
+            ; ldp x6, x7, [x29, base_ofs_r + 6 * 8]
+            ; ldp x8, x9, [x29, base_ofs_r + 8 * 8]
+            ; ldp x10, x11, [x29, base_ofs_r + 10 * 8]
+            ; ldp x12, x13, [x29, base_ofs_r + 12 * 8]
+            ; ldp x19, x20, [x29, base_ofs_r + 14 * 8]
+            ; ldp x21, x22, [x29, base_ofs_r + 16 * 8]
+        );
         self.emit_propagate_memory_error_if_null(0);
 
         dynasm!(self.mc ; .arch aarch64 ; =>done);

--- a/majit/majit-backend-dynasm/src/regalloc.rs
+++ b/majit/majit-backend-dynasm/src/regalloc.rs
@@ -2858,7 +2858,9 @@ impl<'a> RegAlloc<'a> {
             OpCode::CondCallValueI | OpCode::CondCallValueR => {
                 self.consider_raw_call_like_j2(dst, args, op, i, output, SAVE_DEFAULT_REGS);
             }
-            OpCode::CallMallocNursery => self.consider_call_malloc_nursery_j2(dst, args, i, output),
+            OpCode::CallMallocNursery | OpCode::CallMallocNurseryHeaderless => {
+                self.consider_call_malloc_nursery_j2(dst, args, i, output)
+            }
             OpCode::CallMallocNurseryVarsizeFrame => {
                 self.consider_call_malloc_nursery_varsize_frame_j2(dst, args, i, output);
             }
@@ -3333,7 +3335,7 @@ impl<'a> RegAlloc<'a> {
                 self.consider_raw_call_like(op, i, output, SAVE_DEFAULT_REGS);
             }
             // aarch64/regalloc.py:958 prepare_op_call_malloc_nursery
-            OpCode::CallMallocNursery => {
+            OpCode::CallMallocNursery | OpCode::CallMallocNurseryHeaderless => {
                 self.consider_call_malloc_nursery(op, i, output);
             }
             OpCode::CallMallocNurseryVarsizeFrame => {

--- a/majit/majit-backend-dynasm/src/runner.rs
+++ b/majit/majit-backend-dynasm/src/runner.rs
@@ -678,6 +678,22 @@ pub extern "C" fn dynasm_nursery_slowpath(total_size: u64) -> u64 {
     ptr
 }
 
+/// Headerless nursery overflow slow path.
+///
+/// `size` is the exact allocation size.  Returns the allocation base,
+/// matching the headerless fast path.
+pub extern "C" fn dynasm_nursery_slowpath_headerless(size: u64) -> u64 {
+    let ptr = with_dynasm_active_gc_mut(|gc| gc.alloc_nursery(size as usize).0 as u64)
+        .unwrap_or_else(|| unsafe { libc::calloc(1, size as usize) as u64 });
+    if majit_ir::debug::have_debug_prints() {
+        majit_ir::debug::log_one(
+            "jit-backend",
+            &format!("nursery-headerless size={size} base=0x{ptr:x}"),
+        );
+    }
+    ptr
+}
+
 /// malloc_cond_varsize_frame slow path for JITFRAME allocation.
 ///
 /// `frame_size` is `jfi_frame_size`: bytes from the JITFRAME payload base
@@ -2031,6 +2047,10 @@ impl Backend for DynasmBackend {
         let malloc_slowpath_fixed = self
             .arch_cpu_ext
             .ensure_malloc_slowpath_fixed(&self.descr_attachments);
+        #[cfg(target_arch = "x86_64")]
+        let malloc_slowpath_headerless = self
+            .arch_cpu_ext
+            .ensure_malloc_slowpath_headerless(&self.descr_attachments);
         let mut asm = Asm::new(
             trace_id,
             header_pc,
@@ -2043,6 +2063,8 @@ impl Backend for DynasmBackend {
             cpu_handle,
             #[cfg(target_arch = "x86_64")]
             malloc_slowpath_fixed,
+            #[cfg(target_arch = "x86_64")]
+            malloc_slowpath_headerless,
             inputargs,
             &prepared_ops,
         );
@@ -2273,6 +2295,10 @@ impl Backend for DynasmBackend {
         let malloc_slowpath_fixed = self
             .arch_cpu_ext
             .ensure_malloc_slowpath_fixed(&self.descr_attachments);
+        #[cfg(target_arch = "x86_64")]
+        let malloc_slowpath_headerless = self
+            .arch_cpu_ext
+            .ensure_malloc_slowpath_headerless(&self.descr_attachments);
         let mut asm = Asm::new(
             trace_id,
             0,
@@ -2285,6 +2311,8 @@ impl Backend for DynasmBackend {
             cpu_handle,
             #[cfg(target_arch = "x86_64")]
             malloc_slowpath_fixed,
+            #[cfg(target_arch = "x86_64")]
+            malloc_slowpath_headerless,
             inputargs,
             &prepared_ops,
         );
@@ -3591,6 +3619,8 @@ impl Backend for DynasmBackend {
                 .ensure_propagate_exception_path(&self.descr_attachments);
             self.arch_cpu_ext
                 .ensure_malloc_slowpath_fixed(&self.descr_attachments);
+            self.arch_cpu_ext
+                .ensure_malloc_slowpath_headerless(&self.descr_attachments);
         }
     }
 

--- a/majit/majit-backend-dynasm/src/runner.rs
+++ b/majit/majit-backend-dynasm/src/runner.rs
@@ -681,9 +681,10 @@ pub extern "C" fn dynasm_nursery_slowpath(total_size: u64) -> u64 {
 /// Headerless nursery overflow slow path.
 ///
 /// `size` is the exact allocation size.  Returns the allocation base,
-/// matching the headerless fast path.
+/// matching the headerless fast path.  Headered collectors such as MiniMarkGC
+/// are not headerless-aware and must fail via `alloc_nursery_headerless`.
 pub extern "C" fn dynasm_nursery_slowpath_headerless(size: u64) -> u64 {
-    let ptr = with_dynasm_active_gc_mut(|gc| gc.alloc_nursery(size as usize).0 as u64)
+    let ptr = with_dynasm_active_gc_mut(|gc| gc.alloc_nursery_headerless(size as usize).0 as u64)
         .unwrap_or_else(|| unsafe { libc::calloc(1, size as usize) as u64 });
     if majit_ir::debug::have_debug_prints() {
         majit_ir::debug::log_one(

--- a/majit/majit-backend-dynasm/src/x86/assembler.rs
+++ b/majit/majit-backend-dynasm/src/x86/assembler.rs
@@ -8098,6 +8098,16 @@ impl<'a> Assembler386<'a> {
 
     /// Headerless fixed-size nursery allocation.  `size` excludes any GC
     /// header; result is the old nursery base.
+    ///
+    /// The fast path raw-bumps `dynasm_nursery_addrs()`, so it is correct only
+    /// when the active dynasm GC is headerless-aware — its nursery must yield a
+    /// raw base carrying no `GcHeader` (aheui's `NurseryGcAllocator`, whose
+    /// nursery is the aheui node arena collected by aheui's own copying node
+    /// GC).  A headered collector such as MiniMarkGC must never back this op:
+    /// its nursery walk reads a `GcHeader` at `base - GcHeader::SIZE`, which a
+    /// raw base lacks.  The overflow slowpath enforces this via
+    /// `alloc_nursery_headerless`'s panicking default; the fast path relies on
+    /// the same invariant being upheld by whoever declares `headerless_structs`.
     fn genop_call_malloc_nursery_headerless(&mut self, op: &Op, result_loc: Option<&Loc>) {
         let size_ref = op.arg(0).to_opref();
         let size = size_ref.inline_const_bits().unwrap_or_else(|| {

--- a/majit/majit-backend-dynasm/src/x86/assembler.rs
+++ b/majit/majit-backend-dynasm/src/x86/assembler.rs
@@ -419,6 +419,25 @@ pub(crate) fn build_malloc_slowpath_fixed(
     (buffer, ptr)
 }
 
+pub(crate) fn build_malloc_slowpath_headerless(
+    cpu_handle: &crate::guard::CpuDescrHandle,
+    propagate_path: usize,
+) -> (ExecutableBuffer, usize) {
+    let _ = cpu_handle;
+    let mut asm = Assembler::new().expect("malloc_slowpath_headerless: new Assembler");
+
+    dynasm!(asm ; .arch x64 ; sub rdx, rcx);
+
+    let slowpath_fn = crate::runner::dynasm_nursery_slowpath_headerless as *const () as i64;
+    build_malloc_slowpath_body(&mut asm, slowpath_fn, propagate_path);
+
+    let buffer = asm
+        .finalize()
+        .expect("malloc_slowpath_headerless: finalize");
+    let ptr = crate::codebuf::buffer_ptr(&buffer) as usize;
+    (buffer, ptr)
+}
+
 /// Body of the single PyPy `malloc_slowpath` trampoline used by both
 /// `CallMallocNursery` (fixed-size object alloc) and
 /// `CallMallocNurseryVarsizeFrame` (JITFRAME alloc).  Emits the
@@ -860,6 +879,8 @@ pub struct Assembler386<'a> {
     /// passed in at construction time so the emit path bakes it as a
     /// 64-bit immediate without re-touching the backend.
     malloc_slowpath_fixed: usize,
+    /// Headerless fixed-size nursery malloc slowpath trampoline.
+    malloc_slowpath_headerless: usize,
     /// `assembler.py:1545` `genop_load_from_gc_table`: base address of
     /// this loop's per-loop `GcTable` slot array. Baked as a 64-bit
     /// immediate by the `LoadFromGcTable` genop; 0 when the trace
@@ -965,6 +986,7 @@ impl<'a> Assembler386<'a> {
         attached_descrs: crate::guard::AttachedDescrPtrs,
         cpu_handle: crate::guard::CpuDescrHandle,
         malloc_slowpath_fixed: usize,
+        malloc_slowpath_headerless: usize,
         inputargs: &'a [InputArg],
         operations: &'a [Op],
     ) -> Self {
@@ -1010,6 +1032,7 @@ impl<'a> Assembler386<'a> {
             frame_depth_to_patch: Vec::new(),
             jump_target_frame_depth: 0,
             malloc_slowpath_fixed,
+            malloc_slowpath_headerless,
             gc_table_base: 0,
         }
     }
@@ -4259,6 +4282,9 @@ impl<'a> Assembler386<'a> {
             // ── Allocation (rewritten by GC rewriter) ──
             OpCode::CallMallocNursery => {
                 self.genop_call_malloc_nursery(op, result_loc);
+            }
+            OpCode::CallMallocNurseryHeaderless => {
+                self.genop_call_malloc_nursery_headerless(op, result_loc);
             }
             // assembler.py:2567 malloc_cond_varsize_frame parity.
             // The varsize_frame call site shares the entire slowpath
@@ -8064,6 +8090,82 @@ impl<'a> Assembler386<'a> {
             // RAX (now caller-live) instead of the object pointer.
             let Some(Loc::Reg(r)) = result_loc else {
                 panic!("CallMallocNursery result_loc must be a register; got {result_loc:?}");
+            };
+            let rv = r.value;
+            dynasm!(self.mc ; .arch x64 ; mov [rbp + offset], Rq(rv));
+        }
+    }
+
+    /// Headerless fixed-size nursery allocation.  `size` excludes any GC
+    /// header; result is the old nursery base.
+    fn genop_call_malloc_nursery_headerless(&mut self, op: &Op, result_loc: Option<&Loc>) {
+        let size_ref = op.arg(0).to_opref();
+        let size = size_ref.inline_const_bits().unwrap_or_else(|| {
+            self.constants
+                .get(&size_ref.raw())
+                .map(|c| c.as_raw_i64())
+                .unwrap_or(size_ref.raw() as i64)
+        });
+        let (nf_addr, nt_addr) = crate::runner::dynasm_nursery_addrs();
+        let nf = nf_addr as i64;
+        let nt = nt_addr as i64;
+        let scratch = crate::regloc::X86_64_SCRATCH_REG.value;
+
+        dynasm!(self.mc ; .arch x64
+            ; mov Rq(scratch), QWORD nf
+            ; mov rcx, [Rq(scratch)]
+            ; lea rdx, [rcx + size as i32]
+            ; mov Rq(scratch), QWORD nt
+            ; cmp rdx, [Rq(scratch)]
+        );
+
+        let slow_path = self.mc.new_dynamic_label();
+        let done = self.mc.new_dynamic_label();
+        dynasm!(self.mc ; .arch x64 ; ja =>slow_path);
+
+        let result_reg = match result_loc {
+            Some(Loc::Reg(r)) => r.value,
+            _ => crate::regloc::ECX.value,
+        };
+        dynasm!(self.mc ; .arch x64
+            ; mov Rq(scratch), QWORD nf
+            ; mov [Rq(scratch)], rdx
+        );
+        if result_reg != crate::regloc::ECX.value {
+            dynasm!(self.mc ; .arch x64 ; mov Rq(result_reg), rcx);
+        }
+        dynasm!(self.mc ; .arch x64 ; jmp =>done);
+
+        dynasm!(self.mc ; .arch x64 ; =>slow_path);
+        let gcmap_ofs = crate::jitframe::JF_GCMAP_OFS;
+        if let Some(gcmap) = self.pending_malloc_nursery_gcmap {
+            self.push_gcmap(gcmap as *mut usize);
+        } else {
+            dynasm!(self.mc ; .arch x64 ; mov QWORD [rbp + gcmap_ofs], 0);
+        }
+        let helper_addr = self.malloc_slowpath_headerless as i64;
+        let call_scratch = crate::regloc::X86_64_SCRATCH_REG.value;
+        dynasm!(self.mc ; .arch x64
+            ; mov Rq(call_scratch), QWORD helper_addr
+            ; call Rq(call_scratch)
+        );
+        if let Some(Loc::Reg(r)) = result_loc {
+            if r.value != crate::regloc::ECX.value {
+                let rv = r.value;
+                dynasm!(self.mc ; .arch x64 ; mov Rq(rv), rcx);
+            }
+        }
+        let _ = gcmap_ofs;
+
+        dynasm!(self.mc ; .arch x64 ; =>done);
+        let pos = op.pos.get();
+        if !pos.is_none() {
+            let slot = self.allocate_slot(pos);
+            let offset = Self::slot_offset(slot);
+            let Some(Loc::Reg(r)) = result_loc else {
+                panic!(
+                    "CallMallocNurseryHeaderless result_loc must be a register; got {result_loc:?}"
+                );
             };
             let rv = r.value;
             dynasm!(self.mc ; .arch x64 ; mov [rbp + offset], Rq(rv));

--- a/majit/majit-backend-dynasm/src/x86/assembler.rs
+++ b/majit/majit-backend-dynasm/src/x86/assembler.rs
@@ -8111,17 +8111,28 @@ impl<'a> Assembler386<'a> {
         let nt = nt_addr as i64;
         let scratch = crate::regloc::X86_64_SCRATCH_REG.value;
 
-        dynasm!(self.mc ; .arch x64
-            ; mov Rq(scratch), QWORD nf
-            ; mov rcx, [Rq(scratch)]
-            ; lea rdx, [rcx + size as i32]
-            ; mov Rq(scratch), QWORD nt
-            ; cmp rdx, [Rq(scratch)]
-        );
-
         let slow_path = self.mc.new_dynamic_label();
         let done = self.mc.new_dynamic_label();
-        dynasm!(self.mc ; .arch x64 ; ja =>slow_path);
+
+        if nf_addr == 0 || nt_addr == 0 {
+            // Mirror the headered inactive-nursery path without touching
+            // `[nf]`: seed the slowpath's `rdx - rcx` size contract directly.
+            dynasm!(self.mc ; .arch x64
+                ; xor ecx, ecx
+                ; mov rdx, QWORD size
+                ; jmp =>slow_path
+            );
+        } else {
+            dynasm!(self.mc ; .arch x64
+                ; mov Rq(scratch), QWORD nf
+                ; mov rcx, [Rq(scratch)]
+                ; lea rdx, [rcx + size as i32]
+                ; mov Rq(scratch), QWORD nt
+                ; cmp rdx, [Rq(scratch)]
+            );
+
+            dynasm!(self.mc ; .arch x64 ; ja =>slow_path);
+        }
 
         let result_reg = match result_loc {
             Some(Loc::Reg(r)) => r.value,

--- a/majit/majit-backend-dynasm/src/x86/cpu_ext.rs
+++ b/majit/majit-backend-dynasm/src/x86/cpu_ext.rs
@@ -35,6 +35,8 @@ pub(crate) struct X86CpuExt {
     /// this struct.
     malloc_slowpath_fixed: Option<usize>,
     _malloc_slowpath_fixed_buffer: Option<ExecutableBuffer>,
+    malloc_slowpath_headerless: Option<usize>,
+    _malloc_slowpath_headerless_buffer: Option<ExecutableBuffer>,
     /// `assembler.py:344 self.propagate_exception_path` parity.
     /// Standalone trampoline that the malloc slowpath (and, in PyPy,
     /// the stack check slowpath) JMPs to on OOM / propagate.
@@ -47,6 +49,8 @@ impl X86CpuExt {
         Self {
             malloc_slowpath_fixed: None,
             _malloc_slowpath_fixed_buffer: None,
+            malloc_slowpath_headerless: None,
+            _malloc_slowpath_headerless_buffer: None,
             propagate_exception_path: None,
             _propagate_exception_path_buffer: None,
         }
@@ -102,6 +106,26 @@ impl X86CpuExt {
         addr
     }
 
+    pub(crate) fn ensure_malloc_slowpath_headerless(
+        &mut self,
+        cpu_handle: &CpuDescrHandle,
+    ) -> usize {
+        if let Some(addr) = self.malloc_slowpath_headerless {
+            return addr;
+        }
+        let propagate_path = self.ensure_propagate_exception_path(cpu_handle);
+        let (buffer, addr) =
+            super::assembler::build_malloc_slowpath_headerless(cpu_handle, propagate_path);
+        debug_assert!(
+            addr != 0,
+            "build_malloc_slowpath_headerless returned NULL entry address — \
+             dynasm finalize is expected to yield a non-zero buffer_ptr"
+        );
+        self._malloc_slowpath_headerless_buffer = Some(buffer);
+        self.malloc_slowpath_headerless = Some(addr);
+        addr
+    }
+
     /// Whether either trampoline that bakes `propagate_exception_descr`
     /// as an immediate has already been materialised.  Used by
     /// `DynasmBackend::set_propagate_exception_descr` to refuse a
@@ -115,6 +139,8 @@ impl X86CpuExt {
     /// upholds the same invariant by panicking instead of dropping
     /// the buffer.
     pub(crate) fn has_propagate_dependent_caches(&self) -> bool {
-        self.malloc_slowpath_fixed.is_some() || self.propagate_exception_path.is_some()
+        self.malloc_slowpath_fixed.is_some()
+            || self.malloc_slowpath_headerless.is_some()
+            || self.propagate_exception_path.is_some()
     }
 }

--- a/majit/majit-backend-dynasm/src/x86/reghint.rs
+++ b/majit/majit-backend-dynasm/src/x86/reghint.rs
@@ -121,6 +121,7 @@ impl RegisterHints {
             }
             // reghint.py:123-128 consider_call_malloc_nursery + varsize variants
             OpCode::CallMallocNursery
+            | OpCode::CallMallocNurseryHeaderless
             | OpCode::CallMallocNurseryVarsize
             | OpCode::CallMallocNurseryVarsizeFrame => {
                 self.consider_call_malloc_nursery(longevity, op, position);

--- a/majit/majit-gc/src/lib.rs
+++ b/majit/majit-gc/src/lib.rs
@@ -150,6 +150,23 @@ pub trait GcAllocator: Send {
     /// Allocate a fixed-size object in the nursery.
     fn alloc_nursery(&mut self, size: usize) -> GcRef;
 
+    /// Allocate a HEADERLESS nursery object of exactly `size` bytes and return
+    /// the RAW base (no GcHeader, no type word), matching the JIT headerless
+    /// fast-path contract. Only a headerless-aware GC box may serve this.
+    /// `MiniMarkGC` is a headered collector: its nursery walk reads a GcHeader
+    /// at `obj - GcHeader::SIZE`, which a headerless object lacks, so it must
+    /// never serve a headerless allocation. The default panics to turn a future
+    /// misconfiguration (an interpreter that declares `headerless_structs` while
+    /// leaving MiniMarkGC as the active dynasm GC) into a loud failure instead of
+    /// a silently mis-based pointer + untraceable object.
+    fn alloc_nursery_headerless(&mut self, _size: usize) -> GcRef {
+        panic!(
+            "alloc_nursery_headerless called on a headerless-unaware GcAllocator \
+             (e.g. MiniMarkGC); headerless nursery allocation requires a \
+             headerless-aware active dynasm GC box"
+        );
+    }
+
     /// Allocate a fixed-size object with a known GC type id.
     fn alloc_nursery_typed(&mut self, type_id: u32, size: usize) -> GcRef {
         let _ = type_id;

--- a/majit/majit-gc/src/rewrite.rs
+++ b/majit/majit-gc/src/rewrite.rs
@@ -1011,6 +1011,11 @@ impl GcRewriterImpl {
 
         if descr.headerless() {
             let size = round_up(descr.size());
+            debug_assert!(
+                self.can_use_nursery(size),
+                "headerless NEW currently has only a nursery allocation path; \
+                 headerless structs must remain fixed-size and nursery-eligible"
+            );
             let result_pos = op.pos.get();
             st.emitting_an_operation_that_can_collect();
             let size_ref = st.const_int(size as i64);

--- a/majit/majit-gc/src/rewrite.rs
+++ b/majit/majit-gc/src/rewrite.rs
@@ -1011,26 +1011,31 @@ impl GcRewriterImpl {
 
         if descr.headerless() {
             let size = round_up(descr.size());
-            debug_assert!(
-                self.can_use_nursery(size),
-                "headerless NEW currently has only a nursery allocation path; \
-                 headerless structs must remain fixed-size and nursery-eligible"
-            );
-            // Headerless nursery allocations intentionally skip
-            // clear_gc_fields: there is no GC header/tid store, and the fast
-            // path exists for structs whose ref fields are fully initialized by
-            // immediate SETFIELD_GC ops before any can-collect operation.  A
-            // collector must never observe an uninitialized headerless ref
-            // field; keep new headerless users to that invariant instead of
-            // adding per-field zeroing here.
             let result_pos = op.pos.get();
-            st.emitting_an_operation_that_can_collect();
-            let size_ref = st.const_int(size as i64);
-            let malloc_op = mk_op(OpCode::CallMallocNurseryHeaderless, &[size_ref]);
-            let obj_ref = st.emit_result(malloc_op, result_pos);
+            let obj_ref = if self.can_use_nursery(size) {
+                // Headerless nursery allocations intentionally skip
+                // clear_gc_fields: there is no GC header/tid store, and the fast
+                // path exists for structs whose ref fields are fully initialized by
+                // immediate SETFIELD_GC ops before any can-collect operation.  A
+                // collector must never observe an uninitialized headerless ref
+                // field; keep new headerless users to that invariant instead of
+                // adding per-field zeroing here.
+                st.emitting_an_operation_that_can_collect();
+                let size_ref = st.const_int(size as i64);
+                let malloc_op = mk_op(OpCode::CallMallocNurseryHeaderless, &[size_ref]);
+                let obj_ref = st.emit_result(malloc_op, result_pos);
+                st.last_malloced_ref = obj_ref.clone();
+                st.remember_wb(&obj_ref);
+                obj_ref
+            } else {
+                // rewrite.py:884-886 parity: if nursery malloc is disallowed,
+                // decline to the same fixed-size non-nursery helper used by
+                // the headered branch below.  That helper takes the headered
+                // total size and stamps the type id itself.
+                let total_size = round_up(descr.size() + crate::header::GcHeader::SIZE);
+                self.gen_malloc_fixedsize(total_size, descr.type_id(), result_pos, st)
+            };
             st.record_result_mapping(result_pos, obj_ref.clone());
-            st.last_malloced_ref = obj_ref.clone();
-            st.remember_wb(&obj_ref);
             return;
         }
 
@@ -3155,6 +3160,7 @@ mod tests {
         size: usize,
         type_id: u32,
         vtable: usize,
+        headerless: bool,
         gc_fields: Vec<Arc<dyn FieldDescr>>,
     }
 
@@ -3179,6 +3185,9 @@ mod tests {
         }
         fn vtable(&self) -> usize {
             self.vtable
+        }
+        fn headerless(&self) -> bool {
+            self.headerless
         }
         fn gc_fielddescrs(&self) -> &[Arc<dyn FieldDescr>] {
             &self.gc_fields
@@ -3324,6 +3333,17 @@ mod tests {
             size,
             type_id,
             vtable: 0,
+            headerless: false,
+            gc_fields: Vec::new(),
+        })
+    }
+
+    fn headerless_size_descr(size: usize, type_id: u32) -> DescrRef {
+        Arc::new(TestSizeDescr {
+            size,
+            type_id,
+            vtable: 0,
+            headerless: true,
             gc_fields: Vec::new(),
         })
     }
@@ -3337,6 +3357,7 @@ mod tests {
             size,
             type_id,
             vtable: 0,
+            headerless: false,
             gc_fields,
         })
     }
@@ -3346,6 +3367,7 @@ mod tests {
             size,
             type_id,
             vtable,
+            headerless: false,
             gc_fields: Vec::new(),
         })
     }
@@ -3444,6 +3466,49 @@ mod tests {
                  for each constant it mints"
             );
         }
+    }
+
+    #[test]
+    fn test_headerless_new_declines_large_nursery_alloc() {
+        let rw = make_rewriter();
+        let payload_size = 8192;
+        let type_id = 77;
+        let ops = vec![Op::with_descr(
+            OpCode::New,
+            &[],
+            headerless_size_descr(payload_size, type_id),
+        )];
+
+        let (result, _constants, _gcrefs) =
+            rw.rewrite_for_gc_with_constants(&ops, &ConstMap::new());
+
+        assert_eq!(result.len(), 2);
+        assert_eq!(result[0].opcode, OpCode::CallR);
+        assert_eq!(result[1].opcode, OpCode::CheckMemoryError);
+        assert_eq!(
+            result[0]
+                .arg(0)
+                .to_opref()
+                .inline_const_bits()
+                .expect("malloc_big_fixedsize fn const"),
+            TEST_MALLOC_BIG_FIXEDSIZE_FN
+        );
+        assert_eq!(
+            result[0]
+                .arg(1)
+                .to_opref()
+                .inline_const_bits()
+                .expect("headered total size const"),
+            round_up(payload_size + crate::header::GcHeader::SIZE) as i64
+        );
+        assert_eq!(
+            result[0]
+                .arg(2)
+                .to_opref()
+                .inline_const_bits()
+                .expect("type id const"),
+            type_id as i64
+        );
     }
 
     // ── Test 2: NEW_ARRAY → CALL_MALLOC_NURSERY_VARSIZE ──

--- a/majit/majit-gc/src/rewrite.rs
+++ b/majit/majit-gc/src/rewrite.rs
@@ -1009,6 +1009,19 @@ impl GcRewriterImpl {
             .as_size_descr()
             .expect("NEW descr must be SizeDescr");
 
+        if descr.headerless() {
+            let size = round_up(descr.size());
+            let result_pos = op.pos.get();
+            st.emitting_an_operation_that_can_collect();
+            let size_ref = st.const_int(size as i64);
+            let malloc_op = mk_op(OpCode::CallMallocNurseryHeaderless, &[size_ref]);
+            let obj_ref = st.emit_result(malloc_op, result_pos);
+            st.record_result_mapping(result_pos, obj_ref.clone());
+            st.last_malloced_ref = obj_ref.clone();
+            st.remember_wb(&obj_ref);
+            return;
+        }
+
         // rewrite.py:474-484 handle_malloc_operation parity:
         // descr.size in RPython already includes the GC header (the
         // OBJECT type is built with `size = sizeof(header) + sizeof(fields)`).

--- a/majit/majit-gc/src/rewrite.rs
+++ b/majit/majit-gc/src/rewrite.rs
@@ -1016,6 +1016,13 @@ impl GcRewriterImpl {
                 "headerless NEW currently has only a nursery allocation path; \
                  headerless structs must remain fixed-size and nursery-eligible"
             );
+            // Headerless nursery allocations intentionally skip
+            // clear_gc_fields: there is no GC header/tid store, and the fast
+            // path exists for structs whose ref fields are fully initialized by
+            // immediate SETFIELD_GC ops before any can-collect operation.  A
+            // collector must never observe an uninitialized headerless ref
+            // field; keep new headerless users to that invariant instead of
+            // adding per-field zeroing here.
             let result_pos = op.pos.get();
             st.emitting_an_operation_that_can_collect();
             let size_ref = st.const_int(size as i64);

--- a/majit/majit-ir/src/descr.rs
+++ b/majit/majit-ir/src/descr.rs
@@ -1900,6 +1900,12 @@ pub trait Descr: Send + Sync + std::fmt::Debug {
         false
     }
 
+    /// Whether a virtual RHS stored to this field must be materialized at
+    /// guard time instead of being recorded in rd_pendingfields.
+    fn force_virtual_at_guard(&self) -> bool {
+        false
+    }
+
     /// compile.py: isinstance(resumekey, ResumeAtPositionDescr).
     /// Guards created during loop unrolling / short preamble inlining
     /// return true. When bridge compilation starts from such a guard,
@@ -2738,6 +2744,14 @@ pub trait SizeDescr: Descr {
     /// `vtable == 0`.
     fn is_gc_managed(&self) -> bool {
         true
+    }
+
+    /// Whether `NEW` for this descr should be rewritten to a headerless
+    /// nursery allocation.  Separate from `is_gc_managed()`: headerless
+    /// allocation changes the rewriter/backend malloc shape, while
+    /// `is_gc_managed()` gates runtime type-header guards.
+    fn headerless(&self) -> bool {
+        false
     }
 
     /// Vtable address, if is_object().
@@ -3614,6 +3628,7 @@ pub struct SimpleFieldDescr {
     /// FLAG_POINTER, FLAG_FLOAT, FLAG_SIGNED, FLAG_UNSIGNED, FLAG_STRUCT, FLAG_VOID.
     flag: ArrayFlag,
     virtualizable: bool,
+    force_virtual_at_guard: bool,
     /// descr.py:158 FieldDescr.index — slot position within the
     /// parent struct's `all_fielddescrs`.
     pub index_in_parent: usize,
@@ -3647,6 +3662,7 @@ impl Clone for SimpleFieldDescr {
             is_quasi_immutable: self.is_quasi_immutable,
             flag: self.flag,
             virtualizable: self.virtualizable,
+            force_virtual_at_guard: self.force_virtual_at_guard,
             index_in_parent: self.index_in_parent,
             parent_descr: self.parent_descr.clone(),
             vinfo: self.vinfo.clone(),
@@ -3677,6 +3693,7 @@ impl SimpleFieldDescr {
             is_quasi_immutable: false,
             flag,
             virtualizable: false,
+            force_virtual_at_guard: false,
             index_in_parent: 0,
             parent_descr: None,
             vinfo: None,
@@ -3707,6 +3724,7 @@ impl SimpleFieldDescr {
             is_quasi_immutable: false,
             flag,
             virtualizable: false,
+            force_virtual_at_guard: false,
             index_in_parent: 0,
             parent_descr: None,
             vinfo: None,
@@ -3748,6 +3766,11 @@ impl SimpleFieldDescr {
 
     pub fn with_virtualizable(mut self, virtualizable: bool) -> Self {
         self.virtualizable = virtualizable;
+        self
+    }
+
+    pub fn with_force_virtual_at_guard(mut self, force_virtual_at_guard: bool) -> Self {
+        self.force_virtual_at_guard = force_virtual_at_guard;
         self
     }
 
@@ -3805,6 +3828,9 @@ impl Descr for SimpleFieldDescr {
     }
     fn is_virtualizable(&self) -> bool {
         self.virtualizable
+    }
+    fn force_virtual_at_guard(&self) -> bool {
+        self.force_virtual_at_guard
     }
     fn as_field_descr(&self) -> Option<&dyn FieldDescr> {
         Some(self)
@@ -3882,6 +3908,9 @@ pub struct SimpleSizeDescr {
     /// `is_object()` (`vtable != 0`) because a `new_struct` GC struct
     /// also has `vtable == 0`.
     is_gc_managed: bool,
+    /// Explicit allocation-shape bit for `NEW` rewriting.  Defaults false:
+    /// normal JIT-GC structs are headered unless an emitter opts in.
+    headerless: bool,
     /// descr.py:72 `self.all_fielddescrs = all_fielddescrs`.
     all_fielddescrs: Vec<Arc<dyn FieldDescr>>,
     /// descr.py:71 `self.gc_fielddescrs = gc_fielddescrs`.
@@ -3902,6 +3931,7 @@ impl Clone for SimpleSizeDescr {
             is_immutable: self.is_immutable,
             vtable: self.vtable,
             is_gc_managed: self.is_gc_managed,
+            headerless: self.headerless,
             all_fielddescrs: self.all_fielddescrs.clone(),
             gc_fielddescrs: self.gc_fielddescrs.clone(),
         }
@@ -3919,6 +3949,7 @@ impl SimpleSizeDescr {
             is_immutable: false,
             vtable: 0,
             is_gc_managed: true,
+            headerless: false,
             all_fielddescrs: Vec::new(),
             gc_fielddescrs: Vec::new(),
         }
@@ -3934,6 +3965,7 @@ impl SimpleSizeDescr {
             is_immutable: false,
             vtable,
             is_gc_managed: true,
+            headerless: false,
             all_fielddescrs: Vec::new(),
             gc_fielddescrs: Vec::new(),
         }
@@ -3952,6 +3984,11 @@ impl SimpleSizeDescr {
     /// `GuardGcType` must not be emitted for it).
     pub fn set_gc_managed(&mut self, is_gc_managed: bool) {
         self.is_gc_managed = is_gc_managed;
+    }
+
+    /// Override the allocation-shape flag (default `false`).
+    pub fn set_headerless(&mut self, headerless: bool) {
+        self.headerless = headerless;
     }
 
     /// descr.py:123-126 — `get_size_descr` calls
@@ -4020,6 +4057,9 @@ impl SizeDescr for SimpleSizeDescr {
     fn is_gc_managed(&self) -> bool {
         self.is_gc_managed
     }
+    fn headerless(&self) -> bool {
+        self.headerless
+    }
     fn vtable(&self) -> usize {
         self.vtable
     }
@@ -4042,6 +4082,7 @@ pub struct SimpleFieldDescrSpec {
     /// descr.py:151: FieldDescr.flag — get_type_flag(FIELDTYPE).
     pub flag: ArrayFlag,
     pub virtualizable: bool,
+    pub force_virtual_at_guard: bool,
     pub index_in_parent: usize,
 }
 
@@ -4071,6 +4112,28 @@ pub fn make_simple_descr_group_keyed(
     is_gc_managed: bool,
     field_specs: &[SimpleFieldDescrSpec],
 ) -> SimpleDescrGroup {
+    make_simple_descr_group_keyed_with_headerless(
+        index,
+        size,
+        type_id,
+        cache_key,
+        vtable,
+        is_gc_managed,
+        false,
+        field_specs,
+    )
+}
+
+pub fn make_simple_descr_group_keyed_with_headerless(
+    index: u32,
+    size: usize,
+    type_id: u32,
+    cache_key: u64,
+    vtable: usize,
+    is_gc_managed: bool,
+    headerless: bool,
+    field_specs: &[SimpleFieldDescrSpec],
+) -> SimpleDescrGroup {
     let group = make_simple_descr_group_inner(
         index,
         size,
@@ -4078,6 +4141,7 @@ pub fn make_simple_descr_group_keyed(
         cache_key,
         vtable,
         is_gc_managed,
+        headerless,
         field_specs,
     );
     let struct_key = LLType::struct_key(cache_key);
@@ -4124,6 +4188,7 @@ fn make_simple_descr_group_inner(
     cache_key: u64,
     vtable: usize,
     is_gc_managed: bool,
+    headerless: bool,
     field_specs: &[SimpleFieldDescrSpec],
 ) -> SimpleDescrGroup {
     let field_descrs_cell = std::cell::RefCell::new(Vec::<Arc<SimpleFieldDescr>>::new());
@@ -4145,6 +4210,7 @@ fn make_simple_descr_group_inner(
                     is_quasi_immutable: spec.is_quasi_immutable,
                     flag: spec.flag,
                     virtualizable: spec.virtualizable,
+                    force_virtual_at_guard: spec.force_virtual_at_guard,
                     index_in_parent: spec.index_in_parent,
                     parent_descr: Some(parent_descr.clone()),
                     vinfo: None,
@@ -4167,6 +4233,7 @@ fn make_simple_descr_group_inner(
         // landing on a stale slot via `type_id` widening.
         sd.set_cache_key(cache_key);
         sd.set_gc_managed(is_gc_managed);
+        sd.set_headerless(headerless);
         sd.with_all_fielddescrs(all_fielddescrs)
     });
     let field_descrs = field_descrs_cell.into_inner();
@@ -4193,7 +4260,8 @@ pub fn make_simple_descr_group(
     // No-cache legacy mint sites are JIT-allocated structs; default
     // `is_gc_managed = true` (the raw-struct path goes through the keyed
     // factory with an explicit flag).
-    let group = make_simple_descr_group_inner(index, size, type_id, 0, vtable, true, field_specs);
+    let group =
+        make_simple_descr_group_inner(index, size, type_id, 0, vtable, true, false, field_specs);
     // descr.py:236-247 `get_size_descr` cache-miss branch — snapshot
     // order only.
     crate::descr_registry::register_size(group.size_descr.clone() as DescrRef);
@@ -4803,6 +4871,7 @@ pub fn make_vtable_field_descr() -> DescrRef {
                     is_quasi_immutable: false,
                     flag: ArrayFlag::Signed,
                     virtualizable: false,
+                    force_virtual_at_guard: false,
                     index_in_parent: 0,
                     parent_descr: Some(parent_descr),
                     vinfo: None,

--- a/majit/majit-ir/src/descr.rs
+++ b/majit/majit-ir/src/descr.rs
@@ -1900,12 +1900,6 @@ pub trait Descr: Send + Sync + std::fmt::Debug {
         false
     }
 
-    /// Whether a virtual RHS stored to this field must be materialized at
-    /// guard time instead of being recorded in rd_pendingfields.
-    fn force_virtual_at_guard(&self) -> bool {
-        false
-    }
-
     /// compile.py: isinstance(resumekey, ResumeAtPositionDescr).
     /// Guards created during loop unrolling / short preamble inlining
     /// return true. When bridge compilation starts from such a guard,
@@ -3628,7 +3622,6 @@ pub struct SimpleFieldDescr {
     /// FLAG_POINTER, FLAG_FLOAT, FLAG_SIGNED, FLAG_UNSIGNED, FLAG_STRUCT, FLAG_VOID.
     flag: ArrayFlag,
     virtualizable: bool,
-    force_virtual_at_guard: bool,
     /// descr.py:158 FieldDescr.index — slot position within the
     /// parent struct's `all_fielddescrs`.
     pub index_in_parent: usize,
@@ -3662,7 +3655,6 @@ impl Clone for SimpleFieldDescr {
             is_quasi_immutable: self.is_quasi_immutable,
             flag: self.flag,
             virtualizable: self.virtualizable,
-            force_virtual_at_guard: self.force_virtual_at_guard,
             index_in_parent: self.index_in_parent,
             parent_descr: self.parent_descr.clone(),
             vinfo: self.vinfo.clone(),
@@ -3693,7 +3685,6 @@ impl SimpleFieldDescr {
             is_quasi_immutable: false,
             flag,
             virtualizable: false,
-            force_virtual_at_guard: false,
             index_in_parent: 0,
             parent_descr: None,
             vinfo: None,
@@ -3724,7 +3715,6 @@ impl SimpleFieldDescr {
             is_quasi_immutable: false,
             flag,
             virtualizable: false,
-            force_virtual_at_guard: false,
             index_in_parent: 0,
             parent_descr: None,
             vinfo: None,
@@ -3766,11 +3756,6 @@ impl SimpleFieldDescr {
 
     pub fn with_virtualizable(mut self, virtualizable: bool) -> Self {
         self.virtualizable = virtualizable;
-        self
-    }
-
-    pub fn with_force_virtual_at_guard(mut self, force_virtual_at_guard: bool) -> Self {
-        self.force_virtual_at_guard = force_virtual_at_guard;
         self
     }
 
@@ -3828,9 +3813,6 @@ impl Descr for SimpleFieldDescr {
     }
     fn is_virtualizable(&self) -> bool {
         self.virtualizable
-    }
-    fn force_virtual_at_guard(&self) -> bool {
-        self.force_virtual_at_guard
     }
     fn as_field_descr(&self) -> Option<&dyn FieldDescr> {
         Some(self)
@@ -4082,7 +4064,6 @@ pub struct SimpleFieldDescrSpec {
     /// descr.py:151: FieldDescr.flag — get_type_flag(FIELDTYPE).
     pub flag: ArrayFlag,
     pub virtualizable: bool,
-    pub force_virtual_at_guard: bool,
     pub index_in_parent: usize,
 }
 
@@ -4210,7 +4191,6 @@ fn make_simple_descr_group_inner(
                     is_quasi_immutable: spec.is_quasi_immutable,
                     flag: spec.flag,
                     virtualizable: spec.virtualizable,
-                    force_virtual_at_guard: spec.force_virtual_at_guard,
                     index_in_parent: spec.index_in_parent,
                     parent_descr: Some(parent_descr.clone()),
                     vinfo: None,
@@ -4871,7 +4851,6 @@ pub fn make_vtable_field_descr() -> DescrRef {
                     is_quasi_immutable: false,
                     flag: ArrayFlag::Signed,
                     virtualizable: false,
-                    force_virtual_at_guard: false,
                     index_in_parent: 0,
                     parent_descr: Some(parent_descr),
                     vinfo: None,

--- a/majit/majit-ir/src/resoperation.rs
+++ b/majit/majit-ir/src/resoperation.rs
@@ -2107,6 +2107,7 @@ pub enum OpCode {
     CallPureN,
     CheckMemoryError,
     CallMallocNursery,
+    CallMallocNurseryHeaderless,
     CallMallocNurseryVarsize,
     CallMallocNurseryVarsizeFrame,
     RecordKnownResult,
@@ -3078,6 +3079,7 @@ static OPARITY: [Option<u8>; OPCODE_COUNT] = {
     // Calls: all variadic (None) - default
     set!(CheckMemoryError, 1);
     set!(CallMallocNursery, 1);
+    set!(CallMallocNurseryHeaderless, 1);
     set!(CallMallocNurseryVarsizeFrame, 1);
     // Overflow
     set!(IntAddOvf, 2);
@@ -3433,6 +3435,7 @@ static OPRESTYPE: [Type; OPCODE_COUNT] = {
         CallLoopinvariantR,
         ThreadlocalrefGet,
         CallMallocNursery,
+        CallMallocNurseryHeaderless,
         CallMallocNurseryVarsize,
         CallMallocNurseryVarsizeFrame,
         SaveException
@@ -3683,6 +3686,7 @@ static OPNAME: [&str; OPCODE_COUNT] = {
         CallPureN,
         CheckMemoryError,
         CallMallocNursery,
+        CallMallocNurseryHeaderless,
         CallMallocNurseryVarsize,
         CallMallocNurseryVarsizeFrame,
         RecordKnownResult,
@@ -3872,6 +3876,7 @@ mod tests {
             OpCode::IncrementDebugCounter,
             OpCode::LeavePortalFrame,
             OpCode::CallMallocNursery,
+            OpCode::CallMallocNurseryHeaderless,
             OpCode::CallMallocNurseryVarsizeFrame,
         ];
         for op in &unary_ops {
@@ -4128,6 +4133,7 @@ mod tests {
             OpCode::CondCallValueR,
             OpCode::ThreadlocalrefGet,
             OpCode::CallMallocNursery,
+            OpCode::CallMallocNurseryHeaderless,
             OpCode::CallMallocNurseryVarsize,
             OpCode::CallMallocNurseryVarsizeFrame,
             OpCode::SaveException,

--- a/majit/majit-macros/src/jit_interp/codegen_trace.rs
+++ b/majit/majit-macros/src/jit_interp/codegen_trace.rs
@@ -38,7 +38,6 @@ pub fn generate_trace_fn(config: &JitInterpConfig, func: &ItemFn) -> TokenStream
         &config.ref_fields,
         &config.call_returns,
         &config.headerless_structs,
-        &config.force_at_guard,
         &config.native_int_binops,
         &config.native_tag_small,
         config.split_dispatch,

--- a/majit/majit-macros/src/jit_interp/codegen_trace.rs
+++ b/majit/majit-macros/src/jit_interp/codegen_trace.rs
@@ -37,6 +37,8 @@ pub fn generate_trace_fn(config: &JitInterpConfig, func: &ItemFn) -> TokenStream
         &config.pool_arrays,
         &config.ref_fields,
         &config.call_returns,
+        &config.headerless_structs,
+        &config.force_at_guard,
         &config.native_int_binops,
         &config.native_tag_small,
         config.split_dispatch,

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/helpers.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/helpers.rs
@@ -480,6 +480,13 @@ pub(super) fn opcode_for_binop(op: &BinOp) -> Option<Ident> {
         BinOp::BitAnd(_) => "IntAnd",
         BinOp::BitOr(_) => "IntOr",
         BinOp::BitXor(_) => "IntXor",
+        // Logical `&&`/`||` on boolean operands (Rust requires `bool`, whose
+        // lowered register holds 0/1) is bit-for-bit the same as `&`/`|`; the
+        // operands are evaluated unconditionally, matching the IntEq+IntOr
+        // chain `lower_match_stmt` emits for multi-value arms.  A green operand
+        // folds so only the taken branch survives.
+        BinOp::And(_) => "IntAnd",
+        BinOp::Or(_) => "IntOr",
         BinOp::Shl(_) => "IntLshift",
         BinOp::Shr(_) => "IntRshift",
         BinOp::Eq(_) => "IntEq",

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/helpers.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/helpers.rs
@@ -481,10 +481,12 @@ pub(super) fn opcode_for_binop(op: &BinOp) -> Option<Ident> {
         BinOp::BitOr(_) => "IntOr",
         BinOp::BitXor(_) => "IntXor",
         // Logical `&&`/`||` on boolean operands (Rust requires `bool`, whose
-        // lowered register holds 0/1) is bit-for-bit the same as `&`/`|`; the
-        // operands are evaluated unconditionally, matching the IntEq+IntOr
-        // chain `lower_match_stmt` emits for multi-value arms.  A green operand
-        // folds so only the taken branch survives.
+        // lowered register holds 0/1) is bit-for-bit the same as `&`/`|`.
+        // M4 audit: every macro-lowered `&&`/`||` operand is pure/safe to
+        // evaluate unconditionally; no audited `#[jit_interp]` body depends on
+        // short-circuiting (only closure-literal `|| {}` tokens appear in the
+        // current annotated bodies).  A green operand folds so only the taken
+        // branch survives.
         BinOp::And(_) => "IntAnd",
         BinOp::Or(_) => "IntOr",
         BinOp::Shl(_) => "IntLshift",

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/lower_vable.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/lower_vable.rs
@@ -925,13 +925,12 @@ impl<'c> Lowerer<'c> {
         // fallback (the marker function's own body) rather than miscompiling an
         // unrelated helper into a `getarrayitem_gc_r`.
         let func_segments = canonical_expr_segments(&call.func)?;
-        if !config
+        let element_type = config
             .pool_arrays
             .iter()
-            .any(|(base, getter)| base == &base_name && getter == &func_segments)
-        {
-            return None;
-        }
+            .find(|(base, getter, _)| base == &base_name && getter == &func_segments)?
+            .2
+            .clone();
         // Lower the `state.<base>` ref-scalar (declares its ref identity slot
         // live for resume) and the index, then read the pointer element.
         let base = self.lower_state_field_read(&call.args[0])?;
@@ -965,7 +964,7 @@ impl<'c> Lowerer<'c> {
             reg: result_reg,
             kind: BindingKind::Ref,
             depends_on_stack: base.depends_on_stack || index.depends_on_stack,
-            struct_type: None,
+            struct_type: element_type,
         })
     }
 

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/lower_vable.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/lower_vable.rs
@@ -708,6 +708,8 @@ impl<'c> Lowerer<'c> {
         let ref_field_key = format!("{}::{}", struct_last, member_name);
         let ref_field_entry = config.ref_fields.get(&ref_field_key);
         let is_ref_field = ref_field_entry.is_some();
+        let force_virtual_at_guard =
+            config.force_virtual_at_guard_field(&struct_path, &member_name);
         // Raw (headerless) ref-scalar pointee → `is_gc_managed = false`, a
         // distinct descriptor id from any GC `new_struct` of the same type.
         let tid = struct_type_id(&struct_path, false);
@@ -733,10 +735,12 @@ impl<'c> Lowerer<'c> {
                         ::core::mem::size_of::<#struct_path>(),
                         #tid,
                         false,
+                        false,
                         &[(
                             ::core::mem::offset_of!(#struct_path, #member),
                             true,
                             stringify!(#member),
+                            #force_virtual_at_guard,
                         )],
                     );
                     __builder.getfield_gc_r(
@@ -766,10 +770,12 @@ impl<'c> Lowerer<'c> {
                         ::core::mem::size_of::<#struct_path>(),
                         #tid,
                         false,
+                        false,
                         &[(
                             ::core::mem::offset_of!(#struct_path, #member),
                             false,
                             stringify!(#member),
+                            #force_virtual_at_guard,
                         )],
                     );
                     __builder.getfield_gc_i(
@@ -819,6 +825,8 @@ impl<'c> Lowerer<'c> {
         let ref_field_key = format!("{}::{}", struct_last, member_name);
         let ref_field_entry = config.ref_fields.get(&ref_field_key);
         let is_ref_field = ref_field_entry.is_some();
+        let force_virtual_at_guard =
+            config.force_virtual_at_guard_field(&struct_path, &member_name);
         let tid = struct_type_id(&struct_path, false);
         let base_reg = binding.reg;
         let result_reg = self.alloc_reg();
@@ -834,10 +842,12 @@ impl<'c> Lowerer<'c> {
                         ::core::mem::size_of::<#struct_path>(),
                         #tid,
                         false,
+                        false,
                         &[(
                             ::core::mem::offset_of!(#struct_path, #member),
                             true,
                             stringify!(#member),
+                            #force_virtual_at_guard,
                         )],
                     );
                     __builder.getfield_gc_r(
@@ -866,10 +876,12 @@ impl<'c> Lowerer<'c> {
                         ::core::mem::size_of::<#struct_path>(),
                         #tid,
                         false,
+                        false,
                         &[(
                             ::core::mem::offset_of!(#struct_path, #member),
                             false,
                             stringify!(#member),
+                            #force_virtual_at_guard,
                         )],
                     );
                     __builder.getfield_gc_i(
@@ -1001,6 +1013,8 @@ impl<'c> Lowerer<'c> {
             .unwrap_or_default();
         let ref_field_key = format!("{}::{}", struct_last, member_name);
         let is_ref_field = config.ref_fields.contains_key(&ref_field_key);
+        let force_virtual_at_guard =
+            config.force_virtual_at_guard_field(&struct_path, &member_name);
         // Raw (headerless) ref-scalar pointee → `is_gc_managed = false`, the
         // same id the matching getfield uses so this setfield invalidates it.
         let tid = struct_type_id(&struct_path, false);
@@ -1027,10 +1041,12 @@ impl<'c> Lowerer<'c> {
                         ::core::mem::size_of::<#struct_path>(),
                         #tid,
                         false,
+                        false,
                         &[(
                             ::core::mem::offset_of!(#struct_path, #member),
                             true,
                             stringify!(#member),
+                            #force_virtual_at_guard,
                         )],
                     );
                     __builder.setfield_gc_r(
@@ -1058,10 +1074,12 @@ impl<'c> Lowerer<'c> {
                         ::core::mem::size_of::<#struct_path>(),
                         #tid,
                         false,
+                        false,
                         &[(
                             ::core::mem::offset_of!(#struct_path, #member),
                             false,
                             stringify!(#member),
+                            #force_virtual_at_guard,
                         )],
                     );
                     __builder.setfield_gc_i(
@@ -1106,6 +1124,8 @@ impl<'c> Lowerer<'c> {
             .unwrap_or_default();
         let ref_field_key = format!("{}::{}", struct_last, member_name);
         let is_ref_field = config.ref_fields.contains_key(&ref_field_key);
+        let force_virtual_at_guard =
+            config.force_virtual_at_guard_field(&struct_path, &member_name);
         let tid = struct_type_id(&struct_path, false);
         let base_reg = binding.reg;
         let rhs = self.lower_value_expr(&assign.right)?;
@@ -1125,10 +1145,12 @@ impl<'c> Lowerer<'c> {
                         ::core::mem::size_of::<#struct_path>(),
                         #tid,
                         false,
+                        false,
                         &[(
                             ::core::mem::offset_of!(#struct_path, #member),
                             true,
                             stringify!(#member),
+                            #force_virtual_at_guard,
                         )],
                     );
                     __builder.setfield_gc_r(
@@ -1155,10 +1177,12 @@ impl<'c> Lowerer<'c> {
                         ::core::mem::size_of::<#struct_path>(),
                         #tid,
                         false,
+                        false,
                         &[(
                             ::core::mem::offset_of!(#struct_path, #member),
                             false,
                             stringify!(#member),
+                            #force_virtual_at_guard,
                         )],
                     );
                     __builder.setfield_gc_i(

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/lower_vable.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/lower_vable.rs
@@ -708,8 +708,6 @@ impl<'c> Lowerer<'c> {
         let ref_field_key = format!("{}::{}", struct_last, member_name);
         let ref_field_entry = config.ref_fields.get(&ref_field_key);
         let is_ref_field = ref_field_entry.is_some();
-        let force_virtual_at_guard =
-            config.force_virtual_at_guard_field(&struct_path, &member_name);
         // Raw (headerless) ref-scalar pointee → `is_gc_managed = false`, a
         // distinct descriptor id from any GC `new_struct` of the same type.
         let tid = struct_type_id(&struct_path, false);
@@ -740,7 +738,6 @@ impl<'c> Lowerer<'c> {
                             ::core::mem::offset_of!(#struct_path, #member),
                             true,
                             stringify!(#member),
-                            #force_virtual_at_guard,
                         )],
                     );
                     __builder.getfield_gc_r(
@@ -775,7 +772,6 @@ impl<'c> Lowerer<'c> {
                             ::core::mem::offset_of!(#struct_path, #member),
                             false,
                             stringify!(#member),
-                            #force_virtual_at_guard,
                         )],
                     );
                     __builder.getfield_gc_i(
@@ -825,8 +821,6 @@ impl<'c> Lowerer<'c> {
         let ref_field_key = format!("{}::{}", struct_last, member_name);
         let ref_field_entry = config.ref_fields.get(&ref_field_key);
         let is_ref_field = ref_field_entry.is_some();
-        let force_virtual_at_guard =
-            config.force_virtual_at_guard_field(&struct_path, &member_name);
         let tid = struct_type_id(&struct_path, false);
         let base_reg = binding.reg;
         let result_reg = self.alloc_reg();
@@ -847,7 +841,6 @@ impl<'c> Lowerer<'c> {
                             ::core::mem::offset_of!(#struct_path, #member),
                             true,
                             stringify!(#member),
-                            #force_virtual_at_guard,
                         )],
                     );
                     __builder.getfield_gc_r(
@@ -881,7 +874,6 @@ impl<'c> Lowerer<'c> {
                             ::core::mem::offset_of!(#struct_path, #member),
                             false,
                             stringify!(#member),
-                            #force_virtual_at_guard,
                         )],
                     );
                     __builder.getfield_gc_i(
@@ -1013,8 +1005,6 @@ impl<'c> Lowerer<'c> {
             .unwrap_or_default();
         let ref_field_key = format!("{}::{}", struct_last, member_name);
         let is_ref_field = config.ref_fields.contains_key(&ref_field_key);
-        let force_virtual_at_guard =
-            config.force_virtual_at_guard_field(&struct_path, &member_name);
         // Raw (headerless) ref-scalar pointee → `is_gc_managed = false`, the
         // same id the matching getfield uses so this setfield invalidates it.
         let tid = struct_type_id(&struct_path, false);
@@ -1046,7 +1036,6 @@ impl<'c> Lowerer<'c> {
                             ::core::mem::offset_of!(#struct_path, #member),
                             true,
                             stringify!(#member),
-                            #force_virtual_at_guard,
                         )],
                     );
                     __builder.setfield_gc_r(
@@ -1079,7 +1068,6 @@ impl<'c> Lowerer<'c> {
                             ::core::mem::offset_of!(#struct_path, #member),
                             false,
                             stringify!(#member),
-                            #force_virtual_at_guard,
                         )],
                     );
                     __builder.setfield_gc_i(
@@ -1124,8 +1112,6 @@ impl<'c> Lowerer<'c> {
             .unwrap_or_default();
         let ref_field_key = format!("{}::{}", struct_last, member_name);
         let is_ref_field = config.ref_fields.contains_key(&ref_field_key);
-        let force_virtual_at_guard =
-            config.force_virtual_at_guard_field(&struct_path, &member_name);
         let tid = struct_type_id(&struct_path, false);
         let base_reg = binding.reg;
         let rhs = self.lower_value_expr(&assign.right)?;
@@ -1150,7 +1136,6 @@ impl<'c> Lowerer<'c> {
                             ::core::mem::offset_of!(#struct_path, #member),
                             true,
                             stringify!(#member),
-                            #force_virtual_at_guard,
                         )],
                     );
                     __builder.setfield_gc_r(
@@ -1182,7 +1167,6 @@ impl<'c> Lowerer<'c> {
                             ::core::mem::offset_of!(#struct_path, #member),
                             false,
                             stringify!(#member),
-                            #force_virtual_at_guard,
                         )],
                     );
                     __builder.setfield_gc_i(

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/lower_value.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/lower_value.rs
@@ -122,8 +122,40 @@ impl<'c> Lowerer<'c> {
                 })
             }
             Expr::Path(ExprPath { path, .. }) => {
-                let ident = path.get_ident()?;
-                self.bindings.get(&ident.to_string()).cloned()
+                // A single-segment path naming a known local binding resolves
+                // to that binding.
+                if let Some(ident) = path.get_ident() {
+                    if let Some(binding) = self.bindings.get(&ident.to_string()) {
+                        return Some(binding.clone());
+                    }
+                }
+                // Otherwise a path whose final segment is a SCREAMING_CASE
+                // symbolic constant (`VAL_QUEUE`, `aheui::VAL_PORT`) lowers to
+                // a runtime int const — the same `#path as i64` form match-arm
+                // patterns use (`extract_pat_value_tokens`); the Rust compiler
+                // resolves the const value while building the JitCode, and a
+                // green consumer folds it. A lowercase non-binding path stays
+                // unlowerable (fail-closed).
+                let last = path.segments.last()?;
+                if !last.arguments.is_none()
+                    || !last
+                        .ident
+                        .to_string()
+                        .starts_with(|c: char| c.is_uppercase())
+                {
+                    return None;
+                }
+                let reg = self.alloc_reg();
+                self.emit_op(
+                    OpMeta::linear(OpKind::LoadConstI, vec![], vec![Register::int(reg)]),
+                    quote! { __builder.load_const_i_value(#reg, #path as i64); },
+                );
+                Some(Binding {
+                    reg,
+                    kind: BindingKind::Int,
+                    depends_on_stack: false,
+                    struct_type: None,
+                })
             }
             Expr::Cast(ExprCast { expr, ty, .. }) if is_supported_int_cast(ty) => {
                 let binding = self.lower_value_expr(expr)?;

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/lower_value.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/lower_value.rs
@@ -294,16 +294,11 @@ impl<'c> Lowerer<'c> {
             .iter()
             .map(|(member, value)| {
                 let is_ref = matches!(value.kind, BindingKind::Ref);
-                let force_virtual_at_guard = self.config.map_or(false, |cfg| {
-                    let member_name = canonical_member_name(member);
-                    cfg.force_virtual_at_guard_field(struct_path, &member_name)
-                });
                 quote! {
                     (
                         ::core::mem::offset_of!(#struct_path, #member),
                         #is_ref,
                         stringify!(#member),
-                        #force_virtual_at_guard,
                     )
                 }
             })

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/lower_value.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/lower_value.rs
@@ -294,15 +294,23 @@ impl<'c> Lowerer<'c> {
             .iter()
             .map(|(member, value)| {
                 let is_ref = matches!(value.kind, BindingKind::Ref);
+                let force_virtual_at_guard = self.config.map_or(false, |cfg| {
+                    let member_name = canonical_member_name(member);
+                    cfg.force_virtual_at_guard_field(struct_path, &member_name)
+                });
                 quote! {
                     (
                         ::core::mem::offset_of!(#struct_path, #member),
                         #is_ref,
                         stringify!(#member),
+                        #force_virtual_at_guard,
                     )
                 }
             })
             .collect();
+        let headerless = self
+            .config
+            .map_or(false, |cfg| cfg.is_headerless_struct(struct_path));
         self.emit_op(
             OpMeta::linear(OpKind::New, vec![], vec![Register::ref_(result_reg)]),
             quote! {
@@ -310,6 +318,7 @@ impl<'c> Lowerer<'c> {
                     #result_reg,
                     ::core::mem::size_of::<#struct_path>(),
                     #type_id,
+                    #headerless,
                     &[ #(#field_layout),* ],
                 );
             },

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/mod.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/mod.rs
@@ -181,11 +181,11 @@ pub struct LowererConfig {
     /// `getfield_gc_i`.  Source: `JitInterpConfig.residual_writes`, the struct
     /// `Path` recovered from `state_ref_scalars[ref_scalar]`.
     pub(super) residual_writes: Vec<(Vec<String>, syn::Path, Ident)>,
-    /// `(pool-base ref-scalar name, getter function path segments)`.  A call
-    /// `<getter>(state.<base>, <int>)` whose function path matches `getter` AND
-    /// whose arg0 is the `base` lowers to `getarrayitem_gc_r` instead of a
-    /// residual CALL_R.  Source: `JitInterpConfig.pool_arrays`.
-    pub(super) pool_arrays: Vec<(String, Vec<String>)>,
+    /// `(pool-base ref-scalar name, getter function path segments, element type)`.
+    /// A call `<getter>(state.<base>, <int>)` whose function path matches
+    /// `getter` AND whose arg0 is the `base` lowers to `getarrayitem_gc_r`
+    /// instead of a residual CALL_R.  Source: `JitInterpConfig.pool_arrays`.
+    pub(super) pool_arrays: Vec<(String, Vec<String>, Option<syn::Path>)>,
     /// Ref-kind struct field declarations.  Key = `"StructType::field"`,
     /// value = `(struct_path, field_ident, pointee_path)`.  When the lowerer
     /// encounters a field access and the `(struct, field)` pair matches, it
@@ -1021,6 +1021,7 @@ impl LowererConfig {
                     (
                         entry.base.to_string(),
                         canonical_path_segments(&entry.getter),
+                        entry.element_type.clone(),
                     )
                 })
                 .collect(),

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/mod.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/mod.rs
@@ -196,6 +196,10 @@ pub struct LowererConfig {
     /// result is bound, the lowerer sets `Binding.struct_type` from this map
     /// so subsequent `result.field` accesses resolve through `ref_fields`.
     pub(super) call_returns: HashMap<Vec<String>, syn::Path>,
+    /// Struct types whose `New` allocation should carry the headerless bit.
+    pub(super) headerless_structs: std::collections::HashSet<Vec<String>>,
+    /// Field keys (`StructLast::field`) whose virtual RHS is guard-forced.
+    pub(super) force_at_guard_fields: std::collections::HashSet<String>,
     /// Pure function → native IR integer binop aliases.  Key = canonical func
     /// path segments, value = IR opcode name (e.g. "IntAdd").  When
     /// `lower_native_int_binop_call` encounters a call whose path matches a
@@ -828,6 +832,8 @@ impl LowererConfig {
         pool_arrays: &[crate::jit_interp::PoolArrayEntry],
         ref_fields: &[crate::jit_interp::RefFieldEntry],
         call_returns: &[(Path, Path)],
+        headerless_structs: &[Path],
+        force_at_guard: &[crate::jit_interp::ForceAtGuardEntry],
         native_int_binops: &[(Path, Ident)],
         native_tag_small: &[Path],
         split_dispatch: bool,
@@ -1015,6 +1021,22 @@ impl LowererConfig {
                 .iter()
                 .map(|(func, ret_type)| (canonical_path_segments(func), ret_type.clone()))
                 .collect(),
+            headerless_structs: headerless_structs
+                .iter()
+                .map(canonical_path_segments)
+                .collect(),
+            force_at_guard_fields: force_at_guard
+                .iter()
+                .map(|entry| {
+                    let struct_name = entry
+                        .struct_type
+                        .segments
+                        .last()
+                        .map(|s| s.ident.to_string())
+                        .unwrap_or_default();
+                    format!("{}::{}", struct_name, entry.field)
+                })
+                .collect(),
             pool_arrays: pool_arrays
                 .iter()
                 .map(|entry| {
@@ -1044,6 +1066,25 @@ impl LowererConfig {
             cloned.vable_input_ref_reg = Some(reg);
         }
         cloned
+    }
+
+    pub(super) fn is_headerless_struct(&self, struct_path: &syn::Path) -> bool {
+        self.headerless_structs
+            .contains(&canonical_path_segments(struct_path))
+    }
+
+    pub(super) fn force_virtual_at_guard_field(
+        &self,
+        struct_path: &syn::Path,
+        field_name: &str,
+    ) -> bool {
+        let struct_name = struct_path
+            .segments
+            .last()
+            .map(|s| s.ident.to_string())
+            .unwrap_or_default();
+        self.force_at_guard_fields
+            .contains(&format!("{}::{}", struct_name, field_name))
     }
 }
 

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/mod.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/mod.rs
@@ -1028,13 +1028,9 @@ impl LowererConfig {
             force_at_guard_fields: force_at_guard
                 .iter()
                 .map(|entry| {
-                    let struct_name = entry
-                        .struct_type
-                        .segments
-                        .last()
-                        .map(|s| s.ident.to_string())
-                        .unwrap_or_default();
-                    format!("{}::{}", struct_name, entry.field)
+                    let mut key = canonical_path_segments(&entry.struct_type);
+                    key.push(entry.field.to_string());
+                    key.join("::")
                 })
                 .collect(),
             pool_arrays: pool_arrays
@@ -1078,13 +1074,9 @@ impl LowererConfig {
         struct_path: &syn::Path,
         field_name: &str,
     ) -> bool {
-        let struct_name = struct_path
-            .segments
-            .last()
-            .map(|s| s.ident.to_string())
-            .unwrap_or_default();
-        self.force_at_guard_fields
-            .contains(&format!("{}::{}", struct_name, field_name))
+        let mut key = canonical_path_segments(struct_path);
+        key.push(field_name.to_string());
+        self.force_at_guard_fields.contains(&key.join("::"))
     }
 }
 

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/mod.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/mod.rs
@@ -198,8 +198,6 @@ pub struct LowererConfig {
     pub(super) call_returns: HashMap<Vec<String>, syn::Path>,
     /// Struct types whose `New` allocation should carry the headerless bit.
     pub(super) headerless_structs: std::collections::HashSet<Vec<String>>,
-    /// Field keys (`StructLast::field`) whose virtual RHS is guard-forced.
-    pub(super) force_at_guard_fields: std::collections::HashSet<String>,
     /// Pure function → native IR integer binop aliases.  Key = canonical func
     /// path segments, value = IR opcode name (e.g. "IntAdd").  When
     /// `lower_native_int_binop_call` encounters a call whose path matches a
@@ -833,7 +831,6 @@ impl LowererConfig {
         ref_fields: &[crate::jit_interp::RefFieldEntry],
         call_returns: &[(Path, Path)],
         headerless_structs: &[Path],
-        force_at_guard: &[crate::jit_interp::ForceAtGuardEntry],
         native_int_binops: &[(Path, Ident)],
         native_tag_small: &[Path],
         split_dispatch: bool,
@@ -1025,14 +1022,6 @@ impl LowererConfig {
                 .iter()
                 .map(canonical_path_segments)
                 .collect(),
-            force_at_guard_fields: force_at_guard
-                .iter()
-                .map(|entry| {
-                    let mut key = canonical_path_segments(&entry.struct_type);
-                    key.push(entry.field.to_string());
-                    key.join("::")
-                })
-                .collect(),
             pool_arrays: pool_arrays
                 .iter()
                 .map(|entry| {
@@ -1069,15 +1058,6 @@ impl LowererConfig {
             .contains(&canonical_path_segments(struct_path))
     }
 
-    pub(super) fn force_virtual_at_guard_field(
-        &self,
-        struct_path: &syn::Path,
-        field_name: &str,
-    ) -> bool {
-        let mut key = canonical_path_segments(struct_path);
-        key.push(field_name.to_string());
-        self.force_at_guard_fields.contains(&key.join("::"))
-    }
 }
 
 pub(super) fn canonical_path_segments(path: &Path) -> Vec<String> {

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/mod.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/mod.rs
@@ -1057,7 +1057,6 @@ impl LowererConfig {
         self.headerless_structs
             .contains(&canonical_path_segments(struct_path))
     }
-
 }
 
 pub(super) fn canonical_path_segments(path: &Path) -> Vec<String> {

--- a/majit/majit-macros/src/jit_interp/mod.rs
+++ b/majit/majit-macros/src/jit_interp/mod.rs
@@ -149,6 +149,12 @@ pub struct JitInterpConfig {
     /// `allocator_func(v0, v1)`.  The JIT path already handles struct
     /// literals natively via `lower_struct_value` (New + SetfieldGc).
     pub struct_allocs: Vec<(Path, Path)>,
+    /// Structs whose `New` allocation should use the headerless nursery opcode.
+    /// `headerless_structs = { StructType, ... }`.
+    pub headerless_structs: Vec<Path>,
+    /// Fields whose virtual RHS must be forced to memory at guards.
+    /// `force_at_guard = { StructType::field, ... }`.
+    pub force_at_guard: Vec<ForceAtGuardEntry>,
     /// Pure function → native IR integer binop aliases.
     /// `native_int_binops = { val_add => IntAdd, ... }`.  When the JIT-path
     /// lowerer encounters a call whose path matches a key, it emits the named
@@ -376,6 +382,12 @@ pub struct RefFieldEntry {
     pub pointee_type: Path,
 }
 
+#[derive(Clone)]
+pub struct ForceAtGuardEntry {
+    pub struct_type: Path,
+    pub field: Ident,
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum CallPolicyKind {
     ResidualVoid,
@@ -552,6 +564,8 @@ impl Parse for JitInterpConfig {
         let mut ref_fields: Vec<RefFieldEntry> = Vec::new();
         let mut call_returns: Vec<(Path, Path)> = Vec::new();
         let mut struct_allocs: Vec<(Path, Path)> = Vec::new();
+        let mut headerless_structs: Vec<Path> = Vec::new();
+        let mut force_at_guard: Vec<ForceAtGuardEntry> = Vec::new();
         let mut native_int_binops: Vec<(Path, Ident)> = Vec::new();
         let mut native_tag_small: Vec<Path> = Vec::new();
         let mut split_dispatch = false;
@@ -617,6 +631,12 @@ impl Parse for JitInterpConfig {
                 "struct_allocs" => {
                     struct_allocs = parse_call_returns_map(input)?;
                 }
+                "headerless_structs" => {
+                    headerless_structs = parse_path_set(input)?;
+                }
+                "force_at_guard" => {
+                    force_at_guard = parse_force_at_guard_set(input)?;
+                }
                 "native_int_binops" => {
                     native_int_binops = parse_native_int_binops_map(input)?;
                 }
@@ -677,6 +697,8 @@ impl Parse for JitInterpConfig {
             ref_fields,
             call_returns,
             struct_allocs,
+            headerless_structs,
+            force_at_guard,
             native_int_binops,
             native_tag_small,
             split_dispatch,
@@ -785,26 +807,52 @@ fn parse_native_tag_small_list(input: ParseStream) -> syn::Result<Vec<Path>> {
     Ok(entries)
 }
 
+fn parse_path_set(input: ParseStream) -> syn::Result<Vec<Path>> {
+    let content;
+    braced!(content in input);
+    let mut entries = Vec::new();
+    while !content.is_empty() {
+        entries.push(content.parse::<Path>()?);
+        let _ = content.parse::<Token![,]>();
+    }
+    Ok(entries)
+}
+
+fn split_struct_field_path(full_path: Path) -> syn::Result<(Path, Ident)> {
+    let mut segments: Vec<_> = full_path.segments.into_iter().collect();
+    if segments.len() < 2 {
+        return Err(syn::Error::new_spanned(
+            &full_path.leading_colon,
+            "entry must be `Struct::field`",
+        ));
+    }
+    let field_seg = segments.pop().unwrap();
+    let field = field_seg.ident;
+    let struct_type = syn::Path {
+        leading_colon: full_path.leading_colon,
+        segments: segments.into_iter().collect(),
+    };
+    Ok((struct_type, field))
+}
+
+fn parse_force_at_guard_set(input: ParseStream) -> syn::Result<Vec<ForceAtGuardEntry>> {
+    let content;
+    braced!(content in input);
+    let mut entries = Vec::new();
+    while !content.is_empty() {
+        let (struct_type, field) = split_struct_field_path(content.parse::<Path>()?)?;
+        entries.push(ForceAtGuardEntry { struct_type, field });
+        let _ = content.parse::<Token![,]>();
+    }
+    Ok(entries)
+}
+
 fn parse_ref_fields_map(input: ParseStream) -> syn::Result<Vec<RefFieldEntry>> {
     let content;
     braced!(content in input);
     let mut entries = Vec::new();
     while !content.is_empty() {
-        let full_path: Path = content.parse()?;
-        // Split the last segment as the field name.
-        let mut segments: Vec<_> = full_path.segments.into_iter().collect();
-        if segments.len() < 2 {
-            return Err(syn::Error::new_spanned(
-                &full_path.leading_colon,
-                "ref_fields entry must be `Struct::field => Pointee`",
-            ));
-        }
-        let field_seg = segments.pop().unwrap();
-        let field = field_seg.ident;
-        let struct_type = syn::Path {
-            leading_colon: full_path.leading_colon,
-            segments: segments.into_iter().collect(),
-        };
+        let (struct_type, field) = split_struct_field_path(content.parse::<Path>()?)?;
         content.parse::<Token![=>]>()?;
         let pointee_type: Path = content.parse()?;
         entries.push(RefFieldEntry {

--- a/majit/majit-macros/src/jit_interp/mod.rs
+++ b/majit/majit-macros/src/jit_interp/mod.rs
@@ -118,8 +118,9 @@ pub struct JitInterpConfig {
     pub residual_writes: Vec<ResidualWriteEntry>,
     /// `ref(T)` state scalars that are bases of a contiguous raw-pointer array
     /// (`[*mut U; N]` at offset 0 of `T`), declared as
-    /// `pool_arrays = { <ref> => <getter>, ... }`.  The indexing marker call
-    /// `<getter>(state.<ref>, <int>)` lowers to `getarrayitem_gc_r` (a
+    /// `pool_arrays = { <ref> => <getter> [-> ElementType], ... }`.  The
+    /// indexing marker call `<getter>(state.<ref>, <int>)` lowers to
+    /// `getarrayitem_gc_r` (a
     /// re-producible heap read) instead of an opaque residual CALL_R, so the
     /// loaded element re-derives from the index each loop entry and the short
     /// preamble can re-emit it.  Selection is keyed on the `getter` function
@@ -344,15 +345,20 @@ pub struct ResidualWriteEntry {
 
 /// A `ref(T)` state scalar that is the base of a contiguous raw-pointer array,
 /// paired with the marker `getter` function whose call indexes it.  Declared as
-/// `pool_arrays = { <ref> => <getter>, ... }`.  The lowering recognizes a pool
-/// read only when BOTH the call's function path matches `getter` AND arg0 is
-/// `state.<base>` — operation identity, not arg shape alone, so an unrelated
-/// helper that happens to take the same `(state.<base>, int)` shape is not
-/// miscompiled into a `getarrayitem_gc_r`.
+/// `pool_arrays = { <ref> => <getter> [-> ElementType], ... }`.  The lowering
+/// recognizes a pool read only when BOTH the call's function path matches
+/// `getter` AND arg0 is `state.<base>` — operation identity, not arg shape
+/// alone, so an unrelated helper that happens to take the same
+/// `(state.<base>, int)` shape is not miscompiled into a `getarrayitem_gc_r`.
 #[derive(Clone)]
 pub struct PoolArrayEntry {
     pub base: Ident,
     pub getter: Path,
+    /// The concrete element type each array slot points at (`pools: [*mut T; N]`),
+    /// declared as `<base> => <getter> -> T`.  Supplies `struct_type` for the
+    /// getter's ref binding so field access on a LOCAL `let x = <getter>(...)`
+    /// resolves the layout (state-field refs get this from their decl instead).
+    pub element_type: Option<Path>,
 }
 
 /// One entry in `ref_fields = { Struct::field => PointeeType, ... }`.
@@ -706,8 +712,9 @@ fn parse_residual_writes_map(input: ParseStream) -> syn::Result<Vec<ResidualWrit
     Ok(entries)
 }
 
-/// Parse `pool_arrays = { <ref> => <getter>, ... }`.  Each entry maps a `ref(T)`
-/// state scalar (the array base) to the marker function whose call indexes it.
+/// Parse `pool_arrays = { <ref> => <getter> [-> ElementType], ... }`.  Each
+/// entry maps a `ref(T)` state scalar (the array base) to the marker function
+/// whose call indexes it, optionally tagging the loaded element's struct type.
 fn parse_pool_arrays_map(input: ParseStream) -> syn::Result<Vec<PoolArrayEntry>> {
     let content;
     braced!(content in input);
@@ -716,7 +723,17 @@ fn parse_pool_arrays_map(input: ParseStream) -> syn::Result<Vec<PoolArrayEntry>>
         let base: Ident = content.parse()?;
         content.parse::<Token![=>]>()?;
         let getter: Path = content.parse()?;
-        entries.push(PoolArrayEntry { base, getter });
+        let element_type = if content.peek(Token![->]) {
+            content.parse::<Token![->]>()?;
+            Some(content.parse::<Path>()?)
+        } else {
+            None
+        };
+        entries.push(PoolArrayEntry {
+            base,
+            getter,
+            element_type,
+        });
         let _ = content.parse::<Token![,]>();
     }
     Ok(entries)
@@ -1676,6 +1693,16 @@ fn transform_function(config: &JitInterpConfig, func: &ItemFn) -> TokenStream {
                         func.segments.iter().map(|s| s.ident.to_string()).collect();
                     (segs, ret_type.clone())
                 })
+                .chain(config.pool_arrays.iter().filter_map(|entry| {
+                    let ret_type = entry.element_type.clone()?;
+                    let segs: Vec<String> = entry
+                        .getter
+                        .segments
+                        .iter()
+                        .map(|s| s.ident.to_string())
+                        .collect();
+                    Some((segs, ret_type))
+                }))
                 .collect();
             let struct_allocs_map: std::collections::HashMap<Vec<String>, syn::Path> = config
                 .struct_allocs

--- a/majit/majit-macros/src/jit_interp/mod.rs
+++ b/majit/majit-macros/src/jit_interp/mod.rs
@@ -152,9 +152,6 @@ pub struct JitInterpConfig {
     /// Structs whose `New` allocation should use the headerless nursery opcode.
     /// `headerless_structs = { StructType, ... }`.
     pub headerless_structs: Vec<Path>,
-    /// Fields whose virtual RHS must be forced to memory at guards.
-    /// `force_at_guard = { StructType::field, ... }`.
-    pub force_at_guard: Vec<ForceAtGuardEntry>,
     /// Pure function → native IR integer binop aliases.
     /// `native_int_binops = { val_add => IntAdd, ... }`.  When the JIT-path
     /// lowerer encounters a call whose path matches a key, it emits the named
@@ -382,12 +379,6 @@ pub struct RefFieldEntry {
     pub pointee_type: Path,
 }
 
-#[derive(Clone)]
-pub struct ForceAtGuardEntry {
-    pub struct_type: Path,
-    pub field: Ident,
-}
-
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum CallPolicyKind {
     ResidualVoid,
@@ -565,7 +556,6 @@ impl Parse for JitInterpConfig {
         let mut call_returns: Vec<(Path, Path)> = Vec::new();
         let mut struct_allocs: Vec<(Path, Path)> = Vec::new();
         let mut headerless_structs: Vec<Path> = Vec::new();
-        let mut force_at_guard: Vec<ForceAtGuardEntry> = Vec::new();
         let mut native_int_binops: Vec<(Path, Ident)> = Vec::new();
         let mut native_tag_small: Vec<Path> = Vec::new();
         let mut split_dispatch = false;
@@ -634,9 +624,6 @@ impl Parse for JitInterpConfig {
                 "headerless_structs" => {
                     headerless_structs = parse_path_set(input)?;
                 }
-                "force_at_guard" => {
-                    force_at_guard = parse_force_at_guard_set(input)?;
-                }
                 "native_int_binops" => {
                     native_int_binops = parse_native_int_binops_map(input)?;
                 }
@@ -698,7 +685,6 @@ impl Parse for JitInterpConfig {
             call_returns,
             struct_allocs,
             headerless_structs,
-            force_at_guard,
             native_int_binops,
             native_tag_small,
             split_dispatch,
@@ -833,18 +819,6 @@ fn split_struct_field_path(full_path: Path) -> syn::Result<(Path, Ident)> {
         segments: segments.into_iter().collect(),
     };
     Ok((struct_type, field))
-}
-
-fn parse_force_at_guard_set(input: ParseStream) -> syn::Result<Vec<ForceAtGuardEntry>> {
-    let content;
-    braced!(content in input);
-    let mut entries = Vec::new();
-    while !content.is_empty() {
-        let (struct_type, field) = split_struct_field_path(content.parse::<Path>()?)?;
-        entries.push(ForceAtGuardEntry { struct_type, field });
-        let _ = content.parse::<Token![,]>();
-    }
-    Ok(entries)
 }
 
 fn parse_ref_fields_map(input: ParseStream) -> syn::Result<Vec<RefFieldEntry>> {

--- a/majit/majit-metainterp/src/jitcode/assembler.rs
+++ b/majit/majit-metainterp/src/jitcode/assembler.rs
@@ -454,7 +454,7 @@ impl JitCodeBuilder {
     /// Emit `new/d>r` (`blackhole.py:1301 bhimpl_new`): allocate a zeroed
     /// struct of `size` bytes; ref result in `dest`. No vtable write.
     ///
-    /// `fields` is the struct's full `(offset, is_ref, name, force_at_guard)` layout in
+    /// `fields` is the struct's full `(offset, is_ref, name)` layout in
     /// `index_in_parent` order (`descr.py:122-126` `init_size_descr`
     /// populates `SizeDescr.all_fielddescrs` from
     /// `heaptracker.all_fielddescrs(STRUCT)`).  It is recorded into the
@@ -468,7 +468,7 @@ impl JitCodeBuilder {
         size: usize,
         type_id: u64,
         headerless: bool,
-        fields: &[(usize, bool, &str, bool)],
+        fields: &[(usize, bool, &str)],
     ) {
         self.touch_ref_reg(dest);
         // descr.py:108-120 get_size_descr + init_size_descr: cache the
@@ -504,7 +504,7 @@ impl JitCodeBuilder {
         self.push_reg_u8(dest, "new result");
     }
 
-    /// Register a struct's `(offset, is_ref, name, force_at_guard)` layout under `type_id`
+    /// Register a struct's `(offset, is_ref, name)` layout under `type_id`
     /// WITHOUT emitting a `new/d>r` allocation op.  Used for a struct that
     /// is allocated natively (outside the JIT) but whose fields are still
     /// read/written through `getfield_gc_*` / `setfield_gc_*`: the layout
@@ -527,7 +527,7 @@ impl JitCodeBuilder {
         type_id: u64,
         is_gc_managed: bool,
         headerless: bool,
-        fields: &[(usize, bool, &str, bool)],
+        fields: &[(usize, bool, &str)],
     ) {
         let new_fields = Self::field_specs_from_layout(fields);
         // Merge into existing spec if present — each getfield/setfield
@@ -568,7 +568,7 @@ impl JitCodeBuilder {
         }
     }
 
-    /// Build `Vec<BhFieldSpec>` from a `(offset, is_ref, name, force_at_guard)` layout,
+    /// Build `Vec<BhFieldSpec>` from a `(offset, is_ref, name)` layout,
     /// mirroring `descr.py:230-231 FieldDescr(name, offset, size, flag,
     /// index_in_parent, is_pure)` for each field.  Scalar fields are one
     /// machine word (`field_size = 8`); the flag/sign follow the field
@@ -583,13 +583,13 @@ impl JitCodeBuilder {
     /// literal of the same struct an identical, deterministic
     /// `all_fielddescrs` order so the `type_id`-keyed cache is not polluted
     /// and the optimizer's `FieldDescr.n()` indexing stays consistent.
-    fn field_specs_from_layout(fields: &[(usize, bool, &str, bool)]) -> Vec<BhFieldSpec> {
-        let mut ordered: Vec<(usize, bool, &str, bool)> = fields.to_vec();
-        ordered.sort_by_key(|&(offset, _, _, _)| offset);
+    fn field_specs_from_layout(fields: &[(usize, bool, &str)]) -> Vec<BhFieldSpec> {
+        let mut ordered: Vec<(usize, bool, &str)> = fields.to_vec();
+        ordered.sort_by_key(|&(offset, _, _)| offset);
         ordered
             .iter()
             .enumerate()
-            .map(|(idx, &(offset, is_ref, name, force_virtual_at_guard))| {
+            .map(|(idx, &(offset, is_ref, name))| {
                 let (field_type, field_flag, is_field_signed) = if is_ref {
                     (
                         majit_ir::value::Type::Ref,
@@ -616,7 +616,6 @@ impl JitCodeBuilder {
                     is_field_signed,
                     is_immutable: false,
                     is_quasi_immutable: false,
-                    force_virtual_at_guard,
                     index_in_parent: idx,
                 }
             })

--- a/majit/majit-metainterp/src/jitcode/assembler.rs
+++ b/majit/majit-metainterp/src/jitcode/assembler.rs
@@ -473,8 +473,13 @@ impl JitCodeBuilder {
         self.touch_ref_reg(dest);
         // descr.py:108-120 get_size_descr + init_size_descr: cache the
         // full per-struct layout so the matching setfield_gc_* resolves
-        // the parent SizeDescr and field index (descr.py:238).  A JIT
-        // `new` allocates a GC-headered struct, so `is_gc_managed = true`.
+        // the parent SizeDescr and field index (descr.py:238).  Even a
+        // headerless JIT `new` keeps `is_gc_managed = true`: the result
+        // ref is still rooted by the reg/frame gcmap walk and collector
+        // traced.  It just carries no GcHeader, so it must never be
+        // subject to GUARD_GC_TYPE (which reads at `ref - GcHeader::SIZE`).
+        // Headerless is only used for monomorphic structs that are never
+        // type-guarded.
         self.register_struct_layout(size, type_id, true, headerless, fields);
         let all_fielddescrs = self
             .struct_size_specs
@@ -556,6 +561,7 @@ impl JitCodeBuilder {
                     type_id,
                     vtable: 0,
                     is_gc_managed,
+                    headerless,
                     all_fielddescrs: new_fields,
                 },
             );

--- a/majit/majit-metainterp/src/jitcode/assembler.rs
+++ b/majit/majit-metainterp/src/jitcode/assembler.rs
@@ -10,6 +10,8 @@ use majit_backend::JitCellToken;
 use majit_ir::OpCode;
 use majit_translate::jitcode::{BhFieldSpec, BhSizeSpec};
 
+const HEADERLESS_SIZE_OWNER_MARKER: &str = "__majit_headerless_size__";
+
 use crate::jitcode;
 
 use super::{
@@ -452,7 +454,7 @@ impl JitCodeBuilder {
     /// Emit `new/d>r` (`blackhole.py:1301 bhimpl_new`): allocate a zeroed
     /// struct of `size` bytes; ref result in `dest`. No vtable write.
     ///
-    /// `fields` is the struct's full `(offset, is_ref, name)` layout in
+    /// `fields` is the struct's full `(offset, is_ref, name, force_at_guard)` layout in
     /// `index_in_parent` order (`descr.py:122-126` `init_size_descr`
     /// populates `SizeDescr.all_fielddescrs` from
     /// `heaptracker.all_fielddescrs(STRUCT)`).  It is recorded into the
@@ -465,14 +467,15 @@ impl JitCodeBuilder {
         dest: u16,
         size: usize,
         type_id: u64,
-        fields: &[(usize, bool, &str)],
+        headerless: bool,
+        fields: &[(usize, bool, &str, bool)],
     ) {
         self.touch_ref_reg(dest);
         // descr.py:108-120 get_size_descr + init_size_descr: cache the
         // full per-struct layout so the matching setfield_gc_* resolves
         // the parent SizeDescr and field index (descr.py:238).  A JIT
         // `new` allocates a GC-headered struct, so `is_gc_managed = true`.
-        self.register_struct_layout(size, type_id, true, fields);
+        self.register_struct_layout(size, type_id, true, headerless, fields);
         let all_fielddescrs = self
             .struct_size_specs
             .get(&type_id)
@@ -483,7 +486,11 @@ impl JitCodeBuilder {
             size,
             type_id,
             vtable: 0,
-            owner: String::new(),
+            owner: if headerless {
+                HEADERLESS_SIZE_OWNER_MARKER.to_string()
+            } else {
+                String::new()
+            },
             all_fielddescrs,
             is_gc_managed: true,
         });
@@ -492,7 +499,7 @@ impl JitCodeBuilder {
         self.push_reg_u8(dest, "new result");
     }
 
-    /// Register a struct's `(offset, is_ref, name)` layout under `type_id`
+    /// Register a struct's `(offset, is_ref, name, force_at_guard)` layout under `type_id`
     /// WITHOUT emitting a `new/d>r` allocation op.  Used for a struct that
     /// is allocated natively (outside the JIT) but whose fields are still
     /// read/written through `getfield_gc_*` / `setfield_gc_*`: the layout
@@ -514,7 +521,8 @@ impl JitCodeBuilder {
         size: usize,
         type_id: u64,
         is_gc_managed: bool,
-        fields: &[(usize, bool, &str)],
+        headerless: bool,
+        fields: &[(usize, bool, &str, bool)],
     ) {
         let new_fields = Self::field_specs_from_layout(fields);
         // Merge into existing spec if present — each getfield/setfield
@@ -554,7 +562,7 @@ impl JitCodeBuilder {
         }
     }
 
-    /// Build `Vec<BhFieldSpec>` from a `(offset, is_ref, name)` layout,
+    /// Build `Vec<BhFieldSpec>` from a `(offset, is_ref, name, force_at_guard)` layout,
     /// mirroring `descr.py:230-231 FieldDescr(name, offset, size, flag,
     /// index_in_parent, is_pure)` for each field.  Scalar fields are one
     /// machine word (`field_size = 8`); the flag/sign follow the field
@@ -569,13 +577,13 @@ impl JitCodeBuilder {
     /// literal of the same struct an identical, deterministic
     /// `all_fielddescrs` order so the `type_id`-keyed cache is not polluted
     /// and the optimizer's `FieldDescr.n()` indexing stays consistent.
-    fn field_specs_from_layout(fields: &[(usize, bool, &str)]) -> Vec<BhFieldSpec> {
-        let mut ordered: Vec<(usize, bool, &str)> = fields.to_vec();
-        ordered.sort_by_key(|&(offset, _, _)| offset);
+    fn field_specs_from_layout(fields: &[(usize, bool, &str, bool)]) -> Vec<BhFieldSpec> {
+        let mut ordered: Vec<(usize, bool, &str, bool)> = fields.to_vec();
+        ordered.sort_by_key(|&(offset, _, _, _)| offset);
         ordered
             .iter()
             .enumerate()
-            .map(|(idx, &(offset, is_ref, name))| {
+            .map(|(idx, &(offset, is_ref, name, force_virtual_at_guard))| {
                 let (field_type, field_flag, is_field_signed) = if is_ref {
                     (
                         majit_ir::value::Type::Ref,
@@ -602,6 +610,7 @@ impl JitCodeBuilder {
                     is_field_signed,
                     is_immutable: false,
                     is_quasi_immutable: false,
+                    force_virtual_at_guard,
                     index_in_parent: idx,
                 }
             })
@@ -5436,7 +5445,7 @@ mod tests {
     #[test]
     fn canonical_new_struct_emit_uses_size_descr_without_vtable() {
         let mut builder = JitCodeBuilder::new();
-        builder.new_struct(3, 16, 0xCD, &[]);
+        builder.new_struct(3, 16, 0xCD, false, &[]);
         let jitcode = builder.finish();
         let opcode = jitcode::insn_byte("new/d>r");
         assert_eq!(jitcode.code, vec![opcode, 0, 0, 3]);

--- a/majit/majit-metainterp/src/jitcode/assembler.rs
+++ b/majit/majit-metainterp/src/jitcode/assembler.rs
@@ -478,8 +478,7 @@ impl JitCodeBuilder {
         // ref is still rooted by the reg/frame gcmap walk and collector
         // traced.  It just carries no GcHeader, so it must never be
         // subject to GUARD_GC_TYPE (which reads at `ref - GcHeader::SIZE`).
-        // Headerless is only used for monomorphic structs that are never
-        // type-guarded.
+        // `StructPtrInfo.make_guards` gates that guard on `!sd.headerless()`.
         self.register_struct_layout(size, type_id, true, headerless, fields);
         let all_fielddescrs = self
             .struct_size_specs

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -2036,13 +2036,12 @@ impl<S: JitState> JitDriver<S> {
                 // Successful compile-into-existing-target: raise_if_successful()
                 // raises ContinueRunningNormally (pyjitpl.py:3095-3123), which
                 // bypasses the `except SwitchToBlackhole` handler, so only the
-                // live history teardown runs — `aborted_tracing` accounting is
-                // NOT reached on success (the loop/bridge counter was already
-                // bumped at backend-compile time). Call the live-teardown half
-                // only, not the accounting half.
-                self.meta.abort_trace_live(false);
+                // successful live history teardown runs — `aborted_tracing`
+                // accounting is NOT reached on success (the loop/bridge counter
+                // was already bumped at backend-compile time).
+                self.meta.finish_trace_live();
                 // No aborted_tracing follows on success, so drop the
-                // pending_abort_* payload abort_trace_live staged (else it
+                // pending_abort_* payload finish_trace_live staged (else it
                 // attaches this key to a later, unrelated abort's hook).
                 self.meta.clear_pending_abort();
                 self.sym = None;

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -3099,24 +3099,8 @@ impl<S: JitState> JitDriver<S> {
                 let rd_consts_slice: &[Const] = storage.rd_consts();
 
                 // Convert RdVirtualInfo → VirtualInfo for blackhole resume.
-                let rd_virtuals_converted: Option<Vec<crate::resume::VirtualInfo>> = {
-                    let count = raw_values.len() as i32;
-                    let num_virtuals = storage.rd_virtuals.len();
-                    Some(
-                        storage
-                            .rd_virtuals
-                            .iter()
-                            .map(|rd| {
-                                crate::resume::rd_virtual_to_virtual_info(
-                                    rd,
-                                    rd_consts_slice,
-                                    count,
-                                    num_virtuals,
-                                )
-                            })
-                            .collect(),
-                    )
-                };
+                let rd_virtuals_converted =
+                    Some(convert_rd_virtuals_for_storage(storage, raw_values.len()));
                 let rd_virtuals_slice = rd_virtuals_converted.as_deref();
 
                 // resume.py:1338-1340: `jitcode = jitcodes[jitcode_pos];

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -2211,7 +2211,7 @@ impl<S: JitState> JitDriver<S> {
                                     // Success edge: live teardown only, no
                                     // aborted_tracing accounting (see the
                                     // CompileTrace arm above).
-                                    self.meta.abort_trace_live(false);
+                                    self.meta.finish_trace_live();
                                     self.meta.clear_pending_abort();
                                     return;
                                 }
@@ -2371,7 +2371,7 @@ impl<S: JitState> JitDriver<S> {
                                 // Success edge: live teardown only, no
                                 // aborted_tracing accounting (see the
                                 // CompileTrace arm above).
-                                self.meta.abort_trace_live(false);
+                                self.meta.finish_trace_live();
                                 self.meta.clear_pending_abort();
                                 return;
                             }

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -185,62 +185,47 @@ fn format_rca_live_values(labels: Option<&[String]>, values: &[Value]) -> String
     out
 }
 
-/// `resume.py:993-1007 _prepare_pendingfields` parity for the bridge /
-/// deopt path — replay deferred SetfieldGc / SetarrayitemGc writes
-/// via descr-method dispatch (`resume.py:1509-1518` setfield,
-/// `resume.py:1531-1541` setarrayitem_int / _ref / _float).
-fn materialize_pending_fields(exit_layout: &CompiledExitLayout, raw_values: &[i64]) {
-    let Some(ref recovery) = exit_layout.recovery_layout else {
+fn convert_rd_virtuals_for_storage(
+    storage: &crate::resume::ResumeStorage,
+    raw_value_count: usize,
+) -> Vec<crate::resume::VirtualInfo> {
+    let rd_consts = storage.rd_consts();
+    let count = raw_value_count as i32;
+    let num_virtuals = storage.rd_virtuals.len();
+    storage
+        .rd_virtuals
+        .iter()
+        .map(|rd| crate::resume::rd_virtual_to_virtual_info(rd, rd_consts, count, num_virtuals))
+        .collect()
+}
+
+/// Bridge / legacy deopt heap preparation. This is intentionally routed
+/// through resume.rs so pending fields decode TAGVIRTUAL values after the
+/// virtual cache has been rooted, matching `blackhole_from_resumedata`.
+fn prepare_exit_resume_heap(
+    exit_layout: &CompiledExitLayout,
+    raw_values: &[i64],
+    all_liveness: &[u8],
+    allocator: &dyn crate::resume::BlackholeAllocator,
+) {
+    let Some(storage) = exit_layout.storage.as_deref() else {
         return;
     };
-    for pf in &recovery.pending_field_layouts {
-        let struct_ptr = match &pf.target {
-            ExitValueSourceLayout::ExitValue(slot) if *slot < raw_values.len() => {
-                raw_values[*slot] as *mut u8
-            }
-            ExitValueSourceLayout::Constant(c, _) => *c as *mut u8,
-            _ => std::ptr::null_mut(),
-        };
-        let value = match &pf.value {
-            ExitValueSourceLayout::ExitValue(slot) if *slot < raw_values.len() => raw_values[*slot],
-            ExitValueSourceLayout::Constant(c, _) => *c,
-            _ => 0,
-        };
-        if struct_ptr.is_null() {
-            continue;
-        }
-        // resume.py:1000 PENDINGFIELDSTRUCT.lldescr is always present in
-        // RPython — fail loud if it's missing, the entry cannot be
-        // replayed without it.
-        let descr = pf
-            .descr
-            .as_ref()
-            .expect("resume.py:1000 PENDINGFIELDSTRUCT.lldescr must be set");
-        let (offset, size) = if pf.is_array_item {
-            let ad = descr
-                .as_array_descr()
-                .expect("setarrayitem pending field must carry an ArrayDescr");
-            let item_index = pf
-                .item_index
-                .expect("setarrayitem pending field must carry an item_index");
-            (ad.base_size() + item_index * ad.item_size(), ad.item_size())
-        } else {
-            let fd = descr
-                .as_field_descr()
-                .expect("setfield pending field must carry a FieldDescr");
-            (fd.offset(), fd.field_size())
-        };
-        unsafe {
-            let p = struct_ptr.add(offset);
-            match size {
-                8 => *(p as *mut i64) = value,
-                4 => *(p as *mut i32) = value as i32,
-                2 => *(p as *mut i16) = value as i16,
-                1 => *(p as *mut u8) = value as u8,
-                _ => {}
-            }
-        }
+    if storage.rd_pendingfields.is_empty() {
+        return;
     }
+    let rd_consts = storage.rd_consts();
+    let rd_virtuals = convert_rd_virtuals_for_storage(storage, raw_values.len());
+    crate::resume::prepare_resume_heap(
+        &storage.rd_numb,
+        rd_consts,
+        all_liveness,
+        raw_values,
+        Some(exit_layout.exit_types.as_slice()),
+        Some(rd_virtuals.as_slice()),
+        Some(&storage.rd_pendingfields),
+        allocator,
+    );
 }
 
 use crate::TraceAction;
@@ -5323,10 +5308,18 @@ impl<S: JitState> JitDriver<S> {
                 // resume.py:924/993 `_prepare(storage)`: apply the guard's pending
                 // heap writes (`rd_pendingfields`) to the live storage BEFORE
                 // reconstructing state, so `on_guard_failure` (the interpreter's
-                // recover) reads the post-write heap. Both PyPy rebuild paths
-                // (`rebuild_from_resumedata`, `blackhole_from_resumedata`) share
-                // `_prepare`; run it before the reconstruction, not after.
-                materialize_pending_fields(&exit_layout, &raw_values);
+                // recover) reads the post-write heap. Route through the resume
+                // reader so TAGVIRTUAL pending values materialize under the same
+                // resume-ref roots as `blackhole_from_resumedata`.
+                {
+                    let fallback_alloc = crate::resume::NullAllocator;
+                    let allocator: &dyn crate::resume::BlackholeAllocator = self
+                        .blackhole_allocator
+                        .as_deref()
+                        .unwrap_or(&fallback_alloc);
+                    let all_liveness = self.meta_interp().staticdata.liveness_info.as_slice();
+                    prepare_exit_resume_heap(&exit_layout, &raw_values, all_liveness, allocator);
+                }
                 // Restore state for bridge tracing start point.
                 let resume_pc = on_guard_failure(state, &result_meta, &raw_values, &exit_layout);
                 let resume_pc = resume_pc.unwrap_or(guard_resume_pc);
@@ -5351,25 +5344,9 @@ impl<S: JitState> JitDriver<S> {
                 let rd_consts_slice: &[Const] = storage.rd_consts();
 
                 // Convert RdVirtualInfo → VirtualInfo for blackhole resume.
-                let rd_virtuals_converted: Option<Vec<crate::resume::VirtualInfo>> = {
-                    let count = raw_values.len() as i32;
-                    let num_virtuals = storage.rd_virtuals.len();
-                    Some(
-                        storage
-                            .rd_virtuals
-                            .iter()
-                            .map(|rd| {
-                                crate::resume::rd_virtual_to_virtual_info(
-                                    rd,
-                                    rd_consts_slice,
-                                    count,
-                                    num_virtuals,
-                                )
-                            })
-                            .collect(),
-                    )
-                };
-                let rd_virtuals_slice = rd_virtuals_converted.as_deref();
+                let rd_virtuals_converted =
+                    convert_rd_virtuals_for_storage(storage, raw_values.len());
+                let rd_virtuals_slice = Some(rd_virtuals_converted.as_slice());
 
                 // resume.py:1338-1340 multi-frame chain reconstruction
                 // (mirrors the loop_jit guard-fail path):
@@ -5483,8 +5460,17 @@ impl<S: JitState> JitDriver<S> {
 
             // Legacy fallback: no rd_numb or jitcode resolution failed.
             // resume.py:993 `_prepare(storage)`: pending heap writes before
-            // reconstruction (mirrors the bridge branch above).
-            materialize_pending_fields(&exit_layout, &raw_values);
+            // reconstruction (mirrors the bridge branch above), with virtual
+            // materialization rooted by the resume reader.
+            {
+                let fallback_alloc = crate::resume::NullAllocator;
+                let allocator: &dyn crate::resume::BlackholeAllocator = self
+                    .blackhole_allocator
+                    .as_deref()
+                    .unwrap_or(&fallback_alloc);
+                let all_liveness = self.meta_interp().staticdata.liveness_info.as_slice();
+                prepare_exit_resume_heap(&exit_layout, &raw_values, all_liveness, allocator);
+            }
             let resume_pc = on_guard_failure(state, &result_meta, &raw_values, &exit_layout);
             let resume_pc = resume_pc.unwrap_or(target_pc);
             self.sync_after(state, &result_meta, descriptor.as_ref());

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -3941,6 +3941,20 @@ impl<S: JitState> JitDriver<S> {
         &mut self.meta
     }
 
+    fn prepare_exit_resume_heap_with_blackhole_allocator(
+        &self,
+        exit_layout: &CompiledExitLayout,
+        raw_values: &[i64],
+    ) {
+        let fallback_alloc = crate::resume::NullAllocator;
+        let allocator: &dyn crate::resume::BlackholeAllocator = self
+            .blackhole_allocator
+            .as_deref()
+            .unwrap_or(&fallback_alloc);
+        let all_liveness = self.meta_interp().staticdata.liveness_info.as_slice();
+        prepare_exit_resume_heap(exit_layout, raw_values, all_liveness, allocator);
+    }
+
     /// framework.py `root_walker.walk_roots` parity: visit every Ref-typed
     /// entry in every live compiled trace's `rd_consts` pool so the minor
     /// collector can forward them. See `MetaInterp::walk_rd_consts_refs`
@@ -5294,15 +5308,7 @@ impl<S: JitState> JitDriver<S> {
                 // recover) reads the post-write heap. Route through the resume
                 // reader so TAGVIRTUAL pending values materialize under the same
                 // resume-ref roots as `blackhole_from_resumedata`.
-                {
-                    let fallback_alloc = crate::resume::NullAllocator;
-                    let allocator: &dyn crate::resume::BlackholeAllocator = self
-                        .blackhole_allocator
-                        .as_deref()
-                        .unwrap_or(&fallback_alloc);
-                    let all_liveness = self.meta_interp().staticdata.liveness_info.as_slice();
-                    prepare_exit_resume_heap(&exit_layout, &raw_values, all_liveness, allocator);
-                }
+                self.prepare_exit_resume_heap_with_blackhole_allocator(&exit_layout, &raw_values);
                 // Restore state for bridge tracing start point.
                 let resume_pc = on_guard_failure(state, &result_meta, &raw_values, &exit_layout);
                 let resume_pc = resume_pc.unwrap_or(guard_resume_pc);
@@ -5445,15 +5451,7 @@ impl<S: JitState> JitDriver<S> {
             // resume.py:993 `_prepare(storage)`: pending heap writes before
             // reconstruction (mirrors the bridge branch above), with virtual
             // materialization rooted by the resume reader.
-            {
-                let fallback_alloc = crate::resume::NullAllocator;
-                let allocator: &dyn crate::resume::BlackholeAllocator = self
-                    .blackhole_allocator
-                    .as_deref()
-                    .unwrap_or(&fallback_alloc);
-                let all_liveness = self.meta_interp().staticdata.liveness_info.as_slice();
-                prepare_exit_resume_heap(&exit_layout, &raw_values, all_liveness, allocator);
-            }
+            self.prepare_exit_resume_heap_with_blackhole_allocator(&exit_layout, &raw_values);
             let resume_pc = on_guard_failure(state, &result_meta, &raw_values, &exit_layout);
             let resume_pc = resume_pc.unwrap_or(target_pc);
             self.sync_after(state, &result_meta, descriptor.as_ref());

--- a/majit/majit-metainterp/src/optimizeopt/heap.rs
+++ b/majit/majit-metainterp/src/optimizeopt/heap.rs
@@ -1320,10 +1320,6 @@ impl OptHeap {
             // heap.py:617-618: val = op.getarg(1); if is_virtual(val)
             let is_virtual = ctx.is_virtual(&op.arg(1).get_box_replacement(false));
             if is_virtual {
-                if descr.force_virtual_at_guard() {
-                    self.force_lazy_set_field(&descr, true, ctx);
-                    continue;
-                }
                 // heap.py:618-619: virtual value → pendingfields
                 pendingfields.push(op);
                 continue;

--- a/majit/majit-metainterp/src/optimizeopt/heap.rs
+++ b/majit/majit-metainterp/src/optimizeopt/heap.rs
@@ -1320,6 +1320,10 @@ impl OptHeap {
             // heap.py:617-618: val = op.getarg(1); if is_virtual(val)
             let is_virtual = ctx.is_virtual(&op.arg(1).get_box_replacement(false));
             if is_virtual {
+                if descr.force_virtual_at_guard() {
+                    self.force_lazy_set_field(&descr, true, ctx);
+                    continue;
+                }
                 // heap.py:618-619: virtual value → pendingfields
                 pendingfields.push(op);
                 continue;

--- a/majit/majit-metainterp/src/optimizeopt/info.rs
+++ b/majit/majit-metainterp/src/optimizeopt/info.rs
@@ -548,22 +548,19 @@ impl PtrInfoExt for PtrInfo {
                 //       short.extend([GUARD_NONNULL[op],
                 //                     GUARD_GC_TYPE[op, c_typeid]])
                 short.push(Op::new(OpCode::GuardNonnull, &[op_b.clone()]));
-                // GUARD_GC_TYPE only for a real `GcStruct`: it reads a
-                // type-id word at `ref - 8` (the GC header).  A header-less
-                // raw native struct (registered via `register_struct_layout`
-                // — e.g. a `ref(T)` state scalar's target, or a `pools[i]`
-                // element loaded by `getarrayitem_gc_r`) has no such word,
-                // so the guard would read content-dependent garbage that
-                // mutates on every push/pop and fail on every loop
-                // re-entry.  RPython emits GUARD_GC_TYPE only for
-                // `lltype.GcStruct`; a raw `Struct` gets GUARD_NONNULL only.
+                // GUARD_GC_TYPE only for a real headered `GcStruct`: it
+                // reads a type-id word at `ref - 8` (the GC header).  A raw
+                // native struct and a headerless nursery allocation both lack
+                // that word, so the guard would read payload bytes and fail
+                // spuriously.  RPython emits GUARD_GC_TYPE only when a header
+                // exists; headerless structs get GUARD_NONNULL only.
                 // No descr → preserve the guard (default true).
-                let is_gc_managed = info
+                let has_gc_type_header = info
                     .descr
                     .as_size_descr()
-                    .map(|sd| sd.is_gc_managed())
+                    .map(|sd| sd.is_gc_managed() && !sd.headerless())
                     .unwrap_or(true);
-                if is_gc_managed {
+                if has_gc_type_header {
                     let type_id = info
                         .descr
                         .as_size_descr()

--- a/majit/majit-metainterp/src/optimizeopt/virtualize.rs
+++ b/majit/majit-metainterp/src/optimizeopt/virtualize.rs
@@ -3736,7 +3736,6 @@ mod tests {
                 is_quasi_immutable: false,
                 flag: majit_ir::ArrayFlag::Signed,
                 virtualizable: false,
-                force_virtual_at_guard: false,
                 index_in_parent: 0,
             }],
         );
@@ -5377,7 +5376,6 @@ mod tests {
                 is_quasi_immutable: false,
                 flag: majit_ir::ArrayFlag::Unsigned,
                 virtualizable: false,
-                force_virtual_at_guard: false,
                 index_in_parent: 0,
             }],
         );

--- a/majit/majit-metainterp/src/optimizeopt/virtualize.rs
+++ b/majit/majit-metainterp/src/optimizeopt/virtualize.rs
@@ -3736,6 +3736,7 @@ mod tests {
                 is_quasi_immutable: false,
                 flag: majit_ir::ArrayFlag::Signed,
                 virtualizable: false,
+                force_virtual_at_guard: false,
                 index_in_parent: 0,
             }],
         );
@@ -5376,6 +5377,7 @@ mod tests {
                 is_quasi_immutable: false,
                 flag: majit_ir::ArrayFlag::Unsigned,
                 virtualizable: false,
+                force_virtual_at_guard: false,
                 index_in_parent: 0,
             }],
         );

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -6734,6 +6734,7 @@ impl<M: Clone> MetaInterp<M> {
             )
         };
 
+        let partial_ops_before = partial.ops.len();
         let trace_ops: Vec<Op> = {
             let loop_data = compile::UnrolledLoopData::new(
                 &trace,
@@ -6749,7 +6750,9 @@ impl<M: Clone> MetaInterp<M> {
                 .map(|rc| (**rc).clone())
                 .collect()
         };
-        let num_ops_before = trace_ops.len();
+        // `num_combined_ops` below counts the saved partial preamble plus the
+        // retrace body, so the before/after compile-stat slice must do the same.
+        let num_ops_before = partial_ops_before + trace_ops.len();
 
         if crate::majit_log_enabled() {
             eprintln!("--- retrace body (before opt) ---");

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -6167,6 +6167,13 @@ impl<M: Clone> MetaInterp<M> {
                         next_global_opref,
                     },
                 );
+                self.warm_state.log_compile(
+                    green_key,
+                    num_ops_before,
+                    num_ops_after,
+                    std::time::Duration::ZERO,
+                    std::time::Duration::ZERO,
+                );
                 // warmstate.py:339-348 attach the same compiled token object.
                 self.attach_procedure_with_redirect(green_key, Arc::clone(&token));
 
@@ -6742,6 +6749,7 @@ impl<M: Clone> MetaInterp<M> {
                 .map(|rc| (**rc).clone())
                 .collect()
         };
+        let num_ops_before = trace_ops.len();
 
         if crate::majit_log_enabled() {
             eprintln!("--- retrace body (before opt) ---");
@@ -7072,6 +7080,13 @@ impl<M: Clone> MetaInterp<M> {
                         next_global_opref,
                     },
                 );
+                self.warm_state.log_compile(
+                    green_key,
+                    num_ops_before,
+                    num_combined_ops,
+                    std::time::Duration::ZERO,
+                    std::time::Duration::ZERO,
+                );
                 self.attach_procedure_with_redirect(green_key, Arc::clone(&token));
                 self.stats.loops_compiled += 1;
                 // `cpu.tracker.total_compiled_loops` is bumped inside
@@ -7164,15 +7179,31 @@ impl<M: Clone> MetaInterp<M> {
         self.clear_trace_session();
     }
 
-    /// Drop the `pending_abort_*` payload staged by `abort_trace_live`.
+    /// Successful trace teardown: same live cleanup as `abort_trace_live`,
+    /// but without abort accounting on the warm-state cell or JIT logger.
+    pub fn finish_trace_live(&mut self) {
+        self.force_finish_trace = false;
+        self.clear_retrace_state();
+        if let Some(ctx) = self.tracing.take() {
+            let green_key = ctx.green_key;
+            self.warm_state.finish_tracing(green_key);
+            self.pending_token = None;
+            self.pending_abort_green_key = Some(green_key);
+            self.pending_abort_permanent = false;
+            self.clear_trace_session();
+        }
+        self.clear_trace_session();
+    }
+
+    /// Drop the `pending_abort_*` payload staged by live trace teardown.
     ///
-    /// `abort_trace_live` always stages `(green_key, permanent)` for the
+    /// `abort_trace_live` stages `(green_key, permanent)` for the
     /// `aborted_tracing` call that normally follows on the `SwitchToBlackhole`
-    /// unwind. A *successful* compile teardown runs `abort_trace_live` for its
-    /// live cleanup but fires no `aborted_tracing` (raise_if_successful raises
+    /// unwind. Successful compile teardown stages the same payload for cleanup
+    /// parity but fires no `aborted_tracing` (raise_if_successful raises
     /// `ContinueRunningNormally`, pyjitpl.py:3095-3123), so the staged key must
-    /// be dropped here — leaving it would attach this successfully-compiled
-    /// key to a later, unrelated abort's `on_trace_abort` hook.
+    /// be dropped here — leaving it would attach this successfully-compiled key
+    /// to a later, unrelated abort's `on_trace_abort` hook.
     pub fn clear_pending_abort(&mut self) {
         self.pending_abort_green_key = None;
         self.pending_abort_permanent = false;

--- a/majit/majit-metainterp/src/pyjitpl/dispatch.rs
+++ b/majit/majit-metainterp/src/pyjitpl/dispatch.rs
@@ -62,7 +62,6 @@ fn field_spec_from_bh(
         is_quasi_immutable: f.is_quasi_immutable,
         flag: f.field_flag,
         virtualizable: false,
-        force_virtual_at_guard: f.force_virtual_at_guard,
         index_in_parent: f.index_in_parent,
     }
 }
@@ -246,7 +245,6 @@ pub fn struct_field_write_effect_info(
                 is_quasi_immutable: false,
                 flag,
                 virtualizable: false,
-                force_virtual_at_guard: false,
                 index_in_parent: idx,
             }
         })

--- a/majit/majit-metainterp/src/pyjitpl/dispatch.rs
+++ b/majit/majit-metainterp/src/pyjitpl/dispatch.rs
@@ -8669,7 +8669,7 @@ mod tests {
             16,
             0xCD,
             false,
-            &[(0, false, "value", false), (8, true, "next", false)],
+            &[(0, false, "value"), (8, true, "next")],
         ); // ref reg 0 = Node*
         builder.load_const_i_value(0, 99); // int reg 0 = 99
         builder.setfield_gc_i(0, 0, 0, 0xCD); // Node.value = 99
@@ -8741,7 +8741,7 @@ mod tests {
             16,
             0xCE,
             false,
-            &[(0, false, "value", false), (8, true, "next", false)],
+            &[(0, false, "value"), (8, true, "next")],
         );
         builder.setfield_gc_i_c(0, -7, 0, 0xCE); // Node.value = -7 (inline const)
         let jitcode = builder.finish();

--- a/majit/majit-metainterp/src/pyjitpl/dispatch.rs
+++ b/majit/majit-metainterp/src/pyjitpl/dispatch.rs
@@ -15,6 +15,8 @@ use crate::jitcode::insns::MAX_HOST_CALL_ARITY;
 use crate::jitcode::{self, JitArgKind, JitCallArg, JitCallTarget, JitCode, JitCodeRuntimeExt};
 use crate::{TraceAction, TraceCtx};
 
+const HEADERLESS_SIZE_OWNER_MARKER: &str = "__majit_headerless_size__";
+
 /// Decode a virtualizable shadow Value (RPython Box concrete) back into the
 /// raw int/ref/float bit pattern that pyre stores in register shadows
 /// (`frame.int_values`, `frame.ref_values`, `frame.float_values`).
@@ -60,6 +62,7 @@ fn field_spec_from_bh(
         is_quasi_immutable: f.is_quasi_immutable,
         flag: f.field_flag,
         virtualizable: false,
+        force_virtual_at_guard: f.force_virtual_at_guard,
         index_in_parent: f.index_in_parent,
     }
 }
@@ -79,6 +82,7 @@ fn size_descr_ref_from_bh(descr: &crate::blackhole::BhDescr) -> majit_ir::DescrR
         size,
         type_id,
         vtable,
+        owner,
         all_fielddescrs,
         is_gc_managed,
         ..
@@ -86,13 +90,14 @@ fn size_descr_ref_from_bh(descr: &crate::blackhole::BhDescr) -> majit_ir::DescrR
     {
         if !all_fielddescrs.is_empty() {
             let specs: Vec<_> = all_fielddescrs.iter().map(field_spec_from_bh).collect();
-            let group = majit_ir::descr::make_simple_descr_group_keyed(
+            let group = majit_ir::descr::make_simple_descr_group_keyed_with_headerless(
                 u32::MAX,
                 *size,
                 *type_id as u32,
                 *type_id,
                 *vtable as usize,
                 *is_gc_managed,
+                owner == HEADERLESS_SIZE_OWNER_MARKER,
                 &specs,
             );
             let sd: majit_ir::DescrRef = group.size_descr;
@@ -102,20 +107,18 @@ fn size_descr_ref_from_bh(descr: &crate::blackhole::BhDescr) -> majit_ir::DescrR
     let size = descr.as_size();
     let vtable = descr.get_vtable();
     let type_id = descr.get_type_id() as u32;
-    let sd: majit_ir::DescrRef = if vtable != 0 {
-        Arc::new(majit_ir::descr::SimpleSizeDescr::with_vtable(
-            u32::MAX,
-            size,
-            type_id,
-            vtable,
-        ))
+    let headerless = if let crate::blackhole::BhDescr::Size { owner, .. } = descr {
+        owner == HEADERLESS_SIZE_OWNER_MARKER
     } else {
-        Arc::new(majit_ir::descr::SimpleSizeDescr::new(
-            u32::MAX,
-            size,
-            type_id,
-        ))
+        false
     };
+    let mut sd = if vtable != 0 {
+        majit_ir::descr::SimpleSizeDescr::with_vtable(u32::MAX, size, type_id, vtable)
+    } else {
+        majit_ir::descr::SimpleSizeDescr::new(u32::MAX, size, type_id)
+    };
+    sd.set_headerless(headerless);
+    let sd: majit_ir::DescrRef = Arc::new(sd);
     sd
 }
 
@@ -152,13 +155,14 @@ fn field_descr_ref_from_bh(descr: &crate::blackhole::BhDescr) -> (usize, majit_i
                     // Weak parent back-reference upgrades — a freshly built
                     // group would drop its size descr here (the op only
                     // carries the field) and dangle the parent.
-                    majit_ir::descr::make_simple_descr_group_keyed(
+                    majit_ir::descr::make_simple_descr_group_keyed_with_headerless(
                         u32::MAX,
                         p.size,
                         p.type_id as u32,
                         p.type_id,
                         p.vtable as usize,
                         p.is_gc_managed,
+                        false,
                         &specs,
                     );
                     let struct_key = majit_ir::descr::LLType::Struct(p.type_id);
@@ -242,6 +246,7 @@ pub fn struct_field_write_effect_info(
                 is_quasi_immutable: false,
                 flag,
                 virtualizable: false,
+                force_virtual_at_guard: false,
                 index_in_parent: idx,
             }
         })
@@ -8612,7 +8617,7 @@ mod tests {
         // SizeDescr (size from the per-jitcode descr pool) and binds the
         // allocation pointer to the destination ref register.
         let mut builder = JitCodeBuilder::new();
-        builder.new_struct(0, 16, 0xCD, &[]);
+        builder.new_struct(0, 16, 0xCD, false, &[]);
         let jitcode = builder.finish();
 
         let mut ctx = TraceCtx::for_test(0);
@@ -8661,7 +8666,13 @@ mod tests {
         // through the live struct ptr, then read them back.  Exercises the
         // emit -> trace-dispatch -> record path for plain getfield/setfield_gc.
         let mut builder = JitCodeBuilder::new();
-        builder.new_struct(0, 16, 0xCD, &[(0, false, "value"), (8, true, "next")]); // ref reg 0 = Node*
+        builder.new_struct(
+            0,
+            16,
+            0xCD,
+            false,
+            &[(0, false, "value", false), (8, true, "next", false)],
+        ); // ref reg 0 = Node*
         builder.load_const_i_value(0, 99); // int reg 0 = 99
         builder.setfield_gc_i(0, 0, 0, 0xCD); // Node.value = 99
         builder.setfield_gc_r(0, 0, 8, 0xCD); // Node.next  = Node (self-ref)
@@ -8727,7 +8738,13 @@ mod tests {
         // plain `/rid` form — byte 222 (BC_SETFIELD_GC_I_C) is distinct from
         // the NEW family so the arm is reached (insns.rs deconfliction).
         let mut builder = JitCodeBuilder::new();
-        builder.new_struct(0, 16, 0xCE, &[(0, false, "value"), (8, true, "next")]);
+        builder.new_struct(
+            0,
+            16,
+            0xCE,
+            false,
+            &[(0, false, "value", false), (8, true, "next", false)],
+        );
         builder.setfield_gc_i_c(0, -7, 0, 0xCE); // Node.value = -7 (inline const)
         let jitcode = builder.finish();
 

--- a/majit/majit-metainterp/src/pyjitpl/dispatch.rs
+++ b/majit/majit-metainterp/src/pyjitpl/dispatch.rs
@@ -161,7 +161,7 @@ fn field_descr_ref_from_bh(descr: &crate::blackhole::BhDescr) -> (usize, majit_i
                         p.type_id,
                         p.vtable as usize,
                         p.is_gc_managed,
-                        false,
+                        p.headerless,
                         &specs,
                     );
                     let struct_key = majit_ir::descr::LLType::Struct(p.type_id);

--- a/majit/majit-metainterp/src/resume.rs
+++ b/majit/majit-metainterp/src/resume.rs
@@ -7144,6 +7144,69 @@ impl Drop for ResumeRefRootsScope {
     }
 }
 
+fn prepare_resume_heap_with_roots<'a>(
+    resumereader: &mut ResumeDataDirectReader<'a>,
+    rd_virtuals: Option<&'a [VirtualInfo]>,
+    rd_guard_pendingfields: Option<&[majit_ir::GuardPendingFieldEntry]>,
+) -> ResumeRefRootsScope {
+    // resume.py:1324 _prepare = _prepare_virtuals + _prepare_pendingfields.
+    //
+    // Root the lazily-filled `virtuals_cache` for the whole construction
+    // window: decoding a virtual target (`getvirtual_ptr` → allocator)
+    // materializes a fresh boxed object, and a minor collection triggered by a
+    // later materialization relocates the already-built ones. The cache must be
+    // rooted BEFORE the first materialization, including materialization that
+    // happens while applying pending fields.
+    let resume_roots = ResumeRefRootsScope::enter();
+    // resume.py:925 _prepare_virtuals
+    resumereader.prepare_virtuals(rd_virtuals);
+    unsafe {
+        majit_gc::shadow_stack::push_resume_ref_roots(
+            &mut resumereader.virtuals_cache.virtuals_ptr_cache,
+        );
+    }
+    // resume.py:926 _prepare_pendingfields
+    if let Some(guard_pf) = rd_guard_pendingfields {
+        resumereader.prepare_guard_pendingfields(guard_pf);
+    }
+    resume_roots
+}
+
+/// Prepare resume heap side effects without entering a blackhole.
+///
+/// This is the bridge / legacy-deopt counterpart to the heap-prepare block in
+/// `blackhole_from_resumedata`: it sizes `rd_virtuals`, roots the virtual cache,
+/// materializes virtual pending-field targets/values on demand, and applies
+/// `rd_pendingfields`.
+pub fn prepare_resume_heap<'a>(
+    rd_numb: &'a [u8],
+    rd_consts: &'a [majit_ir::Const],
+    all_liveness: &'a [u8],
+    deadframe: &'a [i64],
+    deadframe_types: Option<&'a [majit_ir::Type]>,
+    rd_virtuals: Option<&'a [VirtualInfo]>,
+    rd_guard_pendingfields: Option<&[majit_ir::GuardPendingFieldEntry]>,
+    allocator: &'a dyn BlackholeAllocator,
+) {
+    let Some(guard_pf) = rd_guard_pendingfields else {
+        return;
+    };
+    if guard_pf.is_empty() {
+        return;
+    }
+    let mut resumereader = ResumeDataDirectReader::new(
+        rd_numb,
+        rd_consts,
+        all_liveness,
+        deadframe,
+        deadframe_types,
+        None,
+        allocator,
+    );
+    let _resume_roots =
+        prepare_resume_heap_with_roots(&mut resumereader, rd_virtuals, Some(guard_pf));
+}
+
 pub fn blackhole_from_resumedata<'a>(
     builder: &mut crate::blackhole::BlackholeInterpBuilder,
     resolve_jitcode: &dyn Fn(i32, i32) -> Option<ResolvedJitCode>,
@@ -7180,36 +7243,8 @@ pub fn blackhole_from_resumedata<'a>(
         allocator,
     );
 
-    // resume.py:1324 _prepare = _prepare_virtuals + _prepare_pendingfields.
-    //
-    // Root the lazily-filled `virtuals_cache` (and, in the loop below, each
-    // frame's `registers_r`) for the whole construction window: decoding a
-    // virtual target (`getvirtual_ptr` → allocator) materializes a fresh
-    // boxed object, and a minor collection triggered by a later
-    // materialization relocates the already-built ones.  The raw `Vec`
-    // copies are not otherwise forwarded until `run()`'s `push_bh_regs`, so
-    // a from-space pointer would survive into the blackhole.  RPython traces
-    // these through the GC-managed reader/blackhole objects.
-    //
-    // The cache must be rooted BEFORE the first materialization.
-    // `_prepare_pendingfields` (resume.py:926) already materializes virtual
-    // targets via `decode_ref` → `getvirtual_ptr`, so split `_prepare` and
-    // register the ref cache between sizing it (`_prepare_virtuals`) and the
-    // pending-field application.  The cache buffer is stable after
-    // `_prepare_virtuals` (pre-sized; `set_ptr` only indexes), so the
-    // captured pointer stays valid for the window.
-    let _resume_roots = ResumeRefRootsScope::enter();
-    // resume.py:925 _prepare_virtuals
-    resumereader.prepare_virtuals(rd_virtuals);
-    unsafe {
-        majit_gc::shadow_stack::push_resume_ref_roots(
-            &mut resumereader.virtuals_cache.virtuals_ptr_cache,
-        );
-    }
-    // resume.py:926 _prepare_pendingfields
-    if let Some(guard_pf) = rd_guard_pendingfields {
-        resumereader.prepare_guard_pendingfields(guard_pf);
-    }
+    let _resume_roots =
+        prepare_resume_heap_with_roots(&mut resumereader, rd_virtuals, rd_guard_pendingfields);
 
     // resume.py:1325
     resumereader.consume_vref_and_vable(vrefinfo, vinfo, ginfo, virtualizable_identity_override);

--- a/majit/majit-trace/src/logger.rs
+++ b/majit/majit-trace/src/logger.rs
@@ -196,6 +196,7 @@ impl Logger {
 === JIT Statistics ===
 Traces compiled: {}
 Traces aborted: {}
+Traces bridged: {}
 Total ops recorded: {}
 Total ops after opt: {} ({:.0}% reduction)
 Guard failures: {}
@@ -203,6 +204,7 @@ Optimization time: {:.1}ms
 Compilation time: {:.1}ms",
             self.traces_compiled(),
             self.traces_aborted(),
+            self.bridges_compiled(),
             total_before,
             total_after,
             reduction_pct,

--- a/majit/majit-translate/src/codewriter/assembler.rs
+++ b/majit/majit-translate/src/codewriter/assembler.rs
@@ -2996,7 +2996,6 @@ fn bh_field_spec_from_parts(
         is_field_signed: field_flag == majit_ir::descr::ArrayFlag::Signed,
         is_immutable,
         is_quasi_immutable,
-        force_virtual_at_guard: false,
         index_in_parent,
     }
 }
@@ -3357,7 +3356,6 @@ fn bh_field_spec_from_descr(fd: &dyn majit_ir::descr::FieldDescr) -> crate::jitc
         is_field_signed: fd.is_field_signed(),
         is_immutable: fd.is_immutable(),
         is_quasi_immutable: fd.is_quasi_immutable(),
-        force_virtual_at_guard: fd.force_virtual_at_guard(),
         index_in_parent: fd.index_in_parent(),
     }
 }

--- a/majit/majit-translate/src/codewriter/assembler.rs
+++ b/majit/majit-translate/src/codewriter/assembler.rs
@@ -3032,6 +3032,7 @@ fn bh_size_spec_from_callcontrol(
         // header-less gate is driven by the runtime
         // `register_struct_layout` path.
         is_gc_managed: true,
+        headerless: false,
         // `descr.py:105-127 get_size_descr` keys `_cache_size[STRUCT]` on
         // the lltype STRUCT object identity.  Pyre's analogue is
         // `path_hash(owner)` per `majit_ir::descr::path_hash` doc
@@ -3380,6 +3381,7 @@ fn bh_size_spec_from_descr(sd: &dyn majit_ir::descr::SizeDescr) -> crate::jitcod
         // struct stays raw through the inverse path (it must not regain
         // a spurious `GUARD_GC_TYPE`).
         is_gc_managed: sd.is_gc_managed(),
+        headerless: sd.headerless(),
         all_fielddescrs: sd
             .all_fielddescrs()
             .iter()
@@ -3407,6 +3409,7 @@ pub(crate) fn bh_interior_field_specs_from_array_descr(
                     type_id: 0,
                     vtable: 0,
                     is_gc_managed: true,
+                    headerless: false,
                     all_fielddescrs: vec![field.clone()],
                 });
             Some(crate::jitcode::BhInteriorFieldSpec {

--- a/majit/majit-translate/src/codewriter/assembler.rs
+++ b/majit/majit-translate/src/codewriter/assembler.rs
@@ -2996,6 +2996,7 @@ fn bh_field_spec_from_parts(
         is_field_signed: field_flag == majit_ir::descr::ArrayFlag::Signed,
         is_immutable,
         is_quasi_immutable,
+        force_virtual_at_guard: false,
         index_in_parent,
     }
 }
@@ -3355,6 +3356,7 @@ fn bh_field_spec_from_descr(fd: &dyn majit_ir::descr::FieldDescr) -> crate::jitc
         is_field_signed: fd.is_field_signed(),
         is_immutable: fd.is_immutable(),
         is_quasi_immutable: fd.is_quasi_immutable(),
+        force_virtual_at_guard: fd.force_virtual_at_guard(),
         index_in_parent: fd.index_in_parent(),
     }
 }

--- a/majit/majit-translate/src/codewriter/jitcode.rs
+++ b/majit/majit-translate/src/codewriter/jitcode.rs
@@ -1096,6 +1096,11 @@ pub struct BhSizeSpec {
     /// emitting its guard (default `true`).
     #[serde(default = "bh_gc_managed_default")]
     pub is_gc_managed: bool,
+    /// True when `NEW` for this descr should use the headerless nursery
+    /// allocation opcode.  Default false for older serialized specs and
+    /// analyzer paths that describe ordinary GC-headered structs.
+    #[serde(default)]
+    pub headerless: bool,
     pub all_fielddescrs: Vec<BhFieldSpec>,
 }
 

--- a/majit/majit-translate/src/codewriter/jitcode.rs
+++ b/majit/majit-translate/src/codewriter/jitcode.rs
@@ -1017,6 +1017,7 @@ pub struct BhFieldSpec {
     pub is_field_signed: bool,
     pub is_immutable: bool,
     pub is_quasi_immutable: bool,
+    pub force_virtual_at_guard: bool,
     pub index_in_parent: usize,
 }
 
@@ -1048,6 +1049,7 @@ impl BhFieldSpec {
             is_field_signed: fd.is_field_signed(),
             is_immutable: fd.is_immutable(),
             is_quasi_immutable: fd.is_quasi_immutable(),
+            force_virtual_at_guard: fd.force_virtual_at_guard(),
             index_in_parent: fd.index_in_parent(),
         }
     }

--- a/majit/majit-translate/src/codewriter/jitcode.rs
+++ b/majit/majit-translate/src/codewriter/jitcode.rs
@@ -1017,7 +1017,6 @@ pub struct BhFieldSpec {
     pub is_field_signed: bool,
     pub is_immutable: bool,
     pub is_quasi_immutable: bool,
-    pub force_virtual_at_guard: bool,
     pub index_in_parent: usize,
 }
 
@@ -1049,7 +1048,6 @@ impl BhFieldSpec {
             is_field_signed: fd.is_field_signed(),
             is_immutable: fd.is_immutable(),
             is_quasi_immutable: fd.is_quasi_immutable(),
-            force_virtual_at_guard: fd.force_virtual_at_guard(),
             index_in_parent: fd.index_in_parent(),
         }
     }

--- a/pyre/pyre-jit-trace/src/descr.rs
+++ b/pyre/pyre-jit-trace/src/descr.rs
@@ -32,6 +32,7 @@ use majit_ir::{
 const FIELD_DESCR_TAG: u32 = 0x1000_0000;
 const ARRAY_DESCR_TAG: u32 = 0x2000_0000;
 const SIZE_DESCR_TAG: u32 = 0x3000_0000;
+const HEADERLESS_SIZE_OWNER_MARKER: &str = "__majit_headerless_size__";
 
 // Reserved, hand-assigned indices for mutable-cell payload fields. The
 // runtime `HeapCache` keys entries by `descr.index()`; `stable_field_index`
@@ -2756,6 +2757,7 @@ mod tests {
             type_id: 7,
             vtable: 0,
             is_gc_managed: true,
+            headerless: false,
             all_fielddescrs: vec![
                 BhFieldSpec {
                     index: 0,
@@ -3020,6 +3022,7 @@ mod tests {
             type_id: 11,
             vtable: 0,
             is_gc_managed: true,
+            headerless: false,
             all_fielddescrs: fields.clone(),
         };
         let interior_fields = vec![
@@ -3180,13 +3183,14 @@ fn simple_descr_group_from_bh_size(
         // gc_cache.init_size_descr in the canonical path; this factory
         // bypasses that, so the tid stays a path_hash-derived u32 with
         // birthday-paradox collision risk around 2^16 distinct STRUCTs).
-        majit_ir::descr::make_simple_descr_group_keyed(
+        majit_ir::descr::make_simple_descr_group_keyed_with_headerless(
             u32::MAX,
             spec.size,
             spec.type_id as u32,
             spec.type_id,
             spec.vtable as usize,
             spec.is_gc_managed,
+            spec.headerless,
             &field_specs,
         )
     };
@@ -3876,6 +3880,7 @@ pub fn make_descr_from_bh(bh: &majit_translate::jitcode::BhDescr) -> DescrRef {
             size,
             type_id,
             vtable,
+            owner,
             all_fielddescrs,
             is_gc_managed,
             ..
@@ -3918,7 +3923,8 @@ pub fn make_descr_from_bh(bh: &majit_translate::jitcode::BhDescr) -> DescrRef {
             // `pyre-jit/src/eval.rs` (`bh_new` / `bh_new_with_vtable`
             // dispatch) carries an empty list and falls through to the
             // bare ctor, which is the existing test-helper shape.
-            if all_fielddescrs.is_empty() {
+            let headerless = owner == HEADERLESS_SIZE_OWNER_MARKER;
+            if all_fielddescrs.is_empty() && !headerless {
                 // TODO: `make_size_descr_with_type_and_vtable`
                 // takes the u32 gc tid; `*type_id` is the u64 cache key.
                 // Truncate `as u32` until gc_cache routing.
@@ -3929,6 +3935,7 @@ pub fn make_descr_from_bh(bh: &majit_translate::jitcode::BhDescr) -> DescrRef {
                     type_id: *type_id,
                     vtable: *vtable,
                     is_gc_managed: *is_gc_managed,
+                    headerless,
                     all_fielddescrs: all_fielddescrs.clone(),
                 };
                 simple_descr_group_from_bh_size(&spec).size_descr.clone()

--- a/pyre/pyre-jit-trace/src/descr.rs
+++ b/pyre/pyre-jit-trace/src/descr.rs
@@ -2486,7 +2486,6 @@ pub fn ec_sys_exc_value_descr() -> DescrRef {
                 is_quasi_immutable: false,
                 flag: ArrayFlag::Unsigned,
                 virtualizable: false,
-                force_virtual_at_guard: false,
                 index_in_parent: 0,
             }],
         )
@@ -2769,7 +2768,6 @@ mod tests {
                     is_field_signed: false,
                     is_immutable: false,
                     is_quasi_immutable: false,
-                    force_virtual_at_guard: false,
                     index_in_parent: 0,
                 },
                 BhFieldSpec {
@@ -2782,7 +2780,6 @@ mod tests {
                     is_field_signed: true,
                     is_immutable: true,
                     is_quasi_immutable: false,
-                    force_virtual_at_guard: false,
                     index_in_parent: 1,
                 },
             ],
@@ -3000,7 +2997,6 @@ mod tests {
                 is_field_signed: true,
                 is_immutable: false,
                 is_quasi_immutable: false,
-                force_virtual_at_guard: false,
                 index_in_parent: 0,
             },
             BhFieldSpec {
@@ -3013,7 +3009,6 @@ mod tests {
                 is_field_signed: false,
                 is_immutable: false,
                 is_quasi_immutable: false,
-                force_virtual_at_guard: false,
                 index_in_parent: 1,
             },
         ];
@@ -3129,7 +3124,6 @@ fn simple_field_spec_from_bh(
         is_quasi_immutable: spec.is_quasi_immutable,
         flag: spec.field_flag,
         virtualizable: false,
-        force_virtual_at_guard: spec.force_virtual_at_guard,
         index_in_parent: spec.index_in_parent,
     }
 }
@@ -3808,7 +3802,6 @@ pub fn make_descr_from_bh(bh: &majit_translate::jitcode::BhDescr) -> DescrRef {
                 is_field_signed: *is_field_signed,
                 is_immutable: *is_immutable,
                 is_quasi_immutable: *is_quasi_immutable,
-                force_virtual_at_guard: false,
                 index_in_parent: *index_in_parent,
             };
             field_descr_from_bh_field(&field, parent.as_ref())

--- a/pyre/pyre-jit-trace/src/descr.rs
+++ b/pyre/pyre-jit-trace/src/descr.rs
@@ -2485,6 +2485,7 @@ pub fn ec_sys_exc_value_descr() -> DescrRef {
                 is_quasi_immutable: false,
                 flag: ArrayFlag::Unsigned,
                 virtualizable: false,
+                force_virtual_at_guard: false,
                 index_in_parent: 0,
             }],
         )
@@ -2766,6 +2767,7 @@ mod tests {
                     is_field_signed: false,
                     is_immutable: false,
                     is_quasi_immutable: false,
+                    force_virtual_at_guard: false,
                     index_in_parent: 0,
                 },
                 BhFieldSpec {
@@ -2778,6 +2780,7 @@ mod tests {
                     is_field_signed: true,
                     is_immutable: true,
                     is_quasi_immutable: false,
+                    force_virtual_at_guard: false,
                     index_in_parent: 1,
                 },
             ],
@@ -2995,6 +2998,7 @@ mod tests {
                 is_field_signed: true,
                 is_immutable: false,
                 is_quasi_immutable: false,
+                force_virtual_at_guard: false,
                 index_in_parent: 0,
             },
             BhFieldSpec {
@@ -3007,6 +3011,7 @@ mod tests {
                 is_field_signed: false,
                 is_immutable: false,
                 is_quasi_immutable: false,
+                force_virtual_at_guard: false,
                 index_in_parent: 1,
             },
         ];
@@ -3121,6 +3126,7 @@ fn simple_field_spec_from_bh(
         is_quasi_immutable: spec.is_quasi_immutable,
         flag: spec.field_flag,
         virtualizable: false,
+        force_virtual_at_guard: spec.force_virtual_at_guard,
         index_in_parent: spec.index_in_parent,
     }
 }
@@ -3798,6 +3804,7 @@ pub fn make_descr_from_bh(bh: &majit_translate::jitcode::BhDescr) -> DescrRef {
                 is_field_signed: *is_field_signed,
                 is_immutable: *is_immutable,
                 is_quasi_immutable: *is_quasi_immutable,
+                force_virtual_at_guard: false,
                 index_in_parent: *index_in_parent,
             };
             field_descr_from_bh_field(&field, parent.as_ref())


### PR DESCRIPTION
## Summary

Node virtualization for the aheui tracing JIT: the transient push/pop linked-list
`Node` allocations that never escape a trace are folded away instead of emitting a
residual allocation call per push. On the logo benchmark this is a **~1.9x
wall-clock speedup** (independently corroborated by a −47.6% IR reduction,
39210 → 20564 optimized ops), byte-identical output vs the naive interpreter.

The branch carries the 3-commit epic plus two supporting majit commits.

## The node-virt epic (3 commits)

The aheui `Node` (`#[repr(C)] { value @0, next @8 }`, 16B, **headerless** — no
`GcHeader`) is allocated on every `OP_PUSH`/`OP_DUP`/`OP_MOV`. Previously each was a
residual ref-returning call; now the trace emits an `OpCode::New` + field stores
that the optimizer folds when the node does not escape.

Three pieces of majit machinery make this correct:

1. **Headerless nursery-alloc opcode** (`1d8db58`) — a new
   `OpCode::CallMallocNurseryHeaderless` threaded through the descr/rewriter/regalloc
   and the aarch64 + x86 dynasm backends: a 16B inline nursery bump that returns the
   raw base (no `GcHeader`, no header-zeroing), because the aheui copying collector
   assumes headerless 16B node slots. The stock headered `CallMallocNursery` reserves
   and returns `base + GcHeader::SIZE`, which would corrupt the node layout. cranelift
   (non-default backend) lowers the tagged op as an ordinary call. A per-field
   `force_virtual_at_guard` flag lets a flagged field's virtual RHS be materialized at
   a guard rather than deferred.

2. **Bridge/legacy deopt-path reconstruction** (`a5f8117`) — the bridge and legacy
   fallback deopt paths applied guard pending fields via `materialize_pending_fields`,
   which reads `raw_values[slot]` directly with **no** `rd_virtuals` materialization,
   so a pending field whose value is a never-forced virtual resolved to garbage. The
   virtuals-then-pendingfields step is factored out of `blackhole_from_resumedata`
   into `prepare_resume_heap` (`prepare_virtuals` + `push_resume_ref_roots` +
   `prepare_guard_pendingfields`, wrapped in `ResumeRefRootsScope`) and called from
   both paths before recover, so virtual pending-field targets are reconstructed and
   GC-rooted across a mid-reconstruction collect. Non-virtual pending fields decode to
   the same value the previous `raw_values` read produced (behavior-neutral for pyre).

3. **Parity-review robustness fixes** (`a72cd44`) — preserve the headerless flag
   through the inverse descr-reconstruction path (`BhSizeSpec.headerless`), key
   `force_at_guard` on the full canonical struct path (producer + consumer),
   `debug_assert` that a headerless `NEW` size is nursery-eligible, and correct a
   stale `is_gc_managed` comment. No behavior change (see Parity review below).

The concrete aheui-side activation (the `NodeJit` struct literals + `struct_allocs` /
`headerless_structs` config) lives in the separate aheui backend repo; this PR is the
pyre-side infrastructure.

## Supporting commits

- `307e8bc` — jit_interp lowering: pool-array element type, logical `&&`/`||`, and
  const-path values.
- `f02d628` — fix the `MAJIT_STATS` trace counters (compiled / aborted / bridged) so
  the diagnostics report real trace outcomes.

## Parity review

A scoped Codex parity review (`b820a15d823..HEAD` vs upstream RPython/PyPy) found
**no parity regressions** (§1 = 0). Of 6 new mismatches: 4 fixed in `a72cd44`, 1
false positive (headerless slowpath has a dedicated base-returning path), 1
reclassified as an intentional cranelift adaptation. One pre-existing mismatch
(`force_from_resumedata` lacks a `ResumeRefRootsScope`) is tracked as a follow-up; it
is not on any path this change introduces. The 3 structural adaptations (new
headerless opcode / explicit resume-cache rooting / per-field force-at-guard flag) are
valid RPython↔Rust/GC-model gaps and documented in-code.

## Verification

- `pyre/check.py`: **dynasm 181/181, cranelift 181/181, wasm 180/180**.
- logo byte-id: rc 42, 996310 bytes, md5 `7fcdbfff0af449c4283c008e3ca317ce`,
  jit output identical to `--no-jit` (release + debug + small-`NURSERY_SIZE` forced-collect).
- A debug-only chain-length-vs-size canary on every ordinary stack stays silent
  across all deopt paths.
- `majit-backend-dynasm` test corpus green; `cargo fmt` clean.

— *commented by Claude*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for headerless nursery allocations for eligible objects, improving allocation efficiency.
  * Added configuration for headerless structures and fields that must be materialized at guard points.
  * Improved pool-array type tracking for more accurate runtime handling.

* **Bug Fixes**
  * Improved heap preparation and virtual field restoration during exits, bridges, and resumed execution.
  * Corrected boolean `AND` and `OR` lowering behavior.
  * Trace summaries now report bridged traces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->