### PR TITLE
Fix positional staticmethod subclass calls

### DIFF
--- a/pyre/extra_tests/parity_tests/staticmethod_protocol.py
+++ b/pyre/extra_tests/parity_tests/staticmethod_protocol.py
@@ -154,6 +154,7 @@ class CallingStaticMethod(staticmethod):
 
 
 calling_sub = CallingStaticMethod(wrapped)
+assert calling_sub(5) == ("override", (5,), {})
 assert calling_sub(5, b=6) == ("override", (5,), {"b": 6})
 
 alias = staticmethod[int]

--- a/pyre/pyre-interpreter/src/call.rs
+++ b/pyre/pyre-interpreter/src/call.rs
@@ -1035,6 +1035,9 @@ fn call_callable_with_mode(
         let func = unsafe { pyre_object::w_staticmethod_get_func(callable) };
         return call_callable_with_mode(frame, func, args, mode);
     }
+    if let Some(bound) = staticmethod_call_override(callable)? {
+        return call_callable_with_mode(frame, bound, args, mode);
+    }
     if let Some(bound) = classmethod_call_override(callable)? {
         return call_callable_with_mode(frame, bound, args, mode);
     }


### PR DESCRIPTION
## Summary

- route positional calls on `staticmethod` subclasses through their `__call__` override
- cover the positional-only path alongside the already-working keyword path

## Root cause

The common positional `call_callable_with_mode` path checked `classmethod_call_override` after the exact `staticmethod` fast path, but omitted `staticmethod_call_override`. Keyword and residual call paths already performed both checks, so the call modes diverged.

## Validation

- Python 3.14 staticmethod protocol parity test
- interpreter LLBC re-extraction and release prepass
- `cargo check --features dynasm`
- `CARGO_BUILD_JOBS=1 CARGO_PROFILE_TEST_BUILD_OVERRIDE_OPT_LEVEL=3 cargo test --features dynasm`
- full benchmark suite: dynasm 11/11, cranelift 11/11, wasm 10/10
