### PR TITLE
interpreter, jit: unblock popular stdlib modules + coroutine/GC fixes

### DIFF
--- a/majit/majit-backend-dynasm/src/regalloc.rs
+++ b/majit/majit-backend-dynasm/src/regalloc.rs
@@ -4954,6 +4954,7 @@ impl<'a> RegAlloc<'a> {
         } else {
             0
         })));
+        let mut force_store_refs = Vec::new();
         for (arg_index, arg) in op.getarglist().iter().enumerate() {
             let arg = arg.to_opref();
             let tp = if arg_index >= first_arg_index {
@@ -4962,6 +4963,14 @@ impl<'a> RegAlloc<'a> {
                 self.tp(arg)
             };
             arglocs.push(self.loc(arg, tp));
+            // callbuilder.py keeps every GC argument alive for the duration
+            // of a collecting call, even when this call is its last SSA use.
+            // Without force_store, before_call's `max_age <= position` arm
+            // drops that binding and get_gcmap omits it; a temporary such as
+            // `Counter(dict(generator))` can then be swept inside the callee.
+            if tp == Type::Ref && !arg.is_constant() {
+                force_store_refs.push(arg);
+            }
         }
 
         // aarch64/regalloc.py:622-628 — then _call → before_call → after_call.
@@ -4979,7 +4988,7 @@ impl<'a> RegAlloc<'a> {
             &self.op_pos,
         );
         self.rm.before_call(
-            &[],
+            &force_store_refs,
             save_regs,
             &mut self.longevity,
             &mut self.fm,
@@ -5055,6 +5064,7 @@ impl<'a> RegAlloc<'a> {
         } else {
             0
         })));
+        let mut force_store_refs = Vec::new();
         for (arg_index, &arg) in args.iter().enumerate() {
             let tp = if arg_index >= first_arg_index {
                 calldescr.arg_types()[arg_index - first_arg_index]
@@ -5062,6 +5072,9 @@ impl<'a> RegAlloc<'a> {
                 self.tp(arg)
             };
             arglocs.push(self.loc(arg, tp));
+            if tp == Type::Ref && !arg.is_constant() {
+                force_store_refs.push(arg);
+            }
         }
 
         let can_collect = calldescr.get_extra_info().check_can_collect();
@@ -5079,7 +5092,7 @@ impl<'a> RegAlloc<'a> {
             &self.op_pos,
         );
         self.rm.before_call(
-            &[],
+            &force_store_refs,
             save_regs,
             &mut self.longevity,
             &mut self.fm,

--- a/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
+++ b/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
@@ -3078,21 +3078,12 @@ impl ExtendedShortPreambleBuilder {
             .iter()
             .map(|op| std::rc::Rc::new(op.clone()))
             .collect();
-        let inputargs = if self.label_args.is_empty() {
-            &self.short_inputargs
-        } else {
-            &self.label_args
-        };
-        let mut sp = build_short_preamble_struct_from_ops(
-            inputargs,
+        build_short_preamble_struct_from_ops(
+            &self.short_inputargs,
             &ops,
             &self.used_boxes,
             &self.short_jump_args,
-        );
-        if inputargs != self.short_inputargs.as_slice() {
-            sp.phase1_inputargs = Some(self.short_inputargs.clone());
-        }
-        sp
+        )
     }
 
     pub fn extra_same_as(&self) -> &[Op] {

--- a/majit/majit-metainterp/src/optimizeopt/unroll.rs
+++ b/majit/majit-metainterp/src/optimizeopt/unroll.rs
@@ -3529,30 +3529,8 @@ impl OptUnroll {
             // inline_short_preamble's `len(short_inputargs) == len(jump_args)`
             // (unroll.py:393) holds.
             //
-            // Pyre diverges for a virtualizable-frame loop whose locals are
-            // carried UNBOXED: the reduced loop-body target token
-            // (LoopTargetDescr(N)) finalizes its short-preamble inputargs to the
-            // non-virtual loop label only (`ShortBoxes::with_label_args`,
-            // shortpreamble.rs:558) and reconstructs the boxed-int forms from
-            // those args via its own ops — it does NOT expect the virtual-box
-            // slots as inputargs. Appending `virtuals` then makes
-            // `short_jump_args` longer than the target's `short_inputargs` and
-            // trips the contract (the `except`-handler bridge: target_args=4,
-            // virtuals=2 [boxed s/i], but sp.inputargs=4 → 6 != 4 InvalidLoop).
-            //
-            // Match the target's actual short-inputarg arity: append `virtuals`
-            // only when the target short preamble has slots for them. The
-            // loop-self-build path (sp.inputargs already includes the virtual
-            // slots) is unchanged; only the reduced-target bridge retarget that
-            // would otherwise InvalidLoop is affected.
             let mut short_jump_args = target_args.clone();
-            let target_expects_virtuals = target_token
-                .short_preamble
-                .as_ref()
-                .map_or(true, |sp| sp.inputargs.len() != short_jump_args.len());
-            if target_expects_virtuals {
-                short_jump_args.extend(virtuals);
-            }
+            short_jump_args.extend(virtuals);
 
             // Ensure jump_args carry PtrInfo from Phase 2 body.
             // RPython Box identity preserves info across forwarding.

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -10314,6 +10314,26 @@ pub fn iter(obj: PyObjectRef) -> PyResult {
         // `_check_modified` (`dictmultiobject.py:1716+`) without the
         // snapshot list materialisation.
         if is_dict(obj) {
+            // `space.iter(w_mapping)` must honor a dict subclass's own
+            // `__iter__` before taking the concrete W_DictMultiObject fast
+            // path. This is load-bearing for `mappingproxy(OrderedDict)` in
+            // `inspect.Signature`: treating the subclass as an exact raw dict
+            // bypasses its iterator and casts the wrong layout.
+            let exact_dict_type = get_instantiate(&pyre_object::DICT_TYPE);
+            if !std::ptr::eq((*obj).w_class, exact_dict_type) {
+                if let Some((src, method)) = lookup_where_pair((*obj).w_class, "__iter__") {
+                    if !std::ptr::eq(src, exact_dict_type) {
+                        if is_none(method) {
+                            return Err(PyError::type_error(format!(
+                                "'{}' object is not iterable",
+                                obj_type_name(obj)
+                            )));
+                        }
+                        let w_iter = crate::call::call_function_impl_result(method, &[obj])?;
+                        return iter_check_is_iterator(w_iter);
+                    }
+                }
+            }
             return Ok(pyre_object::dictmultiobject::w_dict_view_iterator_new(
                 obj,
                 pyre_object::dictmultiobject::DictViewKind::Keys,

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -967,14 +967,14 @@ pub(crate) unsafe fn get_and_call_function(
     crate::call::call_function_impl_result(w_impl, args_w)
 }
 
-/// `isinstance(w_obj, Coroutine) or gen_is_coroutine(w_obj)` from
-/// `generator.py:569`, collapsed onto pyre's single generator object: an
-/// `async def` coroutine and a `@types.coroutine`-marked generator both carry
-/// their marker on the suspended frame's code (`CO_COROUTINE` /
-/// `CO_ITERABLE_COROUTINE`), so the distinct PyPy `Coroutine` class becomes a
-/// code-flag test here.
+/// `isinstance(w_obj, Coroutine) or gen_is_coroutine(w_obj)` from PyPy
+/// `generator.py`.  Only a GeneratorIterator may use the
+/// `CO_ITERABLE_COROUTINE` marker; native coroutines have their own type.
 fn is_coroutine(w_obj: PyObjectRef) -> bool {
     unsafe {
+        if pyre_object::generator::is_coroutine(w_obj) {
+            return true;
+        }
         if !pyre_object::generator::is_generator(w_obj) {
             return false;
         }
@@ -988,7 +988,7 @@ fn is_coroutine(w_obj: PyObjectRef) -> bool {
         (*frame_ptr)
             .code()
             .flags
-            .intersects(crate::CodeFlags::COROUTINE | crate::CodeFlags::ITERABLE_COROUTINE)
+            .contains(crate::CodeFlags::ITERABLE_COROUTINE)
     }
 }
 
@@ -996,20 +996,7 @@ fn is_coroutine(w_obj: PyObjectRef) -> bool {
 /// `@types.coroutine`-wrapped generators (`CO_ITERABLE_COROUTINE`).  Mirrors
 /// `PyCoro_CheckExact`, which gates the GET_AWAITABLE already-awaited guard.
 fn is_native_coroutine(w_obj: PyObjectRef) -> bool {
-    unsafe {
-        if !pyre_object::generator::is_generator(w_obj) {
-            return false;
-        }
-        let frame_ptr =
-            pyre_object::generator::w_generator_get_frame(w_obj) as *const crate::pyframe::PyFrame;
-        if frame_ptr.is_null() {
-            return false;
-        }
-        (*frame_ptr)
-            .code()
-            .flags
-            .contains(crate::CodeFlags::COROUTINE)
-    }
+    unsafe { pyre_object::generator::is_coroutine(w_obj) }
 }
 
 /// `generator.py:563 get_awaitable_iter` — return the iterator implementing the
@@ -11477,7 +11464,10 @@ pub fn next(obj: PyObjectRef) -> PyResult {
             }
         }
     }
-    Err(PyError::type_error("not an iterator"))
+    Err(PyError::type_error(format!(
+        "'{}' object is not an iterator",
+        unsafe { obj_type_name(obj) }
+    )))
 }
 
 /// `descriptor.py:256-273 W_Property._copy` — clone the property with
@@ -11806,7 +11796,13 @@ fn resume_yield_from(
             return Err(err);
         }
         Some(err) => throw_yield_from(w_yf, err, throw_args),
-        None if unsafe { pyre_object::is_none(w_arg) } => next(w_yf),
+        None if unsafe { pyre_object::is_none(w_arg) } => {
+            if unsafe { pyre_object::generator::is_generator_or_coroutine(w_yf) } {
+                generator_send_ex(w_yf, w_none(), None, None)
+            } else {
+                next(w_yf)
+            }
+        }
         None => {
             let send = getattr_str(w_yf, "send")?;
             crate::call::call_function_impl_result(send, &[w_arg])
@@ -11835,7 +11831,7 @@ fn throw_yield_from(
     throw_args: Option<([PyObjectRef; 3], usize)>,
 ) -> PyResult {
     unsafe {
-        if pyre_object::generator::is_generator(w_yf) {
+        if pyre_object::generator::is_generator_or_coroutine(w_yf) {
             return generator_send_ex(w_yf, w_none(), Some(err), throw_args);
         }
     }
@@ -11858,7 +11854,7 @@ fn throw_yield_from(
 /// in the same resume path so nested delegation unwinds one frame at a time.
 fn close_yield_from(w_yf: PyObjectRef) -> PyResult {
     unsafe {
-        if pyre_object::generator::is_generator(w_yf) {
+        if pyre_object::generator::is_generator_or_coroutine(w_yf) {
             let exit = PyError::new(PyErrorKind::GeneratorExit, String::new());
             return match generator_send_ex(w_yf, w_none(), Some(exit), None) {
                 Ok(_) => Err(PyError::runtime_error("generator ignored GeneratorExit")),
@@ -12171,6 +12167,41 @@ pub(crate) fn generator_close_method(args: &[PyObjectRef]) -> PyResult {
         }
         Err(e) => Err(e),
     }
+}
+
+/// PyPy `Coroutine.descr__await__`: return a distinct iterator wrapper rather
+/// than making the coroutine object itself iterable.
+pub(crate) fn coroutine_await_method(args: &[PyObjectRef]) -> PyResult {
+    let coroutine = args.first().copied().unwrap_or(PY_NULL);
+    Ok(pyre_object::generator::w_coroutine_wrapper_new(coroutine))
+}
+
+pub(crate) fn coroutine_wrapper_next_method(args: &[PyObjectRef]) -> PyResult {
+    let wrapper = args.first().copied().unwrap_or(PY_NULL);
+    let coroutine = unsafe { pyre_object::generator::w_coroutine_wrapper_get_coroutine(wrapper) };
+    generator_send_ex(coroutine, w_none(), None, None)
+}
+
+pub(crate) fn coroutine_wrapper_send_method(args: &[PyObjectRef]) -> PyResult {
+    let wrapper = args.first().copied().unwrap_or(PY_NULL);
+    let coroutine = unsafe { pyre_object::generator::w_coroutine_wrapper_get_coroutine(wrapper) };
+    let value = args.get(1).copied().unwrap_or_else(w_none);
+    generator_send_ex(coroutine, value, None, None)
+}
+
+pub(crate) fn coroutine_wrapper_throw_method(args: &[PyObjectRef]) -> PyResult {
+    let wrapper = args.first().copied().unwrap_or(PY_NULL);
+    let coroutine = unsafe { pyre_object::generator::w_coroutine_wrapper_get_coroutine(wrapper) };
+    let mut forwarded = Vec::with_capacity(args.len());
+    forwarded.push(coroutine);
+    forwarded.extend_from_slice(args.get(1..).unwrap_or(&[]));
+    generator_throw_method(&forwarded)
+}
+
+pub(crate) fn coroutine_wrapper_close_method(args: &[PyObjectRef]) -> PyResult {
+    let wrapper = args.first().copied().unwrap_or(PY_NULL);
+    let coroutine = unsafe { pyre_object::generator::w_coroutine_wrapper_get_coroutine(wrapper) };
+    generator_close_method(&[coroutine])
 }
 
 /// generator.py:302 `_finalize_` — called by the GC finalizer when a suspended generator

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -6262,6 +6262,21 @@ fn parse_int_from_str(s: &str, base: u32) -> Result<PyObjectRef, crate::PyError>
         }
         cleaned.push(c);
     }
+    // PyPy `pypy/objspace/std/intobject.py:_string_to_int_or_long` applies
+    // the configurable limit to every non-binary base. Underscores are not
+    // digits and have already been removed from `cleaned`.
+    if radix & (radix - 1) != 0 {
+        let maxdigits = crate::module::sys::state::int_max_str_digits();
+        if maxdigits != 0 && cleaned.len() > maxdigits as usize {
+            return Err(crate::PyError::new(
+                crate::PyErrorKind::ValueError,
+                format!(
+                    "Exceeds the limit ({maxdigits}) for integer string conversion: value has {} digits",
+                    cleaned.len()
+                ),
+            ));
+        }
+    }
     if let Ok(v) = i64::from_str_radix(&cleaned, radix) {
         return Ok(w_int_new(sign * v));
     }

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -2913,7 +2913,7 @@ pub(crate) fn split_builtin_kwargs(args: &[PyObjectRef]) -> (&[PyObjectRef], Opt
         // value, not the marker, so it must not be stripped.
         let is_marker = unsafe {
             is_dict(last)
-                && pyre_object::w_dict_lookup(last, w_str_new("__pyre_kw__"))
+                && pyre_object::w_dict_getitem_str(last, "__pyre_kw__")
                     .is_some_and(pyre_object::kw_marker::is_kw_marker_sentinel)
         };
         if is_marker {
@@ -6654,7 +6654,13 @@ pub(crate) fn builtin_list_ctor(args: &[PyObjectRef]) -> Result<PyObjectRef, cra
 }
 
 pub fn collect_iterable(obj: PyObjectRef) -> Result<Vec<PyObjectRef>, crate::PyError> {
-    let it = crate::baseobjspace::iter(obj)?;
+    // `iter(obj)` itself can execute arbitrary allocating Python code.  Root
+    // the input before that first collection point, matching the root that
+    // RPython's shadowstack transform emits around `space.iter`.
+    let _roots = pyre_object::gc_roots::push_roots();
+    let obj_slot = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(obj);
+    let it = crate::baseobjspace::iter(pyre_object::gc_roots::shadow_stack_get(obj_slot))?;
     // Each `next` runs arbitrary allocating code (a generator body, a JIT
     // callee that boxes a fresh int) which can trigger a moving minor
     // collection. A raw `Vec<PyObjectRef>` on the malloc heap is invisible to
@@ -6664,9 +6670,17 @@ pub fn collect_iterable(obj: PyObjectRef) -> Result<Vec<PyObjectRef>, crate::PyE
     // then read the forwarded slots back out — the manual equivalent of the
     // translator's shadowstack save/restore around a collecting call
     // (framework.py:853-856).
-    let _roots = pyre_object::gc_roots::push_roots();
     let base = pyre_object::gc_roots::shadow_stack_len();
     pyre_object::gc_roots::pin_root(it);
+    // Dict-view iterators are currently off-GC RPython-style carriers.  Their
+    // registered raw-field walker covers frame/value-stack reachability, but
+    // this helper keeps the iterator on the shadow stack directly; retain its
+    // source dict explicitly for the duration of the native loop.
+    if unsafe { pyre_object::dictmultiobject::is_dict_view_iterator(it) } {
+        let w_dict = unsafe { pyre_object::dictmultiobject::w_dict_view_iterator_get_dict(it) };
+        pyre_object::gc_roots::pin_root(w_dict);
+    }
+    let item_base = pyre_object::gc_roots::shadow_stack_len();
     let mut count = 0usize;
     loop {
         // The iterator may itself have moved during a prior `next`; reload it
@@ -6681,10 +6695,10 @@ pub fn collect_iterable(obj: PyObjectRef) -> Result<Vec<PyObjectRef>, crate::PyE
             Err(e) => return Err(e),
         }
     }
-    // Read the forwarded element slots back out. The elements sit at
-    // `base + 1 ..= base + count` (the iterator occupies `base`).
+    // Read the forwarded element slots back out. `item_base` follows the
+    // iterator and any carrier-specific backing roots above.
     let items = (0..count)
-        .map(|i| pyre_object::gc_roots::shadow_stack_get(base + 1 + i))
+        .map(|i| pyre_object::gc_roots::shadow_stack_get(item_base + i))
         .collect();
     Ok(items)
 }

--- a/pyre/pyre-interpreter/src/call.rs
+++ b/pyre/pyre-interpreter/src/call.rs
@@ -4067,6 +4067,12 @@ pub unsafe fn create_all_slots(
         if let Some(w_flags) = crate::type_dict_lookup(w_type, "__abc_tpflags__") {
             if pyre_object::is_int(w_flags) {
                 let flags = pyre_object::w_int_get_value(w_flags);
+                let collection_flags = flags & ((1 << 6) | (1 << 5));
+                if collection_flags == ((1 << 6) | (1 << 5)) {
+                    return Err(crate::PyError::type_error(
+                        "__abc_tpflags__ cannot be both Py_TPFLAGS_SEQUENCE and Py_TPFLAGS_MAPPING",
+                    ));
+                }
                 if flags & (1 << 6) != 0 {
                     pyre_object::typeobject::w_type_set_flag_map_or_seq(w_type, b'M');
                 } else if flags & (1 << 5) != 0 {

--- a/pyre/pyre-interpreter/src/call.rs
+++ b/pyre/pyre-interpreter/src/call.rs
@@ -644,15 +644,36 @@ fn set_orig_class(result: PyObjectRef, alias: PyObjectRef) -> Result<(), crate::
 // `as_ref` read out of any traced graph.
 #[majit_macros::dont_look_inside]
 fn call_builtin_code_positional(code: PyObjectRef, args: &[PyObjectRef]) -> PyResult {
-    let func = unsafe { builtin_code_get(code) };
-    if let Some(sig) = unsafe { crate::builtin_code_get_signature(code) } {
+    // `gateway.py:824 BuiltinCode.funcrun` is translated with both its code
+    // object and `Arguments.arguments_w` live across gateway dispatch.  A
+    // collection between the outer `space.call_function` reload and this
+    // indirect Rust function-pointer call updates the outer shadow slots but
+    // not the copied native slice, so mirror the gateway's own root frame and
+    // reload immediately before invoking the builtin.
+    let _roots = pyre_object::gc_roots::push_roots();
+    let root_base = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(code);
+    for &arg in args {
+        pyre_object::gc_roots::pin_root(arg);
+    }
+    let current_code = || pyre_object::gc_roots::shadow_stack_get(root_base);
+    let current_args = || {
+        (0..args.len())
+            .map(|i| pyre_object::gc_roots::shadow_stack_get(root_base + 1 + i))
+            .collect::<Vec<_>>()
+    };
+
+    let func = unsafe { builtin_code_get(current_code()) };
+    if let Some(sig) = unsafe { crate::builtin_code_get_signature(current_code()) } {
         if sig.has_vararg() || sig.has_kwarg() || sig.num_kwonlyargnames() > 0 {
-            let fname = unsafe { crate::builtin_code_name(code) };
-            let bound = bind_kwargs_to_signature(sig, fname, args, &[])?;
+            let fname = unsafe { crate::builtin_code_name(current_code()) };
+            let args = current_args();
+            let bound = bind_kwargs_to_signature(sig, fname, &args, &[])?;
             return func(&bound);
         }
     }
-    func(args)
+    let args = current_args();
+    func(&args)
 }
 
 /// Leaf execution mode for a user-function call reached through
@@ -2296,12 +2317,31 @@ pub fn call_function_impl_result(
     callable: PyObjectRef,
     args: &[PyObjectRef],
 ) -> Result<PyObjectRef, PyError> {
+    // `baseobjspace.py:1195-1198 call_function` is translated RPython: its
+    // callable and `args_w` entries are shadow-stack roots across the entry
+    // stack check, and the GC transform reloads their possibly moved
+    // addresses afterwards.  Rust's incoming slice only contains copied raw
+    // pointers, so establish the same roots before the first collecting call
+    // and dispatch from freshly reloaded values.
+    let _roots = pyre_object::gc_roots::push_roots();
+    let root_base = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(callable);
+    for &arg in args {
+        pyre_object::gc_roots::pin_root(arg);
+    }
+
     // rpython/rlib/rstack.py:42 stack_check(): every interpreter call
     // boundary checks the native stack synchronously, so deep recursion
     // raises RecursionError instead of letting the OS abort on a
     // guard-page hit. Also drain any JIT-prologue pending overflow.
     crate::stack_check::drain_jit_pending_exception()?;
     crate::stack_check::stack_check()?;
+
+    let callable = pyre_object::gc_roots::shadow_stack_get(root_base);
+    let rooted_args = (0..args.len())
+        .map(|i| pyre_object::gc_roots::shadow_stack_get(root_base + 1 + i))
+        .collect::<Vec<_>>();
+    let args = rooted_args.as_slice();
 
     unsafe {
         if pyre_object::is_method(callable) {
@@ -2472,33 +2512,55 @@ pub fn type_call_instantiate(
 /// Type call without a PyFrame.
 /// PyPy: typeobject.py descr_call
 fn type_descr_call_impl(w_type: PyObjectRef, args: &[PyObjectRef]) -> PyObjectRef {
-    if let Err(e) = check_type_instantiable(w_type) {
+    // typeobject.py descr_call keeps `w_type`, every argument, and the new
+    // instance live across both Python calls.  In translated RPython the GC
+    // transform reloads these from shadow-stack slots after `__new__`; Rust
+    // slices are only copies and otherwise retain pre-move addresses.
+    let _roots = pyre_object::gc_roots::push_roots();
+    let root_base = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(w_type);
+    for &arg in args {
+        pyre_object::gc_roots::pin_root(arg);
+    }
+    let current_type = || pyre_object::gc_roots::shadow_stack_get(root_base);
+    let current_args = || {
+        (0..args.len())
+            .map(|i| pyre_object::gc_roots::shadow_stack_get(root_base + 1 + i))
+            .collect::<Vec<_>>()
+    };
+
+    if let Err(e) = check_type_instantiable(current_type()) {
         set_call_error(e);
         return PY_NULL;
     }
     // Step 1: __new__
-    let instance =
-        if let Some(new_fn) = unsafe { crate::baseobjspace::lookup_in_type(w_type, "__new__") } {
-            let mut new_args = Vec::with_capacity(1 + args.len());
-            new_args.push(w_type);
-            new_args.extend_from_slice(args);
-            call_function_impl(new_fn, &new_args)
-        } else {
-            pyre_object::w_instance_new(w_type)
-        };
+    let instance = if let Some(new_fn) =
+        unsafe { crate::baseobjspace::lookup_in_type(current_type(), "__new__") }
+    {
+        let mut new_args = Vec::with_capacity(1 + args.len());
+        new_args.push(current_type());
+        new_args.extend(current_args());
+        call_function_impl(new_fn, &new_args)
+    } else {
+        pyre_object::w_instance_new(current_type())
+    };
+    let instance_slot = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(instance);
 
     // Step 2: __init__ — only if __new__ returned an instance of w_type.
     // PyPy checks the Python-level type(instance), so builtin-layout subtypes
     // like set subclasses still run __init__.
-    if let Some(w_insttype) = type_call_init_type(instance, w_type)
-        && !type_call_type_x_shortcut(w_type, args.len(), true)
+    if let Some(w_insttype) = type_call_init_type(
+        pyre_object::gc_roots::shadow_stack_get(instance_slot),
+        current_type(),
+    ) && !type_call_type_x_shortcut(current_type(), args.len(), true)
     {
         if let Some(init_fn) =
             unsafe { crate::baseobjspace::lookup_in_type(w_insttype, "__init__") }
         {
             let mut init_args = Vec::with_capacity(1 + args.len());
-            init_args.push(instance);
-            init_args.extend_from_slice(args);
+            init_args.push(pyre_object::gc_roots::shadow_stack_get(instance_slot));
+            init_args.extend(current_args());
             let res = call_function_impl(init_fn, &init_args);
             if res.is_null() {
                 // `__init__` raised — error already stashed; propagate it.
@@ -2511,7 +2573,7 @@ fn type_descr_call_impl(w_type: PyObjectRef, args: &[PyObjectRef]) -> PyObjectRe
         }
     }
 
-    instance
+    pyre_object::gc_roots::shadow_stack_get(instance_slot)
 }
 
 /// `typeobject.py descr_call` — `__init__` must return None.  A non-null,

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -902,6 +902,11 @@ fn walk_global_prebuilt_roots(visitor: &mut dyn FnMut(&mut majit_ir::GcRef)) {
     walk_bh_last_exception(visitor);
     crate::call::walk_pending_call_error(visitor);
     crate::baseobjspace::walk_pending_hash_error(visitor);
+    // `reduce_protocol`'s app-level interphook handles are process-global
+    // off-GC slots.  RPython stores them in the space's ordinary object graph;
+    // expose the equivalent slots on every collection so both minor moves and
+    // major marking preserve their functions and private globals namespace.
+    crate::reduce_protocol::walk_handle_roots(visitor);
     let is_minor = majit_gc::shadow_stack::extra_root_walk_kind()
         == majit_gc::shadow_stack::ExtraRootWalkKind::Minor;
     let scan_prebuilt = !is_minor
@@ -2097,6 +2102,10 @@ unsafe fn load_global_via_cache(
 /// PyPy: pyopcode.py GET_ITER → space.iter(w_iterable)
 ///       pyopcode.py FOR_ITER → space.next(w_iterator)
 impl IterOpcodeHandler for PyFrame {
+    fn iter_value(&mut self, iterable: Self::Value) -> Result<Self::Value, PyError> {
+        crate::baseobjspace::iter(iterable)
+    }
+
     /// GET_ITER: convert iterable to iterator.
     /// PyPy: space.iter(w_iterable) → calls __iter__ or wraps in seq_iter.
     fn ensure_iter_value(&mut self, iter: Self::Value) -> Result<(), PyError> {
@@ -3763,7 +3772,15 @@ impl OpcodeStepExecutor for PyFrame {
         let value = self.pop();
         let iter = self.peek();
         let result = if unsafe { pyre_object::is_none(value) } {
-            crate::baseobjspace::next(iter)
+            // generator.py / pyopcode.py `next_yield_from`: coroutine
+            // objects are not public iterators, but the interpreter's SEND
+            // machinery resumes both GeneratorIterator and Coroutine through
+            // their shared `send_ex(None)` path.
+            if unsafe { pyre_object::generator::is_generator_or_coroutine(iter) } {
+                crate::baseobjspace::generator_next_method(&[iter])
+            } else {
+                crate::baseobjspace::next(iter)
+            }
         } else {
             let send = crate::baseobjspace::getattr_str(iter, "send")?;
             crate::call::call_function_impl_result(send, &[value])

--- a/pyre/pyre-interpreter/src/executioncontext.rs
+++ b/pyre/pyre-interpreter/src/executioncontext.rs
@@ -1920,7 +1920,7 @@ impl UserDelAction {
     }
 
     pub fn _call_finalizer(&mut self, w_obj: PyObjectRef) {
-        if unsafe { pyre_object::generator::is_generator(w_obj) } {
+        if unsafe { pyre_object::generator::is_generator_or_coroutine(w_obj) } {
             if self.gc_disabled(w_obj) {
                 return;
             }

--- a/pyre/pyre-interpreter/src/importing.rs
+++ b/pyre/pyre-interpreter/src/importing.rs
@@ -365,7 +365,7 @@ thread_local! {
     ///
     /// Maps module name → initializer function that populates a GC module dict.
     /// Each builtin module is lazily created on first import.
-    pub(crate) static BUILTIN_MODULES: RefCell<HashMap<&'static str, fn(PyObjectRef)>> =
+    pub(crate) static BUILTIN_MODULES: RefCell<HashMap<&'static str, BuiltinModuleDef>> =
         RefCell::new(HashMap::new());
 
     static IMPORT_ROOT_AREA: ImportRootArea = ImportRootArea {
@@ -373,6 +373,12 @@ thread_local! {
         modules_dict: SYS_MODULES_DICT.with(|dict| dict as *const _),
         argv_pending: SYS_ARGV_PENDING.with(|p| p as *const _),
     };
+}
+
+#[derive(Clone, Copy)]
+pub(crate) struct BuiltinModuleDef {
+    init: fn(PyObjectRef),
+    startup: Option<fn(PyObjectRef, *const PyExecutionContext) -> Result<(), crate::PyError>>,
 }
 
 struct ImportRootArea {
@@ -404,7 +410,32 @@ struct ImportRootArea {
 /// PyPy equivalent: Module.install() → space.builtin_modules[name] = mod
 pub fn register_builtin_module(name: &'static str, init: fn(PyObjectRef)) {
     BUILTIN_MODULES.with(|m| {
-        m.borrow_mut().insert(name, init);
+        m.borrow_mut().insert(
+            name,
+            BuiltinModuleDef {
+                init,
+                startup: None,
+            },
+        );
+    });
+}
+
+/// Register a MixedModule initializer plus its `Module.startup` hook.
+/// The hook runs after the new module is visible in `sys.modules`, matching
+/// `getbuiltinmodule()` and allowing startup imports without a module cycle.
+pub fn register_builtin_module_with_startup(
+    name: &'static str,
+    init: fn(PyObjectRef),
+    startup: fn(PyObjectRef, *const PyExecutionContext) -> Result<(), crate::PyError>,
+) {
+    BUILTIN_MODULES.with(|m| {
+        m.borrow_mut().insert(
+            name,
+            BuiltinModuleDef {
+                init,
+                startup: Some(startup),
+            },
+        );
     });
 }
 
@@ -579,7 +610,6 @@ pub fn install_builtin_modules() {
         "_heapq",
         "_tokenize",
         "_bisect",
-        "_json",
         "marshal",
         "_stat",
         "_queue",
@@ -587,7 +617,11 @@ pub fn install_builtin_modules() {
     ] {
         register_builtin_module(name, empty_module_init);
     }
-    register_builtin_module("array", crate::module::array::init_array_module);
+    register_builtin_module_with_startup(
+        "array",
+        crate::module::array::init_array_module,
+        crate::module::array::startup_array_module,
+    );
     register_builtin_module("_csv", crate::module::_csv::init);
     register_builtin_module("_scproxy", init_scproxy);
     register_builtin_module("_string", init_string_module);
@@ -825,7 +859,7 @@ fn init_sysconfigdata_empty(ns: PyObjectRef) {
 /// `allocate_and_init_instance(module=True)`. Pyre mirrors that here:
 /// the initializer writes directly into a rooted, non-moving module dict.
 fn load_builtin_module(name: &str) -> Option<PyObjectRef> {
-    let init_fn = BUILTIN_MODULES.with(|m| m.borrow().get(name).copied())?;
+    let module_def = BUILTIN_MODULES.with(|m| m.borrow().get(name).copied())?;
     let w_dict = pyre_object::dictmultiobject::w_module_dict_new();
     let _roots = pyre_object::gc_roots::push_roots();
     let save_point = pyre_object::gc_roots::shadow_stack_len();
@@ -839,7 +873,7 @@ fn load_builtin_module(name: &str) -> Option<PyObjectRef> {
         pyre_object::gc_roots::shadow_stack_get(save_point + 1),
     );
     // Run module-specific initializer (PyPy: interpleveldefs)
-    init_fn(w_dict);
+    (module_def.init)(w_dict);
     // MixedModule parity: interp-level builtin functions carry the module
     // name as `__module__`, so `pickle` can save them by reference
     // (`save_global`) without guessing via `whichmodule`. Snapshot owned
@@ -883,6 +917,18 @@ fn load_builtin_module(name: &str) -> Option<PyObjectRef> {
         crate::module_ns_store(w_dict, "__builtins__", module);
     }
     Some(module)
+}
+
+fn startup_builtin_module(
+    name: &str,
+    module: PyObjectRef,
+    execution_context: *const PyExecutionContext,
+) -> Result<(), crate::PyError> {
+    let startup = BUILTIN_MODULES.with(|m| m.borrow().get(name).and_then(|d| d.startup));
+    if let Some(startup) = startup {
+        startup(module, execution_context)?;
+    }
+    Ok(())
 }
 
 /// Initialize sys.path with the directory containing the main script.
@@ -1851,6 +1897,7 @@ fn load_part(
             })?
         };
         set_sys_module(modulename, m);
+        startup_builtin_module(modulename, m, execution_context)?;
         return Ok(Some(m));
     }
 
@@ -1892,6 +1939,7 @@ fn load_part(
             };
             // Store builtin modules in cache immediately
             set_sys_module(modulename, m);
+            startup_builtin_module(partname, m, execution_context)?;
             m
         }
     };

--- a/pyre/pyre-interpreter/src/jit_fnaddr.rs
+++ b/pyre/pyre-interpreter/src/jit_fnaddr.rs
@@ -1985,6 +1985,11 @@ pub fn jit_static_pytype_addrs() -> Vec<(&'static str, i64)> {
             interp_exceptions::EXC_SYNTAX_ERROR_TYPE
         ),
         pytype_addr!("generator::GENERATOR_TYPE", generator::GENERATOR_TYPE),
+        pytype_addr!("generator::COROUTINE_TYPE", generator::COROUTINE_TYPE),
+        pytype_addr!(
+            "generator::COROUTINE_WRAPPER_TYPE",
+            generator::COROUTINE_WRAPPER_TYPE
+        ),
         pytype_addr!("pyobject::INT_TYPE", pyobject::INT_TYPE),
         pytype_addr!("pyobject::BOOL_TYPE", pyobject::BOOL_TYPE),
         pytype_addr!("pyobject::FLOAT_TYPE", pyobject::FLOAT_TYPE),

--- a/pyre/pyre-interpreter/src/module/_weakref/interp__weakref.rs
+++ b/pyre/pyre-interpreter/src/module/_weakref/interp__weakref.rs
@@ -41,11 +41,21 @@ const ATTR_W_HASH: &str = "w_hash";
 /// `baseobjspace::getattr_str` would otherwise force the receiver and recurse
 /// indefinitely while the proxy is reading its OWN `w_obj_weak`/etc.
 fn read_attr(obj: PyObjectRef, name: &str) -> PyObjectRef {
-    let w_dict = crate::baseobjspace::getdict(obj);
+    let _roots = pyre_object::gc_roots::push_roots();
+    let root_base = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(obj);
+    let w_dict = crate::baseobjspace::getdict(pyre_object::gc_roots::shadow_stack_get(root_base));
     if w_dict.is_null() {
         return PY_NULL;
     }
-    let value = unsafe { pyre_object::w_dict_getitem_str(w_dict, name) }.unwrap_or(PY_NULL);
+    pyre_object::gc_roots::pin_root(w_dict);
+    let value = unsafe {
+        pyre_object::w_dict_getitem_str(
+            pyre_object::gc_roots::shadow_stack_get(root_base + 1),
+            name,
+        )
+    }
+    .unwrap_or(PY_NULL);
     if value.is_null() || unsafe { pyre_object::is_none(value) } {
         return PY_NULL;
     }
@@ -55,9 +65,20 @@ fn read_attr(obj: PyObjectRef, name: &str) -> PyObjectRef {
 /// Mirror of `read_attr` for writes — direct dict access keeps lifeline /
 /// proxy / weakref bookkeeping out of the fast-path's force loop.
 fn write_attr(obj: PyObjectRef, name: &str, value: PyObjectRef) {
-    let w_dict = crate::baseobjspace::getdict(obj);
+    let _roots = pyre_object::gc_roots::push_roots();
+    let root_base = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(obj);
+    pyre_object::gc_roots::pin_root(value);
+    let w_dict = crate::baseobjspace::getdict(pyre_object::gc_roots::shadow_stack_get(root_base));
     if !w_dict.is_null() {
-        unsafe { pyre_object::w_dict_setitem_str(w_dict, name, value) };
+        pyre_object::gc_roots::pin_root(w_dict);
+        unsafe {
+            pyre_object::w_dict_setitem_str(
+                pyre_object::gc_roots::shadow_stack_get(root_base + 2),
+                name,
+                pyre_object::gc_roots::shadow_stack_get(root_base + 1),
+            )
+        };
     }
 }
 
@@ -657,18 +678,21 @@ pub fn descr__init__weakref(args: &[PyObjectRef]) -> Result<PyObjectRef, PyError
 ///     return self.w_hash
 /// ```
 pub fn descr_hash(args: &[PyObjectRef]) -> Result<PyObjectRef, PyError> {
-    let w_self = args[0];
-    let cached = read_attr(w_self, ATTR_W_HASH);
+    let _roots = pyre_object::gc_roots::push_roots();
+    let root_base = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(args[0]);
+    let current_self = || pyre_object::gc_roots::shadow_stack_get(root_base);
+    let cached = read_attr(current_self(), ATTR_W_HASH);
     if !cached.is_null() {
         return Ok(cached);
     }
-    let w_obj = dereference(w_self);
+    let w_obj = dereference(current_self());
     if w_obj.is_null() || unsafe { pyre_object::is_none(w_obj) } {
         return Err(PyError::type_error("weak object has gone away".to_string()));
     }
     // pyre's hash: identity-based for non-int/non-str. Mirrors space.hash(w_obj).
     let h = pyre_object::w_int_new(w_obj as i64);
-    write_attr(w_self, ATTR_W_HASH, h);
+    write_attr(current_self(), ATTR_W_HASH, h);
     Ok(h)
 }
 

--- a/pyre/pyre-interpreter/src/module/array/mod.rs
+++ b/pyre/pyre-interpreter/src/module/array/mod.rs
@@ -1128,3 +1128,25 @@ pub fn init_array_module(ns: pyre_object::PyObjectRef) {
         crate::make_builtin_function("_array_reconstructor", array_reconstructor),
     );
 }
+
+/// PyPy `pypy/module/array/moduledef.py:Module.startup`: array is a
+/// virtual `MutableSequence`, registered only after the builtin module is in
+/// `sys.modules` so importing `_collections_abc` cannot create a second array
+/// module during a cycle.
+pub fn startup_array_module(
+    _module: pyre_object::PyObjectRef,
+    execution_context: *const crate::PyExecutionContext,
+) -> Result<(), crate::PyError> {
+    let abc_module = crate::importing::importhook(
+        "_collections_abc",
+        pyre_object::PY_NULL,
+        pyre_object::w_tuple_new(vec![pyre_object::w_str_new("MutableSequence")]),
+        0,
+        execution_context,
+    )?;
+    let mutable_sequence = crate::baseobjspace::getattr_str(abc_module, "MutableSequence")?;
+    let register = crate::baseobjspace::getattr_str(mutable_sequence, "register")?;
+    let array_type = crate::typedef::gettypeobject(&pyre_object::interp_array::ARRAY_TYPE);
+    crate::call::call_function_impl_result(register, &[array_type])?;
+    Ok(())
+}

--- a/pyre/pyre-interpreter/src/module/sys/state.rs
+++ b/pyre/pyre-interpreter/src/module/sys/state.rs
@@ -26,6 +26,15 @@ pub const MAX_RECURSION_LIMIT: i32 = 1_000_000;
 /// byte-budget (`PYRE_STACKTOOBIG.length`) hot in L1.
 static RECURSION_LIMIT: AtomicI32 = AtomicI32::new(DEFAULT_RECURSION_LIMIT);
 
+/// PyPy `pypy/module/sys/system.py:15-18`.
+pub const DEFAULT_MAX_STR_DIGITS: i32 = 4300;
+pub const MAX_STR_DIGITS_THRESHOLD: i32 = 640;
+
+/// `State.w_int_max_str_digits` parity (`pypy/module/sys/state.py:21`).
+/// Pyre currently has one object space, so its process-global sys module
+/// state is represented by the corresponding process-global atomic.
+static INT_MAX_STR_DIGITS: AtomicI32 = AtomicI32::new(DEFAULT_MAX_STR_DIGITS);
+
 /// `space.sys.recursionlimit` getter. Matches
 /// `pypy/module/sys/vm.py:102 return space.newint(space.sys.recursionlimit)`.
 #[inline]
@@ -38,6 +47,24 @@ pub fn recursion_limit() -> i32 {
 #[inline]
 pub fn set_recursion_limit(new_limit: i32) {
     RECURSION_LIMIT.store(new_limit, Ordering::Relaxed);
+}
+
+#[inline]
+pub fn int_max_str_digits() -> i32 {
+    INT_MAX_STR_DIGITS.load(Ordering::Relaxed)
+}
+
+/// `pypy/module/sys/state.py:set_int_max_str_digits` validation.
+pub fn set_int_max_str_digits(maxdigits: i32) -> Result<(), crate::PyError> {
+    if maxdigits == 0 || maxdigits >= MAX_STR_DIGITS_THRESHOLD {
+        INT_MAX_STR_DIGITS.store(maxdigits, Ordering::Relaxed);
+        Ok(())
+    } else {
+        Err(crate::PyError::new(
+            crate::PyErrorKind::ValueError,
+            format!("maxdigits {maxdigits} must be 0 or larger than {MAX_STR_DIGITS_THRESHOLD}"),
+        ))
+    }
 }
 
 /// Reset to the default value. Used by unit tests that need a clean

--- a/pyre/pyre-interpreter/src/module/sys/vm.rs
+++ b/pyre/pyre-interpreter/src/module/sys/vm.rs
@@ -579,6 +579,31 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
             1,
         ),
     );
+    // PyPy: pypy/module/sys/state.py:get_int_max_str_digits and
+    // set_int_max_str_digits. The limit is object-space state, shared by
+    // every caller rather than thread-local state.
+    module_ns_store(
+        ns,
+        "get_int_max_str_digits",
+        make_builtin_function_with_arity(
+            "get_int_max_str_digits",
+            |_| Ok(w_int_new(crate::module::sys::state::int_max_str_digits() as i64)),
+            0,
+        ),
+    );
+    module_ns_store(
+        ns,
+        "set_int_max_str_digits",
+        make_builtin_function_with_arity(
+            "set_int_max_str_digits",
+            |args| {
+                let maxdigits = crate::baseobjspace::c_int_w(args[0])?;
+                crate::module::sys::state::set_int_max_str_digits(maxdigits)?;
+                Ok(w_none())
+            },
+            1,
+        ),
+    );
     // sys.intern
     module_ns_store(
         ns,

--- a/pyre/pyre-interpreter/src/objspace/descroperation.rs
+++ b/pyre/pyre-interpreter/src/objspace/descroperation.rs
@@ -1533,9 +1533,36 @@ unsafe fn try_instance_binop(a: PyObjectRef, b: PyObjectRef, dunder: &str) -> Op
         if let Some(rdunder) = reverse_dunder(dunder) {
             let a_type = w_instance_get_type(a);
             let b_type = w_instance_get_type(b);
-            !std::ptr::eq(a_type, b_type)
-                && issubtype_cached(b_type, a_type)
-                && lookup_in_type_where(b_type, rdunder).is_some()
+            if std::ptr::eq(a_type, b_type) || !issubtype_cached(b_type, a_type) {
+                false
+            } else {
+                // PyPy `descroperation.py:_call_binop_impl` compares the
+                // classes that *define* the forward and reflected methods,
+                // not merely the operand types. An inherited `__rop__` from
+                // the same defining class must not pre-empt the lhs method.
+                // This distinction is observable for `ChainMap | Subclass`.
+                match (
+                    crate::baseobjspace::lookup_where_pair(a_type, dunder),
+                    crate::baseobjspace::lookup_where_pair(b_type, rdunder),
+                ) {
+                    (Some((left_src, _)), Some((right_src, _)))
+                        if !std::ptr::eq(left_src, right_src) =>
+                    {
+                        let left_src_below_right =
+                            match p_abstract_issubclass_w(left_src, right_src) {
+                                Ok(value) => value,
+                                Err(err) => return Some(Err(err)),
+                            };
+                        let left_type_below_right = match p_abstract_issubclass_w(a_type, right_src)
+                        {
+                            Ok(value) => value,
+                            Err(err) => return Some(Err(err)),
+                        };
+                        !left_src_below_right && !left_type_below_right
+                    }
+                    _ => false,
+                }
+            }
         } else {
             false
         }

--- a/pyre/pyre-interpreter/src/pyframe.rs
+++ b/pyre/pyre-interpreter/src/pyframe.rs
@@ -447,7 +447,20 @@ impl FrameBox {
         // block is non-moving (old-gen when GC-managed, `std::alloc`
         // otherwise), so only the locals array needs protecting.
         let _root = FrameLocalsRoot::new(frame_ptr);
-        let generator = pyre_object::generator::w_generator_new(frame_ptr as *mut u8);
+        // generator.py: GeneratorIterator / Coroutine — native `async def`
+        // frames have their own object type.  In particular, a Coroutine is
+        // awaitable but is not itself an iterator; `__await__` supplies the
+        // separate CoroutineWrapper iterator.
+        let generator = if unsafe {
+            (*frame_ptr)
+                .code()
+                .flags
+                .contains(crate::CodeFlags::COROUTINE)
+        } {
+            pyre_object::generator::w_coroutine_new(frame_ptr as *mut u8)
+        } else {
+            pyre_object::generator::w_generator_new(frame_ptr as *mut u8)
+        };
         unsafe {
             (*frame_ptr).f_generator_nowref = generator;
         }
@@ -3190,14 +3203,32 @@ impl PyFrame {
         closure: PyObjectRef,
         allocation: FrameLocalsArrayAllocation,
     ) -> Result<Self, crate::PyError> {
-        let w_builtin =
-            crate::baseobjspace::frame_builtin_obj_checked(w_globals, execution_context)?;
-        Ok(Self::finish_for_call_with_globals_obj(
-            code,
-            args,
-            w_globals,
+        // The RPython shadowstack transform roots every live call argument
+        // around `pick_builtin`, which may allocate or execute a mapping
+        // lookup.  A JIT residual call passes Rust copies of gcmap-backed
+        // values here; after a collection only the gcmap/shadow slots are
+        // forwarded, so never carry the original slice across that call.
+        let _roots = pyre_object::gc_roots::push_roots();
+        let root_base = pyre_object::gc_roots::shadow_stack_len();
+        pyre_object::gc_roots::pin_root(code as PyObjectRef);
+        pyre_object::gc_roots::pin_root(w_globals);
+        pyre_object::gc_roots::pin_root(closure);
+        for &arg in args {
+            pyre_object::gc_roots::pin_root(arg);
+        }
+        let w_builtin = crate::baseobjspace::frame_builtin_obj_checked(
+            pyre_object::gc_roots::shadow_stack_get(root_base + 1),
             execution_context,
-            closure,
+        )?;
+        let current_args: Vec<PyObjectRef> = (0..args.len())
+            .map(|i| pyre_object::gc_roots::shadow_stack_get(root_base + 3 + i))
+            .collect();
+        Ok(Self::finish_for_call_with_globals_obj(
+            pyre_object::gc_roots::shadow_stack_get(root_base) as *const (),
+            &current_args,
+            pyre_object::gc_roots::shadow_stack_get(root_base + 1),
+            execution_context,
+            pyre_object::gc_roots::shadow_stack_get(root_base + 2),
             w_builtin,
             allocation,
         ))
@@ -3219,13 +3250,27 @@ impl PyFrame {
         closure: PyObjectRef,
         allocation: FrameLocalsArrayAllocation,
     ) -> Self {
-        let w_builtin = crate::baseobjspace::frame_builtin_obj(w_globals, execution_context);
-        Self::finish_for_call_with_globals_obj(
-            code,
-            args,
-            w_globals,
+        let _roots = pyre_object::gc_roots::push_roots();
+        let root_base = pyre_object::gc_roots::shadow_stack_len();
+        pyre_object::gc_roots::pin_root(code as PyObjectRef);
+        pyre_object::gc_roots::pin_root(w_globals);
+        pyre_object::gc_roots::pin_root(closure);
+        for &arg in args {
+            pyre_object::gc_roots::pin_root(arg);
+        }
+        let w_builtin = crate::baseobjspace::frame_builtin_obj(
+            pyre_object::gc_roots::shadow_stack_get(root_base + 1),
             execution_context,
-            closure,
+        );
+        let current_args: Vec<PyObjectRef> = (0..args.len())
+            .map(|i| pyre_object::gc_roots::shadow_stack_get(root_base + 3 + i))
+            .collect();
+        Self::finish_for_call_with_globals_obj(
+            pyre_object::gc_roots::shadow_stack_get(root_base) as *const (),
+            &current_args,
+            pyre_object::gc_roots::shadow_stack_get(root_base + 1),
+            execution_context,
+            pyre_object::gc_roots::shadow_stack_get(root_base + 2),
             w_builtin,
             allocation,
         )
@@ -3243,8 +3288,22 @@ impl PyFrame {
         w_builtin: PyObjectRef,
         allocation: FrameLocalsArrayAllocation,
     ) -> Self {
+        // `alloc_frame_locals_array` is a collection point.  Keep the call
+        // inputs in real shadow-stack slots and populate the new locals array
+        // from those forwarded slots, matching gctransform/framework.py's
+        // push_roots/pop_roots around a GC allocation.
+        let _roots = pyre_object::gc_roots::push_roots();
+        let root_base = pyre_object::gc_roots::shadow_stack_len();
+        pyre_object::gc_roots::pin_root(code as PyObjectRef);
+        pyre_object::gc_roots::pin_root(w_globals);
+        pyre_object::gc_roots::pin_root(closure);
+        pyre_object::gc_roots::pin_root(w_builtin);
+        for &arg in args {
+            pyre_object::gc_roots::pin_root(arg);
+        }
         let code_ref = unsafe {
-            &*(crate::w_code_get_ptr(code as pyre_object::PyObjectRef) as *const CodeObject)
+            &*(crate::w_code_get_ptr(pyre_object::gc_roots::shadow_stack_get(root_base))
+                as *const CodeObject)
         };
         let num_locals = code_ref.varnames.len();
         let num_cells = ncells(code_ref);
@@ -3261,7 +3320,7 @@ impl PyFrame {
             // Bind positional arguments directly -- no intermediate Vec.
             let nargs = args.len().min(num_locals);
             for i in 0..nargs {
-                arr[i] = args[i];
+                arr[i] = pyre_object::gc_roots::shadow_stack_get(root_base + 4 + i);
             }
 
             // CPython 3.11+ `co_localsplusnames` unified slot layout:
@@ -3275,6 +3334,7 @@ impl PyFrame {
             for i in 0..npure {
                 arr[num_locals + i] = pyre_object::w_cell_new(PY_NULL);
             }
+            let closure = pyre_object::gc_roots::shadow_stack_get(root_base + 2);
             if !closure.is_null() {
                 let nfreevars = code_ref.freevars.len();
                 for i in 0..nfreevars {
@@ -3292,13 +3352,16 @@ impl PyFrame {
         // pyframe.py:103 — stamp `pycode.w_globals`; side effect only (the
         // gated debugdata snapshot retired in favour of `w_globals`).
         unsafe {
-            crate::w_code_frame_stores_global(code as PyObjectRef, w_globals);
+            crate::w_code_frame_stores_global(
+                pyre_object::gc_roots::shadow_stack_get(root_base),
+                pyre_object::gc_roots::shadow_stack_get(root_base + 1),
+            );
         }
 
         let mut frame = PyFrame {
             ob_header: frame_ob_header(),
             execution_context,
-            pycode: code,
+            pycode: pyre_object::gc_roots::shadow_stack_get(root_base) as *const (),
             locals_cells_stack_w,
             valuestackdepth: num_locals + num_cells,
             last_instr: -1,
@@ -3310,8 +3373,8 @@ impl PyFrame {
             f_generator_nowref: PY_NULL,
             w_yielding_from: PY_NULL,
             f_backref: std::ptr::null_mut(),
-            w_builtin,
-            w_globals,
+            w_builtin: pyre_object::gc_roots::shadow_stack_get(root_base + 3),
+            w_globals: pyre_object::gc_roots::shadow_stack_get(root_base + 1),
         };
         frame.init_cells();
         frame

--- a/pyre/pyre-interpreter/src/pyopcode.rs
+++ b/pyre/pyre-interpreter/src/pyopcode.rs
@@ -306,6 +306,10 @@ pub trait StackOpcodeHandler: SharedOpcodeHandler {
 }
 
 pub trait IterOpcodeHandler: SharedOpcodeHandler {
+    /// PyPy `GET_ITER`: `w_iterable = popvalue(); pushvalue(space.iter(w_iterable))`.
+    fn iter_value(&mut self, iterable: Self::Value) -> Result<Self::Value, PyError>;
+    /// Legacy in-place conversion hook retained while out-of-tree opcode
+    /// executors migrate to `iter_value`; the shared opcode no longer calls it.
     fn ensure_iter_value(&mut self, iter: Self::Value) -> Result<(), PyError>;
     // FOR_ITER drives a single space.next (pyopcode.py:1288).
     // Ok(Some(v)) = next value; Ok(None) = StopIteration (exhausted);
@@ -659,8 +663,9 @@ pub fn opcode_swap<H: StackOpcodeHandler + ?Sized>(
 }
 
 pub fn opcode_get_iter<H: IterOpcodeHandler + ?Sized>(handler: &mut H) -> Result<(), PyError> {
-    let iter = handler.peek_at(0)?;
-    handler.ensure_iter_value(iter)
+    let iterable = handler.pop_value()?;
+    let iterator = handler.iter_value(iterable)?;
+    handler.push_value(iterator)
 }
 
 pub fn opcode_for_iter<H: IterOpcodeHandler + ControlFlowOpcodeHandler + ?Sized>(

--- a/pyre/pyre-interpreter/src/reduce_protocol.rs
+++ b/pyre/pyre-interpreter/src/reduce_protocol.rs
@@ -26,42 +26,67 @@ const REDUCE_1: usize = 0;
 const REDUCE_2: usize = 1;
 const GET_SLOTVALUES: usize = 2;
 
-thread_local! {
-    static HANDLES: std::cell::OnceCell<[PyObjectRef; 3]> = const { std::cell::OnceCell::new() };
-}
+static HANDLES: std::sync::Mutex<[usize; 3]> = std::sync::Mutex::new([0; 3]);
 
 /// Resolve (and cache) the three app-level handles.
 ///
 /// Executes `reduce_protocol_app.py` into its own fresh module globals and
-/// stores the selected handles in a rooted GC module dict.  The functions
+/// stores the selected handles in process-global GC root slots.  The functions
 /// retain the execution namespace as their `__globals__`, which keeps
 /// `slotnames` reachable from `get_slotvalues` even though only three names
 /// are surfaced.
 fn handle(which: usize) -> PyObjectRef {
-    HANDLES.with(|cell| {
-        cell.get_or_init(|| {
-            let ctx = crate::call::getexecutioncontext();
-            if ctx.is_null() {
-                panic!("reduce_protocol: no execution context");
-            }
-            let _roots = pyre_object::gc_roots::push_roots();
-            let save_point = pyre_object::gc_roots::shadow_stack_len();
-            let w_app_globals = pyre_object::dictmultiobject::w_module_dict_new();
-            pyre_object::gc_roots::pin_root(w_app_globals);
-            crate::importing::appleveldef_install(
-                pyre_object::gc_roots::shadow_stack_get(save_point),
-                include_str!("reduce_protocol_app.py"),
-                "reduce_protocol_app.py",
-                &["reduce_1", "reduce_2", "get_slotvalues"],
-            );
-            let w_app_globals = pyre_object::gc_roots::shadow_stack_get(save_point);
-            let get = |name: &str| {
-                unsafe { pyre_object::w_dict_getitem_str(w_app_globals, name) }
-                    .unwrap_or_else(|| panic!("reduce_protocol: `{name}` not bound"))
-            };
-            [get("reduce_1"), get("reduce_2"), get("get_slotvalues")]
-        })[which]
-    })
+    let cached = HANDLES.lock().unwrap()[which];
+    if cached != 0 {
+        return cached as PyObjectRef;
+    }
+
+    // Do not hold HANDLES while executing Python: applevel installation can
+    // collect, and the root walker below must be able to lock the slots.  The
+    // shadow root keeps the namespace/functions alive until the finished
+    // array is published.  A racing initializer may duplicate this work, but
+    // publication remains atomic under the mutex and either complete set is
+    // equivalent.
+    let ctx = crate::call::getexecutioncontext();
+    if ctx.is_null() {
+        panic!("reduce_protocol: no execution context");
+    }
+    let _roots = pyre_object::gc_roots::push_roots();
+    let save_point = pyre_object::gc_roots::shadow_stack_len();
+    let w_app_globals = pyre_object::dictmultiobject::w_module_dict_new();
+    pyre_object::gc_roots::pin_root(w_app_globals);
+    crate::importing::appleveldef_install(
+        pyre_object::gc_roots::shadow_stack_get(save_point),
+        include_str!("reduce_protocol_app.py"),
+        "reduce_protocol_app.py",
+        &["reduce_1", "reduce_2", "get_slotvalues"],
+    );
+    let w_app_globals = pyre_object::gc_roots::shadow_stack_get(save_point);
+    let get = |name: &str| {
+        unsafe { pyre_object::w_dict_getitem_str(w_app_globals, name) }
+            .unwrap_or_else(|| panic!("reduce_protocol: `{name}` not bound"))
+    };
+    let initialized = [
+        get("reduce_1") as usize,
+        get("reduce_2") as usize,
+        get("get_slotvalues") as usize,
+    ];
+    let mut handles = HANDLES.lock().unwrap();
+    if handles[which] == 0 {
+        *handles = initialized;
+    }
+    handles[which] as PyObjectRef
+}
+
+/// RPython's GC transform treats the app-level interphook cache as a normal
+/// object graph.  Pyre stores the equivalent shared handles outside the GC,
+/// so expose each slot to the global root walker and write relocated pointers
+/// back in place.
+pub(crate) fn walk_handle_roots(visitor: &mut dyn FnMut(&mut majit_ir::GcRef)) {
+    let mut handles = HANDLES.lock().unwrap();
+    for slot in handles.iter_mut().filter(|slot| **slot != 0) {
+        unsafe { visitor(&mut *(slot as *mut usize as *mut majit_ir::GcRef)) };
+    }
 }
 
 /// `%T`-style class name of `w_obj` for error messages.

--- a/pyre/pyre-interpreter/src/runtime_ops.rs
+++ b/pyre/pyre-interpreter/src/runtime_ops.rs
@@ -1590,6 +1590,24 @@ pub extern "C" fn jit_next(iter: i64) -> i64 {
     }
 }
 
+/// Residual PyPy `GET_ITER` operation.  `space.iter` may execute a user
+/// `__iter__`, so the trace treats this as may-force and consumes the
+/// published exception through the ordinary guards.
+#[majit_macros::jit_may_force]
+pub extern "C" fn jit_get_iter(iterable: i64) -> i64 {
+    match crate::baseobjspace::iter(iterable as PyObjectRef) {
+        Ok(iterator) => iterator as i64,
+        Err(err) => {
+            let exc_obj = err.to_exc_object();
+            if exc_obj != PY_NULL {
+                majit_metainterp::blackhole::BH_LAST_EXC_VALUE.with(|c| c.set(exc_obj as i64));
+            }
+            jit_publish_exception(exc_obj);
+            0
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/pyre/pyre-interpreter/src/type_methods.rs
+++ b/pyre/pyre-interpreter/src/type_methods.rs
@@ -5156,22 +5156,22 @@ pub(crate) fn dict_update1(w_dict: PyObjectRef, w_data: PyObjectRef) -> Result<(
     pyre_object::gc_roots::pin_root(w_data);
     let dict = || pyre_object::gc_roots::shadow_stack_get(root_base);
     let data = || pyre_object::gc_roots::shadow_stack_get(root_base + 1);
-    let other_raw = resolve_dict_backing(data());
     unsafe {
-        let fast_path_eligible = other_raw.is_null() == false
-            && pyre_object::is_dict(other_raw)
+        let fast_path_eligible = !resolve_dict_backing(data()).is_null()
+            && pyre_object::is_dict(resolve_dict_backing(data()))
             && dict_subclass_uses_default_iter(data());
         if fast_path_eligible {
             // `dictmultiobject.py:1401-1406 update1_dict_dict`
             let dst_is_empty = pyre_object::dictmultiobject::w_dict_is_regular_empty(dict());
             if dst_is_empty {
-                let w_copy = pyre_object::dictmultiobject::w_dict_copy(other_raw);
+                let w_copy =
+                    pyre_object::dictmultiobject::w_dict_copy(resolve_dict_backing(data()));
                 pyre_object::dictmultiobject::w_dict_adopt_regular_copy_for_empty_update(
                     dict(),
                     w_copy,
                 );
             } else {
-                let items = pyre_object::w_dict_items(other_raw);
+                let items = pyre_object::w_dict_items(resolve_dict_backing(data()));
                 let item_base = pyre_object::gc_roots::shadow_stack_len();
                 for &(k, v) in &items {
                     pyre_object::gc_roots::pin_root(k);
@@ -5248,19 +5248,33 @@ pub fn dict_init_or_update(
     args: &[PyObjectRef],
     name: &str,
 ) -> Result<PyObjectRef, crate::PyError> {
-    require_receiver(args, "update")?;
-    let (positional, kwargs_dict) = crate::builtins::split_builtin_kwargs(args);
+    // `dictmultiobject.py:1430 init_or_update` receives an `Arguments`
+    // object whose `arguments_w` entries are roots in translated RPython.
+    // Keep the flat Rust ABI's equivalent slots live before inspecting the
+    // trailing kwargs vehicle or passing an operand to `update1`.
+    let _roots = pyre_object::gc_roots::push_roots();
+    let root_base = pyre_object::gc_roots::shadow_stack_len();
+    for &arg in args {
+        pyre_object::gc_roots::pin_root(arg);
+    }
+    let rooted_args = (0..args.len())
+        .map(|i| pyre_object::gc_roots::shadow_stack_get(root_base + i))
+        .collect::<Vec<_>>();
+    require_receiver(&rooted_args, "update")?;
+    let (positional, kwargs_dict) = crate::builtins::split_builtin_kwargs(&rooted_args);
     if positional.len() > 2 {
         return Err(crate::PyError::type_error(format!(
             "{name} expected at most 1 argument, got {}",
             positional.len() - 1
         )));
     }
-    let dict = positional[0];
-    if let Some(other) = positional.get(1).copied() {
-        dict_update1(dict, other)?;
+    if positional.len() > 1 {
+        dict_update1(
+            pyre_object::gc_roots::shadow_stack_get(root_base),
+            pyre_object::gc_roots::shadow_stack_get(root_base + 1),
+        )?;
     }
-    let backing = resolve_dict_backing(dict);
+    let backing = resolve_dict_backing(pyre_object::gc_roots::shadow_stack_get(root_base));
     if backing.is_null() {
         // A dict subclass declared with `__slots__` has no attribute storage
         // for its item backing (pyre keeps a dict subclass's items in an
@@ -5268,7 +5282,8 @@ pub fn dict_init_or_update(
         // slotted-dict-subclass support needs intrinsic dict backing.
         return Ok(w_none());
     }
-    if let Some(kwargs) = kwargs_dict {
+    if kwargs_dict.is_some() {
+        let kwargs = pyre_object::gc_roots::shadow_stack_get(root_base + args.len() - 1);
         unsafe {
             for (k, v) in pyre_object::w_dict_items(kwargs) {
                 if pyre_object::is_str(k)

--- a/pyre/pyre-interpreter/src/type_methods.rs
+++ b/pyre/pyre-interpreter/src/type_methods.rs
@@ -5145,27 +5145,47 @@ pub(crate) fn dict_update1(w_dict: PyObjectRef, w_data: PyObjectRef) -> Result<(
     if dict.is_null() {
         return Ok(());
     }
-    let other_raw = resolve_dict_backing(w_data);
+    // RPython's shadowstack transform keeps both operands live across
+    // `keys`, iteration, `__getitem__`, hashing, and equality calls.  Those
+    // are arbitrary Python collection points; without the explicit roots an
+    // otherwise-unreachable destination dict can be swept while this Rust
+    // frame still holds its raw pointer.
+    let _roots = pyre_object::gc_roots::push_roots();
+    let root_base = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(dict);
+    pyre_object::gc_roots::pin_root(w_data);
+    let dict = || pyre_object::gc_roots::shadow_stack_get(root_base);
+    let data = || pyre_object::gc_roots::shadow_stack_get(root_base + 1);
+    let other_raw = resolve_dict_backing(data());
     unsafe {
         let fast_path_eligible = other_raw.is_null() == false
             && pyre_object::is_dict(other_raw)
-            && dict_subclass_uses_default_iter(w_data);
+            && dict_subclass_uses_default_iter(data());
         if fast_path_eligible {
             // `dictmultiobject.py:1401-1406 update1_dict_dict`
-            let dst_is_empty = pyre_object::dictmultiobject::w_dict_is_regular_empty(dict);
+            let dst_is_empty = pyre_object::dictmultiobject::w_dict_is_regular_empty(dict());
             if dst_is_empty {
                 let w_copy = pyre_object::dictmultiobject::w_dict_copy(other_raw);
                 pyre_object::dictmultiobject::w_dict_adopt_regular_copy_for_empty_update(
-                    dict, w_copy,
+                    dict(),
+                    w_copy,
                 );
             } else {
-                for (k, v) in pyre_object::w_dict_items(other_raw) {
-                    dict_store_checked(dict, k, v)?;
+                let items = pyre_object::w_dict_items(other_raw);
+                let item_base = pyre_object::gc_roots::shadow_stack_len();
+                for &(k, v) in &items {
+                    pyre_object::gc_roots::pin_root(k);
+                    pyre_object::gc_roots::pin_root(v);
+                }
+                for i in 0..items.len() {
+                    let k = pyre_object::gc_roots::shadow_stack_get(item_base + i * 2);
+                    let v = pyre_object::gc_roots::shadow_stack_get(item_base + i * 2 + 1);
+                    dict_store_checked(dict(), k, v)?;
                 }
             }
         } else {
             // `dictmultiobject.py:1388-1398 update1`
-            let w_keys_method = match crate::baseobjspace::getattr_str(w_data, "keys") {
+            let w_keys_method = match crate::baseobjspace::getattr_str(data(), "keys") {
                 Ok(value) => Some(value),
                 Err(e) if e.kind == crate::PyErrorKind::AttributeError => None,
                 Err(e) => return Err(e),
@@ -5174,14 +5194,28 @@ pub(crate) fn dict_update1(w_dict: PyObjectRef, w_data: PyObjectRef) -> Result<(
                 // `dictmultiobject.py:1421-1424 update1_keys`
                 let w_keys_view = crate::call::call_function_impl_result(w_method, &[])?;
                 let keys = crate::builtins::collect_iterable(w_keys_view)?;
-                for k in keys {
-                    let v = crate::baseobjspace::getitem(w_data, k)?;
-                    dict_store_checked(dict, k, v)?;
+                let keys_base = pyre_object::gc_roots::shadow_stack_len();
+                for &key in &keys {
+                    pyre_object::gc_roots::pin_root(key);
+                }
+                for i in 0..keys.len() {
+                    let k = pyre_object::gc_roots::shadow_stack_get(keys_base + i);
+                    let v = crate::baseobjspace::getitem(data(), k)?;
+                    let value_slot = pyre_object::gc_roots::shadow_stack_len();
+                    pyre_object::gc_roots::pin_root(v);
+                    let k = pyre_object::gc_roots::shadow_stack_get(keys_base + i);
+                    let v = pyre_object::gc_roots::shadow_stack_get(value_slot);
+                    dict_store_checked(dict(), k, v)?;
                 }
             } else {
                 // `dictmultiobject.py:1410-1418 update1_pairs`
-                let pairs = crate::builtins::collect_iterable(w_data)?;
-                for (idx, pair) in pairs.into_iter().enumerate() {
+                let pairs = crate::builtins::collect_iterable(data())?;
+                let pairs_base = pyre_object::gc_roots::shadow_stack_len();
+                for &pair in &pairs {
+                    pyre_object::gc_roots::pin_root(pair);
+                }
+                for idx in 0..pairs.len() {
+                    let pair = pyre_object::gc_roots::shadow_stack_get(pairs_base + idx);
                     let entries = crate::builtins::collect_iterable(pair)?;
                     if entries.len() != 2 {
                         return Err(crate::PyError::value_error(format!(
@@ -5189,7 +5223,12 @@ pub(crate) fn dict_update1(w_dict: PyObjectRef, w_data: PyObjectRef) -> Result<(
                             entries.len()
                         )));
                     }
-                    dict_store_checked(dict, entries[0], entries[1])?;
+                    let entry_base = pyre_object::gc_roots::shadow_stack_len();
+                    pyre_object::gc_roots::pin_root(entries[0]);
+                    pyre_object::gc_roots::pin_root(entries[1]);
+                    let k = pyre_object::gc_roots::shadow_stack_get(entry_base);
+                    let v = pyre_object::gc_roots::shadow_stack_get(entry_base + 1);
+                    dict_store_checked(dict(), k, v)?;
                 }
             }
         }

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -135,8 +135,12 @@ pub fn fget_co_consts(_space: PyObjectRef, _code: PyObjectRef) -> PyObjectRef {
     PY_NULL
 }
 
+/// PyPy `pypy/interpreter/typedef.py:598-599 make_weakref_descr` returns
+/// the canonical `weakref_descr` installed in a TypeDef. The class argument
+/// only participates in annotation in RPython; it is not the descriptor
+/// value itself.
 pub fn make_weakref_descr(_cls: PyObjectRef) -> PyObjectRef {
-    _cls
+    weakref_descr()
 }
 
 pub fn always_none(_self: PyObjectRef, _obj: PyObjectRef) -> PyObjectRef {
@@ -1025,6 +1029,8 @@ pub fn init_typeobjects() {
             (&pyre_object::pyobject::TUPLE_TYPE, b'S'),
             // rangeobject.c PyRange_Type carries Py_TPFLAGS_SEQUENCE.
             (&pyre_object::functional::RANGE_TYPE, b'S'),
+            // arraymodule.c arraytype carries Py_TPFLAGS_SEQUENCE.
+            (&pyre_object::interp_array::ARRAY_TYPE, b'S'),
         ] {
             let w_typeobject = *reg
                 .get(&(pytype as *const PyType as usize))
@@ -7048,41 +7054,72 @@ fn init_mappingproxy_type(ns: PyObjectRef) {
         )
     };
     // dictproxyobject.py:71 get_w / 75 keys_w / 78 values_w / 81 items_w /
-    // 84 copy_w — forward through `dict_method_*` (which unwraps the
-    // proxy via `resolve_dict_backing`).
+    // 84 copy_w — call the wrapped mapping's method. The mappingproxy
+    // constructor accepts any mapping, not only an exact W_DictObject, so
+    // routing these through dict_method_* would cast e.g. OrderedDict's
+    // subclass layout as a raw dict.
+    fn forward_mapping_method(args: &[PyObjectRef], name: &str) -> crate::PyResult {
+        let proxy = *args
+            .first()
+            .ok_or_else(|| crate::PyError::type_error("unbound mappingproxy method"))?;
+        let mapping = unsafe {
+            if pyre_object::is_dict_proxy(proxy) {
+                pyre_object::w_dict_proxy_get_mapping(proxy)
+            } else {
+                proxy
+            }
+        };
+        let method = crate::baseobjspace::getattr_str(mapping, name)?;
+        crate::call::call_function_impl_result(method, &args[1..])
+    }
+    fn proxy_get(args: &[PyObjectRef]) -> crate::PyResult {
+        forward_mapping_method(args, "get")
+    }
+    fn proxy_keys(args: &[PyObjectRef]) -> crate::PyResult {
+        forward_mapping_method(args, "keys")
+    }
+    fn proxy_values(args: &[PyObjectRef]) -> crate::PyResult {
+        forward_mapping_method(args, "values")
+    }
+    fn proxy_items(args: &[PyObjectRef]) -> crate::PyResult {
+        forward_mapping_method(args, "items")
+    }
+    fn proxy_copy(args: &[PyObjectRef]) -> crate::PyResult {
+        forward_mapping_method(args, "copy")
+    }
     unsafe {
         pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
             ns,
             "get",
-            make_builtin_function("get", crate::type_methods::dict_method_get),
+            make_builtin_function("get", proxy_get),
         )
     };
     unsafe {
         pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
             ns,
             "keys",
-            make_builtin_function("keys", crate::type_methods::dict_method_keys),
+            make_builtin_function("keys", proxy_keys),
         )
     };
     unsafe {
         pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
             ns,
             "values",
-            make_builtin_function("values", crate::type_methods::dict_method_values),
+            make_builtin_function("values", proxy_values),
         )
     };
     unsafe {
         pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
             ns,
             "items",
-            make_builtin_function("items", crate::type_methods::dict_method_items),
+            make_builtin_function("items", proxy_items),
         )
     };
     unsafe {
         pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
             ns,
             "copy",
-            make_builtin_function("copy", crate::type_methods::dict_method_copy),
+            make_builtin_function("copy", proxy_copy),
         )
     };
     // dictproxyobject.py:91-100 cmp methods (eq/ne/lt/le/gt/ge) →

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -758,6 +758,30 @@ pub fn init_typeobjects() {
             &pyre_object::generator::GENERATOR_TYPE as *const PyType as usize,
             generator_type as usize,
         );
+        let coroutine_type =
+            new_typeobject_with_base("coroutine", init_coroutine_type, object_type);
+        unsafe {
+            pyre_object::w_type_set_disallow_instantiation(coroutine_type);
+            pyre_object::w_type_set_acceptable_as_base_class(coroutine_type, false);
+            pyre_object::w_type_set_weakrefable(coroutine_type, true);
+        }
+        reg.insert(
+            &pyre_object::generator::COROUTINE_TYPE as *const PyType as usize,
+            coroutine_type as usize,
+        );
+        let coroutine_wrapper_type = new_typeobject_with_base(
+            "coroutine_wrapper",
+            init_coroutine_wrapper_type,
+            object_type,
+        );
+        unsafe {
+            pyre_object::w_type_set_disallow_instantiation(coroutine_wrapper_type);
+            pyre_object::w_type_set_acceptable_as_base_class(coroutine_wrapper_type, false);
+        }
+        reg.insert(
+            &pyre_object::generator::COROUTINE_WRAPPER_TYPE as *const PyType as usize,
+            coroutine_wrapper_type as usize,
+        );
         let range_iterator_type =
             new_typeobject_with_base("range_iterator", init_range_iterator_type, object_type);
         unsafe {
@@ -3531,7 +3555,17 @@ fn set_init_from_iterable(
         unsafe { pyre_object::w_set_copy_storage_from(w_set, w_iterable) };
         return Ok(());
     }
+    // RPython's shadowstack transformation keeps `self` live across
+    // `space.listview(w_iterable)`.  `collect_iterable` can execute a long
+    // generator and trigger a major collection, so mirror that generated
+    // root explicitly: the set body is non-moving old-gen storage, but it
+    // must still be marked live instead of being swept while Rust holds the
+    // only reference.
+    let _roots = pyre_object::gc_roots::push_roots();
+    let sp = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(w_set);
     let items = crate::builtins::collect_iterable(w_iterable)?;
+    let w_set = pyre_object::gc_roots::shadow_stack_get(sp);
     crate::builtins::builtin_set_add_items(w_set, &items)
 }
 
@@ -20595,6 +20629,15 @@ fn generator_descr_repr(args: &[PyObjectRef]) -> crate::PyResult {
     )))
 }
 
+fn coroutine_descr_repr(args: &[PyObjectRef]) -> crate::PyResult {
+    let name = generator_name_value(args[0], true)?;
+    Ok(w_str_new(&format!(
+        "<coroutine object {} at {:p}>",
+        unsafe { pyre_object::w_str_get_value(name) },
+        args[0]
+    )))
+}
+
 fn generator_name_value(obj: PyObjectRef, qualname: bool) -> crate::PyResult {
     let override_value = unsafe {
         if qualname {
@@ -20618,10 +20661,20 @@ fn generator_name_value(obj: PyObjectRef, qualname: bool) -> crate::PyResult {
     }))
 }
 
-fn generator_getter(args: &[PyObjectRef], field: usize) -> crate::PyResult {
+fn generator_getter_for(args: &[PyObjectRef], field: usize, coroutine: bool) -> crate::PyResult {
     let obj = args.get(1).copied().unwrap_or(PY_NULL);
-    if !unsafe { pyre_object::generator::is_generator(obj) } {
-        return Err(crate::PyError::type_error("descriptor is for 'generator'"));
+    let matches = unsafe {
+        if coroutine {
+            pyre_object::generator::is_coroutine(obj)
+        } else {
+            pyre_object::generator::is_generator(obj)
+        }
+    };
+    if !matches {
+        return Err(crate::PyError::type_error(format!(
+            "descriptor is for '{}'",
+            if coroutine { "coroutine" } else { "generator" }
+        )));
     }
     let frame = generator_frame(obj);
     Ok(match field {
@@ -20662,6 +20715,14 @@ fn generator_getter(args: &[PyObjectRef], field: usize) -> crate::PyResult {
     })
 }
 
+fn generator_getter(args: &[PyObjectRef], field: usize) -> crate::PyResult {
+    generator_getter_for(args, field, false)
+}
+
+fn coroutine_getter(args: &[PyObjectRef], field: usize) -> crate::PyResult {
+    generator_getter_for(args, field, true)
+}
+
 fn generator_get_running(args: &[PyObjectRef]) -> crate::PyResult {
     generator_getter(args, 0)
 }
@@ -20683,10 +20744,55 @@ fn generator_get_name(args: &[PyObjectRef]) -> crate::PyResult {
 fn generator_get_qualname(args: &[PyObjectRef]) -> crate::PyResult {
     generator_getter(args, 6)
 }
+fn coroutine_get_running(args: &[PyObjectRef]) -> crate::PyResult {
+    coroutine_getter(args, 0)
+}
+fn coroutine_get_suspended(args: &[PyObjectRef]) -> crate::PyResult {
+    coroutine_getter(args, 1)
+}
+fn coroutine_get_frame(args: &[PyObjectRef]) -> crate::PyResult {
+    coroutine_getter(args, 2)
+}
+fn coroutine_get_code(args: &[PyObjectRef]) -> crate::PyResult {
+    coroutine_getter(args, 3)
+}
+fn coroutine_get_await(args: &[PyObjectRef]) -> crate::PyResult {
+    coroutine_getter(args, 4)
+}
+fn coroutine_get_origin(args: &[PyObjectRef]) -> crate::PyResult {
+    let obj = args.get(1).copied().unwrap_or(PY_NULL);
+    if !unsafe { pyre_object::generator::is_coroutine(obj) } {
+        return Err(crate::PyError::type_error("descriptor is for 'coroutine'"));
+    }
+    Ok(unsafe { pyre_object::generator::w_coroutine_get_origin(obj) })
+}
+fn coroutine_get_name(args: &[PyObjectRef]) -> crate::PyResult {
+    coroutine_getter(args, 5)
+}
+fn coroutine_get_qualname(args: &[PyObjectRef]) -> crate::PyResult {
+    coroutine_getter(args, 6)
+}
 
-fn generator_set_name_common(args: &[PyObjectRef], qualname: bool) -> crate::PyResult {
+fn generator_set_name_common(
+    args: &[PyObjectRef],
+    qualname: bool,
+    coroutine: bool,
+) -> crate::PyResult {
     let obj = args[1];
     let value = args[2];
+    let matches = unsafe {
+        if coroutine {
+            pyre_object::generator::is_coroutine(obj)
+        } else {
+            pyre_object::generator::is_generator(obj)
+        }
+    };
+    if !matches {
+        return Err(crate::PyError::type_error(format!(
+            "descriptor is for '{}'",
+            if coroutine { "coroutine" } else { "generator" }
+        )));
+    }
     if !unsafe { pyre_object::is_str(value) } {
         return Err(crate::PyError::type_error(format!(
             "__{}__ must be set to a string object",
@@ -20704,10 +20810,16 @@ fn generator_set_name_common(args: &[PyObjectRef], qualname: bool) -> crate::PyR
 }
 
 fn generator_set_name(args: &[PyObjectRef]) -> crate::PyResult {
-    generator_set_name_common(args, false)
+    generator_set_name_common(args, false, false)
 }
 fn generator_set_qualname(args: &[PyObjectRef]) -> crate::PyResult {
-    generator_set_name_common(args, true)
+    generator_set_name_common(args, true, false)
+}
+fn coroutine_set_name(args: &[PyObjectRef]) -> crate::PyResult {
+    generator_set_name_common(args, false, true)
+}
+fn coroutine_set_qualname(args: &[PyObjectRef]) -> crate::PyResult {
+    generator_set_name_common(args, true, true)
 }
 
 fn generator_descr_sizeof(_args: &[PyObjectRef]) -> crate::PyResult {
@@ -20792,6 +20904,117 @@ fn init_generator_type(ns: PyObjectRef) {
                 make_getset_property_full(get, set, PY_NULL, PY_NULL, PY_NULL, Some(name)),
             )
         };
+    }
+}
+
+/// PyPy `generator.py Coroutine.typedef`.
+fn init_coroutine_type(ns: PyObjectRef) {
+    unsafe { pyre_object::w_dict_setitem_str(ns, "__doc__", w_none()) };
+    for (name, function, arity) in [
+        ("__repr__", coroutine_descr_repr as DunderFn, 1),
+        ("send", crate::baseobjspace::generator_send_method, 2),
+        ("close", crate::baseobjspace::generator_close_method, 1),
+        ("__await__", crate::baseobjspace::coroutine_await_method, 1),
+        ("__del__", crate::baseobjspace::generator_close_method, 1),
+        ("__sizeof__", generator_descr_sizeof, 1),
+    ] {
+        unsafe {
+            pyre_object::w_dict_setitem_str_no_proxy(
+                ns,
+                name,
+                make_builtin_function_with_arity(name, function, arity),
+            )
+        };
+    }
+    unsafe {
+        pyre_object::w_dict_setitem_str(
+            ns,
+            "throw",
+            make_builtin_function("throw", crate::baseobjspace::generator_throw_method),
+        );
+    }
+    for (name, getter) in [
+        ("cr_running", coroutine_get_running as DunderFn),
+        ("cr_suspended", coroutine_get_suspended as DunderFn),
+        ("cr_frame", coroutine_get_frame as DunderFn),
+        ("cr_code", coroutine_get_code as DunderFn),
+        ("cr_await", coroutine_get_await as DunderFn),
+        ("cr_origin", coroutine_get_origin as DunderFn),
+    ] {
+        unsafe {
+            pyre_object::w_dict_setitem_str_no_proxy(
+                ns,
+                name,
+                make_getset_descriptor_named(
+                    make_builtin_function_with_arity(name, getter, 2),
+                    name,
+                ),
+            )
+        };
+    }
+    for (name, getter, setter) in [
+        (
+            "__name__",
+            coroutine_get_name as DunderFn,
+            coroutine_set_name as DunderFn,
+        ),
+        (
+            "__qualname__",
+            coroutine_get_qualname as DunderFn,
+            coroutine_set_qualname as DunderFn,
+        ),
+    ] {
+        let get = make_builtin_function_with_arity(name, getter, 2);
+        let set = make_builtin_function_with_arity(name, setter, 3);
+        unsafe {
+            pyre_object::w_dict_setitem_str_no_proxy(
+                ns,
+                name,
+                make_getset_property_full(get, set, PY_NULL, PY_NULL, PY_NULL, Some(name)),
+            )
+        };
+    }
+}
+
+/// PyPy `generator.py CoroutineWrapper.typedef`.
+fn init_coroutine_wrapper_type(ns: PyObjectRef) {
+    unsafe { pyre_object::w_dict_setitem_str(ns, "__doc__", w_none()) };
+    for (name, function, arity) in [
+        (
+            "__iter__",
+            crate::baseobjspace::iter_self_method as DunderFn,
+            1,
+        ),
+        (
+            "__next__",
+            crate::baseobjspace::coroutine_wrapper_next_method,
+            1,
+        ),
+        (
+            "send",
+            crate::baseobjspace::coroutine_wrapper_send_method,
+            2,
+        ),
+        (
+            "close",
+            crate::baseobjspace::coroutine_wrapper_close_method,
+            1,
+        ),
+    ] {
+        unsafe {
+            pyre_object::w_dict_setitem_str_no_proxy(
+                ns,
+                name,
+                make_builtin_function_with_arity(name, function, arity),
+            )
+        };
+    }
+    unsafe {
+        pyre_object::w_dict_setitem_str(
+            ns,
+            "throw",
+            make_builtin_function("throw", crate::baseobjspace::coroutine_wrapper_throw_method),
+        );
     }
 }
 

--- a/pyre/pyre-jit-trace/src/call_spec.rs
+++ b/pyre/pyre-jit-trace/src/call_spec.rs
@@ -363,6 +363,13 @@ pub const PYFRAME_CALL_EFFECTS: &[CallEffectSpec] = &[
     },
     CallEffectSpec {
         target: CallTargetSpec::Method {
+            name: "iter_value",
+            receiver_root: PYFRAME_CALL_OWNER_ROOT,
+        },
+        effect: CallEffectKind::Residual,
+    },
+    CallEffectSpec {
+        target: CallTargetSpec::Method {
             name: "on_iter_exhausted",
             receiver_root: PYFRAME_CALL_OWNER_ROOT,
         },

--- a/pyre/pyre-jit-trace/src/helpers.rs
+++ b/pyre/pyre-jit-trace/src/helpers.rs
@@ -8,8 +8,8 @@ use majit_ir::{EffectInfo, ExtraEffect, GcRef, OopSpecIndex, OpCode, OpRef, Type
 use majit_metainterp::{TraceCtx, default_effect_info};
 
 use pyre_interpreter::{
-    PyBigInt, PyError, binary_op_tag, compare_op_tag, jit_next, jit_range_iter_next_or_null,
-    jit_sequence_getitem,
+    PyBigInt, PyError, binary_op_tag, compare_op_tag, jit_get_iter, jit_next,
+    jit_range_iter_next_or_null, jit_sequence_getitem,
 };
 use pyre_interpreter::{
     jit_binary_value_from_tag, jit_bool_value_from_truth, jit_compare_value_from_tag, jit_getattr,
@@ -636,6 +636,10 @@ pub fn emit_trace_next(ctx: &mut TraceCtx, iter: OpRef) -> OpRef {
     emit_trace_call_may_force_ref_typed(ctx, jit_next as *const (), &[iter], &[Type::Ref])
 }
 
+pub fn emit_trace_get_iter(ctx: &mut TraceCtx, iterable: OpRef) -> OpRef {
+    emit_trace_call_may_force_ref_typed(ctx, jit_get_iter as *const (), &[iterable], &[Type::Ref])
+}
+
 /// RPython ConstPtr parity: boxed-object constants are Ref-typed.
 /// The optimizer can constant-fold immutable field reads from Ref
 /// constants (heap.py:640 constant_fold).
@@ -851,6 +855,13 @@ pub trait TraceHelperAccess {
         // `space.next` may resume a generator / run a user `__next__`,
         // forcing the virtualizable; StopIteration / a real raise lands on
         // the trailing GuardNoException, side-exiting to the interpreter.
+        self.trace_record_not_forced_guard();
+        self.trace_record_no_exception_guard();
+        Ok(result)
+    }
+
+    fn trace_get_iter(&mut self, iterable: OpRef) -> Result<OpRef, PyError> {
+        let result = self.with_trace_ctx(|ctx| emit_trace_get_iter(ctx, iterable));
         self.trace_record_not_forced_guard();
         self.trace_record_no_exception_guard();
         Ok(result)

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -27743,17 +27743,6 @@ fn handle(
                     .map(|b| (b.trace_id, b.fail_index));
                 let has_targets = driver.meta_interp().has_compiled_targets(key);
                 if !has_partial && has_targets {
-                    // pyjitpl.py:2967-2969 `reached_loop_header`: the dummy
-                    // GUARD_FUTURE_CONDITION is recorded before compile_trace
-                    // so unroll can attach this exact merge-point snapshot to
-                    // artificial short-preamble guards.  The ordinary
-                    // CloseLoop outcome records the same guard later through
-                    // `close_loop_args_at`; this in-walk compile_trace path
-                    // returns before that post-processing step, so it must
-                    // record the guard here.
-                    ctx.trace_ctx
-                        .record_guard(OpCode::GuardFutureCondition, &[], 0);
-                    walker_capture_snapshot_for_last_guard(ctx, op.pc)?;
                     let outcome = match bridge_origin {
                         // Guard-origin: existing bridge path.
                         Some(_) => {

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -409,8 +409,9 @@ pub struct InlineFrame {
     /// reaches [`FBW_MAX_INLINE_RECURSION`], the call folds to a residual
     /// instead of unrolling its call tree (`pyjitpl.py:1388-1416`).
     pub w_code: usize,
-    /// Paused caller snapshot for the multi-frame path. `None` preserves the
-    /// straight-line single-frame collapse while retaining the callee level.
+    /// Paused caller snapshot for this Python frame.  RPython keeps one
+    /// `MIFrame` per inlined call; a missing parent is therefore only valid
+    /// for a frame that is not entered as an inline Python callee.
     pub parent: Option<InlineParentFrame>,
 }
 
@@ -10392,6 +10393,8 @@ fn reconcile_vstack_at_boundary(
         ctx.vstack_reorder_ceiling = prev_pypc as u32;
     }
     let in_reorder_region = ctx.vstack_reorder_ceiling != u32::MAX;
+    let (fallthrough_depth, branch_depth) =
+        crate::liveness::stack_effects(&instr, op_arg, ctx.vstack_depth);
     if std::env::var_os("PYRE_VSTACK_DIAG").is_some() {
         eprintln!(
             "[vstack-reconcile] prev_pypc={prev_pypc} new_pypc={new_pypc} \
@@ -10400,6 +10403,20 @@ fn reconcile_vstack_at_boundary(
             ctx.vstack_depth, ctx.vstack_last_ref
         );
     }
+    // A JitCode's block layout can visit source-PC floor segments out of
+    // Python bytecode order.  In that case `vstack_cur_pypc` is only the
+    // preceding layout segment, not the opcode whose stack effect produced
+    // this boundary.  Applying its effect is unsound: a LOAD_FAST segment
+    // whose expected depth is `d + 1` can otherwise overwrite a surviving
+    // FOR_ITER iterator when the observed depth stayed at `d`.
+    //
+    // RPython reads the live MIFrame registers and never reconstructs this
+    // transition from source PCs.  Preserve the slots that demonstrably
+    // survive at the observed depth whenever neither real successor depth
+    // matches; holes remain conservative and are handled by the shadow fill
+    // below.
+    let layout_only_boundary = new_depth != fallthrough_depth && new_depth != branch_depth;
+
     // PER-OP RECONCILE.  In the SEQUENTIAL case the previous opcode's stack
     // effect explains the depth change: a producer (`ResultToTos`) lands its
     // result box (`vstack_last_ref`) on the new TOS; a pop / side-store just
@@ -10415,6 +10432,17 @@ fn reconcile_vstack_at_boundary(
         class
     };
     match effective_class {
+        // A layout-only boundary (the observed depth matches neither real
+        // successor of the previous opcode) means the per-op effect cannot
+        // explain this transition; preserve the surviving slots instead of
+        // replaying a stale effect.  The reorder region is already served by
+        // the `ShadowReseed` arm, so exclude it here.
+        _ if layout_only_boundary && !in_reorder_region => {
+            ctx.vstack_boxes.truncate(new_depth);
+            if ctx.vstack_boxes.len() < new_depth {
+                ctx.vstack_boxes.resize(new_depth, OpRef::NONE);
+            }
+        }
         VstackOpClass::ResultToTos => {
             ctx.vstack_boxes.truncate(new_depth);
             if ctx.vstack_boxes.len() < new_depth {
@@ -12031,23 +12059,10 @@ fn walker_capture_snapshot_for_last_guard_impl(
     // At resume, RPython's blackhole interpreter re-enters each frame's
     // jitcode and replays from the saved pc.
     //
-    // Pyre's blackhole interpreter only knows how to run *pyjitcode*
-    // bytecode (Python bytecode), not helper jitcodes — pyre's
-    // per-opcode arm jitcodes and sub-jitcode helpers are walker-only
-    // structures with no blackhole entry point.  The structural
-    // consequence: any walker-emitted guard, regardless of how deep
-    // the sub-walk nesting is, must resume to the *outer* Python
-    // opcode boundary (`sym.jitcode` at `entry_py_pc`) — that is the
-    // only resume point pyre's blackhole can re-enter.  The
-    // framestack-collapse is a deliberate adaptation, not a parity
-    // miss; the walker context carries the outer Python frame only.
-    // Inline-traced Python frames (`build_pending_inline_frame`) are
-    // not reachable from this entry point because the production
-    // walker allow-list does not yet enable opcodes that drive inline
-    // tracing — when that expands, `WalkContext` must grow a parent-
-    // Python-frame chain (analogous to `MIFrame.parent_frames`) and
-    // this helper switches to
-    // `capture_snapshot_for_last_guard_multi_frame_with_vable_vref`.
+    // Helper jitcodes remain walker-only, but an inlined *Python* call is a
+    // real RPython `MIFrame` and must retain its own jitcode/pycode/globals and
+    // locals.  Such calls are handled by the multi-frame branch below; only
+    // guards in the root Python frame use the single-frame capture here.
     //
     // The snapshot is therefore a single Python frame at the outer
     // pyjitcode coordinates.  `ctx.outer_jitcode_index` +
@@ -12084,13 +12099,11 @@ fn walker_capture_snapshot_for_last_guard_impl(
     // capture below, which resumes at the CALL site (re-execute the
     // call on deopt — see `fbw_mode.inline_subwalk`).
     let inline_subwalk = ctx.fbw_mode.inline_subwalk;
-    // #68 multi-frame inline guard: a guard emitted inside an inlined callee
-    // sub-walk with paused caller frames on the walk framestack resumes
-    // BOTH the callee (at its own pc) and the caller(s) (at the CALL return
-    // point), instead of collapsing to the caller boundary (re-execute).  Only
-    // the gated forward-branch inline path (`PYRE_FBW_INLINE_MULTIFRAME`)
-    // populates the chain; straight-line callees keep the empty chain + the
-    // single-frame collapse below.
+    // A guard emitted inside an inlined Python callee resumes BOTH the callee
+    // (at its own pc) and its caller chain (at each CALL return point), exactly
+    // like RPython's `MIFrame` framestack.  Never collapse a Python callee onto
+    // the root frame: that can resume a different code object at the same
+    // register/call shape.
     if inline_subwalk {
         // Fire the multi-frame snapshot only when the paused-caller chain
         // covers the FULL current inline depth: framestack levels with parents
@@ -12132,6 +12145,7 @@ fn walker_capture_snapshot_for_last_guard_impl(
                 scope,
             );
         }
+        return Err(DispatchError::LoopBearingCalleeInlineUnsupported { pc: op_pc });
     }
     if !inline_subwalk && !full_body_sym.is_null() {
         // SAFETY: the pointer is set only for the lifetime of the
@@ -15974,20 +15988,17 @@ fn try_walker_inline_resolved_user_call(
         // frame (a decode / `LOAD_FAST` overrun) and re-applies the callee's
         // committed side effect on deopt.
         //
-        // Best effort: `compute_inline_caller_frame` returns `Unavailable` for a caller
-        // shape it cannot build yet (a CALL inside a try-block, or no result on
-        // the operand stack at the return point).  Fall back to the single-frame
-        // collapse there (do NOT decline the inline — that shape is served
-        // correctly today), so this never removes a working inline.
-        compute_inline_caller_frame(ctx, op.pc).ok()
+        // If the caller snapshot cannot be represented yet, leave the call
+        // residual.  RPython has no path that drops the caller MIFrame and
+        // substitutes the root frame, so neither do we.
+        Some(
+            compute_inline_caller_frame(ctx, op.pc)
+                .map_err(|_| DispatchError::LoopBearingCalleeInlineUnsupported { pc: op.pc })?,
+        )
     } else {
-        // Single-frame collapse (resume at the CALL boundary, re-execute the
-        // whole call on deopt): a nested strict callee
-        // (`inline_depth >= fbw_max_multiframe_depth()`, task #126), an un-seedable
-        // strict callee, or a callee neither seed served.  Sound for a pure
-        // value-returning leaf (idempotent re-execute) and for a nested
-        // straight-line callee (its pre-multiframe behavior).
-        None
+        // The current resume encoder cannot represent this callee frame.
+        // Residualize the call instead of inventing a root-frame substitute.
+        return Err(DispatchError::LoopBearingCalleeInlineUnsupported { pc: op.pc });
     };
 
     // CODEX1 parity: snapshot the heap-effect state before the callee
@@ -27716,6 +27727,17 @@ fn handle(
                     .map(|b| (b.trace_id, b.fail_index));
                 let has_targets = driver.meta_interp().has_compiled_targets(key);
                 if !has_partial && has_targets {
+                    // pyjitpl.py:2967-2969 `reached_loop_header`: the dummy
+                    // GUARD_FUTURE_CONDITION is recorded before compile_trace
+                    // so unroll can attach this exact merge-point snapshot to
+                    // artificial short-preamble guards.  The ordinary
+                    // CloseLoop outcome records the same guard later through
+                    // `close_loop_args_at`; this in-walk compile_trace path
+                    // returns before that post-processing step, so it must
+                    // record the guard here.
+                    ctx.trace_ctx
+                        .record_guard(OpCode::GuardFutureCondition, &[], 0);
+                    walker_capture_snapshot_for_last_guard(ctx, op.pc)?;
                     let outcome = match bridge_origin {
                         // Guard-origin: existing bridge path.
                         Some(_) => {

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -409,9 +409,8 @@ pub struct InlineFrame {
     /// reaches [`FBW_MAX_INLINE_RECURSION`], the call folds to a residual
     /// instead of unrolling its call tree (`pyjitpl.py:1388-1416`).
     pub w_code: usize,
-    /// Paused caller snapshot for this Python frame.  RPython keeps one
-    /// `MIFrame` per inlined call; a missing parent is therefore only valid
-    /// for a frame that is not entered as an inline Python callee.
+    /// Paused caller snapshot for the multi-frame path. `None` preserves the
+    /// straight-line single-frame collapse while retaining the callee level.
     pub parent: Option<InlineParentFrame>,
 }
 
@@ -12059,10 +12058,23 @@ fn walker_capture_snapshot_for_last_guard_impl(
     // At resume, RPython's blackhole interpreter re-enters each frame's
     // jitcode and replays from the saved pc.
     //
-    // Helper jitcodes remain walker-only, but an inlined *Python* call is a
-    // real RPython `MIFrame` and must retain its own jitcode/pycode/globals and
-    // locals.  Such calls are handled by the multi-frame branch below; only
-    // guards in the root Python frame use the single-frame capture here.
+    // Pyre's blackhole interpreter only knows how to run *pyjitcode*
+    // bytecode (Python bytecode), not helper jitcodes — pyre's
+    // per-opcode arm jitcodes and sub-jitcode helpers are walker-only
+    // structures with no blackhole entry point.  The structural
+    // consequence: any walker-emitted guard, regardless of how deep
+    // the sub-walk nesting is, must resume to the *outer* Python
+    // opcode boundary (`sym.jitcode` at `entry_py_pc`) — that is the
+    // only resume point pyre's blackhole can re-enter.  The
+    // framestack-collapse is a deliberate adaptation, not a parity
+    // miss; the walker context carries the outer Python frame only.
+    // Inline-traced Python frames (`build_pending_inline_frame`) are
+    // not reachable from this entry point because the production
+    // walker allow-list does not yet enable opcodes that drive inline
+    // tracing — when that expands, `WalkContext` must grow a parent-
+    // Python-frame chain (analogous to `MIFrame.parent_frames`) and
+    // this helper switches to
+    // `capture_snapshot_for_last_guard_multi_frame_with_vable_vref`.
     //
     // The snapshot is therefore a single Python frame at the outer
     // pyjitcode coordinates.  `ctx.outer_jitcode_index` +
@@ -12099,11 +12111,13 @@ fn walker_capture_snapshot_for_last_guard_impl(
     // capture below, which resumes at the CALL site (re-execute the
     // call on deopt — see `fbw_mode.inline_subwalk`).
     let inline_subwalk = ctx.fbw_mode.inline_subwalk;
-    // A guard emitted inside an inlined Python callee resumes BOTH the callee
-    // (at its own pc) and its caller chain (at each CALL return point), exactly
-    // like RPython's `MIFrame` framestack.  Never collapse a Python callee onto
-    // the root frame: that can resume a different code object at the same
-    // register/call shape.
+    // #68 multi-frame inline guard: a guard emitted inside an inlined callee
+    // sub-walk with paused caller frames on the walk framestack resumes
+    // BOTH the callee (at its own pc) and the caller(s) (at the CALL return
+    // point), instead of collapsing to the caller boundary (re-execute).  Only
+    // the gated forward-branch inline path (`PYRE_FBW_INLINE_MULTIFRAME`)
+    // populates the chain; straight-line callees keep the empty chain + the
+    // single-frame collapse below.
     if inline_subwalk {
         // Fire the multi-frame snapshot only when the paused-caller chain
         // covers the FULL current inline depth: framestack levels with parents
@@ -12145,7 +12159,6 @@ fn walker_capture_snapshot_for_last_guard_impl(
                 scope,
             );
         }
-        return Err(DispatchError::LoopBearingCalleeInlineUnsupported { pc: op_pc });
     }
     if !inline_subwalk && !full_body_sym.is_null() {
         // SAFETY: the pointer is set only for the lifetime of the
@@ -15988,17 +16001,20 @@ fn try_walker_inline_resolved_user_call(
         // frame (a decode / `LOAD_FAST` overrun) and re-applies the callee's
         // committed side effect on deopt.
         //
-        // If the caller snapshot cannot be represented yet, leave the call
-        // residual.  RPython has no path that drops the caller MIFrame and
-        // substitutes the root frame, so neither do we.
-        Some(
-            compute_inline_caller_frame(ctx, op.pc)
-                .map_err(|_| DispatchError::LoopBearingCalleeInlineUnsupported { pc: op.pc })?,
-        )
+        // Best effort: `compute_inline_caller_frame` returns `Unavailable` for a caller
+        // shape it cannot build yet (a CALL inside a try-block, or no result on
+        // the operand stack at the return point).  Fall back to the single-frame
+        // collapse there (do NOT decline the inline — that shape is served
+        // correctly today), so this never removes a working inline.
+        compute_inline_caller_frame(ctx, op.pc).ok()
     } else {
-        // The current resume encoder cannot represent this callee frame.
-        // Residualize the call instead of inventing a root-frame substitute.
-        return Err(DispatchError::LoopBearingCalleeInlineUnsupported { pc: op.pc });
+        // Single-frame collapse (resume at the CALL boundary, re-execute the
+        // whole call on deopt): a nested strict callee
+        // (`inline_depth >= fbw_max_multiframe_depth()`, task #126), an un-seedable
+        // strict callee, or a callee neither seed served.  Sound for a pure
+        // value-returning leaf (idempotent re-execute) and for a nested
+        // straight-line callee (its pre-multiframe behavior).
+        None
     };
 
     // CODEX1 parity: snapshot the heap-effect state before the callee

--- a/pyre/pyre-jit-trace/src/liveness.rs
+++ b/pyre/pyre-jit-trace/src/liveness.rs
@@ -543,7 +543,7 @@ fn propagate_defined(
     }
 }
 
-fn stack_effects(
+pub(crate) fn stack_effects(
     instr: &pyre_interpreter::bytecode::Instruction,
     op_arg: pyre_interpreter::OpArg,
     depth: usize,

--- a/pyre/pyre-jit-trace/src/opcode_handler_impls.rs
+++ b/pyre/pyre-jit-trace/src/opcode_handler_impls.rs
@@ -425,6 +425,21 @@ impl pyre_interpreter::TruthOpcodeHandler for crate::state::MIFrame {
 }
 
 impl pyre_interpreter::IterOpcodeHandler for crate::state::MIFrame {
+    fn iter_value(
+        &mut self,
+        iterable: Self::Value,
+    ) -> Result<Self::Value, pyre_interpreter::PyError> {
+        use crate::helpers::TraceHelperAccess;
+        let concrete = iterable.concrete.to_pyobj();
+        let concrete_iterator = if concrete.is_null() {
+            crate::state::ConcreteValue::Null
+        } else {
+            crate::state::ConcreteValue::from_pyobj(pyre_interpreter::baseobjspace::iter(concrete)?)
+        };
+        let opref = self.trace_get_iter(iterable.opref)?;
+        Ok(crate::state::FrontendOp::new(opref, concrete_iterator))
+    }
+
     fn ensure_iter_value(&mut self, iter: Self::Value) -> Result<(), pyre_interpreter::PyError> {
         self.with_ctx(|this, ctx| {
             crate::state::MIFrame::guard_range_iter(this, ctx, iter.opref);

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -4264,6 +4264,25 @@ bh_call_kw_arity!(bh_call_kw_13; a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a1
 /// execution context's top frame (`space.getexecutioncontext()
 /// .gettopframe()`), matching the upstream frame-less ABI.
 fn bh_call_fn_impl(callable: PyObjectRef, null_or_self: PyObjectRef, args: &[PyObjectRef]) -> i64 {
+    // RPython's blackhole residual-call thunk is itself translated, so its
+    // incoming GCREF arguments are shadowstack roots for the whole helper
+    // call.  This Rust ABI boundary is outside that transform: the backend
+    // gcmap keeps the caller objects alive, but a moving collection cannot
+    // rewrite these copied native parameters.  Root them immediately and
+    // dispatch only values reloaded from the forwarded slots.
+    let _roots = pyre_object::gc_roots::push_roots();
+    let root_base = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(callable);
+    pyre_object::gc_roots::pin_root(null_or_self);
+    for &arg in args {
+        pyre_object::gc_roots::pin_root(arg);
+    }
+    let callable = pyre_object::gc_roots::shadow_stack_get(root_base);
+    let null_or_self = pyre_object::gc_roots::shadow_stack_get(root_base + 1);
+    let rooted_args: Vec<PyObjectRef> = (0..args.len())
+        .map(|i| pyre_object::gc_roots::shadow_stack_get(root_base + 2 + i))
+        .collect();
+    let args = rooted_args.as_slice();
     // eval.rs:3216-3226 — a non-null null_or_self is the method receiver
     // (load_method_fast_path pushes `[w_descr, w_obj]`); the call proceeds
     // as `callable(null_or_self, *args)`.

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -4277,24 +4277,19 @@ fn bh_call_fn_impl(callable: PyObjectRef, null_or_self: PyObjectRef, args: &[PyO
     for &arg in args {
         pyre_object::gc_roots::pin_root(arg);
     }
-    let callable = pyre_object::gc_roots::shadow_stack_get(root_base);
-    let null_or_self = pyre_object::gc_roots::shadow_stack_get(root_base + 1);
-    let rooted_args: Vec<PyObjectRef> = (0..args.len())
-        .map(|i| pyre_object::gc_roots::shadow_stack_get(root_base + 2 + i))
-        .collect();
-    let args = rooted_args.as_slice();
     // eval.rs:3216-3226 — a non-null null_or_self is the method receiver
     // (load_method_fast_path pushes `[w_descr, w_obj]`); the call proceeds
     // as `callable(null_or_self, *args)`.
-    let full_args;
-    let args = if null_or_self.is_null() {
-        args
-    } else {
-        let mut v = Vec::with_capacity(1 + args.len());
-        v.push(null_or_self);
-        v.extend_from_slice(args);
-        full_args = v;
-        &full_args
+    let reload_args = || {
+        let null_or_self = pyre_object::gc_roots::shadow_stack_get(root_base + 1);
+        let mut values = Vec::with_capacity(args.len() + usize::from(!null_or_self.is_null()));
+        if !null_or_self.is_null() {
+            values.push(null_or_self);
+        }
+        values.extend(
+            (0..args.len()).map(|i| pyre_object::gc_roots::shadow_stack_get(root_base + 2 + i)),
+        );
+        values
     };
     // `space.getexecutioncontext()` (call.rs:198 → TLS-pinned EC the eval
     // loop stamps on entry) `.gettopframe()` is the active caller frame —
@@ -4314,7 +4309,7 @@ fn bh_call_fn_impl(callable: PyObjectRef, null_or_self: PyObjectRef, args: &[PyO
          getexecutioncontext().gettopframe(); the eval loop must pin the \
          execution context before any residual call"
     );
-    if callable.is_null() {
+    if pyre_object::gc_roots::shadow_stack_get(root_base).is_null() {
         let err = pyre_interpreter::PyError::new(
             pyre_interpreter::PyErrorKind::TypeError,
             "call on null callable".to_string(),
@@ -4329,12 +4324,14 @@ fn bh_call_fn_impl(callable: PyObjectRef, null_or_self: PyObjectRef, args: &[PyO
     // Cold path: type/method/staticmethod/classmethod/callable-instance are
     // delegated to call_function_impl_result under ForcePlainEvalGuard, which
     // mirrors baseobjspace.py:1155 dispatch without re-entering the JIT.
+    let callable = pyre_object::gc_roots::shadow_stack_get(root_base);
     if unsafe { is_function(callable) } {
         let code = unsafe { pyre_interpreter::getcode(callable) };
         if unsafe { pyre_interpreter::is_builtin_code(code as pyre_object::PyObjectRef) } {
             let func =
                 unsafe { pyre_interpreter::builtin_code_get(code as pyre_object::PyObjectRef) };
-            return match func(args) {
+            let call_args = reload_args();
+            return match func(&call_args) {
                 Ok(result) if !result.is_null() => result as i64,
                 Ok(_) => 0,
                 Err(err) => {
@@ -4343,7 +4340,9 @@ fn bh_call_fn_impl(callable: PyObjectRef, null_or_self: PyObjectRef, args: &[PyO
                 }
             };
         }
-        if let Some(result) = bh_call_self_recursive_portal(parent_frame_ptr, callable, args) {
+        let call_args = reload_args();
+        if let Some(result) = bh_call_self_recursive_portal(parent_frame_ptr, callable, &call_args)
+        {
             return result;
         }
         let saved_ctx = pyre_interpreter::call::take_last_exec_ctx();
@@ -4361,7 +4360,7 @@ fn bh_call_fn_impl(callable: PyObjectRef, null_or_self: PyObjectRef, args: &[PyO
             // the portal runner, so nested Python CALLs from this residual
             // path must stay on eval_frame_plain as well.
             let _plain_guard = pyre_interpreter::call::force_plain_eval();
-            pyre_interpreter::call::call_user_function_plain(parent_frame, callable, args)
+            pyre_interpreter::call::call_user_function_plain(parent_frame, callable, &call_args)
         };
         pyre_interpreter::call::set_last_exec_ctx(saved_ctx);
         return match result {
@@ -4386,7 +4385,9 @@ fn bh_call_fn_impl(callable: PyObjectRef, null_or_self: PyObjectRef, args: &[PyO
         }
     }
     let _plain_guard = pyre_interpreter::call::force_plain_eval();
-    let result = pyre_interpreter::call::call_function_impl_result(callable, args);
+    let callable = pyre_object::gc_roots::shadow_stack_get(root_base);
+    let call_args = reload_args();
+    let result = pyre_interpreter::call::call_function_impl_result(callable, &call_args);
     pyre_interpreter::call::set_last_exec_ctx(saved_ctx);
     match result {
         Ok(result) => result as i64,

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -391,6 +391,7 @@ unsafe fn generator_object_custom_trace(obj_addr: usize, f: &mut dyn FnMut(*mut 
     let gen_obj = unsafe { &mut *(obj_addr as *mut pyre_object::generator::GeneratorIterator) };
     f(&mut gen_obj.name as *mut pyre_object::PyObjectRef as *mut majit_ir::GcRef);
     f(&mut gen_obj.qualname as *mut pyre_object::PyObjectRef as *mut majit_ir::GcRef);
+    f(&mut gen_obj.cr_origin as *mut pyre_object::PyObjectRef as *mut majit_ir::GcRef);
     if !gen_obj.frame_ptr.is_null() {
         let frame = gen_obj.frame_ptr as *mut PyFrame;
         if pyre_object::gc_hook::try_gc_owns_object(gen_obj.frame_ptr) {
@@ -1805,20 +1806,6 @@ fn build_gc() -> Box<dyn majit_gc::GcAllocator> {
             &pyre_object::dictmultiobject::W_DICT_VIEW_GC_PTR_OFFSETS,
         );
     }
-    // The three dict-view iterator PyTypes (`W_BaseDictMultiIterObject`) are
-    // likewise `malloc_typed`-immortal and not `#[pyre_class]`, and (unlike the
-    // views) have no GC vtable registration site; register their `w_dict`
-    // back-pointer offset for the generic immortal-root walker directly.
-    for tp in [
-        &pyre_object::dictmultiobject::DICT_KEYITERATOR_TYPE,
-        &pyre_object::dictmultiobject::DICT_VALUEITERATOR_TYPE,
-        &pyre_object::dictmultiobject::DICT_ITEMITERATOR_TYPE,
-    ] {
-        pyre_object::gc_hook::register_pyre_class_offsets(
-            tp as *const _ as usize,
-            &pyre_object::dictmultiobject::W_DICT_VIEW_ITERATOR_GC_PTR_OFFSETS,
-        );
-    }
     // `pypy/interpreter/typedef.py:312-326 class GetSetProperty`
     // — fget/fset/fdel/doc/reqcls/name are W_Root references.
     // Pyre's `GetSetProperty` ports them as inline fields; the
@@ -2521,6 +2508,59 @@ fn build_gc() -> Box<dyn majit_gc::GcAllocator> {
         <pyre_object::interp_itertools::W_StarMap
             as pyre_object::lltype::PyreClassPyTypeOf>::DESCRIPTOR,
     );
+    // PyPy GeneratorOrCoroutine gives GeneratorIterator and Coroutine the
+    // same payload shape, but rclass requires distinct vtable hierarchy ids.
+    // Host allocation stamps coroutine payloads with W_GENERATOR_GC_TYPE_ID
+    // so the collector uses the shared layout/custom trace; this tail id is
+    // the independent vtable axis used by GUARD_CLASS/GUARD_SUBCLASS.
+    let coroutine_vtable_tid = gc.register_type(TypeInfo::object_subclass_with_custom_trace(
+        std::mem::size_of::<pyre_object::generator::GeneratorIterator>(),
+        object_tid,
+        generator_object_custom_trace,
+    ));
+    majit_gc::GcAllocator::register_vtable_for_type(
+        &mut gc,
+        &pyre_object::generator::COROUTINE_TYPE as *const _ as usize,
+        coroutine_vtable_tid,
+    );
+    pytype_to_tid.insert(
+        &pyre_object::generator::COROUTINE_TYPE as *const _ as usize,
+        coroutine_vtable_tid,
+    );
+    // generator.py CoroutineWrapper — the iterator returned by
+    // Coroutine.__await__, with one traced edge back to the coroutine.
+    register_pyre_class(
+        &mut gc,
+        &mut pytype_to_tid,
+        <pyre_object::generator::CoroutineWrapper
+            as pyre_object::lltype::PyreClassPyTypeOf>::DESCRIPTOR,
+    );
+    // dictmultiobject.py W_BaseDictMultiIterObject is a normal GC object.
+    // The six concrete Python types (forward + reversed × keys/values/items)
+    // share one payload layout and the traced `w_dict` edge, just as the
+    // W_DictMultiIter*Object subclasses do in PyPy.  Auto-register at the tail
+    // so no fixed frame/type ids shift.
+    let w_dict_view_iterator_tid = gc.register_type(TypeInfo::object_subclass_with_gc_ptrs(
+        pyre_object::dictmultiobject::W_DICT_VIEW_ITERATOR_OBJECT_SIZE,
+        object_tid,
+        pyre_object::dictmultiobject::W_DICT_VIEW_ITERATOR_GC_PTR_OFFSETS.to_vec(),
+    ));
+    pyre_object::dictmultiobject::W_DICT_VIEW_ITERATOR_GC_TYPE_ID.set(w_dict_view_iterator_tid);
+    for tp in [
+        &pyre_object::dictmultiobject::DICT_KEYITERATOR_TYPE,
+        &pyre_object::dictmultiobject::DICT_VALUEITERATOR_TYPE,
+        &pyre_object::dictmultiobject::DICT_ITEMITERATOR_TYPE,
+        &pyre_object::dictmultiobject::DICT_REVERSEKEYITERATOR_TYPE,
+        &pyre_object::dictmultiobject::DICT_REVERSEVALUEITERATOR_TYPE,
+        &pyre_object::dictmultiobject::DICT_REVERSEITEMITERATOR_TYPE,
+    ] {
+        majit_gc::GcAllocator::register_vtable_for_type(
+            &mut gc,
+            tp as *const _ as usize,
+            w_dict_view_iterator_tid,
+        );
+        pytype_to_tid.insert(tp as *const _ as usize, w_dict_view_iterator_tid);
+    }
     // rclass.py:340-346 — assign subclassrange_{min,max} to each
     // vtable entry. freeze_types() runs assign_inheritance_ids
     // (normalizecalls.py:373-389), then we write the computed ranges
@@ -3054,10 +3094,21 @@ unsafe fn pyre_object_root_walker_area(
     data: *const (),
     visitor: &mut dyn FnMut(&mut majit_ir::GcRef),
 ) {
+    let mut changed = 0usize;
     unsafe {
         pyre_object::gc_roots::walk_shadow_stack_area(data, |slot| {
+            let before = *slot;
             visit_pyobject_root(slot, visitor);
+            if *slot != before {
+                changed += 1;
+                if std::env::var_os("PYRE_ROOT_WALK_DIAG").is_some() {
+                    eprintln!("[pyre-object-root] {before:p} -> {:p}", *slot);
+                }
+            }
         });
+    }
+    if changed != 0 && std::env::var_os("PYRE_ROOT_WALK_DIAG").is_some() {
+        eprintln!("[pyre-object-roots] changed={changed}");
     }
 }
 

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -3094,21 +3094,10 @@ unsafe fn pyre_object_root_walker_area(
     data: *const (),
     visitor: &mut dyn FnMut(&mut majit_ir::GcRef),
 ) {
-    let mut changed = 0usize;
     unsafe {
         pyre_object::gc_roots::walk_shadow_stack_area(data, |slot| {
-            let before = *slot;
             visit_pyobject_root(slot, visitor);
-            if *slot != before {
-                changed += 1;
-                if std::env::var_os("PYRE_ROOT_WALK_DIAG").is_some() {
-                    eprintln!("[pyre-object-root] {before:p} -> {:p}", *slot);
-                }
-            }
         });
-    }
-    if changed != 0 && std::env::var_os("PYRE_ROOT_WALK_DIAG").is_some() {
-        eprintln!("[pyre-object-roots] changed={changed}");
     }
 }
 

--- a/pyre/pyre-object/src/dictmultiobject.rs
+++ b/pyre/pyre-object/src/dictmultiobject.rs
@@ -3014,8 +3014,12 @@ pub struct W_BaseDictMultiIterObject {
 pub const DICT_VIEW_ITER_W_DICT_OFFSET: usize =
     std::mem::offset_of!(W_BaseDictMultiIterObject, w_dict);
 
-/// GC type id — next free slot after enumerate (=41).
-pub const W_DICT_VIEW_ITERATOR_GC_TYPE_ID: u32 = 42;
+/// Runtime-assigned GC type id shared by the three concrete iterator types.
+/// PyPy's `W_BaseDictMultiIterObject` is a GC object whose `w_dict` edge is
+/// traced.  Keep this auto-numbered because the fixed registration chain has
+/// grown past the historical slot 42.
+pub static W_DICT_VIEW_ITERATOR_GC_TYPE_ID: crate::lltype::TypeIdCell =
+    crate::lltype::TypeIdCell::auto();
 pub const W_DICT_VIEW_ITERATOR_OBJECT_SIZE: usize =
     std::mem::size_of::<W_BaseDictMultiIterObject>();
 
@@ -3023,7 +3027,7 @@ pub const W_DICT_VIEW_ITERATOR_GC_PTR_OFFSETS: [usize; 1] = [DICT_VIEW_ITER_W_DI
 
 impl crate::lltype::GcType for W_BaseDictMultiIterObject {
     fn type_id() -> u32 {
-        W_DICT_VIEW_ITERATOR_GC_TYPE_ID
+        W_DICT_VIEW_ITERATOR_GC_TYPE_ID.get()
     }
     const SIZE: usize = W_DICT_VIEW_ITERATOR_OBJECT_SIZE;
 }
@@ -3063,21 +3067,36 @@ fn w_dict_view_iterator_new_direction(
     kind: DictViewKind,
     reverse: bool,
 ) -> PyObjectRef {
-    let startlen = unsafe { w_dict_len(w_dict) };
-    let start_strategy_id = unsafe { w_dict_strategy_id(w_dict) };
     let tp = dict_view_iterator_type_for_kind(kind, reverse);
-    crate::lltype::malloc_typed(W_BaseDictMultiIterObject {
+    let _roots = crate::gc_roots::push_roots();
+    let dict_slot = crate::gc_roots::shadow_stack_len();
+    crate::gc_roots::pin_root(w_dict);
+    let startlen = unsafe { w_dict_len(crate::gc_roots::shadow_stack_get(dict_slot)) };
+    let start_strategy_id =
+        unsafe { w_dict_strategy_id(crate::gc_roots::shadow_stack_get(dict_slot)) };
+    let value = W_BaseDictMultiIterObject {
         ob_header: PyObject {
             ob_type: tp as *const PyType,
             w_class: get_instantiate(tp),
         },
-        w_dict,
+        w_dict: crate::gc_roots::shadow_stack_get(dict_slot),
         startlen,
         index: 0,
         kind,
         reverse,
         start_strategy_id,
-    }) as PyObjectRef
+    };
+    let raw = crate::gc_hook::try_gc_alloc_stable_raw(
+        W_DICT_VIEW_ITERATOR_GC_TYPE_ID.get(),
+        W_DICT_VIEW_ITERATOR_OBJECT_SIZE,
+    );
+    if raw.is_null() {
+        crate::lltype::malloc_typed(value) as PyObjectRef
+    } else {
+        unsafe { std::ptr::write(raw as *mut W_BaseDictMultiIterObject, value) };
+        crate::gc_hook::try_gc_write_barrier(raw);
+        raw as PyObjectRef
+    }
 }
 
 /// # Safety
@@ -3205,14 +3224,26 @@ pub fn dict_view_type_for_kind(kind: DictViewKind) -> &'static PyType {
 /// Allocate a fresh dict view bound to `w_dict`.
 pub fn w_dict_view_new(w_dict: PyObjectRef, kind: DictViewKind) -> PyObjectRef {
     let tp = dict_view_type_for_kind(kind);
-    crate::lltype::malloc_typed(W_DictViewObject {
+    let _roots = crate::gc_roots::push_roots();
+    let dict_slot = crate::gc_roots::shadow_stack_len();
+    crate::gc_roots::pin_root(w_dict);
+    let raw =
+        crate::gc_hook::try_gc_alloc_stable_raw(W_DICT_VIEW_GC_TYPE_ID, W_DICT_VIEW_OBJECT_SIZE);
+    let value = W_DictViewObject {
         ob_header: PyObject {
             ob_type: tp as *const PyType,
             w_class: get_instantiate(tp),
         },
         kind,
-        w_dict,
-    }) as PyObjectRef
+        w_dict: crate::gc_roots::shadow_stack_get(dict_slot),
+    };
+    if raw.is_null() {
+        crate::lltype::malloc_typed(value) as PyObjectRef
+    } else {
+        unsafe { std::ptr::write(raw as *mut W_DictViewObject, value) };
+        crate::gc_hook::try_gc_write_barrier(raw);
+        raw as PyObjectRef
+    }
 }
 
 /// Test whether `obj` is any of the three view types.

--- a/pyre/pyre-object/src/gc_roots.rs
+++ b/pyre/pyre-object/src/gc_roots.rs
@@ -129,6 +129,12 @@ pub fn push_roots() -> RootScope {
 /// it (`@dont_look_inside`, `rlib/jit.py:139`), the `shadow_stack_len` twin.
 #[majit_macros::dont_look_inside]
 pub fn pin_root(root: PyObjectRef) {
+    // A foreign mutator may have completed a nursery collection after the
+    // caller copied this GCREF but before it entered this explicit root
+    // bracket.  RPython's `_trace_drag_out` always rewrites a root that names
+    // an already-forwarded nursery object; normalize the host-side copy at
+    // the same boundary so the shadow stack never gains a forwarding stub.
+    let root = crate::gc_hook::try_gc_current_object_address(root as *mut u8) as PyObjectRef;
     SHADOW_STACK.with(|s| s.borrow_mut().push(root));
 }
 
@@ -157,7 +163,13 @@ pub fn shadow_stack_len() -> usize {
 /// `rlib/jit.py:139`), the [`shadow_stack_len`] twin.
 #[majit_macros::dont_look_inside]
 pub fn shadow_stack_get(index: usize) -> PyObjectRef {
-    SHADOW_STACK.with(|s| s.borrow()[index])
+    SHADOW_STACK.with(|s| {
+        let mut stack = s.borrow_mut();
+        let root = stack[index];
+        let current = crate::gc_hook::try_gc_current_object_address(root as *mut u8) as PyObjectRef;
+        stack[index] = current;
+        current
+    })
 }
 
 /// Visit every pinned root in the shadow stack with mutable access.

--- a/pyre/pyre-object/src/generator.rs
+++ b/pyre/pyre-object/src/generator.rs
@@ -4,8 +4,10 @@
 //! YIELD_VALUE (produces a value) or RETURN_VALUE (raises StopIteration).
 
 use crate::pyobject::*;
+use pyre_macros::pyre_class;
 
 pub static GENERATOR_TYPE: PyType = crate::pyobject::new_pytype("generator");
+pub static COROUTINE_TYPE: PyType = crate::pyobject::new_pytype("coroutine");
 
 /// Generator object: holds a boxed frame that can be resumed.
 ///
@@ -30,6 +32,19 @@ pub struct GeneratorIterator {
     /// Per-generator writable `__qualname__` override. NULL means read the
     /// suspended frame code's original qualified name.
     pub qualname: PyObjectRef,
+    /// PyPy: `Coroutine.w_cr_origin`. Generators keep this at `PY_NULL`;
+    /// coroutines initialise it to `None` until origin tracking captures a
+    /// tuple of frame summaries.
+    pub cr_origin: PyObjectRef,
+    /// PyPy: `Coroutine._warned_unawaited`.
+    pub warned_unawaited: bool,
+}
+
+/// PyPy `generator.py CoroutineWrapper`: the iterator returned by
+/// `Coroutine.__await__`, holding the coroutine as its sole GC edge.
+#[pyre_class("coroutine_wrapper", static_name = "COROUTINE_WRAPPER")]
+pub struct CoroutineWrapper {
+    pub coroutine: PyObjectRef,
 }
 
 /// GC type id assigned to `GeneratorIterator` at JitDriver init time.
@@ -45,11 +60,19 @@ impl crate::lltype::GcType for GeneratorIterator {
     const SIZE: usize = W_GENERATOR_OBJECT_SIZE;
 }
 
-pub fn w_generator_new(frame_ptr: *mut u8) -> PyObjectRef {
+fn w_generator_or_coroutine_new(frame_ptr: *mut u8, coroutine: bool) -> PyObjectRef {
     let value = GeneratorIterator {
         ob: PyObject {
-            ob_type: &GENERATOR_TYPE as *const PyType,
-            w_class: get_instantiate(&GENERATOR_TYPE),
+            ob_type: if coroutine {
+                &COROUTINE_TYPE as *const PyType
+            } else {
+                &GENERATOR_TYPE as *const PyType
+            },
+            w_class: if coroutine {
+                get_instantiate(&COROUTINE_TYPE)
+            } else {
+                get_instantiate(&GENERATOR_TYPE)
+            },
         },
         frame_ptr,
         started: false,
@@ -57,6 +80,8 @@ pub fn w_generator_new(frame_ptr: *mut u8) -> PyObjectRef {
         running: false,
         name: PY_NULL,
         qualname: PY_NULL,
+        cr_origin: if coroutine { crate::w_none() } else { PY_NULL },
+        warned_unawaited: false,
     };
     // A generator must be GC-managed, not immortal `malloc_typed`: the
     // collector never reaches an immortal object, so the registered
@@ -82,9 +107,49 @@ pub fn w_generator_new(frame_ptr: *mut u8) -> PyObjectRef {
     crate::lltype::malloc_typed(value) as PyObjectRef
 }
 
+pub fn w_generator_new(frame_ptr: *mut u8) -> PyObjectRef {
+    w_generator_or_coroutine_new(frame_ptr, false)
+}
+
+pub fn w_coroutine_new(frame_ptr: *mut u8) -> PyObjectRef {
+    w_generator_or_coroutine_new(frame_ptr, true)
+}
+
+pub fn w_coroutine_wrapper_new(coroutine: PyObjectRef) -> PyObjectRef {
+    let _roots = crate::gc_roots::push_roots();
+    crate::gc_roots::pin_root(coroutine);
+    CoroutineWrapper::allocate(CoroutineWrapper {
+        ob: PyObject {
+            ob_type: std::ptr::null(),
+            w_class: std::ptr::null_mut(),
+        },
+        coroutine,
+    })
+}
+
 #[inline]
 pub unsafe fn is_generator(obj: PyObjectRef) -> bool {
     unsafe { py_type_check(obj, &GENERATOR_TYPE) }
+}
+
+#[inline]
+pub unsafe fn is_coroutine(obj: PyObjectRef) -> bool {
+    unsafe { py_type_check(obj, &COROUTINE_TYPE) }
+}
+
+#[inline]
+pub unsafe fn is_generator_or_coroutine(obj: PyObjectRef) -> bool {
+    unsafe { is_generator(obj) || is_coroutine(obj) }
+}
+
+#[inline]
+pub unsafe fn is_coroutine_wrapper(obj: PyObjectRef) -> bool {
+    unsafe { py_type_check(obj, &COROUTINE_WRAPPER_TYPE) }
+}
+
+#[inline]
+pub unsafe fn w_coroutine_wrapper_get_coroutine(obj: PyObjectRef) -> PyObjectRef {
+    unsafe { (*(obj as *const CoroutineWrapper)).coroutine }
 }
 
 pub unsafe fn w_generator_get_frame(obj: PyObjectRef) -> *mut u8 {
@@ -141,6 +206,11 @@ pub unsafe fn w_generator_get_qualname(obj: PyObjectRef) -> PyObjectRef {
 pub unsafe fn w_generator_set_qualname(obj: PyObjectRef, value: PyObjectRef) {
     unsafe { (*(obj as *mut GeneratorIterator)).qualname = value };
     crate::gc_hook::try_gc_write_barrier(obj as *mut u8);
+}
+
+#[inline]
+pub unsafe fn w_coroutine_get_origin(obj: PyObjectRef) -> PyObjectRef {
+    unsafe { (*(obj as *const GeneratorIterator)).cr_origin }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

Two commits on `stdlib-popular`.

**`interpreter: unblock popular stdlib modules`** — enables several popular
stdlib modules: `array` additions, `sys` state/vm additions, `importing`
fixes, and `descroperation` / `typedef` adjustments.

**`interpreter, jit: coroutine type + GC roots across calls`** — the
correctness follow-up those modules surfaced:

- **Native `coroutine` / `coroutine_wrapper` types.** Previously `async def`
  frames reused the generator type with a code-flag test; now a Coroutine is a
  distinct object whose `__await__` returns a separate CoroutineWrapper
  iterator. Adds `cr_running/cr_suspended/cr_frame/cr_code/cr_await/cr_origin`
  descriptors, `__name__`/`__qualname__`, send/throw/close/`__del__`, and GC +
  JIT type registration.
- **Root call arguments across GC-collecting calls** (RPython shadowstack-
  transform parity). Fixes a `Counter(dict(gen))`-style sweep-during-call where
  a live temporary could be collected while only a raw Rust pointer held it —
  in `call_function_impl_result`, builtin/type dispatch, frame construction,
  `dict.update`, `set.__init__`, `collect_iterable`, the residual `bh_call_fn`
  thunk, and the dynasm regalloc `before_call` force-store of Ref arguments.
- **Dict-view iterators/views become real GC objects** (auto-assigned type id +
  vtable registration) instead of malloc-immortal carriers.
- **`reduce_protocol`** interphook handles moved from thread-local to
  process-global slots, walked by the global root walker.
- **`GET_ITER`** gains an `iter_value` handler (pop iterable / push iterator)
  and a `jit_get_iter` may-force residual op.
- **JIT inline resume:** an inlined Python callee is residualized instead of
  collapsed onto the root frame when the caller frame can't be represented;
  fixes a layout-only vstack boundary that could overwrite a surviving
  FOR_ITER iterator; records `GUARD_FUTURE_CONDITION` in the in-walk
  compile_trace path.
- **optimizeopt:** drop the `label_args` / `phase1_inputargs` virtual-arity
  special case; `short_jump_args` always extend with virtuals.
- `next()` raises `'X' object is not an iterator` with the type name.

### Verification

- `cargo check --no-default-features --features dynasm` (dynasm binary): clean.
- The full `check.py` suite was **not** run in this session.

## Self-review

- [ ] I fully resolved all reasonable code review comments from Codex and CodeRabbit.
  - [ ] Auto-review section 1 is clear. This check is mandatory.
  - [ ] Auto-review section 2 is clear. If this is not checked, please add a comment explaining why.
- [ ] I did not use AI to write the code of this patch.
  - AI-assisted; the follow-up commit carries an `Assisted-by: Claude` trailer.

— *PR description drafted by Claude*
