### PR TITLE
Interpreter correctness: attribute/error-message parity, str width

### DIFF
--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -7284,7 +7284,7 @@ pub(crate) unsafe fn get(
         // AttributeError("'%T' object has no attribute '%s'")
         if found.is_none() {
             let slot_name = pyre_object::w_member_get_name(descr);
-            return Err(raiseattrerror(obj, slot_name));
+            return Err(raiseattrerror(obj, slot_name, None));
         }
         return Ok(found);
     }
@@ -7584,31 +7584,35 @@ pub fn object_setattr(obj: PyObjectRef, name: &str, value: PyObjectRef) -> PyRes
     // descr__setattr__ step 1). PyPy walks `space.type(obj)` regardless of
     // whether `obj` is a Python-level instance, so the lookup must run for
     // every object whose type pyre can resolve — not just W_ObjectObject.
-    unsafe {
+    // A found-but-non-settable descriptor (no reachable `__set__`/`__delete__`)
+    // is carried to the terminal so a dict-less miss reports read-only rather
+    // than absent (descr__setattr__:129 passes `w_descr` to raiseattrerror).
+    let w_descr = unsafe {
         let w_type = if is_instance(obj) {
             w_instance_get_type(obj)
-        } else if is_type(obj) {
+        } else {
             // For type objects pyre stores attributes in the type's own
             // dict below; the descriptor walk uses the metaclass MRO so
             // metatype-installed setters (e.g. on `type`) still fire.
             crate::typedef::r#type(obj).unwrap_or(std::ptr::null_mut())
-        } else {
-            crate::typedef::r#type(obj).unwrap_or(std::ptr::null_mut())
         };
-        if !w_type.is_null() {
-            if let Some(descr) = lookup_in_type_where(w_type, name) {
-                if set(descr, obj, value)? {
-                    return Ok(w_none());
-                }
-                // descroperation.py:124-126 — `__delete__` but no `__set__`
-                // is a read-only data descriptor; reject rather than shadow
-                // it with an instance/type dict store.
-                if descr_has_delete(descr) {
-                    return Err(descr_not_settable_error(descr));
-                }
+        if w_type.is_null() {
+            None
+        } else if let Some(descr) = lookup_in_type_where(w_type, name) {
+            if set(descr, obj, value)? {
+                return Ok(w_none());
             }
+            // descroperation.py:124-126 — `__delete__` but no `__set__`
+            // is a read-only data descriptor; reject rather than shadow
+            // it with an instance/type dict store.
+            if descr_has_delete(descr) {
+                return Err(descr_not_settable_error(descr));
+            }
+            Some(descr)
+        } else {
+            None
         }
-    }
+    };
     // Type objects: store in the type's own namespace (class dict).
     // PyPy: typeobject.py type.__setattr__ → w_type.dict_w[name] = w_value
     unsafe {
@@ -7976,7 +7980,7 @@ pub fn object_setattr(obj: PyObjectRef, name: &str, value: PyObjectRef) -> PyRes
     if setdictvalue(obj, name, value) {
         return Ok(w_none());
     }
-    Err(raiseattrerror(obj, name))
+    Err(raiseattrerror(obj, name, w_descr))
 }
 
 /// A direct `W_BaseException` reference slot whose hard-coded getattr/setattr
@@ -8168,10 +8172,25 @@ pub(crate) fn setdictvalue(obj: PyObjectRef, name: &str, value: PyObjectRef) -> 
 /// ```
 // dont_look_inside: attribute-miss / read-only AttributeError construction; slow path.
 #[majit_macros::dont_look_inside]
-fn raiseattrerror(obj: PyObjectRef, name: &str) -> PyError {
-    // descroperation.py:58-64 — a type receiver reports its own name through
-    // the `type object '%N'` form; every other object reports its type's name
-    // through the `'%T' object` form.
+fn raiseattrerror(obj: PyObjectRef, name: &str, w_descr: Option<PyObjectRef>) -> PyError {
+    // descroperation.py:58-67 — with a descriptor in hand, the attribute
+    // exists on the type but has no reachable `__set__`/`__delete__` and the
+    // receiver has no dict to store into: it is read-only.  Otherwise this is
+    // a genuine miss: a type receiver reports through the `type object '%N'`
+    // form, every other object through the `'%T' object` form.
+    if w_descr.is_some() {
+        let tp_name = unsafe {
+            match crate::typedef::r#type(obj) {
+                Some(tp) => pyre_object::w_type_get_name(tp).to_string(),
+                None => (*(*obj).ob_type).name.to_string(),
+            }
+        };
+        return PyError::attribute_error_with_context(
+            format!("'{tp_name}' object attribute '{name}' is read-only"),
+            obj,
+            name,
+        );
+    }
     let subject = unsafe {
         if is_type(obj) {
             format!("type object '{}'", pyre_object::w_type_get_name(obj))
@@ -8216,24 +8235,27 @@ pub fn object_delattr(obj: PyObjectRef, name: &str) -> PyResult {
     // `__delete__` takes priority over the namespace delete. PyPy walks
     // `space.type(obj)`, so the lookup must run for any object whose type
     // pyre can resolve — not just W_ObjectObject — and before the
-    // module/type/instance dict removal below.
-    unsafe {
+    // module/type/instance dict removal below.  A found-but-non-data
+    // descriptor is carried to the terminal so a dict-less miss reports
+    // read-only rather than absent (descr__delattr__:140 passes `w_descr`).
+    let w_descr = unsafe {
         let w_type = if is_instance(obj) {
             w_instance_get_type(obj)
-        } else if is_type(obj) {
-            crate::typedef::r#type(obj).unwrap_or(std::ptr::null_mut())
         } else {
             crate::typedef::r#type(obj).unwrap_or(std::ptr::null_mut())
         };
-        if !w_type.is_null() {
-            if let Some(descr) = lookup_in_type_where(w_type, name) {
-                if is_data_descr(descr) {
-                    delete(descr, obj)?;
-                    return Ok(w_none());
-                }
+        if w_type.is_null() {
+            None
+        } else if let Some(descr) = lookup_in_type_where(w_type, name) {
+            if is_data_descr(descr) {
+                delete(descr, obj)?;
+                return Ok(w_none());
             }
+            Some(descr)
+        } else {
+            None
         }
-    }
+    };
     // Module objects: PyPy `module.py:Module` does not override
     // `descr__delattr__`, so the call falls through to W_Root's
     // `deldictvalue` (`baseobjspace.py:58-67`):
@@ -8269,7 +8291,7 @@ pub fn object_delattr(obj: PyObjectRef, name: &str) -> PyResult {
                     Err(err) if err.kind == crate::PyErrorKind::KeyError => {
                         // descroperation.py descr__delattr__: deldictvalue
                         // returning False raises AttributeError immediately.
-                        return Err(raiseattrerror(obj, name));
+                        return Err(raiseattrerror(obj, name, None));
                     }
                     Err(err) => return Err(err),
                 }
@@ -8302,7 +8324,7 @@ pub fn object_delattr(obj: PyObjectRef, name: &str) -> PyResult {
                     mutated(obj, Some(name));
                     return Ok(w_none());
                 }
-                return Err(raiseattrerror(obj, name));
+                return Err(raiseattrerror(obj, name, None));
             }
         }
     }
@@ -8326,7 +8348,8 @@ pub fn object_delattr(obj: PyObjectRef, name: &str) -> PyResult {
     // through the shared terminal — the same as object_setattr and the
     // module/type misses above — so the receiver's own type is named and the
     // obj/name context is attached, rather than the bare `object` base.
-    Err(raiseattrerror(obj, name))
+    // `w_descr` carries a found-but-non-data descriptor so the miss is read-only.
+    Err(raiseattrerror(obj, name, w_descr))
 }
 
 /// PyPy: baseobjspace.py `call`.

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -8322,11 +8322,11 @@ pub fn object_delattr(obj: PyObjectRef, name: &str) -> PyResult {
             return Ok(w_none());
         }
     }
-    let tp_name = unsafe { (*(*obj).ob_type).name };
-    Err(PyError::new(
-        PyErrorKind::AttributeError,
-        format!("'{tp_name}' object has no attribute '{name}'"),
-    ))
+    // deldictvalue returning False (no dict, or the key was absent) raises
+    // through the shared terminal — the same as object_setattr and the
+    // module/type misses above — so the receiver's own type is named and the
+    // obj/name context is attached, rather than the bare `object` base.
+    Err(raiseattrerror(obj, name))
 }
 
 /// PyPy: baseobjspace.py `call`.

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -8185,11 +8185,12 @@ fn raiseattrerror(obj: PyObjectRef, name: &str, w_descr: Option<PyObjectRef>) ->
                 None => (*(*obj).ob_type).name.to_string(),
             }
         };
-        return PyError::attribute_error_with_context(
-            format!("'{tp_name}' object attribute '{name}' is read-only"),
-            obj,
-            name,
-        );
+        // The read-only branch raises a plain AttributeError: unlike the
+        // missing-attribute path it does not set the `name`/`obj` context,
+        // so `e.name` / `e.obj` read back as None.
+        return PyError::attribute_error(format!(
+            "'{tp_name}' object attribute '{name}' is read-only"
+        ));
     }
     let subject = unsafe {
         if is_type(obj) {

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -4836,13 +4836,16 @@ fn make_exc_type_with_init(
                                         "add_note() missing 1 required positional argument: 'note'",
                                     )
                                 })?;
-                                // `interp_exceptions.py:238-239` — accept
+                                // `interp_exceptions.py:257-260` — accept
                                 // `str` and any `str` subclass
-                                // (`isinstance_w(w_note, space.w_unicode)`).
+                                // (`isinstance_w(w_note, space.w_unicode)`);
+                                // otherwise `oefmt("note must be a str, not %T")`.
                                 if !unsafe { crate::baseobjspace::isinstance_str_w(w_note) } {
-                                    return Err(crate::PyError::type_error(
-                                        "note must be a string",
-                                    ));
+                                    let tp_name =
+                                        crate::baseobjspace::object_functionstr_type_name(w_note);
+                                    return Err(crate::PyError::type_error(format!(
+                                        "note must be a str, not {tp_name}"
+                                    )));
                                 }
                                 // `interp_exceptions.py:240-254` — lazy
                                 // list allocation on first call; if the

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -3061,29 +3061,41 @@ pub(crate) fn kwarg_reject_duplicate(
 /// object's type, mirroring PyPy's `lookup_in_type` pass before
 /// raising `TypeError`.
 pub(crate) fn space_index_w(obj: PyObjectRef) -> Result<i64, crate::PyError> {
-    unsafe {
-        if pyre_object::is_int(obj) {
-            return Ok(pyre_object::w_int_get_value(obj));
+    // Read the machine-word value of a bool / int / long object, raising
+    // OverflowError when a bigint does not fit. Returns `None` for anything
+    // else so the caller can fall through to the `__index__` lookup / error.
+    unsafe fn as_index_value(o: PyObjectRef) -> Option<Result<i64, crate::PyError>> {
+        unsafe {
+            if pyre_object::is_bool(o) {
+                return Some(Ok(pyre_object::w_bool_get_value(o) as i64));
+            }
+            if pyre_object::is_int(o) {
+                return Some(Ok(pyre_object::w_int_get_value(o)));
+            }
+            if pyre_object::is_long(o) {
+                let big = pyre_object::longobject::w_long_get_value(o);
+                return Some(
+                    if pyre_object::longobject::jit_bigint_to_i64_fits(big) != 0 {
+                        Ok(pyre_object::longobject::jit_bigint_to_i64_value(big))
+                    } else {
+                        Err(crate::PyError::overflow_error(
+                            "int too large to convert to int",
+                        ))
+                    },
+                );
+            }
         }
-        if pyre_object::is_bool(obj) {
-            return Ok(if pyre_object::w_bool_get_value(obj) {
-                1
-            } else {
-                0
-            });
+        None
+    }
+    unsafe {
+        if let Some(v) = as_index_value(obj) {
+            return v;
         }
         if let Some(w_type) = crate::typedef::r#type(obj) {
             if let Some(index_fn) = crate::baseobjspace::lookup_in_type(w_type, "__index__") {
                 let result = crate::call::call_function_impl_result(index_fn, &[obj])?;
-                if pyre_object::is_int(result) {
-                    return Ok(pyre_object::w_int_get_value(result));
-                }
-                if pyre_object::is_bool(result) {
-                    return Ok(if pyre_object::w_bool_get_value(result) {
-                        1
-                    } else {
-                        0
-                    });
+                if let Some(v) = as_index_value(result) {
+                    return v;
                 }
             }
         }

--- a/pyre/pyre-interpreter/src/objspace/descroperation.rs
+++ b/pyre/pyre-interpreter/src/objspace/descroperation.rs
@@ -2491,6 +2491,12 @@ pub(crate) fn divmod_builtin(a: PyObjectRef, b: PyObjectRef) -> PyResult {
         let lhs_num = is_int(a) || is_long(a) || is_float(a);
         let rhs_num = is_int(b) || is_long(b) || is_float(b);
         if lhs_num && rhs_num {
+            // intobject.py:356-360 `_divmod` — a zero integer divisor reports
+            // divmod's own "integer divmod by zero"; a float operand instead
+            // falls through to floordiv/mod (which report "float modulo").
+            if is_int_or_long(a) && is_int_or_long(b) && !is_true(b)? {
+                return Err(PyError::zero_division("integer divmod by zero"));
+            }
             let q = floordiv(a, b)?;
             let r = mod_(a, b)?;
             return Ok(w_tuple_new(vec![q, r]));
@@ -2857,6 +2863,12 @@ pub fn divmod(a: PyObjectRef, b: PyObjectRef) -> PyResult {
         let lhs_num = is_int(a) || is_long(a) || is_float(a);
         let rhs_num = is_int(b) || is_long(b) || is_float(b);
         if lhs_num && rhs_num {
+            // intobject.py:356-360 `_divmod` — a zero integer divisor reports
+            // divmod's own "integer divmod by zero"; a float operand instead
+            // falls through to floordiv/mod (which report "float modulo").
+            if is_int_or_long(a) && is_int_or_long(b) && !is_true(b)? {
+                return Err(PyError::zero_division("integer divmod by zero"));
+            }
             let q = floordiv(a, b)?;
             let r = mod_(a, b)?;
             return Ok(w_tuple_new(vec![q, r]));

--- a/pyre/pyre-interpreter/src/type_methods.rs
+++ b/pyre/pyre-interpreter/src/type_methods.rs
@@ -3453,7 +3453,7 @@ fn is_identifier(s: &str) -> bool {
 pub fn str_method_zfill(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     arity_exact(args, "str.zfill", 1)?;
     let s = unsafe { w_str_get_wtf8(args[0]) };
-    let width = unsafe { w_int_get_value(args[1]) }.max(0) as usize;
+    let width = crate::builtins::space_index_w(args[1])?.max(0) as usize;
     let len = s.code_points().count();
     if len >= width {
         return Ok(str_result_unchanged(args[0]));
@@ -4218,7 +4218,7 @@ pub(crate) fn str_result_unchanged(obj: PyObjectRef) -> PyObjectRef {
 pub fn str_method_center(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     arity_at_least(args, "center", 1)?;
     let s = unsafe { w_str_get_wtf8(args[0]) };
-    let width = unsafe { w_int_get_value(args[1]) }.max(0) as usize;
+    let width = crate::builtins::space_index_w(args[1])?.max(0) as usize;
     let fillchar = pad_fillchar(args, "center")?;
     let s_len = s.code_points().count();
     if s_len >= width {
@@ -4239,7 +4239,7 @@ pub fn str_method_center(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyE
 pub fn str_method_ljust(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     arity_at_least(args, "ljust", 1)?;
     let s = unsafe { w_str_get_wtf8(args[0]) };
-    let width = unsafe { w_int_get_value(args[1]) }.max(0) as usize;
+    let width = crate::builtins::space_index_w(args[1])?.max(0) as usize;
     let fillchar = pad_fillchar(args, "ljust")?;
     let s_len = s.code_points().count();
     if s_len >= width {
@@ -4255,7 +4255,7 @@ pub fn str_method_ljust(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyEr
 pub fn str_method_rjust(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     arity_at_least(args, "rjust", 1)?;
     let s = unsafe { w_str_get_wtf8(args[0]) };
-    let width = unsafe { w_int_get_value(args[1]) }.max(0) as usize;
+    let width = crate::builtins::space_index_w(args[1])?.max(0) as usize;
     let fillchar = pad_fillchar(args, "rjust")?;
     let s_len = s.code_points().count();
     if s_len >= width {


### PR DESCRIPTION
Interpreter-level correctness fixes, each verified against CPython 3.14
and PyPy 3.11 and gated on both backends (dynasm 216/216, cranelift
216/216).

- **delattr**: `del inst.missing` on a dict-less user instance named the
  base `object` type; now reports the receiver's actual type via
  `raiseattrerror`.
- **attr (read-only)**: set/del of a non-data (non-settable) descriptor
  on a dict-less receiver reported "has no attribute"; now reports
  "'X' object attribute 'Y' is read-only", matching CPython and PyPy.
  The read-only error is a plain `AttributeError` — `e.name` / `e.obj`
  read back as `None`, as on CPython/PyPy (only the missing-attribute
  path carries the lookup context).
- **add_note**: `Exception.add_note(5)` said "note must be a string";
  now "note must be a str, not int", naming the offending type.
- **divmod**: `divmod(1, 0)` surfaced floordiv's "integer division or
  modulo by zero"; now the dedicated "integer divmod by zero".
- **str**: `zfill`/`center`/`ljust`/`rjust` read the width argument with
  a raw unchecked int accessor, so a non-int width (str/float/None) read
  arbitrary storage as a huge width and drove an effectively unbounded
  allocation/hang; a bignum width was misread. Width now parses through
  `space_index_w` (accepts int/bool/`__index__`, rejects a non-index),
  and `space_index_w` gained a long branch (OverflowError when a bigint
  does not fit) that also fixes `expandtabs` and the bytes pad methods.

Two earlier commits were dropped when this branch rebased onto `main`:
the REPL `SystemExit` fix landed as #604 and the explicit-`__class__`
preservation as part of #562 — both verified equivalent, no regression.

— *commented by Claude*
