### PR TITLE
jit: PR#607 review follow-ups — abort/bridge decline reclassification, exc-descr-gated seeding, P2 local-dst seed, w_class init

### DIFF
--- a/majit/majit-gc/src/rewrite.rs
+++ b/majit/majit-gc/src/rewrite.rs
@@ -1093,25 +1093,25 @@ impl GcRewriterImpl {
                 // emit a NULL typeptr.
                 if vtable != 0 {
                     self.gen_initialize_vtable(obj_ref.clone(), vtable, vtable_fd_ref, st);
-                    // Upstream rewrite.py:479-484 rewrites NEW_WITH_VTABLE
-                    // into allocation plus full header initialization. Pyre's
-                    // object layout carries a separate `w_class` Python-class pointer
-                    // alongside the vtable; interpreter, blackhole, and deopt-materialize
-                    // paths all write it, so compiled allocations must too or trace-time
-                    // GuardValue(w_class) folds fail deterministically on trace-made objects.
-                    if let Some(w_class) = descr.w_class_obj() {
-                        if w_class != 0 {
-                            if let Some(w_class_fd) =
-                                descr.gc_fielddescrs().iter().find(|fd| fd.is_w_class())
-                            {
-                                self.gen_initialize_w_class(
-                                    obj_ref.clone(),
-                                    w_class,
-                                    w_class_fd.as_ref(),
-                                    st,
-                                );
-                            }
-                        }
+                }
+            }
+            // Upstream rewrite.py:479-484 rewrites NEW_WITH_VTABLE into allocation
+            // plus full header initialization. Pyre's object layout carries a
+            // separate `w_class` Python-class pointer alongside the vtable;
+            // interpreter, blackhole, and deopt-materialize paths all write it,
+            // so compiled allocations must too or trace-time GuardValue(w_class)
+            // folds fail deterministically on trace-made objects.
+            if let Some(w_class) = descr.w_class_obj() {
+                if w_class != 0 {
+                    if let Some(w_class_fd) =
+                        descr.gc_fielddescrs().iter().find(|fd| fd.is_w_class())
+                    {
+                        self.gen_initialize_w_class(
+                            obj_ref.clone(),
+                            w_class,
+                            w_class_fd.as_ref(),
+                            st,
+                        );
                     }
                 }
             }
@@ -1140,7 +1140,7 @@ impl GcRewriterImpl {
         // per GC-pointer field (`descr.gc_fielddescrs` / unpack_fielddescr).
         let entries = st.delayed_zero_setfields(&result);
         for fd in descr.gc_fielddescrs() {
-            if fd.is_w_class() {
+            if fd.is_w_class() && descr.w_class_obj().is_some_and(|w| w != 0) {
                 continue;
             }
             entries.insert(fd.offset() as i64);
@@ -3194,6 +3194,7 @@ mod tests {
         size: usize,
         type_id: u32,
         vtable: usize,
+        w_class: Option<i64>,
         headerless: bool,
         gc_fields: Vec<Arc<dyn FieldDescr>>,
     }
@@ -3219,6 +3220,9 @@ mod tests {
         }
         fn vtable(&self) -> usize {
             self.vtable
+        }
+        fn w_class_obj(&self) -> Option<i64> {
+            self.w_class
         }
         fn headerless(&self) -> bool {
             self.headerless
@@ -3250,6 +3254,32 @@ mod tests {
         }
         fn field_type(&self) -> Type {
             self.field_type
+        }
+    }
+
+    #[derive(Debug)]
+    struct TestWClassFieldDescr {
+        offset: usize,
+    }
+
+    impl Descr for TestWClassFieldDescr {
+        fn as_field_descr(&self) -> Option<&dyn FieldDescr> {
+            Some(self)
+        }
+    }
+
+    impl FieldDescr for TestWClassFieldDescr {
+        fn offset(&self) -> usize {
+            self.offset
+        }
+        fn field_size(&self) -> usize {
+            8
+        }
+        fn field_type(&self) -> Type {
+            Type::Ref
+        }
+        fn field_name(&self) -> &str {
+            "w_class"
         }
     }
 
@@ -3367,6 +3397,7 @@ mod tests {
             size,
             type_id,
             vtable: 0,
+            w_class: None,
             headerless: false,
             gc_fields: Vec::new(),
         })
@@ -3377,6 +3408,7 @@ mod tests {
             size,
             type_id,
             vtable: 0,
+            w_class: None,
             headerless: true,
             gc_fields: Vec::new(),
         })
@@ -3391,6 +3423,24 @@ mod tests {
             size,
             type_id,
             vtable: 0,
+            w_class: None,
+            headerless: false,
+            gc_fields,
+        })
+    }
+
+    fn size_descr_with_w_class(
+        size: usize,
+        type_id: u32,
+        vtable: usize,
+        w_class: Option<i64>,
+        gc_fields: Vec<Arc<dyn FieldDescr>>,
+    ) -> DescrRef {
+        Arc::new(TestSizeDescr {
+            size,
+            type_id,
+            vtable,
+            w_class,
             headerless: false,
             gc_fields,
         })
@@ -3401,6 +3451,7 @@ mod tests {
             size,
             type_id,
             vtable,
+            w_class: None,
             headerless: false,
             gc_fields: Vec::new(),
         })
@@ -3758,6 +3809,10 @@ mod tests {
         })
     }
 
+    fn w_class_field_descr_at(offset: usize) -> Arc<dyn FieldDescr> {
+        Arc::new(TestWClassFieldDescr { offset })
+    }
+
     /// rewrite.py:499-500 + rewrite.py:761-766 — malloc_zero_filled=true
     /// short-circuits `clear_gc_fields`, so NEW emits no pending NULL
     /// stores at the next flush point.  Mirrors pyre's production
@@ -4100,6 +4155,73 @@ mod tests {
                 .inline_const_bits()
                 .expect("inline ConstInt"),
             0xDEAD_i64
+        );
+    }
+
+    #[test]
+    fn test_new_with_vtable_initializes_w_class_without_vtable_store() {
+        let mut rw = make_rewriter();
+        rw.fielddescr_vtable = None;
+        rw.malloc_zero_filled = false;
+        let w_class = 0xCAFE;
+        let ops = vec![
+            Op::with_descr(
+                OpCode::NewWithVtable,
+                &[],
+                size_descr_with_w_class(48, 3, 0, Some(w_class), vec![w_class_field_descr_at(16)]),
+            ),
+            Op::new(OpCode::Jump, &[]),
+        ];
+
+        let (result, _constants, gcrefs) = rw.rewrite_for_gc_with_constants(&ops, &ConstMap::new());
+
+        assert_eq!(gcrefs, vec![GcRef(w_class as usize)]);
+        assert!(
+            result.iter().any(|o| o.opcode == OpCode::LoadFromGcTable),
+            "non-null w_class constant must be routed through the GC table"
+        );
+        let w_class_stores: Vec<_> = result
+            .iter()
+            .filter(|o| o.opcode == OpCode::GcStore)
+            .filter(|o| o.arg(1).to_opref().inline_const_bits() == Some(16))
+            .collect();
+        assert_eq!(
+            w_class_stores.len(),
+            1,
+            "w_class must be initialized once and not followed by a delayed zero store: {result:?}"
+        );
+        assert_ne!(
+            w_class_stores[0].arg(2).to_opref().inline_const_bits(),
+            Some(0),
+            "w_class initialization must not be a NULL delayed-zero store"
+        );
+    }
+
+    #[test]
+    fn test_clear_gc_fields_zeros_w_class_without_init_value() {
+        let mut rw = make_rewriter();
+        rw.fielddescr_vtable = None;
+        rw.malloc_zero_filled = false;
+        let ops = vec![
+            Op::with_descr(
+                OpCode::NewWithVtable,
+                &[],
+                size_descr_with_w_class(48, 3, 0, None, vec![w_class_field_descr_at(16)]),
+            ),
+            Op::new(OpCode::Jump, &[]),
+        ];
+
+        let (result, _constants, _gcrefs) =
+            rw.rewrite_for_gc_with_constants(&ops, &ConstMap::new());
+
+        assert!(
+            result.iter().any(|o| {
+                o.opcode == OpCode::GcStore
+                    && o.arg(1).to_opref().inline_const_bits() == Some(16)
+                    && o.arg(2).to_opref().inline_const_bits() == Some(0)
+                    && o.arg(3).to_opref().inline_const_bits() == Some(8)
+            }),
+            "w_class field without an init value must be included in delayed-zero stores: {result:?}"
         );
     }
 

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -4951,6 +4951,7 @@ impl<S: JitState> JitDriver<S> {
         // can apply bridge-only behavior without overloading
         // `has_compiled_targets_fn` presence.
         ctx.is_bridge_trace = true;
+        ctx.set_bridge_source_is_exception_guard(retrace.is_exception_guard);
         ctx.bridge_target_header_pc = parent_header_pc;
         ctx.has_compiled_targets_fn = Some(Box::new(move |gk: u64| -> bool {
             let meta = unsafe { &*(meta_ptr as *const crate::pyjitpl::MetaInterp<S::Meta>) };

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -9475,13 +9475,12 @@ impl<M: Clone> MetaInterp<M> {
             .expect("must_compile_with_values: descr_arc must be a FailDescr");
         let trace_id = descr_fd.trace_id();
         let fail_index = descr_fd.fail_index_per_trace();
-        // A guard whose bridge a terminal-declining backend
-        // (`bridge_decline_is_terminal()`) already refused as structurally
-        // `Unsupported` must not re-fire — re-tracing rebuilds the same
-        // unsupported bridge forever (a compile storm). Native backends never
-        // populate this set (their declines are transient), so this only ever
-        // short-circuits wasm guards. Fall back to the blackhole resume the
-        // dormant path always used for this guard.
+        // A guard whose bridge was refused by a terminal-declining backend
+        // (`bridge_decline_is_terminal()`, currently wasm) or by a structural
+        // full-body-walk decline must not re-fire: re-tracing rebuilds the same
+        // unsupported bridge forever. Transient backend and walker aborts do
+        // not populate this set. Fall back to the blackhole resume the dormant
+        // path always used for this guard.
         if self
             .declined_bridge_guards
             .contains(&(trace_id, fail_index))

--- a/majit/majit-metainterp/src/trace_ctx.rs
+++ b/majit/majit-metainterp/src/trace_ctx.rs
@@ -519,6 +519,11 @@ pub struct TraceCtx {
     /// (a static trait method with no metainterp access) can map each
     /// decoded frame value to its sym slot via `reg_idx - identity_base`.
     pub(crate) bridge_reg_indices: Option<crate::resume::FrameLivenessRegIndices>,
+    /// Whether the source guard descr for this bridge is a
+    /// ResumeGuardExcDescr analog. Set by `start_bridge_tracing` from
+    /// `descr_arc.is_guard_exc()` and read by static bridge setup/walkers
+    /// that only receive `TraceCtx`.
+    pub(crate) bridge_source_is_exception_guard: bool,
 }
 
 /// A decoded-but-not-yet-built description of one inlined
@@ -1218,6 +1223,7 @@ impl TraceCtx {
             virtualref_boxes: Vec::new(),
             bridge_inline_carrier: None,
             bridge_reg_indices: None,
+            bridge_source_is_exception_guard: false,
         }
     }
 
@@ -1293,6 +1299,7 @@ impl TraceCtx {
             virtualref_boxes: Vec::new(),
             bridge_inline_carrier: None,
             bridge_reg_indices: None,
+            bridge_source_is_exception_guard: false,
         }
     }
 
@@ -1322,6 +1329,17 @@ impl TraceCtx {
     /// value (laid out int-bank then ref-bank then float) to its sym slot.
     pub fn bridge_reg_indices(&self) -> Option<&crate::resume::FrameLivenessRegIndices> {
         self.bridge_reg_indices.as_ref()
+    }
+
+    /// Mark whether this bridge's source guard is an exception guard
+    /// (`ResumeGuardExcDescr` / `ResumeGuardCopiedExcDescr` analog).
+    pub fn set_bridge_source_is_exception_guard(&mut self, is_exception_guard: bool) {
+        self.bridge_source_is_exception_guard = is_exception_guard;
+    }
+
+    /// True only for bridge traces sourced from an exception guard descr.
+    pub fn bridge_source_is_exception_guard(&self) -> bool {
+        self.bridge_source_is_exception_guard
     }
 
     /// Get or create a constant OpRef for a given i64 value.

--- a/pyre/bench/synth/p2_local_result_bridge.py
+++ b/pyre/bench/synth/p2_local_result_bridge.py
@@ -1,0 +1,33 @@
+# Regression guard for P2 root result seeding when the residual-call result is
+# stored into a root local slot.  The late type flip forces a guard failure in
+# the inlined callee chain; the root stores the returned value in `x` before
+# using it so the P2 drain must keep the local-slot result live for the bridge
+# walk.
+N = 300000
+FLIP_AT = 200000
+
+
+def leaf(x):
+    if x < 3:
+        return x + 10
+    return x * 2
+
+
+def middle(x):
+    return leaf(x) + 1
+
+
+def main():
+    acc = 0.0
+    i = 0
+    while i < N:
+        arg = i % 5
+        if i >= FLIP_AT:
+            arg = float(arg)
+        x = middle(arg)
+        acc = acc + x
+        i = i + 1
+    return acc
+
+
+print(main())

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -2660,12 +2660,16 @@ fn dispatch_switch_id(
 /// **Production wiring**: the full-body-walk walker
 /// (`full_body_walk_trace`) is the caller, dispatching each JitCode
 /// opcode through this entry as it walks the body.
-fn seed_standing_exception_for_walk(
-    sym: &mut crate::state::PyreSym,
-    trace_ctx: &mut TraceCtx,
-    concrete_frame_addr: usize,
-) {
+///
+/// Bridge exception seeding follows `pyjitpl.py:3125-3173`: only a
+/// `ResumeGuardExcDescr`/`ResumeGuardCopiedExcDescr` source guard carries
+/// exception state into bridge tracing. Operand-stack values are never scanned
+/// to infer a standing exception.
+fn seed_standing_exception_for_walk(sym: &mut crate::state::PyreSym, trace_ctx: &mut TraceCtx) {
     if !sym.last_exc_box.is_none() {
+        return;
+    }
+    if trace_ctx.is_bridge_trace && !trace_ctx.bridge_source_is_exception_guard() {
         return;
     }
 
@@ -2691,33 +2695,7 @@ fn seed_standing_exception_for_walk(
         sym.last_exc_value = current;
         sym.last_exc_box = exc_box;
         sym.class_of_last_exc_is_const = true;
-        return;
     }
-
-    if concrete_frame_addr == 0 {
-        return;
-    }
-    let frame = unsafe { &*(concrete_frame_addr as *const pyre_interpreter::pyframe::PyFrame) };
-    if frame.locals_cells_stack_w.is_null() {
-        return;
-    }
-    let nlocals = crate::state::concrete_nlocals(concrete_frame_addr).unwrap_or(0);
-    let stack_top = frame.valuestackdepth.min(frame.locals_w().len());
-    let Some(exc) = frame.locals_w().as_slice()[nlocals.min(stack_top)..stack_top]
-        .iter()
-        .rev()
-        .copied()
-        .find(|obj| !obj.is_null() && unsafe { pyre_object::is_exception(*obj) })
-    else {
-        return;
-    };
-
-    let exc_box = trace_ctx.const_ref(exc as i64);
-    sym.current_exc_value = exc;
-    sym.current_exc_box = exc_box;
-    sym.last_exc_value = exc;
-    sym.last_exc_box = exc_box;
-    sym.class_of_last_exc_is_const = true;
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -2805,7 +2783,7 @@ pub fn dispatch_via_miframe(
     // references it (use-before-def).  Seed here — the trait's pre-guard
     // cache-once analog — so every guard snapshot reads a real EC OpRef.
     seed_execution_context_for_walk(sym, trace_ctx);
-    seed_standing_exception_for_walk(sym, trace_ctx, concrete_frame_addr);
+    seed_standing_exception_for_walk(sym, trace_ctx);
 
     // RPython parity: `metainterp.last_exc_value` (pyjitpl.py:1695)
     // is the standing exception OpRef. Walker's `WalkContext::last_exc_value`

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -7933,56 +7933,38 @@ fn materialize_bridge_virtual(
     }
 }
 
-/// ResumeGuardExcDescr analog for bridge walks that start inside an
-/// already-entered exception handler.
+/// ResumeGuardExcDescr analog for bridge walks.
 ///
 /// `setup_bridge_sym` runs after guard-failure resume has rebuilt the live
-/// frame and restored the execution-context exception slot. If the raise that
-/// reached the handler was delivered by blackhole replay, it was not recorded
-/// in the bridge trace, so `sym.last_exc_box` is still empty even though the
-/// handler's first jitcode ops (`last_exception`, `last_exc_value`, `reraise`)
-/// require RPython's standing `metainterp.last_exc_value`. Seed the standing
-/// slot from the restored current exception only when it is a real exception
-/// object and the walk has not already seeded an in-trace raise.
+/// frame. Per `pyjitpl.py:3125-3173`, only a
+/// ResumeGuardExcDescr/ResumeGuardCopiedExcDescr source guard carries the
+/// pending exception into bridge tracing. Non-exception guards do not seed
+/// standing exception state, and operand-stack values are never scanned to
+/// infer one.
 fn seed_bridge_standing_exception_from_current(
     sym: &mut PyreSym,
     ctx: &mut majit_metainterp::TraceCtx,
-    semantic_mirror: &[OpRef],
-    live_slot_values: &[Value],
-    nlocals: usize,
 ) {
+    if !ctx.bridge_source_is_exception_guard() {
+        return;
+    }
     if !sym.last_exc_box.is_none() {
         return;
     }
 
     let mut exc = sym.current_exc_value;
-    let mut exc_box = sym.current_exc_box;
+    let exc_box = sym.current_exc_box;
     if exc.is_null() || !unsafe { pyre_object::is_exception(exc) } {
         let current = pyre_interpreter::eval::get_current_exception();
         if !current.is_null() && unsafe { pyre_object::is_exception(current) } {
             exc = current;
         } else {
-            let stack_exc = semantic_mirror
-                .iter()
-                .enumerate()
-                .skip(nlocals)
-                .rev()
-                .find_map(|(slot, &opref)| {
-                    let value = live_slot_values.get(slot)?;
-                    let Value::Ref(majit_ir::GcRef(ptr)) = value else {
-                        return None;
-                    };
-                    let obj = *ptr as pyre_object::PyObjectRef;
-                    if obj.is_null() || !unsafe { pyre_object::is_exception(obj) } {
-                        return None;
-                    }
-                    Some((obj, opref))
-                });
-            let Some((stack_exc, stack_opref)) = stack_exc else {
-                return;
-            };
-            exc = stack_exc;
-            exc_box = stack_opref;
+            sym.current_exc_value = std::ptr::null_mut();
+            sym.current_exc_box = OpRef::NONE;
+            sym.last_exc_value = std::ptr::null_mut();
+            sym.last_exc_box = OpRef::NONE;
+            sym.class_of_last_exc_is_const = false;
+            return;
         }
     }
 
@@ -8891,13 +8873,7 @@ impl JitState for PyreJitState {
                 }
             }
         }
-        seed_bridge_standing_exception_from_current(
-            sym,
-            ctx,
-            &semantic_mirror,
-            &live_local_values,
-            nlocals,
-        );
+        seed_bridge_standing_exception_from_current(sym, ctx);
         sym.registers_r = semantic_mirror;
         sym.symbolic_local_types = {
             let mut types = bridge_local_types.clone();

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -913,15 +913,21 @@ fn residual_ref_call_dst_before(code: &[u8], entry: usize) -> Option<usize> {
 /// reconstructed-frame walk plumbing before result-threading + the root walk
 /// are wired. The compile leg is unconditional.
 /// Thread a reconstructed callee's `SubReturn` value into the root portal's
-/// operand-stack result register so the subsequent root walk
-/// (`run_perfn_walk`'s bridge seeding) reads it as the call result at `root_pc`.
+/// residual-call result register so the subsequent root walk reads it as the
+/// call result at `root_pc`.
 ///
 /// `make_result_of_lastop` writes the result to the residual-call body's
 /// trailing `>r` destination byte, so use that register when the call ending at
 /// `root_pc` can be decoded.  Fall back to the codewriter-baked result-color
 /// trivia twin keyed by the call's JitCode pc for older shapes that lack the
-/// canonical residual-call encoding.  Returns `false` (caller declines the
-/// compile) when the register is unresolved.
+/// canonical residual-call encoding.
+///
+/// The result is always mirrored into `bridge_registers_r` for interior-entry
+/// bridge walks, whose Ref-bank seed is color-indexed.  Opcode-entry bridge
+/// walks rebuild slot-indexed locals and operand-stack values from
+/// `bridge_local_oprefs` / `bridge_stack_oprefs`, so mirror the destination
+/// there too.  Returns `false` (caller declines the compile) when the register
+/// is unresolved.
 fn inject_root_call_result(sym: &mut PyreSym, root_pc: usize, result: majit_ir::OpRef) -> bool {
     if sym.jitcode.is_null() {
         return false;
@@ -944,7 +950,14 @@ fn inject_root_call_result(sym: &mut PyreSym, root_pc: usize, result: majit_ir::
         }
         bridge_regs[result_reg] = result;
     }
-    if result_reg >= nlocals {
+    if result_reg < nlocals {
+        if let Some(ref mut locals) = sym.bridge_local_oprefs {
+            if locals.len() <= result_reg {
+                locals.resize(result_reg + 1, majit_ir::OpRef::NONE);
+            }
+            locals[result_reg] = result;
+        }
+    } else {
         let slot = result_reg - nlocals;
         let bridge = sym.bridge_stack_oprefs.get_or_insert_with(Vec::new);
         if bridge.len() <= slot {

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -129,8 +129,7 @@ fn fbw_bridge_decline(ctx: &TraceCtx) {
     }
 }
 
-fn p2_drain_abort(ctx: &TraceCtx) -> TraceAction {
-    fbw_bridge_decline(ctx);
+fn p2_drain_abort() -> TraceAction {
     TraceAction::Abort
 }
 
@@ -995,7 +994,12 @@ fn drive_bridge_carrier_walk(
     }
     let Some(recipe) = carrier.recipes.last() else {
         crate::jitcode_dispatch::census_record("P2Drain::NoRecipes");
-        return p2_drain_abort(ctx);
+        // Churn guard (Task 8): making this class transient retried the same
+        // guard 500 times in depth2_inline_chain_typeflip.py and
+        // p2_local_result_bridge.py (loops_aborted 6 -> 505), so keep only
+        // this measured P2 class permanently declined.
+        fbw_bridge_decline(ctx);
+        return p2_drain_abort();
     };
 
     let pre_pos = ctx.get_trace_position();
@@ -1009,12 +1013,12 @@ fn drive_bridge_carrier_walk(
     else {
         ctx.cut_trace(pre_pos);
         crate::jitcode_dispatch::census_record("P2Drain::SetupFailed");
-        return p2_drain_abort(ctx);
+        return p2_drain_abort();
     };
     let Some(callee_pjc) = crate::state::pyjitcode_for_code(recipe.code_ptr) else {
         ctx.cut_trace(pre_pos);
         crate::jitcode_dispatch::census_record("P2Drain::NoCalleePjc");
-        return p2_drain_abort(ctx);
+        return p2_drain_abort();
     };
     let entry = select_recipe_entry(
         recipe.jitcode_index,
@@ -1024,7 +1028,7 @@ fn drive_bridge_carrier_walk(
     let Some(entry) = entry else {
         ctx.cut_trace(pre_pos);
         crate::jitcode_dispatch::census_record("P2Drain::NoCalleeEntry");
-        return p2_drain_abort(ctx);
+        return p2_drain_abort();
     };
     let callee_w_globals = crate::state::recover_inline_callee_globals(recipe.code_ptr) as usize;
     // The reconstructed callee's local slot concretes (`recipe.concrete_r` is
@@ -1117,7 +1121,7 @@ fn drive_bridge_carrier_walk(
     // pre-walk heap rather than dropping the journals (which would leave every
     // eager store standing to be applied a second time).
     crate::jitcode_dispatch::fbw_store_journal_rollback();
-    p2_drain_abort(ctx)
+    p2_drain_abort()
 }
 
 /// Shape A orthodox multi-frame bridge resume: the escape-hatch driver for a
@@ -1552,7 +1556,7 @@ fn run_perfn_walk(
         sidecar_entry
     } else {
         // Every non-entry resume carries its own JitCode coordinate. Without
-        // one the existing `None` path below declines the walk.
+        // one the site-specific decline below rejects the walk.
         None
     };
     let Some(pc_map_entry) = pc_map_entry else {
@@ -3285,7 +3289,6 @@ fn full_body_walk_trace(
             if crate::jitcode_dispatch::fbw_debug_abort_enabled() {
                 eprintln!("[fbw-abort] start_pc={start_pc} run_perfn_walk returned None");
             }
-            fbw_bridge_decline(ctx);
             TraceAction::Abort
         }
     }

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -91,15 +91,10 @@ fn finish_trace_namespace_dependency(meta: &mut MetaInterp<PyreMeta>) {
 }
 
 thread_local! {
-    /// Green keys whose full-body walk failed on a structural walker
-    /// limitation (the recurring `DispatchError` classes listed in
-    /// `full_body_walk_trace`).  A retrace of such a key skips the walk and
-    /// re-interprets without JIT instead of re-walking and re-failing every
-    /// hot encounter; the location stays trace-eligible (not
-    /// `DONT_TRACE_HERE`), so upstream's invariant that an abort never marks a
-    /// location untraceable (pyjitpl.py:2392 aborted_tracing) holds.  A walker
-    /// improvement that closes one of those `DispatchError` classes shrinks
-    /// this set.
+    /// Green keys whose full-body walk deterministically re-reaches a
+    /// structural walk decline that must skip future walks of the same entry.
+    /// This set is intentionally narrow: transient walker capability gaps
+    /// return a plain abort and rely on the normal hotness/abort machinery.
     static FBW_DECLINED_KEYS: std::cell::RefCell<std::collections::HashSet<u64>> =
         std::cell::RefCell::new(std::collections::HashSet::new());
     /// FOR_ITER green keys whose range-only specialization observed a class
@@ -3220,19 +3215,11 @@ fn full_body_walk_trace(
             }
         },
         Some((_entry, _code_len, Err(e))) => {
-            // Structural walker limitations recur identically on every
-            // retrace of this location (the same jitcode walked from the same
-            // entry produces the same error), so record the key in
-            // `FBW_DECLINED_KEYS` instead of thrashing futile deep re-walks —
-            // each of which executes the body's residual calls concretely
-            // before failing at the unsupported resume / exception / closure
-            // shape.  `FBW_DECLINED_KEYS` is a permanent per-process decline:
-            // the key re-interprets without tracing.  These are the
-            // multi-session-blocked shapes (resume snapshot #124,
-            // exception-handler resume #51c, closure NULL-self #60, unported
-            // raise marker, a residual arg register the walk never binds);
-            // other errors retain the plain `Abort` without declining so a
-            // capability that lands mid-run can still pick the location up.
+            // Record the key in `FBW_DECLINED_KEYS` only for errors that
+            // deterministically re-reach a structural decline of the same
+            // entry.  Transient walker capability gaps retain the plain
+            // `Abort` without declining so a capability that lands mid-run can
+            // still pick the location up.
             use crate::jitcode_dispatch::DispatchError as DE;
             crate::jitcode_dispatch::census_record(e.variant_name());
             if crate::jitcode_dispatch::fbw_debug_abort_enabled() {
@@ -3250,17 +3237,14 @@ fn full_body_walk_trace(
                 // location can never trace soundly — interpret it permanently
                 // (the loop runs correctly under the interpreter).
                 DE::InplaceContainerMutationUnsupported { .. } => TraceAction::AbortPermanent,
-                DE::AbortPermanentMarkerReached { .. }
-                | DE::GuardSnapshotVableUntyped { .. }
+                DE::AbortPermanentMarkerReached { .. } => TraceAction::AbortPermanent,
+                DE::GuardSnapshotVableUntyped { .. }
                 | DE::MayForceNullRefArgUnsupported { .. }
                 | DE::BranchGuardKeptStackUnsupported { .. }
                 | DE::NonStandardVableFinishPortalUnsupported { .. }
                 | DE::LoopBearingCalleeInlineUnsupported { .. }
                 | DE::UnfoldableListAppendResidualUnsupported { .. }
-                | DE::ResidualCallArgUnbound { .. } => {
-                    fbw_decline(crate::driver::make_green_key(w_code, start_pc));
-                    TraceAction::Abort
-                }
+                | DE::ResidualCallArgUnbound { .. } => TraceAction::Abort,
                 // #68 multiframe (`PYRE_FBW_INLINE_MULTIFRAME`): a data-dependent
                 // `goto_if_not` whose branch input is not concrete at trace-time
                 // recurs identically on every retrace of this entry (the same


### PR DESCRIPTION
Follow-ups to #607: the Task #6 S3 abort-decline reclassification plus fixes for every verified finding from #607's code reviews (the codex inline P1 and the parity report §1/§2).

## Commits

- **Reclassify full-body-walk abort declines** — upstream has no permanent per-location penalty for tracing aborts (`can_never_inline` is static, warmstate.py:795-805; other aborts only re-climb the threshold, pyjitpl.py:2392). `AbortPermanentMarkerReached` moves to `AbortPermanent` (the `can_never_inline` analog); seven transient capability-gap classes become plain `Abort` without the permanent `FBW_DECLINED_KEYS` record, bounded by the existing abort ceiling.
- **Mirror P2 local root results into bridge locals** — review P1: `inject_root_call_result` wrote a local-dst result only into the color-indexed `bridge_registers_r`, which opcode-entry bridge walks never read (they rebuild locals from `bridge_local_oprefs`). Empirically all probed P2 carriers enter interior (`bridge_registers_r` consumed), so no wrong output was reproducible; the mirror closes the opcode-entry leg and a new deterministic bench (`p2_local_result_bridge.py`) covers the local-dst P2 shape.
- **Initialize w_class independently of vtable store** — parity §2: `w_class` initialization was nested under `fielddescr_vtable`/`vtable != 0`, leaving a valid `w_class` uninitialized for vtable-less descrs; `clear_gc_fields` now exempts `w_class` from delayed NULL stores only when a nonzero initializer exists. Latent only under the default zero-filled nursery; covered by new majit-gc unit tests.
- **Limit P2 bridge declines to structural aborts** — parity §1.3: every P2 carrier-walk abort permanently suppressed the guard's future bridges via `declined_bridge_guards`; upstream leaves the guard eligible and bounds retries through `jitcounter.tick`'s reset-on-fire re-climb (counter.py:199-200). P2 drain aborts are now transient; the three structural `run_perfn_walk` decline sites stay permanent. Measured exception: all-transient made `P2Drain::NoRecipes` retry 500× (loops_aborted 6→505 on `depth2_inline_chain_typeflip`/`p2_local_result_bridge`), so that single class keeps the permanent decline with the evidence in a comment.
- **Gate bridge exception seeding on guard descr** — parity §1.1/§1.2: both exception seeds ran unconditionally and fell back to scanning operand-stack values for exception-shaped objects, which upstream never does (pyjitpl.py:3125-3173: only `ResumeGuardExcDescr`/`ResumeGuardCopiedExcDescr` failures carry the pending exception; non-exc guards assert none). The source guard's `is_guard_exc()` bit is threaded through `TraceCtx`; bridge seeding is gated on it with `clear_exception` parity, and both operand-stack scans are deleted. A pre-change probe confirmed no corpus test depends on either scan.

## Validation

Each commit was validated at land time: check.py dynasm 218/218, cranelift 218/218, wasm 217/217; `cargo test -p pyre-jit-trace -p majit-metainterp -p majit-gc`; `cargo fmt --check`. After the final rebase onto current main (#600/#626), dynasm 218/218 + unit tests re-verified locally; abort-churn timings on the P2/kept-stack benches stayed at baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
