### PR TITLE
jit: PR #606 review follow-ups — BigInt→i64 gate, range alias tracking, exact-leaf layout dedup

### DIFF
--- a/majit/majit-translate/docs/design-346-foreign-lib-cluster-epic.md
+++ b/majit/majit-translate/docs/design-346-foreign-lib-cluster-epic.md
@@ -2,7 +2,53 @@
 
 ## Why this epic exists
 
-On base `eca75827fe4` the JIT-prepass census has **268 distinct `[PREPASS phaseA fail]`** paths.
+The measurements in this document have the following provenance. They are not
+three readings of one unchanged input set:
+
+- **268 total phaseA failures:** commit `eca75827fe43618b24328653c150751f9b5399e8`,
+  release profile, default features, the then-current frozen `build/llbc`
+  snapshot (not re-extracted), and `PYRE_RTYPER_VERBOSE=1`. The exact command
+  was:
+
+  ```text
+  touch pyre/pyre-jit-trace/build.rs
+  PYRE_RTYPER_VERBOSE=1 cargo build --release -p pyre-jit-trace
+  stderr=$(ls -t target/release/build/pyre-jit-trace-*/stderr | head -1)
+  rg --no-config 'PREPASS phaseA fail' "$stderr" | sort -u | wc -l
+  ```
+
+- **16 `try_from`-headed phaseA failures:** commit
+  `ccdc1a52be2237365154976149e7b573db811d82`, release profile, default
+  features, that worktree's frozen `build/llbc` snapshot, and
+  `PYRE_RTYPER_VERBOSE=1`. This is a filtered diagnostic count, not a total:
+
+  ```text
+  touch pyre/pyre-jit-trace/build.rs
+  PYRE_RTYPER_VERBOSE=1 cargo build --release -p pyre-jit-trace
+  stderr=$(ls -t target/release/build/pyre-jit-trace-*/stderr | head -1)
+  rg --no-config 'PREPASS phaseA fail' "$stderr" | rg --no-config 'try_from' | sort -u | wc -l
+  ```
+
+- **276 total post-Slice-A phaseA failures:** commit
+  `bb6ee8d179c70f170ee4e3a3cb9b4dce99d96d9b`, release profile, default
+  features, and `PYRE_RTYPER_VERBOSE=1`. Slice A changed `pyre-object`, so this
+  run first re-extracted the default LLBC set with the repository's pinned
+  Charon, then rebuilt and counted:
+
+  ```text
+  python3 scripts/extract-llbc.py
+  touch pyre/pyre-jit-trace/build.rs
+  PYRE_RTYPER_VERBOSE=1 cargo build --release -p pyre-jit-trace
+  stderr=$(ls -t target/release/build/pyre-jit-trace-*/stderr | head -1)
+  rg --no-config 'PREPASS phaseA fail' "$stderr" | sort -u | wc -l
+  ```
+
+The 276 run is **not** a direct 268→276 Slice-A delta: `bb6ee8d179c` descends
+from `eca75827fe4` through intervening changes and uses re-extracted LLBC, while
+268 used the older frozen snapshot. The 268 figure is therefore the historical
+pre-Slice-A planning baseline only; the separately configured 276 run is the
+post-Slice-A baseline for Slice-B scoping.
+
 A root-cause analysis (deepest-root, per-record all-blockers) ranked the leaves by "sole-unblock"
 leverage. The top three (`box_assume_init` / vec!, `malachite ::try_from`, and the
 `Wtf8`/`Map::collect`/`IndexMap` group) looked independently high-value, but a **peel-and-recensus**
@@ -18,7 +64,7 @@ of each proved otherwise:
 `w_list_setitem`, `setitem_bytearray`, `plain_int_w`) is guarded by a **stack** of foreign-std walls.
 Peeling one exposes the next:
 
-```
+```text
 box_assume_init (vec!) → malachite ::try_from → String::new → core::slice::get / join
   → Wtf8Buf::with_capacity → Enumerate::next → IndexMap::insert / get
 ```
@@ -44,8 +90,10 @@ default arm and emits `newlist/r>r` — an opname with no blackhole handler — 
 
 ### Slice A — malachite `try_from` (task #21, FIRST, no deps)
 
-**Census (base `ccdc1a52be2`):** 16 phaseA graphs have a `try_from` first wall, split into TWO
+**Census (filtered run at `ccdc1a52be2237365154976149e7b573db811d82`; exact
+configuration and command above):** 16 phaseA graphs have a `try_from` first wall, split into TWO
 unrelated families:
+
 - **13 graphs = malachite** (`["malachite_bigint","bigint","<Impl>","try_from"]`) — the Slice-A target.
 - **3 graphs = int-to-int** (`["core","convert","num","<Impl>","try_from"]`: `int_pow`, `pow`,
   `opcode_get_iter`) — NOT malachite. `int_pow` is `u32::try_from(vb)` with a genuine
@@ -116,7 +164,9 @@ Err arm — MUST still raise IndexError/ValueError, not panic).
 
 ### Slice B — String / Wtf8 / IndexMap / slice / iter-adapter residuals (task #22, after A)
 
-Scoped 7/17 on the post-Slice-A census (base `bb6ee8d179c`, 276 phaseA): **46 distinct unregistered
+Scoped 7/17 on the separate post-Slice-A census run
+(`bb6ee8d179c70f170ee4e3a3cb9b4dce99d96d9b`, 276 total phaseA; exact
+configuration and command above): **46 distinct unregistered
 residual paths**, saved to `/tmp/sliceB_residual_ranking.txt` (de-escape `\"`→`"` before counting).
 The three walls that gate the hot dispatcher heads (innermost per record):
 
@@ -170,6 +220,7 @@ co-land):**
 - **B3 (LAST in B, real rtyper work)** — the (N) native lowerings.
 
 ### Slice C — vec!/NewList recognizer + repr-generic rtype_newlist (task #20, LAST, capstone)
+
 - **Ca** Re-add the front/mir recognizer (verbatim from reverted `f41cb0496dc`): match
   `box_assume_init_into_vec_unsafe(box [e0..eN])` → `OpKind::NewList{args}`. Helpers
   `read_array_literal_elements` (mir.rs:13581) + `fmt_path_ends_with` (mir.rs:13673) still in tree.
@@ -192,8 +243,15 @@ Verify each slice: `cargo test -p majit-translate` + census phaseA set-diff (cou
 `check.py` bit-exact 3-backend.
 
 ## Metric
-Distinct `[PREPASS phaseA fail]` count in the census (268 on base `ccdc1a52be2`). Each slice measured
-by set-diff. GOTCHA: the census **stderr** logs only phaseA *reasons* — the emitted `newlist/r>r`
+
+The metric is the distinct `[PREPASS phaseA fail]` count produced by the exact
+commands and configurations recorded above. Use set-diff only between runs made
+from the same source commit ancestry and the same extracted LLBC snapshot. In
+particular, 268 at `eca75827fe4` is the historical pre-Slice-A planning baseline,
+16 at `ccdc1a52be2` is only the filtered `try_from` subset, and 276 at
+`bb6ee8d179c` is a separately configured post-Slice-A baseline; do not treat
+268→276 as a Slice-A regression. GOTCHA: the census **stderr** logs only phaseA
+*reasons* — the emitted `newlist/r>r`
 opname lives in `insns.bin` (build OUT_DIR `target/debug/build/pyre-jit-trace-<hash>/out/insns.bin`;
 `strings insns.bin | rg newlist`), not stderr. The cluster's hot graphs (`setitem_list`,
 `getitem_list`, `w_list_setitem`, `setitem_bytearray`) only lift once ALL their stacked walls close —

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -6100,36 +6100,32 @@ impl<'a> Lowering<'a> {
                 // `box_assume_init_into_vec_unsafe(box [e0, …, eN])`, whose
                 // `box_assume_init` primitive is unregistered, so the legacy
                 // CodeWriter residualizes it as a plain call (the same
-                // treatment `w_int_new` / `w_float_new` get).  An earlier
-                // recognizer rewrote this shape to `OpKind::NewList` (feeding
-                // the now-repr-generic `rtype_newlist`, which decomposes it to
-                // `ll_fixed_newlist` + `ll_fixed_setitem_fast` for a
-                // never-mutated vec! `FixedSizeListRepr`), but the front-end
-                // rewrite is UNCONDITIONAL: it plants `NewList` into a graph
-                // regardless of whether that graph two-phase lifts or drops to
-                // the legacy walker.  The legacy walker never runs
-                // `rtype_newlist`, so a dropped graph's raw `NewList` reaches
-                // the assembler's default arm and emits `newlist/r>r` — an
-                // opname with no blackhole handler — breaking the build via
-                // `default_bh_builder_unwired_set_matches_task_85_snapshot`.
+                // treatment `w_int_new` / `w_float_new` get).  A recognizer
+                // that rewrites this shape to `OpKind::NewList` (feeding the
+                // repr-generic `rtype_newlist`) is UNCONDITIONAL: it plants
+                // `NewList` into a graph regardless of whether that graph
+                // two-phase lifts or drops to the legacy walker, and the legacy
+                // walker never runs `rtype_newlist`, so a dropped graph's raw
+                // `NewList` reaches the assembler default arm and emits
+                // `newlist/r>r` — an opname with no blackhole handler —
+                // breaking `default_bh_builder_unwired_set_matches_task_85_snapshot`.
                 //
-                // Slice-C measurement (7/18, base 0bdfdb85781, AFTER wall-1 +
-                // wall-2 both closed): re-adding the recognizer STILL trips the
-                // snapshot with `newlist/r>r`.  Wall-1 (cross-block Link box
-                // sweep, `prune_dead_boxing_remnants`) and wall-2 (set/frozenset
-                // constant-`ob_type` monomorphization → `fuse_boxing_alloc`)
-                // are landed and census-verified (head 274→267, `w_set_new`
-                // fully lifts, set `malloc_typed` fuses), but at least one
-                // vec!-bearing graph beyond `make_generic_alias` /
-                // `set_method_difference` still drops to the legacy walker
-                // carrying a raw `NewList`.  The census only surfaces a graph's
-                // FIRST wall, so the blocking graph is one whose earlier wall
-                // hides its vec!; it must be identified (census scan for every
-                // `box_assume_init_into_vec_unsafe` producer graph, then trace
-                // why it fails phaseA) and its wall closed before the recognizer
-                // is safe.  Until then the residual call is the correct
-                // lowering; `rtype_newlist`'s Fixed arm stays implemented and
-                // dormant.
+                // Slice-C 7/18 measurement (base 4d3d6e290f6, assembler
+                // `[ASM newlist DIAG]`): EXACTLY TWO graphs carry a vec! and
+                // still drop to the legacy walker, each behind an INDEPENDENT
+                // non-vec! wall the recognizer does not touch —
+                //   • `_pypy_generic_alias::make_generic_alias`: `collect_parameters`
+                //     → `push_unique` → `slice::iter::Iter::next` (unregistered),
+                //     plus a `collect_parameters` `UnionError: r_uint ∪ int`.
+                //   • `typedef::set_method_difference`: `&args[1..]` →
+                //     `core::slice::index::<Impl>::index` (unregistered), and the
+                //     `set_copy_real` → `w_set_copy_storage_from` storage-copy
+                //     chain.
+                // Until BOTH graphs fully lift (slice-iterator + slice-index +
+                // the collect_parameters UnionError — all annotator-completeness
+                // axis walls, not vec! walls), the unconditional recognizer is
+                // unsafe.  `rtype_newlist`'s Fixed arm stays implemented and
+                // dormant; the residual call is the correct lowering meanwhile.
                 // For a method/direct callee this equals the callee's
                 // `name_path()`; the scope predicate keys on the module
                 // path, which the built `CallTarget::Method` drops.

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -8243,6 +8243,23 @@ impl<'a> Lowering<'a> {
         }
     }
 
+    /// One concrete type argument from an ADT signature type.  Charon stores
+    /// `Result<X, E>` as `Adt.generics.types = [X, E]`; deserialize the chosen
+    /// node back through [`TyRef`] so deduplicated and inline literal forms use
+    /// the same width-atom helpers as top-level signature inputs/outputs.
+    fn tyref_adt_type_arg(&self, ty: &TyRef, index: usize) -> Option<TyRef> {
+        let node = tyref_node(ty, self.llbc)?
+            .as_object()?
+            .get("Adt")?
+            .as_object()?
+            .get("generics")?
+            .as_object()?
+            .get("types")?
+            .as_array()?
+            .get(index)?;
+        serde_json::from_value(node.clone()).ok()
+    }
+
     /// The ADT `def_id` behind a signature [`TyRef`], peeling `Ref` /
     /// `RawPtr` wrappers and dedup / hash-cons indirections first — a
     /// `bool::then` closure env arrives as `&closure`.  Mirrors the
@@ -8965,6 +8982,23 @@ impl<'a> Lowering<'a> {
         let Some(td) = self.llbc.type_by_id(def_id) else {
             return Ok(false);
         };
+        // The synthesized fits test and payload are specifically the signed
+        // machine-word conversion.  Other BigInt TryFrom impls (notably
+        // `u32::try_from(&value)` in formatting.rs::char_arg) have different
+        // bounds and must keep the ordinary residual call.  Read Result's
+        // success payload from `generics.types[0]`, then apply the same
+        // literal-width atom gate as the other integer conversion lowerings.
+        // RPython keeps signed `toint`/`fits_int` distinct from unsigned
+        // `touint` (`rpython/rlib/rbigint.py:465-485, 515-518`).
+        let Some(success_ty) = self.tyref_adt_type_arg(dest_ty, 0) else {
+            return Ok(false);
+        };
+        if !matches!(
+            self.tyref_literal_int_atom(&success_ty),
+            Some("I64" | "Isize")
+        ) {
+            return Ok(false);
+        }
         // Route the runtime-discriminant tagged-pair ctor to the SAME
         // per-instantiation enum root a static `Ok(..)`/`Err(..)` mints,
         // by suffixing the bare template name with the `<X>` the
@@ -16941,8 +16975,55 @@ mod tests {
                 .count()
         };
         assert!(
+            range_call("new") >= 1,
+            "float range constructor stays residual (fold out of scope)"
+        );
+        assert!(
             range_call("contains") >= 1,
             "float range contains stays residual (fold out of scope)"
+        );
+    }
+
+    /// `formatting::char_arg` narrows its BigInt to `u32`, not `i64`.  The
+    /// i64-specific fits/discriminant synthesis must decline and leave the
+    /// original `TryFrom<&BigInt>` call residual.  Ignored by default because
+    /// it loads the real interpreter LLBC.
+    #[test]
+    #[ignore]
+    fn bigint_i64_try_from_real_declines_u32_result() {
+        use crate::model::{CallTarget, OpKind};
+
+        let path = concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../build/llbc/pyre-interpreter.ullbc"
+        );
+        let llbc = Llbc::load(path).expect("load real LLBC");
+        let graph = super::lower_function(&llbc, "char_arg").expect("lower char_arg");
+
+        let calls: Vec<&[String]> = graph
+            .blocks
+            .iter()
+            .flat_map(|b| b.operations.iter())
+            .filter_map(|op| match &op.kind {
+                OpKind::Call {
+                    target: CallTarget::FunctionPath { segments },
+                    ..
+                } => Some(segments.as_slice()),
+                _ => None,
+            })
+            .collect();
+        assert!(
+            calls.iter().any(|segments| {
+                super::fmt_path_ends_with(segments, &["bigint", "<Impl>", "try_from"])
+                    || super::fmt_path_ends_with(segments, &["<Impl>", "try_from"])
+            }),
+            "u32::try_from(&BigInt) must remain a residual FunctionPath call"
+        );
+        assert!(
+            !calls.iter().any(|segments| {
+                segments.last().map(String::as_str) == Some("jit_bigint_to_i64_fits")
+            }),
+            "u32 destination must not use the i64 fits/discriminant lowering"
         );
     }
 

--- a/majit/majit-translate/src/front/range_contains.rs
+++ b/majit/majit-translate/src/front/range_contains.rs
@@ -175,9 +175,11 @@ fn rewire_one_range_contains_site(
     //    definition.  The single-consumer gate below is what makes this
     //    sound; here we only need to pick the producing site.
     let c_block = graph.blocks[c_idx].id;
-    let new_site = new_sites
+    let (new_site, range_trace) = new_sites
         .iter()
-        .find(|s| range_matches_new_site(graph, c_block, &range_v, &s.result_var))
+        .find_map(|s| {
+            range_matches_new_site(graph, c_block, &range_v, &s.result_var).map(|trace| (s, trace))
+        })
         .ok_or_else(|| {
             format!("{name}: range contains receiver traces to no RangeInclusive::new site")
         })?;
@@ -185,12 +187,13 @@ fn rewire_one_range_contains_site(
     // 4. Consumer-shape gate (excludes iteration-form ranges, whose
     //    range carries a stateful `exhausted` field read a second time by
     //    an iterator's `into_iter` / `next`).  The range value must be
-    //    read as an OP operand by exactly the `contains` op being folded —
-    //    link-arg threading of the same Variable is liveness forwarding,
-    //    not consumption.  Any other op reading the range declines.
-    if !range_value_single_op_consumer(graph, &new_site.result_var, &range_v, &site.result_var) {
+    //    read as an OP operand by exactly the `contains` op being folded.
+    //    Only the positional producer-to-consumer Links recorded by the
+    //    trace are permitted; any other Link carrying any traced alias means
+    //    the range survives past (or branches away from) `contains`.
+    if !range_value_single_op_consumer(graph, &range_trace, &site.result_var) {
         return Err(format!(
-            "{name}: range value has a second op consumer — declining (iteration form?)"
+            "{name}: range value has a second consumer — declining (iteration form?)"
         ));
     }
 
@@ -246,21 +249,39 @@ fn rewire_one_range_contains_site(
 /// value at the matching link-arg index, recursing on that supplied
 /// Variable until it either reaches `new_result` (match) or a block that
 /// defines it via an op (must then equal `new_result`).
+struct RangeAliasTrace {
+    aliases: Vec<Variable>,
+    /// `(predecessor block, exit index, link-argument index)` for each
+    /// positional forwarding edge on the producer-to-`contains` trace;
+    /// RPython's `Link.args` carries these Variables positionally
+    /// (`rpython/flowspace/model.py:140-149`).
+    threaded_links: Vec<(BlockId, usize, usize)>,
+}
+
 fn range_matches_new_site(
     graph: &FunctionGraph,
     c_block: BlockId,
     range_v: &Variable,
     new_result: &Variable,
-) -> bool {
+) -> Option<RangeAliasTrace> {
     let mut cur_block = c_block;
     let mut cur_var = range_v.clone();
-    let mut seen: std::collections::HashSet<BlockId> = std::collections::HashSet::new();
+    let mut aliases = vec![cur_var.clone()];
+    let mut threaded_links = Vec::new();
+    let mut hops = 0usize;
     loop {
         if &cur_var == new_result {
-            return true;
+            if !aliases.contains(new_result) {
+                aliases.push(new_result.clone());
+            }
+            return Some(RangeAliasTrace {
+                aliases,
+                threaded_links,
+            });
         }
-        if !seen.insert(cur_block) {
-            return false;
+        hops += 1;
+        if hops > graph.blocks.len() {
+            return None;
         }
         // `cur_var` must be a block inputarg to trace across the edge;
         // if it is defined by an op in `cur_block` and is not
@@ -271,7 +292,7 @@ fn range_matches_new_site(
             .iter()
             .position(|v| v == &cur_var)
         else {
-            return false;
+            return None;
         };
         // Exactly one predecessor edge, carrying the source at `arg_idx`.
         let pred_edges: Vec<(BlockId, usize)> = graph
@@ -287,14 +308,18 @@ fn range_matches_new_site(
             })
             .collect();
         if pred_edges.len() != 1 {
-            return false;
+            return None;
         }
         let (pred_block, exit_idx) = pred_edges[0];
         let Some(LinkArg::Value(src)) = graph.block(pred_block).exits[exit_idx].args.get(arg_idx)
         else {
-            return false;
+            return None;
         };
+        threaded_links.push((pred_block, exit_idx, arg_idx));
         cur_var = src.clone();
+        if !aliases.contains(&cur_var) {
+            aliases.push(cur_var.clone());
+        }
         cur_block = pred_block;
     }
 }
@@ -305,9 +330,10 @@ fn range_matches_new_site(
 /// the private helper of the same name in `model::thread_undefined_op_operands`.
 fn defined_via_single_pred_chain(graph: &FunctionGraph, block: BlockId, var: &Variable) -> bool {
     let mut cur = block;
-    let mut seen: std::collections::HashSet<BlockId> = std::collections::HashSet::new();
+    let mut hops = 0usize;
     loop {
-        if !seen.insert(cur) {
+        hops += 1;
+        if hops > graph.blocks.len() {
             return false;
         }
         let preds = graph.predecessors(cur);
@@ -335,25 +361,18 @@ fn can_thread_to_block(graph: &FunctionGraph, block: BlockId, var: &Variable) ->
 /// iteration-form ranges (whose range carries a stateful `exhausted`
 /// field an iterator's `into_iter` / `next` reads a second time).
 ///
-/// "Consumed" means read as an OP operand — NOT threaded on a link arg.
-/// The front models a value that outlives its defining block by reusing
-/// the SAME `Variable` identity across the intervening blocks' link args
-/// (liveness forwarding toward its eventual drop), so the range's
-/// `new_result` legitimately appears on many `Link.args`; those are not
-/// consumers.  The gate therefore counts only op-operand reads of the
-/// range value — of `new_result` itself and, when the front minted a
-/// fresh C-inputarg for the receiver (framestate SSA), of `receiver` —
-/// and requires every such read to belong to the single `contains` op
-/// (result `contains_result`).  Any other op reading the range (an
-/// iterator, a second `contains`, a `clone`) is a second consumer →
-/// decline.  A range value driving an `exitswitch` also declines.
+/// Framestate SSA can mint a fresh inputarg at every forwarding block, so the
+/// gate checks every Variable in the positional producer trace rather than
+/// only its endpoints.  The trace's own Link slots are the only permitted
+/// forwarding reads.  Any other op, exitswitch, Link arg, exception Link
+/// payload, return, iterator, second `contains`, or clone carrying an alias is
+/// a second consumer and declines before either residual call is removed.
 fn range_value_single_op_consumer(
     graph: &FunctionGraph,
-    new_result: &Variable,
-    receiver: &Variable,
+    trace: &RangeAliasTrace,
     contains_result: &Variable,
 ) -> bool {
-    let is_range_value = |v: &Variable| v == new_result || v == receiver;
+    let is_range_value = |v: &Variable| trace.aliases.contains(v);
     for block in &graph.blocks {
         for op in &block.operations {
             let reads_range = crate::inline::op_variable_refs(&op.kind)
@@ -373,6 +392,31 @@ fn range_value_single_op_consumer(
                 return false;
             }
             _ => {}
+        }
+        for (exit_idx, link) in block.exits.iter().enumerate() {
+            for (arg_idx, arg) in link.args.iter().enumerate() {
+                let LinkArg::Value(var) = arg else { continue };
+                if is_range_value(var)
+                    && !trace
+                        .threaded_links
+                        .contains(&(block.id, exit_idx, arg_idx))
+                {
+                    return false;
+                }
+            }
+            if link
+                .last_exception
+                .as_ref()
+                .and_then(LinkArg::as_variable)
+                .is_some_and(is_range_value)
+                || link
+                    .last_exc_value
+                    .as_ref()
+                    .and_then(LinkArg::as_variable)
+                    .is_some_and(is_range_value)
+            {
+                return false;
+            }
         }
     }
     true
@@ -627,6 +671,86 @@ mod tests {
             }],
         );
         assert_eq!(rewritten, 0, "a second range consumer declines the fold");
+        assert_eq!(
+            functionpath_calls_ending(&g, &["range", "RangeInclusive", "new"]),
+            1,
+            "residual new survives",
+        );
+        assert_eq!(
+            functionpath_calls_ending(&g, &["range", "RangeInclusive", "contains"]),
+            1,
+            "residual contains survives",
+        );
+    }
+
+    /// Framestate threading gives the successor a third identity for the
+    /// range.  Carrying that alias beyond the middle `contains` block must
+    /// keep both residual calls: deleting `new` would leave the successor's
+    /// input undefined.
+    #[test]
+    fn rewrite_declines_when_successor_carries_fresh_range_alias() {
+        let mut g = FunctionGraph::new("test_range_contains_successor_alias");
+        let n = g.startblock;
+        let a = g.push_op_var(n, OpKind::ConstInt(0), true).unwrap();
+        let b = g.push_op_var(n, OpKind::ConstInt(255), true).unwrap();
+        let range = g
+            .push_op_var(
+                n,
+                OpKind::Call {
+                    target: new_target(),
+                    args: vec![a.clone(), b.clone()],
+                    result_ty: ValueType::Ref(Some("RangeInclusive".into())),
+                },
+                true,
+            )
+            .unwrap();
+
+        // Middle block M consumes one alias in `contains`, then threads it
+        // onward.  The successor S receives a fresh framestate inputarg and
+        // consumes that alias independently.
+        let (m, m_args) = g.create_block_with_arg_vars(1);
+        let range_in_m = m_args[0].clone();
+        let x = g.push_op_var(m, OpKind::ConstInt(42), true).unwrap();
+        let contains = g
+            .push_op_var(
+                m,
+                OpKind::Call {
+                    target: contains_target(),
+                    args: vec![range_in_m.clone(), x],
+                    result_ty: ValueType::Int,
+                },
+                true,
+            )
+            .unwrap();
+        let (s, s_args) = g.create_block_with_arg_vars(1);
+        let range_in_s = s_args[0].clone();
+        let later_use = g
+            .push_op_var(
+                s,
+                OpKind::UnaryOp {
+                    op: "invert".to_string(),
+                    operand: range_in_s,
+                    result_ty: ValueType::Ref(None),
+                },
+                true,
+            )
+            .unwrap();
+        g.set_return(s, Some(later_use));
+        g.set_goto(m, s, vec![range_in_m]);
+        g.set_goto(n, m, vec![range.clone()]);
+
+        let rewritten = rewire_range_contains_call_sites(
+            &mut g,
+            &[RangeInclusiveNewSite {
+                result_var: range,
+                lo: a,
+                hi: b,
+            }],
+            &[RangeContainsSite {
+                result_var: contains,
+            }],
+        );
+        assert_eq!(rewritten, 0, "a successor range alias declines the fold");
         assert_eq!(
             functionpath_calls_ending(&g, &["range", "RangeInclusive", "new"]),
             1,

--- a/majit/majit-translate/src/model.rs
+++ b/majit/majit-translate/src/model.rs
@@ -2637,9 +2637,10 @@ pub fn fuse_boxing_alloc(
     // `ob_type` / `w_class` from it, so only the non-header setfield(s) are
     // re-emitted (oracle: `box_trace.rs trace_box_float` / `trace_box_int`).
     // This mirrors the type-generic malloc lowering in the front end
-    // (`rbuiltin.py` `rtype_malloc` / `rclass.py` reads the lltype's field
-    // layout); `struct_field_attrs` is the already-computed layout map the
-    // front end owns, so this pass performs no front-end (Llbc) reads.
+    // (`rpython/rtyper/rbuiltin.py:349-385` `rtype_malloc`; `rclass.py` reads
+    // the exact lltype's field layout); `struct_field_attrs` is the
+    // already-computed layout map the front end owns, so this pass performs no
+    // front-end (Llbc) reads.
     //
     // The ctor carries the bare struct leaf (`W_FloatObject`) while the map is
     // keyed by the crate-stripped qualified path (`floatobject::W_FloatObject`),
@@ -2650,12 +2651,21 @@ pub fn fuse_boxing_alloc(
         owner: &str,
         struct_field_attrs: &std::collections::HashMap<String, Vec<(String, ValueType)>>,
     ) -> Option<Vec<(String, ValueType)>> {
-        let rows = struct_field_attrs.get(owner).or_else(|| {
-            struct_field_attrs
+        let rows = if let Some(exact) = struct_field_attrs.get(owner) {
+            exact
+        } else {
+            let mut leaf_matches = struct_field_attrs
                 .iter()
-                .find(|(k, _)| k.rsplit("::").next() == Some(owner))
-                .map(|(_, v)| v)
-        })?;
+                .filter(|(k, _)| k.rsplit("::").next() == Some(owner));
+            let (_, only) = leaf_matches.next()?;
+            if leaf_matches.next().is_some() {
+                // The layout owner is ambiguous.  As with an unknown owner,
+                // leave malloc_typed residual instead of choosing one map row
+                // by HashMap iteration order.
+                return None;
+            }
+            only
+        };
         Some(
             rows.iter()
                 .filter(|(name, _)| name != "ob_header")
@@ -6183,6 +6193,33 @@ mod tests {
             )
             .unwrap();
         graph.set_return(entry, Some(ret.clone()));
+
+        let mut ambiguous_graph = graph.clone();
+        let mut ambiguous_attrs = numeric_boxing_attrs();
+        ambiguous_attrs.insert(
+            "shadow::W_FloatObject".to_string(),
+            vec![
+                ("ob_header".to_string(), ValueType::Ref(None)),
+                ("wrong_payload".to_string(), ValueType::Int),
+            ],
+        );
+        assert_eq!(
+            fuse_boxing_alloc(&mut ambiguous_graph, &ambiguous_attrs),
+            0,
+            "two qualified owners with the same leaf must decline fusion"
+        );
+        assert!(
+            ambiguous_graph.block(entry).operations.iter().any(|op| {
+                matches!(
+                    &op.kind,
+                    OpKind::Call {
+                        target: CallTarget::FunctionPath { segments },
+                        ..
+                    } if segments.last().map(String::as_str) == Some("malloc_typed")
+                )
+            }),
+            "ambiguous leaf layout keeps malloc_typed residual"
+        );
 
         let fused = fuse_boxing_alloc(&mut graph, &numeric_boxing_attrs());
         assert_eq!(fused, 1, "exactly one boxing cluster must fuse");


### PR DESCRIPTION
#346 
Follow-up to the merged #606, addressing its Codex + CodeRabbit review findings on the now-merged Slice A/B code.

## Correctness

- **BigInt `try_from` lowering gated to i64 results.** `try_lower_bigint_i64_try_from` now reads the destination `Result<X, E>` success payload and fires only when `X` is `I64`/`Isize`. `u32::try_from(&BigInt)` (`formatting::char_arg`) keeps its residual call instead of folding through the i64 fits-check, which would have wrongly routed out-of-u32 values to the `Ok` path. Real-LLBC regression test added.
- **`RangeInclusive::contains` folding tracks every threaded alias.** The consumer gate now records each alias the producer threads `new_result` through plus the exact positional Link slots, and declines when the range value is carried past the folded `contains` by any other op, exitswitch, Link arg, exception Link, or return. Prevents deleting `RangeInclusive::new` while a successor/return link still carries the range. Three-block successor-alias regression test added.
- **`payload_fields` rejects ambiguous leaf matches.** The leaf-name layout fallback now succeeds only when exactly one qualified struct shares the leaf; two-or-more leaves ambiguous leaves `malloc_typed` residual instead of picking a row by `HashMap` iteration order.

## Orthodoxy

- Replaced the two `HashSet<BlockId>` cycle guards in `range_contains` with hop counters bounded by `graph.blocks.len()` (no Rust-native side tables in the ported pass).

## Tests / docs

- Float-range test asserts both `new` and `contains` remain residual.
- Design doc records the exact commit/command/config for each census figure and marks the 276 run as a separate post-Slice-A baseline rather than a 268→276 delta; markdownlint fence/heading fixes.

Verification: `cargo test -p majit-translate` 2997 lib + 2 ignored real-LLBC fail-safe tests pass; `cargo check --workspace` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved BigInt conversion handling for signed machine-word results, avoiding incorrect lowering for unsupported types.
  * Improved range containment rewrites to preserve behavior when aliases or additional consumers are present.
  * Prevented ambiguous allocation layouts from being incorrectly fused, leaving calls safely unchanged instead.
* **Documentation**
  * Clarified failure measurements, baseline comparisons, analysis scope, and reproducibility details for translation diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->