### PR TITLE
jit: pcmap audit retirement — GUARDCAP + RESULT harnesses, inject trivia-twin cutover

### DIFF
--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -11160,30 +11160,6 @@ pub(crate) fn pcmap_midbody_audit_enabled() -> bool {
     *ENABLED.get_or_init(|| std::env::var_os("PYRE_PCMAP_MIDBODY_AUDIT").is_some())
 }
 
-/// `PYRE_PCMAP_GUARDCAP_AUDIT` records the selected JitCode-PC depth twin at
-/// each full-body guard capture. Diagnostic only; the Python-PC table remains
-/// authoritative while the census establishes its coordinate coverage.
-fn pcmap_guardcap_audit_enabled() -> bool {
-    static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
-    *ENABLED.get_or_init(|| std::env::var_os("PYRE_PCMAP_GUARDCAP_AUDIT").is_some())
-}
-
-/// Append one guard-capture depth census result. `check.py` discards
-/// diagnostic stderr, so the audit writes to an explicitly supplied probe.
-fn pcmap_guardcap_audit_probe(flavor: &'static str, verdict: &'static str) {
-    if let Some(path) = std::env::var_os("PYRE_PCMAP_GUARDCAP_AUDIT_PROBE") {
-        use std::io::Write;
-
-        if let Ok(mut probe) = std::fs::OpenOptions::new()
-            .create(true)
-            .append(true)
-            .open(path)
-        {
-            let _ = writeln!(probe, "guardcap_depth\t{flavor}\t{verdict}");
-        }
-    }
-}
-
 /// Record one mid-body pc-map audit result. `check.py` discards diagnostic
 /// stderr, so the optional probe receives one row per attempted comparison.
 pub(crate) fn pcmap_midbody_audit_probe(site: &'static str, verdict: &'static str) {
@@ -12614,49 +12590,6 @@ fn walker_capture_snapshot_for_last_guard_impl(
                     jc.payload.depth_trivia_for_jitcode_pc(op_pc)
                 }
             };
-            if pcmap_guardcap_audit_enabled() {
-                let jc = unsafe { &*sym.jitcode };
-                let table_depth = if jc.payload.code_ptr.is_null() {
-                    None
-                } else {
-                    crate::liveness::liveness_for(jc.payload.code_ptr)
-                        .depth_at_py_pc()
-                        .get(py_pc as usize)
-                        .copied()
-                };
-                let (flavor, verdict) = if loop_close_overshoot {
-                    (
-                        if after_residual_call {
-                            "after_residual"
-                        } else {
-                            "plain"
-                        },
-                        "overshoot",
-                    )
-                } else if after_residual_call
-                    && jc
-                        .payload
-                        .after_residual_marker_for_jitcode_pc(op_pc)
-                        .is_none()
-                {
-                    ("after_residual", "no_marker")
-                } else {
-                    let twin_depth = resume_depth_twin;
-                    assert_eq!(
-                        twin_depth, table_depth,
-                        "PCMAP_GUARDCAP depth mismatch op_pc={op_pc} py_pc={py_pc} twin_depth={twin_depth:?} table_depth={table_depth:?}",
-                    );
-                    (
-                        if after_residual_call {
-                            "after_residual"
-                        } else {
-                            "plain"
-                        },
-                        "eq",
-                    )
-                };
-                pcmap_guardcap_audit_probe(flavor, verdict);
-            }
             // `capture_resumedata(after_residual_call=True)` snapshots the
             // trailing `-live-`, after the residual result has replaced the
             // Python opcode's consumed operands (pyjitpl.py:177-198,
@@ -12783,13 +12716,6 @@ fn walker_capture_snapshot_for_last_guard_impl(
                 let jc = &*sym.jitcode;
                 python_pc_for_jitcode_pc(&jc.payload.metadata, guard_jc_pc)
             });
-            if pcmap_guardcap_audit_enabled() {
-                assert_eq!(
-                    guard_py_pc.is_some(),
-                    scope.branch_guard_jitcode_pc.is_some(),
-                    "PCMAP_GUARDCAP F3 selector diverges",
-                );
-            }
             let stack_sync: Vec<(usize, OpRef)> = if sym.owns_virtualizable_shadow() {
                 let depth = unsafe {
                     let jc = &*sym.jitcode;

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -3073,25 +3073,6 @@ fn compute_bridge_root_parent_frame(
         .bridge_registers_r
         .clone()
         .unwrap_or_else(|| root_sym.registers_r.clone());
-    if result_color_audit_enabled() {
-        let payload = unsafe { &(*root_sym.jitcode).payload };
-        let root_py_pc =
-            crate::state::backxlat_py_pc(jitcode_index as i32, root_pc as i32) as usize;
-        let py_pc = python_pc_for_jitcode_pc(&payload.metadata, root_pc) as usize;
-        assert_eq!(
-            payload.result_color_for_jitcode_pc_pred(root_pc),
-            payload.metadata.result_color_at_pc.get(py_pc).copied(),
-            "result_color_by_jit_pc diverges from result_color_at_pc at jit_pc={root_pc}"
-        );
-        assert_eq!(
-            payload
-                .result_color_trivia_for_jitcode_pc(root_pc)
-                .map(|c| c as usize)
-                .filter(|&c| c != u16::MAX as usize),
-            crate::state::result_color_at_pc_at(jitcode_index as i32, root_py_pc),
-            "result_color trivia twin vs backxlat consumer diverges at jit_pc={root_pc}"
-        );
-    }
     if let Some(result_color) = unsafe { &(*root_sym.jitcode).payload }
         .result_color_trivia_for_jitcode_pc(root_pc)
         .map(|c| c as usize)
@@ -11028,15 +11009,6 @@ fn vstack_enter_exception_handler(
     let _ = reseed_vstack_from_shadow(ctx, handler_depth);
 }
 
-/// `PYRE_PCMAP_RESULT_AUDIT` enables assertions that the audit-only
-/// `result_color_by_jit_pc` twin reproduces `result_color_at_pc` at seams
-/// already carrying a genuine JitCode byte offset. Diagnostic only; off in
-/// production while #73 retains the py_pc-keyed reader.
-pub(crate) fn result_color_audit_enabled() -> bool {
-    static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
-    *ENABLED.get_or_init(|| std::env::var_os("PYRE_PCMAP_RESULT_AUDIT").is_some())
-}
-
 /// `PYRE_PCMAP_RECIPE_RESULTCOLOR_AUDIT` is a report-only census for the
 /// recipe resume-coordinate result-color reader and the multi-frame callee
 /// diagnostic's inversion. The optional `_PROBE` receives a fire row followed
@@ -13473,17 +13445,6 @@ fn compute_inline_caller_frame(
     if depth == 0 {
         return Err(InlineCallerFrameDecline::Unavailable);
     }
-    if result_color_audit_enabled() {
-        if let Some(jit_pc) = resume_marker_jit_pc {
-            let payload = unsafe { &(*caller_sym.jitcode).payload };
-            let py_pc = python_pc_for_jitcode_pc(&payload.metadata, jit_pc) as usize;
-            assert_eq!(
-                payload.result_color_for_jitcode_pc_pred(jit_pc),
-                payload.metadata.result_color_at_pc.get(py_pc).copied(),
-                "result_color_by_jit_pc diverges from result_color_at_pc at jit_pc={jit_pc}"
-            );
-        }
-    }
     let call_stack_overrides = collect_call_stack_overrides(caller_sym, ctx, call_jit_pc);
     // #73: the result slot's color comes from the codewriter-precomputed
     // `result_color_at_pc` (top-of-stack color at the return pc), not the flat
@@ -13603,16 +13564,6 @@ fn compute_nested_inline_caller_frame(
                 "inline_nested_depth_trivia",
                 pjc.depth_trivia_for_jitcode_pc(marker),
                 table_depth,
-            );
-        }
-    }
-    if result_color_audit_enabled() {
-        if let Some(jit_pc) = resume_marker_jit_pc {
-            let py_pc = python_pc_for_jitcode_pc(&pjc.metadata, jit_pc) as usize;
-            assert_eq!(
-                pjc.result_color_for_jitcode_pc_pred(jit_pc),
-                pjc.metadata.result_color_at_pc.get(py_pc).copied(),
-                "result_color_by_jit_pc diverges from result_color_at_pc at jit_pc={jit_pc}"
             );
         }
     }

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -3158,7 +3158,6 @@ fn recipe_parent_frame_from_recipe(
     recipe: &majit_metainterp::ReconstructRecipe,
     root_ec: *const pyre_interpreter::PyExecutionContext,
 ) -> Option<InlineParentFrame> {
-    let py_pc = crate::state::backxlat_py_pc(recipe.jitcode_index, recipe.jitcode_pc) as usize;
     let pjc = crate::state::pyjitcode_for_jitcode_index(recipe.jitcode_index)?;
     if !pjc.is_populated() || pjc.code_ptr.is_null() {
         return None;
@@ -3191,22 +3190,10 @@ fn recipe_parent_frame_from_recipe(
     let (frame_reg, ec_reg) = crate::state::portal_red_regs_at(recipe.jitcode_index);
     let (frame_reg, ec_reg) = (u32::from(frame_reg), u32::from(ec_reg));
     let sentinel = u32::from(u16::MAX);
-    let result_color = crate::state::result_color_at_pc_at(recipe.jitcode_index, py_pc);
-    if pcmap_recipe_resultcolor_audit_enabled() {
-        // `recipe.jitcode_pc` is the reconstructed frame's resolved RESUME
-        // coordinate. The trivia twin has the same marker/predecessor anchor
-        // tiers as that coordinate's inversion and includes its forward-trivia
-        // semantics, so it is the candidate native replacement for this read.
-        let twin = pjc
-            .result_color_trivia_for_jitcode_pc(recipe.jitcode_pc as usize)
-            .map(|color| color as usize)
-            .filter(|&color| color != u16::MAX as usize);
-        pcmap_recipe_resultcolor_audit_probe("recipe_parent_result_color", "fire");
-        pcmap_recipe_resultcolor_audit_probe(
-            "recipe_parent_result_color",
-            if twin == result_color { "eq" } else { "di" },
-        );
-    }
+    let result_color = pjc
+        .result_color_trivia_for_jitcode_pc(recipe.jitcode_pc as usize)
+        .map(|c| c as usize)
+        .filter(|&c| c != u16::MAX as usize);
 
     let banks = crate::state::frame_liveness_reg_indices_by_bank_from_pc(
         recipe.jitcode_index,

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -5848,7 +5848,13 @@ fn reconstruct_inline_recipe(
         None
     };
     let pending_result_color = if in_a_call {
-        Some(result_color_at_pc_at(frame.jitcode_index, py_pc)?)
+        Some(
+            pyjitcode_for_jitcode_index(frame.jitcode_index).and_then(|p| {
+                p.result_color_trivia_for_jitcode_pc(frame.pc as usize)
+                    .map(|c| c as usize)
+                    .filter(|&c| c != u16::MAX as usize)
+            })?,
+        )
     } else {
         None
     };

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -923,9 +923,10 @@ fn residual_ref_call_dst_before(code: &[u8], entry: usize) -> Option<usize> {
 ///
 /// `make_result_of_lastop` writes the result to the residual-call body's
 /// trailing `>r` destination byte, so use that register when the call ending at
-/// `root_pc` can be decoded.  Fall back to the precomputed result-color table
-/// for older shapes that lack the canonical residual-call encoding.  Returns
-/// `false` (caller declines the compile) when the register is unresolved.
+/// `root_pc` can be decoded.  Fall back to the codewriter-baked result-color
+/// trivia twin keyed by the call's JitCode pc for older shapes that lack the
+/// canonical residual-call encoding.  Returns `false` (caller declines the
+/// compile) when the register is unresolved.
 fn inject_root_call_result(sym: &mut PyreSym, root_pc: usize, result: majit_ir::OpRef) -> bool {
     if sym.jitcode.is_null() {
         return false;
@@ -934,7 +935,6 @@ fn inject_root_call_result(sym: &mut PyreSym, root_pc: usize, result: majit_ir::
     let jitcode_index = unsafe { (*sym.jitcode).index as i32 };
     let result_reg = residual_ref_call_dst_before(payload.jitcode.code.as_slice(), root_pc)
         .or_else(|| {
-            let root_py_pc = crate::state::backxlat_py_pc(jitcode_index, root_pc as i32) as usize;
             if crate::jitcode_dispatch::result_color_audit_enabled() {
                 let py_pc =
                     crate::jitcode_dispatch::python_pc_for_jitcode_pc(&payload.metadata, root_pc)
@@ -944,8 +944,21 @@ fn inject_root_call_result(sym: &mut PyreSym, root_pc: usize, result: majit_ir::
                     payload.metadata.result_color_at_pc.get(py_pc).copied(),
                     "result_color_by_jit_pc diverges from result_color_at_pc at jit_pc={root_pc}"
                 );
+                let root_py_pc =
+                    crate::state::backxlat_py_pc(jitcode_index, root_pc as i32) as usize;
+                assert_eq!(
+                    payload
+                        .result_color_trivia_for_jitcode_pc(root_pc)
+                        .map(|c| c as usize)
+                        .filter(|&c| c != u16::MAX as usize),
+                    crate::state::result_color_at_pc_at(jitcode_index, root_py_pc),
+                    "result_color trivia twin vs backxlat consumer diverges at jit_pc={root_pc}"
+                );
             }
-            crate::state::result_color_at_pc_at(jitcode_index, root_py_pc)
+            payload
+                .result_color_trivia_for_jitcode_pc(root_pc)
+                .map(|c| c as usize)
+                .filter(|&c| c != u16::MAX as usize)
         });
     let Some(result_reg) = result_reg else {
         return false;

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -932,29 +932,8 @@ fn inject_root_call_result(sym: &mut PyreSym, root_pc: usize, result: majit_ir::
         return false;
     }
     let payload = unsafe { &(*sym.jitcode).payload };
-    let jitcode_index = unsafe { (*sym.jitcode).index as i32 };
     let result_reg = residual_ref_call_dst_before(payload.jitcode.code.as_slice(), root_pc)
         .or_else(|| {
-            if crate::jitcode_dispatch::result_color_audit_enabled() {
-                let py_pc =
-                    crate::jitcode_dispatch::python_pc_for_jitcode_pc(&payload.metadata, root_pc)
-                        as usize;
-                assert_eq!(
-                    payload.result_color_for_jitcode_pc_pred(root_pc),
-                    payload.metadata.result_color_at_pc.get(py_pc).copied(),
-                    "result_color_by_jit_pc diverges from result_color_at_pc at jit_pc={root_pc}"
-                );
-                let root_py_pc =
-                    crate::state::backxlat_py_pc(jitcode_index, root_pc as i32) as usize;
-                assert_eq!(
-                    payload
-                        .result_color_trivia_for_jitcode_pc(root_pc)
-                        .map(|c| c as usize)
-                        .filter(|&c| c != u16::MAX as usize),
-                    crate::state::result_color_at_pc_at(jitcode_index, root_py_pc),
-                    "result_color trivia twin vs backxlat consumer diverges at jit_pc={root_pc}"
-                );
-            }
             payload
                 .result_color_trivia_for_jitcode_pc(root_pc)
                 .map(|c| c as usize)


### PR DESCRIPTION
## Summary

Rebased onto origin/main (#607 P2-bridge-compile default-ON) and closing out the pcmap audit scaffolding + the certifiable legacy `result_color_at_pc_at` consumers.

1. **retire `PYRE_PCMAP_GUARDCAP_AUDIT`** — guard-capture depth twin census 10,808/10,808 eq on plain + P2 dynasm legs; production already on the depth twins (−74).
2. **inject_root_call_result trivia-twin fallback** — #607 made `residual_ref_call_dst_before` (byte-native dst-register decode) the primary; the `.or_else` marker-miss fallback now reads the result-color trivia twin instead of `backxlat_py_pc` + `result_color_at_pc_at`.
3. **retire `PYRE_PCMAP_RESULT_AUDIT`** — every production result-color read on the JitCode-pc twins; the four assert blocks + gate removed (−68).
4. **recipe-parent + reconstruct result colors from the trivia twin** — `recipe_parent_frame_from_recipe` and `reconstruct_inline_recipe` keyed off the carried JitCode pc via `result_color_trivia_for_jitcode_pc`, dropping the py inversion.

### Certification of commit 4 (the dormant-consumer flip)

Both consumers are corpus-dormant (0 fires even under `PYRE_P2_COMPILE`), so a runtime fire census cannot certify them. Instead a throwaway whole-metadata verifier compared the trivia twin against the legacy `result_color_at_pc[backxlat_py_pc(off)]` reader at **every block-head resume coordinate of every jitcode the corpus builds**: **9,992 coordinates across 426 jitcodes, zero divergence** (control confirmed the harness performed all 9,992 comparisons — up to 266 per jitcode — not a silent no-op). The reads are structurally unchanged.

The two inline-caller marker-miss fallbacks (`compute_inline_caller_frame` / `compute_nested_inline_caller_frame`) stay: when `resume_marker_jit_pc` is None there is no JitCode key for the twin, so they remain the residual keyless floor; the py-keyed `result_color_at_pc` table cannot be fully retired until those (and the build-time twin builder) are addressed.

## Verification

- `check.py` after each stage: dynasm 217/217, cranelift 217/217, wasm 216/216
- `cargo test -p pyre-jit-trace -p pyre-jit --features dynasm`: green
- whole-metadata twin verifier: 9,992/9,992 eq (0 divergence)

🤖 Generated with [Claude Code](https://claude.com/claude-code)