### PR TITLE
dynasm: runtime flag check for GUARD_NOT_INVALIDATED

### DIFF
--- a/majit/majit-backend-dynasm/src/aarch64/assembler.rs
+++ b/majit/majit-backend-dynasm/src/aarch64/assembler.rs
@@ -336,6 +336,15 @@ pub struct AssemblerARM64<'a> {
     /// references no reference constants. Set before `assemble_loop` /
     /// `assemble_bridge` via [`set_gc_table_base`](Self::set_gc_table_base).
     gc_table_base: usize,
+    /// Address of the owning `JitCellToken.invalidated` `AtomicBool`.
+    /// `GUARD_NOT_INVALIDATED` bakes it as a 64-bit immediate and loads
+    /// the byte at runtime, branching to its recovery stub when set.
+    /// PyPy instead emits no runtime code and patches the guard site
+    /// (`invalidate_positions`) when the quasi-immutable field mutates;
+    /// pyre reads the flag live so re-entry through any path (warm entry,
+    /// CALL_ASSEMBLER, resume) observes the invalidation. 0 leaves the
+    /// guard as a no-op (bridges / tests with no owning token).
+    invalidated_flag_addr: usize,
 }
 
 /// assembler.py GuardToken — represents a pending guard needing
@@ -473,6 +482,7 @@ impl<'a> AssemblerARM64<'a> {
             attached_descrs,
             cpu_handle,
             gc_table_base: 0,
+            invalidated_flag_addr: 0,
         }
     }
 
@@ -1805,6 +1815,12 @@ impl<'a> AssemblerARM64<'a> {
     /// call_target_token → code_addr mappings for CALL_ASSEMBLER.
     pub fn set_call_assembler_targets(&mut self, targets: IndexMap<u64, usize>) {
         self.call_assembler_targets = targets;
+    }
+
+    /// Bake the owning token's `invalidated` flag address so
+    /// `GUARD_NOT_INVALIDATED` reads it live at runtime.
+    pub(crate) fn set_invalidated_flag_addr(&mut self, addr: usize) {
+        self.invalidated_flag_addr = addr;
     }
 
     /// llsupport/assembler.py:201 rebuild_faillocs_from_descr — reconstruct
@@ -3449,7 +3465,9 @@ impl<'a> AssemblerARM64<'a> {
                 self.implement_guard_with_faillocs(op, op_index, fail_index, faillocs);
             }
             OpCode::GuardNotInvalidated => {
-                self.implement_guard_nojump_with_faillocs(op, op_index, fail_index, faillocs);
+                self.implement_guard_not_invalidated_with_faillocs(
+                    op, op_index, fail_index, faillocs,
+                );
             }
             OpCode::GuardAlwaysFails => {
                 self.implement_guard_always_fails_with_faillocs(op, op_index, fail_index, faillocs);
@@ -3769,6 +3787,30 @@ impl<'a> AssemblerARM64<'a> {
     ) {
         let fail_label = self.mc.new_dynamic_label();
         dynasm!(self.mc ; .arch aarch64 ; b =>fail_label);
+        self.append_guard_token_with_faillocs(op, op_index, fail_index, fail_label, faillocs);
+    }
+
+    /// `GUARD_NOT_INVALIDATED`: load the owning token's `invalidated` byte
+    /// and branch to the recovery stub when it is set.  This sits at the
+    /// head of the peeled loop body, so every iteration — reached by any
+    /// entry path (warm entry, CALL_ASSEMBLER, blackhole resume) — observes
+    /// a quasi-immutable mutation that flipped the flag and bails out to the
+    /// bridge / interpreter instead of running the stale, const-folded body.
+    fn implement_guard_not_invalidated_with_faillocs(
+        &mut self,
+        op: &Op,
+        op_index: usize,
+        fail_index: u32,
+        faillocs: &[Option<Loc>],
+    ) {
+        let fail_label = self.mc.new_dynamic_label();
+        if self.invalidated_flag_addr != 0 {
+            self.emit_mov_imm64(16, self.invalidated_flag_addr as i64);
+            dynasm!(self.mc ; .arch aarch64
+                ; ldrb w17, [x16]
+                ; cbnz w17, =>fail_label
+            );
+        }
         self.append_guard_token_with_faillocs(op, op_index, fail_index, fail_label, faillocs);
     }
 

--- a/majit/majit-backend-dynasm/src/runner.rs
+++ b/majit/majit-backend-dynasm/src/runner.rs
@@ -2078,6 +2078,7 @@ impl Backend for DynasmBackend {
             asm.set_gc_table_base(table.base_addr());
         }
         asm.set_call_assembler_targets(Self::call_assembler_targets_snapshot());
+        asm.set_invalidated_flag_addr(std::sync::Arc::as_ptr(&token.invalidated) as usize);
         let compiled = asm.assemble_loop()?;
 
         let code_addr = codebuf::buffer_ptr(&compiled.buffer) as usize;
@@ -2325,6 +2326,7 @@ impl Backend for DynasmBackend {
             asm.set_gc_table_base(table.base_addr());
         }
         asm.set_call_assembler_targets(Self::call_assembler_targets_snapshot());
+        asm.set_invalidated_flag_addr(std::sync::Arc::as_ptr(&original_token.invalidated) as usize);
 
         let _orig_compiled = Self::get_compiled(original_token);
 

--- a/majit/majit-backend-dynasm/src/x86/assembler.rs
+++ b/majit/majit-backend-dynasm/src/x86/assembler.rs
@@ -881,6 +881,15 @@ pub struct Assembler386<'a> {
     /// references no reference constants. Set before `assemble_loop` /
     /// `assemble_bridge` via [`set_gc_table_base`](Self::set_gc_table_base).
     gc_table_base: usize,
+    /// Address of the owning `JitCellToken.invalidated` `AtomicBool`.
+    /// `GUARD_NOT_INVALIDATED` bakes it as a 64-bit immediate and loads
+    /// the byte at runtime, branching to its recovery stub when set.
+    /// PyPy instead emits no runtime code and patches the guard site
+    /// (`invalidate_positions`) when the quasi-immutable field mutates;
+    /// pyre reads the flag live so re-entry through any path (warm entry,
+    /// CALL_ASSEMBLER, resume) observes the invalidation. 0 leaves the
+    /// guard as a no-op (bridges / tests with no owning token).
+    invalidated_flag_addr: usize,
 }
 
 /// assembler.py GuardToken — represents a pending guard needing
@@ -1028,6 +1037,7 @@ impl<'a> Assembler386<'a> {
             malloc_slowpath_fixed,
             malloc_slowpath_headerless,
             gc_table_base: 0,
+            invalidated_flag_addr: 0,
         }
     }
 
@@ -2579,6 +2589,12 @@ impl<'a> Assembler386<'a> {
     /// call_target_token → code_addr mappings for CALL_ASSEMBLER.
     pub fn set_call_assembler_targets(&mut self, targets: IndexMap<u64, usize>) {
         self.call_assembler_targets = targets;
+    }
+
+    /// Bake the owning token's `invalidated` flag address so
+    /// `GUARD_NOT_INVALIDATED` reads it live at runtime.
+    pub(crate) fn set_invalidated_flag_addr(&mut self, addr: usize) {
+        self.invalidated_flag_addr = addr;
     }
 
     /// llsupport/assembler.py:201 rebuild_faillocs_from_descr — reconstruct
@@ -4600,7 +4616,24 @@ impl<'a> Assembler386<'a> {
                 self.implement_guard_with_faillocs(op, op_index, fail_index, faillocs);
             }
             OpCode::GuardNotInvalidated => {
-                self.implement_guard_nojump_with_faillocs(op, op_index, fail_index, faillocs);
+                // Load the owning token's `invalidated` byte and fail the
+                // guard when set.  This sits at the head of the peeled loop
+                // body, so every iteration — reached by any entry path (warm
+                // entry, CALL_ASSEMBLER, blackhole resume) — observes a
+                // quasi-immutable mutation that flipped the flag and bails to
+                // the bridge / interpreter instead of running the stale,
+                // const-folded body.  R11 is the dedicated scratch (as in
+                // `_cmp_guard_class`); a 0 address leaves the guard a no-op.
+                if self.invalidated_flag_addr != 0 {
+                    dynasm!(self.mc ; .arch x64
+                        ; mov r11, QWORD self.invalidated_flag_addr as i64
+                        ; cmp BYTE [r11], 0
+                    );
+                    self.guard_success_cc = Some(CC_E);
+                    self.implement_guard_with_faillocs(op, op_index, fail_index, faillocs);
+                } else {
+                    self.implement_guard_nojump_with_faillocs(op, op_index, fail_index, faillocs);
+                }
             }
             OpCode::GuardAlwaysFails => {
                 self.implement_guard_always_fails_with_faillocs(op, op_index, fail_index, faillocs);

--- a/pyre/bench/synth/global_quasiimmut_invalidation.py
+++ b/pyre/bench/synth/global_quasiimmut_invalidation.py
@@ -1,0 +1,32 @@
+# pyre-check: max-pypy-ratio=150
+# Nested compiled loop + a conditional loop-carried store to a MODULE
+# GLOBAL that is read after the (untaken) store.  The read-only global
+# `x` folds to a constant in the primary loop under a
+# GUARD_NOT_INVALIDATED keyed on the module dict's `version?`.  When the
+# store rebinds `x`, the celldict bumps the version and flips the loop's
+# invalidation flag, but the compiled GUARD_NOT_INVALIDATED must re-read
+# that flag at runtime on every iteration so that a re-entry through any
+# path (warm entry, CALL_ASSEMBLER, eval-breaker poll-deopt resume)
+# observes the invalidation.  Previously the guard emitted no runtime
+# code (only the warm-entry lookup filtered invalidated tokens), so after
+# the periodic poll deopt the stale const-folded loop was re-entered and
+# `x` reverted to its pre-store value for the rest of the run.  Function
+# scope is unaffected (locals are never const-folded this way); the
+# module-global read path is the one under test.
+K = 5000
+N = 1000000
+
+x = 1
+i = 0
+s = 0
+
+while i < N:
+    j = 0
+    while j < 2:
+        j = j + 1
+    if i == K:
+        x = 100
+    s = s + x
+    i = i + 1
+
+print(s)


### PR DESCRIPTION
## Summary

The dynasm `GUARD_NOT_INVALIDATED` emitted no runtime code — it recorded a
recovery stub for a bridge to attach but never tested the invalidation flag.
When a compiled loop was invalidated by a quasi-immutable mutation (a
module-global rebind flipping the celldict version watcher), the stale loop was
filtered out **only at warm entry** (`get_procedure_token` skips invalidated
tokens). Re-entry paths that bypass warm entry — `CALL_ASSEMBLER` and the
eval-breaker poll-deopt resume back into the loop body — kept running the stale,
const-folded loop.

The visible symptom: a module global read after a conditional loop-carried store
reverted to its pre-store value once the periodic eval-breaker poll fired.

```python
i=0; x=1; s=0
while i < N:
    j=0
    while j < 2: j += 1     # nested loop -> forces the outer loop to compile
    if i == K: x = 100      # conditional loop-carried store to a module global
    s += x                  # reads x AFTER the (untaken-until-K) store
    i += 1
print(s)
```

Function scope is unaffected (locals are never const-folded this way); only the
module-global read path miscompiled.

## Fix

The guard now bakes the owning `JitCellToken.invalidated` address and, on every
execution, loads that byte and branches to its recovery stub when set:

- **aarch64**: `ldrb w17, [x16]; cbnz w17, =>fail`
- **x86**: `cmp BYTE [r11], 0` with `CC_E` guard-success

The address is threaded into the assembler from `compile_loop` and
`compile_bridge`. `addr == 0` (bridges/tests without a token) stays a no-op, so
there is no codegen change for loops that emit no `GUARD_NOT_INVALIDATED`.

The cranelift backend already performs this live flag check (this brings dynasm
to parity with it); wasm relies on its caller-invalidation retrace path.

## Test plan

- New regression fixture `pyre/bench/synth/global_quasiimmut_invalidation.py`
  (nested loop + conditional loop-carried store to a module global, N=1e6).
  Passes on all three backends; fails on the pre-fix dynasm binary.
- `python pyre/check.py`: dynasm 208/208, cranelift 208/208, wasm 207/207.
- Minimal repros (K=100 N=2000 → 190100; K=5000 N=20000 → 1505000) now match
  `PYRE_NO_JIT=1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
