### PR TITLE
jit: retire foreign-lib cluster walls (gh#346 Slice A + B1a + B2 + B3a)

### DIFF
--- a/majit/majit-translate/docs/design-346-foreign-lib-cluster-epic.md
+++ b/majit/majit-translate/docs/design-346-foreign-lib-cluster-epic.md
@@ -1,0 +1,150 @@
+# gh#346 — Foreign-std-library cluster epic (vec! / malachite / String / Wtf8 / IndexMap)
+
+## Why this epic exists
+
+On base `eca75827fe4` the JIT-prepass census has **268 distinct `[PREPASS phaseA fail]`** paths.
+A root-cause analysis (deepest-root, per-record all-blockers) ranked the leaves by "sole-unblock"
+leverage. The top three (`box_assume_init` / vec!, `malachite ::try_from`, and the
+`Wtf8`/`Map::collect`/`IndexMap` group) looked independently high-value, but a **peel-and-recensus**
+of each proved otherwise:
+
+- vec!/NewList recognizer re-add → census only 268→266 (net −2), and it **breaks the build**
+  (`newlist/r>r` unwired-snapshot).
+- `malachite try_from` via `plain_int_w` `#[dont_look_inside]` → **net ZERO** (and the attribute
+  didn't even take: `plain_int_w` is inlined by rustc/Charon before the JIT sees it).
+- Combined vec!+try_from → 268→265, only `getitem_list` lifts.
+
+**Root insight:** every hot list/dict/str *mutation* graph (`setitem_list`, `getitem_list`,
+`w_list_setitem`, `setitem_bytearray`, `plain_int_w`) is guarded by a **stack** of foreign-std walls.
+Peeling one exposes the next:
+
+```
+box_assume_init (vec!) → malachite ::try_from → String::new → core::slice::get / join
+  → Wtf8Buf::with_capacity → Enumerate::next → IndexMap::insert / get
+```
+
+No *single* leaf yields standalone census lift because the leaves **co-block the same graphs**. The
+only way to lift the cluster's hot graphs is to close the whole wall-stack **together**. This is the
+"census-line depth is a LIAR" phenomenon (documented in the rtyper-legacy rebase memory) at cluster
+scale — the census reports only the first wall per graph.
+
+## Slice ORDER — corrected 7/16 (the recognizer is a CAPSTONE, not a prerequisite)
+
+The original plan put vec!/NewList first because `box_assume_init` is the *census-visible frontier*
+wall. That was wrong, and it was proven wrong empirically (see "Verdict" below). The front/mir vec!
+recognizer is a **shared front-end rewrite**: it plants `OpKind::NewList` into a graph regardless of
+whether that graph will lift through the two-phase prepass or drop to the legacy walker. The legacy
+walker cannot lower `NewList` (it never runs `rtype_newlist`), so its raw op reaches the assembler's
+default arm and emits `newlist/r>r` — an opname with no blackhole handler — which breaks the build via
+`default_bh_builder_unwired_set_matches_task_85_snapshot`. Therefore the recognizer is only safe once
+**no** vec!-bearing graph can still drop to legacy, i.e. after every co-blocking wall closes.
+
+**Corrected order: Slice A (try_from) → Slice B (String/Wtf8/IndexMap/slice/iter) → Slice C
+(vec!/NewList recognizer, LAST).**
+
+### Slice A — malachite `try_from` (task #21, FIRST, no deps)
+
+**Census (base `ccdc1a52be2`):** 16 phaseA graphs have a `try_from` first wall, split into TWO
+unrelated families:
+- **13 graphs = malachite** (`["malachite_bigint","bigint","<Impl>","try_from"]`) — the Slice-A target.
+- **3 graphs = int-to-int** (`["core","convert","num","<Impl>","try_from"]`: `int_pow`, `pow`,
+  `opcode_get_iter`) — NOT malachite. `int_pow` is `u32::try_from(vb)` with a genuine
+  `Err(_)=>return Err(memory_error)` branch (descroperation.rs:860). Out of Slice A's scope; defer.
+
+**Reachability of the 13 malachite graphs** (traced through the census onion): every one reaches the
+wall through exactly one of three functions — `setitem_list` (baseobjspace.rs:2359), `getitem_list`
+(baseobjspace.rs:1268), or `plain_int_w` (listobject.rs:362, reached via `w_list_setitem` /
+`w_list_append` / directly).
+
+**The crux — the narrowing is NOT uniform (verified by direct `rg` census of every
+`i64::try_from(w_long_get_value(...))` site):**
+- **bucket (a) panic** — `plain_int_w` (listobject.rs:366) is `.unwrap_or_else(|_| panic!())`,
+  semantically identical to `jit_bigint_to_i64_value` (longobject.rs:364). A pure target-swap is
+  bit-exact HERE.
+- **bucket (c) genuinely-fallible** — `getitem_list` (baseobjspace.rs:1303) and `setitem_list`
+  (baseobjspace.rs:2372) — and 6 more `getindex_w`-inlined siblings (baseobjspace.rs:1362, 1427,
+  1493, 2523, 2547, 2584; 8 total) — are `match i64::try_from(...) { Ok(i)=>i, Err(_)=>return
+  Err(IndexError/ValueError) }`. Overflow throws a **Python exception**, NOT a panic. A panic-residual
+  swap would be a CORRECTNESS REGRESSION (bit-exact violation). The coercion is deliberately inlined
+  per-callsite ("the same rtyper reason as getitem_list") — no shared choke point.
+
+So Slice A is NOT the "pure target-swap" the original note assumed. Two distinct lowerings:
+
+1. **bucket (a) `plain_int_w`**: pure target-swap of `i64::try_from(<opaque BigInt>)` →
+   `jit_bigint_to_i64_value` (both `#[dont_look_inside]` residuals ALREADY registered,
+   jit_fnaddr.rs:911-919), guarded on `tyref_is_opaque_bigint` (mir.rs:11226). Mirror
+   `bigint_binop_residual_path` (mir.rs:6457). But the enclosing `Result` local — `plain_int_w`'s
+   `try_from` result is immediately `.unwrap_or_else`d, so the MIR may already fold it; verify.
+2. **bucket (c) `match i64::try_from(<opaque BigInt>)`** (8 sites, ALL verified by an exhaustive
+   census: `getitem_list` baseobjspace.rs:1303, `getitem_str` :1362, `getitem_bytes_like` :1427 +
+   :1493, `setitem_list` :2372, `setitem_bytearray` :2523 + :2547, `byte_w` :2584 — each
+   `Ok=>i, Err(_)=>return Err(IndexError/ValueError)`): lower to the runtime-discriminant `Result`
+   aggregate, using `try_lower_checked_neg` (mir.rs:8610) as the EXACT template (it already builds a
+   runtime-disc `Result`/`Option` via `emit_tagged_pair_aggregate`, mir.rs:9339). Emit:
+   `fits = jit_bigint_to_i64_fits(bigint)` (residual, returns 1 when it fits), `disc =
+   BinOp("eq", fits, 0)` (Result convention: **Ok=0, Err=1** — mir.rs:8259, so disc=0 when it fits),
+   a `payload`, then `emit_tagged_pair_aggregate(disc, payload)` with `Ok`=tag 0. The
+   `Err(_)=>return Err(IndexError)` arm survives UNTOUCHED as real user code reached via the disc==1
+   switch branch. This is the substantive part of Slice A.
+
+   **⚠️ EAGER-PAYLOAD PANIC HAZARD (the one non-obvious constraint):** `emit_tagged_pair_aggregate`
+   writes `__pos_0 = payload` UNCONDITIONALLY in the call's block (mir.rs:8682-8689 pushes the payload
+   op before the goto), *before* the consumer's discriminant switch runs in a successor block. For
+   `checked_neg` the payload op is `neg` (total, never traps), so eager eval is safe. But
+   `jit_bigint_to_i64_value` **PANICS on overflow** (longobject.rs:366). If `payload =
+   jit_bigint_to_i64_value(bigint)` is computed eagerly and the BigInt does NOT fit, the residual
+   panics in the walker/blackhole graph BEFORE the switch can route to the `Err` arm — turning
+   `lst[2**100]` into a panic instead of the correct `IndexError`. **A bit-exact regression.**
+   Resolution: `__pos_0` is only READ on the Ok path (disc==0 guarantees fits), so its value on the
+   Err path is dead — the payload op only needs to be TOTAL (non-trapping), not correct-on-overflow.
+   Use a NON-PANICKING total residual for the payload — add `jit_bigint_to_i64_value_or_zero`
+   (`i64::try_from(num).unwrap_or(0)`, mirrors the existing bucket-(d) idiom at listobject.rs:1317)
+   next to the fits/value pair in longobject.rs and register it in jit_fnaddr.rs. On the Ok path it
+   equals `jit_bigint_to_i64_value`; on the (dead) Err path it returns 0 instead of panicking. This is
+   RPython-faithful: upstream `toint`-after-`fits_int`-guard is elidable *because* the guard proves it
+   fits; with no guard in the interpreter graph, the total form is the honest lowering.
+
+   For **bucket (a) `plain_int_w`**: the same aggregate lowering serves it — its `.unwrap_or_else(|_|
+   panic!)` reads `__pos_0` on the (always-taken, precondition-guaranteed) Ok path. Prefer UNIFYING
+   both buckets on one recognizer for `<opaque BigInt>::try_from` rather than a separate target-swap.
+
+Fail-safe by construction (a non-BigInt / unlisted target leaves the residual `<Impl>` call the census
+Skips). Verify: `cargo test -p majit-translate` + census set-diff (expect the 13 malachite graphs to
+drop OR expose their NEXT co-blocking wall) + `default_bh_builder_unwired_set_matches_task_85_snapshot`
+green + `check.py` bit-exact 3-backend (list/dict subscript with huge int indices exercises the
+Err arm — MUST still raise IndexError/ValueError, not panic).
+
+### Slice B — String / Wtf8 / IndexMap / slice / iter-adapter residuals (task #22, after A)
+The cluster tail: `String::new`, `Wtf8Buf::with_capacity`, `Enumerate::next`, `core::slice::get/join`,
+`IndexMap::insert/get`, `Map::collect`, `slice::iter::Iter::next`. Scope per-leaf after Slice A lands
+and re-census reveals which remain co-blocking the hot graphs.
+
+### Slice C — vec!/NewList recognizer + repr-generic rtype_newlist (task #20, LAST, capstone)
+- **Ca** Re-add the front/mir recognizer (verbatim from reverted `f41cb0496dc`): match
+  `box_assume_init_into_vec_unsafe(box [e0..eN])` → `OpKind::NewList{args}`. Helpers
+  `read_array_literal_elements` (mir.rs:13581) + `fmt_path_ends_with` (mir.rs:13673) still in tree.
+- **Cb** `remove_dead_aggregates` (model.rs:2469) already sweeps the dead `Box::new_uninit`. No work.
+- **Cc** repr-generic `rtype_newlist` (rlist.rs:395): accept BOTH `ListRepr` (Resized) AND
+  `FixedSizeListRepr` (Fixed) — a never-mutated vec! annotates NON-resized → `FixedSizeListRepr`
+  (rmodel.rs:3208). Fixed arm builds via `build_ll_newlist_helper_graph(ListLayout::Fixed)` +
+  `build_ll_fixed_setitem_fast_helper_graph`. RPython-faithful (rlist.py:338-344 is repr-generic).
+  **This code was written and verified to compile + pass `cargo test -p majit-translate`; it is
+  correct but INSUFFICIENT alone — it only lifts graphs that fully rtype.** Recover it from this
+  session's transcript / the reverted diff when Slice C lands.
+- **Cd** Only after Slices A+B close every co-blocking wall does the recognizer become safe: with no
+  vec!-graph dropping to legacy, `rtype_newlist` runs on every one, decomposing `NewList` to
+  `ll_newlist` + `ll_fixed_setitem_fast` residual calls before assembly → no raw `newlist` reaches
+  the default arm → `newlist/r>r` snapshot stays green. **Gate every Slice-C attempt on
+  `default_bh_builder_unwired_set_matches_task_85_snapshot` (reads `insns.bin`, NOT census stderr).**
+
+Verify each slice: `cargo test -p majit-translate` + census phaseA set-diff (count distinct
+`[PREPASS phaseA fail]`) + `default_bh_builder_unwired_set_matches_task_85_snapshot` green +
+`check.py` bit-exact 3-backend.
+
+## Metric
+Distinct `[PREPASS phaseA fail]` count in the census (268 on base `ccdc1a52be2`). Each slice measured
+by set-diff. GOTCHA: the census **stderr** logs only phaseA *reasons* — the emitted `newlist/r>r`
+opname lives in `insns.bin` (build OUT_DIR `target/debug/build/pyre-jit-trace-<hash>/out/insns.bin`;
+`strings insns.bin | rg newlist`), not stderr. The cluster's hot graphs (`setitem_list`,
+`getitem_list`, `w_list_setitem`, `setitem_bytearray`) only lift once ALL their stacked walls close —
+expect most of the census movement on the LAST slice.

--- a/majit/majit-translate/docs/design-346-foreign-lib-cluster-epic.md
+++ b/majit/majit-translate/docs/design-346-foreign-lib-cluster-epic.md
@@ -115,9 +115,59 @@ green + `check.py` bit-exact 3-backend (list/dict subscript with huge int indice
 Err arm — MUST still raise IndexError/ValueError, not panic).
 
 ### Slice B — String / Wtf8 / IndexMap / slice / iter-adapter residuals (task #22, after A)
-The cluster tail: `String::new`, `Wtf8Buf::with_capacity`, `Enumerate::next`, `core::slice::get/join`,
-`IndexMap::insert/get`, `Map::collect`, `slice::iter::Iter::next`. Scope per-leaf after Slice A lands
-and re-census reveals which remain co-blocking the hot graphs.
+
+Scoped 7/17 on the post-Slice-A census (base `bb6ee8d179c`, 276 phaseA): **46 distinct unregistered
+residual paths**, saved to `/tmp/sliceB_residual_ranking.txt` (de-escape `\"`→`"` before counting).
+The three walls that gate the hot dispatcher heads (innermost per record):
+
+- `iter::adapters::map::Map::collect` (25 hits) → `setitem_slot`, `w_list_append`, `setitem_list`,
+  `w_list_setitem`.
+- `core::str::<Impl>::as_bytes` (7) → `getitem_slot`, `dict_entries_get_str`.
+- `sync::atomic::AtomicBool::store` (15) → `object_setattr` (via `w_type_set_abstract`).
+
+The 46 paths split into four orthodoxy buckets — **do NOT residualize a bucket-(N) core op** (that is
+the non-orthodox band-aid: a silent perf regression no correctness test catches):
+
+- **(F) foreign-opaque residual** — `Map::collect`, `Wtf8::*`, `IndexMap::{get,insert,get_index,
+  with_capacity,get_index_mut}`, `AtomicBool::store`, `BigInt::{sign,to_u32}`, `fmt::rt::Argument::
+  new_debug`. NOT auto-collected because the owners are EXTERNAL crates (`indexmap`/`wtf8`/`core`/`std`)
+  → `iter_local_fns` (charon-reader:208) never sees them, and `collect_foreign_opaque_method_externals`
+  (mir.rs:10681) only walks LOCAL opaque ADTs with a self-receiver and a modelable result
+  (`foreign_opaque_method_result_valuetype` mir.rs:10773 declines `Option`/enum/tuple/ref). `BigInt`
+  `sign`/`to_u32` owner IS opaque+local but the enum/`Option` result is declined. Fix = wrap the
+  **pyre-side caller** in `#[dont_look_inside]` + `push_alias_pair`. Template already shipped:
+  `w_dict_{store,lookup}_int_strategy` (jit_fnaddr.rs:557-580) residualize their internal
+  `IndexMap::{insert,get}` wholesale.
+- **(N) native-lowerable core op** — `core::slice::{get,first,index,as_ptr,chunks_exact}`,
+  `from_raw_parts`, `f64::abs` (rtyper has `rtype_abs` rfloat.rs:216 → `float_abs`, method callsite
+  unwired), `num::checked_div` (→ runtime-disc `Result`, template `try_lower_checked_neg` mir.rs:8610),
+  `convert::{from,num::try_from}` (int-to-int `try_from` = the Slice-A-deferred `int_pow`/`pow`/
+  `opcode_get_iter`), `RangeInclusive::new` (→ `rtype_builtin_range` rrange.rs:160), `Rev::next`,
+  `mut_ptr::add`, `Vec::{index,index_mut}`. Real rtype/recognizer, never a residual.
+- **(C) vec!/box/alloc cluster** — deferred to Slice C (capstone).
+- **(P) pyre-internal accessor** — `set_async`, `EVAL_NESTING`, `EXC_CLASS_REGISTRY`,
+  `subclass_range_read`, `GcType::type_id`, `Constants::{deref,index}`. `push_alias_pair` siblings of
+  the jit_fnaddr.rs:697-758 runtime-state accessors.
+
+**Sub-slice order (cheapest-per-leverage first; census depth LIES — head movement only when B1+B2
+co-land):**
+
+- **B1a (FIRST, done)** — the `str::as_bytes` / `Wtf8::as_str` identity-fold gap. Root cause:
+  `is_string_as_bytes_identity` (mir.rs:7434) and `is_string_to_str_identity` (mir.rs:7405) both gate on
+  `deref_impl_owner_leaf(fd)` matching an owner leaf, but `deref_impl_owner_leaf` (mir.rs:10530) resolves
+  the owner through `resolve_impl_owner_adt_def_id_free`, which needs an ADT def-id. The primitive `str`
+  is a `{Builtin:"Str"}` node with no def-id, so the literal `"str"` arm is dead; `Wtf8::as_str` fails a
+  different way (`is_string_to_str_identity` gates owner `== "String"` only). Fix: gate both folds on the
+  **receiver** being a string value via `tyref_is_string_value` (mir.rs:11539, which already handles
+  `Builtin("Str")` + `String` + `Wtf8`/`Wtf8Buf` uniformly) rather than the impl-owner leaf. Do NOT
+  touch `deref_impl_owner_leaf` (it also drives the `cast_pointer` thin-pointer rewrite).
+- **B1b** — the (P) register-only accessors + `fmt::Argument::new_debug` fold into the existing fmt
+  family (mir.rs:1757/7500).
+- **B2** — the (F) foreign residuals (`Map::collect`, `AtomicBool::store`, `IndexMap` family, `BigInt`
+  `sign`/`to_u32`). The str-dict path is STRUCTURALLY DIFFERENT from int/bytes: it uses the shared
+  `dict_entries_get_str` helper (dictmultiobject.rs:179, not `#[dont_look_inside]`), not a dedicated
+  strategy leaf — add a `w_dict_lookup_str_strategy`-style residual leaf or mark the shared helper.
+- **B3 (LAST in B, real rtyper work)** — the (N) native lowerings.
 
 ### Slice C — vec!/NewList recognizer + repr-generic rtype_newlist (task #20, LAST, capstone)
 - **Ca** Re-add the front/mir recognizer (verbatim from reverted `f41cb0496dc`): match

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -762,7 +762,12 @@ fn build_semantic_program_from_llbc_with_static_addrs_filtered(
         // production keeps going with a degraded SemanticProgram —
         // failing-loud on the single broken function rather than
         // erroring out at program-build time.
-        let graph = match lower_fun_decl_with_static_addrs(llbc, fd, static_addrs) {
+        let graph = match lower_fun_decl_with_static_addrs_and_attrs(
+            llbc,
+            fd,
+            static_addrs,
+            &struct_field_attrs,
+        ) {
             Ok(g) => g,
             Err(e) => {
                 skipped.push((name.clone(), e.to_string()));
@@ -1522,6 +1527,21 @@ pub fn lower_fun_decl_with_static_addrs(
     fd: &FunDecl,
     static_addrs: crate::HostStaticAddrs<'_>,
 ) -> Result<FunctionGraph, LowerError> {
+    // Derive the struct field-layout map the boxing-alloc fusion reads
+    // (`fuse_boxing_alloc`).  The whole-program build lowers each function
+    // through the `_with_attrs` variant with a single precomputed map; this
+    // stand-alone entry (used by the reader / tests) derives it per call from
+    // the same source of truth so the fusion fires identically.
+    let (_, _, _, _, _, struct_field_attrs, _, _) = derive_program_metadata(llbc);
+    lower_fun_decl_with_static_addrs_and_attrs(llbc, fd, static_addrs, &struct_field_attrs)
+}
+
+fn lower_fun_decl_with_static_addrs_and_attrs(
+    llbc: &Llbc,
+    fd: &FunDecl,
+    static_addrs: crate::HostStaticAddrs<'_>,
+    struct_field_attrs: &std::collections::HashMap<String, Vec<(String, ValueType)>>,
+) -> Result<FunctionGraph, LowerError> {
     let u = fd.unstructured().ok_or_else(|| {
         LowerError::Unsupported(format!(
             "{}: no Unstructured body (extracted with --ullbc?)",
@@ -1559,7 +1579,7 @@ pub fn lower_fun_decl_with_static_addrs(
             // matcher sees the switch, leaving the plain 0/1 pair.
             // Untouched graphs skip this and keep their single
             // end-of-lowering simplify, byte-identical.
-            simplify_lowered_graph(&mut lo.graph);
+            simplify_lowered_graph(&mut lo.graph, struct_field_attrs);
         }
         let mut tail_forwarded_returns = 0usize;
         if !lo.result_exc_call_results.is_empty() {
@@ -1778,7 +1798,7 @@ pub fn lower_fun_decl_with_static_addrs(
         {
             crate::model::clear_unreachable_blocks(&mut lo.graph);
         }
-        simplify_lowered_graph(&mut lo.graph);
+        simplify_lowered_graph(&mut lo.graph, struct_field_attrs);
         // `format!`-chain expansion (#131): rewrite the recognized
         // `Argument::new_display`/`Arguments::new`/`alloc::fmt::format`
         // chain into native `str` + `ll_strconcat` ops so the graph-less
@@ -1814,7 +1834,7 @@ pub fn lower_fun_decl_with_static_addrs(
         // so untouched graphs keep their single end-of-lowering simplify.
         if collapse_panic_message_chains(&mut lo.graph) > 0 {
             crate::model::clear_unreachable_blocks(&mut lo.graph);
-            simplify_lowered_graph(&mut lo.graph);
+            simplify_lowered_graph(&mut lo.graph, struct_field_attrs);
         }
         Ok(())
     };
@@ -1909,7 +1929,10 @@ pub fn lower_fun_decl_with_static_addrs(
 ///   the later backendopt sweep (`backendopt/all.py`); the model
 ///   layer has no later sweep, so it runs here, gated on an actual
 ///   removal to keep untouched graphs byte-identical.
-fn simplify_lowered_graph(graph: &mut FunctionGraph) {
+fn simplify_lowered_graph(
+    graph: &mut FunctionGraph,
+    struct_field_attrs: &std::collections::HashMap<String, Vec<(String, ValueType)>>,
+) {
     crate::model::eliminate_empty_blocks(graph);
     // `eliminate_empty_blocks` (simplify.py:33-78) rewires each incoming
     // link past an operation-less block and leaves the bypassed block
@@ -1932,7 +1955,19 @@ fn simplify_lowered_graph(graph: &mut FunctionGraph) {
     // to a native `NewWithVtable` + payload store before the dead-aggregate
     // sweep, which then reclaims the orphaned construct-on-stack ctor and
     // header field writes.
-    let mut dirty = crate::model::fuse_boxing_alloc(graph) > 0;
+    let mut dirty = crate::model::fuse_boxing_alloc(graph, struct_field_attrs) > 0;
+    // Reclaim boxing-cluster remnants (fused header ctors/casts, and a
+    // `vec![…]` box whose consumer became a `newlist`) using dependency-flow
+    // liveness (`transform_dead_op_vars`, simplify.py:425-479) with the
+    // malloc-removal exemption (`remove_simple_mallocs`, malloc.py).  Unlike
+    // `remove_dead_aggregates` below, it treats a `Link.arg` as a dependency
+    // of the target inputarg, not an unconditional read, so it reaches a box
+    // threaded across a block boundary.  Runs unconditionally: a `vec!`-only
+    // graph has `fused == 0`, and the pass is conservative (fresh-alloc
+    // producers + scoped store exemption) so it is a no-op on graphs with no
+    // such remnants.  A removal leaves dangling threaded inputargs / link args
+    // the `prune_dead_phis` below reclaims, so fold its count into `dirty`.
+    dirty |= crate::model::prune_dead_boxing_remnants(graph) > 0;
     // Drop dead aggregate constructions (malloc + field stores whose
     // result is never read) before the dead-op sweep — `prune_dead_phis`
     // keeps them because a `FieldWrite` is side-effecting, so its `base`
@@ -5570,7 +5605,8 @@ impl<'a> Lowering<'a> {
                 // let a char read byte-compare) without lowering a real
                 // byte-slice view here first, or those indexed uses would
                 // silently gain character semantics.
-                if args.len() == 1 && self.is_string_as_bytes_identity(&reg, first_arg_ty.as_ref()) {
+                if args.len() == 1 && self.is_string_as_bytes_identity(&reg, first_arg_ty.as_ref())
+                {
                     self.local_var[dest_local] = Some(args[0].clone());
                     let target_bb = self.block_id[target];
                     let link_args = self.edge_args(mir_bb, target)?;
@@ -6065,15 +6101,35 @@ impl<'a> Lowering<'a> {
                 // `box_assume_init` primitive is unregistered, so the legacy
                 // CodeWriter residualizes it as a plain call (the same
                 // treatment `w_int_new` / `w_float_new` get).  An earlier
-                // recognizer rewrote this shape to `OpKind::NewList`, but those
-                // graphs fail the two-phase prepass on the dead cross-block
-                // `Box::new_uninit` and drop to the legacy CodeWriter, which
-                // cannot run `rtype_newlist` (the legacy annotator types the
-                // result `Ref`, not `ListRepr`).  The un-lowered `newlist`
-                // opname then reached the build-time `Assembler.insns` table
-                // with no blackhole handler.  Until the vec! graphs two-phase
-                // lift (`rtype_newlist` is implemented but dormant), the
-                // residual call is the correct lowering.
+                // recognizer rewrote this shape to `OpKind::NewList` (feeding
+                // the now-repr-generic `rtype_newlist`, which decomposes it to
+                // `ll_fixed_newlist` + `ll_fixed_setitem_fast` for a
+                // never-mutated vec! `FixedSizeListRepr`), but the front-end
+                // rewrite is UNCONDITIONAL: it plants `NewList` into a graph
+                // regardless of whether that graph two-phase lifts or drops to
+                // the legacy walker.  The legacy walker never runs
+                // `rtype_newlist`, so a dropped graph's raw `NewList` reaches
+                // the assembler's default arm and emits `newlist/r>r` — an
+                // opname with no blackhole handler — breaking the build via
+                // `default_bh_builder_unwired_set_matches_task_85_snapshot`.
+                //
+                // Slice-C measurement (7/18, base 0bdfdb85781, AFTER wall-1 +
+                // wall-2 both closed): re-adding the recognizer STILL trips the
+                // snapshot with `newlist/r>r`.  Wall-1 (cross-block Link box
+                // sweep, `prune_dead_boxing_remnants`) and wall-2 (set/frozenset
+                // constant-`ob_type` monomorphization → `fuse_boxing_alloc`)
+                // are landed and census-verified (head 274→267, `w_set_new`
+                // fully lifts, set `malloc_typed` fuses), but at least one
+                // vec!-bearing graph beyond `make_generic_alias` /
+                // `set_method_difference` still drops to the legacy walker
+                // carrying a raw `NewList`.  The census only surfaces a graph's
+                // FIRST wall, so the blocking graph is one whose earlier wall
+                // hides its vec!; it must be identified (census scan for every
+                // `box_assume_init_into_vec_unsafe` producer graph, then trace
+                // why it fails phaseA) and its wall closed before the recognizer
+                // is safe.  Until then the residual call is the correct
+                // lowering; `rtype_newlist`'s Fixed arm stays implemented and
+                // dormant.
                 // For a method/direct callee this equals the callee's
                 // `name_path()`; the scope predicate keys on the module
                 // path, which the built `CallTarget::Method` drops.
@@ -6720,12 +6776,13 @@ impl<'a> Lowering<'a> {
             && fmt_path_ends_with(segments, &["range", "RangeInclusive", "new"])
             && tyref_is_int_range_inclusive(&call.dest.ty, self.llbc)
         {
-            self.range_inclusive_new_sites
-                .push(crate::front::range_contains::RangeInclusiveNewSite {
+            self.range_inclusive_new_sites.push(
+                crate::front::range_contains::RangeInclusiveNewSite {
                     result_var: result_var.clone(),
                     lo: args[0].clone(),
                     hi: args[1].clone(),
-                });
+                },
+            );
         }
         // Capture `RangeInclusive::contains(&self, &x)` sites for the same
         // fold.  Its `&RangeInclusive` receiver is an opaque foreign ADT
@@ -7545,11 +7602,7 @@ impl<'a> Lowering<'a> {
     /// fails rtype and residualizes rather than miscompiling.  Do NOT add
     /// a `(CharRepr, IntegerRepr)` eq arm without lowering a real
     /// byte-slice view first.
-    fn is_string_as_bytes_identity(
-        &self,
-        reg: &RegularCall,
-        first_arg_ty: Option<&TyRef>,
-    ) -> bool {
+    fn is_string_as_bytes_identity(&self, reg: &RegularCall, first_arg_ty: Option<&TyRef>) -> bool {
         let CallKind::Fun(FunId::Regular { id }) = &reg.kind else {
             return false;
         };
@@ -16828,11 +16881,28 @@ mod tests {
                     .count()
             };
 
-            assert_eq!(range_call("new"), 0, "{fname}: residual RangeInclusive::new removed");
-            assert_eq!(range_call("contains"), 0, "{fname}: residual contains removed");
-            assert!(binops("le") >= 1, "{fname}: at least one `le` compare emitted");
-            assert!(binops("ge") >= 1, "{fname}: at least one `ge` compare emitted");
-            assert!(binops("bitand") >= 1, "{fname}: at least one `bitand` emitted");
+            assert_eq!(
+                range_call("new"),
+                0,
+                "{fname}: residual RangeInclusive::new removed"
+            );
+            assert_eq!(
+                range_call("contains"),
+                0,
+                "{fname}: residual contains removed"
+            );
+            assert!(
+                binops("le") >= 1,
+                "{fname}: at least one `le` compare emitted"
+            );
+            assert!(
+                binops("ge") >= 1,
+                "{fname}: at least one `ge` compare emitted"
+            );
+            assert!(
+                binops("bitand") >= 1,
+                "{fname}: at least one `bitand` emitted"
+            );
         }
     }
 

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -1739,6 +1739,32 @@ pub fn lower_fun_decl_with_static_addrs(
                 &lo.bigint_div_mod_floor_sites,
             );
         }
+        // The `(a..=b).contains(&x)` fold (`front::range_contains`) splices
+        // the residual `contains` method call in place with native
+        // `bitand(le(a, x), ge(b, x))` compares and removes the paired
+        // residual `RangeInclusive::new` call in its predecessor block.  It
+        // threads the `new` bounds into the `contains` block via
+        // `ensure_variable_at_block` (touching predecessor link args /
+        // inputargs only — no fresh blocks, no detached edges).  Removing the
+        // cross-block `new` producer leaves its threaded range value dangling
+        // on the predecessor link arg, so a rewrite MUST be followed by
+        // `prune_dead_phis` to reclaim the dead threaded range inputarg /
+        // link args (the compares never read them) — run it unconditionally
+        // on any rewrite rather than relying on the gated sweep in
+        // `simplify_lowered_graph`.  Fail-safe: a structural mismatch leaves
+        // BOTH residual calls (rtyper Skip) and touches nothing.
+        let range_contains_rewritten = if lo.range_contains_sites.is_empty() {
+            0
+        } else {
+            crate::front::range_contains::rewire_range_contains_call_sites(
+                &mut lo.graph,
+                &lo.range_inclusive_new_sites,
+                &lo.range_contains_sites,
+            )
+        };
+        if range_contains_rewritten > 0 {
+            crate::model::prune_dead_phis(&mut lo.graph);
+        }
         if !lo.result_exc_call_results.is_empty()
             || result_exc_callee
             || next_rewritten > 0
@@ -2115,6 +2141,15 @@ struct Lowering<'a> {
     /// `front::bigint_div_mod_floor` post-pass synthesizes (see
     /// [`crate::front::bigint_div_mod_floor::BigIntDivModFloorSite`]).
     bigint_div_mod_floor_sites: Vec<crate::front::bigint_div_mod_floor::BigIntDivModFloorSite>,
+    /// `RangeInclusive::new(lo, hi)` call sites recorded for the
+    /// `(a..=b).contains(&x)` → `bitand(le, ge)` fold the
+    /// `front::range_contains` post-pass synthesizes (see
+    /// [`crate::front::range_contains::RangeInclusiveNewSite`]).
+    range_inclusive_new_sites: Vec<crate::front::range_contains::RangeInclusiveNewSite>,
+    /// `RangeInclusive::contains(&self, &x)` call sites paired with the
+    /// `new` sites above by the `front::range_contains` post-pass (see
+    /// [`crate::front::range_contains::RangeContainsSite`]).
+    range_contains_sites: Vec<crate::front::range_contains::RangeContainsSite>,
     /// `Option::unwrap_or(opt, default)` call sites recorded for the
     /// discriminant value-select the `front::option_unwrap_or` post-pass
     /// synthesizes after the body lowering completes.  Each carries the
@@ -2298,6 +2333,8 @@ impl<'a> Lowering<'a> {
             bool_then_sites: Vec::new(),
             bigint_div_rem_sites: Vec::new(),
             bigint_div_mod_floor_sites: Vec::new(),
+            range_inclusive_new_sites: Vec::new(),
+            range_contains_sites: Vec::new(),
             unwrap_or_sites: Vec::new(),
             unwrap_sites: Vec::new(),
             map_or_sites: Vec::new(),
@@ -6658,6 +6695,64 @@ impl<'a> Lowering<'a> {
                     result_var: result_var.clone(),
                 },
             );
+        }
+        // Capture `RangeInclusive::new(lo, hi)` sites for the
+        // `(a..=b).contains(&x)` fold `front::range_contains` synthesizes.
+        // `new` is an inherent-impl associated function whose owner
+        // resolves to the opaque `RangeInclusive` ADT, so `lower_call`
+        // emits it as a 2-arg FunctionPath whose segments end
+        // `["range", "RangeInclusive", "new"]` (the owner-qualified
+        // spelling, like `bigint::BigInt::div_rem`).  The int element gate
+        // reads the destination `RangeInclusive`'s type argument
+        // (`call.dest.ty`), which is present even when the bounds are
+        // literal constants — the common `(0..=255)` shape passes
+        // `Operand::Const` bounds, so gating the operand types instead
+        // would miss them.  A float / narrower-width range never records a
+        // site and declines cleanly (both calls stay residual, census
+        // Skip).  The op is still emitted normally; the post-pass removes
+        // it once the paired `contains` folds.
+        if let OpKind::Call {
+            target: CallTarget::FunctionPath { segments },
+            args,
+            ..
+        } = &op_kind
+            && args.len() == 2
+            && fmt_path_ends_with(segments, &["range", "RangeInclusive", "new"])
+            && tyref_is_int_range_inclusive(&call.dest.ty, self.llbc)
+        {
+            self.range_inclusive_new_sites
+                .push(crate::front::range_contains::RangeInclusiveNewSite {
+                    result_var: result_var.clone(),
+                    lo: args[0].clone(),
+                    hi: args[1].clone(),
+                });
+        }
+        // Capture `RangeInclusive::contains(&self, &x)` sites for the same
+        // fold.  Its `&RangeInclusive` receiver is an opaque foreign ADT
+        // whose impl-owner resolution routes it as a 2-arg FunctionPath
+        // (receiver `args[0]`, value `args[1]`) ending
+        // `["range", "RangeInclusive", "contains"]`, NOT a
+        // `CallTarget::Method`.  Gate on the receiver operand type
+        // (`first_arg_ty`) resolving to the opaque `RangeInclusive` ADT
+        // over an int element so a same-named `contains` on any other type
+        // — or a float range — is never recorded; the post-pass pairs each
+        // recorded site with its producing `new` and declines on any
+        // structural mismatch.
+        if let OpKind::Call {
+            target: CallTarget::FunctionPath { segments },
+            args,
+            ..
+        } = &op_kind
+            && args.len() == 2
+            && fmt_path_ends_with(segments, &["range", "RangeInclusive", "contains"])
+            && first_arg_ty
+                .as_ref()
+                .is_some_and(|t| tyref_is_int_range_inclusive(t, self.llbc))
+        {
+            self.range_contains_sites
+                .push(crate::front::range_contains::RangeContainsSite {
+                    result_var: result_var.clone(),
+                });
         }
         // Capture `Option::unwrap_or(opt, default)` /
         // `Result::unwrap_or(res, default)` sites for the discriminant
@@ -11416,6 +11511,53 @@ fn tyref_is_opaque_bigint(ty: &TyRef, llbc: &Llbc) -> bool {
             matches!(td.kind, TypeDeclKind::Opaque)
                 && td.item_meta.name_path().ends_with("bigint::BigInt")
         })
+}
+
+/// True when `ty` (after stripping `&`/`&mut`/`*` wrappers) resolves to
+/// the foreign opaque `core::ops::range::RangeInclusive` ADT whose sole
+/// element type is a word-sized signed integer (`I64` / `Isize`).  Gates
+/// both the `new` and the `contains` recording of the
+/// `(a..=b).contains(&x)` fold so a same-named `contains` on any other
+/// type — and a float / narrower-width range — is never folded to
+/// integer compares.  The element type is read from the ADT reference's
+/// `generics.types[0]`, so it is available even when the `new` bounds are
+/// literal constants (whose operand types the front does not carry);
+/// float ranges decline cleanly (both calls stay residual, census Skip).
+fn tyref_is_int_range_inclusive(ty: &TyRef, llbc: &Llbc) -> bool {
+    let Some(node) = tyref_node(ty, llbc).and_then(|n| strip_ty_wrappers(n, llbc)) else {
+        return false;
+    };
+    let Some(adt) = node
+        .as_object()
+        .and_then(|m| m.get("Adt"))
+        .and_then(|v| v.as_object())
+    else {
+        return false;
+    };
+    let is_range = adt_node_def_id(node)
+        .and_then(|id| llbc.type_by_id(id))
+        .is_some_and(|td| {
+            matches!(td.kind, TypeDeclKind::Opaque)
+                && td.item_meta.name_path() == "core::ops::range::RangeInclusive"
+        });
+    if !is_range {
+        return false;
+    }
+    let elem = adt
+        .get("generics")
+        .and_then(|g| g.as_object())
+        .and_then(|g| g.get("types"))
+        .and_then(|t| t.as_array())
+        .and_then(|t| t.first())
+        .and_then(|n| strip_ty_wrappers(n, llbc));
+    matches!(
+        elem.and_then(|e| e.as_object())
+            .and_then(|m| m.get("Literal"))
+            .and_then(|l| l.as_object())
+            .and_then(|l| l.get("Int"))
+            .and_then(serde_json::Value::as_str),
+        Some("I64" | "Isize")
+    )
 }
 
 /// Classify a struct field [`TyRef`] into the RPython `lltype` register
@@ -16630,6 +16772,107 @@ mod tests {
         assert!(
             !residual,
             "FUNCTION_OBJECT_SIZE must not residualize as a FunctionPath call"
+        );
+    }
+
+    /// Anchor the `(a..=b).contains(&v)` fold to the real lowered IR of
+    /// its int census callers — `setitem_bytearray` / `byte_w`
+    /// (`(0..=255)`, constant bounds) and `c_int_w` (`(i32::MIN as
+    /// i64..=i32::MAX as i64)`, NON-constant bounds).  For each, both
+    /// residual range calls (`RangeInclusive::new` / `contains`) must be
+    /// gone and native `le` / `ge` / `bitand` compares present.  Ignored
+    /// by default (loads the real LLBC); run with `cargo test -p
+    /// majit-translate --lib range_contains_fold_real -- --ignored
+    /// --nocapture`.
+    #[test]
+    #[ignore]
+    fn range_contains_fold_real_int_census_sites() {
+        use crate::model::{CallTarget, OpKind};
+
+        let path = concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../build/llbc/pyre-interpreter.ullbc"
+        );
+        let llbc = Llbc::load(path).expect("load real LLBC");
+
+        for fname in ["setitem_bytearray", "byte_w", "c_int_w"] {
+            let graph = super::lower_function(&llbc, fname)
+                .unwrap_or_else(|e| panic!("lower {fname}: {e:?}"));
+
+            // Calls whose FunctionPath ends `["range", "RangeInclusive",
+            // "new"|"contains"]` (the owner-resolved spelling `lower_call`
+            // emits) and the native compare binops the fold produces.
+            let range_call = |leaf: &str| {
+                graph
+                    .blocks
+                    .iter()
+                    .flat_map(|b| b.operations.iter())
+                    .filter(|op| {
+                        matches!(
+                            &op.kind,
+                            OpKind::Call { target: CallTarget::FunctionPath { segments }, .. }
+                                if super::fmt_path_ends_with(
+                                    segments,
+                                    &["range", "RangeInclusive", leaf],
+                                )
+                        )
+                    })
+                    .count()
+            };
+            let binops = |name: &str| {
+                graph
+                    .blocks
+                    .iter()
+                    .flat_map(|b| b.operations.iter())
+                    .filter(|op| matches!(&op.kind, OpKind::BinOp { op, .. } if op == name))
+                    .count()
+            };
+
+            assert_eq!(range_call("new"), 0, "{fname}: residual RangeInclusive::new removed");
+            assert_eq!(range_call("contains"), 0, "{fname}: residual contains removed");
+            assert!(binops("le") >= 1, "{fname}: at least one `le` compare emitted");
+            assert!(binops("ge") >= 1, "{fname}: at least one `ge` compare emitted");
+            assert!(binops("bitand") >= 1, "{fname}: at least one `bitand` emitted");
+        }
+    }
+
+    /// The float range in `complex_pow` (`descroperation.rs:1459`,
+    /// `(-100.0..=100.0)`) is out of the int-only fold's scope: the
+    /// element gate rejects the `F64` type, so BOTH residual range calls
+    /// survive (the graph census-Skips as before — no regression, no
+    /// float→int miscompile).  Ignored by default (loads the real LLBC).
+    #[test]
+    #[ignore]
+    fn range_contains_fold_real_declines_float_range() {
+        use crate::model::{CallTarget, OpKind};
+
+        let path = concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../build/llbc/pyre-interpreter.ullbc"
+        );
+        let llbc = Llbc::load(path).expect("load real LLBC");
+        let graph = super::lower_function(&llbc, "complex_pow").expect("lower complex_pow");
+
+        let range_call = |leaf: &str| {
+            graph
+                .blocks
+                .iter()
+                .flat_map(|b| b.operations.iter())
+                .filter(|op| {
+                    matches!(
+                        &op.kind,
+                        OpKind::Call { target: CallTarget::FunctionPath { segments }, .. }
+                            if super::fmt_path_ends_with(
+                                segments,
+                                &["range", "RangeInclusive", leaf],
+                            )
+                    )
+                })
+                .count()
+        };
+        assert!(
+            range_call("contains") >= 1,
+            "float range contains stays residual (fold out of scope)"
         );
     }
 

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -6077,6 +6077,17 @@ impl<'a> Lowering<'a> {
                 )? {
                     return Ok(());
                 }
+                if self.try_lower_bigint_i64_try_from(
+                    mir_bb,
+                    &reg.kind,
+                    &segments,
+                    &args,
+                    dest_local,
+                    &call.dest.ty,
+                    target,
+                )? {
+                    return Ok(());
+                }
                 // `<BigInt as {One,Zero}>::{one,zero}()` — a 0-arg associated
                 // fn returning a fresh `BigInt` constant.  Emit `BigInt::from(1)`
                 // / `BigInt::from(0)` (a `ConstInt` operand feeding the
@@ -8700,6 +8711,159 @@ impl<'a> Lowering<'a> {
         // Success (`arg != MIN`) is the `Some` variant (discriminant 1).
         let payload_owner =
             Self::tagged_pair_payload_owner(td, &owner, 1).unwrap_or_else(|| owner.clone());
+        self.emit_tagged_pair_aggregate(
+            mir_bb,
+            &owner,
+            &payload_owner,
+            disc,
+            payload,
+            dest_local,
+            target,
+        )?;
+        Ok(true)
+    }
+
+    /// Lower the runtime-fallible `i64::try_from(&BigInt)`
+    /// (`malachite_bigint::bigint::<Impl>::try_from`, Opaque in the LLBC)
+    /// into its decomposed runtime-discriminant `Result` shape: a
+    /// `__discriminant` tag driven by `rbigint.fits_int()` and a
+    /// `__pos_0` payload holding the narrowed value.  Callers narrow a
+    /// list/str/bytes index or a byte value; overflow raises a Python
+    /// `IndexError`/`ValueError`, so the fallibility must survive the
+    /// lowering — a panic-residual swap would be a bit-exact regression.
+    ///
+    /// The arg type — not the module path — is the robust discriminator
+    /// (same philosophy as the BigInt binary-operator retarget), so this
+    /// guards on the opaque `BigInt` ADT rather than hard-matching
+    /// `malachite_bigint`.
+    ///
+    /// # Eager-payload panic hazard
+    /// [`Self::emit_tagged_pair_aggregate`] writes `__pos_0 = payload`
+    /// UNCONDITIONALLY in the call's block, before the consumer's
+    /// discriminant switch runs in a successor block.  A
+    /// [`jit_bigint_to_i64_value`] payload PANICS on overflow, so on a
+    /// non-fitting index (`lst[2**100]`) it would panic in the
+    /// walker/blackhole graph BEFORE the switch routes to the `Err` arm —
+    /// panic instead of `IndexError`.  `__pos_0` is read only on the
+    /// fits (`Ok`) path, so its value is dead on the `Err` path; the
+    /// payload op only needs to be TOTAL, not correct-on-overflow.  Hence
+    /// the non-trapping [`jit_bigint_to_i64_value_or_zero`] variant, which
+    /// returns 0 out of range.
+    ///
+    /// `Ok=0`/`Err=1`: `disc = (fits == 0)` is 0 when it fits (`Ok` tag)
+    /// and 1 otherwise (`Err` tag).
+    fn try_lower_bigint_i64_try_from(
+        &mut self,
+        mir_bb: usize,
+        kind: &CallKind,
+        segments: &[String],
+        args: &[Variable],
+        dest_local: usize,
+        dest_ty: &TyRef,
+        target: usize,
+    ) -> Result<bool, LowerError> {
+        let [.., impl_seg, leaf] = segments else {
+            return Ok(false);
+        };
+        if impl_seg.as_str() != "<Impl>" || leaf.as_str() != "try_from" {
+            return Ok(false);
+        }
+        let [arg] = args else {
+            return Ok(false);
+        };
+        // Guard on the ARG type (the opaque BigInt ADT), not the module
+        // path — the robust discriminator, so a same-named `try_from`
+        // impl on any other type is never redirected.  The narrowed
+        // operand is the receiver — `try_from(&BigInt)` — so read
+        // `inputs[0]`.
+        let CallKind::Fun(FunId::Regular { id }) = kind else {
+            return Ok(false);
+        };
+        let Some(fd) = self.llbc.fn_by_id(*id) else {
+            return Ok(false);
+        };
+        let Some(src) = fd.signature.inputs.first() else {
+            return Ok(false);
+        };
+        if !tyref_is_opaque_bigint(src, self.llbc) {
+            return Ok(false);
+        }
+        // Resolve the destination `Result` decl so the FieldWrite owner
+        // matches what `resolve_aggregate_adt` would record for a real
+        // `Ok(..)` construction site of the same type.
+        let Some(def_id) = self.tyref_adt_def_id(dest_ty) else {
+            return Ok(false);
+        };
+        let Some(td) = self.llbc.type_by_id(def_id) else {
+            return Ok(false);
+        };
+        // Route the runtime-discriminant tagged-pair ctor to the SAME
+        // per-instantiation enum root a static `Ok(..)`/`Err(..)` mints,
+        // by suffixing the bare template name with the `<X>` the
+        // destination `Result<X, E>` local carries.
+        // Fail-closed: no splitting generic yields "" → bare owner.
+        let owner = format!(
+            "{}{}",
+            td.item_meta.name_path(),
+            tyref_enum_instantiation_suffix(dest_ty, self.llbc)
+        );
+        let arg = arg.clone();
+        let bb_id = self.block_id[mir_bb];
+
+        let push_op = |graph: &mut FunctionGraph, kind: OpKind| {
+            let res = graph.alloc_value_var_with_type(crate::model::ConcreteType::Unknown);
+            graph.block_mut(bb_id).operations.push(SpaceOperation {
+                result: Some(res.clone()),
+                kind,
+            });
+            res
+        };
+        // Non-trapping payload: read only on the fits (`Ok`) path, dead on
+        // the `Err` path, but eagerly evaluated in this block — must not
+        // panic on overflow (see the eager-payload hazard above).
+        let payload = push_op(
+            &mut self.graph,
+            OpKind::Call {
+                target: CallTarget::FunctionPath {
+                    segments: vec![
+                        "pyre_object".to_string(),
+                        "longobject".to_string(),
+                        "jit_bigint_to_i64_value_or_zero".to_string(),
+                    ],
+                },
+                args: vec![arg.clone()],
+                result_ty: ValueType::Int,
+            },
+        );
+        let fits = push_op(
+            &mut self.graph,
+            OpKind::Call {
+                target: CallTarget::FunctionPath {
+                    segments: vec![
+                        "pyre_object".to_string(),
+                        "longobject".to_string(),
+                        "jit_bigint_to_i64_fits".to_string(),
+                    ],
+                },
+                args: vec![arg],
+                result_ty: ValueType::Int,
+            },
+        );
+        let zero = push_op(&mut self.graph, OpKind::ConstInt(0));
+        // `disc = (fits == 0)`: 0 when it fits (`Ok` tag), 1 otherwise
+        // (`Err` tag) — matching the `Ok=0`/`Err=1` convention.
+        let disc = push_op(
+            &mut self.graph,
+            OpKind::BinOp {
+                op: "eq".to_string(),
+                lhs: fits,
+                rhs: zero,
+                result_ty: ValueType::Int,
+            },
+        );
+        // Success is the `Ok` variant (discriminant 0).
+        let payload_owner =
+            Self::tagged_pair_payload_owner(td, &owner, 0).unwrap_or_else(|| owner.clone());
         self.emit_tagged_pair_aggregate(
             mir_bb,
             &owner,

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -5504,7 +5504,9 @@ impl<'a> Lowering<'a> {
                 // the destination to the receiver instead of emitting an
                 // `as_ref` method call the rtyper cannot route on the
                 // classdef-less string receiver.
-                if args.len() == 1 && self.is_string_to_str_identity(&reg, &call.dest.ty) {
+                if args.len() == 1
+                    && self.is_string_to_str_identity(&reg, first_arg_ty.as_ref(), &call.dest.ty)
+                {
                     self.local_var[dest_local] = Some(args[0].clone());
                     let target_bb = self.block_id[target];
                     let link_args = self.edge_args(mir_bb, target)?;
@@ -5531,7 +5533,7 @@ impl<'a> Lowering<'a> {
                 // let a char read byte-compare) without lowering a real
                 // byte-slice view here first, or those indexed uses would
                 // silently gain character semantics.
-                if args.len() == 1 && self.is_string_as_bytes_identity(&reg) {
+                if args.len() == 1 && self.is_string_as_bytes_identity(&reg, first_arg_ty.as_ref()) {
                     self.local_var[dest_local] = Some(args[0].clone());
                     let target_bb = self.block_id[target];
                     let link_args = self.edge_args(mir_bb, target)?;
@@ -7389,20 +7391,27 @@ impl<'a> Lowering<'a> {
     }
 
     /// `<String as AsRef<str>>::as_ref(&self) -> &str`,
-    /// `String::as_str(&self) -> &str`, and
+    /// `String::as_str(&self) -> &str`, `Wtf8::as_str(&self) -> &str`, and
     /// `<String as Borrow<str>>::borrow(&self) -> &str` — every one
     /// returns a `&str` view of the same string, an identity in the
-    /// lifted value model (Rust `String`/`&str`/`str` all lower to the
-    /// immutable rpy_string).  Without the intercept the call keeps a
-    /// `CallTarget::Method` `as_ref` getattr the rtyper cannot route on
-    /// the classdef-less string receiver (the `Cannot find attribute
-    /// "as_ref" on UnicodeString` wall).  Bind the destination to the
-    /// receiver instead, the same alias shape as the container deref
-    /// above.  Gated on the `str`-typed result so `String`'s sibling
-    /// `AsRef<[u8]>` / `AsRef<OsStr>` / `AsRef<Path>` impls — whose
-    /// `&[u8]`/etc. result is a *different* value-model family — keep
-    /// their ordinary lowering.
-    fn is_string_to_str_identity(&self, reg: &RegularCall, dest_ty: &TyRef) -> bool {
+    /// lifted value model (Rust `String`/`&str`/`str`/`Wtf8`/`Wtf8Buf`
+    /// all lower to the immutable rpy_string).  Without the intercept the
+    /// call keeps a `CallTarget::Method` `as_ref` getattr the rtyper
+    /// cannot route on the classdef-less string receiver (the `Cannot
+    /// find attribute "as_ref" on UnicodeString` wall).  Bind the
+    /// destination to the receiver instead, the same alias shape as the
+    /// container deref above.  Gated on the receiver being a string value
+    /// (`tyref_is_string_value`: `str`/`String`/`Wtf8`/`Wtf8Buf`), more
+    /// precise than the impl owner-leaf, plus the `str`-typed result so
+    /// `String`'s sibling `AsRef<[u8]>` / `AsRef<OsStr>` / `AsRef<Path>`
+    /// impls — whose `&[u8]`/etc. result is a *different* value-model
+    /// family — keep their ordinary lowering.
+    fn is_string_to_str_identity(
+        &self,
+        reg: &RegularCall,
+        first_arg_ty: Option<&TyRef>,
+        dest_ty: &TyRef,
+    ) -> bool {
         let CallKind::Fun(FunId::Regular { id }) = &reg.kind else {
             return false;
         };
@@ -7416,7 +7425,7 @@ impl<'a> Lowering<'a> {
         if !matches!(leaf, "as_ref" | "as_str" | "borrow") {
             return false;
         }
-        if deref_impl_owner_leaf(self.llbc, fd).as_deref() != Some("String") {
+        if !first_arg_ty.is_some_and(|ty| tyref_is_string_value(ty, self.llbc)) {
             return false;
         }
         tyref_strips_to_str(dest_ty, self.llbc)
@@ -7429,9 +7438,23 @@ impl<'a> Lowering<'a> {
     /// identity on the receiver — unlike the `&[u8]` family the `as_str`
     /// gate above excludes via `tyref_strips_to_str`, the byte view of a
     /// *string* receiver re-meets that same string value.  Gated on the
-    /// impl owner being a string-family type so a non-string `as_bytes`
-    /// (a real byte-buffer producer) keeps its ordinary lowering.
-    fn is_string_as_bytes_identity(&self, reg: &RegularCall) -> bool {
+    /// receiver being a string value (`tyref_is_string_value`:
+    /// `str`/`String`/`Wtf8`/`Wtf8Buf`), more precise than the impl
+    /// owner-leaf, so a non-string `as_bytes` (a real byte-buffer
+    /// producer) fails the gate and keeps its ordinary lowering.
+    ///
+    /// Sound only for len / equality / iteration consumers.  A scalar
+    /// index (`as_bytes()[i]`) lowers to `getitem` on `StringRepr`, which
+    /// yields a `Char`, not the `u8` the Rust source expects; there is no
+    /// `(CharRepr, IntegerRepr)` eq/arithmetic pairtype, so such a use
+    /// fails rtype and residualizes rather than miscompiling.  Do NOT add
+    /// a `(CharRepr, IntegerRepr)` eq arm without lowering a real
+    /// byte-slice view first.
+    fn is_string_as_bytes_identity(
+        &self,
+        reg: &RegularCall,
+        first_arg_ty: Option<&TyRef>,
+    ) -> bool {
         let CallKind::Fun(FunId::Regular { id }) = &reg.kind else {
             return false;
         };
@@ -7441,10 +7464,7 @@ impl<'a> Lowering<'a> {
         if fd.item_meta.name_path().rsplit("::").next() != Some("as_bytes") {
             return false;
         }
-        matches!(
-            deref_impl_owner_leaf(self.llbc, fd).as_deref(),
-            Some("String" | "str" | "Wtf8" | "Wtf8Buf")
-        )
+        first_arg_ty.is_some_and(|ty| tyref_is_string_value(ty, self.llbc))
     }
 
     /// `<str as ToString>::to_string` / `<String as ToString>::to_string`

--- a/majit/majit-translate/src/front/mod.rs
+++ b/majit/majit-translate/src/front/mod.rs
@@ -78,6 +78,7 @@ pub(crate) mod option_map_or;
 pub(crate) mod option_try;
 pub(crate) mod option_unwrap;
 pub(crate) mod option_unwrap_or;
+pub(crate) mod range_contains;
 pub(crate) mod result_exc;
 pub mod semantic;
 pub mod typestr;

--- a/majit/majit-translate/src/front/range_contains.rs
+++ b/majit/majit-translate/src/front/range_contains.rs
@@ -70,7 +70,9 @@
 //! census Skip) — no regression.
 
 use crate::flowspace::model::Variable;
-use crate::model::{BlockId, CallTarget, FunctionGraph, LinkArg, OpKind, SpaceOperation, ValueType};
+use crate::model::{
+    BlockId, CallTarget, FunctionGraph, LinkArg, OpKind, SpaceOperation, ValueType,
+};
 
 /// A recognized `RangeInclusive::new(lo, hi)` call site captured during
 /// body lowering (`front::mir`).  Carries the result var (the range) and
@@ -216,14 +218,8 @@ fn rewire_one_range_contains_site(
     //    place and reusing its result Variable for the final `bitand`.
     let lo_le = graph.alloc_value_var();
     let hi_ge = graph.alloc_value_var();
-    let inserts = build_range_contains_compares(
-        &site.result_var,
-        lo_in_c,
-        hi_in_c,
-        x,
-        lo_le,
-        hi_ge,
-    );
+    let inserts =
+        build_range_contains_compares(&site.result_var, lo_in_c, hi_in_c, x, lo_le, hi_ge);
     let ops = &mut graph.blocks[c_idx].operations;
     ops.remove(call_idx);
     for (offset, op) in inserts.into_iter().enumerate() {
@@ -307,11 +303,7 @@ fn range_matches_new_site(
 /// single-predecessor edges only — the precondition under which
 /// [`FunctionGraph::ensure_variable_at_block`] threads cleanly.  Mirrors
 /// the private helper of the same name in `model::thread_undefined_op_operands`.
-fn defined_via_single_pred_chain(
-    graph: &FunctionGraph,
-    block: BlockId,
-    var: &Variable,
-) -> bool {
+fn defined_via_single_pred_chain(graph: &FunctionGraph, block: BlockId, var: &Variable) -> bool {
     let mut cur = block;
     let mut seen: std::collections::HashSet<BlockId> = std::collections::HashSet::new();
     loop {
@@ -335,8 +327,7 @@ fn defined_via_single_pred_chain(
 /// `ensure_variable_at_block` succeeds on; checked first so a
 /// multi-predecessor / orphan case declines instead of panicking.
 fn can_thread_to_block(graph: &FunctionGraph, block: BlockId, var: &Variable) -> bool {
-    graph.variable_defined_in_block(block, var)
-        || defined_via_single_pred_chain(graph, block, var)
+    graph.variable_defined_in_block(block, var) || defined_via_single_pred_chain(graph, block, var)
 }
 
 /// `true` when the range value is CONSUMED by exactly the one

--- a/majit/majit-translate/src/front/range_contains.rs
+++ b/majit/majit-translate/src/front/range_contains.rs
@@ -1,0 +1,703 @@
+//! `(a..=b).contains(&x)` → `bitand(le(a, x), ge(b, x))`.
+//!
+//! ## Positioning
+//!
+//! `RangeInclusive::new(a, b)` has an Opaque body in the LLBC, so the
+//! front emits a residual `FunctionPath` call whose owner-qualified
+//! segments end `["range", "RangeInclusive", "new"]` — an unregistered
+//! callee the rtyper census Skips, dropping the enclosing graph to the
+//! legacy walker.  `RangeInclusive::contains(&self, &x)` routes as an
+//! owner-qualified `FunctionPath` too (the opaque foreign receiver has no
+//! extracted body to route a `CallTarget::Method` through), ending
+//! `["range", "RangeInclusive", "contains"]` with `args[0]` the
+//! `&RangeInclusive` receiver and `args[1]` the `&x` value.  `new` is the
+//! wall: it is emitted before `contains`, so the translation loop's
+//! failure surfaces on `new` first.
+//!
+//! The membership test `a <= x && b >= x` has a native lowering — two
+//! integer comparisons joined by a native bitwise-and, exactly the
+//! `a <= x <= b` shape the rtyper lowers.  This pass reproduces it:
+//!
+//! ```text
+//!     r = RangeInclusive::new(a, b)          // residual `new` call (block N)
+//!     ...
+//!     t = r.contains(&x)                     // residual `contains` call (block C)
+//! becomes
+//!     lo_le  = le(a, x)                      // a <= x
+//!     hi_ge  = ge(b, x)                      // b >= x
+//!     t      = bitand(lo_le, hi_ge)          // (block C)
+//! ```
+//!
+//! `le` / `ge` / `bitand` are all pure native binops (CSE/DCE-safe);
+//! `bitand`, not bare `and`, is emitted — bare `and`/`or` are reserved
+//! for short-circuit control flow and rejected downstream.
+//!
+//! ## Cross-block shape
+//!
+//! Each `TermKind::Call` closes its block with a `set_goto`, so `new`
+//! (block N) and `contains` (block C) sit in adjacent blocks, C the
+//! single successor of N's Call edge.  The `new` result rides N → C on a
+//! goto link arg; the front's liveness-forwarding keeps the same
+//! `Variable` identity across the edge (and onward toward the value's
+//! drop), so the `contains` receiver may be that same Variable or a
+//! fresh C inputarg fed positionally from it (framestate SSA).  The fold
+//! traces the receiver back through the single-predecessor link-arg
+//! chain to its `new` site, then threads the bounds `a` / `b` into block
+//! C via [`FunctionGraph::ensure_variable_at_block`] (the same
+//! single-predecessor carry-through) before splicing the compares.
+//!
+//! ## Why `new` must be removed explicitly
+//!
+//! No sweep reclaims a dead `OpKind::Call { FunctionPath }`: `is_pure_op`
+//! returns `false` for `Call`, so `prune_dead_phis` never removes it, and
+//! `remove_dead_aggregates` only handles `SyntheticTransparentCtor` +
+//! `Box::new_uninit`.  A fold that emits the compares at `contains` and
+//! lets `new` "die" is UNSAFE — the orphaned `new` still walls the graph.
+//! So the fold removes the `new` call op itself; the now-dead threaded
+//! range value / link args are reclaimed by `prune_dead_phis` (the caller
+//! runs it after any rewrite).
+//!
+//! ## Scope + fail-safe
+//!
+//! Int-only.  Float ranges (`complex_pow`), exclusive `Range`, and the
+//! pyre `W_Range` Python object are out of scope.  Iteration-form ranges
+//! (`for i in a..=b`) are excluded by the consumer-shape gate: an
+//! iterator reads the range a second time (its stateful `exhausted`
+//! field) as an OP operand, so a range value read by any op other than
+//! the single `contains` being folded declines.  Link-arg threading of
+//! the range value is liveness forwarding, not consumption, so it does
+//! not count.  Every mismatch declines (leaves BOTH residual calls,
+//! census Skip) — no regression.
+
+use crate::flowspace::model::Variable;
+use crate::model::{BlockId, CallTarget, FunctionGraph, LinkArg, OpKind, SpaceOperation, ValueType};
+
+/// A recognized `RangeInclusive::new(lo, hi)` call site captured during
+/// body lowering (`front::mir`).  Carries the result var (the range) and
+/// the two int bounds so the fold can thread them into the `contains`
+/// block.
+#[derive(Clone)]
+pub(crate) struct RangeInclusiveNewSite {
+    /// The `new` call result (the `RangeInclusive` value) — locates the
+    /// producer op and matches the `contains` receiver.
+    pub result_var: Variable,
+    /// Lower bound `a` — the `le(a, x)` left operand.
+    pub lo: Variable,
+    /// Upper bound `b` — the `ge(b, x)` left operand.
+    pub hi: Variable,
+}
+
+/// A recognized `RangeInclusive::contains(&self, &x)` call site captured
+/// during body lowering (`front::mir`).  Carries the result var (the
+/// membership bool) — the fold reuses it for the final `bitand`.
+#[derive(Clone)]
+pub(crate) struct RangeContainsSite {
+    /// The `contains` call result (the membership `bool`) — locates the
+    /// producer op; reused as the `bitand` result.
+    pub result_var: Variable,
+}
+
+/// Rewrite every recorded `(a..=b).contains(&x)` call site into the
+/// native `bitand(le(a, x), ge(b, x))` compare pair.  Fail-safe: a site
+/// that does not match the expected cross-block `new` → `contains` shape
+/// is left untouched (both residual calls survive, census Skip).  Returns
+/// the number of sites rewritten.
+pub(crate) fn rewire_range_contains_call_sites(
+    graph: &mut FunctionGraph,
+    new_sites: &[RangeInclusiveNewSite],
+    contains_sites: &[RangeContainsSite],
+) -> usize {
+    let mut rewritten = 0;
+    for site in contains_sites {
+        match rewire_one_range_contains_site(graph, site, new_sites) {
+            Ok(()) => rewritten += 1,
+            Err(_decline) => {
+                // Leave both residual calls; the unregistered `new`
+                // callee keeps the rtyper census Skip for this graph.
+            }
+        }
+    }
+    rewritten
+}
+
+fn rewire_one_range_contains_site(
+    graph: &mut FunctionGraph,
+    site: &RangeContainsSite,
+    new_sites: &[RangeInclusiveNewSite],
+) -> Result<(), String> {
+    let name = graph.name.clone();
+
+    // 1. Locate the `contains` producer op + its block C.
+    let (c_idx, call_idx) = graph
+        .blocks
+        .iter()
+        .enumerate()
+        .find_map(|(bi, b)| {
+            b.operations
+                .iter()
+                .position(|op| op.result.as_ref() == Some(&site.result_var))
+                .map(|oi| (bi, oi))
+        })
+        .ok_or_else(|| format!("{name}: range contains result var has no producer op"))?;
+
+    // 2. The producer must be the 2-arg `contains` call: `args[0]` the
+    //    `&RangeInclusive` receiver, `args[1]` the `&x` value.  The
+    //    receiver's opaque foreign ADT routes it as an owner-qualified
+    //    `FunctionPath` ending `["range", "RangeInclusive", "contains"]`
+    //    (not a `CallTarget::Method`).
+    let (range_v, x) = match &graph.blocks[c_idx].operations[call_idx].kind {
+        OpKind::Call {
+            target: CallTarget::FunctionPath { segments },
+            args,
+            ..
+        } if segments_end_with(segments, &["range", "RangeInclusive", "contains"])
+            && args.len() == 2 =>
+        {
+            (args[0].clone(), args[1].clone())
+        }
+        other => {
+            return Err(format!(
+                "{name}: range contains producer op is not the 2-arg `contains` FunctionPath: {other:?}"
+            ));
+        }
+    };
+
+    // 3. Match the `RangeInclusiveNewSite` whose `result_var` threads to
+    //    block C.  `new` is in block N (a single predecessor of C) and
+    //    its result rides a goto link-arg that becomes a C inputarg, so
+    //    `range_v` (the C-local receiver) is a distinct Variable.  A
+    //    site matches when its `result_var` is defined in a block
+    //    reachable from C through single-predecessor edges only AND the
+    //    receiver `range_v` is either that same Variable (rare, when
+    //    identity is preserved) or a C inputarg fed exclusively from that
+    //    definition.  The single-consumer gate below is what makes this
+    //    sound; here we only need to pick the producing site.
+    let c_block = graph.blocks[c_idx].id;
+    let new_site = new_sites
+        .iter()
+        .find(|s| range_matches_new_site(graph, c_block, &range_v, &s.result_var))
+        .ok_or_else(|| {
+            format!("{name}: range contains receiver traces to no RangeInclusive::new site")
+        })?;
+
+    // 4. Consumer-shape gate (excludes iteration-form ranges, whose
+    //    range carries a stateful `exhausted` field read a second time by
+    //    an iterator's `into_iter` / `next`).  The range value must be
+    //    read as an OP operand by exactly the `contains` op being folded —
+    //    link-arg threading of the same Variable is liveness forwarding,
+    //    not consumption.  Any other op reading the range declines.
+    if !range_value_single_op_consumer(graph, &new_site.result_var, &range_v, &site.result_var) {
+        return Err(format!(
+            "{name}: range value has a second op consumer — declining (iteration form?)"
+        ));
+    }
+
+    // 5. Thread `lo` / `hi` into block C as inputargs (single-pred carry-
+    //    through).  Decline if either cannot be threaded (orphan / multi-
+    //    predecessor block) rather than panicking.
+    if !can_thread_to_block(graph, c_block, &new_site.lo)
+        || !can_thread_to_block(graph, c_block, &new_site.hi)
+    {
+        return Err(format!(
+            "{name}: RangeInclusive::new bounds cannot thread to the contains block"
+        ));
+    }
+    let lo_in_c = new_site.lo.clone();
+    let hi_in_c = new_site.hi.clone();
+    let ok = graph.ensure_variable_at_block(c_block, &lo_in_c)
+        && graph.ensure_variable_at_block(c_block, &hi_in_c);
+    if !ok {
+        return Err(format!(
+            "{name}: RangeInclusive::new bounds threading failed at the contains block"
+        ));
+    }
+
+    // 6. Splice the compares into block C, replacing the `contains` op in
+    //    place and reusing its result Variable for the final `bitand`.
+    let lo_le = graph.alloc_value_var();
+    let hi_ge = graph.alloc_value_var();
+    let inserts = build_range_contains_compares(
+        &site.result_var,
+        lo_in_c,
+        hi_in_c,
+        x,
+        lo_le,
+        hi_ge,
+    );
+    let ops = &mut graph.blocks[c_idx].operations;
+    ops.remove(call_idx);
+    for (offset, op) in inserts.into_iter().enumerate() {
+        ops.insert(call_idx + offset, op);
+    }
+
+    // 7. Remove the now-unread `new` call op in its block N.  After
+    //    removal `lo` / `hi` stay live (threaded to C); the dead threaded
+    //    range inputarg / link args are reclaimed by `prune_dead_phis`.
+    remove_op_by_result(graph, &new_site.result_var);
+
+    Ok(())
+}
+
+/// `true` when the block-C receiver `range_v` is fed exactly by the
+/// `new` result `new_result` — either the same Variable (identity
+/// preserved across the boundary) or a C inputarg threaded from
+/// `new_result` through a single-predecessor link-arg chain.
+///
+/// The trace is positional and exact so that a body containing two
+/// distinct `a..=b` ranges never pairs a `contains` with the wrong
+/// `new` (which would splice the wrong bounds): at each level the
+/// receiver must be an inputarg whose SINGLE predecessor supplies the
+/// value at the matching link-arg index, recursing on that supplied
+/// Variable until it either reaches `new_result` (match) or a block that
+/// defines it via an op (must then equal `new_result`).
+fn range_matches_new_site(
+    graph: &FunctionGraph,
+    c_block: BlockId,
+    range_v: &Variable,
+    new_result: &Variable,
+) -> bool {
+    let mut cur_block = c_block;
+    let mut cur_var = range_v.clone();
+    let mut seen: std::collections::HashSet<BlockId> = std::collections::HashSet::new();
+    loop {
+        if &cur_var == new_result {
+            return true;
+        }
+        if !seen.insert(cur_block) {
+            return false;
+        }
+        // `cur_var` must be a block inputarg to trace across the edge;
+        // if it is defined by an op in `cur_block` and is not
+        // `new_result`, it is a different value — no match.
+        let Some(arg_idx) = graph
+            .block(cur_block)
+            .inputargs
+            .iter()
+            .position(|v| v == &cur_var)
+        else {
+            return false;
+        };
+        // Exactly one predecessor edge, carrying the source at `arg_idx`.
+        let pred_edges: Vec<(BlockId, usize)> = graph
+            .blocks
+            .iter()
+            .flat_map(|b| {
+                let bid = b.id;
+                b.exits
+                    .iter()
+                    .enumerate()
+                    .filter(move |(_, e)| e.target == cur_block)
+                    .map(move |(i, _)| (bid, i))
+            })
+            .collect();
+        if pred_edges.len() != 1 {
+            return false;
+        }
+        let (pred_block, exit_idx) = pred_edges[0];
+        let Some(LinkArg::Value(src)) = graph.block(pred_block).exits[exit_idx].args.get(arg_idx)
+        else {
+            return false;
+        };
+        cur_var = src.clone();
+        cur_block = pred_block;
+    }
+}
+
+/// `var` is defined in a block reachable from `block` by walking
+/// single-predecessor edges only — the precondition under which
+/// [`FunctionGraph::ensure_variable_at_block`] threads cleanly.  Mirrors
+/// the private helper of the same name in `model::thread_undefined_op_operands`.
+fn defined_via_single_pred_chain(
+    graph: &FunctionGraph,
+    block: BlockId,
+    var: &Variable,
+) -> bool {
+    let mut cur = block;
+    let mut seen: std::collections::HashSet<BlockId> = std::collections::HashSet::new();
+    loop {
+        if !seen.insert(cur) {
+            return false;
+        }
+        let preds = graph.predecessors(cur);
+        if preds.len() != 1 {
+            return false;
+        }
+        let p = preds[0];
+        if graph.variable_defined_in_block(p, var) {
+            return true;
+        }
+        cur = p;
+    }
+}
+
+/// A `var` can be threaded to `block` iff it is already defined there or
+/// reachable through a single-predecessor chain.  Same predicate
+/// `ensure_variable_at_block` succeeds on; checked first so a
+/// multi-predecessor / orphan case declines instead of panicking.
+fn can_thread_to_block(graph: &FunctionGraph, block: BlockId, var: &Variable) -> bool {
+    graph.variable_defined_in_block(block, var)
+        || defined_via_single_pred_chain(graph, block, var)
+}
+
+/// `true` when the range value is CONSUMED by exactly the one
+/// `contains` op being folded — the consumer-shape gate that excludes
+/// iteration-form ranges (whose range carries a stateful `exhausted`
+/// field an iterator's `into_iter` / `next` reads a second time).
+///
+/// "Consumed" means read as an OP operand — NOT threaded on a link arg.
+/// The front models a value that outlives its defining block by reusing
+/// the SAME `Variable` identity across the intervening blocks' link args
+/// (liveness forwarding toward its eventual drop), so the range's
+/// `new_result` legitimately appears on many `Link.args`; those are not
+/// consumers.  The gate therefore counts only op-operand reads of the
+/// range value — of `new_result` itself and, when the front minted a
+/// fresh C-inputarg for the receiver (framestate SSA), of `receiver` —
+/// and requires every such read to belong to the single `contains` op
+/// (result `contains_result`).  Any other op reading the range (an
+/// iterator, a second `contains`, a `clone`) is a second consumer →
+/// decline.  A range value driving an `exitswitch` also declines.
+fn range_value_single_op_consumer(
+    graph: &FunctionGraph,
+    new_result: &Variable,
+    receiver: &Variable,
+    contains_result: &Variable,
+) -> bool {
+    let is_range_value = |v: &Variable| v == new_result || v == receiver;
+    for block in &graph.blocks {
+        for op in &block.operations {
+            let reads_range = crate::inline::op_variable_refs(&op.kind)
+                .iter()
+                .any(is_range_value);
+            if reads_range && op.result.as_ref() != Some(contains_result) {
+                // Some op other than the `contains` being folded reads
+                // the range value — a second consumer (iteration form?).
+                return false;
+            }
+        }
+        match &block.exitswitch {
+            Some(crate::model::ExitSwitch::Value(v)) if is_range_value(v) => return false,
+            Some(crate::model::ExitSwitch::Fused { args, .. })
+                if args.iter().any(is_range_value) =>
+            {
+                return false;
+            }
+            _ => {}
+        }
+    }
+    true
+}
+
+/// Match a `FunctionPath`'s trailing segments against `tail` so a
+/// crate-qualified spelling and the crate-stripped front-end spelling
+/// both resolve — the same contract as `front::mir::fmt_path_ends_with`.
+fn segments_end_with(segments: &[String], tail: &[&str]) -> bool {
+    segments.len() >= tail.len()
+        && segments[segments.len() - tail.len()..]
+            .iter()
+            .zip(tail)
+            .all(|(s, t)| s.as_str() == *t)
+}
+
+/// Remove the (single) op in the graph whose result is `result_var`.
+fn remove_op_by_result(graph: &mut FunctionGraph, result_var: &Variable) {
+    for block in &mut graph.blocks {
+        if let Some(i) = block
+            .operations
+            .iter()
+            .position(|op| op.result.as_ref() == Some(result_var))
+        {
+            block.operations.remove(i);
+            return;
+        }
+    }
+}
+
+/// Build the three native compare ops that replace `contains`:
+/// `lo_le = le(lo, x)`, `hi_ge = ge(hi, x)`, `result = bitand(lo_le, hi_ge)`.
+/// All `ValueType::Int` (bools fold to the int kind), reusing
+/// `result_var` for the final `bitand` so downstream reads are unchanged.
+fn build_range_contains_compares(
+    result_var: &Variable,
+    lo: Variable,
+    hi: Variable,
+    x: Variable,
+    lo_le: Variable,
+    hi_ge: Variable,
+) -> [SpaceOperation; 3] {
+    [
+        SpaceOperation {
+            result: Some(lo_le.clone()),
+            kind: OpKind::BinOp {
+                op: "le".to_string(),
+                lhs: lo,
+                rhs: x.clone(),
+                result_ty: ValueType::Int,
+            },
+        },
+        SpaceOperation {
+            result: Some(hi_ge.clone()),
+            kind: OpKind::BinOp {
+                op: "ge".to_string(),
+                lhs: hi,
+                rhs: x,
+                result_ty: ValueType::Int,
+            },
+        },
+        SpaceOperation {
+            result: Some(result_var.clone()),
+            kind: OpKind::BinOp {
+                op: "bitand".to_string(),
+                lhs: lo_le,
+                rhs: hi_ge,
+                result_ty: ValueType::Int,
+            },
+        },
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn new_target() -> CallTarget {
+        CallTarget::FunctionPath {
+            segments: ["core", "ops", "range", "RangeInclusive", "new"]
+                .iter()
+                .map(|s| s.to_string())
+                .collect(),
+        }
+    }
+
+    fn contains_target() -> CallTarget {
+        CallTarget::FunctionPath {
+            segments: ["core", "ops", "range", "RangeInclusive", "contains"]
+                .iter()
+                .map(|s| s.to_string())
+                .collect(),
+        }
+    }
+
+    /// Count `FunctionPath` calls whose segments end with `tail`.
+    fn functionpath_calls_ending(g: &FunctionGraph, tail: &[&str]) -> usize {
+        g.blocks
+            .iter()
+            .flat_map(|blk| &blk.operations)
+            .filter(|op| {
+                matches!(
+                    &op.kind,
+                    OpKind::Call {
+                        target: CallTarget::FunctionPath { segments },
+                        ..
+                    } if segments_end_with(segments, tail)
+                )
+            })
+            .count()
+    }
+
+    /// Result Variables of every `BinOp` with the given opname.
+    fn binop_results(g: &FunctionGraph, op_name: &str) -> Vec<Variable> {
+        g.blocks
+            .iter()
+            .flat_map(|blk| &blk.operations)
+            .filter_map(|sop| match &sop.kind {
+                OpKind::BinOp { op, .. } if op == op_name => sop.result.clone(),
+                _ => None,
+            })
+            .collect()
+    }
+
+    /// Build a two-block `new` → `contains` graph and assert the rewrite
+    /// drops both residual FunctionPath calls (`new` + `contains`) and
+    /// emits `le` / `ge` / `bitand` with the `bitand` bound to the
+    /// original `contains` result var.
+    #[test]
+    fn rewrite_folds_new_contains_to_compares() {
+        let mut g = FunctionGraph::new("test_range_contains");
+        let n = g.startblock;
+        let a = g.push_op_var(n, OpKind::ConstInt(0), true).unwrap();
+        let b = g.push_op_var(n, OpKind::ConstInt(255), true).unwrap();
+        let range = g
+            .push_op_var(
+                n,
+                OpKind::Call {
+                    target: new_target(),
+                    args: vec![a.clone(), b.clone()],
+                    result_ty: ValueType::Ref(Some("RangeInclusive".into())),
+                },
+                true,
+            )
+            .unwrap();
+        // Block C: one inputarg = the threaded range receiver.
+        let (c, c_args) = g.create_block_with_arg_vars(1);
+        let range_in_c = c_args[0].clone();
+        let x = g.push_op_var(c, OpKind::ConstInt(42), true).unwrap();
+        let contains = g
+            .push_op_var(
+                c,
+                OpKind::Call {
+                    target: contains_target(),
+                    args: vec![range_in_c.clone(), x.clone()],
+                    result_ty: ValueType::Int,
+                },
+                true,
+            )
+            .unwrap();
+        g.set_return(c, Some(contains.clone()));
+        g.set_goto(n, c, vec![range.clone()]);
+
+        let rewritten = rewire_range_contains_call_sites(
+            &mut g,
+            &[RangeInclusiveNewSite {
+                result_var: range.clone(),
+                lo: a.clone(),
+                hi: b.clone(),
+            }],
+            &[RangeContainsSite {
+                result_var: contains.clone(),
+            }],
+        );
+        assert_eq!(rewritten, 1, "the contains site must be rewritten");
+        assert_eq!(
+            functionpath_calls_ending(&g, &["range", "RangeInclusive", "new"]),
+            0,
+            "residual new removed",
+        );
+        assert_eq!(
+            functionpath_calls_ending(&g, &["range", "RangeInclusive", "contains"]),
+            0,
+            "residual contains removed",
+        );
+        assert_eq!(binop_results(&g, "le").len(), 1, "one `le` compare emitted");
+        assert_eq!(binop_results(&g, "ge").len(), 1, "one `ge` compare emitted");
+        let bitands = binop_results(&g, "bitand");
+        assert_eq!(bitands.len(), 1, "one `bitand` emitted");
+        assert_eq!(
+            bitands[0], contains,
+            "the bitand reuses the original contains result var",
+        );
+    }
+
+    /// A second consumer of the range result (an iterator's stateful
+    /// read, modeled here as a dummy op reading the threaded receiver)
+    /// declines the fold.
+    #[test]
+    fn rewrite_declines_when_range_has_second_consumer() {
+        let mut g = FunctionGraph::new("test_range_contains_second_consumer");
+        let n = g.startblock;
+        let a = g.push_op_var(n, OpKind::ConstInt(0), true).unwrap();
+        let b = g.push_op_var(n, OpKind::ConstInt(255), true).unwrap();
+        let range = g
+            .push_op_var(
+                n,
+                OpKind::Call {
+                    target: new_target(),
+                    args: vec![a.clone(), b.clone()],
+                    result_ty: ValueType::Ref(Some("RangeInclusive".into())),
+                },
+                true,
+            )
+            .unwrap();
+        // Second consumer: another op reads the `new` result directly.
+        let _second = g.push_op_var(
+            n,
+            OpKind::UnaryOp {
+                op: "invert".to_string(),
+                operand: range.clone(),
+                result_ty: ValueType::Ref(None),
+            },
+            true,
+        );
+        let (c, c_args) = g.create_block_with_arg_vars(1);
+        let range_in_c = c_args[0].clone();
+        let x = g.push_op_var(c, OpKind::ConstInt(42), true).unwrap();
+        let contains = g
+            .push_op_var(
+                c,
+                OpKind::Call {
+                    target: contains_target(),
+                    args: vec![range_in_c.clone(), x.clone()],
+                    result_ty: ValueType::Int,
+                },
+                true,
+            )
+            .unwrap();
+        g.set_return(c, Some(contains.clone()));
+        g.set_goto(n, c, vec![range.clone()]);
+
+        let rewritten = rewire_range_contains_call_sites(
+            &mut g,
+            &[RangeInclusiveNewSite {
+                result_var: range.clone(),
+                lo: a,
+                hi: b,
+            }],
+            &[RangeContainsSite {
+                result_var: contains,
+            }],
+        );
+        assert_eq!(rewritten, 0, "a second range consumer declines the fold");
+        assert_eq!(
+            functionpath_calls_ending(&g, &["range", "RangeInclusive", "new"]),
+            1,
+            "residual new survives",
+        );
+        assert_eq!(
+            functionpath_calls_ending(&g, &["range", "RangeInclusive", "contains"]),
+            1,
+            "residual contains survives",
+        );
+    }
+
+    /// A producer that is not the 2-arg `contains` FunctionPath (here a
+    /// 1-arg call) declines (fail-safe).
+    #[test]
+    fn rewrite_declines_when_producer_not_contains_method() {
+        let mut g = FunctionGraph::new("test_range_contains_wrong_producer");
+        let n = g.startblock;
+        let a = g.push_op_var(n, OpKind::ConstInt(0), true).unwrap();
+        let b = g.push_op_var(n, OpKind::ConstInt(255), true).unwrap();
+        let range = g
+            .push_op_var(
+                n,
+                OpKind::Call {
+                    target: new_target(),
+                    args: vec![a.clone(), b.clone()],
+                    result_ty: ValueType::Ref(Some("RangeInclusive".into())),
+                },
+                true,
+            )
+            .unwrap();
+        let (c, c_args) = g.create_block_with_arg_vars(1);
+        let range_in_c = c_args[0].clone();
+        // A 1-arg call — not the 2-arg `contains` FunctionPath shape.
+        let result = g
+            .push_op_var(
+                c,
+                OpKind::Call {
+                    target: contains_target(),
+                    args: vec![range_in_c.clone()],
+                    result_ty: ValueType::Int,
+                },
+                true,
+            )
+            .unwrap();
+        g.set_return(c, Some(result.clone()));
+        g.set_goto(n, c, vec![range.clone()]);
+
+        let rewritten = rewire_range_contains_call_sites(
+            &mut g,
+            &[RangeInclusiveNewSite {
+                result_var: range,
+                lo: a,
+                hi: b,
+            }],
+            &[RangeContainsSite { result_var: result }],
+        );
+        assert_eq!(rewritten, 0, "a non-2-arg `contains` producer declines");
+        assert_eq!(
+            functionpath_calls_ending(&g, &["range", "RangeInclusive", "new"]),
+            1,
+            "residual new survives",
+        );
+    }
+}

--- a/majit/majit-translate/src/model.rs
+++ b/majit/majit-translate/src/model.rs
@@ -2625,24 +2625,43 @@ pub fn remove_dead_aggregates(graph: &mut FunctionGraph) -> usize {
 /// The orphaned aggregate ctor + header `FieldWrite`s become dead and are swept
 /// by the `remove_dead_aggregates` + `prune_dead_phis` passes that follow in
 /// `simplify_lowered_graph`.
-pub fn fuse_boxing_alloc(graph: &mut FunctionGraph) -> usize {
+pub fn fuse_boxing_alloc(
+    graph: &mut FunctionGraph,
+    struct_field_attrs: &std::collections::HashMap<String, Vec<(String, ValueType)>>,
+) -> usize {
     use crate::flowspace::model::Variable;
-    // Recognised boxing structs and their scalar payload fields, in struct
-    // order.  The header (`ob_header`: ob_type + w_class) is NOT listed as a
-    // payload — its type pointer is captured separately into
+    // Derive a boxing struct's scalar payload fields from its registered field
+    // layout, in struct-declaration order, skipping the `ob_header` (PyObject
+    // base): the header's type pointer is captured separately into
     // `NewWithVtable.vtable` (see `resolve_vtable_addr`) and the runtime stamps
-    // `ob_type` / `w_class` from it, so only the scalar payload setfield(s) are
+    // `ob_type` / `w_class` from it, so only the non-header setfield(s) are
     // re-emitted (oracle: `box_trace.rs trace_box_float` / `trace_box_int`).
-    fn payload_fields(owner: &str) -> Option<&'static [(&'static str, ValueType)]> {
-        match owner {
-            "W_FloatObject" => Some(&[("floatval", ValueType::Float)]),
-            "W_IntObject" => Some(&[("intval", ValueType::Int)]),
-            "W_ComplexObject" => Some(&[("real", ValueType::Float), ("imag", ValueType::Float)]),
-            // `value: *mut BigInt` — a raw pointer payload, stored as a ref-kind
-            // setfield (`Ref(None)`, opaque pointee).
-            "W_LongObject" => Some(&[("value", ValueType::Ref(None))]),
-            _ => None,
-        }
+    // This mirrors the type-generic malloc lowering in the front end
+    // (`rbuiltin.py` `rtype_malloc` / `rclass.py` reads the lltype's field
+    // layout); `struct_field_attrs` is the already-computed layout map the
+    // front end owns, so this pass performs no front-end (Llbc) reads.
+    //
+    // The ctor carries the bare struct leaf (`W_FloatObject`) while the map is
+    // keyed by the crate-stripped qualified path (`floatobject::W_FloatObject`),
+    // so fall back to a leaf match when the exact key misses.  An unknown struct
+    // yields `None` and is left unfused — the same fail-safe the old hardcoded
+    // set applied to any struct outside the numeric four.
+    fn payload_fields(
+        owner: &str,
+        struct_field_attrs: &std::collections::HashMap<String, Vec<(String, ValueType)>>,
+    ) -> Option<Vec<(String, ValueType)>> {
+        let rows = struct_field_attrs.get(owner).or_else(|| {
+            struct_field_attrs
+                .iter()
+                .find(|(k, _)| k.rsplit("::").next() == Some(owner))
+                .map(|(_, v)| v)
+        })?;
+        Some(
+            rows.iter()
+                .filter(|(name, _)| name != "ob_header")
+                .cloned()
+                .collect(),
+        )
     }
 
     let is_malloc_typed = |target: &CallTarget| -> bool {
@@ -2748,7 +2767,7 @@ pub fn fuse_boxing_alloc(graph: &mut FunctionGraph) -> usize {
                     _ => None,
                 });
             let Some(owner) = owner else { continue };
-            let Some(fields) = payload_fields(&owner) else {
+            let Some(fields) = payload_fields(&owner, struct_field_attrs) else {
                 continue;
             };
             // Resolve every payload field's store: `FieldWrite { base: %agg,
@@ -2757,7 +2776,7 @@ pub fn fuse_boxing_alloc(graph: &mut FunctionGraph) -> usize {
             // than emitting a half-initialised allocation.
             let mut payloads = Vec::with_capacity(fields.len());
             let mut complete = true;
-            for &(field_name, ref payload_ty) in fields {
+            for (field_name, payload_ty) in &fields {
                 let found = graph
                     .blocks
                     .iter()
@@ -2765,7 +2784,7 @@ pub fn fuse_boxing_alloc(graph: &mut FunctionGraph) -> usize {
                     .find_map(|o| match &o.kind {
                         OpKind::FieldWrite {
                             base, field, value, ..
-                        } if base == agg && field.name.as_str() == field_name => {
+                        } if base == agg && field.name.as_str() == field_name.as_str() => {
                             Some((field.clone(), value.clone()))
                         }
                         _ => None,
@@ -2841,9 +2860,6 @@ pub fn fuse_boxing_alloc(graph: &mut FunctionGraph) -> usize {
                 },
             );
         }
-    }
-    if fused > 0 {
-        prune_dead_boxing_remnants(graph);
     }
     fused
 }
@@ -2981,7 +2997,7 @@ pub fn thread_undefined_op_operands(graph: &mut FunctionGraph) {
 /// cluster at once; the inputargs / link args the removed producers leave
 /// dangling (and the now-dead address constants) are reclaimed by the
 /// [`prune_dead_phis`] pass the lowering runs next.
-pub(crate) fn prune_dead_boxing_remnants(graph: &mut FunctionGraph) {
+pub(crate) fn prune_dead_boxing_remnants(graph: &mut FunctionGraph) -> usize {
     use crate::flowspace::model::Variable;
     use std::collections::HashMap;
 
@@ -3012,7 +3028,21 @@ pub(crate) fn prune_dead_boxing_remnants(graph: &mut FunctionGraph) {
                     .iter()
                     .map(String::as_str)
                     .eq(get_instantiate.iter().copied());
-            is_cast || is_get_instantiate
+            // `boxed::Box::new_uninit()` — the no-arg heap-box allocation the
+            // `vec![…]` lowering (`box_assume_init_into_vec_unsafe(box [..])`)
+            // opens.  Once a consumer rewrite turns the `vec!` into a
+            // `newlist`, the box result flows only into the `FieldWrite` that
+            // stored the now-unused `Array` aggregate, so the box is a fresh
+            // alloc nothing reads.  Pin the arity so an unrelated multi-arg
+            // path sharing the leaf is never swept.
+            let new_uninit = ["boxed", "Box", "new_uninit"];
+            let is_box_new_uninit = args.is_empty()
+                && segments.len() >= new_uninit.len()
+                && segments[segments.len() - new_uninit.len()..]
+                    .iter()
+                    .map(String::as_str)
+                    .eq(new_uninit.iter().copied());
+            is_cast || is_get_instantiate || is_box_new_uninit
         }
         _ => false,
     };
@@ -3024,24 +3054,38 @@ pub(crate) fn prune_dead_boxing_remnants(graph: &mut FunctionGraph) {
         .map(|(i, b)| (b.id, i))
         .collect();
 
-    // Fresh stack aggregates (`SyntheticTransparentCtor`) are the only bases
-    // whose field stores may be dropped: a store into an aggregate nothing
-    // reads is itself dead (`malloc.py remove_simple_mallocs`).  A store
-    // *through* an aliasing or loaded base (`__pyre_cast_instance` /
-    // `get_instantiate` / a parameter / …) is a real heap side effect, so the
-    // exemption is scoped to ctor results — every other store roots its base.
-    let synthetic_ctor_results: HashSet<Variable> = graph
+    // Fresh heap allocations are the only bases whose field stores may be
+    // dropped: a store into an allocation nothing reads is itself dead
+    // (`malloc.py remove_simple_mallocs`).  Two producer shapes qualify — a
+    // `SyntheticTransparentCtor` stack construct and a no-arg
+    // `boxed::Box::new_uninit()` heap box (the `vec![…]` lowering's fresh
+    // allocation, which nothing aliases legitimately).  A store *through* an
+    // aliasing or loaded base (`__pyre_cast_instance` / `get_instantiate` / a
+    // parameter / …) is a real heap side effect, so the exemption is scoped to
+    // these fresh-allocation results — every other store roots its base.
+    let fresh_alloc_results: HashSet<Variable> = graph
         .blocks
         .iter()
         .flat_map(|b| &b.operations)
-        .filter(|op| {
-            matches!(
-                &op.kind,
-                OpKind::Call {
-                    target: CallTarget::SyntheticTransparentCtor { .. },
-                    ..
-                }
-            )
+        .filter(|op| match &op.kind {
+            OpKind::Call {
+                target: CallTarget::SyntheticTransparentCtor { .. },
+                ..
+            } => true,
+            OpKind::Call {
+                target: CallTarget::FunctionPath { segments },
+                args,
+                ..
+            } => {
+                let new_uninit = ["boxed", "Box", "new_uninit"];
+                args.is_empty()
+                    && segments.len() >= new_uninit.len()
+                    && segments[segments.len() - new_uninit.len()..]
+                        .iter()
+                        .map(String::as_str)
+                        .eq(new_uninit.iter().copied())
+            }
+            _ => false,
         })
         .filter_map(|op| op.result.clone())
         .collect();
@@ -3053,10 +3097,10 @@ pub(crate) fn prune_dead_boxing_remnants(graph: &mut FunctionGraph) {
     for block in &graph.blocks {
         for op in &block.operations {
             match &op.kind {
-                // A store into a fresh aggregate is live iff the aggregate is
-                // live; the `base` is deliberately not rooted, so an unread
-                // aggregate's stores die with it (malloc-removal exemption).
-                OpKind::FieldWrite { base, value, .. } if synthetic_ctor_results.contains(base) => {
+                // A store into a fresh allocation is live iff the allocation
+                // is live; the `base` is deliberately not rooted, so an unread
+                // allocation's stores die with it (malloc-removal exemption).
+                OpKind::FieldWrite { base, value, .. } if fresh_alloc_results.contains(base) => {
                     if let Some(var) = value.as_variable() {
                         dependencies
                             .entry(base.clone())
@@ -3158,25 +3202,22 @@ pub(crate) fn prune_dead_boxing_remnants(graph: &mut FunctionGraph) {
         })
         .collect();
     if dead.is_empty() {
-        return;
+        return 0;
     }
 
     // Drop the dead producers and every field store targeting one.
+    let mut removed = 0usize;
     for block in &mut graph.blocks {
         block.operations.retain(|op| {
-            if let Some(r) = &op.result {
-                if dead.contains(r) {
-                    return false;
-                }
+            let drop = op.result.as_ref().is_some_and(|r| dead.contains(r))
+                || matches!(&op.kind, OpKind::FieldWrite { base, .. } if dead.contains(base));
+            if drop {
+                removed += 1;
             }
-            if let OpKind::FieldWrite { base, .. } = &op.kind {
-                if dead.contains(base) {
-                    return false;
-                }
-            }
-            true
+            !drop
         });
     }
+    removed
 }
 
 /// Remove dead operations and dead inputargs from `graph` per
@@ -5993,6 +6034,46 @@ mod tests {
         );
     }
 
+    /// The four numeric boxing structs' field layouts, keyed by the
+    /// crate-stripped qualified path (`floatobject::W_FloatObject`) the front
+    /// end registers — exercising `fuse_boxing_alloc`'s leaf-fallback lookup
+    /// (the ctor carries only the bare `W_FloatObject` leaf).  Each row is the
+    /// full field layout including `ob_header`, matching what
+    /// `derive_program_metadata` builds.
+    fn numeric_boxing_attrs() -> std::collections::HashMap<String, Vec<(String, ValueType)>> {
+        std::collections::HashMap::from([
+            (
+                "floatobject::W_FloatObject".to_string(),
+                vec![
+                    ("ob_header".to_string(), ValueType::Ref(None)),
+                    ("floatval".to_string(), ValueType::Float),
+                ],
+            ),
+            (
+                "intobject::W_IntObject".to_string(),
+                vec![
+                    ("ob_header".to_string(), ValueType::Ref(None)),
+                    ("intval".to_string(), ValueType::Int),
+                ],
+            ),
+            (
+                "complexobject::W_ComplexObject".to_string(),
+                vec![
+                    ("ob_header".to_string(), ValueType::Ref(None)),
+                    ("real".to_string(), ValueType::Float),
+                    ("imag".to_string(), ValueType::Float),
+                ],
+            ),
+            (
+                "longobject::W_LongObject".to_string(),
+                vec![
+                    ("ob_header".to_string(), ValueType::Ref(None)),
+                    ("value".to_string(), ValueType::Ref(None)),
+                ],
+            ),
+        ])
+    }
+
     #[test]
     fn fuse_boxing_alloc_lowers_float_box_cluster() {
         // entry: %v       = const (the boxed payload);
@@ -6103,7 +6184,7 @@ mod tests {
             .unwrap();
         graph.set_return(entry, Some(ret.clone()));
 
-        let fused = fuse_boxing_alloc(&mut graph);
+        let fused = fuse_boxing_alloc(&mut graph, &numeric_boxing_attrs());
         assert_eq!(fused, 1, "exactly one boxing cluster must fuse");
 
         let ops = &graph.block(entry).operations;
@@ -6249,7 +6330,7 @@ mod tests {
             .unwrap();
         graph.set_return(entry, Some(ret.clone()));
 
-        let fused = fuse_boxing_alloc(&mut graph);
+        let fused = fuse_boxing_alloc(&mut graph, &numeric_boxing_attrs());
         assert_eq!(fused, 1, "the complex boxing cluster must fuse");
 
         let ops = &graph.block(entry).operations;
@@ -6316,7 +6397,7 @@ mod tests {
             .unwrap();
         graph.set_return(entry, Some(ret));
 
-        let fused = fuse_boxing_alloc(&mut graph);
+        let fused = fuse_boxing_alloc(&mut graph, &numeric_boxing_attrs());
         assert_eq!(fused, 0, "unknown boxing owner must not fuse");
         assert!(
             !graph
@@ -6442,8 +6523,12 @@ mod tests {
             .unwrap();
         graph.set_return(entry, Some(ret.clone()));
 
-        let fused = fuse_boxing_alloc(&mut graph);
+        let fused = fuse_boxing_alloc(&mut graph, &numeric_boxing_attrs());
         assert_eq!(fused, 1, "the nested-header boxing cluster must fuse");
+        // Fusion orphans the header sub-tree but no longer sweeps it itself;
+        // the remnant sweep is a separate pass (run right after fusion in
+        // `simplify_lowered_graph`).
+        prune_dead_boxing_remnants(&mut graph);
 
         let ops = &graph.block(entry).operations;
         // The dead header sub-tree is gone: no SyntheticTransparentCtor and no
@@ -6490,6 +6575,178 @@ mod tests {
             "the live return cast must survive"
         );
         let _ = ret;
+    }
+
+    #[test]
+    fn fuse_boxing_alloc_lowers_non_numeric_struct_generically() {
+        // A non-numeric boxing struct (`W_SetObject`: ob_header + items + len +
+        // hash) fuses through the generic field-layout derivation, not the old
+        // hardcoded numeric set.  The three non-header fields become payload
+        // setfields in struct order, each re-typed from the registered layout;
+        // `ob_header` is dropped (rides the `NewWithVtable` type pointer).
+        let mut graph = FunctionGraph::new("test");
+        let entry = graph.startblock;
+        let items = graph
+            .push_op_var(entry, OpKind::ConstRefAddr(0), true)
+            .unwrap();
+        let len = graph.push_op_var(entry, OpKind::ConstInt(3), true).unwrap();
+        let hash = graph
+            .push_op_var(entry, OpKind::ConstInt(-1), true)
+            .unwrap();
+        // Resolvable `ob_header.ob_type` type-pointer so the fusion fires.
+        let ty_addr = graph
+            .push_op_var(entry, OpKind::ConstRefAddr(4357049520), true)
+            .unwrap();
+        let header = graph
+            .push_op_var(
+                entry,
+                OpKind::Call {
+                    target: CallTarget::synthetic_transparent_ctor("PyObject"),
+                    args: vec![],
+                    result_ty: ValueType::Ref(Some("PyObject".into())),
+                },
+                true,
+            )
+            .unwrap();
+        graph.push_op_var(
+            entry,
+            OpKind::FieldWrite {
+                base: header.clone(),
+                field: FieldDescriptor {
+                    name: "ob_type".into(),
+                    owner_root: Some("PyObject".into()),
+                    owner_id: None,
+                },
+                value: LinkArg::Value(ty_addr),
+                ty: ValueType::Ref(None),
+            },
+            false,
+        );
+        let agg = graph
+            .push_op_var(
+                entry,
+                OpKind::Call {
+                    target: CallTarget::synthetic_transparent_ctor("W_SetObject"),
+                    args: vec![],
+                    result_ty: ValueType::Ref(Some("W_SetObject".into())),
+                },
+                true,
+            )
+            .unwrap();
+        let field =
+            |base: &crate::flowspace::model::Variable, name: &str, value, ty| OpKind::FieldWrite {
+                base: base.clone(),
+                field: FieldDescriptor {
+                    name: name.into(),
+                    owner_root: Some("W_SetObject".into()),
+                    owner_id: None,
+                },
+                value,
+                ty,
+            };
+        graph.push_op_var(
+            entry,
+            field(
+                &agg,
+                "ob_header",
+                LinkArg::Value(header),
+                ValueType::Ref(None),
+            ),
+            false,
+        );
+        graph.push_op_var(
+            entry,
+            field(&agg, "items", LinkArg::Value(items), ValueType::Ref(None)),
+            false,
+        );
+        graph.push_op_var(
+            entry,
+            field(&agg, "len", LinkArg::Value(len), ValueType::Ref(None)),
+            false,
+        );
+        graph.push_op_var(
+            entry,
+            field(&agg, "hash", LinkArg::Value(hash), ValueType::Ref(None)),
+            false,
+        );
+        let ret = graph
+            .push_op_var(
+                entry,
+                OpKind::Call {
+                    target: CallTarget::FunctionPath {
+                        segments: vec![
+                            "pyre_object".into(),
+                            "lltype".into(),
+                            "malloc_typed".into(),
+                        ],
+                    },
+                    args: vec![agg.clone()],
+                    result_ty: ValueType::Ref(Some("W_SetObject".into())),
+                },
+                true,
+            )
+            .unwrap();
+        graph.set_return(entry, Some(ret.clone()));
+
+        // Layout keyed by the crate-stripped qualified path; the ctor carries
+        // only the bare `W_SetObject` leaf, exercising the leaf-fallback lookup.
+        let attrs = std::collections::HashMap::from([(
+            "setobject::W_SetObject".to_string(),
+            vec![
+                ("ob_header".to_string(), ValueType::Ref(None)),
+                ("items".to_string(), ValueType::Ref(None)),
+                ("len".to_string(), ValueType::Int),
+                ("hash".to_string(), ValueType::Int),
+            ],
+        )]);
+        let fused = fuse_boxing_alloc(&mut graph, &attrs);
+        assert_eq!(fused, 1, "the non-numeric boxing cluster must fuse");
+
+        let ops = &graph.block(entry).operations;
+        let nwv_pos = ops
+            .iter()
+            .position(|op| {
+                matches!(&op.kind, OpKind::NewWithVtable { owner, vtable }
+                    if owner == "W_SetObject" && *vtable == 4357049520)
+            })
+            .expect("NewWithVtable must be emitted with the captured type pointer");
+        assert_eq!(
+            ops[nwv_pos].result.as_ref(),
+            Some(&ret),
+            "NewWithVtable must reuse the malloc result register"
+        );
+        // Three payload stores follow in struct order (ob_header dropped),
+        // each re-typed from the registered layout.
+        let mut got: Vec<(String, ValueType)> = Vec::new();
+        for off in 1..=3 {
+            match &ops[nwv_pos + off].kind {
+                OpKind::FieldWrite {
+                    base, field, ty, ..
+                } => {
+                    assert_eq!(base, &ret, "payload store must target the alloc result");
+                    got.push((field.name.clone(), ty.clone()));
+                }
+                other => panic!("expected payload FieldWrite, got {other:?}"),
+            }
+        }
+        assert_eq!(
+            got,
+            vec![
+                ("items".to_string(), ValueType::Ref(None)),
+                ("len".to_string(), ValueType::Int),
+                ("hash".to_string(), ValueType::Int),
+            ],
+            "payloads must be the non-header fields in struct order, re-typed \
+             from the registered layout"
+        );
+        assert!(
+            !ops.iter().any(|op| matches!(
+                &op.kind,
+                OpKind::Call { target: CallTarget::FunctionPath { segments }, .. }
+                    if segments.last().map(String::as_str) == Some("malloc_typed")
+            )),
+            "no malloc_typed call may survive the fusion"
+        );
     }
 
     #[test]
@@ -6760,6 +7017,116 @@ mod tests {
             "the dangling threaded inputargs must be reclaimed by prune_dead_phis"
         );
         let _ = (ret, header, cast2, ty_addr1, ty_addr2);
+    }
+
+    #[test]
+    fn prune_dead_boxing_remnants_sweeps_cross_block_threaded_vec_box() {
+        // The `vec![e0]` lowering after a consumer rewrite to `newlist`: the
+        // `box_assume_init_into_vec_unsafe(box [e0])` idiom leaves a no-arg
+        // `boxed::Box::new_uninit()` allocation storing a fresh `Array`
+        // aggregate.  `front::mir`'s framestate threading splits the box
+        // allocation from the block that consumed it, reusing the SAME
+        // `Variable` as both the entry op result and the successor block's
+        // inputarg, and threads the box pointer through the `Link`.  The
+        // successor no longer reads the box (its consumer became a `newlist`
+        // reading the elements directly), so the whole box → Array → element
+        // store cluster is dead.  `remove_dead_aggregates` cannot prove it —
+        // it counts the threaded `Link.arg` as an unconditional read — but the
+        // dependency-flow sweep reaches it: the box's target inputarg is unread
+        // and the box is a fresh alloc exempt from store-base rooting.
+        type Var = crate::flowspace::model::Variable;
+        let field = |base: &Var, name: &str, value: &Var| OpKind::FieldWrite {
+            base: base.clone(),
+            field: FieldDescriptor {
+                name: name.into(),
+                owner_root: None,
+                owner_id: None,
+            },
+            value: LinkArg::Value(value.clone()),
+            ty: ValueType::Ref(None),
+        };
+        let box_new_uninit = || OpKind::Call {
+            target: CallTarget::FunctionPath {
+                segments: vec!["boxed".into(), "Box".into(), "new_uninit".into()],
+            },
+            args: vec![],
+            result_ty: ValueType::Ref(Some("Box".into())),
+        };
+        let mut graph = FunctionGraph::new("test");
+        let entry = graph.startblock;
+        // A live `vec!` element (a genuine parameter).
+        let elem = graph.alloc_value_var();
+        graph.push_inputarg_var(entry, elem.clone());
+        // DEAD: the `Box::new_uninit()` heap box the `vec!` lowering opens.
+        let boxed = graph.push_op_var(entry, box_new_uninit(), true).unwrap();
+        // DEAD: the fresh `Array` aggregate the box stores, plus its `__pos_0`
+        // element write.
+        let array = graph
+            .push_op_var(
+                entry,
+                OpKind::Call {
+                    target: CallTarget::synthetic_transparent_ctor("Array"),
+                    args: vec![],
+                    result_ty: ValueType::Ref(Some("Array".into())),
+                },
+                true,
+            )
+            .unwrap();
+        graph.push_op_var(entry, field(&array, "__pos_0", &elem), false);
+        // DEAD: the store threading the `Array` into the box.
+        graph.push_op_var(entry, field(&boxed, "ptr", &array), false);
+
+        // Successor block reached after the boundary the framestate threading
+        // opens; its inputarg reuses the SAME `boxed` Variable (id-reuse), and
+        // nothing in it reads the box.
+        let blk = graph.create_block();
+        graph.push_inputarg_var(blk, boxed.clone());
+        graph.set_goto(entry, blk, vec![boxed.clone()]);
+        graph.set_return(blk, None);
+
+        let removed = prune_dead_boxing_remnants(&mut graph);
+        assert!(
+            removed >= 3,
+            "the box, the Array ctor, and both field stores must be swept, got {removed}"
+        );
+
+        let kinds: Vec<&OpKind> = graph
+            .blocks
+            .iter()
+            .flat_map(|b| &b.operations)
+            .map(|o| &o.kind)
+            .collect();
+        assert!(
+            !kinds.iter().any(|k| matches!(
+                k,
+                OpKind::Call { target: CallTarget::FunctionPath { segments }, args, .. }
+                    if args.is_empty()
+                        && segments.last().map(String::as_str) == Some("new_uninit")
+            )),
+            "the dead cross-block `Box::new_uninit` box must be swept: {kinds:#?}"
+        );
+        assert!(
+            !kinds.iter().any(|k| matches!(
+                k,
+                OpKind::Call {
+                    target: CallTarget::SyntheticTransparentCtor { .. },
+                    ..
+                }
+            )),
+            "the dead `Array` aggregate ctor must be swept"
+        );
+        assert!(
+            !kinds.iter().any(|k| matches!(k, OpKind::FieldWrite { .. })),
+            "both dead field stores (the `Array` element write and the box store) must be swept"
+        );
+
+        // `prune_dead_phis` reclaims the now-dangling threaded inputarg / link
+        // arg the sweep leaves behind.
+        prune_dead_phis(&mut graph);
+        assert!(
+            !graph.block(blk).inputargs.contains(&boxed),
+            "the dangling threaded box inputarg must be reclaimed by prune_dead_phis"
+        );
     }
 
     #[test]

--- a/majit/majit-translate/src/translator/rtyper/rlist.rs
+++ b/majit/majit-translate/src/translator/rtyper/rlist.rs
@@ -381,14 +381,18 @@ fn rlist_runtime_deferred(name: &str) -> TyperError {
 ///     return v_result
 /// ```
 ///
-/// Constructs a fresh resized list (`Ptr(GcStruct("list", length, items))`)
-/// via the shared [`build_ll_newlist_helper_graph`] (`ListLayout::Resized`),
-/// then fills it positionally with `ll_setitem_fast` calls
-/// ([`build_ll_setitem_fast_helper_graph`]); the `dum_nocheck` index is
-/// statically `0..n`, so the negative-index / bound-check wrappers are
-/// skipped exactly as upstream's `ll_setitem_nonneg`-fast-path does. Each
+/// Constructs a fresh list via the shared [`build_ll_newlist_helper_graph`],
+/// then fills it positionally with `ll_setitem_fast` calls; the `dum_nocheck`
+/// index is statically `0..n`, so the negative-index / bound-check wrappers
+/// are skipped exactly as upstream's `ll_setitem_nonneg`-fast-path does. Each
 /// element is coerced to `r_list.item_repr` (the internal gcref-wrapped
 /// element repr) before being stored.
+///
+/// `LIST.ll_newlist` is a repr-generic typemethod upstream: the resized
+/// `ListRepr` binds `ll_newlist` (`Ptr(GcStruct("list", length, items))`) and
+/// the never-resized `FixedSizeListRepr` binds `ll_fixed_newlist`
+/// (`Ptr(GcArray)`). This dispatches on the concrete `hop.r_result` repr and
+/// forwards to [`rtype_newlist_layout`] with the matching [`ListLayout`].
 pub fn rtype_newlist(hop: &HighLevelOp) -> RTypeResult {
     let r_result = hop
         .r_result
@@ -396,34 +400,76 @@ pub fn rtype_newlist(hop: &HighLevelOp) -> RTypeResult {
         .clone()
         .ok_or_else(|| TyperError::message("rtype_newlist: r_result missing"))?;
     let any_r: &dyn std::any::Any = r_result.as_ref();
-    let r_list = any_r
-        .downcast_ref::<ListRepr>()
-        .ok_or_else(|| TyperError::message("rtype_newlist: hop.r_result is not a ListRepr"))?;
-    let ptr_lltype = r_list.lltype.clone();
-    let item_lltype = r_list.item_repr.lowleveltype().clone();
+    // `hop.r_result` is a `list` display's repr: the resized `ListRepr`
+    // (`Ptr(GcStruct("list", length, items))`) for a mutated `list(...)`, or
+    // the `FixedSizeListRepr` (`Ptr(GcArray)`) for a never-resized `vec![...]`.
+    // The `LIST.ll_newlist` typemethod is repr-generic upstream
+    // (`ll_newlist` vs `ll_fixed_newlist`); dispatch on the concrete repr and
+    // parameterise the shared body on [`ListLayout`].
+    if let Some(r_list) = any_r.downcast_ref::<ListRepr>() {
+        return rtype_newlist_layout(
+            hop,
+            r_list.lltype.clone(),
+            r_list.item_repr.lowleveltype().clone(),
+            r_list.item_repr.as_ref(),
+            ListLayout::Resized,
+        );
+    }
+    if let Some(r_list) = any_r.downcast_ref::<FixedSizeListRepr>() {
+        return rtype_newlist_layout(
+            hop,
+            r_list.lltype.clone(),
+            r_list.item_repr.lowleveltype().clone(),
+            r_list.item_repr.as_ref(),
+            ListLayout::Fixed,
+        );
+    }
+    Err(TyperError::message(
+        "rtype_newlist: hop.r_result is not a ListRepr or FixedSizeListRepr",
+    ))
+}
+
+/// Repr-generic body of [`rtype_newlist`], shared by the resized `ListRepr`
+/// and the fixed-size `FixedSizeListRepr`. The `LIST.ll_newlist(n)` +
+/// positional `ll_setitem_fast` shape is identical; only the receiver layout
+/// (and hence the concrete helper graphs) differ.
+///
+/// The two layouts build DIFFERENT helper graphs (the resized newlist mallocs
+/// a `GcStruct` header + items array and stores both fields; the fixed newlist
+/// is the bare `malloc_varsize`), so they MUST use distinct helper-fn names —
+/// `lowlevel_helper_function_with_builder` memoises on `(name, args, result)`
+/// and would otherwise be at risk of serving a cached resized graph for a
+/// fixed request. Distinct names (`ll_newlist` / `ll_fixed_newlist`,
+/// `ll_setitem_fast` / `ll_fixed_setitem_fast`) also match the upstream
+/// `ADTIList` / `ADTIFixedList` adtmeth entries.
+fn rtype_newlist_layout(
+    hop: &HighLevelOp,
+    ptr_lltype: LowLevelType,
+    item_lltype: LowLevelType,
+    item_repr: &dyn Repr,
+    layout: ListLayout,
+) -> RTypeResult {
     let n = hop.nb_args();
 
     // upstream `items_v = [hop.inputarg(r_list.item_repr, i) for i in range(n)]`.
-    let converted: Vec<ConvertedTo<'_>> = (0..n)
-        .map(|_| ConvertedTo::Repr(r_list.item_repr.as_ref()))
-        .collect();
+    let converted: Vec<ConvertedTo<'_>> = (0..n).map(|_| ConvertedTo::Repr(item_repr)).collect();
     let items_v = hop.inputargs(converted)?;
+
+    let (newlist_name, setitem_name) = match layout {
+        ListLayout::Fixed => ("ll_fixed_newlist", "ll_fixed_setitem_fast"),
+        ListLayout::Resized => ("ll_newlist", "ll_setitem_fast"),
+    };
 
     // upstream `v_result = llops.gendirectcall(LIST.ll_newlist, cno)`.
     let newlist_fn = {
         let ptr = ptr_lltype.clone();
         let item = item_lltype.clone();
         hop.rtyper.lowlevel_helper_function_with_builder(
-            "ll_newlist".to_string(),
+            newlist_name.to_string(),
             vec![LowLevelType::Signed],
             ptr_lltype.clone(),
             move |_rtyper, _args, _result| {
-                build_ll_newlist_helper_graph(
-                    "ll_newlist",
-                    ListLayout::Resized,
-                    ptr.clone(),
-                    item.clone(),
-                )
+                build_ll_newlist_helper_graph(newlist_name, layout, ptr.clone(), item.clone())
             },
         )?
     };
@@ -438,11 +484,18 @@ pub fn rtype_newlist(hop: &HighLevelOp) -> RTypeResult {
         let ptr = ptr_lltype.clone();
         let item = item_lltype.clone();
         hop.rtyper.lowlevel_helper_function_with_builder(
-            "ll_setitem_fast".to_string(),
+            setitem_name.to_string(),
             vec![ptr_lltype, LowLevelType::Signed, item_lltype],
             LowLevelType::Void,
-            move |_rtyper, _args, _result| {
-                build_ll_setitem_fast_helper_graph("ll_setitem_fast", ptr.clone(), item.clone())
+            move |_rtyper, _args, _result| match layout {
+                ListLayout::Fixed => build_ll_fixed_setitem_fast_helper_graph(
+                    setitem_name,
+                    ptr.clone(),
+                    item.clone(),
+                ),
+                ListLayout::Resized => {
+                    build_ll_setitem_fast_helper_graph(setitem_name, ptr.clone(), item.clone())
+                }
             },
         )?
     };
@@ -5321,6 +5374,87 @@ mod tests {
             3,
             "expected ll_newlist + 2×ll_setitem_fast direct_calls, got {:?}",
             ops.ops.iter().map(|op| &op.opname).collect::<Vec<_>>()
+        );
+    }
+
+    /// The `vec![e0, …, eN]` never-resized display annotates as a
+    /// `FixedSizeListRepr` (bare `Ptr(GcArray)`). `rtype_newlist` must take
+    /// the Fixed arm — `ll_fixed_newlist(N)` + N `ll_fixed_setitem_fast` — and
+    /// mint helper graphs under DISTINCT names from the resized variant, so
+    /// the `(name, args, result)` helper cache never serves a resized-shaped
+    /// graph for the fixed request.
+    #[test]
+    fn translate_operation_newlist_fixed_repr_emits_ll_fixed_helpers() {
+        use crate::annotator::model::SomeValue;
+        use crate::flowspace::model::SpaceOperation;
+        use std::cell::RefCell as StdRef;
+
+        let ann = RPythonAnnotator::new(None, None, None, false);
+        let rtyper = Rc::new(RPythonTyper::new(&ann));
+        rtyper
+            .initialize_exceptiondata()
+            .expect("initialize_exceptiondata in test setup");
+        let r_int: Arc<dyn Repr> = Arc::new(IntegerRepr::new(LowLevelType::Signed, Some("int_")));
+        let r_list: Arc<dyn Repr> = Arc::new(
+            FixedSizeListRepr::new(&rtyper, r_int.clone()).expect("FixedSizeListRepr::new"),
+        );
+
+        let v_a = Variable::new();
+        v_a.set_concretetype(Some(LowLevelType::Signed));
+        let v_b = Variable::new();
+        v_b.set_concretetype(Some(LowLevelType::Signed));
+        let v_a_h = Hlvalue::Variable(v_a);
+        let v_b_h = Hlvalue::Variable(v_b);
+        let result_var = Variable::new();
+        let spaceop = SpaceOperation::new(
+            "newlist".to_string(),
+            vec![v_a_h.clone(), v_b_h.clone()],
+            Hlvalue::Variable(result_var),
+        );
+        let llops = Rc::new(StdRef::new(LowLevelOpList::new(rtyper.clone(), None)));
+        let hop = HighLevelOp::new(rtyper.clone(), spaceop, Vec::new(), llops);
+        hop.args_v.borrow_mut().push(v_a_h);
+        hop.args_s.borrow_mut().push(SomeValue::Impossible);
+        hop.args_r.borrow_mut().push(Some(r_int.clone()));
+        hop.args_v.borrow_mut().push(v_b_h);
+        hop.args_s.borrow_mut().push(SomeValue::Impossible);
+        hop.args_r.borrow_mut().push(Some(r_int.clone()));
+        *hop.r_result.borrow_mut() = Some(r_list.clone());
+
+        rtyper
+            .translate_operation(&hop)
+            .expect("translate_operation newlist must dispatch to rtype_newlist")
+            .expect("newlist returns the fresh list Variable");
+        let ops = hop.llops.borrow();
+        let direct_calls = ops
+            .ops
+            .iter()
+            .filter(|op| op.opname == "direct_call")
+            .count();
+        // `ll_fixed_newlist(len)` + one `ll_fixed_setitem_fast` per element.
+        assert_eq!(
+            direct_calls,
+            3,
+            "expected ll_fixed_newlist + 2×ll_fixed_setitem_fast direct_calls, got {:?}",
+            ops.ops.iter().map(|op| &op.opname).collect::<Vec<_>>()
+        );
+
+        // The Fixed arm must have minted its own `ll_fixed_*` helper graphs
+        // (distinct cache keys), not reused the resized `ll_newlist` graph.
+        let translator = ann.translator.clone();
+        let names: Vec<String> = translator
+            .graphs
+            .borrow()
+            .iter()
+            .map(|g| g.borrow().name.clone())
+            .collect();
+        assert!(
+            names.iter().any(|n| n == "ll_fixed_newlist"),
+            "Fixed arm must mint an ll_fixed_newlist helper graph, got {names:?}"
+        );
+        assert!(
+            names.iter().any(|n| n == "ll_fixed_setitem_fast"),
+            "Fixed arm must mint an ll_fixed_setitem_fast helper graph, got {names:?}"
         );
     }
 

--- a/pyre/pyre-interpreter/src/jit_fnaddr.rs
+++ b/pyre/pyre-interpreter/src/jit_fnaddr.rs
@@ -623,6 +623,16 @@ pub fn jit_trace_fnaddrs() -> Vec<(&'static str, i64)> {
         "pyre_object::try_gc_charge_oldgen_external",
         pyre_object::gc_hook::try_gc_charge_oldgen_external as *const (),
     );
+    // `w_type_set_abstract` stores the runtime-mutable `flag_abstract` atomic — a
+    // side effect on per-type state, not a build-time constant, so it carries
+    // `#[dont_look_inside]` and binds its `()`-returning `fn` directly by
+    // qualified path (sibling of `note_alloc`).
+    push_alias_pair(
+        &mut entries,
+        "pyre_object::typeobject::w_type_set_abstract",
+        "pyre_object::w_type_set_abstract",
+        pyre_object::w_type_set_abstract as *const (),
+    );
     push_fnaddr(
         &mut entries,
         "pyre_interpreter::module::_weakref::interp__weakref::dereference",
@@ -965,6 +975,17 @@ pub fn jit_trace_fnaddrs() -> Vec<(&'static str, i64)> {
         "pyre_object::listobject::list_write_barrier",
         "pyre_object::list_write_barrier",
         pyre_object::list_write_barrier as *const (),
+    );
+    // The cold list strategy dehomogenization `switch_to_object_strategy` bulk
+    // re-boxes typed int/float storage into an Object items block via
+    // Vec/collect allocation the tracer cannot model. Register it so the hot
+    // append/setitem paths that call it resolve the residual to a
+    // runtime-patchable address instead of tracing into the transition.
+    push_alias_pair(
+        &mut entries,
+        "pyre_object::listobject::switch_to_object_strategy",
+        "pyre_object::switch_to_object_strategy",
+        pyre_object::switch_to_object_strategy as *const (),
     );
     push_alias_pair(
         &mut entries,

--- a/pyre/pyre-interpreter/src/jit_fnaddr.rs
+++ b/pyre/pyre-interpreter/src/jit_fnaddr.rs
@@ -920,6 +920,12 @@ pub fn jit_trace_fnaddrs() -> Vec<(&'static str, i64)> {
     );
     push_alias_pair(
         &mut entries,
+        "pyre_object::longobject::jit_bigint_to_i64_value_or_zero",
+        "pyre_object::jit_bigint_to_i64_value_or_zero",
+        pyre_object::jit_bigint_to_i64_value_or_zero as *const (),
+    );
+    push_alias_pair(
+        &mut entries,
         "pyre_object::longobject::jit_bigint_to_u64_fits",
         "pyre_object::jit_bigint_to_u64_fits",
         pyre_object::jit_bigint_to_u64_fits as *const (),

--- a/pyre/pyre-object/src/listobject.rs
+++ b/pyre/pyre-object/src/listobject.rs
@@ -396,7 +396,19 @@ fn boxed_from_floats(values: &[f64]) -> Vec<PyObjectRef> {
     values.iter().map(|&value| w_float_new(value)).collect()
 }
 
-unsafe fn switch_to_object_strategy(list: &mut W_ListObject) {
+/// Cold list strategy dehomogenization: a typed int/float list gained a
+/// non-numeric element, so its unboxed backing storage is bulk re-boxed into
+/// an Object-strategy items block one time.
+///
+/// `dont_look_inside`: the transition drives Vec/collect allocation the tracer
+/// cannot model — `boxed_from_ints` / `boxed_from_floats` build a fresh
+/// `Vec<PyObjectRef>` via `.map(...).collect()`, and
+/// `set_object_items_from_vec` / `IntArray::from_vec` / `FloatArray::from_vec`
+/// tear down the typed storage through raw-Vec construction. Residualize the
+/// whole cold transition via the registered fnaddr so the hot append/setitem
+/// paths that call it stay traceable.
+#[majit_macros::dont_look_inside]
+pub unsafe fn switch_to_object_strategy(list: &mut W_ListObject) {
     if list.strategy == ListStrategy::Object {
         return;
     }

--- a/pyre/pyre-object/src/longobject.rs
+++ b/pyre/pyre-object/src/longobject.rs
@@ -367,6 +367,15 @@ pub fn jit_bigint_to_i64_value(num: &BigInt) -> i64 {
     })
 }
 
+/// `rbigint.toint()` payload for the runtime-fallible narrowing lowering:
+/// the value is read only on the fits (Ok) path, so out-of-range returns 0
+/// instead of panicking — the walker's discriminant switch discards it on
+/// the Err path. Companion of [`jit_bigint_to_i64_fits`].
+#[majit_macros::dont_look_inside]
+pub fn jit_bigint_to_i64_value_or_zero(num: &BigInt) -> i64 {
+    i64::try_from(num).unwrap_or(0)
+}
+
 /// `BigInt::to_u64().is_some()` on a borrowed BigInt payload. Scalar half of
 /// the `BigInt::to_u64()` split so the two-phase rtyper never has to model an
 /// `Option<u64>` ABI. Companion of [`jit_bigint_to_u64_value`].

--- a/pyre/pyre-object/src/setobject.rs
+++ b/pyre/pyre-object/src/setobject.rs
@@ -140,14 +140,15 @@ fn set_write_barrier(obj: PyObjectRef) {
     crate::gc_hook::try_gc_write_barrier(obj as *mut u8);
 }
 
-fn alloc_set_with_type(tp: &'static PyType) -> PyObjectRef {
+/// Allocate an empty `set`.
+pub fn w_set_new() -> PyObjectRef {
     let items = crate::lltype::malloc_raw(indexmap::IndexMap::<
         crate::dictmultiobject::ObjectKey,
         (),
     >::new());
     let header = PyObject {
-        ob_type: tp as *const PyType,
-        w_class: get_instantiate(tp),
+        ob_type: &SET_TYPE as *const PyType,
+        w_class: get_instantiate(&SET_TYPE),
     };
     // Allocate the body in GC old-gen (mark-sweep, non-moving) so it
     // carries TRACK_YOUNG_PTRS, mirroring `w_list_new` / `w_tuple_new`.
@@ -181,14 +182,41 @@ fn alloc_set_with_type(tp: &'static PyType) -> PyObjectRef {
     }
 }
 
-/// Allocate an empty `set`.
-pub fn w_set_new() -> PyObjectRef {
-    alloc_set_with_type(&SET_TYPE)
-}
-
 /// Allocate an empty `frozenset`.
+///
+/// Same body as [`w_set_new`] with the constant `&FROZENSET_TYPE` baked
+/// into `ob_type`; see that constructor for the GC old-gen rationale.
 pub fn w_frozenset_new() -> PyObjectRef {
-    alloc_set_with_type(&FROZENSET_TYPE)
+    let items = crate::lltype::malloc_raw(indexmap::IndexMap::<
+        crate::dictmultiobject::ObjectKey,
+        (),
+    >::new());
+    let header = PyObject {
+        ob_type: &FROZENSET_TYPE as *const PyType,
+        w_class: get_instantiate(&FROZENSET_TYPE),
+    };
+    let raw = crate::gc_hook::try_gc_alloc_stable_raw(W_SET_GC_TYPE_ID, W_SET_OBJECT_SIZE);
+    if !raw.is_null() {
+        unsafe {
+            std::ptr::write(
+                raw as *mut W_SetObject,
+                W_SetObject {
+                    ob_header: header,
+                    items,
+                    len: 0,
+                    hash: -1,
+                },
+            );
+        }
+        raw as PyObjectRef
+    } else {
+        crate::lltype::malloc_typed(W_SetObject {
+            ob_header: header,
+            items,
+            len: 0,
+            hash: -1,
+        }) as PyObjectRef
+    }
 }
 
 /// Allocate a populated set from a slice of elements (deduped).

--- a/pyre/pyre-object/src/typeobject.rs
+++ b/pyre/pyre-object/src/typeobject.rs
@@ -549,8 +549,14 @@ pub unsafe fn w_type_is_abstract(w_type: PyObjectRef) -> bool {
 
 /// `W_TypeObject.set_abstract` (typeobject.py:600-601).
 ///
+/// `dont_look_inside`: the `flag_abstract` atomic store is a runtime-mutable
+/// side effect on per-type state, not a build-time constant, so the JIT
+/// residualises the call via the registered fnaddr rather than tracing the
+/// store the tracer cannot model.
+///
 /// # Safety
 /// `w_type` must point at a `W_TypeObject`.
+#[majit_macros::dont_look_inside]
 pub unsafe fn w_type_set_abstract(w_type: PyObjectRef, abstract_: bool) {
     if w_type.is_null() || !is_type(w_type) {
         return;


### PR DESCRIPTION
Part of gh#346 (retire the rtyper legacy walker). Four slices of the foreign-std-library cluster: each closes a class of `[PREPASS phaseA fail]` residual wall that dropped hot list/dict/str/bytearray dispatcher graphs to the legacy walker. Each slice was verified by census set-diff and `check.py` bit-exact 3-backend (dynasm 208/208 + cranelift 208/208 + wasm 207/207).

## Slice A — malachite `try_from` narrowing
Lower `i64::try_from(&BigInt)` to a runtime-discriminant `Result` aggregate via `emit_tagged_pair_aggregate`: `disc = eq(jit_bigint_to_i64_fits(x), 0)`, payload = `jit_bigint_to_i64_value_or_zero(x)`. The consumer's `Discriminant` switch and its `Err(_) => return Err(IndexError/ValueError)` arm survive unchanged. The new non-trapping `jit_bigint_to_i64_value_or_zero` payload keeps `lst[2**100]` raising `IndexError` rather than panicking (the aggregate writes the payload unconditionally before the switch).

## Slice B1a — string identity-fold receiver gate
`is_string_as_bytes_identity` / `is_string_to_str_identity` matched the impl-owner leaf via `deref_impl_owner_leaf`, which resolves an owner only when it is an ADT with a def-id. The primitive `str` is a `{Builtin:"Str"}` node with no def-id, so `<str>::as_bytes` never folded; `is_string_to_str_identity` additionally gated owner `== "String"` only, so `Wtf8::as_str` never folded. Gate both on the receiver being a string value via `tyref_is_string_value` (str / String / Wtf8 / Wtf8Buf). `is_string_to_str_identity` keeps its `tyref_strips_to_str(dest)` gate, so a fallible `Wtf8::as_str` returning `Option`/`Result<&str>` (surrogate-bearing) still declines.

## Slice B2 — residualize the cold list strategy transition + type abstract-flag store
`switch_to_object_strategy` (typed-list dehomogenization on a non-numeric append) bulk re-boxes through `boxed_from_ints`/`boxed_from_floats` (`Map::collect`) and rebuilds typed storage through `IntArray`/`FloatArray::from_vec`. `w_type_set_abstract` does a runtime-mutable `AtomicBool` store. Both walled their hot dispatcher graphs on the inner foreign-std call. Mark both `#[majit_macros::dont_look_inside]` and register their fnaddrs so the JIT residualizes the whole call. Distinct phaseA-fail head count 277 → 272.

## Slice B3a — fold `RangeInclusive::contains` into native integer comparisons
`(a..=b).contains(&x)` over an i64/isize range lowered to an opaque `RangeInclusive::new` call that failed phaseA (`setitem_bytearray`, `byte_w`, `c_int_w`). A new front post-pass (`front/range_contains.rs`, mirroring `front/bigint_div_rem`) recognizes the cross-block `new`/`contains` pair and rewrites the `contains` result to `bitand(le(lo, x), ge(hi, x))` — the same native compare chain the rtyper emits for `lo <= x <= b`. The `new` call is removed explicitly (no DCE sweeps a dead `FunctionPath` call). Gated to the opaque `RangeInclusive` ADT with an I64/Isize element type (read from the ADT generic, present even for literal-constant bounds); float ranges and ranges whose value has a second consumer (iteration, stateful `exhausted`) decline cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance**
  - Improved integer range membership lowering to use native comparisons when safe.
  - Added faster, non-panicking BigInt-to-64-bit conversion for fallible paths.
  - Optimized empty `set`/`frozenset` construction and improved list strategy transitions.

- **Bug Fixes**
  - Prevented out-of-range conversions from producing incorrect failure behavior.
  - Tightened string identity handling to ensure correct intercepting.
  - Improved safety of JIT list representation transitions.

- **Documentation**
  - Added a design document detailing the foreign standard-library translation plan and verification approach.

- **Tests**
  - Added coverage for successful and safely declined range-membership rewrites (including float-range cases).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->