### PR TITLE
builtins: complete memoryview and Python 3.14 parity

### DIFF
--- a/majit/majit-gc/src/collector.rs
+++ b/majit/majit-gc/src/collector.rs
@@ -2676,9 +2676,15 @@ impl MiniMarkGC {
         } else {
             None
         };
+        // incminimark.py:2361-2369 `minor_and_major_collection`: first finish
+        // the current major cycle, if any.  Objects promoted by the complete
+        // minor below must be considered by a fresh major snapshot, not folded
+        // into a marking cycle that started before they existed.
+        self.gc_step_until_scanning();
+
         // Minor collection first to empty the nursery.
-        // Note: do_collect_nursery may itself start/advance an incremental
-        // cycle, but we need a complete mark-sweep here regardless.
+        // This is the `_minor_collection()` performed by upstream's
+        // `gc_step_until(STATE_MARKING)` before it starts the fresh cycle.
         self.do_collect_nursery();
 
         if self.gc_state == GcState::Scanning {
@@ -6214,6 +6220,25 @@ mod tests {
         }
         assert_eq!(count, 5, "entire chain should be reachable after cycle");
 
+        gc.roots.clear();
+    }
+
+    #[test]
+    fn full_collection_finishes_active_cycle_then_runs_fresh_cycle() {
+        let mut gc = test_gc(4096);
+        let tid = gc.register_type(TypeInfo::simple(16));
+        let mut rooted = gc.alloc_with_type(tid, 16);
+        unsafe { gc.roots.add(&mut rooted) };
+        gc.do_collect_nursery();
+
+        gc.start_incremental_cycle();
+        assert!(gc.is_incremental_marking());
+        let major_before = gc.major_collections;
+
+        gc.do_collect_full();
+
+        assert_eq!(gc.major_collections, major_before + 2);
+        assert!(gc.oldgen.contains(rooted.0));
         gc.roots.clear();
     }
 

--- a/majit/majit-gc/src/collector.rs
+++ b/majit/majit-gc/src/collector.rs
@@ -2676,11 +2676,12 @@ impl MiniMarkGC {
         } else {
             None
         };
-        // incminimark.py:2361-2369 `minor_and_major_collection`: first finish
-        // the current major cycle, if any.  Objects promoted by the complete
-        // minor below must be considered by a fresh major snapshot, not folded
-        // into a marking cycle that started before they existed.
-        self.gc_step_until_scanning();
+        // incminimark.py:2361-2378 `minor_and_major_collection` /
+        // `gc_step_until`: first finish the current major cycle, if any, with
+        // a minor collection before every major step.  Besides discovering
+        // new roots, that minor forwards every nursery edge held by the
+        // in-progress marking state before the next gray object is consumed.
+        self.gc_step_until_scanning_with_minors();
 
         // Minor collection first to empty the nursery.
         // This is the `_minor_collection()` performed by upstream's
@@ -2690,10 +2691,7 @@ impl MiniMarkGC {
         if self.gc_state == GcState::Scanning {
             self.start_incremental_cycle();
         }
-        // incminimark.py:2366-2378 `gc_step_until(STATE_SCANNING)`: bounded
-        // state-machine steps are still looped to completion inside this one
-        // stop-the-world call.
-        self.gc_step_until_scanning();
+        self.gc_step_until_scanning_with_minors();
     }
 
     /// Reclaim dead old-gen objects WITHOUT moving the nursery.
@@ -2749,6 +2747,26 @@ impl MiniMarkGC {
 
     fn gc_step_until_scanning(&mut self) {
         while self.gc_state != GcState::Scanning {
+            self.major_collection_step();
+        }
+    }
+
+    /// incminimark.py:2375-2378 `gc_step_until`: explicit full collection
+    /// performs a minor before every major state-machine step.  The ordinary
+    /// non-moving oldgen entry deliberately uses [`gc_step_until_scanning`]
+    /// instead because its contract is to leave the nursery byte-for-byte in
+    /// place.
+    fn gc_step_until_scanning_with_minors(&mut self) {
+        while self.gc_state != GcState::Scanning {
+            // `do_collect_nursery` is pyre's public
+            // `minor_collection_with_major_progress`, whereas upstream calls
+            // the lower-level `_minor_collection` here and then advances one
+            // explicit step.  Suppress that wrapper's automatic progress so
+            // this remains the literal one-minor/one-major loop.
+            let was_enabled = self.enabled;
+            self.enabled = false;
+            self.do_collect_nursery();
+            self.enabled = was_enabled;
             self.major_collection_step();
         }
     }
@@ -6239,6 +6257,41 @@ mod tests {
 
         assert_eq!(gc.major_collections, major_before + 2);
         assert!(gc.oldgen.contains(rooted.0));
+        gc.roots.clear();
+    }
+
+    #[test]
+    fn full_collection_forwards_nursery_references_held_by_gray_objects() {
+        let ptr_size = std::mem::size_of::<GcRef>();
+        let mut gc = test_gc(4096);
+        let holder_tid = gc.register_type(TypeInfo::with_gc_ptrs(ptr_size, vec![0]));
+        let leaf_tid = gc.register_type(TypeInfo::simple(16));
+
+        let holder = gc.alloc_with_type(holder_tid, ptr_size);
+        unsafe { *(holder.0 as *mut GcRef) = GcRef::NULL };
+        let mut root = holder;
+        unsafe { gc.roots.add(&mut root) };
+        gc.do_collect_nursery();
+
+        gc.set_mark_budget(1);
+        gc.start_incremental_cycle();
+        assert_eq!(gc.incr_state.gray_stack, vec![root.0]);
+
+        let young = gc.alloc_with_type(leaf_tid, 16);
+        unsafe {
+            *(young.0 as *mut u64) = 0xF011_C011_EC70;
+            *(root.0 as *mut GcRef) = young;
+        }
+
+        // incminimark.py `minor_and_major_collection` finishes the active
+        // cycle through `gc_step_until`, whose leading minor forwards this
+        // edge before the gray holder is consumed.
+        gc.do_collect_full();
+
+        let forwarded = unsafe { *(root.0 as *const GcRef) };
+        assert!(!gc.is_in_nursery(forwarded.0));
+        assert_eq!(unsafe { *(forwarded.0 as *const u64) }, 0xF011_C011_EC70);
+        assert!(gc.oldgen.contains(forwarded.0));
         gc.roots.clear();
     }
 

--- a/pyre/check.py
+++ b/pyre/check.py
@@ -90,6 +90,9 @@ BENCH_DIR = "pyre/bench"
 SYNTHETIC_BENCH_DIR = "pyre/bench/synth"
 SNAP_DIR = "pyre/check.snap"
 BENCH_COMPARE_BUFFER_S = 0.005
+# Windows process CPU accounting advances in scheduler ticks (normally 1/64 s).
+# Keep the execution floor at least one observable tick on that platform.
+WIN_TIMER_QUANTUM_S = 1.0 / 64
 # Empty-program user-CPU startup is MEASURED per interpreter/backend (median of
 # STARTUP_SAMPLES runs) and subtracted from every timed run before ratios and
 # perf gates are computed, so a large fixed startup — notably wasmtime
@@ -98,17 +101,11 @@ BENCH_COMPARE_BUFFER_S = 0.005
 # Floored so a bench at/below its own startup (or noise) cannot drive a time
 # to <= 0 and blow up a ratio.
 STARTUP_SAMPLES = 3
-EXEC_TIME_FLOOR_S = 0.005
+EXEC_TIME_FLOOR_S = WIN_TIMER_QUANTUM_S if sys.platform == "win32" else 0.005
 # A single slow sample is retried before failing a performance gate. Windows
 # needs more samples because its process CPU accounting is scheduler-tick
-# quantized (see WIN_TIMER_QUANTUM_S below).
+# quantized (see WIN_TIMER_QUANTUM_S above).
 PERF_RETRY_RUNS = 5 if sys.platform == "win32" else 3
-# Windows `GetProcessTimes` / JobObject user-CPU accounting is quantized to
-# the system scheduler tick (default 1/64 s ≈ 15.625 ms).  Any measured time
-# could be off by up to one tick, so add one tick to every Windows
-# measurement to absorb the quantization error.
-WIN_TIMER_QUANTUM_S = 1.0 / 64
-
 CARGO_CONFIG = {
     "dynasm": {
         "extra": ["--no-default-features", "--features", "dynasm"],
@@ -260,7 +257,6 @@ def _run_timed_win32(args, timeout_s, env=None):
         ):
             utime = ((ut.dwHighDateTime << 32) | ut.dwLowDateTime) / 1e7
     kernel32.CloseHandle(job)
-    utime += WIN_TIMER_QUANTUM_S
     return (
         stdout_bytes.decode("utf-8", errors="replace"),
         utime,
@@ -995,10 +991,20 @@ class Check:
         The pass/fail decision compares execution-only (startup-subtracted)
         times; the returned elapsed/baseline stay raw for reporting.
         """
+        # Each execution-only value is a difference between two independently
+        # measured quantities (bench - empty-program startup).  On Windows each
+        # quantity may be off by one scheduler tick, so the comparison
+        # ``pyre <= baseline * limit`` needs 2q on the left and 2q*limit on the
+        # right.  Adding one tick to every raw sample cannot model this: those
+        # additions cancel during startup subtraction.
+        compare_buffer = BENCH_COMPARE_BUFFER_S
+        if sys.platform == "win32":
+            compare_buffer += 2 * WIN_TIMER_QUANTUM_S * (1 + limit)
+
         if (
             self._exec_time(backend, elapsed)
             <= self._exec_time(baseline_key, baseline_time) * limit
-            + BENCH_COMPARE_BUFFER_S
+            + compare_buffer
         ):
             return True, elapsed, baseline_time, ""
 
@@ -1010,7 +1016,7 @@ class Check:
             if (
                 self._exec_time(backend, median_elapsed)
                 <= self._exec_time(baseline_key, median_baseline) * limit
-                + BENCH_COMPARE_BUFFER_S
+                + compare_buffer
             ):
                 return True, median_elapsed, median_baseline, f"median {PERF_RETRY_RUNS}"
             return False, median_elapsed, median_baseline, f"median {PERF_RETRY_RUNS}"

--- a/pyre/check.py
+++ b/pyre/check.py
@@ -85,6 +85,11 @@ WASM_ENGINE = "wasmtime"
 # slower still on loaded CI runners, so give it extra headroom by default to
 # avoid flaky timeouts. Overridable with --wasm-timeout-scale.
 WASM_TIMEOUT_SCALE = 4.0
+# Native Windows CI can spend substantially more wall time than reported
+# process user-CPU while antivirus and concurrent matrix jobs contend for the
+# runner.  Keep the timeout as a hang guard by granting native backends 2x
+# headroom; performance still gates on measured user-CPU below.
+WIN_NATIVE_TIMEOUT_SCALE = 2.0
 
 BENCH_DIR = "pyre/bench"
 SYNTHETIC_BENCH_DIR = "pyre/bench/synth"
@@ -570,6 +575,8 @@ class Check:
                 return self.args.wasm_timeout_scale
             # Default wasm headroom composes with --timeout-scale.
             return WASM_TIMEOUT_SCALE * self.args.timeout_scale
+        if sys.platform == "win32":
+            return WIN_NATIVE_TIMEOUT_SCALE * self.args.timeout_scale
         return self.args.timeout_scale
 
     def measure_startups(self):

--- a/pyre/extra_tests/parity_tests/bool_python314.py
+++ b/pyre/extra_tests/parity_tests/bool_python314.py
@@ -1,11 +1,30 @@
 """bool surface where CPython 3.14 differs from the bundled PyPy source."""
 
+import warnings
+
 
 assert "__doc__" in bool.__dict__
 assert "__invert__" in bool.__dict__
 assert "__str__" not in bool.__dict__
-assert bool.__invert__(True) == -2
-assert bool.__invert__(False) == -1
+with warnings.catch_warnings(record=True) as caught:
+    warnings.simplefilter("always", DeprecationWarning)
+    assert bool.__invert__(True) == -2
+    assert bool.__invert__(False) == -1
+assert len(caught) == 2
+assert all(item.category is DeprecationWarning for item in caught)
+assert all("Bitwise inversion '~' on bool is deprecated" in str(item.message) for item in caught)
+
+for args, message in [
+    ((), "descriptor '__invert__' of 'bool' object needs an argument"),
+    ((1,), "descriptor '__invert__' requires a 'bool' object but received a 'int'"),
+    ((False, True), "expected 0 arguments, got 1"),
+]:
+    try:
+        bool.__invert__(*args)
+    except TypeError as error:
+        assert str(error) == message
+    else:
+        raise AssertionError(args)
 assert str(True) == "True"
 assert str(False) == "False"
 assert bool.__doc__.startswith("Returns True when the argument is true")

--- a/pyre/extra_tests/snippets/builtin_dict.py
+++ b/pyre/extra_tests/snippets/builtin_dict.py
@@ -503,6 +503,34 @@ assert cm.exception.__notes__ == [
 ]
 
 
+# Python 3.14 makes the concrete dict view types non-instantiable and final.
+for dict_view_type in (
+    type({}.keys()),
+    type({}.values()),
+    type({}.items()),
+):
+    assert "__new__" not in dict_view_type.__dict__
+    assert_raises(TypeError, dict_view_type)
+    assert_raises(TypeError, dict_view_type, {})
+    assert_raises(TypeError, type, "DictViewSubclass", (dict_view_type,), {})
+
+
+recursive_view_dict = {}
+recursive_view_dict[42] = recursive_view_dict.values()
+assert isinstance(repr(recursive_view_dict), str)
+recursive_view_dict[42] = recursive_view_dict.items()
+assert isinstance(repr(recursive_view_dict), str)
+
+
+# OrderedDict uses the Python 3.14 collections ABC view classes now that the
+# concrete dict view types are final.
+ordered_view_dict = collections.OrderedDict((("a", 1), ("b", 2)))
+assert list(ordered_view_dict.keys()) == ["a", "b"]
+assert list(reversed(ordered_view_dict.keys())) == ["b", "a"]
+assert list(reversed(ordered_view_dict.items())) == [("b", 2), ("a", 1)]
+assert list(reversed(ordered_view_dict.values())) == [2, 1]
+
+
 def failing_dict_pair():
     yield "key"
     raise TypeError("pair iteration failed")

--- a/pyre/extra_tests/snippets/builtin_dict.py
+++ b/pyre/extra_tests/snippets/builtin_dict.py
@@ -462,10 +462,11 @@ iterator_value_dict[0] = 1
 assert next(iterator_value_iter) == 0
 
 
-# A dict operation that hashes an unhashable key raises a TypeError carrying
-# `unhashable type: 'list'`. PyPy raises it bare; CPython 3.14
-# (`dict_unhashable_type`) prefixes the key type, so match on the substring.
-unhashable_key_message = "unhashable type: 'list'"
+# Python 3.14's `dict_unhashable_type` adds the dict-key context to an exact
+# hashing TypeError.
+unhashable_key_message = (
+    "cannot use 'list' as a dict key (unhashable type: 'list')"
+)
 unhashable_dict = {"present": 1}
 for operation in (
     lambda: [] in unhashable_dict,
@@ -477,7 +478,7 @@ for operation in (
 ):
     with assert_raises(TypeError) as cm:
         operation()
-    assert unhashable_key_message in str(cm.exception)
+    assert str(cm.exception) == unhashable_key_message
 
 
 class DictHashTypeErrorSubclass(TypeError):

--- a/pyre/extra_tests/snippets/builtin_memoryview.py
+++ b/pyre/extra_tests/snippets/builtin_memoryview.py
@@ -126,6 +126,30 @@ def test_bytesio_readinto():
 test_bytesio_readinto()
 
 
+# PyPy interp_buffer.py descr_new_picklebuffer acquires the buffer in
+# __new__, and its typedef is explicitly final.  CPython 3.14 exposes the
+# same constructor and final-type behavior through pickle.PickleBuffer.
+pickle_buffer_source = bytearray(b"abc")
+pickle_buffer = pickle.PickleBuffer(memoryview(pickle_buffer_source))
+assert pickle_buffer.raw().tobytes() == b"abc"
+pickle_buffer_source[0] = ord("z")
+assert pickle_buffer.raw().tobytes() == b"zbc"
+assert weakref.ref(pickle_buffer)() is pickle_buffer
+
+assert_raises(TypeError, lambda: pickle.PickleBuffer(1))
+released_pickle_buffer_source = memoryview(b"released")
+released_pickle_buffer_source.release()
+assert_raises(ValueError, lambda: pickle.PickleBuffer(released_pickle_buffer_source))
+
+
+def subclass_pickle_buffer():
+    class PickleBufferSubclass(pickle.PickleBuffer):
+        pass
+
+
+assert_raises(TypeError, subclass_pickle_buffer)
+
+
 def test_pickle_rejected():
     view = memoryview(b"abc")
     assert_raises(TypeError, lambda: copy.copy(view))

--- a/pyre/extra_tests/snippets/builtin_memoryview.py
+++ b/pyre/extra_tests/snippets/builtin_memoryview.py
@@ -1,4 +1,13 @@
 import array
+import copy
+import gc
+import io
+import mmap
+import os
+import pickle
+import struct
+import tempfile
+import weakref
 
 from testutils import assert_raises
 
@@ -24,6 +33,7 @@ memoryview(bytearray("abcde", encoding="utf-8"))
 memoryview(array.array("i", [1, 2, 3]))
 memoryview(A("b", [0]))
 memoryview(B("abcde", encoding="utf-8"))
+assert memoryview(object=b"abcde").tobytes() == b"abcde"
 
 assert_raises(TypeError, lambda: memoryview([1, 2, 3]))
 assert_raises(TypeError, lambda: memoryview((1, 2, 3)))
@@ -74,6 +84,134 @@ def test_slice():
 
 
 test_slice()
+
+
+def test_half_float():
+    packed = struct.pack("eee", 0.0, -1.5, 1.5)
+    view = memoryview(packed).cast("e")
+    assert view.itemsize == 2
+    assert view.tolist() == [0.0, -1.5, 1.5]
+
+
+test_half_float()
+
+
+def test_index_uses_element_shape():
+    values = array.array("i", [10, 20, 30])
+    view = memoryview(values)
+    assert view.index(30) == 2
+    assert view.index(20, -3, -1) == 1
+    assert_raises(ValueError, lambda: view.index(40))
+    assert_raises(ValueError, lambda: view.index(30, 0, 2))
+
+
+test_index_uses_element_shape()
+
+
+def test_bytesio_readinto():
+    stream = io.BytesIO(b"hello")
+    target = bytearray(b"testing")
+    assert stream.readinto(target) == 5
+    assert target == bytearray(b"hellong")
+
+    stream.seek(0)
+    writable = memoryview(bytearray(5))
+    assert stream.readinto1(writable) == 5
+    assert writable.tobytes() == b"hello"
+
+    stream.seek(0)
+    assert_raises(TypeError, lambda: stream.readinto(memoryview(b"hello")))
+
+
+test_bytesio_readinto()
+
+
+def test_pickle_rejected():
+    view = memoryview(b"abc")
+    assert_raises(TypeError, lambda: copy.copy(view))
+    for protocol in range(pickle.HIGHEST_PROTOCOL + 1):
+        assert_raises(TypeError, lambda protocol=protocol: pickle.dumps(view, protocol))
+
+
+test_pickle_rejected()
+
+
+def test_reentrant_release_is_export_guarded():
+    class HashingArray(array.array):
+        def __hash__(self):
+            hash_view.release()
+            self.clear()
+            return 123
+
+    exporter = HashingArray("B", b"A" * 32)
+    hash_view = memoryview(exporter).toreadonly()
+    assert_raises(BufferError, lambda: hash(hash_view))
+
+    backing = bytearray(b"A" * 32)
+    hex_view = memoryview(backing)
+
+    class Separator(bytes):
+        def __len__(self):
+            hex_view.release()
+            backing.clear()
+            return 1
+
+    assert_raises(BufferError, lambda: hex_view.hex(Separator(b":")))
+
+
+test_reentrant_release_is_export_guarded()
+
+
+def test_weakref_and_exporter_cycles():
+    callbacks = []
+    view = memoryview(b"abc")
+    ref = weakref.ref(view, lambda dead: callbacks.append(dead))
+    del view
+    gc.collect()
+    assert ref() is None
+    assert callbacks == [ref]
+
+    class Source(bytearray):
+        pass
+
+    class Payload:
+        pass
+
+    source = Source(b"abc")
+    view = memoryview(source)
+    payload = Payload()
+    source.view = view
+    source.payload = payload
+    payload_ref = weakref.ref(payload)
+    del source, view, payload
+    gc.collect()
+    assert payload_ref() is None
+
+
+test_weakref_and_exporter_cycles()
+
+
+def test_mmap_buffer_protocol():
+    fd, path = tempfile.mkstemp()
+    try:
+        os.ftruncate(fd, 64)
+        mapped = mmap.mmap(fd, 64)
+        view = memoryview(mapped)
+        struct.pack_into("q", view, 0, 1234)
+        assert struct.unpack_from("q", view, 0) == (1234,)
+        view.release()
+        mapped.close()
+
+        with open(path, "wb") as output:
+            assert output.write(memoryview(b"abc")) == 3
+        with open(path, "rb") as source:
+            assert source.read() == b"abc"
+    finally:
+        os.close(fd)
+        os.unlink(path)
+
+
+test_mmap_buffer_protocol()
 
 
 def test_compare_buffer_exporters():

--- a/pyre/extra_tests/snippets/builtin_memoryview.py
+++ b/pyre/extra_tests/snippets/builtin_memoryview.py
@@ -50,6 +50,28 @@ def test_slice():
     assert m[::-1].tobytes() == b"987654321"
     assert m[::-2].tobytes() == b"97531"
 
+    # CPython 3.14 `memory_subscript` registers the result view before slice
+    # bound conversion.  Releasing the source from `__index__` therefore
+    # rejects scalar access but leaves a slice result backed by the original
+    # export (gh-92888).
+    source = bytearray(b"abcdefgh")
+    m = memoryview(source)
+
+    class ReleasingIndex:
+        def __index__(self):
+            m.release()
+            return 4
+
+    assert_raises(ValueError, lambda: m[ReleasingIndex()])
+
+    source = bytearray(b"abcdefgh")
+    m = memoryview(source)
+    sliced = m[:ReleasingIndex()]
+    assert sliced.tobytes() == b"abcd"
+    assert_raises(BufferError, lambda: source.append(0))
+    sliced.release()
+    source.append(0)
+
 
 test_slice()
 

--- a/pyre/extra_tests/snippets/builtin_object.py
+++ b/pyre/extra_tests/snippets/builtin_object.py
@@ -11,13 +11,13 @@ assert not myobj != myobj
 object.__subclasshook__(1) == NotImplemented
 
 
-def assert_type_error(callable, *args):
+def assert_type_error(func, *args):
     try:
-        callable(*args)
+        func(*args)
     except TypeError:
         pass
     else:
-        assert False, "TypeError expected"
+        raise AssertionError("TypeError expected")
 
 
 # PyPy's interp2app gateway enforces these descriptor signatures.  The Rust

--- a/pyre/extra_tests/snippets/builtin_object.py
+++ b/pyre/extra_tests/snippets/builtin_object.py
@@ -10,6 +10,37 @@ assert not myobj != myobj
 
 object.__subclasshook__(1) == NotImplemented
 
+
+def assert_type_error(callable, *args):
+    try:
+        callable(*args)
+    except TypeError:
+        pass
+    else:
+        assert False, "TypeError expected"
+
+
+# PyPy's interp2app gateway enforces these descriptor signatures.  The Rust
+# builtin arity is a dispatch hint, so the implementations must preserve the
+# same checks explicitly rather than indexing a missing receiver.
+for method in (
+    object.__repr__,
+    object.__str__,
+    object.__format__,
+    object.__reduce__,
+    object.__reduce_ex__,
+    object.__getstate__,
+    object.__dir__,
+    object.__sizeof__,
+):
+    assert_type_error(method)
+
+assert_type_error(object.__format__, object())
+assert_type_error(object.__reduce__, object(), None)
+assert_type_error(object.__getstate__, object(), None)
+assert_type_error(object.__dir__, object(), None)
+assert_type_error(object.__sizeof__, object(), None)
+
 assert MyObject().__eq__(MyObject()) == NotImplemented
 assert MyObject().__ne__(MyObject()) == NotImplemented
 assert MyObject().__lt__(MyObject()) == NotImplemented

--- a/pyre/extra_tests/snippets/builtin_property.py
+++ b/pyre/extra_tests/snippets/builtin_property.py
@@ -85,3 +85,30 @@ assert p1.__get__(None, object) is p1
 
 p2 = property("a", doc="pdoc")
 # assert p2.__doc__ == 'pdoc'
+
+
+def documented_getter_2(self):
+    """doc 2"""
+
+
+def documented_getter_3(self):
+    """doc 3"""
+
+
+# Python 3.14 keeps the constructor's getter-doc provenance even after a
+# direct write, so replacing the getter derives the replacement doc again.
+p3 = property(documented_getter_2)
+p3.__doc__ = "user"
+assert p3.getter(documented_getter_3).__doc__ == "doc 3"
+
+
+class SlottedProperty(property):
+    __slots__ = ("__doc__",)
+
+
+assert SlottedProperty(doc="slot doc").__doc__ == "slot doc"
+assert SlottedProperty(documented_getter_2).__doc__ == "doc 2"
+
+for count in (0, 1, 3):
+    with assert_raises(TypeError):
+        property().__set_name__(*([0] * count))

--- a/pyre/extra_tests/snippets/builtin_set.py
+++ b/pyre/extra_tests/snippets/builtin_set.py
@@ -500,3 +500,22 @@ for _set_base in (set, frozenset):
     gc.collect()
     gc.collect()
     assert _finalized == [True]
+
+
+# test_set.py TestJointOps.test_container_iterator: the iterator's source and
+# an element may form a cycle.  A full explicit collection must finish any
+# in-progress major cycle and then collect this cycle in a fresh major pass.
+import weakref
+
+
+for _set_base in (set, frozenset):
+    class _SetCycleElement:
+        pass
+
+    _set_cycle_element = _SetCycleElement()
+    _set_cycle_ref = weakref.ref(_set_cycle_element)
+    _set_cycle_container = _set_base([_set_cycle_element, 1])
+    _set_cycle_element.iterator = iter(_set_cycle_container)
+    del _set_cycle_element, _set_cycle_container
+    gc.collect()
+    assert _set_cycle_ref() is None

--- a/pyre/extra_tests/snippets/builtin_set.py
+++ b/pyre/extra_tests/snippets/builtin_set.py
@@ -475,3 +475,28 @@ mutating_target = {mutating_key}
 MutatingSetKey.target = mutating_target
 MutatingSetKey.enabled = True
 mutating_target -= {0}
+
+
+# test_set.py TestJointOps.test_free_after_iterating: exhausting a set
+# iterator releases its source immediately. Layout-specific allocation must
+# also register `__del__` on set/frozenset subclasses, just like PyPy's common
+# objspace.allocate_instance path.
+import gc
+
+
+for _set_base in (set, frozenset):
+    _finalized = []
+
+    class _FinalizedSet(_set_base):
+        def __del__(self):
+            _finalized.append(True)
+
+    _set_iter = iter(_FinalizedSet())
+    try:
+        next(_set_iter)
+    except StopIteration:
+        pass
+    gc.collect()
+    gc.collect()
+    gc.collect()
+    assert _finalized == [True]

--- a/pyre/extra_tests/snippets/builtin_super.py
+++ b/pyre/extra_tests/snippets/builtin_super.py
@@ -16,3 +16,38 @@ superB = super(testB)
 assert superB.__thisclass__ == testB
 assert superB.__self_class__ is None
 assert superB.__self__ is None
+
+
+# CPython 3.14 LOAD_SUPER_ATTR calls the value loaded from the `super`
+# global. Bit 1 of the opcode chooses the zero- or two-argument call shape;
+# exercise both repeatedly so the generated JIT residual keeps that contract.
+class _SuperResult:
+    value = 41
+
+
+_super_calls = []
+
+
+def _shadowed_super(*args):
+    _super_calls.append(args)
+    return _SuperResult()
+
+
+super = _shadowed_super
+
+
+class _Shadowed:
+    def zero(self):
+        return super().value
+
+    def two(self):
+        return super(_Shadowed, self).value
+
+
+_shadowed = _Shadowed()
+for _ in range(100):
+    assert _shadowed.zero() == 41
+    assert _shadowed.two() == 41
+
+assert _super_calls[0] == ()
+assert _super_calls[1] == (_Shadowed, _shadowed)

--- a/pyre/extra_tests/snippets/builtin_super.py
+++ b/pyre/extra_tests/snippets/builtin_super.py
@@ -51,3 +51,72 @@ for _ in range(100):
 
 assert _super_calls[0] == ()
 assert _super_calls[1] == (_Shadowed, _shadowed)
+
+
+# test_super.py:test_various___class___pathologies — an explicit class-body
+# binding belongs to the namespace, while methods still close over the
+# implicit cell that type.__new__ fills with the new class.
+class _ExplicitClass:
+    def captured_class(self):
+        return __class__
+
+    __class__ = 413
+
+
+_explicit_class = _ExplicitClass()
+assert _explicit_class.captured_class() is _ExplicitClass
+assert _explicit_class.__class__ == 413
+
+
+# A class-body read still uses LOAD_NAME even when a nested method makes
+# `__class__` a cell variable.  It therefore sees the surrounding global,
+# while the method observes the class installed into the distinct cell.
+__class__ = type
+
+
+class _ReadClassName:
+    namespace_value = __class__
+
+    def captured_class(self):
+        return __class__
+
+
+assert _ReadClassName.namespace_value is type
+assert _ReadClassName().captured_class() is _ReadClassName
+del __class__
+
+
+# The pinned compiler likewise spells CPython's DELETE_NAME as DELETE_DEREF
+# when the implicit class cell exists.  Deleting the absent namespace binding
+# raises NameError and must not clear that cell instead.
+try:
+    class _DeleteClassName:
+        def captured_class(self):
+            return __class__
+
+        del __class__
+except NameError:
+    pass
+else:
+    raise AssertionError("NameError expected")
+
+
+# test_super.py:test___class___mro — type.__new__ fills __classcell__ before a
+# custom metaclass mro() runs, so code invoked by mro() already observes the
+# newly allocated class.
+_class_seen_during_mro = None
+
+
+class _MroMeta(type):
+    def mro(self):
+        self.__dict__["capture_class"]()
+        return type.mro(self)
+
+
+class _ClassCellDuringMro(metaclass=_MroMeta):
+    def capture_class():
+        global _class_seen_during_mro
+        _class_seen_during_mro = __class__
+
+
+assert _class_seen_during_mro is _ClassCellDuringMro

--- a/pyre/extra_tests/snippets/builtin_type_mro.py
+++ b/pyre/extra_tests/snippets/builtin_type_mro.py
@@ -27,3 +27,29 @@ class C(A, B):
 assert (C, A, B, X, Y, object) == C.__mro__
 
 assert type.__mro__ == (type, object)
+
+
+# typeobject.py:1585-1630 compute_mro — a metaclass override supplies the
+# installed MRO. Extra ancestors are registered for invalidation, but are not
+# reported as real direct subclasses.
+class CustomAncestor:
+    marker = 1
+
+
+class RealBase:
+    pass
+
+
+class Meta(type):
+    def mro(cls):
+        return [cls, CustomAncestor, RealBase, object]
+
+
+class CustomMro(RealBase, metaclass=Meta):
+    pass
+
+
+assert CustomMro.__mro__ == (CustomMro, CustomAncestor, RealBase, object)
+assert CustomMro.marker == 1
+assert CustomMro not in CustomAncestor.__subclasses__()
+assert CustomMro in RealBase.__subclasses__()

--- a/pyre/extra_tests/snippets/bytes_fromhex_hex_sep.py
+++ b/pyre/extra_tests/snippets/bytes_fromhex_hex_sep.py
@@ -22,6 +22,45 @@ assert b'abcd'.hex('-', 2) == '6162-6364'
 assert b'abcd'.hex('_', -2) == '6162_6364'
 assert bytearray(b'ab').hex(':', 0) == '6162'
 
+# CPython 3.14 asks a separator subclass for its Python-visible length before
+# reading the raw payload (gh-143195).  A reported length of one accepts a
+# longer payload and uses its first unit.
+class BytesSep(bytes):
+    calls = 0
+
+    def __len__(self):
+        type(self).calls += 1
+        return 1
+
+
+class StrSep(str):
+    calls = 0
+
+    def __len__(self):
+        type(self).calls += 1
+        return 1
+
+
+assert b'ab'.hex(BytesSep(b'::')) == '61:62'
+assert BytesSep.calls == 1
+assert b'ab'.hex(StrSep('::')) == '61:62'
+assert StrSep.calls == 1
+
+# bytes_per_sep coercion can mutate a bytearray receiver.  Its payload must be
+# read after __index__ returns, not kept as a stale pre-call slice.
+class ClearReceiver:
+    def __init__(self, receiver):
+        self.receiver = receiver
+
+    def __index__(self):
+        self.receiver.clear()
+        return 1
+
+
+receiver = bytearray(b'ab')
+assert receiver.hex(':', ClearReceiver(receiver)) == ''
+assert receiver == bytearray()
+
 # slice.indices() with the wrong number of arguments raises TypeError,
 # not a Rust panic.
 try:

--- a/pyre/extra_tests/snippets/operator_membership.py
+++ b/pyre/extra_tests/snippets/operator_membership.py
@@ -65,3 +65,60 @@ class MyContainingClass:
 
 assert 2 in MyContainingClass(2)
 assert 1 not in MyContainingClass(2)
+
+
+# PyPy descroperation.py sequence_contains obtains iter(container) before
+# scanning.  An explicit __iter__ therefore wins over any __getitem__ path.
+class IterOnly:
+    def __iter__(self):
+        return iter((1, 2, 3))
+
+    def __getitem__(self, index):
+        raise AssertionError("membership bypassed __iter__")
+
+
+assert 2 in IterOnly()
+assert 4 not in IterOnly()
+
+
+# Special methods are resolved on the type, never from the instance dict.
+instance_only = MyNotContainingClass()
+instance_only.__contains__ = lambda value: True
+assert_raises(TypeError, lambda: 1 in instance_only)
+
+
+# Python 3.14 membership diagnostics and exception propagation while
+# acquiring the fallback iterator.
+class RaisingIterTypeError:
+    def __iter__(self):
+        raise TypeError("custom iterator error")
+
+
+try:
+    1 in RaisingIterTypeError()
+except TypeError as exc:
+    assert str(exc) == (
+        "argument of type 'RaisingIterTypeError' is not a container or iterable"
+    )
+else:
+    raise AssertionError("membership accepted a raising iterator")
+
+
+class RaisingIterValueError:
+    def __iter__(self):
+        raise ValueError("custom iterator error")
+
+
+assert_raises(ValueError, lambda: 1 in RaisingIterValueError())
+
+
+class BlockContains(IterOnly):
+    __contains__ = None
+
+
+try:
+    1 in BlockContains()
+except TypeError as exc:
+    assert str(exc) == "'BlockContains' object is not a container"
+else:
+    raise AssertionError("__contains__ = None did not block iteration fallback")

--- a/pyre/extra_tests/snippets/pickle_callableiter.py
+++ b/pyre/extra_tests/snippets/pickle_callableiter.py
@@ -1,0 +1,25 @@
+import pickle
+
+
+class Counter:
+    def __init__(self):
+        self.value = 0
+
+    def __call__(self):
+        value = self.value
+        self.value += 1
+        return value
+
+
+callable_iterator = iter(Counter(), 3)
+reconstructor, args = callable_iterator.__reduce__()
+assert reconstructor is iter
+assert args[1] == 3
+
+for protocol in range(pickle.HIGHEST_PROTOCOL + 1):
+    restored = pickle.loads(pickle.dumps(callable_iterator, protocol))
+    assert list(restored) == [0, 1, 2]
+
+exhausted = iter(lambda: 1, 1)
+assert list(exhausted) == []
+assert exhausted.__reduce__() == (iter, ((),))

--- a/pyre/extra_tests/snippets/stdlib_collections.py
+++ b/pyre/extra_tests/snippets/stdlib_collections.py
@@ -1,4 +1,33 @@
-from collections import deque
+from collections import defaultdict, deque
+
+
+# Python 3.14's defaultdict.__missing__ preserves a value installed by a
+# re-entrant factory call instead of overwriting it with the outer result.
+defaultdict_key = "conflict"
+defaultdict_calls = 0
+
+
+def reentrant_default_factory():
+    global defaultdict_calls
+    defaultdict_calls += 1
+    call = defaultdict_calls
+    if call == 1:
+        reentrant_defaultdict[defaultdict_key]
+    return call
+
+
+reentrant_defaultdict = defaultdict(reentrant_default_factory)
+assert reentrant_defaultdict[defaultdict_key] == 2
+assert defaultdict_calls == 2
+
+
+class DefaultDictSetDefaultOverride(defaultdict):
+    def setdefault(self, *args):
+        raise AssertionError("defaultdict.__missing__ called overridden setdefault")
+
+
+setdefault_override = DefaultDictSetDefaultOverride(lambda: 3)
+assert setdefault_override["key"] == 3
 
 d = deque([0, 1, 2])
 

--- a/pyre/extra_tests/snippets/stdlib_collections_deque.py
+++ b/pyre/extra_tests/snippets/stdlib_collections_deque.py
@@ -98,5 +98,27 @@ class D(deque):
 assert repr(D()) == "D([])"
 assert repr(D([1, 2, 3])) == "D([1, 2, 3])"
 
+assert deque("abc") + deque("def") == deque("abcdef")
+assert deque("abcdef", maxlen=4) + deque("gh") == deque("efgh")
+assert type(D([1]) + deque([2])) is D
+assert_raises(TypeError, lambda: deque("abc") + "def")
+
+
+class EmptyIterDeque(deque):
+    def __iter__(self):
+        return iter(())
+
+
+subclass_sum = EmptyIterDeque([1, 2]) + deque([3])
+assert type(subclass_sum) is EmptyIterDeque
+assert len(subclass_sum) == 1
+assert subclass_sum[0] == 3
+
+d = deque("a")
+d += "bcd"
+assert d == deque("abcd")
+d += d
+assert d == deque("abcdabcd")
+
 
 assert_raises(ValueError, lambda: deque().index(10, 0, 10000000000000000000000000))

--- a/pyre/extra_tests/snippets/stdlib_io.py
+++ b/pyre/extra_tests/snippets/stdlib_io.py
@@ -110,3 +110,24 @@ textio = TextIOWrapper(raw, encoding="utf-8", write_through=True)
 raw.textio = textio
 with assert_raises(AttributeError):
     textio.writelines(["x"])
+
+
+# PyPy's interp2app signature rejects a wrong argument count before the
+# receiver can observe any writes.  The registered Rust arity is only a call
+# dispatch hint, so the implementation must retain the same gateway check.
+class WriteSink(RawIOBase):
+    def __init__(self):
+        self.items = []
+
+    def write(self, item):
+        self.items.append(item)
+
+
+sink = WriteSink()
+with assert_raises(TypeError):
+    sink.writelines()
+with assert_raises(TypeError):
+    sink.writelines([b"line"], "surplus")
+assert sink.items == []
+sink.writelines([b"first", b"second"])
+assert sink.items == [b"first", b"second"]

--- a/pyre/extra_tests/snippets/stdlib_posix.py
+++ b/pyre/extra_tests/snippets/stdlib_posix.py
@@ -1,0 +1,32 @@
+import os
+
+from testutils import assert_raises
+
+
+if hasattr(os, "ftruncate"):
+    class Index:
+        def __init__(self, value):
+            self.value = value
+
+        def __index__(self):
+            return self.value
+
+    class IntOnly:
+        def __int__(self):
+            return 0
+
+    path = "/tmp/pyre_ftruncate_" + str(os.getpid())
+    fd = os.open(path, os.O_RDWR | os.O_CREAT | os.O_EXCL)
+    try:
+        assert os.write(fd, b"abcdefgh") == 8
+        os.ftruncate(Index(fd), Index(3))
+        assert os.stat(path).st_size == 3
+        os.ftruncate(fd, 8)
+        assert os.stat(path).st_size == 8
+        assert_raises(TypeError, lambda: os.ftruncate(IntOnly(), 0))
+        assert_raises(TypeError, lambda: os.ftruncate(fd, IntOnly()))
+        assert_raises(TypeError, lambda: os.ftruncate(fd))
+        assert_raises(TypeError, lambda: os.ftruncate(fd, 0, 0))
+    finally:
+        os.close(fd)
+        os.remove(path)

--- a/pyre/extra_tests/snippets/stdlib_posix.py
+++ b/pyre/extra_tests/snippets/stdlib_posix.py
@@ -1,9 +1,12 @@
 import os
+import posix
 
 from testutils import assert_raises
 
 
-if hasattr(os, "ftruncate"):
+# Sandbox builds still expose a raising `ftruncate` stub, so the capability
+# bit is the check that tracks the real fd mutation.
+if "HAVE_FTRUNCATE" in posix._have_functions:
     class Index:
         def __init__(self, value):
             self.value = value

--- a/pyre/extra_tests/snippets/time_clock_info.py
+++ b/pyre/extra_tests/snippets/time_clock_info.py
@@ -1,0 +1,23 @@
+import time
+
+
+for name in ("time", "monotonic", "perf_counter", "process_time"):
+    info = time.get_clock_info(name)
+    assert isinstance(info.implementation, str)
+    assert info.implementation
+    assert isinstance(info.monotonic, bool)
+    assert isinstance(info.adjustable, bool)
+    assert isinstance(info.resolution, float)
+    assert 0.0 < info.resolution <= 1.0
+
+assert not time.get_clock_info("time").monotonic
+assert time.get_clock_info("time").adjustable
+assert time.get_clock_info("monotonic").monotonic
+assert not time.get_clock_info("monotonic").adjustable
+
+try:
+    time.get_clock_info("unknown")
+except ValueError as exc:
+    assert str(exc) == "unknown clock"
+else:
+    raise AssertionError("unknown clock name was accepted")

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -101,10 +101,25 @@ pub fn take_pending_dict_key_error(key: PyObjectRef) -> PyError {
 /// The direct-hash counterpart of [`take_pending_dict_key_error`], used by
 /// bytecode paths which compute the key hash before entering `r_dict`.
 ///
-/// A bad dict key raises the bare `unhashable type: '<type>'` TypeError from
-/// hashing, with no container-specific prefix, so the error passes through.
-pub fn wrap_dict_key_hash_error(_key: PyObjectRef, err: PyError) -> PyError {
-    err
+/// Python 3.14 adds dict-key context to an exact `TypeError` raised while
+/// hashing. A different exception, including a `TypeError` subclass,
+/// propagates unchanged.
+pub fn wrap_dict_key_hash_error(key: PyObjectRef, err: PyError) -> PyError {
+    if err.kind != PyErrorKind::TypeError {
+        return err;
+    }
+    if !err.exc_object.is_null() {
+        let exact_type_error = crate::builtins::lookup_exc_class("TypeError");
+        let raised_type = crate::typedef::r#type(err.exc_object).unwrap_or(PY_NULL);
+        if exact_type_error.is_none_or(|expected| !std::ptr::eq(raised_type, expected)) {
+            return err;
+        }
+    }
+    PyError::type_error(format!(
+        "cannot use '{}' as a dict key ({})",
+        object_functionstr_type_name(key),
+        err.message,
+    ))
 }
 
 /// The set-element counterpart of [`wrap_dict_key_hash_error`]: a bad element

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -1941,6 +1941,44 @@ pub(crate) fn seq_iter_reduce_method(args: &[PyObjectRef]) -> PyResult {
     }
 }
 
+/// Python 3.14 `calliter_reduce` — a live `iter(callable, sentinel)` reduces
+/// to `(iter, (callable, sentinel))`; an exhausted iterator reduces through
+/// the same empty-iterator shape as the other builtin iterators.
+pub(crate) fn callable_iter_reduce_method(args: &[PyObjectRef]) -> PyResult {
+    let obj = args.first().copied().unwrap_or(PY_NULL);
+    if obj.is_null() || unsafe { !pyre_object::operation::is_callable_iterator(obj) } {
+        return Err(PyError::type_error(
+            "descriptor '__reduce__' requires a 'callable_iterator' object",
+        ));
+    }
+    let _roots = pyre_object::gc_roots::push_roots();
+    let sp = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(obj);
+    pyre_object::gc_roots::pin_root(builtin_callable("iter"));
+    let obj = pyre_object::gc_roots::shadow_stack_get(sp);
+    let callable = unsafe { pyre_object::operation::w_callable_iterator_get_callable(obj) };
+    let state = if callable.is_null() {
+        let empty = w_tuple_new(vec![]);
+        pyre_object::gc_roots::pin_root(empty);
+        w_tuple_new(vec![pyre_object::gc_roots::shadow_stack_get(
+            pyre_object::gc_roots::shadow_stack_len() - 1,
+        )])
+    } else {
+        let sentinel = unsafe { pyre_object::operation::w_callable_iterator_get_sentinel(obj) };
+        pyre_object::gc_roots::pin_root(callable);
+        pyre_object::gc_roots::pin_root(sentinel);
+        w_tuple_new(vec![
+            pyre_object::gc_roots::shadow_stack_get(sp + 2),
+            pyre_object::gc_roots::shadow_stack_get(sp + 3),
+        ])
+    };
+    pyre_object::gc_roots::pin_root(state);
+    Ok(w_tuple_new(vec![
+        pyre_object::gc_roots::shadow_stack_get(sp + 1),
+        pyre_object::gc_roots::shadow_stack_get(pyre_object::gc_roots::shadow_stack_len() - 1),
+    ]))
+}
+
 /// `sequenceiterator.__setstate__(index)` — `iterobject.py:40-45
 /// W_AbstractSeqIterObject.descr_setstate`: restore the cursor only while the
 /// sequence is live, clamping a negative index to 0.  There is no upper clamp —
@@ -4450,6 +4488,11 @@ fn getattr_str_impl(obj: PyObjectRef, name: &str, call_getattr: bool) -> PyResul
                 match name {
                     "__reduce__" => Some((zip_reduce_method, "__reduce__", 1)),
                     "__setstate__" => Some((zip_setstate_method, "__setstate__", 2)),
+                    _ => None,
+                }
+            } else if pyre_object::operation::is_callable_iterator(obj) {
+                match name {
+                    "__reduce__" => Some((callable_iter_reduce_method, "__reduce__", 1)),
                     _ => None,
                 }
             } else {

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -3724,6 +3724,53 @@ pub fn getdict(obj: PyObjectRef) -> PyObjectRef {
     if unsafe { pyre_object::is_exception(obj) } {
         return unsafe { pyre_object::interp_exceptions::w_exception_getdict(obj) };
     }
+    // bytesobject.py W_BytesObject subclasses inherit mapdict support.  Their
+    // dict SPECIAL slot lives on the native bytes payload so the GC sees the
+    // `subclass -> dict` edge and can collect cycles through a memoryview.
+    if unsafe { pyre_object::bytesobject::is_bytes(obj) } {
+        let Some(w_type) = crate::typedef::r#type(obj) else {
+            return PY_NULL;
+        };
+        if unsafe { pyre_object::w_type_get_hasdict(w_type) } {
+            let existing = unsafe { pyre_object::bytesobject::w_bytes_getdict(obj) };
+            if !existing.is_null() {
+                return existing;
+            }
+            let _roots = pyre_object::gc_roots::push_roots();
+            let root_base = pyre_object::gc_roots::shadow_stack_len();
+            pyre_object::gc_roots::pin_root(obj);
+            let w_dict = pyre_object::w_dict_new();
+            unsafe {
+                pyre_object::bytesobject::w_bytes_setdict(
+                    pyre_object::gc_roots::shadow_stack_get(root_base),
+                    w_dict,
+                )
+            };
+            return w_dict;
+        }
+    }
+    if unsafe { pyre_object::bytearrayobject::is_bytearray(obj) } {
+        let Some(w_type) = crate::typedef::r#type(obj) else {
+            return PY_NULL;
+        };
+        if unsafe { pyre_object::w_type_get_hasdict(w_type) } {
+            let existing = unsafe { pyre_object::bytearrayobject::w_bytearray_getdict(obj) };
+            if !existing.is_null() {
+                return existing;
+            }
+            let _roots = pyre_object::gc_roots::push_roots();
+            let root_base = pyre_object::gc_roots::shadow_stack_len();
+            pyre_object::gc_roots::pin_root(obj);
+            let w_dict = pyre_object::w_dict_new();
+            unsafe {
+                pyre_object::bytearrayobject::w_bytearray_setdict(
+                    pyre_object::gc_roots::shadow_stack_get(root_base),
+                    w_dict,
+                )
+            };
+            return w_dict;
+        }
+    }
     let w_type = match crate::typedef::r#type(obj) {
         Some(tp) => tp,
         None => return pyre_object::PY_NULL,
@@ -3825,6 +3872,28 @@ pub fn setdict(obj: PyObjectRef, w_dict: PyObjectRef) -> Result<(), PyError> {
         unsafe { pyre_object::interp_exceptions::w_exception_setdict(obj, w_dict) };
         return Ok(());
     }
+    if unsafe { pyre_object::bytesobject::is_bytes(obj) } {
+        let w_dict_type = crate::typedef::gettypeobject(&pyre_object::pyobject::DICT_TYPE);
+        if !unsafe { isinstance_w(w_dict, w_dict_type) } {
+            return Err(PyError::type_error(format!(
+                "__dict__ must be set to a dictionary, not a '{}'",
+                object_functionstr_type_name(w_dict),
+            )));
+        }
+        unsafe { pyre_object::bytesobject::w_bytes_setdict(obj, w_dict) };
+        return Ok(());
+    }
+    if unsafe { pyre_object::bytearrayobject::is_bytearray(obj) } {
+        let w_dict_type = crate::typedef::gettypeobject(&pyre_object::pyobject::DICT_TYPE);
+        if !unsafe { isinstance_w(w_dict, w_dict_type) } {
+            return Err(PyError::type_error(format!(
+                "__dict__ must be set to a dictionary, not a '{}'",
+                object_functionstr_type_name(w_dict),
+            )));
+        }
+        unsafe { pyre_object::bytearrayobject::w_bytearray_setdict(obj, w_dict) };
+        return Ok(());
+    }
     let w_type = match crate::typedef::r#type(obj) {
         Some(tp) => tp,
         None => {
@@ -3870,6 +3939,28 @@ fn getdict_backing(obj: PyObjectRef) -> PyObjectRef {
 ///
 /// MapdictWeakrefSupport.getweakref overrides it.
 pub fn getweakref(obj: PyObjectRef) -> Option<PyObjectRef> {
+    if unsafe { pyre_object::memoryview::is_w_memoryview(obj) } {
+        let lifeline = unsafe { pyre_object::memoryview::w_memoryview_getweakref(obj) };
+        return (!lifeline.is_null()).then_some(lifeline);
+    }
+    if unsafe { pyre_object::bytesobject::is_bytes(obj) } {
+        if crate::typedef::r#type(obj)
+            .is_some_and(|w_type| unsafe { pyre_object::w_type_get_weakrefable(w_type) })
+        {
+            let lifeline = unsafe { pyre_object::bytesobject::w_bytes_getweakref(obj) };
+            return (!lifeline.is_null()).then_some(lifeline);
+        }
+        return None;
+    }
+    if unsafe { pyre_object::bytearrayobject::is_bytearray(obj) } {
+        if crate::typedef::r#type(obj)
+            .is_some_and(|w_type| unsafe { pyre_object::w_type_get_weakrefable(w_type) })
+        {
+            let lifeline = unsafe { pyre_object::bytearrayobject::w_bytearray_getweakref(obj) };
+            return (!lifeline.is_null()).then_some(lifeline);
+        }
+        return None;
+    }
     let w_type = crate::typedef::r#type(obj)?;
     if unsafe { pyre_object::w_type_get_weakrefable(w_type) } {
         crate::objspace::std::mapdict::getweakref(obj)
@@ -3888,6 +3979,26 @@ pub fn getweakref(obj: PyObjectRef) -> Option<PyObjectRef> {
 ///
 /// MapdictWeakrefSupport.setweakref overrides it.
 pub fn setweakref(obj: PyObjectRef, weakreflifeline: PyObjectRef) -> Result<(), PyError> {
+    if unsafe { pyre_object::memoryview::is_w_memoryview(obj) } {
+        unsafe { pyre_object::memoryview::w_memoryview_setweakref(obj, weakreflifeline) };
+        return Ok(());
+    }
+    if unsafe { pyre_object::bytesobject::is_bytes(obj) } {
+        if crate::typedef::r#type(obj)
+            .is_some_and(|w_type| unsafe { pyre_object::w_type_get_weakrefable(w_type) })
+        {
+            unsafe { pyre_object::bytesobject::w_bytes_setweakref(obj, weakreflifeline) };
+            return Ok(());
+        }
+    }
+    if unsafe { pyre_object::bytearrayobject::is_bytearray(obj) } {
+        if crate::typedef::r#type(obj)
+            .is_some_and(|w_type| unsafe { pyre_object::w_type_get_weakrefable(w_type) })
+        {
+            unsafe { pyre_object::bytearrayobject::w_bytearray_setweakref(obj, weakreflifeline) };
+            return Ok(());
+        }
+    }
     let w_type = match crate::typedef::r#type(obj) {
         Some(tp) => tp,
         None => {
@@ -3915,6 +4026,26 @@ pub fn setweakref(obj: PyObjectRef, weakreflifeline: PyObjectRef) -> Result<(), 
 ///     pass
 /// ```
 pub fn delweakref(obj: PyObjectRef) {
+    if unsafe { pyre_object::memoryview::is_w_memoryview(obj) } {
+        unsafe { pyre_object::memoryview::w_memoryview_setweakref(obj, PY_NULL) };
+        return;
+    }
+    if unsafe { pyre_object::bytesobject::is_bytes(obj) } {
+        if crate::typedef::r#type(obj)
+            .is_some_and(|w_type| unsafe { pyre_object::w_type_get_weakrefable(w_type) })
+        {
+            unsafe { pyre_object::bytesobject::w_bytes_setweakref(obj, PY_NULL) };
+            return;
+        }
+    }
+    if unsafe { pyre_object::bytearrayobject::is_bytearray(obj) } {
+        if crate::typedef::r#type(obj)
+            .is_some_and(|w_type| unsafe { pyre_object::w_type_get_weakrefable(w_type) })
+        {
+            unsafe { pyre_object::bytearrayobject::w_bytearray_setweakref(obj, PY_NULL) };
+            return;
+        }
+    }
     let w_type = match crate::typedef::r#type(obj) {
         Some(tp) => tp,
         None => return,

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -1920,24 +1920,69 @@ pub(crate) fn builtin_callable(name: &str) -> PyObjectRef {
     unsafe { (*ctx).lookup_builtin(name).unwrap_or(PY_NULL) }
 }
 
+/// Build the common iterator pickle tuple after the reconstructor lookup and
+/// the subsequent state read.  Keep every component rooted while tuple
+/// allocation runs: these methods are deliberately exercised with a hostile
+/// builtins dict whose equality hook can exhaust the receiver and allocate.
+fn iterator_reduce_tuple(
+    callable: PyObjectRef,
+    seq: PyObjectRef,
+    index: i64,
+    empty_kind: u8,
+) -> PyResult {
+    let _roots = pyre_object::gc_roots::push_roots();
+    let sp = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(callable);
+    if seq.is_null() {
+        // CPython 3.14 retains the concrete producer shape for the
+        // specialized string/list iterators; generic sequence, bytes and
+        // tuple iterators use the canonical empty tuple.
+        let empty = match empty_kind {
+            1 => w_str_new(""),
+            2 => w_list_new(vec![]),
+            _ => w_tuple_new(vec![]),
+        };
+        pyre_object::gc_roots::pin_root(empty);
+        let state = w_tuple_new(vec![pyre_object::gc_roots::shadow_stack_get(sp + 1)]);
+        pyre_object::gc_roots::pin_root(state);
+        return Ok(w_tuple_new(vec![
+            pyre_object::gc_roots::shadow_stack_get(sp),
+            pyre_object::gc_roots::shadow_stack_get(sp + 2),
+        ]));
+    }
+    pyre_object::gc_roots::pin_root(seq);
+    let state = w_tuple_new(vec![pyre_object::gc_roots::shadow_stack_get(sp + 1)]);
+    pyre_object::gc_roots::pin_root(state);
+    let w_index = w_int_new(index);
+    pyre_object::gc_roots::pin_root(w_index);
+    Ok(w_tuple_new(vec![
+        pyre_object::gc_roots::shadow_stack_get(sp),
+        pyre_object::gc_roots::shadow_stack_get(sp + 2),
+        pyre_object::gc_roots::shadow_stack_get(sp + 3),
+    ]))
+}
+
 /// `sequenceiterator.__reduce__()` — `iterobject.py
 /// W_AbstractSeqIterObject.descr_reduce`: `(iter, (seq,), index)` for a live
 /// sequence; an exhausted iterator (`w_seq is None`) pickles to `_empty_iterable`
 /// (`iterobject.py:251-253`) = `(iter, ((),))` so it restores empty.
 pub(crate) fn seq_iter_reduce_method(args: &[PyObjectRef]) -> PyResult {
+    // CPython 3.14 issue #101765: resolving `builtins.iter` can run an
+    // equality hook which exhausts this iterator.  Root the receiver, perform
+    // that lookup first, and only then read its live sequence and cursor.
+    let _roots = pyre_object::gc_roots::push_roots();
+    let sp = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(args[0]);
+    let callable = builtin_callable("iter");
+    pyre_object::gc_roots::pin_root(callable);
     unsafe {
-        let seq = pyre_object::w_seq_iter_seq(args[0]);
-        if seq.is_null() {
-            let empty_state = w_tuple_new(vec![w_tuple_new(vec![])]);
-            return Ok(w_tuple_new(vec![builtin_callable("iter"), empty_state]));
-        }
-        let index = pyre_object::w_seq_iter_index(args[0]);
-        let state = w_tuple_new(vec![seq]);
-        Ok(w_tuple_new(vec![
-            builtin_callable("iter"),
-            state,
-            w_int_new(index),
-        ]))
+        let receiver = pyre_object::gc_roots::shadow_stack_get(sp);
+        iterator_reduce_tuple(
+            pyre_object::gc_roots::shadow_stack_get(sp + 1),
+            pyre_object::w_seq_iter_seq(receiver),
+            pyre_object::w_seq_iter_index(receiver),
+            pyre_object::w_seq_iter_empty_kind(receiver),
+        )
     }
 }
 
@@ -2020,19 +2065,19 @@ pub(crate) fn seq_iter_length_hint_method(args: &[PyObjectRef]) -> PyResult {
 /// `iterobject.py W_AbstractSeqIterObject.descr_reduce`, for the specialized
 /// `W_FastListIterObject` payload used by Python 3.14's `list_iterator`.
 pub(crate) fn list_iter_reduce_method(args: &[PyObjectRef]) -> PyResult {
+    let _roots = pyre_object::gc_roots::push_roots();
+    let sp = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(args[0]);
+    let callable = builtin_callable("iter");
+    pyre_object::gc_roots::pin_root(callable);
     unsafe {
-        let seq = pyre_object::w_list_iter_seq(args[0]);
-        if seq.is_null() {
-            return Ok(w_tuple_new(vec![
-                builtin_callable("iter"),
-                w_tuple_new(vec![w_tuple_new(vec![])]),
-            ]));
-        }
-        Ok(w_tuple_new(vec![
-            builtin_callable("iter"),
-            w_tuple_new(vec![seq]),
-            w_int_new(pyre_object::w_list_iter_index(args[0])),
-        ]))
+        let receiver = pyre_object::gc_roots::shadow_stack_get(sp);
+        iterator_reduce_tuple(
+            pyre_object::gc_roots::shadow_stack_get(sp + 1),
+            pyre_object::w_list_iter_seq(receiver),
+            pyre_object::w_list_iter_index(receiver),
+            2,
+        )
     }
 }
 
@@ -2066,19 +2111,19 @@ pub(crate) fn list_iter_length_hint_method(args: &[PyObjectRef]) -> PyResult {
 }
 
 pub(crate) fn tuple_iter_reduce_method(args: &[PyObjectRef]) -> PyResult {
+    let _roots = pyre_object::gc_roots::push_roots();
+    let sp = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(args[0]);
+    let callable = builtin_callable("iter");
+    pyre_object::gc_roots::pin_root(callable);
     unsafe {
-        let seq = pyre_object::w_tuple_iter_seq(args[0]);
-        if seq.is_null() {
-            return Ok(w_tuple_new(vec![
-                builtin_callable("iter"),
-                w_tuple_new(vec![w_tuple_new(vec![])]),
-            ]));
-        }
-        Ok(w_tuple_new(vec![
-            builtin_callable("iter"),
-            w_tuple_new(vec![seq]),
-            w_int_new(pyre_object::w_tuple_iter_index(args[0])),
-        ]))
+        let receiver = pyre_object::gc_roots::shadow_stack_get(sp);
+        iterator_reduce_tuple(
+            pyre_object::gc_roots::shadow_stack_get(sp + 1),
+            pyre_object::w_tuple_iter_seq(receiver),
+            pyre_object::w_tuple_iter_index(receiver),
+            0,
+        )
     }
 }
 
@@ -2113,19 +2158,19 @@ pub(crate) fn tuple_iter_length_hint_method(args: &[PyObjectRef]) -> PyResult {
 
 /// `iterobject.py W_ReverseSeqIterObject` pickle/state/length protocol.
 pub(crate) fn list_reverse_iter_reduce_method(args: &[PyObjectRef]) -> PyResult {
+    let _roots = pyre_object::gc_roots::push_roots();
+    let sp = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(args[0]);
+    let callable = builtin_callable("reversed");
+    pyre_object::gc_roots::pin_root(callable);
     unsafe {
-        let seq = pyre_object::w_list_reverse_iter_seq(args[0]);
-        if seq.is_null() {
-            return Ok(w_tuple_new(vec![
-                builtin_callable("iter"),
-                w_tuple_new(vec![w_tuple_new(vec![])]),
-            ]));
-        }
-        Ok(w_tuple_new(vec![
-            builtin_callable("reversed"),
-            w_tuple_new(vec![seq]),
-            w_int_new(pyre_object::w_list_reverse_iter_index(args[0])),
-        ]))
+        let receiver = pyre_object::gc_roots::shadow_stack_get(sp);
+        iterator_reduce_tuple(
+            pyre_object::gc_roots::shadow_stack_get(sp + 1),
+            pyre_object::w_list_reverse_iter_seq(receiver),
+            pyre_object::w_list_reverse_iter_index(receiver),
+            2,
+        )
     }
 }
 
@@ -13159,6 +13204,12 @@ pub fn contains(haystack: PyObjectRef, needle: PyObjectRef) -> Result<bool, PyEr
             || pyre_object::is_set_or_frozenset(haystack)
         {
             if let Some((method, w_type)) = subclass_special_override(haystack, "__contains__") {
+                // CPython 3.14 `slot_sq_contains`: assigning the special
+                // method to None blocks both the inherited slot and the
+                // iterator fallback.
+                if is_none(method) {
+                    return Err(not_container_error(haystack));
+                }
                 let result = get_and_call_function(method, haystack, w_type, &[needle])?;
                 return Ok(is_true(result)?);
             }
@@ -13353,11 +13404,9 @@ pub(crate) fn contains_slot(haystack: PyObjectRef, needle: PyObjectRef) -> Resul
         if is_instance(haystack) {
             let w_type = w_instance_get_type(haystack);
             if let Some(method) = lookup_in_type_where(w_type, "__contains__") {
-                let result = crate::builtins::call_and_check(method, &[haystack, needle])?;
-                return Ok(is_true(result)?);
-            }
-            // Also check per-instance attributes
-            if let Ok(method) = getattr_str(haystack, "__contains__") {
+                if is_none(method) {
+                    return Err(not_container_error(haystack));
+                }
                 let result = crate::builtins::call_and_check(method, &[haystack, needle])?;
                 return Ok(is_true(result)?);
             }
@@ -13373,28 +13422,52 @@ pub(crate) fn contains_slot(haystack: PyObjectRef, needle: PyObjectRef) -> Resul
     unsafe {
         if let Some(w_type) = crate::typedef::r#type(haystack) {
             if let Some(method) = lookup_in_type_where(w_type, "__contains__") {
+                if is_none(method) {
+                    return Err(not_container_error(haystack));
+                }
                 let result = crate::builtins::call_and_check(method, &[haystack, needle])?;
                 return Ok(is_true(result)?);
             }
         }
     }
-    // Fallback: `space.sequence_contains` — scan via getitem(obj, i) for
-    // i = 0, 1, ….  An `IndexError` ends the scan (not found); any other
-    // error (e.g. a released/non-contiguous memoryview) propagates, matching
-    // `PySequence_Contains`.
-    let mut i = 0i64;
+    // PyPy `descroperation.py:514-520 sequence_contains`: obtain the
+    // iterator first, then repeatedly call `space.next`.  The iterator may
+    // itself be the sequence iterator produced by `iter()`'s `__getitem__`
+    // fallback, but an explicit `__iter__` must take precedence.
+    let iterator = match iter(haystack) {
+        Ok(iterator) => iterator,
+        // CPython 3.14 `PySequence_Contains` replaces an iterator-acquisition
+        // TypeError (including one raised by user `__iter__`) with its
+        // membership-specific diagnostic.  Other exceptions propagate.
+        Err(err) if err.kind == PyErrorKind::TypeError => {
+            return Err(not_container_or_iterable_error(haystack));
+        }
+        Err(err) => return Err(err),
+    };
     loop {
-        match getitem(haystack, pyre_object::w_int_new(i)) {
+        match next(iterator) {
             Ok(item) => {
                 if eq_w(item, needle)? {
                     return Ok(true);
                 }
-                i += 1;
             }
-            Err(e) if e.kind == PyErrorKind::IndexError => return Ok(false),
+            Err(e) if e.kind == PyErrorKind::StopIteration => return Ok(false),
             Err(e) => return Err(e),
         }
     }
+}
+
+fn not_container_error(obj: PyObjectRef) -> PyError {
+    PyError::type_error(format!("'{}' object is not a container", unsafe {
+        obj_type_name(obj)
+    }))
+}
+
+fn not_container_or_iterable_error(obj: PyObjectRef) -> PyError {
+    PyError::type_error(format!(
+        "argument of type '{}' is not a container or iterable",
+        unsafe { obj_type_name(obj) }
+    ))
 }
 
 /// `pypy/interpreter/baseobjspace.py:840-845 W_ObjectSpace.hash_w` —

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -6872,7 +6872,7 @@ pub unsafe fn mutated(w_type: PyObjectRef, key: Option<&str>) {
         pyre_object::w_type_set_hasuserdel(w_type, true);
     }
     // typeobject.py:288-291 — walk direct subclasses recursively.
-    let subs = pyre_object::typeobject::w_type_get_subclasses(w_type);
+    let subs = pyre_object::typeobject::w_type_get_subclasses(w_type, false);
     for w_sub in subs {
         mutated(w_sub, key);
     }
@@ -7579,6 +7579,69 @@ pub unsafe fn super_lookup_binding(
 /// Public wrapper for use by isinstance and other external callers.
 pub unsafe fn compute_default_mro(w_type: PyObjectRef) -> Vec<PyObjectRef> {
     compute_mro(w_type)
+}
+
+/// `typeobject.py:1595-1613 compute_mro` — install the default C3 MRO, or
+/// call a heap type's metaclass override before installing its validated
+/// result.
+///
+/// The new type already has its metaclass and `__classcell__` installed when
+/// this runs. That ordering is observable: a custom `Meta.mro()` may execute
+/// a method from the nascent class dictionary, and that method's
+/// zero-argument `super()` / `__class__` closure must already resolve to the
+/// new type.
+pub(crate) unsafe fn compute_and_set_mro(w_self: PyObjectRef) -> PyResult {
+    let default_mro = compute_default_mro(w_self);
+    if pyre_object::w_type_is_heaptype(w_self) {
+        let w_metaclass = (*w_self).w_class;
+        if !w_metaclass.is_null() {
+            if let Some((w_where, w_mro_func)) = lookup_where_with_method_cache(w_metaclass, "mro")
+            {
+                if !std::ptr::eq(w_where, crate::typedef::w_type()) {
+                    let w_mro = get_and_call_function(w_mro_func, w_self, w_metaclass, &[])?;
+                    let mro_w = crate::builtins::collect_iterable(w_mro)?;
+                    // `fixedview` keeps PyPy's items GC-visible through the
+                    // returned list.  Pyre materializes an untraced Rust Vec,
+                    // so pin every yielded class while validation can execute
+                    // Python (`abstract_isclass_w`) and allocate.
+                    let _mro_roots = pyre_object::gc_roots::push_roots();
+                    let mro_root_start = pyre_object::gc_roots::shadow_stack_len();
+                    for &w_class in &mro_w {
+                        pyre_object::gc_roots::pin_root(w_class);
+                    }
+                    for index in 0..mro_w.len() {
+                        let w_class =
+                            pyre_object::gc_roots::shadow_stack_get(mro_root_start + index);
+                        if !abstract_isclass_w(w_class)? {
+                            return Err(PyError::type_error("mro() returned a non-class"));
+                        }
+                    }
+                    let mro_w: Vec<_> = (0..mro_w.len())
+                        .map(|index| {
+                            pyre_object::gc_roots::shadow_stack_get(mro_root_start + index)
+                        })
+                        .collect();
+                    pyre_object::w_type_set_mro(w_self, mro_w.clone());
+
+                    // typeobject.py `_add_mro_classes_as_subclasses`: custom
+                    // MRO entries outside the default hierarchy participate
+                    // in invalidation just like real bases.
+                    for w_ancestor in mro_w {
+                        if !default_mro
+                            .iter()
+                            .any(|&default| std::ptr::eq(default, w_ancestor))
+                            && pyre_object::is_type(w_ancestor)
+                        {
+                            pyre_object::typeobject::w_type_add_subclass(w_ancestor, w_self);
+                        }
+                    }
+                    return Ok(pyre_object::w_none());
+                }
+            }
+        }
+    }
+    pyre_object::w_type_set_mro(w_self, default_mro);
+    Ok(pyre_object::w_none())
 }
 
 /// Reject a base tuple whose C3 merge has no valid next head.

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -4287,7 +4287,12 @@ fn getattr_str_impl(obj: PyObjectRef, name: &str, call_getattr: bool) -> PyResul
                             // descriptor.py:76-82 — class-mode
                             // `super(C, C)` calls `__get__(None, C)`.
                             let descr_obj = if std::ptr::eq(bound_obj, w_obj_type) {
-                                w_none()
+                                // `get` represents class access with PY_NULL
+                                // and exposes `space.w_None` only when it
+                                // invokes a user `__get__`. Passing the None
+                                // singleton here would bind plain functions to
+                                // None instead of returning them unbound.
+                                PY_NULL
                             } else {
                                 bound_obj
                             };

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -81,6 +81,20 @@ pub fn walk_pending_hash_error(visitor: &mut dyn FnMut(&mut majit_ir::GcRef)) {
     });
 }
 
+/// interp_gc.py:12-15 — clear `space.fromcache(MethodCache)` before an
+/// explicit full collection.
+#[majit_macros::dont_look_inside]
+pub fn clear_method_cache() {
+    METHOD_CACHE.with(|cache| {
+        let mut cache = cache.borrow_mut();
+        cache.versions.fill(0);
+        cache.names.fill(None);
+        cache
+            .lookup_where
+            .fill((std::ptr::null_mut(), std::ptr::null_mut()));
+    });
+}
+
 /// CPython 3.14 `dict_unhashable_type` (`Objects/dictobject.c`) parity.
 /// Only an exact `TypeError` raised while hashing is replaced; equality
 /// callback errors, non-TypeError exceptions, and TypeError subclasses pass

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -2010,6 +2010,14 @@ pub(crate) fn callable_iter_reduce_method(args: &[PyObjectRef]) -> PyResult {
             "descriptor '__reduce__' requires a 'callable_iterator' object",
         ));
     }
+    // The registered arity is only a dispatch hint; surplus positional
+    // arguments must be rejected here.
+    if args.len() > 1 {
+        return Err(PyError::type_error(format!(
+            "callable_iterator.__reduce__() takes no arguments ({} given)",
+            args.len() - 1,
+        )));
+    }
     let _roots = pyre_object::gc_roots::push_roots();
     let sp = pyre_object::gc_roots::shadow_stack_len();
     pyre_object::gc_roots::pin_root(obj);

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -3793,6 +3793,15 @@ pub fn getdict(obj: PyObjectRef) -> PyObjectRef {
 /// (`mapdict::INSTANCE_DICT`) that already holds the subclass's regular
 /// attributes. `None`/`false` means the receiver has no writable dict.
 pub(crate) fn native_slot_get(obj: PyObjectRef, name: &str) -> Option<PyObjectRef> {
+    // Python 3.14 permits a native-layout `property` subclass to declare an
+    // explicit `__doc__` slot.  PyPy's extended instance layout stores that
+    // slot on the object; pyre's equivalent object-resident location is the
+    // existing `W_Property.w_doc` field, not the native-subclass dict
+    // fallback below (a slots-only subclass deliberately has no dict).
+    if name == "__doc__" && unsafe { pyre_object::descriptor::is_property(obj) } {
+        let value = unsafe { pyre_object::descriptor::w_property_get_doc(obj) };
+        return (!value.is_null()).then_some(value);
+    }
     let w_dict = getdict(obj);
     if w_dict.is_null() {
         return None;
@@ -3801,6 +3810,10 @@ pub(crate) fn native_slot_get(obj: PyObjectRef, name: &str) -> Option<PyObjectRe
 }
 
 pub(crate) fn native_slot_set(obj: PyObjectRef, name: &str, value: PyObjectRef) -> bool {
+    if name == "__doc__" && unsafe { pyre_object::descriptor::is_property(obj) } {
+        unsafe { pyre_object::descriptor::w_property_set_doc(obj, value) };
+        return true;
+    }
     let w_dict = getdict(obj);
     if w_dict.is_null() {
         return false;
@@ -3810,6 +3823,14 @@ pub(crate) fn native_slot_set(obj: PyObjectRef, name: &str, value: PyObjectRef) 
 }
 
 pub(crate) fn native_slot_del(obj: PyObjectRef, name: &str) -> bool {
+    if name == "__doc__" && unsafe { pyre_object::descriptor::is_property(obj) } {
+        let value = unsafe { pyre_object::descriptor::w_property_get_doc(obj) };
+        if value.is_null() {
+            return false;
+        }
+        unsafe { pyre_object::descriptor::w_property_set_doc(obj, pyre_object::PY_NULL) };
+        return true;
+    }
     let w_dict = getdict(obj);
     if w_dict.is_null() {
         return false;
@@ -12042,11 +12063,15 @@ unsafe fn property_no_accessor(
 pub(crate) fn property_set_name_impl(args: &[PyObjectRef]) -> PyResult {
     // descriptor.py:274-276 `set_name(self, w_type, w_name)` — the bound
     // method receives `[property, owner, name]`.
-    let prop = property_require_obj(args.first().copied().unwrap_or(PY_NULL), "__set_name__")?;
-    if args.len() > 2 {
-        let w_name = args[2];
-        unsafe { pyre_object::descriptor::w_property_set_name(prop, w_name) };
+    if args.len() != 3 {
+        return Err(crate::PyError::type_error(format!(
+            "__set_name__() takes 2 positional arguments but {} were given",
+            args.len().saturating_sub(1),
+        )));
     }
+    let prop = property_require_obj(args.first().copied().unwrap_or(PY_NULL), "__set_name__")?;
+    let w_name = args[2];
+    unsafe { pyre_object::descriptor::w_property_set_name(prop, w_name) };
     Ok(pyre_object::w_none())
 }
 

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -6139,7 +6139,7 @@ pub(crate) fn space_int(obj: PyObjectRef) -> Result<PyObjectRef, PyError> {
         let tp = crate::type_methods::arg_type_name(w_result);
         crate::warn::warn_deprecation(&format!(
             "__int__ returned non-int (type {tp}).  The ability to return an instance of a strict subclass of int is deprecated, and may be removed in a future version of Python."
-        ));
+        ))?;
         return Ok(w_result);
     }
     // baseobjspace.py:338-339 non-int result → TypeError.
@@ -9560,7 +9560,7 @@ pub fn space_index(obj: PyObjectRef) -> Result<PyObjectRef, PyError> {
         let tp = crate::type_methods::arg_type_name(w_result);
         crate::warn::warn_deprecation(&format!(
             "__index__ returned non-int (type {tp}).  The ability to return an instance of a strict subclass of int is deprecated, and may be removed in a future version of Python."
-        ));
+        ))?;
         // descroperation.py:622-627 `space.index` — return a base int,
         // never the strict subclass supplied by `__index__`.
         unsafe {

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -477,7 +477,11 @@ fn memoryview_pack_value(
         if unsafe { pyre_object::is_int_or_long(w_val) } {
             Ok(w_val)
         } else {
-            unsafe { crate::baseobjspace::space_index(w_val) }.map_err(|_| bad_type())
+            match unsafe { crate::baseobjspace::space_index(w_val) } {
+                Ok(index) => Ok(index),
+                Err(err) if err.kind == crate::PyErrorKind::TypeError => Err(bad_type()),
+                Err(err) => Err(err),
+            }
         }
     };
     let int_val = || -> Result<i64, crate::PyError> {
@@ -523,17 +527,22 @@ fn memoryview_pack_value(
             v.to_ne_bytes().to_vec()
         }
         b'f' => {
-            if !unsafe { pyre_object::is_int_or_long(w_val) || pyre_object::is_float(w_val) } {
-                return Err(bad_type());
-            }
-            let v = crate::baseobjspace::float_w(w_val).map_err(|_| bad_type())? as f32;
+            // `PackFormatIterator.accept_float_arg`: use `space.float_w`,
+            // including a user `__float__`; only TypeError becomes the
+            // memoryview format error and other user exceptions propagate.
+            let v = match crate::baseobjspace::float_w(w_val) {
+                Ok(value) => value,
+                Err(err) if err.kind == crate::PyErrorKind::TypeError => return Err(bad_type()),
+                Err(err) => return Err(err),
+            } as f32;
             v.to_ne_bytes().to_vec()
         }
         b'd' => {
-            if !unsafe { pyre_object::is_int_or_long(w_val) || pyre_object::is_float(w_val) } {
-                return Err(bad_type());
-            }
-            let v = crate::baseobjspace::float_w(w_val).map_err(|_| bad_type())?;
+            let v = match crate::baseobjspace::float_w(w_val) {
+                Ok(value) => value,
+                Err(err) if err.kind == crate::PyErrorKind::TypeError => return Err(bad_type()),
+                Err(err) => return Err(err),
+            };
             v.to_ne_bytes().to_vec()
         }
         b'?' => {
@@ -587,7 +596,46 @@ unsafe fn memoryview_slice_view(
         } else {
             0
         };
-        let (start, stop, step) = crate::baseobjspace::normalize_slice(index, count)?;
+
+        // CPython 3.14 `memory_subscript`: `mbuf_add_view(self->mbuf, view)`
+        // registers the result *before* `init_slice` evaluates the slice
+        // bounds.  A bound's `__index__` may release `mv`; the registered
+        // result must keep the export alive and continue from its private
+        // view snapshot (gh-92888).
+        let _roots = pyre_object::gc_roots::push_roots();
+        let sp = pyre_object::gc_roots::shadow_stack_len();
+        pyre_object::gc_roots::pin_root(mv);
+        pyre_object::gc_roots::pin_root(index);
+        let sliced = w_memoryview_alloc_header(false, true);
+        let r_mv = pyre_object::gc_roots::shadow_stack_get(sp);
+        let snapshot = w_memoryview_view(r_mv).clone();
+        // The root `Buffer` tag was fixed by `buffer_w`; follow it directly
+        // instead of repeating an objspace isinstance lookup in this hot/JIT
+        // path.  `Buffer::sub` never nests, so one parent peel is sufficient.
+        let backing = snapshot.backing();
+        match backing {
+            pyre_object::buffer::Buffer::Byte { w_obj } => {
+                pyre_object::bytearrayobject::w_bytearray_exports_incref(*w_obj)
+            }
+            pyre_object::buffer::Buffer::Array { w_obj } => {
+                pyre_object::interp_array::w_array_exports_incref(*w_obj)
+            }
+            pyre_object::buffer::Buffer::Sub { parent, .. } => match parent.as_ref() {
+                pyre_object::buffer::Buffer::Byte { w_obj } => {
+                    pyre_object::bytearrayobject::w_bytearray_exports_incref(*w_obj)
+                }
+                pyre_object::buffer::Buffer::Array { w_obj } => {
+                    pyre_object::interp_array::w_array_exports_incref(*w_obj)
+                }
+                _ => {}
+            },
+            _ => {}
+        }
+        w_memoryview_set_view(sliced, bufferview_alloc(snapshot));
+        pyre_object::gc_roots::pin_root(sliced);
+
+        let r_index = pyre_object::gc_roots::shadow_stack_get(sp + 1);
+        let (start, stop, step) = crate::baseobjspace::normalize_slice(r_index, count)?;
         let slicelength = if (step < 0 && stop >= start) || (step > 0 && start >= stop) {
             0
         } else if step < 0 {
@@ -595,9 +643,13 @@ unsafe fn memoryview_slice_view(
         } else {
             (stop - start - 1) / step + 1
         };
-        Ok(w_memoryview_new_derived(mv, |v| unsafe {
-            v.new_slice(start, step, slicelength)
-        }))
+        let r_sliced = pyre_object::gc_roots::shadow_stack_get(sp + 2);
+        let old_view =
+            (*(r_sliced as *mut W_MemoryView)).view as *mut pyre_object::bufferview::BufferView;
+        let view = (&*old_view).new_slice(start, step, slicelength);
+        w_memoryview_set_view(r_sliced, bufferview_alloc(view));
+        drop(Box::from_raw(old_view));
+        Ok(r_sliced)
     }
 }
 
@@ -688,7 +740,12 @@ unsafe fn memoryview_start_from_tuple(
             if !memoryview_is_index(w) {
                 return Err(crate::PyError::type_error("memoryview: invalid slice key"));
             }
-            start += memoryview_get_offset(mv, dim, getindex_w(w)?)?;
+            let index = getindex_w(w)?;
+            // memoryobject.py `_start_from_tuple`: `__index__` is arbitrary
+            // Python code and may release this memoryview before the offset
+            // reads its view geometry.
+            memoryview_check_released(mv)?;
+            start += memoryview_get_offset(mv, dim, index)?;
         }
         Ok(start)
     }
@@ -742,6 +799,9 @@ fn memoryview_getitem(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyErro
             let length = w_memoryview_length(mv);
             let count = if itemsize > 0 { length / itemsize } else { 0 };
             let mut i = getindex_w(index)?;
+            // memoryobject.py `descr_getitem`: `_decode_index` may invoke a
+            // user `__index__` which releases the view.
+            memoryview_check_released(mv)?;
             if i < 0 {
                 i += count;
             }
@@ -834,6 +894,9 @@ fn memoryview_setitem(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyErro
                 ));
             }
             let (start, stop, step) = crate::baseobjspace::normalize_slice(index, count)?;
+            // `decode_index4` evaluates arbitrary slice-bound `__index__`
+            // methods before the assignment touches the backing.
+            memoryview_check_released(mv)?;
             let mut indices = Vec::new();
             let mut i = start;
             while (step > 0 && i < stop) || (step < 0 && i > stop) {

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -7005,12 +7005,10 @@ pub(crate) fn builtin_super(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::
         super_check(cls, obj)?;
         return Ok(pyre_object::descriptor::w_super_new(cls, obj));
     }
-    // Zero-arg super(): find __class__ cell and first arg from calling frame
-    //
-    // IMPORTANT: CURRENT_FRAME points to the frame that is currently
-    // executing the `super()` CALL.  For zero-arg super the __class__
-    // cell lives in the *caller* of super(), which IS the current frame
-    // (super is a builtin, not a user function that gets its own frame).
+    // descriptor.py `_super_from_frame`: zero-arg super() finds the first
+    // argument and the `__class__` free variable in the live caller frame.
+    // CURRENT_FRAME is that caller because a builtin call creates no Python
+    // frame of its own.
     crate::eval::CURRENT_FRAME.with(|current| {
         let frame_ptr = current.get();
         if frame_ptr.is_null() {
@@ -7018,75 +7016,54 @@ pub(crate) fn builtin_super(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::
         }
         let frame = unsafe { &*frame_ptr };
         let code = frame.code();
-
-        // Find __class__ in freevars (it's a cell variable from the enclosing class scope)
-        let num_locals = code.varnames.len();
-        let ncellvars = code.cellvars.len();
-        let locals = frame.locals_w().as_slice();
-
-        let mut w_class = pyre_object::PY_NULL;
-
-        // Check freevars for __class__
-        for (slot, name) in code.freevars.iter().enumerate() {
-            if name == "__class__" {
-                let idx = num_locals + ncellvars + slot;
-                if idx < locals.len() {
-                    let cell = locals[idx];
-                    if !cell.is_null() {
-                        if unsafe { pyre_object::is_cell(cell) } {
-                            w_class = unsafe { pyre_object::w_cell_get(cell) };
-                        } else {
-                            w_class = cell;
-                        }
-                    }
-                }
-                break;
-            }
+        if code.arg_count == 0 {
+            return Err(crate::PyError::runtime_error("super(): no arguments"));
         }
 
-        // Also check cellvars for __class__
-        if w_class.is_null() {
-            for (slot, name) in code.cellvars.iter().enumerate() {
-                if name == "__class__" {
-                    let idx = if code.varnames.iter().any(|v| v == name) {
-                        code.varnames.iter().position(|v| v == name).unwrap()
-                    } else {
-                        num_locals + slot
-                    };
-                    if idx < locals.len() {
-                        let cell = locals[idx];
-                        if !cell.is_null() {
-                            if unsafe { pyre_object::is_cell(cell) } {
-                                w_class = unsafe { pyre_object::w_cell_get(cell) };
-                            } else {
-                                w_class = cell;
-                            }
-                        }
-                    }
-                    break;
-                }
-            }
-        }
-
-        if w_class.is_null() {
-            return Err(crate::PyError::runtime_error(
-                "super(): __class__ cell not found",
-            ));
-        }
-
-        // First argument is self/cls/mcs (locals[0])
-        let w_self = if locals.is_empty() {
-            pyre_object::PY_NULL
+        // CPython 3.11+ localsplus lets an argument cellvar share slot zero;
+        // this is PyPy's `_get_self_location` / `_getcell(self_cell)` branch
+        // expressed in the unified slot layout.
+        let self_slot = frame.locals_w()[0];
+        let first_arg_is_cellvar = code
+            .varnames
+            .first()
+            .is_some_and(|first| code.cellvars.iter().any(|cell| cell == first));
+        let w_self = if first_arg_is_cellvar
+            && !self_slot.is_null()
+            && unsafe { pyre_object::is_cell(self_slot) }
+        {
+            unsafe { pyre_object::w_cell_get(self_slot) }
         } else {
-            locals[0]
+            self_slot
         };
-
         if w_self.is_null() {
+            return Err(crate::PyError::runtime_error("super(): arg[0] deleted"));
+        }
+
+        let class_freevar = code
+            .freevars
+            .iter()
+            .position(|name| name == "__class__")
+            .ok_or_else(|| crate::PyError::runtime_error("super(): __class__ cell not found"))?;
+        let class_slot = code.varnames.len() + crate::pyframe::npure_cellvars(code) + class_freevar;
+        let class_cell = frame
+            .locals_w()
+            .as_slice()
+            .get(class_slot)
+            .copied()
+            .unwrap_or(PY_NULL);
+        let w_class = if !class_cell.is_null() && unsafe { pyre_object::is_cell(class_cell) } {
+            unsafe { pyre_object::w_cell_get(class_cell) }
+        } else {
+            class_cell
+        };
+        if w_class.is_null() {
             return Err(crate::PyError::runtime_error(
-                "super(): no first argument found",
+                "super(): empty __class__ cell",
             ));
         }
 
+        super_check(w_class, w_self)?;
         Ok(pyre_object::descriptor::w_super_new(w_class, w_self))
     })
 }

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -240,6 +240,39 @@ unsafe fn w_memoryview_new_plain(
     }
 }
 
+/// Build the `W_MMap.readbuf_w`/`writebuf_w` view: one contiguous external
+/// byte window whose owner remains the mmap object.
+#[cfg(unix)]
+unsafe fn w_memoryview_new_mmap(
+    w_obj: PyObjectRef,
+    address: usize,
+    length: usize,
+    readonly: bool,
+) -> PyObjectRef {
+    use pyre_object::buffer::Buffer;
+    use pyre_object::bufferview::BufferView;
+    unsafe {
+        let _roots = pyre_object::gc_roots::push_roots();
+        let sp = pyre_object::gc_roots::shadow_stack_len();
+        pyre_object::gc_roots::pin_root(w_obj);
+        let mv = pyre_object::memoryview::w_memoryview_alloc_header(false, true);
+        let r_obj = pyre_object::gc_roots::shadow_stack_get(sp);
+        let view = BufferView::Simple {
+            backing: Buffer::External {
+                w_obj: r_obj,
+                address,
+                size: length,
+                readonly,
+            },
+            w_obj: r_obj,
+            length: length as i64,
+        };
+        let view_ptr = pyre_object::memoryview::bufferview_alloc(view);
+        pyre_object::memoryview::w_memoryview_set_view(mv, view_ptr);
+        mv
+    }
+}
+
 /// The LIVE logical bytes of a view, honouring `offset`/strides/shape so a
 /// strided slice (`m[::2]`, `m[::-1]`) or an N-D view gathers the right
 /// elements in C order (`buffer.py as_str`).  Reads the backing object's own
@@ -317,6 +350,11 @@ pub(crate) fn w_memoryview_new(w_obj: PyObjectRef) -> Result<PyObjectRef, crate:
             // clone preserves the variant, so copying a sliced / plain view
             // keeps its zero-copy window and derived geometry.
             return Ok(w_memoryview_new_derived(w_obj, |v| v.clone()));
+        }
+        #[cfg(unix)]
+        if let Some(view) = crate::module::mmap::interp_mmap::mmap_buffer_view(w_obj) {
+            let (address, length, readonly) = view?;
+            return Ok(w_memoryview_new_mmap(w_obj, address, length, readonly));
         }
         #[cfg(all(unix, feature = "host_env", not(feature = "sandbox")))]
         if let Some((backing_obj, offset, byte_len, fmt, itemsize, shape)) =
@@ -442,6 +480,10 @@ unsafe fn memoryview_unpack_element(
     match memoryview_format_code(fmt) {
         b'c' => pyre_object::bytesobject::w_bytes_from_bytes(buf),
         b'?' => w_bool_from(buf.iter().any(|&x| x != 0)),
+        b'e' => {
+            let bits = u16::from_ne_bytes(buf.try_into().unwrap());
+            w_float_new(crate::module::r#struct::unpack_half(bits))
+        }
         tc => {
             let w = pyre_object::interp_array::unpack_value(tc, buf);
             if w == pyre_object::PY_NULL {
@@ -544,6 +586,16 @@ fn memoryview_pack_value(
                 Err(err) => return Err(err),
             };
             v.to_ne_bytes().to_vec()
+        }
+        b'e' => {
+            let v = match crate::baseobjspace::float_w(w_val) {
+                Ok(value) => value,
+                Err(err) if err.kind == crate::PyErrorKind::TypeError => return Err(bad_type()),
+                Err(err) => return Err(err),
+            };
+            crate::module::r#struct::pack_half(v)?
+                .to_ne_bytes()
+                .to_vec()
         }
         b'?' => {
             vec![crate::baseobjspace::is_true(w_val)? as u8]
@@ -670,7 +722,7 @@ fn memoryview_native_fmtchar(fmt: &str) -> Option<i64> {
     };
     Some(match f {
         b'c' | b'b' | b'B' | b'?' => 1,
-        b'h' | b'H' => 2,
+        b'h' | b'H' | b'e' => 2,
         b'i' | b'I' | b'f' => 4,
         b'l' | b'L' | b'q' | b'Q' | b'n' | b'N' | b'd' | b'P' => 8,
         _ => return None,
@@ -1361,6 +1413,22 @@ fn memoryview_release(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyErro
     let mv = args.first().copied().unwrap_or(w_none());
     unsafe {
         if !pyre_object::memoryview::w_memoryview_released(mv) {
+            let exports = pyre_object::memoryview::w_memoryview_exports(mv);
+            if exports > 0 {
+                return Err(crate::PyError::new(
+                    crate::PyErrorKind::BufferError,
+                    format!(
+                        "memoryview has {exports} exported buffer{}",
+                        if exports == 1 { "" } else { "s" }
+                    ),
+                ));
+            }
+            if exports < 0 {
+                return Err(crate::PyError::new(
+                    crate::PyErrorKind::SystemError,
+                    "memoryview: negative export count",
+                ));
+            }
             // `_release_underlying`: read the backing before `set_released`
             // drops the view box.  A slice / copy (`owns_export == false`)
             // shares the export and must not release it.
@@ -1588,7 +1656,14 @@ fn memoryview_hex(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     let mut fwd = Vec::with_capacity(args.len());
     fwd.push(w_bytes);
     fwd.extend_from_slice(&args[1..]);
-    crate::typedef::bytes_method_hex(&fwd)
+    // CPython 3.14 `memoryview_hex_impl`: a contiguous view increments its
+    // export count while separator coercion may run arbitrary Python code.
+    // All pyre memoryview formats accepted here are gathered from the same
+    // live view, so retain the identical release guard across the formatter.
+    unsafe { pyre_object::memoryview::w_memoryview_exports_incref(mv) };
+    let result = crate::typedef::bytes_method_hex(&fwd);
+    unsafe { pyre_object::memoryview::w_memoryview_exports_decref(mv) };
+    result
 }
 
 /// `descr_hash` (memoryobject.py:476) — a writable view is unhashable; a
@@ -1606,6 +1681,15 @@ unsafe fn memoryview_hash_value(mv: PyObjectRef) -> Result<i64, crate::PyError> 
                     "cannot hash writable memoryview object",
                 ));
             }
+            // CPython 3.14 `memory_hash`: hash the exporter while holding a
+            // temporary export.  The digest is deliberately discarded; the
+            // call validates hashability and, crucially, prevents a
+            // re-entrant `mv.release()` from freeing the bytes being hashed.
+            let backing = pyre_object::memoryview::w_memoryview_obj(mv);
+            pyre_object::memoryview::w_memoryview_exports_incref(mv);
+            let backing_hash = crate::baseobjspace::hash_w_strict(backing);
+            pyre_object::memoryview::w_memoryview_exports_decref(mv);
+            backing_hash?;
             // `compute_hash(self.view.as_str())` — the same content digest the
             // bytes path uses, so `hash(memoryview(b)) == hash(b)`.
             hash = hash_str_bytes(&memoryview_gather_bytes(mv));
@@ -1781,7 +1865,23 @@ fn memoryview_index(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError>
     }
     let mv = args[0];
     unsafe { memoryview_check_released(mv)? };
-    let n = unsafe { pyre_object::memoryview::w_memoryview_length(mv) };
+    let ndim = unsafe { pyre_object::memoryview::w_memoryview_ndim(mv) };
+    if ndim == 0 {
+        return Err(crate::PyError::type_error("invalid lookup on 0-dim memory"));
+    }
+    if ndim != 1 {
+        return Err(crate::PyError::not_implemented(
+            "multi-dimensional lookup is not implemented",
+        ));
+    }
+    // CPython 3.14 `memoryview_index_impl`: lookup bounds are measured in
+    // elements (`view->shape[0]`), not bytes (`view->len`).
+    let n = unsafe {
+        pyre_object::memoryview::w_memoryview_native_shape(mv)
+            .first()
+            .copied()
+            .unwrap_or(0)
+    };
     let mut start = if args.len() >= 3 {
         crate::baseobjspace::getindex_w(args[2])?
     } else {
@@ -9933,6 +10033,30 @@ fn file_method_readlines(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyE
     Ok(w_list_new(lines))
 }
 
+/// `_io/interp_fileio.py:write_w` — `space.getarg_w('s*', w_data).as_str()`.
+/// The `s*` converter accepts readable buffer exporters, not only bytes.
+unsafe fn file_write_buffer_bytes(obj: PyObjectRef) -> Result<Vec<u8>, crate::PyError> {
+    unsafe {
+        if pyre_object::bytesobject::is_bytes_like(obj) {
+            return Ok(pyre_object::bytesobject::bytes_like_data(obj).to_vec());
+        }
+        if pyre_object::memoryview::is_w_memoryview(obj) {
+            memoryview_check_released(obj)?;
+            if !memoryview_contiguity(obj).0 {
+                return Err(crate::PyError::new(
+                    crate::PyErrorKind::BufferError,
+                    "memoryview: underlying buffer is not C-contiguous",
+                ));
+            }
+            return Ok(memoryview_gather_bytes(obj));
+        }
+        if pyre_object::interp_array::is_array(obj) {
+            return Ok(pyre_object::interp_array::w_array_bytes(obj).to_vec());
+        }
+        Err(crate::PyError::type_error("write() expects str or bytes"))
+    }
+}
+
 fn file_method_write(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     if args.len() < 2 {
         return Err(crate::PyError::type_error("write() requires (self, data)"));
@@ -9947,10 +10071,8 @@ fn file_method_write(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError
                 // `w_str_get_value`.
                 let (encoding, errors) = stream_encoding_errors(args[0]);
                 crate::type_methods::encode_object(args[1], &encoding, &errors)?
-            } else if pyre_object::bytesobject::is_bytes_like(args[1]) {
-                pyre_object::bytesobject::bytes_like_data(args[1]).to_vec()
             } else {
-                return Err(crate::PyError::type_error("write() expects str or bytes"));
+                file_write_buffer_bytes(args[1])?
             }
         };
         #[cfg(all(feature = "host_env", not(target_arch = "wasm32")))]
@@ -9989,12 +10111,10 @@ fn file_method_write(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError
             let (encoding, errors) = stream_encoding_errors(args[0]);
             let bytes = crate::type_methods::encode_object(args[1], &encoding, &errors)?;
             (bytes, pyre_object::w_str_len(args[1]))
-        } else if pyre_object::bytesobject::is_bytes_like(args[1]) {
-            let data = pyre_object::bytesobject::bytes_like_data(args[1]).to_vec();
+        } else {
+            let data = file_write_buffer_bytes(args[1])?;
             let len = data.len();
             (data, len)
-        } else {
-            return Err(crate::PyError::type_error("write() expects str or bytes"));
         };
         prev.extend_from_slice(&bytes);
         let _ = crate::baseobjspace::setattr_str(

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -9397,6 +9397,17 @@ pub(crate) fn init_file_wrapper_type(ns: PyObjectRef) {
     unsafe {
         pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
             ns,
+            "writelines",
+            make_builtin_function_with_arity(
+                "writelines",
+                crate::module::_io::iobase_writelines,
+                2,
+            ),
+        )
+    };
+    unsafe {
+        pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
+            ns,
             "close",
             make_builtin_function_with_arity("close", file_method_close, 1),
         )
@@ -10670,17 +10681,14 @@ fn textio_method_close(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyErr
 
 /// Shared `_io.TextIOWrapper` type for text-mode file objects.
 pub fn text_io_wrapper_type() -> PyObjectRef {
-    thread_local! {
-        static TYPE: std::cell::OnceCell<PyObjectRef> = const { std::cell::OnceCell::new() };
-    }
-    TYPE.with(|c| {
-        *c.get_or_init(|| {
-            let tp =
-                crate::typedef::make_builtin_type("_io.TextIOWrapper", init_text_io_wrapper_type);
-            unsafe { pyre_object::typeobject::w_type_set_hasdict(tp, true) };
-            tp
-        })
-    })
+    // PyPy owns one W_TypeObject process-wide.  A TLS cache would create
+    // incompatible TextIOWrapper identities in different host threads.
+    static TYPE: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
+    *TYPE.get_or_init(|| {
+        let tp = crate::typedef::make_builtin_type("_io.TextIOWrapper", init_text_io_wrapper_type);
+        unsafe { pyre_object::typeobject::w_type_set_hasdict(tp, true) };
+        tp as usize
+    }) as PyObjectRef
 }
 
 fn init_text_io_wrapper_type(ns: PyObjectRef) {
@@ -10731,6 +10739,17 @@ fn init_text_io_wrapper_type(ns: PyObjectRef) {
             ns,
             "write",
             make_builtin_function_with_arity("write", textio_method_write, 2),
+        )
+    };
+    unsafe {
+        pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
+            ns,
+            "writelines",
+            make_builtin_function_with_arity(
+                "writelines",
+                crate::module::_io::iobase_writelines,
+                2,
+            ),
         )
     };
     unsafe {

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -3823,20 +3823,24 @@ fn type_descr_new_with_metaclass(
         unsafe {
             (*w_type).w_class = w_metaclass;
         }
-        let mro = unsafe { crate::baseobjspace::compute_default_mro(w_type) };
-        unsafe { pyre_object::w_type_set_mro(w_type, mro) };
-        // typeobject.py:373-377 ready() — link self into each base's
-        // `weak_subclasses` so `mutated()` and `__subclasses__()`
-        // observe this class.
-        unsafe { pyre_object::typeobject::w_type_ready(w_type) };
 
         // type_new_classcell — bind the captured `__classcell__` to the
         // new type so `__class__` / zero-arg `super()` in the methods
         // resolve; the key was already dropped from the namespace above.
+        // PyPy `_store_type_in_classcell` runs before W_TypeObject.__init__,
+        // whose `ensure_common_attributes` invokes a custom metaclass mro().
         if let Some(classcell_root) = classcell_root {
             let classcell = pyre_object::gc_roots::shadow_stack_get(classcell_root);
             unsafe { pyre_object::w_cell_set(classcell, w_type) };
         }
+
+        // typeobject.py:1595-1613 compute_mro — a custom metaclass `mro`
+        // runs after the class cell is bound and before ready().
+        unsafe { crate::baseobjspace::compute_and_set_mro(w_type)? };
+        // typeobject.py:373-377 ready() — link self into each base's
+        // `weak_subclasses` so `mutated()` and `__subclasses__()`
+        // observe this class.
+        unsafe { pyre_object::typeobject::w_type_ready(w_type) };
 
         // _set_names (typeobject.py:1006) — call `__set_name__(owner, name)`
         // on each descriptor in the type's FINAL `__dict__` (`w_type.dict_w`),

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -11326,7 +11326,6 @@ pub(crate) fn builtin_complex(args: &[PyObjectRef]) -> Result<PyObjectRef, crate
             return Ok(w_complex_new(r, i));
         }
     }
-    let mut real_is_complex = false;
     let (mut real, mut imag) = match w_real {
         Some(a) => {
             let has_real_protocol = unsafe { complex_constructor_has_real_protocol(a) };
@@ -11353,31 +11352,31 @@ pub(crate) fn builtin_complex(args: &[PyObjectRef]) -> Result<PyObjectRef, crate
                     crate::type_methods::arg_type_name(a)
                 ))?;
             }
-            real_is_complex = has_complex_protocol;
             value
         }
         None => (0.0, 0.0),
     };
     if let Some(b) = w_imag {
-        let (br, bi, imag_is_complex) = if unsafe { is_complex(b) } {
+        let (br, bi) = if unsafe { is_complex(b) } {
             crate::warn::warn_deprecation(&format!(
                 "complex() argument 'imag' must be a real number, not {}",
                 crate::type_methods::arg_type_name(b)
             ))?;
-            unsafe { (w_complex_get_real(b), w_complex_get_imag(b), true) }
+            unsafe { (w_complex_get_real(b), w_complex_get_imag(b)) }
         } else {
             if !unsafe { complex_constructor_has_real_protocol(b) } {
                 return Err(complex_constructor_argument_error("imag", b));
             }
             let converted = builtin_float(&[b])?;
-            (unsafe { w_float_get_value(converted) }, 0.0, false)
+            (unsafe { w_float_get_value(converted) }, 0.0)
         };
-        // CPython 3.14 complex_new_impl: only genuinely complex arguments
-        // contribute the cross lanes; real inputs leave those lanes absent.
-        if imag_is_complex {
+        // complex(x, y) == x + y*j even if y is already complex; preserve the
+        // signs of zero lanes by subtracting/adding only when the source lane
+        // is nonzero, otherwise taking the operand's real part directly.
+        if bi != 0.0 {
             real -= bi;
         }
-        if real_is_complex {
+        if imag != 0.0 {
             imag += br;
         } else {
             imag = br;
@@ -11640,7 +11639,7 @@ mod tests {
     }
 
     #[test]
-    fn test_builtin_complex_uses_python314_signed_zero_with_complex_real() {
+    fn test_builtin_complex_preserves_imag_arg_negative_zero_with_complex_real() {
         crate::typedef::init_typeobjects();
         let result = builtin_complex(&[w_complex_new(1.0, 0.0), w_float_new(-0.0)]).unwrap();
         assert_eq!(
@@ -11649,7 +11648,7 @@ mod tests {
         );
         assert_eq!(
             unsafe { w_complex_get_imag(result).to_bits() },
-            0.0f64.to_bits()
+            (-0.0f64).to_bits()
         );
     }
 

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -6433,7 +6433,7 @@ pub(crate) fn builtin_float(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::
                          The ability to return an instance of a strict subclass of \
                          float is deprecated, and may be removed in a future version \
                          of Python."
-                    ));
+                    ))?;
                     return Ok(floatobject::w_float_new(w_float_get_value(result)));
                 }
             }
@@ -11049,7 +11049,7 @@ fn complex_coerce(obj: PyObjectRef) -> Result<(f64, f64), crate::PyError> {
                     crate::warn::warn_deprecation(&format!(
                         "__complex__ returned non-complex (type {}). The ability to return an instance of a strict subclass of complex is deprecated, and may be removed in a future version of Python.",
                         crate::type_methods::arg_type_name(res)
-                    ));
+                    ))?;
                 }
                 return Ok((w_complex_get_real(res), w_complex_get_imag(res)));
             }
@@ -11168,7 +11168,7 @@ pub(crate) fn builtin_complex(args: &[PyObjectRef]) -> Result<PyObjectRef, crate
                 crate::warn::warn_deprecation(&format!(
                     "complex() argument 'real' must be a real number, not {}",
                     crate::type_methods::arg_type_name(a)
-                ));
+                ))?;
             }
             real_is_complex = has_complex_protocol;
             value
@@ -11180,7 +11180,7 @@ pub(crate) fn builtin_complex(args: &[PyObjectRef]) -> Result<PyObjectRef, crate
             crate::warn::warn_deprecation(&format!(
                 "complex() argument 'imag' must be a real number, not {}",
                 crate::type_methods::arg_type_name(b)
-            ));
+            ))?;
             unsafe { (w_complex_get_real(b), w_complex_get_imag(b), true) }
         } else {
             if !unsafe { complex_constructor_has_real_protocol(b) } {

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -351,7 +351,7 @@ pub(crate) fn w_memoryview_new(w_obj: PyObjectRef) -> Result<PyObjectRef, crate:
             // keeps its zero-copy window and derived geometry.
             return Ok(w_memoryview_new_derived(w_obj, |v| v.clone()));
         }
-        #[cfg(unix)]
+        #[cfg(all(unix, not(feature = "sandbox")))]
         if let Some(view) = crate::module::mmap::interp_mmap::mmap_buffer_view(w_obj) {
             let (address, length, readonly) = view?;
             return Ok(w_memoryview_new_mmap(w_obj, address, length, readonly));

--- a/pyre/pyre-interpreter/src/call.rs
+++ b/pyre/pyre-interpreter/src/call.rs
@@ -2188,6 +2188,29 @@ pub fn call_with_kwargs(
     // For type objects: allocate via __new__ then call __init__ with kwargs.
     // PyPy: typeobject.py descr_call → __new__ + __init__
     if unsafe { pyre_object::is_type(callable) } {
+        // Types with acceptable_as_base_class=false (bool, NoneType) reject kwargs.
+        // PyPy: boolobject.py descr_new uses @unwrap_spec (positional only).
+        // The `function` and `memoryview` types are non-acceptable-as-base
+        // too, but their `tp_new` functions accept keywords: FunctionType
+        // has `kwdefaults=...`, and CPython 3.14 exposes
+        // `memoryview(object=...)`.  Route both through `__new__`.
+        let accepts_keywords_despite_nonbase = std::ptr::eq(
+            callable,
+            crate::typedef::gettypeobject(&crate::FUNCTION_TYPE),
+        ) || std::ptr::eq(
+            callable,
+            crate::typedef::gettypeobject(&pyre_object::memoryview::MEMORYVIEW_TYPE),
+        );
+        if !kwargs.is_empty()
+            && !accepts_keywords_despite_nonbase
+            && !unsafe { pyre_object::w_type_get_acceptable_as_base_class(callable) }
+        {
+            let type_name = unsafe { pyre_object::w_type_get_name(callable) };
+            return Err(crate::PyError::type_error(format!(
+                "{}() takes no keyword arguments",
+                type_name,
+            )));
+        }
         // Calculate the winning metaclass from bases.
         // type(name, bases, dict, **kw) needs to find the correct metaclass
         // and call its __new__ with the kwargs.

--- a/pyre/pyre-interpreter/src/call.rs
+++ b/pyre/pyre-interpreter/src/call.rs
@@ -3710,20 +3710,10 @@ fn build_class_inner(
                 "metaclass call for {name} returned NULL"
             )));
         }
-        // baseobjspace.py:76 getclass() — set w_class to the metaclass
-        // so type(C) returns the correct metatype.
-        if unsafe { pyre_object::is_type(result) } {
-            let mro = unsafe { crate::baseobjspace::compute_default_mro(result) };
-            unsafe { pyre_object::w_type_set_mro(result, mro) };
-            // typeobject.py:373-377 ready() — register self on each
-            // base's `weak_subclasses` after MRO is in place.
-            unsafe { pyre_object::typeobject::w_type_ready(result) };
-            unsafe {
-                if (*result).w_class.is_null() {
-                    (*result).w_class = w_metaclass;
-                }
-            }
-        }
+        // compiling.py:224 `w_class = space.call_args(w_meta, args)` returns
+        // the metaclass result unchanged. `type.__new__` owns classcell, MRO,
+        // ready(), and metaclass identity; a custom metaclass that bypasses
+        // type.__new__ must not be repaired or overwritten here.
         result
     } else {
         // No metaclass observes the namespace on the default path, so

--- a/pyre/pyre-interpreter/src/call.rs
+++ b/pyre/pyre-interpreter/src/call.rs
@@ -2190,16 +2190,23 @@ pub fn call_with_kwargs(
     if unsafe { pyre_object::is_type(callable) } {
         // Types with acceptable_as_base_class=false (bool, NoneType) reject kwargs.
         // PyPy: boolobject.py descr_new uses @unwrap_spec (positional only).
-        // The `function` and `memoryview` types are non-acceptable-as-base
-        // too, but their `tp_new` functions accept keywords: FunctionType
-        // has `kwdefaults=...`, and CPython 3.14 exposes
-        // `memoryview(object=...)`.  Route both through `__new__`.
+        // The `function`, `memoryview`, and deque iterator types are
+        // non-acceptable-as-base too, but their `tp_new` functions accept
+        // keywords: FunctionType has `kwdefaults=...`, CPython 3.14 exposes
+        // `memoryview(object=...)`, and the deque iterator constructors accept
+        // (and ignore) `index=...`.  Route them through `__new__`.
         let accepts_keywords_despite_nonbase = std::ptr::eq(
             callable,
             crate::typedef::gettypeobject(&crate::FUNCTION_TYPE),
         ) || std::ptr::eq(
             callable,
             crate::typedef::gettypeobject(&pyre_object::memoryview::MEMORYVIEW_TYPE),
+        ) || std::ptr::eq(
+            callable,
+            crate::module::_collections::deque_iter::public_type(),
+        ) || std::ptr::eq(
+            callable,
+            crate::module::_collections::deque_rev_iter::public_type(),
         );
         if !kwargs.is_empty()
             && !accepts_keywords_despite_nonbase

--- a/pyre/pyre-interpreter/src/display.rs
+++ b/pyre/pyre-interpreter/src/display.rs
@@ -740,12 +740,13 @@ pub unsafe fn py_repr(obj: PyObjectRef) -> Result<String, crate::PyError> {
             tp,
             &pyre_object::dictmultiobject::DICT_ITEMS_TYPE as *const PyType,
         ) {
-            // `pypy/objspace/std/dictmultiobject.py`
-            // `W_DictViewKeysObject.descr_repr` →
-            // `"dict_keys([k1, k2, ...])"` (and the same shape for
-            // values / items).  Pyre snapshots the source dict via
-            // `dict_view_snapshot` so the rendered list matches what
-            // the iter dispatch would produce.
+            // `dictmultiobject.py viewrepr`: the view itself participates in
+            // the shared identity recursion set and emits `...` on re-entry.
+            // This is distinct from the owning dict's `{...}` placeholder: a
+            // dict may contain one of its own values/items views.
+            let Some(_guard) = ReprGuard::enter(obj) else {
+                return Ok("...".to_string());
+            };
             let kind = pyre_object::dictmultiobject::w_dict_view_get_kind(obj);
             let label = match kind {
                 pyre_object::dictmultiobject::DictViewKind::Keys => "dict_keys",

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -2829,6 +2829,14 @@ impl OpcodeStepExecutor for PyFrame {
     /// PyPy: pyopcode.py STORE_DEREF → cell.set(value)
     fn store_deref(&mut self, idx: usize) -> Result<(), PyError> {
         let value = self.pop();
+        // CPython 3.14 compile.c keeps an explicit class-body `__class__`
+        // assignment in the namespace (`STORE_NAME`) while the implicit cell
+        // remains available for methods and is filled by `type.__new__`.
+        // The pinned RustPython compiler emits STORE_DEREF for that assignment;
+        // normalize its semantics at the opcode boundary.
+        if crate::pyframe::class_scope_class_deref_is_name(self.code(), idx) {
+            return self.store_name_value("__class__", 0, value);
+        }
         let slot = self.locals_w()[idx];
         if !slot.is_null() && unsafe { pyre_object::is_cell(slot) } {
             unsafe { pyre_object::w_cell_set(slot, value) };
@@ -2870,6 +2878,9 @@ impl OpcodeStepExecutor for PyFrame {
     }
 
     fn delete_deref(&mut self, idx: usize) -> Result<(), PyError> {
+        if crate::pyframe::class_scope_class_deref_is_name(self.code(), idx) {
+            return self.delete_name("__class__");
+        }
         // `pyopcode.py:580 DELETE_DEREF`: fetch the cell, raise if empty, then
         // `cell.set(None)` — clear the cell *contents* (PY_NULL is the empty
         // marker), not the slot pointer that holds the cell.  The cell lives at
@@ -3384,18 +3395,62 @@ impl OpcodeStepExecutor for PyFrame {
     fn load_from_dict_or_deref(&mut self, idx: usize, name: &str) -> Result<(), PyError> {
         let mapping = self.pop();
         let key = pyre_object::w_str_new(name);
-        if let Ok(val) = crate::baseobjspace::getitem(mapping, key) {
-            self.push(val);
-            return Ok(());
+        match crate::baseobjspace::getitem(mapping, key) {
+            Ok(value) => {
+                self.push(value);
+                return Ok(());
+            }
+            Err(err) if matches!(err.kind, PyErrorKind::KeyError) => {}
+            Err(err) => return Err(err),
         }
-        let slot = self.locals_w()[idx];
+        // CPython 3.14 addresses the outer `__class__` freevar in the
+        // class-cell collision. The pinned compiler encodes the implicit
+        // method cell instead; if no outer cell exists, it emits this opcode
+        // where CPython uses LOAD_NAME, so preserve globals/builtins fallback.
+        let deref_idx = if crate::pyframe::class_scope_class_deref_is_name(self.code(), idx) {
+            match crate::pyframe::class_scope_outer_class_freevar(self.code()) {
+                Some(free_idx) => free_idx,
+                None => {
+                    // This deref name has no `co_names` index, so do the
+                    // uncached LOAD_NAME fallback directly rather than
+                    // corrupting an unrelated per-code LOAD_GLOBAL cache slot.
+                    let w_globals = self.get_w_globals();
+                    if !w_globals.is_null() {
+                        if let Some(value) = unsafe {
+                            pyre_object::dictmultiobject::w_dict_getitem_str(w_globals, name)
+                        } {
+                            self.push(value);
+                            return Ok(());
+                        }
+                    }
+                    if !self.w_builtin.is_null()
+                        && unsafe { pyre_object::is_module(self.w_builtin) }
+                    {
+                        let w_dict = unsafe { pyre_object::w_module_get_w_dict(self.w_builtin) };
+                        if !w_dict.is_null() {
+                            if let Some(value) = crate::baseobjspace::finditem_str(w_dict, name)? {
+                                self.push(value);
+                                return Ok(());
+                            }
+                        }
+                    }
+                    return Err(PyError::name_error_with_name(
+                        format!("name '{name}' is not defined"),
+                        name,
+                    ));
+                }
+            }
+        } else {
+            idx
+        };
+        let slot = self.locals_w()[deref_idx];
         let value = if !slot.is_null() && unsafe { pyre_object::is_cell(slot) } {
             unsafe { pyre_object::w_cell_get(slot) }
         } else {
             slot
         };
         if value == PY_NULL {
-            return Err(crate::pyframe::deref_unbound_error(self.code(), idx));
+            return Err(crate::pyframe::deref_unbound_error(self.code(), deref_idx));
         }
         self.push(value);
         Ok(())

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -3911,12 +3911,26 @@ impl OpcodeStepExecutor for PyFrame {
     // ── load_super_attr ──
     // CPython 3.12 LOAD_SUPER_ATTR: stack = [global_super, class, self]
     // → super(class, self).attr
-    fn load_super_attr_with(&mut self, name: &str, is_method: bool) -> Result<(), PyError> {
+    fn load_super_attr_with(
+        &mut self,
+        name: &str,
+        is_method: bool,
+        is_two_arg: bool,
+    ) -> Result<(), PyError> {
         let self_obj = self.pop();
         let cls = self.pop();
-        let _global_super = self.pop();
+        let global_super = self.pop();
 
-        let proxy = pyre_object::descriptor::w_super_new(cls, self_obj);
+        // CPython 3.14 `LOAD_SUPER_ATTR`: the callable loaded from globals is
+        // authoritative (it may shadow builtins.super).  Bit 1 distinguishes
+        // `super(type, obj)` from zero-argument `super()`; `cls` / `self_obj`
+        // are stack operands for the fast builtin case but are not arguments
+        // to a shadowing zero-arg callable.
+        let proxy = if is_two_arg {
+            crate::call::call_function_impl_result(global_super, &[cls, self_obj])?
+        } else {
+            crate::call::call_function_impl_result(global_super, &[])?
+        };
         let result = crate::baseobjspace::getattr_str(proxy, name)?;
 
         // CPython _PySuper_Lookup: determines whether the resolved attr

--- a/pyre/pyre-interpreter/src/module/__pypy__/interp_buffer.rs
+++ b/pyre/pyre-interpreter/src/module/__pypy__/interp_buffer.rs
@@ -15,29 +15,39 @@ pub struct W_PickleBuffer {
 }
 
 #[crate::pyre_methods(
-    doc = "PickleBuffer(buffer) -> wrapper for potentially out-of-band serialization."
+    doc = "PickleBuffer(buffer) -> wrapper for potentially out-of-band serialization.",
+    // interp_buffer.py:209 make_weakref_descr(W_PickleBuffer)
+    weakrefable
 )]
 impl W_PickleBuffer {
     #[staticmethod]
-    fn __new__(_cls: PyObjectRef) -> PyObjectRef {
-        W_PickleBuffer::allocate(W_PickleBuffer {
-            ob: pyre_object::PyObject {
-                ob_type: std::ptr::null(),
-                w_class: std::ptr::null_mut(),
-            },
-            w_obj: pyre_object::w_none(),
-        })
-    }
-
-    fn __init__(&mut self, buffer: PyObjectRef) -> Result<(), PyError> {
-        if !is_buffer_like(buffer) {
-            let name = type_name(buffer);
+    fn __new__(_cls: PyObjectRef, w_obj: PyObjectRef) -> Result<PyObjectRef, PyError> {
+        // interp_buffer.py:201-203 descr_new_picklebuffer — acquire the
+        // export while constructing the object; PickleBuffer has no separate
+        // __init__ phase.
+        if !is_buffer_like(w_obj) {
+            let name = type_name(w_obj);
             return Err(PyError::type_error(format!(
                 "a bytes-like object is required, not '{name}'"
             )));
         }
-        self.w_obj = buffer;
-        Ok(())
+        // `space.buffer_w(w_obj, BUF_FULL_RO)` rejects a released
+        // memoryview at construction time, before the PickleBuffer exists.
+        if is_memoryview(w_obj) {
+            unsafe { crate::builtins::memoryview_check_released(w_obj) }?;
+        }
+        let _roots = pyre_object::gc_roots::push_roots();
+        let sp = pyre_object::gc_roots::shadow_stack_len();
+        pyre_object::gc_roots::pin_root(w_obj);
+        // `allocate` may collect; store the post-collection exporter rather
+        // than the stale Rust-stack copy.
+        Ok(W_PickleBuffer::allocate(W_PickleBuffer {
+            ob: pyre_object::PyObject {
+                ob_type: std::ptr::null(),
+                w_class: std::ptr::null_mut(),
+            },
+            w_obj: pyre_object::gc_roots::shadow_stack_get(sp),
+        }))
     }
 
     /// `raw()` — a memoryview of the raw bytes underlying the wrapped buffer.
@@ -70,6 +80,16 @@ impl W_PickleBuffer {
     fn release(&mut self) {
         self.w_obj = pyre_object::w_none();
     }
+}
+
+/// `W_PickleBuffer.typedef.acceptable_as_base_class = False` — return the
+/// shared type after applying PyPy's explicit final-type flag. Both
+/// `__pypy__.PickleBuffer` and `_pickle.PickleBuffer` call this accessor, so
+/// the flag is installed regardless of which module is imported first.
+pub(crate) fn picklebuffer_type_object() -> PyObjectRef {
+    let tp = type_object();
+    unsafe { pyre_object::w_type_set_acceptable_as_base_class(tp, false) };
+    tp
 }
 
 impl W_PickleBuffer {

--- a/pyre/pyre-interpreter/src/module/__pypy__/mod.rs
+++ b/pyre/pyre-interpreter/src/module/__pypy__/mod.rs
@@ -25,7 +25,7 @@ crate::py_module! {
     // buffers; `identity_dict` keys a memo by object identity (id(key))
     // so the Pickler can memoize unhashable containers.
     interpleveldefs: {
-        "PickleBuffer" => interp_buffer::type_object(),
+        "PickleBuffer" => interp_buffer::picklebuffer_type_object(),
     },
     appleveldefs: {
         "identity_dict_app.py" =>

--- a/pyre/pyre-interpreter/src/module/_abc/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_abc/mod.rs
@@ -181,7 +181,7 @@ fn subclass_of(cls: PyObjectRef, subclass: PyObjectRef) -> Result<bool, crate::P
         }
     }
     // _py_abc.py:140-144 — subclass of a subclass (recursive).
-    for scls in unsafe { w_type_get_subclasses(cls) } {
+    for scls in unsafe { w_type_get_subclasses(cls, false) } {
         if crate::baseobjspace::issubclass(subclass, scls)? {
             return Ok(true);
         }

--- a/pyre/pyre-interpreter/src/module/_collections/app_defaultdict.py
+++ b/pyre/pyre-interpreter/src/module/_collections/app_defaultdict.py
@@ -7,8 +7,9 @@ mirrors ``_collectionsmodule.c``'s ``defaultdict``:
 
 * ``__init__`` takes the ``default_factory`` (``None`` or a callable) as the
   first positional argument and forwards the rest to ``dict.__init__``.
-* ``__missing__`` stores and returns ``default_factory()`` for an absent key,
-  or raises ``KeyError(key)`` when there is no factory.
+* ``__missing__`` calls ``default_factory()`` and atomically inserts its value
+  only if the key is still absent, or raises ``KeyError(key)`` when there is
+  no factory.
 * ``__reduce__`` returns ``(type, args, None, None, iter(items))`` where
   ``args`` is ``()`` for a ``None`` factory and ``(factory,)`` otherwise.
 * ``copy``/``__copy__``, ``__or__``/``__ror__`` and ``__repr__`` preserve the
@@ -44,8 +45,10 @@ class defaultdict(dict):
         factory = self.default_factory
         if factory is None:
             raise KeyError(key)
-        self[key] = value = factory()
-        return value
+        # CPython 3.14 `defdict_missing` uses `PyDict_SetDefaultRef`, not an
+        # unconditional assignment.  The factory can re-enter this mapping
+        # and populate the same key; in that case the inner value wins.
+        return dict.setdefault(self, key, factory())
 
     def __reduce__(self):
         if self.default_factory is None:

--- a/pyre/pyre-interpreter/src/module/_collections/app_odict.py
+++ b/pyre/pyre-interpreter/src/module/_collections/app_odict.py
@@ -1,4 +1,5 @@
 from __pypy__ import reversed_dict, move_to_end, objects_in_repr
+from _collections_abc import KeysView, ItemsView, ValuesView
 from _operator import eq as _eq
 
 
@@ -149,20 +150,16 @@ class OrderedDict(dict):
         "D.values() -> an object providing a view on D's values"
         return _OrderedDictValuesView(self)
 
-dict_keys = type({}.keys())
-dict_values = type({}.values())
-dict_items = type({}.items())
-
-class _OrderedDictKeysView(dict_keys):
+class _OrderedDictKeysView(KeysView):
     def __reversed__(self):
-        yield from reversed_dict(self._dict)
+        yield from reversed_dict(self._mapping)
 
-class _OrderedDictItemsView(dict_items):
+class _OrderedDictItemsView(ItemsView):
     def __reversed__(self):
-        for key in reversed_dict(self._dict):
-            yield (key, self._dict[key])
+        for key in reversed_dict(self._mapping):
+            yield (key, self._mapping[key])
 
-class _OrderedDictValuesView(dict_values):
+class _OrderedDictValuesView(ValuesView):
     def __reversed__(self):
-        for key in reversed_dict(self._dict):
-            yield self._dict[key]
+        for key in reversed_dict(self._mapping):
+            yield self._mapping[key]

--- a/pyre/pyre-interpreter/src/module/_collections/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_collections/mod.rs
@@ -1,52 +1,115 @@
 //! _collections module — PyPy: `pypy/module/_collections/`.
 //!
 //! Provides the C-accelerated `deque` / `defaultdict` / `OrderedDict`
-//! types.  `deque` is an interp-level typed-payload `#[pyre_class]`, backed
-//! by a list payload field; semantically correct for
-//! `collections.py`'s `MutableSequence` consumers but not performant
-//! (PyPy's `W_Deque` is a doubly-linked block list — porting that needs
-//! a separate algorithm migration).  `defaultdict` and `OrderedDict` are
+//! types.  `deque` is an interp-level typed-payload `#[pyre_class]` backed
+//! by the same doubly-linked list of fixed-size blocks as PyPy's `W_Deque`.
+//! `defaultdict` and `OrderedDict` are
 //! app-level `dict` subclasses in `app_defaultdict.py` / `app_odict.py`,
 //! mirroring PyPy (neither runtime can subclass the app-level `dict` from
 //! interp-level).
 
 use pyre_object::*;
 
+const BLOCKLEN: i64 = 62;
+const CENTER: i64 = (BLOCKLEN - 1) / 2;
+
+/// `interp_deque.py Block`: links and element storage are GC-visible object
+/// references, exactly like the RPython object's three attributes.
+pub mod deque_block {
+    use pyre_object::*;
+
+    #[crate::pyre_class("_collections._deque_block")]
+    pub struct W_DequeBlock {
+        pub leftlink: PyObjectRef,
+        pub rightlink: PyObjectRef,
+        pub data: PyObjectRef,
+    }
+
+    pub fn new(leftlink: PyObjectRef, rightlink: PyObjectRef) -> PyObjectRef {
+        let data = w_list_new(vec![w_none(); super::BLOCKLEN as usize]);
+        W_DequeBlock::allocate_stable(W_DequeBlock {
+            ob: PyObject {
+                ob_type: std::ptr::null(),
+                w_class: std::ptr::null_mut(),
+            },
+            leftlink,
+            rightlink,
+            data,
+        })
+    }
+}
+
+use deque_block::W_DequeBlock;
+
 /// `pypy/module/_collections/interp_deque.py` — `W_Deque` surface
 /// (append / appendleft / pop / popleft / clear / extend / extendleft /
 /// rotate / count / remove / reverse / index / copy + container and repr
-/// protocols, with `maxlen` bounding) backed by an inner list at
-/// `self.data`.  The bound is kept in `self.maxlen` and surfaced read-only
-/// via the `maxlen` property.
+/// protocols, with `maxlen` bounding).
 #[crate::pyre_class("collections.deque")]
 pub struct W_Deque {
-    /// Backing list object (a real `list`); always a valid list after `__new__`.
-    data: PyObjectRef,
+    leftblock: PyObjectRef,
+    rightblock: PyObjectRef,
+    leftindex: i64,
+    rightindex: i64,
+    len: i64,
     /// Bound: `-1` = unbounded, `>= 0` = the maxlen. Validated non-negative at `__init__`.
     maxlen: i64,
     /// Lightweight iteration-lock counter (`interp_deque.py` `state`); bumped on every mutation.
     state: i64,
 }
 
-fn data(self_obj: PyObjectRef) -> PyObjectRef {
-    W_Deque::from_obj(self_obj)
-        .map(|d| d.data)
-        .unwrap_or_else(w_none)
+fn block(block: PyObjectRef) -> &'static mut W_DequeBlock {
+    W_DequeBlock::from_obj(block).expect("deque block")
+}
+
+fn block_get(block_obj: PyObjectRef, index: i64) -> PyObjectRef {
+    unsafe { w_list_getitem(block(block_obj).data, index) }.expect("deque block index")
+}
+
+fn block_set(block_obj: PyObjectRef, index: i64, value: PyObjectRef) {
+    let stored = unsafe { w_list_setitem(block(block_obj).data, index, value) };
+    debug_assert!(stored);
+}
+
+fn deque_len(self_obj: PyObjectRef) -> i64 {
+    W_Deque::from_obj(self_obj).map(|d| d.len).unwrap_or(0)
 }
 
 /// Snapshot the backing list into a `Vec`.
 fn snapshot(self_obj: PyObjectRef) -> Vec<PyObjectRef> {
-    let d = data(self_obj);
-    unsafe {
-        (0..w_list_len(d))
-            .filter_map(|i| w_list_getitem(d, i as i64))
-            .collect()
+    let Some(deque) = W_Deque::from_obj(self_obj) else {
+        return vec![];
+    };
+    let mut result = Vec::with_capacity(deque.len as usize);
+    let mut block_obj = deque.leftblock;
+    let mut index = deque.leftindex;
+    for _ in 0..deque.len {
+        result.push(block_get(block_obj, index));
+        index += 1;
+        if index >= BLOCKLEN {
+            block_obj = block(block_obj).rightlink;
+            index = 0;
+        }
+    }
+    result
+}
+
+/// Replace the block chain with `items`.
+fn store(self_obj: PyObjectRef, items: Vec<PyObjectRef>) {
+    clear_blocks(self_obj);
+    for item in items {
+        append_right(self_obj, item);
     }
 }
 
-/// Replace the backing list with `items`.
-fn store(self_obj: PyObjectRef, items: Vec<PyObjectRef>) {
-    W_Deque::from_obj(self_obj).unwrap().data = w_list_new(items);
+fn clear_blocks(self_obj: PyObjectRef) {
+    let new_block = deque_block::new(PY_NULL, PY_NULL);
+    let deque = W_Deque::from_obj(self_obj).expect("deque");
+    deque.leftblock = new_block;
+    deque.rightblock = new_block;
+    deque.leftindex = CENTER + 1;
+    deque.rightindex = CENTER;
+    deque.len = 0;
     modified(self_obj);
 }
 
@@ -122,12 +185,13 @@ pub use deque_rev_iter::W_DequeRevIter;
 // `W_DequeIter`: the iterator owns the deque, current position, number
 // of remaining entries, and a snapshot of the deque mutation lock.
 pub mod deque_iter {
-    use super::{W_Deque, checklock, data, getlock};
+    use super::{BLOCKLEN, W_Deque, block, block_get, checklock, getlock};
     use pyre_object::*;
 
     #[crate::pyre_class("_collections._deque_iterator")]
     pub struct W_DequeIter {
         deque: PyObjectRef,
+        block: PyObjectRef,
         index: i64,
         counter: i64,
         lock: i64,
@@ -183,10 +247,13 @@ pub mod deque_iter {
             if self.counter <= 0 {
                 return Err(crate::PyError::stop_iteration());
             }
-            let item = unsafe { w_list_getitem(data(self.deque), self.index) }
-                .ok_or_else(crate::PyError::stop_iteration)?;
-            self.index += 1;
             self.counter -= 1;
+            let item = block_get(self.block, self.index);
+            self.index += 1;
+            if self.index >= BLOCKLEN {
+                self.block = block(self.block).rightlink;
+                self.index = 0;
+            }
             Ok(item)
         }
 
@@ -194,7 +261,7 @@ pub mod deque_iter {
             let self_obj = self as *const W_DequeIter as PyObjectRef;
             let ty = unsafe { w_instance_get_type(self_obj) };
             let consumed = W_Deque::from_obj(self.deque)
-                .map(|deque| unsafe { w_list_len(deque.data) as i64 } - self.counter)
+                .map(|deque| deque.len - self.counter)
                 .unwrap_or(0);
             w_tuple_new(vec![ty, w_tuple_new(vec![self.deque, w_int_new(consumed)])])
         }
@@ -202,10 +269,22 @@ pub mod deque_iter {
 
     pub fn make(deque: PyObjectRef, requested: i64) -> PyObjectRef {
         let _ = type_object();
-        let len = W_Deque::from_obj(deque)
-            .map(|deque| unsafe { w_list_len(deque.data) as i64 })
-            .unwrap_or(0);
-        let index = requested.max(0);
+        let (len, mut block_obj, mut index) = W_Deque::from_obj(deque)
+            .map(|deque| (deque.len, deque.leftblock, deque.leftindex))
+            .unwrap_or((0, PY_NULL, 0));
+        let requested_index = requested.max(0);
+        let mut remaining = requested_index;
+        while remaining > 0 && remaining < len {
+            let available = BLOCKLEN - index;
+            if remaining < available {
+                index += remaining;
+                remaining = 0;
+            } else {
+                remaining -= available;
+                block_obj = block(block_obj).rightlink;
+                index = 0;
+            }
+        }
         let _roots = pyre_object::gc_roots::push_roots();
         pyre_object::gc_roots::pin_root(deque);
         W_DequeIter::allocate_stable(W_DequeIter {
@@ -214,8 +293,9 @@ pub mod deque_iter {
                 w_class: std::ptr::null_mut(),
             },
             deque,
+            block: block_obj,
             index,
-            counter: len - index,
+            counter: len - requested_index,
             lock: getlock(deque),
         })
     }
@@ -232,12 +312,13 @@ pub mod deque_iter {
 // PyPy `W_DequeRevIter`, with the same state shape and reverse indexing into
 // pyre's list-backed deque payload.
 pub mod deque_rev_iter {
-    use super::{W_Deque, checklock, data, getlock};
+    use super::{BLOCKLEN, W_Deque, block, block_get, checklock, getlock};
     use pyre_object::*;
 
     #[crate::pyre_class("_collections._deque_reverse_iterator")]
     pub struct W_DequeRevIter {
         deque: PyObjectRef,
+        block: PyObjectRef,
         index: i64,
         counter: i64,
         lock: i64,
@@ -285,10 +366,13 @@ pub mod deque_rev_iter {
             if self.counter <= 0 {
                 return Err(crate::PyError::stop_iteration());
             }
-            let item = unsafe { w_list_getitem(data(self.deque), self.index) }
-                .ok_or_else(crate::PyError::stop_iteration)?;
-            self.index -= 1;
             self.counter -= 1;
+            let item = block_get(self.block, self.index);
+            self.index -= 1;
+            if self.index < 0 {
+                self.block = block(self.block).leftlink;
+                self.index = BLOCKLEN - 1;
+            }
             Ok(item)
         }
 
@@ -296,7 +380,7 @@ pub mod deque_rev_iter {
             let self_obj = self as *const W_DequeRevIter as PyObjectRef;
             let ty = unsafe { w_instance_get_type(self_obj) };
             let consumed = W_Deque::from_obj(self.deque)
-                .map(|deque| unsafe { w_list_len(deque.data) as i64 } - self.counter)
+                .map(|deque| deque.len - self.counter)
                 .unwrap_or(0);
             w_tuple_new(vec![ty, w_tuple_new(vec![self.deque, w_int_new(consumed)])])
         }
@@ -304,10 +388,22 @@ pub mod deque_rev_iter {
 
     pub fn make(deque: PyObjectRef, requested: i64) -> PyObjectRef {
         let _ = type_object();
-        let len = W_Deque::from_obj(deque)
-            .map(|deque| unsafe { w_list_len(deque.data) as i64 })
-            .unwrap_or(0);
+        let (len, mut block_obj, mut index) = W_Deque::from_obj(deque)
+            .map(|deque| (deque.len, deque.rightblock, deque.rightindex))
+            .unwrap_or((0, PY_NULL, 0));
         let offset = requested.max(0);
+        let mut remaining = offset;
+        while remaining > 0 && remaining < len {
+            let available = index + 1;
+            if remaining < available {
+                index -= remaining;
+                remaining = 0;
+            } else {
+                remaining -= available;
+                block_obj = block(block_obj).leftlink;
+                index = BLOCKLEN - 1;
+            }
+        }
         let _roots = pyre_object::gc_roots::push_roots();
         pyre_object::gc_roots::pin_root(deque);
         W_DequeRevIter::allocate_stable(W_DequeRevIter {
@@ -316,7 +412,8 @@ pub mod deque_rev_iter {
                 w_class: std::ptr::null_mut(),
             },
             deque,
-            index: len - offset - 1,
+            block: block_obj,
+            index,
             counter: len - offset,
             lock: getlock(deque),
         })
@@ -331,18 +428,107 @@ pub mod deque_rev_iter {
     }
 }
 
-/// `W_Deque.append` + `trimleft`: drop from the left once over the bound.
-fn do_append(self_obj: PyObjectRef, item: PyObjectRef) {
-    let d = data(self_obj);
-    unsafe { w_list_append(d, item) };
+/// `W_Deque.append` + `trimleft`, ported from `interp_deque.py`.
+fn append_right(self_obj: PyObjectRef, item: PyObjectRef) {
+    let _roots = pyre_object::gc_roots::push_roots();
+    pyre_object::gc_roots::pin_root(item);
+    let mut ri = W_Deque::from_obj(self_obj).expect("deque").rightindex + 1;
+    if ri >= BLOCKLEN {
+        let old_right = W_Deque::from_obj(self_obj).expect("deque").rightblock;
+        let new_right = deque_block::new(old_right, PY_NULL);
+        block(old_right).rightlink = new_right;
+        W_Deque::from_obj(self_obj).expect("deque").rightblock = new_right;
+        ri = 0;
+    }
+    let deque = W_Deque::from_obj(self_obj).expect("deque");
+    deque.rightindex = ri;
+    block_set(
+        deque.rightblock,
+        ri,
+        pyre_object::gc_roots::shadow_stack_get(pyre_object::gc_roots::shadow_stack_len() - 1),
+    );
+    deque.len += 1;
+    if maxlen_bound(self_obj).is_some_and(|maxlen| deque.len > maxlen as i64) {
+        let _ = pop_left(self_obj).expect("trimleft on non-empty deque");
+    }
     modified(self_obj);
-    if let Some(m) = maxlen_bound(self_obj) {
-        let mut items = snapshot(self_obj);
-        if items.len() > m {
-            items.drain(0..items.len() - m);
-            store(self_obj, items);
+}
+
+fn append_left(self_obj: PyObjectRef, item: PyObjectRef) {
+    let _roots = pyre_object::gc_roots::push_roots();
+    pyre_object::gc_roots::pin_root(item);
+    let mut li = W_Deque::from_obj(self_obj).expect("deque").leftindex - 1;
+    if li < 0 {
+        let old_left = W_Deque::from_obj(self_obj).expect("deque").leftblock;
+        let new_left = deque_block::new(PY_NULL, old_left);
+        block(old_left).leftlink = new_left;
+        W_Deque::from_obj(self_obj).expect("deque").leftblock = new_left;
+        li = BLOCKLEN - 1;
+    }
+    let deque = W_Deque::from_obj(self_obj).expect("deque");
+    deque.leftindex = li;
+    block_set(
+        deque.leftblock,
+        li,
+        pyre_object::gc_roots::shadow_stack_get(pyre_object::gc_roots::shadow_stack_len() - 1),
+    );
+    deque.len += 1;
+    if maxlen_bound(self_obj).is_some_and(|maxlen| deque.len > maxlen as i64) {
+        let _ = pop_right(self_obj).expect("trimright on non-empty deque");
+    }
+    modified(self_obj);
+}
+
+fn pop_right(self_obj: PyObjectRef) -> Result<PyObjectRef, crate::PyError> {
+    let deque = W_Deque::from_obj(self_obj).expect("deque");
+    if deque.len == 0 {
+        return Err(crate::PyError::index_error("pop from an empty deque"));
+    }
+    deque.len -= 1;
+    let item = block_get(deque.rightblock, deque.rightindex);
+    block_set(deque.rightblock, deque.rightindex, w_none());
+    let mut ri = deque.rightindex - 1;
+    if ri < 0 {
+        if deque.len == 0 {
+            deque.leftindex = CENTER + 1;
+            ri = CENTER;
+        } else {
+            let old_right = deque.rightblock;
+            let new_right = block(old_right).leftlink;
+            deque.rightblock = new_right;
+            block(new_right).rightlink = PY_NULL;
+            ri = BLOCKLEN - 1;
         }
     }
+    deque.rightindex = ri;
+    modified(self_obj);
+    Ok(item)
+}
+
+fn pop_left(self_obj: PyObjectRef) -> Result<PyObjectRef, crate::PyError> {
+    let deque = W_Deque::from_obj(self_obj).expect("deque");
+    if deque.len == 0 {
+        return Err(crate::PyError::index_error("pop from an empty deque"));
+    }
+    deque.len -= 1;
+    let item = block_get(deque.leftblock, deque.leftindex);
+    block_set(deque.leftblock, deque.leftindex, w_none());
+    let mut li = deque.leftindex + 1;
+    if li >= BLOCKLEN {
+        if deque.len == 0 {
+            li = CENTER + 1;
+            deque.rightindex = CENTER;
+        } else {
+            let old_left = deque.leftblock;
+            let new_left = block(old_left).rightlink;
+            deque.leftblock = new_left;
+            block(new_left).leftlink = PY_NULL;
+            li = 0;
+        }
+    }
+    deque.leftindex = li;
+    modified(self_obj);
+    Ok(item)
 }
 
 /// `space.decode_index4` index-only case — reject a slice with a
@@ -361,6 +547,28 @@ fn deque_index(index: PyObjectRef, len: i64) -> Result<usize, crate::PyError> {
         return Err(crate::PyError::index_error("index out of range"));
     }
     Ok(idx as usize)
+}
+
+/// `W_Deque.locate`: choose the nearer endpoint and walk whole blocks.
+fn locate(self_obj: PyObjectRef, mut index: i64) -> (PyObjectRef, i64) {
+    let deque = W_Deque::from_obj(self_obj).expect("deque");
+    if index < (deque.len >> 1) {
+        index += deque.leftindex;
+        let mut block_obj = deque.leftblock;
+        while index >= BLOCKLEN {
+            block_obj = block(block_obj).rightlink;
+            index -= BLOCKLEN;
+        }
+        (block_obj, index)
+    } else {
+        index = index - deque.len + 1 + deque.rightindex;
+        let mut block_obj = deque.rightblock;
+        while index < 0 {
+            block_obj = block(block_obj).leftlink;
+            index += BLOCKLEN;
+        }
+        (block_obj, index)
+    }
 }
 
 /// `W_Deque.compare` — element-wise (`compare_by_iteration`) ordering
@@ -445,16 +653,6 @@ fn deque_repeat(self_obj: PyObjectRef, n: PyObjectRef) -> Result<PyObjectRef, cr
     }
 }
 
-/// `W_Deque.appendleft` + `trimright`: drop from the right once over the bound.
-fn do_appendleft(self_obj: PyObjectRef, item: PyObjectRef) {
-    let mut items = snapshot(self_obj);
-    items.insert(0, item);
-    if let Some(m) = maxlen_bound(self_obj) {
-        items.truncate(m);
-    }
-    store(self_obj, items);
-}
-
 #[crate::pyre_methods(weakrefable, unhashable)]
 impl W_Deque {
     // `deque_new` allocates an empty unbounded payload; the construction
@@ -468,15 +666,20 @@ impl W_Deque {
         // catch-all so a subclass with its own `__init__` keyword parameters
         // does not trip an unknown-keyword error in `__new__`.
         let _ = _args;
-        // Stable (non-moving) allocation: the mutators re-derive `self`
-        // from a raw `PyObjectRef` across list-allocating calls (`store`),
-        // so the payload must not relocate under them.
+        let initial_block = deque_block::new(PY_NULL, PY_NULL);
+        // Stable (non-moving) allocation: mutators re-derive `self` across
+        // block allocations, just as the translated RPython object retains
+        // identity while its block chain grows.
         W_Deque::allocate_stable(W_Deque {
             ob: pyre_object::PyObject {
                 ob_type: std::ptr::null(),
                 w_class: std::ptr::null_mut(),
             },
-            data: w_list_new(vec![]),
+            leftblock: initial_block,
+            rightblock: initial_block,
+            leftindex: CENTER + 1,
+            rightindex: CENTER,
+            len: 0,
             maxlen: -1,
             state: 0,
         })
@@ -511,53 +714,40 @@ impl W_Deque {
         // reset; an already-empty deque leaves `state` untouched, so re-init
         // while iterating an empty deque yields StopIteration, not a mutation
         // RuntimeError.
-        if unsafe { w_list_len(data(self_obj)) } > 0 {
-            store(self_obj, vec![]);
+        if deque_len(self_obj) > 0 {
+            clear_blocks(self_obj);
         }
         if let Some(it) = iterable {
             for item in crate::builtins::collect_iterable(it)? {
-                do_append(self_obj, item);
+                append_right(self_obj, item);
             }
         }
         Ok(())
     }
     fn append(&mut self, item: PyObjectRef) {
         let self_obj = self as *mut W_Deque as PyObjectRef;
-        do_append(self_obj, item);
+        append_right(self_obj, item);
     }
     fn appendleft(&mut self, item: PyObjectRef) {
         let self_obj = self as *mut W_Deque as PyObjectRef;
-        do_appendleft(self_obj, item);
+        append_left(self_obj, item);
     }
     fn pop(&mut self) -> Result<PyObjectRef, crate::PyError> {
         let self_obj = self as *mut W_Deque as PyObjectRef;
-        // `W_Deque.pop` — empty raises IndexError.
-        let mut items = snapshot(self_obj);
-        let item = items
-            .pop()
-            .ok_or_else(|| crate::PyError::index_error("pop from an empty deque"))?;
-        store(self_obj, items);
-        Ok(item)
+        pop_right(self_obj)
     }
     fn popleft(&mut self) -> Result<PyObjectRef, crate::PyError> {
         let self_obj = self as *mut W_Deque as PyObjectRef;
-        // `W_Deque.popleft` — empty raises IndexError.
-        let mut items = snapshot(self_obj);
-        if items.is_empty() {
-            return Err(crate::PyError::index_error("pop from an empty deque"));
-        }
-        let item = items.remove(0);
-        store(self_obj, items);
-        Ok(item)
+        pop_left(self_obj)
     }
     fn clear(&mut self) {
         let self_obj = self as *mut W_Deque as PyObjectRef;
-        store(self_obj, vec![]);
+        clear_blocks(self_obj);
     }
     fn extend(&mut self, iterable: PyObjectRef) -> Result<(), crate::PyError> {
         let self_obj = self as *mut W_Deque as PyObjectRef;
         for item in crate::builtins::collect_iterable(iterable)? {
-            do_append(self_obj, item);
+            append_right(self_obj, item);
         }
         Ok(())
     }
@@ -566,7 +756,7 @@ impl W_Deque {
         // Each element is appended on the left, so the result is
         // the reverse of `iterable`.
         for item in crate::builtins::collect_iterable(iterable)? {
-            do_appendleft(self_obj, item);
+            append_left(self_obj, item);
         }
         Ok(())
     }
@@ -629,14 +819,16 @@ impl W_Deque {
     }
     fn reverse(&mut self) {
         let self_obj = self as *mut W_Deque as PyObjectRef;
-        let mut items = snapshot(self_obj);
-        items.reverse();
-        // interp_deque.py swaps block entries without `modified()`. Existing
-        // iterators therefore stay valid and observe the reversed payload.
-        let backing = data(self_obj);
-        for (index, item) in items.into_iter().enumerate() {
-            let stored = unsafe { w_list_setitem(backing, index as i64, item) };
-            debug_assert!(stored);
+        // `interp_deque.py reverse`: swap entries from both endpoints without
+        // invalidating iterators.
+        let len = deque_len(self_obj);
+        for index in 0..(len >> 1) {
+            let (left_block, left_index) = locate(self_obj, index);
+            let (right_block, right_index) = locate(self_obj, len - index - 1);
+            let left = block_get(left_block, left_index);
+            let right = block_get(right_block, right_index);
+            block_set(left_block, left_index, right);
+            block_set(right_block, right_index, left);
         }
     }
     fn rotate(&mut self, n: Option<PyObjectRef>) -> Result<(), crate::PyError> {
@@ -771,7 +963,7 @@ impl W_Deque {
     }
     fn __len__(&self) -> i64 {
         let self_obj = self as *const W_Deque as PyObjectRef;
-        (unsafe { w_list_len(data(self_obj)) }) as i64
+        deque_len(self_obj)
     }
     fn __iter__(&self) -> Result<PyObjectRef, crate::PyError> {
         let self_obj = self as *const W_Deque as PyObjectRef;
@@ -783,9 +975,9 @@ impl W_Deque {
     }
     fn __getitem__(&self, index: PyObjectRef) -> Result<PyObjectRef, crate::PyError> {
         let self_obj = self as *const W_Deque as PyObjectRef;
-        let items = snapshot(self_obj);
-        let idx = deque_index(index, items.len() as i64)?;
-        Ok(items[idx])
+        let idx = deque_index(index, deque_len(self_obj))? as i64;
+        let (block_obj, block_index) = locate(self_obj, idx);
+        Ok(block_get(block_obj, block_index))
     }
     fn __setitem__(
         &mut self,
@@ -793,14 +985,13 @@ impl W_Deque {
         value: PyObjectRef,
     ) -> Result<(), crate::PyError> {
         let self_obj = self as *mut W_Deque as PyObjectRef;
-        let backing = data(self_obj);
-        let idx = deque_index(index, unsafe { w_list_len(backing) } as i64)?;
+        let idx = deque_index(index, deque_len(self_obj))? as i64;
         // interp_deque.py W_Deque.setitem replaces the block entry in place
         // and deliberately does not call `modified()`: deque iterators remain
         // valid and observe subsequently assigned elements (including after
         // pickle reconstruction).
-        let stored = unsafe { w_list_setitem(backing, idx as i64, value) };
-        debug_assert!(stored);
+        let (block_obj, block_index) = locate(self_obj, idx);
+        block_set(block_obj, block_index, value);
         Ok(())
     }
     fn __delitem__(&mut self, index: PyObjectRef) -> Result<(), crate::PyError> {
@@ -844,10 +1035,8 @@ impl W_Deque {
             )));
         }
 
-        // interp_deque.py W_Deque.add: make the same left-hand copy as
-        // `copy()`, then extend it from the right deque.  Calling the live
-        // left type with `self` preserves Python 3.14's observable subclass
-        // constructor/iterator behavior.
+        // CPython 3.14 deque_concat copies the left operand, preserving its
+        // concrete subtype, then extends that copy with the right deque.
         let copy = self.copy()?;
         if W_Deque::from_obj(copy).is_none() {
             return Err(crate::PyError::type_error(
@@ -858,7 +1047,7 @@ impl W_Deque {
         let root_base = pyre_object::gc_roots::shadow_stack_len();
         pyre_object::gc_roots::pin_root(copy);
         for item in snapshot(other) {
-            do_append(pyre_object::gc_roots::shadow_stack_get(root_base), item);
+            append_right(pyre_object::gc_roots::shadow_stack_get(root_base), item);
         }
         Ok(pyre_object::gc_roots::shadow_stack_get(root_base))
     }

--- a/pyre/pyre-interpreter/src/module/_collections/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_collections/mod.rs
@@ -535,11 +535,15 @@ fn pop_left(self_obj: PyObjectRef) -> Result<PyObjectRef, crate::PyError> {
 /// `TypeError`, route any `__index__`-able object through
 /// `getindex_w`, apply the negative-index wrap and the in-range
 /// check, and return the resolved element position.
-fn deque_index(index: PyObjectRef, len: i64) -> Result<usize, crate::PyError> {
+fn deque_index(index: PyObjectRef, len_of: impl FnOnce() -> i64) -> Result<usize, crate::PyError> {
     if unsafe { pyre_object::is_slice(index) } {
         return Err(crate::PyError::type_error("deque[:] is not supported"));
     }
     let mut idx = crate::builtins::getindex_w(index)?;
+    // `decode_index4(w_index, self)` bounds the converted index against the
+    // deque as it stands *after* `__index__` ran, so a re-entrant clear or
+    // shrink is reported as IndexError instead of addressing stale storage.
+    let len = len_of();
     if idx < 0 {
         idx += len;
     }
@@ -975,7 +979,7 @@ impl W_Deque {
     }
     fn __getitem__(&self, index: PyObjectRef) -> Result<PyObjectRef, crate::PyError> {
         let self_obj = self as *const W_Deque as PyObjectRef;
-        let idx = deque_index(index, deque_len(self_obj))? as i64;
+        let idx = deque_index(index, || deque_len(self_obj))? as i64;
         let (block_obj, block_index) = locate(self_obj, idx);
         Ok(block_get(block_obj, block_index))
     }
@@ -985,7 +989,7 @@ impl W_Deque {
         value: PyObjectRef,
     ) -> Result<(), crate::PyError> {
         let self_obj = self as *mut W_Deque as PyObjectRef;
-        let idx = deque_index(index, deque_len(self_obj))? as i64;
+        let idx = deque_index(index, || deque_len(self_obj))? as i64;
         // interp_deque.py W_Deque.setitem replaces the block entry in place
         // and deliberately does not call `modified()`: deque iterators remain
         // valid and observe subsequently assigned elements (including after
@@ -996,8 +1000,8 @@ impl W_Deque {
     }
     fn __delitem__(&mut self, index: PyObjectRef) -> Result<(), crate::PyError> {
         let self_obj = self as *mut W_Deque as PyObjectRef;
+        let idx = deque_index(index, || deque_len(self_obj))?;
         let mut items = snapshot(self_obj);
-        let idx = deque_index(index, items.len() as i64)?;
         items.remove(idx);
         store(self_obj, items);
         Ok(())

--- a/pyre/pyre-interpreter/src/module/_collections/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_collections/mod.rs
@@ -121,7 +121,7 @@ pub use deque_rev_iter::W_DequeRevIter;
 
 // `W_DequeIter`: the iterator owns the deque, current position, number
 // of remaining entries, and a snapshot of the deque mutation lock.
-mod deque_iter {
+pub mod deque_iter {
     use super::{W_Deque, checklock, data, getlock};
     use pyre_object::*;
 
@@ -231,7 +231,7 @@ mod deque_iter {
 
 // PyPy `W_DequeRevIter`, with the same state shape and reverse indexing into
 // pyre's list-backed deque payload.
-mod deque_rev_iter {
+pub mod deque_rev_iter {
     use super::{W_Deque, checklock, data, getlock};
     use pyre_object::*;
 
@@ -590,7 +590,15 @@ impl W_Deque {
         let mut pos = None;
         for (i, &it) in items.iter().enumerate() {
             let equal = crate::baseobjspace::eq_w(it, x)?;
-            checklock(self_obj, lock)?;
+            // CPython 3.14's deque.remove reports re-entrant mutation as
+            // IndexError (PyPy's older block-list port reports RuntimeError).
+            // The comparison may have cleared or otherwise resized the live
+            // deque, so do not continue against the stale snapshot.
+            if lock_state(self_obj) != lock {
+                return Err(crate::PyError::index_error(
+                    "deque mutated during iteration",
+                ));
+            }
             if equal {
                 pos = Some(i);
                 break;
@@ -623,7 +631,13 @@ impl W_Deque {
         let self_obj = self as *mut W_Deque as PyObjectRef;
         let mut items = snapshot(self_obj);
         items.reverse();
-        store(self_obj, items);
+        // interp_deque.py swaps block entries without `modified()`. Existing
+        // iterators therefore stay valid and observe the reversed payload.
+        let backing = data(self_obj);
+        for (index, item) in items.into_iter().enumerate() {
+            let stored = unsafe { w_list_setitem(backing, index as i64, item) };
+            debug_assert!(stored);
+        }
     }
     fn rotate(&mut self, n: Option<PyObjectRef>) -> Result<(), crate::PyError> {
         let self_obj = self as *mut W_Deque as PyObjectRef;
@@ -719,13 +733,16 @@ impl W_Deque {
         let self_obj = self as *const W_Deque as PyObjectRef;
         // `type(self)(self)` or `type(self)(self, maxlen)`.
         let ty = unsafe { w_instance_get_type(self_obj) };
-        let list = w_list_new(snapshot(self_obj));
         let m = maxlen_obj(self_obj);
         if unsafe { is_none(m) } {
-            crate::call::call_function_impl_result(ty, &[list])
+            crate::call::call_function_impl_result(ty, &[self_obj])
         } else {
-            crate::call::call_function_impl_result(ty, &[list, m])
+            crate::call::call_function_impl_result(ty, &[self_obj, m])
         }
+    }
+    fn __copy__(&self) -> Result<PyObjectRef, crate::PyError> {
+        // interp_deque.py typedef: `__copy__ = interp2app(W_Deque.copy)`.
+        self.copy()
     }
     fn __reduce__(&self) -> Result<PyObjectRef, crate::PyError> {
         let self_obj = self as *const W_Deque as PyObjectRef;
@@ -747,7 +764,9 @@ impl W_Deque {
             w_tuple_new(vec![w_tuple_new(vec![]), m])
         };
         let state = crate::reduce_protocol::object_getstate_default(self_obj)?;
-        let items = crate::baseobjspace::iter(w_list_new(snapshot(self_obj)))?;
+        // interp_deque.py W_Deque.reduce calls `space.iter(self)`, preserving
+        // subclass __iter__ overrides (including an override that raises).
+        let items = crate::baseobjspace::iter(self_obj)?;
         Ok(w_tuple_new(vec![ty, args, state, items]))
     }
     fn __len__(&self) -> i64 {
@@ -774,10 +793,14 @@ impl W_Deque {
         value: PyObjectRef,
     ) -> Result<(), crate::PyError> {
         let self_obj = self as *mut W_Deque as PyObjectRef;
-        let mut items = snapshot(self_obj);
-        let idx = deque_index(index, items.len() as i64)?;
-        items[idx] = value;
-        store(self_obj, items);
+        let backing = data(self_obj);
+        let idx = deque_index(index, unsafe { w_list_len(backing) } as i64)?;
+        // interp_deque.py W_Deque.setitem replaces the block entry in place
+        // and deliberately does not call `modified()`: deque iterators remain
+        // valid and observe subsequently assigned elements (including after
+        // pickle reconstruction).
+        let stored = unsafe { w_list_setitem(backing, idx as i64, value) };
+        debug_assert!(stored);
         Ok(())
     }
     fn __delitem__(&mut self, index: PyObjectRef) -> Result<(), crate::PyError> {
@@ -811,6 +834,39 @@ impl W_Deque {
     fn __ge__(&self, other: PyObjectRef) -> Result<PyObjectRef, crate::PyError> {
         let self_obj = self as *const W_Deque as PyObjectRef;
         deque_compare(self_obj, other, crate::baseobjspace::CompareOp::Ge)
+    }
+    fn __add__(&self, other: PyObjectRef) -> Result<PyObjectRef, crate::PyError> {
+        let self_obj = self as *const W_Deque as PyObjectRef;
+        if W_Deque::from_obj(other).is_none() {
+            return Err(crate::PyError::type_error(format!(
+                "can only concatenate deque (not \"{}\") to deque",
+                unsafe { pyre_object::type_name_of(other) },
+            )));
+        }
+
+        // interp_deque.py W_Deque.add: make the same left-hand copy as
+        // `copy()`, then extend it from the right deque.  Calling the live
+        // left type with `self` preserves Python 3.14's observable subclass
+        // constructor/iterator behavior.
+        let copy = self.copy()?;
+        if W_Deque::from_obj(copy).is_none() {
+            return Err(crate::PyError::type_error(
+                "deque.__add__ returned a non-deque",
+            ));
+        }
+        let _roots = pyre_object::gc_roots::push_roots();
+        let root_base = pyre_object::gc_roots::shadow_stack_len();
+        pyre_object::gc_roots::pin_root(copy);
+        for item in snapshot(other) {
+            do_append(pyre_object::gc_roots::shadow_stack_get(root_base), item);
+        }
+        Ok(pyre_object::gc_roots::shadow_stack_get(root_base))
+    }
+    fn __iadd__(&mut self, iterable: PyObjectRef) -> Result<PyObjectRef, crate::PyError> {
+        // interp_deque.py W_Deque.iadd: extend in place and return self.
+        let self_obj = self as *mut W_Deque as PyObjectRef;
+        self.extend(iterable)?;
+        Ok(self_obj)
     }
     fn __mul__(&self, n: PyObjectRef) -> Result<PyObjectRef, crate::PyError> {
         let self_obj = self as *const W_Deque as PyObjectRef;

--- a/pyre/pyre-interpreter/src/module/_ctypes/metaclass.rs
+++ b/pyre/pyre-interpreter/src/module/_ctypes/metaclass.rs
@@ -778,7 +778,7 @@ fn process_fields(cls: PyObjectRef, fields: PyObjectRef, is_union: bool) -> PyRe
     {
         crate::warn::warn_deprecation(
             "_pack_ without explicit _layout_ uses deprecated MSVC layout",
-        );
+        )?;
     }
 
     // Reject before mutating the class: a type already frozen (used as a field

--- a/pyre/pyre-interpreter/src/module/_io/_io_app.py
+++ b/pyre/pyre-interpreter/src/module/_io/_io_app.py
@@ -41,6 +41,22 @@ class BytesIO:
     def read1(self, size=-1):
         return self.read(size)
 
+    def readinto(self, buffer):
+        self._check_closed()
+        # PyPy `W_BytesIO.readinto_w`: acquire a writable buffer for the
+        # duration of the read, consume at most its byte length, copy the
+        # output at offset zero, and return the number of bytes copied.
+        with memoryview(buffer) as view:
+            if view.readonly:
+                raise TypeError("readinto() argument must be read-write bytes-like object")
+            target = view.cast("B")
+            output = self.read(target.nbytes)
+            target[:len(output)] = output
+            return len(output)
+
+    def readinto1(self, buffer):
+        return self.readinto(buffer)
+
     def readline(self, size=-1):
         self._check_closed()
         buf = self._buffer

--- a/pyre/pyre-interpreter/src/module/_io/_io_app.py
+++ b/pyre/pyre-interpreter/src/module/_io/_io_app.py
@@ -28,7 +28,10 @@ class BytesIO:
         self._check_closed()
         return True
 
-    def read(self, size=-1):
+    def _read_from_buffer(self, size=-1):
+        # `W_BytesIO.read_w` copies straight out of the internal buffer, so the
+        # sibling slots below reach it here rather than through `self.read`,
+        # which a subclass may override.
         self._check_closed()
         if size is None or size < 0:
             end = len(self._buffer)
@@ -38,24 +41,30 @@ class BytesIO:
         self._pos = end
         return data
 
-    def read1(self, size=-1):
-        return self.read(size)
+    def read(self, size=-1):
+        return self._read_from_buffer(size)
 
-    def readinto(self, buffer):
+    def read1(self, size=-1):
+        return self._read_from_buffer(size)
+
+    def _readinto_from_buffer(self, buffer):
         self._check_closed()
-        # PyPy `W_BytesIO.readinto_w`: acquire a writable buffer for the
+        # `W_BytesIO.readinto_w`: acquire a writable buffer for the
         # duration of the read, consume at most its byte length, copy the
         # output at offset zero, and return the number of bytes copied.
         with memoryview(buffer) as view:
             if view.readonly:
                 raise TypeError("readinto() argument must be read-write bytes-like object")
             target = view.cast("B")
-            output = self.read(target.nbytes)
+            output = self._read_from_buffer(target.nbytes)
             target[:len(output)] = output
             return len(output)
 
+    def readinto(self, buffer):
+        return self._readinto_from_buffer(buffer)
+
     def readinto1(self, buffer):
-        return self.readinto(buffer)
+        return self._readinto_from_buffer(buffer)
 
     def readline(self, size=-1):
         self._check_closed()

--- a/pyre/pyre-interpreter/src/module/_io/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_io/mod.rs
@@ -49,10 +49,18 @@ pub(crate) fn iobase_writelines(args: &[PyObjectRef]) -> crate::PyResult {
         .first()
         .copied()
         .ok_or_else(|| crate::PyError::type_error("writelines() requires self"))?;
-    let lines = args
-        .get(1)
-        .copied()
-        .ok_or_else(|| crate::PyError::type_error("writelines() requires lines"))?;
+    // The registered arity is only a fast-dispatch hint, so surplus
+    // positionals still arrive here.  PyPy's interp2app gateway exposes one
+    // argument after the bound receiver and rejects the call before it can
+    // iterate or write anything.
+    if args.len() != 2 {
+        return Err(crate::PyError::type_error(format!(
+            "{}.writelines() takes exactly one argument ({} given)",
+            crate::type_methods::arg_type_name(self_obj),
+            args.len() - 1,
+        )));
+    }
+    let lines = args[1];
     if io_closed(self_obj) {
         return Err(crate::PyError::value_error("I/O operation on closed file."));
     }

--- a/pyre/pyre-interpreter/src/module/_io/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_io/mod.rs
@@ -40,6 +40,49 @@ fn iobase_isatty(args: &[PyObjectRef]) -> crate::PyResult {
     Ok(w_bool_from(false))
 }
 
+/// `interp_iobase.py:303-322 W_IOBase.writelines_w` — validate the stream,
+/// obtain the input iterator, and call the receiver's (possibly overridden)
+/// `write` method once for each line.  The iteration is deliberately lazy;
+/// no list snapshot is introduced.
+pub(crate) fn iobase_writelines(args: &[PyObjectRef]) -> crate::PyResult {
+    let self_obj = args
+        .first()
+        .copied()
+        .ok_or_else(|| crate::PyError::type_error("writelines() requires self"))?;
+    let lines = args
+        .get(1)
+        .copied()
+        .ok_or_else(|| crate::PyError::type_error("writelines() requires lines"))?;
+    if io_closed(self_obj) {
+        return Err(crate::PyError::value_error("I/O operation on closed file."));
+    }
+
+    let _roots = pyre_object::gc_roots::push_roots();
+    let sp = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(self_obj);
+    pyre_object::gc_roots::pin_root(lines);
+    let iterator = crate::baseobjspace::iter(pyre_object::gc_roots::shadow_stack_get(sp + 1))?;
+    pyre_object::gc_roots::pin_root(iterator);
+    loop {
+        let iterator = pyre_object::gc_roots::shadow_stack_get(sp + 2);
+        let line = match crate::baseobjspace::next(iterator) {
+            Ok(line) => line,
+            Err(err) if err.kind == crate::PyErrorKind::StopIteration => break,
+            Err(err) => return Err(err),
+        };
+        let _line_root = pyre_object::gc_roots::push_roots();
+        pyre_object::gc_roots::pin_root(line);
+        let line =
+            pyre_object::gc_roots::shadow_stack_get(pyre_object::gc_roots::shadow_stack_len() - 1);
+        call_method_result(
+            pyre_object::gc_roots::shadow_stack_get(sp),
+            "write",
+            &[line],
+        )?;
+    }
+    Ok(w_none())
+}
+
 fn init_iobase_type(ns: PyObjectRef) {
     type_method(ns, "closed", w_bool_from(false));
     type_method(
@@ -51,6 +94,11 @@ fn init_iobase_type(ns: PyObjectRef) {
         ns,
         "isatty",
         crate::make_builtin_function_with_arity("isatty", iobase_isatty, 1),
+    );
+    type_method(
+        ns,
+        "writelines",
+        crate::make_builtin_function_with_arity("writelines", iobase_writelines, 2),
     );
     type_method(
         ns,

--- a/pyre/pyre-interpreter/src/module/_pickle/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_pickle/mod.rs
@@ -425,7 +425,8 @@ crate::py_module! {
         "Unpickler" => unpickler::type_object(),
         // Shared singleton with `__pypy__.PickleBuffer`; `pickle.py` does
         // `from _pickle import PickleBuffer` to set `_HAVE_PICKLE_BUFFER`.
-        "PickleBuffer" => crate::module::__pypy__::interp_buffer::type_object(),
+        "PickleBuffer" =>
+            crate::module::__pypy__::interp_buffer::picklebuffer_type_object(),
     },
     exceptions: {
         "PickleError" => crate::builtins::lookup_exc_class("Exception")

--- a/pyre/pyre-interpreter/src/module/gc/mod.rs
+++ b/pyre/pyre-interpreter/src/module/gc/mod.rs
@@ -1,7 +1,7 @@
 //! gc module — PyPy: `pypy/module/gc/`.
 //!
-//! Partial port of `interp_gc.py`. Explicit collection uses pyre's non-moving
-//! old-gen major, then drains the RPython finalizer queue synchronously.
+//! Partial port of `interp_gc.py`. Explicit collection runs the complete
+//! RPython collection, then drains the finalizer queue synchronously.
 
 use pyre_object::*;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -66,10 +66,11 @@ crate::py_module! {
     },
     functions: {
         // `interp_gc.py:7-26 collect` — argument `generation` ignored per
-        // upstream.  MethodCache / MapAttrCache clears (`:14-17`) skipped
-        // because pyre has no equivalent caches.
+        // upstream.
         "collect"       / 1 = |_| {
-            pyre_object::gc_hook::try_gc_collect_oldgen();
+            crate::baseobjspace::clear_method_cache();
+            crate::objspace::std::mapdict::clear_map_attr_cache();
+            pyre_object::gc_hook::try_gc_collect();
             if let Some(action) = user_del_action() {
                 let temp_reenable = !action.enabled_at_app_level;
                 if temp_reenable {

--- a/pyre/pyre-interpreter/src/module/math/interp_math.rs
+++ b/pyre/pyre-interpreter/src/module/math/interp_math.rs
@@ -60,7 +60,7 @@ pub fn try_get_double(obj: PyObjectRef) -> Result<f64, crate::PyError> {
                              The ability to return an instance of a strict subclass of \
                              float is deprecated, and may be removed in a future version \
                              of Python."
-                        ));
+                        ))?;
                     }
                     return Ok(floatobject::w_float_get_value(result));
                 }

--- a/pyre/pyre-interpreter/src/module/mmap/interp_mmap.rs
+++ b/pyre/pyre-interpreter/src/module/mmap/interp_mmap.rs
@@ -137,6 +137,23 @@ fn mmap_ptr(obj: pyre_object::PyObjectRef) -> Result<(*mut u8, usize), crate::Py
     Ok((p, len))
 }
 
+/// `W_MMap.readbuf_w` / `writebuf_w` — expose the live mapping to the
+/// object-space buffer protocol.  `None` means the object is not an mmap;
+/// the inner error preserves the closed-mapping failure.
+#[cfg(unix)]
+pub(crate) fn mmap_buffer_view(
+    obj: pyre_object::PyObjectRef,
+) -> Option<Result<(usize, usize, bool), crate::PyError>> {
+    let w_type = crate::typedef::r#type(obj)?;
+    if !std::ptr::eq(w_type, mmap_type()) {
+        return None;
+    }
+    Some(mmap_ptr(obj).map(|(ptr, len)| {
+        let readonly = mmap_get_attr_i64(obj, "_access") == MMAP_ACCESS_READ;
+        (ptr as usize, len, readonly)
+    }))
+}
+
 #[cfg(unix)]
 fn mmap_get_attr_obj(obj: pyre_object::PyObjectRef, key: &str) -> pyre_object::PyObjectRef {
     let d = crate::baseobjspace::getdict(obj);

--- a/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
+++ b/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
@@ -213,7 +213,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
         "HAVE_FPATHCONF",
         #[cfg(not(feature = "sandbox"))]
         "HAVE_FSTATVFS",
-        #[cfg(not(feature = "sandbox"))]
+        #[cfg(all(unix, not(feature = "sandbox")))]
         "HAVE_FTRUNCATE",
         "HAVE_FUTIMENS",
         "HAVE_FUTIMES",
@@ -2251,19 +2251,57 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
         // real fd mutation whenever HAVE_FTRUNCATE is advertised.  Shared
         // memory sizes its newly-created object through this call before
         // mapping it.
-        #[cfg(not(feature = "sandbox"))]
+        #[cfg(all(unix, not(feature = "sandbox")))]
         crate::module_ns_store(
             ns,
             "ftruncate",
             crate::make_builtin_function_with_arity(
                 "ftruncate",
                 |args| {
-                    let fd = (unsafe { pyre_object::w_int_get_value(args[0]) }) as libc::c_int;
-                    let length =
-                        (unsafe { pyre_object::w_int_get_value(args[1]) }) as libc::off_t;
-                    let r = unsafe { libc::ftruncate(fd, length) };
-                    if r < 0 {
-                        return Err(io_err(std::io::Error::last_os_error(), ""));
+                    // interp_posix.py:404 `@unwrap_spec(fd=c_int, length=r_longlong)`.
+                    // CPython 3.14's clinic gateway accepts `__index__` but not
+                    // `__int__`; that newer coercion wins over PyPy's legacy
+                    // `gateway_int_w` behavior.
+                    if args.len() != 2 {
+                        return Err(crate::PyError::type_error(format!(
+                            "ftruncate expected 2 arguments, got {}",
+                            args.len(),
+                        )));
+                    }
+                    let w_fd = crate::baseobjspace::space_index(args[0])?;
+                    let fd_value = crate::baseobjspace::int_w(w_fd).map_err(|err| {
+                        if err.kind == crate::PyErrorKind::OverflowError {
+                            crate::PyError::overflow_error(
+                                "Python int too large to convert to C int",
+                            )
+                        } else {
+                            err
+                        }
+                    })?;
+                    let fd = libc::c_int::try_from(fd_value).map_err(|_| {
+                        crate::PyError::overflow_error("Python int too large to convert to C int")
+                    })?;
+                    let w_length = crate::baseobjspace::space_index(args[1])?;
+                    let length = crate::baseobjspace::int_w(w_length).map_err(|err| {
+                        if err.kind == crate::PyErrorKind::OverflowError {
+                            crate::PyError::overflow_error(
+                                "Python int too large to convert to C long",
+                            )
+                        } else {
+                            err
+                        }
+                    })? as libc::off_t;
+                    // interp_posix.py:407-412: retry EINTR, propagate every
+                    // other OSError.
+                    loop {
+                        let r = unsafe { libc::ftruncate(fd, length) };
+                        if r == 0 {
+                            break;
+                        }
+                        let err = std::io::Error::last_os_error();
+                        if err.kind() != std::io::ErrorKind::Interrupted {
+                            return Err(io_err(err, ""));
+                        }
                     }
                     Ok(pyre_object::w_none())
                 },

--- a/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
+++ b/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
@@ -2247,6 +2247,30 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
             ),
         );
 
+        // rpython/rlib/rposix.py `ftruncate(fd, length)` — this must be a
+        // real fd mutation whenever HAVE_FTRUNCATE is advertised.  Shared
+        // memory sizes its newly-created object through this call before
+        // mapping it.
+        #[cfg(not(feature = "sandbox"))]
+        crate::module_ns_store(
+            ns,
+            "ftruncate",
+            crate::make_builtin_function_with_arity(
+                "ftruncate",
+                |args| {
+                    let fd = (unsafe { pyre_object::w_int_get_value(args[0]) }) as libc::c_int;
+                    let length =
+                        (unsafe { pyre_object::w_int_get_value(args[1]) }) as libc::off_t;
+                    let r = unsafe { libc::ftruncate(fd, length) };
+                    if r < 0 {
+                        return Err(io_err(std::io::Error::last_os_error(), ""));
+                    }
+                    Ok(pyre_object::w_none())
+                },
+                2,
+            ),
+        );
+
         // os.mkfifo(path, mode=0o666) -> None
         #[cfg(not(feature = "sandbox"))]
         crate::module_ns_store(

--- a/pyre/pyre-interpreter/src/module/struct/mod.rs
+++ b/pyre/pyre-interpreter/src/module/struct/mod.rs
@@ -961,8 +961,11 @@ pub struct W_Struct {
 
 #[crate::pyre_methods(doc = "Struct(fmt) --> compiled struct object")]
 impl W_Struct {
+    /// `interp_struct.py:256 descr__new__` — the format string is consumed by
+    /// `__init__`, so the allocator accepts and discards the trailing
+    /// `__args__` instead of failing the gateway arity check.
     #[staticmethod]
-    fn __new__(_cls: PyObjectRef) -> PyObjectRef {
+    fn __new__(_cls: PyObjectRef, _args: &[PyObjectRef]) -> PyObjectRef {
         W_Struct::allocate_stable(W_Struct {
             ob: pyre_object::PyObject {
                 ob_type: std::ptr::null(),

--- a/pyre/pyre-interpreter/src/module/struct/mod.rs
+++ b/pyre/pyre-interpreter/src/module/struct/mod.rs
@@ -620,15 +620,13 @@ unsafe fn writebuf<'a>(obj: PyObjectRef) -> Result<&'a mut [u8], crate::PyError>
                 ));
             }
             let view = memoryview::w_memoryview_view(obj);
-            if bytearrayobject::is_bytearray(view.backing().w_obj())
-                && memoryview::w_memoryview_stride0(obj) == memoryview::w_memoryview_itemsize(obj)
-            {
+            if crate::builtins::memoryview_contiguity(obj).0 {
                 let off = view.offset() as usize;
                 let len = memoryview::w_memoryview_length(obj) as usize;
-                // The backing storage is already the view's `Buffer::Sub`
-                // window for a zero-copy slice.
                 if let Some(full) = view.backing().as_bytes_mut() {
-                    return Ok(&mut full[off..off + len]);
+                    if off <= full.len() && len <= full.len() - off {
+                        return Ok(&mut full[off..off + len]);
+                    }
                 }
             }
         }
@@ -871,7 +869,7 @@ fn ldexp(x: f64, e: i32) -> f64 {
 
 /// `_PyFloat_Pack2` — round `x` to IEEE binary16, raising `OverflowError`
 /// for a finite value too large to represent.
-fn pack_half(x: f64) -> Result<u16, crate::PyError> {
+pub(crate) fn pack_half(x: f64) -> Result<u16, crate::PyError> {
     let sign: u16;
     let e: i32;
     let bits: u16;
@@ -929,7 +927,7 @@ fn pack_half(x: f64) -> Result<u16, crate::PyError> {
 }
 
 /// `_PyFloat_Unpack2` — decode an IEEE binary16 to a double.
-fn unpack_half(bits: u16) -> f64 {
+pub(crate) fn unpack_half(bits: u16) -> f64 {
     let sign = (bits >> 15) & 1 == 1;
     let e = ((bits >> 10) & 0x1f) as i32;
     let f = (bits & 0x3ff) as u32;
@@ -1178,12 +1176,26 @@ pub fn is_unpack_iter(obj: PyObjectRef) -> bool {
 unsafe fn readbuf<'a>(obj: PyObjectRef) -> Result<&'a [u8], crate::PyError> {
     unsafe {
         if bytesobject::is_bytes_like(obj) {
-            Ok(bytesobject::bytes_like_data(obj))
-        } else {
-            Err(crate::PyError::type_error(
-                "a bytes-like object is required",
-            ))
+            return Ok(bytesobject::bytes_like_data(obj));
         }
+        if interp_array::is_array(obj) {
+            return Ok(interp_array::w_array_bytes(obj));
+        }
+        if memoryview::is_w_memoryview(obj) {
+            crate::builtins::memoryview_check_released(obj)?;
+            if crate::builtins::memoryview_contiguity(obj).0 {
+                let view = memoryview::w_memoryview_view(obj);
+                let full = view.backing().as_bytes();
+                let off = view.offset() as usize;
+                let len = memoryview::w_memoryview_length(obj) as usize;
+                if off <= full.len() && len <= full.len() - off {
+                    return Ok(&full[off..off + len]);
+                }
+            }
+        }
+        Err(crate::PyError::type_error(
+            "a bytes-like object is required",
+        ))
     }
 }
 

--- a/pyre/pyre-interpreter/src/module/sys/vm.rs
+++ b/pyre/pyre-interpreter/src/module/sys/vm.rs
@@ -587,7 +587,18 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
         "get_int_max_str_digits",
         make_builtin_function_with_arity(
             "get_int_max_str_digits",
-            |_| Ok(w_int_new(crate::module::sys::state::int_max_str_digits() as i64)),
+            |args| {
+                // The fixed arity above is only a fast-dispatch hint; the
+                // direct path still delivers whatever the caller passed.
+                if !args.is_empty() {
+                    return Err(crate::PyError::type_error(format!(
+                        "get_int_max_str_digits() takes 0 positional arguments but {} {} given",
+                        args.len(),
+                        if args.len() == 1 { "was" } else { "were" },
+                    )));
+                }
+                Ok(w_int_new(crate::module::sys::state::int_max_str_digits() as i64))
+            },
             0,
         ),
     );
@@ -597,6 +608,19 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
         make_builtin_function_with_arity(
             "set_int_max_str_digits",
             |args| {
+                if args.len() != 1 {
+                    let message = if args.is_empty() {
+                        "set_int_max_str_digits() missing 1 required positional argument: \
+                         'maxdigits'"
+                            .to_string()
+                    } else {
+                        format!(
+                            "set_int_max_str_digits() takes 1 positional argument but {} were given",
+                            args.len(),
+                        )
+                    };
+                    return Err(crate::PyError::type_error(message));
+                }
                 let maxdigits = crate::baseobjspace::c_int_w(args[0])?;
                 crate::module::sys::state::set_int_max_str_digits(maxdigits)?;
                 Ok(w_none())

--- a/pyre/pyre-interpreter/src/module/time/interp_time.rs
+++ b/pyre/pyre-interpreter/src/module/time/interp_time.rs
@@ -245,6 +245,41 @@ pub fn perf_counter_ns(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyErr
     Ok(w_int_new(monotonic_nanos() as i64))
 }
 
+/// `interp_time.py:915-932 _get_time_info` — fill the app-level namespace
+/// used by `time.get_clock_info`.  The observable fields follow Python 3.14;
+/// all clocks exposed by pyre have nanosecond representation internally.
+pub fn get_time_info(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    let name_obj = args[0];
+    let info = args[1];
+    if unsafe { !pyre_object::is_str(name_obj) } {
+        return Err(crate::PyError::type_error(format!(
+            "time._get_time_info() argument 1 must be str, not {}",
+            crate::type_methods::arg_type_name(name_obj)
+        )));
+    }
+    let name = unsafe { pyre_object::w_str_get_value(name_obj) };
+    let (implementation, monotonic, adjustable) = match name {
+        "time" => ("clock_gettime(CLOCK_REALTIME)", false, true),
+        "monotonic" | "perf_counter" => {
+            #[cfg(target_os = "macos")]
+            {
+                ("mach_absolute_time()", true, false)
+            }
+            #[cfg(not(target_os = "macos"))]
+            {
+                ("clock_gettime(CLOCK_MONOTONIC)", true, false)
+            }
+        }
+        "process_time" => ("clock_gettime(CLOCK_PROCESS_CPUTIME_ID)", true, false),
+        _ => return Err(crate::PyError::value_error("unknown clock")),
+    };
+    crate::baseobjspace::setattr_str(info, "implementation", w_str_new(implementation))?;
+    crate::baseobjspace::setattr_str(info, "monotonic", w_bool_from(monotonic))?;
+    crate::baseobjspace::setattr_str(info, "adjustable", w_bool_from(adjustable))?;
+    crate::baseobjspace::setattr_str(info, "resolution", floatobject::w_float_new(1.0e-9))?;
+    Ok(w_none())
+}
+
 /// Process CPU time (kernel + user) as nanoseconds.
 ///
 /// Prefers `clock_gettime(CLOCK_PROCESS_CPUTIME_ID)`; falls back to

--- a/pyre/pyre-interpreter/src/module/time/interp_time.rs
+++ b/pyre/pyre-interpreter/src/module/time/interp_time.rs
@@ -249,6 +249,17 @@ pub fn perf_counter_ns(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyErr
 /// used by `time.get_clock_info`.  The observable fields follow Python 3.14;
 /// all clocks exposed by pyre have nanosecond representation internally.
 pub fn get_time_info(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    // The registered arity is only a dispatch hint, so the positional count
+    // is enforced here rather than by the caller.
+    if args.len() != 2 {
+        let message = match args.len() {
+            0 => "_get_time_info() missing 2 required positional arguments: 'name' and 'info'"
+                .to_string(),
+            1 => "_get_time_info() missing 1 required positional argument: 'info'".to_string(),
+            n => format!("_get_time_info() takes 2 positional arguments but {n} were given"),
+        };
+        return Err(crate::PyError::type_error(message));
+    }
     let name_obj = args[0];
     let info = args[1];
     if unsafe { !pyre_object::is_str(name_obj) } {

--- a/pyre/pyre-interpreter/src/module/time/mod.rs
+++ b/pyre/pyre-interpreter/src/module/time/mod.rs
@@ -28,7 +28,19 @@ crate::py_module! {
 def strptime(string, format="%a %b %d %H:%M:%S %Y"):
     import _strptime
     return _strptime._strptime_time(string, format)
-"# => ["strptime"],
+
+def get_clock_info(name):
+    # PyPy app_time.py:36-44.  `types.SimpleNamespace` is the concrete type of
+    # sys.implementation in pyre's stdlib bootstrap.
+    import sys, time
+    info = type(sys.implementation)()
+    info.implementation = ""
+    info.monotonic = False
+    info.adjustable = False
+    info.resolution = 1.0
+    time._get_time_info(name, info)
+    return info
+"# => ["strptime", "get_clock_info"],
     },
     functions: {
         "time"         / 0 = t::time,
@@ -40,6 +52,7 @@ def strptime(string, format="%a %b %d %H:%M:%S %Y"):
         "perf_counter_ns" / 0 = t::perf_counter_ns,
         "process_time" / 0 = t::process_time,
         "process_time_ns" / 0 = t::process_time_ns,
+        "_get_time_info" / 2 = t::get_time_info,
         "localtime"    / * = t::localtime,
         "gmtime"       / * = t::gmtime,
         "strftime"     / * = t::strftime,

--- a/pyre/pyre-interpreter/src/objspace/descroperation.rs
+++ b/pyre/pyre-interpreter/src/objspace/descroperation.rs
@@ -3775,7 +3775,20 @@ pub fn invert(a: PyObjectRef) -> PyResult {
         if let Some(result) = try_numeric_unaryop_override(a, "__invert__") {
             return result;
         }
-        if is_int(a) || is_bool(a) {
+        if is_bool(a) {
+            // CPython 3.14 `Objects/boolobject.c:bool_invert`.  The bundled
+            // PyPy source inherits `W_IntObject.descr_invert`; 3.14 inserts
+            // this warning-bearing bool slot before the integer inversion.
+            crate::warn::warn_deprecation(
+                "Bitwise inversion '~' on bool is deprecated and will be removed in \
+Python 3.16. This returns the bitwise inversion of the underlying int \
+object and is usually not what you expect from negating a bool. \
+Use the 'not' operator for boolean negation or ~int(x) if you really want \
+the bitwise inversion of the underlying int.",
+            )?;
+            return Ok(w_int_new(!int_value(a)));
+        }
+        if is_int(a) {
             return Ok(w_int_new(!int_value(a)));
         }
         if is_long(a) {

--- a/pyre/pyre-interpreter/src/objspace/std/mapdict.rs
+++ b/pyre/pyre-interpreter/src/objspace/std/mapdict.rs
@@ -2,8 +2,7 @@
 //!
 //! Mapdict provides per-instance dict and weakref slots for hasdict /
 //! weakrefable types. PyPy stores these inside the mapdict map's "dict"
-//! and "weakref" SPECIAL slots; pyre keeps thread-local side tables
-//! keyed by object address because pyre has no mapdict.
+//! and "weakref" SPECIAL slots; pyre does the same for user instances.
 //!
 //! The names below mirror PyPy: `MapdictDictSupport.getdict` →
 //! `_obj_getdict`, `MapdictWeakrefSupport.setweakref` →
@@ -439,6 +438,51 @@ pub unsafe fn instance_set_dict_slot(obj: PyObjectRef, w_dict: PyObjectRef) -> b
     node_write(map, inst, Wtf8::new("dict"), SPECIAL, w_dict)
 }
 
+/// Read the weakref lifeline from the instance's `"weakref"` SPECIAL slot
+/// (mapdict.py:787 `self._get_mapdict_map().read(self, "weakref", SPECIAL)`).
+///
+/// # Safety
+/// `obj` must be a live `W_ObjectObject`.
+#[majit_macros::dont_look_inside]
+pub unsafe fn instance_get_weakref_slot(obj: PyObjectRef) -> Option<PyObjectRef> {
+    ensure_mapdict_initialized(obj);
+    let inst = &*(obj as *const pyre_object::W_ObjectObject);
+    let map = inst._get_mapdict_map();
+    node_read(map, inst, Wtf8::new("weakref"), SPECIAL)
+}
+
+/// Write the weakref lifeline into the instance's `"weakref"` SPECIAL slot
+/// (mapdict.py:798 `self._get_mapdict_map().write(...)`).
+///
+/// # Safety
+/// `obj` must be a live `W_ObjectObject`.
+#[majit_macros::dont_look_inside]
+pub unsafe fn instance_set_weakref_slot(obj: PyObjectRef, lifeline: PyObjectRef) -> bool {
+    ensure_mapdict_initialized(obj);
+    let inst = &mut *(obj as *mut pyre_object::W_ObjectObject);
+    let map = inst._get_mapdict_map();
+    node_write(map, inst, Wtf8::new("weakref"), SPECIAL, lifeline)
+}
+
+/// Clear the weakref lifeline in place, matching mapdict.py:802
+/// `self._get_mapdict_map().write(self, "weakref", SPECIAL, None)`.
+///
+/// # Safety
+/// `obj` must be a live `W_ObjectObject`.
+#[majit_macros::dont_look_inside]
+pub unsafe fn instance_del_weakref_slot(obj: PyObjectRef) {
+    ensure_mapdict_initialized(obj);
+    let inst = &mut *(obj as *mut pyre_object::W_ObjectObject);
+    let map = inst._get_mapdict_map();
+    let _ = node_write(
+        map,
+        inst,
+        Wtf8::new("weakref"),
+        SPECIAL,
+        pyre_object::PY_NULL,
+    );
+}
+
 // ── methods needed for slots (mapdict.py:764-780 MapdictSlotsSupport) ──
 
 /// mapdict.py:766-768 `MapdictSlotsSupport.getslotvalue` —
@@ -746,6 +790,13 @@ thread_local! {
     /// `space.fromcache(MapAttrCache)` (mapdict.py:80) — one cache per space;
     /// pyre runs one space per thread.
     static MAP_ATTR_CACHE: RefCell<MapAttrCache> = RefCell::new(MapAttrCache::new());
+}
+
+/// interp_gc.py:14-17 — clear `space.fromcache(MapAttrCache)` before an
+/// explicit full collection so cached map nodes do not retain stale entries.
+#[majit_macros::dont_look_inside]
+pub fn clear_map_attr_cache() {
+    MAP_ATTR_CACHE.with(|cache| cache.borrow_mut().clear());
 }
 
 /// `objectmodel.compute_hash(name)` for a (utf8-encoded) str (mapdict.py:94).
@@ -2472,7 +2523,9 @@ unsafe fn get_new_attr(
     // (mapdict.py:149-156). Map nodes are process-global in pyre, so keep the
     // lookup, holder construction, and insertion under one lock: parallel
     // interpreters must intern exactly one transition for a given key.
-    let mut cache = unsafe { (*self_node).cache_attrs() }.lock().unwrap();
+    let mut cache = unsafe { (*self_node).cache_attrs() }
+        .lock()
+        .unwrap_or_else(|error| error.into_inner());
     if let Some(&holder) = cache.get(&key) {
         return holder;
     }
@@ -2501,7 +2554,7 @@ unsafe fn find_branch_to_move_into(
     loop {
         let holder = unsafe { (*current).cache_attrs() }
             .lock()
-            .unwrap()
+            .unwrap_or_else(|error| error.into_inner())
             .get(&key)
             .copied();
         let reached_top = match holder {
@@ -2774,8 +2827,8 @@ thread_local! {
 thread_local! {
     /// objspace/std/mapdict.py:780-797 MapdictWeakrefSupport stores the
     /// lifeline in the "weakref" SPECIAL slot of the mapdict map. pyre
-    /// keeps a side table because there is no mapdict; semantically
-    /// this is the same per-instance lifeline storage.
+    /// uses that slot for `W_ObjectObject`; this table remains only for
+    /// weakrefable non-instance wrappers that have no mapdict carrier.
     pub static WEAKREF_TABLE: RefCell<HashMap<usize, PyObjectRef>> =
         RefCell::new(HashMap::new());
 
@@ -3458,7 +3511,11 @@ pub fn _obj_setdict(self_ref: PyObjectRef, w_dict: PyObjectRef) -> Result<(), Py
 ///     return lifeline
 /// ```
 pub fn getweakref(self_ref: PyObjectRef) -> Option<PyObjectRef> {
-    WEAKREF_TABLE.with(|table| table.borrow().get(&(self_ref as usize)).copied())
+    if unsafe { pyre_object::is_instance(self_ref) } {
+        unsafe { instance_get_weakref_slot(self_ref) }
+    } else {
+        WEAKREF_TABLE.with(|table| table.borrow().get(&(self_ref as usize)).copied())
+    }
 }
 
 /// objspace/std/mapdict.py:789-793 MapdictWeakrefSupport.setweakref.
@@ -3470,11 +3527,16 @@ pub fn getweakref(self_ref: PyObjectRef) -> Option<PyObjectRef> {
 ///     self._get_mapdict_map().write(self, "weakref", SPECIAL, weakreflifeline)
 /// ```
 pub fn setweakref(self_ref: PyObjectRef, weakreflifeline: PyObjectRef) {
-    WEAKREF_TABLE.with(|table| {
-        table
-            .borrow_mut()
-            .insert(self_ref as usize, weakreflifeline);
-    });
+    if unsafe { pyre_object::is_instance(self_ref) } {
+        let flag = unsafe { instance_set_weakref_slot(self_ref, weakreflifeline) };
+        debug_assert!(flag, "write to the weakref SPECIAL slot failed");
+    } else {
+        WEAKREF_TABLE.with(|table| {
+            table
+                .borrow_mut()
+                .insert(self_ref as usize, weakreflifeline);
+        });
+    }
 }
 
 /// objspace/std/mapdict.py:795-797 MapdictWeakrefSupport.delweakref.
@@ -3484,9 +3546,13 @@ pub fn setweakref(self_ref: PyObjectRef, weakreflifeline: PyObjectRef) {
 ///     self._get_mapdict_map().write(self, "weakref", SPECIAL, None)
 /// ```
 pub fn delweakref(self_ref: PyObjectRef) {
-    WEAKREF_TABLE.with(|table| {
-        table.borrow_mut().remove(&(self_ref as usize));
-    });
+    if unsafe { pyre_object::is_instance(self_ref) } {
+        unsafe { instance_del_weakref_slot(self_ref) };
+    } else {
+        WEAKREF_TABLE.with(|table| {
+            table.borrow_mut().remove(&(self_ref as usize));
+        });
+    }
 }
 
 #[cfg(test)]

--- a/pyre/pyre-interpreter/src/pyframe.rs
+++ b/pyre/pyre-interpreter/src/pyframe.rs
@@ -1465,6 +1465,32 @@ pub fn deref_name_and_kind(code: &CodeObject, idx: usize) -> (&str, bool) {
     }
 }
 
+/// Whether the pinned RustPython compiler encoded a class-namespace
+/// `__class__` assignment as `STORE_DEREF`.  CPython 3.14 emits `STORE_NAME`
+/// for the explicit binding while retaining the separate implicit
+/// `__class__` cell used by methods.  A class body is non-optimized and the
+/// affected slot is a cell variable, never a free variable (`nonlocal
+/// __class__` must continue to mutate its enclosing cell).
+#[inline]
+pub fn class_scope_class_deref_is_name(code: &CodeObject, idx: usize) -> bool {
+    if code.flags.contains(CodeFlags::OPTIMIZED) {
+        return false;
+    }
+    let (name, is_free) = deref_name_and_kind(code, idx);
+    !is_free && name == "__class__"
+}
+
+/// Unified localsplus index of an outer `__class__` free variable, when a
+/// class body also owns the distinct implicit `__class__` cell.  CPython 3.14
+/// addresses this collision with `LOAD_FROM_DICT_OR_DEREF`.
+pub fn class_scope_outer_class_freevar(code: &CodeObject) -> Option<usize> {
+    let free_pos = code
+        .freevars
+        .iter()
+        .position(|name| name.as_str() == "__class__")?;
+    Some(code.varnames.len() + npure_cellvars(code) + free_pos)
+}
+
 pub fn deref_unbound_error(code: &CodeObject, idx: usize) -> crate::PyError {
     let (name, is_free) = deref_name_and_kind(code, idx);
     let message = if is_free {

--- a/pyre/pyre-interpreter/src/pyopcode.rs
+++ b/pyre/pyre-interpreter/src/pyopcode.rs
@@ -1343,7 +1343,12 @@ pub trait OpcodeStepExecutor: SharedOpcodeHandler {
     fn load_super_attr(&mut self) -> Result<(), PyError> {
         Err(crate::PyError::type_error("load_super_attr not implemented").into())
     }
-    fn load_super_attr_with(&mut self, _name: &str, _is_method: bool) -> Result<(), PyError> {
+    fn load_super_attr_with(
+        &mut self,
+        _name: &str,
+        _is_method: bool,
+        _is_two_arg: bool,
+    ) -> Result<(), PyError> {
         Err(crate::PyError::type_error("load_super_attr not implemented").into())
     }
     fn load_locals(&mut self) -> Result<(), PyError> {
@@ -3264,7 +3269,8 @@ pub fn execute_load_super_attr<E: OpcodeStepExecutor>(
     let idx = raw >> 2;
     let name = &code.names[idx];
     let is_method = (raw & 1) != 0;
-    executor.load_super_attr_with(name, is_method)?;
+    let is_two_arg = (raw & 2) != 0;
+    executor.load_super_attr_with(name, is_method, is_two_arg)?;
     Ok(StepResult::Continue)
 }
 

--- a/pyre/pyre-interpreter/src/reduce_protocol.rs
+++ b/pyre/pyre-interpreter/src/reduce_protocol.rs
@@ -306,11 +306,16 @@ pub fn descr_reduce_ex(w_obj: PyObjectRef, proto: i64) -> PyResult {
         // reconstruct, and that supplies no `__getnewargs__`, cannot be
         // rebuilt via `__newobj__`.  `reduce_newobj` gates this on
         // `tp_basicsize` exceeding the object+dict+weakref+slots baseline;
-        // pyre has no basicsize notion, so it recognises the one such builtin
-        // layout
-        // that reaches object-reduce — `module` (native name + dict
-        // payload).  Matches the proto < 2 `copyreg._reduce_ex` refusal.
-        if !hasargs && unsafe { pyre_object::is_module(w_obj) } {
+        // pyre has no basicsize notion, so recognise the native layouts that
+        // reach object-reduce with unreconstructable C-level state: `module`
+        // (native name + dict payload) and `memoryview` (private buffer view
+        // geometry/export state).  This is the `_PyObject_GetState(required)`
+        // refusal used by CPython 3.14 for every pickle protocol.
+        if !hasargs
+            && unsafe {
+                pyre_object::is_module(w_obj) || pyre_object::memoryview::is_w_memoryview(w_obj)
+            }
+        {
             return Err(PyError::type_error(format!(
                 "cannot pickle '{}' object",
                 typename(w_obj)

--- a/pyre/pyre-interpreter/src/type_methods.rs
+++ b/pyre/pyre-interpreter/src/type_methods.rs
@@ -5719,7 +5719,10 @@ mod dict_method_tests {
     fn assert_type_error<T: std::fmt::Debug>(result: Result<T, crate::PyError>) {
         let err = result.expect_err("operation should reject unhashable dict key");
         assert_eq!(err.kind, crate::PyErrorKind::TypeError);
-        assert_eq!(err.message, "unhashable type: 'list'");
+        assert_eq!(
+            err.message,
+            "cannot use 'list' as a dict key (unhashable type: 'list')"
+        );
     }
 
     #[test]

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -837,6 +837,19 @@ pub fn init_typeobjects() {
             &pyre_object::iterobject::SEQ_ITER_TYPE as *const PyType as usize,
             seq_iterator_type as usize,
         );
+        let callable_iterator_type = new_typeobject_with_base(
+            "callable_iterator",
+            init_callable_iterator_type,
+            object_type,
+        );
+        unsafe {
+            pyre_object::w_type_set_disallow_instantiation(callable_iterator_type);
+            pyre_object::w_type_set_acceptable_as_base_class(callable_iterator_type, false);
+        }
+        reg.insert(
+            &pyre_object::operation::CALLABLE_ITERATOR_TYPE as *const PyType as usize,
+            callable_iterator_type as usize,
+        );
         for (pytype, name, init) in [
             (
                 &pyre_object::iterobject::LIST_ITER_TYPE as *const PyType,
@@ -21443,6 +21456,31 @@ fn init_sequence_iterator_type(ns: PyObjectRef) {
     ];
     for (name, value) in entries {
         unsafe { pyre_object::w_dict_setitem_str_no_proxy(ns, name, value) };
+    }
+}
+
+/// Python 3.14 `PyCallIter_Type` (`callable_iterator`) surface. PyPy 3.11's
+/// `_CallableIterator` is app-level and has only the iteration methods; 3.14
+/// additionally exposes the native pickle reduction hook.
+fn init_callable_iterator_type(ns: PyObjectRef) {
+    for (name, function) in [
+        (
+            "__iter__",
+            crate::baseobjspace::iter_self_method as fn(&[PyObjectRef]) -> crate::PyResult,
+        ),
+        ("__next__", crate::baseobjspace::iter_next_method),
+        (
+            "__reduce__",
+            crate::baseobjspace::callable_iter_reduce_method,
+        ),
+    ] {
+        unsafe {
+            pyre_object::w_dict_setitem_str_no_proxy(
+                ns,
+                name,
+                make_builtin_function_with_arity(name, function, 1),
+            )
+        };
     }
 }
 

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -13515,11 +13515,7 @@ fn init_int_type(ns: PyObjectRef) {
         pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
             ns,
             "__invert__",
-            make_builtin_function_with_arity(
-                "__invert__",
-                |args| crate::objspace::descroperation::invert(args[0]),
-                1,
-            ),
+            make_builtin_function_with_arity("__invert__", int_descr_invert, 1),
         )
     };
     unsafe {
@@ -14588,6 +14584,31 @@ fn bool_repr(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     let w_self = args.first().copied().unwrap_or(pyre_object::PY_NULL);
     let truthy = !w_self.is_null() && crate::baseobjspace::is_true(w_self)?;
     Ok(w_str_new(if truthy { "True" } else { "False" }))
+}
+
+/// `W_IntObject.descr_invert` — the integer inversion slot.  `~x` reaches
+/// bool's warning-bearing slot first, but `int.__invert__` resolves straight
+/// to this one, so a bool receiver is inverted without the deprecation
+/// warning.  The registered arity is only a dispatch hint, so the positional
+/// count is enforced here.
+fn int_descr_invert(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    let Some(&w_self) = args.first() else {
+        return Err(crate::PyError::type_error(
+            "int.__invert__() missing 1 required positional argument: 'self'",
+        ));
+    };
+    if args.len() > 1 {
+        return Err(crate::PyError::type_error(format!(
+            "int.__invert__() takes 1 positional argument but {} were given",
+            args.len(),
+        )));
+    }
+    if unsafe { pyre_object::is_bool(w_self) } {
+        return Ok(w_int_new(
+            !unsafe { crate::objspace::descroperation::int_value(w_self) },
+        ));
+    }
+    crate::objspace::descroperation::invert(w_self)
 }
 
 /// CPython 3.14 `Objects/boolobject.c:bool_invert`.

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -431,40 +431,43 @@ pub fn init_typeobjects() {
             &pyre_object::MODULE_TYPE as *const PyType as usize,
             module_type as usize,
         );
-        // `pypy/objspace/std/dictmultiobject.py:449/459/469` —
-        // dict_keys / dict_values / dict_items.  PyPy registers
-        // each as a distinct TypeDef but they share the
-        // _iter_keys/_iter_values/_iter_items dispatch.  Pyre's
-        // baseobjspace iter/len/contains arms cover the runtime
-        // semantics, so the per-typedef init body stays empty for
-        // now — what matters is that `type(d.keys())` resolves to
-        // the right W_TypeObject (otherwise `builtin_type` falls
-        // back to a str return).  All three view typedefs carry
-        // `__new__ = interp2app(new_dict_*)`, so `acceptable_as_base_class`
-        // is True (`'__new__' in rawdict`): `class Sub(dict_keys)` is
-        // allowed, which `collections.OrderedDict`'s reversed-view
-        // classes rely on.
+        // `pypy/objspace/std/dictmultiobject.py` dict_keys / dict_values /
+        // dict_items TypeDefs, with the Python 3.14 type flags.  PyPy's
+        // current TypeDefs expose `new_dict_*` and permit subclassing for its
+        // app-level OrderedDict views.  Python 3.14 instead gives all three
+        // types a null `tp_new` and clears BASETYPE; pyre targets that newer
+        // public contract.  Its OrderedDict views therefore use the 3.14
+        // `_collections_abc` bases in `app_odict.py`.
         // dict_keys / dict_items get the SetLikeDictView surface
         // per dictmultiobject.py:1802-1829 / 1773-1800; dict_values
         // stops at the common slots per dictmultiobject.py:1831-1840
         // (values views are intentionally NOT set-like).
         let dict_keys_type =
-            new_typeobject_with_base("dict_keys", init_dict_keys_type, object_type);
-        unsafe { pyre_object::w_type_set_acceptable_as_base_class(dict_keys_type, true) };
+            new_typeobject_with_base("dict_keys", init_dict_view_keys_type, object_type);
+        unsafe {
+            pyre_object::w_type_set_acceptable_as_base_class(dict_keys_type, false);
+            pyre_object::w_type_set_disallow_instantiation(dict_keys_type);
+        }
         reg.insert(
             &pyre_object::dictmultiobject::DICT_KEYS_TYPE as *const PyType as usize,
             dict_keys_type as usize,
         );
         let dict_values_type =
-            new_typeobject_with_base("dict_values", init_dict_values_type_with_new, object_type);
-        unsafe { pyre_object::w_type_set_acceptable_as_base_class(dict_values_type, true) };
+            new_typeobject_with_base("dict_values", init_dict_view_values_type, object_type);
+        unsafe {
+            pyre_object::w_type_set_acceptable_as_base_class(dict_values_type, false);
+            pyre_object::w_type_set_disallow_instantiation(dict_values_type);
+        }
         reg.insert(
             &pyre_object::dictmultiobject::DICT_VALUES_TYPE as *const PyType as usize,
             dict_values_type as usize,
         );
         let dict_items_type =
-            new_typeobject_with_base("dict_items", init_dict_items_type, object_type);
-        unsafe { pyre_object::w_type_set_acceptable_as_base_class(dict_items_type, true) };
+            new_typeobject_with_base("dict_items", init_dict_view_items_type, object_type);
+        unsafe {
+            pyre_object::w_type_set_acceptable_as_base_class(dict_items_type, false);
+            pyre_object::w_type_set_disallow_instantiation(dict_items_type);
+        }
         reg.insert(
             &pyre_object::dictmultiobject::DICT_ITEMS_TYPE as *const PyType as usize,
             dict_items_type as usize,
@@ -5804,151 +5807,6 @@ fn init_dict_view_common_slots(
             ),
         )
     };
-    // `_dict = interp_attrproperty_w('w_dict')` — the underlying dict.
-    // `collections.OrderedDict`'s reversed-view classes read `self._dict`.
-    unsafe {
-        pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
-            ns,
-            "_dict",
-            make_getset_property_named_doc(
-                make_builtin_function_with_arity(
-                    "_dict",
-                    |args| {
-                        let view = args[1];
-                        if view.is_null() {
-                            return Ok(pyre_object::w_none());
-                        }
-                        let dict =
-                            unsafe { pyre_object::dictmultiobject::w_dict_view_get_dict(view) };
-                        if dict.is_null() {
-                            return Ok(pyre_object::w_none());
-                        }
-                        Ok(dict)
-                    },
-                    2,
-                ),
-                pyre_object::PY_NULL,
-                pyre_object::PY_NULL,
-                "the dict this view refers to",
-                "_dict",
-            ),
-        )
-    };
-}
-
-/// Shared `__new__` for the three dict views — `new_dict_keys` /
-/// `new_dict_items` / `new_dict_values` (`dictmultiobject.py`).  Each
-/// takes the dict positionally and allocates a view over it; the
-/// Python-visible class is re-pointed to the caller's subtype so
-/// `class _OrderedDictKeysView(dict_keys)` instances see themselves.
-fn dict_view_descr_new(
-    args: &[PyObjectRef],
-    kind: pyre_object::dictmultiobject::DictViewKind,
-    static_tp: &'static pyre_object::PyType,
-    name: &str,
-) -> Result<PyObjectRef, crate::PyError> {
-    // `interp2app(new_dict_*)` binds exactly `(w_type, w_dict)`; the arity
-    // is enforced before the body runs.
-    match args.len() {
-        0 => {
-            return Err(crate::PyError::type_error(format!(
-                "{name}.__new__() missing 2 required positional arguments: 'type' and 'dict'"
-            )));
-        }
-        1 => {
-            return Err(crate::PyError::type_error(format!(
-                "{name}.__new__() missing 1 required positional argument: 'dict'"
-            )));
-        }
-        2 => {}
-        n => {
-            return Err(crate::PyError::type_error(format!(
-                "{name}.__new__() takes 2 positional arguments but {n} were given"
-            )));
-        }
-    }
-    let cls = args[0];
-    // `interp_w(W_DictMultiObject, w_dict)` — accept a dict or any dict
-    // subclass (e.g. an `OrderedDict` passing itself to the view).
-    let dict_type = gettypeobject(&pyre_object::pyobject::DICT_TYPE);
-    if !unsafe { crate::baseobjspace::isinstance_w(args[1], dict_type) } {
-        return Err(crate::PyError::type_error(format!(
-            "'dict' object expected, got '{}' instead",
-            crate::baseobjspace::object_functionstr_type_name(args[1])
-        )));
-    }
-    // `allocate_instance(W_DictView*Object, w_type)` validates the target:
-    // a non-type, a non-subtype, or a foreign-layout subtype is rejected
-    // before the view is allocated.
-    let static_obj = gettypeobject(static_tp);
-    check_user_subclass(static_obj, cls)?;
-    // A dict subclass keeps its entries in a native backing dict; the view
-    // binds to that, exactly as `dict.keys()`/`values()`/`items()` do.
-    let w_dict = crate::type_methods::resolve_dict_backing(args[1]);
-    let view = pyre_object::dictmultiobject::w_dict_view_new(w_dict, kind);
-    // Re-point the Python-visible class to the validated subtype.
-    if !std::ptr::eq(cls, static_obj) {
-        unsafe { (*view).w_class = cls };
-    }
-    Ok(view)
-}
-
-fn dict_keys_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    dict_view_descr_new(
-        args,
-        pyre_object::dictmultiobject::DictViewKind::Keys,
-        &pyre_object::dictmultiobject::DICT_KEYS_TYPE,
-        "dict_keys",
-    )
-}
-
-fn dict_values_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    dict_view_descr_new(
-        args,
-        pyre_object::dictmultiobject::DictViewKind::Values,
-        &pyre_object::dictmultiobject::DICT_VALUES_TYPE,
-        "dict_values",
-    )
-}
-
-fn dict_items_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    dict_view_descr_new(
-        args,
-        pyre_object::dictmultiobject::DictViewKind::Items,
-        &pyre_object::dictmultiobject::DICT_ITEMS_TYPE,
-        "dict_items",
-    )
-}
-
-fn register_dict_view_new(
-    ns: PyObjectRef,
-    new_fn: fn(&[PyObjectRef]) -> Result<PyObjectRef, crate::PyError>,
-) {
-    unsafe {
-        pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
-            ns,
-            "__new__",
-            pyre_object::w_staticmethod_new(make_builtin_function("__new__", new_fn)),
-        )
-    };
-}
-
-/// `dict_keys` typedef body — set-like surface plus `__new__`.
-fn init_dict_keys_type(ns: PyObjectRef) {
-    init_dict_view_keys_type(ns);
-    register_dict_view_new(ns, dict_keys_descr_new);
-}
-
-/// `dict_items` typedef body — set-like surface plus `__new__`.
-fn init_dict_items_type(ns: PyObjectRef) {
-    init_dict_view_items_type(ns);
-    register_dict_view_new(ns, dict_items_descr_new);
-}
-
-/// `dict_values` typedef body — common slots plus `__new__`.
-fn init_dict_values_type_with_new(ns: PyObjectRef) {
-    init_dict_view_values_type(ns);
-    register_dict_view_new(ns, dict_values_descr_new);
 }
 
 /// `dictmultiobject.py` `W_DictViewKeysObject` /

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -9160,13 +9160,12 @@ fn init_type_type(ns: PyObjectRef) {
     // returns the tuple).  Bound as a regular method, so `cls` is at args[0].
     let mro_method = make_builtin_function("mro", |args| {
         let cls = args[0];
-        unsafe {
-            let mro_ptr = pyre_object::w_type_get_mro(cls);
-            if mro_ptr.is_null() {
-                return Ok(pyre_object::w_list_new(vec![]));
-            }
-            Ok(pyre_object::w_list_new((*mro_ptr).to_vec()))
-        }
+        // typeobject.py:1081-1084 `descr_mro` computes the default C3 MRO
+        // afresh. In particular this is callable from `Meta.mro()` while the
+        // nascent class has not installed its final MRO yet.
+        Ok(pyre_object::w_list_new(unsafe {
+            crate::baseobjspace::compute_default_mro(cls)
+        }))
     });
     unsafe { pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(ns, "mro", mro_method) };
 
@@ -9186,7 +9185,7 @@ fn init_type_type(ns: PyObjectRef) {
                 ));
             }
         };
-        let subs = unsafe { pyre_object::w_type_get_subclasses(cls) };
+        let subs = unsafe { pyre_object::w_type_get_subclasses(cls, true) };
         Ok(pyre_object::w_list_new(subs))
     });
     unsafe {

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -15004,7 +15004,13 @@ fn init_object_type(ns: PyObjectRef) {
                 "__eq__",
                 |args| {
                     crate::type_methods::arity_slot(args, 1)?;
-                    Ok(pyre_object::w_bool_from(std::ptr::eq(args[0], args[1])))
+                    if std::ptr::eq(args[0], args[1]) {
+                        Ok(pyre_object::w_bool_from(true))
+                    } else {
+                        // objectobject.py descr__eq__: give the reflected
+                        // comparison a chance instead of deciding False here.
+                        Ok(pyre_object::w_not_implemented())
+                    }
                 },
                 2,
             ),
@@ -15022,11 +15028,25 @@ fn init_object_type(ns: PyObjectRef) {
                 "__ne__",
                 |args| {
                     crate::type_methods::arity_slot(args, 1)?;
-                    let eq = crate::baseobjspace::compare(
-                        args[0],
-                        args[1],
-                        crate::baseobjspace::CompareOp::Eq,
-                    )?;
+                    // objectobject.py descr__ne__: look up and call the live
+                    // receiver's __eq__ descriptor, then invert that one
+                    // result.  Running the full comparison dispatcher here
+                    // would apply reflection and the identity fallback too
+                    // early.
+                    let eq_descr = unsafe {
+                        crate::baseobjspace::lookup(args[0], "__eq__")
+                            .expect("every object type inherits object.__eq__")
+                    };
+                    let w_type =
+                        crate::typedef::r#type(args[0]).expect("every Python object has a type");
+                    let eq = unsafe {
+                        crate::baseobjspace::get_and_call_function(
+                            eq_descr,
+                            args[0],
+                            w_type,
+                            &[args[1]],
+                        )?
+                    };
                     // A `NotImplemented` from `__eq__` must pass through so the
                     // caller can try the reflected comparison.
                     if unsafe { pyre_object::is_not_implemented(eq) } {
@@ -15046,7 +15066,14 @@ fn init_object_type(ns: PyObjectRef) {
             pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
                 ns,
                 name,
-                make_builtin_function_with_arity(name, |_| Ok(pyre_object::w_not_implemented()), 2),
+                make_builtin_function_with_arity(
+                    name,
+                    |args| {
+                        crate::type_methods::arity_slot(args, 1)?;
+                        Ok(pyre_object::w_not_implemented())
+                    },
+                    2,
+                ),
             )
         };
     }
@@ -15086,8 +15113,11 @@ fn init_object_type(ns: PyObjectRef) {
                 "__repr__",
                 |args| {
                     if args.is_empty() {
-                        return Ok(pyre_object::w_str_new("<object>"));
+                        return Err(crate::PyError::type_error(
+                            "descriptor '__repr__' of 'object' object needs an argument",
+                        ));
                     }
+                    crate::type_methods::arity_no_args(args, "object.__repr__")?;
                     let obj = args[0];
                     unsafe {
                         if pyre_object::is_instance(obj) {
@@ -15113,8 +15143,11 @@ fn init_object_type(ns: PyObjectRef) {
                 "__str__",
                 |args| {
                     if args.is_empty() {
-                        return Ok(pyre_object::w_str_new("<object>"));
+                        return Err(crate::PyError::type_error(
+                            "descriptor '__str__' of 'object' object needs an argument",
+                        ));
                     }
+                    crate::type_methods::arity_no_args(args, "object.__str__")?;
                     // Delegate to __repr__ to avoid infinite recursion
                     // PyPy: objectobject.py descr___str__ → space.repr(w_self)
                     Ok(pyre_object::w_str_new(&unsafe { crate::py_repr(args[0])? }))
@@ -15132,23 +15165,22 @@ fn init_object_type(ns: PyObjectRef) {
                 "__format__",
                 |args| {
                     if args.is_empty() {
-                        return Ok(pyre_object::w_str_new(""));
+                        return Err(crate::PyError::type_error(
+                            "unbound method object.__format__() needs an argument",
+                        ));
                     }
-                    if args.len() > 1 {
-                        // object.__format__(self, format_spec): the spec must be
-                        // a `str` (a `bytes` spec is rejected like any other
-                        // non-`str`); a non-empty one is unsupported, an empty
-                        // one falls through to `str(self)`.
-                        let spec = crate::type_methods::read_format_spec(
-                            args[1],
-                            "__format__() argument",
-                        )?;
-                        if !spec.is_empty() {
-                            return Err(crate::PyError::type_error(format!(
-                                "unsupported format string passed to {}.__format__",
-                                crate::type_methods::arg_type_name(args[0])
-                            )));
-                        }
+                    crate::type_methods::arity_exact(args, "object.__format__", 1)?;
+                    // object.__format__(self, format_spec): the spec must be
+                    // a `str` (a `bytes` spec is rejected like any other
+                    // non-`str`); a non-empty one is unsupported, an empty
+                    // one falls through to `str(self)`.
+                    let spec =
+                        crate::type_methods::read_format_spec(args[1], "__format__() argument")?;
+                    if !spec.is_empty() {
+                        return Err(crate::PyError::type_error(format!(
+                            "unsupported format string passed to {}.__format__",
+                            crate::type_methods::arg_type_name(args[0])
+                        )));
                     }
                     Ok(pyre_object::w_str_new(&unsafe { crate::py_str(args[0])? }))
                 },
@@ -15163,7 +15195,15 @@ fn init_object_type(ns: PyObjectRef) {
             "__reduce__",
             make_builtin_function_with_arity(
                 "__reduce__",
-                |args| crate::reduce_protocol::descr_reduce(args[0]),
+                |args| {
+                    if args.is_empty() {
+                        return Err(crate::PyError::type_error(
+                            "unbound method object.__reduce__() needs an argument",
+                        ));
+                    }
+                    crate::type_methods::arity_no_args(args, "object.__reduce__")?;
+                    crate::reduce_protocol::descr_reduce(args[0])
+                },
                 1,
             ),
         )
@@ -15175,6 +15215,12 @@ fn init_object_type(ns: PyObjectRef) {
             make_builtin_function_with_arity(
                 "__reduce_ex__",
                 |args| {
+                    if args.is_empty() {
+                        return Err(crate::PyError::type_error(
+                            "unbound method object.__reduce_ex__() needs an argument",
+                        ));
+                    }
+                    crate::type_methods::arity_exact(args, "object.__reduce_ex__", 1)?;
                     let proto = crate::builtins::space_index_w(args[1])?;
                     crate::reduce_protocol::descr_reduce_ex(args[0], proto)
                 },
@@ -15188,7 +15234,15 @@ fn init_object_type(ns: PyObjectRef) {
             "__getstate__",
             make_builtin_function_with_arity(
                 "__getstate__",
-                |args| crate::reduce_protocol::object_getstate_default(args[0]),
+                |args| {
+                    if args.is_empty() {
+                        return Err(crate::PyError::type_error(
+                            "unbound method object.__getstate__() needs an argument",
+                        ));
+                    }
+                    crate::type_methods::arity_no_args(args, "object.__getstate__")?;
+                    crate::reduce_protocol::object_getstate_default(args[0])
+                },
                 1,
             ),
         )
@@ -15200,20 +15254,13 @@ fn init_object_type(ns: PyObjectRef) {
             make_builtin_function_with_arity(
                 "__dir__",
                 |args| {
-                    // `object.__dir__` is a no-extra-arg method: reject a
-                    // missing receiver and any surplus positional.
-                    let Some(&receiver) = args.first() else {
+                    if args.is_empty() {
                         return Err(crate::PyError::type_error(
-                            "unbound method object.__dir__() needs an argument".to_string(),
+                            "unbound method object.__dir__() needs an argument",
                         ));
-                    };
-                    if args.len() > 1 {
-                        return Err(crate::PyError::type_error(format!(
-                            "object.__dir__() takes no arguments ({} given)",
-                            args.len() - 1
-                        )));
                     }
-                    crate::builtins::object_dir_default(receiver)
+                    crate::type_methods::arity_no_args(args, "object.__dir__")?;
+                    crate::builtins::object_dir_default(args[0])
                 },
                 1,
             ),
@@ -15223,7 +15270,19 @@ fn init_object_type(ns: PyObjectRef) {
         pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
             ns,
             "__sizeof__",
-            make_builtin_function_with_arity("__sizeof__", object_descr_sizeof, 1),
+            make_builtin_function_with_arity(
+                "__sizeof__",
+                |args| {
+                    if args.is_empty() {
+                        return Err(crate::PyError::type_error(
+                            "unbound method object.__sizeof__() needs an argument",
+                        ));
+                    }
+                    crate::type_methods::arity_no_args(args, "object.__sizeof__")?;
+                    object_descr_sizeof(args)
+                },
+                1,
+            ),
         )
     };
     // typeobject.py descr___init_subclass__ — the default accepts no

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -14715,6 +14715,27 @@ fn bool_repr(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     Ok(w_str_new(if truthy { "True" } else { "False" }))
 }
 
+/// CPython 3.14 `Objects/boolobject.c:bool_invert`.
+///
+/// The bundled PyPy source inherits `int.__invert__`; Python 3.14 instead
+/// installs a bool-specific number slot solely to issue this deprecation
+/// warning before delegating to the underlying integer inversion.
+fn bool_descr_invert(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    let Some(&w_self) = args.first() else {
+        return Err(crate::PyError::type_error(
+            "descriptor '__invert__' of 'bool' object needs an argument",
+        ));
+    };
+    if !unsafe { pyre_object::is_bool(w_self) } {
+        return Err(crate::PyError::type_error(format!(
+            "descriptor '__invert__' requires a 'bool' object but received a '{}'",
+            crate::baseobjspace::object_functionstr_type_name(w_self),
+        )));
+    }
+    crate::type_methods::arity_slot(args, 0)?;
+    crate::objspace::descroperation::invert(w_self)
+}
+
 fn init_bool_type(ns: PyObjectRef) {
     unsafe {
         pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
@@ -14741,25 +14762,13 @@ fn init_bool_type(ns: PyObjectRef) {
             make_builtin_function("__repr__", bool_repr),
         )
     };
-    // CPython 3.14 gives bool an explicit deprecated `__invert__` wrapper.
-    // It still returns the inversion of the underlying integer (`~True ==
-    // -2`, `~False == -1`); the removal is scheduled for Python 3.16.
+    // CPython 3.14 gives bool an explicit deprecated `__invert__` wrapper;
+    // the bundled PyPy source inherits the int descriptor instead.
     unsafe {
         pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
             ns,
             "__invert__",
-            make_builtin_function_with_arity(
-                "__invert__",
-                |args| {
-                    let value = if crate::baseobjspace::is_true(args[0])? {
-                        1i64
-                    } else {
-                        0i64
-                    };
-                    Ok(w_int_new(!value))
-                },
-                1,
-            ),
+            make_builtin_function("__invert__", bool_descr_invert),
         )
     };
     // boolobject.py:97-106 — bool defines its own bitwise dunders so that

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -3500,6 +3500,11 @@ fn set_alloc_for_class(
             (*obj).w_class = cls;
         }
     }
+    // objspace.py:486 `allocate_instance` registers every freshly allocated
+    // instance whose class carries `hasuserdel`.  Set/frozenset subclasses use
+    // this layout-specific allocator instead of `w_instance_new`, so perform
+    // the same post-allocation step after installing the real subclass.
+    pyre_object::gc_hook::maybe_register_finalizer(obj);
     Ok(obj)
 }
 

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -14604,9 +14604,9 @@ fn int_descr_invert(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError>
         )));
     }
     if unsafe { pyre_object::is_bool(w_self) } {
-        return Ok(w_int_new(
-            !unsafe { crate::objspace::descroperation::int_value(w_self) },
-        ));
+        return Ok(w_int_new(!unsafe {
+            crate::objspace::descroperation::int_value(w_self)
+        }));
     }
     crate::objspace::descroperation::invert(w_self)
 }

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -15056,7 +15056,23 @@ fn init_object_type(ns: PyObjectRef) {
             "__hash__",
             make_builtin_function_with_arity(
                 "__hash__",
-                |args| Ok(default_identity_hash(pyre_object::PY_NULL, args[0])),
+                |args| {
+                    // The fixed arity above is only a fast-dispatch hint; the
+                    // direct path still delivers whatever the caller passed.
+                    if args.len() != 1 {
+                        let message = if args.is_empty() {
+                            "object.__hash__() missing 1 required positional argument: 'obj'"
+                                .to_string()
+                        } else {
+                            format!(
+                                "object.__hash__() takes 1 positional argument but {} were given",
+                                args.len(),
+                            )
+                        };
+                        return Err(crate::PyError::type_error(message));
+                    }
+                    Ok(default_identity_hash(pyre_object::PY_NULL, args[0]))
+                },
                 1,
             ),
         )
@@ -15342,10 +15358,7 @@ fn bytearray_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyErr
     let value = bytearray_descr_new_impl(args)?;
     if let Some(sub) = subclass_to_tag(cls, &pyre_object::bytearrayobject::BYTEARRAY_TYPE)? {
         let data = unsafe { pyre_object::bytesobject::bytes_like_data(value).to_vec() };
-        let fresh = pyre_object::bytearrayobject::w_bytearray_from_bytes(&data);
-        unsafe {
-            (*fresh).w_class = sub;
-        }
+        let fresh = pyre_object::bytearrayobject::w_bytearray_subclass_from_bytes(&data, sub);
         return Ok(fresh);
     }
     Ok(value)
@@ -17456,18 +17469,21 @@ pub(crate) fn bytes_method_hex(args: &[PyObjectRef]) -> Result<PyObjectRef, crat
     // sep validation — must be a length-1 ASCII string or length-1
     // bytes; otherwise ValueError per PyPy.
     let sep_obj = sep_arg.unwrap();
+    // CPython 3.14 `_Py_strhex_impl` deliberately uses `PyObject_Length`
+    // before inspecting the separator payload.  A bytes/str subclass may
+    // therefore run arbitrary `__len__` code here (gh-143195).
+    if crate::baseobjspace::len_w(sep_obj)? != 1 {
+        return Err(crate::PyError::new(
+            crate::PyErrorKind::ValueError,
+            "sep must be length 1.",
+        ));
+    }
     let sep_char: char = if unsafe { pyre_object::is_str(sep_obj) } {
         let s = unsafe { pyre_object::w_str_get_value(sep_obj) };
         let mut chars = s.chars();
         let first = chars.next().ok_or_else(|| {
             crate::PyError::new(crate::PyErrorKind::ValueError, "sep must be length 1.")
         })?;
-        if chars.next().is_some() {
-            return Err(crate::PyError::new(
-                crate::PyErrorKind::ValueError,
-                "sep must be length 1.",
-            ));
-        }
         if (first as u32) >= 0x80 {
             return Err(crate::PyError::new(
                 crate::PyErrorKind::ValueError,
@@ -17477,15 +17493,9 @@ pub(crate) fn bytes_method_hex(args: &[PyObjectRef]) -> Result<PyObjectRef, crat
         first
     } else if unsafe { pyre_object::is_bytes(sep_obj) } {
         let sep_bytes = unsafe { pyre_object::bytesobject::bytes_like_data(sep_obj) };
-        if sep_bytes.len() != 1 {
-            return Err(crate::PyError::new(
-                crate::PyErrorKind::ValueError,
-                "sep must be length 1.",
-            ));
-        }
         sep_bytes[0] as char
     } else {
-        return Err(crate::PyError::type_error("sep must be str or bytes"));
+        return Err(crate::PyError::type_error("sep must be str or bytes."));
     };
     let sep_str = sep_char.to_string();
     // `bytearrayobject.py:680-692` — positive `bytes_per_sep` groups
@@ -18193,10 +18203,7 @@ fn bytes_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> 
         // `bytes(b)` may return the argument unchanged, so rebuild a
         // fresh object before retagging to avoid aliasing the input.
         let data = unsafe { pyre_object::bytesobject::bytes_like_data(value).to_vec() };
-        let fresh = pyre_object::bytesobject::w_bytes_from_bytes(&data);
-        unsafe {
-            (*fresh).w_class = sub;
-        }
+        let fresh = pyre_object::bytesobject::w_bytes_subclass_from_bytes(&data, sub);
         return Ok(fresh);
     }
     Ok(value)

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -17522,7 +17522,6 @@ pub(crate) fn bytes_method_hex(args: &[PyObjectRef]) -> Result<PyObjectRef, crat
     crate::builtins::kwarg_reject_unknown(kwargs, &["sep", "bytes_per_sep"], "hex")?;
     crate::builtins::kwarg_reject_duplicate(kwargs, "hex", "sep", pos.get(1).is_some())?;
     crate::builtins::kwarg_reject_duplicate(kwargs, "hex", "bytes_per_sep", pos.get(2).is_some())?;
-    let data = unsafe { pyre_object::bytesobject::bytes_like_data(pos[0]) };
     // No sep / default grouping — produces "ffff" for [0xff, 0xff].
     // The sep + bytes_per_sep kwargs are deferred until first observed
     // need; CPython callers without args hit the hot path.
@@ -17531,6 +17530,8 @@ pub(crate) fn bytes_method_hex(args: &[PyObjectRef]) -> Result<PyObjectRef, crat
         .copied()
         .or_else(|| crate::builtins::kwarg_get(kwargs, "sep"));
     if sep_arg.is_none() {
+        // Nothing below can run Python code, so the payload is read here.
+        let data = unsafe { pyre_object::bytesobject::bytes_like_data(pos[0]) };
         let mut out = String::with_capacity(data.len() * 2);
         for &b in data {
             out.push_str(&format!("{:02x}", b));
@@ -17543,29 +17544,28 @@ pub(crate) fn bytes_method_hex(args: &[PyObjectRef]) -> Result<PyObjectRef, crat
     let sep_obj = sep_arg.unwrap();
     // CPython 3.14 `_Py_strhex_impl` deliberately uses `PyObject_Length`
     // before inspecting the separator payload.  A bytes/str subclass may
-    // therefore run arbitrary `__len__` code here (gh-143195).
+    // therefore run arbitrary `__len__` code here (gh-143195).  Once it
+    // reports one, the first payload unit is used; an empty payload supplies
+    // the terminating NUL, matching `_PyUnicode_AsUTF8AndSize`/`PyBytes_AS_STRING`.
+    let sep_length_error =
+        || crate::PyError::new(crate::PyErrorKind::ValueError, "sep must be length 1.");
+    let sep_ascii_error =
+        || crate::PyError::new(crate::PyErrorKind::ValueError, "sep must be ASCII.");
     if crate::baseobjspace::len_w(sep_obj)? != 1 {
-        return Err(crate::PyError::new(
-            crate::PyErrorKind::ValueError,
-            "sep must be length 1.",
-        ));
+        return Err(sep_length_error());
     }
     let sep_char: char = if unsafe { pyre_object::is_str(sep_obj) } {
         let s = unsafe { pyre_object::w_str_get_value(sep_obj) };
-        let mut chars = s.chars();
-        let first = chars.next().ok_or_else(|| {
-            crate::PyError::new(crate::PyErrorKind::ValueError, "sep must be length 1.")
-        })?;
-        if (first as u32) >= 0x80 {
-            return Err(crate::PyError::new(
-                crate::PyErrorKind::ValueError,
-                "sep must be ASCII.",
-            ));
+        if !s.is_ascii() {
+            return Err(sep_ascii_error());
         }
-        first
+        s.chars().next().unwrap_or('\0')
     } else if unsafe { pyre_object::is_bytes(sep_obj) } {
         let sep_bytes = unsafe { pyre_object::bytesobject::bytes_like_data(sep_obj) };
-        sep_bytes[0] as char
+        if !sep_bytes.is_ascii() {
+            return Err(sep_ascii_error());
+        }
+        sep_bytes.first().copied().unwrap_or(0) as char
     } else {
         return Err(crate::PyError::type_error("sep must be str or bytes."));
     };
@@ -17583,6 +17583,10 @@ pub(crate) fn bytes_method_hex(args: &[PyObjectRef]) -> Result<PyObjectRef, crat
     };
     let group = raw_group.unsigned_abs() as usize;
     let group_from_left = raw_group < 0;
+    // Read the payload only now: `bytes_per_sep` coercion above can run
+    // `__index__`, which may clear or resize a bytearray receiver and
+    // leave any slice taken earlier describing a stale length.
+    let data = unsafe { pyre_object::bytesobject::bytes_like_data(pos[0]) };
     let mut out = String::with_capacity(data.len() * 2 + data.len());
     for (i, b) in data.iter().enumerate() {
         if i > 0 && group != 0 {

--- a/pyre/pyre-interpreter/src/warn.rs
+++ b/pyre/pyre-interpreter/src/warn.rs
@@ -8,13 +8,13 @@
 /// _warnings C-extension module (not yet ported).
 
 /// baseobjspace.py:2087: space.warn(space.newtext(msg), space.w_DeprecationWarning)
-pub fn warn_deprecation(msg: &str) {
+pub fn warn_deprecation(msg: &str) -> Result<(), crate::PyError> {
     if let (Some(warnings), Some(category)) = (
         crate::importing::get_sys_module("warnings"),
         crate::builtins::lookup_exc_class("DeprecationWarning"),
     ) {
         if let Ok(warn_fn) = crate::baseobjspace::getattr_str(warnings, "warn") {
-            if crate::call::call_function_impl_result(
+            crate::call::call_function_impl_result(
                 warn_fn,
                 &[
                     pyre_object::w_str_new(msg),
@@ -22,13 +22,12 @@ pub fn warn_deprecation(msg: &str) {
                     pyre_object::w_int_new(2),
                 ],
             )
-            .is_ok()
-            {
-                return;
-            }
+            .map(|_| ())?;
+            return Ok(());
         }
     }
     warn(msg, "DeprecationWarning");
+    Ok(())
 }
 
 /// baseobjspace.py:2087-2093

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -4959,17 +4959,20 @@ pub extern "C" fn bh_import_from_fn(module: i64, w_code_ptr: i64, name_idx: i64)
 
 /// LOAD_SUPER_ATTR residual (`load_super_attr` HLOp → `residual_call_ir_r`).
 /// Resolves the attribute name from the jitcode's code object via `name_idx`
-/// (same `co_names` invariant as `bh_load_attr_fn`), builds the `super(cls,
-/// self)` proxy, and runs `getattr` (a descriptor `__get__` may run Python →
-/// `MayForce`).  Returns the raw resolved attribute; the `is_method` form
+/// (same `co_names` invariant as `bh_load_attr_fn`), calls the actual global
+/// `super` value with zero or two arguments, and runs `getattr` (both calls may
+/// run Python → `MayForce`). Returns the raw resolved attribute; the
+/// `is_method` form
 /// post-processes it through [`bh_super_attr_unwrap_fn`].  On error the
 /// exception is published through `BH_LAST_EXC_VALUE` for the trailing
 /// `GuardNoException` and the call returns 0.
 pub extern "C" fn bh_load_super_attr_fn(
+    global_super: i64,
     self_obj: i64,
     cls: i64,
     w_code_ptr: i64,
     name_idx: i64,
+    is_two_arg: i64,
 ) -> i64 {
     let w_code = w_code_ptr as pyre_object::PyObjectRef;
     let code = unsafe {
@@ -4985,11 +4988,16 @@ pub extern "C" fn bh_load_super_attr_fn(
         return 0;
     }
     let name = code.names[idx].as_ref();
-    let proxy = pyre_object::descriptor::w_super_new(
-        cls as pyre_object::PyObjectRef,
-        self_obj as pyre_object::PyObjectRef,
-    );
-    match pyre_interpreter::baseobjspace::getattr_str(proxy, name) {
+    let global_super = global_super as pyre_object::PyObjectRef;
+    let self_obj = self_obj as pyre_object::PyObjectRef;
+    let cls = cls as pyre_object::PyObjectRef;
+    let proxy = if is_two_arg != 0 {
+        pyre_interpreter::call::call_function_impl_result(global_super, &[cls, self_obj])
+    } else {
+        pyre_interpreter::call::call_function_impl_result(global_super, &[])
+    };
+    let result = proxy.and_then(|proxy| pyre_interpreter::baseobjspace::getattr_str(proxy, name));
+    match result {
         Ok(result) => result as i64,
         Err(mut err) => {
             let exc_obj = err.to_exc_object();

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -499,20 +499,26 @@ unsafe fn dict_object_custom_trace(obj_addr: usize, f: &mut dyn FnMut(*mut majit
 /// the guard skips it.
 unsafe fn bytes_object_custom_trace(obj_addr: usize, f: &mut dyn FnMut(*mut majit_ir::GcRef)) {
     let bytes = unsafe { &mut *(obj_addr as *mut pyre_object::bytesobject::W_BytesObject) };
+    f(&mut bytes.ob_header.w_class as *mut pyre_object::PyObjectRef as *mut majit_ir::GcRef);
     if !bytes.data.is_null() && pyre_object::gc_hook::try_gc_owns_object(bytes.data as *mut u8) {
         let data_slot = std::ptr::addr_of_mut!(bytes.data);
         f(data_slot as *mut majit_ir::GcRef);
     }
+    f(&mut bytes.w_dict as *mut pyre_object::PyObjectRef as *mut majit_ir::GcRef);
+    f(&mut bytes.w_weakreflifeline as *mut pyre_object::PyObjectRef as *mut majit_ir::GcRef);
 }
 
 /// Custom trace for `W_BytearrayObject`. Same GC-managed leaf storage box as
 /// `W_BytesObject` (off-GC storage epic S4).
 unsafe fn bytearray_object_custom_trace(obj_addr: usize, f: &mut dyn FnMut(*mut majit_ir::GcRef)) {
     let ba = unsafe { &mut *(obj_addr as *mut pyre_object::bytearrayobject::W_BytearrayObject) };
+    f(&mut ba.ob_header.w_class as *mut pyre_object::PyObjectRef as *mut majit_ir::GcRef);
     if !ba.data.is_null() && pyre_object::gc_hook::try_gc_owns_object(ba.data as *mut u8) {
         let data_slot = std::ptr::addr_of_mut!(ba.data);
         f(data_slot as *mut majit_ir::GcRef);
     }
+    f(&mut ba.w_dict as *mut pyre_object::PyObjectRef as *mut majit_ir::GcRef);
+    f(&mut ba.w_weakreflifeline as *mut pyre_object::PyObjectRef as *mut majit_ir::GcRef);
 }
 
 /// Custom trace for `W_ObjectObject` (instance `map`+`storage`,
@@ -826,34 +832,6 @@ unsafe fn memoryview_object_custom_trace(obj_addr: usize, f: &mut dyn FnMut(*mut
         return;
     }
     trace_bufferview(unsafe { &mut *view_ptr }, f);
-}
-
-/// W_BytesObject's mapdict SPECIAL slots for user subclasses.  Exact bytes
-/// leave both null, while subclass instances are managed and cycle-visible.
-unsafe fn bytes_object_custom_trace(obj_addr: usize, f: &mut dyn FnMut(*mut majit_ir::GcRef)) {
-    let bytes = obj_addr as *mut pyre_object::bytesobject::W_BytesObject;
-    f(
-        unsafe { &mut (*bytes).ob_header.w_class } as *mut pyre_object::PyObjectRef
-            as *mut majit_ir::GcRef,
-    );
-    f(unsafe { &mut (*bytes).w_dict } as *mut pyre_object::PyObjectRef as *mut majit_ir::GcRef);
-    f(
-        unsafe { &mut (*bytes).w_weakreflifeline } as *mut pyre_object::PyObjectRef
-            as *mut majit_ir::GcRef,
-    );
-}
-
-unsafe fn bytearray_object_custom_trace(obj_addr: usize, f: &mut dyn FnMut(*mut majit_ir::GcRef)) {
-    let bytes = obj_addr as *mut pyre_object::bytearrayobject::W_BytearrayObject;
-    f(
-        unsafe { &mut (*bytes).ob_header.w_class } as *mut pyre_object::PyObjectRef
-            as *mut majit_ir::GcRef,
-    );
-    f(unsafe { &mut (*bytes).w_dict } as *mut pyre_object::PyObjectRef as *mut majit_ir::GcRef);
-    f(
-        unsafe { &mut (*bytes).w_weakreflifeline } as *mut pyre_object::PyObjectRef
-            as *mut majit_ir::GcRef,
-    );
 }
 
 /// Reclaim the off-heap `BufferView` box (and any nested `Buffer::Sub`

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -812,12 +812,48 @@ fn trace_bufferview(
 }
 
 unsafe fn memoryview_object_custom_trace(obj_addr: usize, f: &mut dyn FnMut(*mut majit_ir::GcRef)) {
-    let mv = obj_addr as *const pyre_object::memoryview::W_MemoryView;
+    let mv = obj_addr as *mut pyre_object::memoryview::W_MemoryView;
+    f(unsafe { &mut (*mv).ob.w_class } as *mut pyre_object::PyObjectRef as *mut majit_ir::GcRef);
+    // memoryobject.py's make_weakref_descr(W_MemoryView) stores the lifeline
+    // inline on the view.  A custom trace replaces fixed-offset tracing, so
+    // forward that field explicitly before walking the off-heap BufferView.
+    f(
+        unsafe { &mut (*mv).w_weakreflifeline } as *mut pyre_object::PyObjectRef
+            as *mut majit_ir::GcRef,
+    );
     let view_ptr = unsafe { (*mv).view } as *mut pyre_object::bufferview::BufferView;
     if view_ptr.is_null() {
         return;
     }
     trace_bufferview(unsafe { &mut *view_ptr }, f);
+}
+
+/// W_BytesObject's mapdict SPECIAL slots for user subclasses.  Exact bytes
+/// leave both null, while subclass instances are managed and cycle-visible.
+unsafe fn bytes_object_custom_trace(obj_addr: usize, f: &mut dyn FnMut(*mut majit_ir::GcRef)) {
+    let bytes = obj_addr as *mut pyre_object::bytesobject::W_BytesObject;
+    f(
+        unsafe { &mut (*bytes).ob_header.w_class } as *mut pyre_object::PyObjectRef
+            as *mut majit_ir::GcRef,
+    );
+    f(unsafe { &mut (*bytes).w_dict } as *mut pyre_object::PyObjectRef as *mut majit_ir::GcRef);
+    f(
+        unsafe { &mut (*bytes).w_weakreflifeline } as *mut pyre_object::PyObjectRef
+            as *mut majit_ir::GcRef,
+    );
+}
+
+unsafe fn bytearray_object_custom_trace(obj_addr: usize, f: &mut dyn FnMut(*mut majit_ir::GcRef)) {
+    let bytes = obj_addr as *mut pyre_object::bytearrayobject::W_BytearrayObject;
+    f(
+        unsafe { &mut (*bytes).ob_header.w_class } as *mut pyre_object::PyObjectRef
+            as *mut majit_ir::GcRef,
+    );
+    f(unsafe { &mut (*bytes).w_dict } as *mut pyre_object::PyObjectRef as *mut majit_ir::GcRef);
+    f(
+        unsafe { &mut (*bytes).w_weakreflifeline } as *mut pyre_object::PyObjectRef
+            as *mut majit_ir::GcRef,
+    );
 }
 
 /// Reclaim the off-heap `BufferView` box (and any nested `Buffer::Sub`

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -2744,15 +2744,11 @@ fn build_gc() -> Box<dyn majit_gc::GcAllocator> {
         );
         pytype_to_tid.insert(tp as *const _ as usize, w_dict_view_iterator_tid);
     }
-    // `collections.deque` W_Deque — AUTO-ID typed payload allocated via
-    // `allocate_stable` (GC-managed old-gen).  Managed only means the marker
-    // *scans* it; tracing its `data` backing list still needs a registered tid
-    // + offsets.  Unregistered, its cell stays UNASSIGNED and
-    // `malloc_typed_stable` stamps tid 0 (= `object`: empty offsets, no custom
-    // trace), so the marker forwards none of its children and `data` is swept
-    // while the deque is live — use-after-free on the next `len`/index/iterate.
-    // Register at the absolute tail like the auto-id iterators above so no
-    // earlier fixed slot shifts.
+    // `interp_deque.py Block` and `W_Deque` — AUTO-ID typed payloads allocated
+    // via `allocate_stable` (GC-managed old-gen).  The block marker follows
+    // both links and its 62-slot list; the deque marker follows its two
+    // endpoint blocks.  Register at the absolute tail like the auto-id
+    // iterators above so no earlier fixed slot shifts.
     register_pyre_class(
         &mut gc,
         &mut pytype_to_tid,
@@ -2852,6 +2848,19 @@ fn build_gc() -> Box<dyn majit_gc::GcAllocator> {
         <pyre_interpreter::module::_tokenize::W_TokenizerIter
             as pyre_object::lltype::PyreClassPyTypeOf>::DESCRIPTOR,
     );
+    // A Block is GC-managed but is not an rclass.OBJECT subclass and has no
+    // Python-visible vtable.  Registering it through `register_pyre_class`
+    // would add a spurious subclass-range alias and shift W_Deque's canonical
+    // object type id.  PyPy likewise treats Block as the deque's internal
+    // storage node, not as an exposed Python class.
+    let deque_block_descr =
+        <pyre_interpreter::module::_collections::deque_block::W_DequeBlock
+            as pyre_object::lltype::PyreClassPyTypeOf>::DESCRIPTOR;
+    let deque_block_tid = gc.register_type(TypeInfo::with_gc_ptrs(
+        deque_block_descr.object_size,
+        deque_block_descr.ptr_offsets.to_vec(),
+    ));
+    deque_block_descr.gc_type_id.set(deque_block_tid);
     // ── GC-root registration completeness oracle ─────────────────────────
     // Every `#[pyre_class]` type appends its descriptor to the whole-program
     // `PYRE_CLASS_DESCRIPTORS` slice.  A type with inline managed children

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -2963,10 +2963,12 @@ fn emit_frontend_import_from(
 fn emit_frontend_load_super_attr(
     graph: &mut super::flow::FunctionGraph,
     block: &super::flow::BlockRef,
+    global_super: super::flow::FlowValue,
     self_value: super::flow::FlowValue,
     cls_value: super::flow::FlowValue,
     code: super::flow::FlowValue,
     name_idx: super::flow::FlowValue,
+    is_two_arg: super::flow::FlowValue,
     offset: i64,
 ) -> super::flow::Variable {
     emit_graph_op_with_result(
@@ -2974,10 +2976,12 @@ fn emit_frontend_load_super_attr(
         block,
         "load_super_attr",
         vec![
+            global_super.into(),
             self_value.into(),
             cls_value.into(),
             code.into(),
             name_idx.into(),
+            is_two_arg.into(),
         ],
         Kind::Ref,
         offset,
@@ -11126,12 +11130,14 @@ impl CodeWriter {
                         // global_super=TOS2). is_method=false → pushes 1
                         // (result). Net: -2.  is_method=true → pushes 2 (func,
                         // self_or_null). Net: -1.  `oparg >> 2` is the co_names
-                        // index, `oparg & 1` the is_method flag (both
-                        // compile-time constants).  `load_super_attr(self, cls,
-                        // code, name_idx)` HLOp →
-                        // `residual_call_ir_r(load_super_attr_fn, ListI[name_idx],
-                        // ListR[self, cls, code])` resolves `getattr(super(cls,
-                        // self), name)` (MayForce).  The is_method form runs the
+                        // index, `oparg & 1` the is_method flag, and `oparg & 2`
+                        // the two-argument-super flag (all compile-time
+                        // constants). `load_super_attr(global_super, self, cls,
+                        // code, name_idx, is_two_arg)` HLOp →
+                        // `residual_call_ir_r(load_super_attr_fn,
+                        // ListI[name_idx, is_two_arg], ListR[global_super,
+                        // self, cls, code])` calls the actual global value and
+                        // resolves the attribute (MayForce). The is_method form runs the
                         // runtime bound-method unwrap through two pure
                         // `super_attr_unwrap(raw, which)` residuals (which 0 =
                         // func slot, 1 = self slot), mirroring the LOAD_ATTR
@@ -11139,6 +11145,7 @@ impl CodeWriter {
                         Instruction::LoadSuperAttr { .. } => {
                             let name_idx = (u32::from(op_arg) >> 2) as usize;
                             let is_method = (u32::from(op_arg) & 1) != 0;
+                            let is_two_arg = (u32::from(op_arg) & 2) != 0;
                             let code_const: super::flow::FlowValue = super::flow::Constant::new(
                                 super::flow::ConstantValue::Signed(w_code as i64),
                                 Some(Kind::Ref),
@@ -11146,19 +11153,23 @@ impl CodeWriter {
                             .into();
                             let name_idx_const: super::flow::FlowValue =
                                 super::flow::Constant::signed(name_idx as i64).into();
+                            let is_two_arg_const: super::flow::FlowValue =
+                                super::flow::Constant::signed(is_two_arg as i64).into();
                             let _ = emit_popvalue_ref!(current_depth, py_pc);
                             let self_value = pop_ref_or_fresh(&mut current_state, &mut graph);
                             let _ = emit_popvalue_ref!(current_depth, py_pc);
                             let cls_value = pop_ref_or_fresh(&mut current_state, &mut graph);
                             let _ = emit_popvalue_ref!(current_depth, py_pc);
-                            let _global_super = pop_ref_or_fresh(&mut current_state, &mut graph);
+                            let global_super = pop_ref_or_fresh(&mut current_state, &mut graph);
                             let raw_value = emit_frontend_load_super_attr(
                                 &mut graph,
                                 &current_block.block(),
+                                global_super,
                                 self_value,
                                 cls_value,
                                 code_const,
                                 name_idx_const,
+                                is_two_arg_const,
                                 py_pc as i64,
                             );
                             if is_method {

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -6984,6 +6984,18 @@ impl CodeWriter {
                         restore_canraise_exit_order(&current_block.block());
                     }
                     merged
+                } else if current_block
+                    .framestate()
+                    .is_some_and(|state| state.next_offset == py_pc)
+                {
+                    // `flowcontext.py:399-416 build_flow` pops a concrete
+                    // SpamBlock and records that exact block.  A PC may have
+                    // several union-incompatible joinpoint candidates; a
+                    // later candidate is then at the head of `joinpoints`,
+                    // but it must not replace the block just popped from
+                    // `pendingblocks`.  Preserve the pending block identity
+                    // at its entry PC, matching `record_block(block)`.
+                    current_block.clone()
                 } else if let Some(target) = joinpoints
                     .get(&py_pc)
                     .and_then(|blocks| blocks.iter().find(|b| !b.dead()))

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -11794,20 +11794,40 @@ impl CodeWriter {
                         // mirroring the STORE_FAST shadow write.
                         Instruction::StoreDeref { i } => {
                             let idx = i.get(op_arg).as_usize() as u16;
-                            emit_load_fast_ref!(current_depth, idx, py_pc);
-                            let _cell_reg = emit_popvalue_ref!(current_depth, py_pc);
-                            let cell_value = pop_ref_or_fresh(&mut current_state, &mut graph);
-                            let _value_reg = emit_popvalue_ref!(current_depth, py_pc);
-                            let value_value = pop_ref_or_fresh(&mut current_state, &mut graph);
-                            let result_value = emit_graph_op_with_result(
-                                &mut graph,
-                                &current_block.block(),
-                                "store_deref_value",
-                                vec![cell_value.into(), value_value.into()],
-                                Kind::Ref,
-                                py_pc as i64,
-                            );
-                            {
+                            // CPython 3.14 emits STORE_NAME for an explicit
+                            // class-body `__class__` binding.  Normalize the
+                            // pinned compiler's STORE_DEREF exactly as the
+                            // interpreter opcode boundary does, preserving the
+                            // distinct implicit cell filled by type.__new__.
+                            if pyre_interpreter::pyframe::class_scope_class_deref_is_name(
+                                code,
+                                idx as usize,
+                            ) {
+                                let _value_reg = emit_popvalue_ref!(current_depth, py_pc);
+                                let value_value = pop_ref_or_fresh(&mut current_state, &mut graph);
+                                let name = super::flow::Constant::string("__class__");
+                                emit_frontend_store_name(
+                                    &mut graph,
+                                    &current_block.block(),
+                                    frame_var.into(),
+                                    name.into(),
+                                    value_value,
+                                    py_pc as i64,
+                                );
+                            } else {
+                                emit_load_fast_ref!(current_depth, idx, py_pc);
+                                let _cell_reg = emit_popvalue_ref!(current_depth, py_pc);
+                                let cell_value = pop_ref_or_fresh(&mut current_state, &mut graph);
+                                let _value_reg = emit_popvalue_ref!(current_depth, py_pc);
+                                let value_value = pop_ref_or_fresh(&mut current_state, &mut graph);
+                                let result_value = emit_graph_op_with_result(
+                                    &mut graph,
+                                    &current_block.block(),
+                                    "store_deref_value",
+                                    vec![cell_value.into(), value_value.into()],
+                                    Kind::Ref,
+                                    py_pc as i64,
+                                );
                                 let local_slot = local_to_vable_slot(idx as usize) as i64;
                                 let v_idx: super::flow::FlowValue =
                                     super::flow::Constant::signed(local_slot).into();
@@ -11822,8 +11842,8 @@ impl CodeWriter {
                                     None,
                                     py_pc as i64,
                                 );
+                                current_state.store_local_value(idx as usize, result_value.into());
                             }
-                            current_state.store_local_value(idx as usize, result_value.into());
                         }
 
                         // MAKE_CELL: wraps the slot value in a cell. Touches
@@ -12079,51 +12099,63 @@ impl CodeWriter {
                         // that they are bound (pyopcode.py:597 DELETE_DEREF).
                         Instruction::DeleteDeref { i } => {
                             let idx = i.get(op_arg).as_usize() as u16;
-                            let code_const: super::flow::FlowValue = super::flow::Constant::new(
-                                super::flow::ConstantValue::Signed(w_code as i64),
-                                Some(Kind::Ref),
-                            )
-                            .into();
-                            let deref_idx_const: super::flow::FlowValue =
-                                super::flow::Constant::signed(idx as i64).into();
-                            emit_load_fast_ref!(current_depth, idx, py_pc);
-                            let _cell_reg = emit_popvalue_ref!(current_depth, py_pc);
-                            let cell_value = pop_ref_or_fresh(&mut current_state, &mut graph);
-                            let _checked = emit_graph_op_with_result(
-                                &mut graph,
-                                &current_block.block(),
-                                "load_deref_value",
-                                vec![
-                                    cell_value.clone().into(),
-                                    code_const.into(),
-                                    deref_idx_const.into(),
-                                ],
-                                Kind::Ref,
-                                py_pc as i64,
-                            );
-                            let result_value = emit_graph_op_with_result(
-                                &mut graph,
-                                &current_block.block(),
-                                "store_deref_value",
-                                vec![cell_value.into(), super::flow::Constant::none().into()],
-                                Kind::Ref,
-                                py_pc as i64,
-                            );
-                            let local_slot = local_to_vable_slot(idx as usize) as i64;
-                            let v_idx: super::flow::FlowValue =
-                                super::flow::Constant::signed(local_slot).into();
-                            record_graph_op(
-                                &current_block.block(),
-                                "setarrayitem_vable_r",
-                                vable_setarrayitem_ref_graph_args(
-                                    frame_var.into(),
-                                    v_idx.into(),
-                                    super::flow::FlowValue::from(result_value).into(),
-                                ),
-                                None,
-                                py_pc as i64,
-                            );
-                            current_state.store_local_value(idx as usize, result_value.into());
+                            if pyre_interpreter::pyframe::class_scope_class_deref_is_name(
+                                code,
+                                idx as usize,
+                            ) {
+                                // DELETE_NAME already forms a permanent trace
+                                // boundary.  Resume this compiler-normalized
+                                // case in the interpreter with the namespace
+                                // and operand stack untouched.
+                                emit_abort_permanent!(py_pc);
+                            } else {
+                                let code_const: super::flow::FlowValue =
+                                    super::flow::Constant::new(
+                                        super::flow::ConstantValue::Signed(w_code as i64),
+                                        Some(Kind::Ref),
+                                    )
+                                    .into();
+                                let deref_idx_const: super::flow::FlowValue =
+                                    super::flow::Constant::signed(idx as i64).into();
+                                emit_load_fast_ref!(current_depth, idx, py_pc);
+                                let _cell_reg = emit_popvalue_ref!(current_depth, py_pc);
+                                let cell_value = pop_ref_or_fresh(&mut current_state, &mut graph);
+                                let _checked = emit_graph_op_with_result(
+                                    &mut graph,
+                                    &current_block.block(),
+                                    "load_deref_value",
+                                    vec![
+                                        cell_value.clone().into(),
+                                        code_const.into(),
+                                        deref_idx_const.into(),
+                                    ],
+                                    Kind::Ref,
+                                    py_pc as i64,
+                                );
+                                let result_value = emit_graph_op_with_result(
+                                    &mut graph,
+                                    &current_block.block(),
+                                    "store_deref_value",
+                                    vec![cell_value.into(), super::flow::Constant::none().into()],
+                                    Kind::Ref,
+                                    py_pc as i64,
+                                );
+                                let local_slot = local_to_vable_slot(idx as usize) as i64;
+                                let v_idx: super::flow::FlowValue =
+                                    super::flow::Constant::signed(local_slot).into();
+                                record_graph_op(
+                                    &current_block.block(),
+                                    "setarrayitem_vable_r",
+                                    vable_setarrayitem_ref_graph_args(
+                                        frame_var.into(),
+                                        v_idx.into(),
+                                        super::flow::FlowValue::from(result_value).into(),
+                                    ),
+                                    None,
+                                    py_pc as i64,
+                                );
+                                current_state.store_local_value(idx as usize, result_value.into());
+                            }
                         }
 
                         // Instructions that don't touch the operand stack (locals/cells only).

--- a/pyre/pyre-jit/src/jit/cpu.rs
+++ b/pyre/pyre-jit/src/jit/cpu.rs
@@ -215,10 +215,10 @@ pub struct Cpu {
     /// submodule-import fallback that may run module top-level Python →
     /// fallible) through the TLS-pinned execution context.
     pub import_from_fn: extern "C" fn(i64, i64, i64) -> i64,
-    /// `bh_load_super_attr_fn(self, cls, code, name_idx)` — LOAD_SUPER_ATTR
-    /// `getattr(super(cls, self), name)` residual (descriptor `__get__` may
-    /// run Python → fallible).
-    pub load_super_attr_fn: extern "C" fn(i64, i64, i64, i64) -> i64,
+    /// `bh_load_super_attr_fn(global_super, self, cls, code, name_idx,
+    /// is_two_arg)` — LOAD_SUPER_ATTR residual. Calls the actual global
+    /// callable with zero or two args, then resolves the attribute.
+    pub load_super_attr_fn: extern "C" fn(i64, i64, i64, i64, i64, i64) -> i64,
     /// `bh_super_attr_unwrap_fn(raw, which)` — LOAD_SUPER_ATTR method-form
     /// unwrap (`which` 0 = func slot, 1 = self slot); pure / infallible.
     pub super_attr_unwrap_fn: extern "C" fn(i64, i64) -> i64,

--- a/pyre/pyre-jit/src/jit/flatten.rs
+++ b/pyre/pyre-jit/src/jit/flatten.rs
@@ -3405,10 +3405,11 @@ pub struct LoweringContext {
     /// Python → `MayForce`).
     pub import_from_fn_idx: u16,
     /// `load_super_attr_fn` descrs-pool index.  LOAD_SUPER_ATTR records the
-    /// `load_super_attr(self, cls, code, name_idx)` HLOp lowered to
-    /// `residual_call_ir_r(ConstInt(fn_idx), ListI([name_idx]), ListR([self,
-    /// cls, code]), Descr) → reg` via [`lower_load_super_attr_hlop_to_insn`];
-    /// `bh_load_super_attr_fn` resolves `getattr(super(cls, self), name)`
+    /// `load_super_attr(global_super, self, cls, code, name_idx, is_two_arg)`
+    /// HLOp lowered to `residual_call_ir_r(ConstInt(fn_idx), ListI([name_idx,
+    /// is_two_arg]), ListR([global_super, self, cls, code]), Descr) → reg` via
+    /// [`lower_load_super_attr_hlop_to_insn`]; `bh_load_super_attr_fn` calls
+    /// the actual global `super` value, then resolves the attribute
     /// (descriptor `__get__` may run → `MayForce`).
     pub load_super_attr_fn_idx: u16,
     /// `super_attr_unwrap_fn` descrs-pool index.  The LOAD_SUPER_ATTR
@@ -6327,12 +6328,13 @@ where
     ))
 }
 
-/// Lower the LOAD_SUPER_ATTR pyre HLOp `load_super_attr(self, cls, code,
-/// name_idx)` → `result: Ref` to `residual_call_ir_r(ConstInt(
-/// load_super_attr_fn_idx), ListI([name_idx]), ListR([self, cls, code]),
-/// Descr) → reg` — the same three-Ref shape as IMPORT_NAME.
-/// `bh_load_super_attr_fn` resolves `getattr(super(cls, self), name)`
-/// (descriptor `__get__` may run → `MayForce`).
+/// Lower the LOAD_SUPER_ATTR pyre HLOp `load_super_attr(global_super, self,
+/// cls, code, name_idx, is_two_arg)` → `result: Ref` to
+/// `residual_call_ir_r(ConstInt(load_super_attr_fn_idx),
+/// ListI([name_idx, is_two_arg]), ListR([global_super, self, cls, code]),
+/// Descr) → reg`. `bh_load_super_attr_fn` calls the actual global `super`
+/// value with zero or two arguments, then resolves the attribute (descriptor
+/// `__get__` may run → `MayForce`).
 ///
 /// Returns `None` for non-`load_super_attr` opnames so the caller can fall
 /// through to other lowering arms.
@@ -6346,13 +6348,15 @@ where
     F: FnMut(super::flow::Variable) -> Register,
     LC: FnMut(&Constant) -> Operand,
 {
-    if op.opname != "load_super_attr" || op.args.len() != 4 {
+    if op.opname != "load_super_attr" || op.args.len() != 6 {
         return None;
     }
-    let self_obj = operand_for_value_arg(&op.args[0], get_register, lower_constant)?;
-    let cls = operand_for_value_arg(&op.args[1], get_register, lower_constant)?;
-    let code = operand_for_value_arg(&op.args[2], get_register, lower_constant)?;
-    let name_idx = const_int_for_value_arg(&op.args[3])?;
+    let global_super = operand_for_value_arg(&op.args[0], get_register, lower_constant)?;
+    let self_obj = operand_for_value_arg(&op.args[1], get_register, lower_constant)?;
+    let cls = operand_for_value_arg(&op.args[2], get_register, lower_constant)?;
+    let code = operand_for_value_arg(&op.args[3], get_register, lower_constant)?;
+    let name_idx = const_int_for_value_arg(&op.args[4])?;
+    let is_two_arg = const_int_for_value_arg(&op.args[5])?;
     let dst_reg = match &op.result {
         Some(super::flow::FlowValue::Variable(var)) => get_register(*var),
         _ => return None,
@@ -6360,7 +6364,14 @@ where
     let effect_info = effect_info_for_call_flavor(CallFlavor::MayForce);
     let descr_operand = Operand::descr(DescrOperand::CallDescrStub(CallDescrStub {
         effect_info,
-        arg_kinds: vec![Kind::Ref, Kind::Ref, Kind::Ref, Kind::Int],
+        arg_kinds: vec![
+            Kind::Ref,
+            Kind::Ref,
+            Kind::Ref,
+            Kind::Ref,
+            Kind::Int,
+            Kind::Int,
+        ],
         result_kind: Some(Kind::Ref),
     }));
     Some(Insn::op_with_result(
@@ -6369,9 +6380,12 @@ where
             Operand::ConstInt(ctx.load_super_attr_fn_idx as i64),
             Operand::ListOfKind(ListOfKind::new(
                 Kind::Int,
-                vec![Operand::ConstInt(name_idx)],
+                vec![Operand::ConstInt(name_idx), Operand::ConstInt(is_two_arg)],
             )),
-            Operand::ListOfKind(ListOfKind::new(Kind::Ref, vec![self_obj, cls, code])),
+            Operand::ListOfKind(ListOfKind::new(
+                Kind::Ref,
+                vec![global_super, self_obj, cls, code],
+            )),
             descr_operand,
         ],
         dst_reg,
@@ -13161,11 +13175,13 @@ mod tests {
 
     #[test]
     fn lower_load_super_attr_hlop_emits_load_super_attr_fn_residual() {
-        // `load_super_attr(self, cls, code, name_idx)` →
+        // `load_super_attr(global_super, self, cls, code, name_idx,
+        // is_two_arg)` →
         // `residual_call_ir_r(ConstInt(load_super_attr_fn_idx),
-        // ListI([name_idx]), ListR([self, cls, code]), Descr) → reg`
-        // (MayForce — descriptor `__get__` may run).  Same three-Ref shape
-        // as IMPORT_NAME.
+        // ListI([name_idx, is_two_arg]), ListR([global_super, self, cls,
+        // code]), Descr) → reg` (MayForce — calling the global and descriptor
+        // `__get__` may run).
+        let global_super_var = Variable::new(VariableId(7), Kind::Ref);
         let self_var = Variable::new(VariableId(8), Kind::Ref);
         let cls_var = Variable::new(VariableId(10), Kind::Ref);
         let result_var = Variable::new(VariableId(9), Kind::Ref);
@@ -13173,15 +13189,21 @@ mod tests {
         let op = super::super::flow::SpaceOperation::new(
             "load_super_attr",
             vec![
+                global_super_var.into(),
                 self_var.into(),
                 cls_var.into(),
                 code_const.into(),
                 name_idx_const.into(),
+                Constant::signed(1).into(),
             ],
             Some(result_var.into()),
             0,
         );
         let mut get_register = |var: Variable| match var.id {
+            VariableId(7) => Register {
+                kind: Kind::Ref,
+                index: 100,
+            },
             VariableId(8) => Register {
                 kind: Kind::Ref,
                 index: 101,
@@ -13203,7 +13225,7 @@ mod tests {
             &mut get_register,
             &mut lower_constant,
         )
-        .expect("4-arg load_super_attr lowering must succeed");
+        .expect("6-arg load_super_attr lowering must succeed");
         match insn {
             Insn::Op {
                 opname,
@@ -13220,8 +13242,11 @@ mod tests {
                     Operand::ListOfKind(list) => {
                         assert_eq!(list.kind, Kind::Int);
                         assert!(
-                            matches!(&list.content[..], [Operand::ConstInt(5)]),
-                            "ListI = [name_idx], got {:?}",
+                            matches!(
+                                &list.content[..],
+                                [Operand::ConstInt(5), Operand::ConstInt(1)]
+                            ),
+                            "ListI = [name_idx, is_two_arg], got {:?}",
                             list.content
                         );
                     }
@@ -13232,15 +13257,22 @@ mod tests {
                         assert_eq!(list.kind, Kind::Ref);
                         match &list.content[..] {
                             [
+                                Operand::Register(g),
                                 Operand::Register(s),
                                 Operand::Register(c),
                                 Operand::ConstRef(0x2000),
                             ] => {
-                                assert_eq!(s.index, 101, "leading Ref operand must be self");
-                                assert_eq!(c.index, 103, "second Ref operand must be cls");
+                                assert_eq!(
+                                    g.index, 100,
+                                    "leading Ref operand must be global_super"
+                                );
+                                assert_eq!(s.index, 101, "second Ref operand must be self");
+                                assert_eq!(c.index, 103, "third Ref operand must be cls");
                             }
                             other => {
-                                panic!("ListR must be [self, cls, code], got {other:?}")
+                                panic!(
+                                    "ListR must be [global_super, self, cls, code], got {other:?}"
+                                )
                             }
                         }
                     }

--- a/pyre/pyre-macros/src/lib.rs
+++ b/pyre/pyre-macros/src/lib.rs
@@ -1731,6 +1731,49 @@ fn expand_pyre_methods(
             }
         };
 
+        // PyPy's `interp2app` gateway validates the positional count before
+        // entering the typed interp-level method.  `make_builtin_function`
+        // stores no signature contract of its own, so the generated wrapper
+        // must reject surplus positional arguments instead of silently
+        // ignoring everything beyond the final typed parameter.
+        let arity_preamble = {
+            let is_property = matches!(
+                kind,
+                MethodKind::Getter(..) | MethodKind::Setter(..) | MethodKind::Deleter(..)
+            );
+            if has_varargs || is_property {
+                quote! {}
+            } else {
+                let receiver_slots = usize::from(matches!(kind, MethodKind::Instance));
+                let visible_max = param_names.len();
+                let visible_required = param_required.iter().filter(|&&required| required).count();
+                let expected_total = receiver_slots + visible_max;
+                let fn_name = mname.to_string();
+                let expected = if visible_required == visible_max {
+                    match visible_max {
+                        0 => "no arguments".to_string(),
+                        1 => "exactly one argument".to_string(),
+                        n => format!("exactly {n} arguments"),
+                    }
+                } else {
+                    format!(
+                        "at most {visible_max} argument{}",
+                        if visible_max == 1 { "" } else { "s" }
+                    )
+                };
+                quote! {
+                    if args.len() > #expected_total {
+                        return ::std::result::Result::Err(crate::PyError::type_error(format!(
+                            "{}() takes {} ({} given)",
+                            #fn_name,
+                            #expected,
+                            args.len().saturating_sub(#receiver_slots),
+                        )));
+                    }
+                }
+            }
+        };
+
         let call_inner = quote! { #call_target( #(#call_args),* ) };
         let body = wrap_return(&m.sig.output, call_inner)?;
 
@@ -1779,6 +1822,7 @@ fn expand_pyre_methods(
                 args: &[::pyre_object::PyObjectRef],
             ) -> ::std::result::Result<::pyre_object::PyObjectRef, crate::PyError> {
                 #kwargs_preamble
+                #arity_preamble
                 #preamble
                 #(#unwrap_stmts)*
                 #body

--- a/pyre/pyre-object/src/bytearrayobject.rs
+++ b/pyre/pyre-object/src/bytearrayobject.rs
@@ -16,6 +16,9 @@ pub struct W_BytearrayObject {
     /// `_exports` — count of active buffer exports.  Size-changing mutators
     /// are refused while this is positive (`_check_exports`).
     pub exports: i64,
+    /// Mapdict `dict`/`weakref` SPECIAL slots for user subclasses.
+    pub w_dict: PyObjectRef,
+    pub w_weakreflifeline: PyObjectRef,
 }
 
 /// GC type id assigned to `W_BytearrayObject` at JitDriver init time.
@@ -60,6 +63,8 @@ fn w_bytearray_alloc(buf: Vec<u8>) -> PyObjectRef {
                     ob_header: header,
                     data,
                     exports: 0,
+                    w_dict: PY_NULL,
+                    w_weakreflifeline: PY_NULL,
                 },
             );
         }
@@ -69,6 +74,8 @@ fn w_bytearray_alloc(buf: Vec<u8>) -> PyObjectRef {
             ob_header: header,
             data,
             exports: 0,
+            w_dict: PY_NULL,
+            w_weakreflifeline: PY_NULL,
         }) as PyObjectRef
     }
 }
@@ -89,6 +96,56 @@ pub fn w_bytearray_new(size: usize) -> PyObjectRef {
 #[majit_macros::dont_look_inside]
 pub fn w_bytearray_from_bytes(bytes: &[u8]) -> PyObjectRef {
     w_bytearray_alloc(bytes.to_vec())
+}
+
+/// Allocate a bytearray user subclass in the managed heap so its mapdict
+/// edges and buffer-export cycles participate in collection.
+pub fn w_bytearray_subclass_from_bytes(bytes: &[u8], w_class: PyObjectRef) -> PyObjectRef {
+    let _roots = crate::gc_roots::push_roots();
+    let root_base = crate::gc_roots::shadow_stack_len();
+    crate::gc_roots::pin_root(w_class);
+    let raw = crate::gc_hook::try_gc_alloc_stable_raw(
+        <W_BytearrayObject as crate::lltype::GcType>::type_id(),
+        <W_BytearrayObject as crate::lltype::GcType>::SIZE,
+    );
+    let payload = W_BytearrayObject {
+        ob_header: PyObject {
+            ob_type: &BYTEARRAY_TYPE as *const PyType,
+            w_class: crate::gc_roots::shadow_stack_get(root_base),
+        },
+        data: crate::lltype::malloc_raw(bytes.to_vec()),
+        exports: 0,
+        w_dict: PY_NULL,
+        w_weakreflifeline: PY_NULL,
+    };
+    if raw.is_null() {
+        crate::lltype::malloc_typed(payload) as PyObjectRef
+    } else {
+        unsafe { std::ptr::write(raw as *mut W_BytearrayObject, payload) };
+        raw as PyObjectRef
+    }
+}
+
+#[inline]
+pub unsafe fn w_bytearray_getdict(obj: PyObjectRef) -> PyObjectRef {
+    unsafe { (*(obj as *const W_BytearrayObject)).w_dict }
+}
+
+#[inline]
+pub unsafe fn w_bytearray_setdict(obj: PyObjectRef, w_dict: PyObjectRef) {
+    unsafe { (*(obj as *mut W_BytearrayObject)).w_dict = w_dict };
+    crate::gc_hook::try_gc_write_barrier(obj as *mut u8);
+}
+
+#[inline]
+pub unsafe fn w_bytearray_getweakref(obj: PyObjectRef) -> PyObjectRef {
+    unsafe { (*(obj as *const W_BytearrayObject)).w_weakreflifeline }
+}
+
+#[inline]
+pub unsafe fn w_bytearray_setweakref(obj: PyObjectRef, lifeline: PyObjectRef) {
+    unsafe { (*(obj as *mut W_BytearrayObject)).w_weakreflifeline = lifeline };
+    crate::gc_hook::try_gc_write_barrier(obj as *mut u8);
 }
 
 pub unsafe fn is_bytearray(obj: PyObjectRef) -> bool {

--- a/pyre/pyre-object/src/bytesobject.rs
+++ b/pyre/pyre-object/src/bytesobject.rs
@@ -48,6 +48,12 @@ pub struct W_BytesObject {
     /// `sys.getrefcount` compatibility without changing object identity or
     /// storing a parallel object side table.
     pub ctypes_keepalive_refs: usize,
+    /// Mapdict's per-instance `dict` SPECIAL slot for a user subclass.
+    /// Exact bytes objects leave this null.
+    pub w_dict: PyObjectRef,
+    /// Mapdict's per-instance `weakref` SPECIAL slot for a user subclass.
+    /// Exact bytes objects leave this null.
+    pub w_weakreflifeline: PyObjectRef,
 }
 
 /// GC type id assigned to `W_BytesObject` at JitDriver init time.
@@ -91,6 +97,8 @@ pub fn w_bytes_from_bytes(bytes: &[u8]) -> PyObjectRef {
                     data,
                     len,
                     ctypes_keepalive_refs: 0,
+                    w_dict: PY_NULL,
+                    w_weakreflifeline: PY_NULL,
                 },
             );
         }
@@ -101,8 +109,63 @@ pub fn w_bytes_from_bytes(bytes: &[u8]) -> PyObjectRef {
             data,
             len,
             ctypes_keepalive_refs: 0,
+            w_dict: PY_NULL,
+            w_weakreflifeline: PY_NULL,
         }) as PyObjectRef
     }
+}
+
+/// Allocate a bytes-subclass instance in the managed heap.  PyPy's
+/// `W_BytesObject` user subclasses carry mapdict state and therefore
+/// participate in cycle collection; only exact immutable bytes may use the
+/// prebuilt/immortal allocation path above.
+pub fn w_bytes_subclass_from_bytes(bytes: &[u8], w_class: PyObjectRef) -> PyObjectRef {
+    let _roots = crate::gc_roots::push_roots();
+    let root_base = crate::gc_roots::shadow_stack_len();
+    crate::gc_roots::pin_root(w_class);
+    let raw = crate::gc_hook::try_gc_alloc_stable_raw(
+        <W_BytesObject as crate::lltype::GcType>::type_id(),
+        <W_BytesObject as crate::lltype::GcType>::SIZE,
+    );
+    let payload = W_BytesObject {
+        ob_header: PyObject {
+            ob_type: &BYTES_TYPE as *const PyType,
+            w_class: crate::gc_roots::shadow_stack_get(root_base),
+        },
+        data: crate::lltype::malloc_raw(bytes.to_vec()),
+        len: bytes.len(),
+        ctypes_keepalive_refs: 0,
+        w_dict: PY_NULL,
+        w_weakreflifeline: PY_NULL,
+    };
+    if raw.is_null() {
+        crate::lltype::malloc_typed(payload) as PyObjectRef
+    } else {
+        unsafe { std::ptr::write(raw as *mut W_BytesObject, payload) };
+        raw as PyObjectRef
+    }
+}
+
+#[inline]
+pub unsafe fn w_bytes_getdict(obj: PyObjectRef) -> PyObjectRef {
+    unsafe { (*(obj as *const W_BytesObject)).w_dict }
+}
+
+#[inline]
+pub unsafe fn w_bytes_setdict(obj: PyObjectRef, w_dict: PyObjectRef) {
+    unsafe { (*(obj as *mut W_BytesObject)).w_dict = w_dict };
+    crate::gc_hook::try_gc_write_barrier(obj as *mut u8);
+}
+
+#[inline]
+pub unsafe fn w_bytes_getweakref(obj: PyObjectRef) -> PyObjectRef {
+    unsafe { (*(obj as *const W_BytesObject)).w_weakreflifeline }
+}
+
+#[inline]
+pub unsafe fn w_bytes_setweakref(obj: PyObjectRef, lifeline: PyObjectRef) {
+    unsafe { (*(obj as *mut W_BytesObject)).w_weakreflifeline = lifeline };
+    crate::gc_hook::try_gc_write_barrier(obj as *mut u8);
 }
 
 /// Allocate an empty bytes object.

--- a/pyre/pyre-object/src/descriptor.rs
+++ b/pyre/pyre-object/src/descriptor.rs
@@ -238,12 +238,14 @@ pub unsafe fn w_property_get_doc(obj: PyObjectRef) -> PyObjectRef {
     (*(obj as *const W_Property)).w_doc
 }
 
-/// `descriptor.py:252-254 W_Property.set_doc` — explicit doc writes
-/// also clear `getter_doc`.
+/// `descriptor.py:252-254 W_Property.set_doc`, with the Python 3.14
+/// `property_set_doc` rule taking precedence: replacing the visible member
+/// does not change whether the constructor originally copied it from the
+/// getter.  `_copy` still needs that provenance so a later `.getter()` can
+/// derive the new getter's docstring.
 pub unsafe fn w_property_set_doc(obj: PyObjectRef, w_doc: PyObjectRef) {
     let prop = obj as *mut W_Property;
     (*prop).w_doc = w_doc;
-    (*prop).getter_doc = false;
     // Record the old→young edge: `w_doc` is a traced slot and the
     // property may already have been promoted out of the nursery.
     crate::gc_hook::try_gc_write_barrier(obj as *mut u8);

--- a/pyre/pyre-object/src/dictmultiobject.rs
+++ b/pyre/pyre-object/src/dictmultiobject.rs
@@ -163,8 +163,14 @@ impl indexmap::Equivalent<ObjectKey> for StrLookupKey<'_> {
                 // above allocates nothing.
                 dict_keys_equal(crate::w_str_new(self.key), k.obj)
             } else {
-                // A non-str stored key never equals a str query.
-                false
+                // ObjectDictStrategy uses the ordinary object equality hook
+                // for every hash collision.  A non-str key is allowed to
+                // compare equal to an exact str (and its `__eq__` may have
+                // observable side effects), so the borrowed-str fast path
+                // must not reject it by layout.  Materialise the query only
+                // on this rare collision path, matching
+                // `object_key_for(w_str_new(key))`.
+                dict_keys_equal(crate::w_str_new(self.key), k.obj)
             }
         }
     }

--- a/pyre/pyre-object/src/gc_hook.rs
+++ b/pyre/pyre-object/src/gc_hook.rs
@@ -246,7 +246,7 @@ pub fn clear_gc_collect_hook() {
 
 /// Trigger a full mark-sweep collection via the installed hook. No-op
 /// when no hook is installed.
-#[inline]
+#[majit_macros::dont_look_inside]
 pub fn try_gc_collect() {
     if let Some(f) = GC_COLLECT_HOOK.get() {
         f();

--- a/pyre/pyre-object/src/iterobject.rs
+++ b/pyre/pyre-object/src/iterobject.rs
@@ -12,6 +12,11 @@ pub struct W_SeqIterObject {
     pub seq: PyObjectRef,
     pub index: i64,
     pub length: i64,
+    /// Python 3.14 has producer-specific iterator types whose exhausted
+    /// reduce form retains the producer's empty shape.  Pyre shares this
+    /// payload for those iterators, so retain that type tag on the iterator
+    /// itself: 0 = tuple, 1 = str.
+    pub empty_kind: u8,
 }
 
 /// `iterobject.py W_FastListIterObject`.  PyPy shares the abstract
@@ -52,6 +57,7 @@ pub fn w_seq_iter_new(seq: PyObjectRef, length: usize) -> PyObjectRef {
         seq,
         index: 0,
         length: length as i64,
+        empty_kind: unsafe { if crate::is_str(seq) { 1 } else { 0 } },
     })
 }
 
@@ -216,6 +222,12 @@ pub unsafe fn w_seq_iter_index(obj: PyObjectRef) -> i64 {
 #[inline]
 pub unsafe fn w_seq_iter_length(obj: PyObjectRef) -> i64 {
     unsafe { (*(obj as *const W_SeqIterObject)).length }
+}
+
+/// Empty producer shape used by Python 3.14's exhausted reduce form.
+#[inline]
+pub unsafe fn w_seq_iter_empty_kind(obj: PyObjectRef) -> u8 {
+    unsafe { (*(obj as *const W_SeqIterObject)).empty_kind }
 }
 
 /// Set the cursor position.

--- a/pyre/pyre-object/src/memoryview.rs
+++ b/pyre/pyre-object/src/memoryview.rs
@@ -33,6 +33,15 @@ pub struct W_MemoryView {
     pub w_hash: i64,
     /// Flips on `release()` / context-manager exit.
     pub released: bool,
+    /// CPython 3.14 `PyMemoryViewObject.exports`: active buffers exported by
+    /// this view.  `release()` is forbidden while this is positive; hash and
+    /// contiguous hex temporarily increment it across re-entrant callbacks.
+    pub exports: i64,
+    /// `W_Root`'s per-object weakref lifeline.  PyPy's memoryview typedef
+    /// installs `make_weakref_descr(W_MemoryView)`, so the lifeline belongs
+    /// to this exact view and dies with it; it must not live in a global
+    /// side-table.
+    pub w_weakreflifeline: PyObjectRef,
     /// `owns_export` (`memoryobject.py`).  True for a view built directly over
     /// an exporter (holds one `_exports` count on the backing); false for a
     /// slice or a copy that shares the original's export.  Only an owning view
@@ -69,6 +78,8 @@ pub fn w_memoryview_alloc_header(released: bool, owns_export: bool) -> PyObjectR
         view: std::ptr::null(),
         w_hash: -1,
         released,
+        exports: 0,
+        w_weakreflifeline: PY_NULL,
         owns_export,
     };
     let raw = crate::gc_hook::try_gc_alloc_stable_raw(
@@ -162,6 +173,44 @@ mv_view_scalar!(w_memoryview_readonly, readonly, bool);
 #[inline]
 pub unsafe fn w_memoryview_released(obj: PyObjectRef) -> bool {
     unsafe { (*(obj as *const W_MemoryView)).released }
+}
+
+/// Number of buffers currently exported by this memoryview.
+#[inline]
+pub unsafe fn w_memoryview_exports(obj: PyObjectRef) -> i64 {
+    unsafe { (*(obj as *const W_MemoryView)).exports }
+}
+
+/// Temporarily protect the view from `release()` across a callback.
+#[inline]
+pub unsafe fn w_memoryview_exports_incref(obj: PyObjectRef) {
+    unsafe { (*(obj as *mut W_MemoryView)).exports += 1 }
+}
+
+/// End a temporary/exported-buffer protection interval.
+#[inline]
+pub unsafe fn w_memoryview_exports_decref(obj: PyObjectRef) {
+    unsafe {
+        let mv = obj as *mut W_MemoryView;
+        debug_assert!((*mv).exports > 0);
+        (*mv).exports -= 1;
+    }
+}
+
+/// `W_Root.getweakref()` storage supplied by
+/// `make_weakref_descr(W_MemoryView)` in PyPy's memoryview typedef.
+#[inline]
+pub unsafe fn w_memoryview_getweakref(obj: PyObjectRef) -> PyObjectRef {
+    unsafe { (*(obj as *const W_MemoryView)).w_weakreflifeline }
+}
+
+/// Store the per-view weakref lifeline and remember the old-to-young edge.
+#[inline]
+pub unsafe fn w_memoryview_setweakref(obj: PyObjectRef, lifeline: PyObjectRef) {
+    unsafe {
+        (*(obj as *mut W_MemoryView)).w_weakreflifeline = lifeline;
+    }
+    crate::gc_hook::try_gc_write_barrier(obj as *mut u8);
 }
 
 /// The cached content hash (`self._hash`), `-1` until computed.

--- a/pyre/pyre-object/src/operation.rs
+++ b/pyre/pyre-object/src/operation.rs
@@ -30,7 +30,7 @@
 use crate::pyobject::*;
 use pyre_macros::pyre_class;
 
-#[pyre_class("_CallableIterator", static_name = "CALLABLE_ITERATOR")]
+#[pyre_class("callable_iterator", static_name = "CALLABLE_ITERATOR")]
 pub struct _CallableIterator {
     /// The zero-argument callable invoked on each `__next__`.  Set to
     /// `PY_NULL` once the sentinel has been returned, latching the

--- a/pyre/pyre-object/src/typeobject.rs
+++ b/pyre/pyre-object/src/typeobject.rs
@@ -1092,15 +1092,16 @@ pub unsafe fn w_type_remove_subclass(w_parent: PyObjectRef, w_subclass: PyObject
 /// Returns the recorded direct subclasses.  Under PyPy's weakref
 /// path, dead refs are filtered; pyre's strong-ref fallback has
 /// no dead entries to filter so the result is a copy of the
-/// stored vector.  The `only_real_subclasses` flag from PyPy
-/// (`:672-688`) — used by `descr___subclasses__` to filter
-/// metaclass-mro override leaks — is omitted because pyre has no
-/// `_add_mro_classes_as_subclasses` call site yet; invalidation
-/// callers only need the inclusive list.
+/// stored vector.  `only_real_subclasses` mirrors PyPy's filter for
+/// `descr___subclasses__`: custom-MRO ancestors are registered for cache
+/// invalidation but are not real entries in the subclass's `__bases__`.
 ///
 /// # Safety
 /// `w_parent` must point at a valid `W_TypeObject`.
-pub unsafe fn w_type_get_subclasses(w_parent: PyObjectRef) -> Vec<PyObjectRef> {
+pub unsafe fn w_type_get_subclasses(
+    w_parent: PyObjectRef,
+    only_real_subclasses: bool,
+) -> Vec<PyObjectRef> {
     if w_parent.is_null() || !is_type(w_parent) {
         return Vec::new();
     }
@@ -1115,6 +1116,17 @@ pub unsafe fn w_type_get_subclasses(w_parent: PyObjectRef) -> Vec<PyObjectRef> {
     for &slot in subs.iter() {
         let target = crate::weakref::w_weakref_deref(slot);
         if !target.is_null() {
+            if only_real_subclasses {
+                let bases = w_type_get_bases(target);
+                if bases.is_null()
+                    || !(0..crate::tupleobject::w_tuple_len(bases)).any(|index| {
+                        crate::tupleobject::w_tuple_getitem(bases, index as i64)
+                            .is_some_and(|base| std::ptr::eq(base, w_parent))
+                    })
+                {
+                    continue;
+                }
+            }
             alive.push(target);
         }
     }


### PR DESCRIPTION
## Summary

- complete CPython 3.14 memoryview behavior, buffer exports, weak references, and subclass lifetime support
- extend readable/writable buffer consumers across io, mmap, struct, bytes, and bytearray
- preserve Python 3.14 bool, complex signed-zero, and builtin call semantics
- keep Windows JIT benchmark gates stable

## Validation

Before the final rebase onto origin/main:

- cargo check --features dynasm
- cargo test --features dynasm
- cargo test -p pyre-interpreter --features dynasm (380 passed)
- target/debug/pyre -m unittest -v test.test_memoryview (171 passed, 18 skipped)
- PYRE_RTYPER_VERBOSE=1 python3 pyre/check.py --backend dynasm,cranelift,wasm --no-synthetic (all backends passed; cranelift warm rerun 11/11)

The local WIP object-descriptor commit is intentionally excluded from this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `BytesIO.readinto()` and `readinto1()`.
  * Added POSIX `os.ftruncate()`.
  * Added `time.get_clock_info()`.
  * Expanded `memoryview` with half-float format support and mmap-backed views.

* **Bug Fixes**
  * Improved Python 3.14 compatibility for `bool.__invert__`, dict key `TypeError` text, `__contains__ = None`, and `sys.set_int_max_str_digits`.
  * Tightened pickling/reduce behavior for `PickleBuffer` and callable iterators, and improved `memoryview` export/release lifecycle safety.
  * Refined `deque` concatenation/copy/iteration-safety and related protocol behaviors.

* **Tests**
  * Added/expanded regression coverage across `memoryview`, membership/iterator edge cases, arity/type errors, and various builtin/property behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->