### PR TITLE
jit: express the back-edge eval-breaker poll as traced IR (#568)

### DIFF
--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -10405,50 +10405,6 @@ impl CraneliftBackend {
                     }
                 }
 
-                OpCode::GuardEvalBreaker => {
-                    let info = &guard_infos[guard_idx];
-                    guard_idx += 1;
-
-                    let bitmask_addr = majit_ir::eval_breaker_word::eval_breaker_word_addr();
-                    if bitmask_addr != 0 {
-                        let addr = builder.ins().iconst(cl_types::I64, bitmask_addr as i64);
-                        let word = builder
-                            .ins()
-                            .load(cl_types::I64, MemFlags::trusted(), addr, 0);
-                        let zero = builder.ins().iconst(cl_types::I64, 0);
-                        let cond = builder.ins().icmp(IntCC::NotEqual, word, zero);
-
-                        // Both back-edge reasons share this one guard exit and
-                        // its existing resume snapshot.
-                        let exit_block = builder.create_block();
-                        builder.set_cold_block(exit_block);
-                        let cont_block = builder.create_block();
-                        if preamble_phase {
-                            builder.set_cold_block(cont_block);
-                        }
-                        builder.ins().brif(cond, exit_block, &[], cont_block, &[]);
-
-                        builder.switch_to_block(exit_block);
-                        builder.seal_block(exit_block);
-                        let cur_jf = builder.ins().get_pinned_reg(ptr_type);
-                        emit_guard_exit(
-                            &mut builder,
-                            &constants,
-                            cur_jf,
-                            info,
-                            &ref_root_slots,
-                            &stale_ref_vars,
-                            &demoted_failarg_slots,
-                            ref_root_base_ofs,
-                            ptr_type,
-                            call_conv,
-                        );
-
-                        builder.switch_to_block(cont_block);
-                        builder.seal_block(cont_block);
-                    }
-                }
-
                 OpCode::GuardFutureCondition => {
                     // Future condition: the guard condition is computed lazily.
                     // For now, behave like GuardTrue on args[0].
@@ -17190,14 +17146,6 @@ mod tests {
     use std::sync::Mutex;
     use std::sync::atomic::{AtomicUsize, Ordering};
 
-    struct ClearEvalBreakerAddrOverride;
-
-    impl Drop for ClearEvalBreakerAddrOverride {
-        fn drop(&mut self) {
-            majit_ir::eval_breaker_word::set_addr_override_for_test(0);
-        }
-    }
-
     fn mk_op(opcode: OpCode, args: &[OpRef], pos: u32) -> majit_ir::OpRc {
         let bx: Vec<Operand> = args.iter().map(|a| rb(*a)).collect();
         let o = Op::new(opcode, &bx);
@@ -17205,32 +17153,38 @@ mod tests {
         std::rc::Rc::new(o)
     }
 
-    fn compile_eval_breaker_guard_trace(trace_id: u64) -> (CraneliftBackend, JitCellToken) {
+    fn compile_eval_breaker_poll_trace(
+        trace_id: u64,
+        word_addr: usize,
+    ) -> (CraneliftBackend, JitCellToken) {
         let mut backend = CraneliftBackend::new();
-        let guard = Op::new(OpCode::GuardEvalBreaker, &[]);
-        guard.pos.set(OpRef::void_op(0));
+        let word = mk_op_with_descr(
+            OpCode::RawLoadI,
+            &[OpRef::const_int(word_addr as i64), OpRef::const_int(0)],
+            0,
+            majit_ir::make_array_descr_signed(0, 8, Type::Int, true),
+        );
+        let armed = std::rc::Rc::new(Op::new(OpCode::IntIsTrue, &[Operand::from_bound_op(&word)]));
+        armed.pos.set(OpRef::int_op(1));
+        let guard = Op::new(OpCode::GuardFalse, &[Operand::from_bound_op(&armed)]);
+        guard.pos.set(OpRef::void_op(2));
         guard.set_fail_arg_types(vec![]);
         guard.setfailargs(vec![].into());
         let finish = Op::new(OpCode::Finish, &[]);
-        finish.pos.set(OpRef::void_op(1));
+        finish.pos.set(OpRef::void_op(3));
         finish.set_fail_arg_types(vec![]);
         finish.setfailargs(vec![].into());
-        let ops = vec![std::rc::Rc::new(guard), std::rc::Rc::new(finish)];
+        let ops = vec![
+            word,
+            armed,
+            std::rc::Rc::new(guard),
+            std::rc::Rc::new(finish),
+        ];
         let mut token = JitCellToken::new(trace_id);
         backend
             .compile_loop(&[], &ops, &mut token)
-            .expect("compile GuardEvalBreaker");
+            .expect("compile eval-breaker poll IR");
         (backend, token)
-    }
-
-    fn assert_inert_eval_breaker_guard() {
-        majit_ir::eval_breaker_word::set_addr_override_for_test(0);
-        let (backend, token) = compile_eval_breaker_guard_trace(517);
-        let frame = backend.execute_token(&token, &[]);
-        assert!(
-            backend.get_latest_descr(&frame).is_finish(),
-            "an unpublished bitmask address must leave the guard inert"
-        );
     }
 
     use majit_ir::forwarding::bound_operand_from_opref as rb;
@@ -24815,16 +24769,11 @@ mod tests {
     }
 
     #[test]
-    fn guard_eval_breaker_deopts_when_bitmask_set() {
-        assert_inert_eval_breaker_guard();
-
+    fn eval_breaker_poll_deopts_when_bitmask_set() {
         let test_word = AtomicUsize::new(0);
-        majit_ir::eval_breaker_word::set_addr_override_for_test(
-            &test_word as *const AtomicUsize as usize,
-        );
-        let _clear_override = ClearEvalBreakerAddrOverride;
+        let word_addr = &test_word as *const AtomicUsize as usize;
 
-        let (backend, token) = compile_eval_breaker_guard_trace(518);
+        let (backend, token) = compile_eval_breaker_poll_trace(518, word_addr);
         let frame = backend.execute_token(&token, &[]);
         assert!(
             backend.get_latest_descr(&frame).is_finish(),
@@ -24843,7 +24792,8 @@ mod tests {
         );
         test_word.fetch_and(!majit_ir::eval_breaker_word::EB_STW, Ordering::Relaxed);
 
-        let (backend_after_clear, token_after_clear) = compile_eval_breaker_guard_trace(519);
+        let (backend_after_clear, token_after_clear) =
+            compile_eval_breaker_poll_trace(519, word_addr);
         let frame = backend_after_clear.execute_token(&token_after_clear, &[]);
         assert!(
             backend_after_clear.get_latest_descr(&frame).is_finish(),
@@ -24859,16 +24809,13 @@ mod tests {
     }
 
     #[test]
-    fn guard_eval_breaker_cross_trace_inherits_bitmask() {
+    fn eval_breaker_poll_cross_trace_uses_same_word() {
         let test_word = AtomicUsize::new(0);
-        majit_ir::eval_breaker_word::set_addr_override_for_test(
-            &test_word as *const AtomicUsize as usize,
-        );
-        let _clear_override = ClearEvalBreakerAddrOverride;
+        let word_addr = &test_word as *const AtomicUsize as usize;
 
-        let (backend_a, token_a) = compile_eval_breaker_guard_trace(520);
+        let (backend_a, token_a) = compile_eval_breaker_poll_trace(520, word_addr);
         test_word.fetch_or(majit_ir::eval_breaker_word::EB_ASYNC, Ordering::Relaxed);
-        let (backend_b, token_b) = compile_eval_breaker_guard_trace(521);
+        let (backend_b, token_b) = compile_eval_breaker_poll_trace(521, word_addr);
 
         let frame_a = backend_a.execute_token(&token_a, &[]);
         assert!(

--- a/majit/majit-backend-dynasm/src/aarch64/assembler.rs
+++ b/majit/majit-backend-dynasm/src/aarch64/assembler.rs
@@ -3473,20 +3473,6 @@ impl<'a> AssemblerARM64<'a> {
             OpCode::GuardNotInvalidated => {
                 self.implement_guard_nojump_with_faillocs(op, op_index, fail_index, faillocs);
             }
-            OpCode::GuardEvalBreaker => {
-                let bitmask_addr = majit_ir::eval_breaker_word::eval_breaker_word_addr();
-                if bitmask_addr != 0 {
-                    // Bitmask address is loop-invariant, baked into x24 by the
-                    // trace prologue; load the word and deopt if any bit is set.
-                    dynasm!(self.mc ; .arch aarch64 ; ldr X(16), [x24] ; cmp X(16), xzr);
-                    let label = self.emit_guard_jcc(CC_NE);
-                    self.append_guard_token_with_faillocs(
-                        op, op_index, fail_index, label, faillocs,
-                    );
-                } else {
-                    self.implement_guard_nojump_with_faillocs(op, op_index, fail_index, faillocs);
-                }
-            }
             OpCode::GuardAlwaysFails => {
                 self.implement_guard_always_fails_with_faillocs(op, op_index, fail_index, faillocs);
             }
@@ -7187,61 +7173,61 @@ mod tests {
     use std::time::Duration;
 
     use majit_backend::{Backend, JitCellToken};
-    use majit_ir::{Op, OpCode, OpRef, make_loop_target_descr};
+    use majit_ir::operand::Operand;
+    use majit_ir::{Op, OpCode, OpRef, Type, make_array_descr_signed, make_loop_target_descr};
 
     use crate::runner::DynasmBackend;
 
-    struct ClearEvalBreakerAddrOverride;
-
-    impl Drop for ClearEvalBreakerAddrOverride {
-        fn drop(&mut self) {
-            majit_ir::eval_breaker_word::set_addr_override_for_test(0);
-        }
+    fn eval_breaker_poll_ops(word_addr: usize, first_pos: u32) -> (Rc<Op>, Rc<Op>, Rc<Op>) {
+        let word = Rc::new(Op::with_descr(
+            OpCode::RawLoadI,
+            &[
+                Operand::from_opref(OpRef::const_int(word_addr as i64)),
+                Operand::from_opref(OpRef::const_int(0)),
+            ],
+            make_array_descr_signed(0, 8, Type::Int, true),
+        ));
+        word.pos.set(OpRef::int_op(first_pos));
+        let armed = Rc::new(Op::new(OpCode::IntIsTrue, &[Operand::from_bound_op(&word)]));
+        armed.pos.set(OpRef::int_op(first_pos + 1));
+        let guard = Rc::new(Op::new(
+            OpCode::GuardFalse,
+            &[Operand::from_bound_op(&armed)],
+        ));
+        guard.pos.set(OpRef::void_op(first_pos + 2));
+        guard.set_fail_arg_types(vec![]);
+        guard.setfailargs(vec![].into());
+        (word, armed, guard)
     }
 
-    fn compile_guard_trace(trace_id: u64) -> (DynasmBackend, JitCellToken) {
+    fn compile_eval_breaker_poll_trace(
+        trace_id: u64,
+        word_addr: usize,
+    ) -> (DynasmBackend, JitCellToken) {
         let mut backend = DynasmBackend::new();
         backend.attach_default_test_descrs();
         let mut token = JitCellToken::new(trace_id);
 
-        let guard = Op::new(OpCode::GuardEvalBreaker, &[]);
-        guard.pos.set(OpRef::void_op(0));
-        guard.set_fail_arg_types(vec![]);
-        guard.setfailargs(vec![].into());
+        let (word, armed, guard) = eval_breaker_poll_ops(word_addr, 0);
 
         let finish = Op::new(OpCode::Finish, &[]);
-        finish.pos.set(OpRef::void_op(1));
+        finish.pos.set(OpRef::void_op(3));
         finish.set_fail_arg_types(vec![]);
         finish.setfailargs(vec![].into());
 
-        let ops = vec![Rc::new(guard), Rc::new(finish)];
+        let ops = vec![word, armed, guard, Rc::new(finish)];
         backend
             .compile_loop(&[], &ops, &mut token)
-            .expect("compile GuardEvalBreaker");
+            .expect("compile eval-breaker poll IR");
         (backend, token)
     }
 
-    fn assert_inert_guard() {
-        majit_ir::eval_breaker_word::set_addr_override_for_test(0);
-        let (backend, token) = compile_guard_trace(517);
-        let frame = backend.execute_token(&token, &[]);
-        assert!(
-            backend.get_latest_descr(&frame).is_finish(),
-            "an unpublished bitmask address must leave the guard inert"
-        );
-    }
-
     #[test]
-    fn guard_eval_breaker_deopts_when_bitmask_set() {
-        assert_inert_guard();
-
+    fn eval_breaker_poll_deopts_when_bitmask_set() {
         let test_word = AtomicUsize::new(0);
-        majit_ir::eval_breaker_word::set_addr_override_for_test(
-            &test_word as *const AtomicUsize as usize,
-        );
-        let _clear_override = ClearEvalBreakerAddrOverride;
+        let word_addr = &test_word as *const AtomicUsize as usize;
 
-        let (backend, token) = compile_guard_trace(518);
+        let (backend, token) = compile_eval_breaker_poll_trace(518, word_addr);
         let frame = backend.execute_token(&token, &[]);
         assert!(
             backend.get_latest_descr(&frame).is_finish(),
@@ -7256,7 +7242,8 @@ mod tests {
         );
         test_word.fetch_and(!majit_ir::eval_breaker_word::EB_STW, Ordering::Relaxed);
 
-        let (backend_after_clear, token_after_clear) = compile_guard_trace(519);
+        let (backend_after_clear, token_after_clear) =
+            compile_eval_breaker_poll_trace(519, word_addr);
         let frame = backend_after_clear.execute_token(&token_after_clear, &[]);
         assert!(
             backend_after_clear.get_latest_descr(&frame).is_finish(),
@@ -7272,12 +7259,9 @@ mod tests {
     }
 
     #[test]
-    fn guard_eval_breaker_cross_trace_inherits_bitmask() {
+    fn eval_breaker_poll_cross_trace_uses_same_word() {
         let test_word = AtomicUsize::new(0);
-        majit_ir::eval_breaker_word::set_addr_override_for_test(
-            &test_word as *const AtomicUsize as usize,
-        );
-        let _clear_override = ClearEvalBreakerAddrOverride;
+        let word_addr = &test_word as *const AtomicUsize as usize;
 
         let mut backend = DynasmBackend::new();
         backend.attach_default_test_descrs();
@@ -7289,13 +7273,10 @@ mod tests {
         label.pos.set(OpRef::void_op(0));
         label.setdescr(target_descr.clone());
 
-        let guard = Op::new(OpCode::GuardEvalBreaker, &[]);
-        guard.pos.set(OpRef::void_op(1));
-        guard.set_fail_arg_types(vec![]);
-        guard.setfailargs(vec![].into());
+        let (word, armed, guard) = eval_breaker_poll_ops(word_addr, 1);
 
         let finish = Op::new(OpCode::Finish, &[]);
-        finish.pos.set(OpRef::void_op(2));
+        finish.pos.set(OpRef::void_op(4));
         finish.set_fail_arg_types(vec![]);
         finish.setfailargs(vec![].into());
 
@@ -7303,15 +7284,15 @@ mod tests {
         backend
             .compile_loop(
                 &[],
-                &[Rc::new(label), Rc::new(guard), Rc::new(finish)],
+                &[Rc::new(label), word, armed, guard, Rc::new(finish)],
                 &mut target_token,
             )
             .expect("compile cross-trace bitmask target");
 
         test_word.fetch_or(majit_ir::eval_breaker_word::EB_STW, Ordering::Relaxed);
 
-        // Enter the target loop body through an external BR. Its prologue is
-        // skipped, so the target poll must inherit x24 from this source entry.
+        // Enter the target loop body through an external branch. The ordinary
+        // IR poll must still load the same constant-address word.
         let jump = Op::new(OpCode::Jump, &[]);
         jump.pos.set(OpRef::void_op(0));
         jump.setdescr(target_descr);
@@ -7329,7 +7310,7 @@ mod tests {
         let frame = backend.execute_token(&source_token, &[]);
         assert!(
             !backend.get_latest_descr(&frame).is_finish(),
-            "external entry must inherit x24 and deopt on the same bitmask"
+            "external entry must deopt on the same bitmask word"
         );
     }
 
@@ -7351,29 +7332,22 @@ mod tests {
         let worker_test_word = test_word.clone();
         let worker = std::thread::spawn(move || {
             majit_gc::gc_sync::register_thread();
-            majit_ir::eval_breaker_word::set_addr_override_for_test(
-                Arc::as_ptr(&worker_test_word) as usize
-            );
-            let _clear_override = ClearEvalBreakerAddrOverride;
-
             let mut backend = DynasmBackend::new();
             backend.attach_default_test_descrs();
             let target_descr = make_loop_target_descr(522, false);
             let label = Op::new(OpCode::Label, &[]);
             label.pos.set(OpRef::void_op(0));
             label.setdescr(target_descr.clone());
-            let guard = Op::new(OpCode::GuardEvalBreaker, &[]);
-            guard.pos.set(OpRef::void_op(1));
-            guard.set_fail_arg_types(vec![]);
-            guard.setfailargs(vec![].into());
+            let (word, armed, guard) =
+                eval_breaker_poll_ops(Arc::as_ptr(&worker_test_word) as usize, 1);
             let jump = Op::new(OpCode::Jump, &[]);
-            jump.pos.set(OpRef::void_op(2));
+            jump.pos.set(OpRef::void_op(4));
             jump.setdescr(target_descr);
             let mut token = JitCellToken::new(522);
             backend
                 .compile_loop(
                     &[],
-                    &[Rc::new(label), Rc::new(guard), Rc::new(jump)],
+                    &[Rc::new(label), word, armed, guard, Rc::new(jump)],
                     &mut token,
                 )
                 .expect("compile polling loop on worker");

--- a/majit/majit-backend-dynasm/src/aarch64/assembler.rs
+++ b/majit/majit-backend-dynasm/src/aarch64/assembler.rs
@@ -35,24 +35,16 @@ const AARCH64_GEN_REGS: [crate::regloc::RegLoc; 18] = crate::aarch64::registers:
 
 const AARCH64_FLOAT_REGS: [crate::regloc::RegLoc; 8] = crate::aarch64::registers::ALL_VFP_REGS;
 
-/// Bytes the trace entry frame reserves: the frame-pointer/link pair, the
-/// callee-saved registers the trace body clobbers, and the reserved
-/// bitmask-address register. The prologue, the stack-overflow early return and
-/// the epilogue must all agree on this, or the return unwinds a corrupt SP.
-const CALL_FRAME_SIZE: u32 = 64;
+/// Bytes the trace entry frame reserves: the frame-pointer/link pair and the
+/// callee-saved registers the trace body clobbers. The prologue, the
+/// stack-overflow early return and the epilogue must all agree on this, or the
+/// return unwinds a corrupt SP.
+const CALL_FRAME_SIZE: u32 = 48;
 
-/// Offset of `BITMASK_ADDR_REG`'s save slot within the entry frame.
-const X24_SAVE_OFFSET: u32 = 56;
-
-const _: () = assert!(X24_SAVE_OFFSET + 8 <= CALL_FRAME_SIZE);
 const _: () = assert!(
     CALL_FRAME_SIZE % 16 == 0,
     "aarch64 SP stays 16-byte aligned"
 );
-// The prologue/epilogue spell the reserved register as a dynasm `x24` literal,
-// which no expression ties back to `registers`. Fail the build rather than
-// silently save the wrong register if the reservation ever moves.
-const _: () = assert!(crate::aarch64::registers::BITMASK_ADDR_REG.value == 24);
 
 /// Resolved argument: either a frame slot (frame-pointer-relative offset) or a constant.
 enum ResolvedArg {
@@ -1284,20 +1276,8 @@ impl<'a> AssemblerARM64<'a> {
             ; stp x29, x30, [sp, -(CALL_FRAME_SIZE as i32)]!
             ; stp x19, x20, [sp, #16]   // save callee-saved regs
             ; stp x21, x22, [sp, #32]   // save callee-saved regs
-            ; str x24, [sp, X24_SAVE_OFFSET]  // save reserved bitmask-addr reg
             ; mov x29, x0
         );
-        // Bake the process-global eval-breaker-word address into the reserved
-        // register once per trace entry; the back-edge poll then loads the word
-        // x24-relative. Gated identically to the poll (0 = not published ->
-        // no reg, no poll).
-        let bitmask_addr = majit_ir::eval_breaker_word::eval_breaker_word_addr();
-        if bitmask_addr != 0 {
-            self.emit_mov_imm64(
-                crate::aarch64::registers::BITMASK_ADDR_REG.value as u32,
-                bitmask_addr as i64,
-            );
-        }
         let propagate_descr = self.propagate_exception_descr_ptr();
         if propagate_descr != 0 {
             if let Some(addrs) = crate::stack_check_addresses() {
@@ -1345,7 +1325,6 @@ impl<'a> AssemblerARM64<'a> {
                     ; mov x0, x29
                     ; ldp x19, x20, [sp, #16]
                     ; ldp x21, x22, [sp, #32]
-                    ; ldr x24, [sp, X24_SAVE_OFFSET]
                     ; ldp x29, x30, [sp], CALL_FRAME_SIZE as i32
                     ; ret
                     ; =>continue_label
@@ -1369,7 +1348,6 @@ impl<'a> AssemblerARM64<'a> {
             ; mov x0, x29
             ; ldp x19, x20, [sp, #16]   // restore callee-saved regs
             ; ldp x21, x22, [sp, #32]   // restore callee-saved regs
-            ; ldr x24, [sp, X24_SAVE_OFFSET]  // restore reserved bitmask-addr reg
             ; ldp x29, x30, [sp], CALL_FRAME_SIZE as i32
             ; ret
         );

--- a/majit/majit-backend-dynasm/src/aarch64/registers.rs
+++ b/majit/majit-backend-dynasm/src/aarch64/registers.rs
@@ -141,4 +141,3 @@ pub const CALLEE_RESP: [RegLoc; 4] = CALLEE_SAVED_REGISTERS;
 
 /// registers.py:36 `caller_resp = argument_regs + [x8, x9, x10, x11, x12, x13]`
 pub const CALLER_RESP: [RegLoc; 14] = [X0, X1, X2, X3, X4, X5, X6, X7, X8, X9, X10, X11, X12, X13];
-

--- a/majit/majit-backend-dynasm/src/aarch64/registers.rs
+++ b/majit/majit-backend-dynasm/src/aarch64/registers.rs
@@ -31,11 +31,6 @@ pub const X21: RegLoc = RegLoc::new(21, false);
 pub const X22: RegLoc = RegLoc::new(22, false);
 pub const X23: RegLoc = RegLoc::new(23, false);
 pub const X24: RegLoc = RegLoc::new(24, false);
-/// Callee-saved register reserved to hold the process-global eval-breaker-word
-/// address for the whole trace, so the back-edge poll loads the word without
-/// re-materialising the 64-bit address each iteration. Kept OUT of ALL_REGS;
-/// saved/restored by the trace prologue/epilogue.
-pub const BITMASK_ADDR_REG: RegLoc = X24;
 pub const X25: RegLoc = RegLoc::new(25, false);
 pub const X26: RegLoc = RegLoc::new(26, false);
 pub const X27: RegLoc = RegLoc::new(27, false);
@@ -147,17 +142,3 @@ pub const CALLEE_RESP: [RegLoc; 4] = CALLEE_SAVED_REGISTERS;
 /// registers.py:36 `caller_resp = argument_regs + [x8, x9, x10, x11, x12, x13]`
 pub const CALLER_RESP: [RegLoc; 14] = [X0, X1, X2, X3, X4, X5, X6, X7, X8, X9, X10, X11, X12, X13];
 
-#[cfg(test)]
-mod tests {
-    use super::{ALL_REGS, BITMASK_ADDR_REG};
-
-    #[test]
-    fn bitmask_addr_reg_is_reserved_x24() {
-        assert_eq!(BITMASK_ADDR_REG.value, 24);
-        assert!(
-            !ALL_REGS
-                .iter()
-                .any(|reg| reg.value == BITMASK_ADDR_REG.value)
-        );
-    }
-}

--- a/majit/majit-backend-dynasm/src/x86/assembler.rs
+++ b/majit/majit-backend-dynasm/src/x86/assembler.rs
@@ -76,59 +76,55 @@ mod tests {
     use std::sync::atomic::{AtomicUsize, Ordering};
 
     use majit_backend::{Backend, JitCellToken};
-    use majit_ir::{Op, OpCode, OpRef};
+    use majit_ir::operand::Operand;
+    use majit_ir::{Op, OpCode, OpRef, Type, make_array_descr_signed};
 
     use crate::runner::DynasmBackend;
 
-    struct ClearEvalBreakerAddrOverride;
-
-    impl Drop for ClearEvalBreakerAddrOverride {
-        fn drop(&mut self) {
-            majit_ir::eval_breaker_word::set_addr_override_for_test(0);
-        }
-    }
-
-    fn compile_guard_trace(trace_id: u64) -> (DynasmBackend, JitCellToken) {
+    fn compile_eval_breaker_poll_trace(
+        trace_id: u64,
+        word_addr: usize,
+    ) -> (DynasmBackend, JitCellToken) {
         let mut backend = DynasmBackend::new();
         backend.attach_default_test_descrs();
         let mut token = JitCellToken::new(trace_id);
 
-        let guard = Op::new(OpCode::GuardEvalBreaker, &[]);
-        guard.pos.set(OpRef::void_op(0));
+        let word = Rc::new(Op::with_descr(
+            OpCode::RawLoadI,
+            &[
+                Operand::from_opref(OpRef::const_int(word_addr as i64)),
+                Operand::from_opref(OpRef::const_int(0)),
+            ],
+            make_array_descr_signed(0, 8, Type::Int, true),
+        ));
+        word.pos.set(OpRef::int_op(0));
+        let armed = Rc::new(Op::new(OpCode::IntIsTrue, &[Operand::from_bound_op(&word)]));
+        armed.pos.set(OpRef::int_op(1));
+        let guard = Op::new(OpCode::GuardFalse, &[Operand::from_bound_op(&armed)]);
+        guard.pos.set(OpRef::void_op(2));
         guard.set_fail_arg_types(vec![]);
         guard.setfailargs(vec![].into());
         let finish = Op::new(OpCode::Finish, &[]);
-        finish.pos.set(OpRef::void_op(1));
+        finish.pos.set(OpRef::void_op(3));
         finish.set_fail_arg_types(vec![]);
         finish.setfailargs(vec![].into());
 
         backend
-            .compile_loop(&[], &[Rc::new(guard), Rc::new(finish)], &mut token)
-            .expect("compile GuardEvalBreaker");
+            .compile_loop(
+                &[],
+                &[word, armed, Rc::new(guard), Rc::new(finish)],
+                &mut token,
+            )
+            .expect("compile eval-breaker poll IR");
         (backend, token)
     }
 
-    fn assert_inert_guard() {
-        majit_ir::eval_breaker_word::set_addr_override_for_test(0);
-        let (backend, token) = compile_guard_trace(517);
-        let frame = backend.execute_token(&token, &[]);
-        assert!(
-            backend.get_latest_descr(&frame).is_finish(),
-            "an unpublished bitmask address must leave the guard inert"
-        );
-    }
-
     #[test]
-    fn guard_eval_breaker_deopts_when_bitmask_set() {
-        assert_inert_guard();
-
+    fn eval_breaker_poll_deopts_when_bitmask_set() {
         let test_word = AtomicUsize::new(0);
-        majit_ir::eval_breaker_word::set_addr_override_for_test(
-            &test_word as *const AtomicUsize as usize,
-        );
-        let _clear_override = ClearEvalBreakerAddrOverride;
+        let word_addr = &test_word as *const AtomicUsize as usize;
 
-        let (backend, token) = compile_guard_trace(518);
+        let (backend, token) = compile_eval_breaker_poll_trace(518, word_addr);
         let frame = backend.execute_token(&token, &[]);
         assert!(backend.get_latest_descr(&frame).is_finish());
 
@@ -137,7 +133,8 @@ mod tests {
         assert!(!backend.get_latest_descr(&frame).is_finish());
         test_word.fetch_and(!majit_ir::eval_breaker_word::EB_STW, Ordering::Relaxed);
 
-        let (backend_after_clear, token_after_clear) = compile_guard_trace(519);
+        let (backend_after_clear, token_after_clear) =
+            compile_eval_breaker_poll_trace(519, word_addr);
         let frame = backend_after_clear.execute_token(&token_after_clear, &[]);
         assert!(backend_after_clear.get_latest_descr(&frame).is_finish());
 
@@ -147,16 +144,13 @@ mod tests {
     }
 
     #[test]
-    fn guard_eval_breaker_cross_trace_inherits_bitmask() {
+    fn eval_breaker_poll_cross_trace_uses_same_word() {
         let test_word = AtomicUsize::new(0);
-        majit_ir::eval_breaker_word::set_addr_override_for_test(
-            &test_word as *const AtomicUsize as usize,
-        );
-        let _clear_override = ClearEvalBreakerAddrOverride;
+        let word_addr = &test_word as *const AtomicUsize as usize;
 
-        let (backend_a, token_a) = compile_guard_trace(520);
+        let (backend_a, token_a) = compile_eval_breaker_poll_trace(520, word_addr);
         test_word.fetch_or(majit_ir::eval_breaker_word::EB_ASYNC, Ordering::Relaxed);
-        let (backend_b, token_b) = compile_guard_trace(521);
+        let (backend_b, token_b) = compile_eval_breaker_poll_trace(521, word_addr);
 
         let frame_a = backend_a.execute_token(&token_a, &[]);
         assert!(!backend_a.get_latest_descr(&frame_a).is_finish());
@@ -4607,21 +4601,6 @@ impl<'a> Assembler386<'a> {
             }
             OpCode::GuardNotInvalidated => {
                 self.implement_guard_nojump_with_faillocs(op, op_index, fail_index, faillocs);
-            }
-            OpCode::GuardEvalBreaker => {
-                let bitmask_addr = majit_ir::eval_breaker_word::eval_breaker_word_addr();
-                if bitmask_addr != 0 {
-                    let scratch = crate::regloc::X86_64_SCRATCH_REG.value;
-                    dynasm!(self.mc ; .arch x64
-                        ; mov Rq(scratch), QWORD bitmask_addr as i64
-                        ; cmp QWORD [Rq(scratch)], 0);
-                    let label = self.emit_guard_jcc(CC_NE);
-                    self.append_guard_token_with_faillocs(
-                        op, op_index, fail_index, label, faillocs,
-                    );
-                } else {
-                    self.implement_guard_nojump_with_faillocs(op, op_index, fail_index, faillocs);
-                }
             }
             OpCode::GuardAlwaysFails => {
                 self.implement_guard_always_fails_with_faillocs(op, op_index, fail_index, faillocs);

--- a/majit/majit-backend-wasm/src/codegen.rs
+++ b/majit/majit-backend-wasm/src/codegen.rs
@@ -2665,7 +2665,8 @@ fn build_function(
                     emit_resolve(&mut sink, constants, value_types, op.arg(1).to_opref()); // offset
                     sink.i32_wrap_i64();
                     sink.i32_add();
-                    sink.i64_load(mem64(0));
+                    let (item_size, signed) = array_item_size_sign_from_descr(op);
+                    emit_sized_int_load(&mut sink, 0, item_size, signed);
                     sink.local_set(1 + vi);
                 }
             }
@@ -2676,7 +2677,8 @@ fn build_function(
                 sink.i32_wrap_i64();
                 sink.i32_add();
                 emit_resolve(&mut sink, constants, value_types, op.arg(2).to_opref());
-                sink.i64_store(mem64(0));
+                let (item_size, _signed) = array_item_size_sign_from_descr(op);
+                emit_sized_int_store(&mut sink, 0, item_size);
             }
 
             // ── Exception handling ──

--- a/majit/majit-backend-wasm/src/codegen.rs
+++ b/majit/majit-backend-wasm/src/codegen.rs
@@ -2103,13 +2103,8 @@ fn build_function(
                 guard_idx += 1;
             }
             // Guards that always pass in wasm MVP (no force-token /
-            // invalidation tracking yet). GuardEvalBreaker is inert here too:
-            // wasm32-unknown-unknown has no OS signals, so the ticker never
-            // goes negative.
-            OpCode::GuardNotInvalidated
-            | OpCode::GuardNotForced
-            | OpCode::GuardNotForced2
-            | OpCode::GuardEvalBreaker => {
+            // invalidation tracking yet).
+            OpCode::GuardNotInvalidated | OpCode::GuardNotForced | OpCode::GuardNotForced2 => {
                 guard_idx += 1;
             }
             OpCode::GuardNoException => {

--- a/majit/majit-ir/src/eval_breaker_word.rs
+++ b/majit/majit-ir/src/eval_breaker_word.rs
@@ -28,6 +28,13 @@ pub const EB_STW: usize = 2;
 /// The shared eval-breaker word (see module docs).
 static EVAL_BREAKER_WORD: AtomicUsize = AtomicUsize::new(0);
 
+/// Width of the word, in bytes. The back-edge poll's load descriptor must use
+/// exactly this size: a wider load reads past the word into the adjacent
+/// static, so the poll's nonzero test would always be true and every back-edge
+/// guard would fail. Pointer-width rather than fixed-64 keeps `fetch_or`
+/// lock-free — `set_async` runs inside an OS signal handler.
+pub const EVAL_BREAKER_WORD_SIZE: usize = size_of::<AtomicUsize>();
+
 /// Published address of `EVAL_BREAKER_WORD`; `0` until published.
 static EVAL_BREAKER_WORD_ADDR: AtomicUsize = AtomicUsize::new(0);
 
@@ -62,3 +69,8 @@ pub fn set_stw() {
 pub fn clear_stw() {
     EVAL_BREAKER_WORD.fetch_and(!EB_STW, Ordering::Release);
 }
+
+/// Every flag must fit in the word the poll actually loads. Checked per target,
+/// so a flag too wide for a 32-bit `usize` fails the wasm32 build rather than
+/// silently reading as unarmed there.
+const _: () = assert!((EB_ASYNC | EB_STW) < (1 << (EVAL_BREAKER_WORD_SIZE * 8 - 1)));

--- a/majit/majit-ir/src/eval_breaker_word.rs
+++ b/majit/majit-ir/src/eval_breaker_word.rs
@@ -10,21 +10,15 @@
 //! park gate remain authoritative; this word is only the JIT's deopt trigger.
 //!
 //! Immortal process-global, zero from process start, so the guard is harmless
-//! until a bit is armed. The published-address holder (`EVAL_BREAKER_WORD_ADDR`)
-//! reads `0` until published, and backends treat the back-edge poll as inert
-//! in that case.
+//! until a bit is armed. The trace records the address as the poll's constant
+//! operand; the published-address holder (`EVAL_BREAKER_WORD_ADDR`) reads `0`
+//! until published, and no poll is recorded in that case.
 //!
 //! The STW bit and authoritative request occupy two locations. A relaxed poll
 //! can briefly deopt before the request is visible, then resume and re-deopt
 //! until coherence propagates it; this is a bounded park-latency window.
 
-use std::cell::Cell;
 use std::sync::atomic::{AtomicUsize, Ordering};
-
-thread_local! {
-    /// Test-only per-thread override for the baked back-edge poll address.
-    static ADDR_OVERRIDE: Cell<usize> = const { Cell::new(0) };
-}
 
 /// bit0 — async action / signal pending (mirrors a negative ticker).
 pub const EB_ASYNC: usize = 1;
@@ -37,7 +31,7 @@ static EVAL_BREAKER_WORD: AtomicUsize = AtomicUsize::new(0);
 /// Published address of `EVAL_BREAKER_WORD`; `0` until published.
 static EVAL_BREAKER_WORD_ADDR: AtomicUsize = AtomicUsize::new(0);
 
-/// Publish the word's address for the backends to bake. Idempotent — the
+/// Publish the word's address for the tracer to record. Idempotent — the
 /// address is an immortal static, so re-publishing stores the same value.
 pub fn publish_addr() {
     EVAL_BREAKER_WORD_ADDR.store(
@@ -46,21 +40,10 @@ pub fn publish_addr() {
     );
 }
 
-/// Address the backend bakes into the back-edge poll, or `0` if not published.
+/// Address the trace records as the back-edge poll's constant, or `0` if not
+/// published — in which case no poll is recorded.
 pub fn eval_breaker_word_addr() -> usize {
-    let ov = ADDR_OVERRIDE.with(|c| c.get());
-    if ov != 0 {
-        return ov;
-    }
     EVAL_BREAKER_WORD_ADDR.load(Ordering::Relaxed)
-}
-
-/// Test-only: on the current thread, make the backend bake its back-edge poll
-/// against `addr` (a caller-owned word) instead of the process-global word, so
-/// unit tests never publish the global address (which would activate every
-/// other compiled trace in the test binary). Pass 0 to clear.
-pub fn set_addr_override_for_test(addr: usize) {
-    ADDR_OVERRIDE.with(|c| c.set(addr));
 }
 
 // --- async (bit0): armed by the OS signal handler / action dispatcher ---

--- a/majit/majit-ir/src/resoperation.rs
+++ b/majit/majit-ir/src/resoperation.rs
@@ -1841,7 +1841,6 @@ pub enum OpCode {
     GuardNotForced,
     GuardNotForced2,
     GuardNotInvalidated,
-    GuardEvalBreaker,
     GuardFutureCondition,
     GuardAlwaysFails,
 
@@ -2882,7 +2881,6 @@ static OPARITY: [Option<u8>; OPCODE_COUNT] = {
     set!(GuardNotForced, 0);
     set!(GuardNotForced2, 0);
     set!(GuardNotInvalidated, 0);
-    set!(GuardEvalBreaker, 0);
     set!(GuardFutureCondition, 0);
     set!(GuardAlwaysFails, 0);
     // Arithmetic (binary)
@@ -3121,7 +3119,6 @@ static OPWITHDESCR: [bool; OPCODE_COUNT] = {
         GuardNotForced,
         GuardNotForced2,
         GuardNotInvalidated,
-        GuardEvalBreaker,
         GuardFutureCondition,
         GuardAlwaysFails,
         // Array/field access
@@ -3481,7 +3478,6 @@ static OPNAME: [&str; OPCODE_COUNT] = {
         GuardNotForced,
         GuardNotForced2,
         GuardNotInvalidated,
-        GuardEvalBreaker,
         GuardFutureCondition,
         GuardAlwaysFails,
         IntAdd,
@@ -3810,7 +3806,6 @@ mod tests {
             OpCode::GuardNotForced,
             OpCode::GuardNotForced2,
             OpCode::GuardNotInvalidated,
-            OpCode::GuardEvalBreaker,
             OpCode::GuardFutureCondition,
             OpCode::GuardAlwaysFails,
             OpCode::VecI,
@@ -4244,7 +4239,6 @@ mod tests {
             OpCode::GuardNotForced,
             OpCode::GuardNotForced2,
             OpCode::GuardNotInvalidated,
-            OpCode::GuardEvalBreaker,
             OpCode::GuardFutureCondition,
             OpCode::GuardAlwaysFails,
         ];
@@ -4281,7 +4275,6 @@ mod tests {
             OpCode::GuardNoException,
             OpCode::GuardNotForced,
             OpCode::GuardNotInvalidated,
-            OpCode::GuardEvalBreaker,
             OpCode::GuardAlwaysFails,
         ];
         for op in &non_foldable {
@@ -4301,6 +4294,15 @@ mod tests {
                 );
             }
         }
+    }
+
+    #[test]
+    fn test_raw_load_i_stays_non_pure_for_eval_breaker_poll() {
+        // The back-edge eval-breaker poll depends on this classification. If
+        // RawLoadI becomes always-pure, optimize_guard_false deletes the poll
+        // from the loop body and compiled loops stop responding to signals/STW.
+        assert!(!OpCode::RawLoadI.is_always_pure());
+        assert!(OpCode::RawLoadI.has_no_side_effect());
     }
 
     #[test]

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -10715,8 +10715,8 @@ pub(crate) fn m73_armpath_carry_enabled() -> bool {
 }
 
 /// `PYRE_M73_LOOPCLOSE_CARRY` (#73 S5 phase-3 slice-6, default ON): carry
-/// the merge-point resume-marker twin into the `GuardEvalBreaker` and
-/// `GuardFutureCondition` loop-close snapshot words. Certified by the
+/// the merge-point resume-marker twin into the back-edge eval-breaker poll
+/// and `GuardFutureCondition` loop-close snapshot words. Certified by the
 /// `M73_LOOPCLOSE` census (362 captures across pyre/bench + synth, 100%
 /// eq=1) and check.py (162×2, on and off). Disable with
 /// `PYRE_M73_LOOPCLOSE_CARRY=0`.

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -2379,8 +2379,9 @@ pub struct MIFrame {
     /// `None` keeps the legacy `fallthrough_pc` liveness.
     pub residual_call_pc: Option<usize>,
     /// Resume-marker twin for the loop-close guards' snapshot word.
-    /// `close_loop_args_at` sets and clears it around the `GuardEvalBreaker`
-    /// and `GuardFutureCondition` emits; it is `None` outside that window.
+    /// `close_loop_args_at` sets and clears it around the back-edge
+    /// eval-breaker poll and `GuardFutureCondition` emits; it is `None`
+    /// outside that window.
     pub(crate) loop_close_marker_jit_pc: Option<usize>,
 }
 

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -6,6 +6,7 @@
 use crate::state::*;
 
 use std::borrow::Cow;
+use std::sync::OnceLock;
 
 use majit_ir::{DescrRef, GcRef, OpCode, OpRef, Type, Value};
 use majit_metainterp::{
@@ -13,6 +14,13 @@ use majit_metainterp::{
 };
 
 use pyre_interpreter::bytecode::{BinaryOperator, CodeObject, ComparisonOperator, Instruction};
+
+fn eval_breaker_word_descr() -> DescrRef {
+    static DESCR: OnceLock<DescrRef> = OnceLock::new();
+    DESCR
+        .get_or_init(|| majit_ir::descr::make_array_descr_signed(0, 8, Type::Int, true))
+        .clone()
+}
 
 extern "C" fn trace_function_get_defaults(func: i64) -> i64 {
     unsafe { function_get_defaults(func as PyObjectRef) as i64 }
@@ -2976,15 +2984,33 @@ impl MIFrame {
         header_marker_jit_pc: Option<usize>,
     ) -> Vec<OpRef> {
         self.loop_close_marker_jit_pc = header_marker_jit_pc;
-        // `JUMP_BACKWARD` eval-breaker poll (`CHECK_EVAL_BREAKER`): emit
-        // a `GuardEvalBreaker` in the loop body before the closing JUMP so the
-        // compiled loop polls the async-action ticker at the back-edge and
-        // deopts when a signal / async action is pending, instead of running
-        // uninterruptibly until natural loop exit. Nullary guard: no data
-        // operands, so its resume snapshot is the ordinary loop-body liveness
-        // (like GuardNotInvalidated). Captured before the flush/materialize
-        // below so the snapshot reflects the pre-close loop-body state.
-        self.generate_guard(ctx, OpCode::GuardEvalBreaker, &[]);
+        // Mirror pypy/module/pypyjit/test_pypy_c/model.py's `--TICK--` shape:
+        // load a process-global raw word through a baked constant address,
+        // compare it, then guard the result. The folded eval-breaker word is a
+        // bitmask, so this uses a nonzero test rather than upstream's
+        // `int_lt(ticker, 0)`.
+        //
+        // Load-bearing invariant: RawLoadI must remain outside the always-pure
+        // range and this descriptor must remain non-pure. Otherwise CSE can
+        // forward the preamble's guarded-zero value into the loop body and
+        // `optimize_guard_false` deletes the body's poll, leaving compiled
+        // loops unable to respond to signals or stop-the-world requests.
+        //
+        // Captured before the flush/materialize below so the guard snapshot
+        // reflects the pre-close loop-body state. A zero address means the
+        // poll is simply not recorded; startup publishes it before tracing.
+        let eb_addr = majit_ir::eval_breaker_word::eval_breaker_word_addr();
+        if eb_addr != 0 {
+            let base = ctx.const_int(eb_addr as i64);
+            let offset = ctx.const_int(0);
+            let word = ctx.record_op_with_descr(
+                OpCode::RawLoadI,
+                &[base, offset],
+                eval_breaker_word_descr(),
+            );
+            let armed = ctx.record_op(OpCode::IntIsTrue, &[word]);
+            self.generate_guard(ctx, OpCode::GuardFalse, &[armed]);
+        }
         // pyjitpl.py:2954-2965 reached_loop_header: virtualizable_boxes
         // (read from locals_cells_stack_w[*] by virtualizable.py:86-98
         // read_boxes) are carried into the JUMP unchanged, including

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -15,10 +15,21 @@ use majit_metainterp::{
 
 use pyre_interpreter::bytecode::{BinaryOperator, CodeObject, ComparisonOperator, Instruction};
 
+/// Descriptor for the back-edge poll's load of the eval-breaker word.
+///
+/// Mirrors `rffi.CArray(Signed)`: the load is exactly as wide as the word it
+/// reads, taking the width from the word itself rather than restating it.
 fn eval_breaker_word_descr() -> DescrRef {
     static DESCR: OnceLock<DescrRef> = OnceLock::new();
     DESCR
-        .get_or_init(|| majit_ir::descr::make_array_descr_signed(0, 8, Type::Int, true))
+        .get_or_init(|| {
+            majit_ir::descr::make_array_descr_signed(
+                0,
+                majit_ir::eval_breaker_word::EVAL_BREAKER_WORD_SIZE,
+                Type::Int,
+                true,
+            )
+        })
         .clone()
 }
 

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -2558,8 +2558,8 @@ fn build_gc_global() {
     // Publish the eval-breaker word address before store_singleton flips the
     // GC-initialized flag (Release). A concurrent initializer that observes the
     // flag set (Acquire) early-returns above; ordering the publish first makes
-    // that observer also see a non-zero poll address, so its compiled
-    // GuardEvalBreaker ops are not baked inert.
+    // that observer also sees a non-zero address when recording the
+    // back-edge eval-breaker poll.
     majit_ir::eval_breaker_word::publish_addr();
     majit_gc::gc_sync::store_singleton(gc);
 }


### PR DESCRIPTION
Retires `GuardEvalBreaker` (gh#568) and records the back-edge eval-breaker poll as ordinary IR.

## Why the issue body changed first

**gh#568's original body prescribed a shape that is correctness-wrong, not merely stale.** It was written before #517 landed and asked for `getfield actionflag._ticker + int_lt + guard_false`. That shape gets hoisted out of the loop:

- Upstream asserts it in its own test — `rpython/jit/metainterp/optimizeopt/test/test_optimizeopt.py:1418-1436` `test_getfield_gc_nonpure_2`: a `getfield_gc_i(ConstPtr, mutable descr)` with no intervening store is present in the `preamble` and **absent from the `expected` loop body**.
- The heap cache is deliberately carried across the back-edge (`unroll.py:463-515`); nothing about a LABEL invalidates it.

A tight compiled loop would then never poll — Ctrl-C and STW would not interrupt it — and **no test would fail**. The issue body was rewritten with the correct shape and full citations before writing any code; the original is preserved in its edit history.

## What upstream actually does

`pypy/module/pypyjit/test_pypy_c/model.py:324-330` — the `--TICK--` template every PyPy trace test matches:

```
ticker0 = getfield_raw_i(#, descr=<FieldS pypysig_long_struct_inner.c_value .*>)
ticker_cond0 = int_lt(ticker0, 0)
guard_false(ticker_cond0, descr=...)
```

Three things follow, all of which make #517's design look better than it did:

1. **Upstream's ticker is itself a process-global raw word at a constant address** (`rpython/rlib/rsignal.py:97-99`), not an object field — the signal module rebinds the actionflag class (`pypy/module/signal/moduledef.py:67`) to one that reads through `pypysig_getaddr_occurred()`. So the #517 folded word is upstream-shaped; the arity-0 **opcode** was the only deviation.
2. The address getter is `elidable_function=True` (`rsignal.py:101-103`) so the address const-folds while the load stays non-pure. The elidable is on the address, not the load.
3. **No per-back-edge store in the shipping default.** `has_bytecode_counter` is set only by the thread module (`gil.py:22-23`); signal passes `use_bytecode_counter=False` (`moduledef.py:61-62`) because the C handler sets the ticker to -1. pyre matches this (`executioncontext.rs` `has_bytecode_counter` stays false). So "the setfield is what stops the hoist" is false — the op choice is.

## The change

`close_loop_args_at` now records:

```
RawLoadI(ConstInt(eval_breaker_word_addr), ConstInt(0))
IntIsTrue(word)
GuardFalse(armed)
```

The folded word is a bitmask (`EB_ASYNC|EB_STW`), so the compare is a nonzero test rather than `int_lt(_, 0)`. One load, one branch — the fold #517 measured is preserved.

`OpCode::GuardEvalBreaker` and the four backend legs that each materialized the address and hand-rolled load+cmp+branch are deleted. The address is now an operand, so the affected backend tests supply it directly rather than through the `set_addr_override_for_test` thread-local.

A zero address means the poll is not recorded. `init_gc_subsystem` → `build_gc_global` publishes it at startup, strictly before any trace is recorded; this replaces the backends' codegen-time addr==0 inert path.

## The load-bearing invariant

`is_always_pure(RawLoadI) == false` is the **single** barrier keeping the poll in the loop body. It is not belt-and-braces:

- `setup()` runs once per optimization run, not per label (`optimizer.rs:2509-2512`); neither heap.rs nor pure.rs has an `OpCode::Label` arm. **The back-edge protects nothing.**
- If the load were pure: `rewrite.rs:2350-2352` `postprocess(GuardFalse)` taints the preamble's value to constant 0 via `make_constant_arg`; the body's load would CSE-forward to it; `optimize_guard_false` (`rewrite.rs:675-690`) hits `if val == 0 { Remove }` — the body's poll is deleted.
- pyre has no volatile/uncacheable marker, so there would be no way to close that cliff again.

`RawLoadI` already sits above `ALWAYS_PURE_LAST` and `make_array_descr_signed` yields `is_pure: false`. `test_raw_load_i_stays_non_pure_for_eval_breaker_poll` pins it, because a future reclassification would kill the poll with no other test failing.

## Verification

| gate | result |
|---|---|
| `python3 pyre/check.py --backend dynasm` | **ALL PASSED 189/189** |
| `python3 pyre/check.py --backend cranelift` | **ALL PASSED 189/189** |
| `cargo check` (majit-ir, pyre-jit-trace, pyre-jit, dynasm) | clean |
| `cargo test -p majit-ir` incl. the new regression test | pass |

Unit tests cannot catch a dead poll, so two independent proofs were run against the release binary:

**Static — the poll survives optimization.** Disassembling `MAJIT_DUMP` output for a tight `while i < n` loop, the sequence appears **exactly twice** (preamble + peeled body), both against the same address:

```
movz x16, #0xc968
movk x16, #0x398, lsl #16
movk x16, #0x1,   lsl #32     ; x16 = eval-breaker word
ldr  x9,  [x16]               ; RawLoadI
tst  x9,  x9                  ; IntIsTrue
b.<cond>                      ; GuardFalse
```

Had it been CSE'd or hoisted, the body copy would be gone and only one would remain.

**Dynamic — a compiled tight loop still takes a signal.** A hot integer loop (`while True: i += 1`, no calls in the body) with a pending SIGALRM:

| | loops_compiled | guard_failures | outcome |
|---|---|---|---|
| JIT on | 1 | **1** | interrupted after 11,934,080 iterations |
| `PYRE_NO_JIT=1` control | 0 | 0 | interrupted after 2,048,173 iterations |

`guard_failures=1` is the poll firing. The 5.8x iteration gap confirms the loop was running compiled when the signal landed.

### A note on a transient fib_recursive failure

An earlier dynasm run failed `fib_recursive timeout (>5s)`. It is a load artifact of running both backend suites concurrently on a box at load 16–30 that also had two other worktrees' check.py running. Direct runs measure 1.35–2.53s (CPython 1.67s). The tracer change is backend-shared, and cranelift passed the same benchmark at 1.89s at the same moment; the dynasm-only re-run is 189/189 with fib_recursive at 1.38s. Only one loop trace is compiled for that benchmark, so the change adds three instructions to a single back-edge.

## Second commit: dropping the now-dead x24 reservation

`aarch64: drop the now-unused eval-breaker address register` removes what the first commit orphaned: the `BITMASK_ADDR_REG` reservation, the once-per-trace-entry address bake, the prologue/epilogue save+restore, and the `CALL_FRAME_SIZE`/`X24_SAVE_OFFSET` constants added in #571. The entry frame returns to the 48 bytes it used before #517.

**Correcting something I claimed earlier in this PR:** I had said un-reserving x24 changes register allocation and so needed to be a separate slice. That is wrong — x24 was never in `ALL_REGS` (upstream `all_regs = registers[:14] + [x19, x20]`, plus the x21/x22 pair pyre enables), so the "reservation" never took anything from the allocator. It frees no register and changes no allocation; it only deletes per-trace-entry work and 16 bytes of frame.

`set_addr_override_for_test` also loses its last caller. That thread-local existed only because the backends read the address at codegen time, where a test could not reach it; as a constant operand, a test simply supplies its own address.

Verified: dynasm check.py **191/191**. The prologue disassembles to `stp x29, x30, [sp, #-48]!` with zero x24 traffic in the trace, the poll still appears exactly twice, and the SIGALRM proof still reports `loops_compiled=1 guard_failures=1`.

## wasm polls too — after fixing a width bug this PR introduced

**Correcting a claim I published in this PR before I had evidence for it.** I wrote that "the lowering is safe and precedented" on wasm. It was not: as first pushed, this PR **miscompiled every wasm trace**. Two wasm benches failed (`synth/attr_cache_invalidation` printed 4238880 instead of 3400000; `synth/residual_raise_except_resume` ran 0.34s). I had asserted the wasm story rather than tested it.

Root cause: the poll's load descriptor hard-coded item size 8, but the word is an `AtomicUsize` — **4 bytes on wasm32**. `EVAL_BREAKER_WORD_ADDR` is declared directly after the word and is non-zero once published, so the 8-byte load pulled it into the high half, `IntIsTrue` was always true, and **every back-edge guard failed**. Both wasm symptoms were that one cause.

The fix takes the width from the word itself (`EVAL_BREAKER_WORD_SIZE`), mirroring `rffi.CArray(Signed)`. The word stays pointer-width rather than a fixed `u64`: a 64-bit atomic RMW on a 32-bit target can lower to a locking libcall, which would break the documented `fetch_or` lock-free ⇒ async-signal-safe invariant (`set_async` runs in a signal handler).

Fixing the descriptor alone was not enough — the wasm backend's `RawLoadI`/`RawStore` **ignored the descr item size entirely** and always emitted `i64_load`/`i64_store`. That is a **pre-existing bug independent of this PR**, reachable from `BC_RAW_LOAD_I`/`BC_RAW_STORE_I`, which record itemsize 1/2/4/8 — so any narrow Python-level raw access miscompiled on wasm, and a narrow raw store corrupted memory. Both now use the same `emit_sized_int_load`/`emit_sized_int_store` helpers the array paths already used; their size-8 arms emit exactly the previous instructions, so item size 8 is untouched.

So wasm does keep the poll — the conclusion I reached prematurely turns out right, but for a reason I had not established.

## What I had never actually tested

The SIGALRM proof only showed the poll **fires**. It never showed a deopt **resuming and finishing correctly**. Closing that gap: a repeating `setitimer(0.005, 0.005)` over a 200M-iteration `while i < N: total += i`, checked against the closed form.

- dynasm: `handler_fired=70`, `guard_failures=71` (70 polls + 1 loop-exit), sum exact
- cranelift: `handler_fired=77`, `guard_failures=77`, sum exact

One signal produces exactly one poll deopt, with no re-executed or skipped iteration.

## Gates

- dynasm **191/191**, cranelift **191/191**
- wasm **189 passed, 1 failed** — `synth/residual_raise_except_resume` 0.21s vs a `max-pypy-ratio=10` gate (0.1s). **Pre-existing, not this PR**: with the poll emit fully suppressed the same bench still runs **0.20s / 20.2x** and still fails. The poll accounts for ~5% (0.20s → 0.21s). wasm routinely runs 20–40x pypy on benches that pass only because they declare no ratio; this gate is not reachable on wasm. Filed as #588.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Updated JIT eval-breaker polling to lazily guard based on an “armed” bit derived from the global word value.
  - Improved loop-back-edge handling to use the new polling/guard sequence consistently.

- **Bug Fixes**
  - Fixed WebAssembly raw array loads/stores to use per-element sizing, preventing adjacent overwrites on wasm32.
  - Improved interruption/eval-breaker deoptimization behavior, including correct behavior after clearing and reuse across traces.

- **Documentation**
  - Refreshed comments describing the back-edge eval-breaker poll and related guard snapshots.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->