### PR TITLE
Complete builtin iterator, descriptor, and code parity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2161,6 +2161,7 @@ dependencies = [
  "majit-macros",
  "majit-metainterp",
  "malachite-bigint",
+ "num-complex",
  "num-integer",
  "num-traits",
  "paste",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,6 +71,7 @@ rustpython-common = { git = "https://github.com/RustPython/RustPython.git", rev 
 rustpython-literal = { git = "https://github.com/RustPython/RustPython.git", rev = "238bed66fbb0102a83dd9b5c8244e0276fbe8eac" }
 rustpython-compiler = { git = "https://github.com/RustPython/RustPython.git", rev = "238bed66fbb0102a83dd9b5c8244e0276fbe8eac" }
 rustpython-compiler-core = { git = "https://github.com/RustPython/RustPython.git", rev = "238bed66fbb0102a83dd9b5c8244e0276fbe8eac" }
+num-complex = "0.4"
 rustpython-host_env = { git = "https://github.com/RustPython/RustPython.git", rev = "238bed66fbb0102a83dd9b5c8244e0276fbe8eac" }
 rustpython-wtf8 = { git = "https://github.com/RustPython/RustPython.git", rev = "238bed66fbb0102a83dd9b5c8244e0276fbe8eac" }
 rustpython-unicode = { git = "https://github.com/RustPython/RustPython.git", rev = "238bed66fbb0102a83dd9b5c8244e0276fbe8eac" }

--- a/pyre/check.py
+++ b/pyre/check.py
@@ -405,6 +405,8 @@ def scaled_timeout(base, scale):
 def fmt_time(t):
     if t is None or t == "-":
         return "-"
+    if isinstance(t, (int, float)):
+        return f"{t:.2f}s"
     return f"{t}s"
 
 
@@ -1115,7 +1117,7 @@ class Check:
                 return
             if retry_note:
                 elapsed = checked_elapsed
-                t_pypy = f"{checked_baseline:.2f}"
+                t_pypy = checked_baseline
                 ratio = _ratio(elapsed, t_pypy)
 
         snap_status, snap_reason = self._apply_snapshot_gate(
@@ -1167,16 +1169,16 @@ class Check:
             sys.stdout.write(f"    {'cpython':<10s}")
             sys.stdout.flush()
             cpython_output, t_cpu, cpython_code, _ = run_timed([PYTHON3, script])
-            t_cpython = f"{t_cpu:.2f}"
+            t_cpython = t_cpu
             if cpython_code != 0:
                 print(f"{red('CRASH')} (exit {cpython_code})")
             else:
-                print(f"{dim('done')}  {t_cpython}s")
+                print(f"{dim('done')}  {t_cpython:.2f}s")
 
         sys.stdout.write(f"    {'pypy':<10s}")
         sys.stdout.flush()
         pypy_output, pypy_cpu, pypy_code, _ = run_timed([PYPY3, script])
-        t_pypy = f"{pypy_cpu:.2f}" if pypy_code == 0 else "-"
+        t_pypy = pypy_cpu if pypy_code == 0 else "-"
         if pypy_code != 0:
             print(f"{red('CRASH')} (exit {pypy_code})")
             for backend in ALL_BACKENDS:
@@ -1184,7 +1186,7 @@ class Check:
                     self._record(backend, False, name, "pypy crash")
                     self._append_comparison(backend, name, t_cpython, "-", "FAIL")
             return
-        print(f"{dim('done')}  {t_pypy}s")
+        print(f"{dim('done')}  {t_pypy:.2f}s")
 
         for backend, vs_cpython, vs_pypy in [
             ("dynasm", dynasm_vs_cpython, dynasm_vs_pypy),
@@ -1295,8 +1297,8 @@ class Check:
                     self._append_comparison(backend, name, "-", "-", "FAIL")
             return
         else:
-            t_cpython = f"{cpython_time:.2f}"
-            print(f"{dim('done')}  {t_cpython}s")
+            t_cpython = cpython_time
+            print(f"{dim('done')}  {t_cpython:.2f}s")
 
         sys.stdout.write(f"    {'pypy':<10s}")
         sys.stdout.flush()
@@ -1310,8 +1312,8 @@ class Check:
                     self._record(backend, False, name, "pypy crash")
                     self._append_comparison(backend, name, t_cpython, "-", "FAIL")
             return
-        t_pypy = f"{pypy_time:.2f}"
-        print(f"{dim('done')}  {t_pypy}s")
+        t_pypy = pypy_time
+        print(f"{dim('done')}  {t_pypy:.2f}s")
 
         if cpython_output is not None and cpython_output != pypy_output:
             print(f"    {'baseline':<10s}{red('WRONG')}  cpython output differs from pypy")

--- a/pyre/extra_tests/parity_tests/builtin_function_python314.py
+++ b/pyre/extra_tests/parity_tests/builtin_function_python314.py
@@ -41,6 +41,16 @@ assert len.__self__ is builtins
 assert math.sqrt.__self__ is math
 assert len.__reduce__() == "len"
 assert len.__reduce_ex__(4) == "len"
+for bound_builtin, owner, name in (
+    (int.__new__, int, "__new__"),
+    (dict.fromkeys, dict, "fromkeys"),
+):
+    reconstructor, reduce_args = bound_builtin.__reduce__()
+    assert reconstructor is getattr
+    assert reduce_args == (owner, name)
+    rebuilt = reconstructor(*reduce_args)
+    assert rebuilt.__self__ is owner
+    assert rebuilt.__name__ == name
 assert len.__repr__() == "<built-in function len>"
 assert t.__dict__["__call__"](len, [1, 2, 3]) == 3
 

--- a/pyre/extra_tests/parity_tests/builtin_function_python314.py
+++ b/pyre/extra_tests/parity_tests/builtin_function_python314.py
@@ -54,6 +54,20 @@ for bound_builtin, owner, name in (
 assert len.__repr__() == "<built-in function len>"
 assert t.__dict__["__call__"](len, [1, 2, 3]) == 3
 
+for method_name, args in (
+    ("__call__", ()),
+    ("__eq__", (len,)),
+    ("__ne__", (len,)),
+    ("__lt__", (len,)),
+    ("__le__", (len,)),
+    ("__gt__", (len,)),
+    ("__ge__", (len,)),
+    ("__hash__", ()),
+    ("__repr__", ()),
+    ("__reduce__", ()),
+):
+    raises(TypeError, lambda n=method_name, a=args: t.__dict__[n](object(), *a))
+
 assert len == len
 assert len != abs
 assert isinstance(hash(len), int)

--- a/pyre/extra_tests/parity_tests/classmethod_protocol.py
+++ b/pyre/extra_tests/parity_tests/classmethod_protocol.py
@@ -172,6 +172,12 @@ class ClassMethodSubclass(classmethod):
 sub = ClassMethodSubclass(wrapped)
 assert type(sub) is ClassMethodSubclass
 assert sub.__func__ is wrapped
+try:
+    sub()
+except TypeError as exc:
+    assert str(exc) == "'ClassMethodSubclass' object is not callable"
+else:
+    raise AssertionError("a classmethod subclass without __call__ was callable")
 
 
 class CallableClassMethod(classmethod):
@@ -188,5 +194,12 @@ alias = classmethod[int]
 assert type(alias).__name__ == "GenericAlias"
 assert alias.__origin__ is classmethod
 assert alias.__args__ == (int,)
+
+try:
+    classmethod(wrapped).__get__(None, None)
+except TypeError:
+    pass
+else:
+    raise AssertionError("classmethod.__get__(None, None) must fail")
 
 print("OK")

--- a/pyre/extra_tests/parity_tests/closure_cell_protocol.py
+++ b/pyre/extra_tests/parity_tests/closure_cell_protocol.py
@@ -105,7 +105,7 @@ try:
 except TypeError:
     pass
 else:
-    assert False, "cell arithmetic must not operate on its contents"
+    raise AssertionError("cell arithmetic must not operate on its contents")
 
 
 def _make(x):

--- a/pyre/extra_tests/parity_tests/code_python314.py
+++ b/pyre/extra_tests/parity_tests/code_python314.py
@@ -94,6 +94,60 @@ assert same_dunder == code
 assert hash(same) == hash(code)
 assert code.replace(co_name="renamed").co_name == "renamed"
 assert code.replace(co_qualname="outer.renamed").co_qualname == "outer.renamed"
+different_lines = code.replace(co_linetable=b"")
+different_exceptions = code.replace(co_exceptiontable=b"x")
+assert different_lines != code
+assert different_exceptions != code
+assert hash(different_lines) != hash(code)
+assert hash(different_exceptions) != hash(code)
+assert list(different_lines.co_positions()) != positions
+
+for changes in (
+    {"co_argcount": len(code.co_varnames) + 1},
+    {"co_posonlyargcount": code.co_argcount + 1},
+    {"co_kwonlyargcount": len(code.co_varnames) + 1},
+    {"co_nlocals": code.co_nlocals + 1},
+):
+    try:
+        code.replace(**changes)
+    except (ValueError, SystemError):
+        pass
+    else:
+        raise AssertionError(f"code.replace accepted inconsistent counts: {changes}")
+
+for field in ("co_argcount", "co_stacksize", "co_flags", "co_firstlineno"):
+    try:
+        code.replace(**{field: 1 << 40})
+    except OverflowError:
+        pass
+    else:
+        raise AssertionError(f"code.replace accepted an oversized {field}")
+
+
+def constants_sample():
+    return 1j, frozenset({1, 2})
+
+
+constants_code = constants_sample.__code__
+assert constants_code.replace(co_consts=constants_code.co_consts) == constants_code
+
+
+def outer(captured):
+    def inner():
+        return captured
+
+    return inner
+
+
+outer_code = outer.__code__
+assert outer_code._varname_from_oparg(0) == "captured"
+try:
+    outer_code._varname_from_oparg(len(outer_code.co_varnames))
+except IndexError:
+    pass
+else:
+    raise AssertionError("cellvar/local alias was exposed as a second locals-plus slot")
+
 assert types.CodeType.__eq__(code, object()) is NotImplemented
 assert types.CodeType.__ne__(code, object()) is NotImplemented
 for name in ("__lt__", "__le__", "__gt__", "__ge__"):

--- a/pyre/extra_tests/parity_tests/code_python314.py
+++ b/pyre/extra_tests/parity_tests/code_python314.py
@@ -86,6 +86,27 @@ assert len(positions) == len(code.co_code) // 2
 assert lines and all(len(row) == 3 for row in lines)
 assert branches == [(12, 18, 48)]
 
+
+def loop(values):
+    for value in values:
+        pass
+
+
+assert list(loop.__code__.co_branches()) == [(6, 10, 20)]
+
+large_namespace = {}
+large_body = "\n".join(f"        value = {number}" for number in range(300))
+exec(
+    "def large_branch(flag):\n"
+    "    if flag:\n"
+    f"{large_body}\n"
+    "    return value\n",
+    large_namespace,
+)
+large_branches = list(large_namespace["large_branch"].__code__.co_branches())
+assert large_branches
+assert max(max(row) for row in large_branches) > 512
+
 same = code.replace()
 same_dunder = code.__replace__()
 assert same is not code

--- a/pyre/extra_tests/parity_tests/function_member_descriptors_python314.py
+++ b/pyre/extra_tests/parity_tests/function_member_descriptors_python314.py
@@ -50,6 +50,14 @@ for name in MEMBERS:
     assert reduced == (getattr, (types.FunctionType, name))
     assert reduced[0] is getattr
 
+for method_name in ("__repr__", "__reduce__"):
+    try:
+        getattr(types.MemberDescriptorType, method_name)(1)
+    except TypeError:
+        pass
+    else:
+        raise AssertionError(f"member descriptor {method_name} accepted an int")
+
 
 def make_closure(value):
     def inner():

--- a/pyre/extra_tests/parity_tests/function_member_descriptors_python314.py
+++ b/pyre/extra_tests/parity_tests/function_member_descriptors_python314.py
@@ -49,6 +49,12 @@ for name in MEMBERS:
     reduced = descriptor.__reduce__()
     assert reduced == (getattr, (types.FunctionType, name))
     assert reduced[0] is getattr
+    try:
+        descriptor.__get__(object(), object)
+    except TypeError:
+        pass
+    else:
+        raise AssertionError(f"function member {name} accepted a foreign receiver")
 
 for method_name in ("__repr__", "__reduce__"):
     try:

--- a/pyre/extra_tests/parity_tests/function_python314.py
+++ b/pyre/extra_tests/parity_tests/function_python314.py
@@ -114,7 +114,17 @@ assert len(identity.__type_params__) == 1
 assert identity.__type_params__[0].__name__ == "T"
 assert identity(5) == 5
 
-for descriptor_name in ("__annotate__", "__type_params__"):
+for descriptor_name in (
+    "__name__",
+    "__qualname__",
+    "__defaults__",
+    "__kwdefaults__",
+    "__code__",
+    "__annotations__",
+    "__annotate__",
+    "__dict__",
+    "__type_params__",
+):
     descriptor = type(f).__dict__[descriptor_name]
     try:
         descriptor.__get__(42, int)
@@ -122,3 +132,15 @@ for descriptor_name in ("__annotate__", "__type_params__"):
         pass
     else:
         raise AssertionError(f"function {descriptor_name} accepted a foreign receiver")
+
+for method_name, args in (
+    ("__call__", ()),
+    ("__get__", (None, type(None))),
+    ("__repr__", ()),
+):
+    try:
+        type(f).__dict__[method_name](len, *args)
+    except TypeError:
+        pass
+    else:
+        raise AssertionError(f"function {method_name} accepted a foreign receiver")

--- a/pyre/extra_tests/parity_tests/function_python314.py
+++ b/pyre/extra_tests/parity_tests/function_python314.py
@@ -60,8 +60,8 @@ else:
 assert f.__annotate__ is None
 
 
-def annotate(format):
-    assert format == 1
+def annotate(annotation_format):
+    assert annotation_format == 1
     return {"value": int}
 
 
@@ -113,3 +113,12 @@ def identity[T](value: T) -> T:
 assert len(identity.__type_params__) == 1
 assert identity.__type_params__[0].__name__ == "T"
 assert identity(5) == 5
+
+for descriptor_name in ("__annotate__", "__type_params__"):
+    descriptor = type(f).__dict__[descriptor_name]
+    try:
+        descriptor.__get__(42, int)
+    except TypeError:
+        pass
+    else:
+        raise AssertionError(f"function {descriptor_name} accepted a foreign receiver")

--- a/pyre/extra_tests/parity_tests/functional_iterators_python314.py
+++ b/pyre/extra_tests/parity_tests/functional_iterators_python314.py
@@ -252,6 +252,31 @@ assert iter(z) is z and next(z) == (1, 3)
 assert z.__reduce__()[0] is zip
 assert list(z) == [(2, 4)]
 
+
+class ZipSubclass(zip):
+    pass
+
+
+z = ZipSubclass([1], [2])
+assert z.__reduce__()[0] is ZipSubclass
+z.__setstate__([1])
+assert z.__reduce__()[2] is True
+z.__setstate__([])
+assert len(z.__reduce__()) == 2
+
+for name, call_args in [
+    ("__iter__", (42,)),
+    ("__next__", (42,)),
+    ("__reduce__", (42,)),
+    ("__setstate__", (42, True)),
+]:
+    try:
+        getattr(zip, name)(*call_args)
+    except TypeError:
+        pass
+    else:
+        raise AssertionError(f"zip.{name} must validate its receiver")
+
 try:
     list(zip([1], [2, 3], strict=True))
 except ValueError:

--- a/pyre/extra_tests/parity_tests/functional_iterators_python314.py
+++ b/pyre/extra_tests/parity_tests/functional_iterators_python314.py
@@ -21,6 +21,46 @@ assert reduced[0] is enumerate and reduced[1][1] == 11
 alias = enumerate[str]
 assert alias.__origin__ is enumerate and alias.__args__ == (str,)
 
+
+class HugeIndex:
+    def __index__(self):
+        return 10**30
+
+
+for start, expected in [
+    (10**30, 10**30),
+    (-(10**30), -(10**30)),
+    (HugeIndex(), 10**30),
+]:
+    e = enumerate(["x", "y"], start)
+    assert next(e) == (expected, "x")
+    reduced = e.__reduce__()
+    assert reduced[0] is enumerate
+    assert reduced[1][1] == expected + 1
+    assert next(e) == (expected + 1, "y")
+
+# Crossing the machine-word boundary promotes the counter to the same bigint
+# state used when construction starts outside the fast range.
+e = enumerate(iter([1, 2]), 2**63 - 1)
+assert next(e) == (2**63 - 1, 1)
+assert next(e) == (2**63, 2)
+assert e.__reduce__()[1][1] == 2**63 + 1
+
+try:
+    enumerate([], None)
+except TypeError:
+    pass
+else:
+    raise AssertionError("an explicit None start must be passed through __index__")
+
+for name in ("__iter__", "__next__", "__reduce__"):
+    try:
+        getattr(enumerate, name)(42)
+    except TypeError:
+        pass
+    else:
+        raise AssertionError(f"enumerate.{name} must validate its receiver")
+
 r = reversed([1, 2, 3])
 assert iter(r) is r and operator.length_hint(r) == 3
 assert next(r) == 3 and operator.length_hint(r) == 2

--- a/pyre/extra_tests/parity_tests/functional_iterators_python314.py
+++ b/pyre/extra_tests/parity_tests/functional_iterators_python314.py
@@ -187,6 +187,31 @@ assert iter(m) is m and next(m) == 2
 assert m.__reduce__()[0] is map
 assert list(m) == [3]
 
+
+class MapSubclass(map):
+    pass
+
+
+m = MapSubclass(str, [1])
+assert m.__reduce__()[0] is MapSubclass
+m.__setstate__([1])
+assert m.__reduce__()[2] is True
+m.__setstate__([])
+assert len(m.__reduce__()) == 2
+
+for name, call_args in [
+    ("__iter__", (42,)),
+    ("__next__", (42,)),
+    ("__reduce__", (42,)),
+    ("__setstate__", (42, True)),
+]:
+    try:
+        getattr(map, name)(*call_args)
+    except TypeError:
+        pass
+    else:
+        raise AssertionError(f"map.{name} must validate its receiver")
+
 f = filter(None, [0, 1, "", "x"])
 assert iter(f) is f and f.__reduce__()[0] is filter
 assert list(f) == [1, "x"]

--- a/pyre/extra_tests/parity_tests/functional_iterators_python314.py
+++ b/pyre/extra_tests/parity_tests/functional_iterators_python314.py
@@ -61,11 +61,126 @@ for name in ("__iter__", "__next__", "__reduce__"):
     else:
         raise AssertionError(f"enumerate.{name} must validate its receiver")
 
+
+class EnumerateSubclass(enumerate):
+    pass
+
+
+assert EnumerateSubclass([1]).__reduce__()[0] is EnumerateSubclass
+
 r = reversed([1, 2, 3])
 assert iter(r) is r and operator.length_hint(r) == 3
 assert next(r) == 3 and operator.length_hint(r) == 2
 r.__setstate__(0)
 assert list(r) == [1]
+
+
+class Sequence:
+    def __init__(self, values):
+        self.values = values
+
+    def __len__(self):
+        return len(self.values)
+
+    def __getitem__(self, index):
+        return self.values[index]
+
+
+seq = Sequence([0, 1, 2])
+r = reversed(seq)
+assert type(r) is reversed
+assert r.__reduce__()[0] is reversed
+assert r.__reduce__()[1] == (seq,)
+assert r.__reduce__()[2] == 2
+assert operator.length_hint(r) == 3
+assert next(r) == 2
+r.__setstate__(99)
+assert operator.length_hint(r) == 3 and next(r) == 2
+r.__setstate__(-99)
+assert operator.length_hint(r) == 0
+try:
+    next(r)
+except StopIteration:
+    pass
+else:
+    raise AssertionError("reversed negative state must clamp to exhaustion")
+
+# The length hint re-reads the live sequence length, as required by PyPy and
+# CPython's dedicated regression test.
+seq = Sequence([0, 1, 2])
+r = reversed(seq)
+seq.values[:] = [0]
+assert operator.length_hint(r) == 0
+
+
+class ReversedSubclass(reversed):
+    pass
+
+
+r = ReversedSubclass((1, 2))
+assert r.__reduce__()[0] is ReversedSubclass
+assert list(r) == [2, 1]
+assert r.__reduce__()[0] is ReversedSubclass
+
+for name, call_args in [
+    ("__iter__", (42,)),
+    ("__next__", (42,)),
+    ("__length_hint__", (42,)),
+    ("__reduce__", (42,)),
+    ("__setstate__", (42, 0)),
+]:
+    try:
+        getattr(reversed, name)(*call_args)
+    except TypeError:
+        pass
+    else:
+        raise AssertionError(f"reversed.{name} must validate its receiver")
+
+
+class IndexState:
+    def __index__(self):
+        return 1
+
+
+class IntState:
+    def __int__(self):
+        return 1
+
+
+for state in (IndexState(), IntState(), 1.25):
+    try:
+        reversed(Sequence([1])).__setstate__(state)
+    except TypeError:
+        pass
+    else:
+        raise AssertionError("reversed state must be a concrete Python int")
+
+try:
+    reversed(Sequence([1])).__setstate__(10**30)
+except OverflowError:
+    pass
+else:
+    raise AssertionError("reversed state must fit Py_ssize_t")
+
+for non_reversible in (iter(range(3)), iter([1, 2])):
+    try:
+        reversed(non_reversible)
+    except TypeError:
+        pass
+    else:
+        raise AssertionError("iterators are not reversible in Python 3.14")
+
+
+class DisabledReversed(Sequence):
+    __reversed__ = None
+
+
+try:
+    reversed(DisabledReversed([1]))
+except TypeError:
+    pass
+else:
+    raise AssertionError("__reversed__ = None must disable sequence fallback")
 
 m = map(lambda x: x + 1, [1, 2])
 assert iter(m) is m and next(m) == 2

--- a/pyre/extra_tests/parity_tests/functional_iterators_python314.py
+++ b/pyre/extra_tests/parity_tests/functional_iterators_python314.py
@@ -216,6 +216,37 @@ f = filter(None, [0, 1, "", "x"])
 assert iter(f) is f and f.__reduce__()[0] is filter
 assert list(f) == [1, "x"]
 
+
+class FilterSubclass(filter):
+    pass
+
+
+assert FilterSubclass(None, [1]).__reduce__()[0] is FilterSubclass
+
+
+class FilterInitSubclass(filter):
+    def __init__(self, *args, **kwargs):
+        self.init_args = args
+        self.init_kwargs = kwargs
+
+
+f = FilterInitSubclass(None, [1], marker=42)
+assert f.init_args == (None, [1]) and f.init_kwargs == {"marker": 42}
+try:
+    FilterSubclass(None, [1], marker=42)
+except TypeError:
+    pass
+else:
+    raise AssertionError("filter subclass without __init__ override must reject keywords")
+
+for name in ("__iter__", "__next__", "__reduce__"):
+    try:
+        getattr(filter, name)(42)
+    except TypeError:
+        pass
+    else:
+        raise AssertionError(f"filter.{name} must validate its receiver")
+
 z = zip([1, 2], [3, 4])
 assert iter(z) is z and next(z) == (1, 3)
 assert z.__reduce__()[0] is zip

--- a/pyre/extra_tests/parity_tests/itertools_compress_python314.py
+++ b/pyre/extra_tests/parity_tests/itertools_compress_python314.py
@@ -1,0 +1,108 @@
+"""PyPy W_Compress structure with Python 3.14 public surface."""
+
+import itertools
+
+
+assert isinstance(itertools.compress, type)
+assert itertools.compress.__module__ == "itertools"
+assert itertools.compress.__name__ == "compress"
+assert itertools.compress.__doc__ == (
+    "Return data elements corresponding to true selector elements.\n\n"
+    "Forms a shorter iterator from selected data elements using the selectors to\n"
+    "choose the data elements."
+)
+assert {"__new__", "__iter__", "__next__", "__doc__"} <= set(
+    itertools.compress.__dict__
+)
+assert "__reduce__" not in itertools.compress.__dict__
+
+
+events = []
+
+
+class Source:
+    def __init__(self, name, values):
+        self.name = name
+        self.values = iter(values)
+
+    def __iter__(self):
+        events.append(("iter", self.name))
+        return self
+
+    def __next__(self):
+        value = next(self.values)
+        events.append(("next", self.name, value))
+        return value
+
+
+obj = itertools.compress(Source("data", ["a", "b", "c"]), Source("selectors", [0, 1, 1]))
+assert type(obj) is itertools.compress
+assert iter(obj) is obj
+assert events == [("iter", "data"), ("iter", "selectors")]
+assert next(obj) == "b"
+assert events == [
+    ("iter", "data"),
+    ("iter", "selectors"),
+    ("next", "data", "a"),
+    ("next", "selectors", 0),
+    ("next", "data", "b"),
+    ("next", "selectors", 1),
+]
+assert list(obj) == ["c"]
+
+# The shortest input stops first, and data is pulled before the corresponding
+# selector exactly as W_Compress.next_w specifies.
+events = []
+obj = itertools.compress(Source("data", [1, 2]), Source("selectors", []))
+try:
+    next(obj)
+except StopIteration:
+    pass
+else:
+    raise AssertionError("compress did not stop with its selectors")
+assert events == [
+    ("iter", "data"),
+    ("iter", "selectors"),
+    ("next", "data", 1),
+]
+
+# Python 3.14 accepts the two Argument Clinic keyword names.
+assert list(itertools.compress(data=[1, 2], selectors=[True, False])) == [1]
+assert list(itertools.compress([1, 2], selectors=[False, True])) == [2]
+
+for args in ((), ([],), ([], [], None)):
+    try:
+        itertools.compress(*args)
+    except TypeError:
+        pass
+    else:
+        raise AssertionError(args)
+
+for name in ("__iter__", "__next__"):
+    try:
+        getattr(itertools.compress, name)(iter(()))
+    except TypeError as exc:
+        assert str(exc) == (
+            f"descriptor '{name}' requires a 'itertools.compress' object "
+            "but received a 'tuple_iterator'"
+        )
+    else:
+        raise AssertionError(f"compress.{name} accepted a foreign receiver")
+
+
+class CompressSubclass(itertools.compress):
+    pass
+
+
+sub = CompressSubclass([1, 2], [0, 1])
+assert type(sub) is CompressSubclass
+assert list(sub) == [2]
+
+try:
+    itertools.compress([], []).__reduce__()
+except TypeError:
+    pass
+else:
+    raise AssertionError("Python 3.14 compress unexpectedly became picklable")
+
+print("itertools.compress Python 3.14 parity ok")

--- a/pyre/extra_tests/parity_tests/itertools_starmap_python314.py
+++ b/pyre/extra_tests/parity_tests/itertools_starmap_python314.py
@@ -1,0 +1,91 @@
+"""PyPy W_StarMap structure with Python 3.14 public surface."""
+
+import itertools
+
+
+assert isinstance(itertools.starmap, type)
+assert itertools.starmap.__module__ == "itertools"
+assert itertools.starmap.__name__ == "starmap"
+assert itertools.starmap.__doc__ == (
+    "Return an iterator whose values are returned from the function evaluated "
+    "with an argument tuple taken from the given sequence."
+)
+assert {"__new__", "__iter__", "__next__", "__doc__"} <= set(
+    itertools.starmap.__dict__
+)
+
+
+events = []
+
+
+class Source:
+    def __init__(self):
+        self.items = iter([(2, 3), [3, 2]])
+
+    def __iter__(self):
+        events.append("iter")
+        return self
+
+    def __next__(self):
+        value = next(self.items)
+        events.append(("next", value))
+        return value
+
+
+def function(a, b):
+    events.append(("call", a, b))
+    return a**b
+
+
+obj = itertools.starmap(function, Source())
+assert type(obj) is itertools.starmap
+assert iter(obj) is obj
+assert events == ["iter"]
+assert next(obj) == 8
+assert events == ["iter", ("next", (2, 3)), ("call", 2, 3)]
+assert list(obj) == [9]
+
+# The source stays live: an exception is raised at the corresponding next(),
+# not during construction, and the source has advanced by one bundle.
+events = []
+obj = itertools.starmap(function, Source())
+assert events == ["iter"]
+assert next(obj) == 8
+assert events[-1] == ("call", 2, 3)
+
+for args in ((), (function,), (function, [], None)):
+    try:
+        itertools.starmap(*args)
+    except TypeError:
+        pass
+    else:
+        raise AssertionError(args)
+
+try:
+    itertools.starmap(function=function, iterable=[])
+except TypeError as exc:
+    assert str(exc) == "starmap() takes no keyword arguments"
+else:
+    raise AssertionError("starmap accepted keyword arguments")
+
+for name in ("__iter__", "__next__"):
+    try:
+        getattr(itertools.starmap, name)(iter(()))
+    except TypeError as exc:
+        assert str(exc) == (
+            f"descriptor '{name}' requires a 'itertools.starmap' object "
+            "but received a 'tuple_iterator'"
+        )
+    else:
+        raise AssertionError(f"starmap.{name} accepted a foreign receiver")
+
+
+class StarMapSubclass(itertools.starmap):
+    pass
+
+
+sub = StarMapSubclass(pow, [(2, 4)])
+assert type(sub) is StarMapSubclass
+assert list(sub) == [16]
+
+print("itertools.starmap Python 3.14 parity ok")

--- a/pyre/extra_tests/parity_tests/list_python314.py
+++ b/pyre/extra_tests/parity_tests/list_python314.py
@@ -1,0 +1,133 @@
+EXPECTED = {
+    "__add__",
+    "__class_getitem__",
+    "__contains__",
+    "__delitem__",
+    "__doc__",
+    "__eq__",
+    "__ge__",
+    "__getitem__",
+    "__gt__",
+    "__hash__",
+    "__iadd__",
+    "__imul__",
+    "__init__",
+    "__iter__",
+    "__le__",
+    "__len__",
+    "__lt__",
+    "__mul__",
+    "__ne__",
+    "__new__",
+    "__repr__",
+    "__reversed__",
+    "__rmul__",
+    "__setitem__",
+    "__sizeof__",
+    "append",
+    "clear",
+    "copy",
+    "count",
+    "extend",
+    "index",
+    "insert",
+    "pop",
+    "remove",
+    "reverse",
+    "sort",
+}
+
+assert set(list.__dict__) == EXPECTED
+
+WRAPPER_DESCRIPTORS = {
+    "__add__",
+    "__contains__",
+    "__delitem__",
+    "__eq__",
+    "__ge__",
+    "__gt__",
+    "__iadd__",
+    "__imul__",
+    "__init__",
+    "__iter__",
+    "__le__",
+    "__len__",
+    "__lt__",
+    "__mul__",
+    "__ne__",
+    "__repr__",
+    "__rmul__",
+    "__setitem__",
+}
+
+METHOD_DESCRIPTORS = {
+    "__getitem__",
+    "__reversed__",
+    "__sizeof__",
+    "append",
+    "clear",
+    "copy",
+    "count",
+    "extend",
+    "index",
+    "insert",
+    "pop",
+    "remove",
+    "reverse",
+    "sort",
+}
+
+for name in WRAPPER_DESCRIPTORS:
+    descriptor = list.__dict__[name]
+    try:
+        descriptor(())
+    except TypeError as exc:
+        assert str(exc) == (
+            f"descriptor '{name}' requires a 'list' object but received a 'tuple'"
+        )
+    else:
+        raise AssertionError(f"list.{name} accepted a tuple receiver")
+
+    try:
+        descriptor()
+    except TypeError as exc:
+        assert str(exc) == f"descriptor '{name}' of 'list' object needs an argument"
+    else:
+        raise AssertionError(f"list.{name} accepted a missing receiver")
+
+for name in METHOD_DESCRIPTORS:
+    descriptor = list.__dict__[name]
+    try:
+        descriptor(())
+    except TypeError as exc:
+        assert str(exc) == (
+            f"descriptor '{name}' for 'list' objects doesn't apply to a 'tuple' object"
+        )
+    else:
+        raise AssertionError(f"list.{name} accepted a tuple receiver")
+
+    try:
+        descriptor()
+    except TypeError as exc:
+        assert str(exc) == f"unbound method list.{name}() needs an argument"
+    else:
+        raise AssertionError(f"list.{name} accepted a missing receiver")
+
+
+class ListSubclass(list):
+    pass
+
+
+value = ListSubclass([3, 1, 2])
+list.append(value, 4)
+list.sort(value)
+assert value == [1, 2, 3, 4]
+assert list.copy(value) == [1, 2, 3, 4]
+
+values = list(range(6))
+values[1:0] = ["a", "b"]
+assert values == [0, "a", "b", 1, 2, 3, 4, 5]
+values[6:2] = []
+assert values == [0, "a", "b", 1, 2, 3, 4, 5]
+
+print("OK")

--- a/pyre/extra_tests/parity_tests/list_python314.py
+++ b/pyre/extra_tests/parity_tests/list_python314.py
@@ -130,4 +130,20 @@ assert values == [0, "a", "b", 1, 2, 3, 4, 5]
 values[6:2] = []
 assert values == [0, "a", "b", 1, 2, 3, 4, 5]
 
+for base in (object, list, tuple):
+    side_effects = [1]
+
+    class IterableSubclass(base):
+        def __iter__(self):
+            side_effects.append(2)
+
+            def inner():
+                yield 3
+                side_effects.append(4)
+
+            return inner()
+
+    unpacked = [*side_effects, *IterableSubclass(), *side_effects.copy()]
+    assert unpacked == [1, 3, 1, 2, 4]
+
 print("OK")

--- a/pyre/extra_tests/parity_tests/memoryview_python314.py
+++ b/pyre/extra_tests/parity_tests/memoryview_python314.py
@@ -1,5 +1,6 @@
 """Python 3.14 memoryview additions layered on PyPy's W_MemoryView typedef."""
 
+import array
 import weakref
 
 
@@ -9,15 +10,20 @@ required = {
     "__doc__",
     "__enter__",
     "__eq__",
+    "__ge__",
+    "__gt__",
     "__exit__",
     "__getitem__",
     "__hash__",
     "__iter__",
     "__len__",
+    "__le__",
+    "__lt__",
     "__new__",
     "__release_buffer__",
     "__repr__",
     "__setitem__",
+    "_from_flags",
     "cast",
     "count",
     "hex",
@@ -28,6 +34,52 @@ required = {
     "toreadonly",
 }
 assert required <= set(memoryview.__dict__)
+
+left = memoryview(array.array("i", [1]))
+right = memoryview(array.array("f", [1.0]))
+assert left == right
+assert left != memoryview(array.array("f", [2.0]))
+assert memoryview(array.array("i", [1065353216])) != right
+for name in ("__lt__", "__le__", "__gt__", "__ge__"):
+    method = memoryview.__dict__[name]
+    assert method(left, right) is NotImplemented
+    try:
+        method(object(), right)
+    except TypeError:
+        pass
+    else:
+        raise AssertionError(f"{name} must validate its receiver")
+for name in ("__eq__", "__ne__"):
+    try:
+        memoryview.__dict__[name](object(), right)
+    except TypeError:
+        pass
+    else:
+        raise AssertionError(f"{name} must validate its receiver")
+
+flagged = memoryview._from_flags(b"abc", 0)
+assert flagged.tobytes() == b"abc" and flagged.readonly
+flagged.release()
+try:
+    memoryview._from_flags(b"abc", 1)
+except BufferError as exc:
+    assert str(exc) == "Object is not writable."
+else:
+    raise AssertionError("PyBUF_WRITABLE must reject bytes")
+flagged = memoryview._from_flags(bytearray(b"abc"), 1)
+assert not flagged.readonly
+flagged.release()
+source = memoryview(b"abc")
+flagged = memoryview._from_flags(source, 1)
+assert flagged.readonly and flagged.tobytes() == b"abc"
+flagged.release()
+source.release()
+try:
+    memoryview._from_flags(b"abc", 1 << 40)
+except OverflowError:
+    pass
+else:
+    raise AssertionError("flags must fit a C int")
 
 mv = memoryview(bytearray(b"abaca"))
 assert mv.count(ord("a")) == 3

--- a/pyre/extra_tests/parity_tests/method_python314.py
+++ b/pyre/extra_tests/parity_tests/method_python314.py
@@ -117,4 +117,11 @@ assert reconstructor is getattr
 assert reduce_args == (c, "method")
 assert reconstructor(*reduce_args).__func__ is function
 
+try:
+    types.MethodType.__getattribute__(bound, 123)
+except TypeError:
+    pass
+else:
+    raise AssertionError("method.__getattribute__ accepted a non-string name")
+
 print("OK")

--- a/pyre/extra_tests/parity_tests/method_python314.py
+++ b/pyre/extra_tests/parity_tests/method_python314.py
@@ -124,4 +124,33 @@ except TypeError:
 else:
     raise AssertionError("method.__getattribute__ accepted a non-string name")
 
+for name, args in (
+    ("__call__", ()),
+    ("__get__", (None, C)),
+    ("__getattribute__", ("__name__",)),
+    ("__eq__", (bound,)),
+    ("__ne__", (bound,)),
+    ("__lt__", (bound,)),
+    ("__le__", (bound,)),
+    ("__gt__", (bound,)),
+    ("__ge__", (bound,)),
+    ("__hash__", ()),
+    ("__repr__", ()),
+    ("__reduce__", ()),
+):
+    try:
+        types.MethodType.__dict__[name](object(), *args)
+    except TypeError:
+        pass
+    else:
+        raise AssertionError(f"method {name} accepted a foreign receiver")
+
+for name in ("__doc__", "__func__", "__self__"):
+    try:
+        types.MethodType.__dict__[name].__get__(object())
+    except TypeError:
+        pass
+    else:
+        raise AssertionError(f"method {name} accepted a foreign receiver")
+
 print("OK")

--- a/pyre/extra_tests/parity_tests/module_type_python314.py
+++ b/pyre/extra_tests/parity_tests/module_type_python314.py
@@ -121,9 +121,9 @@ else:
 calls = []
 
 
-def annotate(format):
-    calls.append(format)
-    return {"answer": format}
+def annotate(annotation_format):
+    calls.append(annotation_format)
+    return {"answer": annotation_format}
 
 
 module.__annotations__ = {"old": True}
@@ -145,12 +145,31 @@ else:
     raise AssertionError("module.__annotate__ deletion succeeded")
 
 module = types.ModuleType("sample")
-module.__annotate__ = lambda format: 1
+module.__annotate__ = lambda _annotation_format: 1
 try:
     module.__annotations__
 except TypeError as exc:
     assert str(exc) == "__annotate__ returned non-dict of type 'int'"
 else:
     raise AssertionError("non-dict annotations result was accepted")
+
+for method_name, args in (
+    ("__repr__", (42,)),
+    ("__getattribute__", (42, "x")),
+    ("__dir__", (42,)),
+):
+    try:
+        getattr(types.ModuleType, method_name)(*args)
+    except TypeError:
+        pass
+    else:
+        raise AssertionError(f"module {method_name} accepted a foreign receiver")
+
+try:
+    types.ModuleType.__init__(name="missing-self")
+except TypeError:
+    pass
+else:
+    raise AssertionError("module.__init__ accepted a missing receiver")
 
 print("OK")

--- a/pyre/extra_tests/parity_tests/property_protocol.py
+++ b/pyre/extra_tests/parity_tests/property_protocol.py
@@ -157,6 +157,21 @@ class ReadOnly:
     item = property()
 
 
+class RaisingDescriptor:
+    def __get__(self, instance, owner):
+        raise AttributeError("descriptor miss")
+
+
+class PropertyWithGetattr(property):
+    missing = RaisingDescriptor()
+
+    def __getattr__(self, name):
+        return f"fallback:{name}"
+
+
+assert PropertyWithGetattr().missing == "fallback:missing"
+
+
 try:
     ReadOnly().item
 except AttributeError as exc:
@@ -189,5 +204,12 @@ for action in (
         pass
     else:
         assert False, "invalid property constructor arguments must raise"
+
+try:
+    property.__delete__(property())
+except TypeError:
+    pass
+else:
+    raise AssertionError("property.__delete__ accepted a missing target")
 
 print("OK")

--- a/pyre/extra_tests/parity_tests/python314_singletons.py
+++ b/pyre/extra_tests/parity_tests/python314_singletons.py
@@ -7,6 +7,32 @@ except TypeError as exc:
 else:
     raise AssertionError("Python 3.14 makes bool(NotImplemented) an error")
 
+for singleton, constructor_error in (
+    (Ellipsis, "EllipsisType takes no arguments"),
+    (NotImplemented, "NotImplementedType takes no arguments"),
+    (None, "NoneType takes no arguments"),
+):
+    singleton_type = type(singleton)
+    assert singleton_type() is singleton
+    try:
+        singleton_type(1)
+    except TypeError as exc:
+        assert str(exc) == constructor_error
+    else:
+        raise AssertionError(f"{singleton_type.__name__} accepted an argument")
+
+    for name in singleton_type.__dict__:
+        if name in {"__doc__", "__new__"}:
+            continue
+        method = getattr(singleton_type, name)
+        call_args = (42, 0) if name in {"__eq__", "__ne__", "__lt__", "__le__", "__gt__", "__ge__"} else (42,)
+        try:
+            method(*call_args)
+        except TypeError:
+            pass
+        else:
+            raise AssertionError(f"{singleton_type.__name__}.{name} accepted a foreign receiver")
+
 none_type = type(None)
 assert none_type() is None
 try:

--- a/pyre/extra_tests/parity_tests/range_python314.py
+++ b/pyre/extra_tests/parity_tests/range_python314.py
@@ -81,6 +81,23 @@ except OverflowError:
 else:
     raise AssertionError("range.__len__ must overflow Py_ssize_t")
 
+small_type = type(iter(range(1)))
+long_type = type(iter(range(10**30, 10**30 + 1)))
+assert small_type.__name__ == "range_iterator"
+assert long_type.__name__ == "longrange_iterator"
+assert small_type is not long_type
+
+iterator_surface = {
+    "__iter__",
+    "__length_hint__",
+    "__next__",
+    "__reduce__",
+    "__setstate__",
+    "__doc__",
+}
+assert set(small_type.__dict__) == iterator_surface
+assert set(long_type.__dict__) == iterator_surface
+
 for source in (range(5), range(10**30, 10**30 + 4)):
     iterator = iter(source)
     iterator_type = type(iterator)
@@ -111,6 +128,43 @@ for source in (range(5), range(10**30, 10**30 + 4)):
     iterator.__setstate__(99)
     assert list(iterator) == []
 
+for iterator_type, foreign in (
+    (small_type, iter(range(10**30, 10**30 + 1))),
+    (long_type, iter(range(1))),
+):
+    for name in ("__iter__", "__next__", "__length_hint__", "__reduce__", "__setstate__"):
+        descriptor = iterator_type.__dict__[name]
+        args = (foreign, 0) if name == "__setstate__" else (foreign,)
+        try:
+            descriptor(*args)
+        except TypeError as exc:
+            owner = iterator_type.__name__
+            received = type(foreign).__name__
+            if name in ("__iter__", "__next__"):
+                expected = (
+                    f"descriptor '{name}' requires a '{owner}' object "
+                    f"but received a '{received}'"
+                )
+            else:
+                expected = (
+                    f"descriptor '{name}' for '{owner}' objects "
+                    f"doesn't apply to a '{received}' object"
+                )
+            assert str(exc) == expected
+        else:
+            raise AssertionError("range iterator descriptors must validate their receiver")
+
+        try:
+            descriptor()
+        except TypeError as exc:
+            if name in ("__iter__", "__next__"):
+                expected = f"descriptor '{name}' of '{owner}' object needs an argument"
+            else:
+                expected = f"unbound method {owner}.{name}() needs an argument"
+            assert str(exc) == expected
+        else:
+            raise AssertionError("range iterator descriptors must require a receiver")
+
 iterator = iter(range(5))
 try:
     iterator.__setstate__(10**40)
@@ -118,5 +172,22 @@ except OverflowError:
     pass
 else:
     raise AssertionError("machine range iterator state must fit a C long")
+
+class IndexState:
+    def __index__(self):
+        return 2
+
+iterator = iter(range(5))
+iterator.__setstate__(IndexState())
+assert next(iterator) == 2
+
+for state in (True, IndexState()):
+    iterator = iter(range(10**30))
+    try:
+        iterator.__setstate__(state)
+    except TypeError as exc:
+        assert str(exc) == "state must be an int, not " + type(state).__name__
+    else:
+        raise AssertionError("longrange_iterator state must be an exact int")
 
 print("OK")

--- a/pyre/extra_tests/parity_tests/sequence_dict_iterators_python314.py
+++ b/pyre/extra_tests/parity_tests/sequence_dict_iterators_python314.py
@@ -59,11 +59,114 @@ for factory, expected_name, expected in factories:
     assert operator.length_hint(iterator) == 2
     reduced = iterator.__reduce__()
     assert reduced[0] is iter and list(reduced[1][0]) == expected[1:]
+    foreign = iter([])
+    for name in ("__iter__", "__next__", "__length_hint__", "__reduce__"):
+        descriptor = iterator_type.__dict__[name]
+        try:
+            descriptor(foreign)
+        except TypeError as exc:
+            if name in ("__iter__", "__next__"):
+                message = (
+                    f"descriptor '{name}' requires a '{expected_name}' object "
+                    "but received a 'list_iterator'"
+                )
+            else:
+                message = (
+                    f"descriptor '{name}' for '{expected_name}' objects "
+                    "doesn't apply to a 'list_iterator' object"
+                )
+            assert str(exc) == message
+        else:
+            raise AssertionError("dict iterator accepted a foreign receiver")
     try:
         iterator_type()
     except TypeError:
         pass
     else:
         raise AssertionError("dict iterator must not be directly instantiable")
+
+reverse_factories = (
+    (reversed, "dict_reversekeyiterator", ["c", "b", "a"]),
+    (lambda d: reversed(d.values()), "dict_reversevalueiterator", [3, 2, 1]),
+    (
+        lambda d: reversed(d.items()),
+        "dict_reverseitemiterator",
+        [("c", 3), ("b", 2), ("a", 1)],
+    ),
+)
+iterator_surface = {
+    "__doc__",
+    "__iter__",
+    "__next__",
+    "__length_hint__",
+    "__reduce__",
+}
+for factory, expected_name, expected in reverse_factories:
+    source = {"a": 1, "b": 2, "c": 3}
+    iterator = factory(source)
+    iterator_type = type(iterator)
+    assert iterator_type.__name__ == expected_name
+    assert set(iterator_type.__dict__) == iterator_surface
+    assert iter(iterator) is iterator
+    assert operator.length_hint(iterator) == 3
+    assert next(iterator) == expected[0]
+    assert operator.length_hint(iterator) == 2
+    reduced = iterator.__reduce__()
+    assert reduced[0] is iter and reduced[1] == (expected[1:],)
+
+    foreign = iter({"x": 1})
+    for name in ("__iter__", "__next__", "__length_hint__", "__reduce__"):
+        descriptor = iterator_type.__dict__[name]
+        try:
+            descriptor(foreign)
+        except TypeError as exc:
+            if name in ("__iter__", "__next__"):
+                message = (
+                    f"descriptor '{name}' requires a '{expected_name}' object "
+                    "but received a 'dict_keyiterator'"
+                )
+            else:
+                message = (
+                    f"descriptor '{name}' for '{expected_name}' objects "
+                    "doesn't apply to a 'dict_keyiterator' object"
+                )
+            assert str(exc) == message
+        else:
+            raise AssertionError("reverse dict iterator accepted a foreign receiver")
+
+    source["d"] = 4
+    assert operator.length_hint(iterator) == 0
+    try:
+        next(iterator)
+    except RuntimeError as exc:
+        assert str(exc) == "dictionary changed size during iteration"
+    else:
+        raise AssertionError("reverse dict iterator missed a size mutation")
+
+    try:
+        iterator_type()
+    except TypeError:
+        pass
+    else:
+        raise AssertionError("reverse dict iterator must not be directly instantiable")
+
+reverse_owners = (
+    (dict, "dict"),
+    (type({}.keys()), "dict_keys"),
+    (type({}.values()), "dict_values"),
+    (type({}.items()), "dict_items"),
+    (type(type.__dict__), "mappingproxy"),
+)
+for owner, owner_name in reverse_owners:
+    descriptor = owner.__dict__["__reversed__"]
+    try:
+        descriptor(None)
+    except TypeError as exc:
+        assert str(exc) == (
+            f"descriptor '__reversed__' for '{owner_name}' objects "
+            "doesn't apply to a 'NoneType' object"
+        )
+    else:
+        raise AssertionError(f"{owner_name}.__reversed__ accepted a foreign receiver")
 
 print("OK")

--- a/pyre/extra_tests/parity_tests/set_iterator_python314.py
+++ b/pyre/extra_tests/parity_tests/set_iterator_python314.py
@@ -1,0 +1,87 @@
+iterator_type = type(iter(set()))
+
+assert iterator_type.__name__ == "set_iterator"
+assert set(iterator_type.__dict__) == {
+    "__doc__",
+    "__iter__",
+    "__length_hint__",
+    "__next__",
+    "__reduce__",
+}
+
+WRAPPERS = {"__iter__", "__next__"}
+METHODS = {"__length_hint__", "__reduce__"}
+
+for name in WRAPPERS:
+    descriptor = iterator_type.__dict__[name]
+    try:
+        descriptor(iter([]))
+    except TypeError as exc:
+        assert str(exc) == (
+            f"descriptor '{name}' requires a 'set_iterator' object "
+            "but received a 'list_iterator'"
+        )
+    else:
+        raise AssertionError(f"set_iterator.{name} accepted a list iterator")
+
+    try:
+        descriptor()
+    except TypeError as exc:
+        assert str(exc) == (
+            f"descriptor '{name}' of 'set_iterator' object needs an argument"
+        )
+    else:
+        raise AssertionError(f"set_iterator.{name} accepted a missing receiver")
+
+for name in METHODS:
+    descriptor = iterator_type.__dict__[name]
+    try:
+        descriptor(iter([]))
+    except TypeError as exc:
+        assert str(exc) == (
+            f"descriptor '{name}' for 'set_iterator' objects "
+            "doesn't apply to a 'list_iterator' object"
+        )
+    else:
+        raise AssertionError(f"set_iterator.{name} accepted a list iterator")
+
+    try:
+        descriptor()
+    except TypeError as exc:
+        assert str(exc) == (
+            f"unbound method set_iterator.{name}() needs an argument"
+        )
+    else:
+        raise AssertionError(f"set_iterator.{name} accepted a missing receiver")
+
+
+values = {1, 2, 3}
+iterator = iter(values)
+assert iter(iterator) is iterator
+assert iterator.__length_hint__() == 3
+
+first = next(iterator)
+reduced = iterator.__reduce__()
+assert reduced[0] is iter
+assert len(reduced) == 2
+remaining = reduced[1][0]
+assert isinstance(remaining, list)
+assert set(remaining) == values - {first}
+assert iterator.__length_hint__() == 2
+assert set(iterator) == values - {first}
+assert iterator.__length_hint__() == 0
+assert iterator.__reduce__() == (iter, ([],))
+
+values = {1, 2}
+iterator = iter(values)
+values.add(3)
+for operation in (iterator.__next__, iterator.__reduce__):
+    try:
+        operation()
+    except RuntimeError as exc:
+        assert str(exc) == "Set changed size during iteration"
+    else:
+        raise AssertionError("set mutation did not invalidate iterator")
+assert iterator.__length_hint__() == 0
+
+print("OK")

--- a/pyre/extra_tests/parity_tests/set_method_receivers_python314.py
+++ b/pyre/extra_tests/parity_tests/set_method_receivers_python314.py
@@ -1,0 +1,74 @@
+METHODS = {
+    "__contains__",
+    "__reduce__",
+    "__sizeof__",
+    "copy",
+    "difference",
+    "intersection",
+    "isdisjoint",
+    "issubset",
+    "issuperset",
+    "symmetric_difference",
+    "union",
+}
+
+for owner, wrong in ((set, frozenset()), (frozenset, set())):
+    owner_name = owner.__name__
+    wrong_name = type(wrong).__name__
+    for name in METHODS:
+        descriptor = owner.__dict__[name]
+        try:
+            descriptor(wrong)
+        except TypeError as exc:
+            assert str(exc) == (
+                f"descriptor '{name}' for '{owner_name}' objects "
+                f"doesn't apply to a '{wrong_name}' object"
+            )
+        else:
+            raise AssertionError(f"{owner_name}.{name} accepted {wrong_name}")
+
+        try:
+            descriptor()
+        except TypeError as exc:
+            assert str(exc) == (
+                f"unbound method {owner_name}.{name}() needs an argument"
+            )
+        else:
+            raise AssertionError(f"{owner_name}.{name} accepted a missing receiver")
+
+
+class SetSubclass(set):
+    pass
+
+
+class FrozenSubclass(frozenset):
+    pass
+
+
+set_subclass = SetSubclass((1, 2))
+frozen_subclass = FrozenSubclass((1, 2))
+
+assert set.__contains__(set_subclass, 1)
+assert frozenset.__contains__(frozen_subclass, 1)
+assert set.union(set_subclass, (3,)) == {1, 2, 3}
+assert frozenset.union(frozen_subclass, (3,)) == frozenset((1, 2, 3))
+assert set.intersection(set_subclass, (2, 3)) == {2}
+assert frozenset.intersection(frozen_subclass, (2, 3)) == frozenset((2,))
+assert set.difference(set_subclass, (2,)) == {1}
+assert frozenset.difference(frozen_subclass, (2,)) == frozenset((1,))
+assert set.symmetric_difference(set_subclass, (2, 3)) == {1, 3}
+assert frozenset.symmetric_difference(frozen_subclass, (2, 3)) == frozenset((1, 3))
+assert set.issubset(set_subclass, (1, 2, 3))
+assert frozenset.issubset(frozen_subclass, (1, 2, 3))
+assert set.issuperset(set_subclass, (1,))
+assert frozenset.issuperset(frozen_subclass, (1,))
+assert set.isdisjoint(set_subclass, (3, 4))
+assert frozenset.isdisjoint(frozen_subclass, (3, 4))
+assert type(set.copy(set_subclass)) is set
+assert type(frozenset.copy(frozen_subclass)) is frozenset
+assert isinstance(set.__sizeof__(set_subclass), int)
+assert isinstance(frozenset.__sizeof__(frozen_subclass), int)
+assert isinstance(set.__reduce__(set_subclass), tuple)
+assert isinstance(frozenset.__reduce__(frozen_subclass), tuple)
+
+print("OK")

--- a/pyre/extra_tests/parity_tests/set_mutator_receivers_python314.py
+++ b/pyre/extra_tests/parity_tests/set_mutator_receivers_python314.py
@@ -1,0 +1,75 @@
+WRAPPER_DESCRIPTORS = {
+    "__init__",
+    "__iand__",
+    "__ior__",
+    "__isub__",
+    "__ixor__",
+}
+
+METHOD_DESCRIPTORS = {
+    "add",
+    "clear",
+    "difference_update",
+    "discard",
+    "intersection_update",
+    "pop",
+    "remove",
+    "symmetric_difference_update",
+    "update",
+}
+
+for name in WRAPPER_DESCRIPTORS:
+    descriptor = set.__dict__[name]
+    try:
+        descriptor(frozenset())
+    except TypeError as exc:
+        assert str(exc) == (
+            f"descriptor '{name}' requires a 'set' object but received a 'frozenset'"
+        )
+    else:
+        raise AssertionError(f"set.{name} accepted a frozenset receiver")
+
+    try:
+        descriptor()
+    except TypeError as exc:
+        assert str(exc) == f"descriptor '{name}' of 'set' object needs an argument"
+    else:
+        raise AssertionError(f"set.{name} accepted a missing receiver")
+
+for name in METHOD_DESCRIPTORS:
+    descriptor = set.__dict__[name]
+    try:
+        descriptor(frozenset())
+    except TypeError as exc:
+        assert str(exc) == (
+            f"descriptor '{name}' for 'set' objects doesn't apply to a 'frozenset' object"
+        )
+    else:
+        raise AssertionError(f"set.{name} accepted a frozenset receiver")
+
+    try:
+        descriptor()
+    except TypeError as exc:
+        assert str(exc) == f"unbound method set.{name}() needs an argument"
+    else:
+        raise AssertionError(f"set.{name} accepted a missing receiver")
+
+
+class SetSubclass(set):
+    pass
+
+
+value = SetSubclass((1, 2))
+set.add(value, 3)
+set.update(value, (4, 5))
+set.difference_update(value, (1,))
+set.intersection_update(value, (2, 3, 4))
+set.symmetric_difference_update(value, (4, 6))
+assert value == {2, 3, 6}
+set.discard(value, 2)
+set.remove(value, 3)
+assert set.pop(value) == 6
+set.clear(value)
+assert value == set()
+
+print("OK")

--- a/pyre/extra_tests/parity_tests/set_wrapper_receivers_python314.py
+++ b/pyre/extra_tests/parity_tests/set_wrapper_receivers_python314.py
@@ -1,0 +1,88 @@
+WRAPPERS = {
+    "__and__",
+    "__eq__",
+    "__ge__",
+    "__gt__",
+    "__iter__",
+    "__le__",
+    "__len__",
+    "__lt__",
+    "__ne__",
+    "__or__",
+    "__rand__",
+    "__repr__",
+    "__ror__",
+    "__rsub__",
+    "__rxor__",
+    "__sub__",
+    "__xor__",
+}
+
+for owner, wrong in ((set, frozenset()), (frozenset, set())):
+    owner_name = owner.__name__
+    wrong_name = type(wrong).__name__
+    for name in WRAPPERS:
+        descriptor = owner.__dict__[name]
+        try:
+            descriptor(wrong)
+        except TypeError as exc:
+            assert str(exc) == (
+                f"descriptor '{name}' requires a '{owner_name}' object "
+                f"but received a '{wrong_name}'"
+            )
+        else:
+            raise AssertionError(f"{owner_name}.{name} accepted {wrong_name}")
+
+        try:
+            descriptor()
+        except TypeError as exc:
+            assert str(exc) == (
+                f"descriptor '{name}' of '{owner_name}' object needs an argument"
+            )
+        else:
+            raise AssertionError(f"{owner_name}.{name} accepted a missing receiver")
+
+for args in ((), (set(),)):
+    try:
+        frozenset.__hash__(*args)
+    except TypeError as exc:
+        if args:
+            assert str(exc) == (
+                "descriptor '__hash__' requires a 'frozenset' object "
+                "but received a 'set'"
+            )
+        else:
+            assert str(exc) == (
+                "descriptor '__hash__' of 'frozenset' object needs an argument"
+            )
+    else:
+        raise AssertionError("frozenset.__hash__ accepted an invalid receiver")
+
+
+class SetSubclass(set):
+    def __iter__(self):
+        return iter(("override",))
+
+    def __repr__(self):
+        return "override repr"
+
+
+class FrozenSubclass(frozenset):
+    def __iter__(self):
+        return iter(("override",))
+
+    def __repr__(self):
+        return "override repr"
+
+
+set_subclass = SetSubclass((1, 2))
+frozen_subclass = FrozenSubclass((1, 2))
+assert sorted(set.__iter__(set_subclass)) == [1, 2]
+assert sorted(frozenset.__iter__(frozen_subclass)) == [1, 2]
+assert set.__repr__(set_subclass) == "SetSubclass({1, 2})"
+assert frozenset.__repr__(frozen_subclass) == "FrozenSubclass({1, 2})"
+assert set.__len__(set_subclass) == 2
+assert frozenset.__len__(frozen_subclass) == 2
+assert isinstance(frozenset.__hash__(frozen_subclass), int)
+
+print("OK")

--- a/pyre/extra_tests/parity_tests/slice_python314.py
+++ b/pyre/extra_tests/parity_tests/slice_python314.py
@@ -33,4 +33,38 @@ except TypeError:
 else:
     raise AssertionError("slice component hash error")
 
+for name, call_args in (
+    ("__repr__", (42,)),
+    ("__hash__", (42,)),
+    ("__reduce__", (42,)),
+    ("__eq__", (42, a)),
+    ("__ne__", (42, a)),
+    ("__lt__", (42, a)),
+    ("__le__", (42, a)),
+    ("__gt__", (42, a)),
+    ("__ge__", (42, a)),
+    ("indices", (42, 3)),
+):
+    try:
+        getattr(slice, name)(*call_args)
+    except TypeError:
+        pass
+    else:
+        raise AssertionError(f"slice.{name} accepted a foreign receiver")
+
+for name in ("__repr__", "__hash__", "__reduce__"):
+    try:
+        getattr(slice, name)()
+    except TypeError:
+        pass
+    else:
+        raise AssertionError(f"slice.{name} accepted a missing receiver")
+
+try:
+    slice.__new__(42, 1)
+except TypeError:
+    pass
+else:
+    raise AssertionError("slice.__new__ accepted a non-type class")
+
 print("OK")

--- a/pyre/extra_tests/parity_tests/staticmethod_protocol.py
+++ b/pyre/extra_tests/parity_tests/staticmethod_protocol.py
@@ -147,6 +147,15 @@ assert type(sub) is StaticMethodSubclass
 assert sub(5, b=6) == "11"
 assert sub.__func__ is wrapped
 
+
+class CallingStaticMethod(staticmethod):
+    def __call__(self, *args, **kwargs):
+        return "override", args, kwargs
+
+
+calling_sub = CallingStaticMethod(wrapped)
+assert calling_sub(5, b=6) == ("override", (5,), {"b": 6})
+
 alias = staticmethod[int]
 assert type(alias).__name__ == "GenericAlias"
 assert alias.__origin__ is staticmethod

--- a/pyre/extra_tests/parity_tests/tuple_python314.py
+++ b/pyre/extra_tests/parity_tests/tuple_python314.py
@@ -1,0 +1,125 @@
+EXPECTED = {
+    "__add__",
+    "__class_getitem__",
+    "__contains__",
+    "__doc__",
+    "__eq__",
+    "__ge__",
+    "__getitem__",
+    "__getnewargs__",
+    "__gt__",
+    "__hash__",
+    "__iter__",
+    "__le__",
+    "__len__",
+    "__lt__",
+    "__mul__",
+    "__ne__",
+    "__new__",
+    "__repr__",
+    "__rmul__",
+    "count",
+    "index",
+}
+
+assert set(tuple.__dict__) == EXPECTED
+
+WRAPPER_DESCRIPTORS = {
+    "__add__",
+    "__contains__",
+    "__eq__",
+    "__ge__",
+    "__getitem__",
+    "__gt__",
+    "__hash__",
+    "__iter__",
+    "__le__",
+    "__len__",
+    "__lt__",
+    "__mul__",
+    "__ne__",
+    "__repr__",
+    "__rmul__",
+}
+
+METHOD_DESCRIPTORS = {"__getnewargs__", "count", "index"}
+
+for name in WRAPPER_DESCRIPTORS:
+    descriptor = tuple.__dict__[name]
+    try:
+        descriptor([])
+    except TypeError as exc:
+        assert str(exc) == (
+            f"descriptor '{name}' requires a 'tuple' object but received a 'list'"
+        )
+    else:
+        raise AssertionError(f"tuple.{name} accepted a list receiver")
+
+    try:
+        descriptor()
+    except TypeError as exc:
+        assert str(exc) == f"descriptor '{name}' of 'tuple' object needs an argument"
+    else:
+        raise AssertionError(f"tuple.{name} accepted a missing receiver")
+
+for name in METHOD_DESCRIPTORS:
+    descriptor = tuple.__dict__[name]
+    try:
+        descriptor([])
+    except TypeError as exc:
+        assert str(exc) == (
+            f"descriptor '{name}' for 'tuple' objects doesn't apply to a 'list' object"
+        )
+    else:
+        raise AssertionError(f"tuple.{name} accepted a list receiver")
+
+    try:
+        descriptor()
+    except TypeError as exc:
+        assert str(exc) == f"unbound method tuple.{name}() needs an argument"
+    else:
+        raise AssertionError(f"tuple.{name} accepted a missing receiver")
+
+
+class EqualToNeedle:
+    def __init__(self, label):
+        self.label = label
+
+    def __eq__(self, other):
+        return other == "needle"
+
+
+values = (EqualToNeedle("first"), 0, EqualToNeedle("second"))
+assert values.count("needle") == 2
+assert values.index("needle") == 0
+assert values.index("needle", 1) == 2
+assert values.index("needle", -1) == 2
+
+
+class Index:
+    def __init__(self, value):
+        self.value = value
+
+    def __index__(self):
+        return self.value
+
+
+assert values.index("needle", Index(1), Index(3)) == 2
+try:
+    values.index("needle", 1, 2)
+except ValueError as exc:
+    assert str(exc) == "tuple.index(x): x not in tuple"
+else:
+    raise AssertionError("tuple.index ignored stop")
+
+
+class TupleSubclass(tuple):
+    pass
+
+
+subclass = TupleSubclass((1, 2, 1))
+assert tuple.count(subclass, 1) == 2
+assert tuple.index(subclass, 2) == 1
+assert tuple.__getnewargs__(subclass) == ((1, 2, 1),)
+
+print("OK")

--- a/pyre/pyre-interpreter/Cargo.toml
+++ b/pyre/pyre-interpreter/Cargo.toml
@@ -43,6 +43,7 @@ majit-metainterp = { workspace = true }
 stacker = { workspace = true }
 rustpython-compiler = { workspace = true }
 rustpython-compiler-core = { workspace = true }
+num-complex = { workspace = true }
 malachite-bigint = { workspace = true }
 num-traits = { workspace = true }
 num-integer = { workspace = true }

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -2063,21 +2063,17 @@ pub(crate) fn range_iter_setstate_method(args: &[PyObjectRef]) -> PyResult {
     unsafe {
         if pyre_object::is_range_iter(args[0]) {
             // CPython 3.14 `rangeiter_setstate`: `PyLong_AsLong`, so an
-            // overflowing Python int raises instead of being clipped.
-            if !(is_int(args[1]) || is_long(args[1]) || is_bool(args[1])) {
-                return Err(PyError::type_error("state must be an int"));
-            }
-            let mut state = BigInt::from(int_w(args[1])?);
-            if state < BigInt::zero() {
-                state = BigInt::zero();
-            }
+            // overflowing Python int raises instead of being clipped. Unlike
+            // the long variant, PyLong_AsLong also accepts `__index__`.
+            let state = int_w(space_index(args[1])?).map_err(|err| {
+                if err.kind == PyErrorKind::OverflowError {
+                    PyError::overflow_error("Python int too large to convert to C long")
+                } else {
+                    err
+                }
+            })?;
             let (current, remaining, step) = pyre_object::w_range_iter_fields(args[0]);
-            let remaining_b = BigInt::from(remaining);
-            if state > remaining_b {
-                state = remaining_b;
-            }
-            let state_obj = pyre_object::range_bigint_to_obj(state);
-            let skipped = pyre_object::range_obj_as_i64(state_obj).unwrap_or(remaining);
+            let skipped = state.clamp(0, remaining);
             let next = (current as i128 + skipped as i128 * step as i128) as i64;
             pyre_object::w_range_iter_set_cursor(args[0], next, remaining - skipped);
         } else {

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -2508,21 +2508,49 @@ unsafe fn pull_iterator_tuple(
 /// `(map, (func, *iterators))`, with a trailing `True` when `strict`
 /// (CPython 3.14).  The captured iterators carry their positions.
 pub(crate) fn map_reduce_method(args: &[PyObjectRef]) -> PyResult {
+    let self_ = map_receiver(args, "__reduce__")?;
     unsafe {
-        let w_fun = pyre_object::functional::w_map_get_fun(args[0]);
-        let w_iterators = pyre_object::functional::w_map_get_iterators(args[0]);
+        let _roots = pyre_object::gc_roots::push_roots();
+        pyre_object::gc_roots::pin_root(self_);
+        let self_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+        let self_ = pyre_object::gc_roots::shadow_stack_get(self_slot);
+        let self_type = crate::typedef::r#type(self_).unwrap_or(pyre_object::PY_NULL);
+        pyre_object::gc_roots::pin_root(self_type);
+        let self_type_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+        let w_fun = pyre_object::functional::w_map_get_fun(self_);
+        pyre_object::gc_roots::pin_root(w_fun);
+        let fun_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+        let w_iterators = pyre_object::functional::w_map_get_iterators(self_);
+        pyre_object::gc_roots::pin_root(w_iterators);
+        let iterators_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         let n = pyre_object::w_list_len(w_iterators);
         let mut state_items = Vec::with_capacity(n as usize + 1);
-        state_items.push(w_fun);
+        state_items.push(pyre_object::gc_roots::shadow_stack_get(fun_slot));
         for i in 0..n {
-            state_items.push(pyre_object::w_list_getitem(w_iterators, i as i64).unwrap());
+            let w_iter = pyre_object::w_list_getitem(
+                pyre_object::gc_roots::shadow_stack_get(iterators_slot),
+                i as i64,
+            )
+            .unwrap();
+            pyre_object::gc_roots::pin_root(w_iter);
+            state_items.push(w_iter);
         }
         let state = w_tuple_new(state_items);
-        let map_fn = builtin_callable("map");
-        if pyre_object::functional::w_map_get_strict(args[0]) {
-            Ok(w_tuple_new(vec![map_fn, state, w_bool_from(true)]))
+        pyre_object::gc_roots::pin_root(state);
+        let state_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+        if pyre_object::functional::w_map_get_strict(pyre_object::gc_roots::shadow_stack_get(
+            self_slot,
+        )) {
+            Ok(w_tuple_new(vec![
+                pyre_object::gc_roots::shadow_stack_get(self_type_slot),
+                pyre_object::gc_roots::shadow_stack_get(state_slot),
+                w_bool_from(true),
+            ]))
         } else {
-            Ok(w_tuple_new(vec![map_fn, state]))
+            Ok(w_tuple_new(vec![
+                pyre_object::gc_roots::shadow_stack_get(self_type_slot),
+                pyre_object::gc_roots::shadow_stack_get(state_slot),
+            ]))
         }
     }
 }
@@ -2530,11 +2558,40 @@ pub(crate) fn map_reduce_method(args: &[PyObjectRef]) -> PyResult {
 /// `map.__setstate__(strict)` — CPython 3.14: set the `strict` flag from the
 /// unpickled state.
 pub(crate) fn map_setstate_method(args: &[PyObjectRef]) -> PyResult {
-    let strict = is_true(args[1])?;
+    let self_ = map_receiver(args, "__setstate__")?;
+    let state = args.get(1).copied().unwrap_or(pyre_object::PY_NULL);
+    let _roots = pyre_object::gc_roots::push_roots();
+    pyre_object::gc_roots::pin_root(self_);
+    let self_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+    pyre_object::gc_roots::pin_root(state);
+    let state_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+    let strict = is_true(unsafe { pyre_object::gc_roots::shadow_stack_get(state_slot) })?;
     unsafe {
-        pyre_object::functional::w_map_set_strict(args[0], strict);
+        pyre_object::functional::w_map_set_strict(
+            pyre_object::gc_roots::shadow_stack_get(self_slot),
+            strict,
+        );
     }
     Ok(w_none())
+}
+
+fn map_receiver(args: &[PyObjectRef], name: &str) -> Result<PyObjectRef, PyError> {
+    let self_ = args.first().copied().unwrap_or(pyre_object::PY_NULL);
+    if self_.is_null() || !unsafe { pyre_object::functional::is_map(self_) } {
+        return Err(PyError::type_error(format!(
+            "descriptor '{name}' for 'map' objects doesn't apply to a '{}' object",
+            object_functionstr_type_name(self_),
+        )));
+    }
+    Ok(self_)
+}
+
+pub(crate) fn map_iter_method(args: &[PyObjectRef]) -> PyResult {
+    map_receiver(args, "__iter__")
+}
+
+pub(crate) fn map_next_method(args: &[PyObjectRef]) -> PyResult {
+    next(map_receiver(args, "__next__")?)
 }
 
 /// `zip.__reduce__()` — `functional.py:1081-1087 W_Zip.descr_reduce`:
@@ -10633,12 +10690,35 @@ pub fn next(obj: PyObjectRef) -> PyResult {
         // (strict raises on mismatch).
         if pyre_object::functional::is_map(obj) {
             use pyre_object::functional as mo;
+            let _roots = pyre_object::gc_roots::push_roots();
+            pyre_object::gc_roots::pin_root(obj);
+            let obj_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+            let obj = pyre_object::gc_roots::shadow_stack_get(obj_slot);
             let w_iterators = mo::w_map_get_iterators(obj);
+            pyre_object::gc_roots::pin_root(w_iterators);
+            let iterators_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
             let strict = mo::w_map_get_strict(obj);
-            return match pull_iterator_tuple(w_iterators, strict, "map")? {
+            return match pull_iterator_tuple(
+                pyre_object::gc_roots::shadow_stack_get(iterators_slot),
+                strict,
+                "map",
+            )? {
                 Some(items) => {
-                    let w_fun = mo::w_map_get_fun(obj);
-                    crate::call::call_function_impl_result(w_fun, &items)
+                    let items_base = pyre_object::gc_roots::shadow_stack_len();
+                    for &item in &items {
+                        pyre_object::gc_roots::pin_root(item);
+                    }
+                    let w_fun =
+                        mo::w_map_get_fun(pyre_object::gc_roots::shadow_stack_get(obj_slot));
+                    pyre_object::gc_roots::pin_root(w_fun);
+                    let fun_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+                    let rooted_items: Vec<_> = (0..items.len())
+                        .map(|index| pyre_object::gc_roots::shadow_stack_get(items_base + index))
+                        .collect();
+                    crate::call::call_function_impl_result(
+                        pyre_object::gc_roots::shadow_stack_get(fun_slot),
+                        &rooted_items,
+                    )
                 }
                 None => Err(PyError::stop_iteration()),
             };

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -2145,9 +2145,23 @@ pub(crate) fn dict_view_iter_length_hint_method(args: &[PyObjectRef]) -> PyResul
 /// `enumerate.__reduce__()` — `functional.py W_Enumerate.descr_reduce`:
 /// `(enumerate, (source_iter, index))`.
 pub(crate) fn enumerate_reduce_method(args: &[PyObjectRef]) -> PyResult {
+    let self_ = args.first().copied().unwrap_or(pyre_object::PY_NULL);
+    if self_.is_null() || !unsafe { pyre_object::functional::is_enumerate(self_) } {
+        return Err(PyError::type_error(format!(
+            "descriptor '__reduce__' for 'enumerate' objects doesn't apply to a '{}' object",
+            object_functionstr_type_name(self_),
+        )));
+    }
     unsafe {
-        let i64_index = pyre_object::functional::w_enumerate_get_index(args[0]);
-        let raw = pyre_object::functional::w_enumerate_get_iter_or_list(args[0]);
+        // `descr___reduce__` may allocate while normalising the list fast path.
+        // Keep `self` live and reload it before every later field read, matching
+        // the GC-transformed RPython object's rooted `self` local.
+        let _roots = pyre_object::gc_roots::push_roots();
+        pyre_object::gc_roots::pin_root(args[0]);
+        let self_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+        let self_ = pyre_object::gc_roots::shadow_stack_get(self_slot);
+        let i64_index = pyre_object::functional::w_enumerate_get_index(self_);
+        let raw = pyre_object::functional::w_enumerate_get_iter_or_list(self_);
         let w_iter = if raw.is_null() {
             // Exhausted enumerate (`:294-295` set `w_iter_or_list` to
             // null); substitute an empty seq-iter so the reduce stays
@@ -2167,15 +2181,55 @@ pub(crate) fn enumerate_reduce_method(args: &[PyObjectRef]) -> PyResult {
         } else {
             raw
         };
-        let w_index_slot = pyre_object::functional::w_enumerate_get_w_index(args[0]);
+        pyre_object::gc_roots::pin_root(w_iter);
+        let iter_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+        let self_ = pyre_object::gc_roots::shadow_stack_get(self_slot);
+        let w_index_slot = pyre_object::functional::w_enumerate_get_w_index(self_);
         let index = if w_index_slot.is_null() {
             w_int_new(i64_index)
         } else {
             w_index_slot
         };
-        let state = w_tuple_new(vec![w_iter, index]);
-        Ok(w_tuple_new(vec![builtin_callable("enumerate"), state]))
+        pyre_object::gc_roots::pin_root(index);
+        let index_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+        let state = w_tuple_new(vec![
+            pyre_object::gc_roots::shadow_stack_get(iter_slot),
+            pyre_object::gc_roots::shadow_stack_get(index_slot),
+        ]);
+        pyre_object::gc_roots::pin_root(state);
+        let state_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+        Ok(w_tuple_new(vec![
+            builtin_callable("enumerate"),
+            pyre_object::gc_roots::shadow_stack_get(state_slot),
+        ]))
     }
+}
+
+/// `W_Enumerate.descr___iter__` receiver-unwrapping parity. PyPy's
+/// `interp2app` binds `self: W_Enumerate`, so a direct descriptor call with a
+/// foreign object raises before the body returns `self`.
+pub(crate) fn enumerate_iter_method(args: &[PyObjectRef]) -> PyResult {
+    let self_ = args.first().copied().unwrap_or(pyre_object::PY_NULL);
+    if self_.is_null() || !unsafe { pyre_object::functional::is_enumerate(self_) } {
+        return Err(PyError::type_error(format!(
+            "descriptor '__iter__' requires a 'enumerate' object but received a '{}'",
+            object_functionstr_type_name(self_),
+        )));
+    }
+    Ok(self_)
+}
+
+/// `W_Enumerate.descr_next` receiver-unwrapping parity; the actual line-by-line
+/// iteration state machine remains in [`next`].
+pub(crate) fn enumerate_next_method(args: &[PyObjectRef]) -> PyResult {
+    let self_ = args.first().copied().unwrap_or(pyre_object::PY_NULL);
+    if self_.is_null() || !unsafe { pyre_object::functional::is_enumerate(self_) } {
+        return Err(PyError::type_error(format!(
+            "descriptor '__next__' requires a 'enumerate' object but received a '{}'",
+            object_functionstr_type_name(self_),
+        )));
+    }
+    next(self_)
 }
 
 /// `reversed.__reduce__()` — `functional.py:407-417
@@ -10790,6 +10844,13 @@ pub fn next(obj: PyObjectRef) -> PyResult {
         }
         if pyre_object::functional::is_enumerate(obj) {
             use pyre_object::functional as eo;
+            // `space.add` and `space.next` below can allocate or invoke Python.
+            // RPython's GC transform keeps `self` and the active bigint Box
+            // rooted; mirror that explicitly and reload fields after calls.
+            let _roots = pyre_object::gc_roots::push_roots();
+            pyre_object::gc_roots::pin_root(obj);
+            let obj_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+            let obj = pyre_object::gc_roots::shadow_stack_get(obj_slot);
             let w_index_slot = eo::w_enumerate_get_w_index(obj);
             let mut w_iter_or_list = eo::w_enumerate_get_iter_or_list(obj);
             let mut w_item: PyObjectRef = pyre_object::PY_NULL;
@@ -10820,10 +10881,23 @@ pub fn next(obj: PyObjectRef) -> PyResult {
                             // Promote to bigint slot per `:299-302`.
                             let w_idx =
                                 pyre_object::w_long_new(::malachite_bigint::BigInt::from(index));
+                            pyre_object::gc_roots::pin_root(w_idx);
+                            let w_idx_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
                             let one =
                                 pyre_object::w_long_new(::malachite_bigint::BigInt::from(1i64));
-                            let bumped = add(w_idx, one)?;
-                            eo::w_enumerate_set_w_index(obj, bumped);
+                            pyre_object::gc_roots::pin_root(one);
+                            let one_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+                            let bumped = add(
+                                pyre_object::gc_roots::shadow_stack_get(w_idx_slot),
+                                pyre_object::gc_roots::shadow_stack_get(one_slot),
+                            )?;
+                            pyre_object::gc_roots::pin_root(bumped);
+                            let bumped_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+                            let obj = pyre_object::gc_roots::shadow_stack_get(obj_slot);
+                            eo::w_enumerate_set_w_index(
+                                obj,
+                                pyre_object::gc_roots::shadow_stack_get(bumped_slot),
+                            );
                             eo::w_enumerate_set_index(obj, -1);
                         }
                     }
@@ -10831,21 +10905,42 @@ pub fn next(obj: PyObjectRef) -> PyResult {
                 w_index = pyre_object::w_int_new(index);
             } else {
                 // Bigint slot active — bump via `space.add`.
+                pyre_object::gc_roots::pin_root(w_index_slot);
+                let w_index_slot_root = pyre_object::gc_roots::shadow_stack_len() - 1;
                 let one = pyre_object::w_int_new(1);
-                let bumped = add(w_index_slot, one)?;
-                eo::w_enumerate_set_w_index(obj, bumped);
-                w_index = w_index_slot;
+                pyre_object::gc_roots::pin_root(one);
+                let one_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+                let bumped = add(
+                    pyre_object::gc_roots::shadow_stack_get(w_index_slot_root),
+                    pyre_object::gc_roots::shadow_stack_get(one_slot),
+                )?;
+                pyre_object::gc_roots::pin_root(bumped);
+                let bumped_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+                let obj = pyre_object::gc_roots::shadow_stack_get(obj_slot);
+                eo::w_enumerate_set_w_index(
+                    obj,
+                    pyre_object::gc_roots::shadow_stack_get(bumped_slot),
+                );
+                w_index = pyre_object::gc_roots::shadow_stack_get(w_index_slot_root);
             }
+            pyre_object::gc_roots::pin_root(w_index);
+            let result_index_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
             if w_item.is_null() {
                 // Re-read slot — list fast-path already set w_item;
                 // otherwise we need to pull from the iterator.
+                let obj = pyre_object::gc_roots::shadow_stack_get(obj_slot);
                 w_iter_or_list = eo::w_enumerate_get_iter_or_list(obj);
                 if w_iter_or_list.is_null() {
                     return Err(PyError::stop_iteration());
                 }
-                w_item = next(w_iter_or_list)?;
+                pyre_object::gc_roots::pin_root(w_iter_or_list);
+                let iter_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+                w_item = next(pyre_object::gc_roots::shadow_stack_get(iter_slot))?;
             }
-            return Ok(pyre_object::w_tuple_new(vec![w_index, w_item]));
+            return Ok(pyre_object::w_tuple_new(vec![
+                pyre_object::gc_roots::shadow_stack_get(result_index_slot),
+                w_item,
+            ]));
         }
         // `pypy/module/__builtin__/functional.py:385-405
         // W_ReversedIterator.descr_next` — `getitem(sequence, remaining)`

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -2160,6 +2160,9 @@ pub(crate) fn enumerate_reduce_method(args: &[PyObjectRef]) -> PyResult {
         pyre_object::gc_roots::pin_root(args[0]);
         let self_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         let self_ = pyre_object::gc_roots::shadow_stack_get(self_slot);
+        let self_type = crate::typedef::r#type(self_).unwrap_or(pyre_object::PY_NULL);
+        pyre_object::gc_roots::pin_root(self_type);
+        let self_type_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         let i64_index = pyre_object::functional::w_enumerate_get_index(self_);
         let raw = pyre_object::functional::w_enumerate_get_iter_or_list(self_);
         let w_iter = if raw.is_null() {
@@ -2199,7 +2202,7 @@ pub(crate) fn enumerate_reduce_method(args: &[PyObjectRef]) -> PyResult {
         pyre_object::gc_roots::pin_root(state);
         let state_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         Ok(w_tuple_new(vec![
-            builtin_callable("enumerate"),
+            pyre_object::gc_roots::shadow_stack_get(self_type_slot),
             pyre_object::gc_roots::shadow_stack_get(state_slot),
         ]))
     }
@@ -2235,22 +2238,46 @@ pub(crate) fn enumerate_next_method(args: &[PyObjectRef]) -> PyResult {
 /// `reversed.__reduce__()` — `functional.py:407-417
 /// W_ReversedIterator.descr___reduce__`: `(reversed, (sequence,),
 /// remaining)` while live; `(reversed, ((),))` once exhausted (the slot
-/// is cleared to `PY_NULL`).  The reconstructor is the `reversed`
-/// builtin so `pickle` recreates the iterator via `reversed(sequence)`.
+/// is cleared to `PY_NULL`).  As in PyPy, the reconstructor is
+/// `space.type(self)`, preserving subclasses while recreating the iterator
+/// through the same reversed-sequence constructor protocol.
 pub(crate) fn reversed_reduce_method(args: &[PyObjectRef]) -> PyResult {
+    let self_ = reversed_receiver(args, "__reduce__")?;
     unsafe {
-        let seq = pyre_object::functional::w_reversed_get_sequence(args[0]);
+        let _roots = pyre_object::gc_roots::push_roots();
+        pyre_object::gc_roots::pin_root(self_);
+        let self_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+        let self_ = pyre_object::gc_roots::shadow_stack_get(self_slot);
+        let self_type = crate::typedef::r#type(self_).unwrap_or(pyre_object::PY_NULL);
+        pyre_object::gc_roots::pin_root(self_type);
+        let self_type_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+        let seq = pyre_object::functional::w_reversed_get_sequence(self_);
         if !seq.is_null() {
-            let remaining = pyre_object::functional::w_reversed_get_remaining(args[0]);
-            let state = w_tuple_new(vec![seq]);
+            pyre_object::gc_roots::pin_root(seq);
+            let seq_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+            let remaining = pyre_object::functional::w_reversed_get_remaining(self_);
+            let state = w_tuple_new(vec![pyre_object::gc_roots::shadow_stack_get(seq_slot)]);
+            pyre_object::gc_roots::pin_root(state);
+            let state_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+            let w_remaining = w_int_new(remaining);
+            pyre_object::gc_roots::pin_root(w_remaining);
+            let remaining_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
             Ok(w_tuple_new(vec![
-                builtin_callable("reversed"),
-                state,
-                w_int_new(remaining),
+                pyre_object::gc_roots::shadow_stack_get(self_type_slot),
+                pyre_object::gc_roots::shadow_stack_get(state_slot),
+                pyre_object::gc_roots::shadow_stack_get(remaining_slot),
             ]))
         } else {
-            let state = w_tuple_new(vec![w_tuple_new(vec![])]);
-            Ok(w_tuple_new(vec![builtin_callable("reversed"), state]))
+            let empty = w_tuple_new(vec![]);
+            pyre_object::gc_roots::pin_root(empty);
+            let empty_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+            let state = w_tuple_new(vec![pyre_object::gc_roots::shadow_stack_get(empty_slot)]);
+            pyre_object::gc_roots::pin_root(state);
+            let state_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+            Ok(w_tuple_new(vec![
+                pyre_object::gc_roots::shadow_stack_get(self_type_slot),
+                pyre_object::gc_roots::shadow_stack_get(state_slot),
+            ]))
         }
     }
 }
@@ -2259,16 +2286,40 @@ pub(crate) fn reversed_reduce_method(args: &[PyObjectRef]) -> PyResult {
 /// descr___setstate__`: set `remaining` then clamp into `[-1, n-1]`
 /// (`n == len(sequence)`, or 0 once exhausted).
 pub(crate) fn reversed_setstate_method(args: &[PyObjectRef]) -> PyResult {
-    let mut remaining = int_w(args[1])?;
+    let self_ = reversed_receiver(args, "__setstate__")?;
+    let state = args.get(1).copied().unwrap_or(pyre_object::PY_NULL);
+    if state.is_null()
+        || !unsafe {
+            pyre_object::is_int(state) || pyre_object::is_long(state) || pyre_object::is_bool(state)
+        }
+    {
+        return Err(PyError::type_error("an integer is required"));
+    }
+    let _roots = pyre_object::gc_roots::push_roots();
+    pyre_object::gc_roots::pin_root(self_);
+    let self_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+    pyre_object::gc_roots::pin_root(state);
+    let state_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+    let mut remaining = int_w(unsafe { pyre_object::gc_roots::shadow_stack_get(state_slot) })?;
     unsafe {
-        let seq = pyre_object::functional::w_reversed_get_sequence(args[0]);
-        let n = if !seq.is_null() { len_w(seq)? } else { 0 };
+        let self_ = pyre_object::gc_roots::shadow_stack_get(self_slot);
+        let seq = pyre_object::functional::w_reversed_get_sequence(self_);
+        pyre_object::gc_roots::pin_root(seq);
+        let seq_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+        let n = if !seq.is_null() {
+            len_w(pyre_object::gc_roots::shadow_stack_get(seq_slot))?
+        } else {
+            0
+        };
         if remaining < -1 {
             remaining = -1;
         } else if remaining > n - 1 {
             remaining = n - 1;
         }
-        pyre_object::functional::w_reversed_set_remaining(args[0], remaining);
+        pyre_object::functional::w_reversed_set_remaining(
+            pyre_object::gc_roots::shadow_stack_get(self_slot),
+            remaining,
+        );
     }
     Ok(w_none())
 }
@@ -2276,12 +2327,23 @@ pub(crate) fn reversed_setstate_method(args: &[PyObjectRef]) -> PyResult {
 /// `reversed.__length_hint__()` — `functional.py:374-383
 /// descr_length_hint`: elements not yet produced, `0` once exhausted.
 pub(crate) fn reversed_length_hint_method(args: &[PyObjectRef]) -> PyResult {
+    let self_ = reversed_receiver(args, "__length_hint__")?;
+    let _roots = pyre_object::gc_roots::push_roots();
+    pyre_object::gc_roots::pin_root(self_);
+    let self_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     unsafe {
-        let remaining = pyre_object::functional::w_reversed_get_remaining(args[0]);
+        let self_ = pyre_object::gc_roots::shadow_stack_get(self_slot);
+        let remaining = pyre_object::functional::w_reversed_get_remaining(self_);
         let mut res = 0i64;
         if remaining >= 0 {
-            let seq = pyre_object::functional::w_reversed_get_sequence(args[0]);
-            let total = if !seq.is_null() { len_w(seq)? } else { 0 };
+            let seq = pyre_object::functional::w_reversed_get_sequence(self_);
+            pyre_object::gc_roots::pin_root(seq);
+            let seq_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+            let total = if !seq.is_null() {
+                len_w(pyre_object::gc_roots::shadow_stack_get(seq_slot))?
+            } else {
+                0
+            };
             let rem_length = remaining + 1;
             if rem_length <= total {
                 res = rem_length;
@@ -2289,6 +2351,29 @@ pub(crate) fn reversed_length_hint_method(args: &[PyObjectRef]) -> PyResult {
         }
         Ok(w_int_new(res))
     }
+}
+
+fn reversed_receiver(args: &[PyObjectRef], name: &str) -> Result<PyObjectRef, PyError> {
+    let self_ = args.first().copied().unwrap_or(pyre_object::PY_NULL);
+    if self_.is_null() || !unsafe { pyre_object::functional::is_reversed(self_) } {
+        return Err(PyError::type_error(format!(
+            "descriptor '{name}' for 'reversed' objects doesn't apply to a '{}' object",
+            object_functionstr_type_name(self_),
+        )));
+    }
+    Ok(self_)
+}
+
+/// `W_ReversedIterator.descr___iter__` with the receiver check supplied by
+/// PyPy's `interp2app` gateway before its one-line `return self` body.
+pub(crate) fn reversed_iter_method(args: &[PyObjectRef]) -> PyResult {
+    reversed_receiver(args, "__iter__")
+}
+
+/// `W_ReversedIterator.descr_next` gateway wrapper. The state-machine body is
+/// shared with the interpreter's [`next`] dispatcher below.
+pub(crate) fn reversed_next_method(args: &[PyObjectRef]) -> PyResult {
+    next(reversed_receiver(args, "__next__")?)
 }
 
 /// `filter.__reduce__()` — `functional.py:944-949 W_Filter.descr_reduce`:
@@ -10955,8 +11040,17 @@ pub fn next(obj: PyObjectRef) -> PyResult {
                 let _roots = pyre_object::gc_roots::push_roots();
                 pyre_object::gc_roots::pin_root(obj);
                 let obj_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
-                let seq = ro::w_reversed_get_sequence(obj);
-                match getitem(seq, w_int_new(remaining)) {
+                let seq =
+                    ro::w_reversed_get_sequence(pyre_object::gc_roots::shadow_stack_get(obj_slot));
+                pyre_object::gc_roots::pin_root(seq);
+                let seq_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+                let index = w_int_new(remaining);
+                pyre_object::gc_roots::pin_root(index);
+                let index_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+                match getitem(
+                    pyre_object::gc_roots::shadow_stack_get(seq_slot),
+                    pyre_object::gc_roots::shadow_stack_get(index_slot),
+                ) {
                     Ok(w_item) => {
                         ro::w_reversed_set_remaining(
                             pyre_object::gc_roots::shadow_stack_get(obj_slot),

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -2113,7 +2113,11 @@ pub(crate) fn dict_view_iter_reduce_method(args: &[PyObjectRef]) -> PyResult {
         let w_dict = pyre_object::dictmultiobject::w_dict_view_iterator_get_dict(args[0]);
         let kind = pyre_object::dictmultiobject::w_dict_view_iterator_get_kind(args[0]);
         let index = pyre_object::dictmultiobject::w_dict_view_iterator_get_index(args[0]);
-        let entries = pyre_object::w_dict_items(w_dict);
+        let reverse = pyre_object::dictmultiobject::w_dict_view_iterator_get_reverse(args[0]);
+        let mut entries = pyre_object::w_dict_items(w_dict);
+        if reverse {
+            entries.reverse();
+        }
         let mut items = Vec::new();
         for (k, v) in entries.into_iter().skip(index) {
             let item = match kind {
@@ -2132,8 +2136,12 @@ pub(crate) fn dict_view_iter_reduce_method(args: &[PyObjectRef]) -> PyResult {
 pub(crate) fn dict_view_iter_length_hint_method(args: &[PyObjectRef]) -> PyResult {
     unsafe {
         let w_dict = pyre_object::dictmultiobject::w_dict_view_iterator_get_dict(args[0]);
+        let startlen = pyre_object::dictmultiobject::w_dict_view_iterator_get_startlen(args[0]);
+        if pyre_object::w_dict_len(w_dict) != startlen {
+            return Ok(w_int_new(0));
+        }
         let index = pyre_object::dictmultiobject::w_dict_view_iterator_get_index(args[0]);
-        let remaining = (pyre_object::w_dict_len(w_dict) as i64) - (index as i64);
+        let remaining = (startlen as i64) - (index as i64);
         Ok(w_int_new(remaining.max(0)))
     }
 }
@@ -11053,7 +11061,17 @@ pub fn next(obj: PyObjectRef) -> PyResult {
                 ));
             }
             let index = dv::w_dict_view_iterator_get_index(obj);
-            let Some((k, mut v)) = pyre_object::dictmultiobject::w_dict_nth_item(dict, index)
+            if index >= startlen {
+                return Err(PyError::stop_iteration());
+            }
+            let reverse = dv::w_dict_view_iterator_get_reverse(obj);
+            let storage_index = if reverse {
+                startlen.saturating_sub(index + 1)
+            } else {
+                index
+            };
+            let Some((k, mut v)) =
+                pyre_object::dictmultiobject::w_dict_nth_item(dict, storage_index)
             else {
                 return Err(PyError::stop_iteration());
             };

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -4566,8 +4566,11 @@ pub(crate) unsafe fn object_getattribute_surrogate(
             }
             // typeobject.py:820-823: the type's own MRO value, bound through
             // `space.get(w_value, space.w_None, self)` = `__get__(None, type)`.
+            // Internally a null receiver distinguishes this class access from
+            // attribute access on the actual `None` singleton; `get` converts
+            // it back to `w_None` only for a Python-visible `__get__` call.
             if let Some(w_value) = lookup_in_type_wtf8(obj, name) {
-                if let Some(result) = get(w_value, w_none(), obj)? {
+                if let Some(result) = get(w_value, PY_NULL, obj)? {
                     return Ok(result);
                 }
                 return Ok(w_value);
@@ -5192,11 +5195,11 @@ fn object_getattr_miss(obj: PyObjectRef, name: &str, call_getattr: bool) -> PyRe
             // typeobject.py:820-823 — the type's own MRO value, bound via
             // `space.get(w_value, space.w_None, self)` = `__get__(None, type)`
             // (functions stay unbound, classmethod binds the class, a custom
-            // descriptor sees `obj is None`).  The receiver must be the `None`
-            // singleton, not a null pointer, or a Python
-            // `__get__(self, obj, objtype=None)` loses its `obj` argument.
+            // descriptor sees `obj is None`).  A null internal receiver keeps
+            // this distinct from looking up a descriptor on the actual None
+            // singleton; `get` materialises `w_None` for custom `__get__`.
             if let Some(value) = lookup_in_type_where(obj, name) {
-                match get(value, w_none(), obj) {
+                match get(value, PY_NULL, obj) {
                     Ok(Some(result)) => return Ok(result),
                     Ok(None) => return Ok(value),
                     Err(e) => {
@@ -7542,7 +7545,7 @@ pub(crate) unsafe fn get(
         if std::ptr::eq(ob_type, &crate::FUNCTION_TYPE as *const _)
             && crate::is_builtin_code(crate::function_get_code(descr) as pyre_object::PyObjectRef)
         {
-            if obj.is_null() || is_none(obj) {
+            if obj.is_null() {
                 return Ok(Some(descr));
             }
             return Ok(Some(pyre_object::w_method_new(descr, obj, w_type)));
@@ -7551,10 +7554,10 @@ pub(crate) unsafe fn get(
 
     // property: PyPy W_Property.get → call fget(obj)
     if is_property(descr) {
-        // W_Property.get: `if space.is_w(w_obj, space.w_None): return self`
-        // — a `None` receiver (class-level access via `__get__(None, type)`)
-        // returns the property itself, the same as a null receiver.
-        if obj.is_null() || is_none(obj) {
+        // W_Property.get receives `space.w_None` for class access.  Internally
+        // that state is a null pointer so the actual None singleton can still
+        // be a property-bearing instance.
+        if obj.is_null() {
             return Ok(Some(descr));
         }
         let fget = w_property_get_fget(descr);
@@ -7574,7 +7577,7 @@ pub(crate) unsafe fn get(
     //   return w_result
     if pyre_object::is_member(descr) {
         // typedef.py:507-508
-        if obj.is_null() || is_none(obj) {
+        if obj.is_null() {
             return Ok(Some(descr));
         }
         // typedef.py:510: self.typecheck(space, w_obj) → TypeError
@@ -7625,7 +7628,9 @@ pub(crate) unsafe fn get(
     if let Some(descr_type) = crate::typedef::r#type(descr) {
         if let Some(get_fn) = lookup_in_type_where(descr_type, "__get__") {
             if !get_fn.is_null() {
-                let result = crate::call::call_function_impl_result(get_fn, &[descr, obj, w_type])?;
+                let visible_obj = if obj.is_null() { w_none() } else { obj };
+                let result =
+                    crate::call::call_function_impl_result(get_fn, &[descr, visible_obj, w_type])?;
                 return Ok(Some(result));
             }
         }

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -2464,6 +2464,7 @@ unsafe fn pull_iterator_tuple(
     w_iterators: PyObjectRef,
     strict: bool,
     func_name: &str,
+    w_zip: Option<PyObjectRef>,
 ) -> Result<Option<Vec<PyObjectRef>>, PyError> {
     let n = pyre_object::w_list_len(w_iterators) as usize;
     if n == 0 {
@@ -2479,6 +2480,16 @@ unsafe fn pull_iterator_tuple(
     // later iterations dereference it again — a raw local would go stale.
     pyre_object::gc_roots::pin_root(w_iterators);
     let iters_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+    let zip_slot = w_zip.map(|zip| {
+        pyre_object::gc_roots::pin_root(zip);
+        pyre_object::gc_roots::shadow_stack_len() - 1
+    });
+    if let Some(slot) = zip_slot {
+        pyre_object::functional::w_zip_set_iteration_progress(
+            pyre_object::gc_roots::shadow_stack_get(slot),
+            0,
+        );
+    }
     let base = pyre_object::gc_roots::shadow_stack_len();
     for i in 0..n {
         let it = pyre_object::w_list_getitem(
@@ -2487,15 +2498,30 @@ unsafe fn pull_iterator_tuple(
         )
         .unwrap();
         match next(it) {
-            Ok(v) => pyre_object::gc_roots::pin_root(v),
+            Ok(v) => {
+                pyre_object::gc_roots::pin_root(v);
+                if let Some(slot) = zip_slot {
+                    pyre_object::functional::w_zip_set_iteration_progress(
+                        pyre_object::gc_roots::shadow_stack_get(slot),
+                        i + 1,
+                    );
+                }
+            }
             Err(e) if e.kind == PyErrorKind::StopIteration => {
                 if !strict {
                     return Ok(None);
                 }
                 // A StopIteration in strict mode is a length mismatch.
                 // `i` iterators yielded before this one ran dry.
-                if i > 0 {
-                    return Err(strict_zip_error(func_name, i, "shorter"));
+                let iteration_progress = if let Some(slot) = zip_slot {
+                    pyre_object::functional::w_zip_get_iteration_progress(
+                        pyre_object::gc_roots::shadow_stack_get(slot),
+                    )
+                } else {
+                    i
+                };
+                if iteration_progress > 0 {
+                    return Err(strict_zip_error(func_name, iteration_progress, "shorter"));
                 }
                 if n == 1 {
                     // A single iterable can never mismatch.
@@ -2636,19 +2662,45 @@ pub(crate) fn map_next_method(args: &[PyObjectRef]) -> PyResult {
 /// `zip.__reduce__()` — `functional.py:1081-1087 W_Zip.descr_reduce`:
 /// `(zip, (*iterators))`, with a trailing `True` when `strict`.
 pub(crate) fn zip_reduce_method(args: &[PyObjectRef]) -> PyResult {
+    let self_ = zip_receiver(args, "__reduce__")?;
     unsafe {
-        let w_iterators = pyre_object::functional::w_zip_get_iterators(args[0]);
+        let _roots = pyre_object::gc_roots::push_roots();
+        pyre_object::gc_roots::pin_root(self_);
+        let self_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+        let self_ = pyre_object::gc_roots::shadow_stack_get(self_slot);
+        let self_type = crate::typedef::r#type(self_).unwrap_or(pyre_object::PY_NULL);
+        pyre_object::gc_roots::pin_root(self_type);
+        let self_type_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+        let w_iterators = pyre_object::functional::w_zip_get_iterators(self_);
+        pyre_object::gc_roots::pin_root(w_iterators);
+        let iterators_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         let n = pyre_object::w_list_len(w_iterators);
         let mut state_items = Vec::with_capacity(n as usize);
         for i in 0..n {
-            state_items.push(pyre_object::w_list_getitem(w_iterators, i as i64).unwrap());
+            let w_iter = pyre_object::w_list_getitem(
+                pyre_object::gc_roots::shadow_stack_get(iterators_slot),
+                i as i64,
+            )
+            .unwrap();
+            pyre_object::gc_roots::pin_root(w_iter);
+            state_items.push(w_iter);
         }
         let state = w_tuple_new(state_items);
-        let zip_fn = builtin_callable("zip");
-        if pyre_object::functional::w_zip_get_strict(args[0]) {
-            Ok(w_tuple_new(vec![zip_fn, state, w_bool_from(true)]))
+        pyre_object::gc_roots::pin_root(state);
+        let state_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+        if pyre_object::functional::w_zip_get_strict(pyre_object::gc_roots::shadow_stack_get(
+            self_slot,
+        )) {
+            Ok(w_tuple_new(vec![
+                pyre_object::gc_roots::shadow_stack_get(self_type_slot),
+                pyre_object::gc_roots::shadow_stack_get(state_slot),
+                w_bool_from(true),
+            ]))
         } else {
-            Ok(w_tuple_new(vec![zip_fn, state]))
+            Ok(w_tuple_new(vec![
+                pyre_object::gc_roots::shadow_stack_get(self_type_slot),
+                pyre_object::gc_roots::shadow_stack_get(state_slot),
+            ]))
         }
     }
 }
@@ -2656,11 +2708,40 @@ pub(crate) fn zip_reduce_method(args: &[PyObjectRef]) -> PyResult {
 /// `zip.__setstate__(strict)` — `functional.py:1089-1091
 /// W_Zip.descr_setstate`: `self.strict = bool(state)`.
 pub(crate) fn zip_setstate_method(args: &[PyObjectRef]) -> PyResult {
-    let strict = is_true(args[1])?;
+    let self_ = zip_receiver(args, "__setstate__")?;
+    let state = args.get(1).copied().unwrap_or(pyre_object::PY_NULL);
+    let _roots = pyre_object::gc_roots::push_roots();
+    pyre_object::gc_roots::pin_root(self_);
+    let self_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+    pyre_object::gc_roots::pin_root(state);
+    let state_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+    let strict = is_true(unsafe { pyre_object::gc_roots::shadow_stack_get(state_slot) })?;
     unsafe {
-        pyre_object::functional::w_zip_set_strict(args[0], strict);
+        pyre_object::functional::w_zip_set_strict(
+            pyre_object::gc_roots::shadow_stack_get(self_slot),
+            strict,
+        );
     }
     Ok(w_none())
+}
+
+fn zip_receiver(args: &[PyObjectRef], name: &str) -> Result<PyObjectRef, PyError> {
+    let self_ = args.first().copied().unwrap_or(pyre_object::PY_NULL);
+    if self_.is_null() || !unsafe { pyre_object::functional::is_zip(self_) } {
+        return Err(PyError::type_error(format!(
+            "descriptor '{name}' for 'zip' objects doesn't apply to a '{}' object",
+            object_functionstr_type_name(self_),
+        )));
+    }
+    Ok(self_)
+}
+
+pub(crate) fn zip_iter_method(args: &[PyObjectRef]) -> PyResult {
+    zip_receiver(args, "__iter__")
+}
+
+pub(crate) fn zip_next_method(args: &[PyObjectRef]) -> PyResult {
+    next(zip_receiver(args, "__next__")?)
 }
 
 /// `pypy/interpreter/baseobjspace.py:870 finditem` — return the value
@@ -10750,6 +10831,7 @@ pub fn next(obj: PyObjectRef) -> PyResult {
                 pyre_object::gc_roots::shadow_stack_get(iterators_slot),
                 strict,
                 "map",
+                None,
             )? {
                 Some(items) => {
                     let items_base = pyre_object::gc_roots::shadow_stack_len();
@@ -10776,10 +10858,26 @@ pub fn next(obj: PyObjectRef) -> PyResult {
         // mismatch).
         if pyre_object::functional::is_zip(obj) {
             use pyre_object::functional as zo;
+            let _roots = pyre_object::gc_roots::push_roots();
+            pyre_object::gc_roots::pin_root(obj);
+            let obj_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+            let obj = pyre_object::gc_roots::shadow_stack_get(obj_slot);
             let w_iterators = zo::w_zip_get_iterators(obj);
+            pyre_object::gc_roots::pin_root(w_iterators);
+            let iterators_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
             let strict = zo::w_zip_get_strict(obj);
-            return match pull_iterator_tuple(w_iterators, strict, "zip")? {
-                Some(items) => Ok(pyre_object::w_tuple_new(items)),
+            return match pull_iterator_tuple(
+                pyre_object::gc_roots::shadow_stack_get(iterators_slot),
+                strict,
+                "zip",
+                Some(pyre_object::gc_roots::shadow_stack_get(obj_slot)),
+            )? {
+                Some(items) => {
+                    for &item in &items {
+                        pyre_object::gc_roots::pin_root(item);
+                    }
+                    Ok(pyre_object::w_tuple_new(items))
+                }
                 None => Err(PyError::stop_iteration()),
             };
         }

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -2894,7 +2894,12 @@ unsafe fn setitem_list_slice(obj: PyObjectRef, index: PyObjectRef, value: PyObje
     };
     if step == 1 {
         let s_lo = start.max(0) as usize;
-        let s_hi = stop.max(0) as usize;
+        // listobject.py passes `(start, step, slicelength)` to `setslice`;
+        // its contiguous replacement range is therefore
+        // `start..start+slicelength`.  A normalized slice such as `5:2`
+        // has zero length and inserts/deletes at 5, rather than forming the
+        // invalid Rust range `5..2`.
+        let s_hi = stop.max(start).max(0) as usize;
         pyre_object::listobject::w_list_setslice(obj, s_lo, s_hi, w_other)
             .expect("w_other is always a valid list");
         return Ok(w_none());

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -3968,6 +3968,7 @@ fn getattr_str_impl(obj: PyObjectRef, name: &str, call_getattr: bool) -> PyResul
             || pyre_object::interp_itertools::is_takewhile(obj)
             || pyre_object::interp_itertools::is_dropwhile(obj)
             || pyre_object::interp_itertools::is_filterfalse(obj)
+            || pyre_object::interp_itertools::is_compress(obj)
             || pyre_object::interp_itertools::is_pairwise(obj)
             || pyre_object::interp_itertools::is_cycle(obj)
             || pyre_object::interp_itertools::is_chain(obj)
@@ -10064,6 +10065,7 @@ pub fn is_iterable(obj: PyObjectRef) -> bool {
             || pyre_object::interp_itertools::is_takewhile(obj)
             || pyre_object::interp_itertools::is_dropwhile(obj)
             || pyre_object::interp_itertools::is_filterfalse(obj)
+            || pyre_object::interp_itertools::is_compress(obj)
             || pyre_object::interp_itertools::is_pairwise(obj)
             || pyre_object::interp_itertools::is_cycle(obj)
             || pyre_object::interp_itertools::is_chain(obj)
@@ -10309,6 +10311,7 @@ pub fn iter(obj: PyObjectRef) -> PyResult {
             || pyre_object::interp_itertools::is_takewhile(obj)
             || pyre_object::interp_itertools::is_dropwhile(obj)
             || pyre_object::interp_itertools::is_filterfalse(obj)
+            || pyre_object::interp_itertools::is_compress(obj)
             || pyre_object::interp_itertools::is_pairwise(obj)
             || pyre_object::interp_itertools::is_cycle(obj)
             || pyre_object::interp_itertools::is_chain(obj)
@@ -10771,6 +10774,38 @@ pub fn next(obj: PyObjectRef) -> PyResult {
                 };
                 if !pred {
                     return Ok(w_obj);
+                }
+            }
+        }
+        // itertools.compress — interp_itertools.py W_Compress.next_w.
+        // Pull data first, then its matching selector; exhaustion of either
+        // input stops the iterator.  Keep the owner and yielded data item
+        // rooted across both arbitrary Python iterator/truth calls.
+        if pyre_object::interp_itertools::is_compress(obj) {
+            let _roots = pyre_object::gc_roots::push_roots();
+            pyre_object::gc_roots::pin_root(obj);
+            let obj_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+            loop {
+                let _iteration_roots = pyre_object::gc_roots::push_roots();
+                let w_data = (*(pyre_object::gc_roots::shadow_stack_get(obj_slot)
+                    as *const pyre_object::interp_itertools::W_Compress))
+                    .w_data;
+                pyre_object::gc_roots::pin_root(w_data);
+                let data_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+                let w_item = next(pyre_object::gc_roots::shadow_stack_get(data_slot))?;
+                pyre_object::gc_roots::pin_root(w_item);
+                let item_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+
+                let w_selectors = (*(pyre_object::gc_roots::shadow_stack_get(obj_slot)
+                    as *const pyre_object::interp_itertools::W_Compress))
+                    .w_selectors;
+                pyre_object::gc_roots::pin_root(w_selectors);
+                let selectors_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+                let w_selector = next(pyre_object::gc_roots::shadow_stack_get(selectors_slot))?;
+                pyre_object::gc_roots::pin_root(w_selector);
+                let selector_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+                if is_true(pyre_object::gc_roots::shadow_stack_get(selector_slot))? {
+                    return Ok(pyre_object::gc_roots::shadow_stack_get(item_slot));
                 }
             }
         }

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -2382,17 +2382,56 @@ pub(crate) fn reversed_next_method(args: &[PyObjectRef]) -> PyResult {
 /// `filter(predicate, iterable)`; the captured iterator carries its
 /// position.
 pub(crate) fn filter_reduce_method(args: &[PyObjectRef]) -> PyResult {
+    let self_ = filter_receiver(args, "__reduce__")?;
     unsafe {
-        let w_predicate = pyre_object::functional::w_filter_get_predicate(args[0]);
-        let w_predicate = if w_predicate.is_null() {
+        let _roots = pyre_object::gc_roots::push_roots();
+        pyre_object::gc_roots::pin_root(self_);
+        let self_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+        let self_ = pyre_object::gc_roots::shadow_stack_get(self_slot);
+        let self_type = crate::typedef::r#type(self_).unwrap_or(pyre_object::PY_NULL);
+        pyre_object::gc_roots::pin_root(self_type);
+        let self_type_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+        let raw_predicate = pyre_object::functional::w_filter_get_predicate(self_);
+        let w_predicate = if raw_predicate.is_null() {
             w_none()
         } else {
-            w_predicate
+            raw_predicate
         };
-        let w_iterable = pyre_object::functional::w_filter_get_iterable(args[0]);
-        let state = w_tuple_new(vec![w_predicate, w_iterable]);
-        Ok(w_tuple_new(vec![builtin_callable("filter"), state]))
+        pyre_object::gc_roots::pin_root(w_predicate);
+        let predicate_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+        let w_iterable = pyre_object::functional::w_filter_get_iterable(self_);
+        pyre_object::gc_roots::pin_root(w_iterable);
+        let iterable_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+        let state = w_tuple_new(vec![
+            pyre_object::gc_roots::shadow_stack_get(predicate_slot),
+            pyre_object::gc_roots::shadow_stack_get(iterable_slot),
+        ]);
+        pyre_object::gc_roots::pin_root(state);
+        let state_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+        Ok(w_tuple_new(vec![
+            pyre_object::gc_roots::shadow_stack_get(self_type_slot),
+            pyre_object::gc_roots::shadow_stack_get(state_slot),
+        ]))
     }
+}
+
+fn filter_receiver(args: &[PyObjectRef], name: &str) -> Result<PyObjectRef, PyError> {
+    let self_ = args.first().copied().unwrap_or(pyre_object::PY_NULL);
+    if self_.is_null() || !unsafe { pyre_object::functional::is_filter(self_) } {
+        return Err(PyError::type_error(format!(
+            "descriptor '{name}' for 'filter' objects doesn't apply to a '{}' object",
+            object_functionstr_type_name(self_),
+        )));
+    }
+    Ok(self_)
+}
+
+pub(crate) fn filter_iter_method(args: &[PyObjectRef]) -> PyResult {
+    filter_receiver(args, "__iter__")
+}
+
+pub(crate) fn filter_next_method(args: &[PyObjectRef]) -> PyResult {
+    next(filter_receiver(args, "__next__")?)
 }
 
 /// `functional.py:1065-1067 _raise_strict_error` — the strict zip/map
@@ -10664,7 +10703,12 @@ pub fn next(obj: PyObjectRef) -> PyResult {
                 let w_iterable = (*(pyre_object::gc_roots::shadow_stack_get(obj_slot)
                     as *const pyre_object::functional::W_Filter))
                     .w_iterable;
-                let w_obj = next(w_iterable)?;
+                let w_obj = {
+                    let _iter_roots = pyre_object::gc_roots::push_roots();
+                    pyre_object::gc_roots::pin_root(w_iterable);
+                    let iterable_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+                    next(pyre_object::gc_roots::shadow_stack_get(iterable_slot))?
+                };
                 let _r = pyre_object::gc_roots::push_roots();
                 pyre_object::gc_roots::pin_root(w_obj);
                 let w_obj_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
@@ -10674,11 +10718,15 @@ pub fn next(obj: PyObjectRef) -> PyResult {
                 let pred = if w_predicate.is_null() {
                     is_true(pyre_object::gc_roots::shadow_stack_get(w_obj_slot))?
                 } else {
+                    pyre_object::gc_roots::pin_root(w_predicate);
+                    let predicate_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
                     let w_pred = crate::call::call_function_impl_result(
-                        w_predicate,
+                        pyre_object::gc_roots::shadow_stack_get(predicate_slot),
                         &[pyre_object::gc_roots::shadow_stack_get(w_obj_slot)],
                     )?;
-                    is_true(w_pred)?
+                    pyre_object::gc_roots::pin_root(w_pred);
+                    let pred_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+                    is_true(pyre_object::gc_roots::shadow_stack_get(pred_slot))?
                 };
                 if pred {
                     return Ok(pyre_object::gc_roots::shadow_stack_get(w_obj_slot));

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -3969,6 +3969,7 @@ fn getattr_str_impl(obj: PyObjectRef, name: &str, call_getattr: bool) -> PyResul
             || pyre_object::interp_itertools::is_dropwhile(obj)
             || pyre_object::interp_itertools::is_filterfalse(obj)
             || pyre_object::interp_itertools::is_compress(obj)
+            || pyre_object::interp_itertools::is_starmap(obj)
             || pyre_object::interp_itertools::is_pairwise(obj)
             || pyre_object::interp_itertools::is_cycle(obj)
             || pyre_object::interp_itertools::is_chain(obj)
@@ -10066,6 +10067,7 @@ pub fn is_iterable(obj: PyObjectRef) -> bool {
             || pyre_object::interp_itertools::is_dropwhile(obj)
             || pyre_object::interp_itertools::is_filterfalse(obj)
             || pyre_object::interp_itertools::is_compress(obj)
+            || pyre_object::interp_itertools::is_starmap(obj)
             || pyre_object::interp_itertools::is_pairwise(obj)
             || pyre_object::interp_itertools::is_cycle(obj)
             || pyre_object::interp_itertools::is_chain(obj)
@@ -10312,6 +10314,7 @@ pub fn iter(obj: PyObjectRef) -> PyResult {
             || pyre_object::interp_itertools::is_dropwhile(obj)
             || pyre_object::interp_itertools::is_filterfalse(obj)
             || pyre_object::interp_itertools::is_compress(obj)
+            || pyre_object::interp_itertools::is_starmap(obj)
             || pyre_object::interp_itertools::is_pairwise(obj)
             || pyre_object::interp_itertools::is_cycle(obj)
             || pyre_object::interp_itertools::is_chain(obj)
@@ -10808,6 +10811,41 @@ pub fn next(obj: PyObjectRef) -> PyResult {
                     return Ok(pyre_object::gc_roots::shadow_stack_get(item_slot));
                 }
             }
+        }
+        // itertools.starmap — interp_itertools.py W_StarMap.next_w:
+        // fetch one argument bundle and call `w_fun(*bundle)`.  Every edge is
+        // re-read from the rooted owner across calls that may move the heap.
+        if pyre_object::interp_itertools::is_starmap(obj) {
+            let _roots = pyre_object::gc_roots::push_roots();
+            pyre_object::gc_roots::pin_root(obj);
+            let obj_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+            let w_iterable = (*(pyre_object::gc_roots::shadow_stack_get(obj_slot)
+                as *const pyre_object::interp_itertools::W_StarMap))
+                .w_iterable;
+            pyre_object::gc_roots::pin_root(w_iterable);
+            let iterable_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+            let w_obj = next(pyre_object::gc_roots::shadow_stack_get(iterable_slot))?;
+            pyre_object::gc_roots::pin_root(w_obj);
+            let obj_args_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+            let call_args = crate::builtins::collect_iterable(
+                pyre_object::gc_roots::shadow_stack_get(obj_args_slot),
+            )?;
+            let first_arg_slot = pyre_object::gc_roots::shadow_stack_len();
+            for &arg in &call_args {
+                pyre_object::gc_roots::pin_root(arg);
+            }
+            let rooted_args: Vec<_> = (0..call_args.len())
+                .map(|index| pyre_object::gc_roots::shadow_stack_get(first_arg_slot + index))
+                .collect();
+            let w_fun = (*(pyre_object::gc_roots::shadow_stack_get(obj_slot)
+                as *const pyre_object::interp_itertools::W_StarMap))
+                .w_fun;
+            pyre_object::gc_roots::pin_root(w_fun);
+            let fun_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+            return crate::call::call_function_impl_result(
+                pyre_object::gc_roots::shadow_stack_get(fun_slot),
+                &rooted_args,
+            );
         }
         // `pypy/module/__builtin__/functional.py:930-942 W_Filter.next_w`
         // (reverse=False): pull from the iterator until the predicate (or

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -4946,11 +4946,8 @@ fn object_getattr_miss(obj: PyObjectRef, name: &str, call_getattr: bool) -> PyRe
     if (name == "__reduce__" || name == "__reduce_ex__")
         && unsafe { pyre_object::py_type_check(obj, &crate::function::BUILTIN_FUNCTION_TYPE) }
     {
-        let reduce_fn: fn(&[PyObjectRef]) -> PyResult = |args| {
-            Ok(w_str_new(&unsafe {
-                crate::function::function_get_qualname(args[0])
-            }))
-        };
+        let reduce_fn: fn(&[PyObjectRef]) -> PyResult =
+            |args| unsafe { crate::function::descr_builtin_function_reduce(args[0]) };
         let (sname, arity): (&'static str, u16) = if name == "__reduce_ex__" {
             ("__reduce_ex__", 2)
         } else {
@@ -4978,8 +4975,13 @@ fn object_getattr_miss(obj: PyObjectRef, name: &str, call_getattr: bool) -> PyRe
                 let w_descr = lookup_in_type_where(w_type, name);
                 if let Some(descr) = w_descr {
                     if is_data_descr(descr) {
-                        if let Some(result) = get(descr, obj, w_type)? {
-                            return Ok(result);
+                        match get(descr, obj, w_type) {
+                            Ok(Some(result)) => return Ok(result),
+                            Ok(None) => {}
+                            Err(e) if e.kind == PyErrorKind::AttributeError => {
+                                return instance_getattr_hook_or_err(w_type, obj, name, e);
+                            }
+                            Err(e) => return Err(e),
                         }
                     }
                 }
@@ -4993,8 +4995,13 @@ fn object_getattr_miss(obj: PyObjectRef, name: &str, call_getattr: bool) -> PyRe
                     if crate::is_function(descr) {
                         return Ok(pyre_object::w_method_new(descr, obj, w_type));
                     }
-                    if let Some(result) = get(descr, obj, w_type)? {
-                        return Ok(result);
+                    match get(descr, obj, w_type) {
+                        Ok(Some(result)) => return Ok(result),
+                        Ok(None) => {}
+                        Err(e) if e.kind == PyErrorKind::AttributeError => {
+                            return instance_getattr_hook_or_err(w_type, obj, name, e);
+                        }
+                        Err(e) => return Err(e),
                     }
                     return Ok(descr);
                 }
@@ -11081,7 +11088,9 @@ pub(crate) fn property_descr_set_impl(args: &[PyObjectRef]) -> PyResult {
 pub(crate) fn property_descr_delete_impl(args: &[PyObjectRef]) -> PyResult {
     unsafe {
         let prop = property_require_obj(args.first().copied().unwrap_or(PY_NULL), "__delete__")?;
-        let obj = args[1];
+        let obj = args.get(1).copied().ok_or_else(|| {
+            crate::PyError::type_error("property.__delete__() takes exactly one argument (0 given)")
+        })?;
         let fdel = w_property_get_fdel(prop);
         if fdel.is_null() || is_none(fdel) {
             return Err(property_no_accessor(prop, obj, "deleter")?);

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -8459,17 +8459,42 @@ pub(crate) fn builtin_zip(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::Py
     // before the positional walk and look up `strict` from it.
     let (args, kwargs) = split_builtin_kwargs(args);
     kwarg_reject_unknown(kwargs, &["strict"], "zip")?;
-    let strict = kwarg_get(kwargs, "strict")
-        .map(|v| crate::baseobjspace::is_true(v))
+    let _roots = pyre_object::gc_roots::push_roots();
+    let args_base = pyre_object::gc_roots::shadow_stack_len();
+    for &arg in args {
+        pyre_object::gc_roots::pin_root(arg);
+    }
+    let strict_slot = kwarg_get(kwargs, "strict").map(|value| {
+        pyre_object::gc_roots::pin_root(value);
+        pyre_object::gc_roots::shadow_stack_len() - 1
+    });
+    let strict = strict_slot
+        .map(|slot| {
+            crate::baseobjspace::is_true(unsafe { pyre_object::gc_roots::shadow_stack_get(slot) })
+        })
         .transpose()?
         .unwrap_or(false);
     // `functional.py:835-836 build_iterators_from_args` — `iter()` each input.
-    let mut iters = Vec::with_capacity(args.len());
-    for &arg in args {
-        iters.push(crate::baseobjspace::iter(arg)?);
+    let mut iter_slots = Vec::with_capacity(args.len());
+    for index in 0..args.len() {
+        let w_iter = crate::baseobjspace::iter(unsafe {
+            pyre_object::gc_roots::shadow_stack_get(args_base + index)
+        })?;
+        pyre_object::gc_roots::pin_root(w_iter);
+        iter_slots.push(pyre_object::gc_roots::shadow_stack_len() - 1);
     }
-    let w_iterators = pyre_object::w_list_new(iters);
-    Ok(pyre_object::functional::w_zip_new(w_iterators, strict))
+    let w_iterators = pyre_object::w_list_new(
+        iter_slots
+            .into_iter()
+            .map(|slot| unsafe { pyre_object::gc_roots::shadow_stack_get(slot) })
+            .collect(),
+    );
+    pyre_object::gc_roots::pin_root(w_iterators);
+    let iterators_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+    Ok(pyre_object::functional::w_zip_new(
+        unsafe { pyre_object::gc_roots::shadow_stack_get(iterators_slot) },
+        strict,
+    ))
 }
 
 /// `pypy/module/__builtin__/functional.py:253-272 W_Enumerate.descr_new`

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -8355,13 +8355,24 @@ fn builtin_chr(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
 /// W_Filter___new__`.  A lazy iterator: `function == None` keeps truthy
 /// items, otherwise `function(item)` is the predicate.
 pub(crate) fn builtin_filter(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    let (args, kwargs) = split_builtin_kwargs(args);
+    if has_real_kwargs(kwargs) {
+        return Err(crate::PyError::type_error(
+            "filter() takes no keyword arguments",
+        ));
+    }
     if args.len() != 2 {
         return Err(crate::PyError::type_error(format!(
             "filter expected 2 arguments, got {}",
             args.len()
         )));
     }
-    let func = args[0];
+    let _roots = pyre_object::gc_roots::push_roots();
+    pyre_object::gc_roots::pin_root(args[0]);
+    let predicate_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+    pyre_object::gc_roots::pin_root(args[1]);
+    let iterable_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+    let func = unsafe { pyre_object::gc_roots::shadow_stack_get(predicate_slot) };
     // `functional.py:921-924` — a None predicate is stored as PY_NULL.
     let w_predicate = if unsafe { pyre_object::is_none(func) } {
         pyre_object::PY_NULL
@@ -8369,10 +8380,18 @@ pub(crate) fn builtin_filter(args: &[PyObjectRef]) -> Result<PyObjectRef, crate:
         func
     };
     // `functional.py:925 self.w_iterable = space.iter(w_iterable)`.
-    let w_iterable = crate::baseobjspace::iter(args[1])?;
+    let w_iterable = crate::baseobjspace::iter(unsafe {
+        pyre_object::gc_roots::shadow_stack_get(iterable_slot)
+    })?;
+    pyre_object::gc_roots::pin_root(w_iterable);
+    let iterator_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     Ok(pyre_object::functional::w_filter_new(
-        w_predicate,
-        w_iterable,
+        if w_predicate.is_null() {
+            pyre_object::PY_NULL
+        } else {
+            unsafe { pyre_object::gc_roots::shadow_stack_get(predicate_slot) }
+        },
+        unsafe { pyre_object::gc_roots::shadow_stack_get(iterator_slot) },
     ))
 }
 

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -8382,25 +8382,51 @@ pub(crate) fn builtin_filter(args: &[PyObjectRef]) -> Result<PyObjectRef, crate:
 pub(crate) fn builtin_map(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     let (args, kwargs) = split_builtin_kwargs(args);
     kwarg_reject_unknown(kwargs, &["strict"], "map")?;
-    let strict = kwarg_get(kwargs, "strict")
-        .map(|v| crate::baseobjspace::is_true(v))
-        .transpose()?
-        .unwrap_or(false);
     if args.len() < 2 {
         return Err(crate::PyError::type_error(
             "map() must have at least two arguments.",
         ));
     }
-    let func = args[0];
-    // `functional.py:835-836 build_iterators_from_args` — `iter()` each input.
-    let mut iters = Vec::with_capacity(args.len() - 1);
-    for &arg in &args[1..] {
-        iters.push(crate::baseobjspace::iter(arg)?);
+
+    // PyPy's `args_w` and `build_iterators_from_args` keep every argument live
+    // while `space.iter` and the Python 3.14 `strict` truth conversion execute.
+    let _roots = pyre_object::gc_roots::push_roots();
+    let args_base = pyre_object::gc_roots::shadow_stack_len();
+    for &arg in args {
+        pyre_object::gc_roots::pin_root(arg);
     }
-    let w_iterators = pyre_object::w_list_new(iters);
+    let w_strict = kwarg_get(kwargs, "strict");
+    let strict_slot = w_strict.map(|value| {
+        pyre_object::gc_roots::pin_root(value);
+        pyre_object::gc_roots::shadow_stack_len() - 1
+    });
+    let strict = strict_slot
+        .map(|slot| {
+            crate::baseobjspace::is_true(unsafe { pyre_object::gc_roots::shadow_stack_get(slot) })
+        })
+        .transpose()?
+        .unwrap_or(false);
+
+    // `functional.py:835-836 build_iterators_from_args` — `iter()` each input.
+    let mut iter_slots = Vec::with_capacity(args.len() - 1);
+    for index in 1..args.len() {
+        let w_iter = crate::baseobjspace::iter(unsafe {
+            pyre_object::gc_roots::shadow_stack_get(args_base + index)
+        })?;
+        pyre_object::gc_roots::pin_root(w_iter);
+        iter_slots.push(pyre_object::gc_roots::shadow_stack_len() - 1);
+    }
+    let w_iterators = pyre_object::w_list_new(
+        iter_slots
+            .into_iter()
+            .map(|slot| unsafe { pyre_object::gc_roots::shadow_stack_get(slot) })
+            .collect(),
+    );
+    pyre_object::gc_roots::pin_root(w_iterators);
+    let iterators_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     Ok(pyre_object::functional::w_map_new(
-        func,
-        w_iterators,
+        unsafe { pyre_object::gc_roots::shadow_stack_get(args_base) },
+        unsafe { pyre_object::gc_roots::shadow_stack_get(iterators_slot) },
         strict,
     ))
 }

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -1339,30 +1339,25 @@ fn memoryview_exit(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> 
     memoryview_release(&args[..1])
 }
 
-/// The raw logical bytes (`view.as_str`) of an operand that exports a
-/// contiguous buffer, or `None` when it exports none (so `__eq__` returns
-/// NotImplemented).  `descr__cmp` compares the two `as_str` byte strings,
-/// mirroring `space.buffer_w(w_other, space.BUF_CONTIG_RO)`: a memoryview,
-/// a bytes-like object, or a non-bytes contiguous exporter (`array.array`)
-/// are all gathered to bytes and compared.
-unsafe fn memoryview_operand_bytes(obj: PyObjectRef) -> Option<Vec<u8>> {
-    unsafe {
-        if pyre_object::memoryview::is_w_memoryview(obj) {
-            // A released view has no buffer to gather (its box is dropped);
-            // `descr__cmp` falls through to identity, so report no bytes.
-            if pyre_object::memoryview::w_memoryview_released(obj) {
-                return None;
-            }
-            return Some(memoryview_gather_bytes(obj));
-        }
-        if pyre_object::bytesobject::is_bytes_like(obj) {
-            return Some(pyre_object::bytesobject::bytes_like_data(obj).to_vec());
-        }
-        if let Ok(Some(b)) = crate::typedef::buffer_as_bytes_like(obj) {
-            return Some(pyre_object::bytesobject::bytes_like_data(b).to_vec());
-        }
-        None
+/// Gateway receiver check shared by the rich-comparison descriptors.  The
+/// type slot normally guarantees this, but direct descriptor calls must raise
+/// instead of interpreting an arbitrary object as `W_MemoryView`.
+fn memoryview_receiver(args: &[PyObjectRef], name: &str) -> Result<PyObjectRef, crate::PyError> {
+    let mv = args.first().copied().unwrap_or(pyre_object::PY_NULL);
+    if mv.is_null() {
+        return Err(crate::PyError::type_error(format!(
+            "descriptor '{name}' of 'memoryview' object needs an argument"
+        )));
     }
+    if !unsafe { pyre_object::memoryview::is_w_memoryview(mv) } {
+        let received = crate::typedef::r#type(mv)
+            .map(|t| unsafe { pyre_object::w_type_get_name(t) })
+            .unwrap_or("object");
+        return Err(crate::PyError::type_error(format!(
+            "descriptor '{name}' requires a 'memoryview' object but received a '{received}'"
+        )));
+    }
+    Ok(mv)
 }
 
 /// True when `mv` or a memoryview `other` operand is released — either side
@@ -1375,39 +1370,148 @@ unsafe fn memoryview_released_either(mv: PyObjectRef, other: PyObjectRef) -> boo
     }
 }
 
-/// `memoryview.__eq__` — `descr__cmp('eq')`: compares the two views'
-/// raw byte strings (`as_str`); NotImplemented for any other operand.
-fn memoryview_eq(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    let mv = args.first().copied().unwrap_or(w_none());
+/// Python 3.14 `memory_richcompare`: equality first requires equivalent
+/// shapes, then compares unpacked element values.  Raw bytes are deliberately
+/// insufficient (`int(1)` and `float(1.0)` compare equal despite different
+/// encodings, while identical bytes can decode to unequal values).
+fn memoryview_compare_eq(args: &[PyObjectRef], name: &str) -> Result<Option<bool>, crate::PyError> {
+    let mv = memoryview_receiver(args, name)?;
     let other = args.get(1).copied().unwrap_or(w_none());
     unsafe {
-        // A released view (on either side) compares by identity (`view is None`
-        // branch); its backing must not be read after release.
         if memoryview_released_either(mv, other) {
-            return Ok(w_bool_from(mv == other));
+            return Ok(Some(mv == other));
         }
-        let a = memoryview_gather_bytes(mv);
-        match memoryview_operand_bytes(other) {
-            Some(b) => Ok(w_bool_from(a == b)),
-            None => Ok(pyre_object::w_not_implemented()),
+
+        let _roots = pyre_object::gc_roots::push_roots();
+        let base = pyre_object::gc_roots::shadow_stack_len();
+        pyre_object::gc_roots::pin_root(mv);
+        pyre_object::gc_roots::pin_root(other);
+        let other = pyre_object::gc_roots::shadow_stack_get(base + 1);
+        let (rhs, temporary) = if pyre_object::memoryview::is_w_memoryview(other) {
+            (other, false)
+        } else {
+            match w_memoryview_new(other) {
+                Ok(view) => {
+                    pyre_object::gc_roots::pin_root(view);
+                    (pyre_object::gc_roots::shadow_stack_get(base + 2), true)
+                }
+                // `PyObject_GetBuffer(..., PyBUF_FULL_RO)` failures are
+                // cleared by CPython's `memory_richcompare`.
+                Err(_) => return Ok(None),
+            }
+        };
+        let lhs = pyre_object::gc_roots::shadow_stack_get(base);
+        let comparison = (|| -> Result<bool, crate::PyError> {
+            if pyre_object::memoryview::w_memoryview_ndim(lhs)
+                != pyre_object::memoryview::w_memoryview_ndim(rhs)
+                || pyre_object::memoryview::w_memoryview_native_shape(lhs)
+                    != pyre_object::memoryview::w_memoryview_native_shape(rhs)
+            {
+                return Ok(false);
+            }
+            let lhs_data = memoryview_gather_bytes(lhs);
+            let rhs_data = memoryview_gather_bytes(rhs);
+            let lhs_size = pyre_object::memoryview::w_memoryview_itemsize(lhs) as usize;
+            let rhs_size = pyre_object::memoryview::w_memoryview_itemsize(rhs) as usize;
+            if lhs_size == 0 || rhs_size == 0 {
+                return Ok(lhs_data.is_empty() && rhs_data.is_empty());
+            }
+            let count = lhs_data.len() / lhs_size;
+            if count != rhs_data.len() / rhs_size {
+                return Ok(false);
+            }
+            let lhs_fmt = pyre_object::memoryview::w_memoryview_format_str(lhs);
+            let rhs_fmt = pyre_object::memoryview::w_memoryview_format_str(rhs);
+            for index in 0..count {
+                let _values = pyre_object::gc_roots::push_roots();
+                let values = pyre_object::gc_roots::shadow_stack_len();
+                pyre_object::gc_roots::pin_root(memoryview_unpack_element(
+                    lhs_fmt,
+                    &lhs_data,
+                    index * lhs_size,
+                    lhs_size,
+                ));
+                pyre_object::gc_roots::pin_root(memoryview_unpack_element(
+                    rhs_fmt,
+                    &rhs_data,
+                    index * rhs_size,
+                    rhs_size,
+                ));
+                if !crate::baseobjspace::eq_w(
+                    pyre_object::gc_roots::shadow_stack_get(values),
+                    pyre_object::gc_roots::shadow_stack_get(values + 1),
+                )? {
+                    return Ok(false);
+                }
+            }
+            Ok(true)
+        })();
+        if temporary {
+            let release = memoryview_release(&[rhs]);
+            if comparison.is_ok() {
+                release?;
+            }
         }
+        comparison.map(Some)
     }
 }
 
-/// `memoryview.__ne__` — `descr__cmp('ne')`, the negation of `__eq__`.
+fn memoryview_eq(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    Ok(match memoryview_compare_eq(args, "__eq__")? {
+        Some(equal) => w_bool_from(equal),
+        None => pyre_object::w_not_implemented(),
+    })
+}
+
+/// `memoryview.__ne__` — the negation of the same element-wise comparison.
 fn memoryview_ne(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    let mv = args.first().copied().unwrap_or(w_none());
-    let other = args.get(1).copied().unwrap_or(w_none());
+    Ok(match memoryview_compare_eq(args, "__ne__")? {
+        Some(equal) => w_bool_from(!equal),
+        None => pyre_object::w_not_implemented(),
+    })
+}
+
+/// Python 3.14 exposes all ordering slots but `memory_richcompare` returns
+/// `NotImplemented` for them after validating the descriptor receiver.
+fn memoryview_order(args: &[PyObjectRef], name: &str) -> Result<PyObjectRef, crate::PyError> {
+    memoryview_receiver(args, name)?;
+    Ok(pyre_object::w_not_implemented())
+}
+
+fn memoryview_lt(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    memoryview_order(args, "__lt__")
+}
+fn memoryview_le(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    memoryview_order(args, "__le__")
+}
+fn memoryview_gt(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    memoryview_order(args, "__gt__")
+}
+fn memoryview_ge(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    memoryview_order(args, "__ge__")
+}
+
+/// Python 3.14 `memoryview._from_flags(object, flags)`.  A memoryview input
+/// is cloned with its managed buffer and ignores flags.  For other exporters,
+/// pyre currently provides the full read-only view; the observable writable
+/// request bit is enforced here exactly like `PyBUF_WRITABLE`.
+fn memoryview_from_flags(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    let object = args.get(1).copied().unwrap_or(w_none());
+    let flags = crate::baseobjspace::c_int_w(args.get(2).copied().unwrap_or(w_none()))?;
+    let view = w_memoryview_new(object)?;
     unsafe {
-        if memoryview_released_either(mv, other) {
-            return Ok(w_bool_from(mv != other));
-        }
-        let a = memoryview_gather_bytes(mv);
-        match memoryview_operand_bytes(other) {
-            Some(b) => Ok(w_bool_from(a != b)),
-            None => Ok(pyre_object::w_not_implemented()),
+        if !pyre_object::memoryview::is_w_memoryview(object)
+            && flags & 0x0001 != 0
+            && pyre_object::memoryview::w_memoryview_readonly(view)
+        {
+            memoryview_release(&[view])?;
+            return Err(crate::PyError::new(
+                crate::PyErrorKind::BufferError,
+                "Object is not writable.",
+            ));
         }
     }
+    Ok(view)
 }
 
 /// `memoryview.hex` — the view's bytes as a hex string, reusing the
@@ -1679,6 +1783,10 @@ pub(crate) fn init_memoryview_type(ns: PyObjectRef) {
         ("__repr__", memoryview_repr, 1),
         ("__eq__", memoryview_eq, 2),
         ("__ne__", memoryview_ne, 2),
+        ("__lt__", memoryview_lt, 2),
+        ("__le__", memoryview_le, 2),
+        ("__gt__", memoryview_gt, 2),
+        ("__ge__", memoryview_ge, 2),
         ("count", memoryview_count, 2),
         ("tobytes", memoryview_tobytes, 1),
         ("tolist", memoryview_tolist, 1),
@@ -1708,6 +1816,15 @@ pub(crate) fn init_memoryview_type(ns: PyObjectRef) {
             pyre_object::function::w_classmethod_new(make_builtin_function(
                 "__class_getitem__",
                 crate::_pypy_generic_alias::generic_alias_class_getitem,
+            )),
+        );
+        pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
+            ns,
+            "_from_flags",
+            pyre_object::function::w_classmethod_new(make_builtin_function_with_arity(
+                "_from_flags",
+                memoryview_from_flags,
+                3,
             )),
         );
         pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -8555,7 +8555,13 @@ pub(crate) fn builtin_reversed(args: &[PyObjectRef]) -> Result<PyObjectRef, crat
             args.len()
         )));
     }
-    let obj = args[0];
+    // `descr___new__2` can execute `__reversed__`, `__len__`, or allocate an
+    // iterator. The translated RPython argument remains a GC root throughout;
+    // keep the Rust carrier in the shadow stack and reload at each call site.
+    let _roots = pyre_object::gc_roots::push_roots();
+    pyre_object::gc_roots::pin_root(args[0]);
+    let obj_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+    let obj = unsafe { pyre_object::gc_roots::shadow_stack_get(obj_slot) };
     unsafe {
         // EXACT builtin list → `iterobject.py W_ReverseSeqIterObject` (the
         // Python 3.14-visible `list_reverseiterator`); tuple and the other
@@ -8568,11 +8574,17 @@ pub(crate) fn builtin_reversed(args: &[PyObjectRef]) -> Result<PyObjectRef, crat
         if pyre_object::is_exact_builtin_instance(obj) {
             if pyre_object::is_list(obj) {
                 let n = pyre_object::w_list_len(obj) as i64;
-                return Ok(pyre_object::w_list_reverse_iter_new(obj, n - 1));
+                return Ok(pyre_object::w_list_reverse_iter_new(
+                    pyre_object::gc_roots::shadow_stack_get(obj_slot),
+                    n - 1,
+                ));
             }
             if pyre_object::is_tuple(obj) {
                 let n = pyre_object::w_tuple_len(obj) as i64;
-                return Ok(pyre_object::functional::w_reversed_new(obj, n - 1));
+                return Ok(pyre_object::functional::w_reversed_new(
+                    pyre_object::gc_roots::shadow_stack_get(obj_slot),
+                    n - 1,
+                ));
             }
             // bytes / bytearray expose the sequence protocol at the C level but
             // not as `__getitem__` / `__len__` type slots, so they would miss
@@ -8582,48 +8594,41 @@ pub(crate) fn builtin_reversed(args: &[PyObjectRef]) -> Result<PyObjectRef, crat
                 || pyre_object::bytearrayobject::is_bytearray(obj)
             {
                 let n = crate::baseobjspace::len_w(obj)?;
-                return Ok(pyre_object::functional::w_reversed_new(obj, n - 1));
+                return Ok(pyre_object::functional::w_reversed_new(
+                    pyre_object::gc_roots::shadow_stack_get(obj_slot),
+                    n - 1,
+                ));
             }
         }
         // range: functional.py W_Range.descr_reversed — reflect
         // the span and hand back a fresh reverse-walking iterator. (range is
         // not subclassable, so no override can apply.)
         if pyre_object::is_w_range(obj) {
-            return Ok(pyre_object::w_range_reversed(obj));
-        }
-        // range_iterator: a bare iterator (e.g. from `iter(range(n))`)
-        // can also be reversed. Mirror `W_IntRangeIterator`'s live
-        // `(current, remaining, step)` cursor by starting at the last
-        // remaining item, keeping the same count, and negating the step.
-        if pyre_object::is_range_iter(obj) {
-            let (current, remaining, step) = pyre_object::w_range_iter_fields(obj);
-            if remaining <= 0 {
-                return Ok(pyre_object::w_range_iter_new(0, 0, 1));
-            }
-            let last = current + (remaining - 1) * step;
-            return Ok(pyre_object::w_range_iter_new(last, remaining, -step));
-        }
-        // bytes / bytearray: yield the byte values in reverse.
-        if pyre_object::bytesobject::is_bytes_like(obj) {
-            let n = pyre_object::bytesobject::bytes_like_len(obj);
-            let mut items = Vec::with_capacity(n);
-            for i in (0..n).rev() {
-                items.push(w_int_new(
-                    pyre_object::bytesobject::bytes_like_getitem(obj, i) as i64,
-                ));
-            }
-            return Ok(pyre_object::w_seq_iter_new(
-                pyre_object::w_list_new(items),
-                n,
+            return Ok(pyre_object::w_range_reversed(
+                pyre_object::gc_roots::shadow_stack_get(obj_slot),
             ));
         }
     }
     // `__reversed__` resolved through the type MRO (`functional.py:362-366`) —
     // honors a subclass override and the inherited builtin `list.__reversed__`,
     // and any user object defining `__reversed__`.
+    let obj = unsafe { pyre_object::gc_roots::shadow_stack_get(obj_slot) };
     if let Some(tp) = crate::typedef::r#type(obj) {
         if let Some(method) = unsafe { crate::baseobjspace::lookup_in_type(tp, "__reversed__") } {
-            return Ok(crate::call_function(method, &[obj]));
+            // Python 3.14 `slot1` semantics: explicitly assigning None disables
+            // the protocol and does not fall back to `__len__`/`__getitem__`.
+            if unsafe { pyre_object::is_none(method) } {
+                return Err(crate::PyError::type_error(format!(
+                    "'{}' object is not reversible",
+                    crate::baseobjspace::object_functionstr_type_name(obj)
+                )));
+            }
+            pyre_object::gc_roots::pin_root(method);
+            let method_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+            return Ok(crate::call_function(
+                unsafe { pyre_object::gc_roots::shadow_stack_get(method_slot) },
+                &[unsafe { pyre_object::gc_roots::shadow_stack_get(obj_slot) }],
+            ));
         }
     }
     // functional.py:351 — without `__reversed__`, require the sequence
@@ -8636,7 +8641,10 @@ pub(crate) fn builtin_reversed(args: &[PyObjectRef]) -> Result<PyObjectRef, crat
         if has_getitem {
             // `functional.py:354-359` — reverse lazily through `W_ReversedIterator`.
             let n = crate::baseobjspace::len_w(obj)?;
-            return Ok(pyre_object::functional::w_reversed_new(obj, n - 1));
+            return Ok(pyre_object::functional::w_reversed_new(
+                unsafe { pyre_object::gc_roots::shadow_stack_get(obj_slot) },
+                n - 1,
+            ));
         }
     }
     Err(crate::PyError::type_error(format!(

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -8491,28 +8491,53 @@ pub(crate) fn builtin_enumerate(args: &[PyObjectRef]) -> Result<PyObjectRef, cra
     } else {
         kwarg_get(kwargs, "start")
     };
-    // `functional.py:255-264 descr___new__` — `space.index(w_start)`
-    // then `space.int_w(w_start)`; on OverflowError, drop into bigint
-    // slot.  Pyre uses i64 directly and would overflow on bigint
-    // start; TODO: W_Enumerate
-    // can still promote during iteration once start fits in i64).
-    let start = match start_obj {
-        Some(o) if !unsafe { pyre_object::is_none(o) } => space_index_w(o)?,
-        _ => 0,
+    // The constructor can execute user `__index__` and allocate. Keep both
+    // arguments in the shadow stack exactly as the translated RPython locals
+    // remain GC-visible across `space.index` / `space.iter`.
+    let _roots = pyre_object::gc_roots::push_roots();
+    pyre_object::gc_roots::pin_root(source);
+    let source_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+    let raw_start = start_obj.unwrap_or(pyre_object::PY_NULL);
+    pyre_object::gc_roots::pin_root(raw_start);
+    let raw_start_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+
+    // `functional.py:255-264 descr___new__` — `space.index(w_start)` then
+    // `space.int_w(w_start)`; ONLY OverflowError activates the bigint slot.
+    // This preserves an arbitrary-precision start object verbatim, while a
+    // machine-sized int/long/bool stays in the unboxed `index` fast path.
+    let (start, w_start) = if raw_start.is_null() {
+        (0, pyre_object::PY_NULL)
+    } else {
+        let indexed = crate::baseobjspace::space_index(unsafe {
+            pyre_object::gc_roots::shadow_stack_get(raw_start_slot)
+        })?;
+        pyre_object::gc_roots::pin_root(indexed);
+        let indexed_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+        match crate::baseobjspace::int_w(indexed) {
+            Ok(value) => (value, pyre_object::PY_NULL),
+            Err(e) if e.kind == crate::PyErrorKind::OverflowError => (-1, unsafe {
+                pyre_object::gc_roots::shadow_stack_get(indexed_slot)
+            }),
+            Err(e) => return Err(e),
+        }
     };
+    pyre_object::gc_roots::pin_root(w_start);
+    let w_start_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     // `functional.py:268-271` — `if start == 0 and type(w_iterable) is
     // W_ListObject: w_iter = w_iterable` (skip space.iter for the
     // common list-source case so __next__ can `getitem(index)`
     // directly).  Otherwise call `space.iter(w_iterable)`.
-    let w_iter_or_list = if start == 0 && unsafe { pyre_object::is_list(source) } {
-        source
-    } else {
-        crate::baseobjspace::iter(source)?
-    };
+    let source = unsafe { pyre_object::gc_roots::shadow_stack_get(source_slot) };
+    let w_iter_or_list =
+        if start == 0 && w_start.is_null() && unsafe { pyre_object::is_list(source) } {
+            source
+        } else {
+            crate::baseobjspace::iter(source)?
+        };
     Ok(pyre_object::functional::w_enumerate_new(
         w_iter_or_list,
         start,
-        pyre_object::PY_NULL, // i64 fast-path active per :225-227
+        unsafe { pyre_object::gc_roots::shadow_stack_get(w_start_slot) },
     ))
 }
 

--- a/pyre/pyre-interpreter/src/call.rs
+++ b/pyre/pyre-interpreter/src/call.rs
@@ -690,7 +690,7 @@ pub fn call_function_ex(
             unpacked
         }
     };
-    if !self_or_null.is_null() && !unsafe { pyre_object::is_none(self_or_null) } {
+    if !self_or_null.is_null() {
         args.insert(0, self_or_null);
     }
 
@@ -737,7 +737,7 @@ pub fn call_kw(
 ) -> PyResult {
     let mut args: Vec<PyObjectRef> = positional.to_vec();
 
-    if self_or_null != pyre_object::PY_NULL && !unsafe { pyre_object::is_none(self_or_null) } {
+    if self_or_null != pyre_object::PY_NULL {
         args.insert(0, self_or_null);
     }
 
@@ -748,7 +748,7 @@ pub fn call_kw(
     let callable_unwrapped = if unsafe { pyre_object::is_method(callable_unwrapped) } {
         let func = unsafe { pyre_object::w_method_get_func(callable_unwrapped) };
         let receiver = unsafe { pyre_object::w_method_get_self(callable_unwrapped) };
-        if !receiver.is_null() && !unsafe { pyre_object::is_none(receiver) } {
+        if !receiver.is_null() {
             args.insert(0, receiver);
         }
         func
@@ -896,13 +896,13 @@ pub fn call_kw(
         let func = unsafe { pyre_object::w_method_get_func(callable_unwrapped) };
         let receiver = unsafe {
             let w_self = pyre_object::w_method_get_self(callable_unwrapped);
-            if !w_self.is_null() && !pyre_object::is_none(w_self) {
+            if !w_self.is_null() {
                 w_self
             } else {
                 pyre_object::w_method_get_class(callable_unwrapped)
             }
         };
-        if !receiver.is_null() && unsafe { !pyre_object::is_none(receiver) } {
+        if !receiver.is_null() {
             let mut prepended = Vec::with_capacity(1 + args.len());
             prepended.push(receiver);
             prepended.extend_from_slice(&args);
@@ -1009,14 +1009,14 @@ fn call_callable_with_mode(
         let func = unsafe { pyre_object::w_method_get_func(callable) };
         let receiver = unsafe {
             let w_self = pyre_object::w_method_get_self(callable);
-            if !w_self.is_null() && !pyre_object::is_none(w_self) {
+            if !w_self.is_null() {
                 w_self
             } else {
                 pyre_object::w_method_get_class(callable)
             }
         };
         let mut call_args = Vec::with_capacity(1 + args.len());
-        if !receiver.is_null() && unsafe { !pyre_object::is_none(receiver) } {
+        if !receiver.is_null() {
             call_args.push(receiver);
         }
         call_args.extend_from_slice(args);
@@ -1716,7 +1716,7 @@ pub fn call_with_kwargs(
         let func = unsafe { pyre_object::w_method_get_func(callable) };
         let receiver = unsafe { pyre_object::w_method_get_self(callable) };
         let mut full_args = Vec::with_capacity(1 + pos_args.len());
-        if !receiver.is_null() && !unsafe { pyre_object::is_none(receiver) } {
+        if !receiver.is_null() {
             full_args.push(receiver);
         }
         full_args.extend_from_slice(pos_args);
@@ -2187,7 +2187,7 @@ pub fn call_with_kwargs(
         let func = unsafe { pyre_object::w_method_get_func(callable) };
         let w_self = unsafe { pyre_object::w_method_get_self(callable) };
         let mut full_args = Vec::with_capacity(1 + pos_args.len());
-        if !w_self.is_null() && unsafe { !pyre_object::is_none(w_self) } {
+        if !w_self.is_null() {
             full_args.push(w_self);
         }
         full_args.extend_from_slice(pos_args);
@@ -2287,13 +2287,13 @@ pub fn call_function_impl_result(
         if pyre_object::is_method(callable) {
             let func = pyre_object::w_method_get_func(callable);
             let w_self = pyre_object::w_method_get_self(callable);
-            let receiver = if !w_self.is_null() && !pyre_object::is_none(w_self) {
+            let receiver = if !w_self.is_null() {
                 w_self
             } else {
                 pyre_object::w_method_get_class(callable)
             };
             let mut call_args = Vec::with_capacity(1 + args.len());
-            if !receiver.is_null() && !pyre_object::is_none(receiver) {
+            if !receiver.is_null() {
                 call_args.push(receiver);
             }
             call_args.extend_from_slice(args);
@@ -3881,7 +3881,7 @@ fn type_descr_call_with_mode(
     // typeobject.py:726 — `w_newfunc = space.get(w_newdescr, space.w_None,
     // w_type=self)`.  A descriptor with no __get__ (`get` → None) is its own
     // bound value, matching `space.get`'s `if w_get is None: return w_descr`.
-    let new_fn = unsafe { crate::baseobjspace::get(new_descr, pyre_object::w_none(), w_type)? }
+    let new_fn = unsafe { crate::baseobjspace::get(new_descr, pyre_object::PY_NULL, w_type)? }
         .unwrap_or(new_descr);
     // typeobject.py:731 — `space.call_obj_args(w_newfunc, self, __args__)`.
     let mut new_args = Vec::with_capacity(1 + args.len());

--- a/pyre/pyre-interpreter/src/call.rs
+++ b/pyre/pyre-interpreter/src/call.rs
@@ -977,6 +977,28 @@ fn classmethod_call_override(callable: PyObjectRef) -> Result<Option<PyObjectRef
     Ok(Some(bound))
 }
 
+/// Resolve a `__call__` introduced by a staticmethod subtype. Exact builtin
+/// wrappers use the direct unwrap fast path; subtypes honor their override.
+fn staticmethod_call_override(callable: PyObjectRef) -> Result<Option<PyObjectRef>, PyError> {
+    if !unsafe { pyre_object::is_staticmethod(callable) }
+        || unsafe {
+            pyre_object::is_exact_type(callable, &pyre_object::function::STATICMETHOD_TYPE)
+        }
+    {
+        return Ok(None);
+    }
+    let Some(w_type) = crate::typedef::r#type(callable) else {
+        return Ok(None);
+    };
+    let Some(call_descr) = (unsafe { crate::baseobjspace::lookup_in_type(w_type, "__call__") })
+    else {
+        return Ok(None);
+    };
+    let bound =
+        unsafe { crate::baseobjspace::get(call_descr, callable, w_type) }?.unwrap_or(call_descr);
+    Ok(Some(bound))
+}
+
 fn call_callable_with_mode(
     frame: &mut PyFrame,
     callable: PyObjectRef,
@@ -1009,7 +1031,7 @@ fn call_callable_with_mode(
 
     // staticmethod → unwrap
     // PyPy: function.py StaticMethod.descr_call
-    if unsafe { pyre_object::is_staticmethod(callable) } {
+    if unsafe { pyre_object::is_exact_type(callable, &pyre_object::function::STATICMETHOD_TYPE) } {
         let func = unsafe { pyre_object::w_staticmethod_get_func(callable) };
         return call_callable_with_mode(frame, func, args, mode);
     }
@@ -1669,16 +1691,24 @@ pub fn call_with_kwargs(
     // function.py:712-713 StaticMethod.descr_call — the wrapper contributes
     // no implicit argument; forward the original positional and keyword
     // collections unchanged to its w_function.
-    if unsafe { pyre_object::is_staticmethod(callable) } {
+    if unsafe { pyre_object::is_exact_type(callable, &pyre_object::function::STATICMETHOD_TYPE) } {
         let func = unsafe { pyre_object::w_staticmethod_get_func(callable) };
         return call_with_kwargs(frame, func, pos_args, kwargs);
+    }
+    if let Some(bound) = staticmethod_call_override(callable)? {
+        return call_with_kwargs(frame, bound, pos_args, kwargs);
     }
 
     if unsafe { pyre_object::is_classmethod(callable) } {
         if let Some(bound) = classmethod_call_override(callable)? {
             return call_with_kwargs(frame, bound, pos_args, kwargs);
         }
-        return Err(PyError::type_error("'classmethod' object is not callable"));
+        let type_name = crate::typedef::r#type(callable)
+            .map(|tp| unsafe { pyre_object::w_type_get_name(tp) })
+            .unwrap_or("classmethod");
+        return Err(PyError::type_error(format!(
+            "'{type_name}' object is not callable"
+        )));
     }
 
     // Unwrap bound methods: prepend receiver to pos_args.
@@ -2310,9 +2340,12 @@ pub fn call_function_impl_result(
         }
         // staticmethod → unwrap and call the wrapped function
         // PyPy: function.py StaticMethod.descr_staticmethod__call__
-        if pyre_object::is_staticmethod(callable) {
+        if pyre_object::is_exact_type(callable, &pyre_object::function::STATICMETHOD_TYPE) {
             let func = pyre_object::w_staticmethod_get_func(callable);
             return call_function_impl_result(func, args);
+        }
+        if let Some(bound) = staticmethod_call_override(callable)? {
+            return call_function_impl_result(bound, args);
         }
         if let Some(bound) = classmethod_call_override(callable)? {
             return call_function_impl_result(bound, args);
@@ -2341,9 +2374,11 @@ pub fn call_function_impl_result(
             }
         }
     }
+    let type_name = crate::typedef::r#type(callable)
+        .map(|tp| unsafe { pyre_object::w_type_get_name(tp) })
+        .unwrap_or_else(|| unsafe { (*(*callable).ob_type).name });
     Err(PyError::type_error(format!(
-        "'{}' object is not callable",
-        unsafe { (*(*callable).ob_type).name }
+        "'{type_name}' object is not callable"
     )))
 }
 

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -206,6 +206,10 @@ unsafe fn walk_raw_function_roots(
         visitor(&mut *(&mut func.w_qualname as *mut PyObjectRef as *mut majit_ir::GcRef));
         visitor(&mut *(&mut func.w_objclass as *mut PyObjectRef as *mut majit_ir::GcRef));
         visitor(&mut *(&mut func.w_text_signature as *mut PyObjectRef as *mut majit_ir::GcRef));
+        // BuiltinFunction.w_moduleobj is an ordinary movable module reference.
+        // Builtin functions are immortal, so only this raw-root walker can
+        // forward the slot during a collection.
+        visitor(&mut *(&mut func.w_moduleobj as *mut PyObjectRef as *mut majit_ir::GcRef));
     }
 }
 

--- a/pyre/pyre-interpreter/src/executioncontext.rs
+++ b/pyre/pyre-interpreter/src/executioncontext.rs
@@ -1044,12 +1044,23 @@ impl ExecutionContext {
         // W_ModuleDictObject in `self.builtins_module`; wrap it
         // through `w_module_new_aliasing_dict` without a raw storage
         // pointer (the strategy storage IS the canonical store).
+        // Enumerating a dict materialises key objects and can collect.  Keep
+        // only owned key strings across that operation; raw values must be
+        // looked up again after the module allocation.
+        let keys: Vec<String> = unsafe { pyre_object::w_dict_str_entries(self.builtins_module) }
+            .into_iter()
+            .map(|(key, _)| key)
+            .collect();
         let module = pyre_object::w_module_new_aliasing_dict("builtins", self.builtins_module);
         // function.py:797-815 BuiltinFunction.w_moduleobj. The defining
         // module object does not exist while `new_builtin_module_dict` fills
         // the namespace, so bind each builtin's `__self__` now.
-        for (_, value) in unsafe { pyre_object::w_dict_str_entries(self.builtins_module) } {
-            unsafe { crate::function::builtin_function_set_module_obj(value, module) };
+        for key in keys {
+            if let Some(value) =
+                unsafe { pyre_object::w_dict_getitem_str(self.builtins_module, &key) }
+            {
+                unsafe { crate::function::builtin_function_set_module_obj(value, module) };
+            }
         }
         self.builtin_dict_cache.set(module);
         // `pypy/interpreter/baseobjspace.py:647` —

--- a/pyre/pyre-interpreter/src/function.rs
+++ b/pyre/pyre-interpreter/src/function.rs
@@ -382,10 +382,13 @@ pub(crate) fn function_new_impl(
     // part of the same `malloc_typed` call, so it never spans a
     // collection point.
     let _roots = pyre_object::gc_roots::push_roots();
+    let closure_slot = pyre_object::gc_roots::shadow_stack_len();
     pyre_object::gc_roots::pin_root(closure);
+    let code_slot = pyre_object::gc_roots::shadow_stack_len();
     pyre_object::gc_roots::pin_root(code as PyObjectRef);
     // `function.py:57 self.w_func_globals = w_globals` stores the dict
     // object directly as the function's sole globals carrier.
+    let globals_slot = pyre_object::gc_roots::shadow_stack_len();
     pyre_object::gc_roots::pin_root(w_func_globals_obj);
 
     // CPython 3.14 `_PyEval_BuiltinsFromGlobals` at function construction:
@@ -404,7 +407,16 @@ pub(crate) fn function_new_impl(
             selected
         }
     };
+    let builtins_slot = pyre_object::gc_roots::shadow_stack_len();
     pyre_object::gc_roots::pin_root(w_builtins);
+
+    // `pick_builtin_obj` and later allocations may collect.  Reload every
+    // pinned input before embedding it in the new Function; the original raw
+    // locals are not rewritten when the shadow-stack slots are forwarded.
+    let closure = pyre_object::gc_roots::shadow_stack_get(closure_slot);
+    let code = pyre_object::gc_roots::shadow_stack_get(code_slot) as *const ();
+    let w_func_globals_obj = pyre_object::gc_roots::shadow_stack_get(globals_slot);
+    let w_builtins = pyre_object::gc_roots::shadow_stack_get(builtins_slot);
 
     let name_ptr = pyre_object::lltype::malloc_raw(name) as *const String;
     let function = Function {
@@ -611,6 +623,25 @@ pub unsafe fn function_get_self_or_none(obj: PyObjectRef) -> PyObjectRef {
     } else {
         w_self
     }
+}
+
+/// CPython 3.14 `meth_reduce`: type-bound builtins reconstruct through
+/// `getattr(__self__, __name__)`; module-level builtins reduce by qualname.
+pub unsafe fn descr_builtin_function_reduce(obj: PyObjectRef) -> crate::PyResult {
+    let w_self = unsafe { function_get_self_or_none(obj) };
+    if !w_self.is_null()
+        && !unsafe { pyre_object::is_none(w_self) }
+        && !unsafe { pyre_object::is_module(w_self) }
+    {
+        let name = pyre_object::w_str_new(unsafe { crate::function_get_name(obj) });
+        return Ok(pyre_object::w_tuple_new(vec![
+            crate::baseobjspace::builtin_callable("getattr"),
+            pyre_object::w_tuple_new(vec![w_self, name]),
+        ]));
+    }
+    Ok(pyre_object::w_str_new(&unsafe {
+        function_get_qualname(obj)
+    }))
 }
 
 /// Stamp PyPy `BuiltinFunction.w_moduleobj` after the defining module object
@@ -2196,6 +2227,9 @@ pub unsafe fn descr_method_getattribute(
     obj: PyObjectRef,
     name: PyObjectRef,
 ) -> Result<PyObjectRef, crate::PyError> {
+    if !unsafe { pyre_object::is_str(name) } {
+        return Err(crate::PyError::type_error("attribute name must be string"));
+    }
     let Some(name) = (unsafe { pyre_object::w_str_get_value_opt(name) }) else {
         return Err(crate::PyError::type_error("attribute name must be string"));
     };

--- a/pyre/pyre-interpreter/src/function.rs
+++ b/pyre/pyre-interpreter/src/function.rs
@@ -2125,12 +2125,29 @@ pub unsafe fn descr_method__new__(
     Ok(pyre_object::w_method_new(w_function, w_instance, w_class))
 }
 
+/// `interp2app` unwraps the receiver as `Method` before entering PyPy's
+/// method bodies.  Reproduce that gateway contract before reading the Rust
+/// payload, including for direct descriptor calls with a foreign receiver.
+#[inline]
+pub fn require_method(method: PyObjectRef, name: &str) -> Result<PyObjectRef, crate::PyError> {
+    if method.is_null() || !unsafe { pyre_object::function::is_method(method) } {
+        let received = crate::typedef::r#type(method)
+            .map(|tp| unsafe { pyre_object::w_type_get_name(tp) })
+            .unwrap_or("object");
+        return Err(crate::PyError::type_error(format!(
+            "descriptor '{name}' requires a 'method' object but received a '{received}'"
+        )));
+    }
+    Ok(method)
+}
+
 #[inline]
 pub unsafe fn descr_method_get(
     method: PyObjectRef,
     obj: PyObjectRef,
     cls: PyObjectRef,
 ) -> Result<PyObjectRef, crate::PyError> {
+    let method = require_method(method, "__get__")?;
     let obj_is_none = obj.is_null() || unsafe { pyre_object::is_none(obj) };
     let cls_is_none = cls.is_null() || unsafe { pyre_object::is_none(cls) };
     if obj_is_none && cls_is_none {
@@ -2142,7 +2159,10 @@ pub unsafe fn descr_method_get(
 #[inline]
 pub fn descr_method_call(args: &[PyObjectRef]) -> crate::PyResult {
     let (positional, kwargs) = crate::builtins::split_builtin_kwargs(args);
-    let method = positional.first().copied().unwrap_or(pyre_object::PY_NULL);
+    let method = require_method(
+        positional.first().copied().unwrap_or(pyre_object::PY_NULL),
+        "__call__",
+    )?;
     let call_args = positional.get(1..).unwrap_or(&[]);
     if !crate::builtins::has_real_kwargs(kwargs) {
         return crate::call::call_function_impl_result(method, call_args);
@@ -2170,6 +2190,7 @@ pub unsafe fn descr_method_eq(
     this: PyObjectRef,
     other: PyObjectRef,
 ) -> Result<PyObjectRef, crate::PyError> {
+    let this = require_method(this, "__eq__")?;
     if !unsafe { pyre_object::is_method(other) } {
         return Ok(pyre_object::special::w_not_implemented());
     }
@@ -2187,6 +2208,7 @@ pub unsafe fn descr_method_ne(
     this: PyObjectRef,
     other: PyObjectRef,
 ) -> Result<PyObjectRef, crate::PyError> {
+    require_method(this, "__ne__")?;
     let equal = unsafe { descr_method_eq(this, other)? };
     if unsafe { pyre_object::is_not_implemented(equal) } {
         Ok(equal)
@@ -2199,6 +2221,7 @@ pub unsafe fn descr_method_ne(
 
 #[inline]
 pub unsafe fn descr_method_repr(obj: PyObjectRef) -> Result<PyObjectRef, crate::PyError> {
+    let obj = require_method(obj, "__repr__")?;
     let function = unsafe { pyre_object::w_method_get_func(obj) };
     let instance = unsafe { pyre_object::w_method_get_self(obj) };
     let w_name = match crate::baseobjspace::getattr_str(function, "__qualname__") {
@@ -2227,6 +2250,7 @@ pub unsafe fn descr_method_getattribute(
     obj: PyObjectRef,
     name: PyObjectRef,
 ) -> Result<PyObjectRef, crate::PyError> {
+    let obj = require_method(obj, "__getattribute__")?;
     if !unsafe { pyre_object::is_str(name) } {
         return Err(crate::PyError::type_error("attribute name must be string"));
     }
@@ -2248,6 +2272,7 @@ pub unsafe fn descr_method_getattribute(
 
 #[inline]
 pub unsafe fn descr_method_hash(obj: PyObjectRef) -> Result<i64, crate::PyError> {
+    let obj = require_method(obj, "__hash__")?;
     let function = unsafe { pyre_object::w_method_get_func(obj) };
     let instance = unsafe { pyre_object::w_method_get_self(obj) };
     let x = pyre_object::gc_hook::gc_identity_hash(instance as usize) as i64;
@@ -2258,6 +2283,7 @@ pub unsafe fn descr_method_hash(obj: PyObjectRef) -> Result<i64, crate::PyError>
 
 #[inline]
 pub unsafe fn descr_method__reduce__(obj: PyObjectRef) -> Result<PyObjectRef, crate::PyError> {
+    let obj = require_method(obj, "__reduce__")?;
     let function = unsafe { pyre_object::w_method_get_func(obj) };
     let instance = unsafe { pyre_object::w_method_get_self(obj) };
     let name = crate::baseobjspace::getattr_str(function, "__name__")?;

--- a/pyre/pyre-interpreter/src/jit_fnaddr.rs
+++ b/pyre/pyre-interpreter/src/jit_fnaddr.rs
@@ -2069,6 +2069,10 @@ pub fn jit_static_pytype_addrs() -> Vec<(&'static str, i64)> {
             interp_itertools::COMPRESS_TYPE
         ),
         pytype_addr!(
+            "interp_itertools::STARMAP_TYPE",
+            interp_itertools::STARMAP_TYPE
+        ),
+        pytype_addr!(
             "interp_itertools::PAIRWISE_TYPE",
             interp_itertools::PAIRWISE_TYPE
         ),

--- a/pyre/pyre-interpreter/src/jit_fnaddr.rs
+++ b/pyre/pyre-interpreter/src/jit_fnaddr.rs
@@ -1849,6 +1849,18 @@ pub fn jit_static_pytype_addrs() -> Vec<(&'static str, i64)> {
             dictmultiobject::DICT_ITEMITERATOR_TYPE
         ),
         pytype_addr!(
+            "dictmultiobject::DICT_REVERSEKEYITERATOR_TYPE",
+            dictmultiobject::DICT_REVERSEKEYITERATOR_TYPE
+        ),
+        pytype_addr!(
+            "dictmultiobject::DICT_REVERSEVALUEITERATOR_TYPE",
+            dictmultiobject::DICT_REVERSEVALUEITERATOR_TYPE
+        ),
+        pytype_addr!(
+            "dictmultiobject::DICT_REVERSEITEMITERATOR_TYPE",
+            dictmultiobject::DICT_REVERSEITEMITERATOR_TYPE
+        ),
+        pytype_addr!(
             "interp_exceptions::EXCEPTION_TYPE",
             interp_exceptions::EXCEPTION_TYPE
         ),

--- a/pyre/pyre-interpreter/src/jit_fnaddr.rs
+++ b/pyre/pyre-interpreter/src/jit_fnaddr.rs
@@ -2065,6 +2065,10 @@ pub fn jit_static_pytype_addrs() -> Vec<(&'static str, i64)> {
             interp_itertools::FILTERFALSE_TYPE
         ),
         pytype_addr!(
+            "interp_itertools::COMPRESS_TYPE",
+            interp_itertools::COMPRESS_TYPE
+        ),
+        pytype_addr!(
             "interp_itertools::PAIRWISE_TYPE",
             interp_itertools::PAIRWISE_TYPE
         ),

--- a/pyre/pyre-interpreter/src/module/itertools/interp_itertools.rs
+++ b/pyre/pyre-interpreter/src/module/itertools/interp_itertools.rs
@@ -28,27 +28,13 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
     crate::setattr_str(chain_fn, "from_iterable", from_iterable_fn)
         .expect("attach itertools.chain.from_iterable");
     crate::module_ns_store(ns, "chain", chain_fn);
-    // starmap(function, iterable) — PyPy: W_StarMap.  Calls
-    // `function(*args)` for each `args` tuple produced by the iterable.
+    // PyPy exports W_StarMap.typedef itself; its __new__ stores a live source
+    // iterator and next_w performs one expanded call at a time.
     crate::module_ns_store(
         ns,
         "starmap",
-        crate::make_builtin_function_with_arity(
-            "starmap",
-            |args| {
-                let func = args[0];
-                let items = crate::builtins::collect_iterable(args[1])?;
-                let mut out = Vec::with_capacity(items.len());
-                for item in items {
-                    let call_args = crate::builtins::collect_iterable(item)?;
-                    out.push(crate::call::call_function_impl_result(func, &call_args)?);
-                }
-                let n = out.len();
-                let list = pyre_object::w_list_new(out);
-                Ok(pyre_object::w_seq_iter_new(list, n))
-            },
-            2,
-        ),
+        crate::typedef::gettypefor(&pyre_object::interp_itertools::STARMAP_TYPE)
+            .expect("itertools.starmap TypeDef initialized"),
     );
     // PyPy exposes W_Count.typedef / W_Repeat.typedef themselves from the
     // module, not function-shaped constructor shims.  Their `__new__` slots

--- a/pyre/pyre-interpreter/src/module/itertools/interp_itertools.rs
+++ b/pyre/pyre-interpreter/src/module/itertools/interp_itertools.rs
@@ -380,30 +380,13 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
             Ok(pyre_object::w_seq_iter_new(list, n))
         }),
     );
-    // compress(data, selectors)
+    // W_Compress.typedef is exported directly, matching PyPy's dedicated
+    // live iterator rather than materializing both inputs into a list.
     crate::module_ns_store(
         ns,
         "compress",
-        crate::make_builtin_function_with_arity(
-            "compress",
-            |args| {
-                if args.len() < 2 {
-                    return Ok(pyre_object::w_list_new(vec![]));
-                }
-                let data = crate::builtins::collect_iterable(args[0])?;
-                let selectors = crate::builtins::collect_iterable(args[1])?;
-                let mut out = Vec::new();
-                for (d, s) in data.iter().zip(selectors.iter()) {
-                    if crate::baseobjspace::is_true(*s)? {
-                        out.push(*d);
-                    }
-                }
-                let n = out.len();
-                let list = pyre_object::w_list_new(out);
-                Ok(pyre_object::w_seq_iter_new(list, n))
-            },
-            2,
-        ),
+        crate::typedef::gettypefor(&pyre_object::interp_itertools::COMPRESS_TYPE)
+            .expect("itertools.compress TypeDef initialized"),
     );
     // PyPy exposes these W_Root subclasses through their TypeDefs.  Their
     // `__new__` slots retain the two-argument/subclass-init gateway behavior.

--- a/pyre/pyre-interpreter/src/opcode_ops.rs
+++ b/pyre/pyre-interpreter/src/opcode_ops.rs
@@ -243,44 +243,20 @@ pub fn load_common_constant_value(cc: crate::bytecode::CommonConstant) -> PyObje
 /// sources, generic iterator-protocol fallback otherwise (which surfaces
 /// "Value after * must be an iterable, not <T>" when not iterable).
 pub fn list_extend_value(list: PyObjectRef, iterable: PyObjectRef) -> Result<(), PyError> {
-    unsafe {
-        if pyre_object::is_list(iterable) {
-            let src_len = pyre_object::w_list_len(iterable);
-            for j in 0..src_len {
-                if let Some(item) = pyre_object::w_list_getitem(iterable, j as i64) {
-                    pyre_object::w_list_append(list, item);
-                }
-            }
-            return Ok(());
-        }
-        if pyre_object::is_tuple(iterable) {
-            let src_len = pyre_object::w_tuple_len(iterable);
-            for j in 0..src_len {
-                if let Some(item) = pyre_object::w_tuple_getitem(iterable, j as i64) {
-                    pyre_object::w_list_append(list, item);
-                }
-            }
-            return Ok(());
-        }
-        // Generic iter-protocol fallback for dict/set/range/generator/etc.
-        let iter = crate::baseobjspace::iter(iterable).map_err(|_| {
+    // pyopcode.py LIST_EXTEND calls the target list's `extend` method.  The
+    // builtin body preserves exact-list/tuple storage fast paths while list
+    // and tuple subclasses go through `iter()` so an overridden `__iter__`
+    // is observed.
+    match crate::type_methods::list_method_extend(&[list, iterable]) {
+        Ok(_) => Ok(()),
+        Err(error) if crate::baseobjspace::is_iterable(iterable) => Err(error),
+        Err(_) => unsafe {
             let type_name = (*(*iterable).ob_type).name;
-            PyError::type_error(format!(
-                "Value after * must be an iterable, not {}",
-                type_name
-            ))
-        })?;
-        loop {
-            match crate::baseobjspace::next(iter) {
-                Ok(item) => {
-                    pyre_object::w_list_append(list, item);
-                }
-                Err(e) if e.kind == crate::PyErrorKind::StopIteration => break,
-                Err(e) => return Err(e),
-            }
-        }
+            Err(PyError::type_error(format!(
+                "Value after * must be an iterable, not {type_name}"
+            )))
+        },
     }
-    Ok(())
 }
 
 /// SET_ADD — `set.add(value)` (or `list.append` for the list-shaped

--- a/pyre/pyre-interpreter/src/pycode.rs
+++ b/pyre/pyre-interpreter/src/pycode.rs
@@ -469,7 +469,7 @@ unsafe fn require_code(
         )));
     }
     let ptr = unsafe { w_code_get_ptr(obj) } as *const crate::CodeObject;
-    if ptr.is_null() {
+    if ptr.is_null() || !(ptr as usize).is_multiple_of(std::mem::align_of::<crate::CodeObject>()) {
         return Err(crate::PyError::type_error("code object has no code body"));
     }
     Ok(unsafe { &*ptr })
@@ -576,8 +576,8 @@ pub unsafe fn code_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyErr
     let posonly = unsafe { read_code_u32(args[2], "posonlyargcount")? };
     let kwonly = unsafe { read_code_u32(args[3], "kwonlyargcount")? };
     let nlocals = unsafe { read_code_u32(args[4], "nlocals")? };
-    let stacksize_value = unsafe { crate::builtins::space_index_w(args[5])? };
-    let flags_value = unsafe { crate::builtins::space_index_w(args[6])? };
+    let stacksize_value = unsafe { read_code_c_int(args[5])? };
+    let flags_value = unsafe { read_code_c_int(args[6])? };
     if stacksize_value < 0 || flags_value < 0 {
         return Err(crate::PyError::new(
             crate::PyErrorKind::SystemError,
@@ -598,7 +598,7 @@ pub unsafe fn code_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyErr
     let source_path = unsafe { read_code_str(args[11], "filename")? };
     let obj_name = unsafe { read_code_str(args[12], "name")? };
     let qualname = unsafe { read_code_str(args[13], "qualname")? };
-    let first_line = unsafe { crate::builtins::space_index_w(args[14])? };
+    let first_line = unsafe { read_code_c_int(args[14])? } as i64;
     let first_line_number = if first_line <= 0 {
         None
     } else {
@@ -683,6 +683,8 @@ fn code_data_equal(a: &crate::CodeObject, b: &crate::CodeObject) -> bool {
         && a.freevars == b.freevars
         && a.cellvars == b.cellvars
         && a.names == b.names
+        && a.linetable == b.linetable
+        && a.exceptiontable == b.exceptiontable
         && crate::pyframe::code_constants(a)
             .iter()
             .zip(crate::pyframe::code_constants(b).iter())
@@ -784,6 +786,14 @@ pub unsafe fn code_hash(obj: PyObjectRef) -> Result<i64, crate::PyError> {
         &mut result,
         pyre_object::bytesobject::w_bytes_from_bytes(&code.instructions.original_bytes()),
     )?;
+    add_obj(
+        &mut result,
+        pyre_object::bytesobject::w_bytes_from_bytes(&code.linetable),
+    )?;
+    add_obj(
+        &mut result,
+        pyre_object::bytesobject::w_bytes_from_bytes(&code.exceptiontable),
+    )?;
     for names in [&code.varnames, &code.freevars, &code.cellvars, &code.names] {
         for name in names.iter() {
             add_obj(&mut result, w_str_new(name))?;
@@ -833,10 +843,15 @@ pub unsafe fn code_varname_from_oparg(
             return Ok(w_str_new(name));
         }
         index -= code.varnames.len() as i64;
-        if let Some(name) = code.cellvars.get(index as usize) {
+        let pure_cellvars = code
+            .cellvars
+            .iter()
+            .filter(|cell| !code.varnames.iter().any(|var| var == *cell));
+        let pure_cellvar_count = pure_cellvars.clone().count();
+        if let Some(name) = pure_cellvars.skip(index as usize).next() {
             return Ok(w_str_new(name));
         }
-        index -= code.cellvars.len() as i64;
+        index -= pure_cellvar_count as i64;
         if let Some(name) = code.freevars.get(index as usize) {
             return Ok(w_str_new(name));
         }
@@ -977,16 +992,14 @@ pub unsafe fn code_replace(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::P
     if let Some(v) = get("co_kwonlyargcount") {
         code.kwonlyarg_count = unsafe { read_code_u32(v, "co_kwonlyargcount")? };
     }
-    // co_nlocals is derived from the varnames length; it is accepted for
-    // constructor-signature compatibility but carries no independent field.
-    if let Some(v) = get("co_nlocals") {
-        let _ = unsafe { read_code_u32(v, "co_nlocals")? };
-    }
+    let requested_nlocals = get("co_nlocals")
+        .map(|v| unsafe { read_code_u32(v, "co_nlocals") })
+        .transpose()?;
     if let Some(v) = get("co_stacksize") {
         code.max_stackdepth = unsafe { read_code_u32(v, "co_stacksize")? };
     }
     if let Some(v) = get("co_flags") {
-        let value = unsafe { crate::builtins::space_index_w(v)? };
+        let value = unsafe { read_code_c_int(v)? };
         if value < 0 {
             return Err(crate::PyError::value_error(
                 "co_flags must be a positive integer",
@@ -996,7 +1009,7 @@ pub unsafe fn code_replace(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::P
         code.flags = crate::bytecode::CodeFlags::from_bits_retain(bits);
     }
     if let Some(v) = get("co_firstlineno") {
-        let n = unsafe { crate::builtins::space_index_w(v)? };
+        let n = unsafe { read_code_c_int(v)? } as i64;
         if n < 0 {
             return Err(crate::PyError::value_error(
                 "co_firstlineno must be a positive integer",
@@ -1043,12 +1056,50 @@ pub unsafe fn code_replace(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::P
         code.instructions = unsafe { read_code_units(v)? };
     }
 
+    if requested_nlocals.is_some_and(|n| n as usize != code.varnames.len()) {
+        return Err(crate::PyError::value_error(
+            "code: co_nlocals != len(co_varnames)",
+        ));
+    }
+    if code.posonlyarg_count > code.arg_count {
+        return Err(crate::PyError::new(
+            crate::PyErrorKind::SystemError,
+            "Objects/codeobject.c: bad argument to internal function",
+        ));
+    }
+    if code.arg_count as usize + code.kwonlyarg_count as usize > code.varnames.len() {
+        return Err(crate::PyError::value_error(
+            "code: co_varnames is too small",
+        ));
+    }
+
+    // CPython's locals-plus table marks local/cell aliases in their existing
+    // local slot, then appends pure cells and free variables.
+    let mut localspluskinds = vec![crate::bytecode::CO_FAST_LOCAL; code.varnames.len()];
+    for cell in code.cellvars.iter() {
+        if let Some(index) = code.varnames.iter().position(|name| name == cell) {
+            localspluskinds[index] |= crate::bytecode::CO_FAST_CELL;
+        } else {
+            localspluskinds.push(crate::bytecode::CO_FAST_CELL);
+        }
+    }
+    localspluskinds.extend(std::iter::repeat_n(
+        crate::bytecode::CO_FAST_FREE,
+        code.freevars.len(),
+    ));
+    code.localspluskinds = localspluskinds.into_boxed_slice();
+    code.locations = rustpython_compiler_core::marshal::linetable_to_locations(
+        &code.linetable,
+        firstlineno_raw,
+        code.instructions.len(),
+    );
+
     Ok(box_code_constant_with_firstlineno(&code, firstlineno_raw))
 }
 
 /// A non-negative `co_*` count argument as `u32`.
 unsafe fn read_code_u32(v: PyObjectRef, field: &str) -> Result<u32, crate::PyError> {
-    let n = unsafe { crate::builtins::space_index_w(v)? };
+    let n = unsafe { read_code_c_int(v)? } as i64;
     if n < 0 {
         let message = if field.starts_with("co_") {
             format!("{field} must be a positive integer")
@@ -1058,6 +1109,17 @@ unsafe fn read_code_u32(v: PyObjectRef, field: &str) -> Result<u32, crate::PyErr
         return Err(crate::PyError::value_error(message));
     }
     Ok(n as u32)
+}
+
+/// Argument Clinic converts every public code-object integer through C `int`.
+unsafe fn read_code_c_int(v: PyObjectRef) -> Result<i32, crate::PyError> {
+    let n = unsafe { crate::builtins::space_index_w(v)? };
+    i32::try_from(n).map_err(|_| {
+        crate::PyError::new(
+            crate::PyErrorKind::OverflowError,
+            "Python int too large to convert to C int",
+        )
+    })
 }
 
 /// A `str` `co_*` field as an owned `String` (the compiler `Name` type).
@@ -1174,6 +1236,14 @@ unsafe fn obj_to_constant_data(
                 value: pyre_object::w_float_get_value(obj),
             });
         }
+        if pyre_object::is_complex(obj) {
+            return Ok(ConstantData::Complex {
+                value: num_complex::Complex64::new(
+                    pyre_object::w_complex_get_real(obj),
+                    pyre_object::w_complex_get_imag(obj),
+                ),
+            });
+        }
         if pyre_object::is_str(obj) {
             return Ok(ConstantData::Str {
                 value: pyre_object::w_str_get_wtf8(obj).to_owned(),
@@ -1193,6 +1263,13 @@ unsafe fn obj_to_constant_data(
                 elements.push(obj_to_constant_data(e)?);
             }
             return Ok(ConstantData::Tuple { elements });
+        }
+        if pyre_object::setobject::is_frozenset(obj) {
+            let elements = pyre_object::w_set_items(obj)
+                .into_iter()
+                .map(|item| obj_to_constant_data(item))
+                .collect::<Result<Vec<_>, _>>()?;
+            return Ok(ConstantData::Frozenset { elements });
         }
         if is_code(obj) {
             let ptr = w_code_get_ptr(obj) as *const crate::CodeObject;

--- a/pyre/pyre-interpreter/src/pycode.rs
+++ b/pyre/pyre-interpreter/src/pycode.rs
@@ -905,29 +905,58 @@ pub unsafe fn code_branches(obj: PyObjectRef) -> Result<PyObjectRef, crate::PyEr
     let code = unsafe { require_code(obj, "co_branches")? };
     let mut rows = Vec::new();
     let mut index = 0usize;
+    let mut op_arg = 0usize;
     while index < code.instructions.len() {
         let op = code.instructions.read_op(index).deoptimize();
         let next = index + 1 + op.cache_entries();
-        if op.has_jump() && !op.is_unconditional_jump() {
-            let delta = u8::from(code.instructions.read_arg(index)) as usize;
-            let target = next.saturating_add(delta);
-            // Python 3.14 inserts NOT_TAKEN at the fallthrough edge so branch
-            // instrumentation can distinguish the untaken path. `co_branches`
-            // reports the first real instruction after that marker.
-            let fallthrough = if next < code.instructions.len()
-                && matches!(
-                    code.instructions.read_op(next).deoptimize(),
+        let arg = u8::from(code.instructions.read_arg(index)) as usize;
+        match op {
+            crate::bytecode::Instruction::ExtendedArg => {
+                op_arg = (op_arg << 8) | arg;
+            }
+            crate::bytecode::Instruction::ForIter { .. } => {
+                op_arg = (op_arg << 8) | arg;
+                rows.push(w_tuple_new(vec![
+                    w_int_new((index * 2) as i64),
+                    w_int_new((next * 2) as i64),
+                    w_int_new(((next + op_arg + 2) * 2) as i64),
+                ]));
+                op_arg = 0;
+            }
+            crate::bytecode::Instruction::PopJumpIfFalse { .. }
+            | crate::bytecode::Instruction::PopJumpIfTrue { .. }
+            | crate::bytecode::Instruction::PopJumpIfNone { .. }
+            | crate::bytecode::Instruction::PopJumpIfNotNone { .. } => {
+                op_arg = (op_arg << 8) | arg;
+                // Python 3.14 inserts NOT_TAKEN at the fallthrough edge so
+                // branch instrumentation can distinguish the untaken path.
+                let not_taken = next + 1;
+                rows.push(w_tuple_new(vec![
+                    w_int_new((index * 2) as i64),
+                    w_int_new((not_taken * 2) as i64),
+                    w_int_new(((next + op_arg) * 2) as i64),
+                ]));
+                op_arg = 0;
+            }
+            crate::bytecode::Instruction::EndAsyncFor => {
+                op_arg = (op_arg << 8) | arg;
+                let source = next - op_arg;
+                debug_assert!(matches!(
+                    code.instructions.read_op(source).deoptimize(),
+                    crate::bytecode::Instruction::EndSend
+                ));
+                debug_assert!(matches!(
+                    code.instructions.read_op(source + 1).deoptimize(),
                     crate::bytecode::Instruction::NotTaken
-                ) {
-                next + 1
-            } else {
-                next
-            };
-            rows.push(w_tuple_new(vec![
-                w_int_new((index * 2) as i64),
-                w_int_new((fallthrough * 2) as i64),
-                w_int_new((target * 2) as i64),
-            ]));
+                ));
+                rows.push(w_tuple_new(vec![
+                    w_int_new((source * 2) as i64),
+                    w_int_new(((source + 2) * 2) as i64),
+                    w_int_new((next * 2) as i64),
+                ]));
+                op_arg = 0;
+            }
+            _ => op_arg = 0,
         }
         index = next.max(index + 1);
     }

--- a/pyre/pyre-interpreter/src/runtime_ops.rs
+++ b/pyre/pyre-interpreter/src/runtime_ops.rs
@@ -421,9 +421,11 @@ where
                 on_user(callable)
             }
         } else {
+            let type_name = crate::typedef::r#type(callable)
+                .map(|tp| unsafe { pyre_object::w_type_get_name(tp) })
+                .unwrap_or_else(|| unsafe { (*(*callable).ob_type).name });
             Err(PyError::type_error(format!(
-                "'{}' object is not callable",
-                (*(*callable).ob_type).name
+                "'{type_name}' object is not callable"
             )))
         }
     }

--- a/pyre/pyre-interpreter/src/type_methods.rs
+++ b/pyre/pyre-interpreter/src/type_methods.rs
@@ -346,6 +346,50 @@ pub(crate) fn require_set_iterator_receiver(
     Ok(receiver)
 }
 
+/// Receiver validation supplied by `W_AbstractRangeIterator.typedef`'s
+/// gateways. Python 3.14 gives the machine-word and arbitrary-precision
+/// implementations distinct public owner names even though PyPy shares the
+/// abstract typedef implementation.
+pub(crate) fn require_range_iterator_receiver(
+    args: &[PyObjectRef],
+    name: &str,
+    method_descriptor: bool,
+    long: bool,
+) -> Result<PyObjectRef, crate::PyError> {
+    let owner = if long {
+        "longrange_iterator"
+    } else {
+        "range_iterator"
+    };
+    let Some(&receiver) = args.first() else {
+        let message = if method_descriptor {
+            format!("unbound method {owner}.{name}() needs an argument")
+        } else {
+            format!("descriptor '{name}' of '{owner}' object needs an argument")
+        };
+        return Err(crate::PyError::type_error(message));
+    };
+    let matches = unsafe {
+        if long {
+            pyre_object::is_long_range_iter(receiver)
+        } else {
+            pyre_object::is_range_iter(receiver)
+        }
+    };
+    if !matches {
+        let received = crate::baseobjspace::object_functionstr_type_name(receiver);
+        let message = if method_descriptor {
+            format!(
+                "descriptor '{name}' for '{owner}' objects doesn't apply to a '{received}' object"
+            )
+        } else {
+            format!("descriptor '{name}' requires a '{owner}' object but received a '{received}'")
+        };
+        return Err(crate::PyError::type_error(message));
+    }
+    Ok(receiver)
+}
+
 /// Receiver-only arity for `str` methods that take no arguments (`isspace`,
 /// `lower`, …).  Rejects a missing receiver and any extra positional argument,
 /// matching `str.{name}() takes no arguments (N given)`.

--- a/pyre/pyre-interpreter/src/type_methods.rs
+++ b/pyre/pyre-interpreter/src/type_methods.rs
@@ -313,6 +313,39 @@ pub(crate) fn require_frozenset_receiver(
     Ok(receiver)
 }
 
+/// The receiver check supplied by PyPy's
+/// `interp2app(W_SetIterObject.descr_*)` gateway.  Python 3.14 exposes
+/// `__iter__`/`__next__` as slot wrappers and the remaining operations as
+/// method descriptors.
+pub(crate) fn require_set_iterator_receiver(
+    args: &[PyObjectRef],
+    name: &str,
+    method_descriptor: bool,
+) -> Result<PyObjectRef, crate::PyError> {
+    let Some(&receiver) = args.first() else {
+        let message = if method_descriptor {
+            format!("unbound method set_iterator.{name}() needs an argument")
+        } else {
+            format!("descriptor '{name}' of 'set_iterator' object needs an argument")
+        };
+        return Err(crate::PyError::type_error(message));
+    };
+    if !unsafe { pyre_object::is_set_iterator(receiver) } {
+        let received = crate::baseobjspace::object_functionstr_type_name(receiver);
+        let message = if method_descriptor {
+            format!(
+                "descriptor '{name}' for 'set_iterator' objects doesn't apply to a '{received}' object"
+            )
+        } else {
+            format!(
+                "descriptor '{name}' requires a 'set_iterator' object but received a '{received}'"
+            )
+        };
+        return Err(crate::PyError::type_error(message));
+    }
+    Ok(receiver)
+}
+
 /// Receiver-only arity for `str` methods that take no arguments (`isspace`,
 /// `lower`, …).  Rejects a missing receiver and any extra positional argument,
 /// matching `str.{name}() takes no arguments (N given)`.

--- a/pyre/pyre-interpreter/src/type_methods.rs
+++ b/pyre/pyre-interpreter/src/type_methods.rs
@@ -282,6 +282,37 @@ pub(crate) fn require_set_receiver(
     Ok(receiver)
 }
 
+/// The receiver check supplied by PyPy's
+/// `interp2app(W_FrozensetObject.descr_*)` gateway.  The inherited
+/// `W_BaseSetObject` implementation is shared with set, while the gateway
+/// still requires a frozenset receiver.
+pub(crate) fn require_frozenset_receiver(
+    args: &[PyObjectRef],
+    name: &str,
+    method_descriptor: bool,
+) -> Result<PyObjectRef, crate::PyError> {
+    let Some(&receiver) = args.first() else {
+        let message = if method_descriptor {
+            format!("unbound method frozenset.{name}() needs an argument")
+        } else {
+            format!("descriptor '{name}' of 'frozenset' object needs an argument")
+        };
+        return Err(crate::PyError::type_error(message));
+    };
+    if !unsafe { pyre_object::is_frozenset(receiver) } {
+        let received = crate::baseobjspace::object_functionstr_type_name(receiver);
+        let message = if method_descriptor {
+            format!(
+                "descriptor '{name}' for 'frozenset' objects doesn't apply to a '{received}' object"
+            )
+        } else {
+            format!("descriptor '{name}' requires a 'frozenset' object but received a '{received}'")
+        };
+        return Err(crate::PyError::type_error(message));
+    }
+    Ok(receiver)
+}
+
 /// Receiver-only arity for `str` methods that take no arguments (`isspace`,
 /// `lower`, …).  Rejects a missing receiver and any extra positional argument,
 /// matching `str.{name}() takes no arguments (N given)`.

--- a/pyre/pyre-interpreter/src/type_methods.rs
+++ b/pyre/pyre-interpreter/src/type_methods.rs
@@ -253,6 +253,35 @@ pub(crate) fn require_tuple_receiver(
     Ok(receiver)
 }
 
+/// The receiver check supplied by PyPy's
+/// `interp2app(W_SetObject.descr_*)` gateway.  CPython 3.14 exposes set's
+/// slot wrappers and ordinary methods as two descriptor kinds with distinct
+/// public mismatch messages.
+pub(crate) fn require_set_receiver(
+    args: &[PyObjectRef],
+    name: &str,
+    method_descriptor: bool,
+) -> Result<PyObjectRef, crate::PyError> {
+    let Some(&receiver) = args.first() else {
+        let message = if method_descriptor {
+            format!("unbound method set.{name}() needs an argument")
+        } else {
+            format!("descriptor '{name}' of 'set' object needs an argument")
+        };
+        return Err(crate::PyError::type_error(message));
+    };
+    if !unsafe { pyre_object::is_set(receiver) } {
+        let received = crate::baseobjspace::object_functionstr_type_name(receiver);
+        let message = if method_descriptor {
+            format!("descriptor '{name}' for 'set' objects doesn't apply to a '{received}' object")
+        } else {
+            format!("descriptor '{name}' requires a 'set' object but received a '{received}'")
+        };
+        return Err(crate::PyError::type_error(message));
+    }
+    Ok(receiver)
+}
+
 /// Receiver-only arity for `str` methods that take no arguments (`isspace`,
 /// `lower`, …).  Rejects a missing receiver and any extra positional argument,
 /// matching `str.{name}() takes no arguments (N given)`.

--- a/pyre/pyre-interpreter/src/type_methods.rs
+++ b/pyre/pyre-interpreter/src/type_methods.rs
@@ -193,6 +193,35 @@ pub(crate) fn require_receiver(args: &[PyObjectRef], name: &str) -> Result<(), c
     Ok(())
 }
 
+/// The receiver check normally supplied by PyPy's
+/// `interp2app(W_ListObject.descr_*)` gateway.  CPython 3.14 exposes list's
+/// slot wrappers and ordinary methods as two descriptor kinds with distinct
+/// public mismatch messages, so callers identify which surface they expose.
+pub(crate) fn require_list_receiver(
+    args: &[PyObjectRef],
+    name: &str,
+    method_descriptor: bool,
+) -> Result<PyObjectRef, crate::PyError> {
+    let Some(&receiver) = args.first() else {
+        let message = if method_descriptor {
+            format!("unbound method list.{name}() needs an argument")
+        } else {
+            format!("descriptor '{name}' of 'list' object needs an argument")
+        };
+        return Err(crate::PyError::type_error(message));
+    };
+    if !unsafe { pyre_object::is_list(receiver) } {
+        let received = crate::baseobjspace::object_functionstr_type_name(receiver);
+        let message = if method_descriptor {
+            format!("descriptor '{name}' for 'list' objects doesn't apply to a '{received}' object")
+        } else {
+            format!("descriptor '{name}' requires a 'list' object but received a '{received}'")
+        };
+        return Err(crate::PyError::type_error(message));
+    }
+    Ok(receiver)
+}
+
 /// Receiver-only arity for `str` methods that take no arguments (`isspace`,
 /// `lower`, …).  Rejects a missing receiver and any extra positional argument,
 /// matching `str.{name}() takes no arguments (N given)`.
@@ -215,12 +244,14 @@ pub(crate) fn require_no_args(args: &[PyObjectRef], name: &str) -> Result<(), cr
 // All take self (list) as first arg.
 
 pub fn list_method_append(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    require_list_receiver(args, "append", true)?;
     arity_exact(args, "list.append", 1)?;
     unsafe { w_list_append(args[0], args[1]) };
     Ok(w_none())
 }
 
 pub fn list_method_extend(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    require_list_receiver(args, "extend", true)?;
     arity_exact(args, "list.extend", 1)?;
     let list = args[0];
     let other = args[1];
@@ -277,6 +308,7 @@ pub fn list_method_extend(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::Py
 
 /// PyPy: listobject.py descr_insert — list.insert(index, item)
 pub fn list_method_insert(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    require_list_receiver(args, "insert", true)?;
     arity_exact_unpack(args, "insert", 2)?;
     // `@unwrap_spec(index='index')` → getindex_w(index, OverflowError): coerce
     // through `__index__`; `get_positive_index` then clamps to `[0, len]`
@@ -290,7 +322,7 @@ pub fn list_method_insert(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::Py
 /// listobject.py:759-772 — empty list raises "pop from empty list",
 /// otherwise out-of-range raises "pop index out of range".
 pub fn list_method_pop(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    require_receiver(args, "pop")?;
+    require_list_receiver(args, "pop", true)?;
     // `descr_pop` checks arity before touching the list, so `pop(1, 2)` on an
     // empty list reports the surplus argument rather than "pop from empty list".
     arity_at_most(args, "pop", 1)?;
@@ -319,14 +351,14 @@ pub fn list_method_pop(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyErr
 
 /// PyPy: listobject.py descr_clear — list.clear()
 pub fn list_method_clear(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    require_receiver(args, "clear")?;
+    require_list_receiver(args, "clear", true)?;
     unsafe { pyre_object::listobject::w_list_clear(args[0]) };
     Ok(w_none())
 }
 
 /// PyPy: listobject.py descr_copy — list.copy()
 pub fn list_method_copy(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    require_receiver(args, "copy")?;
+    require_list_receiver(args, "copy", true)?;
     let list = args[0];
     unsafe {
         let n = w_list_len(list);
@@ -342,14 +374,14 @@ pub fn list_method_copy(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyEr
 
 /// PyPy: listobject.py descr_reverse — list.reverse()
 pub fn list_method_reverse(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    require_receiver(args, "reverse")?;
+    require_list_receiver(args, "reverse", true)?;
     unsafe { pyre_object::listobject::w_list_reverse(args[0]) };
     Ok(w_none())
 }
 
 /// PyPy: listobject.py descr_sort — list.sort()
 pub fn list_method_sort(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    require_receiver(args, "sort")?;
+    require_list_receiver(args, "sort", true)?;
     let list = args[0];
     // Keep the argument decoding shared with `sorted()` before changing the
     // receiver's visible storage.
@@ -420,6 +452,7 @@ pub fn list_method_sort(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyEr
 
 /// listobject.py:795 `descr_index` — list.index(value[, start[, stop]]).
 pub fn list_method_index(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    require_list_receiver(args, "index", true)?;
     arity_at_least(args, "index", 1)?;
     arity_at_most(args, "index", 3)?;
     let list = args[0];
@@ -461,6 +494,7 @@ pub fn list_method_index(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyE
 
 /// listobject.py:744 `descr_count` — list.count(value)
 pub fn list_method_count(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    require_list_receiver(args, "count", true)?;
     arity_exact(args, "list.count", 1)?;
     let list = args[0];
     let value = args[1];
@@ -475,6 +509,7 @@ pub fn list_method_count(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyE
 
 /// listobject.py:782 `descr_remove` — list.remove(value).
 pub fn list_method_remove(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    require_list_receiver(args, "remove", true)?;
     arity_exact(args, "list.remove", 1)?;
     crate::listobject::w_list_remove(args[0], args[1])?;
     Ok(w_none())

--- a/pyre/pyre-interpreter/src/type_methods.rs
+++ b/pyre/pyre-interpreter/src/type_methods.rs
@@ -222,6 +222,37 @@ pub(crate) fn require_list_receiver(
     Ok(receiver)
 }
 
+/// The receiver check supplied by PyPy's
+/// `interp2app(W_AbstractTupleObject.descr_*)` gateway.  As with list,
+/// CPython 3.14 distinguishes slot-wrapper and method-descriptor mismatch
+/// messages on the public surface.
+pub(crate) fn require_tuple_receiver(
+    args: &[PyObjectRef],
+    name: &str,
+    method_descriptor: bool,
+) -> Result<PyObjectRef, crate::PyError> {
+    let Some(&receiver) = args.first() else {
+        let message = if method_descriptor {
+            format!("unbound method tuple.{name}() needs an argument")
+        } else {
+            format!("descriptor '{name}' of 'tuple' object needs an argument")
+        };
+        return Err(crate::PyError::type_error(message));
+    };
+    if !unsafe { pyre_object::is_tuple(receiver) } {
+        let received = crate::baseobjspace::object_functionstr_type_name(receiver);
+        let message = if method_descriptor {
+            format!(
+                "descriptor '{name}' for 'tuple' objects doesn't apply to a '{received}' object"
+            )
+        } else {
+            format!("descriptor '{name}' requires a 'tuple' object but received a '{received}'")
+        };
+        return Err(crate::PyError::type_error(message));
+    }
+    Ok(receiver)
+}
+
 /// Receiver-only arity for `str` methods that take no arguments (`isspace`,
 /// `lower`, …).  Rejects a missing receiver and any extra positional argument,
 /// matching `str.{name}() takes no arguments (N given)`.
@@ -5270,25 +5301,29 @@ mod dict_method_tests {
 
 /// PyPy: tupleobject.py descr_index — tuple.index(value)
 pub fn tuple_method_index(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    require_tuple_receiver(args, "index", true)?;
     if args.len() < 2 {
         return Err(crate::PyError::type_error(format!(
             "index expected at least 1 argument, got {}",
             args.len().saturating_sub(1)
         )));
     }
+    if args.len() > 4 {
+        return Err(crate::PyError::type_error(format!(
+            "index expected at most 3 arguments, got {}",
+            args.len() - 1
+        )));
+    }
     let tup = args[0];
     let value = args[1];
-    unsafe {
-        let n = w_tuple_len(tup);
-        for i in 0..n {
-            if let Some(item) = w_tuple_getitem(tup, i as i64) {
-                if std::ptr::eq(item, value) {
-                    return Ok(w_int_new(i as i64));
-                }
-                if is_int(item) && is_int(value) && w_int_get_value(item) == w_int_get_value(value)
-                {
-                    return Ok(w_int_new(i as i64));
-                }
+    let length = unsafe { w_tuple_len(tup) } as i64;
+    let w_start = args.get(2).copied().unwrap_or_else(|| w_int_new(0));
+    let w_stop = args.get(3).copied().unwrap_or_else(|| w_int_new(i64::MAX));
+    let (start, stop) = crate::sliceobject::unwrap_start_stop(length, w_start, w_stop)?;
+    for i in start..stop.min(length) {
+        if let Some(item) = unsafe { w_tuple_getitem(tup, i) } {
+            if crate::baseobjspace::eq_w(item, value)? {
+                return Ok(w_int_new(i));
             }
         }
     }
@@ -5299,6 +5334,7 @@ pub fn tuple_method_index(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::Py
 
 /// PyPy: tupleobject.py descr_count — tuple.count(value)
 pub fn tuple_method_count(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    require_tuple_receiver(args, "count", true)?;
     if args.len() != 2 {
         return Err(crate::PyError::type_error(format!(
             "tuple.count() takes exactly one argument ({} given)",
@@ -5312,11 +5348,7 @@ pub fn tuple_method_count(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::Py
         let n = w_tuple_len(tup);
         for i in 0..n {
             if let Some(item) = w_tuple_getitem(tup, i as i64) {
-                if std::ptr::eq(item, value)
-                    || (is_int(item)
-                        && is_int(value)
-                        && w_int_get_value(item) == w_int_get_value(value))
-                {
+                if crate::baseobjspace::eq_w(item, value)? {
                     count += 1;
                 }
             }

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -2565,7 +2565,14 @@ fn filter_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError>
 /// W_Zip.descr___new__`.
 fn zip_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     let cls = args.first().copied().unwrap_or(pyre_object::PY_NULL);
+    let _roots = pyre_object::gc_roots::push_roots();
+    pyre_object::gc_roots::pin_root(cls);
+    let cls_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     let value = crate::builtins::builtin_zip(args.get(1..).unwrap_or(&[]))?;
+    pyre_object::gc_roots::pin_root(value);
+    let value_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+    let value = unsafe { pyre_object::gc_roots::shadow_stack_get(value_slot) };
+    let cls = unsafe { pyre_object::gc_roots::shadow_stack_get(cls_slot) };
     if let Some(sub) = subclass_to_tag(cls, &pyre_object::functional::ZIP_TYPE)? {
         unsafe {
             (*value).w_class = sub;
@@ -3149,10 +3156,10 @@ fn init_zip_type(ns: PyObjectRef) {
     for (name, function, arity) in [
         (
             "__iter__",
-            crate::baseobjspace::iter_self_method as DunderFn,
+            crate::baseobjspace::zip_iter_method as DunderFn,
             1,
         ),
-        ("__next__", crate::baseobjspace::iter_next_method, 1),
+        ("__next__", crate::baseobjspace::zip_next_method, 1),
         ("__reduce__", crate::baseobjspace::zip_reduce_method, 1),
         ("__setstate__", crate::baseobjspace::zip_setstate_method, 2),
     ] {

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -1607,6 +1607,11 @@ fn module_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError>
 /// in the module dict.
 fn module_descr_init(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     let (positional, kwargs) = crate::builtins::split_builtin_kwargs(args);
+    if positional.is_empty() {
+        return Err(crate::PyError::type_error(
+            "descriptor '__init__' of 'module' object needs an argument",
+        ));
+    }
     let given = positional.len().saturating_sub(1);
     if given > 2 {
         return Err(crate::PyError::type_error(format!(
@@ -1680,7 +1685,17 @@ fn module_descr_init(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError
 /// `_frozen_importlib._module_repr`, which implements the spec/file/name
 /// precedence shared by CPython 3.14.
 fn module_descr_repr(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    Ok(pyre_object::w_str_new(&module_repr_string(args[0])?))
+    let module = module_require(args.first().copied().unwrap_or(PY_NULL), "__repr__")?;
+    Ok(pyre_object::w_str_new(&module_repr_string(module)?))
+}
+
+fn module_require(obj: PyObjectRef, name: &str) -> Result<PyObjectRef, crate::PyError> {
+    if obj.is_null() || !unsafe { pyre_object::is_module(obj) } {
+        return Err(crate::PyError::type_error(format!(
+            "descriptor '{name}' for 'module' objects doesn't apply to this object"
+        )));
+    }
+    Ok(obj)
 }
 
 pub(crate) fn module_repr_string(module: PyObjectRef) -> Result<String, crate::PyError> {
@@ -1754,14 +1769,14 @@ pub(crate) fn module_repr_string(module: PyObjectRef) -> Result<String, crate::P
 /// module-specific AttributeError wording, so the descriptor is the direct
 /// entry point into that same implementation.
 fn module_descr_getattribute(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    let module = args[0];
+    let module = module_require(args.first().copied().unwrap_or(PY_NULL), "__getattribute__")?;
     let name = crate::baseobjspace::text_w(args[1])?;
     crate::baseobjspace::getattr_str(module, name)
 }
 
 /// module.py:164-173 `Module.descr_module__dir__`.
 fn module_descr_dir(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    let module = args[0];
+    let module = module_require(args.first().copied().unwrap_or(PY_NULL), "__dir__")?;
     let w_dict = unsafe { pyre_object::w_module_get_w_dict(module) };
     if w_dict.is_null()
         || (!unsafe { pyre_object::is_dict(w_dict) }
@@ -1782,7 +1797,7 @@ fn module_descr_dir(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError>
 }
 
 fn module_annotations_get(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    let module = args[1];
+    let module = module_require(args.get(1).copied().unwrap_or(PY_NULL), "__annotations__")?;
     let w_dict = unsafe { pyre_object::w_module_get_w_dict(module) };
     let _roots = pyre_object::gc_roots::push_roots();
     let dict_slot = pyre_object::gc_roots::shadow_stack_len();
@@ -1823,7 +1838,7 @@ fn module_annotations_get(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::Py
 }
 
 fn module_annotations_set(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    let module = args[1];
+    let module = module_require(args.get(1).copied().unwrap_or(PY_NULL), "__annotations__")?;
     let value = args[2];
     let w_dict = unsafe { pyre_object::w_module_get_w_dict(module) };
     let _roots = pyre_object::gc_roots::push_roots();
@@ -1846,7 +1861,7 @@ fn module_annotations_set(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::Py
 }
 
 fn module_annotations_del(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    let module = args[1];
+    let module = module_require(args.get(1).copied().unwrap_or(PY_NULL), "__annotations__")?;
     let w_dict = unsafe { pyre_object::w_module_get_w_dict(module) };
     let _roots = pyre_object::gc_roots::push_roots();
     let dict_slot = pyre_object::gc_roots::shadow_stack_len();
@@ -1868,7 +1883,7 @@ fn module_annotations_del(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::Py
 }
 
 fn module_annotate_get(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    let module = args[1];
+    let module = module_require(args.get(1).copied().unwrap_or(PY_NULL), "__annotate__")?;
     let w_dict = unsafe { pyre_object::w_module_get_w_dict(module) };
     if let Some(annotate) = crate::baseobjspace::finditem_str(w_dict, "__annotate__")? {
         return Ok(annotate);
@@ -1879,7 +1894,7 @@ fn module_annotate_get(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyErr
 }
 
 fn module_annotate_set(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    let module = args[1];
+    let module = module_require(args.get(1).copied().unwrap_or(PY_NULL), "__annotate__")?;
     let value = args[2];
     if !unsafe { pyre_object::is_none(value) } && !crate::baseobjspace::callable_w(value) {
         return Err(crate::PyError::type_error(
@@ -9190,16 +9205,37 @@ fn init_function_type(ns: PyObjectRef) {
     // CPython 3.14 `function.__annotate__`: callable-or-None, not deletable.
     let annotate_getter = make_builtin_function("__annotate__", |args| {
         let function = args.get(1).copied().unwrap_or(pyre_object::PY_NULL);
+        if function.is_null()
+            || !unsafe { pyre_object::py_type_check(function, &crate::function::FUNCTION_TYPE) }
+        {
+            return Err(crate::PyError::type_error(
+                "descriptor '__annotate__' requires a 'function' object",
+            ));
+        }
         Ok(unsafe { crate::function::function_get_annotate(function) })
     });
     let annotate_setter = make_builtin_function("__annotate__", |args| {
         let function = args.get(1).copied().unwrap_or(pyre_object::PY_NULL);
+        if function.is_null()
+            || !unsafe { pyre_object::py_type_check(function, &crate::function::FUNCTION_TYPE) }
+        {
+            return Err(crate::PyError::type_error(
+                "descriptor '__annotate__' requires a 'function' object",
+            ));
+        }
         let value = args.get(2).copied().unwrap_or(pyre_object::PY_NULL);
         unsafe { crate::function::function_set_annotate(function, value)? };
         Ok(pyre_object::w_none())
     });
     let annotate_deleter = make_builtin_function("__annotate__", |args| {
         let function = args.get(1).copied().unwrap_or(pyre_object::PY_NULL);
+        if function.is_null()
+            || !unsafe { pyre_object::py_type_check(function, &crate::function::FUNCTION_TYPE) }
+        {
+            return Err(crate::PyError::type_error(
+                "descriptor '__annotate__' requires a 'function' object",
+            ));
+        }
         unsafe { crate::function::function_set_annotate(function, pyre_object::PY_NULL)? };
         Ok(pyre_object::w_none())
     });
@@ -9213,16 +9249,37 @@ fn init_function_type(ns: PyObjectRef) {
     // CPython 3.14 `function.__type_params__`: tuple-only and not deletable.
     let typeparams_getter = make_builtin_function("__type_params__", |args| {
         let function = args.get(1).copied().unwrap_or(pyre_object::PY_NULL);
+        if function.is_null()
+            || !unsafe { pyre_object::py_type_check(function, &crate::function::FUNCTION_TYPE) }
+        {
+            return Err(crate::PyError::type_error(
+                "descriptor '__type_params__' requires a 'function' object",
+            ));
+        }
         Ok(unsafe { crate::function::function_get_typeparams(function) })
     });
     let typeparams_setter = make_builtin_function("__type_params__", |args| {
         let function = args.get(1).copied().unwrap_or(pyre_object::PY_NULL);
+        if function.is_null()
+            || !unsafe { pyre_object::py_type_check(function, &crate::function::FUNCTION_TYPE) }
+        {
+            return Err(crate::PyError::type_error(
+                "descriptor '__type_params__' requires a 'function' object",
+            ));
+        }
         let value = args.get(2).copied().unwrap_or(pyre_object::PY_NULL);
         unsafe { crate::function::function_set_typeparams(function, value)? };
         Ok(pyre_object::w_none())
     });
     let typeparams_deleter = make_builtin_function("__type_params__", |args| {
         let function = args.get(1).copied().unwrap_or(pyre_object::PY_NULL);
+        if function.is_null()
+            || !unsafe { pyre_object::py_type_check(function, &crate::function::FUNCTION_TYPE) }
+        {
+            return Err(crate::PyError::type_error(
+                "descriptor '__type_params__' requires a 'function' object",
+            ));
+        }
         unsafe { crate::function::function_set_typeparams(function, pyre_object::PY_NULL)? };
         Ok(pyre_object::w_none())
     });
@@ -9411,11 +9468,7 @@ fn init_builtin_function_type(ns: PyObjectRef) {
             "__reduce__",
             make_builtin_function_with_arity(
                 "__reduce__",
-                |args| {
-                    Ok(pyre_object::w_str_new(&unsafe {
-                        crate::function::function_get_qualname(args[0])
-                    }))
-                },
+                |args| unsafe { crate::function::descr_builtin_function_reduce(args[0]) },
                 1,
             ),
         )
@@ -10375,6 +10428,11 @@ fn init_member_descriptor_type(ns: PyObjectRef) {
                 "__repr__",
                 |args| {
                     let member = args.first().copied().unwrap_or(pyre_object::PY_NULL);
+                    if member.is_null() || !unsafe { pyre_object::typedef::is_member(member) } {
+                        return Err(crate::PyError::type_error(
+                            "descriptor '__repr__' requires a 'member_descriptor' object",
+                        ));
+                    }
                     Ok(pyre_object::w_str_new(&unsafe {
                         member_descriptor_repr(member)
                     }))
@@ -10392,6 +10450,11 @@ fn init_member_descriptor_type(ns: PyObjectRef) {
                 "__reduce__",
                 |args| {
                     let member = args.first().copied().unwrap_or(pyre_object::PY_NULL);
+                    if member.is_null() || !unsafe { pyre_object::typedef::is_member(member) } {
+                        return Err(crate::PyError::type_error(
+                            "descriptor '__reduce__' requires a 'member_descriptor' object",
+                        ));
+                    }
                     let owner = unsafe { pyre_object::w_member_get_cls(member) };
                     let name =
                         pyre_object::w_str_new(unsafe { pyre_object::w_member_get_name(member) });
@@ -11020,6 +11083,9 @@ fn classmethod_descr_get(args: &[PyObjectRef]) -> crate::PyResult {
     let w_obj = args.get(1).copied().unwrap_or(PY_NULL);
     let mut w_klass = args.get(2).copied().unwrap_or(PY_NULL);
     if w_klass.is_null() || unsafe { pyre_object::is_none(w_klass) } {
+        if w_obj.is_null() || unsafe { pyre_object::is_none(w_obj) } {
+            return Err(crate::PyError::type_error("__get__(None, None) is invalid"));
+        }
         w_klass = r#type(w_obj).unwrap_or(PY_NULL);
     }
     let function = unsafe { pyre_object::function::w_classmethod_get_func(cm) };
@@ -11517,9 +11583,10 @@ fn init_property_type(ns: PyObjectRef) {
         ),
         (
             "__delete__",
-            make_builtin_function(
+            make_builtin_function_with_arity(
                 "__delete__",
                 crate::baseobjspace::property_descr_delete_impl,
+                2,
             ),
         ),
         (

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -2481,7 +2481,14 @@ fn enumerate_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyErr
 /// W_Map.descr___new__`.
 fn map_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     let cls = args.first().copied().unwrap_or(pyre_object::PY_NULL);
+    let _roots = pyre_object::gc_roots::push_roots();
+    pyre_object::gc_roots::pin_root(cls);
+    let cls_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     let value = crate::builtins::builtin_map(args.get(1..).unwrap_or(&[]))?;
+    pyre_object::gc_roots::pin_root(value);
+    let value_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+    let value = unsafe { pyre_object::gc_roots::shadow_stack_get(value_slot) };
+    let cls = unsafe { pyre_object::gc_roots::shadow_stack_get(cls_slot) };
     if let Some(sub) = subclass_to_tag(cls, &pyre_object::functional::MAP_TYPE)? {
         unsafe {
             (*value).w_class = sub;
@@ -3037,10 +3044,10 @@ fn init_map_type(ns: PyObjectRef) {
     for (name, function, arity) in [
         (
             "__iter__",
-            crate::baseobjspace::iter_self_method as DunderFn,
+            crate::baseobjspace::map_iter_method as DunderFn,
             1,
         ),
-        ("__next__", crate::baseobjspace::iter_next_method, 1),
+        ("__next__", crate::baseobjspace::map_next_method, 1),
         ("__reduce__", crate::baseobjspace::map_reduce_method, 1),
         ("__setstate__", crate::baseobjspace::map_setstate_method, 2),
     ] {

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -959,6 +959,15 @@ pub fn init_typeobjects() {
             ) as usize,
         );
         reg.insert(
+            &pyre_object::interp_itertools::STARMAP_TYPE as *const PyType as usize,
+            new_typeobject_with_base_and_layout(
+                "itertools.starmap",
+                init_starmap_type,
+                object_type,
+                &pyre_object::interp_itertools::STARMAP_TYPE as *const PyType,
+            ) as usize,
+        );
+        reg.insert(
             &pyre_object::interp_itertools::PAIRWISE_TYPE as *const PyType as usize,
             new_typeobject_with_base("itertools.pairwise", |_| {}, object_type) as usize,
         );
@@ -21304,6 +21313,50 @@ fn compress_iter_next(args: &[PyObjectRef]) -> crate::PyResult {
     crate::baseobjspace::next(obj)
 }
 
+fn starmap_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    // interp_itertools.py W_StarMap___new__, kept in source order.
+    let exact = gettypefor(&pyre_object::interp_itertools::STARMAP_TYPE).unwrap_or(PY_NULL);
+    let (cls, w_fun, w_iterable) = itertools_twoarg_new(args, exact, "starmap")?;
+    let _roots = pyre_object::gc_roots::push_roots();
+    pyre_object::gc_roots::pin_root(cls);
+    let cls_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+    pyre_object::gc_roots::pin_root(w_fun);
+    let fun_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+    pyre_object::gc_roots::pin_root(w_iterable);
+    let iterable_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+    let iterator = crate::baseobjspace::iter(unsafe {
+        pyre_object::gc_roots::shadow_stack_get(iterable_slot)
+    })?;
+    let obj = pyre_object::interp_itertools::w_starmap_new(
+        unsafe { pyre_object::gc_roots::shadow_stack_get(fun_slot) },
+        iterator,
+    );
+    itertools_alloc_for_class(
+        unsafe { pyre_object::gc_roots::shadow_stack_get(cls_slot) },
+        exact,
+        obj,
+    )
+}
+
+fn starmap_iter_self(args: &[PyObjectRef]) -> crate::PyResult {
+    singleton_receiver(
+        args,
+        "itertools.starmap",
+        "__iter__",
+        pyre_object::interp_itertools::is_starmap,
+    )
+}
+
+fn starmap_iter_next(args: &[PyObjectRef]) -> crate::PyResult {
+    let obj = singleton_receiver(
+        args,
+        "itertools.starmap",
+        "__next__",
+        pyre_object::interp_itertools::is_starmap,
+    )?;
+    crate::baseobjspace::next(obj)
+}
+
 fn init_takewhile_type(ns: PyObjectRef) {
     // W_TakeWhile.typedef, in source order (minus the 3.14-removed pickle
     // entries between __next__ and __doc__).
@@ -21394,6 +21447,30 @@ fn init_compress_type(ns: PyObjectRef) {
             "__doc__",
             w_str_new(
                 "Return data elements corresponding to true selector elements.\n\nForms a shorter iterator from selected data elements using the selectors to\nchoose the data elements.",
+            ),
+        ),
+    ];
+    for (name, value) in entries {
+        unsafe { pyre_object::w_dict_setitem_str_no_proxy(ns, name, value) };
+    }
+}
+
+fn init_starmap_type(ns: PyObjectRef) {
+    // interp_itertools.py W_StarMap.typedef, with Python 3.14's public doc.
+    let entries = [
+        ("__new__", make_new_descr(starmap_descr_new)),
+        (
+            "__iter__",
+            make_builtin_function_with_arity("__iter__", starmap_iter_self, 1),
+        ),
+        (
+            "__next__",
+            make_builtin_function_with_arity("__next__", starmap_iter_next, 1),
+        ),
+        (
+            "__doc__",
+            w_str_new(
+                "Return an iterator whose values are returned from the function evaluated with an argument tuple taken from the given sequence.",
             ),
         ),
     ];

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -2524,8 +2524,15 @@ fn zip_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
 /// object.
 fn reversed_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     let cls = args.first().copied().unwrap_or(pyre_object::PY_NULL);
+    let _roots = pyre_object::gc_roots::push_roots();
+    pyre_object::gc_roots::pin_root(cls);
+    let cls_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     let value = crate::builtins::builtin_reversed(args.get(1..).unwrap_or(&[]))?;
+    pyre_object::gc_roots::pin_root(value);
+    let value_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+    let value = unsafe { pyre_object::gc_roots::shadow_stack_get(value_slot) };
     if unsafe { pyre_object::functional::is_reversed(value) } {
+        let cls = unsafe { pyre_object::gc_roots::shadow_stack_get(cls_slot) };
         if let Some(sub) = subclass_to_tag(cls, &pyre_object::functional::REVERSED_TYPE)? {
             unsafe {
                 (*value).w_class = sub;
@@ -2993,10 +3000,10 @@ fn init_reversed_type(ns: PyObjectRef) {
     for (name, function, arity) in [
         (
             "__iter__",
-            crate::baseobjspace::iter_self_method as DunderFn,
+            crate::baseobjspace::reversed_iter_method as DunderFn,
             1,
         ),
-        ("__next__", crate::baseobjspace::iter_next_method, 1),
+        ("__next__", crate::baseobjspace::reversed_next_method, 1),
         (
             "__length_hint__",
             crate::baseobjspace::reversed_length_hint_method,

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -819,17 +819,17 @@ pub fn init_typeobjects() {
             }
             reg.insert(pytype as usize, iterator_type as usize);
         }
-        let long_range_iterator_type =
-            new_typeobject_with_base("range_iterator", init_range_iterator_type, object_type);
+        let long_range_iterator_type = new_typeobject_with_base(
+            "longrange_iterator",
+            init_long_range_iterator_type,
+            object_type,
+        );
         unsafe {
             pyre_object::w_type_set_disallow_instantiation(long_range_iterator_type);
             pyre_object::w_type_set_acceptable_as_base_class(long_range_iterator_type, false);
         }
         reg.insert(
             &pyre_object::functional::LONG_RANGE_ITER_TYPE as *const PyType as usize,
-            // `W_AbstractRangeIterator.typedef` names every range-iterator
-            // class `range_iterator` (`functional.py`); the word-fit and bignum
-            // iterators share that public name though they are distinct types.
             long_range_iterator_type as usize,
         );
         reg.insert(
@@ -20563,20 +20563,52 @@ fn init_dict_iterator_type(ns: PyObjectRef) {
     }
 }
 
+fn range_iterator_self(args: &[PyObjectRef]) -> crate::PyResult {
+    crate::type_methods::require_range_iterator_receiver(args, "__iter__", false, false)
+}
+
+fn range_iterator_next(args: &[PyObjectRef]) -> crate::PyResult {
+    crate::type_methods::require_range_iterator_receiver(args, "__next__", false, false)?;
+    crate::baseobjspace::next(args[0])
+}
+
 fn range_iterator_length_hint(args: &[PyObjectRef]) -> crate::PyResult {
-    if unsafe { pyre_object::is_range_iter(args[0]) } {
-        crate::baseobjspace::range_iter_length_hint_method(args)
-    } else {
-        crate::baseobjspace::long_range_iter_length_hint_method(args)
-    }
+    crate::type_methods::require_range_iterator_receiver(args, "__length_hint__", true, false)?;
+    crate::baseobjspace::range_iter_length_hint_method(args)
 }
 
 fn range_iterator_reduce(args: &[PyObjectRef]) -> crate::PyResult {
-    if unsafe { pyre_object::is_range_iter(args[0]) } {
-        crate::baseobjspace::range_iter_reduce_method(args)
-    } else {
-        crate::baseobjspace::long_range_iter_reduce_method(args)
-    }
+    crate::type_methods::require_range_iterator_receiver(args, "__reduce__", true, false)?;
+    crate::baseobjspace::range_iter_reduce_method(args)
+}
+
+fn range_iterator_setstate(args: &[PyObjectRef]) -> crate::PyResult {
+    crate::type_methods::require_range_iterator_receiver(args, "__setstate__", true, false)?;
+    crate::baseobjspace::range_iter_setstate_method(args)
+}
+
+fn long_range_iterator_self(args: &[PyObjectRef]) -> crate::PyResult {
+    crate::type_methods::require_range_iterator_receiver(args, "__iter__", false, true)
+}
+
+fn long_range_iterator_next(args: &[PyObjectRef]) -> crate::PyResult {
+    crate::type_methods::require_range_iterator_receiver(args, "__next__", false, true)?;
+    crate::baseobjspace::next(args[0])
+}
+
+fn long_range_iterator_length_hint(args: &[PyObjectRef]) -> crate::PyResult {
+    crate::type_methods::require_range_iterator_receiver(args, "__length_hint__", true, true)?;
+    crate::baseobjspace::long_range_iter_length_hint_method(args)
+}
+
+fn long_range_iterator_reduce(args: &[PyObjectRef]) -> crate::PyResult {
+    crate::type_methods::require_range_iterator_receiver(args, "__reduce__", true, true)?;
+    crate::baseobjspace::long_range_iter_reduce_method(args)
+}
+
+fn long_range_iterator_setstate(args: &[PyObjectRef]) -> crate::PyResult {
+    crate::type_methods::require_range_iterator_receiver(args, "__setstate__", true, true)?;
+    crate::baseobjspace::range_iter_setstate_method(args)
 }
 
 /// PyPy `functional.py W_AbstractRangeIterator.typedef`.
@@ -20585,7 +20617,7 @@ fn init_range_iterator_type(ns: PyObjectRef) {
     let entries = [
         (
             "__iter__",
-            make_builtin_function_with_arity("__iter__", crate::baseobjspace::iter_self_method, 1),
+            make_builtin_function_with_arity("__iter__", range_iterator_self, 1),
         ),
         (
             "__length_hint__",
@@ -20593,7 +20625,7 @@ fn init_range_iterator_type(ns: PyObjectRef) {
         ),
         (
             "__next__",
-            make_builtin_function_with_arity("__next__", crate::baseobjspace::iter_next_method, 1),
+            make_builtin_function_with_arity("__next__", range_iterator_next, 1),
         ),
         (
             "__reduce__",
@@ -20601,11 +20633,38 @@ fn init_range_iterator_type(ns: PyObjectRef) {
         ),
         (
             "__setstate__",
-            make_builtin_function_with_arity(
-                "__setstate__",
-                crate::baseobjspace::range_iter_setstate_method,
-                2,
-            ),
+            make_builtin_function_with_arity("__setstate__", range_iterator_setstate, 2),
+        ),
+    ];
+    for (name, value) in entries {
+        unsafe { pyre_object::w_dict_setitem_str_no_proxy(ns, name, value) };
+    }
+}
+
+/// Python 3.14 exposes the arbitrary-precision implementation as the distinct
+/// `longrange_iterator` type, while retaining the same five protocol entries.
+fn init_long_range_iterator_type(ns: PyObjectRef) {
+    unsafe { pyre_object::w_dict_setitem_str(ns, "__doc__", pyre_object::w_none()) };
+    let entries = [
+        (
+            "__iter__",
+            make_builtin_function_with_arity("__iter__", long_range_iterator_self, 1),
+        ),
+        (
+            "__length_hint__",
+            make_builtin_function_with_arity("__length_hint__", long_range_iterator_length_hint, 1),
+        ),
+        (
+            "__next__",
+            make_builtin_function_with_arity("__next__", long_range_iterator_next, 1),
+        ),
+        (
+            "__reduce__",
+            make_builtin_function_with_arity("__reduce__", long_range_iterator_reduce, 1),
+        ),
+        (
+            "__setstate__",
+            make_builtin_function_with_arity("__setstate__", long_range_iterator_setstate, 2),
         ),
     ];
     for (name, value) in entries {

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -8904,6 +8904,23 @@ fn type_set_bases(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
 /// `**rawdict` pattern. Function-only slots (currently just `__get__`) and
 /// BuiltinFunction-only overrides (`__new__`, `__self__`, `__repr__`)
 /// live in their respective wrappers.
+fn function_receiver(obj: PyObjectRef, name: &str) -> Result<PyObjectRef, crate::PyError> {
+    if obj.is_null() || !unsafe { pyre_object::py_type_check(obj, &crate::function::FUNCTION_TYPE) }
+    {
+        let received = if obj.is_null() {
+            "object"
+        } else {
+            crate::typedef::r#type(obj)
+                .map(|tp| unsafe { pyre_object::w_type_get_name(tp) })
+                .unwrap_or("object")
+        };
+        return Err(crate::PyError::type_error(format!(
+            "descriptor '{name}' for 'function' objects doesn't apply to a '{received}' object"
+        )));
+    }
+    Ok(obj)
+}
+
 fn init_function_type_common(ns: PyObjectRef) {
     // `pypy/interpreter/typedef.py:802 __doc__ = getset_func_doc` —
     // `getset_func_doc = GetSetProperty(Function.fget_func_doc,
@@ -8918,20 +8935,26 @@ fn init_function_type_common(ns: PyObjectRef) {
     // gate inside the setter/deleter still raises `TypeError` for
     // builtin functions (`can_change_code = False`).
     let doc_getter = make_builtin_function("__doc__", |args| {
-        let func = args.get(1).copied().unwrap_or(pyre_object::PY_NULL);
-        if func.is_null() {
-            return Ok(pyre_object::w_none());
-        }
+        let func = function_receiver(
+            args.get(1).copied().unwrap_or(pyre_object::PY_NULL),
+            "__doc__",
+        )?;
         Ok(unsafe { crate::function::fget_func_doc(func) })
     });
     let doc_setter = make_builtin_function("__doc__", |args| {
-        let func = args.get(1).copied().unwrap_or(pyre_object::PY_NULL);
+        let func = function_receiver(
+            args.get(1).copied().unwrap_or(pyre_object::PY_NULL),
+            "__doc__",
+        )?;
         let value = args.get(2).copied().unwrap_or(pyre_object::PY_NULL);
         unsafe { crate::function::fset_func_doc(func, value)? };
         Ok(pyre_object::w_none())
     });
     let doc_deleter = make_builtin_function("__doc__", |args| {
-        let func = args.get(1).copied().unwrap_or(pyre_object::PY_NULL);
+        let func = function_receiver(
+            args.get(1).copied().unwrap_or(pyre_object::PY_NULL),
+            "__doc__",
+        )?;
         unsafe { crate::function::fdel_func_doc(func)? };
         Ok(pyre_object::w_none())
     });
@@ -8953,20 +8976,26 @@ fn init_function_type_common(ns: PyObjectRef) {
     // `w_ann` directly).  The setter validates the new value as a
     // dict per `function.py:557-558` and clears the slot on `None`.
     let ann_getter = make_builtin_function("__annotations__", |args| {
-        let func = args.get(1).copied().unwrap_or(pyre_object::PY_NULL);
-        if func.is_null() {
-            return Ok(pyre_object::w_dict_new());
-        }
+        let func = function_receiver(
+            args.get(1).copied().unwrap_or(pyre_object::PY_NULL),
+            "__annotations__",
+        )?;
         Ok(unsafe { crate::function::function_get_annotations(func) })
     });
     let ann_setter = make_builtin_function("__annotations__", |args| {
-        let func = args.get(1).copied().unwrap_or(pyre_object::PY_NULL);
+        let func = function_receiver(
+            args.get(1).copied().unwrap_or(pyre_object::PY_NULL),
+            "__annotations__",
+        )?;
         let value = args.get(2).copied().unwrap_or(pyre_object::PY_NULL);
         unsafe { crate::function::fset_func_annotations(func, value)? };
         Ok(pyre_object::w_none())
     });
     let ann_deleter = make_builtin_function("__annotations__", |args| {
-        let func = args.get(1).copied().unwrap_or(pyre_object::PY_NULL);
+        let func = function_receiver(
+            args.get(1).copied().unwrap_or(pyre_object::PY_NULL),
+            "__annotations__",
+        )?;
         unsafe { crate::function::fdel_func_annotations(func)? };
         Ok(pyre_object::w_none())
     });
@@ -8990,14 +9019,17 @@ fn init_function_type_common(ns: PyObjectRef) {
     // `typedef.py:780 getset_func_name = GetSetProperty(fget_func_name,
     //                                                    fset_func_name)`.
     let name_getter = make_builtin_function("__name__", |args| {
-        let func = args.get(1).copied().unwrap_or(pyre_object::PY_NULL);
-        if func.is_null() {
-            return Ok(pyre_object::w_str_new(""));
-        }
+        let func = function_receiver(
+            args.get(1).copied().unwrap_or(pyre_object::PY_NULL),
+            "__name__",
+        )?;
         Ok(unsafe { crate::function::fget_func_name(func) })
     });
     let name_setter = make_builtin_function("__name__", |args| {
-        let func = args.get(1).copied().unwrap_or(pyre_object::PY_NULL);
+        let func = function_receiver(
+            args.get(1).copied().unwrap_or(pyre_object::PY_NULL),
+            "__name__",
+        )?;
         let value = args.get(2).copied().unwrap_or(pyre_object::PY_NULL);
         unsafe { crate::function::fset_func_name(func, value)? };
         Ok(pyre_object::w_none())
@@ -9016,15 +9048,18 @@ fn init_function_type_common(ns: PyObjectRef) {
     // (function.py:476-485) instead of falling through to
     // `setdictvalue` and silently shadowing the slot.
     let qualname_getter = make_builtin_function("__qualname__", |args| {
-        let func = args.get(1).copied().unwrap_or(pyre_object::PY_NULL);
-        if func.is_null() {
-            return Ok(pyre_object::w_str_new(""));
-        }
+        let func = function_receiver(
+            args.get(1).copied().unwrap_or(pyre_object::PY_NULL),
+            "__qualname__",
+        )?;
         let s = unsafe { crate::function::function_get_qualname(func) };
         Ok(pyre_object::w_str_new(&s))
     });
     let qualname_setter = make_builtin_function("__qualname__", |args| {
-        let func = args.get(1).copied().unwrap_or(pyre_object::PY_NULL);
+        let func = function_receiver(
+            args.get(1).copied().unwrap_or(pyre_object::PY_NULL),
+            "__qualname__",
+        )?;
         let value = args.get(2).copied().unwrap_or(pyre_object::PY_NULL);
         unsafe { crate::function::fset_func_qualname(func, value)? };
         Ok(pyre_object::w_none())
@@ -9039,20 +9074,26 @@ fn init_function_type_common(ns: PyObjectRef) {
     // `typedef.py:768-770 getset___module__ = GetSetProperty(
     //   Function.fget___module__, fset___module__, fdel___module__)`.
     let module_getter = make_builtin_function("__module__", |args| {
-        let func = args.get(1).copied().unwrap_or(pyre_object::PY_NULL);
-        if func.is_null() {
-            return Ok(pyre_object::w_none());
-        }
+        let func = function_receiver(
+            args.get(1).copied().unwrap_or(pyre_object::PY_NULL),
+            "__module__",
+        )?;
         Ok(unsafe { crate::function::fget___module__(func) })
     });
     let module_setter = make_builtin_function("__module__", |args| {
-        let func = args.get(1).copied().unwrap_or(pyre_object::PY_NULL);
+        let func = function_receiver(
+            args.get(1).copied().unwrap_or(pyre_object::PY_NULL),
+            "__module__",
+        )?;
         let value = args.get(2).copied().unwrap_or(pyre_object::PY_NULL);
         unsafe { crate::function::fset___module__(func, value)? };
         Ok(pyre_object::w_none())
     });
     let module_deleter = make_builtin_function("__module__", |args| {
-        let func = args.get(1).copied().unwrap_or(pyre_object::PY_NULL);
+        let func = function_receiver(
+            args.get(1).copied().unwrap_or(pyre_object::PY_NULL),
+            "__module__",
+        )?;
         unsafe { crate::function::fdel___module__(func)? };
         Ok(pyre_object::w_none())
     });
@@ -9066,20 +9107,26 @@ fn init_function_type_common(ns: PyObjectRef) {
     // `typedef.py:772-774 getset_func_defaults = GetSetProperty(
     //   Function.fget_func_defaults, fset_func_defaults, fdel_func_defaults)`.
     let defaults_getter = make_builtin_function("__defaults__", |args| {
-        let func = args.get(1).copied().unwrap_or(pyre_object::PY_NULL);
-        if func.is_null() {
-            return Ok(pyre_object::w_none());
-        }
+        let func = function_receiver(
+            args.get(1).copied().unwrap_or(pyre_object::PY_NULL),
+            "__defaults__",
+        )?;
         Ok(unsafe { crate::function::fget_func_defaults(func) })
     });
     let defaults_setter = make_builtin_function("__defaults__", |args| {
-        let func = args.get(1).copied().unwrap_or(pyre_object::PY_NULL);
+        let func = function_receiver(
+            args.get(1).copied().unwrap_or(pyre_object::PY_NULL),
+            "__defaults__",
+        )?;
         let value = args.get(2).copied().unwrap_or(pyre_object::PY_NULL);
         unsafe { crate::function::fset_func_defaults(func, value)? };
         Ok(pyre_object::w_none())
     });
     let defaults_deleter = make_builtin_function("__defaults__", |args| {
-        let func = args.get(1).copied().unwrap_or(pyre_object::PY_NULL);
+        let func = function_receiver(
+            args.get(1).copied().unwrap_or(pyre_object::PY_NULL),
+            "__defaults__",
+        )?;
         unsafe { crate::function::fdel_func_defaults(func)? };
         Ok(pyre_object::w_none())
     });
@@ -9092,20 +9139,26 @@ fn init_function_type_common(ns: PyObjectRef) {
     };
     // `typedef.py:775-777 getset_func_kwdefaults = GetSetProperty(...)`.
     let kwdefaults_getter = make_builtin_function("__kwdefaults__", |args| {
-        let func = args.get(1).copied().unwrap_or(pyre_object::PY_NULL);
-        if func.is_null() {
-            return Ok(pyre_object::w_none());
-        }
+        let func = function_receiver(
+            args.get(1).copied().unwrap_or(pyre_object::PY_NULL),
+            "__kwdefaults__",
+        )?;
         Ok(unsafe { crate::function::fget_func_kwdefaults(func) })
     });
     let kwdefaults_setter = make_builtin_function("__kwdefaults__", |args| {
-        let func = args.get(1).copied().unwrap_or(pyre_object::PY_NULL);
+        let func = function_receiver(
+            args.get(1).copied().unwrap_or(pyre_object::PY_NULL),
+            "__kwdefaults__",
+        )?;
         let value = args.get(2).copied().unwrap_or(pyre_object::PY_NULL);
         unsafe { crate::function::fset_func_kwdefaults(func, value)? };
         Ok(pyre_object::w_none())
     });
     let kwdefaults_deleter = make_builtin_function("__kwdefaults__", |args| {
-        let func = args.get(1).copied().unwrap_or(pyre_object::PY_NULL);
+        let func = function_receiver(
+            args.get(1).copied().unwrap_or(pyre_object::PY_NULL),
+            "__kwdefaults__",
+        )?;
         unsafe { crate::function::fdel_func_kwdefaults(func)? };
         Ok(pyre_object::w_none())
     });
@@ -9119,15 +9172,18 @@ fn init_function_type_common(ns: PyObjectRef) {
     // `typedef.py:778-779 getset_func_code = GetSetProperty(
     //   Function.fget_func_code, fset_func_code)`.
     let code_getter = make_builtin_function("__code__", |args| {
-        let func = args.get(1).copied().unwrap_or(pyre_object::PY_NULL);
-        if func.is_null() {
-            return Ok(pyre_object::w_none());
-        }
+        let func = function_receiver(
+            args.get(1).copied().unwrap_or(pyre_object::PY_NULL),
+            "__code__",
+        )?;
         let raw = unsafe { crate::function::fget_func_code(func) };
         Ok(raw as pyre_object::PyObjectRef)
     });
     let code_setter = make_builtin_function("__code__", |args| {
-        let func = args.get(1).copied().unwrap_or(pyre_object::PY_NULL);
+        let func = function_receiver(
+            args.get(1).copied().unwrap_or(pyre_object::PY_NULL),
+            "__code__",
+        )?;
         let value = args.get(2).copied().unwrap_or(pyre_object::PY_NULL);
         unsafe { crate::function::fset_func_code(func, value)? };
         Ok(pyre_object::w_none())
@@ -9142,10 +9198,10 @@ fn init_function_type_common(ns: PyObjectRef) {
     // `typedef.py:813 __closure__ = GetSetProperty(Function.fget_func_closure)`
     // — read-only.
     let closure_getter = make_builtin_function("__closure__", |args| {
-        let func = args.get(1).copied().unwrap_or(pyre_object::PY_NULL);
-        if func.is_null() {
-            return Ok(pyre_object::w_none());
-        }
+        let func = function_receiver(
+            args.get(1).copied().unwrap_or(pyre_object::PY_NULL),
+            "__closure__",
+        )?;
         Ok(unsafe { crate::function::fget_func_closure(func) })
     });
     unsafe {
@@ -9315,7 +9371,18 @@ fn init_function_type_common(ns: PyObjectRef) {
 /// Arguments object, including keyword names, to the wrapped function.
 fn function_descr_call(args: &[PyObjectRef]) -> crate::PyResult {
     let (positional, kwargs) = crate::builtins::split_builtin_kwargs(args);
-    let function = positional.first().copied().unwrap_or(pyre_object::PY_NULL);
+    let function = function_receiver(
+        positional.first().copied().unwrap_or(pyre_object::PY_NULL),
+        "__call__",
+    )?;
+    function_descr_call_impl(positional, kwargs, function)
+}
+
+fn function_descr_call_impl(
+    positional: &[PyObjectRef],
+    kwargs: Option<PyObjectRef>,
+    function: PyObjectRef,
+) -> crate::PyResult {
     let call_args = positional.get(1..).unwrap_or(&[]);
     if !crate::builtins::has_real_kwargs(kwargs) {
         return crate::call::call_function_impl_result(function, call_args);
@@ -9444,7 +9511,10 @@ fn init_function_type(ns: PyObjectRef) {
             make_builtin_function_with_arity(
                 "__repr__",
                 |args| {
-                    let function = args[0];
+                    let function = function_receiver(
+                        args.first().copied().unwrap_or(pyre_object::PY_NULL),
+                        "__repr__",
+                    )?;
                     let qualname = unsafe { crate::function::function_get_qualname(function) };
                     Ok(pyre_object::w_str_new(&format!(
                         "<function {qualname} at {function:p}>"
@@ -9457,8 +9527,28 @@ fn init_function_type(ns: PyObjectRef) {
     // PyPy typedef.py:796 `getset_func_dict = GetSetProperty(
     // descr_get_dict, descr_set_dict, cls=Function)` — storage is the
     // typed `Function.w_func_dict` field from function.py:68.
-    let dict_getter = make_builtin_function_with_arity("__dict__", descr_get_dict, 2);
-    let dict_setter = make_builtin_function_with_arity("__dict__", descr_set_dict, 3);
+    let dict_getter = make_builtin_function_with_arity(
+        "__dict__",
+        |args| {
+            function_receiver(
+                args.get(1).copied().unwrap_or(pyre_object::PY_NULL),
+                "__dict__",
+            )?;
+            descr_get_dict(args)
+        },
+        2,
+    );
+    let dict_setter = make_builtin_function_with_arity(
+        "__dict__",
+        |args| {
+            function_receiver(
+                args.get(1).copied().unwrap_or(pyre_object::PY_NULL),
+                "__dict__",
+            )?;
+            descr_set_dict(args)
+        },
+        3,
+    );
     unsafe {
         pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
             ns,
@@ -9468,38 +9558,26 @@ fn init_function_type(ns: PyObjectRef) {
     };
     // CPython 3.14 `function.__annotate__`: callable-or-None, not deletable.
     let annotate_getter = make_builtin_function("__annotate__", |args| {
-        let function = args.get(1).copied().unwrap_or(pyre_object::PY_NULL);
-        if function.is_null()
-            || !unsafe { pyre_object::py_type_check(function, &crate::function::FUNCTION_TYPE) }
-        {
-            return Err(crate::PyError::type_error(
-                "descriptor '__annotate__' requires a 'function' object",
-            ));
-        }
+        let function = function_receiver(
+            args.get(1).copied().unwrap_or(pyre_object::PY_NULL),
+            "__annotate__",
+        )?;
         Ok(unsafe { crate::function::function_get_annotate(function) })
     });
     let annotate_setter = make_builtin_function("__annotate__", |args| {
-        let function = args.get(1).copied().unwrap_or(pyre_object::PY_NULL);
-        if function.is_null()
-            || !unsafe { pyre_object::py_type_check(function, &crate::function::FUNCTION_TYPE) }
-        {
-            return Err(crate::PyError::type_error(
-                "descriptor '__annotate__' requires a 'function' object",
-            ));
-        }
+        let function = function_receiver(
+            args.get(1).copied().unwrap_or(pyre_object::PY_NULL),
+            "__annotate__",
+        )?;
         let value = args.get(2).copied().unwrap_or(pyre_object::PY_NULL);
         unsafe { crate::function::function_set_annotate(function, value)? };
         Ok(pyre_object::w_none())
     });
     let annotate_deleter = make_builtin_function("__annotate__", |args| {
-        let function = args.get(1).copied().unwrap_or(pyre_object::PY_NULL);
-        if function.is_null()
-            || !unsafe { pyre_object::py_type_check(function, &crate::function::FUNCTION_TYPE) }
-        {
-            return Err(crate::PyError::type_error(
-                "descriptor '__annotate__' requires a 'function' object",
-            ));
-        }
+        let function = function_receiver(
+            args.get(1).copied().unwrap_or(pyre_object::PY_NULL),
+            "__annotate__",
+        )?;
         unsafe { crate::function::function_set_annotate(function, pyre_object::PY_NULL)? };
         Ok(pyre_object::w_none())
     });
@@ -9512,38 +9590,26 @@ fn init_function_type(ns: PyObjectRef) {
     };
     // CPython 3.14 `function.__type_params__`: tuple-only and not deletable.
     let typeparams_getter = make_builtin_function("__type_params__", |args| {
-        let function = args.get(1).copied().unwrap_or(pyre_object::PY_NULL);
-        if function.is_null()
-            || !unsafe { pyre_object::py_type_check(function, &crate::function::FUNCTION_TYPE) }
-        {
-            return Err(crate::PyError::type_error(
-                "descriptor '__type_params__' requires a 'function' object",
-            ));
-        }
+        let function = function_receiver(
+            args.get(1).copied().unwrap_or(pyre_object::PY_NULL),
+            "__type_params__",
+        )?;
         Ok(unsafe { crate::function::function_get_typeparams(function) })
     });
     let typeparams_setter = make_builtin_function("__type_params__", |args| {
-        let function = args.get(1).copied().unwrap_or(pyre_object::PY_NULL);
-        if function.is_null()
-            || !unsafe { pyre_object::py_type_check(function, &crate::function::FUNCTION_TYPE) }
-        {
-            return Err(crate::PyError::type_error(
-                "descriptor '__type_params__' requires a 'function' object",
-            ));
-        }
+        let function = function_receiver(
+            args.get(1).copied().unwrap_or(pyre_object::PY_NULL),
+            "__type_params__",
+        )?;
         let value = args.get(2).copied().unwrap_or(pyre_object::PY_NULL);
         unsafe { crate::function::function_set_typeparams(function, value)? };
         Ok(pyre_object::w_none())
     });
     let typeparams_deleter = make_builtin_function("__type_params__", |args| {
-        let function = args.get(1).copied().unwrap_or(pyre_object::PY_NULL);
-        if function.is_null()
-            || !unsafe { pyre_object::py_type_check(function, &crate::function::FUNCTION_TYPE) }
-        {
-            return Err(crate::PyError::type_error(
-                "descriptor '__type_params__' requires a 'function' object",
-            ));
-        }
+        let function = function_receiver(
+            args.get(1).copied().unwrap_or(pyre_object::PY_NULL),
+            "__type_params__",
+        )?;
         unsafe { crate::function::function_set_typeparams(function, pyre_object::PY_NULL)? };
         Ok(pyre_object::w_none())
     });
@@ -9576,7 +9642,10 @@ fn init_function_type(ns: PyObjectRef) {
             ns,
             "__get__",
             make_builtin_function("__get__", |args| {
-                let w_function = args.first().copied().unwrap_or(pyre_object::w_none());
+                let w_function = function_receiver(
+                    args.first().copied().unwrap_or(pyre_object::PY_NULL),
+                    "__get__",
+                )?;
                 let w_obj = args.get(1).copied().unwrap_or(pyre_object::PY_NULL);
                 let w_cls = args.get(2).copied().unwrap_or(pyre_object::PY_NULL);
                 // function.py:464-470 descr_function_get
@@ -9634,6 +9703,24 @@ fn init_function_type(ns: PyObjectRef) {
 /// missing `dict_storage_store(ns, "__get__", ...)` call after it expresses the
 /// `del rawdict['__get__']` step. The `update({...})` overrides go below as
 /// pyre starts modeling them.
+fn builtin_function_receiver(obj: PyObjectRef, name: &str) -> Result<PyObjectRef, crate::PyError> {
+    if obj.is_null()
+        || !unsafe { pyre_object::py_type_check(obj, &crate::function::BUILTIN_FUNCTION_TYPE) }
+    {
+        let received = if obj.is_null() {
+            "object"
+        } else {
+            crate::typedef::r#type(obj)
+                .map(|tp| unsafe { pyre_object::w_type_get_name(tp) })
+                .unwrap_or("object")
+        };
+        return Err(crate::PyError::type_error(format!(
+            "descriptor '{name}' for 'builtin_function_or_method' objects doesn't apply to a '{received}' object"
+        )));
+    }
+    Ok(obj)
+}
+
 fn init_builtin_function_type(ns: PyObjectRef) {
     init_function_type_common(ns);
 
@@ -9706,16 +9793,30 @@ fn init_builtin_function_type(ns: PyObjectRef) {
     unsafe {
         pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
             ns,
+            "__call__",
+            make_builtin_function("__call__", |args| {
+                let (positional, kwargs) = crate::builtins::split_builtin_kwargs(args);
+                let function = builtin_function_receiver(
+                    positional.first().copied().unwrap_or(pyre_object::PY_NULL),
+                    "__call__",
+                )?;
+                function_descr_call_impl(positional, kwargs, function)
+            }),
+        )
+    };
+
+    unsafe {
+        pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
+            ns,
             "__repr__",
             make_builtin_function_with_arity(
                 "__repr__",
                 |args| {
-                    let func = args.first().copied().unwrap_or(pyre_object::PY_NULL);
-                    let name = if func.is_null() {
-                        "<unknown>"
-                    } else {
-                        unsafe { crate::function_get_name(func) }
-                    };
+                    let func = builtin_function_receiver(
+                        args.first().copied().unwrap_or(pyre_object::PY_NULL),
+                        "__repr__",
+                    )?;
+                    let name = unsafe { crate::function_get_name(func) };
                     Ok(pyre_object::w_str_new(&format!(
                         "<built-in function {name}>"
                     )))
@@ -9732,7 +9833,13 @@ fn init_builtin_function_type(ns: PyObjectRef) {
             "__reduce__",
             make_builtin_function_with_arity(
                 "__reduce__",
-                |args| unsafe { crate::function::descr_builtin_function_reduce(args[0]) },
+                |args| unsafe {
+                    let function = builtin_function_receiver(
+                        args.first().copied().unwrap_or(pyre_object::PY_NULL),
+                        "__reduce__",
+                    )?;
+                    crate::function::descr_builtin_function_reduce(function)
+                },
                 1,
             ),
         )
@@ -9743,11 +9850,20 @@ fn init_builtin_function_type(ns: PyObjectRef) {
     for (name, method) in [
         (
             "__eq__",
-            (|args: &[PyObjectRef]| Ok(pyre_object::w_bool_from(std::ptr::eq(args[0], args[1]))))
-                as fn(&[PyObjectRef]) -> crate::PyResult,
+            (|args: &[PyObjectRef]| {
+                let function = builtin_function_receiver(
+                    args.first().copied().unwrap_or(pyre_object::PY_NULL),
+                    "__eq__",
+                )?;
+                Ok(pyre_object::w_bool_from(std::ptr::eq(function, args[1])))
+            }) as fn(&[PyObjectRef]) -> crate::PyResult,
         ),
         ("__ne__", |args: &[PyObjectRef]| {
-            Ok(pyre_object::w_bool_from(!std::ptr::eq(args[0], args[1])))
+            let function = builtin_function_receiver(
+                args.first().copied().unwrap_or(pyre_object::PY_NULL),
+                "__ne__",
+            )?;
+            Ok(pyre_object::w_bool_from(!std::ptr::eq(function, args[1])))
         }),
     ] {
         unsafe {
@@ -9758,12 +9874,34 @@ fn init_builtin_function_type(ns: PyObjectRef) {
             )
         };
     }
-    for name in ["__lt__", "__le__", "__gt__", "__ge__"] {
+    type BuiltinOrderFn = fn(&[PyObjectRef]) -> crate::PyResult;
+    fn order(args: &[PyObjectRef], name: &str) -> crate::PyResult {
+        builtin_function_receiver(args.first().copied().unwrap_or(pyre_object::PY_NULL), name)?;
+        Ok(pyre_object::w_not_implemented())
+    }
+    fn lt(args: &[PyObjectRef]) -> crate::PyResult {
+        order(args, "__lt__")
+    }
+    fn le(args: &[PyObjectRef]) -> crate::PyResult {
+        order(args, "__le__")
+    }
+    fn gt(args: &[PyObjectRef]) -> crate::PyResult {
+        order(args, "__gt__")
+    }
+    fn ge(args: &[PyObjectRef]) -> crate::PyResult {
+        order(args, "__ge__")
+    }
+    for (name, function) in [
+        ("__lt__", lt as BuiltinOrderFn),
+        ("__le__", le),
+        ("__gt__", gt),
+        ("__ge__", ge),
+    ] {
         unsafe {
             pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
                 ns,
                 name,
-                make_builtin_function_with_arity(name, |_| Ok(pyre_object::w_not_implemented()), 2),
+                make_builtin_function_with_arity(name, function, 2),
             )
         };
     }
@@ -9773,7 +9911,13 @@ fn init_builtin_function_type(ns: PyObjectRef) {
             "__hash__",
             make_builtin_function_with_arity(
                 "__hash__",
-                |args| Ok(pyre_object::w_int_new(args[0] as i64)),
+                |args| {
+                    let function = builtin_function_receiver(
+                        args.first().copied().unwrap_or(pyre_object::PY_NULL),
+                        "__hash__",
+                    )?;
+                    Ok(pyre_object::w_int_new(function as i64))
+                },
                 1,
             ),
         )

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -2956,12 +2956,12 @@ fn init_enumerate_type(ns: PyObjectRef) {
     install_functional_entry(
         ns,
         "__iter__",
-        make_builtin_function_with_arity("__iter__", crate::baseobjspace::iter_self_method, 1),
+        make_builtin_function_with_arity("__iter__", crate::baseobjspace::enumerate_iter_method, 1),
     );
     install_functional_entry(
         ns,
         "__next__",
-        make_builtin_function_with_arity("__next__", crate::baseobjspace::iter_next_method, 1),
+        make_builtin_function_with_arity("__next__", crate::baseobjspace::enumerate_next_method, 1),
     );
     install_functional_entry(
         ns,

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -2507,12 +2507,7 @@ fn list_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
 
 fn list_descr_init(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     let (params, kwargs) = crate::builtins::split_builtin_kwargs(args);
-    let list = params.first().copied().unwrap_or(pyre_object::PY_NULL);
-    if list.is_null() || !unsafe { pyre_object::is_list(list) } {
-        return Err(crate::PyError::type_error(
-            "descriptor '__init__' requires a 'list' object",
-        ));
-    }
+    let list = crate::type_methods::require_list_receiver(params, "__init__", false)?;
     if crate::builtins::has_real_kwargs(kwargs) {
         return Err(crate::PyError::type_error(
             "list() takes no keyword arguments",
@@ -3594,7 +3589,10 @@ fn init_list_type(ns: PyObjectRef) {
             "__repr__",
             make_builtin_function_with_arity(
                 "__repr__",
-                |args| Ok(w_str_new(&unsafe { crate::display::list_repr(args[0])? })),
+                |args| {
+                    let list = crate::type_methods::require_list_receiver(args, "__repr__", false)?;
+                    Ok(w_str_new(&unsafe { crate::display::list_repr(list)? }))
+                },
                 1,
             ),
         )
@@ -3607,12 +3605,14 @@ fn init_list_type(ns: PyObjectRef) {
             make_builtin_function_with_arity(
                 "__sizeof__",
                 |args| {
+                    let list =
+                        crate::type_methods::require_list_receiver(args, "__sizeof__", true)?;
                     // CPython 3.14's PyListObject header is five machine
                     // words; the item array contributes one pointer per
                     // allocated slot. This is the version oracle where PyPy
                     // does not expose a list-specific descriptor.
                     let size = 5 * std::mem::size_of::<usize>()
-                        + unsafe { pyre_object::w_list_capacity(args[0]) }
+                        + unsafe { pyre_object::w_list_capacity(list) }
                             * std::mem::size_of::<PyObjectRef>();
                     Ok(w_int_new(size as i64))
                 },
@@ -3724,6 +3724,7 @@ fn init_list_type(ns: PyObjectRef) {
             make_builtin_function_with_arity(
                 "__getitem__",
                 |args| {
+                    crate::type_methods::require_list_receiver(args, "__getitem__", true)?;
                     crate::type_methods::arity_exact(args, "list.__getitem__", 1)?;
                     crate::baseobjspace::getitem_slot(args[0], args[1])
                 },
@@ -3738,6 +3739,7 @@ fn init_list_type(ns: PyObjectRef) {
             make_builtin_function_with_arity(
                 "__setitem__",
                 |args| {
+                    crate::type_methods::require_list_receiver(args, "__setitem__", false)?;
                     crate::type_methods::arity_exact_unpack(args, "__setitem__", 2)?;
                     crate::baseobjspace::setitem_slot(args[0], args[1], args[2])?;
                     Ok(pyre_object::w_none())
@@ -3753,6 +3755,7 @@ fn init_list_type(ns: PyObjectRef) {
             make_builtin_function_with_arity(
                 "__delitem__",
                 |args| {
+                    crate::type_methods::require_list_receiver(args, "__delitem__", false)?;
                     crate::type_methods::arity_slot(args, 1)?;
                     crate::baseobjspace::delitem_slot(args[0], args[1])?;
                     Ok(pyre_object::w_none())
@@ -3768,6 +3771,7 @@ fn init_list_type(ns: PyObjectRef) {
             make_builtin_function_with_arity(
                 "__len__",
                 |args| {
+                    crate::type_methods::require_list_receiver(args, "__len__", false)?;
                     crate::type_methods::arity_slot(args, 0)?;
                     crate::baseobjspace::len_slot(args[0])
                 },
@@ -3782,6 +3786,7 @@ fn init_list_type(ns: PyObjectRef) {
             make_builtin_function_with_arity(
                 "__contains__",
                 |args| {
+                    crate::type_methods::require_list_receiver(args, "__contains__", false)?;
                     crate::type_methods::arity_slot(args, 1)?;
                     let found = crate::baseobjspace::contains_slot(args[0], args[1])?;
                     Ok(pyre_object::w_bool_from(found))
@@ -3800,10 +3805,7 @@ fn init_list_type(ns: PyObjectRef) {
             make_builtin_function_with_arity(
                 "__iter__",
                 |args| {
-                    let obj = args.first().copied().unwrap_or(pyre_object::PY_NULL);
-                    if obj.is_null() {
-                        return Ok(pyre_object::w_none());
-                    }
+                    let obj = crate::type_methods::require_list_receiver(args, "__iter__", false)?;
                     crate::type_methods::arity_slot(args, 0)?;
                     Ok(pyre_object::w_list_iter_new(obj))
                 },
@@ -3821,8 +3823,9 @@ fn init_list_type(ns: PyObjectRef) {
                     // `listobject.py:737 descr_reversed` — a lazy reverse iterator
                     // over the list, the same `W_ReversedIterator` representation as
                     // `reversed(list)` (walks `getitem(seq, remaining)` downward).
+                    let obj =
+                        crate::type_methods::require_list_receiver(args, "__reversed__", true)?;
                     crate::type_methods::arity_no_args(args, "list.__reversed__")?;
-                    let obj = args[0];
                     let n = unsafe { pyre_object::w_list_len(obj) } as i64;
                     Ok(pyre_object::w_list_reverse_iter_new(obj, n - 1))
                 },
@@ -3841,6 +3844,7 @@ fn init_list_type(ns: PyObjectRef) {
             make_builtin_function_with_arity(
                 "__add__",
                 |args| {
+                    crate::type_methods::require_list_receiver(args, "__add__", false)?;
                     crate::type_methods::arity_slot(args, 1)?;
                     if unsafe { pyre_object::is_list(args[1]) } {
                         unsafe { crate::objspace::descroperation::list_concat(args[0], args[1]) }
@@ -3863,7 +3867,7 @@ fn init_list_type(ns: PyObjectRef) {
         pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
             ns,
             "__rmul__",
-            make_builtin_function_with_arity("__rmul__", list_descr_mul, 2),
+            make_builtin_function_with_arity("__rmul__", list_descr_rmul, 2),
         )
     };
     unsafe {
@@ -3873,6 +3877,7 @@ fn init_list_type(ns: PyObjectRef) {
             make_builtin_function_with_arity(
                 "__iadd__",
                 |args| {
+                    crate::type_methods::require_list_receiver(args, "__iadd__", false)?;
                     // Validate the slot arity before delegating so a bad call
                     // reports "expected 1 argument, got M" rather than the
                     // `extend` message surfaced by the shared implementation.
@@ -3891,6 +3896,7 @@ fn init_list_type(ns: PyObjectRef) {
             make_builtin_function_with_arity(
                 "__imul__",
                 |args| {
+                    crate::type_methods::require_list_receiver(args, "__imul__", false)?;
                     // listobject.py descr_inplace_mul: the count goes through
                     // `__index__`; a non-index operand becomes NotImplemented.
                     crate::type_methods::arity_slot(args, 1)?;
@@ -3962,6 +3968,15 @@ fn list_repeat_index(w_obj: PyObjectRef) -> Result<Option<PyObjectRef>, crate::P
 /// `listobject.c:list_repeat` — `list * n` / `n * list`.  The count goes
 /// through `__index__`, so any object implementing it repeats the list.
 fn list_descr_mul(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    list_descr_mul_impl(args, "__mul__")
+}
+
+fn list_descr_rmul(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    list_descr_mul_impl(args, "__rmul__")
+}
+
+fn list_descr_mul_impl(args: &[PyObjectRef], name: &str) -> Result<PyObjectRef, crate::PyError> {
+    crate::type_methods::require_list_receiver(args, name, false)?;
     crate::type_methods::arity_slot(args, 1)?;
     let Some(w_count) = list_repeat_index(args[1])? else {
         return Ok(pyre_object::w_not_implemented());
@@ -12586,15 +12601,29 @@ cmp_dunder_set!(
     str_dunder_ge,
     cmp_guard_str
 );
-cmp_dunder_set!(
-    list_dunder_eq,
-    list_dunder_ne,
-    list_dunder_lt,
-    list_dunder_le,
-    list_dunder_gt,
-    list_dunder_ge,
-    cmp_guard_list
-);
+macro_rules! list_cmp_dunder {
+    ($function:ident, $name:literal, $op:ident) => {
+        fn $function(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+            crate::type_methods::require_list_receiver(args, $name, false)?;
+            crate::type_methods::arity_slot(args, 1)?;
+            if cmp_guard_list(args[1]) {
+                crate::objspace::descroperation::compare_slot(
+                    args[0],
+                    args[1],
+                    crate::objspace::descroperation::CompareOp::$op,
+                )
+            } else {
+                Ok(pyre_object::w_not_implemented())
+            }
+        }
+    };
+}
+list_cmp_dunder!(list_dunder_eq, "__eq__", Eq);
+list_cmp_dunder!(list_dunder_ne, "__ne__", Ne);
+list_cmp_dunder!(list_dunder_lt, "__lt__", Lt);
+list_cmp_dunder!(list_dunder_le, "__le__", Le);
+list_cmp_dunder!(list_dunder_gt, "__gt__", Gt);
+list_cmp_dunder!(list_dunder_ge, "__ge__", Ge);
 cmp_dunder_set!(
     tuple_dunder_eq,
     tuple_dunder_ne,

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -18784,6 +18784,44 @@ fn setlike_descr_repr(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyErro
     unsafe { Ok(pyre_object::w_str_new(&crate::display::py_repr(args[0])?)) }
 }
 
+fn setlike_descr_sizeof(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    let size = std::mem::size_of::<pyre_object::setobject::W_SetObject>()
+        + unsafe { pyre_object::w_set_capacity(args[0]) }
+            * std::mem::size_of::<pyre_object::dictmultiobject::ObjectKey>();
+    Ok(pyre_object::w_int_new(size as i64))
+}
+
+fn setlike_descr_contains_impl(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    Ok(pyre_object::w_bool_from(set_descr_contains(
+        args[0], args[1],
+    )?))
+}
+
+fn setlike_descr_reduce(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    crate::reduce_protocol::set_reduce(args[0])
+}
+
+fn setlike_descr_isdisjoint(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    if unsafe { pyre_object::is_set_or_frozenset(args[1]) } {
+        return Ok(pyre_object::w_bool_from(set_is_disjoint_from(
+            args[0], args[1],
+        )?));
+    }
+    for item in crate::builtins::collect_iterable(args[1])? {
+        if crate::type_methods::set_contains_checked(args[0], item)? {
+            return Ok(pyre_object::w_bool_from(false));
+        }
+    }
+    Ok(pyre_object::w_bool_from(true))
+}
+
+fn setlike_descr_copy(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    if unsafe { pyre_object::is_exact_type(args[0], &pyre_object::setobject::FROZENSET_TYPE) } {
+        return Ok(args[0]);
+    }
+    Ok(set_copy_real(args[0]))
+}
+
 macro_rules! setlike_wrapper_gateways {
     ($set_fn:ident, $frozenset_fn:ident, $name:literal, $implementation:ident) => {
         fn $set_fn(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
@@ -18793,6 +18831,20 @@ macro_rules! setlike_wrapper_gateways {
 
         fn $frozenset_fn(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
             crate::type_methods::require_frozenset_receiver(args, $name, false)?;
+            $implementation(args)
+        }
+    };
+}
+
+macro_rules! setlike_method_gateways {
+    ($set_fn:ident, $frozenset_fn:ident, $name:literal, $implementation:ident) => {
+        fn $set_fn(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+            crate::type_methods::require_set_receiver(args, $name, true)?;
+            $implementation(args)
+        }
+
+        fn $frozenset_fn(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+            crate::type_methods::require_frozenset_receiver(args, $name, true)?;
             $implementation(args)
         }
     };
@@ -18860,6 +18912,72 @@ setlike_wrapper_gateways!(set_gateway_le, frozenset_gateway_le, "__le__", set_de
 setlike_wrapper_gateways!(set_gateway_ge, frozenset_gateway_ge, "__ge__", set_descr_ge);
 setlike_wrapper_gateways!(set_gateway_lt, frozenset_gateway_lt, "__lt__", set_descr_lt);
 setlike_wrapper_gateways!(set_gateway_gt, frozenset_gateway_gt, "__gt__", set_descr_gt);
+setlike_method_gateways!(
+    set_gateway_sizeof,
+    frozenset_gateway_sizeof,
+    "__sizeof__",
+    setlike_descr_sizeof
+);
+setlike_method_gateways!(
+    set_gateway_contains,
+    frozenset_gateway_contains,
+    "__contains__",
+    setlike_descr_contains_impl
+);
+setlike_method_gateways!(
+    set_gateway_reduce,
+    frozenset_gateway_reduce,
+    "__reduce__",
+    setlike_descr_reduce
+);
+setlike_method_gateways!(
+    set_gateway_union,
+    frozenset_gateway_union,
+    "union",
+    set_method_union
+);
+setlike_method_gateways!(
+    set_gateway_intersection,
+    frozenset_gateway_intersection,
+    "intersection",
+    set_method_intersection
+);
+setlike_method_gateways!(
+    set_gateway_difference,
+    frozenset_gateway_difference,
+    "difference",
+    set_method_difference
+);
+setlike_method_gateways!(
+    set_gateway_symmetric_difference,
+    frozenset_gateway_symmetric_difference,
+    "symmetric_difference",
+    set_method_symmetric_difference
+);
+setlike_method_gateways!(
+    set_gateway_issubset,
+    frozenset_gateway_issubset,
+    "issubset",
+    set_method_le
+);
+setlike_method_gateways!(
+    set_gateway_issuperset,
+    frozenset_gateway_issuperset,
+    "issuperset",
+    set_method_ge
+);
+setlike_method_gateways!(
+    set_gateway_isdisjoint,
+    frozenset_gateway_isdisjoint,
+    "isdisjoint",
+    setlike_descr_isdisjoint
+);
+setlike_method_gateways!(
+    set_gateway_copy,
+    frozenset_gateway_copy,
+    "copy",
+    setlike_descr_copy
+);
 
 fn setlike_gateway(
     frozen: bool,
@@ -18880,12 +18998,7 @@ fn init_setlike_common(ns: PyObjectRef, frozen: bool) {
             "__sizeof__",
             make_builtin_function_with_arity(
                 "__sizeof__",
-                |args| {
-                    let size = std::mem::size_of::<pyre_object::setobject::W_SetObject>()
-                        + unsafe { pyre_object::w_set_capacity(args[0]) }
-                            * std::mem::size_of::<pyre_object::dictmultiobject::ObjectKey>();
-                    Ok(pyre_object::w_int_new(size as i64))
-                },
+                setlike_gateway(frozen, set_gateway_sizeof, frozenset_gateway_sizeof),
                 1,
             ),
         )
@@ -18896,19 +19009,7 @@ fn init_setlike_common(ns: PyObjectRef, frozen: bool) {
             "__contains__",
             make_builtin_function_with_arity(
                 "__contains__",
-                |args| {
-                    if args.len() < 2 {
-                        return Ok(pyre_object::w_bool_from(false));
-                    }
-                    unsafe {
-                        if pyre_object::is_set_or_frozenset(args[0]) {
-                            return Ok(pyre_object::w_bool_from(set_descr_contains(
-                                args[0], args[1],
-                            )?));
-                        }
-                    }
-                    Ok(pyre_object::w_bool_from(false))
-                },
+                setlike_gateway(frozen, set_gateway_contains, frozenset_gateway_contains),
                 2,
             ),
         )
@@ -18952,7 +19053,7 @@ fn init_setlike_common(ns: PyObjectRef, frozen: bool) {
             "__reduce__",
             make_builtin_function_with_arity(
                 "__reduce__",
-                |args| crate::reduce_protocol::set_reduce(args[0]),
+                setlike_gateway(frozen, set_gateway_reduce, frozenset_gateway_reduce),
                 1,
             ),
         )
@@ -19115,21 +19216,34 @@ fn init_setlike_common(ns: PyObjectRef, frozen: bool) {
         pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
             ns,
             "union",
-            make_builtin_function("union", set_method_union),
+            make_builtin_function(
+                "union",
+                setlike_gateway(frozen, set_gateway_union, frozenset_gateway_union),
+            ),
         )
     };
     unsafe {
         pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
             ns,
             "intersection",
-            make_builtin_function("intersection", set_method_intersection),
+            make_builtin_function(
+                "intersection",
+                setlike_gateway(
+                    frozen,
+                    set_gateway_intersection,
+                    frozenset_gateway_intersection,
+                ),
+            ),
         )
     };
     unsafe {
         pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
             ns,
             "difference",
-            make_builtin_function("difference", set_method_difference),
+            make_builtin_function(
+                "difference",
+                setlike_gateway(frozen, set_gateway_difference, frozenset_gateway_difference),
+            ),
         )
     };
     unsafe {
@@ -19138,7 +19252,11 @@ fn init_setlike_common(ns: PyObjectRef, frozen: bool) {
             "symmetric_difference",
             make_builtin_function_with_arity(
                 "symmetric_difference",
-                set_method_symmetric_difference,
+                setlike_gateway(
+                    frozen,
+                    set_gateway_symmetric_difference,
+                    frozenset_gateway_symmetric_difference,
+                ),
                 2,
             ),
         )
@@ -19147,14 +19265,22 @@ fn init_setlike_common(ns: PyObjectRef, frozen: bool) {
         pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
             ns,
             "issubset",
-            make_builtin_function_with_arity("issubset", set_method_le, 2),
+            make_builtin_function_with_arity(
+                "issubset",
+                setlike_gateway(frozen, set_gateway_issubset, frozenset_gateway_issubset),
+                2,
+            ),
         )
     };
     unsafe {
         pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
             ns,
             "issuperset",
-            make_builtin_function_with_arity("issuperset", set_method_ge, 2),
+            make_builtin_function_with_arity(
+                "issuperset",
+                setlike_gateway(frozen, set_gateway_issuperset, frozenset_gateway_issuperset),
+                2,
+            ),
         )
     };
     unsafe {
@@ -19163,26 +19289,7 @@ fn init_setlike_common(ns: PyObjectRef, frozen: bool) {
             "isdisjoint",
             make_builtin_function_with_arity(
                 "isdisjoint",
-                |args| {
-                    if args.len() < 2 {
-                        return Ok(pyre_object::w_bool_from(true));
-                    }
-                    // `setobject.py descr_isdisjoint` — a set operand is
-                    // compared through its storage.
-                    if unsafe { pyre_object::is_set_or_frozenset(args[1]) } {
-                        return Ok(pyre_object::w_bool_from(set_is_disjoint_from(
-                            args[0], args[1],
-                        )?));
-                    }
-                    // `:383-385` — any other iterable is walked and each key
-                    // hashed by the lookup, which raises on an unhashable one.
-                    for item in crate::builtins::collect_iterable(args[1])? {
-                        if crate::type_methods::set_contains_checked(args[0], item)? {
-                            return Ok(pyre_object::w_bool_from(false));
-                        }
-                    }
-                    Ok(pyre_object::w_bool_from(true))
-                },
+                setlike_gateway(frozen, set_gateway_isdisjoint, frozenset_gateway_isdisjoint),
                 2,
             ),
         )
@@ -19195,20 +19302,7 @@ fn init_setlike_common(ns: PyObjectRef, frozen: bool) {
             // storage over rather than hashing the elements again.
             make_builtin_function_with_arity(
                 "copy",
-                |args| {
-                    if args.is_empty() {
-                        return Ok(pyre_object::w_set_new());
-                    }
-                    // setobject.py — only the exact built-in
-                    // frozenset is immutable enough for copy() to return
-                    // itself.  A subclass is copied into a base frozenset.
-                    if unsafe {
-                        pyre_object::is_exact_type(args[0], &pyre_object::setobject::FROZENSET_TYPE)
-                    } {
-                        return Ok(args[0]);
-                    }
-                    Ok(set_copy_real(args[0]))
-                },
+                setlike_gateway(frozen, set_gateway_copy, frozenset_gateway_copy),
                 1,
             ),
         )

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -20191,14 +20191,16 @@ fn init_frozenset_type(ns: PyObjectRef) {
 }
 
 fn set_iter_self(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    Ok(args[0])
+    crate::type_methods::require_set_iterator_receiver(args, "__iter__", false)
 }
 
 fn set_iter_next(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    crate::type_methods::require_set_iterator_receiver(args, "__next__", false)?;
     crate::baseobjspace::next(args[0])
 }
 
 fn set_iter_length_hint(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    crate::type_methods::require_set_iterator_receiver(args, "__length_hint__", true)?;
     unsafe {
         let w_set = pyre_object::w_set_iter_get_set(args[0]);
         let startlen = pyre_object::w_set_iter_get_startlen(args[0]);
@@ -20213,6 +20215,7 @@ fn set_iter_length_hint(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyEr
 /// setobject.py `W_SetIterObject.descr_reduce`: materialize only
 /// the clone's remaining entries, then return `(iter, (list,))`.
 fn set_iter_reduce(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    crate::type_methods::require_set_iterator_receiver(args, "__reduce__", true)?;
     unsafe {
         let w_set = pyre_object::w_set_iter_get_set(args[0]);
         let startlen = pyre_object::w_set_iter_get_startlen(args[0]);

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -431,7 +431,7 @@ pub fn init_typeobjects() {
         // stops at the common slots per dictmultiobject.py:1831-1840
         // (values views are intentionally NOT set-like).
         let dict_keys_type =
-            new_typeobject_with_base("dict_keys", init_dict_view_set_like_type, object_type);
+            new_typeobject_with_base("dict_keys", init_dict_view_keys_type, object_type);
         unsafe { pyre_object::w_type_set_acceptable_as_base_class(dict_keys_type, false) };
         reg.insert(
             &pyre_object::dictmultiobject::DICT_KEYS_TYPE as *const PyType as usize,
@@ -445,7 +445,7 @@ pub fn init_typeobjects() {
             dict_values_type as usize,
         );
         let dict_items_type =
-            new_typeobject_with_base("dict_items", init_dict_view_set_like_type, object_type);
+            new_typeobject_with_base("dict_items", init_dict_view_items_type, object_type);
         unsafe { pyre_object::w_type_set_acceptable_as_base_class(dict_items_type, false) };
         reg.insert(
             &pyre_object::dictmultiobject::DICT_ITEMS_TYPE as *const PyType as usize,
@@ -852,22 +852,39 @@ pub fn init_typeobjects() {
             &pyre_object::functional::ZIP_TYPE as *const PyType as usize,
             new_typeobject_with_base("zip", init_zip_type, object_type) as usize,
         );
-        for (pytype, name) in [
+        for (pytype, name, init) in [
             (
                 &pyre_object::dictmultiobject::DICT_KEYITERATOR_TYPE as *const PyType,
                 "dict_keyiterator",
+                init_dict_key_iterator_type as fn(PyObjectRef),
             ),
             (
                 &pyre_object::dictmultiobject::DICT_VALUEITERATOR_TYPE as *const PyType,
                 "dict_valueiterator",
+                init_dict_value_iterator_type as fn(PyObjectRef),
             ),
             (
                 &pyre_object::dictmultiobject::DICT_ITEMITERATOR_TYPE as *const PyType,
                 "dict_itemiterator",
+                init_dict_item_iterator_type as fn(PyObjectRef),
+            ),
+            (
+                &pyre_object::dictmultiobject::DICT_REVERSEKEYITERATOR_TYPE as *const PyType,
+                "dict_reversekeyiterator",
+                init_dict_reverse_key_iterator_type as fn(PyObjectRef),
+            ),
+            (
+                &pyre_object::dictmultiobject::DICT_REVERSEVALUEITERATOR_TYPE as *const PyType,
+                "dict_reversevalueiterator",
+                init_dict_reverse_value_iterator_type as fn(PyObjectRef),
+            ),
+            (
+                &pyre_object::dictmultiobject::DICT_REVERSEITEMITERATOR_TYPE as *const PyType,
+                "dict_reverseitemiterator",
+                init_dict_reverse_item_iterator_type as fn(PyObjectRef),
             ),
         ] {
-            let iterator_type =
-                new_typeobject_with_base(name, init_dict_iterator_type, object_type);
+            let iterator_type = new_typeobject_with_base(name, init, object_type);
             unsafe {
                 pyre_object::w_type_set_disallow_instantiation(iterator_type);
                 pyre_object::w_type_set_acceptable_as_base_class(iterator_type, false);
@@ -5289,21 +5306,23 @@ fn init_dict_type(ns: PyObjectRef) {
             make_builtin_function_with_arity(
                 "__reversed__",
                 |args| {
-                    // `dictmultiobject.py:207 descr_reversed`: reverse iterator
-                    // over the dict keys.
+                    // `dictmultiobject.py:207 descr_reversed`:
+                    // `strategy.w_iterreversed(self)` returns the live
+                    // `W_DictMultiIterKeysReversedObject` cursor.
+                    dict_iterator_receiver(
+                        args,
+                        "__reversed__",
+                        true,
+                        "dict",
+                        &pyre_object::DICT_TYPE,
+                    )?;
                     let d = crate::type_methods::resolve_dict_backing(args[0]);
-                    let mut keys: Vec<PyObjectRef> = if d.is_null() {
-                        Vec::new()
-                    } else {
-                        unsafe { pyre_object::w_dict_items(d) }
-                            .into_iter()
-                            .map(|(k, _)| k)
-                            .collect()
-                    };
-                    keys.reverse();
-                    let n = keys.len();
-                    let list = pyre_object::w_list_new(keys);
-                    Ok(pyre_object::w_seq_iter_new(list, n))
+                    Ok(
+                        pyre_object::dictmultiobject::w_dict_view_reverse_iterator_new(
+                            d,
+                            pyre_object::dictmultiobject::DictViewKind::Keys,
+                        ),
+                    )
                 },
                 1,
             ),
@@ -5426,7 +5445,48 @@ fn init_dict_type(ns: PyObjectRef) {
 /// `dict_values` stops here; `dict_keys` / `dict_items` extend with
 /// the SetLikeDictView surface in
 /// `init_dict_view_set_like_type` below.
-fn init_dict_view_common_slots(ns: PyObjectRef) {
+fn dict_view_reversed(
+    args: &[PyObjectRef],
+    owner: &str,
+    expected: &'static PyType,
+    kind: pyre_object::dictmultiobject::DictViewKind,
+) -> crate::PyResult {
+    let view = dict_iterator_receiver(args, "__reversed__", true, owner, expected)?;
+    let dict = unsafe { pyre_object::dictmultiobject::w_dict_view_get_dict(view) };
+    Ok(pyre_object::dictmultiobject::w_dict_view_reverse_iterator_new(dict, kind))
+}
+
+fn dict_keys_reversed(args: &[PyObjectRef]) -> crate::PyResult {
+    dict_view_reversed(
+        args,
+        "dict_keys",
+        &pyre_object::dictmultiobject::DICT_KEYS_TYPE,
+        pyre_object::dictmultiobject::DictViewKind::Keys,
+    )
+}
+
+fn dict_values_reversed(args: &[PyObjectRef]) -> crate::PyResult {
+    dict_view_reversed(
+        args,
+        "dict_values",
+        &pyre_object::dictmultiobject::DICT_VALUES_TYPE,
+        pyre_object::dictmultiobject::DictViewKind::Values,
+    )
+}
+
+fn dict_items_reversed(args: &[PyObjectRef]) -> crate::PyResult {
+    dict_view_reversed(
+        args,
+        "dict_items",
+        &pyre_object::dictmultiobject::DICT_ITEMS_TYPE,
+        pyre_object::dictmultiobject::DictViewKind::Items,
+    )
+}
+
+fn init_dict_view_common_slots(
+    ns: PyObjectRef,
+    reversed_fn: fn(&[PyObjectRef]) -> crate::PyResult,
+) {
     unsafe {
         pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
             ns,
@@ -5453,18 +5513,7 @@ fn init_dict_view_common_slots(ns: PyObjectRef) {
         pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
             ns,
             "__reversed__",
-            make_builtin_function_with_arity(
-                "__reversed__",
-                |args| {
-                    let view = args[0];
-                    let mut snapshot = crate::type_methods::dict_view_snapshot(view);
-                    snapshot.reverse();
-                    let n = snapshot.len();
-                    let list = pyre_object::w_list_new(snapshot);
-                    Ok(pyre_object::w_seq_iter_new(list, n))
-                },
-                1,
-            ),
+            make_builtin_function_with_arity("__reversed__", reversed_fn, 1),
         )
     };
     unsafe {
@@ -5519,8 +5568,11 @@ fn init_dict_view_common_slots(ns: PyObjectRef) {
 /// `W_DictViewItemsObject`
 /// typedef body — common slots plus `__contains__` and the
 /// SetLikeDictView surface (comparisons, set ops, isdisjoint).
-fn init_dict_view_set_like_type(ns: PyObjectRef) {
-    init_dict_view_common_slots(ns);
+fn init_dict_view_set_like_type(
+    ns: PyObjectRef,
+    reversed_fn: fn(&[PyObjectRef]) -> crate::PyResult,
+) {
+    init_dict_view_common_slots(ns, reversed_fn);
     unsafe {
         pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
             ns,
@@ -5548,7 +5600,15 @@ fn init_dict_view_set_like_type(ns: PyObjectRef) {
 /// have no `__contains__` / set ops / comparisons of their own;
 /// equality falls through to `object.__eq__`'s identity check.
 fn init_dict_view_values_type(ns: PyObjectRef) {
-    init_dict_view_common_slots(ns);
+    init_dict_view_common_slots(ns, dict_values_reversed);
+}
+
+fn init_dict_view_keys_type(ns: PyObjectRef) {
+    init_dict_view_set_like_type(ns, dict_keys_reversed);
+}
+
+fn init_dict_view_items_type(ns: PyObjectRef) {
+    init_dict_view_set_like_type(ns, dict_items_reversed);
 }
 
 /// `pypy/interpreter/pytraceback.py:17-101 PyTraceback.typedef` —
@@ -6805,29 +6865,26 @@ fn init_mappingproxy_type(ns: PyObjectRef) {
         )
     };
     // dictproxyobject.py:87 descr_reversed →
-    // `space.call_method(self.w_mapping, '__reversed__')`.  Pyre lacks
-    // a dedicated reverse iterator on dict, so fall back to building
-    // a list of keys in reverse insertion order.
+    // `space.call_method(self.w_mapping, '__reversed__')`.
     unsafe {
         pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
             ns,
             "__reversed__",
             make_builtin_function("__reversed__", |args| {
-                if args.is_empty() {
-                    return Ok(pyre_object::w_list_new(vec![]));
-                }
+                dict_iterator_receiver(
+                    args,
+                    "__reversed__",
+                    true,
+                    "mappingproxy",
+                    &pyre_object::MAPPING_PROXY_TYPE,
+                )?;
                 let dict = crate::type_methods::resolve_dict_backing(args[0]);
-                if dict.is_null() {
-                    return Ok(pyre_object::w_list_new(vec![]));
-                }
-                let mut keys: Vec<pyre_object::PyObjectRef> = unsafe {
-                    pyre_object::w_dict_items(dict)
-                        .into_iter()
-                        .map(|(k, _)| k)
-                        .collect()
-                };
-                keys.reverse();
-                crate::baseobjspace::iter(pyre_object::w_list_new(keys))
+                Ok(
+                    pyre_object::dictmultiobject::w_dict_view_reverse_iterator_new(
+                        dict,
+                        pyre_object::dictmultiobject::DictViewKind::Keys,
+                    ),
+                )
             }),
         )
     };
@@ -20529,39 +20586,140 @@ fn init_sequence_iterator_type(ns: PyObjectRef) {
     }
 }
 
-/// PyPy `dictmultiobject.py W_DictMultiIter{Keys,Values,Items}Object.typedef`.
-fn init_dict_iterator_type(ns: PyObjectRef) {
-    unsafe { pyre_object::w_dict_setitem_str(ns, "__doc__", pyre_object::w_none()) };
-    let entries = [
-        (
-            "__iter__",
-            make_builtin_function_with_arity("__iter__", crate::baseobjspace::iter_self_method, 1),
-        ),
-        (
-            "__next__",
-            make_builtin_function_with_arity("__next__", crate::baseobjspace::iter_next_method, 1),
-        ),
-        (
-            "__length_hint__",
-            make_builtin_function_with_arity(
-                "__length_hint__",
-                crate::baseobjspace::dict_view_iter_length_hint_method,
-                1,
-            ),
-        ),
-        (
-            "__reduce__",
-            make_builtin_function_with_arity(
-                "__reduce__",
-                crate::baseobjspace::dict_view_iter_reduce_method,
-                1,
-            ),
-        ),
-    ];
-    for (name, value) in entries {
-        unsafe { pyre_object::w_dict_setitem_str_no_proxy(ns, name, value) };
+fn dict_iterator_receiver(
+    args: &[PyObjectRef],
+    name: &str,
+    method_descriptor: bool,
+    owner: &str,
+    expected: &'static PyType,
+) -> Result<PyObjectRef, crate::PyError> {
+    let Some(&receiver) = args.first() else {
+        let message = if method_descriptor {
+            format!("unbound method {owner}.{name}() needs an argument")
+        } else {
+            format!("descriptor '{name}' of '{owner}' object needs an argument")
+        };
+        return Err(crate::PyError::type_error(message));
+    };
+    if !unsafe { pyre_object::py_type_check(receiver, expected) } {
+        let received = crate::baseobjspace::object_functionstr_type_name(receiver);
+        let message = if method_descriptor {
+            format!(
+                "descriptor '{name}' for '{owner}' objects doesn't apply to a '{received}' object"
+            )
+        } else {
+            format!("descriptor '{name}' requires a '{owner}' object but received a '{received}'")
+        };
+        return Err(crate::PyError::type_error(message));
     }
+    Ok(receiver)
 }
+
+/// PyPy's six concrete `W_BaseDictMultiIterObject` typedefs share their
+/// implementations, while each interp2app gateway still enforces its own
+/// concrete receiver class.
+macro_rules! define_dict_iterator_type {
+    ($init:ident, $self_fn:ident, $next_fn:ident, $len_fn:ident, $reduce_fn:ident, $owner:literal, $expected:path) => {
+        fn $self_fn(args: &[PyObjectRef]) -> crate::PyResult {
+            dict_iterator_receiver(args, "__iter__", false, $owner, &$expected)
+        }
+
+        fn $next_fn(args: &[PyObjectRef]) -> crate::PyResult {
+            dict_iterator_receiver(args, "__next__", false, $owner, &$expected)?;
+            crate::baseobjspace::next(args[0])
+        }
+
+        fn $len_fn(args: &[PyObjectRef]) -> crate::PyResult {
+            dict_iterator_receiver(args, "__length_hint__", true, $owner, &$expected)?;
+            crate::baseobjspace::dict_view_iter_length_hint_method(args)
+        }
+
+        fn $reduce_fn(args: &[PyObjectRef]) -> crate::PyResult {
+            dict_iterator_receiver(args, "__reduce__", true, $owner, &$expected)?;
+            crate::baseobjspace::dict_view_iter_reduce_method(args)
+        }
+
+        fn $init(ns: PyObjectRef) {
+            unsafe { pyre_object::w_dict_setitem_str(ns, "__doc__", pyre_object::w_none()) };
+            let entries = [
+                (
+                    "__iter__",
+                    make_builtin_function_with_arity("__iter__", $self_fn, 1),
+                ),
+                (
+                    "__next__",
+                    make_builtin_function_with_arity("__next__", $next_fn, 1),
+                ),
+                (
+                    "__length_hint__",
+                    make_builtin_function_with_arity("__length_hint__", $len_fn, 1),
+                ),
+                (
+                    "__reduce__",
+                    make_builtin_function_with_arity("__reduce__", $reduce_fn, 1),
+                ),
+            ];
+            for (name, value) in entries {
+                unsafe { pyre_object::w_dict_setitem_str_no_proxy(ns, name, value) };
+            }
+        }
+    };
+}
+
+define_dict_iterator_type!(
+    init_dict_key_iterator_type,
+    dict_key_iter_self,
+    dict_key_iter_next,
+    dict_key_iter_len,
+    dict_key_iter_reduce,
+    "dict_keyiterator",
+    pyre_object::dictmultiobject::DICT_KEYITERATOR_TYPE
+);
+define_dict_iterator_type!(
+    init_dict_value_iterator_type,
+    dict_value_iter_self,
+    dict_value_iter_next,
+    dict_value_iter_len,
+    dict_value_iter_reduce,
+    "dict_valueiterator",
+    pyre_object::dictmultiobject::DICT_VALUEITERATOR_TYPE
+);
+define_dict_iterator_type!(
+    init_dict_item_iterator_type,
+    dict_item_iter_self,
+    dict_item_iter_next,
+    dict_item_iter_len,
+    dict_item_iter_reduce,
+    "dict_itemiterator",
+    pyre_object::dictmultiobject::DICT_ITEMITERATOR_TYPE
+);
+define_dict_iterator_type!(
+    init_dict_reverse_key_iterator_type,
+    dict_reverse_key_iter_self,
+    dict_reverse_key_iter_next,
+    dict_reverse_key_iter_len,
+    dict_reverse_key_iter_reduce,
+    "dict_reversekeyiterator",
+    pyre_object::dictmultiobject::DICT_REVERSEKEYITERATOR_TYPE
+);
+define_dict_iterator_type!(
+    init_dict_reverse_value_iterator_type,
+    dict_reverse_value_iter_self,
+    dict_reverse_value_iter_next,
+    dict_reverse_value_iter_len,
+    dict_reverse_value_iter_reduce,
+    "dict_reversevalueiterator",
+    pyre_object::dictmultiobject::DICT_REVERSEVALUEITERATOR_TYPE
+);
+define_dict_iterator_type!(
+    init_dict_reverse_item_iterator_type,
+    dict_reverse_item_iter_self,
+    dict_reverse_item_iter_next,
+    dict_reverse_item_iter_len,
+    dict_reverse_item_iter_reduce,
+    "dict_reverseitemiterator",
+    pyre_object::dictmultiobject::DICT_REVERSEITEMITERATOR_TYPE
+);
 
 fn range_iterator_self(args: &[PyObjectRef]) -> crate::PyResult {
     crate::type_methods::require_range_iterator_receiver(args, "__iter__", false, false)

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -10049,7 +10049,10 @@ fn init_method_type(ns: PyObjectRef) {
     let doc_getter = make_builtin_function_with_arity(
         "__doc__",
         |args| {
-            let method = args.get(1).copied().unwrap_or(pyre_object::PY_NULL);
+            let method = crate::function::require_method(
+                args.get(1).copied().unwrap_or(pyre_object::PY_NULL),
+                "__doc__",
+            )?;
             let function = unsafe { pyre_object::w_method_get_func(method) };
             crate::baseobjspace::getattr_str(function, "__doc__")
         },
@@ -10108,10 +10111,10 @@ fn init_method_type(ns: PyObjectRef) {
     let func_getter = make_builtin_function_with_arity(
         "__func__",
         |args| {
-            let method = args.get(1).copied().unwrap_or(pyre_object::PY_NULL);
-            if !unsafe { pyre_object::function::is_method(method) } {
-                return Ok(pyre_object::w_none());
-            }
+            let method = crate::function::require_method(
+                args.get(1).copied().unwrap_or(pyre_object::PY_NULL),
+                "__func__",
+            )?;
             let w_value = unsafe { pyre_object::w_method_get_func(method) };
             if w_value.is_null() {
                 Ok(pyre_object::w_none())
@@ -10131,10 +10134,10 @@ fn init_method_type(ns: PyObjectRef) {
     let self_getter = make_builtin_function_with_arity(
         "__self__",
         |args| {
-            let method = args.get(1).copied().unwrap_or(pyre_object::PY_NULL);
-            if !unsafe { pyre_object::function::is_method(method) } {
-                return Ok(pyre_object::w_none());
-            }
+            let method = crate::function::require_method(
+                args.get(1).copied().unwrap_or(pyre_object::PY_NULL),
+                "__self__",
+            )?;
             let w_value = unsafe { pyre_object::w_method_get_self(method) };
             if w_value.is_null() {
                 Ok(pyre_object::w_none())
@@ -10184,16 +10187,37 @@ fn init_method_type(ns: PyObjectRef) {
             ),
         )
     };
-    for name in ["__lt__", "__le__", "__gt__", "__ge__"] {
+    type MethodOrderFn = fn(&[PyObjectRef]) -> crate::PyResult;
+    fn order(args: &[PyObjectRef], name: &str) -> crate::PyResult {
+        crate::function::require_method(
+            args.first().copied().unwrap_or(pyre_object::PY_NULL),
+            name,
+        )?;
+        Ok(pyre_object::special::w_not_implemented())
+    }
+    fn lt(args: &[PyObjectRef]) -> crate::PyResult {
+        order(args, "__lt__")
+    }
+    fn le(args: &[PyObjectRef]) -> crate::PyResult {
+        order(args, "__le__")
+    }
+    fn gt(args: &[PyObjectRef]) -> crate::PyResult {
+        order(args, "__gt__")
+    }
+    fn ge(args: &[PyObjectRef]) -> crate::PyResult {
+        order(args, "__ge__")
+    }
+    for (name, function) in [
+        ("__lt__", lt as MethodOrderFn),
+        ("__le__", le),
+        ("__gt__", gt),
+        ("__ge__", ge),
+    ] {
         unsafe {
             pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
                 ns,
                 name,
-                make_builtin_function_with_arity(
-                    name,
-                    |_args| Ok(pyre_object::special::w_not_implemented()),
-                    2,
-                ),
+                make_builtin_function_with_arity(name, function, 2),
             )
         };
     }

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -18770,7 +18770,110 @@ fn set_discard_from_set(w_set: PyObjectRef, w_item: PyObjectRef) -> Result<bool,
     }
 }
 
-fn init_setlike_common(ns: PyObjectRef) {
+fn setlike_descr_len(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    Ok(pyre_object::w_int_new(
+        unsafe { pyre_object::w_set_len(args[0]) } as i64,
+    ))
+}
+
+fn setlike_descr_iter(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    Ok(pyre_object::w_set_iter_new(args[0]))
+}
+
+fn setlike_descr_repr(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    unsafe { Ok(pyre_object::w_str_new(&crate::display::py_repr(args[0])?)) }
+}
+
+macro_rules! setlike_wrapper_gateways {
+    ($set_fn:ident, $frozenset_fn:ident, $name:literal, $implementation:ident) => {
+        fn $set_fn(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+            crate::type_methods::require_set_receiver(args, $name, false)?;
+            $implementation(args)
+        }
+
+        fn $frozenset_fn(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+            crate::type_methods::require_frozenset_receiver(args, $name, false)?;
+            $implementation(args)
+        }
+    };
+}
+
+setlike_wrapper_gateways!(
+    set_gateway_len,
+    frozenset_gateway_len,
+    "__len__",
+    setlike_descr_len
+);
+setlike_wrapper_gateways!(
+    set_gateway_iter,
+    frozenset_gateway_iter,
+    "__iter__",
+    setlike_descr_iter
+);
+setlike_wrapper_gateways!(
+    set_gateway_repr,
+    frozenset_gateway_repr,
+    "__repr__",
+    setlike_descr_repr
+);
+setlike_wrapper_gateways!(set_gateway_or, frozenset_gateway_or, "__or__", set_op_or);
+setlike_wrapper_gateways!(
+    set_gateway_and,
+    frozenset_gateway_and,
+    "__and__",
+    set_op_and
+);
+setlike_wrapper_gateways!(
+    set_gateway_sub,
+    frozenset_gateway_sub,
+    "__sub__",
+    set_op_sub
+);
+setlike_wrapper_gateways!(
+    set_gateway_xor,
+    frozenset_gateway_xor,
+    "__xor__",
+    set_op_xor
+);
+setlike_wrapper_gateways!(
+    set_gateway_rsub,
+    frozenset_gateway_rsub,
+    "__rsub__",
+    set_op_rsub
+);
+setlike_wrapper_gateways!(
+    set_gateway_rand,
+    frozenset_gateway_rand,
+    "__rand__",
+    set_op_and
+);
+setlike_wrapper_gateways!(set_gateway_ror, frozenset_gateway_ror, "__ror__", set_op_or);
+setlike_wrapper_gateways!(
+    set_gateway_rxor,
+    frozenset_gateway_rxor,
+    "__rxor__",
+    set_op_xor
+);
+setlike_wrapper_gateways!(set_gateway_eq, frozenset_gateway_eq, "__eq__", set_descr_eq);
+setlike_wrapper_gateways!(set_gateway_ne, frozenset_gateway_ne, "__ne__", set_descr_ne);
+setlike_wrapper_gateways!(set_gateway_le, frozenset_gateway_le, "__le__", set_descr_le);
+setlike_wrapper_gateways!(set_gateway_ge, frozenset_gateway_ge, "__ge__", set_descr_ge);
+setlike_wrapper_gateways!(set_gateway_lt, frozenset_gateway_lt, "__lt__", set_descr_lt);
+setlike_wrapper_gateways!(set_gateway_gt, frozenset_gateway_gt, "__gt__", set_descr_gt);
+
+fn setlike_gateway(
+    frozen: bool,
+    set_gateway: crate::gateway::BuiltinCodeFn,
+    frozenset_gateway: crate::gateway::BuiltinCodeFn,
+) -> crate::gateway::BuiltinCodeFn {
+    if frozen {
+        frozenset_gateway
+    } else {
+        set_gateway
+    }
+}
+
+fn init_setlike_common(ns: PyObjectRef, frozen: bool) {
     unsafe {
         pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
             ns,
@@ -18816,19 +18919,7 @@ fn init_setlike_common(ns: PyObjectRef) {
             "__len__",
             make_builtin_function_with_arity(
                 "__len__",
-                |args| {
-                    if args.is_empty() {
-                        return Ok(pyre_object::w_int_new(0));
-                    }
-                    unsafe {
-                        if pyre_object::is_set_or_frozenset(args[0]) {
-                            return Ok(pyre_object::w_int_new(
-                                pyre_object::w_set_len(args[0]) as i64
-                            ));
-                        }
-                    }
-                    Ok(pyre_object::w_int_new(0))
-                },
+                setlike_gateway(frozen, set_gateway_len, frozenset_gateway_len),
                 1,
             ),
         )
@@ -18839,12 +18930,7 @@ fn init_setlike_common(ns: PyObjectRef) {
             "__iter__",
             make_builtin_function_with_arity(
                 "__iter__",
-                |args| {
-                    if args.is_empty() {
-                        return Ok(pyre_object::w_none());
-                    }
-                    crate::baseobjspace::iter(args[0])
-                },
+                setlike_gateway(frozen, set_gateway_iter, frozenset_gateway_iter),
                 1,
             ),
         )
@@ -18855,7 +18941,7 @@ fn init_setlike_common(ns: PyObjectRef) {
             "__repr__",
             make_builtin_function_with_arity(
                 "__repr__",
-                |args| unsafe { Ok(pyre_object::w_str_new(&crate::display::py_repr(args[0])?)) },
+                setlike_gateway(frozen, set_gateway_repr, frozenset_gateway_repr),
                 1,
             ),
         )
@@ -18875,98 +18961,154 @@ fn init_setlike_common(ns: PyObjectRef) {
         pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
             ns,
             "__or__",
-            make_builtin_function_with_arity("__or__", set_op_or, 2),
+            make_builtin_function_with_arity(
+                "__or__",
+                setlike_gateway(frozen, set_gateway_or, frozenset_gateway_or),
+                2,
+            ),
         )
     };
     unsafe {
         pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
             ns,
             "__and__",
-            make_builtin_function_with_arity("__and__", set_op_and, 2),
+            make_builtin_function_with_arity(
+                "__and__",
+                setlike_gateway(frozen, set_gateway_and, frozenset_gateway_and),
+                2,
+            ),
         )
     };
     unsafe {
         pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
             ns,
             "__sub__",
-            make_builtin_function_with_arity("__sub__", set_op_sub, 2),
+            make_builtin_function_with_arity(
+                "__sub__",
+                setlike_gateway(frozen, set_gateway_sub, frozenset_gateway_sub),
+                2,
+            ),
         )
     };
     unsafe {
         pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
             ns,
             "__xor__",
-            make_builtin_function_with_arity("__xor__", set_op_xor, 2),
+            make_builtin_function_with_arity(
+                "__xor__",
+                setlike_gateway(frozen, set_gateway_xor, frozenset_gateway_xor),
+                2,
+            ),
         )
     };
     unsafe {
         pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
             ns,
             "__rsub__",
-            make_builtin_function_with_arity("__rsub__", set_op_rsub, 2),
+            make_builtin_function_with_arity(
+                "__rsub__",
+                setlike_gateway(frozen, set_gateway_rsub, frozenset_gateway_rsub),
+                2,
+            ),
         )
     };
     unsafe {
         pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
             ns,
             "__rand__",
-            make_builtin_function_with_arity("__rand__", set_op_and, 2),
+            make_builtin_function_with_arity(
+                "__rand__",
+                setlike_gateway(frozen, set_gateway_rand, frozenset_gateway_rand),
+                2,
+            ),
         )
     };
     unsafe {
         pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
             ns,
             "__ror__",
-            make_builtin_function_with_arity("__ror__", set_op_or, 2),
+            make_builtin_function_with_arity(
+                "__ror__",
+                setlike_gateway(frozen, set_gateway_ror, frozenset_gateway_ror),
+                2,
+            ),
         )
     };
     unsafe {
         pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
             ns,
             "__rxor__",
-            make_builtin_function_with_arity("__rxor__", set_op_xor, 2),
+            make_builtin_function_with_arity(
+                "__rxor__",
+                setlike_gateway(frozen, set_gateway_rxor, frozenset_gateway_rxor),
+                2,
+            ),
         )
     };
     unsafe {
         pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
             ns,
             "__eq__",
-            make_builtin_function_with_arity("__eq__", set_descr_eq, 2),
+            make_builtin_function_with_arity(
+                "__eq__",
+                setlike_gateway(frozen, set_gateway_eq, frozenset_gateway_eq),
+                2,
+            ),
         )
     };
     unsafe {
         pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
             ns,
             "__ne__",
-            make_builtin_function_with_arity("__ne__", set_descr_ne, 2),
+            make_builtin_function_with_arity(
+                "__ne__",
+                setlike_gateway(frozen, set_gateway_ne, frozenset_gateway_ne),
+                2,
+            ),
         )
     };
     unsafe {
         pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
             ns,
             "__le__",
-            make_builtin_function_with_arity("__le__", set_descr_le, 2),
+            make_builtin_function_with_arity(
+                "__le__",
+                setlike_gateway(frozen, set_gateway_le, frozenset_gateway_le),
+                2,
+            ),
         )
     };
     unsafe {
         pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
             ns,
             "__ge__",
-            make_builtin_function_with_arity("__ge__", set_descr_ge, 2),
+            make_builtin_function_with_arity(
+                "__ge__",
+                setlike_gateway(frozen, set_gateway_ge, frozenset_gateway_ge),
+                2,
+            ),
         )
     };
     unsafe {
         pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
             ns,
             "__lt__",
-            make_builtin_function_with_arity("__lt__", set_descr_lt, 2),
+            make_builtin_function_with_arity(
+                "__lt__",
+                setlike_gateway(frozen, set_gateway_lt, frozenset_gateway_lt),
+                2,
+            ),
         )
     };
     unsafe {
         pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
             ns,
             "__gt__",
-            make_builtin_function_with_arity("__gt__", set_descr_gt, 2),
+            make_builtin_function_with_arity(
+                "__gt__",
+                setlike_gateway(frozen, set_gateway_gt, frozenset_gateway_gt),
+                2,
+            ),
         )
     };
     unsafe {
@@ -19711,7 +19853,7 @@ fn init_set_type(ns: PyObjectRef) {
             make_builtin_function("__init__", set_descr_init),
         )
     };
-    init_setlike_common(ns);
+    init_setlike_common(ns, false);
     // setobject.py `__hash__ = None` — keep the slot visible to
     // introspection as well as the unhashable fast path in builtin_hash.
     unsafe {
@@ -19932,7 +20074,7 @@ fn init_frozenset_type(ns: PyObjectRef) {
             )),
         )
     };
-    init_setlike_common(ns);
+    init_setlike_common(ns, true);
     // setobject.py descr_hash.  The Result-bearing hash helper walks the
     // elements and propagates an element hash error; the storage itself is not
     // rebuilt and no set element is re-inserted.
@@ -19943,6 +20085,7 @@ fn init_frozenset_type(ns: PyObjectRef) {
             make_builtin_function_with_arity(
                 "__hash__",
                 |args| {
+                    crate::type_methods::require_frozenset_receiver(args, "__hash__", false)?;
                     Ok(pyre_object::w_int_new(crate::builtins::try_hash_value(
                         args[0],
                     )?))

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -2500,8 +2500,59 @@ fn map_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
 /// `filter.__new__(cls, predicate, iterable)` — `functional.py:917-925
 /// W_Filter.descr___new__`.
 fn filter_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    let cls = args.first().copied().unwrap_or(pyre_object::PY_NULL);
-    let value = crate::builtins::builtin_filter(args.get(1..).unwrap_or(&[]))?;
+    let (positional, kwargs) = crate::builtins::split_builtin_kwargs(args);
+    let cls = positional.first().copied().unwrap_or(pyre_object::PY_NULL);
+    let args_w = positional.get(1..).unwrap_or(&[]);
+    if args_w.len() != 2 {
+        return Err(crate::PyError::type_error(format!(
+            "filter expected 2 arguments, got {}",
+            args_w.len()
+        )));
+    }
+
+    // `space.getattr` and keyword-name inspection are allowed to allocate in
+    // the source gateway. Keep the subtype and both positional arguments live
+    // before reproducing that conditional keyword check.
+    let _roots = pyre_object::gc_roots::push_roots();
+    pyre_object::gc_roots::pin_root(cls);
+    let cls_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+    pyre_object::gc_roots::pin_root(args_w[0]);
+    let predicate_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+    pyre_object::gc_roots::pin_root(args_w[1]);
+    let iterable_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+    let kwargs_slot = kwargs.map(|dict| {
+        pyre_object::gc_roots::pin_root(dict);
+        pyre_object::gc_roots::shadow_stack_len() - 1
+    });
+    let cls = unsafe { pyre_object::gc_roots::shadow_stack_get(cls_slot) };
+    let filter_type =
+        gettypefor(&pyre_object::functional::FILTER_TYPE).unwrap_or(pyre_object::PY_NULL);
+    let init_matches = std::ptr::eq(cls, filter_type)
+        || unsafe {
+            match (
+                crate::baseobjspace::lookup_in_type(cls, "__init__"),
+                crate::baseobjspace::lookup_in_type(filter_type, "__init__"),
+            ) {
+                (Some(sub), Some(base)) => std::ptr::eq(sub, base),
+                (None, None) => true,
+                _ => false,
+            }
+        };
+    let rooted_kwargs =
+        kwargs_slot.map(|slot| unsafe { pyre_object::gc_roots::shadow_stack_get(slot) });
+    if init_matches && crate::builtins::has_real_kwargs(rooted_kwargs) {
+        return Err(crate::PyError::type_error(
+            "filter() takes no keyword arguments",
+        ));
+    }
+    let value = crate::builtins::builtin_filter(&[
+        unsafe { pyre_object::gc_roots::shadow_stack_get(predicate_slot) },
+        unsafe { pyre_object::gc_roots::shadow_stack_get(iterable_slot) },
+    ])?;
+    pyre_object::gc_roots::pin_root(value);
+    let value_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+    let value = unsafe { pyre_object::gc_roots::shadow_stack_get(value_slot) };
+    let cls = unsafe { pyre_object::gc_roots::shadow_stack_get(cls_slot) };
     if let Some(sub) = subclass_to_tag(cls, &pyre_object::functional::FILTER_TYPE)? {
         unsafe {
             (*value).w_class = sub;
@@ -3072,9 +3123,9 @@ fn init_filter_type(ns: PyObjectRef) {
     for (name, function) in [
         (
             "__iter__",
-            crate::baseobjspace::iter_self_method as DunderFn,
+            crate::baseobjspace::filter_iter_method as DunderFn,
         ),
-        ("__next__", crate::baseobjspace::iter_next_method),
+        ("__next__", crate::baseobjspace::filter_next_method),
         ("__reduce__", crate::baseobjspace::filter_reduce_method),
     ] {
         install_functional_entry(

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -3487,21 +3487,7 @@ fn set_init_from_iterable(
 /// so anything beyond `(self, iterable)` raises TypeError; pyre enforces the
 /// same maxargs explicitly here.
 fn set_descr_init(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    let set_obj = args.first().copied().unwrap_or(pyre_object::PY_NULL);
-    // gateway.interp2app(W_SetObject.descr_init) enforces that `self` is a
-    // W_SetObject before the body runs; without this check pyre would cast
-    // arbitrary args[0] values straight to the set layout below.
-    if set_obj.is_null() || !unsafe { pyre_object::is_set(set_obj) } {
-        let tp_name = if set_obj.is_null() {
-            "NoneType".to_string()
-        } else {
-            unsafe { (*(*set_obj).ob_type).name.to_string() }
-        };
-        return Err(crate::PyError::type_error(format!(
-            "descriptor '__init__' requires a 'set' object but received a '{}'",
-            tp_name,
-        )));
-    }
+    let set_obj = crate::type_methods::require_set_receiver(args, "__init__", false)?;
     // setobject.py `descr_init(self, space, w_iterable=None, __posonly__=None)`
     // — `iterable` is a single positional-only optional argument.  Parse the
     // gateway args against that signature (gateway interp2app `parse_into_scope`)
@@ -19653,6 +19639,7 @@ fn set_symmetric_difference_storage(
 fn set_op_inplace_sub(
     args: &[pyre_object::PyObjectRef],
 ) -> Result<pyre_object::PyObjectRef, crate::PyError> {
+    crate::type_methods::require_set_receiver(args, "__isub__", false)?;
     if set_op_requires_set(args) {
         return Ok(pyre_object::w_not_implemented());
     }
@@ -19662,6 +19649,7 @@ fn set_op_inplace_sub(
 fn set_op_inplace_and(
     args: &[pyre_object::PyObjectRef],
 ) -> Result<pyre_object::PyObjectRef, crate::PyError> {
+    crate::type_methods::require_set_receiver(args, "__iand__", false)?;
     if set_op_requires_set(args) {
         return Ok(pyre_object::w_not_implemented());
     }
@@ -19671,6 +19659,7 @@ fn set_op_inplace_and(
 fn set_op_inplace_or(
     args: &[pyre_object::PyObjectRef],
 ) -> Result<pyre_object::PyObjectRef, crate::PyError> {
+    crate::type_methods::require_set_receiver(args, "__ior__", false)?;
     if set_op_requires_set(args) {
         return Ok(pyre_object::w_not_implemented());
     }
@@ -19680,6 +19669,7 @@ fn set_op_inplace_or(
 fn set_op_inplace_xor(
     args: &[pyre_object::PyObjectRef],
 ) -> Result<pyre_object::PyObjectRef, crate::PyError> {
+    crate::type_methods::require_set_receiver(args, "__ixor__", false)?;
     if set_op_requires_set(args) {
         return Ok(pyre_object::w_not_implemented());
     }
@@ -19738,6 +19728,7 @@ fn init_set_type(ns: PyObjectRef) {
             make_builtin_function_with_arity(
                 "add",
                 |args| {
+                    crate::type_methods::require_set_receiver(args, "add", true)?;
                     if args.len() >= 2 {
                         // `try_hash_value` may run a user `__hash__` that
                         // allocates and triggers a moving minor collection;
@@ -19769,6 +19760,7 @@ fn init_set_type(ns: PyObjectRef) {
             make_builtin_function_with_arity(
                 "discard",
                 |args| {
+                    crate::type_methods::require_set_receiver(args, "discard", true)?;
                     if args.len() >= 2 {
                         set_discard_from_set(args[0], args[1])?;
                     }
@@ -19785,6 +19777,7 @@ fn init_set_type(ns: PyObjectRef) {
             make_builtin_function_with_arity(
                 "remove",
                 |args| {
+                    crate::type_methods::require_set_receiver(args, "remove", true)?;
                     if args.len() < 2 {
                         return Err(crate::PyError::type_error("remove() requires an argument"));
                     }
@@ -19804,12 +19797,7 @@ fn init_set_type(ns: PyObjectRef) {
             make_builtin_function_with_arity(
                 "pop",
                 |args| {
-                    if args.is_empty() {
-                        return Err(crate::PyError::new(
-                            crate::PyErrorKind::KeyError,
-                            "pop from an empty set",
-                        ));
-                    }
+                    crate::type_methods::require_set_receiver(args, "pop", true)?;
                     if let Some(item) = unsafe { pyre_object::w_set_popitem(args[0]) } {
                         return Ok(item);
                     }
@@ -19829,9 +19817,8 @@ fn init_set_type(ns: PyObjectRef) {
             make_builtin_function_with_arity(
                 "clear",
                 |args| {
-                    if !args.is_empty() {
-                        unsafe { pyre_object::w_set_clear(args[0]) };
-                    }
+                    crate::type_methods::require_set_receiver(args, "clear", true)?;
+                    unsafe { pyre_object::w_set_clear(args[0]) };
                     Ok(pyre_object::w_none())
                 },
                 1,
@@ -19842,7 +19829,10 @@ fn init_set_type(ns: PyObjectRef) {
         pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
             ns,
             "update",
-            make_builtin_function("update", set_method_update),
+            make_builtin_function("update", |args| {
+                crate::type_methods::require_set_receiver(args, "update", true)?;
+                set_method_update(args)
+            }),
         )
     };
     // `setobject.py W_BaseSetObject.descr_difference_update` /
@@ -19853,24 +19843,34 @@ fn init_set_type(ns: PyObjectRef) {
         pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
             ns,
             "difference_update",
-            make_builtin_function("difference_update", set_method_difference_update),
+            make_builtin_function("difference_update", |args| {
+                crate::type_methods::require_set_receiver(args, "difference_update", true)?;
+                set_method_difference_update(args)
+            }),
         )
     };
     unsafe {
         pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
             ns,
             "intersection_update",
-            make_builtin_function("intersection_update", set_method_intersection_update),
+            make_builtin_function("intersection_update", |args| {
+                crate::type_methods::require_set_receiver(args, "intersection_update", true)?;
+                set_method_intersection_update(args)
+            }),
         )
     };
     unsafe {
         pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
             ns,
             "symmetric_difference_update",
-            make_builtin_function(
-                "symmetric_difference_update",
-                set_method_symmetric_difference_update,
-            ),
+            make_builtin_function("symmetric_difference_update", |args| {
+                crate::type_methods::require_set_receiver(
+                    args,
+                    "symmetric_difference_update",
+                    true,
+                )?;
+                set_method_symmetric_difference_update(args)
+            }),
         )
     };
     // `setobject.py` __isub__/__iand__/__ior__/__ixor__ — mutable-set-only

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -6992,7 +6992,11 @@ fn init_tuple_type(ns: PyObjectRef) {
             "__repr__",
             make_builtin_function_with_arity(
                 "__repr__",
-                |args| Ok(w_str_new(&unsafe { crate::display::tuple_repr(args[0])? })),
+                |args| {
+                    let tuple =
+                        crate::type_methods::require_tuple_receiver(args, "__repr__", false)?;
+                    Ok(w_str_new(&unsafe { crate::display::tuple_repr(tuple)? }))
+                },
                 1,
             ),
         )
@@ -7003,7 +7007,11 @@ fn init_tuple_type(ns: PyObjectRef) {
             "__hash__",
             make_builtin_function_with_arity(
                 "__hash__",
-                |args| Ok(w_int_new(crate::builtins::try_hash_value(args[0])?)),
+                |args| {
+                    let tuple =
+                        crate::type_methods::require_tuple_receiver(args, "__hash__", false)?;
+                    Ok(w_int_new(crate::builtins::try_hash_value(tuple)?))
+                },
                 1,
             ),
         )
@@ -7041,6 +7049,7 @@ fn init_tuple_type(ns: PyObjectRef) {
             make_builtin_function_with_arity(
                 "__contains__",
                 |args| {
+                    crate::type_methods::require_tuple_receiver(args, "__contains__", false)?;
                     crate::type_methods::arity_slot(args, 1)?;
                     Ok(pyre_object::w_bool_from(
                         crate::baseobjspace::contains_slot(args[0], args[1]).unwrap_or(false),
@@ -7057,12 +7066,11 @@ fn init_tuple_type(ns: PyObjectRef) {
             make_builtin_function_with_arity(
                 "__len__",
                 |args| {
-                    if args.is_empty() {
-                        return Ok(pyre_object::w_int_new(0));
-                    }
+                    let tuple =
+                        crate::type_methods::require_tuple_receiver(args, "__len__", false)?;
                     crate::type_methods::arity_slot(args, 0)?;
                     Ok(pyre_object::w_int_new(
-                        unsafe { pyre_object::w_tuple_len(args[0]) } as i64,
+                        unsafe { pyre_object::w_tuple_len(tuple) } as i64,
                     ))
                 },
                 1,
@@ -7079,10 +7087,8 @@ fn init_tuple_type(ns: PyObjectRef) {
             make_builtin_function_with_arity(
                 "__iter__",
                 |args| {
-                    let obj = args.first().copied().unwrap_or(pyre_object::PY_NULL);
-                    if obj.is_null() {
-                        return Ok(pyre_object::w_none());
-                    }
+                    let obj = crate::type_methods::require_tuple_receiver(args, "__iter__", false)?;
+                    crate::type_methods::arity_slot(args, 0)?;
                     Ok(pyre_object::w_tuple_iter_new(obj))
                 },
                 1,
@@ -7096,6 +7102,7 @@ fn init_tuple_type(ns: PyObjectRef) {
             make_builtin_function_with_arity(
                 "__getitem__",
                 |args| {
+                    crate::type_methods::require_tuple_receiver(args, "__getitem__", false)?;
                     crate::type_methods::arity_slot(args, 1)?;
                     crate::baseobjspace::getitem_slot(args[0], args[1])
                 },
@@ -7114,6 +7121,7 @@ fn init_tuple_type(ns: PyObjectRef) {
             make_builtin_function_with_arity(
                 "__add__",
                 |args| {
+                    crate::type_methods::require_tuple_receiver(args, "__add__", false)?;
                     crate::type_methods::arity_slot(args, 1)?;
                     if unsafe { pyre_object::is_tuple(args[1]) } {
                         unsafe { crate::objspace::descroperation::tuple_concat(args[0], args[1]) }
@@ -7136,7 +7144,7 @@ fn init_tuple_type(ns: PyObjectRef) {
         pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
             ns,
             "__rmul__",
-            make_builtin_function_with_arity("__rmul__", tuple_descr_mul, 2),
+            make_builtin_function_with_arity("__rmul__", tuple_descr_rmul, 2),
         )
     };
     for (name, func) in [
@@ -7163,7 +7171,9 @@ fn init_tuple_type(ns: PyObjectRef) {
             make_builtin_function_with_arity(
                 "__getnewargs__",
                 |args| {
-                    let items = unsafe { pyre_object::w_tuple_items_copy_as_vec(args[0]) };
+                    let tuple =
+                        crate::type_methods::require_tuple_receiver(args, "__getnewargs__", true)?;
+                    let items = unsafe { pyre_object::w_tuple_items_copy_as_vec(tuple) };
                     Ok(pyre_object::w_tuple_new(vec![pyre_object::w_tuple_new(
                         items,
                     )]))
@@ -7177,6 +7187,15 @@ fn init_tuple_type(ns: PyObjectRef) {
 /// `tupleobject.c` `tuple * n` / `n * tuple`.  A non-integer count
 /// raises the `__index__` TypeError.
 fn tuple_descr_mul(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    tuple_descr_mul_impl(args, "__mul__")
+}
+
+fn tuple_descr_rmul(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    tuple_descr_mul_impl(args, "__rmul__")
+}
+
+fn tuple_descr_mul_impl(args: &[PyObjectRef], name: &str) -> Result<PyObjectRef, crate::PyError> {
+    crate::type_methods::require_tuple_receiver(args, name, false)?;
     crate::type_methods::arity_slot(args, 1)?;
     // tupleobject descr_mul routes the count through getindex_w, so a custom
     // __index__ repeats the tuple (and an out-of-range one overflows).
@@ -12624,15 +12643,29 @@ list_cmp_dunder!(list_dunder_lt, "__lt__", Lt);
 list_cmp_dunder!(list_dunder_le, "__le__", Le);
 list_cmp_dunder!(list_dunder_gt, "__gt__", Gt);
 list_cmp_dunder!(list_dunder_ge, "__ge__", Ge);
-cmp_dunder_set!(
-    tuple_dunder_eq,
-    tuple_dunder_ne,
-    tuple_dunder_lt,
-    tuple_dunder_le,
-    tuple_dunder_gt,
-    tuple_dunder_ge,
-    cmp_guard_tuple
-);
+macro_rules! tuple_cmp_dunder {
+    ($function:ident, $name:literal, $op:ident) => {
+        fn $function(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+            crate::type_methods::require_tuple_receiver(args, $name, false)?;
+            crate::type_methods::arity_slot(args, 1)?;
+            if cmp_guard_tuple(args[1]) {
+                crate::objspace::descroperation::compare_slot(
+                    args[0],
+                    args[1],
+                    crate::objspace::descroperation::CompareOp::$op,
+                )
+            } else {
+                Ok(pyre_object::w_not_implemented())
+            }
+        }
+    };
+}
+tuple_cmp_dunder!(tuple_dunder_eq, "__eq__", Eq);
+tuple_cmp_dunder!(tuple_dunder_ne, "__ne__", Ne);
+tuple_cmp_dunder!(tuple_dunder_lt, "__lt__", Lt);
+tuple_cmp_dunder!(tuple_dunder_le, "__le__", Le);
+tuple_cmp_dunder!(tuple_dunder_gt, "__gt__", Gt);
+tuple_cmp_dunder!(tuple_dunder_ge, "__ge__", Ge);
 cmp_dunder_set!(
     bytes_dunder_eq,
     bytes_dunder_ne,

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -7180,26 +7180,45 @@ fn tuple_descr_mul(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> 
 // PyPy: pypy/objspace/std/typeobject.py TypeDef("type", ...)
 
 /// types.UnionType — PyPy: _pypy_generic_alias.py UnionType
-/// sliceobject.py:148 `W_SliceObject.descr_indices`.
-fn slice_method_indices(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    if args.len() != 2 {
+fn slice_receiver(args: &[PyObjectRef], name: &str) -> Result<PyObjectRef, crate::PyError> {
+    let self_ = args.first().copied().unwrap_or(pyre_object::PY_NULL);
+    if self_.is_null() {
         return Err(crate::PyError::type_error(format!(
-            "indices() takes exactly one argument ({} given)",
-            args.len().saturating_sub(1)
+            "descriptor '{name}' of 'slice' object needs an argument"
         )));
     }
-    let length = crate::builtins::getindex_w(args[1])?;
+    if !unsafe { pyre_object::sliceobject::is_slice(self_) } {
+        return Err(crate::PyError::type_error(format!(
+            "descriptor '{name}' requires a 'slice' object but received a '{}'",
+            type_name_of(self_),
+        )));
+    }
+    Ok(self_)
+}
+
+/// sliceobject.py:148 `W_SliceObject.descr_indices`.
+fn slice_method_indices(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    let self_ = slice_receiver(args, "indices")?;
+    let _roots = pyre_object::gc_roots::push_roots();
+    pyre_object::gc_roots::pin_root(self_);
+    let self_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+    pyre_object::gc_roots::pin_root(args[1]);
+    let length_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+    let length = crate::builtins::getindex_w(unsafe {
+        pyre_object::gc_roots::shadow_stack_get(length_slot)
+    })?;
     if length < 0 {
         return Err(crate::PyError::new(
             crate::PyErrorKind::ValueError,
             "length should not be negative".to_string(),
         ));
     }
+    let self_ = unsafe { pyre_object::gc_roots::shadow_stack_get(self_slot) };
     let (start, stop, step) = unsafe {
         crate::sliceobject::indices3(
-            pyre_object::sliceobject::w_slice_get_start(args[0]),
-            pyre_object::sliceobject::w_slice_get_stop(args[0]),
-            pyre_object::sliceobject::w_slice_get_step(args[0]),
+            pyre_object::sliceobject::w_slice_get_start(self_),
+            pyre_object::sliceobject::w_slice_get_stop(self_),
+            pyre_object::sliceobject::w_slice_get_step(self_),
             length,
         )?
     };
@@ -7212,7 +7231,10 @@ fn slice_method_indices(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyEr
 
 /// sliceobject.py `W_SliceObject.descr__new__` — `slice([start,] stop[, step])`.
 fn slice_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    let (params, kwargs) = crate::builtins::split_builtin_kwargs(&args[1..]);
+    let cls = args.first().copied().unwrap_or(pyre_object::PY_NULL);
+    let slice_type = gettypefor(&pyre_object::sliceobject::SLICE_TYPE).unwrap_or(PY_NULL);
+    check_user_subclass(slice_type, cls)?;
+    let (params, kwargs) = crate::builtins::split_builtin_kwargs(args.get(1..).unwrap_or(&[]));
     if crate::builtins::has_real_kwargs(kwargs) {
         return Err(crate::PyError::type_error(
             "slice() takes no keyword arguments",
@@ -7254,28 +7276,75 @@ fn slice_getter(
 
 /// sliceobject.py `descr_repr` — `"slice(%r, %r, %r)"`.
 fn slice_descr_repr(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    Ok(w_str_new(&unsafe { crate::display::py_repr(args[0])? }))
+    let self_ = slice_receiver(args, "__repr__")?;
+    Ok(w_str_new(&unsafe { crate::display::py_repr(self_)? }))
 }
 
 /// sliceobject.py `descr_eq` / `descr_ne` — compare the three components.
 /// `slice is slice` is always equal even with non-comparable params.
 fn slice_components_eq(a: PyObjectRef, b: PyObjectRef) -> Result<bool, crate::PyError> {
-    unsafe {
-        Ok(crate::baseobjspace::eq_w(
-            pyre_object::sliceobject::w_slice_get_start(a),
-            pyre_object::sliceobject::w_slice_get_start(b),
-        )? && crate::baseobjspace::eq_w(
-            pyre_object::sliceobject::w_slice_get_stop(a),
-            pyre_object::sliceobject::w_slice_get_stop(b),
-        )? && crate::baseobjspace::eq_w(
-            pyre_object::sliceobject::w_slice_get_step(a),
-            pyre_object::sliceobject::w_slice_get_step(b),
-        )?)
-    }
+    let _roots = pyre_object::gc_roots::push_roots();
+    pyre_object::gc_roots::pin_root(a);
+    let a_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+    pyre_object::gc_roots::pin_root(b);
+    let b_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+    Ok(
+        slice_component_eq(a_slot, b_slot, pyre_object::sliceobject::w_slice_get_start)?
+            && slice_component_eq(a_slot, b_slot, pyre_object::sliceobject::w_slice_get_stop)?
+            && slice_component_eq(a_slot, b_slot, pyre_object::sliceobject::w_slice_get_step)?,
+    )
+}
+
+fn slice_component_eq(
+    a_slot: usize,
+    b_slot: usize,
+    field: unsafe fn(PyObjectRef) -> PyObjectRef,
+) -> Result<bool, crate::PyError> {
+    let (left, right) = unsafe {
+        (
+            field(pyre_object::gc_roots::shadow_stack_get(a_slot)),
+            field(pyre_object::gc_roots::shadow_stack_get(b_slot)),
+        )
+    };
+    let _roots = pyre_object::gc_roots::push_roots();
+    pyre_object::gc_roots::pin_root(left);
+    let left_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+    pyre_object::gc_roots::pin_root(right);
+    let right_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+    crate::baseobjspace::eq_w(
+        unsafe { pyre_object::gc_roots::shadow_stack_get(left_slot) },
+        unsafe { pyre_object::gc_roots::shadow_stack_get(right_slot) },
+    )
+}
+
+fn slice_components_tuple(s: PyObjectRef) -> PyObjectRef {
+    let _roots = pyre_object::gc_roots::push_roots();
+    pyre_object::gc_roots::pin_root(s);
+    let s_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+    let start = unsafe {
+        pyre_object::sliceobject::w_slice_get_start(pyre_object::gc_roots::shadow_stack_get(s_slot))
+    };
+    pyre_object::gc_roots::pin_root(start);
+    let start_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+    let stop = unsafe {
+        pyre_object::sliceobject::w_slice_get_stop(pyre_object::gc_roots::shadow_stack_get(s_slot))
+    };
+    pyre_object::gc_roots::pin_root(stop);
+    let stop_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+    let step = unsafe {
+        pyre_object::sliceobject::w_slice_get_step(pyre_object::gc_roots::shadow_stack_get(s_slot))
+    };
+    pyre_object::gc_roots::pin_root(step);
+    let step_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+    w_tuple_new(vec![
+        unsafe { pyre_object::gc_roots::shadow_stack_get(start_slot) },
+        unsafe { pyre_object::gc_roots::shadow_stack_get(stop_slot) },
+        unsafe { pyre_object::gc_roots::shadow_stack_get(step_slot) },
+    ])
 }
 
 fn slice_descr_eq(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    let (a, b) = (args[0], args[1]);
+    let (a, b) = (slice_receiver(args, "__eq__")?, args[1]);
     if a == b {
         return Ok(pyre_object::w_bool_from(true));
     }
@@ -7287,7 +7356,7 @@ fn slice_descr_eq(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
 }
 
 fn slice_descr_ne(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    let (a, b) = (args[0], args[1]);
+    let (a, b) = (slice_receiver(args, "__ne__")?, args[1]);
     if a == b {
         return Ok(pyre_object::w_bool_from(false));
     }
@@ -7327,7 +7396,14 @@ fn slice_descr_richcompare(
     args: &[PyObjectRef],
     op: crate::baseobjspace::CompareOp,
 ) -> Result<PyObjectRef, crate::PyError> {
-    let (a, b) = (args[0], args[1]);
+    let name = match op {
+        crate::baseobjspace::CompareOp::Lt => "__lt__",
+        crate::baseobjspace::CompareOp::Le => "__le__",
+        crate::baseobjspace::CompareOp::Gt => "__gt__",
+        crate::baseobjspace::CompareOp::Ge => "__ge__",
+        _ => unreachable!(),
+    };
+    let (a, b) = (slice_receiver(args, name)?, args[1]);
     if !unsafe { pyre_object::sliceobject::is_slice(b) } {
         return Ok(pyre_object::w_not_implemented());
     }
@@ -7337,34 +7413,48 @@ fn slice_descr_richcompare(
             crate::baseobjspace::CompareOp::Le | crate::baseobjspace::CompareOp::Ge
         )));
     }
-    let components = |s| unsafe {
-        w_tuple_new(vec![
-            pyre_object::sliceobject::w_slice_get_start(s),
-            pyre_object::sliceobject::w_slice_get_stop(s),
-            pyre_object::sliceobject::w_slice_get_step(s),
-        ])
-    };
-    crate::baseobjspace::compare(components(a), components(b), op)
+    let _roots = pyre_object::gc_roots::push_roots();
+    pyre_object::gc_roots::pin_root(a);
+    let a_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+    pyre_object::gc_roots::pin_root(b);
+    let b_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+    let left = slice_components_tuple(unsafe { pyre_object::gc_roots::shadow_stack_get(a_slot) });
+    pyre_object::gc_roots::pin_root(left);
+    let left_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+    let right = slice_components_tuple(unsafe { pyre_object::gc_roots::shadow_stack_get(b_slot) });
+    pyre_object::gc_roots::pin_root(right);
+    let right_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+    crate::baseobjspace::compare(
+        unsafe { pyre_object::gc_roots::shadow_stack_get(left_slot) },
+        unsafe { pyre_object::gc_roots::shadow_stack_get(right_slot) },
+        op,
+    )
 }
 
 /// CPython 3.14 `slice_hash`, copied from the tuplehash-style three-lane
 /// mixer in `Objects/sliceobject.c`.
 fn slice_descr_hash(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    Ok(w_int_new(crate::builtins::try_hash_value(args[0])?))
+    let self_ = slice_receiver(args, "__hash__")?;
+    Ok(w_int_new(crate::builtins::try_hash_value(self_)?))
 }
 
 /// sliceobject.py `descr__reduce__` — `(type(self), (start, stop, step))`.
 fn slice_descr_reduce(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    let s = args[0];
+    let s = slice_receiver(args, "__reduce__")?;
+    let _roots = pyre_object::gc_roots::push_roots();
+    pyre_object::gc_roots::pin_root(s);
+    let s_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     let ty = r#type(s).unwrap_or(pyre_object::PY_NULL);
-    let components = unsafe {
-        w_tuple_new(vec![
-            pyre_object::sliceobject::w_slice_get_start(s),
-            pyre_object::sliceobject::w_slice_get_stop(s),
-            pyre_object::sliceobject::w_slice_get_step(s),
-        ])
-    };
-    Ok(w_tuple_new(vec![ty, components]))
+    pyre_object::gc_roots::pin_root(ty);
+    let ty_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+    let components =
+        slice_components_tuple(unsafe { pyre_object::gc_roots::shadow_stack_get(s_slot) });
+    pyre_object::gc_roots::pin_root(components);
+    let components_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+    Ok(w_tuple_new(vec![
+        unsafe { pyre_object::gc_roots::shadow_stack_get(ty_slot) },
+        unsafe { pyre_object::gc_roots::shadow_stack_get(components_slot) },
+    ]))
 }
 
 fn init_slice_type(ns: PyObjectRef) {
@@ -7388,28 +7478,28 @@ fn init_slice_type(ns: PyObjectRef) {
         pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
             ns,
             "__repr__",
-            make_builtin_function("__repr__", slice_descr_repr),
+            make_builtin_function_with_arity("__repr__", slice_descr_repr, 1),
         )
     };
     unsafe {
         pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
             ns,
             "__eq__",
-            make_builtin_function("__eq__", slice_descr_eq),
+            make_builtin_function_with_arity("__eq__", slice_descr_eq, 2),
         )
     };
     unsafe {
         pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
             ns,
             "__ne__",
-            make_builtin_function("__ne__", slice_descr_ne),
+            make_builtin_function_with_arity("__ne__", slice_descr_ne, 2),
         )
     };
     unsafe {
         pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
             ns,
             "__lt__",
-            make_builtin_function("__lt__", slice_descr_lt),
+            make_builtin_function_with_arity("__lt__", slice_descr_lt, 2),
         )
     };
     for (name, func) in [
@@ -7421,7 +7511,7 @@ fn init_slice_type(ns: PyObjectRef) {
             pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
                 ns,
                 name,
-                make_builtin_function(name, func),
+                make_builtin_function_with_arity(name, func, 2),
             )
         };
     }
@@ -7430,14 +7520,14 @@ fn init_slice_type(ns: PyObjectRef) {
         pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
             ns,
             "__hash__",
-            make_builtin_function("__hash__", slice_descr_hash),
+            make_builtin_function_with_arity("__hash__", slice_descr_hash, 1),
         )
     };
     unsafe {
         pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
             ns,
             "__reduce__",
-            make_builtin_function("__reduce__", slice_descr_reduce),
+            make_builtin_function_with_arity("__reduce__", slice_descr_reduce, 1),
         )
     };
     unsafe {
@@ -7486,7 +7576,7 @@ fn init_slice_type(ns: PyObjectRef) {
         pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
             ns,
             "indices",
-            make_builtin_function("indices", slice_method_indices),
+            make_builtin_function_with_arity("indices", slice_method_indices, 2),
         )
     };
 }

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -2008,8 +2008,30 @@ fn init_module_type(ns: PyObjectRef) {
     };
 }
 
+fn singleton_receiver(
+    args: &[PyObjectRef],
+    owner: &str,
+    name: &str,
+    predicate: unsafe fn(PyObjectRef) -> bool,
+) -> Result<PyObjectRef, crate::PyError> {
+    let self_ = args.first().copied().unwrap_or(pyre_object::PY_NULL);
+    if self_.is_null() || !unsafe { predicate(self_) } {
+        return Err(crate::PyError::type_error(format!(
+            "descriptor '{name}' requires a '{owner}' object but received a '{}'",
+            type_name_of(self_),
+        )));
+    }
+    Ok(self_)
+}
+
 fn ellipsis_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    let cls = args.first().copied().unwrap_or(pyre_object::PY_NULL);
+    let (positional, kwargs) = crate::builtins::split_builtin_kwargs(args);
+    if positional.len() > 1 || crate::builtins::has_real_kwargs(kwargs) {
+        return Err(crate::PyError::type_error(
+            "EllipsisType takes no arguments",
+        ));
+    }
+    let cls = positional.first().copied().unwrap_or(pyre_object::PY_NULL);
     if let Some(w_ellipsis) = gettypefor(&pyre_object::ELLIPSIS_TYPE) {
         check_user_subclass(w_ellipsis, cls)?;
     }
@@ -2035,21 +2057,41 @@ fn init_ellipsis_type(ns: PyObjectRef) {
         pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
             ns,
             "__repr__",
-            make_builtin_function_with_arity("__repr__", |_args| Ok(w_str_new("Ellipsis")), 1),
+            make_builtin_function_with_arity(
+                "__repr__",
+                |args| {
+                    singleton_receiver(args, "ellipsis", "__repr__", pyre_object::is_ellipsis)?;
+                    Ok(w_str_new("Ellipsis"))
+                },
+                1,
+            ),
         )
     };
     unsafe {
         pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
             ns,
             "__reduce__",
-            make_builtin_function_with_arity("__reduce__", |_args| Ok(w_str_new("Ellipsis")), 1),
+            make_builtin_function_with_arity(
+                "__reduce__",
+                |args| {
+                    singleton_receiver(args, "ellipsis", "__reduce__", pyre_object::is_ellipsis)?;
+                    Ok(w_str_new("Ellipsis"))
+                },
+                1,
+            ),
         )
     };
 }
 
 /// special.py:20: NotImplemented.descr_new_notimplemented
 fn notimplemented_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    let cls = args.first().copied().unwrap_or(pyre_object::PY_NULL);
+    let (positional, kwargs) = crate::builtins::split_builtin_kwargs(args);
+    if positional.len() > 1 || crate::builtins::has_real_kwargs(kwargs) {
+        return Err(crate::PyError::type_error(
+            "NotImplementedType takes no arguments",
+        ));
+    }
+    let cls = positional.first().copied().unwrap_or(pyre_object::PY_NULL);
     if let Some(w_notimplemented) = gettypefor(&pyre_object::pyobject::NOTIMPLEMENTED_TYPE) {
         check_user_subclass(w_notimplemented, cls)?;
     }
@@ -2078,7 +2120,15 @@ fn init_notimplemented_type(ns: PyObjectRef) {
             "__repr__",
             make_builtin_function_with_arity(
                 "__repr__",
-                |_args| Ok(w_str_new("NotImplemented")),
+                |args| {
+                    singleton_receiver(
+                        args,
+                        "NotImplementedType",
+                        "__repr__",
+                        pyre_object::is_not_implemented,
+                    )?;
+                    Ok(w_str_new("NotImplemented"))
+                },
                 1,
             ),
         )
@@ -2089,7 +2139,15 @@ fn init_notimplemented_type(ns: PyObjectRef) {
             "__reduce__",
             make_builtin_function_with_arity(
                 "__reduce__",
-                |_args| Ok(w_str_new("NotImplemented")),
+                |args| {
+                    singleton_receiver(
+                        args,
+                        "NotImplementedType",
+                        "__reduce__",
+                        pyre_object::is_not_implemented,
+                    )?;
+                    Ok(w_str_new("NotImplemented"))
+                },
                 1,
             ),
         )
@@ -2102,7 +2160,13 @@ fn init_notimplemented_type(ns: PyObjectRef) {
             "__bool__",
             make_builtin_function_with_arity(
                 "__bool__",
-                |_args| {
+                |args| {
+                    singleton_receiver(
+                        args,
+                        "NotImplementedType",
+                        "__bool__",
+                        pyre_object::is_not_implemented,
+                    )?;
                     Err(crate::PyError::type_error(
                         "NotImplemented should not be used in a boolean context",
                     ))
@@ -2129,6 +2193,27 @@ fn none_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     Ok(pyre_object::w_none())
 }
 
+fn none_ordering(args: &[PyObjectRef], name: &str) -> Result<PyObjectRef, crate::PyError> {
+    singleton_receiver(args, "NoneType", name, pyre_object::is_none)?;
+    Ok(pyre_object::w_not_implemented())
+}
+
+fn none_lt(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    none_ordering(args, "__lt__")
+}
+
+fn none_le(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    none_ordering(args, "__le__")
+}
+
+fn none_gt(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    none_ordering(args, "__gt__")
+}
+
+fn none_ge(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    none_ordering(args, "__ge__")
+}
+
 fn init_none_type(ns: PyObjectRef) {
     let entries = [
         (
@@ -2140,19 +2225,33 @@ fn init_none_type(ns: PyObjectRef) {
             "__bool__",
             make_builtin_function_with_arity(
                 "__bool__",
-                |_args| Ok(pyre_object::w_bool_from(false)),
+                |args| {
+                    singleton_receiver(args, "NoneType", "__bool__", pyre_object::is_none)?;
+                    Ok(pyre_object::w_bool_from(false))
+                },
                 1,
             ),
         ),
         (
             "__repr__",
-            make_builtin_function_with_arity("__repr__", |_args| Ok(w_str_new("None")), 1),
+            make_builtin_function_with_arity(
+                "__repr__",
+                |args| {
+                    singleton_receiver(args, "NoneType", "__repr__", pyre_object::is_none)?;
+                    Ok(w_str_new("None"))
+                },
+                1,
+            ),
         ),
         (
             "__hash__",
             make_builtin_function_with_arity(
                 "__hash__",
-                |args| Ok(pyre_object::w_int_new(crate::builtins::hash_value(args[0]))),
+                |args| {
+                    let self_ =
+                        singleton_receiver(args, "NoneType", "__hash__", pyre_object::is_none)?;
+                    Ok(pyre_object::w_int_new(crate::builtins::hash_value(self_)))
+                },
                 1,
             ),
         ),
@@ -2161,6 +2260,7 @@ fn init_none_type(ns: PyObjectRef) {
             make_builtin_function_with_arity(
                 "__eq__",
                 |args| {
+                    singleton_receiver(args, "NoneType", "__eq__", pyre_object::is_none)?;
                     if args.len() >= 2 && unsafe { pyre_object::is_none(args[1]) } {
                         Ok(pyre_object::w_bool_from(true))
                     } else {
@@ -2175,6 +2275,7 @@ fn init_none_type(ns: PyObjectRef) {
             make_builtin_function_with_arity(
                 "__ne__",
                 |args| {
+                    singleton_receiver(args, "NoneType", "__ne__", pyre_object::is_none)?;
                     if args.len() >= 2 && unsafe { pyre_object::is_none(args[1]) } {
                         Ok(pyre_object::w_bool_from(false))
                     } else {
@@ -2188,16 +2289,17 @@ fn init_none_type(ns: PyObjectRef) {
     for (name, value) in entries {
         unsafe { pyre_object::w_dict_setitem_str(ns, name, value) };
     }
-    for name in ["__lt__", "__le__", "__gt__", "__ge__"] {
+    for (name, function) in [
+        ("__lt__", none_lt as DunderFn),
+        ("__le__", none_le as DunderFn),
+        ("__gt__", none_gt as DunderFn),
+        ("__ge__", none_ge as DunderFn),
+    ] {
         unsafe {
             pyre_object::w_dict_setitem_str(
                 ns,
                 name,
-                make_builtin_function_with_arity(
-                    name,
-                    |_args| Ok(pyre_object::w_not_implemented()),
-                    2,
-                ),
+                make_builtin_function_with_arity(name, function, 2),
             )
         };
     }

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -950,6 +950,15 @@ pub fn init_typeobjects() {
             ) as usize,
         );
         reg.insert(
+            &pyre_object::interp_itertools::COMPRESS_TYPE as *const PyType as usize,
+            new_typeobject_with_base_and_layout(
+                "itertools.compress",
+                init_compress_type,
+                object_type,
+                &pyre_object::interp_itertools::COMPRESS_TYPE as *const PyType,
+            ) as usize,
+        );
+        reg.insert(
             &pyre_object::interp_itertools::PAIRWISE_TYPE as *const PyType as usize,
             new_typeobject_with_base("itertools.pairwise", |_| {}, object_type) as usize,
         );
@@ -21243,6 +21252,58 @@ fn filterfalse_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyE
     itertools_alloc_for_class(cls, exact, obj)
 }
 
+fn compress_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    // PyPy W_Compress__new__ allocates the subtype and applies space.iter to
+    // both inputs.  Python 3.14's Argument Clinic surface additionally
+    // accepts the `data` and `selectors` keyword names.
+    let exact = gettypefor(&pyre_object::interp_itertools::COMPRESS_TYPE).unwrap_or(PY_NULL);
+    let (cls, scope_w) =
+        itertools_constructor_scope(args, "compress", vec!["data", "selectors"], &[])?;
+    let _roots = pyre_object::gc_roots::push_roots();
+    pyre_object::gc_roots::pin_root(cls);
+    let cls_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+    pyre_object::gc_roots::pin_root(scope_w[0]);
+    let data_arg_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+    pyre_object::gc_roots::pin_root(scope_w[1]);
+    let selectors_arg_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+    let w_data = crate::baseobjspace::iter(unsafe {
+        pyre_object::gc_roots::shadow_stack_get(data_arg_slot)
+    })?;
+    pyre_object::gc_roots::pin_root(w_data);
+    let data_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+    let w_selectors = crate::baseobjspace::iter(unsafe {
+        pyre_object::gc_roots::shadow_stack_get(selectors_arg_slot)
+    })?;
+    let obj = pyre_object::interp_itertools::w_compress_new(
+        unsafe { pyre_object::gc_roots::shadow_stack_get(data_slot) },
+        w_selectors,
+    );
+    itertools_alloc_for_class(
+        unsafe { pyre_object::gc_roots::shadow_stack_get(cls_slot) },
+        exact,
+        obj,
+    )
+}
+
+fn compress_iter_self(args: &[PyObjectRef]) -> crate::PyResult {
+    singleton_receiver(
+        args,
+        "itertools.compress",
+        "__iter__",
+        pyre_object::interp_itertools::is_compress,
+    )
+}
+
+fn compress_iter_next(args: &[PyObjectRef]) -> crate::PyResult {
+    let obj = singleton_receiver(
+        args,
+        "itertools.compress",
+        "__next__",
+        pyre_object::interp_itertools::is_compress,
+    )?;
+    crate::baseobjspace::next(obj)
+}
+
 fn init_takewhile_type(ns: PyObjectRef) {
     // W_TakeWhile.typedef, in source order (minus the 3.14-removed pickle
     // entries between __next__ and __doc__).
@@ -21308,6 +21369,31 @@ fn init_filterfalse_type(ns: PyObjectRef) {
             "__doc__",
             w_str_new(
                 "Return those items of iterable for which function(item) is false.\n\nIf function is None, return the items that are false.",
+            ),
+        ),
+    ];
+    for (name, value) in entries {
+        unsafe { pyre_object::w_dict_setitem_str_no_proxy(ns, name, value) };
+    }
+}
+
+fn init_compress_type(ns: PyObjectRef) {
+    // interp_itertools.py W_Compress.typedef, in source order.  Python 3.14
+    // uses the shorter public docstring below.
+    let entries = [
+        ("__new__", make_new_descr(compress_descr_new)),
+        (
+            "__iter__",
+            make_builtin_function_with_arity("__iter__", compress_iter_self, 1),
+        ),
+        (
+            "__next__",
+            make_builtin_function_with_arity("__next__", compress_iter_next, 1),
+        ),
+        (
+            "__doc__",
+            w_str_new(
+                "Return data elements corresponding to true selector elements.\n\nForms a shorter iterator from selected data elements using the selectors to\nchoose the data elements.",
             ),
         ),
     ];

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -2512,6 +2512,15 @@ fn build_gc() -> Box<dyn majit_gc::GcAllocator> {
         <pyre_object::interp_itertools::W_Compress
             as pyre_object::lltype::PyreClassPyTypeOf>::DESCRIPTOR,
     );
+    // W_StarMap (`itertools.starmap`) — AUTO-ID; the function and live
+    // source iterator are traced edges.  Append after every existing type so
+    // this new registration cannot renumber one.
+    register_pyre_class(
+        &mut gc,
+        &mut pytype_to_tid,
+        <pyre_object::interp_itertools::W_StarMap
+            as pyre_object::lltype::PyreClassPyTypeOf>::DESCRIPTOR,
+    );
     // rclass.py:340-346 — assign subclassrange_{min,max} to each
     // vtable entry. freeze_types() runs assign_inheritance_ids
     // (normalizecalls.py:373-389), then we write the computed ranges

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -2502,6 +2502,16 @@ fn build_gc() -> Box<dyn majit_gc::GcAllocator> {
         <pyre_object::iterobject::W_TupleIterObject
             as pyre_object::lltype::PyreClassPyTypeOf>::DESCRIPTOR,
     );
+    // W_Compress (`itertools.compress`) — AUTO-ID; the live data and
+    // selectors iterators are both traced edges.  Keep this at the absolute
+    // tail, after the fixed FrameDebugData/FrameBlock slots and every prior
+    // AUTO-ID type, so adding it cannot renumber an existing GC type.
+    register_pyre_class(
+        &mut gc,
+        &mut pytype_to_tid,
+        <pyre_object::interp_itertools::W_Compress
+            as pyre_object::lltype::PyreClassPyTypeOf>::DESCRIPTOR,
+    );
     // rclass.py:340-346 — assign subclassrange_{min,max} to each
     // vtable entry. freeze_types() runs assign_inheritance_ids
     // (normalizecalls.py:373-389), then we write the computed ranges

--- a/pyre/pyre-object/src/dictmultiobject.rs
+++ b/pyre/pyre-object/src/dictmultiobject.rs
@@ -2963,6 +2963,12 @@ pub enum DictViewKind {
 pub static DICT_KEYITERATOR_TYPE: PyType = crate::pyobject::new_pytype("dict_keyiterator");
 pub static DICT_VALUEITERATOR_TYPE: PyType = crate::pyobject::new_pytype("dict_valueiterator");
 pub static DICT_ITEMITERATOR_TYPE: PyType = crate::pyobject::new_pytype("dict_itemiterator");
+pub static DICT_REVERSEKEYITERATOR_TYPE: PyType =
+    crate::pyobject::new_pytype("dict_reversekeyiterator");
+pub static DICT_REVERSEVALUEITERATOR_TYPE: PyType =
+    crate::pyobject::new_pytype("dict_reversevalueiterator");
+pub static DICT_REVERSEITEMITERATOR_TYPE: PyType =
+    crate::pyobject::new_pytype("dict_reverseitemiterator");
 
 /// `dictmultiobject.py:809-845 _new_next` — captures both the source
 /// dict's `len` and the active strategy at iter() time; `next()`
@@ -2992,6 +2998,10 @@ pub struct W_BaseDictMultiIterObject {
     /// kinds (`W_DictMultiIterKeysObject` / `ValuesObject` /
     /// `ItemsObject`).
     pub kind: DictViewKind,
+    /// Whether the strategy iterator walks insertion order backwards.
+    /// PyPy represents this in the concrete `iterreversed()` implementation;
+    /// the cursor position remains the number of already-consumed entries.
+    pub reverse: bool,
     /// `:807 self.strategy = strategy` — strategy identity at iter()
     /// time, stored as the strategy pointer cast to `usize` for
     /// identity comparison (PyPy's `self.strategy is
@@ -3020,11 +3030,14 @@ impl crate::lltype::GcType for W_BaseDictMultiIterObject {
 
 /// Pick the Python-visible iterator type for a given view kind so
 /// `type(iter(d.keys())) is dict_keyiterator` (etc.).
-pub fn dict_view_iterator_type_for_kind(kind: DictViewKind) -> &'static PyType {
-    match kind {
-        DictViewKind::Keys => &DICT_KEYITERATOR_TYPE,
-        DictViewKind::Values => &DICT_VALUEITERATOR_TYPE,
-        DictViewKind::Items => &DICT_ITEMITERATOR_TYPE,
+pub fn dict_view_iterator_type_for_kind(kind: DictViewKind, reverse: bool) -> &'static PyType {
+    match (kind, reverse) {
+        (DictViewKind::Keys, false) => &DICT_KEYITERATOR_TYPE,
+        (DictViewKind::Values, false) => &DICT_VALUEITERATOR_TYPE,
+        (DictViewKind::Items, false) => &DICT_ITEMITERATOR_TYPE,
+        (DictViewKind::Keys, true) => &DICT_REVERSEKEYITERATOR_TYPE,
+        (DictViewKind::Values, true) => &DICT_REVERSEVALUEITERATOR_TYPE,
+        (DictViewKind::Items, true) => &DICT_REVERSEITEMITERATOR_TYPE,
     }
 }
 
@@ -3037,9 +3050,22 @@ pub fn dict_view_iterator_type_for_kind(kind: DictViewKind) -> &'static PyType {
 /// self.len = w_dict.length()
 /// ```
 pub fn w_dict_view_iterator_new(w_dict: PyObjectRef, kind: DictViewKind) -> PyObjectRef {
+    w_dict_view_iterator_new_direction(w_dict, kind, false)
+}
+
+/// Allocate the reversed concrete iterator corresponding to `kind`.
+pub fn w_dict_view_reverse_iterator_new(w_dict: PyObjectRef, kind: DictViewKind) -> PyObjectRef {
+    w_dict_view_iterator_new_direction(w_dict, kind, true)
+}
+
+fn w_dict_view_iterator_new_direction(
+    w_dict: PyObjectRef,
+    kind: DictViewKind,
+    reverse: bool,
+) -> PyObjectRef {
     let startlen = unsafe { w_dict_len(w_dict) };
     let start_strategy_id = unsafe { w_dict_strategy_id(w_dict) };
-    let tp = dict_view_iterator_type_for_kind(kind);
+    let tp = dict_view_iterator_type_for_kind(kind, reverse);
     crate::lltype::malloc_typed(W_BaseDictMultiIterObject {
         ob_header: PyObject {
             ob_type: tp as *const PyType,
@@ -3049,6 +3075,7 @@ pub fn w_dict_view_iterator_new(w_dict: PyObjectRef, kind: DictViewKind) -> PyOb
         startlen,
         index: 0,
         kind,
+        reverse,
         start_strategy_id,
     }) as PyObjectRef
 }
@@ -3061,6 +3088,9 @@ pub unsafe fn is_dict_view_iterator(obj: PyObjectRef) -> bool {
         py_type_check(obj, &DICT_KEYITERATOR_TYPE)
             || py_type_check(obj, &DICT_VALUEITERATOR_TYPE)
             || py_type_check(obj, &DICT_ITEMITERATOR_TYPE)
+            || py_type_check(obj, &DICT_REVERSEKEYITERATOR_TYPE)
+            || py_type_check(obj, &DICT_REVERSEVALUEITERATOR_TYPE)
+            || py_type_check(obj, &DICT_REVERSEITEMITERATOR_TYPE)
     }
 }
 
@@ -3076,6 +3106,12 @@ pub unsafe fn w_dict_view_iterator_get_dict(obj: PyObjectRef) -> PyObjectRef {
 #[inline]
 pub unsafe fn w_dict_view_iterator_get_kind(obj: PyObjectRef) -> DictViewKind {
     unsafe { (*(obj as *const W_BaseDictMultiIterObject)).kind }
+}
+
+/// Direction selected by the concrete iterator class.
+#[inline]
+pub unsafe fn w_dict_view_iterator_get_reverse(obj: PyObjectRef) -> bool {
+    unsafe { (*(obj as *const W_BaseDictMultiIterObject)).reverse }
 }
 
 /// # Safety

--- a/pyre/pyre-object/src/functional.rs
+++ b/pyre/pyre-object/src/functional.rs
@@ -208,6 +208,7 @@ pub unsafe fn w_reversed_get_sequence(obj: PyObjectRef) -> PyObjectRef {
 pub unsafe fn w_reversed_set_sequence(obj: PyObjectRef, value: PyObjectRef) {
     unsafe {
         (*(obj as *mut W_ReversedIterator)).w_sequence = value;
+        crate::gc_hook::try_gc_write_barrier(obj as *mut u8);
     }
 }
 

--- a/pyre/pyre-object/src/functional.rs
+++ b/pyre/pyre-object/src/functional.rs
@@ -403,6 +403,10 @@ pub struct W_Zip {
     pub w_iterators: PyObjectRef,
     /// `functional.py:1014 self.strict`; `descr_setstate` toggles it.
     pub strict: bool,
+    /// `functional.py:1017 self._iteration_progress` — number of iterators
+    /// already consumed in the current tuple, used by strict mismatch
+    /// reporting when a later iterator stops.
+    pub iteration_progress: usize,
 }
 
 /// Allocate a `W_Zip`.  `w_iterators` is a `list` of already-built
@@ -417,6 +421,7 @@ pub fn w_zip_new(w_iterators: PyObjectRef, strict: bool) -> PyObjectRef {
         },
         w_iterators,
         strict,
+        iteration_progress: 0,
     })
 }
 
@@ -448,6 +453,22 @@ pub unsafe fn w_zip_set_strict(obj: PyObjectRef, value: bool) {
     unsafe {
         (*(obj as *mut W_Zip)).strict = value;
     }
+}
+
+/// # Safety
+/// `obj` must point to a valid `W_Zip`.
+#[inline]
+pub unsafe fn w_zip_set_iteration_progress(obj: PyObjectRef, value: usize) {
+    unsafe {
+        (*(obj as *mut W_Zip)).iteration_progress = value;
+    }
+}
+
+/// # Safety
+/// `obj` must point to a valid `W_Zip`.
+#[inline]
+pub unsafe fn w_zip_get_iteration_progress(obj: PyObjectRef) -> usize {
+    unsafe { (*(obj as *const W_Zip)).iteration_progress }
 }
 /// Machine-int range iterator object.
 ///

--- a/pyre/pyre-object/src/functional.rs
+++ b/pyre/pyre-object/src/functional.rs
@@ -1040,7 +1040,7 @@ pub fn range_length_big(start: &BigInt, stop: &BigInt, step: &BigInt) -> BigInt 
 // advances by one each step (`self.w_index`), so the cursor keeps arbitrary
 // precision and never overflows for a range longer than a machine word.
 
-#[pyre_class("range_iterator", type_id = 8, static_name = "LONG_RANGE_ITER")]
+#[pyre_class("longrange_iterator", type_id = 8, static_name = "LONG_RANGE_ITER")]
 pub struct W_LongRangeIterator {
     pub start: PyObjectRef,
     pub step: PyObjectRef,

--- a/pyre/pyre-object/src/functional.rs
+++ b/pyre/pyre-object/src/functional.rs
@@ -85,6 +85,7 @@ pub unsafe fn w_enumerate_get_iter_or_list(obj: PyObjectRef) -> PyObjectRef {
 pub unsafe fn w_enumerate_set_iter_or_list(obj: PyObjectRef, value: PyObjectRef) {
     unsafe {
         (*(obj as *mut W_Enumerate)).w_iter_or_list = value;
+        crate::gc_hook::try_gc_write_barrier(obj as *mut u8);
     }
 }
 
@@ -117,6 +118,7 @@ pub unsafe fn w_enumerate_get_w_index(obj: PyObjectRef) -> PyObjectRef {
 pub unsafe fn w_enumerate_set_w_index(obj: PyObjectRef, value: PyObjectRef) {
     unsafe {
         (*(obj as *mut W_Enumerate)).w_index = value;
+        crate::gc_hook::try_gc_write_barrier(obj as *mut u8);
     }
 }
 

--- a/pyre/pyre-object/src/interp_itertools.rs
+++ b/pyre/pyre-object/src/interp_itertools.rs
@@ -322,6 +322,50 @@ pub unsafe fn is_filterfalse(obj: PyObjectRef) -> bool {
     unsafe { py_type_check(obj, &FILTERFALSE_TYPE) }
 }
 
+// ── W_Compress — pypy/module/itertools/interp_itertools.py:W_Compress ──
+//
+// ```python
+// class W_Compress(W_Root):
+//     def __init__(self, space, w_data, w_selectors):
+//         self.space = space
+//         self.w_data = space.iter(w_data)
+//         self.w_selectors = space.iter(w_selectors)
+// ```
+//
+// `next_w` lives in the interpreter because it invokes both iterators and
+// selector truth testing.  The two live iterators are traced GC edges.
+
+#[pyre_class("itertools.compress", static_name = "COMPRESS")]
+pub struct W_Compress {
+    pub w_data: PyObjectRef,
+    pub w_selectors: PyObjectRef,
+}
+
+/// Both arguments must already have had `space.iter` applied, matching
+/// `W_Compress.__init__`.
+pub fn w_compress_new(w_data: PyObjectRef, w_selectors: PyObjectRef) -> PyObjectRef {
+    let _roots = crate::gc_roots::push_roots();
+    crate::gc_roots::pin_root(w_data);
+    crate::gc_roots::pin_root(w_selectors);
+    W_Compress::allocate(W_Compress {
+        ob: PyObject {
+            ob_type: std::ptr::null(),
+            w_class: std::ptr::null_mut(),
+        },
+        w_data,
+        w_selectors,
+    })
+}
+
+/// Check if an object is a `W_Compress`.
+///
+/// # Safety
+/// `obj` must be a valid, non-null pointer to a `PyObject`.
+#[inline]
+pub unsafe fn is_compress(obj: PyObjectRef) -> bool {
+    unsafe { py_type_check(obj, &COMPRESS_TYPE) }
+}
+
 // ── W_Pairwise — pypy/module/itertools/interp_itertools.py:class W_Pairwise ──
 //
 // ```python
@@ -592,6 +636,23 @@ mod tests {
         assert_eq!(
             <W_FilterFalse as crate::lltype::GcType>::SIZE,
             W_FILTERFALSE_OBJECT_SIZE
+        );
+    }
+
+    #[test]
+    fn w_compress_gc_descriptor_traces_both_iterator_fields() {
+        assert_eq!(W_COMPRESS_GC_PTR_OFFSETS.len(), 2);
+        assert_eq!(
+            W_COMPRESS_GC_PTR_OFFSETS[0],
+            std::mem::offset_of!(W_Compress, w_data)
+        );
+        assert_eq!(
+            W_COMPRESS_GC_PTR_OFFSETS[1],
+            std::mem::offset_of!(W_Compress, w_selectors)
+        );
+        assert_eq!(
+            <W_Compress as crate::lltype::GcType>::SIZE,
+            W_COMPRESS_OBJECT_SIZE
         );
     }
 

--- a/pyre/pyre-object/src/interp_itertools.rs
+++ b/pyre/pyre-object/src/interp_itertools.rs
@@ -366,6 +366,49 @@ pub unsafe fn is_compress(obj: PyObjectRef) -> bool {
     unsafe { py_type_check(obj, &COMPRESS_TYPE) }
 }
 
+// ── W_StarMap — pypy/module/itertools/interp_itertools.py:W_StarMap ──
+//
+// ```python
+// class W_StarMap(W_Root):
+//     def __init__(self, space, w_fun, w_iterable):
+//         self.space = space
+//         self.w_fun = w_fun
+//         self.w_iterable = self.space.iter(w_iterable)
+// ```
+//
+// `next_w` lives in the interpreter because it expands the next object into
+// call arguments and invokes `w_fun`.  Both fields are traced GC edges.
+
+#[pyre_class("itertools.starmap", static_name = "STARMAP")]
+pub struct W_StarMap {
+    pub w_fun: PyObjectRef,
+    pub w_iterable: PyObjectRef,
+}
+
+/// `w_iterable` must already have had `space.iter` applied.
+pub fn w_starmap_new(w_fun: PyObjectRef, w_iterable: PyObjectRef) -> PyObjectRef {
+    let _roots = crate::gc_roots::push_roots();
+    crate::gc_roots::pin_root(w_fun);
+    crate::gc_roots::pin_root(w_iterable);
+    W_StarMap::allocate(W_StarMap {
+        ob: PyObject {
+            ob_type: std::ptr::null(),
+            w_class: std::ptr::null_mut(),
+        },
+        w_fun,
+        w_iterable,
+    })
+}
+
+/// Check if an object is a `W_StarMap`.
+///
+/// # Safety
+/// `obj` must be a valid, non-null pointer to a `PyObject`.
+#[inline]
+pub unsafe fn is_starmap(obj: PyObjectRef) -> bool {
+    unsafe { py_type_check(obj, &STARMAP_TYPE) }
+}
+
 // ── W_Pairwise — pypy/module/itertools/interp_itertools.py:class W_Pairwise ──
 //
 // ```python
@@ -653,6 +696,23 @@ mod tests {
         assert_eq!(
             <W_Compress as crate::lltype::GcType>::SIZE,
             W_COMPRESS_OBJECT_SIZE
+        );
+    }
+
+    #[test]
+    fn w_starmap_gc_descriptor_traces_function_and_iterator() {
+        assert_eq!(W_STARMAP_GC_PTR_OFFSETS.len(), 2);
+        assert_eq!(
+            W_STARMAP_GC_PTR_OFFSETS[0],
+            std::mem::offset_of!(W_StarMap, w_fun)
+        );
+        assert_eq!(
+            W_STARMAP_GC_PTR_OFFSETS[1],
+            std::mem::offset_of!(W_StarMap, w_iterable)
+        );
+        assert_eq!(
+            <W_StarMap as crate::lltype::GcType>::SIZE,
+            W_STARMAP_OBJECT_SIZE
         );
     }
 


### PR DESCRIPTION
## Summary

- complete Python 3.14 parity for enumerate, reversed, map, filter, zip, range_iterator, longrange_iterator, singleton, slice, memoryview, method, function, and builtin-function surfaces
- address the remaining PR 610 code-object review findings, including `co_branches()` extended-argument and branch-kind decoding
- restore PyPy-style list receiver gates, contiguous empty-slice assignment, and iterable-subclass behavior during list unpacking

## Why

Several builtin entry points still bypassed the typed receiver checks normally supplied by PyPy's `interp2app` gateways. Some paths could read an unrelated object through the list/function layout and panic. List unpacking also used storage fast paths for subclasses, skipping overridden `__iter__`, while `co_branches()` truncated extended jump arguments and omitted Python 3.14 branch kinds.

The range iterator implementations also shared the public `range_iterator` name and dispatch path even though Python 3.14 exposes arbitrary-precision cursors as a distinct `longrange_iterator`. Their descriptor receivers and `__setstate__` coercion now match the 3.14 split.

## Validation

- Python 3.14 parity tests for each completed builtin surface
- `python3 scripts/extract-llbc.py`
- `cargo check --features dynasm`
- `cargo test --features dynasm`
- full pre-merge benchmark suite: dynasm 11/11, cranelift 11/11, wasm 10/10

The final branch is rebased onto the current `origin/main`.