### PR TITLE
gc: free off-GC storage Boxes on sweep for bytes/bytearray/set/function

### DIFF
--- a/pyre/pyre-interpreter/src/function.rs
+++ b/pyre/pyre-interpreter/src/function.rs
@@ -20,7 +20,7 @@ pub static BUILTIN_FUNCTION_TYPE: PyType = pyre_object::pyobject::new_pytype("bu
 ///   function.py:47 — `_immutable_fields_ = ['code?', ...]`
 /// - `can_change_code`: function.py:33 — True by default; False for
 ///   `FunctionWithFixedCode` subclass (used by builtins).
-/// - `name_ptr`: leaked `Box<String>` containing the function name
+/// - `name_ptr`: off-GC `Box<String>` containing the function name
 /// - `closure`:  tuple of cell objects, or PY_NULL if no closure
 /// - `w_func_globals_obj`: the module namespace dict object (`__globals__`)
 #[repr(C)]
@@ -32,7 +32,7 @@ pub struct Function {
     /// function.py:33 — `can_change_code = True`
     /// False for FunctionWithFixedCode subclass.
     pub can_change_code: bool,
-    /// Function name (leaked Box<String>).
+    /// Function name (off-GC Box<String>).
     pub name: *const String,
     /// Closure: tuple of cell objects from the enclosing scope,
     /// or PY_NULL if this function has no free variables.
@@ -273,10 +273,23 @@ impl pyre_object::lltype::GcType for Function {
     const SIZE: usize = FUNCTION_OBJECT_SIZE;
 }
 
+/// Free the off-GC name string owned by a `Function`.
+///
+/// # Safety
+/// `obj` must point at a valid `Function` whose `name` Box is not aliased by
+/// another owner.
+pub unsafe fn function_dealloc_name(obj: PyObjectRef) {
+    let raw = unsafe { &mut *(obj as *mut Function) };
+    if !raw.name.is_null() {
+        unsafe { drop(Box::from_raw(raw.name as *mut String)) };
+        raw.name = std::ptr::null();
+    }
+}
+
 /// Allocate a new `Function`.
 ///
 /// `code` is a pointer to a Code object (PyCode) cast to `*const ()`.
-/// `name` is the function name string (leaked).
+/// `name` is the function name string stored in an off-GC Box.
 /// `w_func_globals_obj` is the defining module's namespace dict object
 /// (shared), or `PY_NULL` for a globals-less carrier.
 pub fn function_new(code: *const (), name: String, w_func_globals_obj: PyObjectRef) -> PyObjectRef {

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -478,6 +478,30 @@ unsafe fn module_dict_object_destructor(obj_addr: usize) {
     unsafe { pyre_object::dictmultiobject::w_module_dict_dealloc_storage(obj) };
 }
 
+/// Reclaim the off-GC byte buffer of a swept bytes object.
+unsafe fn bytes_object_destructor(obj_addr: usize) {
+    let obj = obj_addr as pyre_object::PyObjectRef;
+    unsafe { pyre_object::bytesobject::w_bytes_dealloc(obj) };
+}
+
+/// Reclaim the off-GC byte buffer of a swept bytearray object.
+unsafe fn bytearray_object_destructor(obj_addr: usize) {
+    let obj = obj_addr as pyre_object::PyObjectRef;
+    unsafe { pyre_object::bytearrayobject::w_bytearray_dealloc(obj) };
+}
+
+/// Reclaim the off-GC item container of a swept set object.
+unsafe fn set_object_destructor(obj_addr: usize) {
+    let obj = obj_addr as pyre_object::PyObjectRef;
+    unsafe { pyre_object::setobject::w_set_dealloc_items(obj) };
+}
+
+/// Reclaim the off-GC name string of a swept function object.
+unsafe fn function_object_destructor(obj_addr: usize) {
+    let obj = obj_addr as pyre_object::PyObjectRef;
+    unsafe { pyre_interpreter::function::function_dealloc_name(obj) };
+}
+
 /// Custom trace for `W_ObjectObject` (instance `map`+`storage`,
 /// `mapdict.py:907-910`).  The `storage` list is an off-GC
 /// `Box<Vec<PyObjectRef>>`, so — exactly as `dict_object_custom_trace`
@@ -1298,11 +1322,14 @@ fn build_gc() -> Box<dyn majit_gc::GcAllocator> {
     // (`pypy/interpreter/function.py:706 BuiltinFunction`) but its
     // instances are the same Rust struct, so the vtable map sends
     // both PyTypes to `function_tid`.
-    let function_tid = gc.register_type(TypeInfo::object_subclass_with_gc_ptrs(
-        std::mem::size_of::<pyre_interpreter::function::Function>(),
-        object_tid,
-        pyre_interpreter::function::FUNCTION_GC_PTR_OFFSETS.to_vec(),
-    ));
+    let function_tid = gc.register_type(
+        TypeInfo::object_subclass_with_gc_ptrs(
+            std::mem::size_of::<pyre_interpreter::function::Function>(),
+            object_tid,
+            pyre_interpreter::function::FUNCTION_GC_PTR_OFFSETS.to_vec(),
+        )
+        .with_destructor_fn(function_object_destructor),
+    );
     debug_assert_eq!(function_tid, FUNCTION_GC_TYPE_ID);
     majit_gc::GcAllocator::register_vtable_for_type(
         &mut gc,
@@ -1422,10 +1449,13 @@ fn build_gc() -> Box<dyn majit_gc::GcAllocator> {
     // `PyObjectRef`. Pre-registered with `object_subclass(size, ...)`
     // so the foreign-pytype loop's `sizeof(PyObject)` approximation
     // does not under-count the payload.
-    let w_bytes_tid = gc.register_type(TypeInfo::object_subclass(
-        std::mem::size_of::<pyre_object::bytesobject::W_BytesObject>(),
-        object_tid,
-    ));
+    let w_bytes_tid = gc.register_type(
+        TypeInfo::object_subclass(
+            std::mem::size_of::<pyre_object::bytesobject::W_BytesObject>(),
+            object_tid,
+        )
+        .with_destructor_fn(bytes_object_destructor),
+    );
     debug_assert_eq!(w_bytes_tid, W_BYTES_GC_TYPE_ID);
     majit_gc::GcAllocator::register_vtable_for_type(
         &mut gc,
@@ -1439,10 +1469,13 @@ fn build_gc() -> Box<dyn majit_gc::GcAllocator> {
     // W_BytearrayObject (mutable byte sequence) carries a raw
     // `*mut Vec<u8>` (`data`). Same registration shape as
     // W_BytesObject.
-    let w_bytearray_tid = gc.register_type(TypeInfo::object_subclass(
-        std::mem::size_of::<pyre_object::bytearrayobject::W_BytearrayObject>(),
-        object_tid,
-    ));
+    let w_bytearray_tid = gc.register_type(
+        TypeInfo::object_subclass(
+            std::mem::size_of::<pyre_object::bytearrayobject::W_BytearrayObject>(),
+            object_tid,
+        )
+        .with_destructor_fn(bytearray_object_destructor),
+    );
     debug_assert_eq!(w_bytearray_tid, W_BYTEARRAY_GC_TYPE_ID);
     majit_gc::GcAllocator::register_vtable_for_type(
         &mut gc,
@@ -1475,11 +1508,14 @@ fn build_gc() -> Box<dyn majit_gc::GcAllocator> {
     // W_SetObject carries `items: *mut IndexMap<ObjectKey, ()>`. Register a
     // custom trace hook so GC forwarding updates indirect key object slots.
     // Both `set` and `frozenset` PyTypes share this Rust struct/tid.
-    let w_set_tid = gc.register_type(TypeInfo::object_subclass_with_custom_trace(
-        std::mem::size_of::<pyre_object::setobject::W_SetObject>(),
-        object_tid,
-        set_object_custom_trace,
-    ));
+    let w_set_tid = gc.register_type(
+        TypeInfo::object_subclass_with_custom_trace(
+            std::mem::size_of::<pyre_object::setobject::W_SetObject>(),
+            object_tid,
+            set_object_custom_trace,
+        )
+        .with_destructor_fn(set_object_destructor),
+    );
     debug_assert_eq!(w_set_tid, W_SET_GC_TYPE_ID);
     majit_gc::GcAllocator::register_vtable_for_type(
         &mut gc,

--- a/pyre/pyre-object/src/bytearrayobject.rs
+++ b/pyre/pyre-object/src/bytearrayobject.rs
@@ -31,6 +31,19 @@ impl crate::lltype::GcType for W_BytearrayObject {
     const SIZE: usize = W_BYTEARRAY_OBJECT_SIZE;
 }
 
+/// Free the off-GC byte buffer owned by a `W_BytearrayObject`.
+///
+/// # Safety
+/// `obj` must point at a valid `W_BytearrayObject` whose `data` Box is not
+/// aliased by another owner.
+pub unsafe fn w_bytearray_dealloc(obj: PyObjectRef) {
+    let raw = unsafe { &mut *(obj as *mut W_BytearrayObject) };
+    if !raw.data.is_null() {
+        unsafe { drop(Box::from_raw(raw.data)) };
+        raw.data = std::ptr::null_mut();
+    }
+}
+
 /// Allocate a new bytearray filled with zeros.
 pub fn w_bytearray_new(size: usize) -> PyObjectRef {
     let data = crate::lltype::malloc_raw(vec![0u8; size]);

--- a/pyre/pyre-object/src/bytesobject.rs
+++ b/pyre/pyre-object/src/bytesobject.rs
@@ -34,6 +34,19 @@ impl crate::lltype::GcType for W_BytesObject {
     const SIZE: usize = W_BYTES_OBJECT_SIZE;
 }
 
+/// Free the off-GC byte buffer owned by a `W_BytesObject`.
+///
+/// # Safety
+/// `obj` must point at a valid `W_BytesObject` whose `data` Box is not
+/// aliased by another owner.
+pub unsafe fn w_bytes_dealloc(obj: PyObjectRef) {
+    let raw = unsafe { &mut *(obj as *mut W_BytesObject) };
+    if !raw.data.is_null() {
+        unsafe { drop(Box::from_raw(raw.data as *mut Vec<u8>)) };
+        raw.data = std::ptr::null();
+    }
+}
+
 /// Allocate a new bytes object from a byte slice.
 ///
 /// Allocates the `W_BytesObject` via `malloc_typed` (`NewWithVtable`) which

--- a/pyre/pyre-object/src/setobject.rs
+++ b/pyre/pyre-object/src/setobject.rs
@@ -39,6 +39,19 @@ impl crate::lltype::GcType for W_SetObject {
     const SIZE: usize = W_SET_OBJECT_SIZE;
 }
 
+/// Free the off-GC item container owned by a `W_SetObject`.
+///
+/// # Safety
+/// `obj` must point at a valid `W_SetObject` whose `items` Box is not aliased
+/// by another owner.
+pub unsafe fn w_set_dealloc_items(obj: PyObjectRef) {
+    let raw = &mut *(obj as *mut W_SetObject);
+    if !raw.items.is_null() {
+        drop(Box::from_raw(raw.items));
+        raw.items = std::ptr::null_mut();
+    }
+}
+
 #[inline]
 pub unsafe fn is_set(obj: PyObjectRef) -> bool {
     unsafe { py_type_check(obj, &SET_TYPE) }


### PR DESCRIPTION
## Summary

Follow-up to the `W_DictObject` (`dict_object_destructor`) and `W_ModuleDictObject` (`w_module_dict_dealloc_storage`) off-GC Box sweep-leak fixes. An audit of **every** GC-registered type found 4 more mortal types that own a `lltype::malloc_raw` (`Box::into_raw`) container the GC does not trace or free; with no `.with_destructor_fn`, the container leaked when a mortal instance was swept.

| Type | Leaked off-GC field |
|---|---|
| `W_BytesObject` | `data: *const Vec<u8>` |
| `W_BytearrayObject` | `data: *mut Vec<u8>` |
| `W_SetObject` | `items: *mut IndexMap<ObjectKey, ()>` (dict-dstorage analog) |
| `Function` | `name: *const String` (not in `FUNCTION_GC_PTR_OFFSETS`) |

Each gets a `*_dealloc` helper (null-check → `Box::from_raw` → null-after, idempotent) + a destructor in `eval.rs` + `.with_destructor_fn`, mirroring the two existing templates. The function destructor frees **only** `name` — `code`/closure/globals/defs are GC edges the collector reclaims.

## Safety

- Every freed field re-verified to be a genuine `malloc_raw`/`Box::into_raw` allocation, **not** a GC-managed one (not in the type's gc-ptr offsets / custom trace) — freeing a GC-owned field would double-free/UAF.
- Immortal builtin-code functions use `malloc_typed` → never enrolled in the GC destructor list → the function destructor never fires for them (no double-free).
- Dealloc helpers null after free, so a second call (e.g. `__name__` setter then sweep) is a no-op.
- bytearray grow / set rehash mutate the existing `Vec`/`IndexMap` in place; the outer raw Box pointer is stable and freed once on sweep — no separate leak.

## Verification

- `cargo test -p pyre-jit --features dynasm --test gc_stress` — 6/0 (the sweep gate)
- `cargo test -p pyre-object` — 211/0
- `cargo test --all --no-default-features --features dynasm` — 95 test binaries, 0 fail
- `python3 pyre/check.py` — dynasm 191/191, cranelift 191/191, output parity all backends

🤖 Generated with [Claude Code](https://claude.com/claude-code)
