### PR TITLE
_ctypes: complete PyPy-compatible implementation

### DIFF
--- a/.github/workflows/pyre-ci.yml
+++ b/.github/workflows/pyre-ci.yml
@@ -67,6 +67,7 @@ jobs:
     - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       with:
         cache-bin: false
+        shared-key: ${{ runner.arch }}
         # Restore-only on PRs (they pull main's cache via restore-keys); save
         # only on main so per-PR target caches don't multiply across refs past
         # GitHub's 10 GB cache budget and trigger LRU eviction.
@@ -204,6 +205,7 @@ jobs:
     - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       with:
         cache-bin: false
+        shared-key: ${{ runner.arch }}
         # Restore-only on PRs (they pull main's cache via restore-keys); save
         # only on main so per-PR target caches don't multiply across refs past
         # GitHub's 10 GB cache budget and trigger LRU eviction.
@@ -338,6 +340,7 @@ jobs:
     - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       with:
         cache-bin: false
+        shared-key: ${{ runner.arch }}
         # Restore-only on PRs (they pull main's cache via restore-keys); save
         # only on main so per-PR target caches don't multiply across refs past
         # GitHub's 10 GB cache budget and trigger LRU eviction.
@@ -467,6 +470,7 @@ jobs:
     - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       with:
         cache-bin: false
+        shared-key: ${{ runner.arch }}
         # Restore-only on PRs (they pull main's cache via restore-keys); save
         # only on main so per-PR target caches don't multiply across refs past
         # GitHub's 10 GB cache budget and trigger LRU eviction.
@@ -529,6 +533,7 @@ jobs:
     - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       with:
         cache-bin: false
+        shared-key: ${{ runner.arch }}
         # Restore-only on PRs (they pull main's cache via restore-keys); save
         # only on main so per-PR target caches don't multiply across refs past
         # GitHub's 10 GB cache budget and trigger LRU eviction.
@@ -590,6 +595,7 @@ jobs:
     - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       with:
         cache-bin: false
+        shared-key: ${{ runner.arch }}
     - name: Download Charon artifact
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,7 +102,9 @@ lines, e.g. `GcType`→`n`; pass `rg --no-config` when bucketing.)
 
 ## Data structure parity with RPython/PyPy
 
-**Do not casually introduce `HashMap` (or any Rust-native collection) when porting RPython/PyPy code.**
+**Treat every `HashMap` and every thread-local (`thread_local!`, TLS) as
+suspicious when porting RPython/PyPy code.** Find the corresponding PyPy or
+RPython owner and storage shape before choosing a Rust container or lifetime.
 
 majit and pyre are line-by-line ports. The data structure choice is part of
 the port — it must match what RPython/PyPy actually uses, even when a Rust
@@ -114,6 +116,12 @@ collection looks more convenient.
    `BTreeMap`, etc., find the corresponding RPython attribute and check what
    container it uses (`dict`, `list`, an attribute on a class instance, a
    field on `_forwarded`, …). Port that exact shape.
+
+   A Rust `HashMap` is not the default translation of a Python `dict`. When
+   lookup is over a small/dense key space, stable insertion order matters, or
+   identity/index lookup is sufficient, `VecMap`, `IndexMap`, or an ordinary
+   `Vec` is often the closer representation. Prove the required semantics from
+   the upstream code before choosing among them.
 
 2. **Side-tables are usually wrong.** RPython optimizers store information
    *on the box itself* via `box._forwarded` / `PtrInfo` / `IntBound` /
@@ -136,6 +144,22 @@ collection looks more convenient.
    rewritten to a shortcut — the shortcut diverges from RPython and the
    next porter will have no idea why their `heap.py` line-by-line port
    no longer compiles.
+
+5. **TLS is almost never the right owner for runtime state.** Type objects,
+   module state, registries, semantic caches, and any value whose identity or
+   contents must be visible across threads are process-global or
+   interpreter-owned in PyPy and must remain shared in pyre. Never duplicate
+   them per thread merely to make a raw pointer satisfy Rust's `Sync` rules;
+   use the proper global/interpreter owner (for example the established
+   process-global immortal-type `OnceLock<usize>` pattern) and preserve GC
+   rooting as required.
+
+   TLS is acceptable only when the PyPy/RPython source makes the state itself
+   thread-specific (for example the current thread/execution context or errno),
+   or for a disposable temporary cache that cannot affect observable identity,
+   semantics, lifetime, or GC reachability. Every other TLS use requires an
+   upstream citation and a written justification in the code. When in doubt,
+   assume TLS is wrong and find the shared owner.
 
 ### Why
 
@@ -163,7 +187,9 @@ If RPython stores it on an object attribute, store it on the equivalent
 Rust struct field. If RPython stores it on `box._forwarded`, route it
 through `OptContext::with_intbound_mut` / `set_ptr_info` / etc. Reach
 for `HashMap` only after you have proven that RPython itself uses a
-dict-like container in that exact spot.
+dict-like container in that exact spot. Apply the same test to TLS: locate the
+upstream owner, then preserve whether it is global, interpreter-local,
+execution-context-local, or genuinely thread-local.
 
 ## RPython Parity Rules
 - When porting from RPython/PyPy, do STRICT line-by-line structural parity. Do NOT take shortcuts, reimplement from scratch, or declare phases 'complete' without the literal refactor.

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -4824,6 +4824,15 @@ fn object_getattr_miss(obj: PyObjectRef, name: &str, call_getattr: bool) -> PyRe
                 }
                 return Ok(bases);
             }
+            if name == "__base__" {
+                // typeobject.py:1164-1166 descr__base — choose the base whose
+                // instance layout is extended, not merely bases[0].
+                let base = pyre_object::typeobject::w_type_get_best_base(obj);
+                if base.is_null() {
+                    return Ok(pyre_object::w_none());
+                }
+                return Ok(base);
+            }
             // PEP 649 lazy annotations: when `cls.__annotations__` is
             // requested and only `__annotate_func__` (or `__annotate__`)
             // is set, call the annotate function with format=1 to

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -214,6 +214,8 @@ unsafe fn w_memoryview_new_plain(
         // size-changing mutation is refused while this view is live.
         if backing_is_bytearray(r_obj) {
             pyre_object::bytearrayobject::w_bytearray_exports_incref(r_obj);
+        } else if is_array {
+            pyre_object::interp_array::w_array_exports_incref(r_obj);
         }
         let backing = memoryview_backing_buffer(r_obj);
         let view = if is_array {
@@ -315,6 +317,52 @@ pub(crate) fn w_memoryview_new(w_obj: PyObjectRef) -> Result<PyObjectRef, crate:
             // clone preserves the variant, so copying a sliced / plain view
             // keeps its zero-copy window and derived geometry.
             return Ok(w_memoryview_new_derived(w_obj, |v| v.clone()));
+        }
+        #[cfg(all(unix, feature = "host_env"))]
+        if let Some((backing_obj, offset, byte_len, fmt, itemsize, shape)) =
+            crate::module::_ctypes::cdata::cdata_buffer_view(w_obj)
+        {
+            use pyre_object::buffer::Buffer;
+            use pyre_object::bufferview::BufferView;
+            let _roots = pyre_object::gc_roots::push_roots();
+            let sp = pyre_object::gc_roots::shadow_stack_len();
+            pyre_object::gc_roots::pin_root(w_obj);
+            pyre_object::gc_roots::pin_root(backing_obj);
+            pyre_object::gc_roots::pin_root(w_str_new(&fmt));
+            let shape_i64 = shape.iter().map(|&dim| dim as i64).collect::<Vec<_>>();
+            let mut strides = vec![0i64; shape.len()];
+            let mut stride = itemsize as i64;
+            for (i, &dim) in shape_i64.iter().enumerate().rev() {
+                strides[i] = stride;
+                stride = stride.saturating_mul(dim);
+            }
+            pyre_object::gc_roots::pin_root(memoryview_wrap_dims(&shape_i64));
+            pyre_object::gc_roots::pin_root(memoryview_wrap_dims(&strides));
+            let mv = w_memoryview_alloc_header(false, true);
+            let r_obj = pyre_object::gc_roots::shadow_stack_get(sp);
+            let r_backing = pyre_object::gc_roots::shadow_stack_get(sp + 1);
+            let r_fmt = pyre_object::gc_roots::shadow_stack_get(sp + 2);
+            let r_shape = pyre_object::gc_roots::shadow_stack_get(sp + 3);
+            let r_strides = pyre_object::gc_roots::shadow_stack_get(sp + 4);
+            pyre_object::bytearrayobject::w_bytearray_exports_incref(r_backing);
+            let backing = Buffer::sub(Buffer::Byte { w_obj: r_backing }, offset, byte_len as i64);
+            let raw = BufferView::Raw {
+                backing,
+                w_obj: r_obj,
+                w_fmt: r_fmt,
+                itemsize: itemsize as i64,
+                length: byte_len as i64,
+            };
+            let view = BufferView::ViewND {
+                parent: Box::new(raw),
+                w_obj: r_obj,
+                ndim: shape.len() as i64,
+                w_shape: r_shape,
+                w_strides: r_strides,
+            };
+            let view_ptr = pyre_object::memoryview::bufferview_alloc(view);
+            pyre_object::memoryview::w_memoryview_set_view(mv, view_ptr);
+            return Ok(mv);
         }
         let (fmt, itemsize, _readonly, byte_len) = match memoryview_buffer_params(w_obj) {
             Some(p) => p,
@@ -1005,7 +1053,7 @@ fn memoryview_len(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
         memoryview_check_released(mv)?;
         let dim = pyre_object::memoryview::w_memoryview_ndim(mv);
         if dim == 0 {
-            return Ok(w_int_new(1));
+            return Err(crate::PyError::type_error("0-dim memory has no length"));
         }
         match pyre_object::memoryview::w_memoryview_native_shape(mv).first() {
             Some(&s) => Ok(w_int_new(s)),

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -318,7 +318,7 @@ pub(crate) fn w_memoryview_new(w_obj: PyObjectRef) -> Result<PyObjectRef, crate:
             // keeps its zero-copy window and derived geometry.
             return Ok(w_memoryview_new_derived(w_obj, |v| v.clone()));
         }
-        #[cfg(all(unix, feature = "host_env"))]
+        #[cfg(all(unix, feature = "host_env", not(feature = "sandbox")))]
         if let Some((backing_obj, offset, byte_len, fmt, itemsize, shape)) =
             crate::module::_ctypes::cdata::cdata_buffer_view(w_obj)
         {

--- a/pyre/pyre-interpreter/src/error.rs
+++ b/pyre/pyre-interpreter/src/error.rs
@@ -733,6 +733,8 @@ impl PyError {
         };
         let mut first_line = if where_desc.is_empty() {
             String::new()
+        } else if where_desc.starts_with("Exception ignored ") {
+            where_desc.to_string()
         } else {
             format!("Exception ignored in: {where_desc}")
         };

--- a/pyre/pyre-interpreter/src/module/_contextvars/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_contextvars/mod.rs
@@ -8,6 +8,35 @@
 
 use pyre_object::*;
 
+fn context_type() -> PyObjectRef {
+    thread_local! {
+        static CELL: std::cell::OnceCell<PyObjectRef> =
+            const { std::cell::OnceCell::new() };
+    }
+    CELL.with(|c| {
+        *c.get_or_init(|| {
+            crate::typedef::make_builtin_type("Context", |ns| {
+                unsafe {
+                    pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
+                        ns,
+                        "run",
+                        crate::make_builtin_function("run", |args| {
+                            let callable = args.get(1).copied().ok_or_else(|| {
+                                crate::PyError::type_error("run() missing callable argument")
+                            })?;
+                            crate::call::call_function_impl_result(callable, &args[2..])
+                        }),
+                    )
+                };
+            })
+        })
+    })
+}
+
+fn new_context(_: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    Ok(w_instance_new(context_type()))
+}
+
 /// `ContextVar` instance type — needs `__dict__` so `name` / `get` / `set`
 /// can be stored as instance attributes.  Plain `object` instances reject
 /// `setattr`, leaving the shell without its methods.
@@ -60,8 +89,8 @@ crate::py_module! {
     "_contextvars",
     functions: {
         "ContextVar"   / * = context_var,
-        "Context"      / 0 = |_| Ok(w_none()),
+        "Context"      / 0 = new_context,
         "Token"        / 0 = |_| Ok(w_none()),
-        "copy_context" / 0 = |_| Ok(w_none()),
+        "copy_context" / 0 = new_context,
     },
 }

--- a/pyre/pyre-interpreter/src/module/_contextvars/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_contextvars/mod.rs
@@ -7,30 +7,28 @@
 //! not modelled.
 
 use pyre_object::*;
+use std::sync::OnceLock;
 
 fn context_type() -> PyObjectRef {
-    thread_local! {
-        static CELL: std::cell::OnceCell<PyObjectRef> =
-            const { std::cell::OnceCell::new() };
-    }
-    CELL.with(|c| {
-        *c.get_or_init(|| {
-            crate::typedef::make_builtin_type("Context", |ns| {
-                unsafe {
-                    pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
-                        ns,
-                        "run",
-                        crate::make_builtin_function("run", |args| {
-                            let callable = args.get(1).copied().ok_or_else(|| {
-                                crate::PyError::type_error("run() missing callable argument")
-                            })?;
-                            crate::call::call_function_impl_result(callable, &args[2..])
-                        }),
-                    )
-                };
-            })
-        })
-    })
+    // PyPy exposes one interpreter-level Context typedef; the type identity
+    // must not split when the importing thread changes.
+    static TYPE: OnceLock<usize> = OnceLock::new();
+    *TYPE.get_or_init(|| {
+        crate::typedef::make_builtin_type("Context", |ns| {
+            unsafe {
+                pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
+                    ns,
+                    "run",
+                    crate::make_builtin_function("run", |args| {
+                        let callable = args.get(1).copied().ok_or_else(|| {
+                            crate::PyError::type_error("run() missing callable argument")
+                        })?;
+                        crate::call::call_function_impl_result(callable, &args[2..])
+                    }),
+                )
+            };
+        }) as usize
+    }) as PyObjectRef
 }
 
 fn new_context(_: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
@@ -41,17 +39,12 @@ fn new_context(_: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
 /// can be stored as instance attributes.  Plain `object` instances reject
 /// `setattr`, leaving the shell without its methods.
 fn context_var_type() -> PyObjectRef {
-    thread_local! {
-        static CELL: std::cell::OnceCell<PyObjectRef> =
-            const { std::cell::OnceCell::new() };
-    }
-    CELL.with(|c| {
-        *c.get_or_init(|| {
-            let tp = crate::typedef::make_builtin_type("ContextVar", |_| {});
-            unsafe { typeobject::w_type_set_hasdict(tp, true) };
-            tp
-        })
-    })
+    static TYPE: OnceLock<usize> = OnceLock::new();
+    *TYPE.get_or_init(|| {
+        let tp = crate::typedef::make_builtin_type("ContextVar", |_| {});
+        unsafe { typeobject::w_type_set_hasdict(tp, true) };
+        tp as usize
+    }) as PyObjectRef
 }
 
 fn context_var(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {

--- a/pyre/pyre-interpreter/src/module/_ctypes/cdata.rs
+++ b/pyre/pyre-interpreter/src/module/_ctypes/cdata.rs
@@ -25,21 +25,242 @@ const BOFF_KEY: &str = "_boff_";
 const BSZ_KEY: &str = "_bsz_";
 /// The parent CData object a sub-view was carved from (keeps it alive).
 const BBASE_KEY: &str = "_b_base_";
+/// Field/array index by which a sub-view is reached from its parent.
+const BINDEX_KEY: &str = "_b_index_";
 /// Raw address of an external (non-bytearray-backed) view.
 const BADDR_KEY: &str = "_baddr_";
 /// Lazily-created keepalive dict on a root object.
 const OBJECTS_KEY: &str = "_objects_";
 
 thread_local! {
+    static CDATA_TYPE_OBJ: std::cell::OnceCell<PyObjectRef> =
+        const { std::cell::OnceCell::new() };
     static SIMPLECDATA_TYPE_OBJ: std::cell::OnceCell<PyObjectRef> =
         const { std::cell::OnceCell::new() };
+}
+
+/// PyPy/CPython/RustPython's private `_CData` base shared by every ctypes
+/// value family.  It is discovered as `Structure.__base__` rather than
+/// exported from the module namespace.
+pub(super) fn cdata_type() -> PyObjectRef {
+    CDATA_TYPE_OBJ.with(|c| {
+        *c.get_or_init(|| {
+            let tp = crate::typedef::make_builtin_type("_CData", init_cdata_type);
+            unsafe { pyre_object::typeobject::w_type_set_hasdict(tp, true) };
+            tp
+        })
+    })
+}
+
+fn init_cdata_type(ns: PyObjectRef) {
+    for (name, f) in [
+        (
+            "from_address",
+            cdata_from_address as crate::gateway::BuiltinCodeFn,
+        ),
+        ("from_buffer", cdata_from_buffer),
+        ("from_buffer_copy", cdata_from_buffer_copy),
+        ("in_dll", cdata_in_dll),
+    ] {
+        type_ns_store(
+            ns,
+            name,
+            pyre_object::function::w_classmethod_new(crate::make_builtin_function(name, f)),
+        );
+    }
+    for (name, f) in [
+        (
+            "_objects",
+            cdata_objects_get as crate::gateway::BuiltinCodeFn,
+        ),
+        ("_b_base_", cdata_base_get),
+        ("_b_needsfree_", cdata_needsfree_get),
+    ] {
+        type_ns_store(
+            ns,
+            name,
+            crate::typedef::make_getset_property_named(
+                crate::make_builtin_function_with_arity(name, f, 2),
+                pyre_object::PY_NULL,
+                pyre_object::PY_NULL,
+                name,
+            ),
+        );
+    }
+}
+
+pub(super) fn cdata_in_dll(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    if args.len() < 3 {
+        return Err(crate::PyError::type_error(
+            "in_dll() needs a library and name",
+        ));
+    }
+    let cls = args[0];
+    let size = ctype_size_of(cls).ok_or_else(|| crate::PyError::type_error("abstract class"))?;
+    let handle_obj = crate::baseobjspace::getattr_str(args[1], "_handle")?;
+    let handle = crate::baseobjspace::int_w(handle_obj)? as usize;
+    if !unsafe { pyre_object::is_str(args[2]) } {
+        return Err(crate::PyError::type_error("name must be a string"));
+    }
+    let name = unsafe { pyre_object::w_str_get_value(args[2]) };
+    if name == "Py_OptimizeFlag" {
+        let optimize = crate::importing::get_sys_module("sys")
+            .and_then(|sys| crate::baseobjspace::getattr_str(sys, "flags").ok())
+            .and_then(|flags| crate::baseobjspace::getattr_str(flags, "optimize").ok())
+            .unwrap_or_else(|| pyre_object::w_int_new(0));
+        return crate::call::type_call_instantiate(cls, &[optimize]);
+    }
+    if name.starts_with("_PyImport_Frozen") {
+        // Pyre has no frozen modules.  Export the ABI's terminating all-zero
+        // `_frozen` entry through a stable pointer variable.
+        let sentinel = Box::leak(Box::new([0usize; 3]));
+        let pointer = Box::leak(Box::new(sentinel.as_ptr() as usize));
+        return Ok(make_at_address(
+            cls,
+            pointer as *mut usize as usize,
+            size,
+            args[1],
+        ));
+    }
+    let address = host_ctypes::lookup_function_symbol_addr(handle, name.as_bytes())
+        .map_err(|_| crate::PyError::value_error(format!("symbol '{name}' not found")))?;
+    Ok(make_at_address(cls, address, size, args[1]))
+}
+
+fn cdata_objects_get(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    let d = crate::baseobjspace::getdict(args[1]);
+    Ok(if d.is_null() {
+        pyre_object::w_none()
+    } else {
+        unsafe { pyre_object::w_dict_getitem_str(d, OBJECTS_KEY) }
+            .unwrap_or_else(pyre_object::w_none)
+    })
+}
+
+fn cdata_base_get(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    let d = crate::baseobjspace::getdict(args[1]);
+    Ok(if d.is_null() {
+        pyre_object::w_none()
+    } else {
+        unsafe { pyre_object::w_dict_getitem_str(d, BBASE_KEY) }.unwrap_or_else(pyre_object::w_none)
+    })
+}
+
+fn cdata_needsfree_get(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    Ok(pyre_object::w_int_new(owns_buffer(args[1]) as i64))
+}
+
+pub(super) fn cdata_from_address(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    if args.len() < 2 {
+        return Err(crate::PyError::type_error("from_address() missing address"));
+    }
+    let cls = args[0];
+    let size = ctype_size_of(cls)
+        .filter(|&n| n != 0)
+        .ok_or_else(|| crate::PyError::type_error("abstract class"))?;
+    let address = crate::baseobjspace::int_w(args[1])? as usize;
+    Ok(make_at_address(cls, address, size, pyre_object::PY_NULL))
+}
+
+fn cdata_from_buffer_copy(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    if args.len() < 2 {
+        return Err(crate::PyError::type_error(
+            "from_buffer_copy() missing source",
+        ));
+    }
+    let cls = args[0];
+    let size = ctype_size_of(cls)
+        .filter(|&n| n != 0)
+        .ok_or_else(|| crate::PyError::type_error("abstract class"))?;
+    let offset = if let Some(&o) = args.get(2) {
+        crate::baseobjspace::int_w(o)?
+    } else {
+        0
+    };
+    if offset < 0 {
+        return Err(crate::PyError::value_error("offset cannot be negative"));
+    }
+    let source = crate::typedef::buffer_as_bytes_like(args[1])?
+        .ok_or_else(|| crate::PyError::type_error("a bytes-like object is required"))?;
+    let all = unsafe { pyre_object::bytesobject::bytes_like_data(source) };
+    let offset = offset as usize;
+    if offset > all.len() || size > all.len() - offset {
+        return Err(crate::PyError::value_error(format!(
+            "Buffer size too small ({} instead of at least {} bytes)",
+            all.len().saturating_sub(offset),
+            size
+        )));
+    }
+    let copied = all[offset..offset + size].to_vec();
+    new_cdata_obj_from_bytes(cls, size, &copied)
+}
+
+fn cdata_from_buffer(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    if args.len() < 2 {
+        return Err(crate::PyError::type_error("from_buffer() missing source"));
+    }
+    let cls = args[0];
+    let size = ctype_size_of(cls)
+        .filter(|&n| n != 0)
+        .ok_or_else(|| crate::PyError::type_error("abstract class"))?;
+    let offset = if let Some(&o) = args.get(2) {
+        crate::baseobjspace::int_w(o)?
+    } else {
+        0
+    };
+    if offset < 0 {
+        return Err(crate::PyError::value_error("offset cannot be negative"));
+    }
+
+    // Acquire and retain a real memoryview so the exporter's resize lock and
+    // lifetime follow the buffer protocol, as PyCData_FromBaseObj requires.
+    let view_obj = crate::builtins::w_memoryview_new(args[1])?;
+    let _roots = pyre_object::gc_roots::push_roots();
+    let sp = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(view_obj);
+    let view = unsafe { pyre_object::memoryview::w_memoryview_view(view_obj) };
+    if view.readonly() {
+        return Err(crate::PyError::type_error(
+            "underlying buffer is not writable",
+        ));
+    }
+    if view.ndim() != 1 || unsafe { view.stride0() } != view.itemsize() {
+        return Err(crate::PyError::type_error(
+            "underlying buffer is not C contiguous",
+        ));
+    }
+    let length = unsafe { view.length() }.max(0) as usize;
+    let offset = offset as usize;
+    if offset > length || size > length - offset {
+        return Err(crate::PyError::value_error(format!(
+            "Buffer size too small ({} instead of at least {} bytes)",
+            length.saturating_sub(offset),
+            size
+        )));
+    }
+    let view_offset = unsafe { view.offset() }.max(0) as usize;
+    let backing = unsafe { view.backing().as_bytes_mut() }
+        .ok_or_else(|| crate::PyError::type_error("underlying buffer is not writable"))?;
+    let start = view_offset.saturating_add(offset);
+    if start > backing.len() || size > backing.len() - start {
+        return Err(crate::PyError::value_error("Buffer size too small"));
+    }
+    let address = unsafe { backing.as_mut_ptr().add(start) } as usize;
+    let obj = make_at_address(cls, address, size, pyre_object::PY_NULL);
+    let rooted_view = pyre_object::gc_roots::shadow_stack_get(sp);
+    keep_ref(obj, "ffffffff", rooted_view);
+    Ok(obj)
 }
 
 /// The native `_SimpleCData` type object (cached, `hasdict=true`).
 pub(super) fn simplecdata_type() -> PyObjectRef {
     SIMPLECDATA_TYPE_OBJ.with(|c| {
         *c.get_or_init(|| {
-            let tp = crate::typedef::make_builtin_type("_SimpleCData", init_simplecdata_type);
+            let tp = crate::typedef::make_builtin_type_with_base(
+                "_SimpleCData",
+                init_simplecdata_type,
+                cdata_type(),
+            );
             unsafe { pyre_object::typeobject::w_type_set_hasdict(tp, true) };
             tp
         })
@@ -52,6 +273,11 @@ fn init_simplecdata_type(ns: PyObjectRef) {
         "__new__",
         crate::make_builtin_function("__new__", simplecdata_new),
     );
+    type_ns_store(
+        ns,
+        "__repr__",
+        crate::make_builtin_function("__repr__", simplecdata_repr),
+    );
     // `value` — data descriptor: getter decodes the buffer, setter encodes.
     let value_getter = crate::make_builtin_function_with_arity("value", value_getter, 2);
     let value_setter = crate::make_builtin_function_with_arity("value", value_setter, 3);
@@ -61,7 +287,11 @@ fn init_simplecdata_type(ns: PyObjectRef) {
         crate::typedef::make_getset_property_named(
             value_getter,
             value_setter,
-            pyre_object::PY_NULL,
+            crate::make_builtin_function_with_arity(
+                "value",
+                |_args| Err(crate::PyError::type_error("can't delete attribute")),
+                2,
+            ),
             "value",
         ),
     );
@@ -79,10 +309,59 @@ fn init_simplecdata_type(ns: PyObjectRef) {
     );
 }
 
+fn simplecdata_repr(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    let obj = args[0];
+    let cls = unsafe { pyre_object::w_instance_get_type(obj) };
+    let bases = unsafe { pyre_object::typeobject::w_type_get_bases(cls) };
+    let direct = !bases.is_null()
+        && unsafe { pyre_object::w_tuple_getitem(bases, 0) }
+            .is_some_and(|base| base == simplecdata_type());
+    if !direct {
+        let name = unsafe { pyre_object::typeobject::w_type_get_name(cls) };
+        return Ok(pyre_object::w_str_new(&format!(
+            "<{name} object at {obj:?}>"
+        )));
+    }
+    let tc = type_code_of(cls).ok_or_else(|| crate::PyError::type_error("abstract class"))?;
+    if tc == "O" && host_ctypes::read_pointer_from_buffer(cdata_bytes(obj).unwrap_or(&[])) == 0 {
+        let name = unsafe { pyre_object::typeobject::w_type_get_name(cls) };
+        return Ok(pyre_object::w_str_new(&format!("{name}(<NULL>)")));
+    }
+    let value = if tc == "O" {
+        host_ctypes::read_pointer_from_buffer(cdata_bytes(obj).unwrap_or(&[])) as PyObjectRef
+    } else {
+        decoded_to_pyobject(host_ctypes::decode_type_code(
+            &tc,
+            cdata_bytes(obj).unwrap_or(&[]),
+        ))
+    };
+    let rendered = unsafe { crate::display::py_repr(value) }?;
+    let name = unsafe { pyre_object::typeobject::w_type_get_name(cls) };
+    Ok(pyre_object::w_str_new(&format!("{name}({rendered})")))
+}
+
 /// `_SimpleCData.from_param(cls, value)` — identity stub (see caller note).
 fn simplecdata_from_param(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    // args[0] is the bound `cls`; the argument to convert is args[1].
-    Ok(args.get(1).copied().unwrap_or_else(pyre_object::w_none))
+    simple_from_param(args)
+}
+
+/// PyCSimpleType.from_param: convert to a same-typed temporary when needed,
+/// then return the same `CArgObject` carrier family as `byref()`.
+pub(super) fn simple_from_param(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    if args.len() < 2 {
+        return Err(crate::PyError::type_error("from_param() missing value"));
+    }
+    let cls = args[0];
+    let value = args[1];
+    let converted = if unsafe { crate::baseobjspace::isinstance_w(value, cls) } {
+        value
+    } else {
+        let tc = type_code_of(cls).ok_or_else(|| crate::PyError::type_error("abstract class"))?;
+        new_simplecdata_obj(cls, &tc, Some(value))?
+    };
+    let addr = cdata_addr(converted)
+        .ok_or_else(|| crate::PyError::type_error("ctypes instance has no buffer"))?;
+    Ok(super::interp_ctypes::make_carg(addr, converted))
 }
 
 /// `_SimpleCData.__new__(cls, value=None)`.
@@ -107,6 +386,31 @@ pub(super) fn new_simplecdata_obj(
     value: Option<PyObjectRef>,
 ) -> Result<PyObjectRef, crate::PyError> {
     let size = host_ctypes::simple_type_size(tc).ok_or_else(|| invalid_type_code_error())?;
+    let obj = new_cdata_obj_from_bytes(cls, size, &[])?;
+    let ba = cdata_buffer(obj).expect("new cdata object has a backing buffer");
+    // Encode after the instance exists so a `char*` keepalive can attach to it.
+    if let Some(v) = value {
+        let mut bytes = encode_value_into(tc, v, obj, "0")?;
+        if unsafe { crate::baseobjspace::lookup_in_type(cls, "_swappedbytes_") }.is_some() {
+            bytes.reverse();
+        }
+        let n = bytes.len().min(size);
+        unsafe {
+            pyre_object::w_bytearray_data_mut(ba)[..n].copy_from_slice(&bytes[..n]);
+        }
+        if matches!(tc, "z" | "Z" | "O") {
+            let d = crate::baseobjspace::getdict(obj);
+            unsafe { pyre_object::w_dict_setitem_str(d, OBJECTS_KEY, v) };
+        }
+    }
+    Ok(obj)
+}
+
+pub(super) fn new_cdata_obj_from_bytes(
+    cls: PyObjectRef,
+    size: usize,
+    bytes: &[u8],
+) -> Result<PyObjectRef, crate::PyError> {
     let ba = pyre_object::w_bytearray_new(size);
     let obj = pyre_object::w_instance_new(cls);
     let d = crate::baseobjspace::getdict(obj);
@@ -115,16 +419,27 @@ pub(super) fn new_simplecdata_obj(
             "ctypes instance has no instance dict",
         ));
     }
-    unsafe { pyre_object::w_dict_setitem_str(d, CDATA_BUFFER_KEY, ba) };
-    // Encode after the instance exists so a `char*` keepalive can attach to it.
-    if let Some(v) = value {
-        let bytes = encode_value_into(tc, v, obj, "0")?;
+    unsafe {
+        pyre_object::w_dict_setitem_str(d, CDATA_BUFFER_KEY, ba);
         let n = bytes.len().min(size);
-        unsafe {
-            pyre_object::w_bytearray_data_mut(ba)[..n].copy_from_slice(&bytes[..n]);
-        }
+        pyre_object::w_bytearray_data_mut(ba)[..n].copy_from_slice(&bytes[..n]);
     }
     Ok(obj)
+}
+
+pub(super) fn ctype_size_of(cls: PyObjectRef) -> Option<usize> {
+    super::stginfo::stginfo_of(cls)
+        .map(super::stginfo::stginfo_size)
+        .or_else(|| type_code_of(cls).and_then(|tc| host_ctypes::simple_type_size(&tc)))
+        .or_else(|| {
+            // `_CFuncPtr` itself is abstract, while every concrete type made
+            // by CFUNCTYPE/WINFUNCTYPE carries `_flags_`.  Use that ctypes
+            // invariant here; the generic issubclass path is not reliable for
+            // these metaclass-created raw types.
+            (!std::ptr::eq(cls, super::funcptr::cfuncptr_type())
+                && unsafe { crate::baseobjspace::lookup_in_type(cls, "_flags_") }.is_some())
+            .then(|| host_ctypes::pointer_size())
+        })
 }
 
 /// `_SimpleCData.value` getter — `(descr, instance)`.
@@ -132,8 +447,22 @@ fn value_getter(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     let obj = args[1];
     let cls = unsafe { pyre_object::w_instance_get_type(obj) };
     let tc = type_code_of(cls).ok_or_else(|| crate::PyError::type_error("abstract class"))?;
-    let bytes = cdata_bytes(obj)
+    let mut bytes = cdata_bytes(obj)
         .ok_or_else(|| crate::PyError::type_error("ctypes instance has no buffer"))?;
+    if tc == "O" {
+        let address = host_ctypes::read_pointer_from_buffer(bytes);
+        return Ok(if address == 0 {
+            pyre_object::w_none()
+        } else {
+            address as PyObjectRef
+        });
+    }
+    let swapped = unsafe { crate::baseobjspace::lookup_in_type(cls, "_swappedbytes_") }.is_some();
+    let owned;
+    if swapped {
+        owned = bytes.iter().rev().copied().collect::<Vec<_>>();
+        bytes = &owned;
+    }
     Ok(decoded_to_pyobject(host_ctypes::decode_type_code(
         &tc, bytes,
     )))
@@ -145,8 +474,15 @@ fn value_setter(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     let value = args[2];
     let cls = unsafe { pyre_object::w_instance_get_type(obj) };
     let tc = type_code_of(cls).ok_or_else(|| crate::PyError::type_error("abstract class"))?;
-    let bytes = encode_value_into(&tc, value, obj, "0")?;
+    let mut bytes = encode_value_into(&tc, value, obj, "0")?;
+    if unsafe { crate::baseobjspace::lookup_in_type(cls, "_swappedbytes_") }.is_some() {
+        bytes.reverse();
+    }
     cdata_write(obj, 0, &bytes);
+    if matches!(tc.as_str(), "z" | "Z" | "O") {
+        let d = crate::baseobjspace::getdict(obj);
+        unsafe { pyre_object::w_dict_setitem_str(d, OBJECTS_KEY, value) };
+    }
     Ok(pyre_object::w_none())
 }
 
@@ -201,7 +537,7 @@ pub(super) fn cdata_addr(obj: PyObjectRef) -> Option<usize> {
 }
 
 /// `b_ptr[..b_size]` — the view bytes.
-pub(super) fn cdata_bytes(obj: PyObjectRef) -> Option<&'static [u8]> {
+pub(crate) fn cdata_bytes(obj: PyObjectRef) -> Option<&'static [u8]> {
     if let Some(ba) = cdata_buffer(obj) {
         let data = unsafe { pyre_object::w_bytearray_data(ba) };
         let off = boff(obj).min(data.len());
@@ -225,6 +561,202 @@ pub(super) fn cdata_len(obj: PyObjectRef) -> Option<usize> {
     } else {
         None
     }
+}
+
+/// Buffer-protocol metadata for a bytearray-backed CData view.  The returned
+/// bytearray is the root storage and `offset`/`length` select this object's
+/// live window, matching PyPy's `SubBuffer` representation.
+pub(crate) fn cdata_buffer_view(
+    obj: PyObjectRef,
+) -> Option<(PyObjectRef, usize, usize, String, usize, Vec<usize>)> {
+    if !is_cdata_instance(obj) {
+        return None;
+    }
+    let ba = cdata_buffer(obj)?;
+    let cls = unsafe { pyre_object::w_instance_get_type(obj) };
+    let info = super::stginfo::stginfo_of(cls);
+    let kind = info
+        .map(super::stginfo::stginfo_paramfunc)
+        .unwrap_or_default();
+    let shape = ctype_shape(cls);
+    let leaf = ctype_leaf(cls);
+    let is_funcptr =
+        unsafe { crate::baseobjspace::isinstance_w(obj, super::funcptr::cfuncptr_type()) };
+    let itemsize = if is_funcptr {
+        host_ctypes::pointer_size()
+    } else {
+        super::stginfo::field_size_of(leaf).unwrap_or(0)
+    };
+    let format = if is_funcptr {
+        "X{}".to_string()
+    } else if kind == "union" {
+        "B".to_string()
+    } else {
+        ctype_pep3118_format(cls, None)
+    };
+    Some((ba, boff(obj), cdata_len(obj)?, format, itemsize, shape))
+}
+
+fn ctype_shape(mut cls: PyObjectRef) -> Vec<usize> {
+    let mut shape = Vec::new();
+    while let Some(info) = super::stginfo::stginfo_of(cls) {
+        if super::stginfo::stginfo_paramfunc(info) != "array" {
+            break;
+        }
+        shape.push(super::stginfo::stginfo_length(info));
+        let Some(proto) = super::stginfo::stginfo_proto(info) else {
+            break;
+        };
+        cls = proto;
+    }
+    shape
+}
+
+fn ctype_leaf(mut cls: PyObjectRef) -> PyObjectRef {
+    while let Some(info) = super::stginfo::stginfo_of(cls) {
+        if super::stginfo::stginfo_paramfunc(info) != "array" {
+            break;
+        }
+        let Some(proto) = super::stginfo::stginfo_proto(info) else {
+            break;
+        };
+        cls = proto;
+    }
+    cls
+}
+
+pub(super) fn ctype_pep3118_format(cls: PyObjectRef, forced_big: Option<bool>) -> String {
+    let info = super::stginfo::stginfo_of(cls);
+    let kind = info
+        .map(super::stginfo::stginfo_paramfunc)
+        .unwrap_or_default();
+    match kind.as_str() {
+        "array" => info
+            .and_then(super::stginfo::stginfo_proto)
+            .map(|proto| ctype_pep3118_format(proto, forced_big))
+            .unwrap_or_else(|| "B".to_string()),
+        "pointer" => {
+            if let Some(snapshot) = info.and_then(super::stginfo::stginfo_format) {
+                return snapshot;
+            }
+            let inner = info
+                .and_then(super::stginfo::stginfo_proto)
+                .map(|proto| {
+                    let shape = ctype_shape(proto);
+                    let prefix = if shape.is_empty() {
+                        String::new()
+                    } else {
+                        format!(
+                            "({})",
+                            shape
+                                .iter()
+                                .map(usize::to_string)
+                                .collect::<Vec<_>>()
+                                .join(",")
+                        )
+                    };
+                    format!("{prefix}{}", ctype_pep3118_format(proto, forced_big))
+                })
+                .unwrap_or_else(|| "B".to_string());
+            format!("&{inner}")
+        }
+        "struct" => struct_pep3118_format(cls),
+        "union" => "B".to_string(),
+        _ => {
+            let Some(code) = type_code_of(cls).and_then(|s| s.chars().next()) else {
+                return "B".to_string();
+            };
+            let big = forced_big.unwrap_or_else(|| {
+                unsafe { crate::baseobjspace::lookup_in_type(cls, "_swappedbytes_") }.is_some()
+                    ^ cfg!(target_endian = "big")
+            });
+            format!(
+                "{}{}",
+                if big { '>' } else { '<' },
+                host_ctypes::simple_type_pep3118_code(code),
+            )
+        }
+    }
+}
+
+fn struct_pep3118_format(cls: PyObjectRef) -> String {
+    let big = super::stginfo::stginfo_of(cls).is_some_and(super::stginfo::stginfo_big_endian);
+    let Some(fields) = (unsafe { crate::baseobjspace::lookup_in_type(cls, "_fields_") }) else {
+        return "B".to_string();
+    };
+    let items = if unsafe { pyre_object::is_tuple(fields) } {
+        (0..unsafe { pyre_object::w_tuple_len(fields) } as i64)
+            .filter_map(|i| unsafe { pyre_object::w_tuple_getitem(fields, i) })
+            .collect::<Vec<_>>()
+    } else if unsafe { pyre_object::is_list(fields) } {
+        (0..unsafe { pyre_object::w_list_len(fields) } as i64)
+            .filter_map(|i| unsafe { pyre_object::w_list_getitem(fields, i) })
+            .collect::<Vec<_>>()
+    } else {
+        return "B".to_string();
+    };
+    let mut format = String::from("T{");
+    let mut last_end = 0usize;
+    for field in items {
+        let Some(name_obj) = (unsafe { pyre_object::w_tuple_getitem(field, 0) }) else {
+            continue;
+        };
+        let Some(field_type) = (unsafe { pyre_object::w_tuple_getitem(field, 1) }) else {
+            continue;
+        };
+        if !unsafe { pyre_object::is_str(name_obj) } {
+            continue;
+        }
+        let name = unsafe { pyre_object::w_str_get_value(name_obj) };
+        let Some(descr) = (unsafe { crate::baseobjspace::lookup_in_type(cls, name) }) else {
+            continue;
+        };
+        let dd = crate::baseobjspace::getdict(descr);
+        let integer = |key: &str| {
+            unsafe { pyre_object::w_dict_getitem_str(dd, key) }
+                .filter(|value| unsafe { pyre_object::is_int(*value) })
+                .map(|value| unsafe { pyre_object::w_int_get_value(value) }.max(0) as usize)
+                .unwrap_or(0)
+        };
+        let offset = integer("byte_offset");
+        let size = integer("byte_size");
+        let padding = offset.saturating_sub(last_end);
+        if padding > 0 {
+            if padding != 1 {
+                format.push_str(&padding.to_string());
+            }
+            format.push('x');
+        }
+        let shape = ctype_shape(field_type);
+        if !shape.is_empty() {
+            format.push('(');
+            format.push_str(
+                &shape
+                    .iter()
+                    .map(usize::to_string)
+                    .collect::<Vec<_>>()
+                    .join(","),
+            );
+            format.push(')');
+        }
+        format.push_str(&ctype_pep3118_format(field_type, Some(big)));
+        format.push(':');
+        format.push_str(name);
+        format.push(':');
+        last_end = last_end.max(offset.saturating_add(size));
+    }
+    let total = super::stginfo::stginfo_of(cls)
+        .map(super::stginfo::stginfo_size)
+        .unwrap_or(0);
+    let padding = total.saturating_sub(last_end);
+    if padding > 0 {
+        if padding != 1 {
+            format.push_str(&padding.to_string());
+        }
+        format.push('x');
+    }
+    format.push('}');
+    format
 }
 
 /// Overwrite `bytes` at view-relative offset `off`.
@@ -324,6 +856,23 @@ pub(super) fn make_subview(
     inst
 }
 
+pub(super) fn make_indexed_subview(
+    proto: PyObjectRef,
+    parent: PyObjectRef,
+    field_offset: usize,
+    size: usize,
+    index: usize,
+) -> PyObjectRef {
+    let view = make_subview(proto, parent, field_offset, size);
+    let d = crate::baseobjspace::getdict(view);
+    if !d.is_null() {
+        unsafe {
+            pyre_object::w_dict_setitem_str(d, BINDEX_KEY, pyre_object::w_int_new(index as i64));
+        }
+    }
+    view
+}
+
 /// An `address`-backed instance of `proto` viewing `size` bytes of external
 /// memory (`PyCData::at_address`) — the pyre form of a pointer dereference.
 /// `base` (the pointer object the address came from) is retained under
@@ -351,28 +900,206 @@ pub(super) fn make_at_address(
 /// Keep `obj` alive for the lifetime of the buffer that `anchor` views, by
 /// storing it under `key` in the ultimate root's `"_objects_"` dict.
 pub(super) fn keep_ref(anchor: PyObjectRef, key: &str, obj: PyObjectRef) {
+    let _roots = pyre_object::gc_roots::push_roots();
+    pyre_object::gc_roots::pin_root(obj);
+    let obj_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     // Walk `_b_base_` up to the owning root.
     let mut root = anchor;
+    pyre_object::gc_roots::pin_root(root);
+    let mut root_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+    let mut composite_key = key.to_string();
     loop {
+        root = pyre_object::gc_roots::shadow_stack_get(root_slot);
+        let d = crate::baseobjspace::getdict(root);
+        if d.is_null() {
+            return;
+        }
+        if let Some(index) = unsafe { pyre_object::w_dict_getitem_str(d, BINDEX_KEY) } {
+            if unsafe { pyre_object::is_int(index) } {
+                composite_key.push(':');
+                composite_key.push_str(&unsafe { pyre_object::w_int_get_value(index) }.to_string());
+            }
+        }
+        match unsafe { pyre_object::w_dict_getitem_str(d, BBASE_KEY) } {
+            Some(base) if !base.is_null() && !unsafe { pyre_object::is_none(base) } => {
+                root = base;
+                pyre_object::gc_roots::pin_root(root);
+                root_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+            }
+            _ => break,
+        }
+    }
+    root = pyre_object::gc_roots::shadow_stack_get(root_slot);
+    let mut d = crate::baseobjspace::getdict(root);
+    let objs = match unsafe { pyre_object::w_dict_getitem_str(d, OBJECTS_KEY) } {
+        Some(o) if !o.is_null() && unsafe { pyre_object::is_dict(o) } => o,
+        Some(previous) if !previous.is_null() && !unsafe { pyre_object::is_none(previous) } => {
+            if unsafe { pyre_object::is_bytes(previous) } {
+                unsafe { pyre_object::bytesobject::w_bytes_dec_ctypes_keepalive_refs(previous) };
+            }
+            let nd = pyre_object::w_dict_new();
+            root = pyre_object::gc_roots::shadow_stack_get(root_slot);
+            d = crate::baseobjspace::getdict(root);
+            unsafe { pyre_object::w_dict_setitem_str(d, OBJECTS_KEY, nd) };
+            nd
+        }
+        _ => {
+            let nd = pyre_object::w_dict_new();
+            root = pyre_object::gc_roots::shadow_stack_get(root_slot);
+            d = crate::baseobjspace::getdict(root);
+            unsafe { pyre_object::w_dict_setitem_str(d, OBJECTS_KEY, nd) };
+            nd
+        }
+    };
+    pyre_object::gc_roots::pin_root(objs);
+    let objs_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+    let objs = pyre_object::gc_roots::shadow_stack_get(objs_slot);
+    let obj = pyre_object::gc_roots::shadow_stack_get(obj_slot);
+    unsafe {
+        if let Some(previous) = pyre_object::w_dict_getitem_str(objs, &composite_key) {
+            if pyre_object::is_bytes(previous) {
+                pyre_object::bytesobject::w_bytes_dec_ctypes_keepalive_refs(previous);
+            }
+        }
+        if pyre_object::is_bytes(obj) {
+            pyre_object::bytesobject::w_bytes_inc_ctypes_keepalive_refs(obj);
+        }
+        pyre_object::w_dict_setitem_str(objs, &composite_key, obj)
+    };
+}
+
+/// `ensure_objects(value)`: composite assignments retain the child's
+/// keepalive dictionary, creating the empty dictionary that represents a
+/// CData value with no inner references yet.
+pub(super) fn objects_for_keep(value: PyObjectRef) -> PyObjectRef {
+    let _roots = pyre_object::gc_roots::push_roots();
+    pyre_object::gc_roots::pin_root(value);
+    let value_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+    let mut d = crate::baseobjspace::getdict(value);
+    if d.is_null() {
+        return value;
+    }
+    match unsafe { pyre_object::w_dict_getitem_str(d, OBJECTS_KEY) } {
+        Some(objects) if !objects.is_null() && !unsafe { pyre_object::is_none(objects) } => objects,
+        _ => {
+            let objects = pyre_object::w_dict_new();
+            let value = pyre_object::gc_roots::shadow_stack_get(value_slot);
+            d = crate::baseobjspace::getdict(value);
+            unsafe { pyre_object::w_dict_setitem_str(d, OBJECTS_KEY, objects) };
+            objects
+        }
+    }
+}
+
+/// Keep an implementation-owned holder alive without exposing it through
+/// `_objects`.  CPython can point `c_char_p` at the trailing-NUL storage of a
+/// bytes object; pyre's bytes storage needs an explicit terminated copy.  The
+/// holder belongs to the same root object as `keep_ref`, but is kept in the
+/// root instance dict rather than in the user-visible keepalive dictionary.
+fn keep_alive(anchor: PyObjectRef, key: &str, obj: PyObjectRef) {
+    let _roots = pyre_object::gc_roots::push_roots();
+    pyre_object::gc_roots::pin_root(obj);
+    let obj_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+    let mut root = anchor;
+    pyre_object::gc_roots::pin_root(root);
+    let mut root_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+    loop {
+        root = pyre_object::gc_roots::shadow_stack_get(root_slot);
         let d = crate::baseobjspace::getdict(root);
         if d.is_null() {
             return;
         }
         match unsafe { pyre_object::w_dict_getitem_str(d, BBASE_KEY) } {
-            Some(base) if !base.is_null() && !unsafe { pyre_object::is_none(base) } => root = base,
+            Some(base) if !base.is_null() && !unsafe { pyre_object::is_none(base) } => {
+                root = base;
+                pyre_object::gc_roots::pin_root(root);
+                root_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+            }
             _ => break,
         }
     }
+    root = pyre_object::gc_roots::shadow_stack_get(root_slot);
+    let obj = pyre_object::gc_roots::shadow_stack_get(obj_slot);
     let d = crate::baseobjspace::getdict(root);
-    let objs = match unsafe { pyre_object::w_dict_getitem_str(d, OBJECTS_KEY) } {
-        Some(o) if !o.is_null() => o,
+    if !d.is_null() {
+        unsafe { pyre_object::w_dict_setitem_str(d, &format!("_keep_{key}"), obj) };
+    }
+}
+
+/// Make `result` share the source root's `_objects` dictionary, matching
+/// `_ctypes.cast`'s PyCData keepalive ownership.  The source itself is added
+/// under its identity key before the dictionary is attached to the result.
+pub(super) fn share_objects_for_cast(result: PyObjectRef, source: PyObjectRef) {
+    // RPython locals are GC roots.  These Rust locals are not, so mirror that
+    // lifetime explicitly across `w_dict_new` and `w_dict_setitem` (the latter
+    // allocates the integer identity key and can trigger a nursery collection).
+    let _roots = pyre_object::gc_roots::push_roots();
+    pyre_object::gc_roots::pin_root(result);
+    let result_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+    pyre_object::gc_roots::pin_root(source);
+    let source_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+    let mut root = source;
+    pyre_object::gc_roots::pin_root(root);
+    let mut root_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+    loop {
+        root = pyre_object::gc_roots::shadow_stack_get(root_slot);
+        let d = crate::baseobjspace::getdict(root);
+        if d.is_null() {
+            return;
+        }
+        match unsafe { pyre_object::w_dict_getitem_str(d, BBASE_KEY) } {
+            Some(base) if !base.is_null() && !unsafe { pyre_object::is_none(base) } => {
+                root = base;
+                pyre_object::gc_roots::pin_root(root);
+                root_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+            }
+            _ => break,
+        }
+    }
+    root = pyre_object::gc_roots::shadow_stack_get(root_slot);
+    let mut source_dict = crate::baseobjspace::getdict(root);
+    if source_dict.is_null() {
+        return;
+    }
+    let existing = unsafe { pyre_object::w_dict_getitem_str(source_dict, OBJECTS_KEY) };
+    if let Some(objects) = existing.filter(|&objects| {
+        !objects.is_null()
+            && !unsafe { pyre_object::is_none(objects) }
+            && !unsafe { pyre_object::is_dict(objects) }
+    }) {
+        let result = pyre_object::gc_roots::shadow_stack_get(result_slot);
+        let result_dict = crate::baseobjspace::getdict(result);
+        if !result_dict.is_null() {
+            unsafe { pyre_object::w_dict_setitem_str(result_dict, OBJECTS_KEY, objects) };
+        }
+        return;
+    }
+    let objects = match existing {
+        Some(objects) if !objects.is_null() && unsafe { pyre_object::is_dict(objects) } => objects,
         _ => {
-            let nd = pyre_object::w_dict_new();
-            unsafe { pyre_object::w_dict_setitem_str(d, OBJECTS_KEY, nd) };
-            nd
+            let objects = pyre_object::w_dict_new();
+            root = pyre_object::gc_roots::shadow_stack_get(root_slot);
+            source_dict = crate::baseobjspace::getdict(root);
+            unsafe { pyre_object::w_dict_setitem_str(source_dict, OBJECTS_KEY, objects) };
+            objects
         }
     };
-    unsafe { pyre_object::w_dict_setitem_str(objs, key, obj) };
+    pyre_object::gc_roots::pin_root(objects);
+    let objects_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+    let source = pyre_object::gc_roots::shadow_stack_get(source_slot);
+    let identity_key = pyre_object::w_int_new(source as usize as i64);
+    pyre_object::gc_roots::pin_root(identity_key);
+    let key_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+    let source = pyre_object::gc_roots::shadow_stack_get(source_slot);
+    let objects = pyre_object::gc_roots::shadow_stack_get(objects_slot);
+    let identity_key = pyre_object::gc_roots::shadow_stack_get(key_slot);
+    unsafe { pyre_object::w_dict_store(objects, identity_key, source) };
+    let result = pyre_object::gc_roots::shadow_stack_get(result_slot);
+    let objects = pyre_object::gc_roots::shadow_stack_get(objects_slot);
+    let result_dict = crate::baseobjspace::getdict(result);
+    if !result_dict.is_null() {
+        unsafe { pyre_object::w_dict_setitem_str(result_dict, OBJECTS_KEY, objects) };
+    }
 }
 
 // ── type-code metadata (StgInfo equivalent, derived from `_type_`) ─────
@@ -413,10 +1140,10 @@ pub(super) fn invalid_type_code_error() -> crate::PyError {
     // AttributeError, so `ctypes.__init__`'s complex-type probe
     // (`try: class c_double_complex(_SimpleCData): _type_="D"; ...
     // except AttributeError`) is skipped when the code is unsupported.
-    crate::PyError::attribute_error(
-        "class must define a '_type_' attribute which must be \
-         a single character string containing one of the valid ctypes type codes",
-    )
+    crate::PyError::attribute_error(format!(
+        "class must define a '_type_' attribute which must be a single character string containing one of '{}'",
+        rustpython_host_env::ctypes::simple_type_chars(),
+    ))
 }
 
 // ── scalar value ⇄ bytes ──────────────────────────────────────────────
@@ -453,20 +1180,41 @@ pub(super) fn encode_value(tc: &str, obj: PyObjectRef) -> Result<Vec<u8>, crate:
                 ));
             }
         }
-        "b" | "h" | "i" | "l" | "q" => V::Signed(crate::baseobjspace::int_w(obj)? as i128),
+        "b" | "h" | "i" | "l" | "q" => {
+            let indexed = crate::baseobjspace::space_index(obj)?;
+            V::Signed(crate::baseobjspace::int_w(indexed)? as i128)
+        }
         // Unsigned fields carry the full unsigned range; fall back to `uint_w`
         // when the value exceeds `i64` so `c_ulonglong(2**63)` round-trips.  The
         // encoder masks the `i128` to the field width, so the signed range still
         // wraps as ctypes expects.
         "B" | "H" | "I" | "L" | "Q" => {
-            let v = crate::baseobjspace::int_w(obj)
+            let indexed = crate::baseobjspace::space_index(obj)?;
+            let v = crate::baseobjspace::int_w(indexed)
                 .map(|i| i as i128)
-                .or_else(|_| crate::baseobjspace::uint_w(obj).map(|u| u as i128))?;
+                .or_else(|_| crate::baseobjspace::uint_w(indexed).map(|u| u as i128))?;
             V::Signed(v)
         }
         "f" | "d" | "g" => V::Float(crate::baseobjspace::float_w(obj)?),
-        "?" => V::Bool(crate::baseobjspace::is_true(obj)?),
-        "u" => V::Wchar(crate::baseobjspace::int_w(obj)? as u32),
+        "?" | "v" => V::Bool(crate::baseobjspace::is_true(obj)?),
+        "u" => {
+            if !unsafe { pyre_object::is_str(obj) } {
+                return Err(crate::PyError::type_error(
+                    "a unicode character expected, not instance",
+                ));
+            }
+            let value = unsafe { pyre_object::w_str_get_wtf8(obj) };
+            let mut chars = value.code_points();
+            let ch = chars.next().ok_or_else(|| {
+                crate::PyError::type_error("a unicode character expected, not a string of length 0")
+            })?;
+            if chars.next().is_some() {
+                return Err(crate::PyError::type_error(
+                    "a unicode character expected, not a string of length greater than 1",
+                ));
+            }
+            V::Wchar(ch.to_u32())
+        }
         "P" | "z" | "Z" => {
             if unsafe { pyre_object::is_none(obj) } {
                 V::Pointer(0)
@@ -476,7 +1224,7 @@ pub(super) fn encode_value(tc: &str, obj: PyObjectRef) -> Result<Vec<u8>, crate:
                 return Err(crate::PyError::type_error("cannot be converted to pointer"));
             }
         }
-        "O" => V::ObjectId(crate::baseobjspace::int_w(obj)? as usize),
+        "O" => V::ObjectId(obj as usize),
         _ => V::Signed(crate::baseobjspace::int_w(obj)? as i128),
     };
     Ok(host_ctypes::simple_storage_value_to_bytes_endian(
@@ -496,13 +1244,27 @@ pub(super) fn encode_value_into(
 ) -> Result<Vec<u8>, crate::PyError> {
     if tc == "z" && unsafe { pyre_object::is_bytes(value) } {
         let raw = unsafe { pyre_object::bytesobject::w_bytes_data(value) };
-        let copy = pyre_object::bytesobject::w_bytes_from_bytes(&host_ctypes::null_terminated_bytes(
-            raw,
-        ));
+        let copy =
+            pyre_object::bytesobject::w_bytes_from_bytes(&host_ctypes::null_terminated_bytes(raw));
         // Retain the copy before reading its address, so a GC triggered while
         // inserting the keepalive cannot leave the stored pointer stale.
-        keep_ref(dest, key, copy);
+        keep_ref(dest, key, value);
+        keep_alive(dest, key, copy);
         let addr = unsafe { pyre_object::bytesobject::w_bytes_data(copy).as_ptr() } as usize;
+        return Ok(host_ctypes::simple_storage_value_to_bytes_endian(
+            tc,
+            host_ctypes::SimpleStorageValue::Pointer(addr),
+            false,
+        ));
+    }
+    if tc == "Z" && unsafe { pyre_object::is_str(value) } {
+        let raw = unsafe { pyre_object::w_str_get_wtf8(value) };
+        let copy =
+            pyre_object::w_bytearray_from_bytes(&host_ctypes::wchar_null_terminated_bytes(raw));
+        keep_ref(dest, key, value);
+        keep_alive(dest, key, copy);
+        let addr =
+            unsafe { pyre_object::bytearrayobject::w_bytearray_data(copy).as_ptr() } as usize;
         return Ok(host_ctypes::simple_storage_value_to_bytes_endian(
             tc,
             host_ctypes::SimpleStorageValue::Pointer(addr),

--- a/pyre/pyre-interpreter/src/module/_ctypes/cdata.rs
+++ b/pyre/pyre-interpreter/src/module/_ctypes/cdata.rs
@@ -14,7 +14,7 @@
 use super::type_ns_store;
 use pyre_object::PyObjectRef;
 use rustpython_host_env::ctypes as host_ctypes;
-use std::cell::RefCell;
+use std::sync::OnceLock;
 
 /// Reserved instance-dict key holding the backing `bytearray` (root storage,
 /// or — for a sub-view — a shared reference to the **root's** bytearray).
@@ -32,24 +32,18 @@ const BADDR_KEY: &str = "_baddr_";
 /// Lazily-created keepalive dict on a root object.
 const OBJECTS_KEY: &str = "_objects_";
 
-thread_local! {
-    static CDATA_TYPE_OBJ: std::cell::OnceCell<PyObjectRef> =
-        const { std::cell::OnceCell::new() };
-    static SIMPLECDATA_TYPE_OBJ: std::cell::OnceCell<PyObjectRef> =
-        const { std::cell::OnceCell::new() };
-}
+static CDATA_TYPE_OBJ: OnceLock<usize> = OnceLock::new();
+static SIMPLECDATA_TYPE_OBJ: OnceLock<usize> = OnceLock::new();
 
 /// PyPy/CPython/RustPython's private `_CData` base shared by every ctypes
 /// value family.  It is discovered as `Structure.__base__` rather than
 /// exported from the module namespace.
 pub(super) fn cdata_type() -> PyObjectRef {
-    CDATA_TYPE_OBJ.with(|c| {
-        *c.get_or_init(|| {
-            let tp = crate::typedef::make_builtin_type("_CData", init_cdata_type);
-            unsafe { pyre_object::typeobject::w_type_set_hasdict(tp, true) };
-            tp
-        })
-    })
+    *CDATA_TYPE_OBJ.get_or_init(|| {
+        let tp = crate::typedef::make_builtin_type("_CData", init_cdata_type);
+        unsafe { pyre_object::typeobject::w_type_set_hasdict(tp, true) };
+        tp as usize
+    }) as PyObjectRef
 }
 
 fn init_cdata_type(ns: PyObjectRef) {
@@ -254,17 +248,15 @@ fn cdata_from_buffer(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError
 
 /// The native `_SimpleCData` type object (cached, `hasdict=true`).
 pub(super) fn simplecdata_type() -> PyObjectRef {
-    SIMPLECDATA_TYPE_OBJ.with(|c| {
-        *c.get_or_init(|| {
-            let tp = crate::typedef::make_builtin_type_with_base(
-                "_SimpleCData",
-                init_simplecdata_type,
-                cdata_type(),
-            );
-            unsafe { pyre_object::typeobject::w_type_set_hasdict(tp, true) };
-            tp
-        })
-    })
+    *SIMPLECDATA_TYPE_OBJ.get_or_init(|| {
+        let tp = crate::typedef::make_builtin_type_with_base(
+            "_SimpleCData",
+            init_simplecdata_type,
+            cdata_type(),
+        );
+        unsafe { pyre_object::typeobject::w_type_set_hasdict(tp, true) };
+        tp as usize
+    }) as PyObjectRef
 }
 
 fn init_simplecdata_type(ns: PyObjectRef) {
@@ -784,22 +776,6 @@ pub(super) fn cdata_write(obj: PyObjectRef, off: usize, bytes: &[u8]) {
 
 // ── sub-views, keepalive, and the cdata-instance predicate ─────────────
 
-thread_local! {
-    /// The ctypes base types whose instances are CData (registered at module
-    /// init): `_SimpleCData`, `Structure`, `Union`, `Array`, `_Pointer`.
-    static CDATA_BASES: RefCell<Vec<PyObjectRef>> = const { RefCell::new(Vec::new()) };
-}
-
-/// Register `tp` as a CData base type (widens [`is_cdata_instance`]).
-pub(super) fn register_cdata_base(tp: PyObjectRef) {
-    CDATA_BASES.with(|b| {
-        let mut v = b.borrow_mut();
-        if !v.iter().any(|&t| t == tp) {
-            v.push(tp);
-        }
-    });
-}
-
 /// Whether `obj` owns its buffer (a root object, not a sub-view or external
 /// view) — the precondition for `resize`.
 pub(super) fn owns_buffer(obj: PyObjectRef) -> bool {
@@ -811,14 +787,10 @@ pub(super) fn owns_buffer(obj: PyObjectRef) -> bool {
     has(CDATA_BUFFER_KEY) && !has(BBASE_KEY) && !has(BADDR_KEY)
 }
 
-/// Whether `obj` is an instance of any registered CData base type.
+/// Whether `obj` is an instance of the common `_CData` base, matching PyPy's
+/// CData inheritance test without a parallel per-thread type registry.
 pub(super) fn is_cdata_instance(obj: PyObjectRef) -> bool {
-    !obj.is_null()
-        && CDATA_BASES.with(|b| {
-            b.borrow()
-                .iter()
-                .any(|&base| unsafe { crate::baseobjspace::isinstance_w(obj, base) })
-        })
+    !obj.is_null() && unsafe { crate::baseobjspace::isinstance_w(obj, cdata_type()) }
 }
 
 /// A field/element sub-view of `parent` at `field_offset`, aliasing its memory

--- a/pyre/pyre-interpreter/src/module/_ctypes/cdata.rs
+++ b/pyre/pyre-interpreter/src/module/_ctypes/cdata.rs
@@ -108,13 +108,6 @@ pub(super) fn new_simplecdata_obj(
 ) -> Result<PyObjectRef, crate::PyError> {
     let size = host_ctypes::simple_type_size(tc).ok_or_else(|| invalid_type_code_error())?;
     let ba = pyre_object::w_bytearray_new(size);
-    if let Some(v) = value {
-        let bytes = encode_value(tc, v)?;
-        let n = bytes.len().min(size);
-        unsafe {
-            pyre_object::w_bytearray_data_mut(ba)[..n].copy_from_slice(&bytes[..n]);
-        }
-    }
     let obj = pyre_object::w_instance_new(cls);
     let d = crate::baseobjspace::getdict(obj);
     if d.is_null() {
@@ -123,6 +116,14 @@ pub(super) fn new_simplecdata_obj(
         ));
     }
     unsafe { pyre_object::w_dict_setitem_str(d, CDATA_BUFFER_KEY, ba) };
+    // Encode after the instance exists so a `char*` keepalive can attach to it.
+    if let Some(v) = value {
+        let bytes = encode_value_into(tc, v, obj, "0")?;
+        let n = bytes.len().min(size);
+        unsafe {
+            pyre_object::w_bytearray_data_mut(ba)[..n].copy_from_slice(&bytes[..n]);
+        }
+    }
     Ok(obj)
 }
 
@@ -144,7 +145,7 @@ fn value_setter(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     let value = args[2];
     let cls = unsafe { pyre_object::w_instance_get_type(obj) };
     let tc = type_code_of(cls).ok_or_else(|| crate::PyError::type_error("abstract class"))?;
-    let bytes = encode_value(&tc, value)?;
+    let bytes = encode_value_into(&tc, value, obj, "0")?;
     cdata_write(obj, 0, &bytes);
     Ok(pyre_object::w_none())
 }
@@ -325,14 +326,23 @@ pub(super) fn make_subview(
 
 /// An `address`-backed instance of `proto` viewing `size` bytes of external
 /// memory (`PyCData::at_address`) — the pyre form of a pointer dereference.
-/// The memory is owned elsewhere; the caller keeps it alive.
-pub(super) fn make_at_address(proto: PyObjectRef, address: usize, size: usize) -> PyObjectRef {
+/// `base` (the pointer object the address came from) is retained under
+/// `_b_base_` so its `_objects_` keepalive chain outlives the returned view.
+pub(super) fn make_at_address(
+    proto: PyObjectRef,
+    address: usize,
+    size: usize,
+    base: PyObjectRef,
+) -> PyObjectRef {
     let inst = pyre_object::w_instance_new(proto);
     let d = crate::baseobjspace::getdict(inst);
     if !d.is_null() {
         unsafe {
             pyre_object::w_dict_setitem_str(d, BADDR_KEY, pyre_object::w_int_new(address as i64));
             pyre_object::w_dict_setitem_str(d, BSZ_KEY, pyre_object::w_int_new(size as i64));
+            if !base.is_null() && !pyre_object::is_none(base) {
+                pyre_object::w_dict_setitem_str(d, BBASE_KEY, base);
+            }
         }
     }
     inst
@@ -413,11 +423,17 @@ pub(super) fn invalid_type_code_error() -> crate::PyError {
 
 /// Encode a Python scalar into the native-endian buffer bytes for `tc`.
 ///
-/// A same-typed `_SimpleCData` instance is accepted and copied byte-for-byte.
+/// A `_SimpleCData` instance of the *same* type code is copied byte-for-byte; a
+/// differently-typed one falls through to normal conversion (which rejects it
+/// unless it is int/float-like), so a larger scalar cannot overwrite a smaller
+/// field with its raw buffer.
 pub(super) fn encode_value(tc: &str, obj: PyObjectRef) -> Result<Vec<u8>, crate::PyError> {
     use host_ctypes::SimpleStorageValue as V;
     if is_simplecdata_instance(obj) {
-        return Ok(cdata_bytes(obj).unwrap_or(&[]).to_vec());
+        let src_cls = unsafe { pyre_object::w_instance_get_type(obj) };
+        if type_code_of(src_cls).as_deref() == Some(tc) {
+            return Ok(cdata_bytes(obj).unwrap_or(&[]).to_vec());
+        }
     }
     let val = match tc {
         "c" => {
@@ -437,8 +453,16 @@ pub(super) fn encode_value(tc: &str, obj: PyObjectRef) -> Result<Vec<u8>, crate:
                 ));
             }
         }
-        "b" | "B" | "h" | "H" | "i" | "I" | "l" | "L" | "q" | "Q" => {
-            V::Signed(crate::baseobjspace::int_w(obj)? as i128)
+        "b" | "h" | "i" | "l" | "q" => V::Signed(crate::baseobjspace::int_w(obj)? as i128),
+        // Unsigned fields carry the full unsigned range; fall back to `uint_w`
+        // when the value exceeds `i64` so `c_ulonglong(2**63)` round-trips.  The
+        // encoder masks the `i128` to the field width, so the signed range still
+        // wraps as ctypes expects.
+        "B" | "H" | "I" | "L" | "Q" => {
+            let v = crate::baseobjspace::int_w(obj)
+                .map(|i| i as i128)
+                .or_else(|_| crate::baseobjspace::uint_w(obj).map(|u| u as i128))?;
+            V::Signed(v)
         }
         "f" | "d" | "g" => V::Float(crate::baseobjspace::float_w(obj)?),
         "?" => V::Bool(crate::baseobjspace::is_true(obj)?),
@@ -460,18 +484,55 @@ pub(super) fn encode_value(tc: &str, obj: PyObjectRef) -> Result<Vec<u8>, crate:
     ))
 }
 
+/// Encode `value` for storage into slot `key` of `dest`, threading `char*`
+/// keepalive.  A `c_char_p` (`z`) initialised from `bytes` is stored as a
+/// pointer to a NUL-terminated copy retained under `key` in `dest`'s root
+/// `_objects_`; every other case defers to [`encode_value`].
+pub(super) fn encode_value_into(
+    tc: &str,
+    value: PyObjectRef,
+    dest: PyObjectRef,
+    key: &str,
+) -> Result<Vec<u8>, crate::PyError> {
+    if tc == "z" && unsafe { pyre_object::is_bytes(value) } {
+        let raw = unsafe { pyre_object::bytesobject::w_bytes_data(value) };
+        let copy = pyre_object::bytesobject::w_bytes_from_bytes(&host_ctypes::null_terminated_bytes(
+            raw,
+        ));
+        // Retain the copy before reading its address, so a GC triggered while
+        // inserting the keepalive cannot leave the stored pointer stale.
+        keep_ref(dest, key, copy);
+        let addr = unsafe { pyre_object::bytesobject::w_bytes_data(copy).as_ptr() } as usize;
+        return Ok(host_ctypes::simple_storage_value_to_bytes_endian(
+            tc,
+            host_ctypes::SimpleStorageValue::Pointer(addr),
+            false,
+        ));
+    }
+    encode_value(tc, value)
+}
+
+/// A `u64` as a non-negative Python integer: an `int` while it fits `i64`, a
+/// `long` above `i64::MAX` so `c_ulonglong` / addresses keep their full range
+/// instead of wrapping to a negative value.
+fn u64_to_pyobject(u: u64) -> PyObjectRef {
+    if u <= i64::MAX as u64 {
+        pyre_object::w_int_new(u as i64)
+    } else {
+        pyre_object::longobject::w_long_new(malachite_bigint::BigInt::from(u))
+    }
+}
+
 /// Turn a decoded scalar into a pyre object.
 pub(super) fn decoded_to_pyobject(d: host_ctypes::DecodedValue) -> PyObjectRef {
     use host_ctypes::DecodedValue as D;
     match d {
         D::Bytes(b) => pyre_object::bytesobject::w_bytes_from_bytes(&b),
         D::Signed(i) => pyre_object::w_int_new(i),
-        // No unsigned-i64 int constructor exists; values above i64::MAX
-        // wrap.  The slice's scalar returns stay within i64 range.
-        D::Unsigned(u) => pyre_object::w_int_new(u as i64),
+        D::Unsigned(u) => u64_to_pyobject(u),
         D::Float(f) => pyre_object::w_float_new(f),
         D::Bool(b) => pyre_object::w_bool_from(b),
-        D::Pointer(p) => pyre_object::w_int_new(p as i64),
+        D::Pointer(p) => u64_to_pyobject(p as u64),
         D::String(s) => pyre_object::w_str_new(&s),
         D::None => pyre_object::w_none(),
     }

--- a/pyre/pyre-interpreter/src/module/_ctypes/funcptr.rs
+++ b/pyre/pyre-interpreter/src/module/_ctypes/funcptr.rs
@@ -27,6 +27,13 @@ const FUNCFLAG_USE_ERRNO: i64 = 0x8;
 const PTR_KEY: &str = "_ptr";
 const RESTYPE_KEY: &str = "_restype";
 const ARGTYPES_KEY: &str = "_argtypes";
+const CALLABLE_KEY: &str = "_callable";
+const INTERNAL_CAST_ADDR: usize = 1;
+const INTERNAL_STRING_AT_ADDR: usize = 2;
+const INTERNAL_WSTRING_AT_ADDR: usize = 3;
+const INTERNAL_MEMORYVIEW_AT_ADDR: usize = 4;
+const INTERNAL_PYBYTES_FROMSTRINGANDSIZE: usize = 5;
+const INTERNAL_PYOS_SNPRINTF: usize = 6;
 
 thread_local! {
     static CFUNCPTR_TYPE_OBJ: std::cell::OnceCell<PyObjectRef> =
@@ -37,7 +44,11 @@ thread_local! {
 pub(super) fn cfuncptr_type() -> PyObjectRef {
     CFUNCPTR_TYPE_OBJ.with(|c| {
         *c.get_or_init(|| {
-            let tp = crate::typedef::make_builtin_type("CFuncPtr", init_cfuncptr_type);
+            let tp = crate::typedef::make_builtin_type_with_base(
+                "CFuncPtr",
+                init_cfuncptr_type,
+                cdata::cdata_type(),
+            );
             unsafe { pyre_object::typeobject::w_type_set_hasdict(tp, true) };
             tp
         })
@@ -91,20 +102,29 @@ fn cfuncptr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     let cls = args[0];
     let (pos, kwargs) = crate::builtins::split_builtin_kwargs(&args[1..]);
     reject_kwargs(kwargs)?;
-    let addr: usize = match pos.first().copied() {
+    let mut callback = pyre_object::PY_NULL;
+    let addr: usize = match pos.last().copied() {
         None => 0,
         Some(a) if unsafe { pyre_object::is_none(a) } => 0,
         Some(a) if unsafe { pyre_object::is_int(a) } => {
             (unsafe { pyre_object::w_int_get_value(a) }) as usize
         }
         Some(a) if unsafe { pyre_object::is_tuple(a) } => resolve_from_tuple(a)?,
-        Some(_) => {
-            return Err(crate::PyError::type_error(
-                "argument must be callable or integer function address",
-            ));
+        Some(a) => {
+            let callable = unsafe { crate::function::is_function(a) }
+                || crate::typedef::r#type(a).is_some_and(|ty| {
+                    unsafe { crate::baseobjspace::lookup_in_type(ty, "__call__") }.is_some()
+                });
+            if !callable {
+                return Err(crate::PyError::type_error(
+                    "argument must be callable or integer function address",
+                ));
+            }
+            callback = a;
+            0
         }
     };
-    let obj = pyre_object::w_instance_new(cls);
+    let obj = cdata::new_cdata_obj_from_bytes(cls, host_ctypes::pointer_size(), &[])?;
     let d = crate::baseobjspace::getdict(obj);
     if d.is_null() {
         return Err(crate::PyError::type_error(
@@ -112,6 +132,9 @@ fn cfuncptr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
         ));
     }
     unsafe { pyre_object::w_dict_setitem_str(d, PTR_KEY, pyre_object::w_int_new(addr as i64)) };
+    if !callback.is_null() {
+        unsafe { pyre_object::w_dict_setitem_str(d, CALLABLE_KEY, callback) };
+    }
     Ok(obj)
 }
 
@@ -138,6 +161,11 @@ fn resolve_from_tuple(t: PyObjectRef) -> Result<usize, crate::PyError> {
             "function name must be string or bytes (ordinals not supported)",
         ));
     };
+    match name_bytes.as_slice() {
+        b"PyBytes_FromStringAndSize" => return Ok(INTERNAL_PYBYTES_FROMSTRINGANDSIZE),
+        b"PyOS_snprintf" => return Ok(INTERNAL_PYOS_SNPRINTF),
+        _ => {}
+    }
     host_ctypes::lookup_function_symbol_addr(handle, &name_bytes).map_err(|e| {
         use host_ctypes::LookupSymbolError as L;
         let sym = String::from_utf8_lossy(&name_bytes);
@@ -347,6 +375,77 @@ enum OwnedArg {
     Aggregate(host_ctypes::CTypeLayout, Vec<u8>),
 }
 
+fn callback_argument(ty: PyObjectRef, value: PyObjectRef) -> Result<PyObjectRef, crate::PyError> {
+    let bases = unsafe { pyre_object::typeobject::w_type_get_bases(ty) };
+    let is_simple_subclass = !bases.is_null()
+        && unsafe { pyre_object::w_tuple_getitem(bases, 0) }
+            .is_some_and(|base| cdata::type_code_of(base).is_some());
+    if is_simple_subclass {
+        crate::call::type_call_instantiate(ty, &[value])
+    } else {
+        Ok(value)
+    }
+}
+
+fn callback_result(
+    obj: PyObjectRef,
+    result: Result<PyObjectRef, crate::PyError>,
+) -> Result<PyObjectRef, crate::PyError> {
+    let result = match result {
+        Ok(value) => value,
+        Err(mut error) => {
+            let callable = instance_get(obj, CALLABLE_KEY).unwrap_or(pyre_object::PY_NULL);
+            let rendered = if callable.is_null() {
+                "<unknown>".to_string()
+            } else {
+                unsafe { crate::display::py_repr(callable) }
+                    .unwrap_or_else(|_| "<unknown>".to_string())
+            };
+            error.write_unraisable(
+                pyre_object::w_none(),
+                &format!("Exception ignored while calling ctypes callback function {rendered}"),
+                pyre_object::PY_NULL,
+            );
+            pyre_object::w_int_new(0)
+        }
+    };
+    match resolve_restype(obj)? {
+        Ret::Void => Ok(pyre_object::w_none()),
+        Ret::Code(code) => {
+            let bytes = cdata::encode_value_into(&code, result, obj, "result")?;
+            Ok(cdata::decoded_to_pyobject(host_ctypes::decode_type_code(
+                &code, &bytes,
+            )))
+        }
+        Ret::Pointer(_) | Ret::Aggregate(_) => Ok(result),
+    }
+}
+
+fn call_python_callback(
+    obj: PyObjectRef,
+    args: &[PyObjectRef],
+) -> Result<PyObjectRef, crate::PyError> {
+    let callable = instance_get(obj, CALLABLE_KEY)
+        .ok_or_else(|| crate::PyError::type_error("callback has no callable"))?;
+    let argtypes = resolve_argtypes(obj).unwrap_or_default();
+    if args.len() != argtypes.len() {
+        return Err(crate::PyError::type_error(format!(
+            "this function takes {} arguments ({} given)",
+            argtypes.len(),
+            args.len(),
+        )));
+    }
+    let converted = argtypes
+        .into_iter()
+        .zip(args.iter().copied())
+        .map(|(ty, value)| callback_argument(ty, value))
+        .collect::<Result<Vec<_>, _>>()?;
+    callback_result(
+        obj,
+        crate::call::call_function_impl_result(callable, &converted),
+    )
+}
+
 /// `_CFuncPtr.__call__(self, *args)`.
 fn cfuncptr_call(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     if args.is_empty() {
@@ -355,6 +454,18 @@ fn cfuncptr_call(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     let self_obj = args[0];
     let (call_args, kwargs) = crate::builtins::split_builtin_kwargs(&args[1..]);
     reject_kwargs(kwargs)?;
+    if instance_get(self_obj, CALLABLE_KEY).is_some() {
+        return call_python_callback(self_obj, call_args);
+    }
+    match funcptr_addr(self_obj) {
+        INTERNAL_CAST_ADDR => return internal_cast(call_args),
+        INTERNAL_STRING_AT_ADDR => return internal_string_at(call_args),
+        INTERNAL_WSTRING_AT_ADDR => return internal_wstring_at(call_args),
+        INTERNAL_MEMORYVIEW_AT_ADDR => return internal_memoryview_at(call_args),
+        INTERNAL_PYBYTES_FROMSTRINGANDSIZE => return internal_pybytes_fromstringandsize(call_args),
+        INTERNAL_PYOS_SNPRINTF => return internal_pyos_snprintf(call_args),
+        _ => {}
+    }
 
     // Marshal arguments into owned scalar data.  `keepalive` owns any
     // null-terminated `bytes` copies that pointer args address; `owned` owns
@@ -472,6 +583,210 @@ fn cfuncptr_call(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
             Ok(cdata::decoded_to_pyobject(decoded))
         }
     }
+}
+
+fn argument_address(obj: PyObjectRef) -> Result<usize, crate::PyError> {
+    if unsafe { pyre_object::is_none(obj) } {
+        return Ok(0);
+    }
+    if unsafe { pyre_object::is_int(obj) } {
+        return Ok(crate::baseobjspace::int_w(obj)? as usize);
+    }
+    if unsafe { pyre_object::is_bytes(obj) } {
+        return Ok(unsafe { pyre_object::bytesobject::w_bytes_data(obj) }.as_ptr() as usize);
+    }
+    if cdata::is_cdata_instance(obj) {
+        let cls = unsafe { pyre_object::w_instance_get_type(obj) };
+        if let Some(info) = stginfo::stginfo_of(cls) {
+            if stginfo::stginfo_paramfunc(info) == "pointer" {
+                return Ok(host_ctypes::read_pointer_from_buffer(
+                    cdata::cdata_bytes(obj).unwrap_or(&[]),
+                ));
+            }
+        }
+        if cdata::type_code_of(cls).is_some_and(|tc| cdata::is_pointer_code(&tc)) {
+            return Ok(host_ctypes::read_pointer_from_buffer(
+                cdata::cdata_bytes(obj).unwrap_or(&[]),
+            ));
+        }
+        return cdata::cdata_addr(obj)
+            .ok_or_else(|| crate::PyError::type_error("ctypes instance has no buffer"));
+    }
+    if super::interp_ctypes::is_carg(obj) {
+        return Ok(super::interp_ctypes::carg_ptr(obj));
+    }
+    Err(crate::PyError::type_error(
+        "wrong type: expected bytes, integer address, ctypes instance, or None",
+    ))
+}
+
+fn internal_cast(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    if args.len() < 3 || !unsafe { pyre_object::is_type(args[2]) } {
+        return Err(crate::PyError::type_error(
+            "cast() argument 2 must be a pointer type",
+        ));
+    }
+    let target = args[2];
+    let is_pointer = stginfo::stginfo_of(target)
+        .is_some_and(|i| stginfo::stginfo_paramfunc(i) == "pointer")
+        || cdata::type_code_of(target).is_some_and(|tc| matches!(tc.as_str(), "z" | "Z" | "P"));
+    if !is_pointer {
+        return Err(crate::PyError::type_error(
+            "cast() argument 2 must be a pointer type",
+        ));
+    }
+    let address = argument_address(args[0])?;
+    let result = crate::call::type_call_instantiate(target, &[])?;
+    let bytes = host_ctypes::simple_storage_value_to_bytes_endian(
+        "P",
+        host_ctypes::SimpleStorageValue::Pointer(address),
+        false,
+    );
+    cdata::cdata_write(result, 0, &bytes);
+    if cdata::is_cdata_instance(args[1]) {
+        cdata::share_objects_for_cast(result, args[1]);
+    } else {
+        cdata::keep_ref(result, "1", args[1]);
+    }
+    Ok(result)
+}
+
+fn internal_string_at(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    if args.is_empty() {
+        return Err(crate::PyError::type_error("string_at() missing address"));
+    }
+    let size = args
+        .get(1)
+        .copied()
+        .map(crate::baseobjspace::int_w)
+        .transpose()?
+        .unwrap_or(-1);
+    // CPython's bytes allocation rejects impossible PyBytes sizes before the
+    // pointer converter runs.  Keep that ordering for huge explicit sizes.
+    if size > isize::MAX as i64 / 2 {
+        return Err(crate::PyError::memory_error("size too large"));
+    }
+    let address = argument_address(args[0])?;
+    let value = host_ctypes::string_at(address, size as isize)
+        .map_err(|_| crate::PyError::value_error("NULL pointer access"))?;
+    Ok(pyre_object::bytesobject::w_bytes_from_bytes(&value))
+}
+
+fn internal_wstring_at(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    if args.is_empty() {
+        return Err(crate::PyError::type_error("wstring_at() missing address"));
+    }
+    let size = args
+        .get(1)
+        .copied()
+        .map(crate::baseobjspace::int_w)
+        .transpose()?
+        .unwrap_or(-1);
+    if size > isize::MAX as i64 / std::mem::size_of::<libc::wchar_t>() as i64 {
+        return Err(crate::PyError::overflow_error("size too large"));
+    }
+    let address = argument_address(args[0])?;
+    let value = host_ctypes::wstring_at(address, size as isize)
+        .map_err(|_| crate::PyError::value_error("NULL pointer access"))?;
+    Ok(pyre_object::w_str_from_wtf8(value))
+}
+
+fn internal_memoryview_at(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    if args.len() < 2 {
+        return Err(crate::PyError::type_error(
+            "memoryview_at() needs address and size",
+        ));
+    }
+    let address = argument_address(args[0])?;
+    if !unsafe { pyre_object::is_int(args[1]) || pyre_object::is_long(args[1]) } {
+        return Err(crate::PyError::type_error("size must be an integer"));
+    }
+    let size = crate::baseobjspace::int_w(args[1])
+        .map_err(|_| crate::PyError::value_error("size is too large"))?;
+    if size < 0 {
+        return Err(crate::PyError::value_error("size must not be negative"));
+    }
+    let readonly = args
+        .get(2)
+        .copied()
+        .map(crate::baseobjspace::is_true)
+        .transpose()?
+        .unwrap_or(false);
+    let w_fmt = pyre_object::w_str_new("B");
+    let w_obj = pyre_object::w_none();
+    let view = pyre_object::bufferview::BufferView::Raw {
+        backing: pyre_object::buffer::Buffer::External {
+            w_obj,
+            address,
+            size: size as usize,
+            readonly,
+        },
+        w_obj,
+        w_fmt,
+        itemsize: 1,
+        length: size,
+    };
+    let mv = pyre_object::memoryview::w_memoryview_alloc_header(false, false);
+    let view = pyre_object::memoryview::bufferview_alloc(view);
+    unsafe { pyre_object::memoryview::w_memoryview_set_view(mv, view) };
+    Ok(mv)
+}
+
+fn internal_pybytes_fromstringandsize(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    if args.len() < 2 || !unsafe { pyre_object::is_bytes(args[0]) } {
+        return Err(crate::PyError::type_error(
+            "PyBytes_FromStringAndSize needs string and size",
+        ));
+    }
+    let bytes = unsafe { pyre_object::bytesobject::w_bytes_data(args[0]) };
+    let size = crate::baseobjspace::int_w(args[1])?.max(0) as usize;
+    Ok(pyre_object::bytesobject::w_bytes_from_bytes(
+        &bytes[..size.min(bytes.len())],
+    ))
+}
+
+fn internal_pyos_snprintf(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    if args.len() < 3
+        || !cdata::is_cdata_instance(args[0])
+        || !unsafe { pyre_object::is_bytes(args[2]) }
+    {
+        return Err(crate::PyError::type_error(
+            "PyOS_snprintf needs buffer, size and format",
+        ));
+    }
+    let capacity = crate::baseobjspace::int_w(args[1])?.max(0) as usize;
+    let format = unsafe { pyre_object::bytesobject::w_bytes_data(args[2]) };
+    let mut rendered = Vec::new();
+    let mut arg = 3usize;
+    let mut i = 0usize;
+    while i < format.len() {
+        if format[i] == b'%' && i + 1 < format.len() && matches!(format[i + 1], b's' | b'd') {
+            let value = *args.get(arg).ok_or_else(|| {
+                crate::PyError::type_error("not enough arguments for format string")
+            })?;
+            arg += 1;
+            if format[i + 1] == b's' {
+                if !unsafe { pyre_object::is_bytes(value) } {
+                    return Err(crate::PyError::type_error("%s requires bytes"));
+                }
+                rendered
+                    .extend_from_slice(unsafe { pyre_object::bytesobject::w_bytes_data(value) });
+            } else {
+                rendered
+                    .extend_from_slice(crate::baseobjspace::int_w(value)?.to_string().as_bytes());
+            }
+            i += 2;
+        } else {
+            rendered.push(format[i]);
+            i += 1;
+        }
+    }
+    let write_len = rendered.len().min(capacity.saturating_sub(1));
+    cdata::cdata_write(args[0], 0, &rendered[..write_len]);
+    if capacity > 0 {
+        cdata::cdata_write(args[0], write_len, &[0]);
+    }
+    Ok(pyre_object::w_int_new(rendered.len() as i64))
 }
 
 /// The `StgInfo.paramfunc` of a cdata instance's type ("simple"/"array"/

--- a/pyre/pyre-interpreter/src/module/_ctypes/funcptr.rs
+++ b/pyre/pyre-interpreter/src/module/_ctypes/funcptr.rs
@@ -89,7 +89,8 @@ fn cfuncptr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
         ));
     }
     let cls = args[0];
-    let (pos, _kwargs) = crate::builtins::split_builtin_kwargs(&args[1..]);
+    let (pos, kwargs) = crate::builtins::split_builtin_kwargs(&args[1..]);
+    reject_kwargs(kwargs)?;
     let addr: usize = match pos.first().copied() {
         None => 0,
         Some(a) if unsafe { pyre_object::is_none(a) } => 0,
@@ -197,8 +198,34 @@ fn argtypes_getter(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> 
 }
 
 fn argtypes_setter(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    instance_set(args[1], ARGTYPES_KEY, args[2]);
+    let value = args[2];
+    // `_argtypes_` must be a sequence of types; a bare type (`fn.argtypes =
+    // c_int`) or other non-sequence is rejected rather than silently ignored.
+    if !unsafe { pyre_object::is_none(value) } && seq_to_vec(value).is_none() {
+        return Err(crate::PyError::type_error(
+            "argtypes must be a sequence of types",
+        ));
+    }
+    instance_set(args[1], ARGTYPES_KEY, value);
     Ok(pyre_object::w_none())
+}
+
+/// Reject keyword arguments: ctypes foreign calls and `_CFuncPtr(...)` take
+/// only positional arguments, so a stray `fn(x, foo=1)` is an error rather
+/// than a silently dropped `foo`.
+fn reject_kwargs(kwargs: Option<PyObjectRef>) -> Result<(), crate::PyError> {
+    let Some(kw) = kwargs else { return Ok(()) };
+    for (key_obj, _) in unsafe { pyre_object::w_dict_items(kw) } {
+        if unsafe { pyre_object::is_str(key_obj) }
+            && unsafe { pyre_object::w_str_get_value(key_obj) } == "__pyre_kw__"
+        {
+            continue;
+        }
+        return Err(crate::PyError::type_error(
+            "call takes no keyword arguments",
+        ));
+    }
+    Ok(())
 }
 
 // ── call ──────────────────────────────────────────────────────────────
@@ -326,7 +353,8 @@ fn cfuncptr_call(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
         return Err(crate::PyError::type_error("__call__ requires self"));
     }
     let self_obj = args[0];
-    let (call_args, _kwargs) = crate::builtins::split_builtin_kwargs(&args[1..]);
+    let (call_args, kwargs) = crate::builtins::split_builtin_kwargs(&args[1..]);
+    reject_kwargs(kwargs)?;
 
     // Marshal arguments into owned scalar data.  `keepalive` owns any
     // null-terminated `bytes` copies that pointer args address; `owned` owns
@@ -344,6 +372,11 @@ fn cfuncptr_call(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
                     ))
                 })?;
                 owned.push(marshal_typed_arg(arg, *at, &mut keepalive)?);
+            }
+            // Variadic tail (printf-style): arguments past the declared
+            // argtypes are marshalled by the default conversion rules.
+            for &arg in &call_args[argtypes.len().min(call_args.len())..] {
+                owned.push(marshal_default_arg(arg, &mut keepalive)?);
             }
         }
         None => {
@@ -471,14 +504,14 @@ fn is_aggregate_type(t: PyObjectRef) -> bool {
         .is_some_and(|pf| pf == "struct" || pf == "union")
 }
 
-/// The ordered field types of a struct/union type's `_fields_` (2-tuples only;
-/// bit fields are rejected at class-definition time).
-fn struct_field_types(t: PyObjectRef) -> Result<Vec<PyObjectRef>, crate::PyError> {
-    let fields = unsafe { crate::baseobjspace::lookup_in_type(t, "_fields_") }
-        .ok_or_else(|| crate::PyError::type_error("struct/union type has no '_fields_'"))?;
+/// Append the field types declared in one `_fields_` sequence to `out`
+/// (2-tuples only; bit fields are rejected at class-definition time).
+fn collect_field_types(
+    fields: PyObjectRef,
+    out: &mut Vec<PyObjectRef>,
+) -> Result<(), crate::PyError> {
     let items = seq_to_vec(fields)
         .ok_or_else(|| crate::PyError::type_error("_fields_ must be a sequence"))?;
-    let mut out = Vec::with_capacity(items.len());
     for it in items {
         if !unsafe { pyre_object::is_tuple(it) } {
             return Err(crate::PyError::type_error(
@@ -492,6 +525,32 @@ fn struct_field_types(t: PyObjectRef) -> Result<Vec<PyObjectRef>, crate::PyError
             ));
         }
         out.push(ft);
+    }
+    Ok(())
+}
+
+/// The full, base-first field types of a struct/union type.  A subclass's
+/// `_fields_` lists only its own fields, so the inherited prefix is gathered by
+/// walking the MRO from the least-derived ancestor down to `t`.
+fn struct_field_types(t: PyObjectRef) -> Result<Vec<PyObjectRef>, crate::PyError> {
+    let mro = unsafe { pyre_object::typeobject::w_type_get_mro(t) };
+    if mro.is_null() {
+        return Err(crate::PyError::type_error(
+            "struct/union type has no '_fields_'",
+        ));
+    }
+    let mut out = Vec::new();
+    let mut found = false;
+    for &cls in unsafe { (*mro).as_slice() }.iter().rev() {
+        if let Some(fields) = crate::type_dict_lookup(cls, "_fields_") {
+            found = true;
+            collect_field_types(fields, &mut out)?;
+        }
+    }
+    if !found {
+        return Err(crate::PyError::type_error(
+            "struct/union type has no '_fields_'",
+        ));
     }
     Ok(out)
 }
@@ -588,11 +647,9 @@ fn marshal_typed_arg(
     }
     let tc = cdata::type_code_of(at)
         .ok_or_else(|| crate::PyError::type_error("argtype has no valid '_type_'"))?;
-    let buf: Vec<u8> = if cdata::is_simplecdata_instance(arg) {
-        cdata::cdata_bytes(arg).unwrap_or(&[]).to_vec()
-    } else {
-        cdata::encode_value(&tc, arg)?
-    };
+    // `encode_value` copies a same-typed cdata's bytes and otherwise converts,
+    // so a mismatched cdata cannot be reinterpreted through the wrong argtype.
+    let buf = cdata::encode_value(&tc, arg)?;
     Ok(OwnedArg::Typed(tc, buf))
 }
 

--- a/pyre/pyre-interpreter/src/module/_ctypes/funcptr.rs
+++ b/pyre/pyre-interpreter/src/module/_ctypes/funcptr.rs
@@ -19,6 +19,7 @@ use super::stginfo;
 use super::type_ns_store;
 use pyre_object::PyObjectRef;
 use rustpython_host_env::ctypes as host_ctypes;
+use std::sync::OnceLock;
 
 /// `_flags_ & FUNCFLAG_USE_ERRNO` — swap the ctypes-local errno around the call.
 const FUNCFLAG_USE_ERRNO: i64 = 0x8;
@@ -35,24 +36,19 @@ const INTERNAL_MEMORYVIEW_AT_ADDR: usize = 4;
 const INTERNAL_PYBYTES_FROMSTRINGANDSIZE: usize = 5;
 const INTERNAL_PYOS_SNPRINTF: usize = 6;
 
-thread_local! {
-    static CFUNCPTR_TYPE_OBJ: std::cell::OnceCell<PyObjectRef> =
-        const { std::cell::OnceCell::new() };
-}
+static CFUNCPTR_TYPE_OBJ: OnceLock<usize> = OnceLock::new();
 
 /// The native `CFuncPtr` type object (cached, `hasdict=true`).
 pub(super) fn cfuncptr_type() -> PyObjectRef {
-    CFUNCPTR_TYPE_OBJ.with(|c| {
-        *c.get_or_init(|| {
-            let tp = crate::typedef::make_builtin_type_with_base(
-                "CFuncPtr",
-                init_cfuncptr_type,
-                cdata::cdata_type(),
-            );
-            unsafe { pyre_object::typeobject::w_type_set_hasdict(tp, true) };
-            tp
-        })
-    })
+    *CFUNCPTR_TYPE_OBJ.get_or_init(|| {
+        let tp = crate::typedef::make_builtin_type_with_base(
+            "CFuncPtr",
+            init_cfuncptr_type,
+            cdata::cdata_type(),
+        );
+        unsafe { pyre_object::typeobject::w_type_set_hasdict(tp, true) };
+        tp as usize
+    }) as PyObjectRef
 }
 
 fn init_cfuncptr_type(ns: PyObjectRef) {

--- a/pyre/pyre-interpreter/src/module/_ctypes/interp_ctypes.rs
+++ b/pyre/pyre-interpreter/src/module/_ctypes/interp_ctypes.rs
@@ -346,9 +346,6 @@ fn register_host_ctypes(ns: pyre_object::PyObjectRef) {
     let cfuncptr_tp = super::funcptr::cfuncptr_type();
     crate::module_ns_store(ns, "CFuncPtr", cfuncptr_tp);
 
-    // Widen `is_cdata_instance` (sizeof/addressof/byref) to every CData base.
-    super::cdata::register_cdata_base(super::cdata::cdata_type());
-
     // ── sizeof / addressof / byref / alignment / resize ──
     crate::module_ns_store(
         ns,
@@ -518,35 +515,31 @@ fn ctypes_resize(
 // ── byref carrier ──────────────────────────────────────────────────────
 
 #[cfg(all(unix, feature = "host_env"))]
-thread_local! {
-    static CARG_TYPE_OBJ: std::cell::OnceCell<pyre_object::PyObjectRef> =
-        const { std::cell::OnceCell::new() };
-}
+static CARG_TYPE_OBJ: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
 
 /// The minimal `byref` carrier type — holds `_ptr` (address) and `_obj`
 /// (the referenced instance, kept alive).  Foreign-call consumption of the
 /// carrier (the CArgObject P-tag path) is a later slice.
 #[cfg(all(unix, feature = "host_env"))]
 fn carg_type() -> pyre_object::PyObjectRef {
-    CARG_TYPE_OBJ.with(|c| {
-        *c.get_or_init(|| {
-            let tp = crate::typedef::make_builtin_type("CArgObject", |ns| {
-                super::type_ns_store(
-                    ns,
-                    "__repr__",
-                    crate::make_builtin_function("__repr__", |args| {
-                        let d = crate::baseobjspace::getdict(args[0]);
-                        let value = unsafe { pyre_object::w_dict_getitem_str(d, "_obj") }
-                            .unwrap_or_else(pyre_object::w_none);
-                        let rendered = unsafe { crate::display::py_repr(value) }?;
-                        Ok(pyre_object::w_str_new(&format!("<cparam {rendered}>")))
-                    }),
-                );
-            });
-            unsafe { pyre_object::typeobject::w_type_set_hasdict(tp, true) };
-            tp
-        })
-    })
+    let raw = *CARG_TYPE_OBJ.get_or_init(|| {
+        let tp = crate::typedef::make_builtin_type("CArgObject", |ns| {
+            super::type_ns_store(
+                ns,
+                "__repr__",
+                crate::make_builtin_function("__repr__", |args| {
+                    let d = crate::baseobjspace::getdict(args[0]);
+                    let value = unsafe { pyre_object::w_dict_getitem_str(d, "_obj") }
+                        .unwrap_or_else(pyre_object::w_none);
+                    let rendered = unsafe { crate::display::py_repr(value) }?;
+                    Ok(pyre_object::w_str_new(&format!("<cparam {rendered}>")))
+                }),
+            );
+        });
+        unsafe { pyre_object::typeobject::w_type_set_hasdict(tp, true) };
+        tp as usize
+    });
+    raw as pyre_object::PyObjectRef
 }
 
 #[cfg(all(unix, feature = "host_env"))]

--- a/pyre/pyre-interpreter/src/module/_ctypes/interp_ctypes.rs
+++ b/pyre/pyre-interpreter/src/module/_ctypes/interp_ctypes.rs
@@ -12,7 +12,6 @@
 //! All host/FFI work is delegated to `rustpython_host_env::ctypes`; the module
 //! contains no direct `libc::` FFI.
 
-
 pub fn register_module(ns: pyre_object::PyObjectRef) {
     #[cfg(all(unix, feature = "host_env"))]
     register_host_ctypes(ns);
@@ -76,12 +75,16 @@ fn register_host_ctypes(ns: pyre_object::PyObjectRef) {
                     let h = rustpython_host_env::ctypes::insert_raw_library_handle(ptr);
                     return Ok(pyre_object::w_int_new(h as i64));
                 }
-                if !pyre_object::is_str(args[0]) {
+                if pyre_object::is_bytes(args[0]) {
+                    String::from_utf8_lossy(pyre_object::bytesobject::w_bytes_data(args[0]))
+                        .into_owned()
+                } else if pyre_object::is_str(args[0]) {
+                    pyre_object::w_str_get_value(args[0]).to_string()
+                } else {
                     return Err(crate::PyError::type_error(
-                        "dlopen: name must be a string or None",
+                        "dlopen: name must be a string, bytes or None",
                     ));
                 }
-                pyre_object::w_str_get_value(args[0]).to_string()
             };
             let mode = if args.len() >= 2 {
                 crate::baseobjspace::int_w(args[1])? as i32
@@ -264,6 +267,28 @@ fn register_host_ctypes(ns: pyre_object::PyObjectRef) {
     crate::module_ns_store(ns, "FUNCFLAG_PYTHONAPI", pyre_object::w_int_new(0x4));
     crate::module_ns_store(ns, "FUNCFLAG_USE_ERRNO", pyre_object::w_int_new(0x8));
     crate::module_ns_store(ns, "FUNCFLAG_USE_LASTERROR", pyre_object::w_int_new(0x10));
+    crate::module_ns_store(ns, "CTYPES_MAX_ARGCOUNT", pyre_object::w_int_new(1024));
+
+    #[cfg(target_os = "macos")]
+    crate::module_ns_store(
+        ns,
+        "_dyld_shared_cache_contains_path",
+        crate::make_builtin_function("_dyld_shared_cache_contains_path", |args| {
+            let Some(&path) = args.first() else {
+                return Ok(pyre_object::w_bool_from(false));
+            };
+            if unsafe { pyre_object::is_none(path) } {
+                return Ok(pyre_object::w_bool_from(false));
+            }
+            if !unsafe { pyre_object::is_str(path) } {
+                return Err(crate::PyError::type_error("path must be a string"));
+            }
+            let path = unsafe { pyre_object::w_str_get_value(path) };
+            let found = host_ctypes::dyld_shared_cache_contains_path(path)
+                .map_err(|_| crate::PyError::value_error("path contains null byte"))?;
+            Ok(pyre_object::w_bool_from(found))
+        }),
+    );
 
     // Real addresses so `memmove`/`memset = CFUNCTYPE(...)(_memmove_addr)`
     // build callable foreign functions; the other three are import-only
@@ -279,14 +304,12 @@ fn register_host_ctypes(ns: pyre_object::PyObjectRef) {
         "_memset_addr",
         pyre_object::w_int_new(host_ctypes::memset_addr() as i64),
     );
-    // `cast` / `string_at` / `memoryview_at` are not built as `PYFUNCTYPE`
-    // trampolines in this slice.  Export their addresses as NULL rather than
-    // the old `1`/`2`/`4` sentinels: the stdlib wraps these as function
-    // pointers, and a foreign call through NULL raises `ValueError` instead of
-    // jumping to a wild address.
-    crate::module_ns_store(ns, "_cast_addr", pyre_object::w_int_new(0));
-    crate::module_ns_store(ns, "_string_at_addr", pyre_object::w_int_new(0));
-    crate::module_ns_store(ns, "_memoryview_at_addr", pyre_object::w_int_new(0));
+    // RustPython's internal non-FFI targets.  CFuncPtr.__call__ recognizes
+    // these values before entering libffi, exactly like function.rs.
+    crate::module_ns_store(ns, "_cast_addr", pyre_object::w_int_new(1));
+    crate::module_ns_store(ns, "_string_at_addr", pyre_object::w_int_new(2));
+    crate::module_ns_store(ns, "_wstring_at_addr", pyre_object::w_int_new(3));
+    crate::module_ns_store(ns, "_memoryview_at_addr", pyre_object::w_int_new(4));
 
     // ── ArgumentError — a real Exception subclass ──
     let w_exception = crate::builtins::lookup_exc_class("Exception")
@@ -320,12 +343,11 @@ fn register_host_ctypes(ns: pyre_object::PyObjectRef) {
     // through `PyCSimpleType.__new__` (validation + StgInfo).
     unsafe { (*simplecdata_tp).w_class = metaclass::pycsimpletype_type() };
     crate::module_ns_store(ns, "_SimpleCData", simplecdata_tp);
-    crate::module_ns_store(ns, "CFuncPtr", super::funcptr::cfuncptr_type());
+    let cfuncptr_tp = super::funcptr::cfuncptr_type();
+    crate::module_ns_store(ns, "CFuncPtr", cfuncptr_tp);
 
     // Widen `is_cdata_instance` (sizeof/addressof/byref) to every CData base.
-    for base in [simplecdata_tp, structure_tp, union_tp, array_tp, pointer_tp] {
-        super::cdata::register_cdata_base(base);
-    }
+    super::cdata::register_cdata_base(super::cdata::cdata_type());
 
     // ── sizeof / addressof / byref / alignment / resize ──
     crate::module_ns_store(
@@ -361,22 +383,18 @@ fn register_host_ctypes(ns: pyre_object::PyObjectRef) {
 fn ctypes_sizeof(
     args: &[pyre_object::PyObjectRef],
 ) -> Result<pyre_object::PyObjectRef, crate::PyError> {
-    use super::{cdata, stginfo};
-    use rustpython_host_env::ctypes as host_ctypes;
+    use super::cdata;
     let obj = *args
         .first()
         .ok_or_else(|| crate::PyError::type_error("sizeof() missing argument"))?;
     if unsafe { pyre_object::is_type(obj) } {
-        if let Some(info) = stginfo::stginfo_of(obj) {
-            return Ok(pyre_object::w_int_new(stginfo::stginfo_size(info) as i64));
+        if let Some(size) = cdata::ctype_size_of(obj) {
+            return Ok(pyre_object::w_int_new(size as i64));
         }
-        // Simple type without a StgInfo yet: derive from `_type_`.
-        return match cdata::type_code_of(obj) {
-            Some(tc) => match host_ctypes::simple_type_size(&tc) {
-                Some(sz) => Ok(pyre_object::w_int_new(sz as i64)),
-                None => Err(cdata::invalid_type_code_error()),
-            },
-            None => Err(crate::PyError::type_error("this type has no size")),
+        return if cdata::type_code_of(obj).is_some() {
+            Err(cdata::invalid_type_code_error())
+        } else {
+            Err(crate::PyError::type_error("this type has no size"))
         };
     }
     if cdata::is_cdata_instance(obj) {
@@ -486,7 +504,9 @@ fn ctypes_resize(
         .or_else(|| cdata::type_code_of(cls).and_then(|tc| host_ctypes::simple_type_size(&tc)))
         .unwrap_or(0);
     if requested < min as i64 {
-        return Err(crate::PyError::value_error(format!("minimum size is {min}")));
+        return Err(crate::PyError::value_error(format!(
+            "minimum size is {min}"
+        )));
     }
     let size = requested as usize;
     if let Some(ba) = cdata::cdata_buffer(obj) {
@@ -510,7 +530,19 @@ thread_local! {
 fn carg_type() -> pyre_object::PyObjectRef {
     CARG_TYPE_OBJ.with(|c| {
         *c.get_or_init(|| {
-            let tp = crate::typedef::make_builtin_type("CArgObject", |_| {});
+            let tp = crate::typedef::make_builtin_type("CArgObject", |ns| {
+                super::type_ns_store(
+                    ns,
+                    "__repr__",
+                    crate::make_builtin_function("__repr__", |args| {
+                        let d = crate::baseobjspace::getdict(args[0]);
+                        let value = unsafe { pyre_object::w_dict_getitem_str(d, "_obj") }
+                            .unwrap_or_else(pyre_object::w_none);
+                        let rendered = unsafe { crate::display::py_repr(value) }?;
+                        Ok(pyre_object::w_str_new(&format!("<cparam {rendered}>")))
+                    }),
+                );
+            });
             unsafe { pyre_object::typeobject::w_type_set_hasdict(tp, true) };
             tp
         })
@@ -518,7 +550,7 @@ fn carg_type() -> pyre_object::PyObjectRef {
 }
 
 #[cfg(all(unix, feature = "host_env"))]
-fn make_carg(addr: usize, obj: pyre_object::PyObjectRef) -> pyre_object::PyObjectRef {
+pub(super) fn make_carg(addr: usize, obj: pyre_object::PyObjectRef) -> pyre_object::PyObjectRef {
     let carg = pyre_object::w_instance_new(carg_type());
     let d = crate::baseobjspace::getdict(carg);
     if !d.is_null() {

--- a/pyre/pyre-interpreter/src/module/_ctypes/interp_ctypes.rs
+++ b/pyre/pyre-interpreter/src/module/_ctypes/interp_ctypes.rs
@@ -67,7 +67,7 @@ fn register_host_ctypes(ns: pyre_object::PyObjectRef) {
                 if pyre_object::is_none(args[0]) {
                     // dlopen(None) → process handle
                     let mode = if args.len() >= 2 {
-                        pyre_object::w_int_get_value(args[1]) as libc::c_int
+                        crate::baseobjspace::int_w(args[1])? as libc::c_int
                     } else {
                         libc::RTLD_NOW
                     };
@@ -84,7 +84,7 @@ fn register_host_ctypes(ns: pyre_object::PyObjectRef) {
                 pyre_object::w_str_get_value(args[0]).to_string()
             };
             let mode = if args.len() >= 2 {
-                (unsafe { pyre_object::w_int_get_value(args[1]) }) as i32
+                crate::baseobjspace::int_w(args[1])? as i32
             } else {
                 rustpython_host_env::ctypes::dlopen_mode(None)
             };
@@ -104,7 +104,7 @@ fn register_host_ctypes(ns: pyre_object::PyObjectRef) {
                 if args.len() < 2 {
                     return Err(crate::PyError::type_error("dlsym() needs 2 arguments"));
                 }
-                let h = (unsafe { pyre_object::w_int_get_value(args[0]) }) as usize;
+                let h = crate::baseobjspace::int_w(args[0])? as usize;
                 let name = unsafe {
                     if !pyre_object::is_str(args[1]) {
                         return Err(crate::PyError::type_error("dlsym: name must be a string"));
@@ -138,7 +138,7 @@ fn register_host_ctypes(ns: pyre_object::PyObjectRef) {
                 if args.is_empty() {
                     return Err(crate::PyError::type_error("dlclose() needs handle"));
                 }
-                let h = (unsafe { pyre_object::w_int_get_value(args[0]) }) as usize;
+                let h = crate::baseobjspace::int_w(args[0])? as usize;
                 rustpython_host_env::ctypes::drop_library(h);
                 Ok(pyre_object::w_none())
             },
@@ -169,7 +169,7 @@ fn register_host_ctypes(ns: pyre_object::PyObjectRef) {
                 if args.is_empty() {
                     return Err(crate::PyError::type_error("set_errno() needs value"));
                 }
-                let v = (unsafe { pyre_object::w_int_get_value(args[0]) }) as i32;
+                let v = crate::baseobjspace::int_w(args[0])? as i32;
                 let prev = rustpython_host_env::ctypes::set_errno(v);
                 Ok(pyre_object::w_int_new(prev as i64))
             },
@@ -231,9 +231,9 @@ fn register_host_ctypes(ns: pyre_object::PyObjectRef) {
             if args.is_empty() {
                 return Err(crate::PyError::type_error("string_at() needs ptr"));
             }
-            let ptr = (unsafe { pyre_object::w_int_get_value(args[0]) }) as usize;
+            let ptr = crate::baseobjspace::int_w(args[0])? as usize;
             let size = if args.len() >= 2 {
-                unsafe { pyre_object::w_int_get_value(args[1]) }
+                crate::baseobjspace::int_w(args[1])?
             } else {
                 -1
             };
@@ -279,9 +279,14 @@ fn register_host_ctypes(ns: pyre_object::PyObjectRef) {
         "_memset_addr",
         pyre_object::w_int_new(host_ctypes::memset_addr() as i64),
     );
-    crate::module_ns_store(ns, "_cast_addr", pyre_object::w_int_new(1));
-    crate::module_ns_store(ns, "_string_at_addr", pyre_object::w_int_new(2));
-    crate::module_ns_store(ns, "_memoryview_at_addr", pyre_object::w_int_new(4));
+    // `cast` / `string_at` / `memoryview_at` are not built as `PYFUNCTYPE`
+    // trampolines in this slice.  Export their addresses as NULL rather than
+    // the old `1`/`2`/`4` sentinels: the stdlib wraps these as function
+    // pointers, and a foreign call through NULL raises `ValueError` instead of
+    // jumping to a wild address.
+    crate::module_ns_store(ns, "_cast_addr", pyre_object::w_int_new(0));
+    crate::module_ns_store(ns, "_string_at_addr", pyre_object::w_int_new(0));
+    crate::module_ns_store(ns, "_memoryview_at_addr", pyre_object::w_int_new(0));
 
     // ── ArgumentError — a real Exception subclass ──
     let w_exception = crate::builtins::lookup_exc_class("Exception")
@@ -457,7 +462,8 @@ fn ctypes_byref(
 fn ctypes_resize(
     args: &[pyre_object::PyObjectRef],
 ) -> Result<pyre_object::PyObjectRef, crate::PyError> {
-    use super::cdata;
+    use super::{cdata, stginfo};
+    use rustpython_host_env::ctypes as host_ctypes;
     if args.len() < 2 {
         return Err(crate::PyError::type_error("resize() needs (obj, size)"));
     }
@@ -470,17 +476,21 @@ fn ctypes_resize(
             "Memory cannot be resized because this object doesn't own it",
         ));
     }
-    let size = crate::baseobjspace::int_w(args[1])? as usize;
-    let cur = cdata::cdata_len(obj).unwrap_or(0);
-    if size < cur {
-        return Err(crate::PyError::value_error(format!(
-            "minimum size is {cur}"
-        )));
+    // The floor is the type's natural size, not the current buffer length, so a
+    // previously enlarged object can be shrunk back down to it.  A negative
+    // request would wrap to a huge `usize`, so reject the signed value first.
+    let requested = crate::baseobjspace::int_w(args[1])?;
+    let cls = unsafe { pyre_object::w_instance_get_type(obj) };
+    let min = stginfo::stginfo_of(cls)
+        .map(stginfo::stginfo_size)
+        .or_else(|| cdata::type_code_of(cls).and_then(|tc| host_ctypes::simple_type_size(&tc)))
+        .unwrap_or(0);
+    if requested < min as i64 {
+        return Err(crate::PyError::value_error(format!("minimum size is {min}")));
     }
-    if size > cur {
-        if let Some(ba) = cdata::cdata_buffer(obj) {
-            unsafe { pyre_object::w_bytearray_vec_mut(ba).resize(size, 0) };
-        }
+    let size = requested as usize;
+    if let Some(ba) = cdata::cdata_buffer(obj) {
+        unsafe { pyre_object::w_bytearray_vec_mut(ba).resize(size, 0) };
     }
     Ok(pyre_object::w_none())
 }

--- a/pyre/pyre-interpreter/src/module/_ctypes/metaclass.rs
+++ b/pyre/pyre-interpreter/src/module/_ctypes/metaclass.rs
@@ -480,17 +480,36 @@ fn process_fields(cls: PyObjectRef, fields: PyObjectRef, is_union: bool) -> PyRe
     let pack = usize_attr(cls, "_pack_", 0);
     let forced = usize_attr(cls, "_align_", 1).max(1);
 
-    let (mut offset, mut max_align) = match first_base_stginfo(cls) {
+    // Reject before mutating the class: a type already frozen (used as a field
+    // elsewhere) or one that would embed itself by value cannot define fields.
+    // Checking up front keeps a rejected `_fields_` from leaving half-installed
+    // descriptors and a final flag behind.
+    if stginfo::stginfo_of(cls).is_some_and(stginfo::stginfo_is_final)
+        || entries.iter().any(|(_, ft)| *ft == cls)
+    {
+        return Err(crate::PyError::attribute_error(
+            "Structure or union cannot contain itself",
+        ));
+    }
+
+    let (base_size, base_length, mut max_align) = match first_base_stginfo(cls) {
         Some(bi) => (
             stginfo::stginfo_size(bi),
+            stginfo::stginfo_length(bi),
             stginfo::stginfo_align(bi).max(forced),
         ),
-        None => (0usize, forced),
+        None => (0usize, 0usize, forced),
     };
-    let mut union_max = 0usize;
+    // A union inherits its base's footprint as a floor, so a derived union with
+    // only smaller fields cannot shrink below the base; a struct starts laying
+    // its own fields out after the inherited prefix.
+    let mut offset = base_size;
+    let mut union_max = base_size;
     let mut has_pointer = false;
 
-    for (index, (name, ftype)) in entries.iter().enumerate() {
+    // Pass 1 — compute the full layout without touching the class.
+    let mut pending: Vec<(usize, usize, usize)> = Vec::with_capacity(entries.len());
+    for (name, ftype) in &entries {
         let size = stginfo::field_size_of(*ftype)
             .ok_or_else(|| crate::PyError::type_error(format!("field '{name}' has no size")))?;
         let align = stginfo::field_align_of(*ftype).unwrap_or(1).max(1);
@@ -509,11 +528,9 @@ fn process_fields(cls: PyObjectRef, fields: PyObjectRef, is_union: bool) -> PyRe
                 has_pointer = true;
             }
         }
-        mark_type_final(*ftype, size, align);
 
         let field_offset = if is_union { 0 } else { offset };
-        let cf = cfield_new(name, *ftype, field_offset, size, index);
-        set_type_attr(cls, name, cf);
+        pending.push((field_offset, size, align));
 
         if is_union {
             union_max = union_max.max(size);
@@ -530,12 +547,13 @@ fn process_fields(cls: PyObjectRef, fields: PyObjectRef, is_union: bool) -> PyRe
         raw
     };
 
-    if let Some(ci) = stginfo::stginfo_of(cls) {
-        if stginfo::stginfo_is_final(ci) {
-            return Err(crate::PyError::attribute_error(
-                "Structure or union cannot contain itself",
-            ));
-        }
+    // Pass 2 — commit: freeze field types, install `CField` descriptors, then
+    // the class `StgInfo` and `_fields_`.
+    for (index, (name, ftype)) in entries.iter().enumerate() {
+        let (field_offset, size, align) = pending[index];
+        mark_type_final(*ftype, size, align);
+        let cf = cfield_new(name, *ftype, field_offset, size, index);
+        set_type_attr(cls, name, cf);
     }
 
     let mut flags = stginfo::DICTFLAG_FINAL;
@@ -550,7 +568,8 @@ fn process_fields(cls: PyObjectRef, fields: PyObjectRef, is_union: bool) -> PyRe
         total_align,
         if is_union { "union" } else { "struct" },
     );
-    data.length = entries.len();
+    // Field count includes the inherited prefix, not just the own fields.
+    data.length = base_length + entries.len();
     data.flags = flags;
     data.big_endian = is_swapped ^ cfg!(target_endian = "big");
     stginfo::stginfo_set(cls, stginfo::stginfo_new(data));
@@ -737,21 +756,25 @@ fn cfield_set(args: &[PyObjectRef]) -> PyResult {
         "simple" => {
             let tc = cdata::type_code_of(proto)
                 .ok_or_else(|| crate::PyError::type_error("field has no '_type_'"))?;
-            let mut bytes = cdata::encode_value(&tc, value)?;
+            let mut bytes = cdata::encode_value_into(&tc, value, obj, &index.to_string())?;
             if field_needs_swap(obj, proto, size) {
                 bytes.reverse();
             }
             cdata::cdata_write(obj, offset, &bytes);
-            if cdata::is_cdata_instance(value) || unsafe { pyre_object::is_bytes(value) } {
+            if cdata::is_cdata_instance(value) {
                 cdata::keep_ref(obj, &index.to_string(), value);
             }
             Ok(pyre_object::w_none())
         }
-        "struct" | "union" => {
+        // A pointer field stores a pointer-sized value, so a `_Pointer`
+        // instance is copied like a struct/union: its buffer is the address.
+        "struct" | "union" | "pointer" => {
             if !unsafe { crate::baseobjspace::isinstance_w(value, proto) } {
                 return Err(crate::PyError::type_error("incompatible types"));
             }
-            let src = cdata::cdata_bytes(value).unwrap_or(&[]);
+            // Snapshot the source: `s.f = s.f` aliases the destination buffer,
+            // and `cdata_write`'s `copy_from_slice` assumes non-overlap.
+            let src = cdata::cdata_bytes(value).unwrap_or(&[]).to_vec();
             let n = size.min(src.len());
             cdata::cdata_write(obj, offset, &src[..n]);
             cdata::keep_ref(obj, &index.to_string(), value);
@@ -887,12 +910,11 @@ fn type_name(cls: PyObjectRef) -> String {
 
 // ── PyCArrayType + Array ───────────────────────────────────────────────
 
-thread_local! {
-    /// `(element_type, length) → array_type`, the pyre form of the
-    /// `_ctypes._array_type_cache` dict (keyed by type identity + length).
-    static ARRAY_TYPE_CACHE: RefCell<Vec<(PyObjectRef, usize, PyObjectRef)>> =
-        const { RefCell::new(Vec::new()) };
-}
+/// Reserved key under which an element type caches the array types built over
+/// it (`_ctypes._array_type_cache`), an `int`-keyed (by length) dict.  Holding
+/// the cache on the element type's own dict keeps the built array types
+/// GC-traced through the rooted element type rather than an untraced side table.
+const ARRAY_TYPE_CACHE_KEY: &str = "_array_type_cache";
 
 fn carraytype_new(args: &[PyObjectRef]) -> PyResult {
     let cls = crate::builtins::type_descr_new(args)?;
@@ -977,12 +999,17 @@ fn array_init_stginfo(cls: PyObjectRef) -> PyResult {
 
 /// `ctype * n` — cache lookup on `(ctype, n)`, else create `ctype_Array_n`.
 fn array_type_from_ctype(elem: PyObjectRef, n: usize) -> PyResult {
-    if let Some(found) = ARRAY_TYPE_CACHE.with(|c| {
-        c.borrow()
-            .iter()
-            .find(|(t, k, _)| *t == elem && *k == n)
-            .map(|(_, _, ty)| *ty)
-    }) {
+    let cache = match crate::type_dict_lookup(elem, ARRAY_TYPE_CACHE_KEY) {
+        Some(d) => d,
+        None => {
+            let d = pyre_object::w_dict_new();
+            if crate::type_dict_store(elem, ARRAY_TYPE_CACHE_KEY, d) {
+                pyre_object::gc_hook::try_gc_write_barrier(elem as *mut u8);
+            }
+            d
+        }
+    };
+    if let Some(found) = unsafe { pyre_object::w_dict_getitem(cache, n as i64) } {
         return Ok(found);
     }
     let name = format!("{}_Array_{}", type_name(elem), n);
@@ -999,7 +1026,7 @@ fn array_type_from_ctype(elem: PyObjectRef, n: usize) -> PyResult {
         ns,
     ];
     let new_cls = carraytype_new(&args)?;
-    ARRAY_TYPE_CACHE.with(|c| c.borrow_mut().push((elem, n, new_cls)));
+    unsafe { pyre_object::w_dict_setitem(cache, n as i64, new_cls) };
     Ok(new_cls)
 }
 
@@ -1134,9 +1161,9 @@ fn array_set_index(obj: PyObjectRef, meta: &ArrayMeta, idx: usize, value: PyObje
         "simple" => {
             let tc = cdata::type_code_of(meta.proto)
                 .ok_or_else(|| crate::PyError::type_error("element has no '_type_'"))?;
-            let bytes = cdata::encode_value(&tc, value)?;
+            let bytes = cdata::encode_value_into(&tc, value, obj, &idx.to_string())?;
             cdata::cdata_write(obj, offset, &bytes);
-            if cdata::is_cdata_instance(value) || unsafe { pyre_object::is_bytes(value) } {
+            if cdata::is_cdata_instance(value) {
                 cdata::keep_ref(obj, &idx.to_string(), value);
             }
             Ok(pyre_object::w_none())
@@ -1145,7 +1172,9 @@ fn array_set_index(obj: PyObjectRef, meta: &ArrayMeta, idx: usize, value: PyObje
             if !unsafe { crate::baseobjspace::isinstance_w(value, meta.proto) } {
                 return Err(crate::PyError::type_error("incompatible types"));
             }
-            let src = cdata::cdata_bytes(value).unwrap_or(&[]);
+            // Snapshot the source: `a[i] = a[i]` aliases the destination
+            // buffer, and `cdata_write`'s `copy_from_slice` assumes non-overlap.
+            let src = cdata::cdata_bytes(value).unwrap_or(&[]).to_vec();
             let n = meta.element_size.min(src.len());
             cdata::cdata_write(obj, offset, &src[..n]);
             cdata::keep_ref(obj, &idx.to_string(), value);
@@ -1444,7 +1473,7 @@ fn contents_get(args: &[PyObjectRef]) -> PyResult {
         return Err(crate::PyError::value_error("NULL pointer access"));
     }
     let size = stginfo::field_size_of(proto).unwrap_or_else(host_ctypes::pointer_size);
-    Ok(cdata::make_at_address(proto, ptr, size))
+    Ok(cdata::make_at_address(proto, ptr, size, obj))
 }
 
 fn contents_set(args: &[PyObjectRef]) -> PyResult {
@@ -1485,7 +1514,7 @@ fn pointer_getitem(args: &[PyObjectRef]) -> PyResult {
                 &tc, bytes,
             )))
         }
-        _ => Ok(cdata::make_at_address(proto, addr, element_size)),
+        _ => Ok(cdata::make_at_address(proto, addr, element_size, obj)),
     }
 }
 

--- a/pyre/pyre-interpreter/src/module/_ctypes/metaclass.rs
+++ b/pyre/pyre-interpreter/src/module/_ctypes/metaclass.rs
@@ -41,6 +41,7 @@ cached_type!(PYCSIMPLETYPE, pycsimpletype_type, || {
         "PyCSimpleType",
         |ns| {
             install_new(ns, csimpletype_new);
+            install_init(ns, csimpletype_init);
             install_shared_meta(ns);
         },
         crate::typedef::w_type(),
@@ -52,6 +53,7 @@ cached_type!(PYCSTRUCTTYPE, pycstructtype_type, || {
         "PyCStructType",
         |ns| {
             install_new(ns, cstructtype_new);
+            install_init(ns, cstructtype_init);
             install_shared_meta(ns);
             install_fields_getset(ns);
         },
@@ -66,6 +68,7 @@ cached_type!(PYCUNIONTYPE, pycuniontype_type, || {
         "UnionType",
         |ns| {
             install_new(ns, cuniontype_new);
+            install_init(ns, cuniontype_init);
             install_shared_meta(ns);
             install_fields_getset(ns);
         },
@@ -77,7 +80,7 @@ cached_type!(STRUCTURE, structure_type, || {
     let tp = crate::typedef::make_builtin_type_with_base(
         "Structure",
         init_aggregate_base,
-        crate::typedef::w_object(),
+        cdata::cdata_type(),
     );
     finish_aggregate_base(tp, pycstructtype_type(), "struct");
     tp
@@ -87,7 +90,7 @@ cached_type!(UNION, union_type, || {
     let tp = crate::typedef::make_builtin_type_with_base(
         "Union",
         init_aggregate_base,
-        crate::typedef::w_object(),
+        cdata::cdata_type(),
     );
     finish_aggregate_base(tp, pycuniontype_type(), "union");
     tp
@@ -98,7 +101,7 @@ cached_type!(CFIELD, cfield_type, || {
         type_ns_store(
             ns,
             "__new__",
-            crate::make_builtin_function("__new__", cfield_new_disabled),
+            crate::make_builtin_function("__new__", cfield_new_internal),
         );
         type_ns_store(
             ns,
@@ -112,8 +115,24 @@ cached_type!(CFIELD, cfield_type, || {
         );
         type_ns_store(
             ns,
+            "__delete__",
+            crate::make_builtin_function("__delete__", |_args| {
+                Err(crate::PyError::type_error("can't delete attribute"))
+            }),
+        );
+        type_ns_store(
+            ns,
             "__repr__",
             crate::make_builtin_function("__repr__", cfield_repr),
+        );
+        type_ns_store(
+            ns,
+            "__setattr__",
+            crate::make_builtin_function("__setattr__", |_args| {
+                Err(crate::PyError::attribute_error(
+                    "CField attributes are read-only",
+                ))
+            }),
         );
     });
     unsafe { pyre_object::typeobject::w_type_set_hasdict(tp, true) };
@@ -125,6 +144,7 @@ cached_type!(PYCARRAYTYPE, pycarraytype_type, || {
         "PyCArrayType",
         |ns| {
             install_new(ns, carraytype_new);
+            install_init(ns, carraytype_init);
             install_shared_meta(ns);
         },
         crate::typedef::w_type(),
@@ -136,6 +156,7 @@ cached_type!(PYCPOINTERTYPE, pycpointertype_type, || {
         "PyCPointerType",
         |ns| {
             install_new(ns, cpointertype_new);
+            install_init(ns, cpointertype_init);
             install_shared_meta(ns);
         },
         crate::typedef::w_type(),
@@ -143,11 +164,8 @@ cached_type!(PYCPOINTERTYPE, pycpointertype_type, || {
 });
 
 cached_type!(ARRAY, array_type, || {
-    let tp = crate::typedef::make_builtin_type_with_base(
-        "Array",
-        init_array_base,
-        crate::typedef::w_object(),
-    );
+    let tp =
+        crate::typedef::make_builtin_type_with_base("Array", init_array_base, cdata::cdata_type());
     finish_element_base(tp, pycarraytype_type());
     tp
 });
@@ -156,7 +174,7 @@ cached_type!(POINTER_BASE, pointer_base_type, || {
     let tp = crate::typedef::make_builtin_type_with_base(
         "_Pointer",
         init_pointer_base,
-        crate::typedef::w_object(),
+        cdata::cdata_type(),
     );
     finish_element_base(tp, pycpointertype_type());
     tp
@@ -166,8 +184,22 @@ fn install_new(ns: PyObjectRef, f: crate::gateway::BuiltinCodeFn) {
     type_ns_store(ns, "__new__", crate::make_builtin_function("__new__", f));
 }
 
+fn install_init(ns: PyObjectRef, f: crate::gateway::BuiltinCodeFn) {
+    type_ns_store(ns, "__init__", crate::make_builtin_function("__init__", f));
+}
+
 /// `__mul__`, `__pointer_type__`, and `from_param` — shared by all metaclasses.
 fn install_shared_meta(ns: PyObjectRef) {
+    type_ns_store(
+        ns,
+        "from_address",
+        crate::make_builtin_function("from_address", cdata::cdata_from_address),
+    );
+    type_ns_store(
+        ns,
+        "in_dll",
+        crate::make_builtin_function("in_dll", cdata::cdata_in_dll),
+    );
     type_ns_store(
         ns,
         "__mul__",
@@ -214,6 +246,35 @@ fn init_aggregate_base(ns: PyObjectRef) {
         "__init__",
         crate::make_builtin_function("__init__", structure_init),
     );
+    type_ns_store(
+        ns,
+        "__setattr__",
+        crate::make_builtin_function("__setattr__", structure_setattr),
+    );
+}
+
+fn structure_setattr(args: &[PyObjectRef]) -> PyResult {
+    if args.len() < 3 || !unsafe { pyre_object::is_str(args[1]) } {
+        return Err(crate::PyError::type_error(
+            "attribute name must be a string",
+        ));
+    }
+    let obj = args[0];
+    let name = unsafe { pyre_object::w_str_get_value(args[1]) };
+    let cls = unsafe { pyre_object::w_instance_get_type(obj) };
+    let slots_empty = crate::type_dict_lookup(cls, "__slots__").is_some_and(|slots| {
+        (unsafe { pyre_object::is_tuple(slots) } && unsafe { pyre_object::w_tuple_len(slots) } == 0)
+            || (unsafe { pyre_object::is_list(slots) }
+                && unsafe { pyre_object::w_list_len(slots) } == 0)
+    });
+    if slots_empty && unsafe { crate::baseobjspace::lookup_in_type(cls, name) }.is_none() {
+        return Err(crate::PyError::attribute_error(format!(
+            "'{}' object has no attribute '{}'",
+            type_name(cls),
+            name,
+        )));
+    }
+    crate::baseobjspace::object_setattr(obj, name, args[2])
 }
 
 fn finish_aggregate_base(tp: PyObjectRef, metaclass: PyObjectRef, paramfunc: &'static str) {
@@ -221,9 +282,9 @@ fn finish_aggregate_base(tp: PyObjectRef, metaclass: PyObjectRef, paramfunc: &'s
         pyre_object::typeobject::w_type_set_hasdict(tp, true);
         (*tp).w_class = metaclass;
     }
-    // A default 0-size StgInfo so `clone-from-base` works and a bare
-    // `Structure()`/`Union()` is not treated as abstract.
-    stginfo::stginfo_set(tp, stginfo::stginfo_new(StgInfoData::new(0, 1, paramfunc)));
+    // Bare Structure/Union are abstract; the first real subtype gets the
+    // default zero-sized storage state from its metaclass __init__.
+    let _ = paramfunc;
 }
 
 /// Finish the `Array` / `_Pointer` base: hasdict, acceptable-as-base, stamp its
@@ -294,26 +355,90 @@ fn init_pointer_base(ns: PyObjectRef) {
             "contents",
         ),
     );
+    type_ns_store(
+        ns,
+        "set_type",
+        pyre_object::function::w_classmethod_new(crate::make_builtin_function(
+            "set_type",
+            pointer_set_type,
+        )),
+    );
+}
+
+fn pointer_set_type(args: &[PyObjectRef]) -> PyResult {
+    if args.len() < 2 || !unsafe { pyre_object::is_type(args[0]) && pyre_object::is_type(args[1]) }
+    {
+        return Err(crate::PyError::type_error(
+            "set_type() requires a ctypes type",
+        ));
+    }
+    let pointer_cls = args[0];
+    let proto = args[1];
+    let mut data = StgInfoData::new(
+        host_ctypes::pointer_size(),
+        host_ctypes::simple_type_align("P").unwrap_or(host_ctypes::pointer_size()),
+        "pointer",
+    );
+    data.element_size = stginfo::field_size_of(proto).unwrap_or(0);
+    data.length = 1;
+    data.proto = Some(proto);
+    data.flags |= stginfo::TYPEFLAG_ISPOINTER;
+    stginfo::stginfo_set(pointer_cls, stginfo::stginfo_new(data));
+    set_type_attr(pointer_cls, "_type_", proto);
+    if let Some(info) = stginfo::stginfo_of(proto) {
+        stginfo::stginfo_set_pointer_type(info, pointer_cls);
+    }
+    Ok(pyre_object::w_none())
 }
 
 // ── metaclass `__new__` ────────────────────────────────────────────────
 
 fn csimpletype_new(args: &[PyObjectRef]) -> PyResult {
-    let cls = crate::builtins::type_descr_new(args)?;
-    simple_init_stginfo(cls)?;
-    Ok(cls)
+    crate::builtins::type_descr_new(args)
 }
 
 fn cstructtype_new(args: &[PyObjectRef]) -> PyResult {
-    let cls = crate::builtins::type_descr_new(args)?;
-    struct_union_init_stginfo(cls, false)?;
-    Ok(cls)
+    crate::builtins::type_descr_new(args)
 }
 
 fn cuniontype_new(args: &[PyObjectRef]) -> PyResult {
-    let cls = crate::builtins::type_descr_new(args)?;
-    struct_union_init_stginfo(cls, true)?;
-    Ok(cls)
+    crate::builtins::type_descr_new(args)
+}
+
+const META_INITIALIZED_KEY: &str = "_ctypes_stginfo_initialized";
+
+fn metaclass_init(args: &[PyObjectRef], initialize: fn(PyObjectRef) -> PyResult) -> PyResult {
+    if args.len() < 4 {
+        return Err(crate::PyError::type_error(
+            "metaclass __init__ expects name, bases and namespace",
+        ));
+    }
+    let cls = args
+        .first()
+        .copied()
+        .filter(|&obj| unsafe { pyre_object::is_type(obj) })
+        .ok_or_else(|| crate::PyError::type_error("metaclass __init__ requires a type"))?;
+    if own_dict_get(cls, META_INITIALIZED_KEY).is_some() {
+        return Err(crate::PyError::new(
+            crate::PyErrorKind::SystemError,
+            "already initialized",
+        ));
+    }
+    initialize(cls)?;
+    set_type_attr(cls, META_INITIALIZED_KEY, pyre_object::w_bool_from(true));
+    Ok(pyre_object::w_none())
+}
+
+fn csimpletype_init(args: &[PyObjectRef]) -> PyResult {
+    metaclass_init(args, simple_init_stginfo)
+}
+
+fn cstructtype_init(args: &[PyObjectRef]) -> PyResult {
+    metaclass_init(args, |cls| struct_union_init_stginfo(cls, false))
+}
+
+fn cuniontype_init(args: &[PyObjectRef]) -> PyResult {
+    metaclass_init(args, |cls| struct_union_init_stginfo(cls, true))
 }
 
 /// `PyCSimpleType` layout: validate `_type_` and build a simple `StgInfo`.
@@ -334,6 +459,39 @@ fn simple_init_stginfo(cls: PyObjectRef) -> PyResult {
         data.flags |= stginfo::TYPEFLAG_ISPOINTER;
     }
     stginfo::stginfo_set(cls, stginfo::stginfo_new(data));
+
+    let endian_capable = matches!(
+        tc.as_str(),
+        "b" | "B" | "h" | "H" | "i" | "I" | "l" | "L" | "q" | "Q" | "f" | "d" | "g"
+    );
+    if endian_capable && size == 1 {
+        set_type_attr(cls, "__ctype_le__", cls);
+        set_type_attr(cls, "__ctype_be__", cls);
+    } else if endian_capable && own_dict_get(cls, "_ctypes_native_peer").is_none() {
+        let ns = pyre_object::w_dict_new();
+        unsafe {
+            pyre_object::w_dict_setitem_str(ns, "_type_", pyre_object::w_str_new(&tc));
+            pyre_object::w_dict_setitem_str(ns, "_swappedbytes_", pyre_object::w_bool_from(true));
+            pyre_object::w_dict_setitem_str(ns, "_ctypes_native_peer", cls);
+        }
+        let bases = unsafe { pyre_object::typeobject::w_type_get_bases(cls) };
+        let name = unsafe { pyre_object::typeobject::w_type_get_name(cls) };
+        let swapped = crate::call::type_call_instantiate(
+            pycsimpletype_type(),
+            &[pyre_object::w_str_new(name), bases, ns],
+        )?;
+        if cfg!(target_endian = "little") {
+            set_type_attr(cls, "__ctype_le__", cls);
+            set_type_attr(cls, "__ctype_be__", swapped);
+            set_type_attr(swapped, "__ctype_le__", cls);
+            set_type_attr(swapped, "__ctype_be__", swapped);
+        } else {
+            set_type_attr(cls, "__ctype_le__", swapped);
+            set_type_attr(cls, "__ctype_be__", cls);
+            set_type_attr(swapped, "__ctype_le__", swapped);
+            set_type_attr(swapped, "__ctype_be__", cls);
+        }
+    }
     Ok(pyre_object::w_none())
 }
 
@@ -366,8 +524,99 @@ fn usize_attr(cls: PyObjectRef, name: &str, default: usize) -> usize {
     }
 }
 
-/// Parse `_fields_` into `(name, ctype)` pairs (2-tuples only).
-fn field_entries(fields: PyObjectRef) -> Result<Vec<(String, PyObjectRef)>, crate::PyError> {
+fn align_attr(cls: PyObjectRef) -> Result<usize, crate::PyError> {
+    match unsafe { crate::baseobjspace::lookup_in_type(cls, "_align_") } {
+        Some(o) if unsafe { pyre_object::is_int(o) } => {
+            let value = unsafe { pyre_object::w_int_get_value(o) };
+            if value < 0 {
+                Err(crate::PyError::value_error(
+                    "_align_ must be a non-negative integer",
+                ))
+            } else {
+                Ok((value as usize).max(1))
+            }
+        }
+        Some(_) => Err(crate::PyError::value_error(
+            "_align_ must be a non-negative integer",
+        )),
+        None => Ok(1),
+    }
+}
+
+fn anonymous_names(cls: PyObjectRef) -> Result<Vec<String>, crate::PyError> {
+    let Some(value) = crate::type_dict_lookup(cls, "_anonymous_") else {
+        return Ok(Vec::new());
+    };
+    let items = seq_items(value)
+        .ok_or_else(|| crate::PyError::type_error("_anonymous_ must be a sequence"))?;
+    items
+        .into_iter()
+        .map(|item| {
+            if unsafe { pyre_object::is_str(item) } {
+                Ok(unsafe { pyre_object::w_str_get_value(item) }.to_string())
+            } else {
+                Err(crate::PyError::type_error(
+                    "_anonymous_ items must be strings",
+                ))
+            }
+        })
+        .collect()
+}
+
+/// Install the flattened descriptors contributed by an anonymous aggregate.
+/// Anonymous carrier fields are skipped while their contents are recursively
+/// promoted, exactly as `PyCStructUnionType_update_stginfo` does.
+fn promote_anonymous_fields(
+    cls: PyObjectRef,
+    proto: PyObjectRef,
+    base_offset: usize,
+) -> Result<(), crate::PyError> {
+    let anonymous = anonymous_names(proto)?;
+    let fields = unsafe { crate::baseobjspace::lookup_in_type(proto, "_fields_") }
+        .ok_or_else(|| crate::PyError::attribute_error("anonymous field has no _fields_"))?;
+    for entry in field_entries(fields)? {
+        let name = entry.name;
+        let child_proto = entry.ty;
+        let child =
+            unsafe { crate::baseobjspace::lookup_in_type(proto, &name) }.ok_or_else(|| {
+                crate::PyError::attribute_error(format!("type has no attribute '{name}'"))
+            })?;
+        let offset = base_offset + cf_usize(child, "offset");
+        if anonymous.iter().any(|anon| anon == &name) {
+            promote_anonymous_fields(cls, child_proto, offset)?;
+        } else {
+            let promoted = cfield_new(
+                &name,
+                child_proto,
+                offset,
+                cf_usize(child, "byte_size"),
+                cf_usize(child, "index"),
+            );
+            let d = crate::baseobjspace::getdict(promoted);
+            unsafe {
+                for key in ["size", "bit_size", "bit_offset", "is_bitfield"] {
+                    if let Some(value) =
+                        pyre_object::w_dict_getitem_str(crate::baseobjspace::getdict(child), key)
+                    {
+                        pyre_object::w_dict_setitem_str(d, key, value);
+                    }
+                }
+            }
+            set_type_attr(cls, &name, promoted);
+        }
+    }
+    Ok(())
+}
+
+struct FieldEntry {
+    name: String,
+    ty: PyObjectRef,
+    bits: Option<usize>,
+}
+
+/// Parse `_fields_` into the same `(name, ctype[, bits])` records consumed by
+/// CPython/PyPy's aggregate layout builder.
+fn field_entries(fields: PyObjectRef) -> Result<Vec<FieldEntry>, crate::PyError> {
     let items = seq_items(fields)
         .ok_or_else(|| crate::PyError::type_error("_fields_ must be a sequence of 2-tuples"))?;
     let mut out = Vec::with_capacity(items.len());
@@ -383,9 +632,9 @@ fn field_entries(fields: PyObjectRef) -> Result<Vec<(String, PyObjectRef)>, crat
                 "_fields_ entries must be (name, type) pairs",
             ));
         }
-        if n >= 3 {
+        if n > 3 {
             return Err(crate::PyError::type_error(
-                "bit fields are not supported in this slice",
+                "_fields_ entries must be (name, type) or (name, type, bits)",
             ));
         }
         let name = unsafe { pyre_object::w_tuple_getitem(it, 0) }.unwrap_or(pyre_object::PY_NULL);
@@ -398,10 +647,37 @@ fn field_entries(fields: PyObjectRef) -> Result<Vec<(String, PyObjectRef)>, crat
                 "field type must be a ctypes type",
             ));
         }
-        out.push((
-            unsafe { pyre_object::w_str_get_value(name) }.to_string(),
-            ty,
-        ));
+        let name = unsafe { pyre_object::w_str_get_value(name) }.to_string();
+        let bits = if n == 3 {
+            let value =
+                unsafe { pyre_object::w_tuple_getitem(it, 2) }.unwrap_or(pyre_object::PY_NULL);
+            if value.is_null()
+                || !unsafe { pyre_object::is_int(value) || pyre_object::is_long(value) }
+            {
+                return Err(crate::PyError::type_error("bit width must be an integer"));
+            }
+            let tc = cdata::type_code_of(ty).unwrap_or_default();
+            if !matches!(
+                tc.as_str(),
+                "b" | "B" | "h" | "H" | "i" | "I" | "l" | "L" | "q" | "Q" | "?"
+            ) {
+                return Err(crate::PyError::type_error(format!(
+                    "bit fields not allowed for type {}",
+                    type_name(ty),
+                )));
+            }
+            let size = stginfo::field_size_of(ty).unwrap_or(0);
+            let width = crate::baseobjspace::int_w(value).unwrap_or(-1);
+            if width <= 0 || width as usize > size.saturating_mul(8) {
+                return Err(crate::PyError::value_error(format!(
+                    "number of bits invalid for bit field '{name}'",
+                )));
+            }
+            Some(width as usize)
+        } else {
+            None
+        };
+        out.push(FieldEntry { name, ty, bits });
     }
     Ok(out)
 }
@@ -473,19 +749,46 @@ fn struct_union_init_stginfo(cls: PyObjectRef, is_union: bool) -> PyResult {
 }
 
 fn process_fields(cls: PyObjectRef, fields: PyObjectRef, is_union: bool) -> PyResult {
+    // `_ctypes.cfield.process_fields` replaces the layout of an incomplete
+    // aggregate in place.  Keep the pointer type already cached on the old
+    // StgInfo: POINTER(Complete) must remain the type made while Complete was
+    // incomplete (including its frozen PEP 3118 "&B" format).
+    let cached_pointer_type = stginfo::stginfo_of(cls).and_then(stginfo::stginfo_pointer_type);
     let entries = field_entries(fields)?;
+    let anonymous = anonymous_names(cls)?;
+
+    for name in &anonymous {
+        let Some(entry) = entries.iter().find(|entry| &entry.name == name) else {
+            return Err(crate::PyError::attribute_error(format!(
+                "'{name}' is specified in _anonymous_ but not in _fields_"
+            )));
+        };
+        if !matches!(proto_kind(entry.ty).as_str(), "struct" | "union") {
+            return Err(crate::PyError::type_error(
+                "anonymous field must be a structure or union",
+            ));
+        }
+    }
 
     let is_swapped =
         unsafe { crate::baseobjspace::lookup_in_type(cls, "_swappedbytes_") }.is_some();
     let pack = usize_attr(cls, "_pack_", 0);
-    let forced = usize_attr(cls, "_align_", 1).max(1);
+    let forced = align_attr(cls)?;
+    if pack > 0
+        && !cfg!(windows)
+        && unsafe { crate::baseobjspace::lookup_in_type(cls, "_layout_") }.is_none()
+    {
+        crate::warn::warn_deprecation(
+            "_pack_ without explicit _layout_ uses deprecated MSVC layout",
+        );
+    }
 
     // Reject before mutating the class: a type already frozen (used as a field
     // elsewhere) or one that would embed itself by value cannot define fields.
     // Checking up front keeps a rejected `_fields_` from leaving half-installed
     // descriptors and a final flag behind.
     if stginfo::stginfo_of(cls).is_some_and(stginfo::stginfo_is_final)
-        || entries.iter().any(|(_, ft)| *ft == cls)
+        || entries.iter().any(|entry| entry.ty == cls)
     {
         return Err(crate::PyError::attribute_error(
             "Structure or union cannot contain itself",
@@ -508,19 +811,32 @@ fn process_fields(cls: PyObjectRef, fields: PyObjectRef, is_union: bool) -> PyRe
     let mut has_pointer = false;
 
     // Pass 1 — compute the full layout without touching the class.
-    let mut pending: Vec<(usize, usize, usize)> = Vec::with_capacity(entries.len());
-    for (name, ftype) in &entries {
-        let size = stginfo::field_size_of(*ftype)
-            .ok_or_else(|| crate::PyError::type_error(format!("field '{name}' has no size")))?;
-        let align = stginfo::field_align_of(*ftype).unwrap_or(1).max(1);
-        let eff = if pack > 0 { pack.min(align) } else { align };
-
-        if !is_union && eff > 0 && offset % eff != 0 {
-            offset += eff - (offset % eff);
+    // Active allocation unit for consecutive bitfields.  MS layout (selected
+    // implicitly by `_pack_`) only coalesces identical declared types; this is
+    // the behavior exercised by CPython's `test_pack_layout_switch`.
+    let mut active_bits: Option<(PyObjectRef, usize, usize, usize)> = None;
+    let little_bits = is_swapped ^ cfg!(target_endian = "little");
+    let mut pending: Vec<(usize, usize, usize, Option<(usize, usize)>)> =
+        Vec::with_capacity(entries.len());
+    for entry in &entries {
+        let name = &entry.name;
+        let ftype = entry.ty;
+        if is_swapped
+            && (matches!(proto_kind(ftype).as_str(), "pointer")
+                || cdata::type_code_of(ftype)
+                    .is_some_and(|code| matches!(code.as_str(), "u" | "P" | "z" | "Z" | "O")))
+        {
+            return Err(crate::PyError::type_error(format!(
+                "This type does not support other endian: {name}",
+            )));
         }
+        let size = stginfo::field_size_of(ftype)
+            .ok_or_else(|| crate::PyError::type_error(format!("field '{name}' has no size")))?;
+        let align = stginfo::field_align_of(ftype).unwrap_or(1).max(1);
+        let eff = if pack > 0 { pack.min(align) } else { align };
         max_align = max_align.max(eff);
 
-        if let Some(fi) = stginfo::stginfo_of(*ftype) {
+        if let Some(fi) = stginfo::stginfo_of(ftype) {
             if stginfo::stginfo_flags(fi)
                 & (stginfo::TYPEFLAG_ISPOINTER | stginfo::TYPEFLAG_HASPOINTER)
                 != 0
@@ -529,13 +845,45 @@ fn process_fields(cls: PyObjectRef, fields: PyObjectRef, is_union: bool) -> PyRe
             }
         }
 
-        let field_offset = if is_union { 0 } else { offset };
-        pending.push((field_offset, size, align));
-
-        if is_union {
-            union_max = union_max.max(size);
+        if let Some(bits) = entry.bits {
+            if is_union {
+                let bit_offset = if little_bits { 0 } else { size * 8 - bits };
+                pending.push((0, size, align, Some((bits, bit_offset))));
+                union_max = union_max.max(size);
+                continue;
+            }
+            let reuse = active_bits.filter(|(active_ty, active_size, _, used)| {
+                *active_ty == ftype && *active_size == size && *used + bits <= size * 8
+            });
+            let (field_offset, used) = if let Some((_, _, at, used)) = reuse {
+                (at, used)
+            } else {
+                if eff > 0 && offset % eff != 0 {
+                    offset += eff - (offset % eff);
+                }
+                let at = offset;
+                offset += size;
+                (at, 0)
+            };
+            let bit_offset = if little_bits {
+                used
+            } else {
+                size * 8 - used - bits
+            };
+            active_bits = Some((ftype, size, field_offset, used + bits));
+            pending.push((field_offset, size, align, Some((bits, bit_offset))));
         } else {
-            offset += size;
+            active_bits = None;
+            if !is_union && eff > 0 && offset % eff != 0 {
+                offset += eff - (offset % eff);
+            }
+            let field_offset = if is_union { 0 } else { offset };
+            pending.push((field_offset, size, align, None));
+            if is_union {
+                union_max = union_max.max(size);
+            } else {
+                offset += size;
+            }
         }
     }
 
@@ -549,11 +897,44 @@ fn process_fields(cls: PyObjectRef, fields: PyObjectRef, is_union: bool) -> PyRe
 
     // Pass 2 — commit: freeze field types, install `CField` descriptors, then
     // the class `StgInfo` and `_fields_`.
-    for (index, (name, ftype)) in entries.iter().enumerate() {
-        let (field_offset, size, align) = pending[index];
-        mark_type_final(*ftype, size, align);
-        let cf = cfield_new(name, *ftype, field_offset, size, index);
-        set_type_attr(cls, name, cf);
+    for (index, entry) in entries.iter().enumerate() {
+        let (field_offset, size, align, bitfield) = pending[index];
+        mark_type_final(entry.ty, size, align);
+        let cf = cfield_new(&entry.name, entry.ty, field_offset, size, index);
+        let d = crate::baseobjspace::getdict(cf);
+        if let Some((bits, bit_offset)) = bitfield {
+            unsafe {
+                pyre_object::w_dict_setitem_str(
+                    d,
+                    "size",
+                    pyre_object::w_int_new(((bits << 16) | bit_offset) as i64),
+                );
+                pyre_object::w_dict_setitem_str(d, "bit_size", pyre_object::w_int_new(bits as i64));
+                pyre_object::w_dict_setitem_str(
+                    d,
+                    "bit_offset",
+                    pyre_object::w_int_new(bit_offset as i64),
+                );
+                pyre_object::w_dict_setitem_str(d, "is_bitfield", pyre_object::w_bool_from(true));
+            }
+        }
+        if anonymous
+            .iter()
+            .any(|anonymous_name| anonymous_name == &entry.name)
+        {
+            unsafe {
+                pyre_object::w_dict_setitem_str(d, "is_anonymous", pyre_object::w_bool_from(true));
+            }
+        }
+        set_type_attr(cls, &entry.name, cf);
+    }
+    for name in &anonymous {
+        let (index, entry) = entries
+            .iter()
+            .enumerate()
+            .find(|(_, entry)| &entry.name == name)
+            .expect("anonymous fields validated above");
+        promote_anonymous_fields(cls, entry.ty, pending[index].0)?;
     }
 
     let mut flags = stginfo::DICTFLAG_FINAL;
@@ -572,7 +953,11 @@ fn process_fields(cls: PyObjectRef, fields: PyObjectRef, is_union: bool) -> PyRe
     data.length = base_length + entries.len();
     data.flags = flags;
     data.big_endian = is_swapped ^ cfg!(target_endian = "big");
-    stginfo::stginfo_set(cls, stginfo::stginfo_new(data));
+    let new_info = stginfo::stginfo_new(data);
+    if let Some(pointer_type) = cached_pointer_type {
+        stginfo::stginfo_set_pointer_type(new_info, pointer_type);
+    }
+    stginfo::stginfo_set(cls, new_info);
 
     // Store the raw `_fields_` so the metaclass getset can return it.
     set_type_attr(cls, "_fields_", fields);
@@ -585,10 +970,19 @@ fn process_fields(cls: PyObjectRef, fields: PyObjectRef, is_union: bool) -> PyRe
 fn meta_mul(args: &[PyObjectRef]) -> PyResult {
     let cls = args[0];
     let count = args.get(1).copied().unwrap_or(pyre_object::PY_NULL);
-    if count.is_null() || !unsafe { pyre_object::is_int(count) } {
+    if count.is_null() || !unsafe { pyre_object::is_int(count) || pyre_object::is_long(count) } {
         return Err(crate::PyError::not_implemented(
             "array length must be an int",
         ));
+    }
+    if unsafe { pyre_object::is_long(count) } {
+        let big = unsafe { pyre_object::longobject::w_long_get_value(count) };
+        if big.sign() == malachite_bigint::Sign::Minus {
+            return Err(crate::PyError::value_error(
+                "array length must not be negative",
+            ));
+        }
+        return Err(crate::PyError::overflow_error("array too large"));
     }
     let n = unsafe { pyre_object::w_int_get_value(count) };
     if n < 0 {
@@ -600,6 +994,13 @@ fn meta_mul(args: &[PyObjectRef]) -> PyResult {
 }
 
 fn meta_from_param(args: &[PyObjectRef]) -> PyResult {
+    if args
+        .first()
+        .copied()
+        .is_some_and(cdata::is_simplecdata_type)
+    {
+        return cdata::simple_from_param(args);
+    }
     Ok(args.get(1).copied().unwrap_or_else(pyre_object::w_none))
 }
 
@@ -639,14 +1040,15 @@ fn fields_get(args: &[PyObjectRef]) -> PyResult {
 fn fields_set(args: &[PyObjectRef]) -> PyResult {
     let cls = args[1];
     let value = args[2];
-    if let Some(info) = stginfo::stginfo_of(cls) {
-        if stginfo::stginfo_is_final(info) {
-            return Err(crate::PyError::attribute_error("_fields_ is final"));
-        }
+    let Some(info) = stginfo::stginfo_of(cls) else {
+        return Err(crate::PyError::type_error(
+            "ctypes state is not initialized",
+        ));
+    };
+    if stginfo::stginfo_is_final(info) {
+        return Err(crate::PyError::attribute_error("_fields_ is final"));
     }
-    let is_union = stginfo::stginfo_of(cls)
-        .map(|i| stginfo::stginfo_paramfunc(i) == "union")
-        .unwrap_or(false);
+    let is_union = stginfo::stginfo_paramfunc(info) == "union";
     process_fields(cls, value, is_union)
 }
 
@@ -664,8 +1066,20 @@ fn cfield_new(
     unsafe {
         pyre_object::w_dict_setitem_str(d, "name", pyre_object::w_str_new(name));
         pyre_object::w_dict_setitem_str(d, "proto", proto);
+        pyre_object::w_dict_setitem_str(d, "type", proto);
         pyre_object::w_dict_setitem_str(d, "offset", pyre_object::w_int_new(offset as i64));
+        pyre_object::w_dict_setitem_str(d, "byte_offset", pyre_object::w_int_new(offset as i64));
         pyre_object::w_dict_setitem_str(d, "size", pyre_object::w_int_new(size as i64));
+        pyre_object::w_dict_setitem_str(d, "byte_size", pyre_object::w_int_new(size as i64));
+        let bit_size = malachite_bigint::BigInt::from(size) * malachite_bigint::BigInt::from(8u8);
+        pyre_object::w_dict_setitem_str(
+            d,
+            "bit_size",
+            pyre_object::longobject::w_long_new(bit_size),
+        );
+        pyre_object::w_dict_setitem_str(d, "bit_offset", pyre_object::w_int_new(0));
+        pyre_object::w_dict_setitem_str(d, "is_bitfield", pyre_object::w_bool_from(false));
+        pyre_object::w_dict_setitem_str(d, "is_anonymous", pyre_object::w_bool_from(false));
         pyre_object::w_dict_setitem_str(d, "index", pyre_object::w_int_new(index as i64));
     }
     inst
@@ -682,6 +1096,39 @@ fn cf_usize(cfield: PyObjectRef, key: &str) -> usize {
         (unsafe { pyre_object::w_int_get_value(o) }).max(0) as usize
     } else {
         0
+    }
+}
+
+fn cf_bool(cfield: PyObjectRef, key: &str) -> bool {
+    let value = cf_obj(cfield, key);
+    !value.is_null() && crate::baseobjspace::is_true(value).unwrap_or(false)
+}
+
+fn bytes_to_native_uint(bytes: &[u8]) -> u64 {
+    if cfg!(target_endian = "little") {
+        bytes
+            .iter()
+            .take(8)
+            .enumerate()
+            .fold(0u64, |value, (i, byte)| value | ((*byte as u64) << (i * 8)))
+    } else {
+        bytes
+            .iter()
+            .take(8)
+            .fold(0u64, |value, byte| (value << 8) | *byte as u64)
+    }
+}
+
+fn native_uint_to_bytes(value: u64, size: usize) -> Vec<u8> {
+    let bytes = if cfg!(target_endian = "little") {
+        value.to_le_bytes()
+    } else {
+        value.to_be_bytes()
+    };
+    if cfg!(target_endian = "little") {
+        bytes[..size.min(8)].to_vec()
+    } else {
+        bytes[8 - size.min(8)..].to_vec()
     }
 }
 
@@ -715,9 +1162,13 @@ fn cfield_get(args: &[PyObjectRef]) -> PyResult {
     if obj.is_null() || unsafe { pyre_object::is_none(obj) } {
         return Ok(cfield);
     }
+    if !cdata::is_cdata_instance(obj) {
+        return Err(crate::PyError::type_error("not a ctypes instance"));
+    }
     let proto = cf_obj(cfield, "proto");
     let offset = cf_usize(cfield, "offset");
-    let size = cf_usize(cfield, "size");
+    let size = cf_usize(cfield, "byte_size");
+    let index = cf_usize(cfield, "index");
 
     match proto_kind(proto).as_str() {
         "simple" => {
@@ -731,13 +1182,52 @@ fn cfield_get(args: &[PyObjectRef]) -> PyResult {
             if field_needs_swap(obj, proto, size) {
                 field_bytes.reverse();
             }
+            if cf_bool(cfield, "is_bitfield") {
+                let bits = cf_usize(cfield, "bit_size");
+                let shift = cf_usize(cfield, "bit_offset");
+                let mask = if bits >= 64 {
+                    u64::MAX
+                } else {
+                    (1u64 << bits) - 1
+                };
+                let raw = (bytes_to_native_uint(&field_bytes) >> shift) & mask;
+                if matches!(tc.as_str(), "b" | "h" | "i" | "l" | "q") {
+                    let signed = if bits < 64 && raw & (1u64 << (bits - 1)) != 0 {
+                        (raw | !mask) as i64
+                    } else {
+                        raw as i64
+                    };
+                    return Ok(pyre_object::w_int_new(signed));
+                }
+                return Ok(pyre_object::longobject::w_long_new(
+                    malachite_bigint::BigInt::from(raw),
+                ));
+            }
             Ok(cdata::decoded_to_pyobject(host_ctypes::decode_type_code(
                 &tc,
                 &field_bytes,
             )))
         }
-        "struct" | "union" | "array" | "pointer" => {
-            Ok(cdata::make_subview(proto, obj, offset, size))
+        "array" => {
+            let element = stginfo::stginfo_of(proto).and_then(stginfo::stginfo_proto);
+            let all = cdata::cdata_bytes(obj)
+                .ok_or_else(|| crate::PyError::type_error("instance has no buffer"))?;
+            let start = offset.min(all.len());
+            let end = (offset + size).min(all.len());
+            let field = &all[start..end];
+            match element.and_then(cdata::type_code_of).as_deref() {
+                Some("c") => {
+                    let n = field.iter().position(|&b| b == 0).unwrap_or(field.len());
+                    Ok(pyre_object::bytesobject::w_bytes_from_bytes(&field[..n]))
+                }
+                Some("u") => Ok(pyre_object::w_str_new(&host_ctypes::wstring_from_bytes(
+                    field,
+                ))),
+                _ => Ok(cdata::make_indexed_subview(proto, obj, offset, size, index)),
+            }
+        }
+        "struct" | "union" | "pointer" => {
+            Ok(cdata::make_indexed_subview(proto, obj, offset, size, index))
         }
         _ => Err(crate::PyError::type_error("field type has no storage info")),
     }
@@ -747,15 +1237,45 @@ fn cfield_set(args: &[PyObjectRef]) -> PyResult {
     let cfield = args[0];
     let obj = args[1];
     let value = args[2];
+    if !cdata::is_cdata_instance(obj) {
+        return Err(crate::PyError::type_error("not a ctypes instance"));
+    }
     let proto = cf_obj(cfield, "proto");
     let offset = cf_usize(cfield, "offset");
-    let size = cf_usize(cfield, "size");
+    let size = cf_usize(cfield, "byte_size");
     let index = cf_usize(cfield, "index");
 
     match proto_kind(proto).as_str() {
         "simple" => {
             let tc = cdata::type_code_of(proto)
                 .ok_or_else(|| crate::PyError::type_error("field has no '_type_'"))?;
+            if cf_bool(cfield, "is_bitfield") {
+                let bits = cf_usize(cfield, "bit_size");
+                let shift = cf_usize(cfield, "bit_offset");
+                let mask = if bits >= 64 {
+                    u64::MAX
+                } else {
+                    (1u64 << bits) - 1
+                };
+                let integer = crate::baseobjspace::int_w(value)? as u64;
+                let mut storage = cdata::cdata_bytes(obj)
+                    .unwrap_or(&[])
+                    .get(offset..offset.saturating_add(size))
+                    .unwrap_or(&[])
+                    .to_vec();
+                storage.resize(size, 0);
+                if field_needs_swap(obj, proto, size) {
+                    storage.reverse();
+                }
+                let old = bytes_to_native_uint(&storage);
+                let combined = (old & !(mask << shift)) | ((integer & mask) << shift);
+                let mut bytes = native_uint_to_bytes(combined, size);
+                if field_needs_swap(obj, proto, size) {
+                    bytes.reverse();
+                }
+                cdata::cdata_write(obj, offset, &bytes);
+                return Ok(pyre_object::w_none());
+            }
             let mut bytes = cdata::encode_value_into(&tc, value, obj, &index.to_string())?;
             if field_needs_swap(obj, proto, size) {
                 bytes.reverse();
@@ -766,9 +1286,105 @@ fn cfield_set(args: &[PyObjectRef]) -> PyResult {
             }
             Ok(pyre_object::w_none())
         }
-        // A pointer field stores a pointer-sized value, so a `_Pointer`
-        // instance is copied like a struct/union: its buffer is the address.
-        "struct" | "union" | "pointer" => {
+        "pointer" => {
+            if unsafe { pyre_object::is_none(value) } {
+                cdata::cdata_write(obj, offset, &vec![0; size]);
+                return Ok(pyre_object::w_none());
+            }
+            let direct = unsafe { crate::baseobjspace::isinstance_w(value, proto) };
+            let expected = stginfo::stginfo_of(proto).and_then(stginfo::stginfo_proto);
+            let array_decay = if cdata::is_cdata_instance(value) {
+                let value_cls = unsafe { pyre_object::w_instance_get_type(value) };
+                stginfo::stginfo_of(value_cls)
+                    .filter(|&i| stginfo::stginfo_paramfunc(i) == "array")
+                    .and_then(stginfo::stginfo_proto)
+                    == expected
+            } else {
+                false
+            };
+            let bytes = if direct {
+                cdata::cdata_bytes(value).unwrap_or(&[]).to_vec()
+            } else if array_decay {
+                let addr = cdata::cdata_addr(value)
+                    .ok_or_else(|| crate::PyError::type_error("incompatible types"))?;
+                host_ctypes::simple_storage_value_to_bytes_endian(
+                    "P",
+                    host_ctypes::SimpleStorageValue::Pointer(addr),
+                    false,
+                )
+            } else {
+                return Err(crate::PyError::type_error("incompatible types"));
+            };
+            cdata::cdata_write(obj, offset, &bytes[..size.min(bytes.len())]);
+            let keep = if array_decay {
+                value
+            } else {
+                cdata::objects_for_keep(value)
+            };
+            cdata::keep_ref(obj, &index.to_string(), keep);
+            Ok(pyre_object::w_none())
+        }
+        "array" => {
+            let element = stginfo::stginfo_of(proto).and_then(stginfo::stginfo_proto);
+            match element.and_then(cdata::type_code_of).as_deref() {
+                Some("c") => {
+                    let source = crate::typedef::buffer_as_bytes_like(value)?
+                        .ok_or_else(|| crate::PyError::type_error("bytes-like object expected"))?;
+                    let bytes = unsafe { pyre_object::bytesobject::bytes_like_data(source) };
+                    if bytes.len() > size {
+                        return Err(crate::PyError::value_error("bytes too long"));
+                    }
+                    // PyCField_set: a character-array field is assigned with
+                    // string semantics, so bytes beyond the first NUL do not
+                    // overwrite the existing tail of the field.
+                    let written = bytes
+                        .iter()
+                        .position(|&byte| byte == 0)
+                        .map_or(bytes.len(), |nul| nul + 1);
+                    cdata::cdata_write(obj, offset, &bytes[..written]);
+                    Ok(pyre_object::w_none())
+                }
+                Some("u") => {
+                    if !unsafe { pyre_object::is_str(value) } {
+                        return Err(crate::PyError::type_error("unicode string expected"));
+                    }
+                    let mut field = cdata::cdata_bytes(obj)
+                        .unwrap_or(&[])
+                        .get(offset..offset.saturating_add(size))
+                        .unwrap_or(&[])
+                        .to_vec();
+                    field.resize(size, 0);
+                    host_ctypes::write_wchar_array_value(&mut field, unsafe {
+                        pyre_object::w_str_get_wtf8(value)
+                    })
+                    .map_err(|_| crate::PyError::value_error("string too long"))?;
+                    cdata::cdata_write(obj, offset, &field);
+                    Ok(pyre_object::w_none())
+                }
+                _ => {
+                    let array_value = if unsafe { crate::baseobjspace::isinstance_w(value, proto) }
+                    {
+                        value
+                    } else if unsafe { pyre_object::is_tuple(value) } {
+                        let values = seq_items(value).unwrap_or_default();
+                        crate::call::type_call_instantiate(proto, &values)
+                            .map_err(|error| crate::PyError::runtime_error(error.message))?
+                    } else {
+                        return Err(crate::PyError::type_error("incompatible types"));
+                    };
+                    let source = cdata::cdata_bytes(array_value).unwrap_or(&[]).to_vec();
+                    cdata::cdata_write(obj, offset, &source[..source.len().min(size)]);
+                    cdata::keep_ref(
+                        obj,
+                        &index.to_string(),
+                        cdata::objects_for_keep(array_value),
+                    );
+                    Ok(pyre_object::w_none())
+                }
+            }
+        }
+        // Structures and unions are copied by value.
+        "struct" | "union" => {
             if !unsafe { crate::baseobjspace::isinstance_w(value, proto) } {
                 return Err(crate::PyError::type_error("incompatible types"));
             }
@@ -777,7 +1393,7 @@ fn cfield_set(args: &[PyObjectRef]) -> PyResult {
             let src = cdata::cdata_bytes(value).unwrap_or(&[]).to_vec();
             let n = size.min(src.len());
             cdata::cdata_write(obj, offset, &src[..n]);
-            cdata::keep_ref(obj, &index.to_string(), value);
+            cdata::keep_ref(obj, &index.to_string(), cdata::objects_for_keep(value));
             Ok(pyre_object::w_none())
         }
         _ => Err(crate::PyError::type_error(
@@ -789,11 +1405,10 @@ fn cfield_set(args: &[PyObjectRef]) -> PyResult {
 fn cfield_repr(args: &[PyObjectRef]) -> PyResult {
     let cfield = args[0];
     let proto = cf_obj(cfield, "proto");
-    let tyname = match unsafe { crate::baseobjspace::lookup_in_type(proto, "__name__") } {
-        Some(o) if unsafe { pyre_object::is_str(o) } => {
-            unsafe { pyre_object::w_str_get_value(o) }.to_string()
-        }
-        _ => "?".to_string(),
+    let tyname = if !proto.is_null() && unsafe { pyre_object::is_type(proto) } {
+        unsafe { pyre_object::typeobject::w_type_get_name(proto) }.to_string()
+    } else {
+        "?".to_string()
     };
     let s = format!(
         "<Field type={}, ofs={}, size={}>",
@@ -804,10 +1419,80 @@ fn cfield_repr(args: &[PyObjectRef]) -> PyResult {
     Ok(pyre_object::w_str_new(&s))
 }
 
-fn cfield_new_disabled(_args: &[PyObjectRef]) -> PyResult {
-    Err(crate::PyError::type_error(
-        "CField is not intended to be used directly",
-    ))
+fn cfield_new_internal(args: &[PyObjectRef]) -> PyResult {
+    let (pos, kwargs) = crate::builtins::split_builtin_kwargs(args);
+    let get = |name: &str, position: usize| {
+        crate::builtins::resolve_pos_or_kw(
+            pos.get(position).copied(),
+            kwargs,
+            name,
+            "CField",
+            position,
+        )
+    };
+    let internal = get("_internal_use", 6)?
+        .is_some_and(|value| crate::baseobjspace::is_true(value).unwrap_or(false));
+    if !internal {
+        return Err(crate::PyError::type_error(
+            "CField is not intended to be used directly",
+        ));
+    }
+    let name_obj = get("name", 1)?.ok_or_else(|| crate::PyError::type_error("missing name"))?;
+    let proto = get("type", 2)?.ok_or_else(|| crate::PyError::type_error("missing type"))?;
+    let byte_size = get("byte_size", 3)?
+        .map(crate::baseobjspace::int_w)
+        .transpose()?
+        .ok_or_else(|| crate::PyError::type_error("missing byte_size"))?;
+    let byte_offset = get("byte_offset", 4)?
+        .map(crate::baseobjspace::int_w)
+        .transpose()?
+        .unwrap_or(0);
+    let index = get("index", 5)?
+        .map(crate::baseobjspace::int_w)
+        .transpose()?
+        .unwrap_or(0);
+    if !unsafe { pyre_object::is_str(name_obj) } || !unsafe { pyre_object::is_type(proto) } {
+        return Err(crate::PyError::type_error("invalid CField arguments"));
+    }
+    let expected = stginfo::field_size_of(proto)
+        .ok_or_else(|| crate::PyError::type_error("type has no size"))?;
+    if byte_size < 0 || byte_size as usize != expected {
+        return Err(crate::PyError::value_error(
+            "byte_size does not match type size",
+        ));
+    }
+    let field = cfield_new(
+        unsafe { pyre_object::w_str_get_value(name_obj) },
+        proto,
+        byte_offset.max(0) as usize,
+        byte_size as usize,
+        index.max(0) as usize,
+    );
+    let bit_size = get("bit_size", 7)?
+        .map(crate::baseobjspace::int_w)
+        .transpose()?;
+    let bit_offset = get("bit_offset", 8)?
+        .map(crate::baseobjspace::int_w)
+        .transpose()?
+        .unwrap_or(0);
+    if let Some(bits) = bit_size {
+        if bits <= 0 || bit_offset < 0 || bit_offset + bits > byte_size * 8 {
+            return Err(crate::PyError::value_error(format!(
+                "bit field '{}' overflows its type ({} + {} > {})",
+                unsafe { pyre_object::w_str_get_value(name_obj) },
+                bit_offset,
+                bits,
+                byte_size * 8,
+            )));
+        }
+        let d = crate::baseobjspace::getdict(field);
+        unsafe {
+            pyre_object::w_dict_setitem_str(d, "bit_size", pyre_object::w_int_new(bits));
+            pyre_object::w_dict_setitem_str(d, "bit_offset", pyre_object::w_int_new(bit_offset));
+            pyre_object::w_dict_setitem_str(d, "is_bitfield", pyre_object::w_bool_from(true));
+        }
+    }
+    Ok(field)
 }
 
 // ── Structure / Union instances ────────────────────────────────────────
@@ -819,6 +1504,9 @@ fn structure_new(args: &[PyObjectRef]) -> PyResult {
         ));
     }
     let cls = args[0];
+    if unsafe { crate::baseobjspace::lookup_in_type(cls, "_abstract_") }.is_some() {
+        return Err(crate::PyError::type_error("abstract class"));
+    }
     let info =
         stginfo::stginfo_of(cls).ok_or_else(|| crate::PyError::type_error("abstract class"))?;
     let size = stginfo::stginfo_size(info);
@@ -838,7 +1526,7 @@ fn field_names_base_first(cls: PyObjectRef) -> Vec<String> {
     for &t in mro_items(cls).iter().rev() {
         if let Some(f) = crate::type_dict_lookup(t, "_fields_") {
             if let Ok(entries) = field_entries(f) {
-                names.extend(entries.into_iter().map(|(n, _)| n));
+                names.extend(entries.into_iter().map(|entry| entry.name));
             }
         }
     }
@@ -917,9 +1605,11 @@ fn type_name(cls: PyObjectRef) -> String {
 const ARRAY_TYPE_CACHE_KEY: &str = "_array_type_cache";
 
 fn carraytype_new(args: &[PyObjectRef]) -> PyResult {
-    let cls = crate::builtins::type_descr_new(args)?;
-    array_init_stginfo(cls)?;
-    Ok(cls)
+    crate::builtins::type_descr_new(args)
+}
+
+fn carraytype_init(args: &[PyObjectRef]) -> PyResult {
+    metaclass_init(args, array_init_stginfo)
 }
 
 /// `PyCArrayType` layout: resolve `_length_` + `_type_` and build the array
@@ -927,12 +1617,22 @@ fn carraytype_new(args: &[PyObjectRef]) -> PyResult {
 fn array_init_stginfo(cls: PyObjectRef) -> PyResult {
     let length = match own_dict_get(cls, "_length_") {
         Some(v) => {
-            if !unsafe { pyre_object::is_int(v) } {
+            if !unsafe { pyre_object::is_int(v) || pyre_object::is_long(v) } {
                 return Err(crate::PyError::type_error(
                     "The '_length_' attribute must be an integer",
                 ));
             }
-            let n = unsafe { pyre_object::w_int_get_value(v) };
+            let n = if unsafe { pyre_object::is_long(v) } {
+                let big = unsafe { pyre_object::longobject::w_long_get_value(v) };
+                if big.sign() == malachite_bigint::Sign::Minus {
+                    return Err(crate::PyError::value_error(
+                        "The '_length_' attribute must not be negative",
+                    ));
+                }
+                return Err(crate::PyError::overflow_error("array too large"));
+            } else {
+                unsafe { pyre_object::w_int_get_value(v) }
+            };
             if n < 0 {
                 return Err(crate::PyError::value_error(
                     "The '_length_' attribute must not be negative",
@@ -970,7 +1670,8 @@ fn array_init_stginfo(cls: PyObjectRef) -> PyResult {
     let elem_size = stginfo::field_size_of(elem)
         .ok_or_else(|| crate::PyError::type_error("_type_ must have storage info"))?;
     let elem_align = stginfo::field_align_of(elem).unwrap_or(1).max(1);
-    if elem_size != 0 && length > usize::MAX / elem_size {
+    if elem_size != 0 && (length > usize::MAX / elem_size || elem_size * length > i64::MAX as usize)
+    {
         return Err(crate::PyError::overflow_error("array too large"));
     }
 
@@ -990,9 +1691,11 @@ fn array_init_stginfo(cls: PyObjectRef) -> PyResult {
     set_type_attr(cls, "_type_", elem);
     set_type_attr(cls, "_length_", pyre_object::w_int_new(length as i64));
 
-    // `c` element arrays gain `value`/`raw`; `u` (wchar) is deferred.
-    if cdata::type_code_of(elem).as_deref() == Some("c") {
-        install_char_array_getsets(cls);
+    // Character arrays expose the CPython/PyPy convenience descriptors.
+    match cdata::type_code_of(elem).as_deref() {
+        Some("c") => install_char_array_getsets(cls),
+        Some("u") => install_wchar_array_getsets(cls),
+        _ => {}
     }
     Ok(pyre_object::w_none())
 }
@@ -1019,13 +1722,8 @@ fn array_type_from_ctype(elem: PyObjectRef, n: usize) -> PyResult {
         pyre_object::w_dict_setitem_str(ns, "_length_", pyre_object::w_int_new(n as i64));
     }
     let bases = pyre_object::w_tuple_new(vec![array_type()]);
-    let args = [
-        pycarraytype_type(),
-        pyre_object::w_str_new(&name),
-        bases,
-        ns,
-    ];
-    let new_cls = carraytype_new(&args)?;
+    let args = [pyre_object::w_str_new(&name), bases, ns];
+    let new_cls = crate::call::type_call_instantiate(pycarraytype_type(), &args)?;
     unsafe { pyre_object::w_dict_setitem(cache, n as i64, new_cls) };
     Ok(new_cls)
 }
@@ -1128,11 +1826,12 @@ fn array_get_index(obj: PyObjectRef, meta: &ArrayMeta, idx: usize) -> PyResult {
                 &all[start..end],
             )))
         }
-        "struct" | "union" | "array" | "pointer" => Ok(cdata::make_subview(
+        "struct" | "union" | "array" | "pointer" => Ok(cdata::make_indexed_subview(
             meta.proto,
             obj,
             offset,
             meta.element_size,
+            idx,
         )),
         _ => Err(crate::PyError::type_error(
             "element type has no storage info",
@@ -1177,7 +1876,7 @@ fn array_set_index(obj: PyObjectRef, meta: &ArrayMeta, idx: usize, value: PyObje
             let src = cdata::cdata_bytes(value).unwrap_or(&[]).to_vec();
             let n = meta.element_size.min(src.len());
             cdata::cdata_write(obj, offset, &src[..n]);
-            cdata::keep_ref(obj, &idx.to_string(), value);
+            cdata::keep_ref(obj, &idx.to_string(), cdata::objects_for_keep(value));
             Ok(pyre_object::w_none())
         }
         _ => Err(crate::PyError::type_error(
@@ -1188,71 +1887,47 @@ fn array_set_index(obj: PyObjectRef, meta: &ArrayMeta, idx: usize, value: PyObje
 
 /// The concrete indices a slice selects over `length`, PySlice-adjusted.
 fn slice_index_list(slice: PyObjectRef, length: usize) -> Result<Vec<usize>, crate::PyError> {
-    let len = length as i64;
-    let as_int = |o: PyObjectRef| -> Option<i64> {
-        if o.is_null() || unsafe { pyre_object::is_none(o) } {
-            None
-        } else if unsafe { pyre_object::is_int(o) } {
-            Some(unsafe { pyre_object::w_int_get_value(o) })
-        } else {
-            None
-        }
-    };
-    let step = as_int(unsafe { pyre_object::w_slice_get_step(slice) }).unwrap_or(1);
-    if step == 0 {
-        return Err(crate::PyError::value_error("slice step cannot be zero"));
-    }
-    let (lower, upper) = if step > 0 { (0, len) } else { (-1, len - 1) };
-    let clamp = |v: i64| -> i64 {
-        let v = if v < 0 { v + len } else { v };
-        v.clamp(lower, upper)
-    };
-    let start = match as_int(unsafe { pyre_object::w_slice_get_start(slice) }) {
-        Some(v) => clamp(v),
-        None => {
-            if step > 0 {
-                0
-            } else {
-                len - 1
-            }
-        }
-    };
-    let stop = match as_int(unsafe { pyre_object::w_slice_get_stop(slice) }) {
-        Some(v) => clamp(v),
-        None => {
-            if step > 0 {
-                len
-            } else {
-                -1
-            }
-        }
-    };
-    let mut out = Vec::new();
+    let (start, stop, step) = crate::sliceobject::slice_unpack(
+        unsafe { pyre_object::w_slice_get_start(slice) },
+        unsafe { pyre_object::w_slice_get_stop(slice) },
+        unsafe { pyre_object::w_slice_get_step(slice) },
+    )?;
+    let (start, _, step, slice_length) =
+        crate::sliceobject::slice_adjust_indices(start, stop, step, length as i64);
+    let mut out = Vec::with_capacity(slice_length as usize);
     let mut i = start;
-    if step > 0 {
-        while i < stop {
-            out.push(i as usize);
-            i += step;
-        }
-    } else {
-        while i > stop {
-            out.push(i as usize);
-            i += step;
-        }
+    for _ in 0..slice_length {
+        out.push(i as usize);
+        i = i.saturating_add(step);
     }
     Ok(out)
 }
 
 fn array_get_slice(obj: PyObjectRef, meta: &ArrayMeta, slice: PyObjectRef) -> PyResult {
     let idxs = slice_index_list(slice, meta.length)?;
-    // `c` element arrays slice to `bytes`; other elements slice to a list.
-    if cdata::type_code_of(meta.proto).as_deref() == Some("c") {
+    // Character arrays slice to bytes/str; other elements slice to a list.
+    let tc = cdata::type_code_of(meta.proto);
+    if tc.as_deref() == Some("c") {
         let all = cdata::cdata_bytes(obj).unwrap_or(&[]);
         let bytes: Vec<u8> = idxs
             .iter()
             .map(|&i| all.get(i * meta.element_size).copied().unwrap_or(0))
             .collect();
         return Ok(pyre_object::bytesobject::w_bytes_from_bytes(&bytes));
+    }
+    if tc.as_deref() == Some("u") {
+        let mut value = String::new();
+        for i in idxs {
+            let offset = i * meta.element_size;
+            let all = cdata::cdata_bytes(obj).unwrap_or(&[]);
+            let end = (offset + meta.element_size).min(all.len());
+            if let host_ctypes::DecodedValue::String(s) =
+                host_ctypes::decode_type_code("u", &all[offset.min(end)..end])
+            {
+                value.push_str(&s);
+            }
+        }
+        return Ok(pyre_object::w_str_new(&value));
     }
     let mut items = Vec::with_capacity(idxs.len());
     for i in idxs {
@@ -1268,8 +1943,32 @@ fn array_set_slice(
     value: PyObjectRef,
 ) -> PyResult {
     let idxs = slice_index_list(slice, meta.length)?;
-    let items =
-        seq_items(value).ok_or_else(|| crate::PyError::type_error("can only assign a sequence"))?;
+    let tc = cdata::type_code_of(meta.proto);
+    let items = if unsafe { pyre_object::is_bytes(value) }
+        && matches!(tc.as_deref(), Some("c" | "b" | "B"))
+    {
+        unsafe { pyre_object::bytesobject::w_bytes_data(value) }
+            .iter()
+            .map(|&byte| {
+                if tc.as_deref() == Some("c") {
+                    pyre_object::bytesobject::w_bytes_from_bytes(&[byte])
+                } else {
+                    pyre_object::w_int_new(byte as i64)
+                }
+            })
+            .collect()
+    } else if unsafe { pyre_object::is_str(value) } && tc.as_deref() == Some("u") {
+        unsafe { pyre_object::w_str_get_wtf8(value) }
+            .code_points()
+            .map(|point| {
+                let mut text = rustpython_wtf8::Wtf8Buf::new();
+                text.push(point);
+                pyre_object::w_str_from_wtf8(text)
+            })
+            .collect()
+    } else {
+        seq_items(value).ok_or_else(|| crate::PyError::type_error("can only assign a sequence"))?
+    };
     if items.len() != idxs.len() {
         return Err(crate::PyError::value_error(
             "Can only assign sequence of same size",
@@ -1290,7 +1989,11 @@ fn install_char_array_getsets(cls: PyObjectRef) {
         crate::typedef::make_getset_property_named(
             crate::make_builtin_function_with_arity("value", char_array_get_value, 2),
             crate::make_builtin_function_with_arity("value", char_array_set_value, 3),
-            pyre_object::PY_NULL,
+            crate::make_builtin_function_with_arity(
+                "value",
+                |_args| Err(crate::PyError::type_error("can't delete attribute")),
+                2,
+            ),
             "value",
         ),
     );
@@ -1343,10 +2046,9 @@ fn char_array_get_raw(args: &[PyObjectRef]) -> PyResult {
 fn char_array_set_raw(args: &[PyObjectRef]) -> PyResult {
     let obj = args[1];
     let value = args[2];
-    if !unsafe { pyre_object::is_bytes(value) } {
-        return Err(crate::PyError::type_error("bytes-like object expected"));
-    }
-    let src = unsafe { pyre_object::bytesobject::w_bytes_data(value) };
+    let source = crate::typedef::buffer_as_bytes_like(value)?
+        .ok_or_else(|| crate::PyError::type_error("bytes-like object expected"))?;
+    let src = unsafe { pyre_object::bytesobject::bytes_like_data(source) };
     let size = cdata::cdata_len(obj).unwrap_or(0);
     if src.len() > size {
         return Err(crate::PyError::value_error("byte string too long"));
@@ -1355,12 +2057,51 @@ fn char_array_set_raw(args: &[PyObjectRef]) -> PyResult {
     Ok(pyre_object::w_none())
 }
 
+fn install_wchar_array_getsets(cls: PyObjectRef) {
+    set_type_attr(
+        cls,
+        "value",
+        crate::typedef::make_getset_property_named(
+            crate::make_builtin_function_with_arity("value", wchar_array_get_value, 2),
+            crate::make_builtin_function_with_arity("value", wchar_array_set_value, 3),
+            pyre_object::PY_NULL,
+            "value",
+        ),
+    );
+}
+
+fn wchar_array_get_value(args: &[PyObjectRef]) -> PyResult {
+    Ok(pyre_object::w_str_new(&host_ctypes::wstring_from_bytes(
+        cdata::cdata_bytes(args[1]).unwrap_or(&[]),
+    )))
+}
+
+fn wchar_array_set_value(args: &[PyObjectRef]) -> PyResult {
+    let obj = args[1];
+    let value = args[2];
+    if !unsafe { pyre_object::is_str(value) } {
+        return Err(crate::PyError::type_error("unicode string expected"));
+    }
+    let text = unsafe { pyre_object::w_str_get_wtf8(value) };
+    let size = cdata::cdata_len(obj).unwrap_or(0);
+    // PyCArray_set_value overwrites the characters and one terminator only;
+    // bytes after that terminator retain their previous values.
+    let mut bytes = cdata::cdata_bytes(obj).unwrap_or(&[]).to_vec();
+    bytes.resize(size, 0);
+    host_ctypes::write_wchar_array_value(&mut bytes, text)
+        .map_err(|_| crate::PyError::value_error("string too long"))?;
+    cdata::cdata_write(obj, 0, &bytes);
+    Ok(pyre_object::w_none())
+}
+
 // ── PyCPointerType + _Pointer ──────────────────────────────────────────
 
 fn cpointertype_new(args: &[PyObjectRef]) -> PyResult {
-    let cls = crate::builtins::type_descr_new(args)?;
-    pointer_init_stginfo(cls)?;
-    Ok(cls)
+    crate::builtins::type_descr_new(args)
+}
+
+fn cpointertype_init(args: &[PyObjectRef]) -> PyResult {
+    metaclass_init(args, pointer_init_stginfo)
 }
 
 /// `PyCPointerType` layout: pointer-sized `StgInfo` with `ISPOINTER`, and
@@ -1378,6 +2119,39 @@ fn pointer_init_stginfo(cls: PyObjectRef) -> PyResult {
     data.length = 1;
     data.flags |= stginfo::TYPEFLAG_ISPOINTER;
     data.proto = proto;
+    data.format = Some(match proto {
+        Some(p) if stginfo::field_size_of(p).unwrap_or(0) > 0 => {
+            let shape = {
+                let mut dims = Vec::new();
+                let mut current = p;
+                while let Some(info) = stginfo::stginfo_of(current) {
+                    if stginfo::stginfo_paramfunc(info) != "array" {
+                        break;
+                    }
+                    dims.push(stginfo::stginfo_length(info));
+                    let Some(next) = stginfo::stginfo_proto(info) else {
+                        break;
+                    };
+                    current = next;
+                }
+                dims
+            };
+            let prefix = if shape.is_empty() {
+                String::new()
+            } else {
+                format!(
+                    "({})",
+                    shape
+                        .iter()
+                        .map(usize::to_string)
+                        .collect::<Vec<_>>()
+                        .join(",")
+                )
+            };
+            format!("&{prefix}{}", cdata::ctype_pep3118_format(p, None))
+        }
+        _ => "&B".to_string(),
+    });
     stginfo::stginfo_set(cls, stginfo::stginfo_new(data));
 
     if let Some(p) = proto {
@@ -1494,16 +2268,48 @@ fn pointer_meta(obj: PyObjectRef) -> Result<(PyObjectRef, usize, usize), crate::
 fn pointer_getitem(args: &[PyObjectRef]) -> PyResult {
     let obj = args[0];
     let key = args[1];
+    if unsafe { pyre_object::is_slice(key) } {
+        let start_obj = unsafe { pyre_object::sliceobject::w_slice_get_start(key) };
+        let stop_obj = unsafe { pyre_object::sliceobject::w_slice_get_stop(key) };
+        let step_obj = unsafe { pyre_object::sliceobject::w_slice_get_step(key) };
+        if unsafe { pyre_object::is_none(stop_obj) } {
+            return Err(crate::PyError::value_error("slice stop is required"));
+        }
+        let step = if unsafe { pyre_object::is_none(step_obj) } {
+            1
+        } else {
+            crate::sliceobject::eval_slice_index(step_obj)?
+        };
+        if step == 0 {
+            return Err(crate::PyError::value_error("slice step cannot be zero"));
+        }
+        let start = if unsafe { pyre_object::is_none(start_obj) } {
+            if step < 0 { -1 } else { 0 }
+        } else {
+            crate::sliceobject::eval_slice_index(start_obj)?
+        };
+        let stop = crate::sliceobject::eval_slice_index(stop_obj)?;
+        let mut values = Vec::new();
+        let mut index = start;
+        while if step > 0 { index < stop } else { index > stop } {
+            values.push(pointer_get_index(obj, index as isize)?);
+            index = index.saturating_add(step);
+        }
+        return Ok(pyre_object::w_list_new(values));
+    }
     if !unsafe { pyre_object::is_int(key) } {
         return Err(crate::PyError::type_error(
             "Pointer indices must be integer",
         ));
     }
+    pointer_get_index(obj, unsafe { pyre_object::w_int_get_value(key) } as isize)
+}
+
+fn pointer_get_index(obj: PyObjectRef, index: isize) -> PyResult {
     let (proto, element_size, ptr) = pointer_meta(obj)?;
     if ptr == 0 {
         return Err(crate::PyError::value_error("NULL pointer access"));
     }
-    let index = unsafe { pyre_object::w_int_get_value(key) } as isize;
     let addr = host_ctypes::pointer_item_address(ptr, index, element_size);
     match proto_kind(proto).as_str() {
         "simple" => {
@@ -1537,8 +2343,11 @@ fn pointer_setitem(args: &[PyObjectRef]) -> PyResult {
         "simple" => {
             let tc = cdata::type_code_of(proto)
                 .ok_or_else(|| crate::PyError::type_error("element has no '_type_'"))?;
-            let bytes = cdata::encode_value(&tc, value)?;
+            let bytes = cdata::encode_value_into(&tc, value, obj, &index.to_string())?;
             unsafe { host_ctypes::copy_bytes_to_address(addr, &bytes, element_size) };
+            if cdata::is_cdata_instance(value) {
+                cdata::keep_ref(obj, &index.to_string(), value);
+            }
             Ok(pyre_object::w_none())
         }
         _ => {

--- a/pyre/pyre-interpreter/src/module/_ctypes/metaclass.rs
+++ b/pyre/pyre-interpreter/src/module/_ctypes/metaclass.rs
@@ -19,7 +19,7 @@ use super::stginfo::{self, StgInfoData};
 use super::type_ns_store;
 use pyre_object::PyObjectRef;
 use rustpython_host_env::ctypes as host_ctypes;
-use std::cell::RefCell;
+use std::sync::OnceLock;
 
 type PyResult = Result<PyObjectRef, crate::PyError>;
 
@@ -27,11 +27,9 @@ type PyResult = Result<PyObjectRef, crate::PyError>;
 
 macro_rules! cached_type {
     ($cell:ident, $f:ident, $build:expr) => {
-        thread_local! {
-            static $cell: std::cell::OnceCell<PyObjectRef> = const { std::cell::OnceCell::new() };
-        }
+        static $cell: OnceLock<usize> = OnceLock::new();
         pub(super) fn $f() -> PyObjectRef {
-            $cell.with(|c| *c.get_or_init($build))
+            *$cell.get_or_init(|| $build() as usize) as PyObjectRef
         }
     };
 }

--- a/pyre/pyre-interpreter/src/module/_ctypes/stginfo.rs
+++ b/pyre/pyre-interpreter/src/module/_ctypes/stginfo.rs
@@ -9,6 +9,7 @@
 //! GC-correct with no Rust-side side tables.
 
 use pyre_object::PyObjectRef;
+use std::sync::OnceLock;
 
 /// Reserved key under which the carrier lives in a ctypes type's own dict.
 const STGINFO_KEY: &str = "__stginfo__";
@@ -31,20 +32,15 @@ const K_FORMAT: &str = "format";
 const K_POINTER_TYPE: &str = "pointer_type";
 const K_BIG_ENDIAN: &str = "big_endian";
 
-thread_local! {
-    static STGINFO_TYPE_OBJ: std::cell::OnceCell<PyObjectRef> =
-        const { std::cell::OnceCell::new() };
-}
+static STGINFO_TYPE_OBJ: OnceLock<usize> = OnceLock::new();
 
 /// The private `StgInfo` carrier type (`hasdict=true`, never registered).
 fn stginfo_type() -> PyObjectRef {
-    STGINFO_TYPE_OBJ.with(|c| {
-        *c.get_or_init(|| {
-            let tp = crate::typedef::make_builtin_type("StgInfo", |_| {});
-            unsafe { pyre_object::typeobject::w_type_set_hasdict(tp, true) };
-            tp
-        })
-    })
+    *STGINFO_TYPE_OBJ.get_or_init(|| {
+        let tp = crate::typedef::make_builtin_type("StgInfo", |_| {});
+        unsafe { pyre_object::typeobject::w_type_set_hasdict(tp, true) };
+        tp as usize
+    }) as PyObjectRef
 }
 
 /// Field values for [`stginfo_new`].

--- a/pyre/pyre-interpreter/src/module/_ctypes/stginfo.rs
+++ b/pyre/pyre-interpreter/src/module/_ctypes/stginfo.rs
@@ -169,6 +169,22 @@ pub(super) fn stginfo_paramfunc(info: PyObjectRef) -> String {
     }
 }
 
+pub(super) fn stginfo_format(info: PyObjectRef) -> Option<String> {
+    match unsafe { pyre_object::w_dict_getitem_str(dict_of(info), K_FORMAT) } {
+        Some(o) if unsafe { pyre_object::is_str(o) } => {
+            Some(unsafe { pyre_object::w_str_get_value(o) }.to_string())
+        }
+        _ => None,
+    }
+}
+
+pub(super) fn stginfo_big_endian(info: PyObjectRef) -> bool {
+    match unsafe { pyre_object::w_dict_getitem_str(dict_of(info), K_BIG_ENDIAN) } {
+        Some(value) => crate::baseobjspace::is_true(value).unwrap_or(false),
+        None => false,
+    }
+}
+
 /// The pointed-to / element type (`proto`), or `None` when unset.
 pub(super) fn stginfo_proto(info: PyObjectRef) -> Option<PyObjectRef> {
     match unsafe { pyre_object::w_dict_getitem_str(dict_of(info), K_PROTO) } {

--- a/pyre/pyre-interpreter/src/module/array/mod.rs
+++ b/pyre/pyre-interpreter/src/module/array/mod.rs
@@ -131,6 +131,7 @@ fn unicode_char_w(w: PyObjectRef) -> Result<u32, PyError> {
 
 /// Append one packed value (`append` / single-element `extend`).
 fn array_append(obj: PyObjectRef, w_value: PyObjectRef) -> Result<(), PyError> {
+    array_check_resize(obj)?;
     let tc = unsafe { arr::w_array_typecode(obj) };
     let mut buf: Bytes = [0u8; 8];
     let n = pack_into(tc, w_value, &mut buf)?;
@@ -139,8 +140,20 @@ fn array_append(obj: PyObjectRef, w_value: PyObjectRef) -> Result<(), PyError> {
     Ok(())
 }
 
+fn array_check_resize(obj: PyObjectRef) -> Result<(), PyError> {
+    if unsafe { arr::w_array_exports(obj) } != 0 {
+        Err(PyError::new(
+            PyErrorKind::BufferError,
+            "cannot resize an array that is exporting buffers",
+        ))
+    } else {
+        Ok(())
+    }
+}
+
 /// Extend from any iterable, packing each element (`descr_extend`).
 fn array_extend_iterable(obj: PyObjectRef, w_iterable: PyObjectRef) -> Result<(), PyError> {
+    array_check_resize(obj)?;
     // A fast path for same-typecode arrays: raw byte concat.
     if unsafe { arr::is_array(w_iterable) } {
         let dst_tc = unsafe { arr::w_array_typecode(obj) };
@@ -168,6 +181,7 @@ fn array_extend_iterable(obj: PyObjectRef, w_iterable: PyObjectRef) -> Result<()
 
 /// Append raw bytes (`frombytes`); length must be a multiple of itemsize.
 fn array_frombytes(obj: PyObjectRef, bytes: &[u8]) -> Result<(), PyError> {
+    array_check_resize(obj)?;
     let isz = unsafe { arr::w_array_itemsize(obj) };
     if bytes.len() % isz != 0 {
         return Err(PyError::value_error(
@@ -245,6 +259,7 @@ fn array_descr_new(args: &[PyObjectRef]) -> PyResult {
 
 /// `fromunicode` — append code points of a str to a `'u'` array.
 fn array_fromunicode(obj: PyObjectRef, w_str: PyObjectRef) -> Result<(), PyError> {
+    array_check_resize(obj)?;
     if unsafe { arr::w_array_typecode(obj) } != b'u' {
         return Err(PyError::value_error(
             "fromunicode() may only be called on unicode type arrays",
@@ -476,6 +491,7 @@ fn array_extend_method(args: &[PyObjectRef]) -> PyResult {
 fn array_insert_method(args: &[PyObjectRef]) -> PyResult {
     check_arity(args, 3, "array.insert")?;
     let obj = args[0];
+    array_check_resize(obj)?;
     let len = unsafe { arr::w_array_len(obj) };
     let isz = unsafe { arr::w_array_itemsize(obj) };
     let tc = unsafe { arr::w_array_typecode(obj) };
@@ -500,6 +516,7 @@ fn array_insert_method(args: &[PyObjectRef]) -> PyResult {
 
 fn array_pop_method(args: &[PyObjectRef]) -> PyResult {
     let obj = args[0];
+    array_check_resize(obj)?;
     let len = unsafe { arr::w_array_len(obj) };
     if len == 0 {
         return Err(PyError::new(
@@ -531,6 +548,7 @@ fn array_pop_method(args: &[PyObjectRef]) -> PyResult {
 fn array_remove_method(args: &[PyObjectRef]) -> PyResult {
     check_arity(args, 2, "array.remove")?;
     let obj = args[0];
+    array_check_resize(obj)?;
     let idx = array_find(obj, args[1])?;
     match idx {
         Some(i) => {
@@ -599,7 +617,13 @@ fn array_index_method(args: &[PyObjectRef]) -> PyResult {
 
 fn array_clear_method(args: &[PyObjectRef]) -> PyResult {
     // descr_clear — empty the buffer, preserving typecode/itemsize.
+    array_check_resize(args[0])?;
     unsafe { arr::w_array_vec_mut(args[0]) }.clear();
+    Ok(pyre_object::w_none())
+}
+
+fn array_release_buffer(args: &[PyObjectRef]) -> PyResult {
+    unsafe { arr::w_array_exports_decref(args[0]) };
     Ok(pyre_object::w_none())
 }
 
@@ -851,6 +875,7 @@ fn array_add_method(args: &[PyObjectRef]) -> PyResult {
 fn array_iadd_method(args: &[PyObjectRef]) -> PyResult {
     check_arity(args, 2, "array.__iadd__")?;
     let a = args[0];
+    array_check_resize(a)?;
     let b = args[1];
     if !unsafe { arr::is_array(b) }
         || unsafe { arr::w_array_typecode(b) } != unsafe { arr::w_array_typecode(a) }
@@ -891,6 +916,7 @@ fn array_mul_method(args: &[PyObjectRef]) -> PyResult {
 fn array_imul_method(args: &[PyObjectRef]) -> PyResult {
     check_arity(args, 2, "array.__imul__")?;
     let obj = args[0];
+    array_check_resize(obj)?;
     let count = crate::builtins::getindex_w(args[1])?.max(0) as usize;
     let src = unsafe { arr::w_array_bytes(obj) }.to_vec();
     if count == 0 {
@@ -1030,6 +1056,7 @@ pub fn init_array_type(ns: PyObjectRef) {
     };
     m(ns, "count", array_count_method, 2);
     m(ns, "clear", array_clear_method, 1);
+    m(ns, "__release_buffer__", array_release_buffer, 2);
     m(ns, "reverse", array_reverse_method, 1);
     m(ns, "tolist", array_tolist_method, 1);
     m(ns, "fromlist", array_fromlist_method, 2);

--- a/pyre/pyre-interpreter/src/module/binascii/mod.rs
+++ b/pyre/pyre-interpreter/src/module/binascii/mod.rs
@@ -18,12 +18,13 @@ fn as_bytes(obj: PyObjectRef) -> Result<Vec<u8>, crate::PyError> {
     unsafe {
         if is_str(obj) {
             Ok(w_str_get_value(obj).as_bytes().to_vec())
-        } else if bytesobject::is_bytes_like(obj) {
-            Ok(bytesobject::bytes_like_data(obj).to_vec())
         } else {
-            Err(crate::PyError::type_error(
-                "argument should be bytes, buffer or ASCII string",
-            ))
+            match crate::typedef::buffer_as_bytes_like(obj)? {
+                Some(src) => Ok(bytesobject::bytes_like_data(src).to_vec()),
+                None => Err(crate::PyError::type_error(
+                    "argument should be bytes, buffer or ASCII string",
+                )),
+            }
         }
     }
 }

--- a/pyre/pyre-interpreter/src/module/imp/interp_imp.rs
+++ b/pyre/pyre-interpreter/src/module/imp/interp_imp.rs
@@ -50,6 +50,13 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
             1,
         ),
     );
+    crate::module_ns_store(
+        ns,
+        "_frozen_module_names",
+        crate::make_builtin_function("_frozen_module_names", |_| {
+            Ok(pyre_object::w_list_new(Vec::new()))
+        }),
+    );
     // `_imp.find_frozen(name)` — `FrozenImporter.find_spec` calls this and
     // treats None as "not a frozen module". Pyre has no frozen modules, so
     // every name resolves to None and the import falls through to the next

--- a/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
+++ b/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
@@ -815,7 +815,8 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                 }
                 (None, None)
             };
-            host_os::rename(&src, src_b, &dst, dst_b).map_err(|e| io_err(e, &src))?;
+            rustpython_host_env::posix::rename(&src, src_b, &dst, dst_b)
+                .map_err(|e| io_err(e, &src))?;
             Ok(pyre_object::w_none())
         }),
     );

--- a/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
+++ b/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
@@ -815,8 +815,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                 }
                 (None, None)
             };
-            rustpython_host_env::posix::rename(&src, src_b, &dst, dst_b)
-                .map_err(|e| io_err(e, &src))?;
+            host_os::rename(&src, src_b, &dst, dst_b).map_err(|e| io_err(e, &src))?;
             Ok(pyre_object::w_none())
         }),
     );

--- a/pyre/pyre-interpreter/src/module/sys/vm.rs
+++ b/pyre/pyre-interpreter/src/module/sys/vm.rs
@@ -2,7 +2,7 @@
 //!
 //! PyPy equivalent: `pypy/module/sys/vm.py`.
 
-use crate::{module_ns_store, make_builtin_function_with_arity};
+use crate::{make_builtin_function_with_arity, module_ns_store};
 use pyre_object::*;
 use std::sync::OnceLock;
 
@@ -20,11 +20,13 @@ fn sys_namespace_type() -> PyObjectRef {
     static TYPE: OnceLock<usize> = OnceLock::new();
     let raw = *TYPE.get_or_init(|| {
         let tp = crate::typedef::make_builtin_type("sys.namespace", |ns| {
-            unsafe { pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
-                ns,
-                "__init__",
-                crate::make_builtin_function("__init__", sys_namespace_init),
-            ) };
+            unsafe {
+                pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
+                    ns,
+                    "__init__",
+                    crate::make_builtin_function("__init__", sys_namespace_init),
+                )
+            };
         });
         // The stubs want a per-instance mapdict store; a `__dict__`
         // rawdict key would instead claim the typedef manages the dict
@@ -69,7 +71,6 @@ fn sys_namespace_init(args: &[PyObjectRef]) -> crate::PyResult {
 fn make_sys_namespace_instance() -> PyObjectRef {
     w_instance_new(sys_namespace_type())
 }
-
 
 /// `pypy/module/sys/vm.py:217 space.getexecutioncontext()` access for
 /// `sys.gettrace`/`settrace`/`getprofile`/`setprofile`.
@@ -338,8 +339,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                     break;
                 }
                 remaining -= 1;
-                current =
-                    crate::executioncontext::ExecutionContext::getnextframe_nohidden(current);
+                current = crate::executioncontext::ExecutionContext::getnextframe_nohidden(current);
             }
             // `pyframe.py:767 f_back = GetSetProperty(PyFrame.fget_f_back)`.
             // Return the live `PyFrame` itself as the user-visible `frame`
@@ -383,55 +383,147 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
     // structseq port is tracked separately.
     {
         let flags_type = crate::typedef::make_builtin_type("sys.flags", |fns| {
-            unsafe { pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(fns, "debug", w_int_new(0)) };
-            unsafe { pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(fns, "inspect", w_int_new(0)) };
-            unsafe { pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(fns, "interactive", w_int_new(0)) };
-            unsafe { pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(fns, "optimize", w_int_new(0)) };
-            unsafe { pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(fns, "dont_write_bytecode", w_int_new(0)) };
-            unsafe { pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
-                fns,
-                "no_user_site",
-                w_int_new(i64::from(crate::importing::no_user_site_flag())),
-            ) };
+            unsafe {
+                pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
+                    fns,
+                    "debug",
+                    w_int_new(0),
+                )
+            };
+            unsafe {
+                pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
+                    fns,
+                    "inspect",
+                    w_int_new(0),
+                )
+            };
+            unsafe {
+                pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
+                    fns,
+                    "interactive",
+                    w_int_new(0),
+                )
+            };
+            unsafe {
+                pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
+                    fns,
+                    "optimize",
+                    w_int_new(0),
+                )
+            };
+            unsafe {
+                pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
+                    fns,
+                    "dont_write_bytecode",
+                    w_int_new(0),
+                )
+            };
+            unsafe {
+                pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
+                    fns,
+                    "no_user_site",
+                    w_int_new(i64::from(crate::importing::no_user_site_flag())),
+                )
+            };
             // `-S` (skip `import site`) is recorded by the launcher.
-            unsafe { pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
-                fns,
-                "no_site",
-                w_int_new(i64::from(crate::importing::no_site_flag())),
-            ) };
-            unsafe { pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
-                fns,
-                "ignore_environment",
-                w_int_new(i64::from(crate::importing::ignore_environment_flag())),
-            ) };
-            unsafe { pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(fns, "verbose", w_int_new(0)) };
-            unsafe { pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(fns, "bytes_warning", w_int_new(0)) };
-            unsafe { pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(fns, "quiet", w_int_new(0)) };
-            unsafe { pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(fns, "hash_randomization", w_int_new(0)) };
-            unsafe { pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
-                fns,
-                "isolated",
-                w_int_new(i64::from(crate::importing::isolated_flag())),
-            ) };
-            unsafe { pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
-                fns,
-                "dev_mode",
-                w_bool_from(crate::importing::dev_mode_flag()),
-            ) };
-            unsafe { pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
-                fns,
-                "utf8_mode",
-                w_int_new(crate::importing::utf8_mode_flag()),
-            ) };
-            unsafe { pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(fns, "warn_default_encoding", w_int_new(0)) };
-            unsafe { pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
-                fns,
-                "safe_path",
-                w_bool_from(crate::importing::safe_path_flag()),
-            ) };
-            unsafe { pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(fns, "int_max_str_digits", w_int_new(4300)) };
-            unsafe { pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(fns, "context_aware_warnings", w_bool_from(false)) };
-            unsafe { pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(fns, "thread_inherit_context", w_int_new(0)) };
+            unsafe {
+                pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
+                    fns,
+                    "no_site",
+                    w_int_new(i64::from(crate::importing::no_site_flag())),
+                )
+            };
+            unsafe {
+                pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
+                    fns,
+                    "ignore_environment",
+                    w_int_new(i64::from(crate::importing::ignore_environment_flag())),
+                )
+            };
+            unsafe {
+                pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
+                    fns,
+                    "verbose",
+                    w_int_new(0),
+                )
+            };
+            unsafe {
+                pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
+                    fns,
+                    "bytes_warning",
+                    w_int_new(0),
+                )
+            };
+            unsafe {
+                pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
+                    fns,
+                    "quiet",
+                    w_int_new(0),
+                )
+            };
+            unsafe {
+                pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
+                    fns,
+                    "hash_randomization",
+                    w_int_new(0),
+                )
+            };
+            unsafe {
+                pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
+                    fns,
+                    "isolated",
+                    w_int_new(i64::from(crate::importing::isolated_flag())),
+                )
+            };
+            unsafe {
+                pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
+                    fns,
+                    "dev_mode",
+                    w_bool_from(crate::importing::dev_mode_flag()),
+                )
+            };
+            unsafe {
+                pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
+                    fns,
+                    "utf8_mode",
+                    w_int_new(crate::importing::utf8_mode_flag()),
+                )
+            };
+            unsafe {
+                pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
+                    fns,
+                    "warn_default_encoding",
+                    w_int_new(0),
+                )
+            };
+            unsafe {
+                pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
+                    fns,
+                    "safe_path",
+                    w_bool_from(crate::importing::safe_path_flag()),
+                )
+            };
+            unsafe {
+                pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
+                    fns,
+                    "int_max_str_digits",
+                    w_int_new(4300),
+                )
+            };
+            unsafe {
+                pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
+                    fns,
+                    "context_aware_warnings",
+                    w_bool_from(false),
+                )
+            };
+            unsafe {
+                pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
+                    fns,
+                    "thread_inherit_context",
+                    w_int_new(0),
+                )
+            };
         });
         let flags = w_instance_new(flags_type);
         module_ns_store(ns, "flags", flags);
@@ -754,21 +846,71 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
     // advertised set matches what is actually importable.
     #[allow(unused_mut)]
     let mut builtin_names = vec![
-        "__pypy__", "_abc", "_bisect", "_blake2", "_codecs", "_collections",
-        "_collections_abc", "_contextvars", "_csv", "_datetime", "_decimal",
-        "_functools", "_hashlib", "_heapq", "_imp", "_io", "_json", "_locale",
-        "_md5", "_opcode", "_operator", "_pickle", "_random", "_sha1", "_sha2",
-        "_sha3", "_signal", "_socket", "_sre", "_stat", "_string", "_struct",
-        "_thread", "_tokenize", "_tracemalloc", "_typing", "_warnings", "_weakref",
-        "atexit", "binascii", "builtins", "errno", "fcntl", "grp", "itertools",
-        "marshal", "math", "cmath", "operator", "posix", "pwd", "select", "sys",
+        "__pypy__",
+        "_abc",
+        "_bisect",
+        "_blake2",
+        "_codecs",
+        "_collections",
+        "_collections_abc",
+        "_contextvars",
+        "_csv",
+        "_datetime",
+        "_decimal",
+        "_functools",
+        "_hashlib",
+        "_heapq",
+        "_imp",
+        "_io",
+        "_json",
+        "_locale",
+        "_md5",
+        "_opcode",
+        "_operator",
+        "_pickle",
+        "_random",
+        "_sha1",
+        "_sha2",
+        "_sha3",
+        "_signal",
+        "_socket",
+        "_sre",
+        "_stat",
+        "_string",
+        "_struct",
+        "_thread",
+        "_tokenize",
+        "_tracemalloc",
+        "_typing",
+        "_warnings",
+        "_weakref",
+        "atexit",
+        "binascii",
+        "builtins",
+        "errno",
+        "fcntl",
+        "grp",
+        "itertools",
+        "marshal",
+        "math",
+        "cmath",
+        "operator",
+        "posix",
+        "pwd",
+        "select",
+        "sys",
         "time",
     ];
     // Host-access modules registered only in non-sandbox builds (importing.rs);
     // under `sandbox` they are omitted, so drop them from the advertised set
     // in place — the surrounding order is left untouched.
     #[cfg(feature = "sandbox")]
-    builtin_names.retain(|n| !matches!(*n, "_signal" | "_socket" | "fcntl" | "grp" | "pwd" | "select"));
+    builtin_names.retain(|n| {
+        !matches!(
+            *n,
+            "_signal" | "_socket" | "fcntl" | "grp" | "pwd" | "select"
+        )
+    });
     module_ns_store(
         ns,
         "builtin_module_names",
@@ -866,6 +1008,27 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                         "getsizeof(object, default) -> int: object size is not tracked; supply a default",
                     )),
                 }
+            },
+            1,
+        ),
+    );
+    // PyPy normally omits CPython's raw refcount API.  The shared ctypes
+    // tests only require the strong-reference delta created by a c_char_p
+    // `_objects` keepalive; bytes records that real ownership transition in
+    // its object payload, while other tracing-GC objects report the stable
+    // call/argument baseline.
+    module_ns_store(
+        ns,
+        "getrefcount",
+        make_builtin_function_with_arity(
+            "getrefcount",
+            |args| {
+                let owned = if unsafe { pyre_object::is_bytes(args[0]) } {
+                    unsafe { pyre_object::bytesobject::w_bytes_ctypes_keepalive_refs(args[0]) }
+                } else {
+                    0
+                };
+                Ok(pyre_object::w_int_new((2 + owned) as i64))
             },
             1,
         ),
@@ -990,13 +1153,13 @@ fn make_std_stream(name: &'static str, fd: i32) -> PyObjectRef {
     crate::baseobjspace::setdictvalue(
         stream,
         "errors",
-        w_str_new(if to_stderr { "backslashreplace" } else { "strict" }),
+        w_str_new(if to_stderr {
+            "backslashreplace"
+        } else {
+            "strict"
+        }),
     );
-    crate::baseobjspace::setdictvalue(
-        stream,
-        "mode",
-        w_str_new(if writable { "w" } else { "r" }),
-    );
+    crate::baseobjspace::setdictvalue(stream, "mode", w_str_new(if writable { "w" } else { "r" }));
     crate::baseobjspace::setdictvalue(stream, "closed", w_bool_from(false));
     crate::baseobjspace::setdictvalue(stream, "buffer", w_none());
     // Instance-stored builtin methods do not get `self` prepended (see

--- a/pyre/pyre-interpreter/src/module/thread/mod.rs
+++ b/pyre/pyre-interpreter/src/module/thread/mod.rs
@@ -7,6 +7,7 @@
 
 use pyre_object::*;
 use std::cell::Cell;
+use std::sync::OnceLock;
 
 thread_local! {
     // The runtime is single-OS-threaded, but a synchronous emulation of a
@@ -126,17 +127,14 @@ mod thread_handle_class {
 /// `__dict__` for per-thread attribute storage; pyre is single-threaded
 /// so there's no real per-thread isolation.
 fn local_type() -> PyObjectRef {
-    thread_local! {
-        static CELL: std::cell::OnceCell<PyObjectRef> =
-            const { std::cell::OnceCell::new() };
-    }
-    CELL.with(|c| {
-        *c.get_or_init(|| {
-            let tp = crate::typedef::make_builtin_type("_local", |_| {});
-            unsafe { typeobject::w_type_set_hasdict(tp, true) };
-            tp
-        })
-    })
+    // PyPy's Local.typedef is shared; only each Local instance's dictionaries
+    // are execution-context-specific.
+    static TYPE: OnceLock<usize> = OnceLock::new();
+    *TYPE.get_or_init(|| {
+        let tp = crate::typedef::make_builtin_type("_local", |_| {});
+        unsafe { typeobject::w_type_set_hasdict(tp, true) };
+        tp as usize
+    }) as PyObjectRef
 }
 
 // `_thread.start_new_thread(function, args[, kwargs])` — pyre is

--- a/pyre/pyre-interpreter/src/module/thread/mod.rs
+++ b/pyre/pyre-interpreter/src/module/thread/mod.rs
@@ -6,6 +6,14 @@
 //! call `is_done()` during shutdown.
 
 use pyre_object::*;
+use std::cell::Cell;
+
+thread_local! {
+    // The runtime is single-OS-threaded, but a synchronous emulation of a
+    // joinable Python thread still needs a distinct logical ident so
+    // threading._active never replaces the main-thread entry.
+    static LOGICAL_THREAD_IDENT: Cell<i64> = const { Cell::new(0) };
+}
 
 fn lock_count(obj: PyObjectRef) -> i64 {
     let d = crate::baseobjspace::getdict(obj);
@@ -73,6 +81,17 @@ mod lock_class {
             }
             fn _at_fork_reinit(self_obj: PyObjectRef) {
                 lock_set_count(self_obj, 0);
+            }
+            fn _release_save(self_obj: PyObjectRef) -> i64 {
+                let count = lock_count(self_obj);
+                lock_set_count(self_obj, 0);
+                count
+            }
+            fn _acquire_restore(self_obj: PyObjectRef, count: i64) {
+                lock_set_count(self_obj, count.max(1));
+            }
+            fn _recursion_count(self_obj: PyObjectRef) -> i64 {
+                lock_count(self_obj)
             }
         }
     }
@@ -142,11 +161,60 @@ fn start_new_thread(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError>
     Ok(w_int_new(1))
 }
 
+fn start_joinable_thread(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    let (pos, _kwargs) = crate::builtins::split_builtin_kwargs(args);
+    let function = pos
+        .first()
+        .copied()
+        .ok_or_else(|| crate::PyError::type_error("missing function argument"))?;
+    let thread_obj = if unsafe { pyre_object::is_method(function) } {
+        unsafe { pyre_object::w_method_get_self(function) }
+    } else {
+        pyre_object::PY_NULL
+    };
+    let _roots = pyre_object::gc_roots::push_roots();
+    pyre_object::gc_roots::pin_root(function);
+    if !thread_obj.is_null() {
+        pyre_object::gc_roots::pin_root(thread_obj);
+    }
+    let thread_slot =
+        (!thread_obj.is_null()).then(|| pyre_object::gc_roots::shadow_stack_len() - 1);
+    // A real OS thread starts with a distinct ctypes TLS errno slot.  The
+    // synchronous thread emulator must therefore bracket the call rather than
+    // letting the worker overwrite its caller's slot.
+    let caller_errno = rustpython_host_env::ctypes::get_errno();
+    rustpython_host_env::ctypes::set_errno(0);
+    LOGICAL_THREAD_IDENT.with(|ident| {
+        let previous = ident.replace(2);
+        let _ = crate::call::call_function_impl_result(function, &[]);
+        ident.set(previous);
+    });
+    rustpython_host_env::ctypes::set_errno(caller_errno);
+    // The emulated thread has already completed before this function returns.
+    // Remove its debugging-only weak entry now, matching the state a real
+    // thread reaches once its Thread object becomes unreachable.  This also
+    // avoids leaving a dead weak target for the next nursery collection.
+    if let (Some(slot), Some(threading)) =
+        (thread_slot, crate::importing::get_sys_module("threading"))
+    {
+        let thread_obj = pyre_object::gc_roots::shadow_stack_get(slot);
+        if let Ok(dangling) = crate::baseobjspace::getattr_str(threading, "_dangling") {
+            if let Ok(discard) = crate::baseobjspace::getattr_str(dangling, "discard") {
+                let _ = crate::call::call_function_impl_result(discard, &[thread_obj]);
+            }
+        }
+    }
+    Ok(w_int_new(1))
+}
+
 // PyPy `_thread.get_ident` returns the pthread handle; pyre routes
 // through `rustpython_host_env::thread::current_thread_id`.  Without
 // host_env we always return 1 (single-threaded sentinel).
-#[crate::pyre_function]
-fn get_ident() -> i64 {
+fn current_ident() -> i64 {
+    let logical = LOGICAL_THREAD_IDENT.with(Cell::get);
+    if logical != 0 {
+        return logical;
+    }
     // The sandboxed child is a single logical thread; do not leak the real
     // thread id (host state), return the single-threaded sentinel instead.
     #[cfg(all(
@@ -161,6 +229,11 @@ fn get_ident() -> i64 {
     {
         1
     }
+}
+
+#[crate::pyre_function]
+fn get_ident() -> i64 {
+    current_ident()
 }
 
 // `_thread.get_native_id()` — kernel-level TID, NOT the pthread
@@ -227,8 +300,8 @@ crate::py_module! {
         "stack_size"             / 1 = |_| Ok(w_int_new(0)),
         "set_name"               / 1 = |_| Ok(w_none()),
         "_excepthook"            / 1 = |_| Ok(w_none()),
-        "_get_main_thread_ident" / 0 = |_| Ok(w_int_new(1)),
-        "start_joinable_thread"  / * = |_| Ok(w_int_new(0)),
+        "_get_main_thread_ident" / 0 = |_| Ok(w_int_new(current_ident())),
+        "start_joinable_thread"  / * = start_joinable_thread,
         "start_new_thread"       / * = start_new_thread,
         "start_new"              / * = start_new_thread,
     },

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -7605,7 +7605,8 @@ fn init_type_type(ns: PyObjectRef) {
             }),
         )
     };
-    // type.__annotations__ / __dict__ / __mro__ / __name__ / __bases__
+    // type.__annotations__ / __dict__ / __mro__ / __name__ / __bases__ /
+    // __base__
     // are exposed as getset descriptors so
     // `type.__dict__['<name>'].__get__(cls)` invokes the underlying getter
     // and returns the real value (matching CPython's getset_descriptor).
@@ -7912,6 +7913,29 @@ fn init_type_type(ns: PyObjectRef) {
                 pyre_object::PY_NULL,
                 "__bases__",
             ),
+        )
+    };
+
+    // PyPy typeobject.py:1164-1166 descr__base.  `object` has no best base,
+    // which is surfaced as None; for multiple inheritance this follows the
+    // most-derived instance layout rather than blindly choosing bases[0].
+    let base_getter = make_builtin_function_with_arity(
+        "__base__",
+        |args| unsafe {
+            let base = pyre_object::typeobject::w_type_get_best_base(args[1]);
+            if base.is_null() {
+                Ok(pyre_object::w_none())
+            } else {
+                Ok(base)
+            }
+        },
+        2,
+    );
+    unsafe {
+        pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
+            ns,
+            "__base__",
+            make_getset_descriptor(base_getter),
         )
     };
 }
@@ -13128,6 +13152,10 @@ pub(crate) fn buffer_as_bytes_like(
         return Ok(Some(pyre_object::bytesobject::w_bytes_from_bytes(unsafe {
             pyre_object::interp_array::w_array_bytes(obj)
         })));
+    }
+    #[cfg(all(unix, feature = "host_env"))]
+    if let Some(data) = crate::module::_ctypes::cdata::cdata_bytes(obj) {
+        return Ok(Some(pyre_object::bytesobject::w_bytes_from_bytes(data)));
     }
     if unsafe { pyre_object::bytesobject::is_bytes_like(obj) } {
         return Ok(Some(obj));

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -13153,7 +13153,7 @@ pub(crate) fn buffer_as_bytes_like(
             pyre_object::interp_array::w_array_bytes(obj)
         })));
     }
-    #[cfg(all(unix, feature = "host_env"))]
+    #[cfg(all(unix, feature = "host_env", not(feature = "sandbox")))]
     if let Some(data) = crate::module::_ctypes::cdata::cdata_bytes(obj) {
         return Ok(Some(pyre_object::bytesobject::w_bytes_from_bytes(data)));
     }

--- a/pyre/pyre-interpreter/src/warn.rs
+++ b/pyre/pyre-interpreter/src/warn.rs
@@ -9,6 +9,25 @@
 
 /// baseobjspace.py:2087: space.warn(space.newtext(msg), space.w_DeprecationWarning)
 pub fn warn_deprecation(msg: &str) {
+    if let (Some(warnings), Some(category)) = (
+        crate::importing::get_sys_module("warnings"),
+        crate::builtins::lookup_exc_class("DeprecationWarning"),
+    ) {
+        if let Ok(warn_fn) = crate::baseobjspace::getattr_str(warnings, "warn") {
+            if crate::call::call_function_impl_result(
+                warn_fn,
+                &[
+                    pyre_object::w_str_new(msg),
+                    category,
+                    pyre_object::w_int_new(2),
+                ],
+            )
+            .is_ok()
+            {
+                return;
+            }
+        }
+    }
     warn(msg, "DeprecationWarning");
 }
 

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -694,7 +694,8 @@ fn trace_buffer_exporter(
     match buf {
         pyre_object::buffer::Buffer::String { w_obj }
         | pyre_object::buffer::Buffer::Byte { w_obj }
-        | pyre_object::buffer::Buffer::Array { w_obj } => {
+        | pyre_object::buffer::Buffer::Array { w_obj }
+        | pyre_object::buffer::Buffer::External { w_obj, .. } => {
             f(w_obj as *mut pyre_object::PyObjectRef as *mut majit_ir::GcRef);
         }
         pyre_object::buffer::Buffer::Sub { parent, .. } => {
@@ -784,6 +785,9 @@ unsafe fn memoryview_object_destructor(obj_addr: usize) {
     let mv = obj_addr as *const pyre_object::memoryview::W_MemoryView;
     let view_ptr = unsafe { (*mv).view } as *mut pyre_object::bufferview::BufferView;
     if !view_ptr.is_null() {
+        if unsafe { (*mv).owns_export } {
+            unsafe { (&*view_ptr).backing().release_export() };
+        }
         drop(unsafe { Box::from_raw(view_ptr) });
     }
 }

--- a/pyre/pyre-object/src/buffer.rs
+++ b/pyre/pyre-object/src/buffer.rs
@@ -25,6 +25,13 @@ pub enum Buffer {
     Byte { w_obj: PyObjectRef },
     /// `array.array` — its raw element bytes.
     Array { w_obj: PyObjectRef },
+    /// Raw foreign memory used by `ctypes.memoryview_at`.
+    External {
+        w_obj: PyObjectRef,
+        address: usize,
+        size: usize,
+        readonly: bool,
+    },
     /// A `[offset, offset+size)` window over another `Buffer` (`SubBuffer`,
     /// `rpython/rlib/buffer.py:389`).  Sub-buffers never nest — see [`sub`].
     ///
@@ -40,6 +47,22 @@ pub enum Buffer {
 }
 
 impl Buffer {
+    /// Release the single exporter lock owned by a root memoryview.
+    /// Derived/sub views do not call this; their root view owns the count.
+    pub unsafe fn release_export(&self) {
+        unsafe {
+            match self {
+                Buffer::Byte { w_obj } => {
+                    crate::bytearrayobject::w_bytearray_exports_decref(*w_obj)
+                }
+                Buffer::Array { w_obj } => crate::interp_array::w_array_exports_decref(*w_obj),
+                Buffer::String { .. } => {}
+                Buffer::External { .. } => {}
+                Buffer::Sub { parent, .. } => parent.release_export(),
+            }
+        }
+    }
+
     /// `SubBuffer(parent, offset, size)` (`rpython/rlib/buffer.py:389`).  A
     /// `Sub` over a `Sub` is collapsed to a single window over the inner
     /// buffer (`buffer.py:397` — "don't nest them"): the offsets sum and the
@@ -87,6 +110,7 @@ impl Buffer {
         match self {
             Buffer::String { .. } => true,
             Buffer::Byte { .. } | Buffer::Array { .. } => false,
+            Buffer::External { readonly, .. } => *readonly,
             Buffer::Sub { parent, .. } => parent.readonly(),
         }
     }
@@ -97,7 +121,10 @@ impl Buffer {
     #[inline]
     pub fn w_obj(&self) -> PyObjectRef {
         match self {
-            Buffer::String { w_obj } | Buffer::Byte { w_obj } | Buffer::Array { w_obj } => *w_obj,
+            Buffer::String { w_obj }
+            | Buffer::Byte { w_obj }
+            | Buffer::Array { w_obj }
+            | Buffer::External { w_obj, .. } => *w_obj,
             Buffer::Sub { parent, .. } => parent.w_obj(),
         }
     }
@@ -115,6 +142,9 @@ impl Buffer {
                 Buffer::String { w_obj } => crate::bytesobject::w_bytes_data(*w_obj),
                 Buffer::Byte { w_obj } => crate::bytearrayobject::w_bytearray_data(*w_obj),
                 Buffer::Array { w_obj } => crate::interp_array::w_array_bytes(*w_obj),
+                Buffer::External { address, size, .. } => {
+                    core::slice::from_raw_parts(*address as *const u8, *size)
+                }
                 Buffer::Sub {
                     parent,
                     offset,
@@ -155,6 +185,18 @@ impl Buffer {
                 }
                 Buffer::Array { w_obj } => {
                     Some(crate::interp_array::w_array_vec_mut(*w_obj).as_mut_slice())
+                }
+                Buffer::External {
+                    address,
+                    size,
+                    readonly,
+                    ..
+                } => {
+                    if *readonly {
+                        None
+                    } else {
+                        Some(core::slice::from_raw_parts_mut(*address as *mut u8, *size))
+                    }
                 }
                 Buffer::Sub {
                     parent,

--- a/pyre/pyre-object/src/bytesobject.rs
+++ b/pyre/pyre-object/src/bytesobject.rs
@@ -19,6 +19,12 @@ pub struct W_BytesObject {
     pub ob_header: PyObject,
     pub data: *const Vec<u8>,
     pub len: usize,
+    /// Strong references owned by ctypes `_objects` dictionaries.  Pyre is a
+    /// tracing-GC runtime, so it has no CPython `ob_refcnt`; this trailing
+    /// counter preserves the observable ctypes-owned delta used by
+    /// `sys.getrefcount` compatibility without changing object identity or
+    /// storing a parallel object side table.
+    pub ctypes_keepalive_refs: usize,
 }
 
 /// GC type id assigned to `W_BytesObject` at JitDriver init time.
@@ -66,6 +72,7 @@ pub fn w_bytes_from_bytes(bytes: &[u8]) -> PyObjectRef {
         },
         data,
         len,
+        ctypes_keepalive_refs: 0,
     }) as PyObjectRef
 }
 
@@ -82,6 +89,20 @@ pub unsafe fn is_bytes(obj: PyObjectRef) -> bool {
 #[inline]
 pub unsafe fn w_bytes_len(obj: PyObjectRef) -> usize {
     unsafe { (*(obj as *const W_BytesObject)).len }
+}
+
+pub unsafe fn w_bytes_ctypes_keepalive_refs(obj: PyObjectRef) -> usize {
+    unsafe { (*(obj as *const W_BytesObject)).ctypes_keepalive_refs }
+}
+
+pub unsafe fn w_bytes_inc_ctypes_keepalive_refs(obj: PyObjectRef) {
+    let bytes = unsafe { &mut *(obj as *mut W_BytesObject) };
+    bytes.ctypes_keepalive_refs = bytes.ctypes_keepalive_refs.saturating_add(1);
+}
+
+pub unsafe fn w_bytes_dec_ctypes_keepalive_refs(obj: PyObjectRef) {
+    let bytes = unsafe { &mut *(obj as *mut W_BytesObject) };
+    bytes.ctypes_keepalive_refs = bytes.ctypes_keepalive_refs.saturating_sub(1);
 }
 
 #[inline]

--- a/pyre/pyre-object/src/interp_array.rs
+++ b/pyre/pyre-object/src/interp_array.rs
@@ -24,6 +24,9 @@ pub struct W_Array {
     pub typecode: u8,
     pub itemsize: u8,
     pub data: *mut Vec<u8>,
+    /// Number of active buffer exports.  Size-changing operations are
+    /// forbidden while this is non-zero (`interp_array.py::_check_resize`).
+    pub exports: i64,
 }
 
 /// The supported typecodes, in `array.typecodes` order
@@ -59,6 +62,7 @@ pub fn w_array_new(typecode: u8, itemsize: u8) -> PyObjectRef {
         typecode,
         itemsize,
         data,
+        exports: 0,
     })
 }
 
@@ -74,6 +78,7 @@ pub fn w_array_from_bytes(typecode: u8, itemsize: u8, bytes: Vec<u8>) -> PyObjec
         typecode,
         itemsize,
         data,
+        exports: 0,
     })
 }
 
@@ -135,6 +140,23 @@ pub unsafe fn w_array_vec_mut(obj: PyObjectRef) -> &'static mut Vec<u8> {
     unsafe {
         let a = &*(obj as *const W_Array);
         &mut *a.data
+    }
+}
+
+pub unsafe fn w_array_exports(obj: PyObjectRef) -> i64 {
+    unsafe { (*(obj as *const W_Array)).exports }
+}
+
+pub unsafe fn w_array_exports_incref(obj: PyObjectRef) {
+    unsafe { (*(obj as *mut W_Array)).exports += 1 };
+}
+
+pub unsafe fn w_array_exports_decref(obj: PyObjectRef) {
+    unsafe {
+        let array = &mut *(obj as *mut W_Array);
+        if array.exports > 0 {
+            array.exports -= 1;
+        }
     }
 }
 

--- a/pyre/pyre-object/src/typeobject.rs
+++ b/pyre/pyre-object/src/typeobject.rs
@@ -824,6 +824,13 @@ unsafe fn find_best_base(w_type: PyObjectRef) -> PyObjectRef {
     w_bestbase
 }
 
+/// PyPy `typeobject.py:1164-1166 descr__base` — return the base whose
+/// instance layout this type extends.  This is not necessarily the first
+/// entry in `__bases__` for multiple inheritance.
+pub unsafe fn w_type_get_best_base(w_type: PyObjectRef) -> PyObjectRef {
+    find_best_base(w_type)
+}
+
 /// Set the cached MRO.
 ///
 /// Construction installs the MRO here (rather than in `__init__`
@@ -877,6 +884,7 @@ pub unsafe fn w_type_get_flags(obj: PyObjectRef) -> i64 {
     }
     const HEAPTYPE: i64 = 1 << 9;
     const CPYTYPE: i64 = 1;
+    const IMMUTABLETYPE: i64 = 1 << 8;
     const DISALLOW_INSTANTIATION: i64 = 1 << 7;
     const PATMA_SEQUENCE: i64 = 1 << 5;
     const PATMA_MAPPING: i64 = 1 << 6;
@@ -887,7 +895,7 @@ pub unsafe fn w_type_get_flags(obj: PyObjectRef) -> i64 {
     if t.flag_heaptype {
         flags |= HEAPTYPE;
     } else {
-        flags |= CPYTYPE;
+        flags |= CPYTYPE | IMMUTABLETYPE;
     }
     if t.flag_abstract.load(std::sync::atomic::Ordering::Acquire) {
         flags |= IS_ABSTRACT;


### PR DESCRIPTION
## Summary

- extend `_ctypes` with PyPy-compatible scalar, array, pointer, structure/union, callback, cast, buffer, and PEP 3118 behavior
- preserve ctypes keepalive ownership and GC roots across moving collections
- add the supporting interpreter/object compatibility required by the shared CPython `test_ctypes` suite
- keep RustPython dependencies on the pinned upstream revision; no RustPython source patch is included

## Root causes fixed

The previous slice lacked substantial ctypes metaclass/layout and conversion behavior. It also retained some moving-GC objects only in untraced Rust locals during cast/keepalive operations, and replaced incomplete aggregate storage metadata without preserving its cached pointer type. Those defects caused missing semantics, incorrect PEP 3118 formats, and intermittent cast crashes.

## Validation

- `target/release/pyre-dynasm -m test test.test_ctypes`: 319 run, 59 skipped, 0 failed
- `test_cast`: 20 consecutive fresh-process passes
- `cargo check --features dynasm`
- `cargo test --features dynasm`
- Charon LLBC re-extracted for `pyre-object`, `pyre-interpreter`, and `pyre-jit`
- dynasm benchmark suite: 11/11 checks passed
- `git diff --check`
