### PR TITLE
typedef parity: code/function/method/cell/property/class/staticmethod (3.14)

### DIFF
--- a/majit/majit-backend-wasm/src/codegen.rs
+++ b/majit/majit-backend-wasm/src/codegen.rs
@@ -1270,6 +1270,10 @@ pub fn build_wasm_module(
     // Inline nursery-bump fast path for eligible `New`/`NewWithVtable`
     // (see `NurseryAllocParams`); `None` keeps allocations on the helper.
     nursery: Option<&NurseryAllocParams>,
+    // Address of the owning JitCellToken.invalidated AtomicBool in shared
+    // linear memory. GUARD_NOT_INVALIDATED reads this byte at runtime, like
+    // the native backends bake the same Arc allocation's address.
+    invalidated_flag_addr: u32,
     fail_index_base: u32,
     // Table slot of the loop a JUMP-with-no-local-LABEL re-enters (a loop-closing
     // bridge). `0` for a loop trace (its JUMP is a local back-edge `br`) and for a
@@ -1559,6 +1563,7 @@ pub fn build_wasm_module(
         &ref_homes,
         cells_base,
         bridge_dispatch,
+        invalidated_flag_addr,
         fail_index_base,
         external_jump_slot,
         external_jump_key,
@@ -1600,6 +1605,7 @@ fn build_function(
     ref_homes: &RefHomes,
     cells_base: u32,
     bridge_dispatch: bool,
+    invalidated_flag_addr: u32,
     fail_index_base: u32,
     external_jump_slot: u32,
     // Resume-at-LABEL dispatch key the terminal external JUMP writes before
@@ -2105,9 +2111,33 @@ fn build_function(
                 }
                 guard_idx += 1;
             }
-            // Guards that always pass in wasm MVP (no force-token /
-            // invalidation tracking yet).
-            OpCode::GuardNotInvalidated | OpCode::GuardNotForced | OpCode::GuardNotForced2 => {
+            OpCode::GuardNotInvalidated => {
+                // x86/assembler.py:4618-4637 parity: the guard site observes
+                // the owning loop token's invalidation flag on every entry.
+                // On wasm32 the Arc allocation lives in shared linear memory,
+                // so its stable pointer is directly addressable by the trace.
+                if invalidated_flag_addr != 0 {
+                    sink.i32_const(invalidated_flag_addr as i32);
+                    sink.i32_load8_u(MemArg {
+                        offset: 0,
+                        align: 0,
+                        memory_index: 0,
+                    });
+                    sink.i32_const(0);
+                    sink.i32_ne();
+                    emit_guard_if_exit(
+                        &mut sink,
+                        constants,
+                        value_types,
+                        guard_idx,
+                        op,
+                        block_exit_depth,
+                    );
+                }
+                guard_idx += 1;
+            }
+            // Force-token guards still always pass in the wasm backend.
+            OpCode::GuardNotForced | OpCode::GuardNotForced2 => {
                 guard_idx += 1;
             }
             OpCode::GuardNoException => {

--- a/majit/majit-backend-wasm/src/lib.rs
+++ b/majit/majit-backend-wasm/src/lib.rs
@@ -1555,6 +1555,7 @@ impl majit_backend::Backend for WasmBackend {
                 alloc_array_fn_ptr,
                 wb_fn_ptr,
                 nursery_alloc_params(ops).as_ref(),
+                Arc::as_ptr(&token.invalidated) as usize as u32,
                 fail_index_base,
                 0, // external_jump_slot: a loop's JUMP is a local back-edge `br`
                 0, // external_jump_key: unused without an external JUMP
@@ -1852,6 +1853,19 @@ impl majit_backend::Backend for WasmBackend {
         let ops_owned: Vec<Op> = ops.iter().map(|rc| (**rc).clone()).collect();
         let ops: &[Op] = &ops_owned;
         diag_bump(0); // compile_bridge entered
+
+        // PyPy patches every GUARD_NOT_INVALIDATED in a loop and its already
+        // attached bridges to their recovery stubs at invalidation time. A
+        // wasm guard reads the equivalent live token flag instead. Never add
+        // a new in-module bridge after that transition: in particular, a
+        // bridge attached to the newly failing invalidation guard could jump
+        // back into the same permanently-invalidated loop and form a closed
+        // loop↔bridge cycle without returning to the blackhole interpreter.
+        if original_token.is_invalidated() {
+            return Err(BackendError::Unsupported(
+                "wasm backend: cannot attach a bridge to an invalidated loop".into(),
+            ));
+        }
 
         // is_loop=false: a bridge's terminal JUMP with no LABEL is a loop-closing
         // bridge whose re-entry target is plumbed via `external_jump_slot`.
@@ -2251,6 +2265,7 @@ impl majit_backend::Backend for WasmBackend {
                 alloc_array_fn_ptr,
                 wb_fn_ptr,
                 nursery_alloc_params(ops).as_ref(),
+                Arc::as_ptr(&original_token.invalidated) as usize as u32,
                 base,
                 // A loop-closing bridge's terminal JUMP re-enters the target
                 // loop (own or sibling, resolved via `LABEL_TARGETS`) through
@@ -2777,11 +2792,11 @@ impl majit_backend::Backend for WasmBackend {
         crate::jit_exc_clear();
     }
 
-    fn invalidate_loop(&self, _token: &JitCellToken) {
-        // No native code to invalidate — wasm modules are immutable.
-        // A CALL_ASSEMBLER module bakes the stable dispatch entry's address;
-        // its lifetime ends only when CompiledWasmLoop::drop retracts every
-        // alias for that compiled_ptr.
+    fn invalidate_loop(&self, token: &JitCellToken) {
+        // x86/assembler.py:641-648 invalidate_loop parity. The wasm module is
+        // immutable, so GUARD_NOT_INVALIDATED loads this live flag instead of
+        // having its instruction bytes patched in place.
+        token.invalidated.store(true, Ordering::Release);
     }
 
     fn redirect_call_assembler(

--- a/majit/majit-backend-wasm/tests/codegen_test.rs
+++ b/majit/majit-backend-wasm/tests/codegen_test.rs
@@ -210,6 +210,7 @@ fn build_module(
         0,
         0,
         None, // nursery
+        0,    // invalidated_flag_addr
         0,    // fail_index_base
         0,    // external_jump_slot
         0,    // external_jump_key
@@ -435,7 +436,7 @@ fn test_guard_types() {
             op.setfailargs(smallvec![rb(OpRef::input_arg_int(0))]);
             op
         },
-        // GuardNotInvalidated (0 args, always pass)
+        // GuardNotInvalidated (0 args; address 0 in this generic smoke test)
         {
             let op = Op::new(OpCode::GuardNotInvalidated, &[]);
             op.setfailargs(smallvec![rb(OpRef::input_arg_int(0))]);
@@ -451,6 +452,58 @@ fn test_guard_types() {
     let (bytes, guards) = build_module_default(&inputargs, &ops, &constants);
     validate_wasm(&bytes);
     assert_eq!(guards.len(), 7);
+}
+
+/// GUARD_NOT_INVALIDATED must read the owning token's live AtomicBool rather
+/// than being folded to an always-passing guard. The runtime regression is
+/// covered by global_quasiimmut_invalidation.py; this pins the emitted load.
+#[test]
+fn test_guard_not_invalidated_loads_runtime_flag() {
+    let inputargs = vec![InputArg::from_type(Type::Int, 0)];
+    let guard = Op::new(OpCode::GuardNotInvalidated, &[]);
+    guard.setfailargs(smallvec![rb(OpRef::input_arg_int(0))]);
+    let ops = vec![
+        guard,
+        Op::new(OpCode::Finish, &[rb(OpRef::input_arg_int(0))]),
+    ];
+    let constants = indexmap::IndexMap::new();
+    let (bytes, guards, _, _, _) = codegen::build_wasm_module(
+        &inputargs,
+        &ops,
+        &constants,
+        None,
+        &HashMap::new(),
+        &codegen::GuardGcTypeInfo::default(),
+        0,
+        0,
+        0,
+        None,
+        0x1000,
+        0,
+        0,
+        0,
+        codegen::FrameGeometry::fixed(),
+        codegen::CaParams::default(),
+    )
+    .expect("wasm codegen should succeed");
+
+    validate_wasm(&bytes);
+    assert_eq!(guards.len(), 2);
+    let mut saw_flag_load = false;
+    for payload in wasmparser::Parser::new(0).parse_all(&bytes) {
+        if let wasmparser::Payload::CodeSectionEntry(body) = payload.unwrap() {
+            let mut operators = body.get_operators_reader().unwrap();
+            while !operators.eof() {
+                if matches!(
+                    operators.read().unwrap(),
+                    wasmparser::Operator::I32Load8U { .. }
+                ) {
+                    saw_flag_load = true;
+                }
+            }
+        }
+    }
+    assert!(saw_flag_load, "GUARD_NOT_INVALIDATED omitted its flag load");
 }
 
 /// GuardNoException loads the global exception slot and fails when it is set;

--- a/pyre/bench/synth/classmethod_protocol_hot.py
+++ b/pyre/bench/synth/classmethod_protocol_hot.py
@@ -1,0 +1,23 @@
+"""Hot classmethod binding and wrapper-dictionary parity."""
+
+
+class Base:
+    @classmethod
+    def calculate(cls, value):
+        return value + len(cls.__name__)
+
+
+class Derived(Base):
+    pass
+
+
+wrapper = Base.__dict__["calculate"]
+wrapper.offset = 3
+
+total = 0
+for i in range(1001):
+    total += Derived.calculate(i) + wrapper.offset
+
+print(total)
+print(callable(wrapper))
+print(wrapper.__func__.__name__, wrapper.__dict__["offset"])

--- a/pyre/bench/synth/property_protocol_hot.py
+++ b/pyre/bench/synth/property_protocol_hot.py
@@ -1,0 +1,34 @@
+"""Hot property get/set plus Python 3.14 metadata surface."""
+
+
+class Counter:
+    def __init__(self):
+        self._value = 0
+
+    @property
+    def value(self):
+        "counter value"
+        return self._value
+
+    @value.setter
+    def value(self, value):
+        self._value = value
+
+
+def main():
+    counter = Counter()
+    total = 0
+    i = 0
+    while i < 200000:
+        counter.value = i
+        total += counter.value
+        i += 1
+
+    prop = Counter.__dict__["value"]
+    print(total, counter.value)
+    # PyPy 3.11 has not yet gained property.__name__; keep the synthetic
+    # output version-neutral while the dedicated 3.14 parity test covers it.
+    print(prop.fget.__name__, prop.__doc__)
+
+
+main()

--- a/pyre/extra_tests/parity_tests/builtin_function_python314.py
+++ b/pyre/extra_tests/parity_tests/builtin_function_python314.py
@@ -1,0 +1,77 @@
+"""CPython 3.14 surface and protocol parity for builtin functions."""
+
+import builtins
+import math
+
+
+def raises(exc_type, action):
+    try:
+        action()
+    except exc_type:
+        return
+    raise AssertionError(f"expected {exc_type.__name__}")
+
+
+t = type(len)
+assert t.__name__ == "builtin_function_or_method"
+assert sorted(t.__dict__) == [
+    "__call__",
+    "__doc__",
+    "__eq__",
+    "__ge__",
+    "__gt__",
+    "__hash__",
+    "__le__",
+    "__lt__",
+    "__module__",
+    "__name__",
+    "__ne__",
+    "__qualname__",
+    "__reduce__",
+    "__repr__",
+    "__self__",
+    "__text_signature__",
+]
+
+assert not hasattr(len, "__dict__")
+assert len.__module__ == "builtins"
+assert len.__name__ == "len"
+assert len.__qualname__ == "len"
+assert len.__self__ is builtins
+assert math.sqrt.__self__ is math
+assert len.__reduce__() == "len"
+assert len.__reduce_ex__(4) == "len"
+assert len.__repr__() == "<built-in function len>"
+assert t.__dict__["__call__"](len, [1, 2, 3]) == 3
+
+assert len == len
+assert len != abs
+assert isinstance(hash(len), int)
+raises(TypeError, lambda: len < abs)
+raises(TypeError, t)
+
+descriptor_kinds = {
+    "__doc__": "getset_descriptor",
+    "__module__": "member_descriptor",
+    "__name__": "getset_descriptor",
+    "__qualname__": "getset_descriptor",
+    "__self__": "getset_descriptor",
+    "__text_signature__": "getset_descriptor",
+}
+for name, kind in descriptor_kinds.items():
+    descriptor = t.__dict__[name]
+    assert type(descriptor).__name__ == kind
+    assert descriptor.__objclass__ is t
+    raises(TypeError, lambda d=descriptor: d.__get__(1, int))
+    if name == "__module__":
+        continue
+    raises(AttributeError, lambda n=name: setattr(len, n, "changed"))
+    raises(AttributeError, lambda n=name: delattr(len, n))
+
+len.__module__ = "changed"
+assert len.__module__ == "changed"
+del len.__module__
+assert len.__module__ is None
+len.__module__ = "builtins"
+
+print("builtin_function_or_method Python 3.14 parity: ok")

--- a/pyre/extra_tests/parity_tests/classmethod_protocol.py
+++ b/pyre/extra_tests/parity_tests/classmethod_protocol.py
@@ -1,0 +1,192 @@
+"""Python 3.14 / PyPy structural parity for ``classmethod``.
+
+PyPy ``interpreter/function.py:718-768 ClassMethod`` supplies the wrapped
+callable, lazy instance dictionary, descriptor and repr operations.
+``interpreter/typedef.py:878-908`` exposes them in the type dictionary.
+Python 3.14 additionally proxies PEP 649's ``__annotations__`` and
+``__annotate__`` attributes and exposes ``__class_getitem__``; it omits
+PyPy 3.11's ``__reduce_ex__`` entry and does not make the wrapper callable.
+"""
+
+
+EXPECTED_SURFACE = {
+    "__annotate__",
+    "__annotations__",
+    "__class_getitem__",
+    "__dict__",
+    "__doc__",
+    "__func__",
+    "__get__",
+    "__init__",
+    "__isabstractmethod__",
+    "__new__",
+    "__repr__",
+    "__wrapped__",
+}
+
+assert set(classmethod.__dict__) == EXPECTED_SURFACE
+assert classmethod.__doc__.startswith("Convert a function to be a class method.\n")
+assert classmethod.__doc__.endswith("see the staticmethod builtin.")
+
+
+def wrapped(cls, value: int = 2) -> str:
+    "wrapped doc"
+    return f"{cls.__name__}:{value}"
+
+
+cm = classmethod(wrapped)
+assert cm.__func__ is wrapped
+assert cm.__wrapped__ is wrapped
+assert cm.__dict__ == {
+    "__module__": __name__,
+    "__name__": "wrapped",
+    "__qualname__": "wrapped",
+    "__doc__": "wrapped doc",
+}
+assert repr(cm).startswith("<classmethod(<function wrapped")
+assert repr(cm).endswith(")>")
+assert not callable(cm)
+try:
+    cm()
+except TypeError as exc:
+    assert str(exc) == "'classmethod' object is not callable"
+else:
+    assert False, "a raw classmethod wrapper must not be callable"
+
+
+class Base:
+    method = cm
+
+
+class Derived(Base):
+    pass
+
+
+assert Base.method(3) == "Base:3"
+assert Base().method(4) == "Base:4"
+assert Derived.method(5) == "Derived:5"
+assert Derived().method(6) == "Derived:6"
+bound = cm.__get__(None, Derived)
+assert bound.__func__ is wrapped
+assert bound.__self__ is Derived
+assert bound(7) == "Derived:7"
+
+# Python 3.14 cm_descr_get binds the stored object directly rather than
+# invoking a descriptor nested inside classmethod.
+nested = property(lambda obj: "property result")
+nested_bound = classmethod(nested).__get__(None, Base)
+assert nested_bound.__func__ is nested
+assert nested_bound.__self__ is Base
+
+# PyPy ClassMethod.getdict/setdict: arbitrary attributes and wholesale dict
+# replacement use the object's w_dict field, including dict subclasses.
+cm.extra = 9
+assert cm.extra == 9
+assert cm.__dict__["extra"] == 9
+
+
+class DictSubclass(dict):
+    pass
+
+
+replacement = DictSubclass(marker=11)
+cm.__dict__ = replacement
+assert cm.__dict__ is replacement
+assert cm.marker == 11
+cm.more = 12
+assert replacement["more"] == 12
+
+try:
+    cm.__dict__ = 1
+except TypeError as exc:
+    assert str(exc) == "__dict__ must be set to a dictionary, not a 'int'"
+else:
+    assert False, "classmethod.__dict__ must reject non-dicts"
+
+try:
+    del cm.__dict__
+except TypeError as exc:
+    assert str(exc) == "cannot delete __dict__"
+else:
+    assert False, "classmethod.__dict__ cannot be deleted"
+
+# CPython 3.14 descriptor_get_wrapped_attribute: first read obtains the
+# wrapped function's value and caches it locally. Setting/deleting affects the
+# wrapper dictionary, never the wrapped function.
+cm = classmethod(wrapped)
+assert "__annotations__" not in cm.__dict__
+assert "__annotate__" not in cm.__dict__
+assert cm.__annotations__ is wrapped.__annotations__
+assert cm.__annotate__ is wrapped.__annotate__
+assert cm.__dict__["__annotations__"] is wrapped.__annotations__
+assert cm.__dict__["__annotate__"] is wrapped.__annotate__
+
+wrapped_annotations = wrapped.__annotations__
+wrapped_annotate = wrapped.__annotate__
+cm.__annotations__ = 42
+cm.__annotate__ = 43
+assert cm.__annotations__ == 42
+assert cm.__annotate__ == 43
+assert wrapped.__annotations__ is wrapped_annotations
+assert wrapped.__annotate__ is wrapped_annotate
+del cm.__annotations__
+del cm.__annotate__
+assert cm.__annotations__ is wrapped_annotations
+assert cm.__annotate__ is wrapped_annotate
+
+fresh = classmethod(wrapped)
+for name in ("__annotations__", "__annotate__"):
+    try:
+        delattr(fresh, name)
+    except AttributeError as exc:
+        assert str(exc) == f"'classmethod' object has no attribute '{name}'"
+    else:
+        assert False, f"deleting uncached {name} must fail"
+
+try:
+    classmethod()
+except TypeError as exc:
+    assert str(exc) == "classmethod expected 1 argument, got 0"
+else:
+    assert False, "classmethod requires one argument"
+
+try:
+    classmethod(wrapped, wrapped)
+except TypeError as exc:
+    assert str(exc) == "classmethod expected 1 argument, got 2"
+else:
+    assert False, "classmethod accepts exactly one argument"
+
+try:
+    classmethod(function=wrapped)
+except TypeError as exc:
+    assert str(exc) == "classmethod() takes no keyword arguments"
+else:
+    assert False, "classmethod's argument is positional-only"
+
+
+class ClassMethodSubclass(classmethod):
+    pass
+
+
+sub = ClassMethodSubclass(wrapped)
+assert type(sub) is ClassMethodSubclass
+assert sub.__func__ is wrapped
+
+
+class CallableClassMethod(classmethod):
+    def __call__(self, value):
+        return self.__func__(Base, value)
+
+
+callable_sub = CallableClassMethod(wrapped)
+assert callable(callable_sub)
+assert callable_sub(8) == "Base:8"
+assert callable_sub(value=9) == "Base:9"
+
+alias = classmethod[int]
+assert type(alias).__name__ == "GenericAlias"
+assert alias.__origin__ is classmethod
+assert alias.__args__ == (int,)
+
+print("OK")

--- a/pyre/extra_tests/parity_tests/closure_cell_protocol.py
+++ b/pyre/extra_tests/parity_tests/closure_cell_protocol.py
@@ -1,4 +1,4 @@
-"""Phase 6 parity test: cell object protocol via __closure__.
+"""Cell TypeDef parity via ``types.CellType`` and ``__closure__``.
 
 PyPy `nestedscope.py:22-125 Cell` + `typedef.py:934-952 Cell.typedef`:
 
@@ -18,13 +18,95 @@ PyPy `nestedscope.py:22-125 Cell` + `typedef.py:934-952 Cell.typedef`:
 `ValueError` for a re-delete (`:121-125`).
 
 Pinned contract:
-  1. `f.__closure__[i]` returns a `cell` (not the unwrapped value),
-  2. `cell.cell_contents` reads the captured value,
-  3. assignment to `cell.cell_contents` writes through the cell so
+  1. the Python 3.14 CellType surface is complete,
+  2. construction, comparison, repr and hash semantics match 3.14,
+  3. `f.__closure__[i]` returns a `cell` (not the unwrapped value),
+  4. `cell.cell_contents` reads the captured value,
+  5. assignment to `cell.cell_contents` writes through the cell so
      the inner function observes the new value,
-  4. `del cell.cell_contents` clears the cell; subsequent reads raise
+  6. `del cell.cell_contents` clears the cell; subsequent reads raise
      `ValueError`.
 """
+
+import types
+
+
+CellType = types.CellType
+assert set(CellType.__dict__) == {
+    "__doc__",
+    "__eq__",
+    "__ge__",
+    "__gt__",
+    "__hash__",
+    "__le__",
+    "__lt__",
+    "__ne__",
+    "__new__",
+    "__repr__",
+    "cell_contents",
+}
+assert CellType.__hash__ is None
+
+empty = CellType()
+one = CellType(1)
+one_again = CellType(1)
+two = CellType(2)
+assert repr(empty).startswith("<cell at 0x") and repr(empty).endswith(": empty>")
+assert repr(one).startswith("<cell at 0x") and ": int object at 0x" in repr(one)
+assert empty < one < two
+assert empty <= CellType()
+assert one == one_again and one != two
+assert two > one and two >= one
+assert CellType.__eq__(one, 1) is NotImplemented
+assert CellType.__lt__(one, 1) is NotImplemented
+
+try:
+    hash(one)
+except TypeError:
+    pass
+else:
+    assert False, "cell must be unhashable"
+
+try:
+    CellType(contents=1)
+except TypeError:
+    pass
+else:
+    assert False, "cell constructor arguments are positional-only"
+
+try:
+    CellType(1, 2)
+except TypeError:
+    pass
+else:
+    assert False, "cell accepts at most one content argument"
+
+try:
+    type("CellSubclass", (CellType,), {})
+except TypeError:
+    pass
+else:
+    assert False, "cell is not an acceptable base type"
+
+# A cell is an ordinary visible Python object. Storing one in another cell
+# must not transparently unwrap the inner cell at an object-space boundary.
+nested = CellType(one)
+assert nested.cell_contents is one
+assert nested != one
+assert bool(empty) and bool(one)
+assert not isinstance(one, int)
+box = [None]
+box[0] = one
+assert box[0] is one
+mapping = {"cell": one}
+assert mapping["cell"] is one
+try:
+    one + 1
+except TypeError:
+    pass
+else:
+    assert False, "cell arithmetic must not operate on its contents"
+
 
 def _make(x):
     def _inner():

--- a/pyre/extra_tests/parity_tests/code_python314.py
+++ b/pyre/extra_tests/parity_tests/code_python314.py
@@ -1,0 +1,146 @@
+import types
+
+
+EXPECTED = {
+    "__doc__",
+    "__eq__",
+    "__ge__",
+    "__gt__",
+    "__hash__",
+    "__le__",
+    "__lt__",
+    "__ne__",
+    "__new__",
+    "__replace__",
+    "__repr__",
+    "__sizeof__",
+    "_co_code_adaptive",
+    "_varname_from_oparg",
+    "co_argcount",
+    "co_branches",
+    "co_cellvars",
+    "co_code",
+    "co_consts",
+    "co_exceptiontable",
+    "co_filename",
+    "co_firstlineno",
+    "co_flags",
+    "co_freevars",
+    "co_kwonlyargcount",
+    "co_lines",
+    "co_linetable",
+    "co_lnotab",
+    "co_name",
+    "co_names",
+    "co_nlocals",
+    "co_positions",
+    "co_posonlyargcount",
+    "co_qualname",
+    "co_stacksize",
+    "co_varnames",
+    "replace",
+}
+
+assert set(types.CodeType.__dict__) == EXPECTED
+assert types.CodeType.__doc__ == "Create a code object.  Not for the faint of heart."
+
+
+def sample(a, /, b=2, *, c=3):
+    if a:
+        return a + b + c
+    return 0
+
+
+code = sample.__code__
+assert code.co_argcount == 2
+assert code.co_posonlyargcount == 1
+assert code.co_kwonlyargcount == 1
+assert code.co_nlocals == len(code.co_varnames)
+assert code.co_varnames[:3] == ("a", "b", "c")
+assert code.co_name == "sample"
+assert code.co_qualname == "sample"
+assert isinstance(code.co_code, bytes)
+assert isinstance(code._co_code_adaptive, bytes)
+assert len(code._co_code_adaptive) == len(code.co_code)
+assert isinstance(code.co_consts, tuple)
+assert isinstance(code.co_names, tuple)
+assert isinstance(code.co_freevars, tuple)
+assert isinstance(code.co_cellvars, tuple)
+assert isinstance(code.co_linetable, bytes)
+assert isinstance(code.co_lnotab, bytes)
+assert code.co_lnotab
+assert isinstance(code.co_exceptiontable, bytes)
+assert code._varname_from_oparg(0) == "a"
+
+try:
+    code._varname_from_oparg(-1)
+except IndexError as exc:
+    assert str(exc) == "tuple index out of range"
+else:
+    raise AssertionError("negative local index was accepted")
+
+positions = list(code.co_positions())
+lines = list(code.co_lines())
+branches = list(code.co_branches())
+assert len(positions) == len(code.co_code) // 2
+assert lines and all(len(row) == 3 for row in lines)
+assert branches == [(12, 18, 48)]
+
+same = code.replace()
+same_dunder = code.__replace__()
+assert same is not code
+assert same == code
+assert same_dunder == code
+assert hash(same) == hash(code)
+assert code.replace(co_name="renamed").co_name == "renamed"
+assert code.replace(co_qualname="outer.renamed").co_qualname == "outer.renamed"
+assert types.CodeType.__eq__(code, object()) is NotImplemented
+assert types.CodeType.__ne__(code, object()) is NotImplemented
+for name in ("__lt__", "__le__", "__gt__", "__ge__"):
+    assert getattr(types.CodeType, name)(code, same) is NotImplemented
+
+assert repr(code).startswith("<code object sample at 0x")
+assert 'file "' in repr(code)
+assert code.__sizeof__() > 0
+
+code_args = (
+    code.co_argcount,
+    code.co_posonlyargcount,
+    code.co_kwonlyargcount,
+    code.co_nlocals,
+    code.co_stacksize,
+    code.co_flags,
+    code.co_code,
+    code.co_consts,
+    code.co_names,
+    code.co_varnames,
+    code.co_filename,
+    code.co_name,
+    code.co_qualname,
+    code.co_firstlineno,
+    code.co_linetable,
+    code.co_exceptiontable,
+    code.co_freevars,
+    code.co_cellvars,
+)
+rebuilt = types.CodeType(*code_args)
+assert rebuilt == code
+assert rebuilt.co_lnotab == code.co_lnotab
+assert list(rebuilt.co_lines()) == lines
+assert list(rebuilt.co_positions()) == positions
+rebuilt_function = types.FunctionType(rebuilt, globals())
+assert rebuilt_function(4, 5, c=6) == 15
+
+negative_line_args = list(code_args)
+negative_line_args[13] = -1
+negative_line = types.CodeType(*negative_line_args)
+assert negative_line.co_firstlineno == -1
+
+try:
+    code.replace(unknown=1)
+except TypeError as exc:
+    assert str(exc) == "replace() got an unexpected keyword argument 'unknown'"
+else:
+    raise AssertionError("code.replace accepted an unknown field")
+
+print("OK")

--- a/pyre/extra_tests/parity_tests/function_member_descriptors_python314.py
+++ b/pyre/extra_tests/parity_tests/function_member_descriptors_python314.py
@@ -1,0 +1,130 @@
+import builtins
+import types
+
+
+MEMBERS = {
+    "__closure__",
+    "__doc__",
+    "__globals__",
+    "__module__",
+    "__builtins__",
+}
+GETSETS = {
+    "__code__",
+    "__defaults__",
+    "__kwdefaults__",
+    "__annotations__",
+    "__annotate__",
+    "__dict__",
+    "__name__",
+    "__qualname__",
+    "__type_params__",
+}
+
+function_dict = types.FunctionType.__dict__
+for name in MEMBERS:
+    assert type(function_dict[name]) is types.MemberDescriptorType
+for name in GETSETS:
+    assert type(function_dict[name]) is types.GetSetDescriptorType
+
+assert set(types.MemberDescriptorType.__dict__) == {
+    "__delete__",
+    "__doc__",
+    "__get__",
+    "__name__",
+    "__objclass__",
+    "__qualname__",
+    "__reduce__",
+    "__repr__",
+    "__set__",
+}
+
+for name in MEMBERS:
+    descriptor = function_dict[name]
+    assert descriptor.__name__ == name
+    assert descriptor.__qualname__ == f"function.{name}"
+    assert descriptor.__objclass__ is types.FunctionType
+    assert descriptor.__doc__ is None
+    assert repr(descriptor) == f"<member '{name}' of 'function' objects>"
+    reduced = descriptor.__reduce__()
+    assert reduced == (getattr, (types.FunctionType, name))
+    assert reduced[0] is getattr
+
+
+def make_closure(value):
+    def inner():
+        "inner doc"
+        return value
+
+    return inner
+
+
+function = make_closure(42)
+assert function_dict["__closure__"].__get__(function, types.FunctionType) is function.__closure__
+assert function_dict["__doc__"].__get__(function, types.FunctionType) == "inner doc"
+assert function_dict["__globals__"].__get__(function, types.FunctionType) is globals()
+assert function_dict["__module__"].__get__(function, types.FunctionType) == __name__
+assert function_dict["__builtins__"].__get__(function, types.FunctionType) is builtins.__dict__
+assert function_dict["__globals__"].__get__(None, types.FunctionType) is function_dict["__globals__"]
+
+custom_globals = {"__builtins__": {"marker": 1}}
+custom = types.FunctionType((lambda: None).__code__, custom_globals)
+selected_builtins = custom.__builtins__
+assert selected_builtins is custom_globals["__builtins__"]
+custom_globals["__builtins__"] = {"marker": 2}
+assert custom.__builtins__ is selected_builtins
+del custom_globals["__builtins__"]
+assert custom.__builtins__ is selected_builtins
+
+function_dict["__doc__"].__set__(function, "changed")
+assert function.__doc__ == "changed"
+function_dict["__doc__"].__delete__(function)
+assert function.__doc__ is None
+
+function_dict["__module__"].__set__(function, "changed_module")
+assert function.__module__ == "changed_module"
+function_dict["__module__"].__delete__(function)
+assert function.__module__ is None
+
+for name in ("__closure__", "__globals__", "__builtins__"):
+    descriptor = function_dict[name]
+    try:
+        descriptor.__set__(function, None)
+    except AttributeError as exc:
+        assert str(exc) == "readonly attribute"
+    else:
+        raise AssertionError(f"{name} accepted assignment")
+    try:
+        descriptor.__delete__(function)
+    except AttributeError as exc:
+        assert str(exc) == "readonly attribute"
+    else:
+        raise AssertionError(f"{name} accepted deletion")
+
+
+class Outer:
+    class Inner:
+        __slots__ = ("slot",)
+
+
+slot_descriptor = Outer.Inner.slot
+assert type(slot_descriptor) is types.MemberDescriptorType
+assert slot_descriptor.__name__ == "slot"
+assert slot_descriptor.__qualname__ == "Outer.Inner.slot"
+assert slot_descriptor.__objclass__ is Outer.Inner
+assert slot_descriptor.__doc__ is None
+assert repr(slot_descriptor) == "<member 'slot' of 'Inner' objects>"
+assert slot_descriptor.__reduce__() == (getattr, (Outer.Inner, "slot"))
+
+instance = Outer.Inner()
+slot_descriptor.__set__(instance, 7)
+assert slot_descriptor.__get__(instance, Outer.Inner) == 7
+slot_descriptor.__delete__(instance)
+try:
+    slot_descriptor.__get__(instance, Outer.Inner)
+except AttributeError:
+    pass
+else:
+    raise AssertionError("deleted slot remained readable")
+
+print("OK")

--- a/pyre/extra_tests/parity_tests/function_python314.py
+++ b/pyre/extra_tests/parity_tests/function_python314.py
@@ -1,0 +1,115 @@
+import types
+
+
+EXPECTED = {
+    "__annotate__",
+    "__annotations__",
+    "__builtins__",
+    "__call__",
+    "__closure__",
+    "__code__",
+    "__defaults__",
+    "__dict__",
+    "__doc__",
+    "__get__",
+    "__globals__",
+    "__kwdefaults__",
+    "__module__",
+    "__name__",
+    "__new__",
+    "__qualname__",
+    "__repr__",
+    "__type_params__",
+}
+
+
+assert set(types.FunctionType.__dict__) == EXPECTED
+
+
+def f(value=1):
+    return value
+
+
+assert types.FunctionType.__call__(f, 7) == 7
+
+
+def keyword_only(*, value):
+    return value
+
+
+assert types.FunctionType.__call__(keyword_only, value=8) == 8
+assert types.FunctionType.__repr__(f).startswith("<function f at 0x")
+assert types.FunctionType.__repr__(f).endswith(">")
+
+first_dict = f.__dict__
+assert first_dict == {}
+assert f.__dict__ is first_dict
+f.marker = 42
+assert f.__dict__ == {"marker": 42}
+replacement = {"other": 3}
+f.__dict__ = replacement
+assert f.__dict__ is replacement
+
+try:
+    f.__dict__ = []
+except TypeError:
+    pass
+else:
+    raise AssertionError("function.__dict__ accepted a non-dict")
+
+assert f.__annotate__ is None
+
+
+def annotate(format):
+    assert format == 1
+    return {"value": int}
+
+
+f.__annotate__ = annotate
+assert f.__annotate__ is annotate
+assert f.__annotations__ == {"value": int}
+f.__annotations__ = {"result": str}
+assert f.__annotate__ is None
+assert f.__annotations__ == {"result": str}
+
+try:
+    f.__annotate__ = 1
+except TypeError as exc:
+    assert str(exc) == "__annotate__ must be callable or None"
+else:
+    raise AssertionError("function.__annotate__ accepted a non-callable")
+
+try:
+    del f.__annotate__
+except TypeError as exc:
+    assert str(exc) == "__annotate__ cannot be deleted"
+else:
+    raise AssertionError("function.__annotate__ was deletable")
+
+assert f.__type_params__ == ()
+params = (int, str)
+f.__type_params__ = params
+assert f.__type_params__ is params
+
+try:
+    f.__type_params__ = []
+except TypeError as exc:
+    assert str(exc) == "__type_params__ must be set to a tuple"
+else:
+    raise AssertionError("function.__type_params__ accepted a non-tuple")
+
+try:
+    del f.__type_params__
+except TypeError as exc:
+    assert str(exc) == "__type_params__ must be set to a tuple"
+else:
+    raise AssertionError("function.__type_params__ was deletable")
+
+
+def identity[T](value: T) -> T:
+    return value
+
+
+assert len(identity.__type_params__) == 1
+assert identity.__type_params__[0].__name__ == "T"
+assert identity(5) == 5

--- a/pyre/extra_tests/parity_tests/getset_descriptor_python314.py
+++ b/pyre/extra_tests/parity_tests/getset_descriptor_python314.py
@@ -1,0 +1,86 @@
+import types
+
+
+expected = {
+    "__delete__",
+    "__doc__",
+    "__get__",
+    "__name__",
+    "__objclass__",
+    "__qualname__",
+    "__repr__",
+    "__set__",
+}
+assert set(types.GetSetDescriptorType.__dict__) == expected
+
+code_descriptor = types.FunctionType.__code__
+assert type(code_descriptor) is types.GetSetDescriptorType
+assert code_descriptor.__name__ == "__code__"
+assert code_descriptor.__qualname__ == "function.__code__"
+assert code_descriptor.__objclass__ is types.FunctionType
+assert code_descriptor.__doc__ is None
+assert repr(code_descriptor) == "<attribute '__code__' of 'function' objects>"
+assert types.GetSetDescriptorType.__repr__(code_descriptor) == repr(code_descriptor)
+
+try:
+    types.GetSetDescriptorType.__repr__(1)
+except TypeError as exc:
+    assert str(exc) == (
+        "descriptor '__repr__' requires a 'getset_descriptor' object "
+        "but received a 'int'"
+    )
+else:
+    raise AssertionError("getset_descriptor.__repr__ accepted an int")
+
+
+def first():
+    return 1
+
+
+def second():
+    return 2
+
+
+assert code_descriptor.__get__(first, types.FunctionType) is first.__code__
+first.__code__ = second.__code__
+assert first() == 2
+
+
+class Outer:
+    class Inner:
+        pass
+
+
+dict_descriptor = Outer.Inner.__dict__["__dict__"]
+assert type(dict_descriptor) is types.GetSetDescriptorType
+assert dict_descriptor.__name__ == "__dict__"
+assert dict_descriptor.__qualname__ == "Outer.Inner.__dict__"
+assert dict_descriptor.__objclass__ is Outer.Inner
+assert dict_descriptor.__doc__ == "dictionary for instance variables"
+assert repr(dict_descriptor) == "<attribute '__dict__' of 'Inner' objects>"
+
+weakref_descriptor = Outer.Inner.__dict__["__weakref__"]
+assert type(weakref_descriptor) is types.GetSetDescriptorType
+assert weakref_descriptor.__name__ == "__weakref__"
+assert weakref_descriptor.__qualname__ == "Outer.Inner.__weakref__"
+assert weakref_descriptor.__objclass__ is Outer.Inner
+assert weakref_descriptor.__doc__ == "list of weak references to the object"
+assert repr(weakref_descriptor) == "<attribute '__weakref__' of 'Inner' objects>"
+
+metadata_descriptor = types.GetSetDescriptorType.__dict__["__doc__"]
+assert type(metadata_descriptor) is types.GetSetDescriptorType
+assert metadata_descriptor.__qualname__ == "getset_descriptor.__doc__"
+assert metadata_descriptor.__objclass__ is types.GetSetDescriptorType
+assert repr(metadata_descriptor) == (
+    "<attribute '__doc__' of 'getset_descriptor' objects>"
+)
+
+mapping_descriptor = type({}.keys()).mapping
+assert type(mapping_descriptor) is types.GetSetDescriptorType
+assert mapping_descriptor.__name__ == "mapping"
+assert mapping_descriptor.__qualname__ == "dict_keys.mapping"
+assert mapping_descriptor.__objclass__ is type({}.keys())
+assert mapping_descriptor.__doc__ == "dictionary that this view refers to"
+assert repr(mapping_descriptor) == "<attribute 'mapping' of 'dict_keys' objects>"
+
+print("OK")

--- a/pyre/extra_tests/parity_tests/mappingproxy_python314.py
+++ b/pyre/extra_tests/parity_tests/mappingproxy_python314.py
@@ -1,0 +1,66 @@
+import types
+
+
+EXPECTED = {
+    "__class_getitem__",
+    "__contains__",
+    "__doc__",
+    "__eq__",
+    "__ge__",
+    "__getitem__",
+    "__gt__",
+    "__hash__",
+    "__ior__",
+    "__iter__",
+    "__le__",
+    "__len__",
+    "__lt__",
+    "__ne__",
+    "__new__",
+    "__or__",
+    "__repr__",
+    "__reversed__",
+    "__ror__",
+    "__str__",
+    "copy",
+    "get",
+    "items",
+    "keys",
+    "values",
+}
+
+assert set(types.MappingProxyType.__dict__) == EXPECTED
+assert types.MappingProxyType.__doc__ == "Read-only proxy of a mapping."
+
+proxy = types.MappingProxyType({"x": 1})
+try:
+    hash(proxy)
+except TypeError as exc:
+    assert str(exc) == "unhashable type: 'dict'"
+else:
+    raise AssertionError("mappingproxy(dict) was hashable")
+
+
+class HashableMapping:
+    def __getitem__(self, key):
+        return key
+
+    def __hash__(self):
+        return 42
+
+
+hashable_proxy = types.MappingProxyType(HashableMapping())
+assert hash(hashable_proxy) == 42
+assert types.MappingProxyType.__hash__(hashable_proxy) == 42
+
+try:
+    types.MappingProxyType.__hash__({})
+except TypeError as exc:
+    assert str(exc) == (
+        "descriptor '__hash__' requires a 'mappingproxy' object "
+        "but received a 'dict'"
+    )
+else:
+    raise AssertionError("mappingproxy.__hash__ accepted dict")
+
+print("OK")

--- a/pyre/extra_tests/parity_tests/method_python314.py
+++ b/pyre/extra_tests/parity_tests/method_python314.py
@@ -1,0 +1,120 @@
+import types
+
+
+EXPECTED = {
+    "__call__",
+    "__doc__",
+    "__eq__",
+    "__func__",
+    "__ge__",
+    "__get__",
+    "__getattribute__",
+    "__gt__",
+    "__hash__",
+    "__le__",
+    "__lt__",
+    "__ne__",
+    "__new__",
+    "__reduce__",
+    "__repr__",
+    "__self__",
+}
+
+assert set(types.MethodType.__dict__) == EXPECTED
+assert types.MethodType.__doc__ == "Create a bound instance method object."
+assert types.FunctionType.__doc__.startswith("Create a function object.\n\n  code\n")
+
+
+class C:
+    def method(self, value=1, *, scale=1):
+        "method documentation"
+        return self.base + value * scale
+
+
+c = C()
+c.base = 10
+function = C.__dict__["method"]
+
+# Python 3.14 function descriptor behavior, including omitted owner.
+try:
+    function.__get__(None)
+except TypeError as exc:
+    assert str(exc) == "__get__(None, None) is invalid"
+else:
+    raise AssertionError("function.__get__(None) did not fail")
+
+assert function.__get__(None, C) is function
+bound = function.__get__(c)
+assert isinstance(bound, types.MethodType)
+assert bound.__func__ is function
+assert bound.__self__ is c
+assert bound(2, scale=3) == 16
+assert types.MethodType.__call__(bound, 4, scale=2) == 18
+
+# An already-bound method stays bound under descriptor access.
+try:
+    bound.__get__(None)
+except TypeError as exc:
+    assert str(exc) == "__get__(None, None) is invalid"
+else:
+    raise AssertionError("method.__get__(None) did not fail")
+
+assert bound.__get__(None, C) is bound
+assert bound.__get__(object()) is bound
+
+# Method attributes are forwarded to the wrapped function after the
+# method type's own namespace has been checked.
+assert bound.__doc__ == "method documentation"
+assert bound.__name__ == "method"
+assert bound.__qualname__ == "C.method"
+assert bound.__annotations__ == function.__annotations__
+assert types.MethodType.__getattribute__(bound, "__name__") == "method"
+
+constructed = types.MethodType(function, c)
+assert constructed.__func__ is function
+assert constructed.__self__ is c
+assert constructed() == 11
+
+for args in ((), (function,), (function, c, C)):
+    try:
+        types.MethodType(*args)
+    except TypeError as exc:
+        assert str(exc) == f"method expected 2 arguments, got {len(args)}"
+    else:
+        raise AssertionError(f"MethodType accepted {len(args)} arguments")
+
+try:
+    types.MethodType(1, c)
+except TypeError as exc:
+    assert str(exc) == "first argument must be callable"
+else:
+    raise AssertionError("MethodType accepted a non-callable")
+
+try:
+    types.MethodType(function, None)
+except TypeError as exc:
+    assert str(exc) == "instance must not be None"
+else:
+    raise AssertionError("MethodType accepted None as the instance")
+
+same = types.MethodType(function, c)
+other = C()
+other.base = 10
+different_self = types.MethodType(function, other)
+assert bound == same
+assert bound != different_self
+assert types.MethodType.__eq__(bound, object()) is NotImplemented
+assert types.MethodType.__ne__(bound, object()) is NotImplemented
+for name in ("__lt__", "__le__", "__gt__", "__ge__"):
+    assert getattr(types.MethodType, name)(bound, same) is NotImplemented
+
+assert hash(bound) == hash(same)
+assert repr(bound).startswith("<bound method C.method of <")
+assert repr(bound).endswith(">>")
+
+reconstructor, reduce_args = bound.__reduce__()
+assert reconstructor is getattr
+assert reduce_args == (c, "method")
+assert reconstructor(*reduce_args).__func__ is function
+
+print("OK")

--- a/pyre/extra_tests/parity_tests/module_type_python314.py
+++ b/pyre/extra_tests/parity_tests/module_type_python314.py
@@ -1,0 +1,156 @@
+import types
+
+
+expected = {
+    "__annotate__",
+    "__annotations__",
+    "__dict__",
+    "__dir__",
+    "__doc__",
+    "__getattribute__",
+    "__init__",
+    "__new__",
+    "__repr__",
+}
+assert set(types.ModuleType.__dict__) == expected
+assert types.ModuleType.__doc__ == (
+    "Create a module object.\n\n"
+    "The name must be a string; the optional doc argument can have any type."
+)
+
+module = types.ModuleType("sample", "documentation")
+assert module.__dict__ == {
+    "__name__": "sample",
+    "__doc__": "documentation",
+    "__package__": None,
+    "__loader__": None,
+    "__spec__": None,
+}
+assert repr(module) == "<module 'sample'>"
+module.__file__ = "/tmp/sample.py"
+assert repr(module) == "<module 'sample' from '/tmp/sample.py'>"
+del module.__name__
+assert repr(module) == "<module '?' from '/tmp/sample.py'>"
+
+module = types.ModuleType(name="sample", doc="documentation")
+assert module.__name__ == "sample"
+assert module.__doc__ == "documentation"
+assert types.ModuleType.__getattribute__(module, "__name__") == "sample"
+
+for args, kwargs, message in [
+    ((), {}, "module() missing required argument 'name' (pos 1)"),
+    (("x", "d", 1), {}, "module() takes at most 2 arguments (3 given)"),
+    ((1,), {}, "module() argument 'name' must be str, not int"),
+    (("x",), {"name": "y"}, "argument for module() given by name ('name') and position (1)"),
+    (("x",), {"bad": 1}, "module() got an unexpected keyword argument 'bad'"),
+]:
+    try:
+        types.ModuleType(*args, **kwargs)
+    except TypeError as exc:
+        assert str(exc) == message
+    else:
+        raise AssertionError((args, kwargs))
+
+dict_descriptor = types.ModuleType.__dict__["__dict__"]
+assert type(dict_descriptor) is types.MemberDescriptorType
+assert dict_descriptor.__name__ == "__dict__"
+assert dict_descriptor.__qualname__ == "module.__dict__"
+assert dict_descriptor.__objclass__ is types.ModuleType
+assert repr(dict_descriptor) == "<member '__dict__' of 'module' objects>"
+try:
+    module.__dict__ = {}
+except AttributeError as exc:
+    assert str(exc) == "readonly attribute"
+else:
+    raise AssertionError("module.__dict__ accepted assignment")
+
+for name in ("__annotations__", "__annotate__"):
+    descriptor = types.ModuleType.__dict__[name]
+    for operation in ("get", "set", "delete"):
+        try:
+            if operation == "get":
+                descriptor.__get__(1, int)
+            elif operation == "set":
+                descriptor.__set__(1, None)
+            else:
+                descriptor.__delete__(1)
+        except TypeError as exc:
+            assert str(exc) == (
+                f"descriptor '{name}' for 'module' objects "
+                "doesn't apply to a 'int' object"
+            )
+        else:
+            raise AssertionError((name, operation))
+
+module = types.ModuleType("sample")
+module.z = 1
+module.a = 2
+assert module.__dir__()[-2:] == ["z", "a"]
+module.__dir__ = lambda: ("z", "a")
+assert types.ModuleType.__dir__(module) == ("z", "a")
+assert dir(module) == ["a", "z"]
+
+module = types.ModuleType("sample")
+assert "__annotations__" not in module.__dict__
+annotations = module.__annotations__
+assert annotations == {}
+assert module.__annotations__ is annotations
+assert module.__dict__["__annotations__"] is annotations
+
+module.__annotations__ = 1
+assert module.__annotations__ == 1
+del module.__annotations__
+assert "__annotations__" not in module.__dict__
+try:
+    del module.__annotations__
+except AttributeError as exc:
+    assert str(exc) == "__annotations__"
+else:
+    raise AssertionError("missing module.__annotations__ deletion succeeded")
+
+module = types.ModuleType("sample")
+assert module.__annotate__ is None
+assert module.__dict__["__annotate__"] is None
+try:
+    module.__annotate__ = 1
+except TypeError as exc:
+    assert str(exc) == "__annotate__ must be callable or None"
+else:
+    raise AssertionError("module.__annotate__ accepted a non-callable")
+
+calls = []
+
+
+def annotate(format):
+    calls.append(format)
+    return {"answer": format}
+
+
+module.__annotations__ = {"old": True}
+module.__annotate__ = annotate
+assert "__annotations__" not in module.__dict__
+assert module.__annotations__ == {"answer": 1}
+assert calls == [1]
+assert module.__annotations__ == {"answer": 1}
+assert calls == [1]
+
+module.__annotations__ = {"eager": True}
+assert "__annotate__" not in module.__dict__
+assert module.__annotations__ == {"eager": True}
+try:
+    del module.__annotate__
+except TypeError as exc:
+    assert str(exc) == "cannot delete __annotate__ attribute"
+else:
+    raise AssertionError("module.__annotate__ deletion succeeded")
+
+module = types.ModuleType("sample")
+module.__annotate__ = lambda format: 1
+try:
+    module.__annotations__
+except TypeError as exc:
+    assert str(exc) == "__annotate__ returned non-dict of type 'int'"
+else:
+    raise AssertionError("non-dict annotations result was accepted")
+
+print("OK")

--- a/pyre/extra_tests/parity_tests/property_protocol.py
+++ b/pyre/extra_tests/parity_tests/property_protocol.py
@@ -1,0 +1,193 @@
+"""PyPy structural parity and Python 3.14 semantics for ``property``.
+
+PyPy ``module/__builtin__/descriptor.py:W_Property`` supplies the native
+accessor/doc fields, split ``__new__``/``__init__``, descriptor operations and
+copying decorators.  Python 3.14 takes precedence for ``__name__`` fallback,
+``__set_name__``, rich missing-accessor messages, subclass doc placement and
+the exact public type-dictionary surface.
+"""
+
+
+EXPECTED_SURFACE = {
+    "__delete__",
+    "__doc__",
+    "__get__",
+    "__init__",
+    "__isabstractmethod__",
+    "__name__",
+    "__new__",
+    "__set__",
+    "__set_name__",
+    "deleter",
+    "fdel",
+    "fget",
+    "fset",
+    "getter",
+    "setter",
+}
+
+assert set(property.__dict__) == EXPECTED_SURFACE
+assert property.__doc__.startswith("Property attribute.\n")
+assert property.__doc__.endswith("        del self._x")
+
+
+def get_value(self):
+    "getter doc"
+    return self._value
+
+
+def set_value(self, value):
+    self._value = value
+
+
+def del_value(self):
+    del self._value
+
+
+class Managed:
+    value = property(get_value, set_value, del_value)
+
+
+obj = Managed()
+obj.value = 12
+assert obj.value == 12
+del obj.value
+assert not hasattr(obj, "_value")
+
+p = Managed.__dict__["value"]
+assert p.fget is get_value
+assert p.fset is set_value
+assert p.fdel is del_value
+assert p.__doc__ == "getter doc"
+assert p.__name__ == "value"
+assert p.__get__(None, Managed) is p
+
+# Python 3.14 property_name: an explicit name wins, deletion clears only that
+# slot and reveals the getter's __name__ fallback again.
+plain = property(get_value)
+assert plain.__name__ == "get_value"
+plain.__name__ = "explicit"
+assert plain.__name__ == "explicit"
+del plain.__name__
+assert plain.__name__ == "get_value"
+del plain.__name__
+assert plain.__name__ == "get_value"
+
+unnamed = property()
+assert not hasattr(unnamed, "__name__")
+del unnamed.__name__
+assert not hasattr(unnamed, "__name__")
+
+plain.__doc__ = "replacement"
+assert plain.__doc__ == "replacement"
+del plain.__doc__
+assert plain.__doc__ is None
+
+# Python 3.14 property_copy treats None as an omitted replacement and keeps
+# the old accessor.  A getter-derived doc is re-derived on each copy.
+for method in ("getter", "setter", "deleter"):
+    copy = getattr(property(get_value), method)(None)
+    assert copy.fget is get_value
+    assert copy.fset is None
+    assert copy.fdel is None
+    assert copy.__doc__ == "getter doc"
+
+named = property(get_value, doc="explicit doc")
+named.__set_name__(Managed, "renamed")
+for copy in (named.getter(get_value), named.setter(set_value), named.deleter(del_value)):
+    assert type(copy) is property
+    assert copy.__name__ == "renamed"
+    assert copy.__doc__ == "explicit doc"
+
+# __new__ only allocates.  __init__ performs all field setup and can safely be
+# called again, clearing the name and prior accessor/doc state first.
+raw = property.__new__(property, object(), ignored=True)
+assert raw.fget is None and raw.fset is None and raw.fdel is None
+property.__init__(raw, fget=get_value, fset=set_value, doc="raw doc")
+raw.__set_name__(Managed, "raw")
+assert raw.fget is get_value and raw.fset is set_value
+assert raw.__doc__ == "raw doc" and raw.__name__ == "raw"
+property.__init__(raw)
+assert raw.fget is None and raw.fset is None and raw.fdel is None
+assert raw.__doc__ is None and not hasattr(raw, "__name__")
+
+
+class PropertySubclass(property):
+    pass
+
+
+sub = PropertySubclass(get_value)
+assert type(sub) is PropertySubclass
+assert sub.__dict__ == {"__doc__": "getter doc"}
+assert sub.__doc__ == "getter doc"
+sub_copy = sub.setter(set_value)
+assert type(sub_copy) is PropertySubclass
+assert sub_copy.__dict__ == {"__doc__": "getter doc"}
+sub.extra = 17
+assert sub.extra == 17
+assert sub.__dict__["extra"] == 17
+
+property.__init__(sub)
+assert sub.__dict__ == {"__doc__": None, "extra": 17}
+assert sub.__doc__ is None
+
+try:
+    plain.fget = None
+except AttributeError:
+    pass
+else:
+    assert False, "property.fget must be read-only"
+
+
+class AbstractCallable:
+    __isabstractmethod__ = True
+
+    def __call__(self, *args):
+        return None
+
+
+abstract = AbstractCallable()
+assert property(abstract).__isabstractmethod__ is True
+assert property(None, abstract).__isabstractmethod__ is True
+assert property(None, None, abstract).__isabstractmethod__ is True
+assert property().__isabstractmethod__ is False
+
+
+class ReadOnly:
+    item = property()
+
+
+try:
+    ReadOnly().item
+except AttributeError as exc:
+    assert str(exc) == "property 'item' of 'ReadOnly' object has no getter"
+else:
+    assert False, "missing getter must raise"
+
+try:
+    ReadOnly().item = 1
+except AttributeError as exc:
+    assert str(exc) == "property 'item' of 'ReadOnly' object has no setter"
+else:
+    assert False, "missing setter must raise"
+
+try:
+    del ReadOnly().item
+except AttributeError as exc:
+    assert str(exc) == "property 'item' of 'ReadOnly' object has no deleter"
+else:
+    assert False, "missing deleter must raise"
+
+for action in (
+    lambda: property(1, 2, 3, 4, 5),
+    lambda: property(foo=1),
+    lambda: property(1, fget=2),
+):
+    try:
+        action()
+    except TypeError:
+        pass
+    else:
+        assert False, "invalid property constructor arguments must raise"
+
+print("OK")

--- a/pyre/extra_tests/parity_tests/range_python314.py
+++ b/pyre/extra_tests/parity_tests/range_python314.py
@@ -3,7 +3,7 @@
 import operator
 
 
-required = {
+expected_surface = {
     "__doc__",
     "__new__",
     "__repr__",
@@ -14,6 +14,11 @@ required = {
     "__reduce__",
     "__contains__",
     "__eq__",
+    "__ne__",
+    "__lt__",
+    "__le__",
+    "__gt__",
+    "__ge__",
     "__hash__",
     "__bool__",
     "count",
@@ -22,7 +27,7 @@ required = {
     "stop",
     "step",
 }
-assert required <= set(range.__dict__)
+assert set(range.__dict__) == expected_surface
 
 r = range(2, 13, 3)
 assert repr(r) == "range(2, 13, 3)"
@@ -39,8 +44,27 @@ assert r.index(8) == 2 and r.index(8.0) == 2
 assert range(0, 3, 2) == range(0, 4, 2)
 assert hash(range(0, 3, 2)) == hash(range(0, 4, 2))
 assert range.__eq__(r, object()) is NotImplemented
+assert range.__ne__(r, range(2, 13, 3)) is False
+assert range.__ne__(r, range(2, 15, 3)) is True
+assert range.__ne__(r, object()) is NotImplemented
+for name in ("__lt__", "__le__", "__gt__", "__ge__"):
+    assert getattr(range, name)(r, range(2, 15, 3)) is NotImplemented
+    assert getattr(range, name)(r, object()) is NotImplemented
 assert r.__reduce__() == (range, (2, 13, 3))
 assert not range(0)
+
+for compare in (
+    lambda: r < range(2, 15, 3),
+    lambda: r <= range(2, 15, 3),
+    lambda: r > range(2, 15, 3),
+    lambda: r >= range(2, 15, 3),
+):
+    try:
+        compare()
+    except TypeError:
+        pass
+    else:
+        raise AssertionError("range ordering must remain unsupported")
 
 try:
     r.start = 9

--- a/pyre/extra_tests/parity_tests/staticmethod_protocol.py
+++ b/pyre/extra_tests/parity_tests/staticmethod_protocol.py
@@ -1,0 +1,155 @@
+"""Python 3.14 / PyPy structural parity for ``staticmethod``.
+
+PyPy ``interpreter/function.py:671-716 StaticMethod`` supplies the wrapped
+callable, lazy instance dictionary, descriptor, call and repr operations.
+``interpreter/typedef.py:852-877`` exposes them in the type dictionary.
+Python 3.14 additionally proxies PEP 649's ``__annotations__`` and
+``__annotate__`` attributes and exposes ``__class_getitem__``; it omits
+PyPy 3.11's ``__reduce_ex__`` entry.
+"""
+
+
+EXPECTED_SURFACE = {
+    "__annotate__",
+    "__annotations__",
+    "__call__",
+    "__class_getitem__",
+    "__dict__",
+    "__doc__",
+    "__func__",
+    "__get__",
+    "__init__",
+    "__isabstractmethod__",
+    "__new__",
+    "__repr__",
+    "__wrapped__",
+}
+
+assert set(staticmethod.__dict__) == EXPECTED_SURFACE
+assert staticmethod.__doc__.startswith("Convert a function to be a static method.\n")
+assert staticmethod.__doc__.endswith("see the classmethod builtin.")
+
+
+def wrapped(a: int, *, b: int = 2) -> str:
+    "wrapped doc"
+    return str(a + b)
+
+
+sm = staticmethod(wrapped)
+assert sm.__func__ is wrapped
+assert sm.__wrapped__ is wrapped
+assert sm.__dict__ == {
+    "__module__": __name__,
+    "__name__": "wrapped",
+    "__qualname__": "wrapped",
+    "__doc__": "wrapped doc",
+}
+assert repr(sm).startswith("<staticmethod(<function wrapped")
+assert repr(sm).endswith(")>")
+assert sm(3, b=4) == "7"
+assert sm.__call__(3, b=4) == "7"
+assert sm.__get__(None, object) is wrapped
+assert sm.__get__(object(), object) is wrapped
+
+# PyPy StaticMethod.getdict/setdict: arbitrary attributes and wholesale dict
+# replacement use the object's w_dict field, including dict subclasses.
+sm.extra = 9
+assert sm.extra == 9
+assert sm.__dict__["extra"] == 9
+
+
+class DictSubclass(dict):
+    pass
+
+
+replacement = DictSubclass(marker=11)
+sm.__dict__ = replacement
+assert sm.__dict__ is replacement
+assert sm.marker == 11
+sm.more = 12
+assert replacement["more"] == 12
+
+try:
+    sm.__dict__ = 1
+except TypeError as exc:
+    assert str(exc) == "__dict__ must be set to a dictionary, not a 'int'"
+else:
+    assert False, "staticmethod.__dict__ must reject non-dicts"
+
+try:
+    del sm.__dict__
+except TypeError as exc:
+    assert str(exc) == "cannot delete __dict__"
+else:
+    assert False, "staticmethod.__dict__ cannot be deleted"
+
+# CPython 3.14 descriptor_get_wrapped_attribute: first read obtains the
+# wrapped function's value and caches it locally. Setting/deleting affects the
+# wrapper dictionary, never the wrapped function.
+sm = staticmethod(wrapped)
+assert "__annotations__" not in sm.__dict__
+assert "__annotate__" not in sm.__dict__
+assert sm.__annotations__ is wrapped.__annotations__
+assert sm.__annotate__ is wrapped.__annotate__
+assert sm.__dict__["__annotations__"] is wrapped.__annotations__
+assert sm.__dict__["__annotate__"] is wrapped.__annotate__
+
+wrapped_annotations = wrapped.__annotations__
+wrapped_annotate = wrapped.__annotate__
+sm.__annotations__ = 42
+sm.__annotate__ = 43
+assert sm.__annotations__ == 42
+assert sm.__annotate__ == 43
+assert wrapped.__annotations__ is wrapped_annotations
+assert wrapped.__annotate__ is wrapped_annotate
+del sm.__annotations__
+del sm.__annotate__
+assert sm.__annotations__ is wrapped_annotations
+assert sm.__annotate__ is wrapped_annotate
+
+fresh = staticmethod(wrapped)
+for name in ("__annotations__", "__annotate__"):
+    try:
+        delattr(fresh, name)
+    except AttributeError as exc:
+        assert str(exc) == f"'staticmethod' object has no attribute '{name}'"
+    else:
+        assert False, f"deleting uncached {name} must fail"
+
+try:
+    staticmethod()
+except TypeError as exc:
+    assert str(exc) == "staticmethod expected 1 argument, got 0"
+else:
+    assert False, "staticmethod requires one argument"
+
+try:
+    staticmethod(wrapped, wrapped)
+except TypeError as exc:
+    assert str(exc) == "staticmethod expected 1 argument, got 2"
+else:
+    assert False, "staticmethod accepts exactly one argument"
+
+try:
+    staticmethod(function=wrapped)
+except TypeError as exc:
+    assert str(exc) == "staticmethod() takes no keyword arguments"
+else:
+    assert False, "staticmethod's argument is positional-only"
+
+
+class StaticMethodSubclass(staticmethod):
+    pass
+
+
+sub = StaticMethodSubclass(wrapped)
+assert type(sub) is StaticMethodSubclass
+assert sub(5, b=6) == "11"
+assert sub.__func__ is wrapped
+
+alias = staticmethod[int]
+assert type(alias).__name__ == "GenericAlias"
+assert alias.__origin__ is staticmethod
+assert alias.__args__ == (int,)
+
+print("OK")

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -7277,9 +7277,7 @@ pub(crate) unsafe fn get(
         // than mapdict's numbered `__slots__` storage.  Their tagged index is
         // only a member-kind discriminator; never pass it to getslotvalue.
         if pyre_object::w_member_is_direct(descr) {
-            return Ok(Some(crate::typedef::function_direct_member_get(
-                descr, obj,
-            )?));
+            return Ok(Some(crate::typedef::direct_member_get(descr, obj)?));
         }
         // typedef.py:511: w_result = w_obj.getslotvalue(self.index)
         let index = pyre_object::w_member_get_index(descr);
@@ -7365,7 +7363,7 @@ unsafe fn set(
             )));
         }
         if pyre_object::w_member_is_direct(descr) {
-            crate::typedef::function_direct_member_set(descr, obj, value)?;
+            crate::typedef::direct_member_set(descr, obj, value)?;
             return Ok(true);
         }
         // typedef.py:522: w_obj.setslotvalue(self.index, w_value)
@@ -7438,7 +7436,7 @@ unsafe fn delete(descr: PyObjectRef, obj: PyObjectRef) -> Result<(), crate::PyEr
             )));
         }
         if pyre_object::w_member_is_direct(descr) {
-            crate::typedef::function_direct_member_delete(descr, obj)?;
+            crate::typedef::direct_member_delete(descr, obj)?;
             return Ok(());
         }
         // typedef.py:527-531: success = w_obj.delslotvalue(self.index)

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -3288,6 +3288,11 @@ pub(crate) fn len_slot(obj: PyObjectRef) -> PyResult {
 /// it to call `_obj_getdict`. pyre dispatches at runtime via the type's
 /// hasdict flag because Rust has no per-class virtual table.
 pub fn getdict(obj: PyObjectRef) -> PyObjectRef {
+    // function.py:678-681 StaticMethod.getdict — the dictionary is a
+    // real field on the descriptor object, not mapdict side storage.
+    if unsafe { pyre_object::function::is_staticmethod(obj) } {
+        return unsafe { pyre_object::function::w_staticmethod_getdict(obj) };
+    }
     // exceptions/interp_exceptions.py:222-225 W_BaseException.getdict
     // override — lazily allocates the instance dict on the typed slot.
     if unsafe { pyre_object::is_exception(obj) } {
@@ -3351,6 +3356,18 @@ pub(crate) fn native_slot_del(obj: PyObjectRef, name: &str) -> bool {
 /// objspace/std/mapdict.py:820-821 MapdictDictSupport.setdict overrides
 /// it to call `_obj_setdict`.
 pub fn setdict(obj: PyObjectRef, w_dict: PyObjectRef) -> Result<(), PyError> {
+    // function.py:683-688 StaticMethod.setdict.
+    if unsafe { pyre_object::function::is_staticmethod(obj) } {
+        let w_dict_type = crate::typedef::gettypeobject(&pyre_object::pyobject::DICT_TYPE);
+        if !unsafe { isinstance_w(w_dict, w_dict_type) } {
+            return Err(PyError::type_error(format!(
+                "__dict__ must be set to a dictionary, not a '{}'",
+                object_functionstr_type_name(w_dict),
+            )));
+        }
+        unsafe { pyre_object::function::w_staticmethod_setdict(obj, w_dict) };
+        return Ok(());
+    }
     // exceptions/interp_exceptions.py:227-231 W_BaseException.setdict
     // override — validates the value is a dict, then writes the slot.
     // `space.isinstance_w(w_dict, space.w_dict)` accepts dict subclasses.

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -4857,6 +4857,22 @@ fn object_getattr_miss(obj: PyObjectRef, name: &str, call_getattr: bool) -> PyRe
                 return Ok(w_str_new(crate::typedef::PROPERTY_DOC));
             }
             if name == "__doc__"
+                && std::ptr::eq(
+                    obj,
+                    crate::typedef::gettypeobject(&crate::function::FUNCTION_TYPE),
+                )
+            {
+                return Ok(w_str_new(crate::typedef::FUNCTION_DOC));
+            }
+            if name == "__doc__"
+                && std::ptr::eq(
+                    obj,
+                    crate::typedef::gettypeobject(&pyre_object::function::METHOD_TYPE),
+                )
+            {
+                return Ok(w_str_new(crate::typedef::METHOD_DOC));
+            }
+            if name == "__doc__"
                 || name == "__code__"
                 || name == "__func__"
                 || name == "__self__"

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -153,28 +153,6 @@ impl ObjSpace {
     }
 }
 
-// ── Cell unwrap ──────────────────────────────────────────────────────
-// CPython 3.13 unified locals+cells means LoadFast can return cell
-// objects. All operations must transparently unwrap cells.
-// PyPy: each opcode implementation calls space.unwrap_cell() implicitly.
-
-/// Unwrap a cell object to its contents. Non-cells pass through.
-#[inline(always)]
-pub fn unwrap_cell(obj: PyObjectRef) -> PyObjectRef {
-    if obj.is_null() {
-        return obj;
-    }
-    if unsafe { is_cell(obj) } {
-        let inner = unsafe { w_cell_get(obj) };
-        if !inner.is_null() {
-            return inner;
-        }
-        // Cell with null content — return cell itself (caller will handle)
-        return obj;
-    }
-    obj
-}
-
 /// pypy/interpreter/baseobjspace.py `issubtype_w` — `cls` is in
 /// `w_type.mro_w`. Uses the cached MRO when present, otherwise
 /// recomputes via `compute_default_mro`.
@@ -570,8 +548,6 @@ unsafe fn p_recursive_issubclass_w(
 /// looked up via `space.lookup(w_klass_or_tuple, "__instancecheck__")`,
 /// then the abstract `__class__`/`__bases__` walk.
 pub fn isinstance(obj: PyObjectRef, classinfo: PyObjectRef) -> Result<bool, PyError> {
-    let obj = unwrap_cell(obj);
-    let classinfo = unwrap_cell(classinfo);
     unsafe {
         // abstractinst.py:104-106 — quick exact-type test.
         if let Some(t) = crate::typedef::r#type(obj) {
@@ -637,8 +613,6 @@ pub fn isinstance(obj: PyObjectRef, classinfo: PyObjectRef) -> Result<bool, PyEr
 /// Tuple/union recursion, `__subclasscheck__` override looked up on
 /// `type(classinfo)`, then the abstract `__bases__` walk.
 pub fn issubclass(derived: PyObjectRef, classinfo: PyObjectRef) -> Result<bool, PyError> {
-    let derived = unwrap_cell(derived);
-    let classinfo = unwrap_cell(classinfo);
     unsafe {
         // abstractinst.py:181-187 — tuple recursion.
         if is_tuple(classinfo) {
@@ -780,7 +754,6 @@ pub(crate) unsafe fn subclass_special_override(
 /// generic tail, which consults `__bool__` then `__len__`, where the call
 /// exceptions — and the non-bool-`__bool__` TypeError — propagate.
 pub fn is_true(obj: PyObjectRef) -> Result<bool, PyError> {
-    let obj = unwrap_cell(obj);
     // descroperation.py:265 — `__bool__` (anywhere in the MRO) is consulted
     // before `__len__`.  An exact builtin's `__bool__` / `__len__` are the
     // inherited builtin slots, so its truthiness is computed by layout in
@@ -828,7 +801,6 @@ fn is_true_lookup(obj: PyObjectRef) -> Result<bool, PyError> {
 /// `__bool__` base slots bind here so that the lookup path can invoke them
 /// (for non-overriding subclasses) without recursing through `is_true`.
 pub(crate) fn is_true_slot(obj: PyObjectRef) -> Result<bool, PyError> {
-    let obj = unwrap_cell(obj);
     unsafe {
         if is_bool(obj) {
             return Ok(w_bool_get_value(obj));
@@ -1153,8 +1125,6 @@ pub(crate) fn dict_missing_or_key_error(obj: PyObjectRef, index: PyObjectRef) ->
 /// Dispatches based on the type of `obj`.
 
 pub fn getitem(obj: PyObjectRef, index: PyObjectRef) -> PyResult {
-    let obj = unwrap_cell(obj);
-    let index = unwrap_cell(index);
     // `pypy/objspace/std/dictproxyobject.py:35 descr_getitem` →
     // `space.getitem(self.w_mapping, w_key)` — forward through the
     // proxy to its wrapped mapping.  The unwrap happens at the
@@ -1192,8 +1162,6 @@ pub fn getitem(obj: PyObjectRef, index: PyObjectRef) -> PyResult {
 /// to the inherited builtin subscript instead of re-entering override
 /// dispatch (which would recurse).
 pub(crate) fn getitem_slot(obj: PyObjectRef, index: PyObjectRef) -> PyResult {
-    let obj = unwrap_cell(obj);
-    let index = unwrap_cell(index);
     unsafe {
         if is_list(obj) {
             return getitem_list(obj, index);
@@ -2518,9 +2486,6 @@ pub fn finditem(obj: PyObjectRef, index: PyObjectRef) -> Result<Option<PyObjectR
 // result, so the void-ness lives at the opcode boundary, not in this
 // method's `PyResult` type.
 pub fn setitem(obj: PyObjectRef, index: PyObjectRef, value: PyObjectRef) -> PyResult {
-    let obj = unwrap_cell(obj);
-    let index = unwrap_cell(index);
-    let value = unwrap_cell(value);
     unsafe {
         // `pypy/objspace/std/dictproxyobject.py` exposes neither
         // `__setitem__` nor `__delitem__`, so `space.setitem` on a
@@ -2551,9 +2516,6 @@ pub fn setitem(obj: PyObjectRef, index: PyObjectRef, value: PyObjectRef) -> PyRe
 /// inherited builtin assignment instead of re-entering override dispatch
 /// (which would recurse).
 pub(crate) fn setitem_slot(obj: PyObjectRef, index: PyObjectRef, value: PyObjectRef) -> PyResult {
-    let obj = unwrap_cell(obj);
-    let index = unwrap_cell(index);
-    let value = unwrap_cell(value);
     unsafe {
         if is_list(obj) {
             return setitem_list(obj, index, value);
@@ -3531,9 +3493,9 @@ fn getattr_str_impl(obj: PyObjectRef, name: &str, call_getattr: bool) -> PyResul
     // cell type's descriptor namespace (e.g. `cell_contents` from
     // `nestedscope.py:Cell.typedef`).  Pyre previously prepended an
     // `unwrap_cell` here to keep `LOAD_FAST` on a cellvar slot
-    // transparent, but the only valid escape of a cell to user-visible
-    // code is through `function.__closure__` indexing — where the cell
-    // is what the user wants.
+    // transparent.  Cellvar loads must instead be dereferenced by the
+    // dedicated deref opcodes; a cell that reaches ordinary object-space
+    // operations is a user-visible object in its own right.
     //
     // pypy/module/_weakref/interp__weakref.py:356-394 — proxy_typedef_dict
     // wraps every space op in `force(space, w_obj)`. PyPy then dispatches
@@ -4393,7 +4355,6 @@ unsafe fn setattr_surrogate(
     name: &Wtf8,
     value: PyObjectRef,
 ) -> PyResult {
-    let value = unwrap_cell(value);
     let obj = crate::module::_weakref::interp__weakref::force(obj)?;
     unsafe {
         if is_instance(obj) {
@@ -4419,7 +4380,6 @@ pub(crate) unsafe fn object_setattr_surrogate(
     name: &Wtf8,
     value: PyObjectRef,
 ) -> PyResult {
-    let value = unwrap_cell(value);
     let obj = crate::module::_weakref::interp__weakref::force(obj)?;
     unsafe {
         // descroperation.py:114-123 — a data descriptor's `__set__` takes
@@ -4583,7 +4543,6 @@ fn attr_error_wtf8(obj: PyObjectRef, name: &Wtf8) -> PyError {
 /// `object.__getattribute__` terminal — the default descriptor protocol
 /// without the user `__getattribute__` override check.
 pub fn object_getattribute(obj: PyObjectRef, name: &str) -> PyResult {
-    let obj = unwrap_cell(obj);
     unsafe {
         if is_instance(obj) {
             let w_type = w_instance_get_type(obj);
@@ -7535,7 +7494,6 @@ pub(crate) fn descr_set___class__(w_obj: PyObjectRef, w_newcls: PyObjectRef) -> 
 }
 
 pub fn setattr_str(obj: PyObjectRef, name: &str, value: PyObjectRef) -> PyResult {
-    let value = unwrap_cell(value);
     let obj = crate::module::_weakref::interp__weakref::force(obj)?;
     // `super` proxies only `__getattribute__` (descriptor.py W_Super); it has
     // no `__setattr__`, so `super().name = value` uses the object default and
@@ -7580,7 +7538,6 @@ pub fn setattr_str(obj: PyObjectRef, name: &str, value: PyObjectRef) -> PyResult
 /// through the descriptor / instance-dict path.  Called by
 /// `object.__setattr__` and as the default path in `setattr`.
 pub fn object_setattr(obj: PyObjectRef, name: &str, value: PyObjectRef) -> PyResult {
-    let value = unwrap_cell(value);
     let obj = crate::module::_weakref::interp__weakref::force(obj)?;
     // Data descriptor __set__ takes priority (PyPy: descroperation.py
     // descr__setattr__ step 1). PyPy walks `space.type(obj)` regardless of
@@ -9570,8 +9527,7 @@ pub fn ismapping_w(w_obj: PyObjectRef) -> bool {
     }
 }
 
-pub fn is_iterable(w_obj: PyObjectRef) -> bool {
-    let obj = unwrap_cell(w_obj);
+pub fn is_iterable(obj: PyObjectRef) -> bool {
     if obj.is_null() {
         return false;
     }
@@ -9602,7 +9558,7 @@ pub fn is_iterable(w_obj: PyObjectRef) -> bool {
         }
         // descroperation.py:320 — `space.lookup(w_obj, '__iter__')`.
         // MRO-only walk; no `__getattr__` / descriptor execution.
-        if lookup(w_obj, "__iter__").is_some() {
+        if lookup(obj, "__iter__").is_some() {
             return true;
         }
         // descroperation.py:322-323 — fallback to `__getitem__` only
@@ -9612,9 +9568,9 @@ pub fn is_iterable(w_obj: PyObjectRef) -> bool {
         // lives on `W_TypeObject` (typeobject.py:169) so user-defined
         // `dict`/`list`/`tuple` subclasses inherit the marker via
         // `inherit_flag_map_or_seq` at heap-type construction.
-        let w_type = crate::typedef::r#type(w_obj).unwrap_or(std::ptr::null_mut());
+        let w_type = crate::typedef::r#type(obj).unwrap_or(std::ptr::null_mut());
         let is_mapping = pyre_object::typeobject::w_type_get_flag_map_or_seq(w_type) == b'M';
-        if !is_mapping && lookup(w_obj, "__getitem__").is_some() {
+        if !is_mapping && lookup(obj, "__getitem__").is_some() {
             return true;
         }
     }
@@ -9687,7 +9643,6 @@ unsafe fn iter_check_is_iterator(w_iterator: PyObjectRef) -> PyResult {
 /// `iter(obj)` — PyPy: space.iter(w_obj)
 /// Calls __iter__ on the object if available.
 pub fn iter(obj: PyObjectRef) -> PyResult {
-    let obj = unwrap_cell(obj);
     if obj.is_null() {
         return Err(PyError::type_error("'NoneType' object is not iterable"));
     }
@@ -10014,7 +9969,6 @@ pub fn iter(obj: PyObjectRef) -> PyResult {
 
 /// `next(iterator)` — PyPy: space.next(w_iter)
 pub fn next(obj: PyObjectRef) -> PyResult {
-    let obj = unwrap_cell(obj);
     unsafe {
         // iterobject.py W_FastListIterObject.descr_next — read the list's
         // current length on every step so appends are observed and removals

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -5168,60 +5168,30 @@ fn object_getattr_miss(obj: PyObjectRef, name: &str, call_getattr: bool) -> PyRe
         // generic type-dict fallback below reaches them.  The hardcoded
         // arm previously here predated the descriptor registration.
         if crate::pycode::is_code(obj) {
-            let code_ptr = crate::pycode::w_code_get_ptr(obj) as *const crate::CodeObject;
-            if code_ptr.is_null() {
-                return Ok(w_none());
-            }
-            let code = &*code_ptr;
-            match name {
-                "co_varnames" => {
-                    let items = code
-                        .varnames
-                        .iter()
-                        .map(|item| w_str_new(item.as_ref()))
-                        .collect();
-                    return Ok(w_tuple_new(items));
-                }
-                // `pycode.py:335-336 fget_co_cellvars`:
-                //     return space.newtuple([space.newtext(name)
-                //                            for name in self.co_cellvars])
-                "co_cellvars" => {
-                    let items = code
-                        .cellvars
-                        .iter()
-                        .map(|item| w_str_new(item.as_ref()))
-                        .collect();
-                    return Ok(w_tuple_new(items));
-                }
-                // `pycode.py:338-339 fget_co_freevars`:
-                //     return space.newtuple([space.newtext(name)
-                //                            for name in self.co_freevars])
-                "co_freevars" => {
-                    let items = code
-                        .freevars
-                        .iter()
-                        .map(|item| w_str_new(item.as_ref()))
-                        .collect();
-                    return Ok(w_tuple_new(items));
-                }
-                "co_argcount" => return Ok(w_int_new(code.arg_count as i64)),
-                "co_kwonlyargcount" => return Ok(w_int_new(code.kwonlyarg_count as i64)),
-                "co_name" => return Ok(w_str_new(code.obj_name.as_ref())),
-                // `pycode.py` `co_qualname` (3.11+) — the dotted qualified
-                // name the compiler stamped (`<module>.Class.method`).
-                "co_qualname" => return Ok(w_str_new(code.qualname.as_ref())),
-                "co_filename" => return Ok(w_str_new(code.source_path.as_ref())),
-                "co_flags" => return Ok(w_int_new(code.flags.bits() as i64)),
-                // `pypy/interpreter/pycode.py:143` — `self.co_firstlineno = firstlineno`,
-                // `typedef.py:718` — `co_firstlineno = interp_attrproperty('co_firstlineno', cls=PyCode, wrapfn="newint")`.
-                // RustPython exposes the field as `Option<OneIndexed>`; map None to 1
-                // (matching CPython's default for module-level code).
-                "co_firstlineno" => {
-                    return Ok(w_int_new(
-                        code.first_line_number.map_or(1, |n| n.get() as i64),
-                    ));
-                }
-                _ => {}
+            if matches!(
+                name,
+                "_co_code_adaptive"
+                    | "co_argcount"
+                    | "co_posonlyargcount"
+                    | "co_kwonlyargcount"
+                    | "co_nlocals"
+                    | "co_stacksize"
+                    | "co_flags"
+                    | "co_code"
+                    | "co_consts"
+                    | "co_names"
+                    | "co_varnames"
+                    | "co_freevars"
+                    | "co_cellvars"
+                    | "co_filename"
+                    | "co_name"
+                    | "co_qualname"
+                    | "co_firstlineno"
+                    | "co_linetable"
+                    | "co_exceptiontable"
+                    | "co_lnotab"
+            ) {
+                return crate::pycode::code_get_field(obj, name);
             }
         }
     }

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -3288,6 +3288,12 @@ pub(crate) fn len_slot(obj: PyObjectRef) -> PyResult {
 /// it to call `_obj_getdict`. pyre dispatches at runtime via the type's
 /// hasdict flag because Rust has no per-class virtual table.
 pub fn getdict(obj: PyObjectRef) -> PyObjectRef {
+    // function.py:231-234 Function.getdict — typed `w_func_dict` field.
+    if unsafe { crate::is_function(obj) }
+        && unsafe { std::ptr::eq((*obj).ob_type, &crate::function::FUNCTION_TYPE) }
+    {
+        return unsafe { crate::function::function_getdict(obj) };
+    }
     // function.py:678-681 StaticMethod.getdict — the dictionary is a
     // real field on the descriptor object, not mapdict side storage.
     if unsafe { pyre_object::function::is_staticmethod(obj) } {
@@ -3360,6 +3366,12 @@ pub(crate) fn native_slot_del(obj: PyObjectRef, name: &str) -> bool {
 /// objspace/std/mapdict.py:820-821 MapdictDictSupport.setdict overrides
 /// it to call `_obj_setdict`.
 pub fn setdict(obj: PyObjectRef, w_dict: PyObjectRef) -> Result<(), PyError> {
+    // function.py:236-241 Function.setdict — replace the typed field.
+    if unsafe { crate::is_function(obj) }
+        && unsafe { std::ptr::eq((*obj).ob_type, &crate::function::FUNCTION_TYPE) }
+    {
+        return unsafe { crate::function::function_setdict(obj, w_dict) };
+    }
     // function.py:683-688 StaticMethod.setdict.
     if unsafe { pyre_object::function::is_staticmethod(obj) } {
         let w_dict_type = crate::typedef::gettypeobject(&pyre_object::pyobject::DICT_TYPE);

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -3293,6 +3293,10 @@ pub fn getdict(obj: PyObjectRef) -> PyObjectRef {
     if unsafe { pyre_object::function::is_staticmethod(obj) } {
         return unsafe { pyre_object::function::w_staticmethod_getdict(obj) };
     }
+    // function.py:726-729 ClassMethod.getdict.
+    if unsafe { pyre_object::function::is_classmethod(obj) } {
+        return unsafe { pyre_object::function::w_classmethod_getdict(obj) };
+    }
     // exceptions/interp_exceptions.py:222-225 W_BaseException.getdict
     // override — lazily allocates the instance dict on the typed slot.
     if unsafe { pyre_object::is_exception(obj) } {
@@ -3366,6 +3370,18 @@ pub fn setdict(obj: PyObjectRef, w_dict: PyObjectRef) -> Result<(), PyError> {
             )));
         }
         unsafe { pyre_object::function::w_staticmethod_setdict(obj, w_dict) };
+        return Ok(());
+    }
+    // function.py:731-736 ClassMethod.setdict.
+    if unsafe { pyre_object::function::is_classmethod(obj) } {
+        let w_dict_type = crate::typedef::gettypeobject(&pyre_object::pyobject::DICT_TYPE);
+        if !unsafe { isinstance_w(w_dict, w_dict_type) } {
+            return Err(PyError::type_error(format!(
+                "__dict__ must be set to a dictionary, not a '{}'",
+                object_functionstr_type_name(w_dict),
+            )));
+        }
+        unsafe { pyre_object::function::w_classmethod_setdict(obj, w_dict) };
         return Ok(());
     }
     // exceptions/interp_exceptions.py:227-231 W_BaseException.setdict
@@ -8425,7 +8441,7 @@ pub fn call_function(callable: PyObjectRef, args: &[PyObjectRef]) -> PyObjectRef
 /// PyPy: baseobjspace.py `callable_w`.
 pub fn callable_w(obj: PyObjectRef) -> bool {
     // `PyCallable_Check` — the builtin callable kinds (function / builtin
-    // function, bound method, static- and classmethod, type) dispatch through
+    // function, bound method, staticmethod, type) dispatch through
     // dedicated slots rather than a `__call__` dict entry, so each is
     // recognised directly; any other object is callable iff its type defines
     // `__call__`.  Mirrors `builtins::builtin_callable`.
@@ -8434,7 +8450,6 @@ pub fn callable_w(obj: PyObjectRef) -> bool {
             || is_type(obj)
             || pyre_object::is_method(obj)
             || pyre_object::function::is_staticmethod(obj)
-            || pyre_object::function::is_classmethod(obj)
             || crate::typedef::r#type(obj)
                 .and_then(|t| lookup_in_type(t, "__call__"))
                 .is_some()

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -3869,55 +3869,6 @@ fn getattr_str_impl(obj: PyObjectRef, name: &str, call_getattr: bool) -> PyResul
         }
     }
 
-    // Property descriptor methods — PyPy: descriptor.py W_Property.setter / getter / deleter
-    // Returns a bound method (W_Method) that captures the property via w_self,
-    // so the static handler can extract the property from args[0].
-    unsafe {
-        if is_property(obj) {
-            let static_name: Option<(
-                &'static str,
-                fn(&[PyObjectRef]) -> Result<PyObjectRef, crate::PyError>,
-                u16,
-            )> = match name {
-                "setter" => Some(("setter", property_setter_impl, 2)),
-                "getter" => Some(("getter", property_getter_impl, 2)),
-                "deleter" => Some(("deleter", property_deleter_impl, 2)),
-                "__set_name__" => Some(("__set_name__", property_set_name_impl, 3)),
-                _ => None,
-            };
-            if let Some((sname, func, arity)) = static_name {
-                let builtin = crate::make_builtin_function_with_arity(sname, func, arity);
-                return Ok(pyre_object::function::w_method_new(
-                    builtin,
-                    obj,
-                    pyre_object::PY_NULL,
-                ));
-            }
-            match name {
-                "fget" => return Ok(w_property_get_fget(obj)),
-                "fset" => return Ok(w_property_get_fset(obj)),
-                "fdel" => return Ok(w_property_get_fdel(obj)),
-                "__name__" => {
-                    // descriptor.py exposes the name set by `__set_name__`;
-                    // an unset name falls through to the normal
-                    // `'property' object has no attribute '__name__'`.
-                    let w_name = pyre_object::descriptor::w_property_get_name(obj);
-                    if !w_name.is_null() {
-                        return Ok(w_name);
-                    }
-                }
-                "__doc__" => {
-                    // descriptor.py:316-318 `__doc__ = GetSetProperty(
-                    // W_Property.get_doc, W_Property.set_doc)` → :249-250
-                    // get_doc returns the `w_doc` slot.
-                    let stored = pyre_object::descriptor::w_property_get_doc(obj);
-                    return Ok(if stored.is_null() { w_none() } else { stored });
-                }
-                _ => {}
-            }
-        }
-    }
-
     // Member descriptor attributes — typedef.py:443 Member.__name__, __objclass__
     unsafe {
         if pyre_object::typedef::is_member(obj) {
@@ -4880,6 +4831,19 @@ fn object_getattr_miss(obj: PyObjectRef, name: &str, call_getattr: bool) -> PyRe
                     call_getattr,
                 );
             }
+            // PyPy replaces `W_Property.typedef.rawdict['__doc__']` with the
+            // instance descriptor while retaining the TypeDef doc separately;
+            // CPython likewise keeps `tp_doc` beside a member descriptor under
+            // the same dict key.  Pyre has no separate type-doc slot, so serve
+            // that exact builtin split here without affecting subclasses.
+            if name == "__doc__"
+                && std::ptr::eq(
+                    obj,
+                    crate::typedef::gettypeobject(&pyre_object::descriptor::PROPERTY_TYPE),
+                )
+            {
+                return Ok(w_str_new(crate::typedef::PROPERTY_DOC));
+            }
             if name == "__doc__"
                 || name == "__code__"
                 || name == "__func__"
@@ -4993,6 +4957,44 @@ fn object_getattr_miss(obj: PyObjectRef, name: &str, call_getattr: bool) -> PyRe
             obj,
             pyre_object::PY_NULL,
         ));
+    }
+
+    // W_Property is a native W_Root allocation, but a property subclass is a
+    // normal heap type with an instance dict.  Run the same five-step
+    // descriptor protocol as `W_ObjectObject` before the generic builtin
+    // TypeDef shortcut below: data descriptor, instance dict, non-data
+    // descriptor.  This is the structural consequence of PyPy's
+    // `W_Property(W_Root)` + `getclass(space)`, and is what lets the subclass
+    // class's `__doc__ = None` entry be shadowed by the doc value that
+    // property.__init__ writes into the subclass instance dict.
+    unsafe {
+        if is_property(obj) {
+            if let Some(w_type) = crate::typedef::r#type(obj) {
+                let w_descr = lookup_in_type_where(w_type, name);
+                if let Some(descr) = w_descr {
+                    if is_data_descr(descr) {
+                        if let Some(result) = get(descr, obj, w_type)? {
+                            return Ok(result);
+                        }
+                    }
+                }
+                let w_dict = getdict_backing(obj);
+                if !w_dict.is_null() {
+                    if let Some(value) = pyre_object::w_dict_getitem_str(w_dict, name) {
+                        return Ok(value);
+                    }
+                }
+                if let Some(descr) = w_descr {
+                    if crate::is_function(descr) {
+                        return Ok(pyre_object::w_method_new(descr, obj, w_type));
+                    }
+                    if let Some(result) = get(descr, obj, w_type)? {
+                        return Ok(result);
+                    }
+                    return Ok(descr);
+                }
+            }
+        }
     }
 
     // Builtin type method lookup via TypeDef registry.
@@ -7243,7 +7245,7 @@ pub(crate) unsafe fn get(
         }
         let fget = w_property_get_fget(descr);
         if fget.is_null() || is_none(fget) {
-            return Err(property_no_accessor(descr, obj, "getter"));
+            return Err(property_no_accessor(descr, obj, "getter")?);
         }
         // W_Property.get → `space.call_function(self.fget, w_obj)`: the
         // getter's exception propagates rather than being swallowed.
@@ -7331,7 +7333,7 @@ unsafe fn set(
     if is_property(descr) {
         let fset = w_property_get_fset(descr);
         if fset.is_null() || is_none(fset) {
-            return Err(property_no_accessor(descr, obj, "setter"));
+            return Err(property_no_accessor(descr, obj, "setter")?);
         }
         // descriptor.py:228 W_Property.set → `space.call_function(self.fset,
         // w_obj, w_value)`: the setter's exception propagates rather than
@@ -7407,7 +7409,7 @@ unsafe fn delete(descr: PyObjectRef, obj: PyObjectRef) -> Result<(), crate::PyEr
     if is_property(descr) {
         let fdel = w_property_get_fdel(descr);
         if fdel.is_null() || is_none(fdel) {
-            return Err(property_no_accessor(descr, obj, "deleter"));
+            return Err(property_no_accessor(descr, obj, "deleter")?);
         }
         crate::call::call_function_impl_result(fdel, &[obj])?;
         return Ok(());
@@ -7681,23 +7683,6 @@ pub fn object_setattr(obj: PyObjectRef, name: &str, value: PyObjectRef) -> PyRes
             let w_dict = pyre_object::w_module_get_w_dict(obj);
             if !w_dict.is_null() {
                 setitem(w_dict, w_str_new(name), value)?;
-                return Ok(w_none());
-            }
-        }
-    }
-    // descriptor.py:316-318 `__doc__ = GetSetProperty(W_Property.get_doc,
-    // W_Property.set_doc)` — the only writable property attribute;
-    // `property.__doc__ = "..."` is common in stdlib (dis.py, etc.).
-    // Other names (and member descriptors, which expose no setter,
-    // typedef.py:533-540) fall through to raiseattrerror.
-    unsafe {
-        if is_property(obj) {
-            if name == "__doc__" {
-                pyre_object::descriptor::w_property_set_doc(obj, value);
-                return Ok(w_none());
-            }
-            if name == "__name__" {
-                pyre_object::descriptor::w_property_set_name(obj, value);
                 return Ok(w_none());
             }
         }
@@ -8083,21 +8068,6 @@ pub fn delattr_str(obj: PyObjectRef, name: &str) -> PyResult {
 /// Terminal `object.__delattr__` — bypasses user override.
 pub fn object_delattr(obj: PyObjectRef, name: &str) -> PyResult {
     let obj = crate::module::_weakref::interp__weakref::force(obj)?;
-    // `property.__name__` is a writable/deletable slot; deleting clears
-    // the name recorded by `__set_name__`, and deleting when unset
-    // raises like a missing attribute.
-    unsafe {
-        if is_property(obj) && name == "__name__" {
-            let w_name = pyre_object::descriptor::w_property_get_name(obj);
-            if w_name.is_null() {
-                return Err(crate::PyError::attribute_error(
-                    "'property' object has no attribute '__name__'",
-                ));
-            }
-            pyre_object::descriptor::w_property_set_name(obj, pyre_object::PY_NULL);
-            return Ok(w_none());
-        }
-    }
     // descroperation.py:131-140 descr__delattr__: a data descriptor's
     // `__delete__` takes priority over the namespace delete. PyPy walks
     // `space.type(obj)`, so the lookup must run for any object whose type
@@ -10762,6 +10732,15 @@ pub fn next(obj: PyObjectRef) -> PyResult {
 /// one accessor replaced.  A getter-inherited doc (`getter_doc`) does
 /// not survive a getter replacement (descriptor.py:263-266); the
 /// constructor's doc capture then re-derives it from the new getter.
+fn property_require_obj(obj: PyObjectRef, name: &str) -> Result<PyObjectRef, crate::PyError> {
+    if obj.is_null() || !unsafe { is_property(obj) } {
+        return Err(crate::PyError::type_error(format!(
+            "descriptor '{name}' requires a 'property' object"
+        )));
+    }
+    Ok(obj)
+}
+
 unsafe fn property_copy(
     prop: PyObjectRef,
     w_getter: Option<PyObjectRef>,
@@ -10770,7 +10749,12 @@ unsafe fn property_copy(
 ) -> PyResult {
     let w_none = pyre_object::w_none();
     let resolve = |slot: Option<PyObjectRef>, get: unsafe fn(PyObjectRef) -> PyObjectRef| {
-        let v = slot.unwrap_or_else(|| unsafe { get(prop) });
+        // CPython 3.14 property_copy treats an explicit None like an omitted
+        // replacement; `p.getter(None)` therefore keeps `p.fget`.
+        let v = match slot {
+            Some(v) if !v.is_null() && !unsafe { is_none(v) } => v,
+            _ => unsafe { get(prop) },
+        };
         if v.is_null() { w_none } else { v }
     };
     let getter = resolve(w_getter, w_property_get_fget);
@@ -10807,7 +10791,11 @@ unsafe fn property_copy(
 
 /// `descriptor.py:206-217 W_Property._properror` — AttributeError naming
 /// the missing accessor and, when known, the property's `__name__`.
-unsafe fn property_no_accessor(prop: PyObjectRef, obj: PyObjectRef, kind: &str) -> crate::PyError {
+unsafe fn property_no_accessor(
+    prop: PyObjectRef,
+    obj: PyObjectRef,
+    kind: &str,
+) -> Result<crate::PyError, crate::PyError> {
     let qualname = match crate::typedef::r#type(obj) {
         Some(w_type) => match getattr_str(w_type, "__qualname__") {
             Ok(q) if !q.is_null() && is_str(q) => pyre_object::w_str_get_value(q).to_string(),
@@ -10815,42 +10803,59 @@ unsafe fn property_no_accessor(prop: PyObjectRef, obj: PyObjectRef, kind: &str) 
         },
         None => (*(*obj).ob_type).name.to_string(),
     };
-    let w_name = pyre_object::descriptor::w_property_get_name(prop);
+    // CPython 3.14 property_name: an explicitly assigned/set_name value wins;
+    // otherwise fall back to fget.__name__.  PyPy's object-resident name slot
+    // shape is retained; only the 3.14 lookup extension is added.
+    let mut w_name = pyre_object::descriptor::w_property_get_name(prop);
+    if w_name.is_null() {
+        let fget = w_property_get_fget(prop);
+        if !fget.is_null() && !is_none(fget) {
+            match getattr_str(fget, "__name__") {
+                Ok(name) => w_name = name,
+                Err(err) if err.kind == PyErrorKind::AttributeError => {}
+                Err(err) => return Err(err),
+            }
+        }
+    }
     let msg = if !w_name.is_null() {
         let name_repr = crate::display::py_repr(w_name).unwrap_or_else(|_| "<name>".to_string());
         format!("property {name_repr} of '{qualname}' object has no {kind}")
     } else {
         format!("property of '{qualname}' object has no {kind}")
     };
-    crate::PyError::attribute_error(msg)
+    Ok(crate::PyError::attribute_error(msg))
 }
 
-fn property_set_name_impl(args: &[PyObjectRef]) -> PyResult {
+pub(crate) fn property_set_name_impl(args: &[PyObjectRef]) -> PyResult {
     // descriptor.py:274-276 `set_name(self, w_type, w_name)` — the bound
     // method receives `[property, owner, name]`.
+    let prop = property_require_obj(args.first().copied().unwrap_or(PY_NULL), "__set_name__")?;
     if args.len() > 2 {
         let w_name = args[2];
-        unsafe { pyre_object::descriptor::w_property_set_name(args[0], w_name) };
+        unsafe { pyre_object::descriptor::w_property_set_name(prop, w_name) };
     }
     Ok(pyre_object::w_none())
 }
 
-fn property_setter_impl(args: &[PyObjectRef]) -> PyResult {
+pub(crate) fn property_setter_impl(args: &[PyObjectRef]) -> PyResult {
     // descriptor.py:243-244 `setter` → `_copy(space, w_setter=w_setter)`
     let w_setter = if args.len() > 1 { Some(args[1]) } else { None };
-    unsafe { property_copy(args[0], None, w_setter, None) }
+    let prop = property_require_obj(args.first().copied().unwrap_or(PY_NULL), "setter")?;
+    unsafe { property_copy(prop, None, w_setter, None) }
 }
 
-fn property_getter_impl(args: &[PyObjectRef]) -> PyResult {
+pub(crate) fn property_getter_impl(args: &[PyObjectRef]) -> PyResult {
     // descriptor.py:240-241 `getter` → `_copy(space, w_getter=w_getter)`
     let w_getter = if args.len() > 1 { Some(args[1]) } else { None };
-    unsafe { property_copy(args[0], w_getter, None, None) }
+    let prop = property_require_obj(args.first().copied().unwrap_or(PY_NULL), "getter")?;
+    unsafe { property_copy(prop, w_getter, None, None) }
 }
 
-fn property_deleter_impl(args: &[PyObjectRef]) -> PyResult {
+pub(crate) fn property_deleter_impl(args: &[PyObjectRef]) -> PyResult {
     // descriptor.py:246-247 `deleter` → `_copy(space, w_deleter=w_deleter)`
     let w_deleter = if args.len() > 1 { Some(args[1]) } else { None };
-    unsafe { property_copy(args[0], None, None, w_deleter) }
+    let prop = property_require_obj(args.first().copied().unwrap_or(PY_NULL), "deleter")?;
+    unsafe { property_copy(prop, None, None, w_deleter) }
 }
 
 /// `descriptor.py W_Property.get` as the type-dict `__get__` entry — args
@@ -10860,7 +10865,7 @@ fn property_deleter_impl(args: &[PyObjectRef]) -> PyResult {
 /// introspection see it.
 pub(crate) fn property_descr_get_impl(args: &[PyObjectRef]) -> PyResult {
     unsafe {
-        let prop = args[0];
+        let prop = property_require_obj(args.first().copied().unwrap_or(PY_NULL), "__get__")?;
         let obj = if args.len() > 1 {
             args[1]
         } else {
@@ -10872,7 +10877,7 @@ pub(crate) fn property_descr_get_impl(args: &[PyObjectRef]) -> PyResult {
         }
         let fget = w_property_get_fget(prop);
         if fget.is_null() || is_none(fget) {
-            return Err(property_no_accessor(prop, obj, "getter"));
+            return Err(property_no_accessor(prop, obj, "getter")?);
         }
         crate::call::call_function_impl_result(fget, &[obj])
     }
@@ -10881,7 +10886,7 @@ pub(crate) fn property_descr_get_impl(args: &[PyObjectRef]) -> PyResult {
 /// `descriptor.py W_Property.set` — args `[property, obj, value]`.
 pub(crate) fn property_descr_set_impl(args: &[PyObjectRef]) -> PyResult {
     unsafe {
-        let prop = args[0];
+        let prop = property_require_obj(args.first().copied().unwrap_or(PY_NULL), "__set__")?;
         let obj = args[1];
         let value = if args.len() > 2 {
             args[2]
@@ -10890,7 +10895,7 @@ pub(crate) fn property_descr_set_impl(args: &[PyObjectRef]) -> PyResult {
         };
         let fset = w_property_get_fset(prop);
         if fset.is_null() || is_none(fset) {
-            return Err(property_no_accessor(prop, obj, "setter"));
+            return Err(property_no_accessor(prop, obj, "setter")?);
         }
         crate::call::call_function_impl_result(fset, &[obj, value])?;
         Ok(pyre_object::w_none())
@@ -10900,11 +10905,11 @@ pub(crate) fn property_descr_set_impl(args: &[PyObjectRef]) -> PyResult {
 /// `descriptor.py W_Property.delete` — args `[property, obj]`.
 pub(crate) fn property_descr_delete_impl(args: &[PyObjectRef]) -> PyResult {
     unsafe {
-        let prop = args[0];
+        let prop = property_require_obj(args.first().copied().unwrap_or(PY_NULL), "__delete__")?;
         let obj = args[1];
         let fdel = w_property_get_fdel(prop);
         if fdel.is_null() || is_none(fdel) {
-            return Err(property_no_accessor(prop, obj, "deleter"));
+            return Err(property_no_accessor(prop, obj, "deleter")?);
         }
         crate::call::call_function_impl_result(fdel, &[obj])?;
         Ok(pyre_object::w_none())

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -7272,6 +7272,15 @@ pub(crate) unsafe fn get(
                 (*(*obj).ob_type).name,
             )));
         }
+        // CPython 3.14 `PyFunction_Type` exposes five `PyMemberDef`
+        // descriptors whose values live in the native Function fields rather
+        // than mapdict's numbered `__slots__` storage.  Their tagged index is
+        // only a member-kind discriminator; never pass it to getslotvalue.
+        if pyre_object::w_member_is_direct(descr) {
+            return Ok(Some(crate::typedef::function_direct_member_get(
+                descr, obj,
+            )?));
+        }
         // typedef.py:511: w_result = w_obj.getslotvalue(self.index)
         let index = pyre_object::w_member_get_index(descr);
         let found = if is_instance(obj) {
@@ -7355,6 +7364,10 @@ unsafe fn set(
                 (*(*obj).ob_type).name,
             )));
         }
+        if pyre_object::w_member_is_direct(descr) {
+            crate::typedef::function_direct_member_set(descr, obj, value)?;
+            return Ok(true);
+        }
         // typedef.py:522: w_obj.setslotvalue(self.index, w_value)
         let index = pyre_object::w_member_get_index(descr);
         if is_instance(obj) {
@@ -7423,6 +7436,10 @@ unsafe fn delete(descr: PyObjectRef, obj: PyObjectRef) -> Result<(), crate::PyEr
                 pyre_object::w_type_get_name(w_cls),
                 (*(*obj).ob_type).name,
             )));
+        }
+        if pyre_object::w_member_is_direct(descr) {
+            crate::typedef::function_direct_member_delete(descr, obj)?;
+            return Ok(());
         }
         // typedef.py:527-531: success = w_obj.delslotvalue(self.index)
         let index = pyre_object::w_member_get_index(descr);

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -6196,8 +6196,8 @@ fn builtin_next(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
 fn builtin_callable(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     let obj = args[0];
     // `PyCallable_Check` — true when `type(obj)` has `tp_call`.  The builtin
-    // callable kinds (function / builtin function, bound method, static- and
-    // classmethod, type) are dispatched through dedicated slots in `call.rs`
+    // callable kinds (function / builtin function, bound method,
+    // staticmethod, type) are dispatched through dedicated slots in `call.rs`
     // rather than a `__call__` dict entry, so each is recognised directly;
     // any other object is callable iff its type defines `__call__`.
     let is_callable = unsafe {
@@ -6205,7 +6205,6 @@ fn builtin_callable(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError>
             || pyre_object::is_type(obj)
             || pyre_object::is_method(obj)
             || pyre_object::function::is_staticmethod(obj)
-            || pyre_object::function::is_classmethod(obj)
             || crate::typedef::r#type(obj)
                 .and_then(|t| crate::baseobjspace::lookup_in_type(t, "__call__"))
                 .is_some()

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -5045,7 +5045,7 @@ pub(crate) fn builtin_str(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::Py
         return crate::typedef::bytes_method_decode(&decode_args);
     }
     // A tagged `int` immediate stringifies to its decimal value; format it
-    // before `is_str` / `unwrap_cell` / `ob_type` touch it as a pointer.
+    // before `is_str` / `ob_type` touch it as a pointer.
     // Mirrors `py_str_wtf8` / `py_repr_obj`. Gated on `CAN_BE_TAGGED`.
     if pyre_object::tagged_int::CAN_BE_TAGGED && pyre_object::tagged_int::is_tagged_int(obj) {
         return Ok(w_str_new(&format!(
@@ -5075,7 +5075,6 @@ pub(crate) fn builtin_str(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::Py
         }
     }
     unsafe {
-        let obj = crate::baseobjspace::unwrap_cell(obj);
         if !obj.is_null() && std::ptr::eq((*obj).ob_type, &INSTANCE_TYPE as *const PyType) {
             if let Some(r) = crate::display::try_call_dunder_obj_above_object(obj, "__str__")? {
                 return Ok(r);
@@ -5097,7 +5096,6 @@ unsafe fn py_repr_obj(obj: PyObjectRef) -> Result<PyObjectRef, crate::PyError> {
                 pyre_object::tagged_int::untag_int(obj)
             )));
         }
-        let obj = crate::baseobjspace::unwrap_cell(obj);
         if !obj.is_null() {
             let tp = (*obj).ob_type;
             if let Some(r) = crate::display::builtin_subclass_dunder_obj(obj, tp, "__repr__")? {

--- a/pyre/pyre-interpreter/src/call.rs
+++ b/pyre/pyre-interpreter/src/call.rs
@@ -326,7 +326,6 @@ fn fill_user_function_args(
     if nargs > nparams && !has_varargs {
         let fname = unsafe { crate::function_get_qualname(callable) };
         let ndefaults = if !defaults.is_null() {
-            let defaults = crate::baseobjspace::unwrap_cell(defaults);
             if unsafe { pyre_object::is_tuple(defaults) } {
                 unsafe { pyre_object::w_tuple_len(defaults) }
             } else {
@@ -371,7 +370,6 @@ fn fill_user_function_args(
 
     // Fill positional defaults for slots [n_pos_copied..nparams).
     if n_pos_copied < nparams && !defaults.is_null() {
-        let defaults = crate::baseobjspace::unwrap_cell(defaults);
         let ndefaults = if unsafe { pyre_object::is_tuple(defaults) } {
             unsafe { pyre_object::w_tuple_len(defaults) }
         } else {
@@ -746,7 +744,7 @@ pub fn call_kw(
     // Unwrap bound methods: load_method pushes (method, PY_NULL) for
     // bound methods. Extract the underlying function and prepend the
     // receiver so resolve_kwargs sees the correct function signature.
-    let callable_unwrapped = crate::baseobjspace::unwrap_cell(callable);
+    let callable_unwrapped = callable;
     let callable_unwrapped = if unsafe { pyre_object::is_method(callable_unwrapped) } {
         let func = unsafe { pyre_object::w_method_get_func(callable_unwrapped) };
         let receiver = unsafe { pyre_object::w_method_get_self(callable_unwrapped) };
@@ -920,7 +918,6 @@ fn call_callable_with_mode(
     args: &[PyObjectRef],
     mode: CallMode,
 ) -> PyResult {
-    let callable = crate::baseobjspace::unwrap_cell(callable);
     if unsafe { pyre_object::is_method(callable) } {
         let func = unsafe { pyre_object::w_method_get_func(callable) };
         let receiver = unsafe {
@@ -1299,7 +1296,6 @@ pub(crate) fn resolve_kwargs(
         let ndefaults = {
             let defaults = unsafe { crate::function_get_defaults(target_func) };
             if !defaults.is_null() {
-                let defaults = crate::baseobjspace::unwrap_cell(defaults);
                 if unsafe { pyre_object::is_tuple(defaults) } {
                     unsafe { pyre_object::w_tuple_len(defaults) }
                 } else {
@@ -1368,7 +1364,6 @@ pub(crate) fn resolve_kwargs(
     // Defaults cover the LAST N of the positional params (arg_count).
     let defaults = unsafe { crate::function_get_defaults(target_func) };
     if !defaults.is_null() {
-        let defaults = crate::baseobjspace::unwrap_cell(defaults);
         if unsafe { pyre_object::is_tuple(defaults) } {
             let ndefaults = unsafe { pyre_object::w_tuple_len(defaults) };
             let first_default = n_pos_params.saturating_sub(ndefaults);
@@ -1603,8 +1598,6 @@ pub fn call_with_kwargs(
     pos_args: &[PyObjectRef],
     kwargs: &[(Wtf8Buf, PyObjectRef)],
 ) -> PyResult {
-    let callable = crate::baseobjspace::unwrap_cell(callable);
-
     // Unwrap bound methods: prepend receiver to pos_args.
     if unsafe { pyre_object::is_method(callable) } {
         let func = unsafe { pyre_object::w_method_get_func(callable) };
@@ -1840,7 +1833,6 @@ pub fn call_with_kwargs(
                 let ndefaults = {
                     let defaults = unsafe { crate::function_get_defaults(callable) };
                     if !defaults.is_null() {
-                        let defaults = crate::baseobjspace::unwrap_cell(defaults);
                         if unsafe { pyre_object::is_tuple(defaults) } {
                             unsafe { pyre_object::w_tuple_len(defaults) }
                         } else {
@@ -1877,7 +1869,6 @@ pub fn call_with_kwargs(
             // Fill positional defaults from __defaults__ tuple.
             let defaults = unsafe { crate::function_get_defaults(callable) };
             if !defaults.is_null() {
-                let defaults = crate::baseobjspace::unwrap_cell(defaults);
                 if unsafe { pyre_object::is_tuple(defaults) } {
                     let ndefaults = unsafe { pyre_object::w_tuple_len(defaults) };
                     let first_default = n_pos_params.saturating_sub(ndefaults);

--- a/pyre/pyre-interpreter/src/call.rs
+++ b/pyre/pyre-interpreter/src/call.rs
@@ -756,6 +756,29 @@ pub fn call_kw(
         callable_unwrapped
     };
 
+    // function.py:712-713 `StaticMethod.descr_call` receives the original
+    // Arguments object.  Preserve the positional/keyword split before the
+    // generic signature resolver (a staticmethod wrapper has no Python
+    // signature of its own) and forward both collections unchanged.
+    if unsafe { pyre_object::is_staticmethod(callable_unwrapped) } {
+        let nkw = if unsafe { pyre_object::is_tuple(kwarg_names) } {
+            unsafe { pyre_object::w_tuple_len(kwarg_names) }
+        } else {
+            0
+        };
+        let n_pos = args.len().saturating_sub(nkw);
+        let pos_args = args[..n_pos].to_vec();
+        let mut kw_entries = Vec::with_capacity(nkw);
+        for ki in 0..nkw {
+            if let Some(name_obj) = unsafe { pyre_object::w_tuple_getitem(kwarg_names, ki as i64) }
+            {
+                let key = unsafe { pyre_object::w_str_get_wtf8(name_obj) }.to_owned();
+                kw_entries.push((key, args[n_pos + ki]));
+            }
+        }
+        return call_with_kwargs(frame, callable_unwrapped, &pos_args, &kw_entries);
+    }
+
     // For type objects with kwargs: use call_with_kwargs which handles
     // __new__/__init__ kwargs forwarding correctly.
     if unsafe { pyre_object::is_type(callable_unwrapped) } {
@@ -1598,6 +1621,14 @@ pub fn call_with_kwargs(
     pos_args: &[PyObjectRef],
     kwargs: &[(Wtf8Buf, PyObjectRef)],
 ) -> PyResult {
+    // function.py:712-713 StaticMethod.descr_call — the wrapper contributes
+    // no implicit argument; forward the original positional and keyword
+    // collections unchanged to its w_function.
+    if unsafe { pyre_object::is_staticmethod(callable) } {
+        let func = unsafe { pyre_object::w_staticmethod_get_func(callable) };
+        return call_with_kwargs(frame, func, pos_args, kwargs);
+    }
+
     // Unwrap bound methods: prepend receiver to pos_args.
     if unsafe { pyre_object::is_method(callable) } {
         let func = unsafe { pyre_object::w_method_get_func(callable) };

--- a/pyre/pyre-interpreter/src/call.rs
+++ b/pyre/pyre-interpreter/src/call.rs
@@ -779,6 +779,28 @@ pub fn call_kw(
         return call_with_kwargs(frame, callable_unwrapped, &pos_args, &kw_entries);
     }
 
+    // A base classmethod has no tp_call, but a user subtype may define
+    // `__call__`. Split the keyword tail before generic signature handling;
+    // call_with_kwargs performs the special-method descriptor binding.
+    if unsafe { pyre_object::is_classmethod(callable_unwrapped) } {
+        let nkw = if unsafe { pyre_object::is_tuple(kwarg_names) } {
+            unsafe { pyre_object::w_tuple_len(kwarg_names) }
+        } else {
+            0
+        };
+        let n_pos = args.len().saturating_sub(nkw);
+        let pos_args = args[..n_pos].to_vec();
+        let mut kw_entries = Vec::with_capacity(nkw);
+        for ki in 0..nkw {
+            if let Some(name_obj) = unsafe { pyre_object::w_tuple_getitem(kwarg_names, ki as i64) }
+            {
+                let key = unsafe { pyre_object::w_str_get_wtf8(name_obj) }.to_owned();
+                kw_entries.push((key, args[n_pos + ki]));
+            }
+        }
+        return call_with_kwargs(frame, callable_unwrapped, &pos_args, &kw_entries);
+    }
+
     // For type objects with kwargs: use call_with_kwargs which handles
     // __new__/__init__ kwargs forwarding correctly.
     if unsafe { pyre_object::is_type(callable_unwrapped) } {
@@ -935,6 +957,26 @@ fn metaclass_call_override(callable: PyObjectRef) -> Option<PyObjectRef> {
     Some(bound)
 }
 
+/// Resolve a `__call__` introduced by a classmethod *subtype*. The base
+/// classmethod has no such slot in PyPy or CPython 3.14. Descriptor binding
+/// is essential here: an ordinary function receives the wrapper, while a
+/// staticmethod override does not.
+fn classmethod_call_override(callable: PyObjectRef) -> Result<Option<PyObjectRef>, PyError> {
+    if !unsafe { pyre_object::is_classmethod(callable) } {
+        return Ok(None);
+    }
+    let Some(w_type) = crate::typedef::r#type(callable) else {
+        return Ok(None);
+    };
+    let Some(call_descr) = (unsafe { crate::baseobjspace::lookup_in_type(w_type, "__call__") })
+    else {
+        return Ok(None);
+    };
+    let bound =
+        unsafe { crate::baseobjspace::get(call_descr, callable, w_type) }?.unwrap_or(call_descr);
+    Ok(Some(bound))
+}
+
 fn call_callable_with_mode(
     frame: &mut PyFrame,
     callable: PyObjectRef,
@@ -971,8 +1013,11 @@ fn call_callable_with_mode(
         let func = unsafe { pyre_object::w_staticmethod_get_func(callable) };
         return call_callable_with_mode(frame, func, args, mode);
     }
-    // ClassMethod defines no descr_call (function.py), so a raw classmethod
-    // object is not callable; it falls through to the not-callable error.
+    if let Some(bound) = classmethod_call_override(callable)? {
+        return call_callable_with_mode(frame, bound, args, mode);
+    }
+    // The base ClassMethod defines no descr_call (function.py), so a raw
+    // classmethod object falls through to the not-callable error.
 
     // Instance with __call__ — PyPy: descroperation.py descr_call
     if unsafe { pyre_object::is_instance(callable) } {
@@ -1629,6 +1674,13 @@ pub fn call_with_kwargs(
         return call_with_kwargs(frame, func, pos_args, kwargs);
     }
 
+    if unsafe { pyre_object::is_classmethod(callable) } {
+        if let Some(bound) = classmethod_call_override(callable)? {
+            return call_with_kwargs(frame, bound, pos_args, kwargs);
+        }
+        return Err(PyError::type_error("'classmethod' object is not callable"));
+    }
+
     // Unwrap bound methods: prepend receiver to pos_args.
     if unsafe { pyre_object::is_method(callable) } {
         let func = unsafe { pyre_object::w_method_get_func(callable) };
@@ -2262,12 +2314,12 @@ pub fn call_function_impl_result(
             let func = pyre_object::w_staticmethod_get_func(callable);
             return call_function_impl_result(func, args);
         }
-        // classmethod → unwrap and call the wrapped function
-        // PyPy: function.py ClassMethod.descr_classmethod__call__
-        if pyre_object::is_classmethod(callable) {
-            let func = pyre_object::w_classmethod_get_func(callable);
-            return call_function_impl_result(func, args);
+        if let Some(bound) = classmethod_call_override(callable)? {
+            return call_function_impl_result(bound, args);
         }
+        // ClassMethod has no descr_call (function.py:718-768; CPython 3.14
+        // `PyClassMethod_Type.tp_call = 0`), so a raw wrapper falls through
+        // to the ordinary not-callable error.
         // GenericAlias.__call__ (`_pypy_generic_alias.py:41`) —
         // `self.__origin__(*args, **kwargs)`, then best-effort
         // `result.__orig_class__ = self`.  Resolved here because the call

--- a/pyre/pyre-interpreter/src/display.rs
+++ b/pyre/pyre-interpreter/src/display.rs
@@ -708,6 +708,9 @@ pub unsafe fn py_repr(obj: PyObjectRef) -> Result<String, crate::PyError> {
             // `b"mappingproxy(%s)" % space.utf8_w(space.repr(self.w_mapping))`.
             let inner = pyre_object::w_dict_proxy_get_mapping(obj);
             format!("mappingproxy({})", py_repr(inner)?)
+        } else if pyre_object::typedef::is_getset_property(obj) {
+            // CPython 3.14 `PyGetSetDescr_Type.tp_repr`.
+            crate::typedef::getset_descriptor_repr(obj)
         } else if pyre_object::is_member(obj) {
             // CPython 3.14 `PyMemberDescr_Type.tp_repr = member_repr`.
             // Member descriptors are native-layout objects with no `w_class`,

--- a/pyre/pyre-interpreter/src/display.rs
+++ b/pyre/pyre-interpreter/src/display.rs
@@ -389,7 +389,6 @@ pub unsafe fn py_repr_wtf8(obj: PyObjectRef) -> Result<Wtf8Buf, crate::PyError> 
                 pyre_object::tagged_int::untag_int(obj)
             )));
         }
-        let obj = crate::baseobjspace::unwrap_cell(obj);
         if !obj.is_null() {
             let tp = (*obj).ob_type;
             // A builtin leaf subclass's `__repr__` override may return a
@@ -448,13 +447,12 @@ unsafe fn exc_user_dunder_obj(obj: PyObjectRef, name: &str) -> Option<PyObjectRe
 }
 
 pub unsafe fn py_repr(obj: PyObjectRef) -> Result<String, crate::PyError> {
-    // A tagged immediate must be formatted before `unwrap_cell` /
-    // `ob_type` touch it as a pointer; `repr` of a plain `int` is its
+    // A tagged immediate must be formatted before `ob_type` touches it as a
+    // pointer; `repr` of a plain `int` is its
     // decimal value. Gated on `CAN_BE_TAGGED` (default false).
     if pyre_object::tagged_int::CAN_BE_TAGGED && pyre_object::tagged_int::is_tagged_int(obj) {
         return Ok(format!("{}", pyre_object::tagged_int::untag_int(obj)));
     }
-    let obj = crate::baseobjspace::unwrap_cell(obj);
     if obj.is_null() {
         return Ok("NULL".to_string());
     }
@@ -811,12 +809,11 @@ pub unsafe fn py_repr(obj: PyObjectRef) -> Result<String, crate::PyError> {
 pub unsafe fn py_str(obj: PyObjectRef) -> Result<String, crate::PyError> {
     unsafe {
         // `str` of a tagged `int` immediate is its decimal value; format
-        // it before `unwrap_cell` / `ob_type` deref. Gated on
+        // it before `ob_type` deref. Gated on
         // `CAN_BE_TAGGED` (default false).
         if pyre_object::tagged_int::CAN_BE_TAGGED && pyre_object::tagged_int::is_tagged_int(obj) {
             return Ok(format!("{}", pyre_object::tagged_int::untag_int(obj)));
         }
-        let obj = crate::baseobjspace::unwrap_cell(obj);
         if obj.is_null() {
             return Ok("NULL".to_string());
         }
@@ -1007,7 +1004,7 @@ pub unsafe fn py_str(obj: PyObjectRef) -> Result<String, crate::PyError> {
 pub unsafe fn py_str_wtf8(obj: PyObjectRef) -> Result<Wtf8Buf, crate::PyError> {
     unsafe {
         // A tagged `int` immediate stringifies to its decimal value
-        // (plain ASCII); format it before `unwrap_cell` / `ob_type`
+        // (plain ASCII); format it before `ob_type`
         // touch it as a pointer. Gated on `CAN_BE_TAGGED` (default false).
         if pyre_object::tagged_int::CAN_BE_TAGGED && pyre_object::tagged_int::is_tagged_int(obj) {
             return Ok(Wtf8Buf::from_string(format!(
@@ -1015,7 +1012,6 @@ pub unsafe fn py_str_wtf8(obj: PyObjectRef) -> Result<Wtf8Buf, crate::PyError> {
                 pyre_object::tagged_int::untag_int(obj)
             )));
         }
-        let obj = crate::baseobjspace::unwrap_cell(obj);
         if !obj.is_null() {
             let tp = (*obj).ob_type;
             if std::ptr::eq(tp, &STR_TYPE as *const PyType) {
@@ -1109,7 +1105,6 @@ unsafe fn exception_descr_str_wtf8(obj: PyObjectRef) -> Option<Wtf8Buf> {
             return None;
         }
         let first = pyre_object::w_tuple_getitem(args, 0).unwrap_or(args);
-        let first = crate::baseobjspace::unwrap_cell(first);
         if first.is_null() || !std::ptr::eq((*first).ob_type, &STR_TYPE as *const PyType) {
             return None;
         }

--- a/pyre/pyre-interpreter/src/display.rs
+++ b/pyre/pyre-interpreter/src/display.rs
@@ -698,8 +698,7 @@ pub unsafe fn py_repr(obj: PyObjectRef) -> Result<String, crate::PyError> {
             // GenericAlias.__repr__ (`_pypy_generic_alias.py:57`).
             return crate::_pypy_generic_alias::repr(obj);
         } else if std::ptr::eq(tp, &MODULE_TYPE as *const PyType) {
-            let name = pyre_object::w_module_get_name(obj);
-            format!("<module '{name}'>")
+            crate::typedef::module_repr_string(obj)?
         } else if std::ptr::eq(
             tp,
             &pyre_object::pyobject::MAPPING_PROXY_TYPE as *const PyType,

--- a/pyre/pyre-interpreter/src/display.rs
+++ b/pyre/pyre-interpreter/src/display.rs
@@ -708,6 +708,12 @@ pub unsafe fn py_repr(obj: PyObjectRef) -> Result<String, crate::PyError> {
             // `b"mappingproxy(%s)" % space.utf8_w(space.repr(self.w_mapping))`.
             let inner = pyre_object::w_dict_proxy_get_mapping(obj);
             format!("mappingproxy({})", py_repr(inner)?)
+        } else if pyre_object::is_member(obj) {
+            // CPython 3.14 `PyMemberDescr_Type.tp_repr = member_repr`.
+            // Member descriptors are native-layout objects with no `w_class`,
+            // so the generic builtin-dunder fallback below cannot discover
+            // their registered __repr__ method.
+            crate::typedef::member_descriptor_repr(obj)
         } else if std::ptr::eq(
             tp,
             &pyre_object::dictmultiobject::DICT_KEYS_TYPE as *const PyType,

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -199,6 +199,8 @@ unsafe fn walk_raw_function_roots(
         visitor(&mut *(&mut func.w_func_globals_obj as *mut PyObjectRef as *mut majit_ir::GcRef));
         visitor(&mut *(&mut func.w_ann as *mut PyObjectRef as *mut majit_ir::GcRef));
         visitor(&mut *(&mut func.w_annotate as *mut PyObjectRef as *mut majit_ir::GcRef));
+        visitor(&mut *(&mut func.w_func_dict as *mut PyObjectRef as *mut majit_ir::GcRef));
+        visitor(&mut *(&mut func.w_typeparams as *mut PyObjectRef as *mut majit_ir::GcRef));
         visitor(&mut *(&mut func.w_doc as *mut PyObjectRef as *mut majit_ir::GcRef));
         visitor(&mut *(&mut func.w_qualname as *mut PyObjectRef as *mut majit_ir::GcRef));
         visitor(&mut *(&mut func.w_objclass as *mut PyObjectRef as *mut majit_ir::GcRef));

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -197,6 +197,7 @@ unsafe fn walk_raw_function_roots(
         visitor(&mut *(&mut func.w_kw_defs as *mut PyObjectRef as *mut majit_ir::GcRef));
         visitor(&mut *(&mut func.w_module as *mut PyObjectRef as *mut majit_ir::GcRef));
         visitor(&mut *(&mut func.w_func_globals_obj as *mut PyObjectRef as *mut majit_ir::GcRef));
+        visitor(&mut *(&mut func.w_builtins as *mut PyObjectRef as *mut majit_ir::GcRef));
         visitor(&mut *(&mut func.w_ann as *mut PyObjectRef as *mut majit_ir::GcRef));
         visitor(&mut *(&mut func.w_annotate as *mut PyObjectRef as *mut majit_ir::GcRef));
         visitor(&mut *(&mut func.w_func_dict as *mut PyObjectRef as *mut majit_ir::GcRef));

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -5957,10 +5957,10 @@ result = c.f([1, 2, 3])";
         }
     }
 
-    /// `pypy/interpreter/typedef.py:817-831 Function.typedef.acceptable_as_base_class
-    /// = False` enforces that `type(len)()` raises `TypeError("cannot
-    /// create 'builtin_function' instances")` via the
-    /// `init_builtin_function_type` `__new__` staticmethod.  This was
+    /// `pypy/interpreter/typedef.py BuiltinFunction.typedef.acceptable_as_base_class
+    /// = False` plus CPython 3.14's null `tp_new` enforce that `type(len)()`
+    /// raises `TypeError("cannot create 'builtin_function_or_method'
+    /// instances")`. This was
     /// previously failing because `PyError::type_error(msg)` produced
     /// an exception whose `args_w` slot stayed `PY_NULL`, so
     /// `str(e)` (which reads `W_BaseException.args_w` per
@@ -5979,7 +5979,7 @@ result = c.f([1, 2, 3])";
         // functions").
         let source = "\
 doc_value = len.__doc__
-self_is_none = len.__self__ is None
+self_is_module = type(len.__self__).__name__ == 'module'
 repr_result = len.__repr__()
 new_err = ''
 try:
@@ -6000,16 +6000,16 @@ except AttributeError as e:
         res.expect("builtin_function typedef overrides failed");
         unsafe {
             let _doc_value = w_dict_getitem_str(frame.w_globals, "doc_value").unwrap();
-            let self_is_none = w_dict_getitem_str(frame.w_globals, "self_is_none").unwrap();
+            let self_is_module = w_dict_getitem_str(frame.w_globals, "self_is_module").unwrap();
             let repr_result = w_dict_getitem_str(frame.w_globals, "repr_result").unwrap();
             let new_err = w_dict_getitem_str(frame.w_globals, "new_err").unwrap();
             let set_err = w_dict_getitem_str(frame.w_globals, "set_err").unwrap();
             let del_err = w_dict_getitem_str(frame.w_globals, "del_err").unwrap();
-            assert!(w_bool_get_value(self_is_none));
+            assert!(w_bool_get_value(self_is_module));
             assert_eq!(w_str_get_value(repr_result), "<built-in function len>");
             assert_eq!(
                 w_str_get_value(new_err),
-                "cannot create 'builtin_function' instances"
+                "cannot create 'builtin_function_or_method' instances"
             );
             assert!(
                 w_str_get_value(set_err).contains("__doc__"),

--- a/pyre/pyre-interpreter/src/executioncontext.rs
+++ b/pyre/pyre-interpreter/src/executioncontext.rs
@@ -1045,6 +1045,12 @@ impl ExecutionContext {
         // through `w_module_new_aliasing_dict` without a raw storage
         // pointer (the strategy storage IS the canonical store).
         let module = pyre_object::w_module_new_aliasing_dict("builtins", self.builtins_module);
+        // function.py:797-815 BuiltinFunction.w_moduleobj. The defining
+        // module object does not exist while `new_builtin_module_dict` fills
+        // the namespace, so bind each builtin's `__self__` now.
+        for (_, value) in unsafe { pyre_object::w_dict_str_entries(self.builtins_module) } {
+            unsafe { crate::function::builtin_function_set_module_obj(value, module) };
+        }
         self.builtin_dict_cache.set(module);
         // `pypy/interpreter/baseobjspace.py:647` —
         // `self.setitem(self.builtin.w_dict, 'builtins',  w_builtin)`.

--- a/pyre/pyre-interpreter/src/function.rs
+++ b/pyre/pyre-interpreter/src/function.rs
@@ -2655,6 +2655,7 @@ mod tests {
 
     #[test]
     fn test_function_create() {
+        crate::test_hooks::install_hash_hook();
         // Function.code now stores a Code-level wrapper (PyCode).
         let raw_code = 0xDEAD_BEEF as *const ();
         let w_code = crate::w_code_new(raw_code);

--- a/pyre/pyre-interpreter/src/function.rs
+++ b/pyre/pyre-interpreter/src/function.rs
@@ -53,6 +53,12 @@ pub struct Function {
     /// `__dict__` and frames built from this function share globals.
     /// `PY_NULL` for globals-less carriers (gateway builtins).
     pub w_func_globals_obj: PyObjectRef,
+    /// CPython 3.14 `PyFunctionObject.func_builtins` — resolved once from
+    /// globals at function construction and then exposed by the direct
+    /// read-only `__builtins__` member.  This is intentionally distinct from
+    /// frame builtin selection: replacing `globals['__builtins__']` later
+    /// does not change `function.__builtins__`.
+    pub w_builtins: PyObjectRef,
     /// `function.py:50 w_ann=None` constructor default plus
     /// `function.py:548-551 fget_func_annotations` lazy-init shape:
     /// PyPy stores the annotations dict directly on the function and
@@ -183,6 +189,8 @@ pub const FUNCTION_W_MODULE_OFFSET: usize = std::mem::offset_of!(Function, w_mod
 /// lazy-cached canonical W_DictObject for `w_func_globals`.
 pub const FUNCTION_W_FUNC_GLOBALS_OBJ_OFFSET: usize =
     std::mem::offset_of!(Function, w_func_globals_obj);
+/// Field offset of CPython 3.14 `func_builtins`.
+pub const FUNCTION_W_BUILTINS_OFFSET: usize = std::mem::offset_of!(Function, w_builtins);
 /// Field offset of `w_ann` within `Function` — the
 /// `function.py:50 w_ann` annotations dict slot.
 pub const FUNCTION_W_ANN_OFFSET: usize = std::mem::offset_of!(Function, w_ann);
@@ -244,7 +252,7 @@ pub const FUNCTION_OBJECT_SIZE: usize = std::mem::size_of::<Function>();
 /// W_FloatObject leave the typeptr-shaped header field out of their
 /// `gc_ptr_offsets`. W_TypeObject instances are static-region and
 /// not subject to nursery relocation.
-pub const FUNCTION_GC_PTR_OFFSETS: [usize; 14] = [
+pub const FUNCTION_GC_PTR_OFFSETS: [usize; 15] = [
     FUNCTION_CODE_OFFSET,
     FUNCTION_CLOSURE_OFFSET,
     FUNCTION_DEFS_W_OFFSET,
@@ -254,6 +262,8 @@ pub const FUNCTION_GC_PTR_OFFSETS: [usize; 14] = [
     // the function's sole globals carrier; traced for the lifetime of the
     // function so its `__globals__` identity survives minor collection.
     FUNCTION_W_FUNC_GLOBALS_OBJ_OFFSET,
+    // CPython 3.14 `func_builtins` — frozen at Function construction.
+    FUNCTION_W_BUILTINS_OFFSET,
     // `function.py:50 w_ann` — annotations dict, allocated lazily on
     // first read by the getter or stamped at MAKE_FUNCTION time.
     FUNCTION_W_ANN_OFFSET,
@@ -368,6 +378,24 @@ pub(crate) fn function_new_impl(
     // object directly as the function's sole globals carrier.
     pyre_object::gc_roots::pin_root(w_func_globals_obj);
 
+    // CPython 3.14 `_PyEval_BuiltinsFromGlobals` at function construction:
+    // retain the selected mapping identity even if the globals entry changes
+    // later.  Builtin/gateway carriers have no globals and keep a null slot.
+    let w_builtins = if w_func_globals_obj.is_null() {
+        PY_NULL
+    } else {
+        let selected = crate::baseobjspace::pick_builtin_obj(
+            w_func_globals_obj,
+            crate::call::take_last_exec_ctx(),
+        );
+        if !selected.is_null() && unsafe { pyre_object::is_module(selected) } {
+            unsafe { pyre_object::w_module_get_w_dict(selected) }
+        } else {
+            selected
+        }
+    };
+    pyre_object::gc_roots::pin_root(w_builtins);
+
     let name_ptr = pyre_object::lltype::malloc_raw(name) as *const String;
     let function = Function {
         ob: PyObject {
@@ -382,6 +410,7 @@ pub(crate) fn function_new_impl(
         w_kw_defs: PY_NULL,
         w_module: PY_NULL,
         w_func_globals_obj,
+        w_builtins,
         w_ann: PY_NULL,
         w_annotate: PY_NULL,
         w_func_dict: PY_NULL,
@@ -746,6 +775,13 @@ pub unsafe fn fget_func_name(obj: PyObjectRef) -> PyObjectRef {
 #[inline]
 pub unsafe fn function_get_globals_obj(obj: PyObjectRef) -> PyObjectRef {
     unsafe { (*(obj as *const Function)).w_func_globals_obj }
+}
+
+/// CPython 3.14 `PyFunctionObject.func_builtins`, resolved once during
+/// construction. Returns `PY_NULL` for globals-less builtin carriers.
+#[inline]
+pub unsafe fn function_get_builtins(obj: PyObjectRef) -> PyObjectRef {
+    unsafe { (*(obj as *const Function)).w_builtins }
 }
 
 /// Get the closure tuple from a function object.
@@ -2676,6 +2712,7 @@ mod tests {
                 std::mem::offset_of!(Function, w_kw_defs),
                 std::mem::offset_of!(Function, w_module),
                 std::mem::offset_of!(Function, w_func_globals_obj),
+                std::mem::offset_of!(Function, w_builtins),
                 std::mem::offset_of!(Function, w_ann),
                 std::mem::offset_of!(Function, w_annotate),
                 std::mem::offset_of!(Function, w_func_dict),

--- a/pyre/pyre-interpreter/src/function.rs
+++ b/pyre/pyre-interpreter/src/function.rs
@@ -2001,74 +2001,157 @@ pub unsafe fn descr_method__new__(
     _subtype: PyObjectRef,
     w_function: PyObjectRef,
     w_instance: PyObjectRef,
-    w_class: PyObjectRef,
-) -> PyObjectRef {
+) -> Result<PyObjectRef, crate::PyError> {
     let _ = _subtype;
-    if w_function.is_null() {
-        pyre_object::w_none()
-    } else {
-        pyre_object::w_method_new(w_function, w_instance, w_class)
+    if w_function.is_null() || !crate::baseobjspace::callable_w(w_function) {
+        return Err(crate::PyError::type_error(
+            "first argument must be callable",
+        ));
     }
+    if w_instance.is_null() || unsafe { pyre_object::is_none(w_instance) } {
+        return Err(crate::PyError::type_error("instance must not be None"));
+    }
+    let w_class = crate::typedef::r#type(w_instance).unwrap_or(pyre_object::PY_NULL);
+    Ok(pyre_object::w_method_new(w_function, w_instance, w_class))
 }
 
 #[inline]
 pub unsafe fn descr_method_get(
-    _func: PyObjectRef,
+    method: PyObjectRef,
     obj: PyObjectRef,
     cls: PyObjectRef,
-) -> PyObjectRef {
-    let _ = _func;
-    if obj.is_null() || unsafe { pyre_object::is_none(obj) } {
-        _func
+) -> Result<PyObjectRef, crate::PyError> {
+    let obj_is_none = obj.is_null() || unsafe { pyre_object::is_none(obj) };
+    let cls_is_none = cls.is_null() || unsafe { pyre_object::is_none(cls) };
+    if obj_is_none && cls_is_none {
+        return Err(crate::PyError::type_error("__get__(None, None) is invalid"));
+    }
+    Ok(method)
+}
+
+#[inline]
+pub fn descr_method_call(args: &[PyObjectRef]) -> crate::PyResult {
+    let (positional, kwargs) = crate::builtins::split_builtin_kwargs(args);
+    let method = positional.first().copied().unwrap_or(pyre_object::PY_NULL);
+    let call_args = positional.get(1..).unwrap_or(&[]);
+    if !crate::builtins::has_real_kwargs(kwargs) {
+        return crate::call::call_function_impl_result(method, call_args);
+    }
+    let keyword_args: Vec<(rustpython_wtf8::Wtf8Buf, PyObjectRef)> = unsafe {
+        pyre_object::w_dict_str_entries(kwargs.unwrap())
+            .into_iter()
+            .filter(|(name, _)| name != "__pyre_kw__")
+            .map(|(name, value)| (rustpython_wtf8::Wtf8Buf::from_string(name), value))
+            .collect()
+    };
+    crate::eval::CURRENT_FRAME.with(|current| {
+        let frame = current.get();
+        if frame.is_null() {
+            return Err(crate::PyError::runtime_error(
+                "method call has no current frame",
+            ));
+        }
+        crate::call::call_with_kwargs(unsafe { &mut *frame }, method, call_args, &keyword_args)
+    })
+}
+
+#[inline]
+pub unsafe fn descr_method_eq(
+    this: PyObjectRef,
+    other: PyObjectRef,
+) -> Result<PyObjectRef, crate::PyError> {
+    if !unsafe { pyre_object::is_method(other) } {
+        return Ok(pyre_object::special::w_not_implemented());
+    }
+    let funcs_equal =
+        crate::baseobjspace::eq_w(unsafe { pyre_object::w_method_get_func(this) }, unsafe {
+            pyre_object::w_method_get_func(other)
+        })?;
+    let selves_identical =
+        unsafe { pyre_object::w_method_get_self(this) == pyre_object::w_method_get_self(other) };
+    Ok(pyre_object::w_bool_from(funcs_equal && selves_identical))
+}
+
+#[inline]
+pub unsafe fn descr_method_ne(
+    this: PyObjectRef,
+    other: PyObjectRef,
+) -> Result<PyObjectRef, crate::PyError> {
+    let equal = unsafe { descr_method_eq(this, other)? };
+    if unsafe { pyre_object::is_not_implemented(equal) } {
+        Ok(equal)
     } else {
-        let owner = if cls.is_null() {
-            pyre_object::w_none()
-        } else {
-            cls
-        };
-        pyre_object::w_method_new(_func, obj, owner)
+        Ok(pyre_object::w_bool_from(!unsafe {
+            pyre_object::w_bool_get_value(equal)
+        }))
     }
 }
 
 #[inline]
-pub unsafe fn descr_method_call(obj: PyObjectRef, args: &[PyObjectRef]) -> PyObjectRef {
-    if args.is_empty() {
-        call_obj_args(obj, pyre_object::w_none(), args)
-    } else {
-        call_obj_args(obj, args[0], &args[1..])
+pub unsafe fn descr_method_repr(obj: PyObjectRef) -> Result<PyObjectRef, crate::PyError> {
+    let function = unsafe { pyre_object::w_method_get_func(obj) };
+    let instance = unsafe { pyre_object::w_method_get_self(obj) };
+    let w_name = match crate::baseobjspace::getattr_str(function, "__qualname__") {
+        Ok(value) => Some(value),
+        Err(err) if err.kind == crate::PyErrorKind::AttributeError => {
+            match crate::baseobjspace::getattr_str(function, "__name__") {
+                Ok(value) => Some(value),
+                Err(err) if err.kind == crate::PyErrorKind::AttributeError => None,
+                Err(err) => return Err(err),
+            }
+        }
+        Err(err) => return Err(err),
+    };
+    let name = w_name
+        .filter(|&value| unsafe { pyre_object::is_str(value) })
+        .and_then(|value| unsafe { pyre_object::w_str_get_value_opt(value) })
+        .unwrap_or("?");
+    let instance_repr = unsafe { crate::display::py_repr(instance)? };
+    Ok(pyre_object::w_str_new(&format!(
+        "<bound method {name} of {instance_repr}>"
+    )))
+}
+
+#[inline]
+pub unsafe fn descr_method_getattribute(
+    obj: PyObjectRef,
+    name: PyObjectRef,
+) -> Result<PyObjectRef, crate::PyError> {
+    let Some(name) = (unsafe { pyre_object::w_str_get_value_opt(name) }) else {
+        return Err(crate::PyError::type_error("attribute name must be string"));
+    };
+    // function.py:604-614 — method attributes win, except `__doc__`;
+    // an AttributeError falls back to the wrapped function.
+    if name != "__doc__" {
+        match crate::baseobjspace::object_getattribute(obj, name) {
+            Ok(value) => return Ok(value),
+            Err(err) if err.kind == crate::PyErrorKind::AttributeError => {}
+            Err(err) => return Err(err),
+        }
     }
+    let function = unsafe { pyre_object::w_method_get_func(obj) };
+    crate::baseobjspace::getattr_str(function, name)
 }
 
 #[inline]
-pub unsafe fn descr_method_eq(_self: PyObjectRef, other: PyObjectRef) -> bool {
-    _self == other
+pub unsafe fn descr_method_hash(obj: PyObjectRef) -> Result<i64, crate::PyError> {
+    let function = unsafe { pyre_object::w_method_get_func(obj) };
+    let instance = unsafe { pyre_object::w_method_get_self(obj) };
+    let x = pyre_object::gc_hook::gc_identity_hash(instance as usize) as i64;
+    let y = crate::baseobjspace::hash_w_strict(function)?;
+    let value = x ^ y;
+    Ok(if value == -1 { -2 } else { value })
 }
 
 #[inline]
-pub unsafe fn descr_method_ne(_self: PyObjectRef, other: PyObjectRef) -> bool {
-    _self != other
-}
-
-#[inline]
-pub unsafe fn descr_method_repr(obj: PyObjectRef) -> PyObjectRef {
-    pyre_object::w_str_new(&format!("method {obj:?}"))
-}
-
-#[inline]
-pub unsafe fn descr_method_getattribute(obj: PyObjectRef, _name: PyObjectRef) -> PyObjectRef {
-    let _ = _name;
-    obj
-}
-
-#[inline]
-pub unsafe fn descr_method_hash(_self: PyObjectRef) -> isize {
-    _self as isize
-}
-
-#[inline]
-pub unsafe fn descr_method__reduce__(_obj: PyObjectRef) -> PyObjectRef {
-    let _ = _obj;
-    pyre_object::w_tuple_new(vec![pyre_object::w_str_new("method")])
+pub unsafe fn descr_method__reduce__(obj: PyObjectRef) -> Result<PyObjectRef, crate::PyError> {
+    let function = unsafe { pyre_object::w_method_get_func(obj) };
+    let instance = unsafe { pyre_object::w_method_get_self(obj) };
+    let name = crate::baseobjspace::getattr_str(function, "__name__")?;
+    Ok(pyre_object::w_tuple_new(vec![
+        crate::baseobjspace::builtin_callable("getattr"),
+        pyre_object::w_tuple_new(vec![instance, name]),
+    ]))
 }
 
 #[inline]

--- a/pyre/pyre-interpreter/src/function.rs
+++ b/pyre/pyre-interpreter/src/function.rs
@@ -2658,9 +2658,8 @@ mod tests {
         );
     }
 
-    /// `FUNCTION_GC_PTR_OFFSETS` must list the five inline
-    /// `PyObjectRef`-shaped fields the GC traces (the four
-    /// `PyObjectRef` payload fields plus `code`, which is `*const ()`
+    /// `FUNCTION_GC_PTR_OFFSETS` must list every inline
+    /// `PyObjectRef`-shaped field the GC traces (`code` is `*const ()`
     /// but points at a `[ob: PyObject, ...]`-prefixed Code object so
     /// the walker can interpret it as a typed reference). If a new GC
     /// field is added to `Function` (or one of these fields is removed)
@@ -2679,6 +2678,8 @@ mod tests {
                 std::mem::offset_of!(Function, w_func_globals_obj),
                 std::mem::offset_of!(Function, w_ann),
                 std::mem::offset_of!(Function, w_annotate),
+                std::mem::offset_of!(Function, w_func_dict),
+                std::mem::offset_of!(Function, w_typeparams),
                 std::mem::offset_of!(Function, w_doc),
                 std::mem::offset_of!(Function, w_qualname),
                 std::mem::offset_of!(Function, w_objclass),

--- a/pyre/pyre-interpreter/src/function.rs
+++ b/pyre/pyre-interpreter/src/function.rs
@@ -73,6 +73,13 @@ pub struct Function {
     /// PEP 649); the typed slot mirrors how `w_ann` sits on the
     /// function object rather than a side table.
     pub w_annotate: PyObjectRef,
+    /// `function.py:68 self.w_func_dict = None` — lazily allocated
+    /// per-function attribute dictionary.  This is a field on the function,
+    /// not mapdict side storage, matching PyPy's `Function.getdict`.
+    pub w_func_dict: PyObjectRef,
+    /// CPython 3.14 `PyFunctionObject.func_typeparams` — the declared type
+    /// parameters tuple.  `PY_NULL` represents the default empty tuple.
+    pub w_typeparams: PyObjectRef,
     /// `function.py:375 self.w_doc = w_doc` constructor slot plus
     /// `function.py:446-449 fget_func_doc` cache:
     ///
@@ -182,6 +189,10 @@ pub const FUNCTION_W_ANN_OFFSET: usize = std::mem::offset_of!(Function, w_ann);
 /// Field offset of `w_annotate` within `Function` — the PEP 649
 /// `__annotate__` callable slot.
 pub const FUNCTION_W_ANNOTATE_OFFSET: usize = std::mem::offset_of!(Function, w_annotate);
+/// Field offset of PyPy `Function.w_func_dict`.
+pub const FUNCTION_W_FUNC_DICT_OFFSET: usize = std::mem::offset_of!(Function, w_func_dict);
+/// Field offset of CPython 3.14 `func_typeparams`.
+pub const FUNCTION_W_TYPEPARAMS_OFFSET: usize = std::mem::offset_of!(Function, w_typeparams);
 /// Field offset of `w_doc` within `Function` — the
 /// `function.py:375 w_doc` docstring cache slot.
 pub const FUNCTION_W_DOC_OFFSET: usize = std::mem::offset_of!(Function, w_doc);
@@ -233,7 +244,7 @@ pub const FUNCTION_OBJECT_SIZE: usize = std::mem::size_of::<Function>();
 /// W_FloatObject leave the typeptr-shaped header field out of their
 /// `gc_ptr_offsets`. W_TypeObject instances are static-region and
 /// not subject to nursery relocation.
-pub const FUNCTION_GC_PTR_OFFSETS: [usize; 12] = [
+pub const FUNCTION_GC_PTR_OFFSETS: [usize; 14] = [
     FUNCTION_CODE_OFFSET,
     FUNCTION_CLOSURE_OFFSET,
     FUNCTION_DEFS_W_OFFSET,
@@ -250,6 +261,10 @@ pub const FUNCTION_GC_PTR_OFFSETS: [usize; 12] = [
     // Annotate flag; live until the first `__annotations__` read
     // materialises `w_ann`.
     FUNCTION_W_ANNOTATE_OFFSET,
+    // `function.py:68 w_func_dict` — lazily allocated instance dict.
+    FUNCTION_W_FUNC_DICT_OFFSET,
+    // CPython 3.14 `func_typeparams` — tuple or null for the empty default.
+    FUNCTION_W_TYPEPARAMS_OFFSET,
     // `function.py:375 w_doc` — docstring slot cached on first read.
     FUNCTION_W_DOC_OFFSET,
     // `function.py:54 qualname` — qualified name slot stamped at
@@ -369,6 +384,8 @@ pub(crate) fn function_new_impl(
         w_func_globals_obj,
         w_ann: PY_NULL,
         w_annotate: PY_NULL,
+        w_func_dict: PY_NULL,
+        w_typeparams: PY_NULL,
         w_doc: PY_NULL,
         w_qualname: PY_NULL,
         w_objclass: PY_NULL,
@@ -786,7 +803,14 @@ pub unsafe fn function_set_kwdefaults(obj: PyObjectRef, kwdefaults: PyObjectRef)
 /// PyPy-compatible `__dict__` storage field alias.
 #[inline]
 pub unsafe fn function_getdict(obj: PyObjectRef) -> PyObjectRef {
-    crate::baseobjspace::getattr_str(obj, "__dict__").unwrap_or(pyre_object::w_none())
+    unsafe {
+        let func = obj as *mut Function;
+        if (*func).w_func_dict.is_null() {
+            function_write_barrier(obj);
+            (*func).w_func_dict = pyre_object::w_dict_new();
+        }
+        (*func).w_func_dict
+    }
 }
 
 /// `function.py:238 Function.setdict` — replace the function's instance
@@ -795,7 +819,79 @@ pub unsafe fn function_getdict(obj: PyObjectRef) -> PyObjectRef {
 /// "__dict__", ..)` which would store a literal `"__dict__"` dict entry.
 #[inline]
 pub unsafe fn function_setdict(obj: PyObjectRef, value: PyObjectRef) -> Result<(), crate::PyError> {
-    crate::baseobjspace::setdict(obj, value)
+    let w_dict_type = crate::typedef::gettypeobject(&pyre_object::pyobject::DICT_TYPE);
+    if !unsafe { crate::baseobjspace::isinstance_w(value, w_dict_type) } {
+        return Err(crate::PyError::type_error(
+            "setting function's dictionary to a non-dict",
+        ));
+    }
+    unsafe {
+        function_write_barrier(obj);
+        (*(obj as *mut Function)).w_func_dict = value;
+    }
+    Ok(())
+}
+
+/// CPython 3.14 `function.__annotate__` getter.
+pub unsafe fn function_get_annotate(obj: PyObjectRef) -> PyObjectRef {
+    let value = unsafe { (*(obj as *const Function)).w_annotate };
+    if value.is_null() {
+        pyre_object::w_none()
+    } else {
+        value
+    }
+}
+
+/// CPython 3.14 `function.__annotate__` setter.
+pub unsafe fn function_set_annotate(
+    obj: PyObjectRef,
+    value: PyObjectRef,
+) -> Result<(), crate::PyError> {
+    if value.is_null() {
+        return Err(crate::PyError::type_error("__annotate__ cannot be deleted"));
+    }
+    if !pyre_object::is_none(value) && !crate::baseobjspace::callable_w(value) {
+        return Err(crate::PyError::type_error(
+            "__annotate__ must be callable or None",
+        ));
+    }
+    unsafe {
+        function_write_barrier(obj);
+        let func = obj as *mut Function;
+        (*func).w_annotate = value;
+        if !pyre_object::is_none(value) {
+            (*func).w_ann = PY_NULL;
+        }
+    }
+    Ok(())
+}
+
+/// CPython 3.14 `function.__type_params__` getter.
+pub unsafe fn function_get_typeparams(obj: PyObjectRef) -> PyObjectRef {
+    let value = unsafe { (*(obj as *const Function)).w_typeparams };
+    if value.is_null() {
+        pyre_object::w_tuple_new(vec![])
+    } else {
+        value
+    }
+}
+
+/// CPython 3.14 `function.__type_params__` setter and
+/// `_Py_set_function_type_params` opcode helper.
+pub unsafe fn function_set_typeparams(
+    obj: PyObjectRef,
+    value: PyObjectRef,
+) -> Result<(), crate::PyError> {
+    if value.is_null() || !pyre_object::is_tuple(value) {
+        return Err(crate::PyError::type_error(
+            "__type_params__ must be set to a tuple",
+        ));
+    }
+    unsafe {
+        function_write_barrier(obj);
+        (*(obj as *mut Function)).w_typeparams = value;
+    }
+    Ok(())
 }
 
 /// PyPy-compatible `getdict()` descriptor helper.
@@ -982,7 +1078,9 @@ pub unsafe fn function_set_annotations(obj: PyObjectRef, w_ann: PyObjectRef) {
             return;
         }
         function_write_barrier(obj);
-        (*(obj as *mut Function)).w_ann = w_ann;
+        let func = obj as *mut Function;
+        (*func).w_ann = w_ann;
+        (*func).w_annotate = PY_NULL;
     }
 }
 
@@ -1019,7 +1117,11 @@ pub unsafe fn fset_func_annotations(
             return Err(crate::PyError::type_error("__annotations__ must be a dict"));
         };
         function_write_barrier(obj);
-        (*(obj as *mut Function)).w_ann = stored;
+        let func = obj as *mut Function;
+        (*func).w_ann = stored;
+        // CPython 3.14 function___annotations___set_impl clears the lazy
+        // annotation callable whenever eager annotations are assigned.
+        (*func).w_annotate = PY_NULL;
         Ok(())
     }
 }
@@ -1041,7 +1143,9 @@ pub unsafe fn fdel_func_annotations(obj: PyObjectRef) -> Result<(), crate::PyErr
             return Ok(());
         }
         function_write_barrier(obj);
-        (*(obj as *mut Function)).w_ann = PY_NULL;
+        let func = obj as *mut Function;
+        (*func).w_ann = PY_NULL;
+        (*func).w_annotate = PY_NULL;
         Ok(())
     }
 }

--- a/pyre/pyre-interpreter/src/function.rs
+++ b/pyre/pyre-interpreter/src/function.rs
@@ -2221,11 +2221,7 @@ pub fn funccall_valuestack(
         let natural_arity = fast_natural_arity & 0xff;
         if nargs < natural_arity {
             let raw_defs = unsafe { crate::function_get_defaults(func) };
-            let defs = if raw_defs.is_null() {
-                std::ptr::null_mut()
-            } else {
-                crate::baseobjspace::unwrap_cell(raw_defs)
-            };
+            let defs = raw_defs;
             let defs_len = if defs.is_null() || !unsafe { pyre_object::is_tuple(defs) } {
                 0
             } else {

--- a/pyre/pyre-interpreter/src/function.rs
+++ b/pyre/pyre-interpreter/src/function.rs
@@ -11,7 +11,8 @@ use pyre_object::pyobject::*;
 /// Type descriptor for user-defined functions.
 pub static FUNCTION_TYPE: PyType = pyre_object::pyobject::new_pytype("function");
 /// Type descriptor for module-level builtins.
-pub static BUILTIN_FUNCTION_TYPE: PyType = pyre_object::pyobject::new_pytype("builtin_function");
+pub static BUILTIN_FUNCTION_TYPE: PyType =
+    pyre_object::pyobject::new_pytype("builtin_function_or_method");
 
 /// User-defined function object.
 ///
@@ -130,6 +131,11 @@ pub struct Function {
     /// has no `__self__`); only stamped on the per-type builtin
     /// `__new__` carriers at type-finalisation time.
     pub w_new_self: PyObjectRef,
+    /// function.py:797-815 `BuiltinFunction.w_moduleobj` — the module object
+    /// bound as `__self__` for an interp-level module function. PyPy stores
+    /// this on each BuiltinFunction; CPython 3.14 likewise exposes the
+    /// defining module object from `PyCFunction_GET_SELF`.
+    pub w_moduleobj: PyObjectRef,
 }
 
 /// function.py:706 — `class BuiltinFunction(Function): can_change_code = False`
@@ -217,6 +223,8 @@ pub const FUNCTION_W_TEXT_SIGNATURE_OFFSET: usize =
 /// Field offset of `w_new_self` within `Function` — the builtin
 /// `__new__` descriptor's `__self__` (defining type).
 pub const FUNCTION_W_NEW_SELF_OFFSET: usize = std::mem::offset_of!(Function, w_new_self);
+/// Field offset of PyPy `BuiltinFunction.w_moduleobj`.
+pub const FUNCTION_W_MODULEOBJ_OFFSET: usize = std::mem::offset_of!(Function, w_moduleobj);
 
 /// GC type id assigned to `Function` at JitDriver init time. Held as
 /// a constant alongside the struct (rather than runtime-queried) so
@@ -252,7 +260,7 @@ pub const FUNCTION_OBJECT_SIZE: usize = std::mem::size_of::<Function>();
 /// W_FloatObject leave the typeptr-shaped header field out of their
 /// `gc_ptr_offsets`. W_TypeObject instances are static-region and
 /// not subject to nursery relocation.
-pub const FUNCTION_GC_PTR_OFFSETS: [usize; 15] = [
+pub const FUNCTION_GC_PTR_OFFSETS: [usize; 16] = [
     FUNCTION_CODE_OFFSET,
     FUNCTION_CLOSURE_OFFSET,
     FUNCTION_DEFS_W_OFFSET,
@@ -289,6 +297,8 @@ pub const FUNCTION_GC_PTR_OFFSETS: [usize; 15] = [
     // `w_new_self` is intentionally absent: it holds the defining type
     // of a builtin `__new__` carrier, a static-region W_TypeObject that
     // is never nursery-relocated (same reasoning as `ob.w_class`).
+    // PyPy `BuiltinFunction.w_moduleobj` is an ordinary GC module reference.
+    FUNCTION_W_MODULEOBJ_OFFSET,
 ];
 
 impl pyre_object::lltype::GcType for Function {
@@ -420,6 +430,7 @@ pub(crate) fn function_new_impl(
         w_objclass: PY_NULL,
         w_text_signature: PY_NULL,
         w_new_self: PY_NULL,
+        w_moduleobj: PY_NULL,
     };
 
     // A `BuiltinCode`-backed function is a permanent type / module slot (the
@@ -554,6 +565,16 @@ pub unsafe fn builtin_function_set_module(obj: PyObjectRef, w_module: PyObjectRe
     }
 }
 
+/// CPython 3.14 `PyCFunctionObject.m_module` member assignment. Unlike
+/// PyPy's shared Function getset, builtin `__module__` is a writable direct
+/// member and accepts any object; deletion stores `None`.
+pub unsafe fn builtin_function_set_module_attr(obj: PyObjectRef, value: PyObjectRef) {
+    unsafe {
+        function_write_barrier(obj);
+        (*(obj as *mut Function)).w_module = value;
+    }
+}
+
 /// Stamp the `__self__` of a builtin `__new__` carrier — the defining
 /// type whose `tp_new` it wraps (`typeobject.c add_tp_new_wrapper`).
 /// Only touches functions whose `w_new_self` is still unset, so an
@@ -579,11 +600,33 @@ pub unsafe fn function_set_new_self(obj: PyObjectRef, w_type: PyObjectRef) {
 /// # Safety
 /// `obj` must be a valid, non-null pointer to a `Function`.
 pub unsafe fn function_get_self_or_none(obj: PyObjectRef) -> PyObjectRef {
-    let w_self = unsafe { (*(obj as *const Function)).w_new_self };
+    let func = unsafe { &*(obj as *const Function) };
+    let w_self = if !func.w_moduleobj.is_null() {
+        func.w_moduleobj
+    } else {
+        func.w_new_self
+    };
     if w_self.is_null() {
         pyre_object::w_none()
     } else {
         w_self
+    }
+}
+
+/// Stamp PyPy `BuiltinFunction.w_moduleobj` after the defining module object
+/// has been created. The module name is installed first through
+/// `builtin_function_set_module`; this second field preserves the distinct
+/// `__module__` (string) / `__self__` (module object) identities.
+///
+/// # Safety
+/// `obj` must be a valid PyObjectRef. Non-builtin functions are ignored.
+pub unsafe fn builtin_function_set_module_obj(obj: PyObjectRef, w_module: PyObjectRef) {
+    unsafe {
+        if py_type_check(obj, &BUILTIN_FUNCTION_TYPE) {
+            let func = obj as *mut Function;
+            function_write_barrier(obj);
+            (*func).w_moduleobj = w_module;
+        }
     }
 }
 
@@ -2722,6 +2765,7 @@ mod tests {
                 std::mem::offset_of!(Function, w_qualname),
                 std::mem::offset_of!(Function, w_objclass),
                 std::mem::offset_of!(Function, w_text_signature),
+                std::mem::offset_of!(Function, w_moduleobj),
             ]
         );
     }

--- a/pyre/pyre-interpreter/src/importing.rs
+++ b/pyre/pyre-interpreter/src/importing.rs
@@ -861,6 +861,15 @@ fn load_builtin_module(name: &str) -> Option<PyObjectRef> {
         }
     }
     let module = pyre_object::w_module_new_aliasing_dict(name, w_dict);
+    // function.py:797-815 BuiltinFunction.w_moduleobj — MixedModule binds
+    // every interp-level function to the live defining module object.
+    for key in &keys {
+        if let Some(value) =
+            unsafe { pyre_object::dictmultiobject::w_dict_getitem_str(w_dict, key) }
+        {
+            unsafe { crate::function::builtin_function_set_module_obj(value, module) };
+        }
+    }
     // `pypy/interpreter/baseobjspace.py:647` installs the self
     // reference `space.builtin.w_dict['__builtins__'] = space.builtin`
     // so user code can reach the builtins module through

--- a/pyre/pyre-interpreter/src/module/_codecs/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_codecs/mod.rs
@@ -101,24 +101,8 @@ fn normalize(encoding: &str) -> String {
 }
 
 fn is_callable(obj: PyObjectRef) -> bool {
-    if obj.is_null() {
-        return false;
-    }
-    unsafe {
-        if crate::is_function(obj)
-            || pyre_object::is_method(obj)
-            || pyre_object::is_type(obj)
-            || pyre_object::is_staticmethod(obj)
-            || pyre_object::is_classmethod(obj)
-        {
-            return true;
-        }
-        if pyre_object::is_instance(obj) {
-            let w_type = pyre_object::w_instance_get_type(obj);
-            return crate::baseobjspace::lookup_in_type(w_type, "__call__").is_some();
-        }
-    }
-    false
+    // interp_codecs.py:151/663 `space.is_true(space.callable(...))`.
+    !obj.is_null() && crate::baseobjspace::callable_w(obj)
 }
 
 struct CodecException {

--- a/pyre/pyre-interpreter/src/module/_weakref/interp__weakref.rs
+++ b/pyre/pyre-interpreter/src/module/_weakref/interp__weakref.rs
@@ -751,24 +751,8 @@ fn is_w_weakref(obj: PyObjectRef) -> bool {
 }
 
 fn is_callable(obj: PyObjectRef) -> bool {
-    if obj.is_null() {
-        return false;
-    }
-    unsafe {
-        if crate::is_function(obj)
-            || pyre_object::is_method(obj)
-            || pyre_object::is_type(obj)
-            || pyre_object::is_staticmethod(obj)
-            || pyre_object::is_classmethod(obj)
-        {
-            return true;
-        }
-        if pyre_object::is_instance(obj) {
-            let w_type = pyre_object::w_instance_get_type(obj);
-            return crate::baseobjspace::lookup_in_type(w_type, "__call__").is_some();
-        }
-    }
-    false
+    // interp__weakref.py:87/124 `space.is_true(space.callable(w_obj))`.
+    !obj.is_null() && crate::baseobjspace::callable_w(obj)
 }
 
 // ── module-level helpers ──────────────────────────────────────────────

--- a/pyre/pyre-interpreter/src/objspace/descroperation.rs
+++ b/pyre/pyre-interpreter/src/objspace/descroperation.rs
@@ -17,7 +17,7 @@ use rustpython_wtf8::Wtf8Buf;
 
 use crate::baseobjspace::{
     getattr, getitem, is_true, issubtype_w, lookup, lookup_in_type, lookup_in_type_where,
-    lookup_where_with_method_cache, p_abstract_issubclass_w, unwrap_cell,
+    lookup_where_with_method_cache, p_abstract_issubclass_w,
 };
 pub use crate::{PyError, PyErrorKind, PyResult};
 
@@ -1917,8 +1917,6 @@ unsafe fn try_numeric_unaryop_override(a: PyObjectRef, dunder: &str) -> Option<P
 }
 
 pub fn add(a: PyObjectRef, b: PyObjectRef) -> PyResult {
-    let a = unwrap_cell(a);
-    let b = unwrap_cell(b);
     unsafe {
         if needs_numeric_binop_dispatch(a, b, "__add__", "__radd__") {
             if let Some(result) = try_dispatch_binary_special(a, b, "__add__", "__radd__")? {
@@ -2013,8 +2011,6 @@ pub fn add(a: PyObjectRef, b: PyObjectRef) -> PyResult {
 }
 
 pub fn matmul(a: PyObjectRef, b: PyObjectRef) -> PyResult {
-    let a = unwrap_cell(a);
-    let b = unwrap_cell(b);
     unsafe {
         if let Some(result) = try_dispatch_binary_special(a, b, "__matmul__", "__rmatmul__")? {
             return Ok(result);
@@ -2028,8 +2024,6 @@ pub fn matmul(a: PyObjectRef, b: PyObjectRef) -> PyResult {
 }
 
 pub fn sub(a: PyObjectRef, b: PyObjectRef) -> PyResult {
-    let a = unwrap_cell(a);
-    let b = unwrap_cell(b);
     unsafe {
         let set_override = needs_set_binop_dispatch(a, b);
         if set_override {
@@ -2083,8 +2077,6 @@ pub fn sub(a: PyObjectRef, b: PyObjectRef) -> PyResult {
 }
 
 pub fn mul(a: PyObjectRef, b: PyObjectRef) -> PyResult {
-    let a = unwrap_cell(a);
-    let b = unwrap_cell(b);
     unsafe {
         if needs_numeric_binop_dispatch(a, b, "__mul__", "__rmul__") {
             if let Some(result) = try_dispatch_binary_special(a, b, "__mul__", "__rmul__")? {
@@ -2176,8 +2168,6 @@ pub fn mul(a: PyObjectRef, b: PyObjectRef) -> PyResult {
 }
 
 pub fn floordiv(a: PyObjectRef, b: PyObjectRef) -> PyResult {
-    let a = unwrap_cell(a);
-    let b = unwrap_cell(b);
     unsafe {
         if needs_numeric_binop_dispatch(a, b, "__floordiv__", "__rfloordiv__") {
             if let Some(result) =
@@ -2210,8 +2200,6 @@ pub fn floordiv(a: PyObjectRef, b: PyObjectRef) -> PyResult {
 }
 
 pub fn mod_(a: PyObjectRef, b: PyObjectRef) -> PyResult {
-    let a = unwrap_cell(a);
-    let b = unwrap_cell(b);
     unsafe {
         if needs_numeric_binop_dispatch(a, b, "__mod__", "__rmod__") {
             if let Some(result) = try_dispatch_binary_special(a, b, "__mod__", "__rmod__")? {
@@ -2276,8 +2264,6 @@ pub fn mod_(a: PyObjectRef, b: PyObjectRef) -> PyResult {
 /// `rbigint.truediv` and reissues it as
 /// "integer division result too large for a float".
 pub fn truediv(a: PyObjectRef, b: PyObjectRef) -> PyResult {
-    let a = unwrap_cell(a);
-    let b = unwrap_cell(b);
     unsafe {
         if needs_numeric_binop_dispatch(a, b, "__truediv__", "__rtruediv__") {
             if let Some(result) = try_dispatch_binary_special(a, b, "__truediv__", "__rtruediv__")?
@@ -2320,8 +2306,6 @@ pub fn truediv(a: PyObjectRef, b: PyObjectRef) -> PyResult {
 /// Power operation dispatch (`**` operator).
 
 pub fn pow(a: PyObjectRef, b: PyObjectRef) -> PyResult {
-    let a = unwrap_cell(a);
-    let b = unwrap_cell(b);
     unsafe {
         if needs_numeric_binop_dispatch(a, b, "__pow__", "__rpow__") {
             if let Some(result) = try_dispatch_binary_special(a, b, "__pow__", "__rpow__")? {
@@ -2373,8 +2357,6 @@ pub fn pow(a: PyObjectRef, b: PyObjectRef) -> PyResult {
 // NotImplemented is reached only defensively.
 
 pub(crate) fn add_builtin(a: PyObjectRef, b: PyObjectRef) -> PyResult {
-    let a = unwrap_cell(a);
-    let b = unwrap_cell(b);
     unsafe {
         if is_int_like(a) && is_int_like(b) {
             return int_add(a, b);
@@ -2393,8 +2375,6 @@ pub(crate) fn add_builtin(a: PyObjectRef, b: PyObjectRef) -> PyResult {
 }
 
 pub(crate) fn sub_builtin(a: PyObjectRef, b: PyObjectRef) -> PyResult {
-    let a = unwrap_cell(a);
-    let b = unwrap_cell(b);
     unsafe {
         if is_int_like(a) && is_int_like(b) {
             return int_sub(a, b);
@@ -2413,8 +2393,6 @@ pub(crate) fn sub_builtin(a: PyObjectRef, b: PyObjectRef) -> PyResult {
 }
 
 pub(crate) fn mul_builtin(a: PyObjectRef, b: PyObjectRef) -> PyResult {
-    let a = unwrap_cell(a);
-    let b = unwrap_cell(b);
     unsafe {
         if is_int_like(a) && is_int_like(b) {
             return int_mul(a, b);
@@ -2433,8 +2411,6 @@ pub(crate) fn mul_builtin(a: PyObjectRef, b: PyObjectRef) -> PyResult {
 }
 
 pub(crate) fn truediv_builtin(a: PyObjectRef, b: PyObjectRef) -> PyResult {
-    let a = unwrap_cell(a);
-    let b = unwrap_cell(b);
     unsafe {
         let a_num = is_int(a) || is_float(a) || is_long(a);
         let b_num = is_int(b) || is_float(b) || is_long(b);
@@ -2459,8 +2435,6 @@ pub(crate) fn truediv_builtin(a: PyObjectRef, b: PyObjectRef) -> PyResult {
 }
 
 pub(crate) fn floordiv_builtin(a: PyObjectRef, b: PyObjectRef) -> PyResult {
-    let a = unwrap_cell(a);
-    let b = unwrap_cell(b);
     unsafe {
         if is_int_like(a) && is_int_like(b) {
             return int_floordiv(a, b);
@@ -2476,8 +2450,6 @@ pub(crate) fn floordiv_builtin(a: PyObjectRef, b: PyObjectRef) -> PyResult {
 }
 
 pub(crate) fn mod_builtin(a: PyObjectRef, b: PyObjectRef) -> PyResult {
-    let a = unwrap_cell(a);
-    let b = unwrap_cell(b);
     unsafe {
         if is_int_like(a) && is_int_like(b) {
             return int_mod(a, b);
@@ -2493,8 +2465,6 @@ pub(crate) fn mod_builtin(a: PyObjectRef, b: PyObjectRef) -> PyResult {
 }
 
 pub(crate) fn pow_builtin(a: PyObjectRef, b: PyObjectRef) -> PyResult {
-    let a = unwrap_cell(a);
-    let b = unwrap_cell(b);
     unsafe {
         if is_int_like(a) && is_int_like(b) {
             return int_pow(a, b);
@@ -2517,8 +2487,6 @@ pub(crate) fn pow_builtin(a: PyObjectRef, b: PyObjectRef) -> PyResult {
 }
 
 pub(crate) fn divmod_builtin(a: PyObjectRef, b: PyObjectRef) -> PyResult {
-    let a = unwrap_cell(a);
-    let b = unwrap_cell(b);
     unsafe {
         let lhs_num = is_int(a) || is_long(a) || is_float(a);
         let rhs_num = is_int(b) || is_long(b) || is_float(b);
@@ -2532,8 +2500,6 @@ pub(crate) fn divmod_builtin(a: PyObjectRef, b: PyObjectRef) -> PyResult {
 }
 
 pub(crate) fn lshift_builtin(a: PyObjectRef, b: PyObjectRef) -> PyResult {
-    let a = unwrap_cell(a);
-    let b = unwrap_cell(b);
     unsafe {
         if is_int_like(a) && is_int_like(b) {
             return int_lshift(a, b);
@@ -2546,8 +2512,6 @@ pub(crate) fn lshift_builtin(a: PyObjectRef, b: PyObjectRef) -> PyResult {
 }
 
 pub(crate) fn rshift_builtin(a: PyObjectRef, b: PyObjectRef) -> PyResult {
-    let a = unwrap_cell(a);
-    let b = unwrap_cell(b);
     unsafe {
         if is_int_like(a) && is_int_like(b) {
             return int_rshift(a, b);
@@ -2560,8 +2524,6 @@ pub(crate) fn rshift_builtin(a: PyObjectRef, b: PyObjectRef) -> PyResult {
 }
 
 pub(crate) fn and_builtin(a: PyObjectRef, b: PyObjectRef) -> PyResult {
-    let a = unwrap_cell(a);
-    let b = unwrap_cell(b);
     unsafe {
         // int.__and__ — bool operands are treated as ints; the bool-typed
         // result is produced by bool.__and__ (init_bool_type), not here.
@@ -2576,8 +2538,6 @@ pub(crate) fn and_builtin(a: PyObjectRef, b: PyObjectRef) -> PyResult {
 }
 
 pub(crate) fn or_builtin(a: PyObjectRef, b: PyObjectRef) -> PyResult {
-    let a = unwrap_cell(a);
-    let b = unwrap_cell(b);
     unsafe {
         if is_int(a) && is_int(b) {
             return int_bitor(a, b);
@@ -2590,8 +2550,6 @@ pub(crate) fn or_builtin(a: PyObjectRef, b: PyObjectRef) -> PyResult {
 }
 
 pub(crate) fn xor_builtin(a: PyObjectRef, b: PyObjectRef) -> PyResult {
-    let a = unwrap_cell(a);
-    let b = unwrap_cell(b);
     unsafe {
         if is_int(a) && is_int(b) {
             return int_bitxor(a, b);
@@ -2873,9 +2831,6 @@ pub(crate) fn ternary_builtin_type_error(
 /// forward `NotImplemented` raises the three-operand type error rather than
 /// falling through to the right operand.
 pub fn pow3(base: PyObjectRef, exp: PyObjectRef, modulus: PyObjectRef) -> PyResult {
-    let base = unwrap_cell(base);
-    let exp = unwrap_cell(exp);
-    let modulus = unwrap_cell(modulus);
     if unsafe { is_none(modulus) } {
         return pow(base, exp);
     }
@@ -2898,8 +2853,6 @@ pub fn pow3(base: PyObjectRef, exp: PyObjectRef, modulus: PyObjectRef) -> PyResu
 /// fast path then forward + reverse special-method dispatch with the
 /// standard NotImplemented fallback.
 pub fn divmod(a: PyObjectRef, b: PyObjectRef) -> PyResult {
-    let a = unwrap_cell(a);
-    let b = unwrap_cell(b);
     unsafe {
         let lhs_num = is_int(a) || is_long(a) || is_float(a);
         let rhs_num = is_int(b) || is_long(b) || is_float(b);
@@ -3028,8 +2981,6 @@ fn float_pow_impl(x: f64, y: f64) -> PyResult {
 /// Left shift dispatch (`<<` operator).
 
 pub fn lshift(a: PyObjectRef, b: PyObjectRef) -> PyResult {
-    let a = unwrap_cell(a);
-    let b = unwrap_cell(b);
     unsafe {
         if needs_numeric_binop_dispatch(a, b, "__lshift__", "__rlshift__") {
             if let Some(result) = try_dispatch_binary_special(a, b, "__lshift__", "__rlshift__")? {
@@ -3059,8 +3010,6 @@ pub fn lshift(a: PyObjectRef, b: PyObjectRef) -> PyResult {
 /// Right shift dispatch (`>>` operator).
 
 pub fn rshift(a: PyObjectRef, b: PyObjectRef) -> PyResult {
-    let a = unwrap_cell(a);
-    let b = unwrap_cell(b);
     unsafe {
         if needs_numeric_binop_dispatch(a, b, "__rshift__", "__rrshift__") {
             if let Some(result) = try_dispatch_binary_special(a, b, "__rshift__", "__rrshift__")? {
@@ -3090,8 +3039,6 @@ pub fn rshift(a: PyObjectRef, b: PyObjectRef) -> PyResult {
 /// Bitwise AND dispatch (`&` operator).
 
 pub fn and_(a: PyObjectRef, b: PyObjectRef) -> PyResult {
-    let a = unwrap_cell(a);
-    let b = unwrap_cell(b);
     unsafe {
         let set_override = needs_set_binop_dispatch(a, b);
         if set_override {
@@ -3161,8 +3108,6 @@ pub(crate) fn unionable(obj: PyObjectRef) -> bool {
 /// Bitwise OR dispatch (`|` operator).
 
 pub fn or_(a: PyObjectRef, b: PyObjectRef) -> PyResult {
-    let a = unwrap_cell(a);
-    let b = unwrap_cell(b);
     // `pypy/objspace/std/dictproxyobject.py:51 descr_or` /
     // `pypy/objspace/std/dictproxyobject.py:60 descr_ror` —
     // mappingproxy `|` dispatches by copying the proxy's wrapped
@@ -3257,8 +3202,6 @@ pub fn or_(a: PyObjectRef, b: PyObjectRef) -> PyResult {
 /// Bitwise XOR dispatch (`^` operator).
 
 pub fn xor(a: PyObjectRef, b: PyObjectRef) -> PyResult {
-    let a = unwrap_cell(a);
-    let b = unwrap_cell(b);
     unsafe {
         let set_override = needs_set_binop_dispatch(a, b);
         if set_override {
@@ -3313,8 +3256,6 @@ pub fn xor(a: PyObjectRef, b: PyObjectRef) -> PyResult {
 /// Comparison operation dispatch.
 
 pub fn compare(a: PyObjectRef, b: PyObjectRef, op: CompareOp) -> PyResult {
-    let a = unwrap_cell(a);
-    let b = unwrap_cell(b);
     // A builtin subclass overriding the comparison dunder dispatches the
     // override first (with reflected-subclass priority); exact builtins and
     // non-overriding subclasses fall through to the by-layout comparison slot,
@@ -3334,8 +3275,6 @@ pub fn compare(a: PyObjectRef, b: PyObjectRef, op: CompareOp) -> PyResult {
 /// builtin comparison instead of re-entering override dispatch (which would
 /// recurse).
 pub fn compare_slot(a: PyObjectRef, b: PyObjectRef, op: CompareOp) -> PyResult {
-    let a = unwrap_cell(a);
-    let b = unwrap_cell(b);
     unsafe {
         if is_int_like(a) && is_int_like(b) {
             return match op {
@@ -3663,7 +3602,6 @@ impl CompareOp {
 /// Unary positive (`+a`).
 
 pub fn pos(a: PyObjectRef) -> PyResult {
-    let a = unwrap_cell(a);
     unsafe {
         if let Some(result) = try_numeric_unaryop_override(a, "__pos__") {
             return result;
@@ -3699,7 +3637,6 @@ pub fn pos(a: PyObjectRef) -> PyResult {
 /// Unary negation.
 
 pub fn neg(a: PyObjectRef) -> PyResult {
-    let a = unwrap_cell(a);
     unsafe {
         if let Some(result) = try_numeric_unaryop_override(a, "__neg__") {
             return result;
@@ -3739,7 +3676,6 @@ pub fn neg(a: PyObjectRef) -> PyResult {
 /// Unary bitwise inversion.
 
 pub fn invert(a: PyObjectRef) -> PyResult {
-    let a = unwrap_cell(a);
     unsafe {
         if let Some(result) = try_numeric_unaryop_override(a, "__invert__") {
             return result;

--- a/pyre/pyre-interpreter/src/objspace/std/mapdict.rs
+++ b/pyre/pyre-interpreter/src/objspace/std/mapdict.rs
@@ -1019,6 +1019,7 @@ unsafe fn classify_attr(
             // only a `__slots__` Member that belongs to this type is cacheable.
             if unsafe { crate::baseobjspace::is_data_descr(d) } {
                 if unsafe { pyre_object::is_member(d) }
+                    && !unsafe { pyre_object::w_member_is_direct(d) }
                     && unsafe {
                         crate::baseobjspace::issubtype_w(w_type, pyre_object::w_member_get_cls(d))
                     }

--- a/pyre/pyre-interpreter/src/opcode_ops.rs
+++ b/pyre/pyre-interpreter/src/opcode_ops.rs
@@ -33,8 +33,6 @@ pub fn binary_value(
     b: PyObjectRef,
     op: BinaryOperator,
 ) -> Result<PyObjectRef, PyError> {
-    let a = crate::baseobjspace::unwrap_cell(a);
-    let b = crate::baseobjspace::unwrap_cell(b);
     // descroperation.py:825 `inplace_impl` — consult the in-place
     // special first; fall through to the binary op below when absent or
     // `NotImplemented`.
@@ -117,8 +115,6 @@ pub fn compare_value(
     b: PyObjectRef,
     op: ComparisonOperator,
 ) -> Result<PyObjectRef, PyError> {
-    let a = crate::baseobjspace::unwrap_cell(a);
-    let b = crate::baseobjspace::unwrap_cell(b);
     let cmp_op = match op {
         ComparisonOperator::Less => CompareOp::Lt,
         ComparisonOperator::LessOrEqual => CompareOp::Le,
@@ -160,17 +156,14 @@ pub fn compare_value_from_tag(
 }
 
 pub fn unary_negative_value(value: PyObjectRef) -> Result<PyObjectRef, PyError> {
-    let value = crate::baseobjspace::unwrap_cell(value);
     neg(value)
 }
 
 pub fn unary_invert_value(value: PyObjectRef) -> Result<PyObjectRef, PyError> {
-    let value = crate::baseobjspace::unwrap_cell(value);
     invert(value)
 }
 
 pub fn unary_positive_value(value: PyObjectRef) -> Result<PyObjectRef, PyError> {
-    let value = crate::baseobjspace::unwrap_cell(value);
     crate::baseobjspace::pos(value)
 }
 
@@ -194,7 +187,6 @@ pub fn list_to_tuple_value(value: PyObjectRef) -> Result<PyObjectRef, PyError> {
     Err(PyError::type_error("expected list for list_to_tuple"))
 }
 pub fn truth_value(value: PyObjectRef) -> Result<bool, PyError> {
-    let value = crate::baseobjspace::unwrap_cell(value);
     is_true(value)
 }
 

--- a/pyre/pyre-interpreter/src/pycode.rs
+++ b/pyre/pyre-interpreter/src/pycode.rs
@@ -5,6 +5,9 @@
 //! MakeFunction then extracts this pointer to build a function object.
 
 use pyre_object::pyobject::*;
+use pyre_object::{
+    w_bool_from, w_bool_get_value, w_int_new, w_list_new, w_seq_iter_new, w_str_new, w_tuple_new,
+};
 
 /// Compatibility marker for malformed bytecode.
 #[derive(Debug, Clone)]
@@ -148,6 +151,11 @@ pub struct PyCode {
     pub ob_header: PyObject,
     /// Opaque pointer to a `CodeObject` (owned via Box::into_raw).
     pub code_ptr: *const (),
+    /// `pycode.py:143 self.co_firstlineno = firstlineno`. RustPython's
+    /// `CodeObject.first_line_number: Option<OneIndexed>` cannot represent
+    /// the zero/negative values accepted by Python 3.14's CodeType
+    /// constructor, so preserve the exact Python integer on the PyCode itself.
+    pub co_firstlineno_raw: i32,
     /// PyPy: `PyCode.w_globals` — the globals dict OBJECT (`W_DictMultiObject`,
     /// `pycode.py:105 "w_globals?"`).  Module globals are `malloc_typed`-
     /// immortal, but `exec`/custom-globals dicts are `try_gc_alloc` movable.
@@ -375,12 +383,20 @@ pub fn w_code_new_with_hidden_applevel(code_ptr: *const (), hidden_applevel: boo
         let code_ref = unsafe { &*(code_ptr as *const crate::CodeObject) };
         crate::pyframe::npure_cellvars(code_ref) as u32
     };
+    let co_firstlineno_raw = if code_ptr.is_null() || (code_ptr as i64) & align_mask != 0 {
+        1
+    } else {
+        unsafe { &*(code_ptr as *const crate::CodeObject) }
+            .first_line_number
+            .map_or(1, |line| line.get() as i32)
+    };
     let obj = Box::new(PyCode {
         ob_header: PyObject {
             ob_type: &CODE_TYPE as *const PyType,
             w_class: pyre_object::pyobject::get_instantiate(&CODE_TYPE),
         },
         code_ptr,
+        co_firstlineno_raw,
         w_globals: pyre_object::PY_NULL,
         hidden_applevel,
         fast_natural_arity,
@@ -411,6 +427,14 @@ pub fn box_code_constant(code: &crate::CodeObject) -> PyObjectRef {
     w_code_new(code_ptr)
 }
 
+fn box_code_constant_with_firstlineno(code: &crate::CodeObject, firstlineno: i32) -> PyObjectRef {
+    let obj = box_code_constant(code);
+    unsafe {
+        (*(obj as *mut PyCode)).co_firstlineno_raw = firstlineno;
+    }
+    obj
+}
+
 /// The keyword-only fields `code.replace` accepts, in the order
 /// `pypy/interpreter/pycode.py:77-81` reconstructs the code object.
 const REPLACE_KWARGS: [&str; 18] = [
@@ -433,6 +457,468 @@ const REPLACE_KWARGS: [&str; 18] = [
     "co_linetable",
     "co_exceptiontable",
 ];
+
+#[inline]
+unsafe fn require_code(
+    obj: PyObjectRef,
+    descriptor: &str,
+) -> Result<&'static crate::CodeObject, crate::PyError> {
+    if obj.is_null() || !unsafe { is_code(obj) } {
+        return Err(crate::PyError::type_error(format!(
+            "descriptor '{descriptor}' requires a 'code' object"
+        )));
+    }
+    let ptr = unsafe { w_code_get_ptr(obj) } as *const crate::CodeObject;
+    if ptr.is_null() {
+        return Err(crate::PyError::type_error("code object has no code body"));
+    }
+    Ok(unsafe { &*ptr })
+}
+
+fn names_tuple(names: &[String]) -> PyObjectRef {
+    w_tuple_new(names.iter().map(|name| w_str_new(name)).collect())
+}
+
+fn constants_tuple(code: &crate::CodeObject) -> PyObjectRef {
+    w_tuple_new(
+        crate::pyframe::code_constants(code)
+            .iter()
+            .map(crate::pyframe::pyobject_from_constant)
+            .collect(),
+    )
+}
+
+fn legacy_lnotab(code: &crate::CodeObject, firstlineno: i64) -> Vec<u8> {
+    fn encode_pair(mut address: usize, mut line: i64, out: &mut Vec<u8>) {
+        while address > 255 {
+            out.extend_from_slice(&[255, 0]);
+            address -= 255;
+        }
+        while line < -128 {
+            out.extend_from_slice(&[address as u8, 128]);
+            line += 128;
+            address = 0;
+        }
+        while line > 127 {
+            out.extend_from_slice(&[address as u8, 127]);
+            line -= 127;
+            address = 0;
+        }
+        out.extend_from_slice(&[address as u8, line as i8 as u8]);
+    }
+
+    let mut out = Vec::new();
+    let mut line = firstlineno;
+    let mut start_offset = 0usize;
+    for (index, (start, _)) in code.locations.iter().enumerate() {
+        let next_line = start.line.get() as i64;
+        if next_line != line {
+            let offset = index * 2;
+            encode_pair(offset - start_offset, next_line - line, &mut out);
+            line = next_line;
+            start_offset = offset;
+        }
+    }
+    out
+}
+
+/// `PyCode.typedef` field getters. Each type-dict descriptor delegates here so
+/// the object carries one authoritative compiler `CodeObject`, matching
+/// `pycode.py`'s direct `co_*` attributes rather than a parallel side table.
+pub unsafe fn code_get_field(obj: PyObjectRef, name: &str) -> Result<PyObjectRef, crate::PyError> {
+    let code = unsafe { require_code(obj, name)? };
+    Ok(match name {
+        "co_argcount" => w_int_new(code.arg_count as i64),
+        "co_posonlyargcount" => w_int_new(code.posonlyarg_count as i64),
+        "co_kwonlyargcount" => w_int_new(code.kwonlyarg_count as i64),
+        "co_nlocals" => w_int_new(code.varnames.len() as i64),
+        "co_stacksize" => w_int_new(code.max_stackdepth as i64),
+        "co_flags" => w_int_new(code.flags.bits() as i64),
+        "co_code" | "_co_code_adaptive" => {
+            pyre_object::bytesobject::w_bytes_from_bytes(&code.instructions.original_bytes())
+        }
+        "co_consts" => constants_tuple(code),
+        "co_names" => names_tuple(&code.names),
+        "co_varnames" => names_tuple(&code.varnames),
+        "co_freevars" => names_tuple(&code.freevars),
+        "co_cellvars" => names_tuple(&code.cellvars),
+        "co_filename" => w_str_new(&code.source_path),
+        "co_name" => w_str_new(&code.obj_name),
+        "co_qualname" => w_str_new(&code.qualname),
+        "co_firstlineno" => w_int_new((*(obj as *const PyCode)).co_firstlineno_raw as i64),
+        "co_linetable" => pyre_object::bytesobject::w_bytes_from_bytes(&code.linetable),
+        "co_exceptiontable" => pyre_object::bytesobject::w_bytes_from_bytes(&code.exceptiontable),
+        // location.py:163-182 `linetable2lnotab`, reconstructed from the
+        // canonical decoded positions kept on CodeObject.
+        "co_lnotab" => pyre_object::bytesobject::w_bytes_from_bytes(&legacy_lnotab(
+            code,
+            (*(obj as *const PyCode)).co_firstlineno_raw as i64,
+        )),
+        _ => {
+            return Err(crate::PyError::attribute_error(format!(
+                "'code' object has no attribute '{name}'"
+            )));
+        }
+    })
+}
+
+/// CPython 3.14 `code.__new__` positional-only constructor, with the PyPy
+/// `descr_code__new__` validations and field order adjusted to 3.14 (the
+/// exception table precedes freevars/cellvars).
+pub unsafe fn code_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    if !(17..=19).contains(&args.len()) {
+        return Err(crate::PyError::type_error(format!(
+            "code expected at least 16 arguments, got {}",
+            args.len().saturating_sub(1),
+        )));
+    }
+    let argcount = unsafe { read_code_u32(args[1], "argcount")? };
+    let posonly = unsafe { read_code_u32(args[2], "posonlyargcount")? };
+    let kwonly = unsafe { read_code_u32(args[3], "kwonlyargcount")? };
+    let nlocals = unsafe { read_code_u32(args[4], "nlocals")? };
+    let stacksize_value = unsafe { crate::builtins::space_index_w(args[5])? };
+    let flags_value = unsafe { crate::builtins::space_index_w(args[6])? };
+    if stacksize_value < 0 || flags_value < 0 {
+        return Err(crate::PyError::new(
+            crate::PyErrorKind::SystemError,
+            "Objects/codeobject.c: bad argument to internal function",
+        ));
+    }
+    let stacksize = stacksize_value as u32;
+    let flags_bits = flags_value as u32;
+    let instructions = unsafe { read_code_units(args[7])? };
+    let constants = unsafe { read_code_consts(args[8])? };
+    let names = unsafe { read_code_names(args[9], "names")? };
+    let varnames = unsafe { read_code_names(args[10], "varnames")? };
+    if varnames.len() != nlocals as usize {
+        return Err(crate::PyError::value_error(format!(
+            "code: co_nlocals != len(co_varnames)"
+        )));
+    }
+    let source_path = unsafe { read_code_str(args[11], "filename")? };
+    let obj_name = unsafe { read_code_str(args[12], "name")? };
+    let qualname = unsafe { read_code_str(args[13], "qualname")? };
+    let first_line = unsafe { crate::builtins::space_index_w(args[14])? };
+    let first_line_number = if first_line <= 0 {
+        None
+    } else {
+        rustpython_compiler_core::OneIndexed::new(first_line as usize)
+    };
+    let linetable = unsafe { read_code_bytes(args[15], "linetable")? };
+    let exceptiontable = unsafe { read_code_bytes(args[16], "exceptiontable")? };
+    let freevars = if args.len() >= 18 {
+        unsafe { read_code_names(args[17], "freevars")? }
+    } else {
+        Vec::<String>::new().into_boxed_slice()
+    };
+    let cellvars = if args.len() >= 19 {
+        unsafe { read_code_names(args[18], "cellvars")? }
+    } else {
+        Vec::<String>::new().into_boxed_slice()
+    };
+    if argcount + kwonly > nlocals || posonly > argcount {
+        return Err(crate::PyError::value_error("code: invalid argument count"));
+    }
+
+    // CPython's localsplus table stores cell aliases on the local slot and
+    // appends only pure cells, followed by free variables.
+    let mut localspluskinds = vec![crate::bytecode::CO_FAST_LOCAL; varnames.len()];
+    for cell in cellvars.iter() {
+        if let Some(index) = varnames.iter().position(|name| name == cell) {
+            localspluskinds[index] |= crate::bytecode::CO_FAST_CELL;
+        } else {
+            localspluskinds.push(crate::bytecode::CO_FAST_CELL);
+        }
+    }
+    localspluskinds.extend(std::iter::repeat_n(
+        crate::bytecode::CO_FAST_FREE,
+        freevars.len(),
+    ));
+
+    let locations = rustpython_compiler_core::marshal::linetable_to_locations(
+        &linetable,
+        first_line.clamp(i32::MIN as i64, i32::MAX as i64) as i32,
+        instructions.len(),
+    );
+    let code = crate::CodeObject {
+        instructions,
+        locations,
+        flags: crate::bytecode::CodeFlags::from_bits_retain(flags_bits),
+        posonlyarg_count: posonly,
+        arg_count: argcount,
+        kwonlyarg_count: kwonly,
+        source_path,
+        first_line_number,
+        max_stackdepth: stacksize,
+        obj_name,
+        qualname,
+        constants,
+        names,
+        varnames,
+        cellvars,
+        freevars,
+        localspluskinds: localspluskinds.into_boxed_slice(),
+        linetable,
+        exceptiontable,
+    };
+    Ok(box_code_constant_with_firstlineno(
+        &code,
+        first_line.clamp(i32::MIN as i64, i32::MAX as i64) as i32,
+    ))
+}
+
+fn code_data_equal(a: &crate::CodeObject, b: &crate::CodeObject) -> bool {
+    a.obj_name == b.obj_name
+        && a.qualname == b.qualname
+        && a.arg_count == b.arg_count
+        && a.posonlyarg_count == b.posonlyarg_count
+        && a.kwonlyarg_count == b.kwonlyarg_count
+        && a.varnames.len() == b.varnames.len()
+        && a.flags == b.flags
+        && a.first_line_number == b.first_line_number
+        && a.instructions.original_bytes() == b.instructions.original_bytes()
+        && a.names.len() == b.names.len()
+        && a.constants.len() == b.constants.len()
+        && a.varnames == b.varnames
+        && a.freevars == b.freevars
+        && a.cellvars == b.cellvars
+        && a.names == b.names
+        && crate::pyframe::code_constants(a)
+            .iter()
+            .zip(crate::pyframe::code_constants(b).iter())
+            .all(|(left, right)| constant_strong_equal(left, right))
+}
+
+fn constant_strong_equal(
+    left: &crate::bytecode::ConstantData,
+    right: &crate::bytecode::ConstantData,
+) -> bool {
+    use crate::bytecode::ConstantData;
+    match (left, right) {
+        (ConstantData::Code { code: a }, ConstantData::Code { code: b }) => code_data_equal(a, b),
+        (ConstantData::Tuple { elements: a }, ConstantData::Tuple { elements: b }) => {
+            a.len() == b.len()
+                && a.iter()
+                    .zip(b.iter())
+                    .all(|(x, y)| constant_strong_equal(x, y))
+        }
+        (ConstantData::Slice { elements: a }, ConstantData::Slice { elements: b }) => a
+            .iter()
+            .zip(b.iter())
+            .all(|(x, y)| constant_strong_equal(x, y)),
+        (ConstantData::Frozenset { elements: a }, ConstantData::Frozenset { elements: b }) => {
+            if a.len() != b.len() {
+                return false;
+            }
+            let mut matched = vec![false; b.len()];
+            a.iter().all(|item| {
+                b.iter()
+                    .enumerate()
+                    .find(|(index, candidate)| {
+                        !matched[*index] && constant_strong_equal(item, candidate)
+                    })
+                    .map(|(index, _)| {
+                        matched[index] = true;
+                    })
+                    .is_some()
+            })
+        }
+        _ => left == right,
+    }
+}
+
+pub unsafe fn code_eq(
+    this: PyObjectRef,
+    other: PyObjectRef,
+) -> Result<PyObjectRef, crate::PyError> {
+    if !unsafe { is_code(other) } {
+        return Ok(pyre_object::special::w_not_implemented());
+    }
+    let a = unsafe { require_code(this, "__eq__")? };
+    let b = unsafe { require_code(other, "__eq__")? };
+    if (*(this as *const PyCode)).co_firstlineno_raw
+        != (*(other as *const PyCode)).co_firstlineno_raw
+    {
+        return Ok(w_bool_from(false));
+    }
+    Ok(w_bool_from(code_data_equal(a, b)))
+}
+
+pub unsafe fn code_ne(
+    this: PyObjectRef,
+    other: PyObjectRef,
+) -> Result<PyObjectRef, crate::PyError> {
+    let equal = unsafe { code_eq(this, other)? };
+    if unsafe { pyre_object::is_not_implemented(equal) } {
+        Ok(equal)
+    } else {
+        Ok(w_bool_from(!unsafe { w_bool_get_value(equal) }))
+    }
+}
+
+pub unsafe fn code_hash(obj: PyObjectRef) -> Result<i64, crate::PyError> {
+    let code = unsafe { require_code(obj, "__hash__")? };
+    #[inline]
+    fn scramble(result: i64, value: i64) -> i64 {
+        ((result as u64 ^ value as u64).wrapping_mul(1_000_003)) as i64
+    }
+    #[inline]
+    fn add_obj(result: &mut i64, value: PyObjectRef) -> Result<(), crate::PyError> {
+        *result = scramble(*result, crate::baseobjspace::hash_w_strict(value)?);
+        Ok(())
+    }
+    let mut result = 20_250_211i64;
+    add_obj(&mut result, w_str_new(&code.obj_name))?;
+    add_obj(&mut result, w_str_new(&code.qualname))?;
+    for value in [
+        code.arg_count as i64,
+        code.posonlyarg_count as i64,
+        code.kwonlyarg_count as i64,
+        code.varnames.len() as i64,
+        code.flags.bits() as i64,
+        (*(obj as *const PyCode)).co_firstlineno_raw as i64,
+    ] {
+        result = scramble(result, value);
+    }
+    add_obj(
+        &mut result,
+        pyre_object::bytesobject::w_bytes_from_bytes(&code.instructions.original_bytes()),
+    )?;
+    for names in [&code.varnames, &code.freevars, &code.cellvars, &code.names] {
+        for name in names.iter() {
+            add_obj(&mut result, w_str_new(name))?;
+        }
+    }
+    for constant in crate::pyframe::code_constants(code) {
+        add_obj(
+            &mut result,
+            crate::pyframe::pyobject_from_constant(constant),
+        )?;
+    }
+    Ok(if result == -1 { -2 } else { result })
+}
+
+pub unsafe fn code_repr(obj: PyObjectRef) -> Result<PyObjectRef, crate::PyError> {
+    let code = unsafe { require_code(obj, "__repr__")? };
+    let line = (*(obj as *const PyCode)).co_firstlineno_raw as i64;
+    Ok(w_str_new(&format!(
+        "<code object {} at {obj:p}, file \"{}\", line {line}>",
+        code.obj_name, code.source_path,
+    )))
+}
+
+pub unsafe fn code_sizeof(obj: PyObjectRef) -> Result<PyObjectRef, crate::PyError> {
+    let code = unsafe { require_code(obj, "__sizeof__")? };
+    let size = std::mem::size_of::<PyCode>()
+        + std::mem::size_of::<crate::CodeObject>()
+        + code.instructions.len() * 2
+        + code.locations.len()
+            * std::mem::size_of::<(
+                rustpython_compiler_core::SourceLocation,
+                rustpython_compiler_core::SourceLocation,
+            )>()
+        + code.linetable.len()
+        + code.exceptiontable.len();
+    Ok(w_int_new(size as i64))
+}
+
+pub unsafe fn code_varname_from_oparg(
+    obj: PyObjectRef,
+    index: PyObjectRef,
+) -> Result<PyObjectRef, crate::PyError> {
+    let code = unsafe { require_code(obj, "_varname_from_oparg")? };
+    let mut index = unsafe { crate::builtins::space_index_w(index)? };
+    if index >= 0 {
+        if let Some(name) = code.varnames.get(index as usize) {
+            return Ok(w_str_new(name));
+        }
+        index -= code.varnames.len() as i64;
+        if let Some(name) = code.cellvars.get(index as usize) {
+            return Ok(w_str_new(name));
+        }
+        index -= code.cellvars.len() as i64;
+        if let Some(name) = code.freevars.get(index as usize) {
+            return Ok(w_str_new(name));
+        }
+    }
+    Err(crate::PyError::new(
+        crate::PyErrorKind::IndexError,
+        "tuple index out of range",
+    ))
+}
+
+pub unsafe fn code_positions(obj: PyObjectRef) -> Result<PyObjectRef, crate::PyError> {
+    let code = unsafe { require_code(obj, "co_positions")? };
+    let rows = code
+        .locations
+        .iter()
+        .map(|(start, end)| {
+            w_tuple_new(vec![
+                w_int_new(start.line.get() as i64),
+                w_int_new(end.line.get() as i64),
+                w_int_new(start.character_offset.get().saturating_sub(1) as i64),
+                w_int_new(end.character_offset.get().saturating_sub(1) as i64),
+            ])
+        })
+        .collect::<Vec<_>>();
+    let n = rows.len();
+    Ok(w_seq_iter_new(w_list_new(rows), n))
+}
+
+pub unsafe fn code_lines(obj: PyObjectRef) -> Result<PyObjectRef, crate::PyError> {
+    let code = unsafe { require_code(obj, "co_lines")? };
+    let mut rows = Vec::new();
+    let mut start = 0usize;
+    while start < code.locations.len() {
+        let line = code.locations[start].0.line.get();
+        let mut end = start + 1;
+        while end < code.locations.len() && code.locations[end].0.line.get() == line {
+            end += 1;
+        }
+        rows.push(w_tuple_new(vec![
+            w_int_new((start * 2) as i64),
+            w_int_new((end * 2) as i64),
+            w_int_new(line as i64),
+        ]));
+        start = end;
+    }
+    let n = rows.len();
+    Ok(w_seq_iter_new(w_list_new(rows), n))
+}
+
+pub unsafe fn code_branches(obj: PyObjectRef) -> Result<PyObjectRef, crate::PyError> {
+    let code = unsafe { require_code(obj, "co_branches")? };
+    let mut rows = Vec::new();
+    let mut index = 0usize;
+    while index < code.instructions.len() {
+        let op = code.instructions.read_op(index).deoptimize();
+        let next = index + 1 + op.cache_entries();
+        if op.has_jump() && !op.is_unconditional_jump() {
+            let delta = u8::from(code.instructions.read_arg(index)) as usize;
+            let target = next.saturating_add(delta);
+            // Python 3.14 inserts NOT_TAKEN at the fallthrough edge so branch
+            // instrumentation can distinguish the untaken path. `co_branches`
+            // reports the first real instruction after that marker.
+            let fallthrough = if next < code.instructions.len()
+                && matches!(
+                    code.instructions.read_op(next).deoptimize(),
+                    crate::bytecode::Instruction::NotTaken
+                ) {
+                next + 1
+            } else {
+                next
+            };
+            rows.push(w_tuple_new(vec![
+                w_int_new((index * 2) as i64),
+                w_int_new((fallthrough * 2) as i64),
+                w_int_new((target * 2) as i64),
+            ]));
+        }
+        index = next.max(index + 1);
+    }
+    let n = rows.len();
+    Ok(w_seq_iter_new(w_list_new(rows), n))
+}
 
 /// `code.replace(**kwds)` — `pypy/interpreter/pycode.py:74-91` applevel
 /// `replace`, which gathers every `co_*` attribute (taking the keyword
@@ -466,7 +952,7 @@ pub unsafe fn code_replace(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::P
             }
             if !REPLACE_KWARGS.contains(&key.as_str()) {
                 return Err(crate::PyError::type_error(format!(
-                    "'{key}' is an invalid keyword argument for replace()"
+                    "replace() got an unexpected keyword argument '{key}'"
                 )));
             }
         }
@@ -479,6 +965,7 @@ pub unsafe fn code_replace(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::P
         ));
     }
     let mut code = unsafe { (*code_ptr).clone() };
+    let mut firstlineno_raw = unsafe { (*(w_self as *const PyCode)).co_firstlineno_raw };
     let get = |name: &str| crate::builtins::kwarg_get(kwargs, name);
 
     if let Some(v) = get("co_argcount") {
@@ -499,11 +986,23 @@ pub unsafe fn code_replace(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::P
         code.max_stackdepth = unsafe { read_code_u32(v, "co_stacksize")? };
     }
     if let Some(v) = get("co_flags") {
-        let bits = unsafe { crate::builtins::space_index_w(v)? } as u32;
+        let value = unsafe { crate::builtins::space_index_w(v)? };
+        if value < 0 {
+            return Err(crate::PyError::value_error(
+                "co_flags must be a positive integer",
+            ));
+        }
+        let bits = value as u32;
         code.flags = crate::bytecode::CodeFlags::from_bits_retain(bits);
     }
     if let Some(v) = get("co_firstlineno") {
         let n = unsafe { crate::builtins::space_index_w(v)? };
+        if n < 0 {
+            return Err(crate::PyError::value_error(
+                "co_firstlineno must be a positive integer",
+            ));
+        }
+        firstlineno_raw = n.clamp(i32::MIN as i64, i32::MAX as i64) as i32;
         code.first_line_number = if n <= 0 {
             None
         } else {
@@ -544,16 +1043,19 @@ pub unsafe fn code_replace(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::P
         code.instructions = unsafe { read_code_units(v)? };
     }
 
-    Ok(box_code_constant(&code))
+    Ok(box_code_constant_with_firstlineno(&code, firstlineno_raw))
 }
 
 /// A non-negative `co_*` count argument as `u32`.
 unsafe fn read_code_u32(v: PyObjectRef, field: &str) -> Result<u32, crate::PyError> {
     let n = unsafe { crate::builtins::space_index_w(v)? };
     if n < 0 {
-        return Err(crate::PyError::value_error(format!(
-            "{field} must be a non-negative integer"
-        )));
+        let message = if field.starts_with("co_") {
+            format!("{field} must be a positive integer")
+        } else {
+            format!("code: {field} must not be negative")
+        };
+        return Err(crate::PyError::value_error(message));
     }
     Ok(n as u32)
 }

--- a/pyre/pyre-interpreter/src/pyframe.rs
+++ b/pyre/pyre-interpreter/src/pyframe.rs
@@ -3433,7 +3433,7 @@ pub(crate) fn code_constants(code: &CodeObject) -> &[crate::bytecode::ConstantDa
 /// `&mut PyFrame` to dispatch through the trait, so this free function
 /// mirrors each `*_constant` body directly. Variant order matches
 /// `pyopcode.rs::load_const_value` so future additions stay in sync.
-fn pyobject_from_constant(constant: &crate::bytecode::ConstantData) -> PyObjectRef {
+pub(crate) fn pyobject_from_constant(constant: &crate::bytecode::ConstantData) -> PyObjectRef {
     use crate::bytecode::ConstantData;
     use num_traits::ToPrimitive;
     match constant {

--- a/pyre/pyre-interpreter/src/pyopcode.rs
+++ b/pyre/pyre-interpreter/src/pyopcode.rs
@@ -1452,7 +1452,9 @@ pub trait OpcodeStepExecutor: SharedOpcodeHandler {
             IntrinsicFunction2::SetFunctionTypeParams => {
                 // arg2 = type_params, arg1 = function
                 // Set __type_params__ attribute on the function; push function back
-                let _type_params = self.pop_value()?;
+                let type_params = self.pop_value()?;
+                let function = self.peek_at(0)?;
+                self.set_function_typeparams(function, type_params)?;
                 // just leave the function on the stack
                 Ok(())
             }

--- a/pyre/pyre-interpreter/src/shared_opcode.rs
+++ b/pyre/pyre-interpreter/src/shared_opcode.rs
@@ -14,6 +14,13 @@ pub trait SharedOpcodeHandler {
     }
 
     fn make_function(&mut self, code_obj: Self::Value) -> OpcodeResult<Self::Value>;
+    fn set_function_typeparams(
+        &mut self,
+        function: Self::Value,
+        typeparams: Self::Value,
+    ) -> OpcodeResult<()> {
+        self.store_attr(function, "__type_params__", typeparams)
+    }
     fn call_callable(
         &mut self,
         callable: Self::Value,

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -6037,6 +6037,16 @@ fn mappingproxy_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::Py
 }
 
 fn init_mappingproxy_type(ns: PyObjectRef) {
+    // Python 3.14 `PyDictProxy_Type`: "Read-only proxy of a mapping."
+    // PyPy's module doc spells out the same contract, while its TypeDef
+    // predates the explicit type-doc slot.
+    unsafe {
+        pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
+            ns,
+            "__doc__",
+            pyre_object::w_str_new("Read-only proxy of a mapping."),
+        )
+    };
     // dictproxyobject.py:105 __new__=interp2app(descr_new)
     unsafe {
         pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
@@ -6147,6 +6157,33 @@ fn init_mappingproxy_type(ns: PyObjectRef) {
                     "'|=' is not supported by mappingproxy; use '|' instead",
                 ))
             }),
+        )
+    };
+    // Python 3.14 `mappingproxy_hash`: delegate to the wrapped mapping.
+    // This is newer than PyPy's current `dictproxyobject.py` TypeDef. A
+    // proxy around dict therefore raises `unhashable type: 'dict'`, while a
+    // proxy around a custom hashable mapping returns that mapping's hash.
+    unsafe {
+        pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
+            ns,
+            "__hash__",
+            make_builtin_function_with_arity(
+                "__hash__",
+                |args| {
+                    let proxy = args[0];
+                    if !unsafe { pyre_object::is_dict_proxy(proxy) } {
+                        let received = unsafe { (*(*proxy).ob_type).name };
+                        return Err(crate::PyError::type_error(format!(
+                            "descriptor '__hash__' requires a 'mappingproxy' object but received a '{received}'"
+                        )));
+                    }
+                    let mapping = unsafe { pyre_object::w_dict_proxy_get_mapping(proxy) };
+                    Ok(pyre_object::w_int_new(crate::baseobjspace::hash_w_strict(
+                        mapping,
+                    )?))
+                },
+                1,
+            ),
         )
     };
     // dictproxyobject.py:51 descr_or →

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -8473,8 +8473,128 @@ fn init_function_type_common(ns: PyObjectRef) {
     };
 }
 
+/// PyPy `Function.descr_function_call(self, __args__)`: forward the complete
+/// Arguments object, including keyword names, to the wrapped function.
+fn function_descr_call(args: &[PyObjectRef]) -> crate::PyResult {
+    let (positional, kwargs) = crate::builtins::split_builtin_kwargs(args);
+    let function = positional.first().copied().unwrap_or(pyre_object::PY_NULL);
+    let call_args = positional.get(1..).unwrap_or(&[]);
+    if !crate::builtins::has_real_kwargs(kwargs) {
+        return crate::call::call_function_impl_result(function, call_args);
+    }
+    let keyword_args: Vec<(Wtf8Buf, PyObjectRef)> = unsafe {
+        pyre_object::w_dict_str_entries(kwargs.unwrap())
+            .into_iter()
+            .filter(|(name, _)| name != "__pyre_kw__")
+            .map(|(name, value)| (Wtf8Buf::from_string(name), value))
+            .collect()
+    };
+    crate::eval::CURRENT_FRAME.with(|current| {
+        let frame = current.get();
+        if frame.is_null() {
+            return Err(crate::PyError::runtime_error(
+                "function call has no current frame",
+            ));
+        }
+        crate::call::call_with_kwargs(unsafe { &mut *frame }, function, call_args, &keyword_args)
+    })
+}
+
 fn init_function_type(ns: PyObjectRef) {
     init_function_type_common(ns);
+    // CPython 3.14 `PyFunction_Type.tp_call = _PyObject_MakeTpCall` and
+    // PyPy `Function.typedef.__call__ = descr_function_call`.
+    unsafe {
+        pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
+            ns,
+            "__call__",
+            make_builtin_function("__call__", function_descr_call),
+        )
+    };
+    // CPython 3.14 func_repr: `<function {qualname} at {address}>`.
+    unsafe {
+        pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
+            ns,
+            "__repr__",
+            make_builtin_function_with_arity(
+                "__repr__",
+                |args| {
+                    let function = args[0];
+                    let qualname = unsafe { crate::function::function_get_qualname(function) };
+                    Ok(pyre_object::w_str_new(&format!(
+                        "<function {qualname} at {function:p}>"
+                    )))
+                },
+                1,
+            ),
+        )
+    };
+    // PyPy typedef.py:796 `getset_func_dict = GetSetProperty(
+    // descr_get_dict, descr_set_dict, cls=Function)` — storage is the
+    // typed `Function.w_func_dict` field from function.py:68.
+    let dict_getter = make_builtin_function_with_arity("__dict__", descr_get_dict, 2);
+    let dict_setter = make_builtin_function_with_arity("__dict__", descr_set_dict, 3);
+    unsafe {
+        pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
+            ns,
+            "__dict__",
+            make_getset_property(dict_getter, dict_setter, pyre_object::PY_NULL),
+        )
+    };
+    // CPython 3.14 `function.__annotate__`: callable-or-None, not deletable.
+    let annotate_getter = make_builtin_function("__annotate__", |args| {
+        let function = args.get(1).copied().unwrap_or(pyre_object::PY_NULL);
+        Ok(unsafe { crate::function::function_get_annotate(function) })
+    });
+    let annotate_setter = make_builtin_function("__annotate__", |args| {
+        let function = args.get(1).copied().unwrap_or(pyre_object::PY_NULL);
+        let value = args.get(2).copied().unwrap_or(pyre_object::PY_NULL);
+        unsafe { crate::function::function_set_annotate(function, value)? };
+        Ok(pyre_object::w_none())
+    });
+    let annotate_deleter = make_builtin_function("__annotate__", |args| {
+        let function = args.get(1).copied().unwrap_or(pyre_object::PY_NULL);
+        unsafe { crate::function::function_set_annotate(function, pyre_object::PY_NULL)? };
+        Ok(pyre_object::w_none())
+    });
+    unsafe {
+        pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
+            ns,
+            "__annotate__",
+            make_getset_property(annotate_getter, annotate_setter, annotate_deleter),
+        )
+    };
+    // CPython 3.14 `function.__type_params__`: tuple-only and not deletable.
+    let typeparams_getter = make_builtin_function("__type_params__", |args| {
+        let function = args.get(1).copied().unwrap_or(pyre_object::PY_NULL);
+        Ok(unsafe { crate::function::function_get_typeparams(function) })
+    });
+    let typeparams_setter = make_builtin_function("__type_params__", |args| {
+        let function = args.get(1).copied().unwrap_or(pyre_object::PY_NULL);
+        let value = args.get(2).copied().unwrap_or(pyre_object::PY_NULL);
+        unsafe { crate::function::function_set_typeparams(function, value)? };
+        Ok(pyre_object::w_none())
+    });
+    let typeparams_deleter = make_builtin_function("__type_params__", |args| {
+        let function = args.get(1).copied().unwrap_or(pyre_object::PY_NULL);
+        unsafe { crate::function::function_set_typeparams(function, pyre_object::PY_NULL)? };
+        Ok(pyre_object::w_none())
+    });
+    unsafe {
+        pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
+            ns,
+            "__type_params__",
+            make_getset_property(typeparams_getter, typeparams_setter, typeparams_deleter),
+        )
+    };
+    // The shared rawdict mirrors PyPy and is still used by
+    // BuiltinFunction.  Python 3.14's user `function` type omits these
+    // PyPy-only introspection extensions.
+    unsafe {
+        pyre_object::dictmultiobject::w_dict_delitem_str_no_proxy(ns, "__objclass__");
+        pyre_object::dictmultiobject::w_dict_delitem_str_no_proxy(ns, "__text_signature__");
+        pyre_object::dictmultiobject::w_dict_delitem_str_no_proxy(ns, "__defaults_count__");
+    }
     // `funcobject.c func_new` — `FunctionType(code, globals, name=None,
     // argdefs=None, closure=None, kwdefaults=None)`.
     unsafe {

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -860,9 +860,18 @@ pub fn init_typeobjects() {
             }
             reg.insert(pytype as usize, iterator_type as usize);
         }
+        let cell_type = new_typeobject_with_base_and_layout(
+            "cell",
+            init_cell_type,
+            object_type,
+            &pyre_object::nestedscope::CELL_TYPE as *const PyType,
+        );
+        // typedef.py:953 `Cell.typedef.acceptable_as_base_class = False`;
+        // CPython 3.14 likewise omits Py_TPFLAGS_BASETYPE.
+        unsafe { pyre_object::w_type_set_acceptable_as_base_class(cell_type, false) };
         reg.insert(
             &pyre_object::nestedscope::CELL_TYPE as *const PyType as usize,
-            new_typeobject_with_base("cell", init_cell_type, object_type) as usize,
+            cell_type as usize,
         );
         reg.insert(
             &pyre_object::interp_itertools::COUNT_TYPE as *const PyType as usize,
@@ -1006,6 +1015,7 @@ pub fn init_typeobjects() {
         patch_object_class_descriptor();
         patch_builtin_function_descriptors();
         patch_frame_traceback_descriptors();
+        patch_cell_descriptor();
         patch_getset_descriptor_metadata();
         patch_typeobject_descriptor_names();
     });
@@ -8574,6 +8584,23 @@ fn patch_builtin_function_descriptors() {
     }
 }
 
+/// typedef.py:947-951 stamps `cls=Cell` on `cell_contents`. The descriptor
+/// is constructed before the cell W_TypeObject exists, so fill its `reqcls`
+/// field in the same post-registration pass used for BuiltinFunction and
+/// frame descriptors.
+fn patch_cell_descriptor() {
+    let cell_type =
+        gettypefor(&pyre_object::nestedscope::CELL_TYPE).unwrap_or(pyre_object::PY_NULL);
+    if cell_type.is_null() || !crate::type_dict_has_storage(cell_type) {
+        return;
+    }
+    if let Some(descr) = crate::type_dict_lookup(cell_type, "cell_contents") {
+        if unsafe { pyre_object::typedef::is_getset_property(descr) } {
+            unsafe { pyre_object::typedef::w_getset_set_reqcls(descr, cell_type) };
+        }
+    }
+}
+
 /// typedef.py:736-770 — `PyFrame.typedef` / `PyTraceback.typedef` build
 /// their getsets as `GetSetProperty(PyFrame.fget_*, cls=PyFrame)` /
 /// `GetSetProperty(PyTraceback.descr_*, cls=PyTraceback)`.  The `cls`
@@ -9104,27 +9131,170 @@ fn init_member_descriptor_type(ns: PyObjectRef) {
     };
 }
 
-/// `nestedscope.py:Cell` typedef.  PyPy `typedef.py:934-952 Cell.typedef`:
-///
-/// ```python
-/// Cell.typedef = TypeDef("cell",
-///     ...
-///     __repr__     = interp2app(Cell.descr__repr__),
-///     ...
-///     cell_contents= GetSetProperty(
-///         Cell.descr__cell_contents,
-///         Cell.descr_set_cell_contents,
-///         Cell.descr_del_cell_contents,
-///         cls=Cell),
-/// )
-/// ```
-///
-/// Only the user-visible read/write/delete of `cell_contents` is ported
-/// here.  `__eq__`/`__ne__`/`__lt__`/`__gt__`/`__le__`/`__ge__` cell-vs-cell
-/// comparisons (`nestedscope.py:9-19 make_cell_cmp`) and `__hash__ = None`
-/// remain unimplemented as a wider parity gap — they are not needed for
-/// the descriptor-on-tuple-of-cells path that motivates this work.
+/// CPython 3.14 `cell_new`, matching PyPy `descr_new_cell` except that the
+/// 3.14 positional-only argument surface rejects keywords.
+fn cell_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    let (positional, kwargs) = crate::builtins::split_builtin_kwargs(args);
+    if crate::builtins::has_real_kwargs(kwargs) {
+        return Err(crate::PyError::type_error(
+            "cell() takes no keyword arguments",
+        ));
+    }
+    let cls = positional.first().copied().unwrap_or(PY_NULL);
+    let cell_type = gettypefor(&pyre_object::nestedscope::CELL_TYPE).unwrap_or(PY_NULL);
+    check_user_subclass(cell_type, cls)?;
+    let contents = match positional.get(1..) {
+        Some([]) | None => PY_NULL,
+        Some([contents]) => *contents,
+        Some(rest) => {
+            return Err(crate::PyError::type_error(format!(
+                "cell expected at most 1 argument, got {}",
+                rest.len()
+            )));
+        }
+    };
+    Ok(pyre_object::w_cell_new(contents))
+}
+
+/// `nestedscope.py:9-19 make_cell_cmp` / CPython 3.14
+/// `cell_compare_impl`: compare contents, with an empty cell ordered before
+/// a populated cell. A foreign right operand returns NotImplemented.
+fn cell_descr_compare(
+    args: &[PyObjectRef],
+    op: crate::baseobjspace::CompareOp,
+) -> Result<PyObjectRef, crate::PyError> {
+    let a = args.first().copied().unwrap_or(PY_NULL);
+    let b = args.get(1).copied().unwrap_or(PY_NULL);
+    if a.is_null() || !unsafe { pyre_object::is_cell(a) } {
+        let dunder = match op {
+            crate::baseobjspace::CompareOp::Eq => "__eq__",
+            crate::baseobjspace::CompareOp::Ne => "__ne__",
+            crate::baseobjspace::CompareOp::Lt => "__lt__",
+            crate::baseobjspace::CompareOp::Le => "__le__",
+            crate::baseobjspace::CompareOp::Gt => "__gt__",
+            crate::baseobjspace::CompareOp::Ge => "__ge__",
+        };
+        return Err(crate::PyError::type_error(format!(
+            "descriptor '{}' requires a 'cell' object",
+            dunder
+        )));
+    }
+    if b.is_null() || !unsafe { pyre_object::is_cell(b) } {
+        return Ok(pyre_object::w_not_implemented());
+    }
+    let a_value = unsafe { pyre_object::w_cell_get(a) };
+    let b_value = unsafe { pyre_object::w_cell_get(b) };
+    if !a_value.is_null() && !b_value.is_null() {
+        return crate::baseobjspace::compare(a_value, b_value, op);
+    }
+    // Cell._cmp_one_empty: empty/empty = 0, empty/value = -1,
+    // value/empty = 1; compare that result with zero using the requested op.
+    let ordering = match (a_value.is_null(), b_value.is_null()) {
+        (true, true) => 0,
+        (true, false) => -1,
+        (false, true) => 1,
+        (false, false) => unreachable!(),
+    };
+    Ok(pyre_object::w_bool_from(match op {
+        crate::baseobjspace::CompareOp::Eq => ordering == 0,
+        crate::baseobjspace::CompareOp::Ne => ordering != 0,
+        crate::baseobjspace::CompareOp::Lt => ordering < 0,
+        crate::baseobjspace::CompareOp::Le => ordering <= 0,
+        crate::baseobjspace::CompareOp::Gt => ordering > 0,
+        crate::baseobjspace::CompareOp::Ge => ordering >= 0,
+    }))
+}
+
+fn cell_descr_eq(args: &[PyObjectRef]) -> crate::PyResult {
+    cell_descr_compare(args, crate::baseobjspace::CompareOp::Eq)
+}
+fn cell_descr_ne(args: &[PyObjectRef]) -> crate::PyResult {
+    cell_descr_compare(args, crate::baseobjspace::CompareOp::Ne)
+}
+fn cell_descr_lt(args: &[PyObjectRef]) -> crate::PyResult {
+    cell_descr_compare(args, crate::baseobjspace::CompareOp::Lt)
+}
+fn cell_descr_gt(args: &[PyObjectRef]) -> crate::PyResult {
+    cell_descr_compare(args, crate::baseobjspace::CompareOp::Gt)
+}
+fn cell_descr_le(args: &[PyObjectRef]) -> crate::PyResult {
+    cell_descr_compare(args, crate::baseobjspace::CompareOp::Le)
+}
+fn cell_descr_ge(args: &[PyObjectRef]) -> crate::PyResult {
+    cell_descr_compare(args, crate::baseobjspace::CompareOp::Ge)
+}
+
+/// `nestedscope.py:101-110 Cell.descr__repr__`, with CPython 3.14's
+/// 80-character type-name cap from `Objects/cellobject.c:cell_repr`.
+fn cell_descr_repr(args: &[PyObjectRef]) -> crate::PyResult {
+    let cell = args.first().copied().unwrap_or(PY_NULL);
+    if cell.is_null() || !unsafe { pyre_object::is_cell(cell) } {
+        let received = crate::baseobjspace::object_functionstr_type_name(cell);
+        return Err(crate::PyError::type_error(format!(
+            "descriptor '__repr__' requires a 'cell' object but received a '{received}'"
+        )));
+    }
+    let value = unsafe { pyre_object::w_cell_get(cell) };
+    let text = if value.is_null() {
+        format!("<cell at 0x{:x}: empty>", cell as usize)
+    } else {
+        let type_name = crate::typedef::r#type(value)
+            .map(|tp| unsafe { pyre_object::w_type_get_name(tp) })
+            .unwrap_or_else(|| unsafe { (*(*value).ob_type).name });
+        let type_name: String = type_name.chars().take(80).collect();
+        format!(
+            "<cell at 0x{:x}: {type_name} object at 0x{:x}>",
+            cell as usize, value as usize
+        )
+    };
+    Ok(w_str_new(&text))
+}
+
+/// `nestedscope.py:934-952 Cell.typedef`, in source order. CPython 3.14 is
+/// the version oracle where it differs: its public cell type deliberately
+/// omits PyPy 3.11's `__reduce__` and `__setstate__` pickle hooks.
 fn init_cell_type(ns: PyObjectRef) {
+    let entries = [
+        (
+            "__doc__",
+            w_str_new(
+                "Create a new cell object.\n\n  contents\n    the contents of the cell. If not specified, the cell will be empty,\n    and \n further attempts to access its cell_contents attribute will\n    raise a ValueError.",
+            ),
+        ),
+        ("__new__", make_new_descr(cell_descr_new)),
+        (
+            "__eq__",
+            make_builtin_function_with_arity("__eq__", cell_descr_eq, 2),
+        ),
+        (
+            "__ne__",
+            make_builtin_function_with_arity("__ne__", cell_descr_ne, 2),
+        ),
+        (
+            "__lt__",
+            make_builtin_function_with_arity("__lt__", cell_descr_lt, 2),
+        ),
+        (
+            "__gt__",
+            make_builtin_function_with_arity("__gt__", cell_descr_gt, 2),
+        ),
+        (
+            "__le__",
+            make_builtin_function_with_arity("__le__", cell_descr_le, 2),
+        ),
+        (
+            "__ge__",
+            make_builtin_function_with_arity("__ge__", cell_descr_ge, 2),
+        ),
+        ("__hash__", w_none()),
+        (
+            "__repr__",
+            make_builtin_function_with_arity("__repr__", cell_descr_repr, 1),
+        ),
+    ];
+    for (name, value) in entries {
+        unsafe { pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(ns, name, value) };
+    }
     // `nestedscope.py:112-116 descr__cell_contents`:
     //
     //     def descr__cell_contents(self, space):
@@ -11548,8 +11718,8 @@ fn bool_bitwise_binop(
     if args.len() < 2 {
         return Err(crate::PyError::type_error("expected 1 argument, got 0"));
     }
-    let a = crate::baseobjspace::unwrap_cell(args[0]);
-    let b = crate::baseobjspace::unwrap_cell(args[1]);
+    let a = args[0];
+    let b = args[1];
     if !unsafe { pyre_object::is_bool(b) } {
         return int_op(a, b);
     }
@@ -11707,7 +11877,7 @@ fn object_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError>
             "object.__new__(): not enough arguments",
         ));
     }
-    let cls = crate::baseobjspace::unwrap_cell(args[0]);
+    let cls = args[0];
     // cls should be a W_TypeObject — create instance of it
     if unsafe { is_type(cls) } {
         // objectobject.py:131 descr__new__ — abstract classes refuse instantiation.
@@ -18538,5 +18708,65 @@ mod tests {
             assert_eq!(pyre_object::w_type_get_name(w_type), "ellipsis");
             assert!(!pyre_object::w_type_get_acceptable_as_base_class(w_type));
         }
+        check_cell_typedef_python314_surface();
+        check_cell_comparison_repr_and_hash();
+    }
+
+    fn check_cell_typedef_python314_surface() {
+        crate::typedef::init_typeobjects();
+        let w_type = crate::typedef::gettypefor(&pyre_object::nestedscope::CELL_TYPE)
+            .expect("cell should resolve to a W_TypeObject");
+        let expected = [
+            "__doc__",
+            "__eq__",
+            "__ge__",
+            "__gt__",
+            "__hash__",
+            "__le__",
+            "__lt__",
+            "__ne__",
+            "__new__",
+            "__repr__",
+            "cell_contents",
+        ];
+        for name in expected {
+            assert!(crate::type_dict_lookup(w_type, name).is_some(), "{name}");
+        }
+        assert!(crate::type_dict_lookup(w_type, "__reduce__").is_none());
+        assert!(crate::type_dict_lookup(w_type, "__setstate__").is_none());
+        unsafe {
+            assert!(!pyre_object::w_type_get_acceptable_as_base_class(w_type));
+        }
+        let contents = crate::type_dict_lookup(w_type, "cell_contents").unwrap();
+        assert!(std::ptr::eq(
+            unsafe { pyre_object::typedef::w_getset_get_reqcls(contents) },
+            w_type
+        ));
+    }
+
+    fn check_cell_comparison_repr_and_hash() {
+        crate::typedef::init_typeobjects();
+        let empty = pyre_object::w_cell_new(pyre_object::PY_NULL);
+        let one = pyre_object::w_cell_new(pyre_object::w_int_new(1));
+        let one_again = pyre_object::w_cell_new(pyre_object::w_int_new(1));
+        let two = pyre_object::w_cell_new(pyre_object::w_int_new(2));
+
+        assert!(
+            crate::baseobjspace::is_true(super::cell_descr_lt(&[empty, one]).unwrap()).unwrap()
+        );
+        assert!(
+            crate::baseobjspace::is_true(super::cell_descr_eq(&[one, one_again]).unwrap()).unwrap()
+        );
+        assert!(crate::baseobjspace::is_true(super::cell_descr_gt(&[two, one]).unwrap()).unwrap());
+        let foreign = super::cell_descr_eq(&[one, pyre_object::w_int_new(1)]).unwrap();
+        assert!(unsafe { pyre_object::is_not_implemented(foreign) });
+
+        let repr = super::cell_descr_repr(&[one]).unwrap();
+        let repr = unsafe { pyre_object::w_str_get_value(repr) };
+        assert!(repr.starts_with("<cell at 0x"));
+        assert!(repr.contains(": int object at 0x"));
+        let err = crate::builtins::try_hash_value(one).unwrap_err();
+        assert_eq!(err.kind, crate::PyErrorKind::TypeError);
+        assert_eq!(err.message, "unhashable type: 'cell'");
     }
 }

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -1014,6 +1014,7 @@ pub fn init_typeobjects() {
     PATCH_TYPEOBJECTS.call_once(|| {
         patch_object_class_descriptor();
         patch_builtin_function_descriptors();
+        patch_function_member_descriptors();
         patch_frame_traceback_descriptors();
         patch_cell_descriptor();
         patch_getset_descriptor_metadata();
@@ -8381,25 +8382,17 @@ fn init_function_type_common(ns: PyObjectRef) {
             make_getset_descriptor(globals_getter),
         )
     };
-    // `func.__builtins__` — `_PyEval_BuiltinsFromGlobals(globals)`: look up
-    // `__builtins__` in the function's globals; a Module yields its dict,
-    // any other value is returned directly, and an absent key falls back to
-    // the default builtin Module.  `pick_builtin_obj` already performs that
-    // resolution (honoring a custom `__builtins__`); convert the Module it
-    // returns to its dict so callers see a mapping (annotationlib's
-    // `{**annotate.__builtins__, **annotate.__globals__}`).
+    // CPython 3.14 `func.__builtins__` is the construction-time
+    // `func_builtins` field, not a fresh lookup in `func_globals`.  The
+    // allocator resolves a Module to its dict and roots that exact object.
     let func_builtins_getter = make_builtin_function("__builtins__", |args| {
         let func = args.get(1).copied().unwrap_or(pyre_object::PY_NULL);
         if func.is_null() {
             return Ok(pyre_object::w_none());
         }
-        let w_globals = unsafe { crate::function::function_get_globals_obj(func) };
-        let exec_ctx = crate::call::take_last_exec_ctx();
-        let w_builtin = crate::baseobjspace::pick_builtin_obj(w_globals, exec_ctx);
+        let w_builtin = unsafe { crate::function::function_get_builtins(func) };
         if w_builtin.is_null() {
             Ok(pyre_object::w_none())
-        } else if unsafe { pyre_object::is_module(w_builtin) } {
-            Ok(unsafe { pyre_object::w_module_get_w_dict(w_builtin) })
         } else {
             Ok(w_builtin)
         }
@@ -8537,8 +8530,101 @@ fn function_descr_call(args: &[PyObjectRef]) -> crate::PyResult {
     })
 }
 
+/// Python 3.14 `PyFunction_Type` direct `PyMemberDef` accessors. PyPy's
+/// `Function.typedef` spells these values as GetSetProperty entries, but 3.14
+/// exposes them as member_descriptor objects. The tagged Member index keeps
+/// the descriptor shape distinct while these helpers preserve the existing
+/// Function field semantics.
+pub(crate) unsafe fn function_direct_member_get(
+    member: PyObjectRef,
+    function: PyObjectRef,
+) -> crate::PyResult {
+    match unsafe { pyre_object::w_member_get_direct_kind(member) } {
+        pyre_object::MEMBER_FUNCTION_CLOSURE => {
+            Ok(unsafe { crate::function::fget_func_closure(function) })
+        }
+        pyre_object::MEMBER_FUNCTION_DOC => Ok(unsafe { crate::function::fget_func_doc(function) }),
+        pyre_object::MEMBER_FUNCTION_GLOBALS => {
+            let value = unsafe { crate::function::function_get_globals_obj(function) };
+            Ok(if value.is_null() {
+                pyre_object::w_none()
+            } else {
+                value
+            })
+        }
+        pyre_object::MEMBER_FUNCTION_MODULE => {
+            Ok(unsafe { crate::function::fget___module__(function) })
+        }
+        pyre_object::MEMBER_FUNCTION_BUILTINS => {
+            let builtins = unsafe { crate::function::function_get_builtins(function) };
+            Ok(if builtins.is_null() {
+                pyre_object::w_none()
+            } else {
+                builtins
+            })
+        }
+        _ => Err(crate::PyError::attribute_error(unsafe {
+            pyre_object::w_member_get_name(member)
+        })),
+    }
+}
+
+pub(crate) unsafe fn function_direct_member_set(
+    member: PyObjectRef,
+    function: PyObjectRef,
+    value: PyObjectRef,
+) -> crate::PyResult {
+    match unsafe { pyre_object::w_member_get_direct_kind(member) } {
+        pyre_object::MEMBER_FUNCTION_DOC => {
+            unsafe { crate::function::fset_func_doc(function, value)? };
+            Ok(pyre_object::w_none())
+        }
+        pyre_object::MEMBER_FUNCTION_MODULE => {
+            unsafe { crate::function::fset___module__(function, value)? };
+            Ok(pyre_object::w_none())
+        }
+        _ => Err(crate::PyError::attribute_error("readonly attribute")),
+    }
+}
+
+pub(crate) unsafe fn function_direct_member_delete(
+    member: PyObjectRef,
+    function: PyObjectRef,
+) -> crate::PyResult {
+    match unsafe { pyre_object::w_member_get_direct_kind(member) } {
+        pyre_object::MEMBER_FUNCTION_DOC => {
+            unsafe { crate::function::fdel_func_doc(function)? };
+            Ok(pyre_object::w_none())
+        }
+        pyre_object::MEMBER_FUNCTION_MODULE => {
+            unsafe { crate::function::fdel___module__(function)? };
+            Ok(pyre_object::w_none())
+        }
+        _ => Err(crate::PyError::attribute_error("readonly attribute")),
+    }
+}
+
 fn init_function_type(ns: PyObjectRef) {
     init_function_type_common(ns);
+    // CPython 3.14 `func_memberlist`: these five entries are direct
+    // member_descriptor objects. PyPy's equivalent values live in
+    // Function.typedef as GetSetProperty; the observable descriptor kind is
+    // the 3.14 difference selected by this project.
+    for (name, kind) in [
+        ("__closure__", pyre_object::MEMBER_FUNCTION_CLOSURE),
+        ("__doc__", pyre_object::MEMBER_FUNCTION_DOC),
+        ("__globals__", pyre_object::MEMBER_FUNCTION_GLOBALS),
+        ("__module__", pyre_object::MEMBER_FUNCTION_MODULE),
+        ("__builtins__", pyre_object::MEMBER_FUNCTION_BUILTINS),
+    ] {
+        unsafe {
+            pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
+                ns,
+                name,
+                pyre_object::w_member_new_direct(kind, name.to_owned(), pyre_object::PY_NULL),
+            );
+        }
+    }
     // CPython 3.14 `PyFunction_Type.tp_call = _PyObject_MakeTpCall` and
     // PyPy `Function.typedef.__call__ = descr_function_call`.
     unsafe {
@@ -8804,6 +8890,30 @@ fn patch_builtin_function_descriptors() {
                 // store rather than the previous side-table read /
                 // mutate / write back dance.
                 unsafe { pyre_object::typedef::w_getset_set_reqcls(descr, bf_type) };
+            }
+        }
+    }
+}
+
+/// Stamp the owner of Python 3.14's direct function member descriptors after
+/// the Function W_TypeObject is available. This is the Member counterpart of
+/// the GetSetProperty reqcls patch immediately above.
+fn patch_function_member_descriptors() {
+    let function_type =
+        gettypefor(&crate::FUNCTION_TYPE as *const PyType).unwrap_or(pyre_object::PY_NULL);
+    if function_type.is_null() || !crate::type_dict_has_storage(function_type) {
+        return;
+    }
+    for name in [
+        "__closure__",
+        "__doc__",
+        "__globals__",
+        "__module__",
+        "__builtins__",
+    ] {
+        if let Some(descr) = crate::type_dict_lookup(function_type, name) {
+            if unsafe { pyre_object::is_member(descr) && pyre_object::w_member_is_direct(descr) } {
+                unsafe { pyre_object::w_member_set_cls(descr, function_type) };
             }
         }
     }
@@ -9408,6 +9518,9 @@ fn init_member_descriptor_type(ns: PyObjectRef) {
                         )));
                     }
                 }
+                if unsafe { pyre_object::w_member_is_direct(descr) } {
+                    return unsafe { function_direct_member_get(descr, obj) };
+                }
                 // typedef.py:511-516: w_result = w_obj.getslotvalue(self.index);
                 // None → AttributeError("'%T' object has no attribute '%s'").
                 let slot_name = unsafe { pyre_object::w_member_get_name(descr) };
@@ -9459,6 +9572,9 @@ fn init_member_descriptor_type(ns: PyObjectRef) {
                         )));
                     }
                 }
+                if unsafe { pyre_object::w_member_is_direct(descr) } {
+                    return unsafe { function_direct_member_set(descr, obj, value) };
+                }
                 // typedef.py:522: w_obj.setslotvalue(self.index, w_value)
                 let index = unsafe { pyre_object::w_member_get_index(descr) };
                 if unsafe { pyre_object::is_instance(obj) } {
@@ -9506,6 +9622,9 @@ fn init_member_descriptor_type(ns: PyObjectRef) {
                             (*(*obj).ob_type).name,
                         )));
                     }
+                }
+                if unsafe { pyre_object::w_member_is_direct(descr) } {
+                    return unsafe { function_direct_member_delete(descr, obj) };
                 }
                 // typedef.py:527-531: success = w_obj.delslotvalue(self.index)
                 let slot_name = unsafe { pyre_object::w_member_get_name(descr) };
@@ -9577,6 +9696,109 @@ fn init_member_descriptor_type(ns: PyObjectRef) {
             make_getset_descriptor(objclass_getter),
         )
     };
+    // CPython 3.14 `PyMemberDescr_Type` metadata.  PyPy's Member typedef
+    // stops at __name__/__objclass__; these four entries are the selected
+    // 3.14 surface.
+    let doc_getter =
+        make_builtin_function_with_arity("__doc__", |_args| Ok(pyre_object::w_none()), 2);
+    unsafe {
+        pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
+            ns,
+            "__doc__",
+            make_getset_descriptor_named(doc_getter, "__doc__"),
+        )
+    };
+
+    let qualname_getter = make_builtin_function_with_arity(
+        "__qualname__",
+        |args| {
+            let member = args.get(1).copied().unwrap_or(pyre_object::PY_NULL);
+            if member.is_null() || !unsafe { pyre_object::typedef::is_member(member) } {
+                return Ok(pyre_object::w_none());
+            }
+            let name = unsafe { pyre_object::w_member_get_name(member) };
+            let owner = unsafe { pyre_object::w_member_get_cls(member) };
+            let owner_qualname = if owner.is_null() {
+                "?".to_string()
+            } else {
+                // `type.__getattribute__` also sees the metatype's
+                // `__qualname__` getset.  Read the class namespace itself,
+                // matching `type.getqualname`: heap classes carry the
+                // compiler-stamped string there; static types fall back to
+                // their bare `tp_name` component.
+                match crate::type_dict_lookup(owner, "__qualname__") {
+                    Some(value) if unsafe { pyre_object::is_str(value) } => {
+                        unsafe { pyre_object::w_str_get_value(value) }.to_string()
+                    }
+                    _ => {
+                        let full = unsafe { pyre_object::w_type_get_name(owner) };
+                        full.rsplit('.').next().unwrap_or(full).to_string()
+                    }
+                }
+            };
+            Ok(pyre_object::w_str_new(&format!("{owner_qualname}.{name}")))
+        },
+        2,
+    );
+    unsafe {
+        pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
+            ns,
+            "__qualname__",
+            make_getset_descriptor_named(qualname_getter, "__qualname__"),
+        )
+    };
+
+    unsafe {
+        pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
+            ns,
+            "__repr__",
+            make_builtin_function_with_arity(
+                "__repr__",
+                |args| {
+                    let member = args.first().copied().unwrap_or(pyre_object::PY_NULL);
+                    Ok(pyre_object::w_str_new(&unsafe {
+                        member_descriptor_repr(member)
+                    }))
+                },
+                1,
+            ),
+        )
+    };
+
+    unsafe {
+        pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
+            ns,
+            "__reduce__",
+            make_builtin_function_with_arity(
+                "__reduce__",
+                |args| {
+                    let member = args.first().copied().unwrap_or(pyre_object::PY_NULL);
+                    let owner = unsafe { pyre_object::w_member_get_cls(member) };
+                    let name =
+                        pyre_object::w_str_new(unsafe { pyre_object::w_member_get_name(member) });
+                    Ok(pyre_object::w_tuple_new(vec![
+                        crate::baseobjspace::builtin_callable("getattr"),
+                        pyre_object::w_tuple_new(vec![owner, name]),
+                    ]))
+                },
+                1,
+            ),
+        )
+    };
+}
+
+/// CPython 3.14 `member_get_qualname` / `member_repr` surface shared by the
+/// registered `__repr__` method and `display::py_repr`'s native descriptor
+/// dispatch.
+pub(crate) unsafe fn member_descriptor_repr(member: PyObjectRef) -> String {
+    let name = unsafe { pyre_object::w_member_get_name(member) };
+    let owner = unsafe { pyre_object::w_member_get_cls(member) };
+    let owner_name = if owner.is_null() {
+        "?"
+    } else {
+        unsafe { pyre_object::w_type_get_name(owner) }
+    };
+    format!("<member '{name}' of '{owner_name}' objects>")
 }
 
 /// CPython 3.14 `cell_new`, matching PyPy `descr_new_cell` except that the

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -9926,133 +9926,366 @@ fn init_classmethod_type(ns: PyObjectRef) {
     }
 }
 
-/// `property.__new__(cls, fget=None, fset=None, fdel=None, doc=None)`
-/// — descriptor.py W_Property.descr_new
-fn init_property_type(ns: PyObjectRef) {
-    unsafe {
-        pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
-            ns,
-            "__new__",
-            make_builtin_function("__new__", |args| {
-                // args[0] is cls; fget/fset/fdel/doc follow.
-                // descriptor.py:186-189 `@unwrap_spec(w_fget=..., w_fset=...,
-                // w_fdel=..., w_doc=...)` — keyword forms bind too.
-                let (pos, kwargs) = crate::builtins::split_builtin_kwargs(args);
-                crate::builtins::kwarg_reject_unknown(
-                    kwargs,
-                    &["fget", "fset", "fdel", "doc"],
-                    "property",
-                )?;
-                let arg = |idx: usize, name: &str| {
-                    pos.get(idx)
-                        .copied()
-                        .or_else(|| crate::builtins::kwarg_get(kwargs, name))
-                        .unwrap_or(pyre_object::PY_NULL)
-                };
-                let cls = pos.first().copied().unwrap_or(pyre_object::PY_NULL);
-                let fget = arg(1, "fget");
-                let fset = arg(2, "fset");
-                let fdel = arg(3, "fdel");
-                let w_doc = arg(4, "doc");
-                let prop = pyre_object::w_property_new(fget, fset, fdel);
-                // typeobject.py:511 `allocate_instance(W_Property, w_subtype)`
-                // — `generic_new_descr(W_Property)` honours the subtype, so a
-                // `property` subclass instance keeps its own class.
-                let property_type =
-                    crate::typedef::gettypeobject(&pyre_object::descriptor::PROPERTY_TYPE);
-                if !cls.is_null() && !std::ptr::eq(cls, property_type) {
-                    check_user_subclass(property_type, cls)?;
-                    unsafe {
-                        (*prop).w_class = cls;
-                    }
-                }
-                unsafe {
-                    // descriptor.py:193 `self.w_doc = w_doc`
-                    if !w_doc.is_null() && !pyre_object::is_none(w_doc) {
-                        pyre_object::descriptor::w_property_set_doc(prop, w_doc);
-                    } else if !fget.is_null() && !pyre_object::is_none(fget) {
-                        // descriptor.py:195-204 — without an explicit doc,
-                        // inherit `fget.__doc__` and mark `getter_doc`.
-                        // (The subclass `space.setattr` branch at :202-203
-                        // is folded into the field write: pyre property
-                        // subclass instances share the W_Property
-                        // layout, so the slot is the only storage.)
-                        if let Ok(getter_doc) = crate::baseobjspace::getattr_str(fget, "__doc__") {
-                            if !getter_doc.is_null() && !pyre_object::is_none(getter_doc) {
-                                pyre_object::descriptor::w_property_set_getter_doc(
-                                    prop, getter_doc,
-                                );
-                            }
-                        }
-                    }
-                }
-                Ok(prop)
-            }),
-        )
+/// CPython 3.14 `PyProperty_Type.tp_doc`.  The instance-level `__doc__`
+/// descriptor occupies the same type-dict key; `baseobjspace` serves this
+/// separate type doc for the exact builtin, matching PyPy's TypeDef rawdict
+/// replacement and CPython's `tp_doc` + member-descriptor split.
+pub(crate) const PROPERTY_DOC: &str = r#"Property attribute.
+
+  fget
+    function to be used for getting an attribute value
+  fset
+    function to be used for setting an attribute value
+  fdel
+    function to be used for del'ing an attribute
+  doc
+    docstring
+
+Typical use is to define a managed attribute x:
+
+class C(object):
+    def getx(self): return self._x
+    def setx(self, value): self._x = value
+    def delx(self): del self._x
+    x = property(getx, setx, delx, "I'm the 'x' property.")
+
+Decorators make defining new properties or modifying existing ones easy:
+
+class C(object):
+    @property
+    def x(self):
+        "I am the 'x' property."
+        return self._x
+    @x.setter
+    def x(self, value):
+        self._x = value
+    @x.deleter
+    def x(self):
+        del self._x"#;
+
+fn property_require(obj: PyObjectRef, name: &str) -> Result<PyObjectRef, crate::PyError> {
+    if obj.is_null() || !unsafe { pyre_object::descriptor::is_property(obj) } {
+        let received = if obj.is_null() {
+            "NULL".to_string()
+        } else {
+            crate::type_methods::arg_type_name(obj)
+        };
+        return Err(crate::PyError::type_error(format!(
+            "descriptor '{name}' for 'property' objects doesn't apply to a '{received}' object"
+        )));
+    }
+    Ok(obj)
+}
+
+/// PyPy `generic_new_descr(W_Property)` / CPython 3.14 `PyType_GenericNew`:
+/// allocate the requested subtype and leave argument processing to `__init__`.
+fn property_descr_new(args: &[PyObjectRef]) -> crate::PyResult {
+    let cls = args.first().copied().unwrap_or(PY_NULL);
+    if cls.is_null() {
+        return Err(crate::PyError::type_error(
+            "property.__new__(): not enough arguments",
+        ));
+    }
+    let property_type = gettypeobject(&pyre_object::descriptor::PROPERTY_TYPE);
+    check_user_subclass(property_type, cls)?;
+    let prop = pyre_object::w_property_new(PY_NULL, PY_NULL, PY_NULL);
+    if !std::ptr::eq(cls, property_type) {
+        unsafe { (*prop).w_class = cls };
+    }
+    Ok(prop)
+}
+
+/// PyPy `W_Property.init`, with CPython 3.14's `prop_name` reset and
+/// subclass-doc placement taking precedence where the versions differ.
+fn property_descr_init(args: &[PyObjectRef]) -> crate::PyResult {
+    let (positional, kwargs) = crate::builtins::split_builtin_kwargs(args);
+    if positional.is_empty() {
+        return Err(crate::PyError::type_error(
+            "descriptor '__init__' of 'property' object needs an argument",
+        ));
+    }
+    let prop = positional[0];
+    if !unsafe { pyre_object::descriptor::is_property(prop) } {
+        return Err(crate::PyError::type_error(format!(
+            "descriptor '__init__' requires a 'property' object but received a '{}'",
+            crate::type_methods::arg_type_name(prop),
+        )));
+    }
+    let supplied = positional.len() - 1;
+    if supplied > 4 {
+        return Err(crate::PyError::type_error(format!(
+            "property() takes at most 4 arguments ({supplied} given)"
+        )));
+    }
+    crate::builtins::kwarg_reject_unknown(kwargs, &["fget", "fset", "fdel", "doc"], "property")?;
+    let fget = crate::builtins::resolve_pos_or_kw(
+        positional.get(1).copied(),
+        kwargs,
+        "fget",
+        "property",
+        1,
+    )?
+    .unwrap_or_else(w_none);
+    let fset = crate::builtins::resolve_pos_or_kw(
+        positional.get(2).copied(),
+        kwargs,
+        "fset",
+        "property",
+        2,
+    )?
+    .unwrap_or_else(w_none);
+    let fdel = crate::builtins::resolve_pos_or_kw(
+        positional.get(3).copied(),
+        kwargs,
+        "fdel",
+        "property",
+        3,
+    )?
+    .unwrap_or_else(w_none);
+    let w_doc = crate::builtins::resolve_pos_or_kw(
+        positional.get(4).copied(),
+        kwargs,
+        "doc",
+        "property",
+        4,
+    )?
+    .unwrap_or_else(w_none);
+
+    unsafe { pyre_object::descriptor::w_property_reinit(prop, fget, fset, fdel) };
+
+    // CPython 3.14 property_init_impl: explicit non-None doc wins; otherwise
+    // inherit a non-None getter doc and remember that `_copy` must rederive it.
+    let mut getter_doc = false;
+    let prop_doc = if !unsafe { pyre_object::is_none(w_doc) } {
+        Some(w_doc)
+    } else if !unsafe { pyre_object::is_none(fget) } {
+        match crate::baseobjspace::getattr_str(fget, "__doc__") {
+            Ok(value) if !unsafe { pyre_object::is_none(value) } => {
+                getter_doc = true;
+                Some(value)
+            }
+            Ok(_) => None,
+            Err(err) if err.kind == crate::PyErrorKind::AttributeError => None,
+            Err(err) => return Err(err),
+        }
+    } else {
+        None
     };
-    // descriptor.py W_Property.typedef `__get__` / `__set__` / `__delete__`
-    // — the implicit descriptor path special-cases properties, but the
-    // type-dict entries make `prop.__get__`, `hasattr(prop, '__get__')`,
-    // and `_is_descriptor` see the property as a descriptor.
-    unsafe {
-        pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
-            ns,
+
+    let property_type = gettypeobject(&pyre_object::descriptor::PROPERTY_TYPE);
+    let exact = r#type(prop).is_some_and(|tp| std::ptr::eq(tp, property_type));
+    if exact {
+        if let Some(doc) = prop_doc {
+            unsafe {
+                if getter_doc {
+                    pyre_object::descriptor::w_property_set_getter_doc(prop, doc);
+                } else {
+                    pyre_object::descriptor::w_property_set_doc(prop, doc);
+                }
+            }
+        }
+    } else {
+        // CPython 3.14 puts a subclass property's doc in its instance dict or
+        // designated slot because the subclass class dict shadows the base
+        // descriptor with its own `__doc__` entry.
+        let visible_doc = prop_doc.unwrap_or_else(w_none);
+        match crate::baseobjspace::setattr_str(prop, "__doc__", visible_doc) {
+            Ok(_) => {}
+            Err(err) if !getter_doc && err.kind == crate::PyErrorKind::AttributeError => {}
+            Err(err) => return Err(err),
+        }
+        if getter_doc {
+            unsafe { pyre_object::descriptor::w_property_mark_getter_doc(prop) };
+        }
+    }
+    Ok(w_none())
+}
+
+fn property_fget(args: &[PyObjectRef]) -> crate::PyResult {
+    let prop = property_require(args.get(1).copied().unwrap_or(PY_NULL), "fget")?;
+    let value = unsafe { pyre_object::descriptor::w_property_get_fget(prop) };
+    Ok(if value.is_null() { w_none() } else { value })
+}
+
+fn property_fset(args: &[PyObjectRef]) -> crate::PyResult {
+    let prop = property_require(args.get(1).copied().unwrap_or(PY_NULL), "fset")?;
+    let value = unsafe { pyre_object::descriptor::w_property_get_fset(prop) };
+    Ok(if value.is_null() { w_none() } else { value })
+}
+
+fn property_fdel(args: &[PyObjectRef]) -> crate::PyResult {
+    let prop = property_require(args.get(1).copied().unwrap_or(PY_NULL), "fdel")?;
+    let value = unsafe { pyre_object::descriptor::w_property_get_fdel(prop) };
+    Ok(if value.is_null() { w_none() } else { value })
+}
+
+fn property_doc_get(args: &[PyObjectRef]) -> crate::PyResult {
+    let prop = property_require(args.get(1).copied().unwrap_or(PY_NULL), "__doc__")?;
+    let value = unsafe { pyre_object::descriptor::w_property_get_doc(prop) };
+    Ok(if value.is_null() { w_none() } else { value })
+}
+
+fn property_doc_set(args: &[PyObjectRef]) -> crate::PyResult {
+    let prop = property_require(args.get(1).copied().unwrap_or(PY_NULL), "__doc__")?;
+    let value = args.get(2).copied().unwrap_or(PY_NULL);
+    unsafe { pyre_object::descriptor::w_property_set_doc(prop, value) };
+    Ok(w_none())
+}
+
+fn property_doc_del(args: &[PyObjectRef]) -> crate::PyResult {
+    let prop = property_require(args.get(1).copied().unwrap_or(PY_NULL), "__doc__")?;
+    unsafe { pyre_object::descriptor::w_property_set_doc(prop, PY_NULL) };
+    Ok(w_none())
+}
+
+fn property_name_get(args: &[PyObjectRef]) -> crate::PyResult {
+    let prop = property_require(args.get(1).copied().unwrap_or(PY_NULL), "__name__")?;
+    let stored = unsafe { pyre_object::descriptor::w_property_get_name(prop) };
+    if !stored.is_null() {
+        return Ok(stored);
+    }
+    let fget = unsafe { pyre_object::descriptor::w_property_get_fget(prop) };
+    if !fget.is_null() && !unsafe { pyre_object::is_none(fget) } {
+        match crate::baseobjspace::getattr_str(fget, "__name__") {
+            Ok(name) => return Ok(name),
+            Err(err) if err.kind == crate::PyErrorKind::AttributeError => {}
+            Err(err) => return Err(err),
+        }
+    }
+    Err(crate::PyError::attribute_error(
+        "'property' object has no attribute '__name__'",
+    ))
+}
+
+fn property_name_set(args: &[PyObjectRef]) -> crate::PyResult {
+    let prop = property_require(args.get(1).copied().unwrap_or(PY_NULL), "__name__")?;
+    let value = args.get(2).copied().unwrap_or(PY_NULL);
+    unsafe { pyre_object::descriptor::w_property_set_name(prop, value) };
+    Ok(w_none())
+}
+
+fn property_name_del(args: &[PyObjectRef]) -> crate::PyResult {
+    let prop = property_require(args.get(1).copied().unwrap_or(PY_NULL), "__name__")?;
+    unsafe { pyre_object::descriptor::w_property_set_name(prop, PY_NULL) };
+    Ok(w_none())
+}
+
+fn property_isabstract(args: &[PyObjectRef]) -> crate::PyResult {
+    let prop = property_require(
+        args.get(1).copied().unwrap_or(PY_NULL),
+        "__isabstractmethod__",
+    )?;
+    let is_abstract = |f: PyObjectRef| -> Result<bool, crate::PyError> {
+        if f.is_null() || unsafe { pyre_object::is_none(f) } {
+            Ok(false)
+        } else {
+            crate::baseobjspace::isabstractmethod_w(f)
+        }
+    };
+    let result = is_abstract(unsafe { pyre_object::descriptor::w_property_get_fget(prop) })?
+        || is_abstract(unsafe { pyre_object::descriptor::w_property_get_fset(prop) })?
+        || is_abstract(unsafe { pyre_object::descriptor::w_property_get_fdel(prop) })?;
+    Ok(pyre_object::w_bool_from(result))
+}
+
+/// PyPy `W_Property.typedef`, extended only where Python 3.14's public
+/// surface differs (`__name__`, `__set_name__`, no PyPy-3.11 `__reduce__`).
+fn init_property_type(ns: PyObjectRef) {
+    let entries = [
+        ("__new__", make_new_descr(property_descr_new)),
+        (
+            "__init__",
+            make_builtin_function("__init__", property_descr_init),
+        ),
+        (
             "__get__",
             make_builtin_function("__get__", crate::baseobjspace::property_descr_get_impl),
-        )
-    };
-    unsafe {
-        pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
-            ns,
+        ),
+        (
             "__set__",
             make_builtin_function("__set__", crate::baseobjspace::property_descr_set_impl),
-        )
-    };
-    unsafe {
-        pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
-            ns,
+        ),
+        (
             "__delete__",
             make_builtin_function(
                 "__delete__",
                 crate::baseobjspace::property_descr_delete_impl,
             ),
-        )
-    };
-    // descriptor.py `__isabstractmethod__` — `isabstract(fget) or
-    // isabstract(fset) or isabstract(fdel)`.
-    unsafe {
-        pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
-            ns,
+        ),
+        (
+            "fget",
+            make_getset_descriptor(make_builtin_function_with_arity("fget", property_fget, 2)),
+        ),
+        (
+            "fset",
+            make_getset_descriptor(make_builtin_function_with_arity("fset", property_fset, 2)),
+        ),
+        (
+            "fdel",
+            make_getset_descriptor(make_builtin_function_with_arity("fdel", property_fdel, 2)),
+        ),
+        (
+            "__doc__",
+            make_getset_property_named(
+                make_builtin_function_with_arity("__doc__", property_doc_get, 2),
+                make_builtin_function_with_arity("__doc__", property_doc_set, 3),
+                make_builtin_function_with_arity("__doc__", property_doc_del, 2),
+                "__doc__",
+            ),
+        ),
+        (
+            "__name__",
+            make_getset_property_named(
+                make_builtin_function_with_arity("__name__", property_name_get, 2),
+                make_builtin_function_with_arity("__name__", property_name_set, 3),
+                make_builtin_function_with_arity("__name__", property_name_del, 2),
+                "__name__",
+            ),
+        ),
+        (
             "__isabstractmethod__",
             make_getset_descriptor(make_builtin_function_with_arity(
                 "__isabstractmethod__",
-                |args| {
-                    let prop = args.get(1).copied().unwrap_or(pyre_object::PY_NULL);
-                    if !unsafe { pyre_object::descriptor::is_property(prop) } {
-                        return Ok(pyre_object::w_bool_from(false));
-                    }
-                    // A missing accessor is `PY_NULL`; treat it as not-abstract.
-                    let is_abstract = |f: PyObjectRef| -> Result<bool, crate::PyError> {
-                        if f.is_null() {
-                            Ok(false)
-                        } else {
-                            crate::baseobjspace::isabstractmethod_w(f)
-                        }
-                    };
-                    let result =
-                        is_abstract(unsafe { pyre_object::descriptor::w_property_get_fget(prop) })?
-                            || is_abstract(unsafe {
-                                pyre_object::descriptor::w_property_get_fset(prop)
-                            })?
-                            || is_abstract(unsafe {
-                                pyre_object::descriptor::w_property_get_fdel(prop)
-                            })?;
-                    Ok(pyre_object::w_bool_from(result))
-                },
+                property_isabstract,
                 2,
             )),
-        )
-    };
+        ),
+        (
+            "getter",
+            make_builtin_function_with_arity(
+                "getter",
+                crate::baseobjspace::property_getter_impl,
+                2,
+            ),
+        ),
+        (
+            "setter",
+            make_builtin_function_with_arity(
+                "setter",
+                crate::baseobjspace::property_setter_impl,
+                2,
+            ),
+        ),
+        (
+            "deleter",
+            make_builtin_function_with_arity(
+                "deleter",
+                crate::baseobjspace::property_deleter_impl,
+                2,
+            ),
+        ),
+        (
+            "__set_name__",
+            make_builtin_function_with_arity(
+                "__set_name__",
+                crate::baseobjspace::property_set_name_impl,
+                3,
+            ),
+        ),
+    ];
+    for (name, value) in entries {
+        unsafe { pyre_object::w_dict_setitem_str_no_proxy(ns, name, value) };
+    }
 }
 
 /// `self` as a plain int — `int.real` / `numerator` / `conjugate` /

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -9153,102 +9153,189 @@ fn init_method_type(ns: PyObjectRef) {
     };
 }
 
+fn code_descr_new(args: &[PyObjectRef]) -> crate::PyResult {
+    unsafe { crate::pycode::code_new(args) }
+}
+
+fn code_descr_eq(args: &[PyObjectRef]) -> crate::PyResult {
+    unsafe { crate::pycode::code_eq(args[0], args[1]) }
+}
+
+fn code_descr_ne(args: &[PyObjectRef]) -> crate::PyResult {
+    unsafe { crate::pycode::code_ne(args[0], args[1]) }
+}
+
+fn code_descr_positions(args: &[PyObjectRef]) -> crate::PyResult {
+    unsafe { crate::pycode::code_positions(args[0]) }
+}
+
+fn code_descr_lines(args: &[PyObjectRef]) -> crate::PyResult {
+    unsafe { crate::pycode::code_lines(args[0]) }
+}
+
+fn code_descr_branches(args: &[PyObjectRef]) -> crate::PyResult {
+    unsafe { crate::pycode::code_branches(args[0]) }
+}
+
+fn code_field_getter(args: &[PyObjectRef]) -> crate::PyResult {
+    let descriptor = args.first().copied().unwrap_or(pyre_object::PY_NULL);
+    let name = unsafe { pyre_object::typedef::w_getset_get_name(descriptor) };
+    let Some(name) = (unsafe { pyre_object::w_str_get_value_opt(name) }) else {
+        return Err(crate::PyError::runtime_error(
+            "code field descriptor has no name",
+        ));
+    };
+    unsafe {
+        crate::pycode::code_get_field(args.get(1).copied().unwrap_or(pyre_object::PY_NULL), name)
+    }
+}
+
 fn init_code_type(ns: PyObjectRef) {
-    // code.replace(**kwargs) — pycode.py:543-550 W_PyCode.descr_replace →
-    // reconstruct the code object with the given co_* fields overridden.
+    // PyPy typedef.py:695-725 `PyCode.typedef`, with the Python 3.14-only
+    // slots (`__replace__`, `co_branches`, adaptive bytes and ordering
+    // wrappers) added from `PyCode_Type`. Every field descriptor reads the
+    // single compiler CodeObject stored by `PyCode`.
     unsafe {
         pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
             ns,
-            "replace",
-            make_builtin_function("replace", |args| unsafe {
-                crate::pycode::code_replace(args)
-            }),
-        )
-    };
-    // `pypy/interpreter/typedef.py:720`
-    // `co_exceptiontable = interp_attrproperty('co_exceptiontable', cls=PyCode,
-    //                                          wrapfn="newbytes")`.
-    //
-    // Read-only attribute exposing the raw varint-packed table.  The
-    // matching getset descriptor wraps the field as a `bytes` object
-    // (PyPy `wrapfn="newbytes"`).  `args[0]` is the descriptor itself,
-    // `args[1]` is the PyCode instance (typedef.py:467-470 calling
-    // convention via `descr_property_get`).
+            "__doc__",
+            pyre_object::w_str_new("Create a code object.  Not for the faint of heart."),
+        );
+        pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
+            ns,
+            "__new__",
+            make_new_descr(code_descr_new),
+        );
+    }
+    for (name, function) in [
+        ("__eq__", code_descr_eq as crate::gateway::BuiltinCodeFn),
+        ("__ne__", code_descr_ne as crate::gateway::BuiltinCodeFn),
+    ] {
+        unsafe {
+            pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
+                ns,
+                name,
+                make_builtin_function_with_arity(name, function, 2),
+            );
+        }
+    }
+    for name in ["__lt__", "__le__", "__gt__", "__ge__"] {
+        unsafe {
+            pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
+                ns,
+                name,
+                make_builtin_function_with_arity(
+                    name,
+                    |_args| Ok(pyre_object::special::w_not_implemented()),
+                    2,
+                ),
+            );
+        }
+    }
     unsafe {
         pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
             ns,
-            "co_exceptiontable",
-            make_getset_descriptor(make_builtin_function_with_arity(
-                "co_exceptiontable",
-                |args| {
-                    let w_self = args.get(1).copied().unwrap_or(pyre_object::PY_NULL);
-                    if w_self.is_null() {
-                        return Ok(pyre_object::bytesobject::w_bytes_from_bytes(&[]));
-                    }
-                    if !unsafe { crate::pycode::is_code(w_self) } {
-                        return Err(crate::PyError::type_error(
-                            "descriptor 'co_exceptiontable' requires a 'code' object",
-                        ));
-                    }
-                    let bytes = unsafe { crate::pycode::w_code_exceptiontable(w_self) };
-                    Ok(pyre_object::bytesobject::w_bytes_from_bytes(&bytes))
-                },
+            "__hash__",
+            make_builtin_function_with_arity(
+                "__hash__",
+                |args| unsafe { Ok(pyre_object::w_int_new(crate::pycode::code_hash(args[0])?)) },
+                1,
+            ),
+        );
+        pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
+            ns,
+            "__repr__",
+            make_builtin_function_with_arity(
+                "__repr__",
+                |args| unsafe { crate::pycode::code_repr(args[0]) },
+                1,
+            ),
+        );
+        pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
+            ns,
+            "__sizeof__",
+            make_builtin_function_with_arity(
+                "__sizeof__",
+                |args| unsafe { crate::pycode::code_sizeof(args[0]) },
+                1,
+            ),
+        );
+    }
+
+    for name in ["replace", "__replace__"] {
+        unsafe {
+            pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
+                ns,
+                name,
+                make_builtin_function(name, |args| unsafe { crate::pycode::code_replace(args) }),
+            );
+        }
+    }
+    unsafe {
+        pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
+            ns,
+            "_varname_from_oparg",
+            make_builtin_function_with_arity(
+                "_varname_from_oparg",
+                |args| unsafe { crate::pycode::code_varname_from_oparg(args[0], args[1]) },
                 2,
-            )),
-        )
-    };
-    // code.co_positions() — PEP 657 per-instruction source positions
-    // (`pycode.py` exposes `co_positions` via `co_positions_iterator`).
-    // Yields one `(start_line, end_line, start_col, end_col)` tuple per
-    // instruction from the decoded `CodeObject.locations` table.
-    // `traceback._get_code_position` indexes the result at `tb_lasti // 2`,
-    // so the `tb_lasti` getter reports the byte-offset form
-    // (`2 * instruction_index`) to land on the same entry.
-    //
-    // The column fields are reported as `None`: pyre lacks the
-    // `compile(PyCF_ONLY_AST)` AST surface that `traceback`'s 3.14 caret
-    // anchoring (`_should_show_carets` / `_byte_offset_to_character_offset`)
-    // re-parses, and a `None` column makes `format_frame_summary`
-    // (`traceback.py:556-561`) take the column-free single-line branch —
-    // the same graceful degradation CPython uses when range info is absent
-    // (`-X no_debug_ranges`).  Line numbers stay exact.
-    unsafe {
-        pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
-            ns,
+            ),
+        );
+    }
+    for (name, function) in [
+        (
             "co_positions",
-            make_builtin_function("co_positions", |args| {
-                let w_self = args.first().copied().unwrap_or(pyre_object::PY_NULL);
-                if w_self.is_null() || !unsafe { crate::pycode::is_code(w_self) } {
-                    return Err(crate::PyError::type_error(
-                        "descriptor 'co_positions' requires a 'code' object",
-                    ));
-                }
-                let code_ptr =
-                    unsafe { crate::pycode::w_code_get_ptr(w_self) } as *const crate::CodeObject;
-                let rows: Vec<pyre_object::PyObjectRef> = if code_ptr.is_null() {
-                    Vec::new()
-                } else {
-                    let code = unsafe { &*code_ptr };
-                    code.locations
-                        .iter()
-                        .map(|(start, end)| {
-                            pyre_object::w_tuple_new(vec![
-                                pyre_object::w_int_new(start.line.get() as i64),
-                                pyre_object::w_int_new(end.line.get() as i64),
-                                pyre_object::w_none(),
-                                pyre_object::w_none(),
-                            ])
-                        })
-                        .collect()
-                };
-                let n = rows.len();
-                Ok(pyre_object::w_seq_iter_new(
-                    pyre_object::w_list_new(rows),
-                    n,
-                ))
-            }),
-        )
-    };
+            code_descr_positions as crate::gateway::BuiltinCodeFn,
+        ),
+        (
+            "co_lines",
+            code_descr_lines as crate::gateway::BuiltinCodeFn,
+        ),
+        (
+            "co_branches",
+            code_descr_branches as crate::gateway::BuiltinCodeFn,
+        ),
+    ] {
+        unsafe {
+            pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
+                ns,
+                name,
+                make_builtin_function_with_arity(name, function, 1),
+            );
+        }
+    }
+
+    for name in [
+        "_co_code_adaptive",
+        "co_argcount",
+        "co_posonlyargcount",
+        "co_kwonlyargcount",
+        "co_nlocals",
+        "co_stacksize",
+        "co_flags",
+        "co_code",
+        "co_consts",
+        "co_names",
+        "co_varnames",
+        "co_freevars",
+        "co_cellvars",
+        "co_filename",
+        "co_name",
+        "co_qualname",
+        "co_firstlineno",
+        "co_linetable",
+        "co_exceptiontable",
+        "co_lnotab",
+    ] {
+        let getter = make_builtin_function_with_arity(name, code_field_getter, 2);
+        unsafe {
+            pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
+                ns,
+                name,
+                make_getset_descriptor_named(getter, name),
+            );
+        }
+    }
 }
 
 /// typedef.py:533-540 Member.typedef

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -406,9 +406,15 @@ pub fn init_typeobjects() {
         // `__flags__`, `isinstance(m, object)` and the inherited
         // `object.__reduce_ex__` all resolve.  `get_instantiate(&MODULE_TYPE)`
         // (read by `w_module_new`) is wired by the `set_instantiate` loop below.
+        let module_type = new_typeobject_with_base("module", init_module_type, object_type);
+        unsafe {
+            // module.py Module.getdict plus Module.typedef.__weakref__.
+            pyre_object::w_type_set_hasdict(module_type, true);
+            pyre_object::w_type_set_weakrefable(module_type, true);
+        }
         reg.insert(
             &pyre_object::MODULE_TYPE as *const PyType as usize,
-            new_typeobject_with_base("module", init_module_type, object_type) as usize,
+            module_type as usize,
         );
         // `pypy/objspace/std/dictmultiobject.py:449/459/469` —
         // dict_keys / dict_values / dict_items.  PyPy registers
@@ -1015,6 +1021,7 @@ pub fn init_typeobjects() {
         patch_object_class_descriptor();
         patch_builtin_function_descriptors();
         patch_function_member_descriptors();
+        patch_module_descriptors();
         patch_frame_traceback_descriptors();
         patch_cell_descriptor();
         patch_getset_descriptor_metadata();
@@ -1186,6 +1193,16 @@ unsafe fn stamp_new_descr_self(ns: PyObjectRef, type_obj: PyObjectRef) {
         let Some(descr) = pyre_object::w_dict_getitem_str(ns, &key) else {
             continue;
         };
+        // CPython member descriptors carry their defining type in d_type;
+        // PyPy's Member receives w_cls while the TypeDef is materialised.
+        // Builtin TypeDef initializers necessarily create the descriptor
+        // before `type_obj` exists, so fill the equivalent typed field here.
+        if !descr.is_null() && pyre_object::is_member(descr) {
+            let owner = pyre_object::w_member_get_cls(descr);
+            if owner.is_null() {
+                pyre_object::w_member_set_cls(descr, type_obj);
+            }
+        }
         if !descr.is_null() && pyre_object::typedef::is_getset_property(descr) {
             let descr_slot = pyre_object::gc_roots::shadow_stack_len();
             pyre_object::gc_roots::pin_root(descr);
@@ -1581,19 +1598,64 @@ fn module_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError>
 /// `__name__` / `__doc__` / `__package__` / `__loader__` / `__spec__`
 /// in the module dict.
 fn module_descr_init(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    let (positional, _kwargs) = crate::builtins::split_builtin_kwargs(args);
-    if positional.len() < 2 {
-        return Err(crate::PyError::type_error(
-            "module.__init__() missing required argument 'name' (pos 1)".to_string(),
-        ));
+    let (positional, kwargs) = crate::builtins::split_builtin_kwargs(args);
+    let given = positional.len().saturating_sub(1);
+    if given > 2 {
+        return Err(crate::PyError::type_error(format!(
+            "module() takes at most 2 arguments ({given} given)"
+        )));
     }
+    let mut w_name = positional.get(1).copied();
+    let mut w_doc = positional.get(2).copied();
+    if let Some(kwargs) = kwargs {
+        for (key, value) in unsafe { pyre_object::w_dict_str_entries_wtf8(kwargs) } {
+            let Ok(key) = key.as_str() else {
+                continue;
+            };
+            if key == "__pyre_kw__" {
+                continue;
+            }
+            match key {
+                "name" if w_name.is_none() => w_name = Some(value),
+                "name" => {
+                    return Err(crate::PyError::type_error(
+                        "argument for module() given by name ('name') and position (1)",
+                    ));
+                }
+                "doc" if w_doc.is_none() => w_doc = Some(value),
+                "doc" => {
+                    return Err(crate::PyError::type_error(
+                        "argument for module() given by name ('doc') and position (2)",
+                    ));
+                }
+                other => {
+                    return Err(crate::PyError::type_error(format!(
+                        "module() got an unexpected keyword argument '{other}'"
+                    )));
+                }
+            }
+        }
+    }
+    let Some(w_name) = w_name else {
+        return Err(crate::PyError::type_error(
+            "module() missing required argument 'name' (pos 1)",
+        ));
+    };
     let self_ = positional[0];
-    let w_name = positional[1];
-    let w_doc = positional
-        .get(2)
-        .copied()
-        .unwrap_or_else(pyre_object::w_none);
-    let name = crate::baseobjspace::text_w(w_name)?;
+    if !unsafe { pyre_object::is_str(w_name) } {
+        let received = if unsafe { pyre_object::is_none(w_name) } {
+            "None".to_string()
+        } else {
+            crate::typedef::r#type(w_name)
+                .map(|tp| unsafe { pyre_object::w_type_get_name(tp) }.to_string())
+                .unwrap_or_else(|| unsafe { (*(*w_name).ob_type).name }.to_string())
+        };
+        return Err(crate::PyError::type_error(format!(
+            "module() argument 'name' must be str, not {received}"
+        )));
+    }
+    let w_doc = w_doc.unwrap_or_else(pyre_object::w_none);
+    let name = unsafe { pyre_object::w_str_get_value(w_name) };
     unsafe { pyre_object::w_module_set_name(self_, name) };
     let w_dict = unsafe { pyre_object::w_module_get_w_dict(self_) };
     unsafe {
@@ -1604,6 +1666,244 @@ fn module_descr_init(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError
         pyre_object::w_dict_setitem_str(w_dict, "__spec__", pyre_object::w_none());
     }
     Ok(pyre_object::w_none())
+}
+
+/// module.py:126-128 `Module.descr_module__repr__` — delegate to
+/// `_frozen_importlib._module_repr`, which implements the spec/file/name
+/// precedence shared by CPython 3.14.
+fn module_descr_repr(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    Ok(pyre_object::w_str_new(&module_repr_string(args[0])?))
+}
+
+pub(crate) fn module_repr_string(module: PyObjectRef) -> Result<String, crate::PyError> {
+    let importlib = crate::importing::get_sys_module("_frozen_importlib")
+        .or_else(|| crate::importing::get_sys_module("importlib._bootstrap"));
+    if let Some(importlib) = importlib {
+        let repr_fn = crate::baseobjspace::getattr_str(importlib, "_module_repr")?;
+        let result = crate::call::call_function_impl_result(repr_fn, &[module])?;
+        return Ok(crate::baseobjspace::text_w(result)?.to_string());
+    }
+    let w_dict = unsafe { pyre_object::w_module_get_w_dict(module) };
+    let loader = crate::baseobjspace::finditem_str(w_dict, "__loader__")?;
+    if let Some(spec) = crate::baseobjspace::finditem_str(w_dict, "__spec__")? {
+        if !spec.is_null()
+            && !unsafe { pyre_object::is_none(spec) }
+            && crate::baseobjspace::is_true(spec)?
+        {
+            let mut name = crate::baseobjspace::getattr_str(spec, "name")?;
+            if unsafe { pyre_object::is_none(name) } {
+                name = pyre_object::w_str_new("?");
+            }
+            let origin = crate::baseobjspace::getattr_str(spec, "origin")?;
+            if unsafe { pyre_object::is_none(origin) } {
+                let spec_loader = crate::baseobjspace::getattr_str(spec, "loader")?;
+                if unsafe { pyre_object::is_none(spec_loader) } {
+                    return Ok(format!("<module {}>", unsafe {
+                        crate::display::py_repr(name)?
+                    }));
+                }
+                return Ok(format!(
+                    "<module {} ({})>",
+                    unsafe { crate::display::py_repr(name)? },
+                    unsafe { crate::display::py_repr(spec_loader)? }
+                ));
+            }
+            let has_location = crate::baseobjspace::getattr_str(spec, "has_location")?;
+            if crate::baseobjspace::is_true(has_location)? {
+                return Ok(format!(
+                    "<module {} from {}>",
+                    unsafe { crate::display::py_repr(name)? },
+                    unsafe { crate::display::py_repr(origin)? }
+                ));
+            }
+            return Ok(format!(
+                "<module {} ({})>",
+                unsafe { crate::display::py_repr(name)? },
+                unsafe { crate::display::py_str(origin)? }
+            ));
+        }
+    }
+    let name = crate::baseobjspace::finditem_str(w_dict, "__name__")?
+        .unwrap_or_else(|| pyre_object::w_str_new("?"));
+    let name_repr = unsafe { crate::display::py_repr(name)? };
+    if let Some(filename) = crate::baseobjspace::finditem_str(w_dict, "__file__")? {
+        return Ok(format!("<module {name_repr} from {}>", unsafe {
+            crate::display::py_repr(filename)?
+        }));
+    }
+    if let Some(loader) = loader {
+        if !loader.is_null() && !unsafe { pyre_object::is_none(loader) } {
+            return Ok(format!("<module {name_repr} ({})>", unsafe {
+                crate::display::py_repr(loader)?
+            }));
+        }
+    }
+    Ok(format!("<module {name_repr}>"))
+}
+
+/// module.py:130-160 `Module.descr_getattribute`. The object-space module
+/// path already performs the normal lookup, PEP 562 `__getattr__`, and the
+/// module-specific AttributeError wording, so the descriptor is the direct
+/// entry point into that same implementation.
+fn module_descr_getattribute(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    let module = args[0];
+    let name = crate::baseobjspace::text_w(args[1])?;
+    crate::baseobjspace::getattr_str(module, name)
+}
+
+/// module.py:164-173 `Module.descr_module__dir__`.
+fn module_descr_dir(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    let module = args[0];
+    let w_dict = unsafe { pyre_object::w_module_get_w_dict(module) };
+    if w_dict.is_null()
+        || (!unsafe { pyre_object::is_dict(w_dict) }
+            && !unsafe { pyre_object::dictmultiobject::is_module_dict(w_dict) }
+            && !gettypefor(&pyre_object::DICT_TYPE).is_some_and(|dict_type| unsafe {
+                crate::baseobjspace::isinstance_w(w_dict, dict_type)
+            }))
+    {
+        return Err(crate::PyError::type_error(format!(
+            "{}.__dict__ is not a dictionary",
+            unsafe { crate::display::py_repr(module)? }
+        )));
+    }
+    if let Some(w_dir) = crate::baseobjspace::finditem_str(w_dict, "__dir__")? {
+        return crate::call::call_function_impl_result(w_dir, &[]);
+    }
+    crate::builtins::builtin_list_ctor(&[w_dict])
+}
+
+fn module_annotations_get(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    let module = args[1];
+    let w_dict = unsafe { pyre_object::w_module_get_w_dict(module) };
+    let _roots = pyre_object::gc_roots::push_roots();
+    let dict_slot = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(w_dict);
+    if let Some(annotations) = crate::baseobjspace::finditem_str(w_dict, "__annotations__")? {
+        return Ok(annotations);
+    }
+    let annotations = match crate::baseobjspace::finditem_str(w_dict, "__annotate__")? {
+        Some(annotate) if !annotate.is_null() && !unsafe { pyre_object::is_none(annotate) } => {
+            let annotate_slot = pyre_object::gc_roots::shadow_stack_len();
+            pyre_object::gc_roots::pin_root(annotate);
+            let format = pyre_object::w_int_new(1);
+            let result = crate::call::call_function_impl_result(
+                pyre_object::gc_roots::shadow_stack_get(annotate_slot),
+                &[format],
+            )?;
+            if !unsafe { pyre_object::is_dict(result) } {
+                let received = crate::typedef::r#type(result)
+                    .map(|tp| unsafe { pyre_object::w_type_get_name(tp) }.to_string())
+                    .unwrap_or_else(|| unsafe { (*(*result).ob_type).name }.to_string());
+                return Err(crate::PyError::type_error(format!(
+                    "__annotate__ returned non-dict of type '{received}'"
+                )));
+            }
+            result
+        }
+        _ => pyre_object::w_dict_new(),
+    };
+    let annotations_slot = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(annotations);
+    let key = pyre_object::w_str_new("__annotations__");
+    crate::baseobjspace::setitem(
+        pyre_object::gc_roots::shadow_stack_get(dict_slot),
+        key,
+        pyre_object::gc_roots::shadow_stack_get(annotations_slot),
+    )?;
+    Ok(pyre_object::gc_roots::shadow_stack_get(annotations_slot))
+}
+
+fn module_annotations_set(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    let module = args[1];
+    let value = args[2];
+    let w_dict = unsafe { pyre_object::w_module_get_w_dict(module) };
+    let _roots = pyre_object::gc_roots::push_roots();
+    let dict_slot = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(w_dict);
+    let value_slot = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(value);
+    let annotations_key = pyre_object::w_str_new("__annotations__");
+    crate::baseobjspace::setitem(
+        pyre_object::gc_roots::shadow_stack_get(dict_slot),
+        annotations_key,
+        pyre_object::gc_roots::shadow_stack_get(value_slot),
+    )?;
+    let annotate_key = pyre_object::w_str_new("__annotate__");
+    let _ = crate::baseobjspace::delitem(
+        pyre_object::gc_roots::shadow_stack_get(dict_slot),
+        annotate_key,
+    );
+    Ok(pyre_object::w_none())
+}
+
+fn module_annotations_del(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    let module = args[1];
+    let w_dict = unsafe { pyre_object::w_module_get_w_dict(module) };
+    let _roots = pyre_object::gc_roots::push_roots();
+    let dict_slot = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(w_dict);
+    if crate::baseobjspace::finditem_str(w_dict, "__annotations__")?.is_none() {
+        return Err(crate::PyError::attribute_error("__annotations__"));
+    }
+    let annotations_key = pyre_object::w_str_new("__annotations__");
+    crate::baseobjspace::delitem(
+        pyre_object::gc_roots::shadow_stack_get(dict_slot),
+        annotations_key,
+    )?;
+    let annotate_key = pyre_object::w_str_new("__annotate__");
+    let _ = crate::baseobjspace::delitem(
+        pyre_object::gc_roots::shadow_stack_get(dict_slot),
+        annotate_key,
+    );
+    Ok(pyre_object::w_none())
+}
+
+fn module_annotate_get(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    let module = args[1];
+    let w_dict = unsafe { pyre_object::w_module_get_w_dict(module) };
+    if let Some(annotate) = crate::baseobjspace::finditem_str(w_dict, "__annotate__")? {
+        return Ok(annotate);
+    }
+    let none = pyre_object::w_none();
+    crate::baseobjspace::setitem(w_dict, pyre_object::w_str_new("__annotate__"), none)?;
+    Ok(none)
+}
+
+fn module_annotate_set(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    let module = args[1];
+    let value = args[2];
+    if !unsafe { pyre_object::is_none(value) } && !crate::baseobjspace::callable_w(value) {
+        return Err(crate::PyError::type_error(
+            "__annotate__ must be callable or None",
+        ));
+    }
+    let w_dict = unsafe { pyre_object::w_module_get_w_dict(module) };
+    let _roots = pyre_object::gc_roots::push_roots();
+    let dict_slot = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(w_dict);
+    let value_slot = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(value);
+    let annotate_key = pyre_object::w_str_new("__annotate__");
+    crate::baseobjspace::setitem(
+        pyre_object::gc_roots::shadow_stack_get(dict_slot),
+        annotate_key,
+        pyre_object::gc_roots::shadow_stack_get(value_slot),
+    )?;
+    if !unsafe { pyre_object::is_none(value) } {
+        let annotations_key = pyre_object::w_str_new("__annotations__");
+        let _ = crate::baseobjspace::delitem(
+            pyre_object::gc_roots::shadow_stack_get(dict_slot),
+            annotations_key,
+        );
+    }
+    Ok(pyre_object::w_none())
+}
+
+fn module_annotate_del(_args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    Err(crate::PyError::type_error(
+        "cannot delete __annotate__ attribute",
+    ))
 }
 
 /// `module.py Module.typedef` — wire `__new__` / `__init__` so
@@ -1622,6 +1922,65 @@ fn init_module_type(ns: PyObjectRef) {
             ns,
             "__init__",
             make_builtin_function("__init__", module_descr_init),
+        )
+    };
+    for (name, function, arity) in [
+        (
+            "__repr__",
+            module_descr_repr as crate::gateway::BuiltinCodeFn,
+            1,
+        ),
+        ("__getattribute__", module_descr_getattribute, 2),
+        ("__dir__", module_descr_dir, 1),
+    ] {
+        unsafe {
+            pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
+                ns,
+                name,
+                make_builtin_function_with_arity(name, function, arity),
+            )
+        };
+    }
+    unsafe {
+        pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
+            ns,
+            "__dict__",
+            pyre_object::w_member_new_direct(
+                pyre_object::MEMBER_MODULE_DICT,
+                "__dict__".to_owned(),
+                pyre_object::PY_NULL,
+            ),
+        )
+    };
+    unsafe {
+        pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
+            ns,
+            "__annotations__",
+            make_getset_property(
+                make_builtin_function_with_arity("__annotations__", module_annotations_get, 2),
+                make_builtin_function_with_arity("__annotations__", module_annotations_set, 3),
+                make_builtin_function_with_arity("__annotations__", module_annotations_del, 2),
+            ),
+        )
+    };
+    unsafe {
+        pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
+            ns,
+            "__annotate__",
+            make_getset_property(
+                make_builtin_function_with_arity("__annotate__", module_annotate_get, 2),
+                make_builtin_function_with_arity("__annotate__", module_annotate_set, 3),
+                make_builtin_function_with_arity("__annotate__", module_annotate_del, 2),
+            ),
+        )
+    };
+    unsafe {
+        pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
+            ns,
+            "__doc__",
+            pyre_object::w_str_new(
+                "Create a module object.\n\nThe name must be a string; the optional doc argument can have any type.",
+            ),
         )
     };
 }
@@ -7246,11 +7605,7 @@ fn init_getset_descriptor_type(ns: PyObjectRef) {
                 if !reqcls.is_null() {
                     if let Err(e) = crate::baseobjspace::descr_self_interp_w(reqcls, w_obj) {
                         if e.kind == crate::PyErrorKind::DescrMismatch {
-                            return Err(crate::baseobjspace::descr_call_mismatch(
-                                w_obj,
-                                "__getattribute__",
-                                reqcls,
-                            ));
+                            return Err(getset_descr_mismatch(w_self, w_obj, reqcls));
                         }
                         return Err(e);
                     }
@@ -7261,9 +7616,9 @@ fn init_getset_descriptor_type(ns: PyObjectRef) {
                 }
                 match crate::call::call_function_impl_result(fget, &[w_self, w_obj]) {
                     Ok(v) => Ok(v),
-                    Err(e) if e.kind == crate::PyErrorKind::DescrMismatch => Err(
-                        crate::baseobjspace::descr_call_mismatch(w_obj, "__getattribute__", reqcls),
-                    ),
+                    Err(e) if e.kind == crate::PyErrorKind::DescrMismatch => {
+                        Err(getset_descr_mismatch(w_self, w_obj, reqcls))
+                    }
                     Err(e) => Err(e),
                 }
             }),
@@ -7303,20 +7658,16 @@ fn init_getset_descriptor_type(ns: PyObjectRef) {
                     if !reqcls.is_null() {
                         if let Err(e) = crate::baseobjspace::descr_self_interp_w(reqcls, w_obj) {
                             if e.kind == crate::PyErrorKind::DescrMismatch {
-                                return Err(crate::baseobjspace::descr_call_mismatch(
-                                    w_obj,
-                                    "__setattr__",
-                                    reqcls,
-                                ));
+                                return Err(getset_descr_mismatch(w_self, w_obj, reqcls));
                             }
                             return Err(e);
                         }
                     }
                     match crate::call::call_function_impl_result(fset, &[w_self, w_obj, w_value]) {
                         Ok(_) => Ok(pyre_object::w_none()),
-                        Err(e) if e.kind == crate::PyErrorKind::DescrMismatch => Err(
-                            crate::baseobjspace::descr_call_mismatch(w_obj, "__setattr__", reqcls),
-                        ),
+                        Err(e) if e.kind == crate::PyErrorKind::DescrMismatch => {
+                            Err(getset_descr_mismatch(w_self, w_obj, reqcls))
+                        }
                         Err(e) => Err(e),
                     }
                 },
@@ -7375,20 +7726,16 @@ fn init_getset_descriptor_type(ns: PyObjectRef) {
                     if !reqcls.is_null() {
                         if let Err(e) = crate::baseobjspace::descr_self_interp_w(reqcls, w_obj) {
                             if e.kind == crate::PyErrorKind::DescrMismatch {
-                                return Err(crate::baseobjspace::descr_call_mismatch(
-                                    w_obj,
-                                    "__delattr__",
-                                    reqcls,
-                                ));
+                                return Err(getset_descr_mismatch(w_self, w_obj, reqcls));
                             }
                             return Err(e);
                         }
                     }
                     match crate::call::call_function_impl_result(fdel, &[w_self, w_obj]) {
                         Ok(_) => Ok(pyre_object::w_none()),
-                        Err(e) if e.kind == crate::PyErrorKind::DescrMismatch => Err(
-                            crate::baseobjspace::descr_call_mismatch(w_obj, "__delattr__", reqcls),
-                        ),
+                        Err(e) if e.kind == crate::PyErrorKind::DescrMismatch => {
+                            Err(getset_descr_mismatch(w_self, w_obj, reqcls))
+                        }
                         Err(e) => Err(e),
                     }
                 },
@@ -8671,74 +9018,67 @@ fn function_descr_call(args: &[PyObjectRef]) -> crate::PyResult {
     })
 }
 
-/// Python 3.14 `PyFunction_Type` direct `PyMemberDef` accessors. PyPy's
-/// `Function.typedef` spells these values as GetSetProperty entries, but 3.14
-/// exposes them as member_descriptor objects. The tagged Member index keeps
-/// the descriptor shape distinct while these helpers preserve the existing
-/// Function field semantics.
-pub(crate) unsafe fn function_direct_member_get(
-    member: PyObjectRef,
-    function: PyObjectRef,
-) -> crate::PyResult {
+/// Python 3.14 direct `PyMemberDef` accessors. The tagged Member index keeps
+/// native object fields on the descriptor itself rather than in a side table.
+pub(crate) unsafe fn direct_member_get(member: PyObjectRef, obj: PyObjectRef) -> crate::PyResult {
     match unsafe { pyre_object::w_member_get_direct_kind(member) } {
         pyre_object::MEMBER_FUNCTION_CLOSURE => {
-            Ok(unsafe { crate::function::fget_func_closure(function) })
+            Ok(unsafe { crate::function::fget_func_closure(obj) })
         }
-        pyre_object::MEMBER_FUNCTION_DOC => Ok(unsafe { crate::function::fget_func_doc(function) }),
+        pyre_object::MEMBER_FUNCTION_DOC => Ok(unsafe { crate::function::fget_func_doc(obj) }),
         pyre_object::MEMBER_FUNCTION_GLOBALS => {
-            let value = unsafe { crate::function::function_get_globals_obj(function) };
+            let value = unsafe { crate::function::function_get_globals_obj(obj) };
             Ok(if value.is_null() {
                 pyre_object::w_none()
             } else {
                 value
             })
         }
-        pyre_object::MEMBER_FUNCTION_MODULE => {
-            Ok(unsafe { crate::function::fget___module__(function) })
-        }
+        pyre_object::MEMBER_FUNCTION_MODULE => Ok(unsafe { crate::function::fget___module__(obj) }),
         pyre_object::MEMBER_FUNCTION_BUILTINS => {
-            let builtins = unsafe { crate::function::function_get_builtins(function) };
+            let builtins = unsafe { crate::function::function_get_builtins(obj) };
             Ok(if builtins.is_null() {
                 pyre_object::w_none()
             } else {
                 builtins
             })
         }
+        pyre_object::MEMBER_MODULE_DICT => Ok(unsafe { pyre_object::w_module_get_w_dict(obj) }),
         _ => Err(crate::PyError::attribute_error(unsafe {
             pyre_object::w_member_get_name(member)
         })),
     }
 }
 
-pub(crate) unsafe fn function_direct_member_set(
+pub(crate) unsafe fn direct_member_set(
     member: PyObjectRef,
-    function: PyObjectRef,
+    obj: PyObjectRef,
     value: PyObjectRef,
 ) -> crate::PyResult {
     match unsafe { pyre_object::w_member_get_direct_kind(member) } {
         pyre_object::MEMBER_FUNCTION_DOC => {
-            unsafe { crate::function::fset_func_doc(function, value)? };
+            unsafe { crate::function::fset_func_doc(obj, value)? };
             Ok(pyre_object::w_none())
         }
         pyre_object::MEMBER_FUNCTION_MODULE => {
-            unsafe { crate::function::fset___module__(function, value)? };
+            unsafe { crate::function::fset___module__(obj, value)? };
             Ok(pyre_object::w_none())
         }
         _ => Err(crate::PyError::attribute_error("readonly attribute")),
     }
 }
 
-pub(crate) unsafe fn function_direct_member_delete(
+pub(crate) unsafe fn direct_member_delete(
     member: PyObjectRef,
-    function: PyObjectRef,
+    obj: PyObjectRef,
 ) -> crate::PyResult {
     match unsafe { pyre_object::w_member_get_direct_kind(member) } {
         pyre_object::MEMBER_FUNCTION_DOC => {
-            unsafe { crate::function::fdel_func_doc(function)? };
+            unsafe { crate::function::fdel_func_doc(obj)? };
             Ok(pyre_object::w_none())
         }
         pyre_object::MEMBER_FUNCTION_MODULE => {
-            unsafe { crate::function::fdel___module__(function)? };
+            unsafe { crate::function::fdel___module__(obj)? };
             Ok(pyre_object::w_none())
         }
         _ => Err(crate::PyError::attribute_error("readonly attribute")),
@@ -9055,6 +9395,24 @@ fn patch_function_member_descriptors() {
         if let Some(descr) = crate::type_dict_lookup(function_type, name) {
             if unsafe { pyre_object::is_member(descr) && pyre_object::w_member_is_direct(descr) } {
                 unsafe { pyre_object::w_member_set_cls(descr, function_type) };
+            }
+        }
+    }
+}
+
+/// module.py Module.typedef binds the `__annotations__` methods to Module;
+/// stamp that inferred `cls=Module` after the W_TypeObject is registered so
+/// foreign receivers fail in GetSetProperty.typecheck before field access.
+fn patch_module_descriptors() {
+    let module_type =
+        gettypefor(&pyre_object::MODULE_TYPE as *const PyType).unwrap_or(pyre_object::PY_NULL);
+    if module_type.is_null() || !crate::type_dict_has_storage(module_type) {
+        return;
+    }
+    for name in ["__annotations__", "__annotate__"] {
+        if let Some(descr) = crate::type_dict_lookup(module_type, name) {
+            if unsafe { pyre_object::typedef::is_getset_property(descr) } {
+                unsafe { pyre_object::typedef::w_getset_set_reqcls(descr, module_type) };
             }
         }
     }
@@ -9660,7 +10018,7 @@ fn init_member_descriptor_type(ns: PyObjectRef) {
                     }
                 }
                 if unsafe { pyre_object::w_member_is_direct(descr) } {
-                    return unsafe { function_direct_member_get(descr, obj) };
+                    return unsafe { direct_member_get(descr, obj) };
                 }
                 // typedef.py:511-516: w_result = w_obj.getslotvalue(self.index);
                 // None → AttributeError("'%T' object has no attribute '%s'").
@@ -9714,7 +10072,7 @@ fn init_member_descriptor_type(ns: PyObjectRef) {
                     }
                 }
                 if unsafe { pyre_object::w_member_is_direct(descr) } {
-                    return unsafe { function_direct_member_set(descr, obj, value) };
+                    return unsafe { direct_member_set(descr, obj, value) };
                 }
                 // typedef.py:522: w_obj.setslotvalue(self.index, w_value)
                 let index = unsafe { pyre_object::w_member_get_index(descr) };
@@ -9765,7 +10123,7 @@ fn init_member_descriptor_type(ns: PyObjectRef) {
                     }
                 }
                 if unsafe { pyre_object::w_member_is_direct(descr) } {
-                    return unsafe { function_direct_member_delete(descr, obj) };
+                    return unsafe { direct_member_delete(descr, obj) };
                 }
                 // typedef.py:527-531: success = w_obj.delslotvalue(self.index)
                 let slot_name = unsafe { pyre_object::w_member_get_name(descr) };
@@ -19903,6 +20261,31 @@ fn read_descr_name(descr: pyre_object::PyObjectRef) -> pyre_object::PyObjectRef 
         return pyre_object::PY_NULL;
     }
     unsafe { pyre_object::typedef::w_getset_get_name(descr) }
+}
+
+/// CPython 3.14 `getset_get` / `getset_set` receiver mismatch wording.
+/// PyPy routes the same `DescrMismatch` through `descr_call_mismatch`; only
+/// the version-selected public TypeError text differs here.
+fn getset_descr_mismatch(
+    descr: pyre_object::PyObjectRef,
+    obj: pyre_object::PyObjectRef,
+    reqcls: pyre_object::PyObjectRef,
+) -> crate::PyError {
+    let name_obj = read_descr_name(descr);
+    let name = if !name_obj.is_null() && unsafe { pyre_object::is_str(name_obj) } {
+        unsafe { pyre_object::w_str_get_value(name_obj) }
+    } else {
+        "<generic property>"
+    };
+    let owner = if reqcls.is_null() {
+        "?"
+    } else {
+        unsafe { pyre_object::w_type_get_name(reqcls) }
+    };
+    crate::PyError::type_error(format!(
+        "descriptor '{name}' for '{owner}' objects doesn't apply to a '{}' object",
+        type_name_of(obj)
+    ))
 }
 
 /// typedef.py:337-345 GetSetProperty.copy_for_type.

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -8627,13 +8627,22 @@ fn init_function_type(ns: PyObjectRef) {
                 // as a plain function rather than a bound method.
                 let cls_is_none = unsafe { w_cls.is_null() || pyre_object::is_none(w_cls) };
                 let obj_is_none = unsafe { w_obj.is_null() || pyre_object::is_none(w_obj) };
-                let cls_is_none_type = std::ptr::eq(w_cls, gettypeobject(&pyre_object::NONE_TYPE));
-                let asking_for_function = cls_is_none || (obj_is_none && !cls_is_none_type);
-                if asking_for_function {
+                // Python 3.14 `func_descr_get`: omitting `type` is equivalent
+                // to passing None, but `__get__(None, None)` is invalid.
+                if obj_is_none && cls_is_none {
+                    return Err(crate::PyError::type_error("__get__(None, None) is invalid"));
+                }
+                if obj_is_none {
                     Ok(w_function)
                 } else {
-                    // function.py:470  Method(space, w_function, w_obj, w_cls)
-                    Ok(pyre_object::w_method_new(w_function, w_obj, w_cls))
+                    // function.py:470 Method(space, w_function, w_obj, w_cls),
+                    // with CPython's inferred owner when `type` is omitted.
+                    let owner = if cls_is_none {
+                        r#type(w_obj).unwrap_or(pyre_object::PY_NULL)
+                    } else {
+                        w_cls
+                    };
+                    Ok(pyre_object::w_method_new(w_function, w_obj, owner))
                 }
             }),
         )
@@ -8951,6 +8960,59 @@ fn init_builtin_code_type(ns: PyObjectRef) {
 }
 
 fn init_method_type(ns: PyObjectRef) {
+    // typedef.py:833-848 Method.typedef, completed with CPython 3.14's
+    // ordering wrappers. Bound methods carry one wrapped callable and one
+    // bound instance; every operation below reads those two typed fields.
+    let doc_getter = make_builtin_function_with_arity(
+        "__doc__",
+        |args| {
+            let method = args.get(1).copied().unwrap_or(pyre_object::PY_NULL);
+            let function = unsafe { pyre_object::w_method_get_func(method) };
+            crate::baseobjspace::getattr_str(function, "__doc__")
+        },
+        2,
+    );
+    unsafe {
+        pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
+            ns,
+            "__doc__",
+            make_getset_descriptor(doc_getter),
+        )
+    };
+    unsafe {
+        pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
+            ns,
+            "__new__",
+            make_new_descr(|args| {
+                if args.len() != 3 {
+                    return Err(crate::PyError::type_error(format!(
+                        "method expected 2 arguments, got {}",
+                        args.len().saturating_sub(1),
+                    )));
+                }
+                crate::function::descr_method__new__(args[0], args[1], args[2])
+            }),
+        )
+    };
+    unsafe {
+        pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
+            ns,
+            "__call__",
+            make_builtin_function("__call__", crate::function::descr_method_call),
+        )
+    };
+    unsafe {
+        pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
+            ns,
+            "__get__",
+            make_builtin_function("__get__", |args| unsafe {
+                let method = args.first().copied().unwrap_or(pyre_object::PY_NULL);
+                let obj = args.get(1).copied().unwrap_or(pyre_object::PY_NULL);
+                let cls = args.get(2).copied().unwrap_or(pyre_object::PY_NULL);
+                crate::function::descr_method_get(method, obj, cls)
+            }),
+        )
+    };
     // typedef.py:839-840 ─
     //   __func__ = interp_attrproperty_w('w_function', cls=Method),
     //   __self__ = interp_attrproperty_w('w_instance', cls=Method),
@@ -9004,6 +9066,89 @@ fn init_method_type(ns: PyObjectRef) {
             ns,
             "__self__",
             make_getset_descriptor(self_getter),
+        )
+    };
+    unsafe {
+        pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
+            ns,
+            "__getattribute__",
+            make_builtin_function_with_arity(
+                "__getattribute__",
+                |args| unsafe { crate::function::descr_method_getattribute(args[0], args[1]) },
+                2,
+            ),
+        )
+    };
+    unsafe {
+        pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
+            ns,
+            "__eq__",
+            make_builtin_function_with_arity(
+                "__eq__",
+                |args| unsafe { crate::function::descr_method_eq(args[0], args[1]) },
+                2,
+            ),
+        )
+    };
+    unsafe {
+        pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
+            ns,
+            "__ne__",
+            make_builtin_function_with_arity(
+                "__ne__",
+                |args| unsafe { crate::function::descr_method_ne(args[0], args[1]) },
+                2,
+            ),
+        )
+    };
+    for name in ["__lt__", "__le__", "__gt__", "__ge__"] {
+        unsafe {
+            pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
+                ns,
+                name,
+                make_builtin_function_with_arity(
+                    name,
+                    |_args| Ok(pyre_object::special::w_not_implemented()),
+                    2,
+                ),
+            )
+        };
+    }
+    unsafe {
+        pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
+            ns,
+            "__hash__",
+            make_builtin_function_with_arity(
+                "__hash__",
+                |args| unsafe {
+                    Ok(pyre_object::w_int_new(crate::function::descr_method_hash(
+                        args[0],
+                    )?))
+                },
+                1,
+            ),
+        )
+    };
+    unsafe {
+        pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
+            ns,
+            "__repr__",
+            make_builtin_function_with_arity(
+                "__repr__",
+                |args| unsafe { crate::function::descr_method_repr(args[0]) },
+                1,
+            ),
+        )
+    };
+    unsafe {
+        pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
+            ns,
+            "__reduce__",
+            make_builtin_function_with_arity(
+                "__reduce__",
+                |args| unsafe { crate::function::descr_method__reduce__(args[0]) },
+                1,
+            ),
         )
     };
 }
@@ -10104,6 +10249,27 @@ fn init_classmethod_type(ns: PyObjectRef) {
         unsafe { pyre_object::w_dict_setitem_str_no_proxy(ns, name, value) };
     }
 }
+
+/// CPython 3.14 `PyFunction_Type.tp_doc`. The instance `__doc__` getset
+/// occupies the function type dictionary's key, so exact type access is
+/// served separately by `baseobjspace`, as for property.
+pub(crate) const FUNCTION_DOC: &str = r#"Create a function object.
+
+  code
+    a code object
+  globals
+    the globals dictionary
+  name
+    a string that overrides the name from the code object
+  argdefs
+    a tuple that specifies the default argument values
+  closure
+    a tuple that supplies the bindings for free variables
+  kwdefaults
+    a dictionary that specifies the default keyword argument values"#;
+
+/// CPython 3.14 `PyMethod_Type.tp_doc`.
+pub(crate) const METHOD_DOC: &str = "Create a bound instance method object.";
 
 /// CPython 3.14 `PyProperty_Type.tp_doc`.  The instance-level `__doc__`
 /// descriptor occupies the same type-dict key; `baseobjspace` serves this

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -1054,6 +1054,7 @@ fn patch_object_class_descriptor() {
             class_getter,
             class_setter,
             pyre_object::PY_NULL,
+            pyre_object::PY_NULL,
             object_type,
             Some("__class__"),
         ),
@@ -4931,21 +4932,28 @@ fn init_dict_view_common_slots(ns: PyObjectRef) {
         pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
             ns,
             "mapping",
-            make_getset_descriptor(make_builtin_function_with_arity(
+            make_getset_property_named_doc(
+                make_builtin_function_with_arity(
+                    "mapping",
+                    |args| {
+                        let view = args[1];
+                        if view.is_null() {
+                            return Ok(pyre_object::w_none());
+                        }
+                        let dict =
+                            unsafe { pyre_object::dictmultiobject::w_dict_view_get_dict(view) };
+                        if dict.is_null() {
+                            return Ok(pyre_object::w_dict_proxy_new(pyre_object::w_dict_new()));
+                        }
+                        Ok(pyre_object::w_dict_proxy_new(dict))
+                    },
+                    2,
+                ),
+                pyre_object::PY_NULL,
+                pyre_object::PY_NULL,
+                "dictionary that this view refers to",
                 "mapping",
-                |args| {
-                    let view = args[1];
-                    if view.is_null() {
-                        return Ok(pyre_object::w_none());
-                    }
-                    let dict = unsafe { pyre_object::dictmultiobject::w_dict_view_get_dict(view) };
-                    if dict.is_null() {
-                        return Ok(pyre_object::w_dict_proxy_new(pyre_object::w_dict_new()));
-                    }
-                    Ok(pyre_object::w_dict_proxy_new(dict))
-                },
-                2,
-            )),
+            ),
         )
     };
 }
@@ -7388,6 +7396,39 @@ fn init_getset_descriptor_type(ns: PyObjectRef) {
             ),
         )
     };
+    // CPython 3.14 `PyGetSetDescr_Type.tp_repr` renders
+    // `<attribute 'name' of 'Owner' objects>`. PyPy's GetSetProperty typedef
+    // has no explicit repr; this is the selected 3.14 surface.
+    unsafe {
+        pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
+            ns,
+            "__repr__",
+            make_builtin_function_with_arity(
+                "__repr__",
+                |args| {
+                    let descr = args.first().copied().unwrap_or(pyre_object::PY_NULL);
+                    if descr.is_null()
+                        || !unsafe { pyre_object::typedef::is_getset_property(descr) }
+                    {
+                        let received = if descr.is_null() {
+                            "NoneType".to_string()
+                        } else {
+                            crate::typedef::r#type(descr)
+                                .map(|tp| unsafe { pyre_object::w_type_get_name(tp) }.to_string())
+                                .unwrap_or_else(|| "object".to_string())
+                        };
+                        return Err(crate::PyError::type_error(format!(
+                            "descriptor '__repr__' requires a 'getset_descriptor' object but received a '{received}'"
+                        )));
+                    }
+                    Ok(pyre_object::w_str_new(&unsafe {
+                        getset_descriptor_repr(descr)
+                    }))
+                },
+                1,
+            ),
+        )
+    };
     // The four metadata getsets (typedef.py:470-473
     // __name__/__qualname__/__objclass__/__doc__) cannot be
     // installed inside this function — each one allocates a fresh
@@ -7426,21 +7467,27 @@ fn patch_getset_descriptor_metadata() {
     crate::type_dict_store(
         tp,
         "__name__",
-        make_getset_descriptor(make_builtin_function_with_arity(
-            "__name__",
-            |args| {
-                let descr = args[1];
-                if descr.is_null() {
-                    return Ok(pyre_object::w_none());
-                }
-                let name = unsafe { pyre_object::typedef::w_getset_get_name(descr) };
-                if name.is_null() {
-                    return Ok(pyre_object::w_none());
-                }
-                Ok(name)
-            },
-            2,
-        )),
+        copy_for_type(
+            make_getset_descriptor_named(
+                make_builtin_function_with_arity(
+                    "__name__",
+                    |args| {
+                        let descr = args[1];
+                        if descr.is_null() {
+                            return Ok(pyre_object::w_none());
+                        }
+                        let name = unsafe { pyre_object::typedef::w_getset_get_name(descr) };
+                        if name.is_null() {
+                            return Ok(pyre_object::w_none());
+                        }
+                        Ok(name)
+                    },
+                    2,
+                ),
+                "__name__",
+            ),
+            tp,
+        ),
     );
     // typedef.py:471 __qualname__ = GetSetProperty(descr_get_qualname)
     //
@@ -7463,61 +7510,64 @@ fn patch_getset_descriptor_metadata() {
     crate::type_dict_store(
         tp,
         "__qualname__",
-        make_getset_descriptor(make_builtin_function_with_arity(
-            "__qualname__",
-            |args| {
-                let descr = args[1];
-                if descr.is_null() {
-                    return Ok(pyre_object::w_none());
-                }
-                unsafe {
-                    let cached = pyre_object::typedef::w_getset_get_qualname(descr);
-                    if !cached.is_null() {
-                        return Ok(cached);
-                    }
-                    // typedef.py:425-432 _calculate_qualname:
-                    //   if self.reqcls is None: type_qualname = '?'
-                    //   else:
-                    //       w_type = space.gettypeobject(self.reqcls.typedef)
-                    //       type_qualname = space.text_w(
-                    //           space.getattr(w_type, space.newtext('__qualname__')))
-                    //
-                    // PyPy reads the bound class's `__qualname__`
-                    // (which respects nested-class scoping and any
-                    // explicit `__qualname__` assignment in the class
-                    // body), NOT the bare `__name__`.  Pyre's
-                    // `getattr(w_type, '__qualname__')` resolves
-                    // through the type-side __qualname__ getset that
-                    // already mirrors PyPy's lookup-then-fallback
-                    // chain (`baseobjspace.rs:4004-4009`).
-                    let reqcls = pyre_object::typedef::w_getset_get_reqcls(descr);
-                    let type_qualname = if reqcls.is_null() {
-                        "?".to_string()
-                    } else {
-                        match crate::baseobjspace::getattr_str(reqcls, "__qualname__") {
-                            Ok(qn) if pyre_object::is_str(qn) => {
-                                pyre_object::w_str_get_value(qn).to_string()
-                            }
-                            // PyPy raises through here on AttributeError;
-                            // pyre falls back to the bare type name to
-                            // avoid surfacing an unrelated AttributeError
-                            // when introspecting `descr.__qualname__`.
-                            _ => pyre_object::w_type_get_name(reqcls).to_string(),
+        copy_for_type(
+            make_getset_descriptor_named(
+                make_builtin_function_with_arity(
+                    "__qualname__",
+                    |args| {
+                        let descr = args[1];
+                        if descr.is_null() {
+                            return Ok(pyre_object::w_none());
                         }
-                    };
-                    let name_obj = pyre_object::typedef::w_getset_get_name(descr);
-                    let name = if !name_obj.is_null() && pyre_object::is_str(name_obj) {
-                        pyre_object::w_str_get_value(name_obj).to_string()
-                    } else {
-                        "<generic property>".to_string()
-                    };
-                    let combined = pyre_object::w_str_new(&format!("{type_qualname}.{name}"));
-                    pyre_object::typedef::w_getset_set_qualname(descr, combined);
-                    Ok(combined)
-                }
-            },
-            2,
-        )),
+                        unsafe {
+                            let cached = pyre_object::typedef::w_getset_get_qualname(descr);
+                            if !cached.is_null() {
+                                return Ok(cached);
+                            }
+                            // typedef.py:425-432 _calculate_qualname:
+                            //   if self.reqcls is None: type_qualname = '?'
+                            //   else:
+                            //       w_type = space.gettypeobject(self.reqcls.typedef)
+                            //       type_qualname = space.text_w(
+                            //           space.getattr(w_type, space.newtext('__qualname__')))
+                            //
+                            // PyPy reads the bound class's `__qualname__`
+                            // (which respects nested-class scoping and any
+                            // explicit `__qualname__` assignment in the class
+                            // body), NOT the bare `__name__`.  Pyre's
+                            // `getattr(w_type, '__qualname__')` resolves
+                            // through the type-side __qualname__ getset that
+                            // already mirrors PyPy's lookup-then-fallback
+                            // chain (`baseobjspace.rs:4004-4009`).
+                            // PyPy's original only consults `reqcls`. During type
+                            // materialisation `copy_for_type` deliberately leaves
+                            // reqcls null and records the concrete owner in
+                            // `w_objclass`; CPython 3.14 uses that owner for both
+                            // __objclass__ and __qualname__, so prefer it here.
+                            let owner = getset_descriptor_owner(descr);
+                            let type_qualname = if owner.is_null() {
+                                "?".to_string()
+                            } else {
+                                descriptor_owner_qualname(owner)
+                            };
+                            let name_obj = pyre_object::typedef::w_getset_get_name(descr);
+                            let name = if !name_obj.is_null() && pyre_object::is_str(name_obj) {
+                                pyre_object::w_str_get_value(name_obj).to_string()
+                            } else {
+                                "<generic property>".to_string()
+                            };
+                            let combined =
+                                pyre_object::w_str_new(&format!("{type_qualname}.{name}"));
+                            pyre_object::typedef::w_getset_set_qualname(descr, combined);
+                            Ok(combined)
+                        }
+                    },
+                    2,
+                ),
+                "__qualname__",
+            ),
+            tp,
+        ),
     );
     // typedef.py:472 __objclass__ = GetSetProperty(descr_get_objclass)
     //
@@ -7533,52 +7583,107 @@ fn patch_getset_descriptor_metadata() {
     crate::type_dict_store(
         tp,
         "__objclass__",
-        make_getset_descriptor(make_builtin_function_with_arity(
-            "__objclass__",
-            |args| {
-                let descr = args[1];
-                if descr.is_null() {
-                    return Err(crate::PyError::attribute_error(
-                        "generic self has no __objclass__",
-                    ));
-                }
-                unsafe {
-                    let w_objclass = pyre_object::typedef::w_getset_get_objclass(descr);
-                    if !w_objclass.is_null() {
-                        return Ok(w_objclass);
-                    }
-                    let reqcls = pyre_object::typedef::w_getset_get_reqcls(descr);
-                    if !reqcls.is_null() {
-                        return Ok(reqcls);
-                    }
-                    Err(crate::PyError::attribute_error(
-                        "generic self has no __objclass__",
-                    ))
-                }
-            },
-            2,
-        )),
+        copy_for_type(
+            make_getset_descriptor_named(
+                make_builtin_function_with_arity(
+                    "__objclass__",
+                    |args| {
+                        let descr = args[1];
+                        if descr.is_null() {
+                            return Err(crate::PyError::attribute_error(
+                                "generic self has no __objclass__",
+                            ));
+                        }
+                        unsafe {
+                            let w_objclass = pyre_object::typedef::w_getset_get_objclass(descr);
+                            if !w_objclass.is_null() {
+                                return Ok(w_objclass);
+                            }
+                            let reqcls = pyre_object::typedef::w_getset_get_reqcls(descr);
+                            if !reqcls.is_null() {
+                                return Ok(reqcls);
+                            }
+                            Err(crate::PyError::attribute_error(
+                                "generic self has no __objclass__",
+                            ))
+                        }
+                    },
+                    2,
+                ),
+                "__objclass__",
+            ),
+            tp,
+        ),
     );
     // typedef.py:473 __doc__ = interp_attrproperty('doc', ...)
     crate::type_dict_store(
         tp,
         "__doc__",
-        make_getset_descriptor(make_builtin_function_with_arity(
-            "__doc__",
-            |args| {
-                let descr = args[1];
-                if descr.is_null() {
-                    return Ok(pyre_object::w_none());
-                }
-                let doc = unsafe { pyre_object::typedef::w_getset_get_doc(descr) };
-                if doc.is_null() {
-                    return Ok(pyre_object::w_none());
-                }
-                Ok(doc)
-            },
-            2,
-        )),
+        copy_for_type(
+            make_getset_descriptor_named(
+                make_builtin_function_with_arity(
+                    "__doc__",
+                    |args| {
+                        let descr = args[1];
+                        if descr.is_null() {
+                            return Ok(pyre_object::w_none());
+                        }
+                        let doc = unsafe { pyre_object::typedef::w_getset_get_doc(descr) };
+                        if doc.is_null() {
+                            return Ok(pyre_object::w_none());
+                        }
+                        Ok(doc)
+                    },
+                    2,
+                ),
+                "__doc__",
+            ),
+            tp,
+        ),
     );
+}
+
+#[inline]
+unsafe fn getset_descriptor_owner(descr: PyObjectRef) -> PyObjectRef {
+    let objclass = unsafe { pyre_object::typedef::w_getset_get_objclass(descr) };
+    if !objclass.is_null() {
+        objclass
+    } else {
+        unsafe { pyre_object::typedef::w_getset_get_reqcls(descr) }
+    }
+}
+
+/// The owner component used by CPython 3.14 descriptor `__qualname__`.
+/// Heap classes carry their compiler-stamped qualified name in their own
+/// namespace; static types fall back to the bare final component of tp_name.
+unsafe fn descriptor_owner_qualname(owner: PyObjectRef) -> String {
+    match crate::type_dict_lookup(owner, "__qualname__") {
+        Some(value) if unsafe { pyre_object::is_str(value) } => {
+            unsafe { pyre_object::w_str_get_value(value) }.to_string()
+        }
+        _ => {
+            let full = unsafe { pyre_object::w_type_get_name(owner) };
+            full.rsplit('.').next().unwrap_or(full).to_string()
+        }
+    }
+}
+
+/// CPython 3.14 getset descriptor repr, shared with `display::py_repr` because
+/// native GetSetProperty instances do not carry a heap-instance `w_class`.
+pub(crate) unsafe fn getset_descriptor_repr(descr: PyObjectRef) -> String {
+    let name_obj = unsafe { pyre_object::typedef::w_getset_get_name(descr) };
+    let name = if !name_obj.is_null() && unsafe { pyre_object::is_str(name_obj) } {
+        unsafe { pyre_object::w_str_get_value(name_obj) }
+    } else {
+        "<generic property>"
+    };
+    let owner = unsafe { getset_descriptor_owner(descr) };
+    let owner_name = if owner.is_null() {
+        "?"
+    } else {
+        unsafe { pyre_object::w_type_get_name(owner) }
+    };
+    format!("<attribute '{name}' of '{owner_name}' objects>")
 }
 
 /// `GetSetProperty(fget)` — read-only getset descriptor with no required class.
@@ -7587,6 +7692,7 @@ fn patch_getset_descriptor_metadata() {
 fn make_getset_descriptor(getter: pyre_object::PyObjectRef) -> pyre_object::PyObjectRef {
     make_getset_property_full(
         getter,
+        pyre_object::PY_NULL,
         pyre_object::PY_NULL,
         pyre_object::PY_NULL,
         pyre_object::PY_NULL,
@@ -7608,6 +7714,7 @@ pub(crate) fn make_getset_descriptor_named(
         pyre_object::PY_NULL,
         pyre_object::PY_NULL,
         pyre_object::PY_NULL,
+        pyre_object::PY_NULL,
         Some(name),
     )
 }
@@ -7620,7 +7727,14 @@ fn make_getset_property(
     fset: pyre_object::PyObjectRef,
     fdel: pyre_object::PyObjectRef,
 ) -> pyre_object::PyObjectRef {
-    make_getset_property_full(fget, fset, fdel, pyre_object::PY_NULL, None)
+    make_getset_property_full(
+        fget,
+        fset,
+        fdel,
+        pyre_object::PY_NULL,
+        pyre_object::PY_NULL,
+        None,
+    )
 }
 
 /// `GetSetProperty(fget, fset, fdel)` with explicit `name` — see
@@ -7631,7 +7745,33 @@ pub(crate) fn make_getset_property_named(
     fdel: pyre_object::PyObjectRef,
     name: &str,
 ) -> pyre_object::PyObjectRef {
-    make_getset_property_full(fget, fset, fdel, pyre_object::PY_NULL, Some(name))
+    make_getset_property_full(
+        fget,
+        fset,
+        fdel,
+        pyre_object::PY_NULL,
+        pyre_object::PY_NULL,
+        Some(name),
+    )
+}
+
+/// `GetSetProperty(..., doc=..., name=...)` — the full descriptor payload
+/// used by doc-bearing getsets such as `mapping`, `__dict__`, and `__weakref__`.
+fn make_getset_property_named_doc(
+    fget: pyre_object::PyObjectRef,
+    fset: pyre_object::PyObjectRef,
+    fdel: pyre_object::PyObjectRef,
+    doc: &str,
+    name: &str,
+) -> pyre_object::PyObjectRef {
+    make_getset_property_full(
+        fget,
+        fset,
+        fdel,
+        pyre_object::w_str_new(doc),
+        pyre_object::PY_NULL,
+        Some(name),
+    )
 }
 
 /// `GetSetProperty(fget, fset, fdel, cls=cls)` — full getset descriptor
@@ -7644,6 +7784,7 @@ fn make_getset_property_full(
     fget: pyre_object::PyObjectRef,
     fset: pyre_object::PyObjectRef,
     fdel: pyre_object::PyObjectRef,
+    doc: pyre_object::PyObjectRef,
     cls: pyre_object::PyObjectRef,
     name: Option<&str>,
 ) -> pyre_object::PyObjectRef {
@@ -7665,7 +7806,7 @@ fn make_getset_property_full(
         fget,
         fset,
         fdel,
-        pyre_object::PY_NULL, // doc
+        doc,
         cls,
         false, // use_closure
         resolved_name,
@@ -18998,7 +19139,7 @@ fn init_generator_type(ns: PyObjectRef) {
             pyre_object::w_dict_setitem_str_no_proxy(
                 ns,
                 name,
-                make_getset_property_full(get, set, PY_NULL, PY_NULL, Some(name)),
+                make_getset_property_full(get, set, PY_NULL, PY_NULL, PY_NULL, Some(name)),
             )
         };
     }
@@ -19640,7 +19781,13 @@ pub fn dict_descr() -> pyre_object::PyObjectRef {
         // `"__dict__"` instead of the `"<generic property>"` sentinel.
         // The earlier setattr fix-up was masked by the new read-only
         // `__name__` getset and silently failed.
-        make_getset_property_named(fget, fset, fdel, "__dict__") as usize
+        make_getset_property_named_doc(
+            fget,
+            fset,
+            fdel,
+            "dictionary for instance variables",
+            "__dict__",
+        ) as usize
     });
     addr as pyre_object::PyObjectRef
 }
@@ -19659,7 +19806,13 @@ pub fn weakref_descr() -> pyre_object::PyObjectRef {
         let fget = make_builtin_function_with_arity("descr_get_weakref", descr_get_weakref, 2);
         // typedef.py:591 `weakref_descr.name = '__weakref__'` —
         // see `dict_descr` for the parity rationale.
-        make_getset_descriptor_named(fget, "__weakref__") as usize
+        make_getset_property_named_doc(
+            fget,
+            pyre_object::PY_NULL,
+            pyre_object::PY_NULL,
+            "list of weak references to the object",
+            "__weakref__",
+        ) as usize
     });
     addr as pyre_object::PyObjectRef
 }

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -9382,138 +9382,290 @@ fn init_cell_type(ns: PyObjectRef) {
     };
 }
 
-/// `staticmethod.__new__(cls, func)` — PyPy: function.py StaticMethod.descr__new__
-fn init_staticmethod_type(ns: PyObjectRef) {
-    unsafe {
-        pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
-            ns,
-            "__new__",
-            make_builtin_function("__new__", |args| {
-                // staticmethod(func) — args[0] is cls (staticmethod type), args[1] is func
-                let cls = args.first().copied().unwrap_or(pyre_object::PY_NULL);
-                let func = if args.len() > 1 {
-                    args[1]
-                } else {
-                    pyre_object::w_none()
-                };
-                let sm = pyre_object::function::w_staticmethod_new(func);
-                // function.py `allocate_instance(StaticMethod, w_subtype)` —
-                // honour the subtype so `abstractstaticmethod(func)` yields an
-                // `abstractstaticmethod` instance, not a bare `staticmethod`.
-                let staticmethod_type =
-                    crate::typedef::gettypeobject(&pyre_object::function::STATICMETHOD_TYPE);
-                if !cls.is_null() && !std::ptr::eq(cls, staticmethod_type) {
-                    check_user_subclass(staticmethod_type, cls)?;
-                    unsafe {
-                        (*sm).w_class = cls;
-                    }
-                }
-                Ok(sm)
-            }),
-        )
-    };
-    // `typedef.py:866 __get__ = interp2app(
-    //     StaticMethod.descr_staticmethod_get)`.  `function.py:691-693`:
-    //
-    //     def descr_staticmethod_get(self, w_obj, w_cls=None):
-    //         """staticmethod(x).__get__(obj[, type]) -> x"""
-    //         return self.w_function
-    //
-    // Arity 3 covers `__get__(self, obj, cls=None)`.  `args[0]` is the
-    // staticmethod instance; the remaining slots are ignored beyond the
-    // type guard.  Returning `w_function` without binding is the
-    // canonical staticmethod semantic (`function.py:864 …does not
-    // receive an implicit first argument`).
-    unsafe {
-        pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
-            ns,
-            "__get__",
-            make_builtin_function_with_arity(
-                "__get__",
-                |args| {
-                    let sm = args.first().copied().unwrap_or(pyre_object::PY_NULL);
-                    if !unsafe { pyre_object::function::is_staticmethod(sm) } {
-                        return Err(crate::PyError::type_error(
-                            "descriptor '__get__' requires a 'staticmethod' object",
-                        ));
-                    }
-                    let w_func = unsafe { pyre_object::function::w_staticmethod_get_func(sm) };
-                    if w_func.is_null() {
-                        Ok(pyre_object::w_none())
-                    } else {
-                        Ok(w_func)
-                    }
-                },
-                3,
-            ),
-        )
-    };
-    // typedef.py:870-871 ─
-    //   __func__ = interp_attrproperty_w('w_function', cls=StaticMethod),
-    //   __wrapped__ = interp_attrproperty_w('w_function', cls=StaticMethod),
-    // — same `w_function` slot, two aliases, both routed through
-    // the interp_attrproperty_w fget shape (typedef.py:465-474):
-    // substitute w_None when the fetched slot is None.
-    fn staticmethod_func_attr(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-        let obj = args.get(1).copied().unwrap_or(pyre_object::PY_NULL);
-        if !unsafe { pyre_object::function::is_staticmethod(obj) } {
-            return Ok(pyre_object::w_none());
-        }
-        let w_value = unsafe { pyre_object::function::w_staticmethod_get_func(obj) };
-        if w_value.is_null() {
-            Ok(pyre_object::w_none())
-        } else {
-            Ok(w_value)
+fn staticmethod_require(obj: PyObjectRef, name: &str) -> Result<PyObjectRef, crate::PyError> {
+    if obj.is_null() || !unsafe { pyre_object::function::is_staticmethod(obj) } {
+        return Err(crate::PyError::type_error(format!(
+            "descriptor '{name}' requires a 'staticmethod' object"
+        )));
+    }
+    Ok(obj)
+}
+
+/// function.py:695-698 `StaticMethod.descr_staticmethod__new__` / CPython
+/// 3.14 `sm_new`: allocate first with a None callable; `__init__` installs
+/// the user argument and copies presentation attributes.
+fn staticmethod_descr_new(args: &[PyObjectRef]) -> crate::PyResult {
+    let cls = args.first().copied().unwrap_or(PY_NULL);
+    let staticmethod_type = gettypeobject(&pyre_object::function::STATICMETHOD_TYPE);
+    check_user_subclass(staticmethod_type, cls)?;
+    let sm = pyre_object::function::w_staticmethod_new(w_none());
+    if !std::ptr::eq(cls, staticmethod_type) {
+        unsafe { (*sm).w_class = cls };
+    }
+    Ok(sm)
+}
+
+/// function.py:700-703 `StaticMethod.descr_init`, adjusted to CPython 3.14:
+/// `functools_wraps` copies the four presentation attributes while
+/// `__annotations__` and `__annotate__` remain lazy proxy descriptors.
+fn staticmethod_descr_init(args: &[PyObjectRef]) -> crate::PyResult {
+    let (positional, kwargs) = crate::builtins::split_builtin_kwargs(args);
+    if crate::builtins::has_real_kwargs(kwargs) {
+        return Err(crate::PyError::type_error(
+            "staticmethod() takes no keyword arguments",
+        ));
+    }
+    let sm = staticmethod_require(positional.first().copied().unwrap_or(PY_NULL), "__init__")?;
+    let supplied = positional.len().saturating_sub(1);
+    if supplied != 1 {
+        return Err(crate::PyError::type_error(format!(
+            "staticmethod expected 1 argument, got {supplied}"
+        )));
+    }
+    let function = positional[1];
+    unsafe { pyre_object::function::w_staticmethod_set_func(sm, function) };
+    let w_dict = unsafe { pyre_object::function::w_staticmethod_getdict(sm) };
+    for name in ["__module__", "__name__", "__qualname__", "__doc__"] {
+        match crate::baseobjspace::getattr_str(function, name) {
+            Ok(value) => {
+                crate::baseobjspace::setitem(w_dict, w_str_new(name), value)?;
+            }
+            Err(err) if err.kind == crate::PyErrorKind::AttributeError => {}
+            Err(err) => return Err(err),
         }
     }
-    unsafe {
-        pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
-            ns,
+    Ok(w_none())
+}
+
+/// function.py:691-693 `descr_staticmethod_get`.
+fn staticmethod_descr_get(args: &[PyObjectRef]) -> crate::PyResult {
+    let sm = staticmethod_require(args.first().copied().unwrap_or(PY_NULL), "__get__")?;
+    let function = unsafe { pyre_object::function::w_staticmethod_get_func(sm) };
+    Ok(if function.is_null() {
+        w_none()
+    } else {
+        function
+    })
+}
+
+/// function.py:712-713 `descr_call` / CPython 3.14 `sm_call`.
+fn staticmethod_descr_call(args: &[PyObjectRef]) -> crate::PyResult {
+    let (positional, kwargs) = crate::builtins::split_builtin_kwargs(args);
+    let sm = staticmethod_require(positional.first().copied().unwrap_or(PY_NULL), "__call__")?;
+    let function = unsafe { pyre_object::function::w_staticmethod_get_func(sm) };
+    let call_args = positional.get(1..).unwrap_or(&[]);
+    if !crate::builtins::has_real_kwargs(kwargs) {
+        return crate::call::call_function_impl_result(function, call_args);
+    }
+    let keyword_args: Vec<(Wtf8Buf, PyObjectRef)> = unsafe {
+        pyre_object::w_dict_str_entries(kwargs.unwrap())
+            .into_iter()
+            .filter(|(name, _)| name != "__pyre_kw__")
+            .map(|(name, value)| (Wtf8Buf::from_string(name), value))
+            .collect()
+    };
+    crate::eval::CURRENT_FRAME.with(|current| {
+        let frame = current.get();
+        if frame.is_null() {
+            return Err(crate::PyError::runtime_error(
+                "staticmethod call has no current frame",
+            ));
+        }
+        crate::call::call_with_kwargs(unsafe { &mut *frame }, function, call_args, &keyword_args)
+    })
+}
+
+fn staticmethod_func_attr(args: &[PyObjectRef]) -> crate::PyResult {
+    let sm = staticmethod_require(args.get(1).copied().unwrap_or(PY_NULL), "__func__")?;
+    let value = unsafe { pyre_object::function::w_staticmethod_get_func(sm) };
+    Ok(if value.is_null() { w_none() } else { value })
+}
+
+fn staticmethod_isabstract(args: &[PyObjectRef]) -> crate::PyResult {
+    let sm = staticmethod_require(
+        args.get(1).copied().unwrap_or(PY_NULL),
+        "__isabstractmethod__",
+    )?;
+    let function = unsafe { pyre_object::function::w_staticmethod_get_func(sm) };
+    Ok(w_bool_from(crate::baseobjspace::isabstractmethod_w(
+        function,
+    )?))
+}
+
+fn staticmethod_wrapped_attr_get(obj: PyObjectRef, name: &str) -> crate::PyResult {
+    let sm = staticmethod_require(obj, name)?;
+    let w_dict = unsafe { pyre_object::function::w_staticmethod_getdict(sm) };
+    if let Some(value) = crate::baseobjspace::finditem_str(w_dict, name)? {
+        return Ok(value);
+    }
+    let function = unsafe { pyre_object::function::w_staticmethod_get_func(sm) };
+    let value = crate::baseobjspace::getattr_str(function, name)?;
+    crate::baseobjspace::setitem(w_dict, w_str_new(name), value)?;
+    Ok(value)
+}
+
+fn staticmethod_annotations_get(args: &[PyObjectRef]) -> crate::PyResult {
+    staticmethod_wrapped_attr_get(args.get(1).copied().unwrap_or(PY_NULL), "__annotations__")
+}
+
+fn staticmethod_annotate_get(args: &[PyObjectRef]) -> crate::PyResult {
+    staticmethod_wrapped_attr_get(args.get(1).copied().unwrap_or(PY_NULL), "__annotate__")
+}
+
+fn staticmethod_wrapped_attr_set(args: &[PyObjectRef], name: &str) -> crate::PyResult {
+    let sm = staticmethod_require(args.get(1).copied().unwrap_or(PY_NULL), name)?;
+    let value = args.get(2).copied().unwrap_or(PY_NULL);
+    let w_dict = unsafe { pyre_object::function::w_staticmethod_getdict(sm) };
+    crate::baseobjspace::setitem(w_dict, w_str_new(name), value)?;
+    Ok(w_none())
+}
+
+fn staticmethod_annotations_set(args: &[PyObjectRef]) -> crate::PyResult {
+    staticmethod_wrapped_attr_set(args, "__annotations__")
+}
+
+fn staticmethod_annotate_set(args: &[PyObjectRef]) -> crate::PyResult {
+    staticmethod_wrapped_attr_set(args, "__annotate__")
+}
+
+fn staticmethod_wrapped_attr_del(args: &[PyObjectRef], name: &str) -> crate::PyResult {
+    let sm = staticmethod_require(args.get(1).copied().unwrap_or(PY_NULL), name)?;
+    let w_dict = unsafe { pyre_object::function::w_staticmethod_getdict(sm) };
+    if let Err(err) = crate::baseobjspace::delitem(w_dict, w_str_new(name)) {
+        if err.kind == crate::PyErrorKind::KeyError {
+            return Err(crate::PyError::attribute_error(format!(
+                "'staticmethod' object has no attribute '{name}'"
+            )));
+        }
+        return Err(err);
+    }
+    Ok(w_none())
+}
+
+fn staticmethod_annotations_del(args: &[PyObjectRef]) -> crate::PyResult {
+    staticmethod_wrapped_attr_del(args, "__annotations__")
+}
+
+fn staticmethod_annotate_del(args: &[PyObjectRef]) -> crate::PyResult {
+    staticmethod_wrapped_attr_del(args, "__annotate__")
+}
+
+fn staticmethod_dict_del(_args: &[PyObjectRef]) -> crate::PyResult {
+    Err(crate::PyError::type_error("cannot delete __dict__"))
+}
+
+/// function.py:715-716 / CPython 3.14 `sm_repr`.
+fn staticmethod_descr_repr(args: &[PyObjectRef]) -> crate::PyResult {
+    let sm = staticmethod_require(args.first().copied().unwrap_or(PY_NULL), "__repr__")?;
+    let function = unsafe { pyre_object::function::w_staticmethod_get_func(sm) };
+    let repr = if function.is_null() {
+        "<NULL>".to_string()
+    } else {
+        unsafe { crate::display::py_repr(function)? }
+    };
+    Ok(w_str_new(&format!("<staticmethod({repr})>")))
+}
+
+/// PyPy `typedef.py:852-877 StaticMethod.typedef`, with the CPython 3.14
+/// surface taking precedence: PEP 649 proxy descriptors and generic alias
+/// support are present, while PyPy 3.11's `__reduce_ex__` is absent.
+fn init_staticmethod_type(ns: PyObjectRef) {
+    let dict_getter = make_builtin_function_with_arity("__dict__", descr_get_dict, 2);
+    let dict_setter = make_builtin_function_with_arity("__dict__", descr_set_dict, 3);
+    let dict_deleter = make_builtin_function_with_arity("__dict__", staticmethod_dict_del, 2);
+    let annotations_getter =
+        make_builtin_function_with_arity("__annotations__", staticmethod_annotations_get, 2);
+    let annotations_setter =
+        make_builtin_function_with_arity("__annotations__", staticmethod_annotations_set, 3);
+    let annotations_deleter =
+        make_builtin_function_with_arity("__annotations__", staticmethod_annotations_del, 2);
+    let annotate_getter =
+        make_builtin_function_with_arity("__annotate__", staticmethod_annotate_get, 2);
+    let annotate_setter =
+        make_builtin_function_with_arity("__annotate__", staticmethod_annotate_set, 3);
+    let annotate_deleter =
+        make_builtin_function_with_arity("__annotate__", staticmethod_annotate_del, 2);
+    let entries = [
+        (
+            "__doc__",
+            w_str_new(
+                "Convert a function to be a static method.\n\nA static method does not receive an implicit first argument.\nTo declare a static method, use this idiom:\n\n     class C:\n         @staticmethod\n         def f(arg1, arg2, argN):\n             ...\n\nIt can be called either on the class (e.g. C.f()) or on an instance\n(e.g. C().f()). Both the class and the instance are ignored, and\nneither is passed implicitly as the first argument to the method.\n\nStatic methods in Python are similar to those found in Java or C++.\nFor a more advanced concept, see the classmethod builtin.",
+            ),
+        ),
+        (
+            "__get__",
+            make_builtin_function("__get__", staticmethod_descr_get),
+        ),
+        ("__new__", make_new_descr(staticmethod_descr_new)),
+        (
+            "__init__",
+            make_builtin_function("__init__", staticmethod_descr_init),
+        ),
+        (
+            "__call__",
+            make_builtin_function("__call__", staticmethod_descr_call),
+        ),
+        (
             "__func__",
             make_getset_descriptor(make_builtin_function_with_arity(
                 "__func__",
                 staticmethod_func_attr,
                 2,
             )),
-        )
-    };
-    unsafe {
-        pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
-            ns,
+        ),
+        (
             "__wrapped__",
             make_getset_descriptor(make_builtin_function_with_arity(
                 "__wrapped__",
                 staticmethod_func_attr,
                 2,
             )),
-        )
-    };
-    // typedef.py:872 `__isabstractmethod__ = GetSetProperty(
-    //     StaticMethod.descr_isabstract)`.  function.py:705-706:
-    //
-    //     def descr_isabstract(self, space):
-    //         return space.newbool(space.isabstractmethod_w(self.w_function))
-    //
-    // `baseobjspace.isabstractmethod_w` already factored above.
-    unsafe {
-        pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
-            ns,
+        ),
+        (
             "__isabstractmethod__",
             make_getset_descriptor(make_builtin_function_with_arity(
                 "__isabstractmethod__",
-                |args| {
-                    let sm = args.get(1).copied().unwrap_or(pyre_object::PY_NULL);
-                    if !unsafe { pyre_object::function::is_staticmethod(sm) } {
-                        return Ok(pyre_object::w_bool_from(false));
-                    }
-                    let func = unsafe { pyre_object::function::w_staticmethod_get_func(sm) };
-                    let result = crate::baseobjspace::isabstractmethod_w(func)?;
-                    Ok(pyre_object::w_bool_from(result))
-                },
+                staticmethod_isabstract,
                 2,
             )),
-        )
-    };
+        ),
+        (
+            "__dict__",
+            make_getset_property_named(dict_getter, dict_setter, dict_deleter, "__dict__"),
+        ),
+        (
+            "__annotations__",
+            make_getset_property_named(
+                annotations_getter,
+                annotations_setter,
+                annotations_deleter,
+                "__annotations__",
+            ),
+        ),
+        (
+            "__annotate__",
+            make_getset_property_named(
+                annotate_getter,
+                annotate_setter,
+                annotate_deleter,
+                "__annotate__",
+            ),
+        ),
+        (
+            "__class_getitem__",
+            pyre_object::function::w_classmethod_new(make_builtin_function(
+                "__class_getitem__",
+                crate::_pypy_generic_alias::generic_alias_class_getitem,
+            )),
+        ),
+        (
+            "__repr__",
+            make_builtin_function("__repr__", staticmethod_descr_repr),
+        ),
+    ];
+    for (name, value) in entries {
+        unsafe { pyre_object::w_dict_setitem_str_no_proxy(ns, name, value) };
+    }
 }
 
 /// `classmethod.__new__(cls, func)` — PyPy: function.py ClassMethod.descr__new__

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -2361,14 +2361,53 @@ fn range_descr_contains(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyEr
     )?))
 }
 
-/// `functional.py W_Range.descr_eq`.
-fn range_descr_eq(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+/// CPython 3.14 `range_richcompare`, layered on PyPy
+/// `functional.py W_Range.descr_eq`.  PyPy only publishes `descr_eq`; 3.14
+/// takes precedence and exposes the whole rich-comparison slot surface.
+fn range_descr_richcompare(
+    args: &[PyObjectRef],
+    op: crate::baseobjspace::CompareOp,
+) -> Result<PyObjectRef, crate::PyError> {
     if !unsafe { pyre_object::is_w_range(args[1]) } {
         return Ok(w_not_implemented());
     }
-    Ok(w_bool_from(unsafe {
-        pyre_object::w_range_eq(args[0], args[1])
-    }))
+    match op {
+        crate::baseobjspace::CompareOp::Eq | crate::baseobjspace::CompareOp::Ne => {
+            let mut result = unsafe { pyre_object::w_range_eq(args[0], args[1]) };
+            if matches!(op, crate::baseobjspace::CompareOp::Ne) {
+                result = !result;
+            }
+            Ok(w_bool_from(result))
+        }
+        crate::baseobjspace::CompareOp::Le
+        | crate::baseobjspace::CompareOp::Ge
+        | crate::baseobjspace::CompareOp::Lt
+        | crate::baseobjspace::CompareOp::Gt => Ok(w_not_implemented()),
+    }
+}
+
+fn range_descr_eq(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    range_descr_richcompare(args, crate::baseobjspace::CompareOp::Eq)
+}
+
+fn range_descr_ne(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    range_descr_richcompare(args, crate::baseobjspace::CompareOp::Ne)
+}
+
+fn range_descr_lt(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    range_descr_richcompare(args, crate::baseobjspace::CompareOp::Lt)
+}
+
+fn range_descr_le(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    range_descr_richcompare(args, crate::baseobjspace::CompareOp::Le)
+}
+
+fn range_descr_gt(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    range_descr_richcompare(args, crate::baseobjspace::CompareOp::Gt)
+}
+
+fn range_descr_ge(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    range_descr_richcompare(args, crate::baseobjspace::CompareOp::Ge)
 }
 
 /// `functional.py W_Range.descr_bool`.
@@ -2459,6 +2498,26 @@ fn init_range_type(ns: PyObjectRef) {
         (
             "__eq__",
             make_builtin_function_with_arity("__eq__", range_descr_eq, 2),
+        ),
+        (
+            "__ne__",
+            make_builtin_function_with_arity("__ne__", range_descr_ne, 2),
+        ),
+        (
+            "__lt__",
+            make_builtin_function_with_arity("__lt__", range_descr_lt, 2),
+        ),
+        (
+            "__le__",
+            make_builtin_function_with_arity("__le__", range_descr_le, 2),
+        ),
+        (
+            "__gt__",
+            make_builtin_function_with_arity("__gt__", range_descr_gt, 2),
+        ),
+        (
+            "__ge__",
+            make_builtin_function_with_arity("__ge__", range_descr_ge, 2),
         ),
         (
             "__hash__",

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -9668,141 +9668,262 @@ fn init_staticmethod_type(ns: PyObjectRef) {
     }
 }
 
-/// `classmethod.__new__(cls, func)` — PyPy: function.py ClassMethod.descr__new__
-fn init_classmethod_type(ns: PyObjectRef) {
-    unsafe {
-        pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
-            ns,
-            "__new__",
-            make_builtin_function("__new__", |args| {
-                let cls = args.first().copied().unwrap_or(pyre_object::PY_NULL);
-                let func = if args.len() > 1 {
-                    args[1]
-                } else {
-                    pyre_object::w_none()
-                };
-                let cm = pyre_object::function::w_classmethod_new(func);
-                // function.py `allocate_instance(ClassMethod, w_subtype)` —
-                // honour the subtype so `abstractclassmethod(func)` yields an
-                // `abstractclassmethod` instance, not a bare `classmethod`.
-                let classmethod_type =
-                    crate::typedef::gettypeobject(&pyre_object::function::CLASSMETHOD_TYPE);
-                if !cls.is_null() && !std::ptr::eq(cls, classmethod_type) {
-                    check_user_subclass(classmethod_type, cls)?;
-                    unsafe {
-                        (*cm).w_class = cls;
-                    }
-                }
-                Ok(cm)
-            }),
-        )
-    };
-    // `typedef.py:883 __get__ = interp2app(
-    //     ClassMethod.descr_classmethod_get)`.  `function.py:738-748`:
-    //
-    //     def descr_classmethod_get(self, space, w_obj, w_klass=None):
-    //         if space.is_none(w_klass):
-    //             w_klass = space.type(w_obj)
-    //         w_func = self.w_function
-    //         w_bound = space.get(w_func, w_klass, w_klass)
-    //         if w_bound is not w_func:
-    //             return w_bound
-    //         # the object doesn't have a get, but it might still be
-    //         # callable, so make a Method object
-    //         return Method(space, w_func, w_klass)
-    //
-    // The two branches collapse into a single `Method(func, klass)`
-    // construction because pyre's `w_method_new` is the same shape
-    // that `Function.descr_function_get` would return when
-    // `w_func.__get__(klass, klass)` fires.  This matches the
-    // pre-existing hardcoded classmethod arm in
-    // `baseobjspace::get` (`baseobjspace.rs:5420-5427`).
-    unsafe {
-        pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
-            ns,
-            "__get__",
-            make_builtin_function_with_arity(
-                "__get__",
-                |args| {
-                    let cm = args.first().copied().unwrap_or(pyre_object::PY_NULL);
-                    if !unsafe { pyre_object::function::is_classmethod(cm) } {
-                        return Err(crate::PyError::type_error(
-                            "descriptor '__get__' requires a 'classmethod' object",
-                        ));
-                    }
-                    let w_obj = args.get(1).copied().unwrap_or(pyre_object::PY_NULL);
-                    let mut w_klass = args.get(2).copied().unwrap_or(pyre_object::PY_NULL);
-                    if w_klass.is_null() || unsafe { pyre_object::is_none(w_klass) } {
-                        w_klass = crate::typedef::r#type(w_obj).unwrap_or(pyre_object::PY_NULL);
-                    }
-                    let w_func = unsafe { pyre_object::function::w_classmethod_get_func(cm) };
-                    Ok(pyre_object::w_method_new(w_func, w_klass, w_klass))
-                },
-                3,
-            ),
-        )
-    };
-    // typedef.py:884-885 ─
-    //   __func__ = interp_attrproperty_w('w_function', cls=ClassMethod),
-    //   __wrapped__ = interp_attrproperty_w('w_function', cls=ClassMethod),
-    fn classmethod_func_attr(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-        let obj = args.get(1).copied().unwrap_or(pyre_object::PY_NULL);
-        if !unsafe { pyre_object::function::is_classmethod(obj) } {
-            return Ok(pyre_object::w_none());
-        }
-        let w_value = unsafe { pyre_object::function::w_classmethod_get_func(obj) };
-        if w_value.is_null() {
-            Ok(pyre_object::w_none())
-        } else {
-            Ok(w_value)
+fn classmethod_require(obj: PyObjectRef, name: &str) -> Result<PyObjectRef, crate::PyError> {
+    if obj.is_null() || !unsafe { pyre_object::function::is_classmethod(obj) } {
+        return Err(crate::PyError::type_error(format!(
+            "descriptor '{name}' requires a 'classmethod' object"
+        )));
+    }
+    Ok(obj)
+}
+
+/// function.py:750-753 `ClassMethod.descr_classmethod__new__` / CPython
+/// 3.14 `cm_new`: allocate the requested subtype with a temporary None
+/// callable; `__init__` installs the actual callable.
+fn classmethod_descr_new(args: &[PyObjectRef]) -> crate::PyResult {
+    let cls = args.first().copied().unwrap_or(PY_NULL);
+    let classmethod_type = gettypeobject(&pyre_object::function::CLASSMETHOD_TYPE);
+    check_user_subclass(classmethod_type, cls)?;
+    let cm = pyre_object::function::w_classmethod_new(w_none());
+    if !std::ptr::eq(cls, classmethod_type) {
+        unsafe { (*cm).w_class = cls };
+    }
+    Ok(cm)
+}
+
+/// function.py:755-758 `ClassMethod.descr_init`, adjusted to CPython 3.14's
+/// `functools_wraps`: copy the four eager presentation attributes while the
+/// two annotation attributes remain lazy proxy descriptors.
+fn classmethod_descr_init(args: &[PyObjectRef]) -> crate::PyResult {
+    let (positional, kwargs) = crate::builtins::split_builtin_kwargs(args);
+    if crate::builtins::has_real_kwargs(kwargs) {
+        return Err(crate::PyError::type_error(
+            "classmethod() takes no keyword arguments",
+        ));
+    }
+    let cm = classmethod_require(positional.first().copied().unwrap_or(PY_NULL), "__init__")?;
+    let supplied = positional.len().saturating_sub(1);
+    if supplied != 1 {
+        return Err(crate::PyError::type_error(format!(
+            "classmethod expected 1 argument, got {supplied}"
+        )));
+    }
+    let function = positional[1];
+    unsafe { pyre_object::function::w_classmethod_set_func(cm, function) };
+    let w_dict = unsafe { pyre_object::function::w_classmethod_getdict(cm) };
+    for name in ["__module__", "__name__", "__qualname__", "__doc__"] {
+        match crate::baseobjspace::getattr_str(function, name) {
+            Ok(value) => {
+                crate::baseobjspace::setitem(w_dict, w_str_new(name), value)?;
+            }
+            Err(err) if err.kind == crate::PyErrorKind::AttributeError => {}
+            Err(err) => return Err(err),
         }
     }
-    unsafe {
-        pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
-            ns,
+    Ok(w_none())
+}
+
+/// function.py:738-748 `descr_classmethod_get`. Python 3.14's `cm_descr_get`
+/// binds the stored callable directly to the selected class; it no longer
+/// invokes a descriptor nested inside classmethod.
+fn classmethod_descr_get(args: &[PyObjectRef]) -> crate::PyResult {
+    let cm = classmethod_require(args.first().copied().unwrap_or(PY_NULL), "__get__")?;
+    let w_obj = args.get(1).copied().unwrap_or(PY_NULL);
+    let mut w_klass = args.get(2).copied().unwrap_or(PY_NULL);
+    if w_klass.is_null() || unsafe { pyre_object::is_none(w_klass) } {
+        w_klass = r#type(w_obj).unwrap_or(PY_NULL);
+    }
+    let function = unsafe { pyre_object::function::w_classmethod_get_func(cm) };
+    Ok(pyre_object::w_method_new(function, w_klass, w_klass))
+}
+
+fn classmethod_func_attr(args: &[PyObjectRef]) -> crate::PyResult {
+    let cm = classmethod_require(args.get(1).copied().unwrap_or(PY_NULL), "__func__")?;
+    let value = unsafe { pyre_object::function::w_classmethod_get_func(cm) };
+    Ok(if value.is_null() { w_none() } else { value })
+}
+
+fn classmethod_isabstract(args: &[PyObjectRef]) -> crate::PyResult {
+    let cm = classmethod_require(
+        args.get(1).copied().unwrap_or(PY_NULL),
+        "__isabstractmethod__",
+    )?;
+    let function = unsafe { pyre_object::function::w_classmethod_get_func(cm) };
+    Ok(w_bool_from(crate::baseobjspace::isabstractmethod_w(
+        function,
+    )?))
+}
+
+fn classmethod_wrapped_attr_get(obj: PyObjectRef, name: &str) -> crate::PyResult {
+    let cm = classmethod_require(obj, name)?;
+    let w_dict = unsafe { pyre_object::function::w_classmethod_getdict(cm) };
+    if let Some(value) = crate::baseobjspace::finditem_str(w_dict, name)? {
+        return Ok(value);
+    }
+    let function = unsafe { pyre_object::function::w_classmethod_get_func(cm) };
+    let value = crate::baseobjspace::getattr_str(function, name)?;
+    crate::baseobjspace::setitem(w_dict, w_str_new(name), value)?;
+    Ok(value)
+}
+
+fn classmethod_annotations_get(args: &[PyObjectRef]) -> crate::PyResult {
+    classmethod_wrapped_attr_get(args.get(1).copied().unwrap_or(PY_NULL), "__annotations__")
+}
+
+fn classmethod_annotate_get(args: &[PyObjectRef]) -> crate::PyResult {
+    classmethod_wrapped_attr_get(args.get(1).copied().unwrap_or(PY_NULL), "__annotate__")
+}
+
+fn classmethod_wrapped_attr_set(args: &[PyObjectRef], name: &str) -> crate::PyResult {
+    let cm = classmethod_require(args.get(1).copied().unwrap_or(PY_NULL), name)?;
+    let value = args.get(2).copied().unwrap_or(PY_NULL);
+    let w_dict = unsafe { pyre_object::function::w_classmethod_getdict(cm) };
+    crate::baseobjspace::setitem(w_dict, w_str_new(name), value)?;
+    Ok(w_none())
+}
+
+fn classmethod_annotations_set(args: &[PyObjectRef]) -> crate::PyResult {
+    classmethod_wrapped_attr_set(args, "__annotations__")
+}
+
+fn classmethod_annotate_set(args: &[PyObjectRef]) -> crate::PyResult {
+    classmethod_wrapped_attr_set(args, "__annotate__")
+}
+
+fn classmethod_wrapped_attr_del(args: &[PyObjectRef], name: &str) -> crate::PyResult {
+    let cm = classmethod_require(args.get(1).copied().unwrap_or(PY_NULL), name)?;
+    let w_dict = unsafe { pyre_object::function::w_classmethod_getdict(cm) };
+    if let Err(err) = crate::baseobjspace::delitem(w_dict, w_str_new(name)) {
+        if err.kind == crate::PyErrorKind::KeyError {
+            return Err(crate::PyError::attribute_error(format!(
+                "'classmethod' object has no attribute '{name}'"
+            )));
+        }
+        return Err(err);
+    }
+    Ok(w_none())
+}
+
+fn classmethod_annotations_del(args: &[PyObjectRef]) -> crate::PyResult {
+    classmethod_wrapped_attr_del(args, "__annotations__")
+}
+
+fn classmethod_annotate_del(args: &[PyObjectRef]) -> crate::PyResult {
+    classmethod_wrapped_attr_del(args, "__annotate__")
+}
+
+fn classmethod_dict_del(_args: &[PyObjectRef]) -> crate::PyResult {
+    Err(crate::PyError::type_error("cannot delete __dict__"))
+}
+
+/// function.py:767-768 `descr_repr` / CPython 3.14 `cm_repr`.
+fn classmethod_descr_repr(args: &[PyObjectRef]) -> crate::PyResult {
+    let cm = classmethod_require(args.first().copied().unwrap_or(PY_NULL), "__repr__")?;
+    let function = unsafe { pyre_object::function::w_classmethod_get_func(cm) };
+    let repr = if function.is_null() {
+        "<NULL>".to_string()
+    } else {
+        unsafe { crate::display::py_repr(function)? }
+    };
+    Ok(w_str_new(&format!("<classmethod({repr})>")))
+}
+
+/// PyPy `typedef.py:878-908 ClassMethod.typedef`, with the Python 3.14
+/// surface taking precedence: PEP 649 proxy descriptors and generic alias
+/// support replace PyPy 3.11's eager annotations copy and `__reduce_ex__`.
+fn init_classmethod_type(ns: PyObjectRef) {
+    let dict_getter = make_builtin_function_with_arity("__dict__", descr_get_dict, 2);
+    let dict_setter = make_builtin_function_with_arity("__dict__", descr_set_dict, 3);
+    let dict_deleter = make_builtin_function_with_arity("__dict__", classmethod_dict_del, 2);
+    let annotations_getter =
+        make_builtin_function_with_arity("__annotations__", classmethod_annotations_get, 2);
+    let annotations_setter =
+        make_builtin_function_with_arity("__annotations__", classmethod_annotations_set, 3);
+    let annotations_deleter =
+        make_builtin_function_with_arity("__annotations__", classmethod_annotations_del, 2);
+    let annotate_getter =
+        make_builtin_function_with_arity("__annotate__", classmethod_annotate_get, 2);
+    let annotate_setter =
+        make_builtin_function_with_arity("__annotate__", classmethod_annotate_set, 3);
+    let annotate_deleter =
+        make_builtin_function_with_arity("__annotate__", classmethod_annotate_del, 2);
+    let entries = [
+        (
+            "__doc__",
+            w_str_new(
+                "Convert a function to be a class method.\n\nA class method receives the class as implicit first argument,\njust like an instance method receives the instance.\nTo declare a class method, use this idiom:\n\n  class C:\n      @classmethod\n      def f(cls, arg1, arg2, argN):\n          ...\n\nIt can be called either on the class (e.g. C.f()) or on an instance\n(e.g. C().f()).  The instance is ignored except for its class.\nIf a class method is called for a derived class, the derived class\nobject is passed as the implied first argument.\n\nClass methods are different than C++ or Java static methods.\nIf you want those, see the staticmethod builtin.",
+            ),
+        ),
+        (
+            "__get__",
+            make_builtin_function("__get__", classmethod_descr_get),
+        ),
+        ("__new__", make_new_descr(classmethod_descr_new)),
+        (
+            "__init__",
+            make_builtin_function("__init__", classmethod_descr_init),
+        ),
+        (
             "__func__",
             make_getset_descriptor(make_builtin_function_with_arity(
                 "__func__",
                 classmethod_func_attr,
                 2,
             )),
-        )
-    };
-    unsafe {
-        pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
-            ns,
+        ),
+        (
             "__wrapped__",
             make_getset_descriptor(make_builtin_function_with_arity(
                 "__wrapped__",
                 classmethod_func_attr,
                 2,
             )),
-        )
-    };
-    // typedef.py:886 `__isabstractmethod__ = GetSetProperty(
-    //     ClassMethod.descr_isabstract)`.  function.py:760-761:
-    //
-    //     def descr_isabstract(self, space):
-    //         return space.newbool(space.isabstractmethod_w(self.w_function))
-    unsafe {
-        pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
-            ns,
+        ),
+        (
             "__isabstractmethod__",
             make_getset_descriptor(make_builtin_function_with_arity(
                 "__isabstractmethod__",
-                |args| {
-                    let cm = args.get(1).copied().unwrap_or(pyre_object::PY_NULL);
-                    if !unsafe { pyre_object::function::is_classmethod(cm) } {
-                        return Ok(pyre_object::w_bool_from(false));
-                    }
-                    let func = unsafe { pyre_object::function::w_classmethod_get_func(cm) };
-                    let result = crate::baseobjspace::isabstractmethod_w(func)?;
-                    Ok(pyre_object::w_bool_from(result))
-                },
+                classmethod_isabstract,
                 2,
             )),
-        )
-    };
+        ),
+        (
+            "__dict__",
+            make_getset_property_named(dict_getter, dict_setter, dict_deleter, "__dict__"),
+        ),
+        (
+            "__annotations__",
+            make_getset_property_named(
+                annotations_getter,
+                annotations_setter,
+                annotations_deleter,
+                "__annotations__",
+            ),
+        ),
+        (
+            "__annotate__",
+            make_getset_property_named(
+                annotate_getter,
+                annotate_setter,
+                annotate_deleter,
+                "__annotate__",
+            ),
+        ),
+        (
+            "__class_getitem__",
+            pyre_object::function::w_classmethod_new(make_builtin_function(
+                "__class_getitem__",
+                crate::_pypy_generic_alias::generic_alias_class_getitem,
+            )),
+        ),
+        (
+            "__repr__",
+            make_builtin_function("__repr__", classmethod_descr_repr),
+        ),
+    ];
+    for (name, value) in entries {
+        unsafe { pyre_object::w_dict_setitem_str_no_proxy(ns, name, value) };
+    }
 }
 
 /// `property.__new__(cls, fget=None, fset=None, fdel=None, doc=None)`

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -495,13 +495,21 @@ pub fn init_typeobjects() {
             function_type as usize,
         );
 
-        // builtin_function — PyPy: typedef.py BuiltinFunction.typedef
-        // Mirrors Function.typedef except `__get__` is intentionally absent.
-        let builtin_function_type =
-            new_typeobject_with_base("builtin_function", init_builtin_function_type, object_type);
-        unsafe { pyre_object::w_type_set_acceptable_as_base_class(builtin_function_type, false) };
+        // builtin_function — PyPy: typedef.py BuiltinFunction.typedef. The
+        // externally visible name follows CPython 3.14.
+        let builtin_function_type = new_typeobject_with_base(
+            "builtin_function_or_method",
+            init_builtin_function_type,
+            object_type,
+        );
         unsafe {
-            pyre_object::w_type_set_hasdict(builtin_function_type, true);
+            pyre_object::w_type_set_acceptable_as_base_class(builtin_function_type, false);
+            pyre_object::w_type_set_disallow_instantiation(builtin_function_type);
+        }
+        unsafe {
+            // CPython 3.14 PyCFunction objects are weakrefable but have no
+            // instance dict. PyPy's copied Function rawdict differs here.
+            pyre_object::w_type_set_hasdict(builtin_function_type, false);
             pyre_object::w_type_set_weakrefable(builtin_function_type, true);
         }
         reg.insert(
@@ -8989,6 +8997,15 @@ fn init_function_type_common(ns: PyObjectRef) {
             )),
         )
     };
+    // typedef.py:793-794 `Function.typedef.__call__`; copied verbatim into
+    // `BuiltinFunction.typedef` by `**Function.typedef.rawdict`.
+    unsafe {
+        pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
+            ns,
+            "__call__",
+            make_builtin_function("__call__", function_descr_call),
+        )
+    };
 }
 
 /// PyPy `Function.descr_function_call(self, __args__)`: forward the complete
@@ -9061,7 +9078,11 @@ pub(crate) unsafe fn direct_member_set(
             Ok(pyre_object::w_none())
         }
         pyre_object::MEMBER_FUNCTION_MODULE => {
-            unsafe { crate::function::fset___module__(obj, value)? };
+            if unsafe { pyre_object::py_type_check(obj, &crate::function::BUILTIN_FUNCTION_TYPE) } {
+                unsafe { crate::function::builtin_function_set_module_attr(obj, value) };
+            } else {
+                unsafe { crate::function::fset___module__(obj, value)? };
+            }
             Ok(pyre_object::w_none())
         }
         _ => Err(crate::PyError::attribute_error("readonly attribute")),
@@ -9078,7 +9099,13 @@ pub(crate) unsafe fn direct_member_delete(
             Ok(pyre_object::w_none())
         }
         pyre_object::MEMBER_FUNCTION_MODULE => {
-            unsafe { crate::function::fdel___module__(obj)? };
+            if unsafe { pyre_object::py_type_check(obj, &crate::function::BUILTIN_FUNCTION_TYPE) } {
+                unsafe {
+                    crate::function::builtin_function_set_module_attr(obj, pyre_object::w_none())
+                };
+            } else {
+                unsafe { crate::function::fdel___module__(obj)? };
+            }
             Ok(pyre_object::w_none())
         }
         _ => Err(crate::PyError::attribute_error("readonly attribute")),
@@ -9106,15 +9133,6 @@ fn init_function_type(ns: PyObjectRef) {
             );
         }
     }
-    // CPython 3.14 `PyFunction_Type.tp_call = _PyObject_MakeTpCall` and
-    // PyPy `Function.typedef.__call__ = descr_function_call`.
-    unsafe {
-        pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
-            ns,
-            "__call__",
-            make_builtin_function("__call__", function_descr_call),
-        )
-    };
     // CPython 3.14 func_repr: `<function {qualname} at {address}>`.
     unsafe {
         pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
@@ -9273,47 +9291,72 @@ fn init_function_type(ns: PyObjectRef) {
 /// pyre starts modeling them.
 fn init_builtin_function_type(ns: PyObjectRef) {
     init_function_type_common(ns);
+
+    // CPython 3.14 `PyCFunction_Type` does not expose the user-function
+    // storage copied by PyPy's `**Function.typedef.rawdict`. Keep the PyPy
+    // construction above, then apply the version-selected surface delta.
+    for name in [
+        "__annotations__",
+        "__builtins__",
+        "__closure__",
+        "__code__",
+        "__defaults__",
+        "__defaults_count__",
+        "__globals__",
+        "__kwdefaults__",
+        "__new__",
+        "__objclass__",
+    ] {
+        unsafe { pyre_object::dictmultiobject::w_dict_delitem_str_no_proxy(ns, name) };
+    }
+
+    // methodobject.c `meth_members`: `__module__` is the one direct member;
+    // it accepts arbitrary assignments and deletion stores None.
     unsafe {
         pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
             ns,
-            "__new__",
-            make_new_descr(|_args| {
-                Err(crate::PyError::type_error(
-                    "cannot create 'builtin_function' instances",
-                ))
-            }),
+            "__module__",
+            pyre_object::w_member_new_direct(
+                pyre_object::MEMBER_FUNCTION_MODULE,
+                "__module__".to_owned(),
+                pyre_object::PY_NULL,
+            ),
         )
     };
 
-    // typedef.py:816 GetSetProperty(always_none, cls=BuiltinFunction). The
-    // `cls=` argument routes through descr_self_interp_w so wrong-class
-    // instances raise DescrMismatch instead of silently returning None.
-    // `init_builtin_function_type` runs while the BuiltinFunction
-    // W_TypeObject is still under construction, so `cls` cannot be
-    // resolved here; `patch_builtin_function_descriptors` runs after the
-    // type cache is populated and writes the missing reqcls.
-    // A builtin `__new__` carrier reports its defining type as `__self__`
-    // (`typeobject.c add_tp_new_wrapper`), stamped via
-    // `stamp_new_descr_self`; every other builtin function keeps the
-    // `always_none` behaviour.
-    let self_getter = make_builtin_function_with_arity(
-        "__self__",
-        |args| {
-            let func = args.get(1).copied().unwrap_or(pyre_object::PY_NULL);
-            if func.is_null() {
-                return Ok(pyre_object::w_none());
-            }
-            Ok(unsafe { crate::function::function_get_self_or_none(func) })
-        },
-        2,
-    );
-    unsafe {
-        pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
-            ns,
-            "__self__",
-            make_getset_descriptor(self_getter),
-        )
-    };
+    // methodobject.c `meth_getsets`. All five are read-only in 3.14. PyPy's
+    // `BuiltinFunction.w_moduleobj` supplies `__self__`; type `__new__`
+    // carriers fall back to their separately stamped defining type.
+    for (name, getter) in [
+        (
+            "__doc__",
+            (|args: &[PyObjectRef]| Ok(unsafe { crate::function::fget_func_doc(args[1]) }))
+                as fn(&[PyObjectRef]) -> crate::PyResult,
+        ),
+        ("__name__", |args: &[PyObjectRef]| {
+            Ok(unsafe { crate::function::fget_func_name(args[1]) })
+        }),
+        ("__qualname__", |args: &[PyObjectRef]| {
+            Ok(pyre_object::w_str_new(&unsafe {
+                crate::function::function_get_qualname(args[1])
+            }))
+        }),
+        ("__self__", |args: &[PyObjectRef]| {
+            Ok(unsafe { crate::function::function_get_self_or_none(args[1]) })
+        }),
+        ("__text_signature__", |args: &[PyObjectRef]| unsafe {
+            crate::function::fget_func_text_signature(args[1])
+        }),
+    ] {
+        let get = make_builtin_function_with_arity(name, getter, 2);
+        unsafe {
+            pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
+                ns,
+                name,
+                make_getset_descriptor(get),
+            )
+        };
+    }
 
     unsafe {
         pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
@@ -9337,21 +9380,69 @@ fn init_builtin_function_type(ns: PyObjectRef) {
         )
     };
 
-    // `pypy/interpreter/typedef.py:899-906`
-    // `BuiltinFunction.typedef.rawdict.update({...})` re-asserts
-    // `__doc__` from the inherited `Function.typedef.rawdict` slot
-    // (also `getset_func_doc`).  Pyre installs `__doc__` once in
-    // `init_function_type_common` so both function types share the
-    // same getter/setter/deleter; the `_check_code_mutable` gate
-    // inside the setter/deleter raises `TypeError` for builtin
-    // instances because `can_change_code = False`.
+    // function.py:807-808 `BuiltinFunction.descr__reduce__`.
+    unsafe {
+        pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
+            ns,
+            "__reduce__",
+            make_builtin_function_with_arity(
+                "__reduce__",
+                |args| {
+                    Ok(pyre_object::w_str_new(&unsafe {
+                        crate::function::function_get_qualname(args[0])
+                    }))
+                },
+                1,
+            ),
+        )
+    };
+
+    // CPython 3.14's method-wrapper slots are materialised directly on
+    // `PyCFunction_Type`. Their semantics are the object identity defaults.
+    for (name, method) in [
+        (
+            "__eq__",
+            (|args: &[PyObjectRef]| Ok(pyre_object::w_bool_from(std::ptr::eq(args[0], args[1]))))
+                as fn(&[PyObjectRef]) -> crate::PyResult,
+        ),
+        ("__ne__", |args: &[PyObjectRef]| {
+            Ok(pyre_object::w_bool_from(!std::ptr::eq(args[0], args[1])))
+        }),
+    ] {
+        unsafe {
+            pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
+                ns,
+                name,
+                make_builtin_function_with_arity(name, method, 2),
+            )
+        };
+    }
+    for name in ["__lt__", "__le__", "__gt__", "__ge__"] {
+        unsafe {
+            pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
+                ns,
+                name,
+                make_builtin_function_with_arity(name, |_| Ok(pyre_object::w_not_implemented()), 2),
+            )
+        };
+    }
+    unsafe {
+        pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
+            ns,
+            "__hash__",
+            make_builtin_function_with_arity(
+                "__hash__",
+                |args| Ok(pyre_object::w_int_new(args[0] as i64)),
+                1,
+            ),
+        )
+    };
 }
 
-/// typedef.py:816,818 wires `cls=BuiltinFunction` on the `__self__` and
-/// `__doc__` GetSetProperty entries; the inner `init_builtin_function_type`
-/// runs while the W_TypeObject is still under construction, so the reqcls
-/// patch happens here, after `init_typeobjects` has filled the cache and
-/// the BuiltinFunction typeobject is reachable.
+/// Stamp CPython 3.14's builtin-function getset/member descriptors after the
+/// W_TypeObject is reachable. PyPy supplies `cls=BuiltinFunction` for the
+/// inherited descriptors; CPython's `PyGetSetDef` / `PyMemberDef` entries all
+/// carry `PyCFunction_Type` as their owner.
 fn patch_builtin_function_descriptors() {
     let bf_type =
         gettypefor(&crate::BUILTIN_FUNCTION_TYPE as *const PyType).unwrap_or(pyre_object::PY_NULL);
@@ -9361,17 +9452,22 @@ fn patch_builtin_function_descriptors() {
     if !crate::type_dict_has_storage(bf_type) {
         return;
     }
-    for name in ["__self__", "__doc__"] {
+    for name in [
+        "__doc__",
+        "__name__",
+        "__qualname__",
+        "__self__",
+        "__text_signature__",
+    ] {
         if let Some(descr) = crate::type_dict_lookup(bf_type, name) {
             if unsafe { pyre_object::typedef::is_getset_property(descr) } {
-                // typedef.py:818 `cls=BuiltinFunction` — patch the
-                // `reqcls` slot in place now that the BuiltinFunction
-                // typeobject exists.  GetSetProperty's reqcls is a
-                // single PyObjectRef field, so this is a one-line
-                // store rather than the previous side-table read /
-                // mutate / write back dance.
                 unsafe { pyre_object::typedef::w_getset_set_reqcls(descr, bf_type) };
             }
+        }
+    }
+    if let Some(descr) = crate::type_dict_lookup(bf_type, "__module__") {
+        if unsafe { pyre_object::is_member(descr) && pyre_object::w_member_is_direct(descr) } {
+            unsafe { pyre_object::w_member_set_cls(descr, bf_type) };
         }
     }
 }

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -39,7 +39,7 @@ extern "C" fn trace_function_get_defaults(func: i64) -> i64 {
 
 extern "C" fn trace_function_get_kwdefaults(func: i64) -> i64 {
     let kwdefaults = unsafe { pyre_interpreter::function_get_kwdefaults(func as PyObjectRef) };
-    pyre_interpreter::baseobjspace::unwrap_cell(kwdefaults) as i64
+    kwdefaults as i64
 }
 
 extern "C" fn trace_dict_lookup_jit(dict: i64, key: i64) -> i64 {
@@ -409,7 +409,6 @@ fn positional_defaults_to_load(
         return None;
     }
 
-    let defaults = pyre_interpreter::baseobjspace::unwrap_cell(defaults);
     let ndefaults = if unsafe { pyre_object::is_tuple(defaults) } {
         unsafe { w_tuple_len(defaults) }
     } else {
@@ -9369,7 +9368,6 @@ impl OpcodeStepExecutor for MIFrame {
                 );
                 this.implement_guard_value(ctx, defaults, defaults_obj as i64);
             });
-            let defaults_obj = pyre_interpreter::baseobjspace::unwrap_cell(defaults_obj);
             if unsafe { pyre_object::is_tuple(defaults_obj) } {
                 let ndefaults = unsafe { w_tuple_len(defaults_obj) };
                 let first_default = n_pos_params.saturating_sub(ndefaults);
@@ -9388,9 +9386,7 @@ impl OpcodeStepExecutor for MIFrame {
         }
 
         // Fill keyword-only defaults.
-        let kwdefaults = pyre_interpreter::baseobjspace::unwrap_cell(unsafe {
-            pyre_interpreter::function_get_kwdefaults(target_func)
-        });
+        let kwdefaults = unsafe { pyre_interpreter::function_get_kwdefaults(target_func) };
         if !kwdefaults.is_null() && unsafe { pyre_object::is_dict(kwdefaults) } {
             let kwdefaults_opref = self.with_ctx(|this, ctx| {
                 let runtime_kwdefaults = ctx.call_ref_typed_with_effect(

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -3371,7 +3371,6 @@ fn fill_positional_defaults_for_jit_call<'a>(
         return Cow::Borrowed(args);
     }
 
-    let defaults = pyre_interpreter::baseobjspace::unwrap_cell(defaults);
     let ndefaults = if unsafe { pyre_object::is_tuple(defaults) } {
         unsafe { pyre_object::w_tuple_len(defaults) }
     } else {

--- a/pyre/pyre-object/src/descriptor.rs
+++ b/pyre/pyre-object/src/descriptor.rs
@@ -122,7 +122,7 @@ mod super_tests {
 
 /// Python property descriptor object.
 ///
-/// Layout: `[ob_type | fget | fset | fdel | w_doc | getter_doc]`
+/// Layout: `[ob_type | fget | fset | fdel | w_doc | w_name | getter_doc]`
 #[pyre_class("property", type_id = 19, static_name = "PROPERTY")]
 pub struct W_Property {
     pub fget: PyObjectRef,
@@ -209,6 +209,29 @@ pub unsafe fn w_property_get_fdel(obj: PyObjectRef) -> PyObjectRef {
     (*(obj as *const W_Property)).fdel
 }
 
+/// Re-run `property.__init__` on an existing allocation.
+///
+/// PyPy `descriptor.py:W_Property.init` assigns the three accessors and
+/// resets `w_doc` / `getter_doc` before deriving a docstring from the new
+/// getter.  CPython 3.14 additionally clears `prop_name` on every init.  Keep
+/// those object-resident fields together here instead of maintaining an
+/// interpreter-side shadow table.
+pub unsafe fn w_property_reinit(
+    obj: PyObjectRef,
+    fget: PyObjectRef,
+    fset: PyObjectRef,
+    fdel: PyObjectRef,
+) {
+    let prop = obj as *mut W_Property;
+    (*prop).fget = fget;
+    (*prop).fset = fset;
+    (*prop).fdel = fdel;
+    (*prop).w_doc = PY_NULL;
+    (*prop).w_name = PY_NULL;
+    (*prop).getter_doc = false;
+    crate::gc_hook::try_gc_write_barrier(obj as *mut u8);
+}
+
 /// `descriptor.py:249-250 W_Property.get_doc` — returns the raw slot
 /// (NULL plays None; the caller wraps).
 pub unsafe fn w_property_get_doc(obj: PyObjectRef) -> PyObjectRef {
@@ -233,6 +256,14 @@ pub unsafe fn w_property_set_getter_doc(obj: PyObjectRef, w_doc: PyObjectRef) {
     (*prop).w_doc = w_doc;
     (*prop).getter_doc = true;
     crate::gc_hook::try_gc_write_barrier(obj as *mut u8);
+}
+
+/// Mark that a property subclass obtained its visible `__doc__` from the
+/// getter.  CPython 3.14 stores that visible value in the subclass instance
+/// dict (because the subclass class dict shadows property's member), while
+/// `_copy` still consults the flag on the native property payload.
+pub unsafe fn w_property_mark_getter_doc(obj: PyObjectRef) {
+    (*(obj as *mut W_Property)).getter_doc = true;
 }
 
 /// `self.w_name` — NULL plays unset.
@@ -263,6 +294,27 @@ mod property_tests {
         unsafe {
             assert!(is_property(obj));
             assert!(!is_int(obj));
+        }
+    }
+
+    #[test]
+    fn property_reinit_replaces_accessors_and_clears_metadata() {
+        let obj = w_property_new(PY_NULL, PY_NULL, PY_NULL);
+        let old_doc = crate::w_int_new(10);
+        let old_name = crate::w_int_new(11);
+        let fget = crate::w_int_new(1);
+        let fset = crate::w_int_new(2);
+        let fdel = crate::w_int_new(3);
+        unsafe {
+            w_property_set_getter_doc(obj, old_doc);
+            w_property_set_name(obj, old_name);
+            w_property_reinit(obj, fget, fset, fdel);
+            assert_eq!(w_property_get_fget(obj), fget);
+            assert_eq!(w_property_get_fset(obj), fset);
+            assert_eq!(w_property_get_fdel(obj), fdel);
+            assert!(w_property_get_doc(obj).is_null());
+            assert!(w_property_get_name(obj).is_null());
+            assert!(!(*(obj as *const W_Property)).getter_doc);
         }
     }
 

--- a/pyre/pyre-object/src/function.rs
+++ b/pyre/pyre-object/src/function.rs
@@ -108,6 +108,10 @@ pub unsafe fn w_method_get_class(obj: PyObjectRef) -> PyObjectRef {
 #[pyre_class("staticmethod", type_id = 20, static_name = "STATICMETHOD")]
 pub struct StaticMethod {
     pub w_function: PyObjectRef,
+    /// function.py:676 `self.w_dict = None` — lazily allocated by
+    /// `StaticMethod.getdict`, then populated by `descr_init` with the
+    /// wrapped function's presentation attributes.
+    pub w_dict: PyObjectRef,
 }
 
 pub fn w_staticmethod_new(func: PyObjectRef) -> PyObjectRef {
@@ -133,6 +137,7 @@ pub fn w_staticmethod_new(func: PyObjectRef) -> PyObjectRef {
                 StaticMethod {
                     ob: header,
                     w_function: func,
+                    w_dict: PY_NULL,
                 },
             );
         }
@@ -142,11 +147,45 @@ pub fn w_staticmethod_new(func: PyObjectRef) -> PyObjectRef {
     StaticMethod::allocate(StaticMethod {
         ob: header,
         w_function: func,
+        w_dict: PY_NULL,
     })
 }
 
 pub unsafe fn w_staticmethod_get_func(obj: PyObjectRef) -> PyObjectRef {
     (*(obj as *const StaticMethod)).w_function
+}
+
+/// function.py:697 `self.w_function = w_function`.
+#[inline]
+pub unsafe fn w_staticmethod_set_func(obj: PyObjectRef, func: PyObjectRef) {
+    unsafe {
+        (*(obj as *mut StaticMethod)).w_function = func;
+        crate::gc_hook::try_gc_write_barrier(obj as *mut u8);
+    }
+}
+
+/// function.py:678-681 `StaticMethod.getdict` — allocate the instance
+/// dictionary on first access and retain its identity.
+#[inline]
+pub unsafe fn w_staticmethod_getdict(obj: PyObjectRef) -> PyObjectRef {
+    unsafe {
+        let sm = obj as *mut StaticMethod;
+        if (*sm).w_dict.is_null() {
+            (*sm).w_dict = crate::w_dict_new();
+            crate::gc_hook::try_gc_write_barrier(obj as *mut u8);
+        }
+        (*sm).w_dict
+    }
+}
+
+/// function.py:683-688 `StaticMethod.setdict`; the caller performs the
+/// dict type check before replacing this field.
+#[inline]
+pub unsafe fn w_staticmethod_setdict(obj: PyObjectRef, w_dict: PyObjectRef) {
+    unsafe {
+        (*(obj as *mut StaticMethod)).w_dict = w_dict;
+        crate::gc_hook::try_gc_write_barrier(obj as *mut u8);
+    }
 }
 
 #[inline]

--- a/pyre/pyre-object/src/function.rs
+++ b/pyre/pyre-object/src/function.rs
@@ -202,6 +202,9 @@ pub unsafe fn is_staticmethod(obj: PyObjectRef) -> bool {
 #[pyre_class("classmethod", type_id = 21, static_name = "CLASSMETHOD")]
 pub struct ClassMethod {
     pub w_function: PyObjectRef,
+    /// function.py:724 `self.w_dict = None` — a real per-wrapper field,
+    /// allocated lazily by `ClassMethod.getdict`.
+    pub w_dict: PyObjectRef,
 }
 
 pub fn w_classmethod_new(func: PyObjectRef) -> PyObjectRef {
@@ -227,6 +230,7 @@ pub fn w_classmethod_new(func: PyObjectRef) -> PyObjectRef {
                 ClassMethod {
                     ob: header,
                     w_function: func,
+                    w_dict: PY_NULL,
                 },
             );
         }
@@ -236,11 +240,44 @@ pub fn w_classmethod_new(func: PyObjectRef) -> PyObjectRef {
     ClassMethod::allocate(ClassMethod {
         ob: header,
         w_function: func,
+        w_dict: PY_NULL,
     })
 }
 
 pub unsafe fn w_classmethod_get_func(obj: PyObjectRef) -> PyObjectRef {
     (*(obj as *const ClassMethod)).w_function
+}
+
+/// function.py:752 `self.w_function = w_function`.
+#[inline]
+pub unsafe fn w_classmethod_set_func(obj: PyObjectRef, func: PyObjectRef) {
+    unsafe {
+        (*(obj as *mut ClassMethod)).w_function = func;
+        crate::gc_hook::try_gc_write_barrier(obj as *mut u8);
+    }
+}
+
+/// function.py:726-729 `ClassMethod.getdict`.
+#[inline]
+pub unsafe fn w_classmethod_getdict(obj: PyObjectRef) -> PyObjectRef {
+    unsafe {
+        let cm = obj as *mut ClassMethod;
+        if (*cm).w_dict.is_null() {
+            (*cm).w_dict = crate::w_dict_new();
+            crate::gc_hook::try_gc_write_barrier(obj as *mut u8);
+        }
+        (*cm).w_dict
+    }
+}
+
+/// function.py:731-736 `ClassMethod.setdict`; the object-space layer checks
+/// for dict or a dict subclass before replacing the field.
+#[inline]
+pub unsafe fn w_classmethod_setdict(obj: PyObjectRef, w_dict: PyObjectRef) {
+    unsafe {
+        (*(obj as *mut ClassMethod)).w_dict = w_dict;
+        crate::gc_hook::try_gc_write_barrier(obj as *mut u8);
+    }
 }
 
 #[inline]

--- a/pyre/pyre-object/src/typedef.rs
+++ b/pyre/pyre-object/src/typedef.rs
@@ -243,6 +243,18 @@ pub struct W_MemberDescr {
     pub w_cls: PyObjectRef,
 }
 
+/// Python 3.14's function type exposes five direct `PyMemberDef` entries.
+/// PyPy represents the same values with GetSetProperty, while ordinary PyPy
+/// `Member` objects use `index` for `__slots__`.  Reserve the high bit so the
+/// existing slot-index shape stays intact and the interpreter can distinguish
+/// the 3.14 direct members without a side table.
+pub const MEMBER_DIRECT_FLAG: u32 = 1 << 31;
+pub const MEMBER_FUNCTION_CLOSURE: u32 = MEMBER_DIRECT_FLAG;
+pub const MEMBER_FUNCTION_DOC: u32 = MEMBER_DIRECT_FLAG | 1;
+pub const MEMBER_FUNCTION_GLOBALS: u32 = MEMBER_DIRECT_FLAG | 2;
+pub const MEMBER_FUNCTION_MODULE: u32 = MEMBER_DIRECT_FLAG | 3;
+pub const MEMBER_FUNCTION_BUILTINS: u32 = MEMBER_DIRECT_FLAG | 4;
+
 /// Create a new Member descriptor.
 pub fn w_member_new(index: u32, name: String, w_cls: PyObjectRef) -> PyObjectRef {
     // `gct_fv_gc_malloc` bracket pattern (`framework.py:853-856`).
@@ -258,6 +270,12 @@ pub fn w_member_new(index: u32, name: String, w_cls: PyObjectRef) -> PyObjectRef
         name,
         w_cls,
     })
+}
+
+/// Create one of Python 3.14's direct function member descriptors.
+pub fn w_member_new_direct(kind: u32, name: String, w_cls: PyObjectRef) -> PyObjectRef {
+    debug_assert_ne!(kind & MEMBER_DIRECT_FLAG, 0);
+    w_member_new(kind, name, w_cls)
 }
 
 /// Check if an object is a Member descriptor.
@@ -276,11 +294,29 @@ pub unsafe fn w_member_get_cls(obj: PyObjectRef) -> PyObjectRef {
     unsafe { (*(obj as *const W_MemberDescr)).w_cls }
 }
 
+/// Fill a descriptor owner after the built-in type registry is published.
+pub unsafe fn w_member_set_cls(obj: PyObjectRef, w_cls: PyObjectRef) {
+    crate::gc_roots::mark_prebuilt_roots_dirty();
+    unsafe { (*(obj as *mut W_MemberDescr)).w_cls = w_cls }
+}
+
 /// `typedef.py:446 Member.index` — the slot index (`base_nslots + position`),
 /// used by the LOAD_ATTR/STORE_ATTR cache to form the `SLOTS_STARTING_FROM +
 /// index` attrkind (mapdict.py:1520).
 pub unsafe fn w_member_get_index(obj: PyObjectRef) -> u32 {
     unsafe { (*(obj as *const W_MemberDescr)).index }
+}
+
+#[inline]
+pub unsafe fn w_member_is_direct(obj: PyObjectRef) -> bool {
+    unsafe { w_member_get_index(obj) & MEMBER_DIRECT_FLAG != 0 }
+}
+
+#[inline]
+pub unsafe fn w_member_get_direct_kind(obj: PyObjectRef) -> u32 {
+    let kind = unsafe { w_member_get_index(obj) };
+    debug_assert_ne!(kind & MEMBER_DIRECT_FLAG, 0);
+    kind
 }
 
 #[cfg(test)]

--- a/pyre/pyre-object/src/typedef.rs
+++ b/pyre/pyre-object/src/typedef.rs
@@ -254,6 +254,8 @@ pub const MEMBER_FUNCTION_DOC: u32 = MEMBER_DIRECT_FLAG | 1;
 pub const MEMBER_FUNCTION_GLOBALS: u32 = MEMBER_DIRECT_FLAG | 2;
 pub const MEMBER_FUNCTION_MODULE: u32 = MEMBER_DIRECT_FLAG | 3;
 pub const MEMBER_FUNCTION_BUILTINS: u32 = MEMBER_DIRECT_FLAG | 4;
+/// CPython 3.14 `module_members`: the authoritative Module.w_dict field.
+pub const MEMBER_MODULE_DICT: u32 = MEMBER_DIRECT_FLAG | 5;
 
 /// Create a new Member descriptor.
 pub fn w_member_new(index: u32, name: String, w_cls: PyObjectRef) -> PyObjectRef {


### PR DESCRIPTION
Completes typedef parity for the callable/descriptor family and the code
object against Python 3.14, and adds parity tests for each.

## Type objects

- **code** — `pycode.rs`/`typedef.rs`: the 3.14 `code` type layout, members,
  and methods (`replace`, `co_*` attributes) with a GC offset coverage test fix.
- **function** — `function.rs`/`pyre-object/src/function.rs`: function typedef
  members and `__dict__`/`__weakref__` exposure.
- **method** — bound-method typedef.
- **cell** — cell typedef; visible cells are preserved.
- **property** — property typedef and the descriptor protocol.
- **classmethod** / **staticmethod** — descriptor typedefs.
- **range** — rich comparison parity.

## check.py

Measures each interpreter's empty-program startup time and subtracts it from
the reported perf ratios and gates.

## Tests

New parity tests under `pyre/extra_tests/parity_tests/`
(`code_python314.py`, `function_python314.py`, `method_python314.py`,
`property_protocol.py`, `classmethod_protocol.py`, `staticmethod_protocol.py`,
updated `closure_cell_protocol.py`, `range_python314.py`) and synthetic
benchmarks for the property/classmethod protocols.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved Python 3.14 compatibility across descriptors, functions, methods, properties, modules, ranges, cells, and mapping proxies.
  * Added support for richer function metadata (annotations, type parameters, built-in linkage) and descriptor dictionaries.
  * WebAssembly backend now performs runtime invalidation checks for relevant guards/bridges.
* **Bug Fixes**
  * Refined callable and operand handling to better match CPython descriptor precedence and error behavior.
  * Improved code-object `firstlineno` preservation and related `replace()` behavior.
* **Tests**
  * Expanded Python 3.14 parity/regression coverage for multiple runtime and descriptor APIs.
  * Added/updated benchmarks for classmethod and property protocol behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->