### PR TITLE
jit: #368 key the close-loop restart pc off the block-head twin; source inject_root_call_result colors from the trivia twin

### DIFF
--- a/pyre/pyre-jit-trace/src/pyjitcode.rs
+++ b/pyre/pyre-jit-trace/src/pyjitcode.rs
@@ -715,6 +715,18 @@ impl PyJitCode {
         Self::predecessor_index(search).and_then(|i| pred[i].1)
     }
 
+    /// Block-entry Python pc for a `-live-` marker byte offset — the
+    /// EXACT-match tier of `python_pc_for_jitcode_pc`, without its
+    /// predecessor fallback. `None` when `jit_pc` is not a marker offset or
+    /// the table is empty (skeleton / fixture).
+    pub fn block_head_py_for_jitcode_pc(&self, jit_pc: usize) -> Option<u32> {
+        let table = &self.metadata.block_head_py_by_jit_pc;
+        table
+            .binary_search_by_key(&jit_pc, |&(off, _)| off)
+            .ok()
+            .map(|i| table[i].1)
+    }
+
     /// task#73 S5 phase-2: codewrite-time after-residual fallthrough marker
     /// keyed by a JitCode byte offset, resolved with the SAME two tiers as
     /// `python_pc_for_jitcode_pc`: an EXACT marker match first (block-head

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -884,17 +884,18 @@ fn select_recipe_entry(
 /// `bridge_stack_oprefs` seeding) reads it as the call result at `root_pc`.
 ///
 /// The result lands at the codewriter-precomputed result color for the call's
-/// return pc (`result_color_at_pc_at`), mapped to its `bridge_stack_oprefs`
-/// stack slot (`color - nlocals`).  Returns `false` (caller declines the
-/// compile) when the color is unresolved or sits below the operand stack.
+/// return pc, read from the trivia-aware jitcode-keyed twin
+/// (`result_color_trivia_for_jitcode_pc`), mapped to its
+/// `bridge_stack_oprefs` stack slot (`color - nlocals`).  Returns `false`
+/// (caller declines the compile) when the color is unresolved or sits below
+/// the operand stack.
 fn inject_root_call_result(sym: &mut PyreSym, root_pc: usize, result: majit_ir::OpRef) -> bool {
     if sym.jitcode.is_null() {
         return false;
     }
-    let jitcode_index = unsafe { (*sym.jitcode).index as i32 };
-    let root_py_pc = crate::state::backxlat_py_pc(jitcode_index, root_pc as i32) as usize;
+    let payload = unsafe { &(*sym.jitcode).payload };
     if crate::jitcode_dispatch::result_color_audit_enabled() {
-        let payload = unsafe { &(*sym.jitcode).payload };
+        let jitcode_index = unsafe { (*sym.jitcode).index as i32 };
         let py_pc =
             crate::jitcode_dispatch::python_pc_for_jitcode_pc(&payload.metadata, root_pc) as usize;
         assert_eq!(
@@ -902,8 +903,21 @@ fn inject_root_call_result(sym: &mut PyreSym, root_pc: usize, result: majit_ir::
             payload.metadata.result_color_at_pc.get(py_pc).copied(),
             "result_color_by_jit_pc diverges from result_color_at_pc at jit_pc={root_pc}"
         );
+        let root_py_pc = crate::state::backxlat_py_pc(jitcode_index, root_pc as i32) as usize;
+        assert_eq!(
+            payload
+                .result_color_trivia_for_jitcode_pc(root_pc)
+                .map(|c| c as usize)
+                .filter(|&c| c != u16::MAX as usize),
+            crate::state::result_color_at_pc_at(jitcode_index, root_py_pc),
+            "result_color trivia twin vs backxlat consumer diverges at jit_pc={root_pc}"
+        );
     }
-    let Some(result_color) = crate::state::result_color_at_pc_at(jitcode_index, root_py_pc) else {
+    let Some(result_color) = payload
+        .result_color_trivia_for_jitcode_pc(root_pc)
+        .map(|c| c as usize)
+        .filter(|&c| c != u16::MAX as usize)
+    else {
         return false;
     };
     let nlocals = sym.nlocals;

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -1884,9 +1884,14 @@ fn run_perfn_walk(
                 },
                 _end_pc,
             )) => Some(loop_header_marker_jit_pc.map_or(*loop_header_pc, |marker| {
-                let marker_py =
-                    crate::jitcode_dispatch::python_pc_for_jitcode_pc(&pjc.metadata, marker)
-                        as usize;
+                // A resume marker is always a block-head offset, so the
+                // exact tier is the whole resolution; an offset the table
+                // does not carry (skeleton / fixture) restarts at the
+                // header itself instead of a predecessor-scanned py.
+                let Some(marker_py) = pjc.block_head_py_for_jitcode_pc(marker) else {
+                    return *loop_header_pc;
+                };
+                let marker_py = marker_py as usize;
                 if marker_py == *loop_header_pc
                     && pjc.merge_entry_for(*loop_header_pc) != Some(marker)
                 {


### PR DESCRIPTION
Stacked on #602 (base: `rewrite-tracer`). Two follow-up cutovers on the pc_map-removal frontier.

**Restart-pc twin keying** — #602's S6 deduplicated the WALK_END restart derivation into a single point but kept the full `python_pc_for_jitcode_pc` inversion. Resolve the loop-header marker with the new `block_head_py_for_jitcode_pc` exact-match reader instead: a resume marker is always a block-head offset (the marker twins store dense pc_map offsets and `derive_resume_marker` returns block-head table entries), so the inversion's exact tier is the whole resolution — a corpus census at the seam measured 430/430 exact-tier reads equal to the full inversion. A marker the table does not carry (skeleton / fixture) now restarts at the header itself, where the retired predecessor fallback could fabricate a coordinate.

**`inject_root_call_result` cutover** — the seam #589 deferred as not byte-certifiable by the default corpus. Certified here with the opt-in path exercised: a corpus census (plain + `PYRE_P2_COMPILE=1`) measured 2586/2586 twin reads equal to the backxlat derivation, and the audit-enforced runs below keep the assertions live at the seam. The primary read is `result_color_trivia_for_jitcode_pc` with the `u16::MAX` sentinel filter; a twin miss declines the compile; the backxlat comparison is retained under `PYRE_PCMAP_RESULT_AUDIT`, mirroring `compute_bridge_root_parent_frame`.

Verification (fresh LLBC per cycle):
- `PYRE_PCMAP_RESULT_AUDIT=1` dynasm 208/208
- `PYRE_PCMAP_RESULT_AUDIT=1 PYRE_P2_COMPILE=1` dynasm 208/208
- plain dynasm 208/208 + cranelift 208/208
- `cargo test -p pyre-jit-trace -p pyre-jit --features dynasm` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)