### PR TITLE
traceback: don't let caret rendering crash when ast.parse returns a code object

### DIFF
--- a/lib-python/3/traceback.py
+++ b/lib-python/3/traceback.py
@@ -709,7 +709,7 @@ class StackSummary(list):
         return ''.join(row)
 
     def _should_show_carets(self, start_offset, end_offset, all_lines, anchors):
-        with suppress(SyntaxError, ImportError):
+        with suppress(SyntaxError, ImportError, AttributeError):
             import ast
             tree = ast.parse('\n'.join(all_lines))
             if not tree.body:


### PR DESCRIPTION
## Problem

pyre has no AST surface (`_ast` only exposes type stubs), so `compile(src, PyCF_ONLY_AST)` / `ast.parse()` returns a **code object** rather than a real AST node. In `StackSummary._should_show_carets` this makes `tree.body` raise `AttributeError`, which the surrounding `suppress(SyntaxError, ImportError)` does **not** catch — so the exception escapes.

Because `_should_show_carets` runs while formatting *any* traceback with column info, a genuine failure gets turned into an uncaught crash that masks the real error. Concretely, `cargo run -- -m test test_math` reported:

```
test test_math crashed -- Traceback (most recent call last):
  File ".../traceback.py", line 715, in _should_show_carets
    if not tree.body:
AttributeError: 'code' object has no attribute 'body'
...
test_math failed (uncaught exception)
Total tests: run=0
```

instead of the actual `testFactorial` assertion failure. The whole test file collapsed to "crashed / run=0".

## Fix

Add `AttributeError` to the suppressed set so the caret optimisation is simply skipped and control falls through to the anchor/whitespace heuristic below — the same graceful degradation the adjacent `_extract_caret_anchors_from_line_segment` call already gets from `suppress(Exception)`.

This is a stopgap for the missing AST surface, not a fix for it; it only stops crash-masking so real failures surface.

## After

```
test test_math failed -- Traceback (most recent call last):
  File ".../test/test_math.py", line 544, in testFactorial
    self.assertEqual(math.factorial(i), py_factorial(i))
AssertionError: 2658271574788448768043625811014615890319638528000000000 != 1239945716190355200728741115120844800000
...
test_math failed (1 failure)
Total tests: run=89 failures=1 skipped=5
```

The traceback now renders without crashing and the real failure is visible. (The remaining `testFactorial` failure is a separate JIT miscompilation, tracked independently.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved traceback formatting by preventing internal attribute errors from interrupting caret-marker rendering.
  * Exception details now display more reliably when source-code anchors cannot be detected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->