### PR TITLE
wasm: pick loop-header label by JUMP descr; jit: scope abort_permanent to loop body

### DIFF
--- a/majit/majit-backend-wasm/src/codegen.rs
+++ b/majit/majit-backend-wasm/src/codegen.rs
@@ -1549,12 +1549,10 @@ fn build_function(
 
     // A peeled loop arrives as `[preamble..][LABEL][body..][JUMP]`: the
     // preamble runs once on entry, the LABEL is the loop-back target, and
-    // JUMP branches back to it. Emit the `loop` at the LABEL (not the top)
-    // so the preamble is not re-executed every iteration; wrap everything in
-    // a `block` so guard exits `br` out to the function epilogue. Use the
-    // LAST label (a peeled trace may carry an outer entry label plus the
-    // inner loop header).
-    let loop_label_idx = ops.iter().rposition(|op| op.opcode == OpCode::Label);
+    // JUMP branches back to it. Emit the `loop` at the LABEL selected by the
+    // terminal JUMP's descr (not merely the last LABEL) so multi-label traces
+    // re-execute the complete loop body.
+    let loop_label_idx = find_loop_label_index(ops);
     let has_loop = loop_label_idx.is_some();
 
     // Def / last-use positions for the post-collection Ref reload filter.
@@ -1757,7 +1755,7 @@ fn build_function(
                 // value to a later read. Do all reads first (push every resolved
                 // jump arg onto the operand stack), then all writes (pop into the
                 // targets in reverse, the stack being LIFO).
-                let label_args = find_label_args(ops);
+                let label_args = find_label_args(ops, op);
                 let jump_args = op.getarglist();
                 let n = jump_args.len().min(label_args.len());
                 for jump_arg in jump_args.iter().take(n) {
@@ -3907,10 +3905,17 @@ fn build_function(
 /// its JUMP's descr identifies one of the source loop's OWN labels
 /// (`label_descrs`) with matching arity and a resume-safe live set.
 pub fn is_resumable_peeled(ops: &[Op]) -> bool {
-    let Some(last_label) = ops.iter().rposition(|op| op.opcode == OpCode::Label) else {
+    let Some(loop_label) = find_loop_label_index(ops) else {
         return false;
     };
-    ops[..last_label]
+    // The current entry br_table closes every label-loader block before it
+    // opens the wasm `loop`, so it supports only the shape whose actual JUMP
+    // target is the last LABEL. Other multi-label shapes still compile as a
+    // normal local loop but do not advertise in-module label re-entry.
+    if ops.iter().rposition(|op| op.opcode == OpCode::Label) != Some(loop_label) {
+        return false;
+    }
+    ops[..loop_label]
         .iter()
         .any(|op| op.opcode != OpCode::Label)
 }
@@ -3978,10 +3983,37 @@ pub fn label_resume_safety(ops: &[Op]) -> Vec<bool> {
         .collect()
 }
 
-fn find_label_args(ops: &[Op]) -> Vec<OpRef> {
-    // The JUMP branches back to the loop-header label, which is the LAST
-    // label in a peeled trace (an outer entry label may precede it). The
-    // `loop` is emitted at that same label in `build_function`.
+fn find_jump_target_label_index(ops: &[Op], jump: &Op) -> Option<usize> {
+    let target = jump.getdescr()?;
+    ops.iter().position(|op| {
+        op.opcode == OpCode::Label
+            && op
+                .getdescr()
+                .is_some_and(|descr| std::sync::Arc::ptr_eq(&descr, &target))
+    })
+}
+
+fn find_loop_label_index(ops: &[Op]) -> Option<usize> {
+    ops.iter()
+        .rev()
+        .find(|op| op.opcode == OpCode::Jump)
+        .and_then(|jump| find_jump_target_label_index(ops, jump))
+        .or_else(|| ops.iter().rposition(|op| op.opcode == OpCode::Label))
+}
+
+fn find_label_args(ops: &[Op], jump: &Op) -> Vec<OpRef> {
+    // A multi-label trace's JUMP does not necessarily target its last label.
+    // LABEL and JUMP share the loop-target descr, so resolve the target by Arc
+    // identity just like compile_bridge's external-JUMP path. Falling back to
+    // the last label preserves the historical behavior for legacy IR whose
+    // JUMP carries no descr.
+    if let Some(label_idx) = find_jump_target_label_index(ops, jump) {
+        return ops[label_idx]
+            .getarglist()
+            .iter()
+            .map(|arg| arg.to_opref())
+            .collect();
+    }
     for op in ops.iter().rev() {
         if op.opcode == OpCode::Label {
             return op.getarglist().iter().map(|a| a.to_opref()).collect();

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -2254,25 +2254,58 @@ fn probe_walk_perfn_jitcode(
 /// loop-input register seeding, so the walk mis-evaluates the loop guard,
 /// exits the loop on the first pass, and concretely executes the post-loop
 /// tail — double-running its side effects and leaving the frame positioned
-/// past the loop (#125).  The walk's reactive `abort_permanent` decline
+/// past the loop.  The walk's reactive `abort_permanent` decline
 /// never fires because the corrupted guard exits before reaching the
-/// marker.  The scan is scoped to ops at/after the first `jit_merge_point`
-/// (the inner loop header) so a prologue-only marker (e.g. `COPY_FREE_VARS`
-/// ahead of a clean hot loop) does not over-decline.
-fn loop_body_has_abort_permanent(w_code: *const ()) -> bool {
+/// marker.  When the loop is not inside a `try`, the scan is scoped to ops
+/// after the first `jit_merge_point` and before the loop's final back-edge, so
+/// neither a prologue-only marker (e.g. `COPY_FREE_VARS` ahead of a clean hot
+/// loop) nor a post-loop marker over-declines the loop.  A loop covered by an
+/// exception handler keeps the full-tail scan so a post-loop
+/// `abort_permanent` (e.g. the `DELETE_FAST` cleanup for `except X as e`)
+/// still declines it, because compiled-loop delivery of an uncaught raise to
+/// the handler is not yet supported.
+fn loop_body_has_abort_permanent(w_code: *const (), start_pc: usize) -> bool {
     let Some(pjc) = crate::state::pyjitcode_for_code(w_code) else {
         return false;
     };
     let code = pjc.jitcode.code.as_slice();
-    let mut seen_merge_point = false;
-    for op in crate::jitcode_runtime::decoded_ops(code) {
-        if op.opname == "jit_merge_point" {
-            seen_merge_point = true;
-        } else if seen_merge_point && op.opname == "abort_permanent" {
-            return true;
+    let Some(merge_point) = crate::jitcode_runtime::decoded_ops(code)
+        .find(|op| op.opname == "jit_merge_point")
+        .map(|op| op.pc)
+    else {
+        return false;
+    };
+
+    let mut back_edge_end: Option<usize> = None;
+    let mut first_abort_permanent = None;
+    for op in crate::jitcode_runtime::decoded_ops(code).filter(|op| op.pc > merge_point) {
+        if op.opname == "abort_permanent" && first_abort_permanent.is_none() {
+            first_abort_permanent = Some(op.pc);
+        }
+        if op.opname.starts_with("goto") && op.argcodes.ends_with('L') {
+            let target =
+                u16::from_le_bytes([code[op.next_pc - 2], code[op.next_pc - 1]]) as usize;
+            if target <= merge_point {
+                back_edge_end = Some(back_edge_end.map_or(op.pc, |end| end.max(op.pc)));
+            }
         }
     }
-    false
+
+    // `start_pc` is a code-unit index; the exception table lookup takes byte offsets (×2).
+    let loop_in_try = unsafe {
+        pyre_interpreter::pycode::w_code_lookup_exceptiontable(
+            w_code as pyre_object::PyObjectRef,
+            (start_pc as u32) * 2,
+        )
+    }
+    .is_some();
+
+    let scan_end = if loop_in_try || std::env::var_os("PYRE_FBW_LOOPBODY_SCAN_FULL").is_some() {
+        code.len()
+    } else {
+        back_edge_end.unwrap_or(code.len())
+    };
+    first_abort_permanent.is_some_and(|pc| pc < scan_end)
 }
 
 /// True when the hot loop body in `w_code` inline-calls — transitively — a
@@ -2517,7 +2550,7 @@ fn full_body_walk_trace(
     // routing to the trait tracer (which handles the unported op) is the
     // same outcome the reactive in-walk `abort_permanent` decline reaches,
     // minus the frame corruption.
-    if loop_body_has_abort_permanent(w_code) {
+    if loop_body_has_abort_permanent(w_code, start_pc) {
         // Tag the decline so `PYRE_FBW_DEBUG_ABORT` census attributes it to the
         // up-front `abort_permanent` scan, not the trait retry fall-through
         // (`Trait::DeclinedAbort`).  Without this the real declining class is

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -2283,8 +2283,7 @@ fn loop_body_has_abort_permanent(w_code: *const (), start_pc: usize) -> bool {
             first_abort_permanent = Some(op.pc);
         }
         if op.opname.starts_with("goto") && op.argcodes.ends_with('L') {
-            let target =
-                u16::from_le_bytes([code[op.next_pc - 2], code[op.next_pc - 1]]) as usize;
+            let target = u16::from_le_bytes([code[op.next_pc - 2], code[op.next_pc - 1]]) as usize;
             if target <= merge_point {
                 back_edge_end = Some(back_edge_end.map_or(op.pc, |end| end.max(op.pc)));
             }


### PR DESCRIPTION
Two related JIT correctness changes on the `ec-wiring` branch.

## jit: scope loop abort_permanent decline to the loop body

`loop_body_has_abort_permanent` was over-broad: an `except X as e` anywhere in a
function marked the whole hot loop abort-permanent, so the loop never
JIT-compiled and the exc/resume path stayed in the interpreter. Scoping the
decline to the loop body lets these loops compile.

## wasm: select loop-header label by terminal JUMP's descr

The wasm backend chose the loop-header label of a multi-label (peeled) trace by
taking the **last** `LABEL`, not the label the terminal `JUMP` actually targets.
When the JUMP's descr points at a non-last label, `find_label_args` (the
back-edge parallel move) and `loop_label_idx` (the emitted `loop`) bound to the
wrong label, so loop-carried locals cross-loaded — a loop-invariant
range-iterator local read back as an unrelated int and `FOR_ITER` raised
`TypeError: not an iterator`.

`find_jump_target_label_index` / `find_loop_label_index` now resolve the target
label by the JUMP descr's identity (falling back to the last label for
descr-less IR), and `is_resumable_peeled` declines the key-dispatch shape unless
the JUMP target is the last label (such shapes compile as a plain local loop).

This is confined to `majit-backend-wasm/src/codegen.rs`; the native dynasm and
cranelift backends do not link it and are unaffected.

### Verification

- wasm synthetic suite: **170/170** (no regression from the `is_resumable_peeled` change)
- dynasm: **181/181**; cranelift: **181/181** (the wasm change is inert on native)
- The miscompile was pinned on a hot `for _ in range(N): s += G` loop whose
  peeled trace's terminal JUMP targets a non-last label; the corrupted
  loop-carried iterator (read back as an int) is corrected by the label-selection
  fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
