### PR TITLE
jit/gc: #551 review follow-ups + correct the #519 aliasing fix-plan

### DIFF
--- a/majit/majit-backend-dynasm/src/aarch64/assembler.rs
+++ b/majit/majit-backend-dynasm/src/aarch64/assembler.rs
@@ -35,6 +35,22 @@ const AARCH64_GEN_REGS: [crate::regloc::RegLoc; 18] = crate::aarch64::registers:
 
 const AARCH64_FLOAT_REGS: [crate::regloc::RegLoc; 8] = crate::aarch64::registers::ALL_VFP_REGS;
 
+/// Bytes the trace entry frame reserves: the frame-pointer/link pair, the
+/// callee-saved registers the trace body clobbers, and the reserved
+/// bitmask-address register. The prologue, the stack-overflow early return and
+/// the epilogue must all agree on this, or the return unwinds a corrupt SP.
+const CALL_FRAME_SIZE: u32 = 64;
+
+/// Offset of `BITMASK_ADDR_REG`'s save slot within the entry frame.
+const X24_SAVE_OFFSET: u32 = 56;
+
+const _: () = assert!(X24_SAVE_OFFSET + 8 <= CALL_FRAME_SIZE);
+const _: () = assert!(CALL_FRAME_SIZE % 16 == 0, "aarch64 SP stays 16-byte aligned");
+// The prologue/epilogue spell the reserved register as a dynasm `x24` literal,
+// which no expression ties back to `registers`. Fail the build rather than
+// silently save the wrong register if the reservation ever moves.
+const _: () = assert!(crate::aarch64::registers::BITMASK_ADDR_REG.value == 24);
+
 /// Resolved argument: either a frame slot (frame-pointer-relative offset) or a constant.
 enum ResolvedArg {
     /// Frame-pointer-relative byte offset: [rbp + offset] on x64, [x29, #offset] on aarch64.
@@ -1262,10 +1278,10 @@ impl<'a> AssemblerARM64<'a> {
     /// ```
     fn _call_header(&mut self, inputargs: &[InputArg]) {
         dynasm!(self.mc ; .arch aarch64
-            ; stp x29, x30, [sp, #-64]!
+            ; stp x29, x30, [sp, -(CALL_FRAME_SIZE as i32)]!
             ; stp x19, x20, [sp, #16]   // save callee-saved regs
             ; stp x21, x22, [sp, #32]   // save callee-saved regs
-            ; str x24, [sp, #56]        // save reserved bitmask-addr reg
+            ; str x24, [sp, X24_SAVE_OFFSET]  // save reserved bitmask-addr reg
             ; mov x29, x0
         );
         // Bake the process-global eval-breaker-word address into the reserved
@@ -1326,8 +1342,8 @@ impl<'a> AssemblerARM64<'a> {
                     ; mov x0, x29
                     ; ldp x19, x20, [sp, #16]
                     ; ldp x21, x22, [sp, #32]
-                    ; ldr x24, [sp, #56]
-                    ; ldp x29, x30, [sp], #64
+                    ; ldr x24, [sp, X24_SAVE_OFFSET]
+                    ; ldp x29, x30, [sp], CALL_FRAME_SIZE as i32
                     ; ret
                     ; =>continue_label
                 );
@@ -1350,8 +1366,8 @@ impl<'a> AssemblerARM64<'a> {
             ; mov x0, x29
             ; ldp x19, x20, [sp, #16]   // restore callee-saved regs
             ; ldp x21, x22, [sp, #32]   // restore callee-saved regs
-            ; ldr x24, [sp, #56]        // restore reserved bitmask-addr reg
-            ; ldp x29, x30, [sp], #64
+            ; ldr x24, [sp, X24_SAVE_OFFSET]  // restore reserved bitmask-addr reg
+            ; ldp x29, x30, [sp], CALL_FRAME_SIZE as i32
             ; ret
         );
     }

--- a/majit/majit-backend-dynasm/src/aarch64/assembler.rs
+++ b/majit/majit-backend-dynasm/src/aarch64/assembler.rs
@@ -45,7 +45,10 @@ const CALL_FRAME_SIZE: u32 = 64;
 const X24_SAVE_OFFSET: u32 = 56;
 
 const _: () = assert!(X24_SAVE_OFFSET + 8 <= CALL_FRAME_SIZE);
-const _: () = assert!(CALL_FRAME_SIZE % 16 == 0, "aarch64 SP stays 16-byte aligned");
+const _: () = assert!(
+    CALL_FRAME_SIZE % 16 == 0,
+    "aarch64 SP stays 16-byte aligned"
+);
 // The prologue/epilogue spell the reserved register as a dynasm `x24` literal,
 // which no expression ties back to `registers`. Fail the build rather than
 // silently save the wrong register if the reservation ever moves.

--- a/pyre/pyre-interpreter/src/module/signal/signalstate.rs
+++ b/pyre/pyre-interpreter/src/module/signal/signalstate.rs
@@ -263,6 +263,14 @@ mod tests {
         unsafe { &*(addr as *const AtomicUsize) }.load(Ordering::Relaxed)
     }
 
+    /// Drives process-global signal state: installs a real SIGINT handler,
+    /// registers this `ActionFlag`'s ticker as *the* cell the handler writes
+    /// (`TICKER_PTR`), raises a real signal, and asserts on the shared
+    /// eval-breaker word. Nothing serializes that, so this must stay the only
+    /// test in the crate that touches those globals — a second one running in
+    /// parallel would race it. Tests that merely build an `ActionFlag` are safe
+    /// alongside it: the async-bit mirror is gated on the registered ticker, so
+    /// an unregistered flag's `reset_ticker` never reaches the shared word.
     #[test]
     fn signal_during_warmup_sets_async_bit() {
         let _reset = ResetSignalState;

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -2811,17 +2811,32 @@ unsafe fn compile_snapshot_root_walker_area(
 ///
 /// # Safety / aliasing
 ///
-/// This mints a `&mut JitDriverPair` from the `JIT_DRIVER` cell. When a
-/// collection is triggered by an allocation inside a `MetaInterp` method that
-/// is itself reached through a live `driver_pair()` `&mut`, that outer borrow
-/// and this one both alias the same cell — formally undefined under
-/// stacked/tree borrows. It holds in practice because the collection runs at a
-/// safepoint with the mutator paused and the walker only rewrites `GcRef`
-/// slots in place (moving-GC forwarding), which the outer borrow re-reads as
-/// forwarded pointers when it resumes. The orthodox fix is to move the
-/// GC-visible root fields (`compiled_loops` / `partial_trace` /
-/// `exported_state` / `framestack` / `tracing`) behind interior mutability so
-/// the walker forwards them without re-borrowing the whole driver.
+/// This mints a second `&mut JitDriverPair` from the `JIT_DRIVER` cell. A
+/// collection triggered by an allocation under a live `driver_pair()` `&mut`
+/// arrives here on the *same* thread — the allocating thread becomes the
+/// collector and walks its own registered areas — so the outer borrow is a
+/// suspended frame on this stack, not another thread's. Two live `&mut` to one
+/// cell is undefined under stacked/tree borrows.
+///
+/// It has not been observed to miscompile: the walker only rewrites `GcRef`
+/// slots in place (moving-GC forwarding) and the outer borrow re-reads them as
+/// forwarded pointers when it resumes. That explains why it survives; it does
+/// not license the aliasing.
+///
+/// The minimum sound configuration is a load-bearing triple — dropping any one
+/// leg leaves the aliasing intact:
+///   1. this walker stops forming a `&mut` (or `&`) to the pair;
+///   2. `driver_pair()` stops returning `&'static mut` — the exclusivity is
+///      minted there, and that is what invalidates every other access;
+///   3. the GC-visible root fields (`compiled_loops` / `partial_trace` /
+///      `exported_state` / `framestack` / `tracing`) move behind interior
+///      mutability.
+///
+/// Wrapping the fields alone does NOT help: `UnsafeCell` only opts out of the
+/// immutability of `&T`, while a `&mut T` retag is `Unique` over the whole
+/// pointee, UnsafeCell bytes included. Nor does switching this walker to raw
+/// pointers: its `data` is captured at registration, so its tag sits below the
+/// outer `&mut`'s on the borrow stack and even a read through it pops that tag.
 unsafe fn jit_driver_pair_from_root_area(data: *const ()) -> Option<&'static mut JitDriverPair> {
     let cell = unsafe { &*(data as *const UnsafeCell<Option<JitDriverPair>>) };
     unsafe { (&mut *cell.get()).as_mut() }


### PR DESCRIPTION
Three small follow-ups from #551 (merged as `9ba9913623e`). Two are the review findings deferred out of that PR; one corrects a note #551 itself landed.

### `jit: correct the driver_pair aliasing safety note`

#551 added a `# Safety / aliasing` note to `jit_driver_pair_from_root_area` that prescribed the wrong fix. It said the orthodox fix was to move the five GC-visible root fields behind interior mutability — **that is insufficient on its own**: `UnsafeCell` opts out only of the immutability guarantee of `&T`, while a `&mut T` retag is `Unique` over the whole pointee, UnsafeCell bytes included. As long as `driver_pair()` returns `&'static mut`, wrapping the fields changes nothing, so a future implementer following the note would have paid the entire epic and still had the UB.

The note now states the minimum sound configuration as a load-bearing triple — the walker forms no reference to the pair, `driver_pair()` returns no `&mut`, and the fields move behind interior mutability — and records that dropping any one leg leaves the aliasing intact. It also records that a raw-pointer walker does not help (its `data` tag is captured at registration and sits *below* the outer `&mut`'s on the borrow stack, so even a read through it pops that tag), and that the reentrant walk is same-thread: the allocating thread becomes the collector and walks its own areas, so there is no "different thread can't alias T's stack" escape.

Doc-only. Full analysis, including the reachability paths and why severity is currently unknown (no Miri in the repo), is on #519, which stays open.

### `aarch64: name the entry frame size and x24 save offset`

The 64-byte frame size and the x24 save offset were dynasm literals at three sites that must agree — the prologue, the stack-overflow early return, and the epilogue — and where a disagreement corrupts SP on return. All three now route through `CALL_FRAME_SIZE` / `X24_SAVE_OFFSET`; dynasm takes both as expressions in the pre-index, post-index and unsigned-offset forms.

Three compile-time assertions back it: the save slot fits inside the frame, the frame keeps SP 16-byte aligned, and `BITMASK_ADDR_REG` is still x24. The last one answers the other half of the review note — the dynasm register literals cannot reference `registers`, so the build now fails instead of silently saving the wrong register if the reservation ever moves.

### `signal: note the async-bit test's global exclusivity`

The review asked to serialize `signal_during_warmup_sets_async_bit`. Re-checking the premise, there is nothing to serialize against: it is the only test in the crate touching the process-global signal / eval-breaker state (the `executioncontext.rs` tests are dict-storage / namespace-slot), and the `is_registered_ticker` gate keeps an unregistered `ActionFlag`'s `reset_ticker` off the shared word. A mutex would be a no-op, and `#[ignore]` would discard the only coverage that proves the real OS handler arms bit0.

So the implicit invariant is made explicit on the test instead: it must stay the only such test, and the reason its siblings are safe alongside it. Worth revisiting only if a second signal test appears or a flake is observed.

### Verification

| gate | result |
|---|---|
| `check.py --backend cranelift` | **188/188 ALL PASSED** (current base) |
| `check.py --backend dynasm` | **188/188 ALL PASSED** (on `09c32a82c18`, this same tree) |
| `cargo test -p majit-backend-dynasm` | **59 + 12 green** — real traces execute through the changed prologue/epilogue |
| `cargo test -p pyre-interpreter … signal_during_warmup_sets_async_bit` | green |

One caveat, stated plainly: the dynasm gate's clean 188/188 was taken before `origin/main` advanced under the branch. Re-runs on the current base flake on the known load-sensitive pair — the local box is at load average 21 with 89 users, and the failing test *rotates* between runs (`raise_catch` 1.5× fail → 1.4× pass, then `nested_loop` at exactly the 2.0× threshold) with no code change in between, which is variance rather than a regression. The change is a literal→const substitution in the prologue, which runs once per trace entry and cannot reach the loop body these benchmarks measure. CI decides.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Reliability**
  * Improved AArch64 runtime frame handling with validated stack alignment and register preservation safeguards.
  * Added consistency checks to help detect invalid low-level configuration during development.

* **Documentation**
  * Expanded documentation for signal-handling tests, including shared-state and concurrency considerations.
  * Clarified safety assumptions around garbage-collection root processing and thread-local runtime state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->