### PR TITLE
_pickle: accept and ignore constructor args in Pickler/Unpickler __new__

### DIFF
--- a/pyre/bench/synth/pickle_ctor_args.py
+++ b/pyre/bench/synth/pickle_ctor_args.py
@@ -1,0 +1,65 @@
+# _pickle.Pickler/Unpickler accept their constructor arguments positionally and
+# by keyword: tp_new allocates and ignores them, __init__ validates and stores
+# them. `pickle.Pickler` binds to the C accelerator where it exists and to the
+# pure-Python class otherwise; both agree on the observable results asserted
+# here (protocol given positionally or by keyword, fix_imports, out-of-band
+# buffers via buffer_callback / the Unpickler buffers argument, and the
+# protocol<5 buffer_callback rejection).
+import io
+import pickle
+from pickle import Pickler, Unpickler, PickleBuffer
+
+
+def roundtrip(obj, protocol):
+    data = io.BytesIO()
+    Pickler(data, protocol).dump(obj)
+    data.seek(0)
+    return Unpickler(data).load()
+
+
+def roundtrip_kw(obj, protocol, fix_imports):
+    data = io.BytesIO()
+    Pickler(data, protocol=protocol, fix_imports=fix_imports).dump(obj)
+    data.seek(0)
+    return Unpickler(data, fix_imports=fix_imports).load()
+
+
+def oob_roundtrip(obj, protocol):
+    buffers = []
+    data = io.BytesIO()
+    Pickler(data, protocol, buffer_callback=buffers.append).dump(obj)
+    data.seek(0)
+    restored = Unpickler(data, buffers=iter(buffers)).load()
+    return bytes(restored), [bytes(b) for b in buffers]
+
+
+def warm(n):
+    acc = 0
+    for i in range(n):
+        acc += roundtrip(i % 7, 2)
+        acc += len(roundtrip([i % 3, i % 5], 4))
+    return acc
+
+
+def m(label, fn):
+    try:
+        print(label, "->", repr(fn()))
+    except BaseException as e:
+        print(label, "!!", type(e).__name__)
+
+
+def main():
+    print("warm", warm(15000))
+    m("proto_positional", lambda: roundtrip("abc", 2))
+    m("proto_positional_hi", lambda: roundtrip(("x", "y", "z"), 5))
+    m("proto_keyword", lambda: roundtrip_kw({"a": 1, "b": 2}, 4, True))
+    m("fix_imports_false", lambda: roundtrip_kw([1, 2, 3], 2, False))
+    m("oob_bytes", lambda: oob_roundtrip(PickleBuffer(b"hello"), 5))
+    m("oob_bytearray", lambda: oob_roundtrip(PickleBuffer(bytearray(b"world")), 5))
+    # buffer_callback requires protocol >= 5
+    m("cb_low_proto", lambda: Pickler(io.BytesIO(), 4, buffer_callback=lambda b: None))
+    # file must expose a write attribute
+    m("no_write_attr", lambda: Pickler(object(), 2))
+
+
+main()

--- a/pyre/pyre-interpreter/src/module/_pickle/pickler.rs
+++ b/pyre/pyre-interpreter/src/module/_pickle/pickler.rs
@@ -247,7 +247,12 @@ impl Framer {
 #[crate::pyre_methods(doc = "Pickler(file, protocol=None) -> pickler writing to file.")]
 impl W_Pickler {
     #[staticmethod]
-    fn __new__(_cls: PyObjectRef) -> PyObjectRef {
+    fn __new__(_cls: PyObjectRef, _args: &[PyObjectRef]) -> PyObjectRef {
+        // Construction arguments are consumed/validated by `__init__`; accept
+        // (and ignore) any positional or keyword args here via the whole-slice
+        // catch-all so the ctor keyword parameters (protocol/fix_imports/
+        // buffer_callback) do not trip an unknown-argument error in `__new__`.
+        let _ = _args;
         W_Pickler::allocate(W_Pickler {
             ob: pyre_object::PyObject {
                 ob_type: std::ptr::null(),

--- a/pyre/pyre-interpreter/src/module/_pickle/unpickler.rs
+++ b/pyre/pyre-interpreter/src/module/_pickle/unpickler.rs
@@ -44,7 +44,12 @@ pub struct W_Unpickler {
 #[crate::pyre_methods(doc = "Unpickler(file) -> unpickler reading from file.")]
 impl W_Unpickler {
     #[staticmethod]
-    fn __new__(_cls: PyObjectRef) -> PyObjectRef {
+    fn __new__(_cls: PyObjectRef, _args: &[PyObjectRef]) -> PyObjectRef {
+        // Construction arguments are consumed/validated by `__init__`; accept
+        // (and ignore) any positional or keyword args here via the whole-slice
+        // catch-all so the ctor keyword parameters (fix_imports/encoding/errors/
+        // buffers) do not trip an unknown-argument error in `__new__`.
+        let _ = _args;
         W_Unpickler::allocate(W_Unpickler {
             ob: pyre_object::PyObject {
                 ob_type: std::ptr::null(),


### PR DESCRIPTION
## Summary

`pickle.Pickler(...)` / `pickle.Unpickler(...)` (the `_pickle` C-accelerator classes) raised an unknown-argument error when given their documented constructor arguments, because `__new__` accepted only the class and rejected the ctor args before `__init__` could parse them.

## What changed

- `Pickler.__new__` / `Unpickler.__new__` now take a whole-slice catch-all (`_args: &[PyObjectRef]`) and ignore it; construction arguments are consumed and validated by `__init__`. This lets the ctor arguments (`protocol` / `fix_imports` / `buffer_callback` for Pickler; `fix_imports` / `encoding` / `errors` / `buffers` for Unpickler) reach `__init__` instead of tripping an unknown-argument error in `__new__`.
- New synthetic parity bench `pyre/bench/synth/pickle_ctor_args.py` asserting protocol (positional/keyword), `fix_imports`, and out-of-band buffers round-trip identically.

## Verification

`python3 pyre/check.py --backend dynasm,cranelift --synthetic-only` → dynasm + cranelift ALL PASSED. Bench output is byte-identical across cpython3, pypy3, and both pyre backends.

— *commented by Claude*
