### PR TITLE
jit: nsvable multi-frame resume + callee-locals shadow + exc-edge bridge + portal-runner descr (gated); gc: register deque iterators; vstack NONE-hole

### DIFF
--- a/.github/workflows/pyre-ci.yml
+++ b/.github/workflows/pyre-ci.yml
@@ -387,14 +387,24 @@ jobs:
       # Diff each benchmark's [jit-stats] counters against the committed
       # pyre/bench/<name>.<backend>.jitstats baselines. The counters are decided
       # by the platform-independent tracer, so a diff here means a change moved
-      # what the JIT compiles. Informational: the baselines were recorded on
-      # macOS aarch64 and cross-runner/cross-platform determinism of the
-      # counters is not yet confirmed in CI, so this must not gate main until
-      # the summaries stay clean across real PRs. The .out/.time baselines are
-      # not committed, so their snapshot checks report "missing" and only the
-      # jit-stats diff is exercised. Runs on Linux only (one OS is enough for a
-      # platform-independent signal). Use the runner's standard grep instead
-      # of assuming an optional ripgrep installation.
+      # what the JIT compiles.
+      #
+      # The sign-stable badness subset (loops_aborted, internal_compile_panics)
+      # is already HARD-gated by the "Run pyre/check.py" step above: check.py's
+      # regression floor fails the default run when either counter rises above
+      # its committed 0, so an inline-abort/compile-panic regression reddens CI
+      # immediately without this step. That subset is flake-free because the
+      # healthy value is 0 on every platform.
+      #
+      # This step stays informational for the COUNT-VALUED fields
+      # (guard_failures, loops_compiled, bridges_compiled): the baselines were
+      # recorded on macOS aarch64 and cross-runner/cross-platform determinism of
+      # those absolute counts is not yet confirmed in CI, so they must not gate
+      # main until the summaries stay clean across real PRs. The .out/.time
+      # baselines are not committed, so their snapshot checks report "missing"
+      # and only the jit-stats diff is exercised. Runs on Linux only (one OS is
+      # enough for a platform-independent signal). Use the runner's standard
+      # grep instead of assuming an optional ripgrep installation.
       if: runner.os == 'Linux'
       continue-on-error: true
       env:

--- a/majit/majit-metainterp/src/blackhole.rs
+++ b/majit/majit-metainterp/src/blackhole.rs
@@ -146,9 +146,12 @@ pub struct BhJitDriverSd {
     /// warmspot.py:449 `jd.result_type` projected to the blackhole
     /// dispatch char ('v','i','r','f') via `BhReturnType`.
     pub result_type: BhReturnType,
-    /// warmspot.py:1010-1013 `jd.portal_runner_ptr` — full portal arg
-    /// ABI: `fn(all_i, all_r, all_f) -> i64`.
-    pub portal_runner_ptr: Option<fn(&[i64], &[i64], &[i64]) -> i64>,
+    /// warmspot.py:1010-1013 `jd.portal_runner_ptr` — the portal runner as a
+    /// raw C function matching `mainjitcode_calldescr`. `get_portal_runner`
+    /// hands its address to `bh_call_r`, which invokes it via the calldescr
+    /// (`"iirrr"`: `next_instr:i, is_being_profiled:i, pycode:r, frame:r,
+    /// ec:r`), so the pointee must take those five scalars by the C ABI.
+    pub portal_runner_ptr: Option<extern "C" fn(i64, i64, i64, i64, i64) -> i64>,
     /// `jitdriver_sd.mainjitcode.calldescr` — CallDescr of the portal
     /// function returned by `get_portal_runner` for `bh_call_*`.
     pub mainjitcode_calldescr: BhCallDescr,

--- a/majit/majit-metainterp/src/history.rs
+++ b/majit/majit-metainterp/src/history.rs
@@ -2352,6 +2352,40 @@ impl TraceCtx {
         self.set_last_guard_resume_position(snapshot_id);
     }
 
+    /// Like [`capture_snapshot_for_last_guard_multi_frame_with_vable_vref`] but
+    /// stamps the resume position on the most-recent *guard* op rather than the
+    /// last recorded op — the multi-frame analog of
+    /// [`capture_snapshot_for_last_guard_op_with_vable_vref`].  Used when a
+    /// guard emitted inside a helper (the `_nonstandard_virtualizable` PTR_EQ
+    /// promote) records further non-guard ops (`emit_force_virtualizable`'s
+    /// GETFIELD_GC / PTR_NE / COND_CALL) before the caller captures, yet the
+    /// paused caller chain is available for a full `Snapshot.frames`.
+    pub fn capture_snapshot_for_last_guard_op_multi_frame_with_vable_vref(
+        &mut self,
+        frames: &[(u32, u32, &[OpRef])],
+        vable_boxes: &[crate::recorder::SnapshotTagged],
+        vref_boxes: &[crate::recorder::SnapshotTagged],
+    ) {
+        let recorder_frames: Vec<crate::recorder::SnapshotFrame> = frames
+            .iter()
+            .map(|(jitcode_index, pc, boxes)| {
+                // The pc word is a raw JitCode offset.
+                let encoded = self.encode_snapshot_boxes(boxes);
+                crate::recorder::SnapshotFrame {
+                    jitcode_index: *jitcode_index,
+                    pc: *pc,
+                    boxes: encoded,
+                }
+            })
+            .collect();
+        let snapshot_id = self.capture_resumedata(crate::recorder::Snapshot {
+            frames: recorder_frames,
+            vable_boxes: vable_boxes.to_vec(),
+            vref_boxes: vref_boxes.to_vec(),
+        });
+        self.set_last_guard_op_resume_position(snapshot_id);
+    }
+
     fn encode_snapshot_boxes(
         &self,
         active_boxes: &[OpRef],

--- a/pyre/bench/fannkuch.wasm.jitstats
+++ b/pyre/bench/fannkuch.wasm.jitstats
@@ -1,0 +1,2 @@
+internal_compile_panics=0
+loops_aborted=0

--- a/pyre/bench/fib_loop.wasm.jitstats
+++ b/pyre/bench/fib_loop.wasm.jitstats
@@ -1,0 +1,2 @@
+internal_compile_panics=0
+loops_aborted=0

--- a/pyre/bench/fib_recursive.wasm.jitstats
+++ b/pyre/bench/fib_recursive.wasm.jitstats
@@ -1,0 +1,2 @@
+internal_compile_panics=0
+loops_aborted=0

--- a/pyre/bench/float_loop.wasm.jitstats
+++ b/pyre/bench/float_loop.wasm.jitstats
@@ -1,0 +1,2 @@
+internal_compile_panics=0
+loops_aborted=0

--- a/pyre/bench/inline_helper.wasm.jitstats
+++ b/pyre/bench/inline_helper.wasm.jitstats
@@ -1,0 +1,2 @@
+internal_compile_panics=0
+loops_aborted=0

--- a/pyre/bench/int_loop.wasm.jitstats
+++ b/pyre/bench/int_loop.wasm.jitstats
@@ -1,0 +1,2 @@
+internal_compile_panics=0
+loops_aborted=0

--- a/pyre/bench/nbody.wasm.jitstats
+++ b/pyre/bench/nbody.wasm.jitstats
@@ -1,0 +1,2 @@
+internal_compile_panics=0
+loops_aborted=0

--- a/pyre/bench/nested_loop.wasm.jitstats
+++ b/pyre/bench/nested_loop.wasm.jitstats
@@ -1,0 +1,2 @@
+internal_compile_panics=0
+loops_aborted=0

--- a/pyre/bench/raise_catch_loop.wasm.jitstats
+++ b/pyre/bench/raise_catch_loop.wasm.jitstats
@@ -1,0 +1,2 @@
+internal_compile_panics=0
+loops_aborted=0

--- a/pyre/bench/spectral_norm.wasm.jitstats
+++ b/pyre/bench/spectral_norm.wasm.jitstats
@@ -1,0 +1,2 @@
+internal_compile_panics=0
+loops_aborted=0

--- a/pyre/check.py
+++ b/pyre/check.py
@@ -1685,7 +1685,7 @@ def main():
         chk.run_bench("nested_loop",    f"{B}/nested_loop.py",          5,       None,    2,       None,    3)
         chk.run_bench("raise_catch",    f"{B}/raise_catch_loop.py",     5,       None,    1.5,     None,    2.5)
         chk.run_bench("spectral_norm",  f"{B}/spectral_norm.py",        5,       2,       7,       2,       7)
-        chk.run_bench("nbody",          f"{B}/nbody.py",               10,       3,       None,    3,       None,    wasm_float_tol=True)
+        chk.run_bench("nbody",          f"{B}/nbody.py",               10,       1,       5,       1,       5,    wasm_float_tol=True)
         chk.run_bench("fannkuch",       f"{B}/fannkuch.py",            30,       1,       5,       2,       None)
         # Skipped on wasm: the guard times calls with `time.perf_counter()`, and
         # the wasm guest has no `time` module (import fails before any output),

--- a/pyre/check.py
+++ b/pyre/check.py
@@ -397,6 +397,43 @@ def _jit_stats_diff(saved, current, limit=6):
     return ", ".join(shown)
 
 
+# Sign-stable jit-stats counters: a nonzero value always means something went
+# wrong (a trace aborted, or an internal compile bug fell back to the
+# interpreter), never a tuning choice. They read 0 in every healthy baseline on
+# every platform, so a rise above baseline is a regression the regression floor
+# gates on unconditionally. The count-valued fields (guard_failures,
+# loops_compiled, bridges_compiled) are deliberately excluded: their absolute
+# value is not yet confirmed stable across runners, so they stay informational.
+JITSTATS_BADNESS_FIELDS = ("loops_aborted", "internal_compile_panics")
+
+
+def _jit_stats_regression_floor(saved, current):
+    """Return a failure reason if any badness counter rose above its committed
+    baseline, else "". A rise means the JIT started aborting traces or hitting
+    internal compile panics it did not before — a defect on any platform. A
+    counter that falls (an improvement) or holds never gates, and a field
+    missing from either side is read as 0 so it cannot fire spuriously."""
+    def parse(snapshot):
+        if snapshot is None:
+            return {}
+        return dict(line.split("=", 1) for line in snapshot.splitlines())
+
+    old_fields = parse(saved)
+    new_fields = parse(current)
+    regressions = []
+    for field in JITSTATS_BADNESS_FIELDS:
+        try:
+            base = int(old_fields.get(field, 0))
+            cur = int(new_fields.get(field, 0))
+        except ValueError:
+            continue
+        if cur > base:
+            regressions.append(f"{field} {base} -> {cur}")
+    if regressions:
+        return "jit-stats regression: " + ", ".join(regressions)
+    return ""
+
+
 def scaled_timeout(base, scale):
     v = base * scale
     return int(v) if v == int(v) else float(f"{v:.3f}".rstrip("0").rstrip("."))
@@ -701,6 +738,27 @@ class Check:
         time_path = self._snapshot_path(backend, name, "time")
         jitstats_path = self._jitstats_baseline_path(backend, script)
         jitstats = _jit_stats_snapshot(stderr)
+
+        # Regression floor — enforced on EVERY run, so a structural JIT
+        # regression reddens the default `pyre/check.py` (locally, and in the
+        # bare CI invocation) the instant it lands, with no --snapshot-diff
+        # needed. Only the sign-stable badness counters gate here, so this stays
+        # flake-free where the full-exact jit-stats diff (below, opt-in) cannot:
+        # healthy baselines carry 0 for both on every platform, so a trace that
+        # starts aborting or panicking is a real defect regardless of runner.
+        # This catches the inline-abort class (e.g. an inlined-callee LOAD_GLOBAL
+        # fold that stops resolving: loops_aborted 0 -> 5). Record mode is
+        # writing a fresh baseline, so it is exempt.
+        if (
+            self.args.snapshot_mode != "record"
+            and jitstats is not None
+            and jitstats_path.exists()
+        ):
+            floor = _jit_stats_regression_floor(
+                jitstats_path.read_text(encoding="utf-8"), jitstats
+            )
+            if floor:
+                return "fail", floor
 
         if self.args.snapshot_mode == "record":
             out_path.parent.mkdir(parents=True, exist_ok=True)

--- a/pyre/gate-triage.md
+++ b/pyre/gate-triage.md
@@ -6,6 +6,7 @@ read-expression at every source site (four census passes). Polarity rule:
 `is_some()`/`=="1"`/`.unwrap_or(false)` → default **OFF**; `is_none()` /
 `!= Ok("0")` / `.unwrap_or(true)` → default **ON**; a parse of
 number/path/list/mode → **VALUE** (config, not a boolean gate).
+Re-audited 2026-07-18 on branch `nbody`: §1c added; 10 rows retired.
 
 The charter (§3.6, A7) says a gate is a staging area, not a home: each live
 default-ON experiment gate is kept only until its epic closes, then its OFF
@@ -16,10 +17,12 @@ to retire and when.
 
 The raw `rg 'PYRE_[A-Z0-9_]+'` count (~119) overstates the debt. **~20 of the
 matches are not env gates at all** (Rust consts, macro-generated identifiers,
-runtime symbols, or comment-only dead references). Real live env vars ≈ 99, of
-which ~33 are default-ON experiment gates. Of those 33, the **wasm trio** and
-the **#171 pair** were cleanly settled (epic closed / merged) and are retired
-this pass; the rest are load-bearing kill switches for open reworks.
+runtime symbols, or comment-only dead references). The 2026-07-05 audit found
+that the **wasm trio** and the **#171 pair** were cleanly settled (epic closed
+/ merged) and retired in that pass. The 2026-07-18 re-audit found no new live
+default-ON gate that is safely retirable right now; §1c is book-keeping for
+rows whose source readers were already deleted by closed epics after the
+original audit.
 
 ## §1 — Retired this pass (5)
 
@@ -64,26 +67,31 @@ opt-in dead code.
 **Deferred, not retired** (active on other branches; touching them on pc-map
 would only manufacture conflicts):
 
-- **P2 quintet** (`PYRE_P2_DRAIN`, `_FRAMESTACK`, `_COMPILE`, `_FS_COMPILE`,
-  `_AUTHORITATIVE`) — one dependency tree, owned by the #215 session on
-  `fib_recursive` (PR#374). A full scaffold deletion (`765b24e3ba`, −1931 L)
-  was authored there and then deliberately reverted + reset away: the carrier
-  turned out load-bearing (without it a `frames.len()>1` resume compiles a
-  degenerate single-frame bridge — wrong values/SEGV), and `8731115130` now
-  installs it unconditionally, leaving the gates as driver selectors only.
-  Their fate belongs to that branch.
-- **PYRE_SAME_GREENKEY** — the gated path is broken by construction (its
-  ConstInt filter over `green_boxes` InputArg placeholders is always empty, so
-  it declines every close and hangs); the real fix (close compares ALL greens
-  vs `header_greens`, gate dropped) already exists on the local `aheui` branch
-  (`019a494e13`). Delegated there untouched.
+- **PYRE_P2_DRAIN** — sole live P2 gate left from the former P2 quintet.
+  It remains keep-WIP while epic #343 is open; the other four P2 gates retired
+  when the compile/framestack legs went production-default in PR#607 / PR#374.
 
-**Judged KEEP** (genuine WIP parity ports): `PYRE_SINGLE_PASS` +
-`PYRE_AUTHORITATIVE` (two stages of the gh#344 single-executor epic;
-rework.md F2 "must finish"), `PYRE_INNER_CLOSE` (the missing half of
-`pyjitpl.py:3018-3060 reached_loop_header`; implied ON by single-pass, and
-`PYRE_NO_INNER_CLOSE` stays with it), `PYRE_FBW_VABLE_SCALAR_CA` (S0 seam of
-the vable-owner rework toward `direct_assembler_call` scalar args).
+**Judged KEEP** (genuine WIP parity port): `PYRE_FBW_VABLE_SCALAR_CA` (S0 seam
+of the vable-owner rework toward `direct_assembler_call` scalar args).
+
+## §1c — Retired since the 2026-07-05 audit (10): reader already deleted by a closed epic
+
+Book-keeping only: these OFF-paths were deleted in source by the cited epics
+after the 2026-07-05 audit; this pass removes their stale registry rows. The
+2026-07-18 re-audit verified 0 Rust source read sites for each gate.
+
+| gate | reader deleted by | note |
+|---|---|---|
+| PYRE_57_INLINE_NEXT | PR#387 (`e18ec90cac1`); follow-up `c6cfcb758c2` retired the kill-switch | stale §4 row removed |
+| PYRE_SINGLE_PASS | PR#427 (`57849b62664`) | stale §1b keep mention and §5 list entry removed |
+| PYRE_AUTHORITATIVE | PR#427 (`57849b62664`) + PR#415 (`7e3db1cc490`) | stale §1b keep mention and §5 list entry removed; `PYRE_PROBE_AUTHORITATIVE` is separate and remains live |
+| PYRE_INNER_CLOSE | PR#427 (`57849b62664`) | stale §1b keep mention and §5 list entry removed |
+| PYRE_NO_INNER_CLOSE | PR#427 (`57849b62664`); issue #152 closed 2026-07-13 | stale §1b keep mention, §4 row, and §5 list entry removed |
+| PYRE_P2_COMPILE | PR#607 (`e1c43d3ff08`); follow-up `ca2640e797b` removed the gate | stale §5 deferred entry removed |
+| PYRE_P2_FRAMESTACK | PR#374 (`9a97c47f6e9`) | stale §5 deferred entry removed |
+| PYRE_P2_FS_COMPILE | PR#374 (`9a97c47f6e9`) | stale §5 deferred entry removed |
+| PYRE_P2_AUTHORITATIVE | reader gone; attribution #374 per re-audit | stale §5 deferred entry removed |
+| PYRE_SAME_GREENKEY | PR#390 (`802b79ff8db`); follow-up `111bdb4eeb8` dropped the gate | stale §1b deferred mention and §5 list entry removed |
 
 ## §2 — Not gates (11): Rust identifiers, not env vars
 
@@ -134,9 +142,7 @@ OFF path is a needed safety net. Retire at the listed trigger (A7).
 | PYRE_ORIGINAL_BOXES | greens++reds original_boxes index shape | box-identity #202 / resume F1 |
 | PYRE_MIR_FRAMESTATE | framestate-threaded MIR lowering | MIR front-end #176/#181/#346 |
 | PYRE_GC_ITEMSBLOCK, PYRE_GC_PREBUILT_REMEMBER, PYRE_GC_INTERP_COLLECT | GC-managed items / prebuilt minor-skip / interp collect A/B | WS3 / #355 / F3 GC rework |
-| PYRE_57_INLINE_NEXT | FOR_ITER inline-next fastpath | #57 / task#50 (has admitted unsoundness) |
 | PYRE_CL_NO_CLOSING_JUMP | cranelift attached-loop closing jump | #245 cranelift perf (explicit rollback hatch) |
-| PYRE_NO_INNER_CLOSE | cross-loop-cut inner-close override | #152 cross-loop residency |
 
 `PYRE_GC_INTERP` is default-ON on wasm32 only (`unwrap_or(cfg!(wasm32))`),
 default-OFF on native — not a clean removal candidate.
@@ -156,12 +162,10 @@ Kept as-is; listed for completeness.
   `_GIN`, `_INLINE_RECOG`, `PYRE_WASM_DUMP_ALL_TRACES`, `_DUMP_BAD_TRACE`,
   `_EXEC_TRACE`, `_JIT_STATS`, `PYRE_INTERP_RETURN_LOG`, `PYRE_NBODY_DEBUG`,
   `PYRE_DEBUG_CALL`, `PYRE_DEBUG_CLASS`.
-- **Default-OFF experiments (10 remaining)** — triaged in §1b (4 retired, 4
-  kept as WIP parity ports, 6 deferred to their owning branches):
-  `PYRE_FBW_VABLE_SCALAR_CA`, `PYRE_SINGLE_PASS`, `PYRE_AUTHORITATIVE`,
-  `PYRE_INNER_CLOSE` (keep); `PYRE_P2_AUTHORITATIVE`, `_COMPILE`, `_DRAIN`,
-  `_FRAMESTACK`, `_FS_COMPILE` (fib_recursive/PR#374), `PYRE_SAME_GREENKEY`
-  (aheui).
+- **Default-OFF experiments (2 remaining)** — triaged in §1b/§1c (4 retired
+  in the 2026-07-05 pass, 8 retired since then, 1 kept as a WIP parity port,
+  1 deferred to its owning epic):
+  `PYRE_FBW_VABLE_SCALAR_CA` (keep); `PYRE_P2_DRAIN` (epic #343).
 - **Config / value / master switches (~18)** — tuning, paths, modes; keep:
   `PYRE_FBW_REC_UNROLL`, `PYRE_WALKER_STORE_SUBSCR_FNADDR`,
   `PYRE_MIR_FRONTEND_LLBC`, `PYRE_WASM_ENGINE`, `_FUEL`, `_MODULE`, `_NO_CACHE`,
@@ -174,11 +178,11 @@ Kept as-is; listed for completeness.
 
 | bucket | count |
 |---|---|
-| retired (§1 default-ON pass + §1b default-OFF pass) | 5 + 4 |
+| retired (§1 default-ON pass + §1b default-OFF pass + §1c re-audit book-keeping) | 5 + 4 + 10 |
 | not gates (identifiers) | 11 |
 | dead (no read site) | 9 |
-| live default-ON, kept until epic closes | ~28 |
+| live default-ON, kept until epic closes | ~26 |
 | diagnostics (OFF) | ~34 |
-| default-OFF experiments (4 keep + 6 deferred) | 10 |
+| default-OFF experiments (1 keep + 1 deferred) | 2 |
 | config / value / master | ~18 |
 | test harness | 1 |

--- a/pyre/pyre-interpreter/src/pyopcode.rs
+++ b/pyre/pyre-interpreter/src/pyopcode.rs
@@ -152,6 +152,43 @@ pub fn decode_instruction_at(code: &CodeObject, pc: usize) -> Option<(Instructio
     Some(arg_state.get(code_unit))
 }
 
+/// Whether `code` contains a `FOR_ITER` opcode — i.e. it is loop-bearing
+/// through a `for` loop.  Used to gate the nested-inline decline: a residual
+/// reached inside a loop-bearing inline callee risks the FOR_ITER-exempt
+/// double-advance on a refused Option-C delivery.
+pub fn code_has_for_iter(code: &CodeObject) -> bool {
+    let mut arg_state = OpArgState::default();
+    for unit in code.instructions.iter().copied() {
+        let (instruction, _) = arg_state.get(unit);
+        if matches!(instruction, Instruction::ForIter { .. }) {
+            return true;
+        }
+    }
+    false
+}
+
+/// Whether `code` is directly self-recursive: it references its own name via
+/// `LOAD_GLOBAL <own name>`, the shape a module-level function calling itself
+/// compiles to.  A hot self-recursion forms a `CALL_ASSEMBLER` bridge, which
+/// the nested-inline decline refuses (its moving-nursery callee frame cannot
+/// survive the residual trampoline).  Misses indirect/closure recursion (a
+/// conservative false-negative), never a false positive beyond a function that
+/// names itself without calling (which only over-declines, still correct).
+pub fn code_is_self_recursive(code: &CodeObject) -> bool {
+    let own_name = code.obj_name.as_str();
+    let mut arg_state = OpArgState::default();
+    for unit in code.instructions.iter().copied() {
+        let (instruction, op_arg) = arg_state.get(unit);
+        if let Instruction::LoadGlobal { namei } = instruction {
+            let name_idx = (namei.get(op_arg) as usize) >> 1;
+            if code.names.get(name_idx).map(|n| n.as_ref()) == Some(own_name) {
+                return true;
+            }
+        }
+    }
+    false
+}
+
 /// pypy/interpreter/pyopcode.py:187-193 dispatch_bytecode parity.
 ///
 /// Returns the semantic opcode to execute for a dispatch step starting at

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/bridge_subwalk.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/bridge_subwalk.rs
@@ -186,6 +186,50 @@ pub fn dispatch_via_miframe<Sym: WalkSym>(
         ConcreteValue::Ref(sym.last_exc_value())
     };
 
+    // Exception-edge bridge routing (`PYRE_EXC_EDGE_BRIDGE`): an exception-guard
+    // bridge with a standing exception resumes at the no-exception fallthrough
+    // `-live-`, NOT the `except` handler.  Mirror the blackhole
+    // `handle_exception_in_frame` backward case: route the walk entry to the
+    // in-frame catch target so the handler body (`except KeyError: return -1`)
+    // is recorded as the bridge instead of the NULL raised-call fallthrough.
+    // `call_jit.rs trace_and_compile_from_bridge` only lets a bridge walk begin
+    // with this precondition holding when it has already ROUTED the exc-edge
+    // (published the standing exception into `BH_LAST_EXC_VALUE` and declined to
+    // hand the guard to the blackhole).  So whenever the precondition holds the
+    // walk MUST resume at an `except` handler — falling through to the
+    // no-exception continuation would record the return of the NULL raised-call
+    // result (`Finish(NULL)` → "call failed").
+    let exc_edge_precondition = exc_edge_bridge_enabled()
+        && trace_ctx.is_bridge_trace
+        && trace_ctx.bridge_source_is_exception_guard()
+        && !sym.last_exc_box.is_none()
+        && !sym.last_exc_value.is_null();
+    let exc_edge_catch_target = if exc_edge_precondition {
+        find_catch_before_resume_live(jitcode_code, position)
+            // Only route when the handler rejoins this frame's loop; a handler
+            // that returns out of the frame (called function's `try/except:
+            // return`, compiled as its own function trace) needs cross-frame
+            // resume pyre does not yet reconstruct — decline it to the blackhole.
+            .filter(|&catch_target| exc_handler_rejoins_loop(jitcode_code, catch_target))
+    } else {
+        None
+    };
+    if exc_edge_precondition && exc_edge_catch_target.is_none() {
+        // Routed by `call_jit` but the handler is unroutable here (returns out of
+        // the frame).  Abort BEFORE any recording so the guard failure resumes
+        // via the blackhole (correct caught-exception + callee-return handling),
+        // exactly as when the flag is off.
+        return Err(DispatchError::ExcEdgeCrossFrameReturnUnsupported { pc: position });
+    }
+    let exc_edge_concrete = sym.last_exc_value;
+    // typeptr at offset 0 (`_store_exception` invariant): the expected class the
+    // bridge-entry GUARD_EXCEPTION checks the restored pending exception against.
+    let exc_edge_class = if exc_edge_catch_target.is_some() && !exc_edge_concrete.is_null() {
+        unsafe { *(exc_edge_concrete as *const i64) }
+    } else {
+        0
+    };
+
     let result = {
         let mut wc = WalkContext {
             callee_shadow: None,
@@ -264,8 +308,66 @@ pub fn dispatch_via_miframe<Sym: WalkSym>(
         // entry-boundary reconcile of the not-yet-executed first opcode).
         // Pure side-data: the snapshot read stays LEGACY until a later slice
         // makes it authoritative.
-        seed_vstack_mirror(&mut wc, sym, position);
-        let outcome = walk(jitcode_code, position, &mut wc);
+        // Exception-edge bridge: enter at the in-frame `except` handler target
+        // instead of the no-exception fallthrough.  `vstack_enter_exception_
+        // handler` re-seeds the operand-stack mirror at handler-entry depth and
+        // places the caught exception box on the new TOS (the same reconstruction
+        // the mid-walk SubRaise catch routing uses at handler entry); `wc.
+        // last_exc_value` is already the standing exception box, so the handler's
+        // `last_exc_value/>r` reads it.  On the normal path, seed the mirror at
+        // the first-walked pc as before.
+        let walk_position = if let Some(catch_target) = exc_edge_catch_target {
+            // RPython `pyjitpl.py:3125-3173` exception-guard resumption, emitted
+            // at the bridge-entry frame state so the GUARD_EXCEPTION captures a
+            // fresh resume snapshot (the call-site prologue cannot — no frame is
+            // reconstructed there):
+            //   SAVE_EXC_CLASS / SAVE_EXCEPTION (no-arg record0 — read the
+            //   pending exc cell at runtime) → RESTORE_EXCEPTION → GUARD_EXCEPTION
+            //   (`handle_possible_exception`; deopts on a class mismatch, and
+            //   consumes/clears the pending exception cell on match).
+            let class_op = wc.trace_ctx.save_exc_class();
+            let value_op = wc.trace_ctx.save_exception();
+            wc.trace_ctx.restore_exception(class_op, value_op);
+            // `RefFrontendOp(pos, gcref)` parity (`history.py:803`): SAVE_EXCEPTION
+            // returns `exc_value_box`, whose `getref()` is the concrete restored
+            // exception pointer at trace-recording time (`pyjitpl.py:3163
+            // execute_ll_raised`).  Stamp that concrete onto `value_op` so the box
+            // stays symbolic (emits at runtime, class protected by the
+            // GUARD_EXCEPTION below) yet carries a trace-time value: the handler's
+            // `CHECK_EXC_MATCH` residual (`ll_issubclass(exc, KeyError)`) is then
+            // concrete-executable and folds, instead of declining to a symbolic
+            // result whose downstream `POP_JUMP_IF_FALSE` has no branch direction
+            // (the residual-call executor keys concreteness on `box_value`, which
+            // reads the frontend value slot — not the register `reg_shadow`).
+            wc.trace_ctx.set_opref_concrete(
+                value_op,
+                majit_ir::Value::Ref(majit_ir::GcRef(exc_edge_concrete as usize)),
+            );
+            let exc_class_const = wc.trace_ctx.const_int(exc_edge_class);
+            wc.trace_ctx
+                .record_guard(OpCode::GuardException, &[exc_class_const], 0);
+            walker_capture_snapshot_for_last_guard(&mut wc, position)?;
+            // `execute_ll_raised` parity: the standing exception the handler
+            // reads (`last_exc_value/>r`) is the SAVE_EXCEPTION box — the
+            // runtime-restored value, NOT a baked constant — so a value-using
+            // handler (`except E as e`) sees the actual exception.
+            wc.last_exc_value = Some(value_op);
+            wc.last_exc_value_concrete = ConcreteValue::Ref(exc_edge_concrete);
+            wc.fbw_mode.class_of_last_exc_is_const = true;
+            // Reconstruct the handler-entry operand stack + push the exc box on
+            // the new TOS (mirrors the mid-walk SubRaise catch routing).
+            vstack_enter_exception_handler(&mut wc, catch_target, value_op);
+            // The exception is now caught by this frame's handler; drain the
+            // standing residual-call exception flag so a later trace attempt's
+            // `seed_standing_exception_for_walk` does not re-pick this
+            // already-caught exception (mirrors `blackhole.rs route_to_catch`).
+            majit_metainterp::blackhole::BH_LAST_EXC_VALUE.with(|c| c.set(0));
+            catch_target
+        } else {
+            seed_vstack_mirror(&mut wc, sym, position);
+            position
+        };
+        let outcome = walk(jitcode_code, walk_position, &mut wc);
         // Read final last_exc_value before wc drops so the borrow
         // checker can release sym for the writeback below.
         let final_last_exc = wc.last_exc_value;

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/bridge_subwalk.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/bridge_subwalk.rs
@@ -202,8 +202,8 @@ pub fn dispatch_via_miframe<Sym: WalkSym>(
     let exc_edge_precondition = exc_edge_bridge_enabled()
         && trace_ctx.is_bridge_trace
         && trace_ctx.bridge_source_is_exception_guard()
-        && !sym.last_exc_box.is_none()
-        && !sym.last_exc_value.is_null();
+        && !sym.last_exc_box().is_none()
+        && !sym.last_exc_value().is_null();
     let exc_edge_catch_target = if exc_edge_precondition {
         find_catch_before_resume_live(jitcode_code, position)
             // Only route when the handler rejoins this frame's loop; a handler
@@ -221,7 +221,7 @@ pub fn dispatch_via_miframe<Sym: WalkSym>(
         // exactly as when the flag is off.
         return Err(DispatchError::ExcEdgeCrossFrameReturnUnsupported { pc: position });
     }
-    let exc_edge_concrete = sym.last_exc_value;
+    let exc_edge_concrete = sym.last_exc_value();
     // typeptr at offset 0 (`_store_exception` invariant): the expected class the
     // bridge-entry GUARD_EXCEPTION checks the restored pending exception against.
     let exc_edge_class = if exc_edge_catch_target.is_some() && !exc_edge_concrete.is_null() {

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/fbw_state.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/fbw_state.rs
@@ -82,6 +82,24 @@ pub(crate) fn fbw_inline_multiframe_enabled() -> bool {
     })
 }
 
+/// `PYRE_FBW_NSVABLE_MULTIFRAME` (#73): publish the `_nonstandard_virtualizable`
+/// promote guard through the full multi-frame resume chain (each paused caller
+/// plus the callee's own coordinate) instead of the single-frame sentinel
+/// collapse in [`walker_capture_inline_nonstandard_vable_guard`], which cannot
+/// resolve a JitCode resume word and unconditionally aborts every inline
+/// sub-walk emit of this guard.  Default-on; `PYRE_FBW_NSVABLE_MULTIFRAME=0`
+/// (or `false`) restores the sentinel decline as the rollback escape hatch.
+pub(crate) fn fbw_nsvable_multiframe_enabled() -> bool {
+    static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ENABLED.get_or_init(|| match std::env::var_os("PYRE_FBW_NSVABLE_MULTIFRAME") {
+        Some(v) => {
+            let v = v.to_string_lossy();
+            v != "0" && !v.eq_ignore_ascii_case("false")
+        }
+        None => true,
+    })
+}
+
 /// `PYRE_FBW_REC_MULTIFRAME` (default ON; `=0`/`false` opts out): route
 /// primary-trace self-recursive Python calls through the multiframe inline path
 /// while below `PYRE_FBW_MULTIFRAME_DEPTH`, instead of folding immediately to

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/fbw_state.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/fbw_state.rs
@@ -1181,6 +1181,54 @@ thread_local! {
     pub(crate) static EXCEPTION_STRING_INLINE_ACTIVE: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
 }
 
+/// Whether the active inline sub-walk is one of the hazard classes the blanket
+/// nested-residual decline was masking, as opposed to a straight-line mutating
+/// callee (the #73 depth-≥2 payoff, which inlines).  Two classes decline:
+///
+/// * **Loop-bearing** — a framestack callee whose `CodeObject` has a
+///   `FOR_ITER`.  Its side-effecting `for` consume runs concretely in the
+///   sub-walk, and a later kept-stack guard abort can REFUSE the Option-C item
+///   delivery (a `for..break` frame parked past the loop header,
+///   eval.rs:5445), so the re-run re-executes the consume and double-advances
+///   the iterator (the two `foriter_exempt_*` witnesses).
+/// * **Self-recursive** — the callee calls itself.  A hot self-recursion
+///   forms a `CALL_ASSEMBLER` bridge whose moving-nursery callee frame cannot
+///   survive the residual trampoline retaining a pre-call frame pointer; on
+///   the wasm always-portal path the inlined body also type-confuses the
+///   optimizer (`setintbound: got Ref`, the `wasm_ca_trampoline_decline`
+///   witness).  Detected both dynamically (the same `w_code` already nested in
+///   the framestack — mutual/deep recursion) and statically
+///   (`code_is_self_recursive`), since the recursive call residualizes to a
+///   `CALL_ASSEMBLER` rather than nesting the framestack, so it is already a
+///   hazard at inline depth 1.
+///
+/// The `w_code` field is the `jitcode_for` code key, resolved to the raw
+/// `CodeObject` via the jitcode index (the `current`-frame pattern,
+/// mod.rs:4664).
+fn fbw_inline_callee_hazardous<Sym: WalkSym>(ctx: &WalkContext<'_, '_, Sym>) -> bool {
+    let session = ctx.session.borrow();
+    let mut seen: Vec<usize> = Vec::with_capacity(session.framestack.len());
+    for frame in session.framestack.iter() {
+        if seen.contains(&frame.w_code) {
+            return true;
+        }
+        seen.push(frame.w_code);
+        if let Some(idx) = crate::state::ensure_jitcode_index(frame.w_code as *const ()) {
+            if let Some(raw_code) = crate::state::raw_code_for_jitcode_index(idx) {
+                let code = unsafe { raw_code.as_ref() };
+                if let Some(code) = code {
+                    if pyre_interpreter::code_has_for_iter(code)
+                        || pyre_interpreter::code_is_self_recursive(code)
+                    {
+                        return true;
+                    }
+                }
+            }
+        }
+    }
+    false
+}
+
 pub(crate) fn fbw_abort_nested_unjournaled_residual<Sym: WalkSym>(
     ctx: &WalkContext<'_, '_, Sym>,
     pc: usize,
@@ -1198,10 +1246,24 @@ pub(crate) fn fbw_abort_nested_unjournaled_residual<Sym: WalkSym>(
     // nested-decline guard, which is for FOREIGN unjournaled residuals.
     let in_selfrec_fold = SELFREC_CA_FOLD_ACTIVE.with(|c| c.get());
     let in_exception_string_inline = EXCEPTION_STRING_INLINE_ACTIVE.with(|c| c.get());
+    // Narrowed decline (#73 Slice-1 payoff): the general depth-≥2 nested
+    // residual inline is sound now that the portal-runner ABI is correct — a
+    // straight-line mutating callee inlines bit-exact.  Only two callee shapes
+    // still miscompile, both masked by the old blanket decline and captured by
+    // [`fbw_inline_callee_hazardous`]: a LOOP-BEARING callee (the FOR_ITER
+    // Option-C refused-delivery double-advance, the `foriter_exempt_*`
+    // witnesses) and a SELF-RECURSIVE callee (the hot `CALL_ASSEMBLER`
+    // recursion-bridge / wasm always-portal `setintbound` type-confusion, the
+    // `wasm_ca_trampoline_decline` witness).  Both are properties of the
+    // framestack knowable at the residual decline point, so the whole trace
+    // aborts before the hazardous body is committed.  Every other nested
+    // residual inlines.  The hazard scan is last so the cheap flag checks
+    // short-circuit it.
     if enabled
         && !in_selfrec_fold
         && !in_exception_string_inline
         && !ctx.session.borrow().framestack.is_empty()
+        && fbw_inline_callee_hazardous(ctx)
     {
         let (outer_resume, stack_overrides) = {
             let session = ctx.session.borrow();

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
@@ -2080,8 +2080,18 @@ pub(crate) fn try_walker_inline_resolved_user_call<Sym: WalkSym>(
         //    shadow for `try_multiframe` too gives that re-read a fallback — the
         //    analog of the callee MIFrame register box RPython reads
         //    `box.getint()` off (registers survive a residual call; the heapcache
-        //    does not).  STORE_FAST keeps it current (the `setarrayitem_vable`
-        //    handler re-seeds `set_concrete` on every store).
+        //    does not).  STORE_FAST keeps both maps current (the
+        //    `setarrayitem_vable` handler re-seeds `set_opref` + `set_concrete`
+        //    on every store).
+        //
+        //    `set_opref` is seeded on BOTH paths (not just the fold): the read
+        //    fallback re-resolves the slot's concrete through `concrete_of_opref`
+        //    on this OpRef — a GC-forwarded, rooted channel — in preference to
+        //    the raw `Value` copy in `concrete`, which the trace-ref walker does
+        //    not visit and so dangles if a minor collection moves a nursery Ref
+        //    across the may-force residual.  The fold consumer stays gated by
+        //    `fold_frame_reg` (kept `!try_multiframe`), so seeding `opref` here is
+        //    inert for folding on the multiframe path.
         //
         // Inert when `callee_portal_frame_reg == u16::MAX` (flip OFF / frame reg
         // unresolved).
@@ -2097,9 +2107,7 @@ pub(crate) fn try_walker_inline_resolved_user_call<Sym: WalkSym>(
                     .concrete_of_opref(callee_args[i])
                     .unwrap_or(majit_ir::Value::Void);
                 let shadow = sub_wc.callee_shadow.as_mut().unwrap();
-                if !try_multiframe {
-                    shadow.set_opref(slot, value);
-                }
+                shadow.set_opref(slot, value);
                 shadow.set_concrete(callee_portal_frame_reg, slot, concrete);
             }
         }

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
@@ -2057,17 +2057,38 @@ pub(crate) fn try_walker_inline_resolved_user_call<Sym: WalkSym>(
                 seed_callee_vstack_mirror(&mut sub_wc, &frame);
             }
         }
-        // Strict fresh-frame fold: a branchless leaf inlined without a virtual
-        // frame (not `try_multiframe`) whose body carries the Portal
-        // frame-vable locals prologue resolves its own `getarrayitem_vable_r` /
-        // `setarrayitem_vable_r` register-to-register through the per-slot
-        // shadow.  Seed each param into slot `i` (`local_to_vable_slot` is
-        // identity) and activate the fold so the callee's first LOAD_FAST of a
-        // param folds to the arg OpRef instead of reading its unseeded frame
-        // box.  Inert when `callee_portal_frame_reg == u16::MAX` (flip OFF /
-        // frame reg unresolved) or `try_multiframe` (real virtual frame seeded).
-        if !try_multiframe && callee_portal_frame_reg != u16::MAX {
-            sub_wc.callee_shadow.as_mut().unwrap().fold_frame_reg = callee_portal_frame_reg;
+        // Seed the callee's per-slot concrete-locals shadow from the param
+        // boxes.  Two distinct consumers, gated differently:
+        //
+        // 1. Register-to-register fold (`!try_multiframe` only): a branchless
+        //    leaf inlined without a materialized virtual frame folds its own
+        //    `getarrayitem_vable_r` / `setarrayitem_vable_r` through the per-slot
+        //    OpRef shadow (`fold_frame_reg` + `set_opref`), so the callee's first
+        //    LOAD_FAST of a param folds to the arg OpRef instead of reading its
+        //    unseeded frame box.  A `try_multiframe` callee HAS a real virtual
+        //    frame, so this fold must stay off (its reads go through the frame).
+        //
+        // 2. Concrete-locals fallback (BOTH paths): the `getarrayitem_vable`
+        //    read fallback and the `setarrayitem_vable` re-seed
+        //    (`getarrayitem_vable_via_metainterp` / `setarrayitem_vable`) supply
+        //    the local's recording-time concrete when the heapcache holds no
+        //    entry.  A `try_multiframe` callee's param reads forward through the
+        //    heapcache only until an in-callee may-force op runs
+        //    `reset_keep_likely_virtuals` (heapcache.py:183) and clears the array
+        //    cache; the post-call LOAD_FAST re-read then misses and the branch
+        //    value goes non-concrete (`GotoIfNotValueNotConcrete`).  Seeding the
+        //    shadow for `try_multiframe` too gives that re-read a fallback — the
+        //    analog of the callee MIFrame register box RPython reads
+        //    `box.getint()` off (registers survive a residual call; the heapcache
+        //    does not).  STORE_FAST keeps it current (the `setarrayitem_vable`
+        //    handler re-seeds `set_concrete` on every store).
+        //
+        // Inert when `callee_portal_frame_reg == u16::MAX` (flip OFF / frame reg
+        // unresolved).
+        if callee_portal_frame_reg != u16::MAX {
+            if !try_multiframe {
+                sub_wc.callee_shadow.as_mut().unwrap().fold_frame_reg = callee_portal_frame_reg;
+            }
             for i in 0..nparams {
                 let slot = i as i64;
                 let value = callee_args[i];
@@ -2076,7 +2097,9 @@ pub(crate) fn try_walker_inline_resolved_user_call<Sym: WalkSym>(
                     .concrete_of_opref(callee_args[i])
                     .unwrap_or(majit_ir::Value::Void);
                 let shadow = sub_wc.callee_shadow.as_mut().unwrap();
-                shadow.set_opref(slot, value);
+                if !try_multiframe {
+                    shadow.set_opref(slot, value);
+                }
                 shadow.set_concrete(callee_portal_frame_reg, slot, concrete);
             }
         }

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
@@ -1550,6 +1550,17 @@ pub enum DispatchError {
     /// rewind it and a deliver re-run would double it, so the walk declines BEFORE
     /// the commit and the location interprets permanently (`AbortPermanent`).
     InplaceContainerMutationUnsupported { pc: usize },
+    /// Exception-edge bridge (`PYRE_EXC_EDGE_BRIDGE`): the failing exception
+    /// guard is caught in-frame, but the `except` handler RETURNS out of the
+    /// frame (a called function's `try/except: return`, compiled as its own
+    /// function trace) rather than rejoining this frame's loop.  Routing the
+    /// walk to such a handler records a `Finish`/`DoneWithThisFrame` whose
+    /// cross-frame return pyre cannot yet reconstruct (the caller frame is not
+    /// rebuilt at the bridge → NULL-frame deref on return).  Abort so the guard
+    /// failure resumes via the blackhole, which handles the caught exception and
+    /// the callee return correctly.  The loop-rejoin case (same-frame handler)
+    /// still routes.
+    ExcEdgeCrossFrameReturnUnsupported { pc: usize },
 }
 
 impl DispatchError {
@@ -1615,6 +1626,9 @@ impl DispatchError {
             }
             Self::InplaceContainerMutationUnsupported { .. } => {
                 "InplaceContainerMutationUnsupported"
+            }
+            Self::ExcEdgeCrossFrameReturnUnsupported { .. } => {
+                "ExcEdgeCrossFrameReturnUnsupported"
             }
         }
     }
@@ -2020,6 +2034,110 @@ fn try_catch_exception_at(code: &[u8], position: usize) -> Option<usize> {
         FinishframeLookahead::CatchTarget(target) => Some(target),
         FinishframeLookahead::RvmprofCode { .. } | FinishframeLookahead::NoMatch => None,
     }
+}
+
+/// `PYRE_EXC_EDGE_BRIDGE=1` enables the exception-edge bridge: route an
+/// exception-guard bridge (GUARD_NO_EXCEPTION / GUARD_EXCEPTION) resume to the
+/// in-frame `except` handler instead of declining to the blackhole
+/// (`call_jit.rs` pending-exc decline).  Default-off for A/B while the routing
+/// is validated bit-exact.
+pub fn exc_edge_bridge_enabled() -> bool {
+    static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ENABLED.get_or_init(|| std::env::var_os("PYRE_EXC_EDGE_BRIDGE").is_some())
+}
+
+/// Mirror of `blackhole.rs BlackholeInterpreter::find_catch_before_resume_live`
+/// for the walker.  An after-residual-call exception guard resumes at the
+/// no-exception fallthrough `-live-` (the next opcode after the call); the
+/// `catch_exception/L` that belongs to the just-executed raising op sits BEHIND
+/// that resume `-live-` (between the call's own post-call `-live-` and the next
+/// op), so there is no forward catch to route to.  Scan op boundaries backward
+/// from `resume_live_pos`, newest first, bounded by the first `live/` (the
+/// call's own post-call `-live-`), so only THIS opcode's catch can match.
+/// Returns the handler target (2-byte LE label after `catch_exception/L`), or
+/// `None` when the raising op sits outside any in-frame try (propagate).
+pub(crate) fn find_catch_before_resume_live(code: &[u8], resume_live_pos: usize) -> Option<usize> {
+    let mut pcs: Vec<usize> = crate::jitcode_runtime::decoded_ops(code)
+        .map(|op| op.pc)
+        .filter(|&pc| pc < resume_live_pos)
+        .collect();
+    pcs.sort_unstable_by(|a, b| b.cmp(a));
+    for pc in pcs {
+        let op = decode_op_at(code, pc)?;
+        if op.key == "catch_exception/L" {
+            let lo = code[pc + 1] as usize;
+            let hi = code[pc + 2] as usize;
+            return Some(lo | (hi << 8));
+        }
+        if op.key == "live/" {
+            // The call's own post-call `-live-`: bound the scan so a preceding
+            // opcode's catch can never be mis-selected.
+            return None;
+        }
+    }
+    None
+}
+
+/// Does the `except` handler at `catch_target` flow back into this frame's loop
+/// (reaching a `jit_merge_point` back-edge), rather than returning out of the
+/// frame (`*_return`)?
+///
+/// The exception-edge bridge is only sound when the handler REJOINS the loop in
+/// the SAME frame: the bridge records the handler body and closes with a `Jump`
+/// to the loop header, exactly like the no-exception path.  When the handler
+/// instead RETURNS out of the frame (a called function's `try/except: return`,
+/// compiled as its own function trace, not inlined into the caller's loop), the
+/// walk records a `Finish`/`DoneWithThisFrame` and the bridge must hand the
+/// return value back across the frame boundary to the caller — a cross-frame
+/// exception resume pyre does not yet reconstruct (the caller frame is not
+/// rebuilt at the bridge, so the return path derefs a NULL frame).  Route only
+/// the loop-rejoin case; the caller-return case declines to the blackhole.
+///
+/// Bounded forward reachability from `catch_target`, following `goto`/
+/// `goto_if_not` successors: `true` as soon as any path reaches a
+/// `jit_merge_point`; `false` if every reachable path terminates at a `*_return`
+/// (or the scan hits an un-followed control op / the bound, which conservatively
+/// declines).
+pub(crate) fn exc_handler_rejoins_loop(code: &[u8], catch_target: usize) -> bool {
+    let mut visited = std::collections::HashSet::new();
+    let mut work = vec![catch_target];
+    let mut budget = 4096usize;
+    while let Some(pc) = work.pop() {
+        if budget == 0 {
+            return false;
+        }
+        budget -= 1;
+        if !visited.insert(pc) {
+            continue;
+        }
+        let Some(op) = decode_op_at(code, pc) else {
+            continue;
+        };
+        if op.key.starts_with("jit_merge_point") {
+            return true;
+        }
+        if matches!(
+            op.key,
+            "ref_return/r" | "int_return/i" | "float_return/f" | "void_return/"
+        ) {
+            // Frame-return terminal on this path; do not enqueue successors.
+            continue;
+        }
+        match op.key {
+            "goto/L" => work.push(read_label(code, &op, 0)),
+            "goto_if_not/iL" => {
+                // `iL`: 1B int register + 2B LE label.
+                work.push(read_label(code, &op, 1));
+                work.push(op.next_pc);
+            }
+            key if key.starts_with("switch") => {
+                // Multi-target dispatch not followed; leave this path un-proven
+                // (routing declines unless another path rejoins the loop).
+            }
+            _ => work.push(op.next_pc),
+        }
+    }
+    false
 }
 
 fn reads_last_exc_before_next_catch(code: &[u8], position: usize) -> bool {

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
@@ -1627,9 +1627,7 @@ impl DispatchError {
             Self::InplaceContainerMutationUnsupported { .. } => {
                 "InplaceContainerMutationUnsupported"
             }
-            Self::ExcEdgeCrossFrameReturnUnsupported { .. } => {
-                "ExcEdgeCrossFrameReturnUnsupported"
-            }
+            Self::ExcEdgeCrossFrameReturnUnsupported { .. } => "ExcEdgeCrossFrameReturnUnsupported",
         }
     }
 }

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/resume_snapshot.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/resume_snapshot.rs
@@ -101,6 +101,51 @@ pub(crate) fn walker_capture_inline_nonstandard_vable_guard<Sym: WalkSym>(
     if !ctx.trace_ctx.vable_snapshot_buildable() {
         return Err(DispatchError::GuardSnapshotVableUntyped { pc: op_pc });
     }
+    // #73: give this promote guard the full multi-frame resume every RPython
+    // guard gets — `_nonstandard_virtualizable` (pyjitpl.py:1120) →
+    // `implement_guard_value(eqbox, pc)` (1916) →
+    // `generate_guard(GUARD_VALUE, resumepc=orgpc)` (2582) →
+    // `capture_resumedata(resumepc)` (2610) walking the WHOLE MIFrame chain
+    // (opencoder.py:819).  When the paused-caller chain covers the full inline
+    // depth (the same gate as the standard multi-frame guard path,
+    // `walker_capture_snapshot_for_last_guard_impl`), publish the callee's OWN
+    // coordinate plus each paused caller instead of the single-frame sentinel
+    // collapse below — whose carried word is `NO_JITCODE_PC`, which
+    // `resolve_resume_pc_with_jitcode_pc` rejects, so the collapse
+    // unconditionally aborts (`GuardResumeCoordinateUnavailable`) every inline
+    // sub-walk emit of this guard.  Stamp the last *guard* op, not the last op:
+    // `emit_force_virtualizable` records GETFIELD_GC / PTR_NE / COND_CALL after
+    // the promote.  A chain that is not full, or a callee/caller frame the
+    // publisher cannot build, falls through to (or aborts the same as) the
+    // sentinel below — never a wrong resume.
+    if fbw_nsvable_multiframe_enabled() {
+        let (n_parents, n_callees, parent_frames) = {
+            let session = ctx.session.borrow();
+            (
+                session
+                    .framestack
+                    .iter()
+                    .filter(|frame| frame.parent.is_some())
+                    .count(),
+                session.framestack.len(),
+                session
+                    .framestack
+                    .iter()
+                    .filter_map(|frame| frame.parent.clone())
+                    .collect::<Vec<_>>(),
+            )
+        };
+        if n_parents > 0 && n_parents == n_callees {
+            return walker_capture_multi_frame_inline_snapshot(
+                ctx,
+                op_pc,
+                false,
+                parent_frames,
+                GuardCaptureScope::default(),
+                true,
+            );
+        }
+    }
     // The guard is not the last recorded op: `emit_force_virtualizable`
     // records GETFIELD_GC / PTR_NE / COND_CALL after the promote, so stamp
     // the last *guard* op (`..._for_last_guard_op_...`).  Resume at the
@@ -259,6 +304,7 @@ pub(crate) fn walker_capture_snapshot_for_last_guard_impl<Sym: WalkSym>(
                 after_residual_call,
                 parent_frames,
                 scope,
+                false,
             );
         }
     }
@@ -1455,6 +1501,11 @@ pub(crate) fn walker_capture_multi_frame_inline_snapshot<Sym: WalkSym>(
     after_residual_call: bool,
     parent_frames: Vec<InlineParentFrame>,
     scope: GuardCaptureScope<'_>,
+    // The `_nonstandard_virtualizable` promote guard is not the last recorded op
+    // (`emit_force_virtualizable` records GETFIELD_GC / PTR_NE / COND_CALL after
+    // it), so its caller stamps the resume position on the last *guard* op.
+    // Straight-line / branch inline guards ARE the last op and pass `false`.
+    stamp_last_guard_op: bool,
 ) -> Result<(), DispatchError> {
     if !ctx.trace_ctx.vable_snapshot_buildable() {
         return Err(DispatchError::GuardSnapshotVableUntyped { pc: callee_op_pc });
@@ -1672,11 +1723,20 @@ pub(crate) fn walker_capture_multi_frame_inline_snapshot<Sym: WalkSym>(
         callee_boxes.as_slice(),
     ));
 
-    ctx.trace_ctx
-        .capture_snapshot_for_last_guard_multi_frame_with_vable_vref(
-            &frames,
-            &vable_boxes,
-            &vref_boxes,
-        );
+    if stamp_last_guard_op {
+        ctx.trace_ctx
+            .capture_snapshot_for_last_guard_op_multi_frame_with_vable_vref(
+                &frames,
+                &vable_boxes,
+                &vref_boxes,
+            );
+    } else {
+        ctx.trace_ctx
+            .capture_snapshot_for_last_guard_multi_frame_with_vable_vref(
+                &frames,
+                &vable_boxes,
+                &vref_boxes,
+            );
+    }
     Ok(())
 }

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
@@ -5255,30 +5255,46 @@ pub(crate) fn try_walker_load_global_cell_fold<Sym: WalkSym>(
     // `ns_ptr` module dict.  Mirror `bh_load_global_fn`'s second leg —
     // `frame.get_builtin().getdictvalue(name)` — and fold the builtins cell
     // when the name resolves there.  Requires the live frame operand.
-    if !fbw_builtin_fold_enabled() || frame_ptr == 0 {
+    if !fbw_builtin_fold_enabled() {
         return Ok(false);
     }
-    let frame = unsafe { &*(frame_ptr as *const pyre_interpreter::PyFrame) };
-    // Faithfulness: `bh_load_global_fn` re-resolves the globals it actually
-    // consults from the LIVE frame (`frame.get_w_globals()` when the frame
-    // owns `w_code`, else the code's bound globals) and IGNORES the
-    // `namespace_ptr` operand.  The `ns_ptr` hint usually equals that live
-    // dict, but verify the name is ALSO absent from the authoritative
-    // globals before falling through to builtins — a present name there must
+    // The builtins fallback needs the module `pick_builtin(w_globals)` picks
+    // (`frame.get_builtin()`).  A live frame supplies it directly and also lets
+    // us double-check the name is absent from the frame's AUTHORITATIVE globals
+    // — `bh_load_global_fn` re-resolves the globals it consults from the LIVE
+    // frame (`frame.get_w_globals()` when the frame owns `w_code`, else the
+    // code's bound globals) and IGNORES the `namespace_ptr` operand.  The
+    // `ns_ptr` hint usually equals that live dict, but a present name there must
     // resolve from globals (residual), not the builtin, or the fold would be
-    // wrong.
-    let live_globals = if frame.pycode as usize == w_code_ptr {
-        frame.get_w_globals()
+    // wrong.  An INLINED callee has no materialised frame (`frame_ptr == 0`, its
+    // `portal_frame_reg` unseeded); derive the builtin module from the concrete
+    // globals' `__builtins__` cell instead — the same object `pick_builtin`
+    // resolves (baseobjspace.rs:9716) and the one the interpreter fallback would
+    // rebuild for the resumed callee frame.  #670 keeps `__builtins__` in every
+    // module dict, `ns_ptr` is the callee's own namespace field (so it is the
+    // authoritative globals), and guard (a) below watches the globals `version`,
+    // so a later `__builtins__` rebind fails the loop exactly as a
+    // shadowing-name insert would.
+    let w_builtin = if frame_ptr != 0 {
+        let frame = unsafe { &*(frame_ptr as *const pyre_interpreter::PyFrame) };
+        let live_globals = if frame.pycode as usize == w_code_ptr {
+            frame.get_w_globals()
+        } else {
+            unsafe {
+                pyre_interpreter::w_code_get_w_globals(w_code_ptr as pyre_object::PyObjectRef)
+            }
+        };
+        if !live_globals.is_null()
+            && live_globals as usize != w_globals as usize
+            && crate::state::module_dict_cell_slot_direct(live_globals, &name).is_some()
+        {
+            return Ok(false);
+        }
+        frame.get_builtin()
     } else {
-        unsafe { pyre_interpreter::w_code_get_w_globals(w_code_ptr as pyre_object::PyObjectRef) }
+        unsafe { pyre_object::w_dict_getitem_str(w_globals, "__builtins__") }
+            .unwrap_or(pyre_object::PY_NULL)
     };
-    if !live_globals.is_null()
-        && live_globals as usize != w_globals as usize
-        && crate::state::module_dict_cell_slot_direct(live_globals, &name).is_some()
-    {
-        return Ok(false);
-    }
-    let w_builtin = frame.get_builtin();
     if w_builtin.is_null() || !unsafe { pyre_object::is_module(w_builtin) } {
         return Ok(false);
     }

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/vable_ops.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/vable_ops.rs
@@ -412,11 +412,28 @@ pub(crate) fn getarrayitem_vable_via_metainterp<Sym: WalkSym>(
     // a loop-carried local read after a may-force op in the loop body has no
     // heapcache entry this pass, yet its recording-time concrete is known.
     let shadow_value = if matches!(shadow_value, Value::Void) {
-        ctx.callee_shadow
+        let entry = ctx
+            .callee_shadow
             .as_ref()
             .and_then(|shadow| shadow.concrete.get(&index_value).copied())
-            .filter(|entry| entry.frame_reg == code[op.pc + 1] as u16)
-            .map(|entry| entry.value)
+            .filter(|entry| entry.frame_reg == code[op.pc + 1] as u16);
+        let slot_opref = ctx
+            .callee_shadow
+            .as_ref()
+            .and_then(|shadow| shadow.opref.get(&index_value).copied());
+        // Prefer re-resolving the slot's SSA OpRef through the op-table (a
+        // GC-forwarded, rooted value channel) over the raw concrete copy the
+        // shadow holds: `CalleeLocalsShadow.concrete` is not visited by the
+        // trace-ref walker, so a Ref copy dangles if a minor collection moved a
+        // nursery object across the may-force residual. The op-table concrete IS
+        // forwarded. Fall back to the stored copy when the OpRef carries no live
+        // concrete (ints/floats are value copies of immutable payloads and are
+        // always safe). Only consult the OpRef when a frame-matched `concrete`
+        // entry exists, so the per-frame isolation the `frame_reg` filter gives
+        // `concrete` also bounds the OpRef re-resolution.
+        entry
+            .and_then(|_| slot_opref.and_then(|opref| ctx.trace_ctx.concrete_of_opref(opref)))
+            .or_else(|| entry.map(|entry| entry.value))
             .unwrap_or(Value::Void)
     } else {
         shadow_value
@@ -574,7 +591,12 @@ pub(crate) fn setarrayitem_vable_via_metainterp<Sym: WalkSym>(
     );
     // Keep the inline concrete-locals shadow current so a later read of this
     // slot (after a may-force op clears the heapcache) recovers the concrete.
+    // Seed BOTH maps: the read fallback prefers re-resolving the slot's OpRef
+    // through the (GC-forwarded) op-table over the raw `concrete` copy, so the
+    // OpRef must track the stored value on every write — otherwise a re-stored
+    // slot would re-resolve a stale OpRef while `concrete` held the fresh value.
     if let Some(shadow) = ctx.callee_shadow.as_mut() {
+        shadow.set_opref(index_value, value);
         shadow.set_concrete(code[op.pc + 1] as u16, index_value, concrete);
     }
     walker_capture_inline_nonstandard_vable_guard(ctx, op.pc, guards_before)?;

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/vstack_mirror.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/vstack_mirror.rs
@@ -364,7 +364,10 @@ pub(crate) fn reconcile_vstack_at_boundary<Sym: WalkSym>(
             if ctx.vstack_boxes.len() < new_depth {
                 ctx.vstack_boxes.resize(new_depth, OpRef::NONE);
             }
-            if new_depth > 0 && ctx.vstack_last_ref != OpRef::NONE {
+            if new_depth > 0 {
+                // `NONE` means the result was produced in an unboxed bank;
+                // leave an intentional hole so the capture overlay around
+                // stack_sync omits the slot and resume rematerializes it.
                 ctx.vstack_boxes[new_depth - 1] = ctx.vstack_last_ref;
             }
         }

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -2018,7 +2018,22 @@ pub fn blackhole_resume_via_rd_numb(
     bh.jitdrivers_sd = vec![majit_metainterp::blackhole::BhJitDriverSd {
         result_type: majit_metainterp::blackhole::BhReturnType::Ref,
         portal_runner_ptr: Some(bh_portal_runner),
-        mainjitcode_calldescr: bh.jitcode.calldescr.clone(),
+        mainjitcode_calldescr: {
+            // `get_portal_runner` returns this descr paired with
+            // `bh_portal_runner`, and the blackhole recursive-portal resume
+            // (`bhimpl_recursive_call_r` -> `bh_call_r`) verifies the merged
+            // green+red argument banks against it — so it must describe the
+            // portal runner, not the traced function.  `bh_portal_runner`
+            // consumes the warmspot `portalfunc_ARGS` (`warmspot.py:972-975`):
+            // greens `[next_instr:i, is_being_profiled:i, pycode:r]` + reds
+            // `[frame:r, ec:r]` (`interp_jit.py:67-68`) = 2 int + 3 ref.
+            // `bh.jitcode.calldescr` is the traced function's own frame-based
+            // residual-call descr and does not describe the runner.
+            let mut d = bh.jitcode.calldescr.clone();
+            d.arg_classes = "iirrr".to_string();
+            d.result_type = 'r';
+            d
+        },
     }];
 
     // Portal red-arg registers (`pypy/module/pypyjit/interp_jit.py:67

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -838,12 +838,35 @@ fn resolve_field_offset(owner: &str, field_name: &str) -> usize {
 ///   (Ref, 'red_ref', 0)   → frame = all_r[1]
 ///   (Ref, 'red_ref', 1)   → ec = all_r[2]
 pub(crate) fn bh_portal_runner(all_i: &[i64], all_r: &[i64], _all_f: &[i64]) -> i64 {
-    // warmspot.py:972-975: extract portal args from merged lists.
-    let next_instr = all_i.first().copied().unwrap_or(0) as usize;
-    let _is_being_profiled = all_i.get(1).copied().unwrap_or(0);
-    let pycode = all_r.first().copied().unwrap_or(0) as PyObjectRef;
-    let frame_ptr = all_r.get(1).copied().unwrap_or(0) as *mut PyFrame;
-    let ec = all_r.get(2).copied().unwrap_or(0) as *const pyre_interpreter::PyExecutionContext;
+    // warmspot.py:972-975: extract portal args from merged lists, then run
+    // through the shared `bh_portal_runner_c` body.
+    let next_instr = all_i.first().copied().unwrap_or(0);
+    let is_being_profiled = all_i.get(1).copied().unwrap_or(0);
+    let pycode = all_r.first().copied().unwrap_or(0);
+    let frame_ptr = all_r.get(1).copied().unwrap_or(0);
+    let ec = all_r.get(2).copied().unwrap_or(0);
+    bh_portal_runner_c(next_instr, is_being_profiled, pycode, frame_ptr, ec)
+}
+
+/// C-ABI portal runner matching the `mainjitcode_calldescr` arg layout
+/// (`"iirrr"`: `next_instr:i, is_being_profiled:i, pycode:r, frame:r, ec:r`).
+///
+/// This is the function `get_portal_runner` hands to `bh_call_r` for
+/// `bhimpl_recursive_call_*` (blackhole.py:1109-1116). `bh_call_r` invokes it
+/// through `collect_call_args` + `bh_call_i_dispatch`, i.e. as a raw C function
+/// whose five arguments arrive in integer registers per the calldescr — so the
+/// runner must take those five scalars directly. (A Rust `fn(&[i64], …)` would
+/// receive slice fat pointers there instead, corrupting every argument.)
+pub extern "C" fn bh_portal_runner_c(
+    next_instr: i64,
+    _is_being_profiled: i64,
+    pycode: i64,
+    frame_ptr: i64,
+    ec: i64,
+) -> i64 {
+    let pycode = pycode as PyObjectRef;
+    let frame_ptr = frame_ptr as *mut PyFrame;
+    let ec = ec as *const pyre_interpreter::PyExecutionContext;
 
     if frame_ptr.is_null() {
         return pyre_object::PY_NULL as i64;
@@ -856,7 +879,7 @@ pub(crate) fn bh_portal_runner(all_i: &[i64], all_r: &[i64], _all_f: &[i64]) -> 
     if !ec.is_null() {
         frame.execution_context = ec;
     }
-    frame.set_last_instr_from_next_instr(next_instr);
+    frame.set_last_instr_from_next_instr(next_instr as usize);
     match crate::eval::portal_runner_result(frame) {
         Ok(result) => result as i64,
         Err(mut err) => {
@@ -2017,13 +2040,13 @@ pub fn blackhole_resume_via_rd_numb(
     //   calldescr    = jitdriver_sd.mainjitcode.calldescr
     bh.jitdrivers_sd = vec![majit_metainterp::blackhole::BhJitDriverSd {
         result_type: majit_metainterp::blackhole::BhReturnType::Ref,
-        portal_runner_ptr: Some(bh_portal_runner),
+        portal_runner_ptr: Some(bh_portal_runner_c),
         mainjitcode_calldescr: {
             // `get_portal_runner` returns this descr paired with
-            // `bh_portal_runner`, and the blackhole recursive-portal resume
+            // `bh_portal_runner_c`, and the blackhole recursive-portal resume
             // (`bhimpl_recursive_call_r` -> `bh_call_r`) verifies the merged
             // green+red argument banks against it — so it must describe the
-            // portal runner, not the traced function.  `bh_portal_runner`
+            // portal runner, not the traced function.  `bh_portal_runner_c`
             // consumes the warmspot `portalfunc_ARGS` (`warmspot.py:972-975`):
             // greens `[next_instr:i, is_being_profiled:i, pycode:r]` + reds
             // `[frame:r, ec:r]` (`interp_jit.py:67-68`) = 2 int + 3 ref.

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -2692,28 +2692,37 @@ pub fn trace_and_compile_from_bridge(
         driver.last_bridge_is_exception_guard
     };
     if last_bridge_is_exception_guard {
-        #[cfg(feature = "cranelift")]
-        let exc_class = majit_backend_cranelift::jit_exc_class_raw();
-        #[cfg(not(feature = "cranelift"))]
-        let exc_class: i64 = 0;
-        #[cfg(feature = "cranelift")]
-        let exc_value = majit_backend_cranelift::jit_exc_value_raw();
-        #[cfg(not(feature = "cranelift"))]
-        let exc_value: i64 = 0;
-        if exc_class != 0 {
-            // RPython pyjitpl.py:3125-3126 + 3138:
-            // SAVE_EXC_CLASS, SAVE_EXCEPTION, RESTORE_EXCEPTION
-            {
-                let (driver, _) = crate::eval::driver_pair();
-                driver
-                    .meta_interp_mut()
-                    .emit_exception_bridge_prologue(exc_class, exc_value);
-            }
-            if majit_metainterp::majit_log_enabled() {
-                eprintln!(
-                    "[jit][bridge-exc] exception guard bridge: class={:#x} value={:#x}",
-                    exc_class, exc_value
-                );
+        // With `PYRE_EXC_EDGE_BRIDGE` the walker emits the whole exception
+        // resumption sequence (SAVE_EXC_CLASS/SAVE_EXCEPTION/RESTORE_EXCEPTION +
+        // a snapshotted GUARD_EXCEPTION) at the bridge-entry frame state, where
+        // the guard can capture resume data.  The legacy call-site prologue
+        // below emits a snapshot-less GUARD_EXCEPTION and is only reached on the
+        // declined path (which discards the trace), so skip it when routing is
+        // enabled and let the walker own the sequence.
+        if !pyre_jit_trace::jitcode_dispatch::exc_edge_bridge_enabled() {
+            #[cfg(feature = "cranelift")]
+            let exc_class = majit_backend_cranelift::jit_exc_class_raw();
+            #[cfg(not(feature = "cranelift"))]
+            let exc_class: i64 = 0;
+            #[cfg(feature = "cranelift")]
+            let exc_value = majit_backend_cranelift::jit_exc_value_raw();
+            #[cfg(not(feature = "cranelift"))]
+            let exc_value: i64 = 0;
+            if exc_class != 0 {
+                // RPython pyjitpl.py:3125-3126 + 3138:
+                // SAVE_EXC_CLASS, SAVE_EXCEPTION, RESTORE_EXCEPTION
+                {
+                    let (driver, _) = crate::eval::driver_pair();
+                    driver
+                        .meta_interp_mut()
+                        .emit_exception_bridge_prologue(exc_class, exc_value);
+                }
+                if majit_metainterp::majit_log_enabled() {
+                    eprintln!(
+                        "[jit][bridge-exc] exception guard bridge: class={:#x} value={:#x}",
+                        exc_class, exc_value
+                    );
+                }
             }
         }
         let (driver, _) = crate::eval::driver_pair();
@@ -2807,7 +2816,33 @@ pub fn trace_and_compile_from_bridge(
             pyre_interpreter::pycode::lookup_exceptiontable(&code.exceptiontable, off).is_some()
         }
     };
-    if pending_exc {
+    // Exception-edge bridge (`PYRE_EXC_EDGE_BRIDGE`): route the caught-in-frame
+    // single-frame resume to the in-frame `except` handler (walker
+    // `find_catch_before_resume_live`) instead of declining.  The escaping case
+    // (uncaught) and the multi-frame resume still decline here — those are
+    // separate slices (raising-bridge Finish(exc) / carrier subwalk).
+    let route_exc_edge = caught_in_frame
+        && !is_multiframe_resume
+        && pyre_jit_trace::jitcode_dispatch::exc_edge_bridge_enabled();
+    if route_exc_edge && guard_exc != 0 {
+        // Publish the grabbed exception (`cpu.grab_exc_value` result) so the
+        // walker's `seed_standing_exception_for_walk` threads it into
+        // `sym.last_exc_box`, which the handler's `last_exc_value/>r` reads.
+        majit_metainterp::blackhole::BH_LAST_EXC_VALUE.with(|c| c.set(guard_exc));
+    } else if !pending_exc {
+        // No standing exception at this bridge's source guard (e.g. a
+        // GUARD_NOT_FORCED that fails every iteration because the may-force
+        // residual forced the frame).  A prior residual-call raise may have
+        // left a stale non-null value in `BH_LAST_EXC_VALUE`; the walker's
+        // exc-edge routing seeds `sym.last_exc_value` from it and would route
+        // this exception-free bridge into the `except` handler (recording the
+        // `v = -1` handler body as the bridge body → the handler path runs
+        // every iteration).  Clear it so the walk resumes on the real
+        // no-exception continuation.  The decline path below (`pending_exc &&
+        // !route_exc_edge`) keeps the value for the blackhole.
+        majit_metainterp::blackhole::BH_LAST_EXC_VALUE.with(|c| c.set(0));
+    }
+    if pending_exc && !route_exc_edge {
         if majit_metainterp::majit_log_enabled() {
             eprintln!(
                 "[jit][bridge-trace] decline (pending exc, caught_in_frame={caught_in_frame}) key={} trace={} fail={} resume_pc={}",

--- a/pyre/pyre-wasm-runner/src/main.rs
+++ b/pyre/pyre-wasm-runner/src/main.rs
@@ -465,6 +465,28 @@ fn run(module_path: &PathBuf, source: &str) -> Result<i32> {
             }
         }
     }
+    // Emit the sign-stable badness counters under MAJIT_STATS (the same env
+    // check.py sets for every backend), so the regression floor gates wasm on
+    // loops_aborted / internal_compile_panics like the native backends. Kept
+    // separate from the verbose PYRE_WASM_JIT_STATS block above and emitted
+    // last, so under check.py (MAJIT_STATS only) this is the single [jit-stats]
+    // line the snapshot picks up. The exports read 0 on an old module that
+    // predates them, which is the healthy value, so a stale runner degrades
+    // safely rather than reporting a false regression.
+    if std::env::var_os("MAJIT_STATS").is_some() {
+        let loops_aborted = instance
+            .get_typed_func::<(), u64>(&mut store, "pyre_jit_loops_aborted")
+            .and_then(|f| f.call(&mut store, ()))
+            .unwrap_or(0);
+        let internal_compile_panics = instance
+            .get_typed_func::<(), u64>(&mut store, "pyre_jit_internal_compile_panics")
+            .and_then(|f| f.call(&mut store, ()))
+            .unwrap_or(0);
+        eprintln!(
+            "[jit-stats] loops_aborted={loops_aborted} \
+             internal_compile_panics={internal_compile_panics}"
+        );
+    }
     let packed = match run_result {
         Ok(p) => p,
         Err(e) => {

--- a/pyre/pyre-wasm/src/lib.rs
+++ b/pyre/pyre-wasm/src/lib.rs
@@ -349,7 +349,10 @@ pub extern "C" fn pyre_jit_loops_aborted() -> u64 {
 #[cfg(all(target_arch = "wasm32", feature = "wasm-host"))]
 #[unsafe(no_mangle)]
 pub extern "C" fn pyre_jit_internal_compile_panics() -> u64 {
-    pyre_jit::eval::driver_pair().0.get_stats().internal_compile_panics as u64
+    pyre_jit::eval::driver_pair()
+        .0
+        .get_stats()
+        .internal_compile_panics as u64
 }
 
 #[cfg(any(feature = "web", feature = "wasm-host"))]

--- a/pyre/pyre-wasm/src/lib.rs
+++ b/pyre/pyre-wasm/src/lib.rs
@@ -334,6 +334,24 @@ pub extern "C" fn pyre_jit_mc_diag(i: u32) -> u64 {
     majit_metainterp::mc_diag(i as usize)
 }
 
+/// Sign-stable JIT counters that read 0 in a healthy run, the same badness
+/// fields the native `[jit-stats]` line reports (`pyrex` maybe_print_jit_stats).
+/// A nonzero value means a trace aborted or an internal compile bug degraded
+/// the trace, never a tuning choice — so `check.py`'s regression floor can gate
+/// wasm on them exactly as it gates the native backends. Exported (not imported)
+/// so reading them cannot perturb the JIT's table/function indices.
+#[cfg(all(target_arch = "wasm32", feature = "wasm-host"))]
+#[unsafe(no_mangle)]
+pub extern "C" fn pyre_jit_loops_aborted() -> u64 {
+    pyre_jit::eval::driver_pair().0.get_stats().loops_aborted as u64
+}
+
+#[cfg(all(target_arch = "wasm32", feature = "wasm-host"))]
+#[unsafe(no_mangle)]
+pub extern "C" fn pyre_jit_internal_compile_panics() -> u64 {
+    pyre_jit::eval::driver_pair().0.get_stats().internal_compile_panics as u64
+}
+
 #[cfg(any(feature = "web", feature = "wasm-host"))]
 static PANIC_HOOK: Once = Once::new();
 


### PR DESCRIPTION
Eight changes stacked on `nbody` (rebased onto current `main`).

## 1. Leave NONE holes for unboxed vstack TOS results

`reconcile_vstack_at_boundary`'s `VstackOpClass::ResultToTos` arm previously
kept the prior `vstack_last_ref` when the result was produced in an unboxed
bank (`vstack_last_ref == OpRef::NONE`), publishing a stale box into the
capture overlay. The arm now writes `vstack_last_ref` unconditionally when
`new_depth > 0`; a `NONE` result leaves an intentional hole so the guard-capture
overlay omits the slot and resume rematerializes it.

Strictly narrowing: a real `Ref` result is unchanged; only the unboxed case
(previously a wrong-box publish) now defers. Local-safe subset of the Ref-bank
unboxed-int rematerialize work; the full interior-coordinate fix stays on the
walker Layer-3 frontier.

## 2. Retire 10 dead gate rows in gate-triage re-audit

Doc-only. `pyre/gate-triage.md` re-audited on `nbody`: 10 gates listed as
live/kept/deferred had already had their env readers deleted by closed epics
(0 `.rs` read sites remain — verified). Added §1c recording the retirement with
per-gate PR/commit attribution, struck the stale rows at every location, and
recounted the summary buckets. Still-live gates (`PYRE_PROBE_AUTHORITATIVE`,
`PYRE_P2_DRAIN`, `PYRE_FBW_VABLE_SCALAR_CA`) left intact.

## 3. Publish the nonstandard-virtualizable promote guard through the multi-frame resume chain

The `_nonstandard_virtualizable` PTR_EQ promote `GuardValue` emitted inside an
inline sub-walk was captured by `walker_capture_inline_nonstandard_vable_guard`
with a hardcoded sentinel resume word (`NO_JITCODE_PC`), which
`resolve_resume_pc_with_jitcode_pc` rejects — so every such emit aborted with
`GuardResumeCoordinateUnavailable`, collapsing the guard to a single outer
frame. RPython gives this guard a plain full-framestack resume at its own
`orgpc` (`pyjitpl.py:1120` `_nonstandard_virtualizable` → `1916`
`implement_guard_value(eqbox, pc)` → `2582` `generate_guard(resumepc=orgpc)` →
`2610` `capture_resumedata` walking the whole `MIFrame` chain,
`opencoder.py:819`).

When the paused-caller chain covers the full inline depth (the same gate as the
standard multi-frame guard path), route the guard through
`walker_capture_multi_frame_inline_snapshot`, publishing the callee's own
coordinate plus each paused caller. Because `emit_force_virtualizable` records
`GETFIELD_GC` / `PTR_NE` / `COND_CALL` after the promote, stamp the last *guard*
op: add `capture_snapshot_for_last_guard_op_multi_frame_with_vable_vref` to
majit history and a `stamp_last_guard_op` parameter to the publisher. Keep the
single-frame sentinel as the fallback for a partial chain. Gated
`PYRE_FBW_NSVABLE_MULTIFRAME` (default-on, `=0` restores the sentinel decline).

Infrastructure step toward lifting the depth-≥2 mutating-callee decline (#73):
this guard is a prerequisite for that decline-lift, which stays gated behind
`PYRE_FBW_NESTED_RESID_ABORT` until every downstream wall is cleared. The
promote guard is a runtime tautology (a fresh helper-allocated callee frame is
never pointer-equal to the live caller frame), so its resume is unreachable at
runtime; a malformed snapshot is a loud trace-time encoder abort, never a silent
wrong result.

## 4. Seed inline-callee param concretes into the callee-locals shadow for branching (try_multiframe) inlines

Next wall past change 3 under the decline-lift: a branching callee inlined with
a materialized virtual frame (`emit_new_pyframe_inline_with_params`) hit
`GotoIfNotValueNotConcrete` at its own first in-body branch after a may-force.

`CalleeLocalsShadow` is the walker's per-inline-level MIFrame-register analog —
recording-time concretes that survive a may-force heapcache clear. The
forward-inline sub-walk seeded it from the callee's param boxes only on the
`!try_multiframe` (strict fresh-frame fold) path. A `try_multiframe` callee
instead relied on the heapcache forward that the virtual-frame build registers
for its locals array — which any in-callee may-force op wipes wholesale via
`reset_keep_likely_virtuals` (`heapcache.py:183`; parity-faithful — RPython
wipes the same for `CALL_MAY_FORCE`, `heapcache.py:376`). The post-call
LOAD_FAST re-read of a param then missed the heapcache and produced a
non-concrete value.

The fix seeds `set_concrete(callee_portal_frame_reg, slot, concrete)` for the
`try_multiframe` params too, so the post-call `getarrayitem_vable` read
fallback (`getarrayitem_vable_via_metainterp`, written for exactly "a
loop-carried local read after a may-force op") recovers the param concrete —
the analog of the callee MIFrame register box RPython reads `box.getint()` off
(registers survive a residual; the heapcache does not). The register-to-register
fold (`fold_frame_reg` + `set_opref`) stays gated to `!try_multiframe` (it
bypasses the real virtual frame, so the recorded op stream is byte-identical —
only the Void-fallback gains recovery). `STORE_FAST` already re-seeds the shadow
via the `setarrayitem_vable` handler; the bridge-carrier subwalk already does
the identical seeding for reconstructed callees — the forward multiframe inline
was the one unseeded path. The inline virtual frame has no concrete allocation,
so no residual can reach it and no escape revalidation is needed.

## 5. Re-resolve the callee-locals shadow reads through the GC-forwarded op-table

Hardening follow-up to change 4. `CalleeLocalsShadow.concrete` stores a raw
`majit_ir::Value` copy, and the trace-ref walker does not visit `callee_shadow`
(it lives in `WalkContext`, not `TraceCtx`), so a `Value::Ref` copy held there
is not forwarded when a minor collection moves a nursery object. A Ref param
allocated in-walk and seeded into the shadow could dangle if an in-callee
may-force residual triggered a minor GC before the post-call LOAD_FAST re-read;
change 4 widened this from the strict-fold/carrier paths to the forward inline
params.

The `getarrayitem_vable` read fallback now prefers re-resolving the slot's SSA
OpRef through `concrete_of_opref` (the op-table value channel, which IS
GC-forwarded) over the raw `concrete` copy, falling back to the copy only when
the OpRef carries no live concrete (ints/floats are value copies of immutable
payloads, always safe). To keep the two maps consistent so the preferred OpRef
is never stale: `set_opref` is now seeded on the try_multiframe param path too
(the fold consumer stays gated by `fold_frame_reg`, so it is inert for folding),
and the `setarrayitem_vable` non-fold re-seed updates `set_opref` alongside
`set_concrete` on every store (matching the strict-fold store path). The OpRef
is consulted only when a frame-matched `concrete` entry exists, so the per-frame
isolation the `frame_reg` filter gives `concrete` also bounds the re-resolution.

## 6. Exception-edge bridge routing to the in-frame except handler (gated, default-off)

Adds `exc_edge_bridge_enabled()` (`PYRE_EXC_EDGE_BRIDGE`, default-off). When set,
an exception-guard bridge whose failing guard is caught in-frame routes the walk
to the in-frame `except` handler instead of declining to the blackhole — the
parity companion to the callee-inline decline-lift (changes 3–5), which needs an
exception edge to deliver a raise across an inlined call boundary.

- `jitcode_dispatch`: `find_catch_before_resume_live` selects the opcode's catch
  (backward op scan bounded by the call's post-call `-live-`);
  `exc_handler_rejoins_loop` proves the handler reaches a `jit_merge_point`
  (route) vs terminates at a `*_return` (decline). `dispatch_via_miframe` emits
  the `SAVE_EXC_CLASS` / `SAVE_EXCEPTION` / `RESTORE_EXCEPTION` + `GUARD_EXCEPTION`
  resumption at bridge-entry, stamps the restored-exception concrete onto the
  `SAVE_EXCEPTION` box, enters the handler-entry vstack, and walks from the catch
  target. New `DispatchError::ExcEdgeCrossFrameReturnUnsupported` aborts a
  cross-frame-return handler before any recording.
- `call_jit`: `route_exc_edge` (`caught_in_frame && !is_multiframe_resume &&
  enabled`) publishes the grabbed exception into `BH_LAST_EXC_VALUE` and skips
  the pending-exc decline; clears a stale `BH_LAST_EXC_VALUE` on exception-free
  bridges; skips the legacy call-site exception prologue when routing is on.

Default-off: the OFF path is byte-identical to `main` + changes 1–5; no corpus
behavior changes until the gate is flipped as part of the multi-frame exc-edge
work.

## 7. Describe the portal runner in the blackhole recursive-portal resume descr

`blackhole_resume_via_rd_numb` wired the traced function's own frame-based
residual-call descr (`bh.jitcode.calldescr`, `arg_classes` "r") into
`BhJitDriverSd.mainjitcode_calldescr`. `get_portal_runner`
(`blackhole.py:1095-1099`) returns that descr paired with `bh_portal_runner`,
and the recursive-portal resume (`bhimpl_recursive_call_r` → `bh_call_r`)
verifies the merged green+red argument banks against it — so it must describe
the runner, not the traced function. `bh_portal_runner` consumes the warmspot
`portalfunc_ARGS` (`warmspot.py:972-975`): greens `[next_instr:i,
is_being_profiled:i, pycode:r]` + reds `[frame:r, ec:r]`
(`interp_jit.py:67-68`) = 2 int + 3 ref. Set `arg_classes` to "iirrr" and
`result_type` to 'r' so the descr matches the runner it is paired with.

Latent on `main` — no corpus test reaches the blackhole recursive-portal resume
path (the `PYRE_FBW_NESTED_RESID_ABORT` decline keeps every nested-residual
inline off it). It is a prerequisite of the depth-≥2 decline-lift (changes 3–5):
under `PYRE_FBW_NESTED_RESID_ABORT=0` the traced-descr mismatch panicked
`BhCallDescr` (`arg_classes "r"` has 0 int slots vs 2 merged int args); with the
runner descr the recursive-portal resume verifies the banks correctly.

## 8. Register the deque iterator `#[pyre_class]` types in `build_gc`

Rebasing onto current `main` surfaced a pre-existing native breakage from #682
(stdlib compat): it added `_collections._deque_iterator` /
`_deque_reverse_iterator` (`W_DequeIter` / `W_DequeRevIter`) as `#[pyre_class]`
types, each holding an inline `deque: PyObjectRef` child, but never wired them
into `build_gc`. Their resolved tid stayed `UNASSIGNED`, so malloc stamped tid 0
(`object`: empty offsets) and the marker forwarded none of their children — the
source deque swept while the iterator is live. The GC-root completeness oracle
(`eval.rs`, `cfg(not(wasm32))`) flagged both on every native JIT init, so every
dynasm/cranelift corpus test panicked (wasm PASS: oracle is native-only).

Register each via `register_pyre_class` at the auto-id tail, mirroring `W_Deque`
(#635's "immortal iterators + deque backing list" registration, same bug class),
and re-export the payloads from the `_collections` module so `build_gc` can name
their descriptors. Not part of the #73 JIT work — an independent
main-is-broken fix folded in to unblock this branch's native verification.

## Validation

`python pyre/check.py` → **dynasm 241/241, cranelift 241/241 ALL PASSED**; wasm
239 passed, 1 skipped, **1 pre-existing fail** (`synth/selfrec_tail_exception_unwind`,
see below). Rebased onto current `main` (#674 gh#343 depth-2 recursive inline +
PYPY_GC_MAX, #647 EXTENDED_ARG reset, #682 stdlib compat, #676 loop-perf).
Changes 3, 4, 6 and 7 are default-invisible for the depth-2 witnesses (change 6
only with `PYRE_EXC_EDGE_BRIDGE=1`; changes 3/4/7 only with the decline lifted).

**Native was broken on `main` before change 8** (#682's unregistered deque
iterators panicked every dynasm/cranelift init); change 8 restores it — this
branch is 241/241 native where `main` is 0/241.

**Pre-existing wasm failure, not introduced here.** `synth/selfrec_tail_exception_unwind`
(added by #647) fails on wasm with `TypeError: unsupported operand type(s) for
+: 'int' and 'ZeroDivisionError'` — the self-recursive `CALL_ASSEMBLER`
exception unwind consumes the raised value into the recursive-call return slot.
Confirmed pre-existing by a 3-way A/B: it fails identically (a) with all 8
commits, (b) with change 7's descr reverted, and (c) on pristine `origin/main`
with none of these commits. It reproduces only on wasm, where
`PYRE_FBW_REC_MULTIFRAME` (#674, default-on) is hard-on because the guest cannot
read env vars; native (env-readable, same default-on) passes. Root cause is a
`main`-side wasm resume miscompile, out of scope for this branch.

Rebase note: the only content conflict was change 3's
`fbw_nsvable_multiframe_enabled` gate landing next to #674's
`fbw_rec_multiframe_enabled` default-ON flip in `fbw_state.rs` — resolved as a
blend (both gates kept, #674's default-ON doc preserved). Change 7's descr edit
and #674's per-frame `virtualizable_ptr` binding coexist in
`blackhole_resume_via_rd_numb` with no collision.

— *authored by Claude*
