### PR TITLE
#346: union keystone (residual ref result → SomeInstance) + BigInt/dict-storage leaves

### DIFF
--- a/majit/majit-translate/docs/design-346-dstrategy-trait-object-field.md
+++ b/majit/majit-translate/docs/design-346-dstrategy-trait-object-field.md
@@ -265,3 +265,46 @@ other census "polymorphic-field" symptoms — `message`, `start`/`end`, `save_po
 are four unrelated root causes: PyError classdef-identity dup, Rust stdlib `Range` monomorph
 collapse, signedness, mir-walker synthetic positional fields). This epic is `dstrategy` alone;
 the others are separate.
+
+## ✅ SIBLING FIX (7/16) — residual `ref` result annotates as `SomeInstance`, not `SomePtr`
+
+After the `dstrategy` static-read narrow (B), the residual `_ptr ∪ <other>` panics that remained
+were NOT static/field reads — they were **residual CALL RESULTS**. A `PYRE_UNION_DUMP` probe
+(temporary `eprintln!` in `annrpython.rs` `mergeinputargs` error arm) captured every union operand
+and revealed two residual-registration paths disagreeing on the result-annotation representation:
+
+- `register_foreign_opaque_method_externals` (cutover.rs:2220): `valuetype_to_someshell(result_ty)`
+  → classdef-less `SomeInstance` for a `Ref` return — the faithful annotation-stage projection.
+  `<BigInt as Add>::add` (a method residual) already uses it.
+- The `dont_look_inside` prefill (cutover.rs:1719): the `ref` return token → `GCREF` lltype →
+  `default_someshell_for_lltype` → `lltype_to_annotation(GCREF)` = `SomePtr(GCREF)`. Every
+  `#[dont_look_inside]` **free** fn returning a non-`*mut PyObject` heap pointer (`jit_bigint_*`,
+  `w_long_new`, …) got this — a low-level `SomePtr` at annotation stage.
+
+When a residual result from the prefill path (`SomePtr(GCREF)`) phi-merges with an ordinary `Ref`
+value (`SomeInstance(None)` shell), `model::union` (model.rs:3424 `_` fallback) has no
+`SomePtr ∪ SomeInstance` arm → `_ptr ∪ <other>` UnionError in `mergeinputargs`.
+
+**Orthodoxy:** Adding the union arm (Fix A) is FORBIDDEN — RPython's annotator runs on high-level
+types (`SomeInstance`); the rtyper LATER lowers to lltype (`SomePtr`). They live at different
+PHASES and never phi-merge during annotation, so `binaryop.py` has no such pairtype. The prefill
+path conflated the two phases. Orthodox fix = the prefill's `ref` token builds its stub with the
+`SomeInstance(None)` shell (`valuetype_to_someshell(Ref(None))`), unifying the two residual paths
+on the faithful representation (annotation_state.rs doc-table: every `Ref` → classdef-less
+`SomeInstance`; `SomePtr` reserved for producer-written rtyper-stage annotations).
+
+**Bit-exact safe:** both `SomeInstance(None)→OBJECTPTR` and `SomePtr(GCREF)→GCREF` map through
+`getkind` (model.rs:4054) to `ConcreteType::GcRef`, so the emitted `residual_call_*_r` opcode and
+the fn's C ABI (`jit_fnaddr.rs`) are byte-identical. The `OBJECTPTR_RETURN_TYPE` (`*mut PyObject`)
+token is unchanged — a caller reading the returned object's fields still rtypes against the real
+struct via the typed `OBJECTPTR`.
+
+**Result (same-LLBC census set-diff): 279 → 268 (net −11).** REMOVED: `setdict`, `range_length_big`,
+`w_range_compute_item`, and the entire int/long arithmetic family (`int_add`/`int_sub`/`int_lshift`,
+`long_add`/`long_sub`/`long_bitand`/`long_floordiv`/`long_mod`/`long_lshift`/`long_rshift`) plus
+their domino tails. ADDED: only the `typing_intrinsic_1/2` concurrent-build flicker (±2, unrelated).
+The 8 residual `_ptr` unions that remain are separate roots (`getcode` = `PYRE_REF_OPAQUE` from
+`cast_int_to_ptr`; `truth_value`/`unary_not`/`get`/`setitem_instance` = primitive-side or
+genuinely-heterogeneous — `Int`/`Bool`∪`Instance` won't union regardless).
+
+Implemented at cutover.rs:1719 residualize block. `cargo test -p majit-translate` 2984/0.

--- a/majit/majit-translate/src/front/bigint_binop.rs
+++ b/majit/majit-translate/src/front/bigint_binop.rs
@@ -1,4 +1,4 @@
-//! `<BigInt as {BitAnd,BitOr,BitXor,Sub,Mul}>::op()` → `jit_bigint_*` residual.
+//! `<BigInt as {BitAnd,BitOr,BitXor,Sub,Mul,Add,Div}>::op()` → `jit_bigint_*` residual.
 //!
 //! ## Positioning
 //!
@@ -49,6 +49,7 @@ pub(crate) fn bigint_binop_residual_path(segments: &[String]) -> Option<Vec<Stri
         "sub" => "jit_bigint_sub",
         "mul" => "jit_bigint_mul",
         "add" => "jit_bigint_add",
+        "div" => "jit_bigint_div",
         _ => return None,
     };
     Some(residual_path(residual_leaf))
@@ -70,6 +71,25 @@ pub(crate) fn bigint_shift_residual_path(segments: &[String]) -> Option<Vec<Stri
     let residual_leaf = match leaf.as_str() {
         "shl" => "jit_bigint_shl",
         "shr" => "jit_bigint_shr",
+        _ => return None,
+    };
+    Some(residual_path(residual_leaf))
+}
+
+/// If `segments` is a foreign BigInt **unary** operator impl-method path
+/// (`[…, "<Impl>", "neg"]`), return the `jit_bigint_neg` residual path;
+/// otherwise `None`.  Split from [`bigint_binop_residual_path`] because the
+/// operator takes a single `BigInt` operand: the caller confirms the sole
+/// operand is the opaque `BigInt` ADT before applying the retarget.
+pub(crate) fn bigint_unop_residual_path(segments: &[String]) -> Option<Vec<String>> {
+    let [.., impl_seg, leaf] = segments else {
+        return None;
+    };
+    if impl_seg != "<Impl>" {
+        return None;
+    }
+    let residual_leaf = match leaf.as_str() {
+        "neg" => "jit_bigint_neg",
         _ => return None,
     };
     Some(residual_path(residual_leaf))
@@ -103,6 +123,7 @@ mod tests {
             ("sub", "jit_bigint_sub"),
             ("mul", "jit_bigint_mul"),
             ("add", "jit_bigint_add"),
+            ("div", "jit_bigint_div"),
         ] {
             let path =
                 bigint_binop_residual_path(&segs(&["malachite_bigint", "bigint", "<Impl>", op]))
@@ -128,6 +149,20 @@ mod tests {
             bigint_shift_residual_path(&segs(&["malachite_bigint", "bigint", "<Impl>", "sub"]))
                 .is_none()
         );
+    }
+
+    #[test]
+    fn maps_unary_neg_to_its_residual() {
+        let path =
+            bigint_unop_residual_path(&segs(&["malachite_bigint", "bigint", "<Impl>", "neg"]))
+                .expect("neg must map");
+        assert_eq!(path, desc("jit_bigint_neg"));
+        // Binary operators / shifts are not in the unary map.
+        assert!(
+            bigint_unop_residual_path(&segs(&["malachite_bigint", "bigint", "<Impl>", "add"]))
+                .is_none()
+        );
+        assert!(bigint_unop_residual_path(&segs(&["bigint", "BigInt", "neg"])).is_none());
     }
 
     #[test]

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -6077,6 +6077,46 @@ impl<'a> Lowering<'a> {
                 )? {
                     return Ok(());
                 }
+                // `<BigInt as {One,Zero}>::{one,zero}()` — a 0-arg associated
+                // fn returning a fresh `BigInt` constant.  Emit `BigInt::from(1)`
+                // / `BigInt::from(0)` (a `ConstInt` operand feeding the
+                // `["BigInt", "from"]` residual-external) instead of leaving the
+                // owner-resolved `["bigint", "BigInt", <leaf>]` call unregistered.
+                // `BigInt::from(1i64)` == `Integer::ONE` and `from(0i64)` ==
+                // `Integer::ZERO`, so the constants are byte-identical.
+                if args.is_empty()
+                    && let [.., owner_a, owner_b, leaf] = segments.as_slice()
+                    && owner_a == "bigint"
+                    && owner_b == "BigInt"
+                    && matches!(leaf.as_str(), "one" | "zero")
+                {
+                    let n = if leaf == "one" { 1 } else { 0 };
+                    let cst = self
+                        .graph
+                        .alloc_value_var_with_type(crate::model::ConcreteType::Unknown);
+                    self.graph.block_mut(bb_id).operations.push(SpaceOperation {
+                        result: Some(cst.clone()),
+                        kind: OpKind::ConstInt(n),
+                    });
+                    let res = self
+                        .graph
+                        .alloc_value_var_with_type(crate::model::ConcreteType::Unknown);
+                    self.graph.block_mut(bb_id).operations.push(SpaceOperation {
+                        result: Some(res.clone()),
+                        kind: OpKind::Call {
+                            target: CallTarget::FunctionPath {
+                                segments: vec!["BigInt".to_string(), "from".to_string()],
+                            },
+                            args: vec![cst],
+                            result_ty: ValueType::Ref(None),
+                        },
+                    });
+                    self.local_var[dest_local] = Some(res);
+                    let target_bb = self.block_id[target];
+                    let link_args = self.edge_args(mir_bb, target)?;
+                    self.graph.set_goto(bb_id, target_bb, link_args);
+                    return Ok(());
+                }
                 // `<str as PartialEq>::eq(a, b)` is the string-equality
                 // `BinOp("eq")` (pairtype `rtype_eq` → `ll_streq`) — emit it
                 // instead of leaving the graph-less trait-method extern.
@@ -6448,6 +6488,31 @@ impl<'a> Lowering<'a> {
                 )
             })
             && let Some(residual) = crate::front::bigint_binop::bigint_shift_residual_path(segments)
+        {
+            OpKind::Call {
+                target: CallTarget::FunctionPath { segments: residual },
+                args: args.clone(),
+                result_ty: ValueType::Ref(None),
+            }
+        } else {
+            op_kind
+        };
+
+        // Retarget a foreign BigInt unary-operator call (`<BigInt as Neg>::neg`)
+        // to its `jit_bigint_neg` residual.  Split from the binary retarget
+        // above because the operator takes a single `BigInt` operand: the guard
+        // requires the sole operand to be the opaque `BigInt` ADT.  Same
+        // pure-target-swap, fail-safe contract.
+        let op_kind = if let OpKind::Call {
+            target: CallTarget::FunctionPath { segments },
+            args,
+            ..
+        } = &op_kind
+            && args.len() == 1
+            && first_arg_ty
+                .as_ref()
+                .is_some_and(|t| tyref_is_opaque_bigint(t, self.llbc))
+            && let Some(residual) = crate::front::bigint_binop::bigint_unop_residual_path(segments)
         {
             OpKind::Call {
                 target: CallTarget::FunctionPath { segments: residual },

--- a/majit/majit-translate/src/translator/rtyper/cutover.rs
+++ b/majit/majit-translate/src/translator/rtyper/cutover.rs
@@ -1702,40 +1702,66 @@ pub(crate) fn populate_call_registry_from_call_graphs(
         // the residual call via the fn's registered C ABI address
         // (`pyre/jit_fnaddr.rs`).  The FUNC.RESULT token is the
         // canonical spelling `front::mir::dont_look_inside_return_token`
-        // stamps from the callee's return `ValueType`, so each token
-        // decodes to the lltype whose `getkind` equals the legacy
-        // walker's `valuetype_to_concrete(result_ty)`: scalar tokens to
-        // their primitive lltype, `ref` to the generic `GCREF` Ptr
-        // (`getkind = 'ref'`).  The object-pointer marker
-        // (`OBJECTPTR_RETURN_TYPE`, stamped by `merge_hints_from_llbcs`
-        // for a `*mut PyObject`-returning opaque callee the front-end
-        // left untokened) projects to the typed `OBJECTPTR` — the
-        // `default_someshell_for_lltype` → `lltype_to_annotation` path
-        // already covers `Ptr(_)`.  An unrecognized token (none
-        // currently emitted) falls through to the normal lift.
+        // stamps from the callee's return `ValueType`.  Scalar tokens
+        // decode to their primitive lltype (`getkind` equals the legacy
+        // walker's `valuetype_to_concrete(result_ty)`).
+        //
+        // The `ref` token (a non-`*mut PyObject` heap result — e.g. a
+        // `*mut BigInt`) carries a classdef-less `SomeInstance` result
+        // shell (`valuetype_to_someshell(Ref(None))`), NOT a
+        // `SomePtr(GCREF)`.  A residual result is an annotation-stage
+        // value; the annotation-stage projection of every `Ref` is the
+        // classdef-less `SomeInstance` (`annotation_state.rs` doc-table),
+        // with `SomePtr` reserved for a producer writing
+        // `Variable.annotation` at the rtyper stage.  Emitting a
+        // `SomePtr(GCREF)` here made the result collide with the
+        // `SomeInstance(None)` an ordinary `Ref` merge partner carries
+        // (`_ptr ∪ <other>` UnionError in `mergeinputargs`, the union
+        // has no `SomePtr ∪ SomeInstance` arm).  The `SomeInstance(None)`
+        // shell unions cleanly (the classdef-less widen arm) and is the
+        // same shell the sibling `register_foreign_opaque_method_externals`
+        // path already gives a `BigInt`-returning method residual.  Both
+        // spellings rtype to `getkind = GcRef`, so the emitted
+        // `residual_call_*_r` opcode and C ABI are byte-identical.
+        //
+        // The object-pointer marker (`OBJECTPTR_RETURN_TYPE`, stamped by
+        // `merge_hints_from_llbcs` for a `*mut PyObject`-returning opaque
+        // callee the front-end left untokened) keeps the typed `OBJECTPTR`
+        // lltype so a caller reading the returned object's fields rtypes
+        // against the real struct.  An unrecognized token (none currently
+        // emitted) falls through to the normal lift.
         let residualize = graph.hints.iter().any(|h| h == "dont_look_inside")
             || (crate::front::mir::elidable_residualize_enabled()
                 && graph.hints.iter().any(|h| h == "elidable"));
         if residualize {
-            let return_lltype = match graph.return_type.as_deref() {
-                None | Some("()") => Some(LowLevelType::Void),
-                Some("bool") => Some(LowLevelType::Bool),
-                Some("i64") => Some(LowLevelType::Signed),
-                Some("u64") => Some(LowLevelType::Unsigned),
-                Some("f64") => Some(LowLevelType::Float),
-                Some("ref") => Some(crate::translator::rtyper::lltypesystem::lltype::GCREF.clone()),
-                Some(s) if s == OBJECTPTR_RETURN_TYPE => {
-                    Some(crate::translator::rtyper::rclass::OBJECTPTR.clone())
+            let result_shell = match graph.return_type.as_deref() {
+                Some("ref") => Some(
+                    crate::codewriter::annotation_state::valuetype_to_someshell(
+                        &crate::model::ValueType::Ref(None),
+                    )
+                    .expect("Ref(None) shells to a definite SomeInstance"),
+                ),
+                token => {
+                    let return_lltype = match token {
+                        None | Some("()") => Some(LowLevelType::Void),
+                        Some("bool") => Some(LowLevelType::Bool),
+                        Some("i64") => Some(LowLevelType::Signed),
+                        Some("u64") => Some(LowLevelType::Unsigned),
+                        Some("f64") => Some(LowLevelType::Float),
+                        Some(s) if s == OBJECTPTR_RETURN_TYPE => {
+                            Some(crate::translator::rtyper::rclass::OBJECTPTR.clone())
+                        }
+                        _ => None,
+                    };
+                    return_lltype.and_then(|ll| default_someshell_for_lltype(&ll))
                 }
-                _ => None,
             };
-            if let Some(return_lltype) = return_lltype
-                && let Some(stub) = build_stub_pygraph_for_unsafe_fn(
+            if let Some(result_shell) = result_shell {
+                let stub = build_stub_pygraph_with_result_shell(
                     graph.name.clone(),
                     signature_for_graph(graph),
-                    return_lltype,
-                )
-            {
+                    result_shell,
+                );
                 entry.prefill_default_cache(stub);
                 continue;
             }

--- a/pyre/pyre-interpreter/src/jit_fnaddr.rs
+++ b/pyre/pyre-interpreter/src/jit_fnaddr.rs
@@ -551,6 +551,33 @@ pub fn jit_trace_fnaddrs() -> Vec<(&'static str, i64)> {
         "pyre_object::w_dict_setitem_str",
         pyre_object::dictmultiobject::w_dict_setitem_str as *const (),
     );
+    // The typed int/bytes dict-storage leaves residualise their
+    // `IndexMap::{insert,get}` (an external-crate heap store/lookup the tracer
+    // cannot model): the stores return `()`, the lookups `Option<PyObjectRef>`.
+    push_alias_pair(
+        &mut entries,
+        "pyre_object::dictmultiobject::w_dict_store_int_strategy",
+        "pyre_object::w_dict_store_int_strategy",
+        pyre_object::dictmultiobject::w_dict_store_int_strategy as *const (),
+    );
+    push_alias_pair(
+        &mut entries,
+        "pyre_object::dictmultiobject::w_dict_lookup_int_strategy",
+        "pyre_object::w_dict_lookup_int_strategy",
+        pyre_object::dictmultiobject::w_dict_lookup_int_strategy as *const (),
+    );
+    push_alias_pair(
+        &mut entries,
+        "pyre_object::dictmultiobject::w_dict_store_bytes_strategy",
+        "pyre_object::w_dict_store_bytes_strategy",
+        pyre_object::dictmultiobject::w_dict_store_bytes_strategy as *const (),
+    );
+    push_alias_pair(
+        &mut entries,
+        "pyre_object::dictmultiobject::w_dict_lookup_bytes_strategy",
+        "pyre_object::w_dict_lookup_bytes_strategy",
+        pyre_object::dictmultiobject::w_dict_lookup_bytes_strategy as *const (),
+    );
     push_alias_pair(
         &mut entries,
         "pyre_object::dictmultiobject::w_module_dict_new",
@@ -791,6 +818,13 @@ pub fn jit_trace_fnaddrs() -> Vec<(&'static str, i64)> {
         &mut entries,
         "pyre_interpreter::objspace::descroperation::jit_bigint_add",
         crate::objspace::descroperation::jit_bigint_add as *const (),
+    );
+    // `jit_bigint_neg` residualizes the unary `<BigInt as Neg>::neg` operator;
+    // a single operand pointer.
+    push_fnaddr(
+        &mut entries,
+        "pyre_interpreter::objspace::descroperation::jit_bigint_neg",
+        crate::objspace::descroperation::jit_bigint_neg as *const (),
     );
     // `jit_bigint_{shl,shr}` residualize the BigInt shift-by-`usize` operators
     // (`<BigInt as Shl<usize>>::shl`, …); `b` is the machine shift count.

--- a/pyre/pyre-interpreter/src/objspace/descroperation.rs
+++ b/pyre/pyre-interpreter/src/objspace/descroperation.rs
@@ -199,6 +199,14 @@ pub extern "C" fn jit_bigint_add(a: i64, b: i64) -> *mut BigInt {
     unsafe { pyre_object::longobject::alloc_bigint_nursery_collecting(&*a + &*b) }
 }
 
+/// `rbigint.neg` payload — `-&BigInt`. A unary operator, so a single operand
+/// pointer; the result is a fresh negated `BigInt`. See [`jit_bigint_and`].
+#[majit_macros::dont_look_inside]
+pub extern "C" fn jit_bigint_neg(a: i64) -> *mut BigInt {
+    let a = a as *const BigInt;
+    unsafe { pyre_object::longobject::alloc_bigint_nursery_collecting(-&*a) }
+}
+
 // ── BigInt shift-by-`usize` residuals ────────────────────────────────
 // `<BigInt as Shl<usize>>::shl` / `Shr<usize>::shr` — the shift amount is a
 // plain machine integer, NOT a `BigInt`, so `b` is the count value itself

--- a/pyre/pyre-object/src/dictmultiobject.rs
+++ b/pyre/pyre-object/src/dictmultiobject.rs
@@ -2558,10 +2558,17 @@ pub unsafe fn w_dict_copy(obj: PyObjectRef) -> PyObjectRef {
 /// matching `dictmultiobject.py:1061-1064` (`self.unerase
 /// (w_dict.dstorage)[self.unwrap(w_key)] = w_value`).  Caller must
 /// have already verified `is_correct_type(w_key)`.
+///
+/// Residualise the int-storage setitem leaf (`@dont_look_inside`,
+/// `rlib/jit.py:139`): the `IndexMap::insert` it wraps is an external-crate
+/// heap-store the tracer cannot model — the oopspec'd residual arm of
+/// `rordereddict.ll_dict_setitem` (traced only for a virtual dict).
+///
 /// # Safety
 /// `obj` must point to a valid `W_DictObject` on
 /// [`crate::dictmultiobject::INT_DICT_STRATEGY`]; `key` must be a
 /// plain `W_IntObject` (not bool).
+#[majit_macros::dont_look_inside]
 pub unsafe fn w_dict_store_int_strategy(obj: PyObjectRef, key: PyObjectRef, value: PyObjectRef) {
     let dict = &mut *(obj as *mut W_DictObject);
     let entries = &mut *(dict.dstorage as *mut indexmap::IndexMap<i64, PyObjectRef>);
@@ -2574,8 +2581,14 @@ pub unsafe fn w_dict_store_int_strategy(obj: PyObjectRef, key: PyObjectRef, valu
 /// `dictmultiobject.py:1098 self.unerase(w_dict.dstorage).get(self.unwrap(w_key), None)`.
 /// Caller must have already verified `is_correct_type(w_key)`.
 ///
+/// Residualise the int-storage getitem leaf (`@dont_look_inside`,
+/// `rlib/jit.py:139`): the `IndexMap::get` it wraps is an external-crate
+/// heap-lookup the tracer cannot model — the oopspec'd residual arm of
+/// `rordereddict.ll_dict_getitem` (traced only for a virtual dict).
+///
 /// # Safety
 /// Same as [`w_dict_store_int_strategy`].
+#[majit_macros::dont_look_inside]
 pub unsafe fn w_dict_lookup_int_strategy(
     obj: PyObjectRef,
     key: PyObjectRef,
@@ -2661,10 +2674,16 @@ pub unsafe fn w_dict_clear_int_strategy(obj: PyObjectRef) {
 /// `dictmultiobject.py:1061-1064` direct typed-storage write.  Caller
 /// must have already verified `is_correct_type(w_key)`.
 ///
+/// Residualise the bytes-storage setitem leaf (`@dont_look_inside`,
+/// `rlib/jit.py:139`): the `IndexMap::insert` it wraps is an external-crate
+/// heap-store the tracer cannot model — the oopspec'd residual arm of
+/// `rordereddict.ll_dict_setitem` (traced only for a virtual dict).
+///
 /// # Safety
 /// `obj` must point to a valid `W_DictObject` on
 /// [`crate::dictmultiobject::BYTES_DICT_STRATEGY`]; `key` must be a
 /// `W_BytesObject`.
+#[majit_macros::dont_look_inside]
 pub unsafe fn w_dict_store_bytes_strategy(obj: PyObjectRef, key: PyObjectRef, value: PyObjectRef) {
     let dict = &mut *(obj as *mut W_DictObject);
     let entries = &mut *(dict.dstorage as *mut indexmap::IndexMap<Vec<u8>, PyObjectRef>);
@@ -2677,8 +2696,14 @@ pub unsafe fn w_dict_store_bytes_strategy(obj: PyObjectRef, key: PyObjectRef, va
 /// `dictmultiobject.py:1098`.  Caller must have already verified
 /// `is_correct_type(w_key)`.
 ///
+/// Residualise the bytes-storage getitem leaf (`@dont_look_inside`,
+/// `rlib/jit.py:139`): the `IndexMap::get` it wraps is an external-crate
+/// heap-lookup the tracer cannot model — the oopspec'd residual arm of
+/// `rordereddict.ll_dict_getitem` (traced only for a virtual dict).
+///
 /// # Safety
 /// Same as [`w_dict_store_bytes_strategy`].
+#[majit_macros::dont_look_inside]
 pub unsafe fn w_dict_lookup_bytes_strategy(
     obj: PyObjectRef,
     key: PyObjectRef,

--- a/pyre/pyre-object/src/functional.rs
+++ b/pyre/pyre-object/src/functional.rs
@@ -882,7 +882,7 @@ pub unsafe fn w_range_compute_item(obj: PyObjectRef, index: &BigInt) -> Option<P
         let len_b = range_obj_to_bigint(w_range_length(obj));
         let mut idx = index.clone();
         if idx < BigInt::zero() {
-            idx += &len_b;
+            idx = &idx + &len_b;
         }
         if idx >= len_b || idx < BigInt::zero() {
             return None;


### PR DESCRIPTION
## #346 — retire the rtyper legacy walker (union keystone + BigInt/dict-storage leaves)

Two commits toward the gh#346 metric (distinct `[PREPASS phaseA fail] CallPath` count in the census). Rebased onto `main`.

### 1. `front/mir,descroperation`: register BigInt one/zero/div/neg + int/bytes dict-storage leaves

BigInt constant/operator leaves:
- `<BigInt as {One,Zero}>::{one,zero}()` rewrite to `BigInt::from(1|0)`, reusing the `BigIntFrom` residual.
- `<BigInt as Div>::div` retargets to the existing `jit_bigint_div` residual.
- `<BigInt as Neg>::neg` retargets to a new `jit_bigint_neg` residual (unary, single operand), registered in `jit_fnaddr`.
- `functional.rs w_range_compute_item`: `idx += &len_b` becomes `idx = &idx + &len_b`, routed through the `<Impl>::add` retarget.

Int/bytes dict-storage leaves: mark `w_dict_{store,lookup}_{int,bytes}_strategy` `#[dont_look_inside]` and register their fnaddr alias pairs, residualizing their `IndexMap::{insert,get}`.

### 2. `rtyper/cutover`: residual `ref` result annotates as classdef-less SomeInstance

The `dont_look_inside` prefill built a ref-returning residual's result annotation from the `ref` return token via `GCREF → default_someshell_for_lltype → lltype_to_annotation(GCREF) = SomePtr(GCREF)`. But a residual result is an annotation-stage value; the annotation-stage projection of every `Ref` is the classdef-less `SomeInstance`, with `SomePtr` reserved for a producer writing `Variable.annotation` at the rtyper stage. The `SomePtr(GCREF)` result collided with the `SomeInstance(None)` an ordinary `Ref` merge partner carries: `_ptr ∪ <other>` `UnionError` in `mergeinputargs`, the union having no `SomePtr ∪ SomeInstance` arm (correctly — the two live at different phases and never phi-merge upstream).

Fix: build the `ref`-token stub with the `SomeInstance(None)` shell instead, matching `register_foreign_opaque_method_externals` which already carries a classdef-less `SomeInstance` for a BigInt-returning method residual. Both spellings rtype to `getkind = GcRef`, so the emitted `residual_call_*_r` opcode and the fn's C ABI are byte-identical. The `OBJECTPTR_RETURN_TYPE` (`*mut PyObject`) token keeps its typed OBJECTPTR.

Census phaseA distinct-fail: **279 → 268** (same LLBC). Removed: `setdict`, `range_length_big`, `w_range_compute_item`, and the int/long arithmetic family (`int_add/sub/lshift`, `long_add/sub/bitand/floordiv/mod/lshift/rshift`) plus domino tails.

### Verification (on the rebased base)
- `cargo test -p majit-translate`: 2987/0.
- `pyre/check.py` bit-exact: **dynasm 191/191, cranelift 191/191** ALL PASSED. The sole red is `wasm synth/residual_raise_except_resume` — a perf `SLOWER` timeout (0.20s vs pypy 0.01s, dominated by wasm's ~0.12s startup) under machine load; the same test failed identically in this branch's prior CI before these commits, and neither commit touches the wasm path. Not a correctness regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
