### PR TITLE
aheui JIT: inline_void storage-op lowering + compiled-path deopt fixes

### DIFF
--- a/majit/majit-ir/src/descr.rs
+++ b/majit/majit-ir/src/descr.rs
@@ -670,6 +670,18 @@ pub struct GcCache {
     _cache_call_order: Vec<DescrRef>,
     _cache_interiorfield_order: Vec<DescrRef>,
 
+    /// Superseded SizeDescr Arcs retired by `register_keyed_size`'s
+    /// fuller-layout upgrade.  PyPy's `_cache_size[STRUCT]` holds a single
+    /// canonical SizeDescr that is never freed, so field descrs' Weak parent
+    /// back-references stay valid for the process lifetime.  pyre registers
+    /// struct layouts incrementally and replaces the cached SizeDescr with a
+    /// fuller one; without this vec the replaced Arc would drop while field
+    /// descrs already baked into recorded ops still hold Weak refs to it,
+    /// dangling their `get_parent_descr()`.  Kept OUT of `_cache_size_order`
+    /// so `setup_descrs` descr_index assignment is unchanged — these are
+    /// retired, not re-registered; they exist only to keep the Weak alive.
+    _size_keepalive: Vec<DescrRef>,
+
     /// `gctypelayout.py:301-357 TypeLayoutBuilder.get_type_id` analog —
     /// the shared dense sequential GC type-id allocator covering both
     /// `GcStruct` and `GcArray`.  PyPy's `type_info_group.add_member`
@@ -700,6 +712,7 @@ impl GcCache {
             _cache_arraylen_order: Vec::new(),
             _cache_call_order: Vec::new(),
             _cache_interiorfield_order: Vec::new(),
+            _size_keepalive: Vec::new(),
             // tid 0 is reserved as "no class" / sentinel —
             // `gctypelayout.py:328-331 make_type_info_group` adds a
             // DUMMY member at index 0.
@@ -1155,6 +1168,14 @@ impl GcCache {
             }
         };
         if should_insert {
+            // PyPy never frees a cached SizeDescr; retire the superseded one
+            // into an immortal keepalive so any field descr already baked into
+            // a recorded op keeps a live Weak parent (get_parent_descr()).
+            if let Some(old) = self._cache_size.get(&key) {
+                if !arc_in_vec(&self._size_keepalive, old) {
+                    self._size_keepalive.push(old.clone());
+                }
+            }
             self._cache_size.insert(key.clone(), descr.clone());
             self._cache_size_order.retain(|d| {
                 // Remove the old entry for this key (if any) from the
@@ -1203,10 +1224,21 @@ impl GcCache {
         // Weak can still upgrade; if not, replace it with the new descr
         // whose parent Weak points to the current (upgraded) SizeDescr.
         let inner = self._cache_field.entry(struct_key).or_default();
-        let should_replace = inner
-            .get(&field_name)
-            .map(|existing| existing.get_parent_descr().is_none())
-            .unwrap_or(true); // no entry yet → insert
+        // PyPy's cached field descr always parents the single canonical (fullest)
+        // SizeDescr.  pyre registers incrementally, so replace the cached field
+        // descr when the incoming one's parent carries MORE fields — this keeps
+        // future getfield recordings baking the fullest-layout parent.  (The old
+        // Weak-liveness check is now inert: register_keyed_size retires superseded
+        // SizeDescrs into _size_keepalive instead of freeing them.)
+        let parent_field_count = |fd: &SimpleFieldDescr| -> usize {
+            fd.get_parent_descr()
+                .and_then(|p| p.as_size_descr().map(|sd| sd.all_fielddescrs().len()))
+                .unwrap_or(0)
+        };
+        let should_replace = match inner.get(&field_name) {
+            None => true, // no entry yet -> insert
+            Some(existing) => parent_field_count(&descr) > parent_field_count(existing),
+        };
         if should_replace {
             // Remove stale entry from _order if present.
             if let Some(old) = inner.get(&field_name) {

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/api.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/api.rs
@@ -345,18 +345,15 @@ pub(crate) fn generate_inline_helper_jitcode_with_calls(
         ));
     }
 
-    let ReturnType::Type(_, return_ty) = &func.sig.output else {
-        return Err(syn::Error::new_spanned(
-            &func.sig.output,
-            "#[jit_inline] requires a return type",
-        ));
+    let return_kind = match &func.sig.output {
+        ReturnType::Default => InlineReturnKind::Void,
+        ReturnType::Type(_, return_ty) => classify_param_type(return_ty).ok_or_else(|| {
+            syn::Error::new_spanned(
+                return_ty,
+                "#[jit_inline] supports i64/isize (Int), usize/pointer (Ref), f64 (Float), or void return types",
+            )
+        })?,
     };
-    let return_kind = classify_param_type(return_ty).ok_or_else(|| {
-        syn::Error::new_spanned(
-            return_ty,
-            "#[jit_inline] supports i64/isize (Int), usize/pointer (Ref), or f64 (Float) return types",
-        )
-    })?;
 
     let call_policies = calls
         .iter()
@@ -402,6 +399,7 @@ pub(crate) fn generate_inline_helper_jitcode_with_calls(
             InlineReturnKind::Int => BindingKind::Int,
             InlineReturnKind::Ref => BindingKind::Ref,
             InlineReturnKind::Float => BindingKind::Float,
+            InlineReturnKind::Void => unreachable!("helper parameters cannot be void"),
         };
         let param_name = pat_ident.ident.to_string();
         let declared_struct_type = ref_param_structs.get(&param_name).cloned();
@@ -435,8 +433,18 @@ pub(crate) fn generate_inline_helper_jitcode_with_calls(
     }
     lowerer.next_reg = max_reg;
 
-    let Some(binding) = lowerer.lower_block_value(&func.block) else {
-        return Ok(None);
+    let return_reg = if matches!(return_kind, InlineReturnKind::Void) {
+        for stmt in &func.block.stmts {
+            if lowerer.lower_stmt(stmt).is_none() {
+                return Ok(None);
+            }
+        }
+        0
+    } else {
+        let Some(binding) = lowerer.lower_block_value(&func.block) else {
+            return Ok(None);
+        };
+        binding.reg
     };
 
     let helper_name = func.sig.ident.to_string();
@@ -451,7 +459,7 @@ pub(crate) fn generate_inline_helper_jitcode_with_calls(
         body: quote! {
             #(#statements)*
         },
-        return_reg: binding.reg,
+        return_reg,
         return_kind,
         liveness_prebuild,
     }))
@@ -493,6 +501,7 @@ pub(crate) fn inline_helper_param_layout(
                 next_f = next_f.saturating_add(1);
                 reg
             }
+            InlineReturnKind::Void => unreachable!("helper parameters cannot be void"),
         };
         layout.push((param_kind, reg));
     }
@@ -509,6 +518,7 @@ pub(crate) fn inline_helper_param_counts(func: &ItemFn) -> syn::Result<(u16, u16
             InlineReturnKind::Int => count_i = count_i.saturating_add(1),
             InlineReturnKind::Ref => count_r = count_r.saturating_add(1),
             InlineReturnKind::Float => count_f = count_f.saturating_add(1),
+            InlineReturnKind::Void => {}
         }
     }
     Ok((count_i, count_r, count_f))

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/api.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/api.rs
@@ -339,6 +339,7 @@ pub(crate) fn generate_inline_helper_jitcode_with_calls(
     ref_fields: &[crate::jit_interp::RefFieldEntry],
     native_int_binops: &[(Path, Ident)],
     native_tag_small: &[Path],
+    headerless_structs: &[Path],
 ) -> syn::Result<Option<InlineHelperJitCode>> {
     if !func.sig.generics.params.is_empty() {
         return Err(syn::Error::new_spanned(
@@ -375,6 +376,7 @@ pub(crate) fn generate_inline_helper_jitcode_with_calls(
         && ref_fields.is_empty()
         && native_int_binops.is_empty()
         && native_tag_small.is_empty()
+        && headerless_structs.is_empty()
     {
         None
     } else {
@@ -382,6 +384,7 @@ pub(crate) fn generate_inline_helper_jitcode_with_calls(
             ref_fields,
             native_int_binops,
             native_tag_small,
+            headerless_structs,
         ))
     };
     let mut lowerer = Lowerer::new_with_call_policies(

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/api.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/api.rs
@@ -337,6 +337,8 @@ pub(crate) fn generate_inline_helper_jitcode_with_calls(
     calls: &[crate::jit_interp::CallEntry],
     ref_params: &[(Ident, syn::Path)],
     ref_fields: &[crate::jit_interp::RefFieldEntry],
+    native_int_binops: &[(Path, Ident)],
+    native_tag_small: &[Path],
 ) -> syn::Result<Option<InlineHelperJitCode>> {
     if !func.sig.generics.params.is_empty() {
         return Err(syn::Error::new_spanned(
@@ -369,10 +371,18 @@ pub(crate) fn generate_inline_helper_jitcode_with_calls(
         .iter()
         .map(|(name, struct_type)| (name.to_string(), struct_type.clone()))
         .collect();
-    let inline_config = if ref_param_structs.is_empty() && ref_fields.is_empty() {
+    let inline_config = if ref_param_structs.is_empty()
+        && ref_fields.is_empty()
+        && native_int_binops.is_empty()
+        && native_tag_small.is_empty()
+    {
         None
     } else {
-        Some(LowererConfig::inline_helper(ref_fields))
+        Some(LowererConfig::inline_helper(
+            ref_fields,
+            native_int_binops,
+            native_tag_small,
+        ))
     };
     let mut lowerer = Lowerer::new_with_call_policies(
         inline_config.as_ref(),

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/api.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/api.rs
@@ -335,6 +335,8 @@ pub(crate) fn try_generate_jitcode_pc_return_body_with_caller_bindings(
 pub(crate) fn generate_inline_helper_jitcode_with_calls(
     func: &ItemFn,
     calls: &[crate::jit_interp::CallEntry],
+    ref_params: &[(Ident, syn::Path)],
+    ref_fields: &[crate::jit_interp::RefFieldEntry],
 ) -> syn::Result<Option<InlineHelperJitCode>> {
     if !func.sig.generics.params.is_empty() {
         return Err(syn::Error::new_spanned(
@@ -366,10 +368,23 @@ pub(crate) fn generate_inline_helper_jitcode_with_calls(
             (canonical_path_segments(&entry.path), spec)
         })
         .collect();
-    let mut lowerer =
-        Lowerer::new_with_call_policies(None, call_policies, InferenceFailureMode::Panic);
+    let ref_param_structs: HashMap<String, syn::Path> = ref_params
+        .iter()
+        .map(|(name, struct_type)| (name.to_string(), struct_type.clone()))
+        .collect();
+    let inline_config = if ref_param_structs.is_empty() && ref_fields.is_empty() {
+        None
+    } else {
+        Some(LowererConfig::inline_helper(ref_fields))
+    };
+    let mut lowerer = Lowerer::new_with_call_policies(
+        inline_config.as_ref(),
+        call_policies,
+        InferenceFailureMode::Panic,
+    );
     let param_layout = inline_helper_param_layout(func)?;
     let mut max_reg = 0u16;
+    let mut seen_ref_params = HashSet::new();
     for (arg, (param_kind, reg)) in func.sig.inputs.iter().zip(param_layout.into_iter()) {
         let FnArg::Typed(pat_type) = arg else {
             return Err(syn::Error::new_spanned(
@@ -388,16 +403,35 @@ pub(crate) fn generate_inline_helper_jitcode_with_calls(
             InlineReturnKind::Ref => BindingKind::Ref,
             InlineReturnKind::Float => BindingKind::Float,
         };
+        let param_name = pat_ident.ident.to_string();
+        let declared_struct_type = ref_param_structs.get(&param_name).cloned();
+        if declared_struct_type.is_some() && !matches!(binding_kind, BindingKind::Ref) {
+            return Err(syn::Error::new_spanned(
+                &pat_type.ty,
+                "#[jit_inline(ref_params = { ... })] may only declare usize/pointer ref parameters",
+            ));
+        }
+        if declared_struct_type.is_some() {
+            seen_ref_params.insert(param_name.clone());
+        }
         max_reg = max_reg.max(reg.saturating_add(1));
         lowerer.bindings.insert(
-            pat_ident.ident.to_string(),
+            param_name,
             Binding {
                 reg,
                 kind: binding_kind,
                 depends_on_stack: false,
-                struct_type: None,
+                struct_type: declared_struct_type,
             },
         );
+    }
+    for (name, _) in ref_params {
+        if !seen_ref_params.contains(&name.to_string()) {
+            return Err(syn::Error::new_spanned(
+                name,
+                "#[jit_inline(ref_params = { ... })] names a parameter that does not exist",
+            ));
+        }
     }
     lowerer.next_reg = max_reg;
 

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/helpers.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/helpers.rs
@@ -313,6 +313,49 @@ pub(super) fn inline_call_tokens(
     (call_match, post_live)
 }
 
+pub(super) fn inline_call_tokens_void(bindings: &[Binding]) -> (TokenStream, TokenStream) {
+    let args_i = inline_int_arg_tokens(bindings);
+    let args_r = inline_ref_arg_tokens(bindings);
+    let args_f = inline_float_arg_tokens(bindings);
+    let has_int_args = bindings
+        .iter()
+        .any(|binding| matches!(binding.kind, BindingKind::Int));
+    let has_float_args = bindings
+        .iter()
+        .any(|binding| matches!(binding.kind, BindingKind::Float));
+
+    let call = if has_float_args {
+        quote! {
+            __builder.inline_call_irf_v(
+                __sub_idx,
+                #args_i,
+                #args_r,
+                #args_f,
+                None,
+            );
+        }
+    } else if has_int_args {
+        quote! {
+            __builder.inline_call_ir_v(
+                __sub_idx,
+                #args_i,
+                #args_r,
+                None,
+            );
+        }
+    } else {
+        quote! {
+            __builder.inline_call_r_v(
+                __sub_idx,
+                #args_r,
+                None,
+            );
+        }
+    };
+    let post_live = quote! { let _ = __builder.live_placeholder(); };
+    (call, post_live)
+}
+
 pub(super) fn typed_call_arg_tokens(bindings: &[Binding]) -> TokenStream {
     let args = bindings.iter().map(|binding| {
         let reg = binding.reg;

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/helpers.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/helpers.rs
@@ -329,6 +329,7 @@ pub(super) fn is_supported_int_cast(ty: &Type) -> bool {
     match ty {
         Type::Path(type_path) => {
             type_path.path.is_ident("i64")
+                || type_path.path.is_ident("Val")
                 || type_path.path.is_ident("u64")
                 || type_path.path.is_ident("isize")
                 || type_path.path.is_ident("usize")

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/lower_stmt.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/lower_stmt.rs
@@ -1,4 +1,4 @@
-use super::lower_value::struct_type_id;
+use super::lower_value::struct_type_id_tokens;
 use super::*;
 
 impl<'c> Lowerer<'c> {
@@ -24,7 +24,7 @@ impl<'c> Lowerer<'c> {
         // Raw host-owned struct (the ref-scalar's pointee, no GC header) →
         // `is_gc_managed = false`, the same id the getfield/setfield lowering
         // uses so this write-EI rebuilds the SAME parent SizeDescr identity.
-        let tid = struct_type_id(struct_path, false);
+        let tid = struct_type_id_tokens(struct_path, false);
         Some(quote! {
             // The residual mutates a host-owned native struct field (no
             // GC header) → `is_gc_managed = false`, matching the
@@ -1063,6 +1063,25 @@ impl<'c> Lowerer<'c> {
                             },
                         );
                     }
+                }
+                crate::jit_interp::CallPolicyKind::InlineVoid => {
+                    let builder_path = inline_builder_path(&call.func)?;
+                    let prebuild_path = inline_prebuild_path(&call.func)?;
+                    let (inline_call, post_live) = inline_call_tokens_void(&arg_bindings);
+                    let __arg_regs: Vec<Register> =
+                        arg_bindings.iter().map(Register::from_binding).collect();
+                    self.inline_liveness_prebuild.push(quote! {
+                        #prebuild_path(__asm);
+                    });
+                    self.emit_op(
+                        OpMeta::linear(OpKind::InlineCall, __arg_regs, vec![]),
+                        quote! {
+                            let __sub_jitcode = #builder_path(__asm);
+                            let __sub_idx = __builder.add_sub_jitcode(__sub_jitcode);
+                            #inline_call
+                        },
+                    );
+                    self.emit_op(OpMeta::live_marker(), post_live);
                 }
                 crate::jit_interp::CallPolicyKind::MayForceVoid => {
                     if let Some(arg_regs) = int_arg_regs(&arg_bindings) {

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/lower_vable.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/lower_vable.rs
@@ -1,4 +1,4 @@
-use super::lower_value::struct_type_id;
+use super::lower_value::struct_type_id_tokens;
 use super::*;
 
 impl<'c> Lowerer<'c> {
@@ -710,7 +710,7 @@ impl<'c> Lowerer<'c> {
         let is_ref_field = ref_field_entry.is_some();
         // Raw (headerless) ref-scalar pointee → `is_gc_managed = false`, a
         // distinct descriptor id from any GC `new_struct` of the same type.
-        let tid = struct_type_id(&struct_path, false);
+        let tid = struct_type_id_tokens(&struct_path, false);
         // Lower the `state.<ref_scalar>` base to a ref binding (its
         // load_state_field_ref already declares the ref identity slot live for
         // resume), then read the field off that concrete ref.
@@ -821,7 +821,7 @@ impl<'c> Lowerer<'c> {
         let ref_field_key = format!("{}::{}", struct_last, member_name);
         let ref_field_entry = config.ref_fields.get(&ref_field_key);
         let is_ref_field = ref_field_entry.is_some();
-        let tid = struct_type_id(&struct_path, false);
+        let tid = struct_type_id_tokens(&struct_path, false);
         let base_reg = binding.reg;
         let result_reg = self.alloc_reg();
         if is_ref_field {
@@ -1007,7 +1007,7 @@ impl<'c> Lowerer<'c> {
         let is_ref_field = config.ref_fields.contains_key(&ref_field_key);
         // Raw (headerless) ref-scalar pointee → `is_gc_managed = false`, the
         // same id the matching getfield uses so this setfield invalidates it.
-        let tid = struct_type_id(&struct_path, false);
+        let tid = struct_type_id_tokens(&struct_path, false);
         let base = self.lower_state_field_read(&field.base)?;
         if !matches!(base.kind, BindingKind::Ref) {
             return None;
@@ -1112,7 +1112,7 @@ impl<'c> Lowerer<'c> {
             .unwrap_or_default();
         let ref_field_key = format!("{}::{}", struct_last, member_name);
         let is_ref_field = config.ref_fields.contains_key(&ref_field_key);
-        let tid = struct_type_id(&struct_path, false);
+        let tid = struct_type_id_tokens(&struct_path, false);
         let base_reg = binding.reg;
         let rhs = self.lower_value_expr(&assign.right)?;
         if is_ref_field {

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/lower_value.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/lower_value.rs
@@ -1069,6 +1069,7 @@ impl<'c> Lowerer<'c> {
                             vec![Register::new(result_kind, reg)],
                         ),
                         quote! {
+                            use majit_metainterp::jitcode::JitCodeRuntimeExt as _;
                             let __sub_jitcode = #builder_path(__asm);
                             let (__sub_return_kind, _) = __sub_jitcode
                                 .trailing_return_info()

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/lower_value.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/lower_value.rs
@@ -1,7 +1,13 @@
 use super::*;
 
-/// Deterministic per-struct type id for a size descr.  Hashes the struct path
-/// tokens; the same id keys the builder's `struct_size_specs` cache so each
+/// Legacy macro-time per-struct type id. Hashes the struct path tokens; retain
+/// it for a caller which genuinely needs a compile-time value, but do not use
+/// it for descriptor/layout identities: spelling one Rust type through two
+/// paths gives two different token streams.
+///
+/// Descriptor/layout identities instead use [`struct_type_id_tokens`], which
+/// emits the runtime `TypeId`-based identity helper. The same id keys the
+/// builder's `struct_size_specs` cache so each
 /// `setfield_gc_*` resolves its field's parent SizeDescr + `index_in_parent`
 /// (`descr.py:238`).  Distinct struct paths collide only at `DefaultHasher`'s
 /// 64-bit range, matching the runtime `LLType::Struct(type_id)` cache-key
@@ -24,6 +30,31 @@ pub(super) fn struct_type_id(path: &syn::Path, is_gc_managed: bool) -> u64 {
         "raw".hash(&mut hasher);
     }
     hasher.finish()
+}
+
+/// Emit the runtime lltype-identity surrogate for `path`.
+///
+/// RPython's `descr.py:get_size_descr()` is keyed by the lltype `STRUCT`
+/// object, not by a textual spelling in an individual graph. `TypeId` gives
+/// the corresponding process-local Rust type identity, so an inline helper
+/// using `super::linkedlist::Stack` and a caller using its fully qualified
+/// spelling share the same field descr cache key.
+///
+/// `TypeId::of` requires a `'static` type. A path with generic arguments can
+/// name a non-static type parameter and cannot be proven static by this proc
+/// macro, so preserve the legacy path hash for that conservative fallback.
+/// Concrete JIT structs use the runtime identity path.
+pub(super) fn struct_type_id_tokens(path: &syn::Path, is_gc_managed: bool) -> TokenStream {
+    let has_generic_args = path
+        .segments
+        .iter()
+        .any(|segment| !segment.arguments.is_none());
+    if has_generic_args {
+        let legacy = struct_type_id(path, is_gc_managed);
+        quote! { #legacy }
+    } else {
+        quote! { majit_metainterp::__pyre_struct_type_id::<#path>(#is_gc_managed) }
+    }
 }
 
 impl<'c> Lowerer<'c> {
@@ -281,8 +312,9 @@ impl<'c> Lowerer<'c> {
             depends_on_stack |= value.depends_on_stack;
             fields.push((field.member.clone(), value));
         }
-        // GC-allocated struct (`new_struct`): keep the bare-hash id.
-        let type_id = struct_type_id(struct_path, true);
+        // GC-allocated struct (`new_struct`): TypeId plus the GC-layout
+        // discriminator, shared by every spelling of this concrete type.
+        let type_id = struct_type_id_tokens(struct_path, true);
         let result_reg = self.alloc_reg();
         // descr.py:122-126 init_size_descr: the SizeDescr carries the
         // struct's full `(offset, is_ref, name)` layout so the optimizer can

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/mod.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/mod.rs
@@ -824,6 +824,7 @@ impl LowererConfig {
         ref_fields: &[crate::jit_interp::RefFieldEntry],
         native_int_binops: &[(syn::Path, syn::Ident)],
         native_tag_small: &[syn::Path],
+        headerless_structs: &[syn::Path],
     ) -> Self {
         let ref_fields_map: HashMap<String, (syn::Path, Ident, syn::Path)> = ref_fields
             .iter()
@@ -866,7 +867,10 @@ impl LowererConfig {
             pool_arrays: Vec::new(),
             ref_fields: ref_fields_map,
             call_returns: HashMap::new(),
-            headerless_structs: std::collections::HashSet::new(),
+            headerless_structs: headerless_structs
+                .iter()
+                .map(canonical_path_segments)
+                .collect(),
             native_int_binops: native_int_binops
                 .iter()
                 .map(|(path, op)| (canonical_path_segments(path), op.to_string()))
@@ -2451,6 +2455,7 @@ mod tests {
             &[],
             &[],
             &[],
+            &[],
         )
         .expect("jit_inline lowering should succeed")
         .expect("helper should lower");
@@ -2474,6 +2479,7 @@ mod tests {
             &[],
             &[],
             &[],
+            &[],
         )
         .expect("jit_inline lowering should succeed")
         .expect("helper should lower");
@@ -2493,6 +2499,7 @@ mod tests {
                 "#,
             ),
             &[inline_policy("callee")],
+            &[],
             &[],
             &[],
             &[],

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/mod.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/mod.rs
@@ -815,6 +815,56 @@ pub(super) fn inferred_record_known_result_policy_check(result_kind: BindingKind
 }
 
 impl LowererConfig {
+    pub fn inline_helper(ref_fields: &[crate::jit_interp::RefFieldEntry]) -> Self {
+        let ref_fields_map: HashMap<String, (syn::Path, Ident, syn::Path)> = ref_fields
+            .iter()
+            .map(|entry| {
+                let struct_name = entry
+                    .struct_type
+                    .segments
+                    .last()
+                    .map(|s| s.ident.to_string())
+                    .unwrap_or_default();
+                let key = format!("{}::{}", struct_name, entry.field);
+                (
+                    key,
+                    (
+                        entry.struct_type.clone(),
+                        entry.field.clone(),
+                        entry.pointee_type.clone(),
+                    ),
+                )
+            })
+            .collect();
+        Self {
+            io_shims: Vec::new(),
+            calls: Vec::new(),
+            auto_calls: false,
+            vable_var: None,
+            vable_input_ref_reg: None,
+            vable_fields: HashMap::new(),
+            vable_arrays: HashMap::new(),
+            state_scalars: HashMap::new(),
+            state_arrays: HashMap::new(),
+            state_virt_arrays: HashMap::new(),
+            state_ref_scalars: HashMap::new(),
+            greens: Vec::new(),
+            green_type_tags: Vec::new(),
+            reds: Vec::new(),
+            state_type_name: String::new(),
+            env_type_name: String::new(),
+            residual_writes: Vec::new(),
+            pool_arrays: Vec::new(),
+            ref_fields: ref_fields_map,
+            call_returns: HashMap::new(),
+            headerless_structs: std::collections::HashSet::new(),
+            native_int_binops: Vec::new(),
+            native_tag_small: Vec::new(),
+            split_dispatch: false,
+            switch_dispatch: false,
+        }
+    }
+
     pub fn new(
         io_shims: &[(Path, Ident)],
         calls: &[crate::jit_interp::CallEntry],
@@ -2382,6 +2432,8 @@ mod tests {
                 "#,
             ),
             &[inline_policy("callee")],
+            &[],
+            &[],
         )
         .expect("jit_inline lowering should succeed")
         .expect("helper should lower");
@@ -2401,6 +2453,8 @@ mod tests {
                 "#,
             ),
             &[inline_policy("callee")],
+            &[],
+            &[],
         )
         .expect("jit_inline lowering should succeed")
         .expect("helper should lower");
@@ -2420,6 +2474,8 @@ mod tests {
                 "#,
             ),
             &[inline_policy("callee")],
+            &[],
+            &[],
         )
         .expect("jit_inline lowering should succeed")
         .expect("helper should lower");

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/mod.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/mod.rs
@@ -820,7 +820,11 @@ pub(super) fn inferred_record_known_result_policy_check(result_kind: BindingKind
 }
 
 impl LowererConfig {
-    pub fn inline_helper(ref_fields: &[crate::jit_interp::RefFieldEntry]) -> Self {
+    pub fn inline_helper(
+        ref_fields: &[crate::jit_interp::RefFieldEntry],
+        native_int_binops: &[(syn::Path, syn::Ident)],
+        native_tag_small: &[syn::Path],
+    ) -> Self {
         let ref_fields_map: HashMap<String, (syn::Path, Ident, syn::Path)> = ref_fields
             .iter()
             .map(|entry| {
@@ -863,8 +867,14 @@ impl LowererConfig {
             ref_fields: ref_fields_map,
             call_returns: HashMap::new(),
             headerless_structs: std::collections::HashSet::new(),
-            native_int_binops: Vec::new(),
-            native_tag_small: Vec::new(),
+            native_int_binops: native_int_binops
+                .iter()
+                .map(|(path, op)| (canonical_path_segments(path), op.to_string()))
+                .collect(),
+            native_tag_small: native_tag_small
+                .iter()
+                .map(canonical_path_segments)
+                .collect(),
             split_dispatch: false,
             switch_dispatch: false,
         }
@@ -2439,6 +2449,8 @@ mod tests {
             &[inline_policy("callee")],
             &[],
             &[],
+            &[],
+            &[],
         )
         .expect("jit_inline lowering should succeed")
         .expect("helper should lower");
@@ -2460,6 +2472,8 @@ mod tests {
             &[inline_policy("callee")],
             &[],
             &[],
+            &[],
+            &[],
         )
         .expect("jit_inline lowering should succeed")
         .expect("helper should lower");
@@ -2479,6 +2493,8 @@ mod tests {
                 "#,
             ),
             &[inline_policy("callee")],
+            &[],
+            &[],
             &[],
             &[],
         )

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/mod.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/mod.rs
@@ -39,10 +39,10 @@ mod reexports {
         expr_has_loop_control, extract_block_tail_int, extract_bool_branch_values,
         extract_branch_int, extract_pat_literals, extract_pat_switch_case_tokens,
         extract_pat_value_tokens, extract_stmts, inline_builder_path, inline_call_tokens,
-        inline_float_arg_tokens, inline_int_arg_tokens, inline_prebuild_path,
-        inline_ref_arg_tokens, int_arg_regs, is_supported_float_type, is_supported_int_cast,
-        is_supported_ref_type, opcode_for_assign_binop, opcode_for_binop, stmt_has_loop_control,
-        typed_call_arg_tokens,
+        inline_call_tokens_void, inline_float_arg_tokens, inline_int_arg_tokens,
+        inline_prebuild_path, inline_ref_arg_tokens, int_arg_regs, is_supported_float_type,
+        is_supported_int_cast, is_supported_ref_type, opcode_for_assign_binop, opcode_for_binop,
+        stmt_has_loop_control, typed_call_arg_tokens,
     };
     pub(super) use super::liveness::{
         annotate_live_markers_with_liveness, compute_per_marker_liveness, get_liveness_info,
@@ -294,6 +294,7 @@ pub(crate) enum InlineReturnKind {
     Int,
     Ref,
     Float,
+    Void,
 }
 
 #[derive(Clone)]
@@ -482,6 +483,7 @@ pub(super) fn call_policy_effect_slot(
         | K::InlineInt
         | K::InlineRef
         | K::InlineFloat
+        | K::InlineVoid
         | K::InlinePipelineInt
         | K::InlinePipelineRef
         | K::InlinePipelineFloat
@@ -498,7 +500,9 @@ pub(super) fn call_policy_effect_slot(
 /// can-raise classification decides.  MayForce / ReleaseGil have no
 /// conditional-call slot but force / may raise, so they keep the marker.
 pub(super) fn explicit_call_emits_post_live(kind: crate::jit_interp::CallPolicyKind) -> bool {
-    if binding_kind_for_inline_policy(kind).is_some() {
+    if binding_kind_for_inline_policy(kind).is_some()
+        || matches!(kind, crate::jit_interp::CallPolicyKind::InlineVoid)
+    {
         return false;
     }
     if matches!(kind, crate::jit_interp::CallPolicyKind::ConcreteOnlyVoid) {
@@ -524,6 +528,7 @@ pub(super) fn call_policy_result_kind(
         | K::ReleaseGilVoidWrapped
         | K::LoopInvariantVoid
         | K::LoopInvariantVoidWrapped
+        | K::InlineVoid
         | K::ConcreteOnlyVoid => Some(CallResultKind::Void),
 
         K::ResidualInt

--- a/majit/majit-macros/src/jit_interp/mod.rs
+++ b/majit/majit-macros/src/jit_interp/mod.rs
@@ -458,6 +458,7 @@ pub(crate) enum CallPolicyKind {
     InlineInt,
     InlineRef,
     InlineFloat,
+    InlineVoid,
     /// `BC_INLINE_CALL` ('j' argcode) into a pipeline-built sub-jitcode
     /// resolved by name through the host's `__majit_pipeline_jitcode`, rather
     /// than a macro-generated `__majit_inline_jitcode_<name>` helper. Int /
@@ -529,6 +530,7 @@ pub(crate) fn parse_call_policy_kind(kind: &Ident) -> Option<CallPolicyKind> {
         "inline_int" => CallPolicyKind::InlineInt,
         "inline_ref" => CallPolicyKind::InlineRef,
         "inline_float" => CallPolicyKind::InlineFloat,
+        "inline_void" => CallPolicyKind::InlineVoid,
         "inline_pipeline_int" => CallPolicyKind::InlinePipelineInt,
         "inline_pipeline_ref" => CallPolicyKind::InlinePipelineRef,
         "inline_pipeline_float" => CallPolicyKind::InlinePipelineFloat,

--- a/majit/majit-macros/src/jit_interp/mod.rs
+++ b/majit/majit-macros/src/jit_interp/mod.rs
@@ -755,7 +755,7 @@ fn parse_pool_arrays_map(input: ParseStream) -> syn::Result<Vec<PoolArrayEntry>>
 /// a single `Path` and then split: the last segment is the field name, the
 /// remaining prefix is the struct type.
 /// Parse `call_returns = { func_path => StructType, ... }`.
-fn parse_call_returns_map(input: ParseStream) -> syn::Result<Vec<(Path, Path)>> {
+pub(crate) fn parse_call_returns_map(input: ParseStream) -> syn::Result<Vec<(Path, Path)>> {
     let content;
     braced!(content in input);
     let mut entries = Vec::new();
@@ -795,7 +795,7 @@ pub(crate) fn parse_native_tag_small_list(input: ParseStream) -> syn::Result<Vec
     Ok(entries)
 }
 
-fn parse_path_set(input: ParseStream) -> syn::Result<Vec<Path>> {
+pub(crate) fn parse_path_set(input: ParseStream) -> syn::Result<Vec<Path>> {
     let content;
     braced!(content in input);
     let mut entries = Vec::new();

--- a/majit/majit-macros/src/jit_interp/mod.rs
+++ b/majit/majit-macros/src/jit_interp/mod.rs
@@ -769,7 +769,7 @@ fn parse_call_returns_map(input: ParseStream) -> syn::Result<Vec<(Path, Path)>> 
     Ok(entries)
 }
 
-fn parse_native_int_binops_map(input: ParseStream) -> syn::Result<Vec<(Path, Ident)>> {
+pub(crate) fn parse_native_int_binops_map(input: ParseStream) -> syn::Result<Vec<(Path, Ident)>> {
     let content;
     braced!(content in input);
     let mut entries = Vec::new();
@@ -783,7 +783,7 @@ fn parse_native_int_binops_map(input: ParseStream) -> syn::Result<Vec<(Path, Ide
     Ok(entries)
 }
 
-fn parse_native_tag_small_list(input: ParseStream) -> syn::Result<Vec<Path>> {
+pub(crate) fn parse_native_tag_small_list(input: ParseStream) -> syn::Result<Vec<Path>> {
     let content;
     braced!(content in input);
     let mut entries = Vec::new();

--- a/majit/majit-macros/src/jit_interp/mod.rs
+++ b/majit/majit-macros/src/jit_interp/mod.rs
@@ -821,7 +821,7 @@ fn split_struct_field_path(full_path: Path) -> syn::Result<(Path, Ident)> {
     Ok((struct_type, field))
 }
 
-fn parse_ref_fields_map(input: ParseStream) -> syn::Result<Vec<RefFieldEntry>> {
+pub(crate) fn parse_ref_fields_map(input: ParseStream) -> syn::Result<Vec<RefFieldEntry>> {
     let content;
     braced!(content in input);
     let mut entries = Vec::new();

--- a/majit/majit-macros/src/lib.rs
+++ b/majit/majit-macros/src/lib.rs
@@ -34,6 +34,8 @@ struct JitInlineArgs {
     ref_fields: Vec<jit_interp::RefFieldEntry>,
     native_int_binops: Vec<(Path, Ident)>,
     native_tag_small: Vec<Path>,
+    struct_allocs: Vec<(Path, Path)>,
+    headerless_structs: Vec<Path>,
 }
 
 impl Parse for JitInlineArgs {
@@ -43,6 +45,8 @@ impl Parse for JitInlineArgs {
         let mut ref_fields: Vec<jit_interp::RefFieldEntry> = Vec::new();
         let mut native_int_binops: Vec<(Path, Ident)> = Vec::new();
         let mut native_tag_small: Vec<Path> = Vec::new();
+        let mut struct_allocs: Vec<(Path, Path)> = Vec::new();
+        let mut headerless_structs: Vec<Path> = Vec::new();
         while !input.is_empty() {
             let key: Ident = input.parse()?;
             input.parse::<Token![=]>()?;
@@ -101,6 +105,12 @@ impl Parse for JitInlineArgs {
                 "native_tag_small" => {
                     native_tag_small = jit_interp::parse_native_tag_small_list(input)?;
                 }
+                "struct_allocs" => {
+                    struct_allocs = jit_interp::parse_call_returns_map(input)?;
+                }
+                "headerless_structs" => {
+                    headerless_structs = jit_interp::parse_path_set(input)?;
+                }
                 other => {
                     return Err(syn::Error::new(
                         key.span(),
@@ -116,6 +126,8 @@ impl Parse for JitInlineArgs {
             ref_fields,
             native_int_binops,
             native_tag_small,
+            struct_allocs,
+            headerless_structs,
         })
     }
 }
@@ -124,6 +136,7 @@ fn rewrite_jit_inline_ref_param_fields(
     block: &syn::Block,
     ref_params: &[(Ident, Path)],
     ref_fields: &[jit_interp::RefFieldEntry],
+    struct_allocs: &[(Path, Path)],
 ) -> syn::Block {
     use std::collections::HashMap;
     use syn::visit_mut::VisitMut;
@@ -131,6 +144,7 @@ fn rewrite_jit_inline_ref_param_fields(
     struct InlineRefFieldRewriter {
         local_ref_types: HashMap<String, syn::Path>,
         field_pointees: HashMap<String, syn::Path>,
+        struct_allocs: HashMap<Vec<String>, syn::Path>,
     }
 
     impl InlineRefFieldRewriter {
@@ -173,6 +187,31 @@ fn rewrite_jit_inline_ref_param_fields(
 
     impl VisitMut for InlineRefFieldRewriter {
         fn visit_stmt_mut(&mut self, stmt: &mut syn::Stmt) {
+            // Rewrite struct literal inits on the concrete path:
+            // `let x = StructType { f0: v0, f1: v1 }` where StructType is
+            // in `struct_allocs` → `let x = allocator_func(v0, v1)`. This
+            // must run before `record_ref_field_local`/the default visitor
+            // descend, so `x` stays a plain (non-ref) local bound to the
+            // allocator call's usize result rather than a ref-field local.
+            if let syn::Stmt::Local(local) = stmt {
+                if let Some(init) = &mut local.init {
+                    if let syn::Expr::Struct(s) = &*init.expr {
+                        let segs: Vec<String> = s
+                            .path
+                            .segments
+                            .iter()
+                            .map(|seg| seg.ident.to_string())
+                            .collect();
+                        if let Some(alloc_func) = self.struct_allocs.get(&segs).cloned() {
+                            let field_args: Vec<syn::Expr> =
+                                s.fields.iter().map(|f| f.expr.clone()).collect();
+                            init.expr = Box::new(syn::parse_quote! {
+                                #alloc_func(#(#field_args),*)
+                            });
+                        }
+                    }
+                }
+            }
             if let syn::Stmt::Local(local) = stmt {
                 self.record_ref_field_local(local);
             }
@@ -255,12 +294,24 @@ fn rewrite_jit_inline_ref_param_fields(
             )
         })
         .collect();
+    let struct_allocs_map: HashMap<Vec<String>, syn::Path> = struct_allocs
+        .iter()
+        .map(|(struct_path, alloc_func)| {
+            let segs: Vec<String> = struct_path
+                .segments
+                .iter()
+                .map(|s| s.ident.to_string())
+                .collect();
+            (segs, alloc_func.clone())
+        })
+        .collect();
     let mut rewriter = InlineRefFieldRewriter {
         local_ref_types: ref_params
             .iter()
             .map(|(name, struct_type)| (name.to_string(), struct_type.clone()))
             .collect(),
         field_pointees,
+        struct_allocs: struct_allocs_map,
     };
     let mut block = block.clone();
     if !rewriter.local_ref_types.is_empty() {
@@ -1987,6 +2038,7 @@ pub fn jit_inline(attr: TokenStream, item: TokenStream) -> TokenStream {
         &args.ref_fields,
         &args.native_int_binops,
         &args.native_tag_small,
+        &args.headerless_structs,
     ) {
         Ok(Some(lowered)) => lowered,
         Ok(None) => {
@@ -2003,8 +2055,12 @@ pub fn jit_inline(attr: TokenStream, item: TokenStream) -> TokenStream {
     let attrs = &func.attrs;
     let vis = &func.vis;
     let sig = &func.sig;
-    let block =
-        rewrite_jit_inline_ref_param_fields(&func.block, &args.ref_params, &args.ref_fields);
+    let block = rewrite_jit_inline_ref_param_fields(
+        &func.block,
+        &args.ref_params,
+        &args.ref_fields,
+        &args.struct_allocs,
+    );
     let helper_with_asm_name = format_ident!("__majit_inline_jitcode_{}_with_asm", sig.ident);
     let helper_prebuild_name = format_ident!("__majit_inline_jitcode_{}_prebuild", sig.ident);
     let policy_name = format_ident!("__majit_call_policy_{}", sig.ident);

--- a/majit/majit-macros/src/lib.rs
+++ b/majit/majit-macros/src/lib.rs
@@ -20,8 +20,8 @@
 use proc_macro::TokenStream;
 use quote::{format_ident, quote};
 use syn::{
-    FnArg, Ident, ItemFn, Path, ReturnType, Token, Type, parse::Parse, parse::ParseStream,
-    parse_macro_input,
+    FnArg, Ident, ItemFn, Path, ReturnType, Token, Type, parenthesized, parse::Parse,
+    parse::ParseStream, parse_macro_input,
 };
 
 mod jit_interp;
@@ -30,11 +30,15 @@ mod virtualizable;
 
 struct JitInlineArgs {
     calls: Vec<jit_interp::CallEntry>,
+    ref_params: Vec<(Ident, Path)>,
+    ref_fields: Vec<jit_interp::RefFieldEntry>,
 }
 
 impl Parse for JitInlineArgs {
     fn parse(input: ParseStream) -> syn::Result<Self> {
         let mut calls: Vec<jit_interp::CallEntry> = Vec::new();
+        let mut ref_params: Vec<(Ident, Path)> = Vec::new();
+        let mut ref_fields: Vec<jit_interp::RefFieldEntry> = Vec::new();
         while !input.is_empty() {
             let key: Ident = input.parse()?;
             input.parse::<Token![=]>()?;
@@ -60,6 +64,23 @@ impl Parse for JitInlineArgs {
                         let _ = content.parse::<Token![,]>();
                     }
                 }
+                "ref_params" => {
+                    let content;
+                    syn::braced!(content in input);
+                    while !content.is_empty() {
+                        let name: Ident = content.parse()?;
+                        content.parse::<Token![:]>()?;
+                        content.parse::<Token![ref]>()?;
+                        let inner;
+                        parenthesized!(inner in content);
+                        let struct_type: Path = inner.parse()?;
+                        ref_params.push((name, struct_type));
+                        let _ = content.parse::<Token![,]>();
+                    }
+                }
+                "ref_fields" => {
+                    ref_fields = jit_interp::parse_ref_fields_map(input)?;
+                }
                 "helpers" => {
                     let content;
                     syn::bracketed!(content in input);
@@ -79,8 +100,161 @@ impl Parse for JitInlineArgs {
             }
             let _ = input.parse::<Token![,]>();
         }
-        Ok(Self { calls })
+        Ok(Self {
+            calls,
+            ref_params,
+            ref_fields,
+        })
     }
+}
+
+fn rewrite_jit_inline_ref_param_fields(
+    block: &syn::Block,
+    ref_params: &[(Ident, Path)],
+    ref_fields: &[jit_interp::RefFieldEntry],
+) -> syn::Block {
+    use std::collections::HashMap;
+    use syn::visit_mut::VisitMut;
+
+    struct InlineRefFieldRewriter {
+        local_ref_types: HashMap<String, syn::Path>,
+        field_pointees: HashMap<String, syn::Path>,
+    }
+
+    impl InlineRefFieldRewriter {
+        fn local_ref_struct_of_base(&self, expr: &syn::Expr) -> Option<syn::Path> {
+            let syn::Expr::Path(path) = expr else {
+                return None;
+            };
+            let ident = path.path.get_ident()?;
+            self.local_ref_types.get(&ident.to_string()).cloned()
+        }
+
+        fn field_pointee(&self, struct_path: &syn::Path, field_name: &str) -> Option<syn::Path> {
+            let struct_last = struct_path.segments.last()?.ident.to_string();
+            let key = format!("{}::{}", struct_last, field_name);
+            self.field_pointees.get(&key).cloned()
+        }
+
+        fn record_ref_field_local(&mut self, local: &syn::Local) {
+            let Some(init) = &local.init else {
+                return;
+            };
+            let syn::Expr::Field(field) = &*init.expr else {
+                return;
+            };
+            let Some(struct_path) = self.local_ref_struct_of_base(&field.base) else {
+                return;
+            };
+            let syn::Member::Named(member) = &field.member else {
+                return;
+            };
+            let Some(pointee) = self.field_pointee(&struct_path, &member.to_string()) else {
+                return;
+            };
+            if let syn::Pat::Ident(pat_ident) = &local.pat {
+                self.local_ref_types
+                    .insert(pat_ident.ident.to_string(), pointee);
+            }
+        }
+    }
+
+    impl VisitMut for InlineRefFieldRewriter {
+        fn visit_stmt_mut(&mut self, stmt: &mut syn::Stmt) {
+            if let syn::Stmt::Local(local) = stmt {
+                self.record_ref_field_local(local);
+            }
+            syn::visit_mut::visit_stmt_mut(self, stmt);
+        }
+
+        fn visit_expr_mut(&mut self, expr: &mut syn::Expr) {
+            if let syn::Expr::Assign(assign) = expr {
+                if let syn::Expr::Field(lhs) = &*assign.left {
+                    if let Some(struct_path) = self.local_ref_struct_of_base(&lhs.base) {
+                        let base = (*lhs.base).clone();
+                        let member = lhs.member.clone();
+                        let member_name = match &lhs.member {
+                            syn::Member::Named(id) => id.to_string(),
+                            _ => String::new(),
+                        };
+                        let mut rhs = (*assign.right).clone();
+                        self.visit_expr_mut(&mut rhs);
+                        if let Some(pointee) = self.field_pointee(&struct_path, &member_name) {
+                            *expr = syn::parse_quote! {
+                                unsafe { (*(#base as *mut #struct_path)).#member = #rhs as *mut #pointee }
+                            };
+                        } else {
+                            *expr = syn::parse_quote! {
+                                unsafe { (*(#base as *mut #struct_path)).#member = #rhs }
+                            };
+                        }
+                        return;
+                    }
+                }
+            }
+
+            if let syn::Expr::Field(field) = expr {
+                if let Some(struct_path) = self.local_ref_struct_of_base(&field.base) {
+                    let base = (*field.base).clone();
+                    let member = field.member.clone();
+                    let member_name = match &field.member {
+                        syn::Member::Named(id) => id.to_string(),
+                        _ => String::new(),
+                    };
+                    if self.field_pointee(&struct_path, &member_name).is_some() {
+                        *expr = syn::parse_quote! {
+                            {
+                                let __majit_getfield_obj = #base;
+                                unsafe {
+                                    (*(__majit_getfield_obj as *const #struct_path)).#member as usize
+                                }
+                            }
+                        };
+                    } else {
+                        *expr = syn::parse_quote! {
+                            {
+                                let __majit_getfield_obj = #base;
+                                unsafe {
+                                    (*(__majit_getfield_obj as *const #struct_path)).#member
+                                }
+                            }
+                        };
+                    }
+                    return;
+                }
+            }
+
+            syn::visit_mut::visit_expr_mut(self, expr);
+        }
+    }
+
+    let field_pointees = ref_fields
+        .iter()
+        .map(|entry| {
+            let struct_last = entry
+                .struct_type
+                .segments
+                .last()
+                .map(|s| s.ident.to_string())
+                .unwrap_or_default();
+            (
+                format!("{}::{}", struct_last, entry.field),
+                entry.pointee_type.clone(),
+            )
+        })
+        .collect();
+    let mut rewriter = InlineRefFieldRewriter {
+        local_ref_types: ref_params
+            .iter()
+            .map(|(name, struct_type)| (name.to_string(), struct_type.clone()))
+            .collect(),
+        field_pointees,
+    };
+    let mut block = block.clone();
+    if !rewriter.local_ref_types.is_empty() {
+        rewriter.visit_block_mut(&mut block);
+    }
+    block
 }
 
 fn helper_policy_fn_name(path: &Path) -> syn::Result<Ident> {
@@ -1796,6 +1970,8 @@ pub fn jit_inline(attr: TokenStream, item: TokenStream) -> TokenStream {
     let helper = match jit_interp::jitcode_lower::generate_inline_helper_jitcode_with_calls(
         &func,
         &args.calls,
+        &args.ref_params,
+        &args.ref_fields,
     ) {
         Ok(Some(lowered)) => lowered,
         Ok(None) => {
@@ -1812,7 +1988,8 @@ pub fn jit_inline(attr: TokenStream, item: TokenStream) -> TokenStream {
     let attrs = &func.attrs;
     let vis = &func.vis;
     let sig = &func.sig;
-    let block = &func.block;
+    let block =
+        rewrite_jit_inline_ref_param_fields(&func.block, &args.ref_params, &args.ref_fields);
     let helper_with_asm_name = format_ident!("__majit_inline_jitcode_{}_with_asm", sig.ident);
     let helper_prebuild_name = format_ident!("__majit_inline_jitcode_{}_prebuild", sig.ident);
     let policy_name = format_ident!("__majit_call_policy_{}", sig.ident);

--- a/majit/majit-macros/src/lib.rs
+++ b/majit/majit-macros/src/lib.rs
@@ -32,6 +32,8 @@ struct JitInlineArgs {
     calls: Vec<jit_interp::CallEntry>,
     ref_params: Vec<(Ident, Path)>,
     ref_fields: Vec<jit_interp::RefFieldEntry>,
+    native_int_binops: Vec<(Path, Ident)>,
+    native_tag_small: Vec<Path>,
 }
 
 impl Parse for JitInlineArgs {
@@ -39,6 +41,8 @@ impl Parse for JitInlineArgs {
         let mut calls: Vec<jit_interp::CallEntry> = Vec::new();
         let mut ref_params: Vec<(Ident, Path)> = Vec::new();
         let mut ref_fields: Vec<jit_interp::RefFieldEntry> = Vec::new();
+        let mut native_int_binops: Vec<(Path, Ident)> = Vec::new();
+        let mut native_tag_small: Vec<Path> = Vec::new();
         while !input.is_empty() {
             let key: Ident = input.parse()?;
             input.parse::<Token![=]>()?;
@@ -91,6 +95,12 @@ impl Parse for JitInlineArgs {
                         policy: None,
                     }));
                 }
+                "native_int_binops" => {
+                    native_int_binops = jit_interp::parse_native_int_binops_map(input)?;
+                }
+                "native_tag_small" => {
+                    native_tag_small = jit_interp::parse_native_tag_small_list(input)?;
+                }
                 other => {
                     return Err(syn::Error::new(
                         key.span(),
@@ -104,6 +114,8 @@ impl Parse for JitInlineArgs {
             calls,
             ref_params,
             ref_fields,
+            native_int_binops,
+            native_tag_small,
         })
     }
 }
@@ -1973,6 +1985,8 @@ pub fn jit_inline(attr: TokenStream, item: TokenStream) -> TokenStream {
         &args.calls,
         &args.ref_params,
         &args.ref_fields,
+        &args.native_int_binops,
+        &args.native_tag_small,
     ) {
         Ok(Some(lowered)) => lowered,
         Ok(None) => {

--- a/majit/majit-macros/src/lib.rs
+++ b/majit/majit-macros/src/lib.rs
@@ -1957,10 +1957,11 @@ pub fn look_inside_iff(attr: TokenStream, item: TokenStream) -> TokenStream {
 /// This is the proc-macro side of RPython's `codewriter.py` helper serialization:
 /// the original function stays callable by the interpreter, and the macro also
 /// emits a hidden `__majit_inline_jitcode_*()` function that `#[jit_interp]`
-/// can use when a call policy maps the helper to `inline_int`/`inline_ref`/`inline_float`.
+/// can use when a call policy maps the helper to
+/// `inline_int`/`inline_ref`/`inline_float`/`inline_void`.
 ///
-/// Supports Int (i64/isize), Ref (usize/pointer), and Float (f64) return types
-/// and parameter types.
+/// Supports Int (i64/isize), Ref (usize/pointer), Float (f64), and void return
+/// types. Parameters must be Int, Ref, or Float.
 #[proc_macro_attribute]
 pub fn jit_inline(attr: TokenStream, item: TokenStream) -> TokenStream {
     use jit_interp::jitcode_lower::InlineReturnKind;
@@ -2000,6 +2001,7 @@ pub fn jit_inline(attr: TokenStream, item: TokenStream) -> TokenStream {
         InlineReturnKind::Int => quote! { __builder.int_return(#return_reg); },
         InlineReturnKind::Ref => quote! { __builder.ref_return(#return_reg); },
         InlineReturnKind::Float => quote! { __builder.float_return(#return_reg); },
+        InlineReturnKind::Void => quote! { __builder.void_return(); },
     };
 
     // RPython jtransform.py: rewrite_call() bakes the result kind into the
@@ -2008,13 +2010,15 @@ pub fn jit_inline(attr: TokenStream, item: TokenStream) -> TokenStream {
     // through explicit `inline_ref` / `inline_float` policies.
     let inferred_policy_code: u8 = match helper.return_kind {
         InlineReturnKind::Int => jit_interp::call_policy_byte::INT_INLINE,
-        InlineReturnKind::Ref | InlineReturnKind::Float => {
+        InlineReturnKind::Ref | InlineReturnKind::Float | InlineReturnKind::Void => {
             jit_interp::call_policy_byte::UNSUPPORTED
         }
     };
     let inferred_inline_builder = match helper.return_kind {
         InlineReturnKind::Int => quote! { #helper_with_asm_name as *const () },
-        InlineReturnKind::Ref | InlineReturnKind::Float => quote! { std::ptr::null() },
+        InlineReturnKind::Ref | InlineReturnKind::Float | InlineReturnKind::Void => {
+            quote! { std::ptr::null() }
+        }
     };
 
     // Ensure the right register file for each parameter
@@ -2054,7 +2058,7 @@ pub fn jit_inline(attr: TokenStream, item: TokenStream) -> TokenStream {
         // (`call.py:174-189`), so liveness offsets are always relative
         // to one shared table.
         #[doc(hidden)]
-        pub(crate) fn #helper_with_asm_name(
+        #vis fn #helper_with_asm_name(
             __asm: &mut majit_metainterp::Assembler,
         ) -> majit_metainterp::JitCode {
             let mut __builder = majit_metainterp::JitCodeBuilder::new();
@@ -2076,7 +2080,7 @@ pub fn jit_inline(attr: TokenStream, item: TokenStream) -> TokenStream {
         // `jitcode_lower::inline_prebuild_path`).
         #[allow(non_snake_case, unused_variables, unused_mut)]
         #[doc(hidden)]
-        pub(crate) fn #helper_prebuild_name(
+        #vis fn #helper_prebuild_name(
             __asm: &mut majit_metainterp::Assembler,
         ) {
             #helper_liveness_prebuild
@@ -2084,7 +2088,7 @@ pub fn jit_inline(attr: TokenStream, item: TokenStream) -> TokenStream {
 
         #[doc(hidden)]
         #[allow(non_snake_case)]
-        pub(crate) fn #policy_name() -> (u8, *const (), *const (), *const (), *const (), i32) {
+        #vis fn #policy_name() -> (u8, *const (), *const (), *const (), *const (), i32) {
             (
                 #inferred_policy_code,
                 #inferred_inline_builder,

--- a/majit/majit-metainterp/src/blackhole.rs
+++ b/majit/majit-metainterp/src/blackhole.rs
@@ -7060,13 +7060,34 @@ pub fn build_inline_call_only_bh_builder() -> BlackholeInterpBuilder {
     // a ref base); intbase (`id`/`iid`/`ird`) forms have no canonical byte
     // and are not emitted here.  Additive: every byte is currently unwired.
     for (key, byte) in [
-        ("getfield_gc_i/rd>i", majit_translate::insns::BC_GETFIELD_GC_I),
-        ("getfield_gc_r/rd>r", majit_translate::insns::BC_GETFIELD_GC_R),
-        ("getfield_gc_f/rd>f", majit_translate::insns::BC_GETFIELD_GC_F),
-        ("setfield_gc_i/rid", majit_translate::insns::BC_SETFIELD_GC_I),
-        ("setfield_gc_i/rcd", majit_translate::insns::BC_SETFIELD_GC_I_C),
-        ("setfield_gc_r/rrd", majit_translate::insns::BC_SETFIELD_GC_R),
-        ("setfield_gc_f/rfd", majit_translate::insns::BC_SETFIELD_GC_F),
+        (
+            "getfield_gc_i/rd>i",
+            majit_translate::insns::BC_GETFIELD_GC_I,
+        ),
+        (
+            "getfield_gc_r/rd>r",
+            majit_translate::insns::BC_GETFIELD_GC_R,
+        ),
+        (
+            "getfield_gc_f/rd>f",
+            majit_translate::insns::BC_GETFIELD_GC_F,
+        ),
+        (
+            "setfield_gc_i/rid",
+            majit_translate::insns::BC_SETFIELD_GC_I,
+        ),
+        (
+            "setfield_gc_i/rcd",
+            majit_translate::insns::BC_SETFIELD_GC_I_C,
+        ),
+        (
+            "setfield_gc_r/rrd",
+            majit_translate::insns::BC_SETFIELD_GC_R,
+        ),
+        (
+            "setfield_gc_f/rfd",
+            majit_translate::insns::BC_SETFIELD_GC_F,
+        ),
         (
             "getfield_gc_i_pure/rd>i",
             majit_translate::insns::BC_GETFIELD_GC_I_PURE,

--- a/majit/majit-metainterp/src/blackhole.rs
+++ b/majit/majit-metainterp/src/blackhole.rs
@@ -7044,6 +7044,11 @@ pub fn build_inline_call_only_bh_builder() -> BlackholeInterpBuilder {
         "abort_permanent/".to_string(),
         majit_translate::insns::BC_ABORT_PERMANENT,
     );
+    // blackhole.py:954-960 bhimpl_switch. `handler_switch` is wired in
+    // `wire_bhimpl_handlers` but the byte was absent from this builder's
+    // insns map, so a deopt through a `switch/id` op landed on the
+    // unwired-opcode placeholder. RPython's setup_insns binds every opname.
+    insns.insert("switch/id".to_string(), majit_translate::insns::BC_SWITCH);
     // Sub-slice C.3+C.4 (`subslice_c_register_width_axis_plan_2026_05_07.md`):
     // residual_call family — `JitCodeBuilder::emit_canonical_call_void` /
     // `emit_canonical_call_typed` (assembler.rs:1688, 1923) emit each

--- a/majit/majit-metainterp/src/blackhole.rs
+++ b/majit/majit-metainterp/src/blackhole.rs
@@ -7049,6 +7049,39 @@ pub fn build_inline_call_only_bh_builder() -> BlackholeInterpBuilder {
     // insns map, so a deopt through a `switch/id` op landed on the
     // unwired-opcode placeholder. RPython's setup_insns binds every opname.
     insns.insert("switch/id".to_string(), majit_translate::insns::BC_SWITCH);
+    // GC heap field load/store — `blackhole.py:1432-1481 bhimpl_
+    // {get,set}field_gc_{i,r,f}`.  `handler_{get,set}field_gc_*` are wired
+    // in `wire_bhimpl_handlers` and the canonical bytes exist in
+    // `wellknown_bh_insns`, but the whole family was absent from this
+    // builder's insns map — so a deopt replaying a struct field access
+    // (e.g. an aheui Stack/Queue `size` store, `setfield_gc_i/rid` =
+    // BC_SETFIELD_GC_I 0xac) landed on the unwired-opcode placeholder.
+    // Canonical `rd`/`r{i,r,f}d` argcodes only (aheui accesses fields off
+    // a ref base); intbase (`id`/`iid`/`ird`) forms have no canonical byte
+    // and are not emitted here.  Additive: every byte is currently unwired.
+    for (key, byte) in [
+        ("getfield_gc_i/rd>i", majit_translate::insns::BC_GETFIELD_GC_I),
+        ("getfield_gc_r/rd>r", majit_translate::insns::BC_GETFIELD_GC_R),
+        ("getfield_gc_f/rd>f", majit_translate::insns::BC_GETFIELD_GC_F),
+        ("setfield_gc_i/rid", majit_translate::insns::BC_SETFIELD_GC_I),
+        ("setfield_gc_i/rcd", majit_translate::insns::BC_SETFIELD_GC_I_C),
+        ("setfield_gc_r/rrd", majit_translate::insns::BC_SETFIELD_GC_R),
+        ("setfield_gc_f/rfd", majit_translate::insns::BC_SETFIELD_GC_F),
+        (
+            "getfield_gc_i_pure/rd>i",
+            majit_translate::insns::BC_GETFIELD_GC_I_PURE,
+        ),
+        (
+            "getfield_gc_r_pure/rd>r",
+            majit_translate::insns::BC_GETFIELD_GC_R_PURE,
+        ),
+        (
+            "getfield_gc_f_pure/rd>f",
+            majit_translate::insns::BC_GETFIELD_GC_F_PURE,
+        ),
+    ] {
+        insns.insert(key.to_string(), byte);
+    }
     // Sub-slice C.3+C.4 (`subslice_c_register_width_axis_plan_2026_05_07.md`):
     // residual_call family — `JitCodeBuilder::emit_canonical_call_void` /
     // `emit_canonical_call_typed` (assembler.rs:1688, 1923) emit each

--- a/majit/majit-metainterp/src/lib.rs
+++ b/majit/majit-metainterp/src/lib.rs
@@ -41,6 +41,26 @@ extern crate self as majit_metainterp;
 
 use majit_ir::{OpRef, Type};
 
+/// Runtime surrogate for RPython's lltype `STRUCT` identity.
+///
+/// Descriptor caches are process-global, so this only needs to be stable for
+/// the lifetime of this process. Rust's `TypeId` is exactly that identity and
+/// is independent of whether callers spell the type with an absolute or a
+/// relative module path. Keep GC-managed and raw layouts distinct, matching
+/// RPython's distinct `GcStruct(T)` / `Struct(T)` lltypes.
+#[doc(hidden)]
+pub fn __pyre_struct_type_id<T: 'static>(is_gc_managed: bool) -> u64 {
+    use std::any::TypeId;
+    use std::hash::{Hash, Hasher};
+
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    TypeId::of::<T>().hash(&mut hasher);
+    if !is_gc_managed {
+        "raw".hash(&mut hasher);
+    }
+    hasher.finish()
+}
+
 pub mod blackhole;
 pub mod box_trace;
 pub(crate) mod call_descr;

--- a/majit/majit-metainterp/src/optimizeopt/heap.rs
+++ b/majit/majit-metainterp/src/optimizeopt/heap.rs
@@ -47,6 +47,22 @@ use crate::optimizeopt::info::PtrInfoExt;
 use crate::optimizeopt::{OptContext, Optimization, OptimizationResult};
 use majit_ir::operand::Operand;
 
+fn same_ptr_info(ctx: &OptContext, left: OpRef, right: OpRef) -> bool {
+    let left_box = ctx.get_box_replacement_operand_opt(left);
+    let right_box = ctx.get_box_replacement_operand_opt(right);
+    match (
+        left_box.as_ref().and_then(|b| ctx.getptrinfo_handle(b)),
+        right_box.as_ref().and_then(|b| ctx.getptrinfo_handle(b)),
+    ) {
+        // heap.py possible_aliasing_two_infos: opinfo1.same_info(opinfo2).
+        (Some(left_info), Some(right_info)) => left_info.same_info(&right_info),
+        // Both normal callers install PtrInfo via ensure_ptr_info_arg0 before
+        // reaching this path. Keep synthetic tests conservative without adding
+        // a parallel store.
+        _ => ctx.same_box(left, right),
+    }
+}
+
 #[inline]
 fn make_nonnull_box(ctx: &mut OptContext, arg: &Operand) {
     if let Some(box_ref) = ctx.resolve_operand_operand_opt(arg) {
@@ -151,13 +167,9 @@ impl CachedField {
     /// heap.py:59-65 AbstractCachedEntry.possible_aliasing
     ///
     /// `not info.getptrinfo(self._lazy_set.getarg(0)).same_info(opinfo)`.
-    /// For Ref operands `same_info` is box identity (two distinct Live
-    /// structs hold distinct PtrInfo objects, so `is` ⟺ same terminal box)
-    /// plus ConstPtrInfo value comparison (info.py:774-777) — exactly
-    /// `same_box` on the struct boxes.
     fn possible_aliasing(&self, struct_opref: OpRef, ctx: &OptContext) -> bool {
         match &self.lazy_set {
-            Some(lazy_op) => !ctx.same_box(lazy_op.arg(0).to_opref(), struct_opref),
+            Some(lazy_op) => !same_ptr_info(ctx, lazy_op.arg(0).to_opref(), struct_opref),
             None => false,
         }
     }
@@ -255,7 +267,7 @@ impl CachedField {
         ctx: &mut OptContext,
     ) -> Option<crate::optimizeopt::info::FieldEntry> {
         if let Some(lazy_op) = &self.lazy_set {
-            if ctx.get_replacement_opref(lazy_op.arg(0).to_opref()) == struct_opref {
+            if same_ptr_info(ctx, lazy_op.arg(0).to_opref(), struct_opref) {
                 let rhs = Self::_get_rhs_from_set_op(lazy_op);
                 return Some(crate::optimizeopt::info::FieldEntry::Value(
                     ctx.materialize_operand_at(rhs),
@@ -443,11 +455,10 @@ impl ArrayCachedItem {
 
     /// heap.py:59-65 AbstractCachedEntry.possible_aliasing
     ///
-    /// `not info.getptrinfo(self._lazy_set.getarg(0)).same_info(opinfo)`;
-    /// for Ref operands `same_info` ⟺ `same_box` on the array boxes.
+    /// `not info.getptrinfo(self._lazy_set.getarg(0)).same_info(opinfo)`.
     fn possible_aliasing(&self, array_opref: OpRef, ctx: &OptContext) -> bool {
         match &self.lazy_set {
-            Some(lazy_op) => !ctx.same_box(lazy_op.arg(0).to_opref(), array_opref),
+            Some(lazy_op) => !same_ptr_info(ctx, lazy_op.arg(0).to_opref(), array_opref),
             None => false,
         }
     }
@@ -592,7 +603,7 @@ impl ArrayCachedItem {
         ctx: &mut OptContext,
     ) -> Option<crate::optimizeopt::info::FieldEntry> {
         if let Some(lazy_op) = &self.lazy_set {
-            if ctx.get_replacement_opref(lazy_op.arg(0).to_opref()) == array_opref {
+            if same_ptr_info(ctx, lazy_op.arg(0).to_opref(), array_opref) {
                 let rhs = Self::_get_rhs_from_set_op(lazy_op);
                 return Some(crate::optimizeopt::info::FieldEntry::Value(
                     ctx.materialize_operand_at(rhs),
@@ -2091,9 +2102,9 @@ impl OptHeap {
         if let Some(cf) = self.get_cached_field(&descr) {
             if let Some(lazy_op) = &cf.lazy_set {
                 let lazy_struct = lazy_op.arg(0).to_opref();
-                // heap.py:69 possible_aliasing_two_infos: opinfo1.same_info(opinfo2)
-                //   → MUST_ALIAS. For Ref operands same_info ⟺ same_box.
-                if ctx.same_box(lazy_struct, obj) {
+                // heap.py:69 possible_aliasing_two_infos:
+                // opinfo1.same_info(opinfo2) → MUST_ALIAS.
+                if same_ptr_info(ctx, lazy_struct, obj) {
                     // MUST_ALIAS: lazy_set targets the same struct → return rhs
                     let cached = lazy_op.arg(1).to_opref();
                     let b_old = Operand::from_bound_op(op_rc);
@@ -2672,9 +2683,9 @@ impl OptHeap {
             {
                 if let Some(lazy_op) = &cai.lazy_set {
                     let lazy_struct = lazy_op.arg(0).to_opref();
-                    // heap.py:69 possible_aliasing_two_infos: same_info → MUST_ALIAS.
-                    // For Ref operands same_info ⟺ same_box.
-                    if ctx.same_box(lazy_struct, array) {
+                    // heap.py:69 possible_aliasing_two_infos:
+                    // opinfo1.same_info(opinfo2) → MUST_ALIAS.
+                    if same_ptr_info(ctx, lazy_struct, array) {
                         // MUST_ALIAS: lazy_set targets the same array → return rhs
                         let cached = lazy_op.arg(2).to_opref();
                         let b_old = Operand::from_bound_op(op_rc);

--- a/majit/majit-metainterp/src/pyjitpl/dispatch.rs
+++ b/majit/majit-metainterp/src/pyjitpl/dispatch.rs
@@ -1809,7 +1809,11 @@ where
         sym: &mut S,
     ) -> TraceAction {
         let exc = crate::blackhole::BH_LAST_EXC_VALUE.with(|c| c.get());
-        let resume_pc = self.frames.current_mut().pc;
+        // `code_cursor` is post-call and points at this CALL_ASSEMBLER's
+        // trailing `-live-` marker. `MIFrame::pc` is only the saved resume
+        // position and stays 0 in an inline sub-frame, so do not use it for
+        // this after-residual-call snapshot.
+        let resume_pc = self.frames.current_mut().code_cursor;
 
         if exc == 0 {
             self.record_state_guard(

--- a/majit/majit-metainterp/src/pyjitpl/dispatch.rs
+++ b/majit/majit-metainterp/src/pyjitpl/dispatch.rs
@@ -1091,6 +1091,13 @@ where
             // marker that `get_list_of_active_boxes` (frame.rs:628) reads.
             // The snapshot's liveness decode REQUIRES this to be a JitCode
             // PC; using an interpreter PC underflows `pc - SIZE_LIVE_OP`.
+            // For an `after_residual_call` guard
+            // (`finish_residual_call_exception_path`) `resume_pc` is instead
+            // the post-call `code_cursor` itself: it already points AT that
+            // residual call's trailing LIVE marker, so the snapshot reads it
+            // directly (frame.rs:846-849) WITHOUT the `- SIZE_LIVE_OP`
+            // step-back. `MIFrame::pc` (the saved resume position) stays 0 in
+            // an inline sub-frame, so it must not be used here.
             self.frames.frames[top_idx].pc = resume_pc;
             // RPython only swaps the top frame pc before
             // `capture_resumedata`; it never writes portal state into an
@@ -1748,10 +1755,11 @@ where
         // GUARD_ALWAYS_FAILS) `after_residual_call=True` so the snapshot
         // walks `frame.pc` directly instead of stepping back to the
         // preceding LIVE marker (frame.rs:626-630 / pyjitpl.py:194-198).
-        // `resumepc=-1` (the default for these guards) keeps `frame.pc`
-        // unchanged — pyre's current `frame.pc` is already past the
-        // residual_call's bytecode operands.
-        let resume_pc = self.frames.current_mut().pc;
+        // `next_u*()` advances `code_cursor`; unlike RPython's single `pc`,
+        // `MIFrame::pc` is only the saved resume position.  Capture the
+        // post-call bytecode cursor so the snapshot reads the trailing
+        // `-live-` marker for this residual call.
+        let resume_pc = self.frames.current_mut().code_cursor;
 
         if exc == 0 {
             self.record_state_guard(

--- a/majit/majit-metainterp/src/pyjitpl/dispatch.rs
+++ b/majit/majit-metainterp/src/pyjitpl/dispatch.rs
@@ -1028,6 +1028,21 @@ where
         resume_pc: usize,
         after_residual_call: bool,
     ) -> OpRef {
+        // pyjitpl.py:2582-2584 generate_guard parity:
+        //     if isinstance(box, Const):    # no need for a guard
+        //         return
+        // The first arg of every DATA guard (GuardTrue/False, GuardValue,
+        // GuardClass, ...) is the box being checked; box-less guards pass
+        // args=&[] (gate is a no-op). GuardException is the extraarg-only guard
+        // (RPython records it with box=None) -- its args[0] is the exception-class
+        // Const, not a checked box, so the gate must NOT apply to it.
+        if opcode != OpCode::GuardException {
+            if let Some(&first) = args.first() {
+                if first.is_constant() {
+                    return first;
+                }
+            }
+        }
         if let Some(fail_args) = sym.fail_args_with_ctx(ctx) {
             let fail_types = sym.fail_args_types();
             // slice 3a: snapshot is the source of truth — the
@@ -9015,6 +9030,148 @@ mod tests {
         );
     }
 
+    #[test]
+    fn goto_if_not_const_condition_records_no_guard_and_takes_branch() {
+        let mut builder = JitCodeBuilder::new();
+        let target = builder.new_label();
+        builder.load_const_i_value(0, 0);
+        builder.goto_if_not_int_is_true(0, target);
+        builder.load_const_i_value(1, 10);
+        builder.int_return(1);
+        builder.mark_label(target);
+        builder.load_const_i_value(1, 20);
+        builder.int_return(1);
+        let jitcode = builder.finish();
+
+        let mut ctx = TraceCtx::for_test(0);
+        let mut sym = DummySym;
+        let action = trace_jitcode(&mut ctx, &mut sym, &jitcode, 0, |_pc| 0);
+        let finish_args = match action {
+            TraceAction::Finish {
+                finish_args,
+                exit_with_exception: false,
+                ..
+            } => finish_args,
+            other => panic!("expected const false goto_if_not to finish via target, got {other:?}"),
+        };
+        assert_eq!(ctx.const_value(finish_args[0]), Some(20));
+
+        let recorder = ctx.into_recorder();
+        assert_eq!(
+            recorder.num_ops(),
+            0,
+            "Const GuardFalse/GuardTrue must be skipped at record_state_guard",
+        );
+    }
+
+    #[test]
+    fn int_guard_value_const_register_records_no_guard_and_returns_const() {
+        let mut builder = JitCodeBuilder::new();
+        builder.load_const_i_value(0, 42);
+        builder.int_guard_value(0);
+        builder.int_return(0);
+        let jitcode = builder.finish();
+
+        let mut ctx = TraceCtx::for_test(0);
+        let mut sym = DummySym;
+        let action = trace_jitcode(&mut ctx, &mut sym, &jitcode, 0, |_pc| 0);
+        let finish_args = match action {
+            TraceAction::Finish {
+                finish_args,
+                exit_with_exception: false,
+                ..
+            } => finish_args,
+            other => panic!("expected int_guard_value const path to finish, got {other:?}"),
+        };
+        assert_eq!(ctx.const_value(finish_args[0]), Some(42));
+
+        let recorder = ctx.into_recorder();
+        assert_eq!(
+            recorder.num_ops(),
+            0,
+            "Const GuardValue must be skipped at record_state_guard",
+        );
+    }
+
+    #[test]
+    fn guard_exception_const_exception_class_still_records_guard_and_snapshot() {
+        struct SnapshotSym;
+        impl JitCodeSym for SnapshotSym {
+            fn total_slots(&self) -> usize {
+                1
+            }
+            fn loop_header_pc(&self) -> usize {
+                0
+            }
+            fn fail_args(&self) -> Option<Vec<OpRef>> {
+                Some(vec![OpRef::int_op(50)])
+            }
+            fn populate_frame_int_regs(&self, frame: &mut MIFrame) {
+                frame.int_regs[0] = Some(OpRef::int_op(50));
+                frame.int_values[0] = Some(500);
+            }
+        }
+
+        let mut asm = majit_translate::codewriter::assembler::Assembler::new();
+        let mut builder = JitCodeBuilder::new();
+        builder.load_const_i_value(0, 0);
+        let live_pc = builder.current_pos();
+        builder.live(&mut asm, &[0], &[], &[]);
+        let jitcode = std::sync::Arc::new(builder.finish());
+        let frame = MIFrame::new(jitcode, live_pc);
+        let mut stack = MIFrameStack::empty();
+        stack.frames.push(frame);
+
+        let mut staticdata = crate::MetaInterpStaticData::new();
+        staticdata.op_live = crate::jitcode::insns::BC_LIVE as i32;
+        staticdata.liveness_info = asm.all_liveness().to_vec();
+        let recorder = crate::recorder::Trace::new();
+        let mut ctx = TraceCtx::new(recorder, 0, std::sync::Arc::new(staticdata));
+        let mut sym = SnapshotSym;
+        let exc_class = ctx.const_int(0xc1a55);
+        let mut machine =
+            JitCodeMachine::<SnapshotSym, ClosureRuntime<fn(usize) -> usize>>::with_framestack(
+                &mut stack,
+                &[],
+                &[],
+            );
+        let guard_op = machine.record_state_guard(
+            &mut ctx,
+            &mut sym,
+            OpCode::GuardException,
+            &[exc_class],
+            live_pc,
+            /* after_residual_call */ true,
+        );
+        assert!(!guard_op.is_constant());
+
+        let snapshots = ctx.snapshots().to_vec();
+        assert_eq!(
+            snapshots.len(),
+            1,
+            "GuardException must still capture resumedata despite Const exc class",
+        );
+        assert_eq!(snapshots[0].frames.len(), 1);
+
+        let recorder = ctx.into_recorder();
+        let guards: Vec<_> = recorder
+            .ops()
+            .iter()
+            .filter(|op| op.opcode.is_guard())
+            .collect();
+        assert_eq!(
+            guards.len(),
+            1,
+            "only the GuardException should be recorded"
+        );
+        assert_eq!(guards[0].opcode, OpCode::GuardException);
+        assert_eq!(
+            guards[0].rd_resume_position.get(),
+            0,
+            "GuardException should carry the captured snapshot id",
+        );
+    }
+
     // ── canonical residual_call_*_{i,r,f} may_force tests ──
     //
     // The legacy non-Pure walker arms
@@ -9392,20 +9549,29 @@ mod tests {
         caller.mark_label(handler);
         caller.last_exc_value(0);
         caller.ref_guard_value(0);
+        caller.ref_return(0);
         let jitcode = caller.finish();
 
         let mut ctx = TraceCtx::for_test(0);
         let mut sym = DummySym::default();
         let action = trace_jitcode(&mut ctx, &mut sym, &jitcode, 0, |_pc| 0);
-        assert!(matches!(action, TraceAction::Continue));
+        let finish_args = match action {
+            TraceAction::Finish {
+                finish_args,
+                exit_with_exception: false,
+                ..
+            } => finish_args,
+            other => panic!("expected handler to return last_exc_value, got {other:?}"),
+        };
+        assert_eq!(ctx.const_value(finish_args[0]), Some(exc_raw));
 
         let recorder = ctx.into_recorder();
         assert!(
-            recorder
+            !recorder
                 .ops()
                 .iter()
                 .any(|op| op.opcode == OpCode::GuardValue),
-            "handler must see last_exc_value and be able to promote it",
+            "Const last_exc_value promotion must skip GuardValue",
         );
     }
 
@@ -9426,20 +9592,29 @@ mod tests {
         caller.mark_label(handler);
         caller.last_exception(0);
         caller.int_guard_value(0);
+        caller.int_return(0);
         let jitcode = caller.finish();
 
         let mut ctx = TraceCtx::for_test(0);
         let mut sym = DummySym::default();
         let action = trace_jitcode(&mut ctx, &mut sym, &jitcode, 0, |_pc| 0);
-        assert!(matches!(action, TraceAction::Continue));
+        let finish_args = match action {
+            TraceAction::Finish {
+                finish_args,
+                exit_with_exception: false,
+                ..
+            } => finish_args,
+            other => panic!("expected handler to return last_exception, got {other:?}"),
+        };
+        assert_eq!(ctx.const_value(finish_args[0]), Some(0xc1a55));
 
         let recorder = ctx.into_recorder();
         assert!(
-            recorder
+            !recorder
                 .ops()
                 .iter()
                 .any(|op| op.opcode == OpCode::GuardValue),
-            "handler must see last_exception and be able to promote it",
+            "Const last_exception promotion must skip GuardValue",
         );
     }
 

--- a/majit/majit-metainterp/src/warmstate.rs
+++ b/majit/majit-metainterp/src/warmstate.rs
@@ -543,7 +543,14 @@ impl WarmEnterState {
             if cell.is_compiled() || cell.is_tracing() {
                 return true;
             }
-            if cell.flags & jc_flags::DONT_TRACE_HERE != 0 && cell.has_seen_a_procedure_token() {
+            // A JC_DONT_TRACE_HERE cell declines here, except when the
+            // procedure token it once saw has since been invalidated: that
+            // dead entry must fall through to cleanup_chain (warmstate.py:483-491)
+            // instead of returning early and lingering in the chain.
+            if cell.flags & jc_flags::DONT_TRACE_HERE != 0
+                && cell.has_seen_a_procedure_token()
+                && cell.get_procedure_token().is_some()
+            {
                 return false;
             }
             if cell.has_seen_a_procedure_token() && cell.get_procedure_token().is_none() {
@@ -580,10 +587,15 @@ impl WarmEnterState {
             ) {
                 return self.start_tracing_cell(green_key_hash);
             }
-            if flags & jc_flags::DONT_TRACE_HERE != 0 {
+            // A JC_DONT_TRACE_HERE cell declines here, except when it once saw a
+            // procedure token that has since been invalidated — that dead entry
+            // must fall through to cleanup_chain below (warmstate.py:483-491),
+            // not linger and stall the counter re-arm.
+            let dead_token = has_seen_a_procedure_token && !has_procedure_token;
+            if flags & jc_flags::DONT_TRACE_HERE != 0 && !dead_token {
                 return HotResult::NotHot;
             }
-            if has_seen_a_procedure_token && !has_procedure_token {
+            if dead_token {
                 cleanup_dead_token_cell = true;
             }
         }
@@ -644,10 +656,15 @@ impl WarmEnterState {
             if self.should_start_dont_trace_here_trace(hash, flags, has_seen_a_procedure_token) {
                 return self.start_tracing_cell_for_key(key);
             }
-            if flags & jc_flags::DONT_TRACE_HERE != 0 {
+            // A JC_DONT_TRACE_HERE cell declines here, except when it once saw a
+            // procedure token that has since been invalidated — that dead entry
+            // must fall through to cleanup_chain below (warmstate.py:483-491),
+            // not linger and stall the counter re-arm.
+            let dead_token = has_seen_a_procedure_token && !has_procedure_token;
+            if flags & jc_flags::DONT_TRACE_HERE != 0 && !dead_token {
                 return HotResult::NotHot;
             }
-            if has_seen_a_procedure_token && !has_procedure_token {
+            if dead_token {
                 cleanup_dead_token_cell = true;
             }
         }
@@ -1395,9 +1412,14 @@ impl WarmEnterState {
             }
             if cell.flags & jc_flags::DONT_TRACE_HERE != 0 {
                 if cell.has_seen_a_procedure_token() {
-                    return false;
-                }
-                if cell.flags & jc_flags::TRACING_OCCURRED == 0 {
+                    // A live TEMPORARY token still declines; a token that was
+                    // once seen but has since been invalidated falls through to
+                    // the cleanup gate below (warmstate.py:483-491) rather than
+                    // re-entering the never-traced retry.
+                    if cell.get_procedure_token().is_some() {
+                        return false;
+                    }
+                } else if cell.flags & jc_flags::TRACING_OCCURRED == 0 {
                     return true;
                 }
             }

--- a/majit/majit-metainterp/tests/jit_interp_inline_helper_typed_return.rs
+++ b/majit/majit-metainterp/tests/jit_interp_inline_helper_typed_return.rs
@@ -81,6 +81,29 @@ fn inline_typed_stack_pop_caller(stack: usize) -> i64 {
     inline_typed_stack_pop(stack)
 }
 
+#[jit_inline(
+    ref_params = {
+        stack: ref(InlineTypedStack),
+    },
+    ref_fields = {
+        InlineTypedStack::head => InlineTypedNode,
+        InlineTypedNode::next => InlineTypedNode,
+    },
+)]
+fn inline_typed_stack_swap(stack: usize) {
+    let node1 = stack.head;
+    let node2 = node1.next;
+    let v1 = node1.value;
+    let v2 = node2.value;
+    node1.value = v2;
+    node2.value = v1;
+}
+
+#[jit_inline(calls = { inline_typed_stack_swap => inline_void })]
+fn inline_typed_stack_swap_caller(stack: usize) {
+    inline_typed_stack_swap(stack);
+}
+
 #[dont_look_inside]
 fn wrapped_ref_identity(ptr: *const i64) -> *const i64 {
     ptr
@@ -300,6 +323,131 @@ fn jit_inline_ref_param_field_access_lowers_to_native_field_ops() {
         "inline_call should write stack.head to the next node"
     );
     assert_eq!(stack.size, 1, "inline_call should decrement stack.size");
+}
+
+#[test]
+fn jit_inline_void_ref_param_field_swap_lowers_to_native_field_ops() {
+    let insns = majit_metainterp::jitcode::wellknown_bh_insns();
+    let getfield_i = *insns.get("getfield_gc_i/rd>i").unwrap();
+    let getfield_r = *insns.get("getfield_gc_r/rd>r").unwrap();
+    let setfield_i = *insns.get("setfield_gc_i/rid").unwrap();
+    let inline_call = majit_metainterp::jitcode::insns::BC_INLINE_CALL;
+    let void_return = majit_metainterp::jitcode::insns::BC_VOID_RETURN;
+    let residual_calls = [
+        majit_metainterp::jitcode::insns::BC_RESIDUAL_CALL_R_V,
+        majit_metainterp::jitcode::insns::BC_RESIDUAL_CALL_IR_V,
+        majit_metainterp::jitcode::insns::BC_RESIDUAL_CALL_IRF_V,
+        majit_metainterp::jitcode::insns::BC_RESIDUAL_CALL_R_I,
+        majit_metainterp::jitcode::insns::BC_RESIDUAL_CALL_IR_I,
+        majit_metainterp::jitcode::insns::BC_RESIDUAL_CALL_IRF_I,
+        majit_metainterp::jitcode::insns::BC_RESIDUAL_CALL_R_R,
+        majit_metainterp::jitcode::insns::BC_RESIDUAL_CALL_IR_R,
+        majit_metainterp::jitcode::insns::BC_RESIDUAL_CALL_IRF_R,
+        majit_metainterp::jitcode::insns::BC_RESIDUAL_CALL_IRF_F,
+    ];
+
+    let mut asm = majit_metainterp::Assembler::new();
+    let helper = __majit_inline_jitcode_inline_typed_stack_swap_with_asm(&mut asm);
+    assert_eq!(
+        helper.code.last().copied(),
+        Some(void_return),
+        "void helper should end in BC_VOID_RETURN; code={:?}",
+        helper.code
+    );
+    assert_eq!(
+        helper.trailing_return_info(),
+        None,
+        "BC_VOID_RETURN helpers have no typed trailing return info"
+    );
+    assert!(
+        helper.code.contains(&getfield_r),
+        "typed void helper must read ref fields with getfield_gc_r; code={:?}",
+        helper.code
+    );
+    assert!(
+        helper.code.contains(&getfield_i),
+        "typed void helper must read int fields with getfield_gc_i; code={:?}",
+        helper.code
+    );
+    assert!(
+        helper.code.contains(&setfield_i),
+        "typed void helper must write int fields with setfield_gc_i; code={:?}",
+        helper.code
+    );
+    assert!(
+        residual_calls
+            .iter()
+            .all(|opcode| !helper.code.contains(opcode)),
+        "typed void helper must not fall back to residual calls; code={:?}",
+        helper.code
+    );
+
+    let caller = __majit_inline_jitcode_inline_typed_stack_swap_caller_with_asm(&mut asm);
+    assert!(
+        caller.code.contains(&inline_call),
+        "void caller helper should splice the typed helper through inline_call; code={:?}",
+        caller.code
+    );
+    assert!(
+        residual_calls
+            .iter()
+            .all(|opcode| !caller.code.contains(opcode)),
+        "void caller helper must not use a residual call for inline_typed_stack_swap; code={:?}",
+        caller.code
+    );
+
+    let mut second = InlineTypedNode {
+        value: 22,
+        next: std::ptr::null_mut(),
+    };
+    let mut first = InlineTypedNode {
+        value: 11,
+        next: &mut second,
+    };
+    let mut stack = InlineTypedStack {
+        head: &mut first,
+        size: 2,
+    };
+
+    let mut top = majit_metainterp::JitCodeBuilder::new();
+    let sub_idx = top.add_sub_jitcode(caller);
+    top.inline_call_r_v(sub_idx, &[(0, 0)], None);
+    let top = top.finish();
+
+    let mut bh_insns: indexmap::IndexMap<String, u8> =
+        majit_metainterp::jitcode::wellknown_bh_insns()
+            .iter()
+            .map(|(key, value)| ((*key).to_string(), *value))
+            .collect();
+    bh_insns.extend(
+        majit_metainterp::jitcode::pyre_extension_insns()
+            .iter()
+            .map(|(key, value)| ((*key).to_string(), *value)),
+    );
+    let mut bh_builder = majit_metainterp::blackhole::build_inline_call_only_bh_builder();
+    bh_builder.setup_insns(&bh_insns);
+    bh_builder.setup_cached_control_opcodes(
+        majit_metainterp::jitcode::insns::BC_LIVE as i32,
+        majit_metainterp::jitcode::insns::BC_CATCH_EXCEPTION as i32,
+        majit_metainterp::jitcode::insns::BC_RVMPROF_CODE as i32,
+    );
+    majit_metainterp::blackhole::wire_bhimpl_handlers(&mut bh_builder);
+    let mut bh = bh_builder.acquire_interp();
+    bh.setposition(std::sync::Arc::new(top), 0);
+    bh.registers_r[0] = (&mut stack as *mut InlineTypedStack) as i64;
+    let _ = bh.run();
+
+    assert_eq!(
+        unsafe { (*stack.head).value },
+        22,
+        "inline void helper should swap head"
+    );
+    assert_eq!(
+        unsafe { (*(*stack.head).next).value },
+        11,
+        "inline void helper should swap second node"
+    );
+    assert_eq!(stack.size, 2, "swap should leave stack size unchanged");
 }
 
 #[test]

--- a/majit/majit-metainterp/tests/jit_interp_inline_helper_typed_return.rs
+++ b/majit/majit-metainterp/tests/jit_interp_inline_helper_typed_return.rs
@@ -46,6 +46,41 @@ fn inline_mixed_int_identity(_ptr: usize, value: i64, _scale: f64) -> i64 {
     value
 }
 
+#[repr(C)]
+struct InlineTypedStack {
+    head: *mut InlineTypedNode,
+    size: usize,
+}
+
+#[repr(C)]
+struct InlineTypedNode {
+    value: i64,
+    next: *mut InlineTypedNode,
+}
+
+#[jit_inline(
+    ref_params = {
+        stack: ref(InlineTypedStack),
+    },
+    ref_fields = {
+        InlineTypedStack::head => InlineTypedNode,
+        InlineTypedNode::next => InlineTypedNode,
+    },
+)]
+fn inline_typed_stack_pop(stack: usize) -> i64 {
+    let head = stack.head;
+    let value = head.value;
+    let next = head.next;
+    stack.head = next;
+    stack.size = stack.size - 1usize;
+    value
+}
+
+#[jit_inline(calls = { inline_typed_stack_pop => inline_int })]
+fn inline_typed_stack_pop_caller(stack: usize) -> i64 {
+    inline_typed_stack_pop(stack)
+}
+
 #[dont_look_inside]
 fn wrapped_ref_identity(ptr: *const i64) -> *const i64 {
     ptr
@@ -157,6 +192,114 @@ fn jit_inline_mixed_identity_generates_dense_per_kind_jitcode() {
         majit_metainterp::JitArgKind::Int,
         0,
     );
+}
+
+#[test]
+fn jit_inline_ref_param_field_access_lowers_to_native_field_ops() {
+    let insns = majit_metainterp::jitcode::wellknown_bh_insns();
+    let getfield_i = *insns.get("getfield_gc_i/rd>i").unwrap();
+    let getfield_r = *insns.get("getfield_gc_r/rd>r").unwrap();
+    let setfield_i = *insns.get("setfield_gc_i/rid").unwrap();
+    let setfield_r = *insns.get("setfield_gc_r/rrd").unwrap();
+    let inline_call = majit_metainterp::jitcode::insns::BC_INLINE_CALL;
+    let residual_call_r_i = majit_metainterp::jitcode::insns::BC_RESIDUAL_CALL_R_I;
+    let residual_call_ir_i = majit_metainterp::jitcode::insns::BC_RESIDUAL_CALL_IR_I;
+    let residual_call_irf_i = majit_metainterp::jitcode::insns::BC_RESIDUAL_CALL_IRF_I;
+
+    let mut asm = majit_metainterp::Assembler::new();
+    let helper = __majit_inline_jitcode_inline_typed_stack_pop_with_asm(&mut asm);
+    assert!(
+        helper.code.contains(&getfield_r),
+        "typed ref-param helper must read ref fields with getfield_gc_r; code={:?}",
+        helper.code
+    );
+    assert!(
+        helper.code.contains(&getfield_i),
+        "typed ref-param helper must read int fields with getfield_gc_i; code={:?}",
+        helper.code
+    );
+    assert!(
+        helper.code.contains(&setfield_r),
+        "typed ref-param helper must write ref fields with setfield_gc_r; code={:?}",
+        helper.code
+    );
+    assert!(
+        helper.code.contains(&setfield_i),
+        "typed ref-param helper must write int fields with setfield_gc_i; code={:?}",
+        helper.code
+    );
+    assert!(
+        !helper.code.contains(&residual_call_r_i)
+            && !helper.code.contains(&residual_call_ir_i)
+            && !helper.code.contains(&residual_call_irf_i),
+        "typed field helper must not fall back to residual int calls; code={:?}",
+        helper.code
+    );
+
+    let caller = __majit_inline_jitcode_inline_typed_stack_pop_caller_with_asm(&mut asm);
+    assert!(
+        caller.code.contains(&inline_call),
+        "caller helper should splice the typed helper through inline_call; code={:?}",
+        caller.code
+    );
+    assert!(
+        !caller.code.contains(&residual_call_r_i)
+            && !caller.code.contains(&residual_call_ir_i)
+            && !caller.code.contains(&residual_call_irf_i),
+        "caller helper must not use a residual call for inline_typed_stack_pop; code={:?}",
+        caller.code
+    );
+
+    let mut second = InlineTypedNode {
+        value: 22,
+        next: std::ptr::null_mut(),
+    };
+    let mut first = InlineTypedNode {
+        value: 11,
+        next: &mut second,
+    };
+    let mut stack = InlineTypedStack {
+        head: &mut first,
+        size: 2,
+    };
+
+    let mut top = majit_metainterp::JitCodeBuilder::new();
+    let sub_idx = top.add_sub_jitcode(caller);
+    top.inline_call_r_i(sub_idx, &[(0, 0)], Some(0));
+    let top = top.finish();
+
+    let mut bh_insns: indexmap::IndexMap<String, u8> =
+        majit_metainterp::jitcode::wellknown_bh_insns()
+            .iter()
+            .map(|(key, value)| ((*key).to_string(), *value))
+            .collect();
+    bh_insns.extend(
+        majit_metainterp::jitcode::pyre_extension_insns()
+            .iter()
+            .map(|(key, value)| ((*key).to_string(), *value)),
+    );
+    let mut bh_builder = majit_metainterp::blackhole::build_inline_call_only_bh_builder();
+    bh_builder.setup_insns(&bh_insns);
+    bh_builder.setup_cached_control_opcodes(
+        majit_metainterp::jitcode::insns::BC_LIVE as i32,
+        majit_metainterp::jitcode::insns::BC_CATCH_EXCEPTION as i32,
+        majit_metainterp::jitcode::insns::BC_RVMPROF_CODE as i32,
+    );
+    majit_metainterp::blackhole::wire_bhimpl_handlers(&mut bh_builder);
+    let mut bh = bh_builder.acquire_interp();
+    bh.setposition(std::sync::Arc::new(top), 0);
+    bh.registers_r[0] = (&mut stack as *mut InlineTypedStack) as i64;
+    let _ = bh.run();
+
+    assert_eq!(
+        bh.registers_i[0], 11,
+        "inline_call should return head.value"
+    );
+    assert!(
+        std::ptr::eq(stack.head as *const InlineTypedNode, &second),
+        "inline_call should write stack.head to the next node"
+    );
+    assert_eq!(stack.size, 1, "inline_call should decrement stack.size");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

aheui single-walker JIT work: the `#[jit_inline]` `inline_void` storage-op
lowering epic, a few record-time optimizer refinements, and three
compiled-path deopt/correctness fixes surfaced while driving the aheui
corpus at low `MAJIT_THRESHOLD`.

11 commits on top of `main`.

### `#[jit_inline]` inline_void epic
- `majit-macros`: add the `inline_void` call policy; key struct descriptors
  by `TypeId`; thread ref-param struct typing; accept
  `struct_allocs`/`headerless_structs`; accept
  `native_tag_small`/`native_int_binops`; import `JitCodeRuntimeExt` in the
  InlineInt value-call arm.
- Lets aheui's storage-op helpers (stack/queue mutators) lower as tracked
  native trace ops instead of residual calls.

### Record-time optimizer refinements
- Compare cached-field aliasing by `same_info` rather than box identity.
- Skip `Const`-box data guards at record time in `record_state_guard`.

### warmstate
- `cleanup_chain` no longer invalidates `DONT_TRACE_HERE` cells that have
  already seen a token.

### Compiled-path deopt / correctness fixes
Three independent bugs that only manifested when driving the aheui corpus
at artificially low `MAJIT_THRESHOLD` (deopt-heavy); default threshold was
unaffected:
- **SizeDescr use-after-free** — `register_keyed_size` freed a cached
  `SizeDescr` still referenced by a baked `GetfieldGc`; retire the
  superseded descr into a keepalive instead (restores the immortal
  canonical-SizeDescr invariant).
- **`build_inline_call_only_bh_builder` missing `switch/id`** — the
  production deopt builder's insns map omitted `switch/id`, so a guard-fail
  deopt through a `switch` op landed on the unwired-opcode placeholder and
  panicked. Handler was already wired; only the byte binding was missing.
- **`build_inline_call_only_bh_builder` missing the GC-field family** —
  same class as `switch/id`: the whole `getfield_gc`/`setfield_gc` family
  was absent from the builder's insns map, so a deopt replaying a struct
  field access (e.g. an aheui Stack/Queue `size` store,
  `setfield_gc_i/rid` = `BC_SETFIELD_GC_I` 0xac) hit the placeholder and
  panicked. Add the canonical `rd`/`r{i,r,f}d` + `_pure` ref-base argcodes;
  handlers were already wired in `wire_bhimpl_handlers`.

## Verification
- `pyre/check.py --backend dynasm`: **225/225 PASS**.
- `majit-metainterp` blackhole unit tests: 62 pass, including the
  `unwired_opnames().is_empty()` completeness oracle over
  `build_inline_call_only_bh_builder`.
- aheui byte-id corpus (logo / 99dan / 99bottles) unchanged at
  `MAJIT_THRESHOLD` = 5 / 20 / 40 / default.
- The `0xac` unwired-opcode panic is eliminated on the integer/32bit/64bit
  programs at every threshold; those programs are `jit == naive` and clean
  at the default threshold.

> A separate, deeper pre-existing bug is now exposed underneath the deopt
> fixes at artificial low-mid thresholds only (`frame.rs:887`
> `get_list_of_active_snapshot_boxes: int register uninitialized`, in the
> bignum guard-resume snapshot path). It is not in the blackhole dispatch
> layer and is out of scope for this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for typed reference parameters and native field operations in inline helpers.
  * Added void-returning inline helpers and `inline_void` call handling.
  * Improved support for generic and headerless struct layouts.
* **Bug Fixes**
  * Improved cache stability during incremental layout updates.
  * Corrected guard handling, exception resume behavior, heap alias checks, and tracing cleanup.
  * Expanded opcode coverage for inline execution paths.
* **Tests**
  * Added coverage for typed inline helper returns, void helpers, field operations, and runtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->