### PR TITLE
objspace: pypy-parity sweep batch (attribute lookup, bool/hash/coerce/iter edge cases)

### DIFF
--- a/majit/majit-metainterp/src/history.rs
+++ b/majit/majit-metainterp/src/history.rs
@@ -2382,10 +2382,6 @@ impl TraceCtx {
             frames: recorder_frames,
             vable_boxes: vable_boxes.to_vec(),
             vref_boxes: vref_boxes.to_vec(),
-            // The nested-list append fold resumes through the single-frame
-            // collapse, never this multi-frame path, so no extra virtual roots
-            // flow here.
-            extra_virtual_roots: Vec::new(),
         });
         self.set_last_guard_op_resume_position(snapshot_id);
     }

--- a/pyre/bench/oserror_errno_fields_regression.py
+++ b/pyre/bench/oserror_errno_fields_regression.py
@@ -4,37 +4,54 @@
 # FileExistsError(17).  Native-only: the wasm guest has no os/filesystem
 # (open() raises NotImplementedError, `import os` has no posix backend), so
 # this guard is registered with skip_backends=("wasm",).  Behaviour verified
-# against CPython/PyPy.  The mkdir target is os.getcwd() rather than "/" so
-# the EEXIST path is exercised identically on POSIX and Windows (where "/"
-# is a drive root that raises access-denied, not EEXIST).
+# against CPython/PyPy.
+#
+# The mkdir target is a freshly created temp directory rather than "/" or the
+# cwd: "/" is a Windows drive root (access-denied, not EEXIST) and the cwd is
+# in-use on Windows (also access-denied), whereas a temp dir gives EEXIST on
+# both POSIX and Windows.  The errno/strerror/args *values* are asserted only
+# on POSIX; Windows maps different errno numbers and strerror text, so there
+# the guard checks the exception type and that the fields are populated.
 import os
+import tempfile
 
-PATH = "/no/such/file/xyz_pyre_probe"
+POSIX = os.name == "posix"
+MISSING = os.path.join(tempfile.gettempdir(), "no_such_file_xyz_pyre_probe")
+EXISTING = tempfile.mkdtemp(prefix="pyre_eexist_")
 
 
 def check():
     try:
-        open(PATH, "r")
+        open(MISSING, "r")
     except FileNotFoundError as e:
         assert type(e).__name__ == "FileNotFoundError", type(e).__name__
-        assert e.errno == 2, e.errno
         assert isinstance(e.strerror, str), e.strerror
-        assert e.args == (2, e.strerror), e.args
-        assert e.filename == PATH, e.filename
+        assert e.filename == MISSING, e.filename
+        if POSIX:
+            assert e.errno == 2, e.errno
+            assert e.args == (2, e.strerror), e.args
+        else:
+            assert e.errno is not None, e.errno
     else:
         raise AssertionError("open() of a missing path did not raise")
 
     try:
-        os.mkdir(os.getcwd())
+        os.mkdir(EXISTING)
     except FileExistsError as e:
         assert type(e).__name__ == "FileExistsError", type(e).__name__
-        assert e.errno == 17, e.errno
         assert isinstance(e.strerror, str), e.strerror
-        assert e.args == (17, e.strerror), e.args
+        if POSIX:
+            assert e.errno == 17, e.errno
+            assert e.args == (17, e.strerror), e.args
+        else:
+            assert e.errno is not None, e.errno
     else:
-        raise AssertionError("os.mkdir of the cwd did not raise")
+        raise AssertionError("os.mkdir of an existing path did not raise")
 
 
-for _ in range(200):
-    check()
+try:
+    for _ in range(200):
+        check()
+finally:
+    os.rmdir(EXISTING)
 print("PASS")

--- a/pyre/bench/oserror_errno_fields_regression.py
+++ b/pyre/bench/oserror_errno_fields_regression.py
@@ -1,0 +1,38 @@
+# A failed syscall raises the errno-specific OSError subclass with
+# .errno/.strerror/.filename set and args=(errno, strerror): open() of a
+# missing path -> FileNotFoundError(2), os.mkdir of an existing path ->
+# FileExistsError(17).  Native-only: the wasm guest has no os/filesystem
+# (open() raises NotImplementedError, `import os` has no posix backend), so
+# this guard is registered with skip_backends=("wasm",).  Behaviour verified
+# against CPython/PyPy.
+import os
+
+PATH = "/no/such/file/xyz_pyre_probe"
+
+
+def check():
+    try:
+        open(PATH, "r")
+    except FileNotFoundError as e:
+        assert type(e).__name__ == "FileNotFoundError", type(e).__name__
+        assert e.errno == 2, e.errno
+        assert isinstance(e.strerror, str), e.strerror
+        assert e.args == (2, e.strerror), e.args
+        assert e.filename == PATH, e.filename
+    else:
+        raise AssertionError("open() of a missing path did not raise")
+
+    try:
+        os.mkdir("/")
+    except FileExistsError as e:
+        assert type(e).__name__ == "FileExistsError", type(e).__name__
+        assert e.errno == 17, e.errno
+        assert isinstance(e.strerror, str), e.strerror
+        assert e.args == (17, e.strerror), e.args
+    else:
+        raise AssertionError("os.mkdir('/') did not raise")
+
+
+for _ in range(200):
+    check()
+print("PASS")

--- a/pyre/bench/oserror_errno_fields_regression.py
+++ b/pyre/bench/oserror_errno_fields_regression.py
@@ -6,18 +6,21 @@
 # this guard is registered with skip_backends=("wasm",).  Behaviour verified
 # against CPython/PyPy.
 #
-# The mkdir target is a freshly created temp directory rather than "/" or the
-# cwd: "/" is a Windows drive root (access-denied, not EEXIST) and the cwd is
-# in-use on Windows (also access-denied), whereas a temp dir gives EEXIST on
-# both POSIX and Windows.  The errno/strerror/args *values* are asserted only
-# on POSIX; Windows maps different errno numbers and strerror text, so there
-# the guard checks the exception type and that the fields are populated.
+# Both fixtures come from `os` alone: a pid-named directory this script
+# creates in the cwd, rather than tempfile.mkdtemp, so the guard stays
+# independent of the shutil import chain.  The mkdir target has to be a
+# directory of its own because "/" is a drive root on Windows and the cwd is
+# in use there, and both report access-denied rather than EEXIST.
+#
+# The errno numbers are asserted on every platform, Windows included: the
+# posix module is the one installed there too, and the OS error kind is
+# translated back to a POSIX errno on the way into OSError.
 import os
-import tempfile
 
-POSIX = os.name == "posix"
-MISSING = os.path.join(tempfile.gettempdir(), "no_such_file_xyz_pyre_probe")
-EXISTING = tempfile.mkdtemp(prefix="pyre_eexist_")
+MISSING = "pyre_enoent_probe_missing_file"
+EXISTING = "pyre_eexist_probe_dir_%d" % os.getpid()
+
+os.mkdir(EXISTING)
 
 
 def check():
@@ -25,13 +28,10 @@ def check():
         open(MISSING, "r")
     except FileNotFoundError as e:
         assert type(e).__name__ == "FileNotFoundError", type(e).__name__
+        assert e.errno == 2, e.errno
         assert isinstance(e.strerror, str), e.strerror
         assert e.filename == MISSING, e.filename
-        if POSIX:
-            assert e.errno == 2, e.errno
-            assert e.args == (2, e.strerror), e.args
-        else:
-            assert e.errno is not None, e.errno
+        assert e.args == (2, e.strerror), e.args
     else:
         raise AssertionError("open() of a missing path did not raise")
 
@@ -39,12 +39,9 @@ def check():
         os.mkdir(EXISTING)
     except FileExistsError as e:
         assert type(e).__name__ == "FileExistsError", type(e).__name__
+        assert e.errno == 17, e.errno
         assert isinstance(e.strerror, str), e.strerror
-        if POSIX:
-            assert e.errno == 17, e.errno
-            assert e.args == (17, e.strerror), e.args
-        else:
-            assert e.errno is not None, e.errno
+        assert e.args == (17, e.strerror), e.args
     else:
         raise AssertionError("os.mkdir of an existing path did not raise")
 

--- a/pyre/bench/oserror_errno_fields_regression.py
+++ b/pyre/bench/oserror_errno_fields_regression.py
@@ -4,7 +4,9 @@
 # FileExistsError(17).  Native-only: the wasm guest has no os/filesystem
 # (open() raises NotImplementedError, `import os` has no posix backend), so
 # this guard is registered with skip_backends=("wasm",).  Behaviour verified
-# against CPython/PyPy.
+# against CPython/PyPy.  The mkdir target is os.getcwd() rather than "/" so
+# the EEXIST path is exercised identically on POSIX and Windows (where "/"
+# is a drive root that raises access-denied, not EEXIST).
 import os
 
 PATH = "/no/such/file/xyz_pyre_probe"
@@ -23,14 +25,14 @@ def check():
         raise AssertionError("open() of a missing path did not raise")
 
     try:
-        os.mkdir("/")
+        os.mkdir(os.getcwd())
     except FileExistsError as e:
         assert type(e).__name__ == "FileExistsError", type(e).__name__
         assert e.errno == 17, e.errno
         assert isinstance(e.strerror, str), e.strerror
         assert e.args == (17, e.strerror), e.args
     else:
-        raise AssertionError("os.mkdir('/') did not raise")
+        raise AssertionError("os.mkdir of the cwd did not raise")
 
 
 for _ in range(200):

--- a/pyre/bench/posix_replace_regression.py
+++ b/pyre/bench/posix_replace_regression.py
@@ -1,0 +1,67 @@
+# os.replace(src, dst) renames over an existing destination in one step and
+# leaves no source behind, where os.rename is the raw platform call.  It is
+# what importlib._bootstrap_external._write_atomic uses to publish a .pyc, so
+# the name has to exist before the write-atomic path can run at all.
+# Native-only: the wasm guest has no filesystem, so this guard is registered
+# with skip_backends=("wasm",).  Behaviour verified against CPython/PyPy.
+#
+# The fixtures live in a pid-named directory this script creates in the cwd
+# rather than under tempfile, so the guard stays independent of the shutil
+# import chain.
+import os
+
+BASE = "pyre_replace_probe_%d" % os.getpid()
+SRC = os.path.join(BASE, "src")
+DST = os.path.join(BASE, "dst")
+
+os.mkdir(BASE)
+
+
+def write(path, text):
+    f = open(path, "w")
+    try:
+        f.write(text)
+    finally:
+        f.close()
+
+
+def read(path):
+    f = open(path, "r")
+    try:
+        return f.read()
+    finally:
+        f.close()
+
+
+def check():
+    # A destination that does not exist yet: plain move.
+    write(SRC, "first")
+    os.replace(SRC, DST)
+    assert not os.path.exists(SRC), "source survived the replace"
+    assert read(DST) == "first", read(DST)
+
+    # A destination that does exist: overwritten, no error.
+    write(SRC, "second")
+    os.replace(SRC, DST)
+    assert not os.path.exists(SRC), "source survived the overwrite"
+    assert read(DST) == "second", read(DST)
+
+    # A missing source reports ENOENT through the errno-specific subclass.
+    try:
+        os.replace(os.path.join(BASE, "absent"), DST)
+    except FileNotFoundError as e:
+        assert e.errno == 2, e.errno
+    else:
+        raise AssertionError("os.replace of a missing source did not raise")
+
+
+try:
+    for _ in range(200):
+        check()
+finally:
+    if os.path.exists(DST):
+        os.unlink(DST)
+    if os.path.exists(SRC):
+        os.unlink(SRC)
+    os.rmdir(BASE)
+print("PASS")

--- a/pyre/bench/synth/aiter_anext.py
+++ b/pyre/bench/synth/aiter_anext.py
@@ -1,0 +1,67 @@
+# aiter()/anext() builtins over an async iterator: aiter returns the async
+# iterator, anext drives it item by item, and the two-argument anext yields the
+# default once the iterator is exhausted. Also covers the three TypeError paths
+# (not an async iterable, not an async iterator, __aiter__ returning a
+# non-async-iterator). Coroutines are stepped by hand so no event loop is
+# needed.
+def drive(coro):
+    try:
+        while True:
+            coro.send(None)
+    except StopIteration as e:
+        return e.value
+
+
+class ARange:
+    def __init__(self, n):
+        self.n = n
+        self.i = 0
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        if self.i >= self.n:
+            raise StopAsyncIteration
+        v = self.i
+        self.i += 1
+        return v
+
+
+def main():
+    it = ARange(3)
+    ait = aiter(it)
+    print("aiter returns self:", ait is it)
+
+    out = []
+    while True:
+        try:
+            out.append(drive(anext(ait)))
+        except StopAsyncIteration:
+            break
+    print("collected:", out)
+
+    print("anext default:", drive(anext(ait, "DONE")))
+    print("anext default2:", drive(anext(ait, 42)))
+
+    try:
+        aiter(object())
+    except TypeError as e:
+        print("aiter err:", e)
+
+    try:
+        anext(object())
+    except TypeError as e:
+        print("anext err:", e)
+
+    class Bad:
+        def __aiter__(self):
+            return 123
+
+    try:
+        aiter(Bad())
+    except TypeError as e:
+        print("aiter bad-return err:", e)
+
+
+main()

--- a/pyre/bench/synth/attr_instance_shadows_class.py
+++ b/pyre/bench/synth/attr_instance_shadows_class.py
@@ -1,0 +1,46 @@
+# An instance attribute shadows a same-named non-data-descriptor class
+# attribute on builtin-type subclasses (tuple/int/str), while a data descriptor
+# still wins over the instance dict. Output verified against CPython/PyPy.
+N = 30000
+
+
+class T(tuple):
+    x = "class"
+
+
+class I(int):
+    x = "class"
+
+
+class S(str):
+    x = "class"
+
+
+class DataD:
+    def __get__(self, o, tp):
+        return "data"
+
+    def __set__(self, o, v):
+        pass
+
+
+class TD(tuple):
+    d = DataD()
+
+
+def main():
+    n = 0
+    for i in range(N):
+        t = T([1, 2])
+        t.x = "inst"
+        a = I(5)
+        a.x = "inst"
+        s = S("hi")
+        s.x = "inst"
+        td = TD([1])
+        if t.x == "inst" and a.x == "inst" and s.x == "inst" and td.d == "data":
+            n += 1
+    print(n)
+
+
+main()

--- a/pyre/bench/synth/attr_instance_shadows_class.py
+++ b/pyre/bench/synth/attr_instance_shadows_class.py
@@ -1,6 +1,8 @@
 # An instance attribute shadows a same-named non-data-descriptor class
 # attribute on builtin-type subclasses (tuple/int/str), while a data descriptor
-# still wins over the instance dict. Output verified against CPython/PyPy.
+# still wins over a competing instance-dict entry (injected directly, since the
+# data descriptor's no-op __set__ never writes __dict__). Output verified
+# against CPython/PyPy.
 N = 30000
 
 
@@ -38,6 +40,7 @@ def main():
         s = S("hi")
         s.x = "inst"
         td = TD([1])
+        td.__dict__["d"] = "inst"
         if t.x == "inst" and a.x == "inst" and s.x == "inst" and td.d == "data":
             n += 1
     print(n)

--- a/pyre/bench/synth/attr_instance_shadows_class.py
+++ b/pyre/bench/synth/attr_instance_shadows_class.py
@@ -32,7 +32,7 @@ class TD(tuple):
 
 def main():
     n = 0
-    for i in range(N):
+    for _ in range(N):
         t = T([1, 2])
         t.x = "inst"
         a = I(5)

--- a/pyre/bench/synth/bases_reassign_cache.py
+++ b/pyre/bench/synth/bases_reassign_cache.py
@@ -1,0 +1,59 @@
+# Reassigning type.__bases__ recomputes the MRO of the type and every
+# subclass and invalidates the method/attribute lookup cache, so a method or
+# class attribute that was resolved before the swap resolves through the new
+# base afterwards.
+def main():
+    class A:
+        def who(self):
+            return "A"
+
+    class B:
+        def who(self):
+            return "B"
+
+    class C(A):
+        pass
+
+    class CC(C):
+        pass
+
+    c = C()
+    cc = CC()
+    print(c.who(), cc.who())  # prime the cache on the old hierarchy
+    C.__bases__ = (B,)
+    print(c.who(), cc.who())
+    print([t.__name__ for t in C.__mro__])
+    print([t.__name__ for t in CC.__mro__])
+
+    # data attribute follows the swap too
+    class D:
+        x = 1
+
+    class E:
+        x = 2
+
+    class F(D):
+        pass
+
+    f = F()
+    print(f.x)
+    F.__bases__ = (E,)
+    print(f.x)
+
+    # a method only defined on the new base becomes reachable
+    class G:
+        pass
+
+    class H:
+        def hello(self):
+            return "H"
+
+    class I(G):
+        pass
+
+    i = I()
+    I.__bases__ = (H,)
+    print(i.hello())
+
+
+main()

--- a/pyre/bench/synth/bool_dunder_error_no_leak.py
+++ b/pyre/bench/synth/bool_dunder_error_no_leak.py
@@ -1,0 +1,31 @@
+# A __bool__ that raises surfaces the error exactly once; the interpreter does
+# not stash a duplicate pending exception that resurfaces on a later unrelated
+# statement. Output verified against CPython/PyPy.
+N = 20000
+
+
+class Boom:
+    def __bool__(self):
+        raise ValueError("boom")
+
+
+def check(b):
+    try:
+        if b:
+            return "no-raise"
+    except ValueError:
+        pass
+    # A leaked pending error would resurface on this call boundary.
+    return str(len("ok"))
+
+
+def main():
+    b = Boom()
+    n = 0
+    for i in range(N):
+        if check(b) == "2":
+            n += 1
+    print(n)
+
+
+main()

--- a/pyre/bench/synth/bool_dunder_error_no_leak.py
+++ b/pyre/bench/synth/bool_dunder_error_no_leak.py
@@ -22,7 +22,7 @@ def check(b):
 def main():
     b = Boom()
     n = 0
-    for i in range(N):
+    for _ in range(N):
         if check(b) == "2":
             n += 1
     print(n)

--- a/pyre/bench/synth/bytes_split_whitespace_maxsplit.py
+++ b/pyre/bench/synth/bytes_split_whitespace_maxsplit.py
@@ -1,0 +1,22 @@
+# bytes/bytearray split/rsplit on whitespace (sep=None) with a positive
+# maxsplit keeps the surrounding whitespace of the final remainder field,
+# matching str. Output verified against CPython/PyPy.
+N = 20000
+
+
+def main():
+    hits = 0
+    for _ in range(N):
+        ok = (
+            b"  a  b  ".split(None, 1) == [b"a", b"b  "]
+            and b"  a  b  c  ".rsplit(None, 1) == [b"  a  b", b"c"]
+            and bytearray(b"x  y  z  ").split(None, 1)
+            == [bytearray(b"x"), bytearray(b"y  z  ")]
+            and b"a b c".split(None, 1) == [b"a", b"b c"]
+        )
+        if ok:
+            hits += 1
+    print(hits)
+
+
+main()

--- a/pyre/bench/synth/callable_iterator_type.py
+++ b/pyre/bench/synth/callable_iterator_type.py
@@ -1,0 +1,22 @@
+# iter(callable, sentinel) yields a properly-registered iterator type: type(it)
+# is a real type object, the iterator is an object instance, and __iter__
+# returns self. The concrete type name differs across implementations, so only
+# the structural type-identity invariants are compared. Output verified against
+# CPython/PyPy.
+N = 40000
+
+
+def f():
+    return 1
+
+
+def main():
+    n = 0
+    for i in range(N):
+        it = iter(f, 0)
+        if isinstance(type(it), type) and isinstance(it, object) and iter(it) is it:
+            n += 1
+    print(n)
+
+
+main()

--- a/pyre/bench/synth/callable_iterator_type.py
+++ b/pyre/bench/synth/callable_iterator_type.py
@@ -12,7 +12,7 @@ def f():
 
 def main():
     n = 0
-    for i in range(N):
+    for _ in range(N):
         it = iter(f, 0)
         if isinstance(type(it), type) and isinstance(it, object) and iter(it) is it:
             n += 1

--- a/pyre/bench/synth/complex_from_index.py
+++ b/pyre/bench/synth/complex_from_index.py
@@ -12,7 +12,7 @@ class Idx:
 def main():
     obj = Idx()
     acc = 0.0
-    for i in range(N):
+    for _ in range(N):
         c = complex(obj)
         acc += c.real
     print(complex(obj), acc == N * 3.0)

--- a/pyre/bench/synth/complex_from_index.py
+++ b/pyre/bench/synth/complex_from_index.py
@@ -1,0 +1,21 @@
+# complex() falls back to __index__ when a value defines neither __complex__
+# nor __float__, matching float()'s coercion. Output verified against
+# CPython/PyPy.
+N = 40000
+
+
+class Idx:
+    def __index__(self):
+        return 3
+
+
+def main():
+    obj = Idx()
+    acc = 0.0
+    for i in range(N):
+        c = complex(obj)
+        acc += c.real
+    print(complex(obj), acc == N * 3.0)
+
+
+main()

--- a/pyre/bench/synth/complex_real_imag.py
+++ b/pyre/bench/synth/complex_real_imag.py
@@ -1,0 +1,25 @@
+# complex.real / complex.imag are read-only getset descriptors bound to the
+# complex type: they carry __objclass__ == complex and __name__, reject a
+# non-complex receiver with TypeError, and reject assignment with
+# AttributeError. (The descriptor type name and the exact TypeError/AttributeError
+# text are not printed here: they diverge between the reference interpreters.)
+def main():
+    c = complex(3, -4)
+    print(c.real, c.imag)
+    print(complex.real.__get__(c), complex.imag.__get__(c))
+    print(complex.real.__objclass__.__name__, complex.imag.__objclass__.__name__)
+    print(complex.real.__name__, complex.imag.__name__)
+    for bad in ["x", 42, 3.0]:
+        try:
+            complex.real.__get__(bad)
+            print("no raise")
+        except TypeError:
+            print("TypeError")
+    try:
+        c.real = 1
+        print("no raise")
+    except AttributeError:
+        print("AttributeError")
+
+
+main()

--- a/pyre/bench/synth/enumerate_bignum_start.py
+++ b/pyre/bench/synth/enumerate_bignum_start.py
@@ -1,0 +1,15 @@
+# enumerate(iterable, start) accepts an arbitrary-precision start past i64,
+# activating the bigint index slot instead of raising OverflowError. Output
+# verified against CPython/PyPy.
+N = 20000
+BIG = 2**63
+
+
+def main():
+    last = None
+    for i in range(N):
+        last = list(enumerate(["a", "b", "c"], BIG))
+    print(last)
+
+
+main()

--- a/pyre/bench/synth/enumerate_bignum_start.py
+++ b/pyre/bench/synth/enumerate_bignum_start.py
@@ -7,7 +7,7 @@ BIG = 2**63
 
 def main():
     last = None
-    for i in range(N):
+    for _ in range(N):
         last = list(enumerate(["a", "b", "c"], BIG))
     print(last)
 

--- a/pyre/bench/synth/exception_dict_slot_reject.py
+++ b/pyre/bench/synth/exception_dict_slot_reject.py
@@ -1,0 +1,20 @@
+# A subclass whose base already carries an instance dict rejects a second
+# `__dict__` slot. BaseException subclasses carry the dict through the native
+# exception slot, so they must reject it too.
+def main():
+    for base in (Exception, BaseException, ValueError):
+        try:
+            type("E", (base,), {"__slots__": ("__dict__",)})
+            print(base.__name__, "+ slots(__dict__): no error")
+        except TypeError as e:
+            print(base.__name__, "+ slots(__dict__):", e)
+
+    # object base has no instance dict, so the slot is allowed
+    try:
+        type("S", (object,), {"__slots__": ("__dict__",)})
+        print("object + slots(__dict__): OK")
+    except TypeError as e:
+        print("object + slots(__dict__):", e)
+
+
+main()

--- a/pyre/bench/synth/format_z_negative_zero.py
+++ b/pyre/bench/synth/format_z_negative_zero.py
@@ -1,0 +1,36 @@
+# PEP 682 `z` format option: coerce a negative-zero result to positive zero.
+# The float renderings below are byte-identical across CPython and PyPy; the
+# integer `z` rejection differs only in message wording, so this fixture checks
+# its exception type instead.
+
+float_cases = [
+    ("z.2f", -0.0),
+    ("z.2f", -0.04),
+    ("z.1f", -0.04),
+    ("z.2f", -1.5),
+    ("z.2f", 0.0),
+    ("z.2f", 1.5),
+    ("z.3e", -0.0004),
+    ("z.1e", -0.04),
+    ("z.2e", -0.0),
+    ("z.2g", -0.0004),
+    ("+z.2f", -0.0),
+    (" z.2f", -0.0),
+    ("z10.2f", -0.0004),
+    ("z.0f", -0.4),
+    ("z%", -0.0),
+    ("z", -0.0),
+    ("z.2f", -1e-10),
+]
+for spec, val in float_cases:
+    print(f"{spec!r:8} {val!r:8} -> {format(val, spec)!r}")
+
+# `z` alone requires a float presentation type; an integer rejects it.
+try:
+    format(5, "z")
+    print("int z: no error")
+except ValueError as e:
+    print(f"int z: ValueError (msg-len {len(str(e)) > 0})")
+
+# A float presentation code on an int keeps working with `z` present.
+print("int z.2f ->", format(5, "z.2f"))

--- a/pyre/bench/synth/hash_subclass_disabled.py
+++ b/pyre/bench/synth/hash_subclass_disabled.py
@@ -24,7 +24,7 @@ def main():
     a = T([1, 2])
     b = F([1, 2])
     n = 0
-    for i in range(N):
+    for _ in range(N):
         if (
             kind(lambda: hash(a)) == "TypeError"
             and kind(lambda: {a}) == "TypeError"

--- a/pyre/bench/synth/hash_subclass_disabled.py
+++ b/pyre/bench/synth/hash_subclass_disabled.py
@@ -1,0 +1,37 @@
+# A tuple/frozenset subclass that sets __hash__ = None is unhashable: hash()
+# and set insertion both raise TypeError instead of the structural fast path
+# hashing by contents. Output verified against CPython/PyPy.
+N = 20000
+
+
+class T(tuple):
+    __hash__ = None
+
+
+class F(frozenset):
+    __hash__ = None
+
+
+def kind(fn):
+    try:
+        fn()
+    except TypeError:
+        return "TypeError"
+    return "ok"
+
+
+def main():
+    a = T([1, 2])
+    b = F([1, 2])
+    n = 0
+    for i in range(N):
+        if (
+            kind(lambda: hash(a)) == "TypeError"
+            and kind(lambda: {a}) == "TypeError"
+            and kind(lambda: hash(b)) == "TypeError"
+        ):
+            n += 1
+    print(T.__hash__, n)
+
+
+main()

--- a/pyre/bench/synth/import_from_name_path.py
+++ b/pyre/bench/synth/import_from_name_path.py
@@ -1,0 +1,25 @@
+# A failed `from X import Y` raises ImportError carrying `.name` (the module)
+# and `.path` (its source file), per error.py new_import_error. The absolute
+# path is install-dependent, so only its basename is checked.  `keyword` is a
+# pure-Python stdlib module importable on every backend (including wasm, which
+# has no `os`/`posix`).  Output verified against CPython/PyPy.
+N = 4000
+
+
+def main():
+    ok = 0
+    for _ in range(N):
+        try:
+            from keyword import _no_such_name_xyz_
+        except ImportError as e:
+            if (
+                type(e).__name__ == "ImportError"
+                and e.name == "keyword"
+                and isinstance(e.path, str)
+                and e.path.endswith("keyword.py")
+            ):
+                ok += 1
+    print(ok)
+
+
+main()

--- a/pyre/bench/synth/import_none_sentinel.py
+++ b/pyre/bench/synth/import_none_sentinel.py
@@ -1,0 +1,29 @@
+# A None entry in sys.modules blocks the name: the import raises
+# ModuleNotFoundError('import of X halted; None in sys.modules') with .name set,
+# rather than reloading the module or searching for it. The sentinel is checked
+# before any search, so it applies to a name that was never importable too, and
+# it reaches the `from X import Y` form through the same lookup. Output verified
+# against CPython/PyPy.
+import sys
+
+
+def blocked(name, statement):
+    sys.modules[name] = None
+    try:
+        exec(statement)
+    except ImportError as e:
+        print(type(e).__name__, "|", e, "| name=", e.name)
+    else:
+        print(statement, "did not raise")
+    finally:
+        del sys.modules[name]
+
+
+def main():
+    for _ in range(200):
+        blocked("errno", "import errno")
+        blocked("pyre_never_a_real_module", "import pyre_never_a_real_module")
+        blocked("pyre_never_a_real_pkg", "from pyre_never_a_real_pkg import thing")
+
+
+main()

--- a/pyre/bench/synth/int_base0_error_literal.py
+++ b/pyre/bench/synth/int_base0_error_literal.py
@@ -1,0 +1,11 @@
+# `int(s, 0)` reports the offending literal verbatim, keeping any surrounding
+# whitespace, rather than the internally trimmed value.
+def main():
+    for s in ("   ", "  x  ", " 0b12 "):
+        try:
+            int(s, 0)
+        except ValueError as e:
+            print(str(e))
+
+
+main()

--- a/pyre/bench/synth/int_from_bad_dunder.py
+++ b/pyre/bench/synth/int_from_bad_dunder.py
@@ -1,0 +1,21 @@
+# int() rejects a __int__ result that is not an int with TypeError (not an
+# internal RuntimeError). Output verified against CPython/PyPy.
+N = 40000
+
+
+class BadInt:
+    def __int__(self):
+        return 1.5
+
+
+def main():
+    caught = 0
+    for i in range(N):
+        try:
+            int(BadInt())
+        except TypeError:
+            caught += 1
+    print(caught)
+
+
+main()

--- a/pyre/bench/synth/int_from_bad_dunder.py
+++ b/pyre/bench/synth/int_from_bad_dunder.py
@@ -10,7 +10,7 @@ class BadInt:
 
 def main():
     caught = 0
-    for i in range(N):
+    for _ in range(N):
         try:
             int(BadInt())
         except TypeError:

--- a/pyre/bench/synth/int_max_str_digits.py
+++ b/pyre/bench/synth/int_max_str_digits.py
@@ -1,0 +1,43 @@
+# PEP 674 integer string-conversion length limit: sys.get/set_int_max_str_digits
+# with the default 4300, enforced on str()/repr()/f-string of a large int and on
+# int() parsing of a long decimal literal, bypassed for power-of-two bases, and
+# disabled by a limit of 0. (Error text and whether an explicit format code
+# enforces the limit both diverge between the reference interpreters, so only the
+# exception type is printed here.)
+import sys
+
+
+def main():
+    print(sys.get_int_max_str_digits())
+    print(len(str(10 ** 4299)))  # exactly 4300 digits -> allowed
+
+    for label, fn in [
+        ("over", lambda: str(10 ** 4300)),
+        ("neg", lambda: str(-(10 ** 5000))),
+        ("repr", lambda: repr(10 ** 5000)),
+        ("fstr", lambda: f"{10 ** 5000}"),
+        ("parse", lambda: int("1" * 5000)),
+    ]:
+        try:
+            fn()
+            print(label, "ok")
+        except ValueError:
+            print(label, "ValueError")
+
+    sys.set_int_max_str_digits(6000)
+    print(sys.get_int_max_str_digits())
+    print(len(str(10 ** 5000)))  # 5001 digits <= 6000 -> allowed
+
+    try:
+        sys.set_int_max_str_digits(100)  # below threshold -> rejected
+        print("set100 ok")
+    except ValueError:
+        print("set100 ValueError")
+
+    sys.set_int_max_str_digits(0)  # 0 disables the limit
+    print(len(str(10 ** 5000)))
+
+    print(int("f" * 5000, 16) > 0)  # base 16 bypasses the limit
+
+
+main()

--- a/pyre/bench/synth/iter_sentinel_stopiteration.py
+++ b/pyre/bench/synth/iter_sentinel_stopiteration.py
@@ -1,6 +1,10 @@
 # When the callable of iter(callable, sentinel) raises StopIteration, the
-# iterator latches exhausted and surfaces a bare StopIteration; the callable's
-# StopIteration value does not leak to the consumer.
+# consumer sees a plain StopIteration and a list-consuming loop treats it as
+# normal end-of-iteration. The callable's StopIteration *args* are not printed:
+# whether they leak is CPython-version-sensitive (the exact args differ across
+# 3.x point releases), so it trips a spurious cpython-vs-pypy baseline mismatch
+# and cannot be a synthetic fixture. pyre matching pypy on the bare args is
+# verified separately.
 def main():
     def boom():
         raise StopIteration("leaked message")
@@ -9,8 +13,8 @@ def main():
     try:
         next(it)
         print("no error")
-    except StopIteration as e:
-        print("args:", e.args)
+    except StopIteration:
+        print("stopiteration surfaced")
 
     # a plain list-consuming loop swallows it as normal end-of-iteration
     def make_counter():

--- a/pyre/bench/synth/iter_sentinel_stopiteration.py
+++ b/pyre/bench/synth/iter_sentinel_stopiteration.py
@@ -1,0 +1,30 @@
+# When the callable of iter(callable, sentinel) raises StopIteration, the
+# iterator latches exhausted and surfaces a bare StopIteration; the callable's
+# StopIteration value does not leak to the consumer.
+def main():
+    def boom():
+        raise StopIteration("leaked message")
+
+    it = iter(boom, 42)
+    try:
+        next(it)
+        print("no error")
+    except StopIteration as e:
+        print("args:", e.args)
+
+    # a plain list-consuming loop swallows it as normal end-of-iteration
+    def make_counter():
+        state = {"n": 0}
+
+        def step():
+            state["n"] += 1
+            if state["n"] > 3:
+                raise StopIteration
+            return state["n"]
+
+        return step
+
+    print("collected:", list(iter(make_counter(), 999)))
+
+
+main()

--- a/pyre/bench/synth/len_dunder_validation.py
+++ b/pyre/bench/synth/len_dunder_validation.py
@@ -1,0 +1,35 @@
+# `len()` runs the `__len__` result through `__index__` coercion and the
+# length checks: negative -> ValueError, non-int -> TypeError, and a value
+# too large for a machine word -> OverflowError.
+def check(cls):
+    try:
+        print(len(cls()))
+    except (ValueError, TypeError, OverflowError) as e:
+        print(type(e).__name__, e)
+
+
+def main():
+    class Neg:
+        def __len__(self):
+            return -1
+
+    class Float:
+        def __len__(self):
+            return 1.5
+
+    class Big:
+        def __len__(self):
+            return 2 ** 100
+
+    class Idx:
+        def __len__(self):
+            class I:
+                def __index__(self):
+                    return 3
+            return I()
+
+    for cls in (Neg, Float, Big, Idx):
+        check(cls)
+
+
+main()

--- a/pyre/bench/synth/list_length_hint_validate.py
+++ b/pyre/bench/synth/list_length_hint_validate.py
@@ -1,0 +1,58 @@
+# list(iterable) and list.extend(iterable) consult __length_hint__ before
+# iterating (listobject.py _extend_from_iterable -> space.length_hint), which
+# validates it: a negative hint raises ValueError, one exceeding a C ssize_t
+# raises OverflowError.  A valid hint is used transparently.  Only the
+# exception type is checked (the OverflowError message is install-specific).
+# Output verified against CPython/PyPy.
+N = 5000
+
+
+def make(hint):
+    class E:
+        def __iter__(self):
+            return iter((1, 2, 3))
+
+        def __length_hint__(self):
+            return hint
+
+    return E()
+
+
+def classify_list(hint):
+    try:
+        list(make(hint))
+        return "ok"
+    except ValueError:
+        return "ValueError"
+    except OverflowError:
+        return "OverflowError"
+
+
+def classify_extend(hint):
+    try:
+        r = []
+        r.extend(make(hint))
+        return "ok"
+    except ValueError:
+        return "ValueError"
+    except OverflowError:
+        return "OverflowError"
+
+
+def main():
+    hits = 0
+    for _ in range(N):
+        ok = (
+            classify_list(-1) == "ValueError"
+            and classify_list(2 ** 63) == "OverflowError"
+            and classify_list(5) == "ok"
+            and classify_extend(-1) == "ValueError"
+            and classify_extend(2 ** 63) == "OverflowError"
+            and classify_extend(10) == "ok"
+        )
+        if ok:
+            hits += 1
+    print(hits)
+
+
+main()

--- a/pyre/bench/synth/list_nan_identity.py
+++ b/pyre/bench/synth/list_nan_identity.py
@@ -1,0 +1,26 @@
+# A NaN in an all-float list: the same NaN object is found by index/count/
+# containment and compares equal in list == / <= (bit-pattern identity), even
+# though `nan == nan` is false. Output verified against CPython/PyPy.
+N = 20000
+
+
+def main():
+    x = float("nan")
+    hits = 0
+    for i in range(N):
+        L = [1.0, x, 2.0]
+        ok = (
+            L.index(x) == 1
+            and L.count(x) == 1
+            and (x in L)
+            and ([x] == [x])
+            and ([1.0, x] == [1.0, x])
+            and ([x] <= [x])
+            and not ([x] < [x])
+        )
+        if ok:
+            hits += 1
+    print(hits)
+
+
+main()

--- a/pyre/bench/synth/list_nan_identity.py
+++ b/pyre/bench/synth/list_nan_identity.py
@@ -7,7 +7,7 @@ N = 20000
 def main():
     x = float("nan")
     hits = 0
-    for i in range(N):
+    for _ in range(N):
         L = [1.0, x, 2.0]
         ok = (
             L.index(x) == 1

--- a/pyre/bench/synth/metaclass_conflict.py
+++ b/pyre/bench/synth/metaclass_conflict.py
@@ -1,0 +1,58 @@
+# An unrelated-metaclass clash among the bases (or an explicit metaclass that
+# is not a subclass of a base's metaclass) is a hard TypeError, not silently
+# resolved to the first metaclass.
+class M1(type):
+    pass
+
+
+class M2(type):
+    pass
+
+
+class M3(M1):
+    pass
+
+
+class A(metaclass=M1):
+    pass
+
+
+class B(metaclass=M2):
+    pass
+
+
+class D(metaclass=M3):
+    pass
+
+
+def main():
+    # class-statement inference: A(M1) + B(M2) clash
+    try:
+        class C(A, B):
+            pass
+        print("class C(A,B): no error")
+    except TypeError as e:
+        print("class C(A,B):", e)
+
+    # explicit metaclass that clashes with a base's metaclass
+    try:
+        class E(A, metaclass=M2):
+            pass
+        print("class E(A,meta=M2): no error")
+    except TypeError as e:
+        print("class E(A,meta=M2):", e)
+
+    # 3-arg type() inference clash
+    try:
+        type("F", (A, B), {})
+        print("type(F,(A,B)): no error")
+    except TypeError as e:
+        print("type(F,(A,B)):", e)
+
+    # more-derived metaclass wins with no clash (M1 + M3 subclass -> M3)
+    class G(A, D):
+        pass
+    print("G meta:", type(G).__name__)
+
+
+main()

--- a/pyre/bench/synth/metaclass_getattribute_delattr.py
+++ b/pyre/bench/synth/metaclass_getattribute_delattr.py
@@ -1,0 +1,78 @@
+# A metaclass overriding __getattribute__ / __delattr__ intercepts class
+# attribute reads / deletes (`C.x`, `del C.x`), replacing the builtin
+# type.__getattribute__ / type.__delattr__.  objspace.py:664 runs the
+# __getattribute__ gate on space.type(C) — the metaclass — for a type
+# receiver.  A __getattribute__ raising AttributeError falls back to the
+# metaclass __getattr__.  Ordinary classes (metaclass=type) are unaffected.
+# Output verified against CPython/PyPy.
+N = 5000
+
+
+class Meta1(type):
+    def __getattribute__(cls, name):
+        if name == "boom":
+            return "META[" + name + "]"
+        return type.__getattribute__(cls, name)
+
+
+class C1(metaclass=Meta1):
+    x = 1
+
+
+class Meta2(type):
+    def __getattribute__(cls, name):
+        if name == "missing":
+            raise AttributeError(name)
+        return type.__getattribute__(cls, name)
+
+    def __getattr__(cls, name):
+        return "GETATTR[" + name + "]"
+
+
+class C2(metaclass=Meta2):
+    y = 2
+
+
+class Meta3(type):
+    def __delattr__(cls, name):
+        recorded.append(name)
+
+
+recorded = []
+
+
+class C3(metaclass=Meta3):
+    pass
+
+
+def main():
+    hits = 0
+    for _ in range(N):
+        ok = (
+            C1.boom == "META[boom]"               # __getattribute__ intercepts read
+            and C1.x == 1                         # delegated to type.__getattribute__
+            and C2.missing == "GETATTR[missing]"  # AttributeError -> __getattr__
+            and C2.y == 2
+        )
+        if ok:
+            hits += 1
+
+    # metaclass __delattr__ intercepts and records without removing the key
+    n_before = len(recorded)
+    del C3.marker
+    if recorded[n_before:] == ["marker"]:
+        hits += 1
+
+    # ordinary class: normal read / delete still work
+    class Plain:
+        a = 10
+
+    if Plain.a == 10:
+        del Plain.a
+        if not hasattr(Plain, "a"):
+            hits += 1
+
+    print(hits)
+
+
+main()

--- a/pyre/bench/synth/reversed_disabled.py
+++ b/pyre/bench/synth/reversed_disabled.py
@@ -1,0 +1,35 @@
+# reversed() treats `__reversed__ = None` as not reversible (even with a
+# sequence protocol) and propagates a raised __reversed__ instead of yielding a
+# corrupt null object. Output verified against CPython/PyPy.
+N = 20000
+
+
+class Disabled:
+    __reversed__ = None
+
+    def __getitem__(self, i):
+        return i
+
+    def __len__(self):
+        return 3
+
+
+class Custom:
+    def __reversed__(self):
+        return iter([9, 8, 7])
+
+
+def main():
+    disabled = 0
+    total = 0
+    for i in range(N):
+        try:
+            reversed(Disabled())
+        except TypeError:
+            disabled += 1
+        total += sum(reversed(Custom()))
+        total += sum(reversed([1, 2, 3]))
+    print(disabled, total)
+
+
+main()

--- a/pyre/bench/synth/seq_repeat_overflow.py
+++ b/pyre/bench/synth/seq_repeat_overflow.py
@@ -10,7 +10,7 @@ BIG = 2**63
 def main():
     over = 0
     ident = 0
-    for i in range(N):
+    for _ in range(N):
         try:
             [0] * BIG
         except OverflowError:
@@ -19,7 +19,7 @@ def main():
         b = b"ab"
         s = "ab"
         lst = [1, 2]
-        if (t * 1 is t) and (b * 1 is b) and (s * 1 is s) and not (lst * 1 is lst):
+        if (t * 1 is t) and (b * 1 is b) and (s * 1 is s) and (lst * 1 is not lst):
             ident += 1
     print(over, ident)
 

--- a/pyre/bench/synth/seq_repeat_overflow.py
+++ b/pyre/bench/synth/seq_repeat_overflow.py
@@ -1,0 +1,27 @@
+# Sequence repeat semantics: a count exceeding the signed machine word overflows
+# (OverflowError) rather than wrapping to a huge unsigned count that fails as
+# MemoryError, and a count of 1 on an immutable exact sequence returns the
+# receiver unchanged while a mutable one copies. Output verified against
+# CPython/PyPy.
+N = 40000
+BIG = 2**63
+
+
+def main():
+    over = 0
+    ident = 0
+    for i in range(N):
+        try:
+            [0] * BIG
+        except OverflowError:
+            over += 1
+        t = (1, 2)
+        b = b"ab"
+        s = "ab"
+        lst = [1, 2]
+        if (t * 1 is t) and (b * 1 is b) and (s * 1 is s) and not (lst * 1 is lst):
+            ident += 1
+    print(over, ident)
+
+
+main()

--- a/pyre/bench/synth/set_method_arity.py
+++ b/pyre/bench/synth/set_method_arity.py
@@ -2,9 +2,9 @@
 # positional-argument count instead of silently accepting it. The exact message
 # text differs between CPython and PyPy, so only the exception type (which they
 # agree on) is compared. Output verified against CPython/PyPy.
-def kind(callable, args):
+def kind(fn, args):
     try:
-        callable(*args)
+        fn(*args)
     except TypeError:
         return "TypeError"
     except KeyError:

--- a/pyre/bench/synth/set_method_arity.py
+++ b/pyre/bench/synth/set_method_arity.py
@@ -1,0 +1,42 @@
+# set/frozenset methods with a fixed arity raise TypeError on a wrong
+# positional-argument count instead of silently accepting it. The exact message
+# text differs between CPython and PyPy, so only the exception type (which they
+# agree on) is compared. Output verified against CPython/PyPy.
+def kind(callable, args):
+    try:
+        callable(*args)
+    except TypeError:
+        return "TypeError"
+    except KeyError:
+        return "KeyError"
+    else:
+        return "ok"
+
+
+def main():
+    s = {1}
+    f = frozenset({1})
+    checks = [
+        kind(s.symmetric_difference, ()),
+        kind(s.symmetric_difference, ({2}, {3})),
+        kind(f.issubset, ()),
+        kind(f.issuperset, ({1}, {2})),
+        kind(f.isdisjoint, ()),
+        kind(f.copy, ({2},)),
+        kind(s.add, ()),
+        kind(s.discard, (1, 2)),
+        kind(s.remove, ()),
+        kind(s.pop, (1,)),
+        kind(s.clear, (1,)),
+        kind(s.symmetric_difference_update, ({2}, {3})),
+    ]
+    print(" ".join(checks))
+    # correct-arity calls still work
+    print(s.symmetric_difference({2}) == {1, 2}, f.isdisjoint({2}))
+    s.add(2)
+    s.discard(2)
+    s.symmetric_difference_update({2})
+    print(s == {1, 2})
+
+
+main()

--- a/pyre/bench/synth/simple_namespace_type.py
+++ b/pyre/bench/synth/simple_namespace_type.py
@@ -1,0 +1,55 @@
+# `types.SimpleNamespace` is a dedicated type: keyword construction into the
+# instance dict, a `namespace(...)` repr, `__dict__` exposure, structural
+# equality, unhashability, and `type(sys.implementation)` identity. Multi-key
+# repr ordering differs between implementations, so only single-key/empty repr
+# and order-independent behaviour are printed. Output verified against
+# CPython/PyPy.
+from types import SimpleNamespace
+
+
+def main():
+    n = SimpleNamespace(a=1, b="x")
+    n.c = 3
+    print(n.a, n.b, n.c)
+    print(repr(SimpleNamespace(only=42)))
+    print(repr(SimpleNamespace()))
+    print(n.__dict__ == {"a": 1, "b": "x", "c": 3})
+    print(SimpleNamespace(a=1, b=2) == SimpleNamespace(b=2, a=1))
+    print(SimpleNamespace(a=1) == SimpleNamespace(a=2))
+    print(SimpleNamespace(a=1) != SimpleNamespace(a=2))
+    print(SimpleNamespace(a=1) == 5)
+    print(SimpleNamespace(a=1) != 5)
+    try:
+        hash(SimpleNamespace())
+        print("HASHABLE")
+    except TypeError:
+        print("unhashable")
+    import sys
+    print(type(n) is type(sys.implementation))
+    print(type(n).__name__, type(n).__qualname__, type(n).__module__)
+
+    class Sub(SimpleNamespace):
+        pass
+
+    s = Sub(z=9)
+    print(s.z, isinstance(s, SimpleNamespace))
+    r = SimpleNamespace()
+    r.self = r
+    print(repr(r))
+
+    # construction updates __dict__ directly, so a subclass __setattr__ is not
+    # invoked while building; a later assignment does go through it.
+    log = []
+
+    class Logged(SimpleNamespace):
+        def __setattr__(self, key, value):
+            log.append(key)
+            object.__setattr__(self, key, value)
+
+    lg = Logged(a=1, b=2)
+    print(log, lg.a, lg.b)
+    lg.c = 3
+    print(log)
+
+
+main()

--- a/pyre/bench/synth/slots_class_var_conflict.py
+++ b/pyre/bench/synth/slots_class_var_conflict.py
@@ -1,0 +1,36 @@
+# A `__slots__` entry naming a class variable raises ValueError at class
+# creation, while a duplicate `__slots__` entry is silently ignored.
+# Output verified against CPython/PyPy.
+N = 5000
+
+
+def make_conflict():
+    class C:
+        __slots__ = ("a",)
+        a = 1
+
+    return C
+
+
+def make_duplicate():
+    class D:
+        __slots__ = ("x", "x")
+
+    return D
+
+
+def main():
+    hits = 0
+    for _ in range(N):
+        try:
+            make_conflict()
+            conflict = "no-error"
+        except ValueError:
+            conflict = "ValueError"
+        dup_ok = make_duplicate() is not None
+        if conflict == "ValueError" and dup_ok:
+            hits += 1
+    print(hits)
+
+
+main()

--- a/pyre/bench/synth/str_encode_text_codec.py
+++ b/pyre/bench/synth/str_encode_text_codec.py
@@ -17,7 +17,7 @@ def kind(codec):
 
 def main():
     n = 0
-    for i in range(N):
+    for _ in range(N):
         r = "".join(kind(c) for c in ("hex", "rot13", "base64", "zlib"))
         if r == "LLLL":
             n += 1

--- a/pyre/bench/synth/str_encode_text_codec.py
+++ b/pyre/bench/synth/str_encode_text_codec.py
@@ -1,0 +1,27 @@
+# str.encode() rejects non-text (binary) codecs with LookupError instead of
+# silently producing bytes: the binary codecs' CodecInfo._is_text_encoding
+# (False, stored on a tuple subclass instance) is honored. Output verified
+# against CPython/PyPy.
+N = 20000
+
+
+def kind(codec):
+    try:
+        "hello".encode(codec)
+    except LookupError:
+        return "L"
+    except Exception:
+        return "E"
+    return "ok"
+
+
+def main():
+    n = 0
+    for i in range(N):
+        r = "".join(kind(c) for c in ("hex", "rot13", "base64", "zlib"))
+        if r == "LLLL":
+            n += 1
+    print(n)
+
+
+main()

--- a/pyre/bench/synth/syntaxerror_location.py
+++ b/pyre/bench/synth/syntaxerror_location.py
@@ -1,0 +1,25 @@
+# A compile-time SyntaxError carries its parser location: msg, lineno, offset,
+# text, filename and end_lineno populate the instance (args is
+# (msg, (filename, lineno, offset, text, end_lineno, end_offset))), and __str__
+# renders 'msg (filename, line N)'.  The message text, offset and end positions
+# differ between parsers, so this fixture asserts only the facts stable across
+# CPython, PyPy and pyre's parser: attribute presence and types, the args
+# shape, and the __str__ structure.
+def main():
+    try:
+        compile("x = (1 +\n", "prog.py", "exec")
+    except SyntaxError as e:
+        print(type(e).__name__)
+        print(e.lineno == 1)
+        print(isinstance(e.offset, int) and e.offset >= 1)
+        print(e.filename == "prog.py")
+        print(isinstance(e.text, str) and "x = (1 +" in e.text)
+        print(isinstance(e.end_lineno, int))
+        print(len(e.args) == 2)
+        print(e.args[0] == e.msg)
+        print(isinstance(e.args[1], tuple) and len(e.args[1]) == 6)
+        print(isinstance(e.msg, str) and str(e).startswith(e.msg))
+        print("prog.py" in str(e) and "line" in str(e))
+
+
+main()

--- a/pyre/bench/synth/syntaxerror_str.py
+++ b/pyre/bench/synth/syntaxerror_str.py
@@ -1,11 +1,12 @@
 # SyntaxError.__str__ renders 'msg (filename, line lineno)', degrading through
 # the filename-only, lineno-only and bare-msg shapes; a non-str msg falls back
 # to str(msg). (The end_lineno range form is not exercised here: PyPy renders
-# 'lines N-M' while CPython keeps 'line N', so the two references diverge.)
+# 'lines N-M' while CPython keeps 'line N', so the two references diverge. A
+# filename carrying directory separators is likewise avoided: basename
+# stripping is os-sep-aware and diverges between the references on Windows.)
 def main():
     cases = [
         SyntaxError("bad", ("f.py", 3, 5, "code")),
-        SyntaxError("bad", ("/a/b/f.py", 3, 5, "code")),
         SyntaxError("bad"),
         SyntaxError(),
         SyntaxError("only msg", (None, 7, 1, "x")),

--- a/pyre/bench/synth/syntaxerror_str.py
+++ b/pyre/bench/synth/syntaxerror_str.py
@@ -1,0 +1,17 @@
+# SyntaxError.__str__ renders 'msg (filename, line lineno)', degrading through
+# the filename-only, lineno-only and bare-msg shapes; a non-str msg falls back
+# to str(msg). (The end_lineno range form is not exercised here: PyPy renders
+# 'lines N-M' while CPython keeps 'line N', so the two references diverge.)
+def main():
+    cases = [
+        SyntaxError("bad", ("f.py", 3, 5, "code")),
+        SyntaxError("bad", ("/a/b/f.py", 3, 5, "code")),
+        SyntaxError("bad"),
+        SyntaxError(),
+        SyntaxError("only msg", (None, 7, 1, "x")),
+    ]
+    for e in cases:
+        print(repr(str(e)))
+
+
+main()

--- a/pyre/bench/synth/tuple_contains_eq_raises.py
+++ b/pyre/bench/synth/tuple_contains_eq_raises.py
@@ -1,0 +1,18 @@
+# containment on a 2-tuple compares elements with `__eq__`; an exception it
+# raises propagates rather than being swallowed into a False result.
+def main():
+    class E:
+        def __eq__(self, o):
+            raise ValueError("boom")
+
+        def __hash__(self):
+            return 1
+
+    for probe in ("(E(), 2)", "(E(), 2, 3)"):
+        try:
+            print(1 in eval(probe))
+        except ValueError as e:
+            print("propagated", e)
+
+
+main()

--- a/pyre/bench/synth/type_dotted_name.py
+++ b/pyre/bench/synth/type_dotted_name.py
@@ -1,0 +1,32 @@
+# type.__name__ / __qualname__ dot handling: a heap type built with a dotted
+# name string (type('a.b', (), {})) keeps the name verbatim on both getters,
+# while a static/builtin dotted tp_name strips to its final component. An
+# explicit __qualname__ in the namespace wins, and nested-class qualnames are
+# preserved.
+import re
+
+
+def main():
+    T = type('mod.Name', (), {})
+    print(T.__name__, T.__qualname__)
+
+    U = type('a.b', (), {'__qualname__': 'Outer.Inner'})
+    print(U.__name__, U.__qualname__)
+
+    class Plain:
+        pass
+
+    print(Plain.__name__, Plain.__qualname__)
+
+    class Outer:
+        class Inner:
+            pass
+
+    print(Outer.Inner.__name__, Outer.Inner.__qualname__)
+
+    pat = type(re.compile(''))
+    print(pat.__name__, pat.__qualname__)
+    print(int.__name__, int.__qualname__)
+
+
+main()

--- a/pyre/bench/synth/type_error_message_parity.py
+++ b/pyre/bench/synth/type_error_message_parity.py
@@ -1,0 +1,44 @@
+# Error-message parity across a few type/builtin operations that both
+# reference implementations word identically.
+def main():
+    class A:
+        pass
+
+    # __class__ must be a class
+    try:
+        A().__class__ = 5
+    except TypeError as e:
+        print(e)
+
+    # empty tuple to __bases__
+    class C(A):
+        pass
+    try:
+        C.__bases__ = ()
+    except TypeError as e:
+        print(e)
+
+    # incompatible solid base names the current best base ('A'), not 'C'
+    class B(int):
+        pass
+    try:
+        C.__bases__ = (B,)
+    except TypeError as e:
+        print(e)
+
+    # next() on a non-iterator names the type
+    for x in (5, [1, 2]):
+        try:
+            next(x)
+        except TypeError as e:
+            print(e)
+
+    # complex.__format__ rejects non-float presentation codes as 'complex'
+    for spec in ("d", "x", "s", "%"):
+        try:
+            format(1 + 2j, spec)
+        except ValueError as e:
+            print(e)
+
+
+main()

--- a/pyre/check.py
+++ b/pyre/check.py
@@ -316,6 +316,27 @@ def pyre_env():
     return env
 
 
+def _dump_failed_run(output, stderr, limit=40):
+    """Print the tail of a failed run's captured streams.
+
+    A self-checking guard reports only its exit code, so without this the
+    traceback that explains the failure never reaches the log and a
+    platform-specific break has to be reconstructed from the source. Bounded to
+    the last *limit* lines of each stream so a runaway script cannot flood CI.
+    """
+    for label, text in (("stdout", output), ("stderr", stderr)):
+        if not text or not text.strip():
+            continue
+        lines = text.rstrip().splitlines()
+        clipped = lines[-limit:]
+        print(f"─── {label} ───")
+        if len(clipped) < len(lines):
+            print(dim(f"... {len(lines) - len(clipped)} earlier line(s) omitted"))
+        for line in clipped:
+            print(line)
+    print("────────────────────")
+
+
 def _jit_panic_reason(stderr):
     """Return a failure reason if *stderr* shows a JIT-level Rust panic or a
     nonzero internal_compile_panics stat, else None.
@@ -1329,11 +1350,13 @@ class Check:
                 )
                 self._record(backend, False, name, detail)
                 print(f"{red('FAIL')}  {detail}")
+                _dump_failed_run(output, stderr)
                 self._append_comparison(backend, name, "-", "-", "FAIL")
                 continue
             if expect not in output:
                 self._record(backend, False, name, f"missing '{expect}'")
                 print(f"{red('FAIL')}  missing '{expect}'")
+                _dump_failed_run(output, stderr)
                 self._append_comparison(backend, name, "-", "-", "FAIL")
                 continue
             self._record(backend, True, name, "")

--- a/pyre/check.py
+++ b/pyre/check.py
@@ -1741,6 +1741,13 @@ def main():
             15,
             skip_backends=("wasm",),
         )
+        # Skipped on wasm for the same reason: os.replace needs a filesystem.
+        chk.run_selfcheck(
+            "posix_replace",
+            f"{B}/posix_replace_regression.py",
+            15,
+            skip_backends=("wasm",),
+        )
 
     if not args.no_synthetic:
         print()

--- a/pyre/check.py
+++ b/pyre/check.py
@@ -1709,6 +1709,15 @@ def main():
             15,
             skip_backends=("wasm",),
         )
+        # Skipped on wasm: the guest has no os/filesystem — open() raises
+        # NotImplementedError and `import os` has no posix backend — so the
+        # errno-specific OSError subclass behaviour is native-JIT-backend only.
+        chk.run_selfcheck(
+            "oserror_errno_fields",
+            f"{B}/oserror_errno_fields_regression.py",
+            15,
+            skip_backends=("wasm",),
+        )
 
     if not args.no_synthetic:
         print()

--- a/pyre/pyre-interpreter/src/async_operation.rs
+++ b/pyre/pyre-interpreter/src/async_operation.rs
@@ -1,0 +1,109 @@
+//! `aiter` / `anext` builtins — PyPy: pypy/module/__builtin__/app_operation.py
+//!
+//! The two names are pure app-level functions in PyPy's MixedModule.  The
+//! builtins module dict is populated inside `ExecutionContext::new`, before
+//! the execution context is registered, so `appleveldef_install` cannot run
+//! at builtins-setup time (there is no execution context yet).  Instead the
+//! two names are registered as interp-level builtin functions that resolve
+//! the app-level implementations lazily on first call, when an execution
+//! context exists — the same lazy-resolution shape `reduce_protocol` uses.
+
+use pyre_object::PyObjectRef;
+
+use crate::PyResult;
+
+/// `aiter` / `anext` ported verbatim from app_operation.py:36-81.  The
+/// `_NOT_PROVIDED` sentinel stays in the intermediate namespace that both
+/// functions retain as their `__globals__`, so only the two public names
+/// need to be surfaced.
+const ASYNC_OP_SRC: &str = r#"
+_NOT_PROVIDED = object()
+
+def aiter(obj):
+    """aiter(async_iterable) -> async_iterator
+    aiter(async_callable, sentinel) -> async_iterator
+    Like the iter() builtin but for async iterables and callables.
+    """
+    typ = type(obj)
+    try:
+        meth = typ.__aiter__
+    except AttributeError:
+        raise TypeError(f"'{type(obj).__name__}' object is not an async iterable")
+    ait = meth(obj)
+    if not hasattr(ait, '__anext__'):
+        raise TypeError(f"aiter() returned not an async iterator of type '{type(ait).__name__}'")
+    return ait
+
+def anext(iterator, default=_NOT_PROVIDED):
+    """anext(async_iterator[, default])
+    Return the next item from the async iterator.
+    If default is given and the iterator is exhausted,
+    it is returned instead of raising StopAsyncIteration.
+    """
+    typ = type(iterator)
+
+    try:
+        __anext__ = typ.__anext__
+    except AttributeError:
+        raise TypeError(f"'{type(iterator).__name__}' object is not an async iterator")
+
+    if default is _NOT_PROVIDED:
+        return __anext__(iterator)
+
+    async def anext_impl():
+        try:
+            return await __anext__(iterator)
+        except StopAsyncIteration:
+            return default
+
+    return anext_impl()
+"#;
+
+const AITER: usize = 0;
+const ANEXT: usize = 1;
+
+thread_local! {
+    static HANDLES: std::cell::OnceCell<[PyObjectRef; 2]> = const { std::cell::OnceCell::new() };
+}
+
+/// Resolve (and cache) the two app-level handles.  Executes `ASYNC_OP_SRC`
+/// into its own fresh module globals and stores the `aiter` / `anext`
+/// function objects; both retain that namespace as their `__globals__`,
+/// keeping the `_NOT_PROVIDED` sentinel reachable.
+fn handle(which: usize) -> PyObjectRef {
+    HANDLES.with(|cell| {
+        cell.get_or_init(|| {
+            let ctx = crate::call::getexecutioncontext();
+            if ctx.is_null() {
+                panic!("async_operation: no execution context");
+            }
+            let _roots = pyre_object::gc_roots::push_roots();
+            let save_point = pyre_object::gc_roots::shadow_stack_len();
+            let w_app_globals = pyre_object::dictmultiobject::w_module_dict_new();
+            pyre_object::gc_roots::pin_root(w_app_globals);
+            crate::importing::appleveldef_install(
+                pyre_object::gc_roots::shadow_stack_get(save_point),
+                ASYNC_OP_SRC,
+                "app_operation.py",
+                &["aiter", "anext"],
+            );
+            let w_app_globals = pyre_object::gc_roots::shadow_stack_get(save_point);
+            let get = |name: &str| {
+                unsafe { pyre_object::w_dict_getitem_str(w_app_globals, name) }
+                    .unwrap_or_else(|| panic!("async_operation: `{name}` not bound"))
+            };
+            [get("aiter"), get("anext")]
+        })[which]
+    })
+}
+
+/// `aiter(obj)` — delegates to the app-level `aiter`, whose `def aiter(obj)`
+/// signature enforces the single-argument arity.
+pub fn builtin_aiter(args: &[PyObjectRef]) -> PyResult {
+    crate::call::call_function_impl_result(handle(AITER), args)
+}
+
+/// `anext(iterator[, default])` — delegates to the app-level `anext`.
+pub fn builtin_anext(args: &[PyObjectRef]) -> PyResult {
+    crate::call::call_function_impl_result(handle(ANEXT), args)
+}

--- a/pyre/pyre-interpreter/src/async_operation.rs
+++ b/pyre/pyre-interpreter/src/async_operation.rs
@@ -62,39 +62,60 @@ def anext(iterator, default=_NOT_PROVIDED):
 const AITER: usize = 0;
 const ANEXT: usize = 1;
 
-thread_local! {
-    static HANDLES: std::cell::OnceCell<[PyObjectRef; 2]> = const { std::cell::OnceCell::new() };
-}
+static HANDLES: std::sync::Mutex<[usize; 2]> = std::sync::Mutex::new([0; 2]);
 
 /// Resolve (and cache) the two app-level handles.  Executes `ASYNC_OP_SRC`
 /// into its own fresh module globals and stores the `aiter` / `anext`
 /// function objects; both retain that namespace as their `__globals__`,
 /// keeping the `_NOT_PROVIDED` sentinel reachable.
 fn handle(which: usize) -> PyObjectRef {
-    HANDLES.with(|cell| {
-        cell.get_or_init(|| {
-            let ctx = crate::call::getexecutioncontext();
-            if ctx.is_null() {
-                panic!("async_operation: no execution context");
-            }
-            let _roots = pyre_object::gc_roots::push_roots();
-            let save_point = pyre_object::gc_roots::shadow_stack_len();
-            let w_app_globals = pyre_object::dictmultiobject::w_module_dict_new();
-            pyre_object::gc_roots::pin_root(w_app_globals);
-            crate::importing::appleveldef_install(
-                pyre_object::gc_roots::shadow_stack_get(save_point),
-                ASYNC_OP_SRC,
-                "app_operation.py",
-                &["aiter", "anext"],
-            );
-            let w_app_globals = pyre_object::gc_roots::shadow_stack_get(save_point);
-            let get = |name: &str| {
-                unsafe { pyre_object::w_dict_getitem_str(w_app_globals, name) }
-                    .unwrap_or_else(|| panic!("async_operation: `{name}` not bound"))
-            };
-            [get("aiter"), get("anext")]
-        })[which]
-    })
+    let cached = HANDLES.lock().unwrap()[which];
+    if cached != 0 {
+        return cached as PyObjectRef;
+    }
+
+    // Do not hold HANDLES while executing Python: applevel installation can
+    // collect, and the root walker below must be able to lock the slots.  The
+    // shadow root keeps the namespace/functions alive until the finished
+    // array is published.  A racing initializer may duplicate this work, but
+    // publication remains atomic under the mutex and either complete set is
+    // equivalent.
+    let ctx = crate::call::getexecutioncontext();
+    if ctx.is_null() {
+        panic!("async_operation: no execution context");
+    }
+    let _roots = pyre_object::gc_roots::push_roots();
+    let save_point = pyre_object::gc_roots::shadow_stack_len();
+    let w_app_globals = pyre_object::dictmultiobject::w_module_dict_new();
+    pyre_object::gc_roots::pin_root(w_app_globals);
+    crate::importing::appleveldef_install(
+        pyre_object::gc_roots::shadow_stack_get(save_point),
+        ASYNC_OP_SRC,
+        "app_operation.py",
+        &["aiter", "anext"],
+    );
+    let w_app_globals = pyre_object::gc_roots::shadow_stack_get(save_point);
+    let get = |name: &str| {
+        unsafe { pyre_object::w_dict_getitem_str(w_app_globals, name) }
+            .unwrap_or_else(|| panic!("async_operation: `{name}` not bound"))
+    };
+    let initialized = [get("aiter") as usize, get("anext") as usize];
+    let mut handles = HANDLES.lock().unwrap();
+    if handles[which] == 0 {
+        *handles = initialized;
+    }
+    handles[which] as PyObjectRef
+}
+
+/// RPython's GC transform treats the app-level interphook cache as a normal
+/// object graph.  Pyre stores the equivalent shared handles outside the GC,
+/// so expose each slot to the global root walker and write relocated pointers
+/// back in place.
+pub(crate) fn walk_handle_roots(visitor: &mut dyn FnMut(&mut majit_ir::GcRef)) {
+    let mut handles = HANDLES.lock().unwrap();
+    for slot in handles.iter_mut().filter(|slot| **slot != 0) {
+        unsafe { visitor(&mut *(slot as *mut usize as *mut majit_ir::GcRef)) };
+    }
 }
 
 /// `aiter(obj)` — delegates to the app-level `aiter`, whose `def aiter(obj)`

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -4816,6 +4816,37 @@ fn getattr_str_impl(obj: PyObjectRef, name: &str, call_getattr: bool) -> PyResul
                     name,
                 ),
             );
+        } else if call_getattr && is_type(obj) {
+            // objspace.py:664 runs the `__getattribute__` gate on
+            // `space.type(w_obj)` for every receiver kind.  For a type receiver
+            // that is the metaclass; a metaclass overriding `__getattribute__`
+            // customises class-attribute access (`C.x`), replacing the builtin
+            // `type.__getattribute__` inlined in `object_getattr_miss`.  The
+            // gate returns `None` for the default (metaclass inherits
+            // `object.__getattribute__`), leaving the fast path untouched for
+            // ordinary classes.  Only `space.getattr` (`call_getattr`) routes
+            // here; the bare `object.__getattribute__` slot runs the terminal
+            // lookup without re-dispatching to the override.
+            if let Some(w_metatype) = crate::typedef::r#type(obj) {
+                if let Some(slot) = getattribute_if_not_from_object(w_metatype) {
+                    let name_obj = w_str_new(name);
+                    // objspace.py:666 — bind the metaclass `__getattribute__`
+                    // through `__get__` and call it with the attribute name.
+                    match get_and_call_function(slot, obj, w_metatype, &[name_obj]) {
+                        Ok(v) => return Ok(v),
+                        Err(e) if e.kind == PyErrorKind::AttributeError => {
+                            return type_getattr_hook_or_err(
+                                obj,
+                                &[Some(w_metatype), None],
+                                name,
+                                e,
+                                call_getattr,
+                            );
+                        }
+                        Err(e) => return Err(e),
+                    }
+                }
+            }
         }
     }
 
@@ -9227,6 +9258,23 @@ pub fn delattr_str(obj: PyObjectRef, name: &str) -> PyResult {
                 let w_name = w_str_new(name);
                 return crate::call::call_function_impl_result(da, &[obj, w_name])
                     .map(|_| w_none());
+            }
+        } else if is_type(obj) {
+            // descroperation.py:254 looks up __delattr__ on the receiver type
+            // regardless of receiver kind.  For a type receiver that is the
+            // metaclass; a metaclass overriding __delattr__ customises
+            // `del C.x`.  Only a real override (≠ object.__delattr__) needs
+            // invoking — the default terminal path is object_delattr.
+            if let Some(w_metatype) = crate::typedef::r#type(obj) {
+                if let Some(da) = lookup_in_type(w_metatype, "__delattr__") {
+                    let is_default = lookup_in_type(crate::typedef::w_object(), "__delattr__")
+                        .is_some_and(|d| std::ptr::eq(da, d));
+                    if !is_default {
+                        let w_name = w_str_new(name);
+                        return crate::call::call_function_impl_result(da, &[obj, w_name])
+                            .map(|_| w_none());
+                    }
+                }
             }
         }
     }

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -8482,7 +8482,7 @@ pub(crate) fn descr_set___class__(w_obj: PyObjectRef, w_newcls: PyObjectRef) -> 
         // objectobject.py:139-142 — w_newcls must be a W_TypeObject
         if !is_type(w_newcls) {
             return Err(crate::PyError::type_error(format!(
-                "__class__ must be set to new-style class, not '{}' object",
+                "__class__ must be set to a class, not '{}' object",
                 pyre_object::type_name_of(w_newcls),
             )));
         }
@@ -10055,11 +10055,32 @@ pub fn length_hint(w_obj: PyObjectRef, default: i64) -> Result<i64, crate::PyErr
 /// raise `OverflowError` ("int too large to convert to int") via
 /// `intobject.py:558` / `longobject.py` `_int_w`.
 fn _check_len_result(w_int: PyObjectRef) -> Result<i64, crate::PyError> {
-    let n = int_w(w_int)?;
-    if n < 0 {
+    // `lt(w_int, 0)` — a negative length (including a negative bignum) raises
+    // ValueError, checked before the machine-word fit so it wins over the
+    // OverflowError. `w_int` is already the `space.index` result, so this is a
+    // plain int comparison.
+    let negative = is_true(crate::objspace::descroperation::compare(
+        w_int,
+        pyre_object::w_int_new(0),
+        crate::objspace::descroperation::CompareOp::Lt,
+    )?)?;
+    if negative {
         return Err(crate::PyError::value_error("__len__() should return >= 0"));
     }
-    Ok(n)
+    // `getindex_w(w_int, w_OverflowError)` — a length that does not fit a
+    // machine word reports the source type, `oefmt("cannot fit '%T' into an
+    // index-sized integer", w_obj)`, not the coerced int.
+    match int_w(w_int) {
+        Ok(n) => Ok(n),
+        Err(e) if e.kind == PyErrorKind::OverflowError => Err(PyError::new(
+            PyErrorKind::OverflowError,
+            format!(
+                "cannot fit '{}' into an index-sized integer",
+                object_functionstr_type_name(w_int)
+            ),
+        )),
+        Err(e) => Err(e),
+    }
 }
 
 /// pypy/objspace/descroperation.py:300-302 `len_w`.

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -6920,7 +6920,11 @@ pub fn c_int_w(obj: PyObjectRef) -> Result<i32, PyError> {
 /// baseobjspace.py:1784 text_w.
 pub fn text_w(obj: PyObjectRef) -> Result<&'static str, PyError> {
     if unsafe { !isinstance_str_w(obj) } {
-        return Err(PyError::type_error("expected str"));
+        // `_typed_unwrap_error(space, "str")` — `"expected %s, got %T object"`.
+        return Err(PyError::type_error(format!(
+            "expected str, got {} object",
+            object_functionstr_type_name(obj)
+        )));
     }
     Ok(unsafe { pyre_object::w_str_get_value(obj) })
 }

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -341,7 +341,7 @@ fn exc_blocking_written(obj: PyObjectRef) -> bool {
 /// write lands in the hasdict instance dict: read it first so the write
 /// wins, then derive the construct-time value from `args_w`, and finally
 /// fall back to the `None` class default.
-fn syntax_error_attr(obj: PyObjectRef, name: &str) -> PyObjectRef {
+pub(crate) fn syntax_error_attr(obj: PyObjectRef, name: &str) -> PyObjectRef {
     let w_dict = getdict_backing(obj);
     if !w_dict.is_null() {
         if let Some(v) = unsafe { pyre_object::w_dict_getitem_str(w_dict, name) } {
@@ -12192,9 +12192,12 @@ pub fn next(obj: PyObjectRef) -> PyResult {
                 Err(e) if e.kind == crate::PyErrorKind::StopIteration => {
                     // `calliter_iternext`: when the callable itself raises
                     // `StopIteration`, latch `it_callable` to `PY_NULL` so
-                    // further `next()` stays stopped, then re-raise.
+                    // further `next()` stays stopped. The callable's
+                    // StopIteration is cleared and replaced with a bare one —
+                    // its value/message does not leak to the consumer.
+                    let _ = e;
                     ci::w_callable_iterator_set_callable(obj, pyre_object::PY_NULL);
-                    return Err(e);
+                    return Err(PyError::stop_iteration());
                 }
                 Err(e) => return Err(e),
             };

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -5935,9 +5935,6 @@ fn object_getattr_miss(obj: PyObjectRef, name: &str, call_getattr: bool) -> PyRe
                 }
             }
             if let Some(method) = w_descr {
-                if unsafe { crate::is_function(method) } {
-                    return Ok(pyre_object::w_method_new(method, obj, w_type));
-                }
                 match unsafe { get(method, obj, w_type) } {
                     Ok(Some(result)) => return Ok(result),
                     Ok(None) => {}
@@ -5945,6 +5942,18 @@ fn object_getattr_miss(obj: PyObjectRef, name: &str, call_getattr: bool) -> PyRe
                         return unsafe { instance_getattr_hook_or_err(w_type, obj, name, e) };
                     }
                     Err(e) => return Err(e),
+                }
+                // A plain Python function is the one callable `get` leaves
+                // unhandled; bind it here.  Binding before `get` would also
+                // bind a `BuiltinFunction` class attribute (`class T(tuple):
+                // f = len`), which must stay unbound.
+                if unsafe {
+                    crate::is_function(method)
+                        && !crate::is_builtin_code(
+                            crate::function_get_code(method) as pyre_object::PyObjectRef
+                        )
+                } {
+                    return Ok(pyre_object::w_method_new(method, obj, w_type));
                 }
                 return Ok(method);
             }

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -5865,8 +5865,39 @@ fn object_getattr_miss(obj: PyObjectRef, name: &str, call_getattr: bool) -> PyRe
     // PyPy: space.type(w_obj) → W_TypeObject → MRO lookup in type dict.
     // Each builtin type (list, str, dict, etc.) has a W_TypeObject with
     // methods pre-installed, matching PyPy's TypeDef interpleveldefs.
+    //
     if let Some(w_type) = crate::typedef::r#type(obj) {
-        if let Some(method) = unsafe { lookup_in_type_where(w_type, name) } {
+        // A heap subclass (`class T(tuple): ...`) has its own instance dict, so
+        // an instance attribute must shadow a same-named non-data-descriptor
+        // class attribute. Run the `object.__getattribute__` protocol for such
+        // types: a data descriptor wins, then the instance dict, then a
+        // non-data descriptor / class var. Exact builtins carry no instance
+        // dict (`hasdict` false) and take the direct class-attr fast path.
+        if unsafe { pyre_object::w_type_get_hasdict(w_type) } {
+            let w_descr = unsafe { lookup_in_type_where(w_type, name) };
+            if let Some(descr) = w_descr {
+                if unsafe { is_data_descr(descr) } {
+                    if let Some(result) = unsafe { get(descr, obj, w_type)? } {
+                        return Ok(result);
+                    }
+                }
+            }
+            let w_dict = getdict_backing(obj);
+            if !w_dict.is_null() {
+                if let Some(value) = unsafe { pyre_object::w_dict_getitem_str(w_dict, name) } {
+                    return Ok(value);
+                }
+            }
+            if let Some(method) = w_descr {
+                if unsafe { crate::is_function(method) } {
+                    return Ok(pyre_object::w_method_new(method, obj, w_type));
+                }
+                if let Some(result) = unsafe { get(method, obj, w_type)? } {
+                    return Ok(result);
+                }
+                return Ok(method);
+            }
+        } else if let Some(method) = unsafe { lookup_in_type_where(w_type, name) } {
             if unsafe { crate::is_function(method) } {
                 return Ok(pyre_object::w_method_new(method, obj, w_type));
             }

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -5918,8 +5918,13 @@ fn object_getattr_miss(obj: PyObjectRef, name: &str, call_getattr: bool) -> PyRe
             let w_descr = unsafe { lookup_in_type_where(w_type, name) };
             if let Some(descr) = w_descr {
                 if unsafe { is_data_descr(descr) } {
-                    if let Some(result) = unsafe { get(descr, obj, w_type)? } {
-                        return Ok(result);
+                    match unsafe { get(descr, obj, w_type) } {
+                        Ok(Some(result)) => return Ok(result),
+                        Ok(None) => {}
+                        Err(e) if e.kind == crate::PyErrorKind::AttributeError => {
+                            return unsafe { instance_getattr_hook_or_err(w_type, obj, name, e) };
+                        }
+                        Err(e) => return Err(e),
                     }
                 }
             }
@@ -5933,11 +5938,20 @@ fn object_getattr_miss(obj: PyObjectRef, name: &str, call_getattr: bool) -> PyRe
                 if unsafe { crate::is_function(method) } {
                     return Ok(pyre_object::w_method_new(method, obj, w_type));
                 }
-                if let Some(result) = unsafe { get(method, obj, w_type)? } {
-                    return Ok(result);
+                match unsafe { get(method, obj, w_type) } {
+                    Ok(Some(result)) => return Ok(result),
+                    Ok(None) => {}
+                    Err(e) if e.kind == crate::PyErrorKind::AttributeError => {
+                        return unsafe { instance_getattr_hook_or_err(w_type, obj, name, e) };
+                    }
+                    Err(e) => return Err(e),
                 }
                 return Ok(method);
             }
+            // No type-dict attribute, instance-dict entry, or descriptor
+            // matched.  Fall through to the shared resolvers below (exception
+            // typed slots, function/code attributes, the generic type-dict
+            // path) — the terminal `__getattr__` hook runs at the final miss.
         } else if let Some(method) = unsafe { lookup_in_type_where(w_type, name) } {
             if unsafe { crate::is_function(method) } {
                 return Ok(pyre_object::w_method_new(method, obj, w_type));
@@ -6569,15 +6583,26 @@ fn object_getattr_miss(obj: PyObjectRef, name: &str, call_getattr: bool) -> PyRe
     unsafe {
         // Name the object's type via the tag-safe `typedef::r#type`
         // (a tagged immediate has no `ob_type` slot to deref).
-        let tp_name = match crate::typedef::r#type(obj) {
+        let w_type = crate::typedef::r#type(obj);
+        let tp_name = match w_type {
             Some(tp) => pyre_object::w_type_get_name(tp).to_string(),
             None => "NULL".to_string(),
         };
-        Err(PyError::attribute_error_with_context(
+        let e = PyError::attribute_error_with_context(
             format!("'{tp_name}' object has no attribute '{name}'"),
             obj,
             name,
-        ))
+        );
+        // descroperation.py:243-252 `_handle_getattribute`: on the terminal
+        // miss, `__getattr__` is the last resort.  Gate on `call_getattr` so
+        // `space.getattr` consults the hook while internal lookups propagate
+        // the AttributeError unchanged.
+        if call_getattr {
+            if let Some(w_type) = w_type {
+                return instance_getattr_hook_or_err(w_type, obj, name, e);
+            }
+        }
+        Err(e)
     }
 }
 
@@ -9265,9 +9290,12 @@ pub fn delattr_str(obj: PyObjectRef, name: &str) -> PyResult {
         if is_instance(obj) {
             let w_type = w_instance_get_type(obj);
             if let Some(da) = lookup_in_type(w_type, "__delattr__") {
-                let w_name = w_str_new(name);
-                return crate::call::call_function_impl_result(da, &[obj, w_name])
-                    .map(|_| w_none());
+                let is_default = lookup_in_type(crate::typedef::w_object(), "__delattr__")
+                    .is_some_and(|d| std::ptr::eq(da, d));
+                if !is_default {
+                    let w_name = w_str_new(name);
+                    return get_and_call_function(da, obj, w_type, &[w_name]).map(|_| w_none());
+                }
             }
         } else if is_type(obj) {
             // descroperation.py:254 looks up __delattr__ on the receiver type
@@ -9281,7 +9309,7 @@ pub fn delattr_str(obj: PyObjectRef, name: &str) -> PyResult {
                         .is_some_and(|d| std::ptr::eq(da, d));
                     if !is_default {
                         let w_name = w_str_new(name);
-                        return crate::call::call_function_impl_result(da, &[obj, w_name])
+                        return get_and_call_function(da, obj, w_metatype, &[w_name])
                             .map(|_| w_none());
                     }
                 }

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -5588,14 +5588,24 @@ fn object_getattr_miss(obj: PyObjectRef, name: &str, call_getattr: bool) -> PyRe
                 }
             }
             if name == "__name__" {
-                // `type.__name__` is the bare type name; a dotted tp_name
-                // (e.g. "types.UnionType") carries its module prefix only
-                // in repr, so strip to the final component here.
+                // typeobject.py:626 getname — a heap type keeps its stored
+                // name verbatim (it may legitimately contain a dot when built
+                // via `type('a.b', (), {})`); a static type's dotted tp_name
+                // (e.g. "types.UnionType") carries its module prefix only in
+                // repr, so strip to the final component.
                 let full = w_type_get_name(obj);
-                let bare = full.rsplit('.').next().unwrap_or(full);
+                let bare = if pyre_object::w_type_is_heaptype(obj) {
+                    full
+                } else {
+                    full.rsplit('.').next().unwrap_or(full)
+                };
                 return Ok(w_str_new(bare));
             }
             if name == "__qualname__" {
+                // typeobject.py:637 getqualname returns the stored qualname;
+                // `type_new_take_qualname` popped an explicit class-body
+                // `__qualname__` into it at creation, and the heap/static name
+                // split is already baked into the field.
                 return Ok(w_str_new(pyre_object::w_type_get_qualname(obj)));
             }
             if name == "__mro__" {

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -9144,10 +9144,12 @@ pub(crate) fn builtin_reversed(args: &[PyObjectRef]) -> Result<PyObjectRef, crat
             }
             pyre_object::gc_roots::pin_root(method);
             let method_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
-            return Ok(crate::call_function(
+            // Propagate a raised error from `__reversed__` instead of handing
+            // back a null result.
+            return call_and_check(
                 unsafe { pyre_object::gc_roots::shadow_stack_get(method_slot) },
                 &[unsafe { pyre_object::gc_roots::shadow_stack_get(obj_slot) }],
-            ));
+            );
         }
     }
     // functional.py:351 — without `__reversed__`, require the sequence

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -3660,6 +3660,24 @@ fn type_descr_new_with_metaclass(
         if unsafe { pyre_object::is_str(name_obj) } {
             check_surrogate(name_obj)?;
         }
+        // typeobject.py `type.__new__` — `isinstance_w(w_bases, w_tuple)` and
+        // `isinstance_w(w_dict, w_dict)`: bases must be a tuple and the
+        // namespace a dict (subclasses of each are accepted, e.g. a dict
+        // subclass namespace); neither is silently coerced.
+        let w_tuple_type = crate::typedef::gettypeobject(&pyre_object::pyobject::TUPLE_TYPE);
+        if !unsafe { crate::baseobjspace::isinstance_w(bases, w_tuple_type) } {
+            return Err(crate::PyError::type_error(format!(
+                "type() argument 2 must be tuple, not {}",
+                crate::baseobjspace::object_functionstr_type_name(bases)
+            )));
+        }
+        let w_dict_type = crate::typedef::gettypeobject(&pyre_object::pyobject::DICT_TYPE);
+        if !unsafe { crate::baseobjspace::isinstance_w(w_namespace_dict, w_dict_type) } {
+            return Err(crate::PyError::type_error(format!(
+                "type() argument 3 must be dict, not {}",
+                crate::baseobjspace::object_functionstr_type_name(w_namespace_dict)
+            )));
+        }
         let name = unsafe { pyre_object::w_str_get_value(name_obj) };
 
         // CPython: calculate_metaclass — if bases have a custom metaclass,
@@ -3783,8 +3801,10 @@ fn type_descr_new_with_metaclass(
         } else {
             w_metaclass
         };
-        let w_winner = crate::call::calculate_metaclass(default_meta, w_effective_bases)
-            .unwrap_or(default_meta);
+        // A metaclass conflict among the bases (or an explicit metaclass that
+        // is not a subclass of every base's metaclass) is a hard error, not a
+        // silent fall-back to `default_meta`.
+        let w_winner = crate::call::calculate_metaclass(default_meta, w_effective_bases)?;
         if !std::ptr::eq(w_winner, default_meta) {
             // Winner is a different metaclass — delegate to its __new__
             if let Some(w_metaclass_new) =

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -4283,7 +4283,7 @@ mod wasm_errno {
 /// `interp_exceptions.py:1207-1227 ERRNO_MAP` — the OSError subclass the
 /// exact `OSError` constructor selects for a recognised errno, by
 /// registered class name.  Returns `None` for an unmapped errno.
-fn os_error_errno_subclass(errno: i64) -> Option<&'static str> {
+pub(crate) fn os_error_errno_subclass(errno: i64) -> Option<&'static str> {
     // `ESHUTDOWN` is sourced through `errno_is_eshutdown` (MSVC CRT lacks it);
     // the rest come from `libc`, or the darwin/BSD `wasm_errno` table on wasm32.
     #[cfg(not(target_arch = "wasm32"))]
@@ -10505,9 +10505,9 @@ pub fn builtin_open(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError>
                 Ok(bytes) => bytes,
                 Err(_e) if writing => Vec::new(),
                 Err(e) => {
-                    return Err(crate::PyError::os_error_with_errno(
+                    return Err(crate::PyError::os_error_syscall(
                         e.raw_os_error().unwrap_or(2),
-                        format!("{e}: '{path}'"),
+                        pyre_object::w_str_new(&path),
                     ));
                 }
             }

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -4361,6 +4361,38 @@ pub(crate) fn os_error_errno_subclass(errno: i64) -> Option<&'static str> {
     Some(name)
 }
 
+/// The POSIX errno for a `std::io::Error`, so the errno-specific OSError
+/// subclass (`os_error_errno_subclass`) and the `.errno` slot stay consistent
+/// across platforms.  On Windows `raw_os_error()` reports a Win32 error code
+/// (e.g. `ERROR_ALREADY_EXISTS` 183), not a C errno, so the raw value never
+/// matches the libc constants the subclass table keys on; translate the common
+/// kinds to their POSIX errno through `ErrorKind` (which the standard library
+/// normalises per platform), the way `winerror_to_errno` fills `OSError.errno`
+/// alongside `.winerror`.  Unrecognised kinds keep the raw code.
+pub(crate) fn io_error_posix_errno(e: &std::io::Error) -> i32 {
+    #[cfg(windows)]
+    {
+        use std::io::ErrorKind;
+        let mapped = match e.kind() {
+            ErrorKind::NotFound => Some(libc::ENOENT),
+            ErrorKind::AlreadyExists => Some(libc::EEXIST),
+            ErrorKind::PermissionDenied => Some(libc::EACCES),
+            ErrorKind::ConnectionRefused => Some(libc::ECONNREFUSED),
+            ErrorKind::ConnectionReset => Some(libc::ECONNRESET),
+            ErrorKind::ConnectionAborted => Some(libc::ECONNABORTED),
+            ErrorKind::BrokenPipe => Some(libc::EPIPE),
+            ErrorKind::TimedOut => Some(libc::ETIMEDOUT),
+            ErrorKind::Interrupted => Some(libc::EINTR),
+            ErrorKind::WouldBlock => Some(libc::EWOULDBLOCK),
+            _ => None,
+        };
+        if let Some(errno) = mapped {
+            return errno;
+        }
+    }
+    e.raw_os_error().unwrap_or(0)
+}
+
 /// `_parse_init_args` yields an errno only for a 2..=5 argument call whose
 /// first argument is an int; map that errno to its OSError subclass name.
 fn os_error_errno_subclass_for(args: &[PyObjectRef]) -> Option<&'static str> {
@@ -10560,7 +10592,7 @@ pub fn builtin_open(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError>
                     // bytes path a bytes object (`interp_fileio.py` wraps the raw
                     // `w_name`, not the decoded buffer).
                     return Err(crate::PyError::os_error_syscall(
-                        e.raw_os_error().unwrap_or(2),
+                        io_error_posix_errno(&e),
                         path_obj,
                     ));
                 }

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -7279,14 +7279,32 @@ fn builtin_callable(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError>
 /// bits), `dont_inherit` controls whether the caller's `__future__`
 /// flags are inherited, and `optimize` selects the -1/0/1/2 optimisation
 /// level (assert / `__debug__` / docstring stripping).
-/// Map a compiler failure string to a Python `SyntaxError`, matching
-/// CPython where `compile`/`exec`/`eval`/`ast.parse` raise `SyntaxError`
-/// (not `ValueError`) for malformed source.  The `compile error: ` prefix
-/// `compile_source` prepends is stripped so the message reads like
-/// CPython's (`'yield' outside function`).
-fn compile_err_to_syntax_error(e: String) -> crate::PyError {
-    let msg = e.strip_prefix("compile error: ").unwrap_or(&e).to_string();
-    crate::PyError::syntax_error(msg)
+/// Map a compiler failure to a Python `SyntaxError`, matching where
+/// `compile`/`exec`/`eval`/`ast.parse` raise `SyntaxError` (not
+/// `ValueError`) for malformed source.  The error's `python_location` /
+/// `python_end_location` / `source_path` populate `e.lineno` / `e.offset`
+/// / `e.end_lineno` / `e.end_offset` / `e.filename`, and `e.text` is the
+/// offending line sliced from `source`; a location-less codegen error
+/// (line 0) falls back to a bare, message-only SyntaxError.
+pub fn compile_err_to_syntax_error(e: crate::compile::CompileError, source: &str) -> crate::PyError {
+    let msg = e.to_string();
+    let (lineno, offset) = e.python_location();
+    if lineno == 0 {
+        return crate::PyError::syntax_error(msg);
+    }
+    let (end_lineno, end_offset) = e.python_end_location().unwrap_or((lineno, offset));
+    let filename = e.source_path().to_string();
+    // The offending source line, keeping its trailing newline like `e.text`.
+    let text = source.split_inclusive('\n').nth(lineno - 1);
+    crate::PyError::syntax_error_located(
+        msg,
+        &filename,
+        lineno as i64,
+        offset as i64,
+        end_lineno as i64,
+        end_offset as i64,
+        text,
+    )
 }
 
 /// `pypy/interpreter/astcompiler/consts.py` compilation flag bits.
@@ -7477,13 +7495,9 @@ fn builtin_compile(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> 
         let code_ptr = Box::into_raw(Box::new(code)) as *const ();
         return Ok(crate::w_code_new(code_ptr));
     }
-    let code = crate::compile::compile_source_with_opts(
-        source_str.as_deref().expect("non-AST source"),
-        mode,
-        &filename,
-        opts,
-    )
-    .map_err(compile_err_to_syntax_error)?;
+    let source = source_str.as_deref().expect("non-AST source");
+    let code = crate::compile::compile_source_with_opts(source, mode, &filename, opts)
+        .map_err(|e| compile_err_to_syntax_error(e, source))?;
     let code_ptr = Box::into_raw(Box::new(code)) as *const ();
     Ok(crate::w_code_new(code_ptr))
 }
@@ -7575,8 +7589,8 @@ fn exec_or_eval(
             } else {
                 crate::compile::Mode::Exec
             };
-            let code =
-                crate::compile::compile_source(&s, mode).map_err(compile_err_to_syntax_error)?;
+            let code = crate::compile::compile_source(&s, mode)
+                .map_err(|e| compile_err_to_syntax_error(e, &s))?;
             let code_ptr = Box::into_raw(Box::new(code)) as *const ();
             (crate::w_code_new(code_ptr), false)
         } else if !source.is_null() && crate::is_code(source) {

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -8294,12 +8294,12 @@ pub fn try_hash_value(obj: PyObjectRef) -> Result<i64, crate::PyError> {
             // The concrete builtin advertises `__hash__ = None`, but a user
             // subclass may replace that slot.  PyPy's normal special-method
             // lookup reaches the subclass entry before the inherited typedef
-            // value (Bug #1257731 in CPython's set tests), so only reject the
-            // object after giving a non-None override the call.
+            // value (`descroperation.py:556-565`), so only reject the object
+            // after giving a non-None override the call.
             if let Some(w_type) = crate::typedef::r#type(obj) {
                 if let Some(method) = crate::baseobjspace::lookup_in_type(w_type, "__hash__") {
                     if !pyre_object::is_none(method) {
-                        return hash_call_normalize(method, obj);
+                        return hash_call_normalize(method, obj, w_type);
                     }
                 }
             }
@@ -8340,7 +8340,7 @@ pub fn try_hash_value(obj: PyObjectRef) -> Result<i64, crate::PyError> {
                     let base_hash =
                         base.and_then(|b| crate::baseobjspace::lookup_in_type(b, "__hash__"));
                     if Some(method) != base_hash {
-                        return hash_call_normalize(method, obj);
+                        return hash_call_normalize(method, obj, w_type);
                     }
                 }
             }
@@ -8387,7 +8387,7 @@ pub fn try_hash_value(obj: PyObjectRef) -> Result<i64, crate::PyError> {
                 if pyre_object::is_none(method) {
                     return Err(unhashable_type_error(obj));
                 }
-                return hash_call_normalize(method, obj);
+                return hash_call_normalize(method, obj, w_type);
             }
         }
         // A type may declare itself unhashable via `__hash__ = None`
@@ -8408,7 +8408,7 @@ pub fn try_hash_value(obj: PyObjectRef) -> Result<i64, crate::PyError> {
                 let default_hash =
                     crate::baseobjspace::lookup_in_type(crate::typedef::w_object(), "__hash__");
                 if default_hash != Some(method) {
-                    return hash_call_normalize(method, obj);
+                    return hash_call_normalize(method, obj, w_type);
                 }
             }
         }
@@ -8445,8 +8445,12 @@ fn slice_hash_value(obj: PyObjectRef) -> Result<i64, crate::PyError> {
 /// Call a resolved `__hash__` method and normalize its result:
 /// `descroperation.py:576-579` — accept `bool` / `int` / `long`, reject other
 /// return types, and map a `-1` result to `-2`.
-fn hash_call_normalize(method: PyObjectRef, obj: PyObjectRef) -> Result<i64, crate::PyError> {
-    let r = call_and_check(method, &[obj])?;
+fn hash_call_normalize(
+    method: PyObjectRef,
+    obj: PyObjectRef,
+    w_type: PyObjectRef,
+) -> Result<i64, crate::PyError> {
+    let r = unsafe { crate::baseobjspace::get_and_call_function(method, obj, w_type, &[]) }?;
     let h = unsafe {
         if is_bool(r) {
             pyre_object::w_bool_get_value(r) as i64
@@ -10535,9 +10539,12 @@ pub fn builtin_open(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError>
                 Ok(bytes) => bytes,
                 Err(_e) if writing => Vec::new(),
                 Err(e) => {
+                    // Report the original path object as `.filename`, keeping a
+                    // bytes path a bytes object (`interp_fileio.py` wraps the raw
+                    // `w_name`, not the decoded buffer).
                     return Err(crate::PyError::os_error_syscall(
                         e.raw_os_error().unwrap_or(2),
-                        pyre_object::w_str_new(&path),
+                        path_obj,
                     ));
                 }
             }

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -4368,8 +4368,10 @@ pub(crate) fn os_error_errno_subclass(errno: i64) -> Option<&'static str> {
 /// matches the libc constants the subclass table keys on; translate the common
 /// kinds to their POSIX errno through `ErrorKind` (which the standard library
 /// normalises per platform), the way `winerror_to_errno` fills `OSError.errno`
-/// alongside `.winerror`.  Unrecognised kinds keep the raw code.
-pub(crate) fn io_error_posix_errno(e: &std::io::Error) -> i32 {
+/// alongside `.winerror`.  Unrecognised kinds keep the raw code, and an error
+/// carrying no OS code at all falls back to `default` (the errno each call site
+/// used before the translation existed).
+pub(crate) fn io_error_posix_errno(e: &std::io::Error, default: i32) -> i32 {
     #[cfg(windows)]
     {
         use std::io::ErrorKind;
@@ -4390,7 +4392,7 @@ pub(crate) fn io_error_posix_errno(e: &std::io::Error) -> i32 {
             return errno;
         }
     }
-    e.raw_os_error().unwrap_or(0)
+    e.raw_os_error().unwrap_or(default)
 }
 
 /// `_parse_init_args` yields an errno only for a 2..=5 argument call whose
@@ -10025,7 +10027,7 @@ fn fd_bytes_to_obj(self_obj: PyObjectRef, data: Vec<u8>) -> Result<PyObjectRef, 
 }
 
 fn fd_io_err(e: std::io::Error) -> crate::PyError {
-    crate::PyError::os_error_with_errno(e.raw_os_error().unwrap_or(5), e.to_string())
+    crate::PyError::os_error_with_errno(io_error_posix_errno(&e, 5), e.to_string())
 }
 
 fn file_method_read(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
@@ -10296,7 +10298,7 @@ fn file_method_close(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError
             if unsafe { libc::close(fd) } < 0 {
                 let e = std::io::Error::last_os_error();
                 return Err(crate::PyError::os_error_with_errno(
-                    e.raw_os_error().unwrap_or(0),
+                    io_error_posix_errno(&e, 0),
                     format!("close: {e}"),
                 ));
             }
@@ -10353,7 +10355,7 @@ fn file_flush_dirty(obj: PyObjectRef) -> Result<(), crate::PyError> {
             };
             if let Err(e) = write_res {
                 return Err(crate::PyError::os_error_with_errno(
-                    e.raw_os_error().unwrap_or(5),
+                    io_error_posix_errno(&e, 5),
                     format!("{e}: '{name_s}'"),
                 ));
             }
@@ -10592,7 +10594,7 @@ pub fn builtin_open(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError>
                     // bytes path a bytes object (`interp_fileio.py` wraps the raw
                     // `w_name`, not the decoded buffer).
                     return Err(crate::PyError::os_error_syscall(
-                        io_error_posix_errno(&e),
+                        io_error_posix_errno(&e, 2),
                         path_obj,
                     ));
                 }

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -8286,6 +8286,35 @@ pub fn try_hash_value(obj: PyObjectRef) -> Result<i64, crate::PyError> {
             // read-only view hashes its raw bytes, cached in `_hash`.
             return memoryview_hash_value(obj);
         }
+        // A tuple/frozenset *subclass* can set `__hash__ = None` to become
+        // unhashable, or override `__hash__` with its own method; the
+        // structural fast paths below hash by contents and would ignore both.
+        // For a non-exact receiver consult the `__hash__` slot: `None` raises,
+        // a genuine override dispatches, and the inherited structural hash
+        // falls through to the fast path.
+        let is_tuple_recv = is_tuple(obj);
+        let is_frozenset_recv = pyre_object::is_frozenset(obj);
+        if (is_tuple_recv && !is_exact_type(obj, &TUPLE_TYPE))
+            || (is_frozenset_recv && !is_exact_type(obj, &pyre_object::setobject::FROZENSET_TYPE))
+        {
+            if let Some(w_type) = crate::typedef::r#type(obj) {
+                if let Some(method) = crate::baseobjspace::lookup_in_type(w_type, "__hash__") {
+                    if pyre_object::is_none(method) {
+                        return Err(unhashable_type_error(obj));
+                    }
+                    let base = if is_tuple_recv {
+                        crate::typedef::gettypefor(&TUPLE_TYPE)
+                    } else {
+                        crate::typedef::gettypefor(&pyre_object::setobject::FROZENSET_TYPE)
+                    };
+                    let base_hash =
+                        base.and_then(|b| crate::baseobjspace::lookup_in_type(b, "__hash__"));
+                    if Some(method) != base_hash {
+                        return hash_call_normalize(method, obj);
+                    }
+                }
+            }
+        }
         if is_tuple(obj) {
             let n = w_tuple_len(obj);
             let mut hashes = Vec::with_capacity(n);
@@ -8946,21 +8975,6 @@ pub(crate) fn builtin_zip(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::Py
     ))
 }
 
-/// `pypy/module/__builtin__/functional.py:253-272 W_Enumerate.descr_new`
-/// parity:
-///
-/// ```python
-/// def descr_new(space, w_subtype, w_iterable, w_start=None):
-///     ...
-///     if w_start is None:
-///         start = 0
-///     else:
-///         start = space.index_w(w_start)
-///     ...
-/// ```
-///
-/// `space.index_w` accepts ANY object exposing `__index__`
-/// (subclasses of int, NumPy ints, etc.) — not just exact int.  The
 /// kwarg surface is also strict: anything other than `start=` is a
 /// TypeError per the gateway's parsed signature.
 // `pypy/module/__builtin__/functional.py:253-275 W_Enumerate.descr___new__`

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -2996,10 +2996,10 @@ fn builtin_len(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     // no single-dict value, so route it through the gateway for the faithful
     // `_match_signature` arity error.
     if let [obj] = args {
-        return crate::baseobjspace::len(*obj);
+        return Ok(w_int_new(crate::baseobjspace::len_w(*obj)?));
     }
     let obj = parse_single_required(args, "obj", "len")?;
-    crate::baseobjspace::len(obj)
+    Ok(w_int_new(crate::baseobjspace::len_w(obj)?))
 }
 
 /// `abs(x)` — return the absolute value of a number.

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -7286,7 +7286,10 @@ fn builtin_callable(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError>
 /// / `e.end_lineno` / `e.end_offset` / `e.filename`, and `e.text` is the
 /// offending line sliced from `source`; a location-less codegen error
 /// (line 0) falls back to a bare, message-only SyntaxError.
-pub fn compile_err_to_syntax_error(e: crate::compile::CompileError, source: &str) -> crate::PyError {
+pub fn compile_err_to_syntax_error(
+    e: crate::compile::CompileError,
+    source: &str,
+) -> crate::PyError {
     let msg = e.to_string();
     let (lineno, offset) = e.python_location();
     if lineno == 0 {

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -2152,6 +2152,16 @@ pub fn install_default_builtins(ns: PyObjectRef) {
     crate::module_ns_get_or_insert_with(ns, "next", || {
         make_module_builtin_function("next", builtin_next)
     });
+    // aiter/anext resolve their app-level implementations lazily; the
+    // builtins dict is filled before an execution context exists.  Arity is
+    // enforced by the app-level `def aiter(obj)` / `def anext(iterator,
+    // default=...)` signatures, so no interp-level arity is imposed here.
+    crate::module_ns_get_or_insert_with(ns, "aiter", || {
+        make_module_builtin_function("aiter", crate::async_operation::builtin_aiter)
+    });
+    crate::module_ns_get_or_insert_with(ns, "anext", || {
+        make_module_builtin_function("anext", crate::async_operation::builtin_anext)
+    });
     crate::module_ns_get_or_insert_with(ns, "callable", || {
         make_module_builtin_function_with_arity("callable", builtin_callable, 1)
     });

--- a/pyre/pyre-interpreter/src/call.rs
+++ b/pyre/pyre-interpreter/src/call.rs
@@ -2546,7 +2546,10 @@ pub(crate) fn calculate_metaclass(
             w_winner = w_base_type;
             continue;
         }
-        return Err(PyError::type_error("metaclass conflict"));
+        return Err(PyError::type_error(
+            "metaclass conflict: the metaclass of a derived class must be a \
+             (non-strict) subclass of the metaclasses of all its bases",
+        ));
     }
     Ok(w_winner)
 }
@@ -4207,7 +4210,16 @@ pub unsafe fn create_all_slots(
                 match slot_name.as_str() {
                     // typeobject.py:1165-1169: __dict__ slot
                     "__dict__" => {
-                        if wantdict || pyre_object::w_type_get_hasdict(w_type) {
+                        // A base whose instances already carry a dict disallows
+                        // a second one. Regular classes are flagged `hasdict`;
+                        // BaseException subclasses expose their dict through the
+                        // native exception slot (`w_exception_getdict`) without
+                        // the flag, so check the layout base explicitly.
+                        let base_has_dict = pyre_object::w_type_get_hasdict(w_type)
+                            || (!w_bestbase.is_null()
+                                && crate::builtins::lookup_exc_class("BaseException")
+                                    .is_some_and(|base_exc| issubtype_ptr(w_bestbase, base_exc)));
+                        if wantdict || base_has_dict {
                             return Err(crate::PyError::type_error(
                                 "__dict__ slot disallowed: we already got one".to_string(),
                             ));

--- a/pyre/pyre-interpreter/src/call.rs
+++ b/pyre/pyre-interpreter/src/call.rs
@@ -4244,7 +4244,21 @@ pub unsafe fn create_all_slots(
                 // typeobject.py:1211: slot_name = mangle(slot_name, w_self.name)
                 let mangled = mangle(&newslotnames[i], type_name);
                 if crate::type_dict_contains(w_type, mangled.as_str()) {
-                    // typeobject.py:1219-1220: name conflict → skip this slot
+                    // `create_slot`: a name already present is a conflict — a
+                    // duplicate `__slots__` entry (a Member of this very type)
+                    // is silently ignored, but a class variable of the same
+                    // name is a ValueError.
+                    let is_dup_slot = crate::type_dict_lookup(w_type, mangled.as_str())
+                        .map(|w_prev| unsafe {
+                            pyre_object::is_member(w_prev)
+                                && std::ptr::eq(pyre_object::w_member_get_cls(w_prev), w_type)
+                        })
+                        .unwrap_or(false);
+                    if !is_dup_slot {
+                        return Err(crate::PyError::value_error(format!(
+                            "'{mangled}' in __slots__ conflicts with class variable"
+                        )));
+                    }
                     newslotnames.remove(i);
                 } else {
                     // typeobject.py:1216-1217: create_slot

--- a/pyre/pyre-interpreter/src/compile.rs
+++ b/pyre/pyre-interpreter/src/compile.rs
@@ -11,10 +11,13 @@ pub use rustpython_compiler_core::bytecode::{
 
 /// Compile Python source code to a RustPython CodeObject.
 ///
+/// The filename is the one `exec`/`eval` report for a str source, surfacing
+/// as `co_filename` and as the `SyntaxError.filename` of a failed compile.
+///
 /// The `CompileError` is returned unflattened so the SyntaxError builders
 /// can read its `python_location` / `python_end_location` / `source_path`.
 pub fn compile_source(source: &str, mode: Mode) -> Result<CodeObject, CompileError> {
-    rp_compile(source, mode, "<pyre>".into(), Default::default())
+    rp_compile(source, mode, "<string>".into(), Default::default())
 }
 
 /// Compile Python source code with a custom filename.

--- a/pyre/pyre-interpreter/src/compile.rs
+++ b/pyre/pyre-interpreter/src/compile.rs
@@ -1,5 +1,6 @@
 //! Wrapper around RustPython's compiler to parse and compile Python source.
 
+pub use rustpython_compiler::CompileError;
 pub use rustpython_compiler::CompileOpts;
 pub use rustpython_compiler::Mode;
 pub use rustpython_compiler::compile as rp_compile;
@@ -9,9 +10,11 @@ pub use rustpython_compiler_core::bytecode::{
 };
 
 /// Compile Python source code to a RustPython CodeObject.
-pub fn compile_source(source: &str, mode: Mode) -> Result<CodeObject, String> {
+///
+/// The `CompileError` is returned unflattened so the SyntaxError builders
+/// can read its `python_location` / `python_end_location` / `source_path`.
+pub fn compile_source(source: &str, mode: Mode) -> Result<CodeObject, CompileError> {
     rp_compile(source, mode, "<pyre>".into(), Default::default())
-        .map_err(|e| format!("compile error: {e}"))
 }
 
 /// Compile Python source code with a custom filename.
@@ -21,7 +24,7 @@ pub fn compile_source_with_filename(
     source: &str,
     mode: Mode,
     filename: &str,
-) -> Result<CodeObject, String> {
+) -> Result<CodeObject, CompileError> {
     compile_source_with_opts(source, mode, filename, Default::default())
 }
 
@@ -34,8 +37,8 @@ pub fn compile_source_with_opts(
     mode: Mode,
     filename: &str,
     opts: CompileOpts,
-) -> Result<CodeObject, String> {
-    rp_compile(source, mode, filename.into(), opts).map_err(|e| format!("compile error: {e}"))
+) -> Result<CodeObject, CompileError> {
+    rp_compile(source, mode, filename.into(), opts)
 }
 
 /// Scan the first two lines of `source` for a PEP 263 coding cookie
@@ -183,11 +186,11 @@ pub fn decode_source_bytes(
 }
 
 /// Compile a Python expression.
-pub fn compile_eval(source: &str) -> Result<CodeObject, String> {
+pub fn compile_eval(source: &str) -> Result<CodeObject, CompileError> {
     compile_source(source, Mode::Eval)
 }
 
 /// Compile a Python script (module).
-pub fn compile_exec(source: &str) -> Result<CodeObject, String> {
+pub fn compile_exec(source: &str) -> Result<CodeObject, CompileError> {
     compile_source(source, Mode::Exec)
 }

--- a/pyre/pyre-interpreter/src/display.rs
+++ b/pyre/pyre-interpreter/src/display.rs
@@ -1127,9 +1127,7 @@ unsafe fn exception_descr_str_wtf8(obj: PyObjectRef) -> Result<Option<Wtf8Buf>, 
         if kind == pyre_object::interp_exceptions::ExcKind::SyntaxError {
             let w_msg = crate::baseobjspace::syntax_error_attr(obj, "msg");
             // `type(self.msg) is not str` → `return str(self.msg)`.
-            if w_msg.is_null()
-                || !pyre_object::pyobject::is_exact_type(w_msg, &STR_TYPE)
-            {
+            if w_msg.is_null() || !pyre_object::pyobject::is_exact_type(w_msg, &STR_TYPE) {
                 return Ok(Some(Wtf8Buf::from_string(py_str(w_msg)?)));
             }
             let compose = |extra: Option<Wtf8Buf>| -> Wtf8Buf {

--- a/pyre/pyre-interpreter/src/display.rs
+++ b/pyre/pyre-interpreter/src/display.rs
@@ -973,6 +973,17 @@ pub unsafe fn py_str(obj: PyObjectRef) -> Result<String, crate::PyError> {
                         return Ok(format!("[Errno {errno}] {strerror}"));
                     }
                 }
+                // `interp_exceptions.py:859-883 W_SyntaxError.descr_str` —
+                // a non-str `msg` stringifies plainly; otherwise the message
+                // is suffixed with the `basename(filename)` and `line N` /
+                // `lines N-M` derived from the location attributes.  The
+                // WTF-8 path already implements this; reuse it and drop any
+                // lone surrogates for the plain-`String` caller.
+                pyre_object::interp_exceptions::ExcKind::SyntaxError => {
+                    if let Some(w) = exception_descr_str_wtf8(obj)? {
+                        return Ok(w.to_string_lossy().into_owned());
+                    }
+                }
                 _ => {}
             }
             // A user subclass that overrides `__str__` shadows the builtin

--- a/pyre/pyre-interpreter/src/display.rs
+++ b/pyre/pyre-interpreter/src/display.rs
@@ -1120,6 +1120,70 @@ unsafe fn exception_descr_str_wtf8(obj: PyObjectRef) -> Result<Option<Wtf8Buf>, 
         ) {
             return Ok(None);
         }
+        // `interp_exceptions.py:859 W_SyntaxError.descr_str` — format
+        // `msg (filename, line lineno)`, falling back through the
+        // filename-only, lineno-only, and bare-msg shapes. Shared by the
+        // IndentationError / TabError subclasses (same `ExcKind`).
+        if kind == pyre_object::interp_exceptions::ExcKind::SyntaxError {
+            let w_msg = crate::baseobjspace::syntax_error_attr(obj, "msg");
+            // `type(self.msg) is not str` → `return str(self.msg)`.
+            if w_msg.is_null()
+                || !pyre_object::pyobject::is_exact_type(w_msg, &STR_TYPE)
+            {
+                return Ok(Some(Wtf8Buf::from_string(py_str(w_msg)?)));
+            }
+            let compose = |extra: Option<Wtf8Buf>| -> Wtf8Buf {
+                let mut out = pyre_object::w_str_get_wtf8(w_msg).to_wtf8_buf();
+                if let Some(inner) = extra {
+                    out.push_str(" (");
+                    out.push_wtf8(&inner);
+                    out.push_str(")");
+                }
+                out
+            };
+            // `line %d` / `lines %d-%d` when `end_lineno > lineno`.
+            let w_lineno = crate::baseobjspace::syntax_error_attr(obj, "lineno");
+            let lineno_str: Option<Wtf8Buf> =
+                if pyre_object::pyobject::is_exact_type(w_lineno, &INT_TYPE) {
+                    let lineno = crate::baseobjspace::int_w(w_lineno).unwrap_or(0);
+                    let w_end = crate::baseobjspace::syntax_error_attr(obj, "end_lineno");
+                    let end = if pyre_object::pyobject::is_exact_type(w_end, &INT_TYPE) {
+                        crate::baseobjspace::int_w(w_end).ok()
+                    } else {
+                        None
+                    };
+                    Some(match end {
+                        Some(end) if end > lineno => {
+                            Wtf8Buf::from_string(format!("lines {lineno}-{end}"))
+                        }
+                        _ => Wtf8Buf::from_string(format!("line {lineno}")),
+                    })
+                } else {
+                    None
+                };
+            // `have_filename` → `os.path.basename(self.filename or "???")`.
+            let w_filename = crate::baseobjspace::syntax_error_attr(obj, "filename");
+            if pyre_object::pyobject::is_exact_type(w_filename, &STR_TYPE) {
+                let fbuf = pyre_object::w_str_get_wtf8(w_filename).to_wtf8_buf();
+                let fname = if fbuf.as_bytes().is_empty() {
+                    Wtf8Buf::from_string("???".to_string())
+                } else {
+                    let start = fbuf
+                        .as_bytes()
+                        .iter()
+                        .rposition(|&b| b == b'/')
+                        .map_or(0, |i| i + 1);
+                    fbuf[start..].to_wtf8_buf()
+                };
+                let mut inner = fname;
+                if let Some(l) = lineno_str {
+                    inner.push_str(", ");
+                    inner.push_wtf8(&l);
+                }
+                return Ok(Some(compose(Some(inner))));
+            }
+            return Ok(Some(compose(lineno_str)));
+        }
         let args = pyre_object::interp_exceptions::w_exception_get_args(obj);
         if args.is_null() || !pyre_object::is_tuple(args) {
             return Ok(None);

--- a/pyre/pyre-interpreter/src/error.rs
+++ b/pyre/pyre-interpreter/src/error.rs
@@ -558,19 +558,42 @@ impl PyError {
         let _roots = pyre_object::gc_roots::push_roots();
         let exc = w_exception_new(ExcKind::SyntaxError, &message);
         pyre_object::gc_roots::pin_root(exc);
-        let w_text = match text {
+        // Build the `(filename, lineno, offset, text, end_lineno, end_offset)`
+        // details tuple element by element. Each is pinned as it is created and
+        // reloaded before the tuple is assembled: an int / str allocation for a
+        // later element can trigger a minor collection that relocates an earlier
+        // young element (the filename or text string, or an uncached line/col
+        // int), leaving its raw local pointing at the old address.
+        let filename_slot = pyre_object::gc_roots::shadow_stack_len();
+        pyre_object::gc_roots::pin_root(pyre_object::w_str_new(filename));
+        let lineno_slot = pyre_object::gc_roots::shadow_stack_len();
+        pyre_object::gc_roots::pin_root(pyre_object::w_int_new(lineno));
+        let offset_slot = pyre_object::gc_roots::shadow_stack_len();
+        pyre_object::gc_roots::pin_root(pyre_object::w_int_new(offset));
+        let text_slot = pyre_object::gc_roots::shadow_stack_len();
+        pyre_object::gc_roots::pin_root(match text {
             Some(t) => pyre_object::w_str_new(t),
             None => pyre_object::w_none(),
-        };
+        });
+        let end_lineno_slot = pyre_object::gc_roots::shadow_stack_len();
+        pyre_object::gc_roots::pin_root(pyre_object::w_int_new(end_lineno));
+        let end_offset_slot = pyre_object::gc_roots::shadow_stack_len();
+        pyre_object::gc_roots::pin_root(pyre_object::w_int_new(end_offset));
         let details = pyre_object::w_tuple_new(vec![
-            pyre_object::w_str_new(filename),
-            pyre_object::w_int_new(lineno),
-            pyre_object::w_int_new(offset),
-            w_text,
-            pyre_object::w_int_new(end_lineno),
-            pyre_object::w_int_new(end_offset),
+            pyre_object::gc_roots::shadow_stack_get(filename_slot),
+            pyre_object::gc_roots::shadow_stack_get(lineno_slot),
+            pyre_object::gc_roots::shadow_stack_get(offset_slot),
+            pyre_object::gc_roots::shadow_stack_get(text_slot),
+            pyre_object::gc_roots::shadow_stack_get(end_lineno_slot),
+            pyre_object::gc_roots::shadow_stack_get(end_offset_slot),
         ]);
-        let args_list = pyre_object::w_list_new(vec![pyre_object::w_str_new(&message), details]);
+        // Root the details tuple across the message allocation below before it
+        // becomes `args[1]`.
+        let details_slot = pyre_object::gc_roots::shadow_stack_len();
+        pyre_object::gc_roots::pin_root(details);
+        let w_msg = pyre_object::w_str_new(&message);
+        let details = pyre_object::gc_roots::shadow_stack_get(details_slot);
+        let args_list = pyre_object::w_list_new(vec![w_msg, details]);
         unsafe { pyre_object::interp_exceptions::w_exception_set_args(exc, args_list) };
         PyError {
             kind: PyErrorKind::SyntaxError,
@@ -653,6 +676,7 @@ impl PyError {
         // The key is pinned before `py_repr` because that repr itself
         // allocates.
         let _roots = pyre_object::gc_roots::push_roots();
+        let key_slot = pyre_object::gc_roots::shadow_stack_len();
         if !key.is_null() {
             pyre_object::gc_roots::pin_root(key);
         }
@@ -665,6 +689,10 @@ impl PyError {
         let exc = pyre_object::interp_exceptions::w_exception_new(ExcKind::KeyError, &message);
         pyre_object::gc_roots::pin_root(exc);
         if !key.is_null() {
+            // Reload the key after the repr / exception allocations: the pin
+            // keeps it alive, but a minor collection may have relocated the
+            // young key, leaving this raw local pointing at the old address.
+            let key = pyre_object::gc_roots::shadow_stack_get(key_slot);
             let args_list = pyre_object::w_list_new(vec![key]);
             unsafe { pyre_object::interp_exceptions::w_exception_set_args(exc, args_list) };
         }
@@ -722,6 +750,7 @@ impl PyError {
         // `w_exception_new` / `w_list_new` could sweep them before the setters
         // stamp them onto `exc`.
         let _roots = pyre_object::gc_roots::push_roots();
+        let filename_slot = pyre_object::gc_roots::shadow_stack_len();
         if !w_filename.is_null() {
             pyre_object::gc_roots::pin_root(w_filename);
         }
@@ -750,6 +779,10 @@ impl PyError {
                 pyre_object::w_str_new(&strerror),
             );
             if !w_filename.is_null() {
+                // Reload the filename after the args allocations: the pin keeps
+                // it alive, but a minor collection may have relocated the young
+                // path, leaving this raw local pointing at the old address.
+                let w_filename = pyre_object::gc_roots::shadow_stack_get(filename_slot);
                 pyre_object::interp_exceptions::w_exception_set_filename(exc, w_filename);
             }
         }
@@ -831,9 +864,11 @@ impl PyError {
         // inside `w_exception_new` / `w_str_new` could sweep them before the
         // setters stamp them onto `exc`.
         let _roots = pyre_object::gc_roots::push_roots();
+        let name_slot = pyre_object::gc_roots::shadow_stack_len();
         if !w_name.is_null() {
             pyre_object::gc_roots::pin_root(w_name);
         }
+        let path_slot = pyre_object::gc_roots::shadow_stack_len();
         if !w_path.is_null() {
             pyre_object::gc_roots::pin_root(w_path);
         }
@@ -845,6 +880,20 @@ impl PyError {
             pyre_object::w_none()
         } else {
             pyre_object::w_str_new(&message)
+        };
+        // Reload name/path after the message allocation: the pins keep them
+        // alive, but a minor collection may have relocated the young objects,
+        // leaving these raw locals stale. A null (absent) ref was never pinned,
+        // so it has no slot and stays null.
+        let w_name = if w_name.is_null() {
+            w_name
+        } else {
+            pyre_object::gc_roots::shadow_stack_get(name_slot)
+        };
+        let w_path = if w_path.is_null() {
+            w_path
+        } else {
+            pyre_object::gc_roots::shadow_stack_get(path_slot)
         };
         unsafe {
             pyre_object::interp_exceptions::w_exception_set_import_msg(exc, w_msg);
@@ -908,9 +957,11 @@ impl PyError {
         // `w_exception_new` could sweep them before they are stamped onto `exc`
         // at the `set_name` / `set_attr_obj` calls.
         let _roots = pyre_object::gc_roots::push_roots();
+        let name_ctx_slot = pyre_object::gc_roots::shadow_stack_len();
         if !self.w_name_context.is_null() {
             pyre_object::gc_roots::pin_root(self.w_name_context);
         }
+        let obj_ctx_slot = pyre_object::gc_roots::shadow_stack_len();
         if !self.w_obj_context.is_null() {
             pyre_object::gc_roots::pin_root(self.w_obj_context);
         }
@@ -921,7 +972,9 @@ impl PyError {
         // (non-moving oldgen) exception before it is written through.
         pyre_object::gc_roots::pin_root(exc);
         if !self.message.is_empty() {
+            let msg_slot = pyre_object::gc_roots::shadow_stack_len();
             let msg = pyre_object::w_str_new(&self.message);
+            pyre_object::gc_roots::pin_root(msg);
             let args_list = pyre_object::w_list_new(vec![msg]);
             unsafe { pyre_object::interp_exceptions::w_exception_set_args(exc, args_list) };
             // `ImportError` / `ModuleNotFoundError` expose the message through a
@@ -932,6 +985,10 @@ impl PyError {
                 self.kind,
                 PyErrorKind::ImportError | PyErrorKind::ModuleNotFoundError
             ) {
+                // Reload `msg` after the args allocation: the pin keeps it
+                // alive, but `w_list_new` may have relocated the young string,
+                // leaving this raw local pointing at the old address.
+                let msg = pyre_object::gc_roots::shadow_stack_get(msg_slot);
                 unsafe { pyre_object::interp_exceptions::w_exception_set_import_msg(exc, msg) };
             }
         }
@@ -939,15 +996,16 @@ impl PyError {
         // materialised NameError / AttributeError instance, the lazy
         // equivalent of `_PyEval_FormatExcCheckArg` /
         // `set_attribute_error_context` (Python 3.10+).
+        // Reload the deferred context refs after the exception / args
+        // allocations: the pins keep them alive, but a minor collection may
+        // have relocated the young objects, leaving the stored fields stale.
         if !self.w_name_context.is_null() {
-            unsafe {
-                pyre_object::interp_exceptions::w_exception_set_name(exc, self.w_name_context)
-            };
+            let w_name_context = pyre_object::gc_roots::shadow_stack_get(name_ctx_slot);
+            unsafe { pyre_object::interp_exceptions::w_exception_set_name(exc, w_name_context) };
         }
         if !self.w_obj_context.is_null() {
-            unsafe {
-                pyre_object::interp_exceptions::w_exception_set_attr_obj(exc, self.w_obj_context)
-            };
+            let w_obj_context = pyre_object::gc_roots::shadow_stack_get(obj_ctx_slot);
+            unsafe { pyre_object::interp_exceptions::w_exception_set_attr_obj(exc, w_obj_context) };
         }
         // Write-once memo (`get_w_value` self.w_value): cache the materialised
         // instance so a second call returns the same object (identity `e1 is e2`)

--- a/pyre/pyre-interpreter/src/error.rs
+++ b/pyre/pyre-interpreter/src/error.rs
@@ -748,6 +748,17 @@ impl PyError {
     /// the clean strerror, and the `.errno` / `.strerror` / `.filename` slots.
     /// `w_filename` is the affected path, or `PY_NULL` for none.
     pub fn os_error_syscall(errno: i32, w_filename: PyObjectRef) -> Self {
+        Self::os_error_syscall2(errno, w_filename, pyre_object::PY_NULL)
+    }
+
+    /// `os_error_syscall` for the two-path syscalls (`rename`, `replace`,
+    /// `link`, `symlink`): `w_filename2` becomes the `.filename2` slot, which
+    /// `str(e)` renders as the `" -> 'dest'"` suffix.
+    pub fn os_error_syscall2(
+        errno: i32,
+        w_filename: PyObjectRef,
+        w_filename2: PyObjectRef,
+    ) -> Self {
         let strerror = Self::clean_strerror(errno);
         let subclass = crate::builtins::os_error_errno_subclass(errno as i64);
         // The dedicated FileNotFoundError kind carries its own str/repr; the
@@ -764,10 +775,16 @@ impl PyError {
         // `w_exception_new` / `w_list_new` could sweep them before the setters
         // stamp them onto `exc`.
         let _roots = pyre_object::gc_roots::push_roots();
-        let filename_slot = pyre_object::gc_roots::shadow_stack_len();
-        if !w_filename.is_null() {
-            pyre_object::gc_roots::pin_root(w_filename);
-        }
+        let pin = |obj: PyObjectRef| -> Option<usize> {
+            if obj.is_null() {
+                return None;
+            }
+            let slot = pyre_object::gc_roots::shadow_stack_len();
+            pyre_object::gc_roots::pin_root(obj);
+            Some(slot)
+        };
+        let filename_slot = pin(w_filename);
+        let filename2_slot = pin(w_filename2);
         let exc = w_exception_new(exc_kind, &message);
         pyre_object::gc_roots::pin_root(exc);
         // Retag to the errno subclass through `w_class`, like
@@ -792,12 +809,16 @@ impl PyError {
                 exc,
                 pyre_object::w_str_new(&strerror),
             );
-            if !w_filename.is_null() {
-                // Reload the filename after the args allocations: the pin keeps
-                // it alive, but a minor collection may have relocated the young
-                // path, leaving this raw local pointing at the old address.
-                let w_filename = pyre_object::gc_roots::shadow_stack_get(filename_slot);
+            // Reload the paths after the args allocations: the pins keep them
+            // alive, but a minor collection may have relocated the young
+            // strings, leaving the raw locals pointing at the old addresses.
+            if let Some(slot) = filename_slot {
+                let w_filename = pyre_object::gc_roots::shadow_stack_get(slot);
                 pyre_object::interp_exceptions::w_exception_set_filename(exc, w_filename);
+            }
+            if let Some(slot) = filename2_slot {
+                let w_filename2 = pyre_object::gc_roots::shadow_stack_get(slot);
+                pyre_object::interp_exceptions::w_exception_set_filename2(exc, w_filename2);
             }
         }
         PyError {

--- a/pyre/pyre-interpreter/src/error.rs
+++ b/pyre/pyre-interpreter/src/error.rs
@@ -722,6 +722,20 @@ impl PyError {
     /// Rust's OS-error `Display` is `"{strerror} (os error {errno})"`;
     /// recover the bare strerror the way `rposix.strerror` reports it.
     fn clean_strerror(errno: i32) -> String {
+        // `from_raw_os_error` reads its argument as a Win32 code on Windows,
+        // where these errnos are the POSIX ones `io_error_posix_errno`
+        // translated to, so it would describe an unrelated system error (17 is
+        // EEXIST but also ERROR_NOT_SAME_DEVICE).  The C runtime keeps the
+        // errno-keyed table `strerror` reports from.
+        #[cfg(windows)]
+        {
+            let msg = unsafe { libc::strerror(errno) };
+            if !msg.is_null() {
+                return unsafe { std::ffi::CStr::from_ptr(msg) }
+                    .to_string_lossy()
+                    .into_owned();
+            }
+        }
         let full = std::io::Error::from_raw_os_error(errno).to_string();
         match full.rfind(" (os error ") {
             Some(idx) => full[..idx].to_string(),

--- a/pyre/pyre-interpreter/src/error.rs
+++ b/pyre/pyre-interpreter/src/error.rs
@@ -1,5 +1,7 @@
 use pyre_object::PyObjectRef;
 use pyre_object::interp_exceptions::{ExcKind, exc_kind_name, w_exception_new};
+use ruff_text_size::Ranged;
+use rustpython_compiler::{ast, parser};
 use std::io::Write;
 use std::sync::OnceLock;
 
@@ -1386,18 +1388,34 @@ fn write_traceback_chain_from_exc<W: Write>(
         }
         let w_code = unsafe { crate::pytraceback::w_pytraceback_get_w_code(tb) };
         let lineno = unsafe { crate::pytraceback::w_pytraceback_get_lineno(tb) };
-        let (filename, funcname) = if w_code.is_null() {
-            (String::from("<unknown>"), String::from("<unknown>"))
+        let lasti = unsafe { crate::pytraceback::w_pytraceback_get_lasti(tb) };
+        let (filename, funcname, location) = if w_code.is_null() {
+            (String::from("<unknown>"), String::from("<unknown>"), None)
         } else {
             // `w_code` is a GC-rooted `PyCode` pointer captured
             // at `record_application_traceback` time; the inner
             // `CodeObject` lives as long as `w_code` is reachable.
             let code_obj = unsafe { crate::w_code_get_ptr(w_code) } as *const crate::CodeObject;
             if code_obj.is_null() {
-                (String::from("<unknown>"), String::from("<unknown>"))
+                (String::from("<unknown>"), String::from("<unknown>"), None)
             } else {
                 let code = unsafe { &*code_obj };
-                (code.source_path.to_string(), code.obj_name.to_string())
+                let location = usize::try_from(lasti)
+                    .ok()
+                    .and_then(|index| code.locations.get(index))
+                    .map(|(start, end)| {
+                        (
+                            start.line.get(),
+                            end.line.get(),
+                            start.character_offset.get().saturating_sub(1),
+                            end.character_offset.get().saturating_sub(1),
+                        )
+                    });
+                (
+                    code.source_path.to_string(),
+                    code.obj_name.to_string(),
+                    location,
+                )
             }
         };
         writeln!(
@@ -1406,12 +1424,143 @@ fn write_traceback_chain_from_exc<W: Write>(
             filename, lineno, funcname
         )?;
         if let Some(line) = read_source_line(&filename, lineno) {
-            let trimmed = line.trim_end_matches(['\n', '\r']);
-            writeln!(writer, "    {}", trimmed.trim_start())?;
+            let raw_line = line.trim_end_matches(['\n', '\r']);
+            let shown_line = raw_line.trim_start();
+            writeln!(writer, "    {shown_line}")?;
+
+            if let Some((start_line, end_line, start_col, end_col)) = location
+                && usize::try_from(lineno).ok() == Some(start_line)
+                && end_line == start_line
+                && end_col > start_col
+                && start_col <= raw_line.len()
+                && end_col <= raw_line.len()
+                && raw_line.is_char_boundary(start_col)
+                && raw_line.is_char_boundary(end_col)
+            {
+                let lead = raw_line.len() - shown_line.len();
+                let anchors = traceback_anchors(raw_line, start_col, end_col);
+                // `traceback.py:_should_show_carets` — a plain caret span covering
+                // the whole stripped line (nothing but whitespace before the start
+                // or after the end, and no binary-op/subscript sub-anchor) carries
+                // no information, so it is suppressed. A `<name> = <call>(…)` or
+                // `return <call>(…)` whose call value exactly covers the span is
+                // likewise suppressed even though it has a call sub-anchor.
+                let before_ws_only = raw_line.get(..start_col).unwrap_or("").trim_start().is_empty();
+                let after_ws_only = raw_line.get(end_col..).unwrap_or("").trim_end().is_empty();
+                let full_line_call = spawns_full_line_call(
+                    shown_line,
+                    start_col.saturating_sub(lead),
+                    end_col.saturating_sub(lead),
+                );
+                if !full_line_call && (anchors.is_some() || !before_ws_only || !after_ws_only) {
+                    let mut caret_line = String::from("    ");
+                    caret_line.push_str(&" ".repeat(start_col.saturating_sub(lead)));
+                    for col in start_col..end_col {
+                        let marker = if let Some((lo, hi)) = anchors {
+                            if (lo..hi).contains(&col) { '^' } else { '~' }
+                        } else {
+                            '^'
+                        };
+                        caret_line.push(marker);
+                    }
+                    writeln!(writer, "{caret_line}")?;
+                }
+            }
         }
         tb = unsafe { crate::pytraceback::w_pytraceback_get_w_next(tb) };
     }
     Ok(())
+}
+
+/// `traceback.py:_should_show_carets` special case: a `<name> = <call>(…)` or
+/// `return <call>(…)` statement whose call value exactly spans the failing
+/// instruction (byte offsets `seg_start..seg_end` into `line`, the already-
+/// dedented source line). Such a caret would merely re-underline the whole
+/// right-hand side, so it is suppressed.
+fn spawns_full_line_call(line: &str, seg_start: usize, seg_end: usize) -> bool {
+    let Ok(parsed) = parser::parse_module(line) else {
+        return false;
+    };
+    let body = &parsed.syntax().body;
+    let [stmt] = body.as_slice() else {
+        return false;
+    };
+    let call = match stmt {
+        ast::Stmt::Assign(assign) => {
+            if assign.targets.len() != 1
+                || !matches!(assign.targets.first(), Some(ast::Expr::Name(_)))
+                || !matches!(assign.value.as_ref(), ast::Expr::Call(_))
+            {
+                return false;
+            }
+            assign.value.range()
+        }
+        ast::Stmt::Return(ret) => match ret.value.as_deref() {
+            Some(ast::Expr::Call(call)) if matches!(call.func.as_ref(), ast::Expr::Name(_)) => {
+                call.range()
+            }
+            _ => return false,
+        },
+        _ => return false,
+    };
+    call.start().to_usize() == seg_start && call.end().to_usize() == seg_end
+}
+
+/// Return the secondary-marker span used by `traceback.py` for an expression.
+fn traceback_anchors(raw_line: &str, start_col: usize, end_col: usize) -> Option<(usize, usize)> {
+    let segment = raw_line.get(start_col..end_col)?;
+    let wrapped = format!("(\n{segment}\n)");
+    let parsed = parser::parse_expression(&wrapped).ok()?;
+    let expr = parsed.syntax().body.as_ref();
+
+    let map_offset = |offset: usize| {
+        offset
+            .checked_sub(2)
+            .and_then(|offset| offset.checked_add(start_col))
+            .map(|offset| offset.clamp(start_col, end_col))
+    };
+    let map_range = |lo: usize, hi: usize| {
+        let lo = map_offset(lo)?;
+        let hi = map_offset(hi)?;
+        (lo < hi).then_some((lo, hi))
+    };
+
+    match expr {
+        ast::Expr::BinOp(bin_op) => {
+            let left_end = bin_op.left.range().end().to_usize();
+            let right_start = bin_op.right.range().start().to_usize();
+            if left_end > right_start || right_start > wrapped.len() {
+                return None;
+            }
+            let between = wrapped.as_bytes().get(left_end..right_start)?;
+            let op_relative = between
+                .iter()
+                .position(|byte| !byte.is_ascii_whitespace() && *byte != b')')?;
+            let op_start = left_end.checked_add(op_relative)?;
+            let mut op_end = op_start;
+            while op_end < right_start {
+                let byte = *wrapped.as_bytes().get(op_end)?;
+                if byte.is_ascii_whitespace()
+                    || byte == b')'
+                    || byte.is_ascii_alphanumeric()
+                    || byte == b'_'
+                {
+                    break;
+                }
+                op_end = op_end.checked_add(1)?;
+            }
+            map_range(op_start, op_end)
+        }
+        ast::Expr::Subscript(subscript) => map_range(
+            subscript.value.range().end().to_usize(),
+            expr.range().end().to_usize(),
+        ),
+        ast::Expr::Call(call) => map_range(
+            call.func.range().end().to_usize(),
+            expr.range().end().to_usize(),
+        ),
+        _ => None,
+    }
 }
 
 /// Open `filename` and return its `lineno`-th line (1-indexed).  Returns

--- a/pyre/pyre-interpreter/src/error.rs
+++ b/pyre/pyre-interpreter/src/error.rs
@@ -1378,8 +1378,8 @@ pub fn write_syntax_error<W: Write>(writer: &mut W, err: &PyError) -> std::io::R
             writeln!(writer, "{caret}")?;
         }
     }
-    let name = exc_object_class_name(exc)
-        .unwrap_or_else(|| exc_kind_name(err.to_exc_kind()).to_string());
+    let name =
+        exc_object_class_name(exc).unwrap_or_else(|| exc_kind_name(err.to_exc_kind()).to_string());
     match str_of(attr("msg")) {
         Some(msg) if !msg.is_empty() => writeln!(writer, "{name}: {msg}"),
         _ => writeln!(writer, "{name}"),

--- a/pyre/pyre-interpreter/src/error.rs
+++ b/pyre/pyre-interpreter/src/error.rs
@@ -645,6 +645,17 @@ impl PyError {
     /// key object.  The display message is the key's repr, matching
     /// what `KeyError.__str__` yields.
     pub fn key_error_with_key(key: PyObjectRef) -> Self {
+        // Root the caller's key and the fresh exception across the repr,
+        // exception, and args allocations below: they live only in Rust
+        // locals, which the precise collector does not scan, so a collection
+        // inside `py_repr` / `w_exception_new` / `w_list_new` could sweep the
+        // key or the exception before `w_exception_set_args` stamps them.
+        // The key is pinned before `py_repr` because that repr itself
+        // allocates.
+        let _roots = pyre_object::gc_roots::push_roots();
+        if !key.is_null() {
+            pyre_object::gc_roots::pin_root(key);
+        }
         let message = if key.is_null() {
             "<null>".to_string()
         } else {
@@ -652,6 +663,7 @@ impl PyError {
                 .unwrap_or_else(|_| "<unrepresentable>".to_string())
         };
         let exc = pyre_object::interp_exceptions::w_exception_new(ExcKind::KeyError, &message);
+        pyre_object::gc_roots::pin_root(exc);
         if !key.is_null() {
             let args_list = pyre_object::w_list_new(vec![key]);
             unsafe { pyre_object::interp_exceptions::w_exception_set_args(exc, args_list) };
@@ -813,7 +825,20 @@ impl PyError {
         w_path: PyObjectRef,
     ) -> Self {
         let message = msg.into();
+        // Root the caller's name/path and the fresh exception across the
+        // exception and message allocations below: they live only in Rust
+        // locals, which the precise collector does not scan, so a collection
+        // inside `w_exception_new` / `w_str_new` could sweep them before the
+        // setters stamp them onto `exc`.
+        let _roots = pyre_object::gc_roots::push_roots();
+        if !w_name.is_null() {
+            pyre_object::gc_roots::pin_root(w_name);
+        }
+        if !w_path.is_null() {
+            pyre_object::gc_roots::pin_root(w_path);
+        }
         let exc = w_exception_new(ExcKind::ImportError, &message);
+        pyre_object::gc_roots::pin_root(exc);
         // `ImportError.__init__` mirrors args[0] into the dedicated `msg`
         // slot; the prebuilt-instance path bypasses it, so stamp it here.
         let w_msg = if message.is_empty() {

--- a/pyre/pyre-interpreter/src/error.rs
+++ b/pyre/pyre-interpreter/src/error.rs
@@ -532,6 +532,60 @@ impl PyError {
         Self::new(PyErrorKind::SyntaxError, msg)
     }
 
+    /// Build a compile-time SyntaxError carrying the parser location so
+    /// `e.msg` / `e.filename` / `e.lineno` / `e.offset` / `e.text` /
+    /// `e.end_lineno` / `e.end_offset` read back once the instance is
+    /// materialised.  `args` becomes `(msg, (filename, lineno, offset,
+    /// text, end_lineno, end_offset))`, the shape
+    /// `interp_exceptions.py:836 W_SyntaxError.descr_init` stores and
+    /// `syntax_error_attr` / `descr_str` read from.  `text` is the
+    /// offending source line (`None` → `text` reads back as `None`).
+    #[allow(clippy::too_many_arguments)]
+    pub fn syntax_error_located(
+        msg: impl Into<String>,
+        filename: &str,
+        lineno: i64,
+        offset: i64,
+        end_lineno: i64,
+        end_offset: i64,
+        text: Option<&str>,
+    ) -> Self {
+        let message = msg.into();
+        // Root the fresh exception across the args/details allocations: `exc`
+        // lives only in this Rust local while `w_str_new` / `w_int_new` /
+        // `w_tuple_new` / `w_list_new` run, so a collection there could sweep
+        // the unrooted exception before `w_exception_set_args` writes it.
+        let _roots = pyre_object::gc_roots::push_roots();
+        let exc = w_exception_new(ExcKind::SyntaxError, &message);
+        pyre_object::gc_roots::pin_root(exc);
+        let w_text = match text {
+            Some(t) => pyre_object::w_str_new(t),
+            None => pyre_object::w_none(),
+        };
+        let details = pyre_object::w_tuple_new(vec![
+            pyre_object::w_str_new(filename),
+            pyre_object::w_int_new(lineno),
+            pyre_object::w_int_new(offset),
+            w_text,
+            pyre_object::w_int_new(end_lineno),
+            pyre_object::w_int_new(end_offset),
+        ]);
+        let args_list = pyre_object::w_list_new(vec![pyre_object::w_str_new(&message), details]);
+        unsafe { pyre_object::interp_exceptions::w_exception_set_args(exc, args_list) };
+        PyError {
+            kind: PyErrorKind::SyntaxError,
+            // Leave the display message empty so `message_text` derives it from
+            // `exc_object` via the SyntaxError `descr_str`, which appends the
+            // `(filename, line N)` suffix.
+            message: String::new(),
+            exc_object: exc,
+            attach_tb: true,
+            reraise_lasti: -1,
+            w_name_context: std::ptr::null_mut(),
+            w_obj_context: std::ptr::null_mut(),
+        }
+    }
+
     pub fn zero_division(msg: impl Into<String>) -> Self {
         Self::new(PyErrorKind::ZeroDivisionError, msg)
     }
@@ -1252,6 +1306,67 @@ pub fn write_exception<W: Write>(
     } else {
         writeln!(writer, "{}", err.render_exception())
     }
+}
+
+/// Render an uncaught compile-time SyntaxError as the top-level banner
+/// (`print_error_text`): the `File "…", line N` header, the offending
+/// source line, a caret under the offending column span, and
+/// `<Class>: <msg>` (the raw `msg`, not `str(e)`'s `(file, line N)`
+/// suffix — the header already carries the location).  There is no
+/// traceback frame chain: a malformed source never began executing.
+/// Falls back to the plain header when the instance lacks structured
+/// location (a location-less codegen error).
+pub fn write_syntax_error<W: Write>(writer: &mut W, err: &PyError) -> std::io::Result<()> {
+    let exc = err.exc_object;
+    if exc.is_null() || !unsafe { pyre_object::is_exception(exc) } {
+        return writeln!(writer, "{}", err.render_exception());
+    }
+    let attr = |name: &str| crate::baseobjspace::syntax_error_attr(exc, name);
+    let str_of = |w: PyObjectRef| -> Option<String> {
+        (!w.is_null() && unsafe { pyre_object::is_str(w) })
+            .then(|| unsafe { pyre_object::w_str_get_value(w) }.to_string())
+    };
+    let int_of = |w: PyObjectRef| -> Option<i64> {
+        (!w.is_null() && unsafe { pyre_object::is_int(w) })
+            .then(|| unsafe { pyre_object::intobject::w_int_get_value(w) })
+    };
+    let filename = str_of(attr("filename"));
+    let lineno = int_of(attr("lineno"));
+    if let (Some(fname), Some(lineno)) = (filename.as_ref(), lineno) {
+        writeln!(writer, "  File \"{fname}\", line {lineno}")?;
+    }
+    if let Some(text) = str_of(attr("text")) {
+        let raw = text.trim_end_matches(['\n', '\r']);
+        let shown = raw.trim_start();
+        let lead = raw.len() - shown.len();
+        writeln!(writer, "    {shown}")?;
+        if let Some(offset) = int_of(attr("offset")) {
+            let start_col = (offset.max(1) as usize) - 1;
+            let end_col = int_of(attr("end_offset"))
+                .filter(|&e| e >= offset)
+                .map_or(start_col, |e| (e as usize) - 1);
+            let caret_start = start_col.saturating_sub(lead);
+            let caret_len = end_col.saturating_sub(start_col).max(1);
+            let mut caret = String::from("    ");
+            caret.push_str(&" ".repeat(caret_start));
+            caret.push_str(&"^".repeat(caret_len));
+            writeln!(writer, "{caret}")?;
+        }
+    }
+    let name = exc_object_class_name(exc)
+        .unwrap_or_else(|| exc_kind_name(err.to_exc_kind()).to_string());
+    match str_of(attr("msg")) {
+        Some(msg) if !msg.is_empty() => writeln!(writer, "{name}: {msg}"),
+        _ => writeln!(writer, "{name}"),
+    }
+}
+
+/// Emit `write_syntax_error` through the mediated stderr seam, mirroring
+/// `eprint_exception`.
+pub fn eprint_syntax_error(err: &PyError) {
+    let mut buf: Vec<u8> = Vec::new();
+    let _ = write_syntax_error(&mut buf, err);
+    crate::host_seam::emit_stderr(&buf);
 }
 
 /// `Lib/traceback.py:171-200 TracebackException._format_*` parity —

--- a/pyre/pyre-interpreter/src/error.rs
+++ b/pyre/pyre-interpreter/src/error.rs
@@ -1445,7 +1445,11 @@ fn write_traceback_chain_from_exc<W: Write>(
                 // no information, so it is suppressed. A `<name> = <call>(…)` or
                 // `return <call>(…)` whose call value exactly covers the span is
                 // likewise suppressed even though it has a call sub-anchor.
-                let before_ws_only = raw_line.get(..start_col).unwrap_or("").trim_start().is_empty();
+                let before_ws_only = raw_line
+                    .get(..start_col)
+                    .unwrap_or("")
+                    .trim_start()
+                    .is_empty();
                 let after_ws_only = raw_line.get(end_col..).unwrap_or("").trim_end().is_empty();
                 let full_line_call = spawns_full_line_call(
                     shown_line,

--- a/pyre/pyre-interpreter/src/error.rs
+++ b/pyre/pyre-interpreter/src/error.rs
@@ -650,7 +650,17 @@ impl PyError {
             (PyErrorKind::OSError, ExcKind::OSError)
         };
         let message = format!("[Errno {errno}] {strerror}");
+        // Root the caller's filename and the fresh exception across the
+        // exception and args allocations below: they live only in Rust locals,
+        // which the precise collector does not scan, so a collection inside
+        // `w_exception_new` / `w_list_new` could sweep them before the setters
+        // stamp them onto `exc`.
+        let _roots = pyre_object::gc_roots::push_roots();
+        if !w_filename.is_null() {
+            pyre_object::gc_roots::pin_root(w_filename);
+        }
         let exc = w_exception_new(exc_kind, &message);
+        pyre_object::gc_roots::pin_root(exc);
         // Retag to the errno subclass through `w_class`, like
         // `os_error_family_new`: the subclasses share OSError's layout, so
         // the ExcKind stays OSError and only the class differs.
@@ -716,7 +726,13 @@ impl PyError {
             ExcKind::OSError
         };
         let message = format!("[Errno {errno}] {strerror}");
+        // Root the fresh exception across the args allocation below: `exc`
+        // lives only in this Rust local while `w_int_new` / `w_str_new` /
+        // `w_list_new` run, so a collection there could sweep the unrooted
+        // exception before `w_exception_set_args` writes through it.
+        let _roots = pyre_object::gc_roots::push_roots();
         let exc = w_exception_new(exc_kind, &message);
+        pyre_object::gc_roots::pin_root(exc);
         let args_list = pyre_object::w_list_new(vec![
             pyre_object::w_int_new(errno as i64),
             pyre_object::w_str_new(&strerror),

--- a/pyre/pyre-interpreter/src/error.rs
+++ b/pyre/pyre-interpreter/src/error.rs
@@ -669,6 +669,40 @@ impl PyError {
         }
     }
 
+    /// `error.py:new_import_error` — `ImportError(msg, name=name, path=path)`.
+    /// A failed `from X import Y` (pyopcode.py import_from) raises through
+    /// this so `.name` (the package) and `.path` (its file) are readable,
+    /// which `PyError::new(ImportError, msg)` cannot carry.
+    pub fn import_error_name_path(
+        msg: impl Into<String>,
+        w_name: PyObjectRef,
+        w_path: PyObjectRef,
+    ) -> Self {
+        let message = msg.into();
+        let exc = w_exception_new(ExcKind::ImportError, &message);
+        // `ImportError.__init__` mirrors args[0] into the dedicated `msg`
+        // slot; the prebuilt-instance path bypasses it, so stamp it here.
+        let w_msg = if message.is_empty() {
+            pyre_object::w_none()
+        } else {
+            pyre_object::w_str_new(&message)
+        };
+        unsafe {
+            pyre_object::interp_exceptions::w_exception_set_import_msg(exc, w_msg);
+            pyre_object::interp_exceptions::w_exception_set_name(exc, w_name);
+            pyre_object::interp_exceptions::w_exception_set_import_path(exc, w_path);
+        }
+        PyError {
+            kind: PyErrorKind::ImportError,
+            message,
+            exc_object: exc,
+            attach_tb: true,
+            reraise_lasti: -1,
+            w_name_context: std::ptr::null_mut(),
+            w_obj_context: std::ptr::null_mut(),
+        }
+    }
+
     /// pypy/module/_weakref/interp__weakref.py:347 — raised by `force()`
     /// when the referent of a proxy is no longer alive.
     pub fn reference_error(msg: impl Into<String>) -> Self {

--- a/pyre/pyre-interpreter/src/error.rs
+++ b/pyre/pyre-interpreter/src/error.rs
@@ -623,15 +623,77 @@ impl PyError {
         Self::new(PyErrorKind::OSError, msg)
     }
 
-    /// Raise an OSError (or FileNotFoundError when errno is ENOENT) with
-    /// a platform-style error message.
-    pub fn os_error_with_errno(errno: i32, msg: impl Into<String>) -> Self {
-        let kind = if errno == 2 {
-            PyErrorKind::FileNotFoundError
+    /// Rust's OS-error `Display` is `"{strerror} (os error {errno})"`;
+    /// recover the bare strerror the way `rposix.strerror` reports it.
+    fn clean_strerror(errno: i32) -> String {
+        let full = std::io::Error::from_raw_os_error(errno).to_string();
+        match full.rfind(" (os error ") {
+            Some(idx) => full[..idx].to_string(),
+            None => full,
+        }
+    }
+
+    /// `error.py:_wrap_oserror2` — build the OSError a failed syscall raises:
+    /// `args = (errno, strerror)`, the errno-specific subclass (`ERRNO_MAP`),
+    /// the clean strerror, and the `.errno` / `.strerror` / `.filename` slots.
+    /// `w_filename` is the affected path, or `PY_NULL` for none.
+    pub fn os_error_syscall(errno: i32, w_filename: PyObjectRef) -> Self {
+        let strerror = Self::clean_strerror(errno);
+        let subclass = crate::builtins::os_error_errno_subclass(errno as i64);
+        // The dedicated FileNotFoundError kind carries its own str/repr; the
+        // other errno subclasses share OSError's and differ only by class.
+        let (kind, exc_kind) = if matches!(subclass, Some("FileNotFoundError")) {
+            (PyErrorKind::FileNotFoundError, ExcKind::FileNotFoundError)
         } else {
-            PyErrorKind::OSError
+            (PyErrorKind::OSError, ExcKind::OSError)
         };
-        Self::new(kind, msg)
+        let message = format!("[Errno {errno}] {strerror}");
+        let exc = w_exception_new(exc_kind, &message);
+        // Retag to the errno subclass through `w_class`, like
+        // `os_error_family_new`: the subclasses share OSError's layout, so
+        // the ExcKind stays OSError and only the class differs.
+        if let Some(w_target) = subclass.and_then(crate::builtins::lookup_exc_class) {
+            unsafe {
+                (*(exc as *mut pyre_object::PyObject)).w_class = w_target;
+            }
+        }
+        let args_list = pyre_object::w_list_new(vec![
+            pyre_object::w_int_new(errno as i64),
+            pyre_object::w_str_new(&strerror),
+        ]);
+        unsafe {
+            pyre_object::interp_exceptions::w_exception_set_args(exc, args_list);
+            pyre_object::interp_exceptions::w_exception_set_errno(
+                exc,
+                pyre_object::w_int_new(errno as i64),
+            );
+            pyre_object::interp_exceptions::w_exception_set_strerror(
+                exc,
+                pyre_object::w_str_new(&strerror),
+            );
+            if !w_filename.is_null() {
+                pyre_object::interp_exceptions::w_exception_set_filename(exc, w_filename);
+            }
+        }
+        PyError {
+            kind,
+            // Leave the display message empty so `message_text` derives it from
+            // `exc_object` via `W_OSError.descr_str`, which appends the
+            // `: 'filename'` suffix; the bare "[Errno N] strerror" would bypass
+            // it and the uncaught-traceback header would drop the filename.
+            message: String::new(),
+            exc_object: exc,
+            attach_tb: true,
+            reraise_lasti: -1,
+            w_name_context: std::ptr::null_mut(),
+            w_obj_context: std::ptr::null_mut(),
+        }
+    }
+
+    /// Raise the structured OSError for `errno` (no filename). The caller's
+    /// platform message is superseded by the errno-derived strerror.
+    pub fn os_error_with_errno(errno: i32, _msg: impl Into<String>) -> Self {
+        Self::os_error_syscall(errno, pyre_object::PY_NULL)
     }
 
     /// Raise an OSError carrying the C-level `(errno, strerror)` pair,

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -948,6 +948,8 @@ fn walk_global_prebuilt_roots(visitor: &mut dyn FnMut(&mut majit_ir::GcRef)) {
     // expose the equivalent slots on every collection so both minor moves and
     // major marking preserve their functions and private globals namespace.
     crate::reduce_protocol::walk_handle_roots(visitor);
+    // The aiter/anext app-level handles are the same off-GC-slot case.
+    crate::async_operation::walk_handle_roots(visitor);
     let is_minor = majit_gc::shadow_stack::extra_root_walk_kind()
         == majit_gc::shadow_stack::ExtraRootWalkKind::Minor;
     let scan_prebuilt = !is_minor

--- a/pyre/pyre-interpreter/src/host_seam.rs
+++ b/pyre/pyre-interpreter/src/host_seam.rs
@@ -109,20 +109,19 @@ pub type SeamResult<T> = Result<T, SeamError>;
 
 /// Map a [`SeamError`] onto the interpreter's `PyError`, mirroring the
 /// `io_err`/`fd_io_err` conversions the real-syscall call sites use. `context`
-/// is the path/name woven into the `OSError` message (empty = omit, matching the
-/// `""` path the fd call sites pass). Only the sandbox build routes errors
+/// is the path that becomes the `OSError`'s `filename` (empty = omit, matching
+/// the `""` the fd call sites pass). Only the sandbox build routes errors
 /// through here; the real build keeps its own inline `io_err`.
 #[cfg(feature = "sandbox")]
 pub fn seam_os_err(e: SeamError, context: &str) -> crate::PyError {
     match e {
         SeamError::Os(errno) => {
-            let io = std::io::Error::from_raw_os_error(errno);
-            let msg = if context.is_empty() {
-                io.to_string()
+            let w_filename = if context.is_empty() {
+                pyre_object::PY_NULL
             } else {
-                format!("{io}: '{context}'")
+                pyre_object::w_str_new(context)
             };
-            crate::PyError::os_error_with_errno(errno, msg)
+            crate::PyError::os_error_syscall(errno, w_filename)
         }
         SeamError::Io => crate::PyError::os_error_with_errno(libc::EIO, "I/O error"),
         SeamError::Value => crate::PyError::value_error("embedded null in path"),

--- a/pyre/pyre-interpreter/src/importing.rs
+++ b/pyre/pyre-interpreter/src/importing.rs
@@ -1100,6 +1100,29 @@ fn check_sys_modules(name: &str) -> Option<PyObjectRef> {
     SYS_MODULES.with(|m| m.borrow().get(name).copied())
 }
 
+/// Whether `sys.modules[name]` is bound to `None`, the sentinel that marks
+/// a name as blocked.
+///
+/// `_bootstrap._find_and_load` treats it as a cached "this import must not
+/// succeed" and raises instead of searching, which is how code disables an
+/// import for everything downstream of it.  `check_sys_modules` cannot
+/// report it — `None` is not a module it can hand back, so it falls through
+/// to the search — hence the separate lookup.
+fn sys_modules_blocks(name: &str) -> bool {
+    // Build the key before reading the dict, as `check_sys_modules` does: the
+    // allocation can run a minor collection that relocates the dict, and the
+    // cell holds the address the collector updates.
+    let key = pyre_object::w_str_new(name);
+    let dict = SYS_MODULES_DICT.with(|d| d.get());
+    if dict.is_null() {
+        return false;
+    }
+    match unsafe { pyre_object::w_dict_lookup(dict, key) } {
+        Some(m) => !m.is_null() && unsafe { pyre_object::is_none(m) },
+        None => false,
+    }
+}
+
 /// Look up a loaded module by name in `sys.modules` (Python-visible dict
 /// first, then the interpreter cache). Mirrors `check_sys_modules`.
 pub fn get_sys_module(name: &str) -> Option<PyObjectRef> {
@@ -1894,6 +1917,15 @@ fn load_part(
     parent_dirs: Option<&[PathBuf]>,
     execution_context: *const PyExecutionContext,
 ) -> Result<Option<PyObjectRef>, crate::PyError> {
+    // A blocked name is answered before any search, so it also applies to a
+    // name that was never importable to begin with.
+    if sys_modules_blocks(modulename) {
+        return Err(crate::PyError::module_not_found_with_name(
+            format!("import of {modulename} halted; None in sys.modules"),
+            modulename,
+        ));
+    }
+
     // Check sys.modules cache first
     if let Some(cached) = check_sys_modules(modulename) {
         return Ok(Some(cached));

--- a/pyre/pyre-interpreter/src/importing.rs
+++ b/pyre/pyre-interpreter/src/importing.rs
@@ -2258,10 +2258,27 @@ pub fn import_from(
         }
     }
 
-    Err(crate::PyError::new(
-        crate::PyErrorKind::ImportError,
-        format!("cannot import name '{name}'"),
-    ))
+    // The name is neither a real attribute nor an importable submodule.
+    // `error.py:new_import_error` — raise `ImportError(msg, name=pkgname,
+    // path=pkgpath)`: `pkgname` is the package `__name__` (default "<unknown
+    // module name>"), `pkgpath` its `__file__` (`get_path`, default "unknown
+    // location").  pyopcode.py:1152 resolves the name via
+    // `space.getattr(w_module, '__name__')` and importing.py:460-470 `get_path`
+    // via `space.getattr(w_module, '__file__')`, so a descriptor- or
+    // `__getattr__`-supplied value and a non-module `from` target are honored;
+    // a missing / non-str attribute takes the default.
+    let w_pkgname = match crate::baseobjspace::getattr_str(module, "__name__") {
+        Ok(v) if unsafe { pyre_object::is_str(v) } => v,
+        _ => pyre_object::w_str_new("<unknown module name>"),
+    };
+    let w_pkgpath = match crate::baseobjspace::getattr_str(module, "__file__") {
+        Ok(v) if unsafe { pyre_object::is_str(v) } => v,
+        _ => pyre_object::w_str_new("unknown location"),
+    };
+    let pkgname = unsafe { pyre_object::w_str_get_value(w_pkgname) };
+    let pkgpath = unsafe { pyre_object::w_str_get_value(w_pkgpath) };
+    let msg = format!("cannot import name '{name}' from '{pkgname}' ({pkgpath})");
+    Err(crate::PyError::import_error_name_path(msg, w_pkgname, w_pkgpath))
 }
 
 // ── import_all_from ──────────────────────────────────────────────────

--- a/pyre/pyre-interpreter/src/importing.rs
+++ b/pyre/pyre-interpreter/src/importing.rs
@@ -1520,7 +1520,7 @@ fn parent_package_path(parent: PyObjectRef) -> Option<Vec<PathBuf>> {
 // PyPy equivalent: importing.py `parse_source_module(space, pathname, source)`
 
 fn parse_source_module(pathname: &str, source: &str) -> Result<CodeObject, String> {
-    compile_source_with_filename(source, Mode::Exec, pathname)
+    compile_source_with_filename(source, Mode::Exec, pathname).map_err(|e| e.to_string())
 }
 
 // ── exec_code_module ─────────────────────────────────────────────────

--- a/pyre/pyre-interpreter/src/importing.rs
+++ b/pyre/pyre-interpreter/src/importing.rs
@@ -2266,17 +2266,22 @@ pub fn import_from(
     // `space.getattr(w_module, '__name__')` and importing.py:460-470 `get_path`
     // via `space.getattr(w_module, '__file__')`, so a descriptor- or
     // `__getattr__`-supplied value and a non-module `from` target are honored;
-    // a missing / non-str attribute takes the default.
+    // a missing / None path takes the default.
     let w_pkgname = match crate::baseobjspace::getattr_str(module, "__name__") {
         Ok(v) if unsafe { pyre_object::is_str(v) } => v,
         _ => pyre_object::w_str_new("<unknown module name>"),
     };
+    // pypy/module/imp/importing.py:460 get_path
     let w_pkgpath = match crate::baseobjspace::getattr_str(module, "__file__") {
-        Ok(v) if unsafe { pyre_object::is_str(v) } => v,
-        _ => pyre_object::w_str_new("unknown location"),
+        Ok(v) if unsafe { pyre_object::is_none(v) } => pyre_object::w_str_new("unknown location"),
+        Ok(v) => v,
+        Err(e) if e.kind == crate::PyErrorKind::AttributeError => {
+            pyre_object::w_str_new("unknown location")
+        }
+        Err(e) => return Err(e),
     };
     let pkgname = unsafe { pyre_object::w_str_get_value(w_pkgname) };
-    let pkgpath = unsafe { pyre_object::w_str_get_value(w_pkgpath) };
+    let pkgpath = crate::baseobjspace::utf8_w(w_pkgpath)?;
     let msg = format!("cannot import name '{name}' from '{pkgname}' ({pkgpath})");
     Err(crate::PyError::import_error_name_path(
         msg, w_pkgname, w_pkgpath,

--- a/pyre/pyre-interpreter/src/importing.rs
+++ b/pyre/pyre-interpreter/src/importing.rs
@@ -2278,7 +2278,9 @@ pub fn import_from(
     let pkgname = unsafe { pyre_object::w_str_get_value(w_pkgname) };
     let pkgpath = unsafe { pyre_object::w_str_get_value(w_pkgpath) };
     let msg = format!("cannot import name '{name}' from '{pkgname}' ({pkgpath})");
-    Err(crate::PyError::import_error_name_path(msg, w_pkgname, w_pkgpath))
+    Err(crate::PyError::import_error_name_path(
+        msg, w_pkgname, w_pkgpath,
+    ))
 }
 
 // ── import_all_from ──────────────────────────────────────────────────

--- a/pyre/pyre-interpreter/src/importing.rs
+++ b/pyre/pyre-interpreter/src/importing.rs
@@ -952,6 +952,18 @@ pub(crate) fn create_builtin_module(
     name: &str,
     execution_context: *const PyExecutionContext,
 ) -> Result<Option<PyObjectRef>, crate::PyError> {
+    // `import builtins` must resolve to `space.builtin`, the one Module every
+    // frame uses for its LOAD_GLOBAL fallback. A fresh `load_builtin_module`
+    // would rerun `install_default_builtins`, minting a second exception
+    // hierarchy and overwriting the name→class registry, so a caught
+    // `except KeyError` would then compare against the wrong `BaseException`.
+    // `load_part` routes the name this way; the `_imp.create_builtin` entry
+    // point must too.
+    if name == "builtins" && !execution_context.is_null() {
+        let module = unsafe { (*execution_context).get_builtin() };
+        set_sys_module(name, module);
+        return Ok(Some(module));
+    }
     let _roots = pyre_object::gc_roots::push_roots();
     let module_slot = pyre_object::gc_roots::shadow_stack_len();
     let Some(module) = load_builtin_module(name) else {

--- a/pyre/pyre-interpreter/src/importing.rs
+++ b/pyre/pyre-interpreter/src/importing.rs
@@ -944,6 +944,26 @@ pub(crate) fn load_builtin_module(name: &str) -> Option<PyObjectRef> {
     Some(module)
 }
 
+/// The builtin-module half of `load_part`: build the module, bind it in
+/// `sys.modules`, then run its `startup` hook. `_imp.create_builtin` performs
+/// the same three steps a native `import` does, so the two entry points leave
+/// a builtin module in the same state.
+pub(crate) fn create_builtin_module(
+    name: &str,
+    execution_context: *const PyExecutionContext,
+) -> Result<Option<PyObjectRef>, crate::PyError> {
+    let _roots = pyre_object::gc_roots::push_roots();
+    let module_slot = pyre_object::gc_roots::shadow_stack_len();
+    let Some(module) = load_builtin_module(name) else {
+        return Ok(None);
+    };
+    pyre_object::gc_roots::pin_root(module);
+    set_sys_module(name, pyre_object::gc_roots::shadow_stack_get(module_slot));
+    let module = pyre_object::gc_roots::shadow_stack_get(module_slot);
+    startup_builtin_module(name, module, execution_context)?;
+    Ok(Some(pyre_object::gc_roots::shadow_stack_get(module_slot)))
+}
+
 fn startup_builtin_module(
     name: &str,
     module: PyObjectRef,
@@ -2394,10 +2414,16 @@ pub fn import_from(
     // via `space.getattr(w_module, '__file__')`, so a descriptor- or
     // `__getattr__`-supplied value and a non-module `from` target are honored;
     // a missing / None path takes the default.
+    let _roots = pyre_object::gc_roots::push_roots();
+    let pkgname_slot = pyre_object::gc_roots::shadow_stack_len();
     let w_pkgname = match crate::baseobjspace::getattr_str(module, "__name__") {
         Ok(v) if unsafe { pyre_object::is_str(v) } => v,
         _ => pyre_object::w_str_new("<unknown module name>"),
     };
+    // The `__file__` lookup below can run a descriptor or `__getattr__` and so
+    // collect; the name string is young and movable, so pin it and read it
+    // back from the slot afterwards.
+    pyre_object::gc_roots::pin_root(w_pkgname);
     // pypy/module/imp/importing.py:460 get_path
     let w_pkgpath = match crate::baseobjspace::getattr_str(module, "__file__") {
         Ok(v) if unsafe { pyre_object::is_none(v) } => pyre_object::w_str_new("unknown location"),
@@ -2407,6 +2433,7 @@ pub fn import_from(
         }
         Err(e) => return Err(e),
     };
+    let w_pkgname = pyre_object::gc_roots::shadow_stack_get(pkgname_slot);
     let pkgname = unsafe { pyre_object::w_str_get_value(w_pkgname) };
     let pkgpath = crate::baseobjspace::utf8_w(w_pkgpath)?;
     let msg = format!("cannot import name '{name}' from '{pkgname}' ({pkgpath})");

--- a/pyre/pyre-interpreter/src/importing.rs
+++ b/pyre/pyre-interpreter/src/importing.rs
@@ -883,7 +883,7 @@ fn init_sysconfigdata_empty(ns: PyObjectRef) {
 /// `W_ModuleDictObject` for every module via
 /// `allocate_and_init_instance(module=True)`. Pyre mirrors that here:
 /// the initializer writes directly into a rooted, non-moving module dict.
-fn load_builtin_module(name: &str) -> Option<PyObjectRef> {
+pub(crate) fn load_builtin_module(name: &str) -> Option<PyObjectRef> {
     let module_def = BUILTIN_MODULES.with(|m| m.borrow().get(name).copied())?;
     let w_dict = pyre_object::dictmultiobject::w_module_dict_new();
     let _roots = pyre_object::gc_roots::push_roots();
@@ -1109,9 +1109,9 @@ fn check_sys_modules(name: &str) -> Option<PyObjectRef> {
 /// report it — `None` is not a module it can hand back, so it falls through
 /// to the search — hence the separate lookup.
 fn sys_modules_blocks(name: &str) -> bool {
-    // Build the key before reading the dict, as `check_sys_modules` does: the
-    // allocation can run a minor collection that relocates the dict, and the
-    // cell holds the address the collector updates.
+    // Build the key before reading the dict, the order `check_sys_modules`
+    // uses: reading the thread-local last keeps the borrow off the stack
+    // across the allocation.
     let key = pyre_object::w_str_new(name);
     let dict = SYS_MODULES_DICT.with(|d| d.get());
     if dict.is_null() {
@@ -1849,7 +1849,71 @@ fn load_source_module(
         }
     }
 
+    // `_bootstrap` has no `sys` or `_imp` of its own until it is handed them,
+    // so every entry point through it raises NameError until this runs. Read
+    // the module back out of sys.modules rather than reusing the local: the
+    // body just executed arbitrary code, and a collection in there relocates
+    // a young module while only the dict entry is updated.
+    if modulename == "importlib._bootstrap" {
+        if let Some(loaded) = check_sys_modules(modulename) {
+            install_importlib_bootstrap(loaded, execution_context)?;
+        }
+    }
+
     Ok(module)
+}
+
+/// Wire a freshly executed `importlib._bootstrap` into this interpreter.
+///
+/// PyPy does the same from `_frozen_importlib`'s `install()`: `_install`
+/// binds `sys` / `_imp` into the module globals and appends BuiltinImporter
+/// and FrozenImporter to `sys.meta_path`, then
+/// `_install_external_importers` imports `_bootstrap_external` — reached
+/// through the `_frozen_importlib_external` alias `absolute_import` already
+/// maps — and appends PathFinder.
+///
+/// PyPy runs it while building the space; doing it as the module finishes
+/// loading keeps both bootstrap files off the startup path, since nothing
+/// reads `sys.meta_path` before something has imported the machinery that
+/// fills it.
+#[cfg(feature = "host_env")]
+fn install_importlib_bootstrap(
+    module: PyObjectRef,
+    execution_context: *const PyExecutionContext,
+) -> Result<(), crate::PyError> {
+    use pyre_object::gc_roots::{pin_root, push_roots, shadow_stack_get, shadow_stack_len};
+
+    let _roots = push_roots();
+    let module_slot = shadow_stack_len();
+    pin_root(module);
+
+    let w_sys = absolute_import("sys", pyre_object::PY_NULL, execution_context)?;
+    let sys_slot = shadow_stack_len();
+    pin_root(w_sys);
+
+    let w_imp = absolute_import("_imp", pyre_object::PY_NULL, execution_context)?;
+    let imp_slot = shadow_stack_len();
+    pin_root(w_imp);
+
+    let install = crate::baseobjspace::getattr_str(shadow_stack_get(module_slot), "_install")?;
+    let install_slot = shadow_stack_len();
+    pin_root(install);
+    let args = [shadow_stack_get(sys_slot), shadow_stack_get(imp_slot)];
+    crate::call::call_function_impl_result(shadow_stack_get(install_slot), &args)?;
+
+    let install_external = crate::baseobjspace::getattr_str(
+        shadow_stack_get(module_slot),
+        "_install_external_importers",
+    )?;
+    crate::call::call_function_impl_result(install_external, &[])?;
+
+    // `_install_external_importers` imports `_frozen_importlib_external`,
+    // which aliases that name onto the loaded submodule; the bootstrap module
+    // itself is only reached under its submodule name, so it never picks up
+    // the matching alias. Register it once both installs have succeeded, so a
+    // body that raised leaves no alias behind.
+    set_sys_module("_frozen_importlib", shadow_stack_get(module_slot));
+    Ok(())
 }
 
 // ── load_package ─────────────────────────────────────────────────────

--- a/pyre/pyre-interpreter/src/importing.rs
+++ b/pyre/pyre-interpreter/src/importing.rs
@@ -489,6 +489,10 @@ pub fn install_builtin_modules() {
     // (PyPy: pypy/module/* mixed modules).
     pyre_install_module!(_weakref);
     pyre_install_module!(_warnings);
+    // `sys.platform == "win32"` sends shutil (and so tempfile) through the
+    // `_winapi` import even though the Windows build installs `posix`.
+    #[cfg(windows)]
+    pyre_install_module!(_winapi);
     pyre_install_module!(_abc);
     pyre_install_module!(_functools);
     pyre_install_module!("_thread"(thread));

--- a/pyre/pyre-interpreter/src/importing.rs
+++ b/pyre/pyre-interpreter/src/importing.rs
@@ -573,9 +573,14 @@ pub fn install_builtin_modules() {
     {
         #[cfg(not(target_arch = "wasm32"))]
         pyre_install_module!("_signal"(signal));
-        #[cfg(not(target_arch = "wasm32"))]
+        // Only a POSIX host has the user/group databases these read; the
+        // platforms without them have no `pwd`/`grp` module at all, and the
+        // callers depend on that: `posixpath.expanduser`, `pathlib` and
+        // `tarfile` all reach for the module inside `try/except ImportError`
+        // and take a fallback when it is missing.
+        #[cfg(unix)]
         pyre_install_module!(pwd);
-        #[cfg(not(target_arch = "wasm32"))]
+        #[cfg(unix)]
         pyre_install_module!(grp);
         #[cfg(unix)]
         pyre_install_module!(resource);

--- a/pyre/pyre-interpreter/src/importing.rs
+++ b/pyre/pyre-interpreter/src/importing.rs
@@ -439,6 +439,28 @@ pub fn register_builtin_module_with_startup(
     });
 }
 
+/// The registered builtin module names, for `sys.builtin_module_names`.
+///
+/// PyPy equivalent: `pypy/module/sys/state.py get_builtin_module_names`,
+/// which likewise reads `space.builtin_modules` rather than a second list.
+/// Reading the registry keeps the advertised set equal to the set `import`
+/// can satisfy under every `cfg` combination, which a parallel list cannot:
+/// the modules gated on `unix` / `wasm32` / `sandbox` differ per build.
+/// Dotted keys (`importlib.machinery`, `__pypy__.builders`) are registry
+/// entries for submodules, not top-level modules, so they are left out.
+pub fn builtin_module_names() -> Vec<&'static str> {
+    BUILTIN_MODULES.with(|m| {
+        let mut names: Vec<&'static str> = m
+            .borrow()
+            .keys()
+            .copied()
+            .filter(|name| !name.contains('.'))
+            .collect();
+        names.sort_unstable();
+        names
+    })
+}
+
 /// Install all standard builtin modules.
 ///
 /// Mirrors PyPy's `baseobjspace.make_builtins()` +

--- a/pyre/pyre-interpreter/src/lib.rs
+++ b/pyre/pyre-interpreter/src/lib.rs
@@ -69,6 +69,7 @@ pub mod host_seam {
 pub mod jit_fnaddr;
 pub mod listobject;
 pub mod opcode_ops;
+pub mod async_operation;
 pub mod pycode;
 pub mod pyopcode;
 pub mod pytraceback;

--- a/pyre/pyre-interpreter/src/lib.rs
+++ b/pyre/pyre-interpreter/src/lib.rs
@@ -66,10 +66,10 @@ pub mod host_seam {
         let _ = std::io::stdout().flush();
     }
 }
+pub mod async_operation;
 pub mod jit_fnaddr;
 pub mod listobject;
 pub mod opcode_ops;
-pub mod async_operation;
 pub mod pycode;
 pub mod pyopcode;
 pub mod pytraceback;

--- a/pyre/pyre-interpreter/src/module/_winapi/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_winapi/mod.rs
@@ -1,0 +1,46 @@
+//! _winapi module — partial port of `lib_pypy/_winapi.py`.
+//!
+//! The Windows build reports `sys.platform == "win32"` while `posix` is the
+//! installed filesystem module, so `os.name` is `"posix"` and the stdlib's
+//! `os.name == "nt"` branches stay dormant while its `sys.platform` ones do
+//! not.  Those reach for `_winapi`, and without the module `import shutil`
+//! — hence `tempfile`, and everything downstream — fails outright.
+//!
+//! The one name a shutil call then goes on to need is
+//! `NeedCurrentDirectoryForExePath`, which `shutil.which` invokes on every
+//! executable lookup; the `CopyFile2` flag and error constants round out
+//! that part of the module surface, though `shutil.copyfile` reads them
+//! only behind a `hasattr(_winapi, "CopyFile2")` probe.  `CopyFile2` is
+//! deliberately absent, so the probe fails and the generic read/write copy
+//! runs, which is the path pyre wants.  Neither name appears in
+//! `lib_pypy/_winapi.py`, which predates the stdlib revision pyre ships, so
+//! both are defined against the Win32 headers instead.
+//!
+//! The process and handle half (`CreateProcess`, `DuplicateHandle`, the
+//! pipe calls) has no reachable caller: `subprocess` picks its Windows
+//! implementation on the presence of `msvcrt`, and `multiprocessing`'s
+//! spawn/reduction paths only touch `_winapi` once a Windows process
+//! launch is already underway.
+
+crate::py_module! {
+    "_winapi",
+    int_constants: {
+        // CopyFileEx flags (winbase.h).
+        "COPY_FILE_ALLOW_DECRYPTED_DESTINATION" => 0x0000_0008,
+        "COPY_FILE_COPY_SYMLINK" => 0x0000_0800,
+        // System error codes (winerror.h) a caller compares
+        // `OSError.winerror` against to decide whether to retry.
+        "ERROR_ACCESS_DENIED" => 5,
+        "ERROR_PRIVILEGE_NOT_HELD" => 1314,
+    },
+    inline_functions: {
+        fn NeedCurrentDirectoryForExePath(exe_name: &str) -> bool {
+            unsafe extern "system" {
+                fn NeedCurrentDirectoryForExePathW(exe_name: *const u16) -> i32;
+            }
+            let exe_name_w: Vec<u16> =
+                exe_name.encode_utf16().chain(std::iter::once(0)).collect();
+            unsafe { NeedCurrentDirectoryForExePathW(exe_name_w.as_ptr()) != 0 }
+        }
+    }
+}

--- a/pyre/pyre-interpreter/src/module/grp/mod.rs
+++ b/pyre/pyre-interpreter/src/module/grp/mod.rs
@@ -4,13 +4,10 @@
 //! getgrgid / getgrnam / getgrall return 4-tuples
 //! `(gr_name, gr_passwd, gr_gid, gr_mem)` matching CPython.
 //!
-//! `register_module` is `#[cfg(unix)]`; on Windows the module dict stays
-//! empty so `import grp` still resolves to the builtin module object.
+//! The module is registered only on unix: a host without the user/group
+//! database has no `grp` module for `import grp` to find, which is what the
+//! stdlib's `try/except ImportError` callers expect.
 
 pub mod grp;
 
-#[cfg(unix)]
 pub use grp::register_module as init;
-
-#[cfg(not(unix))]
-pub fn init(_ns: pyre_object::PyObjectRef) {}

--- a/pyre/pyre-interpreter/src/module/imp/interp_imp.rs
+++ b/pyre/pyre-interpreter/src/module/imp/interp_imp.rs
@@ -110,10 +110,29 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
         crate::make_builtin_function_with_arity(
             "create_builtin",
             |args| {
-                if args.is_empty() {
-                    return Ok(pyre_object::w_none());
+                // `BuiltinImporter.create_module` passes the spec and expects the
+                // module back; `_load` then binds it in sys.modules. A name
+                // already imported keeps its module, so the machinery and a plain
+                // `import X` agree on one object.
+                let Some(&spec) = args.first() else {
+                    return Err(crate::PyError::type_error(
+                        "create_builtin() missing required argument 'spec'",
+                    ));
+                };
+                let w_name = crate::baseobjspace::getattr_str(spec, "name")?;
+                if !unsafe { pyre_object::is_str(w_name) } {
+                    return Err(crate::PyError::type_error("spec.name must be a string"));
                 }
-                Ok(args[0])
+                let name = unsafe { pyre_object::w_str_get_value(w_name) }.to_string();
+                if let Some(module) = crate::importing::get_sys_module(&name) {
+                    return Ok(module);
+                }
+                crate::importing::load_builtin_module(&name).ok_or_else(|| {
+                    crate::PyError::new(
+                        crate::PyErrorKind::ImportError,
+                        format!("no built-in module named {name}"),
+                    )
+                })
             },
             1,
         ),

--- a/pyre/pyre-interpreter/src/module/imp/interp_imp.rs
+++ b/pyre/pyre-interpreter/src/module/imp/interp_imp.rs
@@ -127,7 +127,11 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                 if let Some(module) = crate::importing::get_sys_module(&name) {
                     return Ok(module);
                 }
-                crate::importing::load_builtin_module(&name).ok_or_else(|| {
+                crate::importing::create_builtin_module(
+                    &name,
+                    crate::call::getexecutioncontext(),
+                )?
+                .ok_or_else(|| {
                     crate::PyError::new(
                         crate::PyErrorKind::ImportError,
                         format!("no built-in module named {name}"),

--- a/pyre/pyre-interpreter/src/module/mod.rs
+++ b/pyre/pyre-interpreter/src/module/mod.rs
@@ -56,6 +56,9 @@ pub mod _tokenize;
 pub mod _typing;
 pub mod _warnings;
 pub mod _weakref;
+#[allow(non_snake_case)]
+#[cfg(windows)]
+pub mod _winapi;
 pub mod array;
 pub mod atexit;
 pub mod binascii;

--- a/pyre/pyre-interpreter/src/module/mod.rs
+++ b/pyre/pyre-interpreter/src/module/mod.rs
@@ -69,7 +69,7 @@ pub mod faulthandler;
 #[cfg(not(feature = "sandbox"))]
 pub mod fcntl;
 pub mod gc;
-#[cfg(all(not(target_arch = "wasm32"), not(feature = "sandbox")))]
+#[cfg(all(unix, not(feature = "sandbox")))]
 pub mod grp;
 #[allow(non_snake_case)]
 pub mod imp;
@@ -82,7 +82,7 @@ pub mod mmap;
 pub mod operator;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod posix;
-#[cfg(all(not(target_arch = "wasm32"), not(feature = "sandbox")))]
+#[cfg(all(unix, not(feature = "sandbox")))]
 pub mod pwd;
 pub mod pyexpat;
 #[cfg(not(feature = "sandbox"))]

--- a/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
+++ b/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
@@ -453,10 +453,12 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
 
     // ── Helper: convert std::io::Error → PyError (OSError) ──
     fn io_err(e: std::io::Error, path: &str) -> crate::PyError {
-        crate::PyError::os_error_with_errno(
-            e.raw_os_error().unwrap_or(0),
-            format!("{}: '{}'", e, path),
-        )
+        let w_filename = if path.is_empty() {
+            pyre_object::PY_NULL
+        } else {
+            pyre_object::w_str_new(path)
+        };
+        crate::PyError::os_error_syscall(e.raw_os_error().unwrap_or(0), w_filename)
     }
 
     // ── posix.open(path, flags, mode=0o777) → fd ──

--- a/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
+++ b/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
@@ -458,7 +458,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
         } else {
             pyre_object::w_str_new(path)
         };
-        crate::PyError::os_error_syscall(crate::builtins::io_error_posix_errno(&e), w_filename)
+        crate::PyError::os_error_syscall(crate::builtins::io_error_posix_errno(&e, 0), w_filename)
     }
 
     // ── posix.open(path, flags, mode=0o777) → fd ──
@@ -1271,7 +1271,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                     Ok(make_stat_result(&m, st_flags))
                 }
                 Err(e) => {
-                    let kind = e.raw_os_error().unwrap_or(2);
+                    let kind = crate::builtins::io_error_posix_errno(&e, 2);
                     Err(crate::PyError::os_error_with_errno(
                         kind,
                         format!("{}: '{}'", e, path_str),
@@ -1566,7 +1566,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                             Ok(make_stat_result(&m, st_flags))
                         }
                         Err(e) => Err(crate::PyError::os_error_with_errno(
-                            e.raw_os_error().unwrap_or(9),
+                            crate::builtins::io_error_posix_errno(&e, 9),
                             format!("{}", e),
                         )),
                     }
@@ -1895,7 +1895,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                 |_| match host_posix::getlogin() {
                     Some(name) => Ok(pyre_object::w_str_new(name.to_string_lossy().as_ref())),
                     None => Err(crate::PyError::os_error_with_errno(
-                        std::io::Error::last_os_error().raw_os_error().unwrap_or(0),
+                        crate::builtins::io_error_posix_errno(&std::io::Error::last_os_error(), 0),
                         "getlogin",
                     )),
                 },

--- a/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
+++ b/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
@@ -144,6 +144,70 @@ fn times_result_seq_type() -> PyObjectRef {
     })
 }
 
+/// Split `path` into the root and everything after it, the way
+/// `ntpath.splitroot` splits it three ways with the drive and the root joined
+/// back together.
+///
+/// `_bootstrap_external._path_join` maps this over its parts and classifies
+/// each result: a root that starts or ends with a separator is absolute, one
+/// ending in `:` is drive-relative, anything else is a plain relative part.
+///
+/// Both separators count, so the tests are taken on a copy with `/` rewritten
+/// to `\`; that rewrite is character-for-character, so an offset into it
+/// addresses the same character of the original. The offsets are per
+/// character rather than per byte, which is what makes `"ä:\x"` take the
+/// drive branch — at byte 1 it would be a continuation byte and take none.
+///
+/// Compiled everywhere so the tests run on every platform; only the Windows
+/// build has a caller.
+#[cfg_attr(not(windows), allow(dead_code))]
+fn split_root(path: &str) -> (&str, &str) {
+    const SEP: char = '\\';
+    const UNC_PREFIX: &str = "\\\\?\\UNC\\";
+
+    let norm: Vec<char> = path
+        .chars()
+        .map(|c| if c == '/' { SEP } else { c })
+        .collect();
+    let byte_at = |index: usize| {
+        path.char_indices()
+            .nth(index)
+            .map_or(path.len(), |(offset, _)| offset)
+    };
+    let sep_from = |start: usize| {
+        norm.get(start..)
+            .and_then(|rest| rest.iter().position(|&c| c == SEP))
+            .map(|offset| offset + start)
+    };
+
+    if norm.first() != Some(&SEP) {
+        if norm.get(1) == Some(&':') {
+            // `X:\Windows` keeps the separator in the root; `X:Windows` names
+            // a location on the drive's own cursor and has no root at all.
+            let split = if norm.get(2) == Some(&SEP) { 3 } else { 2 };
+            return path.split_at(byte_at(split));
+        }
+        return ("", path);
+    }
+    if norm.get(1) != Some(&SEP) {
+        // A path rooted on the current drive, e.g. `\Windows`.
+        return path.split_at(byte_at(1));
+    }
+    // A UNC share (`\\server\share`, `\\?\UNC\server\share`) or a device
+    // (`\\.\device`): the root runs to the separator after the share name,
+    // and a path that never reaches a second separator is all root.
+    let unc = norm.len() >= 8
+        && norm[..8]
+            .iter()
+            .map(|c| c.to_ascii_uppercase())
+            .eq(UNC_PREFIX.chars());
+    let start = if unc { 8 } else { 2 };
+    match sep_from(start).and_then(|index| sep_from(index + 1)) {
+        Some(index) => path.split_at(byte_at(index + 1)),
+        None => (path, ""),
+    }
+}
+
 /// posix stub — PyPy: pypy/module/posix/ interp_posix.py
 ///
 /// Provides the minimal surface that os.py module init needs to succeed.
@@ -834,6 +898,32 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
         ns,
         "replace",
         crate::make_builtin_function("replace", |args| rename_impl(args, "replace")),
+    );
+
+    // ── posix._path_splitroot(path) → (root, tail) ──
+    // Registered only where `sys.platform` is `win32`, the same condition
+    // `_bootstrap_external` gates its use on.
+    #[cfg(windows)]
+    crate::module_ns_store(
+        ns,
+        "_path_splitroot",
+        crate::make_builtin_function_with_arity(
+            "_path_splitroot",
+            |args| {
+                let Some(&arg) = args.first() else {
+                    return Err(crate::PyError::type_error(
+                        "_path_splitroot() missing required argument 'path'",
+                    ));
+                };
+                let path = extract_path(arg)?;
+                let (root, tail) = split_root(&path);
+                Ok(pyre_object::w_tuple_new(vec![
+                    pyre_object::w_str_new(root),
+                    pyre_object::w_str_new(tail),
+                ]))
+            },
+            1,
+        ),
     );
 
     // ── posix.listdir(path=".") → list of str ──
@@ -3420,4 +3510,59 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
     }
 
     crate::module_ns_store(ns, "error", crate::typedef::w_object());
+}
+
+#[cfg(test)]
+mod split_root_tests {
+    use super::split_root;
+
+    /// Expectations taken from `ntpath.splitroot`, whose three-way split
+    /// joins drive and root into the root this returns.
+    #[test]
+    fn matches_ntpath_splitroot() {
+        let cases: &[(&str, &str, &str)] = &[
+            ("", "", ""),
+            ("Windows", "", "Windows"),
+            ("a/b", "", "a/b"),
+            ("\\", "\\", ""),
+            ("/", "/", ""),
+            ("\\Windows", "\\", "Windows"),
+            ("/Windows", "/", "Windows"),
+            ("C:", "C:", ""),
+            ("C:a", "C:", "a"),
+            ("C:\\", "C:\\", ""),
+            ("C:/Windows", "C:/", "Windows"),
+            (":a", "", ":a"),
+            ("\\\\server", "\\\\server", ""),
+            ("\\\\server\\share", "\\\\server\\share", ""),
+            ("\\\\server\\share\\", "\\\\server\\share\\", ""),
+            ("\\\\server\\share\\dir", "\\\\server\\share\\", "dir"),
+            ("//server/share/dir", "//server/share/", "dir"),
+            ("\\\\.\\device\\x", "\\\\.\\device\\", "x"),
+            ("\\\\?\\C:\\x", "\\\\?\\C:\\", "x"),
+            (
+                "\\\\?\\UNC\\server\\share\\dir",
+                "\\\\?\\UNC\\server\\share\\",
+                "dir",
+            ),
+            ("//?/unc/server/share/dir", "//?/unc/server/share/", "dir"),
+            // No separator after the share name, so the whole path is root.
+            ("\\\\\\a", "\\\\\\a", ""),
+            // Offsets address characters: the drive branch is taken here.
+            ("\u{e4}:\\x", "\u{e4}:\\", "x"),
+            (
+                "\\\\s\u{e4}rver\\share\\dir",
+                "\\\\s\u{e4}rver\\share\\",
+                "dir",
+            ),
+        ];
+        for &(path, root, tail) in cases {
+            assert_eq!(split_root(path), (root, tail), "split_root({path:?})");
+            assert_eq!(
+                format!("{root}{tail}"),
+                path,
+                "split_root({path:?}) lost characters"
+            );
+        }
+    }
 }

--- a/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
+++ b/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
@@ -516,13 +516,17 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
     use crate::gateway::fsencode_w as extract_path;
 
     // ── Helper: convert std::io::Error → PyError (OSError) ──
-    fn io_err(e: std::io::Error, path: &str) -> crate::PyError {
+    fn errno_err(errno: i32, path: &str) -> crate::PyError {
         let w_filename = if path.is_empty() {
             pyre_object::PY_NULL
         } else {
             pyre_object::w_str_new(path)
         };
-        crate::PyError::os_error_syscall(crate::builtins::io_error_posix_errno(&e, 0), w_filename)
+        crate::PyError::os_error_syscall(errno, w_filename)
+    }
+
+    fn io_err(e: std::io::Error, path: &str) -> crate::PyError {
+        errno_err(crate::builtins::io_error_posix_errno(&e, 0), path)
     }
 
     // ── posix.open(path, flags, mode=0o777) → fd ──
@@ -886,7 +890,19 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
             }
             (None, None)
         };
-        host_os::rename(&src, src_b, &dst, dst_b).map_err(|e| io_err(e, &src))?;
+        host_os::rename(&src, src_b, &dst, dst_b).map_err(|e| {
+            let errno = crate::builtins::io_error_posix_errno(&e, 0);
+            // The source string must survive the destination's allocation.
+            let _roots = pyre_object::gc_roots::push_roots();
+            let src_slot = pyre_object::gc_roots::shadow_stack_len();
+            pyre_object::gc_roots::pin_root(pyre_object::w_str_new(&src));
+            let w_dst = pyre_object::w_str_new(&dst);
+            crate::PyError::os_error_syscall2(
+                errno,
+                pyre_object::gc_roots::shadow_stack_get(src_slot),
+                w_dst,
+            )
+        })?;
         Ok(pyre_object::w_none())
     }
     crate::module_ns_store(
@@ -1374,13 +1390,10 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                     let st_flags = 0u32;
                     Ok(make_stat_result(&m, st_flags))
                 }
-                Err(e) => {
-                    let kind = crate::builtins::io_error_posix_errno(&e, 2);
-                    Err(crate::PyError::os_error_with_errno(
-                        kind,
-                        format!("{}: '{}'", e, path_str),
-                    ))
-                }
+                Err(e) => Err(errno_err(
+                    crate::builtins::io_error_posix_errno(&e, 2),
+                    &path_str,
+                )),
             }
         }
     }
@@ -2095,9 +2108,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                     let path = extract_path(args[0])?;
                     let c_path = std::ffi::CString::new(path.as_bytes())
                         .map_err(|_| crate::PyError::value_error("embedded null in path"))?;
-                    host_posix::chdir(&c_path).map_err(|e| {
-                        crate::PyError::os_error_with_errno(e as i32, format!("chdir: '{}'", path))
-                    })?;
+                    host_posix::chdir(&c_path).map_err(|e| errno_err(e as i32, &path))?;
                     Ok(pyre_object::w_none())
                 },
                 1,

--- a/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
+++ b/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
@@ -458,7 +458,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
         } else {
             pyre_object::w_str_new(path)
         };
-        crate::PyError::os_error_syscall(e.raw_os_error().unwrap_or(0), w_filename)
+        crate::PyError::os_error_syscall(crate::builtins::io_error_posix_errno(&e), w_filename)
     }
 
     // ── posix.open(path, flags, mode=0o777) → fd ──

--- a/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
+++ b/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
@@ -757,69 +757,83 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
         ),
     );
 
-    // ── posix.rename(src, dst, *, src_dir_fd=None, dst_dir_fd=None) ──
+    // ── posix.rename / posix.replace(src, dst, *, src_dir_fd=None,
+    //    dst_dir_fd=None) ──
     // A non-None `src_dir_fd` / `dst_dir_fd` resolves the path relative to the
     // open directory descriptor (`renameat`); the descriptors are only usable
     // where `renameat` exists (unix).
+    //
+    // The two entry points take the same arguments and differ only in what a
+    // pre-existing `dst` does: `replace` overwrites it on every platform,
+    // `rename` leaves that to the platform call. The host layer renames
+    // through `std::fs::rename`, which overwrites on both, so one body serves
+    // both and `name` only selects the text of the argument errors.
+    fn rename_impl(
+        args: &[PyObjectRef],
+        name: &'static str,
+    ) -> Result<PyObjectRef, crate::PyError> {
+        let (pos, kwargs) = crate::builtins::split_builtin_kwargs(args);
+        if pos.len() < 2 {
+            return Err(crate::PyError::type_error(format!(
+                "{name}() requires 2 arguments"
+            )));
+        }
+        if pos.len() > 2 {
+            return Err(crate::PyError::type_error(format!(
+                "{name}() takes exactly 2 positional arguments ({} given)",
+                pos.len()
+            )));
+        }
+        crate::builtins::kwarg_reject_unknown(kwargs, &["src_dir_fd", "dst_dir_fd"], name)?;
+        let src = extract_path(pos[0])?;
+        let dst = extract_path(pos[1])?;
+        let dir_fd = |name: &str| -> Result<Option<i32>, crate::PyError> {
+            match crate::builtins::kwarg_get(kwargs, name) {
+                Some(v) if !unsafe { pyre_object::is_none(v) } => {
+                    if !unsafe { pyre_object::is_int(v) } {
+                        let type_name = crate::typedef::r#type(v)
+                            .map(|t| unsafe { pyre_object::typeobject::w_type_get_name(t) })
+                            .unwrap_or("object");
+                        return Err(crate::PyError::type_error(format!(
+                            "argument should be integer or None, not {type_name}"
+                        )));
+                    }
+                    Ok(Some((unsafe { pyre_object::w_int_get_value(v) }) as i32))
+                }
+                _ => Ok(None),
+            }
+        };
+        let src_fd = dir_fd("src_dir_fd")?;
+        let dst_fd = dir_fd("dst_dir_fd")?;
+        #[cfg(unix)]
+        let (src_b, dst_b) = {
+            use rustpython_host_env::crt_fd::Borrowed;
+            (
+                src_fd.map(|fd| unsafe { Borrowed::borrow_raw(fd) }),
+                dst_fd.map(|fd| unsafe { Borrowed::borrow_raw(fd) }),
+            )
+        };
+        #[cfg(not(unix))]
+        let (src_b, dst_b) = {
+            if src_fd.is_some() || dst_fd.is_some() {
+                return Err(crate::PyError::not_implemented(
+                    "dir_fd unavailable on this platform",
+                ));
+            }
+            (None, None)
+        };
+        host_os::rename(&src, src_b, &dst, dst_b).map_err(|e| io_err(e, &src))?;
+        Ok(pyre_object::w_none())
+    }
     crate::module_ns_store(
         ns,
         "rename",
-        crate::make_builtin_function("rename", |args| {
-            let (pos, kwargs) = crate::builtins::split_builtin_kwargs(args);
-            if pos.len() < 2 {
-                return Err(crate::PyError::type_error("rename() requires 2 arguments"));
-            }
-            if pos.len() > 2 {
-                return Err(crate::PyError::type_error(format!(
-                    "rename() takes exactly 2 positional arguments ({} given)",
-                    pos.len()
-                )));
-            }
-            crate::builtins::kwarg_reject_unknown(
-                kwargs,
-                &["src_dir_fd", "dst_dir_fd"],
-                "rename",
-            )?;
-            let src = extract_path(pos[0])?;
-            let dst = extract_path(pos[1])?;
-            let dir_fd = |name: &str| -> Result<Option<i32>, crate::PyError> {
-                match crate::builtins::kwarg_get(kwargs, name) {
-                    Some(v) if !unsafe { pyre_object::is_none(v) } => {
-                        if !unsafe { pyre_object::is_int(v) } {
-                            let type_name = crate::typedef::r#type(v)
-                                .map(|t| unsafe { pyre_object::typeobject::w_type_get_name(t) })
-                                .unwrap_or("object");
-                            return Err(crate::PyError::type_error(format!(
-                                "argument should be integer or None, not {type_name}"
-                            )));
-                        }
-                        Ok(Some((unsafe { pyre_object::w_int_get_value(v) }) as i32))
-                    }
-                    _ => Ok(None),
-                }
-            };
-            let src_fd = dir_fd("src_dir_fd")?;
-            let dst_fd = dir_fd("dst_dir_fd")?;
-            #[cfg(unix)]
-            let (src_b, dst_b) = {
-                use rustpython_host_env::crt_fd::Borrowed;
-                (
-                    src_fd.map(|fd| unsafe { Borrowed::borrow_raw(fd) }),
-                    dst_fd.map(|fd| unsafe { Borrowed::borrow_raw(fd) }),
-                )
-            };
-            #[cfg(not(unix))]
-            let (src_b, dst_b) = {
-                if src_fd.is_some() || dst_fd.is_some() {
-                    return Err(crate::PyError::not_implemented(
-                        "dir_fd unavailable on this platform",
-                    ));
-                }
-                (None, None)
-            };
-            host_os::rename(&src, src_b, &dst, dst_b).map_err(|e| io_err(e, &src))?;
-            Ok(pyre_object::w_none())
-        }),
+        crate::make_builtin_function("rename", |args| rename_impl(args, "rename")),
+    );
+    crate::module_ns_store(
+        ns,
+        "replace",
+        crate::make_builtin_function("replace", |args| rename_impl(args, "replace")),
     );
 
     // ── posix.listdir(path=".") → list of str ──
@@ -3375,7 +3389,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
             // host filesystem mutation that bypasses the controller
             "chmod", "fchmod", "lchmod", "chown", "fchown", "lchown", "chroot",
             "chdir", "fchdir", "link", "symlink", "truncate", "ftruncate",
-            "rename", "rmdir", "mkfifo", "mknod",
+            "rename", "replace", "rmdir", "mkfifo", "mknod",
             // privilege / scheduling
             "setuid", "setgid", "setreuid", "setregid", "setresuid", "setresgid",
             "setgroups", "initgroups", "setsid", "setpgid", "setpgrp", "nice",

--- a/pyre/pyre-interpreter/src/module/pwd/mod.rs
+++ b/pyre/pyre-interpreter/src/module/pwd/mod.rs
@@ -5,13 +5,10 @@
 //! layout.  `struct_passwd` / `struct_pwent` share identity matching
 //! `app_pwd.py:1-21`.
 //!
-//! `register_module` is `#[cfg(unix)]`; on Windows the module dict stays
-//! empty so `import pwd` still resolves to the builtin module object.
+//! The module is registered only on unix: a host without the user/group
+//! database has no `pwd` module for `import pwd` to find, which is what the
+//! stdlib's `try/except ImportError` callers expect.
 
 pub mod interp_pwd;
 
-#[cfg(unix)]
 pub use interp_pwd::register_module as init;
-
-#[cfg(not(unix))]
-pub fn init(_ns: pyre_object::PyObjectRef) {}

--- a/pyre/pyre-interpreter/src/module/sys/vm.rs
+++ b/pyre/pyre-interpreter/src/module/sys/vm.rs
@@ -60,6 +60,10 @@ fn sys_namespace_init(args: &[PyObjectRef]) -> crate::PyResult {
 /// instance dict directly, so `setdictvalue` is used rather than `setattr` — a
 /// subclass `__setattr__` is not consulted during construction.
 fn namespace_apply_kwargs(self_obj: PyObjectRef, kwargs: Option<PyObjectRef>) -> crate::PyResult {
+    // `self.__dict__.update(kwargs)` evaluates `self.__dict__` first, so a
+    // receiver without an instance dict raises AttributeError even for an
+    // empty keyword set.
+    crate::baseobjspace::getattr_str(self_obj, "__dict__")?;
     if let Some(dict) = kwargs {
         unsafe {
             for (key, value) in pyre_object::w_dict_items(dict) {
@@ -168,19 +172,32 @@ fn simple_namespace_repr(args: &[PyObjectRef]) -> crate::PyResult {
         return Ok(w_str_new("namespace(...)"));
     };
     let dict = crate::baseobjspace::getattr_str(self_obj, "__dict__")?;
+    // A user `__lt__`, `__str__` or `__repr__` below can collect, and the
+    // moving GC relocates the items this snapshot holds. Pin every key and
+    // value on the shadow stack and address them by slot from here on: a raw
+    // `(key, value)` vector would go stale at the first such call.
+    let _roots = pyre_object::gc_roots::push_roots();
+    let base = pyre_object::gc_roots::shadow_stack_len();
+    let items = unsafe { pyre_object::w_dict_items(dict) };
+    for (k, v) in &items {
+        pyre_object::gc_roots::pin_root(*k);
+        pyre_object::gc_roots::pin_root(*v);
+    }
+    let key = |i: usize| pyre_object::gc_roots::shadow_stack_get(base + i * 2);
+    let value = |i: usize| pyre_object::gc_roots::shadow_stack_get(base + i * 2 + 1);
+
     // `sorted(self.__dict__.items())` — order by the key objects with Python
     // `<`, not by their `str()`. Incomparable keys (e.g. `int` mixed with
     // `str`) raise, halting the repr as the sort itself does. Rust's `sort_by`
     // closure cannot return `Result`, so a raising comparison is captured in a
     // `Cell` and surfaced once the sort completes.
-    let mut items = unsafe { pyre_object::w_dict_items(dict) };
     let sort_error: std::cell::Cell<Option<crate::PyError>> = std::cell::Cell::new(None);
-    let lt = |x: PyObjectRef, y: PyObjectRef| -> bool {
+    let lt = |x: usize, y: usize| -> bool {
         if let Some(e) = sort_error.take() {
             sort_error.set(Some(e));
             return false;
         }
-        match crate::baseobjspace::compare(x, y, crate::baseobjspace::CompareOp::Lt) {
+        match crate::baseobjspace::compare(key(x), key(y), crate::baseobjspace::CompareOp::Lt) {
             Ok(r) => crate::baseobjspace::is_true(r).unwrap_or_else(|e| {
                 sort_error.set(Some(e));
                 false
@@ -191,10 +208,11 @@ fn simple_namespace_repr(args: &[PyObjectRef]) -> crate::PyResult {
             }
         }
     };
-    items.sort_by(|a, b| {
-        if lt(a.0, b.0) {
+    let mut order: Vec<usize> = (0..items.len()).collect();
+    order.sort_by(|&a, &b| {
+        if lt(a, b) {
             std::cmp::Ordering::Less
-        } else if lt(b.0, a.0) {
+        } else if lt(b, a) {
             std::cmp::Ordering::Greater
         } else {
             std::cmp::Ordering::Equal
@@ -203,12 +221,12 @@ fn simple_namespace_repr(args: &[PyObjectRef]) -> crate::PyResult {
     if let Some(e) = sort_error.take() {
         return Err(e);
     }
-    let mut parts = Vec::with_capacity(items.len());
-    for (k, v) in items {
+    let mut parts = Vec::with_capacity(order.len());
+    for i in order {
         parts.push(format!(
             "{}={}",
-            unsafe { crate::display::py_str(k)? },
-            unsafe { crate::display::py_repr(v)? }
+            unsafe { crate::display::py_str(key(i))? },
+            unsafe { crate::display::py_repr(value(i))? }
         ));
     }
     Ok(w_str_new(&format!("namespace({})", parts.join(", "))))
@@ -217,17 +235,26 @@ fn simple_namespace_repr(args: &[PyObjectRef]) -> crate::PyResult {
 /// `_structseq.py:185 SimpleNamespace.__eq__` — structural over `__dict__`
 /// when `other` is a namespace, NotImplemented otherwise.
 fn simple_namespace_eq(args: &[PyObjectRef]) -> crate::PyResult {
-    simple_namespace_richcompare(args, false)
+    simple_namespace_richcompare(args, "__eq__", false)
 }
 
 /// `_structseq.py:190 SimpleNamespace.__ne__`.
 fn simple_namespace_ne(args: &[PyObjectRef]) -> crate::PyResult {
-    simple_namespace_richcompare(args, true)
+    simple_namespace_richcompare(args, "__ne__", true)
 }
 
-fn simple_namespace_richcompare(args: &[PyObjectRef], negate: bool) -> crate::PyResult {
+fn simple_namespace_richcompare(
+    args: &[PyObjectRef],
+    name: &str,
+    negate: bool,
+) -> crate::PyResult {
+    // `def __eq__(self, other)` — a missing argument is an arity error, not a
+    // NotImplemented result.
     let (Some(&self_obj), Some(&other)) = (args.first(), args.get(1)) else {
-        return Ok(w_not_implemented());
+        return Err(crate::PyError::type_error(format!(
+            "SimpleNamespace.{name}() missing 1 required positional argument: '{}'",
+            if args.is_empty() { "self" } else { "other" }
+        )));
     };
     if !unsafe { crate::baseobjspace::isinstance_w(other, simple_namespace_type()) } {
         return Ok(w_not_implemented());

--- a/pyre/pyre-interpreter/src/module/sys/vm.rs
+++ b/pyre/pyre-interpreter/src/module/sys/vm.rs
@@ -51,13 +51,26 @@ fn sys_namespace_init(args: &[PyObjectRef]) -> crate::PyResult {
             "types.SimpleNamespace() takes no positional arguments",
         ));
     }
+    namespace_apply_kwargs(self_obj, kwargs)
+}
+
+/// Copy the keyword arguments into a namespace instance's dict, skipping the
+/// `__pyre_kw__` marker. Shared by `sys.namespace` and `types.SimpleNamespace`
+/// construction. `_structseq.py:172` `self.__dict__.update(kwargs)` writes the
+/// instance dict directly, so `setdictvalue` is used rather than `setattr` — a
+/// subclass `__setattr__` is not consulted during construction.
+fn namespace_apply_kwargs(self_obj: PyObjectRef, kwargs: Option<PyObjectRef>) -> crate::PyResult {
     if let Some(dict) = kwargs {
         unsafe {
             for (key, value) in pyre_object::w_dict_items(dict) {
-                if pyre_object::is_str(key)
-                    && pyre_object::w_str_get_wtf8(key).as_str() == Ok("__pyre_kw__")
-                {
-                    continue;
+                if pyre_object::is_str(key) {
+                    if let Ok(name) = pyre_object::w_str_get_wtf8(key).as_str() {
+                        if name == "__pyre_kw__" {
+                            continue;
+                        }
+                        crate::baseobjspace::setdictvalue(self_obj, name, value);
+                        continue;
+                    }
                 }
                 crate::baseobjspace::setattr(self_obj, key, value)?;
             }
@@ -70,6 +83,161 @@ fn sys_namespace_init(args: &[PyObjectRef]) -> crate::PyResult {
 /// all the CPython-style attribute bags surfaced by the sys module.
 fn make_sys_namespace_instance() -> PyObjectRef {
     w_instance_new(sys_namespace_type())
+}
+
+/// `_structseq.py:171 SimpleNamespace.__init__(self, **kwargs)` — keyword-only,
+/// so a positional argument raises the arg-count TypeError instead of being
+/// accepted as a mapping.
+fn simple_namespace_init(args: &[PyObjectRef]) -> crate::PyResult {
+    let (positional, kwargs) = crate::builtins::split_builtin_kwargs(args);
+    let Some(&self_obj) = positional.first() else {
+        return Err(crate::PyError::type_error(
+            "__init__() missing 1 required positional argument: 'self'",
+        ));
+    };
+    if positional.len() > 1 {
+        return Err(crate::PyError::type_error(format!(
+            "SimpleNamespace.__init__() takes 1 positional argument but {} were given",
+            positional.len()
+        )));
+    }
+    namespace_apply_kwargs(self_obj, kwargs)
+}
+
+/// `types.SimpleNamespace` — the attribute-bag type exposed as
+/// `type(sys.implementation)` and re-published by `types.py:20`
+/// (`SimpleNamespace = type(sys.implementation)`).
+///
+/// `_structseq.py:166 SimpleNamespace`: keyword-only construction that copies
+/// into the instance dict, a `namespace(...)` repr over the sorted items with
+/// a recursion guard, structural `__eq__`/`__ne__` (NotImplemented against a
+/// non-namespace), and no `__hash__` (so instances are unhashable). The
+/// keyword copy into the instance dict is shared with `sys.namespace` via
+/// `namespace_apply_kwargs`; the positional rejection is `SimpleNamespace`-specific.
+fn simple_namespace_type() -> PyObjectRef {
+    static TYPE: OnceLock<usize> = OnceLock::new();
+    let raw = *TYPE.get_or_init(|| {
+        let tp = crate::typedef::make_builtin_type("types.SimpleNamespace", |ns| {
+            unsafe {
+                pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
+                    ns,
+                    "__init__",
+                    crate::make_builtin_function("__init__", simple_namespace_init),
+                );
+                pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
+                    ns,
+                    "__repr__",
+                    make_builtin_function_with_arity("__repr__", simple_namespace_repr, 1),
+                );
+                pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
+                    ns,
+                    "__eq__",
+                    make_builtin_function_with_arity("__eq__", simple_namespace_eq, 2),
+                );
+                pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
+                    ns,
+                    "__ne__",
+                    make_builtin_function_with_arity("__ne__", simple_namespace_ne, 2),
+                );
+                // SimpleNamespace defines no `__hash__`, so it inherits None
+                // and is unhashable.
+                pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(ns, "__hash__", w_none());
+                pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
+                    ns,
+                    "__dict__",
+                    crate::typedef::dict_descr(),
+                );
+            }
+        });
+        unsafe { w_type_set_hasdict(tp, true) };
+        tp as usize
+    });
+    raw as PyObjectRef
+}
+
+/// `_structseq.py:174 SimpleNamespace.__repr__` — `namespace(k=v, ...)` over
+/// the sorted `__dict__` items (`%s=%r`), returning `namespace(...)` when the
+/// instance is already being repr'd on this thread.
+fn simple_namespace_repr(args: &[PyObjectRef]) -> crate::PyResult {
+    let Some(&self_obj) = args.first() else {
+        return Err(crate::PyError::type_error(
+            "__repr__() missing 1 required positional argument: 'self'",
+        ));
+    };
+    let Some(_guard) = crate::display::ReprGuard::enter(self_obj) else {
+        return Ok(w_str_new("namespace(...)"));
+    };
+    let dict = crate::baseobjspace::getattr_str(self_obj, "__dict__")?;
+    // `sorted(self.__dict__.items())` — order by the key objects with Python
+    // `<`, not by their `str()`. Incomparable keys (e.g. `int` mixed with
+    // `str`) raise, halting the repr as the sort itself does. Rust's `sort_by`
+    // closure cannot return `Result`, so a raising comparison is captured in a
+    // `Cell` and surfaced once the sort completes.
+    let mut items = unsafe { pyre_object::w_dict_items(dict) };
+    let sort_error: std::cell::Cell<Option<crate::PyError>> = std::cell::Cell::new(None);
+    let lt = |x: PyObjectRef, y: PyObjectRef| -> bool {
+        if let Some(e) = sort_error.take() {
+            sort_error.set(Some(e));
+            return false;
+        }
+        match crate::baseobjspace::compare(x, y, crate::baseobjspace::CompareOp::Lt) {
+            Ok(r) => crate::baseobjspace::is_true(r).unwrap_or_else(|e| {
+                sort_error.set(Some(e));
+                false
+            }),
+            Err(e) => {
+                sort_error.set(Some(e));
+                false
+            }
+        }
+    };
+    items.sort_by(|a, b| {
+        if lt(a.0, b.0) {
+            std::cmp::Ordering::Less
+        } else if lt(b.0, a.0) {
+            std::cmp::Ordering::Greater
+        } else {
+            std::cmp::Ordering::Equal
+        }
+    });
+    if let Some(e) = sort_error.take() {
+        return Err(e);
+    }
+    let mut parts = Vec::with_capacity(items.len());
+    for (k, v) in items {
+        parts.push(format!(
+            "{}={}",
+            unsafe { crate::display::py_str(k)? },
+            unsafe { crate::display::py_repr(v)? }
+        ));
+    }
+    Ok(w_str_new(&format!("namespace({})", parts.join(", "))))
+}
+
+/// `_structseq.py:185 SimpleNamespace.__eq__` — structural over `__dict__`
+/// when `other` is a namespace, NotImplemented otherwise.
+fn simple_namespace_eq(args: &[PyObjectRef]) -> crate::PyResult {
+    simple_namespace_richcompare(args, false)
+}
+
+/// `_structseq.py:190 SimpleNamespace.__ne__`.
+fn simple_namespace_ne(args: &[PyObjectRef]) -> crate::PyResult {
+    simple_namespace_richcompare(args, true)
+}
+
+fn simple_namespace_richcompare(args: &[PyObjectRef], negate: bool) -> crate::PyResult {
+    let (Some(&self_obj), Some(&other)) = (args.first(), args.get(1)) else {
+        return Ok(w_not_implemented());
+    };
+    if !unsafe { crate::baseobjspace::isinstance_w(other, simple_namespace_type()) } {
+        return Ok(w_not_implemented());
+    }
+    // `self.__dict__ == other.__dict__` — read through the descriptor so a
+    // subclass `__dict__` override is honoured, as PyPy's attribute access is.
+    let self_dict = crate::baseobjspace::getattr_str(self_obj, "__dict__")?;
+    let other_dict = crate::baseobjspace::getattr_str(other, "__dict__")?;
+    let equal = crate::baseobjspace::eq_w(self_dict, other_dict)?;
+    Ok(w_bool_from(equal ^ negate))
 }
 
 /// `pypy/module/sys/vm.py:217 space.getexecutioncontext()` access for
@@ -646,7 +814,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
     );
     // sys.implementation — structseq-like namespace with name, version, ...
     {
-        let impl_obj = make_sys_namespace_instance();
+        let impl_obj = w_instance_new(simple_namespace_type());
         crate::baseobjspace::setdictvalue(impl_obj, "name", w_str_new("pyre"));
         crate::baseobjspace::setdictvalue(
             impl_obj,

--- a/pyre/pyre-interpreter/src/module/sys/vm.rs
+++ b/pyre/pyre-interpreter/src/module/sys/vm.rs
@@ -1057,77 +1057,10 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
     // sys.warnoptions
     module_ns_store(ns, "warnoptions", w_list_new(vec![]));
     // sys.builtin_module_names — tuple of names of modules compiled into
-    // the interpreter. PyPy: pypy/module/sys/state.py get_builtin_module_names.
-    // Pyre: include all stub/native built-ins from importing.rs. The host-access
-    // modules importing.rs omits under `sandbox` are gated out here too, so the
-    // advertised set matches what is actually importable.
-    #[allow(unused_mut)]
-    let mut builtin_names = vec![
-        "__pypy__",
-        "_abc",
-        "_bisect",
-        "_blake2",
-        "_codecs",
-        "_collections",
-        "_collections_abc",
-        "_contextvars",
-        "_csv",
-        "_datetime",
-        "_decimal",
-        "_functools",
-        "_hashlib",
-        "_heapq",
-        "_imp",
-        "_io",
-        "_json",
-        "_locale",
-        "_md5",
-        "_opcode",
-        "_operator",
-        "_pickle",
-        "_random",
-        "_sha1",
-        "_sha2",
-        "_sha3",
-        "_signal",
-        "_socket",
-        "_sre",
-        "_stat",
-        "_string",
-        "_struct",
-        "_thread",
-        "_tokenize",
-        "_tracemalloc",
-        "_typing",
-        "_warnings",
-        "_weakref",
-        "atexit",
-        "binascii",
-        "builtins",
-        "errno",
-        "fcntl",
-        "grp",
-        "itertools",
-        "marshal",
-        "math",
-        "cmath",
-        "operator",
-        "posix",
-        "pwd",
-        "select",
-        "sys",
-        "time",
-    ];
-    // Host-access modules registered only in non-sandbox builds (importing.rs);
-    // under `sandbox` they are omitted, so drop them from the advertised set
-    // in place — the surrounding order is left untouched.
-    #[cfg(feature = "sandbox")]
-    builtin_names.retain(|n| {
-        !matches!(
-            *n,
-            "_signal" | "_socket" | "fcntl" | "grp" | "pwd" | "select"
-        )
-    });
+    // the interpreter. PyPy: pypy/module/sys/state.py get_builtin_module_names,
+    // which reads the same registry `import` resolves against, so the
+    // advertised set cannot drift from what is actually importable on a build.
+    let builtin_names = crate::importing::builtin_module_names();
     module_ns_store(
         ns,
         "builtin_module_names",

--- a/pyre/pyre-interpreter/src/objspace/descroperation.rs
+++ b/pyre/pyre-interpreter/src/objspace/descroperation.rs
@@ -1095,8 +1095,12 @@ pub(crate) unsafe fn str_concat(a: PyObjectRef, b: PyObjectRef) -> PyResult {
 unsafe fn repeat_count(n: PyObjectRef) -> Result<usize, PyError> {
     if is_long(n) {
         let big = as_bigint(n);
-        match big.to_usize() {
-            Some(v) => Ok(v),
+        // The count coerces to a signed machine word (an index-sized integer):
+        // a non-negative value exceeding `isize::MAX` overflows rather than
+        // wrapping to a huge `usize` count, matching `getindex_w`. Negative
+        // counts clamp to 0.
+        match big.to_isize() {
+            Some(v) => Ok(if v < 0 { 0 } else { v as usize }),
             None if bigint_lt(big, BigInt::from(0)) => Ok(0),
             None => Err(PyError::new(
                 PyErrorKind::OverflowError,
@@ -1167,6 +1171,11 @@ pub(crate) unsafe fn bytes_concat(a: PyObjectRef, b: PyObjectRef) -> PyResult {
 pub(crate) unsafe fn bytes_repeat(s: PyObjectRef, n: PyObjectRef) -> PyResult {
     let data = pyre_object::bytesobject::bytes_like_data(s);
     let count = repeat_count(n)?;
+    // A count of 1 on exact `bytes` (immutable) returns the receiver unchanged;
+    // a subclass yields a fresh base `bytes`, and mutable `bytearray` copies.
+    if count == 1 && pyre_object::pyobject::is_exact_type(s, &pyre_object::bytesobject::BYTES_TYPE) {
+        return Ok(s);
+    }
     let cap = data
         .len()
         .checked_mul(count)

--- a/pyre/pyre-interpreter/src/objspace/descroperation.rs
+++ b/pyre/pyre-interpreter/src/objspace/descroperation.rs
@@ -1173,7 +1173,8 @@ pub(crate) unsafe fn bytes_repeat(s: PyObjectRef, n: PyObjectRef) -> PyResult {
     let count = repeat_count(n)?;
     // A count of 1 on exact `bytes` (immutable) returns the receiver unchanged;
     // a subclass yields a fresh base `bytes`, and mutable `bytearray` copies.
-    if count == 1 && pyre_object::pyobject::is_exact_type(s, &pyre_object::bytesobject::BYTES_TYPE) {
+    if count == 1 && pyre_object::pyobject::is_exact_type(s, &pyre_object::bytesobject::BYTES_TYPE)
+    {
         return Ok(s);
     }
     let cap = data

--- a/pyre/pyre-interpreter/src/type_methods.rs
+++ b/pyre/pyre-interpreter/src/type_methods.rs
@@ -1907,6 +1907,9 @@ fn complex_component_spec(p: &ParsedSpec, sign: char) -> String {
     if sign != '-' {
         spec.push(sign);
     }
+    if p.no_neg_zero {
+        spec.push('z');
+    }
     if p.alt_form {
         spec.push('#');
     }

--- a/pyre/pyre-interpreter/src/type_methods.rs
+++ b/pyre/pyre-interpreter/src/type_methods.rs
@@ -450,6 +450,14 @@ pub fn list_method_extend(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::Py
             let root_base = pyre_object::gc_roots::shadow_stack_len();
             pyre_object::gc_roots::pin_root(list);
             pyre_object::gc_roots::pin_root(other);
+            // listobject.py:1052 _extend_from_iterable — consult the length
+            // hint before iterating.  A `__length_hint__` returning a negative
+            // value raises ValueError, and one exceeding a C ssize_t raises
+            // OverflowError (via `int_w`), rather than being silently ignored.
+            crate::baseobjspace::length_hint(
+                pyre_object::gc_roots::shadow_stack_get(root_base + 1),
+                0,
+            )?;
             let iterator =
                 crate::baseobjspace::iter(pyre_object::gc_roots::shadow_stack_get(root_base + 1))?;
             pyre_object::gc_roots::pin_root(iterator);

--- a/pyre/pyre-interpreter/src/type_methods.rs
+++ b/pyre/pyre-interpreter/src/type_methods.rs
@@ -1768,9 +1768,12 @@ struct ParsedSpec {
     fractional_grouping: Option<char>,
     precision: Option<usize>,
     ty: char,
+    /// The `z` option (PEP 682): coerce a negative-zero result to positive
+    /// zero. Held only in the pyre-side parse — the engine spec drops it.
+    no_neg_zero: bool,
     /// The equivalent pre-3.14 spec accepted by rustpython-common's format
-    /// engine (the fractional grouping marker, and its otherwise-empty dot,
-    /// are removed).
+    /// engine (the fractional grouping marker, its otherwise-empty dot, and
+    /// the `z` option are removed).
     engine_spec: String,
     width_start: usize,
     width_end: usize,
@@ -1793,6 +1796,15 @@ fn parse_spec(spec: &str) -> ParsedSpec {
     let mut sign: Option<char> = None;
     if i < n && matches!(chars[i], '+' | '-' | ' ') {
         sign = Some(chars[i]);
+        i += 1;
+    }
+    // PEP 682 `z`: sits after the sign and before `#`. The engine does not
+    // accept it, so record it and drop its index from `engine_spec` below.
+    let mut no_neg_zero = false;
+    let mut z_index: Option<usize> = None;
+    if i < n && chars[i] == 'z' {
+        no_neg_zero = true;
+        z_index = Some(i);
         i += 1;
     }
     let mut alt_form = false;
@@ -1856,13 +1868,20 @@ fn parse_spec(spec: &str) -> ParsedSpec {
         .iter()
         .enumerate()
         .filter_map(|(index, ch)| {
-            if Some(index) == fractional_grouping_index || Some(index) == empty_precision_dot {
+            if Some(index) == fractional_grouping_index
+                || Some(index) == empty_precision_dot
+                || Some(index) == z_index
+            {
                 None
             } else {
                 Some(*ch)
             }
         })
         .collect();
+    // `z` precedes the width, so dropping it from `engine_spec` shifts the
+    // width slice left by one; `float_engine_spec_with_width` indexes the
+    // engine spec, so bias the recorded bounds to match.
+    let z_shift = z_index.is_some() as usize;
     ParsedSpec {
         fill,
         align,
@@ -1873,9 +1892,10 @@ fn parse_spec(spec: &str) -> ParsedSpec {
         fractional_grouping,
         precision,
         ty,
+        no_neg_zero,
         engine_spec,
-        width_start,
-        width_end,
+        width_start: width_start - z_shift,
+        width_end: width_end - z_shift,
     }
 }
 
@@ -2114,9 +2134,9 @@ fn format_spec_err(
         E::ExclusiveFormat(c1, c2) => {
             crate::PyError::value_error(format!("Cannot specify both '{c1}' and '{c2}'."))
         }
-        E::UnknownFormatCode(c, _) if integer && c == 'z' => crate::PyError::value_error(
-            "Negative zero coercion (z) not allowed in integer format specifier",
-        ),
+        E::UnknownFormatCode(c, _) if integer && c == 'z' => {
+            crate::PyError::value_error("Negative zero coercion (z) not allowed")
+        }
         E::UnknownFormatCode(c, _) => crate::PyError::value_error(format!(
             "Unknown format code '{}' for object of type '{type_name}'",
             unknown_code_display(c)
@@ -2639,6 +2659,28 @@ fn validate_float_spec(spec: &str, p: &ParsedSpec) -> Result<(), crate::PyError>
     Ok(())
 }
 
+/// Probe whether `v` renders to a zero magnitude under `p` — every digit of
+/// the unpadded rendering is `0` — so PEP 682's `z` option coerces its sign.
+fn float_rounds_to_zero(v: f64, p: &ParsedSpec) -> bool {
+    let probe_spec = float_engine_spec_with_width(p, Some(0));
+    let Some(rendered) = rustpython_common::format::FormatSpec::parse(probe_spec.as_str())
+        .ok()
+        .and_then(|f| f.format_float(v).ok())
+    else {
+        return false;
+    };
+    let mut saw_digit = false;
+    for b in rendered.bytes() {
+        if b.is_ascii_digit() {
+            saw_digit = true;
+            if b != b'0' {
+                return false;
+            }
+        }
+    }
+    saw_digit
+}
+
 /// Format a finite `f64` through `spec`.  Every presentation type
 /// (`\0`/`e`/`E`/`f`/`F`/`g`/`G`/`n`/`%`) pads, groups, and rounds through the
 /// shared engine.  `validate_float_spec` still supplies the type and
@@ -2646,6 +2688,14 @@ fn validate_float_spec(spec: &str, p: &ParsedSpec) -> Result<(), crate::PyError>
 fn format_finite_float(v: f64, spec: &str) -> Result<Wtf8Buf, crate::PyError> {
     let p = parse_spec(spec);
     validate_float_spec(spec, &p)?;
+    // PEP 682 `z`: a value that rounds to a zero magnitude renders its sign
+    // away. Format the positive zero in its place so the padded result the
+    // engine produces below already carries the coerced sign.
+    let v = if p.no_neg_zero && v.is_sign_negative() && float_rounds_to_zero(v, &p) {
+        0.0
+    } else {
+        v
+    };
     if let Some(separator) = p.fractional_grouping {
         let unpadded_spec = float_engine_spec_with_width(&p, None);
         let unpadded = rustpython_common::format::FormatSpec::parse(unpadded_spec.as_str())

--- a/pyre/pyre-interpreter/src/type_methods.rs
+++ b/pyre/pyre-interpreter/src/type_methods.rs
@@ -2320,6 +2320,15 @@ fn format_with_spec(val: PyObjectRef, spec: &str) -> Result<Wtf8Buf, crate::PyEr
                     "'=' alignment flag is not allowed in complex format specifier",
                 ));
             }
+            // Only the float presentation types e/E/f/F/g/G/n are valid for
+            // complex; reject any other code with a `complex`-typed message
+            // rather than letting the per-part float formatter report `float`.
+            if p.ty != '\0' && !matches!(p.ty, 'e' | 'E' | 'f' | 'F' | 'g' | 'G' | 'n') {
+                return Err(crate::PyError::value_error(format!(
+                    "Unknown format code '{}' for object of type 'complex'",
+                    p.ty
+                )));
+            }
             let align = p.align.unwrap_or('>');
             // With no component-affecting flags, the default presentation is
             // exactly str(self), padded as a single complex value.

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -913,8 +913,11 @@ pub fn init_typeobjects() {
         // `iter(callable, sentinel)` produces a `_CallableIterator`; register
         // its type so `type(it)` / `it.__class__` resolve like the other
         // iterators. Not directly instantiable.
-        let callable_iterator_type =
-            new_typeobject_with_base("callable_iterator", init_callable_iterator_type, object_type);
+        let callable_iterator_type = new_typeobject_with_base(
+            "callable_iterator",
+            init_callable_iterator_type,
+            object_type,
+        );
         unsafe {
             pyre_object::w_type_set_disallow_instantiation(callable_iterator_type);
             pyre_object::w_type_set_acceptable_as_base_class(callable_iterator_type, false);

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -1156,6 +1156,7 @@ pub fn init_typeobjects() {
     static PATCH_TYPEOBJECTS: std::sync::Once = std::sync::Once::new();
     PATCH_TYPEOBJECTS.call_once(|| {
         patch_object_class_descriptor();
+        patch_complex_realimag_descriptors();
         patch_builtin_function_descriptors();
         patch_function_member_descriptors();
         patch_module_descriptors();
@@ -1203,6 +1204,54 @@ fn patch_object_class_descriptor() {
             Some("__class__"),
         ),
     );
+}
+
+/// Install `complex.real` / `complex.imag` after the complex type exists.
+///
+/// complexobject.py:556-561 `complexwprop` builds each as
+/// `GetSetProperty(fget, doc=doc, cls=W_ComplexObject)`; the `cls` gives the
+/// descriptor its `__objclass__` and rejects a non-complex receiver. The
+/// complex type object is not available while `init_complex_type` fills the
+/// namespace (it is created by the same call that runs the initializer), so
+/// the two descriptors are stored here, once the type is registered.
+fn patch_complex_realimag_descriptors() {
+    let complex_type = gettypefor(&pyre_object::COMPLEX_TYPE).unwrap_or(pyre_object::PY_NULL);
+    if complex_type.is_null() || !crate::type_dict_has_storage(complex_type) {
+        return;
+    }
+    for (name, doc, getter) in [
+        (
+            "real",
+            "the real part of a complex number",
+            make_builtin_function_with_arity(
+                "real",
+                |args| Ok(pyre_object::w_float_new(unsafe { pyre_object::w_complex_get_real(args[1]) })),
+                2,
+            ),
+        ),
+        (
+            "imag",
+            "the imaginary part of a complex number",
+            make_builtin_function_with_arity(
+                "imag",
+                |args| Ok(pyre_object::w_float_new(unsafe { pyre_object::w_complex_get_imag(args[1]) })),
+                2,
+            ),
+        ),
+    ] {
+        crate::type_dict_store(
+            complex_type,
+            name,
+            make_getset_property_full(
+                getter,
+                pyre_object::PY_NULL,
+                pyre_object::PY_NULL,
+                pyre_object::w_str_new(doc),
+                complex_type,
+                Some(name),
+            ),
+        );
+    }
 }
 
 /// `typedef.py:58 add_entries` parity — walk every registered
@@ -13868,45 +13917,10 @@ fn init_complex_type(ns: PyObjectRef) {
             ),
         )
     };
-    // complex.real / complex.imag — read-only float components.
-    unsafe {
-        pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
-            ns,
-            "real",
-            pyre_object::w_property_new(
-                make_builtin_function_with_arity(
-                    "real",
-                    |args| {
-                        Ok(pyre_object::w_float_new(unsafe {
-                            pyre_object::w_complex_get_real(args[0])
-                        }))
-                    },
-                    1,
-                ),
-                pyre_object::PY_NULL,
-                pyre_object::PY_NULL,
-            ),
-        )
-    };
-    unsafe {
-        pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
-            ns,
-            "imag",
-            pyre_object::w_property_new(
-                make_builtin_function_with_arity(
-                    "imag",
-                    |args| {
-                        Ok(pyre_object::w_float_new(unsafe {
-                            pyre_object::w_complex_get_imag(args[0])
-                        }))
-                    },
-                    1,
-                ),
-                pyre_object::PY_NULL,
-                pyre_object::PY_NULL,
-            ),
-        )
-    };
+    // complex.real / complex.imag — read-only float getset descriptors.
+    // Installed post-registration by `patch_complex_realimag_descriptors`
+    // because the required-class check needs the complex type object, which
+    // does not exist yet while this namespace is being filled.
     for (name, func) in [
         ("__add__", complex_dunder_add as DunderFn),
         ("__radd__", complex_dunder_radd),

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -2526,27 +2526,28 @@ fn bool_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
                         "object of this type has no bool()",
                     ));
                 }
-                let result = crate::call_function(method, &[w_obj]);
-                if !result.is_null() {
-                    if !pyre_object::is_bool(result) {
-                        // A tagged immediate is always an exact `int`; name it
-                        // without derefing its (non-pointer) tagged bits as
-                        // `ob_type`. Mirrors the tag short-circuit in
-                        // `builtin_str`. Gated on `CAN_BE_TAGGED`.
-                        let tp_name: &str = if pyre_object::tagged_int::CAN_BE_TAGGED
-                            && pyre_object::tagged_int::is_tagged_int(result)
-                        {
-                            "int"
-                        } else {
-                            (*(*result).ob_type).name
-                        };
-                        return Err(crate::PyError::type_error(format!(
-                            "__bool__ should return bool, returned {}",
-                            tp_name,
-                        )));
-                    }
-                    return Ok(result);
+                // Propagate a raised `__bool__` instead of dropping its
+                // stashed error and falling through to `is_true`, which would
+                // dispatch a second time and leave the first copy pending.
+                let result = crate::builtins::call_and_check(method, &[w_obj])?;
+                if !pyre_object::is_bool(result) {
+                    // A tagged immediate is always an exact `int`; name it
+                    // without derefing its (non-pointer) tagged bits as
+                    // `ob_type`. Mirrors the tag short-circuit in
+                    // `builtin_str`. Gated on `CAN_BE_TAGGED`.
+                    let tp_name: &str = if pyre_object::tagged_int::CAN_BE_TAGGED
+                        && pyre_object::tagged_int::is_tagged_int(result)
+                    {
+                        "int"
+                    } else {
+                        (*(*result).ob_type).name
+                    };
+                    return Err(crate::PyError::type_error(format!(
+                        "__bool__ should return bool, returned {}",
+                        tp_name,
+                    )));
                 }
+                return Ok(result);
             }
             if let Some(len_m) = crate::baseobjspace::lookup_in_type(w_type, "__len__") {
                 if pyre_object::is_none(len_m) {
@@ -2554,9 +2555,10 @@ fn bool_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
                         "object of this type has no len()",
                     ));
                 }
-                // __len__ returning negative → ValueError
-                let len_result = crate::call_function(len_m, &[w_obj]);
-                if !len_result.is_null() && pyre_object::is_int(len_result) {
+                // __len__ returning negative → ValueError. Propagate a raised
+                // `__len__` rather than dropping its stashed error.
+                let len_result = crate::builtins::call_and_check(len_m, &[w_obj])?;
+                if pyre_object::is_int(len_result) {
                     let v = pyre_object::w_int_get_value(len_result);
                     if v < 0 {
                         return Err(crate::PyError::new(

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -16473,11 +16473,10 @@ fn split_bytes_ws(data: &[u8], maxsplit: i64) -> Vec<Vec<u8>> {
             break;
         }
         if maxsplit >= 0 && parts.len() as i64 >= maxsplit {
-            let mut end = n;
-            while end > i && is_ws(data[end - 1]) {
-                end -= 1;
-            }
-            parts.push(data[i..end].to_vec());
+            // `rstring.py split` (sep=None): once maxsplit is reached the rest
+            // of the string is the final field verbatim — trailing whitespace
+            // is kept, not stripped.
+            parts.push(data[i..n].to_vec());
             break;
         }
         let start = i;
@@ -16501,11 +16500,10 @@ fn rsplit_bytes_ws(data: &[u8], maxsplit: i64) -> Vec<Vec<u8>> {
             break;
         }
         if maxsplit >= 0 && parts.len() as i64 >= maxsplit {
-            let mut start = 0;
-            while start < i && is_ws(data[start]) {
-                start += 1;
-            }
-            parts.push(data[start..i].to_vec());
+            // `rstring.py rsplit` (sep=None): once maxsplit is reached the
+            // leading remainder is the final field verbatim — leading
+            // whitespace is kept, not stripped.
+            parts.push(data[0..i].to_vec());
             break;
         }
         let end = i;

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -910,6 +910,19 @@ pub fn init_typeobjects() {
             &pyre_object::functional::ZIP_TYPE as *const PyType as usize,
             new_typeobject_with_base("zip", init_zip_type, object_type) as usize,
         );
+        // `iter(callable, sentinel)` produces a `_CallableIterator`; register
+        // its type so `type(it)` / `it.__class__` resolve like the other
+        // iterators. Not directly instantiable.
+        let callable_iterator_type =
+            new_typeobject_with_base("callable_iterator", init_callable_iterator_type, object_type);
+        unsafe {
+            pyre_object::w_type_set_disallow_instantiation(callable_iterator_type);
+            pyre_object::w_type_set_acceptable_as_base_class(callable_iterator_type, false);
+        }
+        reg.insert(
+            &pyre_object::operation::CALLABLE_ITERATOR_TYPE as *const PyType as usize,
+            callable_iterator_type as usize,
+        );
         for (pytype, name, init) in [
             (
                 &pyre_object::dictmultiobject::DICT_KEYITERATOR_TYPE as *const PyType,
@@ -3300,6 +3313,20 @@ fn init_enumerate_type(ns: PyObjectRef) {
             "__class_getitem__",
             crate::_pypy_generic_alias::generic_alias_class_getitem,
         )),
+    );
+}
+
+/// `operation.py W_IterCallable.typedef` — `iter(callable, sentinel)`.
+fn init_callable_iterator_type(ns: PyObjectRef) {
+    install_functional_entry(
+        ns,
+        "__iter__",
+        make_builtin_function_with_arity("__iter__", crate::baseobjspace::iter_self_method, 1),
+    );
+    install_functional_entry(
+        ns,
+        "__next__",
+        make_builtin_function_with_arity("__next__", crate::baseobjspace::iter_next_method, 1),
     );
 }
 

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -3376,20 +3376,6 @@ fn init_enumerate_type(ns: PyObjectRef) {
     );
 }
 
-/// `operation.py W_IterCallable.typedef` — `iter(callable, sentinel)`.
-fn init_callable_iterator_type(ns: PyObjectRef) {
-    install_functional_entry(
-        ns,
-        "__iter__",
-        make_builtin_function_with_arity("__iter__", crate::baseobjspace::iter_self_method, 1),
-    );
-    install_functional_entry(
-        ns,
-        "__next__",
-        make_builtin_function_with_arity("__next__", crate::baseobjspace::iter_next_method, 1),
-    );
-}
-
 /// PyPy `functional.py W_ReversedIterator.typedef`.
 fn init_reversed_type(ns: PyObjectRef) {
     install_functional_entry(
@@ -9359,7 +9345,7 @@ fn init_type_type(ns: PyObjectRef) {
 unsafe fn mro_subclasses(w_type: PyObjectRef) {
     let mro = crate::baseobjspace::compute_mro(w_type);
     pyre_object::w_type_set_mro(w_type, mro);
-    for w_sc in pyre_object::typeobject::w_type_get_subclasses(w_type) {
+    for w_sc in unsafe { pyre_object::typeobject::w_type_get_subclasses(w_type, false) } {
         mro_subclasses(w_sc);
     }
 }

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -1225,7 +1225,11 @@ fn patch_complex_realimag_descriptors() {
             "the real part of a complex number",
             make_builtin_function_with_arity(
                 "real",
-                |args| Ok(pyre_object::w_float_new(unsafe { pyre_object::w_complex_get_real(args[1]) })),
+                |args| {
+                    Ok(pyre_object::w_float_new(unsafe {
+                        pyre_object::w_complex_get_real(args[1])
+                    }))
+                },
                 2,
             ),
         ),
@@ -1234,7 +1238,11 @@ fn patch_complex_realimag_descriptors() {
             "the imaginary part of a complex number",
             make_builtin_function_with_arity(
                 "imag",
-                |args| Ok(pyre_object::w_float_new(unsafe { pyre_object::w_complex_get_imag(args[1]) })),
+                |args| {
+                    Ok(pyre_object::w_float_new(unsafe {
+                        pyre_object::w_complex_get_imag(args[1])
+                    }))
+                },
                 2,
             ),
         ),

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -9317,7 +9317,7 @@ fn type_set_bases(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
         let n = pyre_object::w_tuple_len(w_value);
         if n == 0 {
             return Err(crate::PyError::type_error(format!(
-                "can only assign non-empty tuple to {type_name}.__bases__"
+                "can only assign non-empty tuple to {type_name}.__bases__, not ()"
             )));
         }
         // find_best_base: pick the base with the most-derived instance layout.
@@ -9353,9 +9353,12 @@ fn type_set_bases(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
         // as Generic is fine; switching to an incompatible solid base is not.
         let cur_layout = pyre_object::w_type_get_layout_ptr(w_type);
         if best_layout != cur_layout {
+            // The clash names the new best base and the type's *current* best
+            // base (`__base__`), not the type being reassigned.
             return Err(crate::PyError::type_error(format!(
-                "__bases__ assignment: '{}' object layout differs from '{type_name}'",
-                pyre_object::w_type_get_name(w_bestbase)
+                "__bases__ assignment: '{}' object layout differs from '{}'",
+                pyre_object::w_type_get_name(w_bestbase),
+                pyre_object::w_type_get_name(pyre_object::typeobject::w_type_get_best_base(w_type))
             )));
         }
         pyre_object::typeobject::w_type_set_bases(w_type, w_value);

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -9343,6 +9343,19 @@ fn init_type_type(ns: PyObjectRef) {
     };
 }
 
+/// `typeobject.py:1090 mro_subclasses` — recompute the MRO of `w_type` and,
+/// recursively, of every subclass, after a base change alters the
+/// linearization.  The subclasses stay reachable through the (rooted) type
+/// hierarchy across each `compute_mro` allocation, so the walk needs no
+/// extra rooting (mirrors `baseobjspace::mutated`).
+unsafe fn mro_subclasses(w_type: PyObjectRef) {
+    let mro = crate::baseobjspace::compute_mro(w_type);
+    pyre_object::w_type_set_mro(w_type, mro);
+    for w_sc in pyre_object::typeobject::w_type_get_subclasses(w_type) {
+        mro_subclasses(w_sc);
+    }
+}
+
 /// `type.__bases__` setter (typeobject.py:1064-1105 `descr_set__bases__`).
 /// Heap types only; the new bases must be a non-empty tuple of classes whose
 /// best base shares the current instance layout (so instances stay valid).
@@ -9410,10 +9423,29 @@ fn type_set_bases(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
                 pyre_object::w_type_get_name(pyre_object::typeobject::w_type_get_best_base(w_type))
             )));
         }
+        // Invalidate the method cache of w_type and every subclass before the
+        // hierarchy changes (typeobject.py:1130 `w_type.mutated(None)`).
+        crate::baseobjspace::mutated(w_type, None);
+        // Unlink w_type from its old bases' subclass lists before switching to
+        // the new bases (typeobject.py:1136-1138 `remove_subclass`); the new
+        // bases are relinked by `w_type_ready` below (typeobject.py:1140-1142
+        // `add_subclass`).
+        let saved_bases = pyre_object::typeobject::w_type_get_bases(w_type);
+        if !saved_bases.is_null() {
+            let old_n = pyre_object::w_tuple_len(saved_bases);
+            for i in 0..old_n as i64 {
+                if let Some(w_oldbase) = pyre_object::w_tuple_getitem(saved_bases, i) {
+                    if pyre_object::is_type(w_oldbase) {
+                        pyre_object::typeobject::w_type_remove_subclass(w_oldbase, w_type);
+                    }
+                }
+            }
+        }
         pyre_object::typeobject::w_type_set_bases(w_type, w_value);
-        let mro = crate::baseobjspace::compute_mro(w_type);
-        pyre_object::w_type_set_mro(w_type, mro);
         pyre_object::typeobject::w_type_ready(w_type);
+        // Recompute the MRO of w_type and, recursively, of every subclass
+        // (typeobject.py:1144 `mro_subclasses`).
+        mro_subclasses(w_type);
         Ok(pyre_object::w_none())
     }
 }

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -19403,6 +19403,12 @@ fn setlike_descr_reduce(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyEr
 }
 
 fn setlike_descr_isdisjoint(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    let name = if unsafe { pyre_object::is_frozenset(args[0]) } {
+        "frozenset.isdisjoint"
+    } else {
+        "set.isdisjoint"
+    };
+    crate::type_methods::arity_exact(args, name, 1)?;
     if unsafe { pyre_object::is_set_or_frozenset(args[1]) } {
         return Ok(pyre_object::w_bool_from(set_is_disjoint_from(
             args[0], args[1],
@@ -20155,12 +20161,12 @@ pub(crate) fn set_method_difference(
 pub(crate) fn set_method_symmetric_difference(
     args: &[pyre_object::PyObjectRef],
 ) -> Result<pyre_object::PyObjectRef, crate::PyError> {
-    if args.len() < 2 {
-        if args.is_empty() {
-            return Ok(pyre_object::w_set_new());
-        }
-        return Ok(args[0]);
-    }
+    let name = if unsafe { pyre_object::is_frozenset(args[0]) } {
+        "frozenset.symmetric_difference"
+    } else {
+        "set.symmetric_difference"
+    };
+    crate::type_methods::arity_exact(args, name, 1)?;
     // `setobject.py symmetric_difference` wraps the computed storage
     // in a set of self's class.
     let w_other_as_set = set_operand_as_set(args[1])?;
@@ -20338,9 +20344,12 @@ pub(crate) fn set_is_subset_of(
 fn set_method_le(
     args: &[pyre_object::PyObjectRef],
 ) -> Result<pyre_object::PyObjectRef, crate::PyError> {
-    if args.len() < 2 {
-        return Ok(pyre_object::w_bool_from(true));
-    }
+    let name = if unsafe { pyre_object::is_frozenset(args[0]) } {
+        "frozenset.issubset"
+    } else {
+        "set.issubset"
+    };
+    crate::type_methods::arity_exact(args, name, 1)?;
     let w_other_as_set = set_operand_as_set(args[1])?;
     Ok(pyre_object::w_bool_from(set_is_subset_of(
         args[0],
@@ -20351,9 +20360,12 @@ fn set_method_le(
 fn set_method_ge(
     args: &[pyre_object::PyObjectRef],
 ) -> Result<pyre_object::PyObjectRef, crate::PyError> {
-    if args.len() < 2 {
-        return Ok(pyre_object::w_bool_from(true));
-    }
+    let name = if unsafe { pyre_object::is_frozenset(args[0]) } {
+        "frozenset.issuperset"
+    } else {
+        "set.issuperset"
+    };
+    crate::type_methods::arity_exact(args, name, 1)?;
     // `setobject.py descr_issuperset` — the operand becomes a set and
     // the subset test runs the other way round.
     let w_other_as_set = set_operand_as_set(args[1])?;
@@ -20432,9 +20444,7 @@ fn set_method_intersection_update(
 fn set_method_symmetric_difference_update(
     args: &[pyre_object::PyObjectRef],
 ) -> Result<pyre_object::PyObjectRef, crate::PyError> {
-    if args.is_empty() || args.len() < 2 {
-        return Ok(pyre_object::w_none());
-    }
+    crate::type_methods::arity_exact(args, "set.symmetric_difference_update", 1)?;
     let w_other_as_set = set_operand_as_set(args[1])?;
     let w_new = set_symmetric_difference_storage(args[0], w_other_as_set)?;
     // `setobject.py` — the computed storage replaces self's.

--- a/pyre/pyre-object/src/listobject.rs
+++ b/pyre/pyre-object/src/listobject.rs
@@ -1314,17 +1314,6 @@ fn int_eq_float(ival: i64, fval: f64) -> bool {
     fval as i64 == ival
 }
 
-/// listobject.py:2103-2125 FloatListStrategy._safe_find_or_count
-/// Fast path for float lists: handles NaN via bit-pattern comparison.
-unsafe fn float_find(items: &[f64], value: f64) -> Option<usize> {
-    if !value.is_nan() {
-        items.iter().position(|&v| v == value)
-    } else {
-        let bits = value.to_bits();
-        items.iter().position(|&v| v.to_bits() == bits)
-    }
-}
-
 /// Outcome of `W_ListObject.find_or_count` fast path. Mirrors the
 /// short-circuit return in `IntegerListStrategy.find_or_count`
 /// (listobject.py:1613) and `FloatListStrategy.find_or_count` — when the

--- a/pyre/pyrex/src/lib.rs
+++ b/pyre/pyrex/src/lib.rs
@@ -816,7 +816,10 @@ fn run_source(source: &str, mode: Mode, filename: &str, no_site: bool) {
     let code = match compile_source_with_filename(source, mode, filename) {
         Ok(code) => code,
         Err(e) => {
-            eprintln!("{e}");
+            // Render the `File "…", line N` + source + caret + `SyntaxError:`
+            // banner for the malformed source, matching an interactive run.
+            let err = pyre_interpreter::compile_err_to_syntax_error(e, source);
+            pyre_interpreter::eprint_syntax_error(&err);
             std::process::exit(1);
         }
     };


### PR DESCRIPTION
A batch of objspace behavior gaps where pyre diverged from CPython 3.14, each
found by a three-way sweep (pyre-dynasm vs CPython 3.14 vs PyPy 3.11) and fixed
to match CPython, with a synth parity bench per fix. Benches compare exception
type / value only where CPython and PyPy message text differs. `pyre/check.py`
green on all three backends.

## Attribute lookup
- **Instance dict now shadows a class attribute on builtin-type subclasses.**
  `object_getattr_miss` returned a class-MRO attribute without consulting the
  instance dict, so a heap subclass of `tuple`/`int`/`str`/… could not shadow a
  same-named non-data-descriptor class attribute with an instance attribute.
  For a `hasdict` type it now runs the `object.__getattribute__` protocol (data
  descriptor → instance dict → non-data / class var); exact builtins keep the
  direct fast path. This also fixes **`str.encode()` accepting non-text
  codecs**: `CodecInfo` is a `tuple` subclass whose binary-codec instances set
  `_is_text_encoding = False`, which the class default `True` was masking — so
  `"x".encode("hex"|"base64"|"zlib"|"rot13")` now raises `LookupError`.

## bool()
- A raised `__bool__`/`__len__` was dispatched through the raw call path, whose
  stashed error was dropped; control fell through to `is_true`, which raised a
  second copy while the first leaked and resurfaced on a later unrelated opcode.
  Both calls now go through `call_and_check`, propagating the error immediately.

## Hashing
- `hash(float('nan'))` returned the `HASH_NAN` constant (0, all NaNs collide);
  a NaN now hashes by object identity.
- A `tuple`/`frozenset` subclass setting `__hash__ = None` reached the
  structural hash fast path and hashed by contents; it now consults the
  `__hash__` slot (None → unhashable, override → dispatch, inherited → fast
  path), for `hash()` and set insertion alike.

## Numeric coercion
- `int(x)` whose `__int__` returns a non-int raised `RuntimeError`; now
  `TypeError` "__int__ returned non-int (type X)" like the `__index__` path.
- `complex(x)` for a value with only `__index__` (no `__complex__`/`__float__`)
  raised "must be real number"; it now falls back to `__index__` like `float()`.

## Sequences
- A repeat count in `[2**63, 2**64)` raised `MemoryError`; a count that
  overflows the signed machine word now raises `OverflowError` like the
  `__index__` path. `tuple * 1` / `bytes * 1` return the receiver for an exact
  immutable type (subclass → fresh base; `list`/`bytearray` copy), matching
  `str`.

## Containers
- A `NaN` in an all-float list was missed by membership, `index`/`count`/
  `remove`, and list/tuple `==`/`<=`, because the float strategy stores
  elements unboxed and so loses the shared-object identity `eq_w`'s `is_w`
  short-circuit relies on. `eq_w` now applies the float `is_w` bit-pattern
  check and the `FloatListStrategy` find fast path matches a NaN needle by bit
  pattern, so `nan in [nan]` / `[nan] == [nan]` hold (matching PyPy) while
  scalar `nan == nan` stays `False`.

## Iteration
- `enumerate(iterable, start)` with a `start` past i64 raised `OverflowError`;
  it now activates the bigint index slot and accepts arbitrary precision.
- `reversed(obj)` with `__reversed__ = None` returned a corrupt null object; it
  now raises "not reversible", and a raised `__reversed__` propagates.
- `iter(callable, sentinel)` produced an object whose type was unregistered
  (`type(it)` broken, `isinstance(it, object)` false); the `callable_iterator`
  type is now registered with `__iter__`/`__next__`.

## set / frozenset method arity
- `symmetric_difference[_update]`, `issubset`, `issuperset`, `isdisjoint`,
  `add`, `discard`, `remove` (exactly one argument) and `pop`, `clear`, `copy`
  (no arguments) now raise `TypeError` on the wrong positional-argument count.
  The variadic `union`/`intersection`/`difference`/`update` are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added built-in `aiter()` and `anext()` support for asynchronous iteration.
  - Added improved `types.SimpleNamespace` behavior, including structured representation, comparison, and keyword initialization.
  - Added PEP 682 `z` formatting support for suppressing negative zero.

- **Bug Fixes**
  - Improved attribute lookup, metaclass handling, class reassignment, hashing, iteration, sequence repetition, and length validation.
  - Enhanced `SyntaxError`, `ImportError`, `OSError`, and traceback details with more accurate locations, fields, messages, and formatting.

- **Tests**
  - Added extensive regression and compatibility coverage for built-ins, exceptions, descriptors, formatting, async iteration, and type behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->