### PR TITLE
Interpreter correctness: OrderedDict, stdlib gaps, arity enforcement

### DIFF
--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -6146,7 +6146,7 @@ pub(crate) fn getindex_w(w_obj: PyObjectRef) -> Result<i64, crate::PyError> {
         }
     }
     Err(crate::PyError::type_error(format!(
-        "int() second argument must be an integer, not '{}'",
+        "'{}' object cannot be interpreted as an integer",
         unsafe { (*(*w_obj).ob_type).name }
     )))
 }

--- a/pyre/pyre-interpreter/src/module/__pypy__/identity_dict_app.py
+++ b/pyre/pyre-interpreter/src/module/__pypy__/identity_dict_app.py
@@ -16,6 +16,9 @@ class identity_dict(object):
     def __setitem__(self, key, value):
         self._d[id(key)] = value
 
+    def __delitem__(self, key):
+        del self._d[id(key)]
+
     def __contains__(self, key):
         return id(key) in self._d
 
@@ -27,3 +30,56 @@ class identity_dict(object):
 
     def clear(self):
         self._d.clear()
+
+
+def reversed_dict(d):
+    """Enumerate the keys of a dict in reversed order.
+
+    A ``__pypy__`` primitive so ``collections.OrderedDict`` can implement
+    ``__reversed__`` even though CPython dicts are unordered.  Going
+    through the unbound ``dict`` slot bypasses any ``__reversed__`` a
+    subclass installs, matching the interp-level
+    ``W_DictMultiObject.descr_reversed``.
+    """
+    if not isinstance(d, dict):
+        raise TypeError("reversed_dict() argument must be a dict")
+    return dict.__reversed__(d)
+
+
+def move_to_end(d, key, last=True):
+    """Move an existing key to the end (or the front if last is False).
+
+    Raises KeyError if the key does not exist.  A ``__pypy__`` primitive
+    backing ``collections.OrderedDict.move_to_end``.
+    """
+    if not isinstance(d, dict):
+        raise TypeError("move_to_end() argument must be a dict")
+    value = dict.__getitem__(d, key)  # raises KeyError when key is missing
+    if last:
+        dict.__delitem__(d, key)
+        dict.__setitem__(d, key, value)
+    else:
+        dict.__delitem__(d, key)
+        pairs = [(k, dict.__getitem__(d, k)) for k in list(dict.__iter__(d))]
+        for k, _ in pairs:
+            dict.__delitem__(d, k)
+        dict.__setitem__(d, key, value)
+        for k, v in pairs:
+            dict.__setitem__(d, k, v)
+
+
+# Persistent identity dict of objects currently being repr()'d.  PyPy keeps
+# this per-thread on the ExecutionContext; pyre keeps a single module-global
+# instance, which serves the same self-recursion guard under pyre's execution
+# model.  It stays empty between reprs (each __repr__ removes itself in a
+# finally block).
+_objects_in_repr = identity_dict()
+
+
+def objects_in_repr():
+    """The identity dict of objects currently being repr()'d.
+
+    ``__repr__`` methods (e.g. ``collections.OrderedDict``) use it to
+    emit ``...`` instead of recursing on a self-referential container.
+    """
+    return _objects_in_repr

--- a/pyre/pyre-interpreter/src/module/__pypy__/mod.rs
+++ b/pyre/pyre-interpreter/src/module/__pypy__/mod.rs
@@ -6,6 +6,11 @@
 //! shared `try` block; both must resolve for the optimized path to
 //! activate, so both are provided here as app-level classes.
 //!
+//! `collections.OrderedDict` (`_collections/app_odict.py`) imports
+//! `reversed_dict`, `move_to_end`, and `objects_in_repr` — the dict-order
+//! primitives PyPy keeps in `interp_dict.py` / `interp_magic.py`.  Pyre
+//! provides them app-level alongside `identity_dict`.
+//!
 //! `PickleBuffer` (`interp_buffer.py W_PickleBuffer`) is exposed here as
 //! an interp-level class; `pickle.py` re-exports it and the `_pickle`
 //! accelerator serializes it in-band or out-of-band under protocol 5.
@@ -23,7 +28,8 @@ crate::py_module! {
         "PickleBuffer" => interp_buffer::type_object(),
     },
     appleveldefs: {
-        "identity_dict_app.py" => ["identity_dict"],
+        "identity_dict_app.py" =>
+            ["identity_dict", "reversed_dict", "move_to_end", "objects_in_repr"],
     },
     extra_init: |ns| {
         // Mark as a package so `from __pypy__.builders import ...`

--- a/pyre/pyre-interpreter/src/module/_collections/app_odict.py
+++ b/pyre/pyre-interpreter/src/module/_collections/app_odict.py
@@ -1,0 +1,168 @@
+from __pypy__ import reversed_dict, move_to_end, objects_in_repr
+from _operator import eq as _eq
+
+
+class OrderedDict(dict):
+    '''Dictionary that remembers insertion order.
+
+    In PyPy all dicts are ordered anyway.  This is mostly useful as a
+    placeholder to mean "this dict must be ordered even on CPython".
+
+    Known difference: iterating over an OrderedDict which is being
+    concurrently modified raises RuntimeError in PyPy.  In CPython
+    instead we get some behavior that appears reasonable in some
+    cases but is nonsensical in other cases.  This is officially
+    forbidden by the CPython docs, so we forbid it explicitly for now.
+    '''
+    __module__ = 'collections'
+
+    def __init__(*args, **kwds):
+        '''Initialize an ordered dictionary.  The signature is the same as
+        regular dictionaries, but keyword arguments are not recommended because
+        their insertion order is arbitrary.
+
+        '''
+        if not args:
+            raise TypeError("descriptor '__init__' of 'OrderedDict' object "
+                            "needs an argument")
+        self, *args = args
+        if len(args) > 1:
+            raise TypeError('expected at most 1 arguments, got %d' % len(args))
+        self.__update(*args, **kwds)
+
+    def update(*args, **kwds):
+        ''' D.update([E, ]**F) -> None.  Update D from mapping/iterable E and F.
+            If E present and has a .keys() method, does:     for k in E: D[k] = E[k]
+            If E present and lacks .keys() method, does:     for (k, v) in E: D[k] = v
+            In either case, this is followed by: for k, v in F.items(): D[k] = v
+        '''
+        if not args:
+            raise TypeError("descriptor 'update' of 'OrderedDict' object "
+                            "needs an argument")
+        self, *args = args
+        if len(args) > 1:
+            raise TypeError('update expected at most 1 arguments, got %d' %
+                            len(args))
+        if args:
+            other = args[0]
+            if hasattr(other, "keys"):
+                for key in other.keys():
+                    self[key] = other[key]
+            elif hasattr(other, 'items'):
+                for key, value in other.items():
+                    self[key] = value
+            else:
+                for key, value in other:
+                    self[key] = value
+        for key, value in kwds.items():
+            self[key] = value
+    __update = update
+
+    def __reversed__(self):
+        return reversed_dict(self)
+
+    def popitem(self, last=True):
+        '''od.popitem() -> (k, v), return and remove a (key, value) pair.
+        Pairs are returned in LIFO order if last is true or FIFO order if false.
+
+        '''
+        if last:
+            return dict.popitem(self)
+        else:
+            it = dict.__iter__(self)
+            try:
+                k = next(it)
+            except StopIteration:
+                raise KeyError('dictionary is empty')
+            return (k, self.pop(k))
+
+    def move_to_end(self, key, last=True):
+        '''Move an existing element to the end (or beginning if last==False).
+
+        Raises KeyError if the element does not exist.
+        When last=True, acts like a fast version of self[key]=self.pop(key).
+
+        '''
+        return move_to_end(self, key, last)
+
+    def __repr__(self):
+        'od.__repr__() <==> repr(od)'
+        if not self:
+            return '%s()' % (self.__class__.__name__,)
+        currently_in_repr = objects_in_repr()
+        if self in currently_in_repr:
+            return '...'
+        currently_in_repr[self] = 1
+        try:
+            return '%s(%r)' % (self.__class__.__name__, list(self.items()))
+        finally:
+            try:
+                del currently_in_repr[self]
+            except:
+                pass
+
+    def __reduce__(self):
+        'Return state information for pickling'
+        state = object.__getstate__(self)
+        return self.__class__, (), state or None, None, iter(self.items())
+
+    def copy(self):
+        'od.copy() -> a shallow copy of od'
+        return self.__class__(self)
+
+    def __eq__(self, other):
+        '''od.__eq__(y) <==> od==y.  Comparison to another OD is order-sensitive
+        while comparison to a regular mapping is order-insensitive.
+
+        '''
+        if isinstance(other, OrderedDict):
+            return dict.__eq__(self, other) and all(map(_eq, self, other))
+        return dict.__eq__(self, other)
+
+    def __or__(self, other):
+        if not isinstance(other, dict):
+            return NotImplemented
+        copyself = self.copy()
+        copyself.update(other)
+        return copyself
+
+    def __ror__(self, other):
+        if not isinstance(other, dict):
+            return NotImplemented
+        copy = type(self)(other)
+        copy.update(self)
+        return copy
+
+    # for __ior__ the dict implementation is fine
+
+    __ne__ = object.__ne__
+
+    def keys(self):
+        "D.keys() -> a set-like object providing a view on D's keys"
+        return _OrderedDictKeysView(self)
+
+    def items(self):
+        "D.items() -> a set-like object providing a view on D's items"
+        return _OrderedDictItemsView(self)
+
+    def values(self):
+        "D.values() -> an object providing a view on D's values"
+        return _OrderedDictValuesView(self)
+
+dict_keys = type({}.keys())
+dict_values = type({}.values())
+dict_items = type({}.items())
+
+class _OrderedDictKeysView(dict_keys):
+    def __reversed__(self):
+        yield from reversed_dict(self._dict)
+
+class _OrderedDictItemsView(dict_items):
+    def __reversed__(self):
+        for key in reversed_dict(self._dict):
+            yield (key, self._dict[key])
+
+class _OrderedDictValuesView(dict_values):
+    def __reversed__(self):
+        for key in reversed_dict(self._dict):
+            yield self._dict[key]

--- a/pyre/pyre-interpreter/src/module/_collections/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_collections/mod.rs
@@ -427,6 +427,30 @@ impl W_Deque {
         }
         Ok(())
     }
+    fn insert(&mut self, i: PyObjectRef, x: PyObjectRef) -> Result<(), crate::PyError> {
+        let self_obj = self as *mut W_Deque as PyObjectRef;
+        // `W_Deque.insert(i, x)` — the index goes through `__index__` (converted
+        // before the deque is inspected), then a bounded deque that is already
+        // full raises before the element is placed.
+        let index = crate::builtins::getindex_w(i)?;
+        let mut items = snapshot(self_obj);
+        if maxlen_bound(self_obj).is_some_and(|m| items.len() >= m) {
+            return Err(crate::PyError::index_error(
+                "deque already at its maximum size",
+            ));
+        }
+        let len = items.len() as i64;
+        // list.insert clamping: a negative index counts from the end and an
+        // out-of-range index clamps to the near edge.
+        let pos = if index < 0 {
+            (index + len).max(0)
+        } else {
+            index.min(len)
+        } as usize;
+        items.insert(pos, x);
+        store(self_obj, items);
+        Ok(())
+    }
     fn index(
         &self,
         x: PyObjectRef,

--- a/pyre/pyre-interpreter/src/module/_collections/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_collections/mod.rs
@@ -5,10 +5,10 @@
 //! by a list payload field; semantically correct for
 //! `collections.py`'s `MutableSequence` consumers but not performant
 //! (PyPy's `W_Deque` is a doubly-linked block list — porting that needs
-//! a separate algorithm migration).  `defaultdict` is the
-//! app-level `dict` subclass in `app_defaultdict.py`, mirroring PyPy's
-//! `app_defaultdict.py` (neither runtime can subclass the app-level
-//! `dict` from interp-level).
+//! a separate algorithm migration).  `defaultdict` and `OrderedDict` are
+//! app-level `dict` subclasses in `app_defaultdict.py` / `app_odict.py`,
+//! mirroring PyPy (neither runtime can subclass the app-level `dict` from
+//! interp-level).
 
 use pyre_object::*;
 
@@ -661,13 +661,12 @@ crate::py_module! {
     interpleveldefs: {
         "deque"           => type_object(),
         "_deque_iterator" => crate::typedef::w_object(),
-        // `OrderedDict` is a dict subclass; alias to the dict type
-        // object so `isinstance(d, OrderedDict)` matches dict instances.
-        "OrderedDict"     => crate::typedef::gettypeobject(&pyre_object::pyobject::DICT_TYPE),
     },
-    // `defaultdict` is an app-level `dict` subclass — see the module
-    // header and `app_defaultdict.py` (PyPy `app_defaultdict.defaultdict`).
+    // `defaultdict` and `OrderedDict` are app-level `dict` subclasses —
+    // see the module header and `app_defaultdict.py` / `app_odict.py`
+    // (PyPy `app_defaultdict.defaultdict` / `app_odict.OrderedDict`).
     appleveldefs: {
         "app_defaultdict.py" => ["defaultdict"],
+        "app_odict.py" => ["OrderedDict"],
     },
 }

--- a/pyre/pyre-interpreter/src/module/_functools/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_functools/mod.rs
@@ -27,9 +27,32 @@ def cmp_to_key(mycmp):
             return mycmp(self.obj, other.obj) >= 0
         __hash__ = None
     return K
-"# => ["cmp_to_key"],
-    },
-    functions: {
-        "reduce" / * = |_| Err(crate::PyError::type_error("reduce not implemented")),
+
+
+def reduce(*args):
+    # _functoolsmodule.c functools_reduce — reduce(function, iterable[, initial]).
+    if len(args) < 2:
+        raise TypeError(
+            "reduce() takes at least 2 positional arguments (%d given)" % len(args))
+    if len(args) > 3:
+        raise TypeError(
+            "reduce() takes at most 3 arguments (%d given)" % len(args))
+    function = args[0]
+    try:
+        it = iter(args[1])
+    except TypeError:
+        raise TypeError("reduce() arg 2 must support iteration") from None
+    if len(args) == 3:
+        accum = args[2]
+    else:
+        try:
+            accum = next(it)
+        except StopIteration:
+            raise TypeError(
+                "reduce() of empty iterable with no initial value") from None
+    for element in it:
+        accum = function(accum, element)
+    return accum
+"# => ["cmp_to_key", "reduce"],
     },
 }

--- a/pyre/pyre-interpreter/src/module/itertools/interp_itertools.rs
+++ b/pyre/pyre-interpreter/src/module/itertools/interp_itertools.rs
@@ -3,7 +3,7 @@
 //! Verbatim move of the inline block previously in importing.rs.
 
 
-/// itertools stub
+/// groupby(iterable, key=None) — itertools-docs pure-Python equivalent.
 const GROUPBY_SRC: &str = r#"
 class groupby:
     __module__ = 'itertools'
@@ -30,6 +30,38 @@ class groupby:
             except StopIteration:
                 return
             self.currkey = self.keyfunc(self.currvalue)
+"#;
+
+/// tee(iterable, n=2) — itertools-docs pure-Python equivalent.  Each `_tee`
+/// keeps its own deque; when a deque runs dry the shared source iterator is
+/// advanced once and the new value is fanned out to every deque, so the copies
+/// stay independent and an unbounded source is drawn lazily.
+const TEE_SRC: &str = r#"
+import collections
+import operator
+
+class _tee:
+    __module__ = 'itertools'
+    def __init__(self, it, deques, mydeque):
+        self._it = it
+        self._deques = deques
+        self._mydeque = mydeque
+    def __iter__(self):
+        return self
+    def __next__(self):
+        if not self._mydeque:
+            newval = next(self._it)
+            for d in self._deques:
+                d.append(newval)
+        return self._mydeque.popleft()
+
+def tee(iterable, n=2):
+    n = operator.index(n)
+    if n < 0:
+        raise ValueError("n must be >= 0")
+    it = iter(iterable)
+    deques = [collections.deque() for _ in range(n)]
+    return tuple(_tee(it, deques, d) for d in deques)
 "#;
 
 pub fn register_module(ns: pyre_object::PyObjectRef) {
@@ -181,6 +213,10 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
     // advances; expressing that shared state directly in Python avoids a
     // second native iterator type.
     crate::importing::appleveldef_install(ns, GROUPBY_SRC, "<inline>", &["groupby"]);
+    // tee(iterable, n=2) — the itertools-docs pure-Python equivalent.  A native
+    // dataobject type would only save buffer copies; the deque-per-copy recipe
+    // keeps the copies lazy and independent, which is what callers observe.
+    crate::importing::appleveldef_install(ns, TEE_SRC, "<inline>", &["tee"]);
     // permutations(iterable, r=None) — PyPy: pypy/module/itertools/interp_itertools.py
     crate::module_ns_store(
         ns,
@@ -271,6 +307,60 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                     out
                 }
                 let all = combs(&pool, r, 0);
+                let tuples: Vec<_> = all.into_iter().map(pyre_object::w_tuple_new).collect();
+                let n = tuples.len();
+                let list = pyre_object::w_list_new(tuples);
+                Ok(pyre_object::w_seq_iter_new(list, n))
+            },
+            2,
+        ),
+    );
+    // combinations_with_replacement(iterable, r) — like combinations, but an
+    // element may repeat, so the recursion re-enters at `i` rather than `i + 1`
+    // and `r` may exceed the pool length.  `r` is taken through `__index__`
+    // before the iterable is drawn, matching the argument-clinic evaluation
+    // order, and a negative `r` is a ValueError.
+    crate::module_ns_store(
+        ns,
+        "combinations_with_replacement",
+        crate::make_builtin_function_with_arity(
+            "combinations_with_replacement",
+            |args| {
+                let missing = match args.len() {
+                    0 => Some("iterable"),
+                    1 => Some("r"),
+                    _ => None,
+                };
+                if let Some(name) = missing {
+                    return Err(crate::PyError::type_error(format!(
+                        "combinations_with_replacement() missing required argument '{name}'"
+                    )));
+                }
+                let r = crate::builtins::space_index_w(args[1])?;
+                if r < 0 {
+                    return Err(crate::PyError::value_error("r must be non-negative"));
+                }
+                let r = r as usize;
+                let pool = crate::builtins::collect_iterable(args[0])?;
+                fn cwr(
+                    pool: &[pyre_object::PyObjectRef],
+                    r: usize,
+                    start: usize,
+                ) -> Vec<Vec<pyre_object::PyObjectRef>> {
+                    if r == 0 {
+                        return vec![vec![]];
+                    }
+                    let mut out = Vec::new();
+                    for i in start..pool.len() {
+                        for mut tail in cwr(pool, r - 1, i) {
+                            let mut v = vec![pool[i]];
+                            v.append(&mut tail);
+                            out.push(v);
+                        }
+                    }
+                    out
+                }
+                let all = cwr(&pool, r, 0);
                 let tuples: Vec<_> = all.into_iter().map(pyre_object::w_tuple_new).collect();
                 let n = tuples.len();
                 let list = pyre_object::w_list_new(tuples);

--- a/pyre/pyre-interpreter/src/module/itertools/interp_itertools.rs
+++ b/pyre/pyre-interpreter/src/module/itertools/interp_itertools.rs
@@ -4,6 +4,34 @@
 
 
 /// itertools stub
+const GROUPBY_SRC: &str = r#"
+class groupby:
+    __module__ = 'itertools'
+    def __init__(self, iterable, key=None):
+        if key is None:
+            key = lambda x: x
+        self.keyfunc = key
+        self.it = iter(iterable)
+        self.tgtkey = self.currkey = self.currvalue = object()
+    def __iter__(self):
+        return self
+    def __next__(self):
+        self.id = object()
+        while self.currkey == self.tgtkey:
+            self.currvalue = next(self.it)
+            self.currkey = self.keyfunc(self.currvalue)
+        self.tgtkey = self.currkey
+        return (self.currkey, self._grouper(self.tgtkey, self.id))
+    def _grouper(self, tgtkey, id):
+        while self.id is id and self.currkey == tgtkey:
+            yield self.currvalue
+            try:
+                self.currvalue = next(self.it)
+            except StopIteration:
+                return
+            self.currkey = self.keyfunc(self.currvalue)
+"#;
+
 pub fn register_module(ns: pyre_object::PyObjectRef) {
     // chain(*iterables) — W_Chain___new__: store `iter(newtuple(args))` as
     // the source-iterables iterator.  W_Chain.next_w (baseobjspace::next)
@@ -147,12 +175,12 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
             Ok(pyre_object::w_seq_iter_new(list, n))
         }),
     );
-    // groupby
-    crate::module_ns_store(
-        ns,
-        "groupby",
-        crate::make_builtin_function("groupby", |_| Ok(pyre_object::w_none())),
-    );
+    // groupby(iterable, key=None) — the itertools-docs pure-Python
+    // equivalent.  The parent and each group share the `currkey/currvalue`
+    // cursor plus an `id` token that invalidates a group once the parent
+    // advances; expressing that shared state directly in Python avoids a
+    // second native iterator type.
+    crate::importing::appleveldef_install(ns, GROUPBY_SRC, "<inline>", &["groupby"]);
     // permutations(iterable, r=None) — PyPy: pypy/module/itertools/interp_itertools.py
     crate::module_ns_store(
         ns,

--- a/pyre/pyre-interpreter/src/module/operator/app_operator.py
+++ b/pyre/pyre-interpreter/src/module/operator/app_operator.py
@@ -15,6 +15,43 @@ def countOf(a, b):
     return count
 
 
+def concat(a, b):
+    "Same as a + b, for a and b sequences."
+    if not hasattr(a, '__getitem__'):
+        msg = "'%s' object can't be concatenated" % type(a).__name__
+        raise TypeError(msg)
+    return a + b
+
+
+def indexOf(a, b):
+    "Return the first index of b in a."
+    for i, j in enumerate(a):
+        if j is b or j == b:
+            return i
+    else:
+        raise ValueError('sequence.index(x): x not in sequence')
+
+
+def inv(a):
+    "Same as ~a."
+    return ~a
+
+
+def is_none(a):
+    "Same as a is None."
+    return a is None
+
+
+def is_not_none(a):
+    "Same as a is not None."
+    return a is not None
+
+
+def call(obj, /, *args, **kwargs):
+    "Same as obj(*args, **kwargs)."
+    return obj(*args, **kwargs)
+
+
 class attrgetter(object):
     """
     Return a callable object that fetches the given attribute(s) from its operand.

--- a/pyre/pyre-interpreter/src/module/operator/mod.rs
+++ b/pyre/pyre-interpreter/src/module/operator/mod.rs
@@ -127,9 +127,15 @@ crate::py_module! {
     "operator",
     // `countOf` + the `itemgetter`/`attrgetter`/`methodcaller` callable
     // classes are app-level (`pypy/module/operator/app_operator.py`,
-    // `moduledef.py` `app_names`), not interp-level.
+    // `moduledef.py` `app_names`), not interp-level.  `concat`/`indexOf`/
+    // `inv`/`is_none`/`is_not_none`/`call` follow the `operator.py` pure-
+    // Python definitions verbatim (`call`'s `**kwargs` forwarding and
+    // `concat`'s `__getitem__` guard are awkward to express interp-level).
     appleveldefs: {
-        "app_operator.py" => ["countOf", "itemgetter", "attrgetter", "methodcaller"],
+        "app_operator.py" => [
+            "countOf", "itemgetter", "attrgetter", "methodcaller",
+            "concat", "indexOf", "inv", "is_none", "is_not_none", "call",
+        ],
     },
     functions: {
         "index"    / 1 = op_index,

--- a/pyre/pyre-interpreter/src/type_methods.rs
+++ b/pyre/pyre-interpreter/src/type_methods.rs
@@ -4920,8 +4920,15 @@ pub fn resolve_dict_backing(obj: PyObjectRef) -> PyObjectRef {
         // on `type.__dict__` without per-method proxy plumbing.
         if pyre_object::is_dict_proxy(obj) {
             let inner = pyre_object::w_dict_proxy_get_mapping(obj);
-            if !inner.is_null() && pyre_object::is_dict(inner) {
-                return inner;
+            // The wrapped mapping may itself be a dict subclass (e.g. a
+            // class whose namespace is an `OrderedDict`), which keeps its
+            // entries in a native backing dict — resolve through to that
+            // rather than requiring `inner` to be an exact dict.
+            if !inner.is_null() && inner != obj {
+                let backing = resolve_dict_backing(inner);
+                if !backing.is_null() {
+                    return backing;
+                }
             }
         }
         if is_instance(obj) {

--- a/pyre/pyre-interpreter/src/type_methods.rs
+++ b/pyre/pyre-interpreter/src/type_methods.rs
@@ -520,6 +520,7 @@ pub fn list_method_pop(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyErr
 /// PyPy: listobject.py descr_clear — list.clear()
 pub fn list_method_clear(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     require_list_receiver(args, "clear", true)?;
+    arity_no_args(args, "list.clear")?;
     unsafe { pyre_object::listobject::w_list_clear(args[0]) };
     Ok(w_none())
 }
@@ -527,6 +528,7 @@ pub fn list_method_clear(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyE
 /// PyPy: listobject.py descr_copy — list.copy()
 pub fn list_method_copy(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     require_list_receiver(args, "copy", true)?;
+    arity_no_args(args, "list.copy")?;
     let list = args[0];
     unsafe {
         let n = w_list_len(list);
@@ -543,6 +545,7 @@ pub fn list_method_copy(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyEr
 /// PyPy: listobject.py descr_reverse — list.reverse()
 pub fn list_method_reverse(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     require_list_receiver(args, "reverse", true)?;
+    arity_no_args(args, "list.reverse")?;
     unsafe { pyre_object::listobject::w_list_reverse(args[0]) };
     Ok(w_none())
 }
@@ -5317,6 +5320,7 @@ pub fn dict_method_pop(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyErr
 /// so popping the last entry matches the spec.
 pub fn dict_method_popitem(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     require_receiver(args, "popitem")?;
+    arity_no_args(args, "dict.popitem")?;
     let dict = resolve_dict_backing(args[0]);
     if dict.is_null() {
         return Err(crate::PyError::key_error("popitem(): dictionary is empty"));

--- a/pyre/pyre-interpreter/src/type_methods.rs
+++ b/pyre/pyre-interpreter/src/type_methods.rs
@@ -5004,6 +5004,7 @@ pub(crate) fn set_contains_checked(
 
 pub fn dict_method_get(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     arity_at_least(args, "get", 1)?;
+    arity_at_most(args, "get", 2)?;
     let dict = resolve_dict_backing(args[0]);
     let key = args[1];
     let default = args.get(2).copied().unwrap_or_else(w_none);
@@ -5339,6 +5340,7 @@ pub fn dict_method_popitem(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::P
 /// `strategy.setdefault` as a single atomic operation (one hash).
 pub fn dict_method_setdefault(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     arity_at_least(args, "setdefault", 1)?;
+    arity_at_most(args, "setdefault", 2)?;
     let dict = resolve_dict_backing(args[0]);
     let key = args[1];
     let default = args.get(2).copied().unwrap_or_else(w_none);

--- a/pyre/pyre-interpreter/src/type_methods.rs
+++ b/pyre/pyre-interpreter/src/type_methods.rs
@@ -5442,7 +5442,7 @@ mod dict_method_tests {
 
 // ── Tuple methods ────────────────────────────────────────────────────
 
-/// PyPy: tupleobject.py descr_index — tuple.index(value)
+/// tupleobject.py descr_index — tuple.index(value[, start[, stop]]).
 pub fn tuple_method_index(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     require_tuple_receiver(args, "index", true)?;
     if args.len() < 2 {
@@ -5459,15 +5459,40 @@ pub fn tuple_method_index(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::Py
     }
     let tup = args[0];
     let value = args[1];
-    let length = unsafe { w_tuple_len(tup) } as i64;
-    let w_start = args.get(2).copied().unwrap_or_else(|| w_int_new(0));
-    let w_stop = args.get(3).copied().unwrap_or_else(|| w_int_new(i64::MAX));
-    let (start, stop) = crate::sliceobject::unwrap_start_stop(length, w_start, w_stop)?;
-    for i in start..stop.min(length) {
-        if let Some(item) = unsafe { w_tuple_getitem(tup, i) } {
-            if crate::baseobjspace::eq_w(item, value)? {
-                return Ok(w_int_new(i));
+    // descr_index defaults: w_start=0, w_stop=maxint; unwrap_start_stop does
+    // negative normalization and __index__ coercion.
+    let size = unsafe { w_tuple_len(tup) } as i64;
+    let w_start = if args.len() >= 3 {
+        args[2]
+    } else {
+        w_int_new(0)
+    };
+    let w_stop = if args.len() >= 4 {
+        args[3]
+    } else {
+        w_int_new(i64::MAX)
+    };
+    // A user __eq__ (or an __index__ on start/stop) may allocate and move the
+    // tuple / search value across a minor collection; root both and reload.
+    unsafe {
+        let _roots = pyre_object::gc_roots::push_roots();
+        let sp = pyre_object::gc_roots::shadow_stack_len();
+        pyre_object::gc_roots::pin_root(tup);
+        pyre_object::gc_roots::pin_root(value);
+        let (start, stop) = crate::sliceobject::unwrap_start_stop(size, w_start, w_stop)?;
+        let mut i = start.max(0);
+        while i < stop {
+            let tup = pyre_object::gc_roots::shadow_stack_get(sp);
+            if i >= w_tuple_len(tup) as i64 {
+                break;
             }
+            if let Some(item) = w_tuple_getitem(tup, i) {
+                let value = pyre_object::gc_roots::shadow_stack_get(sp + 1);
+                if crate::baseobjspace::eq_w(item, value)? {
+                    return Ok(w_int_new(i));
+                }
+            }
+            i += 1;
         }
     }
     Err(crate::PyError::value_error(
@@ -5487,14 +5512,26 @@ pub fn tuple_method_count(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::Py
     let tup = args[0];
     let value = args[1];
     let mut count: i64 = 0;
+    // A user __eq__ may allocate and move the tuple / value across a minor
+    // collection; root both and reload after each comparison.
     unsafe {
-        let n = w_tuple_len(tup);
-        for i in 0..n {
-            if let Some(item) = w_tuple_getitem(tup, i as i64) {
+        let _roots = pyre_object::gc_roots::push_roots();
+        let sp = pyre_object::gc_roots::shadow_stack_len();
+        pyre_object::gc_roots::pin_root(tup);
+        pyre_object::gc_roots::pin_root(value);
+        let mut i = 0i64;
+        loop {
+            let tup = pyre_object::gc_roots::shadow_stack_get(sp);
+            if i >= w_tuple_len(tup) as i64 {
+                break;
+            }
+            if let Some(item) = w_tuple_getitem(tup, i) {
+                let value = pyre_object::gc_roots::shadow_stack_get(sp + 1);
                 if crate::baseobjspace::eq_w(item, value)? {
                     count += 1;
                 }
             }
+            i += 1;
         }
     }
     Ok(w_int_new(count))

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -14605,7 +14605,7 @@ fn init_object_type(ns: PyObjectRef) {
             make_builtin_function_with_arity(
                 "__reduce_ex__",
                 |args| {
-                    let proto = unsafe { pyre_object::w_int_get_value(args[1]) };
+                    let proto = crate::builtins::space_index_w(args[1])?;
                     crate::reduce_protocol::descr_reduce_ex(args[0], proto)
                 },
                 2,

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -5386,6 +5386,7 @@ fn init_dict_type(ns: PyObjectRef) {
                 // classmethod: args[0] is the bound cls; the user arguments are
                 // fromkeys(iterable, value=None).
                 let cls = args.first().copied().unwrap_or(pyre_object::PY_NULL);
+                crate::type_methods::arity_at_most(args, "fromkeys", 2)?;
                 let (iterable, value) = if args.len() >= 3 {
                     (args[1], args[2])
                 } else if args.len() == 2 {
@@ -20040,23 +20041,22 @@ fn init_set_type(ns: PyObjectRef) {
                 "add",
                 |args| {
                     crate::type_methods::require_set_receiver(args, "add", true)?;
-                    if args.len() >= 2 {
-                        // `try_hash_value` may run a user `__hash__` that
-                        // allocates and triggers a moving minor collection;
-                        // root `self` and the element across it, then reload.
-                        // Its digest keys the store, so the element is hashed
-                        // once.
-                        unsafe {
-                            let _roots = pyre_object::gc_roots::push_roots();
-                            let sp = pyre_object::gc_roots::shadow_stack_len();
-                            pyre_object::gc_roots::pin_root(args[0]);
-                            pyre_object::gc_roots::pin_root(args[1]);
-                            let hash = crate::builtins::try_hash_value(args[1])?;
-                            let set = pyre_object::gc_roots::shadow_stack_get(sp);
-                            let item = pyre_object::gc_roots::shadow_stack_get(sp + 1);
-                            pyre_object::w_set_add_hashed_checked(set, item, hash)
-                                .map_err(|_| crate::baseobjspace::take_pending_hash_error())?;
-                        }
+                    crate::type_methods::arity_exact(args, "set.add", 1)?;
+                    // `try_hash_value` may run a user `__hash__` that
+                    // allocates and triggers a moving minor collection;
+                    // root `self` and the element across it, then reload.
+                    // Its digest keys the store, so the element is hashed
+                    // once.
+                    unsafe {
+                        let _roots = pyre_object::gc_roots::push_roots();
+                        let sp = pyre_object::gc_roots::shadow_stack_len();
+                        pyre_object::gc_roots::pin_root(args[0]);
+                        pyre_object::gc_roots::pin_root(args[1]);
+                        let hash = crate::builtins::try_hash_value(args[1])?;
+                        let set = pyre_object::gc_roots::shadow_stack_get(sp);
+                        let item = pyre_object::gc_roots::shadow_stack_get(sp + 1);
+                        pyre_object::w_set_add_hashed_checked(set, item, hash)
+                            .map_err(|_| crate::baseobjspace::take_pending_hash_error())?;
                     }
                     Ok(pyre_object::w_none())
                 },
@@ -20072,9 +20072,8 @@ fn init_set_type(ns: PyObjectRef) {
                 "discard",
                 |args| {
                     crate::type_methods::require_set_receiver(args, "discard", true)?;
-                    if args.len() >= 2 {
-                        set_discard_from_set(args[0], args[1])?;
-                    }
+                    crate::type_methods::arity_exact(args, "set.discard", 1)?;
+                    set_discard_from_set(args[0], args[1])?;
                     Ok(pyre_object::w_none())
                 },
                 2,
@@ -20089,9 +20088,7 @@ fn init_set_type(ns: PyObjectRef) {
                 "remove",
                 |args| {
                     crate::type_methods::require_set_receiver(args, "remove", true)?;
-                    if args.len() < 2 {
-                        return Err(crate::PyError::type_error("remove() requires an argument"));
-                    }
+                    crate::type_methods::arity_exact(args, "set.remove", 1)?;
                     if !set_discard_from_set(args[0], args[1])? {
                         return Err(crate::PyError::key_error_with_key(args[1]));
                     }
@@ -20109,6 +20106,7 @@ fn init_set_type(ns: PyObjectRef) {
                 "pop",
                 |args| {
                     crate::type_methods::require_set_receiver(args, "pop", true)?;
+                    crate::type_methods::arity_no_args(args, "set.pop")?;
                     if let Some(item) = unsafe { pyre_object::w_set_popitem(args[0]) } {
                         return Ok(item);
                     }
@@ -20129,6 +20127,7 @@ fn init_set_type(ns: PyObjectRef) {
                 "clear",
                 |args| {
                     crate::type_methods::require_set_receiver(args, "clear", true)?;
+                    crate::type_methods::arity_no_args(args, "set.clear")?;
                     unsafe { pyre_object::w_set_clear(args[0]) };
                     Ok(pyre_object::w_none())
                 },

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -5336,6 +5336,7 @@ fn init_dict_type(ns: PyObjectRef) {
                         true,
                         "dict",
                         &pyre_object::DICT_TYPE,
+                        true,
                     )?;
                     let d = crate::type_methods::resolve_dict_backing(args[0]);
                     Ok(
@@ -5472,7 +5473,7 @@ fn dict_view_reversed(
     expected: &'static PyType,
     kind: pyre_object::dictmultiobject::DictViewKind,
 ) -> crate::PyResult {
-    let view = dict_iterator_receiver(args, "__reversed__", true, owner, expected)?;
+    let view = dict_iterator_receiver(args, "__reversed__", true, owner, expected, false)?;
     let dict = unsafe { pyre_object::dictmultiobject::w_dict_view_get_dict(view) };
     Ok(pyre_object::dictmultiobject::w_dict_view_reverse_iterator_new(dict, kind))
 }
@@ -7024,6 +7025,7 @@ fn init_mappingproxy_type(ns: PyObjectRef) {
                     true,
                     "mappingproxy",
                     &pyre_object::MAPPING_PROXY_TYPE,
+                    false,
                 )?;
                 let dict = crate::type_methods::resolve_dict_backing(args[0]);
                 Ok(
@@ -20746,6 +20748,7 @@ fn dict_iterator_receiver(
     method_descriptor: bool,
     owner: &str,
     expected: &'static PyType,
+    allow_subclass: bool,
 ) -> Result<PyObjectRef, crate::PyError> {
     let Some(&receiver) = args.first() else {
         let message = if method_descriptor {
@@ -20755,7 +20758,15 @@ fn dict_iterator_receiver(
         };
         return Err(crate::PyError::type_error(message));
     };
-    if !unsafe { pyre_object::py_type_check(receiver, expected) } {
+    // `dict` method descriptors bind to any dict subclass (an `OrderedDict`
+    // passed to `dict.__reversed__`); the concrete iterator typedefs are not
+    // subclassable, so they keep the exact-type check on the hot path.
+    let matches = if allow_subclass {
+        unsafe { crate::baseobjspace::isinstance_w(receiver, gettypeobject(expected)) }
+    } else {
+        unsafe { pyre_object::py_type_check(receiver, expected) }
+    };
+    if !matches {
         let received = crate::baseobjspace::object_functionstr_type_name(receiver);
         let message = if method_descriptor {
             format!(
@@ -20775,21 +20786,21 @@ fn dict_iterator_receiver(
 macro_rules! define_dict_iterator_type {
     ($init:ident, $self_fn:ident, $next_fn:ident, $len_fn:ident, $reduce_fn:ident, $owner:literal, $expected:path) => {
         fn $self_fn(args: &[PyObjectRef]) -> crate::PyResult {
-            dict_iterator_receiver(args, "__iter__", false, $owner, &$expected)
+            dict_iterator_receiver(args, "__iter__", false, $owner, &$expected, false)
         }
 
         fn $next_fn(args: &[PyObjectRef]) -> crate::PyResult {
-            dict_iterator_receiver(args, "__next__", false, $owner, &$expected)?;
+            dict_iterator_receiver(args, "__next__", false, $owner, &$expected, false)?;
             crate::baseobjspace::next(args[0])
         }
 
         fn $len_fn(args: &[PyObjectRef]) -> crate::PyResult {
-            dict_iterator_receiver(args, "__length_hint__", true, $owner, &$expected)?;
+            dict_iterator_receiver(args, "__length_hint__", true, $owner, &$expected, false)?;
             crate::baseobjspace::dict_view_iter_length_hint_method(args)
         }
 
         fn $reduce_fn(args: &[PyObjectRef]) -> crate::PyResult {
-            dict_iterator_receiver(args, "__reduce__", true, $owner, &$expected)?;
+            dict_iterator_receiver(args, "__reduce__", true, $owner, &$expected, false)?;
             crate::baseobjspace::dict_view_iter_reduce_method(args)
         }
 

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -424,29 +424,32 @@ pub fn init_typeobjects() {
         // semantics, so the per-typedef init body stays empty for
         // now — what matters is that `type(d.keys())` resolves to
         // the right W_TypeObject (otherwise `builtin_type` falls
-        // back to a str return).  Mark these non-base-acceptable to
-        // mirror PyPy's `acceptable_as_base_class = False`.
+        // back to a str return).  All three view typedefs carry
+        // `__new__ = interp2app(new_dict_*)`, so `acceptable_as_base_class`
+        // is True (`'__new__' in rawdict`): `class Sub(dict_keys)` is
+        // allowed, which `collections.OrderedDict`'s reversed-view
+        // classes rely on.
         // dict_keys / dict_items get the SetLikeDictView surface
         // per dictmultiobject.py:1802-1829 / 1773-1800; dict_values
         // stops at the common slots per dictmultiobject.py:1831-1840
         // (values views are intentionally NOT set-like).
         let dict_keys_type =
-            new_typeobject_with_base("dict_keys", init_dict_view_keys_type, object_type);
-        unsafe { pyre_object::w_type_set_acceptable_as_base_class(dict_keys_type, false) };
+            new_typeobject_with_base("dict_keys", init_dict_keys_type, object_type);
+        unsafe { pyre_object::w_type_set_acceptable_as_base_class(dict_keys_type, true) };
         reg.insert(
             &pyre_object::dictmultiobject::DICT_KEYS_TYPE as *const PyType as usize,
             dict_keys_type as usize,
         );
         let dict_values_type =
-            new_typeobject_with_base("dict_values", init_dict_view_values_type, object_type);
-        unsafe { pyre_object::w_type_set_acceptable_as_base_class(dict_values_type, false) };
+            new_typeobject_with_base("dict_values", init_dict_values_type_with_new, object_type);
+        unsafe { pyre_object::w_type_set_acceptable_as_base_class(dict_values_type, true) };
         reg.insert(
             &pyre_object::dictmultiobject::DICT_VALUES_TYPE as *const PyType as usize,
             dict_values_type as usize,
         );
         let dict_items_type =
-            new_typeobject_with_base("dict_items", init_dict_view_items_type, object_type);
-        unsafe { pyre_object::w_type_set_acceptable_as_base_class(dict_items_type, false) };
+            new_typeobject_with_base("dict_items", init_dict_items_type, object_type);
+        unsafe { pyre_object::w_type_set_acceptable_as_base_class(dict_items_type, true) };
         reg.insert(
             &pyre_object::dictmultiobject::DICT_ITEMS_TYPE as *const PyType as usize,
             dict_items_type as usize,
@@ -5580,6 +5583,132 @@ fn init_dict_view_common_slots(
             ),
         )
     };
+    // `_dict = interp_attrproperty_w('w_dict')` — the underlying dict.
+    // `collections.OrderedDict`'s reversed-view classes read `self._dict`.
+    unsafe {
+        pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
+            ns,
+            "_dict",
+            make_getset_property_named_doc(
+                make_builtin_function_with_arity(
+                    "_dict",
+                    |args| {
+                        let view = args[1];
+                        if view.is_null() {
+                            return Ok(pyre_object::w_none());
+                        }
+                        let dict =
+                            unsafe { pyre_object::dictmultiobject::w_dict_view_get_dict(view) };
+                        if dict.is_null() {
+                            return Ok(pyre_object::w_none());
+                        }
+                        Ok(dict)
+                    },
+                    2,
+                ),
+                pyre_object::PY_NULL,
+                pyre_object::PY_NULL,
+                "the dict this view refers to",
+                "_dict",
+            ),
+        )
+    };
+}
+
+/// Shared `__new__` for the three dict views — `new_dict_keys` /
+/// `new_dict_items` / `new_dict_values` (`dictmultiobject.py`).  Each
+/// takes the dict positionally and allocates a view over it; the
+/// Python-visible class is re-pointed to the caller's subtype so
+/// `class _OrderedDictKeysView(dict_keys)` instances see themselves.
+fn dict_view_descr_new(
+    args: &[PyObjectRef],
+    kind: pyre_object::dictmultiobject::DictViewKind,
+    static_tp: &'static pyre_object::PyType,
+    name: &str,
+) -> Result<PyObjectRef, crate::PyError> {
+    if args.len() < 2 {
+        return Err(crate::PyError::type_error(format!(
+            "{name}() missing required argument: the source dict"
+        )));
+    }
+    let cls = args[0];
+    // `interp_w(W_DictMultiObject, w_dict)` — accept a dict or any dict
+    // subclass (e.g. an `OrderedDict` passing itself to the view).
+    let dict_type = gettypeobject(&pyre_object::pyobject::DICT_TYPE);
+    if !unsafe { crate::baseobjspace::isinstance_w(args[1], dict_type) } {
+        return Err(crate::PyError::type_error(format!(
+            "{name}() argument must be a dict"
+        )));
+    }
+    // A dict subclass keeps its entries in a native backing dict; the view
+    // binds to that, exactly as `dict.keys()`/`values()`/`items()` do.
+    let w_dict = crate::type_methods::resolve_dict_backing(args[1]);
+    let view = pyre_object::dictmultiobject::w_dict_view_new(w_dict, kind);
+    // Re-point the Python-visible class to a subtype when one was passed
+    // (mirrors the `__new__` subtype fix-up applied to native builtins).
+    let static_obj = gettypeobject(static_tp);
+    if cls != static_obj && unsafe { pyre_object::is_type(cls) } {
+        unsafe { (*view).w_class = cls };
+    }
+    Ok(view)
+}
+
+fn dict_keys_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    dict_view_descr_new(
+        args,
+        pyre_object::dictmultiobject::DictViewKind::Keys,
+        &pyre_object::dictmultiobject::DICT_KEYS_TYPE,
+        "dict_keys",
+    )
+}
+
+fn dict_values_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    dict_view_descr_new(
+        args,
+        pyre_object::dictmultiobject::DictViewKind::Values,
+        &pyre_object::dictmultiobject::DICT_VALUES_TYPE,
+        "dict_values",
+    )
+}
+
+fn dict_items_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    dict_view_descr_new(
+        args,
+        pyre_object::dictmultiobject::DictViewKind::Items,
+        &pyre_object::dictmultiobject::DICT_ITEMS_TYPE,
+        "dict_items",
+    )
+}
+
+fn register_dict_view_new(
+    ns: PyObjectRef,
+    new_fn: fn(&[PyObjectRef]) -> Result<PyObjectRef, crate::PyError>,
+) {
+    unsafe {
+        pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
+            ns,
+            "__new__",
+            pyre_object::w_staticmethod_new(make_builtin_function("__new__", new_fn)),
+        )
+    };
+}
+
+/// `dict_keys` typedef body — set-like surface plus `__new__`.
+fn init_dict_keys_type(ns: PyObjectRef) {
+    init_dict_view_keys_type(ns);
+    register_dict_view_new(ns, dict_keys_descr_new);
+}
+
+/// `dict_items` typedef body — set-like surface plus `__new__`.
+fn init_dict_items_type(ns: PyObjectRef) {
+    init_dict_view_items_type(ns);
+    register_dict_view_new(ns, dict_items_descr_new);
+}
+
+/// `dict_values` typedef body — common slots plus `__new__`.
+fn init_dict_values_type_with_new(ns: PyObjectRef) {
+    init_dict_view_values_type(ns);
+    register_dict_view_new(ns, dict_values_descr_new);
 }
 
 /// `dictmultiobject.py` `W_DictViewKeysObject` /

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -5365,11 +5365,10 @@ fn init_dict_type(ns: PyObjectRef) {
                     // regardless of key type by dispatching through the
                     // strategy's `clear` (`celldict.py:162-164` for
                     // module dicts).  `w_dict_clear` does the dispatch.
-                    if !args.is_empty() {
-                        let d = crate::type_methods::resolve_dict_backing(args[0]);
-                        if !d.is_null() {
-                            unsafe { pyre_object::dictmultiobject::w_dict_clear(d) };
-                        }
+                    crate::type_methods::arity_no_args(args, "dict.clear")?;
+                    let d = crate::type_methods::resolve_dict_backing(args[0]);
+                    if !d.is_null() {
+                        unsafe { pyre_object::dictmultiobject::w_dict_clear(d) };
                     }
                     Ok(pyre_object::w_none())
                 },
@@ -17836,7 +17835,7 @@ fn bytearray_method_imul(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyE
 
 /// `bytearrayobject.py:descr_append` — append one byte in place.
 fn bytearray_method_append(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    crate::type_methods::arity_at_least(args, "append", 1)?;
+    crate::type_methods::arity_exact(args, "bytearray.append", 1)?;
     unsafe { crate::builtins::bytearray_check_exports(args[0])? };
     let b = bytearray_byte_arg(args[1])?;
     unsafe { pyre_object::bytearrayobject::w_bytearray_vec_mut(args[0]).push(b) };
@@ -17962,6 +17961,7 @@ fn bytearray_method_pop(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyEr
 /// `bytearrayobject.py:descr_reverse` — reverse the bytes in place.
 fn bytearray_method_reverse(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     crate::type_methods::require_receiver(args, "reverse")?;
+    crate::type_methods::arity_no_args(args, "bytearray.reverse")?;
     unsafe { pyre_object::bytearrayobject::w_bytearray_vec_mut(args[0]).reverse() };
     Ok(pyre_object::w_none())
 }
@@ -17969,6 +17969,7 @@ fn bytearray_method_reverse(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::
 /// `bytearrayobject.py:descr_clear` — empty the bytearray in place.
 fn bytearray_method_clear(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     crate::type_methods::require_receiver(args, "clear")?;
+    crate::type_methods::arity_no_args(args, "bytearray.clear")?;
     unsafe {
         crate::builtins::bytearray_check_exports(args[0])?;
         pyre_object::bytearrayobject::w_bytearray_vec_mut(args[0]).clear();
@@ -17980,6 +17981,7 @@ fn bytearray_method_clear(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::Py
 /// same bytes.
 fn bytearray_method_copy(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     crate::type_methods::require_receiver(args, "copy")?;
+    crate::type_methods::arity_no_args(args, "bytearray.copy")?;
     let data = unsafe { pyre_object::bytesobject::bytes_like_data(args[0]) };
     Ok(pyre_object::bytearrayobject::w_bytearray_from_bytes(data))
 }
@@ -18892,6 +18894,12 @@ fn setlike_descr_isdisjoint(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::
 }
 
 fn setlike_descr_copy(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    let name = if unsafe { pyre_object::is_frozenset(args[0]) } {
+        "frozenset.copy"
+    } else {
+        "set.copy"
+    };
+    crate::type_methods::arity_no_args(args, name)?;
     if unsafe { pyre_object::is_exact_type(args[0], &pyre_object::setobject::FROZENSET_TYPE) } {
         return Ok(args[0]);
     }


### PR DESCRIPTION
A batch of interpreter-correctness fixes stacked on top of the merged
PR #614, each verified against `python3` 3.14 and `pypy3` and gated on
both JIT backends (dynasm 223/223, cranelift 223/223).

## `collections.OrderedDict` as a real type
Previously `_collections.OrderedDict` was a plain alias to the `dict`
type object, so `type(OrderedDict()) is dict`. Ported PyPy's
`app_odict.py` verbatim and registered it as an appleveldef (matching
PyPy's `'OrderedDict': 'app_odict.OrderedDict'`). This required:

- Making `dict_keys` / `dict_values` / `dict_items` acceptable as base
  classes with a `__new__` and a `_dict` getset, mirroring their PyPy
  typedefs (pyre had dropped this — the view `__new__` binds to a dict
  subclass's native backing via `resolve_dict_backing`).
- Adding `reversed_dict`, `move_to_end`, and `objects_in_repr` to
  `__pypy__` (the dict-order primitives `app_odict` imports), plus
  `identity_dict.__delitem__`.

repr, move_to_end (both directions), popitem, `reversed()` over the
dict and its views, order-sensitive equality, copy, pickle round-trip,
subclassing, and self-referential repr all match the PyPy oracle.

## Missing stdlib functions / methods
- `itertools.groupby` (was a `None`-returning stub), plus
  `combinations_with_replacement` and `tee` (both absent).
- `operator.call` / `concat` / `indexOf` / `inv` / `is_none` /
  `is_not_none` (6 functions absent; adding them also re-activates the
  `__call__` / `__inv__` / `__concat__` aliases).
- `functools.reduce` (was a `not implemented` stub).
- `collections.deque.insert` (only gap in `deque`'s method surface).

## Argument-count enforcement and other fixes
- Reject extra positional arguments on no-argument methods, on
  fixed-arity `set`/`dict` methods, and on `dict.get`/`setdefault`;
  validate the `__reduce_ex__` protocol argument.
- `tuple.index`/`count` now honor `start`/`stop` and compare with rich
  equality instead of identity + an int shortcut.
- `getindex_w`'s generic fallback now raises the standard
  "'X' object cannot be interpreted as an integer" instead of an
  `int()`-specific message that leaked into array/deque/`slice.indices`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
