### PR TITLE
jit: #73 — result-color trivia twin, guard-snapshot JitCode-coordinate decline, guard-kept reads onto jitcode twins

### DIFF
--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -2912,6 +2912,8 @@ fn compute_bridge_root_parent_frame(
         // identical liveness window. `PYRE_M73_OUTERCAP_CARRY=0` falls back to
         // the sentinel-based decode path.
         root_liveness_word,
+        OuterActiveBoxesEntryTwin::Trivia,
+        "bridge_root_parent",
         None,
         &[],
     );
@@ -3729,6 +3731,8 @@ pub fn dispatch_via_miframe_at_opcode_entry<'a>(
         entry_py_pc,
         None,
         majit_ir::resumedata::NO_JITCODE_PC,
+        OuterActiveBoxesEntryTwin::PyPc,
+        "opcode_entry",
         None,
         &[],
     );
@@ -7375,6 +7379,96 @@ fn opref_is_null_const_ptr(op: OpRef) -> bool {
     op.as_const_ptr().is_some_and(|g| g.is_null())
 }
 
+/// The source selected for `collect_outer_active_boxes` entry metadata.  The
+/// audit compares the JitCode-PC variants to the legacy Python-PC tables;
+/// `PyPc` keeps a caller deferred after its census diverged or did not fire.
+#[derive(Clone, Copy)]
+enum OuterActiveBoxesEntryTwin {
+    PyPc,
+    Plain,
+    Trivia,
+}
+
+impl OuterActiveBoxesEntryTwin {
+    fn name(self) -> &'static str {
+        match self {
+            Self::PyPc => "py_pc",
+            Self::Plain => "plain",
+            Self::Trivia => "trivia",
+        }
+    }
+}
+
+/// `PYRE_PCMAP_ENTRY_AUDIT` certifies an entry Python-PC read against the
+/// carried JitCode coordinate for one `collect_outer_active_boxes` caller.
+/// `PYRE_PCMAP_ENTRY_AUDIT_PROBE`, when set, receives one line per assertion
+/// attempt because check.py discards diagnostic stderr.
+fn audit_outer_active_boxes_entry_twin(
+    payload: &crate::pyjitcode::PyJitCode,
+    entry_py_pc: u32,
+    carried_jitcode_pc: i32,
+    twin: OuterActiveBoxesEntryTwin,
+    caller: &'static str,
+) {
+    if !pcmap_entry_audit_enabled()
+        || carried_jitcode_pc < 0
+        || matches!(twin, OuterActiveBoxesEntryTwin::PyPc)
+    {
+        return;
+    }
+    let cjc = carried_jitcode_pc as usize;
+    if let Some(path) = std::env::var_os("PYRE_PCMAP_ENTRY_AUDIT_PROBE") {
+        use std::io::Write;
+
+        if let Ok(mut probe) = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(path)
+        {
+            let _ = writeln!(probe, "{caller}\t{}", twin.name());
+        }
+    }
+    let table_pcdep = payload
+        .metadata
+        .pcdep_color_slots
+        .get(entry_py_pc as usize)
+        .cloned()
+        .unwrap_or_default();
+    let (twin_pcdep, twin_depth) = match twin {
+        OuterActiveBoxesEntryTwin::PyPc => unreachable!("legacy source returns before audit"),
+        OuterActiveBoxesEntryTwin::Plain => (
+            payload.pcdep_for_jitcode_pc(cjc).unwrap_or_default(),
+            payload.depth_for_jitcode_pc_pred(cjc).unwrap_or(0),
+        ),
+        OuterActiveBoxesEntryTwin::Trivia => (
+            payload
+                .pcdep_trivia_for_jitcode_pc(cjc)
+                .map(ToOwned::to_owned)
+                .unwrap_or_default(),
+            payload.depth_trivia_for_jitcode_pc(cjc).unwrap_or(0),
+        ),
+    };
+    assert_eq!(
+        twin_pcdep,
+        table_pcdep,
+        "PCMAP_ENTRY pcdep mismatch caller={caller} flavor={} cjc={cjc} entry_py_pc={entry_py_pc}",
+        twin.name(),
+    );
+    if !payload.code_ptr.is_null() {
+        let table_depth = crate::liveness::liveness_for(payload.code_ptr)
+            .depth_at_py_pc()
+            .get(entry_py_pc as usize)
+            .copied()
+            .unwrap_or(0);
+        assert_eq!(
+            twin_depth,
+            table_depth,
+            "PCMAP_ENTRY depth mismatch caller={caller} flavor={} cjc={cjc} entry_py_pc={entry_py_pc}",
+            twin.name(),
+        );
+    }
+}
+
 fn collect_outer_active_boxes(
     sym: &crate::state::PyreSym,
     trace_ctx: &mut TraceCtx,
@@ -7385,6 +7479,8 @@ fn collect_outer_active_boxes(
     entry_py_pc: u32,
     guard_py_pc: Option<u32>,
     carried_jitcode_pc: i32,
+    entry_twin: OuterActiveBoxesEntryTwin,
+    entry_caller: &'static str,
     vstack: Option<&[OpRef]>,
     kept_recovered: &[(u16, OpRef)],
 ) -> Vec<OpRef> {
@@ -7425,25 +7521,42 @@ fn collect_outer_active_boxes(
             unsafe {
                 let jc = &*sym.jitcode;
                 let payload = &jc.payload;
-                // Operand-stack depth AT the snapshot's `entry_py_pc`.  The
-                // liveness banks (`frame_liveness_reg_indices_by_bank_at`) are
-                // read at that py_pc, so the per-PC color→slot window
-                // (`pcdep_opt`'s stack clamp below) must be the depth at that
-                // py_pc too — NOT `sym.valuestackdepth` (the walker's *current*
-                // position).  For the per-opcode entry caller the two coincide,
-                // but a guard resuming at a not-taken branch target with a kept
-                // operand-stack temp (conditional expr / short-circuit / chained
-                // compare, #124/#281) resumes at a py_pc whose depth `> 0` while
-                // the walker stands at depth 0 — using the current depth there
-                // drops the kept temp's semantic slot, corrupting the frame.
+                audit_outer_active_boxes_entry_twin(
+                    payload,
+                    entry_py_pc,
+                    carried_jitcode_pc,
+                    entry_twin,
+                    entry_caller,
+                );
+                // Operand-stack depth at the snapshot coordinate. The liveness
+                // banks (`frame_liveness_reg_indices_by_bank_at`) are read at
+                // that coordinate too, so the per-PC color→slot window
+                // (`pcdep_opt`'s stack clamp below) must use its depth — NOT
+                // `sym.valuestackdepth` (the walker's *current* position). For
+                // the per-opcode entry caller the two coincide, but a guard
+                // resuming at a not-taken branch target with a kept operand-stack
+                // temp (conditional expr / short-circuit / chained compare,
+                // #124/#281) resumes at a depth `> 0` while the walker stands at
+                // depth 0 — using the current depth there drops the kept temp's
+                // semantic slot, corrupting the frame.
                 let stack_depth_at_pc = if payload.code_ptr.is_null() {
                     0usize
                 } else {
-                    crate::liveness::liveness_for(payload.code_ptr)
-                        .depth_at_py_pc()
-                        .get(entry_py_pc as usize)
-                        .copied()
-                        .unwrap_or(0) as usize
+                    match (entry_twin, carried_jitcode_pc >= 0) {
+                        (OuterActiveBoxesEntryTwin::Plain, true) => payload
+                            .depth_for_jitcode_pc_pred(carried_jitcode_pc as usize)
+                            .unwrap_or(0)
+                            as usize,
+                        (OuterActiveBoxesEntryTwin::Trivia, true) => payload
+                            .depth_trivia_for_jitcode_pc(carried_jitcode_pc as usize)
+                            .unwrap_or(0)
+                            as usize,
+                        _ => crate::liveness::liveness_for(payload.code_ptr)
+                            .depth_at_py_pc()
+                            .get(entry_py_pc as usize)
+                            .copied()
+                            .unwrap_or(0) as usize,
+                    }
                 };
                 (
                     sym.nlocals,
@@ -7454,7 +7567,7 @@ fn collect_outer_active_boxes(
                 )
             }
         };
-    // #348: per-PC color→slot entries at the snapshot PC — the color→slot source
+    // #348: per-snapshot-coordinate color→slot entries — the color→slot source
     // the inversions below consult for every drained (non-portal) jitcode, the
     // per-program-point color space the `-live-` markers carry. Branch-guard
     // resumes (`guard_py_pc.is_some()`) are fully covered here; a per-opcode-entry
@@ -7470,12 +7583,24 @@ fn collect_outer_active_boxes(
     } else {
         unsafe {
             let jc = &*sym.jitcode;
-            jc.payload
-                .metadata
-                .pcdep_color_slots
-                .get(entry_py_pc as usize)
-                .cloned()
-                .unwrap_or_default()
+            match (entry_twin, carried_jitcode_pc >= 0) {
+                (OuterActiveBoxesEntryTwin::Plain, true) => jc
+                    .payload
+                    .pcdep_for_jitcode_pc(carried_jitcode_pc as usize)
+                    .unwrap_or_default(),
+                (OuterActiveBoxesEntryTwin::Trivia, true) => jc
+                    .payload
+                    .pcdep_trivia_for_jitcode_pc(carried_jitcode_pc as usize)
+                    .map(ToOwned::to_owned)
+                    .unwrap_or_default(),
+                _ => jc
+                    .payload
+                    .metadata
+                    .pcdep_color_slots
+                    .get(entry_py_pc as usize)
+                    .cloned()
+                    .unwrap_or_default(),
+            }
         }
     };
     let pcdep_opt: Option<&[(u8, u16, u16)]> =
@@ -10649,6 +10774,15 @@ pub(crate) fn pcmap_guard_kept_audit_enabled() -> bool {
     *ENABLED.get_or_init(|| std::env::var_os("PYRE_PCMAP_GUARD_KEPT_AUDIT").is_some())
 }
 
+/// `PYRE_PCMAP_ENTRY_AUDIT` enables assertions that each carried
+/// `collect_outer_active_boxes` entry coordinate's selected JitCode-PC twin
+/// reproduces the Python-PC depth and pcdep reads. Diagnostic only; off in
+/// production.
+fn pcmap_entry_audit_enabled() -> bool {
+    static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ENABLED.get_or_init(|| std::env::var_os("PYRE_PCMAP_ENTRY_AUDIT").is_some())
+}
+
 /// `PYRE_M73_PEROP_CARRY` (#73 S2, default ON): source a specialization
 /// guard's (`GuardValue`/`GuardClass`) resume coordinate from the walk
 /// cursor's per-op `-live-` BEFORE anchor (`ctx.live_before_jit_pc`,
@@ -12487,6 +12621,16 @@ fn walker_capture_snapshot_for_last_guard_impl(
                 }
                 None => liveness_py_pc,
             };
+            let (entry_twin, entry_caller) = if guard_py_pc.is_some() {
+                (OuterActiveBoxesEntryTwin::Plain, "guard_snapshot_guard_pc")
+            } else {
+                (
+                    // Both plain and trivia twins diverged from this
+                    // fallthrough coordinate in the entry census.
+                    OuterActiveBoxesEntryTwin::PyPc,
+                    "guard_snapshot_fallthrough",
+                )
+            };
             let active = collect_outer_active_boxes(
                 sym,
                 ctx.trace_ctx,
@@ -12497,6 +12641,8 @@ fn walker_capture_snapshot_for_last_guard_impl(
                 liveness_py_pc,
                 guard_py_pc,
                 guard_jitcode_pc,
+                entry_twin,
+                entry_caller,
                 ctx.vstack_valid.then_some(ctx.vstack_boxes.as_slice()),
                 scope.branch_guard_kept_recovered,
             );
@@ -12798,6 +12944,8 @@ fn compute_inline_caller_frame(
         fallthrough_py_pc,
         None,
         caller_liveness_word,
+        OuterActiveBoxesEntryTwin::Trivia,
+        "inline_caller",
         None,
         &[],
     );
@@ -15505,6 +15653,10 @@ fn try_walker_inline_user_call(
                     call_site_py_pc,
                     None,
                     call_site_word,
+                    // The trivia twin diverged at this capture coordinate in
+                    // the entry census.
+                    OuterActiveBoxesEntryTwin::PyPc,
+                    "call_site_capture",
                     None,
                     &[],
                 );
@@ -20265,6 +20417,9 @@ fn orthodox_list_append_commit(
         call_site_py_pc,
         None,
         call_site_word,
+        // This caller did not fire in the entry census.
+        OuterActiveBoxesEntryTwin::PyPc,
+        "w_list_append_call_site",
         None,
         &[],
     );

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -2863,18 +2863,29 @@ fn compute_bridge_root_parent_frame(
         .bridge_registers_r
         .clone()
         .unwrap_or_else(|| root_sym.registers_r.clone());
-    let root_py_pc = crate::state::backxlat_py_pc(jitcode_index as i32, root_pc as i32) as usize;
     if result_color_audit_enabled() {
         let payload = unsafe { &(*root_sym.jitcode).payload };
+        let root_py_pc =
+            crate::state::backxlat_py_pc(jitcode_index as i32, root_pc as i32) as usize;
         let py_pc = python_pc_for_jitcode_pc(&payload.metadata, root_pc) as usize;
         assert_eq!(
             payload.result_color_for_jitcode_pc_pred(root_pc),
             payload.metadata.result_color_at_pc.get(py_pc).copied(),
             "result_color_by_jit_pc diverges from result_color_at_pc at jit_pc={root_pc}"
         );
+        assert_eq!(
+            payload
+                .result_color_trivia_for_jitcode_pc(root_pc)
+                .map(|c| c as usize)
+                .filter(|&c| c != u16::MAX as usize),
+            crate::state::result_color_at_pc_at(jitcode_index as i32, root_py_pc),
+            "result_color trivia twin vs backxlat consumer diverges at jit_pc={root_pc}"
+        );
     }
-    if let Some(result_color) =
-        crate::state::result_color_at_pc_at(jitcode_index as i32, root_py_pc)
+    if let Some(result_color) = unsafe { &(*root_sym.jitcode).payload }
+        .result_color_trivia_for_jitcode_pc(root_pc)
+        .map(|c| c as usize)
+        .filter(|&c| c != u16::MAX as usize)
     {
         if result_color < regs_r.len() {
             regs_r[result_color] = trace_ctx.const_ref(pyre_object::PY_NULL as i64);

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -7488,15 +7488,57 @@ fn collect_outer_active_boxes(
             } else {
                 unsafe {
                     let jc = &*sym.jitcode;
-                    let entries = jc
-                        .payload
-                        .metadata
-                        .pcdep_color_slots
-                        .get(gpc as usize)
-                        .cloned()
-                        .unwrap_or_default();
+                    let cjc = carried_jitcode_pc;
+                    if pcmap_guard_kept_audit_enabled() && cjc >= 0 {
+                        let twin_pcdep = jc
+                            .payload
+                            .pcdep_for_jitcode_pc(cjc as usize)
+                            .unwrap_or_default();
+                        let table_pcdep = jc
+                            .payload
+                            .metadata
+                            .pcdep_color_slots
+                            .get(gpc as usize)
+                            .cloned()
+                            .unwrap_or_default();
+                        assert_eq!(
+                            twin_pcdep, table_pcdep,
+                            "PCMAP_COAB pcdep mismatch cjc={cjc} gpc={gpc}"
+                        );
+                        if !jc.payload.code_ptr.is_null() {
+                            let twin_d = jc
+                                .payload
+                                .depth_for_jitcode_pc_pred(cjc as usize)
+                                .unwrap_or(0);
+                            let table_d = crate::liveness::liveness_for(jc.payload.code_ptr)
+                                .depth_at_py_pc()
+                                .get(gpc as usize)
+                                .copied()
+                                .unwrap_or(0);
+                            assert_eq!(
+                                twin_d, table_d,
+                                "PCMAP_COAB depth mismatch cjc={cjc} gpc={gpc}"
+                            );
+                        }
+                    }
+                    let entries = if cjc >= 0 {
+                        jc.payload
+                            .pcdep_for_jitcode_pc(cjc as usize)
+                            .unwrap_or_default()
+                    } else {
+                        jc.payload
+                            .metadata
+                            .pcdep_color_slots
+                            .get(gpc as usize)
+                            .cloned()
+                            .unwrap_or_default()
+                    };
                     let depth = if jc.payload.code_ptr.is_null() {
                         0usize
+                    } else if cjc >= 0 {
+                        jc.payload
+                            .depth_for_jitcode_pc_pred(cjc as usize)
+                            .unwrap_or(0) as usize
                     } else {
                         crate::liveness::liveness_for(jc.payload.code_ptr)
                             .depth_at_py_pc()

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -11661,23 +11661,20 @@ fn walker_capture_inline_nonstandard_vable_guard(
     // re-executing the whole call on deopt — sound for the side-effect-free
     // leaves this path inlines (the non-standard identity guard is itself
     // deterministic and never fails at runtime).
-    let (vable_boxes, vref_boxes) = ctx.trace_ctx.build_snapshot_vable_vref_boxes();
-    // The non-standard identity guard resumes at the caller's CALL
-    // boundary (`entry_py_pc`), re-executing the whole call on deopt —
-    // there is no kept-stack JitCode coordinate to preserve, so the
-    // frame resumes through the Python pc → jitcode resume-translation path.
-    // This sentinel-twin writer is corpus-untested.
+    // The non-standard identity guard has no representable JitCode resume
+    // coordinate: its carried word is the sentinel, so decline rather than
+    // publishing the caller's Python pc as a JitCode offset.
     let nsvable_word = majit_ir::resumedata::NO_JITCODE_PC;
-    let nsvable_pc_word = crate::state::pyjitcode_for_jitcode_index(ctx.outer_jitcode_index as i32)
-        .and_then(|payload| {
-            payload.resolve_resume_pc_with_jitcode_pc(
-                ctx.entry_py_pc as i32,
-                nsvable_word,
-                crate::state::op_live(),
-            )
-        })
-        .map(|offset| offset as u32)
-        .unwrap_or(ctx.entry_py_pc);
+    let Some(nsvable_pc_word) =
+        crate::state::pyjitcode_for_jitcode_index(ctx.outer_jitcode_index as i32)
+            .and_then(|payload| {
+                payload.resolve_resume_pc_with_jitcode_pc(nsvable_word, crate::state::op_live())
+            })
+            .map(|offset| offset as u32)
+    else {
+        return Err(DispatchError::GuardResumeCoordinateUnavailable { pc: op_pc });
+    };
+    let (vable_boxes, vref_boxes) = ctx.trace_ctx.build_snapshot_vable_vref_boxes();
     ctx.trace_ctx
         .capture_snapshot_for_last_guard_op_with_vable_vref(
             &ctx.outer_active_boxes,
@@ -12409,14 +12406,12 @@ fn walker_capture_snapshot_for_last_guard_impl(
                 scope.branch_guard_kept_recovered,
             );
             let payload = unsafe { &(&*sym.jitcode).payload };
-            let pc_word = payload
-                .resolve_resume_pc_with_jitcode_pc(
-                    resume_py_pc as i32,
-                    guard_jitcode_pc,
-                    crate::state::op_live(),
-                )
+            let Some(pc_word) = payload
+                .resolve_resume_pc_with_jitcode_pc(guard_jitcode_pc, crate::state::op_live())
                 .map(|offset| offset as u32)
-                .unwrap_or(resume_py_pc);
+            else {
+                return Err(DispatchError::GuardResumeCoordinateUnavailable { pc: op_pc });
+            };
             ctx.trace_ctx
                 .capture_snapshot_for_last_guard_with_vable_vref(
                     &active,
@@ -12429,11 +12424,9 @@ fn walker_capture_snapshot_for_last_guard_impl(
         }
     }
 
-    // Per-opcode arm path: `op_pc` (arm-local PC) is not a blackhole
-    // resume point, so the snapshot uses the static outer coordinate and
-    // resumes via the Python pc → jitcode resume-translation path (no JitCode
-    // coordinate).
-    let _ = op_pc;
+    // Per-opcode arm path: `op_pc` is arm-local, so its snapshot must use
+    // the carried static outer JitCode coordinate; an absent coordinate
+    // declines instead of reconstructing one from the Python pc.
     let (vable_boxes, vref_boxes) = ctx.trace_ctx.build_snapshot_vable_vref_boxes();
     let arm_word = if m73_armpath_carry_enabled() {
         ctx.outer_resume_marker_jit_pc
@@ -12442,16 +12435,15 @@ fn walker_capture_snapshot_for_last_guard_impl(
     } else {
         majit_ir::resumedata::NO_JITCODE_PC
     };
-    let arm_pc_word = crate::state::pyjitcode_for_jitcode_index(ctx.outer_jitcode_index as i32)
-        .and_then(|payload| {
-            payload.resolve_resume_pc_with_jitcode_pc(
-                ctx.entry_py_pc as i32,
-                arm_word,
-                crate::state::op_live(),
-            )
-        })
-        .map(|offset| offset as u32)
-        .unwrap_or(ctx.entry_py_pc);
+    let Some(arm_pc_word) =
+        crate::state::pyjitcode_for_jitcode_index(ctx.outer_jitcode_index as i32)
+            .and_then(|payload| {
+                payload.resolve_resume_pc_with_jitcode_pc(arm_word, crate::state::op_live())
+            })
+            .map(|offset| offset as u32)
+    else {
+        return Err(DispatchError::GuardResumeCoordinateUnavailable { pc: op_pc });
+    };
     ctx.trace_ctx
         .capture_snapshot_for_last_guard_with_vable_vref(
             &ctx.outer_active_boxes,
@@ -13013,11 +13005,7 @@ fn walker_capture_multi_frame_inline_snapshot(
         };
         let Some(pf_pc_word) = crate::state::pyjitcode_for_jitcode_index(pf.jitcode_index as i32)
             .and_then(|payload| {
-                payload.resolve_resume_pc_with_jitcode_pc(
-                    pf.resume_py_pc as i32,
-                    pf_word,
-                    crate::state::op_live(),
-                )
+                payload.resolve_resume_pc_with_jitcode_pc(pf_word, crate::state::op_live())
             })
             .map(|offset| offset as u32)
         else {
@@ -25343,10 +25331,38 @@ mod tests {
     use majit_ir::Type;
     use majit_metainterp::make_fail_descr;
 
+    /// Install the minimal `-live-`-anchored outer JitCode required by
+    /// per-opcode guard tests. Production obtains this coordinate from the
+    /// codewriter; these isolated dispatcher fixtures supply the same shape.
+    fn test_outer_resume_jitcode_index() -> u32 {
+        thread_local! {
+            static INDEX: std::cell::Cell<Option<u32>> = const { std::cell::Cell::new(None) };
+        }
+        if let Some(index) = INDEX.with(|slot| slot.get()) {
+            return index;
+        }
+        let runtime_jc = majit_metainterp::jitcode::JitCode::new("guard_resume_test");
+        runtime_jc.set_body(majit_translate::jitcode::JitCodeBody {
+            code: vec![crate::state::op_live(), 0, 0],
+            startpoints: Some([0_usize].into_iter().collect()),
+            ..Default::default()
+        });
+        let mut pyjit = crate::PyJitCode::skeleton(std::ptr::null());
+        pyjit.jitcode = std::sync::Arc::new(runtime_jc);
+        pyjit.metadata.is_drained = true;
+        let jitcode =
+            crate::state::install_jitcode_for(std::ptr::null(), std::sync::Arc::new(pyjit))
+                as *const crate::state::JitCode;
+        let index = unsafe { (*jitcode).index as u32 };
+        INDEX.with(|slot| slot.set(Some(index)));
+        index
+    }
+
     /// Build a fresh `TraceCtx`. Uses the public `for_test_types` +
     /// `const_ref` / `make_fail_descr` factories so the fixture stays
     /// out of `pub(crate)` API.
     fn fresh_trace_ctx() -> TraceCtx {
+        let _ = test_outer_resume_jitcode_index();
         TraceCtx::for_test_types(&[Type::Ref])
     }
 
@@ -28272,6 +28288,8 @@ mod tests {
         };
         // `raise/r` emits the GuardClass during dispatch, then surfaces
         // `SubRaise`; `walk()`'s top-level SubRaise arm records the FINISH.
+        wc.outer_jitcode_index = test_outer_resume_jitcode_index();
+        wc.outer_resume_marker_jit_pc = Some(0);
         let (outcome, _next_pc) = walk(&code, 0, &mut wc).expect("raise/r must dispatch");
         assert_eq!(outcome, DispatchOutcome::Terminate);
         drop(wc);
@@ -30451,6 +30469,8 @@ mod tests {
             live_before_jit_pc: usize::MAX,
             live_after_jit_pc: usize::MAX,
         };
+        wc.outer_jitcode_index = test_outer_resume_jitcode_index();
+        wc.outer_resume_marker_jit_pc = Some(0);
         let (outcome, next_pc) =
             step(&code, 0, &mut wc).expect("ref_guard_value must record GuardValue");
         assert!(matches!(outcome, DispatchOutcome::Continue));
@@ -30638,6 +30658,8 @@ mod tests {
             live_before_jit_pc: usize::MAX,
             live_after_jit_pc: usize::MAX,
         };
+        wc.outer_jitcode_index = test_outer_resume_jitcode_index();
+        wc.outer_resume_marker_jit_pc = Some(0);
         let (outcome, next_pc) =
             step(&code, 0, &mut wc).expect("residual_call_r_r/iRd>r must dispatch");
         assert_eq!(outcome, DispatchOutcome::Continue);
@@ -30810,6 +30832,8 @@ mod tests {
             live_before_jit_pc: usize::MAX,
             live_after_jit_pc: usize::MAX,
         };
+        wc.outer_jitcode_index = test_outer_resume_jitcode_index();
+        wc.outer_resume_marker_jit_pc = Some(0);
         let _ = step(&code, 0, &mut wc).expect("residual_call_r_r/iRd>r must dispatch");
         drop(wc);
         assert_eq!(
@@ -31455,6 +31479,8 @@ mod tests {
             live_before_jit_pc: usize::MAX,
             live_after_jit_pc: usize::MAX,
         };
+        wc.outer_jitcode_index = test_outer_resume_jitcode_index();
+        wc.outer_resume_marker_jit_pc = Some(0);
         let _ = step(&code, 0, &mut wc).expect("residual_call_r_r/iRd>r must dispatch");
         drop(wc);
         assert_eq!(
@@ -31527,6 +31553,8 @@ mod tests {
             live_before_jit_pc: usize::MAX,
             live_after_jit_pc: usize::MAX,
         };
+        wc.outer_jitcode_index = test_outer_resume_jitcode_index();
+        wc.outer_resume_marker_jit_pc = Some(0);
         let _ = step(&code, 0, &mut wc).expect("residual_call_r_r/iRd>r must dispatch");
         drop(wc);
         assert_eq!(
@@ -31601,6 +31629,8 @@ mod tests {
             live_before_jit_pc: usize::MAX,
             live_after_jit_pc: usize::MAX,
         };
+        wc.outer_jitcode_index = test_outer_resume_jitcode_index();
+        wc.outer_resume_marker_jit_pc = Some(0);
         let _ = step(&code, 0, &mut wc).expect("residual_call_r_r/iRd>r must dispatch");
         // The dst slot must hold the OpRef of the recorded CallR. Each
         // Op carries its OpRef in `op.pos` (recorder.rs:159), which lets
@@ -31695,6 +31725,8 @@ mod tests {
             live_before_jit_pc: usize::MAX,
             live_after_jit_pc: usize::MAX,
         };
+        wc.outer_jitcode_index = test_outer_resume_jitcode_index();
+        wc.outer_resume_marker_jit_pc = Some(0);
         let _ = step(&code, 0, &mut wc).expect("residual_call_r_r/iRd>r must dispatch");
         drop(wc);
         let opcodes: Vec<_> = tc.ops().iter().skip(ops_before).map(|o| o.opcode).collect();
@@ -31778,6 +31810,8 @@ mod tests {
             live_before_jit_pc: usize::MAX,
             live_after_jit_pc: usize::MAX,
         };
+        wc.outer_jitcode_index = test_outer_resume_jitcode_index();
+        wc.outer_resume_marker_jit_pc = Some(0);
         let _ = step(&code, 0, &mut wc).expect("residual_call_ir_r/iIRd>r must dispatch");
         drop(wc);
         let opcodes: Vec<_> = tc.ops().iter().skip(ops_before).map(|o| o.opcode).collect();
@@ -32026,6 +32060,8 @@ mod tests {
             live_before_jit_pc: usize::MAX,
             live_after_jit_pc: usize::MAX,
         };
+        wc.outer_jitcode_index = test_outer_resume_jitcode_index();
+        wc.outer_resume_marker_jit_pc = Some(0);
         let (outcome, next_pc) =
             step(&code, 0, &mut wc).expect("residual_call_r_i/iRd>i must dispatch");
         assert_eq!(outcome, DispatchOutcome::Continue);
@@ -32234,6 +32270,8 @@ mod tests {
             live_before_jit_pc: usize::MAX,
             live_after_jit_pc: usize::MAX,
         };
+        wc.outer_jitcode_index = test_outer_resume_jitcode_index();
+        wc.outer_resume_marker_jit_pc = Some(0);
         let (outcome, next_pc) =
             step(&code, 0, &mut wc).expect("residual_call_ir_r/iIRd>r must dispatch");
         assert_eq!(outcome, DispatchOutcome::Continue);
@@ -32373,6 +32411,8 @@ mod tests {
             live_before_jit_pc: usize::MAX,
             live_after_jit_pc: usize::MAX,
         };
+        wc.outer_jitcode_index = test_outer_resume_jitcode_index();
+        wc.outer_resume_marker_jit_pc = Some(0);
         let _ = step(&code, 0, &mut wc).expect("residual_call_ir_r/iIRd>r must dispatch");
         drop(wc);
         let call_op = tc

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -11945,6 +11945,30 @@ fn walker_capture_snapshot_for_last_guard_impl(
             } else {
                 py_pc
             };
+            // `capture_resumedata(after_residual_call=True)` snapshots the
+            // trailing `-live-`, after the residual result has replaced the
+            // Python opcode's consumed operands (pyjitpl.py:177-198,
+            // opencoder.py:767-770).  The walk-level stack mirror normally
+            // applies that replacement only when `step_vstack_mirror` reaches
+            // the next Python opcode.  A guard emitted by the residual itself
+            // captures before that step, so advance the mirror here to the
+            // same post-call boundary before it supplies the vable snapshot.
+            // This is the same transition the following walk step would make;
+            // it merely makes the guard's resume image observe it at the
+            // required point.
+            if after_residual_call && ctx.vstack_valid {
+                let jc = unsafe { &*sym.jitcode };
+                let code_ptr = jc.payload.code_ptr;
+                if !code_ptr.is_null() {
+                    let resume_depth = crate::liveness::liveness_for(code_ptr)
+                        .depth_at_py_pc()
+                        .get(py_pc as usize)
+                        .copied()
+                        .unwrap_or(0) as usize;
+                    let code = unsafe { &*code_ptr };
+                    reconcile_vstack_at_boundary(ctx, code, py_pc, resume_depth);
+                }
+            }
             // Publish `last_instr = py_pc - 1` to the vable static shadow
             // before snapshotting.  The walker walks JitCode and never
             // crosses `set_orgpc`, so the `last_instr` scalar in

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -10598,11 +10598,10 @@ pub(crate) fn result_color_audit_enabled() -> bool {
     *ENABLED.get_or_init(|| std::env::var_os("PYRE_PCMAP_RESULT_AUDIT").is_some())
 }
 
-/// `PYRE_PCMAP_GUARD_KEPT_AUDIT` enables the guard-kept recovery census. It
-/// certifies the plain JitCode-PC pcdep twin before a later slice can retire
-/// the remaining Python-PC consumers; depth is reported as a probe because
-/// its predecessor twin intentionally differs at not-taken branch targets.
-/// Diagnostic only; off in production.
+/// `PYRE_PCMAP_GUARD_KEPT_AUDIT` enables assertions that the guard-kept
+/// recovery's plain JitCode-PC pcdep and predecessor-depth twins reproduce
+/// their Python-PC tables at the guard's own emitted opcode. Diagnostic only;
+/// off in production.
 pub(crate) fn pcmap_guard_kept_audit_enabled() -> bool {
     static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
     *ENABLED.get_or_init(|| std::env::var_os("PYRE_PCMAP_GUARD_KEPT_AUDIT").is_some())
@@ -12088,11 +12087,10 @@ fn walker_capture_snapshot_for_last_guard_impl(
                                 .get(gpc)
                                 .copied()
                                 .unwrap_or(0);
-                            if twin_d != table_d {
-                                eprintln!(
-                                    "PCMAP_GUARD_KEPT_DEPTH_DIVERGE gjc={gjc} gpc={gpc} twin={twin_d} table={table_d}"
-                                );
-                            }
+                            assert_eq!(
+                                twin_d, table_d,
+                                "PCMAP_GUARD_KEPT depth mismatch gjc={gjc} gpc={gpc}"
+                            );
                         }
                     }
                 }
@@ -12100,15 +12098,7 @@ fn walker_capture_snapshot_for_last_guard_impl(
                 let nvs = crate::virtualizable_gen::NUM_VABLE_SCALARS;
                 let depth = unsafe {
                     let jc = &*sym.jitcode;
-                    if jc.payload.code_ptr.is_null() {
-                        0usize
-                    } else {
-                        crate::liveness::liveness_for(jc.payload.code_ptr)
-                            .depth_at_py_pc()
-                            .get(gpc)
-                            .copied()
-                            .unwrap_or(0) as usize
-                    }
+                    jc.payload.depth_for_jitcode_pc_pred(gjc).unwrap_or(0) as usize
                 };
                 let pcdep: Vec<(u8, u16, u16)> = unsafe {
                     let jc = &*sym.jitcode;

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -10598,6 +10598,16 @@ pub(crate) fn result_color_audit_enabled() -> bool {
     *ENABLED.get_or_init(|| std::env::var_os("PYRE_PCMAP_RESULT_AUDIT").is_some())
 }
 
+/// `PYRE_PCMAP_GUARD_KEPT_AUDIT` enables the guard-kept recovery census. It
+/// certifies the plain JitCode-PC pcdep twin before a later slice can retire
+/// the remaining Python-PC consumers; depth is reported as a probe because
+/// its predecessor twin intentionally differs at not-taken branch targets.
+/// Diagnostic only; off in production.
+pub(crate) fn pcmap_guard_kept_audit_enabled() -> bool {
+    static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ENABLED.get_or_init(|| std::env::var_os("PYRE_PCMAP_GUARD_KEPT_AUDIT").is_some())
+}
+
 /// `PYRE_M73_PEROP_CARRY` (#73 S2, default ON): source a specialization
 /// guard's (`GuardValue`/`GuardClass`) resume coordinate from the walk
 /// cursor's per-op `-live-` BEFORE anchor (`ctx.live_before_jit_pc`,
@@ -12052,6 +12062,40 @@ fn walker_capture_snapshot_for_last_guard_impl(
                 && !sym.jitcode.is_null()
             {
                 let gpc = guard_py_pc.unwrap() as usize;
+                // `guard_py_pc` above is the plain JitCode-PC inversion (no
+                // Python-trivia skip), so the pcdep twin here must be the plain
+                // predecessor-keyed flavor too.
+                let gjc = scope.branch_guard_jitcode_pc.unwrap();
+                if pcmap_guard_kept_audit_enabled() {
+                    unsafe {
+                        let jc = &*sym.jitcode;
+                        let twin = jc.payload.pcdep_for_jitcode_pc(gjc).unwrap_or_default();
+                        let table = jc
+                            .payload
+                            .metadata
+                            .pcdep_color_slots
+                            .get(gpc)
+                            .cloned()
+                            .unwrap_or_default();
+                        assert_eq!(
+                            twin, table,
+                            "PCMAP_GUARD_KEPT pcdep mismatch gjc={gjc} gpc={gpc}"
+                        );
+                        if !jc.payload.code_ptr.is_null() {
+                            let twin_d = jc.payload.depth_for_jitcode_pc_pred(gjc).unwrap_or(0);
+                            let table_d = crate::liveness::liveness_for(jc.payload.code_ptr)
+                                .depth_at_py_pc()
+                                .get(gpc)
+                                .copied()
+                                .unwrap_or(0);
+                            if twin_d != table_d {
+                                eprintln!(
+                                    "PCMAP_GUARD_KEPT_DEPTH_DIVERGE gjc={gjc} gpc={gpc} twin={twin_d} table={table_d}"
+                                );
+                            }
+                        }
+                    }
+                }
                 let nlocals = sym.nlocals;
                 let nvs = crate::virtualizable_gen::NUM_VABLE_SCALARS;
                 let depth = unsafe {
@@ -12068,12 +12112,7 @@ fn walker_capture_snapshot_for_last_guard_impl(
                 };
                 let pcdep: Vec<(u8, u16, u16)> = unsafe {
                     let jc = &*sym.jitcode;
-                    jc.payload
-                        .metadata
-                        .pcdep_color_slots
-                        .get(gpc)
-                        .cloned()
-                        .unwrap_or_default()
+                    jc.payload.pcdep_for_jitcode_pc(gjc).unwrap_or_default()
                 };
                 let mut covered: std::collections::HashSet<usize> =
                     stack_sync.iter().map(|&(idx, _)| idx).collect();

--- a/pyre/pyre-jit-trace/src/pyjitcode.rs
+++ b/pyre/pyre-jit-trace/src/pyjitcode.rs
@@ -761,18 +761,13 @@ impl PyJitCode {
     /// data rather than reconstructing a coordinate from a Python pc.
     ///
     /// The encoder (box collection) and decoder (box count + setposition)
-    /// both funnel through this with identical `(raw_pc, carried, op_live)`,
+    /// both funnel through this with identical `(carried, op_live)`,
     /// so the chosen offset — and hence the live-box layout — is symmetric
     /// by construction.
     ///
     /// The carried word is preferred only when it is a `-live-`-anchored
     /// coordinate ([`JitCode::can_decode_live_vars`]).
-    pub fn resolve_resume_pc_with_jitcode_pc(
-        &self,
-        _raw_pc: i32,
-        carried: i32,
-        op_live: u8,
-    ) -> Option<usize> {
+    pub fn resolve_resume_pc_with_jitcode_pc(&self, carried: i32, op_live: u8) -> Option<usize> {
         // #73 S3.5: a depth-0 branch guard may carry its `orgpc` tagged into the
         // word's negative space; expand it to the block-head marker the baseline
         // would have carried before any offset use. No-op for offsets /

--- a/pyre/pyre-jit-trace/src/pyjitcode.rs
+++ b/pyre/pyre-jit-trace/src/pyjitcode.rs
@@ -148,6 +148,13 @@ pub struct PyJitCodeMetadata {
     pub const_ref_trivia_marker_by_jit_pc: Vec<(usize, Vec<(u16, i64)>)>,
     /// Predecessor-op-start tier of the trivia-aware `const_ref_slots_at_pc` twin.
     pub const_ref_trivia_pred_by_jit_pc: Vec<(usize, Vec<(u16, i64)>)>,
+    /// #73-core: trivia-aware twin of `result_color_at_pc`, split into the
+    /// SAME exact-marker / predecessor-op-start tiers as the depth-trivia
+    /// twin. Each entry records
+    /// `result_color_at_pc[skip_python_trivia_forward(py)]`, including an
+    /// out-of-range trailing-trivia overshoot as `None`.
+    pub result_color_trivia_marker_by_jit_pc: Vec<(usize, Option<u16>)>,
+    pub result_color_trivia_pred_by_jit_pc: Vec<(usize, Option<u16>)>,
     /// task#73 S5 phase-0: resume-marker twin split into the SAME two tiers as
     /// `python_pc_for_jitcode_pc` — an EXACT-match marker table
     /// (`resume_marker_marker_by_jit_pc`, block-head precedence) and a
@@ -656,6 +663,26 @@ impl PyJitCode {
         Self::predecessor_index(search).map(|i| pred[i].1.as_slice())
     }
 
+    /// #73-core: trivia-aware result color keyed by a JitCode byte offset,
+    /// resolved with the SAME two tiers as `python_pc_for_jitcode_pc`.
+    /// Equals
+    /// `result_color_at_pc[skip_python_trivia_forward(python_pc_for_jitcode_pc(jit_pc))]`
+    /// by construction, including a trailing-trivia overshoot as `None`.
+    /// `None` when the twin is empty (skeleton / fixture) — distinguish that
+    /// from an in-table `None` via [`Self::result_color_trivia_populated`].
+    pub fn result_color_trivia_for_jitcode_pc(&self, jit_pc: usize) -> Option<u16> {
+        let marker = &self.metadata.result_color_trivia_marker_by_jit_pc;
+        let pred = &self.metadata.result_color_trivia_pred_by_jit_pc;
+        if marker.is_empty() && pred.is_empty() {
+            return None;
+        }
+        if let Ok(i) = marker.binary_search_by_key(&jit_pc, |&(off, _)| off) {
+            return marker[i].1;
+        }
+        let search = pred.binary_search_by_key(&jit_pc, |&(off, _)| off);
+        Self::predecessor_index(search).and_then(|i| pred[i].1)
+    }
+
     /// task#73 S5 phase-0: codewrite-time resume marker keyed by a JitCode byte
     /// offset, resolved with the SAME two tiers as `python_pc_for_jitcode_pc`:
     /// an EXACT marker match first (block-head precedence), else a PREDECESSOR
@@ -715,6 +742,17 @@ impl PyJitCode {
     pub fn depth_trivia_populated(&self) -> bool {
         !self.metadata.depth_trivia_marker_by_jit_pc.is_empty()
             || !self.metadata.depth_trivia_pred_by_jit_pc.is_empty()
+    }
+
+    /// Whether the trivia-aware result-color twin carries entries. `false`
+    /// distinguishes a skeleton / fixture from an in-table `None` caused by a
+    /// trailing-trivia overshoot.
+    pub fn result_color_trivia_populated(&self) -> bool {
+        !self
+            .metadata
+            .result_color_trivia_marker_by_jit_pc
+            .is_empty()
+            || !self.metadata.result_color_trivia_pred_by_jit_pc.is_empty()
     }
 
     /// Resolve a guard frame from its carried direct JitCode coordinate.
@@ -806,6 +844,8 @@ impl PyJitCode {
                 pcdep_trivia_pred_by_jit_pc: Vec::new(),
                 const_ref_trivia_marker_by_jit_pc: Vec::new(),
                 const_ref_trivia_pred_by_jit_pc: Vec::new(),
+                result_color_trivia_marker_by_jit_pc: Vec::new(),
+                result_color_trivia_pred_by_jit_pc: Vec::new(),
                 resume_marker_marker_by_jit_pc: Vec::new(),
                 resume_marker_pred_by_jit_pc: Vec::new(),
                 after_residual_marker_marker_by_jit_pc: Vec::new(),

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -1209,7 +1209,7 @@ pub fn frame_liveness_reg_indices_by_bank_at_with_jitcode_pc(
         // No Python-pc reconstruction is available here: an absent carried
         // coordinate returns the empty result to its decline-aware caller.
         let resolved_jit_pc: Option<usize> =
-            payload.resolve_resume_pc_with_jitcode_pc(pc, carried_jitcode_pc, sd.op_live);
+            payload.resolve_resume_pc_with_jitcode_pc(carried_jitcode_pc, sd.op_live);
         let Some(jit_pc) = resolved_jit_pc else {
             return FrameLivenessRegIndices::default();
         };

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -12345,6 +12345,8 @@ mod tests {
                 pcdep_trivia_pred_by_jit_pc: Vec::new(),
                 const_ref_trivia_marker_by_jit_pc: Vec::new(),
                 const_ref_trivia_pred_by_jit_pc: Vec::new(),
+                result_color_trivia_marker_by_jit_pc: Vec::new(),
+                result_color_trivia_pred_by_jit_pc: Vec::new(),
                 resume_marker_marker_by_jit_pc: Vec::new(),
                 resume_marker_pred_by_jit_pc: vec![(0, Some(0))],
                 after_residual_marker_marker_by_jit_pc: Vec::new(),

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -1458,6 +1458,10 @@ impl MIFrame {
                     None
                 };
                 if marker_call_pc.is_some() {
+                    // This retired MIFrame trait-interpret leg has no production driver.
+                    // Production guard capture (`collect_outer_active_boxes`) captures rather than
+                    // aborts residual-call and inline guards as pyjitpl.py:2599/opencoder.py:819;
+                    // only trait-leg unit tests reach this abort before Phase-6 deletion.
                     crate::state::request_trace_abort();
                     return Vec::new();
                 }
@@ -3868,6 +3872,10 @@ impl MIFrame {
     fn marker_aware_resume_pc(&self, call_pc: usize, after_residual_call: bool) -> usize {
         let flag = majit_ir::resumedata::AFTER_RESIDUAL_CALL_PC_FLAG as usize;
         if after_residual_call {
+            // This retired MIFrame trait-interpret leg has no production driver.
+            // Production guard capture (`walker_capture_snapshot_for_last_guard`)
+            // captures rather than aborts residual-call guards as pyjitpl.py:2599 does; only trait-leg
+            // unit tests reach this abort before Phase-6 deletion.
             return crate::state::abort_unencodable_resume_pc(call_pc);
         }
         if call_pc >= flag {
@@ -3881,6 +3889,10 @@ impl MIFrame {
     fn marker_aware_parent_resume_pc(call_pc: Option<usize>, return_point_pc: usize) -> usize {
         let flag = majit_ir::resumedata::AFTER_RESIDUAL_CALL_PC_FLAG as usize;
         if call_pc.is_some() {
+            // This retired MIFrame trait-interpret leg has no production driver.
+            // Production guard capture (`collect_outer_active_boxes`) captures rather
+            // than aborts inline guards as opencoder.py:819 does; only trait-leg tests reach this
+            // abort before Phase-6 deletion.
             return crate::state::abort_unencodable_resume_pc(return_point_pc);
         }
         if return_point_pc >= flag {
@@ -4009,11 +4021,8 @@ impl MIFrame {
             let parent_pc_word =
                 crate::state::pyjitcode_for_jitcode_index(parent_jitcode_index as i32)
                     .and_then(|payload| {
-                        payload.resolve_resume_pc_with_jitcode_pc(
-                            parent_pc as i32,
-                            parent_word,
-                            crate::state::op_live(),
-                        )
+                        payload
+                            .resolve_resume_pc_with_jitcode_pc(parent_word, crate::state::op_live())
                     })
                     .map(|offset| offset as u32)
                     .unwrap_or_else(|| {
@@ -4070,7 +4079,7 @@ impl MIFrame {
         };
         let payload = unsafe { &(&*self.sym().jitcode).payload };
         let top_pc_word = payload
-            .resolve_resume_pc_with_jitcode_pc(top_pc as i32, top_word, crate::state::op_live())
+            .resolve_resume_pc_with_jitcode_pc(top_word, crate::state::op_live())
             .map(|offset| offset as u32)
             .unwrap_or_else(|| {
                 // A missing carried marker declines this trace before the

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -5031,6 +5031,10 @@ fn jit_merge_point_hook(
             if walk_end_flushed {
                 frame.restore_resume_state_from(&executed_frame);
             } else if let Some(restart_pc) = walk_end_restart_pc {
+                // When `fbw_has_unjournaled_effect` / `PYRE_FBW_END_FLUSH=0`
+                // leaves the end flush uncommitted, the live frame stays at trace entry.
+                // At a super-instruction loop close it only corrects `last_instr` to the
+                // marker-consistent restart pc; walked locals/stack stay out for consistent replay.
                 frame.set_last_instr_from_next_instr(restart_pc);
             }
             propagated_exception = pyre_jit_trace::trace::take_walk_end_propagated_exception();
@@ -5141,6 +5145,10 @@ fn maybe_compile_and_run(
         pyre_jit_trace::state::depth_based_vsd_for_wcode(frame.pycode as usize, loop_header_pc)
     {
         if frame.valuestackdepth != expected_vsd {
+            // A pyre super-instruction compiled-loop exit can rewind next_instr to the header
+            // while retaining an over-counted vable stack depth. Valid Python loops have one depth per bytecode offset,
+            // so this never permanently interprets a traceable loop; PyPy's MIFrame.pc JitCode-offset
+            // plus ResumeDataDirectReader exact-resume invariant structurally preclude it.
             return None;
         }
     }

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -12783,6 +12783,8 @@ impl CodeWriter {
         let mut pcdep_trivia_pred_by_jit_pc: Vec<(usize, Vec<(u8, u16, u16)>)> = Vec::new();
         let mut const_ref_trivia_marker_by_jit_pc: Vec<(usize, Vec<(u16, i64)>)> = Vec::new();
         let mut const_ref_trivia_pred_by_jit_pc: Vec<(usize, Vec<(u16, i64)>)> = Vec::new();
+        let mut result_color_trivia_marker_by_jit_pc: Vec<(usize, Option<u16>)> = Vec::new();
+        let mut result_color_trivia_pred_by_jit_pc: Vec<(usize, Option<u16>)> = Vec::new();
         let mut resume_marker_marker_by_jit_pc: Vec<(usize, Option<usize>)> = Vec::new();
         let mut resume_marker_pred_by_jit_pc: Vec<(usize, Option<usize>)> = Vec::new();
         let mut after_residual_marker_marker_by_jit_pc: Vec<(usize, Option<usize>)> = Vec::new();
@@ -12839,10 +12841,13 @@ impl CodeWriter {
                         .cloned()
                         .unwrap_or_default(),
                 ));
+                let result_color_trivia = result_color_at_pc.get(skipped_py).copied();
+                result_color_trivia_marker_by_jit_pc.push((off, result_color_trivia));
             }
             depth_trivia_marker_by_jit_pc.sort_unstable_by_key(|&(off, _)| off);
             pcdep_trivia_marker_by_jit_pc.sort_unstable_by_key(|&(off, _)| off);
             const_ref_trivia_marker_by_jit_pc.sort_unstable_by_key(|&(off, _)| off);
+            result_color_trivia_marker_by_jit_pc.sort_unstable_by_key(|&(off, _)| off);
             // Op-start tier: predecessor scan, markers EXCLUDED.
             for (py, &pos) in first_jit_pc_by_py_pc.iter().enumerate() {
                 if pos != usize::MAX {
@@ -12864,11 +12869,14 @@ impl CodeWriter {
                             .cloned()
                             .unwrap_or_default(),
                     ));
+                    let result_color_trivia = result_color_at_pc.get(skipped_py).copied();
+                    result_color_trivia_pred_by_jit_pc.push((pos, result_color_trivia));
                 }
             }
             depth_trivia_pred_by_jit_pc.sort_unstable_by_key(|&(off, _)| off);
             pcdep_trivia_pred_by_jit_pc.sort_unstable_by_key(|&(off, _)| off);
             const_ref_trivia_pred_by_jit_pc.sort_unstable_by_key(|&(off, _)| off);
+            result_color_trivia_pred_by_jit_pc.sort_unstable_by_key(|&(off, _)| off);
             // Marker tier: exact-match, block-head precedence.
             for &(off, py) in &block_head_py_by_jit_pc {
                 let skipped_py =
@@ -12977,6 +12985,8 @@ impl CodeWriter {
             pcdep_trivia_pred_by_jit_pc,
             const_ref_trivia_marker_by_jit_pc,
             const_ref_trivia_pred_by_jit_pc,
+            result_color_trivia_marker_by_jit_pc,
+            result_color_trivia_pred_by_jit_pc,
             resume_marker_marker_by_jit_pc,
             resume_marker_pred_by_jit_pc,
             after_residual_marker_marker_by_jit_pc,


### PR DESCRIPTION
Continues the #73 walker-as-tracer epic on top of current `main`. Five commits, each byte-identical on the corpus (dynasm + cranelift 191/191) with `cargo test` green (pyre-jit 311, pyre-jit-trace 263).

## Commits
1. **Add trivia-aware jitcode result-color twin** — mirrors the depth-trivia twin: two-tier (exact block-head marker + predecessor op-start) `result_color_trivia_{marker,pred}_by_jit_pc`, built in `finalize_jitcode` from `result_color_at_pc[skip_python_trivia_forward(py)]`. Additive; no consumer switch.
2. **Use trivia-aware result color for bridge root frame** — flips `compute_bridge_root_parent_frame` to read the trivia twin at `root_pc`; moves the `backxlat_py_pc` inversion into the `result_color_audit_enabled()` block (audit-off production no longer inverts here) + adds a consumer-keyed audit assert.
3. **Decline guard snapshots without JitCode coordinates** — the three single-frame guard-snapshot writers (`walker_capture_snapshot_for_last_guard_impl` main + arm path, `walker_capture_inline_nonstandard_vable_guard`) now `return Err(GuardResumeCoordinateUnavailable)` when the carried word has no representable JitCode coordinate, mirroring the already-landed multi-frame twins, instead of publishing a raw Python pc. Drops the dead `_raw_pc` parameter on `resolve_resume_pc_with_jitcode_pc`. Documents the retired trait-leg abort arms, the walk-end restart branch, and the vsd gate. Census: the decline fires 0× on the corpus (latent only).
4. **Flip guard-kept pcdep read onto the jitcode twin under `PYRE_PCMAP_GUARD_KEPT_AUDIT`** — the guard-kept-recovery `pcdep_color_slots[guard_py_pc]` read moves to `pcdep_for_jitcode_pc(guard_jitcode_pc)`, plus a census gate asserting twin == table.
5. **Flip guard-kept depth read onto the jitcode twin; enforce the depth twin** — the guard-kept `liveness_for(code).depth_at_py_pc()[guard_py_pc]` read moves to `depth_for_jitcode_pc_pred(guard_jitcode_pc)`; the depth probe becomes an enforced assert.

## Verification
- Corpus byte-identical: dynasm 191/191, cranelift 191/191 (audit-off).
- `PYRE_PCMAP_GUARD_KEPT_AUDIT=1` census: the guard-kept block fires ~1016× on the corpus; both the pcdep and depth twin==table asserts hold (0 divergence).
- `cargo test -p pyre-jit -p pyre-jit-trace --features dynasm`: 311 + 263 pass.

Commits 4–5 are phase-0 of the `python_pc_for_jitcode_pc` retirement: they convert two of the guard-kept consumers onto existing jitcode-keyed twins and land the reusable guard-kept census gate; they do not yet retire the inversion call (its remaining `collect_outer_active_boxes` consumer is the next slice).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
