### PR TITLE
interpreter: implement PyPy-shaped FileIO basics

### DIFF
--- a/pyre/extra_tests/snippets/stdlib_io.py
+++ b/pyre/extra_tests/snippets/stdlib_io.py
@@ -4,7 +4,16 @@ from io import BufferedReader, BytesIO, FileIO, RawIOBase, StringIO, TextIOWrapp
 from testutils import assert_raises
 
 fi = FileIO("README.md")
+assert isinstance(fi, RawIOBase)
+assert issubclass(FileIO, RawIOBase)
+assert fi.mode == "rb"
+assert fi.readable()
+assert not fi.writable()
 assert fi.seekable()
+assert fi.tell() == 0
+assert fi.seek(2) == 2
+assert fi.tell() == 2
+assert fi.seek(0) == 0
 bb = BufferedReader(fi)
 assert bb.seekable()
 
@@ -40,6 +49,23 @@ with FileIO("README.md") as fio:
     assert len(nres) == 1
     nres = fio.read(2)
     assert len(nres) == 2
+
+
+# closefd=False leaves an externally owned descriptor usable after close.
+read_fd, write_fd = os.pipe()
+os.write(write_fd, b"pipe")
+os.close(write_fd)
+with FileIO(read_fd, closefd=False) as fio:
+    assert fio.closefd is False
+    assert fio.read() == b"pipe"
+os.close(read_fd)
+
+with assert_raises(ValueError):
+    FileIO("README.md", closefd=False)
+
+for bad_mode in ("", "rr", "rt", "rw", "rbb"):
+    with assert_raises(ValueError):
+        FileIO("README.md", bad_mode)
 
 
 # Test that IOBase.isatty() raises ValueError when called on a closed file.

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -9098,20 +9098,19 @@ fn builtin_any(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
 /// as instance attributes, matching the PyPy FileIO/TextIOWrapper
 /// duck-typing surface without a dedicated W_FileObject.
 pub fn file_wrapper_type() -> PyObjectRef {
-    thread_local! {
-        static FILE_WRAPPER_TYPE: std::cell::OnceCell<PyObjectRef> = const { std::cell::OnceCell::new() };
-    }
-    FILE_WRAPPER_TYPE.with(|c| {
-        *c.get_or_init(|| {
-            let tp = crate::typedef::make_builtin_type("_io.TextIOWrapper", init_file_wrapper_type);
-            unsafe { pyre_object::typeobject::w_type_set_hasdict(tp, true) };
-            tp
-        })
-    })
+    // A Python type is process-global, exactly as PyPy's W_TypeObject is.
+    // Storing it in TLS would manufacture one incompatible TextIOWrapper type
+    // per host thread and break cross-thread isinstance/type identity.
+    static FILE_WRAPPER_TYPE: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
+    *FILE_WRAPPER_TYPE.get_or_init(|| {
+        let tp = crate::typedef::make_builtin_type("_io.TextIOWrapper", init_file_wrapper_type);
+        unsafe { pyre_object::typeobject::w_type_set_hasdict(tp, true) };
+        tp as usize
+    }) as PyObjectRef
 }
 
 /// PyPy: pypy/module/_io/interp_iobase.py W_IOBase.
-fn init_file_wrapper_type(ns: PyObjectRef) {
+pub(crate) fn init_file_wrapper_type(ns: PyObjectRef) {
     unsafe {
         pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
             ns,
@@ -9222,6 +9221,7 @@ fn init_file_wrapper_type(ns: PyObjectRef) {
             make_builtin_function_with_arity(
                 "readable",
                 |args| {
+                    file_check_closed(args[0])?;
                     let mode = crate::baseobjspace::getattr_str(args[0], "__file_mode__")
                         .ok()
                         .map(|m| unsafe { pyre_object::w_str_get_value(m).to_string() })
@@ -9239,6 +9239,7 @@ fn init_file_wrapper_type(ns: PyObjectRef) {
             make_builtin_function_with_arity(
                 "writable",
                 |args| {
+                    file_check_closed(args[0])?;
                     let mode = crate::baseobjspace::getattr_str(args[0], "__file_mode__")
                         .ok()
                         .map(|m| unsafe { pyre_object::w_str_get_value(m).to_string() })
@@ -9264,6 +9265,7 @@ fn init_file_wrapper_type(ns: PyObjectRef) {
                 // file does, a pipe/socket fails with ESPIPE.  The in-memory
                 // path wrapper is always seekable.
                 |args| {
+                    file_check_closed(args[0])?;
                     if let Some(fd) = file_get_fd(args[0]) {
                         #[cfg(all(feature = "host_env", not(target_arch = "wasm32")))]
                         {
@@ -9293,15 +9295,16 @@ fn init_file_wrapper_type(ns: PyObjectRef) {
             ns,
             "seek",
             make_builtin_function("seek", |args| {
+                file_check_closed(args[0])?;
+                let offset = args
+                    .get(1)
+                    .map(|&o| unsafe { pyre_object::w_int_get_value(o) })
+                    .unwrap_or(0);
+                let whence = args
+                    .get(2)
+                    .map(|&o| unsafe { pyre_object::w_int_get_value(o) })
+                    .unwrap_or(0) as i32;
                 if let Some(fd) = file_get_fd(args[0]) {
-                    let offset = args
-                        .get(1)
-                        .map(|&o| unsafe { pyre_object::w_int_get_value(o) })
-                        .unwrap_or(0);
-                    let whence = args
-                        .get(2)
-                        .map(|&o| unsafe { pyre_object::w_int_get_value(o) })
-                        .unwrap_or(0) as i32;
                     #[cfg(all(feature = "host_env", not(target_arch = "wasm32")))]
                     {
                         #[cfg(not(feature = "sandbox"))]
@@ -9325,10 +9328,18 @@ fn init_file_wrapper_type(ns: PyObjectRef) {
                         ));
                     }
                 }
-                if args.len() >= 2 {
-                    let _ = crate::baseobjspace::setattr_str(args[0], "__file_pos__", args[1]);
-                }
-                Ok(w_none())
+                let base = match whence {
+                    0 => 0,
+                    1 => file_get_pos(args[0]) as i64,
+                    2 => file_get_data(args[0]).len() as i64,
+                    _ => return Err(crate::PyError::value_error("invalid whence")),
+                };
+                let pos = base
+                    .checked_add(offset)
+                    .filter(|pos| *pos >= 0)
+                    .ok_or_else(|| crate::PyError::value_error("negative seek position"))?;
+                file_set_pos(args[0], pos as usize);
+                Ok(w_int_new(pos))
             }),
         )
     };
@@ -9339,6 +9350,7 @@ fn init_file_wrapper_type(ns: PyObjectRef) {
             make_builtin_function_with_arity(
                 "tell",
                 |args| {
+                    file_check_closed(args[0])?;
                     if let Some(fd) = file_get_fd(args[0]) {
                         #[cfg(all(feature = "host_env", not(target_arch = "wasm32")))]
                         {
@@ -9370,6 +9382,128 @@ fn init_file_wrapper_type(ns: PyObjectRef) {
             ),
         )
     };
+    unsafe {
+        pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
+            ns,
+            "isatty",
+            make_builtin_function_with_arity("isatty", file_method_isatty, 1),
+        )
+    };
+}
+
+/// `_io.FileIO.__init__` — PyPy `W_FileIO.descr_init`.
+///
+/// The existing file helpers keep their state in reserved instance slots; a
+/// FileIO instance uses the same slots but always exposes a binary raw stream.
+pub(crate) fn fileio_init(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    let (pos, kwargs) = split_builtin_kwargs(args);
+    kwarg_reject_unknown(kwargs, &["file", "mode", "closefd", "opener"], "FileIO")?;
+    let self_obj = pos
+        .first()
+        .copied()
+        .ok_or_else(|| crate::PyError::type_error("FileIO.__init__() missing self"))?;
+    let file = bind_pos_or_kw(pos, kwargs, 1, "file", "FileIO", 1)?
+        .ok_or_else(|| crate::PyError::type_error("FileIO() missing required argument 'file'"))?;
+    let mode_obj =
+        bind_pos_or_kw(pos, kwargs, 2, "mode", "FileIO", 2)?.unwrap_or_else(|| w_str_new("r"));
+    if !unsafe { pyre_object::is_str(mode_obj) } {
+        return Err(crate::PyError::type_error(
+            "FileIO() argument 'mode' must be str",
+        ));
+    }
+    let mode = unsafe { pyre_object::w_str_get_value(mode_obj) };
+    let mut primary = None;
+    let mut updating = false;
+    let mut binary_seen = false;
+    for ch in mode.chars() {
+        match ch {
+            'r' | 'w' | 'a' | 'x' => {
+                if primary.replace(ch).is_some() {
+                    return Err(crate::PyError::value_error("invalid mode"));
+                }
+            }
+            '+' if !updating => updating = true,
+            'b' if !binary_seen => binary_seen = true,
+            _ => return Err(crate::PyError::value_error("invalid mode")),
+        }
+    }
+    let primary = primary.ok_or_else(|| crate::PyError::value_error("invalid mode"))?;
+    let binary_mode = format!("{primary}b{}", if updating { "+" } else { "" });
+
+    let closefd_obj = bind_pos_or_kw(pos, kwargs, 3, "closefd", "FileIO", 3)?
+        .unwrap_or_else(|| w_bool_from(true));
+    let closefd = crate::baseobjspace::is_true(closefd_obj)?;
+    if !unsafe { pyre_object::is_int(file) } && !closefd {
+        return Err(crate::PyError::value_error(
+            "Cannot use closefd=False with file name",
+        ));
+    }
+    let opener = bind_pos_or_kw(pos, kwargs, 4, "opener", "FileIO", 4)?.unwrap_or_else(w_none);
+    let opened = builtin_open(&[
+        file,
+        w_str_new(&binary_mode),
+        w_int_new(-1),
+        w_none(),
+        w_none(),
+        w_none(),
+        closefd_obj,
+        opener,
+    ])?;
+    let _roots = pyre_object::gc_roots::push_roots();
+    pyre_object::gc_roots::pin_root(self_obj);
+    pyre_object::gc_roots::pin_root(opened);
+    for name in [
+        "__file_data__",
+        "__file_pos__",
+        "__file_name__",
+        "__file_mode__",
+        "__file_binary__",
+        "__file_fd__",
+        "__file_dirty__",
+        "name",
+        "encoding",
+        "errors",
+    ] {
+        if let Ok(value) = crate::baseobjspace::getattr_str(opened, name) {
+            crate::baseobjspace::setattr_str(self_obj, name, value)?;
+        }
+    }
+    crate::baseobjspace::setattr_str(self_obj, "mode", w_str_new(&binary_mode))?;
+    crate::baseobjspace::setattr_str(self_obj, "closefd", w_bool_from(closefd))?;
+    crate::baseobjspace::setattr_str(self_obj, "closed", w_bool_from(false))?;
+    Ok(w_none())
+}
+
+fn file_check_closed(self_obj: PyObjectRef) -> Result<(), crate::PyError> {
+    let closed = crate::baseobjspace::getattr_str(self_obj, "closed")
+        .ok()
+        .map(|value| unsafe { pyre_object::is_bool(value) && pyre_object::w_bool_get_value(value) })
+        .unwrap_or(false);
+    if closed {
+        Err(crate::PyError::value_error("I/O operation on closed file"))
+    } else {
+        Ok(())
+    }
+}
+
+fn file_method_isatty(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    let self_obj = args
+        .first()
+        .copied()
+        .ok_or_else(|| crate::PyError::type_error("isatty() requires self"))?;
+    file_check_closed(self_obj)?;
+    let Some(fd) = file_get_fd(self_obj) else {
+        return Ok(w_bool_from(false));
+    };
+    #[cfg(all(feature = "host_env", not(target_arch = "wasm32")))]
+    {
+        return Ok(w_bool_from(unsafe { libc::isatty(fd) } != 0));
+    }
+    #[cfg(any(not(feature = "host_env"), target_arch = "wasm32"))]
+    {
+        let _ = fd;
+        Ok(w_bool_from(false))
+    }
 }
 
 /// The path-backed file object's buffered contents as raw bytes.  Binary and
@@ -9513,6 +9647,7 @@ fn file_method_read(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError>
     if args.is_empty() {
         return Err(crate::PyError::type_error("read() requires self"));
     }
+    file_check_closed(args[0])?;
     if let Some(fd) = file_get_fd(args[0]) {
         let n = args.get(1).and_then(|&o| unsafe {
             if pyre_object::is_int(o) {
@@ -9559,6 +9694,7 @@ fn file_method_readline(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyEr
     if args.is_empty() {
         return Err(crate::PyError::type_error("readline() requires self"));
     }
+    file_check_closed(args[0])?;
     // Optional size cap (`readline(size)`): stop after `size` bytes even
     // before a newline. A missing or negative size means no cap.
     let max = args.get(1).and_then(|&o| unsafe {
@@ -9646,6 +9782,7 @@ fn file_method_write(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError
     if args.len() < 2 {
         return Err(crate::PyError::type_error("write() requires (self, data)"));
     }
+    file_check_closed(args[0])?;
     if let Some(fd) = file_get_fd(args[0]) {
         let bytes: Vec<u8> = unsafe {
             if pyre_object::is_str(args[1]) {
@@ -9736,6 +9873,15 @@ fn file_method_close(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError
             // close reports an error, then surface that error (matching
             // _io.FileIO.close).
             let _ = crate::baseobjspace::setattr_str(args[0], "closed", w_bool_from(true));
+            let closefd = crate::baseobjspace::getattr_str(args[0], "closefd")
+                .ok()
+                .map(|value| unsafe {
+                    !pyre_object::is_bool(value) || pyre_object::w_bool_get_value(value)
+                })
+                .unwrap_or(true);
+            if !closefd {
+                return Ok(w_none());
+            }
             #[cfg(all(
                 feature = "host_env",
                 not(target_arch = "wasm32"),
@@ -9759,6 +9905,7 @@ fn file_method_close(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError
     // If the file was opened in a writable mode, flush the in-memory
     // buffer to disk.
     file_flush_dirty(args[0])?;
+    crate::baseobjspace::setattr_str(args[0], "closed", w_bool_from(true))?;
     Ok(w_none())
 }
 
@@ -9883,6 +10030,7 @@ pub fn builtin_open(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError>
     let encoding_obj =
         resolve_pos_or_kw(open_pos.get(3).copied(), open_kwargs, "encoding", "open", 4)?;
     let errors_obj = resolve_pos_or_kw(open_pos.get(4).copied(), open_kwargs, "errors", "open", 5)?;
+    let opener_obj = resolve_pos_or_kw(open_pos.get(7).copied(), open_kwargs, "opener", "open", 8)?;
     let str_or_none =
         |obj: Option<PyObjectRef>, name: &str| -> Result<Option<String>, crate::PyError> {
             match obj {
@@ -9968,7 +10116,7 @@ pub fn builtin_open(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError>
     // (e.g. `tempfile.NamedTemporaryFile` creates the temp file and records
     // its name in the opener). Call it with `(file, flags)` and wrap the
     // returned fd directly.
-    if let Some(opener) = kwarg_get(open_kwargs, "opener") {
+    if let Some(opener) = opener_obj {
         if !unsafe { pyre_object::is_none(opener) } {
             let flags = open_flags_for_mode(&mode);
             let fd_obj = crate::call::call_function_impl_result(

--- a/pyre/pyre-interpreter/src/module/_io/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_io/mod.rs
@@ -7,6 +7,145 @@
 
 use pyre_object::*;
 
+fn type_method(ns: PyObjectRef, name: &str, function: PyObjectRef) {
+    unsafe {
+        pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(ns, name, function);
+    }
+}
+
+fn io_closed(obj: PyObjectRef) -> bool {
+    crate::baseobjspace::getattr_str(obj, "closed")
+        .ok()
+        .and_then(|value| unsafe {
+            pyre_object::is_bool(value).then(|| pyre_object::w_bool_get_value(value))
+        })
+        .unwrap_or(false)
+}
+
+fn iobase_close(args: &[PyObjectRef]) -> crate::PyResult {
+    if let Some(&self_obj) = args.first() {
+        crate::baseobjspace::setattr_str(self_obj, "closed", w_bool_from(true))?;
+    }
+    Ok(w_none())
+}
+
+fn iobase_isatty(args: &[PyObjectRef]) -> crate::PyResult {
+    let self_obj = args
+        .first()
+        .copied()
+        .ok_or_else(|| crate::PyError::type_error("isatty() requires self"))?;
+    if io_closed(self_obj) {
+        return Err(crate::PyError::value_error("I/O operation on closed file"));
+    }
+    Ok(w_bool_from(false))
+}
+
+fn init_iobase_type(ns: PyObjectRef) {
+    type_method(ns, "closed", w_bool_from(false));
+    type_method(
+        ns,
+        "close",
+        crate::make_builtin_function_with_arity("close", iobase_close, 1),
+    );
+    type_method(
+        ns,
+        "isatty",
+        crate::make_builtin_function_with_arity("isatty", iobase_isatty, 1),
+    );
+    type_method(
+        ns,
+        "__enter__",
+        crate::make_builtin_function_with_arity("__enter__", |args| Ok(args[0]), 1),
+    );
+    type_method(
+        ns,
+        "__exit__",
+        crate::make_builtin_function("__exit__", |args| {
+            iobase_close(&args[..1])?;
+            Ok(w_none())
+        }),
+    );
+}
+
+fn call_method_result(obj: PyObjectRef, name: &str, args: &[PyObjectRef]) -> crate::PyResult {
+    let result = crate::baseobjspace::call_method(obj, name, args);
+    if result.is_null() {
+        Err(crate::call::take_call_error()
+            .unwrap_or_else(|| crate::PyError::runtime_error(format!("{name} failed"))))
+    } else {
+        Ok(result)
+    }
+}
+
+fn buffered_reader_init(args: &[PyObjectRef]) -> crate::PyResult {
+    let self_obj = args
+        .first()
+        .copied()
+        .ok_or_else(|| crate::PyError::type_error("BufferedReader.__init__() missing self"))?;
+    let raw = args
+        .get(1)
+        .copied()
+        .ok_or_else(|| crate::PyError::type_error("BufferedReader() missing raw argument"))?;
+    crate::baseobjspace::setattr_str(self_obj, "raw", raw)?;
+    crate::baseobjspace::setattr_str(self_obj, "closed", w_bool_from(false))?;
+    Ok(w_none())
+}
+
+fn buffered_reader_call(args: &[PyObjectRef], method: &str) -> crate::PyResult {
+    let self_obj = args
+        .first()
+        .copied()
+        .ok_or_else(|| crate::PyError::type_error(format!("{method}() requires self")))?;
+    let raw = crate::baseobjspace::getattr_str(self_obj, "raw")?;
+    call_method_result(raw, method, &args[1..])
+}
+
+fn buffered_reader_close(args: &[PyObjectRef]) -> crate::PyResult {
+    let result = buffered_reader_call(args, "close")?;
+    crate::baseobjspace::setattr_str(args[0], "closed", w_bool_from(true))?;
+    Ok(result)
+}
+
+fn init_buffered_reader_type(ns: PyObjectRef) {
+    type_method(
+        ns,
+        "__init__",
+        crate::make_builtin_function("__init__", buffered_reader_init),
+    );
+    type_method(
+        ns,
+        "read",
+        crate::make_builtin_function("read", |args| buffered_reader_call(args, "read")),
+    );
+    type_method(
+        ns,
+        "seekable",
+        crate::make_builtin_function_with_arity(
+            "seekable",
+            |args| buffered_reader_call(args, "seekable"),
+            1,
+        ),
+    );
+    type_method(
+        ns,
+        "close",
+        crate::make_builtin_function_with_arity("close", buffered_reader_close, 1),
+    );
+    type_method(
+        ns,
+        "__enter__",
+        crate::make_builtin_function_with_arity("__enter__", |args| Ok(args[0]), 1),
+    );
+    type_method(
+        ns,
+        "__exit__",
+        crate::make_builtin_function("__exit__", |args| {
+            buffered_reader_close(&args[..1])?;
+            Ok(w_none())
+        }),
+    );
+}
+
 crate::py_module! {
     "_io",
     interpleveldefs: {
@@ -54,19 +193,29 @@ crate::py_module! {
         }
 
         // Abstract base classes as W_TypeObject (required for io.py class inheritance).
+        // PyPy hierarchy: RawIOBase/BufferedIOBase/TextIOBase all derive IOBase.
         let obj_type = crate::typedef::w_object();
-        let mut io_base_types: std::collections::HashMap<&str, pyre_object::PyObjectRef> =
-            std::collections::HashMap::new();
-        for name in &["_IOBase", "_RawIOBase", "_BufferedIOBase", "_TextIOBase"] {
-            let t = pyre_object::w_type_new(
-                name,
-                pyre_object::w_tuple_new(vec![obj_type]),
-                pyre_object::w_dict_new() as *mut u8,
-            );
-            unsafe { pyre_object::w_type_set_mro(t, vec![t, obj_type]) };
-            unsafe { pyre_object::typeobject::w_type_ready(t) };
-            io_base_types.insert(name, t);
-            crate::module_ns_store(ns, name, t);
+        let io_base = crate::typedef::make_builtin_type_with_base(
+            "_IOBase",
+            init_iobase_type,
+            obj_type,
+        );
+        unsafe { pyre_object::w_type_set_acceptable_as_base_class(io_base, true) };
+        let raw_base = crate::typedef::make_builtin_type_with_base("_RawIOBase", |_| {}, io_base);
+        let buffered_base = crate::typedef::make_builtin_type_with_base(
+            "_BufferedIOBase",
+            |_| {},
+            io_base,
+        );
+        let text_base = crate::typedef::make_builtin_type_with_base("_TextIOBase", |_| {}, io_base);
+        for (name, typ) in [
+            ("_IOBase", io_base),
+            ("_RawIOBase", raw_base),
+            ("_BufferedIOBase", buffered_base),
+            ("_TextIOBase", text_base),
+        ] {
+            unsafe { pyre_object::w_type_set_acceptable_as_base_class(typ, true) };
+            crate::module_ns_store(ns, name, typ);
         }
 
         // Concrete stream classes as subclassable W_TypeObjects.  stdlib
@@ -75,15 +224,51 @@ crate::py_module! {
         // test_io), so they must be real types, not function stubs.
         // `FileIO` derives from `_RawIOBase`; the buffered classes from
         // `_BufferedIOBase` (`Modules/_io/_iomodule.c` PyInit__io).
-        for (name, base_name) in &[
-            ("FileIO", "_RawIOBase"),
-            ("BufferedReader", "_BufferedIOBase"),
-            ("BufferedWriter", "_BufferedIOBase"),
-            ("BufferedRWPair", "_BufferedIOBase"),
-            ("BufferedRandom", "_BufferedIOBase"),
+        let file_io = crate::typedef::make_builtin_type_with_base(
+            "FileIO",
+            |type_ns| {
+                crate::builtins::init_file_wrapper_type(type_ns);
+                type_method(
+                    type_ns,
+                    "__init__",
+                    crate::make_builtin_function("__init__", crate::builtins::fileio_init),
+                );
+            },
+            raw_base,
+        );
+        let buffered_reader = crate::typedef::make_builtin_type_with_base(
+            "BufferedReader",
+            init_buffered_reader_type,
+            buffered_base,
+        );
+        for (name, t) in [
+            ("FileIO", file_io),
+            ("BufferedReader", buffered_reader),
+            (
+                "BufferedWriter",
+                crate::typedef::make_builtin_type_with_base(
+                    "BufferedWriter",
+                    |_| {},
+                    buffered_base,
+                ),
+            ),
+            (
+                "BufferedRWPair",
+                crate::typedef::make_builtin_type_with_base(
+                    "BufferedRWPair",
+                    |_| {},
+                    buffered_base,
+                ),
+            ),
+            (
+                "BufferedRandom",
+                crate::typedef::make_builtin_type_with_base(
+                    "BufferedRandom",
+                    |_| {},
+                    buffered_base,
+                ),
+            ),
         ] {
-            let base = io_base_types[base_name];
-            let t = crate::typedef::make_builtin_type_with_base(name, |_ns| {}, base);
             unsafe {
                 pyre_object::w_type_set_acceptable_as_base_class(t, true);
                 pyre_object::typeobject::w_type_set_hasdict(t, true);


### PR DESCRIPTION
## Summary

- expose `_io.FileIO` as a working `_RawIOBase` subclass backed by pyre's existing path/fd file operations
- restore the PyPy IO base hierarchy and provide IOBase close/context-manager/isatty behavior
- add a minimal delegating `BufferedReader` surface used by the standard library
- make path-backed seek/tell and closed-file checks match FileIO behavior
- honor `closefd=False` for externally owned file descriptors
- replace the `_io` setup HashMap with direct hierarchy construction
- replace the file wrapper's TLS type cache with one process-global `OnceLock`, preserving cross-thread type identity

## Root cause and PyPy parity

`_io.FileIO` and the buffered classes were empty heap-type stubs, while `builtins.open` already had usable path/fd read and write operations on a private wrapper. The standard `io` module could import, but direct `FileIO(...)` construction failed before any I/O.

PyPy models `FileIO` as a `_RawIOBase` instance with per-object mode/fd/closed state, and its IO base classes form a real inheritance chain. This change connects pyre's existing per-instance file state to that public hierarchy and removes the unrelated per-thread type singleton. No RustPython patch or local RustPython dependency is used.

## Validation

- `python3 scripts/extract-llbc.py pyre-interpreter`
- `cargo check --workspace --features dynasm`
- `cargo test --workspace --features dynasm`
- `target/debug/pyre pyre/extra_tests/snippets/stdlib_io.py`
- related `stdlib_io_bytesio.py`, `stdlib_io_stringio.py`, `stdlib_subprocess.py`, and `builtin_open.py`
- `python3 pyre/check.py --backend dynasm --no-synthetic` (all 10 benchmarks plus loop-reentry passed; 11/11)