### PR TITLE
interpreter: align stdlib state and expose public ASTs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2175,6 +2175,7 @@ dependencies = [
  "rustpython-compiler-core",
  "rustpython-host_env",
  "rustpython-literal",
+ "rustpython-ruff_text_size",
  "rustpython-sre_engine",
  "rustpython-unicode",
  "rustpython-wtf8",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,6 +71,7 @@ rustpython-common = { git = "https://github.com/RustPython/RustPython.git", rev 
 rustpython-literal = { git = "https://github.com/RustPython/RustPython.git", rev = "238bed66fbb0102a83dd9b5c8244e0276fbe8eac" }
 rustpython-compiler = { git = "https://github.com/RustPython/RustPython.git", rev = "238bed66fbb0102a83dd9b5c8244e0276fbe8eac" }
 rustpython-compiler-core = { git = "https://github.com/RustPython/RustPython.git", rev = "238bed66fbb0102a83dd9b5c8244e0276fbe8eac" }
+ruff-text-size = { package = "rustpython-ruff_text_size", git = "https://github.com/RustPython/ruff.git", tag = "0.15.19-rustpython" }
 num-complex = "0.4"
 rustpython-host_env = { git = "https://github.com/RustPython/RustPython.git", rev = "238bed66fbb0102a83dd9b5c8244e0276fbe8eac" }
 rustpython-wtf8 = { git = "https://github.com/RustPython/RustPython.git", rev = "238bed66fbb0102a83dd9b5c8244e0276fbe8eac" }

--- a/pyre/extra_tests/parity_tests/builtins_mutation_visible.py
+++ b/pyre/extra_tests/parity_tests/builtins_mutation_visible.py
@@ -3,12 +3,17 @@
 PyPy `pypy/interpreter/baseobjspace.py:642 ObjSpace.builtin` is the
 single `space.builtin.w_dict` consulted by `pick_builtin` and the
 LOAD_GLOBAL builtin fallback (`pyopcode.py:558-565`).  Any mutation
-on that dict is observable to subsequently constructed frames'
-globals because pyre's `fresh_dict_storage` reads from the same
-W_ModuleDictObject (previously it cloned a frozen DictStorage seed
-captured at EC construction time, which silently dropped runtime
-mutations).
+on that dict is observable through every frame's LOAD_GLOBAL builtin
+fallback.  Pyre likewise keeps the live builtins module as the frame's
+builtin owner; builtin names are not copied into module globals.
 """
+
+# A module namespace owns only its definitions plus `__builtins__`; names
+# supplied by the builtin fallback must not leak into globals()/dir(module).
+assert "__builtins__" in globals()
+assert "len" not in globals()
+assert "Ellipsis" not in globals()
+assert len(()) == 0
 
 bd = __builtins__.__dict__ if hasattr(__builtins__, "__dict__") else __builtins__
 
@@ -16,8 +21,7 @@ bd = __builtins__.__dict__ if hasattr(__builtins__, "__dict__") else __builtins_
 bd["_runtime_added_builtin"] = 42
 
 # (2) Defining a new function should see the freshly added builtin
-#     as part of its own globals fallback, because the function's
-#     frame seeds globals from the live builtins module.
+#     through its live builtins fallback.
 def f():
     return _runtime_added_builtin  # noqa: F821 -- injected at runtime
 

--- a/pyre/extra_tests/snippets/builtin_compile.py
+++ b/pyre/extra_tests/snippets/builtin_compile.py
@@ -44,3 +44,28 @@ def _check_flags_error(flags):
 
 _check_flags_error(99999)
 _check_flags_error(0x10000)
+
+
+# PyPy's compile_to_ast path returns public, mutable `_ast` heap objects.
+import ast
+
+tree = compile("x = f'{value!r:>10}'", "<ast>", "exec", ast.PyCF_ONLY_AST)
+assert isinstance(tree, ast.Module)
+assign = tree.body[0]
+assert assign.targets[0].id == "x"
+formatted = assign.value.values[0]
+assert formatted.value.id == "value"
+assert formatted.conversion == ord("r")
+assert formatted.format_spec.values[0].value == ">10"
+assert compile(tree, "<ast>", "exec", ast.PyCF_ONLY_AST) is tree
+
+tree = ast.parse(
+    'match value:\n'
+    '    case {"x": [first, *rest]} if rest:\n'
+    '        pass\n'
+)
+case = tree.body[0].cases[0]
+assert case.pattern.keys[0].value == "x"
+assert case.pattern.patterns[0].patterns[0].name == "first"
+assert case.pattern.patterns[0].patterns[1].name == "rest"
+assert case.guard.id == "rest"

--- a/pyre/pyre-interpreter/Cargo.toml
+++ b/pyre/pyre-interpreter/Cargo.toml
@@ -43,6 +43,7 @@ majit-metainterp = { workspace = true }
 stacker = { workspace = true }
 rustpython-compiler = { workspace = true }
 rustpython-compiler-core = { workspace = true }
+ruff-text-size = { workspace = true }
 num-complex = { workspace = true }
 malachite-bigint = { workspace = true }
 num-traits = { workspace = true }

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -1891,12 +1891,11 @@ pub(crate) fn list_iter_setstate_method(args: &[PyObjectRef]) -> PyResult {
         if pyre_object::w_list_iter_seq(args[0]).is_null() {
             return Ok(w_none());
         }
-        // CPython 3.14's listiter_setstate parses the state through an
-        // unsigned size; a negative value therefore becomes an exhausted
-        // cursor. This is a deliberate 3.14 oracle difference from PyPy's
-        // abstract sequence iterator, which clamps negative state to zero.
+        // PyPy `W_AbstractSeqIterObject.descr_setstate` clamps a negative
+        // cursor to zero for every live sequence iterator, including the
+        // specialised list iterator.
         if index < 0 {
-            index = i64::MAX;
+            index = 0;
         }
         pyre_object::w_list_iter_set_index(args[0], index);
     }

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -7025,6 +7025,7 @@ const PYCF_IGNORE_COOKIE: i64 = 0x0800;
 const PYCF_TYPE_COMMENTS: i64 = 0x4000_0000;
 const PYCF_ALLOW_TOP_LEVEL_AWAIT: i64 = 0x2000;
 const PYCF_ALLOW_INCOMPLETE_INPUT: i64 = 0x4000;
+const PYCF_OPTIMIZED_AST: i64 = 0x8000;
 const PYCF_ACCEPT_NULL_BYTES: i64 = 0x1000_0000;
 /// `future.py` `allowed_flags` — the union of the `__future__`
 /// `compiler_flag` bits (`CO_FUTURE_DIVISION` … `CO_FUTURE_ANNOTATIONS`),
@@ -7035,8 +7036,7 @@ fn builtin_compile(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> 
     // `compile(source, filename, mode, flags=0, dont_inherit=False,
     // optimize=-1, *, _feature_version=-1)`: the three required parameters and
     // flags/dont_inherit/optimize are positional-or-keyword; _feature_version
-    // is keyword-only and accepted but unused (pyre has no AST surface, so the
-    // PyCF_ONLY_AST feature-version gate never fires).
+    // is keyword-only.  PyCF_ONLY_AST follows PyPy's compile_to_ast boundary.
     let (pos, kwargs) = split_builtin_kwargs(args);
     kwarg_reject_unknown(
         kwargs,
@@ -7066,27 +7066,6 @@ fn builtin_compile(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> 
             pyre_object::w_str_get_value(filename_obj).to_string()
         } else {
             "<string>".to_string()
-        }
-    };
-    let source_str = unsafe {
-        if pyre_object::is_str(source) {
-            // The source is decoded to UTF-8 for the tokenizer; a lone
-            // surrogate raises `UnicodeEncodeError` (strict) rather than
-            // panicking in `w_str_get_value`.
-            let bytes = crate::type_methods::encode_object(source, "utf-8", "strict")?;
-            String::from_utf8(bytes).expect("strict utf-8 encode yields valid utf-8")
-        } else if pyre_object::bytesobject::is_bytes_like(source) {
-            // A bytes-like source honours the PEP 263 coding cookie and raises
-            // SyntaxError on undecodable bytes rather than lossily replacing.
-            crate::compile::decode_source_bytes(
-                pyre_object::bytesobject::bytes_like_data(source),
-                &filename,
-                false,
-            )?
-        } else {
-            return Err(crate::PyError::type_error(
-                "compile() arg 1 must be a string or bytes",
-            ));
         }
     };
     let mode = unsafe {
@@ -7120,6 +7099,7 @@ fn builtin_compile(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> 
         | PYCF_TYPE_COMMENTS
         | PYCF_ALLOW_TOP_LEVEL_AWAIT
         | PYCF_ALLOW_INCOMPLETE_INPUT
+        | PYCF_OPTIMIZED_AST
         | PYCF_IGNORE_COOKIE;
     if flags & !recognized != 0 {
         return Err(crate::PyError::value_error("compile(): unrecognised flags"));
@@ -7163,6 +7143,47 @@ fn builtin_compile(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> 
         optimize = 0;
     }
 
+    let source_str = unsafe {
+        if pyre_object::is_str(source) {
+            // The source is decoded to UTF-8 for the tokenizer; a lone
+            // surrogate raises `UnicodeEncodeError` (strict) rather than
+            // panicking in `w_str_get_value`.
+            let bytes = crate::type_methods::encode_object(source, "utf-8", "strict")?;
+            String::from_utf8(bytes).expect("strict utf-8 encode yields valid utf-8")
+        } else if pyre_object::bytesobject::is_bytes_like(source) {
+            // A bytes-like source honours the PEP 263 coding cookie and raises
+            // SyntaxError on undecodable bytes rather than lossily replacing.
+            crate::compile::decode_source_bytes(
+                pyre_object::bytesobject::bytes_like_data(source),
+                &filename,
+                false,
+            )?
+        } else {
+            // PyPy returns an AST input unchanged when ONLY_AST is requested.
+            // Keep this check at the public `_ast.AST` boundary so subclasses
+            // behave the same way as native nodes.
+            let ast_module = crate::importing::importhook(
+                "_ast",
+                PY_NULL,
+                PY_NULL,
+                0,
+                crate::call::take_last_exec_ctx(),
+            )?;
+            let ast_type = crate::baseobjspace::getattr_str(ast_module, "AST")?;
+            if crate::baseobjspace::isinstance_w(source, ast_type) {
+                if flags & PYCF_ONLY_AST != 0 {
+                    return Ok(source);
+                }
+                return Err(crate::PyError::not_implemented(
+                    "compiling an AST object is not implemented",
+                ));
+            }
+            return Err(crate::PyError::type_error(
+                "compile() arg 1 must be a string, bytes or AST object",
+            ));
+        }
+    };
+
     // Assemble CompileOpts: the __future__ feature bits, the two PyCF_*
     // bits the codegen honours, and the optimisation level.
     let opts = crate::compile::CompileOpts {
@@ -7172,6 +7193,9 @@ fn builtin_compile(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> 
         future_features: crate::CodeFlags::from_bits_truncate((flags & COMPILER_FLAGS) as u32),
         ..Default::default()
     };
+    if flags & PYCF_ONLY_AST != 0 {
+        return crate::module::_ast::convert::parse_to_object(&source_str, mode);
+    }
     let code = crate::compile::compile_source_with_opts(&source_str, mode, &filename, opts)
         .map_err(compile_err_to_syntax_error)?;
     let code_ptr = Box::into_raw(Box::new(code)) as *const ();

--- a/pyre/pyre-interpreter/src/call.rs
+++ b/pyre/pyre-interpreter/src/call.rs
@@ -2628,12 +2628,7 @@ fn call_user_function_with_args(func: PyObjectRef, args: &[PyObjectRef]) -> PyOb
     let func_code = unsafe {
         crate::w_code_get_ptr(w_code as pyre_object::PyObjectRef) as *const crate::CodeObject
     };
-    let exec_ctx = build_class_exec_ctx();
-    let exec_ctx = if exec_ctx.is_null() {
-        take_last_exec_ctx()
-    } else {
-        exec_ctx
-    };
+    let exec_ctx = take_last_exec_ctx();
 
     let code_ref = unsafe { &*func_code };
     let final_args = match fill_user_function_args(func, code_ref, args) {
@@ -2710,12 +2705,7 @@ fn call_user_function_resolved_frameless(func: PyObjectRef, args: &[PyObjectRef]
     let func_code = unsafe {
         crate::w_code_get_ptr(w_code as pyre_object::PyObjectRef) as *const crate::CodeObject
     };
-    let exec_ctx = build_class_exec_ctx();
-    let exec_ctx = if exec_ctx.is_null() {
-        take_last_exec_ctx()
-    } else {
-        exec_ctx
-    };
+    let exec_ctx = take_last_exec_ctx();
     let code_ref = unsafe { &*func_code };
 
     let mut frame =
@@ -2779,7 +2769,7 @@ fn call_metaclass_with_kwargs(
             Vec::new()
         };
         let frame = {
-            let stored = build_class_exec_ctx();
+            let stored = take_last_exec_ctx();
             if stored.is_null() {
                 std::ptr::null_mut()
             } else {
@@ -3145,7 +3135,7 @@ fn build_class_inner(
                     _ => Vec::new(),
                 };
                 let prepare_frame = {
-                    let stored = build_class_exec_ctx();
+                    let stored = take_last_exec_ctx();
                     if stored.is_null() {
                         std::ptr::null_mut()
                     } else {
@@ -3275,12 +3265,7 @@ fn build_class_inner(
     // class body stores into it after execution. This lets EnumDict etc.
     // track member definitions via __setitem__.
 
-    let stored = build_class_exec_ctx();
-    let exec_ctx = if stored.is_null() {
-        std::ptr::null::<crate::PyExecutionContext>()
-    } else {
-        stored
-    };
+    let exec_ctx = take_last_exec_ctx();
 
     // Create frame with class_locals set AND closure from enclosing scope.
     // PyPy: executes class body with w_locals = fresh dict, w_globals = module globals,
@@ -3880,12 +3865,7 @@ pub(crate) fn call_init_subclass_on_bases(
         .map(|(k, v)| (unsafe { pyre_object::w_str_get_wtf8(*k) }.to_owned(), *v))
         .collect();
     let frame = {
-        let stored = build_class_exec_ctx();
-        let stored = if stored.is_null() {
-            take_last_exec_ctx()
-        } else {
-            stored
-        };
+        let stored = take_last_exec_ctx();
         if stored.is_null() {
             std::ptr::null_mut()
         } else {
@@ -3910,29 +3890,6 @@ pub(crate) fn call_init_subclass_on_bases(
         ));
     }
     Ok(())
-}
-
-thread_local! {
-    /// Execution context for __build_class__ calls.
-    /// Set before eval_loop starts so build_class can access it.
-    static BUILD_CLASS_EXEC_CTX: Cell<*const crate::PyExecutionContext> =
-        const { Cell::new(std::ptr::null()) };
-}
-
-/// Set the execution context for __build_class__ to use.
-pub fn set_build_class_exec_ctx(ctx: *const crate::PyExecutionContext) {
-    BUILD_CLASS_EXEC_CTX.with(|c| c.set(ctx));
-}
-
-/// Read the __build_class__ execution context.
-///
-/// `dont_look_inside`: the `BUILD_CLASS_EXEC_CTX` thread-local `.with` read
-/// has no extractable graph (front::mir const-folds the `ThreadLocal` global
-/// to None), so the call stays a residual read via the registered fnaddr
-/// (`@dont_look_inside`, `rlib/jit.py:139`), the `take_last_exec_ctx` twin.
-#[majit_macros::dont_look_inside]
-pub fn build_class_exec_ctx() -> *const crate::PyExecutionContext {
-    BUILD_CLASS_EXEC_CTX.with(|c| c.get())
 }
 
 // ── Type calling (instance creation) ─────────────────────────────────

--- a/pyre/pyre-interpreter/src/executioncontext.rs
+++ b/pyre/pyre-interpreter/src/executioncontext.rs
@@ -994,23 +994,17 @@ impl ExecutionContext {
     }
 
     /// Celldict globals for a fresh module (`__main__`, imported source
-    /// modules). Seeds the builtins + `__builtins__` directly into
-    /// the `W_ModuleDictObject`'s authoritative cell storage so the JIT sees a
-    /// stable globals shape up front (same seed-vs-fallback rationale as
-    /// module dict. The `IntMutableCell` in-place write stands alone, matching
-    /// PyPy's `ModuleDictStrategy`.
+    /// modules). PyPy `imp.importing.exec_code_module` adds only the
+    /// `__builtins__` module to this namespace; builtin names remain a
+    /// LOAD_GLOBAL fallback and are not observable module globals.
     pub fn fresh_module_globals(&self) -> PyObjectRef {
         let dict = pyre_object::dictmultiobject::w_module_dict_new();
-        // Root the fresh dict across the seeding loop: each
-        // `w_dict_setitem_str_no_proxy` allocates a cell and may trigger a
-        // minor collection that would otherwise reclaim the not-yet-referenced
-        // dict.
+        // Root the fresh dict while installing `__builtins__`: allocating its
+        // module-dict cell may trigger a minor collection before the caller
+        // has stored the new namespace anywhere else.
         let _root = pyre_object::gc_roots::push_roots();
         pyre_object::gc_roots::pin_root(dict);
         unsafe {
-            for (k, v) in pyre_object::w_dict_str_entries(self.builtins_module) {
-                pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(dict, &k, v);
-            }
             let w_builtin = self.get_builtin();
             if !w_builtin.is_null() {
                 pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(

--- a/pyre/pyre-interpreter/src/jit_fnaddr.rs
+++ b/pyre/pyre-interpreter/src/jit_fnaddr.rs
@@ -1293,18 +1293,10 @@ pub fn jit_trace_fnaddrs() -> Vec<(&'static str, i64)> {
         "pyre_interpreter::call::clear_call_error",
         clear_call_error as *const (),
     );
-    // `#[dont_look_inside]` execution-context thread-local reads
-    // (`BUILD_CLASS_EXEC_CTX` / `LAST_EXEC_CTX`), twins of the call-error
-    // slot accessors above; front::mir const-folds the `ThreadLocal` global
-    // to None, so their bodies have no extractable graph and the call stays
-    // a residual read via the registered fnaddr.
-    let build_class_exec_ctx: fn() -> *const crate::PyExecutionContext =
-        crate::call::build_class_exec_ctx;
-    push_fnaddr(
-        &mut entries,
-        "pyre_interpreter::call::build_class_exec_ctx",
-        build_class_exec_ctx as *const (),
-    );
+    // `#[dont_look_inside]` execution-context thread-local read, a twin of
+    // the call-error slot accessors above. front::mir const-folds the
+    // `ThreadLocal` global to None, so its body has no extractable graph and
+    // the call stays a residual read via the registered fnaddr.
     let take_last_exec_ctx: fn() -> *const crate::PyExecutionContext =
         crate::call::take_last_exec_ctx;
     push_fnaddr(

--- a/pyre/pyre-interpreter/src/module/_ast/convert.rs
+++ b/pyre/pyre-interpreter/src/module/_ast/convert.rs
@@ -1,0 +1,1293 @@
+//! RustPython/Ruff AST → interpreter-level `_ast` objects.
+//!
+//! PyPy's `ast.Node.to_object(space)` performs this same boundary conversion:
+//! parser nodes stay native to the compiler, while the public `ast` module sees
+//! ordinary heap objects carrying ASDL fields and source locations.
+
+use pyre_object::{PY_NULL, PyObjectRef};
+use rustpython_compiler::{ast, parser};
+
+pub fn parse_to_object(source: &str, mode: crate::compile::Mode) -> crate::PyResult {
+    let parsed = match mode {
+        crate::compile::Mode::Eval => parser::parse_expression(source)
+            .map(|parsed| ParsedRoot::Expression(parsed.into_syntax())),
+        crate::compile::Mode::Exec
+        | crate::compile::Mode::Single
+        | crate::compile::Mode::BlockExpr => {
+            parser::parse_module(source).map(|parsed| ParsedRoot::Module(parsed.into_syntax()))
+        }
+    }
+    .map_err(|error| crate::PyError::syntax_error(error.to_string()))?;
+
+    let ast_module = crate::importing::importhook(
+        "_ast",
+        PY_NULL,
+        PY_NULL,
+        0,
+        crate::call::take_last_exec_ctx(),
+    )?;
+    let _roots = pyre_object::gc_roots::push_roots();
+    pyre_object::gc_roots::pin_root(ast_module);
+    let converter = Converter { source, ast_module };
+    match parsed {
+        ParsedRoot::Expression(module) => converter.node(
+            "Expression",
+            None,
+            &[("body", converter.expr(&module.body)?)],
+        ),
+        ParsedRoot::Module(module) => {
+            let root_name = if matches!(mode, crate::compile::Mode::Single) {
+                "Interactive"
+            } else {
+                "Module"
+            };
+            let body = converter.stmt_list(&module.body)?;
+            if root_name == "Module" {
+                converter.node(
+                    root_name,
+                    None,
+                    &[("body", body), ("type_ignores", converter.list(Vec::new()))],
+                )
+            } else {
+                converter.node(root_name, None, &[("body", body)])
+            }
+        }
+    }
+}
+
+enum ParsedRoot {
+    Module(ast::ModModule),
+    Expression(ast::ModExpression),
+}
+
+struct Converter<'a> {
+    source: &'a str,
+    ast_module: PyObjectRef,
+}
+
+impl Converter<'_> {
+    fn pin(&self, value: PyObjectRef) -> PyObjectRef {
+        pyre_object::gc_roots::pin_root(value);
+        value
+    }
+
+    fn list(&self, values: Vec<PyObjectRef>) -> PyObjectRef {
+        self.pin(pyre_object::w_list_new(values))
+    }
+
+    fn string(&self, value: &str) -> PyObjectRef {
+        self.pin(pyre_object::w_str_new(value))
+    }
+
+    fn optional(&self, value: Option<PyObjectRef>) -> PyObjectRef {
+        value.unwrap_or_else(pyre_object::w_none)
+    }
+
+    fn node(
+        &self,
+        name: &str,
+        range: Option<(u32, u32)>,
+        fields: &[(&str, PyObjectRef)],
+    ) -> crate::PyResult {
+        let node_type = crate::baseobjspace::getattr_str(self.ast_module, name)?;
+        let node = self.pin(pyre_object::w_instance_new(node_type));
+        for &(field, value) in fields {
+            crate::baseobjspace::setattr_str(node, field, value)?;
+        }
+        if let Some((start, end)) = range {
+            let (lineno, col_offset) = self.location(start as usize);
+            let (end_lineno, end_col_offset) = self.location(end as usize);
+            for (field, value) in [
+                ("lineno", lineno),
+                ("col_offset", col_offset),
+                ("end_lineno", end_lineno),
+                ("end_col_offset", end_col_offset),
+            ] {
+                crate::baseobjspace::setattr_str(
+                    node,
+                    field,
+                    pyre_object::w_int_new(value as i64),
+                )?;
+            }
+        }
+        Ok(node)
+    }
+
+    fn location(&self, offset: usize) -> (usize, usize) {
+        let bytes = self.source.as_bytes();
+        let offset = offset.min(bytes.len());
+        let prefix = &bytes[..offset];
+        let line_start = prefix
+            .iter()
+            .rposition(|byte| *byte == b'\n')
+            .map_or(0, |i| i + 1);
+        (
+            prefix.iter().filter(|byte| **byte == b'\n').count() + 1,
+            offset - line_start,
+        )
+    }
+
+    fn stmt_list(&self, stmts: &[ast::Stmt]) -> crate::PyResult {
+        stmts
+            .iter()
+            .map(|stmt| self.stmt(stmt))
+            .collect::<Result<Vec<_>, _>>()
+            .map(|items| self.list(items))
+    }
+
+    fn expr_list(&self, exprs: &[ast::Expr]) -> crate::PyResult {
+        exprs
+            .iter()
+            .map(|expr| self.expr(expr))
+            .collect::<Result<Vec<_>, _>>()
+            .map(|items| self.list(items))
+    }
+
+    fn name_list<T: AsRef<str>>(&self, names: &[T]) -> PyObjectRef {
+        self.list(
+            names
+                .iter()
+                .map(|name| self.string(name.as_ref()))
+                .collect(),
+        )
+    }
+
+    fn stmt(&self, stmt: &ast::Stmt) -> crate::PyResult {
+        use ast::Stmt;
+        match stmt {
+            Stmt::FunctionDef(node) => {
+                let name = if node.is_async {
+                    "AsyncFunctionDef"
+                } else {
+                    "FunctionDef"
+                };
+                let decorators = node
+                    .decorator_list
+                    .iter()
+                    .map(|d| self.expr(&d.expression))
+                    .collect::<Result<Vec<_>, _>>()?;
+                self.node(
+                    name,
+                    Some(range(node.range)),
+                    &[
+                        ("name", self.string(node.name.as_str())),
+                        ("args", self.parameters(&node.parameters)?),
+                        ("body", self.stmt_list(&node.body)?),
+                        ("decorator_list", self.list(decorators)),
+                        (
+                            "returns",
+                            self.optional(
+                                node.returns.as_deref().map(|v| self.expr(v)).transpose()?,
+                            ),
+                        ),
+                        (
+                            "type_comment",
+                            self.optional(
+                                node.runtime_type_comment.as_deref().map(|v| self.string(v)),
+                            ),
+                        ),
+                        (
+                            "type_params",
+                            self.type_params(node.type_params.as_deref())?,
+                        ),
+                    ],
+                )
+            }
+            Stmt::ClassDef(node) => {
+                let decorators = node
+                    .decorator_list
+                    .iter()
+                    .map(|d| self.expr(&d.expression))
+                    .collect::<Result<Vec<_>, _>>()?;
+                let (bases, keywords) = if let Some(arguments) = node.arguments.as_deref() {
+                    (
+                        self.expr_list(&arguments.args)?,
+                        self.keyword_list(&arguments.keywords)?,
+                    )
+                } else {
+                    (self.list(Vec::new()), self.list(Vec::new()))
+                };
+                self.node(
+                    "ClassDef",
+                    Some(range(node.range)),
+                    &[
+                        ("name", self.string(node.name.as_str())),
+                        ("bases", bases),
+                        ("keywords", keywords),
+                        ("body", self.stmt_list(&node.body)?),
+                        ("decorator_list", self.list(decorators)),
+                        (
+                            "type_params",
+                            self.type_params(node.type_params.as_deref())?,
+                        ),
+                    ],
+                )
+            }
+            Stmt::Return(node) => self.node(
+                "Return",
+                Some(range(node.range)),
+                &[(
+                    "value",
+                    self.optional(node.value.as_deref().map(|v| self.expr(v)).transpose()?),
+                )],
+            ),
+            Stmt::Delete(node) => self.node(
+                "Delete",
+                Some(range(node.range)),
+                &[("targets", self.expr_list(&node.targets)?)],
+            ),
+            Stmt::TypeAlias(node) => self.node(
+                "TypeAlias",
+                Some(range(node.range)),
+                &[
+                    ("name", self.expr(&node.name)?),
+                    (
+                        "type_params",
+                        self.type_params(node.type_params.as_deref())?,
+                    ),
+                    ("value", self.expr(&node.value)?),
+                ],
+            ),
+            Stmt::Assign(node) => self.node(
+                "Assign",
+                Some(range(node.range)),
+                &[
+                    ("targets", self.expr_list(&node.targets)?),
+                    ("value", self.expr(&node.value)?),
+                    (
+                        "type_comment",
+                        self.optional(node.runtime_type_comment.as_deref().map(|v| self.string(v))),
+                    ),
+                ],
+            ),
+            Stmt::AugAssign(node) => self.node(
+                "AugAssign",
+                Some(range(node.range)),
+                &[
+                    ("target", self.expr(&node.target)?),
+                    ("op", self.operator(node.op)?),
+                    ("value", self.expr(&node.value)?),
+                ],
+            ),
+            Stmt::AnnAssign(node) => self.node(
+                "AnnAssign",
+                Some(range(node.range)),
+                &[
+                    ("target", self.expr(&node.target)?),
+                    ("annotation", self.expr(&node.annotation)?),
+                    (
+                        "value",
+                        self.optional(node.value.as_deref().map(|v| self.expr(v)).transpose()?),
+                    ),
+                    (
+                        "simple",
+                        pyre_object::w_int_new(
+                            node.runtime_simple.unwrap_or(node.simple as i32) as i64
+                        ),
+                    ),
+                ],
+            ),
+            Stmt::For(node) => self.node(
+                if node.is_async { "AsyncFor" } else { "For" },
+                Some(range(node.range)),
+                &[
+                    ("target", self.expr(&node.target)?),
+                    ("iter", self.expr(&node.iter)?),
+                    ("body", self.stmt_list(&node.body)?),
+                    ("orelse", self.stmt_list(&node.orelse)?),
+                    (
+                        "type_comment",
+                        self.optional(node.runtime_type_comment.as_deref().map(|v| self.string(v))),
+                    ),
+                ],
+            ),
+            Stmt::While(node) => self.node(
+                "While",
+                Some(range(node.range)),
+                &[
+                    ("test", self.expr(&node.test)?),
+                    ("body", self.stmt_list(&node.body)?),
+                    ("orelse", self.stmt_list(&node.orelse)?),
+                ],
+            ),
+            Stmt::If(node) => {
+                let mut orelse = Vec::new();
+                for clause in node.elif_else_clauses.iter().rev() {
+                    let body = self.stmt_list(&clause.body)?;
+                    if let Some(test) = clause.test.as_ref() {
+                        orelse = vec![self.node(
+                            "If",
+                            Some(range(clause.range)),
+                            &[
+                                ("test", self.expr(test)?),
+                                ("body", body),
+                                ("orelse", self.list(orelse)),
+                            ],
+                        )?];
+                    } else {
+                        orelse = unsafe { pyre_object::w_list_items_copy_as_vec(body) };
+                    }
+                }
+                self.node(
+                    "If",
+                    Some(range(node.range)),
+                    &[
+                        ("test", self.expr(&node.test)?),
+                        ("body", self.stmt_list(&node.body)?),
+                        ("orelse", self.list(orelse)),
+                    ],
+                )
+            }
+            Stmt::With(node) => self.node(
+                if node.is_async { "AsyncWith" } else { "With" },
+                Some(range(node.range)),
+                &[
+                    ("items", self.with_items(&node.items)?),
+                    ("body", self.stmt_list(&node.body)?),
+                    (
+                        "type_comment",
+                        self.optional(node.runtime_type_comment.as_deref().map(|v| self.string(v))),
+                    ),
+                ],
+            ),
+            Stmt::Raise(node) => self.node(
+                "Raise",
+                Some(range(node.range)),
+                &[
+                    (
+                        "exc",
+                        self.optional(node.exc.as_deref().map(|v| self.expr(v)).transpose()?),
+                    ),
+                    (
+                        "cause",
+                        self.optional(node.cause.as_deref().map(|v| self.expr(v)).transpose()?),
+                    ),
+                ],
+            ),
+            Stmt::Try(node) => self.node(
+                if node.is_star { "TryStar" } else { "Try" },
+                Some(range(node.range)),
+                &[
+                    ("body", self.stmt_list(&node.body)?),
+                    ("handlers", self.handlers(&node.handlers)?),
+                    ("orelse", self.stmt_list(&node.orelse)?),
+                    ("finalbody", self.stmt_list(&node.finalbody)?),
+                ],
+            ),
+            Stmt::Assert(node) => self.node(
+                "Assert",
+                Some(range(node.range)),
+                &[
+                    ("test", self.expr(&node.test)?),
+                    (
+                        "msg",
+                        self.optional(node.msg.as_deref().map(|v| self.expr(v)).transpose()?),
+                    ),
+                ],
+            ),
+            Stmt::Import(node) => self.node(
+                "Import",
+                Some(range(node.range)),
+                &[("names", self.aliases(&node.names)?)],
+            ),
+            Stmt::ImportFrom(node) => self.node(
+                "ImportFrom",
+                Some(range(node.range)),
+                &[
+                    (
+                        "module",
+                        self.optional(node.module.as_ref().map(|v| self.string(v.as_str()))),
+                    ),
+                    ("names", self.aliases(&node.names)?),
+                    (
+                        "level",
+                        pyre_object::w_int_new(
+                            node.runtime_level.unwrap_or(node.level as i32) as i64
+                        ),
+                    ),
+                ],
+            ),
+            Stmt::Global(node) => self.node(
+                "Global",
+                Some(range(node.range)),
+                &[("names", self.name_list(&node.names))],
+            ),
+            Stmt::Nonlocal(node) => self.node(
+                "Nonlocal",
+                Some(range(node.range)),
+                &[("names", self.name_list(&node.names))],
+            ),
+            Stmt::Expr(node) => self.node(
+                "Expr",
+                Some(range(node.range)),
+                &[("value", self.expr(&node.value)?)],
+            ),
+            Stmt::Pass(node) => self.node("Pass", Some(range(node.range)), &[]),
+            Stmt::Break(node) => self.node("Break", Some(range(node.range)), &[]),
+            Stmt::Continue(node) => self.node("Continue", Some(range(node.range)), &[]),
+            Stmt::Match(node) => {
+                let cases = node
+                    .cases
+                    .iter()
+                    .map(|case| self.match_case(case))
+                    .collect::<Result<Vec<_>, _>>()?;
+                self.node(
+                    "Match",
+                    Some(range(node.range)),
+                    &[
+                        ("subject", self.expr(&node.subject)?),
+                        ("cases", self.list(cases)),
+                    ],
+                )
+            }
+            Stmt::IpyEscapeCommand(_) => Err(crate::PyError::not_implemented(
+                "AST conversion for IPython escape commands is not implemented",
+            )),
+        }
+    }
+
+    fn expr(&self, expr: &ast::Expr) -> crate::PyResult {
+        use ast::Expr;
+        match expr {
+            Expr::BoolOp(n) => self.node(
+                "BoolOp",
+                Some(range(n.range)),
+                &[
+                    ("op", self.boolop(n.op)?),
+                    ("values", self.expr_list(&n.values)?),
+                ],
+            ),
+            Expr::Named(n) => self.node(
+                "NamedExpr",
+                Some(range(n.range)),
+                &[
+                    ("target", self.expr(&n.target)?),
+                    ("value", self.expr(&n.value)?),
+                ],
+            ),
+            Expr::BinOp(n) => self.node(
+                "BinOp",
+                Some(range(n.range)),
+                &[
+                    ("left", self.expr(&n.left)?),
+                    ("op", self.operator(n.op)?),
+                    ("right", self.expr(&n.right)?),
+                ],
+            ),
+            Expr::UnaryOp(n) => self.node(
+                "UnaryOp",
+                Some(range(n.range)),
+                &[
+                    ("op", self.unaryop(n.op)?),
+                    ("operand", self.expr(&n.operand)?),
+                ],
+            ),
+            Expr::Lambda(n) => self.node(
+                "Lambda",
+                Some(range(n.range)),
+                &[
+                    ("args", self.parameters_opt(n.parameters.as_deref())?),
+                    ("body", self.expr(&n.body)?),
+                ],
+            ),
+            Expr::If(n) => self.node(
+                "IfExp",
+                Some(range(n.range)),
+                &[
+                    ("test", self.expr(&n.test)?),
+                    ("body", self.expr(&n.body)?),
+                    ("orelse", self.expr(&n.orelse)?),
+                ],
+            ),
+            Expr::Dict(n) => {
+                let keys = n
+                    .items
+                    .iter()
+                    .map(|item| {
+                        item.key
+                            .as_ref()
+                            .map(|key| self.expr(key))
+                            .transpose()
+                            .map(|v| self.optional(v))
+                    })
+                    .collect::<Result<Vec<_>, _>>()?;
+                let values = n
+                    .items
+                    .iter()
+                    .map(|item| self.expr(&item.value))
+                    .collect::<Result<Vec<_>, _>>()?;
+                self.node(
+                    "Dict",
+                    Some(range(n.range)),
+                    &[("keys", self.list(keys)), ("values", self.list(values))],
+                )
+            }
+            Expr::Set(n) => self.node(
+                "Set",
+                Some(range(n.range)),
+                &[("elts", self.expr_list(&n.elts)?)],
+            ),
+            Expr::ListComp(n) => self.node(
+                "ListComp",
+                Some(range(n.range)),
+                &[
+                    ("elt", self.expr(&n.elt)?),
+                    ("generators", self.comprehensions(&n.generators)?),
+                ],
+            ),
+            Expr::SetComp(n) => self.node(
+                "SetComp",
+                Some(range(n.range)),
+                &[
+                    ("elt", self.expr(&n.elt)?),
+                    ("generators", self.comprehensions(&n.generators)?),
+                ],
+            ),
+            Expr::DictComp(n) => self.node(
+                "DictComp",
+                Some(range(n.range)),
+                &[
+                    ("key", self.expr(&n.key)?),
+                    ("value", self.expr(&n.value)?),
+                    ("generators", self.comprehensions(&n.generators)?),
+                ],
+            ),
+            Expr::Generator(n) => self.node(
+                "GeneratorExp",
+                Some(range(n.range)),
+                &[
+                    ("elt", self.expr(&n.elt)?),
+                    ("generators", self.comprehensions(&n.generators)?),
+                ],
+            ),
+            Expr::Await(n) => self.node(
+                "Await",
+                Some(range(n.range)),
+                &[("value", self.expr(&n.value)?)],
+            ),
+            Expr::Yield(n) => self.node(
+                "Yield",
+                Some(range(n.range)),
+                &[(
+                    "value",
+                    self.optional(n.value.as_deref().map(|v| self.expr(v)).transpose()?),
+                )],
+            ),
+            Expr::YieldFrom(n) => self.node(
+                "YieldFrom",
+                Some(range(n.range)),
+                &[("value", self.expr(&n.value)?)],
+            ),
+            Expr::Compare(n) => {
+                let ops = n
+                    .ops
+                    .iter()
+                    .map(|op| self.cmpop(*op))
+                    .collect::<Result<Vec<_>, _>>()?;
+                self.node(
+                    "Compare",
+                    Some(range(n.range)),
+                    &[
+                        ("left", self.expr(&n.left)?),
+                        ("ops", self.list(ops)),
+                        ("comparators", self.expr_list(&n.comparators)?),
+                    ],
+                )
+            }
+            Expr::Call(n) => self.node(
+                "Call",
+                Some(range(n.range)),
+                &[
+                    ("func", self.expr(&n.func)?),
+                    ("args", self.expr_list(&n.arguments.args)?),
+                    ("keywords", self.keyword_list(&n.arguments.keywords)?),
+                ],
+            ),
+            Expr::StringLiteral(n) => self.constant(
+                range(n.range),
+                self.string(n.value.to_str()),
+                if n.value.is_unicode() {
+                    self.string("u")
+                } else {
+                    pyre_object::w_none()
+                },
+            ),
+            Expr::BytesLiteral(n) => self.constant(
+                range(n.range),
+                self.pin(pyre_object::w_bytes_from_bytes(
+                    &n.value.bytes().collect::<Vec<_>>(),
+                )),
+                pyre_object::w_none(),
+            ),
+            Expr::NumberLiteral(n) => self.constant(
+                range(n.range),
+                self.number(&n.value)?,
+                pyre_object::w_none(),
+            ),
+            Expr::BooleanLiteral(n) => self.constant(
+                range(n.range),
+                pyre_object::w_bool_from(n.value),
+                pyre_object::w_none(),
+            ),
+            Expr::NoneLiteral(n) => {
+                self.constant(range(n.range), pyre_object::w_none(), pyre_object::w_none())
+            }
+            Expr::EllipsisLiteral(n) => self.constant(
+                range(n.range),
+                pyre_object::w_ellipsis(),
+                pyre_object::w_none(),
+            ),
+            Expr::Constant(n) => self.constant(
+                range(n.range),
+                self.constant_value(&n.value)?,
+                self.optional(n.kind.as_deref().map(|v| self.string(v))),
+            ),
+            Expr::Attribute(n) => self.node(
+                "Attribute",
+                Some(range(n.range)),
+                &[
+                    ("value", self.expr(&n.value)?),
+                    ("attr", self.string(n.attr.as_str())),
+                    ("ctx", self.context(n.ctx)?),
+                ],
+            ),
+            Expr::Subscript(n) => self.node(
+                "Subscript",
+                Some(range(n.range)),
+                &[
+                    ("value", self.expr(&n.value)?),
+                    ("slice", self.expr(&n.slice)?),
+                    ("ctx", self.context(n.ctx)?),
+                ],
+            ),
+            Expr::Starred(n) => self.node(
+                "Starred",
+                Some(range(n.range)),
+                &[
+                    ("value", self.expr(&n.value)?),
+                    ("ctx", self.context(n.ctx)?),
+                ],
+            ),
+            Expr::Name(n) => self.node(
+                "Name",
+                Some(range(n.range)),
+                &[
+                    ("id", self.string(n.id.as_str())),
+                    ("ctx", self.context(n.ctx)?),
+                ],
+            ),
+            Expr::List(n) => self.node(
+                "List",
+                Some(range(n.range)),
+                &[
+                    ("elts", self.expr_list(&n.elts)?),
+                    ("ctx", self.context(n.ctx)?),
+                ],
+            ),
+            Expr::Tuple(n) => self.node(
+                "Tuple",
+                Some(range(n.range)),
+                &[
+                    ("elts", self.expr_list(&n.elts)?),
+                    ("ctx", self.context(n.ctx)?),
+                ],
+            ),
+            Expr::Slice(n) => self.node(
+                "Slice",
+                Some(range(n.range)),
+                &[
+                    (
+                        "lower",
+                        self.optional(n.lower.as_deref().map(|v| self.expr(v)).transpose()?),
+                    ),
+                    (
+                        "upper",
+                        self.optional(n.upper.as_deref().map(|v| self.expr(v)).transpose()?),
+                    ),
+                    (
+                        "step",
+                        self.optional(n.step.as_deref().map(|v| self.expr(v)).transpose()?),
+                    ),
+                ],
+            ),
+            Expr::FString(n) => self.fstring(n),
+            Expr::TString(_) | Expr::IpyEscapeCommand(_) => Err(crate::PyError::not_implemented(
+                "AST conversion for template strings is not implemented",
+            )),
+        }
+    }
+
+    fn fstring(&self, node: &ast::ExprFString) -> crate::PyResult {
+        if let Some(values) = node.runtime_joined_str.as_deref() {
+            return self.node(
+                "JoinedStr",
+                Some(range(node.range)),
+                &[("values", self.expr_list(values)?)],
+            );
+        }
+        if let Some(values) = node.runtime_values.as_deref() {
+            let values = values
+                .iter()
+                .map(|value| {
+                    value
+                        .as_ref()
+                        .map(|value| self.expr(value))
+                        .transpose()
+                        .map(|value| self.optional(value))
+                })
+                .collect::<Result<Vec<_>, _>>()?;
+            return self.node(
+                "JoinedStr",
+                Some(range(node.range)),
+                &[("values", self.list(values))],
+            );
+        }
+
+        let mut values = Vec::new();
+        for part in node.value.iter() {
+            match part {
+                ast::FStringPart::Literal(literal) => values.push(self.constant(
+                    range(literal.range),
+                    self.string(&literal.value),
+                    pyre_object::w_none(),
+                )?),
+                ast::FStringPart::FString(fstring) => {
+                    values.extend(self.interpolated_elements(&fstring.elements)?);
+                }
+            }
+        }
+        self.node(
+            "JoinedStr",
+            Some(range(node.range)),
+            &[("values", self.list(values))],
+        )
+    }
+
+    fn interpolated_elements(
+        &self,
+        elements: &[ast::InterpolatedStringElement],
+    ) -> Result<Vec<PyObjectRef>, crate::PyError> {
+        let mut values = Vec::new();
+        for element in elements {
+            match element {
+                ast::InterpolatedStringElement::Literal(literal) => values.push(self.constant(
+                    range(literal.range),
+                    self.string(&literal.value),
+                    pyre_object::w_none(),
+                )?),
+                ast::InterpolatedStringElement::Interpolation(interpolation) => {
+                    let format_spec = interpolation
+                        .format_spec
+                        .as_deref()
+                        .map(|spec| {
+                            let values = self.interpolated_elements(&spec.elements)?;
+                            self.node(
+                                "JoinedStr",
+                                Some(range(spec.range)),
+                                &[("values", self.list(values))],
+                            )
+                        })
+                        .transpose()?;
+                    values.push(self.node(
+                        "FormattedValue",
+                        Some(range(interpolation.range)),
+                        &[
+                            ("value", self.expr(&interpolation.expression)?),
+                            (
+                                "conversion",
+                                pyre_object::w_int_new(interpolation.conversion as i8 as i64),
+                            ),
+                            ("format_spec", self.optional(format_spec)),
+                        ],
+                    )?);
+                }
+            }
+        }
+        Ok(values)
+    }
+
+    fn match_case(&self, case: &ast::MatchCase) -> crate::PyResult {
+        self.node(
+            "match_case",
+            None,
+            &[
+                ("pattern", self.pattern(&case.pattern)?),
+                (
+                    "guard",
+                    self.optional(case.guard.as_deref().map(|v| self.expr(v)).transpose()?),
+                ),
+                ("body", self.stmt_list(&case.body)?),
+            ],
+        )
+    }
+
+    fn pattern(&self, pattern: &ast::Pattern) -> crate::PyResult {
+        match pattern {
+            ast::Pattern::MatchValue(node) => self.node(
+                "MatchValue",
+                Some(range(node.range)),
+                &[("value", self.expr(&node.value)?)],
+            ),
+            ast::Pattern::MatchSingleton(node) => self.node(
+                "MatchSingleton",
+                Some(range(node.range)),
+                &[(
+                    "value",
+                    match node.value {
+                        ast::Singleton::None => pyre_object::w_none(),
+                        ast::Singleton::True => pyre_object::w_bool_from(true),
+                        ast::Singleton::False => pyre_object::w_bool_from(false),
+                    },
+                )],
+            ),
+            ast::Pattern::MatchSequence(node) => self.node(
+                "MatchSequence",
+                Some(range(node.range)),
+                &[("patterns", self.pattern_list(&node.patterns)?)],
+            ),
+            ast::Pattern::MatchMapping(node) => self.node(
+                "MatchMapping",
+                Some(range(node.range)),
+                &[
+                    ("keys", self.expr_list(&node.keys)?),
+                    ("patterns", self.pattern_list(&node.patterns)?),
+                    (
+                        "rest",
+                        self.optional(node.rest.as_ref().map(|name| self.string(name.as_str()))),
+                    ),
+                ],
+            ),
+            ast::Pattern::MatchClass(node) => {
+                let kwd_attrs = node
+                    .arguments
+                    .keywords
+                    .iter()
+                    .map(|keyword| self.string(keyword.attr.as_str()))
+                    .collect();
+                let kwd_patterns = node
+                    .arguments
+                    .keywords
+                    .iter()
+                    .map(|keyword| self.pattern(&keyword.pattern))
+                    .collect::<Result<Vec<_>, _>>()?;
+                self.node(
+                    "MatchClass",
+                    Some(range(node.range)),
+                    &[
+                        ("cls", self.expr(&node.cls)?),
+                        ("patterns", self.pattern_list(&node.arguments.patterns)?),
+                        ("kwd_attrs", self.list(kwd_attrs)),
+                        ("kwd_patterns", self.list(kwd_patterns)),
+                    ],
+                )
+            }
+            ast::Pattern::MatchStar(node) => self.node(
+                "MatchStar",
+                Some(range(node.range)),
+                &[(
+                    "name",
+                    self.optional(node.name.as_ref().map(|name| self.string(name.as_str()))),
+                )],
+            ),
+            ast::Pattern::MatchAs(node) => self.node(
+                "MatchAs",
+                Some(range(node.range)),
+                &[
+                    (
+                        "pattern",
+                        self.optional(
+                            node.pattern
+                                .as_deref()
+                                .map(|pattern| self.pattern(pattern))
+                                .transpose()?,
+                        ),
+                    ),
+                    (
+                        "name",
+                        self.optional(node.name.as_ref().map(|name| self.string(name.as_str()))),
+                    ),
+                ],
+            ),
+            ast::Pattern::MatchOr(node) => self.node(
+                "MatchOr",
+                Some(range(node.range)),
+                &[("patterns", self.pattern_list(&node.patterns)?)],
+            ),
+        }
+    }
+
+    fn pattern_list(&self, patterns: &[ast::Pattern]) -> crate::PyResult {
+        patterns
+            .iter()
+            .map(|pattern| self.pattern(pattern))
+            .collect::<Result<Vec<_>, _>>()
+            .map(|patterns| self.list(patterns))
+    }
+
+    fn constant(
+        &self,
+        range: (u32, u32),
+        value: PyObjectRef,
+        kind: PyObjectRef,
+    ) -> crate::PyResult {
+        self.node("Constant", Some(range), &[("value", value), ("kind", kind)])
+    }
+
+    fn number(&self, value: &ast::Number) -> crate::PyResult {
+        Ok(match value {
+            ast::Number::Int(value) => {
+                let int_type =
+                    crate::typedef::gettypefor(&pyre_object::INT_TYPE).unwrap_or(PY_NULL);
+                crate::call::call_function_impl_result(
+                    int_type,
+                    &[self.string(&value.to_string())],
+                )?
+            }
+            ast::Number::Float(value) => self.pin(pyre_object::w_float_new(*value)),
+            ast::Number::Complex { real, imag } => {
+                self.pin(pyre_object::w_complex_new(*real, *imag))
+            }
+        })
+    }
+
+    fn constant_value(&self, value: &ast::ConstantValue) -> crate::PyResult {
+        Ok(match value {
+            ast::ConstantValue::None => pyre_object::w_none(),
+            ast::ConstantValue::Boolean(value) => pyre_object::w_bool_from(*value),
+            ast::ConstantValue::Str(value) => self.string(value),
+            ast::ConstantValue::Bytes(value) => self.pin(pyre_object::w_bytes_from_bytes(value)),
+            ast::ConstantValue::Integer(value) => {
+                let int_type =
+                    crate::typedef::gettypefor(&pyre_object::INT_TYPE).unwrap_or(PY_NULL);
+                crate::call::call_function_impl_result(int_type, &[self.string(value)])?
+            }
+            ast::ConstantValue::Float(value) => self.pin(pyre_object::w_float_new(*value)),
+            ast::ConstantValue::Complex { real, imag } => {
+                self.pin(pyre_object::w_complex_new(*real, *imag))
+            }
+            ast::ConstantValue::Ellipsis => pyre_object::w_ellipsis(),
+            ast::ConstantValue::Tuple(values) => {
+                let values = values
+                    .iter()
+                    .map(|v| self.constant_value(v))
+                    .collect::<Result<Vec<_>, _>>()?;
+                self.pin(pyre_object::w_tuple_new(values))
+            }
+            ast::ConstantValue::Frozenset(_) => {
+                return Err(crate::PyError::not_implemented(
+                    "frozenset AST constants are not implemented",
+                ));
+            }
+        })
+    }
+
+    fn singleton(&self, name: &str) -> crate::PyResult {
+        let typ = crate::baseobjspace::getattr_str(self.ast_module, name)?;
+        Ok(self.pin(pyre_object::w_instance_new(typ)))
+    }
+
+    fn context(&self, value: ast::ExprContext) -> crate::PyResult {
+        self.singleton(match value {
+            ast::ExprContext::Load => "Load",
+            ast::ExprContext::Store => "Store",
+            ast::ExprContext::Del => "Del",
+            ast::ExprContext::Invalid => "Load",
+        })
+    }
+    fn boolop(&self, value: ast::BoolOp) -> crate::PyResult {
+        self.singleton(match value {
+            ast::BoolOp::And => "And",
+            ast::BoolOp::Or => "Or",
+        })
+    }
+    fn operator(&self, value: ast::Operator) -> crate::PyResult {
+        self.singleton(match value {
+            ast::Operator::Add => "Add",
+            ast::Operator::Sub => "Sub",
+            ast::Operator::Mult => "Mult",
+            ast::Operator::MatMult => "MatMult",
+            ast::Operator::Div => "Div",
+            ast::Operator::Mod => "Mod",
+            ast::Operator::Pow => "Pow",
+            ast::Operator::LShift => "LShift",
+            ast::Operator::RShift => "RShift",
+            ast::Operator::BitOr => "BitOr",
+            ast::Operator::BitXor => "BitXor",
+            ast::Operator::BitAnd => "BitAnd",
+            ast::Operator::FloorDiv => "FloorDiv",
+        })
+    }
+    fn unaryop(&self, value: ast::UnaryOp) -> crate::PyResult {
+        self.singleton(match value {
+            ast::UnaryOp::Invert => "Invert",
+            ast::UnaryOp::Not => "Not",
+            ast::UnaryOp::UAdd => "UAdd",
+            ast::UnaryOp::USub => "USub",
+        })
+    }
+    fn cmpop(&self, value: ast::CmpOp) -> crate::PyResult {
+        self.singleton(match value {
+            ast::CmpOp::Eq => "Eq",
+            ast::CmpOp::NotEq => "NotEq",
+            ast::CmpOp::Lt => "Lt",
+            ast::CmpOp::LtE => "LtE",
+            ast::CmpOp::Gt => "Gt",
+            ast::CmpOp::GtE => "GtE",
+            ast::CmpOp::Is => "Is",
+            ast::CmpOp::IsNot => "IsNot",
+            ast::CmpOp::In => "In",
+            ast::CmpOp::NotIn => "NotIn",
+        })
+    }
+
+    fn parameters_opt(&self, parameters: Option<&ast::Parameters>) -> crate::PyResult {
+        match parameters {
+            Some(p) => self.parameters(p),
+            None => self.parameters(&ast::Parameters::default()),
+        }
+    }
+
+    fn parameters(&self, p: &ast::Parameters) -> crate::PyResult {
+        let posonlyargs = p
+            .posonlyargs
+            .iter()
+            .map(|p| self.parameter(&p.parameter))
+            .collect::<Result<Vec<_>, _>>()?;
+        let args = p
+            .args
+            .iter()
+            .map(|p| self.parameter(&p.parameter))
+            .collect::<Result<Vec<_>, _>>()?;
+        let kwonlyargs = p
+            .kwonlyargs
+            .iter()
+            .map(|p| self.parameter(&p.parameter))
+            .collect::<Result<Vec<_>, _>>()?;
+        let mut defaults = Vec::new();
+        defaults.extend(
+            p.posonlyargs
+                .iter()
+                .chain(&p.args)
+                .filter_map(|p| p.default.as_deref())
+                .map(|v| self.expr(v))
+                .collect::<Result<Vec<_>, _>>()?,
+        );
+        let kw_defaults = p
+            .kwonlyargs
+            .iter()
+            .map(|p| {
+                p.default
+                    .as_deref()
+                    .map(|v| self.expr(v))
+                    .transpose()
+                    .map(|v| self.optional(v))
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        self.node(
+            "arguments",
+            None,
+            &[
+                ("posonlyargs", self.list(posonlyargs)),
+                ("args", self.list(args)),
+                (
+                    "vararg",
+                    self.optional(p.vararg.as_deref().map(|v| self.parameter(v)).transpose()?),
+                ),
+                ("kwonlyargs", self.list(kwonlyargs)),
+                ("kw_defaults", self.list(kw_defaults)),
+                (
+                    "kwarg",
+                    self.optional(p.kwarg.as_deref().map(|v| self.parameter(v)).transpose()?),
+                ),
+                ("defaults", self.list(defaults)),
+            ],
+        )
+    }
+
+    fn parameter(&self, p: &ast::Parameter) -> crate::PyResult {
+        self.node(
+            "arg",
+            Some(range(p.range)),
+            &[
+                ("arg", self.string(p.name.as_str())),
+                (
+                    "annotation",
+                    self.optional(p.annotation.as_deref().map(|v| self.expr(v)).transpose()?),
+                ),
+                ("type_comment", pyre_object::w_none()),
+            ],
+        )
+    }
+
+    fn keyword_list(&self, keywords: &[ast::Keyword]) -> crate::PyResult {
+        keywords
+            .iter()
+            .map(|k| {
+                self.node(
+                    "keyword",
+                    Some(range(k.range)),
+                    &[
+                        (
+                            "arg",
+                            self.optional(k.arg.as_ref().map(|v| self.string(v.as_str()))),
+                        ),
+                        ("value", self.expr(&k.value)?),
+                    ],
+                )
+            })
+            .collect::<Result<Vec<_>, _>>()
+            .map(|items| self.list(items))
+    }
+
+    fn aliases(&self, aliases: &[ast::Alias]) -> crate::PyResult {
+        aliases
+            .iter()
+            .map(|a| {
+                self.node(
+                    "alias",
+                    Some(range(a.range)),
+                    &[
+                        ("name", self.string(a.name.as_str())),
+                        (
+                            "asname",
+                            self.optional(a.asname.as_ref().map(|v| self.string(v.as_str()))),
+                        ),
+                    ],
+                )
+            })
+            .collect::<Result<Vec<_>, _>>()
+            .map(|items| self.list(items))
+    }
+
+    fn with_items(&self, items: &[ast::WithItem]) -> crate::PyResult {
+        items
+            .iter()
+            .map(|item| {
+                self.node(
+                    "withitem",
+                    None,
+                    &[
+                        ("context_expr", self.expr(&item.context_expr)?),
+                        (
+                            "optional_vars",
+                            self.optional(
+                                item.optional_vars
+                                    .as_deref()
+                                    .map(|v| self.expr(v))
+                                    .transpose()?,
+                            ),
+                        ),
+                    ],
+                )
+            })
+            .collect::<Result<Vec<_>, _>>()
+            .map(|items| self.list(items))
+    }
+
+    fn comprehensions(&self, comprehensions: &[ast::Comprehension]) -> crate::PyResult {
+        comprehensions
+            .iter()
+            .map(|c| {
+                self.node(
+                    "comprehension",
+                    None,
+                    &[
+                        ("target", self.expr(&c.target)?),
+                        ("iter", self.expr(&c.iter)?),
+                        ("ifs", self.expr_list(&c.ifs)?),
+                        ("is_async", pyre_object::w_int_new(c.is_async as i64)),
+                    ],
+                )
+            })
+            .collect::<Result<Vec<_>, _>>()
+            .map(|items| self.list(items))
+    }
+
+    fn handlers(&self, handlers: &[ast::ExceptHandler]) -> crate::PyResult {
+        handlers
+            .iter()
+            .map(|handler| match handler {
+                ast::ExceptHandler::ExceptHandler(h) => self.node(
+                    "ExceptHandler",
+                    Some(range(h.range)),
+                    &[
+                        (
+                            "type",
+                            self.optional(h.type_.as_deref().map(|v| self.expr(v)).transpose()?),
+                        ),
+                        (
+                            "name",
+                            self.optional(h.name.as_ref().map(|v| self.string(v.as_str()))),
+                        ),
+                        ("body", self.stmt_list(&h.body)?),
+                    ],
+                ),
+            })
+            .collect::<Result<Vec<_>, _>>()
+            .map(|items| self.list(items))
+    }
+
+    fn type_params(&self, params: Option<&ast::TypeParams>) -> crate::PyResult {
+        let Some(params) = params else {
+            return Ok(self.list(Vec::new()));
+        };
+        params
+            .type_params
+            .iter()
+            .map(|param| match param {
+                ast::TypeParam::TypeVar(p) => self.node(
+                    "TypeVar",
+                    Some(range(p.range)),
+                    &[
+                        ("name", self.string(p.name.as_str())),
+                        (
+                            "bound",
+                            self.optional(p.bound.as_deref().map(|v| self.expr(v)).transpose()?),
+                        ),
+                        (
+                            "default_value",
+                            self.optional(p.default.as_deref().map(|v| self.expr(v)).transpose()?),
+                        ),
+                    ],
+                ),
+                ast::TypeParam::TypeVarTuple(p) => self.node(
+                    "TypeVarTuple",
+                    Some(range(p.range)),
+                    &[
+                        ("name", self.string(p.name.as_str())),
+                        (
+                            "default_value",
+                            self.optional(p.default.as_deref().map(|v| self.expr(v)).transpose()?),
+                        ),
+                    ],
+                ),
+                ast::TypeParam::ParamSpec(p) => self.node(
+                    "ParamSpec",
+                    Some(range(p.range)),
+                    &[
+                        ("name", self.string(p.name.as_str())),
+                        (
+                            "default_value",
+                            self.optional(p.default.as_deref().map(|v| self.expr(v)).transpose()?),
+                        ),
+                    ],
+                ),
+            })
+            .collect::<Result<Vec<_>, _>>()
+            .map(|items| self.list(items))
+    }
+}
+
+fn range(range: impl RangeParts) -> (u32, u32) {
+    range.parts()
+}
+
+trait RangeParts {
+    fn parts(self) -> (u32, u32);
+}
+
+impl RangeParts for ruff_text_size::TextRange {
+    fn parts(self) -> (u32, u32) {
+        (self.start().to_u32(), self.end().to_u32())
+    }
+}

--- a/pyre/pyre-interpreter/src/module/_ast/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_ast/mod.rs
@@ -1,7 +1,8 @@
 //! _ast module — PyPy: pypy/module/_ast/
 //!
-//! Exposes the AST node type hierarchy as plain type stubs — enough to
-//! satisfy `from _ast import *` in `ast.py`.  Real AST construction is
-//! not supported (pyre uses RustPython's compiler).
+//! Exposes the AST node hierarchy and converts RustPython/Ruff parser trees
+//! into the interpreter-level objects consumed by `ast.py`.
 
 crate::pyre_module_init!(moduledef);
+
+pub mod convert;

--- a/pyre/pyre-interpreter/src/module/_ast/moduledef.rs
+++ b/pyre/pyre-interpreter/src/module/_ast/moduledef.rs
@@ -5,14 +5,132 @@
 
 use pyre_object::PyObjectRef;
 
+const LOCATION_ATTRIBUTES: &[&str] = &["lineno", "col_offset", "end_lineno", "end_col_offset"];
+
+fn tuple_of_names(names: &[&str]) -> PyObjectRef {
+    pyre_object::w_tuple_new(names.iter().map(|name| pyre_object::w_str_new(name)).collect())
+}
+
+fn ast_init(args: &[PyObjectRef]) -> crate::PyResult {
+    let (positional, kwargs) = crate::builtins::split_builtin_kwargs(args);
+    let Some((&zelf, values)) = positional.split_first() else {
+        return Err(crate::PyError::type_error("AST.__init__() missing self"));
+    };
+    let fields_obj = crate::baseobjspace::getattr_str(zelf, "_fields")?;
+    let fields = unsafe { pyre_object::w_tuple_items_copy_as_vec(fields_obj) };
+    if values.len() > fields.len() {
+        return Err(crate::PyError::type_error(format!(
+            "{} constructor takes at most {} positional arguments",
+            unsafe { pyre_object::type_name_of(zelf) },
+            fields.len()
+        )));
+    }
+    let mut positional_names = Vec::with_capacity(values.len());
+    for (&field, &value) in fields.iter().zip(values) {
+        let name = unsafe { pyre_object::w_str_get_value(field) };
+        positional_names.push(name.to_owned());
+        crate::baseobjspace::setattr_str(zelf, name, value)?;
+    }
+    if let Some(kwargs) = kwargs {
+        for (name, value) in unsafe { pyre_object::w_dict_str_entries(kwargs) } {
+            if name == "__pyre_kw__" {
+                continue;
+            }
+            if positional_names.iter().any(|positional| positional == &name) {
+                return Err(crate::PyError::type_error(format!(
+                    "{} got multiple values for argument '{name}'",
+                    unsafe { pyre_object::type_name_of(zelf) }
+                )));
+            }
+            crate::baseobjspace::setattr_str(zelf, &name, value)?;
+        }
+    }
+    Ok(pyre_object::w_none())
+}
+
+fn node_fields(name: &str) -> &'static [&'static str] {
+    match name {
+        "Module" => &["body", "type_ignores"],
+        "Interactive" => &["body"],
+        "Expression" => &["body"],
+        "FunctionType" => &["argtypes", "returns"],
+        "FunctionDef" | "AsyncFunctionDef" => &["name", "args", "body", "decorator_list", "returns", "type_comment", "type_params"],
+        "ClassDef" => &["name", "bases", "keywords", "body", "decorator_list", "type_params"],
+        "Return" => &["value"],
+        "Delete" => &["targets"],
+        "Assign" => &["targets", "value", "type_comment"],
+        "TypeAlias" => &["name", "type_params", "value"],
+        "AugAssign" => &["target", "op", "value"],
+        "AnnAssign" => &["target", "annotation", "value", "simple"],
+        "For" | "AsyncFor" => &["target", "iter", "body", "orelse", "type_comment"],
+        "While" | "If" => &["test", "body", "orelse"],
+        "With" | "AsyncWith" => &["items", "body", "type_comment"],
+        "Match" => &["subject", "cases"],
+        "Raise" => &["exc", "cause"],
+        "Try" | "TryStar" => &["body", "handlers", "orelse", "finalbody"],
+        "Assert" => &["test", "msg"],
+        "Import" => &["names"],
+        "ImportFrom" => &["module", "names", "level"],
+        "Global" | "Nonlocal" => &["names"],
+        "Expr" => &["value"],
+        "Pass" | "Break" | "Continue" => &[],
+        "BoolOp" => &["op", "values"],
+        "NamedExpr" => &["target", "value"],
+        "BinOp" => &["left", "op", "right"],
+        "UnaryOp" => &["op", "operand"],
+        "Lambda" => &["args", "body"],
+        "IfExp" => &["test", "body", "orelse"],
+        "Dict" => &["keys", "values"],
+        "Set" => &["elts"],
+        "ListComp" | "SetComp" | "GeneratorExp" => &["elt", "generators"],
+        "DictComp" => &["key", "value", "generators"],
+        "Await" | "Yield" | "YieldFrom" => &["value"],
+        "Compare" => &["left", "ops", "comparators"],
+        "Call" => &["func", "args", "keywords"],
+        "FormattedValue" => &["value", "conversion", "format_spec"],
+        "JoinedStr" => &["values"],
+        "Constant" => &["value", "kind"],
+        "Attribute" => &["value", "attr", "ctx"],
+        "Subscript" => &["value", "slice", "ctx"],
+        "Starred" => &["value", "ctx"],
+        "Name" => &["id", "ctx"],
+        "List" | "Tuple" => &["elts", "ctx"],
+        "Slice" => &["lower", "upper", "step"],
+        "ExceptHandler" => &["type", "name", "body"],
+        "MatchValue" => &["value"],
+        "MatchSingleton" => &["value"],
+        "MatchSequence" => &["patterns"],
+        "MatchMapping" => &["keys", "patterns", "rest"],
+        "MatchClass" => &["cls", "patterns", "kwd_attrs", "kwd_patterns"],
+        "MatchStar" => &["name"],
+        "MatchAs" => &["pattern", "name"],
+        "MatchOr" => &["patterns"],
+        "TypeIgnore" => &["lineno", "tag"],
+        "TypeVar" => &["name", "bound", "default_value"],
+        "ParamSpec" | "TypeVarTuple" => &["name", "default_value"],
+        "comprehension" => &["target", "iter", "ifs", "is_async"],
+        "arguments" => &["posonlyargs", "args", "vararg", "kwonlyargs", "kw_defaults", "kwarg", "defaults"],
+        "arg" => &["arg", "annotation", "type_comment"],
+        "keyword" => &["arg", "value"],
+        "alias" => &["name", "asname"],
+        "withitem" => &["context_expr", "optional_vars"],
+        "match_case" => &["pattern", "guard", "body"],
+        _ => &[],
+    }
+}
+
+fn node_has_location(name: &str) -> bool {
+    matches!(name, "FunctionDef" | "AsyncFunctionDef" | "ClassDef" | "Return" | "Delete" | "Assign" | "TypeAlias" | "AugAssign" | "AnnAssign" | "For" | "AsyncFor" | "While" | "If" | "With" | "AsyncWith" | "Match" | "Raise" | "Try" | "TryStar" | "Assert" | "Import" | "ImportFrom" | "Global" | "Nonlocal" | "Expr" | "Pass" | "Break" | "Continue" | "BoolOp" | "NamedExpr" | "BinOp" | "UnaryOp" | "Lambda" | "IfExp" | "Dict" | "Set" | "ListComp" | "SetComp" | "DictComp" | "GeneratorExp" | "Await" | "Yield" | "YieldFrom" | "Compare" | "Call" | "FormattedValue" | "JoinedStr" | "Constant" | "Attribute" | "Subscript" | "Starred" | "Name" | "List" | "Tuple" | "Slice" | "ExceptHandler" | "MatchValue" | "MatchSingleton" | "MatchSequence" | "MatchMapping" | "MatchClass" | "MatchStar" | "MatchAs" | "MatchOr" | "TypeVar" | "ParamSpec" | "TypeVarTuple" | "arg" | "keyword" | "alias")
+}
+
 /// _ast stub — PyPy: pypy/module/_ast/
 ///
 /// Exposes the AST node type hierarchy. The node types are created as **heap
 /// types** (via `type(name, bases, {})`) following the ASDL hierarchy
 /// (`AST` → abstract group → concrete node), so `ast.py` can subclass them
 /// (`class Suite(mod)`) and monkeypatch them (`Tuple.dims = property(...)`),
-/// matching CPython where `_ast` types are heap types. Actual AST node
-/// construction is not supported because pyre uses RustPython's compiler.
+/// matching CPython where `_ast` types are heap types. Compiler-native Ruff
+/// nodes are converted to instances of these public types by `convert.rs`.
 pub fn register_module(ns: pyre_object::PyObjectRef) {
     // `type(name, (base,), {"__module__": "ast"})` — a fresh heap type. The
     // generated AST types report `__module__ == "ast"` (astcompiler/ast.py:150;
@@ -21,6 +139,37 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
         let dict = pyre_object::w_dict_new();
         crate::baseobjspace::setitem(dict, pyre_object::w_str_new("__module__"), pyre_object::w_str_new("ast"))
             .expect("set __module__ on _ast type namespace");
+        crate::baseobjspace::setitem(
+            dict,
+            pyre_object::w_str_new("_fields"),
+            tuple_of_names(node_fields(name)),
+        )
+        .expect("set _fields on _ast type namespace");
+        crate::baseobjspace::setitem(
+            dict,
+            pyre_object::w_str_new("_attributes"),
+            tuple_of_names(if node_has_location(name) {
+                LOCATION_ATTRIBUTES
+            } else {
+                &[]
+            }),
+        )
+        .expect("set _attributes on _ast type namespace");
+        let field_types = pyre_object::w_dict_new();
+        for field in node_fields(name) {
+            crate::baseobjspace::setitem(
+                field_types,
+                pyre_object::w_str_new(field),
+                crate::typedef::w_object(),
+            )
+            .expect("set _field_types item");
+        }
+        crate::baseobjspace::setitem(
+            dict,
+            pyre_object::w_str_new("_field_types"),
+            field_types,
+        )
+        .expect("set _field_types on _ast type namespace");
         let args = [
             pyre_object::w_str_new(name),
             pyre_object::w_tuple_new(vec![base]),
@@ -31,6 +180,12 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
 
     // Root: AST(object).
     let ast = make("AST", crate::typedef::w_object());
+    crate::baseobjspace::setattr_str(
+        ast,
+        "__init__",
+        crate::make_builtin_function("__init__", ast_init),
+    )
+    .expect("set AST.__init__");
     crate::module_ns_store(ns, "AST", ast);
 
     // Abstract groups (direct AST subclasses) and their concrete members,

--- a/pyre/pyre-interpreter/src/module/itertools/interp_itertools.rs
+++ b/pyre/pyre-interpreter/src/module/itertools/interp_itertools.rs
@@ -79,9 +79,13 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
     // callable (the classmethod is read straight off the function object, so
     // it is called with just the outer iterable).
     let from_iterable_fn = crate::make_builtin_function("from_iterable", |args| {
-        let outer = args.first().copied().ok_or_else(|| {
-            crate::PyError::type_error("from_iterable() missing 1 required positional argument")
-        })?;
+        if args.len() != 1 {
+            return Err(crate::PyError::type_error(format!(
+                "chain.from_iterable() takes exactly one argument ({} given)",
+                args.len()
+            )));
+        }
+        let outer = args[0];
         let iterables = crate::baseobjspace::iter(outer)?;
         Ok(pyre_object::interp_itertools::w_chain_new(iterables))
     });

--- a/pyre/pyre-jit/tests/gc_stress.rs
+++ b/pyre/pyre-jit/tests/gc_stress.rs
@@ -26,7 +26,7 @@
 
 use std::rc::Rc;
 
-use pyre_interpreter::call::{register_build_class, set_build_class_exec_ctx, set_last_exec_ctx};
+use pyre_interpreter::call::{register_build_class, set_last_exec_ctx};
 use pyre_interpreter::importing;
 use pyre_interpreter::pyframe::PyFrame;
 use pyre_interpreter::{Mode, PyExecutionContext, compile_source_with_filename};
@@ -59,7 +59,6 @@ fn run_harness(program: &str, name: &str, vacuity_label: &str) -> Result<(), Str
     register_build_class();
 
     let execution_context = Rc::new(PyExecutionContext::default());
-    set_build_class_exec_ctx(Rc::as_ptr(&execution_context));
     set_last_exec_ctx(Rc::as_ptr(&execution_context));
 
     let mut frame = PyFrame::new_with_context(code, execution_context)

--- a/pyre/pyre-wasm/src/lib.rs
+++ b/pyre/pyre-wasm/src/lib.rs
@@ -404,12 +404,9 @@ fn run_python_impl(source: &str) -> String {
     // JIT-compiled loop — can resolve its parent frame instead of tripping the
     // fail-fast topframe assert.
     pyre_interpreter::call::set_last_exec_ctx(std::rc::Rc::as_ptr(&execution_context));
-    // Register the __build_class__ callback and seed its exec-context slot
-    // (pyrex setup_exec_context does the same). Without this, a `class Sub(...,
-    // kw=...)` body cannot resolve the live frame in call_init_subclass_on_bases
-    // and __init_subclass__ keyword arguments are rejected.
+    // Register the __build_class__ callback. Class construction resolves the
+    // live frame from the execution-context slot seeded above.
     pyre_interpreter::call::register_build_class();
-    pyre_interpreter::call::set_build_class_exec_ctx(std::rc::Rc::as_ptr(&execution_context));
     let mut frame =
         match pyre_interpreter::pyframe::PyFrame::new_with_context(code, execution_context) {
             Ok(frame) => frame,

--- a/pyre/pyrex/src/lib.rs
+++ b/pyre/pyrex/src/lib.rs
@@ -6,7 +6,7 @@ use std::rc::Rc;
 use lexopt::Arg::*;
 use lexopt::ValueExt;
 
-use pyre_interpreter::call::{register_build_class, set_build_class_exec_ctx, set_last_exec_ctx};
+use pyre_interpreter::call::{register_build_class, set_last_exec_ctx};
 use pyre_interpreter::importing;
 use pyre_interpreter::pyframe::PyFrame;
 use pyre_interpreter::{
@@ -649,14 +649,13 @@ fn maybe_print_jit_stats() {
 
 /// Shared top-level launcher bootstrap for `run_source` and `run_module`:
 /// register `__build_class__`, create the process `ExecutionContext`, seed
-/// the build-class and `LAST_EXEC_CTX` TLS slots so
+/// the `LAST_EXEC_CTX` TLS slot so
 /// `space.getexecutioncontext()` (sys.settrace/getframe) resolves from the
 /// first user statement, and install SIGINT handling (app_main.py:926).
 fn setup_exec_context() -> Rc<PyExecutionContext> {
     // Register __build_class__ callback (PyPy: setup_builtin_modules)
     register_build_class();
     let execution_context = Rc::new(PyExecutionContext::default());
-    set_build_class_exec_ctx(Rc::as_ptr(&execution_context));
     set_last_exec_ctx(Rc::as_ptr(&execution_context));
     unsafe {
         let ec_ptr = Rc::as_ptr(&execution_context) as *mut PyExecutionContext;

--- a/pyre/pyrex/src/repl.rs
+++ b/pyre/pyrex/src/repl.rs
@@ -6,7 +6,7 @@ use rustpython_compiler::{
     parser::{InterpolatedStringErrorType, LexicalErrorType, ParseErrorType},
 };
 
-use pyre_interpreter::call::{register_build_class, set_build_class_exec_ctx};
+use pyre_interpreter::call::register_build_class;
 use pyre_interpreter::importing;
 use pyre_interpreter::{PyDisplay, PyError, PyExecutionContext};
 use pyre_jit::eval::eval_with_jit;
@@ -48,7 +48,6 @@ pub fn run_repl(quiet: bool, no_site: bool) {
 
     let execution_context = Rc::new(PyExecutionContext::default());
     register_build_class();
-    set_build_class_exec_ctx(Rc::as_ptr(&execution_context));
     // app_main.py:926 — install SIGINT → default_int_handler so Ctrl-C
     // at the REPL raises KeyboardInterrupt rather than killing the
     // process, and register the periodic signal-check action.


### PR DESCRIPTION
## Summary

- keep builtin names out of fresh module globals and rely on the live `__builtins__` fallback, matching PyPy module namespaces
- consolidate class construction on the active execution context and remove the duplicate class-specific TLS slot
- clamp negative sequence-iterator pickle state to zero and validate `chain.from_iterable` arity
- implement `compile(..., PyCF_ONLY_AST)` as a compiler-native Ruff AST to public `_ast` heap-object conversion
- define AST fields, location attributes, constructors, f-string nodes, pattern-matching nodes, and AST identity for `PyCF_ONLY_AST`

## Root cause and PyPy parity

The `_ast` module previously exposed empty type stubs and `compile` ignored `PyCF_ONLY_AST`, so `ast.parse()` returned a code object. PyPy parses to its native compiler AST and then calls `Node.to_object(space)` at the public boundary. This change adds that same boundary conversion while continuing to use the pinned RustPython compiler API; no RustPython patch or local RustPython dependency is needed.

The earlier commits also follow PyPy in keeping builtins behind module `__builtins__`, clamping sequence iterator state, and using the active execution context for class construction.

AST-object-to-bytecode conversion remains separate work; this PR covers source-to-public-AST conversion and the `PyCF_ONLY_AST` identity case.

## Validation

- `python3 scripts/extract-llbc.py pyre-interpreter`
- `cargo check --workspace --features dynasm`
- `cargo test --workspace --features dynasm`
- `target/debug/pyre pyre/extra_tests/snippets/builtin_compile.py`
- targeted `ast.parse` coverage for functions, comparisons, imports, comprehensions, async/await, f-strings, and structural pattern matching
- `traceback` and `asyncio` import smoke tests
- `python3 pyre/check.py --backend dynasm --no-synthetic` (all 10 benchmarks plus loop-reentry passed; 11/11)