### PR TITLE
jit: cut JIT merge-point to the upstream marker path; delete the direct hook (#205 C1)

### DIFF
--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -1146,11 +1146,6 @@ pub struct MetaInterp<M: Clone> {
     pub(crate) vable_array_lengths: Vec<usize>,
     /// warmspot.py:449 jd.result_type — per-driver static result type.
     pub(crate) result_type: Type,
-    /// RPython portal_call_depth parity: call depth at which the current
-    /// trace started. When Some(depth), only merge_point at that depth fires.
-    /// Replaces the pyre-jit TLS JIT_TRACING_DEPTH — state colocated with
-    /// tracing context for single source of truth.
-    pub tracing_call_depth: Option<u32>,
     /// PyPy warmspot.py max_unroll_recursion (default 7).
     pub(crate) max_unroll_recursion: usize,
     /// RPython parity: `prepare_trace_segmenting()` marks the next tracing run
@@ -1285,10 +1280,6 @@ pub struct MetaInterp<M: Clone> {
     /// (pyjitpl.py:2466).  Initialized to `-1` by
     /// `initialize_state_from_start` (pyjitpl.py:3268) so the first
     /// portal frame brings it to `0`.
-    ///
-    /// Distinct from `tracing_call_depth` which captures the depth at
-    /// which the current trace started — that field is a one-shot
-    /// snapshot, this one is the live counter.
     pub portal_call_depth: i32,
 
     /// pyjitpl.py:2400 `self.call_ids = []`.
@@ -2343,7 +2334,6 @@ impl<M: Clone> MetaInterp<M> {
             vable_ptr: std::ptr::null(),
             vable_array_lengths: Vec::new(),
             result_type: Type::Ref,
-            tracing_call_depth: None,
             max_unroll_recursion: 7, // RPython default from rlib/jit.py
             force_finish_trace: false,
             callinfocollection: None,

--- a/majit/majit-metainterp/src/trace_ctx.rs
+++ b/majit/majit-metainterp/src/trace_ctx.rs
@@ -1384,8 +1384,7 @@ impl TraceCtx {
     /// concrete for an OpRef recorded in a context whose op was not
     /// allocated in the active recorder (a deeper inlined / recursive
     /// frame's result).  Leaving that result symbolic makes the downstream
-    /// branch abort the trace into the trait fallback rather than crash
-    /// the tracer.
+    /// branch abort the trace cleanly rather than crash the tracer.
     pub fn try_set_opref_concrete(&mut self, opref: OpRef, concrete: Value) -> bool {
         if opref.is_constant() {
             return true;

--- a/majit/majit-metainterp/src/warmstate.rs
+++ b/majit/majit-metainterp/src/warmstate.rs
@@ -911,7 +911,7 @@ impl WarmEnterState {
 
     /// warmstate.py:444 `finally: cell.flags &= ~JC_TRACING` parity —
     /// unconditional flag clear on the starting cell after tracing ends.
-    /// Called from the tracing entry point (bound_reached / jit_merge_point_hook)
+    /// Called from the synchronous tracing entry point
     /// regardless of whether tracing succeeded, aborted, or cross-loop-cut
     /// installed under a different inner cell. Does not alter state: the
     /// companion `attach_procedure_to_interp` / `abort_tracing` calls own

--- a/majit/majit-translate/src/codewriter/jtransform.rs
+++ b/majit/majit-translate/src/codewriter/jtransform.rs
@@ -7724,6 +7724,95 @@ mod tests {
     }
 
     #[test]
+    fn source_driver_calls_lower_to_jitcode_markers_not_residual_calls() {
+        use crate::codewriter::call::CallControl;
+        use crate::codewriter::type_state::ConcreteType;
+        use crate::parse::CallPath;
+
+        let mut cc = CallControl::new();
+        cc.setup_jitdriver(
+            CallPath::from_segments(["pyre_jit", "other_portal"]),
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+        );
+        let portal_graph = CallPath::from_segments(["pyre_jit", "eval_loop_jit"]);
+        cc.setup_jitdriver(
+            portal_graph.clone(),
+            vec![
+                "next_instr".into(),
+                "is_being_profiled".into(),
+                "pycode".into(),
+            ],
+            vec!["frame".into(), "ec".into()],
+            Vec::new(),
+            Vec::new(),
+        );
+        let resolved_driver = cc
+            .jitdriver_sd_from_portal_graph(&portal_graph)
+            .expect("portal graph must resolve its own driver")
+            .index;
+        let config = GraphTransformConfig::default();
+        let mut transformer = Transformer::new(&config)
+            .with_callcontrol(&mut cc)
+            .with_portal_jd(Some(resolved_driver));
+        let mut graph = crate::model::FunctionGraph::new("eval_loop_jit_source_markers");
+        let receiver = graph.alloc_value_var();
+        let next_instr = graph.alloc_value_var();
+        let profiled = graph.alloc_value_var();
+        let pycode = graph.alloc_value_var();
+        let frame = graph.alloc_value_var();
+        let ec = graph.alloc_value_var();
+        FunctionGraph::set_concretetype_of_inline(&next_instr, ConcreteType::Signed);
+        FunctionGraph::set_concretetype_of_inline(&profiled, ConcreteType::Signed);
+        FunctionGraph::set_concretetype_of_inline(&pycode, ConcreteType::GcRef);
+        FunctionGraph::set_concretetype_of_inline(&frame, ConcreteType::GcRef);
+        FunctionGraph::set_concretetype_of_inline(&ec, ConcreteType::GcRef);
+        let merge_target = CallTarget::method("jit_merge_point", Some("PyPyJitDriver".into()));
+        let merge_key = jit_marker_key_from_target(&merge_target)
+            .expect("source jit_merge_point method must be recognized");
+        let merge_ops = transformer
+            .try_handle_jit_marker(
+                merge_key,
+                &[receiver, next_instr, profiled, pycode, frame, ec],
+                &graph,
+            )
+            .expect("recognized portal marker must lower");
+        assert!(
+            merge_ops
+                .iter()
+                .any(|op| matches!(op.kind, OpKind::JitMergePoint { .. }))
+        );
+        assert!(
+            !merge_ops
+                .iter()
+                .any(|op| matches!(op.kind, OpKind::Call { .. })),
+            "jit_merge_point must not remain a residual call"
+        );
+
+        let enter_target = CallTarget::method("can_enter_jit", Some("PyPyJitDriver".into()));
+        let enter_key = jit_marker_key_from_target(&enter_target)
+            .expect("source can_enter_jit method must be recognized");
+        let enter_ops = transformer
+            .try_handle_jit_marker(enter_key, &[], &graph)
+            .expect("recognized can_enter_jit marker must lower");
+        assert!(matches!(
+            enter_ops.as_slice(),
+            [SpaceOperation {
+                kind: OpKind::LoopHeader { jitdriver_index },
+                ..
+            }] if *jitdriver_index == resolved_driver
+        ));
+        assert!(
+            !enter_ops
+                .iter()
+                .any(|op| matches!(op.kind, OpKind::Call { .. })),
+            "can_enter_jit must not remain a residual call"
+        );
+    }
+
+    #[test]
     fn try_handle_jit_marker_can_enter_jit_aliases_to_loop_header() {
         let config = GraphTransformConfig::default();
         let mut transformer = Transformer::new(&config).with_portal_jd(Some(2));

--- a/pyre/pyre-interpreter/src/pycode.rs
+++ b/pyre/pyre-interpreter/src/pycode.rs
@@ -324,15 +324,17 @@ pub fn w_code_new_with_hidden_applevel(code_ptr: *const (), hidden_applevel: boo
     // `usize`) routes the pointer through the proper LL conversion.
     // `align_of::<T>()` is always a power of two — `& (align - 1)` is
     // equivalent to `% align` for power-of-two alignments and matches the
-    // RPython pattern bit-for-bit.
+    // RPython pattern bit-for-bit.  The residual is computed once and shared
+    // by every field initializer below.
     let align_mask = std::mem::align_of::<crate::CodeObject>() as i64 - 1;
-    let fast_natural_arity = if code_ptr.is_null() || (code_ptr as i64) & align_mask != 0 {
+    let code_ptr_aligned = !code_ptr.is_null() && (code_ptr as i64) & align_mask == 0;
+    let fast_natural_arity = if !code_ptr_aligned {
         crate::gateway::HOPELESS
     } else {
         compute_flatcall(unsafe { &*(code_ptr as *const crate::CodeObject) })
     };
     // `pycode.py:198 self._globals_caches = [None] * len(self.co_names_w)`.
-    let globals_caches = if code_ptr.is_null() || (code_ptr as i64) & align_mask != 0 {
+    let globals_caches = if !code_ptr_aligned {
         std::ptr::null_mut()
     } else {
         let code_ref = unsafe { &*(code_ptr as *const crate::CodeObject) };
@@ -345,7 +347,7 @@ pub fn w_code_new_with_hidden_applevel(code_ptr: *const (), hidden_applevel: boo
     };
     // `mapdict.py:1457-1458 self._mapdict_caches = [INVALID_CACHE_ENTRY] *
     // len(co_names_w)` — `None` is `INVALID_CACHE_ENTRY`.
-    let mapdict_caches = if code_ptr.is_null() || (code_ptr as i64) & align_mask != 0 {
+    let mapdict_caches = if !code_ptr_aligned {
         std::ptr::null_mut()
     } else {
         let code_ref = unsafe { &*(code_ptr as *const crate::CodeObject) };
@@ -358,7 +360,7 @@ pub fn w_code_new_with_hidden_applevel(code_ptr: *const (), hidden_applevel: boo
     // `pycode.py:126 self.co_consts_w = consts` — the realized-constant table
     // sized to the constant count, with code-constant slots filled lazily by
     // `w_code_co_const`.
-    let co_consts_w = if code_ptr.is_null() || (code_ptr as i64) & align_mask != 0 {
+    let co_consts_w = if !code_ptr_aligned {
         std::ptr::null_mut()
     } else {
         let code_ref = unsafe { &*(code_ptr as *const crate::CodeObject) };
@@ -367,7 +369,7 @@ pub fn w_code_new_with_hidden_applevel(code_ptr: *const (), hidden_applevel: boo
         v.resize(consts_len, std::ptr::null_mut());
         Box::into_raw(Box::new(v))
     };
-    let npure_cellvars = if code_ptr.is_null() || (code_ptr as i64) & align_mask != 0 {
+    let npure_cellvars = if !code_ptr_aligned {
         u32::MAX
     } else {
         let code_ref = unsafe { &*(code_ptr as *const crate::CodeObject) };

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -992,11 +992,23 @@ pub fn init_typeobjects() {
         reg
     });
 
-    patch_object_class_descriptor();
-    patch_builtin_function_descriptors();
-    patch_frame_traceback_descriptors();
-    patch_getset_descriptor_metadata();
-    patch_typeobject_descriptor_names();
+    // The `patch_*` passes install descriptors into the shared global type
+    // dicts (e.g. `object.__class__`).  `get_or_init` above serializes only
+    // the type construction: once it returns, every concurrent
+    // `ExecutionContext::new` caller it was blocking falls through to here at
+    // once, so an unguarded first-time `type_dict_store` would race a sibling
+    // thread's `type_dict_contains` read on the same `IndexMap` and tear its
+    // internal index table.  A dedicated `Once` collapses the patch pass to a
+    // single writer; it runs after `TYPEOBJECT_CACHE` is populated so
+    // `patch_typeobject_descriptor_names` still observes the registry.
+    static PATCH_TYPEOBJECTS: std::sync::Once = std::sync::Once::new();
+    PATCH_TYPEOBJECTS.call_once(|| {
+        patch_object_class_descriptor();
+        patch_builtin_function_descriptors();
+        patch_frame_traceback_descriptors();
+        patch_getset_descriptor_metadata();
+        patch_typeobject_descriptor_names();
+    });
 }
 
 /// Install `object.__class__` after the root object type exists.

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -1134,8 +1134,8 @@ pub enum DispatchError {
     /// `orthodox_list_append_commit`, the generic residual dispatcher
     /// concrete-executes `jit_list_append` WITHOUT `fbw_append_journal_push`,
     /// so `fbw_store_journal_rollback` cannot rewind it; a later trace abort +
-    /// interpreter replay would then apply the SAME append twice.  Decline the
-    /// trace to the trait leg instead of falling through, mirroring the
+    /// interpreter replay would then apply the SAME append twice. Decline the
+    /// trace to interpretation instead of falling through, mirroring the
     /// pre-#171 `emit_abort_permanent` LIST_APPEND lowering — the common
     /// int/float/object append still folds; only the decline shapes abort, and
     /// they aborted before #171 too.
@@ -1248,8 +1248,7 @@ pub enum DispatchError {
     /// unresolved, and the baked NULL arg makes the compiled call pass
     /// NULL where the entry needs the callee's globals/closure — yielding
     /// a NULL result at runtime (closures / functions bound to a local
-    /// and called in a loop). The trait tracer declines to trace through
-    /// this shape (it aborts); the walker surfaces a typed abort so the
+    /// and called in a loop). The walker surfaces a typed abort so the
     /// driver maps it to `TraceAction::Abort` and the loop falls back to
     /// the interpreter instead of compiling a wrong trace.
     MayForceNullRefArgUnsupported { pc: usize },
@@ -1268,7 +1267,7 @@ pub enum DispatchError {
     /// identity box `[-1]` of a deeper inlined / recursive frame). Building
     /// the snapshot would trip the `build_vable_snapshot_boxes`
     /// `OpRef::ty()` invariant. The full-body walk surfaces a typed abort so
-    /// the driver maps it to `TraceAction::Abort` → trait fallback instead
+    /// the driver maps it to `TraceAction::Abort` and interpretation instead
     /// of panicking the tracer. Resuming such a guard needs the multi-frame
     /// vable snapshot machinery (task #124).
     GuardSnapshotVableUntyped { pc: usize },
@@ -1351,8 +1350,8 @@ pub enum DispatchError {
     /// guard).  Unlike [`BranchGuardKeptStackUnsupported`], this shape is
     /// miscompiled the SAME way by BOTH the full-body walk and the trait
     /// leg (both re-execute the identical not-taken arm on deopt), so a
-    /// recoverable [`TraceAction::Abort`] that re-routes to the trait leg
-    /// only crashes there too.  The driver maps this to
+    /// recoverable [`TraceAction::Abort`] would retry the unsound shape.
+    /// The driver maps this to
     /// `TraceAction::AbortPermanent` → `DONT_TRACE_HERE`: the loop runs in
     /// the interpreter (correct, matching the pre-#416/#420 decline) and is
     /// never retraced by either leg.
@@ -1379,7 +1378,7 @@ pub enum DispatchError {
     /// slower than interpreting.  The trait tracer inlines such callees via
     /// `push_inline_frame` + the `recursive-call-assembler` loop back-edge
     /// (`pyjitpl.rs` opimpl_recursive_call_assembler).  Surface a typed
-    /// abort so the key routes to the trait leg (`FBW_DECLINED_KEYS`) until
+    /// abort so the key interprets without JIT (`FBW_DECLINED_KEYS`) until
     /// the walker itself covers loop-callee inlining (task #62, the Phase-6
     /// convergence).
     LoopBearingCalleeInlineUnsupported { pc: usize },
@@ -3796,11 +3795,10 @@ pub fn dispatch_via_miframe_at_opcode_entry<'a>(
             concrete_registers_i: &mut concrete_i,
             descr_refs,
             raw_descrs: RawDescrPool::Global,
-            // The per-opcode arm walk is the sole concrete-execution
-            // leg for the traced iteration: `eval_loop_jit` /
-            // `eval_loop_jit_bridge` return the walk's terminal outcome
-            // (`jit_merge_point_hook` → `Some`) without re-running
-            // `execute_opcode_step`, so nothing else applies the arm's
+            // The per-opcode arm walk is the sole concrete-execution leg for
+            // the traced iteration: the synchronous marker walk returns its
+            // terminal outcome without re-running `execute_opcode_step`, so
+            // nothing else applies the arm's
             // residual-call effects.  Tracing executes as it records
             // (`pyjitpl.py:1995 do_residual_call` →
             // `executor.execute_varargs`).
@@ -5981,8 +5979,7 @@ fn try_fold_pure_call_via_executor(
 /// concrete-NULL Ref argument — the specialized direct-call shape whose
 /// baked `ptr(0x0)` (the `PUSH_NULL` self-slot) makes the runtime call pass
 /// NULL where the callee entry expects its globals/closure, yielding a NULL
-/// result (closures / locals-bound callees called in a loop).  Matches the
-/// trait tracer, which declines this shape and aborts.  See
+/// result (closures / locals-bound callees called in a loop). See
 /// [`DispatchError::MayForceNullRefArgUnsupported`].
 fn walker_abort_if_mayforce_null_ref_arg(
     call_opcode: OpCode,
@@ -6132,9 +6129,8 @@ pub fn bool_box_truth_reset() {
 /// without dragging in a `MetaInterp` seam.
 ///
 /// **Why this exists**: the walk is the sole execution leg for the
-/// traced iteration — `eval_loop_jit` returns the walk's terminal
-/// outcome (`jit_merge_point_hook` → `Some`) without re-running
-/// `execute_opcode_step`.  For opcodes whose body contains a
+/// traced iteration — the synchronous marker walk returns its terminal
+/// outcome without re-running `execute_opcode_step`. For opcodes whose body contains a
 /// non-elidable `residual_call_*` (`store_subscr_fn` /
 /// `set_current_exception` / etc.), the helper is never invoked → heap
 /// mutation never happens → next read derefs stale container → SIGBUS
@@ -8194,7 +8190,7 @@ impl Drop for InlineFrameGuard<'_> {
 }
 
 /// `PYRE_FBW_INLINE_MULTIFRAME` (#68): inline branch-bearing callees with a
-/// multi-frame guard snapshot, instead of declining them to the trait leg
+/// multi-frame guard snapshot instead of declining them to interpretation
 /// (`LoopBearingCalleeInlineUnsupported`).  Default-on; `PYRE_FBW_INLINE_MULTIFRAME=0`
 /// (or `false`) is the rollback escape hatch.  The multi-frame snapshot
 /// encode↔decode contract for walker-emitted callee-frame guards is validated
@@ -8253,7 +8249,7 @@ pub(crate) fn fbw_rec_mutual_cutover_enabled() -> bool {
 /// callee's own `jit_merge_point` and a compiled loop token already exists
 /// for that green key, emit a `CALL_ASSEMBLER` into it (mirror of
 /// `opimpl_recursive_call_assembler`) instead of declining the enclosing
-/// trace to the trait leg (`JitMergePointGreenKeyUnresolved`). Default-ON;
+/// trace (`JitMergePointGreenKeyUnresolved`). Default-ON;
 /// `=0`/`false` opts out.
 ///
 /// The default-ON flip rides the same CALL_ASSEMBLER / residual-executor /
@@ -9665,9 +9661,8 @@ pub(crate) fn fbw_abort_carrier_clear() {
 /// applied, so the first compiled iteration is half-applied — one
 /// iteration's contribution silently dropped (#68 depth-2 multiframe:
 /// `s = s + outer(i)` lands short by exactly `outer(N+1)` because the
-/// nested callee's residual never ran).  Decline the enclosing trace to the
-/// trait leg (which inlines the callee via `push_inline_frame` and applies
-/// every iteration exactly once) instead.  At top level (no active inline)
+/// nested callee's residual never ran). Decline the enclosing trace to
+/// interpretation instead. At top level (no active inline)
 /// the unjournaled-effect / legacy-replay path is sound, so only abort when
 /// nested.
 thread_local! {
@@ -11853,7 +11848,7 @@ fn walker_capture_inline_nonstandard_vable_guard(
     }
     // Same buildability precondition as `walker_capture_snapshot_for_last_guard`:
     // every virtualizable box must carry `OpRef::ty()` or the snapshot
-    // encoder panics — abort to the trait path instead.
+    // encoder panics — abort to interpretation instead.
     if !ctx.trace_ctx.vable_snapshot_buildable() {
         return Err(DispatchError::GuardSnapshotVableUntyped { pc: op_pc });
     }
@@ -11899,7 +11894,7 @@ fn walker_capture_snapshot_for_last_guard_impl(
     // not panic.  `build_vable_snapshot_boxes` requires every virtualizable
     // box (including the identity at `[-1]`) to carry `OpRef::ty()`; a
     // deeper inlined / recursive frame can leave the identity untyped.
-    // Surface a typed abort → trait fallback rather than tripping the
+    // Surface a typed abort rather than tripping the
     // invariant panic (the multi-frame vable snapshot is task #124).
     if !ctx.trace_ctx.vable_snapshot_buildable() {
         return Err(DispatchError::GuardSnapshotVableUntyped { pc: op_pc });
@@ -14341,7 +14336,7 @@ fn method_form_callee_body_supported(body_code: &[u8], callee_descr_refs: &[Desc
 /// wrote (`OpRef::NONE` — e.g. a static-ref operand-stack slot that trace-time
 /// int-specialization left only in the int bank, or a py_pc↔jit_pc round-trip
 /// landing on a different liveness window) cannot be sourced, so return `Err`
-/// to abort the multi-frame inline and fall back to the trait leg rather than
+/// to abort the multi-frame inline and interpret rather than
 /// encode a NONE box.  `PYRE_FBW_MF_DIAG` dumps the missing color.
 fn collect_callee_active_boxes(
     regs_i: &[OpRef],
@@ -15225,8 +15220,7 @@ fn try_walker_inline_user_call(
     // vable) cannot be served by the fast-path register seeding.  Emitting
     // the residual leaves it re-interpreted per iteration and lets its short
     // inner loops compile + deopt-storm — strictly slower than interpreting.
-    // The trait leg inlines such callees via `push_inline_frame` +
-    // `recursive-call-assembler`, so route the enclosing key there
+    // Decline the enclosing key to interpretation
     // (`FBW_DECLINED_KEYS`) instead of recording the slow residual.
     // Resolve the callee's own portal frame register up-front so both the
     // strict predicate (own-frame vable acceptance) and the multiframe gate
@@ -15310,7 +15304,7 @@ fn try_walker_inline_user_call(
         );
     if !strict_inlinable && !try_multiframe {
         // A non-self-recursive loop/branch callee that neither the strict nor
-        // the multiframe fast path can serve declines to the trait leg
+        // the multiframe fast path can serve declines to interpretation
         // (`FBW_DECLINED_KEYS`).  Self-recursive calls were already routed to
         // the `CALL_ASSEMBLER` fold or plain residual path above (`Ok(None)`).
         //
@@ -15470,7 +15464,7 @@ fn try_walker_inline_user_call(
             // (`collect_callee_active_boxes` would read a stale/mismatched box), so
             // the encoded liveness stream disagrees with the decoder
             // (`resume.rs decode_ref: unexpected tag`) and the caller frame is
-            // corrupted.  Decline to the ordinary residual call (trait leg) until
+            // corrupted. Decline to the ordinary residual call until
             // the multi-frame resume reboxes int-specialized identity operands.
             // POP_JUMP_IF_TRUE/FALSE stay inlinable: their `bool` truth folds in the
             // int bank, so no Ref rebox is needed.  A strict straight-line callee
@@ -15595,8 +15589,8 @@ fn try_walker_inline_user_call(
     // paused caller frame on the framestack so its in-callee guards
     // snapshot both frames.  Compute it here, while the caller's live register
     // banks (`ctx.registers_*`) are still in scope — at guard-capture time the
-    // walk context is the callee's.  A caller frame that is not snapshot-able
-    // (try-block catch marker / missing liveness) declines to the trait leg.
+    // walk context is the callee's. A caller frame that is not snapshot-able
+    // (try-block catch marker / missing liveness) declines to interpretation.
     let parent_frame = if try_multiframe {
         match compute_inline_caller_frame(ctx, op.pc) {
             Ok(pf) => Some(pf),
@@ -18152,7 +18146,7 @@ fn try_walker_specialize_truediv_op_long(
 /// trait path's `W_SpecialisedTupleObject_ii` value0/value1 reads.  Returns
 /// `Ok(Some(()))` when folded (the caller returns `Continue`); `Ok(None)` to
 /// fall through to the opaque residual record, which stays correct for any
-/// other shape — so a non-foldable sequence is NOT declined to the trait leg.
+/// other shape — so a non-foldable sequence is not declined.
 #[allow(clippy::too_many_arguments)]
 fn try_walker_specialize_unpack(
     ctx: &mut WalkContext<'_, '_>,
@@ -19074,7 +19068,7 @@ fn try_walker_specialize_newlist(
 /// Returns `Ok(Some(()))` when folded (the caller returns `Continue`);
 /// `Ok(None)` to fall through to the opaque residual, which stays correct
 /// for any other shape (object tuple, arity ≠ 2, long element, cache miss)
-/// — so a non-foldable build is NOT declined to the trait leg.
+/// — so a non-foldable build is not declined.
 fn try_walker_specialize_newtuple(
     ctx: &mut WalkContext<'_, '_>,
     op_pc: usize,
@@ -25580,7 +25574,7 @@ fn handle(
                     // multi-frame inline sub-walk the callee's own
                     // `jit_merge_point` (its loop header) carries a pycode green
                     // with no live Ref shadow, so this resolution fails and the
-                    // enclosing trace would decline to the trait leg. Recover
+                    // enclosing trace would decline. Recover
                     // the callee code from the FBW inline stack; if a compiled
                     // loop token already exists for (callee_code, next_instr),
                     // surface a recursive CALL_ASSEMBLER request to the caller's

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -416,6 +416,7 @@ pub fn trace_bytecode(
     mut concrete_frame: pyre_interpreter::pyframe::FrameBox,
     live_frame_addr: usize,
     allow_propagate_out: bool,
+    marker_entry: bool,
 ) -> (TraceAction, pyre_interpreter::pyframe::FrameBox) {
     // `llmodel.py:557` parity — install pyre's `Cpu` impl so the
     // optimizer's `protect_speculative_string` / `bh_strlen` /
@@ -570,7 +571,15 @@ pub fn trace_bytecode(
         && std::env::var_os("PYRE_FULL_BODY_WALK").as_deref() != Some(std::ffi::OsStr::new("0"))
         && !fbw_declined(crate::driver::make_green_key(w_code, start_pc))
     {
-        let action = full_body_walk_trace(ctx, sym, w_code, start_pc, cf_addr, WalkJournals::Reset);
+        let action = full_body_walk_trace(
+            ctx,
+            sym,
+            w_code,
+            start_pc,
+            cf_addr,
+            WalkJournals::Reset,
+            marker_entry,
+        );
         finish_trace_namespace_dependency(meta);
         return (action, concrete_frame);
     }
@@ -1006,6 +1015,7 @@ fn drive_bridge_carrier_walk(
                     root_py_pc,
                     cf_addr,
                     WalkJournals::Keep,
+                    false,
                 );
             }
             crate::jitcode_dispatch::census_record("P2Drain::ResultSlotUnresolved");
@@ -1456,6 +1466,7 @@ fn run_perfn_walk(
     start_pc: usize,
     cf_addr: usize,
     authoritative: bool,
+    marker_entry: bool,
 ) -> Option<(usize, usize, PerfnWalkResult)> {
     let session = std::cell::RefCell::new(crate::jitcode_dispatch::WalkSession::default());
     let Some(pjc) = crate::state::pyjitcode_for_code(w_code) else {
@@ -1608,56 +1619,80 @@ fn run_perfn_walk(
         // standard virtualizable. The #124 operand-stack override below must
         // not overwrite these (a kept temp never lives in a red-input color).
         let mut reserved_red_colors: Vec<u8> = Vec::new();
-        match loop_header_merge_point_regs(pjc.jitcode.code.as_slice(), entry, is_bridge_trace) {
-            Some((gr, rr)) => {
-                if let Some(&r) = gr.first() {
-                    seed(r, pycode_box);
+        if marker_entry && !is_bridge_trace {
+            // C1 marker entry starts at the static sidecar coordinate BEFORE
+            // the source marker.  Seed only the root JitCode's formal red
+            // inputs at their per-JitCode metadata colors; the pre-marker
+            // instructions and BC_JIT_MERGE_POINT payload establish pycode and
+            // the live green/red marker colors themselves.  In particular,
+            // do not reconstruct the first marker at/after entry here.
+            let frame_color = if portal_frame_reg != u16::MAX {
+                portal_frame_reg as u8
+            } else {
+                1
+            };
+            let ec_color = if portal_ec_reg != u16::MAX {
+                portal_ec_reg as u8
+            } else {
+                2
+            };
+            seed(frame_color, frame_box);
+            seed(ec_color, ec_box);
+            reserved_red_colors.push(frame_color);
+            reserved_red_colors.push(ec_color);
+        } else {
+            match loop_header_merge_point_regs(pjc.jitcode.code.as_slice(), entry, is_bridge_trace)
+            {
+                Some((gr, rr)) => {
+                    if let Some(&r) = gr.first() {
+                        seed(r, pycode_box);
+                    }
+                    if let Some(&r) = rr.first() {
+                        seed(r, frame_box);
+                        reserved_red_colors.push(r);
+                    }
+                    if let Some(&r) = rr.get(1) {
+                        seed(r, ec_box);
+                        reserved_red_colors.push(r);
+                    }
                 }
-                if let Some(&r) = rr.first() {
-                    seed(r, frame_box);
-                    reserved_red_colors.push(r);
+                // Straight-line entry, no governing loop header (e.g. a
+                // non-looping function like `fib` or a leaf method): seed the
+                // portal red args `[frame, ec]` at the AUTHORITATIVE
+                // post-regalloc colors the codewriter recorded
+                // (`metadata.portal_frame_reg` / `portal_ec_reg`), the same
+                // colors the loop-header `jit_merge_point` `rr` list carries.
+                // The earlier positional `[pycode=r0, frame=r1, ec=r2]`
+                // convention only coincided with regalloc for an nlocals==1
+                // function (fib: frame=r1); a 2-local leaf method (`value()`)
+                // places frame at r2 / ec at r3, so the positional seed put
+                // `ec_box` in the frame color and every `getfield/getarrayitem
+                // _vable` of a local took the nonstandard-virtualizable leg
+                // (internal promote `GuardValue` + force store-back, no resume
+                // snapshot → `NonStandardVableFinishPortalUnsupported` abort).
+                // pycode (the jitdriver's green ref) is read from the frame's
+                // `pycode` field via `getfield_vable`, so it needs no register
+                // seed once `frame` resolves to the standard virtualizable; the
+                // r0 seed is retained as a defensive best-effort (overwritten by
+                // the entry prologue's first dst in practice).
+                //
+                None => {
+                    seed(0, pycode_box);
+                    let frame_color = if portal_frame_reg != u16::MAX {
+                        portal_frame_reg as u8
+                    } else {
+                        1
+                    };
+                    let ec_color = if portal_ec_reg != u16::MAX {
+                        portal_ec_reg as u8
+                    } else {
+                        2
+                    };
+                    seed(frame_color, frame_box);
+                    seed(ec_color, ec_box);
+                    reserved_red_colors.push(frame_color);
+                    reserved_red_colors.push(ec_color);
                 }
-                if let Some(&r) = rr.get(1) {
-                    seed(r, ec_box);
-                    reserved_red_colors.push(r);
-                }
-            }
-            // Straight-line entry, no governing loop header (e.g. a
-            // non-looping function like `fib` or a leaf method): seed the
-            // portal red args `[frame, ec]` at the AUTHORITATIVE
-            // post-regalloc colors the codewriter recorded
-            // (`metadata.portal_frame_reg` / `portal_ec_reg`), the same
-            // colors the loop-header `jit_merge_point` `rr` list carries.
-            // The earlier positional `[pycode=r0, frame=r1, ec=r2]`
-            // convention only coincided with regalloc for an nlocals==1
-            // function (fib: frame=r1); a 2-local leaf method (`value()`)
-            // places frame at r2 / ec at r3, so the positional seed put
-            // `ec_box` in the frame color and every `getfield/getarrayitem
-            // _vable` of a local took the nonstandard-virtualizable leg
-            // (internal promote `GuardValue` + force store-back, no resume
-            // snapshot → `NonStandardVableFinishPortalUnsupported` abort).
-            // pycode (the jitdriver's green ref) is read from the frame's
-            // `pycode` field via `getfield_vable`, so it needs no register
-            // seed once `frame` resolves to the standard virtualizable; the
-            // r0 seed is retained as a defensive best-effort (overwritten by
-            // the entry prologue's first dst in practice).
-            //
-            None => {
-                seed(0, pycode_box);
-                let frame_color = if portal_frame_reg != u16::MAX {
-                    portal_frame_reg as u8
-                } else {
-                    1
-                };
-                let ec_color = if portal_ec_reg != u16::MAX {
-                    portal_ec_reg as u8
-                } else {
-                    2
-                };
-                seed(frame_color, frame_box);
-                seed(ec_color, ec_box);
-                reserved_red_colors.push(frame_color);
-                reserved_red_colors.push(ec_color);
             }
         }
         // Loop-trace entry seeds no operand-stack colors.  The codewriter's
@@ -2385,7 +2420,7 @@ fn probe_walk_perfn_jitcode(
     // every op the diagnostic recorded (the walk discards its trace).
     let pre_pos = ctx.get_trace_position();
     let Some((entry, code_len, walk_result)) =
-        run_perfn_walk(ctx, sym, w_code, start_pc, cf_addr, authoritative)
+        run_perfn_walk(ctx, sym, w_code, start_pc, cf_addr, authoritative, false)
     else {
         return;
     };
@@ -2735,6 +2770,7 @@ fn full_body_walk_trace(
     start_pc: usize,
     cf_addr: usize,
     journals: WalkJournals,
+    marker_entry: bool,
 ) -> TraceAction {
     // #125: decline up front when a loop body carries an `abort_permanent`
     // marker.  The authoritative walk would otherwise mis-seed the loop
@@ -2804,7 +2840,7 @@ fn full_body_walk_trace(
             .collect();
         ctx.add_merge_point(start_key, input_args, start_pc);
     }
-    let walk_result = run_perfn_walk(ctx, sym, w_code, start_pc, cf_addr, true);
+    let walk_result = run_perfn_walk(ctx, sym, w_code, start_pc, cf_addr, true, marker_entry);
     // A guard snapshot emitted during the walk may have hit a resume
     // coordinate the jitcode pc_map cannot encode (#124/#130) and requested
     // an abort (`state::request_trace_abort`).  The walker does not poll the

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -416,7 +416,6 @@ pub fn trace_bytecode(
     mut concrete_frame: pyre_interpreter::pyframe::FrameBox,
     live_frame_addr: usize,
     allow_propagate_out: bool,
-    marker_entry: bool,
 ) -> (TraceAction, pyre_interpreter::pyframe::FrameBox) {
     // `llmodel.py:557` parity — install pyre's `Cpu` impl so the
     // optimizer's `protect_speculative_string` / `bh_strlen` /
@@ -433,13 +432,10 @@ pub fn trace_bytecode(
     // `TraceCtx.reads_module_global` needs no reset here: a fresh TraceCtx is
     // built per trace (zero-init `false`), unlike the walk-end TLS flags above.
     // Likewise clear any no-replay finish payload a prior trace left
-    // unconsumed.  The FBW walk re-clears this in `run_perfn_walk`; the
-    // trait leg (`trace_step_result_to_action`) has no such epilogue, so
-    // reset here covers both before either can stash a capture.
+    // unconsumed. The full-body walk re-clears this in `run_perfn_walk`.
     crate::jitcode_dispatch::fbw_finish_payload_reset();
     // Likewise drop any cross-frame-resume abort request a prior aborted
-    // trace left unconsumed (`metainterp::interpret` clears it on the normal
-    // path; this guards the paths that exit before the poll runs).
+    // trace left unconsumed.
     let _ = crate::state::take_trace_abort_requested();
 
     let ctx = meta
@@ -449,10 +445,8 @@ pub fn trace_bytecode(
     // pc with the OUTERMOST (`frames[0]`) resume pc. The passed `start_pc` is
     // the INNERMOST frame's pc (`decode_and_restore_guard_failure` returns
     // `jit_state.next_instr()`), which belongs to the deepest reconstructed
-    // callee — NOT the root. A carrier resume now re-interprets without JIT (the
-    // trait leg that reconstructed + pushed the callees is retired, gap-10), so
-    // the walker dispatch below routes it to a plain abort; the root pc is the
-    // relevant trace-start either way.
+    // callee — NOT the root. The dedicated carrier walker below starts from
+    // the root pc and reconstructs the in-flight inline frames.
     let carrier = ctx.take_bridge_inline_carrier();
     let start_pc = if let Some(ref c) = carrier {
         c.root_pc
@@ -492,8 +486,7 @@ pub fn trace_bytecode(
     // capture must read pointer-valued fields (`debugdata` / `lastblock`)
     // from the live frame the compiled loop will run on.  See the
     // `live_vable_frame_addr` field doc (state.rs).  Set before the
-    // full-body-walk leg below so the walker path (the production tracer
-    // post-#73) sees it as well as the trait `interpret()` leg.
+    // full-body-walk leg below so the production tracer sees it.
     //
     // gap 10 slice 2b: set this BEFORE `init_symbolic` so the root vable
     // identity (seed_virtualizable_boxes) is baked against the live frame
@@ -538,13 +531,8 @@ pub fn trace_bytecode(
     // inventory on a live bench now that walk-capability gaps #1/#2/#3
     // are closed.  See
     // `project_issue73_architecture_walker_as_tracer_2026_05_28`.
-    // Both walker entries below are gated on `carrier.is_none()`: a
-    // multi-frame bridge resume carries reconstructed inline-callee
-    // recipes that only the trait path assembles+pushes (the carrier
-    // drain before `interpret()` below — `rebuild_from_resumedata`
-    // resume.py:1049-1056).  The walker has no multi-Python-frame
-    // reconstruction yet (#68); entering it would walk the outer root
-    // frame at `root_pc` instead of the deepest resumed callee.
+    // The generic probe is gated on `carrier.is_none()` because multi-frame
+    // bridge resumes are handled by the dedicated carrier walkers above.
     if carrier.is_none() && std::env::var_os("PYRE_WALK_PERFN_JITCODE").is_some() {
         probe_walk_perfn_jitcode(ctx, sym, w_code, start_pc, cf_addr);
         finish_trace_namespace_dependency(meta);
@@ -553,43 +541,22 @@ pub fn trace_bytecode(
     // Issue #73 Phase 5 production flip: the per-CodeObject JitCode body is
     // traced via the authoritative full-body walk — the walker-as-tracer
     // path that makes `miframe.pc == jitcode_pc` and lets `pc_map` retire.
-    // `PYRE_FULL_BODY_WALK=0` opts back into the trait
-    // `metainterp.interpret` loop below (transition escape hatch; the trait
-    // tracer is deleted in Phase 6).
+    // `PYRE_FULL_BODY_WALK=0` disables tracing for the key.
     //
     // A green key in `FBW_DECLINED_KEYS` had a prior walk fail on a
     // structural walker limitation (the recurring error classes in
-    // `full_body_walk_trace`); the retrace routes through the trait
-    // tracer below instead of permanently blacklisting the location
-    // (`DONT_TRACE_HERE`).  Tracing aborts must not mark a location
-    // untraceable — upstream aborts or switches to the blackhole and the
-    // location stays eligible (pyjitpl.py:2392 aborted_tracing /
-    // blackhole switch); the trait leg is pyre's transitional stand-in
-    // until the walker covers those shapes (deleted with the trait in
-    // Phase 6).
+    // `full_body_walk_trace`); retraces bypass the walker and interpret
+    // without JIT instead of permanently blacklisting the location.
     if carrier.is_none()
         && std::env::var_os("PYRE_FULL_BODY_WALK").as_deref() != Some(std::ffi::OsStr::new("0"))
         && !fbw_declined(crate::driver::make_green_key(w_code, start_pc))
     {
-        let action = full_body_walk_trace(
-            ctx,
-            sym,
-            w_code,
-            start_pc,
-            cf_addr,
-            WalkJournals::Reset,
-            marker_entry,
-        );
+        let action = full_body_walk_trace(ctx, sym, w_code, start_pc, cf_addr, WalkJournals::Reset);
         finish_trace_namespace_dependency(meta);
         return (action, concrete_frame);
     }
-    // gap-10: the trait tracer (`PyreMetaInterp` / `owned_concrete_frame`
-    // interpret loop) is retired.  Any path the walker did not trace above — an
-    // `fbw_declined` key whose walk hit a structural limit, a
-    // `PYRE_FULL_BODY_WALK=0` opt-out, or a multi-frame bridge `carrier` resume
-    // (reconstructed only by the deleted trait leg) — re-interprets without JIT
-    // for this key.  The location stays trace-eligible (no `DONT_TRACE_HERE`);
-    // the next hot encounter re-walks.
+    // Any path the walker did not trace above re-interprets without JIT for
+    // this key. The location stays trace-eligible (no `DONT_TRACE_HERE`).
     crate::jitcode_dispatch::census_record(if carrier.is_some() {
         "Trait::CarrierAbort"
     } else {
@@ -620,9 +587,8 @@ pub fn trace_bytecode(
 /// unfolded `residual_call`).  See
 /// `project_issue73_architecture_walker_as_tracer_2026_05_28`.
 ///
-/// Decode the loop-header `jit_merge_point` that governs the resume
-/// coordinate `entry` and return its green-ref (`gr`) and red (`rr`)
-/// register lists.
+/// Decode the loop-header `jit_merge_point` that governs a bridge resume
+/// coordinate and return its green-ref (`gr`) and red (`rr`) register lists.
 ///
 /// These name the jitcode register colors the loop body reads its
 /// loop-invariant pycode (`gr`) and frame/ec (`rr`) from.  A mid-loop walk
@@ -634,54 +600,23 @@ pub fn trace_bytecode(
 /// when no preceding merge point exists (straight-line resume) or the
 /// operand stream is truncated.
 ///
-/// `body_resume` selects which merge point governs `entry`.  RPython binds
-/// each merge point's greenboxes 1:1 from the op it is ABOUT TO execute
-/// (pyjitpl.py:1537 `opimpl_jit_merge_point(greenboxes, ...)`), because the
-/// MIFrame walks every op forward.  pyre resumes PAST that op at a resume
-/// marker, so it must reconstruct the same op's register colors:
-///  - A HEADER entry (`body_resume=false`, a fresh loop trace) sits at the
-///    loop header's leading `-live-` marker, immediately BEFORE the merge
-///    point the walk is about to reach — so the governing op is the FIRST
-///    merge point at or after `entry`.  Picking the largest one BEFORE
-///    `entry` would select a PRECEDING sibling loop's merge point (a
-///    function with two loops), seeding that loop's pycode/frame/ec colors
-///    and leaving this loop's distinct colors `OpRef::NONE` — the
-///    born-between-loops abort.
-///  - A body-guard bridge resume (`body_resume=true`) enters PAST its loop's
-///    merge point, so the governing op is the LAST merge point at or before
-///    `entry`.
+/// A body-guard bridge enters past its loop's merge point, so the governing
+/// op is the last merge point at or before `entry`. Main traces enter before
+/// the static marker and never use this runtime reconstruction.
 ///
-pub(crate) fn loop_header_merge_point_regs(
+pub(crate) fn bridge_resume_merge_point_regs(
     code: &[u8],
     entry: usize,
-    body_resume: bool,
 ) -> Option<(Vec<u8>, Vec<u8>)> {
     let merge_point_pcs = || {
         crate::jitcode_runtime::decoded_ops(code)
             .filter(|op| op.opname == "jit_merge_point")
             .map(|op| op.pc)
     };
-    let mp_pc = if body_resume {
-        merge_point_pcs()
-            .filter(|&pc| pc <= entry)
-            .max()
-            .or_else(|| merge_point_pcs().filter(|&pc| pc >= entry).min())
-    } else {
-        // Header entry: the governing merge point is the FIRST at or after
-        // `entry` — the op the walk is about to reach — mirroring
-        // opimpl_jit_merge_point binding the merge point it is about to
-        // execute (pyjitpl.py:1537). A sibling loop and a nested inner loop
-        // both forward-select their own header, so a `for` inside a `while`
-        // seeds its own pycode/frame/ec and compiles standalone
-        // (reached_loop_header closes it via same_greenkey on
-        // current_merge_points, pyjitpl.py:3018-3060). Fall back to the last
-        // preceding merge point only for a straight-line entry with no merge
-        // point ahead.
-        merge_point_pcs()
-            .filter(|&pc| pc >= entry)
-            .min()
-            .or_else(|| merge_point_pcs().filter(|&pc| pc <= entry).max())
-    }?;
+    let mp_pc = merge_point_pcs()
+        .filter(|&pc| pc <= entry)
+        .max()
+        .or_else(|| merge_point_pcs().filter(|&pc| pc >= entry).min())?;
     let mut cursor = mp_pc + 1 + 1; // opcode byte + jdindex (`c`)
     let mut lists: [Vec<u8>; 6] = Default::default();
     for slot in lists.iter_mut() {
@@ -1015,7 +950,6 @@ fn drive_bridge_carrier_walk(
                     root_py_pc,
                     cf_addr,
                     WalkJournals::Keep,
-                    false,
                 );
             }
             crate::jitcode_dispatch::census_record("P2Drain::ResultSlotUnresolved");
@@ -1466,7 +1400,6 @@ fn run_perfn_walk(
     start_pc: usize,
     cf_addr: usize,
     authoritative: bool,
-    marker_entry: bool,
 ) -> Option<(usize, usize, PerfnWalkResult)> {
     let session = std::cell::RefCell::new(crate::jitcode_dispatch::WalkSession::default());
     let Some(pjc) = crate::state::pyjitcode_for_code(w_code) else {
@@ -1498,9 +1431,9 @@ fn run_perfn_walk(
         // The frozen pc_map of this already-built body does not encode
         // `start_pc` as a resume coordinate, so the same body walked from
         // the same entry recurs identically on every retrace.  Decline the
-        // key (route its retraces to the trait tracer via FBW_DECLINED_KEYS)
-        // instead of re-walking and re-aborting each iteration; mirrors the
-        // `built_as_portal=false` structural decline below.
+        // key so retraces interpret without JIT instead of re-walking and
+        // re-aborting each iteration; mirrors the `built_as_portal=false`
+        // structural decline below.
         if crate::jitcode_dispatch::fbw_debug_abort_enabled() {
             eprintln!(
                 "[walk-perfn] no jitcode entry for start_pc={start_pc} (pc_map_len={}); declining walk",
@@ -1619,7 +1552,7 @@ fn run_perfn_walk(
         // standard virtualizable. The #124 operand-stack override below must
         // not overwrite these (a kept temp never lives in a red-input color).
         let mut reserved_red_colors: Vec<u8> = Vec::new();
-        if marker_entry && !is_bridge_trace {
+        if !is_bridge_trace {
             // C1 marker entry starts at the static sidecar coordinate BEFORE
             // the source marker.  Seed only the root JitCode's formal red
             // inputs at their per-JitCode metadata colors; the pre-marker
@@ -1641,8 +1574,7 @@ fn run_perfn_walk(
             reserved_red_colors.push(frame_color);
             reserved_red_colors.push(ec_color);
         } else {
-            match loop_header_merge_point_regs(pjc.jitcode.code.as_slice(), entry, is_bridge_trace)
-            {
+            match bridge_resume_merge_point_regs(pjc.jitcode.code.as_slice(), entry) {
                 Some((gr, rr)) => {
                     if let Some(&r) = gr.first() {
                         seed(r, pycode_box);
@@ -1852,8 +1784,8 @@ fn run_perfn_walk(
     // `[frame, ec, next_instr, code, valuestackdepth, debugdata, lastblock,
     //  namespace, locals..., stack...]` (len >= NUM_SCALAR_INPUTARGS).
     // `validate_close_with_jump_args` (state.rs) rejects the reds shape, so
-    // rebuild the explicit vector via `close_loop_args_at`, mirroring the
-    // trait path's `reached_loop_header` (trace_opcode.rs close path).  The
+    // rebuild the explicit vector via `close_loop_args_at`, matching
+    // `reached_loop_header` (trace_opcode.rs close path). The
     // loop-carried local/stack OpRefs come from the virtualizable shadow in
     // the TraceCtx (`virtualizable_box_at`, maintained by the authoritative
     // walk's vable ops), NOT from the walk's private register file, so the
@@ -2420,7 +2352,7 @@ fn probe_walk_perfn_jitcode(
     // every op the diagnostic recorded (the walk discards its trace).
     let pre_pos = ctx.get_trace_position();
     let Some((entry, code_len, walk_result)) =
-        run_perfn_walk(ctx, sym, w_code, start_pc, cf_addr, authoritative, false)
+        run_perfn_walk(ctx, sym, w_code, start_pc, cf_addr, authoritative)
     else {
         return;
     };
@@ -2759,10 +2691,7 @@ enum WalkJournals {
 /// end-to-end case (the four loop benches close under authoritative) — is
 /// mapped to a real `CloseLoopWithArgs`; every other outcome (`Terminate`
 /// finish-arg recovery, `SubReturn`/`SubRaise`, `SwitchToBlackhole`, any
-/// `DispatchError`) aborts the trace so the portal falls back to the trait
-/// tracer.  Default-off → the trait `metainterp.interpret` path is
-/// untouched.  The remaining flip blocker is guard-snapshot/resume
-/// correctness, which this harness exists to validate.
+/// `DispatchError`) aborts the trace and returns to interpretation.
 fn full_body_walk_trace(
     ctx: &mut TraceCtx,
     sym: &mut PyreSym,
@@ -2770,14 +2699,12 @@ fn full_body_walk_trace(
     start_pc: usize,
     cf_addr: usize,
     journals: WalkJournals,
-    marker_entry: bool,
 ) -> TraceAction {
     // #125: decline up front when a loop body carries an `abort_permanent`
     // marker.  The authoritative walk would otherwise mis-seed the loop
     // guard, exit early, and concretely double-execute the post-loop tail;
-    // routing to the trait tracer (which handles the unported op) is the
-    // same outcome the reactive in-walk `abort_permanent` decline reaches,
-    // minus the frame corruption.
+    // declining before the walk reaches the unported op avoids frame
+    // corruption and returns to interpretation.
     if loop_body_has_abort_permanent(w_code, start_pc) {
         // Tag the decline so `PYRE_FBW_DEBUG_ABORT` census attributes it to the
         // up-front `abort_permanent` scan, not the trait retry fall-through
@@ -2798,8 +2725,7 @@ fn full_body_walk_trace(
         fbw_decline(crate::driver::make_green_key(w_code, start_pc));
         return TraceAction::Abort;
     }
-    // Mirror the trait path (trace_bytecode pre-interpret): register the
-    // initial merge point with typed input-arg boxes so the trace head
+    // Register the initial merge point with typed input-arg boxes so the trace head
     // carries the portal's entry signature (`inputarg_types()`).  Without
     // it the compiled loop's entry args don't match what the portal
     // supplies, so the portal cannot enter the compiled loop and re-traces
@@ -2840,13 +2766,13 @@ fn full_body_walk_trace(
             .collect();
         ctx.add_merge_point(start_key, input_args, start_pc);
     }
-    let walk_result = run_perfn_walk(ctx, sym, w_code, start_pc, cf_addr, true, marker_entry);
+    let walk_result = run_perfn_walk(ctx, sym, w_code, start_pc, cf_addr, true);
     // A guard snapshot emitted during the walk may have hit a resume
     // coordinate the jitcode pc_map cannot encode (#124/#130) and requested
     // an abort (`state::request_trace_abort`).  The walker does not poll the
     // flag mid-walk, so honor it here before mapping the outcome — otherwise a
     // walk that reaches a terminator would compile a trace carrying the bad
-    // guard.  Discarding the trace matches the trait leg's `interpret()` poll.
+    // guard. Discard the trace before mapping the terminal outcome.
     if crate::state::take_trace_abort_requested() {
         crate::jitcode_dispatch::census_record("TraceAbortRequested");
         if crate::jitcode_dispatch::fbw_debug_abort_enabled() {
@@ -2893,16 +2819,15 @@ fn full_body_walk_trace(
                 // Type::Ref, recorded the vable store-back + GUARD_NOT_FORCED_2,
                 // and stashed the finish payload.  Build the portal-exit FINISH
                 // from it so the compile pipeline records FINISH from
-                // `finish_args` (mirror of the trait `StepResult::Return`
-                // path, trace_opcode.rs).  Ungated → no payload → `Abort`
+                // `finish_args` (matching `StepResult::Return` in
+                // trace_opcode.rs). Ungated → no payload → `Abort`
                 // exactly as before the slice.
                 match crate::jitcode_dispatch::fbw_finish_payload_take() {
                     // A top-level `void_return/` stashes a `Type::Void`-marked
                     // payload: the portal exits with no value, so build a
                     // FINISH with empty args.  The compile pipeline maps an
                     // empty `finish_arg_types` to `done_with_this_frame_descr_void`
-                    // (pyjitpl.rs `done_with_this_frame_descr_from_types`),
-                    // matching the trait tracer's `BC_VOID_RETURN` action.
+                    // (pyjitpl.rs `done_with_this_frame_descr_from_types`).
                     Some((_, majit_ir::Type::Void)) => TraceAction::Finish {
                         finish_args: vec![],
                         finish_arg_types: vec![],
@@ -2929,9 +2854,7 @@ fn full_body_walk_trace(
                 // in-walk `compile_trace` already compiled+installed the
                 // trace as a (entry) bridge jumping into an existing loop;
                 // hand the dedicated action back so the driver neither
-                // compiles nor aborts this session again — the trait-leg
-                // equivalent is `trace_step_result_to_action`'s
-                // `compile_trace_success_pending()` branch.
+                // compiles nor aborts this session again.
                 TraceAction::CompileTrace
             }
             other => {
@@ -2946,8 +2869,7 @@ fn full_body_walk_trace(
             // Structural walker limitations recur identically on every
             // retrace of this location (the same jitcode walked from the same
             // entry produces the same error), so route the key's retraces to
-            // the trait tracer (`FBW_DECLINED_KEYS` → the trait leg of
-            // `trace_bytecode`) instead of thrashing futile deep re-walks —
+            // interpretation instead of thrashing futile deep re-walks —
             // each of which executes the body's residual calls concretely
             // before failing at the unsupported resume / exception / closure
             // shape.  Permanently blacklisting (`AbortPermanent` →
@@ -2968,9 +2890,7 @@ fn full_body_walk_trace(
             }
             match e {
                 // A kept-stack branch guard whose not-taken arm reads an
-                // unrestorable boxed Ref register miscompiles identically in
-                // the trait leg, so re-routing there (the `fbw_decline` +
-                // recoverable `Abort` path below) would crash there too.
+                // unrestorable boxed Ref register cannot safely be retraced.
                 // Mark the location `DONT_TRACE_HERE` so it interprets
                 // permanently — correct, matching the pre-#416/#420 decline.
                 DE::BranchGuardUnrestorableKeptStackPermanent { .. } => TraceAction::AbortPermanent,
@@ -2999,9 +2919,8 @@ fn full_body_walk_trace(
                 // own origin) walk PAST its prior `LoopBearing` decline and reach
                 // such a branch, which would otherwise re-trace unbounded (each
                 // re-walk executes the body's residual calls before failing) —
-                // a slowdown worse than the trait leg.  Decline it permanently to
-                // the trait leg, mirroring the default path's behavior for the
-                // same location.  Gated on the flag so the default path's plain
+                // an unbounded slowdown. Decline it so the location interprets
+                // instead. Gated on the flag so the default path's plain
                 // `Abort` (a capability landing mid-run can still pick it up) is
                 // byte-identical.
                 DE::GotoIfNotValueNotConcrete { .. }

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -2784,6 +2784,7 @@ pub fn trace_and_compile_from_bridge(
                     trace_frame,
                     live_frame_addr,
                     false,
+                    false,
                 );
                 // pyjitpl.py:3048-3091 raise_continue_running_normally:
                 // a bridge walk that closed at a merge point and committed

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -2741,11 +2741,9 @@ pub fn trace_and_compile_from_bridge(
     // resume state so that a `BridgeCompiled` outcome re-enters
     // `eval_loop_jit` there — the `ContinueRunningNormally` arm does NOT
     // reconstruct the frame, it runs the interpreter forward from the live
-    // frame's `last_instr` / value stack as-is.  The trait tracer interprets
-    // a private `snapshot_for_tracing` copy and never touches the real frame,
-    // so it naturally preserves the resume state.  The full-body walker,
-    // however, runs may-force residual calls concretely through the shared
-    // execution context during the walk, which advances the live frame's
+    // frame's `last_instr` / value stack as-is. The full-body walker runs from
+    // a private `snapshot_for_tracing` copy, but may-force residual calls use
+    // the shared execution context during the walk, which advances the live frame's
     // `last_instr` AND its locals (e.g. a loop counter) to the walked
     // opcode's concrete state.  Snapshot the resume state here and restore it
     // after the walk so the post-bridge interpreter resumes at the guard
@@ -2783,7 +2781,6 @@ pub fn trace_and_compile_from_bridge(
                     resume_pc,
                     trace_frame,
                     live_frame_addr,
-                    false,
                     false,
                 );
                 // pyjitpl.py:3048-3091 raise_continue_running_normally:

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -2618,17 +2618,26 @@ fn install_pyre_object_hooks() {
 /// `gc_sync::is_initialized()` + `gc_sync::store_singleton()` ensures
 /// exactly one GC is created even under cargo test's parallel threads.
 fn build_gc_global() {
-    if majit_gc::gc_sync::is_initialized() {
-        return;
-    }
-    let gc = build_gc();
-    // Publish the eval-breaker word address before store_singleton flips the
-    // GC-initialized flag (Release). A concurrent initializer that observes the
-    // flag set (Acquire) early-returns above; ordering the publish first makes
-    // that observer also sees a non-zero address when recording the
-    // back-edge eval-breaker poll.
-    majit_ir::eval_breaker_word::publish_addr();
-    majit_gc::gc_sync::store_singleton(gc);
+    // `is_initialized()` is a plain check-then-act, so on a fresh process
+    // every thread that reaches here before the first `store_singleton`
+    // observes the flag unset and would each run `build_gc()`.  `build_gc`
+    // calls `freeze_types()` and the subclass-range writeback, which mutate
+    // the shared global `PyType` GC-tid table and `subclassrange_{min,max}`
+    // atomics; concurrent writebacks race a sibling thread reading those
+    // ranges.  A `Once` collapses the build to a single initializer.
+    static BUILT: std::sync::Once = std::sync::Once::new();
+    BUILT.call_once(|| {
+        if majit_gc::gc_sync::is_initialized() {
+            return;
+        }
+        let gc = build_gc();
+        // Publish the eval-breaker word address before store_singleton flips
+        // the GC-initialized flag (Release), so an observer that sees the flag
+        // set also reads a non-zero address when recording the back-edge
+        // eval-breaker poll.
+        majit_ir::eval_breaker_word::publish_addr();
+        majit_gc::gc_sync::store_singleton(gc);
+    });
 }
 
 /// Test-support: give the calling `gc_stress` worker a pristine GC heap by

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -3098,48 +3098,6 @@ pub(crate) fn get_virtualizable_info() -> *const majit_metainterp::virtualizable
     std::sync::Arc::as_ptr(&pair.1)
 }
 
-/// Temporary C1 selector for the merge-point entry cutover.
-///
-/// Parsed once per process.  The default deliberately remains the legacy
-/// direct-hook feed until marker-path equivalence has been demonstrated.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-enum JitMergePath {
-    Hook,
-    Marker,
-}
-
-fn parse_jit_merge_path(value: Option<&std::ffi::OsStr>) -> JitMergePath {
-    match value.and_then(std::ffi::OsStr::to_str) {
-        None | Some("") | Some("hook") => JitMergePath::Hook,
-        Some("marker") => JitMergePath::Marker,
-        Some(other) => {
-            eprintln!(
-                "warning: invalid PYRE_JIT_MERGE_PATH={other:?}; expected hook or marker; using hook"
-            );
-            JitMergePath::Hook
-        }
-    }
-}
-
-#[inline]
-#[majit_macros::dont_look_inside]
-fn jit_merge_path() -> JitMergePath {
-    static PATH: std::sync::OnceLock<JitMergePath> = std::sync::OnceLock::new();
-    *PATH.get_or_init(|| parse_jit_merge_path(std::env::var_os("PYRE_JIT_MERGE_PATH").as_deref()))
-}
-
-#[cfg(test)]
-static MARKER_MODE_DIRECT_HOOK_FEEDS: std::sync::atomic::AtomicUsize =
-    std::sync::atomic::AtomicUsize::new(0);
-
-#[cfg(test)]
-fn note_direct_hook_feed() {
-    if jit_merge_path() == JitMergePath::Marker {
-        MARKER_MODE_DIRECT_HOOK_FEEDS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-        panic!("marker mode reached a direct jit_merge_point_hook feed site");
-    }
-}
-
 /// pypy/module/pypyjit/interp_jit.py → PyPyJitDriver(JitDriver).
 ///
 /// Mirrors RPython JitDriver (`rpython/rlib/jit.py:610-693`) field set:
@@ -3849,9 +3807,6 @@ fn init_callbacks() {
     });
 }
 
-// JIT_TRACING_DEPTH removed — now MetaInterp.tracing_call_depth field.
-// RPython portal_call_depth parity: state colocated with tracing context.
-
 /// Read the call depth from pyre-interpreter's CALL_DEPTH TLS.
 /// Replaces the separate JIT_CALL_DEPTH — single source of truth.
 // dont_look_inside: reads CALL_DEPTH TLS; no registry-resolvable accessor.
@@ -4404,11 +4359,9 @@ fn eval_with_jit_inner(frame: &mut PyFrame) -> PyResult {
     // Set CURRENT_FRAME so zero-arg super() can find __class__ in the caller.
     let _frame_guard = pyre_interpreter::eval::install_current_frame(frame_root.frame());
 
-    // RPython blackhole.py parity: during bridge tracing, concrete
-    // (force helper) calls must use the plain interpreter to avoid
-    // corrupting the bridge trace's symbolic state via eval_loop_jit's
-    // jit_merge_point_hook. RPython's blackhole interpreter has no
-    // JIT hooks; pyre's equivalent is eval_frame_plain.
+    // During bridge tracing, concrete force-helper calls use the plain
+    // interpreter so they cannot recursively enter warmstate or corrupt the
+    // bridge trace's symbolic state.
     {
         let (drv, _) = driver_pair();
         if drv.is_bridge_tracing() {
@@ -4614,9 +4567,8 @@ pub(crate) fn portal_runner_result(frame: &mut PyFrame) -> PyResult {
     // Mirror `eval_with_jit_inner`'s structural-region suppression so a
     // recursive portal entry whose code contains `WITH_EXCEPT_START`
     // keeps nested helper Python frames out of the JIT too. The current
-    // frame is already kept out of trace by `try_function_entry_jit` and
-    // `jit_merge_point_hook`'s `unsupported_jit_shape` check; the guard
-    // extends that to callees.
+    // frame is already kept out of trace by `try_function_entry_jit`; the
+    // guard extends that to callees.
     let code = unsafe { &*pyre_interpreter::pyframe_get_pycode(frame_root.frame()) };
     let _suppression = match unsupported_jit_shape(code) {
         UnsupportedJitShape::StructuralRegion => Some(JitSuppressionGuard::new()),
@@ -4674,43 +4626,6 @@ fn eval_loop_jit(frame: &mut PyFrame) -> LoopResult {
     let code = unsafe { &*pyre_interpreter::pyframe_get_pycode(frame_root.frame()) };
     let env = PyreEnv;
     let (driver, info) = driver_pair();
-    // The codewriter-side portal check
-    // (`CallControl::jitdriver_sd_from_portal_graph`, codewriter.py:37)
-    // is the canonical "is this code a portal" answer once
-    // `setup_jitdriver` has registered it.
-    //
-    // Note: pyre routes every
-    // CodeObject through `jit_merge_point_hook` and `can_enter_jit`
-    // so that recursive calls into a previously-traced function reach
-    // `maybe_compile_and_run` even before the function's own loop
-    // runs. RPython does not need this because portals are an
-    // explicit registry (`jitdrivers_sd`), not an inferred property,
-    // and recursion goes through the portal_runner. Two narrowing
-    // alternatives both regress benchmarks:
-    //   - "is registered portal" alone (post-`setup_jitdriver`):
-    //     non-loop function frames never trigger registration, so
-    //     recursive entry never reaches `maybe_compile_and_run` —
-    //     surfaces as a TLS-drop panic in
-    //     `test_inline_residual_user_call_with_many_args_stays_correct`.
-    //   - "has back-edge AND name != <module>": same problem —
-    //     non-loop function frames are skipped.
-    //
-    // interp_jit.py:81-99 `PyFrame.dispatch` applies `pypyjitdriver`
-    // (`jit_merge_point` :87, `can_enter_jit` :117) to EVERY frame
-    // uniformly — there is no `co_name == "<module>"` gate and no env
-    // switch, so `<module>` frames trace exactly like function frames.
-    // The parity-correct value is unconditional `true`.
-    //
-    // This was briefly gated (a `<module>` exclusion, then a
-    // PYRE_MODULE_LOOP_TRACE env switch) while module-loop tracing was a
-    // deopt-storm regression: a dynamic driver-loop call to a loop-bearing
-    // callee is not inlinable by the full-body walker yet (#62).  That is
-    // resolved — the walk now declines such a key to the trait leg
-    // (`DispatchError::LoopBearingCalleeInlineUnsupported` ->
-    // `FBW_DECLINED_KEYS`), which inlines the callee via
-    // `recursive-call-assembler` — so module-loop tracing is a win
-    // (nbody_50k 0.22s interpreter -> 0.09s traced) and the gate is gone.
-    let is_portal: bool = true;
     // interp_jit.py:66 — next_instr, pycode are greens (managed by jit_merge_point).
     // No explicit promote needed; the JitDriver green-key mechanism handles this.
 
@@ -4735,7 +4650,7 @@ fn eval_loop_jit(frame: &mut PyFrame) -> LoopResult {
         let pc = frame_root.frame().next_instr();
 
         // interp_jit.py:85-87 — source-level marker declaration.  Its
-        // untranslated body is a no-op in both C1 modes; source translation
+        // untranslated body is a no-op; source translation
         // recognizes this method call and lowers it to JitCode
         // `jit_merge_point` rather than leaving a residual call.
         let marker_ec = frame_root.frame().execution_context as *const PyExecutionContext;
@@ -4753,38 +4668,6 @@ fn eval_loop_jit(frame: &mut PyFrame) -> LoopResult {
             Ok(decoded) => decoded,
             Err(err) => return LoopResult::Done(Err(err.into())),
         };
-
-        // ── jit_merge_point (RPython interp_jit.py:85-87) ──
-        // Runtime no-op. Only handles trace feed when tracing is active.
-        if is_portal && jit_merge_path() == JitMergePath::Hook {
-            let tracing_depth: Option<u32> = driver.meta_interp().tracing_call_depth;
-            let mut merge_point_active = if let Some(depth) = tracing_depth {
-                call_depth() == depth
-            } else {
-                driver.is_tracing()
-            };
-            // A frame running under trace-continuation suspend is a
-            // residual-executed callee — the walk reached a self-recursive
-            // call and ran it concretely through `execute_residual_call`
-            // (jitdriver.rs `TraceContinuationSuspendGuard`).  It re-enters
-            // eval_loop_jit at the same call depth as the trace, so the depth
-            // check above mis-identifies it as a merge point.  It is opaque to
-            // the active trace's merge points (`do_residual_call` never
-            // re-enters the portal), so skip the merge-point feed and run it as
-            // plain interpretation.
-            if merge_point_active && majit_metainterp::trace_continuation_suspended() {
-                merge_point_active = false;
-            }
-            if merge_point_active {
-                #[cfg(test)]
-                note_direct_hook_feed();
-                if let Some(loop_result) =
-                    jit_merge_point_hook(frame_root.frame(), code, pc, driver, info, &env)
-                {
-                    return loop_result;
-                }
-            }
-        }
 
         // ── handle_bytecode (RPython interp_jit.py:90) ──
         trace_jit_bytecode(pc, "");
@@ -4913,7 +4796,7 @@ fn eval_loop_jit(frame: &mut PyFrame) -> LoopResult {
                 // every traced step to prevent infinite trace recording.
                 driver.blackhole_if_trace_too_long();
             }
-            Ok(StepResult::CloseLoop { loop_header_pc, .. }) if is_portal => {
+            Ok(StepResult::CloseLoop { loop_header_pc, .. }) => {
                 // ── can_enter_jit (RPython interp_jit.py:114) ──
                 // RPython interp_jit.py:114 → warmstate.py:446
                 let marker_ec = frame_root.frame().execution_context as *const PyExecutionContext;
@@ -4938,82 +4821,9 @@ fn eval_loop_jit(frame: &mut PyFrame) -> LoopResult {
                     return loop_result;
                 }
             }
-            Ok(StepResult::CloseLoop { .. }) => {}
             Ok(StepResult::Return(result)) => return LoopResult::Done(Ok(result)),
             Ok(StepResult::Yield(result)) => return LoopResult::Done(Ok(result)),
             Err(mut err) => {
-                if pyre_interpreter::eval::handle_exception(
-                    frame_root.frame(),
-                    &mut err,
-                    &mut next_instr,
-                ) {
-                    frame_root
-                        .frame()
-                        .set_last_instr_from_next_instr(next_instr);
-                    continue;
-                }
-                return LoopResult::Done(Err(err));
-            }
-        }
-    }
-}
-
-/// pyjitpl.py:2837-2845 _interpret() parity for bridge tracing.
-///
-/// RPython's bridge tracing uses the same MetaInterp._interpret() loop
-/// as normal tracing. This function provides the same eval loop as
-/// eval_loop_jit, but always calls jit_merge_point_hook since tracing
-/// is already active from start_bridge_tracing.
-pub(crate) fn eval_loop_jit_bridge(frame: &mut PyFrame) -> LoopResult {
-    let mut frame_root = FrameRoot::new(frame);
-    // Same as eval_loop_jit: count the activation for the safepoint's
-    // depth gate (gh#393). See the comment in eval_loop_jit.
-    let _eval_activation = pyre_object::gc_interp::EvalActivationGuard::enter();
-    let code = unsafe { &*pyre_interpreter::pyframe_get_pycode(frame_root.frame()) };
-    let env = PyreEnv;
-    let (driver, info) = driver_pair();
-
-    loop {
-        if frame_root.frame().next_instr() >= code.instructions.len() {
-            return LoopResult::Done(Ok(w_none()));
-        }
-
-        let pc = frame_root.frame().next_instr();
-        let (opcode_pc, instruction, op_arg) = match decode_instruction_for_dispatch(code, pc) {
-            Ok(decoded) => decoded,
-            Err(err) => return LoopResult::Done(Err(err.into())),
-        };
-
-        // pyjitpl.py:1892-1914 run_one_step: trace + execute.
-        if driver.is_tracing() {
-            if jit_merge_path() == JitMergePath::Hook {
-                #[cfg(test)]
-                note_direct_hook_feed();
-                if let Some(loop_result) =
-                    jit_merge_point_hook(frame_root.frame(), code, pc, driver, info, &env)
-                {
-                    return loop_result;
-                }
-            }
-        } else {
-            // Tracing ended (bridge compiled or aborted).
-            return LoopResult::Done(Ok(w_none()));
-        }
-
-        // handle_bytecode: execute the bytecode on the concrete frame.
-        let next_instr = opcode_pc + 1;
-        frame_root
-            .frame()
-            .set_last_instr_from_next_instr(next_instr);
-        let step_result =
-            execute_opcode_step(frame_root.frame(), code, instruction, op_arg, next_instr);
-        match step_result {
-            Ok(StepResult::Continue) => {}
-            Ok(StepResult::CloseLoop { .. }) => {}
-            Ok(StepResult::Return(result)) => return LoopResult::Done(Ok(result)),
-            Ok(StepResult::Yield(result)) => return LoopResult::Done(Ok(result)),
-            Err(mut err) => {
-                let mut next_instr = frame_root.frame().next_instr();
                 if pyre_interpreter::eval::handle_exception(
                     frame_root.frame(),
                     &mut err,
@@ -5133,154 +4943,6 @@ fn deliver_inflight_foriter_item(frame: &mut PyFrame) -> bool {
     // (the FOR_ITER `orgpc + 1`).
     frame.set_last_instr_from_next_instr(body_pc);
     true
-}
-
-/// RPython jit_merge_point slow path — only called when tracing is active.
-// dont_look_inside: jit_merge_point slow path; the tracer must not enter the driver.
-#[cold]
-#[majit_macros::dont_look_inside]
-fn jit_merge_point_hook(
-    frame: &mut PyFrame,
-    code: &pyre_interpreter::CodeObject,
-    pc: usize,
-    driver: &mut JitDriver<PyreJitState>,
-    info: &majit_metainterp::virtualizable::VirtualizableInfo,
-    env: &PyreEnv,
-) -> Option<LoopResult> {
-    if jit_suppressed_by_unsupported_frame()
-        || unsupported_jit_shape(code) != UnsupportedJitShape::None
-    {
-        return None;
-    }
-    let concrete_frame = frame as *mut PyFrame as usize;
-    let green_key = make_green_key(frame.pycode, pc);
-
-    // The trace-START decision (counter / threshold / start-tracing) lives
-    // in the warmstate marker path — `maybe_compile_with_key` (back-edge)
-    // and `force_start_tracing_for_key` (function-entry/recursion) walk the
-    // cell chain by `comparekey_matches` and own the decision. This hook is
-    // only the trace FEED: it runs once tracing is already active and hands
-    // each merge-point opcode to `jit_merge_point_keyed`. `make_green_key`
-    // and the warmstate cell key are the same allocation-free
-    // `pypyjit_greenkey_uhash`, so the feed key and the decision key agree.
-
-    let mut jit_state = build_jit_state(frame, info);
-    let current_depth = call_depth();
-    let was_tracing = driver.is_tracing();
-    // warmstate.py:437-444: capture the starting cell's key before
-    // entering the trace body so we can unconditionally clear its
-    // TRACING flag in the post-trace finally block. May differ from
-    // `green_key` when we are mid-trace and the current merge point's
-    // key is not the tracing origin.
-    let starting_tracing_key = driver.starting_green_key();
-    let mut propagated_exception = None;
-    let driver_outcome = driver.jit_merge_point_keyed(
-        green_key,
-        pc,
-        &mut jit_state,
-        env,
-        || {},
-        |meta, sym| {
-            meta.tracing_call_depth = Some(current_depth);
-            // RPython parity: codewriter.make_jitcodes() runs before tracing
-            // starts, populating all_liveness. In pyre, JitCode compilation is
-            // lazy — ensure the code's JitCode (with liveness) exists before
-            // tracing so get_list_of_active_boxes can use it.
-            crate::jit::codewriter::register_portal_jitdriver(code);
-            let snapshot = frame.snapshot_for_tracing();
-            let _ = concrete_frame;
-            let live_frame_addr = &*frame as *const PyFrame as usize;
-            let (action, executed_frame) =
-                trace_bytecode(meta, sym, code, pc, snapshot, live_frame_addr, true, false);
-            // pyjitpl.py:3048-3091 raise_continue_running_normally: tracing
-            // IS execution — a walk that committed its end-of-walk state
-            // into the snapshot (CloseLoop / CompileTracePending flush)
-            // hands that state to the LIVE frame, so the
-            // ContinueRunningNormally re-entry continues from the walked
-            // iteration's end instead of replaying it (re-applying every
-            // concretely executed side effect).  An uncommitted flush
-            // leaves the snapshot at entry state — adopting it is a no-op.
-            let walk_end_flushed = pyre_jit_trace::trace::take_walk_end_flush_committed();
-            let walk_end_restart_pc = pyre_jit_trace::trace::take_walk_end_restart_pc();
-            if walk_end_flushed {
-                frame.restore_resume_state_from(&executed_frame);
-            } else if let Some(restart_pc) = walk_end_restart_pc {
-                // When `fbw_has_unjournaled_effect` / `PYRE_FBW_END_FLUSH=0`
-                // leaves the end flush uncommitted, the live frame stays at trace entry.
-                // At a super-instruction loop close it only corrects `last_instr` to the
-                // marker-consistent restart pc; walked locals/stack stay out for consistent replay.
-                frame.set_last_instr_from_next_instr(restart_pc);
-            }
-            propagated_exception = pyre_jit_trace::trace::take_walk_end_propagated_exception();
-            action
-        },
-    );
-    if let Some(err) = propagated_exception {
-        return Some(LoopResult::Done(Err(err)));
-    }
-    if let Some(outcome) = driver_outcome {
-        match handle_jit_outcome(outcome, &jit_state, frame, info, green_key) {
-            JitAction::Return(result) => return Some(LoopResult::Done(result)),
-            JitAction::ContinueRunningNormally => return Some(LoopResult::ContinueRunningNormally),
-            JitAction::Continue => {}
-        }
-    }
-    // Trace completed or aborted — clear tracing depth.
-    if !driver.is_tracing() {
-        driver.meta_interp_mut().tracing_call_depth = None;
-        // compile.py:269: cross-loop cut stores under inner key.
-        // Use the actual compiled key for post-compilation steps.
-        let compiled_key = driver.last_compiled_key().unwrap_or(green_key);
-        // warmstate.py:444 `finally: cell.flags &= ~JC_TRACING` parity.
-        // `starting_tracing_key` was captured before jit_merge_point_keyed;
-        // its TRACING must be cleared unconditionally — even if cross-loop
-        // cut compiled under a different key, or if the trace aborted.
-        if let Some(k) = starting_tracing_key {
-            driver
-                .meta_interp_mut()
-                .warm_state_mut()
-                .clear_tracing_flag(k);
-        }
-        register_quasi_immutable_deps(compiled_key);
-        // RPython pyjitpl.py:3048-3061 raise_continue_running_normally:
-        // after trace compilation, restart so maybe_compile_and_run
-        // (try_function_entry_jit) dispatches to compiled code.
-        if was_tracing {
-            // #57 Option C (deliver): a FOR_ITER trace that aborted advanced
-            // the real iterator once but discarded its recording.  Deliver
-            // the in-flight item to the live frame (push + reposition at the
-            // body) so the ContinueRunningNormally re-entry runs the body
-            // once for it, instead of bypassing past the now-orphaned
-            // FOR_ITER and dropping the iteration.
-            deliver_inflight_foriter_item(frame);
-            // No-replay portal exit for a loop-free function trace: when the
-            // walk captured its concrete return (the `run_perfn_walk`
-            // epilogue kept the stash only when the walk's eager side
-            // effects stand and no symbolic-only effect needs the replay),
-            // hand that result back directly.  Re-running the freshly
-            // compiled trace for THIS invocation would re-read the heap the
-            // walk already consumed (a side-effecting residual ran once) and
-            // deopt; the compiled trace serves only subsequent invocations.
-            // No capture → the legacy ContinueRunningNormally replay.
-            match pyre_jit_trace::jitcode_dispatch::fbw_finish_concrete_take() {
-                Some(pyre_jit_trace::jitcode_dispatch::FinishConcrete::Return(cv)) => {
-                    let result = match cv {
-                        // A void return stashes `Null`, i.e. Python `None`
-                        // (`ConcreteValue::to_pyobj` would map it to PY_NULL).
-                        pyre_jit_trace::state::ConcreteValue::Null => w_none(),
-                        other => other.to_pyobj(),
-                    };
-                    return Some(LoopResult::Done(Ok(result)));
-                }
-                Some(pyre_jit_trace::jitcode_dispatch::FinishConcrete::Raise(cv)) => {
-                    return Some(LoopResult::Done(Err(finish_concrete_raise_error(cv))));
-                }
-                None => {}
-            }
-            return Some(LoopResult::ContinueRunningNormally);
-        }
-    }
-    None
 }
 
 /// RPython warmstate.py:446-511 maybe_compile_and_run.
@@ -5973,11 +5635,9 @@ enum CompileOnceStart {
 
 /// RPython pyjitpl.py:2876-2888 `_compile_and_run_once`.
 ///
-/// This is the single synchronous portal-trace walker for C1.  Hook mode
-/// preserves the historical split at function entry (start now, feed on the
-/// next dispatch iteration); marker mode registers and resolves the portal's
-/// static JitCode entry and performs the whole walk immediately.  Back-edge
-/// tracing was already synchronous and uses this helper in both modes.
+/// This is the single synchronous portal-trace walker for function-entry and
+/// back-edge tracing. It registers and resolves the portal's static JitCode
+/// entry and performs the whole walk immediately.
 #[cold]
 #[majit_macros::dont_look_inside]
 fn compile_and_run_once(
@@ -5990,20 +5650,17 @@ fn compile_and_run_once(
     env: &PyreEnv,
 ) -> Option<LoopResult> {
     let mut frame_root = FrameRoot::new(frame);
-    let mode = jit_merge_path();
     let code = unsafe { &*pyre_interpreter::pyframe_get_pycode(frame_root.frame()) };
 
     // warmspot/codewriter ordering: the portal and all drained JitCodes are
     // installed before the marker-driven metainterpreter starts.  Resolve the
     // per-green static entry here; `trace_bytecode` consumes the same sidecar
     // when it constructs the root MIFrame.
-    if mode == JitMergePath::Marker {
-        crate::jit::codewriter::register_portal_jitdriver(code);
-        let pjc = pyre_jit_trace::state::pyjitcode_for_code(frame_root.frame().pycode)
-            .expect("registered portal must have a drained PyJitCode");
-        pjc.merge_entry_for(target_pc)
-            .expect("registered portal must have a static merge entry for the hot green");
-    }
+    crate::jit::codewriter::register_portal_jitdriver(code);
+    let pjc = pyre_jit_trace::state::pyjitcode_for_code(frame_root.frame().pycode)
+        .expect("registered portal must have a drained PyJitCode");
+    pjc.merge_entry_for(target_pc)
+        .expect("registered portal must have a static merge entry for the hot green");
 
     let mut jit_state = build_jit_state(frame_root.frame(), info);
     let had_compiled = driver.has_compiled_loop(green_key);
@@ -6020,14 +5677,7 @@ fn compile_and_run_once(
         return None;
     }
 
-    // Exact legacy function-entry behavior: `force_start_tracing` arms the
-    // trace and the following dispatch iteration feeds jit_merge_point_hook.
-    if mode == JitMergePath::Hook && start == CompileOnceStart::FunctionEntry {
-        return None;
-    }
-
     let starting_tracing_key = driver.starting_green_key().unwrap_or(green_key);
-    driver.meta_interp_mut().tracing_call_depth = Some(call_depth());
     let mut propagated_exception = None;
     let outcome = driver.jit_merge_point_keyed(
         green_key,
@@ -6036,11 +5686,6 @@ fn compile_and_run_once(
         env,
         || {},
         |meta, sym| {
-            // Hook-mode back-edge parity: registration historically occurred
-            // inside this closure, after tracing had started.
-            if mode == JitMergePath::Hook {
-                crate::jit::codewriter::register_portal_jitdriver(code);
-            }
             let concrete_frame = frame_root.frame().snapshot_for_tracing();
             let live_frame_addr = frame_root.frame() as *const PyFrame as usize;
             let (action, executed_frame) = trace_bytecode(
@@ -6051,7 +5696,6 @@ fn compile_and_run_once(
                 concrete_frame,
                 live_frame_addr,
                 true,
-                mode == JitMergePath::Marker,
             );
             let walk_end_flushed = pyre_jit_trace::trace::take_walk_end_flush_committed();
             let walk_end_restart_pc = pyre_jit_trace::trace::take_walk_end_restart_pc();
@@ -6068,41 +5712,17 @@ fn compile_and_run_once(
             action
         },
     );
-    driver.meta_interp_mut().tracing_call_depth = None;
-
     let compiled_key = driver.last_compiled_key().unwrap_or(green_key);
     let tracing_finished = !driver.is_tracing();
-    // Preserve the legacy hook-mode exception ordering exactly: the old
-    // back-edge body propagated before quasi-immutable/TRACING cleanup.
-    if mode == JitMergePath::Hook {
-        if let Some(err) = propagated_exception.take() {
-            return Some(LoopResult::Done(Err(err)));
-        }
-    }
     if tracing_finished {
-        if mode == JitMergePath::Marker {
-            // warmstate.py:437-444 `finally`: the starting cell owns JC_TRACING
-            // even when a cross-loop cut attaches the token to another key.
-            driver
-                .meta_interp_mut()
-                .warm_state_mut()
-                .clear_tracing_flag(starting_tracing_key);
-            if !had_compiled && driver.has_compiled_loop(compiled_key) {
-                register_quasi_immutable_deps(compiled_key);
-            }
-        } else {
-            // Preserve the legacy hook-mode back-edge ordering: register deps,
-            // then apply only the cross-loop starting-cell cleanup predicate.
-            if !had_compiled && driver.has_compiled_loop(compiled_key) {
-                register_quasi_immutable_deps(compiled_key);
-            }
-            if !had_compiled && driver.has_compiled_loop(compiled_key) && compiled_key != green_key
-            {
-                driver
-                    .meta_interp_mut()
-                    .warm_state_mut()
-                    .clear_tracing_flag(green_key);
-            }
+        // warmstate.py:437-444 `finally`: the starting cell owns JC_TRACING
+        // even when a cross-loop cut attaches the token to another key.
+        driver
+            .meta_interp_mut()
+            .warm_state_mut()
+            .clear_tracing_flag(starting_tracing_key);
+        if !had_compiled && driver.has_compiled_loop(compiled_key) {
+            register_quasi_immutable_deps(compiled_key);
         }
     }
 
@@ -6294,7 +5914,6 @@ fn bound_reached(
             }
         }
     }
-    driver.meta_interp_mut().tracing_call_depth = None;
     None
 }
 
@@ -9137,19 +8756,6 @@ impl majit_metainterp::resume::BlackholeAllocator for PyreBlackholeAllocator {
 mod tests {
     use super::*;
 
-    #[test]
-    fn jit_merge_path_defaults_to_hook() {
-        assert_eq!(parse_jit_merge_path(None), JitMergePath::Hook);
-        assert_eq!(
-            parse_jit_merge_path(Some(std::ffi::OsStr::new("hook"))),
-            JitMergePath::Hook
-        );
-        assert_eq!(
-            parse_jit_merge_path(Some(std::ffi::OsStr::new("marker"))),
-            JitMergePath::Marker
-        );
-    }
-
     /// Read a global by name from the frame's canonical `w_globals` object.
     fn frame_global(frame: &PyFrame, name: &str) -> pyre_object::PyObjectRef {
         unsafe { pyre_object::w_dict_getitem_str(frame.get_w_globals(), name) }
@@ -9180,26 +8786,6 @@ mod tests {
                 .set_default_params();
             driver.set_param("threshold", JIT_THRESHOLD as i64);
         }
-    }
-
-    #[test]
-    fn marker_mode_executes_zero_direct_hook_feeds() {
-        if jit_merge_path() != JitMergePath::Marker {
-            return;
-        }
-        MARKER_MODE_DIRECT_HOOK_FEEDS.store(0, std::sync::atomic::Ordering::Relaxed);
-        let _jit_params = TestJitParamsGuard::low_threshold();
-        let code = pyre_interpreter::compile_exec(
-            "i = 0\ntotal = 0\nwhile i < 100:\n    total = total + i\n    i = i + 1\n",
-        )
-        .expect("compile failed");
-        let mut frame = PyFrame::new(code);
-        eval_with_jit(&mut frame).expect("marker-mode execution failed");
-        assert_eq!(
-            MARKER_MODE_DIRECT_HOOK_FEEDS.load(std::sync::atomic::Ordering::Relaxed),
-            0,
-            "marker-mode dispatch must never feed jit_merge_point_hook"
-        );
     }
 
     fn function_code_from_module(

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -3098,6 +3098,48 @@ pub(crate) fn get_virtualizable_info() -> *const majit_metainterp::virtualizable
     std::sync::Arc::as_ptr(&pair.1)
 }
 
+/// Temporary C1 selector for the merge-point entry cutover.
+///
+/// Parsed once per process.  The default deliberately remains the legacy
+/// direct-hook feed until marker-path equivalence has been demonstrated.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum JitMergePath {
+    Hook,
+    Marker,
+}
+
+fn parse_jit_merge_path(value: Option<&std::ffi::OsStr>) -> JitMergePath {
+    match value.and_then(std::ffi::OsStr::to_str) {
+        None | Some("") | Some("hook") => JitMergePath::Hook,
+        Some("marker") => JitMergePath::Marker,
+        Some(other) => {
+            eprintln!(
+                "warning: invalid PYRE_JIT_MERGE_PATH={other:?}; expected hook or marker; using hook"
+            );
+            JitMergePath::Hook
+        }
+    }
+}
+
+#[inline]
+#[majit_macros::dont_look_inside]
+fn jit_merge_path() -> JitMergePath {
+    static PATH: std::sync::OnceLock<JitMergePath> = std::sync::OnceLock::new();
+    *PATH.get_or_init(|| parse_jit_merge_path(std::env::var_os("PYRE_JIT_MERGE_PATH").as_deref()))
+}
+
+#[cfg(test)]
+static MARKER_MODE_DIRECT_HOOK_FEEDS: std::sync::atomic::AtomicUsize =
+    std::sync::atomic::AtomicUsize::new(0);
+
+#[cfg(test)]
+fn note_direct_hook_feed() {
+    if jit_merge_path() == JitMergePath::Marker {
+        MARKER_MODE_DIRECT_HOOK_FEEDS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        panic!("marker mode reached a direct jit_merge_point_hook feed site");
+    }
+}
+
 /// pypy/module/pypyjit/interp_jit.py → PyPyJitDriver(JitDriver).
 ///
 /// Mirrors RPython JitDriver (`rpython/rlib/jit.py:610-693`) field set:
@@ -3152,9 +3194,9 @@ pub struct PyPyJitDriver {
 
 impl PyPyJitDriver {
     /// interp_jit.py:85-87 — jit_merge_point inside dispatch loop.
-    /// API-parity stub: the merge point is handled inside
-    /// `eval_loop_jit`'s `jit_merge_point_hook` until the S3 cutover
-    /// replaces this with the upstream marker call.
+    /// The untranslated body is intentionally a runtime no-op.  During source
+    /// translation, `ExtEnterLeaveMarker` lowers the call to `jit_marker` and
+    /// jtransform emits the JitCode `jit_merge_point` operation.
     pub fn jit_merge_point(
         &self,
         frame: &mut PyFrame,
@@ -3167,8 +3209,10 @@ impl PyPyJitDriver {
     }
 
     /// interp_jit.py:114-117 — can_enter_jit at back-edge.
-    /// API-parity stub: handled by `eval_loop_jit`'s
-    /// `maybe_compile_and_run` on `StepResult::CloseLoop`.
+    /// The untranslated body is intentionally a runtime no-op.  The translator
+    /// lowers it to `jit_marker('can_enter_jit', ...)`, which jtransform aliases
+    /// to the JitCode `loop_header` operation.  The live runtime warmstate call
+    /// remains alongside it until generic `warmspot.apply_jit` is wired.
     pub fn can_enter_jit(
         &self,
         frame: &mut PyFrame,
@@ -4689,6 +4733,22 @@ fn eval_loop_jit(frame: &mut PyFrame) -> LoopResult {
         }
 
         let pc = frame_root.frame().next_instr();
+
+        // interp_jit.py:85-87 — source-level marker declaration.  Its
+        // untranslated body is a no-op in both C1 modes; source translation
+        // recognizes this method call and lowers it to JitCode
+        // `jit_merge_point` rather than leaving a residual call.
+        let marker_ec = frame_root.frame().execution_context as *const PyExecutionContext;
+        let marker_pycode = frame_root.frame().pycode as pyre_object::PyObjectRef;
+        let marker_profiled = frame_root.frame().get_is_being_profiled();
+        pypyjitdriver.jit_merge_point(
+            frame_root.frame(),
+            marker_ec,
+            pc,
+            marker_pycode,
+            marker_profiled,
+        );
+
         let (opcode_pc, instruction, op_arg) = match decode_instruction_for_dispatch(code, pc) {
             Ok(decoded) => decoded,
             Err(err) => return LoopResult::Done(Err(err.into())),
@@ -4696,7 +4756,7 @@ fn eval_loop_jit(frame: &mut PyFrame) -> LoopResult {
 
         // ── jit_merge_point (RPython interp_jit.py:85-87) ──
         // Runtime no-op. Only handles trace feed when tracing is active.
-        if is_portal {
+        if is_portal && jit_merge_path() == JitMergePath::Hook {
             let tracing_depth: Option<u32> = driver.meta_interp().tracing_call_depth;
             let mut merge_point_active = if let Some(depth) = tracing_depth {
                 call_depth() == depth
@@ -4716,6 +4776,8 @@ fn eval_loop_jit(frame: &mut PyFrame) -> LoopResult {
                 merge_point_active = false;
             }
             if merge_point_active {
+                #[cfg(test)]
+                note_direct_hook_feed();
                 if let Some(loop_result) =
                     jit_merge_point_hook(frame_root.frame(), code, pc, driver, info, &env)
                 {
@@ -4854,6 +4916,16 @@ fn eval_loop_jit(frame: &mut PyFrame) -> LoopResult {
             Ok(StepResult::CloseLoop { loop_header_pc, .. }) if is_portal => {
                 // ── can_enter_jit (RPython interp_jit.py:114) ──
                 // RPython interp_jit.py:114 → warmstate.py:446
+                let marker_ec = frame_root.frame().execution_context as *const PyExecutionContext;
+                let marker_pycode = frame_root.frame().pycode as pyre_object::PyObjectRef;
+                let marker_profiled = frame_root.frame().get_is_being_profiled();
+                pypyjitdriver.can_enter_jit(
+                    frame_root.frame(),
+                    marker_ec,
+                    loop_header_pc,
+                    marker_pycode,
+                    marker_profiled,
+                );
                 let green_key = make_green_key(frame_root.frame().pycode, loop_header_pc);
                 if let Some(loop_result) = maybe_compile_and_run(
                     frame_root.frame(),
@@ -4914,10 +4986,14 @@ pub(crate) fn eval_loop_jit_bridge(frame: &mut PyFrame) -> LoopResult {
 
         // pyjitpl.py:1892-1914 run_one_step: trace + execute.
         if driver.is_tracing() {
-            if let Some(loop_result) =
-                jit_merge_point_hook(frame_root.frame(), code, pc, driver, info, &env)
-            {
-                return loop_result;
+            if jit_merge_path() == JitMergePath::Hook {
+                #[cfg(test)]
+                note_direct_hook_feed();
+                if let Some(loop_result) =
+                    jit_merge_point_hook(frame_root.frame(), code, pc, driver, info, &env)
+                {
+                    return loop_result;
+                }
             }
         } else {
             // Tracing ended (bridge compiled or aborted).
@@ -5115,7 +5191,7 @@ fn jit_merge_point_hook(
             let _ = concrete_frame;
             let live_frame_addr = &*frame as *const PyFrame as usize;
             let (action, executed_frame) =
-                trace_bytecode(meta, sym, code, pc, snapshot, live_frame_addr, true);
+                trace_bytecode(meta, sym, code, pc, snapshot, live_frame_addr, true, false);
             // pyjitpl.py:3048-3091 raise_continue_running_normally: tracing
             // IS execution — a walk that committed its end-of-walk state
             // into the snapshot (CloseLoop / CompileTracePending flush)
@@ -5889,6 +5965,181 @@ fn execute_assembler(
     }
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum CompileOnceStart {
+    BackEdge,
+    FunctionEntry,
+}
+
+/// RPython pyjitpl.py:2876-2888 `_compile_and_run_once`.
+///
+/// This is the single synchronous portal-trace walker for C1.  Hook mode
+/// preserves the historical split at function entry (start now, feed on the
+/// next dispatch iteration); marker mode registers and resolves the portal's
+/// static JitCode entry and performs the whole walk immediately.  Back-edge
+/// tracing was already synchronous and uses this helper in both modes.
+#[cold]
+#[majit_macros::dont_look_inside]
+fn compile_and_run_once(
+    frame: &mut PyFrame,
+    green_key: u64,
+    target_pc: usize,
+    start: CompileOnceStart,
+    driver: &mut JitDriver<PyreJitState>,
+    info: &majit_metainterp::virtualizable::VirtualizableInfo,
+    env: &PyreEnv,
+) -> Option<LoopResult> {
+    let mut frame_root = FrameRoot::new(frame);
+    let mode = jit_merge_path();
+    let code = unsafe { &*pyre_interpreter::pyframe_get_pycode(frame_root.frame()) };
+
+    // warmspot/codewriter ordering: the portal and all drained JitCodes are
+    // installed before the marker-driven metainterpreter starts.  Resolve the
+    // per-green static entry here; `trace_bytecode` consumes the same sidecar
+    // when it constructs the root MIFrame.
+    if mode == JitMergePath::Marker {
+        crate::jit::codewriter::register_portal_jitdriver(code);
+        let pjc = pyre_jit_trace::state::pyjitcode_for_code(frame_root.frame().pycode)
+            .expect("registered portal must have a drained PyJitCode");
+        pjc.merge_entry_for(target_pc)
+            .expect("registered portal must have a static merge entry for the hot green");
+    }
+
+    let mut jit_state = build_jit_state(frame_root.frame(), info);
+    let had_compiled = driver.has_compiled_loop(green_key);
+    match start {
+        CompileOnceStart::BackEdge => {
+            driver.bound_reached(green_key, target_pc, &mut jit_state, env);
+        }
+        CompileOnceStart::FunctionEntry => {
+            let _frame_locals_root = FrameLocalsRoot::new(frame_root.frame());
+            driver.force_start_tracing(green_key, target_pc, &mut jit_state, env);
+        }
+    }
+    if !driver.is_tracing() {
+        return None;
+    }
+
+    // Exact legacy function-entry behavior: `force_start_tracing` arms the
+    // trace and the following dispatch iteration feeds jit_merge_point_hook.
+    if mode == JitMergePath::Hook && start == CompileOnceStart::FunctionEntry {
+        return None;
+    }
+
+    let starting_tracing_key = driver.starting_green_key().unwrap_or(green_key);
+    driver.meta_interp_mut().tracing_call_depth = Some(call_depth());
+    let mut propagated_exception = None;
+    let outcome = driver.jit_merge_point_keyed(
+        green_key,
+        target_pc,
+        &mut jit_state,
+        env,
+        || {},
+        |meta, sym| {
+            // Hook-mode back-edge parity: registration historically occurred
+            // inside this closure, after tracing had started.
+            if mode == JitMergePath::Hook {
+                crate::jit::codewriter::register_portal_jitdriver(code);
+            }
+            let concrete_frame = frame_root.frame().snapshot_for_tracing();
+            let live_frame_addr = frame_root.frame() as *const PyFrame as usize;
+            let (action, executed_frame) = trace_bytecode(
+                meta,
+                sym,
+                code,
+                target_pc,
+                concrete_frame,
+                live_frame_addr,
+                true,
+                mode == JitMergePath::Marker,
+            );
+            let walk_end_flushed = pyre_jit_trace::trace::take_walk_end_flush_committed();
+            let walk_end_restart_pc = pyre_jit_trace::trace::take_walk_end_restart_pc();
+            if walk_end_flushed {
+                frame_root
+                    .frame()
+                    .restore_resume_state_from(&executed_frame);
+            } else if let Some(restart_pc) = walk_end_restart_pc {
+                frame_root
+                    .frame()
+                    .set_last_instr_from_next_instr(restart_pc);
+            }
+            propagated_exception = pyre_jit_trace::trace::take_walk_end_propagated_exception();
+            action
+        },
+    );
+    driver.meta_interp_mut().tracing_call_depth = None;
+
+    let compiled_key = driver.last_compiled_key().unwrap_or(green_key);
+    let tracing_finished = !driver.is_tracing();
+    // Preserve the legacy hook-mode exception ordering exactly: the old
+    // back-edge body propagated before quasi-immutable/TRACING cleanup.
+    if mode == JitMergePath::Hook {
+        if let Some(err) = propagated_exception.take() {
+            return Some(LoopResult::Done(Err(err)));
+        }
+    }
+    if tracing_finished {
+        if mode == JitMergePath::Marker {
+            // warmstate.py:437-444 `finally`: the starting cell owns JC_TRACING
+            // even when a cross-loop cut attaches the token to another key.
+            driver
+                .meta_interp_mut()
+                .warm_state_mut()
+                .clear_tracing_flag(starting_tracing_key);
+            if !had_compiled && driver.has_compiled_loop(compiled_key) {
+                register_quasi_immutable_deps(compiled_key);
+            }
+        } else {
+            // Preserve the legacy hook-mode back-edge ordering: register deps,
+            // then apply only the cross-loop starting-cell cleanup predicate.
+            if !had_compiled && driver.has_compiled_loop(compiled_key) {
+                register_quasi_immutable_deps(compiled_key);
+            }
+            if !had_compiled && driver.has_compiled_loop(compiled_key) && compiled_key != green_key
+            {
+                driver
+                    .meta_interp_mut()
+                    .warm_state_mut()
+                    .clear_tracing_flag(green_key);
+            }
+        }
+    }
+
+    if let Some(err) = propagated_exception {
+        return Some(LoopResult::Done(Err(err)));
+    }
+
+    if tracing_finished {
+        deliver_inflight_foriter_item(frame_root.frame());
+        match pyre_jit_trace::jitcode_dispatch::fbw_finish_concrete_take() {
+            Some(pyre_jit_trace::jitcode_dispatch::FinishConcrete::Return(cv)) => {
+                let result = match cv {
+                    pyre_jit_trace::state::ConcreteValue::Null => w_none(),
+                    other => other.to_pyobj(),
+                };
+                return Some(LoopResult::Done(Ok(result)));
+            }
+            Some(pyre_jit_trace::jitcode_dispatch::FinishConcrete::Raise(cv)) => {
+                return Some(LoopResult::Done(Err(finish_concrete_raise_error(cv))));
+            }
+            None => {}
+        }
+        return Some(LoopResult::ContinueRunningNormally);
+    }
+
+    if let Some(outcome) = outcome {
+        match handle_jit_outcome(outcome, &jit_state, frame_root.frame(), info, green_key) {
+            JitAction::Return(result) => return Some(LoopResult::Done(result)),
+            JitAction::ContinueRunningNormally => {
+                return Some(LoopResult::ContinueRunningNormally);
+            }
+            JitAction::Continue => {}
+        }
+    }
+    None
+}
+
 /// RPython warmstate.py:425-444 bound_reached.
 ///
 /// Called when counter threshold fires and no compiled code exists.
@@ -5948,6 +6199,17 @@ fn bound_reached(
     {
         return None;
     }
+    if !driver.has_compiled_loop(green_key) && !driver.is_tracing() {
+        return compile_and_run_once(
+            frame_root.frame(),
+            green_key,
+            loop_header_pc,
+            CompileOnceStart::BackEdge,
+            driver,
+            info,
+            env,
+        );
+    }
     // warmstate.py:503-511: procedure_token → EnterJitAssembler.
     let outcome = if driver.has_compiled_loop(green_key) {
         let _frame_locals_root = FrameLocalsRoot::new(frame_root.frame());
@@ -5958,145 +6220,6 @@ fn bound_reached(
             env,
             || {},
         ))
-    } else if !driver.is_tracing() {
-        // warmstate.py:425-444 bound_reached: enter tracing if the cell's
-        // counter / flags allow.  Pyre's `driver.bound_reached` does NOT
-        // compile synchronously — it returns `BackEdgeAction::StartedTracing`
-        // and the actual trace is driven by `jit_merge_point_keyed` below
-        // when `is_tracing()` becomes true after this call.
-        //
-        // PyPy parity: `maybe_compile_and_run` (warmstate.py:482-511)
-        // identifies "the compile we just made" through `cell.procedure_token`
-        // (per-greenkey cell), NOT by reading any global last-compiled
-        // value.  Pyre's equivalent is `has_compiled_loop(green_key)` —
-        // never `last_compiled_key()`, which is a single global slot that
-        // accumulates across iterations and cannot tell "stale prior
-        // compile" from "fresh same-key compile this round".  If a
-        // cross-loop cut compiles an INNER key, attachment goes to the
-        // INNER cell; the next iteration's `has_compiled_loop` query at
-        // the inner entry point dispatches to it (warmstate.py:482-483).
-        let had_compiled = driver.has_compiled_loop(green_key);
-        driver.bound_reached(green_key, loop_header_pc, &mut jit_state, env);
-        if driver.is_tracing() {
-            // RPython pyjitpl.py:2876-2888 _compile_and_run_once:
-            // interpret() traces the entire loop synchronously.
-            // Set tracing_call_depth so inner function calls (which
-            // run their own eval_loop_jit) don't trigger jit_merge_point_hook.
-            driver.meta_interp_mut().tracing_call_depth = Some(call_depth());
-            let code = unsafe { &*pyre_interpreter::pyframe_get_pycode(frame_root.frame()) };
-            let mut propagated_exception = None;
-            let outcome = driver.jit_merge_point_keyed(
-                green_key,
-                loop_header_pc,
-                &mut jit_state,
-                env,
-                || {},
-                |meta, sym| {
-                    use pyre_jit_trace::trace::trace_bytecode;
-                    crate::jit::codewriter::register_portal_jitdriver(code);
-                    let concrete_frame = frame_root.frame().snapshot_for_tracing();
-                    let live_frame_addr = frame_root.frame() as *const PyFrame as usize;
-                    let (action, executed_frame) = trace_bytecode(
-                        meta,
-                        sym,
-                        code,
-                        loop_header_pc,
-                        concrete_frame,
-                        live_frame_addr,
-                        true,
-                    );
-                    // raise_continue_running_normally seam — see the
-                    // jit_merge_point_hook tracing site for the contract.
-                    let walk_end_flushed = pyre_jit_trace::trace::take_walk_end_flush_committed();
-                    let walk_end_restart_pc = pyre_jit_trace::trace::take_walk_end_restart_pc();
-                    if walk_end_flushed {
-                        frame_root
-                            .frame()
-                            .restore_resume_state_from(&executed_frame);
-                    } else if let Some(restart_pc) = walk_end_restart_pc {
-                        frame_root
-                            .frame()
-                            .set_last_instr_from_next_instr(restart_pc);
-                    }
-                    propagated_exception =
-                        pyre_jit_trace::trace::take_walk_end_propagated_exception();
-                    action
-                },
-            );
-            driver.meta_interp_mut().tracing_call_depth = None;
-            if let Some(err) = propagated_exception {
-                return Some(LoopResult::Done(Err(err)));
-            }
-            let compiled_key = driver.last_compiled_key().unwrap_or(green_key);
-            if !had_compiled && driver.has_compiled_loop(compiled_key) {
-                register_quasi_immutable_deps(compiled_key);
-            }
-            // pyjitpl.py:3048-3061 raise_continue_running_normally:
-            // after compilation, restart so execute_assembler runs.
-            if !driver.is_tracing() {
-                // warmstate.py:444 `finally: cell.flags &= ~JC_TRACING`
-                // — green_key is the starting cell. Cross-loop cut
-                // (compile.py:269) installs the token on an inner cell,
-                // so attach_procedure_to_interp does not clear TRACING
-                // on green_key. Restore the clear here. The full
-                // gate `!had_compiled && has_compiled_loop(compiled_key)
-                // && compiled_key != green_key` narrows to "this round
-                // cross-loop-compiled under a different inner key";
-                // without it stale `last_compiled_key` values from
-                // prior iterations trigger spurious clears that can
-                // destabilize active traces (cranelift fannkuch regresses
-                // without this gate).
-                if !had_compiled
-                    && driver.has_compiled_loop(compiled_key)
-                    && compiled_key != green_key
-                {
-                    driver
-                        .meta_interp_mut()
-                        .warm_state_mut()
-                        .clear_tracing_flag(green_key);
-                }
-                // No-replay portal exit for a walk that started at this
-                // loop header but fell through to `done_with_this_frame`
-                // (the back-edge counter tripped on the loop's terminal
-                // iteration, so the loop test exited immediately and the
-                // walk traced the post-loop tail to the frame return).
-                // The walk executed the tail's residual calls concretely
-                // and captured the concrete return value; re-running the
-                // freshly compiled trace for THIS invocation
-                // (ContinueRunningNormally re-enters the live frame still
-                // parked at the loop header) would re-apply those already
-                // executed side effects.  Hand the captured result back
-                // directly, mirroring the `jit_merge_point_hook` tracing
-                // site (which carries the same no-replay logic for the
-                // merge-point-driven trace path).
-                // #57 Option C (deliver): a FOR_ITER trace that aborted on
-                // the back-edge `can_enter_jit` path advanced the real
-                // iterator once but discarded its recording.  Deliver the
-                // in-flight item to the live frame so the
-                // ContinueRunningNormally re-entry runs the body once for it
-                // (the same continuation as the `jit_merge_point_hook`
-                // tracing site).
-                deliver_inflight_foriter_item(frame_root.frame());
-                match pyre_jit_trace::jitcode_dispatch::fbw_finish_concrete_take() {
-                    Some(pyre_jit_trace::jitcode_dispatch::FinishConcrete::Return(cv)) => {
-                        let result = match cv {
-                            // A void return stashes `Null`, i.e. Python `None`.
-                            pyre_jit_trace::state::ConcreteValue::Null => w_none(),
-                            other => other.to_pyobj(),
-                        };
-                        return Some(LoopResult::Done(Ok(result)));
-                    }
-                    Some(pyre_jit_trace::jitcode_dispatch::FinishConcrete::Raise(cv)) => {
-                        return Some(LoopResult::Done(Err(finish_concrete_raise_error(cv))));
-                    }
-                    None => {}
-                }
-                return Some(LoopResult::ContinueRunningNormally);
-            }
-            outcome
-        } else {
-            None
-        }
     } else {
         None
     };
@@ -6445,7 +6568,6 @@ pub fn try_function_entry_jit(frame: &mut PyFrame) -> Option<PyResult> {
         return None;
     }
     let env = PyreEnv;
-    let mut jit_state = build_jit_state(frame_root.frame(), info);
     if majit_metainterp::majit_log_enabled() {
         eprintln!(
             "[jit][func-entry] start tracing key={} arg0={:?}",
@@ -6453,16 +6575,24 @@ pub fn try_function_entry_jit(frame: &mut PyFrame) -> Option<PyResult> {
             debug_first_arg_int(frame_root.frame()),
         );
     }
-    {
-        let _frame_locals_root = FrameLocalsRoot::new(frame_root.frame());
-        driver.force_start_tracing(
-            green_key,
-            frame_root.frame().next_instr(),
-            &mut jit_state,
-            &env,
-        );
+    let next_instr = frame_root.frame().next_instr();
+    match compile_and_run_once(
+        frame_root.frame(),
+        green_key,
+        next_instr,
+        CompileOnceStart::FunctionEntry,
+        driver,
+        info,
+        &env,
+    ) {
+        Some(LoopResult::Done(result)) => Some(result),
+        Some(LoopResult::ContinueRunningNormally) => {
+            // warmspot.py:976-978 portal re-entry.  Marker mode completed the
+            // synchronous walk; continue from the adopted/restart state.
+            Some(handle_jitexception(frame_root.frame()))
+        }
+        None => None,
     }
-    None
 }
 
 // dont_look_inside: JIT-driver outcome dispatch the tracer must not enter.
@@ -9007,6 +9137,19 @@ impl majit_metainterp::resume::BlackholeAllocator for PyreBlackholeAllocator {
 mod tests {
     use super::*;
 
+    #[test]
+    fn jit_merge_path_defaults_to_hook() {
+        assert_eq!(parse_jit_merge_path(None), JitMergePath::Hook);
+        assert_eq!(
+            parse_jit_merge_path(Some(std::ffi::OsStr::new("hook"))),
+            JitMergePath::Hook
+        );
+        assert_eq!(
+            parse_jit_merge_path(Some(std::ffi::OsStr::new("marker"))),
+            JitMergePath::Marker
+        );
+    }
+
     /// Read a global by name from the frame's canonical `w_globals` object.
     fn frame_global(frame: &PyFrame, name: &str) -> pyre_object::PyObjectRef {
         unsafe { pyre_object::w_dict_getitem_str(frame.get_w_globals(), name) }
@@ -9037,6 +9180,26 @@ mod tests {
                 .set_default_params();
             driver.set_param("threshold", JIT_THRESHOLD as i64);
         }
+    }
+
+    #[test]
+    fn marker_mode_executes_zero_direct_hook_feeds() {
+        if jit_merge_path() != JitMergePath::Marker {
+            return;
+        }
+        MARKER_MODE_DIRECT_HOOK_FEEDS.store(0, std::sync::atomic::Ordering::Relaxed);
+        let _jit_params = TestJitParamsGuard::low_threshold();
+        let code = pyre_interpreter::compile_exec(
+            "i = 0\ntotal = 0\nwhile i < 100:\n    total = total + i\n    i = i + 1\n",
+        )
+        .expect("compile failed");
+        let mut frame = PyFrame::new(code);
+        eval_with_jit(&mut frame).expect("marker-mode execution failed");
+        assert_eq!(
+            MARKER_MODE_DIRECT_HOOK_FEEDS.load(std::sync::atomic::Ordering::Relaxed),
+            0,
+            "marker-mode dispatch must never feed jit_merge_point_hook"
+        );
     }
 
     fn function_code_from_module(


### PR DESCRIPTION
Cut the JIT merge-point to the upstream marker path and delete the legacy direct hook (#205 C1).

## Commits

- **`jit: wire marker merge entry behind hook default`** — add source-level `jit_merge_point`/`can_enter_jit` markers (translator-lowered to `JitMergePoint`/`LoopHeader`), a synchronous marker-entry trace helper (`compile_and_run_once`), and marker-aware main-trace reconstruction. Gated behind a temporary `PYRE_JIT_MERGE_PATH=hook(default)|marker` switch so the marker path was proven identical to the direct hook before flipping.
- **`jit: remove legacy merge-point hook`** — flip to marker-only: delete `jit_merge_point_hook` and both feed sites, the `PYRE_JIT_MERGE_PATH`/`JitMergePath` switch, `eval_loop_jit_bridge` (zero callers), and the hook-only call-depth / trace-continuation-suspension dispatch. Main traces now always enter before the static marker; runtime marker-coordinate scanning remains only for bridge resumes.

Net: `434 insertions(+), 660 deletions(-)`. The direct runtime merge-point discovery hook is gone; the merge point is driven entirely by the marker OP the way the upstream warmspot/codewriter protocol does.

## Verification

`pyre/check.py` green on all three backends on the rebased tree:

- dynasm **194/194**
- cranelift **194/194**
- wasm **193/193**

Marker-only reproduces the pre-flip marker reference JIT-stats exactly across the 11 named benchmarks on both native backends (`loops/bridges/aborts/guard_failures/panics`), and `gc_stress` is 6/0.

Rebased onto current `main`; integrates the `WalkJournals` walk-journal handoff (#592) and the env-gate cleanup (#594) — `full_body_walk_trace` now carries both the `journals` parameter and the marker entry it used to gate.

Unblocks #205 C2 (multi-portal driver model): no `jdindex==0` hardcode; per-driver JitCode/descriptor identity and portal red-register metadata are preserved.

— *commented by Claude*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance & Reliability**
  * Improved JIT tracing with more accurate bridge-resume execution-state recovery.
  * Refined handling for declined/aborted traces to consistently fall back to interpreter execution.
  * Centralized JIT compile-and-run flow across loop and function-entry paths for more consistent behavior.
* **Documentation**
  * Updated comments and diagnostics around trace dispatch, resume handling, and exit/abort behavior.
* **Tests**
  * Added coverage to ensure JIT driver marker calls are lowered correctly during translation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->