### PR TITLE
jit: mapdict instance-attr folds + two resume-journal correctness fixes

### DIFF
--- a/majit/majit-ir/src/effectinfo.rs
+++ b/majit/majit-ir/src/effectinfo.rs
@@ -675,18 +675,22 @@ pub enum PyreHelperKind {
     /// `guard_value(getfield(obj, map), map)` + `getfield(obj, storage)` +
     /// `getarrayitem_gc_r(block, C_storageindex)` (the inline read
     /// `mapdict.py:914-916 _mapdict_read_storage`), eliding the opaque
-    /// `CALL_MAY_FORCE` MRO-walk residual.  Falls through to the residual for
-    /// every shape the storage read cannot cover (non-instance receiver, custom
-    /// `__getattribute__`, data descriptor, unboxed slot, attribute absent from
-    /// this instance's map).
+    /// `CALL_MAY_FORCE` MRO-walk residual.  An unboxed slot instead folds to a
+    /// non-forcing raw read of its longlong list (`mapdict.py:600-601
+    /// _prim_direct_read`) with the boxing left in the trace.  Falls through to
+    /// the residual for every shape neither read covers (non-instance receiver,
+    /// custom `__getattribute__`, data descriptor, attribute absent from this
+    /// instance's map, and an unboxed slot whose class has frozen unboxing,
+    /// whose read owes a migration the folded form cannot perform).
     LoadAttr,
     /// `bh_setattr_fn(obj, value, code, name_idx)` — the plain STORE_ATTR
     /// residual (`lower_setattr_hlop_to_insn` → `space.setattr`).  The Ref
     /// operands are the receiver, value, and jitcode's own PyCode; the Int
     /// operand is the co_names index.  The full-body walker recognises this
-    /// tag to fold a plain unboxed same-type integer store to a non-forcing
-    /// raw longlong-list write.  Every unsupported shape keeps the original
-    /// generic setattr residual.
+    /// tag to fold a same-type store to a non-forcing write: an unboxed int or
+    /// float slot takes a raw longlong-list write, a boxed slot a direct
+    /// storage write.  Every unsupported shape keeps the original generic
+    /// setattr residual.
     StoreAttr,
     /// aheui headerless-Node nursery allocation (`jit_alloc_node(value,next)`).
     /// The dynasm backend recognises this tag on the CallR descr to emit an

--- a/majit/majit-ir/src/effectinfo.rs
+++ b/majit/majit-ir/src/effectinfo.rs
@@ -680,6 +680,14 @@ pub enum PyreHelperKind {
     /// `__getattribute__`, data descriptor, unboxed slot, attribute absent from
     /// this instance's map).
     LoadAttr,
+    /// `bh_setattr_fn(obj, value, code, name_idx)` — the plain STORE_ATTR
+    /// residual (`lower_setattr_hlop_to_insn` → `space.setattr`).  The Ref
+    /// operands are the receiver, value, and jitcode's own PyCode; the Int
+    /// operand is the co_names index.  The full-body walker recognises this
+    /// tag to fold a plain unboxed same-type integer store to a non-forcing
+    /// raw longlong-list write.  Every unsupported shape keeps the original
+    /// generic setattr residual.
+    StoreAttr,
     /// aheui headerless-Node nursery allocation (`jit_alloc_node(value,next)`).
     /// The dynasm backend recognises this tag on the CallR descr to emit an
     /// inline nursery bump (RPython malloc_cond shape) instead of a full

--- a/majit/majit-metainterp/src/executor.rs
+++ b/majit/majit-metainterp/src/executor.rs
@@ -799,7 +799,7 @@ pub fn execute_pure_call(
             crate::pyjitpl::call_int_function(func_ptr, args)
         }
         majit_ir::Type::Void => {
-            crate::pyjitpl::call_void_function(func_ptr, args);
+            crate::pyjitpl::call_void_function_typed(func_ptr, args, descr.arg_types());
             0
         }
         // See `execute_varargs`'s Float arm for the i64-bits ABI rationale:
@@ -854,7 +854,7 @@ pub fn execute_residual_call(
             crate::pyjitpl::call_int_function(func_ptr, args)
         }
         majit_ir::Type::Void => {
-            crate::pyjitpl::call_void_function(func_ptr, args);
+            crate::pyjitpl::call_void_function_typed(func_ptr, args, descr.arg_types());
             0
         }
         // See `execute_varargs`'s Float arm for the i64-bits ABI

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -8,7 +8,9 @@ pub use dispatch::{
     trace_jitcode_with_args_and_runtime,
 };
 pub use dispatch::{build_vable_snapshot_boxes, build_vref_snapshot_boxes};
-pub use dispatch::{call_int_function, call_ref_function, call_void_function};
+pub use dispatch::{
+    call_int_function, call_ref_function, call_void_function, call_void_function_typed,
+};
 pub use dispatch::{eval_binop_f, eval_binop_i, eval_float_cmp, eval_unary_f, eval_unary_i};
 pub use frame::{MIFrame, MIFrameStack};
 

--- a/majit/majit-metainterp/src/pyjitpl/dispatch.rs
+++ b/majit/majit-metainterp/src/pyjitpl/dispatch.rs
@@ -8,7 +8,7 @@
 use std::marker::PhantomData;
 use std::sync::Arc;
 
-use majit_ir::{OpCode, OpRef, Value};
+use majit_ir::{OpCode, OpRef, Type, Value};
 
 use super::{MIFrame, MIFrameStack};
 use crate::jitcode::insns::MAX_HOST_CALL_ARITY;
@@ -7581,6 +7581,27 @@ pub fn call_void_function(func_ptr: *const (), args: &[i64]) {
                 MAX_HOST_CALL_ARITY
             ),
         }
+    }
+}
+
+/// Void-call dispatcher for signatures carrying Float-bank arguments.  Args
+/// reach here packed into machine words, so a float argument holds its bits in
+/// an `i64` while the callee's C ABI expects it in a floating-point register;
+/// only `arg_types` still records which is which.  Shapes with no float
+/// argument, and the host-trampoline path (which reflects the callee's real
+/// signature and coerces each argument itself), defer to `call_void_function`.
+pub fn call_void_function_typed(func_ptr: *const (), args: &[i64], arg_types: &[Type]) {
+    if majit_backend::call_stub::residual_host_call().is_some() || !arg_types.contains(&Type::Float)
+    {
+        call_void_function(func_ptr, args);
+        return;
+    }
+    match (args, arg_types) {
+        ([a0, a1, a2, a3], [Type::Ref, Type::Int, Type::Int, Type::Float]) => unsafe {
+            let func: extern "C" fn(i64, i64, i64, f64) = std::mem::transmute(func_ptr);
+            func(*a0, *a1, *a2, f64::from_bits(*a3 as u64));
+        },
+        _ => call_void_function(func_ptr, args),
     }
 }
 

--- a/pyre/bench/synth/mapdict_frozen_unboxing_fold.py
+++ b/pyre/bench/synth/mapdict_frozen_unboxing_fold.py
@@ -1,0 +1,47 @@
+# A type change on one instance freezes unboxing for the whole class
+# (mapdict.py:623). Instances created before the freeze keep an unboxed slot
+# until something reads it: `_direct_read` migrates them off unboxed storage
+# (mapdict.py:594-596). A folded read that performs `_prim_direct_read` alone
+# would skip that migration and leave unboxed and boxed instances mixed under
+# one promoted-map guard.
+N = 40000
+
+
+class C:
+    def __init__(self, v):
+        self.x = v
+
+
+def build(n):
+    # Created while unboxing is still allowed, so each gets an unboxed int
+    # slot, and none of them has been read yet.
+    objs = [C(i) for i in range(n)]
+    freeze = C(0)
+    freeze.x = 1.5
+    return objs, freeze.x
+
+
+def first_reads(objs, n):
+    total = 0
+    i = 0
+    while i < n:
+        total += objs[i].x
+        i += 1
+    return total
+
+
+def reread(objs, n):
+    # Every instance has migrated to boxed storage by now; the same loop must
+    # keep reading the same values.
+    total = 0
+    i = 0
+    while i < n:
+        total += objs[i].x
+        i += 1
+    return total
+
+
+objs, frozen_value = build(N)
+print(first_reads(objs, N))
+print(reread(objs, N))
+print(frozen_value)

--- a/pyre/bench/synth/mapdict_polymorphic_map_attr.py
+++ b/pyre/bench/synth/mapdict_polymorphic_map_attr.py
@@ -1,0 +1,26 @@
+# One LOAD_ATTR site alternates between maps whose insertion order assigns
+# different storage slots to `q`; promoting the map must guard the selected
+# storage coordinate, while a class-layout guard alone cannot (mapdict.py:905-916).
+class A:
+    def __init__(self):
+        self.p = 1
+        self.q = 2
+
+
+class B:
+    def __init__(self):
+        self.q = 20
+        self.p = 10
+
+
+def run(n):
+    objects = [A(), B()]
+    total = 0
+    i = 0
+    while i < n:
+        total += objects[i % 2].q
+        i += 1
+    return total
+
+
+print(run(200000))

--- a/pyre/bench/synth/mapdict_unboxed_type_change_attr.py
+++ b/pyre/bench/synth/mapdict_unboxed_type_change_attr.py
@@ -1,0 +1,41 @@
+# Changing an unboxed int or float slot to the other type creates a boxed map;
+# the promoted-map guard must deopt before the old raw-storage read or write is
+# reused for the new representation (mapdict.py:577-584, 600-619, 905-916).
+class IntSlot:
+    def __init__(self):
+        self.x = 0
+
+
+class FloatSlot:
+    def __init__(self):
+        self.x = 0.0
+
+
+def run_int(n):
+    obj = IntSlot()
+    total = 0
+    i = 0
+    while i < n:
+        obj.x = obj.x + 1
+        if i == n // 2:
+            obj.x = 1.5
+        total += int(obj.x)
+        i += 1
+    return total, obj.x
+
+
+def run_float(n):
+    obj = FloatSlot()
+    total = 0.0
+    i = 0
+    while i < n:
+        obj.x = obj.x + 1.0
+        if i == n // 2:
+            obj.x = 7
+        total += float(obj.x)
+        i += 1
+    return total, obj.x
+
+
+print(run_int(100000))
+print(run_float(100000))

--- a/pyre/check.py
+++ b/pyre/check.py
@@ -365,6 +365,9 @@ def synth_perf_gate(path):
         # pyre-check: max-pypy-ratio=30
     Keeping the gate beside the workload makes a changed loop count or known
     slow path reviewable with the test that needs the allowance.
+
+    The limit is read against the native backends only; `run_synthetic_bench`
+    exempts wasm.
     """
     prefix = "# pyre-check: max-pypy-ratio="
     with open(path, encoding="utf-8") as source:
@@ -1166,9 +1169,15 @@ class Check:
         for backend in ALL_BACKENDS:
             if not self.enabled(backend):
                 continue
+            # wasm carries no perf-ratio gate, matching `run_bench` (which has no
+            # `wasm_vs_*` parameter at all): it legitimately runs a few× slower
+            # than the native backends a fixture's ratio is tuned for, so one
+            # ratio cannot gate both — see WASM_TIMEOUT_SCALE. Its per-bench
+            # timeout stays the hang guard.
+            vs_pypy = None if backend == "wasm" else max_pypy_ratio
             self._run_backend_bench(
                 backend, name, path, timeout,
-                None, max_pypy_ratio, t_cpython, t_pypy, pypy_output,
+                None, vs_pypy, t_cpython, t_pypy, pypy_output,
             )
 
     def run_synthetic_suite(self):

--- a/pyre/pyre-interpreter/src/objspace/std/mapdict.rs
+++ b/pyre/pyre-interpreter/src/objspace/std/mapdict.rs
@@ -1258,14 +1258,59 @@ pub unsafe fn load_attr_unboxed_fast_path(
     let attr = unsafe { find_map_attr(map, Wtf8::new(attrname), attrkind) }?;
     let p = unsafe { (*attr).as_plain() };
     let u = p.unboxed.as_ref()?;
-    Some((
-        w_type,
-        version_tag,
-        map,
-        p.storageindex,
-        u.listindex,
-        u.typ,
-    ))
+    Some((w_type, version_tag, map, p.storageindex, u.listindex, u.typ))
+}
+
+/// The STORE_ATTR counterpart of [`load_attr_unboxed_fast_path`].  An
+/// existing plain unboxed slot resolves through the same map lookup; the
+/// caller separately proves that the incoming value has the slot's unbox
+/// type before performing the in-place write (mapdict.py:615-619).
+///
+/// # Safety
+/// `w_obj` must be a live object.
+pub unsafe fn store_attr_unboxed_fast_path(
+    w_obj: PyObjectRef,
+    name: &str,
+) -> Option<(PyObjectRef, u64, MapRef, usize, usize, UnboxType)> {
+    if name == "__class__" {
+        return None;
+    }
+    // mapdict.py:1591 `if map is not None:` — also filters non-instances.
+    let map = unsafe { mapdict_map_or_null(w_obj) };
+    if map.is_null() {
+        return None;
+    }
+    // mapdict.py:1592 `w_type = map.terminator.w_cls`.
+    let w_type = unsafe { (*(*map).terminator()).as_terminator() }.w_cls;
+    if w_type.is_null() {
+        return None;
+    }
+    // mapdict.py:1612-1614 — a custom `__setattr__` owns the write.
+    if unsafe { crate::baseobjspace::setattr_if_not_from_object(w_type) }.is_some() {
+        return None;
+    }
+    // mapdict.py:1630-1631 — STORE caching also requires the standard
+    // `__getattribute__` so the cached map invariant remains valid.
+    if unsafe { crate::baseobjspace::getattribute_if_not_from_object(w_type) }.is_some() {
+        return None;
+    }
+    // mapdict.py:1616 `if version_tag is not None:`.
+    let version_tag = unsafe { crate::baseobjspace::w_type_version_tag(w_type) };
+    if version_tag == 0 {
+        return None;
+    }
+    // mapdict.py:1618-1627 `_pure_lookup_where_with_method_cache` + classify.
+    let w_descr = unsafe { crate::baseobjspace::lookup_in_type_where(w_type, name) };
+    let (attrkind, is_slot) = unsafe { classify_attr(w_type, w_descr, true) };
+    if attrkind == INVALID {
+        return None;
+    }
+    let attrname = if is_slot { "slot" } else { name };
+    // mapdict.py:1628 `attr = map.find_map_attr(attrname, attrkind)`.
+    let attr = unsafe { find_map_attr(map, Wtf8::new(attrname), attrkind) }?;
+    let p = unsafe { (*attr).as_plain() };
+    let u = p.unboxed.as_ref()?;
+    Some((w_type, version_tag, map, p.storageindex, u.listindex, u.typ))
 }
 
 /// mapdict.py:914-916 `_mapdict_read_storage(storageindex)` for a
@@ -1299,6 +1344,26 @@ pub unsafe fn read_unboxed_storage_raw(
     unsafe {
         let list: &Vec<i64> = &*unerase_unboxed(slot);
         list[listindex]
+    }
+}
+
+/// Write a raw longlong to an unboxed attribute's `(storageindex,
+/// listindex)`, matching the same-type `_direct_write` update before any
+/// boxing conversion (mapdict.py:615-619).
+///
+/// # Safety
+/// `w_obj` must be a live `W_ObjectObject` whose guarded map owns the supplied
+/// unboxed storage coordinates.
+pub unsafe fn write_unboxed_storage_raw(
+    w_obj: PyObjectRef,
+    storageindex: usize,
+    listindex: usize,
+    raw: i64,
+) {
+    let slot = unsafe { read_boxed_storage(w_obj, storageindex) };
+    unsafe {
+        let list: &mut Vec<i64> = &mut *unerase_unboxed(slot);
+        list[listindex] = raw;
     }
 }
 

--- a/pyre/pyre-interpreter/src/objspace/std/mapdict.rs
+++ b/pyre/pyre-interpreter/src/objspace/std/mapdict.rs
@@ -1313,6 +1313,60 @@ pub unsafe fn store_attr_unboxed_fast_path(
     Some((w_type, version_tag, map, p.storageindex, u.listindex, u.typ))
 }
 
+/// Resolve an existing boxed plain slot through the STORE_ATTR caching gates.
+/// Unlike an unboxed slot, the value remains a `PyObjectRef`, so the caller
+/// needs only the guarded map and storage index for the direct write
+/// (mapdict.py:446-447).
+///
+/// # Safety
+/// `w_obj` must be a live object.
+pub unsafe fn store_attr_boxed_fast_path(
+    w_obj: PyObjectRef,
+    name: &str,
+) -> Option<(PyObjectRef, u64, MapRef, usize)> {
+    if name == "__class__" {
+        return None;
+    }
+    // mapdict.py:1591 `if map is not None:` — also filters non-instances.
+    let map = unsafe { mapdict_map_or_null(w_obj) };
+    if map.is_null() {
+        return None;
+    }
+    // mapdict.py:1592 `w_type = map.terminator.w_cls`.
+    let w_type = unsafe { (*(*map).terminator()).as_terminator() }.w_cls;
+    if w_type.is_null() {
+        return None;
+    }
+    // mapdict.py:1612-1614 — a custom `__setattr__` owns the write.
+    if unsafe { crate::baseobjspace::setattr_if_not_from_object(w_type) }.is_some() {
+        return None;
+    }
+    // mapdict.py:1630-1631 — STORE caching also requires the standard
+    // `__getattribute__` so the cached map invariant remains valid.
+    if unsafe { crate::baseobjspace::getattribute_if_not_from_object(w_type) }.is_some() {
+        return None;
+    }
+    // mapdict.py:1616 `if version_tag is not None:`.
+    let version_tag = unsafe { crate::baseobjspace::w_type_version_tag(w_type) };
+    if version_tag == 0 {
+        return None;
+    }
+    // mapdict.py:1618-1627 `_pure_lookup_where_with_method_cache` + classify.
+    let w_descr = unsafe { crate::baseobjspace::lookup_in_type_where(w_type, name) };
+    let (attrkind, is_slot) = unsafe { classify_attr(w_type, w_descr, true) };
+    if attrkind == INVALID {
+        return None;
+    }
+    let attrname = if is_slot { "slot" } else { name };
+    // mapdict.py:1628 `attr = map.find_map_attr(attrname, attrkind)`.
+    let attr = unsafe { find_map_attr(map, Wtf8::new(attrname), attrkind) }?;
+    let p = unsafe { (*attr).as_plain() };
+    if p.unboxed.is_some() {
+        return None;
+    }
+    Some((w_type, version_tag, map, p.storageindex))
+}
+
 /// mapdict.py:914-916 `_mapdict_read_storage(storageindex)` for a
 /// `W_ObjectObject` — the boxed-slot read the JIT LOAD_ATTR fast path folds
 /// to. `load_attr_fast_path` already established that the resolved attribute
@@ -1326,6 +1380,17 @@ pub unsafe fn store_attr_unboxed_fast_path(
 pub unsafe fn read_boxed_storage(w_obj: PyObjectRef, storageindex: usize) -> PyObjectRef {
     let inst = unsafe { &*(w_obj as *const pyre_object::W_ObjectObject) };
     inst._mapdict_read_storage(storageindex)
+}
+
+/// Write a boxed attribute value directly to an existing storage slot,
+/// matching `PlainAttribute._direct_write` (mapdict.py:446-447).
+///
+/// # Safety
+/// `w_obj` must be a live `W_ObjectObject` whose guarded map owns the supplied
+/// boxed storage index.
+pub unsafe fn write_boxed_storage(w_obj: PyObjectRef, storageindex: usize, value: PyObjectRef) {
+    let inst = unsafe { &mut *(w_obj as *mut pyre_object::W_ObjectObject) };
+    inst._mapdict_write_storage(storageindex, value);
 }
 
 /// Read the raw longlong at an unboxed attribute's `(storageindex,

--- a/pyre/pyre-interpreter/src/objspace/std/mapdict.rs
+++ b/pyre/pyre-interpreter/src/objspace/std/mapdict.rs
@@ -1258,6 +1258,17 @@ pub unsafe fn load_attr_unboxed_fast_path(
     let attr = unsafe { find_map_attr(map, Wtf8::new(attrname), attrkind) }?;
     let p = unsafe { (*attr).as_plain() };
     let u = p.unboxed.as_ref()?;
+    // mapdict.py:1539 — `LOAD_ATTR_caching` resolves to `attr._direct_read`,
+    // which for an unboxed attribute also migrates `obj` off unboxed storage
+    // once its class froze unboxing (mapdict.py:594-596). The folded read
+    // performs `_prim_direct_read` alone, so leave a frozen class to the
+    // residual, whose `direct_read` still runs that migration.
+    if !unsafe { (*p.terminator).as_terminator() }
+        .allow_unboxing
+        .get()
+    {
+        return None;
+    }
     Some((w_type, version_tag, map, p.storageindex, u.listindex, u.typ))
 }
 
@@ -1265,6 +1276,10 @@ pub unsafe fn load_attr_unboxed_fast_path(
 /// existing plain unboxed slot resolves through the same map lookup; the
 /// caller separately proves that the incoming value has the slot's unbox
 /// type before performing the in-place write (mapdict.py:615-619).
+///
+/// Resolving marks the attribute `ever_mutated`, as `STORE_ATTR_caching` does
+/// before `_direct_write` (mapdict.py:1635-1637): the write the caller folds
+/// out of the trace must not leave the attribute looking unmutated.
 ///
 /// # Safety
 /// `w_obj` must be a live object.
@@ -1310,6 +1325,10 @@ pub unsafe fn store_attr_unboxed_fast_path(
     let attr = unsafe { find_map_attr(map, Wtf8::new(attrname), attrkind) }?;
     let p = unsafe { (*attr).as_plain() };
     let u = p.unboxed.as_ref()?;
+    // mapdict.py:1635-1636 `if not attr.ever_mutated: attr.ever_mutated = True`.
+    if !p.ever_mutated.get() {
+        p.ever_mutated.set(true);
+    }
     Some((w_type, version_tag, map, p.storageindex, u.listindex, u.typ))
 }
 
@@ -1317,6 +1336,9 @@ pub unsafe fn store_attr_unboxed_fast_path(
 /// Unlike an unboxed slot, the value remains a `PyObjectRef`, so the caller
 /// needs only the guarded map and storage index for the direct write
 /// (mapdict.py:446-447).
+///
+/// Marks `ever_mutated` on the resolved attribute for the same reason as
+/// [`store_attr_unboxed_fast_path`].
 ///
 /// # Safety
 /// `w_obj` must be a live object.
@@ -1363,6 +1385,10 @@ pub unsafe fn store_attr_boxed_fast_path(
     let p = unsafe { (*attr).as_plain() };
     if p.unboxed.is_some() {
         return None;
+    }
+    // mapdict.py:1635-1636 `if not attr.ever_mutated: attr.ever_mutated = True`.
+    if !p.ever_mutated.get() {
+        p.ever_mutated.set(true);
     }
     Some((w_type, version_tag, map, p.storageindex))
 }

--- a/pyre/pyre-interpreter/src/objspace/std/mapdict.rs
+++ b/pyre/pyre-interpreter/src/objspace/std/mapdict.rs
@@ -1215,6 +1215,59 @@ pub unsafe fn load_attr_fast_path(
     Some((w_type, version_tag, map, p.storageindex))
 }
 
+/// The unboxed counterpart of [`load_attr_fast_path`].  It applies the same
+/// LOAD_ATTR resolution gates, but accepts only an `UnboxedPlainAttribute`
+/// and returns the shared longlong-list coordinates and type needed to perform
+/// `_prim_direct_read` (mapdict.py:600-601).
+///
+/// # Safety
+/// `w_obj` must be a live object.
+pub unsafe fn load_attr_unboxed_fast_path(
+    w_obj: PyObjectRef,
+    name: &str,
+) -> Option<(PyObjectRef, u64, MapRef, usize, usize, UnboxType)> {
+    // mapdict.py:1495 `if map is not None:` — also filters non-instances.
+    let map = unsafe { mapdict_map_or_null(w_obj) };
+    if map.is_null() {
+        return None;
+    }
+    // mapdict.py:1496 `w_type = map.terminator.w_cls`.
+    let w_type = unsafe { (*(*map).terminator()).as_terminator() }.w_cls;
+    if w_type.is_null() {
+        return None;
+    }
+    // mapdict.py:1497-1499 — a custom `__getattribute__` handles the access;
+    // not soundly foldable to a storage read.
+    if unsafe { crate::baseobjspace::getattribute_if_not_from_object(w_type) }.is_some() {
+        return None;
+    }
+    // mapdict.py:1500-1501 `version_tag = w_type.version_tag(); if is not None:`.
+    let version_tag = unsafe { crate::baseobjspace::w_type_version_tag(w_type) };
+    if version_tag == 0 {
+        return None;
+    }
+    // mapdict.py:1504-1524 `_pure_lookup_where_with_method_cache` + classify.
+    let w_descr = unsafe { crate::baseobjspace::lookup_in_type_where(w_type, name) };
+    let (attrkind, is_slot) = unsafe { classify_attr(w_type, w_descr, false) };
+    // mapdict.py:1526 `if attrkind != INVALID:`.
+    if attrkind == INVALID {
+        return None;
+    }
+    let attrname = if is_slot { "slot" } else { name };
+    // mapdict.py:1527 `attr = map.find_map_attr(attrname, attrkind)`.
+    let attr = unsafe { find_map_attr(map, Wtf8::new(attrname), attrkind) }?;
+    let p = unsafe { (*attr).as_plain() };
+    let u = p.unboxed.as_ref()?;
+    Some((
+        w_type,
+        version_tag,
+        map,
+        p.storageindex,
+        u.listindex,
+        u.typ,
+    ))
+}
+
 /// mapdict.py:914-916 `_mapdict_read_storage(storageindex)` for a
 /// `W_ObjectObject` — the boxed-slot read the JIT LOAD_ATTR fast path folds
 /// to. `load_attr_fast_path` already established that the resolved attribute
@@ -1228,6 +1281,25 @@ pub unsafe fn load_attr_fast_path(
 pub unsafe fn read_boxed_storage(w_obj: PyObjectRef, storageindex: usize) -> PyObjectRef {
     let inst = unsafe { &*(w_obj as *const pyre_object::W_ObjectObject) };
     inst._mapdict_read_storage(storageindex)
+}
+
+/// Read the raw longlong at an unboxed attribute's `(storageindex,
+/// listindex)`, matching `_prim_direct_read` before it boxes the value
+/// (mapdict.py:600-601).
+///
+/// # Safety
+/// `w_obj` must be a live `W_ObjectObject` whose guarded map owns the supplied
+/// unboxed storage coordinates.
+pub unsafe fn read_unboxed_storage_raw(
+    w_obj: PyObjectRef,
+    storageindex: usize,
+    listindex: usize,
+) -> i64 {
+    let slot = unsafe { read_boxed_storage(w_obj, storageindex) };
+    unsafe {
+        let list: &Vec<i64> = &*unerase_unboxed(slot);
+        list[listindex]
+    }
 }
 
 /// mapdict.py:1574-1586 `STORE_ATTR_caching`. The interpreter STORE_ATTR fast

--- a/pyre/pyre-jit-trace/src/helpers.rs
+++ b/pyre/pyre-jit-trace/src/helpers.rs
@@ -62,6 +62,19 @@ pub fn emit_trace_call_int_typed(
     ctx.call_int_typed_with_effect(helper, args, arg_types, default_effect_info())
 }
 
+/// Float-bank counterpart of [`emit_trace_call_int_typed`], recording a `CallF`
+/// for a helper whose C ABI returns its `f64` in a floating-point register.
+/// Carries the same conservative `default_effect_info()`, so the two differ only
+/// in the result bank.
+pub fn emit_trace_call_float_typed(
+    ctx: &mut TraceCtx,
+    helper: *const (),
+    args: &[OpRef],
+    arg_types: &[Type],
+) -> OpRef {
+    ctx.call_float_typed_with_effect(helper, args, arg_types, default_effect_info())
+}
+
 /// `pyjitpl.py:1941-1958 MIFrame.execute_varargs(opnum, argboxes, descr,
 /// exc=False, pure=True)` parity for direct trace emit paths.
 ///
@@ -269,6 +282,26 @@ pub extern "C" fn jit_mapdict_unboxed_read_raw(
     }
 }
 
+/// Float-bank counterpart of [`jit_mapdict_unboxed_read_raw`].  Unboxed float
+/// storage already contains the value's IEEE-754 bit pattern, so this helper
+/// performs the raw read and reconstructs the float (mapdict.py:577-584).
+/// Null receiver / non-instance returns zero only for a torn recording.
+pub extern "C" fn jit_mapdict_unboxed_read_f(w_obj: i64, storageindex: i64, listindex: i64) -> f64 {
+    let w_obj = w_obj as PyObjectRef;
+    if w_obj.is_null() || !unsafe { is_instance(w_obj) } {
+        return 0.0;
+    }
+    unsafe {
+        f64::from_bits(
+            pyre_interpreter::objspace::std::mapdict::read_unboxed_storage_raw(
+                w_obj,
+                storageindex as usize,
+                listindex as usize,
+            ) as u64,
+        )
+    }
+}
+
 /// Non-forcing raw write for a mapdict unboxed attribute.  The full-body
 /// walker has already guarded the receiver's instance class and exact map,
 /// and proved that the incoming value is an integer, so this is only the
@@ -291,6 +324,30 @@ pub extern "C" fn jit_mapdict_unboxed_write_raw(
             storageindex as usize,
             listindex as usize,
             raw,
+        );
+    }
+}
+
+/// Float-bank counterpart of [`jit_mapdict_unboxed_write_raw`].  A same-type
+/// float update writes its IEEE-754 bit pattern to the existing longlong-list
+/// slot (mapdict.py:615-619).  A torn recording with a null/non-instance
+/// receiver is a defensive no-op.
+pub extern "C" fn jit_mapdict_unboxed_write_f(
+    w_obj: i64,
+    storageindex: i64,
+    listindex: i64,
+    value: f64,
+) {
+    let w_obj = w_obj as usize as PyObjectRef;
+    if w_obj.is_null() || !unsafe { is_instance(w_obj) } {
+        return;
+    }
+    unsafe {
+        pyre_interpreter::objspace::std::mapdict::write_unboxed_storage_raw(
+            w_obj,
+            storageindex as usize,
+            listindex as usize,
+            value.to_bits() as i64,
         );
     }
 }

--- a/pyre/pyre-jit-trace/src/helpers.rs
+++ b/pyre/pyre-jit-trace/src/helpers.rs
@@ -259,6 +259,24 @@ pub extern "C" fn jit_mapdict_read(w_obj: i64, storageindex: i64) -> i64 {
     }
 }
 
+/// Non-forcing boxed write for an existing mapdict attribute.  The guarded
+/// instance class and exact map pin the storage index, and a boxed slot accepts
+/// the incoming object reference directly (mapdict.py:446-447).  A torn
+/// recording with a null/non-instance receiver is a defensive no-op.
+pub extern "C" fn jit_mapdict_boxed_write(w_obj: i64, storageindex: i64, value: i64) {
+    let w_obj = w_obj as PyObjectRef;
+    if w_obj.is_null() || !unsafe { is_instance(w_obj) } {
+        return;
+    }
+    unsafe {
+        pyre_interpreter::objspace::std::mapdict::write_boxed_storage(
+            w_obj,
+            storageindex as usize,
+            value as PyObjectRef,
+        );
+    }
+}
+
 /// Raw unboxed counterpart of [`jit_mapdict_read`].  The guarded map pins the
 /// shared longlong-list coordinates, so this non-forcing helper performs only
 /// `_prim_direct_read`'s storage read (mapdict.py:600-601); boxing stays in the

--- a/pyre/pyre-jit-trace/src/helpers.rs
+++ b/pyre/pyre-jit-trace/src/helpers.rs
@@ -269,6 +269,32 @@ pub extern "C" fn jit_mapdict_unboxed_read_raw(
     }
 }
 
+/// Non-forcing raw write for a mapdict unboxed attribute.  The full-body
+/// walker has already guarded the receiver's instance class and exact map,
+/// and proved that the incoming value is an integer, so this is only the
+/// same-type longlong-list update (mapdict.py:615-619).  A torn recording can
+/// reach the wrapper with a null/non-instance receiver; keep that defensive
+/// path a no-op.
+pub extern "C" fn jit_mapdict_unboxed_write_raw(
+    w_obj: i64,
+    storageindex: i64,
+    listindex: i64,
+    raw: i64,
+) {
+    let w_obj = w_obj as usize as PyObjectRef;
+    if w_obj.is_null() || !unsafe { is_instance(w_obj) } {
+        return;
+    }
+    unsafe {
+        pyre_interpreter::objspace::std::mapdict::write_unboxed_storage_raw(
+            w_obj,
+            storageindex as usize,
+            listindex as usize,
+            raw,
+        );
+    }
+}
+
 pub fn emit_trace_call_void(ctx: &mut TraceCtx, helper: *const (), args: &[OpRef]) {
     ctx.call_void(helper, args);
 }

--- a/pyre/pyre-jit-trace/src/helpers.rs
+++ b/pyre/pyre-jit-trace/src/helpers.rs
@@ -246,6 +246,29 @@ pub extern "C" fn jit_mapdict_read(w_obj: i64, storageindex: i64) -> i64 {
     }
 }
 
+/// Raw unboxed counterpart of [`jit_mapdict_read`].  The guarded map pins the
+/// shared longlong-list coordinates, so this non-forcing helper performs only
+/// `_prim_direct_read`'s storage read (mapdict.py:600-601); boxing stays in the
+/// trace so an immediate consumer can virtualize it away.  Null receiver /
+/// non-instance returns zero only for a torn recording.
+pub extern "C" fn jit_mapdict_unboxed_read_raw(
+    w_obj: i64,
+    storageindex: i64,
+    listindex: i64,
+) -> i64 {
+    let w_obj = w_obj as PyObjectRef;
+    if w_obj.is_null() || !unsafe { is_instance(w_obj) } {
+        return 0;
+    }
+    unsafe {
+        pyre_interpreter::objspace::std::mapdict::read_unboxed_storage_raw(
+            w_obj,
+            storageindex as usize,
+            listindex as usize,
+        )
+    }
+}
+
 pub fn emit_trace_call_void(ctx: &mut TraceCtx, helper: *const (), args: &[OpRef]) {
     ctx.call_void(helper, args);
 }

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -17993,8 +17993,8 @@ fn walker_guard_mapdict_instance_shape(
 /// `mapdict.py:1479-1537 LOAD_ATTR_caching` full-body-walker fast path for a
 /// plain (non-method) instance attribute.  When the concrete receiver is a
 /// monomorphic instance whose attribute resolves to a boxed plain storage slot
-/// or an unboxed integer slot, emit the guarded read PyPy compiles LOAD_ATTR to
-/// under the JIT —
+/// or an unboxed integer/float slot, emit the guarded read PyPy compiles
+/// LOAD_ATTR to under the JIT —
 ///   * `guard_class(obj, &INSTANCE_TYPE)` — the receiver is a `W_ObjectObject`
 ///     (so the `map`/`storage` field reads below are valid; `mapdict.py:1495`
 ///     `if map is not None:` also filters non-instances at trace time).
@@ -18007,18 +18007,18 @@ fn walker_guard_mapdict_instance_shape(
 ///   * boxed: `getfield_gc_r(obj, storage)` +
 ///     `getarrayitem_gc_r(block, C_index)` for
 ///     `mapdict.py:914-916 _mapdict_read_storage`;
-///   * unboxed int: a non-forcing raw longlong read plus `wrapint`, matching
-///     `_prim_direct_read` (mapdict.py:600-601).
+///   * unboxed int/float: a non-forcing typed read plus `wrapint`/`wrapfloat`,
+///     matching `_prim_direct_read` (mapdict.py:577-584, 600-601).
 /// — instead of the opaque `getattr_fn` `CALL_MAY_FORCE` MRO-walk residual.
 ///
 /// Returns `Some(())` after writing the dst; `None` (fall through to the
 /// residual) for every shape [`load_attr_fast_path`] declines: non-instance
 /// receiver, missing map, custom `__getattribute__`, uncacheable `version_tag`,
-/// a data-descriptor / `INVALID` classification, an attribute not on this
-/// instance's map, or an unboxed float slot.  The map `guard_value` proves the
-/// attribute is present on this shape, so a successful fold provably cannot
-/// raise `AttributeError` — dropping the residual's exception guard is sound
-/// even in a handler-bearing body (same reasoning as the LoadGlobal fold).
+/// a data-descriptor / `INVALID` classification, or an attribute not on this
+/// instance's map.  The map `guard_value` proves the attribute is present on
+/// this shape, so a successful fold provably cannot raise `AttributeError` —
+/// dropping the residual's exception guard is sound even in a handler-bearing
+/// body (same reasoning as the LoadGlobal fold).
 #[allow(clippy::too_many_arguments)]
 fn try_walker_specialize_load_attr(
     ctx: &mut WalkContext<'_, '_>,
@@ -18069,12 +18069,6 @@ fn try_walker_specialize_load_attr(
     }) else {
         return Ok(None);
     };
-    // Float slots still use the unchanged getattr residual until an Int-bank
-    // longlong-to-Float-bank bitcast is available to feed `wrapfloat`.
-    if unbox_type == pyre_interpreter::objspace::std::mapdict::UnboxType::Float {
-        return Ok(None);
-    }
-
     walker_guard_mapdict_instance_shape(ctx, op_pc, obj, w_type, version_tag, map)?;
 
     // `_prim_direct_read` (mapdict.py:600-601): read the raw longlong from the
@@ -18083,16 +18077,6 @@ fn try_walker_specialize_load_attr(
     // lets an immediate integer consumer virtualize it away.
     let storageindex_const = ctx.trace_ctx.const_int(storageindex as i64);
     let listindex_const = ctx.trace_ctx.const_int(listindex as i64);
-    let raw = crate::helpers::emit_trace_call_int_typed(
-        ctx.trace_ctx,
-        crate::helpers::jit_mapdict_unboxed_read_raw as *const (),
-        &[obj, storageindex_const, listindex_const],
-        &[
-            majit_ir::Type::Ref,
-            majit_ir::Type::Int,
-            majit_ir::Type::Int,
-        ],
-    );
     let live = unsafe {
         pyre_interpreter::objspace::std::mapdict::read_unboxed_storage_raw(
             concrete_obj,
@@ -18100,19 +18084,55 @@ fn try_walker_specialize_load_attr(
             listindex,
         )
     };
-    ctx.trace_ctx
-        .set_opref_concrete(raw, majit_ir::Value::Int(live));
-    let boxed = walker_box_int(ctx, op_pc, raw, live)?;
-    // The `wrapint` op is a heap box, so its concrete must be a heap ptr too:
-    // box the raw longlong through the same `w_int_new` the unboxed read uses
-    // (mapdict.py:579-584 `_box`); `box_int_concrete` re-homes a tagged small
-    // int to a fresh heap `W_IntObject` so op(NewWithVtable) == concrete(heap).
-    // Without this stamp the boxed result carries no concrete, so a downstream
-    // eager void residual (e.g. the STORE_ATTR that writes `self.value`) cannot
-    // resolve its value arg and the walk aborts `ResidualCallArgUnbound`.
-    let live_ptr = pyre_object::w_int_new(live) as i64;
-    ctx.trace_ctx
-        .set_opref_concrete(boxed, box_int_concrete(live, live_ptr));
+    let boxed = match unbox_type {
+        pyre_interpreter::objspace::std::mapdict::UnboxType::Int => {
+            let raw = crate::helpers::emit_trace_call_int_typed(
+                ctx.trace_ctx,
+                crate::helpers::jit_mapdict_unboxed_read_raw as *const (),
+                &[obj, storageindex_const, listindex_const],
+                &[
+                    majit_ir::Type::Ref,
+                    majit_ir::Type::Int,
+                    majit_ir::Type::Int,
+                ],
+            );
+            ctx.trace_ctx
+                .set_opref_concrete(raw, majit_ir::Value::Int(live));
+            let boxed = walker_box_int(ctx, op_pc, raw, live)?;
+            // The `wrapint` op is a heap box, so its concrete must be a heap ptr too:
+            // box the raw longlong through the same `w_int_new` the unboxed read uses
+            // (mapdict.py:579-584 `_box`); `box_int_concrete` re-homes a tagged small
+            // int to a fresh heap `W_IntObject` so op(NewWithVtable) == concrete(heap).
+            // Without this stamp the boxed result carries no concrete, so a downstream
+            // eager void residual (e.g. the STORE_ATTR that writes `self.value`) cannot
+            // resolve its value arg and the walk aborts `ResidualCallArgUnbound`.
+            let live_ptr = pyre_object::w_int_new(live) as i64;
+            ctx.trace_ctx
+                .set_opref_concrete(boxed, box_int_concrete(live, live_ptr));
+            boxed
+        }
+        pyre_interpreter::objspace::std::mapdict::UnboxType::Float => {
+            let raw = crate::helpers::emit_trace_call_float_typed(
+                ctx.trace_ctx,
+                crate::helpers::jit_mapdict_unboxed_read_f as *const (),
+                &[obj, storageindex_const, listindex_const],
+                &[
+                    majit_ir::Type::Ref,
+                    majit_ir::Type::Int,
+                    majit_ir::Type::Int,
+                ],
+            );
+            let live_f = f64::from_bits(live as u64);
+            ctx.trace_ctx
+                .set_opref_concrete(raw, majit_ir::Value::Float(live_f));
+            let boxed = crate::state::wrapfloat(ctx.trace_ctx, raw);
+            ctx.trace_ctx.set_opref_concrete(
+                boxed,
+                majit_ir::Value::Ref(majit_ir::GcRef(pyre_object::w_float_new(live_f) as usize)),
+            );
+            boxed
+        }
+    };
     write_residual_call_result_to_dst(ctx, op_pc, dst, dst_bank, boxed)?;
     Ok(Some(()))
 }
@@ -18354,12 +18374,12 @@ fn try_walker_fold_load_method_self(
 }
 
 /// STORE_ATTR mirror of [`try_walker_specialize_load_attr`] for an existing
-/// unboxed integer slot.  Recognition proves the plain mapdict write cannot
-/// invoke Python or raise; the returned descriptor/arglist replaces only the
-/// residual helper and effect.  The caller deliberately continues through the
-/// generic residual recorder/executor so concrete execution, body-effect
+/// unboxed integer or float slot.  Recognition proves the plain mapdict write
+/// cannot invoke Python or raise; the returned descriptor/arglist replaces only
+/// the residual helper and effect.  The caller deliberately continues through
+/// the generic residual recorder/executor so concrete execution, body-effect
 /// tracking, and rollback semantics remain identical to the generic setattr
-/// path (mapdict.py:615-619).
+/// path (mapdict.py:577-584, 615-619).
 fn try_walker_specialize_store_attr(
     ctx: &mut WalkContext<'_, '_>,
     op_pc: usize,
@@ -18394,27 +18414,53 @@ fn try_walker_specialize_store_attr(
     }) else {
         return Ok(None);
     };
-    if unbox_type != pyre_interpreter::objspace::std::mapdict::UnboxType::Int {
-        return Ok(None);
-    }
-    // `type(w_value) is space.IntObjectCls` (mapdict.py:615): reject bool,
-    // float, boxed/type-changing values, and every value whose concrete
-    // payload is not the integer representation before emitting any guards.
-    if unsafe {
-        pyre_object::pyobject::is_bool(concrete_value)
-            || !pyre_object::pyobject::is_int(concrete_value)
-    } {
-        return Ok(None);
+    match unbox_type {
+        pyre_interpreter::objspace::std::mapdict::UnboxType::Int => {
+            // `type(w_value) is space.IntObjectCls` (mapdict.py:615): reject bool
+            // and every type-changing value before emitting any guards.
+            if unsafe {
+                pyre_object::pyobject::is_bool(concrete_value)
+                    || !pyre_object::pyobject::is_int(concrete_value)
+            } {
+                return Ok(None);
+            }
+        }
+        pyre_interpreter::objspace::std::mapdict::UnboxType::Float => {
+            // A non-float changes the slot to boxed storage and freezes further
+            // unboxing (mapdict.py:615-619), so retain setattr.
+            if !unsafe { pyre_object::pyobject::is_float(concrete_value) } {
+                return Ok(None);
+            }
+        }
     }
 
     walker_guard_mapdict_instance_shape(ctx, op_pc, obj, w_type, version_tag, map)?;
-    let int_type_addr = &pyre_object::pyobject::INT_TYPE as *const _ as i64;
-    let raw = walker_unbox_int(ctx, op_pc, value, int_type_addr)?;
     let storageindex_const = ctx.trace_ctx.const_int(storageindex as i64);
     let listindex_const = ctx.trace_ctx.const_int(listindex as i64);
-    let helper = ctx
-        .trace_ctx
-        .const_int(crate::helpers::jit_mapdict_unboxed_write_raw as *const () as usize as i64);
+    let (helper_fn, raw, value_type) = match unbox_type {
+        pyre_interpreter::objspace::std::mapdict::UnboxType::Int => {
+            let int_type_addr = &pyre_object::pyobject::INT_TYPE as *const _ as i64;
+            let raw = walker_unbox_int(ctx, op_pc, value, int_type_addr)?;
+            (
+                crate::helpers::jit_mapdict_unboxed_write_raw as *const (),
+                raw,
+                majit_ir::Type::Int,
+            )
+        }
+        pyre_interpreter::objspace::std::mapdict::UnboxType::Float => {
+            let float_type_addr = &pyre_object::pyobject::FLOAT_TYPE as *const _ as i64;
+            let raw = walker_unbox_float(ctx, op_pc, value, float_type_addr)?;
+            let live_f = unsafe { pyre_object::w_float_get_value(concrete_value) };
+            ctx.trace_ctx
+                .set_opref_concrete(raw, majit_ir::Value::Float(live_f));
+            (
+                crate::helpers::jit_mapdict_unboxed_write_f as *const (),
+                raw,
+                majit_ir::Type::Float,
+            )
+        }
+    };
+    let helper = ctx.trace_ctx.const_int(helper_fn as usize as i64);
 
     let mut effect = original_effect.clone();
     effect.extraeffect = majit_ir::ExtraEffect::CannotRaise;
@@ -18424,14 +18470,14 @@ fn try_walker_specialize_store_attr(
             majit_ir::Type::Ref,
             majit_ir::Type::Int,
             majit_ir::Type::Int,
-            majit_ir::Type::Int,
+            value_type,
         ],
         majit_ir::Type::Void,
         effect,
     );
-    // ABI order follows `jit_mapdict_unboxed_write_raw`: receiver and the two
-    // guarded green coordinates, then the raw symbolic integer value.  No
-    // W_IntObject is materialized for this write.
+    // ABI order follows the write helpers: receiver and the two guarded green
+    // coordinates, then the raw symbolic value in its own bank.  No box is
+    // materialized for this write.
     Ok(Some((
         descr,
         vec![helper, obj, storageindex_const, listindex_const, raw],

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -18409,79 +18409,110 @@ fn try_walker_specialize_store_attr(
             None => return Ok(None),
         }
     };
-    let Some((w_type, version_tag, map, storageindex, listindex, unbox_type)) = (unsafe {
+    if let Some((w_type, version_tag, map, storageindex, listindex, unbox_type)) = unsafe {
         pyre_interpreter::objspace::std::mapdict::store_attr_unboxed_fast_path(concrete_obj, &name)
+    } {
+        match unbox_type {
+            pyre_interpreter::objspace::std::mapdict::UnboxType::Int => {
+                // `type(w_value) is space.IntObjectCls` (mapdict.py:615): reject bool
+                // and every type-changing value before emitting any guards.
+                if unsafe {
+                    pyre_object::pyobject::is_bool(concrete_value)
+                        || !pyre_object::pyobject::is_int(concrete_value)
+                } {
+                    return Ok(None);
+                }
+            }
+            pyre_interpreter::objspace::std::mapdict::UnboxType::Float => {
+                // A non-float changes the slot to boxed storage and freezes further
+                // unboxing (mapdict.py:615-619), so retain setattr.
+                if !unsafe { pyre_object::pyobject::is_float(concrete_value) } {
+                    return Ok(None);
+                }
+            }
+        }
+
+        walker_guard_mapdict_instance_shape(ctx, op_pc, obj, w_type, version_tag, map)?;
+        let storageindex_const = ctx.trace_ctx.const_int(storageindex as i64);
+        let listindex_const = ctx.trace_ctx.const_int(listindex as i64);
+        let (helper_fn, raw, value_type) = match unbox_type {
+            pyre_interpreter::objspace::std::mapdict::UnboxType::Int => {
+                let int_type_addr = &pyre_object::pyobject::INT_TYPE as *const _ as i64;
+                let raw = walker_unbox_int(ctx, op_pc, value, int_type_addr)?;
+                (
+                    crate::helpers::jit_mapdict_unboxed_write_raw as *const (),
+                    raw,
+                    majit_ir::Type::Int,
+                )
+            }
+            pyre_interpreter::objspace::std::mapdict::UnboxType::Float => {
+                let float_type_addr = &pyre_object::pyobject::FLOAT_TYPE as *const _ as i64;
+                let raw = walker_unbox_float(ctx, op_pc, value, float_type_addr)?;
+                let live_f = unsafe { pyre_object::w_float_get_value(concrete_value) };
+                ctx.trace_ctx
+                    .set_opref_concrete(raw, majit_ir::Value::Float(live_f));
+                (
+                    crate::helpers::jit_mapdict_unboxed_write_f as *const (),
+                    raw,
+                    majit_ir::Type::Float,
+                )
+            }
+        };
+        let helper = ctx.trace_ctx.const_int(helper_fn as usize as i64);
+
+        let mut effect = original_effect.clone();
+        effect.extraeffect = majit_ir::ExtraEffect::CannotRaise;
+        effect.pyre_helper = majit_ir::PyreHelperKind::StoreAttr;
+        let descr = majit_metainterp::make_call_descr_with_effect(
+            &[
+                majit_ir::Type::Ref,
+                majit_ir::Type::Int,
+                majit_ir::Type::Int,
+                value_type,
+            ],
+            majit_ir::Type::Void,
+            effect,
+        );
+        // ABI order follows the write helpers: receiver and the two guarded green
+        // coordinates, then the raw symbolic value in its own bank.  No box is
+        // materialized for this write.
+        return Ok(Some((
+            descr,
+            vec![helper, obj, storageindex_const, listindex_const, raw],
+        )));
+    }
+
+    let Some((w_type, version_tag, map, storageindex)) = (unsafe {
+        pyre_interpreter::objspace::std::mapdict::store_attr_boxed_fast_path(concrete_obj, &name)
     }) else {
         return Ok(None);
     };
-    match unbox_type {
-        pyre_interpreter::objspace::std::mapdict::UnboxType::Int => {
-            // `type(w_value) is space.IntObjectCls` (mapdict.py:615): reject bool
-            // and every type-changing value before emitting any guards.
-            if unsafe {
-                pyre_object::pyobject::is_bool(concrete_value)
-                    || !pyre_object::pyobject::is_int(concrete_value)
-            } {
-                return Ok(None);
-            }
-        }
-        pyre_interpreter::objspace::std::mapdict::UnboxType::Float => {
-            // A non-float changes the slot to boxed storage and freezes further
-            // unboxing (mapdict.py:615-619), so retain setattr.
-            if !unsafe { pyre_object::pyobject::is_float(concrete_value) } {
-                return Ok(None);
-            }
-        }
-    }
-
     walker_guard_mapdict_instance_shape(ctx, op_pc, obj, w_type, version_tag, map)?;
     let storageindex_const = ctx.trace_ctx.const_int(storageindex as i64);
-    let listindex_const = ctx.trace_ctx.const_int(listindex as i64);
-    let (helper_fn, raw, value_type) = match unbox_type {
-        pyre_interpreter::objspace::std::mapdict::UnboxType::Int => {
-            let int_type_addr = &pyre_object::pyobject::INT_TYPE as *const _ as i64;
-            let raw = walker_unbox_int(ctx, op_pc, value, int_type_addr)?;
-            (
-                crate::helpers::jit_mapdict_unboxed_write_raw as *const (),
-                raw,
-                majit_ir::Type::Int,
-            )
-        }
-        pyre_interpreter::objspace::std::mapdict::UnboxType::Float => {
-            let float_type_addr = &pyre_object::pyobject::FLOAT_TYPE as *const _ as i64;
-            let raw = walker_unbox_float(ctx, op_pc, value, float_type_addr)?;
-            let live_f = unsafe { pyre_object::w_float_get_value(concrete_value) };
-            ctx.trace_ctx
-                .set_opref_concrete(raw, majit_ir::Value::Float(live_f));
-            (
-                crate::helpers::jit_mapdict_unboxed_write_f as *const (),
-                raw,
-                majit_ir::Type::Float,
-            )
-        }
-    };
-    let helper = ctx.trace_ctx.const_int(helper_fn as usize as i64);
+    let helper = ctx
+        .trace_ctx
+        .const_int(crate::helpers::jit_mapdict_boxed_write as *const () as usize as i64);
 
+    // Unlike the unboxed arm, this write stores a GC reference, so the
+    // residual's original may-force effect is kept: only the opaque `setattr_fn`
+    // MRO walk is replaced by the direct slot write, while the force token, the
+    // virtualizable spill, and the trailing force/exception guards stay exactly
+    // as the generic setattr emitted them.
     let mut effect = original_effect.clone();
-    effect.extraeffect = majit_ir::ExtraEffect::CannotRaise;
     effect.pyre_helper = majit_ir::PyreHelperKind::StoreAttr;
     let descr = majit_metainterp::make_call_descr_with_effect(
         &[
             majit_ir::Type::Ref,
             majit_ir::Type::Int,
-            majit_ir::Type::Int,
-            value_type,
+            majit_ir::Type::Ref,
         ],
         majit_ir::Type::Void,
         effect,
     );
-    // ABI order follows the write helpers: receiver and the two guarded green
-    // coordinates, then the raw symbolic value in its own bank.  No box is
-    // materialized for this write.
-    Ok(Some((
-        descr,
-        vec![helper, obj, storageindex_const, listindex_const, raw],
-    )))
+    // ABI order follows `jit_mapdict_boxed_write`: receiver, guarded green
+    // storage index, and the original symbolic object reference.  The value is
+    // neither unboxed nor guarded by type.
+    Ok(Some((descr, vec![helper, obj, storageindex_const, value])))
 }
 
 /// Walker-native mirror of the trait `trace_guard_exact_w_class`

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -17902,8 +17902,9 @@ fn try_walker_specialize_unpack(
 
 /// `mapdict.py:1479-1537 LOAD_ATTR_caching` full-body-walker fast path for a
 /// plain (non-method) instance attribute.  When the concrete receiver is a
-/// monomorphic instance whose attribute resolves to a boxed plain storage slot,
-/// emit the inline read PyPy compiles LOAD_ATTR to under the JIT —
+/// monomorphic instance whose attribute resolves to a boxed plain storage slot
+/// or an unboxed integer slot, emit the guarded read PyPy compiles LOAD_ATTR to
+/// under the JIT —
 ///   * `guard_class(obj, &INSTANCE_TYPE)` — the receiver is a `W_ObjectObject`
 ///     (so the `map`/`storage` field reads below are valid; `mapdict.py:1495`
 ///     `if map is not None:` also filters non-instances at trace time).
@@ -17913,19 +17914,21 @@ fn try_walker_specialize_unpack(
 ///   * `guard_value(getfield_gc_i(obj, map), C_map)` — `jit.promote(self.map)`
 ///     (`mapdict.py:905`); pins the exact instance shape so `find_map_attr`
 ///     const-folds `storageindex` to a green constant.
-///   * `getfield_gc_r(obj, storage)` + `getarrayitem_gc_r(block, C_index)` —
-///     the inline value read `mapdict.py:914-916 _mapdict_read_storage`.
+///   * boxed: `getfield_gc_r(obj, storage)` +
+///     `getarrayitem_gc_r(block, C_index)` for
+///     `mapdict.py:914-916 _mapdict_read_storage`;
+///   * unboxed int: a non-forcing raw longlong read plus `wrapint`, matching
+///     `_prim_direct_read` (mapdict.py:600-601).
 /// — instead of the opaque `getattr_fn` `CALL_MAY_FORCE` MRO-walk residual.
 ///
 /// Returns `Some(())` after writing the dst; `None` (fall through to the
 /// residual) for every shape [`load_attr_fast_path`] declines: non-instance
 /// receiver, missing map, custom `__getattribute__`, uncacheable `version_tag`,
 /// a data-descriptor / `INVALID` classification, an attribute not on this
-/// instance's map, or an unboxed slot (whose read boxes a longlong, not a plain
-/// fetch).  The map `guard_value` proves the attribute is present on this shape,
-/// so a successful fold provably cannot raise `AttributeError` — dropping the
-/// residual's exception guard is sound even in a handler-bearing body (same
-/// reasoning as the LoadGlobal fold).
+/// instance's map, or an unboxed float slot.  The map `guard_value` proves the
+/// attribute is present on this shape, so a successful fold provably cannot
+/// raise `AttributeError` — dropping the residual's exception guard is sound
+/// even in a handler-bearing body (same reasoning as the LoadGlobal fold).
 #[allow(clippy::too_many_arguments)]
 fn try_walker_specialize_load_attr(
     ctx: &mut WalkContext<'_, '_>,
@@ -17951,11 +17954,112 @@ fn try_walker_specialize_load_attr(
     };
     // `mapdict.py:1495-1533` resolution, returning the fold ingredients (the
     // read is left to the caller so it can be folded to a guarded inline read).
-    let Some((w_type, version_tag, map, storageindex)) = (unsafe {
+    if let Some((w_type, version_tag, map, storageindex)) = unsafe {
         pyre_interpreter::objspace::std::mapdict::load_attr_fast_path(concrete_obj, &name)
+    } {
+        // guard_class(obj, &INSTANCE_TYPE): the receiver is a `W_ObjectObject`, so
+        // its `map`/`storage` fields lie at the fixed offsets read below.  Instances
+        // all share `ob_type == &INSTANCE_TYPE` (the class identity lives in
+        // `w_class`); the map `guard_value` then pins the exact class + layout.
+        let instance_type_addr = &pyre_object::pyobject::INSTANCE_TYPE as *const _ as i64;
+        if !ctx.trace_ctx.heap_cache().is_class_known(obj) {
+            let type_const = ctx.trace_ctx.const_int(instance_type_addr);
+            walker_emit_fold_guard_with_snapshot(
+                ctx,
+                op_pc,
+                OpCode::GuardClass,
+                &[obj, type_const],
+            )?;
+            ctx.trace_ctx
+                .heap_cache_mut()
+                .class_now_known(obj, instance_type_addr);
+        }
+
+        // The instance map pins the storage layout, but class mutation can change
+        // lookup precedence without changing that map. Re-read the receiver type's
+        // live version tag at every trace entry and deopt before the inline storage
+        // read when it changes.
+        let w_type_const = ctx.trace_ctx.const_ref(w_type as i64);
+        let version_op = crate::state::opimpl_getfield_gc_i(
+            ctx.trace_ctx,
+            w_type_const,
+            crate::descr::type_version_tag_descr(),
+        );
+        let version_const = ctx.trace_ctx.const_int(version_tag as i64);
+        walker_emit_fold_guard_with_snapshot(
+            ctx,
+            op_pc,
+            OpCode::GuardValue,
+            &[version_op, version_const],
+        )?;
+        ctx.trace_ctx
+            .heap_cache_mut()
+            .replace_box(version_op, version_const);
+
+        // guard_value(getfield_gc_i(obj, map), C_map): `jit.promote(self.map)`
+        // (`mapdict.py:905-906`).  The map nodes are interned + immortal, so the
+        // pointer is a stable identity guarded as an opaque word (object_map_descr
+        // is Int-typed).
+        //
+        // The guard may only be elided when the map read is ALREADY a compile-time
+        // constant — i.e. a prior promotion in this trace pinned it via
+        // `replace_box`.  It must NOT be elided merely because `box_value(map_op)`
+        // reports the concrete map: every traced getfield op carries its live value
+        // (`opimpl_getfield_gc_i` → `set_opref_concrete`, `history.py:803`
+        // FrontendOp), so `box_value == map` holds for the very first read and
+        // would drop the guard on the trace's entry.  A trace whose map guard is
+        // dropped reads `storage[storageindex]` off any same-class receiver whose
+        // map differs (GuardClass alone does not pin the layout), returning a wild
+        // slot value.  Pin the map with `replace_box` after guarding so a later
+        // fold on the same receiver correctly elides (matching the trait
+        // `implement_guard_value`, `trace_opcode.rs:4631-4633`).
+        let map_op = crate::state::opimpl_getfield_gc_i(
+            ctx.trace_ctx,
+            obj,
+            crate::descr::object_map_descr(),
+        );
+        if !map_op.is_constant() {
+            let map_const = ctx.trace_ctx.const_int(map as i64);
+            walker_emit_fold_guard_with_snapshot(
+                ctx,
+                op_pc,
+                OpCode::GuardValue,
+                &[map_op, map_const],
+            )?;
+            ctx.trace_ctx
+                .heap_cache_mut()
+                .replace_box(map_op, map_const);
+        }
+
+        // getfield_gc_r(obj, storage) + getarrayitem_gc_r(block, C_storageindex):
+        // the inline value read (`mapdict.py:914-916`).  `storageindex` is a green
+        // constant (the map guard pinned it); `trace_items_block_getitem_value`
+        // stamps the dst's concrete shadow from the live block slot.
+        let block = crate::state::opimpl_getfield_gc_r(
+            ctx.trace_ctx,
+            obj,
+            crate::descr::object_storage_descr(),
+        );
+        let idx_const = ctx.trace_ctx.const_int(storageindex as i64);
+        let value =
+            crate::state::trace_items_block_getitem_value(ctx.trace_ctx, block, idx_const);
+        write_residual_call_result_to_dst(ctx, op_pc, dst, dst_bank, value)?;
+        return Ok(Some(()));
+    }
+
+    let Some((w_type, version_tag, map, storageindex, listindex, unbox_type)) = (unsafe {
+        pyre_interpreter::objspace::std::mapdict::load_attr_unboxed_fast_path(
+            concrete_obj,
+            &name,
+        )
     }) else {
         return Ok(None);
     };
+    // Float slots still use the unchanged getattr residual until an Int-bank
+    // longlong-to-Float-bank bitcast is available to feed `wrapfloat`.
+    if unbox_type == pyre_interpreter::objspace::std::mapdict::UnboxType::Float {
+        return Ok(None);
+    }
 
     // guard_class(obj, &INSTANCE_TYPE): the receiver is a `W_ObjectObject`, so
     // its `map`/`storage` fields lie at the fixed offsets read below.  Instances
@@ -18018,18 +18122,39 @@ fn try_walker_specialize_load_attr(
             .replace_box(map_op, map_const);
     }
 
-    // getfield_gc_r(obj, storage) + getarrayitem_gc_r(block, C_storageindex):
-    // the inline value read (`mapdict.py:914-916`).  `storageindex` is a green
-    // constant (the map guard pinned it); `trace_items_block_getitem_value`
-    // stamps the dst's concrete shadow from the live block slot.
-    let block = crate::state::opimpl_getfield_gc_r(
+    // `_prim_direct_read` (mapdict.py:600-601): read the raw longlong from the
+    // shared list through a non-forcing, non-elidable residual.  Both indices
+    // are green constants pinned by the map guard; keeping boxing in the trace
+    // lets an immediate integer consumer virtualize it away.
+    let storageindex_const = ctx.trace_ctx.const_int(storageindex as i64);
+    let listindex_const = ctx.trace_ctx.const_int(listindex as i64);
+    let raw = crate::helpers::emit_trace_call_int_typed(
         ctx.trace_ctx,
-        obj,
-        crate::descr::object_storage_descr(),
+        crate::helpers::jit_mapdict_unboxed_read_raw as *const (),
+        &[obj, storageindex_const, listindex_const],
+        &[majit_ir::Type::Ref, majit_ir::Type::Int, majit_ir::Type::Int],
     );
-    let idx_const = ctx.trace_ctx.const_int(storageindex as i64);
-    let value = crate::state::trace_items_block_getitem_value(ctx.trace_ctx, block, idx_const);
-    write_residual_call_result_to_dst(ctx, op_pc, dst, dst_bank, value)?;
+    let live = unsafe {
+        pyre_interpreter::objspace::std::mapdict::read_unboxed_storage_raw(
+            concrete_obj,
+            storageindex,
+            listindex,
+        )
+    };
+    ctx.trace_ctx
+        .set_opref_concrete(raw, majit_ir::Value::Int(live));
+    let boxed = walker_box_int(ctx, op_pc, raw, live)?;
+    // The `wrapint` op is a heap box, so its concrete must be a heap ptr too:
+    // box the raw longlong through the same `w_int_new` the unboxed read uses
+    // (mapdict.py:579-584 `_box`); `box_int_concrete` re-homes a tagged small
+    // int to a fresh heap `W_IntObject` so op(NewWithVtable) == concrete(heap).
+    // Without this stamp the boxed result carries no concrete, so a downstream
+    // eager void residual (e.g. the STORE_ATTR that writes `self.value`) cannot
+    // resolve its value arg and the walk aborts `ResidualCallArgUnbound`.
+    let live_ptr = pyre_object::w_int_new(live) as i64;
+    ctx.trace_ctx
+        .set_opref_concrete(boxed, box_int_concrete(live, live_ptr));
+    write_residual_call_result_to_dst(ctx, op_pc, dst, dst_bank, boxed)?;
     Ok(Some(()))
 }
 

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -8207,6 +8207,24 @@ fn fbw_loadattr_fold_enabled() -> bool {
     })
 }
 
+/// `PYRE_FBW_STOREATTR_FOLD` — gate the full-body-walker STORE_ATTR fast path
+/// ([`try_walker_specialize_store_attr`]).  When on, a plain same-type unboxed
+/// integer store folds to guards + a non-forcing raw longlong-list write
+/// instead of the forcing `setattr_fn` residual (dropping the force token,
+/// vable spill, and the value re-box).  Default ON (`0`/`false` opts out as the
+/// kill switch, independent of the read fold since the write executes a
+/// concrete heap mutation).
+fn fbw_storeattr_fold_enabled() -> bool {
+    static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ENABLED.get_or_init(|| match std::env::var_os("PYRE_FBW_STOREATTR_FOLD") {
+        Some(v) => {
+            let v = v.to_string_lossy();
+            v != "0" && !v.eq_ignore_ascii_case("false")
+        }
+        None => true,
+    })
+}
+
 /// `PYRE_FBW_LOADMETHOD_FOLD` — gate the full-body-walker method-cache fold.
 /// When on, a monomorphic `obj.method(...)` dispatch folds the LOAD_ATTR
 /// method lookup to a constant descriptor plus guards, and folds the paired
@@ -17900,6 +17918,78 @@ fn try_walker_specialize_unpack(
     }
 }
 
+/// Guard the fixed-layout instance representation, the receiver type's live
+/// version tag, and the exact map shape used by the mapdict attribute folds.
+/// `INSTANCE_TYPE` proves the receiver has `W_ObjectObject` fields; the
+/// promoted map identity pins its class and storage coordinates
+/// (mapdict.py:905-906).
+fn walker_guard_mapdict_instance_shape(
+    ctx: &mut WalkContext<'_, '_>,
+    op_pc: usize,
+    obj: OpRef,
+    w_type: pyre_object::PyObjectRef,
+    version_tag: u64,
+    map: pyre_interpreter::objspace::std::mapdict::MapRef,
+) -> Result<(), DispatchError> {
+    let instance_type_addr = &pyre_object::pyobject::INSTANCE_TYPE as *const _ as i64;
+    if !ctx.trace_ctx.heap_cache().is_class_known(obj) {
+        let type_const = ctx.trace_ctx.const_int(instance_type_addr);
+        walker_emit_fold_guard_with_snapshot(ctx, op_pc, OpCode::GuardClass, &[obj, type_const])?;
+        ctx.trace_ctx
+            .heap_cache_mut()
+            .class_now_known(obj, instance_type_addr);
+    }
+
+    // The instance map pins the storage layout, but class mutation can change
+    // lookup precedence without changing that map. Re-read the receiver type's
+    // live version tag at every trace entry and deopt before the folded storage
+    // access when it changes.
+    let w_type_const = ctx.trace_ctx.const_ref(w_type as i64);
+    let version_op = crate::state::opimpl_getfield_gc_i(
+        ctx.trace_ctx,
+        w_type_const,
+        crate::descr::type_version_tag_descr(),
+    );
+    let version_const = ctx.trace_ctx.const_int(version_tag as i64);
+    walker_emit_fold_guard_with_snapshot(
+        ctx,
+        op_pc,
+        OpCode::GuardValue,
+        &[version_op, version_const],
+    )?;
+    ctx.trace_ctx
+        .heap_cache_mut()
+        .replace_box(version_op, version_const);
+
+    // guard_value(getfield_gc_i(obj, map), C_map): `jit.promote(self.map)`
+    // (`mapdict.py:905-906`).  The map nodes are interned + immortal, so the
+    // pointer is a stable identity guarded as an opaque word (object_map_descr
+    // is Int-typed).
+    //
+    // The guard may only be elided when the map read is ALREADY a compile-time
+    // constant — i.e. a prior promotion in this trace pinned it via
+    // `replace_box`.  It must NOT be elided merely because `box_value(map_op)`
+    // reports the concrete map: every traced getfield op carries its live value
+    // (`opimpl_getfield_gc_i` -> `set_opref_concrete`, `history.py:803`
+    // FrontendOp), so `box_value == map` holds for the very first read and
+    // would drop the guard on the trace's entry.  A trace whose map guard is
+    // dropped reads `storage[storageindex]` off any same-class receiver whose
+    // map differs (GuardClass alone does not pin the layout), returning a wild
+    // slot value.  Pin the map with `replace_box` after guarding so a later
+    // fold on the same receiver correctly elides (matching the trait
+    // `implement_guard_value`).
+    let map_op =
+        crate::state::opimpl_getfield_gc_i(ctx.trace_ctx, obj, crate::descr::object_map_descr());
+    if !map_op.is_constant() {
+        let map_const = ctx.trace_ctx.const_int(map as i64);
+        walker_emit_fold_guard_with_snapshot(ctx, op_pc, OpCode::GuardValue, &[map_op, map_const])?;
+        ctx.trace_ctx
+            .heap_cache_mut()
+            .replace_box(map_op, map_const);
+    }
+    Ok(())
+}
+
 /// `mapdict.py:1479-1537 LOAD_ATTR_caching` full-body-walker fast path for a
 /// plain (non-method) instance attribute.  When the concrete receiver is a
 /// monomorphic instance whose attribute resolves to a boxed plain storage slot
@@ -17957,79 +18047,7 @@ fn try_walker_specialize_load_attr(
     if let Some((w_type, version_tag, map, storageindex)) = unsafe {
         pyre_interpreter::objspace::std::mapdict::load_attr_fast_path(concrete_obj, &name)
     } {
-        // guard_class(obj, &INSTANCE_TYPE): the receiver is a `W_ObjectObject`, so
-        // its `map`/`storage` fields lie at the fixed offsets read below.  Instances
-        // all share `ob_type == &INSTANCE_TYPE` (the class identity lives in
-        // `w_class`); the map `guard_value` then pins the exact class + layout.
-        let instance_type_addr = &pyre_object::pyobject::INSTANCE_TYPE as *const _ as i64;
-        if !ctx.trace_ctx.heap_cache().is_class_known(obj) {
-            let type_const = ctx.trace_ctx.const_int(instance_type_addr);
-            walker_emit_fold_guard_with_snapshot(
-                ctx,
-                op_pc,
-                OpCode::GuardClass,
-                &[obj, type_const],
-            )?;
-            ctx.trace_ctx
-                .heap_cache_mut()
-                .class_now_known(obj, instance_type_addr);
-        }
-
-        // The instance map pins the storage layout, but class mutation can change
-        // lookup precedence without changing that map. Re-read the receiver type's
-        // live version tag at every trace entry and deopt before the inline storage
-        // read when it changes.
-        let w_type_const = ctx.trace_ctx.const_ref(w_type as i64);
-        let version_op = crate::state::opimpl_getfield_gc_i(
-            ctx.trace_ctx,
-            w_type_const,
-            crate::descr::type_version_tag_descr(),
-        );
-        let version_const = ctx.trace_ctx.const_int(version_tag as i64);
-        walker_emit_fold_guard_with_snapshot(
-            ctx,
-            op_pc,
-            OpCode::GuardValue,
-            &[version_op, version_const],
-        )?;
-        ctx.trace_ctx
-            .heap_cache_mut()
-            .replace_box(version_op, version_const);
-
-        // guard_value(getfield_gc_i(obj, map), C_map): `jit.promote(self.map)`
-        // (`mapdict.py:905-906`).  The map nodes are interned + immortal, so the
-        // pointer is a stable identity guarded as an opaque word (object_map_descr
-        // is Int-typed).
-        //
-        // The guard may only be elided when the map read is ALREADY a compile-time
-        // constant — i.e. a prior promotion in this trace pinned it via
-        // `replace_box`.  It must NOT be elided merely because `box_value(map_op)`
-        // reports the concrete map: every traced getfield op carries its live value
-        // (`opimpl_getfield_gc_i` → `set_opref_concrete`, `history.py:803`
-        // FrontendOp), so `box_value == map` holds for the very first read and
-        // would drop the guard on the trace's entry.  A trace whose map guard is
-        // dropped reads `storage[storageindex]` off any same-class receiver whose
-        // map differs (GuardClass alone does not pin the layout), returning a wild
-        // slot value.  Pin the map with `replace_box` after guarding so a later
-        // fold on the same receiver correctly elides (matching the trait
-        // `implement_guard_value`, `trace_opcode.rs:4631-4633`).
-        let map_op = crate::state::opimpl_getfield_gc_i(
-            ctx.trace_ctx,
-            obj,
-            crate::descr::object_map_descr(),
-        );
-        if !map_op.is_constant() {
-            let map_const = ctx.trace_ctx.const_int(map as i64);
-            walker_emit_fold_guard_with_snapshot(
-                ctx,
-                op_pc,
-                OpCode::GuardValue,
-                &[map_op, map_const],
-            )?;
-            ctx.trace_ctx
-                .heap_cache_mut()
-                .replace_box(map_op, map_const);
-        }
+        walker_guard_mapdict_instance_shape(ctx, op_pc, obj, w_type, version_tag, map)?;
 
         // getfield_gc_r(obj, storage) + getarrayitem_gc_r(block, C_storageindex):
         // the inline value read (`mapdict.py:914-916`).  `storageindex` is a green
@@ -18041,17 +18059,13 @@ fn try_walker_specialize_load_attr(
             crate::descr::object_storage_descr(),
         );
         let idx_const = ctx.trace_ctx.const_int(storageindex as i64);
-        let value =
-            crate::state::trace_items_block_getitem_value(ctx.trace_ctx, block, idx_const);
+        let value = crate::state::trace_items_block_getitem_value(ctx.trace_ctx, block, idx_const);
         write_residual_call_result_to_dst(ctx, op_pc, dst, dst_bank, value)?;
         return Ok(Some(()));
     }
 
     let Some((w_type, version_tag, map, storageindex, listindex, unbox_type)) = (unsafe {
-        pyre_interpreter::objspace::std::mapdict::load_attr_unboxed_fast_path(
-            concrete_obj,
-            &name,
-        )
+        pyre_interpreter::objspace::std::mapdict::load_attr_unboxed_fast_path(concrete_obj, &name)
     }) else {
         return Ok(None);
     };
@@ -18061,66 +18075,7 @@ fn try_walker_specialize_load_attr(
         return Ok(None);
     }
 
-    // guard_class(obj, &INSTANCE_TYPE): the receiver is a `W_ObjectObject`, so
-    // its `map`/`storage` fields lie at the fixed offsets read below.  Instances
-    // all share `ob_type == &INSTANCE_TYPE` (the class identity lives in
-    // `w_class`); the map `guard_value` then pins the exact class + layout.
-    let instance_type_addr = &pyre_object::pyobject::INSTANCE_TYPE as *const _ as i64;
-    if !ctx.trace_ctx.heap_cache().is_class_known(obj) {
-        let type_const = ctx.trace_ctx.const_int(instance_type_addr);
-        walker_emit_fold_guard_with_snapshot(ctx, op_pc, OpCode::GuardClass, &[obj, type_const])?;
-        ctx.trace_ctx
-            .heap_cache_mut()
-            .class_now_known(obj, instance_type_addr);
-    }
-
-    // The instance map pins the storage layout, but class mutation can change
-    // lookup precedence without changing that map. Re-read the receiver type's
-    // live version tag at every trace entry and deopt before the inline storage
-    // read when it changes.
-    let w_type_const = ctx.trace_ctx.const_ref(w_type as i64);
-    let version_op = crate::state::opimpl_getfield_gc_i(
-        ctx.trace_ctx,
-        w_type_const,
-        crate::descr::type_version_tag_descr(),
-    );
-    let version_const = ctx.trace_ctx.const_int(version_tag as i64);
-    walker_emit_fold_guard_with_snapshot(
-        ctx,
-        op_pc,
-        OpCode::GuardValue,
-        &[version_op, version_const],
-    )?;
-    ctx.trace_ctx
-        .heap_cache_mut()
-        .replace_box(version_op, version_const);
-
-    // guard_value(getfield_gc_i(obj, map), C_map): `jit.promote(self.map)`
-    // (`mapdict.py:905-906`).  The map nodes are interned + immortal, so the
-    // pointer is a stable identity guarded as an opaque word (object_map_descr
-    // is Int-typed).
-    //
-    // The guard may only be elided when the map read is ALREADY a compile-time
-    // constant — i.e. a prior promotion in this trace pinned it via
-    // `replace_box`.  It must NOT be elided merely because `box_value(map_op)`
-    // reports the concrete map: every traced getfield op carries its live value
-    // (`opimpl_getfield_gc_i` → `set_opref_concrete`, `history.py:803`
-    // FrontendOp), so `box_value == map` holds for the very first read and
-    // would drop the guard on the trace's entry.  A trace whose map guard is
-    // dropped reads `storage[storageindex]` off any same-class receiver whose
-    // map differs (GuardClass alone does not pin the layout), returning a wild
-    // slot value.  Pin the map with `replace_box` after guarding so a later
-    // fold on the same receiver correctly elides (matching the trait
-    // `implement_guard_value`, `trace_opcode.rs:4631-4633`).
-    let map_op =
-        crate::state::opimpl_getfield_gc_i(ctx.trace_ctx, obj, crate::descr::object_map_descr());
-    if !map_op.is_constant() {
-        let map_const = ctx.trace_ctx.const_int(map as i64);
-        walker_emit_fold_guard_with_snapshot(ctx, op_pc, OpCode::GuardValue, &[map_op, map_const])?;
-        ctx.trace_ctx
-            .heap_cache_mut()
-            .replace_box(map_op, map_const);
-    }
+    walker_guard_mapdict_instance_shape(ctx, op_pc, obj, w_type, version_tag, map)?;
 
     // `_prim_direct_read` (mapdict.py:600-601): read the raw longlong from the
     // shared list through a non-forcing, non-elidable residual.  Both indices
@@ -18132,7 +18087,11 @@ fn try_walker_specialize_load_attr(
         ctx.trace_ctx,
         crate::helpers::jit_mapdict_unboxed_read_raw as *const (),
         &[obj, storageindex_const, listindex_const],
-        &[majit_ir::Type::Ref, majit_ir::Type::Int, majit_ir::Type::Int],
+        &[
+            majit_ir::Type::Ref,
+            majit_ir::Type::Int,
+            majit_ir::Type::Int,
+        ],
     );
     let live = unsafe {
         pyre_interpreter::objspace::std::mapdict::read_unboxed_storage_raw(
@@ -18392,6 +18351,91 @@ fn try_walker_fold_load_method_self(
     };
     write_residual_call_result_to_dst(ctx, op_pc, dst, dst_bank, bound_op)?;
     Ok(Some(()))
+}
+
+/// STORE_ATTR mirror of [`try_walker_specialize_load_attr`] for an existing
+/// unboxed integer slot.  Recognition proves the plain mapdict write cannot
+/// invoke Python or raise; the returned descriptor/arglist replaces only the
+/// residual helper and effect.  The caller deliberately continues through the
+/// generic residual recorder/executor so concrete execution, body-effect
+/// tracking, and rollback semantics remain identical to the generic setattr
+/// path (mapdict.py:615-619).
+fn try_walker_specialize_store_attr(
+    ctx: &mut WalkContext<'_, '_>,
+    op_pc: usize,
+    obj: OpRef,
+    value: OpRef,
+    w_code_ptr: usize,
+    name_idx: usize,
+    original_effect: &majit_ir::EffectInfo,
+) -> Result<Option<(DescrRef, Vec<OpRef>)>, DispatchError> {
+    if !ctx.is_authoritative_executor || !ctx.is_full_body_walk {
+        return Ok(None);
+    }
+    let (Some(concrete_obj), Some(concrete_value)) = (
+        walker_concrete_ref_object(ctx, obj),
+        walker_concrete_ref_object(ctx, value),
+    ) else {
+        return Ok(None);
+    };
+    let name = unsafe {
+        let code_ptr = pyre_interpreter::w_code_get_ptr(w_code_ptr as pyre_object::PyObjectRef);
+        if code_ptr.is_null() {
+            return Ok(None);
+        }
+        let code = &*(code_ptr as *const pyre_interpreter::CodeObject);
+        match pyre_interpreter::pyframe::load_name_from_code(code, name_idx) {
+            Some(n) => n.to_string(),
+            None => return Ok(None),
+        }
+    };
+    let Some((w_type, version_tag, map, storageindex, listindex, unbox_type)) = (unsafe {
+        pyre_interpreter::objspace::std::mapdict::store_attr_unboxed_fast_path(concrete_obj, &name)
+    }) else {
+        return Ok(None);
+    };
+    if unbox_type != pyre_interpreter::objspace::std::mapdict::UnboxType::Int {
+        return Ok(None);
+    }
+    // `type(w_value) is space.IntObjectCls` (mapdict.py:615): reject bool,
+    // float, boxed/type-changing values, and every value whose concrete
+    // payload is not the integer representation before emitting any guards.
+    if unsafe {
+        pyre_object::pyobject::is_bool(concrete_value)
+            || !pyre_object::pyobject::is_int(concrete_value)
+    } {
+        return Ok(None);
+    }
+
+    walker_guard_mapdict_instance_shape(ctx, op_pc, obj, w_type, version_tag, map)?;
+    let int_type_addr = &pyre_object::pyobject::INT_TYPE as *const _ as i64;
+    let raw = walker_unbox_int(ctx, op_pc, value, int_type_addr)?;
+    let storageindex_const = ctx.trace_ctx.const_int(storageindex as i64);
+    let listindex_const = ctx.trace_ctx.const_int(listindex as i64);
+    let helper = ctx
+        .trace_ctx
+        .const_int(crate::helpers::jit_mapdict_unboxed_write_raw as *const () as usize as i64);
+
+    let mut effect = original_effect.clone();
+    effect.extraeffect = majit_ir::ExtraEffect::CannotRaise;
+    effect.pyre_helper = majit_ir::PyreHelperKind::StoreAttr;
+    let descr = majit_metainterp::make_call_descr_with_effect(
+        &[
+            majit_ir::Type::Ref,
+            majit_ir::Type::Int,
+            majit_ir::Type::Int,
+            majit_ir::Type::Int,
+        ],
+        majit_ir::Type::Void,
+        effect,
+    );
+    // ABI order follows `jit_mapdict_unboxed_write_raw`: receiver and the two
+    // guarded green coordinates, then the raw symbolic integer value.  No
+    // W_IntObject is materialized for this write.
+    Ok(Some((
+        descr,
+        vec![helper, obj, storageindex_const, listindex_const, raw],
+    )))
 }
 
 /// Walker-native mirror of the trait `trace_guard_exact_w_class`
@@ -21886,13 +21930,14 @@ fn dispatch_residual_call_iIRd_kind(
     let (r_args, r_width) = read_ref_var_list(code, op, 1 + i_width, ctx)?;
     let descr_offset = 1 + i_width + r_width;
     let descr_index = decode_descr_index(code, op, descr_offset);
-    let descr = read_descr(code, op, descr_offset, ctx)?;
-    let call_descr = descr
-        .as_call_descr()
-        .ok_or(DispatchError::ResidualCallDescrNotCallDescr {
-            pc: op.pc,
-            descr_index,
-        })?;
+    let mut descr = read_descr(code, op, descr_offset, ctx)?;
+    let original_call_descr =
+        descr
+            .as_call_descr()
+            .ok_or(DispatchError::ResidualCallDescrNotCallDescr {
+                pc: op.pc,
+                descr_index,
+            })?;
     let descr_key = descr.index();
     // Void shape `_ir_v/iIRd` (`pyjitpl.py:1351 opimpl_residual_call_ir_v =
     // _opimpl_residual_call2`) has no `>X` dst byte; see
@@ -21912,7 +21957,58 @@ fn dispatch_residual_call_iIRd_kind(
     argbox_types.extend(std::iter::repeat(Type::Int).take(i_args.len()));
     argboxes.extend_from_slice(&r_args);
     argbox_types.extend(std::iter::repeat(Type::Ref).take(r_args.len()));
-    let allboxes = build_allboxes(funcptr, &argboxes, &argbox_types, call_descr.arg_types());
+    let mut allboxes = build_allboxes(
+        funcptr,
+        &argboxes,
+        &argbox_types,
+        original_call_descr.arg_types(),
+    );
+
+    // STORE_ATTR fold (mapdict.py:1591-1653): recognize an existing unboxed
+    // integer slot and replace only the generic setattr residual's helper,
+    // arguments, and effect.  The transformed CallN continues through the
+    // ordinary record + concrete-execute path below; unsupported receivers,
+    // descriptors, custom hooks, absent/boxed/float slots, and type-changing
+    // values retain the original CallMayForceN unchanged.
+    if ctx.is_authoritative_executor
+        && ctx.is_full_body_walk
+        && original_call_descr.get_extra_info().pyre_helper == majit_ir::PyreHelperKind::StoreAttr
+        && fbw_storeattr_fold_enabled()
+    {
+        if let (Some(&obj_opref), Some(&value_opref), Some(&code_opref), Some(&namei_opref)) =
+            (r_args.first(), r_args.get(1), r_args.get(2), i_args.first())
+        {
+            if let (
+                Some(majit_ir::Value::Ref(majit_ir::GcRef(w_code_ptr))),
+                Some(majit_ir::Value::Int(namei)),
+            ) = (
+                ctx.trace_ctx.box_value(code_opref),
+                ctx.trace_ctx.box_value(namei_opref),
+            ) {
+                if let Some((specialized_descr, specialized_allboxes)) =
+                    try_walker_specialize_store_attr(
+                        ctx,
+                        op.pc,
+                        obj_opref,
+                        value_opref,
+                        w_code_ptr,
+                        namei as usize,
+                        original_call_descr.get_extra_info(),
+                    )?
+                {
+                    descr = specialized_descr;
+                    allboxes = specialized_allboxes;
+                }
+            }
+        }
+    }
+
+    let call_descr = descr
+        .as_call_descr()
+        .ok_or(DispatchError::ResidualCallDescrNotCallDescr {
+            pc: op.pc,
+            descr_index,
+        })?;
 
     let ei = call_descr.get_extra_info();
     clear_walk_exception(ctx);

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -2695,22 +2695,6 @@ fn loop_inlines_abort_permanent_callee(w_code: *const (), cf_addr: usize) -> boo
     false
 }
 
-/// Issue #73 production full-body tracer (Phase 5 flip, gated).
-///
-/// `PYRE_FULL_BODY_WALK=1` drives the per-CodeObject JitCode body via
-/// [`run_perfn_walk`] in authoritative mode AS the production trace — the
-/// walk IS the concrete execution, so unlike the probe it keeps the
-/// recorded trace.  Maps the walk outcome to a [`TraceAction`] for the
-/// caller to compile.
-///
-/// Conservative mapping (first slice): only `CloseLoop` — the validated
-/// end-to-end case (the four loop benches close under authoritative) — is
-/// mapped to a real `CloseLoopWithArgs`; every other outcome (`Terminate`
-/// finish-arg recovery, `SubReturn`/`SubRaise`, `SwitchToBlackhole`, any
-/// `DispatchError`) aborts the trace so the portal falls back to the trait
-/// tracer.  Default-off → the trait `metainterp.interpret` path is
-/// untouched.  The remaining flip blocker is guard-snapshot/resume
-/// correctness, which this harness exists to validate.
 /// Whether [`full_body_walk_trace`] starts a fresh walk or continues one that
 /// has already applied eager stores.
 enum WalkJournals {
@@ -2728,6 +2712,22 @@ enum WalkJournals {
     Keep,
 }
 
+/// Issue #73 production full-body tracer (Phase 5 flip, gated).
+///
+/// `PYRE_FULL_BODY_WALK=1` drives the per-CodeObject JitCode body via
+/// [`run_perfn_walk`] in authoritative mode AS the production trace — the
+/// walk IS the concrete execution, so unlike the probe it keeps the
+/// recorded trace.  Maps the walk outcome to a [`TraceAction`] for the
+/// caller to compile.
+///
+/// Conservative mapping (first slice): only `CloseLoop` — the validated
+/// end-to-end case (the four loop benches close under authoritative) — is
+/// mapped to a real `CloseLoopWithArgs`; every other outcome (`Terminate`
+/// finish-arg recovery, `SubReturn`/`SubRaise`, `SwitchToBlackhole`, any
+/// `DispatchError`) aborts the trace so the portal falls back to the trait
+/// tracer.  Default-off → the trait `metainterp.interpret` path is
+/// untouched.  The remaining flip blocker is guard-snapshot/resume
+/// correctness, which this harness exists to validate.
 fn full_body_walk_trace(
     ctx: &mut TraceCtx,
     sym: &mut PyreSym,

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -570,7 +570,7 @@ pub fn trace_bytecode(
         && std::env::var_os("PYRE_FULL_BODY_WALK").as_deref() != Some(std::ffi::OsStr::new("0"))
         && !fbw_declined(crate::driver::make_green_key(w_code, start_pc))
     {
-        let action = full_body_walk_trace(ctx, sym, w_code, start_pc, cf_addr);
+        let action = full_body_walk_trace(ctx, sym, w_code, start_pc, cf_addr, WalkJournals::Reset);
         finish_trace_namespace_dependency(meta);
         return (action, concrete_frame);
     }
@@ -996,7 +996,17 @@ fn drive_bridge_carrier_walk(
                 let root_py_pc =
                     crate::state::backxlat_py_pc(carrier.root_jitcode_index, root_pc as i32)
                         as usize;
-                return full_body_walk_trace(ctx, sym, w_code, root_py_pc, cf_addr);
+                // The sub-walk above already applied the callee's eager stores
+                // and journaled them; hand those journals to the root walk so
+                // its epilogue settles them exactly once.
+                return full_body_walk_trace(
+                    ctx,
+                    sym,
+                    w_code,
+                    root_py_pc,
+                    cf_addr,
+                    WalkJournals::Keep,
+                );
             }
             crate::jitcode_dispatch::census_record("P2Drain::ResultSlotUnresolved");
         }
@@ -2701,12 +2711,30 @@ fn loop_inlines_abort_permanent_callee(w_code: *const (), cf_addr: usize) -> boo
 /// tracer.  Default-off → the trait `metainterp.interpret` path is
 /// untouched.  The remaining flip blocker is guard-snapshot/resume
 /// correctness, which this harness exists to validate.
+/// Whether [`full_body_walk_trace`] starts a fresh walk or continues one that
+/// has already applied eager stores.
+enum WalkJournals {
+    /// Fresh walk: drop the journals + unjournaled-effect flag a prior aborted
+    /// walk left behind, so this walk's commit cannot apply them.
+    Reset,
+    /// Continuation of a drain sub-walk that already concrete-executed a
+    /// reconstructed callee.  Keep its journals so THIS walk's epilogue settles
+    /// them — commit keeps the stores, non-commit rolls them back for the
+    /// blackhole replay.  Dropping them would leave every eager store standing
+    /// while the blackhole replays the callee from the guard, applying it a
+    /// second time.  The unjournaled-effect flag carries over for the same
+    /// reason: a sub-walk that only recorded a residual must still block the
+    /// root's commit.
+    Keep,
+}
+
 fn full_body_walk_trace(
     ctx: &mut TraceCtx,
     sym: &mut PyreSym,
     w_code: *const (),
     start_pc: usize,
     cf_addr: usize,
+    journals: WalkJournals,
 ) -> TraceAction {
     // #125: decline up front when a loop body carries an `abort_permanent`
     // marker.  The authoritative walk would otherwise mis-seed the loop
@@ -2752,7 +2780,10 @@ fn full_body_walk_trace(
     crate::jitcode_dispatch::fbw_abort_outer_resume_py_pc_reset();
     // Clear the prior walk's store journal + unjournaled-effect flag so
     // dropped (aborted) entries cannot be applied by this walk's commit.
-    crate::jitcode_dispatch::fbw_store_journal_reset();
+    // A continuation keeps them instead: see [`WalkJournals`].
+    if matches!(journals, WalkJournals::Reset) {
+        crate::jitcode_dispatch::fbw_store_journal_reset();
+    }
     // A bridge resumes mid-loop from a guard failure; its input args are the
     // guard's resumedata, already seeded into the bridge sym by
     // `setup_bridge_sym`.  PyPy's `interpret()` (rebuild_state_after_failure →

--- a/pyre/pyre-jit/src/jit/flatten.rs
+++ b/pyre/pyre-jit/src/jit/flatten.rs
@@ -5341,7 +5341,11 @@ where
     let value = operand_for_value_arg(&op.args[1], get_register, lower_constant)?;
     let code = operand_for_value_arg(&op.args[2], get_register, lower_constant)?;
     let name_idx = const_int_for_value_arg(&op.args[3])?;
-    let effect_info = effect_info_for_call_flavor(CallFlavor::MayForce);
+    let mut effect_info = effect_info_for_call_flavor(CallFlavor::MayForce);
+    // Tag the STORE_ATTR helper calldescr so the full-body walker can replace
+    // a plain unboxed same-type integer store with the non-forcing raw write.
+    // A declined fold continues with this unchanged MayForce residual.
+    effect_info.pyre_helper = majit_ir::PyreHelperKind::StoreAttr;
     let descr_operand = Operand::descr(DescrOperand::CallDescrStub(CallDescrStub {
         effect_info,
         arg_kinds: vec![Kind::Ref, Kind::Ref, Kind::Ref, Kind::Int],


### PR DESCRIPTION
Nine commits: the mapdict instance-attribute folds, the two parity gaps the Codex
review found inside them, a `check.py` gate fix, and a correctness fix in the
"committed effect re-applied on resume" family found while validating the folds.

> **Dropped since the first push** (force-pushed): `jit: abort unfoldable
> method-form list.append folds`. It turned the fold's decline into a trace abort,
> and a freshly built list *always* declines — `w_list_new` allocates capacity ==
> length, so `w_list_can_append_without_realloc` is false for the first append and
> `ListStrategy::Empty` refuses outright. A list built and appended to in one traced
> region therefore stopped compiling (`lst = []; lst.append(i)` in a loop:
> `loops_compiled` **1 → 0**). Its own "measured cost zero" was an artifact: no bench
> in the corpus builds a list and appends to it in the same traced region. The hazard
> it addressed is real but latent, and the fix it needs is different — see the end.

## 1. mapdict instance-attribute folds

`LOAD_ATTR` / `STORE_ATTR` on a fixed-layout instance whose guarded shape pins an
existing storage slot lower to a direct slot access instead of the opaque
`getattr_fn` / `setattr_fn` MRO walk. Unboxed int, unboxed float, and boxed
slots. `PYRE_FBW_LOADATTR_FOLD=0` / `PYRE_FBW_STOREATTR_FOLD=0` decline.

All four arms take the receiver type's live `version_tag` guard (main added it
mid-development; it is threaded through the shared
`walker_guard_mapdict_instance_shape` helper so no arm can miss it): the instance
map pins the storage layout, but class mutation can change lookup precedence
without changing that map.

`attr_boxed` at N=60M: **3.77s → 0.5s**. Dropping the residual's may-force effect
on top measures 0.47s, so the win is the removed MRO walk rather than the force
protocol — the boxed arm therefore **keeps** the residual's original may-force
effect (force token, virtualizable spill, trailing force/exception guards) and
replaces only the helper and its arguments. The unboxed arms write no GC
reference and do drop it.

Two synthetic fixtures cover the map guard (polymorphic map, unboxed type
change).

## 2. `mapdict: fold parity for ever_mutated and allow_unboxing`

Both reported by the Codex parity review on this PR; both verified against the
upstream source before fixing.

The folds resolve attributes through the `*_fast_path` ports of
`LOAD_ATTR_caching` / `STORE_ATTR_caching` but skipped two steps those paths take.

**`ever_mutated`** — `STORE_ATTR_caching` sets it before `_direct_write`
(mapdict.py:1635-1637); the two store fast paths did not, so a folded write left
the attribute marked unmutated. Severity is honest: **latent**. Nothing in pyre
reads `ever_mutated` — every `.get()` is the "already set?" check before setting,
and `node_read` documents that both read variants share one body — so no
observable behavior changes.

**`allow_unboxing`** — `LOAD_ATTR_caching` resolves to `attr._direct_read`
(mapdict.py:1539), which for an unboxed attribute migrates the instance off
unboxed storage once its class froze unboxing (mapdict.py:594-596). The folded
read performs `_prim_direct_read` alone. `load_attr_unboxed_fast_path` now
declines a frozen class and leaves the read to the residual, whose `direct_read`
runs the migration.

This is **not a wrong answer** either way — `_direct_read` reads before it
converts — but the gate does fire and changes trace shape. Probe: freeze
unboxing, then hot-loop the first read of 40000 pre-created instances. Both print
799980000:

| | bridges_compiled | guard_failures |
|---|---|---|
| before | 1 | 202 |
| after | **0** | **1** |

Skipping the migration left unboxed and boxed instances mixed under one
promoted-map guard. The residual migrates each on its first read, after which the
boxed fold applies; post-freeze *new* instances are already boxed
(mapdict.py:197), so the window is pre-freeze instances not yet read.

`mapdict_frozen_unboxing_fold.py` covers that shape, which no bench reached. It
**passes without the fix** — no output distinguishes the two, and `check.py` gates
output, not counters — so it is coverage, not a regression guard.

## 3. `check: exempt wasm from the synthetic pypy ratio gate`

`run_synthetic_bench` applied `max-pypy-ratio` to every enabled backend. `run_bench`
takes no `wasm_vs_*` parameter and hardcodes `("wasm", None, None)`, and
`check.py:81` states "The wasm backend has no perf-ratio gate" — the synthetic
suite was the only caller gating wasm on a ratio, i.e. it broke the invariant the
file documents. Pass `None` for wasm; its per-bench timeout stays the hang guard.

This is a live failure on main today (`FAIL wasm synth/residual_raise_except_resume
… x10.0`), not a hypothetical: that bench measured ~11.9x on wasm and passed
before #576 added the header, so only the gate appeared — the number barely moved.

## 4. `jit: settle the drain sub-walk's journals in the root walk`

`drive_bridge_carrier_walk`'s `PYRE_P2_COMPILE` path returns into
`full_body_walk_trace` after its sub-walk has concrete-executed the reconstructed
callee and journaled its eager stores. That walk's entry
`fbw_store_journal_reset()` **dropped** those entries rather than settling them —
its comment assumes a "prior aborted walk", but the drain's sub-walk already ran.
So a root walk that did not commit rolled back only its own entries: the callee's
stores stood while the blackhole replayed the callee from the guard. The drain's
own abort path already rolls back; this second exit did not.

`full_body_walk_trace` takes a `WalkJournals` argument (only two callers exist).
The fresh-walk caller keeps the reset; the drain continuation keeps the journals
so the root walk's epilogue settles them — commit keeps the stores, non-commit
rolls them back.

Measured on the in-repo regression guard
`pyre/bench/synth/inline_multiframe_drain_journaled_store.py` ("hits[0] != N means
the drain doubled"), under `PYRE_P2_COMPILE=1`, both binaries verified distinct:

| | hits[0] | loops_compiled | bridges | loops_aborted |
|---|---|---|---|---|
| before | **120299** | 2 | 0 | 299 |
| after | **120000** | 2 | 0 | 299 |

Every counter identical and `P2Drain::CompileRoot` still fires 598 times, so no
trace decision moved — the 299 aborts are the 299 doubles. 3x deterministic both
ways. `PYRE_P2_COMPILE` is opt-in/default-OFF, so this was latent, not shipping;
the default drain-abort path is untouched.

## Known gap this PR does not close

The `list.append` journal hazard the dropped commit aimed at is real and stays as
it is on main: the generic dispatcher concrete-executes a declined `list.append`
without `fbw_append_journal_push`, so a non-committing walk cannot rewind it. The
abort was the wrong instrument. `try_execute_residual_call_via_executor` already
carries the right one — `inplace_list_journal` captures `(list, len_before)` before
the call and journals it from the success arm — and an append is rewindable by
length under every strategy, so routing the declined append through that path keeps
both the trace and the journal. Left for its own change, with its own repro.

## Verification

`python3 pyre/check.py` on base `ccdc1a52be` (LLBC re-extracted after the rebase; the
run built all four binaries itself): **dynasm 194/194, cranelift 194/194, wasm 193/193,
3/3 backends, 0 FAIL**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
