### PR TITLE
operator/dict-view: interp-level concat, __new__ validation

### DIFF
--- a/pyre/pyre-interpreter/src/module/operator/app_operator.py
+++ b/pyre/pyre-interpreter/src/module/operator/app_operator.py
@@ -15,14 +15,6 @@ def countOf(a, b):
     return count
 
 
-def concat(a, b):
-    "Same as a + b, for a and b sequences."
-    if not hasattr(a, '__getitem__'):
-        msg = "'%s' object can't be concatenated" % type(a).__name__
-        raise TypeError(msg)
-    return a + b
-
-
 def indexOf(a, b):
     "Return the first index of b in a."
     for i, j in enumerate(a):

--- a/pyre/pyre-interpreter/src/module/operator/mod.rs
+++ b/pyre/pyre-interpreter/src/module/operator/mod.rs
@@ -89,6 +89,26 @@ fn op_compare_digest(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError
     Ok(w_bool_from(result == 0))
 }
 
+/// `interp_operator.py:20 concat` — `a + b` for two subscriptable
+/// sequences.  Either operand missing `__getitem__` raises a bare
+/// `TypeError` with no message (`OperationError(space.w_TypeError,
+/// space.w_None)`); otherwise the result is `space.add(a, b)`.
+fn op_concat(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    if args.len() != 2 {
+        return Err(crate::PyError::type_error(format!(
+            "concat expected 2 arguments, got {}",
+            args.len()
+        )));
+    }
+    if unsafe {
+        crate::baseobjspace::lookup(args[0], "__getitem__").is_none()
+            || crate::baseobjspace::lookup(args[1], "__getitem__").is_none()
+    } {
+        return Err(crate::PyError::type_error(String::new()));
+    }
+    add(args[0], args[1])
+}
+
 /// `interp_operator.py:204 iconcat` — `a += b` for two subscriptable
 /// sequences; either operand missing `__getitem__` is a TypeError that
 /// names the left operand.
@@ -127,14 +147,15 @@ crate::py_module! {
     "operator",
     // `countOf` + the `itemgetter`/`attrgetter`/`methodcaller` callable
     // classes are app-level (`pypy/module/operator/app_operator.py`,
-    // `moduledef.py` `app_names`), not interp-level.  `concat`/`indexOf`/
-    // `inv`/`is_none`/`is_not_none`/`call` follow the `operator.py` pure-
-    // Python definitions verbatim (`call`'s `**kwargs` forwarding and
-    // `concat`'s `__getitem__` guard are awkward to express interp-level).
+    // `moduledef.py` `app_names`), not interp-level.  `indexOf`/`inv`/
+    // `is_none`/`is_not_none`/`call` follow the `operator.py` pure-Python
+    // definitions verbatim (`call`'s `**kwargs` forwarding is awkward to
+    // express interp-level).  `concat` is interp-level (`op_concat`,
+    // `interp_operator.py:20`) so it guards both operands for `__getitem__`.
     appleveldefs: {
         "app_operator.py" => [
             "countOf", "itemgetter", "attrgetter", "methodcaller",
-            "concat", "indexOf", "inv", "is_none", "is_not_none", "call",
+            "indexOf", "inv", "is_none", "is_not_none", "call",
         ],
     },
     functions: {
@@ -170,6 +191,7 @@ crate::py_module! {
         "iand"      / 2 = |args| op_binary(args, "iand", |a, b| crate::opcode_ops::binary_value(a, b, crate::bytecode::BinaryOperator::InplaceAnd)),
         "ior"       / 2 = |args| op_binary(args, "ior", |a, b| crate::opcode_ops::binary_value(a, b, crate::bytecode::BinaryOperator::InplaceOr)),
         "ixor"      / 2 = |args| op_binary(args, "ixor", |a, b| crate::opcode_ops::binary_value(a, b, crate::bytecode::BinaryOperator::InplaceXor)),
+        "concat"    / 2 = op_concat,
         "iconcat"   / 2 = op_iconcat,
         "not_"     / 1 = |args| Ok(w_bool_from(!is_true(args[0])?)),
         // interp_operator.py:138

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -5627,10 +5627,25 @@ fn dict_view_descr_new(
     static_tp: &'static pyre_object::PyType,
     name: &str,
 ) -> Result<PyObjectRef, crate::PyError> {
-    if args.len() < 2 {
-        return Err(crate::PyError::type_error(format!(
-            "{name}() missing required argument: the source dict"
-        )));
+    // `interp2app(new_dict_*)` binds exactly `(w_type, w_dict)`; the arity
+    // is enforced before the body runs.
+    match args.len() {
+        0 => {
+            return Err(crate::PyError::type_error(format!(
+                "{name}.__new__() missing 2 required positional arguments: 'type' and 'dict'"
+            )));
+        }
+        1 => {
+            return Err(crate::PyError::type_error(format!(
+                "{name}.__new__() missing 1 required positional argument: 'dict'"
+            )));
+        }
+        2 => {}
+        n => {
+            return Err(crate::PyError::type_error(format!(
+                "{name}.__new__() takes 2 positional arguments but {n} were given"
+            )));
+        }
     }
     let cls = args[0];
     // `interp_w(W_DictMultiObject, w_dict)` — accept a dict or any dict
@@ -5638,17 +5653,21 @@ fn dict_view_descr_new(
     let dict_type = gettypeobject(&pyre_object::pyobject::DICT_TYPE);
     if !unsafe { crate::baseobjspace::isinstance_w(args[1], dict_type) } {
         return Err(crate::PyError::type_error(format!(
-            "{name}() argument must be a dict"
+            "'dict' object expected, got '{}' instead",
+            crate::baseobjspace::object_functionstr_type_name(args[1])
         )));
     }
+    // `allocate_instance(W_DictView*Object, w_type)` validates the target:
+    // a non-type, a non-subtype, or a foreign-layout subtype is rejected
+    // before the view is allocated.
+    let static_obj = gettypeobject(static_tp);
+    check_user_subclass(static_obj, cls)?;
     // A dict subclass keeps its entries in a native backing dict; the view
     // binds to that, exactly as `dict.keys()`/`values()`/`items()` do.
     let w_dict = crate::type_methods::resolve_dict_backing(args[1]);
     let view = pyre_object::dictmultiobject::w_dict_view_new(w_dict, kind);
-    // Re-point the Python-visible class to a subtype when one was passed
-    // (mirrors the `__new__` subtype fix-up applied to native builtins).
-    let static_obj = gettypeobject(static_tp);
-    if cls != static_obj && unsafe { pyre_object::is_type(cls) } {
+    // Re-point the Python-visible class to the validated subtype.
+    if !std::ptr::eq(cls, static_obj) {
         unsafe { (*view).w_class = cls };
     }
     Ok(view)


### PR DESCRIPTION
Two interpreter-correctness fixes where pyre matched neither CPython nor PyPy, each 3-way verified against CPython 3.14.2 and pypy3.

## operator.concat — interp-level, both operands checked
`operator.concat` was registered app-level (CPython `operator.py` verbatim) and checked only the **left** operand for `__getitem__`. PyPy's concat is interp-level (`interp_operator.py:20`): it checks **both** operands via `space.lookup(..., '__getitem__')` and raises a bare `TypeError`.

Discriminator: `operator.concat([1, 2], obj_with___radd__)` returned `obj.__radd__([1, 2])` in pyre; CPython and PyPy both raise. Fixed by adding an interp-level `op_concat` (mirroring the already-correct `op_iconcat`), registering `concat` under it, and dropping the `app_operator.py` definition (matching PyPy `moduledef.py` `app_names`, which lists only `countOf`/`attrgetter`/`itemgetter`/`methodcaller`).

## dict_keys/dict_values/dict_items `__new__` — arity + subtype validation
The shared `__new__` ignored surplus positional arguments and re-pointed the view's class to **any** type without a subtype check, so `dict_keys.__new__(int, d)` produced a dict-view object whose class was `int`.

Now the `(w_type, w_dict)` arity is enforced (matching `interp2app(new_dict_*)`) and the target type is routed through the existing `check_user_subclass` helper (mirroring `new_dict_keys` → `allocate_instance`, `dictmultiobject.py:1746`). Error messages match PyPy; `OrderedDict`'s reversed-view subclasses (`_OrderedDict*View(dict_keys)`) still work.

## Verification
- 3-way probes (CPython 3.14.2 / pypy3 / pyre) match the PyPy oracle on all behavioral cases.
- `pyre/check.py` gate: **dynasm 225/225, cranelift 225/225**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restored `operator.concat` with validation for both operands and clearer errors for invalid inputs.
  * Improved error messages when creating objects with an incorrect number or type of arguments.
  * Added validation for requested subclasses before creating view objects.
  * Corrected class handling for objects created through `__new__`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->