### PR TITLE
unroll: guard short-preamble force-loop on unmapped jump arg

### DIFF
--- a/majit/majit-metainterp/src/optimizeopt/pure.rs
+++ b/majit/majit-metainterp/src/optimizeopt/pure.rs
@@ -981,6 +981,12 @@ impl Optimization for OptPure {
                 }
                 // Record and emit both the OVF op and the guard.
                 self.cache.insert(key, postponed.pos.get());
+                // pure.py:321-322: an is_ovf op followed by GUARD_NO_OVERFLOW is
+                // hoistable into the short preamble, like an is_always_pure op
+                // (pure.py:319-320). Push it so produce_potential_short_preamble_ops
+                // replays it and a loop-invariant overflow-checked op is computed
+                // once in the peeled preamble instead of every iteration.
+                self.short_preamble_pure_ops.push(postponed.clone());
                 ctx.emit(postponed);
                 return OptimizationResult::PassOn; // guard passes through
             } else {

--- a/majit/majit-metainterp/src/optimizeopt/unroll.rs
+++ b/majit/majit-metainterp/src/optimizeopt/unroll.rs
@@ -3956,7 +3956,7 @@ impl OptUnroll {
                 }
             }
 
-            // unroll.py:417-423: force all except virtuals.
+            // unroll.py:417-434: force all except virtuals.
             loop {
                 let short_jump_args = current_short_jump_args(short_preamble, ctx);
                 let num_short_jump_args = short_jump_args.len();
@@ -3977,7 +3977,20 @@ impl OptUnroll {
                 for &arg in args_no_virtuals.iter().chain(mapped_jump_args.iter()) {
                     let _ = optimizer.force_box(arg, ctx);
                 }
-                if current_short_jump_args(short_preamble, ctx).len() == num_short_jump_args {
+                // unroll.py:425-434: if short_jump_args did not grow we are
+                // done. If force_box grew it via add_preamble_op, only re-force
+                // when every new entry is a Const or already in `mapping`;
+                // otherwise break and let the outer replay loop register the
+                // producer first, since the top-of-loop _map_args above would
+                // otherwise read an unmapped arg.
+                let grown = current_short_jump_args(short_preamble, ctx);
+                if grown.len() == num_short_jump_args {
+                    break;
+                }
+                let all_new_mapped = grown[num_short_jump_args..]
+                    .iter()
+                    .all(|arg| arg.is_constant() || mapping.contains_key(arg));
+                if !all_new_mapped {
                     break;
                 }
             }


### PR DESCRIPTION
One commit porting the upstream `inline_short_preamble` inner fix-point guard.

### The bug
`inline_short_preamble`'s inner force-box loop re-forces `short_jump_args` until the list stops growing. When `force_box` grows the list via `add_preamble_op` with a producer short-op not yet replayed, the newly-added jump arg is absent from `mapping`; on the immediate re-loop the top-of-loop `_map_args` panicked (`expect("mapping missing jump_arg")`), aborting the JIT process instead of deferring.

### The fix
Port `unroll.py:425-434` (pypy fix `983edc22e589` / gh-5212): after the list grows, break out of the inner loop when any new non-`Const` entry is not yet in `mapping`, deferring to the outer replay loop to register it; only re-force when every new entry is a `Const` or already mapped. The stale comment citing the pre-guard range (`417-423`) is updated to `417-434`.

### Verification
- `majit-metainterp` lib: dynasm 1396 / cranelift 1394, 0 failed
- `check.py`: dynasm 181/181, cranelift 181/181
- accumulator hot-loop repro: `PYRE_JIT=0` oracle == JIT on both backends

— *commented by Claude*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of overflow-checked operations during optimized loop execution.
  * Fixed short preamble replay behavior when new values are discovered, improving correctness and stability.

* **Performance**
  * Reduced repeated computation inside loops by enabling eligible operations to be calculated once and reused.
  * Improved optimization of unrolled loops and peeled preambles for more efficient runtime execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->