### PR TITLE
gc: free a swept dict's out-of-line dstorage via a strategy destructor (#528)

### DIFF
--- a/pyre/pyre-interpreter/src/objspace/std/mapdict.rs
+++ b/pyre/pyre-interpreter/src/objspace/std/mapdict.rs
@@ -2781,6 +2781,11 @@ impl pyre_object::dictmultiobject::DictStrategy for MapDictStrategy {
         Box::into_raw(Box::new(w_result)) as *mut u8
     }
 
+    /// Production MapDictStrategy storage is a borrowed GC edge to the
+    /// backing `W_ObjectObject` (`strategy.erase(self)`), not a container
+    /// owned by the dict view.  The instance collector reclaims it.
+    unsafe fn dealloc_storage(&self, _w_dict: PyObjectRef) {}
+
     /// mapdict.py:1157-1166 `getitem`.
     unsafe fn getitem(&self, w_dict: PyObjectRef, w_key: PyObjectRef) -> Option<PyObjectRef> {
         if pyre_object::is_str(w_key) {

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -467,6 +467,18 @@ unsafe fn dict_object_custom_trace(obj_addr: usize, f: &mut dyn FnMut(*mut majit
     unsafe { strategy.walk_gc_refs(w_dict, &mut adapter) };
 }
 
+/// Reclaim the Rust-owned erased storage container of a swept regular dict.
+/// The strategy reconstructs the exact Box type; contained PyObjectRefs remain
+/// collector-owned.  MapDictStrategy's dstorage is a borrowed GC edge and its
+/// strategy deallocator is deliberately a no-op.
+unsafe fn dict_object_destructor(obj_addr: usize) {
+    let obj = obj_addr as pyre_object::PyObjectRef;
+    let dict = unsafe { &*(obj as *const pyre_object::dictmultiobject::W_DictObject) };
+    if !dict.dstorage.is_null() {
+        unsafe { dict.dstrategy.dealloc_storage(obj) };
+    }
+}
+
 /// Custom trace for `W_ObjectObject` (instance `map`+`storage`,
 /// `mapdict.py:907-910`).  The `storage` list is an off-GC
 /// `Box<Vec<PyObjectRef>>`, so — exactly as `dict_object_custom_trace`
@@ -1450,11 +1462,14 @@ fn build_gc() -> Box<dyn majit_gc::GcAllocator> {
     // PyObjectRef)>` behind a raw pointer. Register a custom trace
     // hook so the GC updates those indirect key/value slots just as it
     // updates inline object fields.
-    let w_dict_tid = gc.register_type(TypeInfo::object_subclass_with_custom_trace(
-        std::mem::size_of::<pyre_object::dictmultiobject::W_DictObject>(),
-        object_tid,
-        dict_object_custom_trace,
-    ));
+    let w_dict_tid = gc.register_type(
+        TypeInfo::object_subclass_with_custom_trace(
+            std::mem::size_of::<pyre_object::dictmultiobject::W_DictObject>(),
+            object_tid,
+            dict_object_custom_trace,
+        )
+        .with_destructor_fn(dict_object_destructor),
+    );
     debug_assert_eq!(w_dict_tid, W_DICT_GC_TYPE_ID);
     majit_gc::GcAllocator::register_vtable_for_type(
         &mut gc,

--- a/pyre/pyre-object/src/celldict.rs
+++ b/pyre/pyre-object/src/celldict.rs
@@ -938,6 +938,11 @@ impl crate::dictmultiobject::DictStrategy for ModuleDictStrategy {
         crate::lltype::malloc_raw(ModuleDictStorage::new()) as *mut u8
     }
 
+    unsafe fn dealloc_storage(&self, w_dict: PyObjectRef) {
+        let dict = &*(w_dict as *const crate::dictmultiobject::W_ModuleDictObject);
+        drop(Box::from_raw(dict.dstorage));
+    }
+
     /// `celldict.py:131-141 getitem` — str fast path, else
     /// `switch_to_object_strategy` then walk unified entries.
     /// Body in `w_module_dict_lookup_inner` to avoid recursing

--- a/pyre/pyre-object/src/dictmultiobject.rs
+++ b/pyre/pyre-object/src/dictmultiobject.rs
@@ -2579,11 +2579,15 @@ pub unsafe fn w_dict_adopt_regular_copy_for_empty_update(dst: PyObjectRef, w_cop
     debug_assert!(!is_module_dict(w_copy));
 
     let dst_dict = &mut *(dst as *mut W_DictObject);
-    let copy_dict = &*(w_copy as *const W_DictObject);
+    let copy_dict = &mut *(w_copy as *mut W_DictObject);
     let old_dstorage = dst_dict.dstorage;
 
     dst_dict.dstrategy = copy_dict.dstrategy;
     dst_dict.dstorage = copy_dict.dstorage;
+    // `w_copy` is a consumed temporary.  Move, rather than alias, its storage:
+    // once W_DictObject has a GC destructor, leaving both dicts pointing at the
+    // same Box would let the temporary free the destination's live backing.
+    copy_dict.dstorage = std::ptr::null_mut();
     dict_write_barrier(dst);
 
     if !old_dstorage.is_null() {
@@ -3961,6 +3965,15 @@ pub trait DictStrategy {
     /// freshly-allocated erased storage for this strategy.  Required.
     fn get_empty_storage(&self) -> *mut u8;
 
+    /// Free the out-of-line `dstorage` container owned by this dict on
+    /// collection. Frees the Rust map/Vec backing ONLY; the `PyObjectRef`
+    /// keys/values are GC-managed and reclaimed by the collector.
+    ///
+    /// # Safety
+    /// `w_dict` must be a valid `W_DictObject` whose strategy is `self`, and
+    /// called at most once (from the GC destructor of a swept dict).
+    unsafe fn dealloc_storage(&self, w_dict: PyObjectRef);
+
     /// `dictmultiobject.py:469-470 getitem` — required.
     ///
     /// # Safety
@@ -4533,6 +4546,10 @@ impl DictStrategy for EmptyKwargsDictStrategy {
         EMPTY_DICT_STRATEGY.get_empty_storage()
     }
 
+    /// `w_dict_new_kwargs` represents `erased(None)` with a null pointer;
+    /// there is no allocation to reclaim while this strategy is active.
+    unsafe fn dealloc_storage(&self, _w_dict: PyObjectRef) {}
+
     /// An empty kwargs dict has the `erased(None)` null `dstorage` from
     /// `w_dict_new_kwargs` and holds no entries — `setitem`/`setitem_str`
     /// switch to a concrete strategy before storing — so there is nothing
@@ -4638,6 +4655,16 @@ impl DictStrategy for EmptyDictStrategy {
         // until `switch_to_correct_strategy` flips the dict to a
         // concrete strategy and the Vec starts receiving entries.
         std::ptr::null_mut()
+    }
+
+    /// Regular empty dicts carry a per-dict Object-shape placeholder allocated
+    /// by `w_dict_new`; it is not the shared/null `erased(None)` sentinel.
+    unsafe fn dealloc_storage(&self, w_dict: PyObjectRef) {
+        let dict = &*(w_dict as *const crate::dictmultiobject::W_DictObject);
+        drop(Box::from_raw(
+            dict.dstorage
+                as *mut indexmap::IndexMap<crate::dictmultiobject::ObjectKey, PyObjectRef>,
+        ));
     }
 
     /// `dictmultiobject.py:732-736 EmptyDictStrategy.switch_to_object_strategy`
@@ -4832,6 +4859,14 @@ impl DictStrategy for ObjectDictStrategy {
         Box::into_raw(v) as *mut u8
     }
 
+    unsafe fn dealloc_storage(&self, w_dict: PyObjectRef) {
+        let dict = &*(w_dict as *const crate::dictmultiobject::W_DictObject);
+        drop(Box::from_raw(
+            dict.dstorage
+                as *mut indexmap::IndexMap<crate::dictmultiobject::ObjectKey, PyObjectRef>,
+        ));
+    }
+
     /// `dictmultiobject.py:1213-1215 getitem` — `self.unerase
     /// (w_dict.dstorage).get(w_key)` plus pyre's `dict_storage_proxy`
     /// storage-first contract for str keys.  Body in
@@ -5011,6 +5046,13 @@ impl DictStrategy for BytesDictStrategy {
         Box::into_raw(v) as *mut u8
     }
 
+    unsafe fn dealloc_storage(&self, w_dict: PyObjectRef) {
+        let dict = &*(w_dict as *const crate::dictmultiobject::W_DictObject);
+        drop(Box::from_raw(
+            dict.dstorage as *mut indexmap::IndexMap<Vec<u8>, PyObjectRef>,
+        ));
+    }
+
     /// `dictmultiobject.py:1095-1103 AbstractTypedStrategy.getitem`.
     unsafe fn getitem(&self, w_dict: PyObjectRef, w_key: PyObjectRef) -> Option<PyObjectRef> {
         if crate::is_bytes(w_key) {
@@ -5170,6 +5212,14 @@ impl DictStrategy for UnicodeDictStrategy {
         let v: Box<indexmap::IndexMap<crate::dictmultiobject::ObjectKey, PyObjectRef>> =
             Box::new(indexmap::IndexMap::new());
         Box::into_raw(v) as *mut u8
+    }
+
+    unsafe fn dealloc_storage(&self, w_dict: PyObjectRef) {
+        let dict = &*(w_dict as *const crate::dictmultiobject::W_DictObject);
+        drop(Box::from_raw(
+            dict.dstorage
+                as *mut indexmap::IndexMap<crate::dictmultiobject::ObjectKey, PyObjectRef>,
+        ));
     }
 
     /// `dictmultiobject.py:1095-1103 AbstractTypedStrategy.getitem`.
@@ -5379,6 +5429,13 @@ impl DictStrategy for IntDictStrategy {
     fn get_empty_storage(&self) -> *mut u8 {
         let v: Box<indexmap::IndexMap<i64, PyObjectRef>> = Box::new(indexmap::IndexMap::new());
         Box::into_raw(v) as *mut u8
+    }
+
+    unsafe fn dealloc_storage(&self, w_dict: PyObjectRef) {
+        let dict = &*(w_dict as *const crate::dictmultiobject::W_DictObject);
+        drop(Box::from_raw(
+            dict.dstorage as *mut indexmap::IndexMap<i64, PyObjectRef>,
+        ));
     }
 
     /// `dictmultiobject.py:1095-1103 AbstractTypedStrategy.getitem`.

--- a/pyre/pyre-object/src/identitydict.rs
+++ b/pyre/pyre-object/src/identitydict.rs
@@ -149,6 +149,13 @@ impl DictStrategy for IdentityDictStrategy {
         Box::into_raw(v) as *mut u8
     }
 
+    unsafe fn dealloc_storage(&self, w_dict: PyObjectRef) {
+        let dict = &*(w_dict as *const crate::dictmultiobject::W_DictObject);
+        drop(Box::from_raw(
+            dict.dstorage as *mut indexmap::IndexMap<IdentityKey, PyObjectRef>,
+        ));
+    }
+
     /// `dictmultiobject.py:1095-1103 AbstractTypedStrategy.getitem` —
     /// O(1) identity-keyed lookup.
     unsafe fn getitem(&self, w_dict: PyObjectRef, w_key: PyObjectRef) -> Option<PyObjectRef> {

--- a/pyre/pyre-object/src/kwargsdict.rs
+++ b/pyre/pyre-object/src/kwargsdict.rs
@@ -112,6 +112,13 @@ impl DictStrategy for KwargsDictStrategy {
         Box::into_raw(v) as *mut u8
     }
 
+    unsafe fn dealloc_storage(&self, w_dict: PyObjectRef) {
+        let dict = &*(w_dict as *const crate::dictmultiobject::W_DictObject);
+        drop(Box::from_raw(
+            dict.dstorage as *mut (Vec<PyObjectRef>, Vec<PyObjectRef>),
+        ));
+    }
+
     /// `kwargsdict.py:134-141 switch_to_object_strategy` — walk
     /// parallel arrays, rebuild `IndexMap<ObjectKey, PyObjectRef>`,
     /// retire the typed parallel-array box.


### PR DESCRIPTION
Advances #528 by making a collected dict reclaim its out-of-line storage. Follows inc2 (#547, merged) in the #205 DictStorage-elimination line.

## What

`W_DICT_GC_TYPE_ID` was registered with a custom trace but **no destructor**, so every collected `W_DictObject` leaked its out-of-line `dstorage` container (a `Box::into_raw`'d `IndexMap` / kwargs `Vec` pair). This was the last general #528 residual, surfaced (not caused) by inc2 which moved the type-namespace leak onto `W_DictObject.dstorage`.

Add `DictStrategy::dealloc_storage`, implemented per strategy to drop the exact typed `Box` behind `dstorage`, and register a `dict_object_destructor` on `W_DICT_GC_TYPE_ID` that dispatches through `dstrategy.dealloc_storage`. It frees the **Rust container only** — the `PyObjectRef` keys/values are GC-managed and reclaimed by the collector (the custom trace already forwards them).

## Safety (the hard part — a GC free path)

- **Per-strategy typed free**: Object/Unicode → `IndexMap<ObjectKey,_>`, Int → `IndexMap<i64,_>`, Bytes → `IndexMap<Vec<u8>,_>`, Identity → `IndexMap<IdentityKey,_>`, Kwargs → `(Vec,Vec)`, Module → `ModuleDictStorage`. A regular empty dict carries a per-dict `IndexMap<ObjectKey,_>` box (from `w_dict_new`); the `EmptyKwargs` strategy (distinct) and null `dstorage` are no-ops under the destructor's null-guard.
- **`MapDictStrategy` → no-op**: its `dstorage` is a *borrowed* GC edge into the backing `W_ObjectObject` (collector-owned), so it must not be `Box`-freed — the exact failure class of the earlier `mro_w` regression.
- **Aliasing fix**: `w_dict_adopt_regular_copy_for_empty_update` previously left the consumed copy aliasing the destination's box; it now nulls the consumed copy's `dstorage` (a true move), so the destructor can never double-free a live backing.
- **`dict_storage_proxy`** left untouched (externally owned / potentially aliased bridge).

## Verification

- `python3 pyre/check.py` — dynasm 181/181, cranelift 181/181, wasm 180/180 (ALL PASSED).
- `cargo test -p pyre-jit --features dynasm --test gc_stress` — 6/6; full `cargo test -p pyre-jit` — 306 passed.
- #528 bounded-RSS smoke: 200k allocate-and-drop dicts (str/int/bytes/kwargs) under GC pressure → RSS plateaus at ~40 MB (no per-dict `dstorage` growth).
- Retained `.keys()`/`.items()`/`mappingproxy` after collection pressure → correct values, no UAF.
- Adversarial multi-agent GC-soundness review (aliasing-move, empty-dict storage type, double-free / trace-after-free / leak): 3/3 SOUND, no confirmed defects.

## Notes

- Remaining #528 item: the type `terminator` (shared mapdict-node ownership) is still deferred.

— *opened by Claude*
