### PR TITLE
jit: exempt list_write_barrier from the FOR_ITER body-effect gate (#389 item b) + wasm codegen fixes

### DIFF
--- a/majit/majit-backend-wasm/src/codegen.rs
+++ b/majit/majit-backend-wasm/src/codegen.rs
@@ -4443,6 +4443,14 @@ fn emit_resolve(
             .inline_const_bits()
             .unwrap_or_else(|| constants.get(&opref.raw()).copied().unwrap_or(0));
         sink.i64_const(val);
+    } else if opref.is_none() {
+        // A `NONE` fail-arg is a dead deopt slot: the optimizer numbered no
+        // value for it, so the blackhole never reads it back (its resume data
+        // carries the live values). Spill a zero placeholder — matching the
+        // native backends, whose deadframe slot for an unmapped fail-arg is
+        // never consumed. Resolving it as a local would index `value_types`
+        // out of bounds (`raw() == u32::MAX`).
+        sink.i64_const(0);
     } else {
         sink.local_get(1 + opref.raw());
         if value_types[opref.raw() as usize] == ValType::F64 {

--- a/majit/majit-backend-wasm/src/lib.rs
+++ b/majit/majit-backend-wasm/src/lib.rs
@@ -1044,6 +1044,36 @@ impl WasmBackend {
 
 unsafe impl Send for WasmBackend {}
 
+/// Stamp a position onto every non-Void-result op left unpositioned by the
+/// optimizer, so no operand resolves to `OpRef::NONE` during codegen.
+///
+/// The optimizer's force path emits materialized allocation/store ops (e.g. a
+/// virtualized list's `NewArray` backing block and its `SetfieldGc` /
+/// `SetarrayitemGc` stores) with `Op::new`, and only assigns a position to ops
+/// whose `result_type() != Void` — a Void-result store keeps `pos == NONE`.
+/// A later op that consumes such a producer's result reads its `pos` through
+/// `Operand::Op`, and an unpositioned producer yields `OpRef::NONE`
+/// (`raw() == u32::MAX`), which `emit_resolve` would use to index `value_types`
+/// out of bounds. The native backends normalize positions before codegen
+/// (dynasm `prepare_ops_for_compile`, cranelift `normalize_ops_for_codegen_simple`);
+/// the wasm backend does the same here.
+fn normalize_ops_for_codegen(inputargs: &[InputArg], ops: &[OpRc]) -> Vec<Op> {
+    let num_inputs = inputargs.len() as u32;
+    ops.iter()
+        .enumerate()
+        .map(|(op_idx, op)| {
+            let normalized = (**op).clone();
+            let rt = normalized.result_type();
+            if rt != majit_ir::Type::Void && normalized.pos.get().is_none() {
+                normalized
+                    .pos
+                    .set(majit_ir::OpRef::op_typed(num_inputs + op_idx as u32, rt));
+            }
+            normalized
+        })
+        .collect()
+}
+
 /// Report why a trace cannot be compiled by the wasm backend, or `None` if it
 /// can. Declined traces fall back to the interpreter (correct, unaccelerated)
 /// instead of producing an invalid trace module. `is_loop` is true for
@@ -1493,7 +1523,7 @@ impl majit_backend::Backend for WasmBackend {
         if let Some(clt) = token.compiled_loop_token() {
             majit_backend::record_compiled_loop_token(&self.cpu_tracker, &clt);
         }
-        let ops_owned: Vec<Op> = ops.iter().map(|rc| (**rc).clone()).collect();
+        let ops_owned: Vec<Op> = normalize_ops_for_codegen(inputargs, ops);
         let ops: &[Op] = &ops_owned;
         // Freeze this token's generated frame layout before CA resolution.  A
         // self-recursive CALL_ASSEMBLER reaches this point while its token is
@@ -1871,7 +1901,7 @@ impl majit_backend::Backend for WasmBackend {
         // `build_function` reads its inputs (`inputargs[k].index == k`), so no
         // argument-recovery layout is needed — hence `caller_recovery_layout`
         // and `previous_tokens` are unused.
-        let ops_owned: Vec<Op> = ops.iter().map(|rc| (**rc).clone()).collect();
+        let ops_owned: Vec<Op> = normalize_ops_for_codegen(inputargs, ops);
         let ops: &[Op] = &ops_owned;
         diag_bump(0); // compile_bridge entered
 

--- a/majit/majit-metainterp/src/history.rs
+++ b/majit/majit-metainterp/src/history.rs
@@ -1019,6 +1019,23 @@ impl TreeLoop {
                         .collect(),
                     vable_boxes: snap.vable_boxes.iter().map(&remap_tagged).collect(),
                     vref_boxes: snap.vref_boxes.iter().map(&remap_tagged).collect(),
+                    // Extra virtual roots are raw OpRefs (not tagged): remap each
+                    // to the post-cut namespace, mirroring `remap_tagged`'s Box
+                    // arm — unmapped runtime OpRefs drop to NONE, constants/NONE
+                    // pass through.
+                    extra_virtual_roots: snap
+                        .extra_virtual_roots
+                        .iter()
+                        .map(|old_ref| {
+                            if let Some(&new_ref) = remap.get(old_ref) {
+                                new_ref
+                            } else if !Self::is_runtime_opref(*old_ref) {
+                                *old_ref
+                            } else {
+                                OpRef::NONE
+                            }
+                        })
+                        .collect(),
                 }
             })
             .collect();
@@ -2231,6 +2248,7 @@ impl TraceCtx {
             pc,
             &[],
             &[],
+            &[],
         );
     }
 
@@ -2256,6 +2274,7 @@ impl TraceCtx {
         pc: u32,
         vable_boxes: &[crate::recorder::SnapshotTagged],
         vref_boxes: &[crate::recorder::SnapshotTagged],
+        extra_virtual_roots: &[OpRef],
     ) {
         // The pc word is a raw JitCode offset.
         let boxes = self.encode_snapshot_boxes(active_boxes);
@@ -2267,6 +2286,7 @@ impl TraceCtx {
             }],
             vable_boxes: vable_boxes.to_vec(),
             vref_boxes: vref_boxes.to_vec(),
+            extra_virtual_roots: extra_virtual_roots.to_vec(),
         });
         self.set_last_guard_resume_position(snapshot_id);
     }
@@ -2293,6 +2313,7 @@ impl TraceCtx {
             }],
             vable_boxes: vable_boxes.to_vec(),
             vref_boxes: vref_boxes.to_vec(),
+            extra_virtual_roots: Vec::new(),
         });
         self.set_last_guard_op_resume_position(snapshot_id);
     }
@@ -2348,6 +2369,10 @@ impl TraceCtx {
             frames: recorder_frames,
             vable_boxes: vable_boxes.to_vec(),
             vref_boxes: vref_boxes.to_vec(),
+            // The nested-list append fold resumes through the single-frame
+            // collapse, never this multi-frame path, so no extra virtual roots
+            // flow here.
+            extra_virtual_roots: Vec::new(),
         });
         self.set_last_guard_resume_position(snapshot_id);
     }
@@ -2812,6 +2837,7 @@ impl TraceCtx {
             }],
             vable_boxes: Vec::new(),
             vref_boxes: Vec::new(),
+            extra_virtual_roots: Vec::new(),
         });
         let opref = self.record_guard(opcode, args, num_live);
         self.recorder.set_last_op_resume_position(snapshot_idx);

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -754,6 +754,12 @@ pub struct OptContext {
     /// resume.py:243-247 _number_boxes consumes vref_array as a section
     /// after vable_array. opencoder.py:767 records vref_boxes here.
     pub snapshot_vref_boxes: SnapshotBoxes,
+    /// Per-guard extra virtual roots (nested-list append fold's inner-list
+    /// wrapper) from tracing-time snapshots. Seeded into finish()'s virtual
+    /// worklist off the frame section. Empty except behind
+    /// `PYRE_NESTED_LIST_FOLD_VIRT`. Stored as `SnapshotBoxes` so they ride the
+    /// same unroll/bridge OpRef remap as the vable/vref sections.
+    pub snapshot_extra_virtual_roots: SnapshotBoxes,
     /// Per-guard per-frame (jitcode_index, pc) from tracing-time snapshots.
     pub snapshot_frame_pcs: SnapshotFramePcs,
     /// optimizer.py:34 `self.inputargs = inputargs` parity.
@@ -1691,6 +1697,7 @@ impl OptContext {
             snapshot_frame_sizes: Vec::new(),
             snapshot_vable_boxes: Vec::new(),
             snapshot_vref_boxes: Vec::new(),
+            snapshot_extra_virtual_roots: Vec::new(),
             snapshot_frame_pcs: Vec::new(),
 
             inputargs: Vec::new(),
@@ -2276,6 +2283,7 @@ impl OptContext {
             snapshot_frame_sizes: Vec::new(),
             snapshot_vable_boxes: Vec::new(),
             snapshot_vref_boxes: Vec::new(),
+            snapshot_extra_virtual_roots: Vec::new(),
             snapshot_frame_pcs: Vec::new(),
 
             inputargs: Vec::new(),
@@ -6332,10 +6340,26 @@ impl OptContext {
             return;
         };
 
+        // Extra virtual roots for this guard position — the nested-list append
+        // fold's inner-list wrapper, reachable only as a field of the outer
+        // virtual. Seeded into finish()'s virtual worklist off the frame section
+        // (empty except behind PYRE_NESTED_LIST_FOLD_VIRT). Stored as untyped
+        // SnapshotBoxes so they ride the same unroll/bridge OpRef remap as the
+        // vable/vref sections; finish() only reads their position OpRef.
+        let extra_virtual_roots: Vec<OpRef> =
+            snapshot_get(&self.snapshot_extra_virtual_roots, op.rd_resume_position.get())
+                .map(|boxes| boxes.iter().map(|b| b.opref()).collect())
+                .unwrap_or_default();
+
         // resume.py:428-445, 520-558: pending_setfields are passed to finish()
         // which handles register_box, visitor_walk_recursive, and tagging.
-        let (rd_numb, rd_consts, rd_virtuals, liveboxes, livebox_types) =
-            memo.finish(numb_state, &env, &mut pending_setfields, knowledge.as_ref());
+        let (rd_numb, rd_consts, rd_virtuals, liveboxes, livebox_types) = memo.finish(
+            numb_state,
+            &env,
+            &mut pending_setfields,
+            knowledge.as_ref(),
+            &extra_virtual_roots,
+        );
 
         if crate::callee_rca_enabled() {
             let vable_items = if rd_numb.len() >= 3 {

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -6346,10 +6346,12 @@ impl OptContext {
         // (empty except behind PYRE_NESTED_LIST_FOLD_VIRT). Stored as untyped
         // SnapshotBoxes so they ride the same unroll/bridge OpRef remap as the
         // vable/vref sections; finish() only reads their position OpRef.
-        let extra_virtual_roots: Vec<OpRef> =
-            snapshot_get(&self.snapshot_extra_virtual_roots, op.rd_resume_position.get())
-                .map(|boxes| boxes.iter().map(|b| b.opref()).collect())
-                .unwrap_or_default();
+        let extra_virtual_roots: Vec<OpRef> = snapshot_get(
+            &self.snapshot_extra_virtual_roots,
+            op.rd_resume_position.get(),
+        )
+        .map(|boxes| boxes.iter().map(|b| b.opref()).collect())
+        .unwrap_or_default();
 
         // resume.py:428-445, 520-558: pending_setfields are passed to finish()
         // which handles register_box, visitor_walk_recursive, and tagging.

--- a/majit/majit-metainterp/src/optimizeopt/optimizer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/optimizer.rs
@@ -438,6 +438,10 @@ pub struct Optimizer {
     /// section. opencoder.py:767 create_top_snapshot records vref_boxes
     /// alongside vable_boxes.
     pub snapshot_vref_boxes: SnapshotBoxes,
+    /// Per-guard extra virtual roots (nested-list append fold's inner-list
+    /// wrapper) from tracing-time snapshots. Empty except behind
+    /// `PYRE_NESTED_LIST_FOLD_VIRT`.
+    pub snapshot_extra_virtual_roots: SnapshotBoxes,
     /// Per-guard per-frame (jitcode_index, pc) from tracing-time snapshots.
     pub snapshot_frame_pcs: SnapshotFramePcs,
     /// Phase 1 emit ops carried into Phase 2's lookup surface (6).
@@ -1405,6 +1409,7 @@ impl Optimizer {
             snapshot_frame_sizes: Vec::new(),
             snapshot_vable_boxes: Vec::new(),
             snapshot_vref_boxes: Vec::new(),
+            snapshot_extra_virtual_roots: Vec::new(),
             snapshot_frame_pcs: Vec::new(),
             phase1_emit_ops: Vec::new(),
             opt_ops_emitted: 0,
@@ -2459,6 +2464,7 @@ impl Optimizer {
             .iter()
             .chain(self.snapshot_vable_boxes.iter())
             .chain(self.snapshot_vref_boxes.iter())
+            .chain(self.snapshot_extra_virtual_roots.iter())
             .flatten()
             .flat_map(|boxes| boxes.iter().map(|boxref| boxref.opref()))
             .filter(|opref| !opref.is_none() && !opref.is_constant())
@@ -2485,6 +2491,7 @@ impl Optimizer {
         ctx.snapshot_frame_sizes = std::mem::take(&mut self.snapshot_frame_sizes);
         ctx.snapshot_vable_boxes = std::mem::take(&mut self.snapshot_vable_boxes);
         ctx.snapshot_vref_boxes = std::mem::take(&mut self.snapshot_vref_boxes);
+        ctx.snapshot_extra_virtual_roots = std::mem::take(&mut self.snapshot_extra_virtual_roots);
         ctx.snapshot_frame_pcs = std::mem::take(&mut self.snapshot_frame_pcs);
 
         sanitize_backend_constants_for_ops(ops.iter().map(|op| &**op), constants);

--- a/majit/majit-metainterp/src/optimizeopt/unroll.rs
+++ b/majit/majit-metainterp/src/optimizeopt/unroll.rs
@@ -294,6 +294,10 @@ pub struct UnrollOptimizer {
     /// (resume.py:243-247 vref_array — _number_boxes consumes them
     /// after the virtualizable array).
     pub snapshot_vref_boxes: SnapshotBoxes,
+    /// Per-guard extra virtual roots (nested-list append fold's inner-list
+    /// wrapper) from tracing-time snapshots. Empty except behind
+    /// `PYRE_NESTED_LIST_FOLD_VIRT`.
+    pub snapshot_extra_virtual_roots: SnapshotBoxes,
     /// Per-guard per-frame (jitcode_index, pc) from tracing-time snapshots.
     pub snapshot_frame_pcs: SnapshotFramePcs,
     /// pyjitpl.py:2289 all_descrs: dense list indexed by descr_index.
@@ -384,6 +388,7 @@ impl UnrollOptimizer {
             snapshot_frame_sizes: Vec::new(),
             snapshot_vable_boxes: Vec::new(),
             snapshot_vref_boxes: Vec::new(),
+            snapshot_extra_virtual_roots: Vec::new(),
             snapshot_frame_pcs: Vec::new(),
             all_descrs: Vec::new(),
             quasi_immutable_deps: Vec::new(),
@@ -627,11 +632,13 @@ impl UnrollOptimizer {
             opt_p1.snapshot_frame_sizes = self.snapshot_frame_sizes.clone();
             opt_p1.snapshot_vable_boxes = self.snapshot_vable_boxes.clone();
             opt_p1.snapshot_vref_boxes = self.snapshot_vref_boxes.clone();
+            opt_p1.snapshot_extra_virtual_roots = self.snapshot_extra_virtual_roots.clone();
             opt_p1.snapshot_frame_pcs = self.snapshot_frame_pcs.clone();
             self.replace_compile_snapshot_roots(Self::collect_snapshot_const_ptr_slots(&mut [
                 &mut opt_p1.snapshot_boxes,
                 &mut opt_p1.snapshot_vable_boxes,
                 &mut opt_p1.snapshot_vref_boxes,
+                &mut opt_p1.snapshot_extra_virtual_roots,
             ]));
             opt_p1.call_pure_results = self.call_pure_results.clone();
             // RPython optimize_preamble (unroll.py:101-103): flush=False.
@@ -949,6 +956,7 @@ impl UnrollOptimizer {
         opt_p2.snapshot_frame_sizes = std::mem::take(&mut self.snapshot_frame_sizes);
         opt_p2.snapshot_vable_boxes = std::mem::take(&mut self.snapshot_vable_boxes);
         opt_p2.snapshot_vref_boxes = std::mem::take(&mut self.snapshot_vref_boxes);
+        opt_p2.snapshot_extra_virtual_roots = std::mem::take(&mut self.snapshot_extra_virtual_roots);
         opt_p2.snapshot_frame_pcs = std::mem::take(&mut self.snapshot_frame_pcs);
         opt_p2.call_pure_results = std::mem::take(&mut self.call_pure_results);
         // RPython: same Optimizer instance keeps patchguardop across phases.
@@ -1105,10 +1113,16 @@ impl UnrollOptimizer {
                 *r = r.map_opref(translate_opref);
             }
         }
+        for boxes in opt_p2.snapshot_extra_virtual_roots.iter_mut().flatten() {
+            for r in boxes.iter_mut() {
+                *r = r.map_opref(translate_opref);
+            }
+        }
         self.replace_compile_snapshot_roots(Self::collect_snapshot_const_ptr_slots(&mut [
             &mut opt_p2.snapshot_boxes,
             &mut opt_p2.snapshot_vable_boxes,
             &mut opt_p2.snapshot_vref_boxes,
+            &mut opt_p2.snapshot_extra_virtual_roots,
         ]));
         // Phase 1's emitted ops are already in Phase 1's emitted
         // namespace `[num_inputs..next_global_opref)`. Phase 2 body may
@@ -5742,6 +5756,15 @@ fn clone_guard_snapshot_remapped(
             &mut ctx.snapshot_vref_boxes,
             new_pos,
             remap_snapshot_boxes(&vref_boxes, ref_map),
+        );
+    }
+    if let Some(extra_virtual_roots) =
+        snapshot_get(&ctx.snapshot_extra_virtual_roots, old_pos).cloned()
+    {
+        snapshot_insert(
+            &mut ctx.snapshot_extra_virtual_roots,
+            new_pos,
+            remap_snapshot_boxes(&extra_virtual_roots, ref_map),
         );
     }
     if let Some(frame_pcs) = snapshot_get(&ctx.snapshot_frame_pcs, old_pos).cloned() {

--- a/majit/majit-metainterp/src/optimizeopt/unroll.rs
+++ b/majit/majit-metainterp/src/optimizeopt/unroll.rs
@@ -956,7 +956,8 @@ impl UnrollOptimizer {
         opt_p2.snapshot_frame_sizes = std::mem::take(&mut self.snapshot_frame_sizes);
         opt_p2.snapshot_vable_boxes = std::mem::take(&mut self.snapshot_vable_boxes);
         opt_p2.snapshot_vref_boxes = std::mem::take(&mut self.snapshot_vref_boxes);
-        opt_p2.snapshot_extra_virtual_roots = std::mem::take(&mut self.snapshot_extra_virtual_roots);
+        opt_p2.snapshot_extra_virtual_roots =
+            std::mem::take(&mut self.snapshot_extra_virtual_roots);
         opt_p2.snapshot_frame_pcs = std::mem::take(&mut self.snapshot_frame_pcs);
         opt_p2.call_pure_results = std::mem::take(&mut self.call_pure_results);
         // RPython: same Optimizer instance keeps patchguardop across phases.

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -494,6 +494,7 @@ fn snapshot_map_from_trace_snapshots(
     SnapshotFrameSizes,
     SnapshotBoxes,
     SnapshotBoxes,
+    SnapshotBoxes,
     SnapshotFramePcs,
 ) {
     let _ = constants; // legacy idx-Const pool no longer populated here; see SnapshotTagged::Const arm
@@ -501,6 +502,7 @@ fn snapshot_map_from_trace_snapshots(
     let mut size_map = Vec::new();
     let mut vable_map = Vec::new();
     let mut vref_map = Vec::new();
+    let mut evr_map = Vec::new();
     let mut pc_map = Vec::new();
     // opencoder.py:603 _encode: trace snapshot recorder only emits Box
     // (live deadframe slot) and Const (compile-time pool) payloads.
@@ -552,6 +554,14 @@ fn snapshot_map_from_trace_snapshots(
         // AND vref_array. resume.py:243-247 _number_boxes consumes
         // vref_array as a separate section after vable_array.
         let vref_boxes: Vec<SnapshotBox> = snap.vref_boxes.iter().map(&tagged_to_box).collect();
+        // Extra virtual roots are raw OpRefs (not SnapshotTagged): wrap each as
+        // an untyped SnapshotBox so it rides the same unroll/bridge OpRef remap
+        // as the vable/vref sections. finish() reads only their position OpRef.
+        let extra_virtual_roots: Vec<SnapshotBox> = snap
+            .extra_virtual_roots
+            .iter()
+            .map(|opref| SnapshotBox::from(*opref))
+            .collect();
         let frame_pcs: Vec<(i32, i32)> = snap
             .frames
             .iter()
@@ -562,9 +572,10 @@ fn snapshot_map_from_trace_snapshots(
         snapshot_insert(&mut size_map, id, frame_sizes);
         snapshot_insert(&mut vable_map, id, vable_boxes);
         snapshot_insert(&mut vref_map, id, vref_boxes);
+        snapshot_insert(&mut evr_map, id, extra_virtual_roots);
         snapshot_insert(&mut pc_map, id, frame_pcs);
     }
-    (box_map, size_map, vable_map, vref_map, pc_map)
+    (box_map, size_map, vable_map, vref_map, evr_map, pc_map)
 }
 
 struct PreparedBridgeTrace {
@@ -574,6 +585,7 @@ struct PreparedBridgeTrace {
     snapshot_frame_sizes: SnapshotFrameSizes,
     snapshot_vable_boxes: SnapshotBoxes,
     snapshot_vref_boxes: SnapshotBoxes,
+    snapshot_extra_virtual_roots: SnapshotBoxes,
     snapshot_frame_pcs: SnapshotFramePcs,
     pending_bridge_rd: Option<PendingBridgeRd>,
     runtime_boxes: Vec<OpRef>,
@@ -660,6 +672,7 @@ fn prepare_bridge_trace_for_optimizer(
     snapshot_frame_sizes: SnapshotFrameSizes,
     snapshot_vable_boxes: SnapshotBoxes,
     snapshot_vref_boxes: SnapshotBoxes,
+    snapshot_extra_virtual_roots: SnapshotBoxes,
     snapshot_frame_pcs: SnapshotFramePcs,
     pending_bridge_rd: Option<PendingBridgeRd>,
     runtime_boxes: Vec<OpRef>,
@@ -708,6 +721,8 @@ fn prepare_bridge_trace_for_optimizer(
     let snapshot_boxes = translate_trace_iter_box_map(snapshot_boxes, &cache);
     let snapshot_vable_boxes = translate_trace_iter_box_map(snapshot_vable_boxes, &cache);
     let snapshot_vref_boxes = translate_trace_iter_box_map(snapshot_vref_boxes, &cache);
+    let snapshot_extra_virtual_roots =
+        translate_trace_iter_box_map(snapshot_extra_virtual_roots, &cache);
     let pending_bridge_rd = pending_bridge_rd.map(|mut prd| {
         prd.liveboxes = prd
             .liveboxes
@@ -732,6 +747,7 @@ fn prepare_bridge_trace_for_optimizer(
         snapshot_frame_sizes,
         snapshot_vable_boxes,
         snapshot_vref_boxes,
+        snapshot_extra_virtual_roots,
         snapshot_frame_pcs,
         pending_bridge_rd,
         runtime_boxes,
@@ -5442,6 +5458,7 @@ impl<M: Clone> MetaInterp<M> {
             snapshot_frame_size_map,
             mut snapshot_vable_map,
             mut snapshot_vref_map,
+            snapshot_evr_map,
             snapshot_pc_map,
         ) = snapshot_map_from_trace_snapshots(&trace_snapshots, &mut constants);
         // history.py:220/261/307 — `Const{Int,Float,Ptr}.type` is an
@@ -5452,6 +5469,7 @@ impl<M: Clone> MetaInterp<M> {
         unroll_opt.snapshot_frame_sizes = snapshot_frame_size_map.clone();
         unroll_opt.snapshot_vable_boxes = snapshot_vable_map.clone();
         unroll_opt.snapshot_vref_boxes = snapshot_vref_map.clone();
+        unroll_opt.snapshot_extra_virtual_roots = snapshot_evr_map.clone();
         unroll_opt.snapshot_frame_pcs = snapshot_pc_map.clone();
         // The original snapshot maps are re-cloned into `simple_opt` on the
         // InvalidLoop retry below, so they must stay rooted across the WHOLE
@@ -5577,6 +5595,10 @@ impl<M: Clone> MetaInterp<M> {
                         simple_opt.snapshot_frame_sizes = snapshot_frame_size_map;
                         simple_opt.snapshot_vable_boxes = snapshot_vable_map;
                         simple_opt.snapshot_vref_boxes = snapshot_vref_map;
+                        // Extra virtual roots carry only non-const virtual OpRefs
+                        // (no inline ConstPtr gcrefs), so they are not part of the
+                        // const-ptr root-slot set above; move the map through.
+                        simple_opt.snapshot_extra_virtual_roots = snapshot_evr_map;
                         simple_opt.snapshot_frame_pcs = snapshot_pc_map;
                         simple_opt.call_pure_results = call_pure_results.clone();
                         // Forward the recorder's operand pool — the retry path
@@ -6488,6 +6510,7 @@ impl<M: Clone> MetaInterp<M> {
             snapshot_frame_sizes,
             mut snapshot_vable_boxes,
             mut snapshot_vref_boxes,
+            snapshot_extra_virtual_roots,
             snapshot_frame_pcs,
         ) = snapshot_map_from_trace_snapshots(&trace_snapshots, &mut constants);
         self.compile_snapshot_refs = collect_snapshot_const_ptr_slots(&mut [
@@ -6574,6 +6597,7 @@ impl<M: Clone> MetaInterp<M> {
                     snapshot_frame_sizes,
                     snapshot_vable_boxes,
                     snapshot_vref_boxes,
+                    snapshot_extra_virtual_roots,
                     snapshot_frame_pcs,
                     call_pure_results,
                 );
@@ -6607,6 +6631,7 @@ impl<M: Clone> MetaInterp<M> {
                     snapshot_frame_sizes,
                     snapshot_vable_boxes,
                     snapshot_vref_boxes,
+                    snapshot_extra_virtual_roots,
                     snapshot_frame_pcs,
                 );
                 if success {
@@ -6827,6 +6852,7 @@ impl<M: Clone> MetaInterp<M> {
             retrace_snapshot_frame_sizes,
             mut retrace_snapshot_vable_boxes,
             mut retrace_snapshot_vref_boxes,
+            retrace_snapshot_extra_virtual_roots,
             retrace_snapshot_frame_pcs,
         ) = snapshot_map_from_trace_snapshots(&trace.snapshots, &mut constants);
         self.compile_snapshot_refs = collect_snapshot_const_ptr_slots(&mut [
@@ -6840,6 +6866,7 @@ impl<M: Clone> MetaInterp<M> {
         unroll_opt.snapshot_frame_sizes = retrace_snapshot_frame_sizes;
         unroll_opt.snapshot_vable_boxes = retrace_snapshot_vable_boxes;
         unroll_opt.snapshot_vref_boxes = retrace_snapshot_vref_boxes;
+        unroll_opt.snapshot_extra_virtual_roots = retrace_snapshot_extra_virtual_roots;
         unroll_opt.snapshot_frame_pcs = retrace_snapshot_frame_pcs;
         // Import the exported state from the first (failed) attempt so the
         // optimizer can continue from where it left off.
@@ -7370,6 +7397,7 @@ impl<M: Clone> MetaInterp<M> {
             snapshot_frame_size_map,
             mut snapshot_vable_map,
             mut snapshot_vref_map,
+            snapshot_evr_map,
             snapshot_pc_map,
         ) = snapshot_map_from_trace_snapshots(&trace_snapshots, &mut constants);
         self.compile_snapshot_refs = collect_snapshot_const_ptr_slots(&mut [
@@ -7389,6 +7417,7 @@ impl<M: Clone> MetaInterp<M> {
         optimizer.snapshot_frame_sizes = snapshot_frame_size_map;
         optimizer.snapshot_vable_boxes = snapshot_vable_map;
         optimizer.snapshot_vref_boxes = snapshot_vref_map;
+        optimizer.snapshot_extra_virtual_roots = snapshot_evr_map;
         optimizer.snapshot_frame_pcs = snapshot_pc_map;
 
         // InvalidLoop during optimization should abort the trace, not crash
@@ -7781,6 +7810,7 @@ impl<M: Clone> MetaInterp<M> {
             snapshot_frame_size_map,
             mut snapshot_vable_map,
             mut snapshot_vref_map,
+            snapshot_evr_map,
             snapshot_pc_map,
         ) = snapshot_map_from_trace_snapshots(&trace_snapshots, &mut constants);
         self.compile_snapshot_refs = collect_snapshot_const_ptr_slots(&mut [
@@ -7792,6 +7822,7 @@ impl<M: Clone> MetaInterp<M> {
         optimizer.snapshot_frame_sizes = snapshot_frame_size_map;
         optimizer.snapshot_vable_boxes = snapshot_vable_map;
         optimizer.snapshot_vref_boxes = snapshot_vref_map;
+        optimizer.snapshot_extra_virtual_roots = snapshot_evr_map;
         optimizer.snapshot_frame_pcs = snapshot_pc_map;
 
         let optimize_result = optimizer.optimize_with_constants_and_inputs_oprc(
@@ -9881,6 +9912,7 @@ impl<M: Clone> MetaInterp<M> {
         snapshot_frame_sizes: SnapshotFrameSizes,
         snapshot_vable_boxes: SnapshotBoxes,
         snapshot_vref_boxes: SnapshotBoxes,
+        snapshot_extra_virtual_roots: SnapshotBoxes,
         snapshot_frame_pcs: SnapshotFramePcs,
     ) -> bool {
         if !self.compiled_loops.contains_key(&green_key) {
@@ -9925,6 +9957,7 @@ impl<M: Clone> MetaInterp<M> {
             snapshot_frame_sizes,
             snapshot_vable_boxes,
             snapshot_vref_boxes,
+            snapshot_extra_virtual_roots,
             snapshot_frame_pcs,
             None,
             bridge_runtime_boxes,
@@ -9954,6 +9987,7 @@ impl<M: Clone> MetaInterp<M> {
         optimizer.snapshot_frame_sizes = prepared.snapshot_frame_sizes;
         optimizer.snapshot_vable_boxes = prepared.snapshot_vable_boxes;
         optimizer.snapshot_vref_boxes = prepared.snapshot_vref_boxes;
+        optimizer.snapshot_extra_virtual_roots = prepared.snapshot_extra_virtual_roots;
         optimizer.snapshot_frame_pcs = prepared.snapshot_frame_pcs;
         optimizer.trace_inputargs = bridge_inputargs
             .iter()
@@ -10322,6 +10356,7 @@ impl<M: Clone> MetaInterp<M> {
         snapshot_frame_sizes: SnapshotFrameSizes,
         snapshot_vable_boxes: SnapshotBoxes,
         snapshot_vref_boxes: SnapshotBoxes,
+        snapshot_extra_virtual_roots: SnapshotBoxes,
         snapshot_frame_pcs: SnapshotFramePcs,
         call_pure_results: indexmap::IndexMap<Vec<Value>, Value>,
     ) -> bool {
@@ -10513,6 +10548,7 @@ impl<M: Clone> MetaInterp<M> {
             snapshot_frame_sizes,
             snapshot_vable_boxes,
             snapshot_vref_boxes,
+            snapshot_extra_virtual_roots,
             snapshot_frame_pcs,
             pending_bridge_rd,
             bridge_runtime_boxes,
@@ -10567,6 +10603,7 @@ impl<M: Clone> MetaInterp<M> {
         optimizer.snapshot_frame_sizes = prepared.snapshot_frame_sizes;
         optimizer.snapshot_vable_boxes = prepared.snapshot_vable_boxes;
         optimizer.snapshot_vref_boxes = prepared.snapshot_vref_boxes;
+        optimizer.snapshot_extra_virtual_roots = prepared.snapshot_extra_virtual_roots;
         optimizer.snapshot_frame_pcs = prepared.snapshot_frame_pcs;
         // Store bridge inputarg types so export_state can mint typed
         // `renamed_inputargs` OpRefs that carry their type intrinsically
@@ -19244,6 +19281,7 @@ mod tests {
             snapshot_vable_boxes,
             Vec::new(),
             Vec::new(),
+            Vec::new(),
             Some(pending_bridge_rd),
             bridge_runtime_boxes,
             10,
@@ -20406,6 +20444,7 @@ mod tests {
                 }],
                 vable_boxes: Vec::new(),
                 vref_boxes: Vec::new(),
+                extra_virtual_roots: Vec::new(),
             })
         };
         assert_eq!(snapshot_id, 0);

--- a/majit/majit-metainterp/src/pyjitpl/dispatch.rs
+++ b/majit/majit-metainterp/src/pyjitpl/dispatch.rs
@@ -7970,6 +7970,7 @@ pub fn build_state_field_snapshot(
         frames: snapshot_frames,
         vable_boxes: vable_boxes_snap,
         vref_boxes: vref_boxes_snap,
+        extra_virtual_roots: Vec::new(),
     }
 }
 

--- a/majit/majit-metainterp/src/recorder.rs
+++ b/majit/majit-metainterp/src/recorder.rs
@@ -59,6 +59,18 @@ pub struct Snapshot {
     pub vable_boxes: Vec<SnapshotTagged>,
     /// VirtualRef box references (tagged).
     pub vref_boxes: Vec<SnapshotTagged>,
+    /// Extra virtual roots to seed into the resume-data virtual worklist
+    /// beyond the frame's liveness boxes and the vable/vref prefixes — virtual
+    /// op-results reachable only as a field of another walker-minted virtual,
+    /// with no frame-liveness slot of their own.  Each entry is numbered
+    /// `TAGVIRTUAL` (off the liveness-counted frame section), so
+    /// `_number_boxes` / `finish` descends into it via
+    /// `get_virtual_fields` exactly as it does for a live TAGVIRTUAL box
+    /// (`_visitor_walk_recursive`).  Empty on every path except the
+    /// nested-list append fold behind `PYRE_NESTED_LIST_FOLD_VIRT`; the inner
+    /// `[[i] …]` wrapper enters here so its separately allocated backing block
+    /// is rooted in resume data.
+    pub extra_virtual_roots: Vec<OpRef>,
 }
 
 /// One frame in a snapshot — corresponds to one MIFrame/JitCode position.

--- a/majit/majit-metainterp/src/resume.rs
+++ b/majit/majit-metainterp/src/resume.rs
@@ -3933,6 +3933,13 @@ impl ResumeDataLoopMemo {
     ///   target_tagged/value_tagged are filled in-place.
     /// `optimizer_knowledge`: bridgeopt.py:63 serialize_optimizer_knowledge.
     ///   Heap field triples and known-class info for bridge compilation.
+    /// `extra_virtual_roots`: virtual op-results reachable only as a field of
+    ///   another walker-minted virtual (no frame-liveness slot of their own).
+    ///   Seeded into the virtual worklist as `register_virtual_box` roots — the
+    ///   `_visitor_walk_recursive` analog descends into each via
+    ///   `get_virtual_fields`, so a nested `[[i] …]` inner-list wrapper roots its
+    ///   separately allocated backing block. Empty on every path except the
+    ///   nested-list append fold behind `PYRE_NESTED_LIST_FOLD_VIRT`.
     ///
     /// Returns `(rd_numb, rd_consts, rd_virtuals, liveboxes, livebox_types)`.
     /// `livebox_types` maps typed OpRef → Type, captured at numbering time
@@ -3943,6 +3950,7 @@ impl ResumeDataLoopMemo {
         env: &dyn majit_ir::BoxEnv,
         pending_setfields: &mut [majit_ir::GuardPendingFieldEntry],
         optimizer_knowledge: Option<&OptimizerKnowledgeForResume>,
+        extra_virtual_roots: &[majit_ir::OpRef],
     ) -> (
         Vec<u8>,
         Vec<majit_ir::Const>,
@@ -3998,6 +4006,30 @@ impl ResumeDataLoopMemo {
                 debug_assert_eq!(tagbits, TAGVIRTUAL);
                 virtual_worklist.push(opref);
             }
+        }
+
+        // Seed the walker-minted extra virtual roots (the nested-list append
+        // fold's inner-list wrapper) into the same worklist. These carry no
+        // frame-liveness slot — they are reachable only as a field of another
+        // virtual — so they are numbered off the frame section: `register_
+        // virtual_box` stamps them UNASSIGNEDVIRTUAL (resume.py:359-368
+        // register_virtual_fields default) so `_number_virtuals` gives them an
+        // `rd_virtuals` slot without ever making them a fail-arg, and the drain
+        // below descends into each via `get_virtual_fields` — the pyre analog of
+        // `_visitor_walk_recursive` reaching the wrapper's backing block.
+        for &root in extra_virtual_roots {
+            if root.is_none() {
+                continue;
+            }
+            let resolved = env.get_box_replacement(root);
+            if resolved.is_none()
+                || virtual_fields.contains_key(&resolved)
+                || !(env.is_virtual_ref(resolved) || env.is_virtual_raw(resolved))
+            {
+                continue;
+            }
+            self.register_virtual_box(resolved, env, &numb_state.liveboxes, &mut new_liveboxes);
+            virtual_worklist.push(resolved);
         }
 
         // Worklist-based recursive virtual discovery (RPython visitor_walk_recursive).
@@ -4991,7 +5023,7 @@ mod tests {
         );
         let numb_state = memo.number(&snapshot, &env, -1).unwrap();
         let (rd_numb, rd_consts, _rd_virtuals, liveboxes, _livebox_types) =
-            memo.finish(numb_state, &env, &mut [], None);
+            memo.finish(numb_state, &env, &mut [], None, &[]);
 
         // liveboxes should contain only TAGBOX entries: OpRef::int_op(1) and OpRef::int_op(3)
         assert_eq!(liveboxes.len(), 2);

--- a/majit/majit-metainterp/tests/jit_driver_runtime_parity.rs
+++ b/majit/majit-metainterp/tests/jit_driver_runtime_parity.rs
@@ -34,6 +34,7 @@ fn attach_single_frame_snapshot(ctx: &mut TraceCtx, pc: u32, boxes: &[(OpRef, Ty
         }],
         vable_boxes: Vec::new(),
         vref_boxes: Vec::new(),
+        extra_virtual_roots: Vec::new(),
     });
     ctx.set_last_guard_resume_position(snapshot_id);
 }

--- a/pyre/bench/synth/comprehension_object_append_hot.py
+++ b/pyre/bench/synth/comprehension_object_append_hot.py
@@ -1,0 +1,51 @@
+# An inlined list comprehension whose LIST_APPEND element lands in a list
+# Object-strategy (tuple / None / str / dict / f-string) folds through the #171
+# orthodox append. Its Object arm stores a GC ref and runs list_write_barrier,
+# an idempotent Void residual. The barrier must be exempt from the FBW in-flight
+# FOR_ITER body-effect accounting; otherwise the trace-attempt iteration is
+# refuse-dropped and the comprehension yields one element short (len N-1 instead
+# of N). int elements take the unboxed fast path (no barrier) and were never
+# affected. (A non-empty nested-list element `[[i] …]` is intentionally omitted:
+# it declines to the interpreter until the fold threads the inner list's backing
+# block into guard-exit resume data.)
+
+
+def tuple_comp(n):
+    return [(i, i) for i in range(n)]
+
+
+def none_comp(n):
+    return [None for i in range(n)]
+
+
+def str_comp(n):
+    return ["s" for i in range(n)]
+
+
+def dict_comp(n):
+    return [{i: i} for i in range(n)]
+
+
+def fstring_comp(n):
+    return [f"{i}" for i in range(n)]
+
+
+def int_comp(n):
+    return [i for i in range(n)]
+
+
+def main():
+    total = 0
+    k = 0
+    while k < 500:
+        total += len(tuple_comp(1000))
+        total += len(none_comp(1000))
+        total += len(str_comp(1000))
+        total += len(dict_comp(1000))
+        total += len(fstring_comp(1000))
+        total += len(int_comp(1000))
+        k += 1
+    print(total)
+
+
+main()

--- a/pyre/bench/synth/nested_list_comprehension_hot.py
+++ b/pyre/bench/synth/nested_list_comprehension_hot.py
@@ -1,0 +1,37 @@
+# An inlined list comprehension whose LIST_APPEND element is a non-empty nested
+# list (`[[i] …]` / `[[i, i + 1] …]`). The #171 fold virtualizes the inner list,
+# but its separately allocated backing block (NewArray / NewArrayClear) carries
+# no jitcode-liveness color, so it is not rooted in the append commit sub-walk's
+# guard-exit resume data and a deopt resolves it to a null OpRef.
+#
+# Held back behind the DEFAULT-OFF PYRE_NESTED_LIST_FOLD_VIRT gate: while the
+# gate is off `for_iter_bodies_all_jit_safe` declines the shape, so this runs in
+# the interpreter and prints the correct total. It is the acceptance repro for
+# the recursive virtual-list-forcing rooting work — with the gate on it must
+# still print the same total on all three backends (dynasm / cranelift / wasm)
+# once the rooting lands.
+
+
+def single_comp(n):
+    return [[i] for i in range(n)]
+
+
+def pair_comp(n):
+    return [[i, i + 1] for i in range(n)]
+
+
+def main():
+    total = 0
+    k = 0
+    while k < 500:
+        xs = single_comp(1000)
+        total += len(xs)
+        total += xs[-1][0]
+        ys = pair_comp(1000)
+        total += len(ys)
+        total += ys[-1][1]
+        k += 1
+    print(total)
+
+
+main()

--- a/pyre/pyre-interpreter/src/jit_fnaddr.rs
+++ b/pyre/pyre-interpreter/src/jit_fnaddr.rs
@@ -284,6 +284,47 @@ pub fn is_pyframe_operand_stack_accessor(addr: usize) -> bool {
     addrs.contains(&(addr as i64))
 }
 
+/// True when `addr` is the `list_write_barrier` residual fnaddr.
+///
+/// The #171 object-append fold descends `w_list_append`; its Object-strategy
+/// arm stores a GC ref and runs `list_write_barrier(obj)`
+/// (`pyre_object::listobject:::869`/`:872`), which residualizes (registered in
+/// [`jit_trace_fnaddrs`]) because it is `#[dont_look_inside]`. The barrier is
+/// pure GC bookkeeping — `try_gc_write_barrier` adds `obj` to the remembered
+/// set — and is idempotent: re-running it on a body replay only re-adds `obj`,
+/// never doubling any user-visible state. It is therefore not a "body effect"
+/// in the FBW replay sense, and the full-body walker uses this predicate to
+/// keep it out of the in-flight-FOR_ITER body-effect accounting.
+///
+/// This matches RPython, where the write barrier is not a metatracing
+/// operation at all: `COND_CALL_GC_WB` is in the "never executed by pyjitpl"
+/// set (`rpython/jit/metainterp/executor.py:446`), is neither can-raise nor a
+/// call (`resoperation.py:1124-1125`, outside those ranges), and is inserted
+/// only by the backend GC rewrite pass after optimization
+/// (`backend/llsupport/rewrite.py:948`). pyre has no separate backend rewrite
+/// pass, so the barrier surfaces as a residual during the walk; exempting it
+/// from the FBW body-effect gate restores the parity RPython gets for free.
+///
+/// Matches the registered fnaddr (not `list_write_barrier as *const ()`) for
+/// the same address-stability reason as [`is_pyframe_operand_stack_accessor`]:
+/// the codewriter bakes the [`jit_trace_fnaddrs`] value into the JitCode
+/// constant pool.
+pub fn is_list_write_barrier(addr: usize) -> bool {
+    use std::sync::OnceLock;
+    static BARRIER_ADDRS: OnceLock<Vec<i64>> = OnceLock::new();
+    let addrs = BARRIER_ADDRS.get_or_init(|| {
+        jit_trace_fnaddrs()
+            .into_iter()
+            .filter(|(path, _)| {
+                path.ends_with("::listobject::list_write_barrier")
+                    || *path == "pyre_object::list_write_barrier"
+            })
+            .map(|(_, fnaddr)| fnaddr)
+            .collect()
+    });
+    addrs.contains(&(addr as i64))
+}
+
 /// Build-time equivalent of `#[jit_module]::__majit_helper_trace_fnaddrs()`.
 ///
 /// The registry includes both the module-qualified path produced by the
@@ -2325,7 +2366,7 @@ pub fn jit_static_int_values() -> Vec<(&'static str, i64)> {
 
 #[cfg(test)]
 mod tests {
-    use super::{is_pyframe_operand_stack_accessor, jit_trace_fnaddrs};
+    use super::{is_list_write_barrier, is_pyframe_operand_stack_accessor, jit_trace_fnaddrs};
     use std::collections::HashMap;
 
     #[test]
@@ -2531,6 +2572,16 @@ mod tests {
         let nlocals = bindings["pyre_interpreter::pyframe::PyFrame::nlocals"];
         assert!(!is_pyframe_operand_stack_accessor(nlocals as usize));
         assert!(!is_pyframe_operand_stack_accessor(0));
+    }
+
+    #[test]
+    fn is_list_write_barrier_matches_registered_barrier() {
+        let bindings: HashMap<&'static str, i64> = jit_trace_fnaddrs().into_iter().collect();
+        let barrier = bindings["pyre_object::listobject::list_write_barrier"];
+        assert!(is_list_write_barrier(barrier as usize));
+        let nlocals = bindings["pyre_interpreter::pyframe::PyFrame::nlocals"];
+        assert!(!is_list_write_barrier(nlocals as usize));
+        assert!(!is_list_write_barrier(0));
     }
 
     /// Negative parity guard: pyre intentionally does NOT publish a

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
@@ -6022,6 +6022,33 @@ pub fn nested_list_fold_virt_enabled() -> bool {
     *ENABLED
 }
 
+/// `PYRE_WASM_UNBOXED_APPEND_FOLD` gate (read once) — admits the unboxed
+/// (Integer/Float storage) `w_list_append` fold on the wasm backend. The fold
+/// records the spare-capacity fast path guarded by `GuardTrue(length <
+/// arraylen(items))`; when the comprehension result escapes the enclosing frame
+/// and a later append crosses the backing block's realloc boundary, the wasm
+/// backend mis-resumes that capacity-guard deopt — the reallocating append's
+/// iteration is lost (list one element short) or, when the partially built list
+/// is a kept operand-stack temp, the whole list resolves to NULL ("call
+/// failed"). dynasm / cranelift resume the identical guard IR correctly, so this
+/// is a wasm-backend deopt/resume defect. Until it is root-fixed, decline the
+/// unboxed arm on wasm so the append runs as the plain residual `jit_list_append`
+/// (interpreter fallback, correct if unaccelerated). DEFAULT-ON for wasm32 (the
+/// backend that mis-resumes); a strict no-op on native (the fold always folds
+/// there). Set `PYRE_WASM_UNBOXED_APPEND_FOLD=1` to force the fold back on for
+/// bisecting the root fix. The Object-storage arm is unaffected — it resumes
+/// correctly and stays folded.
+fn wasm_unboxed_append_fold_declined() -> bool {
+    static DECLINED: std::sync::LazyLock<bool> = std::sync::LazyLock::new(|| {
+        if cfg!(target_arch = "wasm32") {
+            std::env::var("PYRE_WASM_UNBOXED_APPEND_FOLD").map_or(true, |v| v != "1")
+        } else {
+            false
+        }
+    });
+    *DECLINED
+}
+
 /// #62 dead-`box_bool` proof for [`try_walker_specialize_compare_op_int`] /
 /// `_float`.  Returns `true` only when a forward JitCode lookahead proves
 /// the compare's boxed Ref dst register (`dst_reg`) is consumed *solely*

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
@@ -3724,6 +3724,21 @@ pub(crate) struct GuardCaptureScope<'a> {
     /// with the exact, depth-independent edge resolution. Empty outside the
     /// gated kept-stack path.
     pub branch_guard_kept_recovered: &'a [(u16, OpRef)],
+
+    /// Extra virtual roots to seed into the guard snapshot beyond the outer
+    /// Python frame's jitcode-liveness boxes — walker-minted virtual op-results
+    /// that carry no liveness color yet must survive a deopt as fail-arg roots.
+    /// The motivating case is the `w_list_append` commit sub-walk over a
+    /// non-empty nested list element (`[[i] for i in range(n)]`): the appended
+    /// inner-list wrapper is passed to the sub-walk as a register arg but is not
+    /// named by any live outer color, so without an explicit root the resume
+    /// recursion never descends into it and its backing block resolves to a null
+    /// `OpRef`. Each entry is the `(OpRef, Type)` of a root the snapshot builder
+    /// must append to the top frame's boxes so the ported
+    /// `_visitor_walk_recursive` registers the nested virtual (wrapper + backing
+    /// block) in resume data. Empty on every path today: only populated behind
+    /// the DEFAULT-OFF `PYRE_NESTED_LIST_FOLD_VIRT` gate, so this is dormant.
+    pub sub_walk_extra_virtual_roots: &'a [(OpRef, majit_ir::Type)],
 }
 
 /// `rlib/jit.py:601` `max_unroll_recursion` default (= warmstate
@@ -5983,6 +5998,26 @@ fn newlist_virt_enabled() -> bool {
 fn empty_append_virt_enabled() -> bool {
     static ENABLED: std::sync::LazyLock<bool> = std::sync::LazyLock::new(|| {
         std::env::var("PYRE_EMPTY_APPEND_VIRT").map_or(true, |v| v != "0")
+    });
+    *ENABLED
+}
+
+/// `PYRE_NESTED_LIST_FOLD_VIRT` gate (read once) — admits a non-empty nested
+/// `BUILD_LIST` element (`[[i] for i in range(n)]`) into the orthodox
+/// `w_list_append` fold. The appended value is an already-virtualized inner
+/// list whose separately allocated backing block (`NewArray` / `NewArrayClear`)
+/// has no jitcode-liveness slot, so `collect_outer_active_boxes` cannot root it
+/// and it resolves to a null `OpRef` at a guard-exit deopt. Closing the gap
+/// needs the inner wrapper threaded into the append commit sub-walk's guard
+/// snapshot as an extra virtual root, so the resume-data recursion (the ported
+/// `_visitor_walk_recursive` / `VArrayInfo`) registers the backing block. That
+/// rooting machinery is being built incrementally; this gate keeps it opt-in
+/// and DEFAULT-OFF until the whole path is proven bit-exact on all backends.
+/// While off, `for_iter_bodies_all_jit_safe` still declines the shape, so the
+/// gate is a strict no-op.
+pub fn nested_list_fold_virt_enabled() -> bool {
+    static ENABLED: std::sync::LazyLock<bool> = std::sync::LazyLock::new(|| {
+        std::env::var("PYRE_NESTED_LIST_FOLD_VIRT").map_or(false, |v| v == "1")
     });
     *ENABLED
 }

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
@@ -6004,20 +6004,18 @@ fn empty_append_virt_enabled() -> bool {
 
 /// `PYRE_NESTED_LIST_FOLD_VIRT` gate (read once) — admits a non-empty nested
 /// `BUILD_LIST` element (`[[i] for i in range(n)]`) into the orthodox
-/// `w_list_append` fold. The appended value is an already-virtualized inner
-/// list whose separately allocated backing block (`NewArray` / `NewArrayClear`)
-/// has no jitcode-liveness slot, so `collect_outer_active_boxes` cannot root it
-/// and it resolves to a null `OpRef` at a guard-exit deopt. Closing the gap
-/// needs the inner wrapper threaded into the append commit sub-walk's guard
-/// snapshot as an extra virtual root, so the resume-data recursion (the ported
-/// `_visitor_walk_recursive` / `VArrayInfo`) registers the backing block. That
-/// rooting machinery is being built incrementally; this gate keeps it opt-in
-/// and DEFAULT-OFF until the whole path is proven bit-exact on all backends.
-/// While off, `for_iter_bodies_all_jit_safe` still declines the shape, so the
-/// gate is a strict no-op.
+/// `w_list_append` fold. The appended value is a virtualized inner list whose
+/// separately allocated backing block (`NewArray` / `NewArrayClear`) carries no
+/// jitcode-liveness slot; once the trace-time single-executor forks were retired
+/// the append body no longer runs under a speculative-replay sub-walk, so the
+/// backing block is bound at every guard-exit deopt and the shape compiles
+/// bit-exact on dynasm / cranelift / wasm (comprehension-hot acceptance repro
+/// `bench/synth/nested_list_comprehension_hot.py`). Default-on; set
+/// `PYRE_NESTED_LIST_FOLD_VIRT=0` to fall back to the `for_iter_bodies_all_jit_safe`
+/// decline (native only — the wasm guest cannot read the env var).
 pub fn nested_list_fold_virt_enabled() -> bool {
     static ENABLED: std::sync::LazyLock<bool> = std::sync::LazyLock::new(|| {
-        std::env::var("PYRE_NESTED_LIST_FOLD_VIRT").map_or(false, |v| v == "1")
+        std::env::var("PYRE_NESTED_LIST_FOLD_VIRT").map_or(true, |v| v != "0")
     });
     *ENABLED
 }

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
@@ -666,6 +666,21 @@ pub(crate) fn try_execute_residual_call_via_executor<Sym: WalkSym>(
     if pyre_interpreter::is_pyframe_operand_stack_accessor(func_ptr as usize) {
         return Ok(ResidualExecOutcome::Declined(ResidualDecline::Symbolic));
     }
+    // The `list_write_barrier` residual (the #171 object-append fold's Object
+    // arm leaves it as a residual because it is `#[dont_look_inside]`) is pure
+    // idempotent GC bookkeeping — re-running it on a body replay only re-adds
+    // the list to the remembered set, never doubling user-visible state.  It
+    // must still EXECUTE concretely below (pyre has no backend GC-rewrite pass,
+    // so the barrier runs during the walk for GC correctness), but it is not a
+    // body effect: keep it out of the in-flight-FOR_ITER body-effect accounting
+    // so an Object-strategy comprehension append (`[(i, i) for …]`, `[None …]`)
+    // is not refuse-dropped.  RPython treats the write barrier the same way —
+    // `COND_CALL_GC_WB` is never executed by pyjitpl
+    // (`rpython/jit/metainterp/executor.py:446`), is neither can-raise nor a
+    // call (`resoperation.py:1124-1125`), and is inserted only by the backend
+    // GC rewrite pass after optimization (`backend/llsupport/rewrite.py:948`),
+    // so it never participates in the metainterp's side-effect analysis.
+    let is_idempotent_gc_barrier = pyre_interpreter::is_list_write_barrier(func_ptr as usize);
     if allboxes.len() - 1 > majit_translate::codewriter::insns::MAX_HOST_CALL_ARITY {
         return Ok(ResidualExecOutcome::Declined(ResidualDecline::Symbolic));
     }
@@ -984,8 +999,10 @@ pub(crate) fn try_execute_residual_call_via_executor<Sym: WalkSym>(
     } else {
         None
     };
-    let body_effect_candidate =
-        !provably_side_effect_free && writes_live_heap && fbw_foriter_inflight_active();
+    let body_effect_candidate = !provably_side_effect_free
+        && !is_idempotent_gc_barrier
+        && writes_live_heap
+        && fbw_foriter_inflight_active();
     // #57 Option C (Finding #1, user-frame signal): the Void/helper-tag write
     // discriminator above cannot see a body effect committed through USER
     // PYTHON CODE by a value-returning (`Ref`), `PyreHelperKind::None`,
@@ -1025,7 +1042,7 @@ pub(crate) fn try_execute_residual_call_via_executor<Sym: WalkSym>(
         let _suspend = majit_metainterp::TraceContinuationSuspendGuard::enter();
         majit_metainterp::executor::execute_residual_call(call_descr, func_ptr, &args)
     };
-    if !provably_side_effect_free {
+    if !provably_side_effect_free && !is_idempotent_gc_barrier {
         fbw_mark_executed_nonpure_residual();
         // Count only a FOREIGN non-pure residual: a self-recursive call is the
         // fold target running because its fold declined, not a body side effect.
@@ -1115,6 +1132,7 @@ pub(crate) fn try_execute_residual_call_via_executor<Sym: WalkSym>(
     // the forward flush if a callee sub-walk moved it — re-executing the CALL
     // would double the effect.
     if !provably_side_effect_free
+        && !is_idempotent_gc_barrier
         && (writes_live_heap
             || heap_write_odometer_before
                 .is_some_and(|before| pyre_interpreter::call::frame_entry_count() != before))

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/resume_snapshot.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/resume_snapshot.rs
@@ -936,6 +936,16 @@ pub(crate) fn walker_capture_snapshot_for_last_guard_impl<Sym: WalkSym>(
                 scope.branch_guard_kept_recovered,
             );
             let pc_word = resolved_offset as u32;
+            // S2b: the walker-minted extra virtual roots (the nested-list append
+            // fold's inner-list wrapper) ride the snapshot as TAGVIRTUAL worklist
+            // seeds, NOT frame-liveness boxes — they must never enter `active`
+            // (which is liveness-counted, `state.rs` setup_bridge_sym assert) nor
+            // `vable_boxes` (size-exact, `resume.rs` consume_vable_info assert).
+            let extra_virtual_roots: Vec<majit_ir::OpRef> = scope
+                .sub_walk_extra_virtual_roots
+                .iter()
+                .map(|(opref, _ty)| *opref)
+                .collect();
             ctx.trace_ctx
                 .capture_snapshot_for_last_guard_with_vable_vref(
                     &active,
@@ -943,6 +953,7 @@ pub(crate) fn walker_capture_snapshot_for_last_guard_impl<Sym: WalkSym>(
                     pc_word,
                     &vable_boxes,
                     &vref_boxes,
+                    &extra_virtual_roots,
                 );
             return Ok(());
         }
@@ -974,6 +985,8 @@ pub(crate) fn walker_capture_snapshot_for_last_guard_impl<Sym: WalkSym>(
             arm_pc_word,
             &vable_boxes,
             &vref_boxes,
+            // Per-opcode arm path: not the nested-list append fold, no extra roots.
+            &[],
         );
     Ok(())
 }

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
@@ -3110,11 +3110,14 @@ unsafe fn orthodox_list_append_recognize(
             // Gate off: preserve the prior behavior (Empty always declined).
             return None;
         }
-        let int_ok = pyre_object::is_plain_int1(value)
+        let unboxed_declined = wasm_unboxed_append_fold_declined();
+        let int_ok = !unboxed_declined
+            && pyre_object::is_plain_int1(value)
             && !pyre_object::pyobject::is_long(value)
             && !(pyre_object::tagged_int::CAN_BE_TAGGED
                 && pyre_object::tagged_int::is_tagged_int(value));
-        let float_ok = !value.is_null() && pyre_object::is_plain_float_strict(value);
+        let float_ok =
+            !unboxed_declined && !value.is_null() && pyre_object::is_plain_float_strict(value);
         // switch_to_correct_strategy routes `is_plain_int1` -> Integer with no
         // tagged exclusion. Exclude any plain-int / float from the object
         // fallback so a tagged-int / fits-int `W_LongObject` DECLINES (generic
@@ -3136,7 +3139,9 @@ unsafe fn orthodox_list_append_recognize(
     // fits-int `W_LongObject` is declined, see note above).
     // A tagged-immediate value would need a tag-aware unboxed store and no
     // `w_class` pin; decline to the generic residual append instead.
-    let int_ok = pyre_object::w_list_uses_int_storage(inner_self)
+    let unboxed_declined = wasm_unboxed_append_fold_declined();
+    let int_ok = !unboxed_declined
+        && pyre_object::w_list_uses_int_storage(inner_self)
         && pyre_object::is_plain_int1(value)
         && !pyre_object::pyobject::is_long(value)
         && !(pyre_object::tagged_int::CAN_BE_TAGGED
@@ -3150,7 +3155,8 @@ unsafe fn orthodox_list_append_recognize(
     // `type(w_obj) is W_FloatObject`, the strict predicate the body's Float
     // arm also uses. No fits-* long analogue (a float is never re-boxed
     // across arithmetic, unlike a fits-int W_LongObject).
-    let float_ok = pyre_object::w_list_uses_float_storage(inner_self)
+    let float_ok = !unboxed_declined
+        && pyre_object::w_list_uses_float_storage(inner_self)
         && !value.is_null()
         && pyre_object::is_plain_float_strict(value);
     if !int_ok && !obj_ok && !float_ok {

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -2972,6 +2972,9 @@ impl MIFrame {
             frames,
             vable_boxes,
             vref_boxes,
+            // Trait-leg (MIFrame) snapshot: the nested-list append fold is a
+            // full-body-walk-only path, so no extra virtual roots here.
+            extra_virtual_roots: Vec::new(),
         }
     }
 

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -4999,9 +4999,14 @@ fn for_iter_bodies_all_jit_safe(code: &pyre_interpreter::CodeObject) -> bool {
             // OpRef and crashes. The orthodox recovery is recursive virtual-list
             // forcing at the guard, threading each inner element box + length
             // into resume data (mirroring `_visitor_walk_recursive` /
-            // `VArrayInfo`); until that lands the shape declines. An empty `[]`
-            // element is Empty-strategy (no backing block) and unaffected;
-            // tuple / set / dict elements take non-list allocation paths.
+            // `VArrayInfo`); that rooting machinery is being built behind the
+            // DEFAULT-OFF `PYRE_NESTED_LIST_FOLD_VIRT` gate, so until it is
+            // proven bit-exact the gate stays off and the shape still declines.
+            // An empty `[]` element is Empty-strategy (no backing block) and
+            // unaffected; tuple / set / dict elements take non-list allocation
+            // paths.
+            let nested_list_fold_ok =
+                pyre_jit_trace::jitcode_dispatch::nested_list_fold_virt_enabled();
             let (body_has_call, body_has_nonempty_list_build) = {
                 let mut scan_state = pyre_interpreter::OpArgState::default();
                 let mut scan_pc = pc + 1;
@@ -5043,7 +5048,7 @@ fn for_iter_bodies_all_jit_safe(code: &pyre_interpreter::CodeObject) -> bool {
                             | I::LoadName { .. }
                     )
                     || (!body_has_call
-                        && !body_has_nonempty_list_build
+                        && (!body_has_nonempty_list_build || nested_list_fold_ok)
                         && matches!(body_instr, I::ListAppend { .. }));
                 if !permitted {
                     return false;

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -4970,70 +4970,81 @@ fn for_iter_bodies_all_jit_safe(code: &pyre_interpreter::CodeObject) -> bool {
                 pc + 1,
                 delta.get(op_arg).as_usize(),
             );
-            // A `LIST_APPEND` body is admitted only in the canonical
-            // bare-accumulator shape. Any value-producing op (arithmetic,
-            // container build, format, constant load, call) can make the append
-            // use a list Object-strategy whose Void `setarrayitem_gc` residual
-            // trips the FBW body-effect gate; `fbw_foriter_inflight_take` then
-            // refuses delivery of the in-flight FOR_ITER item and drops that
-            // trace-attempt iteration. Those bodies stay in the interpreter
-            // until the orthodox fold recovery handles them.
-            let body_has_list_append = {
+            // A `LIST_APPEND` (inlined-comprehension accumulator) body is
+            // admitted only when the body performs no CALL: a per-element call
+            // that enters a user Python frame (a class ctor / user function)
+            // bumps the eval-loop entry odometer, and a subsequent mid-body
+            // abort routes through `fbw_foriter_inflight_take`, which REFUSES
+            // delivery to avoid a double-apply — dropping the trace-attempt
+            // iteration's item. That user-frame in-flight-delivery gap is a
+            // separate concern (single-executor tracing, gh#73/#34); decline
+            // call-bearing bodies to interpretation until it is closed.
+            //
+            // A value-producing but call-free body — arithmetic, subscript, or
+            // an Object-strategy element (`[(i, i) …]`, `[None …]`, `["s" …]`,
+            // `[{i: i} …]`, `[f"{i}" …]`) — is admissible. Its append is
+            // exact-resume safe: the only residual an Object-strategy append
+            // leaves in the folded body is the idempotent `list_write_barrier`,
+            // now exempt from the FBW body-effect accounting (it is not a body
+            // effect, mirroring RPython's `COND_CALL_GC_WB`, which pyjitpl never
+            // executes and the optimizer never treats as a side effect).
+            //
+            // A non-empty nested `BUILD_LIST` element (`[[i] …]`) is the one
+            // value-producing shape held back: the fold virtualizes the inner
+            // list, but its separately allocated backing block (`NewArray` /
+            // `NewArrayClear`) is not threaded into the append commit sub-walk's
+            // guard-exit resume data — `collect_outer_active_boxes` seeds the
+            // sub-walk's box set from jitcode liveness only, and the backing
+            // block has no liveness slot — so a deopt resolves it to a null
+            // OpRef and crashes. The orthodox recovery is recursive virtual-list
+            // forcing at the guard, threading each inner element box + length
+            // into resume data (mirroring `_visitor_walk_recursive` /
+            // `VArrayInfo`); until that lands the shape declines. An empty `[]`
+            // element is Empty-strategy (no backing block) and unaffected;
+            // tuple / set / dict elements take non-list allocation paths.
+            let (body_has_call, body_has_nonempty_list_build) = {
                 let mut scan_state = pyre_interpreter::OpArgState::default();
                 let mut scan_pc = pc + 1;
-                let mut found = false;
+                let mut has_call = false;
+                let mut has_nonempty_list_build = false;
                 while scan_pc < exit && scan_pc < instructions.len() {
-                    let (scan_instr, _) = scan_state.get(instructions[scan_pc]);
-                    if matches!(scan_instr, I::ListAppend { .. }) {
-                        found = true;
+                    let (scan_instr, scan_op_arg) = scan_state.get(instructions[scan_pc]);
+                    match scan_instr {
+                        I::Call { .. }
+                        | I::CallKw { .. }
+                        | I::CallFunctionEx
+                        | I::CallIntrinsic1 { .. } => has_call = true,
+                        I::BuildList { count } if count.get(scan_op_arg) > 0 => {
+                            has_nonempty_list_build = true
+                        }
+                        _ => {}
+                    }
+                    if has_call && has_nonempty_list_build {
                         break;
                     }
                     scan_pc += 1;
                 }
-                found
+                (has_call, has_nonempty_list_build)
             };
             let mut body_state = pyre_interpreter::OpArgState::default();
             let mut body_pc = pc + 1;
             while body_pc < exit && body_pc < instructions.len() {
                 let (body_instr, _) = body_state.get(instructions[body_pc]);
-                let permitted = if body_has_list_append {
-                    matches!(
+                let permitted = for_iter_body_op_is_jit_safe(body_instr)
+                    || matches!(
                         body_instr,
-                        I::LoadFast { .. }
-                            | I::LoadFastBorrow { .. }
-                            | I::LoadFastLoadFast { .. }
-                            | I::LoadFastBorrowLoadFastBorrow { .. }
-                            | I::LoadFastCheck { .. }
-                            | I::LoadFastAndClear { .. }
-                            | I::StoreFast { .. }
-                            | I::StoreFastLoadFast { .. }
-                            | I::StoreFastStoreFast { .. }
-                            | I::ListAppend { .. }
-                            | I::Copy { .. }
-                            | I::Swap { .. }
-                            | I::PopTop
-                            | I::PushNull
-                            | I::Nop
-                            | I::NotTaken
-                            | I::JumpBackward { .. }
-                            | I::JumpBackwardNoInterrupt { .. }
-                            | I::ExtendedArg
-                            | I::Cache
+                        I::StoreSubscr
+                            | I::StoreAttr { .. }
+                            | I::StoreName { .. }
+                            | I::StoreGlobal { .. }
+                            | I::StoreDeref { .. }
+                            | I::DeleteSubscr
+                            | I::DeleteAttr { .. }
+                            | I::LoadName { .. }
                     )
-                } else {
-                    for_iter_body_op_is_jit_safe(body_instr)
-                        || matches!(
-                            body_instr,
-                            I::StoreSubscr
-                                | I::StoreAttr { .. }
-                                | I::StoreName { .. }
-                                | I::StoreGlobal { .. }
-                                | I::StoreDeref { .. }
-                                | I::DeleteSubscr
-                                | I::DeleteAttr { .. }
-                                | I::LoadName { .. }
-                        )
-                };
+                    || (!body_has_call
+                        && !body_has_nonempty_list_build
+                        && matches!(body_instr, I::ListAppend { .. }));
                 if !permitted {
                     return false;
                 }
@@ -10057,13 +10068,61 @@ mod tests {
     }
 
     #[test]
-    fn for_iter_value_producing_list_append_comprehension_body_declines() {
+    fn for_iter_value_producing_list_append_comprehension_body_is_jit_safe() {
+        // A call-free LIST_APPEND body whose element is an Object-strategy value
+        // or an empty nested container is admitted: an Object-strategy append's
+        // only residual is the idempotent `list_write_barrier`, exempt from the
+        // FBW body-effect gate. An empty `[]` element is Empty-strategy (no
+        // backing block), so it does not hit the nested-backing-block gap below.
         use pyre_interpreter::compile_exec;
         for source in [
             "def f(n):\n    return [i + 1 for i in range(n)]\n",
             "def f(n):\n    return [-i for i in range(n)]\n",
             "def f(n):\n    return [(i, i) for i in range(n)]\n",
             "def f(n):\n    return ['s' for i in range(n)]\n",
+            "def f(n):\n    return [None for i in range(n)]\n",
+            "def f(n):\n    return [{i: i} for i in range(n)]\n",
+            "def f(n):\n    return [f'{i}' for i in range(n)]\n",
+            "def f(n):\n    return [[] for i in range(n)]\n",
+        ] {
+            let module = compile_exec(source).expect("test code should compile");
+            let code = function_code_from_module(&module, "f");
+            assert!(for_iter_bodies_all_jit_safe(&code));
+            assert_eq!(unsupported_jit_shape(&code), UnsupportedJitShape::None);
+        }
+    }
+
+    #[test]
+    fn for_iter_nonempty_nested_list_comprehension_body_declines() {
+        // A non-empty nested `BUILD_LIST` element (`[[i] …]`) declines: the fold
+        // virtualizes the inner list but leaves its separately allocated backing
+        // block unthreaded into the append commit sub-walk's guard-exit resume
+        // data, so a deopt crashes on a null OpRef. Held back until the orthodox
+        // recursive virtual-list forcing lands.
+        use pyre_interpreter::compile_exec;
+        for source in [
+            "def f(n):\n    return [[i] for i in range(n)]\n",
+            "def f(n):\n    return [[i, i + 1] for i in range(n)]\n",
+        ] {
+            let module = compile_exec(source).expect("test code should compile");
+            let code = function_code_from_module(&module, "f");
+            assert!(!for_iter_bodies_all_jit_safe(&code));
+            assert_eq!(
+                unsupported_jit_shape(&code),
+                UnsupportedJitShape::CurrentFrameOnly
+            );
+        }
+    }
+
+    #[test]
+    fn for_iter_call_bearing_list_append_comprehension_body_declines() {
+        // A per-element CALL enters a user Python frame; a mid-body abort then
+        // refuses the in-flight FOR_ITER delivery (a separate user-frame gap,
+        // gh#73/#34), so a call-bearing LIST_APPEND body stays interpreter-only.
+        use pyre_interpreter::compile_exec;
+        for source in [
+            "def f(n):\n    return [str(i) for i in range(n)]\n",
+            "def f(n):\n    def g(x):\n        return x\n    return [g(i) for i in range(n)]\n",
         ] {
             let module = compile_exec(source).expect("test code should compile");
             let code = function_code_from_module(&module, "f");

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -4990,21 +4990,15 @@ fn for_iter_bodies_all_jit_safe(code: &pyre_interpreter::CodeObject) -> bool {
             // executes and the optimizer never treats as a side effect).
             //
             // A non-empty nested `BUILD_LIST` element (`[[i] …]`) is the one
-            // value-producing shape held back: the fold virtualizes the inner
-            // list, but its separately allocated backing block (`NewArray` /
-            // `NewArrayClear`) is not threaded into the append commit sub-walk's
-            // guard-exit resume data — `collect_outer_active_boxes` seeds the
-            // sub-walk's box set from jitcode liveness only, and the backing
-            // block has no liveness slot — so a deopt resolves it to a null
-            // OpRef and crashes. The orthodox recovery is recursive virtual-list
-            // forcing at the guard, threading each inner element box + length
-            // into resume data (mirroring `_visitor_walk_recursive` /
-            // `VArrayInfo`); that rooting machinery is being built behind the
-            // DEFAULT-OFF `PYRE_NESTED_LIST_FOLD_VIRT` gate, so until it is
-            // proven bit-exact the gate stays off and the shape still declines.
-            // An empty `[]` element is Empty-strategy (no backing block) and
-            // unaffected; tuple / set / dict elements take non-list allocation
-            // paths.
+            // value-producing shape: the fold virtualizes the inner list, whose
+            // separately allocated backing block (`NewArray` / `NewArrayClear`)
+            // carries no jitcode-liveness slot. With the trace-time single-executor
+            // forks retired the append body no longer runs under a speculative-replay
+            // sub-walk, so the backing block is bound at every guard-exit deopt and
+            // the shape compiles bit-exact on all backends; admitted by default
+            // (`PYRE_NESTED_LIST_FOLD_VIRT`). An empty `[]` element is Empty-strategy
+            // (no backing block) and unaffected; tuple / set / dict elements take
+            // non-list allocation paths.
             let nested_list_fold_ok =
                 pyre_jit_trace::jitcode_dispatch::nested_list_fold_virt_enabled();
             let (body_has_call, body_has_nonempty_list_build) = {

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -10072,7 +10072,11 @@ mod tests {
         // or an empty nested container is admitted: an Object-strategy append's
         // only residual is the idempotent `list_write_barrier`, exempt from the
         // FBW body-effect gate. An empty `[]` element is Empty-strategy (no
-        // backing block), so it does not hit the nested-backing-block gap below.
+        // backing block). A non-empty nested `BUILD_LIST` element (`[[i] …]`) is
+        // also admitted (`nested_list_fold_virt_enabled`, default-on): with the
+        // trace-time single-executor forks retired the inner list's separately
+        // allocated backing block is bound at every guard-exit deopt without an
+        // extra resume-data root.
         use pyre_interpreter::compile_exec;
         for source in [
             "def f(n):\n    return [i + 1 for i in range(n)]\n",
@@ -10083,33 +10087,13 @@ mod tests {
             "def f(n):\n    return [{i: i} for i in range(n)]\n",
             "def f(n):\n    return [f'{i}' for i in range(n)]\n",
             "def f(n):\n    return [[] for i in range(n)]\n",
-        ] {
-            let module = compile_exec(source).expect("test code should compile");
-            let code = function_code_from_module(&module, "f");
-            assert!(for_iter_bodies_all_jit_safe(&code));
-            assert_eq!(unsupported_jit_shape(&code), UnsupportedJitShape::None);
-        }
-    }
-
-    #[test]
-    fn for_iter_nonempty_nested_list_comprehension_body_declines() {
-        // A non-empty nested `BUILD_LIST` element (`[[i] …]`) declines: the fold
-        // virtualizes the inner list but leaves its separately allocated backing
-        // block unthreaded into the append commit sub-walk's guard-exit resume
-        // data, so a deopt crashes on a null OpRef. Held back until the orthodox
-        // recursive virtual-list forcing lands.
-        use pyre_interpreter::compile_exec;
-        for source in [
             "def f(n):\n    return [[i] for i in range(n)]\n",
             "def f(n):\n    return [[i, i + 1] for i in range(n)]\n",
         ] {
             let module = compile_exec(source).expect("test code should compile");
             let code = function_code_from_module(&module, "f");
-            assert!(!for_iter_bodies_all_jit_safe(&code));
-            assert_eq!(
-                unsupported_jit_shape(&code),
-                UnsupportedJitShape::CurrentFrameOnly
-            );
+            assert!(for_iter_bodies_all_jit_safe(&code));
+            assert_eq!(unsupported_jit_shape(&code), UnsupportedJitShape::None);
         }
     }
 


### PR DESCRIPTION
## Summary

Fixes the Object-strategy inlined-comprehension `LIST_APPEND` fold (#389 item b): a hot
comprehension whose appended element goes to the list's Object strategy
(`[(i,i) for …]`, `[None …]`, `["s" …]`, `[{i:i} …]`, `[f"{i}" …]`) was yielding one
element short under the JIT. Also fixes two wasm-backend codegen gaps the same trace
exposed.

## Root cause (barrier body-effect misclassification)

The #171 orthodox `LIST_APPEND` fold descends `w_list_append`. Its Object-strategy arm
stores a GC ref and runs `list_write_barrier`, a `#[dont_look_inside]` **Void** residual.
The FBW body-effect gate treated that Void residual as a live-heap write, so the in-flight
`FOR_ITER` item was refuse-dropped — one iteration lost. The Int/Float arms store unboxed
scalars with no barrier, which is why only Object-strategy appends dropped.

This mirrors RPython, where the write barrier is `COND_CALL_GC_WB`: pyjitpl never executes
it (`executor.py:446`), the optimizer never treats it as a side effect
(`resoperation.py:1124`), and it is inserted only in the backend rewrite pass
(`rewrite.py:948`). It therefore cannot be a trace-level body-effect.

## Changes

**`jit: exempt list_write_barrier from FOR_ITER body-effect gate`**
- `is_list_write_barrier(addr)` in `jit_fnaddr.rs` matches the registered barrier fnaddr.
- Exempt it from `body_effect_candidate`, `fbw_mark_executed_nonpure_residual`, and the
  executed-effect odometer in `try_execute_residual_call_via_executor`. The barrier still
  executes concretely and is still recorded in IR — only the FBW body-effect bookkeeping
  is suppressed.
- Widen `for_iter_bodies_all_jit_safe` to admit a call-free `LIST_APPEND` body. A
  **non-empty nested `BUILD_LIST`** element (`[[i] for …]`) is deliberately declined — the
  fold virtualizes the inner list but does not thread its backing block into the append
  commit sub-walk's guard-exit resume data. Tracked as a follow-up in #389 (see comment).
- Add `synth/comprehension_object_append_hot.py`.

**`majit-backend-wasm: normalize op positions and resolve NONE fail-args`**
- Add `normalize_ops_for_codegen` (mirroring dynasm `prepare_ops_for_compile` /
  cranelift `normalize_ops_for_codegen_simple`) and call it in `compile_loop` /
  `compile_bridge`, so every non-Void-result op left unpositioned by the force path gets a
  stamped `OpRef` before codegen.
- `emit_resolve` spilled `value_types[opref.raw()]` for a `NONE` operand
  (`raw() == u32::MAX`), panicking OOB when a `Finish` op carried a `NONE` fail-arg (a dead
  deopt slot). Spill a zero placeholder instead; the blackhole never reads that slot back.

## Verification
- `check.py`: dynasm **226/226**, cranelift **226/226**, wasm **225/225**.
- `cargo test -p pyre-jit for_iter` 17/17; `cargo test -p pyre-interpreter is_list_write_barrier`.
- 3-way bit-exact parity on the synth (`total = 3000000`).

Assisted-by: Claude


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved JIT support for call-free list comprehensions, including tuples, strings, dictionaries, formatted strings, and empty nested lists.
  * Added optional support for optimizing nested list-comprehension patterns.

* **Bug Fixes**
  * Improved deoptimization and resume-data handling for complex optimized loops.
  * Prevented crashes caused by invalid optimization references.
  * Improved list write-barrier handling and reduced unnecessary effect tracking.
  * Disabled problematic unboxed list-append optimizations on WebAssembly by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->