### PR TITLE
jit: instrument carried-coordinate fallback census (#369 closure evidence)

### DIFF
--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -11512,12 +11512,21 @@ fn decode_side_other_target(
 /// never reaches that leg.
 pub(crate) fn expand_branch_carried(payload: &crate::PyJitCode, carried: i32) -> i32 {
     match majit_ir::resumedata::decode_branch_orgpc(carried) {
-        None => carried,
+        None => {
+            pcmap_pivot_audit_record_fire("expand_branch_carried", "passthrough");
+            carried
+        }
         Some((orgpc, flavor)) => {
             let code = payload.jitcode.code.as_slice();
             match decode_side_other_target(code, orgpc, flavor) {
-                Err(_) => majit_ir::resumedata::NO_JITCODE_PC,
-                Ok(derived) => derived as i32,
+                Err(_) => {
+                    pcmap_pivot_audit_record_fire("expand_branch_carried", "expanded_fail");
+                    majit_ir::resumedata::NO_JITCODE_PC
+                }
+                Ok(derived) => {
+                    pcmap_pivot_audit_record_fire("expand_branch_carried", "expanded_ok");
+                    derived as i32
+                }
             }
         }
     }
@@ -12110,7 +12119,12 @@ fn walker_capture_inline_nonstandard_vable_guard(
     let Some(nsvable_pc_word) =
         crate::state::pyjitcode_for_jitcode_index(ctx.outer_jitcode_index as i32)
             .and_then(|payload| {
-                payload.resolve_resume_pc_with_jitcode_pc(nsvable_word, crate::state::op_live())
+                let resolved = payload
+                    .resolve_resume_pc_with_jitcode_pc(nsvable_word, crate::state::op_live());
+                if resolved.is_none() {
+                    pcmap_pivot_audit_record_fire("resolve_none_caller", "nsvable_word");
+                }
+                resolved
             })
             .map(|offset| offset as u32)
     else {
@@ -13012,10 +13026,12 @@ fn walker_capture_snapshot_for_last_guard_impl(
                 scope.branch_guard_kept_recovered,
             );
             let payload = unsafe { &(&*sym.jitcode).payload };
-            let Some(pc_word) = payload
-                .resolve_resume_pc_with_jitcode_pc(guard_jitcode_pc, crate::state::op_live())
-                .map(|offset| offset as u32)
-            else {
+            let resolved = payload
+                .resolve_resume_pc_with_jitcode_pc(guard_jitcode_pc, crate::state::op_live());
+            if resolved.is_none() {
+                pcmap_pivot_audit_record_fire("resolve_none_caller", "guard_snapshot");
+            }
+            let Some(pc_word) = resolved.map(|offset| offset as u32) else {
                 return Err(DispatchError::GuardResumeCoordinateUnavailable { pc: op_pc });
             };
             ctx.trace_ctx
@@ -13044,7 +13060,12 @@ fn walker_capture_snapshot_for_last_guard_impl(
     let Some(arm_pc_word) =
         crate::state::pyjitcode_for_jitcode_index(ctx.outer_jitcode_index as i32)
             .and_then(|payload| {
-                payload.resolve_resume_pc_with_jitcode_pc(arm_word, crate::state::op_live())
+                let resolved =
+                    payload.resolve_resume_pc_with_jitcode_pc(arm_word, crate::state::op_live());
+                if resolved.is_none() {
+                    pcmap_pivot_audit_record_fire("resolve_none_caller", "arm_word");
+                }
+                resolved
             })
             .map(|offset| offset as u32)
     else {
@@ -13706,7 +13727,12 @@ fn walker_capture_multi_frame_inline_snapshot(
         };
         let Some(pf_pc_word) = crate::state::pyjitcode_for_jitcode_index(pf.jitcode_index as i32)
             .and_then(|payload| {
-                payload.resolve_resume_pc_with_jitcode_pc(pf_word, crate::state::op_live())
+                let resolved =
+                    payload.resolve_resume_pc_with_jitcode_pc(pf_word, crate::state::op_live());
+                if resolved.is_none() {
+                    pcmap_pivot_audit_record_fire("resolve_none_caller", "pf_word");
+                }
+                resolved
             })
             .map(|offset| offset as u32)
         else {

--- a/pyre/pyre-jit-trace/src/pyjitcode.rs
+++ b/pyre/pyre-jit-trace/src/pyjitcode.rs
@@ -792,8 +792,24 @@ impl PyJitCode {
             && carried >= 0
             && self.jitcode.can_decode_live_vars(carried as usize, op_live);
         if used_carried {
+            crate::jitcode_dispatch::pcmap_pivot_audit_record_fire(
+                "resolve_resume_pc",
+                "carried_used",
+            );
             Some(carried as usize)
         } else {
+            crate::jitcode_dispatch::pcmap_pivot_audit_record_fire(
+                "resolve_resume_pc",
+                "carried_none",
+            );
+            crate::jitcode_dispatch::pcmap_pivot_audit_record_fire(
+                "resolve_resume_pc",
+                if carried == majit_ir::resumedata::NO_JITCODE_PC || carried < 0 {
+                    "none_sentinel"
+                } else {
+                    "none_not_live_anchored"
+                },
+            );
             None
         }
     }
@@ -809,10 +825,30 @@ impl PyJitCode {
     /// does not name a decodable startpoint (the caller keeps the pc_map entry).
     pub fn resolve_bridge_walk_entry_pc(&self, carried: i32, op_live: u8) -> Option<usize> {
         let carried = crate::jitcode_dispatch::expand_branch_carried(self, carried);
-        (carried != majit_ir::resumedata::NO_JITCODE_PC
+        let used_carried = carried != majit_ir::resumedata::NO_JITCODE_PC
             && carried >= 0
-            && self.jitcode.can_decode_live_vars(carried as usize, op_live))
-        .then_some(carried as usize)
+            && self.jitcode.can_decode_live_vars(carried as usize, op_live);
+        if used_carried {
+            crate::jitcode_dispatch::pcmap_pivot_audit_record_fire(
+                "resolve_bridge_walk_entry",
+                "carried_used",
+            );
+            Some(carried as usize)
+        } else {
+            crate::jitcode_dispatch::pcmap_pivot_audit_record_fire(
+                "resolve_bridge_walk_entry",
+                "carried_none",
+            );
+            crate::jitcode_dispatch::pcmap_pivot_audit_record_fire(
+                "resolve_bridge_walk_entry",
+                if carried == majit_ir::resumedata::NO_JITCODE_PC || carried < 0 {
+                    "none_sentinel"
+                } else {
+                    "none_not_live_anchored"
+                },
+            );
+            None
+        }
     }
 
     /// Skeleton slot inserted by [`Self::skeleton`] — neither `code`

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -794,10 +794,25 @@ pub fn skip_python_trivia_forward_public(
 /// never index with the word, so no wrap results).
 pub fn backxlat_py_pc(jitcode_index: i32, pc_word: i32) -> i32 {
     let fallback = majit_ir::resumedata::decode_resume_pc(pc_word).0;
-    python_pc_for_jitcode_pc_public(jitcode_index, pc_word)
+    match python_pc_for_jitcode_pc_public(jitcode_index, pc_word)
         .and_then(|raw_py_pc| skip_python_trivia_forward_public(jitcode_index, raw_py_pc))
         .map(|(py_pc, _)| py_pc)
-        .unwrap_or(fallback)
+    {
+        Some(py_pc) => {
+            pyre_jit_trace::jitcode_dispatch::pcmap_pivot_audit_record_fire(
+                "backxlat_py_pc",
+                "pivot_hit",
+            );
+            py_pc
+        }
+        None => {
+            pyre_jit_trace::jitcode_dispatch::pcmap_pivot_audit_record_fire(
+                "backxlat_py_pc",
+                "py_word_fallback",
+            );
+            fallback
+        }
+    }
 }
 
 /// `framework.py` `root_walker.walk_roots` hook for the boxed `Ref`
@@ -1065,8 +1080,16 @@ pub fn resolve_bridge_walk_entry_at(jitcode_index: i32, carried_jitcode_pc: i32)
     METAINTERP_SD.with(|r| {
         let sd = r.borrow();
         let jc = sd.jitcodes.get(jitcode_index as usize)?;
-        jc.payload
-            .resolve_bridge_walk_entry_pc(carried_jitcode_pc, sd.op_live)
+        let resolved = jc
+            .payload
+            .resolve_bridge_walk_entry_pc(carried_jitcode_pc, sd.op_live);
+        if resolved.is_none() {
+            pyre_jit_trace::jitcode_dispatch::pcmap_pivot_audit_record_fire(
+                "resolve_none_caller",
+                "bridge_walk_entry",
+            );
+        }
+        resolved
     })
 }
 
@@ -1210,6 +1233,10 @@ pub fn frame_liveness_reg_indices_by_bank_at_with_jitcode_pc(
         let resolved_jit_pc: Option<usize> =
             payload.resolve_resume_pc_with_jitcode_pc(carried_jitcode_pc, sd.op_live);
         let Some(jit_pc) = resolved_jit_pc else {
+            pyre_jit_trace::jitcode_dispatch::pcmap_pivot_audit_record_fire(
+                "resolve_none_caller",
+                "frame_liveness",
+            );
             return FrameLivenessRegIndices::default();
         };
         let off = payload.jitcode.get_live_vars_info(jit_pc, sd.op_live);

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -4071,8 +4071,17 @@ impl MIFrame {
             let parent_pc_word =
                 crate::state::pyjitcode_for_jitcode_index(parent_jitcode_index as i32)
                     .and_then(|payload| {
-                        payload
-                            .resolve_resume_pc_with_jitcode_pc(parent_word, crate::state::op_live())
+                        let resolved = payload.resolve_resume_pc_with_jitcode_pc(
+                            parent_word,
+                            crate::state::op_live(),
+                        );
+                        if resolved.is_none() {
+                            crate::jitcode_dispatch::pcmap_pivot_audit_record_fire(
+                                "resolve_none_caller",
+                                "parent_word",
+                            );
+                        }
+                        resolved
                     })
                     .map(|offset| offset as u32)
                     .unwrap_or_else(|| {
@@ -4128,15 +4137,19 @@ impl MIFrame {
             majit_ir::resumedata::NO_JITCODE_PC
         };
         let payload = unsafe { &(&*self.sym().jitcode).payload };
-        let top_pc_word = payload
-            .resolve_resume_pc_with_jitcode_pc(top_word, crate::state::op_live())
-            .map(|offset| offset as u32)
-            .unwrap_or_else(|| {
-                // A missing carried marker declines this trace before the
-                // provisional snapshot can be installed.
-                crate::state::request_trace_abort();
-                top_pc as u32
-            });
+        let resolved = payload.resolve_resume_pc_with_jitcode_pc(top_word, crate::state::op_live());
+        if resolved.is_none() {
+            crate::jitcode_dispatch::pcmap_pivot_audit_record_fire(
+                "resolve_none_caller",
+                "top_word",
+            );
+        }
+        let top_pc_word = resolved.map(|offset| offset as u32).unwrap_or_else(|| {
+            // A missing carried marker declines this trace before the
+            // provisional snapshot can be installed.
+            crate::state::request_trace_abort();
+            top_pc as u32
+        });
         let top_frame = majit_metainterp::recorder::SnapshotFrame {
             jitcode_index: top_jitcode_index,
             pc: top_pc_word,


### PR DESCRIPTION
Report-only fire counters behind the existing `PYRE_PCMAP_PIVOT_AUDIT` gate + `PYRE_PCMAP_PIVOT_AUDIT_PROBE` sink, covering the carried-coordinate arms that remained after #602:

- `resolve_resume_pc_with_jitcode_pc` / `resolve_bridge_walk_entry_pc`: carried_used vs carried_none (none split into sentinel vs not-live-anchored), plus per-caller None attribution at all 8 call sites
- `expand_branch_carried`: passthrough / expanded_ok / expanded_fail
- `backxlat_py_pc`: pivot_hit vs legacy py-word fallback

Audit-off behavior is byte-identical (counters are gated). The corpus census taken with these counters is the closure evidence recorded on #369: carried coordinate accepted 43,968/47,996 (+1,293 bridge) per backend, every fallback/None arm 0 fires, `expanded_fail` = encode-side self-certification rejection only.

Verification: check.py dynasm 216/216 + cranelift 216/216 audit-off, dynasm 216/216 audit-on; cargo test green (known `test_subclass_range_preorder_bounds` aggregate flake, standalone pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Diagnostics**
  * Added more detailed audit events for JIT resume and coordinate resolution outcomes.
  * Improved visibility into successful, fallback, and unavailable resolution paths.
  * Added contextual information for tracing resolution failures across snapshots, guards, bridge walks, and frame liveness checks.
* **Reliability**
  * Preserved existing fallback and trace-abort behavior when resolution cannot be completed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->