### PR TITLE
jit: root trace-time exception carriers and raise-cause across GC safepoints

### DIFF
--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -2922,6 +2922,15 @@ impl OpcodeStepExecutor for PyFrame {
                 let w_value = self.pop();
                 unsafe {
                     if crate::baseobjspace::exception_is_valid_obj_as_class_w(w_value) {
+                        // Root the normalized `cause` across the class
+                        // instantiation: it is a fresh oldgen exception held only
+                        // in this Rust local, invisible to the precise collector
+                        // until `attach_raise_cause` reads it, and `call_function`
+                        // below can drive a collection.
+                        let _roots = pyre_object::gc_roots::push_roots();
+                        if let Some(c) = cause {
+                            pyre_object::gc_roots::pin_root(c);
+                        }
                         // pyopcode.py:711-713 — class raise: call the type.
                         let result = crate::call_function(w_value, &[]);
                         if pyre_object::is_exception(result) {

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -85,6 +85,73 @@ pub fn walk_walk_end_propagated_exception(visitor: &mut dyn FnMut(&mut majit_ir:
     });
 }
 
+thread_local! {
+    /// Raw pointer to the `PyreSym` being traced on this thread, or null when no
+    /// trace is in flight. Lets [`walk_active_sym_exc_roots`] reach the
+    /// trace-time exception carriers (`trace_built_exc` / `last_exc_value` /
+    /// `current_exc_value`) during a collection triggered mid-trace. Set at
+    /// [`trace_bytecode`] entry, restored on return.
+    static ACTIVE_SYM_EXC: std::cell::Cell<*mut PyreSym> =
+        const { std::cell::Cell::new(std::ptr::null_mut()) };
+}
+
+/// RAII guard restoring the previous [`ACTIVE_SYM_EXC`] on drop, so nested /
+/// re-entrant `trace_bytecode` (recursive portal) unwinds to the outer trace's
+/// sym rather than leaving a stale or null anchor.
+pub(crate) struct ActiveSymExcGuard {
+    prev: *mut PyreSym,
+}
+
+impl Drop for ActiveSymExcGuard {
+    fn drop(&mut self) {
+        ACTIVE_SYM_EXC.with(|c| c.set(self.prev));
+    }
+}
+
+/// Publish `sym` as the active trace's exception-carrier anchor for the lifetime
+/// of the returned guard. Called once at [`trace_bytecode`] entry.
+pub(crate) fn set_active_sym_exc(sym: *mut PyreSym) -> ActiveSymExcGuard {
+    let prev = ACTIVE_SYM_EXC.with(|c| c.replace(sym));
+    ActiveSymExcGuard { prev }
+}
+
+/// Root the trace-time exception carriers held in the active `PyreSym`.
+///
+/// Between construction (`trace_built_exc.insert`, `trace_opcode.rs`) and
+/// lift-out (`swap_remove` at the raise), a trace-built exception is reachable
+/// only through `sym.trace_built_exc`, invisible to the precise collector; an
+/// allocating safepoint in that window would otherwise sweep it. `last_exc_value`
+/// / `current_exc_value` cover the seeded-raise and reraise paths.
+///
+/// Mirrors `walk_jit_exc_value`: the carriers are oldgen-stable exceptions
+/// (`try_gc_alloc_stable_raw`), so a bare mark-by-value suffices — no forwarded
+/// write-back — which means only a shared read of the sym is taken, never a
+/// second `&mut` aliasing the tracer's live borrow.
+pub fn walk_active_sym_exc_roots(visitor: &mut dyn FnMut(&mut majit_ir::GcRef)) {
+    let sym_ptr = ACTIVE_SYM_EXC.with(|c| c.get());
+    if sym_ptr.is_null() {
+        return;
+    }
+    // SAFETY: a collection triggered mid-trace runs on the SAME thread (the
+    // allocating thread becomes the collector), so the tracer's `&mut PyreSym`
+    // up the stack is a suspended frame. Only a shared `&PyreSym` is formed and
+    // oldgen-stable (non-moving) exceptions are marked by value, never writing a
+    // forwarded pointer back — matching the accepted `jit_driver_pair_from_root_area`
+    // convention in `pyre-jit`.
+    let sym = unsafe { &*sym_ptr };
+    let mut mark = |p: pyre_object::PyObjectRef| {
+        if !p.is_null() {
+            let mut gcref = majit_ir::GcRef(p as usize);
+            visitor(&mut gcref);
+        }
+    };
+    mark(sym.last_exc_value);
+    mark(sym.current_exc_value);
+    for exc in sym.trace_built_exc.values() {
+        mark(*exc);
+    }
+}
+
 pub fn take_walk_end_restart_pc() -> Option<usize> {
     WALK_END_RESTART_PC.with(|c| c.replace(None))
 }
@@ -524,6 +591,13 @@ pub fn trace_bytecode(
     // Likewise drop any cross-frame-resume abort request a prior aborted
     // trace left unconsumed.
     let _ = crate::state::take_trace_abort_requested();
+
+    // Publish this trace's `sym` as the exception-carrier root anchor: a
+    // collection triggered by an allocating traced opcode marks the trace-built
+    // exception held only in `sym.trace_built_exc` (and the seeded/caught
+    // `last_exc_value` / `current_exc_value`). The guard restores the prior
+    // anchor on every return path, including panics and nested tracing.
+    let _active_sym_guard = set_active_sym_exc(&mut *sym as *mut PyreSym);
 
     let ctx = meta
         .trace_ctx()

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -9761,6 +9761,14 @@ impl OpcodeStepExecutor for MIFrame {
             // each iteration instead of folding the trace-time heap
             // address into a `const_ref`.
             if pyre_interpreter::baseobjspace::exception_is_valid_obj_as_class_w(exc) {
+                // Root the normalized `cause` across the class instantiation: it
+                // is a fresh oldgen exception held only in this Rust local,
+                // invisible to the precise collector until `attach_raise_cause`
+                // reads it, and the `call_function` below can drive a collection.
+                let _roots = pyre_object::gc_roots::push_roots();
+                if let Some(c) = cause {
+                    pyre_object::gc_roots::pin_root(c);
+                }
                 // Mirror `normalize_raise_value` (pyopcode.py:707/:713): the
                 // trace-time constructor call must stay on the plain
                 // interpreter path so it does not re-enter the tracer.

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -2623,6 +2623,13 @@ fn install_gc_root_walkers() {
     majit_gc::shadow_stack::register_extra_root_walker(
         pyre_jit_trace::trace::walk_walk_end_propagated_exception,
     );
+    // Trace-time exception carriers held only in the active `PyreSym`
+    // (`trace_built_exc` / `last_exc_value` / `current_exc_value`): a
+    // trace-built exception is unreachable to the precise collector between its
+    // construction and the RAISE_VARARGS lift-out.
+    majit_gc::shadow_stack::register_extra_root_walker(
+        pyre_jit_trace::trace::walk_active_sym_exc_roots,
+    );
 }
 
 fn register_thread_root_areas() {

--- a/pyre/pyre-jit/tests/gc_stress.rs
+++ b/pyre/pyre-jit/tests/gc_stress.rs
@@ -505,3 +505,80 @@ assert result == 21, result
         "weak_subclasses gc stress program failed",
     );
 }
+
+/// A trace-built exception raised with a bare-class `from` cause survives a
+/// collection that fires while the fresh exception lives only in the tracer's
+/// `sym.trace_built_exc` (window A). `raise ValueError(n) from KeyError` builds
+/// the `ValueError(n)` instance at trace time and parks it in `trace_built_exc`;
+/// the `KeyError` cause normalization then allocates (a GC safepoint) before the
+/// instance is lifted back out at the raise. The `walk_active_sym_exc_roots`
+/// root walker keeps the parked instance alive across that collection — without
+/// it the caught exception's `args` are read from a swept block (wrong value or
+/// fault). Under `MAJIT_GC_STRESS` every allocation forces a full collection, so
+/// the cause normalization deterministically hits the window.
+#[test]
+fn trace_built_exc_from_class_cause_survives_collection() {
+    const PROGRAM: &str = r#"
+import gc
+
+def run():
+    total = 0
+    n = 0
+    while n < 300:
+        junk = [0] * 16
+        try:
+            raise ValueError(n) from KeyError
+        except ValueError as e:
+            total = total + e.args[0]
+        gc.collect()
+        n = n + 1
+    return total
+
+result = run()
+assert result == 44850, result
+"#;
+    run_on_worker(
+        PROGRAM,
+        "<trace_built_exc_from_class_cause_gc_stress>",
+        "trace-built exception window-A survival check",
+        "trace-built exc from-class-cause gc stress program failed",
+    );
+}
+
+/// A bare-class exception raised with a bare-class `from` cause exercises window
+/// B: the normalized cause (`RuntimeError`) lives only in a Rust local across the
+/// class-exception instantiation (`call_function(ValueError, &[])`), a GC
+/// safepoint, before `attach_raise_cause` reads it. The `push_roots` /
+/// `pin_root(cause)` bracket keeps the cause alive so `__cause__` is a live
+/// `RuntimeError`; without it that read is against a swept block. Under
+/// `MAJIT_GC_STRESS` the instantiation deterministically collects inside the
+/// window.
+#[test]
+fn class_exc_from_class_cause_keeps_cause_across_collection() {
+    const PROGRAM: &str = r#"
+import gc
+
+def run():
+    ok = 0
+    n = 0
+    while n < 300:
+        junk = [0] * 16
+        try:
+            raise ValueError from RuntimeError
+        except ValueError as e:
+            if type(e.__cause__) is RuntimeError:
+                ok = ok + 1
+        gc.collect()
+        n = n + 1
+    return ok
+
+result = run()
+assert result == 300, result
+"#;
+    run_on_worker(
+        PROGRAM,
+        "<class_exc_from_class_cause_gc_stress>",
+        "trace-built exception window-B cause survival check",
+        "class-exc from-class-cause gc stress program failed",
+    );
+}


### PR DESCRIPTION
Successor to #644 (exception GC-rooting epic). Roots two exception carriers the precise collector could not reach across a trace-time GC safepoint.

## Window A — trace-built exception
A trace-built exception is held only in `PyreSym.trace_built_exc` between its construction in the tracer and the `RAISE_VARARGS` lift-out; no other root reaches it. An allocating traced opcode in that window (e.g. the class-cause normalization) could sweep it. Register `walk_active_sym_exc_roots` as an extra GC root walker over the active sym's `trace_built_exc` / `last_exc_value` / `current_exc_value`, anchored to the traced sym for the duration of `trace_bytecode` via a save/restore guard. It marks the oldgen-stable exceptions by value, mirroring `walk_jit_exc_value`. Self-contained in `pyre-jit-trace` (the generic metainterp layer has no `pyre` dependency).

## Window B — normalized `from` cause
The normalized cause of `raise <Class> from <Class>` is held only in a Rust local across the class-exception instantiation `call_function(exc, &[])`, a GC safepoint, before `attach_raise_cause` reads it. Bracket that call with `push_roots` / `pin_root(cause)` in **both** the tracer `raise_varargs` and the interpreter `raise_varargs` argc==2 class paths (a shared latent).

## Tests
Two `gc_stress` fixtures raising `ValueError(n) from KeyError` (window A) and `ValueError from RuntimeError` (window B) in a traced loop.

## Verification
- `check.py` dynasm 225/225
- `gc_stress` 8/8 (6 existing + 2 new) in normal mode and under `MAJIT_GC_STRESS=1` (forced full collection before every allocation)
- Both raise-from loops compile (`loops_compiled=1`), so the trace-time window genuinely opens
- Build + `cargo fmt` clean; wasm/cranelift covered by CI (the fix is backend-independent trace-time code)

🤖 Generated with [Claude Code](https://claude.com/claude-code)