### PR TITLE
jit: fix five fuzz-found dynasm miscompiles (newslice, short-preamble hoist, bridge global fold, DELETE_FAST reraise, nested-break resume)

### DIFF
--- a/majit/majit-metainterp/src/optimizeopt/heap.rs
+++ b/majit/majit-metainterp/src/optimizeopt/heap.rs
@@ -3495,6 +3495,16 @@ impl Optimization for OptHeap {
             .collect();
         sort_descr_item_refs_untranslated(&mut field_entries);
         for (descr, (field_idx, cf)) in field_entries {
+            let effect_idx = Self::field_effect_index(descr);
+            if majit_ir::effectinfo::compute_bitstrings_has_run()
+                && effect_idx == u32::MAX
+                && !descr.is_always_pure()
+            {
+                // Match force_from_effectinfo's conservatism for mutable
+                // descrs outside the bitstring universe: a residual call may
+                // write them, so they must be read live in each peeled body.
+                continue;
+            }
             cf.produce_potential_short_preamble_ops(sb, descr, field_idx, ctx);
         }
         // heap.py:374-377:
@@ -3502,6 +3512,14 @@ impl Optimization for OptHeap {
         //         for index, d in submap.const_indexes.items():
         //             d.produce_potential_short_preamble_ops(self.optimizer, sb, descr, index)
         for (_, descr, submap) in &self.cached_arrayitems {
+            let effect_idx = Self::array_effect_index(descr);
+            if majit_ir::effectinfo::compute_bitstrings_has_run()
+                && effect_idx == u32::MAX
+                && !descr.is_always_pure()
+            {
+                // Same rule for runtime-minted mutable array descrs.
+                continue;
+            }
             for (_, cai) in &submap.const_indexes {
                 cai.produce_potential_short_preamble_ops(sb, &descr, ctx);
             }

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -3554,6 +3554,7 @@ impl<M: Clone> MetaInterp<M> {
     }
 
     fn prepare_trace_start_runtime(&mut self) {
+        self.last_compiled_key = None;
         // pyjitpl.py:2884-2892 `compile_and_run_once` body, line-by-line:
         //   debug_start('jit-tracing')                  # OUTER open
         //   self.staticdata._setup_once()
@@ -10847,6 +10848,8 @@ impl<M: Clone> MetaInterp<M> {
                 // (could be a previous_tokens entry on cross-loop or
                 // post-recompile failures), not the current running loop's
                 // latest token.
+                self.last_quasi_immutable_deps =
+                    std::mem::take(&mut optimizer.quasi_immutable_deps);
                 self.record_loop_or_bridge(&source_jct, &mut optimized_ops, bridge_trace_id);
                 // Mark the bridge as compiled
                 if let Some(compiled) = self.compiled_loops.get_mut(&green_key) {

--- a/pyre/bench/synth/bridge_global_fold_invalidate_hot.py
+++ b/pyre/bench/synth/bridge_global_fold_invalidate_hot.py
@@ -1,0 +1,51 @@
+# A read-only module global read on a COLD arm (a branch, a genexpr, or a
+# function that gets rebound) compiles as a bridge that const-folds the global
+# via a quasi-immutable fold. A mid-loop same-key reassignment (or a function
+# rebind) must invalidate that fold so the bridge re-reads the new value; a
+# stale fold keeps returning the old value. Exercises an int global, a len() of
+# a global set, a str-prefix global, and a rebound global function. Output is
+# verified against CPython/PyPy.
+N = 9000
+
+CFG = 1
+S = {1, 2, 3}
+AFFIX = "pre_"
+
+
+def rd_int(i):
+    return CFG if i & 1 else 0
+
+
+def rd_len(i):
+    return len(S) if i & 1 else 0
+
+
+def chk(s):
+    return s.startswith(AFFIX)
+
+
+def route(n):
+    return n * 2
+
+
+def route2(n):
+    return n + 100
+
+
+def run():
+    global CFG, S, AFFIX, route
+    total = 0
+    for i in range(N):
+        total += rd_int(i) + rd_len(i)
+        if chk(AFFIX + str(i)):
+            total += 1
+        total += route(i % 3)
+        if i == N // 2:
+            CFG = 2
+            S = {1, 2, 3, 4, 5}
+            AFFIX = "post_"
+            route = route2
+    return total
+
+
+print(run())

--- a/pyre/bench/synth/global_cell_shortpreamble_hot.py
+++ b/pyre/bench/synth/global_cell_shortpreamble_hot.py
@@ -1,0 +1,39 @@
+# A module-global int accumulator carried through an inlined function that
+# branches on the loop variable `i`, where the loop body ALSO reads `i` at the
+# tail (a branch / dead guard / mid-loop reassignment). The `LOAD_NAME i` folds
+# to a getfield of the runtime-minted mutable name cell; the tail read
+# re-populates that cache at the end of the preamble, and the short-preamble
+# export must NOT hoist it as a loop invariant — the residual STORE_NAME writes
+# the cell every iteration, so the peeled body must re-read it live or the
+# inlined callee sees the previous iteration's `i` and picks the wrong branch.
+# Output is verified against CPython/PyPy.
+N = 30000
+
+
+def process(x, i):
+    if i % 3 == 0:
+        return x // 97 + 1
+    else:
+        return -(x % 50000) + 3
+
+
+def blend(x, i):
+    if i % 7 >= 5:
+        return x * 3 + 1
+    return x + 2
+
+
+acc = 5
+tot = 5
+for i in range(N):
+    acc = process(acc, i)
+    # tail read of i: a mid-loop reassignment on a rare cold arm.
+    if i == N - 100:
+        acc = -acc - 1
+    tot = blend(tot, i)
+    tot %= 1000000
+    # tail read of i: a dead never-true guard.
+    if i < 0:
+        pass
+
+print(acc, tot)

--- a/pyre/bench/synth/named_reraise_sibling_hot.py
+++ b/pyre/bench/synth/named_reraise_sibling_hot.py
@@ -1,0 +1,68 @@
+# A named `except E as m:` handler whose body bare-re-raises compiles its
+# implicit cleanup to `DELETE_FAST m; RERAISE`, immediately followed by a
+# sibling `except` clause's type check. On the re-raise path the exception must
+# route to the outer re-raise landing and the sibling clause must NOT run; the
+# binding `m` is cleared. A `del` of a bound local inside the try body plus a
+# sibling clause exercises the same walker-native DELETE_FAST bound
+# continuation. Output is verified against CPython/PyPy.
+N = 9000
+
+
+def reraise_sibling(i):
+    try:
+        if i % 9 == 0:
+            raise ValueError
+        return 1
+    except ValueError as m:
+        raise
+    except KeyError:
+        return 100
+
+
+def dual_reraise(i):
+    try:
+        if i % 9 == 0:
+            raise ValueError
+        if i % 7 == 1:
+            raise TypeError
+        return 1
+    except ValueError as v:
+        raise
+    except TypeError:
+        raise
+
+
+def del_in_try(i):
+    x = i
+    try:
+        if i % 15 == 0:
+            raise ValueError
+        del x
+        return 1
+    except ValueError as m:
+        raise
+    except IndexError:
+        return 50
+
+
+def run():
+    total = 0
+    for i in range(N):
+        try:
+            total += reraise_sibling(i)
+        except ValueError:
+            total += 2
+        try:
+            total += dual_reraise(i)
+        except ValueError:
+            total += 3
+        except TypeError:
+            total += 5
+        try:
+            total += del_in_try(i)
+        except ValueError:
+            total += 7
+    return total
+
+
+print(run())

--- a/pyre/bench/synth/nested_break_not_hot.py
+++ b/pyre/bench/synth/nested_break_not_hot.py
@@ -1,0 +1,52 @@
+# A nested `for` loop whose inner `break` lands on the secondary edge of its
+# guard — reached from `if not cond: break` (a POP_JUMP_IF_TRUE fall-through) or
+# from a break-check that is the last statement in the loop body (a
+# POP_JUMP_IF_FALSE that jumps forward to the break) — must reconstruct the
+# operand stack correctly when the inner iterator is popped and control resumes
+# at the outer FOR_ITER. Both the break-check-first and accumulate-first forms,
+# plus a compound `and` guard, are exercised. Output is verified against
+# CPython/PyPy.
+N = 9000
+
+
+def break_check_first(n):
+    t = 0
+    for i in range(n):
+        for j in range(2, 4):
+            if not i % 3 != 0:
+                break
+            t += j
+    return t
+
+
+def accumulate_first(n):
+    t = 0
+    for i in range(n):
+        for j in range(2, 4):
+            t += j
+            if not i % 5 != 0:
+                break
+    return t
+
+
+def compound_guard(n):
+    t = 0
+    for i in range(n):
+        for j in range(2, 4):
+            if not i % 3 != 0 and i % 2 == 0:
+                break
+            t += j
+    return t
+
+
+def plain_break(n):
+    t = 0
+    for i in range(n):
+        for j in range(2, 4):
+            if i % 3 >= 2:
+                break
+            t += j
+    return t
+
+
+print(break_check_first(N), accumulate_first(N), compound_guard(N), plain_break(N))

--- a/pyre/bench/synth/newslice_step_hot.py
+++ b/pyre/bench/synth/newslice_step_hot.py
@@ -1,0 +1,78 @@
+# An extended slice `seq[a:b:c]` (a step operand) compiles the bounds to
+# BUILD_SLICE — the `newslice(start, stop, step)` HLOp — then BINARY_SUBSCR,
+# a distinct lowering from the two-bound BINARY_SLICE path. A `newslice`
+# residual (`bh_build_slice_fn` → `w_slice_new`) must be emitted so the hot
+# body JIT-compiles; without the lowering the assembler aborts on the
+# unmapped opname. Both a literal reverse `seq[::-1]` and variable bounds are
+# exercised, over list/tuple/str/bytes. None bounds and an `__index__` step
+# resolve like plain ints. Output is verified against CPython/PyPy.
+N = 60000
+
+
+class Idx:
+    def __init__(self, v):
+        self.v = v
+
+    def __index__(self):
+        return self.v
+
+
+def show(label, fn):
+    try:
+        print(label, fn())
+    except Exception as e:
+        print(label, type(e).__name__)
+
+
+def main():
+    seq = "abcdefghij"
+    lst = list(range(10))
+    tup = tuple(range(10))
+    bts = b"abcdefghij"
+
+    # Hot loop 1: literal reverse slice `[::-1]` (None/None/-1 bounds) over four
+    # sequence types every iteration — the canonical BUILD_SLICE panic shape.
+    acc = 0
+    i = 0
+    while i < N:
+        acc = acc + len(seq[::-1]) + lst[::-1][0] + tup[::-1][0] + bts[::-1][0]
+        i = i + 1
+    print("acc", acc)
+
+    # Hot loop 2: variable start/stop/step locals — cannot fold to a const
+    # slice, so BUILD_SLICE runs on live operands every iteration.
+    acc2 = 0
+    j = 0
+    a = 8
+    b = 1
+    c = -2
+    while j < N:
+        acc2 = acc2 + sum(lst[a:b:c])
+        j = j + 1
+    print("acc2", acc2)
+
+    # Reverse of each type.
+    show("str_rev", lambda: seq[::-1])
+    show("list_rev", lambda: lst[::-1])
+    show("tuple_rev", lambda: tup[::-1])
+    show("bytes_rev", lambda: list(bts[::-1]))
+
+    # Explicit reverse bounds.
+    show("str_bounds_rev", lambda: seq[8:2:-1])
+    show("list_bounds_rev", lambda: lst[8:2:-1])
+
+    # Positive step.
+    show("str_step2", lambda: seq[::2])
+    show("list_step3", lambda: lst[1:9:3])
+
+    # None start/stop with a step.
+    show("none_bounds_step", lambda: lst[::3])
+
+    # __index__ step resolves like a plain int.
+    show("idx_step", lambda: lst[Idx(0):Idx(9):Idx(2)])
+
+    # Zero step is rejected (ValueError) — the residual must propagate it.
+    show("zero_step", lambda: lst[::0])
+
+
+main()

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -2390,7 +2390,7 @@ fn handle_blackhole_result(bh_result: BlackholeResult, _green_key: u64) -> Optio
 /// returning `false` to drop into blackhole resume.
 // dont_look_inside: bridge-compile identity machinery the tracer must not enter.
 #[majit_macros::dont_look_inside]
-fn bridge_source_identity_from_descr(
+pub(crate) fn bridge_source_identity_from_descr(
     descr_arc: &std::sync::Arc<dyn majit_ir::Descr>,
 ) -> Option<(u64, u64, u32)> {
     let descr_fd = descr_arc.as_fail_descr()?;

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -5258,12 +5258,22 @@ fn handle_fail(
             };
             match resolution {
                 crate::call_jit::BridgeResolution::CompiledContinue => {
+                    if let Some((green_key, _, _)) =
+                        crate::call_jit::bridge_source_identity_from_descr(descr_arc)
+                    {
+                        register_quasi_immutable_deps(green_key);
+                    }
                     // compile.py:708: bridge compiled → ContinueRunningNormally.
                     // RPython: the bridge is attached to the guard descr;
                     // re-entering compiled code will follow the bridge.
                     return HandleFailOutcome::BridgeCompiled;
                 }
                 crate::call_jit::BridgeResolution::Finished(cv) => {
+                    if let Some((green_key, _, _)) =
+                        crate::call_jit::bridge_source_identity_from_descr(descr_arc)
+                    {
+                        register_quasi_immutable_deps(green_key);
+                    }
                     // #177: the walk ran the resumed frame forward to its
                     // return and captured the concrete result; hand it back
                     // as `DoneWithThisFrame` (`interpret()` raising it from
@@ -5277,6 +5287,11 @@ fn handle_fail(
                     return HandleFailOutcome::BridgeFinished(v);
                 }
                 crate::call_jit::BridgeResolution::FinishedException(cv) => {
+                    if let Some((green_key, _, _)) =
+                        crate::call_jit::bridge_source_identity_from_descr(descr_arc)
+                    {
+                        register_quasi_immutable_deps(green_key);
+                    }
                     return HandleFailOutcome::BridgeRaised(finish_concrete_raise_error(cv));
                 }
                 crate::call_jit::BridgeResolution::ResumeBlackhole => {}

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -3977,6 +3977,7 @@ enum UnsupportedJitShape {
     None,
     CurrentFrameOnly,
     StructuralRegion,
+    NestedBreakBridgeResume,
     /// The frame's constant pool plus register file would exceed the
     /// single-byte (`< 256`) register-or-constant index encoding
     /// (`assembler.py:72 chr()`, `assembler.py:132-133`
@@ -4188,6 +4189,131 @@ fn for_iter_frame_is_finally_duplicated(code: &pyre_interpreter::CodeObject) -> 
     for_iter_count > 1 && any_in_handler
 }
 
+/// A nested inner `for` loop `break` — a `POP_TOP` that pops the inner iterator
+/// then a `JUMP_BACKWARD` to the enclosing `FOR_ITER` — miscompiles when the
+/// break lands on the secondary edge of a conditional in the inner-loop guard:
+/// the break edge becomes a guard side-exit whose bridge resume snapshot
+/// mis-maps the outer iterator slot (a boxed value / null lands where the outer
+/// iterator must be), so the resumed `FOR_ITER` dereferences a non-iterator.
+/// Two guard shapes produce that secondary-edge break: a `POP_JUMP_IF_TRUE`
+/// whose true edge continues the loop (break is its fall-through), and a
+/// `POP_JUMP_IF_FALSE` whose false edge jumps forward to the break. Decline
+/// such a frame to the interpreter. The plain `if cond: break` idiom compiles
+/// to a `POP_JUMP_IF_FALSE` whose fall-through IS the break — the primary edge —
+/// and still compiles.
+fn nested_break_bridge_resume_hazard(code: &pyre_interpreter::CodeObject) -> bool {
+    let num_instrs = code.instructions.len();
+    for pop_pc in 0..num_instrs {
+        let Some(target) = pop_top_jumps_back_to_for_iter(code, num_instrs, pop_pc) else {
+            continue;
+        };
+        let mut inner_header = None;
+        for header_pc in target..pop_pc {
+            if matches!(
+                pyre_interpreter::decode_instruction_at(code, header_pc),
+                Some((pyre_interpreter::Instruction::ForIter { .. }, _))
+            ) {
+                inner_header = Some(header_pc);
+            }
+        }
+        let Some(inner_header) = inner_header else {
+            continue;
+        };
+        for guard_pc in (inner_header + 1)..pop_pc {
+            match pyre_interpreter::decode_instruction_at(code, guard_pc) {
+                Some((pyre_interpreter::Instruction::PopJumpIfTrue { .. }, _)) => {
+                    return true;
+                }
+                Some((pyre_interpreter::Instruction::PopJumpIfFalse { delta }, op_arg)) => {
+                    let jump_target = pyre_interpreter::jump_target_forward(
+                        &code.instructions,
+                        guard_pc + 1,
+                        delta.get(op_arg).as_usize(),
+                    );
+                    if skip_branch_trivia(code, jump_target) == pop_pc {
+                        return true;
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+    false
+}
+
+fn pop_top_jumps_back_to_for_iter(
+    code: &pyre_interpreter::CodeObject,
+    num_instrs: usize,
+    pop_pc: usize,
+) -> Option<usize> {
+    if pop_pc >= num_instrs {
+        return None;
+    }
+    if !matches!(
+        pyre_interpreter::decode_instruction_at(code, pop_pc),
+        Some((pyre_interpreter::Instruction::PopTop, _))
+    ) {
+        return None;
+    }
+    let jump_pc = skip_branch_trivia(code, pop_pc + 1);
+    if jump_pc >= num_instrs {
+        return None;
+    }
+    let Some((instr, op_arg)) = pyre_interpreter::decode_instruction_at(code, jump_pc) else {
+        return None;
+    };
+    let target = match instr {
+        pyre_interpreter::Instruction::JumpBackward { delta } => {
+            skip_caches(code, jump_pc + 1).saturating_sub(delta.get(op_arg).as_usize())
+        }
+        pyre_interpreter::Instruction::JumpBackwardNoInterrupt { delta } => {
+            (jump_pc + 1).saturating_sub(delta.get(op_arg).as_usize())
+        }
+        _ => return None,
+    };
+    if target < pop_pc
+        && target < num_instrs
+        && matches!(
+            pyre_interpreter::decode_instruction_at(code, target),
+            Some((pyre_interpreter::Instruction::ForIter { .. }, _))
+        )
+    {
+        Some(target)
+    } else {
+        None
+    }
+}
+
+fn skip_branch_trivia(code: &pyre_interpreter::CodeObject, mut pos: usize) -> usize {
+    while pos < code.instructions.len() {
+        match pyre_interpreter::decode_instruction_at(code, pos) {
+            Some((
+                pyre_interpreter::Instruction::Cache
+                | pyre_interpreter::Instruction::ExtendedArg
+                | pyre_interpreter::Instruction::NotTaken
+                | pyre_interpreter::Instruction::Nop
+                | pyre_interpreter::Instruction::Resume { .. },
+                _,
+            )) => pos += 1,
+            _ => break,
+        }
+    }
+    pos
+}
+
+fn skip_caches(code: &pyre_interpreter::CodeObject, mut pos: usize) -> usize {
+    let mut state = pyre_interpreter::OpArgState::default();
+    while pos < code.instructions.len() {
+        let (instruction, _) = state.get(code.instructions[pos]);
+        if matches!(instruction, pyre_interpreter::Instruction::Cache) {
+            pos += 1;
+        } else {
+            break;
+        }
+    }
+    pos
+}
+
 /// Upper bound on the constant-pool slots one code-object constant can
 /// contribute to the assembled jitcode. A `Tuple`/`Frozenset`/`Slice`
 /// constant can be unpacked into its elements during graph construction —
@@ -4277,6 +4403,10 @@ fn unsupported_jit_shape(code: &pyre_interpreter::CodeObject) -> UnsupportedJitS
         return UnsupportedJitShape::ConstEncodingOverflow;
     }
 
+    if nested_break_bridge_resume_hazard(code) {
+        return UnsupportedJitShape::NestedBreakBridgeResume;
+    }
+
     let mut arg_state = pyre_interpreter::OpArgState::default();
     let mut has_for_iter = false;
     for unit in code.instructions.iter().copied() {
@@ -4354,6 +4484,13 @@ fn eval_with_jit_inner(frame: &mut PyFrame) -> PyResult {
                 "FrameShape::StructuralRegion",
             );
             let _guard = JitSuppressionGuard::new();
+            return frame_root.frame().execute_frame(None, None);
+        }
+        UnsupportedJitShape::NestedBreakBridgeResume => {
+            pyre_jit_trace::jitcode_dispatch::census_record_frame_shape_decline(
+                code as *const _ as usize,
+                "FrameShape::NestedBreakBridgeResume",
+            );
             return frame_root.frame().execute_frame(None, None);
         }
         UnsupportedJitShape::ConstEncodingOverflow => {
@@ -4590,6 +4727,7 @@ pub(crate) fn portal_runner_result(frame: &mut PyFrame) -> PyResult {
         UnsupportedJitShape::StructuralRegion => Some(JitSuppressionGuard::new()),
         UnsupportedJitShape::None
         | UnsupportedJitShape::CurrentFrameOnly
+        | UnsupportedJitShape::NestedBreakBridgeResume
         | UnsupportedJitShape::ConstEncodingOverflow => None,
     };
     portal_runner_dispatch(frame_root.frame())

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -4201,6 +4201,13 @@ fn for_iter_frame_is_finally_duplicated(code: &pyre_interpreter::CodeObject) -> 
 /// such a frame to the interpreter. The plain `if cond: break` idiom compiles
 /// to a `POP_JUMP_IF_FALSE` whose fall-through IS the break — the primary edge —
 /// and still compiles.
+///
+/// The `POP_JUMP_IF_TRUE` test is a deliberate sound over-approximation: any
+/// such branch in the guard (e.g. one arm of a short-circuit `or`) declines the
+/// frame even when that particular arm is provably safe, because a hazardous
+/// arm elsewhere in the same guard (a compound `and`) can reach the break
+/// through it. A few extra interpreted frames are traded for a guarantee that
+/// the mis-mapped resume is never compiled.
 fn nested_break_bridge_resume_hazard(code: &pyre_interpreter::CodeObject) -> bool {
     let num_instrs = code.instructions.len();
     for pop_pc in 0..num_instrs {

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -8320,23 +8320,25 @@ impl CodeWriter {
                             // non-portal callee instead keeps the
                             // `flowcontext.py:856-859 find_global` const-fold,
                             // which the inliner needs as a foldable constant call
-                            // target — EXCEPT when the resolved global is a
-                            // mutable container (dict / list / set).  Such a
-                            // container is grown in place and relocates
-                            // nursery->oldgen after the jitcode is built, so its
-                            // const-folded address dangles when the blackhole
-                            // resumes the unfused callee (dynasm SIGSEGVs;
-                            // cranelift null-softens the read).  Resolve those
-                            // through the `bh_load_global_fn` residual whose
-                            // namespace operand is the callee's module dict
-                            // object, built eagerly at `PyFrame.__init__` so it reaches the non-moving
-                            // oldgen before any jitcode build): the cell-fold
-                            // then reads the container value live through that
-                            // stable dict every iteration instead of baking the
-                            // relocating value.  Functions / classes / modules
-                            // are created at module load and promoted to the
-                            // non-moving oldgen before any jitcode build, so
-                            // const-folding them stays GC-safe.
+                            // target — EXCEPT for a mutable container (dict /
+                            // list / set) or a function.  A container is grown
+                            // in place and relocates nursery->oldgen after the
+                            // jitcode is built, so its const-folded address
+                            // dangles when the blackhole resumes the unfused
+                            // callee (dynasm SIGSEGVs; cranelift null-softens the
+                            // read).  A function global can be rebound through
+                            // its module cell after the jitcode is built, so a
+                            // baked callable goes stale.  Resolve both through
+                            // the `bh_load_global_fn` residual whose namespace
+                            // operand is the callee's module dict object, built
+                            // eagerly at `PyFrame.__init__` so it reaches the
+                            // non-moving oldgen before any jitcode build: the
+                            // cell-fold then reads the value live through that
+                            // stable dict every iteration, giving the optimizer a
+                            // guarded value instead of baking a relocating or
+                            // rebindable one.  Classes / modules are created at
+                            // module load and are neither grown nor rebound, so
+                            // const-folding them stays safe.
                             let result_value: super::flow::FlowValue = if is_true_portal {
                                 let ns_var = emit_graph_op_with_result(
                                     &mut graph,
@@ -8374,30 +8376,33 @@ impl CodeWriter {
                                 let name = code.names.get(name_idx).map(|name| name.as_str());
                                 // Classify the FINAL resolved global — module
                                 // globals OR `__builtins__`.  Only a
-                                // module-load-immortal call target (function,
-                                // class, module) is safe to const-fold: it is
-                                // promoted to the non-moving oldgen before any
-                                // jitcode build, and the inliner needs it as a
+                                // module-load-immortal, non-rebindable call
+                                // target (a class or a module) is safe to
+                                // const-fold: it is promoted to the non-moving
+                                // oldgen before any jitcode build and is not
+                                // rebound in place, and the inliner needs it as a
                                 // foldable constant call target.  Every other
-                                // resolved global is a relocatable value (an
+                                // resolved global is either relocatable (an
                                 // `int`/`str` built at run time, or a mutable
-                                // dict/list/set) whose const-folded address
+                                // dict/list/set whose const-folded address
                                 // dangles once the moving GC relocates it — the
                                 // baked pointer then crashes the blackhole
-                                // resume.  Route those through the live residual
+                                // resume) or rebindable (a function whose module
+                                // cell can be reassigned after the jitcode is
+                                // built, so a baked callable goes stale).  Route
+                                // those through the live residual
                                 // (`bh_load_global_fn` resolves the value from
                                 // the frame's own globals every iteration, never
-                                // baking the relocating pointer); `LOAD_GLOBAL`
-                                // under the JIT always resolves through
-                                // `get_w_globals()` live (celldict.py:287), so
-                                // the residual is the orthodox shape and the
-                                // const-fold is the optimization carve-out.
+                                // baking the relocating or rebindable pointer);
+                                // `LOAD_GLOBAL` under the JIT always resolves
+                                // through `get_w_globals()` live
+                                // (celldict.py:287), so the residual is the
+                                // orthodox shape and the const-fold is the
+                                // optimization carve-out.
                                 let global_is_const_foldable = name
                                     .and_then(|nm| frontend_global_object(w_code, nm))
                                     .is_some_and(|obj| unsafe {
-                                        pyre_interpreter::is_function(obj)
-                                            || pyre_object::is_type(obj)
-                                            || pyre_object::is_module(obj)
+                                        pyre_object::is_type(obj) || pyre_object::is_module(obj)
                                     });
                                 if !global_is_const_foldable {
                                     // The namespace operand is the callee's
@@ -8446,12 +8451,15 @@ impl CodeWriter {
                                         .map(super::flow::FlowValue::from)
                                         .unwrap_or_else(|| fresh_ref_value(&mut graph).into())
                                 } else {
-                                    // Module-load-immortal call target
-                                    // (function / class / module): const-fold so
+                                    // Module-load-immortal, non-rebindable call
+                                    // target (a class or a module): const-fold so
                                     // the inliner sees a foldable constant call
                                     // target.  Such objects reach the non-moving
-                                    // oldgen before any jitcode build, so the
-                                    // baked pointer stays GC-stable.
+                                    // oldgen before any jitcode build and are not
+                                    // rebound, so the baked pointer stays stable.
+                                    // Function globals take the residual path
+                                    // above because rebinding can change their
+                                    // module-cell payload.
                                     name.and_then(|nm| frontend_global_flow_value(w_code, nm))
                                         .unwrap_or_else(|| fresh_ref_value(&mut graph).into())
                                 }

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -1580,6 +1580,23 @@ fn handler_entry_has_explicit_raise_source(
     })
 }
 
+fn next_non_aux_instruction(code: &CodeObject, mut pc: usize) -> Option<(usize, Instruction)> {
+    while pc < code.instructions.len() {
+        let (instruction, _) = pyre_interpreter::decode_instruction_at(code, pc)?;
+        if !matches!(
+            instruction,
+            Instruction::Nop
+                | Instruction::Cache
+                | Instruction::NotTaken
+                | Instruction::ExtendedArg
+        ) {
+            return Some((pc, instruction));
+        }
+        pc += 1;
+    }
+    None
+}
+
 fn initialize_spam_block(
     code: &CodeObject,
     graph: &mut super::flow::FunctionGraph,
@@ -11527,6 +11544,47 @@ impl CodeWriter {
                             if fbw_delete_fast_enabled() {
                                 let idx = var_num.get(op_arg).as_usize();
                                 if current_state.local_value_at(idx).is_none() {
+                                    emit_abort_permanent!(py_pc);
+                                    continue;
+                                }
+                                // The implicit cleanup of a named `except E as m:`
+                                // whose body bare-re-raises compiles to
+                                // `DELETE_FAST m; RERAISE` immediately followed by
+                                // a sibling clause's `LOAD_GLOBAL <T>; CHECK_EXC_MATCH`.
+                                // The covered RERAISE must route to the outer
+                                // re-raise landing, but the walker-native bound
+                                // continuation of this DELETE_FAST falls through
+                                // into that sibling type check with the current
+                                // exception not re-seeded, so CHECK_EXC_MATCH peeks
+                                // a null operand. Decline this shape — and any
+                                // catch-covered DELETE_FAST in a function that
+                                // contains it — so the interpreter runs it.
+                                let cleanup_reraise_to_sibling = |delete_pc: usize| {
+                                    let next = next_non_aux_instruction(code, delete_pc + 1);
+                                    let after_next = next
+                                        .and_then(|(pc, _)| next_non_aux_instruction(code, pc + 1));
+                                    let after_after_next = after_next
+                                        .and_then(|(pc, _)| next_non_aux_instruction(code, pc + 1));
+                                    next.is_some_and(|(pc, instruction)| {
+                                        catch_for_pc.get(pc).copied().flatten().is_some()
+                                            && matches!(instruction, Instruction::Reraise { .. })
+                                    }) && after_next.is_some_and(|(_, instruction)| {
+                                        matches!(instruction, Instruction::LoadGlobal { .. })
+                                    }) && after_after_next.is_some_and(|(_, instruction)| {
+                                        matches!(instruction, Instruction::CheckExcMatch)
+                                    })
+                                };
+                                let function_has_cleanup_reraise_to_sibling =
+                                    (0..num_instrs).any(|pc| {
+                                        matches!(
+                                            pyre_interpreter::decode_instruction_at(code, pc),
+                                            Some((Instruction::DeleteFast { .. }, _))
+                                        ) && cleanup_reraise_to_sibling(pc)
+                                    });
+                                if cleanup_reraise_to_sibling(py_pc)
+                                    || (catch_for_pc.get(py_pc).copied().flatten().is_some()
+                                        && function_has_cleanup_reraise_to_sibling)
+                                {
                                     emit_abort_permanent!(py_pc);
                                     continue;
                                 }

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -5498,7 +5498,7 @@ impl CodeWriter {
                 },
             build_slice_fn:
                 HelperHandle {
-                    idx: _build_slice_fn_idx,
+                    idx: build_slice_fn_idx,
                     flavor: _build_slice_fn_flavor,
                 },
             normalize_raise_varargs_fn:
@@ -5957,6 +5957,7 @@ impl CodeWriter {
                 store_attr_fn_idx,
                 build_map_from_array_fn_idx,
                 binary_slice_fn_idx,
+                build_slice_fn_idx,
                 delete_subscr_fn_idx,
                 delete_attr_fn_idx,
                 build_set_from_array_fn_idx,

--- a/pyre/pyre-jit/src/jit/flatten.rs
+++ b/pyre/pyre-jit/src/jit/flatten.rs
@@ -3314,6 +3314,15 @@ pub struct LoweringContext {
     /// `runtime_ops::binary_slice_values` (a user `__getitem__` fallback may
     /// force virtualizables → `MayForce`).
     pub binary_slice_fn_idx: u16,
+    /// `build_slice_fn` descrs-pool index — see codewriter.rs
+    /// `register_helper_fn_pointers` (`bind(assembler, cpu.build_slice_fn,
+    /// CallFlavor::Plain)`).  BUILD_SLICE records the `newslice(start, stop,
+    /// step)` HLOp (argc=2 synthesizes a None step at emit time) lowered to
+    /// `residual_call_ir_r(ConstInt(fn_idx), ListI([3]), ListR([start, stop,
+    /// step]), Descr) → reg` via [`lower_newslice_hlop_to_insn`];
+    /// `bh_build_slice_fn` runs `w_slice_new` (a fresh `W_SliceObject`
+    /// allocation, no user code → `Plain`).
+    pub build_slice_fn_idx: u16,
     /// `delete_subscr_fn` descrs-pool index — see codewriter.rs
     /// `register_helper_fn_pointers` (`bind(assembler, cpu.delete_subscr_fn,
     /// CallFlavor::MayForce)`).  DELETE_SUBSCR records the `delete_subscr(obj,
@@ -5100,6 +5109,9 @@ where
     if let Some(insn) = lower_binary_slice_hlop_to_insn(op, ctx, get_register, lower_constant) {
         return Some(insn);
     }
+    if let Some(insn) = lower_newslice_hlop_to_insn(op, ctx, get_register, lower_constant) {
+        return Some(insn);
+    }
     if let Some(insn) = lower_store_slice_hlop_to_insn(op, ctx, get_register, lower_constant) {
         return Some(insn);
     }
@@ -5514,6 +5526,57 @@ where
         vec![obj, start, stop],
         CallFlavor::MayForce,
         majit_ir::PyreHelperKind::None,
+        dst_reg,
+    ))
+}
+
+/// Lower the BUILD_SLICE pyre HLOp `newslice(start, stop, step)` → `result:
+/// Ref` to `residual_call_ir_r(ConstInt(build_slice_fn_idx), ListI([3]),
+/// ListR([start, stop, step]), Descr) → reg`.  `emit_frontend_newslice`
+/// always records three ref operands — BUILD_SLICE argc=2 synthesizes a None
+/// step at emit time — so the call is always the argc=3 shape
+/// `bh_build_slice_fn(3, start, stop, step)` = `w_slice_new(start, stop,
+/// step)`, a fresh `W_SliceObject` with no user code (`CallFlavor::Plain`).
+/// Operand-based (unlike the raw-register
+/// [`build_build_slice_fn_residual_call_ir_r_insn`]) so a constant slice
+/// bound — `lst[::-1]` lowers start/stop to `None` and step to `-1` — is
+/// representable.
+///
+/// Returns `None` for non-`newslice` opnames so the caller can fall through.
+pub fn lower_newslice_hlop_to_insn<F, LC>(
+    op: &super::flow::SpaceOperation,
+    ctx: &LoweringContext,
+    get_register: &mut F,
+    lower_constant: &mut LC,
+) -> Option<Insn>
+where
+    F: FnMut(super::flow::Variable) -> Register,
+    LC: FnMut(&Constant) -> Operand,
+{
+    if op.opname != "newslice" || op.args.len() != 3 {
+        return None;
+    }
+    let start = operand_for_value_arg(&op.args[0], get_register, lower_constant)?;
+    let stop = operand_for_value_arg(&op.args[1], get_register, lower_constant)?;
+    let step = operand_for_value_arg(&op.args[2], get_register, lower_constant)?;
+    let dst_reg = match &op.result {
+        Some(super::flow::FlowValue::Variable(var)) => get_register(*var),
+        _ => return None,
+    };
+    let effect_info = effect_info_for_call_flavor(CallFlavor::Plain);
+    let descr_operand = Operand::descr(DescrOperand::CallDescrStub(CallDescrStub {
+        effect_info,
+        arg_kinds: vec![Kind::Int, Kind::Ref, Kind::Ref, Kind::Ref],
+        result_kind: Some(Kind::Ref),
+    }));
+    Some(Insn::op_with_result(
+        "residual_call_ir_r",
+        vec![
+            Operand::ConstInt(ctx.build_slice_fn_idx as i64),
+            Operand::ListOfKind(ListOfKind::new(Kind::Int, vec![Operand::ConstInt(3)])),
+            Operand::ListOfKind(ListOfKind::new(Kind::Ref, vec![start, stop, step])),
+            descr_operand,
+        ],
         dst_reg,
     ))
 }
@@ -11064,6 +11127,7 @@ mod tests {
             store_attr_fn_idx: 95,
             build_map_from_array_fn_idx: 96,
             binary_slice_fn_idx: 97,
+            build_slice_fn_idx: 133,
             delete_subscr_fn_idx: 98,
             delete_attr_fn_idx: 99,
             build_set_from_array_fn_idx: 100,
@@ -11866,6 +11930,103 @@ mod tests {
                                 assert_eq!(stop.index, 105, "ListR[2] must be stop");
                             }
                             other => panic!("ListR must be [obj, start, stop], got {other:?}"),
+                        }
+                    }
+                    other => panic!("expected ListR, got {other:?}"),
+                }
+                assert_eq!(
+                    result,
+                    Some(Register {
+                        kind: Kind::Ref,
+                        index: 102
+                    }),
+                );
+            }
+            _ => panic!("expected Insn::Op, got {insn:?}"),
+        }
+    }
+
+    #[test]
+    fn lower_newslice_hlop_emits_build_slice_fn_residual() {
+        // `newslice(start, stop, step)` →
+        // `residual_call_ir_r(ConstInt(build_slice_fn_idx), ListI([3]),
+        // ListR([start, stop, step]), Descr) → reg`.  Always the argc=3 shape
+        // (`emit_frontend_newslice` synthesizes a None step for argc=2).
+        let start_var = Variable::new(VariableId(10), Kind::Ref);
+        let stop_var = Variable::new(VariableId(12), Kind::Ref);
+        let step_var = Variable::new(VariableId(14), Kind::Ref);
+        let result_var = Variable::new(VariableId(9), Kind::Ref);
+        let (ctx, _, _) = load_attr_lowering_fixture();
+        let op = super::super::flow::SpaceOperation::new(
+            "newslice",
+            vec![start_var.into(), stop_var.into(), step_var.into()],
+            Some(result_var.into()),
+            0,
+        );
+        let mut get_register = |var: Variable| match var.id {
+            VariableId(10) => Register {
+                kind: Kind::Ref,
+                index: 103,
+            },
+            VariableId(12) => Register {
+                kind: Kind::Ref,
+                index: 105,
+            },
+            VariableId(14) => Register {
+                kind: Kind::Ref,
+                index: 107,
+            },
+            VariableId(9) => Register {
+                kind: Kind::Ref,
+                index: 102,
+            },
+            _ => panic!("unexpected var id {:?}", var.id),
+        };
+        let mut lower_constant = super::flatten_constant_operand_for_test;
+        let insn = super::lower_newslice_hlop_to_insn(
+            &op,
+            &ctx,
+            &mut get_register,
+            &mut lower_constant,
+        )
+        .expect("3-arg newslice lowering must succeed");
+        match insn {
+            Insn::Op {
+                opname,
+                args,
+                result,
+            } => {
+                assert_eq!(opname, "residual_call_ir_r");
+                assert!(
+                    matches!(args[0], Operand::ConstInt(133)),
+                    "build_slice_fn pool index, got {:?}",
+                    args[0]
+                );
+                match &args[1] {
+                    Operand::ListOfKind(list) => {
+                        assert_eq!(list.kind, Kind::Int);
+                        assert!(
+                            matches!(list.content[..], [Operand::ConstInt(3)]),
+                            "argc list must be [3], got {:?}",
+                            list.content
+                        );
+                    }
+                    other => panic!("expected ListI argc, got {other:?}"),
+                }
+                match &args[2] {
+                    Operand::ListOfKind(list) => {
+                        assert_eq!(list.kind, Kind::Ref);
+                        match &list.content[..] {
+                            [
+                                Operand::Register(start),
+                                Operand::Register(stop),
+                                Operand::Register(step),
+                            ] => {
+                                assert_eq!(start.index, 103, "ListR[0] must be start");
+                                assert_eq!(stop.index, 105, "ListR[1] must be stop");
+                                assert_eq!(step.index, 107, "ListR[2] must be step");
+                            }
+                            other => panic!("ListR must be [start, stop, step], got {other:?}"),
                         }
                     }
                     other => panic!("expected ListR, got {other:?}"),

--- a/pyre/pyre-jit/src/jit/flatten.rs
+++ b/pyre/pyre-jit/src/jit/flatten.rs
@@ -11983,13 +11983,9 @@ mod tests {
             _ => panic!("unexpected var id {:?}", var.id),
         };
         let mut lower_constant = super::flatten_constant_operand_for_test;
-        let insn = super::lower_newslice_hlop_to_insn(
-            &op,
-            &ctx,
-            &mut get_register,
-            &mut lower_constant,
-        )
-        .expect("3-arg newslice lowering must succeed");
+        let insn =
+            super::lower_newslice_hlop_to_insn(&op, &ctx, &mut get_register, &mut lower_constant)
+                .expect("3-arg newslice lowering must succeed");
         match insn {
             Insn::Op {
                 opname,


### PR DESCRIPTION
Fixes five deterministic dynasm JIT miscompiles found by a fuzz sweep. Each is a
`jit_out != nojit_out` divergence on the same binary; NOJIT and CPython agree.

## C — `newslice` lowering panic (`ac78e884`)
An extended/negative-step slice in a hot loop (`lst[::-1]`) aborted the process
with `unimplemented opname "newslice"`. The `newslice` HLOp (BUILD_SLICE) had no
arm in the flatten lowering dispatch; the helper and builder existed but were
unwired. Added `lower_newslice_hlop_to_insn` emitting a `build_slice_fn`
residual.

## D — short-preamble export of a runtime-minted mutable cell (`0a894c78`)
A written module global's `LOAD_NAME` folds to a getfield on a runtime-minted
mutable name cell; a loop-tail read re-populated the field cache and
`produce_potential_short_preamble_ops` exported it as loop-invariant, so the
peeled body reused a stale value (wrong sign / wrong branch). Skip the
short-preamble export for a field/array whose descr is an out-of-universe
mutable cell, mirroring the invalidation `force_from_effectinfo` already applies.

## A — read-only global const-fold not invalidated in a bridge (`b1deddfa`)
A bridge that const-folds a read-only module global emitted
`GUARD_NOT_INVALIDATED` but dropped the optimizer's `quasi_immutable_deps`
before the module-dict version watcher could register them, so a mid-loop
reassign/`del` never invalidated the fold. `compile_bridge` now copies the deps
and `handle_fail`'s bridge-compiled arms register them. Function globals also
stop const-folding as CALL targets (a function can be rebound through its module
cell), taking the live guarded residual like mutable containers.

## B — walker-native DELETE_FAST except-reraise-sibling cleanup (`9af0718e`)
A named `except E as m:` that bare-re-raises compiles its cleanup to
`DELETE_FAST m; RERAISE`, followed by a sibling clause's `LOAD_GLOBAL;
CHECK_EXC_MATCH`. The walker-native bound continuation fell through into the
sibling type check with the current exception not re-seeded, so
`CHECK_EXC_MATCH` peeked a null operand (null-operand crash, silent miscount, or
an Int/Ref register-kind assembler panic). Detect this shape and
`abort_permanent` it; plain `del` and single-clause `except as` still compile.

## E — nested-loop secondary-edge break bridge resume (`ab6a864f`, doc `e64cffa3`)
A nested inner `for` break — `POP_TOP` popping the inner iterator then a
`JUMP_BACKWARD` to the enclosing `FOR_ITER` — miscompiles when the break lands
on the secondary edge of its inner-loop guard: the break edge becomes a guard
side-exit whose bridge resume snapshot mis-maps the outer iterator slot, so the
resumed `FOR_ITER` dereferences a non-iterator (SIGSEGV / `not an iterator`).
Detect the two secondary-edge guard shapes (a `POP_JUMP_IF_TRUE` in the guard,
or a `POP_JUMP_IF_FALSE` whose forward jump-target is the break) and decline the
frame to the interpreter via a new `UnsupportedJitShape::NestedBreakBridgeResume`.
The plain `if cond: break` idiom (a `POP_JUMP_IF_FALSE` whose fall-through is the
break) still compiles.

B and E land as targeted declines rather than the deeper walker/bridge-resume
repairs, which did not converge; the compiled default path is correct for every
other shape.

## Verification
- `python ./pyre/check.py --backend dynasm` → `ALL PASSED` (221/221).
- Per-cluster family sweeps (scratchpad, not committed): newslice / short-preamble
  / bridge-global-fold / DELETE_FAST-reraise all clean; nested-break across 412
  cases (single, modulus-fragility, compound and/or, for/while/try nesting) →
  0 crash, 0 wrong; common `if cond: break` / `if a and b: break` still compile.
- Synth regression benches added: `named_reraise_sibling_hot`,
  `nested_break_not_hot` (plus C/D/A benches from their commits).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
