### PR TITLE
jit: gh#389(b) nested-loop operand-stack tracking — vstack classify + forward-select merge-point + STORE_FAST mirror recovery

### DIFF
--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -9895,6 +9895,13 @@ fn classify_vstack_opcode(
         | Instruction::StoreSubscr
         | Instruction::DeleteSubscr
         | Instruction::StoreSlice
+        // LIST_APPEND / SET_ADD / MAP_ADD / LIST_EXTEND pop their value operand(s)
+        // and mutate the collection PEEK'd in place below them — a side-store,
+        // same shape as STORE_SUBSCR: the surviving TOS box stays put.
+        | Instruction::ListAppend { .. }
+        | Instruction::SetAdd { .. }
+        | Instruction::MapAdd { .. }
+        | Instruction::ListExtend { .. }
         | Instruction::DeleteFast { .. }
         | Instruction::DeleteName { .. }
         | Instruction::DeleteGlobal { .. }

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -4942,12 +4942,39 @@ fn setarrayitem_vable_via_metainterp(
             });
         }
     };
-    let value = match value_bank {
+    let mut value = match value_bank {
         'i' => read_int_reg(code, op, 2, ctx)?,
         'r' => read_ref_reg(code, op, 2, ctx)?,
         'f' => read_float_reg(code, op, 2, ctx)?,
         _ => unreachable!("value_bank must be 'i', 'r' or 'f'"),
     };
+    // A STORE_FAST (`index < nlocals`) pops the operand-stack TOS and writes
+    // it into a local slot.  When the popped value lives in an operand-stack
+    // temp that spans a nested loop, the loop-header merge-point seeds no
+    // operand-stack color (`trace.rs` loop-header entry), so the codewriter's
+    // value register reads back `OpRef::NONE` even though the box is live.
+    // The walk-level operand-stack mirror (`vstack_boxes`, the analog of
+    // `MIFrame.registers_r`) is the authoritative kept-stack source and was
+    // maintained across the nested loop; recover the TOS box from it.  Writing
+    // the unbound `NONE` into the vable array otherwise leaves an untyped slot
+    // that fails the guard-snapshot buildability precondition
+    // (`GuardSnapshotVableUntyped`).  Gate on a live mirror + a Ref store into
+    // the local region so a genuine null / non-mirrored slot keeps the legacy
+    // read.
+    if value.is_none() && value_bank == 'r' && ctx.vstack_valid {
+        let full_body_sym = ctx.fbw_mode.snapshot_sym;
+        if !full_body_sym.is_null() {
+            // SAFETY: pointer live for the full-body walk; read-only.
+            let nlocals = unsafe { (*full_body_sym).nlocals as i64 };
+            if index_value >= 0 && index_value < nlocals {
+                if let Some(&tos) = ctx.vstack_boxes.last() {
+                    if !tos.is_none() {
+                        value = tos;
+                    }
+                }
+            }
+        }
+    }
     let (fdescr, adescr) = vable_array_descrs_from_jitcode(code, op, 3, 5, ctx)?;
     let concrete = ctx
         .trace_ctx

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -563,37 +563,6 @@ pub fn trace_bytecode(
 /// unfolded `residual_call`).  See
 /// `project_issue73_architecture_walker_as_tracer_2026_05_28`.
 ///
-/// Whether the loop whose header merge point is `header_mp_pc` (the loop a
-/// header entry at `entry` is about to trace) is NESTED inside another loop
-/// still active at `entry`.
-///
-/// A backward `goto/L` (target `< pc`) is a loop back-edge spanning
-/// `[target, goto_pc]`.  The loop being traced is nested iff some back-edge
-/// `[t, g]` ENCLOSES it: it starts before the entry (`t < entry`) and closes
-/// AFTER the whole inner loop (`g > header_mp_pc`).  A PRECEDING sibling
-/// loop's back-edge closes before `entry` (`g < header_mp_pc`) so it does not
-/// match; the inner loop's OWN back-edge is excluded because its target lands
-/// at its own header (the first merge point at or after `t` is `header_mp_pc`
-/// itself, not an earlier loop).
-fn header_entry_is_nested(code: &[u8], entry: usize, header_mp_pc: usize) -> bool {
-    let first_mp_at_or_after = |t: usize| {
-        crate::jitcode_runtime::decoded_ops(code)
-            .filter(|op| op.opname == "jit_merge_point")
-            .map(|op| op.pc)
-            .filter(|&pc| pc >= t)
-            .min()
-    };
-    crate::jitcode_runtime::decoded_ops(code)
-        .filter(|op| op.opname == "goto")
-        .any(|op| {
-            let target = crate::jitcode_dispatch::read_label(code, &op, 0);
-            target < op.pc // backward branch = loop back-edge
-                && target < entry
-                && op.pc > header_mp_pc
-                && first_mp_at_or_after(target).is_some_and(|mp| mp < header_mp_pc)
-        })
-}
-
 /// Decode the loop-header `jit_merge_point` that governs the resume
 /// coordinate `entry` and return its green-ref (`gr`) and red (`rr`)
 /// register lists.
@@ -625,15 +594,6 @@ fn header_entry_is_nested(code: &[u8], entry: usize, header_mp_pc: usize) -> boo
 ///    merge point, so the governing op is the LAST merge point at or before
 ///    `entry`.
 ///
-/// EXCEPTION: a header entry into a loop that is NESTED inside another loop
-/// still active at `entry` (a `for` inside a `while`) keeps the pre-fix
-/// behavior — the enclosing loop's (earlier) merge point is selected, which
-/// leaves the inner loop's own green color `OpRef::NONE` so the inner-loop
-/// trace declines at its merge point instead of compiling.  pyre's walker
-/// miscompiles the bridges an inner nested loop closes into (wrong result),
-/// so declining (and running the inner loop interpreted) is the safe shape
-/// until that separate nested-loop limitation is fixed.  Only the top-level
-/// sibling-loop case is newly enabled by the forward selection.
 pub(crate) fn loop_header_merge_point_regs(
     code: &[u8],
     entry: usize,
@@ -650,14 +610,20 @@ pub(crate) fn loop_header_merge_point_regs(
             .max()
             .or_else(|| merge_point_pcs().filter(|&pc| pc >= entry).min())
     } else {
-        let forward = merge_point_pcs().filter(|&pc| pc >= entry).min();
-        match forward {
-            Some(f) if !header_entry_is_nested(code, entry, f) => Some(f),
-            _ => merge_point_pcs()
-                .filter(|&pc| pc <= entry)
-                .max()
-                .or(forward),
-        }
+        // Header entry: the governing merge point is the FIRST at or after
+        // `entry` — the op the walk is about to reach — mirroring
+        // opimpl_jit_merge_point binding the merge point it is about to
+        // execute (pyjitpl.py:1537). A sibling loop and a nested inner loop
+        // both forward-select their own header, so a `for` inside a `while`
+        // seeds its own pycode/frame/ec and compiles standalone
+        // (reached_loop_header closes it via same_greenkey on
+        // current_merge_points, pyjitpl.py:3018-3060). Fall back to the last
+        // preceding merge point only for a straight-line entry with no merge
+        // point ahead.
+        merge_point_pcs()
+            .filter(|&pc| pc >= entry)
+            .min()
+            .or_else(|| merge_point_pcs().filter(|&pc| pc <= entry).max())
     }?;
     let mut cursor = mp_pc + 1 + 1; // opcode byte + jdindex (`c`)
     let mut lists: [Vec<u8>; 6] = Default::default();


### PR DESCRIPTION
gh#389(b) 계열: with-block/comprehension 내부 hot loop가 JIT token을 받지 못하던 문제 중, 중첩 루프에 걸친 operand-stack 값 추적 계층 세 개.

## 커밋
1. **LIST_APPEND/SET_ADD/MAP_ADD/LIST_EXTEND vstack 분류** (`9be219acf0c`) — 이 opcode들이 값 operand를 pop하는 것을 `classify_vstack_opcode`가 인식하도록 하여 중첩 루프를 가로지르는 동안 vstack mirror가 유효하게 유지됨.
2. **중첩 inner-loop 헤더 merge-point forward-select** (`f278956f4a3`) — `trace.rs`.
3. **중첩 루프에 걸친 STORE_FAST 값을 vstack mirror에서 복구** (`7fd17f7527a`) — inner-loop-header 재시드가 operand-stack color를 심지 않아 값 레지스터가 `OpRef::NONE`으로 읽히는 케이스에서, authoritative kept-stack인 `ctx.vstack_boxes` TOS로부터 값을 회수 (`setarrayitem_vable_via_metainterp`).

## 검증
- `check.py --backend dynasm` 189/189 ALL PASSED
- `check.py --backend cranelift` 189/189 ALL PASSED
- comprehension repro (while 루프 내 `[j for j in range(10)]`) JIT/no-jit/cpython 모두 30000 일치

## 남은 작업
gh#389(b)의 마지막 계층(3b, `UnfoldableListAppendResidualUnsupported`: empty-list 첫 append의 realloc-aware 저널링)은 no-replay 아키텍처 epic에 종속되어 이 브랜치 단독으로는 착지 불가로 스코핑됨. 별도 후속.

— *authored by Claude*
