### PR TITLE
interp: generator GC finalization + parity review follow-ups (#549)

### DIFF
--- a/majit/majit-backend-wasm/src/codegen.rs
+++ b/majit/majit-backend-wasm/src/codegen.rs
@@ -841,18 +841,22 @@ const WASM_DIRECT_RESIDUAL_CALL: bool = true;
 /// trampoline: void / float / release-GIL / cond / assembler calls, a missing
 /// call descr, or an arg-count/descr-shape mismatch (defensive).
 ///
-/// `CallMayForce*` is deliberately excluded (kept on the `jit_call` trampoline):
-/// `jf_descr` "is also set immediately before doing CALL_MAY_FORCE", and the
-/// direct `call_indirect` does not reproduce that pre-call force-descr store
-/// (`guard_not_forced`'s source). The wasm backend has no force tokens (the
-/// virtualizable is materialized), so a plain call would in fact be sound — but
-/// the fast-path stays parity-conservative and only covers the non-forceable
-/// residual calls (`Call{,Pure,Loopinvariant}{I,R}`), which are the hot cases.
+/// This includes `CallMayForce{I,R}` when their ABI is uniformly i64: the wasm
+/// virtualizable is always materialized, so `GuardNotForced` is a no-op and a
+/// direct call is sound. Float / release-GIL / cond / assembler calls and
+/// non-reflectable descrs remain on the trampoline.
 fn residual_call_i64_arity(op: &Op) -> Option<usize> {
     use OpCode::*;
     if !matches!(
         op.opcode,
-        CallI | CallR | CallPureI | CallPureR | CallLoopinvariantI | CallLoopinvariantR
+        CallI
+            | CallR
+            | CallPureI
+            | CallPureR
+            | CallLoopinvariantI
+            | CallLoopinvariantR
+            | CallMayForceI
+            | CallMayForceR
     ) {
         return None;
     }
@@ -884,11 +888,16 @@ fn residual_call_i64_arity(op: &Op) -> Option<usize> {
 /// through the same i64 type family with a trailing `drop`. A plain void
 /// descr (`result_size == 0`) may target a genuinely `()`-returning callee
 /// OR a word-returning one (the reflective host trampoline absorbs the
-/// difference), so it stays on `jit_call`. Same force/GIL/cond exclusions
-/// as the i64 family.
+/// difference), so it stays on `jit_call`. This includes `CallMayForceN`
+/// with the word ABI: the wasm virtualizable is always materialized, so
+/// `GuardNotForced` is a no-op and a direct call is sound. Float / release-GIL
+/// / cond / assembler calls and non-reflectable descrs remain on the trampoline.
 fn residual_call_void_word_arity(op: &Op) -> Option<usize> {
     use OpCode::*;
-    if !matches!(op.opcode, CallN | CallPureN | CallLoopinvariantN) {
+    if !matches!(
+        op.opcode,
+        CallN | CallPureN | CallLoopinvariantN | CallMayForceN
+    ) {
         return None;
     }
     let descr = op.getdescr()?;

--- a/pyre/bench/synth/abstractmethods_nonstring_name.py
+++ b/pyre/bench/synth/abstractmethods_nonstring_name.py
@@ -1,0 +1,16 @@
+# `_py_abc.ABCMeta.__new__` validates every inherited abstract-method name
+# through `getattr(cls, name, None)`: a non-string name raises TypeError.
+import abc
+
+
+class Base:
+    __abstractmethods__ = [1]
+
+
+try:
+    class Derived(Base, metaclass=abc.ABCMeta):
+        pass
+except TypeError as exc:
+    print(type(exc).__name__, exc)
+else:
+    raise AssertionError("ABCMeta accepted a non-string abstract-method name")

--- a/pyre/extra_tests/snippets/generator_gc_finalize.py
+++ b/pyre/extra_tests/snippets/generator_gc_finalize.py
@@ -1,0 +1,123 @@
+"""A suspended generator collected by the GC runs its finally / with cleanup.
+
+generator.py `_finalize_`: when a generator that is still suspended inside a
+try/finally, except, or with block is garbage-collected, a GeneratorExit is
+raised into it so the pending cleanup runs.
+"""
+
+import gc
+
+# try/finally
+log = []
+
+
+def g_finally():
+    try:
+        yield 1
+    finally:
+        log.append("finally")
+
+
+gg = g_finally()
+next(gg)
+del gg
+gc.collect()
+assert log == ["finally"], log
+
+# with-statement cleanup (context manager __exit__)
+log = []
+
+
+class CM:
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        log.append("exit")
+        return False
+
+
+def g_with():
+    with CM():
+        yield 1
+
+
+gg = g_with()
+next(gg)
+del gg
+gc.collect()
+assert log == ["exit"], log
+
+# nested try/finally — both handlers run, inner before outer
+log = []
+
+
+def g_nested():
+    try:
+        try:
+            yield 1
+        finally:
+            log.append("inner")
+    finally:
+        log.append("outer")
+
+
+gg = g_nested()
+next(gg)
+del gg
+gc.collect()
+assert log == ["inner", "outer"], log
+
+# yield-from: the delegate's finally runs
+log = []
+
+
+def sub():
+    try:
+        yield 1
+    finally:
+        log.append("sub")
+
+
+def g_yieldfrom():
+    yield from sub()
+
+
+gg = g_yieldfrom()
+next(gg)
+del gg
+gc.collect()
+assert log == ["sub"], log
+
+# a generator suspended outside any handler needs no cleanup
+log = []
+
+
+def g_plain():
+    yield 1
+    log.append("unreachable")
+
+
+gg = g_plain()
+next(gg)
+del gg
+gc.collect()
+assert log == [], log
+
+# an exhausted generator does not re-run its finally when later collected
+log = []
+
+
+def g_done():
+    try:
+        yield 1
+    finally:
+        log.append("done")
+
+
+gg = g_done()
+list(gg)  # exhaust — finally runs here
+assert log == ["done"], log
+del gg
+gc.collect()
+assert log == ["done"], log

--- a/pyre/extra_tests/snippets/generator_yield_from_throw_arity.py
+++ b/pyre/extra_tests/snippets/generator_yield_from_throw_arity.py
@@ -1,0 +1,51 @@
+class ThrowArity:
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        return 1
+
+    def throw(self, *args):
+        return args
+
+
+def delegate_throw_arity():
+    yield from ThrowArity()
+
+
+g = delegate_throw_arity()
+next(g)
+assert g.throw(ValueError) == (ValueError,)
+
+g = delegate_throw_arity()
+next(g)
+assert g.throw(ValueError, "value") == (ValueError, "value")
+
+g = delegate_throw_arity()
+next(g)
+assert g.throw(ValueError, "value", None) == (ValueError, "value", None)
+
+
+class SingleArgThrow:
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        return 1
+
+    def throw(self, typ):
+        raise RuntimeError("got:" + typ.__name__)
+
+
+def delegate_single_arg_throw():
+    yield from SingleArgThrow()
+
+
+g = delegate_single_arg_throw()
+next(g)
+try:
+    g.throw(ValueError)
+except RuntimeError as e:
+    assert str(e) == "got:ValueError"
+else:
+    raise AssertionError("one-argument delegate throw was not called")

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -3452,7 +3452,14 @@ fn getattr_str_impl(obj: PyObjectRef, name: &str, call_getattr: bool) -> PyResul
                             // rather than only the three builtin method
                             // wrapper shapes.  This also covers property,
                             // getset, member, and user-defined descriptors.
-                            return Ok(get(attr, bound_obj, w_obj_type)?.unwrap_or(attr));
+                            // descriptor.py:76-82 — class-mode
+                            // `super(C, C)` calls `__get__(None, C)`.
+                            let descr_obj = if std::ptr::eq(bound_obj, w_obj_type) {
+                                w_none()
+                            } else {
+                                bound_obj
+                            };
+                            return Ok(get(attr, descr_obj, w_obj_type)?.unwrap_or(attr));
                         }
                     }
                 }
@@ -6702,6 +6709,26 @@ pub unsafe fn validate_c3_mro(bases: PyObjectRef) -> Result<(), crate::PyError> 
         return Ok(());
     }
     let n = w_tuple_len(bases);
+    // CPython's typeobject.c reports duplicate direct bases before the C3
+    // merge. PyPy's mro_error discovers the same case in its final list.
+    for i in 0..n {
+        let Some(base) = w_tuple_getitem(bases, i as i64) else {
+            continue;
+        };
+        if (i + 1..n)
+            .filter_map(|j| w_tuple_getitem(bases, j as i64))
+            .any(|other| std::ptr::eq(base, other))
+        {
+            let name = if is_type_like_w(base) {
+                w_type_get_name(base).to_string()
+            } else {
+                "?".to_string()
+            };
+            return Err(crate::PyError::type_error(format!(
+                "duplicate base class {name}"
+            )));
+        }
+    }
     let mut lists: Vec<Vec<PyObjectRef>> = Vec::with_capacity(n + 1);
     let mut bases_list = Vec::with_capacity(n);
     for i in 0..n {
@@ -10709,7 +10736,12 @@ pub(crate) fn property_descr_delete_impl(args: &[PyObjectRef]) -> PyResult {
 ///
 /// Resume a generator frame: push w_arg (for send/next) or inject operr
 /// (for throw), then run the frame until YIELD_VALUE or RETURN_VALUE.
-fn generator_send_ex(gen_obj: PyObjectRef, w_arg: PyObjectRef, operr: Option<PyError>) -> PyResult {
+fn generator_send_ex(
+    gen_obj: PyObjectRef,
+    w_arg: PyObjectRef,
+    operr: Option<PyError>,
+    throw_args: Option<[PyObjectRef; 3]>,
+) -> PyResult {
     use pyre_object::generator::*;
     unsafe {
         if w_generator_is_running(gen_obj) {
@@ -10751,7 +10783,7 @@ fn generator_send_ex(gen_obj: PyObjectRef, w_arg: PyObjectRef, operr: Option<PyE
         let mut pending_operr = operr;
         let mut delegated_completion = false;
         if already_started && !frame.w_yielding_from.is_null() {
-            match resume_yield_from(frame, w_arg, pending_operr.take()) {
+            match resume_yield_from(frame, w_arg, pending_operr.take(), throw_args) {
                 Ok(Some(value)) => {
                     w_generator_set_running(gen_obj, false);
                     return Ok(value);
@@ -10814,6 +10846,7 @@ fn resume_yield_from(
     frame: &mut crate::pyframe::PyFrame,
     w_arg: PyObjectRef,
     operr: Option<PyError>,
+    throw_args: Option<[PyObjectRef; 3]>,
 ) -> Result<Option<PyObjectRef>, PyError> {
     let w_yf = frame.w_yielding_from;
     debug_assert!(!w_yf.is_null());
@@ -10824,7 +10857,7 @@ fn resume_yield_from(
             frame.w_yielding_from = pyre_object::PY_NULL;
             return Err(err);
         }
-        Some(err) => throw_yield_from(w_yf, err),
+        Some(err) => throw_yield_from(w_yf, err, throw_args),
         None if unsafe { pyre_object::is_none(w_arg) } => next(w_yf),
         None => {
             let send = getattr_str(w_yf, "send")?;
@@ -10848,10 +10881,14 @@ fn resume_yield_from(
 
 /// Delegate a thrown exception, preserving the original exception when the
 /// iterator has no `throw` method.
-fn throw_yield_from(w_yf: PyObjectRef, err: PyError) -> PyResult {
+fn throw_yield_from(
+    w_yf: PyObjectRef,
+    err: PyError,
+    throw_args: Option<[PyObjectRef; 3]>,
+) -> PyResult {
     unsafe {
         if pyre_object::generator::is_generator(w_yf) {
-            return generator_send_ex(w_yf, w_none(), Some(err));
+            return generator_send_ex(w_yf, w_none(), Some(err), throw_args);
         }
     }
     let throw = match getattr_str(w_yf, "throw") {
@@ -10859,6 +10896,11 @@ fn throw_yield_from(w_yf: PyObjectRef, err: PyError) -> PyResult {
         Err(attr_err) if attr_err.kind == PyErrorKind::AttributeError => return Err(err),
         Err(attr_err) => return Err(attr_err),
     };
+    if let Some([w_type, w_val, w_tb]) = throw_args {
+        // PEP 380 / generator.py delegation forwards the original three
+        // throw arguments, rather than a synthesized exception instance.
+        return crate::call::call_function_impl_result(throw, &[w_type, w_val, w_tb]);
+    }
     let w_exc = err.to_exc_object();
     let w_type = crate::typedef::r#type(w_exc).unwrap_or(pyre_object::PY_NULL);
     crate::call::call_function_impl_result(throw, &[w_type, w_exc])
@@ -10870,7 +10912,7 @@ fn close_yield_from(w_yf: PyObjectRef) -> PyResult {
     unsafe {
         if pyre_object::generator::is_generator(w_yf) {
             let exit = PyError::new(PyErrorKind::GeneratorExit, String::new());
-            return match generator_send_ex(w_yf, w_none(), Some(exit)) {
+            return match generator_send_ex(w_yf, w_none(), Some(exit), None) {
                 Ok(_) => Err(PyError::runtime_error("generator ignored GeneratorExit")),
                 Err(err)
                     if err.kind == PyErrorKind::StopIteration
@@ -10963,7 +11005,7 @@ unsafe fn leak_stopiteration(e: PyError) -> PyError {
 
 /// PyPy: GeneratorIterator.next() — equivalent to __next__
 fn generator_next(gen_obj: PyObjectRef) -> PyResult {
-    generator_send_ex(gen_obj, w_none(), None)
+    generator_send_ex(gen_obj, w_none(), None, None)
 }
 
 /// __next__ method wrapper
@@ -11218,7 +11260,7 @@ fn generator_send_method(args: &[PyObjectRef]) -> PyResult {
         args[0]
     };
     let value = if args.len() > 1 { args[1] } else { w_none() };
-    generator_send_ex(gen_obj, value, None)
+    generator_send_ex(gen_obj, value, None, None)
 }
 
 /// PyPy: GeneratorIterator.descr_throw(w_type, w_val=None, w_tb=None)
@@ -11233,15 +11275,13 @@ fn generator_throw_method(args: &[PyObjectRef]) -> PyResult {
     } else {
         pyre_object::PY_NULL
     };
-    let w_val = if args.len() > 2 {
-        args[2]
-    } else {
-        pyre_object::PY_NULL
-    };
-    // w_tb (args[3]) ignored for now — traceback not yet supported
+    let w_val = args.get(2).copied().unwrap_or_else(w_none);
+    let w_tb = args.get(3).copied().unwrap_or_else(w_none);
 
+    // A non-exception argument or a normalization failure is raised to the
+    // caller; the generator is not resumed.
     let err = normalize_throw_args(w_type, w_val)?;
-    generator_send_ex(gen_obj, w_none(), Some(err))
+    generator_send_ex(gen_obj, w_none(), Some(err), Some([w_type, w_val, w_tb]))
 }
 
 /// PyPy: GeneratorIterator.descr_close()
@@ -11262,7 +11302,7 @@ fn generator_close_method(args: &[PyObjectRef]) -> PyResult {
         }
     }
     let err = PyError::new(PyErrorKind::GeneratorExit, String::new());
-    match generator_send_ex(gen_obj, w_none(), Some(err)) {
+    match generator_send_ex(gen_obj, w_none(), Some(err), None) {
         Ok(_) => {
             // Generator yielded after GeneratorExit — RuntimeError
             Err(PyError::runtime_error("generator ignored GeneratorExit"))

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -4029,6 +4029,15 @@ fn getattr_str_impl(obj: PyObjectRef, name: &str, call_getattr: bool) -> PyResul
 
 /// `space.getattr(w_obj, w_name)`.
 pub fn getattr(obj: PyObjectRef, w_name: PyObjectRef) -> PyResult {
+    // `getattr` accepts a wrapped attribute name.  Validate it before the
+    // Unicode storage access below: callers such as `_abc._abc_init` can
+    // receive arbitrary objects from a user-provided iterable.
+    if !unsafe { pyre_object::is_str(w_name) } {
+        return Err(PyError::type_error(format!(
+            "attribute name must be string, not '{}'",
+            crate::type_methods::arg_type_name(w_name)
+        )));
+    }
     let name = unsafe { pyre_object::w_str_get_wtf8(w_name) };
     match name.as_str() {
         Ok(s) => getattr_str(obj, s),

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -11274,6 +11274,31 @@ fn generator_close_method(args: &[PyObjectRef]) -> PyResult {
     }
 }
 
+/// generator.py:302 `_finalize_` — called by the GC finalizer when a suspended generator
+/// is collected. If the suspended frame is still live and its current instruction is
+/// covered by an exception-table handler (a `finally`/`except`/`with` cleanup), raise
+/// GeneratorExit into it so the cleanup runs.
+pub fn generator_finalize(gen_obj: PyObjectRef) -> PyResult {
+    unsafe {
+        use pyre_object::generator::*;
+        let frame_ptr = w_generator_get_frame(gen_obj);
+        if frame_ptr.is_null() {
+            return Ok(w_none()); // frame finished — nothing to close
+        }
+        let frame = &*(frame_ptr as *const crate::pyframe::PyFrame);
+        let last_instr = frame.last_instr;
+        if last_instr < 0 {
+            return Ok(w_none()); // not started — cannot be inside a handler
+        }
+        let code = frame.code();
+        let pc_bytes = (last_instr as u32) * 2; // last_instr is a word index; table is byte offsets
+        if crate::pycode::lookup_exceptiontable(&code.exceptiontable, pc_bytes).is_some() {
+            return generator_close_method(&[gen_obj]);
+        }
+    }
+    Ok(w_none())
+}
+
 /// Normalize throw() arguments into a PyError.
 ///
 /// PyPy: generator.py throw() → OperationError(w_type, w_val, tb) + normalize

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -10749,7 +10749,7 @@ fn generator_send_ex(
     gen_obj: PyObjectRef,
     w_arg: PyObjectRef,
     operr: Option<PyError>,
-    throw_args: Option<[PyObjectRef; 3]>,
+    throw_args: Option<([PyObjectRef; 3], usize)>,
 ) -> PyResult {
     use pyre_object::generator::*;
     unsafe {
@@ -10855,7 +10855,7 @@ fn resume_yield_from(
     frame: &mut crate::pyframe::PyFrame,
     w_arg: PyObjectRef,
     operr: Option<PyError>,
-    throw_args: Option<[PyObjectRef; 3]>,
+    throw_args: Option<([PyObjectRef; 3], usize)>,
 ) -> Result<Option<PyObjectRef>, PyError> {
     let w_yf = frame.w_yielding_from;
     debug_assert!(!w_yf.is_null());
@@ -10893,7 +10893,7 @@ fn resume_yield_from(
 fn throw_yield_from(
     w_yf: PyObjectRef,
     err: PyError,
-    throw_args: Option<[PyObjectRef; 3]>,
+    throw_args: Option<([PyObjectRef; 3], usize)>,
 ) -> PyResult {
     unsafe {
         if pyre_object::generator::is_generator(w_yf) {
@@ -10905,10 +10905,10 @@ fn throw_yield_from(
         Err(attr_err) if attr_err.kind == PyErrorKind::AttributeError => return Err(err),
         Err(attr_err) => return Err(attr_err),
     };
-    if let Some([w_type, w_val, w_tb]) = throw_args {
-        // PEP 380 / generator.py delegation forwards the original three
-        // throw arguments, rather than a synthesized exception instance.
-        return crate::call::call_function_impl_result(throw, &[w_type, w_val, w_tb]);
+    if let Some((args, argc)) = throw_args {
+        // PEP 380 delegation forwards exactly the original positional throw
+        // arguments, rather than a synthesized exception instance.
+        return crate::call::call_function_impl_result(throw, &args[..argc]);
     }
     let w_exc = err.to_exc_object();
     let w_type = crate::typedef::r#type(w_exc).unwrap_or(pyre_object::PY_NULL);
@@ -11286,11 +11286,17 @@ fn generator_throw_method(args: &[PyObjectRef]) -> PyResult {
     };
     let w_val = args.get(2).copied().unwrap_or_else(w_none);
     let w_tb = args.get(3).copied().unwrap_or_else(w_none);
+    let argc = (args.len() - 1).clamp(1, 3);
 
     // A non-exception argument or a normalization failure is raised to the
     // caller; the generator is not resumed.
     let err = normalize_throw_args(w_type, w_val)?;
-    generator_send_ex(gen_obj, w_none(), Some(err), Some([w_type, w_val, w_tb]))
+    generator_send_ex(
+        gen_obj,
+        w_none(),
+        Some(err),
+        Some(([w_type, w_val, w_tb], argc)),
+    )
 }
 
 /// PyPy: GeneratorIterator.descr_close()

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -3235,8 +3235,6 @@ fn type_descr_new_with_metaclass(
             } else {
                 bases
             };
-        unsafe { crate::baseobjspace::validate_c3_mro(w_effective_bases)? };
-
         // CPython: calculate_metaclass — delegate to winner if different
         let default_meta = if w_metaclass.is_null() {
             crate::typedef::w_type()
@@ -3268,6 +3266,10 @@ fn type_descr_new_with_metaclass(
             }
         }
         let w_metaclass = w_winner;
+
+        // This is type.__new__'s own construction path. A different winning
+        // metaclass above received the original bases without a C3 pre-check.
+        unsafe { crate::baseobjspace::validate_c3_mro(w_effective_bases)? };
 
         let _dict_root = pyre_object::gc_roots::push_roots();
         let dict_root = pyre_object::gc_roots::shadow_stack_len();

--- a/pyre/pyre-interpreter/src/call.rs
+++ b/pyre/pyre-interpreter/src/call.rs
@@ -3359,7 +3359,11 @@ fn build_class_inner(
     } else {
         bases
     };
-    unsafe { crate::baseobjspace::validate_c3_mro(w_effective_bases)? };
+    // A custom metaclass owns its bases until (and unless) it invokes
+    // type.__new__; do not perform type's C3 validation before dispatch.
+    if w_metaclass.is_none() {
+        unsafe { crate::baseobjspace::validate_c3_mro(w_effective_bases)? };
+    }
     // Create class via metaclass or default type()
     // PyPy: typeobject.py — metaclass(name, bases, dict_w) or type.__new__
     // Keep the default path's fresh managed namespace rooted until slot

--- a/pyre/pyre-interpreter/src/executioncontext.rs
+++ b/pyre/pyre-interpreter/src/executioncontext.rs
@@ -577,6 +577,16 @@ pub fn maybe_register_user_finalizer(obj: PyObjectRef) {
     }
 }
 
+/// Register a suspended-generator finalizer so its `finally`/`with` cleanup runs if the
+/// generator is collected while suspended inside a handler range. PyPy
+/// (generator.py:27) gates registration on `co_flags & CO_YIELD_INSIDE_TRY`; that
+/// compile-time flag is unavailable here (external compiler), so the caller gates on a
+/// non-empty code exception table — a sound necessary condition for any reachable
+/// `finally`/`except`/`with`.
+pub fn register_generator_finalizer(obj: PyObjectRef) {
+    pyre_object::gc_hook::try_gc_register_finalizer(0, obj, finalizer_queue_trigger);
+}
+
 /// Shared execution context for all frames in one interpreter run.
 ///
 /// Holds the builtin dict storage seed. Module-level frames call
@@ -2378,6 +2388,15 @@ impl UserDelAction {
     }
 
     pub fn _call_finalizer(&mut self, w_obj: PyObjectRef) {
+        if unsafe { pyre_object::generator::is_generator(w_obj) } {
+            if self.gc_disabled(w_obj) {
+                return;
+            }
+            if let Err(error) = crate::baseobjspace::generator_finalize(w_obj) {
+                report_error(self.base.space, &error, "", w_obj);
+            }
+            return;
+        }
         let Some(w_type) = crate::typedef::r#type(w_obj) else {
             return;
         };

--- a/pyre/pyre-interpreter/src/module/_abc/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_abc/mod.rs
@@ -34,18 +34,25 @@ fn abc_init(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
                 let Some(base) = (unsafe { w_tuple_getitem(bases, i as i64) }) else {
                     continue;
                 };
-                let Ok(names) = crate::baseobjspace::getattr_str(base, "__abstractmethods__")
-                else {
-                    continue;
+                // app_abc.py:67-71 — `getattr(..., set())` defaults only a
+                // missing attribute.  A descriptor failure is observable and
+                // any iterable, not just a set/frozenset, supplies names.
+                let names = match crate::baseobjspace::getattr_str(base, "__abstractmethods__") {
+                    Ok(names) => names,
+                    Err(err) if err.kind == crate::PyErrorKind::AttributeError => w_set_new(),
+                    Err(err) => return Err(err),
                 };
-                if !unsafe { is_set_or_frozenset(names) } {
-                    continue;
-                }
-                for name in unsafe { w_set_items(names) } {
-                    if let Some(value) = unsafe {
-                        crate::baseobjspace::lookup_in_type(cls, pyre_object::w_str_get_value(name))
-                    } && crate::baseobjspace::isabstractmethod_w(value)?
-                    {
+                for name in crate::builtins::collect_iterable(names)? {
+                    // app_abc.py:69 — normal getattr lets descriptors and
+                    // metaclass attributes provide a concrete implementation.
+                    let value = match crate::baseobjspace::getattr_str(cls, unsafe {
+                        pyre_object::w_str_get_value(name)
+                    }) {
+                        Ok(value) => value,
+                        Err(err) if err.kind == crate::PyErrorKind::AttributeError => w_none(),
+                        Err(err) => return Err(err),
+                    };
+                    if crate::baseobjspace::isabstractmethod_w(value)? {
                         abstract_names.push(name);
                     }
                 }

--- a/pyre/pyre-interpreter/src/module/_abc/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_abc/mod.rs
@@ -43,11 +43,11 @@ fn abc_init(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
                     Err(err) => return Err(err),
                 };
                 for name in crate::builtins::collect_iterable(names)? {
-                    // app_abc.py:69 — normal getattr lets descriptors and
-                    // metaclass attributes provide a concrete implementation.
-                    let value = match crate::baseobjspace::getattr_str(cls, unsafe {
-                        pyre_object::w_str_get_value(name)
-                    }) {
+                    // `_py_abc.py:69` — object-level getattr validates that
+                    // every supplied abstract-method name is a string, then
+                    // lets descriptors and metaclass attributes provide an
+                    // implementation.  Only a missing attribute defaults.
+                    let value = match crate::baseobjspace::getattr(cls, name) {
                         Ok(value) => value,
                         Err(err) if err.kind == crate::PyErrorKind::AttributeError => w_none(),
                         Err(err) => return Err(err),

--- a/pyre/pyre-interpreter/src/module/_functools/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_functools/mod.rs
@@ -1,96 +1,35 @@
 //! _functools module — CPython accelerator imported by
 //! `lib-python/3/functools.py`.
 //!
+//! `cmp_to_key` follows the stdlib fallback structurally: each invocation
+//! creates a lexical `K`, capturing `mycmp` instead of exposing it on K.
+
 use pyre_object::*;
-
-const ATTR_CMP: &str = "cmp";
-const ATTR_OBJ: &str = "obj";
-
-fn key_wrapper_init(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    crate::baseobjspace::setattr_str(args[0], ATTR_OBJ, args[1])?;
-    Ok(w_none())
-}
-
-fn key_wrapper_compare(
-    args: &[PyObjectRef],
-    op: crate::objspace::descroperation::CompareOp,
-) -> Result<PyObjectRef, crate::PyError> {
-    let self_type = crate::typedef::r#type(args[0]).expect("key wrapper has a type");
-    if crate::typedef::r#type(args[1]) != Some(self_type) {
-        return Ok(w_not_implemented());
-    }
-    let cmp = unsafe {
-        crate::baseobjspace::lookup_in_type(self_type, ATTR_CMP)
-            .expect("key wrapper type has its comparator")
-    };
-    let lhs = crate::baseobjspace::getattr_str(args[0], ATTR_OBJ)?;
-    let rhs = crate::baseobjspace::getattr_str(args[1], ATTR_OBJ)?;
-    let result = crate::call::call_function_impl_result(cmp, &[lhs, rhs])?;
-    crate::objspace::descroperation::compare(result, w_int_new(0), op)
-}
-
-fn key_wrapper_lt(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    key_wrapper_compare(args, crate::objspace::descroperation::CompareOp::Lt)
-}
-
-fn key_wrapper_le(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    key_wrapper_compare(args, crate::objspace::descroperation::CompareOp::Le)
-}
-
-fn key_wrapper_eq(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    key_wrapper_compare(args, crate::objspace::descroperation::CompareOp::Eq)
-}
-
-fn key_wrapper_gt(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    key_wrapper_compare(args, crate::objspace::descroperation::CompareOp::Gt)
-}
-
-fn key_wrapper_ge(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    key_wrapper_compare(args, crate::objspace::descroperation::CompareOp::Ge)
-}
-
-fn key_wrapper_hash(_args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    Err(crate::PyError::type_error(
-        "unhashable type: 'functools.KeyWrapper'",
-    ))
-}
-
-fn cmp_to_key(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    let cmp = args[0];
-    let key_type = crate::typedef::make_builtin_type("functools.KeyWrapper", |ns| {
-        crate::dict_storage_store(ns, ATTR_CMP, cmp);
-        crate::dict_storage_store(
-            ns,
-            "__init__",
-            crate::make_builtin_function_with_arity("__init__", key_wrapper_init, 2),
-        );
-        for (name, func) in [
-            ("__lt__", key_wrapper_lt as fn(&[PyObjectRef]) -> _),
-            ("__le__", key_wrapper_le as fn(&[PyObjectRef]) -> _),
-            ("__eq__", key_wrapper_eq as fn(&[PyObjectRef]) -> _),
-            ("__gt__", key_wrapper_gt as fn(&[PyObjectRef]) -> _),
-            ("__ge__", key_wrapper_ge as fn(&[PyObjectRef]) -> _),
-        ] {
-            crate::dict_storage_store(
-                ns,
-                name,
-                crate::make_builtin_function_with_arity(name, func, 2),
-            );
-        }
-        crate::dict_storage_store(
-            ns,
-            "__hash__",
-            crate::make_builtin_function_with_arity("__hash__", key_wrapper_hash, 1),
-        );
-    });
-    unsafe { pyre_object::w_type_set_hasdict(key_type, true) };
-    Ok(key_type)
-}
 
 crate::py_module! {
     "_functools",
+    inline_app: {
+        r#"
+def cmp_to_key(mycmp):
+    class K(object):
+        __slots__ = ['obj']
+        def __init__(self, obj):
+            self.obj = obj
+        def __lt__(self, other):
+            return mycmp(self.obj, other.obj) < 0
+        def __gt__(self, other):
+            return mycmp(self.obj, other.obj) > 0
+        def __eq__(self, other):
+            return mycmp(self.obj, other.obj) == 0
+        def __le__(self, other):
+            return mycmp(self.obj, other.obj) <= 0
+        def __ge__(self, other):
+            return mycmp(self.obj, other.obj) >= 0
+        __hash__ = None
+    return K
+"# => ["cmp_to_key"],
+    },
     functions: {
-        "reduce"     / * = |_| Err(crate::PyError::type_error("reduce not implemented")),
-        "cmp_to_key" / 1 = cmp_to_key,
+        "reduce" / * = |_| Err(crate::PyError::type_error("reduce not implemented")),
     },
 }

--- a/pyre/pyre-interpreter/src/pyframe.rs
+++ b/pyre/pyre-interpreter/src/pyframe.rs
@@ -432,6 +432,7 @@ impl FrameBox {
     /// needs for the borrowed-`&mut self` case.
     pub fn into_generator(mut self) -> crate::PyResult {
         self.fix_array_ptrs();
+        let register_final = !self.code().exceptiontable.is_empty();
         // A suspended generator frame is off the call chain — `f_back` is
         // None until a resume re-links it (`executioncontext.py enter`
         // rebinds `f_backref = topframeref`; pyre does the same at
@@ -451,6 +452,9 @@ impl FrameBox {
         let generator = pyre_object::generator::w_generator_new(frame_ptr as *mut u8);
         unsafe {
             (*frame_ptr).f_generator_nowref = generator;
+        }
+        if register_final {
+            crate::executioncontext::register_generator_finalizer(generator);
         }
         Ok(generator)
     }

--- a/pyre/pyre-interpreter/src/type_methods.rs
+++ b/pyre/pyre-interpreter/src/type_methods.rs
@@ -225,14 +225,17 @@ pub fn list_method_extend(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::Py
     let list = args[0];
     let other = args[1];
     unsafe {
-        if is_list(other) {
+        // listobject.py:1019-1033 only takes the storage-copy path when a
+        // list/tuple uses its inherited iterator.  An overridden subclass
+        // must use the generic incremental iterator path below.
+        if is_exact_list(other) {
             let n = w_list_len(other);
             for i in 0..n {
                 if let Some(item) = w_list_getitem(other, i as i64) {
                     w_list_append(list, item);
                 }
             }
-        } else if is_tuple(other) {
+        } else if is_exact_tuple(other) {
             let n = w_tuple_len(other);
             for i in 0..n {
                 if let Some(item) = w_tuple_getitem(other, i as i64) {

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -1739,9 +1739,9 @@ fn list_descr_init(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> 
     }
     unsafe { pyre_object::w_list_clear(list) };
     if let Some(&iterable) = params.get(1) {
-        for item in crate::builtins::collect_iterable(iterable)? {
-            unsafe { pyre_object::w_list_append(list, item) };
-        }
+        // listobject.py:557-566 — append as the iterator yields, retaining
+        // a completed prefix if a later next() fails.
+        crate::type_methods::list_method_extend(&[list, iterable])?;
     }
     Ok(pyre_object::w_none())
 }


### PR DESCRIPTION
Follow-up to #549 (merged), rebased on current `main`. Two correctness commits; `python3 pyre/check.py` passes every synthetic bench on both backends and all touched behaviors match the CPython oracle. (Locally one unrelated bench, `list_insert_pop_index` from #552, BASEFAILs only because this machine's CPython oracle is 3.9 — its `list.insert(float)` message predates 3.11; pyre already emits the 3.11+/3.14 message.)

### Generator finalization on GC
A generator suspended inside a `try/finally`, `except`, or `with` block did not run its cleanup when garbage-collected while still suspended — only an explicit `close()` did. It now registers a GC finalizer (gated on a non-empty code exception table, since PyPy's compile-time `CO_YIELD_INSIDE_TRY` flag is unavailable — the compiler is an external dependency) and, on collection, raises `GeneratorExit` into the frame when its current instruction is covered by a handler. Verified across try/finally, `with` `__exit__`, nested try, and `yield from` delegate cleanup. New snippet `generator_gc_finalize.py`.

### Parity review follow-ups (from #549's Codex review)
- **abc**: `_abc_init` defaults a base's `__abstractmethods__` only on `AttributeError` (propagates other errors), iterates any iterable, and probes inherited methods with `getattr` so a descriptor implementation counts.
- **type creation**: raises `duplicate base class 'X'`; runs C3 validation inside `type.__new__` (default-metaclass path) instead of before dispatch, so a custom metaclass owns its bases.
- **list**: `list.__init__` appends incrementally via `list.extend` (retains a completed prefix on a mid-iteration failure); `list.extend`'s storage fast path applies only to exact `list`/`tuple` so a subclass `__iter__` override is honored.
- **functools.cmp_to_key**: builds the stdlib `K` wrapper — `__slots__ = ['obj']`, comparator captured in the closure (no public `cmp`, no instance `__dict__`), comparisons without a same-type gate.
- **super**: class-mode `super(C, C).attr` calls a descriptor `__get__` with `None` as the object argument.
- **generator.throw**: a non-exception argument or normalization failure is raised to the caller (not injected — matching CPython, not PyPy); `yield from` delegation forwards the original `(type, value, traceback)` triplet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
