### PR TITLE
jit(wasm): general CALL_ASSEMBLER + float residual/local perf gaps (nbody/fannkuch/float_loop/spectral)

### DIFF
--- a/majit/majit-backend-wasm/src/codegen.rs
+++ b/majit/majit-backend-wasm/src/codegen.rs
@@ -388,10 +388,10 @@ impl RefHomes {
         }
         if include_ca_collects {
             // The CA arm allocates its callee frame before it resolves this
-            // CallAssemblerR's arguments. Those Ref operands are used at (not
+            // CALL_ASSEMBLER's arguments. Those Ref operands are used at (not
             // after) this op, so ordinary `live_across` deliberately excludes
             // them; they nevertheless need homes through the prior allocation.
-            for op in ops.iter().filter(|op| op.opcode == OpCode::CallAssemblerR) {
+            for op in ops.iter().filter(|op| op.opcode.is_call_assembler()) {
                 for arg in op.getarglist() {
                     let arg = arg.to_opref();
                     if ref_values.contains(arg) {
@@ -444,7 +444,7 @@ impl RefHomes {
 /// region before codegen runs.
 pub fn count_ref_homes(inputargs: &[InputArg], ops: &[Op]) -> usize {
     // This pre-sizing query is used for CA bridges before `CaParams` exists, so
-    // count `CallAssemblerR` as a collecting position to match CA codegen.
+    // count CALL_ASSEMBLER as a collecting position to match CA codegen.
     RefHomes::collect(inputargs, ops, true).len()
 }
 
@@ -1034,10 +1034,10 @@ pub fn has_trampoline_calls(inputargs: &[InputArg], ops: &[Op], emit_ca: bool) -
     }
 
     ops.iter().any(|op| match op.opcode {
-        // `build_function` handles an enabled CA `CallAssemblerR` before the
-        // generic CALL arm, lowering it directly to the source-loop table
-        // slot. It therefore never uses the host call area.
-        OpCode::CallAssemblerR if emit_ca => false,
+        // `build_function` handles an enabled CALL_ASSEMBLER before the generic
+        // CALL arm, lowering it directly to the callee-loop table slot. It
+        // therefore never uses the host call area.
+        opcode if opcode.is_call_assembler() && emit_ca => false,
         // These arms have no direct helper lowering.
         OpCode::Newstr | OpCode::Newunicode => true,
         // Every residual CALL uses the trampoline unless its exact lowering
@@ -1158,15 +1158,15 @@ fn alloc_bridge_cells(num_guards: usize) -> (u32, Option<Box<[u32]>>) {
     }
 }
 
-/// Parameters for the self-recursive CALL_ASSEMBLER guest→guest `call_indirect`
-/// arm (`PYRE_WASM_CA`). `emit_ca == false` (the default) keeps every emitted
-/// module byte-identical to the pre-feature backend.
+/// Parameters for the guest→guest `CALL_ASSEMBLER` `call_indirect` arm.
+/// `emit_ca == false` (the default) keeps every emitted module byte-identical
+/// to the pre-feature backend.
 #[derive(Clone, Copy, Default)]
 pub struct CaParams {
-    /// Emit the dedicated `CallAssemblerR` arm (an in-module `call_indirect`
-    /// into the source loop). Only set by `compile_bridge` for a self-recursive
-    /// single-int bridge; `compile_loop` never sets it.
+    /// Emit the dedicated `CALL_ASSEMBLER` arm into `callee_slot`.
     pub emit_ca: bool,
+    /// Table slot of the compiled callee loop.
+    pub callee_slot: u32,
     /// Bytes to reserve per CA callee frame (the GC `JitFrame`'s data region,
     /// i.e. its Signed item area). This is the source geometry's prefix through
     /// the Ref homes, excluding its tail call area. The trampoline-decline
@@ -1175,7 +1175,7 @@ pub struct CaParams {
     /// runs on this movable frame, so the omitted tail is unreachable. The alloc
     /// trampoline derives the JitFrame item count from this exact byte count.
     pub callee_frame_bytes: u32,
-    /// `fail_index` the SOURCE loop's DoneWithThisFrame Finish writes to frame[0]
+    /// `fail_index` the callee loop's DoneWithThisFrame Finish writes to frame[0]
     /// on the base-case return. The CA arm treats this — or this bridge's own
     /// finish index — as a clean callee finish; anything else is a deopt.
     pub loop_finish_fi: u32,
@@ -1186,10 +1186,12 @@ pub struct CaParams {
     /// instead of trapping. `0` (unset) ⇒ no helper, so `compile_bridge` declines
     /// the CA lift before reaching codegen.
     pub deopt_helper_slot: u32,
-    /// Address of the source loop's `CompiledWasmLoop`, baked as the first
+    pub baseline_helper_slot: u32,
+    pub terminal_declined_ptr: u32,
+    /// Address of the callee loop's `CompiledWasmLoop`, baked as the first
     /// argument to the deopt helper so it can resolve the deopted callee frame's
     /// `fail_descrs`.
-    pub source_compiled_ptr: u64,
+    pub callee_compiled_ptr: u64,
     /// `__indirect_function_table` slot (`fn as usize`) of
     /// `lib.rs::wasm_jit_ca_alloc_frame`, which allocates each callee frame as
     /// a young nursery GC-managed `JitFrame` (push_jf-rooted, traced by its own
@@ -3006,28 +3008,51 @@ fn build_function(
                 );
             }
 
-            // ── Self-recursive CALL_ASSEMBLER (PYRE_WASM_CA) ──
-            // Lower `vi = CallAssemblerR(frame, ec)` into an in-module
-            // `call_indirect` into the SOURCE loop (self-recursion) instead of a
+            // ── CALL_ASSEMBLER ──
+            // Lower the call into an in-module `call_indirect` into its compiled
+            // callee loop instead of a
             // host round-trip. A fresh callee frame is allocated as a real
             // GC-managed nursery `JitFrame` (push_jf-rooted on the jitframe
             // shadow stack; traced by its OWN per-frame gcmap covering
-            // its input + home Ref slots), the two red inputs are written to its
+            // its input + home Ref slots), the descriptor inputs are written to its
             // input slots, the loop runs on it (recursing through this same arm
             // for deeper levels), then the result Ref is read back from output
-            // slot 0. Only emitted for the fib-shaped bridge `compile_bridge`
-            // validated (`bridge_is_self_recursive_int_ca`); a loop never sets
-            // `emit_ca`. The callee `call_indirect` runs the source loop's full
-            // recursion, which allocates and collects; each live callee frame is
+            // slot 0. `compile_loop` and `compile_bridge` validate the descriptor
+            // and target metadata before enabling this arm. The callee
+            // `call_indirect` runs a full compiled loop, which allocates and
+            // collects; each live callee frame is
             // self-described by its gcmap so a collection forwards its Refs (no
             // shared-arena single-stride walker). This bridge's own wasm-local
             // Refs still hold pre-call (from-space) addresses on return, so
             // reload them from the (forwarded) homes after the call.
-            OpCode::CallAssemblerR if ca.emit_ca => {
+            opcode if opcode.is_call_assembler() && ca.emit_ca => {
                 let vi = op.pos.get().raw();
-                // `external_jump_slot` is the source loop's table slot (the CA
-                // self-target), plumbed by `compile_bridge`.
-                let self_slot = external_jump_slot as i32;
+                let callee_slot = ca.callee_slot as i32;
+
+                // A target with a terminally-declined bridge must immediately
+                // return to the ordinary PyFrame entry path.  The bit lives in
+                // guest linear memory, so clean CA calls pay only one byte load.
+                sink.i32_const(ca.terminal_declined_ptr as i32);
+                sink.i32_load8_u(memarg(0, 0));
+                sink.if_(BlockType::Empty);
+                emit_resolve(&mut sink, constants, value_types, op.arg(0).to_opref());
+                sink.i64_const(ca.callee_compiled_ptr as i64);
+                sink.i32_const(ca.baseline_helper_slot as i32);
+                sink.call_indirect(0, ca_helper_type_idx);
+                if !OpRef::raw_is_constant(vi) {
+                    sink.local_set(1 + vi);
+                } else {
+                    sink.drop();
+                }
+                let skip = (!OpRef::raw_is_constant(vi)).then_some(vi);
+                emit_reload_ca_frame_if_necessary(
+                    &mut sink,
+                    residual_type_base,
+                    ca.ca_reload_fn_ptr,
+                    ca.inline,
+                );
+                emit_reload_refs_from_homes(&mut sink, ref_homes, &liveness, op_idx, skip, frame);
+                sink.else_();
 
                 // Allocate the callee frame as a GC JitFrame
                 // (`wasm_jit_ca_alloc_frame(frame_bytes, gcmap_ptr)` — a
@@ -3184,17 +3209,16 @@ fn build_function(
                 sink.local_get(ca_cfp_local);
                 sink.i64_const(0);
                 sink.i64_store(mem64(frame.dispatch_key_ofs));
-                // inputs: F'[1] = arg0 (callee frame), F'[2] = arg1 (ec).
+                // Marshal the descriptor's uniform i64 Int/Ref ABI inputs into
+                // the callee's positional frame slots.
+                for (arg_index, arg) in op.getarglist().iter().enumerate() {
+                    sink.local_get(ca_cfp_local);
+                    emit_resolve(&mut sink, constants, value_types, arg.to_opref());
+                    sink.i64_store(mem64(FRAME_SLOT_BASE + arg_index as u64 * SLOT_SIZE));
+                }
+                // Run the callee loop on F'; discard the returned frame_ptr.
                 sink.local_get(ca_cfp_local);
-                emit_resolve(&mut sink, constants, value_types, op.arg(0).to_opref());
-                sink.i64_store(mem64(FRAME_SLOT_BASE));
-                sink.local_get(ca_cfp_local);
-                emit_resolve(&mut sink, constants, value_types, op.arg(1).to_opref());
-                sink.i64_store(mem64(FRAME_SLOT_BASE + SLOT_SIZE));
-                // run the source loop on F' (non-tail: one wasm frame per
-                // recursion level); discard the returned frame_ptr.
-                sink.local_get(ca_cfp_local);
-                sink.i32_const(self_slot);
+                sink.i32_const(callee_slot);
                 sink.call_indirect(0, 0);
                 sink.drop();
                 // The recursive call may minor-collect and move this nursery
@@ -3250,7 +3274,7 @@ fn build_function(
                 // deopt: wasm_ca_resume_deopt(frame_ptr: i64, compiled_ptr: i64).
                 sink.local_get(ca_cfp_local);
                 sink.i64_extend_i32_u();
-                sink.i64_const(ca.source_compiled_ptr as i64);
+                sink.i64_const(ca.callee_compiled_ptr as i64);
                 sink.i32_const(ca.deopt_helper_slot as i32);
                 // call_indirect(table_index, type_index): the shared table is 0.
                 sink.call_indirect(0, ca_helper_type_idx);
@@ -3322,6 +3346,7 @@ fn build_function(
                     ca.inline,
                 );
                 emit_reload_refs_from_homes(&mut sink, ref_homes, &liveness, op_idx, skip, frame);
+                sink.end();
             }
 
             // ── CALL operations (via trampoline) ──

--- a/majit/majit-backend-wasm/src/codegen.rs
+++ b/majit/majit-backend-wasm/src/codegen.rs
@@ -267,11 +267,23 @@ fn setfield_store_size_from_descr(op: &Op) -> usize {
     std::mem::size_of::<usize>()
 }
 
+fn field_is_float_from_descr(op: &Op) -> bool {
+    op.getdescr()
+        .as_ref()
+        .and_then(|d| d.as_field_descr())
+        .is_some_and(|fd| fd.is_float_field())
+}
+
 /// `(item_size, is_signed)` from an op's ArrayDescr; defaults to 8-byte
 /// signed when the descr is absent.
 fn array_item_size_sign_from_descr(op: &Op) -> (usize, bool) {
     op.with_array_descr(|ad| (ad.item_size(), ad.is_item_signed()))
         .unwrap_or((8, true))
+}
+
+fn array_item_is_float_from_descr(op: &Op) -> bool {
+    op.with_array_descr(|ad| ad.item_type() == Type::Float)
+        .unwrap_or(false)
 }
 
 /// Dense census of every non-constant Ref-typed value (input arg / op result),
@@ -495,6 +507,7 @@ fn has_ref_store_op(ops: &[Op], ref_values: &RefValues) -> bool {
 fn emit_write_barrier(
     sink: &mut InstructionSink<'_>,
     constants: &indexmap::IndexMap<u32, i64>,
+    value_types: &[ValType],
     jit_call_idx: Option<u32>,
     residual_type_base: Option<u32>,
     wb_fn_ptr: i64,
@@ -509,7 +522,7 @@ fn emit_write_barrier(
         const WB_FLAG: i32 = majit_gc::flags::TRACK_YOUNG_PTRS as i32;
         const _: () = assert!(majit_gc::header::FLAG_SHIFT == 32);
         const _: () = assert!(majit_gc::flags::TRACK_YOUNG_PTRS <= u32::MAX as u64);
-        emit_resolve(sink, constants, base_ref);
+        emit_resolve(sink, constants, value_types, base_ref);
         sink.i32_wrap_i64();
         sink.i32_const(FLAGS_HALF_BACKOFS);
         sink.i32_sub();
@@ -521,7 +534,7 @@ fn emit_write_barrier(
         sink.i32_const(WB_FLAG);
         sink.i32_and();
         sink.if_(BlockType::Empty);
-        emit_resolve(sink, constants, base_ref);
+        emit_resolve(sink, constants, value_types, base_ref);
         sink.i32_const(wb_fn_ptr as i32);
         sink.call_indirect(0, base + 1);
         sink.drop(); // returns 0; ignored
@@ -542,7 +555,7 @@ fn emit_write_barrier(
     sink.i64_store(mem64(frame.call_nargs_ofs));
     // arg0 = base object pointer
     sink.local_get(0);
-    emit_resolve(sink, constants, base_ref);
+    emit_resolve(sink, constants, value_types, base_ref);
     sink.i64_store(mem64(frame.call_args_ofs));
     // call trampoline; void result ignored
     sink.local_get(0);
@@ -1089,6 +1102,28 @@ fn collect_guards_and_vars(inputargs: &[InputArg], ops: &[Op]) -> (Vec<GuardExit
     (guards, max_var)
 }
 
+/// Wasm local type for each SSA value. Frame slots deliberately remain i64
+/// bit carriers, while Float values stay in f64 locals between operations.
+fn collect_value_types(inputargs: &[InputArg], ops: &[Op], num_vars: u32) -> Vec<ValType> {
+    let mut value_types = vec![ValType::I64; num_vars as usize];
+    for ia in inputargs {
+        if ia.tp == Type::Float && (ia.index as usize) < value_types.len() {
+            value_types[ia.index as usize] = ValType::F64;
+        }
+    }
+    for op in ops {
+        let result = op.pos.get();
+        if result != OpRef::NONE
+            && !result.is_constant()
+            && op.result_type() == Type::Float
+            && (result.raw() as usize) < value_types.len()
+        {
+            value_types[result.raw() as usize] = ValType::F64;
+        }
+    }
+    value_types
+}
+
 /// Assign each Ref-typed value (input arg or op result) a dense home-slot
 /// index, keyed by its value id (`raw()`), the same id its wasm local uses
 /// (`1 + raw`). Input args and op results share one value-id space (see
@@ -1303,6 +1338,7 @@ pub fn build_wasm_module(
         )));
     }
 
+    let value_types = collect_value_types(inputargs, ops, num_vars);
     let ref_values = RefValues::collect(inputargs, ops);
     let ref_homes = RefHomes::collect(inputargs, ops, ca.emit_ca);
     let num_ref_homes = ref_homes.len();
@@ -1504,6 +1540,7 @@ pub fn build_wasm_module(
         ops,
         constants,
         num_vars,
+        &value_types,
         jit_call_idx,
         vtable_offset,
         classptr_to_typeid,
@@ -1544,6 +1581,7 @@ fn build_function(
     ops: &[Op],
     constants: &indexmap::IndexMap<u32, i64>,
     num_vars: u32,
+    value_types: &[ValType],
     jit_call_idx: Option<u32>,
     vtable_offset: Option<usize>,
     classptr_to_typeid: &HashMap<i64, u32>,
@@ -1607,18 +1645,33 @@ fn build_function(
     let base_i32_locals: u32 = if ca.emit_ca { 3 } else { 1 };
     let alloc_scratch_local = num_vars + UMULHI_SCRATCH + 1 + base_i32_locals;
     let alloc_size_local = alloc_scratch_local + 1;
-    let mut func = Function::new(vec![
-        (num_vars + UMULHI_SCRATCH, ValType::I64),
-        (
-            base_i32_locals
-                + if nursery.is_some() || ca.inline.is_some() {
-                    2
-                } else {
-                    0
-                },
-            ValType::I32,
-        ),
-    ]);
+    debug_assert_eq!(value_types.len(), num_vars as usize);
+    let mut locals = Vec::new();
+    let mut start = 0;
+    while start < value_types.len() {
+        let ty = value_types[start];
+        let mut end = start + 1;
+        while end < value_types.len() && value_types[end] == ty {
+            end += 1;
+        }
+        locals.push(((end - start) as u32, ty));
+        start = end;
+    }
+    if let Some((count, ValType::I64)) = locals.last_mut() {
+        *count += UMULHI_SCRATCH;
+    } else {
+        locals.push((UMULHI_SCRATCH, ValType::I64));
+    }
+    locals.push((
+        base_i32_locals
+            + if nursery.is_some() || ca.inline.is_some() {
+                2
+            } else {
+                0
+            },
+        ValType::I32,
+    ));
+    let mut func = Function::new(locals);
     let mut sink = func.instructions();
 
     // Null-init every Ref-home slot so a slot read before its value is defined
@@ -1712,9 +1765,11 @@ fn build_function(
     for (k, ia) in inputargs.iter().enumerate() {
         let local_idx = 1 + ia.index;
         let offset = FRAME_SLOT_BASE + k as u64 * SLOT_SIZE;
-        sink.local_get(0)
-            .i64_load(mem64(offset))
-            .local_set(local_idx);
+        sink.local_get(0).i64_load(mem64(offset));
+        if value_types[ia.index as usize] == ValType::F64 {
+            sink.f64_reinterpret_i64();
+        }
+        sink.local_set(local_idx);
         if let Some(h) = ref_homes.home_id(ia.index) {
             sink.local_get(0);
             sink.local_get(local_idx);
@@ -1756,6 +1811,9 @@ fn build_function(
             for (i, la) in all_label_args[labels_passed].iter().enumerate() {
                 sink.local_get(0);
                 sink.i64_load(mem64(FRAME_SLOT_BASE + i as u64 * SLOT_SIZE));
+                if value_types[la.raw() as usize] == ValType::F64 {
+                    sink.f64_reinterpret_i64();
+                }
                 sink.local_set(1 + la.raw());
                 if let Some(h) = ref_homes.home(*la) {
                     sink.local_get(0);
@@ -1810,7 +1868,7 @@ fn build_function(
                 let jump_args = op.getarglist();
                 for (i, jump_arg) in jump_args.iter().enumerate() {
                     sink.local_get(0); // frame_ptr
-                    emit_resolve(&mut sink, constants, jump_arg.to_opref());
+                    emit_resolve(&mut sink, constants, value_types, jump_arg.to_opref());
                     sink.i64_store(mem64(FRAME_SLOT_BASE + i as u64 * SLOT_SIZE));
                 }
                 // Set the resume-at-LABEL dispatch key so a peeled target
@@ -1840,8 +1898,12 @@ fn build_function(
                 let label_args = find_label_args(ops, op);
                 let jump_args = op.getarglist();
                 let n = jump_args.len().min(label_args.len());
-                for jump_arg in jump_args.iter().take(n) {
-                    emit_resolve(&mut sink, constants, jump_arg.to_opref());
+                for (jump_arg, label_arg) in jump_args.iter().zip(label_args.iter()).take(n) {
+                    if value_types[label_arg.raw() as usize] == ValType::F64 {
+                        emit_resolve_f64(&mut sink, constants, value_types, jump_arg.to_opref());
+                    } else {
+                        emit_resolve(&mut sink, constants, value_types, jump_arg.to_opref());
+                    }
                 }
                 for i in (0..n).rev() {
                     sink.local_set(1 + label_args[i].raw());
@@ -1875,7 +1937,7 @@ fn build_function(
             }
 
             OpCode::Finish => {
-                emit_guard_exit(&mut sink, constants, guard_idx, op);
+                emit_guard_exit(&mut sink, constants, value_types, guard_idx, op);
                 if let Some(d) = block_exit_depth {
                     sink.br(d);
                 }
@@ -1884,31 +1946,75 @@ fn build_function(
 
             // ── Guards ──
             OpCode::GuardTrue => {
-                emit_guard_true(&mut sink, constants, guard_idx, op, block_exit_depth);
+                emit_guard_true(
+                    &mut sink,
+                    constants,
+                    value_types,
+                    guard_idx,
+                    op,
+                    block_exit_depth,
+                );
                 guard_idx += 1;
             }
             OpCode::GuardFalse => {
-                emit_guard_false(&mut sink, constants, guard_idx, op, block_exit_depth);
+                emit_guard_false(
+                    &mut sink,
+                    constants,
+                    value_types,
+                    guard_idx,
+                    op,
+                    block_exit_depth,
+                );
                 guard_idx += 1;
             }
             OpCode::GuardValue => {
-                emit_resolve(&mut sink, constants, op.arg(0).to_opref());
-                emit_resolve(&mut sink, constants, op.arg(1).to_opref());
-                sink.i64_ne();
-                emit_guard_if_exit(&mut sink, constants, guard_idx, op, block_exit_depth);
+                let arg0 = op.arg(0).to_opref();
+                let is_float =
+                    !arg0.is_constant() && value_types[arg0.raw() as usize] == ValType::F64;
+                if is_float {
+                    emit_resolve_f64(&mut sink, constants, value_types, arg0);
+                    emit_resolve_f64(&mut sink, constants, value_types, op.arg(1).to_opref());
+                    sink.f64_ne();
+                } else {
+                    emit_resolve(&mut sink, constants, value_types, arg0);
+                    emit_resolve(&mut sink, constants, value_types, op.arg(1).to_opref());
+                    sink.i64_ne();
+                }
+                emit_guard_if_exit(
+                    &mut sink,
+                    constants,
+                    value_types,
+                    guard_idx,
+                    op,
+                    block_exit_depth,
+                );
                 guard_idx += 1;
             }
             OpCode::GuardNonnull => {
-                emit_resolve(&mut sink, constants, op.arg(0).to_opref());
+                emit_resolve(&mut sink, constants, value_types, op.arg(0).to_opref());
                 sink.i64_eqz();
-                emit_guard_if_exit(&mut sink, constants, guard_idx, op, block_exit_depth);
+                emit_guard_if_exit(
+                    &mut sink,
+                    constants,
+                    value_types,
+                    guard_idx,
+                    op,
+                    block_exit_depth,
+                );
                 guard_idx += 1;
             }
             OpCode::GuardIsnull => {
-                emit_resolve(&mut sink, constants, op.arg(0).to_opref());
+                emit_resolve(&mut sink, constants, value_types, op.arg(0).to_opref());
                 sink.i64_const(0);
                 sink.i64_ne();
-                emit_guard_if_exit(&mut sink, constants, guard_idx, op, block_exit_depth);
+                emit_guard_if_exit(
+                    &mut sink,
+                    constants,
+                    value_types,
+                    guard_idx,
+                    op,
+                    block_exit_depth,
+                );
                 guard_idx += 1;
             }
             OpCode::GuardClass | OpCode::GuardNonnullClass => {
@@ -1922,7 +2028,7 @@ fn build_function(
                 //       _cmp_guard_gc_type(loc_ptr, ImmedLoc(expected_typeid))
                 if let Some(off_usize) = vtable_offset {
                     let off = off_usize as u64;
-                    emit_resolve(&mut sink, constants, op.arg(0).to_opref());
+                    emit_resolve(&mut sink, constants, value_types, op.arg(0).to_opref());
                     sink.i32_wrap_i64(); // struct ptr (i64) → i32 address
                     // The typeptr (`ob_type`) is a pointer-width field: 4
                     // bytes on wasm32. Reading it as i64 would fold in the
@@ -1934,7 +2040,7 @@ fn build_function(
                         memory_index: 0,
                     });
                     sink.i64_extend_i32_u();
-                    emit_resolve(&mut sink, constants, op.arg(1).to_opref());
+                    emit_resolve(&mut sink, constants, value_types, op.arg(1).to_opref());
                     sink.i64_ne();
                 } else {
                     // gcremovetypeptr fallback (assembler.py:1893-1901):
@@ -1952,7 +2058,7 @@ fn build_function(
                                  backend has no gc_ll_descr.\
                                  get_typeid_from_classptr_if_gcremovetypeptr",
                         );
-                    emit_resolve(&mut sink, constants, op.arg(0).to_opref());
+                    emit_resolve(&mut sink, constants, value_types, op.arg(0).to_opref());
                     sink.i32_wrap_i64();
                     sink.i32_load(MemArg {
                         offset: 0,
@@ -1962,7 +2068,14 @@ fn build_function(
                     sink.i32_const(expected_typeid as i32);
                     sink.i32_ne();
                 }
-                emit_guard_if_exit(&mut sink, constants, guard_idx, op, block_exit_depth);
+                emit_guard_if_exit(
+                    &mut sink,
+                    constants,
+                    value_types,
+                    guard_idx,
+                    op,
+                    block_exit_depth,
+                );
                 guard_idx += 1;
             }
             OpCode::GuardNoOverflow => {
@@ -1972,7 +2085,7 @@ fn build_function(
             }
             OpCode::GuardOverflow => {
                 // Always fails (no overflow detected in wasm MVP).
-                emit_guard_exit(&mut sink, constants, guard_idx, op);
+                emit_guard_exit(&mut sink, constants, value_types, guard_idx, op);
                 match block_exit_depth {
                     Some(d) => {
                         sink.br(d);
@@ -2008,7 +2121,14 @@ fn build_function(
                 sink.i64_load(mem64(0));
                 sink.i64_const(0);
                 sink.i64_ne();
-                emit_guard_if_exit(&mut sink, constants, guard_idx, op, block_exit_depth);
+                emit_guard_if_exit(
+                    &mut sink,
+                    constants,
+                    value_types,
+                    guard_idx,
+                    op,
+                    block_exit_depth,
+                );
                 guard_idx += 1;
             }
             OpCode::GuardException => {
@@ -2020,9 +2140,16 @@ fn build_function(
                 let exc_value_addr = crate::jit_exc_value_addr() as i32;
                 sink.i32_const(exc_type_addr);
                 sink.i64_load(mem64(0));
-                emit_resolve(&mut sink, constants, op.arg(0).to_opref());
+                emit_resolve(&mut sink, constants, value_types, op.arg(0).to_opref());
                 sink.i64_ne();
-                emit_guard_if_exit(&mut sink, constants, guard_idx, op, block_exit_depth);
+                emit_guard_if_exit(
+                    &mut sink,
+                    constants,
+                    value_types,
+                    guard_idx,
+                    op,
+                    block_exit_depth,
+                );
                 guard_idx += 1;
                 // Success path: capture the caught exception into the result
                 // var, then clear both slots.
@@ -2041,53 +2168,62 @@ fn build_function(
             }
 
             // ── Integer arithmetic ──
-            OpCode::IntAdd => emit_binop(&mut sink, constants, op, BinOp::I64Add),
-            OpCode::IntSub => emit_binop(&mut sink, constants, op, BinOp::I64Sub),
-            OpCode::IntMul => emit_binop(&mut sink, constants, op, BinOp::I64Mul),
-            OpCode::IntFloorDiv => emit_binop(&mut sink, constants, op, BinOp::I64DivS),
-            OpCode::IntMod => emit_binop(&mut sink, constants, op, BinOp::I64RemS),
-            OpCode::IntAnd => emit_binop(&mut sink, constants, op, BinOp::I64And),
-            OpCode::IntOr => emit_binop(&mut sink, constants, op, BinOp::I64Or),
-            OpCode::IntXor => emit_binop(&mut sink, constants, op, BinOp::I64Xor),
-            OpCode::IntLshift => emit_binop(&mut sink, constants, op, BinOp::I64Shl),
-            OpCode::IntRshift => emit_binop(&mut sink, constants, op, BinOp::I64ShrS),
-            OpCode::UintRshift => emit_binop(&mut sink, constants, op, BinOp::I64ShrU),
+            OpCode::IntAdd => emit_binop(&mut sink, constants, value_types, op, BinOp::I64Add),
+            OpCode::IntSub => emit_binop(&mut sink, constants, value_types, op, BinOp::I64Sub),
+            OpCode::IntMul => emit_binop(&mut sink, constants, value_types, op, BinOp::I64Mul),
+            OpCode::IntFloorDiv => {
+                emit_binop(&mut sink, constants, value_types, op, BinOp::I64DivS)
+            }
+            OpCode::IntMod => emit_binop(&mut sink, constants, value_types, op, BinOp::I64RemS),
+            OpCode::IntAnd => emit_binop(&mut sink, constants, value_types, op, BinOp::I64And),
+            OpCode::IntOr => emit_binop(&mut sink, constants, value_types, op, BinOp::I64Or),
+            OpCode::IntXor => emit_binop(&mut sink, constants, value_types, op, BinOp::I64Xor),
+            OpCode::IntLshift => emit_binop(&mut sink, constants, value_types, op, BinOp::I64Shl),
+            OpCode::IntRshift => emit_binop(&mut sink, constants, value_types, op, BinOp::I64ShrS),
+            OpCode::UintRshift => emit_binop(&mut sink, constants, value_types, op, BinOp::I64ShrU),
             // High 64 bits of the unsigned 64×64→128 product. The optimizer
             // emits this for division/modulo-by-constant strength reduction;
             // wasm has no mul-high instruction, so expand via 32-bit split.
-            OpCode::UintMulHigh => emit_umulhi(&mut sink, constants, op, num_vars),
+            OpCode::UintMulHigh => emit_umulhi(&mut sink, constants, value_types, op, num_vars),
 
             // Overflow variants: compute result + overflow flag
-            OpCode::IntAddOvf => emit_ovf_binop(&mut sink, constants, op, BinOp::I64Add),
-            OpCode::IntSubOvf => emit_ovf_binop(&mut sink, constants, op, BinOp::I64Sub),
-            OpCode::IntMulOvf => emit_ovf_binop(&mut sink, constants, op, BinOp::I64Mul),
+            OpCode::IntAddOvf => {
+                emit_ovf_binop(&mut sink, constants, value_types, op, BinOp::I64Add)
+            }
+            OpCode::IntSubOvf => {
+                emit_ovf_binop(&mut sink, constants, value_types, op, BinOp::I64Sub)
+            }
+            OpCode::IntMulOvf => {
+                emit_ovf_binop(&mut sink, constants, value_types, op, BinOp::I64Mul)
+            }
 
             // ── Integer comparisons (signed) ──
-            OpCode::IntLt => emit_cmp(&mut sink, constants, op, CmpOp::I64LtS),
-            OpCode::IntLe => emit_cmp(&mut sink, constants, op, CmpOp::I64LeS),
-            OpCode::IntEq => emit_cmp(&mut sink, constants, op, CmpOp::I64Eq),
-            OpCode::IntNe => emit_cmp(&mut sink, constants, op, CmpOp::I64Ne),
-            OpCode::IntGt => emit_cmp(&mut sink, constants, op, CmpOp::I64GtS),
-            OpCode::IntGe => emit_cmp(&mut sink, constants, op, CmpOp::I64GeS),
+            OpCode::IntLt => emit_cmp(&mut sink, constants, value_types, op, CmpOp::I64LtS),
+            OpCode::IntLe => emit_cmp(&mut sink, constants, value_types, op, CmpOp::I64LeS),
+            OpCode::IntEq => emit_cmp(&mut sink, constants, value_types, op, CmpOp::I64Eq),
+            OpCode::IntNe => emit_cmp(&mut sink, constants, value_types, op, CmpOp::I64Ne),
+            OpCode::IntGt => emit_cmp(&mut sink, constants, value_types, op, CmpOp::I64GtS),
+            OpCode::IntGe => emit_cmp(&mut sink, constants, value_types, op, CmpOp::I64GeS),
 
             // ── Integer comparisons (unsigned) ──
-            OpCode::UintLt => emit_cmp(&mut sink, constants, op, CmpOp::I64LtU),
-            OpCode::UintLe => emit_cmp(&mut sink, constants, op, CmpOp::I64LeU),
-            OpCode::UintGt => emit_cmp(&mut sink, constants, op, CmpOp::I64GtU),
-            OpCode::UintGe => emit_cmp(&mut sink, constants, op, CmpOp::I64GeU),
+            OpCode::UintLt => emit_cmp(&mut sink, constants, value_types, op, CmpOp::I64LtU),
+            OpCode::UintLe => emit_cmp(&mut sink, constants, value_types, op, CmpOp::I64LeU),
+            OpCode::UintGt => emit_cmp(&mut sink, constants, value_types, op, CmpOp::I64GtU),
+            OpCode::UintGe => emit_cmp(&mut sink, constants, value_types, op, CmpOp::I64GeU),
 
             // ── Pointer comparisons ──
             OpCode::PtrEq | OpCode::InstancePtrEq => {
-                emit_cmp(&mut sink, constants, op, CmpOp::I64Eq);
+                emit_cmp(&mut sink, constants, value_types, op, CmpOp::I64Eq);
             }
             OpCode::PtrNe | OpCode::InstancePtrNe => {
-                emit_cmp(&mut sink, constants, op, CmpOp::I64Ne);
+                emit_cmp(&mut sink, constants, value_types, op, CmpOp::I64Ne);
             }
 
             // ── Unary ops ──
             OpCode::IntNeg => emit_unary_vi(
                 &mut sink,
                 constants,
+                value_types,
                 op,
                 |s| {
                     s.i64_const(0);
@@ -2099,6 +2235,7 @@ fn build_function(
             OpCode::IntInvert => emit_unary_vi(
                 &mut sink,
                 constants,
+                value_types,
                 op,
                 |s| {
                     s.i64_const(-1);
@@ -2110,7 +2247,7 @@ fn build_function(
             OpCode::IntIsTrue => {
                 let vi = op.pos.get().raw();
                 if !OpRef::raw_is_constant(vi) {
-                    emit_resolve(&mut sink, constants, op.arg(0).to_opref());
+                    emit_resolve(&mut sink, constants, value_types, op.arg(0).to_opref());
                     sink.i64_const(0);
                     sink.i64_ne();
                     sink.i64_extend_i32_u();
@@ -2120,7 +2257,7 @@ fn build_function(
             OpCode::IntIsZero => {
                 let vi = op.pos.get().raw();
                 if !OpRef::raw_is_constant(vi) {
-                    emit_resolve(&mut sink, constants, op.arg(0).to_opref());
+                    emit_resolve(&mut sink, constants, value_types, op.arg(0).to_opref());
                     sink.i64_eqz();
                     sink.i64_extend_i32_u();
                     sink.local_set(1 + vi);
@@ -2132,7 +2269,7 @@ fn build_function(
                 // int_signext(val, num_bytes): sign-extend from num_bytes width
                 let vi = op.pos.get().raw();
                 if !OpRef::raw_is_constant(vi) {
-                    emit_resolve(&mut sink, constants, op.arg(0).to_opref());
+                    emit_resolve(&mut sink, constants, value_types, op.arg(0).to_opref());
                     // num_bytes is arg(1), typically a constant
                     let arg1 = op.arg(1).to_opref();
                     let num_bytes = if arg1.is_constant() {
@@ -2156,7 +2293,7 @@ fn build_function(
                 // max(val, 0)
                 let vi = op.pos.get().raw();
                 if !OpRef::raw_is_constant(vi) {
-                    emit_resolve(&mut sink, constants, op.arg(0).to_opref());
+                    emit_resolve(&mut sink, constants, value_types, op.arg(0).to_opref());
                     // if val < 0, use 0; else use val
                     // Wasm: local.tee + i64.const 0 + local.get + i64.lt_s + select
                     let tmp_local = 1 + vi; // reuse result local as temp
@@ -2171,24 +2308,21 @@ fn build_function(
             }
 
             // ── Float comparisons ──
-            OpCode::FloatLt => emit_float_cmp(&mut sink, constants, op, FloatCmp::Lt),
-            OpCode::FloatLe => emit_float_cmp(&mut sink, constants, op, FloatCmp::Le),
-            OpCode::FloatEq => emit_float_cmp(&mut sink, constants, op, FloatCmp::Eq),
-            OpCode::FloatNe => emit_float_cmp(&mut sink, constants, op, FloatCmp::Ne),
-            OpCode::FloatGt => emit_float_cmp(&mut sink, constants, op, FloatCmp::Gt),
-            OpCode::FloatGe => emit_float_cmp(&mut sink, constants, op, FloatCmp::Ge),
+            OpCode::FloatLt => emit_float_cmp(&mut sink, constants, value_types, op, FloatCmp::Lt),
+            OpCode::FloatLe => emit_float_cmp(&mut sink, constants, value_types, op, FloatCmp::Le),
+            OpCode::FloatEq => emit_float_cmp(&mut sink, constants, value_types, op, FloatCmp::Eq),
+            OpCode::FloatNe => emit_float_cmp(&mut sink, constants, value_types, op, FloatCmp::Ne),
+            OpCode::FloatGt => emit_float_cmp(&mut sink, constants, value_types, op, FloatCmp::Gt),
+            OpCode::FloatGe => emit_float_cmp(&mut sink, constants, value_types, op, FloatCmp::Ge),
 
             // ── Float floor/mod ──
             OpCode::FloatFloorDiv => {
                 let vi = op.pos.get().raw();
                 if !OpRef::raw_is_constant(vi) {
-                    emit_resolve(&mut sink, constants, op.arg(0).to_opref());
-                    sink.f64_reinterpret_i64();
-                    emit_resolve(&mut sink, constants, op.arg(1).to_opref());
-                    sink.f64_reinterpret_i64();
+                    emit_resolve_f64(&mut sink, constants, value_types, op.arg(0).to_opref());
+                    emit_resolve_f64(&mut sink, constants, value_types, op.arg(1).to_opref());
                     sink.f64_div();
                     sink.f64_floor();
-                    sink.i64_reinterpret_f64();
                     sink.local_set(1 + vi);
                 }
             }
@@ -2197,8 +2331,7 @@ fn build_function(
             OpCode::CastFloatToInt => {
                 let vi = op.pos.get().raw();
                 if !OpRef::raw_is_constant(vi) {
-                    emit_resolve(&mut sink, constants, op.arg(0).to_opref());
-                    sink.f64_reinterpret_i64();
+                    emit_resolve_f64(&mut sink, constants, value_types, op.arg(0).to_opref());
                     sink.i64_trunc_sat_f64_s();
                     sink.local_set(1 + vi);
                 }
@@ -2206,17 +2339,23 @@ fn build_function(
             OpCode::CastIntToFloat => {
                 let vi = op.pos.get().raw();
                 if !OpRef::raw_is_constant(vi) {
-                    emit_resolve(&mut sink, constants, op.arg(0).to_opref());
+                    emit_resolve(&mut sink, constants, value_types, op.arg(0).to_opref());
                     sink.f64_convert_i64_s();
-                    sink.i64_reinterpret_f64();
                     sink.local_set(1 + vi);
                 }
             }
-            OpCode::ConvertFloatBytesToLonglong | OpCode::ConvertLonglongBytesToFloat => {
-                // These are bitcast (no-op on the i64 representation)
+            OpCode::ConvertFloatBytesToLonglong => {
                 let vi = op.pos.get().raw();
                 if !OpRef::raw_is_constant(vi) {
-                    emit_resolve(&mut sink, constants, op.arg(0).to_opref());
+                    emit_resolve(&mut sink, constants, value_types, op.arg(0).to_opref());
+                    sink.local_set(1 + vi);
+                }
+            }
+            OpCode::ConvertLonglongBytesToFloat => {
+                let vi = op.pos.get().raw();
+                if !OpRef::raw_is_constant(vi) {
+                    emit_resolve(&mut sink, constants, value_types, op.arg(0).to_opref());
+                    sink.f64_reinterpret_i64();
                     sink.local_set(1 + vi);
                 }
             }
@@ -2225,16 +2364,23 @@ fn build_function(
             OpCode::CastPtrToInt | OpCode::CastIntToPtr | OpCode::CastOpaquePtr => {
                 let vi = op.pos.get().raw();
                 if !OpRef::raw_is_constant(vi) {
-                    emit_resolve(&mut sink, constants, op.arg(0).to_opref());
+                    emit_resolve(&mut sink, constants, value_types, op.arg(0).to_opref());
                     sink.local_set(1 + vi);
                 }
             }
 
             // ── SameAs (forwarding) ──
-            OpCode::SameAsI | OpCode::SameAsR | OpCode::SameAsF => {
+            OpCode::SameAsI | OpCode::SameAsR => {
                 let vi = op.pos.get().raw();
                 if !OpRef::raw_is_constant(vi) {
-                    emit_resolve(&mut sink, constants, op.arg(0).to_opref());
+                    emit_resolve(&mut sink, constants, value_types, op.arg(0).to_opref());
+                    sink.local_set(1 + vi);
+                }
+            }
+            OpCode::SameAsF => {
+                let vi = op.pos.get().raw();
+                if !OpRef::raw_is_constant(vi) {
+                    emit_resolve_f64(&mut sink, constants, value_types, op.arg(0).to_opref());
                     sink.local_set(1 + vi);
                 }
             }
@@ -2243,7 +2389,7 @@ fn build_function(
             OpCode::GetfieldGcI | OpCode::GetfieldGcPureI | OpCode::GetfieldRawI => {
                 let vi = op.pos.get().raw();
                 if !OpRef::raw_is_constant(vi) {
-                    emit_resolve(&mut sink, constants, op.arg(0).to_opref()); // struct ptr (i64)
+                    emit_resolve(&mut sink, constants, value_types, op.arg(0).to_opref()); // struct ptr (i64)
                     sink.i32_wrap_i64(); // convert to i32 address
                     let field_offset = field_offset_from_descr(op);
                     let (size, signed) = field_size_sign_from_descr(op);
@@ -2254,7 +2400,7 @@ fn build_function(
             OpCode::GetfieldGcR | OpCode::GetfieldGcPureR | OpCode::GetfieldRawR => {
                 let vi = op.pos.get().raw();
                 if !OpRef::raw_is_constant(vi) {
-                    emit_resolve(&mut sink, constants, op.arg(0).to_opref());
+                    emit_resolve(&mut sink, constants, value_types, op.arg(0).to_opref());
                     sink.i32_wrap_i64();
                     let field_offset = field_offset_from_descr(op);
                     // Load as i32 (pointer on wasm32) and extend to i64
@@ -2272,6 +2418,7 @@ fn build_function(
                     emit_write_barrier(
                         &mut sink,
                         constants,
+                        value_types,
                         jit_call_idx,
                         residual_type_base,
                         wb_fn_ptr,
@@ -2279,19 +2426,28 @@ fn build_function(
                         frame,
                     );
                 }
-                emit_resolve(&mut sink, constants, op.arg(0).to_opref()); // struct ptr
+                emit_resolve(&mut sink, constants, value_types, op.arg(0).to_opref()); // struct ptr
                 sink.i32_wrap_i64();
                 let field_offset = field_offset_from_descr(op);
-                emit_resolve(&mut sink, constants, op.arg(1).to_opref()); // value
-                let size = setfield_store_size_from_descr(op);
-                emit_sized_int_store(&mut sink, field_offset, size);
+                if field_is_float_from_descr(op) {
+                    emit_resolve_f64(&mut sink, constants, value_types, op.arg(1).to_opref());
+                    sink.f64_store(MemArg {
+                        offset: field_offset,
+                        align: 3,
+                        memory_index: 0,
+                    });
+                } else {
+                    emit_resolve(&mut sink, constants, value_types, op.arg(1).to_opref()); // value
+                    let size = setfield_store_size_from_descr(op);
+                    emit_sized_int_store(&mut sink, field_offset, size);
+                }
             }
 
             // ── Float field access ──
             OpCode::GetfieldGcF | OpCode::GetfieldGcPureF | OpCode::GetfieldRawF => {
                 let vi = op.pos.get().raw();
                 if !OpRef::raw_is_constant(vi) {
-                    emit_resolve(&mut sink, constants, op.arg(0).to_opref());
+                    emit_resolve(&mut sink, constants, value_types, op.arg(0).to_opref());
                     sink.i32_wrap_i64();
                     let field_offset = field_offset_from_descr(op);
                     sink.f64_load(MemArg {
@@ -2299,7 +2455,6 @@ fn build_function(
                         align: 3,
                         memory_index: 0,
                     });
-                    sink.i64_reinterpret_f64();
                     sink.local_set(1 + vi);
                 }
             }
@@ -2308,7 +2463,7 @@ fn build_function(
             OpCode::ArraylenGc => {
                 let vi = op.pos.get().raw();
                 if !OpRef::raw_is_constant(vi) {
-                    emit_resolve(&mut sink, constants, op.arg(0).to_opref()); // array ptr
+                    emit_resolve(&mut sink, constants, value_types, op.arg(0).to_opref()); // array ptr
                     sink.i32_wrap_i64();
                     let (len_offset, len_size) = array_len_layout_from_descr(op);
                     // The length is a word-sized field (`Signed`/`WORD`): read it
@@ -2322,7 +2477,7 @@ fn build_function(
                 let vi = op.pos.get().raw();
                 if !OpRef::raw_is_constant(vi) {
                     // addr = base + base_size + index * item_size
-                    emit_array_addr(&mut sink, constants, op);
+                    emit_array_addr(&mut sink, constants, value_types, op);
                     let (item_size, signed) = array_item_size_sign_from_descr(op);
                     emit_sized_int_load(&mut sink, 0, item_size, signed);
                     sink.local_set(1 + vi);
@@ -2331,7 +2486,7 @@ fn build_function(
             OpCode::GetarrayitemGcR | OpCode::GetarrayitemGcPureR | OpCode::GetarrayitemRawR => {
                 let vi = op.pos.get().raw();
                 if !OpRef::raw_is_constant(vi) {
-                    emit_array_addr(&mut sink, constants, op);
+                    emit_array_addr(&mut sink, constants, value_types, op);
                     sink.i32_load(MemArg {
                         offset: 0,
                         align: 2,
@@ -2344,16 +2499,12 @@ fn build_function(
             OpCode::GetarrayitemGcF | OpCode::GetarrayitemGcPureF | OpCode::GetarrayitemRawF => {
                 let vi = op.pos.get().raw();
                 if !OpRef::raw_is_constant(vi) {
-                    // A Float item is 8 bytes; load it as f64 and carry its bit
-                    // pattern in the i64 value slot (the IntArray/value-slot ABI
-                    // is i64).
-                    emit_array_addr(&mut sink, constants, op);
+                    emit_array_addr(&mut sink, constants, value_types, op);
                     sink.f64_load(MemArg {
                         offset: 0,
                         align: 3,
                         memory_index: 0,
                     });
-                    sink.i64_reinterpret_f64();
                     sink.local_set(1 + vi);
                 }
             }
@@ -2362,6 +2513,7 @@ fn build_function(
                     emit_write_barrier(
                         &mut sink,
                         constants,
+                        value_types,
                         jit_call_idx,
                         residual_type_base,
                         wb_fn_ptr,
@@ -2369,14 +2521,18 @@ fn build_function(
                         frame,
                     );
                 }
-                emit_array_addr(&mut sink, constants, op);
-                emit_resolve(&mut sink, constants, op.arg(2).to_opref()); // value
-                // A Ref item is pointer-width (4 bytes on wasm32). Storing a
-                // fixed 8 bytes would clobber the next item, or run past the
-                // array end on the last item and corrupt the heap. A Float
-                // item is 8 bytes, so its bit pattern stores via the i64 path.
-                let (item_size, _signed) = array_item_size_sign_from_descr(op);
-                emit_sized_int_store(&mut sink, 0, item_size);
+                emit_array_addr(&mut sink, constants, value_types, op);
+                if array_item_is_float_from_descr(op) {
+                    emit_resolve_f64(&mut sink, constants, value_types, op.arg(2).to_opref());
+                    sink.f64_store(mem64(0));
+                } else {
+                    emit_resolve(&mut sink, constants, value_types, op.arg(2).to_opref()); // value
+                    // A Ref item is pointer-width (4 bytes on wasm32). Storing a
+                    // fixed 8 bytes would clobber the next item, or run past the
+                    // array end on the last item and corrupt the heap.
+                    let (item_size, _signed) = array_item_size_sign_from_descr(op);
+                    emit_sized_int_store(&mut sink, 0, item_size);
+                }
             }
 
             // ── Interior field access ──
@@ -2384,7 +2540,7 @@ fn build_function(
                 let vi = op.pos.get().raw();
                 if !OpRef::raw_is_constant(vi) {
                     // getinteriorfield(array, index, offset)
-                    emit_resolve(&mut sink, constants, op.arg(0).to_opref()); // array ptr
+                    emit_resolve(&mut sink, constants, value_types, op.arg(0).to_opref()); // array ptr
                     sink.i32_wrap_i64();
                     let field_offset = field_offset_from_descr(op);
                     // Simplified: use field_offset directly (RPython computes base+index*itemsize+offset)
@@ -2396,7 +2552,7 @@ fn build_function(
             OpCode::GetinteriorfieldGcF => {
                 let vi = op.pos.get().raw();
                 if !OpRef::raw_is_constant(vi) {
-                    emit_resolve(&mut sink, constants, op.arg(0).to_opref()); // array ptr
+                    emit_resolve(&mut sink, constants, value_types, op.arg(0).to_opref()); // array ptr
                     sink.i32_wrap_i64();
                     let field_offset = field_offset_from_descr(op);
                     sink.f64_load(MemArg {
@@ -2404,7 +2560,6 @@ fn build_function(
                         align: 3,
                         memory_index: 0,
                     });
-                    sink.i64_reinterpret_f64();
                     sink.local_set(1 + vi);
                 }
             }
@@ -2413,6 +2568,7 @@ fn build_function(
                     emit_write_barrier(
                         &mut sink,
                         constants,
+                        value_types,
                         jit_call_idx,
                         residual_type_base,
                         wb_fn_ptr,
@@ -2420,19 +2576,28 @@ fn build_function(
                         frame,
                     );
                 }
-                emit_resolve(&mut sink, constants, op.arg(0).to_opref());
+                emit_resolve(&mut sink, constants, value_types, op.arg(0).to_opref());
                 sink.i32_wrap_i64();
                 let field_offset = field_offset_from_descr(op);
-                emit_resolve(&mut sink, constants, op.arg(2).to_opref()); // value
-                let (size, _signed) = field_size_sign_from_descr(op);
-                emit_sized_int_store(&mut sink, field_offset, size);
+                if field_is_float_from_descr(op) {
+                    emit_resolve_f64(&mut sink, constants, value_types, op.arg(2).to_opref());
+                    sink.f64_store(MemArg {
+                        offset: field_offset,
+                        align: 3,
+                        memory_index: 0,
+                    });
+                } else {
+                    emit_resolve(&mut sink, constants, value_types, op.arg(2).to_opref()); // value
+                    let (size, _signed) = field_size_sign_from_descr(op);
+                    emit_sized_int_store(&mut sink, field_offset, size);
+                }
             }
 
             // ── String/Unicode ops (direct memory access) ──
             OpCode::Strlen | OpCode::Unicodelen => {
                 let vi = op.pos.get().raw();
                 if !OpRef::raw_is_constant(vi) {
-                    emit_resolve(&mut sink, constants, op.arg(0).to_opref());
+                    emit_resolve(&mut sink, constants, value_types, op.arg(0).to_opref());
                     sink.i32_wrap_i64();
                     // Length at offset 8 (after ob_type pointer on wasm32)
                     sink.i64_load(mem64(8));
@@ -2443,9 +2608,9 @@ fn build_function(
                 let vi = op.pos.get().raw();
                 if !OpRef::raw_is_constant(vi) {
                     // str[index]: base + header_size + index
-                    emit_resolve(&mut sink, constants, op.arg(0).to_opref());
+                    emit_resolve(&mut sink, constants, value_types, op.arg(0).to_opref());
                     sink.i32_wrap_i64();
-                    emit_resolve(&mut sink, constants, op.arg(1).to_opref()); // index
+                    emit_resolve(&mut sink, constants, value_types, op.arg(1).to_opref()); // index
                     sink.i32_wrap_i64();
                     sink.i32_add();
                     // String data starts after header (assume 16 bytes: ob_type + length)
@@ -2463,7 +2628,7 @@ fn build_function(
             OpCode::GcLoadI => {
                 let vi = op.pos.get().raw();
                 if !OpRef::raw_is_constant(vi) {
-                    emit_resolve(&mut sink, constants, op.arg(0).to_opref());
+                    emit_resolve(&mut sink, constants, value_types, op.arg(0).to_opref());
                     sink.i32_wrap_i64();
                     let offset = field_offset_from_descr(op);
                     sink.i64_load(mem64(offset));
@@ -2473,7 +2638,7 @@ fn build_function(
             OpCode::GcLoadR => {
                 let vi = op.pos.get().raw();
                 if !OpRef::raw_is_constant(vi) {
-                    emit_resolve(&mut sink, constants, op.arg(0).to_opref());
+                    emit_resolve(&mut sink, constants, value_types, op.arg(0).to_opref());
                     sink.i32_wrap_i64();
                     let offset = field_offset_from_descr(op);
                     sink.i32_load(MemArg {
@@ -2486,10 +2651,10 @@ fn build_function(
                 }
             }
             OpCode::GcStore => {
-                emit_resolve(&mut sink, constants, op.arg(0).to_opref());
+                emit_resolve(&mut sink, constants, value_types, op.arg(0).to_opref());
                 sink.i32_wrap_i64();
                 let offset = field_offset_from_descr(op);
-                emit_resolve(&mut sink, constants, op.arg(1).to_opref());
+                emit_resolve(&mut sink, constants, value_types, op.arg(1).to_opref());
                 sink.i64_store(mem64(offset));
             }
 
@@ -2497,9 +2662,9 @@ fn build_function(
             OpCode::RawLoadI => {
                 let vi = op.pos.get().raw();
                 if !OpRef::raw_is_constant(vi) {
-                    emit_resolve(&mut sink, constants, op.arg(0).to_opref()); // ptr
+                    emit_resolve(&mut sink, constants, value_types, op.arg(0).to_opref()); // ptr
                     sink.i32_wrap_i64();
-                    emit_resolve(&mut sink, constants, op.arg(1).to_opref()); // offset
+                    emit_resolve(&mut sink, constants, value_types, op.arg(1).to_opref()); // offset
                     sink.i32_wrap_i64();
                     sink.i32_add();
                     sink.i64_load(mem64(0));
@@ -2507,12 +2672,12 @@ fn build_function(
                 }
             }
             OpCode::RawStore => {
-                emit_resolve(&mut sink, constants, op.arg(0).to_opref());
+                emit_resolve(&mut sink, constants, value_types, op.arg(0).to_opref());
                 sink.i32_wrap_i64();
-                emit_resolve(&mut sink, constants, op.arg(1).to_opref());
+                emit_resolve(&mut sink, constants, value_types, op.arg(1).to_opref());
                 sink.i32_wrap_i64();
                 sink.i32_add();
-                emit_resolve(&mut sink, constants, op.arg(2).to_opref());
+                emit_resolve(&mut sink, constants, value_types, op.arg(2).to_opref());
                 sink.i64_store(mem64(0));
             }
 
@@ -2544,7 +2709,7 @@ fn build_function(
             OpCode::GuardGcType => {
                 let _ = classptr_to_typeid; // typeid is already an immediate
                 if op.num_args() >= 2 {
-                    emit_resolve(&mut sink, constants, op.arg(0).to_opref());
+                    emit_resolve(&mut sink, constants, value_types, op.arg(0).to_opref());
                     // header address = obj - GcHeader::SIZE
                     sink.i64_const(GcHeader::SIZE as i64);
                     sink.i64_sub();
@@ -2556,9 +2721,16 @@ fn build_function(
                     sink.i64_and();
                     // Compare against expected_typeid (arg1 — already an
                     // i64 in the constant pool or a frame slot).
-                    emit_resolve(&mut sink, constants, op.arg(1).to_opref());
+                    emit_resolve(&mut sink, constants, value_types, op.arg(1).to_opref());
                     sink.i64_ne();
-                    emit_guard_if_exit(&mut sink, constants, guard_idx, op, block_exit_depth);
+                    emit_guard_if_exit(
+                        &mut sink,
+                        constants,
+                        value_types,
+                        guard_idx,
+                        op,
+                        block_exit_depth,
+                    );
                 }
                 guard_idx += 1;
             }
@@ -2593,7 +2765,7 @@ fn build_function(
                 // assembler.py:1931-1932 MOV32 loc_typeid, mem(loc_object, 0).
                 // majit's GC header sits at obj - GcHeader::SIZE; the
                 // typeid occupies the lower TYPE_ID_BITS of that word.
-                emit_resolve(&mut sink, constants, op.arg(0).to_opref());
+                emit_resolve(&mut sink, constants, value_types, op.arg(0).to_opref());
                 sink.i64_const(GcHeader::SIZE as i64);
                 sink.i64_sub();
                 sink.i32_wrap_i64();
@@ -2626,7 +2798,14 @@ fn build_function(
                 // assembler.py:1942 guard_success_cc = Conditions['NZ']:
                 // guard passes when byte & flag != 0; fail when == 0.
                 sink.i32_eqz();
-                emit_guard_if_exit(&mut sink, constants, guard_idx, op, block_exit_depth);
+                emit_guard_if_exit(
+                    &mut sink,
+                    constants,
+                    value_types,
+                    guard_idx,
+                    op,
+                    block_exit_depth,
+                );
                 guard_idx += 1;
             }
             // x86/assembler.py:1945-1980 genop_guard_guard_subclass.
@@ -2695,7 +2874,7 @@ fn build_function(
                     // assembler.py:1953-1956
                     //     MOV_rm(loc_tmp, (loc_object, offset))
                     //     MOV_rm(loc_tmp, (loc_tmp, offset2))
-                    emit_resolve(&mut sink, constants, op.arg(0).to_opref());
+                    emit_resolve(&mut sink, constants, value_types, op.arg(0).to_opref());
                     sink.i32_wrap_i64();
                     sink.i64_load(mem64(vtable_off as u64));
                     sink.i32_wrap_i64();
@@ -2707,7 +2886,7 @@ fn build_function(
                     //     MOV loc_tmp, [base_type_info
                     //         + (loc_tmp << shift_by)
                     //         + sizeof_ti + offset2]
-                    emit_resolve(&mut sink, constants, op.arg(0).to_opref());
+                    emit_resolve(&mut sink, constants, value_types, op.arg(0).to_opref());
                     sink.i64_const(GcHeader::SIZE as i64);
                     sink.i64_sub();
                     sink.i32_wrap_i64();
@@ -2735,12 +2914,19 @@ fn build_function(
                 // assembler.py:1979 guard_success_cc = Conditions['B']:
                 // guard passes when sub <u limit; fail when sub >=u limit.
                 sink.i64_ge_u();
-                emit_guard_if_exit(&mut sink, constants, guard_idx, op, block_exit_depth);
+                emit_guard_if_exit(
+                    &mut sink,
+                    constants,
+                    value_types,
+                    guard_idx,
+                    op,
+                    block_exit_depth,
+                );
                 guard_idx += 1;
             }
             OpCode::GuardFutureCondition | OpCode::GuardAlwaysFails => {
                 // GuardAlwaysFails always exits.
-                emit_guard_exit(&mut sink, constants, guard_idx, op);
+                emit_guard_exit(&mut sink, constants, value_types, guard_idx, op);
                 if let Some(d) = block_exit_depth {
                     sink.br(d);
                 }
@@ -2763,7 +2949,7 @@ fn build_function(
                 if let Some(jit_call) = jit_call_idx {
                     let vi = op.pos.get().raw();
                     sink.local_get(0);
-                    emit_resolve(&mut sink, constants, op.arg(0).to_opref()); // length
+                    emit_resolve(&mut sink, constants, value_types, op.arg(0).to_opref()); // length
                     sink.i64_store(mem64(frame.call_args_ofs));
                     sink.local_get(0);
                     sink.i64_const(0); // func_ptr = 0 signals "newstr" to host
@@ -2790,8 +2976,8 @@ fn build_function(
             OpCode::NurseryPtrIncrement => {
                 let vi = op.pos.get().raw();
                 if !OpRef::raw_is_constant(vi) {
-                    emit_resolve(&mut sink, constants, op.arg(0).to_opref());
-                    emit_resolve(&mut sink, constants, op.arg(1).to_opref());
+                    emit_resolve(&mut sink, constants, value_types, op.arg(0).to_opref());
+                    emit_resolve(&mut sink, constants, value_types, op.arg(1).to_opref());
                     sink.i64_add();
                     sink.local_set(1 + vi);
                 }
@@ -2999,10 +3185,10 @@ fn build_function(
                 sink.i64_store(mem64(frame.dispatch_key_ofs));
                 // inputs: F'[1] = arg0 (callee frame), F'[2] = arg1 (ec).
                 sink.local_get(ca_cfp_local);
-                emit_resolve(&mut sink, constants, op.arg(0).to_opref());
+                emit_resolve(&mut sink, constants, value_types, op.arg(0).to_opref());
                 sink.i64_store(mem64(FRAME_SLOT_BASE));
                 sink.local_get(ca_cfp_local);
-                emit_resolve(&mut sink, constants, op.arg(1).to_opref());
+                emit_resolve(&mut sink, constants, value_types, op.arg(1).to_opref());
                 sink.i64_store(mem64(FRAME_SLOT_BASE + SLOT_SIZE));
                 // run the source loop on F' (non-tail: one wasm frame per
                 // recursion level); discard the returned frame_ptr.
@@ -3176,10 +3362,10 @@ fn build_function(
                 {
                     let call_args = &op.getarglist()[1..];
                     for arg in call_args {
-                        emit_resolve(&mut sink, constants, arg.to_opref());
+                        emit_resolve(&mut sink, constants, value_types, arg.to_opref());
                     }
                     // func_ptr (arg 0) is the table slot — wrap to i32 index.
-                    emit_resolve(&mut sink, constants, op.arg(0).to_opref());
+                    emit_resolve(&mut sink, constants, value_types, op.arg(0).to_opref());
                     sink.i32_wrap_i64();
                     // call_indirect(table_index, type_index): table 0, type for arity n.
                     sink.call_indirect(0, base + nargs as u32);
@@ -3212,9 +3398,9 @@ fn build_function(
                     // the i64 family and drop the dummy result.
                     let call_args = &op.getarglist()[1..];
                     for arg in call_args {
-                        emit_resolve(&mut sink, constants, arg.to_opref());
+                        emit_resolve(&mut sink, constants, value_types, arg.to_opref());
                     }
-                    emit_resolve(&mut sink, constants, op.arg(0).to_opref());
+                    emit_resolve(&mut sink, constants, value_types, op.arg(0).to_opref());
                     sink.i32_wrap_i64();
                     sink.call_indirect(0, base + nargs as u32);
                     sink.drop();
@@ -3232,24 +3418,21 @@ fn build_function(
                         .get(&sig)
                         .map(|type_idx| (sig, type_idx))
                 }) {
-                    // Direct in-module float residual call. Float SSA values
-                    // are i64 bit carriers, while the target's table entry has
-                    // the descr-derived mixed `(i64/f64...) -> f64` signature.
+                    // Direct in-module float residual call with the
+                    // descr-derived mixed `(i64/f64...) -> f64` signature.
                     let call_args = &op.getarglist()[1..];
                     debug_assert_eq!(call_args.len(), sig.len());
                     for (arg, ty) in call_args.iter().zip(&sig) {
-                        emit_resolve(&mut sink, constants, arg.to_opref());
                         if *ty == ValType::F64 {
-                            sink.f64_reinterpret_i64();
+                            emit_resolve_f64(&mut sink, constants, value_types, arg.to_opref());
+                        } else {
+                            emit_resolve(&mut sink, constants, value_types, arg.to_opref());
                         }
                     }
                     // func_ptr (arg 0) is the table slot — wrap to i32 index.
-                    emit_resolve(&mut sink, constants, op.arg(0).to_opref());
+                    emit_resolve(&mut sink, constants, value_types, op.arg(0).to_opref());
                     sink.i32_wrap_i64();
                     sink.call_indirect(0, type_idx);
-                    // Retain Float's i64 SSA carrier after the f64-returning
-                    // table entry has completed.
-                    sink.i64_reinterpret_f64();
                     if !OpRef::raw_is_constant(vi) {
                         sink.local_set(1 + vi);
                     } else {
@@ -3278,7 +3461,7 @@ fn build_function(
 
                     // Store func_ptr to call area
                     sink.local_get(0);
-                    emit_resolve(&mut sink, constants, func_ptr_ref);
+                    emit_resolve(&mut sink, constants, value_types, func_ptr_ref);
                     sink.i64_store(mem64(frame.call_func_ofs));
 
                     // Store num_args
@@ -3289,7 +3472,7 @@ fn build_function(
                     // Store each arg
                     for (i, arg) in call_args.iter().enumerate() {
                         sink.local_get(0);
-                        emit_resolve(&mut sink, constants, arg.to_opref());
+                        emit_resolve(&mut sink, constants, value_types, arg.to_opref());
                         sink.i64_store(mem64(frame.call_args_ofs + i as u64 * SLOT_SIZE));
                     }
 
@@ -3310,6 +3493,9 @@ fn build_function(
                     if !OpRef::raw_is_constant(vi) && !is_void {
                         sink.local_get(0);
                         sink.i64_load(mem64(frame.call_result_ofs));
+                        if value_types[vi as usize] == ValType::F64 {
+                            sink.f64_reinterpret_i64();
+                        }
                         sink.local_set(1 + vi);
                     }
                     // Mirror the direct path: a trampoline residual call may force and collect.
@@ -3669,14 +3855,14 @@ fn build_function(
                 {
                     // malloc_cond_varsize: negative lengths compare greater in
                     // the unsigned precheck and go to the collecting slow path.
-                    emit_resolve(&mut sink, constants, op.arg(0).to_opref());
+                    emit_resolve(&mut sink, constants, value_types, op.arg(0).to_opref());
                     sink.i64_const(max_len);
                     sink.i64_gt_u();
                     sink.if_(BlockType::Result(ValType::I64));
                     sink.i64_const(type_id);
                     sink.i64_const(base_size);
                     sink.i64_const(item_size);
-                    emit_resolve(&mut sink, constants, op.arg(0).to_opref());
+                    emit_resolve(&mut sink, constants, value_types, op.arg(0).to_opref());
                     sink.i64_const(len_offset);
                     sink.i32_const(alloc_array_fn_ptr as i32);
                     sink.call_indirect(0, base + 5);
@@ -3697,7 +3883,7 @@ fn build_function(
                     sink.else_();
                     // total = round_up_8(max(header + base + item * length,
                     // MIN_NURSERY_OBJ_SIZE)).
-                    emit_resolve(&mut sink, constants, op.arg(0).to_opref());
+                    emit_resolve(&mut sink, constants, value_types, op.arg(0).to_opref());
                     sink.i64_const(item_size);
                     sink.i64_mul();
                     sink.i64_const(base_total);
@@ -3740,7 +3926,7 @@ fn build_function(
                     sink.i64_const(type_id);
                     sink.i64_const(base_size);
                     sink.i64_const(item_size);
-                    emit_resolve(&mut sink, constants, op.arg(0).to_opref());
+                    emit_resolve(&mut sink, constants, value_types, op.arg(0).to_opref());
                     sink.i64_const(len_offset);
                     sink.i32_const(alloc_array_fn_ptr as i32);
                     sink.call_indirect(0, base + 5);
@@ -3778,7 +3964,7 @@ fn build_function(
                     // Length field (usize, 4 bytes on wasm32) at
                     // `payload + len_offset`.
                     sink.local_get(alloc_scratch_local);
-                    emit_resolve(&mut sink, constants, op.arg(0).to_opref());
+                    emit_resolve(&mut sink, constants, value_types, op.arg(0).to_opref());
                     sink.i32_wrap_i64();
                     sink.i32_store(MemArg {
                         offset: majit_gc::header::GcHeader::SIZE as u64 + len_offset as u64,
@@ -3804,7 +3990,7 @@ fn build_function(
                     sink.i64_const(type_id);
                     sink.i64_const(base_size);
                     sink.i64_const(item_size);
-                    emit_resolve(&mut sink, constants, op.arg(0).to_opref());
+                    emit_resolve(&mut sink, constants, value_types, op.arg(0).to_opref());
                     sink.i64_const(len_offset);
                     sink.i32_const(alloc_array_fn_ptr as i32);
                     sink.call_indirect(0, base + 5);
@@ -3838,7 +4024,7 @@ fn build_function(
                     sink.i64_store(mem64(frame.call_args_ofs + 2 * SLOT_SIZE));
                     // arg3 = length (op.arg(0))
                     sink.local_get(0);
-                    emit_resolve(&mut sink, constants, op.arg(0).to_opref());
+                    emit_resolve(&mut sink, constants, value_types, op.arg(0).to_opref());
                     sink.i64_store(mem64(frame.call_args_ofs + 3 * SLOT_SIZE));
                     // arg4 = len_offset
                     sink.local_get(0);
@@ -3885,11 +4071,8 @@ fn build_function(
             OpCode::FloatAdd | OpCode::FloatSub | OpCode::FloatMul | OpCode::FloatTrueDiv => {
                 let vi = op.pos.get().raw();
                 if !OpRef::raw_is_constant(vi) {
-                    // Values stored as i64 (bitcast from f64)
-                    emit_resolve(&mut sink, constants, op.arg(0).to_opref());
-                    sink.f64_reinterpret_i64();
-                    emit_resolve(&mut sink, constants, op.arg(1).to_opref());
-                    sink.f64_reinterpret_i64();
+                    emit_resolve_f64(&mut sink, constants, value_types, op.arg(0).to_opref());
+                    emit_resolve_f64(&mut sink, constants, value_types, op.arg(1).to_opref());
                     match op.opcode {
                         OpCode::FloatAdd => {
                             sink.f64_add();
@@ -3905,27 +4088,22 @@ fn build_function(
                         }
                         _ => unreachable!(),
                     }
-                    sink.i64_reinterpret_f64();
                     sink.local_set(1 + vi);
                 }
             }
             OpCode::FloatNeg => {
                 let vi = op.pos.get().raw();
                 if !OpRef::raw_is_constant(vi) {
-                    emit_resolve(&mut sink, constants, op.arg(0).to_opref());
-                    sink.f64_reinterpret_i64();
+                    emit_resolve_f64(&mut sink, constants, value_types, op.arg(0).to_opref());
                     sink.f64_neg();
-                    sink.i64_reinterpret_f64();
                     sink.local_set(1 + vi);
                 }
             }
             OpCode::FloatAbs => {
                 let vi = op.pos.get().raw();
                 if !OpRef::raw_is_constant(vi) {
-                    emit_resolve(&mut sink, constants, op.arg(0).to_opref());
-                    sink.f64_reinterpret_i64();
+                    emit_resolve_f64(&mut sink, constants, value_types, op.arg(0).to_opref());
                     sink.f64_abs();
-                    sink.i64_reinterpret_f64();
                     sink.local_set(1 + vi);
                 }
             }
@@ -4149,6 +4327,7 @@ fn find_label_args(ops: &[Op], jump: &Op) -> Vec<OpRef> {
 fn emit_resolve(
     sink: &mut InstructionSink<'_>,
     constants: &indexmap::IndexMap<u32, i64>,
+    value_types: &[ValType],
     opref: OpRef,
 ) {
     if opref.is_constant() {
@@ -4158,6 +4337,29 @@ fn emit_resolve(
             .unwrap_or_else(|| constants.get(&opref.raw()).copied().unwrap_or(0));
         sink.i64_const(val);
     } else {
+        sink.local_get(1 + opref.raw());
+        if value_types[opref.raw() as usize] == ValType::F64 {
+            sink.i64_reinterpret_f64();
+        }
+    }
+}
+
+/// Resolve a Float operand as f64. Constants retain their i64 bit encoding in
+/// the constant pool and are converted at the local boundary.
+fn emit_resolve_f64(
+    sink: &mut InstructionSink<'_>,
+    constants: &indexmap::IndexMap<u32, i64>,
+    value_types: &[ValType],
+    opref: OpRef,
+) {
+    if opref.is_constant() {
+        let val = opref
+            .inline_const_bits()
+            .unwrap_or_else(|| constants.get(&opref.raw()).copied().unwrap_or(0));
+        sink.i64_const(val);
+        sink.f64_reinterpret_i64();
+    } else {
+        debug_assert_eq!(value_types[opref.raw() as usize], ValType::F64);
         sink.local_get(1 + opref.raw());
     }
 }
@@ -4205,15 +4407,16 @@ fn array_len_layout_from_descr(op: &Op) -> (u64, usize) {
 fn emit_array_addr(
     sink: &mut InstructionSink<'_>,
     constants: &indexmap::IndexMap<u32, i64>,
+    value_types: &[ValType],
     op: &Op,
 ) {
     let (base_size, item_size) = op
         .with_array_descr(|ad| (ad.base_size() as u64, ad.item_size() as u64))
         .unwrap_or((16, 8));
-    emit_resolve(sink, constants, op.arg(0).to_opref()); // array ptr
+    emit_resolve(sink, constants, value_types, op.arg(0).to_opref()); // array ptr
     sink.i32_wrap_i64();
     // base + base_size + index * item_size
-    emit_resolve(sink, constants, op.arg(1).to_opref()); // index
+    emit_resolve(sink, constants, value_types, op.arg(1).to_opref()); // index
     sink.i32_wrap_i64();
     sink.i32_const(item_size as i32);
     sink.i32_mul();
@@ -4227,26 +4430,42 @@ fn emit_array_addr(
 fn emit_guard_true(
     sink: &mut InstructionSink<'_>,
     constants: &indexmap::IndexMap<u32, i64>,
+    value_types: &[ValType],
     guard_idx: u32,
     op: &Op,
     block_exit_depth: Option<u32>,
 ) {
-    emit_resolve(sink, constants, op.arg(0).to_opref());
+    emit_resolve(sink, constants, value_types, op.arg(0).to_opref());
     sink.i64_eqz();
-    emit_guard_if_exit(sink, constants, guard_idx, op, block_exit_depth);
+    emit_guard_if_exit(
+        sink,
+        constants,
+        value_types,
+        guard_idx,
+        op,
+        block_exit_depth,
+    );
 }
 
 fn emit_guard_false(
     sink: &mut InstructionSink<'_>,
     constants: &indexmap::IndexMap<u32, i64>,
+    value_types: &[ValType],
     guard_idx: u32,
     op: &Op,
     block_exit_depth: Option<u32>,
 ) {
-    emit_resolve(sink, constants, op.arg(0).to_opref());
+    emit_resolve(sink, constants, value_types, op.arg(0).to_opref());
     sink.i64_const(0);
     sink.i64_ne();
-    emit_guard_if_exit(sink, constants, guard_idx, op, block_exit_depth);
+    emit_guard_if_exit(
+        sink,
+        constants,
+        value_types,
+        guard_idx,
+        op,
+        block_exit_depth,
+    );
 }
 
 /// Common guard exit: condition is on stack (i32), emit if + exit.
@@ -4257,12 +4476,13 @@ fn emit_guard_false(
 fn emit_guard_if_exit(
     sink: &mut InstructionSink<'_>,
     constants: &indexmap::IndexMap<u32, i64>,
+    value_types: &[ValType],
     guard_idx: u32,
     op: &Op,
     block_exit_depth: Option<u32>,
 ) {
     sink.if_(BlockType::Empty);
-    emit_guard_exit(sink, constants, guard_idx, op);
+    emit_guard_exit(sink, constants, value_types, guard_idx, op);
     match block_exit_depth {
         // Loop traces: `br` out of this `if` and the enclosing exit `block`
         // (the `+ 1` accounts for the `if`) to the function epilogue.
@@ -4284,6 +4504,7 @@ fn emit_guard_if_exit(
 fn emit_guard_exit(
     sink: &mut InstructionSink<'_>,
     constants: &indexmap::IndexMap<u32, i64>,
+    value_types: &[ValType],
     guard_idx: u32,
     op: &Op,
 ) {
@@ -4295,7 +4516,7 @@ fn emit_guard_exit(
     for (i, &arg_ref) in fail_args.iter().enumerate() {
         let offset = FRAME_SLOT_BASE + i as u64 * SLOT_SIZE;
         sink.local_get(0);
-        emit_resolve(sink, constants, arg_ref);
+        emit_resolve(sink, constants, value_types, arg_ref);
         sink.i64_store(mem64(offset));
     }
 
@@ -4361,6 +4582,7 @@ fn apply_binop(sink: &mut InstructionSink<'_>, op: BinOp) {
 fn emit_binop(
     sink: &mut InstructionSink<'_>,
     constants: &indexmap::IndexMap<u32, i64>,
+    value_types: &[ValType],
     op: &Op,
     binop: BinOp,
 ) {
@@ -4368,8 +4590,8 @@ fn emit_binop(
     if OpRef::raw_is_constant(vi) {
         return;
     }
-    emit_resolve(sink, constants, op.arg(0).to_opref());
-    emit_resolve(sink, constants, op.arg(1).to_opref());
+    emit_resolve(sink, constants, value_types, op.arg(0).to_opref());
+    emit_resolve(sink, constants, value_types, op.arg(1).to_opref());
     apply_binop(sink, binop);
     sink.local_set(1 + vi);
 }
@@ -4383,6 +4605,7 @@ fn emit_binop(
 fn emit_umulhi(
     sink: &mut InstructionSink<'_>,
     constants: &indexmap::IndexMap<u32, i64>,
+    value_types: &[ValType],
     op: &Op,
     num_vars: u32,
 ) {
@@ -4398,22 +4621,22 @@ fn emit_umulhi(
     let mid1 = num_vars + 5;
 
     // al = a & 0xFFFFFFFF
-    emit_resolve(sink, constants, op.arg(0).to_opref());
+    emit_resolve(sink, constants, value_types, op.arg(0).to_opref());
     sink.i64_const(MASK32);
     sink.i64_and();
     sink.local_set(al);
     // ah = a >>u 32
-    emit_resolve(sink, constants, op.arg(0).to_opref());
+    emit_resolve(sink, constants, value_types, op.arg(0).to_opref());
     sink.i64_const(32);
     sink.i64_shr_u();
     sink.local_set(ah);
     // bl = b & 0xFFFFFFFF
-    emit_resolve(sink, constants, op.arg(1).to_opref());
+    emit_resolve(sink, constants, value_types, op.arg(1).to_opref());
     sink.i64_const(MASK32);
     sink.i64_and();
     sink.local_set(bl);
     // bh = b >>u 32
-    emit_resolve(sink, constants, op.arg(1).to_opref());
+    emit_resolve(sink, constants, value_types, op.arg(1).to_opref());
     sink.i64_const(32);
     sink.i64_shr_u();
     sink.local_set(bh);
@@ -4458,12 +4681,13 @@ fn emit_umulhi(
 fn emit_ovf_binop(
     sink: &mut InstructionSink<'_>,
     constants: &indexmap::IndexMap<u32, i64>,
+    value_types: &[ValType],
     op: &Op,
     binop: BinOp,
 ) {
     // For wasm MVP, just compute the result without overflow detection.
     // GuardNoOverflow/GuardOverflow are treated as always-pass.
-    emit_binop(sink, constants, op, binop);
+    emit_binop(sink, constants, value_types, op, binop);
 }
 
 // ── Comparison ops ──
@@ -4530,6 +4754,7 @@ enum FloatCmp {
 fn emit_float_cmp(
     sink: &mut InstructionSink<'_>,
     constants: &indexmap::IndexMap<u32, i64>,
+    value_types: &[ValType],
     op: &Op,
     cmp: FloatCmp,
 ) {
@@ -4537,10 +4762,8 @@ fn emit_float_cmp(
     if OpRef::raw_is_constant(vi) {
         return;
     }
-    emit_resolve(sink, constants, op.arg(0).to_opref());
-    sink.f64_reinterpret_i64();
-    emit_resolve(sink, constants, op.arg(1).to_opref());
-    sink.f64_reinterpret_i64();
+    emit_resolve_f64(sink, constants, value_types, op.arg(0).to_opref());
+    emit_resolve_f64(sink, constants, value_types, op.arg(1).to_opref());
     match cmp {
         FloatCmp::Lt => {
             sink.f64_lt();
@@ -4568,6 +4791,7 @@ fn emit_float_cmp(
 fn emit_cmp(
     sink: &mut InstructionSink<'_>,
     constants: &indexmap::IndexMap<u32, i64>,
+    value_types: &[ValType],
     op: &Op,
     cmpop: CmpOp,
 ) {
@@ -4575,8 +4799,8 @@ fn emit_cmp(
     if OpRef::raw_is_constant(vi) {
         return;
     }
-    emit_resolve(sink, constants, op.arg(0).to_opref());
-    emit_resolve(sink, constants, op.arg(1).to_opref());
+    emit_resolve(sink, constants, value_types, op.arg(0).to_opref());
+    emit_resolve(sink, constants, value_types, op.arg(1).to_opref());
     apply_cmp(sink, cmpop);
     sink.i64_extend_i32_u();
     sink.local_set(1 + vi);
@@ -4587,6 +4811,7 @@ fn emit_cmp(
 fn emit_unary_vi(
     sink: &mut InstructionSink<'_>,
     constants: &indexmap::IndexMap<u32, i64>,
+    value_types: &[ValType],
     op: &Op,
     prefix: impl FnOnce(&mut InstructionSink<'_>),
     suffix: impl FnOnce(&mut InstructionSink<'_>),
@@ -4594,7 +4819,7 @@ fn emit_unary_vi(
     let vi = op.pos.get().raw();
     if !OpRef::raw_is_constant(vi) {
         prefix(sink);
-        emit_resolve(sink, constants, op.arg(0).to_opref());
+        emit_resolve(sink, constants, value_types, op.arg(0).to_opref());
         suffix(sink);
         sink.local_set(1 + vi);
     }

--- a/majit/majit-backend-wasm/src/codegen.rs
+++ b/majit/majit-backend-wasm/src/codegen.rs
@@ -881,6 +881,49 @@ fn residual_call_i64_arity(op: &Op) -> Option<usize> {
     Some(nargs)
 }
 
+/// If `op` is a residual float CALL whose ABI uses only wasm-representable
+/// word / float arguments, return its wasm parameter types — eligible for a
+/// direct `call_indirect` returning `f64`. `None` keeps the `jit_call`
+/// trampoline: non-float / release-GIL / assembler calls, a missing call
+/// descr, an unsupported argument or result type, or an arg-count/descr-shape
+/// mismatch (defensive).
+///
+/// This includes `CallMayForceF`: the wasm virtualizable is always
+/// materialized, so `GuardNotForced` is a no-op and a direct call is sound.
+fn residual_call_float_sig(op: &Op) -> Option<Vec<ValType>> {
+    use OpCode::*;
+    if !matches!(
+        op.opcode,
+        CallF | CallPureF | CallLoopinvariantF | CallMayForceF
+    ) {
+        return None;
+    }
+    if op.result_type() != Type::Float {
+        return None;
+    }
+    let descr = op.getdescr()?;
+    let cd = descr.as_call_descr()?;
+    if cd.result_type() != Type::Float {
+        return None;
+    }
+    let arg_types = cd.arg_types();
+    let mut params = Vec::with_capacity(arg_types.len());
+    for ty in arg_types {
+        params.push(match ty {
+            Type::Int | Type::Ref => ValType::I64,
+            Type::Float => ValType::F64,
+            _ => return None,
+        });
+    }
+    // `getarglist()[0]` is the func pointer; the call args are `[1..]`. The
+    // descr's `arg_types` describes those call args, so the counts must match.
+    let nargs = op.getarglist().len().saturating_sub(1);
+    if params.len() != nargs {
+        return None;
+    }
+    Some(params)
+}
+
 /// Void-recorded counterpart of [`residual_call_i64_arity`]: an eligible
 /// void residual CALL whose descr records the dummy-word C ABI
 /// (`result_size == 8`, minted by `make_call_descr_void_word_abi`) — the
@@ -966,10 +1009,10 @@ fn has_call_ops(ops: &[Op]) -> bool {
 /// live CA frame.
 ///
 /// Keep this in lockstep with the individual emission arms below: the uniform
-/// i64 residual family, `New*`, and write barriers are direct under
-/// `WASM_DIRECT_RESIDUAL_CALL`; non-uniform CALLs and string allocation retain
-/// the trampoline.  When the direct family is disabled, all of the existing
-/// call-area users return to the trampoline baseline.
+/// i64 and typed float residual families, `New*`, and write barriers are direct
+/// under `WASM_DIRECT_RESIDUAL_CALL`; non-uniform CALLs and string allocation
+/// retain the trampoline. When the direct family is disabled, all of the
+/// existing call-area users return to the trampoline baseline.
 pub fn has_trampoline_calls(inputargs: &[InputArg], ops: &[Op], emit_ca: bool) -> bool {
     let ref_values = RefValues::collect(inputargs, ops);
     if !WASM_DIRECT_RESIDUAL_CALL {
@@ -984,8 +1027,11 @@ pub fn has_trampoline_calls(inputargs: &[InputArg], ops: &[Op], emit_ca: bool) -
         // These arms have no direct helper lowering.
         OpCode::Newstr | OpCode::Newunicode => true,
         // Every residual CALL uses the trampoline unless its exact lowering
-        // predicate supplies an i64 helper ABI.
-        _ if op.opcode.is_call() => direct_helper_i64_arity(op, &ref_values).is_none(),
+        // predicate supplies an i64 helper ABI or a typed float ABI.
+        _ if op.opcode.is_call() => {
+            direct_helper_i64_arity(op, &ref_values).is_none()
+                && residual_call_float_sig(op).is_none()
+        }
         // `New*` and ref-store write barriers are covered by
         // `direct_helper_i64_arity`, so their direct-family arms do not touch
         // the frame call area.
@@ -1316,9 +1362,26 @@ pub fn build_wasm_module(
     } else {
         None
     };
+    // Typed float residual calls use their descr's faithful wasm ABI instead
+    // of the uniform i64 helper family. Preserve first-use order so a given
+    // trace gets stable type indices while declaring each signature once.
+    let mut float_residual_sigs = Vec::new();
+    if WASM_DIRECT_RESIDUAL_CALL {
+        for op in ops {
+            if let Some(sig) = residual_call_float_sig(op) {
+                if !float_residual_sigs.contains(&sig) {
+                    float_residual_sigs.push(sig);
+                }
+            }
+        }
+    }
     // The shared indirect-function table backs direct residual helpers as well
     // as host-trampoline dispatch, chained bridges, and CA recursion.
-    let needs_table = needs_call || bridge_dispatch || residual_max_arity.is_some() || ca.emit_ca;
+    let needs_table = needs_call
+        || bridge_dispatch
+        || residual_max_arity.is_some()
+        || !float_residual_sigs.is_empty()
+        || ca.emit_ca;
     // `ca.emit_ca` forces the direct helper family to include arities 0..=2,
     // so all CA frame-helper trampoline `else` arms below are baseline-only.
     debug_assert!(!ca.emit_ca || residual_max_arity.is_some());
@@ -1359,6 +1422,20 @@ pub fn build_wasm_module(
         types
             .ty()
             .function(vec![ValType::I64, ValType::I64], vec![ValType::I64]);
+    }
+    // Float residual types follow all pre-existing direct helper types. Their
+    // parameter sequence comes from the call descr (`i64` for Int/Ref, `f64`
+    // for Float) and their result is always `f64`; the emitter uses this map to
+    // select the exact `call_indirect` type for each callee.
+    let float_residual_type_base = ca_helper_type_idx + ca.emit_ca as u32;
+    let float_residual_type_indices = float_residual_sigs
+        .iter()
+        .cloned()
+        .enumerate()
+        .map(|(offset, sig)| (sig, float_residual_type_base + offset as u32))
+        .collect::<indexmap::IndexMap<_, _>>();
+    for sig in float_residual_type_indices.keys() {
+        types.ty().function(sig.clone(), vec![ValType::F64]);
     }
     module.section(&types);
 
@@ -1444,6 +1521,7 @@ pub fn build_wasm_module(
         external_jump_key,
         frame,
         residual_max_arity.map(|_| residual_type_base),
+        &float_residual_type_indices,
         ca,
         bridge_finish_fi,
         ca_helper_type_idx,
@@ -1491,6 +1569,10 @@ fn build_function(
     // eligible residual call / `New*` / write barrier, so those arms always
     // use the `jit_call` path.
     residual_type_base: Option<u32>,
+    // Exact wasm type indices for direct float residual calls, keyed by their
+    // descr-derived parameter sequence. These types return `f64`; Float SSA
+    // values are converted to/from their i64 bit carrier around the call.
+    float_residual_type_indices: &indexmap::IndexMap<Vec<ValType>, u32>,
     // Self-recursive CALL_ASSEMBLER arm (`PYRE_WASM_CA`). `ca.emit_ca` off keeps
     // the body byte-identical.
     ca: CaParams,
@@ -3144,6 +3226,48 @@ fn build_function(
                     );
                     emit_reload_refs_from_homes(
                         &mut sink, ref_homes, &liveness, op_idx, None, frame,
+                    );
+                } else if let Some((sig, &type_idx)) = residual_call_float_sig(op).and_then(|sig| {
+                    float_residual_type_indices
+                        .get(&sig)
+                        .map(|type_idx| (sig, type_idx))
+                }) {
+                    // Direct in-module float residual call. Float SSA values
+                    // are i64 bit carriers, while the target's table entry has
+                    // the descr-derived mixed `(i64/f64...) -> f64` signature.
+                    let call_args = &op.getarglist()[1..];
+                    debug_assert_eq!(call_args.len(), sig.len());
+                    for (arg, ty) in call_args.iter().zip(&sig) {
+                        emit_resolve(&mut sink, constants, arg.to_opref());
+                        if *ty == ValType::F64 {
+                            sink.f64_reinterpret_i64();
+                        }
+                    }
+                    // func_ptr (arg 0) is the table slot — wrap to i32 index.
+                    emit_resolve(&mut sink, constants, op.arg(0).to_opref());
+                    sink.i32_wrap_i64();
+                    sink.call_indirect(0, type_idx);
+                    // Retain Float's i64 SSA carrier after the f64-returning
+                    // table entry has completed.
+                    sink.i64_reinterpret_f64();
+                    if !OpRef::raw_is_constant(vi) {
+                        sink.local_set(1 + vi);
+                    } else {
+                        sink.drop(); // value-producing call whose result is unused
+                    }
+                    emit_reload_frame_if_necessary(
+                        &mut sink,
+                        residual_type_base,
+                        ca.ca_reload_fn_ptr,
+                        ca.jf_top_addr,
+                    );
+                    emit_reload_refs_from_homes(
+                        &mut sink,
+                        ref_homes,
+                        &liveness,
+                        op_idx,
+                        (!OpRef::raw_is_constant(vi)).then_some(vi),
+                        frame,
                     );
                 } else {
                     let jit_call = jit_call_idx.expect("CALL op present but jit_call not imported");

--- a/majit/majit-backend-wasm/src/codegen.rs
+++ b/majit/majit-backend-wasm/src/codegen.rs
@@ -894,12 +894,14 @@ fn residual_call_i64_arity(op: &Op) -> Option<usize> {
     Some(nargs)
 }
 
-/// If `op` is a residual float CALL whose ABI uses only wasm-representable
-/// word / float arguments, return its wasm parameter types — eligible for a
-/// direct `call_indirect` returning `f64`. `None` keeps the `jit_call`
-/// trampoline: non-float / release-GIL / assembler calls, a missing call
-/// descr, an unsupported argument or result type, or an arg-count/descr-shape
-/// mismatch (defensive).
+/// If `op` is a residual float CALL with only float arguments, return its wasm
+/// parameter types — eligible for a direct `call_indirect` returning `f64`.
+/// Float-result targets are not audited for a uniform word ABI: a `Ref` or
+/// `Int` argument may actually be an `i32` pointer, such as
+/// `jit_bigint_to_f64_or_inf`. `None` keeps the `jit_call` trampoline:
+/// non-float / release-GIL / assembler calls, a missing call descr, a
+/// non-float argument or result type, or an arg-count/descr-shape mismatch
+/// (defensive).
 ///
 /// This includes `CallMayForceF`: the wasm virtualizable is always
 /// materialized, so `GuardNotForced` is a no-op and a direct call is sound.
@@ -922,11 +924,10 @@ fn residual_call_float_sig(op: &Op) -> Option<Vec<ValType>> {
     let arg_types = cd.arg_types();
     let mut params = Vec::with_capacity(arg_types.len());
     for ty in arg_types {
-        params.push(match ty {
-            Type::Int | Type::Ref => ValType::I64,
-            Type::Float => ValType::F64,
-            _ => return None,
-        });
+        if *ty != Type::Float {
+            return None;
+        }
+        params.push(ValType::F64);
     }
     // `getarglist()[0]` is the func pointer; the call args are `[1..]`. The
     // descr's `arg_types` describes those call args, so the counts must match.

--- a/majit/majit-backend-wasm/src/failguard.rs
+++ b/majit/majit-backend-wasm/src/failguard.rs
@@ -91,6 +91,43 @@ pub struct LabelTarget {
     pub frame: crate::codegen::FrameGeometry,
 }
 
+/// Frozen metadata for entering a compiled loop from a `CALL_ASSEMBLER` arm.
+/// The table slot and frame layout are published only after the loop module is
+/// installed, so a caller can decline before baking an unresolved target.
+#[derive(Clone, Debug)]
+pub struct CallAssemblerTarget {
+    pub func_handle: u32,
+    pub input_types: Vec<Type>,
+    pub callee_frame_bytes: u32,
+    pub callee_gcmap_ptr: i64,
+    pub loop_finish_fi: u32,
+    pub compiled_ptr: u64,
+    pub terminal_declined_ptr: u32,
+    pub has_trampoline_calls: bool,
+}
+
+/// Compiled loop targets keyed by their `JitCellToken` number. Unlike label
+/// targets, CALL_ASSEMBLER identifies its callee by that number directly.
+pub static CALL_ASSEMBLER_TARGETS: std::sync::Mutex<
+    Option<std::collections::HashMap<u64, CallAssemblerTarget>>,
+> = std::sync::Mutex::new(None);
+
+pub fn call_assembler_target(number: u64) -> Option<CallAssemblerTarget> {
+    CALL_ASSEMBLER_TARGETS
+        .lock()
+        .unwrap()
+        .as_ref()
+        .and_then(|targets| targets.get(&number).cloned())
+}
+
+pub fn publish_call_assembler_target(number: u64, target: CallAssemblerTarget) {
+    CALL_ASSEMBLER_TARGETS
+        .lock()
+        .unwrap()
+        .get_or_insert_with(Default::default)
+        .insert(number, target);
+}
+
 /// Global `frame[0]` fail-index space.
 ///
 /// Cross-trace chaining (`LABEL_TARGETS`) means the module that last wrote
@@ -197,6 +234,9 @@ pub struct ChainedTraceMeta {
 
 /// Compiled wasm loop metadata, stored in `JitCellToken.compiled`.
 pub struct CompiledWasmLoop {
+    /// Owning `JitCellToken` number, used to retract this loop's
+    /// CALL_ASSEMBLER target metadata on drop.
+    pub token_number: u64,
     pub trace_id: u64,
     pub input_types: Vec<Type>,
     pub func_handle: u32,
@@ -289,6 +329,13 @@ pub struct CompiledWasmLoop {
     /// CA recursion trips a resume seam that reads a clobbered class — see
     /// the decline site for the failing suite shapes.
     pub ca_active: Cell<bool>,
+    /// A guard reached through this loop as a wasm CALL_ASSEMBLER callee was
+    /// structurally declined by `compile_bridge`.  Admission refuses this
+    /// target, because entering it from compiled wasm would only blackhole.
+    pub ca_terminal_declined: Cell<bool>,
+    /// Compiled callers that baked this loop as their CALL_ASSEMBLER target.
+    /// A terminal callee decline invalidates them for a no-CA retrace.
+    pub ca_callers: RefCell<Vec<std::sync::Arc<std::sync::atomic::AtomicBool>>>,
 }
 
 impl CompiledWasmLoop {
@@ -304,6 +351,16 @@ impl CompiledWasmLoop {
 
 impl Drop for CompiledWasmLoop {
     fn drop(&mut self) {
+        let mut ca_targets = CALL_ASSEMBLER_TARGETS.lock().unwrap();
+        if let Some(targets) = ca_targets.as_mut() {
+            let this = self as *const Self as usize as u64;
+            if targets
+                .get(&self.token_number)
+                .is_some_and(|target| target.compiled_ptr == this)
+            {
+                targets.remove(&self.token_number);
+            }
+        }
         // Retract this loop's published label targets so a later bridge
         // cannot chain into a dropped loop's stale table slot. Guarded by
         // `func_handle`: a recompile that re-stamped the same descr onto its
@@ -330,6 +387,7 @@ mod tests {
 
     fn token_with_trampoline_census(has_trampoline_calls: bool) -> CompiledWasmLoop {
         CompiledWasmLoop {
+            token_number: 0,
             trace_id: 0,
             input_types: Vec::new(),
             func_handle: 0,
@@ -349,6 +407,8 @@ mod tests {
             _bridge_cells_owner: None,
             _bridge_owned_cells: RefCell::new(Vec::new()),
             ca_active: Cell::new(false),
+            ca_terminal_declined: Cell::new(false),
+            ca_callers: RefCell::new(Vec::new()),
         }
     }
 

--- a/majit/majit-backend-wasm/src/glue.rs
+++ b/majit/majit-backend-wasm/src/glue.rs
@@ -14,6 +14,10 @@
 //! Both expose the same `compile_module` / `execute` / `free` surface, so
 //! the rest of the backend stays binding-agnostic.
 
+use core::sync::atomic::{AtomicU64, Ordering};
+
+static JIT_EXECUTE_COUNT: AtomicU64 = AtomicU64::new(0);
+
 #[cfg(all(feature = "web", feature = "host-import"))]
 compile_error!("features `web` and `host-import` are mutually exclusive; enable exactly one");
 
@@ -81,9 +85,27 @@ pub fn execute(func_id: u32, frame_ptr: u32) -> u32 {
         imports::jit_execute_wasm(func_id, frame_ptr)
     }
     #[cfg(not(feature = "web"))]
-    {
-        unsafe { imports::jit_execute_wasm(func_id, frame_ptr) }
+    unsafe {
+        JIT_EXECUTE_COUNT.fetch_add(1, Ordering::Relaxed);
+        // `func_id` is the shared-table (`__indirect_function_table`, exported as
+        // table 0) slot where the host appended this trace. Calling it directly
+        // keeps execution inside the guest; the trace is `(i32) -> i32`.
+        //
+        // Keep the host import referenced on a never-taken path so `wasm-ld` does
+        // not garbage-collect it: dropping the import would shift the module's
+        // import indices and break JIT-baked indices. `black_box` blocks the
+        // optimizer from proving the branch dead.
+        if core::hint::black_box(false) {
+            return imports::jit_execute_wasm(func_id, frame_ptr);
+        }
+        let trace: extern "C" fn(u32) -> u32 = core::mem::transmute(func_id as usize);
+        trace(frame_ptr)
     }
+}
+
+/// Number of guest-side JIT trace entries.
+pub fn jit_execute_count() -> u64 {
+    JIT_EXECUTE_COUNT.load(Ordering::Relaxed)
 }
 
 /// Free a compiled JIT function.

--- a/majit/majit-backend-wasm/src/lib.rs
+++ b/majit/majit-backend-wasm/src/lib.rs
@@ -46,6 +46,12 @@ pub fn bridge_diag(i: usize) -> u64 {
         .unwrap_or(0)
 }
 
+/// Number of JIT trace entries made from the guest.
+#[cfg(all(target_arch = "wasm32", not(target_os = "wasi")))]
+pub fn jit_execute_count() -> u64 {
+    glue::jit_execute_count()
+}
+
 #[inline]
 fn diag_bump(i: usize) {
     BRIDGE_DIAG[i].fetch_add(1, Ordering::Relaxed);

--- a/majit/majit-backend-wasm/src/lib.rs
+++ b/majit/majit-backend-wasm/src/lib.rs
@@ -30,8 +30,9 @@ use std::sync::atomic::{AtomicI64, AtomicU64, Ordering};
 /// decline (TEMP, for the resume-at-last-label measurement): 8 = JUMP descr
 /// did not resolve (target_ord None), 9 = target_ord Some but != last label,
 /// 10 = arity mismatch, 11 = loop-closing bridge advances no loop-carried value
-/// (guard side-trace that would livelock the chained loop), 15 = declined CA
-/// because a trace would use the host call trampoline on a movable CA frame.
+/// (guard side-trace that would livelock the chained loop), 14 = accepted
+/// CALL_ASSEMBLER trace, 15 = declined CA because a trace would use the host
+/// call trampoline on a movable CA frame.
 pub static BRIDGE_DIAG: [AtomicU64; 16] = {
     const Z: AtomicU64 = AtomicU64::new(0);
     [Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z]
@@ -63,8 +64,13 @@ fn diag_bump(i: usize) {
 // offsets. The fib CA path measured raw maxima of 9 positional slots and 15
 // Ref homes, but that is not a bridge fail-arg census for the full suite; keep
 // both existing floors until such a census establishes smaller safe bounds.
-const FROZEN_CHAIN_VALUE_SLOTS: usize = 32;
-const FROZEN_CHAIN_REF_HOMES: usize = 16;
+// A CALL_ASSEMBLER target must retain enough frozen spill/home geometry for a
+// later exit bridge.  nbody's callee bridge needs more Ref homes than the old
+// 16-slot floor; declining it turns every CA invocation into a blackhole.  The
+// larger fixed reserve keeps the bridge in compiled wasm and is still bounded
+// per compiled token.
+const FROZEN_CHAIN_VALUE_SLOTS: usize = 64;
+const FROZEN_CHAIN_REF_HOMES: usize = 64;
 
 /// An arithmetic op whose result advances a loop-carried numeric value (the
 /// `IntAdd`/`IntSub`/… and float-arithmetic block plus the overflow-checked
@@ -140,8 +146,9 @@ fn guard_fail_args_advanced(
 }
 
 use failguard::{
-    ChainedTraceMeta, CompiledWasmLoop, LabelTarget, WasmFailDescr, WasmFrameData, fail_descr_base,
-    global_fail_descr, label_target, publish_label_target, register_fail_descrs,
+    CallAssemblerTarget, ChainedTraceMeta, CompiledWasmLoop, LabelTarget, WasmFailDescr,
+    WasmFrameData, call_assembler_target, fail_descr_base, global_fail_descr, label_target,
+    publish_call_assembler_target, publish_label_target, register_fail_descrs,
 };
 use majit_backend::{AsmInfo, BackendError, DeadFrame, JitCellToken};
 use majit_gc::GcAllocator;
@@ -650,10 +657,11 @@ fn build_callee_gcmap(
 ) -> Box<[usize]> {
     let sign = std::mem::size_of::<isize>();
     let bits_per_word = std::mem::size_of::<usize>() * 8;
-    let input_count = input_types.len();
-    let mut indices: Vec<usize> = Vec::with_capacity(input_count + frame.home_slots);
-    for i in 0..input_count {
-        indices.push((codegen::FRAME_SLOT_BASE as usize + i * 8) / sign);
+    let mut indices: Vec<usize> = Vec::with_capacity(input_types.len() + frame.home_slots);
+    for (i, &tp) in input_types.iter().enumerate() {
+        if tp == majit_ir::Type::Ref {
+            indices.push((codegen::FRAME_SLOT_BASE as usize + i * 8) / sign);
+        }
     }
     for h in 0..frame.home_slots {
         indices.push((frame.home_slot_base as usize + h * 8) / sign);
@@ -815,6 +823,7 @@ fn build_home_gcmap(frame: codegen::FrameGeometry) -> Box<[usize]> {
 /// makes `compile_bridge` decline the CA lift, since the arm would have no way
 /// to complete a deopt. Stored as `u64` to reuse the imported atomics.
 static CA_DEOPT_HELPER_SLOT: AtomicU64 = AtomicU64::new(0);
+static CA_BASELINE_HELPER_SLOT: AtomicU64 = AtomicU64::new(0);
 
 /// Host entry point publishing [`CA_DEOPT_HELPER_SLOT`] (called from pyre-jit's
 /// `init_jit_hooks` with `wasm_ca_resume_deopt as *const () as usize`, which on
@@ -826,6 +835,14 @@ pub fn set_ca_deopt_helper_slot(slot: u32) {
 /// Current CA deopt-helper table slot (0 = unset).
 pub fn ca_deopt_helper_slot() -> u32 {
     CA_DEOPT_HELPER_SLOT.load(Ordering::Relaxed) as u32
+}
+
+pub fn set_ca_baseline_helper_slot(slot: u32) {
+    CA_BASELINE_HELPER_SLOT.store(slot as u64, Ordering::Relaxed);
+}
+
+pub fn ca_baseline_helper_slot() -> u32 {
+    CA_BASELINE_HELPER_SLOT.load(Ordering::Relaxed) as u32
 }
 
 /// A legacy pool-indexed const (`ConstInt(u32)` etc.) reached the wasm backend
@@ -1126,6 +1143,113 @@ fn bridge_is_self_recursive_int_ca(ops: &[Op], source_loop_number: u64) -> bool 
     })
 }
 
+/// Resolve the one compiled target used by every CALL_ASSEMBLER in this trace.
+/// Slice A deliberately accepts one target only: a trace containing distinct
+/// callees needs per-op metadata rather than the single `CaParams` payload.
+fn general_int_call_assembler_target(ops: &[Op]) -> Option<CallAssemblerTarget> {
+    let mut resolved: Option<CallAssemblerTarget> = None;
+    let mut saw_ca = false;
+    for op in ops.iter().filter(|op| op.opcode.is_call_assembler()) {
+        saw_ca = true;
+        if !matches!(
+            op.opcode,
+            majit_ir::OpCode::CallAssemblerI | majit_ir::OpCode::CallAssemblerR
+        ) {
+            return None;
+        }
+        let descr_ref = op.getdescr()?;
+        let descr = descr_ref.as_call_descr()?;
+        let arg_types = descr.arg_types();
+        if !arg_types
+            .iter()
+            .all(|&tp| matches!(tp, majit_ir::Type::Int | majit_ir::Type::Ref))
+            || !matches!(
+                descr.result_type(),
+                majit_ir::Type::Int | majit_ir::Type::Ref
+            )
+        {
+            return None;
+        }
+        let target = call_assembler_target(descr.call_target_token()?)?;
+        if target.input_types.as_slice() != arg_types
+            || target.callee_frame_bytes == 0
+            || target.callee_gcmap_ptr == 0
+            || target.compiled_ptr == 0
+            || target.has_trampoline_calls
+        {
+            return None;
+        }
+        if let Some(previous) = &resolved {
+            if previous.compiled_ptr != target.compiled_ptr {
+                return None;
+            }
+        } else {
+            resolved = Some(target);
+        }
+    }
+    saw_ca.then_some(resolved?).filter(|target| {
+        // A successfully compiled loop is retained by its token while it is
+        // registered. Its chained bridges can subsequently add trampoline
+        // calls, so read the live census before baking a CA entry.
+        unsafe {
+            (target.compiled_ptr as *const CompiledWasmLoop)
+                .as_ref()
+                .is_some_and(|loop_| {
+                    !loop_.has_trampoline_calls.get() && !loop_.ca_terminal_declined.get()
+                })
+        }
+    })
+}
+
+fn bridge_int_call_assembler_target(
+    ops: &[Op],
+    source_loop_number: u64,
+) -> Option<CallAssemblerTarget> {
+    if bridge_is_self_recursive_int_ca(ops, source_loop_number) {
+        // Keep the established self-recursive shape on its explicit admission
+        // path while using the registered target's frozen geometry.
+        return general_int_call_assembler_target(ops);
+    }
+    general_int_call_assembler_target(ops)
+}
+
+fn mark_call_assembler_target_active(target: &CallAssemblerTarget, caller: &JitCellToken) {
+    // The target metadata is removed by `CompiledWasmLoop::drop`; compilation
+    // is single-threaded, and callers only retain the pointer while the token
+    // remains compiled. This is the same lifetime used by the deopt helper.
+    unsafe {
+        if let Some(loop_) = (target.compiled_ptr as *const CompiledWasmLoop).as_ref() {
+            loop_.ca_active.set(true);
+            let caller_flag = caller.invalidation_flag();
+            let mut callers = loop_.ca_callers.borrow_mut();
+            if !callers
+                .iter()
+                .any(|known| std::sync::Arc::ptr_eq(known, &caller_flag))
+            {
+                callers.push(caller_flag);
+            }
+        }
+    }
+}
+
+/// Mark a CA target whose callee guard was structurally declined.  The host
+/// deopt helper calls this only after `MetaInterp` recorded the exact guard in
+/// `declined_bridge_guards`; invalidating the callers forces a retrace whose
+/// admission check above restores the pre-Slice-A call path.
+pub fn mark_call_assembler_terminal_decline(compiled_ptr: usize) {
+    unsafe {
+        let Some(loop_) = (compiled_ptr as *const CompiledWasmLoop).as_ref() else {
+            return;
+        };
+        if loop_.ca_terminal_declined.replace(true) {
+            return;
+        }
+        for caller in loop_.ca_callers.borrow().iter() {
+            caller.store(true, Ordering::Release);
+        }
+    }
+}
+
 /// Reconstruct a [`DeadFrame`] from a callee frame an in-guest `call_indirect`
 /// already ran to a guard/finish exit (the self-recursive CALL_ASSEMBLER fast
 /// path, `PYRE_WASM_CA`). This is the post-`glue::execute` tail of
@@ -1265,9 +1389,14 @@ impl majit_backend::Backend for WasmBackend {
         }
         let ops_owned: Vec<Op> = ops.iter().map(|rc| (**rc).clone()).collect();
         let ops: &[Op] = &ops_owned;
+        // A general CALL_ASSEMBLER can enter an already-compiled loop through
+        // the shared table. Keep one frozen target per trace in Slice A.
+        let ca_target = general_int_call_assembler_target(ops);
+        let allow_ca =
+            ca_deopt_helper_slot() != 0 && ca_baseline_helper_slot() != 0 && ca_target.is_some();
         // This must use the same direct-vs-trampoline predicates as codegen:
         // a CA callee runs this source-loop body on a movable nursery frame.
-        let has_trampoline_calls = codegen::has_trampoline_calls(inputargs, ops, false);
+        let has_trampoline_calls = codegen::has_trampoline_calls(inputargs, ops, allow_ca);
 
         // Decline traces the wasm backend cannot compile correctly, so the
         // metainterp falls back to the interpreter (correct, if unaccelerated)
@@ -1280,8 +1409,11 @@ impl majit_backend::Backend for WasmBackend {
         //     (jump-to-existing-trace); compile_loop cannot supply the target
         //     table slot, so codegen would tail-call slot 0 — the wrong
         //     function. Declined here (is_loop=true).
-        if let Some(reason) = wasm_unsupported_trace_reason(ops, true, false) {
+        if let Some(reason) = wasm_unsupported_trace_reason(ops, true, allow_ca) {
             return Err(BackendError::Unsupported(reason));
+        }
+        if allow_ca {
+            diag_bump(14); // accepted general CALL_ASSEMBLER loop
         }
 
         self.collect_constants_from_ops(ops);
@@ -1325,13 +1457,33 @@ impl majit_backend::Backend for WasmBackend {
                 0, // external_jump_slot: a loop's JUMP is a local back-edge `br`
                 0, // external_jump_key: unused without an external JUMP
                 frame,
-                codegen::CaParams {
-                    // Loops do not emit the CA arm, but they can run on a
-                    // nursery CA frame and must reload local 0 after a collect.
-                    ca_reload_fn_ptr: wasm_jit_ca_reload_frame as *const () as usize as i64,
-                    jf_top_addr: jf_top_addr(),
-                    ..codegen::CaParams::default()
-                },
+                ca_target.as_ref().map_or_else(
+                    || codegen::CaParams {
+                        // A loop can run on a nursery CA frame and must reload
+                        // local 0 after a collection even when it emits no CA.
+                        ca_reload_fn_ptr: wasm_jit_ca_reload_frame as *const () as usize as i64,
+                        jf_top_addr: jf_top_addr(),
+                        ..codegen::CaParams::default()
+                    },
+                    |target| codegen::CaParams {
+                        emit_ca: true,
+                        callee_slot: target.func_handle,
+                        callee_frame_bytes: target.callee_frame_bytes,
+                        loop_finish_fi: target.loop_finish_fi,
+                        deopt_helper_slot: ca_deopt_helper_slot(),
+                        baseline_helper_slot: ca_baseline_helper_slot(),
+                        terminal_declined_ptr: target.terminal_declined_ptr,
+                        callee_compiled_ptr: target.compiled_ptr,
+                        ca_alloc_fn_ptr: wasm_jit_ca_alloc_frame as *const () as usize as i64,
+                        ca_pop_fn_ptr: wasm_jit_ca_pop_frame as *const () as usize as i64,
+                        ca_reload_fn_ptr: wasm_jit_ca_reload_frame as *const () as usize as i64,
+                        ca_reload_caller_fn_ptr: wasm_jit_ca_reload_caller_frame as *const ()
+                            as usize as i64,
+                        callee_gcmap_ptr: target.callee_gcmap_ptr,
+                        inline: ca_inline_params(target.callee_frame_bytes),
+                        jf_top_addr: jf_top_addr(),
+                    },
+                ),
             )?;
 
         // Build fail descriptors
@@ -1480,6 +1632,7 @@ impl majit_backend::Backend for WasmBackend {
         }
 
         let compiled = CompiledWasmLoop {
+            token_number: token.number,
             trace_id,
             input_types: inputargs.iter().map(|ia| ia.tp).collect(),
             func_handle,
@@ -1499,9 +1652,43 @@ impl majit_backend::Backend for WasmBackend {
             _bridge_cells_owner: bridge_cells_owner,
             _bridge_owned_cells: std::cell::RefCell::new(Vec::new()),
             ca_active: std::cell::Cell::new(false),
+            ca_terminal_declined: std::cell::Cell::new(false),
+            ca_callers: std::cell::RefCell::new(Vec::new()),
         };
 
         token.compiled = Some(Box::new(compiled));
+        let compiled = token
+            .compiled
+            .as_ref()
+            .and_then(|compiled| compiled.downcast_ref::<CompiledWasmLoop>())
+            .expect("newly compiled wasm loop is missing");
+        let loop_finish_fi = compiled
+            .fail_descrs
+            .borrow()
+            .iter()
+            .find(|descr| descr.is_finish)
+            .map(|descr| descr.fail_index)
+            .unwrap_or(0);
+        let callee_gcmap_ptr =
+            Box::leak(build_callee_gcmap(&compiled.input_types, compiled.frame)).as_ptr() as i64;
+        publish_call_assembler_target(
+            token.number,
+            CallAssemblerTarget {
+                func_handle: compiled.func_handle,
+                input_types: compiled.input_types.clone(),
+                callee_frame_bytes: compiled.frame.ca_frame_bytes,
+                callee_gcmap_ptr,
+                loop_finish_fi,
+                compiled_ptr: compiled as *const CompiledWasmLoop as usize as u64,
+                terminal_declined_ptr: (&compiled.ca_terminal_declined
+                    as *const std::cell::Cell<bool>) as usize
+                    as u32,
+                has_trampoline_calls: compiled.has_trampoline_calls.get(),
+            },
+        );
+        if let Some(target) = ca_target.as_ref() {
+            mark_call_assembler_target_active(target, token);
+        }
 
         Ok(AsmInfo {
             code_addr: 0,
@@ -1553,10 +1740,11 @@ impl majit_backend::Backend for WasmBackend {
         // The CA arm must be able to complete a callee deopt; without the
         // registered `wasm_ca_resume_deopt` slot it could not, so decline the
         // lift (the host round-trip path still handles the CALL_ASSEMBLER).
-        let ca_candidate = ca_deopt_helper_slot() != 0
-            && bridge_is_self_recursive_int_ca(ops, original_token.number);
-        // The CA candidate's `CallAssemblerR` is a dedicated direct arm; all
-        // other ops are scanned against their normal emission paths.
+        let ca_target = bridge_int_call_assembler_target(ops, original_token.number);
+        let ca_candidate =
+            ca_deopt_helper_slot() != 0 && ca_baseline_helper_slot() != 0 && ca_target.is_some();
+        // The CA candidate is a dedicated direct arm; all other ops are
+        // scanned against their normal emission paths.
         let bridge_has_trampoline_calls =
             codegen::has_trampoline_calls(inputargs, ops, ca_candidate);
 
@@ -1599,9 +1787,6 @@ impl majit_backend::Backend for WasmBackend {
             source_func_handle,
             source_has_preamble,
             source_frame,
-            source_input_types,
-            source_loop_finish_fi,
-            source_compiled_ptr,
             source_ca_active,
             source_has_trampoline_calls,
         ) = {
@@ -1614,16 +1799,6 @@ impl majit_backend::Backend for WasmBackend {
                         "wasm backend: bridge source token has no compiled loop".into(),
                     )
                 })?;
-            // `fail_index` the source loop's DoneWithThisFrame Finish writes to
-            // frame[0] on the base-case return (the CA arm accepts it as a clean
-            // callee finish alongside this bridge's own finish).
-            let loop_finish_fi = source_loop
-                .fail_descrs
-                .borrow()
-                .iter()
-                .find(|d| d.is_finish)
-                .map(|d| d.fail_index)
-                .unwrap_or(0);
             // Resolve the failing guard's owning trace by the descr's
             // `trace_id`: the source loop itself, or one of the bridges
             // already chained onto it (`chained_trace_meta`) — a NESTED
@@ -1664,16 +1839,6 @@ impl majit_backend::Backend for WasmBackend {
                 source_loop.func_handle,
                 source_loop.has_preamble,
                 source_loop.frame,
-                source_loop.input_types.clone(),
-                loop_finish_fi,
-                // Address of the source loop's metadata, baked into the CA arm
-                // (opaque cookie in the deopt-helper ABI; `frame[0]` resolution
-                // itself goes through the global fail-index space). Same
-                // lifetime assumption as `source_func_handle` below: a
-                // recompile invalidates this bridge before the loop's
-                // `CompiledWasmLoop` is replaced, so the arm is unreachable
-                // with a stale pointer.
-                source_loop as *const CompiledWasmLoop as usize as u64,
                 source_loop.ca_active.get(),
                 source_loop.has_trampoline_calls.get(),
             )
@@ -1697,10 +1862,8 @@ impl majit_backend::Backend for WasmBackend {
                 "wasm backend: bridge source guard index has no dispatch cell".into(),
             ));
         }
-        // The CA arm bakes source-LOOP metadata (finish index, compiled ptr);
-        // restrict it to direct loop guards. A CA-shaped bridge on a nested
-        // guard then fails codegen's CALL_ASSEMBLER handling — a deterministic
-        // decline.
+        // Keep CA bridges attached directly to their source loop. Nested
+        // bridge metadata is not yet published as a CALL_ASSEMBLER target.
         let mut allow_ca = ca_candidate && source_is_direct;
         let ca_trampoline_decline = if allow_ca && source_has_trampoline_calls {
             Some(
@@ -1723,6 +1886,9 @@ impl majit_backend::Backend for WasmBackend {
             return Err(BackendError::Unsupported(
                 ca_trampoline_decline.unwrap_or(reason.as_str()).to_string(),
             ));
+        }
+        if allow_ca {
+            diag_bump(14); // accepted CALL_ASSEMBLER bridge
         }
 
         // A chained bridge executes in the source token's *same* frame. Its
@@ -1949,28 +2115,26 @@ impl majit_backend::Backend for WasmBackend {
         // Self-recursive CALL_ASSEMBLER (PYRE_WASM_CA): the CA arm allocates a
         // fresh callee using the source token's frozen geometry. The earlier
         // frame-fit decline guarantees this bridge uses those same offsets.
-        let ca_params = if allow_ca {
-            // Per-bridge callee-frame gcmap (real Ref inputs + home Ref slots),
-            // leaked to live for the program — each callee frame's `jf_gcmap`
-            // points at it.
-            let callee_gcmap_ptr =
-                Box::leak(build_callee_gcmap(&source_input_types, source_frame)).as_ptr() as i64;
+        let ca_params = if let Some(target) = ca_target.as_ref().filter(|_| allow_ca) {
             codegen::CaParams {
                 emit_ca: true,
                 // `compile_bridge`'s trampoline-decline floor above guarantees
                 // no trampoline-lowered op executes on this movable CA callee
                 // frame, so its tail call area is never touched.
-                callee_frame_bytes: source_frame.ca_frame_bytes,
-                loop_finish_fi: source_loop_finish_fi,
+                callee_slot: target.func_handle,
+                callee_frame_bytes: target.callee_frame_bytes,
+                loop_finish_fi: target.loop_finish_fi,
                 deopt_helper_slot: ca_deopt_helper_slot(),
-                source_compiled_ptr,
+                baseline_helper_slot: ca_baseline_helper_slot(),
+                terminal_declined_ptr: target.terminal_declined_ptr,
+                callee_compiled_ptr: target.compiled_ptr,
                 ca_alloc_fn_ptr: wasm_jit_ca_alloc_frame as *const () as usize as i64,
                 ca_pop_fn_ptr: wasm_jit_ca_pop_frame as *const () as usize as i64,
                 ca_reload_fn_ptr: wasm_jit_ca_reload_frame as *const () as usize as i64,
                 ca_reload_caller_fn_ptr: wasm_jit_ca_reload_caller_frame as *const () as usize
                     as i64,
-                callee_gcmap_ptr,
-                inline: ca_inline_params(source_frame.ca_frame_bytes),
+                callee_gcmap_ptr: target.callee_gcmap_ptr,
+                inline: ca_inline_params(target.callee_frame_bytes),
                 jf_top_addr: jf_top_addr(),
             }
         } else {
@@ -2087,10 +2251,10 @@ impl majit_backend::Backend for WasmBackend {
             if let Some(owner) = bridge_cells_owner {
                 source_loop._bridge_owned_cells.borrow_mut().push(owner);
             }
-            if allow_ca {
+            if let Some(target) = ca_target.as_ref().filter(|_| allow_ca) {
                 // Freeze this recursion to the CA mechanism: no further bridge
                 // chains here (see the decline above the codegen call).
-                source_loop.ca_active.set(true);
+                mark_call_assembler_target_active(target, original_token);
             }
         }
 

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -9496,6 +9496,21 @@ impl<M: Clone> MetaInterp<M> {
         (fired, owning_key)
     }
 
+    /// Whether this exact guard's bridge was terminally declined by the
+    /// backend.  The wasm CALL_ASSEMBLER host-deopt path queries the same
+    /// `(trace_id, fail_index)` record that normal guard failures populate,
+    /// so it cannot re-trace a structural decline in a side table.
+    pub fn bridge_declined_terminally(
+        &self,
+        descr_arc: &std::sync::Arc<dyn majit_ir::Descr>,
+    ) -> bool {
+        let descr = descr_arc
+            .as_fail_descr()
+            .expect("bridge_declined_terminally: descr_arc must be a FailDescr");
+        self.declined_bridge_guards
+            .contains(&(descr.trace_id(), descr.fail_index_per_trace()))
+    }
+
     /// memmgr.py:58-61: keep_loop_alive(looptoken).
     /// warmstate.py:402: warmrunnerdesc.memory_manager.keep_loop_alive(loop_token)
     ///

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -2929,6 +2929,78 @@ fn jit_ca_handle_guard_failure(
     compiled
 }
 
+/// Feed a CALL_ASSEMBLER callee guard through the normal bridge-hotness path.
+/// The caller has already recovered the live descriptor and exit values; the
+/// rest is the same must-compile/bridge attachment sequence used by the native
+/// CALL_ASSEMBLER guard callback above.
+struct CaBridgeAttempt {
+    terminal_declined: bool,
+}
+
+fn try_compile_ca_bridge(
+    descr_arc: &std::sync::Arc<dyn majit_ir::Descr>,
+    raw_values: &[i64],
+) -> CaBridgeAttempt {
+    if raw_values.is_empty() {
+        return CaBridgeAttempt {
+            terminal_declined: false,
+        };
+    }
+    let Some((source_green_key, source_trace_id, source_fail_index)) =
+        bridge_source_identity_from_descr(descr_arc)
+    else {
+        return CaBridgeAttempt {
+            terminal_declined: false,
+        };
+    };
+    let (must_compile, owning_key) = {
+        let (driver, _) = crate::eval::driver_pair();
+        driver
+            .meta_interp_mut()
+            .must_compile_with_values(descr_arc, raw_values, source_green_key)
+    };
+    if !must_compile || majit_metainterp::MetaInterp::<()>::stack_almost_full() {
+        let terminal_declined = {
+            let (driver, _) = crate::eval::driver_pair();
+            driver.meta_interp().bridge_declined_terminally(descr_arc)
+        };
+        return CaBridgeAttempt { terminal_declined };
+    }
+    let exit_layout = {
+        let (driver, _) = crate::eval::driver_pair();
+        driver.meta_interp().get_compiled_exit_layout_in_trace(
+            owning_key,
+            source_trace_id,
+            source_fail_index,
+        )
+    };
+    let Some(exit_layout) = exit_layout else {
+        return CaBridgeAttempt {
+            terminal_declined: false,
+        };
+    };
+    let frame_ptr = raw_values[0] as *mut PyFrame;
+    if frame_ptr.is_null() {
+        return CaBridgeAttempt {
+            terminal_declined: false,
+        };
+    }
+    let frame = unsafe { &mut *frame_ptr };
+    let _guard = crate::eval::GuardCompilingScope::new(descr_arc);
+    let _compiled = matches!(
+        trace_and_compile_from_bridge(descr_arc, frame, raw_values, &exit_layout, 0, false),
+        BridgeResolution::CompiledContinue
+    );
+    // `MetaInterp::compile_bridge` records a wasm `Unsupported` before the
+    // walker returns.  Reuse that canonical guard identity here rather than
+    // creating a separate CA-side decline table.
+    let terminal_declined = {
+        let (driver, _) = crate::eval::driver_pair();
+        driver.meta_interp().bridge_declined_terminally(descr_arc)
+    };
+    CaBridgeAttempt { terminal_declined }
+}
+
 /// Host completion for an in-guest self-recursive CALL_ASSEMBLER callee that
 /// deopted (`PYRE_WASM_CA`). The wasm CA arm `call_indirect`s this through the
 /// shared `__indirect_function_table` (its slot published via
@@ -2957,6 +3029,7 @@ pub extern "C" fn wasm_ca_resume_deopt(frame_ptr: i64, compiled_ptr: i64) -> i64
     enum Outcome {
         Finished(i64),
         Deopt {
+            descr_arc: std::sync::Arc<dyn majit_ir::Descr>,
             green_key: u64,
             exit_layout: majit_metainterp::CompiledExitLayout,
             raw_values: Vec<i64>,
@@ -2991,6 +3064,7 @@ pub extern "C" fn wasm_ca_resume_deopt(frame_ptr: i64, compiled_ptr: i64) -> i64
                 .collect();
             let guard_exc = backend.grab_exc_value(&frame).0 as i64;
             Outcome::Deopt {
+                descr_arc,
                 green_key,
                 exit_layout,
                 raw_values,
@@ -3002,17 +3076,43 @@ pub extern "C" fn wasm_ca_resume_deopt(frame_ptr: i64, compiled_ptr: i64) -> i64
     match outcome {
         Outcome::Finished(r) => r,
         Outcome::Deopt {
+            descr_arc,
             green_key,
             exit_layout,
             raw_values,
             guard_exc,
         } => {
+            let attempt = try_compile_ca_bridge(&descr_arc, &raw_values);
+            if attempt.terminal_declined {
+                // This target cannot reach compiled steady state: each CA
+                // invocation would blackhole.  Invalidate callers so the next
+                // trace refuses this target and returns to the baseline path.
+                majit_backend_wasm::mark_call_assembler_terminal_decline(compiled_ptr as usize);
+            }
             let bh = crate::eval::resume_in_blackhole_from_exit_layout(
                 &raw_values,
                 &exit_layout,
                 guard_exc,
             );
             handle_blackhole_result(bh, green_key).unwrap_or(0)
+        }
+    }
+}
+
+/// Execute a target which previously proved unable to leave its compiled entry
+/// through a compiled bridge.  This is the pre-Slice-A call path: run the
+/// callee's live PyFrame through the normal JIT entry, allowing its own hot
+/// inner traces while avoiding a CA deopt-to-blackhole on every call.
+#[cfg(target_arch = "wasm32")]
+pub extern "C" fn wasm_ca_baseline_call(frame_ptr: i64, _compiled_ptr: i64) -> i64 {
+    let Some(frame) = (unsafe { (frame_ptr as *mut PyFrame).as_mut() }) else {
+        return 0;
+    };
+    match crate::eval::eval_with_jit(frame) {
+        Ok(result) => result as i64,
+        Err(err) => {
+            set_pending_ca_exception(err);
+            0
         }
     }
 }

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -2728,6 +2728,10 @@ fn build_jit_driver_pair() -> JitDriverPair {
     majit_backend_wasm::set_ca_deopt_helper_slot(
         crate::call_jit::wasm_ca_resume_deopt as *const () as usize as u32,
     );
+    #[cfg(target_arch = "wasm32")]
+    majit_backend_wasm::set_ca_baseline_helper_slot(
+        crate::call_jit::wasm_ca_baseline_call as *const () as usize as u32,
+    );
     (d, info)
 }
 

--- a/pyre/pyre-wasm-runner/src/main.rs
+++ b/pyre/pyre-wasm-runner/src/main.rs
@@ -381,7 +381,7 @@ fn run(module_path: &PathBuf, source: &str) -> Result<i32> {
                 "decl_noadvance",
                 "ca_cell_set",
                 "ca_cells_zero",
-                "reserved14",
+                "accepted_ca",
                 "decl_ca_trampoline",
             ];
             let mut parts = Vec::new();

--- a/pyre/pyre-wasm-runner/src/main.rs
+++ b/pyre/pyre-wasm-runner/src/main.rs
@@ -422,12 +422,16 @@ fn run(module_path: &PathBuf, source: &str) -> Result<i32> {
             }
             eprintln!("[jit-stats] mc_diag {}", parts.join(" "));
         }
+        let guest_jit_execute_count = instance
+            .get_typed_func::<(), u64>(&mut store, "pyre_jit_execute_count")
+            .and_then(|f| f.call(&mut store, ()))
+            .ok();
         let host = store.data();
         eprintln!(
             "[jit-stats] compiles={} executes={} jit_calls={} linear_mem={} gc_oldgen={} gc_nursery={} \
              gc_minors={} gc_majors={} heap_live_bytes={} heap_live_count={}",
             host.jit_compile_count,
-            host.jit_execute_count,
+            guest_jit_execute_count.unwrap_or(host.jit_execute_count),
             host.jit_call_count,
             lin_mem,
             gc_oldgen,

--- a/pyre/pyre-wasm/src/lib.rs
+++ b/pyre/pyre-wasm/src/lib.rs
@@ -308,6 +308,13 @@ pub extern "C" fn pyre_jit_bridge_diag(i: u32) -> u64 {
     majit_backend_wasm::bridge_diag(i as usize)
 }
 
+/// Diagnostic-only: number of JIT trace entries made from the guest.
+#[cfg(all(target_arch = "wasm32", feature = "wasm-host"))]
+#[unsafe(no_mangle)]
+pub extern "C" fn pyre_jit_execute_count() -> u64 {
+    majit_backend_wasm::jit_execute_count()
+}
+
 /// Diagnostic-only: read a guard-failure → bridge-trace gate tally from the
 /// metainterp (`majit_metainterp::MC_DIAG`). Same export-not-import rationale
 /// as `pyre_jit_bridge_diag`.


### PR DESCRIPTION
Closes the largest wasm-JIT-vs-native(aarch64 dynasm) steady-state perf gaps: float-heavy code (residual crossings + f64 homing) and compiled→compiled loop entry (general `CALL_ASSEMBLER`). Every lever is the direct wasm analogue of what the native backends already do.

## Commits
1. **`lower float residual calls through typed direct call_indirect`** — float residual calls (`CallF`/`CallPureF`/`CallLoopinvariantF`/`CallMayForceF`, e.g. `x ** 0.5` → libm `pow`) went through the `env.jit_call` host trampoline (guest→host→guest signature reflection + arg marshalling). They now use a direct in-module `call_indirect` with a per-descr `(f64…)->f64` wasm signature declared after the existing i64/CA type families. On `nbody` this drops host crossings from **5.28M → 292K**.
2. **`home Float-typed SSA values in f64 wasm locals`** — every SSA value was homed in a uniform `i64` local, so each float op was bracketed by `i64<->f64` reinterprets that Cranelift lowers to real `fmov gp<->fp` moves. Float-typed values now use `f64` locals; a reinterpret is inserted only where a float crosses into the i64 world (frame stores, guards, residual i64-ABI args, loop-seed loads). Int/Ref-only traces coalesce to the prior single i64 local run, so their emitted module is byte-identical.
3. **`restrict direct float residual calls to all-float-arg signatures`** — review follow-up. A float-result residual target whose pointer argument is `i32` on wasm32 (e.g. `jit_bigint_to_f64_or_inf(&BigInt) -> f64`) would trap on a `(i64)->f64` `call_indirect` type mismatch. The direct path now accepts a float residual only when every argument is `Float` (unambiguous `f64`); `Int`/`Ref` args keep the reflecting trampoline. `pow` (`[Float,Float]->Float`) — the dominant win — stays direct.
4. **`enter compiled traces via in-guest call_indirect instead of the host jit_execute round-trip`** — trace entry (`glue::execute`) now transmutes the trace's shared-table slot to `extern "C" fn(u32)->u32` and runs the trace inside the guest instead of crossing to the `jit_execute_wasm` host import (the same slot the host dispatched by, and the one the CA self-recursion arm already re-enters through). The host import is retained on a dead `black_box(false)` branch so `wasm-ld` keeps it in the import table — dropping it would shift import indices and break baked JIT indices. A guest `JIT_EXECUTE_COUNT` atomic, exported as `pyre_jit_execute_count` and read by the runner, preserves the `executes` stat.
5. **`lower general CALL_ASSEMBLER to any compiled-loop callee with a terminal-decline back-off`** — the wasm backend previously declined every trace containing a `CALL_ASSEMBLER` except the self-recursive-int fib shape (`bridge_is_self_recursive_int_ca`), so an outer loop that calls an inner-loop-bearing callee never compiled and round-tripped through the interpreter each iteration.
   - `general_int_call_assembler_target` now admits a loop/bridge whose `CALL_ASSEMBLER` targets any compiled loop when every arg type and the result are `Int|Ref`.
   - `emit_ca` marshals the resolved callee geometry (frame bytes, gcmap, shared-table slot) and `call_indirect(0, callee_slot)`s it, reading the result or blackhole-resuming the callee on a non-finish exit.
   - `try_compile_ca_bridge` feeds the CA callee guard through the normal must-compile/bridge path; when the callee bridge terminally declines on wasm, `mark_call_assembler_terminal_decline` invalidates the callers so the next trace refuses the target and returns to the baseline path (`wasm_ca_baseline_call`), avoiding a deopt-to-blackhole-per-call regression.
   - Frozen-chain frame geometry reserves 64 value slots / 64 Ref homes so a later CA-callee bridge fits the loop's frame layout.

   **nbody 2.44s → 0.46s** (timeout gone); `ca_int`/`ca_innerloop` 14.8s → ~0.8s; byte-exact vs dynasm within the known cross-ISA pow ULP tolerance.

## Measured (wasm-vs-dynasm work-ratio, startup-corrected)
| bench | before | after |
|---|---|---|
| float_loop | 4.5x | **0.9x** |
| spectral_norm | 1.8x | **1.3x** |
| nbody | 17.6x | **2.4x** |

`nbody`: the float levers (host crossings + fmov) took **17.6x → 12.5x**; general `CALL_ASSEMBLER` then took **12.5x → 2.4x** (the module-global dict-call outer loop now compiles instead of round-tripping the interpreter every iteration). fannkuch's remaining **3.16x** is an irreducible wasm array-access instruction-density constant factor (wasm has no scaled-index addressing — `emit_array_addr` ≈ 9 wasm instrs vs one aarch64 `ldr [base,idx,lsl#3,#off]`), verified **not** a loop-peeling/optimizer gap: the peel-abort → retry-without-unroll is PyPy-orthodox (`virtualstate.py:372-375` pins constant jump-values, `intutils.py:1336-42` `widen_update` doesn't loosen small bounds, `pyjitpl.py:3046-50` has the same non-unrolled fallback).

## Verification
- `pyre/check.py --backend dynasm,wasm` green except the pre-existing `synth/list_insert_pop_index` BASEFAIL (both backends): dynasm 187/1, wasm 186/1.
- `float_loop`/`spectral_norm`/`ca_*` byte-exact dynasm-vs-wasm; `nbody` byte-exact within the known cross-ISA `pow` ULP tolerance.
- Bignum→float hot loop no longer traps and is byte-exact dynasm-vs-wasm.
- 18 `majit-backend-wasm` unit tests pass; `int_loop`/`fib_loop` (non-float) unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved WebAssembly JIT support for floating-point operations and optimized compiled calls.
  - Added more reliable handling for compiled call targets, deoptimization, and fallback execution.
  - Added execution-count diagnostics for tracking JIT activity.

- **Bug Fixes**
  - Improved garbage-collection safety and frame handling during compiled calls.
  - Prevented stale compiled-target metadata after recompilation.
  - Enhanced recovery when compiled call bridges cannot be completed.

- **Diagnostics**
  - Updated JIT statistics to report accepted compiled calls and guest-side execution counts when available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
