### PR TITLE
jit: delete five orphaned env gates and correct the docs that cite them

### DIFF
--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -10561,23 +10561,6 @@ fn vstack_enter_exception_handler(
     let _ = reseed_vstack_from_shadow(ctx, handler_depth);
 }
 
-/// `PYRE_PCMAP_BRIDGE_AUDIT` enables the assertion that the predecessor-keyed
-/// `pcdep_by_jit_pc` / `depth_pred_by_jit_pc` twins reproduce the py_pc-indexed
-/// `pcdep_color_slots` / `depth_at_py_pc` values at the decode re-inversion seam
-/// (`bridge_semantic_maps_at_with_jitcode_pc`): for a carried genuine
-/// `jitcode_pc`, `pcdep_for_jitcode_pc(jp)` equals
-/// `pcdep_color_slots[python_pc_for_jitcode_pc(jp)]` and likewise for depth.
-/// Both are compile-time derivations of the same resume-marker / `first_jit`
-/// coordinates, so the equality holds by construction; the audit certifies the
-/// precondition for retiring the decode-side jitcode-pc→py-pc re-inversion
-/// (the twins
-/// can source pcdep/depth from the carried `jitcode_pc` without the py_pc
-/// channel). Diagnostic only; off in production.
-pub(crate) fn bridge_audit_enabled() -> bool {
-    static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
-    *ENABLED.get_or_init(|| std::env::var_os("PYRE_PCMAP_BRIDGE_AUDIT").is_some())
-}
-
 /// `PYRE_PCMAP_RESULT_AUDIT` enables assertions that the audit-only
 /// `result_color_by_jit_pc` twin reproduces `result_color_at_pc` at seams
 /// already carrying a genuine JitCode byte offset. Diagnostic only; off in
@@ -10624,24 +10607,6 @@ pub(crate) fn m73_perop_carry_enabled() -> bool {
 pub(crate) fn m73_branch_carry_enabled() -> bool {
     static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
     *ENABLED.get_or_init(|| match std::env::var_os("PYRE_M73_BRANCH_CARRY") {
-        Some(v) => {
-            let v = v.to_string_lossy();
-            v != "0" && !v.eq_ignore_ascii_case("false")
-        }
-        None => true,
-    })
-}
-
-/// `PYRE_M73_MARKER_CARRY` (#73 S5 phase-1, default ON): source the
-/// nonbranch-marker keystone from the codewrite-time jitcode-keyed twin at the
-/// guard's own jitcode offset, retaining runtime resume-marker derivation as
-/// the fallback for twin-`None` rows (the synthetic loop-close overshoot whose
-/// `entry_py_pc` rebind is runtime-only). Certified by `PYRE_M73_MARKER_AUDIT`
-/// (100% eq=1 across the bench corpus) and check.py (161×2, on and off).
-/// Disable with `PYRE_M73_MARKER_CARRY=0`.
-pub(crate) fn m73_marker_carry_enabled() -> bool {
-    static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
-    *ENABLED.get_or_init(|| match std::env::var_os("PYRE_M73_MARKER_CARRY") {
         Some(v) => {
             let v = v.to_string_lossy();
             v != "0" && !v.eq_ignore_ascii_case("false")
@@ -10776,25 +10741,6 @@ pub(crate) fn m73_inlcaller_carry_enabled() -> bool {
 fn m73_outercap_carry_enabled() -> bool {
     static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
     *ENABLED.get_or_init(|| match std::env::var_os("PYRE_M73_OUTERCAP_CARRY") {
-        Some(v) => {
-            let v = v.to_string_lossy();
-            v != "0" && !v.eq_ignore_ascii_case("false")
-        }
-        None => true,
-    })
-}
-
-/// `PYRE_M73_ARMARKER_CARRY` (#73 S5 phase-2, default ON): source the plain
-/// after-residual-call marker from the codewrite-time fallthrough-marker twin
-/// at the guard's own jitcode offset, retaining runtime resume-marker
-/// derivation as the fallback for twin-`None` rows (the fallthrough-past-end
-/// overshoot whose `entry_py_pc` rebind is runtime-only). Certified by the
-/// `M73_ARMARKER` census (100% eq=1, 2178 captures across 89 bench+synth
-/// programs) and check.py (161×2, on and off). Disable with
-/// `PYRE_M73_ARMARKER_CARRY=0`.
-pub(crate) fn m73_armarker_carry_enabled() -> bool {
-    static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
-    *ENABLED.get_or_init(|| match std::env::var_os("PYRE_M73_ARMARKER_CARRY") {
         Some(v) => {
             let v = v.to_string_lossy();
             v != "0" && !v.eq_ignore_ascii_case("false")

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -10803,37 +10803,6 @@ pub(crate) fn m73_armarker_carry_enabled() -> bool {
     })
 }
 
-/// `PYRE_M73_ENTRY_CARRY` (#73 entry-carry E1, default ON): source a plain
-/// portal loop-header walk's entry coordinate from the codewrite-time sidecar.
-pub(crate) fn m73_entry_carry_enabled() -> bool {
-    static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
-    *ENABLED.get_or_init(|| match std::env::var_os("PYRE_M73_ENTRY_CARRY") {
-        Some(v) => {
-            let v = v.to_string_lossy();
-            v != "0" && !v.eq_ignore_ascii_case("false")
-        }
-        None => true,
-    })
-}
-
-/// #73 S5 p5-s3: decline-convert the entry/recipe derived legs — under
-/// entry-carry, a walk entry whose carried resolution fails DECLINES the
-/// walk instead of reconstructing a block-head coordinate.
-/// Certified by the p4 entry census: `RecipeDerivedTaken` /
-/// `EntryDerivedTaken` / `RecipeMismatch` / `BridgeNoCarry` all 0 across the
-/// 151-program corpus, so the retired fallback leg is unreached and the flip
-/// is byte-identical. Default ON; `PYRE_M73_ENTRY_DECLINE=0` opts out.
-pub(crate) fn m73_entry_decline_enabled() -> bool {
-    static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
-    *ENABLED.get_or_init(|| match std::env::var_os("PYRE_M73_ENTRY_DECLINE") {
-        Some(v) => {
-            let v = v.to_string_lossy();
-            v != "0" && !v.eq_ignore_ascii_case("false")
-        }
-        None => true,
-    })
-}
-
 pub(crate) fn python_pc_for_jitcode_pc(metadata: &crate::PyJitCodeMetadata, jit_pc: usize) -> u32 {
     // Exact inverse: `first_jit_pc_by_py_pc[py]` is the byte offset of the
     // FIRST instruction opcode `py` emitted (`usize::MAX` = the PC emitted

--- a/pyre/pyre-jit-trace/src/pyjitcode.rs
+++ b/pyre/pyre-jit-trace/src/pyjitcode.rs
@@ -113,16 +113,17 @@ pub struct PyJitCodeMetadata {
     /// at-or-before `off`). A PREDECESSOR binary search (largest offset ≤ jit_pc)
     /// then reproduces `pcdep_color_slots[python_pc_for_jitcode_pc(jit_pc)]` for
     /// the carried resume coordinates reaching the decode re-inversion at
-    /// `bridge_semantic_maps_at_with_jitcode_pc`. Sorted ascending by offset;
-    /// empty for skeleton / fixture. `PYRE_PCMAP_BRIDGE_AUDIT`
-    /// certifies the equality.
+    /// `bridge_semantic_maps_at_with_jitcode_pc`. Both sides are compile-time
+    /// derivations of the same resume-marker / `first_jit` coordinates, so the
+    /// equality holds by construction. Sorted ascending by offset; empty for
+    /// skeleton / fixture.
     pub pcdep_by_jit_pc: Vec<(usize, Vec<(u8, u16, u16)>)>,
     /// task#50 phase-1: predecessor-keyed jitcode-pc twin of `depth_at_py_pc`,
     /// built alongside `pcdep_by_jit_pc` with the same `python_pc_for_jitcode_pc`
     /// resolution (marker precedence + first_jit predecessor). Predecessor-covers
-    /// op offsets, so it agrees with the depth read
-    /// at the decode seam for every carried coordinate. `PYRE_PCMAP_BRIDGE_AUDIT`
-    /// certifies it equals `depth_at_py_pc[python_pc_for_jitcode_pc(jit_pc)]`.
+    /// op offsets, so it agrees with the depth read at the decode seam for every
+    /// carried coordinate: it equals
+    /// `depth_at_py_pc[python_pc_for_jitcode_pc(jit_pc)]` by construction.
     pub depth_pred_by_jit_pc: Vec<(usize, u16)>,
     /// task#50 #73-core: trivia-aware STATIC-liveness depth twin, split into the
     /// SAME two tiers as `python_pc_for_jitcode_pc` — an EXACT-match marker table
@@ -547,8 +548,7 @@ impl PyJitCode {
     /// offset via the `pcdep_by_jit_pc` predecessor twin. Equals
     /// `pcdep_color_slots[python_pc_for_jitcode_pc(jit_pc)]` by construction for
     /// a carried resume coordinate; `None` when the twin is empty (skeleton /
-    /// fixture). Scaffolding for the decode-side pc_map re-inversion
-    /// retirement (`PYRE_PCMAP_BRIDGE_AUDIT` certifies the equality).
+    /// fixture). Scaffolding for the decode-side pc_map re-inversion retirement.
     pub fn pcdep_for_jitcode_pc(&self, jit_pc: usize) -> Option<Vec<(u8, u16, u16)>> {
         let table = &self.metadata.pcdep_by_jit_pc;
         if table.is_empty() {

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -12738,8 +12738,9 @@ impl CodeWriter {
         // `table[python_pc_for_jitcode_pc(jit_pc)]` for the carried resume
         // coordinates that reach the decode re-inversion at `state.rs`
         // (`bridge_semantic_maps_at_with_jitcode_pc`), which are the guard's own
-        // op offset or a block-head marker — never a mid-op byte.  Certified by
-        // `PYRE_PCMAP_BRIDGE_AUDIT`; empty for skeleton / portal-bridge.
+        // op offset or a block-head marker — never a mid-op byte.  Both sides
+        // derive from the same coordinates at codewrite time, so the equality
+        // holds by construction; empty for skeleton / portal-bridge.
         let mut pcdep_by_jit_pc: Vec<(usize, Vec<(u8, u16, u16)>)> = Vec::new();
         let mut const_ref_slots_by_jit_pc: Vec<(usize, Vec<(u16, i64)>)> = Vec::new();
         let mut depth_pred_by_jit_pc: Vec<(usize, u16)> = Vec::new();


### PR DESCRIPTION
## Delete five orphaned env gates and correct the docs that cite them

A repo-wide census of the `jitcode_dispatch.rs` env gates found five with **no
callers anywhere in the tree** — only their own definitions and the doc comments
describing them mention the function names or their env vars:

| gate | env var | stranded by |
|---|---|---|
| `m73_entry_carry_enabled` | `PYRE_M73_ENTRY_CARRY` | #569 made `select_recipe_entry` carried-only |
| `m73_entry_decline_enabled` | `PYRE_M73_ENTRY_DECLINE` | #569, same |
| `bridge_audit_enabled` | `PYRE_PCMAP_BRIDGE_AUDIT` | the assertion it gated is no longer in the tree |
| `m73_marker_carry_enabled` | `PYRE_M73_MARKER_CARRY` | no call site |
| `m73_armarker_carry_enabled` | `PYRE_M73_ARMARKER_CARRY` | no call site |

**Why this is not a behavior change.** Each gate is documented as a "default ON,
`=0` opts out" switch. With no call site, reading the env var can change nothing —
the switches already have no effect. Deleting them removes dead code and, more
importantly, stops the docs from advertising knobs that do not exist.

**The doc correction is the substantive half.** `bridge_audit_enabled` is the
stranded half of an audit pair; its sibling `result_color_audit_enabled` keeps its
four callers and is untouched. Four doc comments still advertised
`PYRE_PCMAP_BRIDGE_AUDIT` as *certifying* that the predecessor-keyed
`pcdep_by_jit_pc` / `depth_pred_by_jit_pc` twins equal their `py_pc`-indexed
counterparts. That certification has not run for some time — the claim was false.
The comments are corrected to state the basis they already gave themselves: both
sides are compile-time derivations of the same resume-marker / `first_jit`
coordinates, so the equality holds by construction.

### Verification
- `dynasm` and `cranelift` full `pyre/check.py` runs, plus `cargo test -p pyre-jit-trace -p pyre-jit --features dynasm` and `cargo fmt --check`.
- Census re-verified post-rebase by content: 0 surviving references to any of the five names or their env vars; `result_color_audit_enabled` retains its callers.
- The compile itself is the load-bearing proof for a zero-caller deletion: any surviving reference would fail the build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
