### PR TITLE
jit: exact-resume FOR_ITER gate widening and JIT traceback fidelity

### DIFF
--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -11338,12 +11338,9 @@ impl CraneliftBackend {
                         builder.switch_to_block(helper_block);
                         builder.seal_block(helper_block);
                         builder.set_cold_block(helper_block);
-                        // `call_assembler_guard_failure_inner` follows
-                        // RPython handle_fail via faildescr/resumedata and
-                        // does not consume the old vloc/frame_ptr argument.
-                        // Keep the argument slot for ABI parity without
-                        // loading the callee frame on the normal finish path.
-                        let frame_ptr = builder.ins().iconst(cl_types::I64, 0);
+                        // The helper reads the saved exception from the
+                        // returned callee JitFrame before blackhole resume.
+                        let frame_ptr = ptr_arg_as_i64(&mut builder, result_jf, ptr_type);
                         // CALL_ASSEMBLER helper can compile/execute bridges
                         // and allocate. Treat it as a collecting call for
                         // the caller frame, matching the pending-gcmap

--- a/majit/majit-metainterp/src/blackhole.rs
+++ b/majit/majit-metainterp/src/blackhole.rs
@@ -253,6 +253,16 @@ pub struct BlackholeInterpreter {
     /// Set when handle_exception_in_frame finds a handler.
     /// Read by CheckExcMatch and other exception opcodes in the handler.
     pub exception_last_value: i64,
+    /// Callback for the interpreter-level traceback record that occurs before
+    /// an exception-table handler is entered.  The generic blackhole carries
+    /// only raw frame/exception references; portal integrations install the
+    /// callback that understands their frame and JitCode-PC layouts.
+    pub record_caught_exception: Option<extern "C" fn(i64, i64, i32, i32)>,
+    /// Exception most recently delivered to an in-frame handler.  If that same
+    /// object later leaves through the handler cleanup's `reraise`, its frame
+    /// traceback was already recorded on handler entry and must not be added a
+    /// second time at the bottommost blackhole exit.
+    pub last_caught_exception_value: i64,
     /// blackhole.py bhimpl_getfield_vable_*: pointer to the virtualizable
     /// object (e.g. PyFrame). Used by jitcode::BC_GETFIELD_VABLE_* bytecodes.
     /// Set during blackhole setup from the guard failure's virtualizable ptr.
@@ -339,6 +349,8 @@ impl Default for BlackholeInterpreter {
             got_exception: false,
             last_opcode_position: 0,
             exception_last_value: 0,
+            record_caught_exception: None,
+            last_caught_exception_value: 0,
             virtualizable_ptr: 0,
             virtualizable_info: std::ptr::null(),
             jitdrivers_sd: Vec::new(),
@@ -356,6 +368,7 @@ impl BlackholeInterpreter {
         self.got_exception = false;
         self.last_opcode_position = position;
         self.exception_last_value = 0;
+        self.last_caught_exception_value = 0;
     }
 
     fn init_register_file_from_i64s(
@@ -489,6 +502,7 @@ impl BlackholeInterpreter {
         self.virtualizable_info = parent.virtualizable_info;
         self.jitdrivers_sd = parent.jitdrivers_sd.clone();
         self.virtualizable_stack_base = parent.virtualizable_stack_base;
+        self.record_caught_exception = parent.record_caught_exception;
     }
 
     /// blackhole.py:312 setposition
@@ -1152,7 +1166,16 @@ impl BlackholeInterpreter {
             return false;
         }
         let target = (code[catch_pos + 1] as usize) | ((code[catch_pos + 2] as usize) << 8);
+        if let Some(record) = self.record_caught_exception {
+            record(
+                exc_value,
+                self.virtualizable_ptr,
+                self.jitcode.try_index().map_or(-1, |index| index as i32),
+                self.last_opcode_position as i32,
+            );
+        }
         self.exception_last_value = exc_value;
+        self.last_caught_exception_value = exc_value;
         self.position = target;
         BH_LAST_EXC_VALUE.with(|c| c.set(0));
         // A residual `bh_call` that raised published the exception into BOTH

--- a/pyre/check.py
+++ b/pyre/check.py
@@ -20,8 +20,14 @@ if hasattr(sys.stderr, "reconfigure"):
     sys.stderr.reconfigure(encoding="utf-8", errors="replace")
 
 EXE = ".exe" if sys.platform == "win32" else ""
-PYTHON3 = os.environ.get("PYRE_CHECK_PYTHON3") or (
-    "python3" if shutil.which("python3") else "python"
+# pyre's compat target is CPython 3.14; its native modules (`_sre.MAGIC`) and the
+# vendored `lib-python/3` are coupled to that version. Prefer a version-matched
+# oracle so a stale `python3` on PATH (an older system CPython) does not diverge
+# from pypy on version-sensitive error text and trip a spurious cpython-vs-pypy
+# baseline mismatch.
+PYTHON3 = os.environ.get("PYRE_CHECK_PYTHON3") or next(
+    (cand for cand in ("python3.14", "python3", "python") if shutil.which(cand)),
+    "python3",
 )
 PYPY3 = os.environ.get("PYRE_CHECK_PYPY3") or (
     "pypy3" if shutil.which("pypy3") else "pypy"

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -5661,14 +5661,37 @@ pub(crate) fn builtin_list_ctor(args: &[PyObjectRef]) -> Result<PyObjectRef, cra
 
 pub fn collect_iterable(obj: PyObjectRef) -> Result<Vec<PyObjectRef>, crate::PyError> {
     let it = crate::baseobjspace::iter(obj)?;
-    let mut items = Vec::new();
+    // Each `next` runs arbitrary allocating code (a generator body, a JIT
+    // callee that boxes a fresh int) which can trigger a moving minor
+    // collection. A raw `Vec<PyObjectRef>` on the malloc heap is invisible to
+    // the collector, so already-collected nursery elements would be stranded /
+    // not forwarded. Pin the iterator and each yielded element onto the shadow
+    // stack (a real GC root the collector walks and updates on relocation),
+    // then read the forwarded slots back out — the manual equivalent of the
+    // translator's shadowstack save/restore around a collecting call
+    // (framework.py:853-856).
+    let _roots = pyre_object::gc_roots::push_roots();
+    let base = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(it);
+    let mut count = 0usize;
     loop {
-        match crate::baseobjspace::next(it) {
-            Ok(v) => items.push(v),
+        // The iterator may itself have moved during a prior `next`; reload it
+        // from its (post-relocation) shadow-stack slot before each call.
+        let it_now = pyre_object::gc_roots::shadow_stack_get(base);
+        match crate::baseobjspace::next(it_now) {
+            Ok(v) => {
+                pyre_object::gc_roots::pin_root(v);
+                count += 1;
+            }
             Err(e) if e.kind == crate::PyErrorKind::StopIteration => break,
             Err(e) => return Err(e),
         }
     }
+    // Read the forwarded element slots back out. The elements sit at
+    // `base + 1 ..= base + count` (the iterator occupies `base`).
+    let items = (0..count)
+        .map(|i| pyre_object::gc_roots::shadow_stack_get(base + 1 + i))
+        .collect();
     Ok(items)
 }
 

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -5745,6 +5745,7 @@ pub(crate) fn builtin_dict_ctor(args: &[PyObjectRef]) -> Result<PyObjectRef, cra
         let keys = collect_iterable(keys_obj)?;
         for key in keys {
             let val = crate::baseobjspace::getitem(src, key)?;
+            try_hash_value(key)?;
             unsafe { w_dict_store(dict, key, val) };
         }
         return Ok(dict);
@@ -5762,6 +5763,7 @@ pub(crate) fn builtin_dict_ctor(args: &[PyObjectRef]) -> Result<PyObjectRef, cra
                 elems.len()
             )));
         }
+        try_hash_value(elems[0])?;
         unsafe { w_dict_store(dict, elems[0], elems[1]) };
     }
     Ok(dict)

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -5705,11 +5705,28 @@ pub fn collect_iterable(obj: PyObjectRef) -> Result<Vec<PyObjectRef>, crate::PyE
 /// dedup, and the hash itself is not used for storage.
 pub fn builtin_set_from_items(items: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     let set = pyre_object::w_set_new();
-    for &item in items {
-        try_hash_value(item)?;
-        unsafe { pyre_object::w_set_add(set, item) };
+    unsafe {
+        // `try_hash_value` may run a user `__hash__` that allocates and
+        // triggers a moving minor collection; `set` and every not-yet-added
+        // item are rooted for the whole loop and reloaded after each hash,
+        // matching `set_update_value`.
+        let _roots = pyre_object::gc_roots::push_roots();
+        let sp = pyre_object::gc_roots::shadow_stack_len();
+        pyre_object::gc_roots::pin_root(set);
+        let item_base = sp + 1;
+        for &item in items {
+            pyre_object::gc_roots::pin_root(item);
+        }
+        let item_len = pyre_object::gc_roots::shadow_stack_len() - item_base;
+        for i in 0..item_len {
+            let item = pyre_object::gc_roots::shadow_stack_get(item_base + i);
+            try_hash_value(item)?;
+            let set = pyre_object::gc_roots::shadow_stack_get(sp);
+            let item = pyre_object::gc_roots::shadow_stack_get(item_base + i);
+            pyre_object::w_set_add(set, item);
+        }
+        Ok(pyre_object::gc_roots::shadow_stack_get(sp))
     }
-    Ok(set)
 }
 
 /// `dict()` — PyPy: dictmultiobject.py W_DictMultiObject.descr_init
@@ -5743,11 +5760,37 @@ pub(crate) fn builtin_dict_ctor(args: &[PyObjectRef]) -> Result<PyObjectRef, cra
         let dict = w_dict_new();
         let keys_obj = crate::call_function(keys_method, &[]);
         let keys = collect_iterable(keys_obj)?;
-        for key in keys {
-            let val = crate::baseobjspace::getitem(src, key)?;
-            try_hash_value(key)?;
-            unsafe { w_dict_store(dict, key, val) };
-        }
+        // `getitem` (arbitrary `__getitem__`) and `try_hash_value`
+        // (arbitrary `__hash__`) may both allocate and move `dict`, `src`,
+        // and any collected key, so all of them are rooted for the loop's
+        // duration and reloaded before each use — mirrors
+        // `opcode_ops::dict_update_value`.
+        let dict = unsafe {
+            let _roots = pyre_object::gc_roots::push_roots();
+            let sp = pyre_object::gc_roots::shadow_stack_len();
+            pyre_object::gc_roots::pin_root(dict);
+            pyre_object::gc_roots::pin_root(src);
+            let key_base = sp + 2;
+            for key in keys {
+                pyre_object::gc_roots::pin_root(key);
+            }
+            let key_len = pyre_object::gc_roots::shadow_stack_len() - key_base;
+            for i in 0..key_len {
+                let src = pyre_object::gc_roots::shadow_stack_get(sp + 1);
+                let key = pyre_object::gc_roots::shadow_stack_get(key_base + i);
+                let val = crate::baseobjspace::getitem(src, key)?;
+                let _val_root = pyre_object::gc_roots::push_roots();
+                let val_slot = pyre_object::gc_roots::shadow_stack_len();
+                pyre_object::gc_roots::pin_root(val);
+                let key = pyre_object::gc_roots::shadow_stack_get(key_base + i);
+                try_hash_value(key)?;
+                let dict = pyre_object::gc_roots::shadow_stack_get(sp);
+                let key = pyre_object::gc_roots::shadow_stack_get(key_base + i);
+                let val = pyre_object::gc_roots::shadow_stack_get(val_slot);
+                w_dict_store(dict, key, val);
+            }
+            pyre_object::gc_roots::shadow_stack_get(sp)
+        };
         return Ok(dict);
     }
     // Construct from iterable of (key, value) pairs — dictmultiobject.py
@@ -5755,17 +5798,39 @@ pub(crate) fn builtin_dict_ctor(args: &[PyObjectRef]) -> Result<PyObjectRef, cra
     // iterable), not just tuple/list.
     let dict = w_dict_new();
     let items = collect_iterable(src)?;
-    for (i, pair) in items.into_iter().enumerate() {
-        let elems = collect_iterable(pair)?;
-        if elems.len() != 2 {
-            return Err(crate::PyError::value_error(format!(
-                "dictionary update sequence element #{i} has length {}; 2 is required",
-                elems.len()
-            )));
+    // `dict` and every collected pair-source need the same treatment: each
+    // pair's own `collect_iterable` and `try_hash_value` are collection
+    // points that can move `dict` and any not-yet-processed pair.
+    let dict = unsafe {
+        let _roots = pyre_object::gc_roots::push_roots();
+        let sp = pyre_object::gc_roots::shadow_stack_len();
+        pyre_object::gc_roots::pin_root(dict);
+        let item_base = sp + 1;
+        for item in &items {
+            pyre_object::gc_roots::pin_root(*item);
         }
-        try_hash_value(elems[0])?;
-        unsafe { w_dict_store(dict, elems[0], elems[1]) };
-    }
+        let item_len = items.len();
+        for i in 0..item_len {
+            let pair = pyre_object::gc_roots::shadow_stack_get(item_base + i);
+            let elems = collect_iterable(pair)?;
+            if elems.len() != 2 {
+                return Err(crate::PyError::value_error(format!(
+                    "dictionary update sequence element #{i} has length {}; 2 is required",
+                    elems.len()
+                )));
+            }
+            let _pair_roots = pyre_object::gc_roots::push_roots();
+            let pair_slot = pyre_object::gc_roots::shadow_stack_len();
+            pyre_object::gc_roots::pin_root(elems[0]);
+            pyre_object::gc_roots::pin_root(elems[1]);
+            try_hash_value(elems[0])?;
+            let dict = pyre_object::gc_roots::shadow_stack_get(sp);
+            let key = pyre_object::gc_roots::shadow_stack_get(pair_slot);
+            let val = pyre_object::gc_roots::shadow_stack_get(pair_slot + 1);
+            w_dict_store(dict, key, val);
+        }
+        pyre_object::gc_roots::shadow_stack_get(sp)
+    };
     Ok(dict)
 }
 

--- a/pyre/pyre-interpreter/src/call.rs
+++ b/pyre/pyre-interpreter/src/call.rs
@@ -3219,6 +3219,18 @@ fn build_class_inner(
     // the `debugdata.w_locals` walk in `walk_pyframe_roots`.
     frame.run_with_jit()?;
 
+    // A minor collection during the body (a hot class-level loop compiles
+    // and runs through the JIT portal) can promote the namespace young ->
+    // old, relocating it.  The frame's `debugdata.w_locals` slot and the
+    // shadow-stack pin are forwarded, keeping the object alive at its new
+    // address, but this stack-local `body_ns` copy is not — it is left
+    // pointing at the freed nursery slot.  Re-read the forwarded object
+    // from the frame before any downstream use; a stale read would
+    // dereference reclaimed memory (`resolve_dict_backing` / `w_dict_items`
+    // below, then `__set_name__`).
+    let body_ns = frame.get_w_locals();
+    let mapping_namespace = mapping_namespace.map(|_| body_ns);
+
     // The body wrote through `body_ns`; mirror its final contents into
     // class_ns for the downstream type construction (classcell capture,
     // create_all_slots, __set_name__), which read class_ns.

--- a/pyre/pyre-interpreter/src/opcode_ops.rs
+++ b/pyre/pyre-interpreter/src/opcode_ops.rs
@@ -307,6 +307,7 @@ pub fn list_extend_value(list: PyObjectRef, iterable: PyObjectRef) -> Result<(),
 pub fn set_add_value(set: PyObjectRef, value: PyObjectRef) -> Result<(), PyError> {
     unsafe {
         if pyre_object::is_set_or_frozenset(set) {
+            crate::builtins::try_hash_value(value)?;
             pyre_object::w_set_add(set, value);
         } else if pyre_object::is_list(set) {
             pyre_object::w_list_append(set, value);
@@ -318,12 +319,13 @@ pub fn set_add_value(set: PyObjectRef, value: PyObjectRef) -> Result<(), PyError
 /// SET_UPDATE — `set.update(iterable)` (or `list.extend` for the
 /// list-shaped accumulator).  Shared by the interpreter's `set_update`
 /// and the JIT residual `bh_set_update_fn`.  `set` is peeked, mutated in
-/// place; a user iterator may run Python.
+/// place; a user iterator or element `__hash__` may run Python.
 pub fn set_update_value(set: PyObjectRef, iterable: PyObjectRef) -> Result<(), PyError> {
     unsafe {
         if pyre_object::is_set_or_frozenset(set) {
             let items = crate::builtins::collect_iterable(iterable)?;
             for item in items {
+                crate::builtins::try_hash_value(item)?;
                 pyre_object::w_set_add(set, item);
             }
         } else if pyre_object::is_list(set) {
@@ -344,12 +346,14 @@ pub fn set_update_value(set: PyObjectRef, iterable: PyObjectRef) -> Result<(), P
 
 /// MAP_ADD — `dict[key] = value`.  Shared by the interpreter's `map_add`
 /// and the JIT residual `bh_map_add_fn`.  `dict` is peeked, mutated in
-/// place; runs no user code (raw dict store).
+/// place; the key is hashed before the raw dict store, so a user `__hash__`
+/// may run Python.
 pub fn map_add_value(
     dict: PyObjectRef,
     key: PyObjectRef,
     value: PyObjectRef,
 ) -> Result<(), PyError> {
+    crate::builtins::try_hash_value(key)?;
     unsafe {
         pyre_object::w_dict_store(dict, key, value);
     }
@@ -714,7 +718,27 @@ pub extern "C" fn bh_lookup_exc_class_for_kind(kind_disc: i64) -> i64 {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use pyre_object::{w_bool_get_value, w_int_get_value, w_int_new};
+    use crate::test_hooks::install_hash_hook;
+    use pyre_object::{w_bool_get_value, w_dict_len, w_int_get_value, w_int_new, w_set_len};
+
+    #[test]
+    fn test_accumulator_helpers_reject_unhashable_values_without_inserting() {
+        install_hash_hook();
+
+        let key = pyre_object::w_list_new(vec![]);
+        let dict = pyre_object::w_dict_new();
+        let map_err = map_add_value(dict, key, w_int_new(1))
+            .expect_err("MAP_ADD should reject an unhashable key");
+        assert_eq!(map_err.kind, crate::PyErrorKind::TypeError);
+        assert_eq!(unsafe { w_dict_len(dict) }, 0);
+
+        let value = pyre_object::w_list_new(vec![]);
+        let set = pyre_object::w_set_new();
+        let set_err =
+            set_add_value(set, value).expect_err("SET_ADD should reject an unhashable element");
+        assert_eq!(set_err.kind, crate::PyErrorKind::TypeError);
+        assert_eq!(unsafe { w_set_len(set) }, 0);
+    }
 
     #[test]
     fn test_binary_value_reuses_objspace_dispatch() {

--- a/pyre/pyre-interpreter/src/opcode_ops.rs
+++ b/pyre/pyre-interpreter/src/opcode_ops.rs
@@ -307,7 +307,17 @@ pub fn list_extend_value(list: PyObjectRef, iterable: PyObjectRef) -> Result<(),
 pub fn set_add_value(set: PyObjectRef, value: PyObjectRef) -> Result<(), PyError> {
     unsafe {
         if pyre_object::is_set_or_frozenset(set) {
+            // `try_hash_value` may run a user `__hash__` that allocates and
+            // triggers a moving minor collection; `set`/`value` must be
+            // shadow-stack roots across it, then reloaded, or the store
+            // below can write through a relocated (stale) pointer.
+            let _roots = pyre_object::gc_roots::push_roots();
+            let sp = pyre_object::gc_roots::shadow_stack_len();
+            pyre_object::gc_roots::pin_root(set);
+            pyre_object::gc_roots::pin_root(value);
             crate::builtins::try_hash_value(value)?;
+            let set = pyre_object::gc_roots::shadow_stack_get(sp);
+            let value = pyre_object::gc_roots::shadow_stack_get(sp + 1);
             pyre_object::w_set_add(set, value);
         } else if pyre_object::is_list(set) {
             pyre_object::w_list_append(set, value);
@@ -323,9 +333,25 @@ pub fn set_add_value(set: PyObjectRef, value: PyObjectRef) -> Result<(), PyError
 pub fn set_update_value(set: PyObjectRef, iterable: PyObjectRef) -> Result<(), PyError> {
     unsafe {
         if pyre_object::is_set_or_frozenset(set) {
+            // `collect_iterable` pops its own shadow-stack roots before
+            // returning, so `items` is a bare, unrooted `Vec` — each
+            // element (and `set`) needs re-pinning for the duration of
+            // this loop, since any iteration's `try_hash_value` can move
+            // both `set` and every not-yet-processed item.
             let items = crate::builtins::collect_iterable(iterable)?;
+            let _roots = pyre_object::gc_roots::push_roots();
+            let sp = pyre_object::gc_roots::shadow_stack_len();
+            pyre_object::gc_roots::pin_root(set);
+            let item_base = sp + 1;
             for item in items {
+                pyre_object::gc_roots::pin_root(item);
+            }
+            let item_len = pyre_object::gc_roots::shadow_stack_len() - item_base;
+            for i in 0..item_len {
+                let item = pyre_object::gc_roots::shadow_stack_get(item_base + i);
                 crate::builtins::try_hash_value(item)?;
+                let set = pyre_object::gc_roots::shadow_stack_get(sp);
+                let item = pyre_object::gc_roots::shadow_stack_get(item_base + i);
                 pyre_object::w_set_add(set, item);
             }
         } else if pyre_object::is_list(set) {
@@ -353,8 +379,19 @@ pub fn map_add_value(
     key: PyObjectRef,
     value: PyObjectRef,
 ) -> Result<(), PyError> {
-    crate::builtins::try_hash_value(key)?;
     unsafe {
+        // Root across `try_hash_value` (a possible collection point from a
+        // user `__hash__`) and reload before the store, mirroring
+        // `set_add_value`.
+        let _roots = pyre_object::gc_roots::push_roots();
+        let sp = pyre_object::gc_roots::shadow_stack_len();
+        pyre_object::gc_roots::pin_root(dict);
+        pyre_object::gc_roots::pin_root(key);
+        pyre_object::gc_roots::pin_root(value);
+        crate::builtins::try_hash_value(key)?;
+        let dict = pyre_object::gc_roots::shadow_stack_get(sp);
+        let key = pyre_object::gc_roots::shadow_stack_get(sp + 1);
+        let value = pyre_object::gc_roots::shadow_stack_get(sp + 2);
         pyre_object::w_dict_store(dict, key, value);
     }
     Ok(())
@@ -385,9 +422,38 @@ pub fn dict_update_value(dict: PyObjectRef, source: PyObjectRef) -> Result<(), P
     };
     let keys_obj = crate::call::call_function_impl_result(keys_method, &[])?;
     let keys = crate::builtins::collect_iterable(keys_obj)?;
-    for key in keys {
-        let val = crate::baseobjspace::getitem(source, key)?;
-        unsafe { pyre_object::w_dict_store(dict, key, val) };
+    unsafe {
+        // A generic mapping's keys are not pre-validated the way a real
+        // dict's are (the `is_dict(source)` fast path above skips the hash
+        // check for exactly that reason) — `d[key] = mapping[key]` still
+        // hashes `key`, so an unhashable one must raise here too.  `dict`,
+        // `source`, and every collected key are rooted for the loop's
+        // duration: `getitem` (arbitrary `__getitem__`) and
+        // `try_hash_value` (arbitrary `__hash__`) both may allocate and
+        // move them.
+        let _roots = pyre_object::gc_roots::push_roots();
+        let sp = pyre_object::gc_roots::shadow_stack_len();
+        pyre_object::gc_roots::pin_root(dict);
+        pyre_object::gc_roots::pin_root(source);
+        let key_base = sp + 2;
+        for key in keys {
+            pyre_object::gc_roots::pin_root(key);
+        }
+        let key_len = pyre_object::gc_roots::shadow_stack_len() - key_base;
+        for i in 0..key_len {
+            let source = pyre_object::gc_roots::shadow_stack_get(sp + 1);
+            let key = pyre_object::gc_roots::shadow_stack_get(key_base + i);
+            let val = crate::baseobjspace::getitem(source, key)?;
+            let _val_root = pyre_object::gc_roots::push_roots();
+            let val_slot = pyre_object::gc_roots::shadow_stack_len();
+            pyre_object::gc_roots::pin_root(val);
+            let key = pyre_object::gc_roots::shadow_stack_get(key_base + i);
+            crate::builtins::try_hash_value(key)?;
+            let dict = pyre_object::gc_roots::shadow_stack_get(sp);
+            let key = pyre_object::gc_roots::shadow_stack_get(key_base + i);
+            let val = pyre_object::gc_roots::shadow_stack_get(val_slot);
+            pyre_object::w_dict_store(dict, key, val);
+        }
     }
     Ok(())
 }
@@ -738,6 +804,32 @@ mod tests {
             set_add_value(set, value).expect_err("SET_ADD should reject an unhashable element");
         assert_eq!(set_err.kind, crate::PyErrorKind::TypeError);
         assert_eq!(unsafe { w_set_len(set) }, 0);
+    }
+
+    /// SET_UPDATE (`set.update(iterable)`) rejects an unhashable element
+    /// mid-iterable without inserting the elements that precede it, and
+    /// the rooting added around the per-item `try_hash_value` call does
+    /// not disturb the accept path. Exercises `set_update_value`'s SET
+    /// branch loop added by `416dc05`.
+    #[test]
+    fn test_set_update_value_rejects_unhashable_element_without_inserting() {
+        install_hash_hook();
+
+        let set = pyre_object::w_set_new();
+        let unhashable = pyre_object::w_list_new(vec![]);
+        let iterable = pyre_object::w_list_new(vec![w_int_new(1), w_int_new(2), unhashable]);
+        let err = set_update_value(set, iterable)
+            .expect_err("SET_UPDATE should reject an unhashable element");
+        assert_eq!(err.kind, crate::PyErrorKind::TypeError);
+        // Reject-before-mutate is per-element (matches CPython's left-to-right
+        // partial-update behavior for `set.update`), so the hashable elements
+        // preceding the unhashable one are still inserted.
+        assert_eq!(unsafe { w_set_len(set) }, 2);
+
+        let set = pyre_object::w_set_new();
+        let iterable = pyre_object::w_list_new(vec![w_int_new(1), w_int_new(2), w_int_new(3)]);
+        set_update_value(set, iterable).expect("SET_UPDATE should accept hashable elements");
+        assert_eq!(unsafe { w_set_len(set) }, 3);
     }
 
     #[test]

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -2054,13 +2054,32 @@ fn frozenset_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyErr
     }
 
     let obj = set_alloc_for_class(cls, frozenset_type, true)?;
-    if !iterable.is_null() {
+    let obj = if !iterable.is_null() {
         let items = crate::builtins::collect_iterable(iterable)?;
-        for item in items {
-            crate::builtins::try_hash_value(item)?;
-            unsafe { pyre_object::w_set_add(obj, item) };
+        // `try_hash_value` may run a user `__hash__` that allocates and
+        // triggers a moving minor collection; `obj` and every not-yet-added
+        // item are rooted for the whole loop and reloaded after each hash.
+        unsafe {
+            let _roots = pyre_object::gc_roots::push_roots();
+            let sp = pyre_object::gc_roots::shadow_stack_len();
+            pyre_object::gc_roots::pin_root(obj);
+            let item_base = sp + 1;
+            for item in items {
+                pyre_object::gc_roots::pin_root(item);
+            }
+            let item_len = pyre_object::gc_roots::shadow_stack_len() - item_base;
+            for i in 0..item_len {
+                let item = pyre_object::gc_roots::shadow_stack_get(item_base + i);
+                crate::builtins::try_hash_value(item)?;
+                let obj = pyre_object::gc_roots::shadow_stack_get(sp);
+                let item = pyre_object::gc_roots::shadow_stack_get(item_base + i);
+                pyre_object::w_set_add(obj, item);
+            }
+            pyre_object::gc_roots::shadow_stack_get(sp)
         }
-    }
+    } else {
+        obj
+    };
     Ok(obj)
 }
 
@@ -2128,9 +2147,26 @@ fn set_descr_init(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     // is not None (the parsed default).
     if !w_iterable.is_null() && !unsafe { pyre_object::is_none(w_iterable) } {
         let items = crate::builtins::collect_iterable(w_iterable)?;
-        for item in items {
-            crate::builtins::try_hash_value(item)?;
-            unsafe { pyre_object::w_set_add(set_obj, item) };
+        // `try_hash_value` may run a user `__hash__` that allocates and
+        // triggers a moving minor collection; `set_obj` and every
+        // not-yet-added item are rooted for the whole loop and reloaded
+        // after each hash.
+        unsafe {
+            let _roots = pyre_object::gc_roots::push_roots();
+            let sp = pyre_object::gc_roots::shadow_stack_len();
+            pyre_object::gc_roots::pin_root(set_obj);
+            let item_base = sp + 1;
+            for item in items {
+                pyre_object::gc_roots::pin_root(item);
+            }
+            let item_len = pyre_object::gc_roots::shadow_stack_len() - item_base;
+            for i in 0..item_len {
+                let item = pyre_object::gc_roots::shadow_stack_get(item_base + i);
+                crate::builtins::try_hash_value(item)?;
+                let set_obj = pyre_object::gc_roots::shadow_stack_get(sp);
+                let item = pyre_object::gc_roots::shadow_stack_get(item_base + i);
+                pyre_object::w_set_add(set_obj, item);
+            }
         }
     }
     Ok(pyre_object::w_none())
@@ -3492,10 +3528,31 @@ fn init_dict_type(ns: &mut DictStorage) {
             let w_dict_type = crate::typedef::gettypeobject(&pyre_object::pyobject::DICT_TYPE);
             if cls.is_null() || crate::baseobjspace::is_w(cls, w_dict_type) {
                 let d = pyre_object::w_dict_new();
-                for key in items {
-                    crate::builtins::try_hash_value(key)?;
-                    unsafe { pyre_object::w_dict_store(d, key, value) };
-                }
+                // `try_hash_value` may run a user `__hash__` that allocates
+                // and triggers a moving minor collection; `d`, the shared
+                // `value` (reused across every key), and every not-yet-added
+                // key are rooted for the whole loop and reloaded after each
+                // hash.
+                let d = unsafe {
+                    let _roots = pyre_object::gc_roots::push_roots();
+                    let sp = pyre_object::gc_roots::shadow_stack_len();
+                    pyre_object::gc_roots::pin_root(d);
+                    pyre_object::gc_roots::pin_root(value);
+                    let key_base = sp + 2;
+                    for key in items {
+                        pyre_object::gc_roots::pin_root(key);
+                    }
+                    let key_len = pyre_object::gc_roots::shadow_stack_len() - key_base;
+                    for i in 0..key_len {
+                        let key = pyre_object::gc_roots::shadow_stack_get(key_base + i);
+                        crate::builtins::try_hash_value(key)?;
+                        let d = pyre_object::gc_roots::shadow_stack_get(sp);
+                        let key = pyre_object::gc_roots::shadow_stack_get(key_base + i);
+                        let value = pyre_object::gc_roots::shadow_stack_get(sp + 1);
+                        pyre_object::w_dict_store(d, key, value);
+                    }
+                    pyre_object::gc_roots::shadow_stack_get(sp)
+                };
                 Ok(d)
             } else {
                 let d = crate::call::call_function_impl_result(cls, &[])?;
@@ -13895,8 +13952,19 @@ fn init_set_type(ns: &mut DictStorage) {
             "add",
             |args| {
                 if args.len() >= 2 {
-                    crate::builtins::try_hash_value(args[1])?;
-                    unsafe { pyre_object::w_set_add(args[0], args[1]) };
+                    // `try_hash_value` may run a user `__hash__` that
+                    // allocates and triggers a moving minor collection;
+                    // root `self` and the element across it, then reload.
+                    unsafe {
+                        let _roots = pyre_object::gc_roots::push_roots();
+                        let sp = pyre_object::gc_roots::shadow_stack_len();
+                        pyre_object::gc_roots::pin_root(args[0]);
+                        pyre_object::gc_roots::pin_root(args[1]);
+                        crate::builtins::try_hash_value(args[1])?;
+                        let set = pyre_object::gc_roots::shadow_stack_get(sp);
+                        let item = pyre_object::gc_roots::shadow_stack_get(sp + 1);
+                        pyre_object::w_set_add(set, item);
+                    }
                 }
                 Ok(pyre_object::w_none())
             },
@@ -13984,11 +14052,31 @@ fn init_set_type(ns: &mut DictStorage) {
             if args.is_empty() {
                 return Ok(pyre_object::w_none());
             }
-            for other in &args[1..] {
-                let other_items = crate::builtins::collect_iterable(*other)?;
-                for item in other_items {
-                    crate::builtins::try_hash_value(item)?;
-                    unsafe { pyre_object::w_set_add(args[0], item) };
+            // `self` (`args[0]`) is rooted once for the whole method body:
+            // both `collect_iterable` (an arbitrary iterator) and
+            // `try_hash_value` (an arbitrary `__hash__`) are collection
+            // points that can move it, and every element of the current
+            // `other`'s collected items is rooted for its own loop for the
+            // same reason.
+            unsafe {
+                let _roots = pyre_object::gc_roots::push_roots();
+                let set_slot = pyre_object::gc_roots::shadow_stack_len();
+                pyre_object::gc_roots::pin_root(args[0]);
+                for other in &args[1..] {
+                    let other_items = crate::builtins::collect_iterable(*other)?;
+                    let _item_roots = pyre_object::gc_roots::push_roots();
+                    let item_base = pyre_object::gc_roots::shadow_stack_len();
+                    for item in other_items {
+                        pyre_object::gc_roots::pin_root(item);
+                    }
+                    let item_len = pyre_object::gc_roots::shadow_stack_len() - item_base;
+                    for i in 0..item_len {
+                        let item = pyre_object::gc_roots::shadow_stack_get(item_base + i);
+                        crate::builtins::try_hash_value(item)?;
+                        let set = pyre_object::gc_roots::shadow_stack_get(set_slot);
+                        let item = pyre_object::gc_roots::shadow_stack_get(item_base + i);
+                        pyre_object::w_set_add(set, item);
+                    }
                 }
             }
             Ok(pyre_object::w_none())
@@ -14054,21 +14142,41 @@ fn init_set_type(ns: &mut DictStorage) {
                 return Ok(pyre_object::w_none());
             }
             let other_items = crate::builtins::collect_iterable(args[1])?;
-            for item in other_items {
-                // toggle: remove if present, add otherwise
-                let self_items = unsafe { pyre_object::w_set_items(args[0]) };
-                let mut present = false;
-                for &existing in self_items.iter() {
-                    if crate::baseobjspace::eq_w(item, existing)? {
-                        present = true;
-                        break;
-                    }
+            // `self` (`args[0]`) is rooted once for the whole loop, and
+            // every collected `other` item is rooted for the loop's
+            // duration; `try_hash_value` (an arbitrary `__hash__`, on the
+            // add arm) is a collection point that can move either.
+            unsafe {
+                let _roots = pyre_object::gc_roots::push_roots();
+                let set_slot = pyre_object::gc_roots::shadow_stack_len();
+                pyre_object::gc_roots::pin_root(args[0]);
+                let item_base = set_slot + 1;
+                for item in other_items {
+                    pyre_object::gc_roots::pin_root(item);
                 }
-                if present {
-                    unsafe { pyre_object::w_set_discard(args[0], item) };
-                } else {
-                    crate::builtins::try_hash_value(item)?;
-                    unsafe { pyre_object::w_set_add(args[0], item) };
+                let item_len = pyre_object::gc_roots::shadow_stack_len() - item_base;
+                for i in 0..item_len {
+                    // toggle: remove if present, add otherwise
+                    let set = pyre_object::gc_roots::shadow_stack_get(set_slot);
+                    let item = pyre_object::gc_roots::shadow_stack_get(item_base + i);
+                    let self_items = pyre_object::w_set_items(set);
+                    let mut present = false;
+                    for &existing in self_items.iter() {
+                        if crate::baseobjspace::eq_w(item, existing)? {
+                            present = true;
+                            break;
+                        }
+                    }
+                    let set = pyre_object::gc_roots::shadow_stack_get(set_slot);
+                    let item = pyre_object::gc_roots::shadow_stack_get(item_base + i);
+                    if present {
+                        pyre_object::w_set_discard(set, item);
+                    } else {
+                        crate::builtins::try_hash_value(item)?;
+                        let set = pyre_object::gc_roots::shadow_stack_get(set_slot);
+                        let item = pyre_object::gc_roots::shadow_stack_get(item_base + i);
+                        pyre_object::w_set_add(set, item);
+                    }
                 }
             }
             Ok(pyre_object::w_none())

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -2057,6 +2057,7 @@ fn frozenset_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyErr
     if !iterable.is_null() {
         let items = crate::builtins::collect_iterable(iterable)?;
         for item in items {
+            crate::builtins::try_hash_value(item)?;
             unsafe { pyre_object::w_set_add(obj, item) };
         }
     }
@@ -2128,6 +2129,7 @@ fn set_descr_init(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     if !w_iterable.is_null() && !unsafe { pyre_object::is_none(w_iterable) } {
         let items = crate::builtins::collect_iterable(w_iterable)?;
         for item in items {
+            crate::builtins::try_hash_value(item)?;
             unsafe { pyre_object::w_set_add(set_obj, item) };
         }
     }
@@ -3491,6 +3493,7 @@ fn init_dict_type(ns: &mut DictStorage) {
             if cls.is_null() || crate::baseobjspace::is_w(cls, w_dict_type) {
                 let d = pyre_object::w_dict_new();
                 for key in items {
+                    crate::builtins::try_hash_value(key)?;
                     unsafe { pyre_object::w_dict_store(d, key, value) };
                 }
                 Ok(d)
@@ -13892,6 +13895,7 @@ fn init_set_type(ns: &mut DictStorage) {
             "add",
             |args| {
                 if args.len() >= 2 {
+                    crate::builtins::try_hash_value(args[1])?;
                     unsafe { pyre_object::w_set_add(args[0], args[1]) };
                 }
                 Ok(pyre_object::w_none())
@@ -13983,6 +13987,7 @@ fn init_set_type(ns: &mut DictStorage) {
             for other in &args[1..] {
                 let other_items = crate::builtins::collect_iterable(*other)?;
                 for item in other_items {
+                    crate::builtins::try_hash_value(item)?;
                     unsafe { pyre_object::w_set_add(args[0], item) };
                 }
             }
@@ -14062,6 +14067,7 @@ fn init_set_type(ns: &mut DictStorage) {
                 if present {
                     unsafe { pyre_object::w_set_discard(args[0], item) };
                 } else {
+                    crate::builtins::try_hash_value(item)?;
                     unsafe { pyre_object::w_set_add(args[0], item) };
                 }
             }

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -13998,6 +13998,32 @@ fn try_walker_call_assembler_self_recursive(
     // get_list_of_active_boxes).
     write_residual_call_result_to_dst(ctx, op.pc, dst, dst_bank, ca_result)?;
 
+    // The CALL_ASSEMBLER fold records both post-call guards before the walk
+    // reaches the next Python-opcode boundary, so advance the caller's stack
+    // mirror here.  Keep any operands below the call, discard the callable,
+    // NULL marker, and arguments, then put the assembler result on the new
+    // TOS.  The register writeback above already carries the same result, but
+    // guard snapshotting sources operand-stack slots from this mirror.
+    if ctx.vstack_valid {
+        let caller_jitcode = unsafe { &*sym.jitcode };
+        let caller_code = unsafe { &*caller_jitcode.payload.code_ptr };
+        let call_py_pc = python_pc_for_jitcode_pc(&caller_jitcode.payload.metadata, op.pc) as usize;
+        let resume_py_pc = crate::pyjitpl::semantic_fallthrough_pc(caller_code, call_py_pc) as u32;
+        let resume_depth = crate::liveness::liveness_for(caller_jitcode.payload.code_ptr)
+            .depth_at_py_pc()
+            .get(resume_py_pc as usize)
+            .copied()
+            .unwrap_or(0) as usize;
+        ctx.vstack_boxes.truncate(resume_depth);
+        ctx.vstack_boxes.resize(resume_depth, OpRef::NONE);
+        if resume_depth > 0 {
+            ctx.vstack_boxes[resume_depth - 1] = ca_result;
+        }
+        ctx.vstack_cur_pypc = resume_py_pc;
+        ctx.vstack_depth = resume_depth;
+        ctx.vstack_last_ref = OpRef::NONE;
+    }
+
     // pyjitpl.py:2079: GUARD_NOT_FORCED + resume snapshot advanced past
     // the call (`capture_resumedata(after_residual_call=True)`).
     ctx.trace_ctx.record_guard(OpCode::GuardNotForced, &[], 0);

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -4737,22 +4737,53 @@ fn setarrayitem_vable_via_metainterp(
         shadow.set_concrete(code[op.pc + 1] as u16, index_value, concrete);
     }
     walker_capture_inline_nonstandard_vable_guard(ctx, op.pc, guards_before)?;
-    // #73 (SLICE 1, INERT): a Ref stored to the operand-stack region of the
-    // vable array is an operand-stack PUSH (portal `pyframe.pushvalue`
-    // lowers to `setarrayitem_vable_r(locals_cells_stack_w, depth, w_obj)`).
-    // Capture it as the current opcode's TOS box for the walk-level
-    // operand-stack mirror — this is the chokepoint that catches pushes which
-    // never go through `write_ref_reg` (notably COPY, whose duplicate is
-    // emitted as a bare pushvalue with no compute step).  Gate on the stack
-    // region (`index >= nlocals`) so a STORE_FAST/local-slot store does not
-    // masquerade as a stack TOS.  Writes ONLY `vstack_last_ref` (side-data);
-    // consumed only when the mirror is valid.
+    // A Ref stored to the operand-stack region of the vable array is an
+    // operand-stack push (`pyframe.pushvalue` lowers to
+    // `setarrayitem_vable_r(locals_cells_stack_w, depth, w_obj)`). Retain the
+    // last-write TOS candidate for ordinary single-result opcodes. Method-form
+    // LOAD_ATTR is the one two-result shape that also needs its exact lower
+    // slot mirrored: it writes `[method, self]`, and retaining only `self`
+    // made boundary reconciliation refill the method hole from the stale
+    // pre-LOAD_ATTR receiver. A later guard then resumed CALL with that
+    // receiver as its callee. Scope the positional write to that opcode; the
+    // general boundary model remains authoritative for other push/pop shapes.
+    // Local/cell stores remain excluded by the `index >= nlocals` gate.
     if value_bank == 'r' && ctx.vstack_valid {
         let full_body_sym = ctx.fbw_mode.snapshot_sym;
         if !full_body_sym.is_null() {
             // SAFETY: pointer live for the full-body walk; read-only.
             let nlocals = unsafe { (*full_body_sym).nlocals } as i64;
             if index_value >= nlocals {
+                let method_load = unsafe {
+                    let jitcode = (*full_body_sym).jitcode;
+                    if jitcode.is_null() {
+                        false
+                    } else {
+                        let jitcode = &*jitcode;
+                        if jitcode.payload.code_ptr.is_null() {
+                            false
+                        } else {
+                            pyre_interpreter::decode_instruction_at(
+                                &*jitcode.payload.code_ptr,
+                                ctx.vstack_cur_pypc as usize,
+                            )
+                            .is_some_and(|(instr, op_arg)| match instr
+                            {
+                                pyre_interpreter::Instruction::LoadAttr { namei } => {
+                                    namei.get(op_arg).is_method()
+                                }
+                                _ => false,
+                            })
+                        }
+                    }
+                };
+                if method_load {
+                    let stack_slot = (index_value - nlocals) as usize;
+                    if ctx.vstack_boxes.len() <= stack_slot {
+                        ctx.vstack_boxes.resize(stack_slot + 1, OpRef::NONE);
+                    }
+                    ctx.vstack_boxes[stack_slot] = value;
+                }
                 ctx.vstack_last_ref = value;
             }
         }

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -17353,6 +17353,9 @@ fn try_walker_specialize_unpack(
 ///   * `guard_class(obj, &INSTANCE_TYPE)` — the receiver is a `W_ObjectObject`
 ///     (so the `map`/`storage` field reads below are valid; `mapdict.py:1495`
 ///     `if map is not None:` also filters non-instances at trace time).
+///   * `guard_value(getfield_gc_i(w_type, version_tag), C_version_tag)` — pins
+///     the class lookup result so a later descriptor or `__getattribute__`
+///     mutation deopts on trace re-entry.
 ///   * `guard_value(getfield_gc_i(obj, map), C_map)` — `jit.promote(self.map)`
 ///     (`mapdict.py:905`); pins the exact instance shape so `find_map_attr`
 ///     const-folds `storageindex` to a green constant.
@@ -17394,7 +17397,7 @@ fn try_walker_specialize_load_attr(
     };
     // `mapdict.py:1495-1533` resolution, returning the fold ingredients (the
     // read is left to the caller so it can be folded to a guarded inline read).
-    let Some((_w_type, _version_tag, map, storageindex)) = (unsafe {
+    let Some((w_type, version_tag, map, storageindex)) = (unsafe {
         pyre_interpreter::objspace::std::mapdict::load_attr_fast_path(concrete_obj, &name)
     }) else {
         return Ok(None);
@@ -17412,6 +17415,27 @@ fn try_walker_specialize_load_attr(
             .heap_cache_mut()
             .class_now_known(obj, instance_type_addr);
     }
+
+    // The instance map pins the storage layout, but class mutation can change
+    // lookup precedence without changing that map. Re-read the receiver type's
+    // live version tag at every trace entry and deopt before the inline storage
+    // read when it changes.
+    let w_type_const = ctx.trace_ctx.const_ref(w_type as i64);
+    let version_op = crate::state::opimpl_getfield_gc_i(
+        ctx.trace_ctx,
+        w_type_const,
+        crate::descr::type_version_tag_descr(),
+    );
+    let version_const = ctx.trace_ctx.const_int(version_tag as i64);
+    walker_emit_fold_guard_with_snapshot(
+        ctx,
+        op_pc,
+        OpCode::GuardValue,
+        &[version_op, version_const],
+    )?;
+    ctx.trace_ctx
+        .heap_cache_mut()
+        .replace_box(version_op, version_const);
 
     // guard_value(getfield_gc_i(obj, map), C_map): `jit.promote(self.map)`
     // (`mapdict.py:905-906`).  The map nodes are interned + immortal, so the

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -10922,7 +10922,7 @@ fn kept_stack_has_boxed_int_hazard(
         if depth == 0 {
             return false;
         }
-        let nlocals = code.varnames.len();
+        let stack_base = pjc.metadata.stack_base;
         let pcdep = pjc.metadata.pcdep_color_slots.get(py);
         let consts = pjc.metadata.const_ref_slots_at_pc.get(py);
         // The concrete shadow unboxes exact ints, so a kept slot that holds a
@@ -10935,7 +10935,7 @@ fn kept_stack_has_boxed_int_hazard(
                 && !(0..256).contains(&pyre_object::w_int_get_value(p))
         };
         for s in 0..depth {
-            let slot = (nlocals + s) as u16;
+            let slot = (stack_base + s) as u16;
             // Live Variable slot: inspect its concrete register value.
             if let Some(color) = pcdep.and_then(|e| {
                 e.iter()

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -1368,9 +1368,9 @@ pub fn seed_compiled_trace_jitcode_test_state(
 /// Empty when the index or PC is out of range, or the jitcode was never
 /// colored (portal/skeleton installs).
 ///
-/// Used by tests + tooling that need to translate a semantic slot
-/// (local `i` for `i < nlocals`, `nlocals + d` for operand-stack depth
-/// `d`) into the post-rename register color the dispatcher would touch
+/// Used by tests + tooling that need to translate a physical frame slot
+/// (local `i` for `i < code.varnames.len()`, `metadata.stack_base + d` for
+/// operand-stack depth `d`) into the post-rename register color the dispatcher would touch
 /// at a given PC — colors are per-program-point, so a flat
 /// slot-arithmetic lookup does not exist.
 pub fn pcdep_color_slots_at(jitcode_index: i32, py_pc: i32) -> Vec<(u8, u16, u16)> {

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -265,7 +265,7 @@ fn try_commit_midbody_abort(
             frame.locals_w_mut().as_mut_slice()[slot] = *value;
         }
     }
-    let stack_base = code.varnames.len();
+    let stack_base = code.varnames.len() + pyre_interpreter::pyframe::ncells(code);
     for (rel, value) in current.live_stack.iter().enumerate() {
         let crate::state::ConcreteValue::Ref(value) = value else {
             return false;

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -2060,15 +2060,31 @@ fn run_perfn_walk(
                     // FOR_ITER header whose walk already advanced the iterator; they
                     // differ in whether the consumed item's body ran.
                     let committed = if is_unsupported {
-                        // `BranchGuardKeptStackUnsupported` aborts AFTER the body
-                        // ran for the consumed item (the depth>1 kept operand stack
-                        // the COMPILED trace could not restore); the walk's
-                        // symbolic shadow already counted that iteration.  Resume
-                        // at the FOR_ITER header on the flushed end state WITHOUT
-                        // re-delivering the in-flight item — delivering it would
-                        // re-run the body and double-count the value.  A plain
-                        // end-state flush, gated the same as the marker leg.
-                        crate::state::flush_walk_end_state_to_frame(ctx, cf_addr, resume_py_pc)
+                        if crate::jitcode_dispatch::fbw_foriter_inflight_completed_at_resume(
+                            cf_addr,
+                            resume_py_pc,
+                        ) {
+                            // The consumed item's body already ran, so resume at
+                            // the FOR_ITER header without re-delivering it.
+                            crate::state::flush_walk_end_state_to_frame(ctx, cf_addr, resume_py_pc)
+                        } else {
+                            // A nested inner FOR_ITER can carry the enclosing
+                            // iterator as its kept stack before the consumed
+                            // item's body runs.  Mirror Shape A and deliver that
+                            // in-flight item exactly once.
+                            let push =
+                                crate::jitcode_dispatch::fbw_foriter_inflight_take_for_resume(
+                                    cf_addr,
+                                    resume_py_pc,
+                                );
+                            push.is_some()
+                                && crate::state::flush_walk_end_state_to_frame_with_item(
+                                    ctx,
+                                    cf_addr,
+                                    resume_py_pc,
+                                    push,
+                                )
+                        }
                     } else {
                         // Shape A — a `BranchGuardUnrestorableKeptStackPermanent`
                         // abort resumes AT a FOR_ITER header whose consumed item is

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -1617,6 +1617,12 @@ fn run_perfn_walk(
                             // `NonStandardVableFinishPortalUnsupported`).  The EC
                             // color carries no such identity — the EC stays
                             // recoverable from the frame — so reseeding it is safe.
+                            // This applies regardless of tagged-int state: a leaf
+                            // callee whose LOAD_DEREF result is colored onto the EC
+                            // register (`return CELL + 1`) strands `ConstPtr(ec)` in
+                            // the add's LHS when the cell payload's class flips and a
+                            // guard-failure bridge resumes here — the residual add
+                            // then dereferences the stale pointer and SIGSEGVs.
                             let is_frame_color =
                                 reserved_red_colors.first().copied() == Some(color);
                             let bridge_names_operand =

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -2890,6 +2890,15 @@ fn jit_ca_handle_guard_failure(
         return false;
     };
 
+    // This callback has no channel for the exception value carried by a
+    // failing CALL_ASSEMBLER exception guard.  Compiling from its post-call
+    // resume state would treat the null call result as a normal operand.
+    // Leave exception-guard recovery to the blackhole path, which owns the
+    // callee exception and propagates it through the caller frames.
+    if descr_arc.is_guard_exc() {
+        return false;
+    }
+
     // compile.py:738-784 must_compile: jitcounter.tick(guard_hash, increment)
     let (must_compile, owning_key) = {
         let (driver, _) = crate::eval::driver_pair();

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -575,6 +575,28 @@ pub(crate) fn drain_backend_jit_exc() {
     majit_backend_wasm::jit_exc_clear();
 }
 
+extern "C" fn record_caught_blackhole_traceback(
+    exc_value: i64,
+    frame_value: i64,
+    jitcode_index: i32,
+    opcode_position: i32,
+) {
+    let frame_ptr = frame_value as *mut PyFrame;
+    if frame_ptr.is_null() || exc_value == 0 {
+        return;
+    }
+    let last_instruction =
+        pyre_jit_trace::state::python_pc_for_jitcode_pc_public(jitcode_index, opcode_position)
+            .map_or(unsafe { (*frame_ptr).last_instr as i64 }, i64::from);
+    unsafe {
+        pyre_interpreter::pytraceback::record_application_traceback(
+            exc_value as PyObjectRef,
+            frame_ptr,
+            last_instruction,
+        );
+    }
+}
+
 #[majit_macros::jit_may_force]
 pub extern "C" fn jit_force_callee_frame(frame_ptr: i64) -> i64 {
     #[cfg(feature = "cranelift")]
@@ -1816,10 +1838,11 @@ pub fn blackhole_resume_via_rd_numb(
     // a frame enters a callee.
     {
         let vinfo = bh.virtualizable_info;
-        let mut caller = bh.nextblackholeinterp.as_deref_mut();
-        while let Some(frame) = caller {
+        let mut current = Some(&mut bh);
+        while let Some(frame) = current {
             frame.virtualizable_info = vinfo;
-            caller = frame.nextblackholeinterp.as_deref_mut();
+            frame.record_caught_exception = Some(record_caught_blackhole_traceback);
+            current = frame.nextblackholeinterp.as_deref_mut();
         }
     }
     // blackhole.py:1095-1099 get_portal_runner parity:
@@ -2032,12 +2055,13 @@ pub fn blackhole_resume_via_rd_numb(
             let frame_ptr = bh.virtualizable_ptr as *mut PyFrame;
             let jitcode_index = bh.jitcode.try_index().map(|v| v as i32);
             let last_opcode_position = bh.last_opcode_position;
+            let last_caught_exception_value = bh.last_caught_exception_value;
             release_bh_rd(bh);
             let Some(mut caller_bh) = next.map(|b| *b) else {
                 // blackhole.py:1679-1682 _exit_frame_with_exception:
                 //   e = cast_opaque_ptr(GCREF, e)
                 //   raise ExitFrameWithExceptionRef(e)
-                let err = if exc_value != 0 {
+                let mut err = if exc_value != 0 {
                     unsafe {
                         pyre_interpreter::PyError::from_exc_object(
                             exc_value as pyre_object::PyObjectRef,
@@ -2049,7 +2073,10 @@ pub fn blackhole_resume_via_rd_numb(
                         "blackhole exception (null exc_value)",
                     )
                 };
-                if !frame_ptr.is_null() {
+                let caught_reraise = exc_value != 0 && last_caught_exception_value == exc_value;
+                if caught_reraise {
+                    err.attach_tb = false;
+                } else if !frame_ptr.is_null() {
                     let last_instruction = jitcode_index
                         .and_then(|index| {
                             pyre_jit_trace::state::python_pc_for_jitcode_pc_public(

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -2066,6 +2066,11 @@ pub fn blackhole_resume_via_rd_numb(
                         );
                     }
                 }
+                // A residual helper can publish a raise to both exception
+                // channels.  Blackhole propagation has consumed its own
+                // channel into `ExitFrameWithExceptionRef`; keep the backend
+                // cell in sync before the outer interpreter receives it.
+                drain_backend_jit_exc();
                 return BlackholeResult::ExitFrameWithExceptionRef(err);
             };
             caller_bh.last_opcode_position = caller_bh.position;

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -1907,6 +1907,9 @@ pub fn blackhole_resume_via_rd_numb(
             }
             // blackhole.py:1616 no handler here → propagate to the caller.
             let next = bh.nextblackholeinterp.take();
+            let frame_ptr = bh.virtualizable_ptr as *mut PyFrame;
+            let jitcode_index = bh.jitcode.try_index().map(|v| v as i32);
+            let last_opcode_position = bh.last_opcode_position;
             release_bh_rd(bh);
             match next {
                 Some(caller) => bh = *caller,
@@ -1918,6 +1921,23 @@ pub fn blackhole_resume_via_rd_numb(
                             guard_exc as pyre_object::PyObjectRef,
                         )
                     };
+                    if !frame_ptr.is_null() {
+                        let last_instruction = jitcode_index
+                            .and_then(|index| {
+                                pyre_jit_trace::state::python_pc_for_jitcode_pc_public(
+                                    index,
+                                    last_opcode_position as i32,
+                                )
+                            })
+                            .map_or(unsafe { (*frame_ptr).last_instr as i64 }, i64::from);
+                        unsafe {
+                            pyre_interpreter::pytraceback::record_application_traceback(
+                                err.exc_object,
+                                frame_ptr,
+                                last_instruction,
+                            );
+                        }
+                    }
                     return BlackholeResult::ExitFrameWithExceptionRef(err);
                 }
             }
@@ -2009,6 +2029,9 @@ pub fn blackhole_resume_via_rd_numb(
         if bh.got_exception {
             let exc_value = bh.exception_last_value;
             let next = bh.nextblackholeinterp.take();
+            let frame_ptr = bh.virtualizable_ptr as *mut PyFrame;
+            let jitcode_index = bh.jitcode.try_index().map(|v| v as i32);
+            let last_opcode_position = bh.last_opcode_position;
             release_bh_rd(bh);
             let Some(mut caller_bh) = next.map(|b| *b) else {
                 // blackhole.py:1679-1682 _exit_frame_with_exception:
@@ -2026,6 +2049,23 @@ pub fn blackhole_resume_via_rd_numb(
                         "blackhole exception (null exc_value)",
                     )
                 };
+                if !frame_ptr.is_null() {
+                    let last_instruction = jitcode_index
+                        .and_then(|index| {
+                            pyre_jit_trace::state::python_pc_for_jitcode_pc_public(
+                                index,
+                                last_opcode_position as i32,
+                            )
+                        })
+                        .map_or(unsafe { (*frame_ptr).last_instr as i64 }, i64::from);
+                    unsafe {
+                        pyre_interpreter::pytraceback::record_application_traceback(
+                            err.exc_object,
+                            frame_ptr,
+                            last_instruction,
+                        );
+                    }
+                }
                 return BlackholeResult::ExitFrameWithExceptionRef(err);
             };
             caller_bh.last_opcode_position = caller_bh.position;

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -3855,7 +3855,7 @@ enum UnsupportedJitShape {
 /// arithmetic/comparison (implicit dunder dispatch resumes past the call on
 /// abort — verified), local/const reads and frame-slot writes, stack
 /// manipulation, read-only attribute loads, and intra-body control flow. Every
-/// other opcode — heap-mutating stores outside the abort-free widening and
+/// other opcode — heap-mutating stores outside the direct-store widening and
 /// unsupported mutators — is treated as unsafe so the frame keeps running in
 /// the interpreter. Unknown/future opcodes default to unsafe.
 fn for_iter_body_op_is_jit_safe(instr: pyre_interpreter::Instruction) -> bool {
@@ -3943,42 +3943,6 @@ fn for_iter_body_op_is_jit_safe(instr: pyre_interpreter::Instruction) -> bool {
     )
 }
 
-/// True when the `FOR_ITER` body in `[body_start, exit)` is straight-line with
-/// respect to walk aborts: it contains no call, no nested-loop iterator setup,
-/// and no conditional or forward branch. Such a body has no reachable trigger
-/// for the mid-loop walk abort that hands control to the Option-C
-/// deliver/refuse path, so any eager heap store performed inside it is always
-/// committed exactly once and can never be dropped or doubled (#57).
-/// `JumpBackward` is the loop's own back edge and does not introduce an abort.
-fn for_iter_body_is_abort_free(
-    instructions: &[pyre_interpreter::bytecode::CodeUnit],
-    body_start: usize,
-    exit: usize,
-) -> bool {
-    use pyre_interpreter::Instruction as I;
-    let mut body_state = pyre_interpreter::OpArgState::default();
-    let mut body_pc = body_start;
-    while body_pc < exit && body_pc < instructions.len() {
-        let (body_instr, _) = body_state.get(instructions[body_pc]);
-        if matches!(
-            body_instr,
-            I::Call { .. }
-                | I::CallKw { .. }
-                | I::ForIter { .. }
-                | I::GetIter
-                | I::PopJumpIfFalse { .. }
-                | I::PopJumpIfTrue { .. }
-                | I::PopJumpIfNone { .. }
-                | I::PopJumpIfNotNone { .. }
-                | I::JumpForward { .. }
-        ) {
-            return false;
-        }
-        body_pc += 1;
-    }
-    true
-}
-
 /// True iff every `FOR_ITER` loop body in `code` is admissible. The BASE rule is
 /// `for_iter_body_op_is_jit_safe`. A nested `FOR_ITER` appears as a body
 /// instruction of its enclosing loop, and its own body is scanned when the
@@ -3993,17 +3957,16 @@ fn for_iter_body_is_abort_free(
 /// matches the forward-only resume of `blackhole_from_resumedata`
 /// (resume.py:1312), which never drops or doubles an iteration.
 ///
-/// A straight-line body — one that `for_iter_body_is_abort_free` accepts — may
-/// ADDITIONALLY carry the direct heap-store opcodes `STORE_SUBSCR`,
-/// `STORE_ATTR`, `STORE_NAME`, `STORE_GLOBAL` and the `LOAD_NAME` that reads
-/// module globals. That widening is sound precisely because an abort-free body
-/// cannot reach the deliver/refuse path at all: with no call, branch or nested
-/// loop there is no abort after the store, so the store commits exactly once and
-/// its result coincides with the exact-resume result (#57). Bodies with a call
-/// or a branch stay on the base allow-list. `LOAD_ATTR` is admitted because a
-/// mid-body abort from its method call resumes exactly through
-/// `try_commit_midbody_abort` using forward-exception-delivery / CALL-forward,
-/// rather than dropping the remainder of the iteration.
+/// The direct heap-store opcodes `STORE_SUBSCR`, `STORE_ATTR`, `STORE_NAME`,
+/// `STORE_GLOBAL` and the `LOAD_NAME` that reads module globals are admitted in
+/// any body, including one with a call, branch or nested loop. A mid-body abort
+/// after a committed un-journaled store now resumes exactly through
+/// `try_commit_midbody_abort`: forward-exception-delivery or CALL-forward
+/// replaces the FBW refuse-drop that skipped the iteration tail. The store
+/// therefore commits exactly once and the tail is never dropped, matching the
+/// forward-only resume of `blackhole_from_resumedata`. `LOAD_ATTR` is admitted
+/// because a mid-body abort from its method call follows the same exact-resume
+/// path rather than dropping the remainder of the iteration.
 fn for_iter_bodies_all_jit_safe(code: &pyre_interpreter::CodeObject) -> bool {
     use pyre_interpreter::Instruction as I;
     let instructions = &code.instructions;
@@ -4016,21 +3979,19 @@ fn for_iter_bodies_all_jit_safe(code: &pyre_interpreter::CodeObject) -> bool {
                 pc + 1,
                 delta.get(op_arg).as_usize(),
             );
-            let abort_free = for_iter_body_is_abort_free(instructions, pc + 1, exit);
             let mut body_state = pyre_interpreter::OpArgState::default();
             let mut body_pc = pc + 1;
             while body_pc < exit && body_pc < instructions.len() {
                 let (body_instr, _) = body_state.get(instructions[body_pc]);
                 let permitted = for_iter_body_op_is_jit_safe(body_instr)
-                    || (abort_free
-                        && matches!(
-                            body_instr,
-                            I::StoreSubscr
-                                | I::StoreAttr { .. }
-                                | I::StoreName { .. }
-                                | I::StoreGlobal { .. }
-                                | I::LoadName { .. }
-                        ));
+                    || matches!(
+                        body_instr,
+                        I::StoreSubscr
+                            | I::StoreAttr { .. }
+                            | I::StoreName { .. }
+                            | I::StoreGlobal { .. }
+                            | I::LoadName { .. }
+                    );
                 if !permitted {
                     return false;
                 }
@@ -8870,7 +8831,7 @@ mod tests {
         // A subscript LOAD (`tbl[i]`) lowers to `BinaryOp(Subscr)`, a dispatching
         // op: `__getitem__` runs in a separate user frame and recovers on a walk
         // abort like any other `BinaryOp`, so the body is admitted. Only the
-        // mutating write `STORE_SUBSCR` is the excluded dropper (next test).
+        // mutating write `STORE_SUBSCR` is admitted by the direct-store widening.
         use pyre_interpreter::compile_exec;
         let module = compile_exec(
             "def s(src, tbl):\n    acc = 0\n    for i in src:\n        acc = acc + tbl[i]\n    return acc\n",
@@ -8883,9 +8844,8 @@ mod tests {
 
     #[test]
     fn for_iter_straight_line_store_subscr_body_is_jit_safe() {
-        // A straight-line body `buf[i] = i` (no call, no branch, no nested loop)
-        // is abort-free, so the direct STORE_SUBSCR is admitted: the mid-loop
-        // walk abort that could drop or double the store is unreachable (#57).
+        // The direct STORE_SUBSCR is admitted; a later mid-body abort resumes
+        // exactly, so the store commits once and the iteration tail is preserved.
         use pyre_interpreter::compile_exec;
         let module = compile_exec(
             "def w(src, buf):\n    for i in src:\n        buf[i] = i\n    return len(buf)\n",
@@ -8897,45 +8857,35 @@ mod tests {
     }
 
     #[test]
-    fn for_iter_store_subscr_with_branch_body_is_not_jit_safe() {
-        // A conditional `if i & 1: buf[i] = i` makes the body non-abort-free, so
-        // the direct STORE_SUBSCR is NOT admitted through the widening; the frame
-        // stays interpreted.
+    fn for_iter_store_subscr_with_branch_body_is_jit_safe() {
+        // Exact resume makes STORE_SUBSCR safe even in a body with a branch.
         use pyre_interpreter::compile_exec;
         let module = compile_exec(
             "def w(src, buf):\n    for i in src:\n        if i & 1:\n            buf[i] = i\n    return len(buf)\n",
         )
         .expect("test code should compile");
         let code = function_code_from_module(&module, "w");
-        assert!(!for_iter_bodies_all_jit_safe(&code));
-        assert_eq!(
-            unsupported_jit_shape(&code),
-            UnsupportedJitShape::CurrentFrameOnly
-        );
+        assert!(for_iter_bodies_all_jit_safe(&code));
+        assert_eq!(unsupported_jit_shape(&code), UnsupportedJitShape::None);
     }
 
     #[test]
-    fn for_iter_store_subscr_with_call_body_is_not_jit_safe() {
-        // A body that both calls and stores (`buf[i] = abs(i)`) is non-abort-free
-        // because of the call, so the STORE_SUBSCR is NOT admitted: this is the
-        // hazardous shape whose aborted walk could drop/double the store (#57).
+    fn for_iter_store_subscr_with_call_body_is_jit_safe() {
+        // Exact resume preserves the committed store and the tail when the call
+        // aborts the walk in a body containing both STORE_SUBSCR and append.
         use pyre_interpreter::compile_exec;
         let module = compile_exec(
-            "def w(src, buf):\n    for i in src:\n        buf[i] = abs(i)\n    return len(buf)\n",
+            "def w(src, d, fn, acc):\n    total = 0\n    for i in src:\n        d[i % 8] = i\n        total += fn(i)\n        acc.append(i)\n    return total\n",
         )
         .expect("test code should compile");
         let code = function_code_from_module(&module, "w");
-        assert!(!for_iter_bodies_all_jit_safe(&code));
-        assert_eq!(
-            unsupported_jit_shape(&code),
-            UnsupportedJitShape::CurrentFrameOnly
-        );
+        assert!(for_iter_bodies_all_jit_safe(&code));
+        assert_eq!(unsupported_jit_shape(&code), UnsupportedJitShape::None);
     }
 
     #[test]
     fn for_iter_straight_line_store_attr_body_is_jit_safe() {
-        // A straight-line body `o.x = i` is abort-free, so the direct STORE_ATTR
-        // is admitted through the abort-free store widening.
+        // The direct STORE_ATTR is admitted through the direct-store widening.
         use pyre_interpreter::compile_exec;
         let module =
             compile_exec("def w(src, o):\n    for i in src:\n        o.x = i\n    return o.x\n")

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -3847,6 +3847,16 @@ enum UnsupportedJitShape {
     None,
     CurrentFrameOnly,
     StructuralRegion,
+    /// The frame's constant pool plus register file would exceed the
+    /// single-byte (`< 256`) register-or-constant index encoding
+    /// (`assembler.py:72 chr()`, `assembler.py:132-133`
+    /// `count_regs + len(constants) < 256`). RPython builds jitcodes at
+    /// translation time from the hand-written interpreter, where this
+    /// ceiling is a bounded programming invariant; pyre builds a jitcode
+    /// per *user* Python frame at runtime, so a data-heavy frame (e.g. a
+    /// module body with thousands of literal constants) genuinely exceeds
+    /// it. Such a frame cannot be encoded and must run in the interpreter.
+    ConstEncodingOverflow,
 }
 
 /// True for opcodes that may appear in a `FOR_ITER` loop body without ever
@@ -4048,6 +4058,34 @@ fn for_iter_frame_is_finally_duplicated(code: &pyre_interpreter::CodeObject) -> 
     for_iter_count > 1 && any_in_handler
 }
 
+/// Upper bound on the constant-pool slots one code-object constant can
+/// contribute to the assembled jitcode. A `Tuple`/`Frozenset`/`Slice`
+/// constant can be unpacked into its elements during graph construction —
+/// e.g. a `BUILD_CONST_KEY_MAP` keys tuple lowered to one `ConstRef` per key,
+/// which is how a module body like `html.entities` turns a handful of literal
+/// `code.constants` entries into thousands of pool slots — so every nested
+/// leaf is counted. A `Code` constant belongs to a *separate* callee frame
+/// with its own pool, so it counts as a single ref here (its inner constants
+/// never enter this frame's pool).
+fn const_pool_slot_upper_bound(c: &pyre_interpreter::ConstantData) -> usize {
+    use pyre_interpreter::ConstantData;
+    match c {
+        ConstantData::Tuple { elements } | ConstantData::Frozenset { elements } => {
+            1 + elements
+                .iter()
+                .map(const_pool_slot_upper_bound)
+                .sum::<usize>()
+        }
+        ConstantData::Slice { elements } => {
+            1 + elements
+                .iter()
+                .map(const_pool_slot_upper_bound)
+                .sum::<usize>()
+        }
+        _ => 1,
+    }
+}
+
 fn unsupported_jit_shape(code: &pyre_interpreter::CodeObject) -> UnsupportedJitShape {
     // Structural adaptation: RPython/PyPy traces these bytecodes with
     // fully translated support. Pyre's codewriter still lowers
@@ -4073,6 +4111,42 @@ fn unsupported_jit_shape(code: &pyre_interpreter::CodeObject) -> UnsupportedJitS
     // iteration is silently dropped (#57). Bodies with no explicit
     // mutation/call and no nested `FOR_ITER` cannot reach that path — verified
     // against the battery and adversarial mutation probes.
+
+    // Single-byte register-or-constant index ceiling (`assembler.py:72`
+    // `chr(reg)`; `assembler.py:132-133` / `check_result` assert
+    // `count_regs[kind] + len(constants) <= 256`). RPython assembles jitcodes
+    // at translation time from the hand-written interpreter, where the ceiling
+    // is a bounded invariant; pyre assembles a jitcode per *user* Python frame
+    // at runtime, so a data-heavy frame (a module body with thousands of
+    // literal constants — e.g. `html.entities`, whose `<module>` frame carries
+    // ~4000 string constants) genuinely overruns it and the assembler asserts
+    // mid-emission. Decline such a frame to the interpreter before tracing.
+    //
+    // The predicate over-approximates the assembled counts, so it never admits
+    // an unencodable frame: the per-kind constant pool is bounded above by the
+    // whole constant table (flattened through nestable constants, see
+    // `const_pool_slot_upper_bound`) plus the name table, and each kind's
+    // register file is bounded above by the frame's live-slot capacity — the
+    // operand stack plus every local/cell/free slot, padded for the always-live
+    // vable red args and the transient temporaries one opcode lowering keeps
+    // live at once. When even this loose sum cannot fit in a byte, no assembler
+    // kind bank can encode the frame.
+    const SYNTHESIZED_REG_HEADROOM: usize = 16;
+    let register_slots_upper_bound = SYNTHESIZED_REG_HEADROOM
+        + code.max_stackdepth as usize
+        + code.varnames.len()
+        + code.cellvars.len()
+        + code.freevars.len();
+    let constant_slots_upper_bound = code
+        .constants
+        .iter()
+        .map(const_pool_slot_upper_bound)
+        .sum::<usize>()
+        + code.names.len();
+    if register_slots_upper_bound + constant_slots_upper_bound > 256 {
+        return UnsupportedJitShape::ConstEncodingOverflow;
+    }
+
     let mut arg_state = pyre_interpreter::OpArgState::default();
     let mut has_for_iter = false;
     for unit in code.instructions.iter().copied() {
@@ -4150,6 +4224,20 @@ fn eval_with_jit_inner(frame: &mut PyFrame) -> PyResult {
                 "FrameShape::StructuralRegion",
             );
             let _guard = JitSuppressionGuard::new();
+            return frame_root.frame().execute_frame(None, None);
+        }
+        UnsupportedJitShape::ConstEncodingOverflow => {
+            // The frame's constant pool plus register file overruns the
+            // single-byte register-or-constant index encoding, so no jitcode
+            // can be assembled for it (`unsupported_jit_shape`).  Run this frame
+            // in the plain interpreter; nested callees stay JIT-eligible (the
+            // overflow is per-frame), so no `JitSuppressionGuard`.  Record the
+            // decline in the census so the interpreted frame is visible, not a
+            // silent no-token gap.
+            pyre_jit_trace::jitcode_dispatch::census_record_frame_shape_decline(
+                code as *const _ as usize,
+                "FrameShape::ConstEncodingOverflow",
+            );
             return frame_root.frame().execute_frame(None, None);
         }
     }
@@ -4373,7 +4461,9 @@ pub(crate) fn portal_runner_result(frame: &mut PyFrame) -> PyResult {
     let code = unsafe { &*pyre_interpreter::pyframe_get_pycode(frame_root.frame()) };
     let _suppression = match unsupported_jit_shape(code) {
         UnsupportedJitShape::StructuralRegion => Some(JitSuppressionGuard::new()),
-        UnsupportedJitShape::None | UnsupportedJitShape::CurrentFrameOnly => None,
+        UnsupportedJitShape::None
+        | UnsupportedJitShape::CurrentFrameOnly
+        | UnsupportedJitShape::ConstEncodingOverflow => None,
     };
     portal_runner_dispatch(frame_root.frame())
 }

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -3854,10 +3854,10 @@ enum UnsupportedJitShape {
 /// walk-abort silently drops an iteration (#57). This is an ALLOW-LIST:
 /// arithmetic/comparison (implicit dunder dispatch resumes past the call on
 /// abort — verified), local/const reads and frame-slot writes, stack
-/// manipulation, and intra-body control flow. Every other opcode — explicit
-/// `CALL`, heap-mutating stores, nested `FOR_ITER`, list/set/dict builders and
-/// mutators — is treated as unsafe so the frame keeps running in the
-/// interpreter. Unknown/future opcodes default to unsafe.
+/// manipulation, read-only attribute loads, and intra-body control flow. Every
+/// other opcode — heap-mutating stores outside the abort-free widening and
+/// unsupported mutators — is treated as unsafe so the frame keeps running in
+/// the interpreter. Unknown/future opcodes default to unsafe.
 fn for_iter_body_op_is_jit_safe(instr: pyre_interpreter::Instruction) -> bool {
     use pyre_interpreter::Instruction as I;
     matches!(
@@ -3922,6 +3922,8 @@ fn for_iter_body_op_is_jit_safe(instr: pyre_interpreter::Instruction) -> bool {
             | I::PopIter
             | I::DeleteFast { .. }
             | I::LoadDeref { .. }
+            // An aborting method call resumes exactly via forward-exc-delivery / CALL-forward.
+            | I::LoadAttr { .. }
             // function calls and global reads: the Layer 2 dynamic defense
             // (body_effect_candidate + fbw_foriter_inflight_take) handles
             // walk-abort safety, and inline sub-walks are declined when a
@@ -3979,19 +3981,17 @@ fn for_iter_body_is_abort_free(
 
 /// True iff every `FOR_ITER` loop body in `code` is admissible. The BASE rule is
 /// `for_iter_body_op_is_jit_safe`. A nested `FOR_ITER` appears as a body
-/// instruction of its enclosing loop and is not allow-listed, so nested loops
-/// are rejected without recursion. The iterable setup (`range(n)`, `GET_ITER`)
-/// precedes the `FOR_ITER` and is therefore not part of any body range.
+/// instruction of its enclosing loop, and its own body is scanned when the
+/// outer instruction walk reaches it. The iterable setup (`range(n)`,
+/// `GET_ITER`) precedes the `FOR_ITER` and is therefore not part of any body
+/// range.
 ///
-/// This whole gate is a conservative adaptation, not an upstream mechanism. The
-/// FBW single-pass walker recovers from a mid-body walk abort by REFUSING to
-/// re-deliver the in-flight `FOR_ITER` item (Option-C deliver/refuse), which
-/// drops the rest of that iteration. The register-machine metainterp instead
-/// resumes exactly: it reads the precise `(jitcode, pc)` from the guard's resume
-/// data, `setposition`s a blackhole interpreter there and runs the body to its
-/// end (`blackhole_from_resumedata`, resume.py:1312), so it never drops or
-/// doubles. Until that exact-resume path is ported (#215 P2 / #73 / task#50), a
-/// body is admitted only where the refuse-drop deviation cannot be observed.
+/// This whole gate is a conservative adaptation, not an upstream mechanism.
+/// Mid-body walk aborts now resume exactly through `try_commit_midbody_abort`:
+/// forward-exception-delivery handles propagated exceptions and CALL-forward
+/// re-runs the outer call, instead of using the FBW refuse-drop path. This
+/// matches the forward-only resume of `blackhole_from_resumedata`
+/// (resume.py:1312), which never drops or doubles an iteration.
 ///
 /// A straight-line body — one that `for_iter_body_is_abort_free` accepts — may
 /// ADDITIONALLY carry the direct heap-store opcodes `STORE_SUBSCR`,
@@ -4000,11 +4000,10 @@ fn for_iter_body_is_abort_free(
 /// cannot reach the deliver/refuse path at all: with no call, branch or nested
 /// loop there is no abort after the store, so the store commits exactly once and
 /// its result coincides with the exact-resume result (#57). Bodies with a call
-/// or a branch stay on the base allow-list. `LOAD_ATTR` is deliberately
-/// excluded: it admits a method load whose call declines-to-abort while an item
-/// is in flight, and if an earlier body effect has already committed, the
-/// refuse-drop skips the rest of that iteration — a partial-iteration wrong
-/// answer, not a clean drop.
+/// or a branch stay on the base allow-list. `LOAD_ATTR` is admitted because a
+/// mid-body abort from its method call resumes exactly through
+/// `try_commit_midbody_abort` using forward-exception-delivery / CALL-forward,
+/// rather than dropping the remainder of the iteration.
 fn for_iter_bodies_all_jit_safe(code: &pyre_interpreter::CodeObject) -> bool {
     use pyre_interpreter::Instruction as I;
     let instructions = &code.instructions;
@@ -8839,31 +8838,31 @@ mod tests {
     }
 
     #[test]
-    fn for_iter_nested_append_body_is_not_jit_safe() {
-        // nested FOR_ITER with a direct append = the s3_append dropper -> excluded.
+    fn for_iter_nested_append_body_is_jit_safe() {
+        // Both loop bodies are scanned; the inner LOAD_ATTR+CALL is admitted now
+        // that a mid-body method-call abort resumes exactly.
         use pyre_interpreter::compile_exec;
         let module = compile_exec(
             "def g(n, acc):\n    for a in range(n):\n        for b in range(a):\n            acc.append(a)\n    return len(acc)\n",
         )
         .expect("test code should compile");
         let code = function_code_from_module(&module, "g");
-        assert!(!for_iter_bodies_all_jit_safe(&code));
-        assert_eq!(
-            unsupported_jit_shape(&code),
-            UnsupportedJitShape::CurrentFrameOnly
-        );
+        assert!(for_iter_bodies_all_jit_safe(&code));
+        assert_eq!(unsupported_jit_shape(&code), UnsupportedJitShape::None);
     }
 
     #[test]
-    fn for_iter_single_level_explicit_append_body_is_not_jit_safe() {
-        // explicit list.append in a body is conservatively excluded (LOAD_METHOD+CALL).
+    fn for_iter_single_level_explicit_append_body_is_jit_safe() {
+        // LOAD_ATTR followed by CALL is admitted now that a mid-body method-call
+        // abort resumes exactly instead of dropping the remainder of the iteration.
         use pyre_interpreter::compile_exec;
         let module = compile_exec(
             "def k(src, acc):\n    for x in src:\n        acc.append(x)\n    return len(acc)\n",
         )
         .expect("test code should compile");
         let code = function_code_from_module(&module, "k");
-        assert!(!for_iter_bodies_all_jit_safe(&code));
+        assert!(for_iter_bodies_all_jit_safe(&code));
+        assert_eq!(unsupported_jit_shape(&code), UnsupportedJitShape::None);
     }
 
     #[test]
@@ -8936,11 +8935,23 @@ mod tests {
     #[test]
     fn for_iter_straight_line_store_attr_body_is_jit_safe() {
         // A straight-line body `o.x = i` is abort-free, so the direct STORE_ATTR
-        // is admitted. (LOAD_ATTR reads stay excluded — see the allow-list.)
+        // is admitted through the abort-free store widening.
         use pyre_interpreter::compile_exec;
         let module =
             compile_exec("def w(src, o):\n    for i in src:\n        o.x = i\n    return o.x\n")
                 .expect("test code should compile");
+        let code = function_code_from_module(&module, "w");
+        assert!(for_iter_bodies_all_jit_safe(&code));
+        assert_eq!(unsupported_jit_shape(&code), UnsupportedJitShape::None);
+    }
+
+    #[test]
+    fn for_iter_load_attr_method_body_is_jit_safe() {
+        use pyre_interpreter::compile_exec;
+        let module = compile_exec(
+            "def w(objs):\n    s = 0\n    for o in objs:\n        s += o.bump()\n    return s\n",
+        )
+        .expect("test code should compile");
         let code = function_code_from_module(&module, "w");
         assert!(for_iter_bodies_all_jit_safe(&code));
         assert_eq!(unsupported_jit_shape(&code), UnsupportedJitShape::None);

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -3957,16 +3957,19 @@ fn for_iter_body_op_is_jit_safe(instr: pyre_interpreter::Instruction) -> bool {
 /// matches the forward-only resume of `blackhole_from_resumedata`
 /// (resume.py:1312), which never drops or doubles an iteration.
 ///
-/// The direct heap-store opcodes `STORE_SUBSCR`, `STORE_ATTR`, `STORE_NAME`,
-/// `STORE_GLOBAL` and the `LOAD_NAME` that reads module globals are admitted in
-/// any body, including one with a call, branch or nested loop. A mid-body abort
-/// after a committed un-journaled store now resumes exactly through
-/// `try_commit_midbody_abort`: forward-exception-delivery or CALL-forward
-/// replaces the FBW refuse-drop that skipped the iteration tail. The store
-/// therefore commits exactly once and the tail is never dropped, matching the
-/// forward-only resume of `blackhole_from_resumedata`. `LOAD_ATTR` is admitted
-/// because a mid-body abort from its method call follows the same exact-resume
-/// path rather than dropping the remainder of the iteration.
+/// The direct heap-mutation opcodes `STORE_SUBSCR`, `STORE_ATTR`, `STORE_NAME`,
+/// `STORE_GLOBAL`, `DELETE_SUBSCR`, `DELETE_ATTR`, and the `LOAD_NAME` that reads
+/// module globals are admitted in any body, including one with a call, branch or
+/// nested loop. A mid-body abort after a committed un-journaled store or delete
+/// now resumes exactly through `try_commit_midbody_abort`:
+/// forward-exception-delivery or CALL-forward replaces the FBW refuse-drop that
+/// skipped the iteration tail. The mutation therefore commits exactly once and
+/// the tail is never dropped, matching the forward-only resume of
+/// `blackhole_from_resumedata`. A delete that raises propagates through
+/// forward-exception-delivery; Fix A's exit-frame traceback recording preserves
+/// its traceback exactly. `LOAD_ATTR` is admitted because a mid-body abort from
+/// its method call follows the same exact-resume path rather than dropping the
+/// remainder of the iteration.
 fn for_iter_bodies_all_jit_safe(code: &pyre_interpreter::CodeObject) -> bool {
     use pyre_interpreter::Instruction as I;
     let instructions = &code.instructions;
@@ -3990,6 +3993,8 @@ fn for_iter_bodies_all_jit_safe(code: &pyre_interpreter::CodeObject) -> bool {
                             | I::StoreAttr { .. }
                             | I::StoreName { .. }
                             | I::StoreGlobal { .. }
+                            | I::DeleteSubscr
+                            | I::DeleteAttr { .. }
                             | I::LoadName { .. }
                     );
                 if !permitted {
@@ -8876,6 +8881,34 @@ mod tests {
         use pyre_interpreter::compile_exec;
         let module = compile_exec(
             "def w(src, d, fn, acc):\n    total = 0\n    for i in src:\n        d[i % 8] = i\n        total += fn(i)\n        acc.append(i)\n    return total\n",
+        )
+        .expect("test code should compile");
+        let code = function_code_from_module(&module, "w");
+        assert!(for_iter_bodies_all_jit_safe(&code));
+        assert_eq!(unsupported_jit_shape(&code), UnsupportedJitShape::None);
+    }
+
+    #[test]
+    fn for_iter_delete_subscr_with_branch_and_call_body_is_jit_safe() {
+        // Exact resume preserves a committed delete and the tail when a call
+        // aborts the walk in a body that also contains a branch.
+        use pyre_interpreter::compile_exec;
+        let module = compile_exec(
+            "def w(src, d, fn, acc):\n    for i in src:\n        if i & 1:\n            del d[i]\n        fn(i)\n        acc.append(i)\n    return len(d)\n",
+        )
+        .expect("test code should compile");
+        let code = function_code_from_module(&module, "w");
+        assert!(for_iter_bodies_all_jit_safe(&code));
+        assert_eq!(unsupported_jit_shape(&code), UnsupportedJitShape::None);
+    }
+
+    #[test]
+    fn for_iter_delete_attr_with_branch_and_call_body_is_jit_safe() {
+        // DELETE_ATTR uses the same exact-resume path in a body containing a
+        // branch, an aborting user call, and an append tail.
+        use pyre_interpreter::compile_exec;
+        let module = compile_exec(
+            "def w(src, o, fn, acc):\n    for i in src:\n        if i & 1:\n            del o.x\n        fn(i)\n        acc.append(i)\n    return len(acc)\n",
         )
         .expect("test code should compile");
         let code = function_code_from_module(&module, "w");

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -8973,7 +8973,7 @@ mod tests {
         local_slots: &[u32],
         stack_depths: &[usize],
     ) -> (usize, Vec<u32>, Vec<u32>) {
-        let nlocals = code.varnames.len();
+        let stack_base = code.varnames.len() + pyre_interpreter::pyframe::ncells(code);
         (0..code.instructions.len())
             .find_map(|pc| {
                 let colors: Vec<u32> = local_slots
@@ -8982,7 +8982,7 @@ mod tests {
                     .chain(
                         stack_depths
                             .iter()
-                            .map(|&d| pcdep_color_for_slot(jitcode_index, pc, nlocals + d)),
+                            .map(|&d| pcdep_color_for_slot(jitcode_index, pc, stack_base + d)),
                     )
                     .collect::<Option<Vec<u32>>>()?;
                 let live =

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -3958,18 +3958,21 @@ fn for_iter_body_op_is_jit_safe(instr: pyre_interpreter::Instruction) -> bool {
 /// (resume.py:1312), which never drops or doubles an iteration.
 ///
 /// The direct heap-mutation opcodes `STORE_SUBSCR`, `STORE_ATTR`, `STORE_NAME`,
-/// `STORE_GLOBAL`, `DELETE_SUBSCR`, `DELETE_ATTR`, and the `LOAD_NAME` that reads
-/// module globals are admitted in any body, including one with a call, branch or
-/// nested loop. A mid-body abort after a committed un-journaled store or delete
-/// now resumes exactly through `try_commit_midbody_abort`:
+/// `STORE_GLOBAL`, `STORE_DEREF`, `DELETE_SUBSCR`, `DELETE_ATTR`, and the
+/// `LOAD_NAME` that reads module globals are admitted in any body, including one
+/// with a call, branch or nested loop. A mid-body abort after a committed
+/// un-journaled store, cell write, or delete now resumes exactly through
+/// `try_commit_midbody_abort`:
 /// forward-exception-delivery or CALL-forward replaces the FBW refuse-drop that
 /// skipped the iteration tail. The mutation therefore commits exactly once and
 /// the tail is never dropped, matching the forward-only resume of
-/// `blackhole_from_resumedata`. A delete that raises propagates through
-/// forward-exception-delivery; Fix A's exit-frame traceback recording preserves
-/// its traceback exactly. `LOAD_ATTR` is admitted because a mid-body abort from
-/// its method call follows the same exact-resume path rather than dropping the
-/// remainder of the iteration.
+/// `blackhole_from_resumedata`. STORE_DEREF's cell slot and every subsequent
+/// operand-stack slot are reconstructed independently, including both method
+/// slots consumed by a tail CALL. A mutation that raises, or a later exception
+/// after the cell write, propagates through forward-exception-delivery; Fix A's
+/// exit-frame traceback recording preserves its traceback exactly. `LOAD_ATTR`
+/// is admitted because a mid-body abort from its method call follows the same
+/// exact-resume path rather than dropping the remainder of the iteration.
 fn for_iter_bodies_all_jit_safe(code: &pyre_interpreter::CodeObject) -> bool {
     use pyre_interpreter::Instruction as I;
     let instructions = &code.instructions;
@@ -3993,6 +3996,7 @@ fn for_iter_bodies_all_jit_safe(code: &pyre_interpreter::CodeObject) -> bool {
                             | I::StoreAttr { .. }
                             | I::StoreName { .. }
                             | I::StoreGlobal { .. }
+                            | I::StoreDeref { .. }
                             | I::DeleteSubscr
                             | I::DeleteAttr { .. }
                             | I::LoadName { .. }
@@ -8884,6 +8888,25 @@ mod tests {
         )
         .expect("test code should compile");
         let code = function_code_from_module(&module, "w");
+        assert!(for_iter_bodies_all_jit_safe(&code));
+        assert_eq!(unsupported_jit_shape(&code), UnsupportedJitShape::None);
+    }
+
+    #[test]
+    fn for_iter_store_deref_with_branch_and_call_body_is_jit_safe() {
+        use pyre_interpreter::{Instruction, compile_exec};
+        let module = compile_exec(
+            "def outer(src, fn, acc):\n    n = -1\n    def read():\n        return n\n    for i in src:\n        if i & 1:\n            n = i * 17 + 3\n        n += fn(i)\n        acc.append((i, n))\n    return n, read()\n",
+        )
+        .expect("test code should compile");
+        let code = function_code_from_module(&module, "outer");
+        let mut arg_state = pyre_interpreter::OpArgState::default();
+        assert!(
+            code.instructions
+                .iter()
+                .copied()
+                .any(|unit| { matches!(arg_state.get(unit).0, Instruction::StoreDeref { .. }) })
+        );
         assert!(for_iter_bodies_all_jit_safe(&code));
         assert_eq!(unsupported_jit_shape(&code), UnsupportedJitShape::None);
     }

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -4829,6 +4829,19 @@ fn build_pcdep_color_slots(
     out
 }
 
+/// Translate the compact codewriter slot space (`fast locals | operand stack`)
+/// to the physical `locals_cells_stack_w` layout (`fast locals | deref slots |
+/// operand stack`).
+fn frame_layout_slot(slot: u16, nlocals: usize, stack_base: usize) -> u16 {
+    let slot = slot as usize;
+    let absolute = if slot < nlocals {
+        slot
+    } else {
+        stack_base + (slot - nlocals)
+    };
+    u16::try_from(absolute).expect("locals_cells_stack_w slot must fit in u16")
+}
+
 fn validate_pcdep_color_map(
     pcdep_slot_var: &[Vec<(u16, u32)>],
     colorings: [&std::collections::HashMap<super::flow::VariableId, u16>; 3],
@@ -12478,7 +12491,31 @@ impl CodeWriter {
         // #348 Part (2): ship the marker-consistent per-PC map (the fold-group
         // union) so the runtime inversion covers every color the (possibly
         // folded) `-live-` marker carries.
-        let pcdep_color_slots = marker_pcdep_color_slots;
+        // The graph/register space packs `[fast locals | operand stack]`, but
+        // runtime resume consumers index `locals_cells_stack_w` and therefore
+        // need `[fast locals | pure cells/freevars | operand stack]`. Translate
+        // only at this publication boundary so register allocation stays in
+        // its compact space while every frame slot in metadata is physical.
+        let pcdep_color_slots: Vec<Vec<(u8, u16, u16)>> = marker_pcdep_color_slots
+            .into_iter()
+            .map(|entries| {
+                entries
+                    .into_iter()
+                    .map(|(bank, color, slot)| {
+                        (
+                            bank,
+                            color,
+                            frame_layout_slot(slot, nlocals, stack_base_absolute),
+                        )
+                    })
+                    .collect()
+            })
+            .collect();
+        for entries in &mut const_ref_slots_at_pc {
+            for (slot, _) in entries {
+                *slot = frame_layout_slot(*slot, nlocals, stack_base_absolute);
+            }
+        }
         // Runtime entry/liveness lookups expect the byte offset of the
         // surviving `-live-` marker for each Python PC
         // (`jitcode.get_live_vars_info` first checks `code[pc] ==
@@ -13515,6 +13552,21 @@ mod tests {
         let resume: Vec<Vec<(u16, u32)>> = vec![vec![], vec![], vec![(0u16, 5u32)]];
         let slots = pcdep_canonical_slot(&post, &resume);
         assert_eq!(slots.get(5).copied().flatten(), Some(2));
+    }
+
+    #[test]
+    fn frame_layout_slot_places_operand_stack_after_non_argument_deref_slots() {
+        // A free var or pure cell occupies one physical slot between the three
+        // fast locals and the operand stack.
+        assert_eq!(frame_layout_slot(0, 3, 4), 0);
+        assert_eq!(frame_layout_slot(2, 3, 4), 2);
+        assert_eq!(frame_layout_slot(3, 3, 4), 4);
+        assert_eq!(frame_layout_slot(6, 3, 4), 7);
+
+        // An argument-cell overlaps its fast-local slot, so there is no extra
+        // deref slot and compact and physical stack indices coincide.
+        assert_eq!(frame_layout_slot(3, 3, 3), 3);
+        assert_eq!(frame_layout_slot(6, 3, 3), 6);
     }
 
     fn make_runtime_jitcode_with_fnaddr(fnaddr: usize) -> Arc<majit_metainterp::jitcode::JitCode> {


### PR DESCRIPTION
Widens the #57 FOR_ITER JIT decline gate as exact-resume coverage is proven per opcode group, and closes the JIT traceback-fidelity gaps uncovered along the way. Every increment is gated on adversarial byte-exact parity vs the interpreter on both backends.

## FOR_ITER gate widening (exact-resume)
A committed un-journaled heap effect resumes forward exactly (the loop tail is not dropped); a raising effect propagates via forward-exception-delivery. The gate now admits, alongside the base no-heap-mutation set:
- `STORE_SUBSCR/STORE_ATTR/STORE_NAME/STORE_GLOBAL` (slice-2) and `LOAD_ATTR`/`LOAD_NAME`
- `DELETE_SUBSCR/DELETE_ATTR` (slice-3a)
- `STORE_DEREF` (slice-3b)

Supporting exact-resume fixes: FOR_ITER resume slots for closure frames; in-flight FOR_ITER item delivery on the kept-stack Unsupported branch-flush for nested loops; class-body namespace local refresh after a JIT run.

## JIT traceback fidelity (#9)
A JIT-compiled frame that exits with a residual exception previously dropped its own Python traceback entry.
- **Fix A** — uncaught propagation: record the frame at the blackhole exit-with-exception, translating the faulting JitCode PC to the raise line.
- **Fix C** — caught-in-frame reraise/chaining: `route_to_catch` transferred a residual into a zero-cost handler without recording the frame; a reraise (`raise`), `raise ... from`, or implicit `__context__` chain then escaped with the fault/raise line missing and the chained exception carrying no compiled-frame traceback. A generic `record_caught_exception` callback on the blackhole (raw refs only — no interpreter dependency) records at handler entry; the bottommost exit suppresses the duplicate cleanup entry when the escaping exception is the already-recorded caught object.

## Correctness fixes uncovered by the wider gate
- **Self-recursive CALL_ASSEMBLER fold** value corruption at depth: the post-call guard snapshot sourced stack slot 0 from the stale pre-call operand-stack mirror `[callable, ...]`, so deep-recursion guard-fail recovery substituted the callable for the result. Advance the mirror to the post-call state before the guard; decline the exception-guard bridge compile from the post-call resume state.
- **STORE_DEREF method-load slot mirror**: method-form `LOAD_ATTR` pushes `[method, self]` but the mirror kept only `self`, so a cell-related guard reconstructed the method slot from a stale value and the tail call invoked the wrong object. Mirror both method-load slots at the vable stack-write chokepoint.
- **Raising-DELETE stale exception**: a residual delete that raised left the backend `_store_exception` cell populated after propagating out, so the next JIT'd function resurfaced it. Drain the cell at the bottommost unhandled frame exit.

## Loop admission
`scope loop abort_permanent decline to the loop body`: an `except X as e` handler lowers its cleanup to a post-loop `DELETE_FAST` (abort_permanent) that wrongly declined the hot loop; scope the scan to the loop body so such loops compile (and their caught-reraise tracebacks are exercised).

## Verification
`pyre/check.py --backend dynasm,cranelift` green across the increments (the sole failure on the current base is `synth/list_insert_pop_index`, a pre-existing objspace error-message parity issue from #552 that fails at interpreter level, unrelated to this branch — fixed as a follow-up commit here). Adversarial byte-exact repros (values, final container state, exception type/message, and full multi-frame tracebacks incl. `__cause__`/`__context__` chains) pass on both backends.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved exception tracking and traceback reporting during JIT execution and exception propagation.
  * Fixed GC-related issues in iteration and class construction (namespace now rebuilt safely after JIT execution).
  * Corrected JIT recovery for frame/operand-stack state after interruptions and loop resumes.
  * Ensured `dict`/`set` operations validate hashability up-front: unhashable keys/values now raise `TypeError` without partially mutating the result.
* **Improvements**
  * Expanded JIT support for `FOR_ITER` loop bodies, including method-call patterns and common `STORE_*`/`DELETE_*` cases.
  * Python compatibility checks now prefer Python 3.14 when available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->