### PR TITLE
jit: P2 bridge compile leg default-ON + guard-thrash fixes + vstack-mirror classification

### DIFF
--- a/majit/majit-backend-dynasm/src/aarch64/assembler.rs
+++ b/majit/majit-backend-dynasm/src/aarch64/assembler.rs
@@ -6318,7 +6318,17 @@ impl<'a> AssemblerARM64<'a> {
 
     fn genop_new_with_vtable(&mut self, op: &Op) {
         let obj_size = op.with_size_descr(|sd| sd.size()).unwrap_or(16) as i64;
-        let vtable = op.with_size_descr(|sd| sd.vtable()).unwrap_or(0) as i64;
+        let (vtable, w_class_init) = op
+            .with_size_descr(|sd| {
+                let w_class_init = sd.w_class_obj().and_then(|w_class| {
+                    sd.gc_fielddescrs()
+                        .iter()
+                        .find(|fd| fd.is_w_class())
+                        .map(|fd| (fd.offset() as i64, w_class))
+                });
+                (sd.vtable() as i64, w_class_init)
+            })
+            .unwrap_or((0, None));
         self.emit_mov_imm64(0, obj_size);
         self.emit_mov_imm64(2, Self::new_alloc_fn_addr());
         dynasm!(self.mc ; .arch aarch64 ; blr x2);
@@ -6326,6 +6336,12 @@ impl<'a> AssemblerARM64<'a> {
         if vtable != 0 {
             self.emit_mov_imm64(1, vtable);
             dynasm!(self.mc ; .arch aarch64 ; str x1, [x0]);
+        }
+        if let Some((w_class_offset, w_class)) = w_class_init {
+            if w_class != 0 {
+                self.emit_mov_imm64(1, w_class);
+                dynasm!(self.mc ; .arch aarch64 ; str x1, [x0, w_class_offset as u32]);
+            }
         }
         if !op.pos.get().is_none() {
             self.store_rax_to_result(op.pos.get());

--- a/majit/majit-backend-dynasm/src/x86/assembler.rs
+++ b/majit/majit-backend-dynasm/src/x86/assembler.rs
@@ -8256,7 +8256,17 @@ impl<'a> Assembler386<'a> {
     fn genop_new_with_vtable(&mut self, op: &Op) {
         // Same as New, but also write vtable at offset 0.
         let obj_size = op.with_size_descr(|sd| sd.size()).unwrap_or(16) as i64;
-        let vtable = op.with_size_descr(|sd| sd.vtable()).unwrap_or(0) as i64;
+        let (vtable, w_class_init) = op
+            .with_size_descr(|sd| {
+                let w_class_init = sd.w_class_obj().and_then(|w_class| {
+                    sd.gc_fielddescrs()
+                        .iter()
+                        .find(|fd| fd.is_w_class())
+                        .map(|fd| (fd.offset() as i32, w_class))
+                });
+                (sd.vtable() as i64, w_class_init)
+            })
+            .unwrap_or((0, None));
         let malloc_ptr = Self::new_alloc_fn_addr();
         self.emit_abi_int_arg_from_imm(0, obj_size);
         dynasm!(self.mc ; .arch x64 ; mov rax, QWORD malloc_ptr);
@@ -8276,6 +8286,14 @@ impl<'a> Assembler386<'a> {
                 ; mov rcx, QWORD vtable
                 ; mov [rax], rcx
             );
+        }
+        if let Some((w_class_offset, w_class)) = w_class_init {
+            if w_class != 0 {
+                dynasm!(self.mc ; .arch x64
+                    ; mov rcx, QWORD w_class
+                    ; mov [rax + w_class_offset], rcx
+                );
+            }
         }
         if !op.pos.get().is_none() {
             self.store_rax_to_result(op.pos.get());

--- a/majit/majit-gc/src/rewrite.rs
+++ b/majit/majit-gc/src/rewrite.rs
@@ -1093,6 +1093,12 @@ impl GcRewriterImpl {
                 // emit a NULL typeptr.
                 if vtable != 0 {
                     self.gen_initialize_vtable(obj_ref.clone(), vtable, vtable_fd_ref, st);
+                    // Upstream rewrite.py:479-484 rewrites NEW_WITH_VTABLE
+                    // into allocation plus full header initialization. Pyre's
+                    // object layout carries a separate `w_class` Python-class pointer
+                    // alongside the vtable; interpreter, blackhole, and deopt-materialize
+                    // paths all write it, so compiled allocations must too or trace-time
+                    // GuardValue(w_class) folds fail deterministically on trace-made objects.
                     if let Some(w_class) = descr.w_class_obj() {
                         if w_class != 0 {
                             if let Some(w_class_fd) =

--- a/majit/majit-gc/src/rewrite.rs
+++ b/majit/majit-gc/src/rewrite.rs
@@ -1093,6 +1093,20 @@ impl GcRewriterImpl {
                 // emit a NULL typeptr.
                 if vtable != 0 {
                     self.gen_initialize_vtable(obj_ref.clone(), vtable, vtable_fd_ref, st);
+                    if let Some(w_class) = descr.w_class_obj() {
+                        if w_class != 0 {
+                            if let Some(w_class_fd) =
+                                descr.gc_fielddescrs().iter().find(|fd| fd.is_w_class())
+                            {
+                                self.gen_initialize_w_class(
+                                    obj_ref.clone(),
+                                    w_class,
+                                    w_class_fd.as_ref(),
+                                    st,
+                                );
+                            }
+                        }
+                    }
                 }
             }
         }
@@ -1120,6 +1134,9 @@ impl GcRewriterImpl {
         // per GC-pointer field (`descr.gc_fielddescrs` / unpack_fielddescr).
         let entries = st.delayed_zero_setfields(&result);
         for fd in descr.gc_fielddescrs() {
+            if fd.is_w_class() {
+                continue;
+            }
             entries.insert(fd.offset() as i64);
         }
     }
@@ -2653,6 +2670,17 @@ impl GcRewriterImpl {
             .expect("gc_ll_descr.fielddescr_vtable must be a FieldDescr");
         let vtable_ref = st.const_int(vtable as i64);
         self.emit_setfield(obj, vtable_ref, vtable_fd, st);
+    }
+
+    fn gen_initialize_w_class(
+        &self,
+        obj: Operand,
+        w_class: i64,
+        w_class_fd: &dyn FieldDescr,
+        st: &mut RewriteState,
+    ) {
+        let w_class_ref = Operand::const_from_value(Value::Ref(GcRef(w_class as usize)));
+        self.emit_setfield(obj, w_class_ref, w_class_fd, st);
     }
 
     /// rewrite.py:920-922 gen_initialize_len parity.

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -9566,6 +9566,22 @@ impl<M: Clone> MetaInterp<M> {
             .contains(&(descr.trace_id(), descr.fail_index_per_trace()))
     }
 
+    /// Record that this exact source guard's bridge hit a deterministic
+    /// structural decline before backend compilation.  Subsequent guard
+    /// failures use the existing `must_compile_with_values` short-circuit and
+    /// resume through the blackhole instead of rebuilding the same declined
+    /// bridge every trace-eagerness cycle.
+    pub fn record_declined_bridge_guard(
+        &mut self,
+        descr_arc: &std::sync::Arc<dyn majit_ir::Descr>,
+    ) {
+        let descr = descr_arc
+            .as_fail_descr()
+            .expect("record_declined_bridge_guard: descr_arc must be a FailDescr");
+        self.declined_bridge_guards
+            .insert((descr.trace_id(), descr.fail_index_per_trace()));
+    }
+
     /// memmgr.py:58-61: keep_loop_alive(looptoken).
     /// warmstate.py:402: warmrunnerdesc.memory_manager.keep_loop_alive(loop_token)
     ///

--- a/majit/majit-metainterp/src/warmstate.rs
+++ b/majit/majit-metainterp/src/warmstate.rs
@@ -287,9 +287,10 @@ fn default_enable_opts() -> Vec<String> {
     ]
 }
 
-/// Maximum number of trace aborts before permanently marking a green key
-/// as DONT_TRACE_HERE. Prevents infinite retrace loops when optimization
-/// always fails (e.g. InvalidLoop) for the same key.
+/// Pyre-local abort ceiling with no upstream analogue: after repeated aborts,
+/// mark the green key `DONT_TRACE_HERE`.  Pyre walker aborts are structural
+/// and recur identically on retrace; without a ceiling the same body would
+/// retrace forever, each attempt executing its residual calls concretely.
 const MAX_TRACE_ABORT_COUNT: u32 = 5;
 
 /// rlib/jit.py:599 disable_unrolling = 200
@@ -716,7 +717,7 @@ impl WarmEnterState {
 
     /// Typed-key variant of [`Self::abort_tracing`]. Walks the bucket
     /// chain by comparekey so a collided typed green mutates its own
-    /// cell's `JC_TRACING` / abort-count / `DONT_TRACE_HERE` state.
+    /// cell's `JC_TRACING` / pyre-local abort-count / `DONT_TRACE_HERE` state.
     pub fn abort_tracing_for_key(&mut self, key: &GreenKey, disable_noninlinable_function: bool) {
         if let Some(cell) = self.lookup_chain_with_key_mut(key) {
             cell.flags &= !jc_flags::TRACING;
@@ -842,9 +843,8 @@ impl WarmEnterState {
 
     /// Mark that tracing was aborted for a green key.
     ///
-    /// RPython parity:
-    /// - non-permanent aborts clear TRACING and allow a future retry
-    /// - permanent aborts mark the location as DONT_TRACE_HERE
+    /// Non-permanent aborts clear `JC_TRACING` and allow a future retry until
+    /// pyre's abort ceiling marks the location `DONT_TRACE_HERE`.
     pub fn abort_tracing(&mut self, green_key_hash: u64, disable_noninlinable_function: bool) {
         if let Some(cell) = self.cells.get_mut(&green_key_hash) {
             cell.flags &= !jc_flags::TRACING;

--- a/pyre/bench/synth/foriter_user_iter_kept_stack.py
+++ b/pyre/bench/synth/foriter_user_iter_kept_stack.py
@@ -1,0 +1,98 @@
+# User-defined iterator FOR_ITER paths enter a user frame for each item while
+# the caller keeps a depth > 1 operand stack resident across condexpr and
+# short-circuit branch guards.  The kept-stack branch guards must remain
+# resident and byte-exact when the mirror carries the FOR_ITER item through the
+# ResultToTos boundary, including heap-int (>= 256) merge slots, nested user
+# iterators, and a comprehension.
+
+N = 3000
+
+
+class NextIter:
+    """User __next__ iterator: FOR_ITER consume enters a user frame."""
+
+    def __init__(self, n):
+        self.i = 0
+        self.n = n
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        if self.i >= self.n:
+            raise StopIteration
+        v = self.i
+        self.i += 1
+        return v
+
+
+class GetItemSeq:
+    """Legacy __getitem__ protocol: seqiter calls a user frame per item."""
+
+    def __init__(self, n):
+        self.n = n
+
+    def __getitem__(self, i):
+        if i >= self.n:
+            raise IndexError
+        return i * 2
+
+
+def condexpr_over_user_next():
+    # depth>1 kept stack: (a+i, b-i) held while the condexpr guard evaluates.
+    a, b, s = 3, 7, 0
+    for i in NextIter(N):
+        t = (a + i, b - i, (a + i) if (i % 3 == 0) else (b - i))
+        s += t[0] + t[1] + t[2]
+    return s
+
+
+def shortcircuit_over_user_next():
+    # short-circuit merge slot at depth>1 inside `total + (x + (... or ...))`.
+    total = 0
+    for i in NextIter(N):
+        x = i + 100000
+        total = total + (x + ((i & 1) or 1000000))
+    return total
+
+
+def heap_int_shortcircuit_over_user_next():
+    # heap-int (>=256) merge slot — the boxed-int kept-slot shape.
+    acc = 0
+    for i in NextIter(N):
+        acc = acc + ((i & 1) and 500000) + ((i & 2) or 300000)
+    return acc
+
+
+def condexpr_over_getitem():
+    s = 0
+    for v in GetItemSeq(N):
+        s += (v + 1) if (v % 3 == 0) else (v - 1)
+    return s
+
+
+def nested_user_iter():
+    # iterator kept on the stack across an inner loop's guards.
+    s = 0
+    for i in NextIter(60):
+        for j in NextIter(50):
+            s += (i * j) if (j & 1) else (i + j)
+    return s
+
+
+def user_next_in_comprehension():
+    return sum([(v * 2) if (v & 1) else (v + 3) for v in NextIter(N)])
+
+
+def main():
+    print(
+        condexpr_over_user_next(),
+        shortcircuit_over_user_next(),
+        heap_int_shortcircuit_over_user_next(),
+        condexpr_over_getitem(),
+        nested_user_iter(),
+        user_next_in_comprehension(),
+    )
+
+
+main()

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -1452,14 +1452,11 @@ pub enum DispatchError {
     /// feeds NULL into the consuming op — the boxed-int short-circuit /
     /// conditional-expression resume miscompile (a heap `ConstPtr`, an int
     /// outside the 1-byte immediate range `[0, 256)`, parked in a register
-    /// live-across the guard).  Unlike [`BranchGuardKeptStackUnsupported`],
-    /// this shape is miscompiled the SAME way by BOTH the full-body walk and
-    /// the trait leg (both re-execute the identical not-taken arm on deopt),
-    /// so a recoverable [`TraceAction::Abort`] would retry the unsound shape.
-    /// The driver maps this to
-    /// `TraceAction::AbortPermanent` → `DONT_TRACE_HERE`: the loop runs in
-    /// the interpreter (correct, matching the pre-#416/#420 decline) and is
-    /// never retraced by either leg.
+    /// live-across the guard).  The driver maps this to
+    /// `TraceAction::AbortPermanent` → `DONT_TRACE_HERE`.  Demoting it to a
+    /// plain [`TraceAction::Abort`] would still reach the same terminal state
+    /// through pyre's abort ceiling, so the permanent mapping records the
+    /// structural nature of this abort without changing runtime behavior.
     BranchGuardUnrestorableKeptStackPermanent { pc: usize },
     /// A callee compiled as its own Finish portal (reached via
     /// `call_user_function_with_eval`) accessed its frame through a
@@ -10627,12 +10624,12 @@ fn step_vstack_mirror(ctx: &mut WalkContext<'_, '_>, jit_pc: usize) {
     if !ctx.vstack_valid {
         return;
     }
-    // Inside an inline sub-walk the `jit_pc` is a CALLEE coordinate that
-    // does not exist in the outer (`fbw_mode.snapshot_sym`) jitcode's
-    // py_pc→jitcode tables.  Without the `PYRE_FBW_CALLEE_VSTACK` gate the
-    // mirror declines (a callee `write_ref_reg` would clobber
-    // `vstack_last_ref`); with it, the coordinate is resolved through the
-    // active callee jitcode metadata instead.
+    // On genuine callee sub-walk paths, `jit_pc` is a callee coordinate with
+    // no meaning in the outer (`fbw_mode.snapshot_sym`) jitcode's py_pc→jitcode
+    // tables.  `inline_subwalk` is also set for the carrier walk of root code,
+    // where that premise does not hold and the mirror is simply never seeded.
+    // With `PYRE_FBW_CALLEE_VSTACK` off this branch documents intent only:
+    // `seed_callee_vstack_mirror` is gated by the same flag.
     let (new_pypc, code_ptr, new_depth) = if ctx.fbw_mode.inline_subwalk {
         if !fbw_callee_vstack_enabled() {
             ctx.vstack_valid = false;

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -10154,6 +10154,18 @@ fn classify_vstack_opcode(
         // unmodeled it killed the mirror for the rest of the walk at the first
         // nested `def`, declining any later depth > 1 kept-stack branch guard.
         | Instruction::MakeFunction
+        // SET_FUNCTION_ATTRIBUTE follows MAKE_FUNCTION for defaults,
+        // annotations, and closures, and pushes the updated function back to
+        // TOS.  The remaining ops here also leave one result on the new TOS;
+        // their arg-dependent depths are already baked into
+        // `pyre/pyre-jit-trace/src/liveness.rs`'s depth table.
+        | Instruction::SetFunctionAttribute { .. }
+        | Instruction::CallKw { .. }
+        | Instruction::BuildSlice { .. }
+        | Instruction::CallFunctionEx
+        | Instruction::CallIntrinsic1 { .. }
+        | Instruction::LoadCommonConstant { .. }
+        | Instruction::LoadFromDictOrGlobals { .. }
         // #73: LOAD_FAST/STORE_FAST super-instructions.  Their net
         // result still lands on the new TOS as the LAST Ref written (the
         // second load, resp. the load following the store), so `ResultToTos`
@@ -10189,13 +10201,19 @@ fn classify_vstack_opcode(
         | Instruction::StoreSubscr
         | Instruction::DeleteSubscr
         | Instruction::StoreSlice
-        // LIST_APPEND / SET_ADD / MAP_ADD / LIST_EXTEND pop their value operand(s)
-        // and mutate the collection PEEK'd in place below them — a side-store,
-        // same shape as STORE_SUBSCR: the surviving TOS box stays put.
+        // LIST_APPEND / SET_ADD / MAP_ADD / LIST_EXTEND and the dict/set
+        // update opcodes pop their value operand(s) and mutate the collection
+        // PEEK'd in place below them — a side-store, same shape as
+        // STORE_SUBSCR: the surviving TOS box stays put. MAKE_CELL stores its
+        // result into the frame-local virtualizable slot, not operand TOS.
         | Instruction::ListAppend { .. }
         | Instruction::SetAdd { .. }
         | Instruction::MapAdd { .. }
         | Instruction::ListExtend { .. }
+        | Instruction::DictUpdate { .. }
+        | Instruction::DictMerge { .. }
+        | Instruction::SetUpdate { .. }
+        | Instruction::MakeCell { .. }
         | Instruction::DeleteFast { .. }
         | Instruction::DeleteName { .. }
         | Instruction::DeleteGlobal { .. }

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -2139,6 +2139,30 @@ fn write_ref_reg(
     Ok(())
 }
 
+/// Write a pyre scalar virtualizable Ref field without stamping operand TOS.
+///
+/// Pyre's scalar virtualizable fields are `last_instr(0)`, `pycode(1)`,
+/// `valuestackdepth(2)`, `debugdata(3)`, `lastblock(4)`, and `w_globals(5)`
+/// (`virtualizable_gen.rs:33-60`, `NUM_VABLE_SCALARS = 6`).  They are frame
+/// bookkeeping; the Python operand stack lives in the separate
+/// `locals_cells_stack_w` array (`virtualizable_gen.rs:66-72`,
+/// `pyre-interpreter/src/pyframe.rs:735-739`).  PyPy's `interp_jit.py:24-30`
+/// grounds the same scalar-vs-array split, and `pyjitpl.py:177-234
+/// get_list_of_active_boxes` sources liveness-indexed register boxes, not
+/// scalar virtualizable fields.
+fn write_vable_field_ref_reg(
+    ctx: &mut WalkContext<'_, '_>,
+    pc: usize,
+    dst: usize,
+    value: OpRef,
+    concrete: ConcreteValue,
+) -> Result<(), DispatchError> {
+    let saved = ctx.vstack_last_ref;
+    write_ref_reg(ctx, pc, dst, value, concrete)?;
+    ctx.vstack_last_ref = saved;
+    Ok(())
+}
+
 /// Int-bank twin of [`read_ref_reg_concrete`] (Int-bank concrete shadow).
 /// Reads the Int-bank slot at the operand index from
 /// `ctx.concrete_registers_i`.  Returns `ConcreteValue::Null` for
@@ -4304,7 +4328,7 @@ fn getfield_gc_via_heapcache(
     Ok((DispatchOutcome::Continue, op.next_pc))
 }
 
-/// `interp_jit.py:25-31` PyFrame static-field order
+/// `virtualizable_gen.rs:33-60` pyre PyFrame static-field order
 /// `[last_instr, pycode, valuestackdepth, debugdata, lastblock, w_globals]`.
 const VABLE_CODE_FIELD_IDX: usize = 1;
 const VABLE_NAMESPACE_FIELD_IDX: usize = 5;
@@ -4378,7 +4402,7 @@ fn try_resolve_inline_callee_static_field(
     };
     let result = ctx.trace_ctx.const_ref(const_ptr as i64);
     let dst = code[op.pc + 4] as usize;
-    write_ref_reg(
+    write_vable_field_ref_reg(
         ctx,
         op.pc,
         dst,
@@ -4512,13 +4536,7 @@ fn getfield_vable_via_metainterp(
             write_int_reg(ctx, op.pc, dst, result, concrete_for_shadow)?;
         }
         'r' => {
-            // Scalar vable fields are frame bookkeeping, never Python
-            // operand-stack values, so they must not become the mirror's TOS
-            // candidate. `get_list_of_active_boxes` (pyjitpl.py:177-234)
-            // never names scalar fields as per-PC stack slots.
-            let vstack_last_ref = ctx.vstack_last_ref;
-            write_ref_reg(ctx, op.pc, dst, result, concrete_for_shadow)?;
-            ctx.vstack_last_ref = vstack_last_ref;
+            write_vable_field_ref_reg(ctx, op.pc, dst, result, concrete_for_shadow)?;
         }
         'f' => {
             let len = ctx.registers_f.len();

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -4433,6 +4433,64 @@ fn top_level_live_code(ctx: &WalkContext<'_, '_>) -> Option<*const ()> {
     }
 }
 
+fn guard_current_frame_globals_identity(
+    ctx: &mut WalkContext<'_, '_>,
+    op_pc: usize,
+    expected_globals: pyre_object::PyObjectRef,
+) -> Result<bool, DispatchError> {
+    if expected_globals.is_null() || majit_gc::can_move(majit_ir::GcRef(expected_globals as usize))
+    {
+        return Ok(false);
+    }
+    let Some(w_globals_op) = ctx
+        .trace_ctx
+        .virtualizable_box_at(VABLE_NAMESPACE_FIELD_IDX)
+    else {
+        return Ok(false);
+    };
+    let expected = ctx.trace_ctx.const_ref(expected_globals as i64);
+    if w_globals_op.is_constant() {
+        return Ok(ctx.trace_ctx.const_value(w_globals_op) == Some(expected_globals as i64));
+    }
+    // pypy/objspace/std/celldict.py `elidable_promote('0,1,2')` promotes
+    // `w_dict`; mirror that by pinning the runtime frame's w_globals identity.
+    ctx.trace_ctx
+        .record_guard(OpCode::GuardValue, &[w_globals_op, expected], 0);
+    walker_capture_snapshot_for_last_guard(ctx, op_pc)?;
+    ctx.trace_ctx.replace_box(w_globals_op, expected);
+    for slot in ctx.registers_r.iter_mut() {
+        if *slot == w_globals_op {
+            *slot = expected;
+        }
+    }
+    Ok(true)
+}
+
+fn replace_movable_load_global_namespace_with_frame_globals(
+    ctx: &mut WalkContext<'_, '_>,
+    ei: &majit_ir::EffectInfo,
+    allboxes: &mut [OpRef],
+) {
+    if ei.pyre_helper != majit_ir::PyreHelperKind::LoadGlobal {
+        return;
+    }
+    let Some(ns_box) = allboxes.get_mut(1) else {
+        return;
+    };
+    let Some(Value::Ref(majit_ir::GcRef(ns_ptr))) = ctx.trace_ctx.box_value(*ns_box) else {
+        return;
+    };
+    if !majit_gc::can_move(majit_ir::GcRef(ns_ptr)) {
+        return;
+    }
+    if let Some(w_globals_op) = ctx
+        .trace_ctx
+        .virtualizable_box_at(VABLE_NAMESPACE_FIELD_IDX)
+    {
+        *ns_box = w_globals_op;
+    }
+}
+
 /// Path-1 (#68): resolve a scalar `getfield_vable_r` read off an inlined
 /// callee's OWN (unseeded) portal frame to the callee's compile-time
 /// constant.  This is the walk-time mirror of the codewriter's non-portal
@@ -17064,7 +17122,8 @@ fn dispatch_residual_call_iRd_kind(
 
     // `_r_*` shape: argboxes = R-list only; argbox_types = [Ref; n].
     let argbox_types: Vec<Type> = vec![Type::Ref; r_args.len()];
-    let allboxes = build_allboxes(funcptr, &r_args, &argbox_types, call_descr.arg_types());
+    let mut allboxes = build_allboxes(funcptr, &r_args, &argbox_types, call_descr.arg_types());
+    replace_movable_load_global_namespace_with_frame_globals(ctx, ei, &mut allboxes);
     if let Err(e) = ensure_residual_call_args_bound(&allboxes, op.pc) {
         if fbw_debug_abort_enabled() {
             let len_pc = op.pc + 1 + 1;
@@ -23439,6 +23498,9 @@ fn try_walker_load_global_cell_fold(
     // ignores the slot); use `usize::MAX` as a past-the-end sentinel so the
     // `quasi_immut_cache` key cannot collide with a real cell fold's slot for
     // a DIFFERENT present name on the same module dict.
+    if !guard_current_frame_globals_identity(ctx, op_pc, w_globals)? {
+        return Ok(false);
+    }
     let abs_ns_const = ctx.trace_ctx.const_ref(w_globals as i64);
     let abs_slot_const = ctx.trace_ctx.const_int(usize::MAX as i64);
     crate::state::record_namespace_quasiimmut_field(
@@ -23452,7 +23514,21 @@ fn try_walker_load_global_cell_fold(
     // `emit_namespace_cell_fold` below records a `QUASIIMMUT_FIELD` on the
     // builtins dict + the elidable cell lookup, so a rebind/del of the
     // builtin bumps the builtins-dict `version` and fails the loop.
-    emit_namespace_cell_fold(ctx, op_pc, dst, dst_bank, w_builtin_dict, b_slot, b_stored)?;
+    if majit_gc::can_move(majit_ir::GcRef(w_builtin_dict as usize)) {
+        return Ok(false);
+    }
+    if !emit_namespace_cell_fold(
+        ctx,
+        op_pc,
+        dst,
+        dst_bank,
+        w_builtin_dict,
+        b_slot,
+        b_stored,
+        false,
+    )? {
+        return Ok(false);
+    }
     Ok(true)
 }
 
@@ -23546,8 +23622,9 @@ fn emit_module_dict_cell_fold(
                 // (never nursery), so `can_move` is false and a hot int/object
                 // global folds; a raw movable value does not.
                 if !majit_gc::can_move(majit_ir::GcRef(stored as usize)) {
-                    emit_namespace_cell_fold(ctx, op_pc, dst, dst_bank, w_globals, slot, stored)?;
-                    return Ok(true);
+                    return emit_namespace_cell_fold(
+                        ctx, op_pc, dst, dst_bank, w_globals, slot, stored, true,
+                    );
                 }
             }
         }
@@ -23577,11 +23654,15 @@ fn emit_namespace_cell_fold(
     ns: pyre_object::PyObjectRef,
     slot: usize,
     stored: pyre_object::PyObjectRef,
-) -> Result<(), DispatchError> {
+    guard_frame_globals: bool,
+) -> Result<bool, DispatchError> {
     let is_obj_cell = unsafe { pyre_object::celldict::is_object_mutable_cell(stored) };
     let is_int_cell = unsafe { pyre_object::celldict::is_int_mutable_cell(stored) };
     let result_obj = unsafe { pyre_object::celldict::unwrap_cell(stored) };
 
+    if guard_frame_globals && !guard_current_frame_globals_identity(ctx, op_pc, ns)? {
+        return Ok(false);
+    }
     let ns_const = ctx.trace_ctx.const_ref(ns as i64);
     let slot_const = ctx.trace_ctx.const_int(slot as i64);
     crate::state::record_namespace_quasiimmut_field(
@@ -23649,7 +23730,7 @@ fn emit_namespace_cell_fold(
     // `last_exc_value` set and the walk aborts `CatchExceptionWithActiveException`.
     ctx.last_exc_value = None;
     ctx.last_exc_value_concrete = ConcreteValue::Null;
-    Ok(())
+    Ok(true)
 }
 
 /// LoadName cell fold — module-scope LOAD_NAME mirror of
@@ -24304,6 +24385,8 @@ fn dispatch_residual_call_iIRd_kind(
             }
         }
     }
+
+    replace_movable_load_global_namespace_with_frame_globals(ctx, ei, &mut allboxes);
 
     // Defer the arg-bound check past the short-circuiting LoadConst /
     // LoadGlobal folds above: each resolves the call to a constant from

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -1961,6 +1961,20 @@ fn try_catch_exception_at(code: &[u8], position: usize) -> Option<usize> {
     }
 }
 
+fn reads_last_exc_before_next_catch(code: &[u8], position: usize) -> bool {
+    let mut pc = position;
+    while let Some(op) = decode_op_at(code, pc) {
+        if op.key == "catch_exception/L" {
+            return false;
+        }
+        if matches!(op.key, "last_exception/>i" | "last_exc_value/>r") {
+            return true;
+        }
+        pc = op.next_pc;
+    }
+    false
+}
+
 /// Read a 2-byte little-endian descr index operand and resolve to
 /// the descr from [`WalkContext::descr_refs`]. RPython equivalent:
 /// `BlackholeInterpreter.descrs[code[pc] | (code[pc+1] << 8)]`
@@ -2646,6 +2660,66 @@ fn dispatch_switch_id(
 /// **Production wiring**: the full-body-walk walker
 /// (`full_body_walk_trace`) is the caller, dispatching each JitCode
 /// opcode through this entry as it walks the body.
+fn seed_standing_exception_for_walk(
+    sym: &mut crate::state::PyreSym,
+    trace_ctx: &mut TraceCtx,
+    concrete_frame_addr: usize,
+) {
+    if !sym.last_exc_box.is_none() {
+        return;
+    }
+
+    let bh_exc = majit_metainterp::blackhole::BH_LAST_EXC_VALUE.with(|c| c.get());
+    if bh_exc != 0 {
+        let exc = bh_exc as pyre_object::PyObjectRef;
+        if !exc.is_null() && unsafe { pyre_object::is_exception(exc) } {
+            let exc_box = trace_ctx.const_ref(exc as i64);
+            sym.current_exc_value = exc;
+            sym.current_exc_box = exc_box;
+            sym.last_exc_value = exc;
+            sym.last_exc_box = exc_box;
+            sym.class_of_last_exc_is_const = true;
+            return;
+        }
+    }
+
+    let current = pyre_interpreter::eval::get_current_exception();
+    if !current.is_null() && unsafe { pyre_object::is_exception(current) } {
+        let exc_box = trace_ctx.const_ref(current as i64);
+        sym.current_exc_value = current;
+        sym.current_exc_box = exc_box;
+        sym.last_exc_value = current;
+        sym.last_exc_box = exc_box;
+        sym.class_of_last_exc_is_const = true;
+        return;
+    }
+
+    if concrete_frame_addr == 0 {
+        return;
+    }
+    let frame = unsafe { &*(concrete_frame_addr as *const pyre_interpreter::pyframe::PyFrame) };
+    if frame.locals_cells_stack_w.is_null() {
+        return;
+    }
+    let nlocals = crate::state::concrete_nlocals(concrete_frame_addr).unwrap_or(0);
+    let stack_top = frame.valuestackdepth.min(frame.locals_w().len());
+    let Some(exc) = frame.locals_w().as_slice()[nlocals.min(stack_top)..stack_top]
+        .iter()
+        .rev()
+        .copied()
+        .find(|obj| !obj.is_null() && unsafe { pyre_object::is_exception(*obj) })
+    else {
+        return;
+    };
+
+    let exc_box = trace_ctx.const_ref(exc as i64);
+    sym.current_exc_value = exc;
+    sym.current_exc_box = exc_box;
+    sym.last_exc_value = exc;
+    sym.last_exc_box = exc_box;
+    sym.class_of_last_exc_is_const = true;
+}
+
 #[allow(clippy::too_many_arguments)]
 pub fn dispatch_via_miframe(
     miframe: &mut MIFrame,
@@ -2695,6 +2769,7 @@ pub fn dispatch_via_miframe(
     // means dereferencing both simultaneously is sound.
     let ctx_ptr = miframe.ctx;
     let sym_ptr = miframe.sym;
+    let concrete_frame_addr = miframe.concrete_frame_addr;
     let entry_py_pc = EntryPyPc::Py(miframe.orgpc as u32);
     // SAFETY: both pointers were initialized at MIFrame
     // construction time and outlive this call (TraceCtx and
@@ -2730,6 +2805,7 @@ pub fn dispatch_via_miframe(
     // references it (use-before-def).  Seed here — the trait's pre-guard
     // cache-once analog — so every guard snapshot reads a real EC OpRef.
     seed_execution_context_for_walk(sym, trace_ctx);
+    seed_standing_exception_for_walk(sym, trace_ctx, concrete_frame_addr);
 
     // RPython parity: `metainterp.last_exc_value` (pyjitpl.py:1695)
     // is the standing exception OpRef. Walker's `WalkContext::last_exc_value`
@@ -23790,8 +23866,13 @@ fn dispatch_residual_call_iIRd_kind(
 ) -> Result<(DispatchOutcome, usize), DispatchError> {
     // execute_varargs (pyjitpl.py:1940-1941) clear_exception at every
     // residual-call entry; see dispatch_residual_call_iRd_kind.
-    ctx.last_exc_value = None;
-    ctx.last_exc_value_concrete = ConcreteValue::Null;
+    let saved_last_exc_value = ctx.last_exc_value;
+    let saved_last_exc_value_concrete = ctx.last_exc_value_concrete;
+    let preserve_last_exc_for_handler =
+        saved_last_exc_value.is_some() && reads_last_exc_before_next_catch(code, op.next_pc);
+    if !preserve_last_exc_for_handler {
+        clear_walk_exception(ctx);
+    }
     let funcptr = read_int_reg(code, op, 0, ctx)?;
     let (i_args, i_width) = read_int_var_list(code, op, 1, ctx)?;
     let (r_args, r_width) = read_ref_var_list(code, op, 1 + i_width, ctx)?;
@@ -23886,7 +23967,6 @@ fn dispatch_residual_call_iIRd_kind(
         })?;
 
     let ei = call_descr.get_extra_info();
-    clear_walk_exception(ctx);
     // pyjitpl.py:2003-2005 OS_NOT_IN_TRACE guard — see helper docstring
     // for the convergence rationale.
     if let Some(outcome) = do_not_in_trace_call_result(ei, op.pc)? {
@@ -24327,7 +24407,15 @@ fn dispatch_residual_call_iIRd_kind(
                     // decline for Ref operands → generic residual) when an
                     // operand has no concrete shadow or the match target is
                     // not a valid exception class.
-                    try_walker_fold_check_exc_match(ctx, op.pc, &r_args, dst, dst_bank)?
+                    let keep_last_exc_for_handler =
+                        reads_last_exc_before_next_catch(code, op.next_pc);
+                    let folded =
+                        try_walker_fold_check_exc_match(ctx, op.pc, &r_args, dst, dst_bank)?;
+                    if folded.is_some() && keep_last_exc_for_handler {
+                        ctx.last_exc_value = saved_last_exc_value;
+                        ctx.last_exc_value_concrete = saved_last_exc_value_concrete;
+                    }
+                    folded
                 } else {
                     // int compare first; then long (two-bigint operands keep
                     // bigint comparison); float (incl. mixed int/float) last.
@@ -26747,7 +26835,16 @@ fn handle(
             // so a downstream
             // `last_exc_value/>r` can propagate it into its dst slot.
             let exc = read_ref_reg(code, op, 0, ctx)?;
-            let concrete_exc = read_ref_reg_concrete(code, op, 0, ctx);
+            let mut concrete_exc = read_ref_reg_concrete(code, op, 0, ctx);
+            if matches!(concrete_exc, ConcreteValue::Ref(p) if p.is_null())
+                && let Some(Value::Ref(gc_ref)) = ctx.trace_ctx.box_value(exc)
+                && gc_ref != majit_ir::GcRef::NO_CONCRETE
+            {
+                let ptr = gc_ref.as_usize() as pyre_object::PyObjectRef;
+                if !ptr.is_null() && unsafe { pyre_object::is_exception(ptr) } {
+                    concrete_exc = ConcreteValue::Ref(ptr);
+                }
+            }
             // `pyjitpl.py:1688-1693 opimpl_raise` calls
             // `generate_guard(GUARD_CLASS, exc_value_box, clsbox,
             // resumepc=orgpc)`; the first line of `generate_guard`
@@ -26871,19 +26968,25 @@ fn handle(
             //
             // Operand layout `>i`: 1B dst register only; the dst byte sits
             // at `op.pc + 1`.
-            let _exc = ctx
+            let exc = ctx
                 .last_exc_value
                 .ok_or(DispatchError::LastExceptionWithoutActiveException { pc: op.pc })?;
-            let exc_ptr = match ctx.last_exc_value_concrete {
-                ConcreteValue::Ref(p) if !p.is_null() => p,
-                _ => {
-                    return Err(DispatchError::LastExceptionWithoutActiveException { pc: op.pc });
+            let typeptr = if let Some(cls) = ctx.trace_ctx.heap_cache().get_known_class(exc) {
+                cls
+            } else {
+                let exc_ptr = match ctx.last_exc_value_concrete {
+                    ConcreteValue::Ref(p) if !p.is_null() => p,
+                    _ => {
+                        return Err(DispatchError::LastExceptionWithoutActiveException {
+                            pc: op.pc,
+                        });
+                    }
+                };
+                unsafe {
+                    (*(exc_ptr as *const pyre_object::interp_exceptions::W_BaseException))
+                        .ob_header
+                        .ob_type as i64
                 }
-            };
-            let typeptr = unsafe {
-                (*(exc_ptr as *const pyre_object::interp_exceptions::W_BaseException))
-                    .ob_header
-                    .ob_type as i64
             };
             let dst = code[op.pc + 1] as usize;
             let cls_const = ctx.trace_ctx.const_int(typeptr);

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -1451,11 +1451,11 @@ pub enum DispatchError {
     /// produced inside the arm, so the blackhole resumes it as NULL and
     /// feeds NULL into the consuming op — the boxed-int short-circuit /
     /// conditional-expression resume miscompile (a heap `ConstPtr`, an int
-    /// outside the small-int cache, parked in a register live-across the
-    /// guard).  Unlike [`BranchGuardKeptStackUnsupported`], this shape is
-    /// miscompiled the SAME way by BOTH the full-body walk and the trait
-    /// leg (both re-execute the identical not-taken arm on deopt), so a
-    /// recoverable [`TraceAction::Abort`] would retry the unsound shape.
+    /// outside the 1-byte immediate range `[0, 256)`, parked in a register
+    /// live-across the guard).  Unlike [`BranchGuardKeptStackUnsupported`],
+    /// this shape is miscompiled the SAME way by BOTH the full-body walk and
+    /// the trait leg (both re-execute the identical not-taken arm on deopt),
+    /// so a recoverable [`TraceAction::Abort`] would retry the unsound shape.
     /// The driver maps this to
     /// `TraceAction::AbortPermanent` → `DONT_TRACE_HERE`: the loop runs in
     /// the interpreter (correct, matching the pre-#416/#420 decline) and is
@@ -8302,28 +8302,6 @@ pub(crate) fn fbw_vable_scalar_ca_enabled() -> bool {
     })
 }
 
-/// `PYRE_FBW_DEEPKEPT_INT` (default OFF) — extend the deep-kept operand-stack
-/// recovery in [`walker_capture_snapshot_for_last_guard_impl`] to fill an
-/// UNBOXED-INT hole from the Int register bank. A Ref-typed stack slot
-/// semantically holding an Int (e.g. condexpr's `a+i` `IntAdd` result) is left
-/// a hole by the Ref-only fill; when on, the capture reads `registers_i[color]`
-/// (the color named by `semantic_slot_color_for_int_slot`) and boxes the raw
-/// int into a `W_IntObject` (`wrapint`) so the vable array carries a Ref.
-/// Ports the `if length_i:` i-bank section of `get_list_of_active_boxes`
-/// (`pyjitpl.py:206-210`). Default OFF: flag-off is byte-identical to the
-/// int-as-hole behavior (resume re-materializes the int from its defining IR),
-/// mirroring how the S1 mirror extension staged behind `PYRE_FBW_DEEPKEPT_MIRROR`.
-pub(crate) fn deepkept_int_recovery_enabled() -> bool {
-    static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
-    *ENABLED.get_or_init(|| match std::env::var_os("PYRE_FBW_DEEPKEPT_INT") {
-        Some(v) => {
-            let v = v.to_string_lossy();
-            v != "0" && !v.eq_ignore_ascii_case("false")
-        }
-        None => false,
-    })
-}
-
 /// `PYRE_FBW_RAISE` (default ON) — the FBW walker owns the Python raise/except
 /// loop.  The twin NULL-ref guards exempt the trailing `cause` sentinel of a
 /// [`PyreHelperKind::RaiseVarargs`] residual so the walker records the raise.
@@ -10193,6 +10171,14 @@ fn classify_vstack_opcode(
         | Instruction::ConvertValue { .. }
         | Instruction::BinarySlice
         | Instruction::ImportName { .. }
+        // MAKE_FUNCTION pops the code object and pushes the built function
+        // (net 0, `stack_effects` `(d, d)`).  The `make_function_value`
+        // residual's Ref result reaches the new TOS through the operand-stack
+        // push chokepoint (`emit_pushvalue_ref!`, codewriter.rs:9260), so it is
+        // the same `ResultToTos` shape as the value producers above.  Left
+        // unmodeled it killed the mirror for the rest of the walk at the first
+        // nested `def`, declining any later depth > 1 kept-stack branch guard.
+        | Instruction::MakeFunction
         // #73: LOAD_FAST/STORE_FAST super-instructions.  Their net
         // result still lands on the new TOS as the LAST Ref written (the
         // second load, resp. the load following the store), so `ResultToTos`
@@ -11765,11 +11751,12 @@ fn branch_resume_target_stack_depth(frame: &ActiveResumeFrame, target: usize) ->
 }
 
 /// Flat-free (#267) boxed-int kept-slot hazard: a kept operand-stack slot
-/// holding a heap int outside `[0, 256)` is reconstructed with a WRONG / NULL
-/// value on a kept-stack branch-guard resume (the conditional-expression /
-/// short-circuit boxed-int crash), so its presence forces the conservative
-/// decline.  This replaces the dense `stack_slot_color_map` read the gate used
-/// to inspect: every kept-slot kind has a per-PC source — a live Variable
+/// holding a heap int outside the 1-byte immediate range `[0, 256)` is
+/// reconstructed with a WRONG / NULL value on a kept-stack branch-guard resume
+/// (the conditional-expression / short-circuit boxed-int crash), so its
+/// presence forces the conservative decline.  This replaces the dense
+/// `stack_slot_color_map` read the gate used to inspect: every kept-slot kind
+/// has a per-PC source — a live Variable
 /// through `pcdep_color_slots` (inspect its concrete register), a Ref constant
 /// (the hoisted boxed int `pcdep_color_slots` omits) through
 /// `const_ref_slots_at_pc` (inspect the raw value).  A kept slot in NEITHER map
@@ -11929,10 +11916,10 @@ fn branch_arm_resume_ref_liveness(
 ///
 /// That is the boxed-int short-circuit / conditional-expression resume
 /// miscompile: when the codewriter parks a heap constant (a co_consts
-/// `ConstPtr` — an int outside the small-int cache, `>= 257` or negative —
-/// or any value computed before the branch) in a regular register
+/// `ConstPtr` — an int outside the 1-byte immediate range `[0, 256)` — or any
+/// value computed before the branch) in a regular register
 /// live-ACROSS the guard rather than materializing it inside the arm, the
-/// resume cannot restore it.  Cached small ints materialize via an in-arm
+/// resume cannot restore it.  One-byte immediates materialize via an in-arm
 /// `residual_call` (a write the blackhole re-executes), so their arms stay
 /// restorable and keep compiling.
 ///
@@ -12756,65 +12743,29 @@ fn walker_capture_snapshot_for_last_guard_impl(
                             // `OpRef::ty()`.  An unboxed-int kept temp (a `Ref`-
                             // bank color holding an `IntAdd` result, e.g.
                             // condexpr's `a+i`) is Int-typed and would decode as
-                            // `Box type Int != expected Ref`; it needs a
-                            // `NEW_W_INT` box the capture cannot synthesize
-                            // (boxing here emits into a settled trace →
-                            // `store_final_boxes_in_guard` panic), so leave it a
-                            // hole (the mirror already sourced every restorable
-                            // slot). The int-bank recovery below handles the
-                            // bank-0 channel where a raw int lives in the Int
-                            // register file instead.
+                            // `Box type Int != expected Ref`. Boxing it after
+                            // the guard is appended would make the guard
+                            // snapshot reference a box defined after the guard,
+                            // so the box was never computed on guard failure.
+                            // RPython materializes failargs before appending the
+                            // guard (`optimizer.py:664-672,705,708-710`).
+                            //
+                            // The hole stands because pyre elides the int box at
+                            // the tracer layer, losing the descr/known_class/
+                            // field structure deopt needs. RPython elides at
+                            // the optimizer layer (`virtualize.py:197-209`),
+                            // keeps `InstancePtrInfo`, and serializes a
+                            // TAGVIRTUAL recipe (`resume.py:415-426,487-500`)
+                            // materialized lazily only on guard failure
+                            // (`resume.py:618-621`). The orthodox fix is
+                            // push-time boxing plus optimizer virtualization,
+                            // beyond this capture hook.
                             if box_op != OpRef::NONE
                                 && !opref_is_null_const_ptr(box_op)
                                 && box_op.ty() == Some(majit_ir::Type::Ref)
                             {
                                 augmented.push((vidx, box_op));
                                 covered.insert(vidx);
-                            }
-                        }
-                    }
-                    // Int-bank fill (`get_list_of_active_boxes` `if length_i:`
-                    // section, `pyjitpl.py:206-210` —
-                    // `add_box_to_storage(self.registers_i[index])`), gated
-                    // `PYRE_FBW_DEEPKEPT_INT` (default OFF). Ref precedence:
-                    // only fill a slot the Ref bank left a hole. A bank-0 (Int)
-                    // pcdep entry names the Int-bank color owning slot
-                    // `nlocals + s`, and `registers_i[color]` holds the raw
-                    // unboxed int; box it into a `W_IntObject` (`wrapint`, the
-                    // `NewWithVtable` + `SetfieldGc(intval)` pair
-                    // `materialize_loop_carried_value` emits for a Ref-typed
-                    // loop-carried slot) so the uniformly Ref-typed vable array
-                    // carries a Ref, not a raw Int the resume decode would
-                    // reject as `Box type Int != expected Ref`. Default OFF:
-                    // flag-off leaves the int a hole, byte-identical to today
-                    // (resume re-materializes it from its defining IR).
-                    //
-                    // Scaffolding on the current frontend: pyre's operand stack
-                    // is uniformly Ref-banked in the pcdep map
-                    // (`locals_cells_stack_w` is a `W_Root[]` array), so no
-                    // bank-0 stack entry exists yet and this fires nowhere. The
-                    // real int-hole source — a Ref-bank color whose
-                    // `registers_r[color]` OpRef is itself Int-typed — CANNOT be
-                    // boxed here: `wrapint` emits `NewWithVtable` + `SetfieldGc`
-                    // into an already-settled trace at capture time, which trips
-                    // `store_final_boxes_in_guard` (`resume.py:397`
-                    // `resume_position >= 0`). The box must be synthesized at
-                    // operand-stack PUSH time, not lazily at snapshot capture —
-                    // that is a frontend change beyond this capture hook (a
-                    // bank-0 channel, e.g. the tagged-int epic, or a push-time
-                    // NEW_W_INT), tracked as a follow-up. This literal i-bank
-                    // read stays as the RPython-parity channel for when bank-0
-                    // stack entries do exist.
-                    if deepkept_int_recovery_enabled() && !covered.contains(&vidx) {
-                        if let Some(color) =
-                            crate::state::semantic_slot_color_for_int_slot(&pcdep, nlocals + s)
-                        {
-                            if let Some(&raw) = ctx.registers_i.get(color) {
-                                if raw != OpRef::NONE && raw.ty() == Some(majit_ir::Type::Int) {
-                                    let boxed = crate::state::wrapint(ctx.trace_ctx, raw);
-                                    augmented.push((vidx, boxed));
-                                    covered.insert(vidx);
-                                }
                             }
                         }
                     }

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -6740,16 +6740,6 @@ fn try_execute_residual_call_via_executor(
     // the `for_iter_next` consume itself never counts).
     let user_frame_snapshot = (!provably_side_effect_free && fbw_foriter_inflight_active())
         .then(pyre_interpreter::call::frame_entry_count);
-    // #73/#267: the user-frame gate above excludes the `for_iter_next` consume
-    // itself, so sample the frame odometer separately for it — a user-defined
-    // iterator's `__next__`/`__getitem__` runs Python bytecode (the odometer
-    // advances) while a builtin iterator's next runs at the C level (it does
-    // not).  The operand-stack mirror cannot yet reconcile the inline sub-walk
-    // that the user iterator's bytecode drives, so the post-call decline uses
-    // this to keep the legacy resume for a user-iterator FOR_ITER while a
-    // builtin FOR_ITER stays modeled.
-    let foriter_frame_snapshot = (helper == majit_ir::PyreHelperKind::ForIterNext)
-        .then(pyre_interpreter::call::frame_entry_count);
     // #493: a NEW consume attempt for a FOR_ITER whose prior item is still in
     // flight means that item's body ran to completion — mark the entry BEFORE
     // the call so an attempt that aborts mid-way (a kept-stack guard on the
@@ -6869,19 +6859,6 @@ fn try_execute_residual_call_via_executor(
     {
         fbw_bump_executed_effect();
     }
-    // #73/#267: a user-defined iterator's FOR_ITER runs its item producer
-    // (`__next__`/`__getitem__`) as an inline sub-walk whose operand-stack
-    // boundaries the mirror does not yet reconcile — keeping the mirror valid
-    // across such a FOR_ITER grafts a corrupt box at a loop-body guard resume
-    // ("not an iterator").  Decline the mirror for the rest of this walk (the
-    // legacy resume, unchanged from the pre-`ResultToTos` behaviour) when the
-    // `for_iter_next` consume entered a user frame; a BUILTIN iterator's
-    // consume runs at the C level (no user frame) and stays modeled.
-    let foriter_entered_user_frame = foriter_frame_snapshot
-        .is_some_and(|before| pyre_interpreter::call::frame_entry_count() != before);
-    if foriter_entered_user_frame {
-        ctx.vstack_valid = false;
-    }
     match exec_result {
         Ok(result_i64) => {
             fbw_count_executed_residual(is_void, is_may_force);
@@ -6957,11 +6934,9 @@ fn try_execute_residual_call_via_executor(
                 // still holds whatever inner box the ForIterNext produced.  Seed
                 // it with the item OpRef so the FOR_ITER boundary
                 // (`ResultToTos`) places the item, not a stale box, on the new
-                // TOS.  Reached for a builtin iterator only: a user-defined
-                // iterator already latched `vstack_valid = false` above
-                // (`foriter_entered_user_frame`), so this seed is inert for it
-                // (`vstack_last_ref` is consumed only while the mirror is
-                // valid).
+                // TOS.  This runs for every `ForIterNext` residual once it
+                // returns, placing the item OpRef on the new TOS for the
+                // FOR_ITER `ResultToTos` boundary.
                 ctx.vstack_last_ref = recorded;
                 if fbw_debug_abort_enabled() {
                     pcmap_entrypc_audit_ctx_read(ctx, "foriter_debug");

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -1785,27 +1785,6 @@ pub(crate) fn semantic_slot_for_reg_color(
     stack_match.or(local_match)
 }
 
-/// Bank-generic inverse of [`semantic_slot_for_reg_color`]: given a semantic
-/// `locals_cells_stack_w` slot and a bank tag (`pyjitcode.rs:198-204`:
-/// 0=Int, 1=Ref, 2=Float), return the color of that bank owning the slot at
-/// this PC per the `(bank, color, slot)` map. Returns the smallest matching
-/// color; `None` when no live color of that bank owns the slot at this PC.
-fn semantic_slot_color_for_slot(
-    pcdep_entries: &[(u8, u16, u16)],
-    slot: usize,
-    bank: u8,
-) -> Option<usize> {
-    let mut best: Option<usize> = None;
-    for &(b, color, s) in pcdep_entries {
-        if b != bank || s as usize != slot {
-            continue;
-        }
-        let c = color as usize;
-        best = Some(best.map_or(c, |cur: usize| cur.min(c)));
-    }
-    best
-}
-
 /// Inverse of [`semantic_slot_for_reg_color`] for the Ref bank: given a
 /// semantic `locals_cells_stack_w` slot, return the Ref-bank color that owns
 /// it at this PC per the `(bank, color, slot)` map. Used by the deep-kept
@@ -1817,28 +1796,15 @@ pub(crate) fn semantic_slot_color_for_ref_slot(
     pcdep_entries: &[(u8, u16, u16)],
     slot: usize,
 ) -> Option<usize> {
-    semantic_slot_color_for_slot(pcdep_entries, slot, 1)
-}
-
-/// Int-bank inverse of [`semantic_slot_for_reg_color`]: given a semantic
-/// `locals_cells_stack_w` slot, return the Int-bank color (`registers_i`) that
-/// owns it at this PC per the `(bank, color, slot)` map. The Int-bank sibling
-/// of [`semantic_slot_color_for_ref_slot`], feeding the deep-kept UNBOXED-INT
-/// operand-stack recovery in `walker_capture_snapshot_for_last_guard_impl`: a
-/// bank-0 (Int) stack slot names the guard-PC `registers_i[color]` holding the
-/// raw int, which the capture then boxes into a `W_IntObject`.
-/// `get_list_of_active_boxes` (`pyjitpl.py:206-210`) captures the i-bank via a
-/// separate `if length_i:` section
-/// (`add_box_to_storage(self.registers_i[index])`). Returns the smallest
-/// matching color; `None` when no live Int color owns the slot — which is
-/// every current-frontend stack slot, since pyre banks `locals_cells_stack_w`
-/// uniformly as Ref (bank-1). See the caller for why the Ref-bank Int-typed
-/// hole is NOT recovered by boxing at capture time.
-pub(crate) fn semantic_slot_color_for_int_slot(
-    pcdep_entries: &[(u8, u16, u16)],
-    slot: usize,
-) -> Option<usize> {
-    semantic_slot_color_for_slot(pcdep_entries, slot, 0)
+    let mut best: Option<usize> = None;
+    for &(b, color, s) in pcdep_entries {
+        if b != 1 || s as usize != slot {
+            continue;
+        }
+        let c = color as usize;
+        best = Some(best.map_or(c, |cur: usize| cur.min(c)));
+    }
+    best
 }
 
 // Sentinel null JitCode for uninitialized PyreSym.

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -4585,6 +4585,12 @@ impl PyreSym {
             );
         }
         let valuestackdepth = if self.bridge_stack_oprefs.is_some() {
+            // Bridge resumes keep the resume-decoded root depth. Multi-frame
+            // deopt later rewrites the live frame's valuestackdepth to the
+            // innermost callee depth (eval.rs:7740-7766), while the resume
+            // payload still carries the root depth; heap state is rebuilt from
+            // resume boxes, never the reverse (rebuild_state_after_failure,
+            // pyjitpl.py:3424-3461).
             self.valuestackdepth
         } else {
             concrete_stack_depth(concrete_frame).unwrap_or(nlocals)

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -7921,6 +7921,71 @@ fn materialize_bridge_virtual(
     }
 }
 
+/// ResumeGuardExcDescr analog for bridge walks that start inside an
+/// already-entered exception handler.
+///
+/// `setup_bridge_sym` runs after guard-failure resume has rebuilt the live
+/// frame and restored the execution-context exception slot. If the raise that
+/// reached the handler was delivered by blackhole replay, it was not recorded
+/// in the bridge trace, so `sym.last_exc_box` is still empty even though the
+/// handler's first jitcode ops (`last_exception`, `last_exc_value`, `reraise`)
+/// require RPython's standing `metainterp.last_exc_value`. Seed the standing
+/// slot from the restored current exception only when it is a real exception
+/// object and the walk has not already seeded an in-trace raise.
+fn seed_bridge_standing_exception_from_current(
+    sym: &mut PyreSym,
+    ctx: &mut majit_metainterp::TraceCtx,
+    semantic_mirror: &[OpRef],
+    live_slot_values: &[Value],
+    nlocals: usize,
+) {
+    if !sym.last_exc_box.is_none() {
+        return;
+    }
+
+    let mut exc = sym.current_exc_value;
+    let mut exc_box = sym.current_exc_box;
+    if exc.is_null() || !unsafe { pyre_object::is_exception(exc) } {
+        let current = pyre_interpreter::eval::get_current_exception();
+        if !current.is_null() && unsafe { pyre_object::is_exception(current) } {
+            exc = current;
+        } else {
+            let stack_exc = semantic_mirror
+                .iter()
+                .enumerate()
+                .skip(nlocals)
+                .rev()
+                .find_map(|(slot, &opref)| {
+                    let value = live_slot_values.get(slot)?;
+                    let Value::Ref(majit_ir::GcRef(ptr)) = value else {
+                        return None;
+                    };
+                    let obj = *ptr as pyre_object::PyObjectRef;
+                    if obj.is_null() || !unsafe { pyre_object::is_exception(obj) } {
+                        return None;
+                    }
+                    Some((obj, opref))
+                });
+            let Some((stack_exc, stack_opref)) = stack_exc else {
+                return;
+            };
+            exc = stack_exc;
+            exc_box = stack_opref;
+        }
+    }
+
+    let exc_box = if exc_box.is_none() {
+        ctx.const_ref(exc as i64)
+    } else {
+        exc_box
+    };
+    sym.current_exc_value = exc;
+    sym.current_exc_box = exc_box;
+    sym.last_exc_value = exc;
+    sym.last_exc_box = exc_box;
+    sym.class_of_last_exc_is_const = true;
+}
+
 impl JitState for PyreJitState {
     type Meta = PyreMeta;
     type Sym = PyreSym;
@@ -8814,6 +8879,13 @@ impl JitState for PyreJitState {
                 }
             }
         }
+        seed_bridge_standing_exception_from_current(
+            sym,
+            ctx,
+            &semantic_mirror,
+            &live_local_values,
+            nlocals,
+        );
         sym.registers_r = semantic_mirror;
         sym.symbolic_local_types = {
             let mut types = bridge_local_types.clone();

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -4584,7 +4584,11 @@ impl PyreSym {
                 self.is_function_entry_trace
             );
         }
-        let valuestackdepth = concrete_stack_depth(concrete_frame).unwrap_or(nlocals);
+        let valuestackdepth = if self.bridge_stack_oprefs.is_some() {
+            self.valuestackdepth
+        } else {
+            concrete_stack_depth(concrete_frame).unwrap_or(nlocals)
+        };
         let stack_only_depth = valuestackdepth.saturating_sub(nlocals);
         self.nlocals = nlocals;
         self.locals_cells_stack_array_ref = if self.is_active_vable_owner {

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -134,6 +134,11 @@ fn fbw_bridge_decline(ctx: &TraceCtx) {
     }
 }
 
+fn p2_drain_abort(ctx: &TraceCtx) -> TraceAction {
+    fbw_bridge_decline(ctx);
+    TraceAction::Abort
+}
+
 pub fn take_fbw_bridge_declined() -> bool {
     FBW_BRIDGE_DECLINED.with(|c| c.replace(false))
 }
@@ -994,7 +999,7 @@ fn drive_bridge_carrier_walk(
     }
     let Some(recipe) = carrier.recipes.last() else {
         crate::jitcode_dispatch::census_record("P2Drain::NoRecipes");
-        return TraceAction::Abort;
+        return p2_drain_abort(ctx);
     };
 
     let pre_pos = ctx.get_trace_position();
@@ -1008,12 +1013,12 @@ fn drive_bridge_carrier_walk(
     else {
         ctx.cut_trace(pre_pos);
         crate::jitcode_dispatch::census_record("P2Drain::SetupFailed");
-        return TraceAction::Abort;
+        return p2_drain_abort(ctx);
     };
     let Some(callee_pjc) = crate::state::pyjitcode_for_code(recipe.code_ptr) else {
         ctx.cut_trace(pre_pos);
         crate::jitcode_dispatch::census_record("P2Drain::NoCalleePjc");
-        return TraceAction::Abort;
+        return p2_drain_abort(ctx);
     };
     let entry = select_recipe_entry(
         recipe.jitcode_index,
@@ -1023,7 +1028,7 @@ fn drive_bridge_carrier_walk(
     let Some(entry) = entry else {
         ctx.cut_trace(pre_pos);
         crate::jitcode_dispatch::census_record("P2Drain::NoCalleeEntry");
-        return TraceAction::Abort;
+        return p2_drain_abort(ctx);
     };
     let callee_w_globals = crate::state::recover_inline_callee_globals(recipe.code_ptr) as usize;
     // The reconstructed callee's local slot concretes (`recipe.concrete_r` is
@@ -1117,7 +1122,7 @@ fn drive_bridge_carrier_walk(
     // pre-walk heap rather than dropping the journals (which would leave every
     // eager store standing to be applied a second time).
     crate::jitcode_dispatch::fbw_store_journal_rollback();
-    TraceAction::Abort
+    p2_drain_abort(ctx)
 }
 
 /// Shape A orthodox multi-frame bridge resume: the escape-hatch driver for a

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -134,14 +134,8 @@ fn fbw_bridge_decline(ctx: &TraceCtx) {
     }
 }
 
-fn p2_compile_enabled() -> bool {
-    std::env::var_os("PYRE_P2_COMPILE").as_deref() != Some(std::ffi::OsStr::new("0"))
-}
-
 fn p2_drain_abort(ctx: &TraceCtx) -> TraceAction {
-    if p2_compile_enabled() {
-        fbw_bridge_decline(ctx);
-    }
+    fbw_bridge_decline(ctx);
     TraceAction::Abort
 }
 
@@ -592,8 +586,8 @@ pub fn trace_bytecode(
         // The framestack-walk cross-frame bridge is correctness-buggy for a
         // branchy inlined-callee continuation. Keep it behind
         // `PYRE_P2_DRAIN=0` pending the orthodox multi-frame reconstruction fix
-        // (#343). The drain sub-walk is the safe default: the compile leg runs
-        // unless `PYRE_P2_COMPILE=0` restores drain-and-discard diagnostics.
+        // (#343). The drain sub-walk is the safe default, with the compile leg
+        // enabled unconditionally.
         if crate::state::p2_drain_enabled() {
             let action = drive_bridge_carrier_walk(ctx, sym, w_code, start_pc, cf_addr, carrier);
             finish_trace_namespace_dependency(meta);
@@ -922,8 +916,7 @@ fn residual_ref_call_dst_before(code: &[u8], entry: usize) -> Option<usize> {
 /// (`recipes` is outermost-first, so the last entry is the guard-failing
 /// frame), log the outcome, discard the trace, and abort — validates the
 /// reconstructed-frame walk plumbing before result-threading + the root walk
-/// are wired. The compile leg is now the default; `PYRE_P2_COMPILE=0` restores
-/// the abort-to-blackhole drain-and-discard diagnostic path.
+/// are wired. The compile leg is unconditional.
 /// Thread a reconstructed callee's `SubReturn` value into the root portal's
 /// operand-stack result register so the subsequent root walk
 /// (`run_perfn_walk`'s bridge seeding) reads it as the call result at `root_pc`.
@@ -1060,8 +1053,7 @@ fn drive_bridge_carrier_walk(
     // 2b-ii: on a clean single-recipe `SubReturn`, thread the callee result
     // into the root's operand-stack result slot and walk the ROOT top-level to
     // compile the bridge (the recorded callee continuation + the root
-    // continuation form one bridge body).  Enabled by default; set
-    // `PYRE_P2_COMPILE=0` to restore the drain-and-discard diagnostic path.
+    // continuation form one bridge body).
     // Other shapes / outcomes log + abort (trace discarded).
     let subwalk_result = match &walk {
         Some(Ok((crate::jitcode_dispatch::DispatchOutcome::SubReturn { result: Some(r) }, _))) => {
@@ -1070,7 +1062,7 @@ fn drive_bridge_carrier_walk(
         _ => None,
     };
     if let Some(result) = subwalk_result {
-        if carrier.recipes.len() == 1 && p2_compile_enabled() {
+        if carrier.recipes.len() == 1 {
             if inject_root_call_result(sym, root_pc, result) {
                 crate::jitcode_dispatch::census_record("P2Drain::CompileRoot");
                 let root_py_pc =

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -111,6 +111,11 @@ thread_local! {
     /// executing thread's trace; no cross-thread mutable JIT state is needed.
     static RANGE_FORITER_DEMOTED: std::cell::RefCell<std::collections::HashSet<u64>> =
         std::cell::RefCell::new(std::collections::HashSet::new());
+    /// The current bridge trace's full-body walk hit a deterministic
+    /// structural decline.  The walker only knows `(w_code, start_pc)`; the
+    /// bridge launcher still has the originating guard descr and consumes this
+    /// bit to populate `MetaInterp::declined_bridge_guards`.
+    static FBW_BRIDGE_DECLINED: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
 }
 
 pub(crate) fn fbw_declined(key: u64) -> bool {
@@ -121,6 +126,16 @@ pub(crate) fn fbw_decline(key: u64) {
     FBW_DECLINED_KEYS.with(|s| {
         s.borrow_mut().insert(key);
     });
+}
+
+fn fbw_bridge_decline(ctx: &TraceCtx) {
+    if ctx.is_bridge_trace {
+        FBW_BRIDGE_DECLINED.with(|c| c.set(true));
+    }
+}
+
+pub fn take_fbw_bridge_declined() -> bool {
+    FBW_BRIDGE_DECLINED.with(|c| c.replace(false))
 }
 
 pub(crate) fn range_foriter_demoted(key: u64) -> bool {
@@ -484,6 +499,7 @@ pub fn trace_bytecode(
     WALK_END_PROPAGATED_EXCEPTION.with(|c| *c.borrow_mut() = None);
     WALK_END_PROPAGATE_ALLOWED.with(|c| c.set(allow_propagate_out));
     WALK_END_RESTART_PC.with(|c| c.set(None));
+    FBW_BRIDGE_DECLINED.with(|c| c.set(false));
     // `TraceCtx.reads_module_global` needs no reset here: a fresh TraceCtx is
     // built per trace (zero-init `false`), unlike the walk-end TLS flags above.
     // Likewise clear any no-replay finish payload a prior trace left
@@ -1552,6 +1568,7 @@ fn run_perfn_walk(
                 pjc.metadata.n_py_instrs as usize
             );
         }
+        fbw_bridge_decline(ctx);
         fbw_decline(crate::driver::make_green_key(w_code, start_pc));
         return None;
     };
@@ -1584,6 +1601,7 @@ fn run_perfn_walk(
                      entry_depth={entry_depth} marker_py={marker_py}; declining marker-entry walk"
                 );
             }
+            fbw_bridge_decline(ctx);
             fbw_decline(crate::driver::make_green_key(w_code, start_pc));
             return None;
         }
@@ -1602,6 +1620,7 @@ fn run_perfn_walk(
                  (built_as_portal=false); declining walk"
             );
         }
+        fbw_bridge_decline(ctx);
         fbw_decline(crate::driver::make_green_key(w_code, start_pc));
         return None;
     }
@@ -3107,6 +3126,7 @@ fn full_body_walk_trace(
             if crate::jitcode_dispatch::fbw_debug_abort_enabled() {
                 eprintln!("[fbw-abort] start_pc={start_pc} run_perfn_walk returned None");
             }
+            fbw_bridge_decline(ctx);
             TraceAction::Abort
         }
     }

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -870,6 +870,18 @@ fn select_recipe_entry(
         .flatten()
 }
 
+fn residual_ref_call_dst_before(code: &[u8], entry: usize) -> Option<usize> {
+    crate::jitcode_runtime::decoded_ops(code)
+        .find(|op| op.next_pc == entry && op.opname.starts_with("residual_call"))
+        .and_then(|op| {
+            op.argcodes
+                .ends_with(">r")
+                .then(|| code.get(entry - 1).copied())
+                .flatten()
+        })
+        .map(usize::from)
+}
+
 /// Issue #215 item 2 (P2 drain): drive a multiframe bridge-carrier resume via
 /// the full-body walker instead of aborting to a no-JIT re-interpret.
 ///
@@ -887,37 +899,50 @@ fn select_recipe_entry(
 /// are wired. This abort-to-blackhole drain is the safe default; the experimental
 /// `PYRE_P2_COMPILE` path remains opt-in.
 /// Thread a reconstructed callee's `SubReturn` value into the root portal's
-/// operand-stack result slot so the subsequent root walk (`run_perfn_walk`'s
-/// `bridge_stack_oprefs` seeding) reads it as the call result at `root_pc`.
+/// operand-stack result register so the subsequent root walk
+/// (`run_perfn_walk`'s bridge seeding) reads it as the call result at `root_pc`.
 ///
-/// The result lands at the codewriter-precomputed result color for the call's
-/// return pc (`result_color_at_pc_at`), mapped to its `bridge_stack_oprefs`
-/// stack slot (`color - nlocals`).  Returns `false` (caller declines the
-/// compile) when the color is unresolved or sits below the operand stack.
+/// `make_result_of_lastop` writes the result to the residual-call body's
+/// trailing `>r` destination byte, so use that register when the call ending at
+/// `root_pc` can be decoded.  Fall back to the precomputed result-color table
+/// for older shapes that lack the canonical residual-call encoding.  Returns
+/// `false` (caller declines the compile) when the register is unresolved or
+/// sits below the operand stack.
 fn inject_root_call_result(sym: &mut PyreSym, root_pc: usize, result: majit_ir::OpRef) -> bool {
     if sym.jitcode.is_null() {
         return false;
     }
+    let payload = unsafe { &(*sym.jitcode).payload };
     let jitcode_index = unsafe { (*sym.jitcode).index as i32 };
-    let root_py_pc = crate::state::backxlat_py_pc(jitcode_index, root_pc as i32) as usize;
-    if crate::jitcode_dispatch::result_color_audit_enabled() {
-        let payload = unsafe { &(*sym.jitcode).payload };
-        let py_pc =
-            crate::jitcode_dispatch::python_pc_for_jitcode_pc(&payload.metadata, root_pc) as usize;
-        assert_eq!(
-            payload.result_color_for_jitcode_pc_pred(root_pc),
-            payload.metadata.result_color_at_pc.get(py_pc).copied(),
-            "result_color_by_jit_pc diverges from result_color_at_pc at jit_pc={root_pc}"
-        );
-    }
-    let Some(result_color) = crate::state::result_color_at_pc_at(jitcode_index, root_py_pc) else {
+    let result_reg = residual_ref_call_dst_before(payload.jitcode.code.as_slice(), root_pc)
+        .or_else(|| {
+            let root_py_pc = crate::state::backxlat_py_pc(jitcode_index, root_pc as i32) as usize;
+            if crate::jitcode_dispatch::result_color_audit_enabled() {
+                let py_pc =
+                    crate::jitcode_dispatch::python_pc_for_jitcode_pc(&payload.metadata, root_pc)
+                        as usize;
+                assert_eq!(
+                    payload.result_color_for_jitcode_pc_pred(root_pc),
+                    payload.metadata.result_color_at_pc.get(py_pc).copied(),
+                    "result_color_by_jit_pc diverges from result_color_at_pc at jit_pc={root_pc}"
+                );
+            }
+            crate::state::result_color_at_pc_at(jitcode_index, root_py_pc)
+        });
+    let Some(result_reg) = result_reg else {
         return false;
     };
     let nlocals = sym.nlocals;
-    if result_color < nlocals {
+    if result_reg < nlocals {
         return false;
     }
-    let slot = result_color - nlocals;
+    if let Some(ref mut bridge_regs) = sym.bridge_registers_r {
+        if bridge_regs.len() <= result_reg {
+            bridge_regs.resize(result_reg + 1, majit_ir::OpRef::NONE);
+        }
+        bridge_regs[result_reg] = result;
+    }
+    let slot = result_reg - nlocals;
     let bridge = sym.bridge_stack_oprefs.get_or_insert_with(Vec::new);
     if bridge.len() <= slot {
         bridge.resize(slot + 1, majit_ir::OpRef::NONE);

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -2649,6 +2649,102 @@ fn loop_body_abort_permanent_pc(w_code: *const (), start_pc: usize) -> Option<us
     first_abort_permanent.filter(|pc| *pc < scan_end)
 }
 
+struct CalleeAbortPermanentHit {
+    callee_name: String,
+    marker_jit_pc: usize,
+    marker_py_pc: usize,
+}
+
+fn collect_loop_body_referenced_roots(
+    code: &CodeObject,
+    start_pc: usize,
+) -> Option<(
+    std::collections::HashSet<String>,
+    std::collections::HashSet<usize>,
+)> {
+    use pyre_interpreter::Instruction as I;
+
+    let mut back_edge_pc: Option<usize> = None;
+    let mut arg_state = pyre_interpreter::OpArgState::default();
+    for (pc, unit) in code.instructions.iter().copied().enumerate() {
+        let (instr, op_arg) = arg_state.get(unit);
+        let delta = match instr {
+            I::JumpBackward { delta } | I::JumpBackwardNoInterrupt { delta } => delta,
+            _ => continue,
+        };
+        if pyre_interpreter::jump_target_backward_decoded(code, pc + 1, delta, op_arg) == start_pc {
+            back_edge_pc = Some(back_edge_pc.map_or(pc, |old| old.max(pc)));
+        }
+    }
+    let back_edge_pc = back_edge_pc?;
+
+    let mut global_names = std::collections::HashSet::new();
+    let mut local_slots = std::collections::HashSet::new();
+    let mut scan_pc = |pc: usize| {
+        let Some((instr, op_arg)) = pyre_interpreter::decode_instruction_at(code, pc) else {
+            return;
+        };
+        match instr {
+            I::LoadGlobal { namei } => {
+                let name_idx = (namei.get(op_arg) as usize) >> 1;
+                if let Some(name) = code.names.get(name_idx) {
+                    global_names.insert(name.to_string());
+                }
+            }
+            I::LoadFast { var_num }
+            | I::LoadFastBorrow { var_num }
+            | I::LoadFastCheck { var_num }
+            | I::LoadFastAndClear { var_num } => {
+                local_slots.insert(var_num.get(op_arg).as_usize());
+            }
+            I::LoadDeref { i } => {
+                local_slots.insert(i.get(op_arg).as_usize());
+            }
+            I::LoadFastBorrowLoadFastBorrow { var_nums } | I::LoadFastLoadFast { var_nums } => {
+                let pair = var_nums.get(op_arg);
+                local_slots.insert(u32::from(pair.idx_1()) as usize);
+                local_slots.insert(u32::from(pair.idx_2()) as usize);
+            }
+            I::StoreFastLoadFast { var_nums } => {
+                let pair = var_nums.get(op_arg);
+                local_slots.insert(u32::from(pair.idx_2()) as usize);
+            }
+            _ => {}
+        }
+    };
+
+    for pc in start_pc..=back_edge_pc {
+        scan_pc(pc);
+    }
+
+    let loop_start_byte = (start_pc as u32) * 2;
+    let loop_end_byte = ((back_edge_pc + 1) as u32) * 2;
+    for entry in pyre_interpreter::pycode::decode_exceptiontable(&code.exceptiontable) {
+        if entry.start < loop_start_byte || entry.end > loop_end_byte {
+            continue;
+        }
+        let handler_start = (entry.target / 2) as usize;
+        for pc in handler_start..code.instructions.len() {
+            scan_pc(pc);
+            let Some((instr, _)) = pyre_interpreter::decode_instruction_at(code, pc) else {
+                continue;
+            };
+            if matches!(
+                instr,
+                I::Reraise { .. }
+                    | I::JumpForward { .. }
+                    | I::JumpBackward { .. }
+                    | I::JumpBackwardNoInterrupt { .. }
+                    | I::ReturnValue
+            ) {
+                break;
+            }
+        }
+    }
+
+    Some((global_names, local_slots))
+}
+
 /// True when the hot loop body in `w_code` inline-calls — transitively — a
 /// user function whose per-fn jitcode body carries an `abort_permanent`
 /// marker.
@@ -2667,15 +2763,15 @@ fn loop_body_abort_permanent_pc(w_code: *const (), start_pc: usize) -> Option<us
 /// without JIT (correct, at interpreter speed).
 ///
 /// This is an OVER-DECLINING stopgap, and static: it mirrors the inline path's
-/// static eligibility gates, but can still decline on a function merely
-/// referenced by the loop (present in `co_names`/locals), not just one the
-/// executed path actually calls.  Call-site-dependent gates such as the
-/// passed-argument count and recursion depth cannot be resolved by this scan,
-/// so a callee that would fail one of those gates can also over-decline.  A hot
-/// loop that calls an otherwise inline-eligible helper whose body contains an
-/// unported op (`match`, `async`, chained-compare `SWAP`, …) — even on a rarely
-/// taken path — now runs interpreted in full, not just the aborting call.  The
-/// orthodox mechanism has no up-front scan at all: an unsupported op raises
+/// static eligibility gates, but can still decline on a function referenced by
+/// a loop-body `LOAD_GLOBAL`/local-slot load even when the executed path does
+/// not actually call it.  Call-site-dependent gates such as the passed-argument
+/// count and recursion depth cannot be resolved by this scan, so a callee that
+/// would fail one of those gates can also over-decline.  A hot loop that calls
+/// an otherwise inline-eligible helper whose body contains an unported op
+/// (`match`, `async`, chained-compare `SWAP`, …) — even on a rarely taken path
+/// — now runs interpreted in full, not just the aborting call.  The orthodox
+/// mechanism has no up-front scan at all: an unsupported op raises
 /// `SwitchToBlackhole` mid-trace and
 /// `run_blackhole_interp_to_cancel_tracing` (pyjitpl.py:2949) converts the live
 /// framestack and continues FORWARD in the blackhole interpreter, so nothing
@@ -2684,11 +2780,11 @@ fn loop_body_abort_permanent_pc(w_code: *const (), start_pc: usize) -> Option<us
 /// the outer walk in place instead of rolling back to loop entry.
 ///
 /// The scan resolves candidate callees CONCRETELY from the live frame (the
-/// walk has not run yet, so no store has executed).  Two seed sources:
-/// - the frame's module globals — every referenced name in the CodeObject's
-///   `co_names` is looked up in `w_globals`;
-/// - the ROOT frame's fastlocals + closure cells — a helper passed as an
-///   argument/local (`h([i, i])`) or held in a closure cell resolves here.
+/// walk has not run yet, so no store has executed).  Two root seed sources,
+/// both scoped to identifiers the loop body or its in-loop handlers read:
+/// - module globals named by loop-body `LOAD_GLOBAL`;
+/// - ROOT-frame fastlocals + closure cells whose slots are read by loop-body
+///   local-load opcodes.
 ///
 /// Each plain-function value first passes the inline path's static closure,
 /// positional-parameter, jitcode-body, and Ref-register-capacity gates.  Its
@@ -2704,13 +2800,17 @@ fn loop_body_abort_permanent_pc(w_code: *const (), start_pc: usize) -> Option<us
 /// container elements, or another call's return value, and callees local to a
 /// deeper frame, stay unresolvable before the walk — those rely on the
 /// deferred #126/#215 forward-resume convergence rather than this stopgap.
-fn loop_inlines_abort_permanent_callee(w_code: *const (), cf_addr: usize) -> bool {
+fn loop_inlines_abort_permanent_callee(
+    w_code: *const (),
+    start_pc: usize,
+    cf_addr: usize,
+) -> Option<CalleeAbortPermanentHit> {
     // Gate: only scan when the top-level loop body (ops after the first
     // `jit_merge_point`) contains a `residual_call*` op.  Every inline-eligible
     // user call lowers to a residual_call, so a call-free loop cannot
     // inline-abort — skipping it avoids resolving globals for the common case.
     let Some(pjc) = crate::state::pyjitcode_for_code(w_code) else {
-        return false;
+        return None;
     };
     let mut seen_merge_point = false;
     let mut has_residual_call = false;
@@ -2723,7 +2823,7 @@ fn loop_inlines_abort_permanent_callee(w_code: *const (), cf_addr: usize) -> boo
         }
     }
     if !has_residual_call || cf_addr == 0 {
-        return false;
+        return None;
     }
 
     // Process one concrete candidate value shared by both seed paths (globals
@@ -2739,22 +2839,22 @@ fn loop_inlines_abort_permanent_callee(w_code: *const (), cf_addr: usize) -> boo
         function_type_addr: usize,
         visited: &mut std::collections::HashSet<*const ()>,
         queue: &mut std::collections::VecDeque<(*const (), pyre_object::PyObjectRef)>,
-    ) -> bool {
+    ) -> Option<CalleeAbortPermanentHit> {
         // A tagged immediate int is never a FUNCTION_TYPE callee; skip it
         // before the `ob_type` deref below (which reads an even-aligned heap
         // pointer). Reaches here via the globals-dict scan and via a cell
         // whose contents are a tagged int.
         if pyre_object::tagged_int::CAN_BE_TAGGED && pyre_object::tagged_int::is_tagged_int(cand) {
-            return false;
+            return None;
         }
         // Only plain user functions inline (mirrors the inline path's exact
         // FUNCTION_TYPE gate); builtins carry no CodeObject.
         if cand.is_null() || (*cand).ob_type as *const () as usize != function_type_addr {
-            return false;
+            return None;
         }
         let callee_w_code = pyre_interpreter::function_get_code(cand);
         if callee_w_code.is_null() {
-            return false;
+            return None;
         }
         // A FUNCTION_TYPE object can wrap a BuiltinCode, not a CodeObject:
         // `make_builtin_function*` (gateway.rs:701) puts such a function into
@@ -2763,25 +2863,43 @@ fn loop_inlines_abort_permanent_callee(w_code: *const (), cf_addr: usize) -> boo
         // as a PyCode and derefs garbage, so reject it before the scan — a
         // builtin carries no traceable body and never inlines.
         if pyre_interpreter::is_builtin_code(callee_w_code as pyre_object::PyObjectRef) {
-            return false;
+            return None;
         }
         let Some((callee_w_code, nparams, has_closure)) =
             crate::jitcode_dispatch::resolve_inlinable_callee(cand)
         else {
-            return false;
+            return None;
         };
         if has_closure || nparams == 0 {
-            return false;
+            return None;
         }
         let Some(body) = crate::state::sub_jitcode_body_for_code(callee_w_code) else {
-            return false;
+            return None;
         };
         if nparams > body.num_regs_r || !visited.insert(callee_w_code) {
-            return false;
+            return None;
         }
         for op in crate::jitcode_runtime::decoded_ops(body.code) {
             if op.opname == "abort_permanent" {
-                return true;
+                let raw_code =
+                    pyre_interpreter::w_code_get_ptr(callee_w_code as pyre_object::PyObjectRef)
+                        as *const CodeObject;
+                let callee_name = if raw_code.is_null() {
+                    "<unknown>".to_string()
+                } else {
+                    (*raw_code).obj_name.as_str().to_owned()
+                };
+                let marker_py_pc = crate::state::pyjitcode_for_code(callee_w_code)
+                    .map(|pjc| {
+                        crate::jitcode_dispatch::python_pc_for_jitcode_pc(&pjc.metadata, op.pc)
+                            as usize
+                    })
+                    .unwrap_or(op.pc);
+                return Some(CalleeAbortPermanentHit {
+                    callee_name,
+                    marker_jit_pc: op.pc,
+                    marker_py_pc,
+                });
             }
         }
         // Transitive: resolve this callee's own referenced functions in its own
@@ -2790,7 +2908,7 @@ fn loop_inlines_abort_permanent_callee(w_code: *const (), cf_addr: usize) -> boo
         if !callee_globals.is_null() {
             queue.push_back((callee_w_code, callee_globals));
         }
-        false
+        None
     }
 
     // SAFETY: `cf_addr` is the live `PyFrame` pointer the portal passed to the
@@ -2801,8 +2919,18 @@ fn loop_inlines_abort_permanent_callee(w_code: *const (), cf_addr: usize) -> boo
         let cf = &*(cf_addr as *const pyre_interpreter::pyframe::PyFrame);
         let root_globals = cf.w_globals;
         if root_globals.is_null() {
-            return false;
+            return None;
         }
+        let raw_code = pyre_interpreter::w_code_get_ptr(w_code as pyre_object::PyObjectRef)
+            as *const CodeObject;
+        if raw_code.is_null() {
+            return None;
+        }
+        let Some((loop_body_global_names, loop_body_local_slots)) =
+            collect_loop_body_referenced_roots(&*raw_code, start_pc)
+        else {
+            return None;
+        };
         let function_type_addr = &pyre_interpreter::FUNCTION_TYPE as *const _ as usize;
         let mut visited: std::collections::HashSet<*const ()> = std::collections::HashSet::new();
         // The root's own loop-body `abort_permanent` is handled upstream.
@@ -2810,16 +2938,31 @@ fn loop_inlines_abort_permanent_callee(w_code: *const (), cf_addr: usize) -> boo
         // BFS over (code wrapper ptr, globals in which its `co_names` resolve).
         let mut queue: std::collections::VecDeque<(*const (), pyre_object::PyObjectRef)> =
             std::collections::VecDeque::new();
-        queue.push_back((w_code, root_globals));
+
+        for name in &loop_body_global_names {
+            let Some(cand) =
+                pyre_object::dictmultiobject::w_dict_getitem_str(root_globals, name.as_str())
+            else {
+                continue;
+            };
+            if let Some(hit) =
+                consider_candidate(cand, function_type_addr, &mut visited, &mut queue)
+            {
+                return Some(hit);
+            }
+        }
 
         // Seed from the root frame's fastlocals + closure cells: a helper
-        // passed as an argument/local or held in a cell is not in `co_names`,
-        // so resolve it directly from the frame's initialised locals/cells
-        // region.  Stop at `stack_base()` — operand-stack slots beyond it are
-        // uninitialised.
+        // passed as an argument/local or held in a cell is not in `co_names`, so
+        // resolve it directly from the loop-body-referenced slots in the
+        // frame's initialised locals/cells region.  Stop at `stack_base()` —
+        // operand-stack slots beyond it are uninitialised.
         let slots = cf.locals_w().as_slice();
         let bound = cf.stack_base().min(slots.len());
-        for &slot in &slots[..bound] {
+        for (slot_idx, &slot) in slots[..bound].iter().enumerate() {
+            if !loop_body_local_slots.contains(&slot_idx) {
+                continue;
+            }
             if slot.is_null() {
                 continue;
             }
@@ -2836,8 +2979,10 @@ fn loop_inlines_abort_permanent_callee(w_code: *const (), cf_addr: usize) -> boo
             } else {
                 slot
             };
-            if consider_candidate(value, function_type_addr, &mut visited, &mut queue) {
-                return true;
+            if let Some(hit) =
+                consider_candidate(value, function_type_addr, &mut visited, &mut queue)
+            {
+                return Some(hit);
             }
         }
 
@@ -2853,13 +2998,15 @@ fn loop_inlines_abort_permanent_callee(w_code: *const (), cf_addr: usize) -> boo
                 else {
                     continue;
                 };
-                if consider_candidate(cand, function_type_addr, &mut visited, &mut queue) {
-                    return true;
+                if let Some(hit) =
+                    consider_candidate(cand, function_type_addr, &mut visited, &mut queue)
+                {
+                    return Some(hit);
                 }
             }
         }
     }
-    false
+    None
 }
 
 /// Whether [`full_body_walk_trace`] starts a fresh walk or continues one that
@@ -2923,8 +3070,15 @@ fn full_body_walk_trace(
     // abort the walk, roll back the store journal, and replay from loop entry
     // — re-executing the non-journaled store.  Decline up front, before the
     // walk runs anything.  (See `loop_inlines_abort_permanent_callee`.)
-    if loop_inlines_abort_permanent_callee(w_code, cf_addr) {
+    if let Some(hit) = loop_inlines_abort_permanent_callee(w_code, start_pc, cf_addr) {
         crate::jitcode_dispatch::census_record("FullBodyWalk::CalleeAbortPermanent");
+        if crate::jitcode_dispatch::fbw_debug_abort_enabled() {
+            eprintln!(
+                "[fbw-abort] start_pc={start_pc} callee={} abort_permanent_jit_pc={} \
+                 marker_py={}; declining callee-abort walk",
+                hit.callee_name, hit.marker_jit_pc, hit.marker_py_pc
+            );
+        }
         fbw_decline(crate::driver::make_green_key(w_code, start_pc));
         return TraceAction::Abort;
     }

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -932,8 +932,7 @@ fn residual_ref_call_dst_before(code: &[u8], entry: usize) -> Option<usize> {
 /// trailing `>r` destination byte, so use that register when the call ending at
 /// `root_pc` can be decoded.  Fall back to the precomputed result-color table
 /// for older shapes that lack the canonical residual-call encoding.  Returns
-/// `false` (caller declines the compile) when the register is unresolved or
-/// sits below the operand stack.
+/// `false` (caller declines the compile) when the register is unresolved.
 fn inject_root_call_result(sym: &mut PyreSym, root_pc: usize, result: majit_ir::OpRef) -> bool {
     if sym.jitcode.is_null() {
         return false;
@@ -959,21 +958,20 @@ fn inject_root_call_result(sym: &mut PyreSym, root_pc: usize, result: majit_ir::
         return false;
     };
     let nlocals = sym.nlocals;
-    if result_reg < nlocals {
-        return false;
-    }
     if let Some(ref mut bridge_regs) = sym.bridge_registers_r {
         if bridge_regs.len() <= result_reg {
             bridge_regs.resize(result_reg + 1, majit_ir::OpRef::NONE);
         }
         bridge_regs[result_reg] = result;
     }
-    let slot = result_reg - nlocals;
-    let bridge = sym.bridge_stack_oprefs.get_or_insert_with(Vec::new);
-    if bridge.len() <= slot {
-        bridge.resize(slot + 1, majit_ir::OpRef::NONE);
+    if result_reg >= nlocals {
+        let slot = result_reg - nlocals;
+        let bridge = sym.bridge_stack_oprefs.get_or_insert_with(Vec::new);
+        if bridge.len() <= slot {
+            bridge.resize(slot + 1, majit_ir::OpRef::NONE);
+        }
+        bridge[slot] = result;
     }
-    bridge[slot] = result;
     true
 }
 

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -600,8 +600,10 @@ pub fn trace_bytecode(
     //
     // A green key in `FBW_DECLINED_KEYS` had a prior walk fail on a
     // structural walker limitation (the recurring error classes in
-    // `full_body_walk_trace`); retraces bypass the walker and interpret
-    // without JIT instead of permanently blacklisting the location.
+    // `full_body_walk_trace`).  `FBW_DECLINED_KEYS` is insert/contains only,
+    // so the decline is permanent for this process: retraces bypass the
+    // walker and the key re-interprets without JIT instead of being
+    // permanently blacklisted (`DONT_TRACE_HERE`).
     if carrier.is_none()
         && std::env::var_os("PYRE_FULL_BODY_WALK").as_deref() != Some(std::ffi::OsStr::new("0"))
         && !fbw_declined(crate::driver::make_green_key(w_code, start_pc))
@@ -3014,21 +3016,17 @@ fn full_body_walk_trace(
         Some((_entry, _code_len, Err(e))) => {
             // Structural walker limitations recur identically on every
             // retrace of this location (the same jitcode walked from the same
-            // entry produces the same error), so route the key's retraces to
-            // interpretation instead of thrashing futile deep re-walks —
+            // entry produces the same error), so record the key in
+            // `FBW_DECLINED_KEYS` instead of thrashing futile deep re-walks —
             // each of which executes the body's residual calls concretely
             // before failing at the unsupported resume / exception / closure
-            // shape.  Permanently blacklisting (`AbortPermanent` →
-            // `DONT_TRACE_HERE`) is wrong here: it leaves the location
-            // interpreting forever (a try-protected raise in a hot loop
-            // deopt-storms past any timeout), and upstream never marks a
-            // location untraceable on an abort (pyjitpl.py:2392
-            // aborted_tracing).  These are the multi-session-blocked
-            // shapes (resume snapshot #124, exception-handler resume #51c,
-            // closure NULL-self #60, unported raise marker, a residual
-            // arg register the walk never binds); other errors retain the
-            // plain `Abort` without declining so a capability that lands
-            // mid-run can still pick the location up.
+            // shape.  `FBW_DECLINED_KEYS` is a permanent per-process decline:
+            // the key re-interprets without tracing.  These are the
+            // multi-session-blocked shapes (resume snapshot #124,
+            // exception-handler resume #51c, closure NULL-self #60, unported
+            // raise marker, a residual arg register the walk never binds);
+            // other errors retain the plain `Abort` without declining so a
+            // capability that lands mid-run can still pick the location up.
             use crate::jitcode_dispatch::DispatchError as DE;
             crate::jitcode_dispatch::census_record(e.variant_name());
             if crate::jitcode_dispatch::fbw_debug_abort_enabled() {
@@ -3036,9 +3034,10 @@ fn full_body_walk_trace(
             }
             match e {
                 // A kept-stack branch guard whose not-taken arm reads an
-                // unrestorable boxed Ref register cannot safely be retraced.
-                // Mark the location `DONT_TRACE_HERE` so it interprets
-                // permanently — correct, matching the pre-#416/#420 decline.
+                // unrestorable boxed Ref register is a structural abort.
+                // Keeping the permanent mapping is behavior-neutral: a plain
+                // `Abort` reaches the same `DONT_TRACE_HERE` terminal state
+                // through pyre's abort ceiling.
                 DE::BranchGuardUnrestorableKeptStackPermanent { .. } => TraceAction::AbortPermanent,
                 // #57 (Finding #1): a non-journalable in-place container mutation
                 // in a FOR_ITER body cannot be rolled back on abort, so this

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -134,8 +134,14 @@ fn fbw_bridge_decline(ctx: &TraceCtx) {
     }
 }
 
+fn p2_compile_enabled() -> bool {
+    std::env::var_os("PYRE_P2_COMPILE").as_deref() != Some(std::ffi::OsStr::new("0"))
+}
+
 fn p2_drain_abort(ctx: &TraceCtx) -> TraceAction {
-    fbw_bridge_decline(ctx);
+    if p2_compile_enabled() {
+        fbw_bridge_decline(ctx);
+    }
     TraceAction::Abort
 }
 
@@ -586,9 +592,8 @@ pub fn trace_bytecode(
         // The framestack-walk cross-frame bridge is correctness-buggy for a
         // branchy inlined-callee continuation. Keep it behind
         // `PYRE_P2_DRAIN=0` pending the orthodox multi-frame reconstruction fix
-        // (#343). The drain sub-walk is the safe default: with the experimental
-        // `PYRE_P2_COMPILE` unset it discards the trace and aborts to the
-        // blackhole safety floor.
+        // (#343). The drain sub-walk is the safe default: the compile leg runs
+        // unless `PYRE_P2_COMPILE=0` restores drain-and-discard diagnostics.
         if crate::state::p2_drain_enabled() {
             let action = drive_bridge_carrier_walk(ctx, sym, w_code, start_pc, cf_addr, carrier);
             finish_trace_namespace_dependency(meta);
@@ -917,8 +922,8 @@ fn residual_ref_call_dst_before(code: &[u8], entry: usize) -> Option<usize> {
 /// (`recipes` is outermost-first, so the last entry is the guard-failing
 /// frame), log the outcome, discard the trace, and abort — validates the
 /// reconstructed-frame walk plumbing before result-threading + the root walk
-/// are wired. This abort-to-blackhole drain is the safe default; the experimental
-/// `PYRE_P2_COMPILE` path remains opt-in.
+/// are wired. The compile leg is now the default; `PYRE_P2_COMPILE=0` restores
+/// the abort-to-blackhole drain-and-discard diagnostic path.
 /// Thread a reconstructed callee's `SubReturn` value into the root portal's
 /// operand-stack result register so the subsequent root walk
 /// (`run_perfn_walk`'s bridge seeding) reads it as the call result at `root_pc`.
@@ -1057,9 +1062,9 @@ fn drive_bridge_carrier_walk(
     // 2b-ii: on a clean single-recipe `SubReturn`, thread the callee result
     // into the root's operand-stack result slot and walk the ROOT top-level to
     // compile the bridge (the recorded callee continuation + the root
-    // continuation form one bridge body).  Gated on `PYRE_P2_COMPILE` (requires
-    // the authoritative sub-walk that produced the `SubReturn`); other shapes /
-    // outcomes log + abort (trace discarded).
+    // continuation form one bridge body).  Enabled by default; set
+    // `PYRE_P2_COMPILE=0` to restore the drain-and-discard diagnostic path.
+    // Other shapes / outcomes log + abort (trace discarded).
     let subwalk_result = match &walk {
         Some(Ok((crate::jitcode_dispatch::DispatchOutcome::SubReturn { result: Some(r) }, _))) => {
             Some(*r)
@@ -1067,7 +1072,7 @@ fn drive_bridge_carrier_walk(
         _ => None,
     };
     if let Some(result) = subwalk_result {
-        if carrier.recipes.len() == 1 && std::env::var_os("PYRE_P2_COMPILE").is_some() {
+        if carrier.recipes.len() == 1 && p2_compile_enabled() {
             if inject_root_call_result(sym, root_pc, result) {
                 crate::jitcode_dispatch::census_record("P2Drain::CompileRoot");
                 let root_py_pc =

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -2596,9 +2596,9 @@ fn probe_walk_perfn_jitcode(
 /// `abort_permanent` (e.g. the `DELETE_FAST` cleanup for `except X as e`)
 /// still declines it, because compiled-loop delivery of an uncaught raise to
 /// the handler is not yet supported.
-fn loop_body_has_abort_permanent(w_code: *const (), start_pc: usize) -> bool {
+fn loop_body_abort_permanent_pc(w_code: *const (), start_pc: usize) -> Option<usize> {
     let Some(pjc) = crate::state::pyjitcode_for_code(w_code) else {
-        return false;
+        return None;
     };
     let code = pjc.jitcode.code.as_slice();
     let Some(merge_point) = pjc
@@ -2615,7 +2615,7 @@ fn loop_body_has_abort_permanent(w_code: *const (), start_pc: usize) -> bool {
                 .map(|op| op.pc)
         })
     else {
-        return false;
+        return None;
     };
 
     let mut back_edge_end: Option<usize> = None;
@@ -2646,14 +2646,14 @@ fn loop_body_has_abort_permanent(w_code: *const (), start_pc: usize) -> bool {
     } else {
         back_edge_end.unwrap_or(code.len())
     };
-    first_abort_permanent.is_some_and(|pc| pc < scan_end)
+    first_abort_permanent.filter(|pc| *pc < scan_end)
 }
 
 /// True when the hot loop body in `w_code` inline-calls — transitively — a
 /// user function whose per-fn jitcode body carries an `abort_permanent`
 /// marker.
 ///
-/// [`loop_body_has_abort_permanent`] only scans the top-level per-CodeObject
+/// [`loop_body_abort_permanent_pc`] only scans the top-level per-CodeObject
 /// jitcode, so an `abort_permanent` reached through an inlined callee slips
 /// past it.  That gap causes a walk-time double-apply: a non-journaled
 /// concrete heap store (dict/attr/set item, list `extend`, …) in the loop
@@ -2697,7 +2697,7 @@ fn loop_body_has_abort_permanent(w_code: *const (), start_pc: usize) -> bool {
 /// Non-aborting eligible callees are enqueued and their own referenced
 /// functions scanned transitively through THEIR globals, guarded by a
 /// scan-local visited set.  The root `w_code` is pre-marked visited — its own
-/// loop-body marker is already handled by [`loop_body_has_abort_permanent`].
+/// loop-body marker is already handled by [`loop_body_abort_permanent_pc`].
 ///
 /// Frame-local seeding is ROOT-frame only; a deeper (not-yet-pushed) callee's
 /// locals are not available up front.  Callees reached via attribute access,
@@ -2905,12 +2905,15 @@ fn full_body_walk_trace(
     // guard, exit early, and concretely double-execute the post-loop tail;
     // declining before the walk reaches the unported op avoids frame
     // corruption and returns to interpretation.
-    if loop_body_has_abort_permanent(w_code, start_pc) {
+    if let Some(abort_pc) = loop_body_abort_permanent_pc(w_code, start_pc) {
         // Tag the decline so `PYRE_FBW_DEBUG_ABORT` census attributes it to the
         // up-front `abort_permanent` scan, not the trait retry fall-through
         // (`Trait::DeclinedAbort`).  Without this the real declining class is
         // invisible to the census.
         crate::jitcode_dispatch::census_record("FullBodyWalk::LoopBodyAbortPermanent");
+        if std::env::var_os("PYRE_FBW_DEBUG_ABORT").is_some() {
+            eprintln!("[fbw-abort] start_pc={start_pc} abort_permanent_pc={abort_pc}");
+        }
         fbw_decline(crate::driver::make_green_key(w_code, start_pc));
         return TraceAction::Abort;
     }

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -2807,6 +2807,12 @@ pub fn trace_and_compile_from_bridge(
     // Disarm so the flag cannot leak into a later (non-bridge) walk on this
     // thread; the epilogue has already consumed it.
     pyre_jit_trace::jitcode_dispatch::fbw_bridge_noreplay_arm(false);
+    if pyre_jit_trace::trace::take_fbw_bridge_declined() {
+        let (driver, _) = crate::eval::driver_pair();
+        driver
+            .meta_interp_mut()
+            .record_declined_bridge_guard(descr_arc);
+    }
 
     // #177 bridge `Terminate` no-replay: consume any finish-concrete the walk
     // kept.  A stash survives the epilogue only when `bridge_noreplay_armed`

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -5065,6 +5065,48 @@ pub extern "C" fn bh_load_method_self_fn(
     ) as i64
 }
 
+#[inline]
+fn load_special_method_name(method_kind: i64) -> &'static str {
+    match method_kind {
+        0 => "__enter__",
+        1 => "__exit__",
+        2 => "__aenter__",
+        _ => "__aexit__",
+    }
+}
+
+/// Resolve `getattr(obj, special_method_name(method_kind))` for LOAD_SPECIAL.
+/// This is the fixed-name counterpart of [`bh_load_attr_fn`]: the codewriter
+/// passes the bytecode's special-method discriminant instead of a `co_names`
+/// index.
+pub extern "C" fn bh_load_special_fn(obj: i64, method_kind: i64) -> i64 {
+    let name = load_special_method_name(method_kind);
+    if let Some((_, _, w_descr)) =
+        unsafe { pyre_interpreter::baseobjspace::load_method_fast_path(obj as _, name) }
+    {
+        return w_descr as i64;
+    }
+    match pyre_interpreter::baseobjspace::getattr_str(obj as pyre_object::PyObjectRef, name) {
+        Ok(attr) => attr as i64,
+        Err(err) => {
+            publish_residual_call_exception(err.to_exc_object() as i64);
+            0
+        }
+    }
+}
+
+/// Compute the LOAD_SPECIAL `null_or_self` value for an already-resolved
+/// special method.  Mirrors [`bh_load_method_self_fn`] without a code-object
+/// name lookup.
+pub extern "C" fn bh_load_special_self_fn(obj: i64, attr: i64, method_kind: i64) -> i64 {
+    let name = load_special_method_name(method_kind);
+    pyre_interpreter::eval::compute_load_method_bound(
+        obj as pyre_object::PyObjectRef,
+        attr as pyre_object::PyObjectRef,
+        name,
+    ) as i64
+}
+
 /// `LOAD_NAME` residual for the standalone (blackhole / deopt)
 /// per-CodeObject jitcode.  `pyopcode.py:945-955 LOAD_NAME` — when
 /// `getorcreatedebug().w_locals is not get_w_globals_storage()` the lookup

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -4988,7 +4988,13 @@ fn maybe_compile_and_run(
     if driver.has_compiled_loop(green_key) {
         return execute_assembler(frame, green_key, loop_header_pc, driver, info, env);
     }
-    // warmstate.py:484: DONT_TRACE_HERE → skip counter tick entirely
+    // Pyre-local deviation: this short-circuit treats `DONT_TRACE_HERE` as a
+    // permanent never-trace blacklist and returns before the counter tick.
+    // Upstream `warmstate.py:485-495` uses the identically named flag to force
+    // a separate trace when no procedure token has been seen; the ported
+    // behavior exists in `warmstate.rs::should_start_dont_trace_here_trace`
+    // and `warmstate.rs::can_inline_callable`, but this eval-layer guard
+    // shadows it.
     if driver
         .meta_interp()
         .warm_state_ref()

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -24,7 +24,7 @@ use pyre_jit_trace::{PyJitCode, PyJitCodeMetadata};
 
 use super::assembler::Assembler;
 use super::ssa_emitter::SSAReprEmitter;
-use pyre_interpreter::bytecode::{CodeFlags, CodeObject, Instruction, OpArgState};
+use pyre_interpreter::bytecode::{CodeFlags, CodeObject, Instruction, OpArgState, SpecialMethod};
 use pyre_interpreter::runtime_ops::{binary_op_tag, compare_op_tag};
 
 use super::flatten::{
@@ -2543,6 +2543,41 @@ fn emit_frontend_load_method_self(
     )
 }
 
+fn emit_frontend_load_special(
+    graph: &mut super::flow::FunctionGraph,
+    block: &super::flow::BlockRef,
+    obj: super::flow::FlowValue,
+    method_kind_const: super::flow::FlowValue,
+    offset: i64,
+) -> super::flow::Variable {
+    emit_graph_op_with_result(
+        graph,
+        block,
+        "load_special",
+        vec![obj.into(), method_kind_const.into()],
+        Kind::Ref,
+        offset,
+    )
+}
+
+fn emit_frontend_load_special_self(
+    graph: &mut super::flow::FunctionGraph,
+    block: &super::flow::BlockRef,
+    obj: super::flow::FlowValue,
+    attr: super::flow::FlowValue,
+    method_kind_const: super::flow::FlowValue,
+    offset: i64,
+) -> super::flow::Variable {
+    emit_graph_op_with_result(
+        graph,
+        block,
+        "load_special_self",
+        vec![obj.into(), attr.into(), method_kind_const.into()],
+        Kind::Ref,
+        offset,
+    )
+}
+
 fn emit_frontend_load_name(
     graph: &mut super::flow::FunctionGraph,
     block: &super::flow::BlockRef,
@@ -3330,6 +3365,8 @@ struct FnPtrIndices {
     set_current_exception_fn: HelperHandle,
     load_attr_fn: HelperHandle,
     load_method_self_fn: HelperHandle,
+    load_special_fn: HelperHandle,
+    load_special_self_fn: HelperHandle,
     store_attr_fn: HelperHandle,
     build_map_from_array_fn: HelperHandle,
     binary_slice_fn: HelperHandle,
@@ -3592,6 +3629,16 @@ fn register_helper_fn_pointers(
         assembler,
         cpu.load_method_self_fn as *const (),
         CallFlavor::PlainCannotRaise,
+    );
+    let load_special_fn = bind(
+        assembler,
+        cpu.load_special_fn as *const (),
+        CallFlavor::MayForce,
+    );
+    let load_special_self_fn = bind(
+        assembler,
+        cpu.load_special_self_fn as *const (),
+        CallFlavor::Plain,
     );
     // `bh_load_name_fn` / `bh_store_name_fn` delegate to the interpreter
     // `NamespaceOpcodeHandler` impl (pyopcode.py:945 LOAD_NAME / :855
@@ -4057,6 +4104,8 @@ fn register_helper_fn_pointers(
         set_current_exception_fn,
         load_attr_fn,
         load_method_self_fn,
+        load_special_fn,
+        load_special_self_fn,
         store_attr_fn,
         build_map_from_array_fn,
         binary_slice_fn,
@@ -5552,6 +5601,16 @@ impl CodeWriter {
                     idx: load_method_self_fn_idx,
                     flavor: _load_method_self_fn_flavor,
                 },
+            load_special_fn:
+                HelperHandle {
+                    idx: load_special_fn_idx,
+                    flavor: _load_special_fn_flavor,
+                },
+            load_special_self_fn:
+                HelperHandle {
+                    idx: load_special_self_fn_idx,
+                    flavor: _load_special_self_fn_flavor,
+                },
             store_attr_fn:
                 HelperHandle {
                     idx: store_attr_fn_idx,
@@ -5893,6 +5952,8 @@ impl CodeWriter {
                 ],
                 load_attr_fn_idx,
                 load_method_self_fn_idx,
+                load_special_fn_idx,
+                load_special_self_fn_idx,
                 store_attr_fn_idx,
                 build_map_from_array_fn_idx,
                 binary_slice_fn_idx,
@@ -10999,23 +11060,57 @@ impl CodeWriter {
                         }
 
                         // LoadSpecial: pops 1 (obj), pushes 2 (callable, self_or_null). Net: +1.
-                        // pyopcode.rs:2059 delegates to load_method; eval.rs:2365 pops 1 pushes 2.
+                        // pyopcode.rs delegates to load_method for a fixed special-method name.
                         //
-                        // Enter/Exit are portable (flowspace records a
-                        // `record_maybe_raise_op`), AEnter/AExit are a genuine
-                        // async boundary (`unsupported_rpython("async with is not
-                        // RPython")`).  The portable Enter/Exit half is latent:
-                        // LOAD_SPECIAL only heads a `with` block, whose exception
-                        // table blocks token creation (see WITH_EXCEPT_START), so
-                        // this abort is never reached in practice. No residual yet.
-                        Instruction::LoadSpecial { .. } => {
-                            pop_and_decr_depth(&mut current_state, &mut current_depth);
-                            push_fresh_ref(&mut current_state, &mut graph);
-                            current_depth += 1;
-                            push_fresh_ref(&mut current_state, &mut graph);
-                            current_depth += 1;
-                            emit_abort_permanent!(py_pc);
-                        }
+                        // Enter/Exit lower through the LOAD_ATTR method-form pipeline with the
+                        // bytecode's special-method discriminant instead of a co_names index.
+                        // AEnter/AExit remain a genuine async boundary (`async with` is not in
+                        // the RPython subset, and the downstream await/send path is unported).
+                        Instruction::LoadSpecial { method } => match method.get(op_arg) {
+                            SpecialMethod::Enter | SpecialMethod::Exit => {
+                                let method_kind_const: super::flow::FlowValue =
+                                    super::flow::Constant::signed(u32::from(op_arg) as i64).into();
+                                let _ = emit_popvalue_ref!(current_depth, py_pc);
+                                let obj_value = pop_ref_or_fresh(&mut current_state, &mut graph);
+                                let result_value = emit_frontend_load_special(
+                                    &mut graph,
+                                    &current_block.block(),
+                                    obj_value.clone(),
+                                    method_kind_const.clone(),
+                                    py_pc as i64,
+                                );
+                                current_state.stack.push(result_value.into());
+                                emit_pushvalue_ref!(
+                                    current_depth,
+                                    stack_base + current_depth,
+                                    result_value.into(),
+                                    py_pc
+                                );
+                                let bound_value = emit_frontend_load_special_self(
+                                    &mut graph,
+                                    &current_block.block(),
+                                    obj_value,
+                                    result_value.into(),
+                                    method_kind_const,
+                                    py_pc as i64,
+                                );
+                                current_state.stack.push(bound_value.into());
+                                emit_pushvalue_ref!(
+                                    current_depth,
+                                    stack_base + current_depth,
+                                    bound_value.into(),
+                                    py_pc
+                                );
+                            }
+                            SpecialMethod::AEnter | SpecialMethod::AExit => {
+                                pop_and_decr_depth(&mut current_state, &mut current_depth);
+                                push_fresh_ref(&mut current_state, &mut graph);
+                                current_depth += 1;
+                                push_fresh_ref(&mut current_state, &mut graph);
+                                current_depth += 1;
+                                emit_abort_permanent!(py_pc);
+                            }
+                        },
 
                         // LoadFromDictOrGlobals: pops 1 (dict), pushes 1 (result). Net: 0.
                         // Replace shadow value. eval.rs:2028.

--- a/pyre/pyre-jit/src/jit/cpu.rs
+++ b/pyre/pyre-jit/src/jit/cpu.rs
@@ -157,6 +157,10 @@ pub struct Cpu {
     /// LOOKUP_METHOD `null_or_self` half — `(obj, attr, code, name_idx) →
     /// bound`. Pure binding decision shared with the interpreter.
     pub load_method_self_fn: extern "C" fn(i64, i64, i64, i64) -> i64,
+    /// LOAD_SPECIAL attribute half — `(obj, method_kind) → attr`.
+    pub load_special_fn: extern "C" fn(i64, i64) -> i64,
+    /// LOAD_SPECIAL `null_or_self` half — `(obj, attr, method_kind) → bound`.
+    pub load_special_self_fn: extern "C" fn(i64, i64, i64) -> i64,
     /// STORE_ATTR residual — `(obj, value, code, name_idx) → void`.
     /// Resolves the name from the code object and runs generic `setattr`.
     pub store_attr_fn: extern "C" fn(i64, i64, i64, i64) -> i64,
@@ -441,6 +445,8 @@ impl Cpu {
             call_kw_fn_13: crate::call_jit::bh_call_kw_13,
             load_attr_fn: crate::call_jit::bh_load_attr_fn,
             load_method_self_fn: crate::call_jit::bh_load_method_self_fn,
+            load_special_fn: crate::call_jit::bh_load_special_fn,
+            load_special_self_fn: crate::call_jit::bh_load_special_self_fn,
             store_attr_fn: crate::call_jit::bh_store_attr_fn,
             binary_slice_fn: crate::call_jit::bh_binary_slice_fn,
             store_slice_fn: crate::call_jit::bh_store_slice_fn,

--- a/pyre/pyre-jit/src/jit/flatten.rs
+++ b/pyre/pyre-jit/src/jit/flatten.rs
@@ -3274,6 +3274,17 @@ pub struct LoweringContext {
     /// `compute_load_method_bound` binding decision (reads the type
     /// MRO, never raises → `PlainCannotRaise`).
     pub load_method_self_fn_idx: u16,
+    /// `load_special_fn` descrs-pool index.  LOAD_SPECIAL Enter/Exit records
+    /// `load_special(obj, method_kind)` and lowers to
+    /// `residual_call_ir_r(ConstInt(fn_idx), ListI([method_kind]),
+    /// ListR([obj]), Descr) → reg`; the helper resolves the fixed method name
+    /// from the discriminant and runs `getattr` (`MayForce`).
+    pub load_special_fn_idx: u16,
+    /// `load_special_self_fn` descrs-pool index.  The LOAD_SPECIAL
+    /// `null_or_self` half records `load_special_self(obj, attr, method_kind)`
+    /// and lowers to `residual_call_ir_r(ConstInt(fn_idx),
+    /// ListI([method_kind]), ListR([obj, attr]), Descr) → reg`.
+    pub load_special_self_fn_idx: u16,
     /// `store_attr_fn` descrs-pool index — see codewriter.rs
     /// `register_helper_fn_pointers` for the production source
     /// (`bind(assembler, cpu.store_attr_fn, CallFlavor::MayForce)`).
@@ -5076,6 +5087,13 @@ where
     if let Some(insn) = lower_load_method_self_hlop_to_insn(op, ctx, get_register, lower_constant) {
         return Some(insn);
     }
+    if let Some(insn) = lower_load_special_hlop_to_insn(op, ctx, get_register, lower_constant) {
+        return Some(insn);
+    }
+    if let Some(insn) = lower_load_special_self_hlop_to_insn(op, ctx, get_register, lower_constant)
+    {
+        return Some(insn);
+    }
     if let Some(insn) = lower_setattr_hlop_to_insn(op, ctx, get_register, lower_constant) {
         return Some(insn);
     }
@@ -5268,6 +5286,50 @@ where
                 vec![Operand::ConstInt(name_idx)],
             )),
             Operand::ListOfKind(ListOfKind::new(Kind::Ref, vec![obj, code])),
+            descr_operand,
+        ],
+        dst_reg,
+    ))
+}
+
+/// Lower the LOAD_SPECIAL attribute half — pyre HLOp
+/// `load_special(obj, method_kind)` → `result: Ref` — to
+/// `residual_call_ir_r(ConstInt(load_special_fn_idx),
+/// ListI([method_kind]), ListR([obj]), Descr) → reg`.
+pub fn lower_load_special_hlop_to_insn<F, LC>(
+    op: &super::flow::SpaceOperation,
+    ctx: &LoweringContext,
+    get_register: &mut F,
+    lower_constant: &mut LC,
+) -> Option<Insn>
+where
+    F: FnMut(super::flow::Variable) -> Register,
+    LC: FnMut(&Constant) -> Operand,
+{
+    if op.opname != "load_special" || op.args.len() != 2 {
+        return None;
+    }
+    let obj = operand_for_value_arg(&op.args[0], get_register, lower_constant)?;
+    let method_kind = const_int_for_value_arg(&op.args[1])?;
+    let dst_reg = match &op.result {
+        Some(super::flow::FlowValue::Variable(var)) => get_register(*var),
+        _ => return None,
+    };
+    let effect_info = effect_info_for_call_flavor(CallFlavor::MayForce);
+    let descr_operand = Operand::descr(DescrOperand::CallDescrStub(CallDescrStub {
+        effect_info,
+        arg_kinds: vec![Kind::Ref, Kind::Int],
+        result_kind: Some(Kind::Ref),
+    }));
+    Some(Insn::op_with_result(
+        "residual_call_ir_r",
+        vec![
+            Operand::ConstInt(ctx.load_special_fn_idx as i64),
+            Operand::ListOfKind(ListOfKind::new(
+                Kind::Int,
+                vec![Operand::ConstInt(method_kind)],
+            )),
+            Operand::ListOfKind(ListOfKind::new(Kind::Ref, vec![obj])),
             descr_operand,
         ],
         dst_reg,
@@ -6498,6 +6560,51 @@ where
                 vec![Operand::ConstInt(name_idx)],
             )),
             Operand::ListOfKind(ListOfKind::new(Kind::Ref, vec![obj, attr, code])),
+            descr_operand,
+        ],
+        dst_reg,
+    ))
+}
+
+/// Lower the LOAD_SPECIAL `null_or_self` half — pyre HLOp
+/// `load_special_self(obj, attr, method_kind)` → `result: Ref` — to
+/// `residual_call_ir_r(ConstInt(load_special_self_fn_idx),
+/// ListI([method_kind]), ListR([obj, attr]), Descr) → reg`.
+pub fn lower_load_special_self_hlop_to_insn<F, LC>(
+    op: &super::flow::SpaceOperation,
+    ctx: &LoweringContext,
+    get_register: &mut F,
+    lower_constant: &mut LC,
+) -> Option<Insn>
+where
+    F: FnMut(super::flow::Variable) -> Register,
+    LC: FnMut(&Constant) -> Operand,
+{
+    if op.opname != "load_special_self" || op.args.len() != 3 {
+        return None;
+    }
+    let obj = operand_for_value_arg(&op.args[0], get_register, lower_constant)?;
+    let attr = operand_for_value_arg(&op.args[1], get_register, lower_constant)?;
+    let method_kind = const_int_for_value_arg(&op.args[2])?;
+    let dst_reg = match &op.result {
+        Some(super::flow::FlowValue::Variable(var)) => get_register(*var),
+        _ => return None,
+    };
+    let effect_info = effect_info_for_call_flavor(CallFlavor::Plain);
+    let descr_operand = Operand::descr(DescrOperand::CallDescrStub(CallDescrStub {
+        effect_info,
+        arg_kinds: vec![Kind::Ref, Kind::Ref, Kind::Int],
+        result_kind: Some(Kind::Ref),
+    }));
+    Some(Insn::op_with_result(
+        "residual_call_ir_r",
+        vec![
+            Operand::ConstInt(ctx.load_special_self_fn_idx as i64),
+            Operand::ListOfKind(ListOfKind::new(
+                Kind::Int,
+                vec![Operand::ConstInt(method_kind)],
+            )),
+            Operand::ListOfKind(ListOfKind::new(Kind::Ref, vec![obj, attr])),
             descr_operand,
         ],
         dst_reg,


### PR DESCRIPTION
Seventeen commits in four groups:

## vstack mirror classification (5 commits)
- Model MAKE_FUNCTION in the vstack mirror; delete the unreachable int-bank deep-kept fill
- Keep the vstack mirror across a user-frame FOR_ITER consume
- Classify the remaining live operand-stack opcodes in the vstack mirror
- Route both scalar-vable-field Ref writes through one TOS-preserving helper
- Correct DONT_TRACE_HERE, trait-leg and callee-vstack comments

## P2 bridge-carrier compile leg (gh#366 follow-up)
- Seed P2 root call result from residual dst — decodes the residual_call `>r` dst byte ending at root_pc and seeds both `bridge_registers_r` and `bridge_stack_oprefs`
- Cap deterministic P2 drain bridge aborts — all deterministic P2-drain abort exits route through the declined-bridge channel, ending per-descr retrace treadmills
- Enable P2 compile leg by default
- Allow P2 root results in local slots — `inject_root_call_result` rejected `result_reg < nlocals`; upstream `make_result_of_lastop` writes `registers_r[target]` whether the target is a local or a stack temp (depth2_inline_chain_typeflip: ResultSlotUnresolved/SubWalkOk gone, guard_failures 179,308→100,200, first bridge compiles)
- Remove PYRE_P2_COMPILE gate — the opt-out served its A/B purpose; compile leg is now unconditional

## guard-thrash fixes
- Initialize w_class for compiled vtable allocations — compiled `NewWithVtable` wrote only ob_type while interp/blackhole/deopt-materialize also write `w_class`; `GuardValue(w_class)` pinned by the list-append fold failed deterministically on trace-made boxes
- Preserve bridge resume stack depth in init_symbolic — multi-frame deopt rewrites the live frame's valuestackdepth to the innermost depth; the resume-decoded root depth must survive
- Stop retracing declined FBW bridges — walker declines feed `record_declined_bridge_guard`

## structural abort-class cleanup
- Lower LOAD_SPECIAL through method residuals — the codewriter aborted on LOAD_SPECIAL, pre-walk-declining every `with`-statement loop; Enter/Exit now lower through fixed-name method residuals (method-kind oparg, not co_names); context_manager: 5→0 aborts, fully compiles
- Narrow callee abort scan roots — the pre-walk callee-abort scan seeded from the whole co_names/locals set, declining loops that merely reference (not call) a function with an abort marker; roots now cover only loop-body-referenced identifiers incl. in-loop handler ranges (property_getattr_exceptions and list_error_parity un-declined and compile; true positives stay declined)
- Seed standing exception for bridge handler walks — bridges resuming inside an except handler after a blackhole-delivered raise found an empty exception slot (`LastExc*WithoutActiveException`) and aborted forever; the bridge-entry seed now restores it from the resumed frame (ResumeGuardExcDescr analog); 3 benches 9/5/166→0 aborts, all compile with bridges
- Document w_class allocation init and bridge resume depth rationale

## Measured effects (dynasm)
- list_ops: 1165→0 aborts, 233,539→408 guard failures, 14.5x vs no-JIT (was slower than interp)
- calls_closures: 309→10 aborts, 2.6x vs interp (was 1.7x slower)
- context_manager, property_getattr_exceptions, list_error_parity, exception_loop_warmup, exception_bare_reraise_{restore,nested_outer}: all newly compile, outputs bit-exact vs python3.14
- depth2_inline_chain_typeflip: 901→6 aborts, first P2 bridge compiles (remaining carrier needs the #73 per-pc color→slot design)
- Full corpus A/B at the default flip: zero output diffs
- check.py at tip: dynasm 209/209, cranelift 209/209, wasm 208/208

🤖 Generated with [Claude Code](https://claude.com/claude-code)