### PR TITLE
jit: fix stepped-slice panic and nested-break miscompile

### DIFF
--- a/pyre/bench/synth/nested_break_not_hot.py
+++ b/pyre/bench/synth/nested_break_not_hot.py
@@ -1,0 +1,52 @@
+# A nested `for` loop whose inner `break` lands on the secondary edge of its
+# guard — reached from `if not cond: break` (a POP_JUMP_IF_TRUE fall-through) or
+# from a break-check that is the last statement in the loop body (a
+# POP_JUMP_IF_FALSE that jumps forward to the break) — must reconstruct the
+# operand stack correctly when the inner iterator is popped and control resumes
+# at the outer FOR_ITER. Both the break-check-first and accumulate-first forms,
+# plus a compound `and` guard, are exercised. Output is verified against
+# CPython/PyPy.
+N = 9000
+
+
+def break_check_first(n):
+    t = 0
+    for i in range(n):
+        for j in range(2, 4):
+            if not i % 3 != 0:
+                break
+            t += j
+    return t
+
+
+def accumulate_first(n):
+    t = 0
+    for i in range(n):
+        for j in range(2, 4):
+            t += j
+            if not i % 5 != 0:
+                break
+    return t
+
+
+def compound_guard(n):
+    t = 0
+    for i in range(n):
+        for j in range(2, 4):
+            if not i % 3 != 0 and i % 2 == 0:
+                break
+            t += j
+    return t
+
+
+def plain_break(n):
+    t = 0
+    for i in range(n):
+        for j in range(2, 4):
+            if i % 3 >= 2:
+                break
+            t += j
+    return t
+
+
+print(break_check_first(N), accumulate_first(N), compound_guard(N), plain_break(N))

--- a/pyre/bench/synth/newslice_step_hot.py
+++ b/pyre/bench/synth/newslice_step_hot.py
@@ -1,0 +1,25 @@
+# BUILD_SLICE with a step operand records a `newslice(start, stop, step)` HLOp,
+# lowered to a build_slice residual call.  Without that lowering arm the op
+# reached the assembler un-lowered and panicked whenever a stepped slice (e.g.
+# `lst[::-1]`) sat in a JIT-compiled loop.  The hot body below builds a
+# literal-step, a variable-step, and a bounded negative-step slice each
+# iteration so the residual JIT-compiles instead of declining.
+# Output is verified against CPython/PyPy.
+N = 200000
+
+
+def main():
+    lst = list(range(10))
+    step = -1
+    total = 0
+    i = 0
+    while i < N:
+        rev = lst[::-1]
+        var = lst[::step]
+        bounded = lst[8:2:-1]
+        total = total + rev[0] + var[1] + bounded[-1]
+        i = i + 1
+    print(total)
+
+
+main()

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -3977,6 +3977,7 @@ enum UnsupportedJitShape {
     None,
     CurrentFrameOnly,
     StructuralRegion,
+    NestedBreakBridgeResume,
     /// The frame's constant pool plus register file would exceed the
     /// single-byte (`< 256`) register-or-constant index encoding
     /// (`assembler.py:72 chr()`, `assembler.py:132-133`
@@ -4188,6 +4189,131 @@ fn for_iter_frame_is_finally_duplicated(code: &pyre_interpreter::CodeObject) -> 
     for_iter_count > 1 && any_in_handler
 }
 
+/// A nested inner `for` loop `break` — a `POP_TOP` that pops the inner iterator
+/// then a `JUMP_BACKWARD` to the enclosing `FOR_ITER` — miscompiles when the
+/// break lands on the secondary edge of a conditional in the inner-loop guard:
+/// the break edge becomes a guard side-exit whose bridge resume snapshot
+/// mis-maps the outer iterator slot (a boxed value / null lands where the outer
+/// iterator must be), so the resumed `FOR_ITER` dereferences a non-iterator.
+/// Two guard shapes produce that secondary-edge break: a `POP_JUMP_IF_TRUE`
+/// whose true edge continues the loop (break is its fall-through), and a
+/// `POP_JUMP_IF_FALSE` whose false edge jumps forward to the break. Decline
+/// such a frame to the interpreter. The plain `if cond: break` idiom compiles
+/// to a `POP_JUMP_IF_FALSE` whose fall-through IS the break — the primary edge —
+/// and still compiles.
+fn nested_break_bridge_resume_hazard(code: &pyre_interpreter::CodeObject) -> bool {
+    let num_instrs = code.instructions.len();
+    for pop_pc in 0..num_instrs {
+        let Some(target) = pop_top_jumps_back_to_for_iter(code, num_instrs, pop_pc) else {
+            continue;
+        };
+        let mut inner_header = None;
+        for header_pc in target..pop_pc {
+            if matches!(
+                pyre_interpreter::decode_instruction_at(code, header_pc),
+                Some((pyre_interpreter::Instruction::ForIter { .. }, _))
+            ) {
+                inner_header = Some(header_pc);
+            }
+        }
+        let Some(inner_header) = inner_header else {
+            continue;
+        };
+        for guard_pc in (inner_header + 1)..pop_pc {
+            match pyre_interpreter::decode_instruction_at(code, guard_pc) {
+                Some((pyre_interpreter::Instruction::PopJumpIfTrue { .. }, _)) => {
+                    return true;
+                }
+                Some((pyre_interpreter::Instruction::PopJumpIfFalse { delta }, op_arg)) => {
+                    let jump_target = pyre_interpreter::jump_target_forward(
+                        &code.instructions,
+                        guard_pc + 1,
+                        delta.get(op_arg).as_usize(),
+                    );
+                    if skip_branch_trivia(code, jump_target) == pop_pc {
+                        return true;
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+    false
+}
+
+fn pop_top_jumps_back_to_for_iter(
+    code: &pyre_interpreter::CodeObject,
+    num_instrs: usize,
+    pop_pc: usize,
+) -> Option<usize> {
+    if pop_pc >= num_instrs {
+        return None;
+    }
+    if !matches!(
+        pyre_interpreter::decode_instruction_at(code, pop_pc),
+        Some((pyre_interpreter::Instruction::PopTop, _))
+    ) {
+        return None;
+    }
+    let jump_pc = skip_branch_trivia(code, pop_pc + 1);
+    if jump_pc >= num_instrs {
+        return None;
+    }
+    let Some((instr, op_arg)) = pyre_interpreter::decode_instruction_at(code, jump_pc) else {
+        return None;
+    };
+    let target = match instr {
+        pyre_interpreter::Instruction::JumpBackward { delta } => {
+            skip_caches(code, jump_pc + 1).saturating_sub(delta.get(op_arg).as_usize())
+        }
+        pyre_interpreter::Instruction::JumpBackwardNoInterrupt { delta } => {
+            (jump_pc + 1).saturating_sub(delta.get(op_arg).as_usize())
+        }
+        _ => return None,
+    };
+    if target < pop_pc
+        && target < num_instrs
+        && matches!(
+            pyre_interpreter::decode_instruction_at(code, target),
+            Some((pyre_interpreter::Instruction::ForIter { .. }, _))
+        )
+    {
+        Some(target)
+    } else {
+        None
+    }
+}
+
+fn skip_branch_trivia(code: &pyre_interpreter::CodeObject, mut pos: usize) -> usize {
+    while pos < code.instructions.len() {
+        match pyre_interpreter::decode_instruction_at(code, pos) {
+            Some((
+                pyre_interpreter::Instruction::Cache
+                | pyre_interpreter::Instruction::ExtendedArg
+                | pyre_interpreter::Instruction::NotTaken
+                | pyre_interpreter::Instruction::Nop
+                | pyre_interpreter::Instruction::Resume { .. },
+                _,
+            )) => pos += 1,
+            _ => break,
+        }
+    }
+    pos
+}
+
+fn skip_caches(code: &pyre_interpreter::CodeObject, mut pos: usize) -> usize {
+    let mut state = pyre_interpreter::OpArgState::default();
+    while pos < code.instructions.len() {
+        let (instruction, _) = state.get(code.instructions[pos]);
+        if matches!(instruction, pyre_interpreter::Instruction::Cache) {
+            pos += 1;
+        } else {
+            break;
+        }
+    }
+    pos
+}
+
 /// Upper bound on the constant-pool slots one code-object constant can
 /// contribute to the assembled jitcode. A `Tuple`/`Frozenset`/`Slice`
 /// constant can be unpacked into its elements during graph construction —
@@ -4277,6 +4403,10 @@ fn unsupported_jit_shape(code: &pyre_interpreter::CodeObject) -> UnsupportedJitS
         return UnsupportedJitShape::ConstEncodingOverflow;
     }
 
+    if nested_break_bridge_resume_hazard(code) {
+        return UnsupportedJitShape::NestedBreakBridgeResume;
+    }
+
     let mut arg_state = pyre_interpreter::OpArgState::default();
     let mut has_for_iter = false;
     for unit in code.instructions.iter().copied() {
@@ -4354,6 +4484,13 @@ fn eval_with_jit_inner(frame: &mut PyFrame) -> PyResult {
                 "FrameShape::StructuralRegion",
             );
             let _guard = JitSuppressionGuard::new();
+            return frame_root.frame().execute_frame(None, None);
+        }
+        UnsupportedJitShape::NestedBreakBridgeResume => {
+            pyre_jit_trace::jitcode_dispatch::census_record_frame_shape_decline(
+                code as *const _ as usize,
+                "FrameShape::NestedBreakBridgeResume",
+            );
             return frame_root.frame().execute_frame(None, None);
         }
         UnsupportedJitShape::ConstEncodingOverflow => {
@@ -4590,6 +4727,7 @@ pub(crate) fn portal_runner_result(frame: &mut PyFrame) -> PyResult {
         UnsupportedJitShape::StructuralRegion => Some(JitSuppressionGuard::new()),
         UnsupportedJitShape::None
         | UnsupportedJitShape::CurrentFrameOnly
+        | UnsupportedJitShape::NestedBreakBridgeResume
         | UnsupportedJitShape::ConstEncodingOverflow => None,
     };
     portal_runner_dispatch(frame_root.frame())

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -5498,7 +5498,7 @@ impl CodeWriter {
                 },
             build_slice_fn:
                 HelperHandle {
-                    idx: _build_slice_fn_idx,
+                    idx: build_slice_fn_idx,
                     flavor: _build_slice_fn_flavor,
                 },
             normalize_raise_varargs_fn:
@@ -5970,6 +5970,7 @@ impl CodeWriter {
                 super_attr_unwrap_fn_idx,
                 load_deref_value_fn_idx,
                 store_deref_value_fn_idx,
+                build_slice_fn_idx,
                 make_cell_fn_idx,
                 make_function_fn_idx,
                 set_function_attribute_fn_idx,

--- a/pyre/pyre-jit/src/jit/flatten.rs
+++ b/pyre/pyre-jit/src/jit/flatten.rs
@@ -3424,6 +3424,14 @@ pub struct LoweringContext {
     /// `bh_store_deref_value_fn` mutates the cell's contents
     /// (`PlainCannotRaise` — writes heap, runs no user code, never raises).
     pub store_deref_value_fn_idx: u16,
+    /// `build_slice_fn` descrs-pool index.  BUILD_SLICE records the
+    /// `newslice(start, stop, step)` HLOp lowered to `residual_call_ir_r(
+    /// ConstInt(fn_idx), ListI([argc]), ListR([start, stop, step]), Descr) →
+    /// reg` via [`lower_newslice_hlop_to_insn`].  `bh_build_slice_fn` allocates
+    /// a slice (`Plain` — runs no user code; matches the bind-site flavor). The
+    /// walker always emits three ref operands (an argc=2 slice synthesizes a
+    /// `None` step), so `argc` is 3.
+    pub build_slice_fn_idx: u16,
     /// `make_cell_fn` descrs-pool index.  MAKE_CELL records the
     /// `make_cell_value(current)` HLOp lowered to `residual_call_r_r(ConstInt(
     /// fn_idx), ListR([current]), Descr) → reg` via
@@ -5103,6 +5111,9 @@ where
     if let Some(insn) = lower_store_slice_hlop_to_insn(op, ctx, get_register, lower_constant) {
         return Some(insn);
     }
+    if let Some(insn) = lower_newslice_hlop_to_insn(op, ctx, get_register, lower_constant) {
+        return Some(insn);
+    }
     if let Some(insn) = lower_delsubscr_hlop_to_insn(op, ctx, get_register, lower_constant) {
         return Some(insn);
     }
@@ -5600,6 +5611,55 @@ where
                 vec![Operand::ConstInt(deref_idx)],
             )),
             Operand::ListOfKind(ListOfKind::new(Kind::Ref, vec![cell, code])),
+            descr_operand,
+        ],
+        dst_reg,
+    ))
+}
+
+/// Lower the BUILD_SLICE pyre HLOp `newslice(start, stop, step) → result: Ref`
+/// to `residual_call_ir_r(ConstInt(build_slice_fn_idx), ListI([3]),
+/// ListR([start, stop, step]), Descr) → reg`, the same ir_r shape as
+/// [`lower_load_deref_value_hlop_to_insn`].  The walker always records three ref
+/// operands — an argc=2 slice synthesizes a `None` step — so `argc` is 3 and
+/// `bh_build_slice_fn` uses the step operand directly (`w_slice_new`).
+/// Allocates a slice but runs no user code → `Plain`, matching the bind-site
+/// flavor in `codewriter.rs`.
+///
+/// Returns `None` for a non-`newslice` opname or unexpected arity so the caller
+/// can fall through to other lowering arms.
+pub fn lower_newslice_hlop_to_insn<F, LC>(
+    op: &super::flow::SpaceOperation,
+    ctx: &LoweringContext,
+    get_register: &mut F,
+    lower_constant: &mut LC,
+) -> Option<Insn>
+where
+    F: FnMut(super::flow::Variable) -> Register,
+    LC: FnMut(&Constant) -> Operand,
+{
+    if op.opname != "newslice" || op.args.len() != 3 {
+        return None;
+    }
+    let start = operand_for_value_arg(&op.args[0], get_register, lower_constant)?;
+    let stop = operand_for_value_arg(&op.args[1], get_register, lower_constant)?;
+    let step = operand_for_value_arg(&op.args[2], get_register, lower_constant)?;
+    let dst_reg = match &op.result {
+        Some(super::flow::FlowValue::Variable(var)) => get_register(*var),
+        _ => return None,
+    };
+    let effect_info = effect_info_for_call_flavor(CallFlavor::Plain);
+    let descr_operand = Operand::descr(DescrOperand::CallDescrStub(CallDescrStub {
+        effect_info,
+        arg_kinds: vec![Kind::Int, Kind::Ref, Kind::Ref, Kind::Ref],
+        result_kind: Some(Kind::Ref),
+    }));
+    Some(Insn::op_with_result(
+        "residual_call_ir_r",
+        vec![
+            Operand::ConstInt(ctx.build_slice_fn_idx as i64),
+            Operand::ListOfKind(ListOfKind::new(Kind::Int, vec![Operand::ConstInt(3)])),
+            Operand::ListOfKind(ListOfKind::new(Kind::Ref, vec![start, stop, step])),
             descr_operand,
         ],
         dst_reg,
@@ -11082,6 +11142,7 @@ mod tests {
             unary_negative_fn_idx: 112,
             list_extend_fn_idx: 113,
             store_deref_value_fn_idx: 114,
+            build_slice_fn_idx: 133,
             make_cell_fn_idx: 115,
             make_function_fn_idx: 131,
             set_function_attribute_fn_idx: 132,
@@ -12035,6 +12096,113 @@ mod tests {
                                 !stub.effect_info.check_can_raise(false),
                                 "cannot-raise residual must omit the trailing GUARD_NO_EXCEPTION"
                             );
+                        }
+                        other => panic!("expected CallDescrStub, got {other:?}"),
+                    },
+                    other => panic!("expected Operand::Descr, got {other:?}"),
+                }
+            }
+            _ => panic!("expected Insn::Op, got {insn:?}"),
+        }
+    }
+
+    #[test]
+    fn lower_newslice_hlop_emits_build_slice_fn_residual() {
+        // `newslice(start, stop, step)` →
+        // `residual_call_ir_r(ConstInt(build_slice_fn_idx), ListI([3]),
+        // ListR([start, stop, step]), Descr) → reg` (Plain — allocates a slice,
+        // runs no user code; matches the bind-site flavor).
+        let start_var = Variable::new(VariableId(8), Kind::Ref);
+        let stop_var = Variable::new(VariableId(9), Kind::Ref);
+        let step_var = Variable::new(VariableId(10), Kind::Ref);
+        let result_var = Variable::new(VariableId(11), Kind::Ref);
+        let (ctx, _, _) = load_attr_lowering_fixture();
+        let op = super::super::flow::SpaceOperation::new(
+            "newslice",
+            vec![start_var.into(), stop_var.into(), step_var.into()],
+            Some(result_var.into()),
+            0,
+        );
+        let mut get_register = |var: Variable| match var.id {
+            VariableId(8) => Register {
+                kind: Kind::Ref,
+                index: 101,
+            },
+            VariableId(9) => Register {
+                kind: Kind::Ref,
+                index: 102,
+            },
+            VariableId(10) => Register {
+                kind: Kind::Ref,
+                index: 103,
+            },
+            VariableId(11) => Register {
+                kind: Kind::Ref,
+                index: 104,
+            },
+            _ => panic!("unexpected var id {:?}", var.id),
+        };
+        let mut lower_constant = super::flatten_constant_operand_for_test;
+        let insn =
+            super::lower_newslice_hlop_to_insn(&op, &ctx, &mut get_register, &mut lower_constant)
+                .expect("3-arg newslice lowering must succeed");
+        match insn {
+            Insn::Op {
+                opname,
+                args,
+                result,
+            } => {
+                assert_eq!(opname, "residual_call_ir_r");
+                assert!(
+                    matches!(args[0], Operand::ConstInt(133)),
+                    "build_slice_fn pool index, got {:?}",
+                    args[0]
+                );
+                match &args[1] {
+                    Operand::ListOfKind(list) => {
+                        assert_eq!(list.kind, Kind::Int);
+                        assert!(
+                            matches!(&list.content[..], [Operand::ConstInt(3)]),
+                            "ListI must be [argc=3], got {:?}",
+                            list.content
+                        );
+                    }
+                    other => panic!("expected ListI, got {other:?}"),
+                }
+                match &args[2] {
+                    Operand::ListOfKind(list) => {
+                        assert_eq!(list.kind, Kind::Ref);
+                        match &list.content[..] {
+                            [Operand::Register(a), Operand::Register(b), Operand::Register(c)] => {
+                                assert_eq!(a.index, 101, "ListR[0] must be start");
+                                assert_eq!(b.index, 102, "ListR[1] must be stop");
+                                assert_eq!(c.index, 103, "ListR[2] must be step");
+                            }
+                            other => panic!("ListR must be [start, stop, step], got {other:?}"),
+                        }
+                    }
+                    other => panic!("expected ListR, got {other:?}"),
+                }
+                assert_eq!(
+                    result,
+                    Some(Register {
+                        kind: Kind::Ref,
+                        index: 104
+                    }),
+                );
+                match &args[3] {
+                    Operand::Descr(rc) => match &**rc {
+                        DescrOperand::CallDescrStub(stub) => {
+                            assert_eq!(
+                                stub.effect_info,
+                                effect_info_for_call_flavor(CallFlavor::Plain),
+                                "newslice residual must carry the Plain effect (matches bind site)"
+                            );
+                            assert_eq!(
+                                stub.arg_kinds,
+                                vec![Kind::Int, Kind::Ref, Kind::Ref, Kind::Ref]
+                            );
+                            assert_eq!(stub.result_kind, Some(Kind::Ref));
                         }
                         other => panic!("expected CallDescrStub, got {other:?}"),
                     },


### PR DESCRIPTION
Two JIT correctness fixes, each with a synth regression bench.

## `newslice` HLOp had no lowering arm
`BUILD_SLICE` with a step operand records a `newslice(start, stop, step)` HLOp
that had no arm in the flatten lowering dispatch, so it reached the SSARepr
assembler un-lowered and panicked with `unimplemented opname "newslice"`
whenever a stepped slice (e.g. `lst[::-1]`) sat in a JIT-compiled loop.

Added `lower_newslice_hlop_to_insn`, lowering the three-ref HLOp to
`residual_call_ir_r(ConstInt(build_slice_fn_idx), ListI([3]), ListR([start,
stop, step]), Descr)` against the existing `bh_build_slice_fn` helper. The
lowering flavor is `Plain`, matching the bind site. Synth bench
`newslice_step_hot.py`.

## Nested-loop secondary-edge `break` mis-maps the outer iterator
A nested inner `for` loop `break` (`POP_TOP` popping the inner iterator then a
`JUMP_BACKWARD` to the enclosing `FOR_ITER`) miscompiles when the break lands on
the secondary edge of its inner-loop guard: the break edge becomes a guard
side-exit whose bridge resume snapshot mis-maps the outer iterator slot, so the
resumed `FOR_ITER` dereferences a non-iterator (SIGSEGV, or `TypeError: not an
iterator`).

Detect the two hazardous guard shapes (a `POP_JUMP_IF_TRUE` whose true edge
continues the loop, and a `POP_JUMP_IF_FALSE` that jumps forward to the break)
and route the frame through the interpreter via a new
`UnsupportedJitShape::NestedBreakBridgeResume`. The plain `if cond: break` idiom
(a `POP_JUMP_IF_FALSE` whose fall-through is the break — the primary edge) still
JIT-compiles. Synth bench `nested_break_not_hot.py`.

## Verification
- Both stepped-slice and nested-break repros clear on dynasm and cranelift.
- Discriminator: hazardous nested-break shape declines (`loops_compiled=0`, no
  panic) while the plain-break control still compiles (`loops_compiled=2`).
- `pyre/check.py`: dynasm 219/219, cranelift 219/219, wasm 218/218 — all passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)