### PR TITLE
jit: anchor the abort_permanent loop-body scan at the traced loop

### DIFF
--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -2269,11 +2269,13 @@ fn probe_walk_perfn_jitcode(
 /// tail — double-running its side effects and leaving the frame positioned
 /// past the loop.  The walk's reactive `abort_permanent` decline
 /// never fires because the corrupted guard exits before reaching the
-/// marker.  When the loop is not inside a `try`, the scan is scoped to ops
-/// after the first `jit_merge_point` and before the loop's final back-edge, so
-/// neither a prologue-only marker (e.g. `COPY_FREE_VARS` ahead of a clean hot
-/// loop) nor a post-loop marker over-declines the loop.  A loop covered by an
-/// exception handler keeps the full-tail scan so a post-loop
+/// marker.  The scan is anchored at the merge point governing the loop being
+/// traced, so a marker in a preceding sibling loop cannot decline a clean
+/// following loop.  When the loop is not inside a `try`, the scan is scoped to
+/// ops after that merge point and before the loop's final back-edge, so neither
+/// a prologue-only marker (e.g. `COPY_FREE_VARS` ahead of a clean hot loop) nor
+/// a post-loop marker over-declines the loop.  A loop covered by an exception
+/// handler keeps the full-tail scan so a post-loop
 /// `abort_permanent` (e.g. the `DELETE_FAST` cleanup for `except X as e`)
 /// still declines it, because compiled-loop delivery of an uncaught raise to
 /// the handler is not yet supported.
@@ -2282,9 +2284,19 @@ fn loop_body_has_abort_permanent(w_code: *const (), start_pc: usize) -> bool {
         return false;
     };
     let code = pjc.jitcode.code.as_slice();
-    let Some(merge_point) = crate::jitcode_runtime::decoded_ops(code)
-        .find(|op| op.opname == "jit_merge_point")
-        .map(|op| op.pc)
+    let Some(merge_point) = pjc
+        .merge_entry_for(start_pc)
+        .and_then(|entry| {
+            crate::jitcode_runtime::decoded_ops(code)
+                .filter(|op| op.opname == "jit_merge_point" && op.pc >= entry)
+                .map(|op| op.pc)
+                .min()
+        })
+        .or_else(|| {
+            crate::jitcode_runtime::decoded_ops(code)
+                .find(|op| op.opname == "jit_merge_point")
+                .map(|op| op.pc)
+        })
     else {
         return false;
     };


### PR DESCRIPTION
`loop_body_has_abort_permanent` chose its scan anchor as the **first**
`jit_merge_point` in the per-CodeObject jitcode; `start_pc` was used only for the
exception-table (`loop_in_try`) lookup, never to pick the anchor.

In a function with two **sequential** loops the scan window is therefore loop1's
body whichever loop is being traced — so a marker in a preceding sibling loop
declines a following loop that carries no marker at all. A clean hot loop that
merely follows a marker-bearing loop never JIT-compiles.

## Fix

Anchor at the merge point governing the loop being traced. `start_pc` is the
loop-header green (the same value the caller feeds to `make_green_key`), so
`merge_entry_for` resolves its jitcode trace entry and the governing merge point
is the first one at or after that entry — the same forward selection
`loop_header_merge_point_regs` already makes for a header entry, whose own
doc-comment names this exact hazard:

> Picking the largest one BEFORE `entry` would select a PRECEDING sibling loop's
> merge point (a function with two loops) ... the born-between-loops abort.

Falls back to the previous first-merge-point anchor when the map misses.
`back_edge_end` and the marker scan already filter on `pc > merge_point`, so they
follow the corrected anchor with no further edit — a preceding sibling loop's
back-edge sits before the anchor and is naturally excluded.

The change is local to `loop_body_has_abort_permanent`. `loop_header_merge_point_regs`
is deliberately left alone: it carries a nested-loop exception that is out of scope
for the abort scan.

## Verification

Probed with a `while`-loop pair and a `del G` (DELETE_GLOBAL) marker. `while`, not
`for`: a FOR_ITER frame whose bodies are not all allow-listed is declined
whole-frame by `unsupported_jit_shape` before this function is reached, which
masks the probe.

| probe | before | after |
|---|---:|---:|
| clean loop alone (control) | 1 | 1 |
| marker loop **then clean loop** | **0** | **1** |
| clean loop then marker loop | 1 | 1 |

All probe outputs are byte-identical to CPython.

`pyre/check.py --synthetic-only`: **dynasm 177/177**, **cranelift 177/177**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
