### PR TITLE
fib_recursive: depth-2 recursive inline (gh#343) + PYPY_GC_MAX bounded-heap MemoryError (Task#3)

### DIFF
--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -3177,6 +3177,73 @@ fn emit_call_footer_shadowstack(
         .store(MemFlags::trusted(), new_rst, rst_addr_val, 0);
 }
 
+/// x86/assembler.py:1630-1641 `genop_discard_check_memory_error` /
+/// aarch64/assembler.rs `emit_propagate_memory_error_if_null`: branch to the
+/// `propagate_exception_descr` exit when `ptr_val` is NULL.  The metainterp
+/// emits an explicit `OpCode::CheckMemoryError` only for non-inline mallocs; an
+/// inline nursery/varsize bump has its check emitted by the backend right after
+/// the allocation (RPython `malloc_cond`), so the NULL a bounded `PYPY_GC_MAX`
+/// major collection returns is caught before the following header/field stores
+/// dereference it.  Leaves the builder positioned in the (sealed) continuation
+/// block so subsequent stores run only on the non-NULL path.
+fn emit_memory_error_check(
+    builder: &mut FunctionBuilder,
+    ptr_type: cranelift_codegen::ir::Type,
+    ptr_val: cranelift_codegen::ir::Value,
+    propagate_exception_descr_ptr: usize,
+    preamble_phase: bool,
+) {
+    let zero = builder.ins().iconst(cl_types::I64, 0);
+    let is_null = builder.ins().icmp(IntCC::Equal, ptr_val, zero);
+    let propagate_block = builder.create_block();
+    let cont_block = builder.create_block();
+    if preamble_phase {
+        builder.set_cold_block(cont_block);
+    }
+    builder
+        .ins()
+        .brif(is_null, propagate_block, &[], cont_block, &[]);
+
+    builder.switch_to_block(propagate_block);
+    builder.seal_block(propagate_block);
+    if propagate_exception_descr_ptr == 0 {
+        // Unattached descr (unit tests bypassing `MetaInterp::finish_setup`).
+        builder
+            .ins()
+            .trap(cranelift_codegen::ir::TrapCode::user(1).unwrap());
+    } else {
+        // _store_and_reset_exception (assembler.py:1826-1843): read
+        // JIT_EXC_VALUE → tmp, clear both globals.
+        let exc_val_addr = builder.ins().iconst(ptr_type, jit_exc_value_addr() as i64);
+        let exc_val = builder
+            .ins()
+            .load(cl_types::I64, MemFlags::trusted(), exc_val_addr, 0);
+        builder
+            .ins()
+            .store(MemFlags::trusted(), zero, exc_val_addr, 0);
+        let exc_type_addr = builder.ins().iconst(ptr_type, jit_exc_type_addr() as i64);
+        builder
+            .ins()
+            .store(MemFlags::trusted(), zero, exc_type_addr, 0);
+        // assembler.py:336-340 — MOV [jf_guard_exc], tmp; MOV [jf_descr], descr.
+        let cur_jf = builder.ins().get_pinned_reg(ptr_type);
+        builder
+            .ins()
+            .store(MemFlags::trusted(), exc_val, cur_jf, JF_GUARD_EXC_OFS);
+        let descr_val = builder
+            .ins()
+            .iconst(ptr_type, propagate_exception_descr_ptr as i64);
+        builder
+            .ins()
+            .store(MemFlags::trusted(), descr_val, cur_jf, JF_DESCR_OFS);
+        emit_call_footer_shadowstack(builder, ptr_type);
+        builder.ins().return_(&[cur_jf]);
+    }
+
+    builder.switch_to_block(cont_block);
+    builder.seal_block(cont_block);
+}
+
 /// direct call_assembler path. Ultra-lightweight: just increments
 /// fail count, checks bridge (atomic + mutex only when bridge exists),
 /// and defers bridge compilation. Falls back to force_fn.
@@ -10784,68 +10851,13 @@ impl CraneliftBackend {
                     // that mirrors `_build_propagate_exception_path`,
                     // x86/assembler.py:328-345 / aarch64/assembler.py:559-577).
                     let ptr_val = resolve_opref(&mut builder, &constants, op.arg(0).to_opref());
-                    let zero = builder.ins().iconst(cl_types::I64, 0);
-                    let is_null = builder.ins().icmp(IntCC::Equal, ptr_val, zero);
-                    let propagate_block = builder.create_block();
-                    let cont_block = builder.create_block();
-                    if preamble_phase {
-                        builder.set_cold_block(cont_block);
-                    }
-                    builder
-                        .ins()
-                        .brif(is_null, propagate_block, &[], cont_block, &[]);
-
-                    builder.switch_to_block(propagate_block);
-                    builder.seal_block(propagate_block);
-                    if propagate_exception_descr_ptr == 0 {
-                        // Unattached `propagate_exception_descr` — typical for
-                        // unit tests that bypass `MetaInterp::finish_setup`.
-                        // In production (`pyjitpl.py:2283
-                        // self.cpu.propagate_exception_descr = exc_descr`) the
-                        // descr is always set before `compile_loop` runs.
-                        builder
-                            .ins()
-                            .trap(cranelift_codegen::ir::TrapCode::user(1).unwrap());
-                    } else {
-                        // _store_and_reset_exception (assembler.py:1826-1843):
-                        // read JIT_EXC_VALUE → tmp, clear both globals.
-                        let exc_val_addr =
-                            builder.ins().iconst(ptr_type, jit_exc_value_addr() as i64);
-                        let exc_val =
-                            builder
-                                .ins()
-                                .load(cl_types::I64, MemFlags::trusted(), exc_val_addr, 0);
-                        builder
-                            .ins()
-                            .store(MemFlags::trusted(), zero, exc_val_addr, 0);
-                        let exc_type_addr =
-                            builder.ins().iconst(ptr_type, jit_exc_type_addr() as i64);
-                        builder
-                            .ins()
-                            .store(MemFlags::trusted(), zero, exc_type_addr, 0);
-                        // assembler.py:336-337 — MOV [jf_guard_exc], tmp
-                        // so `cpu.grab_exc_value(deadframe)` in
-                        // `PropagateExceptionDescr.handle_fail`
-                        // (compile.py:1095) can read it back.
-                        let cur_jf = builder.ins().get_pinned_reg(ptr_type);
-                        builder
-                            .ins()
-                            .store(MemFlags::trusted(), exc_val, cur_jf, JF_GUARD_EXC_OFS);
-                        // assembler.py:339-340 — MOV [jf_descr], descr.
-                        let descr_val = builder
-                            .ins()
-                            .iconst(ptr_type, propagate_exception_descr_ptr as i64);
-                        builder
-                            .ins()
-                            .store(MemFlags::trusted(), descr_val, cur_jf, JF_DESCR_OFS);
-                        // assembler.py:1101 _call_footer_shadowstack
-                        // + assembler.py:1097 _call_footer.
-                        emit_call_footer_shadowstack(&mut builder, ptr_type);
-                        builder.ins().return_(&[cur_jf]);
-                    }
-
-                    builder.switch_to_block(cont_block);
-                    builder.seal_block(cont_block);
+                    emit_memory_error_check(
+                        &mut builder,
+                        ptr_type,
+                        ptr_val,
+                        propagate_exception_descr_ptr,
+                        preamble_phase,
+                    );
                 }
 
                 // ── Call operations ──
@@ -11863,6 +11875,17 @@ impl CraneliftBackend {
                     jf_ptr = emit_reload_frame_if_necessary(&mut builder, ptr_type, call_conv);
                     builder.ins().set_pinned_reg(jf_ptr);
                     builder.def_var(var(vi), result);
+                    // malloc_cond parity: the headerless slow path
+                    // (gc_alloc_nursery_headerless_shim) returns NULL on
+                    // host/bounded out-of-memory; propagate before the
+                    // following stores dereference it.
+                    emit_memory_error_check(
+                        &mut builder,
+                        ptr_type,
+                        result,
+                        propagate_exception_descr_ptr,
+                        preamble_phase,
+                    );
                 }
                 OpCode::CallMallocNursery => {
                     // x86/assembler.py:2556-2565 malloc_cond parity.
@@ -12012,6 +12035,17 @@ impl CraneliftBackend {
                             builder.def_var(var(var_idx), params[2 + i]);
                         }
                         builder.def_var(var(vi), result);
+                        // malloc_cond parity: the slow path returns NULL on
+                        // `PYPY_GC_MAX` out-of-memory (gc_alloc_nursery_shim →
+                        // alloc_nursery → GcRef(0)); propagate the MemoryError
+                        // before the following header/field stores dereference it.
+                        emit_memory_error_check(
+                            &mut builder,
+                            ptr_type,
+                            result,
+                            propagate_exception_descr_ptr,
+                            preamble_phase,
+                        );
                     } else {
                         // No active GC — refuse compile, matching the
                         // pre-existing contract that CallMallocNursery
@@ -12057,6 +12091,17 @@ impl CraneliftBackend {
                     jf_ptr = emit_reload_frame_if_necessary(&mut builder, ptr_type, call_conv);
                     builder.ins().set_pinned_reg(jf_ptr);
                     builder.def_var(var(vi), result);
+                    // malloc_cond_varsize parity: the varsize slow path
+                    // (gc_alloc_varsize_shim) returns NULL on `PYPY_GC_MAX`
+                    // out-of-memory; propagate before the following
+                    // header/item stores dereference it.
+                    emit_memory_error_check(
+                        &mut builder,
+                        ptr_type,
+                        result,
+                        propagate_exception_descr_ptr,
+                        preamble_phase,
+                    );
                 }
                 OpCode::CallMallocNurseryVarsizeFrame => {
                     // x86/assembler.py:2567-2582 malloc_cond_varsize_frame:
@@ -12170,6 +12215,18 @@ impl CraneliftBackend {
                     for (i, &(var_idx, _)) in live_refs.iter().enumerate() {
                         builder.def_var(var(var_idx), params[2 + i]);
                     }
+                    // malloc_cond_varsize_frame parity: the slow path
+                    // (gc_alloc_nursery_shim) returns NULL on `PYPY_GC_MAX`
+                    // out-of-memory.  Propagate the MemoryError before the
+                    // jf_gcmap initialization store below dereferences the
+                    // (null) frame pointer.
+                    emit_memory_error_check(
+                        &mut builder,
+                        ptr_type,
+                        result,
+                        propagate_exception_descr_ptr,
+                        preamble_phase,
+                    );
                     // jitframe.py:105-116: the custom tracer reads jf_gcmap
                     // even though it is a raw Ptr(GCMAP), not one of the five
                     // GCREF/forward fields explicitly cleared by

--- a/majit/majit-gc/src/collector.rs
+++ b/majit/majit-gc/src/collector.rs
@@ -2381,6 +2381,11 @@ impl MiniMarkGC {
         self.bytes_made_old_since_cycle = 0;
         self.threshold_bytes_made_old = 0;
 
+        // incminimark.py:2617-2631: pyre has explicit death deques but no
+        // collector-run execute_finalizers phase. Make recursive collections
+        // see SCANNING first, then fire the queue-notification triggers below.
+        self.gc_state = GcState::Scanning;
+
         // incminimark.py:2601-2615 — max heap size (PYPY_GC_MAX). If the capped
         // threshold was bounded by `max_heap_size` and the heap has already
         // reached it, signal out-of-memory. The first time, ask the triggering
@@ -2396,12 +2401,14 @@ impl MiniMarkGC {
             }
             self.max_heap_size_already_raised = true;
             self.oom_pending = true;
+            // incminimark.py:2614-2615: STATE_SCANNING (set above) then an
+            // immediate `raise MemoryError` exits `major_collection_step`
+            // before the finalizing phase. Return before the queue-notification
+            // triggers so none fire ahead of the `MemoryError` the pending NULL
+            // will raise.
+            return;
         }
 
-        // incminimark.py:2617-2631: pyre has explicit death deques but no
-        // collector-run execute_finalizers phase. Make recursive collections
-        // see SCANNING first, then fire the queue-notification triggers now.
-        self.gc_state = GcState::Scanning;
         self.execute_finalizer_triggers();
     }
 

--- a/majit/majit-gc/src/collector.rs
+++ b/majit/majit-gc/src/collector.rs
@@ -473,6 +473,28 @@ pub struct MiniMarkGC {
     /// `0.125 * get_total_memory()`). Caps the absolute next-major threshold
     /// growth per cycle.
     max_delta: f64,
+    /// incminimark.py:309 `self.max_heap_size_already_raised`. Set true the
+    /// first time a bounded major collection finds the heap already over
+    /// `max_heap_size`; a second such event aborts the process
+    /// (`out_of_memory`, minimarkpage.py:611 -> fatalerror) instead of raising
+    /// another MemoryError. Only reachable when `max_heap_size > 0`
+    /// (`PYPY_GC_MAX` set), so it stays false in the default unbounded config.
+    max_heap_size_already_raised: bool,
+    /// Set by `finish_incremental_cycle` when a bounded major collection leaves
+    /// the heap over `max_heap_size`. The allocation that triggered the
+    /// collection (`alloc_with_type`) reads and clears this and returns NULL,
+    /// so the JIT `CHECK_MEMORY_ERROR` path / interpreter allocation chokepoint
+    /// raises `MemoryError` (incminimark.py:2603-2615 `raise MemoryError`,
+    /// lowered to the NULL-return the backend already understands).
+    oom_pending: bool,
+    /// Byte size of the allocation that triggered the current nursery-full
+    /// collection, carried across `do_collect_nursery` so
+    /// `finish_incremental_cycle` can pass it to `threshold_reached`
+    /// (incminimark's `major_collection_step(reserving_size)` argument). Carried
+    /// on the collector rather than threaded through the public
+    /// `do_collect_nursery` signature and its many call sites; reset to 0 by the
+    /// triggering allocation once the collection returns.
+    pending_reserving_size: usize,
     /// incminimark.py:568 `self.next_major_collection_initial`. The
     /// pre-reservation threshold; `set_major_threshold_from` grows the next
     /// threshold relative to this value, bounded by `growth_rate_max`.
@@ -622,6 +644,9 @@ impl MiniMarkGC {
             min_heap_size,
             max_heap_size,
             max_delta,
+            max_heap_size_already_raised: false,
+            oom_pending: false,
+            pending_reserving_size: 0,
             // incminimark.py:568-569 — both initialized to min_heap_size,
             // then refined by set_major_threshold_from(0.0) below.
             next_major_collection_initial: min_heap_size,
@@ -846,8 +871,21 @@ impl MiniMarkGC {
         let ptr = self.nursery.alloc(total_size);
         if ptr.is_null() {
             // Nursery full: trigger minor collection and retry.
-            // minimark.py:1282 collect_and_reserve parity.
+            // minimark.py:1282 collect_and_reserve parity. Carry the triggering
+            // allocation size so a bounded major collection applies the
+            // PYPY_GC_MAX out-of-memory policy against it (threshold_reached).
+            self.pending_reserving_size = total_size;
             self.do_collect_nursery();
+            self.pending_reserving_size = 0;
+            // incminimark.py:2603-2615 — a bounded major collection that leaves
+            // the heap over `max_heap_size` asks this allocation to fail so the
+            // caller raises MemoryError: NULL propagates to the compiled-code
+            // `CHECK_MEMORY_ERROR` path and to the interpreter allocation
+            // chokepoint. Never taken in the unbounded default (`PYPY_GC_MAX`
+            // unset), so the fallback below is unchanged there.
+            if std::mem::take(&mut self.oom_pending) {
+                return GcRef(0);
+            }
             let ptr = self.nursery.alloc(total_size);
             if ptr.is_null() {
                 // Still no space after collection. Allocate in old gen as fallback.
@@ -2328,18 +2366,37 @@ impl MiniMarkGC {
         // `kept_alive_by_finalizer` accounting, so `total_memory_used` is the
         // post-sweep old-gen size directly.)
         let total_memory_used = self.get_total_memory_used() as f64;
-        // The `bounded` result is intentionally dropped: incminimark.py:2603-2615
-        // raises MemoryError when `bounded and threshold_reached(reserving_size)`,
-        // but pyre has no GC out-of-memory path, so only the threshold-capping
-        // side effect of `set_major_threshold_from` is used (the PYPY_GC_MAX OOM
-        // policy is unported).
-        let _bounded = self.set_major_threshold_from(
+        // incminimark.py:2574-2577 — capped next-major threshold. `reserving_size`
+        // is the byte size of the allocation that triggered this collection,
+        // carried on the collector across `do_collect_nursery` (see
+        // `pending_reserving_size`), matching the argument
+        // `major_collection_step(reserving_size)` threads to both
+        // `set_major_threshold_from` and `threshold_reached`.
+        let reserving_size = self.pending_reserving_size;
+        let bounded = self.set_major_threshold_from(
             (total_memory_used * self.major_collection_threshold)
                 .min(total_memory_used + self.max_delta),
-            0.0,
+            reserving_size as f64,
         );
         self.bytes_made_old_since_cycle = 0;
         self.threshold_bytes_made_old = 0;
+
+        // incminimark.py:2601-2615 — max heap size (PYPY_GC_MAX). If the capped
+        // threshold was bounded by `max_heap_size` and the heap has already
+        // reached it, signal out-of-memory. The first time, ask the triggering
+        // allocation to return NULL so `CHECK_MEMORY_ERROR` (compiled code) or
+        // the interpreter allocation chokepoint raises `MemoryError`, giving the
+        // program a chance to quit cleanly; a second occurrence aborts the
+        // process (`out_of_memory` -> fatalerror). `max_heap_size == 0`
+        // (unbounded default) never sets `bounded`, so this is inert unless
+        // `PYPY_GC_MAX` is set.
+        if bounded && self.threshold_reached(reserving_size) {
+            if self.max_heap_size_already_raised {
+                panic!("using too much memory, aborting");
+            }
+            self.max_heap_size_already_raised = true;
+            self.oom_pending = true;
+        }
 
         // incminimark.py:2617-2631: pyre has explicit death deques but no
         // collector-run execute_finalizers phase. Make recursive collections
@@ -3800,6 +3857,55 @@ mod tests {
         let obj = gc.alloc_with_type(0, 16);
         assert!(!obj.is_null());
         assert!(gc.is_in_nursery(obj.0));
+    }
+
+    /// incminimark.py:2601-2615 `PYPY_GC_MAX` out-of-memory policy: a bounded
+    /// major collection over `max_heap_size` signals OOM the first time
+    /// (`oom_pending` so the triggering allocation returns NULL) and aborts on
+    /// the second occurrence. `max_heap_size` below `min_heap_size` makes any
+    /// threshold bounded, so the decision fires on an otherwise empty heap.
+    #[test]
+    fn bounded_max_heap_size_signals_oom_then_aborts() {
+        let mut gc = test_gc(4096);
+        // PYPY_GC_MAX = 1 byte (below min_heap_size), so set_major_threshold_from
+        // caps at 1 and reports `bounded`.
+        gc.max_heap_size = 1.0;
+        // The allocation that triggered the collection is larger than the
+        // remaining headroom (1 - total_memory_used), so threshold_reached holds.
+        gc.pending_reserving_size = 4096;
+
+        // First bounded breach: flag + signal, no abort.
+        gc.gc_state = GcState::Sweeping;
+        gc.finish_incremental_cycle();
+        assert!(
+            gc.max_heap_size_already_raised,
+            "first bounded breach records max_heap_size_already_raised"
+        );
+        assert!(
+            gc.oom_pending,
+            "first bounded breach asks the allocation to fail (NULL)"
+        );
+
+        // Second bounded breach aborts (out_of_memory -> fatalerror == panic).
+        gc.pending_reserving_size = 4096;
+        gc.gc_state = GcState::Sweeping;
+        let second = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            gc.finish_incremental_cycle();
+        }));
+        assert!(second.is_err(), "second bounded breach aborts the process");
+    }
+
+    /// The default (unbounded, `max_heap_size == 0`) config never sets `bounded`,
+    /// so a completed major collection leaves the OOM signals untouched.
+    #[test]
+    fn unbounded_heap_never_signals_oom() {
+        let mut gc = test_gc(4096);
+        assert_eq!(gc.max_heap_size, 0.0);
+        gc.pending_reserving_size = 4096;
+        gc.gc_state = GcState::Sweeping;
+        gc.finish_incremental_cycle();
+        assert!(!gc.max_heap_size_already_raised);
+        assert!(!gc.oom_pending);
     }
 
     #[test]

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -4100,8 +4100,16 @@ impl<M: Clone> MetaInterp<M> {
                 return InlineDecision::ResidualCall;
             };
             let green_key = crate::green_key_hash_typed(green_values, &jd.green_args_spec());
-            let callee_compiled =
-                compiled_loops.contains_key(&green_key) || pending_green_key == Some(green_key);
+            // `callee_compiled` must recognise every token the sibling
+            // `recursive_target` resolver can produce — `warm_state.get_compiled`
+            // returns the cell's procedure token, including the tmp-callback
+            // tokens `get_assembler_token` installs (warmstate.py:714-723).
+            // Without the `get_compiled` disjunct the decision reports "no
+            // token" and aborts while `recursive_target` would have resolved
+            // one, the exact drift `decide_recursive_inline` is meant to prevent.
+            let callee_compiled = compiled_loops.contains_key(&green_key)
+                || pending_green_key == Some(green_key)
+                || warm_state.get_compiled(green_key).is_some();
             let can_inline = warm_state.can_inline_callable(green_key);
             let (decision, _should_disable) = decide_recursive_inline(
                 callee_compiled,
@@ -11583,11 +11591,16 @@ impl<M: Clone> MetaInterp<M> {
         // token on demand (warmstate.py:714). Pyre uses the pending-token
         // entry for inlining-decision purposes only; emitted CALL_ASSEMBLER
         // descrs resolve to either a compiled token or a tmp-callback token.
+        // The `warm_state.get_compiled` disjunct mirrors the production
+        // `recursive_decision` closure so a callee whose only token lives on a
+        // warm cell (a tmp-callback install `get_assembler_token` performed for
+        // a sibling entry) is still recognised as compiled here.
         let callee_compiled = self.compiled_loops.contains_key(&callee_key)
             || self
                 .pending_token
                 .as_ref()
-                .is_some_and(|(k, _)| *k == callee_key);
+                .is_some_and(|(k, _)| *k == callee_key)
+            || self.warm_state.get_compiled(callee_key).is_some();
 
         // Not tracing: pyjitpl.py:1381 `warmrunnerstate.inlining`
         // is only meaningful inside a trace. Route compiled
@@ -14559,9 +14572,11 @@ pub enum InlineDecision {
 /// pyjitpl.py:1404 `dont_trace_here` performs — this returns
 /// `should_disable = true` exactly in that gate.
 ///
-/// `callee_compiled` folds `compiled_loops.contains_key || pending_token`
-/// (the pyre `get_assembler_token` stand-in).  `can_inline` is
-/// `warm_state.can_inline_callable` (pyjitpl.py:1382).
+/// `callee_compiled` folds `compiled_loops.contains_key || pending_token ||
+/// warm_state.get_compiled` (the pyre `get_assembler_token` stand-in — the
+/// `get_compiled` disjunct keeps it aligned with the `recursive_target` token
+/// resolver).  `can_inline` is `warm_state.can_inline_callable`
+/// (pyjitpl.py:1382).
 pub(crate) fn decide_recursive_inline(
     callee_compiled: bool,
     can_inline: bool,

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -9314,7 +9314,7 @@ fn generator_unpack_into(
                 Ok(w_result) => {
                     // generator.py:339-341 — frame finished ⇒ RETURNed,
                     // mark exhausted and stop without appending.
-                    if frame.frame_finished_execution {
+                    if frame.frame_finished_execution() {
                         w_generator_set_exhausted(gen_obj);
                         break;
                     }
@@ -12054,7 +12054,7 @@ fn generator_send_ex(
             Ok(value) => {
                 // generator.py:109-114 — if the frame marked itself finished,
                 // it was RETURNed from; otherwise it YIELDed.
-                if frame.frame_finished_execution {
+                if frame.frame_finished_execution() {
                     w_generator_set_exhausted(gen_obj);
                     // generator.py:117-119 / pyopcode.py RETURN_VALUE in
                     // generator frames — `raise StopIteration(returnvalue)`

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -6963,7 +6963,9 @@ pub(crate) fn super_check(
     // typeobject.c super_init: a type obj names its own class ("type str"),
     // otherwise the message names the instance's class ("instance of str").
     let obj_desc = if unsafe { pyre_object::is_type(obj_or_type) } {
-        format!("type {}", unsafe { pyre_object::w_type_get_name(obj_or_type) })
+        format!("type {}", unsafe {
+            pyre_object::w_type_get_name(obj_or_type)
+        })
     } else {
         let obj_type_name = crate::typedef::r#type(obj_or_type)
             .map(|t| unsafe { pyre_object::w_type_get_name(t) })

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -6960,9 +6960,21 @@ pub(crate) fn super_check(
             Err(e) => return Err(e),
         }
     }
-    Err(crate::PyError::type_error(
-        "super(type, obj): obj must be an instance or subtype of type",
-    ))
+    // typeobject.c super_init: a type obj names its own class ("type str"),
+    // otherwise the message names the instance's class ("instance of str").
+    let obj_desc = if unsafe { pyre_object::is_type(obj_or_type) } {
+        format!("type {}", unsafe { pyre_object::w_type_get_name(obj_or_type) })
+    } else {
+        let obj_type_name = crate::typedef::r#type(obj_or_type)
+            .map(|t| unsafe { pyre_object::w_type_get_name(t) })
+            .unwrap_or("object");
+        format!("instance of {obj_type_name}")
+    };
+    let start_type_name = unsafe { pyre_object::w_type_get_name(start_type) };
+    Err(crate::PyError::type_error(format!(
+        "super(type, obj): obj ({obj_desc}) is not an instance \
+         or subtype of type ({start_type_name})."
+    )))
 }
 
 /// `iter(obj)` / `iter(callable, sentinel)` — PyPy:

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -1408,7 +1408,7 @@ pub fn handle_exception(frame: &mut PyFrame, err: &mut PyError, next_instr: &mut
         frame.last_instr = err.reraise_lasti as isize;
     }
     err.reraise_lasti = -1;
-    frame.frame_finished_execution = true;
+    frame.set_frame_finished_execution(true);
 
     false
 }
@@ -2413,7 +2413,7 @@ impl ControlFlowOpcodeHandler for PyFrame {
                 );
             }
         }
-        self.frame_finished_execution = true;
+        self.set_frame_finished_execution(true);
         Ok(StepResult::Return(value))
     }
 }

--- a/pyre/pyre-interpreter/src/executioncontext.rs
+++ b/pyre/pyre-interpreter/src/executioncontext.rs
@@ -316,7 +316,7 @@ impl ExecutionContext {
         let _frame_vref = self.topframeref;
         unsafe {
             self.topframeref = (*frame).f_backref;
-            if (*frame).escaped || got_exception {
+            if (*frame).escaped() || got_exception {
                 let f_back = (*frame).get_f_back();
                 if !f_back.is_null() {
                     (*f_back).mark_as_escaped();

--- a/pyre/pyre-interpreter/src/pyframe.rs
+++ b/pyre/pyre-interpreter/src/pyframe.rs
@@ -102,8 +102,13 @@ pub struct PyFrame {
     /// runtime never observes a divergence — so this remains a structural
     /// adaptation, not a parity bug.
     pub last_instr: isize,
-    /// pyframe.py:80 escaped — see mark_as_escaped()
-    pub escaped: bool,
+    /// Packed frame status bits, one byte in place of two RPython
+    /// class-level bools: `FLAG_ESCAPED` (pyframe.py:80 escaped — see
+    /// mark_as_escaped()) and `FLAG_FRAME_FINISHED`
+    /// (frame_finished_execution).  Access through the
+    /// `escaped()`/`set_escaped()`/`frame_finished_execution()`/
+    /// `set_frame_finished_execution()` methods.
+    pub flags: u8,
     /// pyframe.py:82 debugdata — lazily allocated tracing/debug payload.
     /// Virtualizable static field (interp_jit.py:28).
     pub debugdata: *mut FrameDebugData,
@@ -113,8 +118,6 @@ pub struct PyFrame {
     /// Virtualizable token — set by JIT when this frame is virtualized.
     /// 0 = not virtualized, nonzero = pointer to JIT state.
     pub vable_token: usize,
-    /// PyPy: `frame_finished_execution = False`.
-    pub frame_finished_execution: bool,
     /// PyPy: `f_generator_nowref = None`.
     pub f_generator_nowref: PyObjectRef,
     /// PyPy: `w_yielding_from = None`.
@@ -1633,8 +1636,7 @@ impl PyFrame {
         };
         self.valuestackdepth = unsafe { (&*raw).varnames.len() + ncells(&*raw) };
         self.last_instr = -1;
-        self.escaped = false;
-        self.frame_finished_execution = false;
+        self.flags = 0;
         self.f_generator_nowref = PY_NULL;
         self.w_yielding_from = PY_NULL;
         self.f_backref = std::ptr::null_mut();
@@ -1843,11 +1845,10 @@ impl PyFrame {
             },
             valuestackdepth: nlocals + ncells,
             last_instr: -1,
-            escaped: false,
+            flags: 0,
             debugdata: std::ptr::null_mut(),
             lastblock: std::ptr::null_mut(),
             vable_token: 0,
-            frame_finished_execution: false,
             f_generator_nowref: PY_NULL,
             w_yielding_from: PY_NULL,
             f_backref: std::ptr::null_mut(),
@@ -1956,11 +1957,10 @@ impl PyFrame {
             },
             valuestackdepth: num_locals + num_cells,
             last_instr: -1,
-            escaped: false,
+            flags: 0,
             debugdata: std::ptr::null_mut(),
             lastblock: std::ptr::null_mut(),
             vable_token: 0,
-            frame_finished_execution: false,
             f_generator_nowref: PY_NULL,
             w_yielding_from: PY_NULL,
             f_backref: std::ptr::null_mut(),
@@ -2020,11 +2020,10 @@ impl PyFrame {
             },
             valuestackdepth: self.valuestackdepth,
             last_instr: self.last_instr,
-            escaped: self.escaped,
+            flags: self.flags,
             debugdata: unsafe { clone_debugdata_ptr(self.debugdata, allocation) },
             lastblock: unsafe { clone_block_chain(self.lastblock, allocation) },
             vable_token: self.vable_token,
-            frame_finished_execution: self.frame_finished_execution,
             f_generator_nowref: self.f_generator_nowref,
             w_yielding_from: self.w_yielding_from,
             f_backref: self.f_backref,
@@ -2517,10 +2516,45 @@ impl PyFrame {
         unsafe { crate::w_code_hidden_applevel(self.pycode as PyObjectRef) }
     }
 
+    /// `escaped` status bit (pyframe.py:80).
+    pub const FLAG_ESCAPED: u8 = 0b01;
+    /// `frame_finished_execution` status bit.
+    pub const FLAG_FRAME_FINISHED: u8 = 0b10;
+
+    /// pyframe.py:80 `escaped`.
+    #[inline]
+    pub fn escaped(&self) -> bool {
+        self.flags & Self::FLAG_ESCAPED != 0
+    }
+
+    #[inline]
+    pub fn set_escaped(&mut self, value: bool) {
+        if value {
+            self.flags |= Self::FLAG_ESCAPED;
+        } else {
+            self.flags &= !Self::FLAG_ESCAPED;
+        }
+    }
+
+    /// `frame_finished_execution`.
+    #[inline]
+    pub fn frame_finished_execution(&self) -> bool {
+        self.flags & Self::FLAG_FRAME_FINISHED != 0
+    }
+
+    #[inline]
+    pub fn set_frame_finished_execution(&mut self, value: bool) {
+        if value {
+            self.flags |= Self::FLAG_FRAME_FINISHED;
+        } else {
+            self.flags &= !Self::FLAG_FRAME_FINISHED;
+        }
+    }
+
     /// pyframe.py:183 mark_as_escaped
     #[inline]
     pub fn mark_as_escaped(&mut self) {
-        self.escaped = true;
+        self.set_escaped(true);
     }
 
     /// pyframe.py:216-220 `get_builtin` — returns `self.builtin` (the
@@ -2604,7 +2638,7 @@ impl PyFrame {
     /// var / stack slot (cells are rebound to fresh empty cells so a
     /// shared inner/outer cell is not mutated).
     pub fn descr_clear(&mut self) -> Result<(), crate::PyError> {
-        if !self.frame_finished_execution {
+        if !self.frame_finished_execution() {
             if !self._is_generator_or_coroutine() {
                 return Err(crate::PyError::runtime_error(
                     "cannot clear an executing frame",
@@ -3365,11 +3399,10 @@ impl PyFrame {
             locals_cells_stack_w,
             valuestackdepth: num_locals + num_cells,
             last_instr: -1,
-            escaped: false,
+            flags: 0,
             debugdata: std::ptr::null_mut(),
             lastblock: std::ptr::null_mut(),
             vable_token: 0,
-            frame_finished_execution: false,
             f_generator_nowref: PY_NULL,
             w_yielding_from: PY_NULL,
             f_backref: std::ptr::null_mut(),
@@ -3672,11 +3705,10 @@ pub fn createframe_obj(
         },
         valuestackdepth: num_locals + num_cells,
         last_instr: -1,
-        escaped: false,
+        flags: 0,
         debugdata: std::ptr::null_mut(),
         lastblock: std::ptr::null_mut(),
         vable_token: 0,
-        frame_finished_execution: false,
         f_generator_nowref: PY_NULL,
         w_yielding_from: PY_NULL,
         f_backref: std::ptr::null_mut(),

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -14787,28 +14787,15 @@ fn init_bool_type(ns: PyObjectRef) {
 // ── Object TypeDef ───────────────────────────────────────────────────
 // PyPy: pypy/objspace/std/objectobject.py TypeDef("object", ...)
 
-/// True when a class's `__new__` / `__init__` slot still resolves to the
-/// one `object` owns — i.e. the class does not override it.  A
-/// `staticmethod`-wrapped `__new__` is unwrapped to its function first
-/// (`_same_static_method`, objectobject.py:113-116) before the identity
-/// compare, so a slot carrying `object`'s own `__new__` staticmethod
-/// matches.
-fn object_slot_inherited(
-    class_slot: Option<PyObjectRef>,
-    object_slot: Option<PyObjectRef>,
-) -> bool {
-    let unwrap = |s: Option<PyObjectRef>| -> PyObjectRef {
-        match s {
-            Some(f) if unsafe { pyre_object::function::is_staticmethod(f) } => unsafe {
-                pyre_object::function::w_staticmethod_get_func(f)
-            },
-            Some(f) => f,
-            None => PY_NULL,
-        }
-    };
-    let a = unwrap(class_slot);
-    !a.is_null() && crate::baseobjspace::is_w(a, unwrap(object_slot))
-}
+// The `__new__` override check below uses raw slot identity
+// (`same_inherited_slot`), not a `staticmethod`-unwrapping compare.  PyPy's
+// `_same_static_method` (objectobject.py:113-116) unwraps a
+// `staticmethod`-wrapped `__new__` to its function before the identity
+// compare, so `__new__ = staticmethod(object.__new__)` counts as inherited;
+// CPython 3.14 keeps the wrapper as a distinct `tp_new` slot, so the same
+// assignment counts as an OVERRIDE and `Cls(1, 2)` raises
+// "object.__new__() takes exactly one argument (the type to instantiate)".
+// pyre targets CPython, so raw identity is the correct comparison here.
 
 /// `object.__new__(cls)` — allocate a bare instance of cls.
 ///

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -15168,7 +15168,22 @@ fn init_object_type(ns: PyObjectRef) {
             "__dir__",
             make_builtin_function_with_arity(
                 "__dir__",
-                |args| crate::builtins::object_dir_default(args[0]),
+                |args| {
+                    // `object.__dir__` is a no-extra-arg method: reject a
+                    // missing receiver and any surplus positional.
+                    let Some(&receiver) = args.first() else {
+                        return Err(crate::PyError::type_error(
+                            "unbound method object.__dir__() needs an argument".to_string(),
+                        ));
+                    };
+                    if args.len() > 1 {
+                        return Err(crate::PyError::type_error(format!(
+                            "object.__dir__() takes no arguments ({} given)",
+                            args.len() - 1
+                        )));
+                    }
+                    crate::builtins::object_dir_default(receiver)
+                },
                 1,
             ),
         )

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/fbw_state.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/fbw_state.rs
@@ -79,15 +79,19 @@ pub(crate) fn fbw_inline_multiframe_enabled() -> bool {
     })
 }
 
-/// `PYRE_FBW_REC_MULTIFRAME` (default OFF): route primary-trace
-/// self-recursive Python calls through the multiframe inline path while below
-/// `PYRE_FBW_MULTIFRAME_DEPTH`, instead of folding immediately to the
-/// recursive portal `CALL_ASSEMBLER`.
+/// `PYRE_FBW_REC_MULTIFRAME` (default ON; `=0`/`false` opts out): route
+/// primary-trace self-recursive Python calls through the multiframe inline path
+/// while below `PYRE_FBW_MULTIFRAME_DEPTH`, instead of folding immediately to
+/// the recursive portal `CALL_ASSEMBLER`.
 ///
-/// RPython parity target: `opimpl_recursive_call` / `do_recursive_call`
-/// (`pyjitpl.py:1376-1432`) inline within `max_unroll_recursion`; once the
-/// cap is reached, recursion falls back to the assembler-call path.  Pyre keeps
-/// this route opt-in while the default remains the existing fold-only policy.
+/// RPython parity: `opimpl_recursive_call` / `do_recursive_call`
+/// (`pyjitpl.py:1376-1432`) inline within `max_unroll_recursion`; only once the
+/// cap is reached does recursion fall back to the assembler-call path.  The
+/// prior fold-only default (every self-recursive call cut straight to
+/// `CALL_ASSEMBLER`) was the pyre deviation; inlining below the depth bound is
+/// the parity behavior, so this is default-on.  The depth bound
+/// (`fbw_max_multiframe_depth`, default 1) still caps how deep the inline
+/// unrolls before falling back to `CALL_ASSEMBLER`.
 pub(crate) fn fbw_rec_multiframe_enabled() -> bool {
     static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
     *ENABLED.get_or_init(|| match std::env::var_os("PYRE_FBW_REC_MULTIFRAME") {
@@ -95,7 +99,7 @@ pub(crate) fn fbw_rec_multiframe_enabled() -> bool {
             let v = v.to_string_lossy();
             v != "0" && !v.eq_ignore_ascii_case("false")
         }
-        None => false,
+        None => true,
     })
 }
 

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
@@ -1389,9 +1389,11 @@ pub(crate) fn try_walker_inline_resolved_user_call(
         if self_recursive {
             // RPython `opimpl_recursive_call` / `do_recursive_call`
             // (`pyjitpl.py:1376-1432`) unroll within `max_unroll_recursion`,
-            // then falls back to the assembler-call path.  Keep pyre's
-            // default fold-only route unchanged; the opt-in flag lets a
-            // primary trace spend the multiframe budget on recursion unrolls.
+            // then fall back to the assembler-call path.  Default-on
+            // (`fbw_rec_multiframe_enabled`): a primary trace spends the
+            // multiframe budget unrolling recursion below the depth bound
+            // before folding the deepest call to the recursive portal
+            // `CALL_ASSEMBLER`.
             let unroll = fbw_rec_multiframe_enabled()
                 && !ctx.fbw_mode.carrier_resume
                 && ctx.session.borrow().framestack.len() < fbw_max_multiframe_depth();

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
@@ -407,6 +407,28 @@ pub(crate) fn walker_abort_if_mayforce_null_ref_arg(
                 ctx.trace_ctx.box_value(b),
                 Some(majit_ir::Value::Ref(majit_ir::GcRef(0)))
             ) {
+                // Phase-1 diagnostic (gh#343 depth-2): pinpoint which Ref arg
+                // folded to concrete NULL and its provenance.  Gated on
+                // `PYRE_P2_DIAG` (the depth-2 framestack-walk diag flag) and
+                // computed only on the abort path, so the default trace path
+                // pays nothing.
+                if std::env::var_os("PYRE_P2_DIAG").is_some() {
+                    eprintln!(
+                        "[p2-mayforce] NULL Ref arg: pc={pc} call_opcode={call_opcode:?} \
+                         helper={:?} arg_index={i} nargs={} funcbox={:?}(={:?})",
+                        call_descr.get_extra_info().pyre_helper,
+                        call_descr.arg_types().len(),
+                        allboxes.first(),
+                        allboxes.first().and_then(|&f| ctx.trace_ctx.box_value(f)),
+                    );
+                    for (j, &aty) in call_descr.arg_types().iter().enumerate() {
+                        let ab = allboxes.get(1 + j).copied();
+                        eprintln!(
+                            "[p2-mayforce]   arg[{j}] ty={aty:?} opref={ab:?} val={:?}",
+                            ab.and_then(|b| ctx.trace_ctx.box_value(b)),
+                        );
+                    }
+                }
                 return Err(DispatchError::MayForceNullRefArgUnsupported { pc });
             }
         }

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/resume_snapshot.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/resume_snapshot.rs
@@ -1330,6 +1330,93 @@ pub(crate) fn compute_nested_inline_caller_frame(
         Ok(b) => b,
         Err(_) => return Err(InlineCallerFrameDecline::Unavailable),
     };
+    // #343 depth-2 operand flush.  `emit_new_pyframe_inline_with_params` seeds
+    // this inlined-callee frame's `locals_cells_stack_w` virtual array with LOCALS
+    // only; its live operand-stack slots live in the register file and are never
+    // written back into the frame array.  When a guard fires inside a NESTED
+    // inline (this frame is the paused MIDDLE caller), the multi-frame snapshot
+    // captures this frame virtual and numbers its array — an unwritten operand
+    // slot numbers to `NULLREF`, which `reconstruct_inline_recipe`
+    // (state.rs:5954-5998, semantic-slot-ordered `arr[k]` read) decodes to a
+    // concrete-NULL Ref box, aborting the reconstructed middle at its next
+    // `CALL_MAY_FORCE` (`MayForceNullRefArgUnsupported`).  Materialize the live
+    // operand boxes into the frame array now — at the point we pause this frame to
+    // enter the nested inline — mirroring the locals seed at `helpers.rs:1418`
+    // (`virtualizable.py:101-113` write_boxes writes the frame's field boxes into
+    // its array when it is forced).  Only NON-pending operand slots are written;
+    // the top slot is the not-yet-produced nested-call result, delivered on resume
+    // (`pending_result_abs_slot`), so the decoder skips it and so do we.  Emitting
+    // here (before the nested callee's body walk) — not at capture — places the
+    // stores ahead of every in-callee guard, so `_number_virtuals` reads the
+    // populated array when it numbers those guards' resume data.
+    if let Some(marker) = resume_marker_jit_pc {
+        if caller_liveness_word != majit_ir::resumedata::NO_JITCODE_PC && depth > 1 {
+            let (frame_reg, _) = crate::state::portal_red_regs_at(jitcode_index as i32);
+            let frame_red = (frame_reg != u16::MAX)
+                .then(|| ctx.registers_r.get(frame_reg as usize).copied())
+                .flatten()
+                .filter(|&r| r != OpRef::NONE);
+            let locals_idx = crate::descr::pyframe_locals_cells_stack_descr().index();
+            if let Some(locals_array) =
+                frame_red.and_then(|fr| ctx.trace_ctx.heapcache_getfield_cached(fr, locals_idx))
+            {
+                // nlocals from the paused caller's own code (varnames count), the
+                // same base the decoder uses (`code_ref.varnames.len()`).
+                let nlocals = unsafe { &*pjc.code_ptr }.varnames.len();
+                // `depth` is the operand-stack depth at the CALL return point,
+                // top slot = the pending nested-call result.
+                let pending_top_slot = nlocals + depth - 1;
+                let maps = crate::state::bridge_semantic_maps_at_with_jitcode_pc(
+                    jitcode_index as i32,
+                    marker as i32,
+                    caller_liveness_word,
+                );
+                let array_descr = crate::state::pyobject_gcarray_descr();
+                // Heapcache array-element key = the virtualizable info's array
+                // item descr, matching the seed store at `helpers.rs:1414-1417`.
+                let item_descr_index = ctx
+                    .trace_ctx
+                    .virtualizable_info()
+                    .map(|info| info.array_item_descr(0).index())
+                    .unwrap_or_else(|| array_descr.index());
+                // Live Ref colors at the CALL return coordinate, same enumeration
+                // as `collect_callee_active_boxes`.
+                let banks = crate::state::frame_liveness_reg_indices_by_bank_from_pc(
+                    jitcode_index as i32,
+                    caller_liveness_word,
+                );
+                for &color in &banks.ref_ {
+                    let Some(slot) = crate::state::semantic_ref_slot_for_reg_color(
+                        nlocals,
+                        depth,
+                        &maps.pcdep_entries,
+                        color as usize,
+                    ) else {
+                        continue;
+                    };
+                    // Locals are already seeded; the pending result slot is
+                    // delivered on resume — only sibling operands need the flush.
+                    if slot < nlocals || slot == pending_top_slot {
+                        continue;
+                    }
+                    let Some(&operand) = ctx.registers_r.get(color as usize) else {
+                        continue;
+                    };
+                    if operand == OpRef::NONE {
+                        continue;
+                    }
+                    let idx = ctx.trace_ctx.const_int(slot as i64);
+                    ctx.trace_ctx.record_op_with_descr(
+                        OpCode::SetarrayitemGc,
+                        &[locals_array, idx, operand],
+                        array_descr.clone(),
+                    );
+                    ctx.trace_ctx
+                        .heapcache_setarrayitem(locals_array, idx, item_descr_index, operand);
+                }
+            }
+        }
+    }
     Ok(InlineParentFrame {
         jitcode_index,
         call_jitcode_pc: Some(call_jit_pc),

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/resume_snapshot.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/resume_snapshot.rs
@@ -1411,8 +1411,12 @@ pub(crate) fn compute_nested_inline_caller_frame(
                         &[locals_array, idx, operand],
                         array_descr.clone(),
                     );
-                    ctx.trace_ctx
-                        .heapcache_setarrayitem(locals_array, idx, item_descr_index, operand);
+                    ctx.trace_ctx.heapcache_setarrayitem(
+                        locals_array,
+                        idx,
+                        item_descr_index,
+                        operand,
+                    );
                 }
             }
         }

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/vstack_mirror.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/vstack_mirror.rs
@@ -152,6 +152,20 @@ pub(crate) fn classify_vstack_opcode(
         | Instruction::JumpBackwardNoInterrupt { .. }
         | Instruction::ReturnValue => VstackOpClass::PopOnlyOrSideStore,
 
+        // TO_BOOL: pops TOS and pushes its bool (net 0, liveness `(d, d)`) and
+        // emits no JitCode (codewriter `Instruction::ToBool => {}`), so it has
+        // no `write_ref_reg` box for the pushed bool.  Its result is always
+        // consumed by the immediately following branch (POP_JUMP_IF_*), never
+        // kept below a guard, so the untracked TOS box is inert; model it as a
+        // net-0 side effect that truncates to the (unchanged) depth and keeps
+        // every surviving box in place — crucially the operand-stack slots
+        // BELOW the tested value.  Classifying it as `Unmodeled` here (the
+        // former `_` fallthrough) latched `vstack_valid = false` whenever the
+        // after-residual guard-capture reconcile re-entered at the TO_BOOL pc
+        // (`prev_pypc == new_pypc`), dropping the kept accumulator below a
+        // residual-call condition (`s = s + (i if f(...) else 0)`).
+        Instruction::ToBool => VstackOpClass::PopOnlyOrSideStore,
+
         // LOAD_GLOBAL: the global value is the new TOS = the last Ref written.
         // When `namei & 1` the lowering also pushes a NULL sentinel BENEATH the
         // result (net +2, for the upcoming method CALL).  Exactly like the
@@ -223,10 +237,11 @@ pub(crate) fn classify_vstack_opcode(
         Instruction::ForIter { .. } => VstackOpClass::ResultToTos,
 
         // Everything else is not modeled — decline; the overlay then omits
-        // the affected slots, which resume re-materializes.  TO_BOOL emits no
-        // JitCode (codewriter.rs:8598
-        // `Instruction::ToBool => {}`) so it never reaches this classifier;
-        // the py-pc boundary mapping skips it.
+        // the affected slots, which resume re-materializes.  The forward walk
+        // maps JitCode pc -> py_pc and so never lands ON a no-JitCode opcode
+        // (TO_BOOL), but the after-residual guard-capture reconcile passes an
+        // explicit resume py_pc that CAN coincide with the TO_BOOL pc, so
+        // TO_BOOL is modeled explicitly above rather than left to this arm.
         _ => VstackOpClass::Unmodeled,
     }
 }

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -5805,13 +5805,27 @@ fn reconstruct_inline_recipe(
     // with the RPython frame shape and creating NO new vable. The color==
     // semantic identity check below only accepts a register-section callee
     // (locals at colors 0..nlocals), which this shape never satisfies.
+    //
+    // An `in_a_call` callee suspended at one of its own CALL sites carries a
+    // pending result whose register was already dropped from the ref bank above
+    // (`pending_value_index`). When that pending-result color coincides with the
+    // `ec` portal red, the removal leaves only `[frame]` live — a one-ref
+    // reduced form of the SAME portal-callee shape. `pec_reg` is consumed only
+    // by this classifier gate; the reconstruction body threads
+    // `pframe_reg` -> `frame_vidx` -> the `locals_cells_stack_w` array and never
+    // reads `ec`, so `[frame]` alone is still faithfully reconstructable (the
+    // pending operand slot is delivered by `make_result_of_lastop`, not from
+    // resumedata, and is skipped by `pending_result_abs_slot` below).
     let (pframe_reg, pec_reg) = portal_red_regs_at(frame.jitcode_index);
     let (pframe_reg, pec_reg) = (pframe_reg as u32, pec_reg as u32);
+    let has_frame = reg_indices.ref_.contains(&pframe_reg);
+    let full_portal =
+        reg_indices.ref_.len() == 2 && has_frame && reg_indices.ref_.contains(&pec_reg);
+    let in_call_portal =
+        in_a_call && pending_value_index.is_some() && reg_indices.ref_.len() == 1 && has_frame;
     if pframe_reg != u32::from(u16::MAX)
         && pec_reg != u32::from(u16::MAX)
-        && reg_indices.ref_.len() == 2
-        && reg_indices.ref_.contains(&pframe_reg)
-        && reg_indices.ref_.contains(&pec_reg)
+        && (full_portal || in_call_portal)
     {
         use majit_ir::resumedata::{RebuiltValue, TAGVIRTUAL, UNINITIALIZED_TAG, untag};
         let frame_pos = reg_indices.ref_.iter().position(|&c| c == pframe_reg)?;

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -1244,8 +1244,25 @@ fn drive_bridge_framestack_walk(
     }
 
     let Some(recipe) = carrier.recipes.last() else {
-        crate::jitcode_dispatch::census_record("P2Framestack::NoRecipes");
-        return TraceAction::Abort;
+        // A 0-recipe carrier is a guard failure with NO paused inline callee
+        // frames: the multi-frame snapshot held only the root frame, so
+        // `rebuild_from_resumedata` → `setup_bridge_sym` (jitdriver.rs:4891)
+        // already seeded the root sym and there is nothing to reconstruct.  This
+        // is semantically a plain ROOT bridge.  resume.py:1042-1057 has ONE
+        // resume path: a resume with no inline frames rebuilds just the root and
+        // continues forward — it never aborts.  Fall through to the full-body
+        // bridge walk from the root pc, mirroring the `carrier.is_none()`
+        // plain-bridge path (trace.rs:621-627), instead of deopting to the
+        // blackhole (which killed the depth-2 payoff — one such carrier per
+        // base-case guard failure).
+        if std::env::var_os("PYRE_FULL_BODY_WALK").as_deref() == Some(std::ffi::OsStr::new("0"))
+            || fbw_declined(crate::driver::make_green_key(w_code, root_pc))
+        {
+            crate::jitcode_dispatch::census_record("P2Framestack::NoRecipes");
+            return TraceAction::Abort;
+        }
+        crate::jitcode_dispatch::census_record("P2Framestack::NoRecipesPlainBridge");
+        return full_body_walk_trace(ctx, sym, w_code, root_pc, cf_addr, WalkJournals::Reset);
     };
 
     let root_ec = sym.concrete_execution_context;

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -7241,7 +7241,7 @@ impl MIFrame {
                 if reraise_lasti >= 0 {
                     frame.last_instr = reraise_lasti as isize;
                 }
-                frame.frame_finished_execution = true;
+                frame.set_frame_finished_execution(true);
             }
             // No handler in this frame — return Abort so metainterp's
             // multi-frame finishframe_exception can pop this frame and

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -3454,7 +3454,7 @@ fn reset_reused_call_frame(frame: &mut PyFrame, args: &[PyObjectRef]) {
     frame.valuestackdepth = frame.stack_base();
     frame.set_last_instr_from_next_instr(0);
     frame.vable_token = 0;
-    frame.frame_finished_execution = false;
+    frame.set_frame_finished_execution(false);
     frame.f_generator_nowref = PY_NULL;
     frame.w_yielding_from = PY_NULL;
     frame.f_backref = std::ptr::null_mut();
@@ -3462,7 +3462,7 @@ fn reset_reused_call_frame(frame: &mut PyFrame, args: &[PyObjectRef]) {
     // debugdata and lastblock are GC-managed refs — release references only,
     // never manually free (JIT snapshots may still hold these pointers).
     frame.debugdata = std::ptr::null_mut();
-    frame.escaped = false;
+    frame.set_escaped(false);
     frame.set_blocklist(&[]);
 }
 

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -919,6 +919,17 @@ unsafe fn pyframe_object_custom_trace(obj_addr: usize, f: &mut dyn FnMut(*mut ma
 pub(crate) enum LoopResult {
     Done(PyResult),
     ContinueRunningNormally,
+    /// warmspot.py:998-1005 `ExitFrameWithExceptionRef`: a direct compiled-code
+    /// exit (e.g. `CHECK_MEMORY_ERROR`'s `propagate_exception_path`) carrying a
+    /// pending exception that has NOT yet been offered to this frame's own
+    /// handler.  Unlike the blackhole-resume path — which re-runs bytecode and
+    /// unwinds the exception table during resume — a `PropagateExceptionDescr`
+    /// exit skips the frame's exception machinery entirely.  RPython's
+    /// `handle_jitexception` re-`raise`s the stored Ref so it re-enters the
+    /// interpreter loop and an enclosing same-frame `try`/`except` can catch it;
+    /// pyre delivers it to `handle_exception` at the eval loop for the same
+    /// effect.
+    ExitFrameWithException(pyre_interpreter::PyError),
 }
 
 /// Action from handle_jit_outcome for eval_loop_jit dispatch.
@@ -4868,6 +4879,11 @@ fn handle_jitexception(frame: &mut PyFrame) -> PyResult {
         }
         match loop_outcome {
             LoopResult::Done(result) => return result,
+            // `eval_loop_jit` consumes `ExitFrameWithException` at its
+            // `maybe_compile_and_run` site (offers it to the frame's exception
+            // table, then re-loops or returns `Done`), so it never surfaces
+            // here; propagate defensively should that invariant change.
+            LoopResult::ExitFrameWithException(err) => return Err(err),
             LoopResult::ContinueRunningNormally => {
                 // RPython warmspot.py:976-978: result = portal_ptr(*args).
                 // The blackhole has already written back the merge point
@@ -4877,6 +4893,27 @@ fn handle_jitexception(frame: &mut PyFrame) -> PyResult {
                 continue;
             }
         }
+    }
+}
+
+/// warmspot.py:998-1005 `ExitFrameWithExceptionRef` delivery for a compiled-run
+/// exit that surfaced outside the eval loop (the `handle_jit_outcome` /
+/// compile-once path).  Offer the pending exception to `frame`'s exception
+/// table; on a match resume interpretation at the handler and return its
+/// result (a same-frame `try`/`except` catches it, matching PyPy's re-raise
+/// into the interpreter loop), otherwise return it for propagation out of the
+/// frame.  The eval loop's own `maybe_compile_and_run` site handles the warm
+/// path inline via `continue` instead of recursing here.
+fn deliver_exit_frame_exception(
+    frame: &mut PyFrame,
+    mut err: pyre_interpreter::PyError,
+) -> PyResult {
+    let mut handler_instr = frame.next_instr();
+    if pyre_interpreter::eval::handle_exception(frame, &mut err, &mut handler_instr) {
+        frame.set_last_instr_from_next_instr(handler_instr);
+        handle_jitexception(frame)
+    } else {
+        Err(err)
     }
 }
 
@@ -5171,6 +5208,25 @@ fn eval_loop_jit(frame: &mut PyFrame) -> LoopResult {
                     info,
                     &env,
                 ) {
+                    // warmspot.py:998-1005 handle_jitexception: an
+                    // `ExitFrameWithExceptionRef` from a direct compiled-code
+                    // exit is re-raised into the interpreter loop.  Offer it to
+                    // this frame's exception table first (mirroring the
+                    // per-opcode `Err` arm below); resume at the handler pc when
+                    // caught, otherwise propagate it out as a plain `Done(Err)`.
+                    if let LoopResult::ExitFrameWithException(mut err) = loop_result {
+                        if pyre_interpreter::eval::handle_exception(
+                            frame_root.frame(),
+                            &mut err,
+                            &mut next_instr,
+                        ) {
+                            frame_root
+                                .frame()
+                                .set_last_instr_from_next_instr(next_instr);
+                            continue;
+                        }
+                        return LoopResult::Done(Err(err));
+                    }
                     return loop_result;
                 }
             }
@@ -5888,7 +5944,12 @@ fn execute_assembler(
                     }
                 };
                 let err = unsafe { pyre_interpreter::PyError::from_exc_object(exc_ref) };
-                return Some(LoopResult::Done(Err(err)));
+                // warmspot.py:998-1005 — hand the compiled-code exception to
+                // this frame's exception table before propagating it out, so a
+                // same-frame `try`/`except` (e.g. around an allocating loop that
+                // tripped `PYPY_GC_MAX`) catches it, matching PyPy's re-raise
+                // into the interpreter loop.
+                return Some(LoopResult::ExitFrameWithException(err));
             }
             let [value] = typed_values.as_slice() else {
                 return Some(LoopResult::Done(Err(
@@ -6584,6 +6645,10 @@ pub fn try_function_entry_jit(frame: &mut PyFrame) -> Option<PyResult> {
         &env,
     ) {
         Some(LoopResult::Done(result)) => Some(result),
+        // `compile_and_run_once` resolves a compiled-code exception exit inside
+        // `handle_jit_outcome` (offering it to the frame's exception table), so
+        // it never surfaces `ExitFrameWithException` here; propagate defensively.
+        Some(LoopResult::ExitFrameWithException(err)) => Some(Err(err)),
         Some(LoopResult::ContinueRunningNormally) => {
             // warmspot.py:976-978 portal re-entry.  Marker mode completed the
             // synchronous walk; continue from the adopted/restart state.
@@ -6628,7 +6693,12 @@ fn handle_jit_outcome(
                     }
                 };
                 let err = unsafe { pyre_interpreter::PyError::from_exc_object(exc_ref) };
-                return JitAction::Return(Err(err));
+                // warmspot.py:998-1005 — deliver to this frame's exception table
+                // (resume at the handler on a match) rather than propagating
+                // straight out, so a same-frame try/except catches a
+                // compiled-code exception such as CHECK_MEMORY_ERROR's
+                // MemoryError.
+                return JitAction::Return(deliver_exit_frame_exception(frame, err));
             }
             let [value] = typed_values.as_slice() else {
                 return JitAction::Return(Err(pyre_interpreter::PyError::type_error(


### PR DESCRIPTION
Rebased onto `main` (#671). 13 commits in three groups.

## gh#343 — depth-2 self-recursive inline

- **jit: classify TO_BOOL as a net-0 vstack op** — the after-residual guard-capture reconcile can re-enter at a TO_BOOL pc; the `_ => Unmodeled` fallthrough latched `vstack_valid = false` and dropped an operand kept below a residual-call condition. Model TO_BOOL as `PopOnlyOrSideStore`.
- **jit: default-on `PYRE_FBW_REC_MULTIFRAME`** — inline self-recursive Python calls below the depth bound before folding the deepest call to the recursive portal `CALL_ASSEMBLER`, matching `opimpl_recursive_call`/`do_recursive_call`; the prior fold-only default was the deviation.
- **jit: `PYRE_P2_DIAG` probe** — abort-path-only diagnostic pinpointing which Ref arg folded to concrete NULL at a mid-body `CALL_MAY_FORCE`.
- **jit: flush inline-callee live operand boxes into the frame array at the nested-inline pause** — a paused middle-caller frame's unwritten operand slots numbered to `NULLREF`, aborting the reconstructed middle at its next `CALL_MAY_FORCE`; materialize the live operand boxes into the frame array before the nested body walk.
- **jit: compile a 0-recipe bridge carrier as a plain root bridge**, and **accept the reduced single-ref portal-callee shape in `reconstruct_inline_recipe`**.

## Task #3 — `PYPY_GC_MAX` bounded-heap OOM → catchable `MemoryError`

- **majit-gc: signal out-of-memory from `finish_incremental_cycle`** — on `bounded && threshold_reached`, first return `GcRef(0)`, second strike `panic!` (incminimark parity).
- **pyre-jit: route compiled-code `ExitFrameWithException` through the frame's exception table** — a JIT-loop OOM now delivers a `MemoryError` that a same-frame `try/except` catches (previously only a caller frame caught it), via the CPython-3.14 exception table (`handle_exception`).
- **cranelift: propagate `MemoryError` on the nursery malloc arms' NULL return** — the four inline/collecting nursery allocation arms lacked the inline null→propagate check that `malloc_cond` inlines (and dynasm already emits), so a bounded-OOM `GcRef(0)` wrote a header to a null pointer and crashed. Extract `emit_memory_error_check` and apply it to `CallMallocNursery{,Headerless,Varsize,VarsizeFrame}`.

## Layout / parity

- **pyframe: pack `escaped` and `frame_finished_execution` into a flags byte.**
- **builtins,typedef: `object.__dir__` arg-count guard and `super(type, obj)` message**; **typedef: remove unused `object_slot_inherited` helper.**
- **pyjitpl: fold `warm_state.get_compiled` into recursive `callee_compiled`.**

## Verification

- `pyre/check.py --backend dynasm` → 225/225
- `pyre/check.py --backend cranelift` → 225/225
- `PYPY_GC_MAX` OOM repros (same-frame / caller-frame / nested / varsize / bare) catch `MemoryError` (or print a proper traceback) on both backends.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
