### PR TITLE
jit: fix nested FOR_ITER outer-body residual dropped-iteration miscompile

### DIFF
--- a/majit/majit-backend/src/resume_guard_descr.rs
+++ b/majit/majit-backend/src/resume_guard_descr.rs
@@ -253,6 +253,13 @@ pub struct ResumeGuardDescr {
     /// reclaimed by the owning crate.  `OnceLock` so the registration
     /// is idempotent across re-attach.
     pub bridge_dispatch_drop_fn: OnceLock<unsafe fn(*mut ())>,
+    /// Pyre-only: FOR_ITER green key protected by a walker-native range
+    /// class guard.  `handle_fail` reads it off the failing descr
+    /// (`Descr::range_foriter_green_key`) to demote the range
+    /// specialization on the first class mismatch, so the demotion no
+    /// longer depends on the guard's per-trace fail index.  `0` = not a
+    /// range guard.
+    pub range_foriter_key: AtomicU64,
 }
 
 // Safety: single-threaded JIT (RPython GIL parity).
@@ -271,6 +278,12 @@ impl Descr for ResumeGuardDescr {
     }
     fn is_resume_guard(&self) -> bool {
         true
+    }
+    fn range_foriter_green_key(&self) -> Option<u64> {
+        match self.range_foriter_key.load(Ordering::Relaxed) {
+            0 => None,
+            key => Some(key),
+        }
     }
     /// compile.py:844-846: ResumeGuardDescr.clone()
     fn clone_descr(&self) -> Option<DescrRef> {
@@ -298,6 +311,9 @@ impl Descr for ResumeGuardDescr {
             bridge_body_ptr_cache: Box::new(AtomicUsize::new(0)),
             bridge_dispatch_cell: AtomicPtr::new(std::ptr::null_mut()),
             bridge_dispatch_drop_fn: OnceLock::new(),
+            // The clone guards the same range site; preserve the tag so a
+            // cloned range class guard still demotes on failure.
+            range_foriter_key: AtomicU64::new(self.range_foriter_key.load(Ordering::Relaxed)),
         }))
     }
 }
@@ -571,6 +587,7 @@ pub fn make_resume_guard_descr_typed(types: Vec<Type>) -> DescrRef {
         bridge_body_ptr_cache: Box::new(AtomicUsize::new(0)),
         bridge_dispatch_cell: AtomicPtr::new(std::ptr::null_mut()),
         bridge_dispatch_drop_fn: OnceLock::new(),
+        range_foriter_key: AtomicU64::new(0),
     })
 }
 

--- a/majit/majit-ir/src/descr.rs
+++ b/majit/majit-ir/src/descr.rs
@@ -1971,6 +1971,19 @@ pub trait Descr: Send + Sync + std::fmt::Debug {
     /// override.
     fn set_prev_descr(&self, _prev: DescrRef) {}
 
+    /// Pyre-only: the FOR_ITER green key whose walker-native range class
+    /// guard this descr backs, or `None`.  `handle_fail` reads it off the
+    /// failing descr to demote the range specialization on the first class
+    /// mismatch, independent of the guard's per-trace fail index (which
+    /// optimizer guard-folding / unroll can shift).  A shared-resume copied
+    /// guard carries no marker of its own, so the default chases `prev` to
+    /// the donor `ResumeGuardDescr` that holds the tag; `ResumeGuardDescr`
+    /// overrides to read its own slot.
+    fn range_foriter_green_key(&self) -> Option<u64> {
+        self.prev_descr()
+            .and_then(|prev| prev.range_foriter_green_key())
+    }
+
     /// intbounds.py: descr.is_integer_bounded() / get_integer_min/max.
     /// Returns (field_size_bytes, is_signed) if this is a field descriptor.
     /// Used by intbounds to narrow GETFIELD result bounds.

--- a/majit/majit-metainterp/src/compile.rs
+++ b/majit/majit-metainterp/src/compile.rs
@@ -3000,6 +3000,7 @@ pub fn make_fail_descr_with_index(fail_index: u32, num_live: usize) -> DescrRef 
         bridge_body_ptr_cache: Box::new(AtomicUsize::new(0)),
         bridge_dispatch_cell: AtomicPtr::new(std::ptr::null_mut()),
         bridge_dispatch_drop_fn: OnceLock::new(),
+        range_foriter_key: AtomicU64::new(0),
     })
 }
 
@@ -3091,7 +3092,27 @@ pub fn make_resume_guard_descr_typed(types: Vec<Type>) -> DescrRef {
         bridge_body_ptr_cache: Box::new(AtomicUsize::new(0)),
         bridge_dispatch_cell: AtomicPtr::new(std::ptr::null_mut()),
         bridge_dispatch_drop_fn: OnceLock::new(),
+        range_foriter_key: AtomicU64::new(0),
     })
+}
+
+/// `make_resume_guard_descr_typed` variant that tags the descr with the
+/// FOR_ITER `green_key` its walker-native range class guard protects.
+/// `handle_fail` reads the tag (`Descr::range_foriter_green_key`) off the
+/// failing descr to demote the range specialization on the first class
+/// mismatch, so the demotion no longer depends on the guard's per-trace
+/// fail index (which optimizer guard-folding / unroll can shift).  Types
+/// start empty; `store_final_boxes_in_guard` fills them from numbering
+/// while preserving this descr (its `op.getdescr().is_some()` arm).
+pub fn make_resume_guard_descr_range_foriter(green_key: u64) -> DescrRef {
+    let descr = make_resume_guard_descr_typed(Vec::new());
+    descr
+        .as_any()
+        .and_then(|any| any.downcast_ref::<ResumeGuardDescr>())
+        .expect("make_resume_guard_descr_typed constructs a ResumeGuardDescr")
+        .range_foriter_key
+        .store(green_key, Ordering::Relaxed);
+    descr
 }
 
 /// compile.py:892: ResumeAtPositionDescr(ResumeGuardDescr) — subclass
@@ -3351,6 +3372,7 @@ pub fn make_resume_at_position_descr_typed(types: Vec<Type>) -> DescrRef {
             bridge_body_ptr_cache: Box::new(AtomicUsize::new(0)),
             bridge_dispatch_cell: AtomicPtr::new(std::ptr::null_mut()),
             bridge_dispatch_drop_fn: OnceLock::new(),
+            range_foriter_key: AtomicU64::new(0),
         },
     })
 }
@@ -3617,6 +3639,7 @@ pub fn make_resume_guard_forced_descr_typed(types: Vec<Type>) -> DescrRef {
             bridge_body_ptr_cache: Box::new(AtomicUsize::new(0)),
             bridge_dispatch_cell: AtomicPtr::new(std::ptr::null_mut()),
             bridge_dispatch_drop_fn: OnceLock::new(),
+            range_foriter_key: AtomicU64::new(0),
         },
     })
 }
@@ -3867,6 +3890,7 @@ pub fn make_resume_guard_exc_descr_typed(types: Vec<Type>) -> DescrRef {
             bridge_body_ptr_cache: Box::new(AtomicUsize::new(0)),
             bridge_dispatch_cell: AtomicPtr::new(std::ptr::null_mut()),
             bridge_dispatch_drop_fn: OnceLock::new(),
+            range_foriter_key: AtomicU64::new(0),
         },
     })
 }
@@ -4826,6 +4850,7 @@ impl majit_ir::Descr for CompileLoopVersionDescr {
                 bridge_body_ptr_cache: Box::new(AtomicUsize::new(0)),
                 bridge_dispatch_cell: AtomicPtr::new(std::ptr::null_mut()),
                 bridge_dispatch_drop_fn: OnceLock::new(),
+                range_foriter_key: AtomicU64::new(0),
             },
         }))
     }
@@ -5045,6 +5070,7 @@ fn make_compile_loop_version_descr_with_payload(types: Vec<Type>, payload: RdPay
             bridge_body_ptr_cache: Box::new(AtomicUsize::new(0)),
             bridge_dispatch_cell: AtomicPtr::new(std::ptr::null_mut()),
             bridge_dispatch_drop_fn: OnceLock::new(),
+            range_foriter_key: AtomicU64::new(0),
         },
     })
 }
@@ -5509,6 +5535,7 @@ mod fail_descr_tests {
                 bridge_body_ptr_cache: Box::new(AtomicUsize::new(0)),
                 bridge_dispatch_cell: AtomicPtr::new(std::ptr::null_mut()),
                 bridge_dispatch_drop_fn: OnceLock::new(),
+                range_foriter_key: AtomicU64::new(0),
             },
         }) as DescrRef;
         let lv_fi = lv.index();

--- a/majit/majit-metainterp/src/history.rs
+++ b/majit/majit-metainterp/src/history.rs
@@ -2430,6 +2430,21 @@ impl TraceCtx {
         Self::do_record_guard(&mut self.recorder, opcode, args, None)
     }
 
+    /// Record a guard carrying a pre-minted `ResumeGuardDescr`.
+    /// `store_final_boxes_in_guard` preserves an existing descr (only
+    /// refreshing its `fail_arg_types`), so a marker stamped on `descr`
+    /// survives optimization guard-folding and unroll — used by the
+    /// walker-native range FOR_ITER specialization to tag its class guard
+    /// for demotion by descr identity (`Descr::range_foriter_green_key`).
+    pub fn record_guard_with_descr(
+        &mut self,
+        opcode: OpCode,
+        args: &[OpRef],
+        descr: DescrRef,
+    ) -> OpRef {
+        Self::do_record_guard(&mut self.recorder, opcode, args, Some(descr))
+    }
+
     /// `pyjitpl.py:2548 generate_guard()` parity: tracer-stage typed
     /// guards carry `descr=None`. The `fail_arg_types` are stamped onto
     /// `op.fail_arg_types` directly so the optimizer's

--- a/majit/majit-metainterp/src/lib.rs
+++ b/majit/majit-metainterp/src/lib.rs
@@ -92,7 +92,10 @@ pub use call_descr::{
     make_call_descr, make_call_descr_from_target_slot, make_call_descr_with_effect,
     nursery_alloc_effect_info,
 };
-pub use compile::{make_fail_descr, make_fail_descr_typed, make_finish_fail_descr_typed};
+pub use compile::{
+    make_fail_descr, make_fail_descr_typed, make_finish_fail_descr_typed,
+    make_resume_guard_descr_range_foriter,
+};
 pub use io_buffer::{
     emit_commit_io, encode_decimal_i64, io_buffer_commit, io_buffer_discard, io_buffer_write,
     io_buffer_write_fmt, jit_write_number_i64, jit_write_utf8_codepoint,

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -6130,6 +6130,22 @@ impl OptContext {
             op.getdescr().map_or(false, |d| d.is_resume_guard_copied())
         );
 
+        // A walker-native range FOR_ITER class guard carries a pre-minted
+        // marker descr (`range_foriter_green_key`) so its failure can demote
+        // the specialization by descr identity.  `Op::clone` shares the descr
+        // Arc, so unroll's phase-1/phase-2 emissions of the guard reach this
+        // function on the same, already-finalized descr.  Mint a fresh marked
+        // descr for this emission — mirroring the `op.descr.is_none()` arm's
+        // fresh-per-emission descr — so the once-per-descr `finish()`
+        // invariant below still holds for it (and for every other guard).
+        let refinalize_marked_key = op
+            .getdescr()
+            .and_then(|d| d.range_foriter_green_key())
+            .filter(|_| op.resolved_rd_numb().is_some());
+        if let Some(key) = refinalize_marked_key {
+            op.setdescr(crate::compile::make_resume_guard_descr_range_foriter(key));
+        }
+
         // resume.py:397 `assert not storage.rd_numb` — finish() runs at
         // most once per ResumeGuardDescr.  RPython makes this invariant
         // load-bearing: a second call would clobber an already-numbered

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -21545,17 +21545,31 @@ fn try_walker_specialize_for_iter_next(
     // guard_class W_IntRangeIterator, unless the operand is already known.
     let range_iter_type_addr = &pyre_object::functional::RANGE_ITER_TYPE as *const _ as i64;
     if !iter_op.is_constant() && !ctx.trace_ctx.heap_cache().is_class_known(iter_op) {
-        let guard_fail_index = ctx.trace_ctx.num_guards() as u32;
         let type_const = ctx.trace_ctx.const_int(range_iter_type_addr);
-        ctx.trace_ctx
-            .record_guard(OpCode::GuardClass, &[iter_op, type_const], 0);
-        walker_capture_snapshot_for_last_guard(ctx, op_pc)?;
-        // `handle_fail` receives only the compiled guard's synthesized
-        // FailDescr. Keep this trace's guard ordinal with the corresponding
-        // FOR_ITER loop key so its failure can demote the specialization.
-        if let Some(green_key) = range_green_key {
-            crate::trace::record_range_foriter_specialization(green_key, guard_fail_index);
+        // Pre-mint the guard's FailDescr tagged with this FOR_ITER green key
+        // so its runtime failure — a definitive polymorphism witness —
+        // demotes the specialization by descr identity, independent of the
+        // guard's per-trace fail index.  `store_final_boxes_in_guard`
+        // preserves an existing ResumeGuardDescr (only refreshing
+        // fail_arg_types), so the tag survives optimizer guard-folding and
+        // unroll; a copied guard chases `prev` to this donor.  With no green
+        // key available (e.g. inline sub-walk) the guard is untagged and the
+        // site is simply never demoted, matching the prior behavior.
+        match range_green_key {
+            Some(green_key) => {
+                let descr = majit_metainterp::make_resume_guard_descr_range_foriter(green_key);
+                ctx.trace_ctx.record_guard_with_descr(
+                    OpCode::GuardClass,
+                    &[iter_op, type_const],
+                    descr,
+                );
+            }
+            None => {
+                ctx.trace_ctx
+                    .record_guard(OpCode::GuardClass, &[iter_op, type_const], 0);
+            }
         }
+        walker_capture_snapshot_for_last_guard(ctx, op_pc)?;
     }
     ctx.trace_ctx
         .heap_cache_mut()

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -14193,9 +14193,14 @@ fn fbw_callee_body_side_effect_free(
                 return false;
             };
             let ei = call_descr.get_extra_info();
-            let provably_side_effect_free = ei.check_is_elidable()
-                || ei.extraeffect == majit_ir::ExtraEffect::LoopInvariant
-                || ei.pyre_helper == majit_ir::PyreHelperKind::ForIterNext;
+            // `ForIterNext` is deliberately not accepted here: it advances the
+            // shared heap iterator irreversibly (no journal undo), so replaying
+            // a callee that contains it from the caller's CALL boundary would
+            // double-consume.  A FOR_ITER-bearing body is declined anyway — its
+            // mandatory `GET_ITER` (`MayForce`) predecessor fails this scan
+            // first — so this only removes a latent landmine, not live inlines.
+            let provably_side_effect_free =
+                ei.check_is_elidable() || ei.extraeffect == majit_ir::ExtraEffect::LoopInvariant;
             if !provably_side_effect_free
                 && !residual_call_is_specialized_plain_int_add(
                     body_code,

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -8708,6 +8708,39 @@ impl JitState for PyreJitState {
                 }
             }
         }
+        // Seed operand-stack slots (kept temps) whose concrete the frame-array
+        // overlay above could not source.  A kept operand's authoritative
+        // post-guard value is the RESUME DATA (`fail_values`, decoded into
+        // `bridge_stamp_orphans`), NOT the frame array — `locals_cells_stack_w`
+        // holds a bare `PY_NULL` for an operand-stack temp above the
+        // materialized `valuestackdepth`.  A CALL's `self_or_null` sentinel is
+        // one such genuine `PY_NULL`: its box decodes to `Ref(GcRef(0))`, which
+        // BOTH the frame-array seed and the orphan seed drop as a "hole",
+        // leaving `box_value == None`.  The residual then declines that arg as
+        // *unavailable* (its `null_or_self` exemption accepts a KNOWN null but
+        // not an unavailable box), the effect goes unjournaled, and the legacy
+        // replay drops the outer iteration.  Seed each still-unstamped operand
+        // opref from its own resume-data decode — INCLUDING a genuine null — so
+        // the residual sees the real (null) sentinel and executes.  Scoped to
+        // operand slots (`>= nlocals`); locals keep the frame-array overlay,
+        // and a slot already carrying a real concrete is left untouched.
+        if seed_bridge_locals {
+            if let Some(orphan_stamps) = bridge_stamp_orphans.as_ref() {
+                for s in nlocals..semantic_prefix_len {
+                    let Some(&opref) = semantic_mirror.get(s) else {
+                        continue;
+                    };
+                    if opref.is_none() || ctx.box_value(opref).is_some() {
+                        continue;
+                    }
+                    if let Some((_, cv)) = orphan_stamps.iter().find(|(o, _)| o == &opref) {
+                        if !matches!(cv, majit_ir::Value::Void) {
+                            ctx.try_set_opref_concrete(opref, *cv);
+                        }
+                    }
+                }
+            }
+        }
         sym.registers_r = semantic_mirror;
         sym.symbolic_local_types = {
             let mut types = bridge_local_types.clone();

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -105,17 +105,12 @@ thread_local! {
     /// FOR_ITER green keys whose range-only specialization observed a class
     /// mismatch.  This gates only the specialization; the full-body walk must
     /// still retrace and compile its generic residual.
-    static RANGE_FORITER_DEMOTED: std::cell::RefCell<std::collections::HashSet<u64>> =
-        std::cell::RefCell::new(std::collections::HashSet::new());
-    /// Current per-trace fail index for each walker-emitted range-iterator
-    /// class guard, keyed by its FOR_ITER green key. A retrace replaces the
-    /// prior ordinal for that key.
     ///
     /// This is deliberately per-thread, like `FBW_DECLINED_KEYS` and the JIT
     /// driver itself.  A guard failure proves polymorphism only for the
     /// executing thread's trace; no cross-thread mutable JIT state is needed.
-    static RANGE_FORITER_SPECIALIZED_GUARDS: std::cell::RefCell<std::collections::HashMap<u64, u32>> =
-        std::cell::RefCell::new(std::collections::HashMap::new());
+    static RANGE_FORITER_DEMOTED: std::cell::RefCell<std::collections::HashSet<u64>> =
+        std::cell::RefCell::new(std::collections::HashSet::new());
 }
 
 pub(crate) fn fbw_declined(key: u64) -> bool {
@@ -132,36 +127,16 @@ pub(crate) fn range_foriter_demoted(key: u64) -> bool {
     RANGE_FORITER_DEMOTED.with(|s| s.borrow().contains(&key))
 }
 
-/// Record the current trace's range FOR_ITER class guard ordinal.
+/// Demote a range FOR_ITER site on the first failure of its class guard —
+/// a definitive polymorphism witness.
 ///
-/// A retrace overwrites any stale ordinal for the same green key. A range key
-/// can cease being a range site only through this guard's class-mismatch
-/// demotion, after which a lingering entry is harmless because the key is
-/// already demoted. Thus a non-range body guard from an earlier trace cannot
-/// be mistaken for the range specialization without pre-stamping its descr.
-pub(crate) fn record_range_foriter_specialization(green_key: u64, fail_index: u32) {
-    RANGE_FORITER_SPECIALIZED_GUARDS.with(|s| {
-        s.borrow_mut().insert(green_key, fail_index);
-    });
-}
-
-/// Return whether this exact range FOR_ITER guard failure should demote its
-/// loop.
-///
-/// The mapping holds only the current trace's ordinal for this green key, so
-/// an unrelated guard from a stale trace cannot trigger demotion.
-pub fn range_foriter_guard_failed(green_key: u64, fail_index: u32) -> bool {
-    let specialized =
-        RANGE_FORITER_SPECIALIZED_GUARDS.with(|s| s.borrow().get(&green_key) == Some(&fail_index));
-    if specialized {
-        RANGE_FORITER_SPECIALIZED_GUARDS.with(|s| {
-            s.borrow_mut().remove(&green_key);
-        });
-        RANGE_FORITER_DEMOTED.with(|s| {
-            s.borrow_mut().insert(green_key);
-        });
-    }
-    specialized
+/// Returns `true` when this call performs the demotion (first class
+/// mismatch), `false` when the site was already demoted (idempotent
+/// re-failure).  `handle_fail` calls this only after confirming the failing
+/// descr carries the range marker (`Descr::range_foriter_green_key`), so an
+/// unrelated body guard at the same loop can never demote the site.
+pub fn range_foriter_demote_once(green_key: u64) -> bool {
+    RANGE_FORITER_DEMOTED.with(|s| s.borrow_mut().insert(green_key))
 }
 
 fn midbody_post_marker_is_effect_free(code: &CodeObject, start_pc: usize) -> bool {

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -5179,7 +5179,7 @@ fn handle_fail(
     frame: &mut PyFrame,
     green_key: u64,
     _trace_id: u64,
-    fail_index: u32,
+    _fail_index: u32,
     descr_arc: &std::sync::Arc<dyn majit_ir::Descr>,
     should_bridge: bool,
     _owning_key: u64,
@@ -5189,11 +5189,16 @@ fn handle_fail(
     _info: &majit_metainterp::virtualizable::VirtualizableInfo,
 ) -> HandleFailOutcome {
     // The range FOR_ITER `GuardClass(RANGE_ITER)` proves its own site
-    // polymorphic on the first failure.  Demote before `should_bridge` can
-    // spend another retrace-limit cycle trying to close a bridge at the same
-    // failing loop header; blackhole resumes this invocation without the
-    // invalidated compiled loop.
-    if pyre_jit_trace::trace::range_foriter_guard_failed(green_key, fail_index) {
+    // polymorphic on the first failure.  The failing descr carries the
+    // FOR_ITER green key it protects (`range_foriter_green_key`), stamped
+    // when the guard was minted, so the demotion is keyed on descr identity
+    // rather than a per-trace fail index the optimizer can shift.  Demote
+    // before `should_bridge` can spend another retrace-limit cycle trying to
+    // close a bridge at the same failing loop header; blackhole resumes this
+    // invocation without the invalidated compiled loop.
+    if descr_arc.range_foriter_green_key().is_some()
+        && pyre_jit_trace::trace::range_foriter_demote_once(green_key)
+    {
         let (driver, _) = driver_pair();
         driver.invalidate_loop(green_key);
         // This is an intentional replacement, unlike ordinary


### PR DESCRIPTION
## Summary

Fixes a silent JIT miscompile where a hot `FOR_ITER` driver calling a function with a nested inner `FOR_ITER` and an executed outer-body method-call residual (e.g. `seen.append(i)`) **drops 1–2 whole outer iterations**. Introduced by #578 (deleting `header_entry_is_nested` let the inner loop compile standalone, exposing a latent bridge-decode gap); reproduces on both backends, `MAJIT_STRICT=1` does not catch it.

## Root cause

The failing operand is a `CALL`'s `self_or_null` sentinel, which is a **genuine `PY_NULL`** (`Ref(GcRef(0))`) — correct at capture. In `setup_bridge_sym`, the frame-array overlay and the two prior seed passes (deferred, orphan) deliberately skip `Ref(GcRef(0))` as a "hole" (guarding a frame-array per-slot color-aliasing clobber), leaving the slot at `box_value == None` (UNAVAILABLE, distinct from KNOWN-null). The eager residual then declines that argument as *unavailable* (its `self_or_null` exemption accepts a known null but not an unavailable box) → `fbw_mark_unjournaled_effect` → legacy replay from the loop header with the outer iterator already advanced → dropped iteration.

## Fix

Add a final operand-slot seed pass in `setup_bridge_sym`: for each operand-stack slot (`>= nlocals`) still at `box_value == None`, stamp it from its own `bridge_stamp_orphans` (resume-data / `fail_values`) decode — **including a genuine null**, excluding only `Void`, and never overwriting a live concrete. The `self_or_null` sentinel then decodes as a known null and the residual executes.

This is sourced **per-opref** from resume data (each opref paired with its own `fail_values[n]`), not per-slot from the frame array, so the color-aliasing clobber the prior passes guard against cannot recur, and the `box_value.is_some()` guard preserves any real concrete. It matches RPython's total resume-data restoration (`get_ref_value` legally returns/stores NULL; bridge decode is the `rebuild_from_resumedata` analog), removing pyre's `None`=unavailable deviation rather than adding one.

## Verification

- `check.py --backend dynasm` **208/208**, `--backend cranelift` **208/208**
- `cargo test -p pyre-jit-trace` **267 passed, 0 failed**
- Repro battery (14: `min1`–`min8`, `insert2`, `adv_sideeffect`, `disambig2`, `drv_range/list`, `norange`) all `JIT == interp`
- Adversarial battery (10 shapes: real-object arg, user-class bound method, two calls, `insert` 2-arg, `d[k]=v`, `None` arg, mixed None/real, triple-nest, `extend`, chained getattr) all identical
- `adv_sideeffect` (`seen.append(f(i))`) confirms **no double-apply** (side-effect count exact)
- 8-agent adversarial review: 3 SOUND (code-safety, orthodoxy, provenance), 8 exotic repros (exception-in-residual, try/except, break, continue, aug-assign, del/pop, call-result-self) 0 FAIL

## Commits

- `jit: drop dead ForIterNext clause from FOR_ITER inline side-effect check`
- `jit: demote range FOR_ITER by descr identity, not fail-index ordinal`
- `jit: seed bridge operand slots from resume-data decode, incl null` (this fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
