### PR TITLE
jit: #621 retire the py-indexed VALUE tables (pcdep_color_slots / result_color_at_pc)

### DIFF
--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -3178,7 +3178,37 @@ fn recipe_parent_frame_from_recipe(
         recipe.jitcode_pc,
     );
     let stack_only = recipe.valuestackdepth.saturating_sub(recipe.nlocals);
-    let maps = crate::state::bridge_semantic_maps_at(recipe.jitcode_index, recipe.jitcode_pc);
+    let maps = if pcmap_pivot_audit_enabled() {
+        pcmap_pivot_audit_record_fire("bridge_maps_recipe", "fire");
+        let legacy = crate::state::bridge_semantic_maps_at(recipe.jitcode_index, recipe.jitcode_pc);
+        let twin =
+            crate::state::bridge_semantic_maps_from_pc(recipe.jitcode_index, recipe.jitcode_pc);
+        if legacy.has_color_map == twin.has_color_map
+            && legacy.stack_depth_at_pc == twin.stack_depth_at_pc
+            && legacy.pcdep_entries == twin.pcdep_entries
+        {
+            pcmap_pivot_audit_record_fire("bridge_maps_recipe", "eq");
+        } else {
+            pcmap_pivot_audit_record_fire("bridge_maps_recipe", "di");
+            pcmap_pivot_audit_record_data(
+                "bridge_maps_recipe",
+                &format!(
+                    "idx={} pc={} legacy=({},{},{:?}) twin=({},{},{:?})",
+                    recipe.jitcode_index,
+                    recipe.jitcode_pc,
+                    legacy.has_color_map,
+                    legacy.stack_depth_at_pc,
+                    legacy.pcdep_entries,
+                    twin.has_color_map,
+                    twin.stack_depth_at_pc,
+                    twin.pcdep_entries,
+                ),
+            );
+        }
+        legacy
+    } else {
+        crate::state::bridge_semantic_maps_at(recipe.jitcode_index, recipe.jitcode_pc)
+    };
     let null_ref = ctx.const_ref(pyre_object::PY_NULL as i64);
     let mut boxes = Vec::with_capacity(banks.total_len());
     for &color in &banks.int {
@@ -7538,65 +7568,117 @@ fn collect_outer_active_boxes(
     // `semantic_ref_slot_for_reg_color`, read the vable shadow for
     // portal-owner frames, and route the two portal red regs through
     // `sym.frame` / `sym.execution_context` directly.
-    let (nlocals, valid_stack_only, owns_vable, portal_frame_reg, portal_ec_reg) =
-        if sym.jitcode.is_null() {
-            (0usize, 0usize, false, u16::MAX, u16::MAX)
-        } else {
-            unsafe {
-                let jc = &*sym.jitcode;
-                let payload = &jc.payload;
-                audit_outer_active_boxes_entry_twin(
-                    payload,
-                    entry_py_pc,
-                    entry_jitcode_pc,
-                    entry_twin,
-                    entry_caller,
-                );
-                // Operand-stack depth at the snapshot coordinate. The liveness
-                // banks (`frame_liveness_reg_indices_by_bank_at`) are read at
-                // that coordinate too, so the per-PC color→slot window
-                // (`pcdep_opt`'s stack clamp below) must use its depth — NOT
-                // `sym.valuestackdepth` (the walker's *current* position). For
-                // the per-opcode entry caller the two coincide, but a guard
-                // resuming at a not-taken branch target with a kept operand-stack
-                // temp (conditional expr / short-circuit / chained compare,
-                // #124/#281) resumes at a depth `> 0` while the walker stands at
-                // depth 0 — using the current depth there drops the kept temp's
-                // semantic slot, corrupting the frame.
-                let stack_depth_at_pc = if payload.code_ptr.is_null() {
-                    0usize
-                } else {
-                    match (entry_twin, entry_jitcode_pc >= 0) {
-                        (OuterActiveBoxesEntryTwin::Plain, true) => payload
-                            .depth_for_jitcode_pc_pred(entry_jitcode_pc as usize)
-                            .unwrap_or(0)
-                            as usize,
-                        (OuterActiveBoxesEntryTwin::Trivia, true) => payload
-                            .depth_trivia_for_jitcode_pc(entry_jitcode_pc as usize)
-                            .unwrap_or(0)
-                            as usize,
-                        _ => {
-                            pcmap_pivot_audit_record_fire(
-                                "collect_outer_active_boxes_depth",
-                                "py_pc_entry",
+    let (nlocals, valid_stack_only, owns_vable, portal_frame_reg, portal_ec_reg) = if sym
+        .jitcode
+        .is_null()
+    {
+        (0usize, 0usize, false, u16::MAX, u16::MAX)
+    } else {
+        unsafe {
+            let jc = &*sym.jitcode;
+            let payload = &jc.payload;
+            audit_outer_active_boxes_entry_twin(
+                payload,
+                entry_py_pc,
+                entry_jitcode_pc,
+                entry_twin,
+                entry_caller,
+            );
+            // Operand-stack depth at the snapshot coordinate. The liveness
+            // banks (`frame_liveness_reg_indices_by_bank_at`) are read at
+            // that coordinate too, so the per-PC color→slot window
+            // (`pcdep_opt`'s stack clamp below) must use its depth — NOT
+            // `sym.valuestackdepth` (the walker's *current* position). For
+            // the per-opcode entry caller the two coincide, but a guard
+            // resuming at a not-taken branch target with a kept operand-stack
+            // temp (conditional expr / short-circuit / chained compare,
+            // #124/#281) resumes at a depth `> 0` while the walker stands at
+            // depth 0 — using the current depth there drops the kept temp's
+            // semantic slot, corrupting the frame.
+            let stack_depth_at_pc = if payload.code_ptr.is_null() {
+                0usize
+            } else {
+                match (entry_twin, entry_jitcode_pc >= 0) {
+                    (OuterActiveBoxesEntryTwin::Plain, true) => payload
+                        .depth_for_jitcode_pc_pred(entry_jitcode_pc as usize)
+                        .unwrap_or(0)
+                        as usize,
+                    (OuterActiveBoxesEntryTwin::Trivia, true) => payload
+                        .depth_trivia_for_jitcode_pc(entry_jitcode_pc as usize)
+                        .unwrap_or(0)
+                        as usize,
+                    _ => {
+                        pcmap_pivot_audit_record_fire(
+                            "collect_outer_active_boxes_depth",
+                            "py_pc_entry",
+                        );
+                        let legacy = crate::liveness::liveness_for(payload.code_ptr)
+                            .depth_at_py_pc()
+                            .get(entry_py_pc as usize)
+                            .copied()
+                            .unwrap_or(0);
+                        if pcmap_pivot_audit_enabled() {
+                            pcmap_pivot_audit_record_fire("coab_pypc_entry_depth", "fire");
+                            let resolved = jc.payload.resolve_resume_pc_with_jitcode_pc(
+                                carried_jitcode_pc,
+                                crate::state::op_live(),
                             );
-                            crate::liveness::liveness_for(payload.code_ptr)
-                                .depth_at_py_pc()
-                                .get(entry_py_pc as usize)
-                                .copied()
-                                .unwrap_or(0) as usize
+                            match resolved {
+                                Some(resolved_off) => {
+                                    let twin = jc
+                                        .payload
+                                        .depth_trivia_for_jitcode_pc(resolved_off)
+                                        .unwrap_or(0);
+                                    let arm = if legacy == twin { "eq" } else { "di" };
+                                    pcmap_pivot_audit_record_fire("coab_pypc_entry_depth", arm);
+                                    if arm == "di" {
+                                        pcmap_pivot_audit_record_data(
+                                            "coab_pypc_entry_depth",
+                                            &format!(
+                                                "jcidx={} py={} carried={} resolved={:?} legacy={:?} twin={:?}",
+                                                jc.index,
+                                                entry_py_pc,
+                                                carried_jitcode_pc,
+                                                resolved,
+                                                legacy,
+                                                twin
+                                            ),
+                                        );
+                                    }
+                                }
+                                None => {
+                                    pcmap_pivot_audit_record_fire(
+                                        "coab_pypc_entry_depth",
+                                        "cand_miss",
+                                    );
+                                    pcmap_pivot_audit_record_data(
+                                        "coab_pypc_entry_depth",
+                                        &format!(
+                                            "jcidx={} py={} carried={} resolved={:?} legacy={:?} twin={:?}",
+                                            jc.index,
+                                            entry_py_pc,
+                                            carried_jitcode_pc,
+                                            resolved,
+                                            legacy,
+                                            Option::<u16>::None
+                                        ),
+                                    );
+                                }
+                            }
                         }
+                        legacy as usize
                     }
-                };
-                (
-                    sym.nlocals,
-                    stack_depth_at_pc,
-                    sym.owns_virtualizable_shadow(),
-                    payload.metadata.portal_frame_reg,
-                    payload.metadata.portal_ec_reg,
-                )
-            }
-        };
+                }
+            };
+            (
+                sym.nlocals,
+                stack_depth_at_pc,
+                sym.owns_virtualizable_shadow(),
+                payload.metadata.portal_frame_reg,
+                payload.metadata.portal_ec_reg,
+            )
+        }
+    };
     // #348: per-snapshot-coordinate color→slot entries — the color→slot source
     // the inversions below consult for every drained (non-portal) jitcode, the
     // per-program-point color space the `-live-` markers carry. Branch-guard
@@ -7628,12 +7710,64 @@ fn collect_outer_active_boxes(
                         "collect_outer_active_boxes_pcdep",
                         "py_pc_entry",
                     );
-                    jc.payload
+                    let legacy = jc
+                        .payload
                         .metadata
                         .pcdep_color_slots
                         .get(entry_py_pc as usize)
                         .cloned()
-                        .unwrap_or_default()
+                        .unwrap_or_default();
+                    if pcmap_pivot_audit_enabled() {
+                        pcmap_pivot_audit_record_fire("coab_pypc_entry", "fire");
+                        let resolved = jc.payload.resolve_resume_pc_with_jitcode_pc(
+                            carried_jitcode_pc,
+                            crate::state::op_live(),
+                        );
+                        match resolved {
+                            Some(resolved_off) => {
+                                let twin = jc
+                                    .payload
+                                    .pcdep_trivia_for_jitcode_pc(resolved_off)
+                                    .unwrap_or_default();
+                                let arm = if legacy.as_slice() == twin {
+                                    "eq"
+                                } else {
+                                    "di"
+                                };
+                                pcmap_pivot_audit_record_fire("coab_pypc_entry", arm);
+                                if arm == "di" {
+                                    pcmap_pivot_audit_record_data(
+                                        "coab_pypc_entry",
+                                        &format!(
+                                            "jcidx={} py={} carried={} resolved={:?} legacy={:?} twin={:?}",
+                                            jc.index,
+                                            entry_py_pc,
+                                            carried_jitcode_pc,
+                                            resolved,
+                                            legacy,
+                                            twin
+                                        ),
+                                    );
+                                }
+                            }
+                            None => {
+                                pcmap_pivot_audit_record_fire("coab_pypc_entry", "cand_miss");
+                                pcmap_pivot_audit_record_data(
+                                    "coab_pypc_entry",
+                                    &format!(
+                                        "jcidx={} py={} carried={} resolved={:?} legacy={:?} twin={:?}",
+                                        jc.index,
+                                        entry_py_pc,
+                                        carried_jitcode_pc,
+                                        resolved,
+                                        legacy,
+                                        Option::<Vec<(u8, u16, u16)>>::None
+                                    ),
+                                );
+                            }
+                        }
+                    }
+                    legacy
                 }
             }
         }
@@ -7686,6 +7820,7 @@ fn collect_outer_active_boxes(
                             .pcdep_for_jitcode_pc(cjc as usize)
                             .unwrap_or_default()
                     } else {
+                        pcmap_pivot_audit_record_fire("coab_guard_cjc_neg", "fire");
                         jc.payload
                             .metadata
                             .pcdep_color_slots
@@ -11404,6 +11539,25 @@ pub fn pcmap_pivot_audit_record_fire(site: &'static str, arm: &'static str) {
     }
 }
 
+/// Append report-only PC-map census data for a divergent or missing candidate.
+pub fn pcmap_pivot_audit_record_data(site: &'static str, data: &str) {
+    if !pcmap_pivot_audit_enabled() {
+        return;
+    }
+    let Some(path) = std::env::var_os("PYRE_PCMAP_PIVOT_AUDIT_PROBE") else {
+        return;
+    };
+    use std::io::Write;
+
+    if let Ok(mut probe) = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)
+    {
+        let _ = writeln!(probe, "pcmap_data\t{site}\t{data}");
+    }
+}
+
 fn floor_boundary_at_or_after(
     metadata: &crate::PyJitCodeMetadata,
     jit_pc: usize,
@@ -13400,6 +13554,7 @@ fn compute_inline_caller_frame(
         // existing Python-keyed path rather than declining a formerly valid
         // caller frame.
         None => unsafe {
+            pcmap_pivot_audit_record_fire("inline_caller_marker_miss", "depth");
             crate::liveness::liveness_for(code_ptr)
                 .depth_at_py_pc()
                 .get(fallthrough_py_pc as usize)
@@ -13505,6 +13660,7 @@ fn compute_nested_inline_caller_frame(
     let depth = match resume_marker_jit_pc {
         Some(marker) => pjc.depth_trivia_for_jitcode_pc(marker).unwrap_or(0) as usize,
         None => {
+            pcmap_pivot_audit_record_fire("nested_inline_caller_marker_miss", "depth");
             let fallthrough_py_pc = legacy_fallthrough_py_pc();
             unsafe {
                 crate::liveness::liveness_for(pjc.code_ptr)

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -3178,37 +3178,7 @@ fn recipe_parent_frame_from_recipe(
         recipe.jitcode_pc,
     );
     let stack_only = recipe.valuestackdepth.saturating_sub(recipe.nlocals);
-    let maps = if pcmap_pivot_audit_enabled() {
-        pcmap_pivot_audit_record_fire("bridge_maps_recipe", "fire");
-        let legacy = crate::state::bridge_semantic_maps_at(recipe.jitcode_index, recipe.jitcode_pc);
-        let twin =
-            crate::state::bridge_semantic_maps_from_pc(recipe.jitcode_index, recipe.jitcode_pc);
-        if legacy.has_color_map == twin.has_color_map
-            && legacy.stack_depth_at_pc == twin.stack_depth_at_pc
-            && legacy.pcdep_entries == twin.pcdep_entries
-        {
-            pcmap_pivot_audit_record_fire("bridge_maps_recipe", "eq");
-        } else {
-            pcmap_pivot_audit_record_fire("bridge_maps_recipe", "di");
-            pcmap_pivot_audit_record_data(
-                "bridge_maps_recipe",
-                &format!(
-                    "idx={} pc={} legacy=({},{},{:?}) twin=({},{},{:?})",
-                    recipe.jitcode_index,
-                    recipe.jitcode_pc,
-                    legacy.has_color_map,
-                    legacy.stack_depth_at_pc,
-                    legacy.pcdep_entries,
-                    twin.has_color_map,
-                    twin.stack_depth_at_pc,
-                    twin.pcdep_entries,
-                ),
-            );
-        }
-        legacy
-    } else {
-        crate::state::bridge_semantic_maps_at(recipe.jitcode_index, recipe.jitcode_pc)
-    };
+    let maps = crate::state::bridge_semantic_maps_from_pc(recipe.jitcode_index, recipe.jitcode_pc);
     let null_ref = ctx.const_ref(pyre_object::PY_NULL as i64);
     let mut boxes = Vec::with_capacity(banks.total_len());
     for &color in &banks.int {
@@ -7431,11 +7401,9 @@ fn opref_is_null_const_ptr(op: OpRef) -> bool {
 }
 
 /// The source selected for `collect_outer_active_boxes` entry metadata.  The
-/// audit compares the JitCode-PC variants to the legacy Python-PC tables;
-/// `PyPc` keeps a caller deferred after its census diverged or did not fire.
+/// audit compares the JitCode-PC variants to the legacy Python-PC tables.
 #[derive(Clone, Copy)]
 enum OuterActiveBoxesEntryTwin {
-    PyPc,
     Plain,
     Trivia,
 }
@@ -7443,7 +7411,6 @@ enum OuterActiveBoxesEntryTwin {
 impl OuterActiveBoxesEntryTwin {
     fn name(self) -> &'static str {
         match self {
-            Self::PyPc => "py_pc",
             Self::Plain => "plain",
             Self::Trivia => "trivia",
         }
@@ -7461,10 +7428,7 @@ fn audit_outer_active_boxes_entry_twin(
     twin: OuterActiveBoxesEntryTwin,
     caller: &'static str,
 ) {
-    if !pcmap_entry_audit_enabled()
-        || carried_jitcode_pc < 0
-        || matches!(twin, OuterActiveBoxesEntryTwin::PyPc)
-    {
+    if !pcmap_entry_audit_enabled() || carried_jitcode_pc < 0 {
         return;
     }
     let cjc = carried_jitcode_pc as usize;
@@ -7486,7 +7450,6 @@ fn audit_outer_active_boxes_entry_twin(
         .cloned()
         .unwrap_or_default();
     let (twin_pcdep, twin_depth) = match twin {
-        OuterActiveBoxesEntryTwin::PyPc => unreachable!("legacy source returns before audit"),
         OuterActiveBoxesEntryTwin::Plain => (
             payload.pcdep_for_jitcode_pc(cjc).unwrap_or_default(),
             payload.depth_for_jitcode_pc_pred(cjc).unwrap_or(0),
@@ -7568,117 +7531,57 @@ fn collect_outer_active_boxes(
     // `semantic_ref_slot_for_reg_color`, read the vable shadow for
     // portal-owner frames, and route the two portal red regs through
     // `sym.frame` / `sym.execution_context` directly.
-    let (nlocals, valid_stack_only, owns_vable, portal_frame_reg, portal_ec_reg) = if sym
-        .jitcode
-        .is_null()
-    {
-        (0usize, 0usize, false, u16::MAX, u16::MAX)
-    } else {
-        unsafe {
-            let jc = &*sym.jitcode;
-            let payload = &jc.payload;
-            audit_outer_active_boxes_entry_twin(
-                payload,
-                entry_py_pc,
-                entry_jitcode_pc,
-                entry_twin,
-                entry_caller,
-            );
-            // Operand-stack depth at the snapshot coordinate. The liveness
-            // banks (`frame_liveness_reg_indices_by_bank_at`) are read at
-            // that coordinate too, so the per-PC color→slot window
-            // (`pcdep_opt`'s stack clamp below) must use its depth — NOT
-            // `sym.valuestackdepth` (the walker's *current* position). For
-            // the per-opcode entry caller the two coincide, but a guard
-            // resuming at a not-taken branch target with a kept operand-stack
-            // temp (conditional expr / short-circuit / chained compare,
-            // #124/#281) resumes at a depth `> 0` while the walker stands at
-            // depth 0 — using the current depth there drops the kept temp's
-            // semantic slot, corrupting the frame.
-            let stack_depth_at_pc = if payload.code_ptr.is_null() {
-                0usize
-            } else {
-                match (entry_twin, entry_jitcode_pc >= 0) {
-                    (OuterActiveBoxesEntryTwin::Plain, true) => payload
-                        .depth_for_jitcode_pc_pred(entry_jitcode_pc as usize)
-                        .unwrap_or(0)
-                        as usize,
-                    (OuterActiveBoxesEntryTwin::Trivia, true) => payload
-                        .depth_trivia_for_jitcode_pc(entry_jitcode_pc as usize)
-                        .unwrap_or(0)
-                        as usize,
-                    _ => {
-                        pcmap_pivot_audit_record_fire(
-                            "collect_outer_active_boxes_depth",
-                            "py_pc_entry",
-                        );
-                        let legacy = crate::liveness::liveness_for(payload.code_ptr)
-                            .depth_at_py_pc()
-                            .get(entry_py_pc as usize)
-                            .copied()
-                            .unwrap_or(0);
-                        if pcmap_pivot_audit_enabled() {
-                            pcmap_pivot_audit_record_fire("coab_pypc_entry_depth", "fire");
-                            let resolved = jc.payload.resolve_resume_pc_with_jitcode_pc(
-                                carried_jitcode_pc,
-                                crate::state::op_live(),
-                            );
-                            match resolved {
-                                Some(resolved_off) => {
-                                    let twin = jc
-                                        .payload
-                                        .depth_trivia_for_jitcode_pc(resolved_off)
-                                        .unwrap_or(0);
-                                    let arm = if legacy == twin { "eq" } else { "di" };
-                                    pcmap_pivot_audit_record_fire("coab_pypc_entry_depth", arm);
-                                    if arm == "di" {
-                                        pcmap_pivot_audit_record_data(
-                                            "coab_pypc_entry_depth",
-                                            &format!(
-                                                "jcidx={} py={} carried={} resolved={:?} legacy={:?} twin={:?}",
-                                                jc.index,
-                                                entry_py_pc,
-                                                carried_jitcode_pc,
-                                                resolved,
-                                                legacy,
-                                                twin
-                                            ),
-                                        );
-                                    }
-                                }
-                                None => {
-                                    pcmap_pivot_audit_record_fire(
-                                        "coab_pypc_entry_depth",
-                                        "cand_miss",
-                                    );
-                                    pcmap_pivot_audit_record_data(
-                                        "coab_pypc_entry_depth",
-                                        &format!(
-                                            "jcidx={} py={} carried={} resolved={:?} legacy={:?} twin={:?}",
-                                            jc.index,
-                                            entry_py_pc,
-                                            carried_jitcode_pc,
-                                            resolved,
-                                            legacy,
-                                            Option::<u16>::None
-                                        ),
-                                    );
-                                }
-                            }
-                        }
-                        legacy as usize
+    let (nlocals, valid_stack_only, owns_vable, portal_frame_reg, portal_ec_reg) =
+        if sym.jitcode.is_null() {
+            (0usize, 0usize, false, u16::MAX, u16::MAX)
+        } else {
+            unsafe {
+                let jc = &*sym.jitcode;
+                let payload = &jc.payload;
+                audit_outer_active_boxes_entry_twin(
+                    payload,
+                    entry_py_pc,
+                    entry_jitcode_pc,
+                    entry_twin,
+                    entry_caller,
+                );
+                // Operand-stack depth at the snapshot coordinate. The liveness
+                // banks (`frame_liveness_reg_indices_by_bank_at`) are read at
+                // that coordinate too, so the per-PC color→slot window
+                // (`pcdep_opt`'s stack clamp below) must use its depth — NOT
+                // `sym.valuestackdepth` (the walker's *current* position). For
+                // the per-opcode entry caller the two coincide, but a guard
+                // resuming at a not-taken branch target with a kept operand-stack
+                // temp (conditional expr / short-circuit / chained compare,
+                // #124/#281) resumes at a depth `> 0` while the walker stands at
+                // depth 0 — using the current depth there drops the kept temp's
+                // semantic slot, corrupting the frame.
+                let stack_depth_at_pc = if payload.code_ptr.is_null() {
+                    0usize
+                } else {
+                    match (entry_twin, entry_jitcode_pc >= 0) {
+                        (OuterActiveBoxesEntryTwin::Plain, true) => payload
+                            .depth_for_jitcode_pc_pred(entry_jitcode_pc as usize)
+                            .unwrap_or(0)
+                            as usize,
+                        (OuterActiveBoxesEntryTwin::Trivia, true) => payload
+                            .depth_trivia_for_jitcode_pc(entry_jitcode_pc as usize)
+                            .unwrap_or(0)
+                            as usize,
+                        // A non-default gate-off configuration can still supply
+                        // no entry coordinate. It has no entry metadata.
+                        _ => 0,
                     }
-                }
-            };
-            (
-                sym.nlocals,
-                stack_depth_at_pc,
-                sym.owns_virtualizable_shadow(),
-                payload.metadata.portal_frame_reg,
-                payload.metadata.portal_ec_reg,
-            )
-        }
-    };
+                };
+                (
+                    sym.nlocals,
+                    stack_depth_at_pc,
+                    sym.owns_virtualizable_shadow(),
+                    payload.metadata.portal_frame_reg,
+                    payload.metadata.portal_ec_reg,
+                )
+            }
+        };
     // #348: per-snapshot-coordinate color→slot entries — the color→slot source
     // the inversions below consult for every drained (non-portal) jitcode, the
     // per-program-point color space the `-live-` markers carry. Branch-guard
@@ -7705,70 +7608,7 @@ fn collect_outer_active_boxes(
                     .pcdep_trivia_for_jitcode_pc(entry_jitcode_pc as usize)
                     .map(ToOwned::to_owned)
                     .unwrap_or_default(),
-                _ => {
-                    pcmap_pivot_audit_record_fire(
-                        "collect_outer_active_boxes_pcdep",
-                        "py_pc_entry",
-                    );
-                    let legacy = jc
-                        .payload
-                        .metadata
-                        .pcdep_color_slots
-                        .get(entry_py_pc as usize)
-                        .cloned()
-                        .unwrap_or_default();
-                    if pcmap_pivot_audit_enabled() {
-                        pcmap_pivot_audit_record_fire("coab_pypc_entry", "fire");
-                        let resolved = jc.payload.resolve_resume_pc_with_jitcode_pc(
-                            carried_jitcode_pc,
-                            crate::state::op_live(),
-                        );
-                        match resolved {
-                            Some(resolved_off) => {
-                                let twin = jc
-                                    .payload
-                                    .pcdep_trivia_for_jitcode_pc(resolved_off)
-                                    .unwrap_or_default();
-                                let arm = if legacy.as_slice() == twin {
-                                    "eq"
-                                } else {
-                                    "di"
-                                };
-                                pcmap_pivot_audit_record_fire("coab_pypc_entry", arm);
-                                if arm == "di" {
-                                    pcmap_pivot_audit_record_data(
-                                        "coab_pypc_entry",
-                                        &format!(
-                                            "jcidx={} py={} carried={} resolved={:?} legacy={:?} twin={:?}",
-                                            jc.index,
-                                            entry_py_pc,
-                                            carried_jitcode_pc,
-                                            resolved,
-                                            legacy,
-                                            twin
-                                        ),
-                                    );
-                                }
-                            }
-                            None => {
-                                pcmap_pivot_audit_record_fire("coab_pypc_entry", "cand_miss");
-                                pcmap_pivot_audit_record_data(
-                                    "coab_pypc_entry",
-                                    &format!(
-                                        "jcidx={} py={} carried={} resolved={:?} legacy={:?} twin={:?}",
-                                        jc.index,
-                                        entry_py_pc,
-                                        carried_jitcode_pc,
-                                        resolved,
-                                        legacy,
-                                        Option::<Vec<(u8, u16, u16)>>::None
-                                    ),
-                                );
-                            }
-                        }
-                    }
-                    legacy
-                }
+                _ => Vec::new(),
             }
         }
     };
@@ -7820,13 +7660,7 @@ fn collect_outer_active_boxes(
                             .pcdep_for_jitcode_pc(cjc as usize)
                             .unwrap_or_default()
                     } else {
-                        pcmap_pivot_audit_record_fire("coab_guard_cjc_neg", "fire");
-                        jc.payload
-                            .metadata
-                            .pcdep_color_slots
-                            .get(gpc as usize)
-                            .cloned()
-                            .unwrap_or_default()
+                        Vec::new()
                     };
                     let depth = if jc.payload.code_ptr.is_null() {
                         0usize
@@ -7835,11 +7669,7 @@ fn collect_outer_active_boxes(
                             .depth_for_jitcode_pc_pred(cjc as usize)
                             .unwrap_or(0) as usize
                     } else {
-                        crate::liveness::liveness_for(jc.payload.code_ptr)
-                            .depth_at_py_pc()
-                            .get(gpc as usize)
-                            .copied()
-                            .unwrap_or(0) as usize
+                        0
                     };
                     (entries, depth)
                 }
@@ -13187,6 +13017,15 @@ fn walker_capture_snapshot_for_last_guard_impl(
             // `collect_outer_active_boxes`.  A non-branch guard carries no guard
             // pc, so it keeps the merge `py_pc` and its exact resume-translation.
             let liveness_py_pc = guard_py_pc.unwrap_or(py_pc);
+            let payload = unsafe { &(&*sym.jitcode).payload };
+            let resolved = payload
+                .resolve_resume_pc_with_jitcode_pc(guard_jitcode_pc, crate::state::op_live());
+            if resolved.is_none() {
+                pcmap_pivot_audit_record_fire("resolve_none_caller", "guard_snapshot");
+            }
+            let Some(resolved_offset) = resolved else {
+                return Err(DispatchError::GuardResumeCoordinateUnavailable { pc: op_pc });
+            };
             // A residual result is installed in the active register bank before
             // the exception guard captures resume data
             // (`rpython/jit/metainterp/pyjitpl.py:1951-1955`).  Project every
@@ -13275,8 +13114,8 @@ fn walker_capture_snapshot_for_last_guard_impl(
                         "guard_snapshot_fallthrough",
                     ),
                     None => (
-                        majit_ir::resumedata::NO_JITCODE_PC,
-                        OuterActiveBoxesEntryTwin::PyPc,
+                        resolved_offset as i32,
+                        OuterActiveBoxesEntryTwin::Trivia,
                         "guard_snapshot_fallthrough",
                     ),
                 }
@@ -13297,15 +13136,7 @@ fn walker_capture_snapshot_for_last_guard_impl(
                 ctx.vstack_valid.then_some(ctx.vstack_boxes.as_slice()),
                 scope.branch_guard_kept_recovered,
             );
-            let payload = unsafe { &(&*sym.jitcode).payload };
-            let resolved = payload
-                .resolve_resume_pc_with_jitcode_pc(guard_jitcode_pc, crate::state::op_live());
-            if resolved.is_none() {
-                pcmap_pivot_audit_record_fire("resolve_none_caller", "guard_snapshot");
-            }
-            let Some(pc_word) = resolved.map(|offset| offset as u32) else {
-                return Err(DispatchError::GuardResumeCoordinateUnavailable { pc: op_pc });
-            };
+            let pc_word = resolved_offset as u32;
             ctx.trace_ctx
                 .capture_snapshot_for_last_guard_with_vable_vref(
                     &active,
@@ -13554,7 +13385,6 @@ fn compute_inline_caller_frame(
         // existing Python-keyed path rather than declining a formerly valid
         // caller frame.
         None => unsafe {
-            pcmap_pivot_audit_record_fire("inline_caller_marker_miss", "depth");
             crate::liveness::liveness_for(code_ptr)
                 .depth_at_py_pc()
                 .get(fallthrough_py_pc as usize)
@@ -13660,7 +13490,6 @@ fn compute_nested_inline_caller_frame(
     let depth = match resume_marker_jit_pc {
         Some(marker) => pjc.depth_trivia_for_jitcode_pc(marker).unwrap_or(0) as usize,
         None => {
-            pcmap_pivot_audit_record_fire("nested_inline_caller_marker_miss", "depth");
             let fallthrough_py_pc = legacy_fallthrough_py_pc();
             unsafe {
                 crate::liveness::liveness_for(pjc.code_ptr)

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -12983,7 +12983,7 @@ fn compute_inline_caller_frame(
     // carries no pcdep entry.
     let result_color = match resume_marker_jit_pc {
         Some(marker) => unsafe { &(*caller_sym.jitcode).payload }
-            .result_color_for_jitcode_pc_pred(marker)
+            .result_color_trivia_for_jitcode_pc(marker)
             .filter(|&color| color != u16::MAX)
             .map(|color| color as usize),
         // Marker-miss: the after-residual result-color twin keys the same
@@ -13103,7 +13103,7 @@ fn compute_nested_inline_caller_frame(
     // the flat `stack_slot_color_map` (see `compute_inline_caller_frame`).
     let result_color = match resume_marker_jit_pc {
         Some(marker) => pjc
-            .result_color_for_jitcode_pc_pred(marker)
+            .result_color_trivia_for_jitcode_pc(marker)
             .filter(|&color| color != u16::MAX)
             .map(|color| color as usize),
         None => pjc

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -7417,72 +7417,6 @@ impl OuterActiveBoxesEntryTwin {
     }
 }
 
-/// `PYRE_PCMAP_ENTRY_AUDIT` certifies an entry Python-PC read against the
-/// carried JitCode coordinate for one `collect_outer_active_boxes` caller.
-/// `PYRE_PCMAP_ENTRY_AUDIT_PROBE`, when set, receives one line per assertion
-/// attempt because check.py discards diagnostic stderr.
-fn audit_outer_active_boxes_entry_twin(
-    payload: &crate::pyjitcode::PyJitCode,
-    entry_py_pc: u32,
-    carried_jitcode_pc: i32,
-    twin: OuterActiveBoxesEntryTwin,
-    caller: &'static str,
-) {
-    if !pcmap_entry_audit_enabled() || carried_jitcode_pc < 0 {
-        return;
-    }
-    let cjc = carried_jitcode_pc as usize;
-    if let Some(path) = std::env::var_os("PYRE_PCMAP_ENTRY_AUDIT_PROBE") {
-        use std::io::Write;
-
-        if let Ok(mut probe) = std::fs::OpenOptions::new()
-            .create(true)
-            .append(true)
-            .open(path)
-        {
-            let _ = writeln!(probe, "{caller}\t{}", twin.name());
-        }
-    }
-    let table_pcdep = payload
-        .metadata
-        .pcdep_color_slots
-        .get(entry_py_pc as usize)
-        .cloned()
-        .unwrap_or_default();
-    let (twin_pcdep, twin_depth) = match twin {
-        OuterActiveBoxesEntryTwin::Plain => (
-            payload.pcdep_for_jitcode_pc(cjc).unwrap_or_default(),
-            payload.depth_for_jitcode_pc_pred(cjc).unwrap_or(0),
-        ),
-        OuterActiveBoxesEntryTwin::Trivia => (
-            payload
-                .pcdep_trivia_for_jitcode_pc(cjc)
-                .map(ToOwned::to_owned)
-                .unwrap_or_default(),
-            payload.depth_trivia_for_jitcode_pc(cjc).unwrap_or(0),
-        ),
-    };
-    assert_eq!(
-        twin_pcdep,
-        table_pcdep,
-        "PCMAP_ENTRY pcdep mismatch caller={caller} flavor={} cjc={cjc} entry_py_pc={entry_py_pc} twin_pcdep={twin_pcdep:?} table_pcdep={table_pcdep:?}",
-        twin.name(),
-    );
-    if !payload.code_ptr.is_null() {
-        let table_depth = crate::liveness::liveness_for(payload.code_ptr)
-            .depth_at_py_pc()
-            .get(entry_py_pc as usize)
-            .copied()
-            .unwrap_or(0);
-        assert_eq!(
-            twin_depth,
-            table_depth,
-            "PCMAP_ENTRY depth mismatch caller={caller} flavor={} cjc={cjc} entry_py_pc={entry_py_pc} twin_depth={twin_depth} table_depth={table_depth} twin_pcdep={twin_pcdep:?} table_pcdep={table_pcdep:?}",
-            twin.name(),
-        );
-    }
-}
-
 fn collect_outer_active_boxes(
     sym: &crate::state::PyreSym,
     trace_ctx: &mut TraceCtx,
@@ -7538,13 +7472,6 @@ fn collect_outer_active_boxes(
             unsafe {
                 let jc = &*sym.jitcode;
                 let payload = &jc.payload;
-                audit_outer_active_boxes_entry_twin(
-                    payload,
-                    entry_py_pc,
-                    entry_jitcode_pc,
-                    entry_twin,
-                    entry_caller,
-                );
                 // Operand-stack depth at the snapshot coordinate. The liveness
                 // banks (`frame_liveness_reg_indices_by_bank_at`) are read at
                 // that coordinate too, so the per-PC color→slot window
@@ -7623,38 +7550,6 @@ fn collect_outer_active_boxes(
                 unsafe {
                     let jc = &*sym.jitcode;
                     let cjc = carried_jitcode_pc;
-                    if pcmap_guard_kept_audit_enabled() && cjc >= 0 {
-                        let twin_pcdep = jc
-                            .payload
-                            .pcdep_for_jitcode_pc(cjc as usize)
-                            .unwrap_or_default();
-                        let table_pcdep = jc
-                            .payload
-                            .metadata
-                            .pcdep_color_slots
-                            .get(gpc as usize)
-                            .cloned()
-                            .unwrap_or_default();
-                        assert_eq!(
-                            twin_pcdep, table_pcdep,
-                            "PCMAP_COAB pcdep mismatch cjc={cjc} gpc={gpc}"
-                        );
-                        if !jc.payload.code_ptr.is_null() {
-                            let twin_d = jc
-                                .payload
-                                .depth_for_jitcode_pc_pred(cjc as usize)
-                                .unwrap_or(0);
-                            let table_d = crate::liveness::liveness_for(jc.payload.code_ptr)
-                                .depth_at_py_pc()
-                                .get(gpc as usize)
-                                .copied()
-                                .unwrap_or(0);
-                            assert_eq!(
-                                twin_d, table_d,
-                                "PCMAP_COAB depth mismatch cjc={cjc} gpc={gpc}"
-                            );
-                        }
-                    }
                     let entries = if cjc >= 0 {
                         jc.payload
                             .pcdep_for_jitcode_pc(cjc as usize)
@@ -11037,15 +10932,6 @@ fn audit_pfresume_twin<T: PartialEq>(site: &'static str, twin: T, table: T) {
     assert!(twin == table, "PFRESUME {site} JitCode-PC twin diverges");
 }
 
-/// `PYRE_PCMAP_GUARD_KEPT_AUDIT` enables assertions that the guard-kept
-/// recovery's plain JitCode-PC pcdep and predecessor-depth twins reproduce
-/// their Python-PC tables at the guard's own emitted opcode. Diagnostic only;
-/// off in production.
-pub(crate) fn pcmap_guard_kept_audit_enabled() -> bool {
-    static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
-    *ENABLED.get_or_init(|| std::env::var_os("PYRE_PCMAP_GUARD_KEPT_AUDIT").is_some())
-}
-
 /// `PYRE_PCMAP_CALLPC_AUDIT` certifies that a nested-inline abort's carried
 /// caller CALL JitCode coordinate resolves at the interpreter-flush boundary.
 /// Diagnostic only; off in production.
@@ -11080,45 +10966,6 @@ pub(crate) fn pcmap_midbody_audit_probe(site: &'static str, verdict: &'static st
 
 /// Audit the mid-body producer's legacy Python-PC metadata reads against the
 /// plain (no trivia skip) JitCode-PC twins at the callee abort opcode.
-fn audit_midbody_abort_plain_twins(
-    payload: &crate::pyjitcode::PyJitCode,
-    callee_py_pc: usize,
-    abort_jitcode_pc: usize,
-) {
-    if !pcmap_midbody_audit_enabled() {
-        return;
-    }
-    let table_depth = payload.metadata.depth_at_py_pc.get(callee_py_pc).copied();
-    let twin_depth = payload.depth_for_jitcode_pc_pred(abort_jitcode_pc);
-    let depth_verdict = if twin_depth == table_depth {
-        "eq"
-    } else {
-        "di"
-    };
-    pcmap_midbody_audit_probe("producer_depth_plain", depth_verdict);
-    assert_eq!(
-        twin_depth, table_depth,
-        "PCMAP_MIDBODY depth mismatch abort_jitcode_pc={abort_jitcode_pc} callee_py_pc={callee_py_pc} twin_depth={twin_depth:?} table_depth={table_depth:?}",
-    );
-
-    let table_pcdep = payload
-        .metadata
-        .pcdep_color_slots
-        .get(callee_py_pc)
-        .cloned();
-    let twin_pcdep = payload.pcdep_for_jitcode_pc(abort_jitcode_pc);
-    let pcdep_verdict = if twin_pcdep == table_pcdep {
-        "eq"
-    } else {
-        "di"
-    };
-    pcmap_midbody_audit_probe("producer_pcdep_plain", pcdep_verdict);
-    assert_eq!(
-        twin_pcdep, table_pcdep,
-        "PCMAP_MIDBODY pcdep mismatch abort_jitcode_pc={abort_jitcode_pc} callee_py_pc={callee_py_pc} twin_pcdep={twin_pcdep:?} table_pcdep={table_pcdep:?}",
-    );
-}
-
 /// `PYRE_PCMAP_ENTRYPC_AUDIT` records every remaining consumer of
 /// `WalkContext::entry_py_pc` against its marker twin. Diagnostic only; off
 /// in production.
@@ -11151,15 +10998,6 @@ fn pcmap_entrypc_audit_ctx_read(ctx: &WalkContext<'_, '_>, site: &'static str) {
         return;
     }
     pcmap_entrypc_audit_probe(site, ctx.entry_py_pc.audit_variant(), "-");
-}
-
-/// `PYRE_PCMAP_ENTRY_AUDIT` enables assertions that each carried
-/// `collect_outer_active_boxes` entry coordinate's selected JitCode-PC twin
-/// reproduces the Python-PC depth and pcdep reads. Diagnostic only; off in
-/// production.
-fn pcmap_entry_audit_enabled() -> bool {
-    static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
-    *ENABLED.get_or_init(|| std::env::var_os("PYRE_PCMAP_ENTRY_AUDIT").is_some())
 }
 
 /// `PYRE_M73_PEROP_CARRY` (#73 S2, default ON): source a specialization
@@ -12725,35 +12563,6 @@ fn walker_capture_snapshot_for_last_guard_impl(
                 // Python-trivia skip), so the pcdep twin here must be the plain
                 // predecessor-keyed flavor too.
                 let gjc = scope.branch_guard_jitcode_pc.unwrap();
-                if pcmap_guard_kept_audit_enabled() {
-                    unsafe {
-                        let jc = &*sym.jitcode;
-                        let twin = jc.payload.pcdep_for_jitcode_pc(gjc).unwrap_or_default();
-                        let table = jc
-                            .payload
-                            .metadata
-                            .pcdep_color_slots
-                            .get(gpc)
-                            .cloned()
-                            .unwrap_or_default();
-                        assert_eq!(
-                            twin, table,
-                            "PCMAP_GUARD_KEPT pcdep mismatch gjc={gjc} gpc={gpc}"
-                        );
-                        if !jc.payload.code_ptr.is_null() {
-                            let twin_d = jc.payload.depth_for_jitcode_pc_pred(gjc).unwrap_or(0);
-                            let table_d = crate::liveness::liveness_for(jc.payload.code_ptr)
-                                .depth_at_py_pc()
-                                .get(gpc)
-                                .copied()
-                                .unwrap_or(0);
-                            assert_eq!(
-                                twin_d, table_d,
-                                "PCMAP_GUARD_KEPT depth mismatch gjc={gjc} gpc={gpc}"
-                            );
-                        }
-                    }
-                }
                 let nlocals = sym.nlocals;
                 let nvs = crate::virtualizable_gen::NUM_VABLE_SCALARS;
                 let depth = unsafe {
@@ -13532,19 +13341,6 @@ fn compute_nested_inline_caller_frame(
             .map(|color| color as usize),
     }
     .ok_or(InlineCallerFrameDecline::Unavailable)?;
-    if pcmap_pfresume_audit_enabled() {
-        if let Some(marker) = resume_marker_jit_pc {
-            let fallthrough_py_pc = legacy_fallthrough_py_pc();
-            audit_pfresume_twin(
-                "inline_nested_result_color_pred",
-                pjc.result_color_for_jitcode_pc_pred(marker),
-                pjc.metadata
-                    .result_color_at_pc
-                    .get(fallthrough_py_pc as usize)
-                    .copied(),
-            );
-        }
-    }
     // Null the not-yet-produced result slot, build the box list, then restore
     // the caller's register (the inlined callee, not the walk, produces the
     // result; the inner frame supplies it on resume) — same as the top-level
@@ -13671,10 +13467,7 @@ fn walker_capture_multi_frame_inline_snapshot(
         }
         if mf_diag {
             let pcdep = callee_pjc
-                .metadata
-                .pcdep_color_slots
-                .get(callee_py_pc as usize)
-                .cloned()
+                .pcdep_for_jitcode_pc(callee_op_pc)
                 .unwrap_or_default();
             let depth = callee_pjc
                 .metadata
@@ -16527,7 +16320,6 @@ fn try_walker_inline_resolved_user_call(
                     let callee_pjc = crate::state::pyjitcode_for_code(w_code)?;
                     let metadata = &callee_pjc.metadata;
                     let callee_py_pc = python_pc_for_jitcode_pc(metadata, abort_pc) as usize;
-                    audit_midbody_abort_plain_twins(&callee_pjc, callee_py_pc, abort_pc);
                     let anchor_ok = match abort_kind {
                         MidBodyAbortKind::Structural => {
                             exact_floor_segment_anchor(metadata, callee_py_pc, abort_pc)
@@ -16582,9 +16374,7 @@ fn try_walker_inline_resolved_user_call(
                             "py_pc_legacy_or_else",
                         );
                     }
-                    let Some(entries) = pcdep_twin
-                        .or_else(|| metadata.pcdep_color_slots.get(callee_py_pc).cloned())
-                    else {
+                    let Some(entries) = pcdep_twin else {
                         return None;
                     };
                     let mut live_stack = Vec::with_capacity(depth);

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -13470,10 +13470,7 @@ fn walker_capture_multi_frame_inline_snapshot(
                 .pcdep_for_jitcode_pc(callee_op_pc)
                 .unwrap_or_default();
             let depth = callee_pjc
-                .metadata
-                .depth_at_py_pc
-                .get(callee_py_pc as usize)
-                .copied()
+                .depth_for_jitcode_pc_pred(callee_op_pc)
                 .unwrap_or(0);
             let banks = crate::state::frame_liveness_reg_indices_by_bank_at(
                 callee_jitcode_index as i32,
@@ -16354,15 +16351,7 @@ fn try_walker_inline_resolved_user_call(
                         return None;
                     }
                     let depth_twin = callee_pjc.depth_for_jitcode_pc_pred(abort_pc);
-                    if depth_twin.is_none() {
-                        pcmap_pivot_audit_record_fire(
-                            "midbody_producer_depth",
-                            "py_pc_legacy_or_else",
-                        );
-                    }
-                    let Some(depth) =
-                        depth_twin.or_else(|| metadata.depth_at_py_pc.get(callee_py_pc).copied())
-                    else {
+                    let Some(depth) = depth_twin else {
                         return None;
                     };
                     let depth = depth as usize;

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -759,8 +759,8 @@ pub struct WalkContext<'frame, 'static_a: 'frame> {
     /// snapshot frame's Python PC.
     pub entry_py_pc: EntryPyPc,
     /// Codewrite-time resume-marker twin for the outer snapshot coordinate
-    /// (`entry_py_pc`), carried by the arm-path snapshot word under
-    /// `PYRE_M73_ARMPATH_CARRY`. `None` when the creation site has no
+    /// (`entry_py_pc`), carried by the arm-path snapshot word. `None` when the
+    /// creation site has no
     /// jitcode-native outer coordinate.
     pub outer_resume_marker_jit_pc: Option<usize>,
     /// JitCode index of the **outer** `PyJitCode.jitcode` — the Python
@@ -963,8 +963,7 @@ pub enum DispatchOutcome {
         jump_args: Vec<OpRef>,
         loop_header_pc: usize,
         /// Codewrite-time resume-marker twin at the merge point op's jitcode
-        /// offset, carried into the loop-close guards' snapshot words under
-        /// `PYRE_M73_LOOPCLOSE_CARRY`.
+        /// offset, carried into the loop-close guards' snapshot words.
         loop_header_marker_jit_pc: Option<usize>,
     },
     /// `jit_merge_point/cIRFIRF` reached a loop header that already has
@@ -3063,7 +3062,7 @@ fn compute_bridge_root_parent_frame(
     let root_word = ((root_pc as i32) != majit_ir::resumedata::NO_JITCODE_PC
         && (root_pc as i32) >= 0)
         .then_some(root_pc);
-    let root_liveness_word = match root_word.filter(|_| m73_outercap_carry_enabled()) {
+    let root_liveness_word = match root_word {
         Some(w) => w as i32,
         None => majit_ir::resumedata::NO_JITCODE_PC,
     };
@@ -3078,8 +3077,7 @@ fn compute_bridge_root_parent_frame(
         None,
         // Key the query off the same carried root-frame word the snapshot and
         // decode side read from `frames[0].jitcode_pc`, so both resolve the
-        // identical liveness window. `PYRE_M73_OUTERCAP_CARRY=0` falls back to
-        // the sentinel-based decode path.
+        // identical liveness window.
         root_liveness_word,
         root_liveness_word,
         OuterActiveBoxesEntryTwin::Trivia,
@@ -3668,7 +3666,7 @@ pub(crate) fn drive_outer_frame_continuation(
         // Mirror `compute_bridge_root_parent_frame` so scatter reads the banks in collection order.
         let banks = crate::state::frame_liveness_reg_indices_by_bank_at_with_jitcode_pc(
             outer_jitcode_index as i32,
-            match root_word.filter(|_| m73_outercap_carry_enabled()) {
+            match root_word {
                 Some(w) => w as i32,
                 None => majit_ir::resumedata::NO_JITCODE_PC,
             },
@@ -7495,8 +7493,8 @@ fn collect_outer_active_boxes(
                             .depth_trivia_for_jitcode_pc(entry_jitcode_pc as usize)
                             .unwrap_or(0)
                             as usize,
-                        // A non-default gate-off configuration can still supply
-                        // no entry coordinate. It has no entry metadata.
+                        // Defensive default for a genuinely absent entry
+                        // coordinate (marker miss); 0-fire across the corpus.
                         _ => 0,
                     }
                 };
@@ -7535,6 +7533,8 @@ fn collect_outer_active_boxes(
                     .pcdep_trivia_for_jitcode_pc(entry_jitcode_pc as usize)
                     .map(ToOwned::to_owned)
                     .unwrap_or_default(),
+                // Defensive default for a genuinely absent entry coordinate
+                // (marker miss); 0-fire across the corpus.
                 _ => Vec::new(),
             }
         }
@@ -8175,38 +8175,6 @@ pub(crate) fn fbw_rec_mutual_cutover_enabled() -> bool {
 pub(crate) fn fbw_loop_callee_ca_enabled() -> bool {
     static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
     *ENABLED.get_or_init(|| match std::env::var_os("PYRE_FBW_LOOP_CALLEE_CA") {
-        Some(v) => {
-            let v = v.to_string_lossy();
-            v != "0" && !v.eq_ignore_ascii_case("false")
-        }
-        None => true,
-    })
-}
-
-/// `PYRE_M366_NONBRANCH_PC` (#366, default OFF): carry a direct JitCode
-/// resume pc for the non-branch specialization guards (`GuardValue` /
-/// `GuardClass`) instead of the `NO_JITCODE_PC` sentinel, so their resume
-/// decode consults the carried word rather than the stored Python pc →
-/// jitcode translation.
-///
-/// The carried word is the guard's codewrite-time `-live-` marker offset —
-/// not the guard op's raw
-/// `op_pc`.  These guards resume by re-executing their own opcode at
-/// `orgpc` with a deterministic operand stack (no kept temp), so the
-/// marker is a valid startpoint
-/// (`can_decode_live_vars`
-/// holds) AND identical to what the decoder would translate to — the encoder
-/// (`collect_outer_active_boxes` reg banks) and decoder (`setposition` /
-/// liveness) resolve the same offset, keeping the box layout symmetric.
-/// Carrying the raw `op_pc` (which may sit mid-opcode,
-/// `op_pc != marker`) is what broke the earlier attempt;
-/// anchoring to the marker
-/// avoids that.  Default ON — corpus-wide OFF/ON byte-equality validated on
-/// both backends (171/171 dynasm + cranelift); opt out with
-/// `PYRE_M366_NONBRANCH_PC=0`.
-pub(crate) fn m366_nonbranch_pc_enabled() -> bool {
-    static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
-    *ENABLED.get_or_init(|| match std::env::var_os("PYRE_M366_NONBRANCH_PC") {
         Some(v) => {
             let v = v.to_string_lossy();
             v != "0" && !v.eq_ignore_ascii_case("false")
@@ -11000,185 +10968,6 @@ fn pcmap_entrypc_audit_ctx_read(ctx: &WalkContext<'_, '_>, site: &'static str) {
     pcmap_entrypc_audit_probe(site, ctx.entry_py_pc.audit_variant(), "-");
 }
 
-/// `PYRE_M73_PEROP_CARRY` (#73 S2, default ON): source a specialization
-/// guard's (`GuardValue`/`GuardClass`) resume coordinate from the walk
-/// cursor's per-op `-live-` BEFORE anchor (`ctx.live_before_jit_pc`,
-/// `pyjitpl.py:198`) instead of a py_pc-keyed block-head
-/// block-head marker — the genuine JitCode cursor the migration authors resume
-/// data from. Byte-behavior-identical: the per-op anchor coincides with the
-/// marker for 99%+ of specialization captures (`PYRE_M73_PEROP_AUDIT` census),
-/// and the divergent minority resumes correctly (per-op == `self.pc -
-/// SIZE_LIVE_OP`). Validated OFF==ON on check.py (155x2), cpython_tests
-/// (39x2), and extra_tests (219x2), both backends. Opt out with
-/// `PYRE_M73_PEROP_CARRY=0`.
-pub(crate) fn m73_perop_carry_enabled() -> bool {
-    static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
-    *ENABLED.get_or_init(|| match std::env::var_os("PYRE_M73_PEROP_CARRY") {
-        Some(v) => {
-            let v = v.to_string_lossy();
-            v != "0" && !v.eq_ignore_ascii_case("false")
-        }
-        None => true,
-    })
-}
-
-/// `PYRE_M73_BRANCH_CARRY` (#73 S3.5, default ON): the terminal branch-guard
-/// flip. A depth-0 `GuardTrue`/`GuardFalse` sources its resume word from the
-/// walk's arm-independent `-live-` BEFORE anchor (`ctx.live_before_jit_pc`,
-/// `orgpc`) TAGGED into the negative space of the `jitcode_pc` word (plus a
-/// 1-bit flavor), instead of a py_pc-keyed block-head
-/// marker. Byte-identical by construction: encode carries the tagged word only
-/// when its decode-side expansion ([`expand_branch_carried`]) reproduces the
-/// baseline `marker` (self-cert), and decode expands it back to that same
-/// `marker` before any consumer reads it. Disabled (`PYRE_M73_BRANCH_CARRY=0`)
-/// → encode never emits a tagged word, so the decode expand is a no-op and the
-/// carried word is the block-head `marker` as before. Certified by
-/// `PYRE_M73_FLIP_AUDIT` (S3.4) and check.py (159×2, on and off).
-pub(crate) fn m73_branch_carry_enabled() -> bool {
-    static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
-    *ENABLED.get_or_init(|| match std::env::var_os("PYRE_M73_BRANCH_CARRY") {
-        Some(v) => {
-            let v = v.to_string_lossy();
-            v != "0" && !v.eq_ignore_ascii_case("false")
-        }
-        None => true,
-    })
-}
-
-/// `PYRE_M73_S1MARKER_CARRY` (#73 S5 phase-3 slice-1, default ON): source
-/// the remaining nonbranch guard resume words from the codewrite-time
-/// jitcode-keyed resume-marker twin. Twin-`None` rows retain the sentinel.
-/// Certified by the `M73_S1MARKER` census (100% eq=1, 1575 captures across
-/// 119 bench+synth programs) and check.py (161×2, on and off). Disable with
-/// `PYRE_M73_S1MARKER_CARRY=0`.
-pub(crate) fn m73_s1marker_carry_enabled() -> bool {
-    static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
-    *ENABLED.get_or_init(|| match std::env::var_os("PYRE_M73_S1MARKER_CARRY") {
-        Some(v) => {
-            let v = v.to_string_lossy();
-            v != "0" && !v.eq_ignore_ascii_case("false")
-        }
-        None => true,
-    })
-}
-
-/// `PYRE_M73_PFMARKER_CARRY` (#73 S5 phase-3 slice-3, default ON): carry
-/// each paused parent frame's codewrite-time resume-marker twin in its frame
-/// word. Certified by the `M73_PFMARKER` census (inline rows 447/447 eq=1;
-/// twin-`None` rows keep the sentinel) and check.py (162×2, on and off).
-/// Disable with `PYRE_M73_PFMARKER_CARRY=0`.
-pub(crate) fn m73_pfmarker_carry_enabled() -> bool {
-    static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
-    *ENABLED.get_or_init(|| match std::env::var_os("PYRE_M73_PFMARKER_CARRY") {
-        Some(v) => {
-            let v = v.to_string_lossy();
-            v != "0" && !v.eq_ignore_ascii_case("false")
-        }
-        None => true,
-    })
-}
-
-/// `PYRE_M369_PFRAME_CARRY` (gh#369 phase-1 slice-1, default ON): carry
-/// trace-opcode framestack parent resume-marker twins in their frame words.
-/// Disable with `PYRE_M369_PFRAME_CARRY=0`.
-pub(crate) fn m369_pframe_carry_enabled() -> bool {
-    static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
-    *ENABLED.get_or_init(|| match std::env::var_os("PYRE_M369_PFRAME_CARRY") {
-        Some(v) => {
-            let v = v.to_string_lossy();
-            v != "0" && !v.eq_ignore_ascii_case("false")
-        }
-        None => true,
-    })
-}
-
-/// `PYRE_M73_ARMPATH_CARRY` (#73 S5 phase-3 slice-4, default ON): carry
-/// the outer snapshot coordinate's codewrite-time resume-marker twin in the
-/// per-opcode arm-path snapshot word. Certified by the `M73_ARMPATH` census
-/// (2105 captures across 8 bench+synth programs, 100% eq=1; twin-`None`
-/// rows keep the sentinel) and check.py (162×2, on and off). Disable with
-/// `PYRE_M73_ARMPATH_CARRY=0`.
-pub(crate) fn m73_armpath_carry_enabled() -> bool {
-    static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
-    *ENABLED.get_or_init(|| match std::env::var_os("PYRE_M73_ARMPATH_CARRY") {
-        Some(v) => {
-            let v = v.to_string_lossy();
-            v != "0" && !v.eq_ignore_ascii_case("false")
-        }
-        None => true,
-    })
-}
-
-/// `PYRE_M73_LOOPCLOSE_CARRY` (#73 S5 phase-3 slice-6, default ON): carry
-/// the merge-point resume-marker twin into the back-edge eval-breaker poll
-/// and `GuardFutureCondition` loop-close snapshot words. Certified by the
-/// `M73_LOOPCLOSE` census (362 captures across pyre/bench + synth, 100%
-/// eq=1) and check.py (162×2, on and off). Disable with
-/// `PYRE_M73_LOOPCLOSE_CARRY=0`.
-pub(crate) fn m73_loopclose_carry_enabled() -> bool {
-    static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
-    *ENABLED.get_or_init(|| match std::env::var_os("PYRE_M73_LOOPCLOSE_CARRY") {
-        Some(v) => {
-            let v = v.to_string_lossy();
-            v != "0" && !v.eq_ignore_ascii_case("false")
-        }
-        None => true,
-    })
-}
-
-/// `PYRE_M73_LCLIVE_CARRY` (#73 S5 phase-5 slice-2, default ON): resolve
-/// the loop-close guards' liveness coordinate in
-/// `get_list_of_active_boxes` from the merge-point resume-marker twin
-/// (`MIFrame::loop_close_marker_jit_pc`) instead of the
-/// legacy block-head translation. Certified by the
-/// `M73_LCLIVE` census (362 captures across pyre/bench + synth, 100%
-/// eq=1) and check.py (162×2, on and off). Disable with
-/// `PYRE_M73_LCLIVE_CARRY=0`.
-pub(crate) fn m73_lclive_carry_enabled() -> bool {
-    static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
-    *ENABLED.get_or_init(|| match std::env::var_os("PYRE_M73_LCLIVE_CARRY") {
-        Some(v) => {
-            let v = v.to_string_lossy();
-            v != "0" && !v.eq_ignore_ascii_case("false")
-        }
-        None => true,
-    })
-}
-
-/// #73 S5 p5-s6: key the paused inline-caller frame's liveness query off the
-/// after-residual marker twin already carried in the frame's snapshot word
-/// (`resume_marker_jit_pc`), instead of the sentinel +
-/// legacy block-head translation. Certified by the
-/// M73_INLCALLER census (bank equality) and the p3-s2 M73_PFMARKER identity.
-/// `PYRE_M73_INLCALLER_CARRY=0` opts out.
-pub(crate) fn m73_inlcaller_carry_enabled() -> bool {
-    static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
-    *ENABLED.get_or_init(|| match std::env::var_os("PYRE_M73_INLCALLER_CARRY") {
-        Some(v) => {
-            let v = v.to_string_lossy();
-            v != "0" && !v.eq_ignore_ascii_case("false")
-        }
-        None => true,
-    })
-}
-
-/// #73 S5 p5-s7: key the remaining outer-frame capture liveness queries
-/// (bridge-root parent frame + its register scatter, inline-call outer capture,
-/// list-append outer capture) off the jitcode-keyed word already in hand
-/// (carried root frame word / call-site marker twin) instead of the sentinel +
-/// historical block-head translation. Certified by the M73_OUTERCAP census
-/// (bank equality). `PYRE_M73_OUTERCAP_CARRY=0` opts out.
-fn m73_outercap_carry_enabled() -> bool {
-    static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
-    *ENABLED.get_or_init(|| match std::env::var_os("PYRE_M73_OUTERCAP_CARRY") {
-        Some(v) => {
-            let v = v.to_string_lossy();
-            v != "0" && !v.eq_ignore_ascii_case("false")
-        }
-        None => true,
-    })
-}
-
 /// `PYRE_PCMAP_PIVOT_AUDIT` records PC-pivot census counters. Off by default.
 pub fn pcmap_pivot_audit_enabled() -> bool {
     static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
@@ -12640,10 +12429,8 @@ fn walker_capture_snapshot_for_last_guard_impl(
             //
             // Every other guard (guard_value / guard_class / guard_no_exception,
             // the `after_residual_call` family) resumes at a `py_pc` whose
-            // operand stack is in a deterministic state with no kept temp, so
-            // its resume-translation is already exact; it keeps the sentinel
-            // and decodes via `py_pc → jitcode`, identical to the flag-off
-            // baseline.  Carrying `op_pc` for those broke encoder ↔ decoder
+            // operand stack is in a deterministic state with no kept temp.
+            // Carrying `op_pc` for those broke encoder ↔ decoder
             // symmetry: `collect_outer_active_boxes` resolves the reg banks at
             // the carried coordinate but `live_locals` / `stack_color_map` at
             // `entry_py_pc`, and for a non-branch guard
@@ -12654,8 +12441,7 @@ fn walker_capture_snapshot_for_last_guard_impl(
                 // `MIFrame.pc`) — the ONE carried word not sourced from the
                 // resume-translation.
                 guard_jc_pc as i32
-            } else if m366_nonbranch_pc_enabled()
-                && !after_residual_call
+            } else if !after_residual_call
                 && matches!(
                     ctx.trace_ctx.last_guard_opcode(),
                     Some(
@@ -12682,7 +12468,7 @@ fn walker_capture_snapshot_for_last_guard_impl(
                 // Every guard-capture point is emitted after a `-live-` marker;
                 // its populated codewrite-time twin is therefore total here.
                 let marker = unsafe { (&*sym.jitcode).payload.resume_marker_for_jitcode_pc(op_pc) };
-                // #73 S2 flip (`PYRE_M73_PEROP_CARRY`, default OFF): a
+                // #73 S2: a
                 // specialization guard (`GuardValue`/`GuardClass`) sources its
                 // resume coordinate from the walk cursor's per-op `-live-`
                 // BEFORE anchor (`ctx.live_before_jit_pc`, `pyjitpl.py:198`)
@@ -12693,8 +12479,7 @@ fn walker_capture_snapshot_for_last_guard_impl(
                 // decode identically for every consumer (banks + bridge maps +
                 // const refill) where the anchor coincides, and flags the
                 // divergent minority for the check.py output-equality gate.
-                // #73 S3.5 flip (`PYRE_M73_BRANCH_CARRY`, default ON, opt-out
-                // `=0`/`false`): a depth-0
+                // #73 S3.5: a depth-0
                 // branch guard (`GuardTrue`/`GuardFalse`) carries the walk's
                 // arm-independent `-live-` BEFORE anchor (`ctx.live_before_jit_pc`,
                 // `orgpc`) TAGGED into the negative space of the word plus the
@@ -12712,8 +12497,7 @@ fn walker_capture_snapshot_for_last_guard_impl(
                     ctx.trace_ctx.last_guard_opcode(),
                     Some(OpCode::GuardTrue | OpCode::GuardFalse)
                 );
-                if m73_branch_carry_enabled()
-                    && is_branch
+                if is_branch
                     && ctx.live_before_jit_pc != usize::MAX
                     && ctx.live_before_jit_pc <= majit_ir::resumedata::BRANCH_ORGPC_MAX
                     && marker.is_some()
@@ -12732,8 +12516,7 @@ fn walker_capture_snapshot_for_last_guard_impl(
                     }
                 {
                     majit_ir::resumedata::encode_branch_orgpc(ctx.live_before_jit_pc, flavor_true)
-                } else if m73_perop_carry_enabled()
-                    && marker.is_some()
+                } else if marker.is_some()
                     && ctx.live_before_jit_pc != usize::MAX
                     && matches!(
                         ctx.trace_ctx.last_guard_opcode(),
@@ -12747,7 +12530,7 @@ fn walker_capture_snapshot_for_last_guard_impl(
                         None => majit_ir::resumedata::NO_JITCODE_PC,
                     }
                 }
-            } else if m366_nonbranch_pc_enabled() && after_residual_call {
+            } else if after_residual_call {
                 // #366: extend the direct-pc carry to the after-residual-call
                 // guard family (`GuardException`/`GuardNoException`/
                 // `GuardNotForced`/`GuardAlwaysFails` — exactly what the
@@ -12796,24 +12579,16 @@ fn walker_capture_snapshot_for_last_guard_impl(
                     Some(jp) => jp as i32,
                     None => majit_ir::resumedata::NO_JITCODE_PC,
                 }
-            } else if m366_nonbranch_pc_enabled() && m73_s1marker_carry_enabled() {
+            } else {
                 // #73 S5 p3-s1: the remaining nonbranch guards (outside the
                 // arm-2 allow-list, not after-residual) carry the same
                 // block-head marker as arm-2, sourced from the jitcode-keyed
-                // twin at the guard's own `op_pc`.  Nested under the #366
-                // nonbranch opt-out so `PYRE_M366_NONBRANCH_PC=0` keeps the
-                // sentinel for every nonbranch guard.
+                // twin at the guard's own `op_pc`.
                 let twin = unsafe { (&*sym.jitcode).payload.resume_marker_for_jitcode_pc(op_pc) };
-                if m73_s1marker_carry_enabled() {
-                    match twin {
-                        Some(jp) => jp as i32,
-                        None => majit_ir::resumedata::NO_JITCODE_PC,
-                    }
-                } else {
-                    majit_ir::resumedata::NO_JITCODE_PC
+                match twin {
+                    Some(jp) => jp as i32,
+                    None => majit_ir::resumedata::NO_JITCODE_PC,
                 }
-            } else {
-                majit_ir::resumedata::NO_JITCODE_PC
             };
             // #124 Approach B: when the carrier holds the guard's own pc (a
             // branch guard whose not-taken arm is reached by RE-EXECUTING
@@ -12962,13 +12737,10 @@ fn walker_capture_snapshot_for_last_guard_impl(
     // the carried static outer JitCode coordinate; an absent coordinate
     // declines instead of reconstructing one from the Python pc.
     let (vable_boxes, vref_boxes) = ctx.trace_ctx.build_snapshot_vable_vref_boxes();
-    let arm_word = if m73_armpath_carry_enabled() {
-        ctx.outer_resume_marker_jit_pc
-            .map(|m| m as i32)
-            .unwrap_or(majit_ir::resumedata::NO_JITCODE_PC)
-    } else {
-        majit_ir::resumedata::NO_JITCODE_PC
-    };
+    let arm_word = ctx
+        .outer_resume_marker_jit_pc
+        .map(|m| m as i32)
+        .unwrap_or(majit_ir::resumedata::NO_JITCODE_PC);
     let Some(arm_pc_word) =
         crate::state::pyjitcode_for_jitcode_index(ctx.outer_jitcode_index as i32)
             .and_then(|payload| {
@@ -13232,8 +13004,7 @@ fn compute_inline_caller_frame(
     }
     // The after-residual marker names the same `-live-` the fallthrough
     // translation resolves to (M73_PFMARKER identity), bypassing the py channel.
-    let caller_liveness_word = match resume_marker_jit_pc.filter(|_| m73_inlcaller_carry_enabled())
-    {
+    let caller_liveness_word = match resume_marker_jit_pc {
         Some(m) => m as i32,
         None => majit_ir::resumedata::NO_JITCODE_PC,
     };
@@ -13352,10 +13123,9 @@ fn compute_nested_inline_caller_frame(
     }
     // The after-residual marker names the same `-live-` the fallthrough
     // translation resolves to (M73_PFMARKER identity), bypassing the py channel.
-    // Without a marker there is no coordinate to encode against, so the sentinel
-    // declines the caller frame (`PYRE_M73_INLCALLER_CARRY=0` forces that).
-    let caller_liveness_word = match resume_marker_jit_pc.filter(|_| m73_inlcaller_carry_enabled())
-    {
+    // Without a marker there is no coordinate to encode against, so the
+    // sentinel declines the caller frame.
+    let caller_liveness_word = match resume_marker_jit_pc {
         Some(m) => m as i32,
         None => majit_ir::resumedata::NO_JITCODE_PC,
     };
@@ -13592,13 +13362,10 @@ fn walker_capture_multi_frame_inline_snapshot(
     // top frame last (innermost).
     let mut frames: Vec<(u32, u32, &[OpRef])> = Vec::with_capacity(parent_frames.len() + 1);
     for pf in &parent_frames {
-        let pf_word = if m73_pfmarker_carry_enabled() {
-            pf.resume_marker_jit_pc
-                .map(|m| m as i32)
-                .unwrap_or(majit_ir::resumedata::NO_JITCODE_PC)
-        } else {
-            majit_ir::resumedata::NO_JITCODE_PC
-        };
+        let pf_word = pf
+            .resume_marker_jit_pc
+            .map(|m| m as i32)
+            .unwrap_or(majit_ir::resumedata::NO_JITCODE_PC);
         let Some(pf_pc_word) = crate::state::pyjitcode_for_jitcode_index(pf.jitcode_index as i32)
             .and_then(|payload| {
                 let resolved =
@@ -16165,8 +15932,7 @@ fn try_walker_inline_resolved_user_call(
                 };
                 let call_site_py_pc =
                     crate::state::backxlat_py_pc(call_site_jc_index as i32, op.pc as i32) as u32;
-                let call_site_word = match call_site_marker.filter(|_| m73_outercap_carry_enabled())
-                {
+                let call_site_word = match call_site_marker {
                     Some(m) => m as i32,
                     None => majit_ir::resumedata::NO_JITCODE_PC,
                 };
@@ -21711,7 +21477,7 @@ fn orthodox_list_append_commit(
             Value::Int(vsd_value),
         );
     }
-    let call_site_word = match call_site_marker.filter(|_| m73_outercap_carry_enabled()) {
+    let call_site_word = match call_site_marker {
         Some(m) => m as i32,
         None => majit_ir::resumedata::NO_JITCODE_PC,
     };

--- a/pyre/pyre-jit-trace/src/pyjitcode.rs
+++ b/pyre/pyre-jit-trace/src/pyjitcode.rs
@@ -91,8 +91,6 @@ pub struct PyJitCodeMetadata {
     /// per materialized trace-entry green. Sorted ascending by green py_pc for
     /// binary search; empty for skeleton / fixture metadata.
     pub merge_entry_by_green: Vec<(u32, u32)>,
-    /// Value-stack depth at each Python PC, in slots above stack_base.
-    pub depth_at_py_pc: Vec<u16>,
     /// task#50 phase-1: predecessor-keyed jitcode-pc twin of `pcdep_color_slots`.
     /// Each entry `(off, colors)` maps a JitCode byte offset to the pcdep
     /// color→slot list of the py_pc that `python_pc_for_jitcode_pc(off)` returns
@@ -893,7 +891,6 @@ impl PyJitCode {
                 after_residual_marker_pred_by_jit_pc: Vec::new(),
                 result_color_after_residual_marker_by_jit_pc: Vec::new(),
                 result_color_after_residual_pred_by_jit_pc: Vec::new(),
-                depth_at_py_pc: Vec::new(),
                 result_color_by_jit_pc: Vec::new(),
                 // Encoder/decoder readers in
                 // `get_list_of_active_boxes`, `regalloc::external/input_indices`,

--- a/pyre/pyre-jit-trace/src/pyjitcode.rs
+++ b/pyre/pyre-jit-trace/src/pyjitcode.rs
@@ -167,11 +167,6 @@ pub struct PyJitCodeMetadata {
     /// fallback. Empty for skeleton / fixture.
     pub result_color_after_residual_marker_by_jit_pc: Vec<(usize, Option<u16>)>,
     pub result_color_after_residual_pred_by_jit_pc: Vec<(usize, Option<u16>)>,
-    /// #73 metadata-inventory twin of `result_color_at_pc`, keyed by JitCode
-    /// byte offset. Entries retain the first Python PC for each shared resume
-    /// marker and are sorted for predecessor lookup. Audit-only for now; the
-    /// py_pc-keyed table remains the runtime source of truth.
-    pub result_color_by_jit_pc: Vec<(usize, u16)>,
     /// Whether codewriter register allocation assigned non-identity frame
     /// colors. Skeleton and portal metadata leave this false.
     pub has_color_map: bool,
@@ -566,18 +561,6 @@ impl PyJitCode {
         Self::predecessor_index(search).map(|i| table[i].1)
     }
 
-    /// #73 metadata-inventory predecessor twin of `result_color_at_pc`.
-    /// Returns the value for the largest JitCode byte offset at or before
-    /// `jit_pc`, or `None` when the audit-only twin is empty.
-    pub fn result_color_for_jitcode_pc_pred(&self, jit_pc: usize) -> Option<u16> {
-        let table = &self.metadata.result_color_by_jit_pc;
-        if table.is_empty() {
-            return None;
-        }
-        let search = table.binary_search_by_key(&jit_pc, |&(off, _)| off);
-        Self::predecessor_index(search).map(|i| table[i].1)
-    }
-
     /// gh#73 S3.2: const operand-stack slots keyed by a JitCode byte offset via
     /// the `const_ref_slots_by_jit_pc` predecessor twin. Equals
     /// `const_ref_slots_at_pc[python_pc_for_jitcode_pc(jit_pc)]` by construction
@@ -891,7 +874,6 @@ impl PyJitCode {
                 after_residual_marker_pred_by_jit_pc: Vec::new(),
                 result_color_after_residual_marker_by_jit_pc: Vec::new(),
                 result_color_after_residual_pred_by_jit_pc: Vec::new(),
-                result_color_by_jit_pc: Vec::new(),
                 // Encoder/decoder readers in
                 // `get_list_of_active_boxes`, `regalloc::external/input_indices`,
                 // and `setup_bridge_sym::portal_red_regs_at` sentinel-skip both

--- a/pyre/pyre-jit-trace/src/pyjitcode.rs
+++ b/pyre/pyre-jit-trace/src/pyjitcode.rs
@@ -160,35 +160,23 @@ pub struct PyJitCodeMetadata {
     /// fixture.
     pub after_residual_marker_marker_by_jit_pc: Vec<(usize, Option<usize>)>,
     pub after_residual_marker_pred_by_jit_pc: Vec<(usize, Option<usize>)>,
-    /// Result color (`result_color_at_pc`) of the call-result operand slot at
-    /// the after-residual fallthrough PC, keyed by JitCode byte offset with the
-    /// same exact-marker / predecessor-op-start split as
-    /// `after_residual_marker_*`. Value =
+    /// Result color of the call-result operand slot at the after-residual
+    /// fallthrough PC, keyed by JitCode byte offset with the same exact-marker
+    /// / predecessor-op-start split as `after_residual_marker_*`. Value =
     /// `result_color_at_pc[semantic_fallthrough_pc(skip_python_trivia_forward(py))]`
-    /// (`None` past the table end). Retires the runtime py-keyed result-color
-    /// read in the inline-caller marker-miss fallback. Empty for skeleton /
-    /// fixture.
+    /// computed at codewrite time (`None` past the table end). Retires the
+    /// runtime py-keyed result-color read in the inline-caller marker-miss
+    /// fallback. Empty for skeleton / fixture.
     pub result_color_after_residual_marker_by_jit_pc: Vec<(usize, Option<u16>)>,
     pub result_color_after_residual_pred_by_jit_pc: Vec<(usize, Option<u16>)>,
-    /// Post-regalloc Ref-bank color of the call-result operand-stack slot
-    /// (top of stack = `depth_at_py_pc[pc] - 1`) at each Python PC, or
-    /// `u16::MAX` where the stack is empty. The inline multiframe capture
-    /// (`jitcode_dispatch::compute_inline_caller_frame` /
-    /// `compute_nested_inline_caller_frame`) nulls the not-yet-produced result
-    /// register before serializing the paused caller frame; that slot is not a
-    /// live Variable at the return PC, so it carries no `pcdep_color_slots`
-    /// entry — the same not-yet-defined call-result box that `_result_argcode`
-    /// (pyjitpl.py) clears in a non-topmost resumed frame (`registers_r[index]
-    /// = CONST_NULL` for the `'r'` argcode). This precomputed table (built in
-    /// `finalize_jitcode` from the compile-time stack coloring) supplies its
-    /// color. Same length as `depth_at_py_pc`; empty for non-compiled skeleton
-    /// metadata.
-    pub result_color_at_pc: Vec<u16>,
     /// #73 metadata-inventory twin of `result_color_at_pc`, keyed by JitCode
     /// byte offset. Entries retain the first Python PC for each shared resume
     /// marker and are sorted for predecessor lookup. Audit-only for now; the
     /// py_pc-keyed table remains the runtime source of truth.
     pub result_color_by_jit_pc: Vec<(usize, u16)>,
+    /// Whether codewriter register allocation assigned non-identity frame
+    /// colors. Skeleton and portal metadata leave this false.
+    pub has_color_map: bool,
     /// Post-regalloc Ref-bank color of the portal jitdriver's first red
     /// argument (`frame`).  RPython parity: `pypy/module/pypyjit/
     /// interp_jit.py:67 reds = ['frame', 'ec']` declares the portal
@@ -224,30 +212,6 @@ pub struct PyJitCodeMetadata {
     /// `nlocals + ncells + max_stackdepth`). Sized to the static peak, not
     /// `max(depth_at_pc)` — JIT-traced PCs may not reach `co_stacksize`.
     pub max_stackdepth: usize,
-    /// Per-Python-PC bank-tagged color↔slot map for the live restorable
-    /// frame slots. Indexed by `py_pc`; each entry is `(bank, color, slot)`
-    /// where bank = `Kind::index()` (0=Int, 1=Ref, 2=Float), color is the
-    /// post-regalloc register within that bank, and slot is the unified
-    /// `locals_cells_stack_w` semantic index (local `i` for `i < nlocals`,
-    /// `nlocals + d` for operand-stack depth `d`). Sorted by
-    /// `(bank, color, slot)`.
-    ///
-    /// Records each slot's TRUE per-program-point SSA color — the runtime
-    /// analog of RPython's compile-time baked register operands, precomputed
-    /// per Python PC so a guard resume can invert color→slot without walking
-    /// the jitcode. It is the static form of the per-bank register enumeration
-    /// that `resume.py`'s `_prepare_next_section` → `enumerate_vars` dispatches
-    /// at resume time to seed `registers_i` / `registers_r` / `registers_f`
-    /// from the encoded section. Stack
-    /// slots and body locals are freely chordal-colored (only the
-    /// startblock inputargs are pinned by `enforce_input_args`,
-    /// `flatten.py:88-100` parity), so there is no `color == slot`
-    /// identity and no flat whole-jitcode slot → color map. Empty when the
-    /// producer did not populate it (skeletons / fixtures); readers branch to the slot-identity reconstruction
-    /// then. When populated, the `-live-` markers carry the SAME per-PC
-    /// colors (built by `filter_liveness_in_place` off this map), so
-    /// encode/decode/`-live-` stay in one consistent color space.
-    pub pcdep_color_slots: Vec<Vec<(u8, u16, u16)>>,
     /// Per-Python-PC operand-stack Ref CONSTANTS (`(semantic_slot, raw_ref)`).
     /// `pcdep_color_slots` records live restorable Variables only; for the
     /// virtualizable ROOT frame the operand-stack constants are rematerialized
@@ -930,7 +894,6 @@ impl PyJitCode {
                 result_color_after_residual_marker_by_jit_pc: Vec::new(),
                 result_color_after_residual_pred_by_jit_pc: Vec::new(),
                 depth_at_py_pc: Vec::new(),
-                result_color_at_pc: Vec::new(),
                 result_color_by_jit_pc: Vec::new(),
                 // Encoder/decoder readers in
                 // `get_list_of_active_boxes`, `regalloc::external/input_indices`,
@@ -943,7 +906,7 @@ impl PyJitCode {
                 built_as_portal: false,
                 stack_base: 0,
                 max_stackdepth: 0,
-                pcdep_color_slots: Vec::new(),
+                has_color_map: false,
                 const_ref_slots_at_pc: Vec::new(),
                 const_ref_slots_by_jit_pc: Vec::new(),
                 is_drained: false,

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -13243,18 +13243,14 @@ pub(crate) fn setup_reconstructed_callee_frame(
     // frame/ec seeding so a reused color resolves to the live stack value.
     // Falls back to identity when no live color owns the slot (empty map /
     // non-diverging coloring).
-    let py_pc = backxlat_py_pc(recipe.jitcode_index, recipe.jitcode_pc);
-    let pcdep = pcdep_color_slots_at(recipe.jitcode_index, py_pc);
+    let pcdep = pcdep_trivia_at(recipe.jitcode_index, recipe.jitcode_pc).unwrap_or_default();
     if crate::jitcode_dispatch::pcmap_pivot_audit_enabled() {
-        let twin = pcdep_trivia_at(recipe.jitcode_index, recipe.jitcode_pc);
-        crate::jitcode_dispatch::pcmap_pivot_audit_record_fire("a1_recipe_pcdep", "fire");
-        crate::jitcode_dispatch::pcmap_pivot_audit_record_fire(
-            "a1_recipe_pcdep",
-            if twin.as_deref().unwrap_or_default() == pcdep.as_slice() {
-                "eq"
-            } else {
-                "di"
-            },
+        let py_pc = backxlat_py_pc(recipe.jitcode_index, recipe.jitcode_pc);
+        assert_eq!(
+            pcdep,
+            pcdep_color_slots_at(recipe.jitcode_index, py_pc),
+            "pcdep trivia twin vs backxlat consumer diverges at jit_pc={}",
+            recipe.jitcode_pc
         );
     }
     for k in nlocals..valuestackdepth {

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -1569,12 +1569,26 @@ pub(crate) fn bridge_semantic_maps_at_with_jitcode_pc(
                         payload.pcdep_for_jitcode_pc(jp),
                     ) {
                         (Some(depth), Some(pcdep)) => (depth as usize, pcdep),
-                        _ => (
-                            via_py_pc(majit_ir::resumedata::decode_resume_pc(pc).0 as usize),
-                            Vec::new(),
-                        ),
+                        _ => {
+                            if crate::jitcode_dispatch::pcmap_pivot_audit_enabled() {
+                                crate::jitcode_dispatch::pcmap_pivot_audit_record_fire(
+                                    "depthfield_via_py_pc",
+                                    "twin_miss",
+                                );
+                            }
+                            (
+                                via_py_pc(majit_ir::resumedata::decode_resume_pc(pc).0 as usize),
+                                Vec::new(),
+                            )
+                        }
                     }
                 } else {
+                    if crate::jitcode_dispatch::pcmap_pivot_audit_enabled() {
+                        crate::jitcode_dispatch::pcmap_pivot_audit_record_fire(
+                            "depthfield_via_py_pc",
+                            "non_decodable",
+                        );
+                    }
                     (
                         via_py_pc(majit_ir::resumedata::decode_resume_pc(pc).0 as usize),
                         Vec::new(),

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -929,7 +929,21 @@ pub(crate) fn sub_jitcode_entry_param_colors(code: *const ()) -> Option<Vec<(u8,
         return None;
     }
     let pjc = pyjitcode_for_code(code)?;
-    pjc.metadata.pcdep_color_slots.first().cloned()
+    let legacy = pjc.metadata.pcdep_color_slots.first().cloned();
+    if crate::jitcode_dispatch::pcmap_pivot_audit_enabled() {
+        crate::jitcode_dispatch::pcmap_pivot_audit_record_fire("entry_param_colors", "fire");
+        let twin = pjc.pcdep_for_jitcode_pc(0);
+        if legacy == twin {
+            crate::jitcode_dispatch::pcmap_pivot_audit_record_fire("entry_param_colors", "eq");
+        } else {
+            crate::jitcode_dispatch::pcmap_pivot_audit_record_fire("entry_param_colors", "di");
+            crate::jitcode_dispatch::pcmap_pivot_audit_record_data(
+                "entry_param_colors",
+                &format!("legacy={legacy:?} twin={twin:?}"),
+            );
+        }
+    }
+    legacy
 }
 
 pub(crate) type SubDescrPool = (
@@ -1620,12 +1634,26 @@ pub(crate) fn bridge_semantic_maps_at_with_jitcode_pc(
                         payload.pcdep_for_jitcode_pc(jp),
                     ) {
                         (Some(depth), Some(pcdep)) => (depth as usize, pcdep),
-                        _ => via_py_pc(majit_ir::resumedata::decode_resume_pc(pc).0 as usize),
+                        _ => {
+                            crate::jitcode_dispatch::pcmap_pivot_audit_record_fire(
+                                "bridge_maps_via_py_pc",
+                                "twin_miss",
+                            );
+                            via_py_pc(majit_ir::resumedata::decode_resume_pc(pc).0 as usize)
+                        }
                     }
                 } else {
+                    crate::jitcode_dispatch::pcmap_pivot_audit_record_fire(
+                        "bridge_maps_via_py_pc",
+                        "non_decodable",
+                    );
                     via_py_pc(majit_ir::resumedata::decode_resume_pc(pc).0 as usize)
                 }
             } else {
+                crate::jitcode_dispatch::pcmap_pivot_audit_record_fire(
+                    "bridge_maps_via_py_pc",
+                    "no_word",
+                );
                 via_py_pc(majit_ir::resumedata::decode_resume_pc(pc).0 as usize)
             };
         BridgeSemanticMaps {
@@ -6043,7 +6071,36 @@ fn reconstruct_inline_recipe(
     // resume pc there is no per-pc map to faithfully rebuild the frame, so
     // decline to the single-frame bridge (whose vable payload IS semantic-
     // ordered) rather than rebuild the frame with mis-slotted boxes.
-    let maps = bridge_semantic_maps_at(frame.jitcode_index, frame.pc);
+    let maps = if crate::jitcode_dispatch::pcmap_pivot_audit_enabled() {
+        crate::jitcode_dispatch::pcmap_pivot_audit_record_fire("bridge_maps_frame", "fire");
+        let legacy = bridge_semantic_maps_at(frame.jitcode_index, frame.pc);
+        let twin = bridge_semantic_maps_from_pc(frame.jitcode_index, frame.pc);
+        if legacy.has_color_map == twin.has_color_map
+            && legacy.stack_depth_at_pc == twin.stack_depth_at_pc
+            && legacy.pcdep_entries == twin.pcdep_entries
+        {
+            crate::jitcode_dispatch::pcmap_pivot_audit_record_fire("bridge_maps_frame", "eq");
+        } else {
+            crate::jitcode_dispatch::pcmap_pivot_audit_record_fire("bridge_maps_frame", "di");
+            crate::jitcode_dispatch::pcmap_pivot_audit_record_data(
+                "bridge_maps_frame",
+                &format!(
+                    "idx={} pc={} legacy=({},{},{:?}) twin=({},{},{:?})",
+                    frame.jitcode_index,
+                    frame.pc,
+                    legacy.has_color_map,
+                    legacy.stack_depth_at_pc,
+                    legacy.pcdep_entries,
+                    twin.has_color_map,
+                    twin.stack_depth_at_pc,
+                    twin.pcdep_entries,
+                ),
+            );
+        }
+        legacy
+    } else {
+        bridge_semantic_maps_at(frame.jitcode_index, frame.pc)
+    };
     if maps.pcdep_entries.is_empty() {
         return None;
     }
@@ -8938,6 +8995,40 @@ impl JitState for PyreJitState {
                 frame0.pc as usize,
                 portal_ec_reg,
             );
+            if crate::jitcode_dispatch::pcmap_pivot_audit_enabled() {
+                crate::jitcode_dispatch::pcmap_pivot_audit_record_fire("ec_color_gate", "fire");
+                let resolved = frame_pc_is_resolved_offset_at(frame0.jitcode_index, frame0.pc);
+                crate::jitcode_dispatch::pcmap_pivot_audit_record_fire(
+                    "ec_color_gate",
+                    if resolved { "resolved" } else { "unresolved" },
+                );
+                let twin =
+                    pyjitcode_for_jitcode_index(frame0.jitcode_index).is_some_and(|payload| {
+                        payload
+                            .pcdep_trivia_for_jitcode_pc(frame0.pc as usize)
+                            .is_some_and(|entries| {
+                                entries
+                                    .iter()
+                                    .any(|&(bank, color, _)| bank == 1 && color == portal_ec_reg)
+                            })
+                    });
+                if ec_color_names_frame_slot == twin {
+                    crate::jitcode_dispatch::pcmap_pivot_audit_record_fire("ec_color_gate", "eq");
+                } else {
+                    crate::jitcode_dispatch::pcmap_pivot_audit_record_fire("ec_color_gate", "di");
+                    crate::jitcode_dispatch::pcmap_pivot_audit_record_data(
+                        "ec_color_gate",
+                        &format!(
+                            "idx={} pc={} resolved={} legacy={} twin={}",
+                            frame0.jitcode_index,
+                            frame0.pc,
+                            resolved,
+                            ec_color_names_frame_slot,
+                            twin,
+                        ),
+                    );
+                }
+            }
             if !ec_color_names_frame_slot {
                 let slot = portal_ec_reg as usize;
                 assert!(

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -1391,33 +1391,6 @@ pub fn seed_compiled_trace_jitcode_test_state(
     }
 }
 
-/// Per-PC `(color, semantic_slot)` resume entries for the registered
-/// jitcode at `jitcode_index` (`metadata.pcdep_color_slots[py_pc]`).
-/// Empty when the index or PC is out of range, or the jitcode was never
-/// colored (portal/skeleton installs).
-///
-/// Used by tests + tooling that need to translate a physical frame slot
-/// (local `i` for `i < code.varnames.len()`, `metadata.stack_base + d` for
-/// operand-stack depth `d`) into the post-rename register color the dispatcher would touch
-/// at a given PC — colors are per-program-point, so a flat
-/// slot-arithmetic lookup does not exist.
-pub fn pcdep_color_slots_at(jitcode_index: i32, py_pc: i32) -> Vec<(u8, u16, u16)> {
-    ensure_finish_setup();
-    METAINTERP_SD.with(|r| {
-        let sd = r.borrow();
-        sd.jitcodes
-            .get(jitcode_index as usize)
-            .and_then(|jc| {
-                jc.payload
-                    .metadata
-                    .pcdep_color_slots
-                    .get(usize::try_from(py_pc).ok()?)
-                    .cloned()
-            })
-            .unwrap_or_default()
-    })
-}
-
 /// Trivia-aware per-PC `(color, semantic_slot)` resume entries keyed directly
 /// by a JitCode byte offset. `None` when the index, offset, or trivia twin is
 /// unavailable; callers that preserve the legacy empty-result behavior may use
@@ -1431,22 +1404,6 @@ pub fn pcdep_trivia_at(jitcode_index: i32, jit_pc: i32) -> Option<Vec<(u8, u16, 
             .payload
             .pcdep_trivia_for_jitcode_pc(usize::try_from(jit_pc).ok()?)
             .map(ToOwned::to_owned)
-    })
-}
-
-/// The post-regalloc Ref-bank color of the call-result operand-stack slot,
-/// keyed directly by a JitCode byte offset through the trivia-aware twin.
-/// Returns `None` for an empty stack, unavailable twin, or invalid coordinate.
-pub fn result_color_trivia_at(jitcode_index: i32, jit_pc: i32) -> Option<usize> {
-    ensure_finish_setup();
-    METAINTERP_SD.with(|r| {
-        let sd = r.borrow();
-        sd.jitcodes
-            .get(jitcode_index as usize)?
-            .payload
-            .result_color_trivia_for_jitcode_pc(usize::try_from(jit_pc).ok()?)
-            .map(|color| color as usize)
-            .filter(|&color| color != u16::MAX as usize)
     })
 }
 
@@ -1587,13 +1544,7 @@ pub(crate) fn bridge_semantic_maps_at_with_jitcode_pc(
                 .get(rp)
                 .copied()
                 .unwrap_or(0) as usize;
-            let pcdep = payload
-                .metadata
-                .pcdep_color_slots
-                .get(rp)
-                .cloned()
-                .unwrap_or_default();
-            (depth, pcdep)
+            depth
         };
         let (stack_depth_at_pc, pcdep_entries) =
             if jitcode_pc != majit_ir::resumedata::NO_JITCODE_PC && jitcode_pc >= 0 {
@@ -1618,33 +1569,28 @@ pub(crate) fn bridge_semantic_maps_at_with_jitcode_pc(
                         payload.pcdep_for_jitcode_pc(jp),
                     ) {
                         (Some(depth), Some(pcdep)) => (depth as usize, pcdep),
-                        _ => {
-                            crate::jitcode_dispatch::pcmap_pivot_audit_record_fire(
-                                "bridge_maps_via_py_pc",
-                                "twin_miss",
-                            );
-                            via_py_pc(majit_ir::resumedata::decode_resume_pc(pc).0 as usize)
-                        }
+                        _ => (
+                            via_py_pc(majit_ir::resumedata::decode_resume_pc(pc).0 as usize),
+                            Vec::new(),
+                        ),
                     }
                 } else {
-                    crate::jitcode_dispatch::pcmap_pivot_audit_record_fire(
-                        "bridge_maps_via_py_pc",
-                        "non_decodable",
-                    );
-                    via_py_pc(majit_ir::resumedata::decode_resume_pc(pc).0 as usize)
+                    (
+                        via_py_pc(majit_ir::resumedata::decode_resume_pc(pc).0 as usize),
+                        Vec::new(),
+                    )
                 }
             } else {
-                crate::jitcode_dispatch::pcmap_pivot_audit_record_fire(
-                    "bridge_maps_via_py_pc",
-                    "no_word",
-                );
-                via_py_pc(majit_ir::resumedata::decode_resume_pc(pc).0 as usize)
+                (
+                    via_py_pc(majit_ir::resumedata::decode_resume_pc(pc).0 as usize),
+                    Vec::new(),
+                )
             };
         BridgeSemanticMaps {
             // #73: the codewriter colored this jitcode iff `pcdep_color_slots`
             // is non-empty — the field-free replacement for the retired flat
             // `local_color_map.is_empty() && stack_color_map.is_empty()` test.
-            has_color_map: !payload.metadata.pcdep_color_slots.is_empty(),
+            has_color_map: payload.metadata.has_color_map,
             stack_depth_at_pc,
             pcdep_entries,
         }
@@ -12575,14 +12521,13 @@ mod tests {
                 result_color_after_residual_marker_by_jit_pc: Vec::new(),
                 result_color_after_residual_pred_by_jit_pc: Vec::new(),
                 depth_at_py_pc: vec![2],
-                result_color_at_pc: Vec::new(),
                 result_color_by_jit_pc: Vec::new(),
+                has_color_map: false,
                 portal_frame_reg: 0,
                 portal_ec_reg: 0,
                 built_as_portal: true,
                 stack_base: 1,
                 max_stackdepth: 0,
-                pcdep_color_slots: Vec::new(),
                 const_ref_slots_at_pc: Vec::new(),
                 const_ref_slots_by_jit_pc: Vec::new(),
                 is_drained: true,
@@ -13261,15 +13206,6 @@ pub(crate) fn setup_reconstructed_callee_frame(
     // Falls back to identity when no live color owns the slot (empty map /
     // non-diverging coloring).
     let pcdep = pcdep_trivia_at(recipe.jitcode_index, recipe.jitcode_pc).unwrap_or_default();
-    if crate::jitcode_dispatch::pcmap_pivot_audit_enabled() {
-        let py_pc = backxlat_py_pc(recipe.jitcode_index, recipe.jitcode_pc);
-        assert_eq!(
-            pcdep,
-            pcdep_color_slots_at(recipe.jitcode_index, py_pc),
-            "pcdep trivia twin vs backxlat consumer diverges at jit_pc={}",
-            recipe.jitcode_pc
-        );
-    }
     for k in nlocals..valuestackdepth {
         let opref = recipe.registers_r[k];
         if opref.is_none() {

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -12509,7 +12509,6 @@ mod tests {
                 after_residual_marker_pred_by_jit_pc: Vec::new(),
                 result_color_after_residual_marker_by_jit_pc: Vec::new(),
                 result_color_after_residual_pred_by_jit_pc: Vec::new(),
-                result_color_by_jit_pc: Vec::new(),
                 has_color_map: false,
                 portal_frame_reg: 0,
                 portal_ec_reg: 0,

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -1404,6 +1404,38 @@ pub fn pcdep_color_slots_at(jitcode_index: i32, py_pc: i32) -> Vec<(u8, u16, u16
     })
 }
 
+/// Trivia-aware per-PC `(color, semantic_slot)` resume entries keyed directly
+/// by a JitCode byte offset. `None` when the index, offset, or trivia twin is
+/// unavailable; callers that preserve the legacy empty-result behavior may use
+/// `unwrap_or_default()`.
+pub fn pcdep_trivia_at(jitcode_index: i32, jit_pc: i32) -> Option<Vec<(u8, u16, u16)>> {
+    ensure_finish_setup();
+    METAINTERP_SD.with(|r| {
+        let sd = r.borrow();
+        sd.jitcodes
+            .get(jitcode_index as usize)?
+            .payload
+            .pcdep_trivia_for_jitcode_pc(usize::try_from(jit_pc).ok()?)
+            .map(ToOwned::to_owned)
+    })
+}
+
+/// The post-regalloc Ref-bank color of the call-result operand-stack slot,
+/// keyed directly by a JitCode byte offset through the trivia-aware twin.
+/// Returns `None` for an empty stack, unavailable twin, or invalid coordinate.
+pub fn result_color_trivia_at(jitcode_index: i32, jit_pc: i32) -> Option<usize> {
+    ensure_finish_setup();
+    METAINTERP_SD.with(|r| {
+        let sd = r.borrow();
+        sd.jitcodes
+            .get(jitcode_index as usize)?
+            .payload
+            .result_color_trivia_for_jitcode_pc(usize::try_from(jit_pc).ok()?)
+            .map(|color| color as usize)
+            .filter(|&color| color != u16::MAX as usize)
+    })
+}
+
 /// Whether `pcdep_color_slots[pc]` maps register color `color` to a semantic
 /// frame slot — i.e. the register allocator assigned this color to a real
 /// local/stack value at `pc`, so the color does NOT carry its force-alived
@@ -13213,6 +13245,18 @@ pub(crate) fn setup_reconstructed_callee_frame(
     // non-diverging coloring).
     let py_pc = backxlat_py_pc(recipe.jitcode_index, recipe.jitcode_pc);
     let pcdep = pcdep_color_slots_at(recipe.jitcode_index, py_pc);
+    if crate::jitcode_dispatch::pcmap_pivot_audit_enabled() {
+        let twin = pcdep_trivia_at(recipe.jitcode_index, recipe.jitcode_pc);
+        crate::jitcode_dispatch::pcmap_pivot_audit_record_fire("a1_recipe_pcdep", "fire");
+        crate::jitcode_dispatch::pcmap_pivot_audit_record_fire(
+            "a1_recipe_pcdep",
+            if twin.as_deref().unwrap_or_default() == pcdep.as_slice() {
+                "eq"
+            } else {
+                "di"
+            },
+        );
+    }
     for k in nlocals..valuestackdepth {
         let opref = recipe.registers_r[k];
         if opref.is_none() {

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -929,7 +929,7 @@ pub(crate) fn sub_jitcode_entry_param_colors(code: *const ()) -> Option<Vec<(u8,
         return None;
     }
     let pjc = pyjitcode_for_code(code)?;
-    let legacy = pjc.metadata.pcdep_color_slots.first().cloned();
+    let legacy = pjc.pcdep_for_jitcode_pc(0);
     if crate::jitcode_dispatch::pcmap_pivot_audit_enabled() {
         crate::jitcode_dispatch::pcmap_pivot_audit_record_fire("entry_param_colors", "fire");
         let twin = pjc.pcdep_for_jitcode_pc(0);

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -1473,10 +1473,6 @@ pub(crate) struct BridgeSemanticMaps {
     pub pcdep_entries: Vec<(u8, u16, u16)>,
 }
 
-pub(crate) fn bridge_semantic_maps_at(jitcode_index: i32, pc: i32) -> BridgeSemanticMaps {
-    bridge_semantic_maps_at_with_jitcode_pc(jitcode_index, pc, majit_ir::resumedata::NO_JITCODE_PC)
-}
-
 /// When a kept-stack branch guard carries the guard's own jitcode
 /// coordinate (`jitcode_pc != NO_JITCODE_PC`), the pcdep/depth tables
 /// must be keyed at the GUARD's Python PC — the encode side
@@ -1536,70 +1532,49 @@ pub(crate) fn bridge_semantic_maps_at_with_jitcode_pc(
         // `liveness_py_pc = guard_py_pc` keying. The guard PC is where the
         // computed kept operand-stack temps are live; at the merge-target PC
         // they've been consumed and carry no pcdep entry.
-        // Index the py_pc-keyed depth/pcdep tables at a resolved Python PC.
-        let via_py_pc = |rp: usize| {
-            let depth = payload
-                .metadata
-                .depth_at_py_pc
+        let via_py_pc = |rp: usize| -> usize {
+            if payload.code_ptr.is_null() {
+                return 0;
+            }
+            crate::liveness::liveness_for(payload.code_ptr)
+                .depth_at_py_pc()
                 .get(rp)
                 .copied()
-                .unwrap_or(0) as usize;
-            depth
+                .unwrap_or(0) as usize
         };
-        let (stack_depth_at_pc, pcdep_entries) =
-            if jitcode_pc != majit_ir::resumedata::NO_JITCODE_PC && jitcode_pc >= 0 {
-                let jp = jitcode_pc as usize;
-                // Validate with `can_decode_live_vars` — symmetric with the
-                // liveness decode in `resolve_resume_pc_with_jitcode_pc`.
-                // A non-decodable carried coordinate falls back to the
-                // merge-target PC so liveness and pcdep key the same point.
-                if payload.jitcode.can_decode_live_vars(jp, sd.op_live) {
-                    // Decode-identity: source depth/pcdep from the carried genuine
-                    // `jitcode_pc` via the predecessor-keyed twins. Every real carried
-                    // coordinate is an op-start or block-head offset of a colored
-                    // jitcode, for which the codewriter seeds these twins; a twin miss
-                    // degrades to the merge-target PC (the same fallback the
-                    // non-decodable path uses below), keeping liveness and pcdep on one
-                    // coordinate. A portal bridge is uncolored — `pcdep_color_slots` /
-                    // `depth_at_py_pc` are empty, so `via_py_pc` returns `(0, empty)`
-                    // for any resolved py — so the merge-target fallback is identical
-                    // to the retired `python_pc_for_jitcode_pc` re-inversion there.
-                    match (
-                        payload.depth_for_jitcode_pc_pred(jp),
-                        payload.pcdep_for_jitcode_pc(jp),
-                    ) {
-                        (Some(depth), Some(pcdep)) => (depth as usize, pcdep),
-                        _ => {
-                            if crate::jitcode_dispatch::pcmap_pivot_audit_enabled() {
-                                crate::jitcode_dispatch::pcmap_pivot_audit_record_fire(
-                                    "depthfield_via_py_pc",
-                                    "twin_miss",
-                                );
-                            }
-                            (
-                                via_py_pc(majit_ir::resumedata::decode_resume_pc(pc).0 as usize),
-                                Vec::new(),
-                            )
-                        }
-                    }
-                } else {
-                    if crate::jitcode_dispatch::pcmap_pivot_audit_enabled() {
-                        crate::jitcode_dispatch::pcmap_pivot_audit_record_fire(
-                            "depthfield_via_py_pc",
-                            "non_decodable",
-                        );
-                    }
-                    (
-                        via_py_pc(majit_ir::resumedata::decode_resume_pc(pc).0 as usize),
-                        Vec::new(),
-                    )
-                }
-            } else {
-                (
+        let (stack_depth_at_pc, pcdep_entries) = if jitcode_pc >= 0
+            && payload
+                .jitcode
+                .can_decode_live_vars(jitcode_pc as usize, sd.op_live)
+        {
+            let jp = jitcode_pc as usize;
+            // Decode-identity: source depth/pcdep from the carried genuine
+            // `jitcode_pc` via the predecessor-keyed twins. Every real carried
+            // coordinate is an op-start or block-head offset of a colored
+            // jitcode, for which the codewriter seeds these twins; a twin miss
+            // degrades to the merge-target PC (the same fallback the
+            // non-decodable path uses below), keeping liveness and pcdep on one
+            // coordinate. A portal bridge is uncolored, so `via_py_pc` returns
+            // `(0, empty)` for any resolved py; the merge-target fallback is
+            // identical to the retired `python_pc_for_jitcode_pc` re-inversion.
+            match (
+                payload.depth_for_jitcode_pc_pred(jp),
+                payload.pcdep_for_jitcode_pc(jp),
+            ) {
+                (Some(depth), Some(pcdep)) => (depth as usize, pcdep),
+                _ => (
                     via_py_pc(majit_ir::resumedata::decode_resume_pc(pc).0 as usize),
                     Vec::new(),
-                )
-            };
+                ),
+            }
+        } else {
+            // A non-decodable carried coordinate falls back to the merge-target
+            // PC so liveness and pcdep key the same point.
+            (
+                via_py_pc(majit_ir::resumedata::decode_resume_pc(pc).0 as usize),
+                Vec::new(),
+            )
+        };
         BridgeSemanticMaps {
             // #73: the codewriter colored this jitcode iff `pcdep_color_slots`
             // is non-empty — the field-free replacement for the retired flat
@@ -12534,7 +12509,6 @@ mod tests {
                 after_residual_marker_pred_by_jit_pc: Vec::new(),
                 result_color_after_residual_marker_by_jit_pc: Vec::new(),
                 result_color_after_residual_pred_by_jit_pc: Vec::new(),
-                depth_at_py_pc: vec![2],
                 result_color_by_jit_pc: Vec::new(),
                 has_color_map: false,
                 portal_frame_reg: 0,

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -1450,22 +1450,6 @@ pub fn result_color_trivia_at(jitcode_index: i32, jit_pc: i32) -> Option<usize> 
     })
 }
 
-/// Whether `pcdep_color_slots[pc]` maps register color `color` to a semantic
-/// frame slot — i.e. the register allocator assigned this color to a real
-/// local/stack value at `pc`, so the color does NOT carry its force-alived
-/// portal-red meaning there (`collect_outer_active_boxes` scratch gate /
-/// `setup_bridge_sym` ec-seed gate).
-pub fn pcdep_color_names_frame_slot_at(jitcode_index: i32, pc: usize, color: u16) -> bool {
-    ensure_finish_setup();
-    METAINTERP_SD.with(|r| {
-        let sd = r.borrow();
-        sd.jitcodes
-            .get(jitcode_index as usize)
-            .and_then(|jc| jc.payload.metadata.pcdep_color_slots.get(pc))
-            .is_some_and(|entries| entries.iter().any(|&(b, c, _)| b == 1 && c == color))
-    })
-}
-
 /// Depth-based `valuestackdepth` for `w_code` at `py_pc`:
 /// `nlocals + ncells + depth_at_py_pc[py_pc]`.  Mirrors the encoder's
 /// published vsd (the `jitcode_dispatch` valuestackdepth publish).  The
@@ -6071,36 +6055,7 @@ fn reconstruct_inline_recipe(
     // resume pc there is no per-pc map to faithfully rebuild the frame, so
     // decline to the single-frame bridge (whose vable payload IS semantic-
     // ordered) rather than rebuild the frame with mis-slotted boxes.
-    let maps = if crate::jitcode_dispatch::pcmap_pivot_audit_enabled() {
-        crate::jitcode_dispatch::pcmap_pivot_audit_record_fire("bridge_maps_frame", "fire");
-        let legacy = bridge_semantic_maps_at(frame.jitcode_index, frame.pc);
-        let twin = bridge_semantic_maps_from_pc(frame.jitcode_index, frame.pc);
-        if legacy.has_color_map == twin.has_color_map
-            && legacy.stack_depth_at_pc == twin.stack_depth_at_pc
-            && legacy.pcdep_entries == twin.pcdep_entries
-        {
-            crate::jitcode_dispatch::pcmap_pivot_audit_record_fire("bridge_maps_frame", "eq");
-        } else {
-            crate::jitcode_dispatch::pcmap_pivot_audit_record_fire("bridge_maps_frame", "di");
-            crate::jitcode_dispatch::pcmap_pivot_audit_record_data(
-                "bridge_maps_frame",
-                &format!(
-                    "idx={} pc={} legacy=({},{},{:?}) twin=({},{},{:?})",
-                    frame.jitcode_index,
-                    frame.pc,
-                    legacy.has_color_map,
-                    legacy.stack_depth_at_pc,
-                    legacy.pcdep_entries,
-                    twin.has_color_map,
-                    twin.stack_depth_at_pc,
-                    twin.pcdep_entries,
-                ),
-            );
-        }
-        legacy
-    } else {
-        bridge_semantic_maps_at(frame.jitcode_index, frame.pc)
-    };
+    let maps = bridge_semantic_maps_from_pc(frame.jitcode_index, frame.pc);
     if maps.pcdep_entries.is_empty() {
         return None;
     }
@@ -8990,45 +8945,16 @@ impl JitState for PyreJitState {
         // `ensure_execution_context` frame-field recovery instead.
         let (_pfr, portal_ec_reg) = crate::state::portal_red_regs_at(frame0.jitcode_index);
         if portal_ec_reg != u16::MAX {
-            let ec_color_names_frame_slot = crate::state::pcdep_color_names_frame_slot_at(
-                frame0.jitcode_index,
-                frame0.pc as usize,
-                portal_ec_reg,
-            );
-            if crate::jitcode_dispatch::pcmap_pivot_audit_enabled() {
-                crate::jitcode_dispatch::pcmap_pivot_audit_record_fire("ec_color_gate", "fire");
-                let resolved = frame_pc_is_resolved_offset_at(frame0.jitcode_index, frame0.pc);
-                crate::jitcode_dispatch::pcmap_pivot_audit_record_fire(
-                    "ec_color_gate",
-                    if resolved { "resolved" } else { "unresolved" },
-                );
-                let twin =
-                    pyjitcode_for_jitcode_index(frame0.jitcode_index).is_some_and(|payload| {
-                        payload
-                            .pcdep_trivia_for_jitcode_pc(frame0.pc as usize)
-                            .is_some_and(|entries| {
-                                entries
-                                    .iter()
-                                    .any(|&(bank, color, _)| bank == 1 && color == portal_ec_reg)
-                            })
-                    });
-                if ec_color_names_frame_slot == twin {
-                    crate::jitcode_dispatch::pcmap_pivot_audit_record_fire("ec_color_gate", "eq");
-                } else {
-                    crate::jitcode_dispatch::pcmap_pivot_audit_record_fire("ec_color_gate", "di");
-                    crate::jitcode_dispatch::pcmap_pivot_audit_record_data(
-                        "ec_color_gate",
-                        &format!(
-                            "idx={} pc={} resolved={} legacy={} twin={}",
-                            frame0.jitcode_index,
-                            frame0.pc,
-                            resolved,
-                            ec_color_names_frame_slot,
-                            twin,
-                        ),
-                    );
-                }
-            }
+            let ec_color_names_frame_slot = pyjitcode_for_jitcode_index(frame0.jitcode_index)
+                .is_some_and(|payload| {
+                    payload
+                        .pcdep_trivia_for_jitcode_pc(frame0.pc as usize)
+                        .is_some_and(|entries| {
+                            entries
+                                .iter()
+                                .any(|&(bank, color, _)| bank == 1 && color == portal_ec_reg)
+                        })
+                });
             if !ec_color_names_frame_slot {
                 let slot = portal_ec_reg as usize;
                 assert!(

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -10090,7 +10090,6 @@ mod tests {
         pyjit.metadata.block_head_py_by_jit_pc = vec![(0, 0)];
         pyjit.metadata.py_floor_by_jit_pc = vec![(0, 0)];
         pyjit.metadata.is_drained = true;
-        pyjit.metadata.depth_at_py_pc.push(1);
         // Per-PC (color, slot) entries the codewriter publishes at pc 0:
         // local 0 -> color 0 (slot 0), local 1 -> color 1 (slot 1), and the
         // live operand-stack slot (depth 0 = abs slot nlocals+0 = 2) -> color

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -1791,7 +1791,7 @@ impl MIFrame {
                                 .then(|| unsafe { &*jitcode_ptr })
                                 .and_then(|jc| {
                                     resume_jit_pc.and_then(|jit_pc| {
-                                        jc.payload.result_color_for_jitcode_pc_pred(jit_pc)
+                                        jc.payload.result_color_trivia_for_jitcode_pc(jit_pc)
                                     })
                                 })
                                 .and_then(|c| (c != u16::MAX).then_some(c as usize));

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -10095,10 +10095,7 @@ mod tests {
         // local 0 -> color 0 (slot 0), local 1 -> color 1 (slot 1), and the
         // live operand-stack slot (depth 0 = abs slot nlocals+0 = 2) -> color
         // 0, reusing dead local 0's color. Sorted by (color, slot).
-        pyjit
-            .metadata
-            .pcdep_color_slots
-            .push(vec![(1, 0, 0), (1, 0, 2), (1, 1, 1)]);
+        pyjit.metadata.has_color_map = true;
         // JitCode-native twins the migrated `get_list_of_active_boxes` reads
         // (`pcdep_for_jitcode_pc` / `depth_for_jitcode_pc_pred`): mirror the
         // py_pc-keyed tables above at the single `-live-` JitCode offset 0.

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -1487,10 +1487,7 @@ impl MIFrame {
                 // resume coordinate at this capture seam. A missing twin uses
                 // the existing trace-abort path below rather than guessing a
                 // block-head position from `live_pc`.
-                match self
-                    .loop_close_marker_jit_pc
-                    .filter(|_| crate::jitcode_dispatch::m73_lclive_carry_enabled())
-                {
+                match self.loop_close_marker_jit_pc {
                     Some(jit_pc) => Some(jit_pc),
                     None => {
                         // This (parent) frame reports a `live_pc` the jitcode
@@ -4060,14 +4057,10 @@ impl MIFrame {
                 &[]
             };
             let parent_pc = Self::marker_aware_parent_resume_pc(parent.call_pc, parent.resume_pc);
-            let parent_word = if crate::jitcode_dispatch::m369_pframe_carry_enabled() {
-                parent
-                    .resume_marker_jit_pc
-                    .map(|m| m as i32)
-                    .unwrap_or(majit_ir::resumedata::NO_JITCODE_PC)
-            } else {
-                majit_ir::resumedata::NO_JITCODE_PC
-            };
+            let parent_word = parent
+                .resume_marker_jit_pc
+                .map(|m| m as i32)
+                .unwrap_or(majit_ir::resumedata::NO_JITCODE_PC);
             let parent_pc_word =
                 crate::state::pyjitcode_for_jitcode_index(parent_jitcode_index as i32)
                     .and_then(|payload| {
@@ -4129,13 +4122,10 @@ impl MIFrame {
         let n = crate::virtualizable_gen::NUM_SCALAR_INPUTARGS;
         let top_snapshot_types = &top_snapshot_types_full[n..];
         let top_jitcode_index = unsafe { (*self.sym().jitcode).index } as u32;
-        let top_word = if crate::jitcode_dispatch::m73_loopclose_carry_enabled() {
-            self.loop_close_marker_jit_pc
-                .map(|m| m as i32)
-                .unwrap_or(majit_ir::resumedata::NO_JITCODE_PC)
-        } else {
-            majit_ir::resumedata::NO_JITCODE_PC
-        };
+        let top_word = self
+            .loop_close_marker_jit_pc
+            .map(|m| m as i32)
+            .unwrap_or(majit_ir::resumedata::NO_JITCODE_PC);
         let payload = unsafe { &(&*self.sym().jitcode).payload };
         let resolved = payload.resolve_resume_pc_with_jitcode_pc(top_word, crate::state::op_live());
         if resolved.is_none() {

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -9244,14 +9244,24 @@ mod tests {
     }
 
     /// Post-regalloc Ref-bank color of semantic slot `slot` at `py_pc`,
-    /// read from the per-PC `pcdep_color_slots` entries (local `i` is
+    /// read from the JitCode-PC twins (local `i` is
     /// slot `i`, operand-stack depth `d` is slot `nlocals + d`). Colors
     /// are per-program-point (chordal coloring may coalesce
     /// disjointly-live slots and re-color across PCs), so there is no
     /// flat slot → color lookup; `None` when the slot carries no live
     /// restorable entry at that PC.
     fn pcdep_color_for_slot(jitcode_index: i32, py_pc: usize, slot: usize) -> Option<u32> {
-        pyre_jit_trace::state::pcdep_color_slots_at(jitcode_index, py_pc as i32)
+        let payload = pyre_jit_trace::state::pyjitcode_for_jitcode_index(jitcode_index)?;
+        let jit_pc = payload
+            .metadata
+            .py_floor_by_jit_pc
+            .iter()
+            .find(|&&(_, py)| py as usize == py_pc)
+            .map(|&(pc, _)| pc as usize)?;
+        payload
+            .pcdep_trivia_for_jitcode_pc(jit_pc)
+            .map(ToOwned::to_owned)
+            .or_else(|| payload.pcdep_for_jitcode_pc(jit_pc))?
             .iter()
             .find(|&&(b, _, s)| b == 1 && s as usize == slot)
             .map(|&(_, c, _)| u32::from(c))

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -13394,7 +13394,6 @@ impl CodeWriter {
             block_head_py_by_jit_pc,
             py_floor_by_jit_pc,
             merge_entry_by_green,
-            depth_at_py_pc: depth_at_pc,
             pcdep_by_jit_pc,
             depth_pred_by_jit_pc,
             depth_trivia_marker_by_jit_pc,

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -13018,20 +13018,14 @@ impl CodeWriter {
         // reads at control-flow entries, so the dense-map owner is already the
         // correct inverse.
         let mut block_head_py_by_jit_pc: Vec<(usize, u32)> = Vec::new();
-        // #73 metadata inventory: retain the existing py_pc-keyed result
-        // color table as the source of truth and derive its JitCode-pc twin
-        // beside the block-head inverse for audit only.
-        let mut result_color_by_jit_pc: Vec<(usize, u16)> = Vec::new();
         {
             let mut seen: std::collections::HashSet<usize> = std::collections::HashSet::new();
             for (py, &off) in pc_map_bytes.iter().enumerate() {
                 if seen.insert(off) {
                     block_head_py_by_jit_pc.push((off, py as u32));
-                    result_color_by_jit_pc.push((off, result_color_at_pc[py]));
                 }
             }
             block_head_py_by_jit_pc.sort_unstable_by_key(|&(off, _)| off);
-            result_color_by_jit_pc.sort_unstable_by_key(|&(off, _)| off);
         }
 
         // Build the JitCode-PC floor tier from the py-indexed predecessor
@@ -13410,7 +13404,6 @@ impl CodeWriter {
             after_residual_marker_pred_by_jit_pc,
             result_color_after_residual_marker_by_jit_pc,
             result_color_after_residual_pred_by_jit_pc,
-            result_color_by_jit_pc,
             has_color_map: !pcdep_color_slots.is_empty(),
             portal_frame_reg,
             portal_ec_reg,

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -13411,8 +13411,8 @@ impl CodeWriter {
             after_residual_marker_pred_by_jit_pc,
             result_color_after_residual_marker_by_jit_pc,
             result_color_after_residual_pred_by_jit_pc,
-            result_color_at_pc,
             result_color_by_jit_pc,
+            has_color_map: !pcdep_color_slots.is_empty(),
             portal_frame_reg,
             portal_ec_reg,
             // Records the INPUT SHAPE (Portal `[frame, ec]` + frame-vable
@@ -13422,7 +13422,6 @@ impl CodeWriter {
             built_as_portal: true,
             stack_base: frame_stack_base,
             max_stackdepth: code.max_stackdepth as usize,
-            pcdep_color_slots,
             const_ref_slots_at_pc,
             const_ref_slots_by_jit_pc,
             is_drained: true,


### PR DESCRIPTION
Closes #621.

After #602 made the resume coordinate jitcode-native, `PyJitCodeMetadata` still carried three py-indexed side tables: `pcdep_color_slots`, `result_color_at_pc`, and `depth_at_py_pc`. This PR retires every remaining py-keyed consumer under the established census discipline and deletes all three; their jitcode-keyed twins (and, for depth, the permitted liveness-crate static analysis) are now the only runtime sources.

## Layer A — carried-coordinate twin flips (census-first)

- Census + flip of the 4 py-keyed readers that hold a jitcode coordinate (recipe pcdep, recipe parent result color, `inject_root_call_result`, `reconstruct_inline_recipe` pending result color). Corpus census (both backends): the one firing site (recipe pcdep, 1293 fires) was 100% equal to the trivia twin; 0 divergences.

## Layer B — residual consumers + color-table deletion

- Census of the 6 residual sites, then:
- **Certified mechanical flips** (0-di / 0-fire): the 26-fire non-emitting-opcode guard-snapshot entry arm now keys entry metadata by the guard's own resolved resume coordinate (trivia twins, 26/26 equal); the `cjc < 0` guard-pcdep fallback and the inline-caller marker-miss arms (all 0-fire) retire to no-metadata / early-decline; `sub_jitcode_entry_param_colors` reads the predecessor twin at offset 0 (986/986 equal).
- **Key-space fixes**: `reconstruct_inline_recipe` and the `setup_bridge_sym` ec-seed gate indexed py-keyed tables with jitcode offsets (wrong key space). The bridge-maps read returned `(depth 0, empty pcdep)` on every corpus fire (500/500 divergent vs the twin), silently forcing the multi-frame recipe path to decline; the ec gate spuriously skipped ec seeding once per corpus run. Both now key by the carried jitcode coordinate.
- **Deletion**: `pcdep_color_slots` + `result_color_at_pc` removed; `has_color_map` is now a codewriter-published bool replacing the emptiness test.

## Tail — `depth_at_py_pc` field deletion

- The third py-indexed table (walk-visited depth). Its 3 field readers — a diagnostic print, the midbody producer `or_else` (structurally dead: coupled 1:1 with the pcdep twin that already declines), and the `via_py_pc` bridge fallback (0-fire in corpus) — are retired. `via_py_pc` now sources depth from the issue-permitted liveness static analysis (null-`code_ptr` guarded → 0 for portal/skeleton); at any reachable resume coordinate the walk-visited depth equals the static depth. The uncalled `bridge_semantic_maps_at` NO_JITCODE wrapper is also deleted.

The liveness-crate method `liveness_for(code).depth_at_py_pc()` (CodeObject static analysis, CPython-derivable) is unchanged, as the issue specifies.

## Verification

- Rebased onto current `main` (#607 P2 bridge compile, #614 interpreter correctness); `inject_root_call_result` conflicts resolved by blending #607's `residual_ref_call_dst_before` primary with the twin fallback.
- `python3 pyre/check.py --backend dynasm` / `--backend cranelift`: 217/217, audit-off and pivot/result-audit-on (no panic).
- `cargo test -p pyre-jit-trace -p pyre-jit --release` (dynasm): all green.
- `cargo fmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved JIT execution metadata handling by using JIT-code program counters for resume, depth, color, and inline-frame reconstruction.
  * Simplified fallback behavior when metadata or mapping entries are unavailable.
  * Reduced legacy metadata storage and consolidated color-map availability tracking.

* **Diagnostics**
  * Added optional pivot-audit reporting for troubleshooting and analysis.
  * Updated diagnostic calculations to use the revised JIT-code mappings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->