### PR TITLE
jit: compile bridges for guard failures inside an inlined callee

### DIFF
--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -4857,7 +4857,21 @@ fn getarrayitem_vable_via_metainterp(
     // Mirror `getfield_vable_via_metainterp`: stamp the read result's
     // concrete so `concrete_of_opref(result)` honors the Box.value
     // contract for downstream consumers; `Value::Void` = no live concrete.
-    if !matches!(shadow_value, Value::Void) {
+    //
+    // An indexed read hands back the STORED box, so the stamp is a write onto a
+    // box that may already carry a live concrete. A frame whose array slot is
+    // still an unmaterialized hole reads NULL while the real Ref lives in the
+    // guard's register file, so stamping that NULL would clobber the live value
+    // (last write wins) and fold a downstream may-force residual's Ref arg to
+    // NULL -> `MayForceNullRefArgUnsupported`. Skip ONLY that clobber: a NULL
+    // read onto a box with no live Ref still stamps, keeping NULL a real
+    // concrete for the slots that genuinely hold one.
+    let clobbers_live_ref = matches!(shadow_value, Value::Ref(majit_ir::GcRef(0)))
+        && matches!(
+            ctx.trace_ctx.box_value(result),
+            Some(Value::Ref(majit_ir::GcRef(addr))) if addr != 0
+        );
+    if !matches!(shadow_value, Value::Void) && !clobbers_live_ref {
         ctx.trace_ctx.set_opref_concrete(result, shadow_value);
     }
     let dst = code[op.pc + 7] as usize;
@@ -24305,13 +24319,48 @@ fn handle(
             // sub-walk — the framestack is non-empty — and only when a token
             // exists) routes the inlined loop-bearing callee to its own compiled
             // loop, the trait-parity `LoopTargetDescr`/`CALL_ASSEMBLER` shape.
+            //
+            // "An inlined callee's own loop" is whose loop this header is, which
+            // a non-empty framestack does not establish: a bridge's outer-frame
+            // continuation runs the trace ROOT forward (with a frame still on the
+            // stack) and reaches the very loop it exited, so the framestack proxy
+            // matches there too and routes a bridge that must close with a JUMP
+            // back into that loop (`CloseLoop` -> `CloseLoopWithArgs`) into a
+            // CALL_ASSEMBLER request no caller consumes, aborting it
+            // (`OuterNonTerminate`). Discriminate on the header's frame vs the
+            // trace root: same code = the root's own loop, so fall through to the
+            // normal loop-crossing path.
+            let fbw_root_code = {
+                let sym_ptr = ctx.fbw_mode.snapshot_sym;
+                if sym_ptr.is_null() {
+                    None
+                } else {
+                    unsafe {
+                        let sym = &*sym_ptr;
+                        if sym.jitcode.is_null() {
+                            None
+                        } else {
+                            let jc = &*sym.jitcode;
+                            let raw = jc.payload.code_ptr;
+                            if raw.is_null() {
+                                None
+                            } else {
+                                Some(pyre_interpreter::live_code_wrapper(raw as *const ()))
+                            }
+                        }
+                    }
+                }
+            };
             if fbw_loop_callee_ca_enabled() {
                 let callee_code = ctx
                     .session
                     .borrow()
                     .framestack
                     .last()
-                    .map(|frame| frame.w_code);
+                    .map(|frame| frame.w_code)
+                    .filter(|&cc| {
+                        fbw_root_code.is_none_or(|root| root as *const () != cc as *const ())
+                    });
                 if let Some(callee_code) = callee_code {
                     let callee_key =
                         crate::driver::make_green_key(callee_code as *const (), next_instr);

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -13013,6 +13013,29 @@ pub(crate) fn setup_reconstructed_callee_frame(
     let ec_const = ctx.const_ref(execution_context as i64);
 
     let locals_boxes: Vec<OpRef> = recipe.registers_r[..nlocals].to_vec();
+    // `registers_r` are the paused root's OpRefs, whose trace concrete can still
+    // read as a stale NULL once reused as the reconstructed callee's locals,
+    // while `concrete_r[k]` holds the value captured at guard failure. A
+    // residual call consuming such a local folds its Ref arg to concrete NULL
+    // and the walk stops on `MayForceNullRefArgUnsupported`, so no bridge is
+    // ever built and the guard re-deopts forever. Restamp each local from its
+    // captured value; a NULL/Void capture is an unmaterialized hole and is left
+    // alone, matching how `setup_bridge_sym` seeds the root frame's slots.
+    for (k, &opref) in locals_boxes.iter().enumerate() {
+        if opref.is_none() {
+            continue;
+        }
+        let Some(&captured) = recipe.concrete_r.get(k) else {
+            continue;
+        };
+        if matches!(
+            captured,
+            majit_ir::Value::Void | majit_ir::Value::Ref(majit_ir::GcRef(0))
+        ) {
+            continue;
+        }
+        ctx.try_set_opref_concrete(opref, captured);
+    }
     let frame_vable = crate::helpers::emit_new_pyframe_inline_with_params(
         ctx,
         &locals_boxes,


### PR DESCRIPTION
## Problem

A hot loop that inlines a callee whose body branches never compiled a bridge for the rare arm — the guard deopted to the blackhole on every failure, leaving the JIT barely ahead of the interpreter.

Probe (3M-iteration loop over a branching helper):

```python
def helper(i):
    if i % 7 == 0:
        return i * 2
    return i + 1

def main():
    s = 0; i = 0
    while i < 3000000:
        s = s + helper(i)
        i = i + 1
    print(s)
main()
```

`bridges_compiled=0, loops_aborted=2142, guard_failures=428544` — 3.75s against 9.06s for the interpreter.

This is **not** the multi-frame epic (gh#343): `n_recipes=1`, and the depth-1 reconstruction machinery already works. It was three bounded defects in the guard-reconstruction path, each masking the next.

## Changes

**`setup_reconstructed_callee_frame`** — the reconstructed callee's local boxes are the paused root's OpRefs, whose trace concrete can read as a stale NULL, while the value captured at guard failure lives in `concrete_r`. Restamp each local from its capture, skipping Void/NULL captures the way `setup_bridge_sym` already skips them when seeding the root frame.

**`getarrayitem_vable_via_metainterp`** — an indexed read hands back the *stored* box, so stamping the read result writes onto a box that may already carry a live concrete. A frame whose array slot is an unmaterialized hole reads NULL while the real Ref is still in the guard's register file; stamping that NULL clobbered the live value and folded a downstream may-force residual's Ref arg to NULL (`MayForceNullRefArgUnsupported`). Skip **only** that clobber — a NULL read onto a box with no live Ref still stamps, so slots that genuinely hold NULL keep it.

**`jit_merge_point`** — the loop-callee `CALL_ASSEMBLER` branch used a non-empty framestack as its "inside a sub-walk" test. A bridge's outer-frame continuation runs the trace root forward with a frame still on the stack and reaches the loop it exited, so that test also matched a bridge which must close with a JUMP, routing it to a `CALL_ASSEMBLER` request no caller consumes (`OuterNonTerminate`). Compare the header's frame against the trace root instead.

All three are required; dropping any one restores `bridges_compiled=0`.

## Results

Probe, both backends — output identical to `PYRE_NO_JIT=1`:

| | before | after |
|---|---|---|
| bridges_compiled | 0 | 1 |
| loops_aborted | 2142 | 1 |
| guard_failures | 428544 | 201 |
| wall clock | 3.75s | 0.04s |

Bench corpus JIT stats are **byte-identical to baseline on all 13 benches** (measured as an explicit A/B against a pristine build, isolated from other load), including `nbody` 5/5/0/1286, `fannkuch` 5/40/0/8202 and `spectral_norm` 3/2/0/441.

`check.py --backend dynasm,cranelift`: **dynasm 189/189, cranelift 189/189**.

## Note for reviewers

An earlier iteration of the middle change used a blanket "never stamp a NULL read" rule. It unlocked the same probe but regressed `nbody` ~8x (0.26s → 2.17s, `loops_aborted` 0 → 5): the may-force check fires only on `Some(Value::Ref(GcRef(0)))`, so a blanket skip left the box *unknown* and merely dodged the safety check, while also suppressing genuine NULL stamps other traces depend on. The narrow `clobbers_live_ref` rule here fixes the actual defect and leaves every genuine NULL stamp intact. Worth knowing that `check.py` cannot see that class of regression — its `nbody` gate is 10s and the regressed build ran 2.17s green on both backends.

🤖 Generated with [Claude Code](https://claude.com/claude-code)