### PR TITLE
jit: recursion-unroll follow-ups — CA bridge re-entrancy bail, gated mutual-recursion portal cutover, deopt-resume GC rooting

### DIFF
--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -5688,34 +5688,6 @@ fn spill_ref_roots(
     }
 }
 
-/// RPython regalloc keeps many REF boxes frame-resident after
-/// `_sync_var_to_stack` / `_bc_spill`.  When Cranelift has already
-/// written a ref box to its jitframe root slot, re-storing it before a
-/// CALL_ASSEMBLER is redundant: the GC updates that slot in-place.
-fn spill_unsynced_ref_roots(
-    builder: &mut FunctionBuilder,
-    jf_ptr: CValue,
-    ref_root_slots: &[(u32, usize)],
-    defined_ref_vars: &IndexSet<u32>,
-    synced_ref_vars: &IndexSet<u32>,
-    demoted_failarg_slots: &IndexMap<u32, i32>,
-    ref_root_base_ofs: i32,
-) {
-    for &(var_idx, slot) in ref_root_slots {
-        if !defined_ref_vars.contains(&var_idx) || synced_ref_vars.contains(&var_idx) {
-            continue;
-        }
-        // Demoted refs are frame-resident with no loop-body SSA definition
-        // (their slot is already a live gcmap root); never `use_var` them.
-        if is_demoted_failarg(demoted_failarg_slots, var_idx) {
-            continue;
-        }
-        let offset = ref_root_base_ofs + (slot as i32) * 8;
-        let val = builder.use_var(var(var_idx));
-        builder.ins().store(MemFlags::new(), val, jf_ptr, offset);
-    }
-}
-
 /// assembler.py:1369-1377 _pop_all_regs_from_frame:
 /// Reload all defined GC ref variables from jf_frame after a call.
 /// The GC may have moved objects and updated the slots in-place.
@@ -11229,12 +11201,12 @@ impl CraneliftBackend {
                         // pops it (_call_footer_shadowstack). The caller does
                         // NOT touch the shadow stack here.
                         jf_ptr = builder.ins().get_pinned_reg(ptr_type);
-                        spill_unsynced_ref_roots(
+                        spill_ref_roots(
                             &mut builder,
                             jf_ptr,
                             &live_ref_root_slots,
                             &defined_ref_vars,
-                            &synced_ref_vars,
+                            &stale_ref_vars,
                             &demoted_failarg_slots,
                             ref_root_base_ofs,
                         );
@@ -11342,12 +11314,12 @@ impl CraneliftBackend {
                         // the caller frame, matching the pending-gcmap
                         // sequence used by the dynasm backend.
                         jf_ptr = builder.ins().get_pinned_reg(ptr_type);
-                        spill_unsynced_ref_roots(
+                        spill_ref_roots(
                             &mut builder,
                             jf_ptr,
                             &live_ref_root_slots,
                             &defined_ref_vars,
-                            &synced_ref_vars,
+                            &stale_ref_vars,
                             &demoted_failarg_slots,
                             ref_root_base_ofs,
                         );
@@ -11423,12 +11395,12 @@ impl CraneliftBackend {
                     // jitframe pointer through the Variable so Cranelift
                     // threads it through the necessary block params.
                     jf_ptr = builder.ins().get_pinned_reg(ptr_type);
-                    spill_unsynced_ref_roots(
+                    spill_ref_roots(
                         &mut builder,
                         jf_ptr,
                         &live_ref_root_slots,
                         &defined_ref_vars,
-                        &synced_ref_vars,
+                        &stale_ref_vars,
                         &demoted_failarg_slots,
                         ref_root_base_ofs,
                     );

--- a/majit/majit-metainterp/src/blackhole.rs
+++ b/majit/majit-metainterp/src/blackhole.rs
@@ -1280,7 +1280,23 @@ impl BlackholeInterpreter {
             }
             depth
         };
+        let vable_roots_depth = majit_gc::shadow_stack::resume_ref_roots_depth();
+        unsafe {
+            let mut current = Some(&mut *self);
+            while let Some(frame) = current {
+                if !frame.virtualizable_info.is_null() {
+                    let vinfo = &*frame.virtualizable_info;
+                    vinfo.push_resume_ref_roots_for_registers(&frame.registers_r);
+                    crate::resume::VirtualizableInfo::push_resume_ref_roots(
+                        vinfo,
+                        frame.virtualizable_ptr,
+                    );
+                }
+                current = frame.nextblackholeinterp.as_deref_mut();
+            }
+        }
         let result = self.run_inner();
+        majit_gc::shadow_stack::pop_resume_ref_roots_to(vable_roots_depth);
         majit_gc::shadow_stack::pop_bh_regs_to(bh_depth);
         result
     }

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -2759,6 +2759,24 @@ impl<M: Clone> MetaInterp<M> {
         self.result_type
     }
 
+    /// `call.py:46-47` `jd.index = idx; self.jitdrivers_sd.append(jd)` —
+    /// register a real portal `JitDriverStaticData` (greens/reds/virtualizable
+    /// + `portal_runner_adr`) so `compile_tmp_callback` / `do_recursive_call`
+    /// have a populated slot.  Wraps
+    /// [`MetaInterpStaticData::register_jitdriver_sd`] with the disjoint
+    /// `staticdata`/`backend` field borrow (mirrors `set_result_type`) so the
+    /// `finish_setup_descrs_for_jitdrivers` tail sees the backend half.
+    pub fn register_jitdriver_sd(&mut self, jd: crate::jitdriver::JitDriverStaticData) -> usize {
+        let Self {
+            staticdata,
+            backend,
+            ..
+        } = self;
+        let sd = std::sync::Arc::get_mut(staticdata)
+            .expect("register_jitdriver_sd: staticdata has other owners");
+        sd.register_jitdriver_sd(jd, backend)
+    }
+
     /// pyjitpl.py:2289 / descr.py:25-47 parity: take back all_descrs from
     /// optimizer after compilation. Optimizer.ensure_descr_index() assigns
     /// sequential descr_index during collect_optimizer_knowledge_for_resume().
@@ -13510,6 +13528,65 @@ impl<M: Clone> MetaInterp<M> {
         // pyjitpl.py:3604-3608 return vablebox per jd.index_of_virtualizable.
         let vablebox = vable_index.and_then(|idx| args.get(idx).map(|(_, opref, _)| *opref));
         (vablebox, Some(op_ref))
+    }
+
+    /// Walker-side analog of [`Self::direct_assembler_call`]'s token branch
+    /// (pyjitpl.py:3597-3599, warmstate.py:714-723): resolve — or synthesise
+    /// via `compile_tmp_callback` — the CALL_ASSEMBLER token number for a
+    /// recursive callee whose own loop has not finished compiling.  Returns the
+    /// token number to key the backend target on, or `None` when the real
+    /// portal driver is unregistered (cutover off) or `compile_tmp_callback`
+    /// fails.
+    ///
+    /// `greenboxes` carries the portal greens in `build_portal_calldescr`
+    /// declaration order (`[next_instr, is_being_profiled, pycode]`);
+    /// `red_arg_types` the reds (`[frame, ec]` → `[Ref, Ref]`).
+    pub fn get_or_make_portal_assembler_token_number(
+        &mut self,
+        green_key: u64,
+        greenboxes: &[Value],
+        red_arg_types: &[Type],
+    ) -> Option<u64> {
+        // The real portal driver has greens; the empty
+        // `ensure_default_driver_sd` placeholder (jitdrivers_sd[0]) has none.
+        let idx = self
+            .staticdata
+            .jitdrivers_sd
+            .iter()
+            .position(|jd| jd.num_greens() > 0)?;
+        let target_sd = self.staticdata.jitdrivers_sd.get(idx).cloned()?;
+        // `compile.py:187` parity: an already-compiled loop token wins.
+        if let Some(arc) = self.get_loop_token_arc(green_key) {
+            return Some(arc.number);
+        }
+        // warmstate.py:714-723 — cell has no procedure_token yet, so synthesise
+        // one via `compile_tmp_callback`.  Reuse an already-allocated pending
+        // token number when present so the backend's pending-target registry
+        // stays consistent.
+        let token_number = self
+            .get_pending_token_number(green_key)
+            .unwrap_or_else(|| self.warm_state.alloc_token_number());
+        let backend = &mut self.backend;
+        match self.warm_state.get_assembler_token(green_key, || {
+            compile::compile_tmp_callback(
+                backend,
+                &target_sd,
+                token_number,
+                green_key,
+                greenboxes,
+                red_arg_types,
+            )
+        }) {
+            Ok(token) => Some(token.number),
+            Err(err) => {
+                if crate::majit_log_enabled() {
+                    eprintln!(
+                        "[jit][walker-ca] compile_tmp_callback failed for key={green_key}: {err:?}"
+                    );
+                }
+                None
+            }
+        }
     }
 
     /// pyjitpl.py:3317-3335 `MetaInterp.vable_and_vrefs_before_residual_call`.

--- a/majit/majit-metainterp/src/pyjitpl/dispatch.rs
+++ b/majit/majit-metainterp/src/pyjitpl/dispatch.rs
@@ -906,11 +906,23 @@ impl Default for StandaloneFrameStack {
     }
 }
 
-#[derive(Clone)]
 struct ActiveStandardVirtualizable {
     vable_opref: OpRef,
     info: std::sync::Arc<crate::virtualizable::VirtualizableInfo>,
-    obj_ptr: *mut u8,
+    obj: Box<i64>,
+    root_depth: usize,
+}
+
+impl ActiveStandardVirtualizable {
+    fn obj_ptr(&self) -> *mut u8 {
+        *self.obj as usize as *mut u8
+    }
+}
+
+impl Drop for ActiveStandardVirtualizable {
+    fn drop(&mut self) {
+        majit_gc::shadow_stack::pop_resume_ref_roots_to(self.root_depth);
+    }
 }
 
 impl<'mi, S, R> JitCodeMachine<'mi, S, R>
@@ -921,7 +933,7 @@ where
     fn active_standard_virtualizable(&self, ctx: &TraceCtx) -> Option<ActiveStandardVirtualizable> {
         let vable_opref = ctx.standard_virtualizable_box()?;
         let info = ctx.virtualizable_info()?.clone();
-        let obj_ptr = self.frames.frames.iter().rev().find_map(|frame| {
+        let obj = self.frames.frames.iter().rev().find_map(|frame| {
             frame
                 .ref_regs
                 .iter()
@@ -930,13 +942,14 @@ where
                     (*slot == Some(vable_opref))
                         .then_some(*concrete)
                         .flatten()
-                        .map(|value| value as usize as *mut u8)
                 })
         })?;
+        let root_depth = majit_gc::shadow_stack::resume_ref_roots_depth();
         Some(ActiveStandardVirtualizable {
             vable_opref,
             info,
-            obj_ptr,
+            obj: Box::new(obj),
+            root_depth,
         })
     }
 
@@ -944,9 +957,12 @@ where
         &mut self,
         ctx: &mut TraceCtx,
     ) -> Option<ActiveStandardVirtualizable> {
-        let active = self.active_standard_virtualizable(ctx)?;
+        let mut active = self.active_standard_virtualizable(ctx)?;
         unsafe {
-            active.info.tracing_before_residual_call(active.obj_ptr);
+            majit_gc::shadow_stack::push_resume_ref_roots(std::slice::from_mut(
+                &mut *active.obj,
+            ));
+            active.info.tracing_before_residual_call(active.obj_ptr());
         }
         let force_token = ctx.force_token();
         ctx.vable_setfield_descr(
@@ -963,7 +979,7 @@ where
         let Some(active) = active else {
             return false;
         };
-        unsafe { active.info.tracing_after_residual_call(active.obj_ptr) }
+        unsafe { active.info.tracing_after_residual_call(active.obj_ptr()) }
     }
 
     fn finalize_standard_virtualizable_may_force(

--- a/majit/majit-metainterp/src/pyjitpl/dispatch.rs
+++ b/majit/majit-metainterp/src/pyjitpl/dispatch.rs
@@ -939,9 +939,7 @@ where
                 .iter()
                 .zip(frame.ref_values.iter())
                 .find_map(|(slot, concrete)| {
-                    (*slot == Some(vable_opref))
-                        .then_some(*concrete)
-                        .flatten()
+                    (*slot == Some(vable_opref)).then_some(*concrete).flatten()
                 })
         })?;
         let root_depth = majit_gc::shadow_stack::resume_ref_roots_depth();
@@ -959,9 +957,7 @@ where
     ) -> Option<ActiveStandardVirtualizable> {
         let mut active = self.active_standard_virtualizable(ctx)?;
         unsafe {
-            majit_gc::shadow_stack::push_resume_ref_roots(std::slice::from_mut(
-                &mut *active.obj,
-            ));
+            majit_gc::shadow_stack::push_resume_ref_roots(std::slice::from_mut(&mut *active.obj));
             active.info.tracing_before_residual_call(active.obj_ptr());
         }
         let force_token = ctx.force_token();

--- a/majit/majit-metainterp/src/resume.rs
+++ b/majit/majit-metainterp/src/resume.rs
@@ -5196,6 +5196,23 @@ pub trait VirtualizableInfo {
     /// resume.py:1407 vinfo.reset_token_gcref(virtualizable)
     fn reset_token_gcref(&self, virtualizable: i64);
 
+    /// pyre: register virtualizable-owned Ref buffers for the resume
+    /// construction window. RPython keeps the virtualizable object and its
+    /// array fields GC-traced while `blackhole_from_resumedata` fills frames.
+    fn push_resume_ref_roots(&self, _virtualizable: i64) {}
+
+    /// pyre: register virtualizable-owned Ref buffers for any virtualizable
+    /// object already present in a blackhole Ref register bank.
+    fn push_resume_ref_roots_for_value(&self, _value: i64) {}
+
+    /// pyre: register virtualizable-owned Ref buffers for any virtualizable
+    /// object already present in a blackhole Ref register bank.
+    fn push_resume_ref_roots_for_registers(&self, registers_r: &[i64]) {
+        for &value in registers_r {
+            self.push_resume_ref_roots_for_value(value);
+        }
+    }
+
     /// resume.py:1408 vinfo.write_from_resume_data_partial(virtualizable, self)
     ///
     /// Read fields from the resume reader and write them into the virtualizable.
@@ -5336,6 +5353,8 @@ pub struct ResumeDataDirectReader<'a> {
     /// Wraps both the ptr and int half so callers go through the RPython
     /// `VirtualCache` API (`get_ptr`/`set_ptr`/`get_int`/`set_int`).
     pub virtuals_cache: VirtualCache,
+
+    virtualizable_root_base_depth: Option<usize>,
 
     /// resume.py:1367 — CPU allocation backend.
     /// RPython uses self.cpu (from metainterp_sd.cpu) for allocate_with_vtable etc.
@@ -6005,6 +6024,7 @@ impl<'a> ResumeDataDirectReader<'a> {
             resume_after_guard_not_forced,
             rd_virtuals: None,
             virtuals_cache,
+            virtualizable_root_base_depth: None,
             allocator,
             all_liveness,
             virtualizable_ptr: 0,
@@ -6512,11 +6532,15 @@ impl<'a> ResumeDataDirectReader<'a> {
     ///     info = blackholeinterp.get_current_position_info()
     ///     self._prepare_next_section(info)
     /// ```
-    pub fn consume_one_section(&mut self, bh: &mut BlackholeInterpreter) {
+    pub fn consume_one_section(
+        &mut self,
+        bh: &mut BlackholeInterpreter,
+        vinfo: Option<&dyn VirtualizableInfo>,
+    ) {
         // resume.py:1383
         let info = bh.get_current_position_info();
         // resume.py:1384
-        self._prepare_next_section(info, bh);
+        self._prepare_next_section(info, bh, vinfo);
     }
 
     /// resume.py:1017-1026 `_prepare_next_section(self, info)`.
@@ -6538,7 +6562,12 @@ impl<'a> ResumeDataDirectReader<'a> {
     /// `next_float` on this reader (resume.py:1028-1038), matching
     /// `_callback_i/_callback_r/_callback_f` plus `write_an_int/write_a_ref/
     /// write_a_float` (resume.py:1590-1597).
-    fn _prepare_next_section(&mut self, info: usize, bh: &mut BlackholeInterpreter) {
+    fn _prepare_next_section(
+        &mut self,
+        info: usize,
+        bh: &mut BlackholeInterpreter,
+        vinfo: Option<&dyn VirtualizableInfo>,
+    ) {
         use majit_translate::liveness::LivenessIterator;
 
         let all_liveness: &[u8] = self.all_liveness;
@@ -6581,6 +6610,9 @@ impl<'a> ResumeDataDirectReader<'a> {
                 }
                 // resume.py:1593-1594 `write_a_ref`.
                 bh.setarg_r(reg_idx as usize, value);
+                if let Some(vinfo) = vinfo {
+                    vinfo.push_resume_ref_roots_for_value(value);
+                }
             }
             offset = it.offset;
         }
@@ -6752,6 +6784,11 @@ impl<'a> ResumeDataDirectReader<'a> {
             self.virtualizable_identity_override = None;
         }
         self.virtualizable_ptr = virtualizable;
+        if self.virtualizable_root_base_depth.is_none() {
+            self.virtualizable_root_base_depth =
+                Some(majit_gc::shadow_stack::resume_ref_roots_depth());
+        }
+        vinfo.push_resume_ref_roots(virtualizable);
         // resume.py:1406: assert vinfo.get_total_size(virtualizable) == vable_size - 1
         let expected = vinfo.get_total_size(virtualizable) as i32;
         assert!(
@@ -7011,6 +7048,14 @@ impl<'a> ResumeDataDirectReader<'a> {
     /// resume.py:1599 int_add_const
     pub fn int_add_const(&self, base: i64, offset: i64) -> i64 {
         base + offset
+    }
+}
+
+impl Drop for ResumeDataDirectReader<'_> {
+    fn drop(&mut self) {
+        if let Some(depth) = self.virtualizable_root_base_depth {
+            majit_gc::shadow_stack::pop_resume_ref_roots_to(depth);
+        }
     }
 }
 
@@ -7300,7 +7345,7 @@ pub fn blackhole_from_resumedata<'a>(
         }
 
         // resume.py:1341
-        resumereader.consume_one_section(&mut nextbh);
+        resumereader.consume_one_section(&mut nextbh, vinfo);
 
         // resume.py:1342
         nextbh.handle_rvmprof_enter();

--- a/majit/majit-metainterp/src/virtualizable.rs
+++ b/majit/majit-metainterp/src/virtualizable.rs
@@ -95,6 +95,8 @@ pub struct VableArrayInfo {
     pub item_size: usize,
     /// Byte offset of the array pointer in the heap object.
     pub field_offset: usize,
+    /// GC type id of the array object stored in a `DirectPointer` field.
+    pub array_type_id: u32,
     /// Storage model for the array field.
     pub storage: VableArrayStorage,
     /// Offset of the length field within the array object.
@@ -483,6 +485,42 @@ impl VirtualizableInfo {
         self.clear_vable_descr = Some(clear_descr);
     }
 
+    /// Register virtualizable array pointer fields for old virtualizable
+    /// objects currently held in a blackhole ref register bank.  The type-id
+    /// check keeps this targeted to the `VTYPEPTR` described by this vinfo,
+    /// rather than treating every Ref register as if it had the virtualizable
+    /// layout.
+    pub fn push_resume_ref_roots_for_registers(&self, registers_r: &[i64]) {
+        for &value in registers_r {
+            self.push_resume_ref_roots_for_value(value);
+        }
+    }
+
+    /// Register virtualizable array pointer fields for one old virtualizable
+    /// object. Nursery virtualizable objects are already traced through the
+    /// rooted Ref slot that points at the object; old virtualizables need their
+    /// young array fields exposed explicitly.
+    pub fn push_resume_ref_roots_for_value(&self, value: i64) {
+        let Some(parent) = &self.parent_descr else {
+            return;
+        };
+        let Some(size_descr) = parent.as_size_descr() else {
+            return;
+        };
+        let vtype_id = size_descr.type_id();
+        if value == 0 {
+            return;
+        }
+        let ptr = value as usize;
+        if !majit_gc::gc_owns_object(ptr) || majit_gc::gc_is_nursery_object(ptr) {
+            return;
+        }
+        let type_id = unsafe { (*majit_gc::header::header_of(ptr)).type_id() };
+        if type_id == vtype_id {
+            crate::resume::VirtualizableInfo::push_resume_ref_roots(self, value);
+        }
+    }
+
     /// virtualizable.py:300-301 `clear_vable_descr` factory. Creates
     /// the CallDescr for the `COND_CALL` that invokes `clear_vable_ptr`.
     ///
@@ -536,11 +574,16 @@ impl VirtualizableInfo {
         array_descr: DescrRef,
     ) {
         let item_size = array_descr_item_size(&array_descr, item_type);
+        let array_type_id = array_descr
+            .as_array_descr()
+            .map(|descr| descr.type_id())
+            .unwrap_or(0);
         self.array_fields.push(VableArrayInfo {
             name: name.into(),
             item_type,
             item_size,
             field_offset,
+            array_type_id,
             storage: VableArrayStorage::DirectPointer,
             length_offset,
             items_offset,
@@ -565,11 +608,16 @@ impl VirtualizableInfo {
         array_descr: DescrRef,
     ) {
         let item_size = array_descr_item_size(&array_descr, item_type);
+        let array_type_id = array_descr
+            .as_array_descr()
+            .map(|descr| descr.type_id())
+            .unwrap_or(0);
         self.array_fields.push(VableArrayInfo {
             name: name.into(),
             item_type,
             item_size,
             field_offset,
+            array_type_id,
             storage: VableArrayStorage::EmbeddedArray { ptr_offset },
             length_offset,
             items_offset,
@@ -593,11 +641,16 @@ impl VirtualizableInfo {
         array_descr: DescrRef,
     ) {
         let item_size = array_descr_item_size(&array_descr, item_type);
+        let array_type_id = array_descr
+            .as_array_descr()
+            .map(|descr| descr.type_id())
+            .unwrap_or(0);
         self.array_fields.push(VableArrayInfo {
             name: name.into(),
             item_type,
             item_size,
             field_offset,
+            array_type_id,
             storage: VableArrayStorage::RustVec {
                 data_ptr_fn,
                 len_fn,
@@ -2631,6 +2684,56 @@ impl crate::resume::VirtualizableInfo for VirtualizableInfo {
         if !vable_ptr.is_null() {
             unsafe { self.reset_vable_token(vable_ptr) };
         }
+    }
+
+    /// RPython keeps virtualizable array fields reachable through the
+    /// GC-traced virtualizable object while resume data is decoded
+    /// (`rpython/jit/metainterp/resume.py:1399`). pyre stores the same
+    /// array pointers in raw frame fields, so expose the pointer slots to
+    /// the resume-construction root stack before `write_from_resume_data_partial`
+    /// and subsequent blackhole frame construction can allocate.
+    fn push_resume_ref_roots(&self, virtualizable: i64) {
+        let vable_ptr = virtualizable as *mut u8;
+        if vable_ptr.is_null() {
+            return;
+        }
+        for array in &self.array_fields {
+            match array.storage {
+                VableArrayStorage::DirectPointer => {
+                    let slot = unsafe { vable_ptr.add(array.field_offset) as *mut i64 };
+                    let value = unsafe { *slot } as usize;
+                    if value != 0 && majit_gc::gc_owns_object(value) {
+                        let current = majit_gc::gc_current_object_address(value);
+                        if current != value {
+                            unsafe {
+                                *slot = current as i64;
+                            }
+                        }
+                        if array.array_type_id != 0 && majit_gc::gc_is_nursery_object(current) {
+                            let type_id =
+                                unsafe { (*majit_gc::header::header_of(current)).type_id() };
+                            if type_id != array.array_type_id {
+                                continue;
+                            }
+                        }
+                    }
+                    unsafe {
+                        majit_gc::shadow_stack::push_resume_ref_roots(
+                            std::slice::from_raw_parts_mut(slot, 1),
+                        );
+                    }
+                }
+                VableArrayStorage::EmbeddedArray { .. } | VableArrayStorage::RustVec { .. } => {}
+            }
+        }
+    }
+
+    fn push_resume_ref_roots_for_value(&self, value: i64) {
+        VirtualizableInfo::push_resume_ref_roots_for_value(self, value);
+    }
+
+    fn push_resume_ref_roots_for_registers(&self, registers_r: &[i64]) {
+        VirtualizableInfo::push_resume_ref_roots_for_registers(self, registers_r);
     }
 
     /// virtualizable.py:126-137 write_from_resume_data_partial

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -8239,15 +8239,13 @@ pub(crate) fn fbw_rec_multiframe_enabled() -> bool {
 /// gate of the same name (eval.rs); default OFF while the migration lands.
 pub(crate) fn fbw_rec_mutual_cutover_enabled() -> bool {
     static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
-    *ENABLED.get_or_init(
-        || match std::env::var_os("PYRE_FBW_REC_MUTUAL_CUTOVER") {
-            Some(v) => {
-                let v = v.to_string_lossy();
-                v != "0" && !v.eq_ignore_ascii_case("false")
-            }
-            None => false,
-        },
-    )
+    *ENABLED.get_or_init(|| match std::env::var_os("PYRE_FBW_REC_MUTUAL_CUTOVER") {
+        Some(v) => {
+            let v = v.to_string_lossy();
+            v != "0" && !v.eq_ignore_ascii_case("false")
+        }
+        None => false,
+    })
 }
 
 /// `PYRE_FBW_LOOP_CALLEE_CA` (gap-10, general loop-bearing-callee →

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -8215,6 +8215,26 @@ pub(crate) fn fbw_rec_multiframe_enabled() -> bool {
     })
 }
 
+/// Full-portal recursive-call cutover (`PYRE_FBW_REC_MUTUAL_CUTOVER`): at the
+/// inline-unroll cap, route a recursive callee (self OR mutual) through
+/// `get_assembler_token` → `compile_tmp_callback` (warmstate.py:714-723,
+/// compile.py:1101-1150) so a not-yet-compiled callee still enters via a real
+/// CALL_ASSEMBLER tmp-callback token instead of poisoning the trace with
+/// `LoopBearingCalleeInlineUnsupported`.  Mirrors the `build_jit_driver_pair`
+/// gate of the same name (eval.rs); default OFF while the migration lands.
+pub(crate) fn fbw_rec_mutual_cutover_enabled() -> bool {
+    static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ENABLED.get_or_init(
+        || match std::env::var_os("PYRE_FBW_REC_MUTUAL_CUTOVER") {
+            Some(v) => {
+                let v = v.to_string_lossy();
+                v != "0" && !v.eq_ignore_ascii_case("false")
+            }
+            None => false,
+        },
+    )
+}
+
 /// `PYRE_FBW_LOOP_CALLEE_CA` (gap-10, general loop-bearing-callee →
 /// CALL_ASSEMBLER): when a multi-frame inlined callee sub-walk reaches the
 /// callee's own `jit_merge_point` and a compiled loop token already exists
@@ -14470,8 +14490,26 @@ fn try_walker_call_assembler_self_recursive(
     let caller_code = unsafe {
         pyre_interpreter::live_code_wrapper((*sym.jitcode).raw_code() as *const ()) as *const ()
     };
+    // Self-fold requires callee code == portal code.  The full-portal cutover
+    // (`PYRE_FBW_REC_MUTUAL_CUTOVER`) additionally admits a *mutual*-recursive
+    // callee — one whose code is already on the inline framestack, i.e. a
+    // genuine recursion cycle (`is_even` → `is_odd` → `is_even` at the unroll
+    // cap).  It must NOT admit an arbitrary foreign call: folding a
+    // non-recursive callee (e.g. a CALL_KW-bearing leaf) to CALL_ASSEMBLER
+    // builds and enters a frame the callee's own loop was never traced against
+    // and faults.  The emit below keys on `w_code` (callee-agnostic); the token
+    // is resolved / synthesised per `callee_key` via `get_assembler_token`.
     if w_code as usize != caller_code as usize {
-        return Ok(None);
+        let admit_mutual = fbw_rec_mutual_cutover_enabled()
+            && ctx
+                .session
+                .borrow()
+                .framestack
+                .iter()
+                .any(|f| f.w_code == w_code as usize);
+        if !admit_mutual {
+            return Ok(None);
+        }
     }
     // A foreign (non self-recursive) non-pure residual already executed
     // concretely earlier in this walk (e.g. `events.append(n)` ahead of the
@@ -14509,16 +14547,61 @@ fn try_walker_call_assembler_self_recursive(
     // pending token `fib` hits before its loop finishes compiling
     // (`trace_opcode.rs:6035-6036`).  A key miss returns `None` here =
     // safe bail to residual.
+    //
+    // The self-recursion token is the callee's OWN reserved pending number,
+    // used directly — NOT re-synthesised through `compile_tmp_callback`.  Under
+    // pyre's number-keyed backend `_ll_function_addr` registry a
+    // `compile_tmp_callback` at the pending number and the later real-loop
+    // install collide on that same number, leaving a stale/garbage address the
+    // CALL_ASSEMBLER jumps to (SIGSEGV).  Converging the self path onto
+    // `get_assembler_token` (as `direct_assembler_call` already is) is blocked
+    // on the descr-identity cutover (Task #211) that re-roots address
+    // resolution on the descr-carried `Arc<JitCellToken>`; until it lands the
+    // reserved pending number resolved through `register_pending_target` +
+    // CA_FORCE_FN is the pyre-orthodox self-recursion path.
     let (driver, _) = crate::driver::driver_pair();
     let callee_key = crate::driver::make_green_key(w_code, 0);
-    let Some(token_number) = driver
+    // `get_loop_token_number` first (compiled loop), else the pending token the
+    // callee hits before its loop finishes compiling.  These take `&self`, so
+    // resolve to an owned `Option<u64>` before the `&mut` synth borrow below.
+    let existing = driver
         .get_loop_token_number(callee_key)
-        .or_else(|| driver.get_pending_token_number(callee_key))
-    else {
-        if std::env::var_os("PYRE_P2_DIAG").is_some() {
-            eprintln!("[p2-ca] decline pc={} reason=no-token", op.pc);
+        .or_else(|| driver.get_pending_token_number(callee_key));
+    let token_number = match existing {
+        Some(n) => n,
+        // Full-portal cutover: no token yet (typically the mutual callee, whose
+        // pending slot the current self-key trace never filled).  Synthesise a
+        // tmp-callback token via `get_assembler_token` → `compile_tmp_callback`
+        // (warmstate.py:714-723, compile.py:1101-1150).  greenboxes carry the
+        // portal greens in `build_portal_calldescr` order
+        // (`[next_instr, is_being_profiled, pycode]`); reds are `[frame, ec]`.
+        None if fbw_rec_mutual_cutover_enabled() => {
+            let greenboxes = [
+                majit_ir::Value::Int(0),
+                majit_ir::Value::Int(0),
+                majit_ir::Value::Ref(majit_ir::GcRef(w_code as usize)),
+            ];
+            let red_types = [Type::Ref, Type::Ref];
+            match driver
+                .meta_interp_mut()
+                .get_or_make_portal_assembler_token_number(callee_key, &greenboxes, &red_types)
+            {
+                Some(n) => n,
+                None => {
+                    if std::env::var_os("PYRE_P2_DIAG").is_some() {
+                        eprintln!("[p2-ca] decline pc={} reason=synth-failed", op.pc);
+                    }
+                    return Ok(None);
+                }
+            }
         }
-        return Ok(None);
+        // A key miss without cutover is a safe bail to the residual path.
+        None => {
+            if std::env::var_os("PYRE_P2_DIAG").is_some() {
+                eprintln!("[p2-ca] decline pc={} reason=no-token", op.pc);
+            }
+            return Ok(None);
+        }
     };
     if std::env::var_os("PYRE_P2_DIAG").is_some() {
         eprintln!("[p2-ca] EMIT pc={} token={token_number}", op.pc);
@@ -15171,6 +15254,13 @@ fn try_walker_inline_user_call(
         // cache; making an uninlineable method body blacklist the whole outer
         // loop turns a correct specialization into a compile regression.
         if method_form {
+            return Ok(None);
+        }
+        // Full-portal cutover: instead of poisoning the trace, fall through to
+        // the CALL_ASSEMBLER fold (`try_walker_call_assembler_self_recursive`,
+        // reached next in the residual-call dispatch) so a recursive callee at
+        // the inline cap enters via its own (possibly tmp-callback) loop token.
+        if fbw_rec_mutual_cutover_enabled() {
             return Ok(None);
         }
         return Err(DispatchError::LoopBearingCalleeInlineUnsupported { pc: op.pc });

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -6668,12 +6668,12 @@ fn try_execute_residual_call_via_executor(
     // virtualizable, or unit-test init disabled the heap pointer) — nothing
     // the callee could force.  The token is armed further below, past every
     // decline gate.
-    let vable_obj_ptr = if is_may_force {
+    let mut vable_obj_root = if is_may_force {
         ctx.trace_ctx
             .standard_virtualizable_box()
             .and_then(|_| ctx.trace_ctx.virtualizable_heap_ptr())
             .filter(|p| !p.is_null())
-            .map(|p| p as *mut u8)
+            .map(|p| Box::new(p as usize as i64))
     } else {
         None
     };
@@ -6776,10 +6776,17 @@ fn try_execute_residual_call_via_executor(
     // `vable_and_vrefs_before_residual_call` (pyjitpl.py:2017) runs only past
     // the OS_NOT_IN_TRACE / force-virtual short-circuits.  Trait mirror:
     // `MIFrame::vable_and_vrefs_before_residual_call` (trace_opcode.rs:2602).
-    if let Some(obj_ptr) = vable_obj_ptr {
+    let vable_root_depth = if let Some(obj) = vable_obj_root.as_mut() {
         let info = crate::frame_layout::build_pyframe_virtualizable_info();
-        unsafe { info.tracing_before_residual_call(obj_ptr) };
-    }
+        let root_depth = majit_gc::shadow_stack::resume_ref_roots_depth();
+        unsafe {
+            majit_gc::shadow_stack::push_resume_ref_roots(std::slice::from_mut(&mut **obj));
+            info.tracing_before_residual_call(**obj as usize as *mut u8);
+        }
+        Some(root_depth)
+    } else {
+        None
+    };
     let body_effect_candidate =
         !provably_side_effect_free && writes_live_heap && fbw_foriter_inflight_active();
     // #57 Option C (Finding #1, user-frame signal): the Void/helper-tag write
@@ -6839,8 +6846,13 @@ fn try_execute_residual_call_via_executor(
             fbw_mark_executed_body_residual();
         }
     }
+    let restored_vable_heap_ptr = vable_obj_root
+        .as_ref()
+        .map(|obj| **obj as usize as *const u8)
+        .or(saved_vable_heap_ptr)
+        .unwrap_or(std::ptr::null());
     ctx.trace_ctx
-        .set_virtualizable_heap_ptr(saved_vable_heap_ptr.unwrap_or(std::ptr::null()));
+        .set_virtualizable_heap_ptr(restored_vable_heap_ptr);
     // pyjitpl.py:3349-3353 `vinfo.tracing_after_residual_call(virtualizable)`
     // heap half: a cleared token means the callee forced the virtualizable —
     // the frame escaped, the trace must abort (pyjitpl.py:3365
@@ -6851,9 +6863,12 @@ fn try_execute_residual_call_via_executor(
     // `load_fields_from_virtualizable` analogue is needed because the FBW
     // abort discards the walk shadow instead of handing it to a blackhole
     // leg.  An intact token is cleared back to TOKEN_NONE.
-    if let Some(obj_ptr) = vable_obj_ptr {
+    if let Some(obj) = vable_obj_root.as_ref() {
         let info = crate::frame_layout::build_pyframe_virtualizable_info();
-        let forced = unsafe { info.tracing_after_residual_call(obj_ptr) };
+        let forced = unsafe { info.tracing_after_residual_call(**obj as usize as *mut u8) };
+        if let Some(depth) = vable_root_depth {
+            majit_gc::shadow_stack::pop_resume_ref_roots_to(depth);
+        }
         if forced {
             return Err(DispatchError::VableEscapedDuringResidualCall { pc: op_pc });
         }

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -2233,6 +2233,11 @@ pub struct PyreSym {
     /// Virtualizable object pointer (PyFrame).
     /// RPython MetaInterp stores the virtualizable separately from MIFrame.
     pub(crate) concrete_vable_ptr: *mut u8,
+    /// Root depth for `concrete_vable_ptr` while a residual call can collect.
+    /// RPython's local `virtualizable` remains a traced GCREF across
+    /// `vable_and_vrefs_before_residual_call` / `vable_after_residual_call`
+    /// (`rpython/jit/metainterp/pyjitpl.py:3317-3366`).
+    pub(crate) active_vable_root_depth: Option<usize>,
     /// Live (interpreter-owned) virtualizable `PyFrame` behind the tracing
     /// snapshot, or 0 when tracing runs without one (tests).
     /// `concrete_vable_ptr` points at the `snapshot_for_tracing` copy whose
@@ -4385,6 +4390,7 @@ impl PyreSym {
             is_function_entry_trace: false,
             concrete_execution_context: std::ptr::null(),
             concrete_vable_ptr: std::ptr::null_mut(),
+            active_vable_root_depth: None,
             live_vable_frame_addr: 0,
             last_exc_value: std::ptr::null_mut(),
             class_of_last_exc_is_const: false,

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -4969,8 +4969,13 @@ pub(crate) fn opimpl_virtual_ref_finish(ctx: &mut TraceCtx, sym: &mut PyreSym, v
 
 impl PyreJitState {
     /// Canonical PyPy portal driver layout from `interp_jit.py:67-74`.
-    #[cfg_attr(not(test), allow(dead_code))]
-    fn pypyjit_driver_descriptor() -> JitDriverStaticData {
+    ///
+    /// Single source of truth for the portal greens/reds/virtualizable shape:
+    /// used both trace-locally (`driver_descriptor` for merge-point payload
+    /// validation) and by the production driver registration in
+    /// `build_jit_driver_pair`, so the `portal_calldescr` ABI stays consistent
+    /// with the descriptor the walker validates against.
+    pub fn pypyjit_driver_descriptor() -> JitDriverStaticData {
         let mut descriptor = JitDriverStaticData::with_virtualizable(
             vec![
                 ("next_instr", Type::Int),

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -2741,7 +2741,14 @@ impl MIFrame {
         //   vinfo.tracing_before_residual_call(virtualizable)
         let info = crate::frame_layout::build_pyframe_virtualizable_info();
         unsafe {
-            info.tracing_before_residual_call(obj_ptr);
+            let sym = self.sym_mut();
+            debug_assert!(sym.active_vable_root_depth.is_none());
+            sym.active_vable_root_depth = Some(majit_gc::shadow_stack::resume_ref_roots_depth());
+            majit_gc::shadow_stack::push_resume_ref_roots(std::slice::from_raw_parts_mut(
+                &mut sym.concrete_vable_ptr as *mut *mut u8 as *mut i64,
+                1,
+            ));
+            info.tracing_before_residual_call(sym.concrete_vable_ptr);
         }
         // pyjitpl.py:3332-3335:
         //   force_token = self.history.record0(rop.FORCE_TOKEN,
@@ -2769,11 +2776,18 @@ impl MIFrame {
             return Ok(());
         }
         let obj_ptr = self.sym().concrete_vable_ptr;
+        let root_depth = self.sym_mut().active_vable_root_depth.take();
         if obj_ptr.is_null() {
+            if let Some(depth) = root_depth {
+                majit_gc::shadow_stack::pop_resume_ref_roots_to(depth);
+            }
             return Ok(());
         }
         let info = crate::frame_layout::build_pyframe_virtualizable_info();
         let vable_forced = unsafe { info.tracing_after_residual_call(obj_ptr) };
+        if let Some(depth) = root_depth {
+            majit_gc::shadow_stack::pop_resume_ref_roots_to(depth);
+        }
         if vable_forced {
             // pyjitpl.py:3356: self.load_fields_from_virtualizable()
             self.load_fields_from_virtualizable();

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -76,8 +76,37 @@ thread_local! {
     /// re-running the resumed region over already-applied effects.
     static CA_WALK_FINISHED_FRAME: std::cell::Cell<usize> =
         const { std::cell::Cell::new(0) };
+    static CA_WALK_RESUME_FRAME: std::cell::Cell<usize> =
+        const { std::cell::Cell::new(0) };
+    static CA_WALK_RESUME_DEADFRAME: std::cell::RefCell<Option<Vec<i64>>> =
+        const { std::cell::RefCell::new(None) };
     static SELF_RECURSIVE_DISPATCH_CACHE: UnsafeCell<Option<(u64, Option<u64>)>> =
         const { UnsafeCell::new(None) };
+}
+
+struct FrameRoot {
+    depth: usize,
+}
+
+impl FrameRoot {
+    fn new(frame: &mut PyFrame) -> Self {
+        Self {
+            depth: majit_gc::shadow_stack::push(majit_ir::GcRef(
+                frame as *mut PyFrame as usize,
+            )),
+        }
+    }
+
+    fn frame(&mut self) -> &mut PyFrame {
+        let frame = majit_gc::shadow_stack::get(self.depth).0 as *mut PyFrame;
+        unsafe { &mut *frame }
+    }
+}
+
+impl Drop for FrameRoot {
+    fn drop(&mut self) {
+        majit_gc::shadow_stack::try_pop_to(self.depth);
+    }
 }
 
 /// Take stashed exception from blackhole/force FFI paths.
@@ -1415,6 +1444,8 @@ fn jit_blackhole_resume_from_guard(
 ) -> Option<i64> {
     let ca_adopted_frame = CA_WALK_ADOPTED_FRAME.with(|c| c.replace(0));
     let ca_finished_frame = CA_WALK_FINISHED_FRAME.with(|c| c.replace(0));
+    let ca_resume_frame = CA_WALK_RESUME_FRAME.with(|c| c.replace(0));
+    let ca_resume_deadframe = CA_WALK_RESUME_DEADFRAME.with(|c| c.borrow_mut().take());
 
     // rstack.stack_check_slowpath → _StackOverflow parity: drain the
     // pending JIT-prologue overflow exception when the backend probe
@@ -1436,7 +1467,17 @@ fn jit_blackhole_resume_from_guard(
         pyre_jit_trace::jitcode_dispatch::fbw_finish_concrete_reset();
         return None;
     }
-    let fail_values = unsafe { std::slice::from_raw_parts(fail_values_ptr, num_fail_values) };
+    let fail_values_raw = unsafe { std::slice::from_raw_parts(fail_values_ptr, num_fail_values) };
+    let mut fail_values_owned;
+    let fail_values = if let Some(values) = ca_resume_deadframe.as_deref() {
+        values
+    } else if ca_resume_frame != 0 {
+        fail_values_owned = fail_values_raw.to_vec();
+        fail_values_owned[0] = ca_resume_frame as i64;
+        fail_values_owned.as_slice()
+    } else {
+        fail_values_raw
+    };
 
     // The CA bridge walk ran the callee to its finishframe concretely and
     // kept the finish-concrete stash (`CA_WALK_FINISHED_FRAME` handshake set
@@ -1498,10 +1539,20 @@ fn jit_blackhole_resume_from_guard(
         };
     }
 
-    let raw_deadframe = if !raw_deadframe_ptr.is_null() && num_raw_deadframe > 0 {
+    let raw_deadframe_raw = if let Some(values) = ca_resume_deadframe.as_deref() {
+        values
+    } else if !raw_deadframe_ptr.is_null() && num_raw_deadframe > 0 {
         unsafe { std::slice::from_raw_parts(raw_deadframe_ptr, num_raw_deadframe) }
     } else {
         fail_values
+    };
+    let mut raw_deadframe_owned;
+    let raw_deadframe = if ca_resume_frame != 0 && !raw_deadframe_raw.is_empty() {
+        raw_deadframe_owned = raw_deadframe_raw.to_vec();
+        raw_deadframe_owned[0] = ca_resume_frame as i64;
+        raw_deadframe_owned.as_slice()
+    } else {
+        raw_deadframe_raw
     };
 
     // compile.py:710-716 `resume_in_blackhole(descr, deadframe)` parity:
@@ -1680,6 +1731,29 @@ struct ResumeDeadframeRoots {
 }
 
 impl ResumeDeadframeRoots {
+    fn register_pyframe_locals_slot(value: i64, slots: &mut Vec<*mut *mut u8>) {
+        let ptr = value as *mut u8;
+        if ptr.is_null()
+            || !pyre_object::gc_hook::try_gc_owns_object(ptr)
+            || majit_gc::gc_is_nursery_object(ptr as usize)
+        {
+            return;
+        }
+        let current = pyre_object::gc_hook::try_gc_current_object_address(ptr);
+        if current.is_null() || !pyre_object::gc_hook::try_gc_owns_object(current) {
+            return;
+        }
+        let type_id = unsafe { (*majit_gc::header::header_of(current as usize)).type_id() };
+        if type_id != pyre_interpreter::pyframe::PYFRAME_GC_TYPE_ID {
+            return;
+        }
+        let frame = current as *mut PyFrame;
+        let slot = unsafe { std::ptr::addr_of_mut!((*frame).locals_cells_stack_w) as *mut *mut u8 };
+        if unsafe { pyre_object::gc_hook::try_gc_add_root(slot) } {
+            slots.push(slot);
+        }
+    }
+
     fn register(deadframe: &mut [i64], deadframe_types: Option<&[majit_ir::Type]>) -> Self {
         let mut slots = Vec::new();
         if let Some(types) = deadframe_types {
@@ -1698,6 +1772,7 @@ impl ResumeDeadframeRoots {
                 if unsafe { pyre_object::gc_hook::try_gc_add_root(slot) } {
                     slots.push(slot);
                 }
+                Self::register_pyframe_locals_slot(*cell, &mut slots);
             }
         }
         Self { slots }
@@ -2651,6 +2726,13 @@ pub fn trace_and_compile_from_bridge(
         return BridgeResolution::ResumeBlackhole;
     }
 
+    // The live frame is a virtualizable GC object held by raw bridge-trace
+    // locals while retracing can collect. RPython keeps the virtualizable
+    // object GC-visible during retracing
+    // (`rpython/jit/metainterp/pyjitpl.py:2839-2841`); pyre roots the frame
+    // word so PyFrame's custom trace can forward `locals_cells_stack_w`.
+    let mut bridge_frame_root = FrameRoot::new(frame);
+
     // pyjitpl.py:2841 interpret(): after start_retrace_from_guard, RPython
     // runs a single interpret() over the resumed frame state until the
     // bridge closes or aborts. `trace_bytecode` is the pyre equivalent of
@@ -2714,10 +2796,12 @@ pub fn trace_and_compile_from_bridge(
                 // re-apply every side effect.  Uncommitted → fall through
                 // to the guard-state restore below (legacy replay).
                 if pyre_jit_trace::trace::take_walk_end_flush_committed() {
+                    let frame = bridge_frame_root.frame();
                     frame.restore_resume_state_from(&executed);
                     adopted_walk_end_state = true;
                     if !allow_finish_direct_return {
-                        CA_WALK_ADOPTED_FRAME.with(|c| c.set(live_frame_addr));
+                        let adopted_frame = frame as *mut PyFrame as usize;
+                        CA_WALK_ADOPTED_FRAME.with(|c| c.set(adopted_frame));
                     }
                 }
                 action
@@ -2757,7 +2841,8 @@ pub fn trace_and_compile_from_bridge(
                 "bridge Terminate no-replay stash kept for a multiframe resume \
                  (frames={num_resume_frames})"
             );
-            CA_WALK_FINISHED_FRAME.with(|c| c.set(live_frame_addr));
+            let finished_frame = bridge_frame_root.frame() as *mut PyFrame as usize;
+            CA_WALK_FINISHED_FRAME.with(|c| c.set(finished_frame));
             if majit_metainterp::majit_log_enabled() {
                 eprintln!(
                     "[jit][bridge-trace] ca-finish-noreplay at resume_pc={} key={}",
@@ -2799,6 +2884,7 @@ pub fn trace_and_compile_from_bridge(
         None => {}
     }
     if !adopted_walk_end_state {
+        let frame = bridge_frame_root.frame();
         frame.restore_resume_state_from(&resume_state);
     }
     // A multi-frame (inlined-callee) guard restored on the non-flush path
@@ -2834,6 +2920,10 @@ pub fn trace_and_compile_from_bridge(
                 resume_pc, green_key, resume_via_blackhole
             );
         }
+        if !allow_finish_direct_return && resume_via_blackhole {
+            let resume_frame = bridge_frame_root.frame() as *mut PyFrame as usize;
+            CA_WALK_RESUME_FRAME.with(|c| c.set(resume_frame));
+        }
         return bridge_resolution_from_bool(!resume_via_blackhole);
     }
 
@@ -2858,6 +2948,10 @@ pub fn trace_and_compile_from_bridge(
                 "[jit][bridge-trace] compiled at resume_pc={} key={} (attached) blackhole_current={}",
                 resume_pc, green_key, resume_via_blackhole
             );
+        }
+        if !allow_finish_direct_return && resume_via_blackhole {
+            let resume_frame = bridge_frame_root.frame() as *mut PyFrame as usize;
+            CA_WALK_RESUME_FRAME.with(|c| c.set(resume_frame));
         }
         return bridge_resolution_from_bool(!resume_via_blackhole);
     }
@@ -2886,7 +2980,12 @@ pub fn trace_and_compile_from_bridge(
                 resume_pc, green_key, compiled, adopted_walk_end_state
             );
         }
-        return bridge_resolution_from_bool(compiled || adopted_walk_end_state);
+        let continue_compiled = compiled || adopted_walk_end_state;
+        if !allow_finish_direct_return && !continue_compiled {
+            let resume_frame = bridge_frame_root.frame() as *mut PyFrame as usize;
+            CA_WALK_RESUME_FRAME.with(|c| c.set(resume_frame));
+        }
+        return bridge_resolution_from_bool(continue_compiled);
     }
 
     // Trace did not converge into a bridge. Abort like RPython's
@@ -2903,6 +3002,10 @@ pub fn trace_and_compile_from_bridge(
     }
     // A committed walk has already executed the region into the live
     // frame; the blackhole replay must not run even on this abort path.
+    if !allow_finish_direct_return && !adopted_walk_end_state {
+        let resume_frame = bridge_frame_root.frame() as *mut PyFrame as usize;
+        CA_WALK_RESUME_FRAME.with(|c| c.set(resume_frame));
+    }
     bridge_resolution_from_bool(adopted_walk_end_state)
 }
 
@@ -2942,7 +3045,8 @@ fn jit_ca_handle_guard_failure(
             return false;
         }
     }
-    let raw_values = unsafe { std::slice::from_raw_parts(raw_values_ptr, num_values) };
+    let raw_values_input = unsafe { std::slice::from_raw_parts(raw_values_ptr, num_values) };
+    let mut raw_values_vec = raw_values_input.to_vec();
 
     // compile.py:706-708 _trace_and_compile_from_bridge.  Native CA code
     // crosses the backend boundary with only the raw descr pointer; recover
@@ -2967,6 +3071,13 @@ fn jit_ca_handle_guard_failure(
     else {
         return false;
     };
+    let deadframe_types = {
+        let (driver, _) = crate::eval::driver_pair();
+        driver.get_recovery_slot_types(source_green_key, source_trace_id, source_fail_index)
+    };
+    let _raw_values_roots =
+        ResumeDeadframeRoots::register(&mut raw_values_vec, deadframe_types.as_deref());
+    let raw_values = raw_values_vec.as_slice();
 
     // This callback has no channel for the exception value carried by a
     // failing CALL_ASSEMBLER exception guard.  Compiling from its post-call
@@ -3056,6 +3167,13 @@ fn jit_ca_handle_guard_failure(
             "[jit][ca-bridge] compiled={} key={} trace={} fail={}",
             compiled, source_green_key, source_trace_id, source_fail_index,
         );
+    }
+
+    drop(_raw_values_roots);
+    if !compiled {
+        CA_WALK_RESUME_DEADFRAME.with(|c| {
+            *c.borrow_mut() = Some(raw_values_vec);
+        });
     }
 
     compiled

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -612,13 +612,20 @@ pub extern "C" fn jit_force_callee_frame(frame_ptr: i64) -> i64 {
     if let Some(raw_local0) = pending {
         return jit_force_self_recursive_call_raw_1(frame_ptr, raw_local0);
     }
-    // Nursery-safe force: read code/namespace/exec_ctx via raw offsets
-    // (valid for both arena PyFrame AND nursery-allocated raw blocks).
-    // Then create a proper PyFrame for the interpreter.
-    //
-    // warmspot.py:1021 assembler_call_helper parity: the callee frame
-    // (deadframe) may be a nursery-allocated JitFrame-like block. We
-    // reconstruct a proper interpreter frame from its raw fields.
+    portal_runner_from_raw_frame_ptr(frame_ptr)
+}
+
+/// warmspot.py:941-959 `ll_portal_runner` core — reconstruct a proper
+/// interpreter frame from a raw JitFrame-like block pointer and run it
+/// through the portal.
+///
+/// Nursery-safe force: read code/namespace/exec_ctx via raw offsets (valid
+/// for both arena `PyFrame` AND nursery-allocated raw blocks), build a proper
+/// `PyFrame`, then hand it to `portal_runner` (`maybe_compile_and_run` +
+/// interpreter main loop; ContinueRunningNormally re-enters the JIT via the
+/// portal, warmspot.py:961-983). The callee frame may be a nursery-allocated
+/// JitFrame-like block, so the fields are recovered from raw offsets.
+fn portal_runner_from_raw_frame_ptr(frame_ptr: i64) -> i64 {
     let (code, w_globals, exec_ctx) = unsafe {
         use pyre_interpreter::pyframe::*;
         let p = frame_ptr as *const u8;
@@ -631,16 +638,41 @@ pub extern "C" fn jit_force_callee_frame(frame_ptr: i64) -> i64 {
     let mut func_frame = PyFrame::new_for_call_with_globals_obj(code, &[], w_globals, exec_ctx);
     func_frame.fix_array_ptrs();
 
-    // warmspot.py:1021-1028 assembler_call_helper:
-    //   fail_descr.handle_fail(deadframe, metainterp_sd, jd)
-    //   except JitException as e: return handle_jitexception(e)
-    //
-    // handle_jitexception (warmspot.py:961) handles ContinueRunningNormally
-    // by calling portal_ptr(*args) — the JIT-aware portal. RPython does
-    // NOT prevent JIT re-entry here. The callee can enter compiled code
-    // through maybe_compile_and_run in the portal runner.
     let result = crate::eval::portal_runner(&mut func_frame);
 
+    // warmspot.py:449 result_type=REF: always boxed Ref
+    result as i64
+}
+
+/// warmspot.py:941-959 `ll_portal_runner` — the raw-address portal entry whose
+/// address is stored in `jd.portal_runner_adr` (warmspot.py:1010-1012) and
+/// called by the synthetic callback loop that `compile_tmp_callback`
+/// (compile.py:1125-1132) builds for a not-yet-compiled recursive callee.
+///
+/// The call uses the `jd.portal_calldescr` ABI —
+/// `JitDriverStaticData::build_portal_calldescr` lays the args out in `vars`
+/// declaration order: greens `[next_instr, is_being_profiled, pycode]` then
+/// reds `[frame, ec]`. The callee `frame` red already carries `pycode` /
+/// `next_instr` baked in by the caller that built it, so only the frame
+/// pointer is needed to resume; the greens are consumed implicitly through the
+/// reconstructed frame, matching the frame-only `assembler_call_helper` entry.
+#[majit_macros::jit_may_force]
+pub extern "C" fn ll_portal_runner_shim(
+    _next_instr: i64,
+    _is_being_profiled: i64,
+    _pycode: i64,
+    frame_ptr: i64,
+    _ec: i64,
+) -> i64 {
+    // The callback loop `compile_tmp_callback` builds (compile.py:1125-1132)
+    // passes the callee `frame` red that `emit_new_pyframe_inline_with_params`
+    // constructed — a proper `PyFrame` with `locals_cells_stack_w` already
+    // populated (NewWithVtable + SetfieldGc).  Run it directly; the greens
+    // (`next_instr` / `pycode`) are redundant because the frame carries them.
+    // (Contrast `jit_force_callee_frame`, whose CA_FORCE_FN deadframe is a raw
+    // JitFrame-like block that must be reconstructed with fresh fields.)
+    let frame = unsafe { &mut *(frame_ptr as *mut PyFrame) };
+    let result = crate::eval::portal_runner(frame);
     // warmspot.py:449 result_type=REF: always boxed Ref
     result as i64
 }

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -2892,6 +2892,24 @@ fn jit_ca_handle_guard_failure(
     if raw_values_ptr.is_null() || num_values == 0 {
         return false;
     }
+    // `enter_profiler_tracing` is not re-entrant (pyjitpl.py:2890 — RPython's
+    // `handle_guard_failure` unwinds to the top-level `execute_token` before any
+    // tracing decision, so a guard never fires while another trace is open).
+    // pyre's CALL_ASSEMBLER guard callback runs synchronously from the backend
+    // trampoline, so it CAN fire mid-trace: the self-recursion fold replays its
+    // CALL_ASSEMBLER concretely while the outer trace is still recording, and a
+    // deopt in that callee reaches here with the outer trace's profiler event
+    // still open.  Starting a nested bridge trace would panic in
+    // `start_retrace_from_guard`'s `enter_profiler_tracing`.  Bail to the
+    // blackhole resume (return false) so the callee completes in the interpreter
+    // and the outer trace keeps recording; the deferred bridge compiles later
+    // when this guard fails outside a trace.
+    {
+        let (driver, _) = crate::eval::driver_pair();
+        if driver.is_tracing() {
+            return false;
+        }
+    }
     let raw_values = unsafe { std::slice::from_raw_parts(raw_values_ptr, num_values) };
 
     // compile.py:706-708 _trace_and_compile_from_bridge.  Native CA code

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -91,9 +91,7 @@ struct FrameRoot {
 impl FrameRoot {
     fn new(frame: &mut PyFrame) -> Self {
         Self {
-            depth: majit_gc::shadow_stack::push(majit_ir::GcRef(
-                frame as *mut PyFrame as usize,
-            )),
+            depth: majit_gc::shadow_stack::push(majit_ir::GcRef(frame as *mut PyFrame as usize)),
         }
     }
 

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -2700,15 +2700,13 @@ thread_local! {
 /// lands slice by slice; `PYRE_FBW_REC_MUTUAL_CUTOVER=1` opts in.
 pub(crate) fn rec_mutual_cutover_enabled() -> bool {
     static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
-    *ENABLED.get_or_init(
-        || match std::env::var_os("PYRE_FBW_REC_MUTUAL_CUTOVER") {
-            Some(v) => {
-                let v = v.to_string_lossy();
-                v != "0" && !v.eq_ignore_ascii_case("false")
-            }
-            None => false,
-        },
-    )
+    *ENABLED.get_or_init(|| match std::env::var_os("PYRE_FBW_REC_MUTUAL_CUTOVER") {
+        Some(v) => {
+            let v = v.to_string_lossy();
+            v != "0" && !v.eq_ignore_ascii_case("false")
+        }
+        None => false,
+    })
 }
 
 fn build_jit_driver_pair() -> JitDriverPair {

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -2693,6 +2693,24 @@ thread_local! {
     static JIT_DRIVER: UnsafeCell<Option<JitDriverPair>> = const { UnsafeCell::new(None) };
 }
 
+/// Gate for the full-portal recursive-call cutover — the PyPy tmp-token
+/// CALL_ASSEMBLER path (`warmstate.py:714-723 get_assembler_token` +
+/// `compile.py:1101-1150 compile_tmp_callback`) that replaces pyre's local
+/// pending-token / `CA_FORCE_FN` mechanism.  Default OFF while the migration
+/// lands slice by slice; `PYRE_FBW_REC_MUTUAL_CUTOVER=1` opts in.
+pub(crate) fn rec_mutual_cutover_enabled() -> bool {
+    static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ENABLED.get_or_init(
+        || match std::env::var_os("PYRE_FBW_REC_MUTUAL_CUTOVER") {
+            Some(v) => {
+                let v = v.to_string_lossy();
+                v != "0" && !v.eq_ignore_ascii_case("false")
+            }
+            None => false,
+        },
+    )
+}
+
 fn build_jit_driver_pair() -> JitDriverPair {
     let info = build_pyframe_virtualizable_info();
     let mut d = JitDriver::new(JIT_THRESHOLD);
@@ -2770,6 +2788,21 @@ fn build_jit_driver_pair() -> JitDriverPair {
     // warmspot.py:449 — jd.result_type = getkind(portal.getreturnvar().concretetype)[0]
     // PyPy dispatch() returns W_Root → Ref.
     d.set_result_type(majit_ir::Type::Ref);
+    // Full-portal cutover (gated, PYRE_FBW_REC_MUTUAL_CUTOVER): register the
+    // real portal `JitDriverStaticData` so `get_assembler_token` /
+    // `compile_tmp_callback` (warmstate.py:714-723, compile.py:1101-1150) have
+    // a slot with `portal_runner_adr` + `portal_calldescr` populated.
+    // Production otherwise carries only the empty `ensure_default_driver_sd`
+    // placeholder (jitdrivers_sd[0], adr=0); this pushes the greens/reds portal
+    // schema at index 1+ per the documented `register_jitdriver_sd` contract.
+    // warmspot.py:1010-1012 `jd.portal_runner_adr = adr_of(ll_portal_runner)`.
+    if rec_mutual_cutover_enabled() {
+        let mut jd = PyreJitState::pypyjit_driver_descriptor();
+        jd.result_type = majit_ir::Type::Ref;
+        jd.virtualizable_info = Some(info.clone());
+        jd.portal_runner_adr = crate::call_jit::ll_portal_runner_shim as *const () as i64;
+        d.meta_interp_mut().register_jitdriver_sd(jd);
+    }
     // rlib/jit.py:842 set_user_param — the translation-time `--jit STR`
     // option's analog. `PYRE_JIT="vec_all=1"` opts vectorization in the
     // PyPy way (parameter; the defaults stay off). `PYRE_JIT=0` keeps its


### PR DESCRIPTION
Three follow-ups on the recursion-unroll work (gh#343):

## 1. `a93624df7bb` — bail the CALL_ASSEMBLER guard-failure bridge when already tracing

`jit_ca_handle_guard_failure` fires synchronously from the backend trampoline, so a concrete CALL_ASSEMBLER replay during tracing could deopt mid-trace and start a nested bridge trace, panicking in `enter_profiler_tracing` (not re-entrant, pyjitpl.py:2890). Bail to blackhole resume instead, mirroring the sibling pending-exception guard; the bridge compiles later when the guard fails outside a trace. Fixes the cold-start deep-recursion panic under `PYRE_FBW_REC_MULTIFRAME` (fib(28)/fib(30)).

## 2. `29ff5657807` — gated full-portal recursive-call cutover (`PYRE_FBW_REC_MUTUAL_CUTOVER`, default OFF)

At the inline-unroll cap, a mutual-recursive callee with no loop token previously declined the trace (poisoning the root key). Under the gate, the walker now follows `_opimpl_recursive_call`/`do_recursive_call` (pyjitpl.py:1376-1422): register a real portal `JitDriverStaticData` with `portal_runner_adr` (an `ll_portal_runner`-ABI shim, warmspot.py:941-959) and synthesize a CALL_ASSEMBLER token via `get_assembler_token`/`compile_tmp_callback` (warmstate.py:714-723, compile.py:1101-1150) for callees on the inline framestack. Self-recursion keeps the pending-token path (converging it is blocked on the descr-identity cutover, task #211 — pending-number collision).

## 3. `67c017c6447` — root virtualizable and deadframe refs across GC in guard-deopt resume

A minor collection during nested deopt/blackhole activity could move objects whose refs were held in raw host buffers. Exposed on cranelift (moving nursery jitframes; dynasm jitframes are pinned libc allocations traced in place): deterministic SIGSEGV with `PYPY_GC_NURSERY=65536 MAJIT_GC_NURSERY_POISON=1` + unroll flags on `fib(18)`.

- register virtualizable `locals_cells_stack_w` DirectPointer slots on the resume-ref-root stack during resume construction and for virtualizables in blackhole ref register banks (resume.py:1399 keeps these reachable through the GC-traced virtualizable)
- root the virtualizable pointer across collecting residual calls while tracing (pyjitpl.py:3317-3366)
- root the live PyFrame across bridge retracing and hand the post-GC frame address and rooted raw fail values from the CALL_ASSEMBLER guard-failure callback to the blackhole resume
- cranelift: use the standard `spill_ref_roots` before CALL_ASSEMBLER instead of skipping already-synced frame-resident refs, whose SSA values can be stale after a collecting call

## Verification

- check.py dynasm 208/208 and cranelift 208/208
- poison repro cranelift fib(15..20) correct (was deterministic SIGSEGV); default-nursery cold-start fib(25..34), s(900), is_even(450) with and without unroll flags
- dynasm neutrality: poison fib(18), fib(30) both configs, linear/mutual
- `cargo test` on pyre-jit-trace, pyre-jit, majit-metainterp

🤖 Generated with [Claude Code](https://claude.com/claude-code)