### PR TITLE
exceptions: PEP 654 except* + reraise/derive/split overridability + implicit __context__ chaining

### DIFF
--- a/pyre/bench/synth/except_star.py
+++ b/pyre/bench/synth/except_star.py
@@ -1,0 +1,59 @@
+def m(label, value):
+    print(label, "->", repr(value))
+
+
+def leaf_names(exc):
+    if isinstance(exc, BaseExceptionGroup):
+        result = []
+        for child in exc.exceptions:
+            result.extend(leaf_names(child))
+        return result
+    return [type(exc).__name__]
+
+
+def exercise():
+    caught = []
+    try:
+        raise ExceptionGroup("warmup", [ValueError(1), TypeError(2)])
+    except* ValueError as group:
+        caught.extend(type(exc).__name__ for exc in group.exceptions)
+    except* TypeError as group:
+        caught.extend(type(exc).__name__ for exc in group.exceptions)
+    return caught
+
+
+for _ in range(2000):
+    exercise()
+
+m("matches", exercise())
+
+try:
+    raise ValueError(1)
+except* ValueError as group:
+    m("naked", (type(group).__name__, [type(exc).__name__ for exc in group.exceptions]))
+
+try:
+    try:
+        raise ExceptionGroup("g", [ValueError(1), TypeError(2)])
+    except* ValueError:
+        pass
+except* TypeError as group:
+    m("rest", [type(exc).__name__ for exc in group.exceptions])
+
+try:
+    try:
+        raise ExceptionGroup("g", [ValueError(1), TypeError(2), KeyError(3)])
+    except* ValueError:
+        raise
+    except* TypeError:
+        pass
+except ExceptionGroup as escaped:
+    m("reraised", sorted(leaf_names(escaped)))
+
+try:
+    try:
+        raise ExceptionGroup("g", [ValueError(1)])
+    except* ExceptionGroup:
+        pass
+except TypeError as exc:
+    m("group target", str(exc))

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -5247,7 +5247,27 @@ pub(crate) fn exception_group_match(
         return Ok((group, pyre_object::w_none()));
     }
     if crate::baseobjspace::isinstance(w_exc, base_group)? {
-        return exception_group_split_inner(w_exc, &ExceptionGroupCondition::Class(w_type));
+        // Partial match: call the (overridable) `split` method and validate it
+        // returns a 2-tuple of (match, rest).
+        let split = crate::baseobjspace::getattr_str(w_exc, "split")?;
+        let pair = crate::call::call_function_impl_result(split, &[w_type])?;
+        if !unsafe { pyre_object::is_tuple(pair) } {
+            let name = crate::baseobjspace::object_functionstr_type_name(pair);
+            return Err(crate::PyError::type_error(format!(
+                "split must return a tuple, not {name}"
+            )));
+        }
+        let n = unsafe { pyre_object::w_tuple_len(pair) };
+        if n < 2 {
+            return Err(crate::PyError::type_error(format!(
+                "split must return a 2-tuple, got tuple of size {n}"
+            )));
+        }
+        // Tuples longer than 2 are accepted for backwards compatibility; only
+        // the first two elements (match, rest) are used.
+        let matching = unsafe { pyre_object::w_tuple_getitem(pair, 0) }.unwrap();
+        let rest = unsafe { pyre_object::w_tuple_getitem(pair, 1) }.unwrap();
+        return Ok((matching, rest));
     }
     Ok((pyre_object::w_none(), w_exc))
 }

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -5083,6 +5083,7 @@ fn exception_group_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyErr
 enum ExceptionGroupCondition {
     Class(PyObjectRef),
     Callable(PyObjectRef),
+    Identity(Vec<usize>),
 }
 
 impl ExceptionGroupCondition {
@@ -5093,6 +5094,7 @@ impl ExceptionGroupCondition {
                 let result = crate::call::call_function_impl_result(callable, &[exc])?;
                 crate::baseobjspace::is_true(result)
             }
+            Self::Identity(ref addresses) => Ok(addresses.contains(&(exc as usize))),
         }
     }
 }
@@ -5227,6 +5229,141 @@ fn exception_group_split_inner(
         exception_group_derive_and_copy(w_self, nonmatching)?
     };
     Ok((yes, no))
+}
+
+pub(crate) fn exception_group_match(
+    w_exc: PyObjectRef,
+    w_type: PyObjectRef,
+) -> Result<(PyObjectRef, PyObjectRef), crate::PyError> {
+    let base_group = lookup_exc_class("BaseExceptionGroup").unwrap();
+    if crate::baseobjspace::isinstance(w_exc, w_type)? {
+        if crate::baseobjspace::isinstance(w_exc, base_group)? {
+            return Ok((w_exc, pyre_object::w_none()));
+        }
+        let message = unsafe { pyre_object::w_str_new("") };
+        let exceptions = pyre_object::w_tuple_new(vec![w_exc]);
+        let group = exception_group_new(&[base_group, message, exceptions])?;
+        return Ok((group, pyre_object::w_none()));
+    }
+    if crate::baseobjspace::isinstance(w_exc, base_group)? {
+        return exception_group_split_inner(w_exc, &ExceptionGroupCondition::Class(w_type));
+    }
+    Ok((pyre_object::w_none(), w_exc))
+}
+
+fn exception_group_notes(w_exc: PyObjectRef) -> Result<Option<PyObjectRef>, crate::PyError> {
+    match crate::baseobjspace::getattr_str(w_exc, "__notes__") {
+        Ok(notes) => Ok(Some(notes)),
+        Err(err) if err.kind == crate::PyErrorKind::AttributeError => Ok(None),
+        Err(err) => Err(err),
+    }
+}
+
+fn exception_group_same_metadata(
+    w_left: PyObjectRef,
+    w_right: PyObjectRef,
+) -> Result<bool, crate::PyError> {
+    let left_notes = exception_group_notes(w_left)?;
+    let right_notes = exception_group_notes(w_right)?;
+    if !match (left_notes, right_notes) {
+        (Some(left), Some(right)) => std::ptr::eq(left, right),
+        (None, None) => true,
+        _ => false,
+    } {
+        return Ok(false);
+    }
+    Ok(unsafe {
+        std::ptr::eq(
+            pyre_object::interp_exceptions::w_exception_get_traceback(w_left),
+            pyre_object::interp_exceptions::w_exception_get_traceback(w_right),
+        ) && std::ptr::eq(
+            pyre_object::interp_exceptions::w_exception_get_cause(w_left),
+            pyre_object::interp_exceptions::w_exception_get_cause(w_right),
+        ) && std::ptr::eq(
+            pyre_object::interp_exceptions::w_exception_get_context(w_left),
+            pyre_object::interp_exceptions::w_exception_get_context(w_right),
+        )
+    })
+}
+
+fn exception_group_collect_leaf_addresses(
+    w_exc: PyObjectRef,
+    addresses: &mut Vec<usize>,
+) -> Result<(), crate::PyError> {
+    if unsafe { pyre_object::is_none(w_exc) } {
+        return Ok(());
+    }
+    let base_group = lookup_exc_class("BaseExceptionGroup").unwrap();
+    if crate::baseobjspace::isinstance(w_exc, base_group)? {
+        let (_, exceptions) = exception_group_fields(w_exc)?;
+        for child in unsafe { pyre_object::w_tuple_items_copy_as_vec(exceptions) } {
+            exception_group_collect_leaf_addresses(child, addresses)?;
+        }
+    } else if unsafe { pyre_object::is_exception(w_exc) } {
+        let address = w_exc as usize;
+        if !addresses.contains(&address) {
+            addresses.push(address);
+        }
+    } else {
+        let name = crate::baseobjspace::object_functionstr_type_name(w_exc);
+        return Err(crate::PyError::type_error(format!(
+            "expected BaseException, got {name}"
+        )));
+    }
+    Ok(())
+}
+
+fn exception_group_projection(
+    w_group: PyObjectRef,
+    keep: &[PyObjectRef],
+) -> Result<PyObjectRef, crate::PyError> {
+    let mut addresses = Vec::new();
+    for w_exc in keep.iter().copied() {
+        exception_group_collect_leaf_addresses(w_exc, &mut addresses)?;
+    }
+    let (matching, _) =
+        exception_group_split_inner(w_group, &ExceptionGroupCondition::Identity(addresses))?;
+    Ok(matching)
+}
+
+pub(crate) fn exception_group_prep_reraise_star(
+    w_orig: PyObjectRef,
+    w_exc_list: PyObjectRef,
+) -> Result<PyObjectRef, crate::PyError> {
+    let exceptions = crate::baseobjspace::fixedview(w_exc_list, -1)?;
+    if exceptions.is_empty() {
+        return Ok(pyre_object::w_none());
+    }
+    let base_group = lookup_exc_class("BaseExceptionGroup").unwrap();
+    if !crate::baseobjspace::isinstance(w_orig, base_group)? {
+        return Ok(exceptions[0]);
+    }
+
+    let mut raised = Vec::new();
+    let mut reraised = Vec::new();
+    for w_exc in exceptions {
+        if !unsafe { pyre_object::is_none(w_exc) } {
+            if exception_group_same_metadata(w_exc, w_orig)? {
+                reraised.push(w_exc);
+            } else {
+                raised.push(w_exc);
+            }
+        }
+    }
+    let reraised_group = exception_group_projection(w_orig, &reraised)?;
+    if raised.is_empty() {
+        return Ok(reraised_group);
+    }
+    if !unsafe { pyre_object::is_none(reraised_group) } {
+        raised.push(reraised_group);
+    }
+    if raised.len() == 1 {
+        return Ok(raised[0]);
+    }
+    let exception_group = lookup_exc_class("ExceptionGroup").unwrap();
+    let message = unsafe { pyre_object::w_str_new("") };
+    let list = pyre_object::w_list_new(raised);
+    exception_group_new(&[exception_group, message, list])
 }
 
 fn exception_group_subgroup(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -5089,7 +5089,10 @@ enum ExceptionGroupCondition {
 impl ExceptionGroupCondition {
     fn matches(&self, exc: PyObjectRef) -> Result<bool, crate::PyError> {
         match *self {
-            Self::Class(classinfo) => crate::baseobjspace::isinstance(exc, classinfo),
+            // Match on the exception's type (`exception_match`), not
+            // `isinstance`, so a matcher class with a custom metaclass
+            // `__instancecheck__` cannot pull unrelated leaves into a subgroup.
+            Self::Class(classinfo) => Ok(crate::eval::check_exc_match_against(exc, classinfo)),
             Self::Callable(callable) => {
                 let result = crate::call::call_function_impl_result(callable, &[exc])?;
                 crate::baseobjspace::is_true(result)
@@ -5237,7 +5240,7 @@ pub(crate) fn exception_group_match(
     w_type: PyObjectRef,
 ) -> Result<(PyObjectRef, PyObjectRef), crate::PyError> {
     let base_group = lookup_exc_class("BaseExceptionGroup").unwrap();
-    if crate::baseobjspace::isinstance(w_exc, w_type)? {
+    if crate::eval::check_exc_match_against(w_exc, w_type) {
         if crate::baseobjspace::isinstance(w_exc, base_group)? {
             return Ok((w_exc, pyre_object::w_none()));
         }
@@ -5397,10 +5400,14 @@ pub(crate) fn exception_group_prep_reraise_star(
     if raised.len() == 1 {
         return Ok(raised[0]);
     }
-    let exception_group = lookup_exc_class("ExceptionGroup").unwrap();
+    // Construct through BaseExceptionGroup so a merged result that carries a
+    // bare BaseException (e.g. a reraised KeyboardInterrupt alongside a freshly
+    // raised Exception) stays a BaseExceptionGroup; the constructor promotes to
+    // ExceptionGroup only when every leaf is an Exception.
+    let base_group = lookup_exc_class("BaseExceptionGroup").unwrap();
     let message = unsafe { pyre_object::w_str_new("") };
     let list = pyre_object::w_list_new(raised);
-    exception_group_new(&[exception_group, message, list])
+    exception_group_new(&[base_group, message, list])
 }
 
 fn exception_group_subgroup(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -5259,6 +5259,22 @@ fn exception_group_notes(w_exc: PyObjectRef) -> Result<Option<PyObjectRef>, crat
     }
 }
 
+/// Identity comparison of a `__traceback__`/`__cause__`/`__context__` slot,
+/// treating an unset (raw NULL) slot and the `None` singleton as the same
+/// Python-level value.  `_is_same_exception_metadata` reads these through the
+/// attribute layer, which normalizes an unset slot to `None`; the raw slot
+/// accessors do not, so a copy made via getattr/setattr (holding `None`) would
+/// otherwise not compare equal to a source whose slot was never materialized.
+fn exception_group_meta_ref_eq(w_left: PyObjectRef, w_right: PyObjectRef) -> bool {
+    let left_none = w_left.is_null() || unsafe { pyre_object::is_none(w_left) };
+    let right_none = w_right.is_null() || unsafe { pyre_object::is_none(w_right) };
+    if left_none || right_none {
+        left_none && right_none
+    } else {
+        std::ptr::eq(w_left, w_right)
+    }
+}
+
 fn exception_group_same_metadata(
     w_left: PyObjectRef,
     w_right: PyObjectRef,
@@ -5273,13 +5289,13 @@ fn exception_group_same_metadata(
         return Ok(false);
     }
     Ok(unsafe {
-        std::ptr::eq(
+        exception_group_meta_ref_eq(
             pyre_object::interp_exceptions::w_exception_get_traceback(w_left),
             pyre_object::interp_exceptions::w_exception_get_traceback(w_right),
-        ) && std::ptr::eq(
+        ) && exception_group_meta_ref_eq(
             pyre_object::interp_exceptions::w_exception_get_cause(w_left),
             pyre_object::interp_exceptions::w_exception_get_cause(w_right),
-        ) && std::ptr::eq(
+        ) && exception_group_meta_ref_eq(
             pyre_object::interp_exceptions::w_exception_get_context(w_left),
             pyre_object::interp_exceptions::w_exception_get_context(w_right),
         )

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -5138,21 +5138,22 @@ fn exception_group_copy_attrs(
     Ok(())
 }
 
-fn exception_group_derive_from(
-    w_self: PyObjectRef,
-    exceptions: Vec<PyObjectRef>,
-) -> Result<PyObjectRef, crate::PyError> {
-    let (message, _) = exception_group_fields(w_self)?;
-    let cls = crate::typedef::r#type(w_self).unwrap();
-    let list = pyre_object::w_list_new(exceptions);
-    crate::call::call_function_impl_result(cls, &[message, list])
-}
-
 fn exception_group_derive_and_copy(
     w_self: PyObjectRef,
     exceptions: Vec<PyObjectRef>,
 ) -> Result<PyObjectRef, crate::PyError> {
-    let group = exception_group_derive_from(w_self, exceptions)?;
+    // _derive_and_copy_attrs: construct the sub-result through the overridable
+    // `derive` method so a subclass can control reconstruction (e.g. thread
+    // extra constructor args), then copy the metadata attrs onto it.
+    let derive = crate::baseobjspace::getattr_str(w_self, "derive")?;
+    let list = pyre_object::w_list_new(exceptions);
+    let group = crate::call::call_function_impl_result(derive, &[list])?;
+    let base_group = lookup_exc_class("BaseExceptionGroup").unwrap();
+    if !crate::baseobjspace::isinstance(group, base_group)? {
+        return Err(crate::PyError::type_error(
+            "derive must return an instance of BaseExceptionGroup",
+        ));
+    }
     exception_group_copy_attrs(w_self, group)?;
     Ok(group)
 }
@@ -5409,9 +5410,13 @@ fn exception_group_derive(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::Py
             "derive() takes exactly one argument",
         ));
     }
+    // The default derive constructs a BaseExceptionGroup (promoted to
+    // ExceptionGroup when every leaf is an Exception), NOT `type(self)`: a
+    // subclass that adds constructor args must override `derive` to preserve
+    // its type, otherwise split/subgroup fall back to the base class.
     let (message, _) = exception_group_fields(args[0])?;
-    let cls = crate::typedef::r#type(args[0]).unwrap();
-    crate::call::call_function_impl_result(cls, &[message, args[1]])
+    let base_group = lookup_exc_class("BaseExceptionGroup").unwrap();
+    crate::call::call_function_impl_result(base_group, &[message, args[1]])
 }
 
 fn exception_group_str(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
@@ -5485,7 +5490,15 @@ fn make_exception_group_type(name: &'static str, bases: &[PyObjectRef]) -> PyObj
                     ns,
                     "__new__",
                     make_builtin_function("__new__", exception_group_new),
-                )
+                );
+                pyre_object::w_dict_setitem_str_no_proxy(
+                    ns,
+                    "__class_getitem__",
+                    pyre_object::function::w_classmethod_new(make_builtin_function(
+                        "__class_getitem__",
+                        crate::_pypy_generic_alias::generic_alias_class_getitem,
+                    )),
+                );
             };
         },
         bases,

--- a/pyre/pyre-interpreter/src/error.rs
+++ b/pyre/pyre-interpreter/src/error.rs
@@ -268,6 +268,30 @@ fn _break_context_cycle(w_value: PyObjectRef, w_context: PyObjectRef) -> Result<
     Ok(())
 }
 
+/// Record `active` as `exc.__context__` when `exc` is raised while `active`
+/// is the exception currently being handled — the shared primitive for both
+/// explicit (`raise`) and implicit (builtin/operator) raises.  Only writes
+/// when no `__context__` is already stamped (so an exception that already
+/// carries one — e.g. an explicit `raise ... from` or a re-raise — is left
+/// untouched) and skips self-context; any cycle through the context chain is
+/// broken first via `_break_context_cycle`.
+pub fn chain_context(exc: PyObjectRef, active: PyObjectRef) {
+    if exc.is_null()
+        || active.is_null()
+        || std::ptr::eq(exc, active)
+        || unsafe { pyre_object::is_none(active) }
+        || !unsafe { pyre_object::is_exception(exc) }
+        || !unsafe { pyre_object::is_exception(active) }
+    {
+        return;
+    }
+    let existing = unsafe { pyre_object::interp_exceptions::w_exception_get_context(exc) };
+    if existing.is_null() {
+        let _ = _break_context_cycle(exc, active);
+        unsafe { pyre_object::interp_exceptions::w_exception_set_context(exc, active) };
+    }
+}
+
 impl From<OperationError> for PyError {
     fn from(value: OperationError) -> Self {
         let message = if value.w_value.is_null() {

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -1055,20 +1055,7 @@ pub fn attach_raise_cause(exc: PyObjectRef, cause: Option<PyObjectRef>) -> Resul
     // `__context__` and `__cause__`/`__suppress_context__` writes land
     // in the typed slots on `W_BaseException` per
     // `interp_exceptions.py:113-117`.
-    let active = get_current_exception();
-    if !active.is_null()
-        && active != exc
-        && unsafe { !pyre_object::is_none(active) }
-        && unsafe { pyre_object::is_exception(exc) }
-    {
-        // `interp_exceptions.py:115 W_BaseException.w_context = None`
-        // class default — only write if no `__context__` is already
-        // stamped on the exception (mirrors `or_insert` semantics).
-        let existing = unsafe { pyre_object::interp_exceptions::w_exception_get_context(exc) };
-        if existing.is_null() {
-            unsafe { pyre_object::interp_exceptions::w_exception_set_context(exc, active) };
-        }
-    }
+    crate::error::chain_context(exc, get_current_exception());
     if let Some(cause_obj) = cause {
         if !cause_obj.is_null() && unsafe { pyre_object::is_exception(exc) } {
             // `interp_exceptions.py:166-174 descr_setcause` — writes
@@ -1230,6 +1217,11 @@ pub fn handle_exception(frame: &mut PyFrame, err: &mut PyError, next_instr: &mut
     if err.exc_object.is_null() {
         err.exc_object = exc_obj;
     }
+    // Implicit __context__ chaining: any exception raised while another is being
+    // handled records that active exception as its __context__, not only an
+    // explicit `raise`.  Recorded once (skipped when a __context__ is already
+    // stamped), so it lands at the frame where the exception first surfaces.
+    crate::error::chain_context(err.exc_object, get_current_exception());
     if err.attach_tb {
         if !ec.is_null() && unsafe { !(*ec).gettrace().is_null() } {
             // The materialized exception is old-gen managed but lives only in the

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -1129,6 +1129,30 @@ pub fn validate_check_exc_match_class(exc_type: PyObjectRef) -> Result<(), PyErr
     Ok(())
 }
 
+fn validate_check_eg_match_class(exc_type: PyObjectRef) -> Result<(), PyError> {
+    validate_check_exc_match_class(exc_type)?;
+    let base_group = crate::builtins::lookup_exc_class("BaseExceptionGroup").unwrap();
+    unsafe {
+        if pyre_object::is_tuple(exc_type) {
+            let n = pyre_object::w_tuple_len(exc_type) as i64;
+            for i in 0..n {
+                if let Some(w_type) = pyre_object::w_tuple_getitem(exc_type, i) {
+                    if crate::baseobjspace::issubclass(w_type, base_group)? {
+                        return Err(PyError::type_error(
+                            "catching ExceptionGroup with except* is not allowed. Use except instead.",
+                        ));
+                    }
+                }
+            }
+        } else if crate::baseobjspace::issubclass(exc_type, base_group)? {
+            return Err(PyError::type_error(
+                "catching ExceptionGroup with except* is not allowed. Use except instead.",
+            ));
+        }
+    }
+    Ok(())
+}
+
 pub fn check_exc_match_against(exc_value: PyObjectRef, exc_type: PyObjectRef) -> bool {
     // pyopcode.py:1040 `return space.exception_match(space.type(w_1), w_2)`.
     // `crate::typedef::r#type` is the `space.type` equivalent — it
@@ -3167,6 +3191,31 @@ impl OpcodeStepExecutor for PyFrame {
         let matched = check_exc_match_against(exc_value, exc_type);
         self.push(pyre_object::w_bool_from(matched));
         Ok(())
+    }
+
+    fn check_eg_match(&mut self) -> Result<(), PyError> {
+        let exc_type = self.pop();
+        validate_check_eg_match_class(exc_type)?;
+        let exc_value = self.pop();
+        let (matching, rest) = if unsafe { pyre_object::is_none(exc_value) } {
+            (pyre_object::w_none(), pyre_object::w_none())
+        } else {
+            crate::builtins::exception_group_match(exc_value, exc_type)?
+        };
+        self.push(rest);
+        self.push(matching);
+        if !unsafe { pyre_object::is_none(matching) } {
+            set_current_exception(matching);
+        }
+        Ok(())
+    }
+
+    fn prep_reraise_star(
+        &mut self,
+        orig: Self::Value,
+        exceptions: Self::Value,
+    ) -> Result<Self::Value, PyError> {
+        crate::builtins::exception_group_prep_reraise_star(orig, exceptions)
     }
 
     // ── PopExcept ──

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -1295,6 +1295,13 @@ pub fn handle_exception(frame: &mut PyFrame, err: &mut PyError, next_instr: &mut
             return false;
         }
     }
+    // `attach_tb=False` (RaiseWithExplicitTraceback) suppresses the traceback
+    // record for the frame that performed the re-raise only.  Once that frame's
+    // record/trace decision is made, the flag is cleared so that if no handler
+    // is found here and the exception propagates to the caller, that outer frame
+    // records its own traceback entry — mirroring the special-exception being
+    // unwrapped to a plain OperationError after one frame.
+    err.attach_tb = true;
     let code = unsafe { &*crate::pyframe_get_pycode(frame) };
     // pyre's `last_instr` is a rustpython code-unit index; the PyPy-shaped
     // `lookup_exceptiontable` lookup takes byte offsets, so multiply by 2.
@@ -2839,7 +2846,15 @@ impl OpcodeStepExecutor for PyFrame {
                 if exc.is_null() || unsafe { pyre_object::is_none(exc) } {
                     Err(PyError::runtime_error("No active exception to reraise"))
                 } else if unsafe { pyre_object::is_exception(exc) } {
-                    Err(unsafe { PyError::from_exc_object(exc) })
+                    // RAISE_VARARGS(nbargs=0) re-raises the active exception via
+                    // RaiseWithExplicitTraceback, i.e. without recording a fresh
+                    // traceback for this frame.  Preserving the exception's existing
+                    // w_traceback keeps its identity stable (mirroring the RERAISE
+                    // opcode below), which the except* metadata check
+                    // (_is_same_exception_metadata) relies on.
+                    let mut err = unsafe { PyError::from_exc_object(exc) };
+                    err.attach_tb = false;
+                    Err(err)
                 } else {
                     Err(PyError::runtime_error("No active exception to reraise"))
                 }

--- a/pyre/pyre-interpreter/src/pyopcode.rs
+++ b/pyre/pyre-interpreter/src/pyopcode.rs
@@ -1158,6 +1158,9 @@ pub trait OpcodeStepExecutor: SharedOpcodeHandler {
     fn check_exc_match(&mut self) -> Result<(), PyError> {
         Err(crate::PyError::type_error("check_exc_match not implemented").into())
     }
+    fn check_eg_match(&mut self) -> Result<(), PyError> {
+        Err(crate::PyError::type_error("check_eg_match not implemented").into())
+    }
     /// `pypy/interpreter/pyopcode.py:1348-1376 RERAISE`.
     ///
     /// `oparg` is the depth (0..) at which the original raise-site lasti
@@ -1369,6 +1372,14 @@ pub trait OpcodeStepExecutor: SharedOpcodeHandler {
         Ok(())
     }
 
+    fn prep_reraise_star(
+        &mut self,
+        _orig: Self::Value,
+        _exceptions: Self::Value,
+    ) -> Result<Self::Value, PyError> {
+        Err(crate::PyError::type_error("prep_reraise_star not implemented").into())
+    }
+
     /// BUILD_TEMPLATE: pop the interpolations and strings tuples and build a
     /// `string.templatelib.Template`.  Overridden by the interpreter; the trace
     /// path declines (t-strings run at import time, never inside a JIT-traced
@@ -1449,6 +1460,13 @@ pub trait OpcodeStepExecutor: SharedOpcodeHandler {
     /// CALL_INTRINSIC_2: two-argument intrinsic operations.
     fn call_intrinsic_2(&mut self, func: IntrinsicFunction2) -> Result<(), PyError> {
         match func {
+            IntrinsicFunction2::PrepReraiseStar => {
+                let exceptions = self.pop_value()?;
+                let orig = self.pop_value()?;
+                let result = self.prep_reraise_star(orig, exceptions)?;
+                self.push_value(result)?;
+                Ok(())
+            }
             IntrinsicFunction2::SetFunctionTypeParams => {
                 // arg2 = type_params, arg1 = function
                 // Set __type_params__ attribute on the function; push function back
@@ -1886,6 +1904,13 @@ pub fn execute_check_exc_match<E: OpcodeStepExecutor>(
     executor: &mut E,
 ) -> Result<StepResult<<E as SharedOpcodeHandler>::Value>, PyError> {
     executor.check_exc_match()?;
+    Ok(StepResult::Continue)
+}
+
+pub fn execute_check_eg_match<E: OpcodeStepExecutor>(
+    executor: &mut E,
+) -> Result<StepResult<<E as SharedOpcodeHandler>::Value>, PyError> {
+    executor.check_eg_match()?;
     Ok(StepResult::Continue)
 }
 
@@ -3362,6 +3387,7 @@ where
         Instruction::PushExcInfo => execute_push_exc_info(executor),
         Instruction::PopExcept => execute_pop_except(executor),
         Instruction::CheckExcMatch => execute_check_exc_match(executor),
+        Instruction::CheckEgMatch => execute_check_eg_match(executor),
         Instruction::RaiseVarargs { .. } => execute_raise_varargs(executor, instruction, op_arg),
         Instruction::Reraise { .. } => execute_reraise(executor, instruction, op_arg),
 

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -13686,6 +13686,18 @@ fn abstract_instantiation_error(cls: PyObjectRef) -> crate::PyError {
     ))
 }
 
+/// Identity comparison of two MRO lookups (`space.is_w`), used to decide
+/// whether a type inherits `object`'s `__new__`/`__init__` unchanged.  An
+/// inherited slot resolves to the very object stored in `object`'s dict, so
+/// pointer identity suffices; an override resolves to a distinct object.
+fn same_inherited_slot(a: Option<PyObjectRef>, b: Option<PyObjectRef>) -> bool {
+    match (a, b) {
+        (Some(x), Some(y)) => x == y,
+        (None, None) => true,
+        _ => false,
+    }
+}
+
 fn object_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     // objectobject.py:118 descr__new__ — `w_type` is a mandatory argument.
     if args.is_empty() {
@@ -13696,6 +13708,26 @@ fn object_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError>
     let cls = args[0];
     // cls should be a W_TypeObject — create instance of it
     if unsafe { is_type(cls) } {
+        // objectobject.py descr__new__ — surplus arguments are accepted only
+        // when __new__ or __init__ is overridden; the bare object() takes
+        // none.  A type that overrides __new__ but forwards excess args to
+        // object.__new__ hits the first error.
+        if args.len() > 1 {
+            let obj = w_object();
+            let tp_new = unsafe { crate::baseobjspace::lookup_in_type(cls, "__new__") };
+            let obj_new = unsafe { crate::baseobjspace::lookup_in_type(obj, "__new__") };
+            if !same_inherited_slot(tp_new, obj_new) {
+                return Err(crate::PyError::type_error(
+                    "object.__new__() takes exactly one argument (the type to instantiate)",
+                ));
+            }
+            let tp_init = unsafe { crate::baseobjspace::lookup_in_type(cls, "__init__") };
+            let obj_init = unsafe { crate::baseobjspace::lookup_in_type(obj, "__init__") };
+            if same_inherited_slot(tp_init, obj_init) {
+                let name = unsafe { pyre_object::w_type_get_name(cls) };
+                return Err(crate::PyError::type_error(format!("{name}() takes no arguments")));
+            }
+        }
         // objectobject.py:131 descr__new__ — abstract classes refuse instantiation.
         if unsafe { pyre_object::w_type_is_abstract(cls) } {
             return Err(abstract_instantiation_error(cls));
@@ -13706,8 +13738,31 @@ fn object_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError>
     Ok(w_instance_new(PY_NULL))
 }
 
-/// `object.__init__(self)` — no-op base __init__.
-fn object_descr_init(_args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+/// `object.__init__(self)` — no-op base __init__.  Surplus arguments are
+/// accepted only when __init__ or __new__ is overridden (objectobject.py
+/// descr__init__); otherwise the bare object initializer takes none.
+fn object_descr_init(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    if args.len() > 1 {
+        let w_obj = args[0];
+        if let Some(w_type) = crate::typedef::r#type(w_obj) {
+            let obj = w_object();
+            let tp_init = unsafe { crate::baseobjspace::lookup_in_type(w_type, "__init__") };
+            let obj_init = unsafe { crate::baseobjspace::lookup_in_type(obj, "__init__") };
+            if !same_inherited_slot(tp_init, obj_init) {
+                return Err(crate::PyError::type_error(
+                    "object.__init__() takes exactly one argument (the instance to initialize)",
+                ));
+            }
+            let tp_new = unsafe { crate::baseobjspace::lookup_in_type(w_type, "__new__") };
+            let obj_new = unsafe { crate::baseobjspace::lookup_in_type(obj, "__new__") };
+            if same_inherited_slot(tp_new, obj_new) {
+                let name = unsafe { pyre_object::w_type_get_name(w_type) };
+                return Err(crate::PyError::type_error(format!(
+                    "{name}.__init__() takes exactly one argument (the instance to initialize)"
+                )));
+            }
+        }
+    }
     Ok(w_none())
 }
 

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -13725,7 +13725,9 @@ fn object_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError>
             let obj_init = unsafe { crate::baseobjspace::lookup_in_type(obj, "__init__") };
             if same_inherited_slot(tp_init, obj_init) {
                 let name = unsafe { pyre_object::w_type_get_name(cls) };
-                return Err(crate::PyError::type_error(format!("{name}() takes no arguments")));
+                return Err(crate::PyError::type_error(format!(
+                    "{name}() takes no arguments"
+                )));
             }
         }
         // objectobject.py:131 descr__new__ — abstract classes refuse instantiation.

--- a/pyre/pyre-jit-trace/src/liveness.rs
+++ b/pyre/pyre-jit-trace/src/liveness.rs
@@ -700,9 +700,8 @@ fn stack_effects(
                 (d - 2, d - 2)
             }
         }
-        // CheckExcMatch: codewriter pops match_type, peeks the caught
-        // exception, then pushes the bool result. Net 0.
-        Instruction::CheckExcMatch => (d, d),
+        // Both exception checks have no net stack effect.
+        Instruction::CheckExcMatch | Instruction::CheckEgMatch => (d, d),
         // Pop 2 push 1 (net -1)
         Instruction::BinaryOp { .. }
         | Instruction::CompareOp { .. }

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -4417,8 +4417,19 @@ fn unsupported_jit_shape(code: &pyre_interpreter::CodeObject) -> UnsupportedJitS
     let mut arg_state = pyre_interpreter::OpArgState::default();
     let mut has_for_iter = false;
     for unit in code.instructions.iter().copied() {
-        if let pyre_interpreter::Instruction::ForIter { .. } = arg_state.get(unit).0 {
-            has_for_iter = true;
+        let (instruction, op_arg) = arg_state.get(unit);
+        match instruction {
+            pyre_interpreter::Instruction::ForIter { .. } => has_for_iter = true,
+            pyre_interpreter::Instruction::CheckEgMatch => {
+                return UnsupportedJitShape::CurrentFrameOnly;
+            }
+            pyre_interpreter::Instruction::CallIntrinsic2 { func }
+                if func.get(op_arg)
+                    == pyre_interpreter::bytecode::IntrinsicFunction2::PrepReraiseStar =>
+            {
+                return UnsupportedJitShape::CurrentFrameOnly;
+            }
+            _ => {}
         }
     }
     if has_for_iter {
@@ -4466,12 +4477,10 @@ fn eval_with_jit_inner(frame: &mut PyFrame) -> PyResult {
     match unsupported_jit_shape(code) {
         UnsupportedJitShape::None => {}
         UnsupportedJitShape::CurrentFrameOnly => {
-            // A FOR_ITER frame the #57 gate cannot trace (a non-journalable
-            // mutator body, or a `finally`-duplicated loop): run it in the plain
-            // interpreter.  The tracer never sees it, so record the frame-shape
-            // decline in the census (deduped per code object) — otherwise a hot
-            // loop declined here reads as a silent no-token gap, indistinguishable
-            // from a loop the JIT never noticed.
+            // Run frames with unsupported current-frame bytecode shapes in the
+            // plain interpreter. The tracer never sees them, so record the
+            // frame-shape decline in the census rather than leaving a silent
+            // no-token gap.
             pyre_jit_trace::jitcode_dispatch::census_record_frame_shape_decline(
                 code as *const _ as usize,
                 "FrameShape::CurrentFrameOnly",

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -9188,6 +9188,22 @@ impl CodeWriter {
                             emit_pushvalue_ref!(current_depth, current_depth, result_value, py_pc);
                         }
 
+                        // CHECK_EG_MATCH replaces the exception and match type
+                        // with the unmatched and matched portions. Exception-group
+                        // handling remains an interpreter boundary, but the graph
+                        // walk still needs the post-opcode stack shape for later
+                        // blocks reached through exception-table control flow.
+                        Instruction::CheckEgMatch => {
+                            for _ in 0..2 {
+                                pop_and_decr_depth(&mut current_state, &mut current_depth);
+                            }
+                            for _ in 0..2 {
+                                push_fresh_ref(&mut current_state, &mut graph);
+                                current_depth += 1;
+                            }
+                            emit_abort_permanent!(py_pc);
+                        }
+
                         Instruction::PopExcept => {
                             // eval.rs:1243-1249 / pyopcode.py:778 parity:
                             //   prev = pop()


### PR DESCRIPTION
Implements PEP 654 `except*` and hardens exception-chaining and object-construction semantics. Stacked on `perf-loop`.

## Commits
- **except\* opcode handling** — `CHECK_EG_MATCH` interp handler (+ `validate_check_eg_match_class`, naked-exc wrap) and `PREP_RERAISE_STAR` (`IntrinsicFunction2::PrepReraiseStar`) porting `_prep_reraise_star`/`_collect_eg_leafs`/`_exception_group_projection`/`_is_same_exception_metadata`; JIT declines frames carrying either opcode.
- **reraise traceback identity** — bare `raise` (RAISE_VARARGS 0) sets `attach_tb=false` (RaiseWithExplicitTraceback), cleared one-shot in `handle_exception` so outer frames still record their own entry; `exception_group_same_metadata` treats a raw-null meta slot as equal to the `None` singleton.
- **derive overridability** — `_derive_and_copy_attrs` constructs via the overridable `self.derive(excs)` and validates the result is a `BaseExceptionGroup`; default `derive` builds `BaseExceptionGroup(message, excs)`; `__class_getitem__` installed on the group type.
- **split overridability** — `CHECK_EG_MATCH` partial match routes through the overridable `self.split(cond)` and validates a 2-tuple return.
- **implicit __context__ chaining** — any exception raised while another is handled records the active one as `__context__` (not only explicit `raise`); the `__context__` write is unified behind `chain_context`, which breaks context-chain cycles before stamping the slot.
- **object surplus-argument rejection** — `object.__new__`/`object.__init__` no longer ignore extra arguments: a type overriding neither slot raises `T() takes no arguments`, and forwarding excess args to the base slots raises the matching `takes exactly one argument` TypeError.
- **review fixes** — `PREP_RERAISE_STAR` builds the merged result through `BaseExceptionGroup` (a mix carrying a bare `BaseException` stays a `BaseExceptionGroup` instead of raising `TypeError`); `CHECK_EG_MATCH` and the class condition match on the exception type (`exception_match`) rather than `isinstance`, so a custom metaclass `__instancecheck__` cannot catch/select unrelated leaves.

## Verification
- `check.py --backend dynasm,cranelift`: **224/224 both backends**.
- `cargo test -p pyre-interpreter` (dynasm,host_env): **376/0**.
- CPython corpus via caret-avoiding runner: `test_except_star` **60/60**, `test_exception_group` **50/52** (remaining 2: a deliberate PyPy-faithful `.exceptions` list-vs-tuple repr, and a `test_repr_raises` case that fails on stock CPython 3.14.2 too).
- All review-flagged behaviors probed against CPython 3.14: the two fixed items diverged from CPython (now match); the rest were already CPython-faithful.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Python `ExceptionGroup` and `except*` matching, including partial matches and nested exception groups.
  * Improved exception chaining, traceback handling, metadata preservation, and re-raising behavior.
  * Added validation for invalid `except*` targets and clearer argument errors for `object.__new__` and `object.__init__`.

* **Benchmarks**
  * Added coverage demonstrating exception-group matching and re-raise scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->