### PR TITLE
_ctypes: functional scalar/aggregate slice with foreign calls

### DIFF
--- a/pyre/pyre-interpreter/src/module/_ctypes/cdata.rs
+++ b/pyre/pyre-interpreter/src/module/_ctypes/cdata.rs
@@ -1,0 +1,478 @@
+//! `_SimpleCData` — the scalar ctypes base type and its byte buffer.
+//!
+//! Each `_SimpleCData` instance carries a fixed-size `bytearray` under the
+//! reserved instance-dict key `"_b_"`; that bytearray's backing `Vec<u8>` is
+//! allocated through `malloc_raw` (a non-movable heap box) so its data pointer
+//! is stable for `addressof`/`byref`/foreign-call arguments as long as the
+//! buffer is never resized — and simple buffers are fixed-size.
+//!
+//! Per-type metadata (`size`, `align`, ffi type, pointer-ness) is derived
+//! lazily from the single-char `_type_` class attribute via `host_env`, rather
+//! than cached in a per-type `StgInfo`.  Reading `_type_` off the class also
+//! transparently handles user subclasses (`class MyInt(c_int)`).
+
+use super::type_ns_store;
+use pyre_object::PyObjectRef;
+use rustpython_host_env::ctypes as host_ctypes;
+use std::cell::RefCell;
+
+/// Reserved instance-dict key holding the backing `bytearray` (root storage,
+/// or — for a sub-view — a shared reference to the **root's** bytearray).
+const CDATA_BUFFER_KEY: &str = "_b_";
+/// Byte offset of a sub-view from the start of the root buffer (absent ⇒ 0).
+const BOFF_KEY: &str = "_boff_";
+/// View size in bytes (absent ⇒ the whole buffer from `_boff_`).
+const BSZ_KEY: &str = "_bsz_";
+/// The parent CData object a sub-view was carved from (keeps it alive).
+const BBASE_KEY: &str = "_b_base_";
+/// Raw address of an external (non-bytearray-backed) view.
+const BADDR_KEY: &str = "_baddr_";
+/// Lazily-created keepalive dict on a root object.
+const OBJECTS_KEY: &str = "_objects_";
+
+thread_local! {
+    static SIMPLECDATA_TYPE_OBJ: std::cell::OnceCell<PyObjectRef> =
+        const { std::cell::OnceCell::new() };
+}
+
+/// The native `_SimpleCData` type object (cached, `hasdict=true`).
+pub(super) fn simplecdata_type() -> PyObjectRef {
+    SIMPLECDATA_TYPE_OBJ.with(|c| {
+        *c.get_or_init(|| {
+            let tp = crate::typedef::make_builtin_type("_SimpleCData", init_simplecdata_type);
+            unsafe { pyre_object::typeobject::w_type_set_hasdict(tp, true) };
+            tp
+        })
+    })
+}
+
+fn init_simplecdata_type(ns: PyObjectRef) {
+    type_ns_store(
+        ns,
+        "__new__",
+        crate::make_builtin_function("__new__", simplecdata_new),
+    );
+    // `value` — data descriptor: getter decodes the buffer, setter encodes.
+    let value_getter = crate::make_builtin_function_with_arity("value", value_getter, 2);
+    let value_setter = crate::make_builtin_function_with_arity("value", value_setter, 3);
+    type_ns_store(
+        ns,
+        "value",
+        crate::typedef::make_getset_property_named(
+            value_getter,
+            value_setter,
+            pyre_object::PY_NULL,
+            "value",
+        ),
+    );
+    // `from_param` — a classmethod the metaclass provides in CPython; the
+    // package's `_reset_cache` reads `c_wchar_p.from_param` at import.  The
+    // slice marshals arguments directly (§5.2) rather than via `from_param`,
+    // so this is an identity stub that only has to exist and be gettable.
+    type_ns_store(
+        ns,
+        "from_param",
+        pyre_object::function::w_classmethod_new(crate::make_builtin_function(
+            "from_param",
+            simplecdata_from_param,
+        )),
+    );
+}
+
+/// `_SimpleCData.from_param(cls, value)` — identity stub (see caller note).
+fn simplecdata_from_param(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    // args[0] is the bound `cls`; the argument to convert is args[1].
+    Ok(args.get(1).copied().unwrap_or_else(pyre_object::w_none))
+}
+
+/// `_SimpleCData.__new__(cls, value=None)`.
+fn simplecdata_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    if args.is_empty() || !unsafe { pyre_object::is_type(args[0]) } {
+        return Err(crate::PyError::type_error(
+            "_SimpleCData.__new__(): not enough arguments",
+        ));
+    }
+    let cls = args[0];
+    let tc = type_code_of(cls).ok_or_else(|| crate::PyError::type_error("abstract class"))?;
+    let (pos, _kwargs) = crate::builtins::split_builtin_kwargs(&args[1..]);
+    let value = pos.first().copied();
+    new_simplecdata_obj(cls, &tc, value)
+}
+
+/// Build a fresh `_SimpleCData` instance of `cls` with type code `tc`,
+/// optionally initialised from a Python `value`.
+pub(super) fn new_simplecdata_obj(
+    cls: PyObjectRef,
+    tc: &str,
+    value: Option<PyObjectRef>,
+) -> Result<PyObjectRef, crate::PyError> {
+    let size = host_ctypes::simple_type_size(tc).ok_or_else(|| invalid_type_code_error())?;
+    let ba = pyre_object::w_bytearray_new(size);
+    if let Some(v) = value {
+        let bytes = encode_value(tc, v)?;
+        let n = bytes.len().min(size);
+        unsafe {
+            pyre_object::w_bytearray_data_mut(ba)[..n].copy_from_slice(&bytes[..n]);
+        }
+    }
+    let obj = pyre_object::w_instance_new(cls);
+    let d = crate::baseobjspace::getdict(obj);
+    if d.is_null() {
+        return Err(crate::PyError::type_error(
+            "ctypes instance has no instance dict",
+        ));
+    }
+    unsafe { pyre_object::w_dict_setitem_str(d, CDATA_BUFFER_KEY, ba) };
+    Ok(obj)
+}
+
+/// `_SimpleCData.value` getter — `(descr, instance)`.
+fn value_getter(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    let obj = args[1];
+    let cls = unsafe { pyre_object::w_instance_get_type(obj) };
+    let tc = type_code_of(cls).ok_or_else(|| crate::PyError::type_error("abstract class"))?;
+    let bytes = cdata_bytes(obj)
+        .ok_or_else(|| crate::PyError::type_error("ctypes instance has no buffer"))?;
+    Ok(decoded_to_pyobject(host_ctypes::decode_type_code(
+        &tc, bytes,
+    )))
+}
+
+/// `_SimpleCData.value` setter — `(descr, instance, value)`.
+fn value_setter(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    let obj = args[1];
+    let value = args[2];
+    let cls = unsafe { pyre_object::w_instance_get_type(obj) };
+    let tc = type_code_of(cls).ok_or_else(|| crate::PyError::type_error("abstract class"))?;
+    let bytes = encode_value(&tc, value)?;
+    cdata_write(obj, 0, &bytes);
+    Ok(pyre_object::w_none())
+}
+
+// ── buffer helpers (b_ptr / b_size / b_base equivalents) ───────────────
+
+/// Read a `usize`-valued reserved key off the instance dict.
+fn dict_usize(obj: PyObjectRef, key: &str) -> Option<usize> {
+    let d = crate::baseobjspace::getdict(obj);
+    if d.is_null() {
+        return None;
+    }
+    match unsafe { pyre_object::w_dict_getitem_str(d, key) } {
+        Some(o) if unsafe { pyre_object::is_int(o) } => {
+            Some(unsafe { pyre_object::w_int_get_value(o) } as usize)
+        }
+        _ => None,
+    }
+}
+
+/// The sub-view byte offset from the root buffer (0 for a root object).
+fn boff(obj: PyObjectRef) -> usize {
+    dict_usize(obj, BOFF_KEY).unwrap_or(0)
+}
+
+/// The explicit view size, if this is a sub-view / external view.
+fn bsz(obj: PyObjectRef) -> Option<usize> {
+    dict_usize(obj, BSZ_KEY)
+}
+
+/// The raw address of an external (`"_baddr_"`) view, if any.
+fn baddr(obj: PyObjectRef) -> Option<usize> {
+    dict_usize(obj, BADDR_KEY)
+}
+
+/// The backing `bytearray` stored under `"_b_"` (the root's, for a sub-view).
+pub(super) fn cdata_buffer(obj: PyObjectRef) -> Option<PyObjectRef> {
+    let d = crate::baseobjspace::getdict(obj);
+    if d.is_null() {
+        return None;
+    }
+    unsafe { pyre_object::w_dict_getitem_str(d, CDATA_BUFFER_KEY) }
+}
+
+/// `b_ptr` — the address of the view's first byte (stable for the instance's
+/// lifetime).  Re-read at each use; never cached across an allocation.
+pub(super) fn cdata_addr(obj: PyObjectRef) -> Option<usize> {
+    if let Some(ba) = cdata_buffer(obj) {
+        Some(unsafe { pyre_object::w_bytearray_data(ba).as_ptr() as usize } + boff(obj))
+    } else {
+        baddr(obj).map(|a| a + boff(obj))
+    }
+}
+
+/// `b_ptr[..b_size]` — the view bytes.
+pub(super) fn cdata_bytes(obj: PyObjectRef) -> Option<&'static [u8]> {
+    if let Some(ba) = cdata_buffer(obj) {
+        let data = unsafe { pyre_object::w_bytearray_data(ba) };
+        let off = boff(obj).min(data.len());
+        let sz = bsz(obj).unwrap_or(data.len() - off);
+        let end = (off + sz).min(data.len());
+        Some(&data[off..end])
+    } else if let Some(addr) = baddr(obj) {
+        let sz = bsz(obj).unwrap_or(0);
+        Some(unsafe { host_ctypes::borrow_memory((addr + boff(obj)) as *const u8, sz) })
+    } else {
+        None
+    }
+}
+
+/// `b_size` — the view length.
+pub(super) fn cdata_len(obj: PyObjectRef) -> Option<usize> {
+    if let Some(ba) = cdata_buffer(obj) {
+        Some(bsz(obj).unwrap_or_else(|| unsafe { pyre_object::w_bytearray_len(ba) } - boff(obj)))
+    } else if baddr(obj).is_some() {
+        Some(bsz(obj).unwrap_or(0))
+    } else {
+        None
+    }
+}
+
+/// Overwrite `bytes` at view-relative offset `off`.
+pub(super) fn cdata_write(obj: PyObjectRef, off: usize, bytes: &[u8]) {
+    if let Some(ba) = cdata_buffer(obj) {
+        let start = boff(obj) + off;
+        let cap = unsafe { pyre_object::w_bytearray_len(ba) };
+        if start >= cap {
+            return;
+        }
+        let n = bytes.len().min(cap - start);
+        unsafe {
+            pyre_object::w_bytearray_data_mut(ba)[start..start + n].copy_from_slice(&bytes[..n]);
+        }
+    } else if let Some(addr) = baddr(obj) {
+        let sz = bsz(obj).unwrap_or(0);
+        if off >= sz {
+            return;
+        }
+        let n = bytes.len().min(sz - off);
+        let dst = unsafe { host_ctypes::borrow_memory_mut((addr + off) as *mut u8, n) };
+        dst.copy_from_slice(&bytes[..n]);
+    }
+}
+
+// ── sub-views, keepalive, and the cdata-instance predicate ─────────────
+
+thread_local! {
+    /// The ctypes base types whose instances are CData (registered at module
+    /// init): `_SimpleCData`, `Structure`, `Union`, `Array`, `_Pointer`.
+    static CDATA_BASES: RefCell<Vec<PyObjectRef>> = const { RefCell::new(Vec::new()) };
+}
+
+/// Register `tp` as a CData base type (widens [`is_cdata_instance`]).
+pub(super) fn register_cdata_base(tp: PyObjectRef) {
+    CDATA_BASES.with(|b| {
+        let mut v = b.borrow_mut();
+        if !v.iter().any(|&t| t == tp) {
+            v.push(tp);
+        }
+    });
+}
+
+/// Whether `obj` owns its buffer (a root object, not a sub-view or external
+/// view) — the precondition for `resize`.
+pub(super) fn owns_buffer(obj: PyObjectRef) -> bool {
+    let d = crate::baseobjspace::getdict(obj);
+    if d.is_null() {
+        return false;
+    }
+    let has = |k: &str| unsafe { pyre_object::w_dict_getitem_str(d, k) }.is_some();
+    has(CDATA_BUFFER_KEY) && !has(BBASE_KEY) && !has(BADDR_KEY)
+}
+
+/// Whether `obj` is an instance of any registered CData base type.
+pub(super) fn is_cdata_instance(obj: PyObjectRef) -> bool {
+    !obj.is_null()
+        && CDATA_BASES.with(|b| {
+            b.borrow()
+                .iter()
+                .any(|&base| unsafe { crate::baseobjspace::isinstance_w(obj, base) })
+        })
+}
+
+/// A field/element sub-view of `parent` at `field_offset`, aliasing its memory
+/// (`PyCData_FromBaseObj`): bytearray-backed → shares the root bytearray with an
+/// accumulated `_boff_`; address-backed → a fresh external view.
+pub(super) fn make_subview(
+    proto: PyObjectRef,
+    parent: PyObjectRef,
+    field_offset: usize,
+    size: usize,
+) -> PyObjectRef {
+    let inst = pyre_object::w_instance_new(proto);
+    let d = crate::baseobjspace::getdict(inst);
+    if d.is_null() {
+        return inst;
+    }
+    unsafe {
+        if let Some(ba) = cdata_buffer(parent) {
+            pyre_object::w_dict_setitem_str(d, CDATA_BUFFER_KEY, ba);
+            pyre_object::w_dict_setitem_str(
+                d,
+                BOFF_KEY,
+                pyre_object::w_int_new((boff(parent) + field_offset) as i64),
+            );
+        } else if let Some(addr) = baddr(parent) {
+            pyre_object::w_dict_setitem_str(
+                d,
+                BADDR_KEY,
+                pyre_object::w_int_new((addr + field_offset) as i64),
+            );
+        }
+        pyre_object::w_dict_setitem_str(d, BSZ_KEY, pyre_object::w_int_new(size as i64));
+        pyre_object::w_dict_setitem_str(d, BBASE_KEY, parent);
+    }
+    inst
+}
+
+/// An `address`-backed instance of `proto` viewing `size` bytes of external
+/// memory (`PyCData::at_address`) — the pyre form of a pointer dereference.
+/// The memory is owned elsewhere; the caller keeps it alive.
+pub(super) fn make_at_address(proto: PyObjectRef, address: usize, size: usize) -> PyObjectRef {
+    let inst = pyre_object::w_instance_new(proto);
+    let d = crate::baseobjspace::getdict(inst);
+    if !d.is_null() {
+        unsafe {
+            pyre_object::w_dict_setitem_str(d, BADDR_KEY, pyre_object::w_int_new(address as i64));
+            pyre_object::w_dict_setitem_str(d, BSZ_KEY, pyre_object::w_int_new(size as i64));
+        }
+    }
+    inst
+}
+
+/// Keep `obj` alive for the lifetime of the buffer that `anchor` views, by
+/// storing it under `key` in the ultimate root's `"_objects_"` dict.
+pub(super) fn keep_ref(anchor: PyObjectRef, key: &str, obj: PyObjectRef) {
+    // Walk `_b_base_` up to the owning root.
+    let mut root = anchor;
+    loop {
+        let d = crate::baseobjspace::getdict(root);
+        if d.is_null() {
+            return;
+        }
+        match unsafe { pyre_object::w_dict_getitem_str(d, BBASE_KEY) } {
+            Some(base) if !base.is_null() && !unsafe { pyre_object::is_none(base) } => root = base,
+            _ => break,
+        }
+    }
+    let d = crate::baseobjspace::getdict(root);
+    let objs = match unsafe { pyre_object::w_dict_getitem_str(d, OBJECTS_KEY) } {
+        Some(o) if !o.is_null() => o,
+        _ => {
+            let nd = pyre_object::w_dict_new();
+            unsafe { pyre_object::w_dict_setitem_str(d, OBJECTS_KEY, nd) };
+            nd
+        }
+    };
+    unsafe { pyre_object::w_dict_setitem_str(objs, key, obj) };
+}
+
+// ── type-code metadata (StgInfo equivalent, derived from `_type_`) ─────
+
+/// The single-char ctypes `_type_` of `cls` (a type), read off the MRO.
+/// Returns `None` when the attribute is absent or not a string.
+pub(super) fn type_code_of(cls: PyObjectRef) -> Option<String> {
+    if cls.is_null() || !unsafe { pyre_object::is_type(cls) } {
+        return None;
+    }
+    let v = unsafe { crate::baseobjspace::lookup_in_type(cls, "_type_") }?;
+    if !unsafe { pyre_object::is_str(v) } {
+        return None;
+    }
+    Some(unsafe { pyre_object::w_str_get_value(v) }.to_string())
+}
+
+/// Whether `obj` is a (subclass) type of `_SimpleCData`.
+pub(super) fn is_simplecdata_type(obj: PyObjectRef) -> bool {
+    !obj.is_null()
+        && unsafe { pyre_object::is_type(obj) }
+        && crate::baseobjspace::issubclass(obj, simplecdata_type()).unwrap_or(false)
+}
+
+/// Whether `obj` is an instance of a `_SimpleCData` subclass.
+pub(super) fn is_simplecdata_instance(obj: PyObjectRef) -> bool {
+    !obj.is_null() && unsafe { crate::baseobjspace::isinstance_w(obj, simplecdata_type()) }
+}
+
+/// Ctypes type codes whose value is a pointer (drives pointer-return
+/// decoding / `TYPEFLAG_ISPOINTER`).
+pub(super) fn is_pointer_code(code: &str) -> bool {
+    matches!(code, "z" | "Z" | "P" | "s" | "X" | "O")
+}
+
+pub(super) fn invalid_type_code_error() -> crate::PyError {
+    // Mirrors PyCSimpleType_init: an unrecognised `_type_` is an
+    // AttributeError, so `ctypes.__init__`'s complex-type probe
+    // (`try: class c_double_complex(_SimpleCData): _type_="D"; ...
+    // except AttributeError`) is skipped when the code is unsupported.
+    crate::PyError::attribute_error(
+        "class must define a '_type_' attribute which must be \
+         a single character string containing one of the valid ctypes type codes",
+    )
+}
+
+// ── scalar value ⇄ bytes ──────────────────────────────────────────────
+
+/// Encode a Python scalar into the native-endian buffer bytes for `tc`.
+///
+/// A same-typed `_SimpleCData` instance is accepted and copied byte-for-byte.
+pub(super) fn encode_value(tc: &str, obj: PyObjectRef) -> Result<Vec<u8>, crate::PyError> {
+    use host_ctypes::SimpleStorageValue as V;
+    if is_simplecdata_instance(obj) {
+        return Ok(cdata_bytes(obj).unwrap_or(&[]).to_vec());
+    }
+    let val = match tc {
+        "c" => {
+            if unsafe { pyre_object::is_bytes(obj) } {
+                let b = unsafe { pyre_object::bytesobject::w_bytes_data(obj) };
+                if b.len() != 1 {
+                    return Err(crate::PyError::type_error(
+                        "one character bytes, bytearray or integer expected",
+                    ));
+                }
+                V::Byte(b[0])
+            } else if unsafe { pyre_object::is_int(obj) } {
+                V::Byte(crate::baseobjspace::int_w(obj)? as u8)
+            } else {
+                return Err(crate::PyError::type_error(
+                    "one character bytes, bytearray or integer expected",
+                ));
+            }
+        }
+        "b" | "B" | "h" | "H" | "i" | "I" | "l" | "L" | "q" | "Q" => {
+            V::Signed(crate::baseobjspace::int_w(obj)? as i128)
+        }
+        "f" | "d" | "g" => V::Float(crate::baseobjspace::float_w(obj)?),
+        "?" => V::Bool(crate::baseobjspace::is_true(obj)?),
+        "u" => V::Wchar(crate::baseobjspace::int_w(obj)? as u32),
+        "P" | "z" | "Z" => {
+            if unsafe { pyre_object::is_none(obj) } {
+                V::Pointer(0)
+            } else if unsafe { pyre_object::is_int(obj) } {
+                V::Pointer(crate::baseobjspace::int_w(obj)? as usize)
+            } else {
+                return Err(crate::PyError::type_error("cannot be converted to pointer"));
+            }
+        }
+        "O" => V::ObjectId(crate::baseobjspace::int_w(obj)? as usize),
+        _ => V::Signed(crate::baseobjspace::int_w(obj)? as i128),
+    };
+    Ok(host_ctypes::simple_storage_value_to_bytes_endian(
+        tc, val, false,
+    ))
+}
+
+/// Turn a decoded scalar into a pyre object.
+pub(super) fn decoded_to_pyobject(d: host_ctypes::DecodedValue) -> PyObjectRef {
+    use host_ctypes::DecodedValue as D;
+    match d {
+        D::Bytes(b) => pyre_object::bytesobject::w_bytes_from_bytes(&b),
+        D::Signed(i) => pyre_object::w_int_new(i),
+        // No unsigned-i64 int constructor exists; values above i64::MAX
+        // wrap.  The slice's scalar returns stay within i64 range.
+        D::Unsigned(u) => pyre_object::w_int_new(u as i64),
+        D::Float(f) => pyre_object::w_float_new(f),
+        D::Bool(b) => pyre_object::w_bool_from(b),
+        D::Pointer(p) => pyre_object::w_int_new(p as i64),
+        D::String(s) => pyre_object::w_str_new(&s),
+        D::None => pyre_object::w_none(),
+    }
+}

--- a/pyre/pyre-interpreter/src/module/_ctypes/funcptr.rs
+++ b/pyre/pyre-interpreter/src/module/_ctypes/funcptr.rs
@@ -1,0 +1,706 @@
+//! `CFuncPtr` (imported as `_CFuncPtr`) — the foreign-function object.
+//!
+//! `__new__` resolves and stores a function-pointer address (`"_ptr"`) from a
+//! `(name, dll)` pair, a bare integer address, or nothing (NULL).  `__call__`
+//! marshals scalar Python arguments into libffi values and performs the call
+//! through `host_env`, then decodes the scalar result.
+//!
+//! All host/FFI work is delegated to `rustpython_host_env::ctypes`.  Arguments
+//! are marshalled into `CallArg`s and the return type into a `CallRet`, then the
+//! call runs through the single `call` entry point, which performs the libffi
+//! call and decodes the result.  By-reference arguments — `byref()` carriers,
+//! `_Pointer`/`Array` instances, and pointer-typed cdata — lower to
+//! `CallArg::Pointer(addr)`; by-value struct/union arguments and returns lower
+//! to `CallArg::Aggregate` / `CallRet::Aggregate`; a pointer-typed `restype`
+//! wraps the returned address in a fresh instance.
+
+use super::cdata;
+use super::stginfo;
+use super::type_ns_store;
+use pyre_object::PyObjectRef;
+use rustpython_host_env::ctypes as host_ctypes;
+
+/// `_flags_ & FUNCFLAG_USE_ERRNO` — swap the ctypes-local errno around the call.
+const FUNCFLAG_USE_ERRNO: i64 = 0x8;
+
+/// Reserved instance-dict keys.
+const PTR_KEY: &str = "_ptr";
+const RESTYPE_KEY: &str = "_restype";
+const ARGTYPES_KEY: &str = "_argtypes";
+
+thread_local! {
+    static CFUNCPTR_TYPE_OBJ: std::cell::OnceCell<PyObjectRef> =
+        const { std::cell::OnceCell::new() };
+}
+
+/// The native `CFuncPtr` type object (cached, `hasdict=true`).
+pub(super) fn cfuncptr_type() -> PyObjectRef {
+    CFUNCPTR_TYPE_OBJ.with(|c| {
+        *c.get_or_init(|| {
+            let tp = crate::typedef::make_builtin_type("CFuncPtr", init_cfuncptr_type);
+            unsafe { pyre_object::typeobject::w_type_set_hasdict(tp, true) };
+            tp
+        })
+    })
+}
+
+fn init_cfuncptr_type(ns: PyObjectRef) {
+    type_ns_store(
+        ns,
+        "__new__",
+        crate::make_builtin_function("__new__", cfuncptr_new),
+    );
+    type_ns_store(
+        ns,
+        "__call__",
+        crate::make_builtin_function("__call__", cfuncptr_call),
+    );
+    // `restype` / `argtypes` — settable data descriptors with class-attr
+    // fallback to `_restype_` / `_argtypes_`.
+    type_ns_store(
+        ns,
+        "restype",
+        crate::typedef::make_getset_property_named(
+            crate::make_builtin_function_with_arity("restype", restype_getter, 2),
+            crate::make_builtin_function_with_arity("restype", restype_setter, 3),
+            pyre_object::PY_NULL,
+            "restype",
+        ),
+    );
+    type_ns_store(
+        ns,
+        "argtypes",
+        crate::typedef::make_getset_property_named(
+            crate::make_builtin_function_with_arity("argtypes", argtypes_getter, 2),
+            crate::make_builtin_function_with_arity("argtypes", argtypes_setter, 3),
+            pyre_object::PY_NULL,
+            "argtypes",
+        ),
+    );
+}
+
+// ── construction ──────────────────────────────────────────────────────
+
+/// `_CFuncPtr.__new__(cls, arg=None)`.
+fn cfuncptr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    if args.is_empty() || !unsafe { pyre_object::is_type(args[0]) } {
+        return Err(crate::PyError::type_error(
+            "CFuncPtr.__new__(): not enough arguments",
+        ));
+    }
+    let cls = args[0];
+    let (pos, _kwargs) = crate::builtins::split_builtin_kwargs(&args[1..]);
+    let addr: usize = match pos.first().copied() {
+        None => 0,
+        Some(a) if unsafe { pyre_object::is_none(a) } => 0,
+        Some(a) if unsafe { pyre_object::is_int(a) } => {
+            (unsafe { pyre_object::w_int_get_value(a) }) as usize
+        }
+        Some(a) if unsafe { pyre_object::is_tuple(a) } => resolve_from_tuple(a)?,
+        Some(_) => {
+            return Err(crate::PyError::type_error(
+                "argument must be callable or integer function address",
+            ));
+        }
+    };
+    let obj = pyre_object::w_instance_new(cls);
+    let d = crate::baseobjspace::getdict(obj);
+    if d.is_null() {
+        return Err(crate::PyError::type_error(
+            "CFuncPtr instance has no instance dict",
+        ));
+    }
+    unsafe { pyre_object::w_dict_setitem_str(d, PTR_KEY, pyre_object::w_int_new(addr as i64)) };
+    Ok(obj)
+}
+
+/// `(name, dll)` → resolved symbol address.  `dll._handle` is the integer
+/// library handle; `name` is the symbol string/bytes.
+fn resolve_from_tuple(t: PyObjectRef) -> Result<usize, crate::PyError> {
+    let name_obj = unsafe { pyre_object::w_tuple_getitem(t, 0) };
+    let dll_obj = unsafe { pyre_object::w_tuple_getitem(t, 1) };
+    let (Some(name_obj), Some(dll_obj)) = (name_obj, dll_obj) else {
+        return Err(crate::PyError::type_error(
+            "CFuncPtr constructor requires a (name, dll) pair",
+        ));
+    };
+    let handle_obj = crate::baseobjspace::getattr_str(dll_obj, "_handle")?;
+    let handle = crate::baseobjspace::int_w(handle_obj)? as usize;
+    let name_bytes: Vec<u8> = if unsafe { pyre_object::is_str(name_obj) } {
+        unsafe { pyre_object::w_str_get_value(name_obj) }
+            .as_bytes()
+            .to_vec()
+    } else if unsafe { pyre_object::is_bytes(name_obj) } {
+        unsafe { pyre_object::bytesobject::w_bytes_data(name_obj) }.to_vec()
+    } else {
+        return Err(crate::PyError::type_error(
+            "function name must be string or bytes (ordinals not supported)",
+        ));
+    };
+    host_ctypes::lookup_function_symbol_addr(handle, &name_bytes).map_err(|e| {
+        use host_ctypes::LookupSymbolError as L;
+        let sym = String::from_utf8_lossy(&name_bytes);
+        match e {
+            L::LibraryNotFound => crate::PyError::value_error("library not found"),
+            L::LibraryClosed => {
+                crate::PyError::attribute_error(format!("function '{sym}' not found"))
+            }
+            L::Load(_) => crate::PyError::attribute_error(format!("function '{sym}' not found")),
+        }
+    })
+}
+
+// ── restype / argtypes descriptors ────────────────────────────────────
+
+fn instance_get(obj: PyObjectRef, key: &str) -> Option<PyObjectRef> {
+    let d = crate::baseobjspace::getdict(obj);
+    if d.is_null() {
+        return None;
+    }
+    unsafe { pyre_object::w_dict_getitem_str(d, key) }
+}
+
+fn instance_set(obj: PyObjectRef, key: &str, value: PyObjectRef) {
+    let d = crate::baseobjspace::getdict(obj);
+    if !d.is_null() {
+        unsafe { pyre_object::w_dict_setitem_str(d, key, value) };
+    }
+}
+
+fn restype_getter(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    let obj = args[1];
+    if let Some(v) = instance_get(obj, RESTYPE_KEY) {
+        return Ok(v);
+    }
+    let cls = unsafe { pyre_object::w_instance_get_type(obj) };
+    Ok(
+        unsafe { crate::baseobjspace::lookup_in_type(cls, "_restype_") }
+            .unwrap_or_else(pyre_object::w_none),
+    )
+}
+
+fn restype_setter(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    instance_set(args[1], RESTYPE_KEY, args[2]);
+    Ok(pyre_object::w_none())
+}
+
+fn argtypes_getter(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    let obj = args[1];
+    if let Some(v) = instance_get(obj, ARGTYPES_KEY) {
+        return Ok(v);
+    }
+    let cls = unsafe { pyre_object::w_instance_get_type(obj) };
+    Ok(
+        unsafe { crate::baseobjspace::lookup_in_type(cls, "_argtypes_") }
+            .unwrap_or_else(pyre_object::w_none),
+    )
+}
+
+fn argtypes_setter(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    instance_set(args[1], ARGTYPES_KEY, args[2]);
+    Ok(pyre_object::w_none())
+}
+
+// ── call ──────────────────────────────────────────────────────────────
+
+/// Resolved return-type selector.
+enum Ret {
+    Void,
+    Code(String),
+    /// A pointer metaclass type (`POINTER(T)`): the result address is wrapped
+    /// in a fresh instance of this type.
+    Pointer(PyObjectRef),
+    /// A by-value struct/union type: the returned aggregate bytes are copied
+    /// into a fresh instance of this type.
+    Aggregate(PyObjectRef),
+}
+
+fn resolve_restype(obj: PyObjectRef) -> Result<Ret, crate::PyError> {
+    let cls = unsafe { pyre_object::w_instance_get_type(obj) };
+    let rt = instance_get(obj, RESTYPE_KEY)
+        .or_else(|| unsafe { crate::baseobjspace::lookup_in_type(cls, "_restype_") });
+    match rt {
+        // CDLL functions default to c_int when no restype is set.
+        None => Ok(Ret::Code("i".to_string())),
+        Some(o) if unsafe { pyre_object::is_none(o) } => Ok(Ret::Void),
+        Some(o) => {
+            // A `_Pointer` subtype returns a live pointer instance; a
+            // struct/union subtype returns a by-value aggregate instance.
+            if let Some(info) = stginfo::stginfo_of(o) {
+                match stginfo::stginfo_paramfunc(info).as_str() {
+                    "pointer" => return Ok(Ret::Pointer(o)),
+                    "struct" | "union" => return Ok(Ret::Aggregate(o)),
+                    _ => {}
+                }
+            }
+            let tc = cdata::type_code_of(o)
+                .ok_or_else(|| crate::PyError::type_error("invalid restype"))?;
+            Ok(Ret::Code(tc))
+        }
+    }
+}
+
+/// Wrap a returned pointer value `p` in a fresh instance of pointer type `rt`.
+fn wrap_pointer_result(rt: PyObjectRef, p: usize) -> Result<PyObjectRef, crate::PyError> {
+    let obj = pyre_object::w_instance_new(rt);
+    let d = crate::baseobjspace::getdict(obj);
+    if d.is_null() {
+        return Err(crate::PyError::type_error("pointer instance has no dict"));
+    }
+    let psize = host_ctypes::pointer_size();
+    let ba = pyre_object::w_bytearray_new(psize);
+    let bytes = host_ctypes::simple_storage_value_to_bytes_endian(
+        "P",
+        host_ctypes::SimpleStorageValue::Pointer(p),
+        false,
+    );
+    let n = bytes.len().min(psize);
+    unsafe {
+        pyre_object::w_bytearray_data_mut(ba)[..n].copy_from_slice(&bytes[..n]);
+        pyre_object::w_dict_setitem_str(d, "_b_", ba);
+    }
+    Ok(obj)
+}
+
+/// The `_argtypes_` sequence as a Vec, or `None` when unset (ConvParam
+/// defaults apply).
+fn resolve_argtypes(obj: PyObjectRef) -> Option<Vec<PyObjectRef>> {
+    let cls = unsafe { pyre_object::w_instance_get_type(obj) };
+    let at = instance_get(obj, ARGTYPES_KEY)
+        .or_else(|| unsafe { crate::baseobjspace::lookup_in_type(cls, "_argtypes_") })?;
+    if unsafe { pyre_object::is_none(at) } {
+        return None;
+    }
+    seq_to_vec(at)
+}
+
+fn seq_to_vec(obj: PyObjectRef) -> Option<Vec<PyObjectRef>> {
+    if unsafe { pyre_object::is_tuple(obj) } {
+        let n = unsafe { pyre_object::w_tuple_len(obj) };
+        Some(
+            (0..n as i64)
+                .filter_map(|i| unsafe { pyre_object::w_tuple_getitem(obj, i) })
+                .collect(),
+        )
+    } else if unsafe { pyre_object::is_list(obj) } {
+        let n = unsafe { pyre_object::w_list_len(obj) };
+        Some(
+            (0..n as i64)
+                .filter_map(|i| unsafe { pyre_object::w_list_getitem(obj, i) })
+                .collect(),
+        )
+    } else {
+        None
+    }
+}
+
+fn funcptr_flags(obj: PyObjectRef) -> i64 {
+    let cls = unsafe { pyre_object::w_instance_get_type(obj) };
+    match unsafe { crate::baseobjspace::lookup_in_type(cls, "_flags_") } {
+        Some(o) if unsafe { pyre_object::is_int(o) } => unsafe { pyre_object::w_int_get_value(o) },
+        _ => 0,
+    }
+}
+
+fn funcptr_addr(obj: PyObjectRef) -> usize {
+    instance_get(obj, PTR_KEY)
+        .filter(|o| unsafe { pyre_object::is_int(*o) })
+        .map(|o| unsafe { pyre_object::w_int_get_value(o) } as usize)
+        .unwrap_or(0)
+}
+
+/// Owned argument data whose buffers must outlive the borrowed `CallArg`s
+/// handed to `call`.
+enum OwnedArg {
+    Typed(String, Vec<u8>),
+    Int(i32),
+    Double(f64),
+    Pointer(usize),
+    /// A by-value aggregate: its recursive layout and a copy of its bytes.
+    Aggregate(host_ctypes::CTypeLayout, Vec<u8>),
+}
+
+/// `_CFuncPtr.__call__(self, *args)`.
+fn cfuncptr_call(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    if args.is_empty() {
+        return Err(crate::PyError::type_error("__call__ requires self"));
+    }
+    let self_obj = args[0];
+    let (call_args, _kwargs) = crate::builtins::split_builtin_kwargs(&args[1..]);
+
+    // Marshal arguments into owned scalar data.  `keepalive` owns any
+    // null-terminated `bytes` copies that pointer args address; `owned` owns
+    // the typed buffers.  Both must outlive the borrowed `SimpleArg`s below.
+    let mut owned: Vec<OwnedArg> = Vec::with_capacity(call_args.len());
+    let mut keepalive: Vec<Vec<u8>> = Vec::new();
+
+    match resolve_argtypes(self_obj) {
+        Some(argtypes) => {
+            for (i, at) in argtypes.iter().enumerate() {
+                let arg = *call_args.get(i).ok_or_else(|| {
+                    crate::PyError::type_error(format!(
+                        "this function takes at least {} argument(s)",
+                        argtypes.len()
+                    ))
+                })?;
+                owned.push(marshal_typed_arg(arg, *at, &mut keepalive)?);
+            }
+        }
+        None => {
+            for &arg in call_args {
+                owned.push(marshal_default_arg(arg, &mut keepalive)?);
+            }
+        }
+    }
+
+    let ret = resolve_restype(self_obj)?;
+    // Build the aggregate return layout (if any) up front so it outlives the
+    // borrowed `CallRet` handed to the call.
+    let ret_layout = match &ret {
+        Ret::Aggregate(ty) => Some(build_layout(*ty)?),
+        _ => None,
+    };
+    let restype = match &ret {
+        Ret::Void => host_ctypes::CallRet::Void,
+        Ret::Code(c) => host_ctypes::CallRet::Code(c.as_str()),
+        Ret::Pointer(_) => host_ctypes::CallRet::Code("P"),
+        Ret::Aggregate(_) => host_ctypes::CallRet::Aggregate(
+            ret_layout.as_ref().expect("aggregate restype has a layout"),
+        ),
+    };
+
+    // Borrow the owned data as `CallArg`s; these borrows end with the call.
+    let host_args: Vec<host_ctypes::CallArg> = owned
+        .iter()
+        .map(|o| match o {
+            OwnedArg::Typed(code, buf) => host_ctypes::CallArg::Typed {
+                code: code.as_str(),
+                buffer: buf.as_slice(),
+            },
+            OwnedArg::Int(v) => host_ctypes::CallArg::Int(*v),
+            OwnedArg::Double(v) => host_ctypes::CallArg::Double(*v),
+            OwnedArg::Pointer(v) => host_ctypes::CallArg::Pointer(*v),
+            OwnedArg::Aggregate(layout, buf) => host_ctypes::CallArg::Aggregate {
+                layout,
+                buffer: buf.as_slice(),
+            },
+        })
+        .collect();
+
+    let addr = funcptr_addr(self_obj);
+    let use_errno = funcptr_flags(self_obj) & FUNCFLAG_USE_ERRNO != 0;
+    let options = host_ctypes::CallOptions {
+        use_errno,
+        ..Default::default()
+    };
+    let result = host_ctypes::call(addr, &host_args, restype, options).map_err(|e| match e {
+        host_ctypes::CallError::NullFunctionPointer => {
+            crate::PyError::value_error("NULL function pointer")
+        }
+        host_ctypes::CallError::UnknownTypeCode(c) => {
+            crate::PyError::type_error(format!("unsupported type code {c:?}"))
+        }
+        host_ctypes::CallError::BufferTooSmall { expected, got } => crate::PyError::value_error(
+            format!("aggregate argument buffer too small: expected {expected}, got {got}"),
+        ),
+    });
+    // `owned` / `keepalive` must outlive the call above.
+    drop(keepalive);
+    let result = result?;
+    match ret {
+        Ret::Pointer(rt) => {
+            let p = match result {
+                host_ctypes::CallValue::Pointer(p) => p,
+                host_ctypes::CallValue::Scalar(b) => host_ctypes::read_pointer_from_buffer(&b),
+                _ => 0,
+            };
+            wrap_pointer_result(rt, p)
+        }
+        Ret::Aggregate(ty) => {
+            let bytes = match result {
+                host_ctypes::CallValue::Aggregate(b) => b,
+                _ => Vec::new(),
+            };
+            make_aggregate_instance(ty, &bytes)
+        }
+        Ret::Void => Ok(cdata::decoded_to_pyobject(host_ctypes::DecodedValue::None)),
+        Ret::Code(c) => {
+            // Reconstruct the raw result bytes and decode exactly as before:
+            // a scalar carries its register image, a pointer-code result its
+            // address bytes.
+            let decoded = match result {
+                host_ctypes::CallValue::Scalar(b) => host_ctypes::decode_type_code(&c, &b),
+                host_ctypes::CallValue::Pointer(p) => {
+                    host_ctypes::decode_type_code(&c, &p.to_ne_bytes())
+                }
+                host_ctypes::CallValue::Void => host_ctypes::DecodedValue::None,
+                host_ctypes::CallValue::Aggregate(b) => host_ctypes::decode_type_code(&c, &b),
+            };
+            Ok(cdata::decoded_to_pyobject(decoded))
+        }
+    }
+}
+
+/// The `StgInfo.paramfunc` of a cdata instance's type ("simple"/"array"/
+/// "pointer"/"struct"/"union"), or empty when it carries no `StgInfo`.
+fn cdata_paramfunc(obj: PyObjectRef) -> String {
+    let cls = unsafe { pyre_object::w_instance_get_type(obj) };
+    stginfo::stginfo_of(cls)
+        .map(stginfo::stginfo_paramfunc)
+        .unwrap_or_default()
+}
+
+/// Whether argument type `at` lowers to a pointer (a pointer metaclass type,
+/// an array type — which decays — or a simple pointer code like `P`/`z`/`Z`).
+fn argtype_is_pointer_kind(at: PyObjectRef) -> bool {
+    if let Some(info) = stginfo::stginfo_of(at) {
+        if stginfo::stginfo_flags(info) & stginfo::TYPEFLAG_ISPOINTER != 0 {
+            return true;
+        }
+        if stginfo::stginfo_paramfunc(info) == "array" {
+            return true;
+        }
+    }
+    matches!(cdata::type_code_of(at).as_deref(), Some(c) if cdata::is_pointer_code(c))
+}
+
+/// Whether type `t` is a by-value aggregate (struct or union).
+fn is_aggregate_type(t: PyObjectRef) -> bool {
+    stginfo::stginfo_of(t)
+        .map(stginfo::stginfo_paramfunc)
+        .is_some_and(|pf| pf == "struct" || pf == "union")
+}
+
+/// The ordered field types of a struct/union type's `_fields_` (2-tuples only;
+/// bit fields are rejected at class-definition time).
+fn struct_field_types(t: PyObjectRef) -> Result<Vec<PyObjectRef>, crate::PyError> {
+    let fields = unsafe { crate::baseobjspace::lookup_in_type(t, "_fields_") }
+        .ok_or_else(|| crate::PyError::type_error("struct/union type has no '_fields_'"))?;
+    let items = seq_to_vec(fields)
+        .ok_or_else(|| crate::PyError::type_error("_fields_ must be a sequence"))?;
+    let mut out = Vec::with_capacity(items.len());
+    for it in items {
+        if !unsafe { pyre_object::is_tuple(it) } {
+            return Err(crate::PyError::type_error(
+                "_fields_ entries must be tuples",
+            ));
+        }
+        let ft = unsafe { pyre_object::w_tuple_getitem(it, 1) }.unwrap_or(pyre_object::PY_NULL);
+        if ft.is_null() || !unsafe { pyre_object::is_type(ft) } {
+            return Err(crate::PyError::type_error(
+                "field type must be a ctypes type",
+            ));
+        }
+        out.push(ft);
+    }
+    Ok(out)
+}
+
+/// Build the recursive `CTypeLayout` of a ctypes type, driven by its `StgInfo`
+/// `paramfunc`: simple → code, pointer → `Pointer`, array → element layout +
+/// length, struct/union → per-field layouts from `_fields_`.
+fn build_layout(t: PyObjectRef) -> Result<host_ctypes::CTypeLayout, crate::PyError> {
+    use host_ctypes::CTypeLayout;
+    let info = stginfo::stginfo_of(t)
+        .ok_or_else(|| crate::PyError::type_error("type has no ctypes layout info"))?;
+    let size = stginfo::stginfo_size(info);
+    let paramfunc = stginfo::stginfo_paramfunc(info);
+    match paramfunc.as_str() {
+        "simple" => {
+            let tc = cdata::type_code_of(t)
+                .ok_or_else(|| crate::PyError::type_error("simple type has no '_type_'"))?;
+            let ch = tc
+                .chars()
+                .next()
+                .ok_or_else(|| crate::PyError::type_error("empty '_type_' code"))?;
+            Ok(CTypeLayout::Simple(ch))
+        }
+        "pointer" => Ok(CTypeLayout::Pointer),
+        "array" => {
+            let element = stginfo::stginfo_proto(info)
+                .ok_or_else(|| crate::PyError::type_error("array type has no element type"))?;
+            Ok(CTypeLayout::Array {
+                element: Box::new(build_layout(element)?),
+                length: stginfo::stginfo_length(info),
+                size,
+            })
+        }
+        "struct" | "union" => {
+            let mut fields = Vec::new();
+            for ft in struct_field_types(t)? {
+                fields.push(build_layout(ft)?);
+            }
+            if paramfunc == "union" {
+                Ok(CTypeLayout::Union { fields, size })
+            } else {
+                Ok(CTypeLayout::Struct { fields, size })
+            }
+        }
+        _ => Ok(CTypeLayout::Opaque { size }),
+    }
+}
+
+/// Marshal a by-value aggregate argument `arg` of type `at`: build the layout
+/// and snapshot the instance's buffer bytes (padded to the layout size).
+fn marshal_aggregate_arg(arg: PyObjectRef, at: PyObjectRef) -> Result<OwnedArg, crate::PyError> {
+    let layout = build_layout(at)?;
+    let bytes = cdata::cdata_bytes(arg).ok_or_else(|| {
+        crate::PyError::type_error("by-value aggregate argument is not a ctypes instance")
+    })?;
+    let buf = host_ctypes::copy_to_sized_bytes(bytes, layout.size());
+    Ok(OwnedArg::Aggregate(layout, buf))
+}
+
+/// Create a fresh instance of aggregate type `ty` whose owned buffer holds the
+/// returned `bytes`.
+fn make_aggregate_instance(ty: PyObjectRef, bytes: &[u8]) -> Result<PyObjectRef, crate::PyError> {
+    let size = stginfo::stginfo_of(ty)
+        .map(stginfo::stginfo_size)
+        .unwrap_or(bytes.len());
+    let ba = pyre_object::w_bytearray_new(size);
+    let n = bytes.len().min(size);
+    unsafe {
+        pyre_object::w_bytearray_data_mut(ba)[..n].copy_from_slice(&bytes[..n]);
+    }
+    let obj = pyre_object::w_instance_new(ty);
+    let d = crate::baseobjspace::getdict(obj);
+    if d.is_null() {
+        return Err(crate::PyError::type_error(
+            "aggregate instance has no instance dict",
+        ));
+    }
+    unsafe { pyre_object::w_dict_setitem_str(d, "_b_", ba) };
+    Ok(obj)
+}
+
+/// Marshal one argument that has an explicit `argtype` `at`.
+fn marshal_typed_arg(
+    arg: PyObjectRef,
+    at: PyObjectRef,
+    keepalive: &mut Vec<Vec<u8>>,
+) -> Result<OwnedArg, crate::PyError> {
+    if argtype_is_pointer_kind(at) {
+        return Ok(OwnedArg::Pointer(resolve_pointer_addr(arg, keepalive)?));
+    }
+    // A by-value struct/union argtype.
+    if is_aggregate_type(at) {
+        return marshal_aggregate_arg(arg, at);
+    }
+    let tc = cdata::type_code_of(at)
+        .ok_or_else(|| crate::PyError::type_error("argtype has no valid '_type_'"))?;
+    let buf: Vec<u8> = if cdata::is_simplecdata_instance(arg) {
+        cdata::cdata_bytes(arg).unwrap_or(&[]).to_vec()
+    } else {
+        cdata::encode_value(&tc, arg)?
+    };
+    Ok(OwnedArg::Typed(tc, buf))
+}
+
+/// Marshal one argument with no explicit `argtype` (ConvParam defaults).
+fn marshal_default_arg(
+    arg: PyObjectRef,
+    keepalive: &mut Vec<Vec<u8>>,
+) -> Result<OwnedArg, crate::PyError> {
+    // `byref()` carrier → the address it wraps.
+    if super::interp_ctypes::is_carg(arg) {
+        return Ok(OwnedArg::Pointer(super::interp_ctypes::carg_ptr(arg)));
+    }
+    // A scalar cdata is passed by value.
+    if cdata::is_simplecdata_instance(arg) {
+        let cls = unsafe { pyre_object::w_instance_get_type(arg) };
+        let tc = cdata::type_code_of(cls)
+            .ok_or_else(|| crate::PyError::type_error("argument type has no '_type_'"))?;
+        let buf = cdata::cdata_bytes(arg).unwrap_or(&[]).to_vec();
+        return Ok(OwnedArg::Typed(tc, buf));
+    }
+    // Aggregate / pointer cdata: arrays and pointers decay to a pointer; a
+    // struct/union with no `byref()` is passed by value.
+    if cdata::is_cdata_instance(arg) {
+        match cdata_paramfunc(arg).as_str() {
+            "pointer" => {
+                return Ok(OwnedArg::Pointer(host_ctypes::read_pointer_from_buffer(
+                    cdata::cdata_bytes(arg).unwrap_or(&[]),
+                )));
+            }
+            "array" => {
+                return Ok(OwnedArg::Pointer(cdata::cdata_addr(arg).unwrap_or(0)));
+            }
+            "struct" | "union" => {
+                let cls = unsafe { pyre_object::w_instance_get_type(arg) };
+                return marshal_aggregate_arg(arg, cls);
+            }
+            _ => {}
+        }
+    }
+    if unsafe { pyre_object::is_none(arg) } {
+        Ok(OwnedArg::Pointer(0))
+    } else if unsafe { pyre_object::is_bytes(arg) } {
+        Ok(OwnedArg::Pointer(bytes_pointer_addr(arg, keepalive)))
+    } else if unsafe { pyre_object::is_str(arg) } {
+        Err(str_arg_unsupported())
+    } else if unsafe { pyre_object::is_float(arg) } {
+        Ok(OwnedArg::Double(crate::baseobjspace::float_w(arg)?))
+    } else if unsafe { pyre_object::is_int(arg) } {
+        Ok(OwnedArg::Int(crate::baseobjspace::int_w(arg)? as i32))
+    } else {
+        Err(crate::PyError::type_error(
+            "Don't know how to convert parameter",
+        ))
+    }
+}
+
+/// Resolve the address a pointer-kind argument lowers to: `byref()` carriers,
+/// `_Pointer`/`Array`/`Structure` instances, pointer-typed scalars, bytes, an
+/// integer address, or `None`.
+fn resolve_pointer_addr(
+    arg: PyObjectRef,
+    keepalive: &mut Vec<Vec<u8>>,
+) -> Result<usize, crate::PyError> {
+    if super::interp_ctypes::is_carg(arg) {
+        return Ok(super::interp_ctypes::carg_ptr(arg));
+    }
+    if cdata::is_simplecdata_instance(arg) {
+        // A pointer-typed scalar stores the target address in its buffer.
+        return Ok(host_ctypes::read_pointer_from_buffer(
+            cdata::cdata_bytes(arg).unwrap_or(&[]),
+        ));
+    }
+    if cdata::is_cdata_instance(arg) {
+        // `_Pointer` → stored address; `Array`/`Structure` → buffer address.
+        return Ok(match cdata_paramfunc(arg).as_str() {
+            "pointer" => {
+                host_ctypes::read_pointer_from_buffer(cdata::cdata_bytes(arg).unwrap_or(&[]))
+            }
+            _ => cdata::cdata_addr(arg).unwrap_or(0),
+        });
+    }
+    if unsafe { pyre_object::is_none(arg) } {
+        Ok(0)
+    } else if unsafe { pyre_object::is_int(arg) } {
+        Ok(crate::baseobjspace::int_w(arg)? as usize)
+    } else if unsafe { pyre_object::is_bytes(arg) } {
+        Ok(bytes_pointer_addr(arg, keepalive))
+    } else if unsafe { pyre_object::is_str(arg) } {
+        Err(str_arg_unsupported())
+    } else {
+        Err(crate::PyError::type_error(
+            "expected bytes, integer address, ctypes instance, or None",
+        ))
+    }
+}
+
+/// Null-terminate a `bytes` payload, keep the copy alive, and return the
+/// address of the copy.
+fn bytes_pointer_addr(arg: PyObjectRef, keepalive: &mut Vec<Vec<u8>>) -> usize {
+    let raw = unsafe { pyre_object::bytesobject::w_bytes_data(arg) };
+    keepalive.push(host_ctypes::null_terminated_bytes(raw));
+    // The inner Vec's heap buffer is stable even if `keepalive` reallocates.
+    keepalive.last().unwrap().as_ptr() as usize
+}
+
+fn str_arg_unsupported() -> crate::PyError {
+    crate::PyError::type_error(
+        "str argument marshalling (wchar_t*) is not implemented in this ctypes slice; \
+         pass bytes for char* arguments",
+    )
+}

--- a/pyre/pyre-interpreter/src/module/_ctypes/interp_ctypes.rs
+++ b/pyre/pyre-interpreter/src/module/_ctypes/interp_ctypes.rs
@@ -1,320 +1,563 @@
-//! _ctypes implementation — PyPy: lib_pypy/_ctypes/
+//! `_ctypes` — the native surface the CPython `ctypes` package sits on.
 //!
-//! Verbatim move of the inline block previously in importing.rs.
+//! On unix with the `host_env` feature this provides a working end-to-end
+//! slice: the dynamic-linker primitives (`dlopen`/`dlsym`/`dlclose`), the
+//! scalar data type (`_SimpleCData`, see [`super::cdata`]), the foreign
+//! function object (`CFuncPtr`, see [`super::funcptr`]), `sizeof`/`addressof`/
+//! `byref`/`alignment`/`resize`, and the import-time constants the package
+//! requires.  `Structure`/`Union`/`Array`/`_Pointer`/`CField` are real
+//! (see [`super::metaclass`]); the metaclasses compute each type's layout and
+//! the buffer-view machinery aliases nested/pointed-to memory.
+//!
+//! All host/FFI work is delegated to `rustpython_host_env::ctypes`; the module
+//! contains no direct `libc::` FFI.
 
-
-// ──────────────────────────────────────────────────────────────────────
-// _ctypes module — PyPy: `pypy/module/_rawffi/` plus `lib_pypy/_ctypes/`.
-//
-// **Slice C1: dlopen / dlsym / dlclose + size/align/memmove constants.**
-//
-// Provides the dynamic-linker primitives that ctypes.CDLL builds on
-// top of, plus the simple-type size/align table and POSIX RTLD_* flags.
-// The full c_int / Structure / CFUNCTYPE / Pointer machinery still
-// requires libffi-style argument marshalling and per-instance heap
-// state — those are later slices.
-// ──────────────────────────────────────────────────────────────────────
 
 pub fn register_module(ns: pyre_object::PyObjectRef) {
     #[cfg(all(unix, feature = "host_env"))]
-    {
-        use rustpython_host_env::ctypes as host_ctypes;
+    register_host_ctypes(ns);
+    #[cfg(not(all(unix, feature = "host_env")))]
+    register_stub_ctypes(ns);
+}
 
-        // dlopen flags (POSIX).
-        crate::module_ns_store(
-            ns,
-            "RTLD_LOCAL",
-            pyre_object::w_int_new(libc::RTLD_LOCAL as i64),
-        );
-        crate::module_ns_store(
-            ns,
-            "RTLD_GLOBAL",
-            pyre_object::w_int_new(libc::RTLD_GLOBAL as i64),
-        );
-        crate::module_ns_store(
-            ns,
-            "RTLD_LAZY",
-            pyre_object::w_int_new(libc::RTLD_LAZY as i64),
-        );
-        crate::module_ns_store(
-            ns,
-            "RTLD_NOW",
-            pyre_object::w_int_new(libc::RTLD_NOW as i64),
-        );
-        crate::module_ns_store(
-            ns,
-            "DEFAULT_MODE",
-            pyre_object::w_int_new(host_ctypes::dlopen_mode(None) as i64),
-        );
+// ──────────────────────────────────────────────────────────────────────
+// Functional surface (unix + host_env)
+// ──────────────────────────────────────────────────────────────────────
 
-        // dlopen(name, mode=DEFAULT_MODE) → handle (opaque integer that
-        // indexes into host_env's libcache).
-        crate::module_ns_store(
-            ns,
-            "dlopen",
-            crate::make_builtin_function("dlopen", |args| {
-                if args.is_empty() {
-                    return Err(crate::PyError::type_error("dlopen() missing library name"));
-                }
-                let name = unsafe {
-                    if pyre_object::is_none(args[0]) {
-                        // dlopen(None) → process handle
-                        let mode = if args.len() >= 2 {
-                            pyre_object::w_int_get_value(args[1]) as libc::c_int
-                        } else {
-                            libc::RTLD_NOW
-                        };
-                        let ptr = rustpython_host_env::ctypes::dlopen_self(mode)
-                            .map_err(|e| crate::PyError::os_error(format!("dlopen(None): {e}")))?;
-                        let h = rustpython_host_env::ctypes::insert_raw_library_handle(ptr);
-                        return Ok(pyre_object::w_int_new(h as i64));
-                    }
-                    if !pyre_object::is_str(args[0]) {
-                        return Err(crate::PyError::type_error(
-                            "dlopen: name must be a string or None",
-                        ));
-                    }
-                    pyre_object::w_str_get_value(args[0]).to_string()
-                };
-                let mode = if args.len() >= 2 {
-                    (unsafe { pyre_object::w_int_get_value(args[1]) }) as i32
-                } else {
-                    rustpython_host_env::ctypes::dlopen_mode(None)
-                };
-                let h = rustpython_host_env::ctypes::open_library_with_mode(&name, mode)
-                    .map_err(|e| crate::PyError::os_error(format!("dlopen({name}): {e}")))?;
-                Ok(pyre_object::w_int_new(h as i64))
-            }),
-        );
+#[cfg(all(unix, feature = "host_env"))]
+fn register_host_ctypes(ns: pyre_object::PyObjectRef) {
+    use rustpython_host_env::ctypes as host_ctypes;
 
-        // dlsym(handle, name) → address (int).  Returns the function
-        // pointer; for data symbols use dlsym(handle, name) the same way.
-        crate::module_ns_store(
-            ns,
-            "dlsym",
-            crate::make_builtin_function_with_arity(
-                "dlsym",
-                |args| {
-                    if args.len() < 2 {
-                        return Err(crate::PyError::type_error("dlsym() needs 2 arguments"));
-                    }
-                    let h = (unsafe { pyre_object::w_int_get_value(args[0]) }) as usize;
-                    let name = unsafe {
-                        if !pyre_object::is_str(args[1]) {
-                            return Err(crate::PyError::type_error("dlsym: name must be a string"));
-                        }
-                        pyre_object::w_str_get_value(args[1]).to_string()
+    // ── dlopen flags (POSIX) ──
+    crate::module_ns_store(
+        ns,
+        "RTLD_LOCAL",
+        pyre_object::w_int_new(libc::RTLD_LOCAL as i64),
+    );
+    crate::module_ns_store(
+        ns,
+        "RTLD_GLOBAL",
+        pyre_object::w_int_new(libc::RTLD_GLOBAL as i64),
+    );
+    crate::module_ns_store(
+        ns,
+        "RTLD_LAZY",
+        pyre_object::w_int_new(libc::RTLD_LAZY as i64),
+    );
+    crate::module_ns_store(
+        ns,
+        "RTLD_NOW",
+        pyre_object::w_int_new(libc::RTLD_NOW as i64),
+    );
+    crate::module_ns_store(
+        ns,
+        "DEFAULT_MODE",
+        pyre_object::w_int_new(host_ctypes::dlopen_mode(None) as i64),
+    );
+
+    // ── dlopen(name, mode=DEFAULT_MODE) → integer handle into host libcache ──
+    crate::module_ns_store(
+        ns,
+        "dlopen",
+        crate::make_builtin_function("dlopen", |args| {
+            if args.is_empty() {
+                return Err(crate::PyError::type_error("dlopen() missing library name"));
+            }
+            let name = unsafe {
+                if pyre_object::is_none(args[0]) {
+                    // dlopen(None) → process handle
+                    let mode = if args.len() >= 2 {
+                        pyre_object::w_int_get_value(args[1]) as libc::c_int
+                    } else {
+                        libc::RTLD_NOW
                     };
-                    let addr = rustpython_host_env::ctypes::lookup_function_symbol_addr(
-                        h,
-                        name.as_bytes(),
-                    )
-                    .map_err(|e| {
-                        use rustpython_host_env::ctypes::LookupSymbolError as L;
-                        let msg = match e {
-                            L::LibraryNotFound => "library not found".to_string(),
-                            L::LibraryClosed => "library closed".to_string(),
-                            L::Load(s) => s,
-                        };
-                        crate::PyError::os_error(format!("dlsym({name}): {msg}"))
-                    })?;
-                    Ok(pyre_object::w_int_new(addr as i64))
-                },
-                2,
-            ),
-        );
-
-        // dlclose(handle) → None
-        crate::module_ns_store(
-            ns,
-            "dlclose",
-            crate::make_builtin_function_with_arity(
-                "dlclose",
-                |args| {
-                    if args.is_empty() {
-                        return Err(crate::PyError::type_error("dlclose() needs handle"));
-                    }
-                    let h = (unsafe { pyre_object::w_int_get_value(args[0]) }) as usize;
-                    rustpython_host_env::ctypes::drop_library(h);
-                    Ok(pyre_object::w_none())
-                },
-                1,
-            ),
-        );
-
-        // get_errno / set_errno — ctypes routes them through host_env so
-        // a saved-errno round-trip across foreign calls survives the
-        // global libc::errno being overwritten by intermediate syscalls.
-        crate::module_ns_store(
-            ns,
-            "get_errno",
-            crate::make_builtin_function_with_arity(
-                "get_errno",
-                |_| {
-                    Ok(pyre_object::w_int_new(
-                        rustpython_host_env::ctypes::get_errno() as i64,
-                    ))
-                },
-                0,
-            ),
-        );
-        crate::module_ns_store(
-            ns,
-            "set_errno",
-            crate::make_builtin_function_with_arity(
-                "set_errno",
-                |args| {
-                    if args.is_empty() {
-                        return Err(crate::PyError::type_error("set_errno() needs value"));
-                    }
-                    let v = (unsafe { pyre_object::w_int_get_value(args[0]) }) as i32;
-                    let prev = rustpython_host_env::ctypes::set_errno(v);
-                    Ok(pyre_object::w_int_new(prev as i64))
-                },
-                1,
-            ),
-        );
-
-        // sizeof / alignment of simple ctypes type codes ('i', 'l', 'd', etc.).
-        crate::module_ns_store(
-            ns,
-            "_sizeof_typecode",
-            crate::make_builtin_function_with_arity(
-                "_sizeof_typecode",
-                |args| {
-                    if args.is_empty() || !unsafe { pyre_object::is_str(args[0]) } {
-                        return Err(crate::PyError::type_error(
-                            "_sizeof_typecode() needs typecode string",
-                        ));
-                    }
-                    let code = unsafe { pyre_object::w_str_get_value(args[0]).to_string() };
-                    match rustpython_host_env::ctypes::simple_type_size(&code) {
-                        Some(n) => Ok(pyre_object::w_int_new(n as i64)),
-                        None => Err(crate::PyError::value_error(format!(
-                            "unknown type code: {code}"
-                        ))),
-                    }
-                },
-                1,
-            ),
-        );
-        crate::module_ns_store(
-            ns,
-            "_alignof_typecode",
-            crate::make_builtin_function_with_arity(
-                "_alignof_typecode",
-                |args| {
-                    if args.is_empty() || !unsafe { pyre_object::is_str(args[0]) } {
-                        return Err(crate::PyError::type_error(
-                            "_alignof_typecode() needs typecode string",
-                        ));
-                    }
-                    let code = unsafe { pyre_object::w_str_get_value(args[0]).to_string() };
-                    match rustpython_host_env::ctypes::simple_type_align(&code) {
-                        Some(n) => Ok(pyre_object::w_int_new(n as i64)),
-                        None => Err(crate::PyError::value_error(format!(
-                            "unknown type code: {code}"
-                        ))),
-                    }
-                },
-                1,
-            ),
-        );
-
-        // Address of memmove / memset for ctypes.memmove / memset.
-        crate::module_ns_store(
-            ns,
-            "memmove",
-            crate::make_builtin_function_with_arity(
-                "memmove",
-                |args| {
-                    if args.len() < 3 {
-                        return Err(crate::PyError::type_error(
-                            "memmove() needs (dst, src, count)",
-                        ));
-                    }
-                    let dst = (unsafe { pyre_object::w_int_get_value(args[0]) }) as usize
-                        as *mut libc::c_void;
-                    let src = (unsafe { pyre_object::w_int_get_value(args[1]) }) as usize
-                        as *const libc::c_void;
-                    let n = (unsafe { pyre_object::w_int_get_value(args[2]) }) as usize;
-                    unsafe { libc::memmove(dst, src, n) };
-                    Ok(pyre_object::w_int_new(dst as usize as i64))
-                },
-                3,
-            ),
-        );
-        crate::module_ns_store(
-            ns,
-            "memset",
-            crate::make_builtin_function_with_arity(
-                "memset",
-                |args| {
-                    if args.len() < 3 {
-                        return Err(crate::PyError::type_error("memset() needs (dst, c, count)"));
-                    }
-                    let dst = (unsafe { pyre_object::w_int_get_value(args[0]) }) as usize
-                        as *mut libc::c_void;
-                    let c = (unsafe { pyre_object::w_int_get_value(args[1]) }) as libc::c_int;
-                    let n = (unsafe { pyre_object::w_int_get_value(args[2]) }) as usize;
-                    unsafe { libc::memset(dst, c, n) };
-                    Ok(pyre_object::w_int_new(dst as usize as i64))
-                },
-                3,
-            ),
-        );
-
-        // string_at(ptr, size=-1) -> bytes
-        crate::module_ns_store(
-            ns,
-            "string_at",
-            crate::make_builtin_function("string_at", |args| {
-                if args.is_empty() {
-                    return Err(crate::PyError::type_error("string_at() needs ptr"));
+                    let ptr = rustpython_host_env::ctypes::dlopen_self(mode)
+                        .map_err(|e| crate::PyError::os_error(format!("dlopen(None): {e}")))?;
+                    let h = rustpython_host_env::ctypes::insert_raw_library_handle(ptr);
+                    return Ok(pyre_object::w_int_new(h as i64));
                 }
-                let ptr = (unsafe { pyre_object::w_int_get_value(args[0]) }) as usize;
-                let size = if args.len() >= 2 {
-                    unsafe { pyre_object::w_int_get_value(args[1]) }
-                } else {
-                    -1
-                };
-                let bytes =
-                    rustpython_host_env::ctypes::string_at(ptr, size as isize).map_err(|e| {
-                        use rustpython_host_env::ctypes::StringAtError as S;
-                        let msg = match e {
-                            S::NullPointer => "NULL pointer access",
-                            S::TooLong => "size too large",
-                        };
-                        crate::PyError::os_error(format!("string_at: {msg}"))
-                    })?;
-                Ok(pyre_object::bytesobject::w_bytes_from_bytes(&bytes))
-            }),
-        );
+                if !pyre_object::is_str(args[0]) {
+                    return Err(crate::PyError::type_error(
+                        "dlopen: name must be a string or None",
+                    ));
+                }
+                pyre_object::w_str_get_value(args[0]).to_string()
+            };
+            let mode = if args.len() >= 2 {
+                (unsafe { pyre_object::w_int_get_value(args[1]) }) as i32
+            } else {
+                rustpython_host_env::ctypes::dlopen_mode(None)
+            };
+            let h = rustpython_host_env::ctypes::open_library_with_mode(&name, mode)
+                .map_err(|e| crate::PyError::os_error(format!("dlopen({name}): {e}")))?;
+            Ok(pyre_object::w_int_new(h as i64))
+        }),
+    );
 
-        // FFI library helpers used by stdlib ctypes/util.py:
-        //   _ctypes.dlopen + DEFAULT_MODE typically come above, but stdlib
-        //   also looks for _ctypes.SIZEOF_TIME_T to size struct timespec.
-        crate::module_ns_store(
-            ns,
-            "SIZEOF_TIME_T",
-            pyre_object::w_int_new(rustpython_host_env::ctypes::SIZEOF_TIME_T as i64),
-        );
+    // ── dlsym(handle, name) → address (int) ──
+    crate::module_ns_store(
+        ns,
+        "dlsym",
+        crate::make_builtin_function_with_arity(
+            "dlsym",
+            |args| {
+                if args.len() < 2 {
+                    return Err(crate::PyError::type_error("dlsym() needs 2 arguments"));
+                }
+                let h = (unsafe { pyre_object::w_int_get_value(args[0]) }) as usize;
+                let name = unsafe {
+                    if !pyre_object::is_str(args[1]) {
+                        return Err(crate::PyError::type_error("dlsym: name must be a string"));
+                    }
+                    pyre_object::w_str_get_value(args[1]).to_string()
+                };
+                let addr =
+                    rustpython_host_env::ctypes::lookup_function_symbol_addr(h, name.as_bytes())
+                        .map_err(|e| {
+                            use rustpython_host_env::ctypes::LookupSymbolError as L;
+                            let msg = match e {
+                                L::LibraryNotFound => "library not found".to_string(),
+                                L::LibraryClosed => "library closed".to_string(),
+                                L::Load(s) => s,
+                            };
+                            crate::PyError::os_error(format!("dlsym({name}): {msg}"))
+                        })?;
+                Ok(pyre_object::w_int_new(addr as i64))
+            },
+            2,
+        ),
+    );
+
+    // ── dlclose(handle) → None ──
+    crate::module_ns_store(
+        ns,
+        "dlclose",
+        crate::make_builtin_function_with_arity(
+            "dlclose",
+            |args| {
+                if args.is_empty() {
+                    return Err(crate::PyError::type_error("dlclose() needs handle"));
+                }
+                let h = (unsafe { pyre_object::w_int_get_value(args[0]) }) as usize;
+                rustpython_host_env::ctypes::drop_library(h);
+                Ok(pyre_object::w_none())
+            },
+            1,
+        ),
+    );
+
+    // ── get_errno / set_errno — routed through host_env's ctypes-local errno ──
+    crate::module_ns_store(
+        ns,
+        "get_errno",
+        crate::make_builtin_function_with_arity(
+            "get_errno",
+            |_| {
+                Ok(pyre_object::w_int_new(
+                    rustpython_host_env::ctypes::get_errno() as i64,
+                ))
+            },
+            0,
+        ),
+    );
+    crate::module_ns_store(
+        ns,
+        "set_errno",
+        crate::make_builtin_function_with_arity(
+            "set_errno",
+            |args| {
+                if args.is_empty() {
+                    return Err(crate::PyError::type_error("set_errno() needs value"));
+                }
+                let v = (unsafe { pyre_object::w_int_get_value(args[0]) }) as i32;
+                let prev = rustpython_host_env::ctypes::set_errno(v);
+                Ok(pyre_object::w_int_new(prev as i64))
+            },
+            1,
+        ),
+    );
+
+    // ── sizeof / alignment of raw type codes ('i', 'l', 'd', …) ──
+    crate::module_ns_store(
+        ns,
+        "_sizeof_typecode",
+        crate::make_builtin_function_with_arity(
+            "_sizeof_typecode",
+            |args| {
+                if args.is_empty() || !unsafe { pyre_object::is_str(args[0]) } {
+                    return Err(crate::PyError::type_error(
+                        "_sizeof_typecode() needs typecode string",
+                    ));
+                }
+                let code = unsafe { pyre_object::w_str_get_value(args[0]).to_string() };
+                match rustpython_host_env::ctypes::simple_type_size(&code) {
+                    Some(n) => Ok(pyre_object::w_int_new(n as i64)),
+                    None => Err(crate::PyError::value_error(format!(
+                        "unknown type code: {code}"
+                    ))),
+                }
+            },
+            1,
+        ),
+    );
+    crate::module_ns_store(
+        ns,
+        "_alignof_typecode",
+        crate::make_builtin_function_with_arity(
+            "_alignof_typecode",
+            |args| {
+                if args.is_empty() || !unsafe { pyre_object::is_str(args[0]) } {
+                    return Err(crate::PyError::type_error(
+                        "_alignof_typecode() needs typecode string",
+                    ));
+                }
+                let code = unsafe { pyre_object::w_str_get_value(args[0]).to_string() };
+                match rustpython_host_env::ctypes::simple_type_align(&code) {
+                    Some(n) => Ok(pyre_object::w_int_new(n as i64)),
+                    None => Err(crate::PyError::value_error(format!(
+                        "unknown type code: {code}"
+                    ))),
+                }
+            },
+            1,
+        ),
+    );
+
+    // ── string_at(ptr, size=-1) → bytes ──
+    crate::module_ns_store(
+        ns,
+        "string_at",
+        crate::make_builtin_function("string_at", |args| {
+            if args.is_empty() {
+                return Err(crate::PyError::type_error("string_at() needs ptr"));
+            }
+            let ptr = (unsafe { pyre_object::w_int_get_value(args[0]) }) as usize;
+            let size = if args.len() >= 2 {
+                unsafe { pyre_object::w_int_get_value(args[1]) }
+            } else {
+                -1
+            };
+            let bytes =
+                rustpython_host_env::ctypes::string_at(ptr, size as isize).map_err(|e| {
+                    use rustpython_host_env::ctypes::StringAtError as S;
+                    let msg = match e {
+                        S::NullPointer => "NULL pointer access",
+                        S::TooLong => "size too large",
+                    };
+                    crate::PyError::os_error(format!("string_at: {msg}"))
+                })?;
+            Ok(pyre_object::bytesobject::w_bytes_from_bytes(&bytes))
+        }),
+    );
+
+    crate::module_ns_store(
+        ns,
+        "SIZEOF_TIME_T",
+        pyre_object::w_int_new(rustpython_host_env::ctypes::SIZEOF_TIME_T as i64),
+    );
+
+    // ── import-time constants ──
+    crate::module_ns_store(ns, "__version__", pyre_object::w_str_new("1.1.0"));
+    // `crates/vm/src/stdlib/_ctypes.rs`: CDECL=0x1, PYTHONAPI=0x4,
+    // USE_ERRNO=0x8, USE_LASTERROR=0x10.
+    crate::module_ns_store(ns, "FUNCFLAG_CDECL", pyre_object::w_int_new(0x1));
+    crate::module_ns_store(ns, "FUNCFLAG_PYTHONAPI", pyre_object::w_int_new(0x4));
+    crate::module_ns_store(ns, "FUNCFLAG_USE_ERRNO", pyre_object::w_int_new(0x8));
+    crate::module_ns_store(ns, "FUNCFLAG_USE_LASTERROR", pyre_object::w_int_new(0x10));
+
+    // Real addresses so `memmove`/`memset = CFUNCTYPE(...)(_memmove_addr)`
+    // build callable foreign functions; the other three are import-only
+    // sentinels (cast/string_at/memoryview PYFUNCTYPE targets are not
+    // exercised by this slice).
+    crate::module_ns_store(
+        ns,
+        "_memmove_addr",
+        pyre_object::w_int_new(host_ctypes::memmove_addr() as i64),
+    );
+    crate::module_ns_store(
+        ns,
+        "_memset_addr",
+        pyre_object::w_int_new(host_ctypes::memset_addr() as i64),
+    );
+    crate::module_ns_store(ns, "_cast_addr", pyre_object::w_int_new(1));
+    crate::module_ns_store(ns, "_string_at_addr", pyre_object::w_int_new(2));
+    crate::module_ns_store(ns, "_memoryview_at_addr", pyre_object::w_int_new(4));
+
+    // ── ArgumentError — a real Exception subclass ──
+    let w_exception = crate::builtins::lookup_exc_class("Exception")
+        .expect("Exception must be installed before _ctypes init");
+    crate::module_ns_store(
+        ns,
+        "ArgumentError",
+        crate::builtins::make_exc_type(
+            "ArgumentError",
+            crate::builtins::exc_exception_new,
+            w_exception,
+        ),
+    );
+
+    // ── aggregate + array/pointer types: real `Structure`/`Union`/`Array`/
+    //    `_Pointer`/`CField` ──
+    use super::metaclass;
+    let structure_tp = metaclass::structure_type();
+    let union_tp = metaclass::union_type();
+    let array_tp = metaclass::array_type();
+    let pointer_tp = metaclass::pointer_base_type();
+    crate::module_ns_store(ns, "Structure", structure_tp);
+    crate::module_ns_store(ns, "Union", union_tp);
+    crate::module_ns_store(ns, "Array", array_tp);
+    crate::module_ns_store(ns, "_Pointer", pointer_tp);
+    crate::module_ns_store(ns, "CField", metaclass::cfield_type());
+
+    // ── the functional scalar + foreign-function types ──
+    let simplecdata_tp = super::cdata::simplecdata_type();
+    // `_SimpleCData`'s metaclass routes `class c_int(_SimpleCData): _type_="i"`
+    // through `PyCSimpleType.__new__` (validation + StgInfo).
+    unsafe { (*simplecdata_tp).w_class = metaclass::pycsimpletype_type() };
+    crate::module_ns_store(ns, "_SimpleCData", simplecdata_tp);
+    crate::module_ns_store(ns, "CFuncPtr", super::funcptr::cfuncptr_type());
+
+    // Widen `is_cdata_instance` (sizeof/addressof/byref) to every CData base.
+    for base in [simplecdata_tp, structure_tp, union_tp, array_tp, pointer_tp] {
+        super::cdata::register_cdata_base(base);
     }
 
-    // Error type alias.
+    // ── sizeof / addressof / byref / alignment / resize ──
+    crate::module_ns_store(
+        ns,
+        "sizeof",
+        crate::make_builtin_function("sizeof", ctypes_sizeof),
+    );
+    crate::module_ns_store(
+        ns,
+        "alignment",
+        crate::make_builtin_function("alignment", ctypes_alignment),
+    );
+    crate::module_ns_store(
+        ns,
+        "addressof",
+        crate::make_builtin_function("addressof", ctypes_addressof),
+    );
+    crate::module_ns_store(
+        ns,
+        "byref",
+        crate::make_builtin_function("byref", ctypes_byref),
+    );
+    crate::module_ns_store(
+        ns,
+        "resize",
+        crate::make_builtin_function("resize", ctypes_resize),
+    );
+}
+
+// ── sizeof / alignment (types and instances) ──────────────────────────
+
+#[cfg(all(unix, feature = "host_env"))]
+fn ctypes_sizeof(
+    args: &[pyre_object::PyObjectRef],
+) -> Result<pyre_object::PyObjectRef, crate::PyError> {
+    use super::{cdata, stginfo};
+    use rustpython_host_env::ctypes as host_ctypes;
+    let obj = *args
+        .first()
+        .ok_or_else(|| crate::PyError::type_error("sizeof() missing argument"))?;
+    if unsafe { pyre_object::is_type(obj) } {
+        if let Some(info) = stginfo::stginfo_of(obj) {
+            return Ok(pyre_object::w_int_new(stginfo::stginfo_size(info) as i64));
+        }
+        // Simple type without a StgInfo yet: derive from `_type_`.
+        return match cdata::type_code_of(obj) {
+            Some(tc) => match host_ctypes::simple_type_size(&tc) {
+                Some(sz) => Ok(pyre_object::w_int_new(sz as i64)),
+                None => Err(cdata::invalid_type_code_error()),
+            },
+            None => Err(crate::PyError::type_error("this type has no size")),
+        };
+    }
+    if cdata::is_cdata_instance(obj) {
+        return Ok(pyre_object::w_int_new(
+            cdata::cdata_len(obj).unwrap_or(0) as i64
+        ));
+    }
+    Err(crate::PyError::type_error("this type has no size"))
+}
+
+#[cfg(all(unix, feature = "host_env"))]
+fn ctypes_alignment(
+    args: &[pyre_object::PyObjectRef],
+) -> Result<pyre_object::PyObjectRef, crate::PyError> {
+    use super::{cdata, stginfo};
+    use rustpython_host_env::ctypes as host_ctypes;
+    let obj = *args
+        .first()
+        .ok_or_else(|| crate::PyError::type_error("alignment() missing argument"))?;
+    let target = if unsafe { pyre_object::is_type(obj) } {
+        obj
+    } else if cdata::is_cdata_instance(obj) {
+        unsafe { pyre_object::w_instance_get_type(obj) }
+    } else {
+        return Err(crate::PyError::type_error("no alignment info"));
+    };
+    if let Some(info) = stginfo::stginfo_of(target) {
+        return Ok(pyre_object::w_int_new(stginfo::stginfo_align(info) as i64));
+    }
+    match cdata::type_code_of(target) {
+        Some(tc) => match host_ctypes::simple_type_align(&tc) {
+            Some(a) => Ok(pyre_object::w_int_new(a as i64)),
+            None => Err(cdata::invalid_type_code_error()),
+        },
+        None => Err(crate::PyError::type_error("no alignment info")),
+    }
+}
+
+// ── addressof / byref / resize (instances) ────────────────────────────
+
+#[cfg(all(unix, feature = "host_env"))]
+fn ctypes_addressof(
+    args: &[pyre_object::PyObjectRef],
+) -> Result<pyre_object::PyObjectRef, crate::PyError> {
+    use super::cdata;
+    let obj = *args
+        .first()
+        .ok_or_else(|| crate::PyError::type_error("addressof() missing argument"))?;
+    if !cdata::is_cdata_instance(obj) {
+        return Err(crate::PyError::type_error("invalid type"));
+    }
+    let addr = cdata::cdata_addr(obj)
+        .ok_or_else(|| crate::PyError::type_error("instance has no buffer"))?;
+    Ok(pyre_object::w_int_new(addr as i64))
+}
+
+#[cfg(all(unix, feature = "host_env"))]
+fn ctypes_byref(
+    args: &[pyre_object::PyObjectRef],
+) -> Result<pyre_object::PyObjectRef, crate::PyError> {
+    use super::cdata;
+    use rustpython_host_env::ctypes as host_ctypes;
+    let obj = *args
+        .first()
+        .ok_or_else(|| crate::PyError::type_error("byref() missing argument"))?;
+    if !cdata::is_cdata_instance(obj) {
+        return Err(crate::PyError::type_error(
+            "byref() argument must be a ctypes instance",
+        ));
+    }
+    let offset = if args.len() >= 2 {
+        crate::baseobjspace::int_w(args[1])? as isize
+    } else {
+        0
+    };
+    let base = cdata::cdata_addr(obj)
+        .ok_or_else(|| crate::PyError::type_error("instance has no buffer"))?;
+    let addr = host_ctypes::offset_address(base, offset);
+    Ok(make_carg(addr, obj))
+}
+
+#[cfg(all(unix, feature = "host_env"))]
+fn ctypes_resize(
+    args: &[pyre_object::PyObjectRef],
+) -> Result<pyre_object::PyObjectRef, crate::PyError> {
+    use super::cdata;
+    if args.len() < 2 {
+        return Err(crate::PyError::type_error("resize() needs (obj, size)"));
+    }
+    let obj = args[0];
+    if !cdata::is_cdata_instance(obj) {
+        return Err(crate::PyError::type_error("excepted ctypes instance"));
+    }
+    if !cdata::owns_buffer(obj) {
+        return Err(crate::PyError::value_error(
+            "Memory cannot be resized because this object doesn't own it",
+        ));
+    }
+    let size = crate::baseobjspace::int_w(args[1])? as usize;
+    let cur = cdata::cdata_len(obj).unwrap_or(0);
+    if size < cur {
+        return Err(crate::PyError::value_error(format!(
+            "minimum size is {cur}"
+        )));
+    }
+    if size > cur {
+        if let Some(ba) = cdata::cdata_buffer(obj) {
+            unsafe { pyre_object::w_bytearray_vec_mut(ba).resize(size, 0) };
+        }
+    }
+    Ok(pyre_object::w_none())
+}
+
+// ── byref carrier ──────────────────────────────────────────────────────
+
+#[cfg(all(unix, feature = "host_env"))]
+thread_local! {
+    static CARG_TYPE_OBJ: std::cell::OnceCell<pyre_object::PyObjectRef> =
+        const { std::cell::OnceCell::new() };
+}
+
+/// The minimal `byref` carrier type — holds `_ptr` (address) and `_obj`
+/// (the referenced instance, kept alive).  Foreign-call consumption of the
+/// carrier (the CArgObject P-tag path) is a later slice.
+#[cfg(all(unix, feature = "host_env"))]
+fn carg_type() -> pyre_object::PyObjectRef {
+    CARG_TYPE_OBJ.with(|c| {
+        *c.get_or_init(|| {
+            let tp = crate::typedef::make_builtin_type("CArgObject", |_| {});
+            unsafe { pyre_object::typeobject::w_type_set_hasdict(tp, true) };
+            tp
+        })
+    })
+}
+
+#[cfg(all(unix, feature = "host_env"))]
+fn make_carg(addr: usize, obj: pyre_object::PyObjectRef) -> pyre_object::PyObjectRef {
+    let carg = pyre_object::w_instance_new(carg_type());
+    let d = crate::baseobjspace::getdict(carg);
+    if !d.is_null() {
+        unsafe {
+            pyre_object::w_dict_setitem_str(d, "_ptr", pyre_object::w_int_new(addr as i64));
+            pyre_object::w_dict_setitem_str(d, "_obj", obj);
+        }
+    }
+    carg
+}
+
+/// Whether `obj` is a `byref()` carrier (consumed by [`super::funcptr`]).
+#[cfg(all(unix, feature = "host_env"))]
+pub(super) fn is_carg(obj: pyre_object::PyObjectRef) -> bool {
+    !obj.is_null() && unsafe { pyre_object::w_instance_get_type(obj) } == carg_type()
+}
+
+/// The address a `byref()` carrier points at.
+#[cfg(all(unix, feature = "host_env"))]
+pub(super) fn carg_ptr(carg: pyre_object::PyObjectRef) -> usize {
+    let d = crate::baseobjspace::getdict(carg);
+    if d.is_null() {
+        return 0;
+    }
+    match unsafe { pyre_object::w_dict_getitem_str(d, "_ptr") } {
+        Some(o) if unsafe { pyre_object::is_int(o) } => {
+            (unsafe { pyre_object::w_int_get_value(o) }) as usize
+        }
+        _ => 0,
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// Stub surface (non-unix or no host_env) — keeps names importable.
+// ──────────────────────────────────────────────────────────────────────
+
+#[cfg(not(all(unix, feature = "host_env")))]
+fn register_stub_ctypes(ns: pyre_object::PyObjectRef) {
     crate::module_ns_store(ns, "ArgumentError", crate::typedef::w_object());
     crate::module_ns_store(ns, "_Pointer", crate::typedef::w_object());
     crate::module_ns_store(ns, "Structure", crate::typedef::w_object());
     crate::module_ns_store(ns, "Union", crate::typedef::w_object());
     crate::module_ns_store(ns, "Array", crate::typedef::w_object());
-    crate::module_ns_store(ns, "_CFuncPtr", crate::typedef::w_object());
-    crate::module_ns_store(ns, "_SimpleCData", crate::typedef::w_object());
+    crate::module_ns_store(ns, "CField", crate::typedef::w_object());
     crate::module_ns_store(ns, "CFuncPtr", crate::typedef::w_object());
-    crate::module_ns_store(ns, "POINTER", crate::typedef::w_object());
-    crate::module_ns_store(ns, "pointer", crate::typedef::w_object());
-    crate::module_ns_store(ns, "byref", crate::typedef::w_object());
-    crate::module_ns_store(ns, "addressof", crate::typedef::w_object());
+    crate::module_ns_store(ns, "_SimpleCData", crate::typedef::w_object());
     crate::module_ns_store(ns, "sizeof", crate::typedef::w_object());
     crate::module_ns_store(ns, "alignment", crate::typedef::w_object());
-    crate::module_ns_store(ns, "_check_HRESULT", crate::typedef::w_object());
+    crate::module_ns_store(ns, "addressof", crate::typedef::w_object());
+    crate::module_ns_store(ns, "byref", crate::typedef::w_object());
+    crate::module_ns_store(ns, "resize", crate::typedef::w_object());
 }

--- a/pyre/pyre-interpreter/src/module/_ctypes/metaclass.rs
+++ b/pyre/pyre-interpreter/src/module/_ctypes/metaclass.rs
@@ -1,0 +1,1529 @@
+//! ctypes metaclasses, `CField` descriptors, and the `Structure`/`Union` bases.
+//!
+//! `PyCSimpleType` / `PyCStructType` / `PyCUnionType` / `PyCArrayType` /
+//! `PyCPointerType` are the metaclasses of `_SimpleCData` / `Structure` /
+//! `Union` / `Array` / `_Pointer`.  Their `__new__` builds the class and
+//! computes its [`super::stginfo::StgInfoData`] (simple validation, the
+//! struct/union layout in [`process_fields`], or the array/pointer element
+//! metadata).  `CField` is the per-field data descriptor installed into a class
+//! dict; its `__get__`/`__set__` read and write the instance buffer at the
+//! field offset, aliasing nested aggregates as sub-views
+//! (`super::cdata::make_subview`).
+//!
+//! `ctype * n` builds a cached `Array` subtype (`array_type_from_ctype`);
+//! `POINTER(T)` builds a cached `_Pointer` subtype, memoised on `T`'s
+//! `StgInfo.pointer_type` and read back through the `__pointer_type__` getset.
+
+use super::cdata;
+use super::stginfo::{self, StgInfoData};
+use super::type_ns_store;
+use pyre_object::PyObjectRef;
+use rustpython_host_env::ctypes as host_ctypes;
+use std::cell::RefCell;
+
+type PyResult = Result<PyObjectRef, crate::PyError>;
+
+// ── cached type objects ────────────────────────────────────────────────
+
+macro_rules! cached_type {
+    ($cell:ident, $f:ident, $build:expr) => {
+        thread_local! {
+            static $cell: std::cell::OnceCell<PyObjectRef> = const { std::cell::OnceCell::new() };
+        }
+        pub(super) fn $f() -> PyObjectRef {
+            $cell.with(|c| *c.get_or_init($build))
+        }
+    };
+}
+
+cached_type!(PYCSIMPLETYPE, pycsimpletype_type, || {
+    crate::typedef::make_builtin_type_with_base(
+        "PyCSimpleType",
+        |ns| {
+            install_new(ns, csimpletype_new);
+            install_shared_meta(ns);
+        },
+        crate::typedef::w_type(),
+    )
+});
+
+cached_type!(PYCSTRUCTTYPE, pycstructtype_type, || {
+    crate::typedef::make_builtin_type_with_base(
+        "PyCStructType",
+        |ns| {
+            install_new(ns, cstructtype_new);
+            install_shared_meta(ns);
+            install_fields_getset(ns);
+        },
+        crate::typedef::w_type(),
+    )
+});
+
+cached_type!(PYCUNIONTYPE, pycuniontype_type, || {
+    // The union metaclass's Python-visible name is `UnionType` (matching
+    // `_ctypes.UnionType`), though its Rust identifier is PyCUnionType.
+    crate::typedef::make_builtin_type_with_base(
+        "UnionType",
+        |ns| {
+            install_new(ns, cuniontype_new);
+            install_shared_meta(ns);
+            install_fields_getset(ns);
+        },
+        crate::typedef::w_type(),
+    )
+});
+
+cached_type!(STRUCTURE, structure_type, || {
+    let tp = crate::typedef::make_builtin_type_with_base(
+        "Structure",
+        init_aggregate_base,
+        crate::typedef::w_object(),
+    );
+    finish_aggregate_base(tp, pycstructtype_type(), "struct");
+    tp
+});
+
+cached_type!(UNION, union_type, || {
+    let tp = crate::typedef::make_builtin_type_with_base(
+        "Union",
+        init_aggregate_base,
+        crate::typedef::w_object(),
+    );
+    finish_aggregate_base(tp, pycuniontype_type(), "union");
+    tp
+});
+
+cached_type!(CFIELD, cfield_type, || {
+    let tp = crate::typedef::make_builtin_type("CField", |ns| {
+        type_ns_store(
+            ns,
+            "__new__",
+            crate::make_builtin_function("__new__", cfield_new_disabled),
+        );
+        type_ns_store(
+            ns,
+            "__get__",
+            crate::make_builtin_function("__get__", cfield_get),
+        );
+        type_ns_store(
+            ns,
+            "__set__",
+            crate::make_builtin_function("__set__", cfield_set),
+        );
+        type_ns_store(
+            ns,
+            "__repr__",
+            crate::make_builtin_function("__repr__", cfield_repr),
+        );
+    });
+    unsafe { pyre_object::typeobject::w_type_set_hasdict(tp, true) };
+    tp
+});
+
+cached_type!(PYCARRAYTYPE, pycarraytype_type, || {
+    crate::typedef::make_builtin_type_with_base(
+        "PyCArrayType",
+        |ns| {
+            install_new(ns, carraytype_new);
+            install_shared_meta(ns);
+        },
+        crate::typedef::w_type(),
+    )
+});
+
+cached_type!(PYCPOINTERTYPE, pycpointertype_type, || {
+    crate::typedef::make_builtin_type_with_base(
+        "PyCPointerType",
+        |ns| {
+            install_new(ns, cpointertype_new);
+            install_shared_meta(ns);
+        },
+        crate::typedef::w_type(),
+    )
+});
+
+cached_type!(ARRAY, array_type, || {
+    let tp = crate::typedef::make_builtin_type_with_base(
+        "Array",
+        init_array_base,
+        crate::typedef::w_object(),
+    );
+    finish_element_base(tp, pycarraytype_type());
+    tp
+});
+
+cached_type!(POINTER_BASE, pointer_base_type, || {
+    let tp = crate::typedef::make_builtin_type_with_base(
+        "_Pointer",
+        init_pointer_base,
+        crate::typedef::w_object(),
+    );
+    finish_element_base(tp, pycpointertype_type());
+    tp
+});
+
+fn install_new(ns: PyObjectRef, f: crate::gateway::BuiltinCodeFn) {
+    type_ns_store(ns, "__new__", crate::make_builtin_function("__new__", f));
+}
+
+/// `__mul__`, `__pointer_type__`, and `from_param` — shared by all metaclasses.
+fn install_shared_meta(ns: PyObjectRef) {
+    type_ns_store(
+        ns,
+        "__mul__",
+        crate::make_builtin_function("__mul__", meta_mul),
+    );
+    type_ns_store(
+        ns,
+        "__pointer_type__",
+        crate::typedef::make_getset_property_named(
+            crate::make_builtin_function_with_arity("__pointer_type__", pointer_type_get, 2),
+            crate::make_builtin_function_with_arity("__pointer_type__", pointer_type_set, 3),
+            pyre_object::PY_NULL,
+            "__pointer_type__",
+        ),
+    );
+    type_ns_store(
+        ns,
+        "from_param",
+        crate::make_builtin_function("from_param", meta_from_param),
+    );
+}
+
+fn install_fields_getset(ns: PyObjectRef) {
+    type_ns_store(
+        ns,
+        "_fields_",
+        crate::typedef::make_getset_property_named(
+            crate::make_builtin_function_with_arity("_fields_", fields_get, 2),
+            crate::make_builtin_function_with_arity("_fields_", fields_set, 3),
+            pyre_object::PY_NULL,
+            "_fields_",
+        ),
+    );
+}
+
+fn init_aggregate_base(ns: PyObjectRef) {
+    type_ns_store(
+        ns,
+        "__new__",
+        crate::make_builtin_function("__new__", structure_new),
+    );
+    type_ns_store(
+        ns,
+        "__init__",
+        crate::make_builtin_function("__init__", structure_init),
+    );
+}
+
+fn finish_aggregate_base(tp: PyObjectRef, metaclass: PyObjectRef, paramfunc: &'static str) {
+    unsafe {
+        pyre_object::typeobject::w_type_set_hasdict(tp, true);
+        (*tp).w_class = metaclass;
+    }
+    // A default 0-size StgInfo so `clone-from-base` works and a bare
+    // `Structure()`/`Union()` is not treated as abstract.
+    stginfo::stginfo_set(tp, stginfo::stginfo_new(StgInfoData::new(0, 1, paramfunc)));
+}
+
+/// Finish the `Array` / `_Pointer` base: hasdict, acceptable-as-base, stamp its
+/// metaclass.  Unlike the aggregate bases these get **no** default `StgInfo`, so
+/// a bare `Array()` / `_Pointer()` is abstract until a subtype supplies
+/// `_type_` (`POINTER(T)`) or `_type_`+`_length_` (`T * n`).
+fn finish_element_base(tp: PyObjectRef, metaclass: PyObjectRef) {
+    unsafe {
+        pyre_object::typeobject::w_type_set_hasdict(tp, true);
+        pyre_object::typeobject::w_type_set_acceptable_as_base_class(tp, true);
+        (*tp).w_class = metaclass;
+    }
+}
+
+fn init_array_base(ns: PyObjectRef) {
+    install_new(ns, array_new);
+    type_ns_store(
+        ns,
+        "__init__",
+        crate::make_builtin_function("__init__", array_init),
+    );
+    type_ns_store(
+        ns,
+        "__len__",
+        crate::make_builtin_function("__len__", array_len),
+    );
+    type_ns_store(
+        ns,
+        "__getitem__",
+        crate::make_builtin_function("__getitem__", array_getitem),
+    );
+    type_ns_store(
+        ns,
+        "__setitem__",
+        crate::make_builtin_function("__setitem__", array_setitem),
+    );
+}
+
+fn init_pointer_base(ns: PyObjectRef) {
+    install_new(ns, pointer_new);
+    type_ns_store(
+        ns,
+        "__init__",
+        crate::make_builtin_function("__init__", pointer_init),
+    );
+    type_ns_store(
+        ns,
+        "__getitem__",
+        crate::make_builtin_function("__getitem__", pointer_getitem),
+    );
+    type_ns_store(
+        ns,
+        "__setitem__",
+        crate::make_builtin_function("__setitem__", pointer_setitem),
+    );
+    type_ns_store(
+        ns,
+        "__bool__",
+        crate::make_builtin_function("__bool__", pointer_bool),
+    );
+    type_ns_store(
+        ns,
+        "contents",
+        crate::typedef::make_getset_property_named(
+            crate::make_builtin_function_with_arity("contents", contents_get, 2),
+            crate::make_builtin_function_with_arity("contents", contents_set, 3),
+            pyre_object::PY_NULL,
+            "contents",
+        ),
+    );
+}
+
+// ── metaclass `__new__` ────────────────────────────────────────────────
+
+fn csimpletype_new(args: &[PyObjectRef]) -> PyResult {
+    let cls = crate::builtins::type_descr_new(args)?;
+    simple_init_stginfo(cls)?;
+    Ok(cls)
+}
+
+fn cstructtype_new(args: &[PyObjectRef]) -> PyResult {
+    let cls = crate::builtins::type_descr_new(args)?;
+    struct_union_init_stginfo(cls, false)?;
+    Ok(cls)
+}
+
+fn cuniontype_new(args: &[PyObjectRef]) -> PyResult {
+    let cls = crate::builtins::type_descr_new(args)?;
+    struct_union_init_stginfo(cls, true)?;
+    Ok(cls)
+}
+
+/// `PyCSimpleType` layout: validate `_type_` and build a simple `StgInfo`.
+fn simple_init_stginfo(cls: PyObjectRef) -> PyResult {
+    let tc = match cdata::type_code_of(cls) {
+        Some(tc) => tc,
+        // No `_type_` at all: `_SimpleCData` itself and abstract intermediates.
+        None => return Ok(pyre_object::w_none()),
+    };
+    if tc.chars().count() != 1 || !host_ctypes::simple_type_chars().contains(tc.as_str()) {
+        return Err(cdata::invalid_type_code_error());
+    }
+    let size = host_ctypes::simple_type_size(&tc).ok_or_else(cdata::invalid_type_code_error)?;
+    let align = host_ctypes::simple_type_align(&tc).ok_or_else(cdata::invalid_type_code_error)?;
+    let mut data = StgInfoData::new(size, align, "simple");
+    data.format = Some(tc.clone());
+    if host_ctypes::simple_type_is_pointer(&tc) {
+        data.flags |= stginfo::TYPEFLAG_ISPOINTER;
+    }
+    stginfo::stginfo_set(cls, stginfo::stginfo_new(data));
+    Ok(pyre_object::w_none())
+}
+
+// ── struct/union layout ────────────────────────────────────────────────
+
+/// MRO items of `cls`; empty while the type is still being initialised and
+/// carries no mro yet.
+fn mro_items<'a>(cls: PyObjectRef) -> &'a [PyObjectRef] {
+    let mro = unsafe { pyre_object::typeobject::w_type_get_mro(cls) };
+    if mro.is_null() {
+        return &[];
+    }
+    unsafe { (*mro).as_slice() }
+}
+
+/// First base (in MRO order after `cls`) that carries a `StgInfo`.
+fn first_base_stginfo(cls: PyObjectRef) -> Option<PyObjectRef> {
+    mro_items(cls)
+        .iter()
+        .skip(1)
+        .find_map(|&t| stginfo::stginfo_of(t))
+}
+
+fn usize_attr(cls: PyObjectRef, name: &str, default: usize) -> usize {
+    match unsafe { crate::baseobjspace::lookup_in_type(cls, name) } {
+        Some(o) if unsafe { pyre_object::is_int(o) } => {
+            (unsafe { pyre_object::w_int_get_value(o) }).max(0) as usize
+        }
+        _ => default,
+    }
+}
+
+/// Parse `_fields_` into `(name, ctype)` pairs (2-tuples only).
+fn field_entries(fields: PyObjectRef) -> Result<Vec<(String, PyObjectRef)>, crate::PyError> {
+    let items = seq_items(fields)
+        .ok_or_else(|| crate::PyError::type_error("_fields_ must be a sequence of 2-tuples"))?;
+    let mut out = Vec::with_capacity(items.len());
+    for it in items {
+        if !unsafe { pyre_object::is_tuple(it) } {
+            return Err(crate::PyError::type_error(
+                "_fields_ entries must be tuples",
+            ));
+        }
+        let n = unsafe { pyre_object::w_tuple_len(it) };
+        if n < 2 {
+            return Err(crate::PyError::type_error(
+                "_fields_ entries must be (name, type) pairs",
+            ));
+        }
+        if n >= 3 {
+            return Err(crate::PyError::type_error(
+                "bit fields are not supported in this slice",
+            ));
+        }
+        let name = unsafe { pyre_object::w_tuple_getitem(it, 0) }.unwrap_or(pyre_object::PY_NULL);
+        let ty = unsafe { pyre_object::w_tuple_getitem(it, 1) }.unwrap_or(pyre_object::PY_NULL);
+        if name.is_null() || !unsafe { pyre_object::is_str(name) } {
+            return Err(crate::PyError::type_error("field name must be a string"));
+        }
+        if ty.is_null() || !unsafe { pyre_object::is_type(ty) } {
+            return Err(crate::PyError::type_error(
+                "field type must be a ctypes type",
+            ));
+        }
+        out.push((
+            unsafe { pyre_object::w_str_get_value(name) }.to_string(),
+            ty,
+        ));
+    }
+    Ok(out)
+}
+
+fn seq_items(obj: PyObjectRef) -> Option<Vec<PyObjectRef>> {
+    if unsafe { pyre_object::is_tuple(obj) } {
+        let n = unsafe { pyre_object::w_tuple_len(obj) } as i64;
+        Some(
+            (0..n)
+                .filter_map(|i| unsafe { pyre_object::w_tuple_getitem(obj, i) })
+                .collect(),
+        )
+    } else if unsafe { pyre_object::is_list(obj) } {
+        let n = unsafe { pyre_object::w_list_len(obj) } as i64;
+        Some(
+            (0..n)
+                .filter_map(|i| unsafe { pyre_object::w_list_getitem(obj, i) })
+                .collect(),
+        )
+    } else {
+        None
+    }
+}
+
+/// Mark a field type's `StgInfo` FINAL (creating a minimal one if absent), so
+/// it cannot later gain `_fields_`.
+fn mark_type_final(ty: PyObjectRef, size: usize, align: usize) {
+    match stginfo::stginfo_of(ty) {
+        Some(info) => stginfo::stginfo_mark_final(info),
+        None => {
+            let mut data = StgInfoData::new(size, align, "simple");
+            data.flags |= stginfo::DICTFLAG_FINAL;
+            stginfo::stginfo_set(ty, stginfo::stginfo_new(data));
+        }
+    }
+}
+
+/// Compute the layout for a struct (`is_union=false`) or union, installing the
+/// `CField` descriptors and the class `StgInfo`.  Port of `process_fields`.
+fn struct_union_init_stginfo(cls: PyObjectRef, is_union: bool) -> PyResult {
+    // `_fields_` directly in the new class dict → process it; else clone the
+    // first base's StgInfo (or a default).
+    let own_fields =
+        crate::type_dict_lookup(cls, "_fields_").filter(|&f| !unsafe { pyre_object::is_none(f) });
+    match own_fields {
+        Some(fields) => process_fields(cls, fields, is_union),
+        None => {
+            let paramfunc = if is_union { "union" } else { "struct" };
+            match first_base_stginfo(cls) {
+                Some(base_info) => {
+                    let mut data = StgInfoData::new(
+                        stginfo::stginfo_size(base_info),
+                        stginfo::stginfo_align(base_info),
+                        paramfunc,
+                    );
+                    data.length = stginfo::stginfo_length(base_info);
+                    // Cleared FINAL / pointer_type on the clone; mark base FINAL.
+                    stginfo::stginfo_set(cls, stginfo::stginfo_new(data));
+                    stginfo::stginfo_mark_final(base_info);
+                }
+                None => stginfo::stginfo_set(
+                    cls,
+                    stginfo::stginfo_new(StgInfoData::new(0, 1, paramfunc)),
+                ),
+            }
+            Ok(pyre_object::w_none())
+        }
+    }
+}
+
+fn process_fields(cls: PyObjectRef, fields: PyObjectRef, is_union: bool) -> PyResult {
+    let entries = field_entries(fields)?;
+
+    let is_swapped =
+        unsafe { crate::baseobjspace::lookup_in_type(cls, "_swappedbytes_") }.is_some();
+    let pack = usize_attr(cls, "_pack_", 0);
+    let forced = usize_attr(cls, "_align_", 1).max(1);
+
+    let (mut offset, mut max_align) = match first_base_stginfo(cls) {
+        Some(bi) => (
+            stginfo::stginfo_size(bi),
+            stginfo::stginfo_align(bi).max(forced),
+        ),
+        None => (0usize, forced),
+    };
+    let mut union_max = 0usize;
+    let mut has_pointer = false;
+
+    for (index, (name, ftype)) in entries.iter().enumerate() {
+        let size = stginfo::field_size_of(*ftype)
+            .ok_or_else(|| crate::PyError::type_error(format!("field '{name}' has no size")))?;
+        let align = stginfo::field_align_of(*ftype).unwrap_or(1).max(1);
+        let eff = if pack > 0 { pack.min(align) } else { align };
+
+        if !is_union && eff > 0 && offset % eff != 0 {
+            offset += eff - (offset % eff);
+        }
+        max_align = max_align.max(eff);
+
+        if let Some(fi) = stginfo::stginfo_of(*ftype) {
+            if stginfo::stginfo_flags(fi)
+                & (stginfo::TYPEFLAG_ISPOINTER | stginfo::TYPEFLAG_HASPOINTER)
+                != 0
+            {
+                has_pointer = true;
+            }
+        }
+        mark_type_final(*ftype, size, align);
+
+        let field_offset = if is_union { 0 } else { offset };
+        let cf = cfield_new(name, *ftype, field_offset, size, index);
+        set_type_attr(cls, name, cf);
+
+        if is_union {
+            union_max = union_max.max(size);
+        } else {
+            offset += size;
+        }
+    }
+
+    let total_align = max_align.max(forced);
+    let raw = if is_union { union_max } else { offset };
+    let aligned = if total_align > 0 {
+        raw.div_ceil(total_align) * total_align
+    } else {
+        raw
+    };
+
+    if let Some(ci) = stginfo::stginfo_of(cls) {
+        if stginfo::stginfo_is_final(ci) {
+            return Err(crate::PyError::attribute_error(
+                "Structure or union cannot contain itself",
+            ));
+        }
+    }
+
+    let mut flags = stginfo::DICTFLAG_FINAL;
+    if has_pointer {
+        flags |= stginfo::TYPEFLAG_HASPOINTER;
+    }
+    if is_union {
+        flags |= stginfo::TYPEFLAG_HASUNION;
+    }
+    let mut data = StgInfoData::new(
+        aligned,
+        total_align,
+        if is_union { "union" } else { "struct" },
+    );
+    data.length = entries.len();
+    data.flags = flags;
+    data.big_endian = is_swapped ^ cfg!(target_endian = "big");
+    stginfo::stginfo_set(cls, stginfo::stginfo_new(data));
+
+    // Store the raw `_fields_` so the metaclass getset can return it.
+    set_type_attr(cls, "_fields_", fields);
+    Ok(pyre_object::w_none())
+}
+
+// ── metaclass namespace methods ────────────────────────────────────────
+
+/// `ctype * n` — build (and cache) the `n`-element array type of `ctype`.
+fn meta_mul(args: &[PyObjectRef]) -> PyResult {
+    let cls = args[0];
+    let count = args.get(1).copied().unwrap_or(pyre_object::PY_NULL);
+    if count.is_null() || !unsafe { pyre_object::is_int(count) } {
+        return Err(crate::PyError::not_implemented(
+            "array length must be an int",
+        ));
+    }
+    let n = unsafe { pyre_object::w_int_get_value(count) };
+    if n < 0 {
+        return Err(crate::PyError::value_error(format!(
+            "Array length must be >= 0, not {n}"
+        )));
+    }
+    array_type_from_ctype(cls, n as usize)
+}
+
+fn meta_from_param(args: &[PyObjectRef]) -> PyResult {
+    Ok(args.get(1).copied().unwrap_or_else(pyre_object::w_none))
+}
+
+fn pointer_type_get(args: &[PyObjectRef]) -> PyResult {
+    let cls = args[1];
+    if let Some(info) = stginfo::stginfo_of(cls) {
+        if let Some(pt) = stginfo::stginfo_pointer_type(info) {
+            return Ok(pt);
+        }
+    }
+    Err(crate::PyError::attribute_error(
+        "type has no attribute '__pointer_type__'",
+    ))
+}
+
+fn pointer_type_set(args: &[PyObjectRef]) -> PyResult {
+    let cls = args[1];
+    let value = args[2];
+    match stginfo::stginfo_of(cls) {
+        Some(info) => {
+            stginfo::stginfo_set_pointer_type(info, value);
+            Ok(pyre_object::w_none())
+        }
+        None => Err(crate::PyError::attribute_error(
+            "cannot set '__pointer_type__'",
+        )),
+    }
+}
+
+fn fields_get(args: &[PyObjectRef]) -> PyResult {
+    let cls = args[1];
+    unsafe { crate::baseobjspace::lookup_in_type(cls, "_fields_") }
+        .filter(|&f| !f.is_null())
+        .ok_or_else(|| crate::PyError::attribute_error("_fields_"))
+}
+
+fn fields_set(args: &[PyObjectRef]) -> PyResult {
+    let cls = args[1];
+    let value = args[2];
+    if let Some(info) = stginfo::stginfo_of(cls) {
+        if stginfo::stginfo_is_final(info) {
+            return Err(crate::PyError::attribute_error("_fields_ is final"));
+        }
+    }
+    let is_union = stginfo::stginfo_of(cls)
+        .map(|i| stginfo::stginfo_paramfunc(i) == "union")
+        .unwrap_or(false);
+    process_fields(cls, value, is_union)
+}
+
+// ── CField descriptor ──────────────────────────────────────────────────
+
+fn cfield_new(
+    name: &str,
+    proto: PyObjectRef,
+    offset: usize,
+    size: usize,
+    index: usize,
+) -> PyObjectRef {
+    let inst = pyre_object::w_instance_new(cfield_type());
+    let d = crate::baseobjspace::getdict(inst);
+    unsafe {
+        pyre_object::w_dict_setitem_str(d, "name", pyre_object::w_str_new(name));
+        pyre_object::w_dict_setitem_str(d, "proto", proto);
+        pyre_object::w_dict_setitem_str(d, "offset", pyre_object::w_int_new(offset as i64));
+        pyre_object::w_dict_setitem_str(d, "size", pyre_object::w_int_new(size as i64));
+        pyre_object::w_dict_setitem_str(d, "index", pyre_object::w_int_new(index as i64));
+    }
+    inst
+}
+
+fn cf_obj(cfield: PyObjectRef, key: &str) -> PyObjectRef {
+    unsafe { pyre_object::w_dict_getitem_str(crate::baseobjspace::getdict(cfield), key) }
+        .unwrap_or(pyre_object::PY_NULL)
+}
+
+fn cf_usize(cfield: PyObjectRef, key: &str) -> usize {
+    let o = cf_obj(cfield, key);
+    if !o.is_null() && unsafe { pyre_object::is_int(o) } {
+        (unsafe { pyre_object::w_int_get_value(o) }).max(0) as usize
+    } else {
+        0
+    }
+}
+
+/// The storage kind of a field's `proto` ("simple"/"struct"/"union"/…).
+fn proto_kind(proto: PyObjectRef) -> String {
+    if let Some(info) = stginfo::stginfo_of(proto) {
+        let pf = stginfo::stginfo_paramfunc(info);
+        if !pf.is_empty() {
+            return pf;
+        }
+    }
+    if cdata::type_code_of(proto).is_some() {
+        return "simple".to_string();
+    }
+    String::new()
+}
+
+fn field_needs_swap(obj: PyObjectRef, proto: PyObjectRef, size: usize) -> bool {
+    if size <= 1 {
+        return false;
+    }
+    let oc = unsafe { pyre_object::w_instance_get_type(obj) };
+    unsafe { crate::baseobjspace::lookup_in_type(oc, "_swappedbytes_") }.is_some()
+        || unsafe { crate::baseobjspace::lookup_in_type(proto, "_swappedbytes_") }.is_some()
+}
+
+fn cfield_get(args: &[PyObjectRef]) -> PyResult {
+    let cfield = args[0];
+    let obj = args.get(1).copied().unwrap_or_else(pyre_object::w_none);
+    // Accessed on the class (`Point.x`) → return the descriptor itself.
+    if obj.is_null() || unsafe { pyre_object::is_none(obj) } {
+        return Ok(cfield);
+    }
+    let proto = cf_obj(cfield, "proto");
+    let offset = cf_usize(cfield, "offset");
+    let size = cf_usize(cfield, "size");
+
+    match proto_kind(proto).as_str() {
+        "simple" => {
+            let tc = cdata::type_code_of(proto)
+                .ok_or_else(|| crate::PyError::type_error("field has no '_type_'"))?;
+            let all = cdata::cdata_bytes(obj)
+                .ok_or_else(|| crate::PyError::type_error("instance has no buffer"))?;
+            let start = offset.min(all.len());
+            let end = (offset + size).min(all.len());
+            let mut field_bytes = all[start..end].to_vec();
+            if field_needs_swap(obj, proto, size) {
+                field_bytes.reverse();
+            }
+            Ok(cdata::decoded_to_pyobject(host_ctypes::decode_type_code(
+                &tc,
+                &field_bytes,
+            )))
+        }
+        "struct" | "union" | "array" | "pointer" => {
+            Ok(cdata::make_subview(proto, obj, offset, size))
+        }
+        _ => Err(crate::PyError::type_error("field type has no storage info")),
+    }
+}
+
+fn cfield_set(args: &[PyObjectRef]) -> PyResult {
+    let cfield = args[0];
+    let obj = args[1];
+    let value = args[2];
+    let proto = cf_obj(cfield, "proto");
+    let offset = cf_usize(cfield, "offset");
+    let size = cf_usize(cfield, "size");
+    let index = cf_usize(cfield, "index");
+
+    match proto_kind(proto).as_str() {
+        "simple" => {
+            let tc = cdata::type_code_of(proto)
+                .ok_or_else(|| crate::PyError::type_error("field has no '_type_'"))?;
+            let mut bytes = cdata::encode_value(&tc, value)?;
+            if field_needs_swap(obj, proto, size) {
+                bytes.reverse();
+            }
+            cdata::cdata_write(obj, offset, &bytes);
+            if cdata::is_cdata_instance(value) || unsafe { pyre_object::is_bytes(value) } {
+                cdata::keep_ref(obj, &index.to_string(), value);
+            }
+            Ok(pyre_object::w_none())
+        }
+        "struct" | "union" => {
+            if !unsafe { crate::baseobjspace::isinstance_w(value, proto) } {
+                return Err(crate::PyError::type_error("incompatible types"));
+            }
+            let src = cdata::cdata_bytes(value).unwrap_or(&[]);
+            let n = size.min(src.len());
+            cdata::cdata_write(obj, offset, &src[..n]);
+            cdata::keep_ref(obj, &index.to_string(), value);
+            Ok(pyre_object::w_none())
+        }
+        _ => Err(crate::PyError::type_error(
+            "assignment to this field type is not supported in this slice",
+        )),
+    }
+}
+
+fn cfield_repr(args: &[PyObjectRef]) -> PyResult {
+    let cfield = args[0];
+    let proto = cf_obj(cfield, "proto");
+    let tyname = match unsafe { crate::baseobjspace::lookup_in_type(proto, "__name__") } {
+        Some(o) if unsafe { pyre_object::is_str(o) } => {
+            unsafe { pyre_object::w_str_get_value(o) }.to_string()
+        }
+        _ => "?".to_string(),
+    };
+    let s = format!(
+        "<Field type={}, ofs={}, size={}>",
+        tyname,
+        cf_usize(cfield, "offset"),
+        cf_usize(cfield, "size"),
+    );
+    Ok(pyre_object::w_str_new(&s))
+}
+
+fn cfield_new_disabled(_args: &[PyObjectRef]) -> PyResult {
+    Err(crate::PyError::type_error(
+        "CField is not intended to be used directly",
+    ))
+}
+
+// ── Structure / Union instances ────────────────────────────────────────
+
+fn structure_new(args: &[PyObjectRef]) -> PyResult {
+    if args.is_empty() || !unsafe { pyre_object::is_type(args[0]) } {
+        return Err(crate::PyError::type_error(
+            "Structure.__new__ requires a type",
+        ));
+    }
+    let cls = args[0];
+    let info =
+        stginfo::stginfo_of(cls).ok_or_else(|| crate::PyError::type_error("abstract class"))?;
+    let size = stginfo::stginfo_size(info);
+    stginfo::stginfo_mark_final(info);
+    let obj = pyre_object::w_instance_new(cls);
+    let d = crate::baseobjspace::getdict(obj);
+    if d.is_null() {
+        return Err(crate::PyError::type_error("ctypes instance has no dict"));
+    }
+    unsafe { pyre_object::w_dict_setitem_str(d, "_b_", pyre_object::w_bytearray_new(size)) };
+    Ok(obj)
+}
+
+/// Field names in base-first order (`init_pos_args`).
+fn field_names_base_first(cls: PyObjectRef) -> Vec<String> {
+    let mut names = Vec::new();
+    for &t in mro_items(cls).iter().rev() {
+        if let Some(f) = crate::type_dict_lookup(t, "_fields_") {
+            if let Ok(entries) = field_entries(f) {
+                names.extend(entries.into_iter().map(|(n, _)| n));
+            }
+        }
+    }
+    names
+}
+
+fn structure_init(args: &[PyObjectRef]) -> PyResult {
+    if args.is_empty() {
+        return Err(crate::PyError::type_error("__init__ requires self"));
+    }
+    let obj = args[0];
+    let (pos, kwargs) = crate::builtins::split_builtin_kwargs(&args[1..]);
+    let cls = unsafe { pyre_object::w_instance_get_type(obj) };
+    let names = field_names_base_first(cls);
+
+    if pos.len() > names.len() {
+        return Err(crate::PyError::type_error("too many initializers"));
+    }
+    for (i, &val) in pos.iter().enumerate() {
+        crate::baseobjspace::setattr_str(obj, &names[i], val)?;
+    }
+
+    if let Some(kw) = kwargs {
+        for (key_obj, val) in unsafe { pyre_object::w_dict_items(kw) } {
+            if !unsafe { pyre_object::is_str(key_obj) } {
+                continue;
+            }
+            let key = unsafe { pyre_object::w_str_get_value(key_obj) }.to_string();
+            if key == "__pyre_kw__" {
+                continue;
+            }
+            // Duplicate positional + keyword assignment for the same field.
+            if let Some(pos_idx) = names.iter().position(|n| *n == key) {
+                if pos_idx < pos.len() {
+                    return Err(crate::PyError::type_error(format!(
+                        "duplicate values for field '{key}'"
+                    )));
+                }
+            }
+            crate::baseobjspace::setattr_str(obj, &key, val)?;
+        }
+    }
+    Ok(pyre_object::w_none())
+}
+
+// ── shared metaclass helpers (arrays / pointers) ───────────────────────
+
+/// Read a key from `cls`'s **own** dict (never the MRO).
+fn own_dict_get(cls: PyObjectRef, key: &str) -> Option<PyObjectRef> {
+    crate::type_dict_lookup(cls, key)
+}
+
+/// Store a class attribute directly and invalidate the type cache for it.
+fn set_type_attr(cls: PyObjectRef, key: &str, value: PyObjectRef) {
+    if crate::type_dict_store(cls, key, value) {
+        pyre_object::gc_hook::try_gc_write_barrier(cls as *mut u8);
+        unsafe { crate::baseobjspace::mutated(cls, Some(key)) };
+    }
+}
+
+fn type_name(cls: PyObjectRef) -> String {
+    match unsafe { crate::baseobjspace::lookup_in_type(cls, "__name__") } {
+        Some(o) if unsafe { pyre_object::is_str(o) } => {
+            unsafe { pyre_object::w_str_get_value(o) }.to_string()
+        }
+        _ => "?".to_string(),
+    }
+}
+
+// ── PyCArrayType + Array ───────────────────────────────────────────────
+
+thread_local! {
+    /// `(element_type, length) → array_type`, the pyre form of the
+    /// `_ctypes._array_type_cache` dict (keyed by type identity + length).
+    static ARRAY_TYPE_CACHE: RefCell<Vec<(PyObjectRef, usize, PyObjectRef)>> =
+        const { RefCell::new(Vec::new()) };
+}
+
+fn carraytype_new(args: &[PyObjectRef]) -> PyResult {
+    let cls = crate::builtins::type_descr_new(args)?;
+    array_init_stginfo(cls)?;
+    Ok(cls)
+}
+
+/// `PyCArrayType` layout: resolve `_length_` + `_type_` and build the array
+/// `StgInfo` (`size = element_size * length`, align = element align).
+fn array_init_stginfo(cls: PyObjectRef) -> PyResult {
+    let length = match own_dict_get(cls, "_length_") {
+        Some(v) => {
+            if !unsafe { pyre_object::is_int(v) } {
+                return Err(crate::PyError::type_error(
+                    "The '_length_' attribute must be an integer",
+                ));
+            }
+            let n = unsafe { pyre_object::w_int_get_value(v) };
+            if n < 0 {
+                return Err(crate::PyError::value_error(
+                    "The '_length_' attribute must not be negative",
+                ));
+            }
+            n as usize
+        }
+        None => match first_base_stginfo(cls) {
+            Some(bi) => stginfo::stginfo_length(bi),
+            None => {
+                return Err(crate::PyError::attribute_error(
+                    "class must define a '_length_' attribute",
+                ));
+            }
+        },
+    };
+
+    let elem = match own_dict_get(cls, "_type_") {
+        Some(t) => {
+            if !unsafe { pyre_object::is_type(t) } {
+                return Err(crate::PyError::type_error("_type_ must be a type"));
+            }
+            t
+        }
+        None => match first_base_stginfo(cls).and_then(stginfo::stginfo_proto) {
+            Some(p) => p,
+            None => {
+                return Err(crate::PyError::attribute_error(
+                    "class must define a '_type_' attribute",
+                ));
+            }
+        },
+    };
+
+    let elem_size = stginfo::field_size_of(elem)
+        .ok_or_else(|| crate::PyError::type_error("_type_ must have storage info"))?;
+    let elem_align = stginfo::field_align_of(elem).unwrap_or(1).max(1);
+    if elem_size != 0 && length > usize::MAX / elem_size {
+        return Err(crate::PyError::overflow_error("array too large"));
+    }
+
+    let mut data = StgInfoData::new(elem_size * length, elem_align, "array");
+    data.length = length;
+    data.element_size = elem_size;
+    data.proto = Some(elem);
+    if let Some(ei) = stginfo::stginfo_of(elem) {
+        if stginfo::stginfo_flags(ei) & (stginfo::TYPEFLAG_ISPOINTER | stginfo::TYPEFLAG_HASPOINTER)
+            != 0
+        {
+            data.flags |= stginfo::TYPEFLAG_HASPOINTER;
+        }
+    }
+    stginfo::stginfo_set(cls, stginfo::stginfo_new(data));
+
+    set_type_attr(cls, "_type_", elem);
+    set_type_attr(cls, "_length_", pyre_object::w_int_new(length as i64));
+
+    // `c` element arrays gain `value`/`raw`; `u` (wchar) is deferred.
+    if cdata::type_code_of(elem).as_deref() == Some("c") {
+        install_char_array_getsets(cls);
+    }
+    Ok(pyre_object::w_none())
+}
+
+/// `ctype * n` — cache lookup on `(ctype, n)`, else create `ctype_Array_n`.
+fn array_type_from_ctype(elem: PyObjectRef, n: usize) -> PyResult {
+    if let Some(found) = ARRAY_TYPE_CACHE.with(|c| {
+        c.borrow()
+            .iter()
+            .find(|(t, k, _)| *t == elem && *k == n)
+            .map(|(_, _, ty)| *ty)
+    }) {
+        return Ok(found);
+    }
+    let name = format!("{}_Array_{}", type_name(elem), n);
+    let ns = pyre_object::w_dict_new();
+    unsafe {
+        pyre_object::w_dict_setitem_str(ns, "_type_", elem);
+        pyre_object::w_dict_setitem_str(ns, "_length_", pyre_object::w_int_new(n as i64));
+    }
+    let bases = pyre_object::w_tuple_new(vec![array_type()]);
+    let args = [
+        pycarraytype_type(),
+        pyre_object::w_str_new(&name),
+        bases,
+        ns,
+    ];
+    let new_cls = carraytype_new(&args)?;
+    ARRAY_TYPE_CACHE.with(|c| c.borrow_mut().push((elem, n, new_cls)));
+    Ok(new_cls)
+}
+
+/// Resolved array-instance metadata.
+struct ArrayMeta {
+    length: usize,
+    element_size: usize,
+    proto: PyObjectRef,
+}
+
+fn array_meta(obj: PyObjectRef) -> Result<ArrayMeta, crate::PyError> {
+    let cls = unsafe { pyre_object::w_instance_get_type(obj) };
+    let info =
+        stginfo::stginfo_of(cls).ok_or_else(|| crate::PyError::type_error("abstract class"))?;
+    let proto =
+        stginfo::stginfo_proto(info).ok_or_else(|| crate::PyError::type_error("abstract class"))?;
+    Ok(ArrayMeta {
+        length: stginfo::stginfo_length(info),
+        element_size: stginfo::stginfo_element_size(info),
+        proto,
+    })
+}
+
+fn array_new(args: &[PyObjectRef]) -> PyResult {
+    if args.is_empty() || !unsafe { pyre_object::is_type(args[0]) } {
+        return Err(crate::PyError::type_error("Array.__new__ requires a type"));
+    }
+    let cls = args[0];
+    let info = stginfo::stginfo_of(cls)
+        .filter(|&i| stginfo::stginfo_proto(i).is_some())
+        .ok_or_else(|| crate::PyError::type_error("abstract class"))?;
+    let size = stginfo::stginfo_size(info);
+    let obj = pyre_object::w_instance_new(cls);
+    let d = crate::baseobjspace::getdict(obj);
+    if d.is_null() {
+        return Err(crate::PyError::type_error("ctypes instance has no dict"));
+    }
+    unsafe { pyre_object::w_dict_setitem_str(d, "_b_", pyre_object::w_bytearray_new(size)) };
+    Ok(obj)
+}
+
+fn array_init(args: &[PyObjectRef]) -> PyResult {
+    if args.is_empty() {
+        return Err(crate::PyError::type_error("__init__ requires self"));
+    }
+    let obj = args[0];
+    let (pos, _kw) = crate::builtins::split_builtin_kwargs(&args[1..]);
+    let meta = array_meta(obj)?;
+    if pos.len() > meta.length {
+        return Err(crate::PyError::index_error("too many initializers"));
+    }
+    for (i, &val) in pos.iter().enumerate() {
+        array_set_index(obj, &meta, i, val)?;
+    }
+    Ok(pyre_object::w_none())
+}
+
+fn array_len(args: &[PyObjectRef]) -> PyResult {
+    let meta = array_meta(args[0])?;
+    Ok(pyre_object::w_int_new(meta.length as i64))
+}
+
+fn normalize_index(mut i: i64, length: usize) -> Result<usize, crate::PyError> {
+    if i < 0 {
+        i += length as i64;
+    }
+    if i < 0 || i >= length as i64 {
+        return Err(crate::PyError::index_error("invalid index"));
+    }
+    Ok(i as usize)
+}
+
+fn array_getitem(args: &[PyObjectRef]) -> PyResult {
+    let obj = args[0];
+    let key = args[1];
+    let meta = array_meta(obj)?;
+    if unsafe { pyre_object::is_int(key) } {
+        let idx = normalize_index(unsafe { pyre_object::w_int_get_value(key) }, meta.length)?;
+        return array_get_index(obj, &meta, idx);
+    }
+    if unsafe { pyre_object::is_slice(key) } {
+        return array_get_slice(obj, &meta, key);
+    }
+    Err(crate::PyError::type_error("indices must be integers"))
+}
+
+fn array_get_index(obj: PyObjectRef, meta: &ArrayMeta, idx: usize) -> PyResult {
+    let offset = idx * meta.element_size;
+    match proto_kind(meta.proto).as_str() {
+        "simple" => {
+            let tc = cdata::type_code_of(meta.proto)
+                .ok_or_else(|| crate::PyError::type_error("element has no '_type_'"))?;
+            let all = cdata::cdata_bytes(obj)
+                .ok_or_else(|| crate::PyError::type_error("instance has no buffer"))?;
+            let end = (offset + meta.element_size).min(all.len());
+            let start = offset.min(end);
+            Ok(cdata::decoded_to_pyobject(host_ctypes::decode_type_code(
+                &tc,
+                &all[start..end],
+            )))
+        }
+        "struct" | "union" | "array" | "pointer" => Ok(cdata::make_subview(
+            meta.proto,
+            obj,
+            offset,
+            meta.element_size,
+        )),
+        _ => Err(crate::PyError::type_error(
+            "element type has no storage info",
+        )),
+    }
+}
+
+fn array_setitem(args: &[PyObjectRef]) -> PyResult {
+    let obj = args[0];
+    let key = args[1];
+    let value = args[2];
+    let meta = array_meta(obj)?;
+    if unsafe { pyre_object::is_int(key) } {
+        let idx = normalize_index(unsafe { pyre_object::w_int_get_value(key) }, meta.length)?;
+        return array_set_index(obj, &meta, idx, value);
+    }
+    if unsafe { pyre_object::is_slice(key) } {
+        return array_set_slice(obj, &meta, key, value);
+    }
+    Err(crate::PyError::type_error("indices must be integers"))
+}
+
+fn array_set_index(obj: PyObjectRef, meta: &ArrayMeta, idx: usize, value: PyObjectRef) -> PyResult {
+    let offset = idx * meta.element_size;
+    match proto_kind(meta.proto).as_str() {
+        "simple" => {
+            let tc = cdata::type_code_of(meta.proto)
+                .ok_or_else(|| crate::PyError::type_error("element has no '_type_'"))?;
+            let bytes = cdata::encode_value(&tc, value)?;
+            cdata::cdata_write(obj, offset, &bytes);
+            if cdata::is_cdata_instance(value) || unsafe { pyre_object::is_bytes(value) } {
+                cdata::keep_ref(obj, &idx.to_string(), value);
+            }
+            Ok(pyre_object::w_none())
+        }
+        "struct" | "union" | "array" | "pointer" => {
+            if !unsafe { crate::baseobjspace::isinstance_w(value, meta.proto) } {
+                return Err(crate::PyError::type_error("incompatible types"));
+            }
+            let src = cdata::cdata_bytes(value).unwrap_or(&[]);
+            let n = meta.element_size.min(src.len());
+            cdata::cdata_write(obj, offset, &src[..n]);
+            cdata::keep_ref(obj, &idx.to_string(), value);
+            Ok(pyre_object::w_none())
+        }
+        _ => Err(crate::PyError::type_error(
+            "assignment to this element type is not supported in this slice",
+        )),
+    }
+}
+
+/// The concrete indices a slice selects over `length`, PySlice-adjusted.
+fn slice_index_list(slice: PyObjectRef, length: usize) -> Result<Vec<usize>, crate::PyError> {
+    let len = length as i64;
+    let as_int = |o: PyObjectRef| -> Option<i64> {
+        if o.is_null() || unsafe { pyre_object::is_none(o) } {
+            None
+        } else if unsafe { pyre_object::is_int(o) } {
+            Some(unsafe { pyre_object::w_int_get_value(o) })
+        } else {
+            None
+        }
+    };
+    let step = as_int(unsafe { pyre_object::w_slice_get_step(slice) }).unwrap_or(1);
+    if step == 0 {
+        return Err(crate::PyError::value_error("slice step cannot be zero"));
+    }
+    let (lower, upper) = if step > 0 { (0, len) } else { (-1, len - 1) };
+    let clamp = |v: i64| -> i64 {
+        let v = if v < 0 { v + len } else { v };
+        v.clamp(lower, upper)
+    };
+    let start = match as_int(unsafe { pyre_object::w_slice_get_start(slice) }) {
+        Some(v) => clamp(v),
+        None => {
+            if step > 0 {
+                0
+            } else {
+                len - 1
+            }
+        }
+    };
+    let stop = match as_int(unsafe { pyre_object::w_slice_get_stop(slice) }) {
+        Some(v) => clamp(v),
+        None => {
+            if step > 0 {
+                len
+            } else {
+                -1
+            }
+        }
+    };
+    let mut out = Vec::new();
+    let mut i = start;
+    if step > 0 {
+        while i < stop {
+            out.push(i as usize);
+            i += step;
+        }
+    } else {
+        while i > stop {
+            out.push(i as usize);
+            i += step;
+        }
+    }
+    Ok(out)
+}
+
+fn array_get_slice(obj: PyObjectRef, meta: &ArrayMeta, slice: PyObjectRef) -> PyResult {
+    let idxs = slice_index_list(slice, meta.length)?;
+    // `c` element arrays slice to `bytes`; other elements slice to a list.
+    if cdata::type_code_of(meta.proto).as_deref() == Some("c") {
+        let all = cdata::cdata_bytes(obj).unwrap_or(&[]);
+        let bytes: Vec<u8> = idxs
+            .iter()
+            .map(|&i| all.get(i * meta.element_size).copied().unwrap_or(0))
+            .collect();
+        return Ok(pyre_object::bytesobject::w_bytes_from_bytes(&bytes));
+    }
+    let mut items = Vec::with_capacity(idxs.len());
+    for i in idxs {
+        items.push(array_get_index(obj, meta, i)?);
+    }
+    Ok(pyre_object::w_list_new(items))
+}
+
+fn array_set_slice(
+    obj: PyObjectRef,
+    meta: &ArrayMeta,
+    slice: PyObjectRef,
+    value: PyObjectRef,
+) -> PyResult {
+    let idxs = slice_index_list(slice, meta.length)?;
+    let items =
+        seq_items(value).ok_or_else(|| crate::PyError::type_error("can only assign a sequence"))?;
+    if items.len() != idxs.len() {
+        return Err(crate::PyError::value_error(
+            "Can only assign sequence of same size",
+        ));
+    }
+    for (i, v) in idxs.into_iter().zip(items) {
+        array_set_index(obj, meta, i, v)?;
+    }
+    Ok(pyre_object::w_none())
+}
+
+// ── c_char array `.value` / `.raw` ─────────────────────────────────────
+
+fn install_char_array_getsets(cls: PyObjectRef) {
+    set_type_attr(
+        cls,
+        "value",
+        crate::typedef::make_getset_property_named(
+            crate::make_builtin_function_with_arity("value", char_array_get_value, 2),
+            crate::make_builtin_function_with_arity("value", char_array_set_value, 3),
+            pyre_object::PY_NULL,
+            "value",
+        ),
+    );
+    set_type_attr(
+        cls,
+        "raw",
+        crate::typedef::make_getset_property_named(
+            crate::make_builtin_function_with_arity("raw", char_array_get_raw, 2),
+            crate::make_builtin_function_with_arity("raw", char_array_set_raw, 3),
+            pyre_object::PY_NULL,
+            "raw",
+        ),
+    );
+}
+
+fn char_array_get_value(args: &[PyObjectRef]) -> PyResult {
+    let obj = args[1];
+    let buf = cdata::cdata_bytes(obj).unwrap_or(&[]);
+    Ok(pyre_object::bytesobject::w_bytes_from_bytes(
+        host_ctypes::char_array_field_value(buf),
+    ))
+}
+
+fn char_array_set_value(args: &[PyObjectRef]) -> PyResult {
+    let obj = args[1];
+    let value = args[2];
+    if !unsafe { pyre_object::is_bytes(value) } {
+        return Err(crate::PyError::type_error("bytes expected"));
+    }
+    let src = unsafe { pyre_object::bytesobject::w_bytes_data(value) };
+    let size = cdata::cdata_len(obj).unwrap_or(0);
+    if src.len() > size {
+        return Err(crate::PyError::value_error("byte string too long"));
+    }
+    // Copy `src`, then a NUL terminator when the buffer has room (no tail zero).
+    let mut buf = src.to_vec();
+    if src.len() < size {
+        buf.push(0);
+    }
+    cdata::cdata_write(obj, 0, &buf);
+    Ok(pyre_object::w_none())
+}
+
+fn char_array_get_raw(args: &[PyObjectRef]) -> PyResult {
+    let obj = args[1];
+    let buf = cdata::cdata_bytes(obj).unwrap_or(&[]);
+    Ok(pyre_object::bytesobject::w_bytes_from_bytes(buf))
+}
+
+fn char_array_set_raw(args: &[PyObjectRef]) -> PyResult {
+    let obj = args[1];
+    let value = args[2];
+    if !unsafe { pyre_object::is_bytes(value) } {
+        return Err(crate::PyError::type_error("bytes-like object expected"));
+    }
+    let src = unsafe { pyre_object::bytesobject::w_bytes_data(value) };
+    let size = cdata::cdata_len(obj).unwrap_or(0);
+    if src.len() > size {
+        return Err(crate::PyError::value_error("byte string too long"));
+    }
+    cdata::cdata_write(obj, 0, src);
+    Ok(pyre_object::w_none())
+}
+
+// ── PyCPointerType + _Pointer ──────────────────────────────────────────
+
+fn cpointertype_new(args: &[PyObjectRef]) -> PyResult {
+    let cls = crate::builtins::type_descr_new(args)?;
+    pointer_init_stginfo(cls)?;
+    Ok(cls)
+}
+
+/// `PyCPointerType` layout: pointer-sized `StgInfo` with `ISPOINTER`, and
+/// memoise the pointer type on the pointed-to type (`POINTER` identity).
+fn pointer_init_stginfo(cls: PyObjectRef) -> PyResult {
+    let proto = unsafe { crate::baseobjspace::lookup_in_type(cls, "_type_") }
+        .filter(|&t| !t.is_null() && unsafe { pyre_object::is_type(t) });
+    if let Some(p) = proto {
+        if stginfo::field_size_of(p).is_none() {
+            return Err(crate::PyError::type_error("_type_ must have storage info"));
+        }
+    }
+    let psize = host_ctypes::pointer_size();
+    let mut data = StgInfoData::new(psize, psize, "pointer");
+    data.length = 1;
+    data.flags |= stginfo::TYPEFLAG_ISPOINTER;
+    data.proto = proto;
+    stginfo::stginfo_set(cls, stginfo::stginfo_new(data));
+
+    if let Some(p) = proto {
+        let pinfo = match stginfo::stginfo_of(p) {
+            Some(i) => i,
+            None => {
+                let size = stginfo::field_size_of(p).unwrap_or(0);
+                let align = stginfo::field_align_of(p).unwrap_or(1);
+                let info = stginfo::stginfo_new(StgInfoData::new(size, align, "simple"));
+                stginfo::stginfo_set(p, info);
+                info
+            }
+        };
+        stginfo::stginfo_set_pointer_type(pinfo, cls);
+    }
+    Ok(pyre_object::w_none())
+}
+
+fn pointer_new(args: &[PyObjectRef]) -> PyResult {
+    if args.is_empty() || !unsafe { pyre_object::is_type(args[0]) } {
+        return Err(crate::PyError::type_error(
+            "_Pointer.__new__ requires a type",
+        ));
+    }
+    let cls = args[0];
+    if stginfo::stginfo_of(cls)
+        .and_then(stginfo::stginfo_proto)
+        .is_none()
+    {
+        return Err(crate::PyError::type_error(
+            "Cannot create instance: has no _type_",
+        ));
+    }
+    let obj = pyre_object::w_instance_new(cls);
+    let d = crate::baseobjspace::getdict(obj);
+    if d.is_null() {
+        return Err(crate::PyError::type_error("ctypes instance has no dict"));
+    }
+    let psize = host_ctypes::pointer_size();
+    unsafe { pyre_object::w_dict_setitem_str(d, "_b_", pyre_object::w_bytearray_new(psize)) };
+    Ok(obj)
+}
+
+fn pointer_init(args: &[PyObjectRef]) -> PyResult {
+    if args.is_empty() {
+        return Err(crate::PyError::type_error("__init__ requires self"));
+    }
+    let obj = args[0];
+    let (pos, _kw) = crate::builtins::split_builtin_kwargs(&args[1..]);
+    if let Some(&val) = pos.first() {
+        if !unsafe { pyre_object::is_none(val) } {
+            pointer_set_contents(obj, val)?;
+        }
+    }
+    Ok(pyre_object::w_none())
+}
+
+/// Store `value`'s buffer address in the pointer and keep `value` alive.
+fn pointer_set_contents(obj: PyObjectRef, value: PyObjectRef) -> PyResult {
+    let cls = unsafe { pyre_object::w_instance_get_type(obj) };
+    let proto = stginfo::stginfo_of(cls)
+        .and_then(stginfo::stginfo_proto)
+        .ok_or_else(|| crate::PyError::type_error("Cannot create instance: has no _type_"))?;
+    if !cdata::is_cdata_instance(value)
+        || !unsafe { crate::baseobjspace::isinstance_w(value, proto) }
+    {
+        return Err(crate::PyError::type_error(format!(
+            "expected {} instead of {}",
+            type_name(proto),
+            type_name(unsafe { pyre_object::w_instance_get_type(value) })
+        )));
+    }
+    let addr = cdata::cdata_addr(value)
+        .ok_or_else(|| crate::PyError::type_error("target has no buffer"))?;
+    let bytes = host_ctypes::simple_storage_value_to_bytes_endian(
+        "P",
+        host_ctypes::SimpleStorageValue::Pointer(addr),
+        false,
+    );
+    cdata::cdata_write(obj, 0, &bytes);
+    cdata::keep_ref(obj, "1", value);
+    Ok(pyre_object::w_none())
+}
+
+fn contents_get(args: &[PyObjectRef]) -> PyResult {
+    let obj = args[1];
+    let cls = unsafe { pyre_object::w_instance_get_type(obj) };
+    let proto = stginfo::stginfo_of(cls)
+        .and_then(stginfo::stginfo_proto)
+        .ok_or_else(|| crate::PyError::type_error("has no _type_"))?;
+    let ptr = host_ctypes::read_pointer_from_buffer(cdata::cdata_bytes(obj).unwrap_or(&[]));
+    if ptr == 0 {
+        return Err(crate::PyError::value_error("NULL pointer access"));
+    }
+    let size = stginfo::field_size_of(proto).unwrap_or_else(host_ctypes::pointer_size);
+    Ok(cdata::make_at_address(proto, ptr, size))
+}
+
+fn contents_set(args: &[PyObjectRef]) -> PyResult {
+    pointer_set_contents(args[1], args[2])
+}
+
+/// `(proto, element_size, ptr_value)` for a pointer instance.
+fn pointer_meta(obj: PyObjectRef) -> Result<(PyObjectRef, usize, usize), crate::PyError> {
+    let cls = unsafe { pyre_object::w_instance_get_type(obj) };
+    let proto = stginfo::stginfo_of(cls)
+        .and_then(stginfo::stginfo_proto)
+        .ok_or_else(|| crate::PyError::type_error("has no _type_"))?;
+    let element_size = stginfo::field_size_of(proto).unwrap_or_else(host_ctypes::pointer_size);
+    let ptr = host_ctypes::read_pointer_from_buffer(cdata::cdata_bytes(obj).unwrap_or(&[]));
+    Ok((proto, element_size, ptr))
+}
+
+fn pointer_getitem(args: &[PyObjectRef]) -> PyResult {
+    let obj = args[0];
+    let key = args[1];
+    if !unsafe { pyre_object::is_int(key) } {
+        return Err(crate::PyError::type_error(
+            "Pointer indices must be integer",
+        ));
+    }
+    let (proto, element_size, ptr) = pointer_meta(obj)?;
+    if ptr == 0 {
+        return Err(crate::PyError::value_error("NULL pointer access"));
+    }
+    let index = unsafe { pyre_object::w_int_get_value(key) } as isize;
+    let addr = host_ctypes::pointer_item_address(ptr, index, element_size);
+    match proto_kind(proto).as_str() {
+        "simple" => {
+            let tc = cdata::type_code_of(proto)
+                .ok_or_else(|| crate::PyError::type_error("element has no '_type_'"))?;
+            let bytes = unsafe { host_ctypes::borrow_memory(addr as *const u8, element_size) };
+            Ok(cdata::decoded_to_pyobject(host_ctypes::decode_type_code(
+                &tc, bytes,
+            )))
+        }
+        _ => Ok(cdata::make_at_address(proto, addr, element_size)),
+    }
+}
+
+fn pointer_setitem(args: &[PyObjectRef]) -> PyResult {
+    let obj = args[0];
+    let key = args[1];
+    let value = args[2];
+    if !unsafe { pyre_object::is_int(key) } {
+        return Err(crate::PyError::type_error(
+            "Pointer indices must be integer",
+        ));
+    }
+    let (proto, element_size, ptr) = pointer_meta(obj)?;
+    if ptr == 0 {
+        return Err(crate::PyError::value_error("NULL pointer access"));
+    }
+    let index = unsafe { pyre_object::w_int_get_value(key) } as isize;
+    let addr = host_ctypes::pointer_item_address(ptr, index, element_size);
+    match proto_kind(proto).as_str() {
+        "simple" => {
+            let tc = cdata::type_code_of(proto)
+                .ok_or_else(|| crate::PyError::type_error("element has no '_type_'"))?;
+            let bytes = cdata::encode_value(&tc, value)?;
+            unsafe { host_ctypes::copy_bytes_to_address(addr, &bytes, element_size) };
+            Ok(pyre_object::w_none())
+        }
+        _ => {
+            if !unsafe { crate::baseobjspace::isinstance_w(value, proto) } {
+                return Err(crate::PyError::type_error("incompatible types"));
+            }
+            let src = cdata::cdata_bytes(value).unwrap_or(&[]);
+            unsafe { host_ctypes::copy_bytes_to_address(addr, src, element_size) };
+            Ok(pyre_object::w_none())
+        }
+    }
+}
+
+fn pointer_bool(args: &[PyObjectRef]) -> PyResult {
+    let ptr = host_ctypes::read_pointer_from_buffer(cdata::cdata_bytes(args[0]).unwrap_or(&[]));
+    Ok(pyre_object::w_bool_from(ptr != 0))
+}

--- a/pyre/pyre-interpreter/src/module/_ctypes/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_ctypes/mod.rs
@@ -1,7 +1,27 @@
 //! _ctypes module — PyPy: `pypy/module/_rawffi/` plus `lib_pypy/_ctypes/`.
 //!
-//! Slice C1: dlopen / dlsym / dlclose + size/align/memmove constants.  The
-//! full c_int / Structure / CFUNCTYPE / Pointer machinery still requires
-//! libffi-style argument marshalling and per-instance heap state.
+//! `interp_ctypes` holds the module-level surface: library handles (dlopen /
+//! dlsym / dlclose), size/align queries, and the raw-memory helpers.  The type
+//! machinery is split across the submodules — `stginfo` carries a ctypes type's
+//! layout, `metaclass` builds the types and their fields, `cdata` holds the
+//! scalar instance buffer, and `funcptr` marshals and performs the foreign
+//! call.  The submodules are unix-only; elsewhere the module is limited to what
+//! `interp_ctypes` can offer without `host_env`.
 
 crate::pyre_module_init!(interp_ctypes);
+
+/// Store into a builtin type's namespace — the dict `make_builtin_type` hands
+/// its init closure.  The type-namespace sibling of `module_ns_store`.
+#[cfg(all(unix, feature = "host_env"))]
+fn type_ns_store(ns: pyre_object::PyObjectRef, name: &str, value: pyre_object::PyObjectRef) {
+    unsafe { pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(ns, name, value) }
+}
+
+#[cfg(all(unix, feature = "host_env"))]
+pub mod cdata;
+#[cfg(all(unix, feature = "host_env"))]
+pub mod funcptr;
+#[cfg(all(unix, feature = "host_env"))]
+pub mod metaclass;
+#[cfg(all(unix, feature = "host_env"))]
+pub mod stginfo;

--- a/pyre/pyre-interpreter/src/module/_ctypes/stginfo.rs
+++ b/pyre/pyre-interpreter/src/module/_ctypes/stginfo.rs
@@ -1,0 +1,221 @@
+//! `StgInfo` — per-ctypes-type storage metadata (size/align/layout).
+//!
+//! pyre types have no type-data slot to hang this off, so the carrier is a
+//! private native object stored in the ctypes type's **own**
+//! dict under the reserved key `"__stginfo__"`.  `stginfo_of` reads it with a
+//! *direct* dict get (never the MRO), so it is non-inherited by construction —
+//! layout inheritance is explicit cloning in the metaclass.  Every reference it
+//! holds (`proto`, `pointer_type`) is an ordinary dict entry, so it stays
+//! GC-correct with no Rust-side side tables.
+
+use pyre_object::PyObjectRef;
+
+/// Reserved key under which the carrier lives in a ctypes type's own dict.
+const STGINFO_KEY: &str = "__stginfo__";
+
+// Storage-flag bits (subset of the full flag set).
+pub(super) const TYPEFLAG_ISPOINTER: i64 = 0x100;
+pub(super) const TYPEFLAG_HASPOINTER: i64 = 0x200;
+pub(super) const TYPEFLAG_HASUNION: i64 = 0x400;
+pub(super) const DICTFLAG_FINAL: i64 = 0x1000;
+
+// Carrier field keys.
+const K_SIZE: &str = "size";
+const K_ALIGN: &str = "align";
+const K_LENGTH: &str = "length";
+const K_ELEMENT_SIZE: &str = "element_size";
+const K_FLAGS: &str = "flags";
+const K_PARAMFUNC: &str = "paramfunc";
+const K_PROTO: &str = "proto";
+const K_FORMAT: &str = "format";
+const K_POINTER_TYPE: &str = "pointer_type";
+const K_BIG_ENDIAN: &str = "big_endian";
+
+thread_local! {
+    static STGINFO_TYPE_OBJ: std::cell::OnceCell<PyObjectRef> =
+        const { std::cell::OnceCell::new() };
+}
+
+/// The private `StgInfo` carrier type (`hasdict=true`, never registered).
+fn stginfo_type() -> PyObjectRef {
+    STGINFO_TYPE_OBJ.with(|c| {
+        *c.get_or_init(|| {
+            let tp = crate::typedef::make_builtin_type("StgInfo", |_| {});
+            unsafe { pyre_object::typeobject::w_type_set_hasdict(tp, true) };
+            tp
+        })
+    })
+}
+
+/// Field values for [`stginfo_new`].
+pub(super) struct StgInfoData {
+    pub size: usize,
+    pub align: usize,
+    pub length: usize,
+    pub element_size: usize,
+    pub flags: i64,
+    pub paramfunc: &'static str,
+    pub proto: Option<PyObjectRef>,
+    pub format: Option<String>,
+    pub big_endian: bool,
+}
+
+impl StgInfoData {
+    /// A minimal simple/aggregate carrier of the given size and alignment.
+    pub(super) fn new(size: usize, align: usize, paramfunc: &'static str) -> Self {
+        StgInfoData {
+            size,
+            align: align.max(1),
+            length: 0,
+            element_size: 0,
+            flags: 0,
+            paramfunc,
+            proto: None,
+            format: None,
+            big_endian: cfg!(target_endian = "big"),
+        }
+    }
+}
+
+fn dict_of(info: PyObjectRef) -> PyObjectRef {
+    crate::baseobjspace::getdict(info)
+}
+
+fn set_int(info: PyObjectRef, key: &str, v: i64) {
+    unsafe { pyre_object::w_dict_setitem_str(dict_of(info), key, pyre_object::w_int_new(v)) };
+}
+
+fn get_int(info: PyObjectRef, key: &str) -> i64 {
+    match unsafe { pyre_object::w_dict_getitem_str(dict_of(info), key) } {
+        Some(o) if unsafe { pyre_object::is_int(o) } => unsafe { pyre_object::w_int_get_value(o) },
+        _ => 0,
+    }
+}
+
+/// Build a fresh `StgInfo` carrier from `data`.
+pub(super) fn stginfo_new(data: StgInfoData) -> PyObjectRef {
+    let info = pyre_object::w_instance_new(stginfo_type());
+    let d = dict_of(info);
+    unsafe {
+        pyre_object::w_dict_setitem_str(d, K_SIZE, pyre_object::w_int_new(data.size as i64));
+        pyre_object::w_dict_setitem_str(d, K_ALIGN, pyre_object::w_int_new(data.align as i64));
+        pyre_object::w_dict_setitem_str(d, K_LENGTH, pyre_object::w_int_new(data.length as i64));
+        pyre_object::w_dict_setitem_str(
+            d,
+            K_ELEMENT_SIZE,
+            pyre_object::w_int_new(data.element_size as i64),
+        );
+        pyre_object::w_dict_setitem_str(d, K_FLAGS, pyre_object::w_int_new(data.flags));
+        pyre_object::w_dict_setitem_str(d, K_PARAMFUNC, pyre_object::w_str_new(data.paramfunc));
+        pyre_object::w_dict_setitem_str(d, K_PROTO, data.proto.unwrap_or_else(pyre_object::w_none));
+        pyre_object::w_dict_setitem_str(
+            d,
+            K_FORMAT,
+            match data.format {
+                Some(s) => pyre_object::w_str_new(&s),
+                None => pyre_object::w_none(),
+            },
+        );
+        pyre_object::w_dict_setitem_str(d, K_POINTER_TYPE, pyre_object::w_none());
+        pyre_object::w_dict_setitem_str(d, K_BIG_ENDIAN, pyre_object::w_bool_from(data.big_endian));
+    }
+    info
+}
+
+/// Direct (non-MRO) lookup of `cls`'s own `StgInfo`, if any.
+pub(super) fn stginfo_of(cls: PyObjectRef) -> Option<PyObjectRef> {
+    if cls.is_null() || !unsafe { pyre_object::is_type(cls) } {
+        return None;
+    }
+    let info = crate::type_dict_lookup(cls, STGINFO_KEY)?;
+    (!unsafe { pyre_object::is_none(info) }).then_some(info)
+}
+
+/// Store `info` as `cls`'s `StgInfo` and invalidate the type cache.
+pub(super) fn stginfo_set(cls: PyObjectRef, info: PyObjectRef) {
+    if crate::type_dict_store(cls, STGINFO_KEY, info) {
+        pyre_object::gc_hook::try_gc_write_barrier(cls as *mut u8);
+        unsafe { crate::baseobjspace::mutated(cls, Some(STGINFO_KEY)) };
+    }
+}
+
+pub(super) fn stginfo_size(info: PyObjectRef) -> usize {
+    get_int(info, K_SIZE).max(0) as usize
+}
+
+pub(super) fn stginfo_align(info: PyObjectRef) -> usize {
+    (get_int(info, K_ALIGN).max(1)) as usize
+}
+
+pub(super) fn stginfo_length(info: PyObjectRef) -> usize {
+    get_int(info, K_LENGTH).max(0) as usize
+}
+
+/// The per-element byte size of an array `StgInfo` (0 for non-arrays).
+pub(super) fn stginfo_element_size(info: PyObjectRef) -> usize {
+    get_int(info, K_ELEMENT_SIZE).max(0) as usize
+}
+
+pub(super) fn stginfo_flags(info: PyObjectRef) -> i64 {
+    get_int(info, K_FLAGS)
+}
+
+pub(super) fn stginfo_paramfunc(info: PyObjectRef) -> String {
+    match unsafe { pyre_object::w_dict_getitem_str(dict_of(info), K_PARAMFUNC) } {
+        Some(o) if unsafe { pyre_object::is_str(o) } => {
+            unsafe { pyre_object::w_str_get_value(o) }.to_string()
+        }
+        _ => String::new(),
+    }
+}
+
+/// The pointed-to / element type (`proto`), or `None` when unset.
+pub(super) fn stginfo_proto(info: PyObjectRef) -> Option<PyObjectRef> {
+    match unsafe { pyre_object::w_dict_getitem_str(dict_of(info), K_PROTO) } {
+        Some(o) if !unsafe { pyre_object::is_none(o) } => Some(o),
+        _ => None,
+    }
+}
+
+pub(super) fn stginfo_is_final(info: PyObjectRef) -> bool {
+    stginfo_flags(info) & DICTFLAG_FINAL != 0
+}
+
+pub(super) fn stginfo_mark_final(info: PyObjectRef) {
+    let f = stginfo_flags(info) | DICTFLAG_FINAL;
+    set_int(info, K_FLAGS, f);
+}
+
+/// The cached `__pointer_type__`, or `None` when unset.
+pub(super) fn stginfo_pointer_type(info: PyObjectRef) -> Option<PyObjectRef> {
+    match unsafe { pyre_object::w_dict_getitem_str(dict_of(info), K_POINTER_TYPE) } {
+        Some(o) if !unsafe { pyre_object::is_none(o) } => Some(o),
+        _ => None,
+    }
+}
+
+pub(super) fn stginfo_set_pointer_type(info: PyObjectRef, ty: PyObjectRef) {
+    unsafe { pyre_object::w_dict_setitem_str(dict_of(info), K_POINTER_TYPE, ty) };
+}
+
+// ── field size/align with the slice-1 `_type_` fallback ────────────────
+
+/// Byte size of a ctypes type `t`: its `StgInfo` size, else the simple-type
+/// size derived from `_type_`.
+pub(super) fn field_size_of(t: PyObjectRef) -> Option<usize> {
+    if let Some(info) = stginfo_of(t) {
+        return Some(stginfo_size(info));
+    }
+    let tc = super::cdata::type_code_of(t)?;
+    rustpython_host_env::ctypes::simple_type_size(&tc)
+}
+
+/// Alignment of a ctypes type `t`: its `StgInfo` align, else the simple-type
+/// alignment derived from `_type_`.
+pub(super) fn field_align_of(t: PyObjectRef) -> Option<usize> {
+    if let Some(info) = stginfo_of(t) {
+        return Some(stginfo_align(info));
+    }
+    let tc = super::cdata::type_code_of(t)?;
+    rustpython_host_env::ctypes::simple_type_align(&tc)
+}

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -6718,7 +6718,7 @@ fn make_getset_property(
 
 /// `GetSetProperty(fget, fset, fdel)` with explicit `name` — see
 /// `make_getset_descriptor_named` for the typedef.py:58 motivation.
-fn make_getset_property_named(
+pub(crate) fn make_getset_property_named(
     fget: pyre_object::PyObjectRef,
     fset: pyre_object::PyObjectRef,
     fdel: pyre_object::PyObjectRef,


### PR DESCRIPTION
Builds `_ctypes` out from the dlopen/dlsym/dlclose stub into a working module:
the simple `c_*` scalar types, `Structure` / `Union` / `Array` / `_Pointer`
layout, and foreign calls marshalled through
`rustpython_host_env::ctypes::call`.

Per-type layout lives in an `StgInfo` carrier (`stginfo.rs`) held in the ctypes
type's own dict, reached through `type_dict_lookup` / `type_dict_store`.
`metaclass.rs` builds the types and their `CField` descriptors, `cdata.rs` holds
the scalar instance buffer, and `funcptr.rs` performs the call. The submodules
are unix + `host_env` only.

`typedef.rs` widens `make_getset_property_named` to `pub(crate)` for the getset
descriptors.

## Namespace stubs this retires

`POINTER`, `pointer`, `_CFuncPtr` and `_check_HRESULT` were bound to `object`,
so e.g. `_ctypes.POINTER is object`. Nothing imports them — `ctypes/__init__.py`
takes `_CFuncPtr` as a local alias of `CFuncPtr` — and `import ctypes` works
without them.

## Verification

- `cargo check --features dynasm --workspace`: 0 errors, 0 warnings
- `cargo test --features dynasm -p pyre-interpreter`: 375 passed, 0 failed
- `import ctypes` works; scalar/aggregate round-trips and `abs` / `sqrt` /
  `strlen` foreign calls were exercised against `CDLL(None)`

## Known gaps

- `stdlib_ctypes.py` still fails, now at `Array.__base__` — `type.__base__` does
  not exist anywhere in pyre (a plain `class A: pass` has none), so this is not
  a `_ctypes` issue. It previously failed one line earlier, on
  `Array.__class__.__name__`.
- `Array.__bases__` is `(object,)`; it should be `(_CData,)`. No `_CData` base
  type in this slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)