### PR TITLE
repl: exit on SystemExit instead of printing a traceback

### DIFF
--- a/pyre/pyrex/src/repl.rs
+++ b/pyre/pyrex/src/repl.rs
@@ -108,6 +108,7 @@ pub fn run_repl(quiet: bool, no_site: bool) {
     let mut full_input = String::new();
     let mut continuing_block = false;
     let mut continuing_line = false;
+    let mut pending_exit: Option<i32> = None;
 
     loop {
         let prompt = if continuing_block || continuing_line {
@@ -176,6 +177,12 @@ pub fn run_repl(quiet: bool, no_site: bool) {
                 continuing_line = false;
             }
             ShellExecResult::RuntimeErr(err) => {
+                if err.kind == pyre_interpreter::PyErrorKind::SystemExit {
+                    // exit()/quit() raise SystemExit; terminate the REPL with
+                    // its code instead of printing a traceback and continuing.
+                    pending_exit = Some(crate::system_exit_code(&err));
+                    break;
+                }
                 pyre_interpreter::eprint_exception(&err, true);
                 full_input.clear();
                 continuing_block = false;
@@ -186,6 +193,11 @@ pub fn run_repl(quiet: bool, no_site: bool) {
 
     if let Err(err) = repl.save_history(&history_path) {
         eprintln!("pyre: could not save REPL history: {err}");
+    }
+
+    if let Some(code) = pending_exit {
+        crate::maybe_print_jit_stats();
+        std::process::exit(code);
     }
 }
 


### PR DESCRIPTION
Fixes #468.

The REPL's runtime-error branch printed every exception and continued, so `exit()` / `quit()` — which raise `SystemExit` — emitted a `SystemExit: None` traceback and kept the prompt running instead of terminating.

Detect `SystemExit` in that branch, break the read loop, and terminate with `system_exit_code()` after saving history, reusing the exit-code mapping the script path (`run_source` / `run_module`) already uses. Breaking rather than exiting immediately preserves the readline history save.

## Verification
- `exit()` / `quit()` → exit 0, no traceback leak
- `exit(3)` → exit 3
- `raise SystemExit("bye")` → exit 1 + `bye` on stderr
- `1/0` then `exit()` → `ZeroDivisionError` traceback still prints and the prompt continues, then `exit()` terminates
- Script-path `SystemExit` (`sys.exit`, `raise SystemExit(n)`) unchanged, matches CPython 3.14
- Gate: `check.py --backend dynasm` 208/208; `cargo fmt --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)