### PR TITLE
jit: register missing #[pyre_class] GC-offsets (immortal iterators + deque backing list)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1421,6 +1421,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "linkme"
+version = "0.3.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83272d46373fb8decca684579ac3e7c8f3d71d4cc3aa693df8759e260ae41cf"
+dependencies = [
+ "linkme-impl",
+]
+
+[[package]]
+name = "linkme-impl"
+version = "0.3.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32d59e20403c7d08fe62b4376edfe5c7fb2ef1e6b1465379686d0f21c8df444b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2155,6 +2175,7 @@ dependencies = [
  "crc32fast",
  "indexmap",
  "libc",
+ "linkme",
  "lz4_flex",
  "majit-gc",
  "majit-ir",
@@ -2267,6 +2288,7 @@ name = "pyre-object"
 version = "0.0.2"
 dependencies = [
  "indexmap",
+ "linkme",
  "majit-gc",
  "majit-macros",
  "malachite-bigint",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -115,6 +115,9 @@ proc-macro2 = "1"
 
 # data structures
 smallvec = "1"
+# link-section distributed slice: `#[pyre_class]` appends each type's GC
+# descriptor to a whole-program slice the JIT driver checks for completeness.
+linkme = "0.3"
 
 # cranelift backend
 cranelift-codegen = "0.132"

--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -16539,15 +16539,11 @@ impl majit_backend::Backend for CraneliftBackend {
     /// llmodel.py:775 bh_new(sizedescr) → gc_ll_descr.gc_malloc(sizedescr).
     fn bh_new(&self, sizedescr: &majit_translate::jitcode::BhDescr) -> i64 {
         let size = sizedescr.as_size();
-        // TODO: `BhDescr.get_type_id()` returns the
-        // u64 `path_hash` cache key, but `gc.alloc_nursery_typed`
-        // expects a u32 GC tid (allocated by `gc_cache.next_struct_tid`).
-        // Truncating loses gc identity; the structural fix is to route
-        // through `gc_cache.get_size_descr` here and use the resolved
-        // descr's allocated tid.
+        // `resolve_gc_tid` routes the serialized `path_hash` cache key back
+        // through `gc_cache` to the allocated dense GC tid; the raw key read
+        // as a tid loses gc identity and indexes past the type table.
         match with_cranelift_gc(|gc| {
-            gc.alloc_nursery_typed(sizedescr.get_type_id() as u32, size)
-                .0 as i64
+            gc.alloc_nursery_typed(sizedescr.resolve_gc_tid(), size).0 as i64
         }) {
             Some(ptr) => ptr,
             None => {
@@ -16563,7 +16559,7 @@ impl majit_backend::Backend for CraneliftBackend {
     fn bh_new_with_vtable(&self, sizedescr: &majit_translate::jitcode::BhDescr) -> i64 {
         let size = sizedescr.as_size();
         let vtable = sizedescr.get_vtable();
-        let type_id = sizedescr.get_type_id() as u32;
+        let type_id = sizedescr.resolve_gc_tid();
         // resume.py direct-reader materialization retains raw pointers across
         // the forward blackhole run.  Match Dynasm's bh_new_with_vtable:
         // typed virtuals are born zero-filled in non-moving oldgen.  The old
@@ -16601,11 +16597,10 @@ impl majit_backend::Backend for CraneliftBackend {
         // allocation requires a real GC type id; tid=0 means the descr
         // never went through `gc.py:548 set_type_id` and the GC tracer
         // would lack the per-item visit shape.
-        // TODO: `BhDescr.get_type_id()` returns the
-        // u64 `path_hash` cache key, but `active_runtime_alloc_*`
-        // expects the u32 GC tid.  Truncate `as u32` until gc_cache
-        // routing resolves the proper allocated tid here.
-        let type_id = arraydescr.get_type_id() as u32;
+        // `resolve_gc_tid` maps the serialized `path_hash` cache key back to
+        // the allocated GC tid (`gc.py:544-549`) the tracer's per-item visit
+        // shape keys on.
+        let type_id = arraydescr.resolve_gc_tid();
         assert!(
             type_id != 0,
             "bh_new_array requires ArrayDescr.tid (descr.py:340) — got 0"

--- a/majit/majit-backend-dynasm/src/runner.rs
+++ b/majit/majit-backend-dynasm/src/runner.rs
@@ -2907,7 +2907,7 @@ impl Backend for DynasmBackend {
         // object would leave those captures stale.  Old-gen keeps every
         // materialized pointer stable for the lifetime of the resume.  Non-GC
         // descrs (`type_id == 0`, raw buffers) keep the plain malloc.
-        let type_id = sizedescr.get_type_id() as u32;
+        let type_id = sizedescr.resolve_gc_tid();
         let ptr = if type_id != 0 {
             dynasm_alloc_oldgen_typed(type_id, size).0 as *mut libc::c_void
         } else {
@@ -2942,10 +2942,10 @@ impl Backend for DynasmBackend {
         // allocation requires a real GC type id; tid=0 means the descr
         // never went through `gc.py:548 set_type_id` and the GC tracer
         // would lack the per-item visit shape.
-        // TODO: `BhDescr.get_type_id()` returns the
-        // u64 `path_hash` cache key, but `dynasm_alloc_*` expects the
-        // u32 GC tid.  Truncate `as u32` until gc_cache routing.
-        let type_id = arraydescr.get_type_id() as u32;
+        // `BhDescr::resolve_gc_tid` maps the serialized `path_hash` cache key
+        // back to the allocated GC tid (`gc.py:544-549`) so the header carries
+        // the per-item visit shape the tracer reads.
+        let type_id = arraydescr.resolve_gc_tid();
         assert!(
             type_id != 0,
             "bh_new_array requires ArrayDescr.tid (descr.py:340) — got 0"

--- a/majit/majit-backend-wasm/src/lib.rs
+++ b/majit/majit-backend-wasm/src/lib.rs
@@ -1422,9 +1422,11 @@ impl majit_backend::Backend for WasmBackend {
     /// llmodel.py:775 bh_new(sizedescr).
     fn bh_new(&self, sizedescr: &majit_translate::jitcode::BhDescr) -> i64 {
         let size = sizedescr.as_size();
-        // TODO: get_type_id() returns the u64 path_hash cache key; the GC tid
-        // is its low 32 bits until gc_cache routing resolves the real tid.
-        let type_id = sizedescr.get_type_id() as u32;
+        // Resolve the serialized `path_hash` cache key back to the dense GC
+        // tid so the nursery object carries a header the collector can trace
+        // (`gc.py:536-542`); a raw cache key read as a tid indexes past the
+        // type table on the first minor collection.
+        let type_id = sizedescr.resolve_gc_tid();
         with_wasm_active_gc_mut(|gc| gc.alloc_nursery_no_collect_typed(type_id, size).0 as i64)
             .unwrap_or(0)
     }
@@ -1434,7 +1436,7 @@ impl majit_backend::Backend for WasmBackend {
     fn bh_new_with_vtable(&self, sizedescr: &majit_translate::jitcode::BhDescr) -> i64 {
         let size = sizedescr.as_size();
         let vtable = sizedescr.get_vtable();
-        let type_id = sizedescr.get_type_id() as u32;
+        let type_id = sizedescr.resolve_gc_tid();
         let ptr =
             with_wasm_active_gc_mut(|gc| gc.alloc_nursery_no_collect_typed(type_id, size).0 as i64)
                 .unwrap_or(0);
@@ -1455,7 +1457,7 @@ impl majit_backend::Backend for WasmBackend {
         let len_offset = arraydescr
             .array_len_offset()
             .expect("bh_new_array requires ArrayDescr.lendescr");
-        let type_id = arraydescr.get_type_id() as u32;
+        let type_id = arraydescr.resolve_gc_tid();
         with_wasm_active_gc_mut(|gc| {
             let obj = gc.alloc_varsize_typed(type_id, base_size, itemsize, length);
             if obj.is_null() {

--- a/majit/majit-ir/src/descr.rs
+++ b/majit/majit-ir/src/descr.rs
@@ -1018,6 +1018,31 @@ impl GcCache {
         descr
     }
 
+    /// Read-only resolution of `LLType::Struct(cache_key)` to the dense GC
+    /// `tid` stamped on the cached `SizeDescr` (`gc.py:536-542` descr.tid),
+    /// or `None` when the key was never minted.  The blackhole/resume
+    /// allocation path holds only the `cache_key` (path_hash) that the
+    /// `BhDescr` serialized (`descr.py:108-118` structural identity) and must
+    /// recover the real GC tid the header write needs, without minting a
+    /// fresh descr the way `get_size_descr` would.  A real dense tid never
+    /// keys a `_cache_size` slot, so a miss reports the value was already a
+    /// tid and the caller keeps it verbatim.
+    pub fn resolve_struct_tid(&self, cache_key: u64) -> Option<u32> {
+        self._cache_size
+            .get(&LLType::Struct(cache_key))
+            .and_then(|d| d.as_size_descr())
+            .map(|sd| sd.type_id())
+    }
+
+    /// Array counterpart of [`resolve_struct_tid`] keyed on
+    /// `LLType::Array(cache_key)` (`descr.py:350`).
+    pub fn resolve_array_tid(&self, cache_key: u64) -> Option<u32> {
+        self._cache_array
+            .get(&LLType::Array(cache_key))
+            .and_then(|d| d.as_array_descr())
+            .map(|ad| ad.type_id())
+    }
+
     /// `descr.py:423-438 get_interiorfield_descr(gc_ll_descr, ARRAY, name, arrayfieldname=None)`
     /// cache-or-mint.  Keys `_cache_interiorfield[(ARRAY, name, arrayfieldname)]`
     /// so the analyzer's `cc.interiorfielddescrof` and the struct-array

--- a/majit/majit-translate/src/codewriter/jitcode.rs
+++ b/majit/majit-translate/src/codewriter/jitcode.rs
@@ -1352,6 +1352,33 @@ impl BhDescr {
         }
     }
 
+    /// Resolve the dense GC `tid` for a blackhole/resume header write from
+    /// the identity this descr carries in [`get_type_id`].  Producers are
+    /// mixed: `allocate_with_vtable` and the walker struct path widen the
+    /// real `descr.tid` into the slot, while `bh_new`, `from_array_descr`,
+    /// and every array path serialize the `cache_key` (`descr.py:108-118` /
+    /// `:348-378` structural identity).  A `_cache_size`/`_cache_array` hit
+    /// maps a `cache_key` back to the allocated tid (`gc.py:536-542`); a
+    /// miss means the value was already the dense tid (a real tid never keys
+    /// a struct/array cache slot).  Backends call this instead of
+    /// `get_type_id() as u32` so a materialized object carries a header the
+    /// collector can trace.
+    pub fn resolve_gc_tid(&self) -> u32 {
+        let raw = self.get_type_id();
+        let resolved = match self {
+            BhDescr::Size { .. } => majit_ir::descr::gc_cache()
+                .lock()
+                .expect("gc_cache poisoned")
+                .resolve_struct_tid(raw),
+            BhDescr::Array { .. } => majit_ir::descr::gc_cache()
+                .lock()
+                .expect("gc_cache poisoned")
+                .resolve_array_tid(raw),
+            _ => None,
+        };
+        resolved.unwrap_or(raw as u32)
+    }
+
     pub fn as_itemsize(&self) -> usize {
         match self {
             BhDescr::Array { itemsize, .. } => *itemsize,

--- a/pyre/bench/synth/gc_deque_backing_list.py
+++ b/pyre/bench/synth/gc_deque_backing_list.py
@@ -1,0 +1,70 @@
+# collections.deque holds its backing list solely through the deque object.
+# If the marker traces the deque with an empty offset set, that list is not
+# forwarded and is swept/moved on a collection driven by a hot allocator loop
+# while the deque is a live root — use-after-free / silent corruption on the
+# next len/index/iterate.  Each case holds a deque live across rounds of heavy
+# nursery allocation (forcing minor + major collections) and folds its contents
+# into a checksum every round; a dropped backing list crashes or diverges the
+# checksum from the interpreter oracle.
+import collections
+
+N = 6000
+ALLOC = 200
+
+
+def churn():
+    s = 0
+    for i in range(ALLOC):
+        x = [i, i + 1, i + 2]
+        s += x[0] + x[2]
+    return s
+
+
+def append_hold():
+    d = collections.deque()
+    for i in range(10):
+        d.append(i)
+    acc = 0
+    for _ in range(N):
+        churn()
+        acc = (acc + sum(d)) % 1000003
+    return acc
+
+
+def grow_each_round():
+    d = collections.deque(range(5))
+    acc = 0
+    for k in range(N):
+        churn()
+        d.append(k)
+        d.popleft()
+        acc = (acc + len(d) + d[0]) % 1000003
+    return acc
+
+
+def deque_of_objects():
+    d = collections.deque(str(i) for i in range(8))
+    acc = 0
+    for _ in range(N):
+        churn()
+        acc = (acc + sum(int(s) for s in d)) % 1000003
+    return acc
+
+
+def nested_field():
+    class Box:
+        def __init__(self):
+            self.q = collections.deque(range(7))
+
+    b = Box()
+    acc = 0
+    for _ in range(N):
+        churn()
+        acc = (acc + sum(b.q)) % 1000003
+    return acc
+
+
+print("append_hold", append_hold())
+print("grow_each_round", grow_each_round())
+print("deque_of_objects", deque_of_objects())
+print("nested_field", nested_field())

--- a/pyre/bench/synth/gc_iterator_source_drop.py
+++ b/pyre/bench/synth/gc_iterator_source_drop.py
@@ -1,0 +1,64 @@
+# Immortal iterator/sequence wrappers (enumerate, itertools.filterfalse,
+# takewhile) hold their source iterator solely through the wrapper object.  The
+# marker never scans an immortal wrapper, so unless its child offsets are
+# registered the source is not forwarded across a collection: a moving GC driven
+# by a hot inner loop then frees it, and the next __next__ reads a garbage
+# source ("not an iterator") or yields wrong values.  Each case builds a wrapper,
+# partially consumes it, forces collections while it is the sole root of its
+# source, then drains the rest and folds it into a checksum.
+from itertools import filterfalse, takewhile
+
+N = 4000
+ALLOC = 250
+
+
+def churn():
+    s = 0
+    for i in range(ALLOC):
+        x = [i, i + 1, i + 2]
+        s += x[0] + x[2]
+    return s
+
+
+def enumerate_hold():
+    acc = 0
+    for k in range(N):
+        src = [k * 10 + j for j in range(8)]
+        it = enumerate(src)
+        first = [next(it), next(it), next(it)]
+        churn()
+        rest = list(it)
+        for idx, val in first + rest:
+            acc = (acc + idx * 31 + val) % 1000003
+    return acc
+
+
+def filterfalse_hold():
+    acc = 0
+    for k in range(N):
+        src = list(range(k, k + 12))
+        it = filterfalse(lambda v: v % 2 == 0, src)
+        first = next(it)
+        churn()
+        rest = list(it)
+        for val in [first] + rest:
+            acc = (acc + val) % 1000003
+    return acc
+
+
+def takewhile_hold():
+    acc = 0
+    for k in range(N):
+        src = list(range(k, k + 20))
+        it = takewhile(lambda v: v < k + 15, src)
+        first = next(it)
+        churn()
+        rest = list(it)
+        for val in [first] + rest:
+            acc = (acc + val * 7) % 1000003
+    return acc
+
+
+print("enumerate_hold", enumerate_hold())
+print("filterfalse_hold", filterfalse_hold())
+print("takewhile_hold", takewhile_hold())

--- a/pyre/pyre-interpreter/Cargo.toml
+++ b/pyre/pyre-interpreter/Cargo.toml
@@ -32,6 +32,10 @@ wasm_vfs = ["dep:lz4_flex", "host_env"]
 pyre-object = { workspace = true }
 pyre-macros = { workspace = true }
 pyre-native = { workspace = true }
+# `#[pyre_class]` emits a `linkme::distributed_slice` element per type into
+# `pyre_object::lltype::PYRE_CLASS_DESCRIPTORS`; the attribute path must resolve
+# in this crate too.
+linkme = { workspace = true }
 rustpython-wtf8 = { workspace = true }
 rustpython-literal = { workspace = true }
 rustpython-common = { workspace = true }

--- a/pyre/pyre-interpreter/src/module/struct/mod.rs
+++ b/pyre/pyre-interpreter/src/module/struct/mod.rs
@@ -1086,7 +1086,7 @@ fn resolve_buffer_offset(args: &[PyObjectRef]) -> Result<(PyObjectRef, i64), cra
 /// `interp_struct.py:177 W_UnpackIter` — an iterator yielding the
 /// successive fixed-size records of a buffer.  Kept in its own module
 /// because each `#[pyre_class]` emits a module-scoped `type_object()`.
-mod unpack_iter {
+pub mod unpack_iter {
     use super::{do_unpack, readbuf, struct_error};
     use pyre_object::*;
 

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -1806,6 +1806,50 @@ fn build_gc() -> Box<dyn majit_gc::GcAllocator> {
             &pyre_object::dictmultiobject::W_DICT_VIEW_GC_PTR_OFFSETS,
         );
     }
+    // Immortal `#[pyre_class]` iterator / sequence wrappers whose managed
+    // children are held SOLELY through the immortal object.  The marker never
+    // scans a `malloc_typed`-immortal, so without a registered offset set the
+    // generic immortal-root walker (`walk_raw_immortal_roots`) cannot forward
+    // the child, and a collection reachable only through the wrapper frees it —
+    // e.g. `enumerate(list)` whose source list-iterator sits on a caller frame
+    // across a hot inner loop's collection, surfacing as
+    // `TypeError: not an iterator` on the next `__next__`.  These have no GC
+    // vtable site (immortal, keyed by `pytype_ptr`), so register the
+    // descriptor's `ptr_offsets` directly like the dict-view offsets above.
+    // The explicit `type_id`s never reach a GC arena, so no `register_type` /
+    // drift-check is involved.  This is the complete set of immortal
+    // `#[pyre_class]` wrappers with managed children that the
+    // `register_pyre_class` list above does not already cover; every other
+    // iterator family (map/filter/zip/cycle/chain/count/repeat, the four
+    // seq/list/tuple/set iterators, reversed, the SRE scanner) is registered
+    // there, and `W_Deque` is `allocate_stable` (GC-managed, not immortal).
+    for descr in [
+        <pyre_object::functional::W_Enumerate
+            as pyre_object::lltype::PyreClassPyTypeOf>::DESCRIPTOR,
+        <pyre_object::functional::W_Range
+            as pyre_object::lltype::PyreClassPyTypeOf>::DESCRIPTOR,
+        <pyre_object::functional::W_LongRangeIterator
+            as pyre_object::lltype::PyreClassPyTypeOf>::DESCRIPTOR,
+        <pyre_object::interp_itertools::W_TakeWhile
+            as pyre_object::lltype::PyreClassPyTypeOf>::DESCRIPTOR,
+        <pyre_object::interp_itertools::W_DropWhile
+            as pyre_object::lltype::PyreClassPyTypeOf>::DESCRIPTOR,
+        <pyre_object::interp_itertools::W_FilterFalse
+            as pyre_object::lltype::PyreClassPyTypeOf>::DESCRIPTOR,
+        <pyre_object::interp_itertools::W_Pairwise
+            as pyre_object::lltype::PyreClassPyTypeOf>::DESCRIPTOR,
+        <pyre_object::operation::_CallableIterator
+            as pyre_object::lltype::PyreClassPyTypeOf>::DESCRIPTOR,
+        <pyre_interpreter::module::r#struct::W_Struct
+            as pyre_object::lltype::PyreClassPyTypeOf>::DESCRIPTOR,
+        <pyre_interpreter::module::r#struct::unpack_iter::W_UnpackIter
+            as pyre_object::lltype::PyreClassPyTypeOf>::DESCRIPTOR,
+    ] {
+        pyre_object::gc_hook::register_pyre_class_offsets(
+            descr.pytype_ptr as usize,
+            descr.ptr_offsets,
+        );
+    }
     // `pypy/interpreter/typedef.py:312-326 class GetSetProperty`
     // — fget/fset/fdel/doc/reqcls/name are W_Root references.
     // Pyre's `GetSetProperty` ports them as inline fields; the

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -2622,6 +2622,21 @@ fn build_gc() -> Box<dyn majit_gc::GcAllocator> {
         );
         pytype_to_tid.insert(tp as *const _ as usize, w_dict_view_iterator_tid);
     }
+    // `collections.deque` W_Deque — AUTO-ID typed payload allocated via
+    // `allocate_stable` (GC-managed old-gen).  Managed only means the marker
+    // *scans* it; tracing its `data` backing list still needs a registered tid
+    // + offsets.  Unregistered, its cell stays UNASSIGNED and
+    // `malloc_typed_stable` stamps tid 0 (= `object`: empty offsets, no custom
+    // trace), so the marker forwards none of its children and `data` is swept
+    // while the deque is live — use-after-free on the next `len`/index/iterate.
+    // Register at the absolute tail like the auto-id iterators above so no
+    // earlier fixed slot shifts.
+    register_pyre_class(
+        &mut gc,
+        &mut pytype_to_tid,
+        <pyre_interpreter::module::_collections::W_Deque
+            as pyre_object::lltype::PyreClassPyTypeOf>::DESCRIPTOR,
+    );
     // rclass.py:340-346 — assign subclassrange_{min,max} to each
     // vtable entry. freeze_types() runs assign_inheritance_ids
     // (normalizecalls.py:373-389), then we write the computed ranges

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -2637,6 +2637,66 @@ fn build_gc() -> Box<dyn majit_gc::GcAllocator> {
         <pyre_interpreter::module::_collections::W_Deque
             as pyre_object::lltype::PyreClassPyTypeOf>::DESCRIPTOR,
     );
+    // ── GC-root registration completeness oracle ─────────────────────────
+    // Every `#[pyre_class]` type appends its descriptor to the whole-program
+    // `PYRE_CLASS_DESCRIPTORS` slice.  A type with inline managed children
+    // (non-empty `ptr_offsets`) whose children are reachable by NEITHER the
+    // marker (its resolved tid's `TypeInfo` traces those offsets or carries a
+    // custom trace) NOR the immortal-root walker (`register_pyre_class_offsets`)
+    // has its backing list / source iterator dropped on the next moving
+    // collection — the recurring unregistered-GC-root bug (the PR#628 hand
+    // walker, the immortal iterator triad, `collections.deque` W_Deque).  Assert
+    // completeness here, before `freeze_types()`, so a newly-added managed-child
+    // type that misses `build_gc` fails loudly at init instead of silently at
+    // the next collection.  Read-only over already-registered state; the slice
+    // is an oracle only (see its docs), so link-section under-population can only
+    // weaken the check, never false-alarm.  Native only: the guard reads
+    // `PYRE_CLASS_DESCRIPTORS`, whose wasm link-section population is not
+    // guaranteed, and the recurring bug is caught on the native CI backends.
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        let mut unregistered: Vec<&'static str> = Vec::new();
+        for descr in pyre_object::lltype::PYRE_CLASS_DESCRIPTORS {
+            if descr.ptr_offsets.is_empty() {
+                // No inline managed children the GC must forward.
+                continue;
+            }
+            // Path 1 — immortal-root walker / closure offset registry.
+            let in_offset_registry =
+                unsafe { pyre_object::gc_hook::offsets_for_pytype(descr.pytype_ptr) }
+                    .is_some_and(|o| !o.is_empty());
+            if in_offset_registry {
+                continue;
+            }
+            // Path 2 — the marker traces the type's own resolved tid.  The
+            // descriptor's `gc_type_id` cell is the real tid (pre-set for
+            // `type_id = N` types, stamped by `register_pyre_class` for auto-id
+            // ones); an unregistered type is `UNASSIGNED` or out of range.
+            let tid = descr.gc_type_id.get();
+            let marker_traced = tid != pyre_object::lltype::TypeIdCell::UNASSIGNED
+                && (tid as usize) < gc.types.len()
+                && {
+                    let ti = gc.types.get(tid);
+                    ti.custom_trace.is_some()
+                        || descr
+                            .ptr_offsets
+                            .iter()
+                            .all(|off| ti.gc_ptr_offsets.contains(off))
+                };
+            if marker_traced {
+                continue;
+            }
+            unregistered.push(descr.pyname);
+        }
+        assert!(
+            unregistered.is_empty(),
+            "GC-root registration gap: #[pyre_class] type(s) with managed \
+             children were never wired into build_gc — neither a marker tid \
+             tracing their inline `PyObjectRef` offsets nor \
+             register_pyre_class_offsets — so their children are dropped on the \
+             next collection.  Register each in build_gc: {unregistered:?}",
+        );
+    }
     // rclass.py:340-346 — assign subclassrange_{min,max} to each
     // vtable entry. freeze_types() runs assign_inheritance_ids
     // (normalizecalls.py:373-389), then we write the computed ranges

--- a/pyre/pyre-macros/src/lib.rs
+++ b/pyre/pyre-macros/src/lib.rs
@@ -1038,6 +1038,7 @@ fn expand_pyre_class(
     let object_size_const = format_ident!("W_{}_OBJECT_SIZE", suffix);
     let ptr_offsets_const = format_ident!("W_{}_GC_PTR_OFFSETS", suffix);
     let descriptor_static = format_ident!("W_{}_PYRE_CLASS_DESCRIPTOR", suffix);
+    let descriptor_slice_elem = format_ident!("W_{}_PYRE_CLASS_DESCRIPTOR_SLICE", suffix);
 
     // When the user declared `type_id = N` we pre-initialize the cell
     // to `N` and additionally emit the legacy `pub const W_X_GC_TYPE_ID:
@@ -1143,7 +1144,16 @@ fn expand_pyre_class(
                 gc_type_id: &#gc_type_id_cell,
                 object_size: #object_size_const,
                 ptr_offsets: &#ptr_offsets_const,
+                pyname: #name_lit,
             };
+
+        /// Link-time registration of this class's descriptor into the
+        /// whole-program `PYRE_CLASS_DESCRIPTORS` slice, so the JIT
+        /// driver's GC-root completeness oracle can see every
+        /// `#[pyre_class]` type without a hand-maintained list.
+        #[::linkme::distributed_slice(::pyre_object::lltype::PYRE_CLASS_DESCRIPTORS)]
+        static #descriptor_slice_elem: &'static ::pyre_object::lltype::PyreClassDescriptor =
+            &#descriptor_static;
 
         impl ::pyre_object::lltype::PyreClassPyTypeOf for #st_name {
             const PYTYPE: *const ::pyre_object::PyType =

--- a/pyre/pyre-macros/src/lib.rs
+++ b/pyre/pyre-macros/src/lib.rs
@@ -1150,7 +1150,9 @@ fn expand_pyre_class(
         /// Link-time registration of this class's descriptor into the
         /// whole-program `PYRE_CLASS_DESCRIPTORS` slice, so the JIT
         /// driver's GC-root completeness oracle can see every
-        /// `#[pyre_class]` type without a hand-maintained list.
+        /// `#[pyre_class]` type without a hand-maintained list.  Native
+        /// only, matching the slice: `distributed_slice` rejects `wasm32`.
+        #[cfg(not(target_arch = "wasm32"))]
         #[::linkme::distributed_slice(::pyre_object::lltype::PYRE_CLASS_DESCRIPTORS)]
         static #descriptor_slice_elem: &'static ::pyre_object::lltype::PyreClassDescriptor =
             &#descriptor_static;

--- a/pyre/pyre-object/Cargo.toml
+++ b/pyre/pyre-object/Cargo.toml
@@ -14,3 +14,4 @@ majit-macros = { workspace = true }
 pyre-macros = { workspace = true }
 indexmap = { workspace = true }
 rustpython-wtf8 = { workspace = true }
+linkme = { workspace = true }

--- a/pyre/pyre-object/src/lltype.rs
+++ b/pyre/pyre-object/src/lltype.rs
@@ -174,6 +174,12 @@ unsafe impl Sync for PyreClassDescriptor {}
 /// is not guaranteed on every backend (notably wasm), and an oracle
 /// degrades gracefully under under-population (it can only under-check,
 /// never false-alarm) whereas a driver could not.
+///
+/// Compiled native-only: `linkme::distributed_slice` rejects `wasm32`
+/// ("distributed_slice is not implemented for this platform"), and the
+/// sole consumer — `build_gc`'s oracle — is itself `wasm32`-gated, so the
+/// registry is dead weight there anyway.
+#[cfg(not(target_arch = "wasm32"))]
 #[::linkme::distributed_slice]
 pub static PYRE_CLASS_DESCRIPTORS: [&'static PyreClassDescriptor] = [..];
 

--- a/pyre/pyre-object/src/lltype.rs
+++ b/pyre/pyre-object/src/lltype.rs
@@ -148,12 +148,34 @@ pub struct PyreClassDescriptor {
     pub object_size: usize,
     /// Byte offsets of inline `PyObjectRef` fields the GC must trace.
     pub ptr_offsets: &'static [usize],
+    /// Python-visible dotted name (`"collections.deque"`), carried for
+    /// diagnostics — the GC-root registration guard reports it by name
+    /// when a type with managed children was left unregistered.
+    pub pyname: &'static str,
 }
 
 // Safety: every field is either a static-`'static` reference (PyType,
-// gc_type_id, ptr_offsets), a primitive, or a raw pointer to read-only
-// static storage; sharing across threads is sound.
+// gc_type_id, ptr_offsets, pyname), a primitive, or a raw pointer to
+// read-only static storage; sharing across threads is sound.
 unsafe impl Sync for PyreClassDescriptor {}
+
+/// Link-time registry of every `#[pyre_class]` type's descriptor.
+///
+/// `#[pyre_class]` appends one element per type (via `linkme`'s
+/// `distributed_slice`), so this slice is the whole-program set of GC
+/// class descriptors — the Rust stand-in for RPython's translation-time
+/// walk over every `GcStruct` in the low-level type graph
+/// (`rpython/memory/gctransform/framework.py`), which pyre cannot do
+/// because Rust has no such pass.  Consumed only as a completeness
+/// *oracle*: the JIT driver's `build_gc` asserts, right before
+/// `freeze_types()`, that every descriptor with managed children was
+/// actually wired into the GC.  It is deliberately NOT used to *drive*
+/// registration — population is a link-section array whose completeness
+/// is not guaranteed on every backend (notably wasm), and an oracle
+/// degrades gracefully under under-population (it can only under-check,
+/// never false-alarm) whereas a driver could not.
+#[::linkme::distributed_slice]
+pub static PYRE_CLASS_DESCRIPTORS: [&'static PyreClassDescriptor] = [..];
 
 /// Compile-time bridge between a `#[pyre_class]` struct and its
 /// per-type static `PyType` / `PyreClassDescriptor`.  Implemented
@@ -249,6 +271,15 @@ pub fn malloc_typed_stable<T: GcType>(value: T) -> *mut T {
     } else {
         unsafe {
             std::ptr::write(raw as *mut T, value);
+            // The object is born old-gen with `TRACK_YOUNG_PTRS` set but is
+            // not yet in the remembered set, so a minor collection would not
+            // scan it — any inline `PyObjectRef` field still pointing into the
+            // nursery would be dropped.  Run the barrier once so the object
+            // joins the remembered set and the first minor GC forwards its
+            // young children, mirroring the hand-written barrier every other
+            // stable allocator runs after its raw write (`w_list_new`,
+            // `w_generator_new`, `tupleobject`).
+            crate::gc_hook::try_gc_write_barrier(raw);
             raw as *mut T
         }
     }


### PR DESCRIPTION
Three commits closing a recurring `#[pyre_class]` GC-root registration gap in
`build_gc`, same underlying shape: a `#[pyre_class]` object holds managed
`PyObjectRef` children, but the GC cannot forward them because the type's offsets
are never registered — so a collection reachable only through the object frees
the child. The first two commits fix the two live instances; the third closes the
class structurally, hardens the stable allocator, and adds regression coverage.
The drops surface only under moving GC + full-body-walk residual execution and
were uncaught by the test suite.

## Commit 1 — immortal iterator / sequence wrappers

Ten immortal `#[pyre_class]` iterator/wrapper types hold their managed children
(source iterator, list, format, buffer) **solely** through the immortal object. A
`malloc_typed`-immortal is never scanned by the marker, so unless its
`ptr_offsets` are in the immortal-root offset registry, `walk_raw_immortal_roots`
cannot forward the child; a moving-GC collection then frees it, surfacing as
`TypeError: not an iterator` on the next `__next__`.

Registers the descriptor `ptr_offsets` (keyed by `pytype_ptr`, mirroring the
dict-view iterator precedent) for the complete set not already covered by the
`register_pyre_class` list: `W_Enumerate`, `W_Range`, `W_LongRangeIterator`
(`functional`); `W_TakeWhile`, `W_DropWhile`, `W_FilterFalse`, `W_Pairwise`
(`interp_itertools`); `_CallableIterator` (`operation`); `W_Struct`,
`W_UnpackIter` (`module::struct`). `struct::unpack_iter` is made `pub mod` so
`W_UnpackIter` is nameable from pyre-jit. A 51-declaration census confirms this
is the complete set of immortal (`::allocate`) types with managed children not
already registered. This was previously mis-attributed to an FBW abort-flush
residual bug; that RCA was falsified (the "drop" is a crash masked by stdout-only
capture).

## Commit 2 — `collections.deque` backing list

`W_Deque` is an auto-id `#[pyre_class]` allocated via `allocate_stable`, so it is
GC-*managed* but never assigned a gc type-id. Its `gc_type_id` cell stays
`UNASSIGNED` and `malloc_typed_stable` stamps type-id **0** (= `object`: empty
offsets, no custom trace), so the marker traces **none** of its children and the
`data` backing list is swept while the deque is live — use-after-free (SIGSEGV in
`baseobjspace::iter`) on the next `len`/index/iterate.

Being managed is not sufficient: the marker only *scans* the object; forwarding
its children needs a registered tid + offsets, which only `register_pyre_class`
provides. Appends `W_Deque` to the `register_pyre_class` chain at the absolute
tail — auto-id, so it takes the next free tid without shifting the positional
tid ordering (guarded by drift asserts).

## Commit 3 — completeness guard, stable-alloc write barrier, regression tests

The Commit 1 & 2 gap recurred three times because `build_gc`'s registration is a
hand-maintained list: a forgotten managed-child type fails silently at the next
collection instead of loudly at registration. This commit closes the class
structurally and adds the missing coverage.

**Completeness guard (recurrence prevention).** `#[pyre_class]` now appends each
type's descriptor to a `linkme::distributed_slice` (`PYRE_CLASS_DESCRIPTORS`) —
the whole-program set of GC class descriptors, the Rust stand-in for RPython's
translation-time walk over every `GcStruct` (`framework.py`), which pyre cannot
do because Rust has no such pass. `build_gc` asserts, right before
`freeze_types()`, that every descriptor with inline managed children is reachable
by the marker (its resolved tid's `TypeInfo` traces those offsets or carries a
custom trace) **or** by the immortal-root walker (`register_pyre_class_offsets`),
panicking by Python type name otherwise. The dual-path check is required: the
~20 hand-registered managed types are marker-traced via their own `TypeInfo` and
do not populate the immortal offset registry, so a registry-only check would
false-positive on them. The slice is used **only as an oracle**, never to drive
registration, so link-section under-population (notably wasm) can only weaken the
check, never false-alarm — and the guard is native-only for the same reason.
Adversarially confirmed: removing the Commit 2 registration makes the guard panic
naming `["collections.deque"]`, proving both that the slice is populated and that
the logic detects an unregistered managed-child type.

**Stable-alloc write barrier.** `malloc_typed_stable` now runs the GC write
barrier after its raw payload write, so an old-gen object born holding a nursery
child joins the remembered set and the first minor collection forwards that
child — mirroring the barrier every hand-written stable allocator (`w_list_new`,
`w_generator_new`, tuple) already runs. This is latent hardening: benign for the
two current generic-path callers (their inline children are old-gen or off-GC),
but it forecloses the same minor-GC drop for any future `allocate_stable` type
that gains an inline young child. It is orthogonal to the offset registration of
Commits 1 & 2 (major-marker) — the barrier is the minor-GC remembered-set gate.

**Regression tests.** `bench/synth/gc_deque_backing_list.py` and
`gc_iterator_source_drop.py` hold a deque / immortal iterator live across heavy
nursery churn and fold contents into a checksum every round, so a dropped child
either crashes (truncated stdout) or diverges the checksum from the PyPy oracle.
Correctness-only (no perf gate), well under the hang guard.

## Verification

- Adversarial triad (cranelift-JIT / dynasm-JIT / interpreter oracle) over 27
  heterogeneous stress programs: **27/27 both backends**. The immortal drivers
  (`enumerate`/`filterfalse`/`takewhile`) and the deque driver (deterministic
  SIGSEGV before Commit 2) all pass.
- `check.py --backend dynasm,cranelift`: **227/227 both backends** (includes the
  two new GC-drop synth tests).
- Completeness guard: no false-positive across every `#[pyre_class]` type;
  adversarially panics by name when a registration is removed.
- `cargo test` (debug): clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
