### PR TITLE
jit: store_deref_value residual is PlainCannotRaise

### DIFF
--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -5608,7 +5608,7 @@ pub extern "C" fn bh_load_deref_value_fn(cell: i64, w_code_ptr: i64, deref_idx: 
 /// write barrier inside) and return the unchanged cell so the caller
 /// re-stores the same pointer into the slot; otherwise return the raw
 /// `value` so the caller writes it into the slot directly.  Runs no user
-/// code and never raises (`CallFlavor::Plain`).
+/// code and never raises (`CallFlavor::PlainCannotRaise`).
 pub extern "C" fn bh_store_deref_value_fn(cell: i64, value: i64) -> i64 {
     let slot = cell as pyre_object::PyObjectRef;
     if !slot.is_null() && unsafe { pyre_object::is_cell(slot) } {

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -11335,8 +11335,8 @@ impl CodeWriter {
                         // `store_deref_value(cell, value)` HLOp →
                         // `residual_call_r_r(store_deref_value_fn,
                         // ListR[cell, value])` mutates the cell's contents in
-                        // place (`bh_store_deref_value_fn`, Plain — writes
-                        // heap, runs no user code) and returns the slot value:
+                        // place (`bh_store_deref_value_fn`, PlainCannotRaise —
+                        // writes heap, runs no user code) and returns the slot value:
                         // the unchanged cell for a cell slot, or the raw
                         // `value` for a non-cell slot. The result is stored
                         // back into the slot via `setarrayitem_vable_r`

--- a/pyre/pyre-jit/src/jit/flatten.rs
+++ b/pyre/pyre-jit/src/jit/flatten.rs
@@ -3410,8 +3410,8 @@ pub struct LoweringContext {
     /// ConstInt(fn_idx), ListR([cell, value]), Descr) → reg` via
     /// [`lower_store_deref_value_hlop_to_insn`] (the two-Ref shape); the result
     /// is the slot value the codewriter re-stores via `setarrayitem_vable_r`.
-    /// `bh_store_deref_value_fn` mutates the cell's contents (`Plain` — writes
-    /// heap, runs no user code, never raises).
+    /// `bh_store_deref_value_fn` mutates the cell's contents
+    /// (`PlainCannotRaise` — writes heap, runs no user code, never raises).
     pub store_deref_value_fn_idx: u16,
     /// `make_cell_fn` descrs-pool index.  MAKE_CELL records the
     /// `make_cell_value(current)` HLOp lowered to `residual_call_r_r(ConstInt(
@@ -5551,7 +5551,7 @@ where
 /// operand.  The result is the slot value the codewriter re-stores via
 /// `setarrayitem_vable_r`: the unchanged cell after the in-place `w_cell_set`,
 /// or the raw `value` for a non-cell slot.  Writes mutable heap but runs no
-/// user code and never raises → `Plain`.
+/// user code and never raises → `PlainCannotRaise`.
 ///
 /// Returns `None` for a non-`store_deref_value` opname or unexpected arity so
 /// the caller can fall through to other lowering arms.
@@ -5577,13 +5577,19 @@ where
     Some(build_residual_call_r_r_insn_from_operands(
         ctx.store_deref_value_fn_idx,
         vec![cell, value],
-        CallFlavor::Plain,
+        // `bh_store_deref_value_fn` runs no user code and never raises (a
+        // `w_cell_set` heap write, or returning the raw slot value), so
+        // `PlainCannotRaise` — writes heap but omits the trailing
+        // `GUARD_NO_EXCEPTION`.  Matches the bind-site flavor in
+        // `codewriter.rs`; `pyopcode.py:574 STORE_DEREF` is `cell.set(...)`.
+        CallFlavor::PlainCannotRaise,
         // #57 Option C (Finding #1): a value-returning (`Ref`) heap WRITE — the
         // in-place cell mutation the FOR_ITER body-effect guard's Void-result
         // write proxy cannot see.  Tag it so the guard flags it as a body
         // effect and an aborting FOR_ITER walk refuses delivery (else
-        // re-running the body doubles the cell write).  The tag does not change
-        // the `Plain`/`EF_CAN_RAISE` classification.
+        // re-running the body doubles the cell write).  The tag is orthogonal
+        // to the raise classification: the FOR_ITER body-effect guard keys on
+        // this `StoreDeref` helper tag, not on the `PlainCannotRaise` flavor.
         majit_ir::PyreHelperKind::StoreDeref,
         dst_reg,
     ))
@@ -11841,8 +11847,8 @@ mod tests {
     fn lower_store_deref_value_hlop_emits_store_deref_value_fn_residual() {
         // `store_deref_value(cell, value)` →
         // `residual_call_r_r(ConstInt(store_deref_value_fn_idx),
-        // ListR([cell, value]), Descr) → reg` (Plain — mutates the cell's
-        // heap contents, runs no user code, never raises).
+        // ListR([cell, value]), Descr) → reg` (PlainCannotRaise — mutates the
+        // cell's heap contents, runs no user code, never raises).
         let cell_var = Variable::new(VariableId(8), Kind::Ref);
         let value_var = Variable::new(VariableId(9), Kind::Ref);
         let result_var = Variable::new(VariableId(10), Kind::Ref);
@@ -11908,6 +11914,25 @@ mod tests {
                         index: 102
                     }),
                 );
+                match &args[2] {
+                    Operand::Descr(rc) => match &**rc {
+                        DescrOperand::CallDescrStub(stub) => {
+                            let mut expected_ei =
+                                effect_info_for_call_flavor(CallFlavor::PlainCannotRaise);
+                            expected_ei.pyre_helper = majit_ir::PyreHelperKind::StoreDeref;
+                            assert_eq!(
+                                stub.effect_info, expected_ei,
+                                "STORE_DEREF residual must carry PlainCannotRaise + StoreDeref tag"
+                            );
+                            assert!(
+                                !stub.effect_info.check_can_raise(false),
+                                "cannot-raise residual must omit the trailing GUARD_NO_EXCEPTION"
+                            );
+                        }
+                        other => panic!("expected CallDescrStub, got {other:?}"),
+                    },
+                    other => panic!("expected Operand::Descr, got {other:?}"),
+                }
             }
             _ => panic!("expected Insn::Op, got {insn:?}"),
         }


### PR DESCRIPTION
Resolves the effect-shape inconsistency reported in #587.

`store_deref_value` had its effect declared in two disagreeing places:
the codewriter bind site (`jit/codewriter.rs`) as `CallFlavor::PlainCannotRaise`,
but the HLOp lowering (`lower_store_deref_value_hlop_to_insn` in `jit/flatten.rs`)
as `CallFlavor::Plain` (= `EF_CAN_RAISE`). The lowering site is the one that
governs the emitted effect: `build_residual_call_r_r_insn_from_operands` turns
the flavor into `effect_info_for_call_flavor` and attaches it to the residual's
`CallDescrStub`, so the `residual_call_r_r` carried a can-raise shape and an
unnecessary trailing `guard_no_exception`.

`bh_store_deref_value_fn` only performs a `w_cell_set` heap write (or returns
the raw slot value) and runs no user code, so it never raises. This changes the
lowering flavor to `PlainCannotRaise`: keeps the heap write (`can_collect`
stays true), omits the guard. Affects `STORE_DEREF` and `DELETE_DEREF` (which
reuse the same helper shape).

The `StoreDeref` `pyre_helper` tag is unchanged; the #57 FOR_ITER body-effect
guard keys on that tag, not on the raise flavor.

## Verification
- `cargo test -p pyre-jit --features dynasm`: `lower_store_deref_value_hlop_emits_store_deref_value_fn_residual`
  (extended to assert `effect_info == PlainCannotRaise + StoreDeref` and cannot-raise)
  and `for_iter_store_deref_with_branch_and_call_body_is_jit_safe` (the #57 guard) both pass.
- `python3 pyre/check.py`: dynasm 210/210, cranelift 211/211. The two remaining
  failures are pre-existing and unrelated to this change: `nested_loop` dynasm
  perf flake, and a wasm-only `global_quasiimmut_invalidation` miscompile (the
  fixture has zero DEREF opcodes, so this lowering path never runs for it).

Point 4 of the issue (a `MAJIT_STATS` measurement quantifying the removed guard)
is deferred as the explicitly low-priority item — `STORE_DEREF`/`DELETE_DEREF`
are not hot-loop dominators.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected internal handling for a heap-value storage operation so it is recognized as non-raising.
  * Updated validation to ensure the operation does not include unnecessary exception checks.

* **Documentation**
  * Clarified internal documentation to accurately describe the operation’s non-raising behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->