### PR TITLE
interpreter: improve collections and stdlib compatibility

### DIFF
--- a/lib-python/3/functools.py
+++ b/lib-python/3/functools.py
@@ -377,6 +377,14 @@ class partial:
     __new__ = _partial_new
     __repr__ = recursive_repr()(_partial_repr)
 
+    def __delattr__(self, name):
+        # The C accelerator exposes __dict__ as a non-deletable getset
+        # descriptor.  Keep the Python fallback behavior identical when
+        # _functools.partial is unavailable.
+        if name == "__dict__":
+            raise TypeError("cannot delete __dict__")
+        object.__delattr__(self, name)
+
     def __call__(self, /, *args, **keywords):
         phcount = self._phcount
         if phcount:

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -11611,6 +11611,17 @@ pub fn next(obj: PyObjectRef) -> PyResult {
                 return crate::call::call_function_impl_result(method, &[obj]);
             }
         }
+        // PyPy `space.next(w_obj)` performs a type-MRO `__next__` lookup for
+        // every W_Root object.  Typed-payload builtins are not INSTANCE_TYPE
+        // layouts, so give them the same generic dispatch used by `iter`
+        // above instead of requiring one hardcoded branch per iterator type.
+        if !is_instance(obj) {
+            if let Some(w_type) = crate::typedef::r#type(obj) {
+                if let Some(method) = lookup_in_type_where(w_type, "__next__") {
+                    return crate::call::call_function_impl_result(method, &[obj]);
+                }
+            }
+        }
     }
     Err(PyError::type_error(format!(
         "'{}' object is not an iterator",

--- a/pyre/pyre-interpreter/src/call.rs
+++ b/pyre/pyre-interpreter/src/call.rs
@@ -2151,25 +2151,6 @@ pub fn call_with_kwargs(
     // For type objects: allocate via __new__ then call __init__ with kwargs.
     // PyPy: typeobject.py descr_call → __new__ + __init__
     if unsafe { pyre_object::is_type(callable) } {
-        // Types with acceptable_as_base_class=false (bool, NoneType) reject kwargs.
-        // PyPy: boolobject.py descr_new uses @unwrap_spec (positional only).
-        // The `function` type is non-acceptable-as-base too, but its
-        // `tp_new` (`FunctionType(code, globals, ..., kwdefaults=...)`)
-        // does take keyword arguments, so route those through `__new__`.
-        let is_function_type = std::ptr::eq(
-            callable,
-            crate::typedef::gettypeobject(&crate::FUNCTION_TYPE),
-        );
-        if !kwargs.is_empty()
-            && !is_function_type
-            && !unsafe { pyre_object::w_type_get_acceptable_as_base_class(callable) }
-        {
-            let type_name = unsafe { pyre_object::w_type_get_name(callable) };
-            return Err(crate::PyError::type_error(format!(
-                "{}() takes no keyword arguments",
-                type_name,
-            )));
-        }
         // Calculate the winning metaclass from bases.
         // type(name, bases, dict, **kw) needs to find the correct metaclass
         // and call its __new__ with the kwargs.

--- a/pyre/pyre-interpreter/src/module/_collections/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_collections/mod.rs
@@ -113,6 +113,218 @@ fn maxlen_obj(self_obj: PyObjectRef) -> PyObjectRef {
     }
 }
 
+// PyPy `W_DequeIter`: the iterator owns the deque, current position, number
+// of remaining entries, and a snapshot of the deque mutation lock.
+mod deque_iter {
+    use super::{W_Deque, checklock, data, getlock};
+    use pyre_object::*;
+
+    #[crate::pyre_class("_collections._deque_iterator")]
+    pub struct W_DequeIter {
+        deque: PyObjectRef,
+        index: i64,
+        counter: i64,
+        lock: i64,
+    }
+
+    fn constructor_args(args: &[PyObjectRef]) -> Result<(PyObjectRef, i64), crate::PyError> {
+        let (positional, _kwargs) = crate::builtins::split_builtin_kwargs(args);
+        // `__new__`'s descriptor ABI leaves the requested class at the front
+        // of the varargs slice (the typed `_cls` slot is the descriptor
+        // receiver).  PyPy's W_DequeIter__new__ starts parsing after it.
+        let positional = positional.get(1..).unwrap_or(&[]);
+        if positional.is_empty() || positional.len() > 2 {
+            return Err(crate::PyError::type_error(format!(
+                "_deque_iterator expected 1 or 2 arguments, got {}",
+                positional.len()
+            )));
+        }
+        let deque = positional[0];
+        if W_Deque::from_obj(deque).is_none() {
+            let name = unsafe { pyre_object::type_name_of(deque) };
+            return Err(crate::PyError::type_error(format!(
+                "must be collections.deque, not {name}"
+            )));
+        }
+        let index = match positional.get(1) {
+            Some(&value) => crate::builtins::space_index_w(value)?,
+            None => 0,
+        };
+        Ok((deque, index))
+    }
+
+    #[crate::pyre_methods]
+    impl W_DequeIter {
+        #[staticmethod]
+        fn __new__(_cls: PyObjectRef, args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+            let (deque, requested) = constructor_args(args)?;
+            Ok(make(deque, requested))
+        }
+
+        fn __iter__(&self) -> PyObjectRef {
+            self as *const W_DequeIter as PyObjectRef
+        }
+
+        fn __length_hint__(&self) -> i64 {
+            self.counter.max(0)
+        }
+
+        fn __next__(&mut self) -> Result<PyObjectRef, crate::PyError> {
+            if let Err(error) = checklock(self.deque, self.lock) {
+                self.counter = 0;
+                return Err(error);
+            }
+            if self.counter <= 0 {
+                return Err(crate::PyError::stop_iteration());
+            }
+            let item = unsafe { w_list_getitem(data(self.deque), self.index) }
+                .ok_or_else(crate::PyError::stop_iteration)?;
+            self.index += 1;
+            self.counter -= 1;
+            Ok(item)
+        }
+
+        fn __reduce__(&self) -> PyObjectRef {
+            let self_obj = self as *const W_DequeIter as PyObjectRef;
+            let ty = unsafe { w_instance_get_type(self_obj) };
+            let consumed = W_Deque::from_obj(self.deque)
+                .map(|deque| unsafe { w_list_len(deque.data) as i64 } - self.counter)
+                .unwrap_or(0);
+            w_tuple_new(vec![ty, w_tuple_new(vec![self.deque, w_int_new(consumed)])])
+        }
+    }
+
+    pub fn make(deque: PyObjectRef, requested: i64) -> PyObjectRef {
+        let _ = type_object();
+        let len = W_Deque::from_obj(deque)
+            .map(|deque| unsafe { w_list_len(deque.data) as i64 })
+            .unwrap_or(0);
+        let index = requested.max(0);
+        let _roots = pyre_object::gc_roots::push_roots();
+        pyre_object::gc_roots::pin_root(deque);
+        W_DequeIter::allocate(W_DequeIter {
+            ob: PyObject {
+                ob_type: std::ptr::null(),
+                w_class: std::ptr::null_mut(),
+            },
+            deque,
+            index,
+            counter: len - index,
+            lock: getlock(deque),
+        })
+    }
+
+    pub fn public_type() -> PyObjectRef {
+        let ty = type_object();
+        // `interp_deque.py`: W_DequeIter.typedef explicitly sets
+        // acceptable_as_base_class=False.
+        unsafe { pyre_object::w_type_set_acceptable_as_base_class(ty, false) };
+        ty
+    }
+}
+
+// PyPy `W_DequeRevIter`, with the same state shape and reverse indexing into
+// pyre's list-backed deque payload.
+mod deque_rev_iter {
+    use super::{W_Deque, checklock, data, getlock};
+    use pyre_object::*;
+
+    #[crate::pyre_class("_collections._deque_reverse_iterator")]
+    pub struct W_DequeRevIter {
+        deque: PyObjectRef,
+        index: i64,
+        counter: i64,
+        lock: i64,
+    }
+
+    #[crate::pyre_methods]
+    impl W_DequeRevIter {
+        #[staticmethod]
+        fn __new__(_cls: PyObjectRef, args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+            let (positional, _kwargs) = crate::builtins::split_builtin_kwargs(args);
+            let positional = positional.get(1..).unwrap_or(&[]);
+            if positional.is_empty() || positional.len() > 2 {
+                return Err(crate::PyError::type_error(format!(
+                    "_deque_reverse_iterator expected 1 or 2 arguments, got {}",
+                    positional.len()
+                )));
+            }
+            let deque = positional[0];
+            if W_Deque::from_obj(deque).is_none() {
+                let name = unsafe { pyre_object::type_name_of(deque) };
+                return Err(crate::PyError::type_error(format!(
+                    "must be collections.deque, not {name}"
+                )));
+            }
+            let requested = match positional.get(1) {
+                Some(&value) => crate::builtins::space_index_w(value)?,
+                None => 0,
+            };
+            Ok(make(deque, requested))
+        }
+
+        fn __iter__(&self) -> PyObjectRef {
+            self as *const W_DequeRevIter as PyObjectRef
+        }
+
+        fn __length_hint__(&self) -> i64 {
+            self.counter.max(0)
+        }
+
+        fn __next__(&mut self) -> Result<PyObjectRef, crate::PyError> {
+            if let Err(error) = checklock(self.deque, self.lock) {
+                self.counter = 0;
+                return Err(error);
+            }
+            if self.counter <= 0 {
+                return Err(crate::PyError::stop_iteration());
+            }
+            let item = unsafe { w_list_getitem(data(self.deque), self.index) }
+                .ok_or_else(crate::PyError::stop_iteration)?;
+            self.index -= 1;
+            self.counter -= 1;
+            Ok(item)
+        }
+
+        fn __reduce__(&self) -> PyObjectRef {
+            let self_obj = self as *const W_DequeRevIter as PyObjectRef;
+            let ty = unsafe { w_instance_get_type(self_obj) };
+            let consumed = W_Deque::from_obj(self.deque)
+                .map(|deque| unsafe { w_list_len(deque.data) as i64 } - self.counter)
+                .unwrap_or(0);
+            w_tuple_new(vec![ty, w_tuple_new(vec![self.deque, w_int_new(consumed)])])
+        }
+    }
+
+    pub fn make(deque: PyObjectRef, requested: i64) -> PyObjectRef {
+        let _ = type_object();
+        let len = W_Deque::from_obj(deque)
+            .map(|deque| unsafe { w_list_len(deque.data) as i64 })
+            .unwrap_or(0);
+        let offset = requested.max(0);
+        let _roots = pyre_object::gc_roots::push_roots();
+        pyre_object::gc_roots::pin_root(deque);
+        W_DequeRevIter::allocate(W_DequeRevIter {
+            ob: PyObject {
+                ob_type: std::ptr::null(),
+                w_class: std::ptr::null_mut(),
+            },
+            deque,
+            index: len - offset - 1,
+            counter: len - offset,
+            lock: getlock(deque),
+        })
+    }
+
+    pub fn public_type() -> PyObjectRef {
+        let ty = type_object();
+        // `interp_deque.py`: W_DequeRevIter.typedef explicitly sets
+        // acceptable_as_base_class=False.
+        unsafe { pyre_object::w_type_set_acceptable_as_base_class(ty, false) };
+        ty
+    }
+}
+
 /// `W_Deque.append` + `trimleft`: drop from the left once over the bound.
 fn do_append(self_obj: PyObjectRef, item: PyObjectRef) {
     let d = data(self_obj);
@@ -538,7 +750,11 @@ impl W_Deque {
     }
     fn __iter__(&self) -> Result<PyObjectRef, crate::PyError> {
         let self_obj = self as *const W_Deque as PyObjectRef;
-        crate::baseobjspace::iter(data(self_obj))
+        Ok(deque_iter::make(self_obj, 0))
+    }
+    fn __reversed__(&self) -> PyObjectRef {
+        let self_obj = self as *const W_Deque as PyObjectRef;
+        deque_rev_iter::make(self_obj, 0)
     }
     fn __getitem__(&self, index: PyObjectRef) -> Result<PyObjectRef, crate::PyError> {
         let self_obj = self as *const W_Deque as PyObjectRef;
@@ -659,8 +875,9 @@ impl W_Deque {
 crate::py_module! {
     "_collections",
     interpleveldefs: {
-        "deque"           => type_object(),
-        "_deque_iterator" => crate::typedef::w_object(),
+        "deque"                   => type_object(),
+        "_deque_iterator"         => deque_iter::public_type(),
+        "_deque_reverse_iterator" => deque_rev_iter::public_type(),
     },
     // `defaultdict` and `OrderedDict` are app-level `dict` subclasses —
     // see the module header and `app_defaultdict.py` / `app_odict.py`

--- a/pyre/pyre-interpreter/src/module/array/mod.rs
+++ b/pyre/pyre-interpreter/src/module/array/mod.rs
@@ -789,37 +789,72 @@ fn array_repr_method(args: &[PyObjectRef]) -> PyResult {
     Ok(pyre_object::w_str_new(&array_repr_string(args[0])?))
 }
 
-// Comparison: lexicographic over elements (`compare_arrays`).
+// `interp_array.py compare_arrays`: compare each element with the requested
+// operation.  In particular, an unordered pair such as NaN is neither less
+// nor greater; treating every non-equal/non-less pair as greater is wrong.
 fn array_richcompare(a: PyObjectRef, b: PyObjectRef, op: u8) -> PyResult {
     if !unsafe { arr::is_array(a) } || !unsafe { arr::is_array(b) } {
         return Ok(pyre_object::w_not_implemented());
     }
     let la = unsafe { arr::w_array_len(a) };
     let lb = unsafe { arr::w_array_len(b) };
+    if op == 0 && la != lb {
+        return Ok(pyre_object::w_bool_from(false));
+    }
+    if op == 1 && la != lb {
+        return Ok(pyre_object::w_bool_from(true));
+    }
     let n = la.min(lb);
-    let mut decided: Option<std::cmp::Ordering> = None;
     for i in 0..n {
         let ea = unsafe { arr::w_array_unpack_item(a, i) };
         let eb = unsafe { arr::w_array_unpack_item(b, i) };
-        if !crate::baseobjspace::eq_w(ea, eb)? {
-            // First differing element decides the ordering via `<`.
-            let lt = crate::baseobjspace::is_true(compare(ea, eb, CompareOp::Lt)?)?;
-            decided = Some(if lt {
-                std::cmp::Ordering::Less
-            } else {
-                std::cmp::Ordering::Greater
-            });
-            break;
+        match op {
+            0 => {
+                if !crate::baseobjspace::is_true(compare(ea, eb, CompareOp::Eq)?)? {
+                    return Ok(pyre_object::w_bool_from(false));
+                }
+            }
+            1 => {
+                if crate::baseobjspace::is_true(compare(ea, eb, CompareOp::Ne)?)? {
+                    return Ok(pyre_object::w_bool_from(true));
+                }
+            }
+            2 | 4 => {
+                let cmp = if op == 2 {
+                    CompareOp::Lt
+                } else {
+                    CompareOp::Gt
+                };
+                if crate::baseobjspace::is_true(compare(ea, eb, cmp)?)? {
+                    return Ok(pyre_object::w_bool_from(true));
+                }
+                if !crate::baseobjspace::is_true(compare(ea, eb, CompareOp::Eq)?)? {
+                    return Ok(pyre_object::w_bool_from(false));
+                }
+            }
+            3 | 5 => {
+                let cmp = if op == 3 {
+                    CompareOp::Le
+                } else {
+                    CompareOp::Ge
+                };
+                if !crate::baseobjspace::is_true(compare(ea, eb, cmp)?)? {
+                    return Ok(pyre_object::w_bool_from(false));
+                }
+                if !crate::baseobjspace::is_true(compare(ea, eb, CompareOp::Eq)?)? {
+                    return Ok(pyre_object::w_bool_from(true));
+                }
+            }
+            _ => unreachable!(),
         }
     }
-    let ord = decided.unwrap_or_else(|| la.cmp(&lb));
     let result = match op {
-        0 => ord == std::cmp::Ordering::Equal,   // ==
-        1 => ord != std::cmp::Ordering::Equal,   // !=
-        2 => ord == std::cmp::Ordering::Less,    // <
-        3 => ord != std::cmp::Ordering::Greater, // <=
-        4 => ord == std::cmp::Ordering::Greater, // >
-        5 => ord != std::cmp::Ordering::Less,    // >=
+        0 => true,
+        1 => false,
+        2 => la < lb,
+        3 => la <= lb,
+        4 => la > lb,
+        5 => la >= lb,
         _ => unreachable!(),
     };
     Ok(pyre_object::w_bool_from(result))

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -2464,6 +2464,12 @@ fn dict_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
 /// check_user_subclass prevents subclassing (acceptable_as_base_class=False).
 /// Only positional obj argument accepted.
 fn bool_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    let (args, kwargs) = crate::builtins::split_builtin_kwargs(args);
+    if crate::builtins::has_real_kwargs(kwargs) {
+        return Err(crate::PyError::type_error(
+            "bool() takes no keyword arguments",
+        ));
+    }
     // args[0] = w_booltype (cls)
     let w_booltype = args.first().copied().unwrap_or(pyre_object::PY_NULL);
     if let Some(w_bool) = gettypefor(&pyre_object::BOOL_TYPE) {


### PR DESCRIPTION
## Summary

- complete the Python `functools.partial` fallback's non-deletable `__dict__` behavior
- add PyPy-shaped forward and reverse deque iterator objects, including mutation locks, length hints, reconstruction, and non-subclassable iterator types
- dispatch `next()` generically through typed builtin classes instead of hardcoding iterator layouts
- decouple keyword acceptance from `acceptable_as_base_class` and keep `bool`'s keyword rejection in its own constructor
- port PyPy's element-by-element `array` rich comparison so unordered NaN values are handled correctly

No RustPython patch was needed.

## Validation

- `python3 scripts/extract-llbc.py pyre-interpreter`
- `cargo build --release -p pyre-jit-trace`
- `cargo check --workspace --features dynasm`
- `cargo test --workspace --features dynasm`
- `stdlib_functools.py`
- `stdlib_collections.py`
- `stdlib_collections_deque.py`
- `stdlib_itertools.py`
- deque iterator mutation, length-hint, constructor, and subclassing regressions
- array NaN rich-comparison regression

## Follow-up survey

The remaining stdlib snippet failures were surveyed separately. The next broad items are AST-object compilation, `marshal`, `time`/`warnings`, and compatibility gaps in `array`, `binascii`, `_imp`, `os`, `socket`, `sqlite3`, `struct`, `sys`, and `weakref`.
