### PR TITLE
jit: generic offset-registry trace-through for immortal registered objects during GC root walk

### DIFF
--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -260,25 +260,108 @@ unsafe fn walk_raw_exception_roots(
     }
 }
 
-/// Mark the GC-reachable children of a Box-immortal `W_SeqIterObject`.
-///
-/// The seq iterator is `malloc_typed`-immortal (its `allocate` uses
-/// `malloc_typed`), so `seed_major_root` ignores it.  Its `seq` field
-/// points to the iterable — often a user-defined instance allocated in
-/// old-gen via `try_gc_alloc_stable`.  Without this walk, that instance
-/// is invisible to the marker and freed while the iterator still holds
-/// a live reference.
-unsafe fn walk_raw_seq_iter_roots(
+/// Maximum recursion depth for `walk_raw_immortal_roots`.  Immortal objects
+/// chain a few levels at most (`map(f, filter(p, iter(seq)))`, a view's dict,
+/// a tuple of iterators); this bounds the walk against a malformed cycle — the
+/// only cycle protection.
+const IMMORTAL_WALK_MAX_DEPTH: u32 = 8;
+
+/// Force-forward the managed children of any `malloc_typed`-immortal REGISTERED
+/// pyre object reachable from a value-stack slot.  Such objects are outside the
+/// GC arenas, so the marker skips them and their registered `gc_ptr_offsets`
+/// trace never fires; a managed child held solely through one is freed by a
+/// collection (a bare `for x in <expr>:` whose iterator sits on the value
+/// stack, a `d.keys()` view, an immortal iterator's source list).  Drive off
+/// the per-type offset registry so every present and future immortal type is
+/// covered.  Runs on both minor and major collections via the
+/// collection-kind-agnostic `visitor`.
+unsafe fn walk_raw_immortal_roots(
     value: PyObjectRef,
     visitor: &mut dyn FnMut(&mut majit_ir::GcRef),
 ) {
+    unsafe { walk_immortal_rec(value, visitor, 0) };
+}
+
+unsafe fn walk_immortal_rec(
+    value: PyObjectRef,
+    visitor: &mut dyn FnMut(&mut majit_ir::GcRef),
+    depth: u32,
+) {
     unsafe {
-        if value.is_null() {
+        if value.is_null() || depth >= IMMORTAL_WALK_MAX_DEPTH {
             return;
         }
-        if pyre_object::iterobject::is_seq_iter(value) {
-            let iter = &mut *(value as *mut pyre_object::W_SeqIterObject);
-            visitor(&mut *(&mut iter.seq as *mut PyObjectRef as *mut majit_ir::GcRef));
+        // A tagged immediate is an int with no managed children; short-circuit
+        // before any predicate below dereferences its `ob_type`. Gated on
+        // `CAN_BE_TAGGED` (default false).
+        if pyre_object::tagged_int::CAN_BE_TAGGED && pyre_object::tagged_int::is_tagged_int(value) {
+            return;
+        }
+
+        // (A) A `malloc_typed`-immortal REGISTERED pyre object: the marker
+        // ignores it, so follow its registered `gc_ptr_offsets` in place and
+        // recurse.  Managed registered objects (`try_gc_owns_object`) are
+        // traced by the marker already, so leave their offsets to `None` and
+        // fall through — re-walking a managed graph here is redundant.
+        // Positive predicate (no `!` over a cross-crate bool): compute the
+        // offsets only for a non-owned object.
+        let immortal_offsets = if pyre_object::gc_hook::try_gc_owns_object(value as *mut u8) {
+            None
+        } else {
+            pyre_object::gc_hook::offsets_for_pytype((*value).ob_type)
+        };
+        if let Some(offsets) = immortal_offsets {
+            for &off in offsets {
+                let slot = (value as usize + off) as *mut PyObjectRef;
+                visitor(&mut *(slot as *mut majit_ir::GcRef));
+                // Re-read the slot AFTER the visitor so a relocated child is
+                // the one recursed into.
+                walk_immortal_rec(*slot, visitor, depth + 1);
+            }
+            return;
+        }
+
+        // (B) A managed container reached AS A CHILD of an immortal (depth>=1):
+        // its immortal elements would otherwise stay untraced-through (the
+        // marker forwards element slots but does not recurse into an immortal
+        // element's own children).  Enumerate element slots in place and
+        // recurse.  Top-level (depth 0) managed containers are left to the
+        // marker — matches prior scope.
+        if depth >= 1 {
+            if pyre_object::is_list(value) {
+                if let Some((ptr, n)) = pyre_object::listobject::w_list_object_items_ptr_len(value)
+                {
+                    for i in 0..n {
+                        let s = ptr.add(i) as *mut PyObjectRef;
+                        visitor(&mut *(s as *mut majit_ir::GcRef));
+                        walk_immortal_rec(*s, visitor, depth + 1);
+                    }
+                }
+            } else if pyre_object::is_tuple(value) {
+                // Dispatch on the concrete tuple layout (general vs specialised
+                // arity-2): a specialised `_oo` stores objects inline, so a
+                // general-tuple block read would mis-cast its inline slots.
+                pyre_object::tupleobject::w_tuple_walk_gc_refs(
+                    value,
+                    &mut |s: *mut PyObjectRef| {
+                        visitor(&mut *(s as *mut majit_ir::GcRef));
+                        walk_immortal_rec(*s, visitor, depth + 1);
+                    },
+                );
+            } else if pyre_object::is_dict(value) {
+                let strat = pyre_object::dictmultiobject::w_dict_get_strategy(value);
+                strat.walk_gc_refs(value, &mut |s: *mut PyObjectRef| {
+                    visitor(&mut *(s as *mut majit_ir::GcRef));
+                    walk_immortal_rec(*s, visitor, depth + 1);
+                });
+            } else if pyre_object::setobject::is_set_or_frozenset(value) {
+                // `set` and `frozenset` share the `W_SetObject` layout and the
+                // marker's `set_object_custom_trace`, so one walker covers both.
+                pyre_object::setobject::w_set_walk_gc_refs(value, &mut |s: *mut PyObjectRef| {
+                    visitor(&mut *(s as *mut majit_ir::GcRef));
+                    walk_immortal_rec(*s, visitor, depth + 1);
+                });
+            }
         }
     }
 }
@@ -668,7 +751,7 @@ pub unsafe fn walk_pyframe_roots_area(
                     unsafe {
                         let value = (*slot_ptr).0 as PyObjectRef;
                         walk_raw_exception_roots(value, visitor);
-                        walk_raw_seq_iter_roots(value, visitor);
+                        walk_raw_immortal_roots(value, visitor);
                     }
                 }
             }

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -1229,6 +1229,11 @@ fn build_gc() -> Box<dyn majit_gc::GcAllocator> {
         let pytype_ptr = descr.pytype_ptr as usize;
         majit_gc::GcAllocator::register_vtable_for_type(gc, pytype_ptr, tid);
         pytype_to_tid.insert(pytype_ptr, tid);
+        // Register this type's inline `gc_ptr_offsets` for the interpreter's
+        // generic immortal-root walker (`walk_raw_immortal_roots`).  Covers
+        // every `#[pyre_class]` type — immortal AND managed; the walker's
+        // immortality gate skips managed ones at walk time.
+        pyre_object::gc_hook::register_pyre_class_offsets(pytype_ptr, descr.ptr_offsets);
         tid
     };
     majit_gc::GcAllocator::register_vtable_for_type(
@@ -1792,6 +1797,27 @@ fn build_gc() -> Box<dyn majit_gc::GcAllocator> {
             w_dict_view_tid,
         );
         pytype_to_tid.insert(tp as *const _ as usize, w_dict_view_tid);
+        // `W_DictViewObject` is `malloc_typed`-immortal and not a
+        // `#[pyre_class]`, so register its `w_dict` back-pointer offset for the
+        // interpreter's generic immortal-root walker.
+        pyre_object::gc_hook::register_pyre_class_offsets(
+            tp as *const _ as usize,
+            &pyre_object::dictmultiobject::W_DICT_VIEW_GC_PTR_OFFSETS,
+        );
+    }
+    // The three dict-view iterator PyTypes (`W_BaseDictMultiIterObject`) are
+    // likewise `malloc_typed`-immortal and not `#[pyre_class]`, and (unlike the
+    // views) have no GC vtable registration site; register their `w_dict`
+    // back-pointer offset for the generic immortal-root walker directly.
+    for tp in [
+        &pyre_object::dictmultiobject::DICT_KEYITERATOR_TYPE,
+        &pyre_object::dictmultiobject::DICT_VALUEITERATOR_TYPE,
+        &pyre_object::dictmultiobject::DICT_ITEMITERATOR_TYPE,
+    ] {
+        pyre_object::gc_hook::register_pyre_class_offsets(
+            tp as *const _ as usize,
+            &pyre_object::dictmultiobject::W_DICT_VIEW_ITERATOR_GC_PTR_OFFSETS,
+        );
     }
     // `pypy/interpreter/typedef.py:312-326 class GetSetProperty`
     // — fget/fset/fdel/doc/reqcls/name are W_Root references.

--- a/pyre/pyre-object/src/gc_hook.rs
+++ b/pyre/pyre-object/src/gc_hook.rs
@@ -24,6 +24,49 @@
 
 use crate::PyObjectRef;
 
+/// Per-`#[pyre_class]`-type registry of inline `PyObjectRef` field offsets
+/// (the descriptor's `gc_ptr_offsets`), keyed by the type's static `PyType`
+/// pointer cast to `usize`.
+///
+/// Populated once at single-threaded JIT-driver init (`register_pyre_class`
+/// in `pyre-jit/src/eval.rs`).  Read during GC marking by the interpreter's
+/// generic immortal-root walker to force-forward the managed children of a
+/// `malloc_typed`-immortal object the marker skips.  The stored slice is the
+/// descriptor's `&'static [usize]`, so a lookup copies a fat pointer with no
+/// allocation.
+static PYRE_CLASS_GC_OFFSETS: std::sync::LazyLock<
+    std::sync::RwLock<std::collections::HashMap<usize, &'static [usize]>>,
+> = std::sync::LazyLock::new(|| std::sync::RwLock::new(std::collections::HashMap::new()));
+
+/// Register a type's inline `gc_ptr_offsets` under its `PyType` pointer.
+/// Called only at single-threaded init; a poisoned lock silently drops the
+/// insert (init is the sole writer, so this cannot happen in practice).
+pub fn register_pyre_class_offsets(pytype_ptr: usize, offsets: &'static [usize]) {
+    if let Ok(mut map) = PYRE_CLASS_GC_OFFSETS.write() {
+        map.insert(pytype_ptr, offsets);
+    }
+}
+
+/// Look up the registered inline `PyObjectRef` field offsets for `ob_type`.
+/// Returns `None` for a null `ob_type` or an unregistered type.  Takes a
+/// process-global read lock — cheap and alloc-free, safe while the collector
+/// is marking; a poisoned lock reads as `None`.
+///
+/// # Safety
+/// `ob_type` must be null or point to a valid, `'static` `PyType`.
+pub unsafe fn offsets_for_pytype(
+    ob_type: *const crate::pyobject::PyType,
+) -> Option<&'static [usize]> {
+    if ob_type.is_null() {
+        return None;
+    }
+    PYRE_CLASS_GC_OFFSETS
+        .read()
+        .ok()?
+        .get(&(ob_type as usize))
+        .copied()
+}
+
 /// Signature of the host-side GC allocation callback.
 ///
 /// `type_id` is the backend-registered GC type id (same id used by

--- a/pyre/pyre-object/src/iterobject.rs
+++ b/pyre/pyre-object/src/iterobject.rs
@@ -96,7 +96,7 @@ pub fn w_tuple_iter_new(seq: PyObjectRef) -> PyObjectRef {
 
 pub unsafe fn is_seq_iter(obj: PyObjectRef) -> bool {
     // A tagged immediate is an `int`, never a seq-iter; short-circuit before
-    // the `ob_type` deref so the GC value-stack walker (`walk_raw_seq_iter_roots`)
+    // the `ob_type` deref so the GC value-stack walker (`walk_raw_immortal_roots`)
     // never dereferences one. Gated on `CAN_BE_TAGGED` (default false).
     if crate::tagged_int::CAN_BE_TAGGED && crate::tagged_int::is_tagged_int(obj) {
         return false;

--- a/pyre/pyre-object/src/listobject.rs
+++ b/pyre/pyre-object/src/listobject.rs
@@ -1052,6 +1052,26 @@ pub unsafe fn w_list_items_copy_as_vec(obj: PyObjectRef) -> Vec<PyObjectRef> {
     temporarily_as_objects(list)
 }
 
+/// Raw `(ptr, len)` view of an Object-strategy list's `PyObjectRef` items for
+/// GC root walking.  Returns `None` for Empty / Integer / Float strategies:
+/// those store unboxed scalars with no GC children, and materialising them
+/// would allocate — forbidden while the collector is marking.
+///
+/// # Safety
+/// `obj` must point to a valid `W_ListObject`.  The returned pointer aliases
+/// the list's live backing store; the caller must not mutate the list while
+/// reading through it.
+pub unsafe fn w_list_object_items_ptr_len(obj: PyObjectRef) -> Option<(*const PyObjectRef, usize)> {
+    let list = &*(obj as *const W_ListObject);
+    match list.strategy {
+        ListStrategy::Object => {
+            let items = list.object_items_slice();
+            Some((items.as_ptr(), items.len()))
+        }
+        _ => None,
+    }
+}
+
 /// listobject.py:363-371 _temporarily_as_objects()
 ///
 /// Returns wrapped object items without mutating the source list's strategy.

--- a/pyre/pyre-object/src/setobject.rs
+++ b/pyre/pyre-object/src/setobject.rs
@@ -631,6 +631,28 @@ pub unsafe fn w_set_items(obj: PyObjectRef) -> Vec<PyObjectRef> {
     (*s.items).keys().map(|key| key.obj).collect()
 }
 
+/// Walk, in place, every element `PyObjectRef` slot of a set for GC root
+/// forwarding.  Forwards each `ObjectKey.obj` slot: `ObjectKey.hash` is
+/// identity-stable across a GC move, so writing the relocated pointer through
+/// the key's `obj` slot keeps the bucket index valid.  Alloc-free — unlike
+/// [`w_set_items`], which materialises a `Vec`.  The port of
+/// `set_object_custom_trace`.
+///
+/// # Safety
+/// `obj` must point to a valid `W_SetObject`.
+pub unsafe fn w_set_walk_gc_refs(obj: PyObjectRef, visitor: &mut dyn FnMut(*mut PyObjectRef)) {
+    let set = &mut *(obj as *mut W_SetObject);
+    if set.items.is_null() {
+        return;
+    }
+    let entries = &mut *set.items;
+    for (key, _) in entries.iter_mut() {
+        let key_ptr = key as *const crate::dictmultiobject::ObjectKey
+            as *mut crate::dictmultiobject::ObjectKey;
+        visitor(std::ptr::addr_of_mut!((*key_ptr).obj) as *mut PyObjectRef);
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/pyre/pyre-object/src/tupleobject.rs
+++ b/pyre/pyre-object/src/tupleobject.rs
@@ -66,6 +66,65 @@ pub struct W_TupleObject {
 pub const W_TUPLE_GC_TYPE_ID: u32 = 8;
 pub const W_TUPLE_OBJECT_SIZE: usize = std::mem::size_of::<W_TupleObject>();
 
+/// Raw `(ptr, len)` view of a tuple's inline `PyObjectRef` items for GC root
+/// walking.  `wrappeditems` is exact-size (`capacity == len`, every slot
+/// written by `alloc_tuple_items_block`), so the block capacity is the live
+/// length.  Returns `None` for a null block.  Alloc-free — mirrors
+/// `listobject::w_list_object_items_ptr_len` and the stationary branch of
+/// `tuple_object_custom_trace`, reading `items_block_items_base` /
+/// `items_block_capacity` over the block.  The returned pointer aliases the
+/// live backing store; the caller must not mutate the tuple while reading
+/// through it.
+///
+/// # Safety
+/// `obj` must point to a valid `W_TupleObject`.
+pub unsafe fn w_tuple_object_items_ptr_len(
+    obj: PyObjectRef,
+) -> Option<(*const PyObjectRef, usize)> {
+    let tuple = &*(obj as *const W_TupleObject);
+    let block = tuple.wrappeditems;
+    if block.is_null() {
+        return None;
+    }
+    let base = items_block_items_base(block);
+    let cap = items_block_capacity(block);
+    Some((base as *const PyObjectRef, cap))
+}
+
+/// Walk, in place, every element `PyObjectRef` slot of any tuple — general
+/// `W_TupleObject` or a specialised arity-2 variant — for GC root forwarding.
+/// `is_tuple` reports all four layouts as `tuple`, but only the general variant
+/// carries a `wrappeditems` block; the specialised `_oo` variant stores its two
+/// objects inline (`value0` / `value1`) and `_ii` / `_ff` hold unboxed scalars
+/// with no GC children.  Dispatch on the concrete layout exactly as the marker
+/// does (`tuple_object_custom_trace` and the `spec_tuple_*` gc_ptr_offsets), so
+/// a specialised tuple is never mis-read as a general one.  Alloc-free.
+///
+/// # Safety
+/// `obj` must point to a valid tuple (`is_tuple(obj)` true).
+pub unsafe fn w_tuple_walk_gc_refs(obj: PyObjectRef, visitor: &mut dyn FnMut(*mut PyObjectRef)) {
+    use crate::specialisedtupleobject::{
+        W_SpecialisedTupleObject_oo, is_specialised_tuple_ff, is_specialised_tuple_ii,
+        is_specialised_tuple_oo,
+    };
+    if is_specialised_tuple_oo(obj) {
+        let t = obj as *mut W_SpecialisedTupleObject_oo;
+        visitor(std::ptr::addr_of_mut!((*t).value0));
+        visitor(std::ptr::addr_of_mut!((*t).value1));
+        return;
+    }
+    // `_ii` / `_ff` are GC-leaf (unboxed scalars) — nothing to forward.
+    if is_specialised_tuple_ii(obj) || is_specialised_tuple_ff(obj) {
+        return;
+    }
+    // General `W_TupleObject`: forward each slot of the exact-size items block.
+    if let Some((ptr, n)) = w_tuple_object_items_ptr_len(obj) {
+        for i in 0..n {
+            visitor(ptr.add(i) as *mut PyObjectRef);
+        }
+    }
+}
+
 /// Allocate a new tuple from a Vec of items.
 ///
 /// Arity-2 tuples are routed through `makespecialisedtuple2`


### PR DESCRIPTION
## Summary

`#[pyre_class]` objects allocate via `malloc_typed` and are **immortal** (outside the nursery/oldgen arenas), so `is_managed_heap_object` is false and the GC marker skips them entirely — their registered `gc_ptr_offsets` trace never fires. A managed (nursery/oldgen) child held **solely** through such an immortal object is therefore reclaimed by a collection while still in use:

- a bare `for x in <expr>:` whose iterator sits on the value stack (the iterator's source list/tuple),
- a `d.keys()` / `d.values()` / `d.items()` view or its iterator (the source dict),
- an immortal iterator's source list (`map`/`zip` hold a list of sub-iterators).

The previous fix force-forwarded a hand-picked set of ~10 iterator types. This PR replaces it with a **generic offset-registry walker** that covers every present and future immortal registered type.

## Approach

- **`gc_hook`**: a `pytype_ptr -> &'static [usize]` registry (`register_pyre_class_offsets` / `offsets_for_pytype`), alloc-free and poison-safe, populated for every `#[pyre_class]` at GC-build time plus the hand-rolled dict-view / dict-view-iterator pytypes.
- **(A)** For a non-owned (immortal) registered object on a value-stack slot, force-forward its registered `gc_ptr_offsets` in place and recurse into each child. Managed registered objects are left to the marker.
- **(B)** For a managed container reached as an immortal's child (depth ≥ 1) — list / tuple / dict / set — descend so a nested immortal element's own children stay reachable. Tuple descent dispatches on the concrete layout (`w_tuple_walk_gc_refs`: general items-block vs specialised arity-2 `_oo` inline slots vs `_ii` / `_ff` leaf), because `is_tuple` also matches the specialised variants and a general-block read of an `_oo` tuple would mis-cast its inline slots; set descent covers `frozenset` (shared `W_SetObject` layout).

Runs on both minor (moving) and major collections via the collection-kind-agnostic visitor. Retires `walk_raw_iter_roots` / `iter_forward_and_recurse` / `walk_raw_iter_list_roots`.

## Verification

- **check.py**: `dynasm 216/216`, `cranelift 216/216`.
- **cargo test** (pyre-object, pyre-interpreter): all pass.
- **Adversarial GC triad** (25 heterogeneous immortal-iterator drivers × cranelift-JIT / dynasm-JIT / interpreter oracle): the generic walker extends coverage to dict-view iterators and `itertools.chain` (which dropped even under the prior 10-type walker), and a specialised-arity-2-tuple `SIGSEGV` in the container-descent path was found and fixed (`w_tuple_walk_gc_refs` concrete-layout dispatch).
  - 3 remaining triad variants (`enumerate` / `filterfalse` / `takewhile` drivers) drop the last iteration on a **pre-existing, unrelated** FBW × moving-item-block interaction, isolated via `PYRE_FULL_BODY_WALK=0` (which fixes the drop while the GC walker stays active) — out of scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
