### PR TITLE
Port time, datetime, and descriptor semantics

### DIFF
--- a/pyre/cpython_tests/baseline.json
+++ b/pyre/cpython_tests/baseline.json
@@ -279,7 +279,7 @@
       "dynasm": "IMPORTERROR"
     },
     "test.test_datetime": {
-      "dynasm": "TIMEOUT"
+      "dynasm": "PASS"
     },
     "test.test_dbm": {
       "dynasm": "IMPORTERROR"

--- a/pyre/cpython_tests/baseline.json
+++ b/pyre/cpython_tests/baseline.json
@@ -279,7 +279,7 @@
       "dynasm": "IMPORTERROR"
     },
     "test.test_datetime": {
-      "dynasm": "CRASH"
+      "dynasm": "PASS"
     },
     "test.test_dbm": {
       "dynasm": "IMPORTERROR"
@@ -1111,7 +1111,7 @@
       "dynasm": "IMPORTERROR"
     },
     "test.test_time": {
-      "dynasm": "IMPORTERROR"
+      "dynasm": "PASS"
     },
     "test.test_timeit": {
       "dynasm": "FAIL"

--- a/pyre/cpython_tests/baseline.json
+++ b/pyre/cpython_tests/baseline.json
@@ -309,7 +309,7 @@
       "dynasm": "IMPORTERROR"
     },
     "test.test_descr": {
-      "dynasm": "IMPORTERROR"
+      "dynasm": "PASS"
     },
     "test.test_descrtut": {
       "dynasm": "IMPORTERROR"

--- a/pyre/cpython_tests/baseline.json
+++ b/pyre/cpython_tests/baseline.json
@@ -279,7 +279,7 @@
       "dynasm": "IMPORTERROR"
     },
     "test.test_datetime": {
-      "dynasm": "PASS"
+      "dynasm": "TIMEOUT"
     },
     "test.test_dbm": {
       "dynasm": "IMPORTERROR"

--- a/pyre/cpython_tests/run.py
+++ b/pyre/cpython_tests/run.py
@@ -13,7 +13,9 @@ Each module is launched one of three ways, selectable with `--mode`:
     as `__main__` so its `if __name__ == "__main__": unittest.main()` block
     fires. Needs only `unittest` plus the module's own imports; bypasses
     `runpy` / `importlib.util.find_spec` (which pyre's native importer does
-    not yet feed), so it is the most robust mode today.
+    not yet feed), so it is the most robust mode today. Runner metadata gives
+    resource-heavy or dotted-identity-sensitive modules the corresponding
+    libregrtest bootstrap without changing this default.
   * module: `pyre -m test.<module>` — same unittest entry but via `runpy`
     (currently blocked until `importlib.util.find_spec` is wired to pyre's
     importer).
@@ -195,12 +197,29 @@ def is_package(module: str) -> bool:
 # Driver that imports a test *package* with real package context (so its
 # `__init__.py` / `load_tests` discovers the sub-suite) and runs it through
 # unittest, emitting the `Ran N`/`OK`/`FAILED (` markers classify() keys on.
-_PKG_DRIVER = (
+_DOTTED_DRIVER = (
     "import sys, unittest\n"
     "mod = {module!r}\n"
     "__import__(mod)\n"
     "unittest.main(module=sys.modules[mod], argv=['pyre'], verbosity=2)\n"
 )
+
+_RESOURCE_DRIVER = (
+    "import runpy\n"
+    "from test import support\n"
+    "support.use_resources = {{}}\n"
+    "runpy.run_path({path!r}, run_name='__main__')\n"
+)
+
+# test_descr asserts fully qualified class names in exception text. Running
+# its file as __main__ changes those names even on CPython, so preserve the
+# dotted identity that libregrtest gives it.
+DOTTED_IDENTITY_MODULES = {"test.test_descr"}
+
+# test_datetime's load_tests appends an exhaustive test class for every
+# installed system timezone when test.support.use_resources is left as None.
+# libregrtest and PyPy's conftest use an empty default resource set.
+DEFAULT_RESOURCE_MODULES = {"test.test_datetime"}
 
 
 def build_cmd(binary: Path, module: str, mode: str) -> list[str]:
@@ -223,7 +242,20 @@ def run_module(binary: Path, module: str, mode: str, timeout: int,
             # running a submodule file directly breaks its relative imports);
             # drive it through a synthesized unittest entry instead.
             driver = Path(cwd) / "_pyre_pkg_main.py"
-            driver.write_text(_PKG_DRIVER.format(module=module), encoding="utf-8")
+            driver.write_text(_DOTTED_DRIVER.format(module=module), encoding="utf-8")
+            cmd = [str(binary), str(driver)]
+        elif mode == "script" and module in DOTTED_IDENTITY_MODULES:
+            driver = Path(cwd) / "_pyre_dotted_main.py"
+            driver.write_text(_DOTTED_DRIVER.format(module=module), encoding="utf-8")
+            cmd = [str(binary), str(driver)]
+        elif mode == "script" and module in DEFAULT_RESOURCE_MODULES:
+            # Match libregrtest's runner-owned default resource policy while
+            # retaining direct-file __main__ semantics.
+            driver = Path(cwd) / "_pyre_script_main.py"
+            driver.write_text(
+                _RESOURCE_DRIVER.format(path=str(module_path(module))),
+                encoding="utf-8",
+            )
             cmd = [str(binary), str(driver)]
         else:
             cmd = build_cmd(binary, module, mode)

--- a/pyre/extra_tests/snippets/stdlib_time.py
+++ b/pyre/extra_tests/snippets/stdlib_time.py
@@ -1,5 +1,21 @@
 import time
 
+for clock_name in ("time", "monotonic", "perf_counter", "process_time"):
+    clock_info = time.get_clock_info(clock_name)
+    assert isinstance(clock_info.implementation, str)
+    assert clock_info.implementation
+    assert isinstance(clock_info.monotonic, bool)
+    assert isinstance(clock_info.adjustable, bool)
+    assert isinstance(clock_info.resolution, float)
+    assert 0.0 < clock_info.resolution <= 1.0
+
+try:
+    time.get_clock_info("unknown")
+except ValueError:
+    pass
+else:
+    raise AssertionError("time.get_clock_info accepted an unknown clock")
+
 x = time.gmtime(1000)
 
 assert x.tm_year == 1970

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -5397,22 +5397,44 @@ unsafe fn super_getattribute_wtf8(
         }
         let super_type = pyre_object::descriptor::w_super_get_type(obj);
         let bound_obj = pyre_object::descriptor::w_super_get_obj(obj);
-        // descriptor.py:127-149 _super_check: `su_obj` is itself a subtype of
-        // `su_type` only in the classmethod / class-level case.  A class whose
-        // metaclass is `su_type` is an *instance* of `su_type`, not a subtype,
-        // so it must resolve through `type(su_obj)` — otherwise its MRO never
-        // reaches `su_type` and the lookup fails.  The `type()` fallback also
-        // lets non-INSTANCE builtin subclasses (W_BaseException and friends)
-        // resolve their class through the path that powers `type(obj)`
-        // (`pypy/objspace/std/typeobject.py:1083 type_get_mro`).
-        let w_obj_type = if is_type(bound_obj) && issubtype_w(bound_obj, super_type) {
-            bound_obj
-        } else if is_instance(bound_obj) {
+        // descriptor.py:127-149 _super_check.  `type(su_obj)` — read from the
+        // instance `w_class` for a heap instance, otherwise the `space.type`
+        // path that also serves non-INSTANCE builtin subclasses (W_BaseException
+        // and friends, `pypy/objspace/std/typeobject.py:1083 type_get_mro`).
+        let w_raw_type = if is_instance(bound_obj) {
             w_instance_get_type(bound_obj)
         } else if let Some(cls) = crate::typedef::r#type(bound_obj) {
             cls.as_ptr()
         } else {
-            return Err(PyError::type_error("super: bad obj type"));
+            std::ptr::null_mut()
+        };
+        let w_obj_type = if is_type(bound_obj) && issubtype_w(bound_obj, super_type) {
+            // classmethod / class-level case: `su_obj` is itself a subtype of
+            // `su_type`.
+            bound_obj
+        } else if !w_raw_type.is_null() && issubtype_w(w_raw_type, super_type) {
+            // normal case: `isinstance(su_obj, su_type)`.  A class whose
+            // metaclass is `su_type` also lands here — it is an instance of
+            // `su_type`, resolved through `type(su_obj)`.
+            w_raw_type
+        } else {
+            // slow path: `su_obj.__class__` honouring `__getattribute__`, so a
+            // proxy that forwards `__class__` to a wrapped object is still a
+            // valid target when that class is a subtype of `su_type`.  A
+            // missing `__class__` falls back to `type(su_obj)`; any other error
+            // propagates.
+            let w_type = match getattr_str(bound_obj, "__class__") {
+                Ok(w) => w,
+                Err(e) if e.kind == crate::PyErrorKind::AttributeError => w_raw_type,
+                Err(e) => return Err(e),
+            };
+            if !w_type.is_null() && issubtype_w(w_type, super_type) {
+                w_type
+            } else {
+                return Err(PyError::type_error(
+                    "super(type, obj): obj must be an instance or subtype of type",
+                ));
+            }
         };
         let mro_ptr = w_type_get_mro(w_obj_type);
         if mro_ptr.is_null() {

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -4277,8 +4277,16 @@ pub fn getdict(obj: PyObjectRef) -> PyResult {
             if !existing.is_null() {
                 return Ok(existing);
             }
+            let _roots = pyre_object::gc_roots::push_roots();
+            let root_base = pyre_object::gc_roots::shadow_stack_len();
+            pyre_object::gc_roots::pin_root(obj);
             let w_dict = pyre_object::w_dict_new();
-            unsafe { pyre_object::floatobject::w_float_setdict(obj, w_dict) };
+            unsafe {
+                pyre_object::floatobject::w_float_setdict(
+                    pyre_object::gc_roots::shadow_stack_get(root_base),
+                    w_dict,
+                )
+            };
             return Ok(w_dict);
         }
     }
@@ -4291,8 +4299,16 @@ pub fn getdict(obj: PyObjectRef) -> PyResult {
             if !existing.is_null() {
                 return Ok(existing);
             }
+            let _roots = pyre_object::gc_roots::push_roots();
+            let root_base = pyre_object::gc_roots::shadow_stack_len();
+            pyre_object::gc_roots::pin_root(obj);
             let w_dict = pyre_object::w_dict_new();
-            unsafe { pyre_object::complexobject::w_complex_setdict(obj, w_dict) };
+            unsafe {
+                pyre_object::complexobject::w_complex_setdict(
+                    pyre_object::gc_roots::shadow_stack_get(root_base),
+                    w_dict,
+                )
+            };
             return Ok(w_dict);
         }
     }

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -8666,6 +8666,30 @@ pub unsafe fn type_repr_qualified_name(w_type: PyObjectRef) -> String {
     }
 }
 
+/// LOAD_SPECIAL attribute resolution, shared by the interpreter
+/// (`eval::load_special`) and the JIT residual (`call_jit::bh_load_special_fn`).
+/// `_PyObject_LookupSpecial` resolves a special method on the type only,
+/// bypassing the instance dict and any `__getattribute__` override, so a pure
+/// `lookup_in_type` followed by the descriptor's `__get__` keeps both engines
+/// calling the same method even when the receiver overrides `__getattribute__`.
+pub fn load_special_resolve(obj: PyObjectRef, name: &str) -> Result<PyObjectRef, crate::PyError> {
+    let w_type = crate::typedef::r#type(obj).map_or(pyre_object::PY_NULL, |w_type| w_type.as_ptr());
+    let descr = if w_type.is_null() {
+        None
+    } else {
+        unsafe { lookup_in_type(w_type, name) }
+    }
+    .ok_or_else(|| {
+        crate::PyError::attribute_error(format!(
+            "'{}' object has no attribute '{}'",
+            object_functionstr_type_name(obj),
+            name,
+        ))
+    })?;
+    let bound = unsafe { get(descr, obj, w_type) }?.unwrap_or(descr);
+    Ok(bound)
+}
+
 /// `callmethod.py:25-85 LOAD_METHOD` fast-path decision, shared by the
 /// interpreter (`eval::load_method`) and the JIT tracer
 /// (`jitcode_dispatch::try_walker_specialize_load_method_attr`) so both produce the

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -4421,6 +4421,20 @@ pub(crate) fn native_slot_del(obj: PyObjectRef, name: &str, index: u32) -> Resul
     Ok(unsafe { pyre_object::dictmultiobject::w_dict_delitem_str(w_dict, name) })
 }
 
+/// `space.isinstance_w(w_dict, space.w_dict)` — the dict-or-dict-subclass
+/// gate every typed-field `setdict` arm shares, raising the standard
+/// `__dict__` TypeError otherwise.
+fn require_dict_for_setdict(w_dict: PyObjectRef) -> Result<(), PyError> {
+    let w_dict_type = crate::typedef::gettypeobject(&pyre_object::pyobject::DICT_TYPE);
+    if unsafe { isinstance_w(w_dict, w_dict_type) } {
+        return Ok(());
+    }
+    Err(PyError::type_error(format!(
+        "__dict__ must be set to a dictionary, not a '{}'",
+        object_functionstr_type_name(w_dict),
+    )))
+}
+
 /// interpreter/baseobjspace.py:70-73 W_Root.setdict(space, w_dict).
 ///
 /// ```python
@@ -4441,25 +4455,13 @@ pub fn setdict(obj: PyObjectRef, w_dict: PyObjectRef) -> Result<(), PyError> {
     }
     // function.py:683-688 StaticMethod.setdict.
     if unsafe { pyre_object::function::is_staticmethod(obj) } {
-        let w_dict_type = crate::typedef::gettypeobject(&pyre_object::pyobject::DICT_TYPE);
-        if !unsafe { isinstance_w(w_dict, w_dict_type) } {
-            return Err(PyError::type_error(format!(
-                "__dict__ must be set to a dictionary, not a '{}'",
-                object_functionstr_type_name(w_dict),
-            )));
-        }
+        require_dict_for_setdict(w_dict)?;
         unsafe { pyre_object::function::w_staticmethod_setdict(obj, w_dict) };
         return Ok(());
     }
     // function.py:731-736 ClassMethod.setdict.
     if unsafe { pyre_object::function::is_classmethod(obj) } {
-        let w_dict_type = crate::typedef::gettypeobject(&pyre_object::pyobject::DICT_TYPE);
-        if !unsafe { isinstance_w(w_dict, w_dict_type) } {
-            return Err(PyError::type_error(format!(
-                "__dict__ must be set to a dictionary, not a '{}'",
-                object_functionstr_type_name(w_dict),
-            )));
-        }
+        require_dict_for_setdict(w_dict)?;
         unsafe { pyre_object::function::w_classmethod_setdict(obj, w_dict) };
         return Ok(());
     }
@@ -4477,46 +4479,22 @@ pub fn setdict(obj: PyObjectRef, w_dict: PyObjectRef) -> Result<(), PyError> {
         return Ok(());
     }
     if unsafe { pyre_object::bytesobject::is_bytes(obj) } {
-        let w_dict_type = crate::typedef::gettypeobject(&pyre_object::pyobject::DICT_TYPE);
-        if !unsafe { isinstance_w(w_dict, w_dict_type) } {
-            return Err(PyError::type_error(format!(
-                "__dict__ must be set to a dictionary, not a '{}'",
-                object_functionstr_type_name(w_dict),
-            )));
-        }
+        require_dict_for_setdict(w_dict)?;
         unsafe { pyre_object::bytesobject::w_bytes_setdict(obj, w_dict) };
         return Ok(());
     }
     if unsafe { pyre_object::bytearrayobject::is_bytearray(obj) } {
-        let w_dict_type = crate::typedef::gettypeobject(&pyre_object::pyobject::DICT_TYPE);
-        if !unsafe { isinstance_w(w_dict, w_dict_type) } {
-            return Err(PyError::type_error(format!(
-                "__dict__ must be set to a dictionary, not a '{}'",
-                object_functionstr_type_name(w_dict),
-            )));
-        }
+        require_dict_for_setdict(w_dict)?;
         unsafe { pyre_object::bytearrayobject::w_bytearray_setdict(obj, w_dict) };
         return Ok(());
     }
     if unsafe { pyre_object::is_float(obj) } {
-        let w_dict_type = crate::typedef::gettypeobject(&pyre_object::pyobject::DICT_TYPE);
-        if !unsafe { isinstance_w(w_dict, w_dict_type) } {
-            return Err(PyError::type_error(format!(
-                "__dict__ must be set to a dictionary, not a '{}'",
-                object_functionstr_type_name(w_dict),
-            )));
-        }
+        require_dict_for_setdict(w_dict)?;
         unsafe { pyre_object::floatobject::w_float_setdict(obj, w_dict) };
         return Ok(());
     }
     if unsafe { pyre_object::is_complex(obj) } {
-        let w_dict_type = crate::typedef::gettypeobject(&pyre_object::pyobject::DICT_TYPE);
-        if !unsafe { isinstance_w(w_dict, w_dict_type) } {
-            return Err(PyError::type_error(format!(
-                "__dict__ must be set to a dictionary, not a '{}'",
-                object_functionstr_type_name(w_dict),
-            )));
-        }
+        require_dict_for_setdict(w_dict)?;
         unsafe { pyre_object::complexobject::w_complex_setdict(obj, w_dict) };
         return Ok(());
     }
@@ -6324,9 +6302,63 @@ fn object_getattr_miss(obj: PyObjectRef, name: &str, call_getattr: bool) -> PyRe
             // but that descriptor's mapdict layout does not apply to the
             // class object and must not shadow `type.__dict__`.
             if name == "__dict__" {
+                // typeobject.py:811-819 — the metatype MRO is consulted first,
+                // so a metaclass that overrides `__dict__`
+                // (`Meta.__dict__ = property(...)`) supersedes the class's
+                // canonical namespace.  The canonical entry is `type`'s own
+                // `__dict__` getset (owner `type`), whose getter already returns
+                // the class proxy handled by the fallback below; every other
+                // metatype defining `__dict__` is a genuine override to invoke.
+                // (Owner layout typedef cannot narrow this: every class,
+                // including `type` and user metaclasses, chains its layout
+                // typedef to `object`'s `INSTANCE_TYPE`, so `type`'s canonical
+                // getset is told apart by owner identity, not by layout.)
+                for w_metaclass in w_metaclasses.iter().flatten() {
+                    let w_metaclass = *w_metaclass;
+                    if !is_type(w_metaclass) {
+                        continue;
+                    }
+                    if let Some((owner, descr)) = lookup_where(w_metaclass, name) {
+                        // A `__dict__` descriptor is a genuine metatype override
+                        // only when its owner is a proper metaclass (a subclass
+                        // of `type`).  A plain base mixed into the metaclass MRO
+                        // ahead of `type` (`class Meta(Base, type)`) contributes
+                        // an *instance* `__dict__` getset that does not apply to
+                        // a class object; fall through to the canonical proxy for
+                        // it, as for `type`'s own getset (owner `type`).
+                        if !std::ptr::eq(owner, w_type_type)
+                            && issubtype_w(owner, w_type_type)
+                            && is_data_descr(descr)
+                        {
+                            match get(descr, obj, w_metaclass) {
+                                Ok(Some(result)) => return Ok(result),
+                                Ok(None) => {}
+                                Err(e) => {
+                                    return type_getattr_hook_or_err(
+                                        obj,
+                                        &w_metaclasses,
+                                        name,
+                                        e,
+                                        call_getattr,
+                                    );
+                                }
+                            }
+                        }
+                    }
+                }
+                // No metatype descriptor overrides `__dict__`; a real type
+                // always exposes its canonical namespace, so a null pointer is
+                // an unfinished bootstrap layout rather than a user-visible
+                // mapping — surface it instead of a throwaway writable proxy.
                 let dict_ptr = w_type_get_dict_ptr(obj);
+                debug_assert!(
+                    !dict_ptr.is_null(),
+                    "type object is missing its canonical __dict__"
+                );
                 if dict_ptr.is_null() {
-                    return Ok(pyre_object::w_dict_proxy_new(pyre_object::w_dict_new()));
+                    return Err(PyError::runtime_error(
+                        "type object has no canonical __dict__",
+                    ));
                 }
                 return Ok(pyre_object::w_dict_proxy_new(dict_ptr as PyObjectRef));
             }
@@ -9858,6 +9890,14 @@ pub fn type_immutable_attr_raise_is_stable(obj: PyObjectRef, name: &str, is_dele
 /// `object.__setattr__` and as the default path in `setattr`.
 pub fn object_setattr(obj: PyObjectRef, name: &str, value: PyObjectRef) -> PyResult {
     let obj = crate::module::_weakref::interp__weakref::force(obj)?;
+    // `W_BaseException` carries its instance dict on the typed `w_dict` slot but
+    // installs no `__dict__` getset in its namespace, so the descriptor walk
+    // below finds no exception `__dict__` setter.  A plain base mixed into an
+    // exception (`class E(Exception, Base)`) does contribute an *instance*
+    // `__dict__` getset (`Base`'s), whose mapdict layout is incompatible with
+    // the exception layout and rejects the receiver — so the walk must not reach
+    // it.  Route exception `__dict__` assignment straight to `setdict`, ahead of
+    // that walk (`interp_exceptions.py:227-231 W_BaseException.setdict`).
     if name == "__dict__" && unsafe { pyre_object::is_exception(obj) } {
         setdict(obj, value)?;
         return Ok(w_none());

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -1171,10 +1171,13 @@ pub(crate) unsafe fn get_and_call_function(
     args_w: &[PyObjectRef],
 ) -> PyResult {
     if !w_descr.is_null()
-        && std::ptr::eq(
+        && (std::ptr::eq(
             unsafe { (*w_descr).ob_type },
             &crate::FUNCTION_TYPE as *const _,
-        )
+        ) || std::ptr::eq(
+            unsafe { (*w_descr).ob_type },
+            &crate::METHOD_DESCRIPTOR_TYPE as *const _,
+        ))
     {
         let mut full = Vec::with_capacity(args_w.len() + 1);
         full.push(w_obj);
@@ -4265,6 +4268,34 @@ pub fn getdict(obj: PyObjectRef) -> PyResult {
             return Ok(w_dict);
         }
     }
+    if unsafe { pyre_object::is_float(obj) } {
+        let Some(w_type) = crate::typedef::r#type(obj) else {
+            return Ok(PY_NULL);
+        };
+        if unsafe { pyre_object::w_type_get_hasdict(w_type.as_ptr()) } {
+            let existing = unsafe { pyre_object::floatobject::w_float_getdict(obj) };
+            if !existing.is_null() {
+                return Ok(existing);
+            }
+            let w_dict = pyre_object::w_dict_new();
+            unsafe { pyre_object::floatobject::w_float_setdict(obj, w_dict) };
+            return Ok(w_dict);
+        }
+    }
+    if unsafe { pyre_object::is_complex(obj) } {
+        let Some(w_type) = crate::typedef::r#type(obj) else {
+            return Ok(PY_NULL);
+        };
+        if unsafe { pyre_object::w_type_get_hasdict(w_type.as_ptr()) } {
+            let existing = unsafe { pyre_object::complexobject::w_complex_getdict(obj) };
+            if !existing.is_null() {
+                return Ok(existing);
+            }
+            let w_dict = pyre_object::w_dict_new();
+            unsafe { pyre_object::complexobject::w_complex_setdict(obj, w_dict) };
+            return Ok(w_dict);
+        }
+    }
     let w_type = match crate::typedef::r#type(obj) {
         Some(tp) => tp,
         None => return Ok(pyre_object::PY_NULL),
@@ -4302,6 +4333,12 @@ pub(crate) fn native_slot_get(
     if unsafe { pyre_object::is_str(obj) } {
         return Ok(unsafe { pyre_object::unicodeobject::w_str_slot_get(obj, index as usize) });
     }
+    if unsafe { pyre_object::is_float(obj) } {
+        return Ok(unsafe { pyre_object::floatobject::w_float_slot_get(obj, index as usize) });
+    }
+    if unsafe { pyre_object::is_complex(obj) } {
+        return Ok(unsafe { pyre_object::complexobject::w_complex_slot_get(obj, index as usize) });
+    }
     let w_dict = getdict(obj)?;
     if w_dict.is_null() {
         return Ok(None);
@@ -4327,6 +4364,14 @@ pub(crate) fn native_slot_set(
         unsafe { pyre_object::unicodeobject::w_str_slot_set(obj, index as usize, value) };
         return Ok(true);
     }
+    if unsafe { pyre_object::is_float(obj) } {
+        unsafe { pyre_object::floatobject::w_float_slot_set(obj, index as usize, value) };
+        return Ok(true);
+    }
+    if unsafe { pyre_object::is_complex(obj) } {
+        unsafe { pyre_object::complexobject::w_complex_slot_set(obj, index as usize, value) };
+        return Ok(true);
+    }
     let w_dict = getdict(obj)?;
     if w_dict.is_null() {
         return Ok(false);
@@ -4346,6 +4391,12 @@ pub(crate) fn native_slot_del(obj: PyObjectRef, name: &str, index: u32) -> Resul
     }
     if unsafe { pyre_object::is_str(obj) } {
         return Ok(unsafe { pyre_object::unicodeobject::w_str_slot_del(obj, index as usize) });
+    }
+    if unsafe { pyre_object::is_float(obj) } {
+        return Ok(unsafe { pyre_object::floatobject::w_float_slot_del(obj, index as usize) });
+    }
+    if unsafe { pyre_object::is_complex(obj) } {
+        return Ok(unsafe { pyre_object::complexobject::w_complex_slot_del(obj, index as usize) });
     }
     let w_dict = getdict(obj)?;
     if w_dict.is_null() {
@@ -4429,6 +4480,28 @@ pub fn setdict(obj: PyObjectRef, w_dict: PyObjectRef) -> Result<(), PyError> {
             )));
         }
         unsafe { pyre_object::bytearrayobject::w_bytearray_setdict(obj, w_dict) };
+        return Ok(());
+    }
+    if unsafe { pyre_object::is_float(obj) } {
+        let w_dict_type = crate::typedef::gettypeobject(&pyre_object::pyobject::DICT_TYPE);
+        if !unsafe { isinstance_w(w_dict, w_dict_type) } {
+            return Err(PyError::type_error(format!(
+                "__dict__ must be set to a dictionary, not a '{}'",
+                object_functionstr_type_name(w_dict),
+            )));
+        }
+        unsafe { pyre_object::floatobject::w_float_setdict(obj, w_dict) };
+        return Ok(());
+    }
+    if unsafe { pyre_object::is_complex(obj) } {
+        let w_dict_type = crate::typedef::gettypeobject(&pyre_object::pyobject::DICT_TYPE);
+        if !unsafe { isinstance_w(w_dict, w_dict_type) } {
+            return Err(PyError::type_error(format!(
+                "__dict__ must be set to a dictionary, not a '{}'",
+                object_functionstr_type_name(w_dict),
+            )));
+        }
+        unsafe { pyre_object::complexobject::w_complex_setdict(obj, w_dict) };
         return Ok(());
     }
     let w_type = match crate::typedef::r#type(obj) {
@@ -4692,6 +4765,32 @@ fn getattr_str_impl(obj: PyObjectRef, name: &str, call_getattr: bool) -> PyResul
     // non-proxy operand, costing only one ptr-equality check on the hot
     // path.
     let obj = crate::module::_weakref::interp__weakref::force(obj)?;
+
+    if name == "__dict__" {
+        if let Some(obj_type) = crate::typedef::r#type(obj) {
+            let module_type = crate::typedef::gettypeobject(&pyre_object::MODULE_TYPE);
+            let shadows_with_foreign_instance_dict = unsafe {
+                lookup_where(obj_type.as_ptr(), "__dict__").is_some_and(|(owner, _)| {
+                    let layout = pyre_object::w_type_get_layout_ptr(owner);
+                    !layout.is_null()
+                        && std::ptr::eq((*layout).typedef, &pyre_object::pyobject::INSTANCE_TYPE)
+                })
+            };
+            if !module_type.is_null()
+                && unsafe { issubtype_w(obj_type.as_ptr(), module_type) }
+                && shadows_with_foreign_instance_dict
+            {
+                let dict = if unsafe { is_module(obj) } {
+                    unsafe { pyre_object::w_module_get_w_dict(obj) }
+                } else {
+                    getdict(obj)?
+                };
+                if !dict.is_null() {
+                    return Ok(dict);
+                }
+            }
+        }
+    }
 
     // GenericAlias.__getattribute__ (`_pypy_generic_alias.py:52`) — every
     // attribute outside `_ATTR_EXCEPTIONS` delegates to `__origin__`.
@@ -6174,6 +6273,17 @@ pub(crate) fn type_del_annotations(obj: PyObjectRef) -> PyResult {
 }
 
 fn object_getattr_miss(obj: PyObjectRef, name: &str, call_getattr: bool) -> PyResult {
+    if name == "__dict__" && unsafe { is_module(obj) } {
+        let dict = unsafe { pyre_object::w_module_get_w_dict(obj) };
+        if !dict.is_null() {
+            return Ok(dict);
+        }
+    }
+    if name == "__doc__" && unsafe { pyre_object::is_member(obj) } {
+        if let Some(doc) = unsafe { pyre_object::w_member_get_doc(obj) } {
+            return Ok(w_str_new(doc));
+        }
+    }
     // Type objects: look up in type's own dict → base dicts
     // PyPy: typeobject.py lookup_where → MRO search + descriptor unwrap
     unsafe {
@@ -6192,6 +6302,18 @@ fn object_getattr_miss(obj: PyObjectRef, name: &str, call_getattr: bool) -> PyRe
                 w_metaclass,
                 crate::typedef::gettypefor((*obj).ob_type).map(|p| p.as_ptr()),
             ];
+            // A class always exposes its canonical namespace through the
+            // metatype's `__dict__` descriptor.  A Python base mixed into the
+            // metaclass can also contribute an instance-`__dict__` getset,
+            // but that descriptor's mapdict layout does not apply to the
+            // class object and must not shadow `type.__dict__`.
+            if name == "__dict__" {
+                let dict_ptr = w_type_get_dict_ptr(obj);
+                if dict_ptr.is_null() {
+                    return Ok(pyre_object::w_dict_proxy_new(pyre_object::w_dict_new()));
+                }
+                return Ok(pyre_object::w_dict_proxy_new(dict_ptr as PyObjectRef));
+            }
             // typeobject.py:811-819 — `space.lookup(self, name)` searches the
             // complete metaclass MRO, and any data descriptor found there is
             // consulted before the class's own MRO.  This includes getsets
@@ -6262,19 +6384,6 @@ fn object_getattr_miss(obj: PyObjectRef, name: &str, call_getattr: bool) -> PyRe
                 // path below would bind it with `obj=None` and yield the raw
                 // descriptor instead of the bitmask.
                 return Ok(w_int_new(w_type_get_flags(obj)));
-            }
-            if name == "__dict__" {
-                // `pypy/objspace/std/typeobject.py:1277 descr_get_dict`
-                // returns `W_DictProxyObject(w_dict)` — a read-only
-                // **live** view of the type's namespace.  The proxy's
-                // identity is fresh per call (a new wrapper) but its
-                // `w_mapping` is the type's canonical W_DictObject.
-                let dict_ptr = w_type_get_dict_ptr(obj);
-                if dict_ptr.is_null() {
-                    return Ok(pyre_object::w_dict_proxy_new(pyre_object::w_dict_new()));
-                }
-                let canonical = dict_ptr as PyObjectRef;
-                return Ok(pyre_object::w_dict_proxy_new(canonical));
             }
             if name == "__bases__" {
                 // typeobject.py:1027 descr_get__bases__ — `object` (the root
@@ -8876,6 +8985,11 @@ pub(crate) unsafe fn compute_and_set_mro(w_self: PyObjectRef) -> PyResult {
                             pyre_object::gc_roots::shadow_stack_get(mro_root_start + index)
                         })
                         .collect();
+                    if !mro_w.iter().any(|&entry| std::ptr::eq(entry, w_self)) {
+                        return Err(PyError::type_error(
+                            "mro() returned a result without the new class",
+                        ));
+                    }
                     pyre_object::w_type_set_mro(w_self, mro_w.clone());
 
                     // typeobject.py `_add_mro_classes_as_subclasses`: custom
@@ -9275,7 +9389,8 @@ pub(crate) unsafe fn get(
         if std::ptr::eq(ob_type, &crate::BUILTIN_FUNCTION_TYPE as *const _) {
             return Ok(Some(descr));
         }
-        if std::ptr::eq(ob_type, &crate::FUNCTION_TYPE as *const _)
+        if (std::ptr::eq(ob_type, &crate::FUNCTION_TYPE as *const _)
+            || std::ptr::eq(ob_type, &crate::METHOD_DESCRIPTOR_TYPE as *const _))
             && crate::is_builtin_code(crate::function_get_code(descr) as pyre_object::PyObjectRef)
         {
             if obj.is_null() {
@@ -9349,7 +9464,11 @@ pub(crate) unsafe fn get(
         // AttributeError("'%T' object has no attribute '%s'")
         if found.is_none() {
             let slot_name = pyre_object::w_member_get_name(descr);
-            return Err(raiseattrerror(obj, slot_name, None));
+            return Err(PyError::attribute_error(format!(
+                "'{}' object has no attribute '{}'",
+                getfulltypename(obj),
+                slot_name,
+            )));
         }
         return Ok(found);
     }
@@ -9582,6 +9701,13 @@ pub(crate) fn descr_set___class__(w_obj: PyObjectRef, w_newcls: PyObjectRef) -> 
                 ));
             }
         };
+        if !w_type_is_heaptype(w_oldcls.as_ptr()) && !std::ptr::eq(w_oldcls.as_ptr(), w_module_type)
+        {
+            return Err(crate::PyError::type_error(
+                "__class__ assignment only supported for mutable types or ModuleType subclasses"
+                    .to_string(),
+            ));
+        }
         // objectobject.py:148-154 — get_full_instance_layout() must match.
         // typeobject.py:125-129 Layout.expand() compares 5-tuple:
         //   (typedef, newslotnames, base_layout, hasdict, weakrefable)
@@ -9716,6 +9842,10 @@ pub fn type_immutable_attr_raise_is_stable(obj: PyObjectRef, name: &str, is_dele
 /// `object.__setattr__` and as the default path in `setattr`.
 pub fn object_setattr(obj: PyObjectRef, name: &str, value: PyObjectRef) -> PyResult {
     let obj = crate::module::_weakref::interp__weakref::force(obj)?;
+    if name == "__dict__" && unsafe { pyre_object::is_exception(obj) } {
+        setdict(obj, value)?;
+        return Ok(w_none());
+    }
     // Data descriptor __set__ takes priority (PyPy: descroperation.py
     // descr__setattr__ step 1). PyPy walks `space.type(obj)` regardless of
     // whether `obj` is a Python-level instance, so the lookup must run for
@@ -11330,24 +11460,23 @@ pub fn length_hint(w_obj: PyObjectRef, default: i64) -> Result<i64, crate::PyErr
     } else {
         unsafe { lookup_in_type_where(w_type, "__length_hint__") }
     };
-    let self_args = [w_obj];
     // baseobjspace.py:1095 `space.get_and_call_function(w_descr, w_obj)` — a
     // type-MRO descriptor is called with the object as self; the builtin
     // method-table result is already bound and called with no extra args.
-    let (callable, args): (PyObjectRef, &[PyObjectRef]) = match w_descr {
-        Some(descr) => (descr, &self_args),
+    let w_hint_result = match w_descr {
+        Some(descr) => unsafe { get_and_call_function(descr, w_obj, w_type, &[]) },
         None => {
             if unsafe { is_instance(w_obj) } {
                 return Ok(default);
             }
             match getattr_str_impl(w_obj, "__length_hint__", false) {
-                Ok(m) => (m, &[]),
+                Ok(m) => crate::call::call_function_impl_result(m, &[]),
                 Err(e) if e.kind == crate::PyErrorKind::AttributeError => return Ok(default),
-                Err(e) => return Err(e),
+                Err(e) => Err(e),
             }
         }
     };
-    let w_hint = match crate::call::call_function_impl_result(callable, args) {
+    let w_hint = match w_hint_result {
         Ok(v) => v,
         Err(err) => {
             if err.kind == crate::PyErrorKind::TypeError

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -6537,29 +6537,10 @@ fn object_getattr_miss(obj: PyObjectRef, name: &str, call_getattr: bool) -> PyRe
             // CPython likewise keeps `tp_doc` beside a member descriptor under
             // the same dict key.  Pyre has no separate type-doc slot, so serve
             // that exact builtin split here without affecting subclasses.
-            if name == "__doc__"
-                && std::ptr::eq(
-                    obj,
-                    crate::typedef::gettypeobject(&pyre_object::descriptor::PROPERTY_TYPE),
-                )
-            {
-                return Ok(w_str_new(crate::typedef::PROPERTY_DOC));
-            }
-            if name == "__doc__"
-                && std::ptr::eq(
-                    obj,
-                    crate::typedef::gettypeobject(&crate::function::FUNCTION_TYPE),
-                )
-            {
-                return Ok(w_str_new(crate::typedef::FUNCTION_DOC));
-            }
-            if name == "__doc__"
-                && std::ptr::eq(
-                    obj,
-                    crate::typedef::gettypeobject(&pyre_object::function::METHOD_TYPE),
-                )
-            {
-                return Ok(w_str_new(crate::typedef::METHOD_DOC));
+            if name == "__doc__" {
+                if let Some(doc) = crate::typedef::type_builtin_own_doc(obj) {
+                    return Ok(doc);
+                }
             }
             // typeobject.py:1166-1179 descr__doc — a heap type reads only its
             // own dict and returns None when absent; class docs are never

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -3941,28 +3941,6 @@ pub(crate) fn type_new_take_qualname(w_type: PyObjectRef, ns: PyObjectRef) -> cr
     Ok(pyre_object::w_none())
 }
 
-/// Copy a real dict without narrowing its key strategy to strings.  Type
-/// namespaces deliberately retain non-string keys (while warning); lookups
-/// may later compare such a key and execute user code.
-fn copy_type_namespace_entries(src: PyObjectRef, dst: PyObjectRef) -> bool {
-    unsafe {
-        let items = pyre_object::w_dict_items(src);
-        let has_non_string = items.iter().any(|(key, _)| !pyre_object::is_str(*key));
-        let _roots = pyre_object::gc_roots::push_roots();
-        let root_base = pyre_object::gc_roots::shadow_stack_len();
-        for &(key, value) in &items {
-            pyre_object::gc_roots::pin_root(key);
-            pyre_object::gc_roots::pin_root(value);
-        }
-        for index in 0..items.len() {
-            let key = pyre_object::gc_roots::shadow_stack_get(root_base + index * 2);
-            let value = pyre_object::gc_roots::shadow_stack_get(root_base + index * 2 + 1);
-            pyre_object::w_dict_store(dst, key, value);
-        }
-        has_non_string
-    }
-}
-
 fn type_descr_new_with_metaclass(
     args: &[PyObjectRef],
     w_metaclass: PyObjectRef,
@@ -4241,11 +4219,14 @@ fn type_descr_new_with_metaclass(
 
         let _dict_root = pyre_object::gc_roots::push_roots();
         let dict_root = pyre_object::gc_roots::shadow_stack_len();
-        let dict_obj = pyre_object::w_dict_new();
-        pyre_object::gc_roots::pin_root(dict_obj);
         let class_ns = pyre_object::gc_roots::shadow_stack_get(class_ns_root);
-        let dict_obj = pyre_object::gc_roots::shadow_stack_get(dict_root);
-        copy_type_namespace_entries(class_ns, dict_obj);
+        // Clone the assembled namespace preserving its cached key hashes,
+        // mirroring the final `PyDict_Copy` for the type's `__dict__`.  A
+        // per-key reinsert would hash every non-string key again, running a
+        // side-effecting `__hash__` an extra time (and dropping any error it
+        // raised, since the store cannot propagate one).
+        let dict_obj = unsafe { pyre_object::w_dict_copy(class_ns) };
+        pyre_object::gc_roots::pin_root(dict_obj);
         let dict_obj = pyre_object::gc_roots::shadow_stack_get(dict_root);
         let w_type = pyre_object::w_type_new(name, w_effective_bases, dict_obj as *mut u8);
         type_new_take_qualname(w_type, dict_obj)?;

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -3941,6 +3941,28 @@ pub(crate) fn type_new_take_qualname(w_type: PyObjectRef, ns: PyObjectRef) -> cr
     Ok(pyre_object::w_none())
 }
 
+/// Copy a real dict without narrowing its key strategy to strings.  Type
+/// namespaces deliberately retain non-string keys (while warning); lookups
+/// may later compare such a key and execute user code.
+fn copy_type_namespace_entries(src: PyObjectRef, dst: PyObjectRef) -> bool {
+    unsafe {
+        let items = pyre_object::w_dict_items(src);
+        let has_non_string = items.iter().any(|(key, _)| !pyre_object::is_str(*key));
+        let _roots = pyre_object::gc_roots::push_roots();
+        let root_base = pyre_object::gc_roots::shadow_stack_len();
+        for &(key, value) in &items {
+            pyre_object::gc_roots::pin_root(key);
+            pyre_object::gc_roots::pin_root(value);
+        }
+        for index in 0..items.len() {
+            let key = pyre_object::gc_roots::shadow_stack_get(root_base + index * 2);
+            let value = pyre_object::gc_roots::shadow_stack_get(root_base + index * 2 + 1);
+            pyre_object::w_dict_store(dst, key, value);
+        }
+        has_non_string
+    }
+}
+
 fn type_descr_new_with_metaclass(
     args: &[PyObjectRef],
     w_metaclass: PyObjectRef,
@@ -4061,22 +4083,26 @@ fn type_descr_new_with_metaclass(
         if !w_ns_backing.is_null() {
             let backing_root = pyre_object::gc_roots::shadow_stack_len();
             pyre_object::gc_roots::pin_root(w_ns_backing);
-            let keys: Vec<rustpython_wtf8::Wtf8Buf> = unsafe {
-                pyre_object::w_dict_str_entries_wtf8(w_ns_backing)
-                    .into_iter()
-                    .map(|(key, _)| key)
-                    .collect()
-            };
-            for key in keys {
-                let w_ns_backing = pyre_object::gc_roots::shadow_stack_get(backing_root);
-                let Some(value) = (unsafe { pyre_object::w_dict_getitem_wtf8(w_ns_backing, &key) })
-                else {
-                    continue;
+            let items = unsafe { pyre_object::w_dict_items(w_ns_backing) };
+            let item_root = pyre_object::gc_roots::shadow_stack_len();
+            for &(key, value) in &items {
+                pyre_object::gc_roots::pin_root(key);
+                pyre_object::gc_roots::pin_root(value);
+            }
+            let mut has_non_string_key = false;
+            for index in 0..items.len() {
+                let key = pyre_object::gc_roots::shadow_stack_get(item_root + index * 2);
+                let value = pyre_object::gc_roots::shadow_stack_get(item_root + index * 2 + 1);
+                let key_text = if unsafe { pyre_object::is_str(key) } {
+                    Some(unsafe { pyre_object::w_str_get_wtf8(key) })
+                } else {
+                    has_non_string_key = true;
+                    None
                 };
-                if value.is_null() {
-                    continue;
-                }
-                if key.as_str() == Ok("__classcell__") {
+                if key_text
+                    .as_ref()
+                    .is_some_and(|key| key.as_str() == Ok("__classcell__"))
+                {
                     if !unsafe { pyre_object::is_cell(value) } {
                         let tp_name = match unsafe { crate::typedef::r#type(value) } {
                             Some(tp) => {
@@ -4093,7 +4119,10 @@ fn type_descr_new_with_metaclass(
                     classcell_root = Some(root);
                     continue;
                 }
-                if key.as_str() == Ok("__classdictcell__") {
+                if key_text
+                    .as_ref()
+                    .is_some_and(|key| key.as_str() == Ok("__classdictcell__"))
+                {
                     if unsafe { pyre_object::is_cell(value) } {
                         let root = pyre_object::gc_roots::shadow_stack_len();
                         pyre_object::gc_roots::pin_root(value);
@@ -4102,7 +4131,14 @@ fn type_descr_new_with_metaclass(
                     continue;
                 }
                 let class_ns = pyre_object::gc_roots::shadow_stack_get(class_ns_root);
-                unsafe { pyre_object::w_dict_setitem_wtf8_no_proxy(class_ns, &key, value) };
+                unsafe { pyre_object::w_dict_store(class_ns, key, value) };
+            }
+            if has_non_string_key {
+                crate::warn::warn_category(
+                    &format!("type '{}' has a non-string key in its dictionary", name),
+                    "RuntimeWarning",
+                    1,
+                )?;
             }
         }
         // typeobject.py:ensure_common_attributes / ensure_module_attr.  Direct
@@ -4208,28 +4244,8 @@ fn type_descr_new_with_metaclass(
         let dict_obj = pyre_object::w_dict_new();
         pyre_object::gc_roots::pin_root(dict_obj);
         let class_ns = pyre_object::gc_roots::shadow_stack_get(class_ns_root);
-        let keys: Vec<rustpython_wtf8::Wtf8Buf> = unsafe {
-            pyre_object::w_dict_str_entries_wtf8(class_ns)
-                .into_iter()
-                .map(|(key, _)| key)
-                .collect()
-        };
-        for key in keys {
-            let class_ns = pyre_object::gc_roots::shadow_stack_get(class_ns_root);
-            let Some(value) = (unsafe { pyre_object::w_dict_getitem_wtf8(class_ns, &key) }) else {
-                continue;
-            };
-            if value.is_null() {
-                continue;
-            }
-            let dict_obj = pyre_object::gc_roots::shadow_stack_get(dict_root);
-            match key.as_str() {
-                Ok(s) => unsafe { pyre_object::w_dict_setitem_str_no_proxy(dict_obj, s, value) },
-                Err(_) => unsafe {
-                    pyre_object::w_dict_setitem_wtf8_no_proxy(dict_obj, &key, value)
-                },
-            }
-        }
+        let dict_obj = pyre_object::gc_roots::shadow_stack_get(dict_root);
+        copy_type_namespace_entries(class_ns, dict_obj);
         let dict_obj = pyre_object::gc_roots::shadow_stack_get(dict_root);
         let w_type = pyre_object::w_type_new(name, w_effective_bases, dict_obj as *mut u8);
         type_new_take_qualname(w_type, dict_obj)?;
@@ -9804,10 +9820,14 @@ pub(crate) fn builtin_reversed(args: &[PyObjectRef]) -> Result<PyObjectRef, crat
             let method_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
             // Propagate a raised error from `__reversed__` instead of handing
             // back a null result.
-            return call_and_check(
-                unsafe { pyre_object::gc_roots::shadow_stack_get(method_slot) },
-                &[unsafe { pyre_object::gc_roots::shadow_stack_get(obj_slot) }],
-            );
+            return unsafe {
+                crate::baseobjspace::get_and_call_function(
+                    pyre_object::gc_roots::shadow_stack_get(method_slot),
+                    pyre_object::gc_roots::shadow_stack_get(obj_slot),
+                    tp.as_ptr(),
+                    &[],
+                )
+            };
         }
     }
     // functional.py:351 — without `__reversed__`, require the sequence
@@ -10397,26 +10417,40 @@ pub(crate) fn init_fileio_type(ns: PyObjectRef) {
     ] {
         unsafe { pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(ns, name, function) };
     }
-    for (name, getter) in [
-        ("closed", fileio_get_closed as crate::gateway::BuiltinCodeFn),
+    for (name, getter, doc) in [
+        (
+            "closed",
+            fileio_get_closed as crate::gateway::BuiltinCodeFn,
+            Some("True if the file is closed"),
+        ),
         (
             "closefd",
             fileio_get_closefd as crate::gateway::BuiltinCodeFn,
+            None,
         ),
-        ("mode", fileio_get_mode as crate::gateway::BuiltinCodeFn),
+        (
+            "mode",
+            fileio_get_mode as crate::gateway::BuiltinCodeFn,
+            None,
+        ),
         (
             "_blksize",
             fileio_get_blksize as crate::gateway::BuiltinCodeFn,
+            None,
         ),
     ] {
         let getter = make_builtin_function_with_arity(name, getter, 2);
-        unsafe {
-            pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
-                ns,
+        let descriptor = match doc {
+            Some(doc) => crate::typedef::make_getset_property_named_doc(
+                getter,
+                pyre_object::PY_NULL,
+                pyre_object::PY_NULL,
+                doc,
                 name,
-                crate::typedef::make_getset_descriptor_named(getter, name),
-            )
+            ),
+            None => crate::typedef::make_getset_descriptor_named(getter, name),
         };
+        unsafe { pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(ns, name, descriptor) };
     }
     unsafe {
         pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
@@ -12313,11 +12347,18 @@ pub(crate) fn builtin_round(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::
         if let Some(method) =
             unsafe { crate::baseobjspace::lookup_in_type(tp.as_ptr(), "__round__") }
         {
-            let result = match ndigits {
-                Some(nd) if !unsafe { pyre_object::is_none(*nd) } => {
-                    crate::call::call_function_impl_result(method, &[obj, *nd])?
+            let result = unsafe {
+                match ndigits {
+                    Some(nd) if !pyre_object::is_none(*nd) => {
+                        crate::baseobjspace::get_and_call_function(
+                            method,
+                            obj,
+                            tp.as_ptr(),
+                            &[*nd],
+                        )?
+                    }
+                    _ => crate::baseobjspace::get_and_call_function(method, obj, tp.as_ptr(), &[])?,
                 }
-                _ => crate::call::call_function_impl_result(method, &[obj])?,
             };
             return Ok(result);
         }
@@ -12524,27 +12565,29 @@ pub(crate) fn complex_coerce(obj: PyObjectRef) -> Result<(f64, f64), crate::PyEr
     // CPython 3.14 try_complex_special_method runs before the complex-subclass
     // fallback, so a subclass override is honored instead of reading its raw
     // lanes.  The inherited complex.__complex__ returns an exact base value.
-    if unsafe { crate::baseobjspace::lookup(obj, "__complex__") }.is_some() {
-        let res = crate::baseobjspace::call_method(obj, "__complex__", &[]);
-        if res.is_null() {
-            return Err(crate::call::take_call_error()
-                .unwrap_or_else(|| crate::PyError::type_error("__complex__ call failed")));
-        }
-        unsafe {
-            if is_complex(res) {
-                if !is_exact_type(res, &COMPLEX_TYPE) {
-                    crate::warn::warn_deprecation(&format!(
-                        "__complex__ returned non-complex (type {}). The ability to return an instance of a strict subclass of complex is deprecated, and may be removed in a future version of Python.",
-                        crate::type_methods::arg_type_name(res)
-                    ))?;
+    if let Some(w_type) = crate::typedef::r#type(obj) {
+        if let Some(w_complex) =
+            unsafe { crate::baseobjspace::lookup_in_type(w_type.as_ptr(), "__complex__") }
+        {
+            let res = unsafe {
+                crate::baseobjspace::get_and_call_function(w_complex, obj, w_type.as_ptr(), &[])?
+            };
+            unsafe {
+                if is_complex(res) {
+                    if !is_exact_type(res, &COMPLEX_TYPE) {
+                        crate::warn::warn_deprecation(&format!(
+                            "__complex__ returned non-complex (type {}). The ability to return an instance of a strict subclass of complex is deprecated, and may be removed in a future version of Python.",
+                            crate::type_methods::arg_type_name(res)
+                        ))?;
+                    }
+                    return Ok((w_complex_get_real(res), w_complex_get_imag(res)));
                 }
-                return Ok((w_complex_get_real(res), w_complex_get_imag(res)));
             }
+            return Err(crate::PyError::type_error(format!(
+                "__complex__ returned non-complex (type {})",
+                crate::type_methods::arg_type_name(res)
+            )));
         }
-        return Err(crate::PyError::type_error(format!(
-            "__complex__ returned non-complex (type {})",
-            crate::type_methods::arg_type_name(res)
-        )));
     }
     unsafe {
         if is_complex(obj) {

--- a/pyre/pyre-interpreter/src/call.rs
+++ b/pyre/pyre-interpreter/src/call.rs
@@ -2695,16 +2695,21 @@ pub(crate) fn calculate_metaclass(
         let Some(base) = (unsafe { pyre_object::w_tuple_getitem(bases, i as i64) }) else {
             continue;
         };
-        let Some(w_base_type) = crate::typedef::r#type(base) else {
+        let w_base_type = unsafe {
+            if pyre_object::is_type(base) && !(*base).w_class.is_null() {
+                Some((*base).w_class)
+            } else {
+                crate::typedef::r#type(base).map(|ty| ty.as_ptr())
+            }
+        };
+        let Some(w_base_type) = w_base_type else {
             continue;
         };
-        if std::ptr::eq(w_winner, w_base_type.as_ptr())
-            || issubtype_ptr(w_winner, w_base_type.as_ptr())
-        {
+        if std::ptr::eq(w_winner, w_base_type) || issubtype_ptr(w_winner, w_base_type) {
             continue;
         }
-        if issubtype_ptr(w_base_type.as_ptr(), w_winner) {
-            w_winner = w_base_type.as_ptr();
+        if issubtype_ptr(w_base_type, w_winner) {
+            w_winner = w_base_type;
             continue;
         }
         return Err(PyError::type_error(
@@ -3324,27 +3329,34 @@ pub(crate) fn real_build_class(args: &[PyObjectRef]) -> Result<PyObjectRef, crat
     };
 
     // If no explicit metaclass, infer from bases (PyPy: calculate_metaclass)
-    let w_metaclass = metaclass.or_else(|| {
-        unsafe {
-            if !pyre_object::is_tuple(bases_tuple) {
-                return None;
-            }
-            let n = pyre_object::w_tuple_len(bases_tuple);
-            for i in 0..n {
-                if let Some(base) = pyre_object::w_tuple_getitem(bases_tuple, i as i64) {
-                    if pyre_object::is_type(base) {
-                        // baseobjspace.py:76 — metaclass from w_class
-                        let w_class = (*base).w_class;
-                        let w_type_type = crate::typedef::w_type();
-                        if !w_class.is_null() && !std::ptr::eq(w_class, w_type_type) {
-                            return Some(w_class);
-                        }
-                    }
+    let w_metaclass = match metaclass {
+        Some(meta) if unsafe { !pyre_object::is_type(meta) } => Some(meta),
+        explicit => {
+            let initial = if let Some(explicit) = explicit {
+                explicit
+            } else if unsafe { pyre_object::w_tuple_len(bases_tuple) } > 0 {
+                unsafe {
+                    pyre_object::w_tuple_getitem(bases_tuple, 0)
+                        .and_then(|base| {
+                            if pyre_object::is_type(base) && !(*base).w_class.is_null() {
+                                Some((*base).w_class)
+                            } else {
+                                crate::typedef::r#type(base).map(|ty| ty.as_ptr())
+                            }
+                        })
+                        .unwrap_or_else(crate::typedef::w_type)
                 }
+            } else {
+                crate::typedef::w_type()
+            };
+            let winner = calculate_metaclass(initial, bases_tuple)?;
+            if std::ptr::eq(winner, crate::typedef::w_type()) {
+                None
+            } else {
+                Some(winner)
             }
         }
-        None
-    });
+    };
 
     build_class_inner(
         body_fn,
@@ -3725,6 +3737,15 @@ fn build_class_inner(
         let class_ns = pyre_object::gc_roots::shadow_stack_get(class_ns_root);
         unsafe { pyre_object::w_dict_getitem_str(class_ns, "__classcell__") }
     };
+    if w_metaclass.is_none()
+        && classcell.is_some_and(|value| unsafe { !pyre_object::is_cell(value) })
+    {
+        let value = classcell.unwrap();
+        return Err(PyError::type_error(format!(
+            "__classcell__ must be a nonlocal cell, not {}",
+            unsafe { pyre_object::type_name_of(value) },
+        )));
+    }
     // CPython 3.14 type_new_set_classdict: compiler-generated annotation
     // functions and comprehensions capture `__classdict__` through this
     // separate cell.  type.__new__ consumes the namespace entry and replaces
@@ -4623,6 +4644,35 @@ unsafe fn check_and_find_best_base(
     w_bases: pyre_object::PyObjectRef,
 ) -> Result<pyre_object::PyObjectRef, crate::PyError> {
     unsafe {
+        let len = if w_bases.is_null() || !pyre_object::is_tuple(w_bases) {
+            0
+        } else {
+            pyre_object::w_tuple_len(w_bases)
+        };
+        for i in 0..len {
+            let Some(w_base) = pyre_object::w_tuple_getitem(w_bases, i as i64) else {
+                continue;
+            };
+            if !pyre_object::is_type(w_base) {
+                return Err(crate::PyError::type_error(format!(
+                    "{}() argument 2 must be tuple of types, not {}",
+                    "type",
+                    pyre_object::type_name_of(w_base),
+                )));
+            }
+            if pyre_object::w_type_get_mro(w_base).is_null() {
+                return Err(crate::PyError::type_error(format!(
+                    "cannot extend incomplete type '{}'",
+                    pyre_object::w_type_get_name(w_base),
+                )));
+            }
+            if !is_acceptable_base_class(w_base) {
+                return Err(crate::PyError::type_error(format!(
+                    "type '{}' is not an acceptable base type",
+                    pyre_object::w_type_get_name(w_base),
+                )));
+            }
+        }
         let w_bestbase = find_best_base(w_bases);
         // typeobject.py:1113-1115
         if w_bestbase.is_null() {
@@ -4642,14 +4692,22 @@ unsafe fn check_and_find_best_base(
         // typeobject.py:1122-1128: check layout conflicts
         let best_layout = pyre_object::w_type_get_layout_ptr(w_bestbase);
         if !best_layout.is_null() && !w_bases.is_null() && pyre_object::is_tuple(w_bases) {
-            let len = pyre_object::w_tuple_len(w_bases);
             for i in 0..len {
                 if let Some(w_base) = pyre_object::w_tuple_getitem(w_bases, i as i64) {
                     if !pyre_object::is_type(w_base) {
                         continue;
                     }
                     let layout = pyre_object::w_type_get_layout_ptr(w_base);
-                    if !layout.is_null() && !(*best_layout).issublayout(layout) {
+                    let native_layout_conflict = !layout.is_null()
+                        && !std::ptr::eq((*best_layout).typedef, (*layout).typedef)
+                        && !std::ptr::eq(
+                            (*best_layout).typedef,
+                            &pyre_object::pyobject::INSTANCE_TYPE,
+                        )
+                        && !std::ptr::eq((*layout).typedef, &pyre_object::pyobject::INSTANCE_TYPE);
+                    if !layout.is_null()
+                        && (!(*best_layout).issublayout(layout) || native_layout_conflict)
+                    {
                         return Err(crate::PyError::type_error(
                             "instance layout conflicts in multiple inheritance".to_string(),
                         ));

--- a/pyre/pyre-interpreter/src/display.rs
+++ b/pyre/pyre-interpreter/src/display.rs
@@ -348,6 +348,7 @@ pub(crate) unsafe fn builtin_subclass_dunder_obj(
         let is_leaf = std::ptr::eq(tp, &INT_TYPE as *const PyType)
             || std::ptr::eq(tp, &LONG_TYPE as *const PyType)
             || std::ptr::eq(tp, &FLOAT_TYPE as *const PyType)
+            || std::ptr::eq(tp, &pyre_object::COMPLEX_TYPE as *const PyType)
             || std::ptr::eq(tp, &BOOL_TYPE as *const PyType)
             || std::ptr::eq(tp, &STR_TYPE as *const PyType)
             || std::ptr::eq(tp, &pyre_object::LIST_TYPE as *const PyType)

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -4156,6 +4156,28 @@ impl OpcodeStepExecutor for PyFrame {
         Ok(())
     }
 
+    fn load_special(&mut self, name: &str) -> Result<(), PyError> {
+        let obj = self.pop();
+        let w_type =
+            crate::typedef::r#type(obj).map_or(pyre_object::PY_NULL, |w_type| w_type.as_ptr());
+        let descr = if w_type.is_null() {
+            None
+        } else {
+            unsafe { crate::baseobjspace::lookup_in_type(w_type, name) }
+        }
+        .ok_or_else(|| {
+            PyError::attribute_error(format!(
+                "'{}' object has no attribute '{}'",
+                crate::baseobjspace::object_functionstr_type_name(obj),
+                name,
+            ))
+        })?;
+        let bound = unsafe { crate::baseobjspace::get(descr, obj, w_type) }?.unwrap_or(descr);
+        self.push(bound);
+        self.push(PY_NULL);
+        Ok(())
+    }
+
     /// pyopcode.py:1024-1027 `LOAD_ATTR` — the interpreter consults the mapdict
     /// attribute cache only off-trace; under the JIT it does the plain
     /// `space.getattr`, which the trace folds via the type's `version_tag`.

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -4158,21 +4158,7 @@ impl OpcodeStepExecutor for PyFrame {
 
     fn load_special(&mut self, name: &str) -> Result<(), PyError> {
         let obj = self.pop();
-        let w_type =
-            crate::typedef::r#type(obj).map_or(pyre_object::PY_NULL, |w_type| w_type.as_ptr());
-        let descr = if w_type.is_null() {
-            None
-        } else {
-            unsafe { crate::baseobjspace::lookup_in_type(w_type, name) }
-        }
-        .ok_or_else(|| {
-            PyError::attribute_error(format!(
-                "'{}' object has no attribute '{}'",
-                crate::baseobjspace::object_functionstr_type_name(obj),
-                name,
-            ))
-        })?;
-        let bound = unsafe { crate::baseobjspace::get(descr, obj, w_type) }?.unwrap_or(descr);
+        let bound = crate::baseobjspace::load_special_resolve(obj, name)?;
         self.push(bound);
         self.push(PY_NULL);
         Ok(())

--- a/pyre/pyre-interpreter/src/function.rs
+++ b/pyre/pyre-interpreter/src/function.rs
@@ -13,6 +13,12 @@ pub static FUNCTION_TYPE: PyType = pyre_object::pyobject::new_pytype("function")
 /// Type descriptor for module-level builtins.
 pub static BUILTIN_FUNCTION_TYPE: PyType =
     pyre_object::pyobject::new_pytype("builtin_function_or_method");
+/// CPython-compatible interp-level method descriptor.
+///
+/// PyPy represents these as `FunctionWithFixedCode`; the separate public
+/// type preserves that payload and call ABI while exposing CPython's
+/// `method_descriptor` surface.
+pub static METHOD_DESCRIPTOR_TYPE: PyType = pyre_object::pyobject::new_pytype("method_descriptor");
 /// CPython-compatible slot wrapper descriptor.
 ///
 /// The public type is distinct from PyPy's `FunctionWithFixedCode`, while the
@@ -529,6 +535,16 @@ pub fn function_new_slot_wrapper(code: *const (), name: String) -> PyObjectRef {
     function_new_impl(&SLOT_WRAPPER_TYPE, code, name, PY_NULL, PY_NULL, false)
 }
 
+/// Retag a freshly materialised `FunctionWithFixedCode` as the public
+/// method-descriptor carrier. TypeDef builds its namespace before the owner
+/// type exists, so this is deliberately performed during materialisation.
+pub unsafe fn function_retag_method_descriptor(obj: PyObjectRef) {
+    unsafe {
+        (*obj).ob_type = &METHOD_DESCRIPTOR_TYPE as *const PyType;
+        (*obj).w_class = get_instantiate(&METHOD_DESCRIPTOR_TYPE);
+    }
+}
+
 /// function.py:385-388 — `_check_code_mutable(attr)`:
 ///
 /// ```python
@@ -569,7 +585,11 @@ pub unsafe fn _get_immutable_code(func: PyObjectRef) -> *const () {
 /// `obj` must be a valid, non-null pointer to a `PyObject`.
 #[inline]
 pub unsafe fn is_function(obj: PyObjectRef) -> bool {
-    unsafe { py_type_check(obj, &FUNCTION_TYPE) || py_type_check(obj, &BUILTIN_FUNCTION_TYPE) }
+    unsafe {
+        py_type_check(obj, &FUNCTION_TYPE)
+            || py_type_check(obj, &BUILTIN_FUNCTION_TYPE)
+            || py_type_check(obj, &METHOD_DESCRIPTOR_TYPE)
+    }
 }
 
 /// Whether `obj` is a CPython-compatible slot-wrapper descriptor.

--- a/pyre/pyre-interpreter/src/lib.rs
+++ b/pyre/pyre-interpreter/src/lib.rs
@@ -957,6 +957,7 @@ pub fn all_subclass_range_aliases() -> Vec<pyre_object::pyobject::SubclassRangeA
         subclass_range_alias(13, &crate::gateway::BUILTIN_CODE_TYPE),
         subclass_range_alias(14, &crate::function::FUNCTION_TYPE),
         subclass_range_alias(14, &crate::function::BUILTIN_FUNCTION_TYPE),
+        subclass_range_alias(14, &crate::function::METHOD_DESCRIPTOR_TYPE),
         subclass_range_alias(14, &crate::function::SLOT_WRAPPER_TYPE),
         subclass_range_alias(43, &crate::pycode::CODE_TYPE),
         subclass_range_alias(44, &crate::pytraceback::PYTRACEBACK_TYPE),

--- a/pyre/pyre-interpreter/src/module/_weakref/interp__weakref.rs
+++ b/pyre/pyre-interpreter/src/module/_weakref/interp__weakref.rs
@@ -2394,13 +2394,12 @@ mod tests {
         assert_eq!(unsafe { pyre_object::w_int_get_value(result) }, 7777);
     }
 
-    /// 3-arg `pow(proxy, b, c)` reaches `space.pow3`, which consults only the
-    /// forward `__pow__` on the base — the reflected `__rpow__` is not tried
-    /// for ternary power (descroperation.py:450). A forward `NotImplemented`
-    /// therefore raises the three-operand type error rather than falling
-    /// through to the right operand's `__rpow__`.
+    /// 3-arg `pow(proxy, b, c)` reaches `space.pow3`. Python 3.14 extends
+    /// reflected-power dispatch to the ternary form: when the forward
+    /// `__pow__` returns `NotImplemented`, the right operand's `__rpow__` is
+    /// tried with `(base, modulus)` after its receiver rather than raising.
     #[test]
-    fn test_proxy_pow_three_arg_does_not_use_rpow() {
+    fn test_proxy_pow_three_arg_uses_rpow() {
         let _g = super::lock_proxy_tests();
         crate::typedef::init_typeobjects();
         let lhs_type = crate::typedef::make_builtin_type("Pow3Lhs", |ns| {
@@ -2419,6 +2418,8 @@ mod tests {
                 pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
                     ns,
                     "__rpow__",
+                    // __rpow__(self, base, modulus) — return the modulus so the
+                    // assertion proves the ternary argument reached the slot.
                     crate::make_builtin_function("__rpow__", |args| Ok(args[2])),
                 )
             };
@@ -2426,12 +2427,8 @@ mod tests {
         let lhs = pyre_object::objectobject::w_instance_new(lhs_type);
         let rhs = pyre_object::objectobject::w_instance_new(rhs_type);
         let proxy_lhs = W_Proxy_new(lhs, PY_NULL);
-        let err = proxy_pow(&[proxy_lhs, rhs, pyre_object::w_int_new(99)]).unwrap_err();
-        assert_eq!(err.kind, crate::PyErrorKind::TypeError);
-        assert_eq!(
-            err.message,
-            "unsupported operand type(s) for pow(): 'Pow3Lhs', 'Pow3Rhs', 'int'"
-        );
+        let result = proxy_pow(&[proxy_lhs, rhs, pyre_object::w_int_new(7)]).unwrap();
+        assert_eq!(unsafe { pyre_object::w_int_get_value(result) }, 7);
     }
 
     /// `divmod(proxy, rhs)` where `lhs.__divmod__` returns NotImplemented

--- a/pyre/pyre-interpreter/src/module/sys/vm.rs
+++ b/pyre/pyre-interpreter/src/module/sys/vm.rs
@@ -1702,29 +1702,42 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
     module_ns_store(
         ns,
         "getsizeof",
-        make_builtin_function("getsizeof", |args| {
-            if args.len() > 2 {
-                return Err(crate::PyError::type_error(format!(
-                    "getsizeof() takes at most 2 arguments ({} given)",
-                    args.len()
-                )));
-            }
-            let Some(&w_obj) = args.first() else {
-                return Err(crate::PyError::type_error(
-                    "getsizeof() takes at least 1 argument (0 given)",
-                ));
-            };
-            if unsafe { pyre_object::is_str(w_obj) } {
-                let method = crate::baseobjspace::getattr_str(w_obj, "__sizeof__")?;
-                return crate::call::call_function_impl_result(method, &[]);
-            }
-            match args.get(1).copied() {
-                Some(w_default) => Ok(w_default),
-                None => Err(crate::PyError::type_error(
-                    "getsizeof(object, default) -> int: object size is not tracked; supply a default",
-                )),
-            }
-        }),
+        make_builtin_function(
+            "getsizeof",
+            |args| {
+                if args.len() > 2 {
+                    return Err(crate::PyError::type_error(format!(
+                        "getsizeof() takes at most 2 arguments ({} given)",
+                        args.len()
+                    )));
+                }
+                let Some(&w_obj) = args.first() else {
+                    return Err(crate::PyError::type_error(
+                        "getsizeof() takes at least 1 argument (0 given)",
+                    ));
+                };
+                if let Some(w_type) = crate::typedef::r#type(w_obj) {
+                    if let Some(w_sizeof) = unsafe {
+                        crate::baseobjspace::lookup_in_type(w_type.as_ptr(), "__sizeof__")
+                    } {
+                        return unsafe {
+                            crate::baseobjspace::get_and_call_function(
+                                w_sizeof,
+                                w_obj,
+                                w_type.as_ptr(),
+                                &[],
+                            )
+                        };
+                    }
+                }
+                match args.get(1).copied() {
+                    Some(w_default) => Ok(w_default),
+                    None => Err(crate::PyError::type_error(
+                        "getsizeof(object, default) -> int: object size is not tracked; supply a default",
+                    )),
+                }
+            },
+        ),
     );
     // PyPy normally omits CPython's raw refcount API.  The shared ctypes
     // tests only require the strong-reference delta created by a c_char_p

--- a/pyre/pyre-interpreter/src/module/sys/vm.rs
+++ b/pyre/pyre-interpreter/src/module/sys/vm.rs
@@ -1720,14 +1720,37 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                     if let Some(w_sizeof) = unsafe {
                         crate::baseobjspace::lookup_in_type(w_type.as_ptr(), "__sizeof__")
                     } {
-                        return unsafe {
+                        let w_size = unsafe {
                             crate::baseobjspace::get_and_call_function(
                                 w_sizeof,
                                 w_obj,
                                 w_type.as_ptr(),
                                 &[],
                             )
-                        };
+                        }?;
+                        // getsizeof must yield a non-negative integer: a
+                        // non-int result is rejected like a failed index
+                        // coercion, and a negative one (including a bignum)
+                        // raises ValueError.
+                        if unsafe { !pyre_object::is_int(w_size) } {
+                            return Err(crate::PyError::type_error(format!(
+                                "'{}' object cannot be interpreted as an integer",
+                                crate::type_methods::arg_type_name(w_size)
+                            )));
+                        }
+                        let negative = crate::baseobjspace::is_true(
+                            crate::objspace::descroperation::compare(
+                                w_size,
+                                pyre_object::w_int_new(0),
+                                crate::objspace::descroperation::CompareOp::Lt,
+                            )?,
+                        )?;
+                        if negative {
+                            return Err(crate::PyError::value_error(
+                                "__sizeof__() should return >= 0",
+                            ));
+                        }
+                        return Ok(w_size);
                     }
                 }
                 match args.get(1).copied() {

--- a/pyre/pyre-interpreter/src/module/time/interp_time.rs
+++ b/pyre/pyre-interpreter/src/module/time/interp_time.rs
@@ -1095,11 +1095,11 @@ pub fn strftime(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
             }
             rendered.extend_from_slice(&render_segment(segment)?);
         }
-        Ok(w_str_from_wtf8(
-            rustpython_wtf8::Wtf8Buf::from_bytes(rendered).unwrap_or_else(|b| {
-                rustpython_wtf8::Wtf8Buf::from_string(String::from_utf8_lossy(&b).into_owned())
-            }),
-        ))
+        // Directives such as %Z/%a render in the LC_TIME locale, so the
+        // bytes need not be UTF-8.  Decode with surrogateescape to preserve
+        // each byte as a lone surrogate rather than raising, mirroring
+        // str_decode_locale_surrogateescape.
+        Ok(crate::typedef::charp2uni(&rendered))
     }
     #[cfg(windows)]
     {

--- a/pyre/pyre-interpreter/src/module/time/interp_time.rs
+++ b/pyre/pyre-interpreter/src/module/time/interp_time.rs
@@ -1095,11 +1095,17 @@ pub fn strftime(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
             }
             rendered.extend_from_slice(&render_segment(segment)?);
         }
-        // Directives such as %Z/%a render in the LC_TIME locale, so the
-        // bytes need not be UTF-8.  Decode with surrogateescape to preserve
-        // each byte as a lone surrogate rather than raising, mirroring
-        // str_decode_locale_surrogateescape.
-        Ok(crate::typedef::charp2uni(&rendered))
+        // libc echoes bytes it does not recognise as a directive verbatim, so
+        // a format that is itself a lone surrogate's WTF-8 encoding comes back
+        // unchanged and must be recovered as WTF-8 to round-trip the surrogate.
+        // Genuinely non-UTF-8 LC_TIME output (from %Z/%a in a non-UTF-8 locale)
+        // is not valid WTF-8; fall back to surrogateescape rather than raising,
+        // mirroring str_decode_locale_surrogateescape.
+        let result = match rustpython_wtf8::Wtf8Buf::from_bytes(rendered) {
+            Ok(wtf8) => pyre_object::w_str_from_wtf8(wtf8),
+            Err(bytes) => crate::typedef::charp2uni(&bytes),
+        };
+        Ok(result)
     }
     #[cfg(windows)]
     {

--- a/pyre/pyre-interpreter/src/module/time/interp_time.rs
+++ b/pyre/pyre-interpreter/src/module/time/interp_time.rs
@@ -141,11 +141,9 @@ pub fn sleep(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
                 let has_int = crate::baseobjspace::lookup(args[0], "__int__").is_some()
                     || crate::baseobjspace::lookup(args[0], "__index__").is_some();
                 if !has_int {
-                    let name = crate::typedef::r#type(args[0])
-                        .map(|tp| w_type_get_name(tp.as_ptr()).to_string())
-                        .unwrap_or_else(|| "object".to_string());
                     return Err(crate::PyError::type_error(format!(
-                        "'{name}' object cannot be interpreted as an integer"
+                        "'{}' object is not an integer or float",
+                        crate::type_methods::arg_type_name(args[0])
                     )));
                 }
                 let w_int = crate::baseobjspace::space_int(args[0])?;
@@ -539,7 +537,7 @@ type time_t = i64;
 fn _c_gmtime(seconds: time_t) -> Result<c_tm, crate::PyError> {
     host_time::gmtime_from_timestamp(seconds as host_time::TimeT)
         .map(|tm| libc_tm_to_c_tm(&tm))
-        .ok_or_else(|| crate::PyError::value_error("unconvertible time"))
+        .ok_or_else(|| crate::PyError::os_error("unconvertible time"))
 }
 
 // wasm32 has no libc `struct tm` calendar conversions; the broken-down-time
@@ -560,7 +558,7 @@ fn _c_gmtime(seconds: time_t) -> Result<c_tm, crate::PyError> {
     let mut tm: libc::tm = unsafe { std::mem::zeroed() };
     let p = unsafe { libc::gmtime_r(&t, &mut tm) };
     if p.is_null() {
-        return Err(crate::PyError::value_error("unconvertible time"));
+        return Err(crate::PyError::os_error("unconvertible time"));
     }
     Ok(libc_tm_to_c_tm(&tm))
 }
@@ -583,7 +581,7 @@ fn _c_gmtime(seconds: time_t) -> Result<c_tm, crate::PyError> {
 fn _c_localtime(seconds: time_t) -> Result<c_tm, crate::PyError> {
     host_time::localtime_from_timestamp(seconds as host_time::TimeT)
         .map(|tm| libc_tm_to_c_tm(&tm))
-        .ok_or_else(|| crate::PyError::value_error("unconvertible time"))
+        .ok_or_else(|| crate::PyError::os_error("unconvertible time"))
 }
 
 #[cfg(target_arch = "wasm32")]
@@ -599,7 +597,7 @@ fn _c_localtime(seconds: time_t) -> Result<c_tm, crate::PyError> {
     let mut tm: libc::tm = unsafe { std::mem::zeroed() };
     let p = unsafe { libc::localtime_r(&t, &mut tm) };
     if p.is_null() {
-        return Err(crate::PyError::value_error("unconvertible time"));
+        return Err(crate::PyError::os_error("unconvertible time"));
     }
     Ok(libc_tm_to_c_tm(&tm))
 }
@@ -666,6 +664,81 @@ fn c_tm_to_libc_tm(tm: &c_tm) -> libc::tm {
         out.tm_isdst = tm.tm_isdst;
         out
     }
+}
+
+/// `interp_time.py:512-611 _init_timezone` — derive the module's four
+/// timezone attributes from libc's January/July broken-down times.  This
+/// preserves the standard-vs-DST ordering in both hemispheres.
+#[cfg(unix)]
+pub(crate) fn init_timezone(ns: PyObjectRef) {
+    const YEAR: i64 = (365 * 24 + 6) * 3600;
+    let start = duration_since_epoch().as_secs() as i64 / YEAR * YEAR;
+    let january = _c_localtime(start);
+    let july = _c_localtime(start + YEAR / 2);
+
+    let (timezone, altzone, daylight, standard_name, daylight_name) = match (january, july) {
+        (Ok(january), Ok(july)) => {
+            let january_offset = -january.tm_gmtoff;
+            let july_offset = -july.tm_gmtoff;
+            let january_name = if january.tm_zone.is_empty() {
+                "   ".to_string()
+            } else {
+                january.tm_zone
+            };
+            let july_name = if july.tm_zone.is_empty() {
+                "   ".to_string()
+            } else {
+                july.tm_zone
+            };
+            if january_offset < july_offset {
+                // DST is reversed in the southern hemisphere.
+                (
+                    july_offset,
+                    january_offset,
+                    i64::from(january_offset != july_offset),
+                    july_name,
+                    january_name,
+                )
+            } else {
+                (
+                    january_offset,
+                    july_offset,
+                    i64::from(january_offset != july_offset),
+                    january_name,
+                    july_name,
+                )
+            }
+        }
+        _ => (0, 0, 0, String::new(), String::new()),
+    };
+
+    crate::module_ns_store(ns, "timezone", w_int_new(timezone));
+    crate::module_ns_store(ns, "altzone", w_int_new(altzone));
+    crate::module_ns_store(ns, "daylight", w_int_new(daylight));
+    crate::module_ns_store(
+        ns,
+        "tzname",
+        w_tuple_new(vec![w_str_new(&standard_name), w_str_new(&daylight_name)]),
+    );
+}
+
+/// `interp_time.py:1106-1122 tzset` — ask libc to reread `TZ`, then refresh
+/// the values installed by `_init_timezone`.
+#[cfg(unix)]
+pub fn tzset(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    let _ = args;
+    unsafe extern "C" {
+        #[link_name = "tzset"]
+        fn c_tzset();
+    }
+    unsafe { c_tzset() };
+    if let Some(module) = crate::importing::get_sys_module("time") {
+        let ns = unsafe { pyre_object::w_module_get_w_dict(module) };
+        if !ns.is_null() {
+            init_timezone(ns);
+        }
+    }
+    Ok(w_none())
 }
 
 // ── Windows helpers ─────────────────────────────────────────────────
@@ -773,21 +846,38 @@ fn _tm_to_tuple(tm: &c_tm) -> PyObjectRef {
     }
 }
 
-/// Extract epoch seconds from an optional argument (int, float, or None/absent → now).
-fn _get_seconds(args: &[PyObjectRef]) -> time_t {
+/// `interp_time.py:738-758 _get_inttime` — extract integral epoch seconds
+/// from an optional real argument (None/absent means now), rejecting NaN and
+/// values that lose at least one second when cast to the platform time_t.
+fn _get_seconds(args: &[PyObjectRef]) -> Result<time_t, crate::PyError> {
     if let Some(&arg) = args.first() {
         unsafe {
             if !is_none(arg) {
-                if is_int(arg) {
-                    return w_int_get_value(arg) as time_t;
+                let seconds = crate::baseobjspace::float_w(arg)?;
+                if seconds.is_nan() {
+                    return Err(crate::PyError::value_error(
+                        "Invalid value Nan (not a number)",
+                    ));
                 }
-                if is_float(arg) {
-                    return floatobject::w_float_get_value(arg) as time_t;
+                // Rust's float-to-int cast saturates.  Guard the boundary
+                // explicitly, then retain PyPy's lost-whole-second check.
+                if seconds >= i64::MAX as f64 || seconds < i64::MIN as f64 {
+                    return Err(crate::PyError::overflow_error(
+                        "timestamp out of range for platform time_t",
+                    ));
                 }
+                let result = seconds as time_t;
+                let diff = seconds - result as f64;
+                if !(-1.0..=1.0).contains(&diff) || diff == -1.0 || diff == 1.0 {
+                    return Err(crate::PyError::overflow_error(
+                        "timestamp out of range for platform time_t",
+                    ));
+                }
+                return Ok(result);
             }
         }
     }
-    duration_since_epoch().as_secs() as time_t
+    Ok(duration_since_epoch().as_secs() as time_t)
 }
 
 /// Extract a `c_tm` from a Python time tuple argument.
@@ -796,7 +886,7 @@ fn _gettmarg(args: &[PyObjectRef], default_now: bool) -> Result<c_tm, crate::PyE
     let tup = if let Some(&arg) = args.first() {
         if unsafe { is_none(arg) } {
             if default_now {
-                return _c_localtime(_get_seconds(&[]));
+                return _c_localtime(_get_seconds(&[])?);
             }
             return Err(crate::PyError::type_error(
                 "Tuple or struct_time argument required",
@@ -804,7 +894,7 @@ fn _gettmarg(args: &[PyObjectRef], default_now: bool) -> Result<c_tm, crate::PyE
         }
         arg
     } else if default_now {
-        return _c_localtime(_get_seconds(&[]));
+        return _c_localtime(_get_seconds(&[])?);
     } else {
         return Err(crate::PyError::type_error(
             "Tuple or struct_time argument required",
@@ -884,14 +974,14 @@ fn _gettmarg(args: &[PyObjectRef], default_now: bool) -> Result<c_tm, crate::PyE
 
 /// time.localtime([seconds]) — interp_time.localtime
 pub fn localtime(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    let seconds = _get_seconds(args);
+    let seconds = _get_seconds(args)?;
     let tm = _c_localtime(seconds)?;
     Ok(_tm_to_tuple(&tm))
 }
 
 /// time.gmtime([seconds]) — interp_time.gmtime
 pub fn gmtime(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    let seconds = _get_seconds(args);
+    let seconds = _get_seconds(args)?;
     let tm = _c_gmtime(seconds)?;
     Ok(_tm_to_tuple(&tm))
 }
@@ -932,23 +1022,27 @@ pub fn strftime(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     let tm = _gettmarg(&args[1..], true)?;
     _checktm(&tm)?;
 
-    let fmt_str = unsafe {
+    let fmt_wtf8 = unsafe {
         if !is_str(fmt) {
             return Err(crate::PyError::type_error(
                 "strftime() argument 1 must be str",
             ));
         }
-        w_str_get_wtf8(fmt).as_bytes()
+        w_str_get_wtf8(fmt)
     };
 
-    let c_fmt = std::ffi::CString::new(fmt_str)
-        .map_err(|_| crate::PyError::value_error("embedded null in format string"))?;
+    // `interp_time.py:1158-1164` has a byte-preserving passthrough for
+    // formats the locale encoder cannot represent.  Keep pyre's WTF-8
+    // backing bytes intact for every format: valid text is ordinary UTF-8,
+    // while lone surrogates stay distinct (including adjacent DCxx bytes
+    // that would otherwise decode back into one Unicode scalar).
+    let format_len = fmt_wtf8.code_points().count();
 
     // wasm32 has no libc `strftime`; the function raises rather than dropping
     // `time` from the module registry (same policy as `gmtime`/`localtime`).
     #[cfg(target_arch = "wasm32")]
     {
-        let _ = c_fmt;
+        let _ = format_len;
         Err(crate::PyError::not_implemented(
             "time.strftime is unavailable on wasm32",
         ))
@@ -957,39 +1051,55 @@ pub fn strftime(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     // sandbox the registration is stubbed, so the real body is compiled out.
     #[cfg(all(unix, feature = "sandbox"))]
     {
-        let _ = c_fmt;
+        let _ = format_len;
         Err(crate::host_seam::stub("time.strftime"))
     }
     // strftime is available on both Unix and Windows CRT.
     #[cfg(all(unix, not(feature = "sandbox")))]
     {
         let libc_tm = c_tm_to_libc_tm(&tm);
-        let mut buf = vec![0u8; 256];
-        unsafe {
+        let render_segment = |segment: &[u8]| -> Result<Vec<u8>, crate::PyError> {
+            if segment.is_empty() {
+                return Ok(Vec::new());
+            }
+            let c_fmt = std::ffi::CString::new(segment)
+                .expect("a segment split at every NUL contains no NUL");
+            let mut buf = vec![0u8; 256];
             loop {
-                let n = libc::strftime(
-                    buf.as_mut_ptr() as *mut libc::c_char,
-                    buf.len(),
-                    c_fmt.as_ptr(),
-                    &libc_tm,
-                );
+                let n = unsafe {
+                    libc::strftime(
+                        buf.as_mut_ptr() as *mut libc::c_char,
+                        buf.len(),
+                        c_fmt.as_ptr(),
+                        &libc_tm,
+                    )
+                };
                 if n != 0 {
-                    return Ok(w_str_from_wtf8(
-                        rustpython_wtf8::Wtf8Buf::from_bytes(buf[..n].to_vec()).unwrap_or_else(
-                            |b| {
-                                rustpython_wtf8::Wtf8Buf::from_string(
-                                    String::from_utf8_lossy(&b).into_owned(),
-                                )
-                            },
-                        ),
-                    ));
+                    return Ok(buf[..n].to_vec());
                 }
-                if buf.len() > 16384 {
-                    return Ok(w_str_new(""));
+                if buf.len() >= 256 * format_len.max(1) {
+                    return Ok(Vec::new());
                 }
                 buf.resize(buf.len() * 2, 0);
             }
+        };
+
+        // CPython gh-124531, mirrored by the current PyPy-facing suite: an
+        // embedded NUL is literal data, not the end of the format. libc's API
+        // cannot represent it, so render each NUL-free segment and restore
+        // the separators verbatim.
+        let mut rendered = Vec::new();
+        for (index, segment) in fmt_wtf8.as_bytes().split(|&byte| byte == 0).enumerate() {
+            if index != 0 {
+                rendered.push(0);
+            }
+            rendered.extend_from_slice(&render_segment(segment)?);
         }
+        Ok(w_str_from_wtf8(
+            rustpython_wtf8::Wtf8Buf::from_bytes(rendered).unwrap_or_else(|b| {
+                rustpython_wtf8::Wtf8Buf::from_string(String::from_utf8_lossy(&b).into_owned())
+            }),
+        ))
     }
     #[cfg(windows)]
     {
@@ -1001,6 +1111,8 @@ pub fn strftime(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
                 timeptr: *const MsvcTm,
             ) -> usize;
         }
+        let c_fmt = std::ffi::CString::new(fmt_wtf8.as_bytes())
+            .map_err(|_| crate::PyError::value_error("embedded null in format string"))?;
         let msvc_tm = c_tm_to_msvc_tm(&tm);
         let mut buf = vec![0u8; 256];
         unsafe {
@@ -1106,7 +1218,7 @@ fn _asctime_from_tm(tm: &c_tm) -> Result<PyObjectRef, crate::PyError> {
 
 /// time.ctime([seconds]) — interp_time.ctime
 pub fn ctime(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    let seconds = _get_seconds(args);
+    let seconds = _get_seconds(args)?;
 
     #[cfg(target_arch = "wasm32")]
     {

--- a/pyre/pyre-interpreter/src/module/time/mod.rs
+++ b/pyre/pyre-interpreter/src/module/time/mod.rs
@@ -107,6 +107,17 @@ def get_clock_info(name):
             crate::module_ns_store(ns, "CLOCK_THREAD_CPUTIME_ID",
                 pyre_object::w_int_new(libc::CLOCK_THREAD_CPUTIME_ID as i64));
         }
+        #[cfg(unix)]
+        {
+            // PyPy `Module.startup` calls `_init_timezone`, and exposes
+            // `tzset` on every POSIX build.
+            t::init_timezone(ns);
+            crate::module_ns_store(
+                ns,
+                "tzset",
+                crate::make_builtin_function_with_arity("tzset", t::tzset, 0),
+            );
+        }
         // localtime/mktime/ctime/strftime consult $TZ + /etc/localtime (and
         // the LC_TIME locale DB), reading host state outside the controller;
         // gmtime (UTC) and asctime (fixed C format) stay pure.

--- a/pyre/pyre-interpreter/src/module/time/mod.rs
+++ b/pyre/pyre-interpreter/src/module/time/mod.rs
@@ -107,10 +107,13 @@ def get_clock_info(name):
             crate::module_ns_store(ns, "CLOCK_THREAD_CPUTIME_ID",
                 pyre_object::w_int_new(libc::CLOCK_THREAD_CPUTIME_ID as i64));
         }
-        #[cfg(unix)]
+        // `Module.startup` calls `_init_timezone`, and exposes `tzset` on
+        // every POSIX build.  Both read host timezone state ($TZ,
+        // /etc/localtime) outside the controller, so under sandbox the four
+        // timezone attributes stay at the UTC interplevel defaults and tzset
+        // is not exposed — matching the tz-dependent stubs installed below.
+        #[cfg(all(unix, not(feature = "sandbox")))]
         {
-            // PyPy `Module.startup` calls `_init_timezone`, and exposes
-            // `tzset` on every POSIX build.
             t::init_timezone(ns);
             crate::module_ns_store(
                 ns,

--- a/pyre/pyre-interpreter/src/objspace/descroperation.rs
+++ b/pyre/pyre-interpreter/src/objspace/descroperation.rs
@@ -3953,15 +3953,34 @@ pub fn pow3(base: PyObjectRef, exp: PyObjectRef, modulus: PyObjectRef) -> PyResu
     if unsafe { is_none(modulus) } {
         return pow(base, exp);
     }
-    // descroperation.py:454-459 — three-arg power looks up only the forward
-    // `__pow__` on the base (so a subclass override is honoured) and never
-    // the reflected `__rpow__`. The `is_cpytype()` `pow3_bug_compat_cpyext`
-    // branch has no equivalent: with no cpyext type model every base takes
-    // the `else` branch. The integer modular-power computation lives in
-    // `int.__pow__`, reached through this lookup.
+    // Python 3.14 extends reflected-power dispatch to the ternary form.  A
+    // strict RHS subtype gets the first opportunity, exactly as for binary
+    // power, and receives `(base, modulus)` after its bound receiver.
+    let base_type = crate::typedef::r#type(base).map(|t| t.as_ptr());
+    let exp_type = crate::typedef::r#type(exp).map(|t| t.as_ptr());
+    let rhs_first = match (base_type, exp_type) {
+        (Some(lhs), Some(rhs)) if !std::ptr::eq(lhs, rhs) => unsafe {
+            crate::baseobjspace::issubtype_w(rhs, lhs)
+        },
+        _ => false,
+    };
+    if rhs_first {
+        if let Some(method) = unsafe { lookup_type_special(exp, "__rpow__") } {
+            if let Some(result) = try_call_special(method, &[exp, base, modulus])? {
+                return Ok(result);
+            }
+        }
+    }
     if let Some(method) = unsafe { lookup_type_special(base, "__pow__") } {
         if let Some(result) = try_call_special(method, &[base, exp, modulus])? {
             return Ok(result);
+        }
+    }
+    if !rhs_first {
+        if let Some(method) = unsafe { lookup_type_special(exp, "__rpow__") } {
+            if let Some(result) = try_call_special(method, &[exp, base, modulus])? {
+                return Ok(result);
+            }
         }
     }
     Err(ternary_builtin_type_error("pow()", base, exp, modulus))

--- a/pyre/pyre-interpreter/src/objspace/std/formatting.rs
+++ b/pyre/pyre-interpreter/src/objspace/std/formatting.rs
@@ -323,7 +323,11 @@ unsafe fn spec_format_bytes(spec: &CFormatSpec, obj: PyObjectRef) -> Result<Vec<
                         crate::baseobjspace::object_functionstr_type_name(obj)
                     )));
                 };
-                let bytes = crate::builtins::call_and_check(method, &[obj])?;
+                // bytesobject.py `invoke_bytes_method`:
+                // `space.get_and_call_function(w_bytes_method, w_source)`.
+                let w_type = crate::typedef::r#type(obj)
+                    .map_or(pyre_object::PY_NULL, |w_type| w_type.as_ptr());
+                let bytes = crate::baseobjspace::get_and_call_function(method, obj, w_type, &[])?;
                 if !pyre_object::is_bytes(bytes) {
                     return Err(PyError::type_error(format!(
                         "__bytes__ returned non-bytes (type {})",

--- a/pyre/pyre-interpreter/src/objspace/std/mapdict.rs
+++ b/pyre/pyre-interpreter/src/objspace/std/mapdict.rs
@@ -3657,15 +3657,12 @@ pub unsafe fn walk_mapdict_roots_area(_data: *const (), mut visitor: impl FnMut(
 /// tracer cannot model; the JIT residualises the call (`@dont_look_inside`).
 #[majit_macros::dont_look_inside]
 pub fn _obj_setdict(self_ref: PyObjectRef, w_dict: PyObjectRef) -> Result<(), PyError> {
-    // Upstream `space.isinstance_w(w_dict, space.w_dict)` also accepts
-    // dict subclasses (their instances are dict-layout
-    // W_DictMultiObject).  Pyre dict-subclass instances are
-    // `__dict_data__`-composed W_ObjectObject (typedef.rs
-    // dict_descr_new), and the devolved/cache readers below this slot
-    // (node SPECIAL reads, classify_attr) do raw layout dict ops, so
-    // only layout dicts are accepted until the subclass layout
-    // converges.
-    if !unsafe { pyre_object::is_dict(w_dict) } {
+    // mapdict.py:848 `space.isinstance_w(w_dict, space.w_dict)` accepts
+    // dict subclasses. Pyre's composed dict-subclass representation is
+    // resolved by the getdict backing helpers at each raw dict operation,
+    // while the SPECIAL slot retains the supplied object's identity.
+    let w_dict_type = crate::typedef::gettypeobject(&pyre_object::pyobject::DICT_TYPE);
+    if !unsafe { crate::baseobjspace::isinstance_w(w_dict, w_dict_type) } {
         return Err(PyError::type_error(
             "setting dictionary to a non-dict".to_string(),
         ));

--- a/pyre/pyre-interpreter/src/opcode_ops.rs
+++ b/pyre/pyre-interpreter/src/opcode_ops.rs
@@ -61,7 +61,22 @@ pub fn binary_value(
         BinaryOperator::FloorDivide | BinaryOperator::InplaceFloorDivide => floordiv(a, b),
         BinaryOperator::Remainder | BinaryOperator::InplaceRemainder => mod_(a, b),
         BinaryOperator::TrueDivide | BinaryOperator::InplaceTrueDivide => truediv(a, b),
-        BinaryOperator::Power | BinaryOperator::InplacePower => pow(a, b),
+        BinaryOperator::Power => pow(a, b),
+        BinaryOperator::InplacePower => match pow(a, b) {
+            Err(err)
+                if err.kind == crate::PyErrorKind::TypeError
+                    && err
+                        .message
+                        .starts_with("unsupported operand type(s) for ** or pow():") =>
+            {
+                Err(crate::PyError::type_error(format!(
+                    "unsupported operand type(s) for **=: '{}' and '{}'",
+                    crate::baseobjspace::object_functionstr_type_name(a),
+                    crate::baseobjspace::object_functionstr_type_name(b),
+                )))
+            }
+            result => result,
+        },
         BinaryOperator::Lshift | BinaryOperator::InplaceLshift => lshift(a, b),
         BinaryOperator::MatrixMultiply | BinaryOperator::InplaceMatrixMultiply => matmul(a, b),
         BinaryOperator::Rshift | BinaryOperator::InplaceRshift => rshift(a, b),

--- a/pyre/pyre-interpreter/src/pyopcode.rs
+++ b/pyre/pyre-interpreter/src/pyopcode.rs
@@ -1143,6 +1143,17 @@ pub trait OpcodeStepExecutor: SharedOpcodeHandler {
         self.push_value(null)
     }
 
+    /// LOAD_SPECIAL bypasses instance `__getattribute__` and resolves the
+    /// descriptor on the type. Concrete frames override this with the direct
+    /// special-method lookup; symbolic executors retain the method-shaped
+    /// stack contract.
+    fn load_special(&mut self, name: &str) -> Result<(), PyError>
+    where
+        Self: SharedOpcodeHandler + NamespaceOpcodeHandler,
+    {
+        self.load_method(name)
+    }
+
     fn store_attr(&mut self, name: &str) -> Result<(), PyError>
     where
         Self: SharedOpcodeHandler,
@@ -2352,7 +2363,7 @@ where
         SpecialMethod::AEnter => "__aenter__",
         _ => "__aexit__",
     };
-    executor.load_method(name)?;
+    executor.load_special(name)?;
     Ok(StepResult::Continue)
 }
 

--- a/pyre/pyre-interpreter/src/reduce_protocol.rs
+++ b/pyre/pyre-interpreter/src/reduce_protocol.rs
@@ -157,7 +157,12 @@ pub fn getnewargs(w_obj: PyObjectRef) -> Result<(bool, PyObjectRef, PyObjectRef)
     let w_args;
     let w_kwargs;
     if let Some(w_descr) = w_descr {
-        let w_result = crate::call::call_function_impl_result(w_descr, &[w_obj])?;
+        // objectobject.py:204:
+        // `space.get_and_call_function(w_descr, w_obj)`.
+        let w_type =
+            crate::typedef::r#type(w_obj).map_or(pyre_object::PY_NULL, |w_type| w_type.as_ptr());
+        let w_result =
+            unsafe { crate::baseobjspace::get_and_call_function(w_descr, w_obj, w_type, &[]) }?;
         if !unsafe { pyre_object::is_tuple(w_result) } {
             return Err(PyError::type_error(format!(
                 "__getnewargs_ex__ should return a tuple, not '{}'",
@@ -191,7 +196,12 @@ pub fn getnewargs(w_obj: PyObjectRef) -> Result<(bool, PyObjectRef, PyObjectRef)
     } else {
         let w_descr = unsafe { crate::baseobjspace::lookup(w_obj, "__getnewargs__") };
         if let Some(w_descr) = w_descr {
-            let wa = crate::call::call_function_impl_result(w_descr, &[w_obj])?;
+            // objectobject.py:212:
+            // `space.get_and_call_function(w_descr, w_obj)`.
+            let w_type = crate::typedef::r#type(w_obj)
+                .map_or(pyre_object::PY_NULL, |w_type| w_type.as_ptr());
+            let wa =
+                unsafe { crate::baseobjspace::get_and_call_function(w_descr, w_obj, w_type, &[]) }?;
             if !unsafe { pyre_object::is_tuple(wa) } {
                 return Err(PyError::type_error(format!(
                     "__getnewargs__ should return a tuple, not '{}'",

--- a/pyre/pyre-interpreter/src/type_methods.rs
+++ b/pyre/pyre-interpreter/src/type_methods.rs
@@ -5488,14 +5488,17 @@ pub unsafe fn has_dict_backing(obj: PyObjectRef) -> bool {
 /// `W_DictMultiObject` payload.  This is a layout-slot operation, not Python
 /// attribute assignment: a subclass may override `__setattr__` with a dict
 /// method before its mapping payload exists.
-pub fn set_dict_backing(obj: PyObjectRef, backing: PyObjectRef) -> bool {
+/// Absolute layout-slot index of the reserved `__dict_data__` payload for
+/// `obj`, walking the layout chain from the object's type toward its base.
+/// `None` when no layout in the chain reserves the slot.
+///
+/// # Safety
+/// `obj` must be a valid, non-null pointer to a `PyObject`.
+unsafe fn dict_data_slot(obj: PyObjectRef) -> Option<u32> {
     unsafe {
-        if !is_instance(obj) || !is_dict(backing) {
-            return false;
-        }
         let w_type = crate::typedef::r#type(obj).map_or(PY_NULL, |p| p.as_ptr());
         if w_type.is_null() {
-            return false;
+            return None;
         }
         let mut layout = pyre_object::w_type_get_layout_ptr(w_type);
         while !layout.is_null() {
@@ -5508,14 +5511,22 @@ pub fn set_dict_backing(obj: PyObjectRef, backing: PyObjectRef) -> bool {
                 .iter()
                 .position(|name| name == "__dict_data__")
             {
-                crate::objspace::std::mapdict::setslotvalue(
-                    obj,
-                    first_slot + offset as u32,
-                    backing,
-                );
-                return true;
+                return Some(first_slot + offset as u32);
             }
             layout = current.base_layout;
+        }
+        None
+    }
+}
+
+pub fn set_dict_backing(obj: PyObjectRef, backing: PyObjectRef) -> bool {
+    unsafe {
+        if !is_instance(obj) || !is_dict(backing) {
+            return false;
+        }
+        if let Some(slot) = dict_data_slot(obj) {
+            crate::objspace::std::mapdict::setslotvalue(obj, slot, backing);
+            return true;
         }
     }
     false
@@ -5551,33 +5562,11 @@ pub fn resolve_dict_backing(obj: PyObjectRef) -> PyObjectRef {
             // Read that reserved layout slot directly: going through
             // `getattr_str` would incorrectly expose internal dict operations
             // to a subclass's Python-level `__getattribute__` hook.
-            let w_type = crate::typedef::r#type(obj).map_or(PY_NULL, |p| p.as_ptr());
-            if !w_type.is_null() {
-                let mut layout = pyre_object::w_type_get_layout_ptr(w_type);
-                while !layout.is_null() {
-                    let current = &*layout;
-                    let newslots = current.newslotnames.len() as u32;
-                    let first_slot = if current.nslots > newslots {
-                        current.nslots - newslots
-                    } else {
-                        0
-                    };
-                    if let Some(offset) = current
-                        .newslotnames
-                        .iter()
-                        .position(|name| name == "__dict_data__")
-                    {
-                        if let Some(backing) = crate::objspace::std::mapdict::getslotvalue(
-                            obj,
-                            first_slot + offset as u32,
-                        ) {
-                            if is_dict(backing) {
-                                return backing;
-                            }
-                        }
-                        break;
+            if let Some(slot) = dict_data_slot(obj) {
+                if let Some(backing) = crate::objspace::std::mapdict::getslotvalue(obj, slot) {
+                    if is_dict(backing) {
+                        return backing;
                     }
-                    layout = current.base_layout;
                 }
             }
         }

--- a/pyre/pyre-interpreter/src/type_methods.rs
+++ b/pyre/pyre-interpreter/src/type_methods.rs
@@ -472,7 +472,6 @@ pub fn list_method_extend(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::Py
             // hint before `_do_extend_from_iterable` obtains and consumes the
             // iterator.  Hint failures other than TypeError/AttributeError are
             // observable and propagate without appending a prefix.
-            let _ = crate::baseobjspace::length_hint(other, 0)?;
             // Append each yielded value before asking for the next one.  An
             // exception from a later `next()` does not roll back the prefix.
             let _roots = pyre_object::gc_roots::push_roots();
@@ -5483,6 +5482,43 @@ pub fn str_method_translate(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::
 /// `obj` must be a valid, non-null pointer to a `PyObject`.
 pub unsafe fn has_dict_backing(obj: PyObjectRef) -> bool {
     !resolve_dict_backing(obj).is_null()
+}
+
+/// Write pyre's object-resident stand-in for a dict subclass's intrinsic
+/// `W_DictMultiObject` payload.  This is a layout-slot operation, not Python
+/// attribute assignment: a subclass may override `__setattr__` with a dict
+/// method before its mapping payload exists.
+pub fn set_dict_backing(obj: PyObjectRef, backing: PyObjectRef) -> bool {
+    unsafe {
+        if !is_instance(obj) || !is_dict(backing) {
+            return false;
+        }
+        let w_type = crate::typedef::r#type(obj).map_or(PY_NULL, |p| p.as_ptr());
+        if w_type.is_null() {
+            return false;
+        }
+        let mut layout = pyre_object::w_type_get_layout_ptr(w_type);
+        while !layout.is_null() {
+            let current = &*layout;
+            let first_slot = current
+                .nslots
+                .saturating_sub(current.newslotnames.len() as u32);
+            if let Some(offset) = current
+                .newslotnames
+                .iter()
+                .position(|name| name == "__dict_data__")
+            {
+                crate::objspace::std::mapdict::setslotvalue(
+                    obj,
+                    first_slot + offset as u32,
+                    backing,
+                );
+                return true;
+            }
+            layout = current.base_layout;
+        }
+    }
+    false
 }
 
 pub fn resolve_dict_backing(obj: PyObjectRef) -> PyObjectRef {

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -2945,11 +2945,13 @@ fn dict_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     // allocation carries an empty backing dict for `__init__` to fill.
     let instance = pyre_object::w_instance_new(cls);
     let backing = pyre_object::w_dict_new();
-    let installed = crate::type_methods::set_dict_backing(instance, backing);
-    debug_assert!(
-        installed,
-        "dict subclass layout has no mapping payload slot"
-    );
+    if !crate::type_methods::set_dict_backing(instance, backing) {
+        // Surface the layout invariant violation at construction rather than
+        // letting every later mapping operation raise a confusing TypeError.
+        return Err(crate::PyError::runtime_error(
+            "dict subclass layout has no mapping payload slot",
+        ));
+    }
     Ok(instance)
 }
 /// boolobject.py descr_new — bool.__new__(cls, obj=False)
@@ -12098,18 +12100,9 @@ fn init_member_descriptor_type(ns: PyObjectRef) {
         )
     };
     // CPython 3.14 `PyMemberDescr_Type` metadata.  PyPy's Member typedef
-    // stops at __name__/__objclass__; these four entries are the selected
+    // stops at __name__/__objclass__; __doc__ is registered above (reporting
+    // the real `member_get_doc`) and these remaining entries are the selected
     // 3.14 surface.
-    let doc_getter =
-        make_builtin_function_with_arity("__doc__", |_args| Ok(pyre_object::w_none()), 2);
-    unsafe {
-        pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
-            ns,
-            "__doc__",
-            make_getset_descriptor_named(doc_getter, "__doc__"),
-        )
-    };
-
     let qualname_getter = make_builtin_function_with_arity(
         "__qualname__",
         |args| {

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -448,7 +448,12 @@ pub fn init_typeobjects() {
         // `__flags__`, `isinstance(m, object)` and the inherited
         // `object.__reduce_ex__` all resolve.  `get_instantiate(&MODULE_TYPE)`
         // (read by `w_module_new`) is wired by the `set_instantiate` loop below.
-        let module_type = new_typeobject_with_base("module", init_module_type, object_type);
+        let module_type = new_typeobject_with_base_and_layout(
+            "module",
+            init_module_type,
+            object_type,
+            &pyre_object::MODULE_TYPE,
+        );
         unsafe {
             // module.py Module.getdict plus Module.typedef.__weakref__.
             pyre_object::w_type_set_hasdict(module_type, true);
@@ -565,10 +570,28 @@ pub fn init_typeobjects() {
             builtin_function_type as usize,
         );
 
+        // CPython `method_descriptor`, backed by PyPy's immutable
+        // FunctionWithFixedCode payload.
+        let method_descriptor_type =
+            new_typeobject_with_base("method_descriptor", init_function_type_common, object_type);
+        unsafe {
+            pyre_object::w_type_set_acceptable_as_base_class(method_descriptor_type, false);
+            pyre_object::w_type_set_disallow_instantiation(method_descriptor_type);
+            pyre_object::typeobject::w_type_set_flag_method_descriptor(
+                method_descriptor_type,
+                true,
+            );
+        }
+        reg.insert(
+            &crate::METHOD_DESCRIPTOR_TYPE as *const PyType as usize,
+            method_descriptor_type as usize,
+        );
+
         // CPython `wrapper_descriptor`: slot wrappers bind their receiver and
         // are callable, but are not Python functions. Their Rust payload is
         // the immutable BuiltinCode-backed Function carrier.
-        let slot_wrapper_type = new_typeobject_with_base("wrapper_descriptor", |_| {}, object_type);
+        let slot_wrapper_type =
+            new_typeobject_with_base("wrapper_descriptor", init_function_type_common, object_type);
         unsafe {
             pyre_object::w_type_set_acceptable_as_base_class(slot_wrapper_type, false);
             pyre_object::w_type_set_disallow_instantiation(slot_wrapper_type);
@@ -1282,6 +1305,7 @@ pub fn init_typeobjects() {
         patch_object_class_descriptor();
         patch_complex_realimag_descriptors();
         patch_builtin_function_descriptors();
+        patch_fixed_code_descriptor_getsets();
         patch_function_member_descriptors();
         patch_module_descriptors();
         patch_frame_traceback_descriptors();
@@ -1344,44 +1368,26 @@ fn patch_complex_realimag_descriptors() {
     if complex_type.is_null() || !crate::type_dict_has_storage(complex_type) {
         return;
     }
-    for (name, doc, getter) in [
+    for (name, kind, doc) in [
         (
             "real",
+            pyre_object::MEMBER_COMPLEX_REAL,
             "the real part of a complex number",
-            make_builtin_function_with_arity(
-                "real",
-                |args| {
-                    Ok(pyre_object::w_float_new(unsafe {
-                        pyre_object::w_complex_get_real(args[1])
-                    }))
-                },
-                2,
-            ),
         ),
         (
             "imag",
+            pyre_object::MEMBER_COMPLEX_IMAG,
             "the imaginary part of a complex number",
-            make_builtin_function_with_arity(
-                "imag",
-                |args| {
-                    Ok(pyre_object::w_float_new(unsafe {
-                        pyre_object::w_complex_get_imag(args[1])
-                    }))
-                },
-                2,
-            ),
         ),
     ] {
         crate::type_dict_store(
             complex_type,
             name,
-            make_getset_property_full(
-                getter,
-                pyre_object::PY_NULL,
-                pyre_object::PY_NULL,
-                pyre_object::w_str_new(doc),
+            pyre_object::w_member_new_with_doc(
+                kind,
+                name.to_owned(),
                 complex_type,
-                Some(name),
+                Some(doc.to_owned()),
             ),
         );
     }
@@ -1647,7 +1653,7 @@ unsafe fn stamp_method_owners(ns: PyObjectRef, owner: &'static crate::gateway::M
         let Some(descr) = pyre_object::w_dict_getitem_str(ns, &key) else {
             continue;
         };
-        if descr.is_null() || !crate::function::is_function(descr) {
+        if descr.is_null() || !crate::function::is_function_carrier(descr) {
             continue;
         }
         let code = crate::function::getcode(descr) as PyObjectRef;
@@ -1726,7 +1732,37 @@ unsafe fn stamp_new_descr_self(ns: PyObjectRef, type_obj: PyObjectRef) {
                 pyre_object::w_member_set_cls(descr, type_obj);
             }
         }
+        // function.py:503-504 `Function.set_objclass(w_type)`.  Interp-level
+        // methods and slot wrappers are immutable Function carriers in PyPy;
+        // TypeDef materialisation records the defining type on each carrier
+        // so both the unbound descriptor and its bound Method expose
+        // `__objclass__`.
+        if !descr.is_null() && crate::function::is_function_with_fixed_code(descr) {
+            crate::function::function_retag_method_descriptor(descr);
+        }
+        if !descr.is_null()
+            && (crate::function::is_function(descr) || crate::function::is_slot_wrapper(descr))
+        {
+            crate::function::function_set_objclass(descr, type_obj);
+            let ob_type = (*descr).ob_type;
+            if std::ptr::eq(ob_type, &crate::METHOD_DESCRIPTOR_TYPE as *const _)
+                || std::ptr::eq(ob_type, &crate::SLOT_WRAPPER_TYPE as *const _)
+            {
+                let owner = pyre_object::w_type_get_qualname(type_obj);
+                crate::function::function_set_qualname(
+                    descr,
+                    pyre_object::w_str_new(&format!("{owner}.{key}")),
+                );
+            }
+        }
         if !descr.is_null() && pyre_object::typedef::is_getset_property(descr) {
+            // `method_descriptor` and `wrapper_descriptor` reuse PyPy's
+            // FunctionWithFixedCode getsets, but their public receiver class
+            // is the concrete descriptor type rather than `function`.
+            let type_name = pyre_object::w_type_get_name(type_obj);
+            if type_name == "method_descriptor" || type_name == "wrapper_descriptor" {
+                pyre_object::typedef::w_getset_set_reqcls(descr, type_obj);
+            }
             let descr_slot = pyre_object::gc_roots::shadow_stack_len();
             pyre_object::gc_roots::pin_root(descr);
             let bound = copy_for_type(descr, type_obj);
@@ -2909,7 +2945,11 @@ fn dict_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     // allocation carries an empty backing dict for `__init__` to fill.
     let instance = pyre_object::w_instance_new(cls);
     let backing = pyre_object::w_dict_new();
-    let _ = crate::baseobjspace::setattr_str(instance, "__dict_data__", backing);
+    let installed = crate::type_methods::set_dict_backing(instance, backing);
+    debug_assert!(
+        installed,
+        "dict subclass layout has no mapping payload slot"
+    );
     Ok(instance)
 }
 /// boolobject.py descr_new — bool.__new__(cls, obj=False)
@@ -4506,7 +4546,7 @@ fn init_list_type(ns: PyObjectRef) {
         pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
             ns,
             "__add__",
-            make_builtin_function_with_arity(
+            crate::make_slot_wrapper_with_arity(
                 "__add__",
                 |args| {
                     crate::type_methods::require_list_receiver(args, "__add__", false)?;
@@ -4525,7 +4565,7 @@ fn init_list_type(ns: PyObjectRef) {
         pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
             ns,
             "__mul__",
-            make_builtin_function_with_arity("__mul__", list_descr_mul, 2),
+            crate::make_slot_wrapper_with_arity("__mul__", list_descr_mul, 2),
         )
     };
     unsafe {
@@ -4589,7 +4629,7 @@ fn init_list_type(ns: PyObjectRef) {
             pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
                 ns,
                 name,
-                make_builtin_function_with_arity(name, func, 2),
+                crate::make_slot_wrapper_with_arity(name, func, 2),
             )
         };
     }
@@ -5443,7 +5483,7 @@ fn init_str_type(ns: PyObjectRef) {
             pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
                 ns,
                 name,
-                make_builtin_function_with_arity(name, func, 2),
+                crate::make_slot_wrapper_with_arity(name, func, 2),
             )
         };
     }
@@ -5588,23 +5628,13 @@ fn init_dict_type(ns: PyObjectRef) {
                 "__setitem__",
                 |args| {
                     crate::type_methods::arity_exact_unpack(args, "__setitem__", 2)?;
-                    // For plain dict: direct store. For dict subclass instance: use backing dict.
-                    unsafe {
-                        if pyre_object::is_dict(args[0]) {
-                            crate::type_methods::dict_store_checked(args[0], args[1], args[2])?;
-                        } else if pyre_object::is_instance(args[0]) {
-                            // dict subclass — store in __dict_data__ backing dict
-                            if let Ok(backing) =
-                                crate::baseobjspace::getattr_str(args[0], "__dict_data__")
-                            {
-                                if pyre_object::is_dict(backing) {
-                                    crate::type_methods::dict_store_checked(
-                                        backing, args[1], args[2],
-                                    )?;
-                                }
-                            }
-                        }
+                    let backing = crate::type_methods::resolve_dict_backing(args[0]);
+                    if backing.is_null() {
+                        return Err(crate::PyError::type_error(
+                            "descriptor '__setitem__' for 'dict' objects doesn't apply to this object",
+                        ));
                     }
+                    crate::type_methods::dict_store_checked(backing, args[1], args[2])?;
                     Ok(pyre_object::w_none())
                 },
                 3,
@@ -5619,37 +5649,27 @@ fn init_dict_type(ns: PyObjectRef) {
                 "__getitem__",
                 |args| {
                     crate::type_methods::arity_exact(args, "dict.__getitem__", 1)?;
+                    let backing = crate::type_methods::resolve_dict_backing(args[0]);
+                    if backing.is_null() {
+                        return Err(crate::PyError::type_error(
+                            "descriptor '__getitem__' for 'dict' objects doesn't apply to this object",
+                        ));
+                    }
+                    // `dictmultiobject.py:166-170` — on a miss, dispatch
+                    // `__missing__` against the subclass instance, not the
+                    // plain backing dict.
                     unsafe {
-                        if pyre_object::is_dict(args[0]) {
-                            return crate::baseobjspace::getitem(args[0], args[1]);
-                        }
-                        if pyre_object::is_instance(args[0]) {
-                            if let Ok(backing) =
-                                crate::baseobjspace::getattr_str(args[0], "__dict_data__")
-                            {
-                                if pyre_object::is_dict(backing) {
-                                    // `dictmultiobject.py:166-170` — on a miss,
-                                    // dispatch `__missing__` against the SUBCLASS
-                                    // instance's type, not the plain-`dict` backing
-                                    // (so e.g. `defaultdict.__missing__` fires).
-                                    return match pyre_object::dictmultiobject::w_dict_lookup_checked(
-                                        backing, args[1],
-                                    ) {
-                                        Ok(Some(val)) => Ok(val),
-                                        Ok(None) => crate::baseobjspace::dict_missing_or_key_error(
-                                            args[0], args[1],
-                                        ),
-                                        Err(_) => {
-                                            Err(crate::baseobjspace::take_pending_dict_key_error(
-                                                args[1],
-                                            ))
-                                        }
-                                    };
-                                }
+                        match pyre_object::dictmultiobject::w_dict_lookup_checked(backing, args[1])
+                        {
+                            Ok(Some(val)) => Ok(val),
+                            Ok(None) => {
+                                crate::baseobjspace::dict_missing_or_key_error(args[0], args[1])
+                            }
+                            Err(_) => {
+                                Err(crate::baseobjspace::take_pending_dict_key_error(args[1]))
                             }
                         }
                     }
-                    crate::baseobjspace::getitem(args[0], args[1])
                 },
                 2,
             ),
@@ -9341,7 +9361,7 @@ pub(crate) fn make_getset_property_named(
 
 /// `GetSetProperty(..., doc=..., name=...)` — the full descriptor payload
 /// used by doc-bearing getsets such as `mapping`, `__dict__`, and `__weakref__`.
-fn make_getset_property_named_doc(
+pub(crate) fn make_getset_property_named_doc(
     fget: pyre_object::PyObjectRef,
     fset: pyre_object::PyObjectRef,
     fdel: pyre_object::PyObjectRef,
@@ -9398,6 +9418,37 @@ fn make_getset_property_full(
 }
 
 fn init_type_type(ns: PyObjectRef) {
+    // `type.__setattr__` is a distinct slot wrapper from
+    // `object.__setattr__`.  Both terminate in the shared storage routine,
+    // but only the metatype wrapper accepts a type-object receiver; keeping
+    // them distinct is what blocks the Carlo Verre indirect-base call.
+    unsafe {
+        pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
+            ns,
+            "__setattr__",
+            crate::make_slot_wrapper_with_arity(
+                "__setattr__",
+                |args| {
+                    if !pyre_object::is_type(args[0]) {
+                        return Err(crate::PyError::type_error(
+                            "descriptor '__setattr__' requires a 'type' object",
+                        ));
+                    }
+                    if !pyre_object::is_str(args[1]) {
+                        return Err(crate::PyError::type_error("attribute name must be string"));
+                    }
+                    let name = pyre_object::w_str_get_wtf8(args[1]);
+                    match name.as_str() {
+                        Ok(name) => crate::baseobjspace::object_setattr(args[0], name, args[2]),
+                        Err(_) => crate::baseobjspace::object_setattr_surrogate(
+                            args[0], args[1], name, args[2],
+                        ),
+                    }
+                },
+                3,
+            ),
+        );
+    }
     // type.__new__(metatype, name, bases, dict) — creates new type
     unsafe {
         pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
@@ -9435,6 +9486,56 @@ fn init_type_type(ns: PyObjectRef) {
                 };
                 crate::call::type_call_instantiate(cls, rest)
             }),
+        )
+    };
+    // typeobject.py `descr__doc__`: class docs are read from the class's own
+    // namespace (never inherited). Heap types may replace the value; deletion
+    // is forbidden, and immutable builtin types reject replacement.
+    let doc_getter = make_builtin_function_with_arity(
+        "__doc__",
+        |args| {
+            let cls = args[1];
+            let Some(doc) = crate::type_dict_lookup(cls, "__doc__") else {
+                return Ok(pyre_object::w_none());
+            };
+            // typeobject.py:984-989 descr__doc__ — heap-type documentation
+            // is a class attribute and therefore participates in descriptor
+            // binding as `space.get(w_result, space.w_None, w_type)`.
+            unsafe { Ok(crate::baseobjspace::get(doc, pyre_object::PY_NULL, cls)?.unwrap_or(doc)) }
+        },
+        2,
+    );
+    let doc_setter = make_builtin_function_with_arity(
+        "__doc__",
+        |args| {
+            let cls = args[1];
+            if !unsafe { pyre_object::w_type_is_heaptype(cls) } {
+                return Err(crate::PyError::type_error(format!(
+                    "cannot set '__doc__' attribute of immutable type '{}'",
+                    unsafe { pyre_object::w_type_get_name(cls) },
+                )));
+            }
+            crate::type_dict_store(cls, "__doc__", args[2]);
+            Ok(pyre_object::w_none())
+        },
+        3,
+    );
+    let doc_deleter = make_builtin_function_with_arity(
+        "__doc__",
+        |args| {
+            let cls = args[1];
+            Err(crate::PyError::type_error(format!(
+                "cannot delete '__doc__' attribute of immutable type '{}'",
+                unsafe { pyre_object::w_type_get_name(cls) },
+            )))
+        },
+        2,
+    );
+    unsafe {
+        pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
+            ns,
+            "__doc__",
+            make_getset_property(doc_getter, doc_setter, doc_deleter),
         )
     };
     // type.__annotations__ / __dict__ / __mro__ / __name__ / __bases__ /
@@ -9483,7 +9584,7 @@ fn init_type_type(ns: PyObjectRef) {
             unsafe {
                 let mro_ptr = pyre_object::w_type_get_mro(cls);
                 if mro_ptr.is_null() {
-                    return Ok(pyre_object::w_tuple_new(vec![]));
+                    return Ok(pyre_object::w_none());
                 }
                 Ok(pyre_object::w_tuple_new((*mro_ptr).to_vec()))
             }
@@ -9731,6 +9832,12 @@ fn init_type_type(ns: PyObjectRef) {
         |args| {
             let w_type = args[1];
             let value = args[2];
+            if !unsafe { pyre_object::w_type_is_heaptype(w_type) } {
+                return Err(crate::PyError::type_error(format!(
+                    "cannot set '__qualname__' attribute of immutable type '{}'",
+                    unsafe { pyre_object::w_type_get_name(w_type) }
+                )));
+            }
             if !unsafe { crate::baseobjspace::isinstance_str_w(value) } {
                 return Err(crate::PyError::type_error(format!(
                     "can only assign string to {}.__qualname__, not '{}'",
@@ -9746,6 +9853,15 @@ fn init_type_type(ns: PyObjectRef) {
         },
         3,
     );
+    let qualname_deleter = make_builtin_function_with_arity(
+        "__qualname__",
+        |_| {
+            Err(crate::PyError::type_error(
+                "cannot delete __qualname__ attribute",
+            ))
+        },
+        2,
+    );
     unsafe {
         pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
             ns,
@@ -9753,7 +9869,7 @@ fn init_type_type(ns: PyObjectRef) {
             make_getset_property_named(
                 qualname_getter,
                 qualname_setter,
-                pyre_object::PY_NULL,
+                qualname_deleter,
                 "__qualname__",
             ),
         )
@@ -9813,12 +9929,27 @@ fn init_type_type(ns: PyObjectRef) {
 /// linearization.  The subclasses stay reachable through the (rooted) type
 /// hierarchy across each `compute_mro` allocation, so the walk needs no
 /// extra rooting (mirrors `baseobjspace::mutated`).
-unsafe fn mro_subclasses(w_type: PyObjectRef) {
-    let mro = crate::baseobjspace::compute_mro(w_type);
-    pyre_object::w_type_set_mro(w_type, mro);
-    for w_sc in unsafe { pyre_object::typeobject::w_type_get_subclasses(w_type, false) } {
-        mro_subclasses(w_sc);
+unsafe fn mro_subclasses(
+    w_type: PyObjectRef,
+    temp: &mut Vec<(PyObjectRef, Option<Vec<PyObjectRef>>)>,
+) -> crate::PyResult {
+    let bases = pyre_object::w_type_get_bases(w_type);
+    crate::baseobjspace::validate_c3_mro(bases)?;
+    let old_mro = pyre_object::w_type_get_mro(w_type);
+    temp.push((
+        w_type,
+        if old_mro.is_null() {
+            None
+        } else {
+            Some((*old_mro).to_vec())
+        },
+    ));
+    crate::baseobjspace::compute_and_set_mro(w_type)?;
+    let subclasses = pyre_object::typeobject::w_type_get_subclasses(w_type, false);
+    for w_sc in subclasses {
+        mro_subclasses(w_sc, temp)?;
     }
+    Ok(pyre_object::w_none())
 }
 
 /// Whether `w_type` appears in `w_base`'s MRO — the `w_type in
@@ -9838,6 +9969,31 @@ unsafe fn type_in_mro(w_base: PyObjectRef, w_type: PyObjectRef) -> bool {
     unsafe { (*mro).as_slice() }
         .iter()
         .any(|&entry| std::ptr::eq(entry, w_type))
+}
+
+unsafe fn type_in_bases(w_base: PyObjectRef, w_type: PyObjectRef) -> bool {
+    let mut pending = vec![w_base];
+    let mut seen = Vec::new();
+    while let Some(current) = pending.pop() {
+        if std::ptr::eq(current, w_type) {
+            return true;
+        }
+        if !pyre_object::is_type(current) || seen.iter().any(|&entry| std::ptr::eq(entry, current))
+        {
+            continue;
+        }
+        seen.push(current);
+        let bases = pyre_object::w_type_get_bases(current);
+        if bases.is_null() {
+            continue;
+        }
+        for index in 0..pyre_object::w_tuple_len(bases) as i64 {
+            if let Some(base) = pyre_object::w_tuple_getitem(bases, index) {
+                pending.push(base);
+            }
+        }
+    }
+    false
 }
 
 /// `type.__bases__` setter (typeobject.py:1064-1105 `descr_set__bases__`).
@@ -9878,7 +10034,7 @@ fn type_set_bases(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
             // not just identity: a base that already derives from `w_type`
             // closes the same loop one step further out, and the subsequent
             // `mro_subclasses` walk would never terminate.
-            if type_in_mro(w_base, w_type) {
+            if type_in_mro(w_base, w_type) || type_in_bases(w_base, w_type) {
                 return Err(crate::PyError::type_error(
                     "a __bases__ item causes an inheritance cycle",
                 ));
@@ -9887,6 +10043,12 @@ fn type_set_bases(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
                 return Err(crate::PyError::type_error(format!(
                     "{type_name}.__bases__ must be tuple of classes, not '{}'",
                     pyre_object::type_name_of(w_base)
+                )));
+            }
+            if !pyre_object::w_type_get_acceptable_as_base_class(w_base) {
+                return Err(crate::PyError::type_error(format!(
+                    "type '{}' is not an acceptable base type",
+                    pyre_object::w_type_get_name(w_base)
                 )));
             }
             let cand_layout = pyre_object::w_type_get_layout_ptr(w_base);
@@ -9939,7 +10101,40 @@ fn type_set_bases(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
         pyre_object::typeobject::w_type_ready(w_type);
         // Recompute the MRO of w_type and, recursively, of every subclass
         // (typeobject.py:1144 `mro_subclasses`).
-        mro_subclasses(w_type);
+        let mut temp = Vec::new();
+        if let Err(err) = mro_subclasses(w_type, &mut temp) {
+            // A nested `__bases__` assignment may have superseded this
+            // operation while custom `mro()` code ran.  Preserve that newer
+            // hierarchy; otherwise restore the exact pre-update state.
+            let bases_now = pyre_object::typeobject::w_type_get_bases(w_type);
+            if std::ptr::eq(bases_now, w_value) {
+                for (cls, old_mro) in temp.into_iter().rev() {
+                    match old_mro {
+                        Some(mro) => pyre_object::w_type_set_mro(cls, mro),
+                        None => pyre_object::w_type_clear_mro(cls),
+                    }
+                }
+                pyre_object::typeobject::w_type_set_bases(w_type, saved_bases);
+                for i in 0..n as i64 {
+                    if let Some(base) = pyre_object::w_tuple_getitem(w_value, i) {
+                        if pyre_object::is_type(base) {
+                            pyre_object::typeobject::w_type_remove_subclass(base, w_type);
+                        }
+                    }
+                }
+                if !saved_bases.is_null() {
+                    let old_n = pyre_object::w_tuple_len(saved_bases);
+                    for i in 0..old_n as i64 {
+                        if let Some(base) = pyre_object::w_tuple_getitem(saved_bases, i) {
+                            if pyre_object::is_type(base) {
+                                pyre_object::typeobject::w_type_add_subclass(base, w_type);
+                            }
+                        }
+                    }
+                }
+            }
+            return Err(err);
+        }
         Ok(pyre_object::w_none())
     }
 }
@@ -9955,8 +10150,7 @@ fn type_set_bases(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
 /// BuiltinFunction-only overrides (`__new__`, `__self__`, `__repr__`)
 /// live in their respective wrappers.
 fn function_receiver(obj: PyObjectRef, name: &str) -> Result<PyObjectRef, crate::PyError> {
-    if obj.is_null() || !unsafe { pyre_object::py_type_check(obj, &crate::function::FUNCTION_TYPE) }
-    {
+    if obj.is_null() || !unsafe { crate::function::is_function_carrier(obj) } {
         let received = if obj.is_null() {
             "object"
         } else {
@@ -10481,6 +10675,12 @@ pub(crate) unsafe fn direct_member_get(member: PyObjectRef, obj: PyObjectRef) ->
             })
         }
         pyre_object::MEMBER_MODULE_DICT => Ok(unsafe { pyre_object::w_module_get_w_dict(obj) }),
+        pyre_object::MEMBER_COMPLEX_REAL => Ok(pyre_object::w_float_new(unsafe {
+            pyre_object::w_complex_get_real(obj)
+        })),
+        pyre_object::MEMBER_COMPLEX_IMAG => Ok(pyre_object::w_float_new(unsafe {
+            pyre_object::w_complex_get_imag(obj)
+        })),
         _ => Err(crate::PyError::attribute_error(unsafe {
             pyre_object::w_member_get_name(member)
         })),
@@ -11008,6 +11208,27 @@ fn patch_builtin_function_descriptors() {
     if let Some(descr) = crate::type_dict_lookup(bf_type, "__module__") {
         if unsafe { pyre_object::is_member(descr) && pyre_object::w_member_is_direct(descr) } {
             unsafe { pyre_object::w_member_set_cls(descr, bf_type) };
+        }
+    }
+}
+
+/// `method_descriptor` and `wrapper_descriptor` share PyPy's
+/// FunctionWithFixedCode getsets, but each public descriptor type is its own
+/// required receiver under CPython's descriptor surface.
+fn patch_fixed_code_descriptor_getsets() {
+    for pytype in [
+        &crate::METHOD_DESCRIPTOR_TYPE as *const PyType,
+        &crate::SLOT_WRAPPER_TYPE as *const PyType,
+    ] {
+        let w_type = gettypefor(pytype).map_or(pyre_object::PY_NULL, |p| p.as_ptr());
+        if w_type.is_null() || !crate::type_dict_has_storage(w_type) {
+            continue;
+        }
+        let ns = unsafe { pyre_object::w_type_get_dict_ptr(w_type) } as PyObjectRef;
+        for (_, descr) in unsafe { pyre_object::w_dict_items(ns) } {
+            if unsafe { pyre_object::typedef::is_getset_property(descr) } {
+                unsafe { pyre_object::typedef::w_getset_set_reqcls(descr, w_type) };
+            }
         }
     }
 }
@@ -11695,12 +11916,33 @@ fn init_member_descriptor_type(ns: PyObjectRef) {
                         crate::PyErrorKind::AttributeError,
                         format!(
                             "'{}' object has no attribute '{}'",
-                            unsafe { (*(*obj).ob_type).name },
+                            unsafe { crate::baseobjspace::getfulltypename(obj) },
                             slot_name,
                         ),
                     )),
                 }
             }),
+        )
+    };
+    // CPython `member_get_doc`: native PyMemberDef entries may carry a doc
+    // string, while Python-level `__slots__` descriptors report None.
+    unsafe {
+        pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
+            ns,
+            "__doc__",
+            make_getset_descriptor_named(
+                make_builtin_function_with_arity(
+                    "__doc__",
+                    |args| {
+                        let descr = args[1];
+                        Ok(unsafe { pyre_object::w_member_get_doc(descr) }
+                            .map(pyre_object::w_str_new)
+                            .unwrap_or_else(pyre_object::w_none))
+                    },
+                    2,
+                ),
+                "__doc__",
+            ),
         )
     };
     // typedef.py:536 __set__ = interp2app(Member.descr_member_set)
@@ -14218,7 +14460,7 @@ fn init_int_type(ns: PyObjectRef) {
             pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
                 ns,
                 name,
-                make_builtin_function_with_arity(name, func, 2),
+                crate::make_slot_wrapper_with_arity(name, func, 2),
             )
         };
     }
@@ -14808,31 +15050,25 @@ fn init_float_type(ns: PyObjectRef) {
         pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
             ns,
             "real",
-            pyre_object::w_property_new(
-                make_builtin_function_with_arity(
-                    "real",
-                    |args| {
-                        Ok(args
-                            .first()
-                            .copied()
-                            .unwrap_or(pyre_object::w_float_new(0.0)))
-                    },
-                    1,
-                ),
-                pyre_object::PY_NULL,
-                pyre_object::PY_NULL,
-            ),
+            make_getset_descriptor(make_builtin_function_with_arity(
+                "real",
+                |args| {
+                    let value = unsafe { pyre_object::w_float_get_value(args[1]) };
+                    Ok(pyre_object::w_float_new(value))
+                },
+                2,
+            )),
         )
     };
     unsafe {
         pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
             ns,
             "imag",
-            pyre_object::w_property_new(
-                make_builtin_function_with_arity("imag", |_| Ok(pyre_object::w_float_new(0.0)), 1),
-                pyre_object::PY_NULL,
-                pyre_object::PY_NULL,
-            ),
+            make_getset_descriptor(make_builtin_function_with_arity(
+                "imag",
+                |_| Ok(pyre_object::w_float_new(0.0)),
+                2,
+            )),
         )
     };
     // floatobject.py:713/715/449-455 — __int__/__trunc__ go through
@@ -15870,6 +16106,11 @@ fn init_object_type(ns: PyObjectRef) {
                     }
                     if !unsafe { pyre_object::is_str(args[1]) } {
                         return Err(crate::PyError::type_error("attribute name must be string"));
+                    }
+                    if unsafe { pyre_object::is_type(args[0]) } {
+                        return Err(crate::PyError::type_error(
+                            "can't apply this __setattr__ to type object",
+                        ));
                     }
                     // `object.__setattr__` is the terminal implementation
                     // that writes directly to the instance dict, bypassing
@@ -19060,7 +19301,11 @@ fn bytes_descr_new_impl(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyEr
         // exact object identity is preserved.  (bytearray does NOT honour
         // __bytes__.)
         if let Some(method) = crate::baseobjspace::lookup(arg, "__bytes__") {
-            let w_bytes = crate::builtins::call_and_check(method, &[arg])?;
+            // bytesobject.py `invoke_bytes_method`:
+            // `space.get_and_call_function(w_bytes_method, w_source)`.
+            let w_type =
+                crate::typedef::r#type(arg).map_or(pyre_object::PY_NULL, |w_type| w_type.as_ptr());
+            let w_bytes = crate::baseobjspace::get_and_call_function(method, arg, w_type, &[])?;
             if !pyre_object::bytesobject::is_bytes(w_bytes) {
                 return Err(crate::PyError::type_error(format!(
                     "__bytes__ returned non-bytes (type {})",
@@ -23736,7 +23981,7 @@ pub fn copy_descriptor_for_type(
 fn descr_get_dict(
     args: &[pyre_object::PyObjectRef],
 ) -> Result<pyre_object::PyObjectRef, crate::PyError> {
-    let _closure = args[0];
+    dict_descr_check_receiver(args[0], args[1])?;
     let w_obj = args[1];
     let w_dict = crate::baseobjspace::getdict(w_obj)?;
     if w_dict.is_null() {
@@ -23758,7 +24003,7 @@ fn descr_get_dict(
 fn descr_set_dict(
     args: &[pyre_object::PyObjectRef],
 ) -> Result<pyre_object::PyObjectRef, crate::PyError> {
-    let _closure = args[0];
+    dict_descr_check_receiver(args[0], args[1])?;
     let w_obj = args[1];
     let w_dict = args[2];
     crate::baseobjspace::setdict(w_obj, w_dict)?;
@@ -23774,10 +24019,44 @@ fn descr_set_dict(
 fn descr_del_dict(
     args: &[pyre_object::PyObjectRef],
 ) -> Result<pyre_object::PyObjectRef, crate::PyError> {
-    let _closure = args[0];
+    dict_descr_check_receiver(args[0], args[1])?;
     let w_obj = args[1];
     crate::baseobjspace::setdict(w_obj, pyre_object::w_dict_new())?;
     Ok(pyre_object::w_none())
+}
+
+/// A copied `dict_descr` belongs to the concrete instance layout that
+/// supplied the slot.  Python-level metaclass inheritance can make a class
+/// or module satisfy `isinstance(obj, owner)` without giving that object the
+/// owner's mapdict layout; direct descriptor calls must reject that Carlo
+/// Verre path.
+fn dict_descr_check_receiver(
+    descr: pyre_object::PyObjectRef,
+    obj: pyre_object::PyObjectRef,
+) -> Result<(), crate::PyError> {
+    unsafe {
+        if pyre_object::is_type(obj) || pyre_object::is_module(obj) {
+            return Err(getset_descr_mismatch(descr, obj, pyre_object::PY_NULL));
+        }
+        let owner = pyre_object::typedef::w_getset_get_objclass(descr);
+        if owner.is_null() {
+            return Ok(());
+        }
+        let Some(actual_type) = crate::typedef::r#type(obj) else {
+            return Err(getset_descr_mismatch(descr, obj, owner));
+        };
+        let owner_layout = pyre_object::w_type_get_layout_ptr(owner);
+        let actual_layout = pyre_object::w_type_get_layout_ptr(actual_type.as_ptr());
+        if !crate::baseobjspace::isinstance_w(obj, owner)
+            || owner_layout.is_null()
+            || actual_layout.is_null()
+            || !std::ptr::eq((*actual_layout).typedef, (*owner_layout).typedef)
+            || !(*actual_layout).issublayout(owner_layout)
+        {
+            return Err(getset_descr_mismatch(descr, obj, owner));
+        }
+        Ok(())
+    }
 }
 
 /// typedef.py:555-559 descr_get_weakref.

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -9944,15 +9944,18 @@ unsafe fn mro_subclasses(
     let bases = pyre_object::w_type_get_bases(w_type);
     crate::baseobjspace::validate_c3_mro(bases)?;
     let old_mro = pyre_object::w_type_get_mro(w_type);
-    temp.push((
-        w_type,
-        if old_mro.is_null() {
-            None
-        } else {
-            Some((*old_mro).to_vec())
-        },
-    ));
+    let old_mro = if old_mro.is_null() {
+        None
+    } else {
+        Some((*old_mro).to_vec())
+    };
+    // Record the class for rollback only once its MRO has been recomputed
+    // successfully (typeobject.c `mro_hierarchy`: append after `mro_internal`).
+    // A class whose own `mro()` raises — including one that reassigns
+    // `__bases__` reentrantly and then fails — is left with the MRO that
+    // reassignment installed rather than being reverted to a stale one.
     crate::baseobjspace::compute_and_set_mro(w_type)?;
+    temp.push((w_type, old_mro));
     let subclasses = pyre_object::typeobject::w_type_get_subclasses(w_type, false);
     for w_sc in subclasses {
         mro_subclasses(w_sc, temp)?;
@@ -10102,6 +10105,11 @@ fn type_set_bases(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
         let _saved_bases_roots = pyre_object::gc_roots::push_roots();
         let saved_bases_sp = pyre_object::gc_roots::shadow_stack_len();
         pyre_object::gc_roots::pin_root(saved_bases);
+        // The new bases can move while `mro()` runs too; pin them so the
+        // reentrancy check on the rollback path compares against their current
+        // address rather than a stale one.
+        let new_bases_sp = pyre_object::gc_roots::shadow_stack_len();
+        pyre_object::gc_roots::pin_root(w_value);
         if !saved_bases.is_null() {
             let old_n = pyre_object::w_tuple_len(saved_bases);
             for i in 0..old_n as i64 {
@@ -10118,31 +10126,39 @@ fn type_set_bases(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
         // (typeobject.py:1144 `mro_subclasses`).
         let mut temp = Vec::new();
         if let Err(err) = mro_subclasses(w_type, &mut temp) {
-            // typeobject.py:961-963 — on any recomputation failure restore every
-            // visited class's previous MRO and the type's old bases.  Reload the
-            // pinned `saved_bases` first: the `mro()` code may have moved it once
-            // the swap above unrooted it.
+            // On a recomputation failure restore every successfully-visited
+            // class's previous MRO.  Reload the pinned tuples first: the `mro()`
+            // code may have moved them once the swap above unrooted the old
+            // bases.
             let saved_bases = pyre_object::gc_roots::shadow_stack_get(saved_bases_sp);
+            let new_bases = pyre_object::gc_roots::shadow_stack_get(new_bases_sp);
             for (cls, old_mro) in temp.into_iter().rev() {
                 match old_mro {
                     Some(mro) => pyre_object::w_type_set_mro(cls, mro),
                     None => pyre_object::w_type_clear_mro(cls),
                 }
             }
-            pyre_object::typeobject::w_type_set_bases(w_type, saved_bases);
-            for i in 0..n as i64 {
-                if let Some(base) = pyre_object::w_tuple_getitem(w_value, i) {
-                    if pyre_object::is_type(base) {
-                        pyre_object::typeobject::w_type_remove_subclass(base, w_type);
+            // Only roll the bases back if the bases are still the ones this call
+            // installed; a reentrant `__bases__` assignment reached through
+            // `mro()` may have already committed different bases, which must
+            // stand (typeobject.c `type_set_bases`: restore only when
+            // `lookup_tp_bases(type) == new_bases`).
+            if std::ptr::eq(pyre_object::typeobject::w_type_get_bases(w_type), new_bases) {
+                pyre_object::typeobject::w_type_set_bases(w_type, saved_bases);
+                for i in 0..n as i64 {
+                    if let Some(base) = pyre_object::w_tuple_getitem(new_bases, i) {
+                        if pyre_object::is_type(base) {
+                            pyre_object::typeobject::w_type_remove_subclass(base, w_type);
+                        }
                     }
                 }
-            }
-            if !saved_bases.is_null() {
-                let old_n = pyre_object::w_tuple_len(saved_bases);
-                for i in 0..old_n as i64 {
-                    if let Some(base) = pyre_object::w_tuple_getitem(saved_bases, i) {
-                        if pyre_object::is_type(base) {
-                            pyre_object::typeobject::w_type_add_subclass(base, w_type);
+                if !saved_bases.is_null() {
+                    let old_n = pyre_object::w_tuple_len(saved_bases);
+                    for i in 0..old_n as i64 {
+                        if let Some(base) = pyre_object::w_tuple_getitem(saved_bases, i) {
+                            if pyre_object::is_type(base) {
+                                pyre_object::typeobject::w_type_add_subclass(base, w_type);
+                            }
                         }
                     }
                 }

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -9425,6 +9425,24 @@ fn make_getset_property_full(
     )
 }
 
+/// `descr__doc` (typeobject.py:982-983): a non-heap type serves its own
+/// TypeDef doc rather than inheriting.  property / function / method keep an
+/// *instance* `__doc__` descriptor under the `__doc__` key, and pyre has no
+/// separate type-doc slot, so their type doc is served from these constants.
+/// Every other type (subclasses included) falls through to its own dict.
+pub(crate) fn type_builtin_own_doc(cls: PyObjectRef) -> Option<PyObjectRef> {
+    let doc = if std::ptr::eq(cls, gettypeobject(&pyre_object::descriptor::PROPERTY_TYPE)) {
+        PROPERTY_DOC
+    } else if std::ptr::eq(cls, gettypeobject(&crate::function::FUNCTION_TYPE)) {
+        FUNCTION_DOC
+    } else if std::ptr::eq(cls, gettypeobject(&pyre_object::function::METHOD_TYPE)) {
+        METHOD_DOC
+    } else {
+        return None;
+    };
+    Some(pyre_object::w_str_new(doc))
+}
+
 fn init_type_type(ns: PyObjectRef) {
     // `type.__setattr__` is a distinct slot wrapper from
     // `object.__setattr__`.  Both terminate in the shared storage routine,
@@ -9503,6 +9521,12 @@ fn init_type_type(ns: PyObjectRef) {
         "__doc__",
         |args| {
             let cls = args[1];
+            // typeobject.py:982-983 — a non-heap type whose `__doc__` key holds
+            // an instance descriptor (property/function/method) serves its own
+            // TypeDef doc, not the bound descriptor.
+            if let Some(doc) = type_builtin_own_doc(cls) {
+                return Ok(doc);
+            }
             let Some(doc) = crate::type_dict_lookup(cls, "__doc__") else {
                 return Ok(pyre_object::w_none());
             };
@@ -10204,6 +10228,13 @@ fn descr_carrier_get(args: &[PyObjectRef]) -> crate::PyResult {
         args.first().copied().unwrap_or(pyre_object::PY_NULL),
         "__get__",
     )?;
+    carrier_descr_bind(w_function, args)
+}
+
+/// The descriptor bind shared once the receiver type has been validated.
+/// Class access (`obj` is None) returns the bare carrier; instance access
+/// binds it into a `method`.
+fn carrier_descr_bind(w_function: PyObjectRef, args: &[PyObjectRef]) -> crate::PyResult {
     let w_obj = args.get(1).copied().unwrap_or(pyre_object::PY_NULL);
     let w_cls = args.get(2).copied().unwrap_or(pyre_object::PY_NULL);
     // The class-access case (`w_obj == None and w_cls is some type`) returns
@@ -10228,6 +10259,41 @@ fn descr_carrier_get(args: &[PyObjectRef]) -> crate::PyResult {
         };
         Ok(pyre_object::w_method_new(w_function, w_obj, owner))
     }
+}
+
+/// Strict receiver check for the `function` type's own slots (`__get__`,
+/// `__repr__`).  `function_receiver` accepts any function-layout carrier so the
+/// `**rawdict` getters shared with `builtin_function` keep working; these slots
+/// instead demand a genuine `function`, since `builtin_function` overrides them
+/// (or, for `__get__`, deletes it) — a builtin reaching them is a mis-applied
+/// descriptor.
+fn function_type_receiver(obj: PyObjectRef, name: &str) -> Result<PyObjectRef, crate::PyError> {
+    if obj.is_null() || !unsafe { pyre_object::py_type_check(obj, &crate::function::FUNCTION_TYPE) }
+    {
+        let received = if obj.is_null() {
+            "object"
+        } else {
+            crate::typedef::r#type(obj)
+                .map(|tp| unsafe { pyre_object::w_type_get_name(tp.as_ptr()) })
+                .unwrap_or("object")
+        };
+        return Err(crate::PyError::type_error(format!(
+            "descriptor '{name}' for 'function' objects doesn't apply to a '{received}' object"
+        )));
+    }
+    Ok(obj)
+}
+
+/// `function.py:464 descr_function_get` — the `function` type's own `__get__`.
+/// Unlike the shared `descr_carrier_get`, the receiver must be a genuine
+/// `function`: `builtin_function` deletes `__get__` (it is already bound), so
+/// `function.__get__(<builtin>, ...)` is a mis-applied descriptor and raises.
+fn descr_function_get(args: &[PyObjectRef]) -> crate::PyResult {
+    let recv = function_type_receiver(
+        args.first().copied().unwrap_or(pyre_object::PY_NULL),
+        "__get__",
+    )?;
+    carrier_descr_bind(recv, args)
 }
 
 /// `init_function_type_common` plus the descriptor `__get__` that
@@ -10843,7 +10909,7 @@ fn init_function_type(ns: PyObjectRef) {
             make_builtin_function_with_arity(
                 "__repr__",
                 |args| {
-                    let function = function_receiver(
+                    let function = function_type_receiver(
                         args.first().copied().unwrap_or(pyre_object::PY_NULL),
                         "__repr__",
                     )?;
@@ -10978,7 +11044,7 @@ fn init_function_type(ns: PyObjectRef) {
         pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
             ns,
             "__get__",
-            make_builtin_function("__get__", descr_carrier_get),
+            make_builtin_function("__get__", descr_function_get),
         )
     };
 }

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -572,8 +572,11 @@ pub fn init_typeobjects() {
 
         // CPython `method_descriptor`, backed by PyPy's immutable
         // FunctionWithFixedCode payload.
-        let method_descriptor_type =
-            new_typeobject_with_base("method_descriptor", init_descriptor_type_common, object_type);
+        let method_descriptor_type = new_typeobject_with_base(
+            "method_descriptor",
+            init_descriptor_type_common,
+            object_type,
+        );
         unsafe {
             pyre_object::w_type_set_acceptable_as_base_class(method_descriptor_type, false);
             pyre_object::w_type_set_disallow_instantiation(method_descriptor_type);
@@ -590,8 +593,11 @@ pub fn init_typeobjects() {
         // CPython `wrapper_descriptor`: slot wrappers bind their receiver and
         // are callable, but are not Python functions. Their Rust payload is
         // the immutable BuiltinCode-backed Function carrier.
-        let slot_wrapper_type =
-            new_typeobject_with_base("wrapper_descriptor", init_descriptor_type_common, object_type);
+        let slot_wrapper_type = new_typeobject_with_base(
+            "wrapper_descriptor",
+            init_descriptor_type_common,
+            object_type,
+        );
         unsafe {
             pyre_object::w_type_set_acceptable_as_base_class(slot_wrapper_type, false);
             pyre_object::w_type_set_disallow_instantiation(slot_wrapper_type);
@@ -10089,6 +10095,13 @@ fn type_set_bases(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
         // bases are relinked by `w_type_ready` below (typeobject.py:1140-1142
         // `add_subclass`).
         let saved_bases = pyre_object::typeobject::w_type_get_bases(w_type);
+        // `w_type_set_bases` below drops `saved_bases`' last rooted owner, and a
+        // custom `mro()` reached through `mro_subclasses` can trigger a
+        // collection before the rollback reads it back.  Pin it so the
+        // collector keeps it alive and updates the slot if it moves.
+        let _saved_bases_roots = pyre_object::gc_roots::push_roots();
+        let saved_bases_sp = pyre_object::gc_roots::shadow_stack_len();
+        pyre_object::gc_roots::pin_root(saved_bases);
         if !saved_bases.is_null() {
             let old_n = pyre_object::w_tuple_len(saved_bases);
             for i in 0..old_n as i64 {
@@ -10105,32 +10118,31 @@ fn type_set_bases(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
         // (typeobject.py:1144 `mro_subclasses`).
         let mut temp = Vec::new();
         if let Err(err) = mro_subclasses(w_type, &mut temp) {
-            // A nested `__bases__` assignment may have superseded this
-            // operation while custom `mro()` code ran.  Preserve that newer
-            // hierarchy; otherwise restore the exact pre-update state.
-            let bases_now = pyre_object::typeobject::w_type_get_bases(w_type);
-            if std::ptr::eq(bases_now, w_value) {
-                for (cls, old_mro) in temp.into_iter().rev() {
-                    match old_mro {
-                        Some(mro) => pyre_object::w_type_set_mro(cls, mro),
-                        None => pyre_object::w_type_clear_mro(cls),
+            // typeobject.py:961-963 — on any recomputation failure restore every
+            // visited class's previous MRO and the type's old bases.  Reload the
+            // pinned `saved_bases` first: the `mro()` code may have moved it once
+            // the swap above unrooted it.
+            let saved_bases = pyre_object::gc_roots::shadow_stack_get(saved_bases_sp);
+            for (cls, old_mro) in temp.into_iter().rev() {
+                match old_mro {
+                    Some(mro) => pyre_object::w_type_set_mro(cls, mro),
+                    None => pyre_object::w_type_clear_mro(cls),
+                }
+            }
+            pyre_object::typeobject::w_type_set_bases(w_type, saved_bases);
+            for i in 0..n as i64 {
+                if let Some(base) = pyre_object::w_tuple_getitem(w_value, i) {
+                    if pyre_object::is_type(base) {
+                        pyre_object::typeobject::w_type_remove_subclass(base, w_type);
                     }
                 }
-                pyre_object::typeobject::w_type_set_bases(w_type, saved_bases);
-                for i in 0..n as i64 {
-                    if let Some(base) = pyre_object::w_tuple_getitem(w_value, i) {
+            }
+            if !saved_bases.is_null() {
+                let old_n = pyre_object::w_tuple_len(saved_bases);
+                for i in 0..old_n as i64 {
+                    if let Some(base) = pyre_object::w_tuple_getitem(saved_bases, i) {
                         if pyre_object::is_type(base) {
-                            pyre_object::typeobject::w_type_remove_subclass(base, w_type);
-                        }
-                    }
-                }
-                if !saved_bases.is_null() {
-                    let old_n = pyre_object::w_tuple_len(saved_bases);
-                    for i in 0..old_n as i64 {
-                        if let Some(base) = pyre_object::w_tuple_getitem(saved_bases, i) {
-                            if pyre_object::is_type(base) {
-                                pyre_object::typeobject::w_type_add_subclass(base, w_type);
-                            }
+                            pyre_object::typeobject::w_type_add_subclass(base, w_type);
                         }
                     }
                 }

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -573,7 +573,7 @@ pub fn init_typeobjects() {
         // CPython `method_descriptor`, backed by PyPy's immutable
         // FunctionWithFixedCode payload.
         let method_descriptor_type =
-            new_typeobject_with_base("method_descriptor", init_function_type_common, object_type);
+            new_typeobject_with_base("method_descriptor", init_descriptor_type_common, object_type);
         unsafe {
             pyre_object::w_type_set_acceptable_as_base_class(method_descriptor_type, false);
             pyre_object::w_type_set_disallow_instantiation(method_descriptor_type);
@@ -591,7 +591,7 @@ pub fn init_typeobjects() {
         // are callable, but are not Python functions. Their Rust payload is
         // the immutable BuiltinCode-backed Function carrier.
         let slot_wrapper_type =
-            new_typeobject_with_base("wrapper_descriptor", init_function_type_common, object_type);
+            new_typeobject_with_base("wrapper_descriptor", init_descriptor_type_common, object_type);
         unsafe {
             pyre_object::w_type_set_acceptable_as_base_class(slot_wrapper_type, false);
             pyre_object::w_type_set_disallow_instantiation(slot_wrapper_type);
@@ -10167,6 +10167,58 @@ fn function_receiver(obj: PyObjectRef, name: &str) -> Result<PyObjectRef, crate:
     Ok(obj)
 }
 
+/// `function.py:464-470 descr_function_get` — the descriptor bind shared by
+/// the `function`, `method_descriptor`, and `wrapper_descriptor` carriers.
+/// Class access (`obj` is None) returns the bare carrier; instance access
+/// binds it into a `method`.
+fn descr_carrier_get(args: &[PyObjectRef]) -> crate::PyResult {
+    let w_function = function_receiver(
+        args.first().copied().unwrap_or(pyre_object::PY_NULL),
+        "__get__",
+    )?;
+    let w_obj = args.get(1).copied().unwrap_or(pyre_object::PY_NULL);
+    let w_cls = args.get(2).copied().unwrap_or(pyre_object::PY_NULL);
+    // The class-access case (`w_obj == None and w_cls is some type`) returns
+    // the bare carrier — that keeps `cls.func` callable as a plain function
+    // rather than a bound method.
+    let cls_is_none = unsafe { w_cls.is_null() || pyre_object::is_none(w_cls) };
+    let obj_is_none = unsafe { w_obj.is_null() || pyre_object::is_none(w_obj) };
+    // Python 3.14 `func_descr_get`: omitting `type` is equivalent to passing
+    // None, but `__get__(None, None)` is invalid.
+    if obj_is_none && cls_is_none {
+        return Err(crate::PyError::type_error("__get__(None, None) is invalid"));
+    }
+    if obj_is_none {
+        Ok(w_function)
+    } else {
+        // function.py:470 Method(space, w_function, w_obj, w_cls), with the
+        // inferred owner when `type` is omitted.
+        let owner = if cls_is_none {
+            r#type(w_obj).map_or(pyre_object::PY_NULL, |p| p.as_ptr())
+        } else {
+            w_cls
+        };
+        Ok(pyre_object::w_method_new(w_function, w_obj, owner))
+    }
+}
+
+/// `init_function_type_common` plus the descriptor `__get__` that
+/// `method_descriptor`/`wrapper_descriptor` expose. Unlike `builtin_function`
+/// (already bound, so PyPy deletes its `__get__`), these carriers are
+/// descriptors: `Type.method.__get__` must bind, and exposing `__get__` keeps
+/// `inspect.ismethoddescriptor` / `getattr_static` from mistaking them for
+/// plain callables and recursing on `type(obj).__call__`.
+fn init_descriptor_type_common(ns: PyObjectRef) {
+    init_function_type_common(ns);
+    unsafe {
+        pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
+            ns,
+            "__get__",
+            make_builtin_function("__get__", descr_carrier_get),
+        )
+    };
+}
+
 fn init_function_type_common(ns: PyObjectRef) {
     // `pypy/interpreter/typedef.py:802 __doc__ = getset_func_doc` —
     // `getset_func_doc = GetSetProperty(Function.fget_func_doc,
@@ -10898,46 +10950,7 @@ fn init_function_type(ns: PyObjectRef) {
         pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
             ns,
             "__get__",
-            make_builtin_function("__get__", |args| {
-                let w_function = function_receiver(
-                    args.first().copied().unwrap_or(pyre_object::PY_NULL),
-                    "__get__",
-                )?;
-                let w_obj = args.get(1).copied().unwrap_or(pyre_object::PY_NULL);
-                let w_cls = args.get(2).copied().unwrap_or(pyre_object::PY_NULL);
-                // function.py:464-470 descr_function_get
-                //
-                //   asking_for_function = (
-                //       space.is_w(w_cls, space.w_None)
-                //       or (
-                //           space.is_w(w_obj, space.w_None)
-                //           and not space.is_w(w_cls, space.type(space.w_None))
-                //       )
-                //   )
-                //
-                // The class-access case (`w_obj == None and w_cls is some type`)
-                // returns the bare function — that's how `cls.func` stays callable
-                // as a plain function rather than a bound method.
-                let cls_is_none = unsafe { w_cls.is_null() || pyre_object::is_none(w_cls) };
-                let obj_is_none = unsafe { w_obj.is_null() || pyre_object::is_none(w_obj) };
-                // Python 3.14 `func_descr_get`: omitting `type` is equivalent
-                // to passing None, but `__get__(None, None)` is invalid.
-                if obj_is_none && cls_is_none {
-                    return Err(crate::PyError::type_error("__get__(None, None) is invalid"));
-                }
-                if obj_is_none {
-                    Ok(w_function)
-                } else {
-                    // function.py:470 Method(space, w_function, w_obj, w_cls),
-                    // with CPython's inferred owner when `type` is omitted.
-                    let owner = if cls_is_none {
-                        r#type(w_obj).map_or(pyre_object::PY_NULL, |p| p.as_ptr())
-                    } else {
-                        w_cls
-                    };
-                    Ok(pyre_object::w_method_new(w_function, w_obj, owner))
-                }
-            }),
+            make_builtin_function("__get__", descr_carrier_get),
         )
     };
 }

--- a/pyre/pyre-jit-trace/src/descr.rs
+++ b/pyre/pyre-jit-trace/src/descr.rs
@@ -761,15 +761,42 @@ static W_FLOAT_DESCR_GROUP: LazyLock<PyreObjectDescrGroup> = LazyLock::new(|| {
         std::mem::size_of::<W_FloatObject>(),
         W_FLOAT_GC_TYPE_ID,
         &FLOAT_TYPE as *const _ as usize,
-        &[(
-            "floatval",
-            FLOAT_FLOATVAL_OFFSET,
-            8,
-            Type::Float,
-            false,
-            true,
-            false,
-        )],
+        &[
+            (
+                "floatval",
+                FLOAT_FLOATVAL_OFFSET,
+                8,
+                Type::Float,
+                false,
+                true,
+                false,
+            ),
+            // Native-subclass `__dict__` / `__slots__` GC-pointer slots. The
+            // runtime TypeInfo traces both, so they must enter gc_fielddescrs
+            // for rewrite.py:498-504 to emit the delayed NULL stores that
+            // malloc_zero_filled=false requires; otherwise a NewWithVtable'd
+            // exact float carries uninitialised nursery bytes here and the
+            // collector traces poison. They follow `floatval` so its stable
+            // field index stays 0.
+            (
+                "w_dict",
+                FLOAT_W_DICT_OFFSET,
+                8,
+                Type::Ref,
+                false,
+                false,
+                false,
+            ),
+            (
+                "w_slots",
+                FLOAT_W_SLOTS_OFFSET,
+                8,
+                Type::Ref,
+                false,
+                false,
+                false,
+            ),
+        ],
         "W_FloatObject",
         "floatobject::W_FloatObject",
     )
@@ -1675,7 +1702,9 @@ pub fn make_array_descr_with_full_id(
 
 // ── Range iterator field descriptors ─────────────────────────────────
 
-use pyre_object::floatobject::{FLOAT_FLOATVAL_OFFSET, W_FloatObject};
+use pyre_object::floatobject::{
+    FLOAT_FLOATVAL_OFFSET, FLOAT_W_DICT_OFFSET, FLOAT_W_SLOTS_OFFSET, W_FloatObject,
+};
 use pyre_object::functional::{
     RANGE_ITER_CURRENT_OFFSET, RANGE_ITER_REMAINING_OFFSET, RANGE_ITER_STEP_OFFSET,
     RANGE_LENGTH_OFFSET, RANGE_START_OFFSET, RANGE_STEP_OFFSET, W_Range,

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -5248,19 +5248,19 @@ fn load_special_method_name(method_kind: i64) -> &'static str {
     }
 }
 
-/// Resolve `getattr(obj, special_method_name(method_kind))` for LOAD_SPECIAL.
-/// This is the fixed-name counterpart of [`bh_load_attr_fn`]: the codewriter
-/// passes the bytecode's special-method discriminant instead of a `co_names`
-/// index.
+/// Resolve the LOAD_SPECIAL method named by `method_kind`.  Mirrors the
+/// interpreter's `load_special` through the shared `load_special_resolve`:
+/// `_PyObject_LookupSpecial` looks the method up on the type only, bypassing
+/// the instance dict and any `__getattribute__` override, so a traced
+/// `with`/`async with` calls the same method the interpreter would.  Returns
+/// the bound method; [`bh_load_special_self_fn`] therefore reports a NULL self.
 pub extern "C" fn bh_load_special_fn(obj: i64, method_kind: i64) -> i64 {
     let name = load_special_method_name(method_kind);
-    if let Some((_, _, w_descr)) =
-        unsafe { pyre_interpreter::baseobjspace::load_method_fast_path(obj as _, name) }
-    {
-        return w_descr as i64;
-    }
-    match pyre_interpreter::baseobjspace::getattr_str(obj as pyre_object::PyObjectRef, name) {
-        Ok(attr) => attr as i64,
+    match pyre_interpreter::baseobjspace::load_special_resolve(
+        obj as pyre_object::PyObjectRef,
+        name,
+    ) {
+        Ok(bound) => bound as i64,
         Err(mut err) => {
             publish_residual_call_exception(err.to_exc_object() as i64);
             0
@@ -5268,16 +5268,11 @@ pub extern "C" fn bh_load_special_fn(obj: i64, method_kind: i64) -> i64 {
     }
 }
 
-/// Compute the LOAD_SPECIAL `null_or_self` value for an already-resolved
-/// special method.  Mirrors [`bh_load_method_self_fn`] without a code-object
-/// name lookup.
-pub extern "C" fn bh_load_special_self_fn(obj: i64, attr: i64, method_kind: i64) -> i64 {
-    let name = load_special_method_name(method_kind);
-    pyre_interpreter::eval::compute_load_method_bound(
-        obj as pyre_object::PyObjectRef,
-        attr as pyre_object::PyObjectRef,
-        name,
-    ) as i64
+/// The LOAD_SPECIAL `null_or_self` value.  [`bh_load_special_fn`] returns the
+/// method already bound through the descriptor's `__get__`, so — as in the
+/// interpreter's `load_special` — the pushed pair carries a NULL self.
+pub extern "C" fn bh_load_special_self_fn(_obj: i64, _attr: i64, _method_kind: i64) -> i64 {
+    pyre_object::PY_NULL as i64
 }
 
 /// `LOAD_NAME` residual for the standalone (blackhole / deopt)

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -1211,7 +1211,10 @@ fn build_gc() -> Box<dyn majit_gc::GcAllocator> {
     // gc.py:642). They are NewWithVtable allocation targets so the
     // payload size must be the actual struct size, and they sit one
     // level below the OBJECT root (`int.__bases__ == (object,)`,
-    // `float.__bases__ == (object,)`).
+    // `float.__bases__ == (object,)`). W_IntObject is a pure leaf;
+    // W_FloatObject additionally traces `w_class`/`w_dict`/`w_slots`, the
+    // last handing slot-value ownership to the list's custom tracer, so it
+    // registers with the gc-pointer offsets below.
     let w_int_tid = gc.register_type(TypeInfo::object_subclass(
         std::mem::size_of::<W_IntObject>(),
         object_tid,
@@ -2356,13 +2359,14 @@ fn build_gc() -> Box<dyn majit_gc::GcAllocator> {
         w_object_object_tid,
         pyre_object::objectobject::W_OBJECT_OBJECT_GC_TYPE_ID,
     );
-    // W_ComplexObject carries two f64s after the `PyObject` header and
-    // no managed pointers — a GC leaf like W_FloatObject.  Registered
-    // immediately after the last hardcoded-constant tid (W_ObjectObject = 53)
-    // so its fixed id 54 precedes the auto-numbered `#[pyre_class]` /
-    // per-ExcKind tids registered below.  Bound to `COMPLEX_TYPE` so the
-    // collector reads the correct size + leaf trace when a managed
-    // container holds a complex.
+    // W_ComplexObject carries two f64s after the `PyObject` header plus
+    // three traced edges — `w_class`, `w_dict`, and the `w_slots` list
+    // whose custom tracer owns the slot values — mirroring W_FloatObject.
+    // Registered immediately after the last hardcoded-constant tid
+    // (W_ObjectObject = 53) so its fixed id 54 precedes the auto-numbered
+    // `#[pyre_class]` / per-ExcKind tids registered below.  Bound to
+    // `COMPLEX_TYPE` so the collector reads the correct size + trace when a
+    // managed container holds a complex.
     let w_complex_tid = gc.register_type(TypeInfo::object_subclass_with_gc_ptrs(
         std::mem::size_of::<pyre_object::complexobject::W_ComplexObject>(),
         object_tid,

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -1217,9 +1217,14 @@ fn build_gc() -> Box<dyn majit_gc::GcAllocator> {
         object_tid,
     ));
     debug_assert_eq!(w_int_tid, W_INT_GC_TYPE_ID);
-    let w_float_tid = gc.register_type(TypeInfo::object_subclass(
+    let w_float_tid = gc.register_type(TypeInfo::object_subclass_with_gc_ptrs(
         std::mem::size_of::<W_FloatObject>(),
         object_tid,
+        vec![
+            pyre_object::pyobject::W_CLASS_OFFSET,
+            pyre_object::floatobject::FLOAT_W_DICT_OFFSET,
+            pyre_object::floatobject::FLOAT_W_SLOTS_OFFSET,
+        ],
     ));
     debug_assert_eq!(w_float_tid, W_FLOAT_GC_TYPE_ID);
     // jitframe.py:49 — rgc.register_custom_trace_hook(JITFRAME, jitframe_trace)
@@ -1562,6 +1567,15 @@ fn build_gc() -> Box<dyn majit_gc::GcAllocator> {
     );
     pytype_to_tid.insert(
         &pyre_interpreter::function::BUILTIN_FUNCTION_TYPE as *const _ as usize,
+        function_tid,
+    );
+    majit_gc::GcAllocator::register_vtable_for_type(
+        &mut gc,
+        &pyre_interpreter::function::METHOD_DESCRIPTOR_TYPE as *const _ as usize,
+        function_tid,
+    );
+    pytype_to_tid.insert(
+        &pyre_interpreter::function::METHOD_DESCRIPTOR_TYPE as *const _ as usize,
         function_tid,
     );
     majit_gc::GcAllocator::register_vtable_for_type(
@@ -2349,9 +2363,14 @@ fn build_gc() -> Box<dyn majit_gc::GcAllocator> {
     // per-ExcKind tids registered below.  Bound to `COMPLEX_TYPE` so the
     // collector reads the correct size + leaf trace when a managed
     // container holds a complex.
-    let w_complex_tid = gc.register_type(TypeInfo::object_subclass(
+    let w_complex_tid = gc.register_type(TypeInfo::object_subclass_with_gc_ptrs(
         std::mem::size_of::<pyre_object::complexobject::W_ComplexObject>(),
         object_tid,
+        vec![
+            pyre_object::pyobject::W_CLASS_OFFSET,
+            pyre_object::complexobject::COMPLEX_W_DICT_OFFSET,
+            pyre_object::complexobject::COMPLEX_W_SLOTS_OFFSET,
+        ],
     ));
     debug_assert_eq!(
         w_complex_tid,
@@ -9204,6 +9223,8 @@ fn materialize_virtual_from_rd(
                         w_class: pyre_object::pyobject::get_instantiate(tp),
                     },
                     floatval: 0.0,
+                    w_dict: std::ptr::null_mut(),
+                    w_slots: std::ptr::null_mut(),
                 });
                 Box::into_raw(obj) as usize
             } else if ob_type != 0 {
@@ -10662,6 +10683,8 @@ impl majit_metainterp::resume::BlackholeAllocator for PyreBlackholeAllocator {
                         ),
                     },
                     floatval: 0.0,
+                    w_dict: std::ptr::null_mut(),
+                    w_slots: std::ptr::null_mut(),
                 });
                 Box::into_raw(obj) as i64
             }

--- a/pyre/pyre-macros/src/lib.rs
+++ b/pyre/pyre-macros/src/lib.rs
@@ -164,6 +164,13 @@ fn expand_pyre_function(func: ItemFn) -> syn::Result<proc_macro2::TokenStream> {
             .iter()
             .filter(|&&positional| positional)
             .count();
+        // `Arguments.parse_obj` fills every parameter slot before the body
+        // runs, so a keyword-only parameter widens the received `args` past
+        // the positional count.  The positional bound stays in the message,
+        // but the surplus guard compares against the full slot count — the
+        // same bound `bind_builtin_kwargs` uses — so a keyword-only slot is
+        // not mistaken for a surplus positional.
+        let slot_total = param_positional.len();
         let required = param_required
             .iter()
             .zip(param_positional.iter())
@@ -176,7 +183,7 @@ fn expand_pyre_function(func: ItemFn) -> syn::Result<proc_macro2::TokenStream> {
             if args.len() < #required {
                 return ::std::result::Result::Err(crate::PyError::type_error(#too_few));
             }
-            if __pyre_positional_count > #total {
+            if __pyre_positional_count > #slot_total {
                 return ::std::result::Result::Err(crate::PyError::type_error(#too_many));
             }
         }
@@ -1909,7 +1916,13 @@ fn expand_pyre_methods(
                     .zip(param_positional.iter())
                     .filter(|(required, positional)| **required && **positional)
                     .count();
-                let expected_total = receiver_slots + visible_max;
+                // `Arguments.parse_obj` fills every parameter slot before the
+                // body runs, so a keyword-only parameter widens `args` past
+                // the positional count.  The positional bound stays in the
+                // message, but the surplus guard compares against the full
+                // slot count so a keyword-only slot is not mistaken for a
+                // surplus positional.
+                let expected_total = receiver_slots + param_positional.len();
                 let fn_name = mname.to_string();
                 let expected = if visible_required == visible_max {
                     match visible_max {

--- a/pyre/pyre-object/src/complexobject.rs
+++ b/pyre/pyre-object/src/complexobject.rs
@@ -11,6 +11,10 @@ pub struct W_ComplexObject {
     pub ob_header: PyObject,
     pub real: f64,
     pub imag: f64,
+    /// Native-subclass mapdict owner. Exact complex values keep this null.
+    pub w_dict: PyObjectRef,
+    /// Native-subclass `__slots__` storage indexed by `Member.index`.
+    pub w_slots: PyObjectRef,
 }
 
 /// Field offset of `real` within `W_ComplexObject`.
@@ -18,11 +22,12 @@ pub const COMPLEX_REAL_OFFSET: usize = std::mem::offset_of!(W_ComplexObject, rea
 
 /// Field offset of `imag` within `W_ComplexObject`.
 pub const COMPLEX_IMAG_OFFSET: usize = std::mem::offset_of!(W_ComplexObject, imag);
+pub const COMPLEX_W_DICT_OFFSET: usize = std::mem::offset_of!(W_ComplexObject, w_dict);
+pub const COMPLEX_W_SLOTS_OFFSET: usize = std::mem::offset_of!(W_ComplexObject, w_slots);
 
 /// GC type id assigned to `W_ComplexObject` at JitDriver init time.
 /// Like `W_FLOAT_GC_TYPE_ID`, held as a constant so the allocation hook
-/// can reach it without a back-channel.  Complex carries no managed
-/// pointers, so its trace is a leaf (same shape as float).
+/// can reach it without a back-channel.
 pub const W_COMPLEX_GC_TYPE_ID: u32 = 54;
 
 /// Fixed payload size for `W_ComplexObject`.
@@ -48,6 +53,8 @@ pub fn w_complex_new(real: f64, imag: f64) -> PyObjectRef {
         },
         real,
         imag,
+        w_dict: PY_NULL,
+        w_slots: PY_NULL,
     }) as PyObjectRef
 }
 
@@ -90,6 +97,53 @@ pub unsafe fn w_complex_get_real(obj: PyObjectRef) -> f64 {
 #[inline]
 pub unsafe fn w_complex_get_imag(obj: PyObjectRef) -> f64 {
     unsafe { (*(obj as *const W_ComplexObject)).imag }
+}
+
+#[inline]
+pub unsafe fn w_complex_getdict(obj: PyObjectRef) -> PyObjectRef {
+    unsafe { (*(obj as *const W_ComplexObject)).w_dict }
+}
+
+#[inline]
+pub unsafe fn w_complex_setdict(obj: PyObjectRef, w_dict: PyObjectRef) {
+    unsafe { (*(obj as *mut W_ComplexObject)).w_dict = w_dict };
+    crate::gc_hook::try_gc_write_barrier(obj as *mut u8);
+}
+
+pub unsafe fn w_complex_slot_get(obj: PyObjectRef, index: usize) -> Option<PyObjectRef> {
+    let slots = unsafe { (*(obj as *const W_ComplexObject)).w_slots };
+    if slots.is_null() {
+        return None;
+    }
+    unsafe { crate::listobject::w_list_getitem(slots, index as i64) }
+        .filter(|value| !value.is_null())
+}
+
+pub unsafe fn w_complex_slot_set(obj: PyObjectRef, index: usize, value: PyObjectRef) {
+    let mut slots = unsafe { (*(obj as *const W_ComplexObject)).w_slots };
+    if slots.is_null() {
+        slots = crate::listobject::w_list_new(vec![PY_NULL; index + 1]);
+        unsafe { (*(obj as *mut W_ComplexObject)).w_slots = slots };
+        crate::gc_hook::try_gc_write_barrier(obj as *mut u8);
+    } else {
+        while unsafe { crate::listobject::w_list_len(slots) } <= index {
+            unsafe { crate::listobject::w_list_append(slots, PY_NULL) };
+        }
+    }
+    unsafe { crate::listobject::w_list_setitem(slots, index as i64, value) };
+}
+
+pub unsafe fn w_complex_slot_del(obj: PyObjectRef, index: usize) -> bool {
+    let slots = unsafe { (*(obj as *const W_ComplexObject)).w_slots };
+    if slots.is_null() || unsafe { crate::listobject::w_list_len(slots) } <= index {
+        return false;
+    }
+    let present = unsafe { crate::listobject::w_list_getitem(slots, index as i64) }
+        .is_some_and(|value| !value.is_null());
+    if present {
+        unsafe { crate::listobject::w_list_setitem(slots, index as i64, PY_NULL) };
+    }
+    present
 }
 
 #[cfg(test)]

--- a/pyre/pyre-object/src/complexobject.rs
+++ b/pyre/pyre-object/src/complexobject.rs
@@ -69,6 +69,8 @@ pub fn w_complex_subclass_new(real: f64, imag: f64) -> PyObjectRef {
         },
         real,
         imag,
+        w_dict: PY_NULL,
+        w_slots: PY_NULL,
     };
     let raw = crate::gc_hook::try_gc_alloc_stable_raw(W_COMPLEX_GC_TYPE_ID, W_COMPLEX_OBJECT_SIZE);
     if raw.is_null() {
@@ -110,40 +112,24 @@ pub unsafe fn w_complex_setdict(obj: PyObjectRef, w_dict: PyObjectRef) {
     crate::gc_hook::try_gc_write_barrier(obj as *mut u8);
 }
 
+/// Address of `W_ComplexObject::w_slots` for the shared slot helpers.
+///
+/// # Safety
+/// `obj` must point to a valid `W_ComplexObject`.
+unsafe fn complex_slots_field(obj: PyObjectRef) -> *mut PyObjectRef {
+    unsafe { &mut (*(obj as *mut W_ComplexObject)).w_slots }
+}
+
 pub unsafe fn w_complex_slot_get(obj: PyObjectRef, index: usize) -> Option<PyObjectRef> {
-    let slots = unsafe { (*(obj as *const W_ComplexObject)).w_slots };
-    if slots.is_null() {
-        return None;
-    }
-    unsafe { crate::listobject::w_list_getitem(slots, index as i64) }
-        .filter(|value| !value.is_null())
+    unsafe { crate::slots::slot_get(obj, index, complex_slots_field) }
 }
 
 pub unsafe fn w_complex_slot_set(obj: PyObjectRef, index: usize, value: PyObjectRef) {
-    let mut slots = unsafe { (*(obj as *const W_ComplexObject)).w_slots };
-    if slots.is_null() {
-        slots = crate::listobject::w_list_new(vec![PY_NULL; index + 1]);
-        unsafe { (*(obj as *mut W_ComplexObject)).w_slots = slots };
-        crate::gc_hook::try_gc_write_barrier(obj as *mut u8);
-    } else {
-        while unsafe { crate::listobject::w_list_len(slots) } <= index {
-            unsafe { crate::listobject::w_list_append(slots, PY_NULL) };
-        }
-    }
-    unsafe { crate::listobject::w_list_setitem(slots, index as i64, value) };
+    unsafe { crate::slots::slot_set(obj, index, value, complex_slots_field) }
 }
 
 pub unsafe fn w_complex_slot_del(obj: PyObjectRef, index: usize) -> bool {
-    let slots = unsafe { (*(obj as *const W_ComplexObject)).w_slots };
-    if slots.is_null() || unsafe { crate::listobject::w_list_len(slots) } <= index {
-        return false;
-    }
-    let present = unsafe { crate::listobject::w_list_getitem(slots, index as i64) }
-        .is_some_and(|value| !value.is_null());
-    if present {
-        unsafe { crate::listobject::w_list_setitem(slots, index as i64, PY_NULL) };
-    }
-    present
+    unsafe { crate::slots::slot_del(obj, index, complex_slots_field) }
 }
 
 #[cfg(test)]

--- a/pyre/pyre-object/src/floatobject.rs
+++ b/pyre/pyre-object/src/floatobject.rs
@@ -10,10 +10,16 @@ use crate::pyobject::*;
 pub struct W_FloatObject {
     pub ob_header: PyObject,
     pub floatval: f64,
+    /// Native-subclass mapdict owner. Exact floats keep this null.
+    pub w_dict: PyObjectRef,
+    /// Native-subclass `__slots__` storage indexed by `Member.index`.
+    pub w_slots: PyObjectRef,
 }
 
 /// Field offset of `floatval` within `W_FloatObject`, for JIT field access.
 pub const FLOAT_FLOATVAL_OFFSET: usize = std::mem::offset_of!(W_FloatObject, floatval);
+pub const FLOAT_W_DICT_OFFSET: usize = std::mem::offset_of!(W_FloatObject, w_dict);
+pub const FLOAT_W_SLOTS_OFFSET: usize = std::mem::offset_of!(W_FloatObject, w_slots);
 
 /// GC type id assigned to `W_FloatObject` at JitDriver init time.
 /// Held as a constant here (rather than runtime-queried) so the
@@ -57,6 +63,8 @@ pub fn w_float_new(value: f64) -> PyObjectRef {
             w_class: get_instantiate(&FLOAT_TYPE),
         },
         floatval: value,
+        w_dict: PY_NULL,
+        w_slots: PY_NULL,
     };
     if crate::gc_interp::enabled() {
         let raw = crate::gc_hook::try_gc_alloc_stable_raw(W_FLOAT_GC_TYPE_ID, W_FLOAT_OBJECT_SIZE);
@@ -110,6 +118,53 @@ pub fn box_float_constant(value: f64) -> PyObjectRef {
 #[inline]
 pub unsafe fn w_float_get_value(obj: PyObjectRef) -> f64 {
     unsafe { (*(obj as *const W_FloatObject)).floatval }
+}
+
+#[inline]
+pub unsafe fn w_float_getdict(obj: PyObjectRef) -> PyObjectRef {
+    unsafe { (*(obj as *const W_FloatObject)).w_dict }
+}
+
+#[inline]
+pub unsafe fn w_float_setdict(obj: PyObjectRef, w_dict: PyObjectRef) {
+    unsafe { (*(obj as *mut W_FloatObject)).w_dict = w_dict };
+    crate::gc_hook::try_gc_write_barrier(obj as *mut u8);
+}
+
+pub unsafe fn w_float_slot_get(obj: PyObjectRef, index: usize) -> Option<PyObjectRef> {
+    let slots = unsafe { (*(obj as *const W_FloatObject)).w_slots };
+    if slots.is_null() {
+        return None;
+    }
+    unsafe { crate::listobject::w_list_getitem(slots, index as i64) }
+        .filter(|value| !value.is_null())
+}
+
+pub unsafe fn w_float_slot_set(obj: PyObjectRef, index: usize, value: PyObjectRef) {
+    let mut slots = unsafe { (*(obj as *const W_FloatObject)).w_slots };
+    if slots.is_null() {
+        slots = crate::listobject::w_list_new(vec![PY_NULL; index + 1]);
+        unsafe { (*(obj as *mut W_FloatObject)).w_slots = slots };
+        crate::gc_hook::try_gc_write_barrier(obj as *mut u8);
+    } else {
+        while unsafe { crate::listobject::w_list_len(slots) } <= index {
+            unsafe { crate::listobject::w_list_append(slots, PY_NULL) };
+        }
+    }
+    unsafe { crate::listobject::w_list_setitem(slots, index as i64, value) };
+}
+
+pub unsafe fn w_float_slot_del(obj: PyObjectRef, index: usize) -> bool {
+    let slots = unsafe { (*(obj as *const W_FloatObject)).w_slots };
+    if slots.is_null() || unsafe { crate::listobject::w_list_len(slots) } <= index {
+        return false;
+    }
+    let present = unsafe { crate::listobject::w_list_getitem(slots, index as i64) }
+        .is_some_and(|value| !value.is_null());
+    if present {
+        unsafe { crate::listobject::w_list_setitem(slots, index as i64, PY_NULL) };
+    }
+    present
 }
 
 #[majit_macros::dont_look_inside]

--- a/pyre/pyre-object/src/floatobject.rs
+++ b/pyre/pyre-object/src/floatobject.rs
@@ -94,6 +94,8 @@ pub fn w_float_subclass_new(value: f64) -> PyObjectRef {
             w_class: get_instantiate(&FLOAT_TYPE),
         },
         floatval: value,
+        w_dict: PY_NULL,
+        w_slots: PY_NULL,
     };
     let raw = crate::gc_hook::try_gc_alloc_stable_raw(W_FLOAT_GC_TYPE_ID, W_FLOAT_OBJECT_SIZE);
     if raw.is_null() {
@@ -131,40 +133,24 @@ pub unsafe fn w_float_setdict(obj: PyObjectRef, w_dict: PyObjectRef) {
     crate::gc_hook::try_gc_write_barrier(obj as *mut u8);
 }
 
+/// Address of `W_FloatObject::w_slots` for the shared slot helpers.
+///
+/// # Safety
+/// `obj` must point to a valid `W_FloatObject`.
+unsafe fn float_slots_field(obj: PyObjectRef) -> *mut PyObjectRef {
+    unsafe { &mut (*(obj as *mut W_FloatObject)).w_slots }
+}
+
 pub unsafe fn w_float_slot_get(obj: PyObjectRef, index: usize) -> Option<PyObjectRef> {
-    let slots = unsafe { (*(obj as *const W_FloatObject)).w_slots };
-    if slots.is_null() {
-        return None;
-    }
-    unsafe { crate::listobject::w_list_getitem(slots, index as i64) }
-        .filter(|value| !value.is_null())
+    unsafe { crate::slots::slot_get(obj, index, float_slots_field) }
 }
 
 pub unsafe fn w_float_slot_set(obj: PyObjectRef, index: usize, value: PyObjectRef) {
-    let mut slots = unsafe { (*(obj as *const W_FloatObject)).w_slots };
-    if slots.is_null() {
-        slots = crate::listobject::w_list_new(vec![PY_NULL; index + 1]);
-        unsafe { (*(obj as *mut W_FloatObject)).w_slots = slots };
-        crate::gc_hook::try_gc_write_barrier(obj as *mut u8);
-    } else {
-        while unsafe { crate::listobject::w_list_len(slots) } <= index {
-            unsafe { crate::listobject::w_list_append(slots, PY_NULL) };
-        }
-    }
-    unsafe { crate::listobject::w_list_setitem(slots, index as i64, value) };
+    unsafe { crate::slots::slot_set(obj, index, value, float_slots_field) }
 }
 
 pub unsafe fn w_float_slot_del(obj: PyObjectRef, index: usize) -> bool {
-    let slots = unsafe { (*(obj as *const W_FloatObject)).w_slots };
-    if slots.is_null() || unsafe { crate::listobject::w_list_len(slots) } <= index {
-        return false;
-    }
-    let present = unsafe { crate::listobject::w_list_getitem(slots, index as i64) }
-        .is_some_and(|value| !value.is_null());
-    if present {
-        unsafe { crate::listobject::w_list_setitem(slots, index as i64, PY_NULL) };
-    }
-    present
+    unsafe { crate::slots::slot_del(obj, index, float_slots_field) }
 }
 
 #[majit_macros::dont_look_inside]

--- a/pyre/pyre-object/src/lib.rs
+++ b/pyre/pyre-object/src/lib.rs
@@ -54,6 +54,7 @@ pub mod rbigint;
 pub mod rutf8;
 pub mod setobject;
 pub mod sliceobject;
+pub mod slots;
 pub mod special;
 pub mod specialisedtupleobject;
 pub mod tagged_int;

--- a/pyre/pyre-object/src/slots.rs
+++ b/pyre/pyre-object/src/slots.rs
@@ -28,7 +28,8 @@ pub unsafe fn slot_get(
     if slots.is_null() {
         return None;
     }
-    unsafe { crate::listobject::w_list_getitem(slots, index as i64) }.filter(|value| !value.is_null())
+    unsafe { crate::listobject::w_list_getitem(slots, index as i64) }
+        .filter(|value| !value.is_null())
 }
 
 /// Store `value` into slot `index`, growing (or creating) the backing list as

--- a/pyre/pyre-object/src/slots.rs
+++ b/pyre/pyre-object/src/slots.rs
@@ -1,0 +1,91 @@
+//! Shared `__slots__` storage helpers for native subclasses (float, complex).
+//!
+//! Each host object stores its `__slots__` values in a list held by a
+//! `w_slots: PyObjectRef` field.  Callers pass an accessor that yields that
+//! field's address from the object pointer, so a single implementation serves
+//! every layout without duplicating the GC-rooting dance.
+
+use crate::pyobject::*;
+
+/// Field accessor: given an object pointer, return the address of its
+/// `w_slots` field.
+///
+/// # Safety
+/// The accessor is called only with a pointer to the concrete host struct it
+/// was written for.
+pub type SlotsField = unsafe fn(PyObjectRef) -> *mut PyObjectRef;
+
+/// Read slot `index`, or `None` when unset (null list or null entry).
+///
+/// # Safety
+/// `obj` must be a valid pointer to the host struct `slots_field` targets.
+pub unsafe fn slot_get(
+    obj: PyObjectRef,
+    index: usize,
+    slots_field: SlotsField,
+) -> Option<PyObjectRef> {
+    let slots = unsafe { *slots_field(obj) };
+    if slots.is_null() {
+        return None;
+    }
+    unsafe { crate::listobject::w_list_getitem(slots, index as i64) }.filter(|value| !value.is_null())
+}
+
+/// Store `value` into slot `index`, growing (or creating) the backing list as
+/// needed.  Creating or growing the list allocates, and `w_list_new` /
+/// `w_list_append` are GC safepoints that can relocate `obj`, `value`, and the
+/// list itself, so pin them and reload the receiver after every allocation
+/// before storing through it.
+///
+/// # Safety
+/// `obj` must be a valid pointer to the host struct `slots_field` targets.
+pub unsafe fn slot_set(
+    obj: PyObjectRef,
+    index: usize,
+    value: PyObjectRef,
+    slots_field: SlotsField,
+) {
+    let slots = unsafe { *slots_field(obj) };
+    if !slots.is_null() && unsafe { crate::listobject::w_list_len(slots) } > index {
+        unsafe { crate::listobject::w_list_setitem(slots, index as i64, value) };
+        return;
+    }
+    let _roots = crate::gc_roots::push_roots();
+    let root_base = crate::gc_roots::shadow_stack_len();
+    crate::gc_roots::pin_root(obj);
+    crate::gc_roots::pin_root(value);
+    if slots.is_null() {
+        let new_slots = crate::listobject::w_list_new(vec![PY_NULL; index + 1]);
+        let obj = crate::gc_roots::shadow_stack_get(root_base);
+        unsafe { *slots_field(obj) = new_slots };
+        crate::gc_hook::try_gc_write_barrier(obj as *mut u8);
+    } else {
+        let mut slots = slots;
+        while unsafe { crate::listobject::w_list_len(slots) } <= index {
+            unsafe { crate::listobject::w_list_append(slots, PY_NULL) };
+            let obj = crate::gc_roots::shadow_stack_get(root_base);
+            slots = unsafe { *slots_field(obj) };
+        }
+    }
+    let obj = crate::gc_roots::shadow_stack_get(root_base);
+    let slots = unsafe { *slots_field(obj) };
+    let value = crate::gc_roots::shadow_stack_get(root_base + 1);
+    unsafe { crate::listobject::w_list_setitem(slots, index as i64, value) };
+}
+
+/// Clear slot `index`, returning whether it held a value beforehand.
+///
+/// # Safety
+/// `obj` must be a valid pointer to the host struct `slots_field` targets.
+pub unsafe fn slot_del(obj: PyObjectRef, index: usize, slots_field: SlotsField) -> bool {
+    let slots = unsafe { *slots_field(obj) };
+    if slots.is_null() || unsafe { crate::listobject::w_list_len(slots) } <= index {
+        return false;
+    }
+    let present = unsafe { crate::listobject::w_list_getitem(slots, index as i64) }
+        .is_some_and(|value| !value.is_null());
+    if present {
+        unsafe { crate::listobject::w_list_setitem(slots, index as i64, PY_NULL) };
+    }
+    present
+}

--- a/pyre/pyre-object/src/typedef.rs
+++ b/pyre/pyre-object/src/typedef.rs
@@ -241,6 +241,10 @@ pub struct W_MemberDescr {
     pub name: *const String,
     /// Owning type object (for typecheck).
     pub w_cls: PyObjectRef,
+    /// `PyMemberDef.doc` for native member descriptors.  Like CPython's
+    /// static C string, this is non-GC metadata; Python `__slots__` members
+    /// leave it null.
+    pub doc: *const String,
 }
 
 /// Python 3.14's function type exposes five direct `PyMemberDef` entries.
@@ -256,13 +260,32 @@ pub const MEMBER_FUNCTION_MODULE: u32 = MEMBER_DIRECT_FLAG | 3;
 pub const MEMBER_FUNCTION_BUILTINS: u32 = MEMBER_DIRECT_FLAG | 4;
 /// CPython 3.14 `module_members`: the authoritative Module.w_dict field.
 pub const MEMBER_MODULE_DICT: u32 = MEMBER_DIRECT_FLAG | 5;
+/// CPython `PyComplex_Type` exposes `real`/`imag` as read-only T_DOUBLE
+/// member descriptors.
+pub const MEMBER_COMPLEX_REAL: u32 = MEMBER_DIRECT_FLAG | 6;
+pub const MEMBER_COMPLEX_IMAG: u32 = MEMBER_DIRECT_FLAG | 7;
 
 /// Create a new Member descriptor.
 pub fn w_member_new(index: u32, name: String, w_cls: PyObjectRef) -> PyObjectRef {
+    w_member_new_with_doc(index, name, w_cls, None)
+}
+
+/// Create a member descriptor carrying the native member definition's doc.
+pub fn w_member_new_with_doc(
+    index: u32,
+    name: String,
+    w_cls: PyObjectRef,
+    doc: Option<String>,
+) -> PyObjectRef {
     // `gct_fv_gc_malloc` bracket pattern (`framework.py:853-856`).
     let _roots = crate::gc_roots::push_roots();
+    let root_base = crate::gc_roots::shadow_stack_len();
     crate::gc_roots::pin_root(w_cls);
     let name = crate::lltype::malloc_raw(name);
+    let doc = doc.map_or(std::ptr::null(), |value| {
+        crate::lltype::malloc_raw(value) as *const String
+    });
+    let w_cls = crate::gc_roots::shadow_stack_get(root_base);
     W_MemberDescr::allocate(W_MemberDescr {
         ob: PyObject {
             ob_type: std::ptr::null(),
@@ -271,6 +294,7 @@ pub fn w_member_new(index: u32, name: String, w_cls: PyObjectRef) -> PyObjectRef
         index,
         name,
         w_cls,
+        doc,
     })
 }
 
@@ -300,6 +324,22 @@ pub unsafe fn w_member_get_cls(obj: PyObjectRef) -> PyObjectRef {
 pub unsafe fn w_member_set_cls(obj: PyObjectRef, w_cls: PyObjectRef) {
     crate::gc_roots::mark_prebuilt_roots_dirty();
     unsafe { (*(obj as *mut W_MemberDescr)).w_cls = w_cls }
+}
+
+pub unsafe fn w_member_get_doc(obj: PyObjectRef) -> Option<&'static str> {
+    if unsafe { w_member_is_direct(obj) } {
+        match unsafe { w_member_get_name(obj) } {
+            "real" => return Some("the real part of a complex number"),
+            "imag" => return Some("the imaginary part of a complex number"),
+            _ => {}
+        }
+    }
+    let doc = unsafe { (*(obj as *const W_MemberDescr)).doc };
+    if !doc.is_null() {
+        Some(unsafe { &*doc })
+    } else {
+        None
+    }
 }
 
 /// `typedef.py:446 Member.index` — the slot index (`base_nslots + position`),

--- a/pyre/pyre-object/src/typeobject.rs
+++ b/pyre/pyre-object/src/typeobject.rs
@@ -978,6 +978,14 @@ pub unsafe fn w_type_set_mro(obj: PyObjectRef, mro: Vec<PyObjectRef>) {
     }
 }
 
+/// Restore the uninitialised `tp_mro == NULL` state while a metaclass MRO
+/// calculation is in progress or when a transactional base update rolls
+/// back a nascent type.
+pub unsafe fn w_type_clear_mro(obj: PyObjectRef) {
+    (*(obj as *mut W_TypeObject)).mro_w = std::ptr::null_mut();
+    crate::gc_hook::try_gc_write_barrier(obj as *mut u8);
+}
+
 /// typeobject.py:1615-1619 `is_mro_purely_of_types(mro_w)`.
 pub unsafe fn is_mro_purely_of_types(mro_w: &[PyObjectRef]) -> bool {
     for &w_class in mro_w {


### PR DESCRIPTION
## Summary

Port PyPy-compatible `time`/`datetime` behavior and the descriptor/type
semantics the CPython `test_time`, `test_datetime`, and `test_descr` suites
depend on, and mark those three modules PASS in the dynasm runner baseline.

## What changed

**`time` / `datetime`**

- implement timezone refresh, `tzset`, timestamp validation, clock metadata,
  and the supporting string/regex behavior for `time` and pure-Python
  `datetime`
- `time.strftime` decodes libc output as canonical WTF-8 first and only falls
  back to `charp2uni` surrogateescape for genuinely non-WTF-8 locale bytes, so
  a lone-surrogate directive round-trips instead of being re-split into three
  surrogate escapes

**descriptors / type object**

- implement descriptor binding and the public descriptor types for methods,
  staticmethods, classmethods, properties, members, getsets, and slot wrappers;
  `method_descriptor` / `wrapper_descriptor` expose `__get__`
- align type construction, metaclass selection, custom MRO, `__bases__`
  mutation/reentrancy, native subclass layout, and special-method lookup with
  PyPy/CPython
- `object.__getattr__` resolves a `__dict__` miss on a class by walking the
  metatype MRO and honoring a genuine metatype `__dict__` override (a data
  descriptor whose owner is a proper subclass of `type`); `type`'s own
  canonical getset is told apart by owner identity, since every class chains
  its layout typedef to `object`'s `INSTANCE_TYPE`
- consolidate the shared `float`/`complex` `__slots__` storage into
  `slot_get`/`slot_set`/`slot_del` helpers that root and reload the receiver
  across the list-growth safepoints, and fold the six duplicated `setdict`
  dict-type validations into one gate

**runner**

- use libregrtest-style default resources for `test_datetime`, avoiding the
  opt-in exhaustive system-tzdata sweep
- preserve dotted module identity for `test_descr`
- mark `test.test_time`, `test.test_datetime`, and `test.test_descr` PASS

## Review fixes

Two rounds of review were applied on top of the feature commits:

- `time` init registration gated behind `not(sandbox)` so a sandbox build keeps
  the UTC interplevel defaults
- `sys.getsizeof` rejects a non-int `__sizeof__` (TypeError) and a negative one
  (ValueError); `sys.getsizeof` prefers the type's `__sizeof__`
- `type.__new__` copies the assembled namespace with `w_dict_copy` so keys are
  not re-hashed while the type dict is built
- `float`/`complex` `__dict__` lazy-init roots and reloads the receiver across
  `w_dict_new`, matching the bytes/bytearray arms
- `member_descriptor.__doc__` no longer shadows the real `member_get_doc`
- `dict` subclass `__new__` raises `RuntimeError` when the layout carries no
  mapping payload slot
- `pow(base, exp, mod)` reaches `__rpow__` in the reflected-power order (3.14)
- exception-instance `__dict__` assignment is routed to `setdict` ahead of the
  descriptor walk, so a plain base mixed into an exception cannot expose a
  layout-incompatible instance `__dict__` getset
- corrected the `W_FloatObject`/`W_ComplexObject` GC-registration comments that
  still described them as pointer-free leaves

## Rebase revalidation fixes

Rebasing onto `main` pulled in #791's `count_preamble` and a newer
`test_descr`, surfacing three gate regressions, all fixed here:

- **builtin arity guard** (`pyre-macros`): `Arguments.parse_obj` fills every
  parameter slot before a builtin body runs, so a keyword-only parameter
  widened the received `args` past the positional count. The generated
  surplus-positional guard compared that widened count against the
  positional-only total, so every non-varargs builtin carrying a keyword-only
  parameter — `warnings.warn` included — raised a spurious "expected at most N
  arguments" `TypeError`, breaking `test_time` and `test_datetime`. The guard
  now compares against the full parameter-slot count, the bound
  `bind_builtin_kwargs` already enforces, and keeps the positional count in the
  message.
- **super() proxy** (`baseobjspace`): when `type(obj)` is not a subtype of the
  start type, `super()` resolves the bound object's type through
  `obj.__class__` honouring `__getattribute__`, so a proxy forwarding
  `__class__` to a wrapped instance is a valid `super()` target
  (`_super_check`); fixes `test_proxy_super`.
- **reentrant __bases__** (`typedef`): a class is recorded for MRO restoration
  only after its MRO recomputes, and the bases roll back only while they are
  still the ones this call installed — a reentrant `__bases__` assignment
  reached through a custom `mro()` that then raises keeps the bases and MRO it
  committed (`mro_hierarchy` / `type_set_bases`); fixes
  `test_tp_subclasses_cycle_error_return_path`.


## Validation

- CPython runner (dynasm, JIT on): `test.test_time`, `test.test_datetime`, and
  `test.test_descr` PASS
- full 42-module baseline-PASS runner sweep: no `PASS -> FAIL/TIMEOUT/CRASH/IMPORTERROR`
  regressions
- `cargo test` on the touched crates
- dynasm benchmark/self-check suite green
- Charon LLBC re-extracted for the modified interpreter/object/JIT crates and
  the prepass rebuilt
- rebased onto `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Unix timezone initialization and `time.tzset()`.
  - Improved `time.strftime()` support, including embedded null characters and broader Unicode handling.
  - Added support for attributes and slots on `float` and `complex` subclasses.
  - Improved special-method behavior for class creation, descriptors, `pow()`, `round()`, `reversed()`, and `complex()`.

- **Bug Fixes**
  - Strengthened validation for timestamps, class bases, metaclasses, dictionaries, and object sizes.
  - Improved error types and messages for invalid time values and unsupported operations.
  - Fixed `sys.getsizeof()` handling and reflected three-argument power operations.

- **Tests**
  - Added coverage for `time.get_clock_info()` and updated CPython compatibility results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

