### PR TITLE
Exception-path JIT: fold exception construction/attrs/str, lower DELETE_FAST/DEREF

### DIFF
--- a/majit/majit-ir/src/resumedata.rs
+++ b/majit/majit-ir/src/resumedata.rs
@@ -399,7 +399,13 @@ pub struct RebuiltFrame {
     pub values: Vec<RebuiltValue>,
 }
 
-fn decode_tagged(
+/// Decode one tagged resume value outside the numbered frame stream.
+///
+/// Pending fields carry their target and value through the same
+/// TAGBOX/TAGCONST/TAGVIRTUAL encoding as frame slots
+/// (`resume.py:_add_pending_fields`).  Bridge setup uses this entry point so
+/// its consume-side view is identical to `rebuild_from_numbering`.
+pub fn decode_tagged_value(
     tagged: i16,
     num_failargs: i32,
     rd_consts: &[Const],
@@ -499,7 +505,7 @@ pub fn rebuild_from_numbering(
             break;
         }
         let tagged = reader.next_item() as i16;
-        vable_values.push(decode_tagged(
+        vable_values.push(decode_tagged_value(
             tagged,
             num_failargs,
             rd_consts,
@@ -516,7 +522,7 @@ pub fn rebuild_from_numbering(
             break;
         }
         let tagged = reader.next_item() as i16;
-        vref_values.push(decode_tagged(
+        vref_values.push(decode_tagged_value(
             tagged,
             num_failargs,
             rd_consts,
@@ -548,7 +554,7 @@ pub fn rebuild_from_numbering(
                 break;
             }
             let tagged = reader.next_item() as i16;
-            values.push(decode_tagged(
+            values.push(decode_tagged_value(
                 tagged,
                 num_failargs,
                 rd_consts,

--- a/majit/majit-translate/src/tool/algo/unionfind.rs
+++ b/majit/majit-translate/src/tool/algo/unionfind.rs
@@ -32,6 +32,7 @@
 //! preserve the upstream absorb-skip semantics.
 
 use indexmap::IndexMap;
+use std::collections::HashMap;
 use std::hash::Hash;
 
 /// RPython `info1.absorb(info2)` (unionfind.py:76) — called by
@@ -54,15 +55,18 @@ where
     K: Eq + Hash + Clone,
 {
     /// RPython `self.link_to_parent` (unionfind.py:8).
-    /// `IndexMap`, not `HashMap`: `keys()`/`infos()` iterate these to
-    /// drive commonbase folding and access-set numbering downstream, and
-    /// upstream stores Python dicts (insertion order).  A `HashMap` would
-    /// make that order — and the resulting classification — run-varying.
+    /// `IndexMap`, not `HashMap`: `keys()` iterates this to drive commonbase
+    /// folding and access-set numbering downstream, matching the upstream
+    /// dictionary's insertion order.
     link_to_parent: IndexMap<K, K>,
     /// RPython `self.weight` (unionfind.py:9).
-    weight: IndexMap<K, usize>,
+    /// Upstream dictionary deletion in `union` is O(1); ordering is carried
+    /// by `link_to_parent`, so hash storage preserves both properties.
+    weight: HashMap<K, usize>,
     /// RPython `self.root_info` (unionfind.py:11).
-    root_info: IndexMap<K, V>,
+    /// Upstream dictionary deletion in `union` is O(1); ordering is derived
+    /// from `link_to_parent`, so hash storage preserves both properties.
+    root_info: HashMap<K, V>,
     /// RPython `self.info_factory` (unionfind.py:10). See module doc
     /// for why the Rust port makes this mandatory.
     info_factory: Box<dyn Fn(&K) -> V>,
@@ -81,8 +85,8 @@ where
     {
         UnionFind {
             link_to_parent: IndexMap::new(),
-            weight: IndexMap::new(),
-            root_info: IndexMap::new(),
+            weight: HashMap::new(),
+            root_info: HashMap::new(),
             info_factory: Box::new(info_factory),
         }
     }
@@ -98,9 +102,13 @@ where
         self.link_to_parent.keys()
     }
 
-    /// RPython `UnionFind.infos(self)` (unionfind.py:31-32).
+    /// RPython `UnionFind.infos(self)` (unionfind.py:31-32). Roots enter all
+    /// three dictionaries together; filtering `link_to_parent` insertion
+    /// order to surviving roots matches upstream `root_info.values()`.
     pub fn infos(&self) -> impl Iterator<Item = &V> {
-        self.root_info.values()
+        self.link_to_parent
+            .keys()
+            .filter_map(move |k| self.root_info.get(k))
     }
 
     /// RPython `UnionFind.__getitem__(self, obj)` (unionfind.py:13-20).
@@ -189,15 +197,13 @@ where
         // take both infos out, absorb, and re-insert the merged one
         // onto the chosen new root below. `()` infos no-op via the
         // trait impl, matching the upstream None branch.
-        // `shift_remove`, not `swap_remove` (IndexMap's `remove`): keep the
-        // insertion order of surviving entries stable for the `infos()` walk.
-        let mut info1 = self.root_info.shift_remove(&rep1).expect("rep1 info");
-        let info2 = self.root_info.shift_remove(&rep2).expect("rep2 info");
+        let mut info1 = self.root_info.remove(&rep1).expect("rep1 info");
+        let info2 = self.root_info.remove(&rep2).expect("rep2 info");
         info1.absorb(info2);
 
         // upstream: weighted union, smaller tree under larger.
-        let w1 = self.weight.shift_remove(&rep1).expect("rep1 weight");
-        let w2 = self.weight.shift_remove(&rep2).expect("rep2 weight");
+        let w1 = self.weight.remove(&rep1).expect("rep1 weight");
+        let w2 = self.weight.remove(&rep2).expect("rep2 weight");
         let w = w1 + w2;
 
         let (new_rep1, new_rep2) = if w1 < w2 { (rep2, rep1) } else { (rep1, rep2) };

--- a/pyre/bench/synth/exception_as_cell_cleanup.py
+++ b/pyre/bench/synth/exception_as_cell_cleanup.py
@@ -1,0 +1,30 @@
+# An `except E as e:` handler whose exception variable `e` is captured by a
+# nested function makes `e` a cell variable, so the implicit handler cleanup
+# emits DELETE_DEREF (clear the cell contents) rather than DELETE_FAST. The
+# traced DELETE_DEREF dereferences the cell to raise if unbound, then clears
+# its contents; this bench pins that a captured-exception handler in a hot
+# loop compiles and returns byte-identically.
+N = 60000
+
+
+def run(n):
+    acc = 0
+    i = 0
+    while i < n:
+        try:
+            if (i % 5) == 0:
+                raise ValueError(i)
+            acc += 1
+        except ValueError as e:
+            def grab():
+                return e          # captures e -> e becomes a cell
+            acc += grab().args[0] & 7
+        i += 1
+    return acc
+
+
+def main():
+    print(run(N))
+
+
+main()

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -7992,6 +7992,138 @@ pub fn object_setattr(obj: PyObjectRef, name: &str, value: PyObjectRef) -> PyRes
     Err(raiseattrerror(obj, name))
 }
 
+/// A direct `W_BaseException` reference slot whose hard-coded getattr/setattr
+/// arm has no value conversion on the selected branch.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ExceptionAttrSlot {
+    Args,
+    Code,
+    Errno,
+    Strerror,
+    Filename,
+    Filename2,
+}
+
+/// Ingredients for the full-body walker's mirror of the typed exception-slot
+/// attribute arms.  This helper deliberately lives beside `getattr_str_impl`
+/// and `object_setattr`, whose branch order it audits.
+///
+/// PyPy exposes these fields through `readwrite_attrproperty_w` in
+/// `interp_exceptions.py`; `GetSetProperty.descr_property_get/set` in
+/// `typedef.py` reaches the tiny slot accessor.  Pyre's equivalent arms run
+/// only after the receiver type lookup.  Therefore a class-dict hit (a user
+/// property or plain shadowing value) declines, while the returned nonzero
+/// version tag lets the JIT pin that miss.  The exception instance dictionary
+/// is consulted only after these whitelisted arms, so it is not a branch input
+/// and must not shadow them.
+///
+/// `GuardClass` on the returned kind-specific `ob_type` pins the `ExcKind`;
+/// heap exception subclasses share that physical layout, so callers must also
+/// guard the exact `w_class` and its version tag.  Loads select only a concrete
+/// non-NULL slot, pinning the stored-value branch instead of the `args_w`
+/// fallback.  `args` returns the raw `args_w` storage as an ingredient only;
+/// the walker must preserve `fixedview` on stores and allocate the public
+/// tuple view on loads, so it declines shapes it cannot decompose safely.
+pub unsafe fn exception_attr_slot_fold(
+    obj: PyObjectRef,
+    name: &str,
+    is_store: bool,
+) -> Option<(
+    ExceptionAttrSlot,
+    pyre_object::interp_exceptions::ExcKind,
+    PyObjectRef,
+    u64,
+    PyObjectRef,
+)> {
+    if !unsafe { pyre_object::is_exception(obj) } {
+        return None;
+    }
+    let kind = unsafe { pyre_object::w_exception_get_kind(obj) };
+    let slot = match name {
+        "args" => ExceptionAttrSlot::Args,
+        "code" if kind == pyre_object::interp_exceptions::ExcKind::SystemExit => {
+            ExceptionAttrSlot::Code
+        }
+        "errno"
+            if matches!(
+                kind,
+                pyre_object::interp_exceptions::ExcKind::OSError
+                    | pyre_object::interp_exceptions::ExcKind::FileNotFoundError
+            ) =>
+        {
+            ExceptionAttrSlot::Errno
+        }
+        "strerror"
+            if matches!(
+                kind,
+                pyre_object::interp_exceptions::ExcKind::OSError
+                    | pyre_object::interp_exceptions::ExcKind::FileNotFoundError
+            ) =>
+        {
+            ExceptionAttrSlot::Strerror
+        }
+        "filename"
+            if matches!(
+                kind,
+                pyre_object::interp_exceptions::ExcKind::OSError
+                    | pyre_object::interp_exceptions::ExcKind::FileNotFoundError
+            ) =>
+        {
+            ExceptionAttrSlot::Filename
+        }
+        "filename2"
+            if matches!(
+                kind,
+                pyre_object::interp_exceptions::ExcKind::OSError
+                    | pyre_object::interp_exceptions::ExcKind::FileNotFoundError
+            ) =>
+        {
+            ExceptionAttrSlot::Filename2
+        }
+        _ => return None,
+    };
+    let w_type = crate::typedef::r#type(obj)?;
+    // Any hit precedes the hard-coded exception arm.  The version-tag guard
+    // below pins this miss across later heap-subclass mutations.
+    if unsafe { lookup_in_type_where(w_type, name) }.is_some() {
+        return None;
+    }
+    let version_tag = unsafe { w_type_version_tag(w_type) };
+    if version_tag == 0 {
+        return None;
+    }
+    let stored = unsafe {
+        match slot {
+            ExceptionAttrSlot::Args => {
+                pyre_object::interp_exceptions::w_exception_get_args_storage(obj)
+            }
+            ExceptionAttrSlot::Code => pyre_object::interp_exceptions::w_exception_get_code(obj),
+            ExceptionAttrSlot::Errno => pyre_object::interp_exceptions::w_exception_get_errno(obj),
+            ExceptionAttrSlot::Strerror => {
+                pyre_object::interp_exceptions::w_exception_get_strerror(obj)
+            }
+            ExceptionAttrSlot::Filename => {
+                pyre_object::interp_exceptions::w_exception_get_filename(obj)
+            }
+            ExceptionAttrSlot::Filename2 => {
+                pyre_object::interp_exceptions::w_exception_get_filename2(obj)
+            }
+        }
+    };
+    if !is_store {
+        if stored.is_null() {
+            return None;
+        }
+        // `w_exception_get_args` accepts a legacy tuple-backed slot, but the
+        // walker decomposition below reads `W_ListObject` fields and therefore
+        // only mirrors the canonical list storage produced by current setters.
+        if slot == ExceptionAttrSlot::Args && !unsafe { pyre_object::is_list(stored) } {
+            return None;
+        }
+    }
+    Some((slot, kind, w_type, version_tag, stored))
+}
+
 /// `pypy/module/exceptions/interp_exceptions.py:156-157
 /// W_BaseException.descr_setargs` parity helper:
 ///

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -1229,9 +1229,6 @@ pub(crate) fn getitem_slot(obj: PyObjectRef, index: PyObjectRef) -> PyResult {
         if pyre_object::is_w_range(obj) {
             return getitem_range(obj, index);
         }
-        if is_range_iter(obj) {
-            return getitem_range_iter(obj, index);
-        }
         // descroperation.py:356-381 DescrOperation.getitem — any object
         // whose type defines `__getitem__` on its MRO is subscriptable
         // (the arms above are fast paths for builtin sequence/mapping
@@ -2461,35 +2458,6 @@ pub(crate) fn zip_setstate_method(args: &[PyObjectRef]) -> PyResult {
         pyre_object::functional::w_zip_set_strict(args[0], strict);
     }
     Ok(w_none())
-}
-
-unsafe fn getitem_range_iter(obj: PyObjectRef, index: PyObjectRef) -> PyResult {
-    let r = &*(obj as *const pyre_object::functional::W_IntRangeIterator);
-    let len = r.remaining;
-    if is_int(index) {
-        // range[i]
-        let i = w_int_get_value(index);
-        let idx = if i < 0 { len + i } else { i };
-        if idx < 0 || idx >= len {
-            return Err(PyError::new(
-                PyErrorKind::IndexError,
-                "range object index out of range",
-            ));
-        }
-        return Ok(w_int_new(r.current + idx * r.step));
-    }
-    if is_slice(index) {
-        // range[start:stop:step] → returns a list
-        let (start, stop, step) = normalize_slice(index, len)?;
-        let mut items = Vec::new();
-        let mut i = start;
-        while (step > 0 && i < stop) || (step < 0 && i > stop) {
-            items.push(w_int_new(r.current + i * r.step));
-            i += step;
-        }
-        return Ok(w_list_new(items));
-    }
-    Err(index_type_error("range", index))
 }
 
 /// `pypy/interpreter/baseobjspace.py:870 finditem` — return the value

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -6150,12 +6150,19 @@ pub(crate) fn super_check(
                 return Ok(obj_type);
             }
         }
-        if let Ok(apparent_type) = crate::baseobjspace::getattr_str(obj_or_type, "__class__") {
-            if pyre_object::is_type(apparent_type)
-                && crate::baseobjspace::issubtype_w(apparent_type, start_type)
-            {
-                return Ok(apparent_type);
+        match crate::baseobjspace::getattr_str(obj_or_type, "__class__") {
+            Ok(apparent_type) => {
+                if pyre_object::is_type(apparent_type)
+                    && crate::baseobjspace::issubtype_w(apparent_type, start_type)
+                {
+                    return Ok(apparent_type);
+                }
             }
+            // descriptor.py:139-143 — only AttributeError falls back to
+            // type(obj) (the normal case already rejected it above); any
+            // other exception from a `__class__` property propagates.
+            Err(e) if e.kind == crate::PyErrorKind::AttributeError => {}
+            Err(e) => return Err(e),
         }
     }
     Err(crate::PyError::type_error(

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -2644,6 +2644,25 @@ pub fn is_builtin_len_function(callable: PyObjectRef) -> bool {
     }
 }
 
+/// True iff `callable` is the canonical builtin `repr` function object.
+/// The JIT walker uses the builtin-code identity to distinguish it from an
+/// arbitrary replacement stored under the same global name.
+pub fn is_builtin_repr_function(callable: PyObjectRef) -> bool {
+    unsafe {
+        if callable.is_null() || !crate::is_function(callable) {
+            return false;
+        }
+        let code = crate::function_get_code(callable) as PyObjectRef;
+        if code.is_null() || !crate::gateway::is_builtin_code(code) {
+            return false;
+        }
+        std::ptr::fn_addr_eq(
+            crate::gateway::builtin_code_get(code),
+            builtin_repr as crate::gateway::BuiltinCodeFn,
+        )
+    }
+}
+
 /// `len(obj)` — return the length of an object.
 /// `len(obj)` — PyPy: operation.py len → space.len_w
 fn builtin_len(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
@@ -5083,6 +5102,16 @@ pub(crate) fn builtin_str(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::Py
             if let Some(r) = crate::display::try_call_dunder_obj(obj, "__repr__")? {
                 return Ok(r);
             }
+        }
+        // `space.str` returns an app-level `__str__` result object directly;
+        // a str subclass is valid and retains its Python class. The WTF-8
+        // conversion below is for builtin formatting, where a fresh base str
+        // is the appropriate result object.
+        if !obj.is_null()
+            && pyre_object::is_exception(obj)
+            && let Some(r) = crate::display::exc_user_dunder_obj(obj, "__str__")?
+        {
+            return Ok(r);
         }
     }
     let w = unsafe { crate::py_str_wtf8(obj)? };

--- a/pyre/pyre-interpreter/src/call.rs
+++ b/pyre/pyre-interpreter/src/call.rs
@@ -3307,10 +3307,11 @@ fn build_class_inner(
     }
 
     // type_new_classcell (typeobject.c) — capture the `__classcell__` cell
-    // so its content can be set to the new class below.  `__class__` /
-    // `__classdict__` are cellvar names that `fast2locals` mirrors into
-    // the namespace; CPython never exposes them as namespace keys, so drop
-    // them now before a metaclass or the class dict ever sees them.
+    // so its content can be set to the new class below.  The `__class__` /
+    // `__classdict__` cells themselves never reach the namespace (the body
+    // writes through `setdictscope`, and their cells stay empty during the
+    // body), so a `__class__` key here is an explicit class-body assignment
+    // (e.g. a `__class__` property) that must survive into the class dict.
     // `__classcell__` / `__classdictcell__` ARE real namespace entries the
     // class body stores explicitly: a custom metaclass observes them
     // (type.__new__ receives the full namespace) and `type.__new__`
@@ -3318,12 +3319,7 @@ fn build_class_inner(
     // construction path below rather than up front.
     let classcell = {
         let class_ns = pyre_object::gc_roots::shadow_stack_get(class_ns_root);
-        let cell = unsafe { pyre_object::w_dict_getitem_str(class_ns, "__classcell__") };
-        let class_ns = pyre_object::gc_roots::shadow_stack_get(class_ns_root);
-        unsafe { pyre_object::w_dict_delitem_str_no_proxy(class_ns, "__class__") };
-        let class_ns = pyre_object::gc_roots::shadow_stack_get(class_ns_root);
-        unsafe { pyre_object::w_dict_delitem_str_no_proxy(class_ns, "__classdict__") };
-        cell
+        unsafe { pyre_object::w_dict_getitem_str(class_ns, "__classcell__") }
     };
 
     // typeobject.c type_new: every class carries `__doc__` (None when the
@@ -3430,24 +3426,6 @@ fn build_class_inner(
                     unsafe {
                         pyre_object::w_dict_setitem_wtf8_no_proxy(w_prepared_dict, &key, value)
                     };
-                }
-            } else {
-                // The body wrote directly into the mapping, so the prepared
-                // dict already holds every store — but `fast2locals` may have
-                // synced the `__class__` / `__classdict__` cellvars into it.
-                // Drop that scaffolding before the metaclass observes it.
-                for scaffold in ["__class__", "__classdict__"] {
-                    // The cellvar sync may not have written these keys, so an
-                    // absent-key KeyError is expected and ignored; any other
-                    // __delitem__ error from a custom mapping propagates.
-                    match crate::baseobjspace::delitem(
-                        w_prepared_dict,
-                        pyre_object::w_str_new(scaffold),
-                    ) {
-                        Ok(()) => {}
-                        Err(e) if e.kind == crate::PyErrorKind::KeyError => {}
-                        Err(e) => return Err(e),
-                    }
                 }
             }
             pyre_object::gc_roots::shadow_stack_get(w_namespace_root)

--- a/pyre/pyre-interpreter/src/display.rs
+++ b/pyre/pyre-interpreter/src/display.rs
@@ -412,38 +412,45 @@ pub unsafe fn py_repr_wtf8(obj: PyObjectRef) -> Result<Wtf8Buf, crate::PyError> 
 /// handled natively in `py_str` / `py_repr`, but a Python subclass
 /// (`class E(Exception): def __str__(self): ...`) installs its own
 /// method that must win, the same way `str(e)` dispatches it in PyPy.
-/// Returns `None` when `__str__`/`__repr__` resolves to the builtin
-/// `BaseException` / `object` registration (no override) or when the
-/// override raises or returns a non-`str`, so the caller falls back to
-/// the native formatting.
-unsafe fn exc_user_dunder(obj: PyObjectRef, name: &str) -> Option<String> {
-    unsafe { exc_user_dunder_obj(obj, name).map(|r| pyre_object::w_str_get_value(r).to_string()) }
+/// Returns `None` only when `__str__`/`__repr__` resolves to the builtin
+/// `BaseException` / `object` registration (no override). A raising override
+/// propagates, and a non-string result raises `TypeError`.
+unsafe fn exc_user_dunder(obj: PyObjectRef, name: &str) -> Result<Option<String>, crate::PyError> {
+    unsafe {
+        Ok(exc_user_dunder_obj(obj, name)?.map(|r| pyre_object::w_str_get_value(r).to_string()))
+    }
 }
 
 /// `exc_user_dunder` variant returning the raw `str` result object so a
 /// WTF-8-preserving caller (`exception_descr_str_wtf8`) can read the
-/// lone-surrogate-carrying bytes directly.  Returns `None` under the
-/// same no-override / non-`str` / raising conditions.
-unsafe fn exc_user_dunder_obj(obj: PyObjectRef, name: &str) -> Option<PyObjectRef> {
+/// lone-surrogate-carrying bytes directly. A raising override propagates and
+/// a non-string result raises `TypeError`, matching descroperation.py's
+/// `space.str` / `space.repr` result check.
+pub(crate) unsafe fn exc_user_dunder_obj(
+    obj: PyObjectRef,
+    name: &str,
+) -> Result<Option<PyObjectRef>, crate::PyError> {
     unsafe {
         let w_class = (*obj).w_class;
         if w_class.is_null() || !pyre_object::is_type(w_class) {
-            return None;
+            return Ok(None);
         }
-        let (src, method) = crate::baseobjspace::lookup_where_pair(w_class, name)?;
+        let Some((src, method)) = crate::baseobjspace::lookup_where_pair(w_class, name) else {
+            return Ok(None);
+        };
         if method.is_null() || std::ptr::eq(src, crate::typedef::w_object()) {
-            return None;
+            return Ok(None);
         }
         if let Some(base) = crate::builtins::lookup_exc_class("BaseException") {
             if std::ptr::eq(src, base) {
-                return None;
+                return Ok(None);
             }
         }
-        let r = crate::call_function(method, &[obj]);
-        if !r.is_null() && pyre_object::is_str(r) {
-            return Some(r);
+        let r = crate::builtins::call_and_check(method, &[obj])?;
+        if pyre_object::is_str(r) {
+            return Ok(Some(r));
         }
-        None
+        Err(dunder_returned_non_string(name, r))
     }
 }
 
@@ -611,7 +618,7 @@ pub unsafe fn py_repr(obj: PyObjectRef) -> Result<String, crate::PyError> {
             // A user subclass that overrides `__repr__` shadows the builtin
             // `W_BaseException.descr_repr`; dispatch it before the native
             // formatting below.
-            if let Some(s) = exc_user_dunder(obj, "__repr__") {
+            if let Some(s) = exc_user_dunder(obj, "__repr__")? {
                 return Ok(s);
             }
             // `pypy/module/exceptions/interp_exceptions.py:135-147
@@ -961,7 +968,7 @@ pub unsafe fn py_str(obj: PyObjectRef) -> Result<String, crate::PyError> {
             // the Unicode / OSError / KeyError `__str__` overrides, so a
             // non-overridden exception here resolves `__str__` to the
             // BaseException builtin and falls through unchanged.
-            if let Some(s) = exc_user_dunder(obj, "__str__") {
+            if let Some(s) = exc_user_dunder(obj, "__str__")? {
                 return Ok(s);
             }
             let args = pyre_object::interp_exceptions::w_exception_get_args(obj);
@@ -1029,7 +1036,7 @@ pub unsafe fn py_str_wtf8(obj: PyObjectRef) -> Result<Wtf8Buf, crate::PyError> {
                 return Ok(pyre_object::w_str_get_wtf8(obj).to_wtf8_buf());
             }
             if pyre_object::is_exception(obj) {
-                if let Some(w) = exception_descr_str_wtf8(obj) {
+                if let Some(w) = exception_descr_str_wtf8(obj)? {
                     return Ok(w);
                 }
             }
@@ -1083,13 +1090,13 @@ pub unsafe fn py_str_display(obj: PyObjectRef) -> String {
 ///
 /// # Safety
 /// `obj` must point to a valid `W_BaseException`.
-unsafe fn exception_descr_str_wtf8(obj: PyObjectRef) -> Option<Wtf8Buf> {
+unsafe fn exception_descr_str_wtf8(obj: PyObjectRef) -> Result<Option<Wtf8Buf>, crate::PyError> {
     unsafe {
         // A user subclass that overrides `__str__` shadows the builtin
         // `W_BaseException.descr_str`; dispatch it (preserving WTF-8)
         // before the single-`str`-arg fast path below, matching `py_str`.
-        if let Some(r) = exc_user_dunder_obj(obj, "__str__") {
-            return Some(pyre_object::w_str_get_wtf8(r).to_wtf8_buf());
+        if let Some(r) = exc_user_dunder_obj(obj, "__str__")? {
+            return Ok(Some(pyre_object::w_str_get_wtf8(r).to_wtf8_buf()));
         }
         let kind = pyre_object::w_exception_get_kind(obj);
         if matches!(
@@ -1099,21 +1106,21 @@ unsafe fn exception_descr_str_wtf8(obj: PyObjectRef) -> Option<Wtf8Buf> {
                 | pyre_object::interp_exceptions::ExcKind::UnicodeEncodeError
                 | pyre_object::interp_exceptions::ExcKind::KeyError
         ) {
-            return None;
+            return Ok(None);
         }
         let args = pyre_object::interp_exceptions::w_exception_get_args(obj);
         if args.is_null() || !pyre_object::is_tuple(args) {
-            return None;
+            return Ok(None);
         }
         if pyre_object::w_tuple_len(args) != 1 {
-            return None;
+            return Ok(None);
         }
         let first = pyre_object::w_tuple_getitem(args, 0).unwrap_or(args);
         let first = crate::baseobjspace::unwrap_cell(first);
         if first.is_null() || !std::ptr::eq((*first).ob_type, &STR_TYPE as *const PyType) {
-            return None;
+            return Ok(None);
         }
-        Some(pyre_object::w_str_get_wtf8(first).to_wtf8_buf())
+        Ok(Some(pyre_object::w_str_get_wtf8(first).to_wtf8_buf()))
     }
 }
 

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -18529,6 +18529,28 @@ fn descr_get_weakref(
 
 #[cfg(test)]
 mod tests {
+    /// Concurrent `init_typeobjects` callers must not observe the
+    /// post-registration patch passes mid-write: the libtest harness
+    /// calls it from many test threads, and an unsynchronized second
+    /// caller used to probe `object`'s type dict while the first was
+    /// still inserting `__class__` into it (IndexMap read/write race).
+    /// Only the first init in the process has the race window, so this
+    /// mainly guards the fix's `Once` barrier when scheduled early.
+    #[test]
+    fn init_typeobjects_races_no_corruption() {
+        let threads: Vec<_> = (0..8)
+            .map(|_| std::thread::spawn(crate::typedef::init_typeobjects))
+            .collect();
+        for t in threads {
+            t.join().expect("concurrent init_typeobjects must not panic");
+        }
+        // Also init on this thread: installs the thread-local hash hook the
+        // dict probe below needs, and exercises the already-initialized path.
+        crate::typedef::init_typeobjects();
+        let object_type = crate::typedef::w_object();
+        assert!(crate::type_dict_contains(object_type, "__class__"));
+    }
+
     #[test]
     fn test_ellipsis_has_registered_typeobject() {
         crate::typedef::init_typeobjects();

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -18542,7 +18542,8 @@ mod tests {
             .map(|_| std::thread::spawn(crate::typedef::init_typeobjects))
             .collect();
         for t in threads {
-            t.join().expect("concurrent init_typeobjects must not panic");
+            t.join()
+                .expect("concurrent init_typeobjects must not panic");
         }
         // Also init on this thread: installs the thread-local hash hook the
         // dict probe below needs, and exercises the already-initialized path.

--- a/pyre/pyre-jit-trace/src/descr.rs
+++ b/pyre/pyre-jit-trace/src/descr.rs
@@ -2403,6 +2403,29 @@ pub fn w_exception_context_descr(kind: ExcKind) -> DescrRef {
     field_descr_from_group(group, 3)
 }
 
+/// Cached field descriptor for a raw reference slot selected by the
+/// exception attribute fold.  Indices are those of `build_w_exception_group`;
+/// no parallel descriptor is constructed.
+pub fn w_exception_slot_descr(
+    kind: ExcKind,
+    slot: pyre_interpreter::baseobjspace::ExceptionAttrSlot,
+) -> DescrRef {
+    let idx = kind as u8 as usize;
+    let mut cache = W_BASE_EXCEPTION_DESCR_CACHE.lock().unwrap();
+    if cache[idx].is_none() {
+        cache[idx] = Some(build_w_exception_group(kind));
+    }
+    let field_index = match slot {
+        pyre_interpreter::baseobjspace::ExceptionAttrSlot::Args => 2,
+        pyre_interpreter::baseobjspace::ExceptionAttrSlot::Errno => 11,
+        pyre_interpreter::baseobjspace::ExceptionAttrSlot::Strerror => 12,
+        pyre_interpreter::baseobjspace::ExceptionAttrSlot::Filename => 13,
+        pyre_interpreter::baseobjspace::ExceptionAttrSlot::Filename2 => 14,
+        pyre_interpreter::baseobjspace::ExceptionAttrSlot::Code => 15,
+    };
+    field_descr_from_group(cache[idx].as_ref().unwrap(), field_index)
+}
+
 /// Field descr for `ExecutionContext::sys_exc_value`, used by the JIT
 /// lowering of PUSH_EXC_INFO / POP_EXCEPT to GETFIELD_GC_R / SETFIELD_GC.
 ///

--- a/pyre/pyre-jit-trace/src/descr.rs
+++ b/pyre/pyre-jit-trace/src/descr.rs
@@ -1097,6 +1097,19 @@ static W_LIST_DESCR_GROUP: LazyLock<PyreObjectDescrGroup> = LazyLock::new(|| {
                 false,
                 false,
             ),
+            // The inline list emit can escape through an exception's args_w
+            // slot and be materialized.  Track the inherited Python class in
+            // the same parent group as tuple objects so its SetfieldGc is a
+            // proper virtual field and materialization reproduces w_list_new.
+            (
+                "PyObject.w_class",
+                pyre_object::pyobject::W_CLASS_OFFSET,
+                8,
+                Type::Ref,
+                false,
+                false,
+                false,
+            ),
         ],
         "W_ListObject",
         "listobject::W_ListObject",
@@ -1964,6 +1977,10 @@ pub fn list_int_items_block_descr() -> DescrRef {
 /// (`float_gcarray_descr`) for `GetarrayitemGcF` / `SetarrayitemGc`.
 pub fn list_float_items_block_descr() -> DescrRef {
     field_descr_from_group(&W_LIST_DESCR_GROUP, 6)
+}
+
+pub fn list_w_class_descr() -> DescrRef {
+    field_descr_from_group(&W_LIST_DESCR_GROUP, 7)
 }
 
 /// `Ptr(GcArray(OBJECTPTR))` — `wrappeditems` body per

--- a/pyre/pyre-jit-trace/src/helpers.rs
+++ b/pyre/pyre-jit-trace/src/helpers.rs
@@ -1143,6 +1143,42 @@ pub fn emit_object_list_inline(ctx: &mut TraceCtx, items: &[OpRef]) -> OpRef {
     list
 }
 
+/// Trace-visible canonical `W_TupleObject` construction from boxed items.
+/// This is the allocation half of `W_BaseException.descr_getargs`: the raw
+/// `args_w` list is copied into a fresh tuple on every public attribute read.
+pub fn emit_object_tuple_inline(ctx: &mut TraceCtx, items: &[OpRef]) -> OpRef {
+    use crate::state::pyobject_gcarray_descr;
+
+    let len = ctx.const_int(items.len() as i64);
+    let array_descr = pyobject_gcarray_descr();
+    let items_block = ctx.record_op_with_descr(OpCode::NewArrayClear, &[len], array_descr.clone());
+    ctx.heap_cache_mut().new_array(items_block, len, true);
+    for (index, &item) in items.iter().enumerate() {
+        let index = ctx.const_int(index as i64);
+        crate::state::trace_items_block_setitem_value(ctx, items_block, index, item);
+    }
+
+    let tuple = ctx.record_op_with_descr(
+        OpCode::NewWithVtable,
+        &[],
+        crate::descr::w_tuple_size_descr(),
+    );
+    ctx.heap_cache_mut().new_object(tuple);
+    let w_class = pyre_object::get_instantiate(&pyre_object::TUPLE_TYPE);
+    let w_class = ctx.const_ref(w_class as i64);
+    let class_descr = crate::descr::tuple_w_class_descr();
+    ctx.record_op_with_descr(OpCode::SetfieldGc, &[tuple, w_class], class_descr.clone());
+    ctx.heapcache_setfield_cached(tuple, class_descr.index(), w_class);
+    let items_descr = crate::descr::tuple_wrappeditems_descr();
+    ctx.record_op_with_descr(
+        OpCode::SetfieldGc,
+        &[tuple, items_block],
+        items_descr.clone(),
+    );
+    ctx.heapcache_setfield_cached(tuple, items_descr.index(), items_block);
+    tuple
+}
+
 /// Emit inline Integer / Float-strategy `W_ListObject` creation: a typed
 /// length-prefixed backing block (`NewArray` + per-element `SetarrayitemGc`)
 /// holding the already-unboxed machine values in `raws`, then the

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -481,6 +481,13 @@ pub struct FbwWalkMode {
     /// `CALL_ASSEMBLER` (`opimpl_recursive_call_assembler`) rather than
     /// re-unrolling the call tree to the multi-frame depth cap.
     pub carrier_resume: bool,
+    /// Bridge-entry view of `ExecutionContext.sys_exc_value` reconstructed
+    /// from the failing guard's pending setfield.  The walk is temporally
+    /// displaced from the guard failure, so live TLS is not a valid source
+    /// until a walked SETFIELD replaces this seed.
+    pub current_exception_seed: Option<OpRef>,
+    /// Concrete shadow paired with [`FbwWalkMode::current_exception_seed`].
+    pub current_exception_seed_concrete: pyre_object::PyObjectRef,
 }
 
 impl Default for FbwWalkMode {
@@ -489,6 +496,8 @@ impl Default for FbwWalkMode {
             snapshot_sym: std::ptr::null(),
             inline_subwalk: false,
             carrier_resume: false,
+            current_exception_seed: None,
+            current_exception_seed_concrete: pyre_object::PY_NULL,
         }
     }
 }
@@ -2719,6 +2728,13 @@ pub fn dispatch_via_miframe(
             inline_callee_consts: None,
             fbw_mode: FbwWalkMode {
                 snapshot_sym: sym_ptr,
+                current_exception_seed: (trace_ctx.is_bridge_trace && !sym.last_exc_box.is_none())
+                    .then_some(sym.last_exc_box),
+                current_exception_seed_concrete: if trace_ctx.is_bridge_trace {
+                    sym.last_exc_value
+                } else {
+                    pyre_object::PY_NULL
+                },
                 ..Default::default()
             },
             session,
@@ -3233,6 +3249,9 @@ fn drive_bridge_frame_subwalk(
                 snapshot_sym: root_sym_ptr,
                 inline_subwalk: true,
                 carrier_resume: true,
+                current_exception_seed: (!root_sym.last_exc_box.is_none())
+                    .then_some(root_sym.last_exc_box),
+                current_exception_seed_concrete: root_sym.last_exc_value,
             },
             session,
             registers_r: &mut regs_r,
@@ -3576,6 +3595,9 @@ pub(crate) fn drive_outer_frame_continuation(
                 snapshot_sym: root_sym_ptr,
                 inline_subwalk: true,
                 carrier_resume: true,
+                current_exception_seed: (!root_sym.last_exc_box.is_none())
+                    .then_some(root_sym.last_exc_box),
+                current_exception_seed_concrete: root_sym.last_exc_value,
             },
             session,
             registers_r: &mut regs_r,
@@ -16564,6 +16586,30 @@ fn dispatch_residual_call_iRd_kind(
         && fbw_raise_enabled()
         && dst_bank == 'r'
         && ei.pyre_helper == majit_ir::PyreHelperKind::RaiseVarargs
+        && r_args.is_empty()
+        && ctx.fbw_mode.current_exception_seed.is_some()
+    {
+        let seed = ctx.fbw_mode.current_exception_seed.unwrap();
+        let concrete = ctx.fbw_mode.current_exception_seed_concrete;
+        if !concrete.is_null() && unsafe { pyre_object::is_exception(concrete) } {
+            // `RAISE_VARARGS 0` may use the normalizing nullary helper rather
+            // than the raw current-exception helper.  A bridge seed is already
+            // a live BaseException, so the helper's successful result is the
+            // pending fieldbox itself; retaining that OpRef keeps the value
+            // loop-variant in the bridge namespace.
+            ctx.trace_ctx.set_opref_concrete(
+                seed,
+                majit_ir::Value::Ref(majit_ir::GcRef(concrete as usize)),
+            );
+            write_residual_call_result_to_dst(ctx, op.pc, dst, 'r', seed)?;
+            return Ok((DispatchOutcome::Continue, op.next_pc));
+        }
+    }
+    if ctx.is_authoritative_executor
+        && ctx.is_full_body_walk
+        && fbw_raise_enabled()
+        && dst_bank == 'r'
+        && ei.pyre_helper == majit_ir::PyreHelperKind::RaiseVarargs
         && try_walker_trace_raise_builtin(ctx, code, op, &r_args, dst)?.is_some()
     {
         return Ok((DispatchOutcome::Continue, op.next_pc));
@@ -21181,17 +21227,25 @@ fn try_walker_lower_exc_info_residual(
         if !r_args.is_empty() || dst_bank != 'r' {
             return Ok(None);
         }
-        let Some(ec) = walker_ensure_execution_context(ctx) else {
-            return Ok(None);
+        let (prev, prev_obj) = if let Some(seed) = ctx.fbw_mode.current_exception_seed {
+            // resume.py:993-1007 applies pending fields before resumed
+            // execution.  Bridge tracing does not mutate the live EC, so use
+            // the decoded fieldbox directly; a runtime GETFIELD here would
+            // read the pre-guard TLS value before the bridge applies anything.
+            (seed, ctx.fbw_mode.current_exception_seed_concrete)
+        } else {
+            let Some(ec) = walker_ensure_execution_context(ctx) else {
+                return Ok(None);
+            };
+            let prev = ctx.trace_ctx.record_op_with_descr(
+                OpCode::GetfieldGcR,
+                &[ec],
+                crate::descr::ec_sys_exc_value_descr(),
+            );
+            (prev, pyre_interpreter::eval::get_current_exception())
         };
-        let prev = ctx.trace_ctx.record_op_with_descr(
-            OpCode::GetfieldGcR,
-            &[ec],
-            crate::descr::ec_sys_exc_value_descr(),
-        );
-        // Stamp the live `prev` concrete (the residual executor would return
-        // it), so a downstream concrete read of the dst sees the right value.
-        let prev_obj = pyre_interpreter::eval::get_current_exception();
+        // Stamp the concrete `prev` so a downstream read sees the value the
+        // residual executor would have returned at this resume point.
         ctx.trace_ctx.set_opref_concrete(
             prev,
             majit_ir::Value::Ref(majit_ir::GcRef(prev_obj as usize)),
@@ -21288,6 +21342,8 @@ fn try_walker_lower_exc_info_residual(
     // exception into the next frame's `sys_exc_value`.
     fbw_sys_exc_journal_push(pyre_interpreter::eval::get_current_exception());
     pyre_interpreter::eval::set_current_exception(store_concrete);
+    ctx.fbw_mode.current_exception_seed = Some(store_op);
+    ctx.fbw_mode.current_exception_seed_concrete = store_concrete;
     Ok(Some(()))
 }
 

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -21207,9 +21207,9 @@ fn try_walker_orthodox_list_append_opcode(
     Ok(Some(()))
 }
 
-/// B3 (`PYRE_FBW_RAISE`): walker-native port of the trait's
-/// [`try_trace_exception_new`] (`trace_opcode.rs:7228`).  A `Type(args)`
-/// `CallFn` residual for a *canonical* builtin exception class becomes a
+/// B3 (`PYRE_FBW_RAISE`): walker-native exception-construction fold.  A
+/// `Type(args)` `CallFn` residual for a canonical builtin exception class or
+/// a heap subclass with the same `__new__` / `__init__` descriptors becomes a
 /// traced `NewWithVtable` + `SetfieldGc` (kind / w_class / args_w) the
 /// optimizer can virtualize when the exception never escapes, instead of
 /// the opaque `bh_call_fn` constructor residual + its
@@ -21223,10 +21223,16 @@ fn try_walker_orthodox_list_append_opcode(
 /// fast path; writes the trace-time concrete exception into the dst
 /// shadow so the `raise/r` GUARD_CLASS reads it.
 ///
-/// Returns `None` (fall through to the generic residual) for any
-/// non-matching shape: a user subclass (whose `__init__` may run Python
-/// code), a non-trivial-args kind (OSError / Unicode errors store extra
-/// fields), or a null concrete arg.
+/// PyPy's `W_TypeObject.descr_call` promotes the class, then resolves
+/// `__new__` and `__init__` through its versioned MRO
+/// (`typeobject.py:703-735`).  When both resolve to
+/// `W_BaseException.descr_new` / `descr_init`
+/// (`interp_exceptions.py:76-126`), a trivial subclass has the same traced
+/// allocation and `args_w` store as its builtin base; only `w_class` differs.
+///
+/// Returns `None` (fall through to the generic residual) for any non-matching
+/// shape: an overriding or uncacheable subclass, a non-trivial-args kind
+/// (OSError / Unicode errors store extra fields), or a null concrete arg.
 fn try_walker_trace_exception_new(
     ctx: &mut WalkContext<'_, '_>,
     code: &[u8],
@@ -21268,12 +21274,92 @@ fn try_walker_trace_exception_new(
     if !is_exc_class || concrete_args.iter().any(|a| a.is_null()) {
         return Ok(None);
     }
-    // Reject user subclasses: their Python `__init__` would run
-    // concretely an extra time per trace attempt (a user-visible side
-    // effect).  Canonical per-kind classes have a pure Rust `descr_init`.
-    if !pyre_object::interp_exceptions::is_canonical_exc_class(concrete_callable) {
-        return Ok(None);
+
+    // Decide the runtime `args_w` list strategy and extract typed payloads
+    // before the concrete constructor can allocate.  The shared typed-list
+    // emitter reproduces `w_list_new`'s Integer layout, allowing the common
+    // `SystemExit(i)` shape to virtualize alongside message-bearing Object
+    // lists.  Other strategies retain the safe residual fallback.
+    enum ArgsEmit {
+        Object,
+        Int(Vec<i64>),
     }
+    let args_emit = match pyre_object::listobject::list_strategy_for(&concrete_args) {
+        pyre_object::listobject::ListStrategy::Object => ArgsEmit::Object,
+        pyre_object::listobject::ListStrategy::Integer => {
+            let int_ty = &pyre_object::pyobject::INT_TYPE as *const pyre_object::pyobject::PyType;
+            let mut values = Vec::with_capacity(concrete_args.len());
+            for &arg in &concrete_args {
+                if pyre_object::tagged_int::CAN_BE_TAGGED
+                    && pyre_object::tagged_int::is_tagged_int(arg)
+                {
+                    return Ok(None);
+                }
+                let exact_int = unsafe {
+                    pyre_object::is_plain_int1(arg) && std::ptr::eq((*arg).ob_type, int_ty)
+                };
+                if !exact_int {
+                    return Ok(None);
+                }
+                values.push(unsafe { pyre_object::w_int_get_value(arg) });
+            }
+            ArgsEmit::Int(values)
+        }
+        pyre_object::listobject::ListStrategy::Empty
+        | pyre_object::listobject::ListStrategy::Float => return Ok(None),
+    };
+
+    let is_canonical = pyre_object::interp_exceptions::is_canonical_exc_class(concrete_callable);
+    let mut subclass_lookups = None;
+    let subclass_version_tag = if is_canonical {
+        None
+    } else {
+        // A heap subclass is safe to construct concretely only after both MRO
+        // lookups have been proved identical to a canonical exception class.
+        // Consequently force_plain_eval below can execute only the builtin
+        // Rust `descr_new` / `descr_init`, never user Python code.  This is the
+        // promoted-class lookup contract of typeobject.py:703-735.
+        if !unsafe { pyre_object::typeobject::w_type_is_heaptype(concrete_callable) } {
+            return Ok(None);
+        }
+        let version_tag =
+            unsafe { pyre_object::typeobject::w_type_get_version_tag(concrete_callable) };
+        if version_tag == 0 {
+            return Ok(None);
+        }
+        let Some(class_new) = (unsafe {
+            pyre_interpreter::baseobjspace::lookup_in_type(concrete_callable, "__new__")
+        }) else {
+            return Ok(None);
+        };
+        let Some(class_init) = (unsafe {
+            pyre_interpreter::baseobjspace::lookup_in_type(concrete_callable, "__init__")
+        }) else {
+            return Ok(None);
+        };
+        let matches_canonical = (0..pyre_object::interp_exceptions::EXC_KIND_COUNT).any(|disc| {
+            // ExcKind is repr(u8) with contiguous discriminants through
+            // EXC_KIND_COUNT, as required by the kind-indexed registry.
+            let candidate_kind: pyre_object::interp_exceptions::ExcKind =
+                unsafe { std::mem::transmute(disc as u8) };
+            let candidate =
+                pyre_object::interp_exceptions::lookup_exc_class_for_kind(candidate_kind);
+            if candidate.is_null() {
+                return false;
+            }
+            unsafe {
+                pyre_interpreter::baseobjspace::lookup_in_type(candidate, "__new__")
+                    == Some(class_new)
+                    && pyre_interpreter::baseobjspace::lookup_in_type(candidate, "__init__")
+                        == Some(class_init)
+            }
+        });
+        if !matches_canonical {
+            return Ok(None);
+        }
+        subclass_lookups = Some((class_new, class_init));
+        Some(version_tag)
+    };
     // Build the exception concretely on the plain eval loop (no tracer
     // re-entry) to read its kind and confirm a flat builtin instance.
     // Trace-time only; discarded after the read.
@@ -21288,9 +21374,41 @@ fn try_walker_trace_exception_new(
         }
         pyre_object::interp_exceptions::w_exception_get_kind(exc)
     };
-    // Only the canonical per-kind builtin class maps to the flat
-    // NewWithVtable layout.
-    if pyre_object::interp_exceptions::lookup_exc_class_for_kind(kind) != concrete_callable {
+    let canonical_class = pyre_object::interp_exceptions::lookup_exc_class_for_kind(kind);
+    if is_canonical {
+        // Preserve the canonical arm's registry identity check.
+        if canonical_class != concrete_callable {
+            return Ok(None);
+        }
+    } else {
+        // The pre-construction descriptor check excludes Python execution;
+        // repeat it for the concrete result's eventual kind so aliases whose
+        // builtin wrapper produces a different physical kind still decline.
+        let Some((class_new, class_init)) = subclass_lookups else {
+            return Ok(None);
+        };
+        if canonical_class.is_null()
+            || unsafe {
+                pyre_interpreter::baseobjspace::lookup_in_type(canonical_class, "__new__")
+                    != Some(class_new)
+                    || pyre_interpreter::baseobjspace::lookup_in_type(canonical_class, "__init__")
+                        != Some(class_init)
+            }
+        {
+            return Ok(None);
+        }
+    }
+    // `exc_new_wrapper` retags only `w_class`; the physical layout remains
+    // the eventual kind's builtin pytype for canonical classes and subclasses.
+    let exc_type_ptr = unsafe {
+        (*(exc as *const pyre_object::interp_exceptions::W_BaseException))
+            .ob_header
+            .ob_type
+    };
+    if !std::ptr::eq(
+        exc_type_ptr,
+        pyre_object::interp_exceptions::exc_kind_to_pytype(kind),
+    ) {
         return Ok(None);
     }
     // Kinds whose `descr_init` stores extra fields (OSError errno /
@@ -21299,19 +21417,6 @@ fn try_walker_trace_exception_new(
     if !kind.has_trivial_args_constructor() {
         return Ok(None);
     }
-    // The walker builds `args_w` inline only for the Object strategy (the
-    // whole list virtualizes alongside the exception).  Empty / Integer /
-    // Float strategies would need a residual `trace_build_list` (a fresh
-    // may-force) the walker has no helper for, so decline them BEFORE
-    // emitting any IR — they fall through to the generic constructor
-    // residual (SAFE, just unoptimized).  `ValueError("msg")` and the
-    // common message-bearing builtins use the Object strategy.
-    if pyre_object::listobject::list_strategy_for(&concrete_args)
-        != pyre_object::listobject::ListStrategy::Object
-    {
-        return Ok(None);
-    }
-
     // --- commit to the specialization: emit IR (no further declines) ---
     // Pin the callable identity so the trace-time kind / vtable stay
     // valid across iterations (`implement_guard_value`).
@@ -21325,10 +21430,52 @@ fn try_walker_trace_exception_new(
             .heap_cache_mut()
             .replace_box(callable_op, expected);
     }
+    if let Some(version_tag) = subclass_version_tag {
+        // Guard the promoted class version that made both MRO descriptor
+        // identities constant.  `W_TypeObject.mutated` recursively changes
+        // subclass tags (`typeobject.py:266-291`), so mutating this class or a
+        // base side-exits before reusing the folded constructor.
+        let class_const = ctx.trace_ctx.const_ref(concrete_callable as i64);
+        let live_version = crate::state::opimpl_getfield_gc_i(
+            ctx.trace_ctx,
+            class_const,
+            crate::descr::type_version_tag_descr(),
+        );
+        let version_const = ctx.trace_ctx.const_int(version_tag as i64);
+        walker_emit_fold_guard_with_snapshot(
+            ctx,
+            op.pc,
+            OpCode::GuardValue,
+            &[live_version, version_const],
+        )?;
+        ctx.trace_ctx
+            .heap_cache_mut()
+            .replace_box(live_version, version_const);
+    }
 
-    // Build `args_w` inline (Object strategy) so the whole list
-    // (W_ListObject + ItemsBlock) virtualizes alongside the exception.
-    let args_list = crate::helpers::emit_object_list_inline(ctx.trace_ctx, args);
+    // Build `args_w` inline so its wrapper and backing block virtualize
+    // alongside the exception.
+    let args_list = match args_emit {
+        ArgsEmit::Object => crate::helpers::emit_object_list_inline(ctx.trace_ctx, args),
+        ArgsEmit::Int(values) => {
+            let int_type_addr = &pyre_object::pyobject::INT_TYPE as *const _ as i64;
+            let mut raws = Vec::with_capacity(args.len());
+            for (&arg, value) in args.iter().zip(values) {
+                let raw = walker_unbox_int(ctx, op.pc, arg, int_type_addr)?;
+                ctx.trace_ctx
+                    .set_opref_concrete(raw, majit_ir::Value::Int(value));
+                raws.push(raw);
+            }
+            crate::helpers::emit_typed_list_inline(
+                ctx.trace_ctx,
+                &raws,
+                crate::state::int_gcarray_descr(),
+                crate::descr::list_int_items_len_descr(),
+                crate::descr::list_int_items_block_descr(),
+                pyre_object::listobject::ListStrategy::Integer,
+            )
+        }
+    };
 
     let new_op =
         crate::helpers::emit_exception_new_inline(ctx.trace_ctx, kind, callable_op, args_list);
@@ -21338,14 +21485,9 @@ fn try_walker_trace_exception_new(
     // `heapcache.class_now_known`).  The vtable on the NewWithVtable
     // already pins the class for the optimizer; this keeps the heapcache
     // model in agreement.
-    let exc_class_ptr = unsafe {
-        (*(exc as *const pyre_object::interp_exceptions::W_BaseException))
-            .ob_header
-            .ob_type
-    };
     ctx.trace_ctx
         .heap_cache_mut()
-        .class_now_known(new_op, exc_class_ptr as usize as i64);
+        .class_now_known(new_op, exc_type_ptr as usize as i64);
 
     // Record the fresh instance so a following `RaiseVarargs` recovers
     // the concrete and takes the instance fast path; stamp the dst shadow

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -9694,6 +9694,12 @@ thread_local! {
     /// pyre's nested-residual decline below is a local protection for
     /// FOREIGN unjournaled residuals.
     static SELFREC_CA_FOLD_ACTIVE: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+    /// The bounded `str(exc)` / `repr(exc)` descriptor inline may retain an
+    /// interior residual such as `repr(self.args)`. The caller's original
+    /// iteration already supplied the concrete result, while the compiled
+    /// trace executes that residual once on later iterations, so the generic
+    /// nested-replay decline does not apply to this resolved descriptor path.
+    static EXCEPTION_STRING_INLINE_ACTIVE: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
 }
 
 /// Scoped setter for [`SELFREC_CA_FOLD_ACTIVE`]. Restores the prior value so
@@ -9719,6 +9725,27 @@ impl Drop for SelfRecCaFoldGuard {
     }
 }
 
+struct ExceptionStringInlineGuard {
+    prior: bool,
+}
+
+impl ExceptionStringInlineGuard {
+    fn enter() -> Self {
+        let prior = EXCEPTION_STRING_INLINE_ACTIVE.with(|c| {
+            let prior = c.get();
+            c.set(true);
+            prior
+        });
+        Self { prior }
+    }
+}
+
+impl Drop for ExceptionStringInlineGuard {
+    fn drop(&mut self) {
+        EXCEPTION_STRING_INLINE_ACTIVE.with(|c| c.set(self.prior));
+    }
+}
+
 fn fbw_abort_nested_unjournaled_residual(
     ctx: &WalkContext<'_, '_>,
     pc: usize,
@@ -9735,7 +9762,12 @@ fn fbw_abort_nested_unjournaled_residual(
     // `CALL_ASSEMBLER` fold's concrete-stamp executor from this pyre-local
     // nested-decline guard, which is for FOREIGN unjournaled residuals.
     let in_selfrec_fold = SELFREC_CA_FOLD_ACTIVE.with(|c| c.get());
-    if enabled && !in_selfrec_fold && !ctx.session.borrow().framestack.is_empty() {
+    let in_exception_string_inline = EXCEPTION_STRING_INLINE_ACTIVE.with(|c| c.get());
+    if enabled
+        && !in_selfrec_fold
+        && !in_exception_string_inline
+        && !ctx.session.borrow().framestack.is_empty()
+    {
         let (outer_resume_py_pc, stack_overrides) = {
             let session = ctx.session.borrow();
             match session.framestack.first().and_then(|f| f.parent.as_ref()) {
@@ -14338,6 +14370,58 @@ fn method_form_callee_body_supported(body_code: &[u8], callee_descr_refs: &[Desc
     true
 }
 
+/// Whether sampling an exception string override before recording can have no
+/// app-visible effect. Portal-frame vable traffic and constant/int boxing are
+/// local; branches, other calls, and live-heap writes decline the sample.
+fn exception_string_override_sample_safe(body_code: &[u8], callee_descr_refs: &[DescrRef]) -> bool {
+    let mut pc = 0usize;
+    while pc < body_code.len() {
+        let Some(d) = crate::jitcode_runtime::decode_op_at(body_code, pc) else {
+            return false;
+        };
+        if d.opname.starts_with("goto_if_not") || d.opname.starts_with("switch") {
+            return false;
+        }
+        if d.opname.starts_with("residual_call") {
+            let kind = residual_call_helper_kind_in_body(body_code, &d, callee_descr_refs);
+            if !matches!(
+                kind,
+                Some(majit_ir::PyreHelperKind::LoadConst | majit_ir::PyreHelperKind::BoxInt)
+            ) {
+                return false;
+            }
+        } else if d.opname.starts_with("setfield_gc")
+            || d.opname.starts_with("setarrayitem_gc")
+            || d.opname.starts_with("setinteriorfield_gc")
+            || d.opname.starts_with("raw_store")
+            || d.opname.starts_with("cond_call")
+            || d.opname.starts_with("call_assembler")
+            || d.opname.starts_with("inline_call")
+        {
+            return false;
+        }
+        pc = d.next_pc;
+    }
+    true
+}
+
+/// The bounded builtin-dispatch route only admits a straight-line app-level
+/// override. A control-flow-bearing method stays on the original residual
+/// dispatch path, where the interpreter owns its frame and branch semantics.
+fn exception_string_override_straight_line(body_code: &[u8]) -> bool {
+    let mut pc = 0usize;
+    while pc < body_code.len() {
+        let Some(d) = crate::jitcode_runtime::decode_op_at(body_code, pc) else {
+            return false;
+        };
+        if d.opname.starts_with("goto_if_not") || d.opname.starts_with("switch") {
+            return false;
+        }
+        pc = d.next_pc;
+    }
+    true
+}
+
 /// Active boxes for an inlined callee's OWN frame in a multi-frame snapshot
 /// (#68).  The fast-path inline predicate guarantees the callee does not own a
 /// virtualizable (any vable op declines the inline), so the owns_vable /
@@ -15148,6 +15232,66 @@ fn try_walker_inline_user_call(
     else {
         return Ok(None);
     };
+    try_walker_inline_resolved_user_call(
+        ctx,
+        op,
+        code,
+        funcptr,
+        r_args,
+        call_descr,
+        dst_bank,
+        dst,
+        callable,
+        r_args[0],
+        callable,
+        arg_concretes,
+        callee_args,
+        callee_arg_concretes,
+        method_form,
+        w_code,
+        nparams,
+        has_closure,
+        None,
+        false,
+        false,
+    )
+}
+
+type ExceptionInlineReceiverGuard = (
+    OpRef,
+    pyre_object::PyObjectRef,
+    pyre_object::PyObjectRef,
+    u64,
+);
+
+/// Shared post-resolution half of the FBW inline lever. Ordinary Python calls
+/// resolve their callee from the CALL operand; builtin-dispatch specializers
+/// resolve an app-level descriptor first and enter here with that function as
+/// the callee while independently pinning the original builtin callable.
+#[allow(clippy::too_many_arguments)]
+fn try_walker_inline_resolved_user_call(
+    ctx: &mut WalkContext<'_, '_>,
+    op: &DecodedOp,
+    code: &[u8],
+    funcptr: OpRef,
+    r_args: &[OpRef],
+    call_descr: &dyn majit_ir::descr::CallDescr,
+    dst_bank: char,
+    dst: usize,
+    callable: pyre_object::PyObjectRef,
+    callable_guard_op: OpRef,
+    callable_guard_value: pyre_object::PyObjectRef,
+    arg_concretes: Vec<ConcreteValue>,
+    callee_args: Vec<OpRef>,
+    callee_arg_concretes: Vec<ConcreteValue>,
+    method_form: bool,
+    w_code: *const (),
+    nparams: usize,
+    has_closure: bool,
+    exception_receiver_guard: Option<ExceptionInlineReceiverGuard>,
+    allow_method_load_attr: bool,
+    require_str_result: bool,
+) -> Result<Option<(DispatchOutcome, usize)>, DispatchError> {
     // Only exact-positional, closure-free calls: every callee local [0..nparams]
     // is bound from a passed arg, none from defaults/varargs/cells.
     if has_closure || callee_args.len() != nparams {
@@ -15203,7 +15347,10 @@ fn try_walker_inline_user_call(
     {
         return Ok(None);
     }
-    if method_form && !method_form_callee_body_supported(body.code, callee_descr_refs) {
+    if method_form
+        && !allow_method_load_attr
+        && !method_form_callee_body_supported(body.code, callee_descr_refs)
+    {
         return Ok(None);
     }
     if std::env::var("PYRE_FBW_INLINE_DIAG").is_ok() {
@@ -15364,11 +15511,26 @@ fn try_walker_inline_user_call(
     // CALL boundary (single outer Python frame — re-execute the whole
     // call on deopt), captured via `fbw_mode.inline_subwalk` for
     // the sub-walk guards below.
-    let callable_opref = r_args[0];
-    let callable_expected = ctx.trace_ctx.const_ref(callable as usize as i64);
-    if !callable_opref.is_constant() {
-        ctx.trace_ctx
-            .record_guard(OpCode::GuardValue, &[callable_opref, callable_expected], 0);
+    if let Some((receiver, concrete_receiver, w_class, version_tag)) = exception_receiver_guard {
+        walker_guard_exception_attr_slot(
+            ctx,
+            op.pc,
+            receiver,
+            concrete_receiver,
+            w_class,
+            version_tag,
+        )?;
+    }
+
+    let callable_expected = ctx
+        .trace_ctx
+        .const_ref(callable_guard_value as usize as i64);
+    if !callable_guard_op.is_constant() {
+        ctx.trace_ctx.record_guard(
+            OpCode::GuardValue,
+            &[callable_guard_op, callable_expected],
+            0,
+        );
         walker_capture_snapshot_for_last_guard(ctx, op.pc)?;
     }
 
@@ -16062,6 +16224,29 @@ fn try_walker_inline_user_call(
             result: Some(value),
         } => {
             let concrete_for_shadow = concrete_from_recorded_opref(ctx, value);
+            if require_str_result
+                && !matches!(
+                    concrete_for_shadow,
+                    ConcreteValue::Ref(obj) if !obj.is_null() && unsafe { pyre_object::is_str(obj) }
+                )
+            {
+                // descroperation.py checks the app-level result before
+                // returning from `space.str` / `space.repr`. Re-run the
+                // original builtin call at the caller boundary so the
+                // interpreter raises its faithful TypeError; the inlined
+                // body has no committed concrete effect at this point.
+                if is_top_inline
+                    && !unjournaled_before_subwalk
+                    && fbw_executed_effect_count() == executed_effects_before
+                {
+                    if let Some(call_pc) = abort_flush_call_py_pc {
+                        if let Some(stack) = reconstructed_all_ref_call_stack(code, op, ctx) {
+                            fbw_set_abort_call_resume(call_pc, stack);
+                        }
+                    }
+                }
+                return Err(DispatchError::LoopBearingCalleeInlineUnsupported { pc: op.pc });
+            }
             match dst_bank {
                 'r' => write_ref_reg(ctx, op.pc, dst, value, concrete_for_shadow)?,
                 'i' => write_int_reg(ctx, op.pc, dst, value, concrete_for_shadow)?,
@@ -16121,6 +16306,154 @@ fn try_walker_inline_user_call(
         }
         other => Ok(Some((other, op.next_pc))),
     }
+}
+
+/// Route `str(exc)` / `repr(exc)` through an app-level exception override.
+/// Pyre's exact `str` type call follows `str_descr_new` → `builtin_str` →
+/// `exc_user_dunder_obj`; the builtin `repr` follows `builtin_repr` →
+/// `py_repr_obj`. Both paths look up the receiver dunder before builtin
+/// exception formatting. This is the walker counterpart of
+/// `descroperation.py`'s `space.lookup` + `get_and_call_function`: pin the
+/// promoted exception class, then enter the ordinary resolved-callee inline
+/// plumbing with the receiver as `self`.
+#[allow(clippy::too_many_arguments)]
+fn try_walker_inline_exception_string_override(
+    ctx: &mut WalkContext<'_, '_>,
+    op: &DecodedOp,
+    code: &[u8],
+    funcptr: OpRef,
+    r_args: &[OpRef],
+    call_descr: &dyn majit_ir::descr::CallDescr,
+    dst: usize,
+) -> Result<Option<(DispatchOutcome, usize)>, DispatchError> {
+    if r_args.len() != 3 {
+        return Ok(None);
+    }
+    let Some(concrete_callable) = walker_concrete_ref_object(ctx, r_args[0]) else {
+        return Ok(None);
+    };
+    if walker_concrete_ref_object(ctx, r_args[1]).is_some() {
+        return Ok(None);
+    }
+    let Some(concrete_receiver) = walker_concrete_ref_object(ctx, r_args[2]) else {
+        return Ok(None);
+    };
+    if !unsafe { pyre_object::is_exception(concrete_receiver) } {
+        return Ok(None);
+    }
+
+    let dunder = if std::ptr::eq(
+        concrete_callable,
+        pyre_interpreter::typedef::gettypeobject(&pyre_object::pyobject::STR_TYPE),
+    ) {
+        "__str__"
+    } else if pyre_interpreter::builtins::is_builtin_repr_function(concrete_callable) {
+        "__repr__"
+    } else {
+        return Ok(None);
+    };
+
+    let w_class = unsafe { (*concrete_receiver).w_class };
+    if w_class.is_null() || !unsafe { pyre_object::is_type(w_class) } {
+        return Ok(None);
+    }
+    let version_tag = unsafe { pyre_object::typeobject::w_type_get_version_tag(w_class) };
+    if version_tag == 0 {
+        return Ok(None);
+    }
+    let Some(method) = (unsafe { pyre_interpreter::baseobjspace::lookup_in_type(w_class, dunder) })
+    else {
+        return Ok(None);
+    };
+    let Some(base_exception) = pyre_interpreter::builtins::lookup_exc_class("BaseException") else {
+        return Ok(None);
+    };
+    let Some(default_method) =
+        (unsafe { pyre_interpreter::baseobjspace::lookup_in_type(base_exception, dunder) })
+    else {
+        return Ok(None);
+    };
+    if std::ptr::eq(method, default_method) {
+        return Ok(None);
+    }
+    let Some((w_code, nparams, has_closure)) = (unsafe { resolve_inlinable_callee(method) }) else {
+        return Ok(None);
+    };
+
+    let Some(body) = crate::state::sub_jitcode_body_for_code(w_code) else {
+        return Ok(None);
+    };
+    if !exception_string_override_straight_line(body.code) {
+        return Ok(None);
+    }
+
+    // A straight-line, effect-free override can be sampled before any IR is
+    // emitted. If its observed result is not a string, decline to the original
+    // builtin residual so the interpreter's result check raises TypeError and
+    // the exception-handler loop remains traceable. More complex bodies are
+    // not executed speculatively; their inlined result is guarded below.
+    if let (Some(body), Some((callee_descr_refs, _, _))) = (
+        crate::state::sub_jitcode_body_for_code(w_code),
+        crate::state::sub_jitcode_descr_pool_for_code(w_code),
+    ) {
+        if exception_string_override_sample_safe(body.code, callee_descr_refs) {
+            let sampled = {
+                let _plain_guard = pyre_interpreter::call::force_plain_eval();
+                pyre_interpreter::call::call_function_impl_result(method, &[concrete_receiver])
+            };
+            let sampled_is_acceptable = matches!(sampled, Ok(result)
+                if !result.is_null() && unsafe { pyre_object::is_str(result) });
+            if !sampled_is_acceptable {
+                return Ok(None);
+            }
+        }
+    }
+
+    let arg_concretes = vec![
+        ConcreteValue::Ref(concrete_callable),
+        ConcreteValue::Null,
+        ConcreteValue::Ref(concrete_receiver),
+    ];
+    let _exception_string_inline = ExceptionStringInlineGuard::enter();
+    let Some(inlined) = try_walker_inline_resolved_user_call(
+        ctx,
+        op,
+        code,
+        funcptr,
+        r_args,
+        call_descr,
+        'r',
+        dst,
+        method,
+        r_args[0],
+        concrete_callable,
+        arg_concretes,
+        vec![r_args[2]],
+        vec![ConcreteValue::Ref(concrete_receiver)],
+        true,
+        w_code,
+        nparams,
+        has_closure,
+        Some((r_args[2], concrete_receiver, w_class, version_tag)),
+        true,
+        true,
+    )?
+    else {
+        return Ok(None);
+    };
+
+    if matches!(inlined.0, DispatchOutcome::Continue) {
+        let result = ctx.registers_r[dst];
+        let str_type = &pyre_object::pyobject::STR_TYPE as *const _ as i64;
+        let str_type_const = ctx.trace_ctx.const_int(str_type);
+        ctx.trace_ctx
+            .record_guard(OpCode::GuardClass, &[result, str_type_const], 0);
+        walker_capture_snapshot_for_last_guard(ctx, op.pc)?;
+        ctx.trace_ctx
+            .heap_cache_mut()
+            .class_now_known(result, str_type);
+    }
+    Ok(Some(inlined))
 }
 
 fn dispatch_residual_call_iRd_kind(
@@ -16197,6 +16530,18 @@ fn dispatch_residual_call_iRd_kind(
         dst,
     )? {
         return Ok(inlined);
+    }
+
+    if ctx.is_authoritative_executor
+        && ctx.is_full_body_walk
+        && dst_bank == 'r'
+        && ei.pyre_helper == majit_ir::PyreHelperKind::CallFn
+    {
+        if let Some(inlined) = try_walker_inline_exception_string_override(
+            ctx, op, code, funcptr, &r_args, call_descr, dst,
+        )? {
+            return Ok(inlined);
+        }
     }
 
     // #62: a self-recursive call the inline path declined (e.g. the

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -20542,7 +20542,8 @@ fn try_walker_specialize_subscr_tuple(
     Ok(Some(()))
 }
 
-/// `len(x)` on an exact canonical `W_ListObject` / `W_UnicodeObject`:
+/// `len(x)` on an exact canonical `W_ListObject` / `W_UnicodeObject` /
+/// `W_TupleObject`:
 /// lower the opaque `bh_call_fn(len_builtin, PY_NULL, x)` residual to the
 /// inline length read the meta-tracer produces upstream
 /// (descroperation.py:294 `_len`): `guard_value(callable)` +
@@ -20550,14 +20551,16 @@ fn try_walker_specialize_subscr_tuple(
 /// `wrapint`.  For a list this reads `W_ListObject.length()` →
 /// `strategy.length`, so it additionally emits `guard_value(strategy)`
 /// (rlist.py); for a str it reads the codepoint field directly
-/// (`W_UnicodeObject.len` → `bh_unicodelen`, no storage strategy).  The
+/// (`W_UnicodeObject.len` → `bh_unicodelen`, no storage strategy); for a
+/// tuple it reads `wrappeditems` and applies `arraylen_gc`, matching
+/// `tupleobject.py` where the tuple carries no separate length field. The
 /// exact `w_class` guard is required because a SUBCLASS shares
-/// `ob_type == &LIST_TYPE`/`&STR_TYPE` but may override `__len__`
+/// `ob_type == &LIST_TYPE`/`&STR_TYPE`/`&TUPLE_TYPE` but may override `__len__`
 /// (`baseobjspace::len` dispatches `subclass_special_override`); it
 /// side-exits to the generic residual.
 ///
 /// Returns `None` (fall through to the generic residual, SAFE) for any
-/// other shape: non-list/str arg, a subclass, empty-strategy list, a
+/// other shape: non-list/str/tuple arg, a subclass, empty-strategy list, a
 /// bound receiver, or wrong arity.
 fn try_walker_specialize_builtin_len(
     ctx: &mut WalkContext<'_, '_>,
@@ -20587,10 +20590,10 @@ fn try_walker_specialize_builtin_len(
     if !pyre_interpreter::builtins::is_builtin_len_function(concrete_callable) {
         return Ok(None);
     }
-    // Exact canonical list / str only (see the doc comment on the subclass
+    // Exact canonical list / str / tuple only (see the doc comment on the subclass
     // `__len__` hazard).  `arg_type_addr` / `exact_w_class` pin the guard
-    // target; `is_str` selects the length path.
-    let (arg_type_addr, exact_w_class, is_str) = unsafe {
+    // target; the booleans select the length path.
+    let (arg_type_addr, exact_w_class, is_str, is_tuple) = unsafe {
         if std::ptr::eq((*list_obj).ob_type, &pyre_object::pyobject::LIST_TYPE)
             && std::ptr::eq(
                 (*list_obj).w_class,
@@ -20600,6 +20603,7 @@ fn try_walker_specialize_builtin_len(
             (
                 &pyre_object::pyobject::LIST_TYPE as *const _ as i64,
                 pyre_object::pyobject::get_instantiate(&pyre_object::pyobject::LIST_TYPE),
+                false,
                 false,
             )
         } else if std::ptr::eq((*list_obj).ob_type, &pyre_object::pyobject::STR_TYPE)
@@ -20612,17 +20616,32 @@ fn try_walker_specialize_builtin_len(
                 &pyre_object::pyobject::STR_TYPE as *const _ as i64,
                 pyre_object::pyobject::get_instantiate(&pyre_object::pyobject::STR_TYPE),
                 true,
+                false,
+            )
+        } else if std::ptr::eq((*list_obj).ob_type, &pyre_object::pyobject::TUPLE_TYPE)
+            && std::ptr::eq(
+                (*list_obj).w_class,
+                pyre_object::pyobject::get_instantiate(&pyre_object::pyobject::TUPLE_TYPE),
+            )
+        {
+            (
+                &pyre_object::pyobject::TUPLE_TYPE as *const _ as i64,
+                pyre_object::pyobject::get_instantiate(&pyre_object::pyobject::TUPLE_TYPE),
+                false,
+                true,
             )
         } else {
             return Ok(None);
         }
     };
     // Length source: str reads the codepoint field directly (no storage
-    // strategy); list resolves its storage strategy (guarded below).  `sid`
-    // is `None` for str.
+    // strategy); tuple reads the wrappeditems GcArray header; list resolves
+    // its storage strategy (guarded below). `sid` is `None` for str/tuple.
     let (sid, concrete_len) = unsafe {
         if is_str {
             (None, pyre_object::w_str_len(list_obj))
+        } else if is_tuple {
+            (None, pyre_object::w_tuple_len(list_obj))
         } else {
             let concrete_len = pyre_object::w_list_len(list_obj);
             let sid = if pyre_object::w_list_uses_int_storage(list_obj) {
@@ -20678,7 +20697,7 @@ fn try_walker_specialize_builtin_len(
     // strategy's length field (rlist.py:116 inline field for object storage;
     // typed items-block length for int/float storage).  str: a plain
     // codepoint-length getfield (no strategy, `bh_unicodelen`).
-    let len_descr = if let Some(sid) = sid {
+    let raw_len = if let Some(sid) = sid {
         let strategy = crate::state::opimpl_getfield_gc_i(
             ctx.trace_ctx,
             list_op,
@@ -20691,15 +20710,26 @@ fn try_walker_specialize_builtin_len(
         ctx.trace_ctx
             .heap_cache_mut()
             .replace_box(strategy, sid_const);
-        match sid {
+        let len_descr = match sid {
             0 => crate::descr::list_length_descr(),
             1 => crate::descr::list_int_items_len_descr(),
             _ => crate::descr::list_float_items_len_descr(),
-        }
+        };
+        crate::state::opimpl_getfield_gc_i(ctx.trace_ctx, list_op, len_descr)
+    } else if is_tuple {
+        let wrappeditems = crate::state::opimpl_getfield_gc_r(
+            ctx.trace_ctx,
+            list_op,
+            crate::descr::tuple_wrappeditems_descr(),
+        );
+        crate::state::opimpl_arraylen_gc(
+            ctx.trace_ctx,
+            wrappeditems,
+            crate::state::pyobject_gcarray_descr(),
+        )
     } else {
-        crate::descr::str_len_descr()
+        crate::state::opimpl_getfield_gc_i(ctx.trace_ctx, list_op, crate::descr::str_len_descr())
     };
-    let raw_len = crate::state::opimpl_getfield_gc_i(ctx.trace_ctx, list_op, len_descr);
     ctx.trace_ctx
         .set_opref_concrete(raw_len, majit_ir::Value::Int(concrete_len as i64));
     let boxed = walker_box_int(ctx, op.pc, raw_len, concrete_len as i64)?;

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -21275,39 +21275,17 @@ fn try_walker_trace_exception_new(
         return Ok(None);
     }
 
-    // Decide the runtime `args_w` list strategy and extract typed payloads
-    // before the concrete constructor can allocate.  The shared typed-list
-    // emitter reproduces `w_list_new`'s Integer layout, allowing the common
-    // `SystemExit(i)` shape to virtualize alongside message-bearing Object
-    // lists.  Other strategies retain the safe residual fallback.
+    // Decide the final runtime `args_w` list strategy and extract typed
+    // payloads.  OSError can rebind the list after parsing a filename, so its
+    // final slice is selected below after the concrete constructor exposes the
+    // value-dependent branch result.  The shared typed-list emitter reproduces
+    // `w_list_new`'s Integer layout, allowing the common `SystemExit(i)` shape
+    // to virtualize alongside message-bearing Object lists.  Other strategies
+    // retain the safe residual fallback.
     enum ArgsEmit {
         Object,
         Int(Vec<i64>),
     }
-    let args_emit = match pyre_object::listobject::list_strategy_for(&concrete_args) {
-        pyre_object::listobject::ListStrategy::Object => ArgsEmit::Object,
-        pyre_object::listobject::ListStrategy::Integer => {
-            let int_ty = &pyre_object::pyobject::INT_TYPE as *const pyre_object::pyobject::PyType;
-            let mut values = Vec::with_capacity(concrete_args.len());
-            for &arg in &concrete_args {
-                if pyre_object::tagged_int::CAN_BE_TAGGED
-                    && pyre_object::tagged_int::is_tagged_int(arg)
-                {
-                    return Ok(None);
-                }
-                let exact_int = unsafe {
-                    pyre_object::is_plain_int1(arg) && std::ptr::eq((*arg).ob_type, int_ty)
-                };
-                if !exact_int {
-                    return Ok(None);
-                }
-                values.push(unsafe { pyre_object::w_int_get_value(arg) });
-            }
-            ArgsEmit::Int(values)
-        }
-        pyre_object::listobject::ListStrategy::Empty
-        | pyre_object::listobject::ListStrategy::Float => return Ok(None),
-    };
 
     let is_canonical = pyre_object::interp_exceptions::is_canonical_exc_class(concrete_callable);
     let mut subclass_lookups = None;
@@ -21411,11 +21389,97 @@ fn try_walker_trace_exception_new(
     ) {
         return Ok(None);
     }
-    // Kinds whose `descr_init` stores extra fields (OSError errno /
-    // strerror / filename; Unicode errors' object / start / end / reason
-    // / encoding) cannot be rebuilt from kind / w_class / args_w alone.
-    if !kind.has_trivial_args_constructor() {
+    let is_os_error_family = matches!(
+        kind,
+        pyre_object::interp_exceptions::ExcKind::OSError
+            | pyre_object::interp_exceptions::ExcKind::FileNotFoundError
+    );
+    // `W_OSError._parse_init_args` / `_init_error`
+    // (`interp_exceptions.py`) fill the flattened slots only for 2..=5
+    // arguments.  Outside that range the ordinary args-only emit is exact.
+    // Unicode constructors still require their dedicated parsing and remain
+    // residual.
+    let fills_os_error_slots = is_os_error_family && (2..=5).contains(&args.len());
+    if !kind.has_trivial_args_constructor() && !is_os_error_family {
         return Ok(None);
+    }
+
+    let exact_os_error = pyre_interpreter::builtins::lookup_exc_class("OSError")
+        .is_some_and(|w_os_error| std::ptr::eq(concrete_callable, w_os_error));
+    if fills_os_error_slots && exact_os_error {
+        // PyPy traces the errno-to-subclass lookup with a loop-variant errno.
+        // The flat NewWithVtable emit needs a constant w_class, so pinning the
+        // unboxed errno deliberately creates per-errno traces/bridges.
+        let errno = concrete_args[0];
+        let exact_int = pyre_object::tagged_int::CAN_BE_TAGGED
+            && pyre_object::tagged_int::is_tagged_int(errno)
+            || unsafe {
+                pyre_object::is_plain_int1(errno)
+                    && std::ptr::eq(
+                        (*errno).ob_type,
+                        &pyre_object::pyobject::INT_TYPE as *const _,
+                    )
+            };
+        if !exact_int {
+            return Ok(None);
+        }
+    }
+
+    let concrete_w_class = unsafe { (*exc).w_class };
+    let is_blocking_io_error = pyre_interpreter::builtins::lookup_exc_class("BlockingIOError")
+        .is_some_and(|blocking| std::ptr::eq(concrete_w_class, blocking));
+    // `W_OSError._init_error` gives an exact BlockingIOError's numeric third
+    // argument the characters_written meaning.  Keep every three-or-more-arg
+    // instance of that concrete class on the complete runtime path.
+    if fills_os_error_slots && args.len() >= 3 && is_blocking_io_error {
+        return Ok(None);
+    }
+
+    let has_filename = fills_os_error_slots
+        && args.len() >= 3
+        && !unsafe { pyre_object::is_none(concrete_args[2]) };
+    let final_args_len = if has_filename { 2 } else { args.len() };
+    let final_args = &args[..final_args_len];
+    let final_concrete_args = &concrete_args[..final_args_len];
+    let args_emit = match pyre_object::listobject::list_strategy_for(final_concrete_args) {
+        pyre_object::listobject::ListStrategy::Object => ArgsEmit::Object,
+        pyre_object::listobject::ListStrategy::Integer => {
+            let int_ty = &pyre_object::pyobject::INT_TYPE as *const pyre_object::pyobject::PyType;
+            let mut values = Vec::with_capacity(final_concrete_args.len());
+            for &arg in final_concrete_args {
+                if pyre_object::tagged_int::CAN_BE_TAGGED
+                    && pyre_object::tagged_int::is_tagged_int(arg)
+                {
+                    return Ok(None);
+                }
+                let exact_int = unsafe {
+                    pyre_object::is_plain_int1(arg) && std::ptr::eq((*arg).ob_type, int_ty)
+                };
+                if !exact_int {
+                    return Ok(None);
+                }
+                values.push(unsafe { pyre_object::w_int_get_value(arg) });
+            }
+            ArgsEmit::Int(values)
+        }
+        pyre_object::listobject::ListStrategy::Empty
+        | pyre_object::listobject::ListStrategy::Float => return Ok(None),
+    };
+
+    // GuardClass pins each None-sensitive `_init_error` branch.  A tagged
+    // immediate cannot be consumed by GuardClass; retain the residual path for
+    // that uncommon filename shape.
+    if fills_os_error_slots {
+        for index in [2usize, 4] {
+            if index >= args.len() || (index == 4 && args.len() != 5) {
+                continue;
+            }
+            if pyre_object::tagged_int::CAN_BE_TAGGED
+                && pyre_object::tagged_int::is_tagged_int(concrete_args[index])
+            {
+                return Ok(None);
+            }
+        }
     }
     // --- commit to the specialization: emit IR (no further declines) ---
     // Pin the callable identity so the trace-time kind / vtable stay
@@ -21453,14 +21517,51 @@ fn try_walker_trace_exception_new(
             .replace_box(live_version, version_const);
     }
 
+    if fills_os_error_slots && exact_os_error {
+        let int_type_addr = &pyre_object::pyobject::INT_TYPE as *const _ as i64;
+        let raw_errno = walker_unbox_int(ctx, op.pc, args[0], int_type_addr)?;
+        let errno_value = unsafe { pyre_object::w_int_get_value(concrete_args[0]) };
+        let errno_const = ctx.trace_ctx.const_int(errno_value);
+        walker_emit_fold_guard_with_snapshot(
+            ctx,
+            op.pc,
+            OpCode::GuardValue,
+            &[raw_errno, errno_const],
+        )?;
+        ctx.trace_ctx
+            .heap_cache_mut()
+            .replace_box(raw_errno, errno_const);
+    }
+    if fills_os_error_slots {
+        for index in [2usize, 4] {
+            if index >= args.len() || (index == 4 && args.len() != 5) {
+                continue;
+            }
+            let arg = args[index];
+            if !ctx.trace_ctx.heap_cache().is_class_known(arg) {
+                let physical_type = unsafe { (*concrete_args[index]).ob_type } as i64;
+                let type_const = ctx.trace_ctx.const_int(physical_type);
+                walker_emit_fold_guard_with_snapshot(
+                    ctx,
+                    op.pc,
+                    OpCode::GuardClass,
+                    &[arg, type_const],
+                )?;
+                ctx.trace_ctx
+                    .heap_cache_mut()
+                    .class_now_known(arg, physical_type);
+            }
+        }
+    }
+
     // Build `args_w` inline so its wrapper and backing block virtualize
     // alongside the exception.
     let args_list = match args_emit {
-        ArgsEmit::Object => crate::helpers::emit_object_list_inline(ctx.trace_ctx, args),
+        ArgsEmit::Object => crate::helpers::emit_object_list_inline(ctx.trace_ctx, final_args),
         ArgsEmit::Int(values) => {
             let int_type_addr = &pyre_object::pyobject::INT_TYPE as *const _ as i64;
-            let mut raws = Vec::with_capacity(args.len());
-            for (&arg, value) in args.iter().zip(values) {
+            let mut raws = Vec::with_capacity(final_args.len());
+            for (&arg, value) in final_args.iter().zip(values) {
                 let raw = walker_unbox_int(ctx, op.pc, arg, int_type_addr)?;
                 ctx.trace_ctx
                     .set_opref_concrete(raw, majit_ir::Value::Int(value));
@@ -21476,9 +21577,57 @@ fn try_walker_trace_exception_new(
             )
         }
     };
+    // A raised exception can keep args_w live through the execution-context
+    // slot, forcing the otherwise-virtual list.  Stamp the canonical list
+    // class just as w_list_new does so that materialization preserves the
+    // `space.type(args_w) is list` branch used by descr_getargs.
+    let list_w_class = pyre_object::get_instantiate(&pyre_object::pyobject::LIST_TYPE);
+    let list_w_class = ctx.trace_ctx.const_ref(list_w_class as i64);
+    let list_w_class_descr = crate::descr::list_w_class_descr();
+    let list_w_class_index = list_w_class_descr.index();
+    ctx.trace_ctx.record_op_with_descr(
+        OpCode::SetfieldGc,
+        &[args_list, list_w_class],
+        list_w_class_descr,
+    );
+    ctx.trace_ctx
+        .heapcache_setfield_cached(args_list, list_w_class_index, list_w_class);
 
+    // `W_OSError.descr_new` can retag exact OSError by errno while retaining
+    // the OSError physical kind.  The guarded errno makes the concrete final
+    // class a valid constant; dedicated classes and subclasses keep the called
+    // class operand as in the ordinary constructor emit.
+    let emitted_w_class = if fills_os_error_slots && exact_os_error {
+        ctx.trace_ctx.const_ref(concrete_w_class as i64)
+    } else {
+        callable_op
+    };
     let new_op =
-        crate::helpers::emit_exception_new_inline(ctx.trace_ctx, kind, callable_op, args_list);
+        crate::helpers::emit_exception_new_inline(ctx.trace_ctx, kind, emitted_w_class, args_list);
+
+    if fills_os_error_slots {
+        use pyre_interpreter::baseobjspace::ExceptionAttrSlot;
+        let mut stores = vec![
+            (ExceptionAttrSlot::Errno, args[0]),
+            (ExceptionAttrSlot::Strerror, args[1]),
+        ];
+        if has_filename {
+            stores.push((ExceptionAttrSlot::Filename, args[2]));
+            // The fourth positional argument is winerror and is ignored on
+            // non-Windows builds, matching W_OSError._parse_init_args.
+            if args.len() == 5 && !unsafe { pyre_object::is_none(concrete_args[4]) } {
+                stores.push((ExceptionAttrSlot::Filename2, args[4]));
+            }
+        }
+        for (slot, value) in stores {
+            let descr = crate::descr::w_exception_slot_descr(kind, slot);
+            let descr_index = descr.index();
+            ctx.trace_ctx
+                .record_op_with_descr(OpCode::SetfieldGc, &[new_op, value], descr);
+            ctx.trace_ctx
+                .heapcache_setfield_cached(new_op, descr_index, value);
+        }
+    }
 
     // Mark the class known so the following `raise/r` skips its
     // redundant GUARD_CLASS (mirrors `seed_raised_exception`'s

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -21123,6 +21123,19 @@ fn try_walker_trace_raise_builtin(
         &[exc_op, active],
         crate::descr::w_exception_context_descr(kind),
     );
+    // The full-body walk is also the authoritative execution of the
+    // tracing iteration.  Apply the same context write to its concrete,
+    // freshly-built exception that the recorded SETFIELD performs on later
+    // compiled iterations; otherwise Python code reached later in this walk
+    // observes a missing __context__ exactly once, while the trace itself is
+    // correct.  This object is private to the inline construction, so no
+    // rollback journal is needed.
+    let active_concrete = pyre_interpreter::eval::get_current_exception();
+    if !active_concrete.is_null() {
+        unsafe {
+            pyre_object::interp_exceptions::w_exception_set_context(exc, active_concrete);
+        }
+    }
 
     // The normalized publish result is the same flat builtin instance;
     // forward the inline-built exc OpRef (carrying its concrete shadow)

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -18420,6 +18420,110 @@ fn try_walker_specialize_load_attr(
         return Ok(Some(()));
     }
 
+    if let Some((slot, kind, w_type, version_tag, stored)) = unsafe {
+        pyre_interpreter::baseobjspace::exception_attr_slot_fold(concrete_obj, &name, false)
+    } {
+        if slot == pyre_interpreter::baseobjspace::ExceptionAttrSlot::Args
+            && unsafe { (*(stored as *const pyre_object::listobject::W_ListObject)).strategy }
+                != pyre_object::listobject::ListStrategy::Object
+        {
+            return Ok(None);
+        }
+        walker_guard_exception_attr_slot(ctx, op_pc, obj, concrete_obj, w_type, version_tag)?;
+        let raw_value = crate::state::opimpl_getfield_gc_r(
+            ctx.trace_ctx,
+            obj,
+            crate::descr::w_exception_slot_descr(kind, slot),
+        );
+        walker_emit_fold_guard_with_snapshot(ctx, op_pc, OpCode::GuardNonnull, &[raw_value])?;
+        ctx.trace_ctx.set_opref_concrete(
+            raw_value,
+            majit_ir::Value::Ref(majit_ir::GcRef(stored as usize)),
+        );
+        let value = if slot == pyre_interpreter::baseobjspace::ExceptionAttrSlot::Args {
+            let list = unsafe { &*(stored as *const pyre_object::listobject::W_ListObject) };
+            if list.strategy != pyre_object::listobject::ListStrategy::Object {
+                return Ok(None);
+            }
+            let list_type = &pyre_object::LIST_TYPE as *const pyre_object::PyType as i64;
+            if !ctx.trace_ctx.heap_cache().is_class_known(raw_value) {
+                let type_const = ctx.trace_ctx.const_int(list_type);
+                walker_emit_fold_guard_with_snapshot(
+                    ctx,
+                    op_pc,
+                    OpCode::GuardClass,
+                    &[raw_value, type_const],
+                )?;
+                ctx.trace_ctx
+                    .heap_cache_mut()
+                    .class_now_known(raw_value, list_type);
+            }
+            walker_guard_exact_w_class(
+                ctx,
+                op_pc,
+                raw_value,
+                pyre_object::get_instantiate(&pyre_object::LIST_TYPE),
+            )?;
+            let strategy = crate::state::opimpl_getfield_gc_i(
+                ctx.trace_ctx,
+                raw_value,
+                crate::descr::list_strategy_descr(),
+            );
+            let object_strategy = ctx
+                .trace_ctx
+                .const_int(pyre_object::listobject::ListStrategy::Object as i64);
+            walker_emit_fold_guard_with_snapshot(
+                ctx,
+                op_pc,
+                OpCode::GuardValue,
+                &[strategy, object_strategy],
+            )?;
+            let len = unsafe { pyre_object::w_list_len(stored) };
+            let length = crate::state::opimpl_getfield_gc_i(
+                ctx.trace_ctx,
+                raw_value,
+                crate::descr::list_length_descr(),
+            );
+            let len_const = ctx.trace_ctx.const_int(len as i64);
+            walker_emit_fold_guard_with_snapshot(
+                ctx,
+                op_pc,
+                OpCode::GuardValue,
+                &[length, len_const],
+            )?;
+            let block = crate::state::opimpl_getfield_gc_r(
+                ctx.trace_ctx,
+                raw_value,
+                crate::descr::list_items_descr(),
+            );
+            let mut items = Vec::with_capacity(len);
+            let mut concrete_items = Vec::with_capacity(len);
+            for index in 0..len {
+                let index_op = ctx.trace_ctx.const_int(index as i64);
+                items.push(crate::state::trace_items_block_getitem_value(
+                    ctx.trace_ctx,
+                    block,
+                    index_op,
+                ));
+                concrete_items.push(
+                    unsafe { pyre_object::w_list_getitem(stored, index as i64) }
+                        .unwrap_or(pyre_object::PY_NULL),
+                );
+            }
+            let tuple = crate::helpers::emit_object_tuple_inline(ctx.trace_ctx, &items);
+            let concrete_tuple = pyre_object::w_tuple_new(concrete_items);
+            ctx.trace_ctx.set_opref_concrete(
+                tuple,
+                majit_ir::Value::Ref(majit_ir::GcRef(concrete_tuple as usize)),
+            );
+            tuple
+        } else {
+            raw_value
+        };
+        write_residual_call_result_to_dst(ctx, op_pc, dst, dst_bank, value)?;
+        return Ok(Some(()));
+    }
+
     let Some((w_type, version_tag, map, storageindex, listindex, unbox_type)) = (unsafe {
         pyre_interpreter::objspace::std::mapdict::load_attr_unboxed_fast_path(concrete_obj, &name)
     }) else {
@@ -18491,6 +18595,61 @@ fn try_walker_specialize_load_attr(
     };
     write_residual_call_result_to_dst(ctx, op_pc, dst, dst_bank, boxed)?;
     Ok(Some(()))
+}
+
+/// Pin every branch input preceding a raw typed exception-slot arm.
+/// `GuardClass` fixes the kind-specific `W_BaseException` layout and kind tag;
+/// `GuardValue(getfield(w_class))` distinguishes heap subclasses sharing that
+/// layout; and the class `version_tag` guard pins the preceding type-dict miss.
+/// Exception `w_dict` lookup follows these arms in `baseobjspace.rs`, so it is
+/// intentionally not part of the guard set.  This is the same promoted-class
+/// lookup shape used by the mapdict folds (`mapdict.py`).
+fn walker_guard_exception_attr_slot(
+    ctx: &mut WalkContext<'_, '_>,
+    op_pc: usize,
+    obj: OpRef,
+    concrete_obj: pyre_object::PyObjectRef,
+    w_type: pyre_object::PyObjectRef,
+    version_tag: u64,
+) -> Result<(), DispatchError> {
+    let physical_type = unsafe { (*concrete_obj).ob_type } as i64;
+    if !ctx.trace_ctx.heap_cache().is_class_known(obj) {
+        let type_const = ctx.trace_ctx.const_int(physical_type);
+        walker_emit_fold_guard_with_snapshot(ctx, op_pc, OpCode::GuardClass, &[obj, type_const])?;
+        ctx.trace_ctx
+            .heap_cache_mut()
+            .class_now_known(obj, physical_type);
+    }
+    let live_w_class =
+        crate::state::opimpl_getfield_gc_r(ctx.trace_ctx, obj, crate::descr::w_class_descr());
+    let w_class_const = ctx.trace_ctx.const_ref(w_type as i64);
+    walker_emit_fold_guard_with_snapshot(
+        ctx,
+        op_pc,
+        OpCode::GuardValue,
+        &[live_w_class, w_class_const],
+    )?;
+    ctx.trace_ctx
+        .heap_cache_mut()
+        .replace_box(live_w_class, w_class_const);
+
+    let type_const = ctx.trace_ctx.const_ref(w_type as i64);
+    let live_version = crate::state::opimpl_getfield_gc_i(
+        ctx.trace_ctx,
+        type_const,
+        crate::descr::type_version_tag_descr(),
+    );
+    let version_const = ctx.trace_ctx.const_int(version_tag as i64);
+    walker_emit_fold_guard_with_snapshot(
+        ctx,
+        op_pc,
+        OpCode::GuardValue,
+        &[live_version, version_const],
+    )?;
+    ctx.trace_ctx
+        .heap_cache_mut()
+        .replace_box(live_version, version_const);
+    Ok(())
 }
 
 fn walker_load_name_from_code(w_code_ptr: usize, name_idx: usize) -> Option<String> {
@@ -18736,6 +18895,11 @@ fn try_walker_fold_load_method_self(
 /// the generic residual recorder/executor so concrete execution, body-effect
 /// tracking, and rollback semantics remain identical to the generic setattr
 /// path (mapdict.py:577-584, 615-619).
+enum WalkerStoreAttrSpecialization {
+    Residual(DescrRef, Vec<OpRef>),
+    Direct,
+}
+
 fn try_walker_specialize_store_attr(
     ctx: &mut WalkContext<'_, '_>,
     op_pc: usize,
@@ -18744,7 +18908,7 @@ fn try_walker_specialize_store_attr(
     w_code_ptr: usize,
     name_idx: usize,
     original_effect: &majit_ir::EffectInfo,
-) -> Result<Option<(DescrRef, Vec<OpRef>)>, DispatchError> {
+) -> Result<Option<WalkerStoreAttrSpecialization>, DispatchError> {
     if !ctx.is_authoritative_executor || !ctx.is_full_body_walk {
         return Ok(None);
     }
@@ -18832,10 +18996,144 @@ fn try_walker_specialize_store_attr(
         // ABI order follows the write helpers: receiver and the two guarded green
         // coordinates, then the raw symbolic value in its own bank.  No box is
         // materialized for this write.
-        return Ok(Some((
+        return Ok(Some(WalkerStoreAttrSpecialization::Residual(
             descr,
             vec![helper, obj, storageindex_const, listindex_const, raw],
         )));
+    }
+
+    if let Some((slot, kind, w_type, version_tag, _stored)) = unsafe {
+        pyre_interpreter::baseobjspace::exception_attr_slot_fold(concrete_obj, &name, true)
+    } {
+        if slot == pyre_interpreter::baseobjspace::ExceptionAttrSlot::Args {
+            let tuple_type = &pyre_object::TUPLE_TYPE as *const pyre_object::PyType;
+            let canonical_tuple_class = pyre_object::get_instantiate(&pyre_object::TUPLE_TYPE);
+            if !unsafe {
+                std::ptr::eq((*concrete_value).ob_type, tuple_type)
+                    && std::ptr::eq((*concrete_value).w_class, canonical_tuple_class)
+            } {
+                return Ok(None);
+            }
+        }
+        walker_guard_exception_attr_slot(ctx, op_pc, obj, concrete_obj, w_type, version_tag)?;
+        let (stored_value, concrete_stored) =
+            if slot == pyre_interpreter::baseobjspace::ExceptionAttrSlot::Args {
+                let tuple_type = &pyre_object::TUPLE_TYPE as *const pyre_object::PyType;
+                let canonical_tuple_class = pyre_object::get_instantiate(&pyre_object::TUPLE_TYPE);
+                if !unsafe {
+                    std::ptr::eq((*concrete_value).ob_type, tuple_type)
+                        && std::ptr::eq((*concrete_value).w_class, canonical_tuple_class)
+                } {
+                    return Ok(None);
+                }
+                let tuple_type_addr = tuple_type as i64;
+                if !ctx.trace_ctx.heap_cache().is_class_known(value) {
+                    let type_const = ctx.trace_ctx.const_int(tuple_type_addr);
+                    walker_emit_fold_guard_with_snapshot(
+                        ctx,
+                        op_pc,
+                        OpCode::GuardClass,
+                        &[value, type_const],
+                    )?;
+                    ctx.trace_ctx
+                        .heap_cache_mut()
+                        .class_now_known(value, tuple_type_addr);
+                }
+                walker_guard_exact_w_class(ctx, op_pc, value, canonical_tuple_class)?;
+                let block = crate::state::opimpl_getfield_gc_r(
+                    ctx.trace_ctx,
+                    value,
+                    crate::descr::tuple_wrappeditems_descr(),
+                );
+                let len = unsafe { pyre_object::w_tuple_len(concrete_value) };
+                let length = crate::state::opimpl_arraylen_gc(
+                    ctx.trace_ctx,
+                    block,
+                    crate::state::pyobject_gcarray_descr(),
+                );
+                let len_const = ctx.trace_ctx.const_int(len as i64);
+                walker_emit_fold_guard_with_snapshot(
+                    ctx,
+                    op_pc,
+                    OpCode::GuardValue,
+                    &[length, len_const],
+                )?;
+                let mut items = Vec::with_capacity(len);
+                let mut concrete_items = Vec::with_capacity(len);
+                for index in 0..len {
+                    let index_op = ctx.trace_ctx.const_int(index as i64);
+                    items.push(crate::state::trace_items_block_getitem_value(
+                        ctx.trace_ctx,
+                        block,
+                        index_op,
+                    ));
+                    concrete_items.push(
+                        unsafe { pyre_object::w_tuple_getitem(concrete_value, index as i64) }
+                            .unwrap_or(pyre_object::PY_NULL),
+                    );
+                }
+                let list = crate::helpers::emit_object_list_inline(ctx.trace_ctx, &items);
+                let concrete_list = pyre_object::w_list_new_object(concrete_items);
+                ctx.trace_ctx.set_opref_concrete(
+                    list,
+                    majit_ir::Value::Ref(majit_ir::GcRef(concrete_list as usize)),
+                );
+                (list, concrete_list)
+            } else {
+                (value, concrete_value)
+            };
+        let field_descr = crate::descr::w_exception_slot_descr(kind, slot);
+        let field_index = field_descr.index();
+        ctx.trace_ctx
+            .record_op_with_descr(OpCode::SetfieldGc, &[obj, stored_value], field_descr);
+        ctx.trace_ctx
+            .heapcache_setfield_cached(obj, field_index, stored_value);
+        // The walk is the authoritative execution path.  Apply the same raw
+        // slot writer now so interpreter execution after a side exit observes
+        // the store; the writer supplies the host-side remembered-set barrier.
+        // Compiled SetfieldGc reference stores receive CondCallGcWb from
+        // majit-gc's rewrite pass, consumed by both dynasm and cranelift.
+        unsafe {
+            match slot {
+                pyre_interpreter::baseobjspace::ExceptionAttrSlot::Args => {
+                    pyre_object::interp_exceptions::w_exception_set_args(
+                        concrete_obj,
+                        concrete_stored,
+                    )
+                }
+                pyre_interpreter::baseobjspace::ExceptionAttrSlot::Code => {
+                    pyre_object::interp_exceptions::w_exception_set_code(
+                        concrete_obj,
+                        concrete_value,
+                    )
+                }
+                pyre_interpreter::baseobjspace::ExceptionAttrSlot::Errno => {
+                    pyre_object::interp_exceptions::w_exception_set_errno(
+                        concrete_obj,
+                        concrete_value,
+                    )
+                }
+                pyre_interpreter::baseobjspace::ExceptionAttrSlot::Strerror => {
+                    pyre_object::interp_exceptions::w_exception_set_strerror(
+                        concrete_obj,
+                        concrete_value,
+                    )
+                }
+                pyre_interpreter::baseobjspace::ExceptionAttrSlot::Filename => {
+                    pyre_object::interp_exceptions::w_exception_set_filename(
+                        concrete_obj,
+                        concrete_value,
+                    )
+                }
+                pyre_interpreter::baseobjspace::ExceptionAttrSlot::Filename2 => {
+                    pyre_object::interp_exceptions::w_exception_set_filename2(
+                        concrete_obj,
+                        concrete_value,
+                    )
+                }
+            }
+        }
+        return Ok(Some(WalkerStoreAttrSpecialization::Direct));
     }
 
     let Some((w_type, version_tag, map, storageindex)) = (unsafe {
@@ -18868,7 +19166,10 @@ fn try_walker_specialize_store_attr(
     // ABI order follows `jit_mapdict_boxed_write`: receiver, guarded green
     // storage index, and the original symbolic object reference.  The value is
     // neither unboxed nor guarded by type.
-    Ok(Some((descr, vec![helper, obj, storageindex_const, value])))
+    Ok(Some(WalkerStoreAttrSpecialization::Residual(
+        descr,
+        vec![helper, obj, storageindex_const, value],
+    )))
 }
 
 /// Walker-native mirror of the trait `trace_guard_exact_w_class`
@@ -22444,19 +22745,27 @@ fn dispatch_residual_call_iIRd_kind(
                 ctx.trace_ctx.box_value(code_opref),
                 ctx.trace_ctx.box_value(namei_opref),
             ) {
-                if let Some((specialized_descr, specialized_allboxes)) =
-                    try_walker_specialize_store_attr(
-                        ctx,
-                        op.pc,
-                        obj_opref,
-                        value_opref,
-                        w_code_ptr,
-                        namei as usize,
-                        original_call_descr.get_extra_info(),
-                    )?
-                {
-                    descr = specialized_descr;
-                    allboxes = specialized_allboxes;
+                if let Some(specialization) = try_walker_specialize_store_attr(
+                    ctx,
+                    op.pc,
+                    obj_opref,
+                    value_opref,
+                    w_code_ptr,
+                    namei as usize,
+                    original_call_descr.get_extra_info(),
+                )? {
+                    match specialization {
+                        WalkerStoreAttrSpecialization::Residual(
+                            specialized_descr,
+                            specialized_allboxes,
+                        ) => {
+                            descr = specialized_descr;
+                            allboxes = specialized_allboxes;
+                        }
+                        WalkerStoreAttrSpecialization::Direct => {
+                            return Ok((DispatchOutcome::Continue, op.next_pc));
+                        }
+                    }
                 }
             }
         }

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -6255,6 +6255,83 @@ fn bridge_decode_box(
     }
 }
 
+/// Seed the bridge walk's current-exception channel from the guard-owned
+/// pending field stream.  `resume.py:_prepare_pendingfields` decodes these
+/// tagged values only after virtual preparation; bridge tracing must decode
+/// the same fieldbox without applying the write to the live execution
+/// context, because the walk may still be abandoned.
+#[allow(clippy::too_many_arguments)]
+fn seed_bridge_pending_current_exception(
+    sym: &mut PyreSym,
+    ctx: &mut majit_metainterp::TraceCtx,
+    resume_data: &majit_metainterp::ResumeDataResult,
+    rd_virtuals: Option<&[std::rc::Rc<majit_ir::RdVirtualInfo>]>,
+    fail_values: &[i64],
+    fail_types: &[Type],
+    backend: &dyn majit_backend::Backend,
+    cache: &mut BridgeVirtualCache,
+) {
+    let Some(storage) = resume_data.storage.as_ref() else {
+        return;
+    };
+    let target_descr = crate::descr::ec_sys_exc_value_descr();
+    for pending in &storage.rd_pendingfields {
+        let Some(descr) = pending.descr.as_ref() else {
+            continue;
+        };
+        if pending.item_index >= 0 || !std::sync::Arc::ptr_eq(descr, &target_descr) {
+            continue;
+        }
+
+        // resume.py:1002-1005: both operands use the same tagged decoder as
+        // frame boxes.  Decode the target as well as the fieldbox so virtual
+        // preparation and malformed-tag checks stay aligned with deopt.
+        let rd_consts = storage.rd_consts();
+        let target = majit_ir::resumedata::decode_tagged_value(
+            pending.target_tagged,
+            resume_data.num_failargs,
+            rd_consts,
+            &resume_data.fail_arg_types,
+            storage.rd_virtuals.len(),
+        );
+        let value = majit_ir::resumedata::decode_tagged_value(
+            pending.value_tagged,
+            resume_data.num_failargs,
+            rd_consts,
+            &resume_data.fail_arg_types,
+            storage.rd_virtuals.len(),
+        );
+        let _ = bridge_decode_box(
+            ctx,
+            &target,
+            Type::Ref,
+            rd_virtuals,
+            resume_data,
+            fail_values,
+            fail_types,
+            backend,
+            cache,
+        );
+        let (value_box, value_concrete) = bridge_decode_box(
+            ctx,
+            &value,
+            Type::Ref,
+            rd_virtuals,
+            resume_data,
+            fail_values,
+            fail_types,
+            backend,
+            cache,
+        );
+        let majit_ir::Value::Ref(value_ref) = value_concrete else {
+            continue;
+        };
+        sym.last_exc_box = value_box;
+        sym.last_exc_value = value_ref.as_usize() as pyre_object::PyObjectRef;
+        sym.class_of_last_exc_is_const = false;
+    }
+}
+
 /// resume.py:1245-1264 decode_box concrete parity for tagged fieldnums.
 /// Converts a tagged i16 (from `rd_virtuals[*].fieldnums`) into raw i64
 /// bits suitable for backend concrete setters/calls.
@@ -9085,6 +9162,17 @@ impl JitState for PyreJitState {
                 recipes,
             });
         }
+
+        seed_bridge_pending_current_exception(
+            sym,
+            ctx,
+            resume_data,
+            rd_virtuals,
+            fail_values,
+            fail_types,
+            backend,
+            &mut virtuals_cache,
+        );
     }
 
     /// resume.py:1042-1057 rebuild_from_resumedata parity.

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -5760,6 +5760,16 @@ pub extern "C" fn bh_load_fast_check_fn(value: i64, w_code_ptr: i64, name_idx: i
     if value as pyre_object::PyObjectRef != pyre_object::PY_NULL {
         return value;
     }
+    let exc_obj = bh_unbound_local_error_fn(w_code_ptr, name_idx);
+    publish_residual_call_exception(exc_obj);
+    0
+}
+
+/// Construct the value raised by DELETE_FAST when its local is unbound.
+/// Unlike `bh_load_fast_check_fn`, this returns the exception object without
+/// publishing it through the residual-exception channel. It allocates but
+/// runs no user code and never raises (`CallFlavor::PlainCannotRaise`).
+pub extern "C" fn bh_unbound_local_error_fn(w_code_ptr: i64, name_idx: i64) -> i64 {
     let code = unsafe {
         &*(pyre_interpreter::w_code_get_ptr(w_code_ptr as pyre_object::PyObjectRef)
             as *const pyre_interpreter::CodeObject)
@@ -5775,13 +5785,11 @@ pub extern "C" fn bh_load_fast_check_fn(value: i64, w_code_ptr: i64, name_idx: i
     } else {
         "<cell>"
     };
-    let exc_obj = pyre_interpreter::PyError::unbound_local_error_with_name(
+    pyre_interpreter::PyError::unbound_local_error_with_name(
         format!("cannot access local variable '{name}' where it is not associated with a value"),
         name,
     )
-    .to_exc_object();
-    publish_residual_call_exception(exc_obj as i64);
-    0
+    .to_exc_object() as i64
 }
 
 #[cfg(test)]

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -1561,6 +1561,25 @@ fn handler_entry_has_lasti_exception_slots(
     })
 }
 
+/// True when an explicit raise can enter this cleanup handler.  Its
+/// propagated value is already in the durable frame stack slot; a reraise
+/// instead continues to use the live exception payload supplied by the
+/// exception edge.
+fn handler_entry_has_explicit_raise_source(
+    code: &CodeObject,
+    catch_sites: &[ExceptionCatchSite],
+    handler_py_pc: usize,
+) -> bool {
+    catch_sites.iter().any(|site| {
+        site.handler_py_pc == handler_py_pc
+            && site.push_lasti
+            && matches!(
+                pyre_interpreter::decode_instruction_at(code, site.lasti_py_pc),
+                Some((Instruction::RaiseVarargs { .. }, _))
+            )
+    })
+}
+
 fn initialize_spam_block(
     code: &CodeObject,
     graph: &mut super::flow::FunctionGraph,
@@ -7334,13 +7353,46 @@ impl CodeWriter {
                         && handler_entry_has_lasti_exception_slots(&catch_sites, py_pc)
                     {
                         if let Some(exc_value) = current_state.stack.last().cloned() {
-                            record_graph_op(
-                                &current_block.block(),
-                                "last_exc_value",
-                                Vec::new(),
-                                Some(exc_value),
-                                py_pc as i64,
-                            );
+                            if matches!(
+                                pyre_interpreter::decode_instruction_at(code, py_pc),
+                                Some((Instruction::Copy { .. }, _))
+                            ) && handler_entry_has_explicit_raise_source(
+                                code,
+                                &catch_sites,
+                                py_pc,
+                            ) {
+                                // Catch dispatch has already stored the
+                                // propagated exception in the frame's top stack
+                                // slot.  Reload that durable slot while giving
+                                // the shadow graph the definition it needs to
+                                // keep the exception and lasti colours distinct.
+                                // Re-reading `last_exc_value` is not sound after
+                                // a clearing residual, and the current-exception
+                                // slot can still name the older exception whose
+                                // handler raised this one.
+                                let stack_slot =
+                                    stack_base_absolute + current_depth.saturating_sub(1) as usize;
+                                let stack_idx: super::flow::FlowValue =
+                                    super::flow::Constant::signed(stack_slot as i64).into();
+                                record_graph_op(
+                                    &current_block.block(),
+                                    "getarrayitem_vable_r",
+                                    vable_getarrayitem_ref_graph_args(
+                                        frame_var.into(),
+                                        stack_idx.into(),
+                                    ),
+                                    Some(exc_value),
+                                    py_pc as i64,
+                                );
+                            } else {
+                                record_graph_op(
+                                    &current_block.block(),
+                                    "last_exc_value",
+                                    Vec::new(),
+                                    Some(exc_value),
+                                    py_pc as i64,
+                                );
+                            }
                         }
                     }
                     // The walker emits one block-identity `Label(block)`

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -3114,6 +3114,37 @@ fn attach_catch_exception_edge(
     link
 }
 
+fn carry_explicit_raise_value_on_catch_stack(
+    link: &super::flow::LinkRef,
+    target: &SpamBlockRef,
+    raised_value: super::flow::FlowValue,
+) {
+    let target_state = target
+        .framestate()
+        .expect("explicit raise catch landing must carry a FrameState");
+    let stack_value = target_state
+        .stack
+        .last()
+        .and_then(super::flow::FlowValue::as_variable)
+        .expect("catch landing must end its stack with the raised value");
+    let input_index = target
+        .block()
+        .borrow()
+        .inputargs
+        .iter()
+        .position(|value| value.as_variable().is_some_and(|v| v.id == stack_value.id))
+        .expect("catch stack value must appear in landing inputargs");
+    link.borrow_mut().args[input_index] = Some(raised_value);
+    let mut link = link.borrow_mut();
+    // Replacing the handler-stack alias changes the exception pair's
+    // positional mapping to value/type order. Keep the Link metadata aligned
+    // so `generate_last_exc` writes `last_exception` to the Int destination
+    // and `last_exc_value` to the Ref destination.
+    let last_exception = link.last_exception;
+    link.last_exception = link.last_exc_value;
+    link.last_exc_value = last_exception;
+}
+
 fn restore_canraise_exit_order(block: &super::flow::BlockRef) {
     let mut block_mut = block.borrow_mut();
     if block_mut.exits.len() < 2 {
@@ -3351,6 +3382,7 @@ struct FnPtrIndices {
     call_kw_fn_11: HelperHandle,
     call_kw_fn_12: HelperHandle,
     call_kw_fn_13: HelperHandle,
+    unbound_local_error_fn: HelperHandle,
 }
 
 /// Register every blackhole helper fn pointer with the assembler in
@@ -3979,6 +4011,14 @@ fn register_helper_fn_pointers(
         cpu.set_function_attribute_fn as *const (),
         CallFlavor::Plain,
     );
+    // DELETE_FAST's unbound arm constructs the exception value without
+    // publishing it or running user code. Allocation touches the heap, so use
+    // `PlainCannotRaise`. Bound last to preserve every existing fn_ptr index.
+    let unbound_local_error_fn = bind(
+        assembler,
+        cpu.unbound_local_error_fn as *const (),
+        CallFlavor::PlainCannotRaise,
+    );
     FnPtrIndices {
         call_fn,
         load_global_fn,
@@ -4070,6 +4110,7 @@ fn register_helper_fn_pointers(
         call_kw_fn_13,
         make_function_fn,
         set_function_attribute_fn,
+        unbound_local_error_fn,
     }
 }
 
@@ -5776,6 +5817,11 @@ impl CodeWriter {
                     idx: set_function_attribute_fn_idx,
                     flavor: _set_function_attribute_fn_flavor,
                 },
+            unbound_local_error_fn:
+                HelperHandle {
+                    idx: unbound_local_error_fn_idx,
+                    flavor: _unbound_local_error_fn_flavor,
+                },
         } = register_helper_fn_pointers(&mut assembler, self.cpu());
 
         // codewriter.py:37 `portal_jd = self.callcontrol.jitdriver_sd_from_portal_graph(graph)`
@@ -5875,6 +5921,7 @@ impl CodeWriter {
                 call_function_ex_fn_idx,
                 unary_not_fn_idx,
                 load_fast_check_fn_idx,
+                unbound_local_error_fn_idx,
                 list_extend_fn_idx,
                 set_add_fn_idx,
                 set_update_fn_idx,
@@ -11379,7 +11426,6 @@ impl CodeWriter {
                                     emit_abort_permanent!(py_pc);
                                     continue;
                                 }
-                                let idx_u16 = idx as u16;
                                 let local_slot = local_to_vable_slot(idx) as i64;
                                 let v_idx: super::flow::FlowValue =
                                     super::flow::Constant::signed(local_slot).into();
@@ -11391,50 +11437,19 @@ impl CodeWriter {
                                     .into();
                                 let name_idx_const: super::flow::FlowValue =
                                     super::flow::Constant::signed(idx as i64).into();
-                                emit_load_fast_ref!(current_depth, idx_u16, py_pc);
-                                let _value_reg = emit_popvalue_ref!(current_depth, py_pc);
-                                let value_value = pop_ref_or_fresh(&mut current_state, &mut graph);
-                                let checked_value = emit_graph_op_with_result(
-                                    &mut graph,
-                                    &current_block.block(),
-                                    "load_fast_check",
-                                    vec![
-                                        value_value.into(),
-                                        code_const.into(),
-                                        name_idx_const.into(),
-                                    ],
-                                    Kind::Ref,
-                                    py_pc as i64,
-                                );
-                                let checked_flow: super::flow::FlowValue = checked_value.into();
-                                let is_null = emit_graph_op_with_result(
-                                    &mut graph,
-                                    &current_block.block(),
-                                    "ptr_iszero",
-                                    vec![checked_flow.clone().into()],
-                                    Kind::Int,
-                                    py_pc as i64,
-                                );
-                                current_block.block().borrow_mut().exitswitch =
-                                    Some(super::flow::ExitSwitch::Value(is_null.into()));
-                                let abort_state = current_state.clone();
-                                let abort_block = SpamBlockRef::new(
-                                    graph.new_block(Vec::new()),
-                                    Some(abort_state.clone()),
-                                );
-                                abort_block.block().borrow_mut().inputargs =
-                                    abort_state.getvariables();
-                                all_walker_blocks.push(abort_block.clone());
-                                append_exit(
-                                    &current_block.block(),
-                                    output_link(&current_state, &abort_state, abort_block.block()),
-                                );
-                                set_last_bool_exitcase(&current_block.block(), true);
-                                {
+                                // pyopcode.py:998 DELETE_FAST checks for an
+                                // unbound local before clearing its slot. A
+                                // statically unbound slot therefore raises
+                                // unconditionally and performs no write.
+                                if matches!(
+                                    current_state.local_value_at(idx),
+                                    Some(super::flow::FlowValue::Constant(c))
+                                        if c.value == super::flow::ConstantValue::None
+                                ) {
                                     let v_li: super::flow::FlowValue =
                                         super::flow::Constant::signed(py_pc as i64 - 1).into();
                                     record_graph_op(
-                                        &abort_block.block(),
+                                        &current_block.block(),
                                         "setfield_vable_i",
                                         vable_setfield_int_graph_args(
                                             frame_var.into(),
@@ -11444,56 +11459,121 @@ impl CodeWriter {
                                         None,
                                         py_pc as i64,
                                     );
-                                    record_graph_op(
-                                        &abort_block.block(),
-                                        "abort_permanent",
-                                        Vec::new(),
-                                        None,
+                                    let exc_value = emit_graph_op_with_result(
+                                        &mut graph,
+                                        &current_block.block(),
+                                        "unbound_local_error",
+                                        vec![code_const.into(), name_idx_const.into()],
+                                        Kind::Ref,
                                         py_pc as i64,
                                     );
-                                    append_exit(
-                                        &abort_block.block(),
-                                        super::flow::Link::new(
-                                            vec![super::flow::Constant::none().into()],
-                                            Some(graph.returnblock.clone()),
-                                            None,
-                                        )
-                                        .into_ref(),
-                                    );
+                                    let exc_flow: super::flow::FlowValue = exc_value.into();
+                                    emit_raise!(0u16, exc_flow, py_pc as i64, true);
+                                    continue;
                                 }
-                                let continue_state = current_state.clone();
-                                let continue_block = SpamBlockRef::new(
-                                    graph.new_block(Vec::new()),
-                                    Some(continue_state.clone()),
+                                let idx_u16 = idx as u16;
+                                emit_load_fast_ref!(current_depth, idx_u16, py_pc);
+                                let _value_reg = emit_popvalue_ref!(current_depth, py_pc);
+                                let value_value = pop_ref_or_fresh(&mut current_state, &mut graph);
+                                let is_null = emit_graph_op_with_result(
+                                    &mut graph,
+                                    &current_block.block(),
+                                    "ptr_iszero",
+                                    vec![value_value.into()],
+                                    Kind::Int,
+                                    py_pc as i64,
                                 );
-                                continue_block.block().borrow_mut().inputargs =
-                                    continue_state.getvariables();
-                                all_walker_blocks.push(continue_block.clone());
+                                current_block.block().borrow_mut().exitswitch =
+                                    Some(super::flow::ExitSwitch::Value(is_null.into()));
+                                let unbound_state = current_state.clone();
+                                let unbound_block = SpamBlockRef::new(
+                                    graph.new_block(Vec::new()),
+                                    Some(unbound_state.clone()),
+                                );
+                                unbound_block.block().borrow_mut().inputargs =
+                                    unbound_state.getvariables();
+                                all_walker_blocks.push(unbound_block.clone());
                                 append_exit(
                                     &current_block.block(),
                                     output_link(
                                         &current_state,
-                                        &continue_state,
-                                        continue_block.block(),
+                                        &unbound_state,
+                                        unbound_block.block(),
                                     ),
                                 );
+                                set_last_bool_exitcase(&current_block.block(), true);
+                                let bound_state = current_state.clone();
+                                let bound_block = SpamBlockRef::new(
+                                    graph.new_block(Vec::new()),
+                                    Some(bound_state.clone()),
+                                );
+                                bound_block.block().borrow_mut().inputargs =
+                                    bound_state.getvariables();
+                                all_walker_blocks.push(bound_block.clone());
+                                append_exit(
+                                    &current_block.block(),
+                                    output_link(&current_state, &bound_state, bound_block.block()),
+                                );
                                 set_last_bool_exitcase(&current_block.block(), false);
-                                current_block = continue_block;
+
+                                // The unbound arm raises before any clear,
+                                // matching pyopcode.py:998 DELETE_FAST. Keep
+                                // last_instr at the deleting instruction so
+                                // exception unwind and deopt share its frame
+                                // coordinate.
+                                current_block = unbound_block;
+                                current_state = unbound_state;
+                                let v_li: super::flow::FlowValue =
+                                    super::flow::Constant::signed(py_pc as i64 - 1).into();
                                 record_graph_op(
                                     &current_block.block(),
-                                    "setarrayitem_vable_r",
-                                    vable_setarrayitem_ref_graph_args(
+                                    "setfield_vable_i",
+                                    vable_setfield_int_graph_args(
                                         frame_var.into(),
-                                        v_idx.clone().into(),
-                                        checked_flow.into(),
+                                        v_li.into(),
+                                        VABLE_LAST_INSTR_FIELD_IDX,
                                     ),
                                     None,
                                     py_pc as i64,
                                 );
-                                // eval.rs:delete_fast writes PY_NULL into the
-                                // locals slot. Mirror STORE_FAST's
-                                // `setarrayitem_vable_r` local write with the
-                                // unbound sentinel as the value.
+                                let exc_value = emit_graph_op_with_result(
+                                    &mut graph,
+                                    &current_block.block(),
+                                    "unbound_local_error",
+                                    vec![code_const.into(), name_idx_const.into()],
+                                    Kind::Ref,
+                                    py_pc as i64,
+                                );
+                                let exc_flow: super::flow::FlowValue = exc_value.into();
+                                emit_raise!(0u16, exc_flow.clone(), py_pc as i64, true);
+                                if let Some(catch_label) =
+                                    catch_for_pc.get(py_pc).copied().flatten()
+                                {
+                                    let site = catch_sites
+                                        .iter()
+                                        .find(|site| site.landing_label == catch_label)
+                                        .expect("catch site for DELETE_FAST raise");
+                                    let link = current_block
+                                        .block()
+                                        .borrow()
+                                        .exits
+                                        .last()
+                                        .cloned()
+                                        .expect("DELETE_FAST raise catch edge");
+                                    carry_explicit_raise_value_on_catch_stack(
+                                        &link,
+                                        &site.landing,
+                                        exc_flow,
+                                    );
+                                }
+
+                                // The bound arm is the continuing block. The
+                                // clear is one PY_NULL write, matching
+                                // pyopcode.py:998 DELETE_FAST's single slot
+                                // assignment after the check succeeds.
+                                current_block = bound_block;
+                                current_state = bound_state;
+                                needs_fallthrough = true;
                                 record_graph_op(
                                     &current_block.block(),
                                     "setarrayitem_vable_r",

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -11460,9 +11460,59 @@ impl CodeWriter {
                             }
                         }
 
+                        // DELETE_DEREF clears the cell contents after checking
+                        // that they are bound (pyopcode.py:597 DELETE_DEREF).
+                        Instruction::DeleteDeref { i } => {
+                            let idx = i.get(op_arg).as_usize() as u16;
+                            let code_const: super::flow::FlowValue = super::flow::Constant::new(
+                                super::flow::ConstantValue::Signed(w_code as i64),
+                                Some(Kind::Ref),
+                            )
+                            .into();
+                            let deref_idx_const: super::flow::FlowValue =
+                                super::flow::Constant::signed(idx as i64).into();
+                            emit_load_fast_ref!(current_depth, idx, py_pc);
+                            let _cell_reg = emit_popvalue_ref!(current_depth, py_pc);
+                            let cell_value = pop_ref_or_fresh(&mut current_state, &mut graph);
+                            let _checked = emit_graph_op_with_result(
+                                &mut graph,
+                                &current_block.block(),
+                                "load_deref_value",
+                                vec![
+                                    cell_value.clone().into(),
+                                    code_const.into(),
+                                    deref_idx_const.into(),
+                                ],
+                                Kind::Ref,
+                                py_pc as i64,
+                            );
+                            let result_value = emit_graph_op_with_result(
+                                &mut graph,
+                                &current_block.block(),
+                                "store_deref_value",
+                                vec![cell_value.into(), super::flow::Constant::none().into()],
+                                Kind::Ref,
+                                py_pc as i64,
+                            );
+                            let local_slot = local_to_vable_slot(idx as usize) as i64;
+                            let v_idx: super::flow::FlowValue =
+                                super::flow::Constant::signed(local_slot).into();
+                            record_graph_op(
+                                &current_block.block(),
+                                "setarrayitem_vable_r",
+                                vable_setarrayitem_ref_graph_args(
+                                    frame_var.into(),
+                                    v_idx.into(),
+                                    super::flow::FlowValue::from(result_value).into(),
+                                ),
+                                None,
+                                py_pc as i64,
+                            );
+                            current_state.store_local_value(idx as usize, result_value.into());
+                        }
+
                         // Instructions that don't touch the operand stack (locals/cells only).
-                        Instruction::DeleteDeref { .. }
-                        | Instruction::DeleteGlobal { .. }
+                        Instruction::DeleteGlobal { .. }
                         | Instruction::DeleteName { .. }
                         | Instruction::SetupAnnotations => {
                             emit_abort_permanent!(py_pc);

--- a/pyre/pyre-jit/src/jit/cpu.rs
+++ b/pyre/pyre-jit/src/jit/cpu.rs
@@ -267,6 +267,9 @@ pub struct Cpu {
     /// `bh_load_fast_check_fn(value, code, name_idx)` — LOAD_FAST_CHECK
     /// unbound-local guard (returns `value`, or raises `NameError`).
     pub load_fast_check_fn: extern "C" fn(i64, i64, i64) -> i64,
+    /// `bh_unbound_local_error_fn(code, name_idx)` — construct and return the
+    /// UnboundLocalError value for DELETE_FAST without publishing it.
+    pub unbound_local_error_fn: extern "C" fn(i64, i64) -> i64,
     /// `bhimpl_compare_op` — RPython compare_op opcodes.
     pub compare_fn: extern "C" fn(i64, i64, i64) -> i64,
     /// `bhimpl_binary_op` — RPython binary_op opcodes.
@@ -471,6 +474,7 @@ impl Cpu {
             list_to_tuple_fn: crate::call_jit::bh_list_to_tuple_fn,
             unary_not_fn: crate::call_jit::bh_unary_not_fn,
             load_fast_check_fn: crate::call_jit::bh_load_fast_check_fn,
+            unbound_local_error_fn: crate::call_jit::bh_unbound_local_error_fn,
             compare_fn: crate::call_jit::bh_compare_fn,
             binary_op_fn: crate::call_jit::bh_binary_op_fn,
             box_int_fn: crate::call_jit::bh_box_int_fn,

--- a/pyre/pyre-jit/src/jit/flatten.rs
+++ b/pyre/pyre-jit/src/jit/flatten.rs
@@ -3506,6 +3506,12 @@ pub struct LoweringContext {
     /// or raises the unbound NameError (reads no heap, runs no user code →
     /// `Plain`).
     pub load_fast_check_fn_idx: u16,
+    /// `unbound_local_error_fn` descrs-pool index. DELETE_FAST records the
+    /// `unbound_local_error(code, name_idx)` HLOp only on its unbound arm,
+    /// lowered to `residual_call_ir_r(ConstInt(fn_idx), ListI([name_idx]),
+    /// ListR([code]), Descr) -> reg`. The helper constructs and returns the
+    /// exception value (`PlainCannotRaise`) for the explicit raise edge.
+    pub unbound_local_error_fn_idx: u16,
     /// `list_extend_fn` descrs-pool index.  LIST_EXTEND records the
     /// `list_extend(list, iterable)` HLOp lowered to
     /// `residual_call_r_v(ConstInt(fn_idx), ListR([list, iterable]), Descr)`
@@ -5157,6 +5163,11 @@ where
     if let Some(insn) = lower_load_fast_check_hlop_to_insn(op, ctx, get_register, lower_constant) {
         return Some(insn);
     }
+    if let Some(insn) =
+        lower_unbound_local_error_hlop_to_insn(op, ctx, get_register, lower_constant)
+    {
+        return Some(insn);
+    }
     None
 }
 
@@ -5307,6 +5318,48 @@ where
                 vec![Operand::ConstInt(name_idx)],
             )),
             Operand::ListOfKind(ListOfKind::new(Kind::Ref, vec![value, code])),
+            descr_operand,
+        ],
+        dst_reg,
+    ))
+}
+
+/// Lower DELETE_FAST's `unbound_local_error(code, name_idx)` HLOp to the
+/// construct-and-return residual used by its explicit raise arm.
+pub fn lower_unbound_local_error_hlop_to_insn<F, LC>(
+    op: &super::flow::SpaceOperation,
+    ctx: &LoweringContext,
+    get_register: &mut F,
+    lower_constant: &mut LC,
+) -> Option<Insn>
+where
+    F: FnMut(super::flow::Variable) -> Register,
+    LC: FnMut(&Constant) -> Operand,
+{
+    if op.opname != "unbound_local_error" || op.args.len() != 2 {
+        return None;
+    }
+    let code = operand_for_value_arg(&op.args[0], get_register, lower_constant)?;
+    let name_idx = const_int_for_value_arg(&op.args[1])?;
+    let dst_reg = match &op.result {
+        Some(super::flow::FlowValue::Variable(var)) => get_register(*var),
+        _ => return None,
+    };
+    let effect_info = effect_info_for_call_flavor(CallFlavor::PlainCannotRaise);
+    let descr_operand = Operand::descr(DescrOperand::CallDescrStub(CallDescrStub {
+        effect_info,
+        arg_kinds: vec![Kind::Ref, Kind::Int],
+        result_kind: Some(Kind::Ref),
+    }));
+    Some(Insn::op_with_result(
+        "residual_call_ir_r",
+        vec![
+            Operand::ConstInt(ctx.unbound_local_error_fn_idx as i64),
+            Operand::ListOfKind(ListOfKind::new(
+                Kind::Int,
+                vec![Operand::ConstInt(name_idx)],
+            )),
+            Operand::ListOfKind(ListOfKind::new(Kind::Ref, vec![code])),
             descr_operand,
         ],
         dst_reg,

--- a/pyre/pyre-object/src/interp_exceptions.rs
+++ b/pyre/pyre-object/src/interp_exceptions.rs
@@ -657,6 +657,16 @@ pub unsafe fn w_exception_get_args(obj: PyObjectRef) -> PyObjectRef {
     }
 }
 
+/// Raw `args_w` storage for JIT field mirrors.  Unlike
+/// [`w_exception_get_args`], this does not allocate the public tuple view.
+///
+/// # Safety
+/// `obj` must point to a valid `W_BaseException`.
+#[inline]
+pub unsafe fn w_exception_get_args_storage(obj: PyObjectRef) -> PyObjectRef {
+    unsafe { (*(obj as *const W_BaseException)).args_w }
+}
+
 /// `interp_exceptions.py:123-124 W_BaseException.descr_init` /
 /// `:156-157 descr_setargs` parity —
 ///


### PR DESCRIPTION
Removes a JIT trace abort on the exception hot path, and fixes an exception-reload
defect that kept two exception loops interpreter-only.

## 1. `DELETE_DEREF` no longer `abort_permanent`

When a nested function closes over an `except E as e:` name, the local becomes a
cell and the handler's implicit `del e` compiles to `DELETE_DEREF`. That opcode
reached `abort_permanent`, and `loop_body_has_abort_permanent` is a *static* scan —
one occurrence declines the whole loop.

It is now lowered by composing existing graph ops — no new residual:
`load_deref_value` (raise-if-unbound) + `store_deref_value(cell, NULL)` (clears the
cell contents, keeps the cell in the slot) + `store_local_value`. The live
interpreter impl is `delete_deref`. Added a guard bench
`exception_as_cell_cleanup.py`, which compiles (`loops_compiled=1`,
`bridges_compiled=2`) and matches the `PYRE_NO_JIT=1` oracle.

## 2. Cleanup-landing exception reloaded from the frame's stack slot

A `Copy` handler landing reached by an explicit raise seeded its top-of-stack
exception with a `last_exc_value` read. A residual call between the raise landing
and that read clears the metainterp exception transient (`execute_varargs` clears
before a call that may itself raise), so the read found no value and the walk
aborted with `LastExcValueWithoutActiveException`.

Those landings now reload the propagated exception from the frame's durable top
stack slot via `getarrayitem_vable_r` — catch dispatch has already stored it there.
Reraise-entered landings keep the `last_exc_value` read, which still carries the
live payload from the exception edge. The per-thread current-exception slot is
deliberately **not** the source: at this landing it can still name the older
exception whose handler raised this one, which would mislink `__context__`.

## Results

- `exception_bare_reraise_restore` and `exception_context_chain_inhandler` now
  compile (`loops_compiled` 0 → 1), output byte-identical to the oracle.
- Wins: `swap_except_return_resume` 2.79 → 0.06s, `finally_bare_raise` 0.86 → 0.05s,
  `exception_oserror_fields` 1.12 → 0.51s.

## Withheld from this PR

**`DELETE_FAST` → #586.** The lowering in the earlier revision of this PR
**miscompiled**: it dropped the arm's `ptr_iszero` guard and emitted the slot clear
unconditionally after the can-raise `load_fast_check`, breaking the
`pyopcode.py:998` shape where the raise *prevents* the clear. `del x; del x` in a
hot loop then swallowed exactly one `UnboundLocalError` (oracle 200000, JIT 199999
— loss is exactly 1 at every N, so it is a trace/compile transition artifact).
`origin/main` is correct here because it declines the loop. Caught by the Codex
parity review; full repro and characterisation in #586.

**Exit-frame raise FINISH → #581.** It made
`synth/exception_inlined_callee_caught` compile a bridge for the first time, which
exposed a pre-existing GC hole and crashed wasm. Root cause is not in that commit:
the wasm backend has no `gcreftracer` / `LoadFromGcTable` path and bakes
`OpRef::ConstPtr(GcRef)` into emitted code as a raw address immediate, where the GC
can neither find nor forward it — dynasm and cranelift both run
`remove_constptrs_in` → `GcTable::from_gcrefs` (RPython's `GCREFTRACER`).

## Gates

`check.py` dynasm and cranelift; lib tests `pyre-jit`, `pyre-jit-trace`,
`majit-metainterp`. wasm's one failing fixture,
`synth/residual_raise_except_resume`, **fails identically on `origin/main`**
(0.21s vs pypy 0.01s = 21.4x): #576 added `# pyre-check: max-pypy-ratio=10` to it
and the wasm backend does not meet it, while unannotated fixtures in the same sweep
run at 13–33x and pass ungated. This branch adds no new wasm failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
