### PR TITLE
jit: fix permuted FOR_ITER resume + add load-immune structural-stats gate to check.py

### DIFF
--- a/.github/workflows/pyre-ci.yml
+++ b/.github/workflows/pyre-ci.yml
@@ -380,6 +380,36 @@ jobs:
         PYRE_CHECK_PYTHON3: ${{ steps.cpython.outputs.python-path }}
         PYRE_CHECK_PYPY3: ${{ steps.pypy.outputs.python-path }}
       run: ${{ steps.cpython.outputs.python-path }} pyre/check.py
+    - name: JIT structural stats vs committed baseline (Linux, informational)
+      # Diff each benchmark's [jit-stats] counters against the committed
+      # pyre/bench/<name>.<backend>.jitstats baselines. The counters are decided
+      # by the platform-independent tracer, so a diff here means a change moved
+      # what the JIT compiles. Informational: the baselines were recorded on
+      # macOS aarch64 and cross-runner/cross-platform determinism of the
+      # counters is not yet confirmed in CI, so this must not gate main until
+      # the summaries stay clean across real PRs. The .out/.time baselines are
+      # not committed, so their snapshot checks report "missing" and only the
+      # jit-stats diff is exercised. Runs on Linux only (one OS is enough for a
+      # platform-independent signal), where ripgrep is preinstalled.
+      if: runner.os == 'Linux'
+      continue-on-error: true
+      env:
+        PYRE_CHECK_PYTHON3: ${{ steps.cpython.outputs.python-path }}
+        PYRE_CHECK_PYPY3: ${{ steps.pypy.outputs.python-path }}
+      run: |
+        set -uo pipefail
+        {
+          echo '### JIT structural stats vs committed baseline'
+          for backend in dynasm cranelift; do
+            echo "#### $backend"
+            echo '```'
+            out=$(${{ steps.cpython.outputs.python-path }} pyre/check.py \
+              --backend "$backend" --no-synthetic --snapshot-diff 2>&1 || true)
+            echo "$out" | rg -i 'jit-stats diff|snapshot diff' \
+              || echo '(no jit-stats output)'
+            echo '```'
+          done
+        } >> "$GITHUB_STEP_SUMMARY"
 
   pyre-check-macos:
     name: pyre/check.py (macos-latest)

--- a/pyre/.gitignore
+++ b/pyre/.gitignore
@@ -1,4 +1,7 @@
 /target
 **/*.rs.bk
 Cargo.lock
+# check.py local scratch: .out/.time snapshots and synthetic .jitstats.
+# The committed benchmark baselines live at pyre/bench/*.jitstats.
 /check.snap/
+/bench/synth/*.jitstats

--- a/pyre/bench/fannkuch.cranelift.jitstats
+++ b/pyre/bench/fannkuch.cranelift.jitstats
@@ -1,0 +1,5 @@
+bridges_compiled=40
+guard_failures=8202
+internal_compile_panics=0
+loops_aborted=0
+loops_compiled=5

--- a/pyre/bench/fannkuch.dynasm.jitstats
+++ b/pyre/bench/fannkuch.dynasm.jitstats
@@ -1,0 +1,5 @@
+bridges_compiled=40
+guard_failures=8202
+internal_compile_panics=0
+loops_aborted=0
+loops_compiled=5

--- a/pyre/bench/fib_loop.cranelift.jitstats
+++ b/pyre/bench/fib_loop.cranelift.jitstats
@@ -1,0 +1,5 @@
+bridges_compiled=0
+guard_failures=189
+internal_compile_panics=0
+loops_aborted=0
+loops_compiled=1

--- a/pyre/bench/fib_loop.dynasm.jitstats
+++ b/pyre/bench/fib_loop.dynasm.jitstats
@@ -1,0 +1,5 @@
+bridges_compiled=0
+guard_failures=189
+internal_compile_panics=0
+loops_aborted=0
+loops_compiled=1

--- a/pyre/bench/fib_recursive.cranelift.jitstats
+++ b/pyre/bench/fib_recursive.cranelift.jitstats
@@ -1,0 +1,5 @@
+bridges_compiled=1
+guard_failures=1
+internal_compile_panics=0
+loops_aborted=0
+loops_compiled=1

--- a/pyre/bench/fib_recursive.dynasm.jitstats
+++ b/pyre/bench/fib_recursive.dynasm.jitstats
@@ -1,0 +1,5 @@
+bridges_compiled=1
+guard_failures=1
+internal_compile_panics=0
+loops_aborted=0
+loops_compiled=1

--- a/pyre/bench/float_loop.cranelift.jitstats
+++ b/pyre/bench/float_loop.cranelift.jitstats
@@ -1,0 +1,5 @@
+bridges_compiled=0
+guard_failures=1
+internal_compile_panics=0
+loops_aborted=0
+loops_compiled=1

--- a/pyre/bench/float_loop.dynasm.jitstats
+++ b/pyre/bench/float_loop.dynasm.jitstats
@@ -1,0 +1,5 @@
+bridges_compiled=0
+guard_failures=1
+internal_compile_panics=0
+loops_aborted=0
+loops_compiled=1

--- a/pyre/bench/inline_helper.cranelift.jitstats
+++ b/pyre/bench/inline_helper.cranelift.jitstats
@@ -1,0 +1,5 @@
+bridges_compiled=0
+guard_failures=1
+internal_compile_panics=0
+loops_aborted=0
+loops_compiled=1

--- a/pyre/bench/inline_helper.dynasm.jitstats
+++ b/pyre/bench/inline_helper.dynasm.jitstats
@@ -1,0 +1,5 @@
+bridges_compiled=0
+guard_failures=1
+internal_compile_panics=0
+loops_aborted=0
+loops_compiled=1

--- a/pyre/bench/int_loop.cranelift.jitstats
+++ b/pyre/bench/int_loop.cranelift.jitstats
@@ -1,0 +1,5 @@
+bridges_compiled=0
+guard_failures=1
+internal_compile_panics=0
+loops_aborted=0
+loops_compiled=1

--- a/pyre/bench/int_loop.dynasm.jitstats
+++ b/pyre/bench/int_loop.dynasm.jitstats
@@ -1,0 +1,5 @@
+bridges_compiled=0
+guard_failures=1
+internal_compile_panics=0
+loops_aborted=0
+loops_compiled=1

--- a/pyre/bench/nbody.cranelift.jitstats
+++ b/pyre/bench/nbody.cranelift.jitstats
@@ -1,0 +1,5 @@
+bridges_compiled=5
+guard_failures=1286
+internal_compile_panics=0
+loops_aborted=0
+loops_compiled=5

--- a/pyre/bench/nbody.dynasm.jitstats
+++ b/pyre/bench/nbody.dynasm.jitstats
@@ -1,0 +1,5 @@
+bridges_compiled=5
+guard_failures=1286
+internal_compile_panics=0
+loops_aborted=0
+loops_compiled=5

--- a/pyre/bench/nested_loop.cranelift.jitstats
+++ b/pyre/bench/nested_loop.cranelift.jitstats
@@ -1,0 +1,5 @@
+bridges_compiled=1
+guard_failures=201
+internal_compile_panics=0
+loops_aborted=0
+loops_compiled=1

--- a/pyre/bench/nested_loop.dynasm.jitstats
+++ b/pyre/bench/nested_loop.dynasm.jitstats
@@ -1,0 +1,5 @@
+bridges_compiled=1
+guard_failures=201
+internal_compile_panics=0
+loops_aborted=0
+loops_compiled=1

--- a/pyre/bench/raise_catch_loop.cranelift.jitstats
+++ b/pyre/bench/raise_catch_loop.cranelift.jitstats
@@ -1,0 +1,5 @@
+bridges_compiled=1
+guard_failures=201
+internal_compile_panics=0
+loops_aborted=0
+loops_compiled=1

--- a/pyre/bench/raise_catch_loop.dynasm.jitstats
+++ b/pyre/bench/raise_catch_loop.dynasm.jitstats
@@ -1,0 +1,5 @@
+bridges_compiled=1
+guard_failures=201
+internal_compile_panics=0
+loops_aborted=0
+loops_compiled=1

--- a/pyre/bench/spectral_norm.cranelift.jitstats
+++ b/pyre/bench/spectral_norm.cranelift.jitstats
@@ -1,0 +1,5 @@
+bridges_compiled=2
+guard_failures=441
+internal_compile_panics=0
+loops_aborted=0
+loops_compiled=3

--- a/pyre/bench/spectral_norm.dynasm.jitstats
+++ b/pyre/bench/spectral_norm.dynasm.jitstats
@@ -1,0 +1,5 @@
+bridges_compiled=2
+guard_failures=441
+internal_compile_panics=0
+loops_aborted=0
+loops_compiled=3

--- a/pyre/check.py
+++ b/pyre/check.py
@@ -347,6 +347,46 @@ def _jit_panic_reason(stderr):
 
 # ── Helpers ──────────────────────────────────────────────────────────
 
+def _jit_stats_snapshot(stderr):
+    """Return the last jit-stats line as normalized key/value text."""
+    stats_line = None
+    for line in stderr.splitlines():
+        if line.startswith("[jit-stats]"):
+            stats_line = line
+    if stats_line is None:
+        return None
+
+    fields = {}
+    for token in stats_line[len("[jit-stats]") :].split():
+        if "=" in token:
+            key, value = token.split("=", 1)
+            fields[key] = value
+    # This watches what the JIT compiles, never how well. A regression that
+    # changes no structure (for example, an extra spill) is invisible here.
+    return "".join(f"{key}={fields[key]}\n" for key in sorted(fields))
+
+
+def _jit_stats_diff(saved, current, limit=6):
+    """Describe normalized jit-stats changes, capped for terminal output."""
+    def parse(snapshot):
+        if snapshot is None:
+            return {}
+        return dict(line.split("=", 1) for line in snapshot.splitlines())
+
+    old_fields = parse(saved)
+    new_fields = parse(current)
+    changes = [
+        f"{key} {old_fields.get(key, '<missing>')} -> "
+        f"{new_fields.get(key, '<missing>')}"
+        for key in sorted(old_fields.keys() | new_fields.keys())
+        if old_fields.get(key) != new_fields.get(key)
+    ]
+    shown = changes[:limit]
+    if len(changes) > limit:
+        shown.append(f"... {len(changes) - limit} more")
+    return ", ".join(shown)
+
+
 def scaled_timeout(base, scale):
     v = base * scale
     return int(v) if v == int(v) else float(f"{v:.3f}".rstrip("0").rstrip("."))
@@ -498,6 +538,8 @@ class Check:
         self.pyre = {}
         self.snapshot_diffs = []
         self.snapshot_missing = []
+        self.jitstats_diffs = []
+        self.jitstats_missing = []
 
     # ── backend helpers ──
 
@@ -568,15 +610,28 @@ class Check:
     def _snapshot_path(self, backend, name, suffix):
         return Path(SNAP_DIR) / backend / f"{name}.{suffix}"
 
-    def _apply_snapshot_gate(self, backend, name, output, elapsed):
+    def _jitstats_baseline_path(self, backend, script):
+        # The committed structural-stats baseline sits beside its benchmark
+        # source (pyre/bench/<name>.<backend>.jitstats), not in the gitignored
+        # check.snap scratch tree that holds the local .out/.time snapshots.
+        source = Path(script)
+        return source.with_name(f"{source.stem}.{backend}.jitstats")
+
+    def _apply_snapshot_gate(self, backend, name, script, output, stderr, elapsed):
         status, reason = "ok", ""
         out_path = self._snapshot_path(backend, name, "out")
         time_path = self._snapshot_path(backend, name, "time")
+        jitstats_path = self._jitstats_baseline_path(backend, script)
+        jitstats = _jit_stats_snapshot(stderr)
 
         if self.args.snapshot_mode == "record":
             out_path.parent.mkdir(parents=True, exist_ok=True)
             out_path.write_text(output, encoding="utf-8")
             time_path.write_text(f"{elapsed:.2f}", encoding="utf-8")
+            if jitstats is None:
+                jitstats_path.unlink(missing_ok=True)
+            else:
+                jitstats_path.write_text(jitstats, encoding="utf-8")
 
         if self.args.snapshot_mode == "diff":
             if not out_path.exists():
@@ -586,6 +641,15 @@ class Check:
                 if output != saved_out:
                     self.snapshot_diffs.append(f"{backend}/{name}")
                     return "fail", "snapshot output diff"
+
+            if not jitstats_path.exists():
+                self.jitstats_missing.append(f"{backend}/{name}")
+            else:
+                saved_jitstats = jitstats_path.read_text(encoding="utf-8")
+                if jitstats != saved_jitstats:
+                    self.jitstats_diffs.append(f"{backend}/{name}")
+                    delta = _jit_stats_diff(saved_jitstats, jitstats)
+                    return "fail", f"jit-stats diff: {delta}"
 
         if (
             self.args.threshold is not None
@@ -962,7 +1026,7 @@ class Check:
                 ratio = f"{elapsed / checked_baseline:.1f}x" if checked_baseline > 0 else "-"
 
         snap_status, snap_reason = self._apply_snapshot_gate(
-            backend, name, output, elapsed,
+            backend, name, script, output, stderr, elapsed,
         )
         if snap_status == "fail":
             self._record(backend, False, name, snap_reason)
@@ -1260,6 +1324,18 @@ class Check:
                     )
                 if not self.snapshot_diffs and not self.snapshot_missing:
                     print(dim("snapshot diff: clean"))
+                if self.jitstats_diffs:
+                    print(
+                        f"{red('jit-stats diff')}: {len(self.jitstats_diffs)} bench(es)"
+                        f" — {' '.join(self.jitstats_diffs)}"
+                    )
+                if self.jitstats_missing:
+                    print(
+                        f"{dim('jit-stats missing')}: {len(self.jitstats_missing)} bench(es)"
+                        f" — {' '.join(self.jitstats_missing)}"
+                    )
+                if not self.jitstats_diffs and not self.jitstats_missing:
+                    print(dim("jit-stats diff: clean"))
             if self.args.threshold is not None:
                 print(dim(f"threshold: ±{self.args.threshold}% vs baseline"))
             print()

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -10491,6 +10491,38 @@ fn vstack_containing_py_pc(metadata: &crate::PyJitCodeMetadata, jit_pc: usize) -
     best_py
 }
 
+fn vstack_initial_py_pc(
+    metadata: &crate::PyJitCodeMetadata,
+    jit_pc: usize,
+    permuted_for_iter_entry: bool,
+) -> u32 {
+    if !permuted_for_iter_entry {
+        return vstack_containing_py_pc(metadata, jit_pc);
+    }
+    metadata_block_head_py_pc(metadata, jit_pc)
+        .unwrap_or_else(|| vstack_containing_py_pc(metadata, jit_pc))
+}
+
+fn metadata_block_head_py_pc(metadata: &crate::PyJitCodeMetadata, jit_pc: usize) -> Option<u32> {
+    metadata
+        .block_head_py_by_jit_pc
+        .binary_search_by_key(&jit_pc, |&(off, _)| off)
+        .ok()
+        .map(|i| metadata.block_head_py_by_jit_pc[i].1)
+}
+
+fn vstack_step_py_pc(
+    metadata: &crate::PyJitCodeMetadata,
+    jit_pc: usize,
+    current_py_pc: u32,
+) -> u32 {
+    if metadata_block_head_py_pc(metadata, jit_pc) == Some(current_py_pc) {
+        current_py_pc
+    } else {
+        vstack_containing_py_pc(metadata, jit_pc)
+    }
+}
+
 /// Reconstruct `pc_map[py]` — the `-live-` resume marker byte offset for
 /// Python PC `py` — from the two surviving tables plus the sparse carry-forward
 /// sidecar, WITHOUT the retired dense `pc_map` Vec.  Same resolution as
@@ -10588,7 +10620,7 @@ fn step_vstack_mirror(ctx: &mut WalkContext<'_, '_>, jit_pc: usize) {
             if jc.payload.code_ptr.is_null() {
                 return;
             }
-            let py_pc = vstack_containing_py_pc(&jc.payload.metadata, jit_pc);
+            let py_pc = vstack_step_py_pc(&jc.payload.metadata, jit_pc, ctx.vstack_cur_pypc);
             let depth = crate::liveness::liveness_for(jc.payload.code_ptr)
                 .depth_at_py_pc()
                 .get(py_pc as usize)
@@ -10633,24 +10665,44 @@ fn seed_vstack_mirror(ctx: &mut WalkContext<'_, '_>, sym: &crate::state::PyreSym
     if sym.jitcode.is_null() || !sym.owns_virtualizable_shadow() {
         return;
     }
-    // Seed the mirror's current coordinate at the containment py_pc of the
-    // ACTUAL first-walked jitcode op (`start_pc`), NOT the resume/loop-header
-    // `entry_py_pc`.  A loop trace's `walk()` starts at `position = start_pc`,
-    // whose containing Python opcode may precede `entry_py_pc` (the
-    // loop-header resume coordinate the snapshot reader uses).  Seeding
-    // `cur_pypc = entry_py_pc` then made the FIRST `step_vstack_mirror`
-    // produce a spurious "backward" boundary (e.g. `5 -> 4`) that reconciled
-    // the not-yet-executed first opcode with `last_ref = None`, leaving a
-    // NONE hole that latched `vstack_valid = false` for the whole walk.
-    // Seeding at the first op's own py_pc makes the first step a no-op
-    // (`new_pypc == cur_pypc` early-out), so the mirror only reconciles
-    // boundaries AFTER the entry — where a previous opcode actually ran.
+    // Ordinarily seed at the opcode containing the first walked jitcode op,
+    // so the first step is a no-op and reconciliation starts only after an
+    // opcode actually runs. A SWAP/COPY immediately preceding a FOR_ITER
+    // block-head marker is different: the shadow already contains the
+    // post-permutation stack at trace entry. Seed that marker at FOR_ITER and
+    // let `vstack_step_py_pc` ignore the marker itself, preventing the
+    // predecessor permutation from being applied to the mirror a second time.
     let (first_pypc, depth, nlocals) = unsafe {
         let jc = &*sym.jitcode;
         if jc.payload.code_ptr.is_null() {
             return;
         }
-        let first_pypc = vstack_containing_py_pc(&jc.payload.metadata, start_pc);
+        let containing_pypc = vstack_containing_py_pc(&jc.payload.metadata, start_pc);
+        let predecessor_permuted_stack = pyre_interpreter::decode_instruction_at(
+            &*jc.payload.code_ptr,
+            containing_pypc as usize,
+        )
+        .is_some_and(|(instr, op_arg)| {
+            matches!(
+                classify_vstack_opcode(&instr, op_arg),
+                VstackOpClass::Swap(_) | VstackOpClass::Copy(_)
+            )
+        });
+        let target_is_for_iter = metadata_block_head_py_pc(&jc.payload.metadata, start_pc)
+            .and_then(|target| {
+                pyre_interpreter::decode_instruction_at(&*jc.payload.code_ptr, target as usize)
+            })
+            .is_some_and(|(instr, _)| {
+                matches!(
+                    instr,
+                    pyre_interpreter::bytecode::Instruction::ForIter { .. }
+                )
+            });
+        let first_pypc = vstack_initial_py_pc(
+            &jc.payload.metadata,
+            start_pc,
+            predecessor_permuted_stack && target_is_for_iter,
+        );
         let d = crate::liveness::liveness_for(jc.payload.code_ptr)
             .depth_at_py_pc()
             .get(first_pypc as usize)
@@ -25819,6 +25871,22 @@ mod tests {
         let index = unsafe { (*jitcode).index as u32 };
         INDEX.with(|slot| slot.set(Some(index)));
         index
+    }
+
+    #[test]
+    fn vstack_permuted_for_iter_entry_uses_block_head_target() {
+        let mut pyjit = crate::PyJitCode::skeleton(std::ptr::null());
+        pyjit.metadata.first_jit_pc_by_py_pc = vec![usize::MAX; 19];
+        pyjit.metadata.first_jit_pc_by_py_pc[17] = 100;
+        pyjit.metadata.first_jit_pc_by_py_pc[18] = 120;
+        pyjit.metadata.block_head_py_by_jit_pc = vec![(110, 18)];
+
+        assert_eq!(vstack_containing_py_pc(&pyjit.metadata, 110), 17);
+        assert_eq!(vstack_initial_py_pc(&pyjit.metadata, 110, true), 18);
+        assert_eq!(vstack_initial_py_pc(&pyjit.metadata, 110, false), 17);
+        assert_eq!(vstack_step_py_pc(&pyjit.metadata, 110, 18), 18);
+        assert_eq!(vstack_step_py_pc(&pyjit.metadata, 110, 17), 17);
+        assert_eq!(vstack_step_py_pc(&pyjit.metadata, 120, 18), 18);
     }
 
     /// Build a fresh `TraceCtx`. Uses the public `for_test_types` +

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -7021,18 +7021,18 @@ impl CodeWriter {
             }};
         }
 
-        // pyframe.py:378-381 `pushvalue` lowers to
+        // `pushvalue` (pyframe.py) lowers to
         // `setarrayitem_vable_r(locals_cells_stack_w, depth, w_object)`
         // + `setfield_vable_i(valuestackdepth, depth + 1)` via
-        // jtransform.py:1898 `do_fixed_list_setitem` +
-        // jtransform.py:920-928. RPython's optimizer folds the per-push
-        // `setarrayitem_vable_r` via OptVirtualize so that the compiled
-        // trace pays only the final force-vable cost; pyre's
-        // OptVirtualize does not yet fold these at the same grain, so
-        // the emission is load-bearing for shadow parity with
-        // `list_of_boxes_virtualizable` + BH `virtualizable_boxes`
-        // reconstruction and the per-push cost is recovered only as the
-        // optimizer port progresses.
+        // `do_fixed_list_setitem` and `do_setfield` (jtransform.py).
+        //
+        // Both are jitcode operations, not IR: `_opimpl_setarrayitem_vable`
+        // (pyjitpl.py) consumes the write at trace time by assigning
+        // `virtualizable_boxes[index]` and synchronizing the image, and only
+        // the `_nonstandard_virtualizable` fallback records a SETARRAYITEM_GC.
+        // On the standard virtualizable the emission therefore costs no
+        // operation in the compiled trace, and no optimizer pass folds it —
+        // there is nothing in the IR to fold.
         macro_rules! emit_pushvalue_ref {
             ($depth:ident, $src:expr, $src_value:expr, $py_pc:expr) => {{
                 let _ = $src;


### PR DESCRIPTION
Four commits: one JIT correctness fix, then a load-immune structural-stats gate for `pyre/check.py` with committed baselines and an informational CI diff.

## 1. jit: seed permuted FOR_ITER vstack entries from the block-head target (gh#570)

A comprehension could return its iterator instead of the built object. Permuted FOR_ITER entries were seeded from the already-permuted virtualizable shadow while the block-head `-live-` marker was attributed to the preceding `SWAP`/`COPY`, so the loop-preheader permutation was applied twice. `SWAP` is an involution, which made "never applied" and "applied twice" observationally identical and masked the bug. The loop-exit bytecodes run interpreted (not bridge-compiled), so the guard snapshot's doubly-permuted arrangement reached the resumed frame and returned the iterator.

Fix: seed permuted FOR_ITER entries from the block-head target via `vstack_initial_py_pc(metadata, jit_pc, permuted_for_iter_entry=true)`. Adds a unit test; `check.py --synthetic-only` is 183/183 on both dynasm and cranelift.

## 2. check: `.jitstats` structural-stats snapshot artifact

The wall-clock benchmark gate crosses its threshold on load noise — this PR's own CI summary shows benchmarks like `nested_loop` flapping between runs of the same binary. The JIT structural counters (`loops_compiled`, `bridges_compiled`, `loops_aborted`, `guard_failures`, `internal_compile_panics`) are load-immune and backend-identical, so they detect a change in *what* the JIT compiles.

Adds a per-benchmark `[jit-stats]` snapshot recorded and diffed byte-for-byte through the existing `--snapshot` / `--snapshot-diff` flags (no new CLI flags). The committed baseline sits **beside its benchmark source** as `pyre/bench/<name>.<backend>.jitstats`; the local `.out`/`.time` snapshots stay in the gitignored `check.snap` scratch tree. A missing baseline is non-fatal; the failure message names each changed field, e.g. `jit-stats diff: loops_compiled 5 -> 6, guard_failures 1286 -> 1450`.

**Limit (stated in the code too):** this watches *what* compiles, never *how well* — a regression with identical structure but worse code inside the loop is byte-identical here and passes.

## 3. Committed baselines + informational CI diff

Commits `pyre/bench/<name>.<backend>.jitstats` for the 10 benchmarks on each backend (dynasm and cranelift record identical counters). `pyre/.gitignore` ignores the `.out`/`.time` scratch and synthetic `.jitstats`; the benchmark baselines are tracked normally. Adds a Linux-only, `continue-on-error` CI step that runs `--no-synthetic --snapshot-diff` for both backends and writes the per-benchmark jit-stats diff to the job step summary.

Informational, not a hard gate yet: the baselines were recorded on macOS aarch64, and cross-runner / cross-platform determinism of the counters is not yet confirmed in CI. Promote to a hard gate once the summaries stay clean across real PRs.

— *commented by Claude*