### PR TITLE
jit: close the branchy-inlined-callee bridge gap (overlay NULL-skip + vable-array re-assertion)

### DIFF
--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -8596,9 +8596,23 @@ impl JitState for PyreJitState {
                         // array) so the seeded bridge walk can fold a branch
                         // derived from it without risking a moved-pointer
                         // stamp (gap-10 bridge sub-class; see seed note above).
+                        // Skip a NULL (`GcRef(0)`) source, matching the
+                        // deferred-overlay seed below: a loop-carried local
+                        // held in a register at an interior guard reads NULL
+                        // from `locals_cells_stack_w` because it was never
+                        // written back.  Stamping that hole poisons the real
+                        // vable box with concrete NULL, folding a later
+                        // residual's Ref arg to NULL →
+                        // `MayForceNullRefArgUnsupported`.  Leaving the box
+                        // unstamped keeps it symbolic so the residual reads
+                        // the runtime value.
                         if seed_bridge_locals {
                             if let Some(&cv) = live_local_values.get(s) {
-                                if !matches!(cv, majit_ir::Value::Void) {
+                                if !matches!(
+                                    cv,
+                                    majit_ir::Value::Void
+                                        | majit_ir::Value::Ref(majit_ir::GcRef(0))
+                                ) {
                                     ctx.try_set_opref_concrete(v, cv);
                                 }
                             }

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -3495,6 +3495,30 @@ fn live_frame_array_values(
         .collect()
 }
 
+/// Write one decoded Ref back into the live frame's locals_cells_stack_w
+/// (the GC-rooted virtualizable array), re-asserting the resume-decoded
+/// vable image after the guard-failure vsd correction cleared root slots
+/// in callee coordinates.  A no-op for a null frame/array, an out-of-range
+/// slot, or a non-Ref value.
+fn store_live_frame_array_slot(vable_ptr: usize, slot: usize, value: majit_ir::Value) {
+    let majit_ir::Value::Ref(r) = value else {
+        return;
+    };
+    if vable_ptr == 0 {
+        return;
+    }
+    let f = unsafe { &*(vable_ptr as *const pyre_interpreter::pyframe::PyFrame) };
+    let lp = f.locals_cells_stack_w;
+    if lp.is_null() {
+        return;
+    }
+    let arr = unsafe { &mut *lp };
+    if slot >= arr.len() {
+        return;
+    }
+    arr.as_mut_slice()[slot] = r.as_usize() as pyre_object::PyObjectRef;
+}
+
 /// pyframe.py:107-110: `locals_cells_stack_w` length =
 /// `co_nlocals + ncellvars + nfreevars + co_stacksize`. Returns the
 /// full heap-side array length (matching `virtualizable.py:86-99
@@ -8333,6 +8357,13 @@ impl JitState for PyreJitState {
                 backend,
                 &mut virtuals_cache,
             );
+            if idx >= vable_array_start {
+                store_live_frame_array_slot(
+                    sym.concrete_vable_ptr as usize,
+                    idx - vable_array_start,
+                    val,
+                );
+            }
             oprefs.push(op);
             concrete_values.push(val);
         }
@@ -9157,17 +9188,13 @@ impl JitState for PyreJitState {
             }
         }
 
-        // pyjitpl.py:3443 `synchronize_virtualizable()` inside
-        // `rebuild_state_after_failure` (pyjitpl.py:3454) writes
-        // `virtualizable_boxes` to the heap via `write_boxes()`
-        // (virtualizable.py:101-113). This is the ONLY call in
-        // RPython's bridge-resume path — there is no second call.
-        //
-        // In pyre, the equivalent write is `sync_virtualizable_after_
-        // guard_failure` (eval.rs:5709, `ResumeVableMode::
-        // GuardFailureSync`) which runs in the compiled bridge's
-        // guard-failure recovery chain BEFORE `setup_bridge_sym`.
-        // No additional synchronize call is needed here.
+        // `sync_virtualizable_after_guard_failure` runs before bridge setup,
+        // but on the multi-frame inlined-callee path its resume-decoded array
+        // image is then clobbered by the vsd-correction `clear_stack_above`
+        // (eval.rs:7766-7774), which applies a callee-coordinate depth to the
+        // root frame before `setup_bridge_sym` reads it. The per-item write in
+        // the vvals loop above re-asserts that array image immediately after
+        // each decode; the statics retain the deliberate PR#569 override.
 
         // Multi-frame bridge. The body above reconstructed
         // the portal (`frames[0]`) into the caller-visible root `sym`. When


### PR DESCRIPTION
Closes the branchy-inlined-callee bridge gap (#343 depth-1 shape): a hot `s = f(s, x)` loop whose data-branchy inlined callee guard-fails now compiles a bridge instead of deopting to the blackhole on every crossing. Two commits, both in `setup_bridge_sym` on the pyre side, no eval.rs/jitdriver.rs changes.

## Commit 1 — overlay NULL-skip (`10b621bd29`)
`overlay_local` stamped a bridge local's concrete from the live frame slot, skipping only `Void`. A loop-carried local held in a register at an interior guard reads NULL (`GcRef(0)`) from `locals_cells_stack_w` (never written back); stamping that hole folds a later may-force residual's `Ref` arg to concrete NULL → `MayForceNullRefArgUnsupported`. Skip a `GcRef(0)` source too, matching the deferred-overlay seed loop, so the box stays symbolic and the residual reads the runtime value.

## Commit 2 — re-assert the vable array image after the vsd correction (`4c8c0bf555`)
For the pure `s = add(s, x)` shape, `sync_virtualizable_after_guard_failure` correctly restores `s` into the heap frame at bridge entry — but the multi-frame vsd correction that runs next (`clear_stack_above` with the *innermost callee's* depth, in callee coordinates, applied to the *root* frame) then NULLs the root frame's register-resident loop-carried locals. `setup_bridge_sym` reads NULL and the bridge aborts.

Re-assert the resume-decoded vable array items into the live frame's `locals_cells_stack_w`, per item inside the vvals decode loop, immediately after each decode (before the alloc-heavy frame-register consume loops). Items are uniformly `Ref` so no boxing; each write roots the value in the fully-walked frame array before the next decode allocates. The vable statics keep the correction's `last_instr`/`valuestackdepth`. This restores the `write_boxes`-runs-at-setup ordering the earlier synchronize skips on the multi-frame path. The vsd correction itself (load-bearing for the interpreter/blackhole fallback) is untouched.

## Evidence
- `probeE` (`s = add(s, x)`, branchy inlined callee): **9.5s → 0.024s (~396x)**, value correct; bridge compiles (`loops_aborted` 299 → 0, `guard_failures` 285887 → 201).
- Acceptance bench `bench/bridge_branchy_callee_regression.py`: **874x → 0.9x PASS**.
- `probeF` (2-level nested callee): correct.
- **check.py ALL PASSED: dynasm 225/225, cranelift 225/225, wasm 224/224.**
- GC-stress (`MAJIT_GC_STRESS=1`, collection per alloc): `probeE` and a loop-carried GC-mobile Ref-object probe both match `PYRE_NO_JIT`; bridge still compiles. The write target is the GC-traced frame array (walked in full every collection), so no stale-address hazard — unlike the earlier off-heap-shadow approach that was reverted.

## Known follow-up (pre-existing, not introduced here)
A virtual-typed vable array item is materialized by two non-shared caches (the guard-recovery `sync` path vs `setup_bridge_sym`'s `BridgeVirtualCache`), so such a slot can hold a distinct physical object with identical field values. Commit 2 makes the frame agree with the trace (an improvement); unifying the two materializers is a separate ticket.

— *commented by Claude*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved JIT bridge setup so decoded reference values from virtualizable array items are correctly re-applied before later overlay/concretization reads.
  * Tightened concrete stamping for bridge-local values to avoid propagating NULL (`Ref(GcRef(0))`) concretes, preventing invalid null references from affecting subsequent operations and improving runtime stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->