### PR TITLE
jit: #368 source inline-caller marker-miss result color from a jitcode-pc twin

### DIFF
--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -13420,10 +13420,12 @@ fn compute_inline_caller_frame(
             .result_color_for_jitcode_pc_pred(marker)
             .filter(|&color| color != u16::MAX)
             .map(|color| color as usize),
-        // Keep the legacy table only for the unkeyed marker-miss fallback.
-        None => {
-            crate::state::result_color_at_pc_at(jitcode_index as i32, fallthrough_py_pc as usize)
-        }
+        // Marker-miss: the after-residual result-color twin keys the same
+        // fallthrough coordinate by JitCode byte offset, retiring the py read.
+        None => unsafe { &(*caller_sym.jitcode).payload }
+            .result_color_after_residual_for_jitcode_pc(call_jit_pc)
+            .filter(|&color| color != u16::MAX)
+            .map(|color| color as usize),
     }
     .ok_or(InlineCallerFrameDecline::Unavailable)?;
     // Null the not-yet-produced result slot, build the box list, then restore
@@ -13539,10 +13541,10 @@ fn compute_nested_inline_caller_frame(
             .result_color_for_jitcode_pc_pred(marker)
             .filter(|&color| color != u16::MAX)
             .map(|color| color as usize),
-        None => crate::state::result_color_at_pc_at(
-            jitcode_index as i32,
-            legacy_fallthrough_py_pc() as usize,
-        ),
+        None => pjc
+            .result_color_after_residual_for_jitcode_pc(call_jit_pc)
+            .filter(|&color| color != u16::MAX)
+            .map(|color| color as usize),
     }
     .ok_or(InlineCallerFrameDecline::Unavailable)?;
     if pcmap_pfresume_audit_enabled() {

--- a/pyre/pyre-jit-trace/src/pyjitcode.rs
+++ b/pyre/pyre-jit-trace/src/pyjitcode.rs
@@ -160,6 +160,16 @@ pub struct PyJitCodeMetadata {
     /// fixture.
     pub after_residual_marker_marker_by_jit_pc: Vec<(usize, Option<usize>)>,
     pub after_residual_marker_pred_by_jit_pc: Vec<(usize, Option<usize>)>,
+    /// Result color (`result_color_at_pc`) of the call-result operand slot at
+    /// the after-residual fallthrough PC, keyed by JitCode byte offset with the
+    /// same exact-marker / predecessor-op-start split as
+    /// `after_residual_marker_*`. Value =
+    /// `result_color_at_pc[semantic_fallthrough_pc(skip_python_trivia_forward(py))]`
+    /// (`None` past the table end). Retires the runtime py-keyed result-color
+    /// read in the inline-caller marker-miss fallback. Empty for skeleton /
+    /// fixture.
+    pub result_color_after_residual_marker_by_jit_pc: Vec<(usize, Option<u16>)>,
+    pub result_color_after_residual_pred_by_jit_pc: Vec<(usize, Option<u16>)>,
     /// Post-regalloc Ref-bank color of the call-result operand-stack slot
     /// (top of stack = `depth_at_py_pc[pc] - 1`) at each Python PC, or
     /// `u16::MAX` where the stack is empty. The inline multiframe capture
@@ -733,6 +743,27 @@ impl PyJitCode {
         Self::predecessor_index(search).and_then(|i| pred[i].1)
     }
 
+    /// Result color of the call-result operand slot at the after-residual
+    /// fallthrough PC, keyed by a JitCode byte offset with the SAME exact-marker
+    /// / predecessor-op-start tiers as `after_residual_marker_for_jitcode_pc`.
+    /// Equals the legacy
+    /// `result_color_at_pc[semantic_fallthrough_pc(python_pc_for_jitcode_pc(jit_pc))]`
+    /// for a call-op coordinate; `u16::MAX` where the return stack is empty;
+    /// `None` when the twin is empty (skeleton / fixture) or the fallthrough is
+    /// past the table end.
+    pub fn result_color_after_residual_for_jitcode_pc(&self, jit_pc: usize) -> Option<u16> {
+        let marker = &self.metadata.result_color_after_residual_marker_by_jit_pc;
+        let pred = &self.metadata.result_color_after_residual_pred_by_jit_pc;
+        if marker.is_empty() && pred.is_empty() {
+            return None;
+        }
+        if let Ok(i) = marker.binary_search_by_key(&jit_pc, |&(off, _)| off) {
+            return marker[i].1;
+        }
+        let search = pred.binary_search_by_key(&jit_pc, |&(off, _)| off);
+        Self::predecessor_index(search).and_then(|i| pred[i].1)
+    }
+
     /// Post-`residual_call` catch resume marker keyed by a JitCode byte
     /// offset, resolved with the SAME exact-marker / predecessor-op-start
     /// tiers as `python_pc_for_jitcode_pc`.
@@ -896,6 +927,8 @@ impl PyJitCode {
                 resume_marker_pred_by_jit_pc: Vec::new(),
                 after_residual_marker_marker_by_jit_pc: Vec::new(),
                 after_residual_marker_pred_by_jit_pc: Vec::new(),
+                result_color_after_residual_marker_by_jit_pc: Vec::new(),
+                result_color_after_residual_pred_by_jit_pc: Vec::new(),
                 depth_at_py_pc: Vec::new(),
                 result_color_at_pc: Vec::new(),
                 result_color_by_jit_pc: Vec::new(),

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -1404,23 +1404,6 @@ pub fn pcdep_color_slots_at(jitcode_index: i32, py_pc: i32) -> Vec<(u8, u16, u16
     })
 }
 
-/// The post-regalloc Ref-bank color of the call-result operand-stack slot
-/// (top of stack) at `pc` — the not-yet-produced slot the inline multiframe
-/// capture (`compute_inline_caller_frame`) nulls before serializing the
-/// paused caller frame.  Returns `None` when the stack is empty there
-/// (`u16::MAX` sentinel) or `pc` / the jitcode is out of range.  Sources the
-/// codewriter-precomputed `metadata.result_color_at_pc`, so the capture no
-/// longer reads the flat `stack_slot_color_map` at runtime.
-pub fn result_color_at_pc_at(jitcode_index: i32, pc: usize) -> Option<usize> {
-    ensure_finish_setup();
-    METAINTERP_SD.with(|r| {
-        let sd = r.borrow();
-        let jc = sd.jitcodes.get(jitcode_index as usize)?;
-        let c = jc.payload.metadata.result_color_at_pc.get(pc).copied()?;
-        (c != u16::MAX).then_some(c as usize)
-    })
-}
-
 /// Whether `pcdep_color_slots[pc]` maps register color `color` to a semantic
 /// frame slot — i.e. the register allocator assigned this color to a real
 /// local/stack value at `pc`, so the color does NOT carry its force-alived
@@ -12540,6 +12523,8 @@ mod tests {
                 resume_marker_pred_by_jit_pc: vec![(0, Some(0))],
                 after_residual_marker_marker_by_jit_pc: Vec::new(),
                 after_residual_marker_pred_by_jit_pc: Vec::new(),
+                result_color_after_residual_marker_by_jit_pc: Vec::new(),
+                result_color_after_residual_pred_by_jit_pc: Vec::new(),
                 depth_at_py_pc: vec![2],
                 result_color_at_pc: Vec::new(),
                 result_color_by_jit_pc: Vec::new(),

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -13177,6 +13177,9 @@ impl CodeWriter {
         let mut resume_marker_pred_by_jit_pc: Vec<(usize, Option<usize>)> = Vec::new();
         let mut after_residual_marker_marker_by_jit_pc: Vec<(usize, Option<usize>)> = Vec::new();
         let mut after_residual_marker_pred_by_jit_pc: Vec<(usize, Option<usize>)> = Vec::new();
+        let mut result_color_after_residual_marker_by_jit_pc: Vec<(usize, Option<u16>)> =
+            Vec::new();
+        let mut result_color_after_residual_pred_by_jit_pc: Vec<(usize, Option<u16>)> = Vec::new();
         let mut after_residual_call_resume_marker_by_jit_pc: Vec<(usize, Option<usize>)> =
             Vec::new();
         let mut after_residual_call_resume_pred_by_jit_pc: Vec<(usize, Option<usize>)> = Vec::new();
@@ -13298,8 +13301,15 @@ impl CodeWriter {
                     .get(ft)
                     .and_then(|_| resolve_marker(ft));
                 after_residual_marker_marker_by_jit_pc.push((off, value));
+                // The retired runtime read took the fallthrough of the RAW
+                // block-head py (no trivia skip); match it exactly so the twin
+                // reproduces `result_color_at_pc[fallthrough(python_pc_for_jitcode_pc(off))]`.
+                let ft_rc = pyre_jit_trace::pyjitpl::semantic_fallthrough_pc(code, py as usize);
+                result_color_after_residual_marker_by_jit_pc
+                    .push((off, result_color_at_pc.get(ft_rc).copied()));
             }
             after_residual_marker_marker_by_jit_pc.sort_unstable_by_key(|&(off, _)| off);
+            result_color_after_residual_marker_by_jit_pc.sort_unstable_by_key(|&(off, _)| off);
             // Op-start tier: predecessor scan, markers EXCLUDED.
             for (py, &pos) in first_jit_pc_by_py_pc.iter().enumerate() {
                 if pos != usize::MAX {
@@ -13309,9 +13319,13 @@ impl CodeWriter {
                         .get(ft)
                         .and_then(|_| resolve_marker(ft));
                     after_residual_marker_pred_by_jit_pc.push((pos, value));
+                    let ft_rc = pyre_jit_trace::pyjitpl::semantic_fallthrough_pc(code, py);
+                    result_color_after_residual_pred_by_jit_pc
+                        .push((pos, result_color_at_pc.get(ft_rc).copied()));
                 }
             }
             after_residual_marker_pred_by_jit_pc.sort_unstable_by_key(|&(off, _)| off);
+            result_color_after_residual_pred_by_jit_pc.sort_unstable_by_key(|&(off, _)| off);
             // Post-residual-call catch marker twin: source values from the
             // same sparse construction inputs, while resolving its key
             // with the exact block-head / predecessor-op-start split of the
@@ -13379,6 +13393,8 @@ impl CodeWriter {
             resume_marker_pred_by_jit_pc,
             after_residual_marker_marker_by_jit_pc,
             after_residual_marker_pred_by_jit_pc,
+            result_color_after_residual_marker_by_jit_pc,
+            result_color_after_residual_pred_by_jit_pc,
             result_color_at_pc,
             result_color_by_jit_pc,
             portal_frame_reg,


### PR DESCRIPTION
## Summary

Retires the last runtime consumers of the Python-pc-keyed `result_color_at_pc_at`
inversion in the inline-caller frame builders (#368 / pc-map).

`compute_inline_caller_frame` and `compute_nested_inline_caller_frame` read the
call-result operand slot's color from the Python-pc-keyed `result_color_at_pc_at`
whenever no after-residual resume marker is available (the marker-miss arm). This
was the last runtime py→jit inversion read in the result-color channel.

This adds a `result_color_after_residual` twin keyed by JitCode byte offset
(exact-marker + predecessor-op-start tiers, mirroring `after_residual_marker_*`),
built beside it in the codewriter. Each entry stores `result_color_at_pc` at the
**raw** fallthrough of its block-head / op-start py — matching the retired runtime
read's trivia handling (no trivia skip), which is what distinguishes it from the
sibling marker twin. The two marker-miss arms now read this twin, and
`result_color_at_pc_at` is deleted (its only callers were those arms).

`result_color_at_pc` (the dense py table) stays as a build-time source for the
trivia twins and this new twin; the only remaining runtime read of it is the
audit-gated pfresume leg.

## Correctness

Both marker-miss arms are corpus-dormant (0 runtime fires even under
`PYRE_P2_COMPILE`), so certification is by a throwaway whole-metadata verifier
hooked at every populated jitcode-install site: for every twin key of every corpus
jitcode it compared the twin against the retired runtime formula
`result_color_at_pc[semantic_fallthrough_pc(python_pc_for_jitcode_pc(off))]`.

- First build (trivia-skipped fallthrough, matching the sibling marker twin):
  **4738 / 24355 coordinates diverged** across 424/426 jitcodes — the verifier
  caught that a result-color twin must match the runtime read's trivia handling,
  not the marker twin's.
- Raw-py fallthrough (this PR): **24355 coordinates / 426 jitcodes / 0 diverged**
  (control: up to 618 checks per jitcode, no zero-check rows — the harness really
  ran).

## Gates

- dynasm 223/223, cranelift 217/217, wasm 216/216 (cranelift/wasm on the pre-#633
  base; dynasm 223/223 re-verified on the current #633 base).
- `cargo test -p pyre-jit-trace -p pyre-jit --features dynasm` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)