### PR TITLE
jit: virtualize BUILD_LIST on the FBW walker (#171)

### DIFF
--- a/majit/majit-ir/src/effectinfo.rs
+++ b/majit/majit-ir/src/effectinfo.rs
@@ -584,6 +584,19 @@ pub enum PyreHelperKind {
     /// `trace_build_tuple_value`), so the backing array build and the
     /// partner [`PyreHelperKind::UnpackItem`] reads DCE to a pure-int loop.
     NewtupleFromArray,
+    /// `newlist_from_array(array)` — the BUILD_LIST array consumer that
+    /// `lower_tuple_build_hlop_to_insn` emits after `new_array_clear` +
+    /// `setarrayitem_gc`.  The full-body walker recognises this tag to
+    /// decompose the list into the virtualizable `opimpl_newlist` shape
+    /// (`pyjitpl.py:779`) — `new_with_vtable` + `new_array` +
+    /// `setarrayitem_gc` + `setfield_gc` — choosing the storage strategy
+    /// from the concrete element shadows the way `w_list_new` /
+    /// `list_strategy_for` does at runtime, so the array build and the
+    /// residual DCE when the list never escapes.  Unlike
+    /// [`PyreHelperKind::NewtupleFromArray`], the element boxes are
+    /// recovered from the backing array (const length + per-index element
+    /// shadows) rather than from residual args.
+    NewlistFromArray,
     /// `n_varargs_fn(frame, exc, cause)` — the RAISE-family residual the
     /// codewriter emits for `n argc>=1` (`build_n_varargs_fn_residual_call_r_r_insn`).
     /// `cause` (the trailing Ref arg) is a `PY_NULL` sentinel for `raise X`

--- a/pyre/pyre-jit-trace/src/helpers.rs
+++ b/pyre/pyre-jit-trace/src/helpers.rs
@@ -947,12 +947,13 @@ pub fn emit_exception_new_inline(
     new_op
 }
 
-/// Emit inline Object-strategy `W_ListObject` creation for the exception
-/// `args_w` list, so a `raise Type(a, b, ...)` builds its argument list
-/// as traced `NewArrayClear` + `SetarrayitemGc` + `NewWithVtable` +
-/// `SetfieldGc` ops the optimizer can virtualize when the exception (and
-/// therefore its args list) never escapes — instead of the opaque
-/// residual `jit_build_list` CallR.
+/// Emit inline Object-strategy `W_ListObject` creation as traced
+/// `NewArrayClear` + `SetarrayitemGc` + `NewWithVtable` + `SetfieldGc`
+/// ops the optimizer can virtualize when the list never escapes — instead
+/// of the opaque residual `jit_build_list` CallR.  Shared by the
+/// `BUILD_LIST` decomposition (`try_walker_specialize_newlist`, Object
+/// strategy) and the exception `args_w` list a `raise Type(a, b, ...)`
+/// constructs.
 ///
 /// Mirrors `listobject.rs::w_list_new` for the Object strategy:
 ///   - `items` points at an `ItemsBlock` GcArray (capacity == `len`);
@@ -968,7 +969,7 @@ pub fn emit_exception_new_inline(
 /// not all-int AND not all-float); the typed Integer / Float strategies
 /// use `int_items` / `float_items` with `items` null and are NOT emitted
 /// here.
-pub fn emit_exception_args_list_inline(ctx: &mut TraceCtx, items: &[OpRef]) -> OpRef {
+pub fn emit_object_list_inline(ctx: &mut TraceCtx, items: &[OpRef]) -> OpRef {
     use crate::descr::{
         list_items_descr, list_length_descr, list_strategy_descr, w_list_size_descr,
     };
@@ -1014,6 +1015,79 @@ pub fn emit_exception_args_list_inline(ctx: &mut TraceCtx, items: &[OpRef]) -> O
     let strategy_idx = strategy_descr.index();
     ctx.record_op_with_descr(OpCode::SetfieldGc, &[list, strategy_const], strategy_descr);
     ctx.heapcache_setfield_cached(list, strategy_idx, strategy_const);
+
+    list
+}
+
+/// Emit inline Integer / Float-strategy `W_ListObject` creation: a typed
+/// length-prefixed backing block (`NewArray` + per-element `SetarrayitemGc`)
+/// holding the already-unboxed machine values in `raws`, then the
+/// `W_ListObject` wrapper (`NewWithVtable` + `strategy` / `int_items.len` /
+/// `int_items.block` — or the `float_items` pair — `SetfieldGc`).  Mirrors the
+/// Integer / Float arm of `listobject.rs::w_list_new` (`IntArray::from_vec` /
+/// `FloatArray::from_vec`), so OptVirtualize can fold the whole list (wrapper +
+/// block) when it never escapes — the orthodox `newlist` shape
+/// (`rlist.py:324 ll_newlist`, two mallocs).
+///
+/// The typed strategy keeps `length = 0` and `items = null`
+/// (`w_list_new_with_strategy` non-Object arm) — both stay zero-filled by
+/// `NewWithVtable`, matching the runtime.  `items_len_descr` / `items_block_descr`
+/// select the `int_items` / `float_items` sub-struct fields and `array_descr`
+/// the matching `int_gcarray_descr` / `float_gcarray_descr`.  Caller must have
+/// guarded + unboxed each element into `raws` already.
+pub fn emit_typed_list_inline(
+    ctx: &mut TraceCtx,
+    raws: &[OpRef],
+    array_descr: majit_ir::DescrRef,
+    items_len_descr: majit_ir::DescrRef,
+    items_block_descr: majit_ir::DescrRef,
+    strategy: pyre_object::listobject::ListStrategy,
+) -> OpRef {
+    use crate::descr::{list_strategy_descr, w_list_size_descr};
+
+    let len = raws.len();
+    let len_ref = ctx.const_int(len as i64);
+
+    // Step 1 — allocate the typed backing block (length-prefixed
+    // `[capacity][i64|f64 ...]`, capacity == len).  The elements are machine
+    // ints / floats (not refs), so `NewArray` (no GC-safe zeroing) matches
+    // `IntArray::from_vec` / `FloatArray::from_vec`; every slot is filled
+    // immediately below.
+    let block = ctx.record_op_with_descr(OpCode::NewArray, &[len_ref], array_descr.clone());
+    ctx.heap_cache_mut().new_array(block, len_ref, true);
+
+    // Step 2 — block[i] = raws[i].
+    let block_descr_idx = array_descr.index();
+    for (i, &raw) in raws.iter().enumerate() {
+        let idx = ctx.const_int(i as i64);
+        ctx.record_op_with_descr(
+            OpCode::SetarrayitemGc,
+            &[block, idx, raw],
+            array_descr.clone(),
+        );
+        ctx.heapcache_setarrayitem(block, idx, block_descr_idx, raw);
+    }
+
+    // Step 3 — allocate the W_ListObject wrapper.
+    let list = ctx.record_op_with_descr(OpCode::NewWithVtable, &[], w_list_size_descr());
+    ctx.heap_cache_mut().new_object(list);
+
+    // Step 4 — strategy / typed-items `len` + `block` SetfieldGc.  `length`
+    // and `items` stay zero-filled (0 / null) by NewWithVtable, as
+    // `w_list_new_with_strategy` leaves them for the typed strategies.
+    let strategy_const = ctx.const_int(strategy as i64);
+    let strategy_descr = list_strategy_descr();
+    let strategy_idx = strategy_descr.index();
+    ctx.record_op_with_descr(OpCode::SetfieldGc, &[list, strategy_const], strategy_descr);
+    ctx.heapcache_setfield_cached(list, strategy_idx, strategy_const);
+
+    let items_len_idx = items_len_descr.index();
+    ctx.record_op_with_descr(OpCode::SetfieldGc, &[list, len_ref], items_len_descr);
+    ctx.heapcache_setfield_cached(list, items_len_idx, len_ref);
+
+    let items_block_idx = items_block_descr.index();
+    ctx.record_op_with_descr(OpCode::SetfieldGc, &[list, block], items_block_descr);
+    ctx.heapcache_setfield_cached(list, items_block_idx, block);
 
     list
 }

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -15914,6 +15914,25 @@ fn dispatch_residual_call_iRd_kind(
         return Ok((DispatchOutcome::Continue, op.next_pc));
     }
 
+    // #171: virtualize a non-escaping BUILD_LIST (`newlist_from_array`) by
+    // decomposing it into the `opimpl_newlist` shape (`pyjitpl.py:779`) —
+    // `new_with_vtable` + `new_array` + `setarrayitem_gc` + `setfield_gc` —
+    // choosing the storage strategy from the concrete element shadows exactly
+    // like `w_list_new` / `list_strategy_for`, so the traced object matches what
+    // the blackhole rebuilds on deopt.  Gated on `PYRE_NEWLIST_VIRT`
+    // (default-on).  Falls through to the opaque residual for any shape it
+    // cannot reproduce faithfully (empty list, non-const array length, an
+    // element without a concrete Ref shadow) — SAFE, never declined.
+    if ctx.is_authoritative_executor
+        && ctx.is_full_body_walk
+        && dst_bank == 'r'
+        && ei.pyre_helper == majit_ir::PyreHelperKind::NewlistFromArray
+        && newlist_virt_enabled()
+        && try_walker_specialize_newlist(ctx, op.pc, &r_args, dst, dst_bank)?.is_some()
+    {
+        return Ok((DispatchOutcome::Continue, op.next_pc));
+    }
+
     // #171: specialize `lst.append(x)` so its array ops reach the trace,
     // replacing the opaque `bh_call_fn` residual (orthodox descent of the
     // real `w_list_append` body; see `try_walker_orthodox_list_append`).  The
@@ -18089,6 +18108,210 @@ fn walker_guard_exact_w_class(
     walker_emit_guard_with_snapshot(ctx, op_pc, OpCode::GuardTrue, &[eq])
 }
 
+/// `PYRE_NEWLIST_VIRT` gate (read once) — routes the `newlist_from_array`
+/// residual through the virtualizable [`try_walker_specialize_newlist`]
+/// instead of recording the opaque CallR.  Default-on (the orthodox
+/// `opimpl_newlist` shape); set `PYRE_NEWLIST_VIRT=0` to fall back to the
+/// residual.
+fn newlist_virt_enabled() -> bool {
+    static ENABLED: std::sync::LazyLock<bool> =
+        std::sync::LazyLock::new(|| std::env::var("PYRE_NEWLIST_VIRT").map_or(true, |v| v != "0"));
+    *ENABLED
+}
+
+/// #171: FBW virtualization of a non-escaping BUILD_LIST.
+/// `lower_tuple_build_hlop_to_insn` lowers BUILD_LIST to `new_array_clear`
+/// + per-index `setarrayitem_gc` + a `newlist_from_array` residual
+/// (oopspec [`majit_ir::PyreHelperKind::NewlistFromArray`]) whose single
+/// r-arg is the already-built backing array.  Decompose that residual into
+/// the virtualizable `opimpl_newlist` shape (`pyjitpl.py:779`) —
+/// `new_with_vtable` + `new_array` + `setarrayitem_gc` + `setfield_gc` —
+/// so the optimizer folds the whole list (wrapper + block) when it never
+/// escapes and the array build + residual DCE.
+///
+/// The element boxes are recovered from the backing array (its const length
+/// from `heapcache.arraylen`, then per-index element shadows via
+/// `heapcache_getarrayitem`), NOT from residual args.  The storage strategy
+/// is chosen from the concrete element shadows exactly as
+/// `list_strategy_for` / `w_list_new` does at runtime, so the traced object
+/// matches the strategy the blackhole rebuilds on deopt:
+///   * `list_strategy_for` → Integer AND every element an exact
+///     `W_IntObject` → Integer (`int_items` typed block, elements unboxed
+///     via `walker_unbox_int`);
+///   * → Float → Float (`float_items` typed block, strict `W_FloatObject`
+///     elements only, so exact-type by construction);
+///   * → Object → Object (boxed refs into an `ItemsBlock`).
+///
+/// Returns `Ok(None)` to fall through to the opaque residual (always
+/// byte-correct) for any shape it cannot reproduce faithfully: empty list
+/// (Empty strategy), a non-const / unrecoverable array length, an element
+/// without a concrete Ref shadow, or an Integer-strategy list that carries a
+/// fits-in-word `W_LongObject` / tagged immediate (which `walker_unbox_int`'s
+/// `&INT_TYPE` guard does not cover).
+fn try_walker_specialize_newlist(
+    ctx: &mut WalkContext<'_, '_>,
+    op_pc: usize,
+    r_args: &[OpRef],
+    dst: usize,
+    dst_bank: char,
+) -> Result<Option<()>, DispatchError> {
+    if !ctx.is_authoritative_executor || !ctx.is_full_body_walk || dst_bank != 'r' {
+        return Ok(None);
+    }
+    if r_args.len() != 1 {
+        return Ok(None);
+    }
+    let arr = r_args[0];
+
+    // Const backing-array length (`new_array_clear(Const(len))` seeded
+    // `heapcache.arraylen` — a cleared array has every slot set, so read the
+    // length directly rather than probing getarrayitem until a miss).  Empty
+    // list → Empty strategy: decline (the residual reproduces it).
+    let len = {
+        let Some(len_op) = ctx.trace_ctx.heap_cache().arraylen(arr) else {
+            return Ok(None);
+        };
+        match len_op.inline_const_to_value() {
+            Some(majit_ir::Value::Int(n)) if n >= 1 => n as usize,
+            _ => return Ok(None),
+        }
+    };
+
+    // Recover the element boxes from the array heap-cache (the values the
+    // BUILD_LIST `setarrayitem_gc` ops stored); a cache miss (clobbered array)
+    // bails to the opaque residual.
+    let descr_idx = crate::state::pyobject_gcarray_descr().index();
+    let mut items: Vec<OpRef> = Vec::with_capacity(len);
+    for i in 0..len {
+        let Some(elem) =
+            ctx.trace_ctx
+                .heapcache_getarrayitem(arr, OpRef::ConstInt(i as i64), descr_idx)
+        else {
+            return Ok(None);
+        };
+        items.push(elem);
+    }
+
+    // Concrete element objects (needed to classify the strategy and extract
+    // the payloads before any allocation).  An element without a concrete Ref
+    // shadow declines to the residual.
+    let mut concretes: Vec<pyre_object::PyObjectRef> = Vec::with_capacity(len);
+    for &it in &items {
+        let Some(obj) = walker_concrete_ref_object(ctx, it) else {
+            return Ok(None);
+        };
+        concretes.push(obj);
+    }
+
+    // Strategy the runtime `w_list_new` would pick — the source of truth for
+    // the concrete shadow, so the traced storage matches on deopt.
+    let strategy = pyre_object::listobject::list_strategy_for(&concretes);
+    use pyre_object::listobject::ListStrategy;
+
+    // Pre-extract the machine payloads BEFORE `build_list_from_refs` allocates
+    // (a minor collection there could move the boxed elements, so the raw
+    // pointers must not be dereferenced afterwards).
+    enum Emit {
+        Int(Vec<i64>),
+        Float(Vec<f64>),
+        Object,
+    }
+    let int_ty = &pyre_object::pyobject::INT_TYPE as *const pyre_object::pyobject::PyType;
+    let emit = match strategy {
+        ListStrategy::Integer => {
+            // `list_strategy_for` accepts fits-in-word `W_LongObject` and
+            // tagged immediates under Integer, but `walker_unbox_int` only
+            // covers the exact `W_IntObject` (`&INT_TYPE` + `intval`) shape —
+            // decline otherwise so the residual (correct for any element)
+            // rebuilds the same Integer list.
+            let mut vals = Vec::with_capacity(len);
+            for &p in &concretes {
+                if pyre_object::tagged_int::CAN_BE_TAGGED
+                    && pyre_object::tagged_int::is_tagged_int(p)
+                {
+                    return Ok(None);
+                }
+                let exact_int =
+                    unsafe { pyre_object::is_plain_int1(p) && std::ptr::eq((*p).ob_type, int_ty) };
+                if !exact_int {
+                    return Ok(None);
+                }
+                vals.push(unsafe { pyre_object::w_int_get_value(p) });
+            }
+            Emit::Int(vals)
+        }
+        ListStrategy::Float => {
+            // `all_floats` is strict `type(w) is W_FloatObject`, so every
+            // element is an exact `W_FloatObject` (`walker_unbox_float`'s
+            // `&FLOAT_TYPE` guard holds).
+            let mut vals = Vec::with_capacity(len);
+            for &p in &concretes {
+                vals.push(unsafe { pyre_object::w_float_get_value(p) });
+            }
+            Emit::Float(vals)
+        }
+        ListStrategy::Object => Emit::Object,
+        // Empty is impossible here (len >= 1); decline defensively.
+        ListStrategy::Empty => return Ok(None),
+    };
+
+    // Concrete shadow: a fresh list built from the element shadows
+    // (`w_list_new` parity — picks the same strategy). A new allocation with
+    // no heap mutation, safe during the walk like `wrapint`.
+    let result_concrete = pyre_interpreter::build_list_from_refs(&concretes);
+    if result_concrete.is_null() {
+        return Ok(None);
+    }
+
+    // --- emit the virtualizable decomposed newlist (walker-native) ---
+    let list_op = match emit {
+        Emit::Int(vals) => {
+            let int_type_addr = int_ty as i64;
+            let mut raws: Vec<OpRef> = Vec::with_capacity(len);
+            for (&it, &v) in items.iter().zip(vals.iter()) {
+                let raw = walker_unbox_int(ctx, op_pc, it, int_type_addr)?;
+                ctx.trace_ctx
+                    .set_opref_concrete(raw, majit_ir::Value::Int(v));
+                raws.push(raw);
+            }
+            crate::helpers::emit_typed_list_inline(
+                &mut *ctx.trace_ctx,
+                &raws,
+                crate::state::int_gcarray_descr(),
+                crate::descr::list_int_items_len_descr(),
+                crate::descr::list_int_items_block_descr(),
+                ListStrategy::Integer,
+            )
+        }
+        Emit::Float(vals) => {
+            let float_type_addr = &pyre_object::pyobject::FLOAT_TYPE as *const _ as i64;
+            let mut raws: Vec<OpRef> = Vec::with_capacity(len);
+            for (&it, &v) in items.iter().zip(vals.iter()) {
+                let raw = walker_unbox_float(ctx, op_pc, it, float_type_addr)?;
+                ctx.trace_ctx
+                    .set_opref_concrete(raw, majit_ir::Value::Float(v));
+                raws.push(raw);
+            }
+            crate::helpers::emit_typed_list_inline(
+                &mut *ctx.trace_ctx,
+                &raws,
+                crate::state::float_gcarray_descr(),
+                crate::descr::list_float_items_len_descr(),
+                crate::descr::list_float_items_block_descr(),
+                ListStrategy::Float,
+            )
+        }
+        Emit::Object => crate::helpers::emit_object_list_inline(&mut *ctx.trace_ctx, &items),
+    };
+
+    ctx.trace_ctx.set_opref_concrete(
+        list_op,
+        majit_ir::Value::Ref(majit_ir::GcRef(result_concrete as usize)),
+    );
+    write_residual_call_result_to_dst(ctx, op_pc, dst, dst_bank, list_op)?;
+    Ok(Some(()))
+}
+
 /// #195 / #73: FBW virtualization of an arity-2 plain-int BUILD_TUPLE.
 /// `lower_tuple_build_hlop_to_insn` lowers BUILD_TUPLE to `new_array_clear`
 /// + per-index `setarrayitem_gc` + a `newtuple_from_array` residual
@@ -20014,7 +20237,7 @@ fn try_walker_trace_exception_new(
 
     // Build `args_w` inline (Object strategy) so the whole list
     // (W_ListObject + ItemsBlock) virtualizes alongside the exception.
-    let args_list = crate::helpers::emit_exception_args_list_inline(ctx.trace_ctx, args);
+    let args_list = crate::helpers::emit_object_list_inline(ctx.trace_ctx, args);
 
     let new_op =
         crate::helpers::emit_exception_new_inline(ctx.trace_ctx, kind, callable_op, args_list);

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -6360,9 +6360,9 @@ impl MIFrame {
     /// `gen_initialize_vtable`), so the result is a fully GC-managed
     /// `W_BaseException` identical to the runtime `malloc_typed` +
     /// `exc_new_wrapper` + `descr_init` path.  `args_w` is built inline
-    /// (`emit_exception_args_list_inline`) when `w_list_new` would pick
-    /// the Object strategy, so the args list virtualizes too; Empty /
-    /// Integer / Float strategies fall back to a residual list.
+    /// (`emit_object_list_inline`) when `w_list_new` would pick the Object
+    /// strategy, so the args list virtualizes too; Empty / Integer / Float
+    /// strategies fall back to a residual list.
     ///
     /// Restricted to a callable that is exactly
     /// `lookup_exc_class_for_kind(kind)`: user subclasses (whose ctor may
@@ -6433,7 +6433,7 @@ impl MIFrame {
         let args_list = if pyre_object::listobject::list_strategy_for(concrete_args)
             == pyre_object::listobject::ListStrategy::Object
         {
-            self.with_ctx(|_this, ctx| crate::helpers::emit_exception_args_list_inline(ctx, args))
+            self.with_ctx(|_this, ctx| crate::helpers::emit_object_list_inline(ctx, args))
         } else {
             TraceHelperAccess::trace_build_list(self, args)?
         };

--- a/pyre/pyre-jit/src/jit/flatten.rs
+++ b/pyre/pyre-jit/src/jit/flatten.rs
@@ -4501,11 +4501,19 @@ where
             // element boxes passed as args are forced by the residual call
             // regardless of flavor.  Matches the pointer-copy-only
             // `newtuple_from_array` sibling (`Plain`).
+            //
+            // Tag the residual as the BUILD_LIST helper so the FBW walker can
+            // intercept it and emit the virtualizable decomposed `newlist`
+            // shape (`pyjitpl.py:779 opimpl_newlist`) instead of recording the
+            // opaque CallR.  Inert on the assembler/baseline path (it reads
+            // fn_idx + args, not `pyre_helper`) and on the legacy trait path
+            // (which never emits this residual); only the FBW intercept, gated
+            // on `PYRE_NEWLIST_VIRT`, keys on it.
             Some(build_residual_call_r_r_insn_from_operands(
                 ctx.newlist_from_array_fn_idx,
                 vec![array_operand],
                 CallFlavor::Plain,
-                majit_ir::PyreHelperKind::None,
+                majit_ir::PyreHelperKind::NewlistFromArray,
                 dst_reg,
             ))
         }


### PR DESCRIPTION
## Summary

`lower_tuple_build_hlop_to_insn` lowers `BUILD_LIST` to `new_array_clear` +
per-index `setarrayitem_gc` + a terminal `newlist_from_array(array)` residual
(`bh_newlist_from_array` → `w_list_new`). The array build is already
virtualizable IR, but the residual is an escape: it force-materialises the
backing array and yields an opaque `W_ListObject` with no `VirtualInfo`, so a
non-escaping list display allocates (array block + wrapper + boxing) every
iteration. Only the arity-2 plain-int **tuple** special-case
(`try_walker_specialize_newtuple`) was virtualized; list/set/map were opaque.

This tags the `newlist_from_array` residual `PyreHelperKind::NewlistFromArray`
and intercepts it on the full-body-walk path, decomposing it into the
virtualizable `opimpl_newlist` shape (`pyjitpl.py:779`) — `new_with_vtable` +
`new_array` + `setarrayitem_gc` + `setfield_gc`. Element boxes are recovered
from the backing array (const `heapcache.arraylen` + per-index element shadows),
and the storage strategy is chosen from the concrete element shadows exactly as
`w_list_new` / `list_strategy_for` does at runtime (Integer / Float typed block,
else Object `ItemsBlock`), so the traced object matches what the blackhole
rebuilds on deopt. When the list never escapes, `OptVirtualize` folds the whole
wrapper + block and the original array build + residual DCE.

`emit_exception_args_list_inline` is renamed to `emit_object_list_inline`
(shared by the Object-strategy `BUILD_LIST` path and the exception `args_w`
list); a new `emit_typed_list_inline` handles the Integer / Float strategies
(sets `strategy` + `int_items` / `float_items` `len` + typed `block`, leaves
`length` / `items` zero-filled, matching `w_list_new_with_strategy`).

### Declines to the opaque residual (always byte-correct)

Empty list; non-const array length; an element without a concrete Ref shadow;
an Integer-strategy list carrying a fits-in-word `W_LongObject` / tagged
immediate. **SET / MAP** (MayForce + fallible hashing — storage is forced at
first hash) and the same-length **setslice** fold are left out (follow-ups).
Gated on `PYRE_NEWLIST_VIRT` (default-on).

## Test plan

- `check.py` **191/191 dynasm + 191/191 cranelift**.
- 7 adversarial break-repros + 4 target benches byte-identical across
  virt-on / virt-off / interp / python3.14 (escape-via-return, deopt-live-resume,
  nested, mixed-object, empty-decline, mutation-strategy-switch, post-force-reread).
- Escaping Integer list byte-identical under `MAJIT_GC_STRESS`.
- `build_list_resume` 0.04s vs 0.28s opaque-residual (~6.5x).

Ref #171.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved JIT optimization of list construction from arrays, including integer, floating-point, and object lists.
  * Enabled virtualization of eligible non-escaping lists to reduce unnecessary runtime allocations.
  * Improved handling of exception argument lists during tracing and optimization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->