### PR TITLE
pyre-jit-trace: guard rhs class and NI in dunder inline

### DIFF
--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -15409,6 +15409,7 @@ fn try_walker_inline_user_call(
         nparams,
         has_closure,
         None,
+        None,
         false,
         false,
     )
@@ -15446,6 +15447,7 @@ fn try_walker_inline_resolved_user_call(
     nparams: usize,
     has_closure: bool,
     exception_receiver_guard: Option<ExceptionInlineReceiverGuard>,
+    arg_class_guard: Option<(OpRef, i64)>,
     allow_method_load_attr: bool,
     require_str_result: bool,
 ) -> Result<Option<(DispatchOutcome, usize)>, DispatchError> {
@@ -15677,6 +15679,9 @@ fn try_walker_inline_resolved_user_call(
             w_class,
             version_tag,
         )?;
+    }
+    if let Some((arg, w_class)) = arg_class_guard {
+        walker_guard_class(ctx, op.pc, arg, w_class)?;
     }
 
     let callable_expected = ctx
@@ -16588,6 +16593,7 @@ fn try_walker_inline_exception_string_override(
         nparams,
         has_closure,
         Some((r_args[2], concrete_receiver, w_class, version_tag)),
+        None,
         true,
         true,
     )?
@@ -16706,6 +16712,7 @@ fn try_walker_inline_user_binop(
         nparams,
         has_closure,
         Some((lhs, concrete_lhs, w_class, version_tag)),
+        Some((rhs, w_typ_r as i64)),
         false,
         false,
     )?
@@ -16721,6 +16728,15 @@ fn try_walker_inline_user_binop(
                 if std::ptr::eq(obj, pyre_object::special::w_not_implemented())
         ) {
             return Err(DispatchError::LoopBearingCalleeInlineUnsupported { pc: op.pc });
+        }
+        if !result.is_constant() {
+            let not_implemented = ctx
+                .trace_ctx
+                .const_ref(pyre_object::special::w_not_implemented() as i64);
+            let is_not_implemented = ctx
+                .trace_ctx
+                .record_op(OpCode::PtrEq, &[result, not_implemented]);
+            walker_emit_guard_with_snapshot(ctx, op.pc, OpCode::GuardFalse, &[is_not_implemented])?;
         }
     }
     Ok(Some(inlined))
@@ -16832,6 +16848,7 @@ fn try_walker_inline_user_compareop(
         nparams,
         has_closure,
         Some((lhs, concrete_lhs, w_class, version_tag)),
+        Some((rhs, w_typ_r as i64)),
         false,
         false,
     )?
@@ -16847,6 +16864,15 @@ fn try_walker_inline_user_compareop(
                 if std::ptr::eq(obj, pyre_object::special::w_not_implemented())
         ) {
             return Err(DispatchError::LoopBearingCalleeInlineUnsupported { pc: op.pc });
+        }
+        if !result.is_constant() {
+            let not_implemented = ctx
+                .trace_ctx
+                .const_ref(pyre_object::special::w_not_implemented() as i64);
+            let is_not_implemented = ctx
+                .trace_ctx
+                .record_op(OpCode::PtrEq, &[result, not_implemented]);
+            walker_emit_guard_with_snapshot(ctx, op.pc, OpCode::GuardFalse, &[is_not_implemented])?;
         }
     }
     Ok(Some(inlined))


### PR DESCRIPTION
Follow-up to #642. The speculative user-dunder inline ("HOOK A") at a declined
`BINARY_OP` / `COMPARE_OP` guarded only the lhs class + version tag, leaving two
soundness gaps (the P1 review findings on #642):

1. **rhs type unguarded** — a later entry whose rhs is a proper subclass of the
   lhs class defining the reflected op runs the recorded forward dunder instead
   of the reflected one (reachable for bodies that ignore `other`, e.g.
   `def __add__(self, other): return 7`).
2. **inlined result not guarded against `NotImplemented`** — a non-constant
   inlined result that becomes the `NotImplemented` singleton at replay leaks it
   as the operator result instead of the interpreter's reflected/`TypeError`
   fallback (e.g. `def __add__(self, other): return other` with an NI rhs).

## Fix

- Emit a `GuardClass` on the rhs pinned to the record-time rhs type, placed
  **before** the inlined body (a guard after the body would re-run side effects
  on deopt). Threaded through `try_walker_inline_resolved_user_call` as a new
  `arg_class_guard` parameter; binop/compareop pass the rhs, the other two
  callers pass `None`.
- Emit a runtime `NotImplemented`-identity `GuardFalse` on non-constant inlined
  results (constant results are decided at record time and skip the guard).

## Verification

- `p1_ni_v6` / `p1_rhs_v4` targeted repros: JIT == interpreter, both backends.
- `check.py`: dynasm 225/225, cranelift 225/225.
- Adversarial differential fuzz (multi-agent, 6 lenses × both backends): NI-result
  channels, reflected-dunder priority, side-effect/deopt double-execution (798
  differential comparisons with an anti-masking oracle that verifies the forward
  dunder runs exactly once), class/version-tag mutation, and broad all-ops — no
  miscompile attributable to this change. The rhs guard folds away when the rhs
  is a constant, so `exception_value_op_caught` stays at its inlined speed.

— *commented by Claude*
