### PR TITLE
jit: fix seven differential-fuzz miscompiles/crashes (DELETE_FAST, unary int, neg-slice del, nested FOR_ITER, bignum-through-local, yield-from)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1565,6 +1565,7 @@ dependencies = [
  "smallvec",
  "wasm-bindgen",
  "wasm-encoder 0.245.1",
+ "wasmi",
  "wasmparser 0.225.0",
 ]
 

--- a/majit/majit-backend-wasm/Cargo.toml
+++ b/majit/majit-backend-wasm/Cargo.toml
@@ -34,3 +34,4 @@ wasm-bindgen = { workspace = true, optional = true }
 majit-ir = { workspace = true, features = ["test-support"] }
 wasmparser = { workspace = true }
 smallvec = { workspace = true }
+wasmi = "1.1"

--- a/majit/majit-backend-wasm/src/codegen.rs
+++ b/majit/majit-backend-wasm/src/codegen.rs
@@ -4478,6 +4478,36 @@ fn find_label_args(ops: &[Op], jump: &Op) -> Vec<OpRef> {
     Vec::new()
 }
 
+/// A legacy pool-indexed const that is absent from the constants pool at emit
+/// time is an optimizer-seeding invariant violation — panic loudly, matching
+/// `collect_constants_from_ops`' `missing_legacy_const`, instead of emitting a
+/// silent `0`. On native a null Ref traps on the first dereference; wasm's
+/// offset 0 is valid linear memory, so a silent `0` is read as garbage and
+/// miscompiles quietly rather than crashing.
+#[cold]
+#[inline(never)]
+fn missing_emit_const(opref: OpRef) -> ! {
+    panic!(
+        "wasm emit_resolve: legacy pool-indexed const OpRef (raw={}) is absent \
+         from the constants pool — the optimizer producer must seed it (or mint \
+         an inline Const) instead of emitting a silent 0.",
+        opref.raw()
+    );
+}
+
+/// Resolve a constant operand's i64 bits: the inline `Const` value if the
+/// variant carries one (`history.py:227/268/314`), else the legacy pool entry.
+/// A pool miss panics via [`missing_emit_const`] rather than falling back to a
+/// silent `0`.
+fn resolve_const_bits(constants: &indexmap::IndexMap<u32, i64>, opref: OpRef) -> i64 {
+    opref.inline_const_bits().unwrap_or_else(|| {
+        constants
+            .get(&opref.raw())
+            .copied()
+            .unwrap_or_else(|| missing_emit_const(opref))
+    })
+}
+
 fn emit_resolve(
     sink: &mut InstructionSink<'_>,
     constants: &indexmap::IndexMap<u32, i64>,
@@ -4485,10 +4515,7 @@ fn emit_resolve(
     opref: OpRef,
 ) {
     if opref.is_constant() {
-        // history.py:227/268/314 — inline-Const variants carry value inline.
-        let val = opref
-            .inline_const_bits()
-            .unwrap_or_else(|| constants.get(&opref.raw()).copied().unwrap_or(0));
+        let val = resolve_const_bits(constants, opref);
         sink.i64_const(val);
     } else {
         sink.local_get(1 + opref.raw());
@@ -4507,9 +4534,7 @@ fn emit_resolve_f64(
     opref: OpRef,
 ) {
     if opref.is_constant() {
-        let val = opref
-            .inline_const_bits()
-            .unwrap_or_else(|| constants.get(&opref.raw()).copied().unwrap_or(0));
+        let val = resolve_const_bits(constants, opref);
         sink.i64_const(val);
         sink.f64_reinterpret_i64();
     } else {
@@ -4521,11 +4546,9 @@ fn emit_resolve_f64(
 /// Compile-time value of a constant operand (what `emit_resolve` would push
 /// as `i64.const`), or `None` for a runtime value.
 fn const_operand_value(constants: &indexmap::IndexMap<u32, i64>, opref: OpRef) -> Option<i64> {
-    opref.is_constant().then(|| {
-        opref
-            .inline_const_bits()
-            .unwrap_or_else(|| constants.get(&opref.raw()).copied().unwrap_or(0))
-    })
+    opref
+        .is_constant()
+        .then(|| resolve_const_bits(constants, opref))
 }
 
 /// Extract field offset from op's descr (FieldDescr).

--- a/majit/majit-backend-wasm/src/codegen.rs
+++ b/majit/majit-backend-wasm/src/codegen.rs
@@ -240,14 +240,15 @@ fn emit_sized_int_store(sink: &mut InstructionSink<'_>, offset: u64, size: usize
     }
 }
 
-/// `(field_size, is_signed)` from an op's FieldDescr; defaults to word-sized
-/// signed when the descr is absent.
+/// `(field_size, is_signed)` from an op's FieldDescr. A field op always carries
+/// a FieldDescr; a missing one is an invariant violation, so panic rather than
+/// emit a silently-wrong width.
 fn field_size_sign_from_descr(op: &Op) -> (usize, bool) {
     let descr = op.getdescr();
     if let Some(fd) = descr.as_ref().and_then(|d| d.as_field_descr()) {
         return (fd.field_size(), fd.is_field_signed());
     }
-    (std::mem::size_of::<usize>(), true)
+    missing_layout_descr("field descr (size/sign)", op)
 }
 
 /// Store width for a `SetfieldGc`/`SetfieldRaw`. A pointer (`Type::Ref`) field
@@ -264,26 +265,27 @@ fn setfield_store_size_from_descr(op: &Op) -> usize {
         }
         return fd.field_size();
     }
-    std::mem::size_of::<usize>()
+    missing_layout_descr("field descr (store size)", op)
 }
 
 fn field_is_float_from_descr(op: &Op) -> bool {
-    op.getdescr()
-        .as_ref()
-        .and_then(|d| d.as_field_descr())
-        .is_some_and(|fd| fd.is_float_field())
+    let descr = op.getdescr();
+    match descr.as_ref().and_then(|d| d.as_field_descr()) {
+        Some(fd) => fd.is_float_field(),
+        None => missing_layout_descr("field descr (is_float)", op),
+    }
 }
 
-/// `(item_size, is_signed)` from an op's ArrayDescr; defaults to 8-byte
-/// signed when the descr is absent.
+/// `(item_size, is_signed)` from an op's ArrayDescr. An array op always carries
+/// an ArrayDescr; a missing one is an invariant violation, so panic.
 fn array_item_size_sign_from_descr(op: &Op) -> (usize, bool) {
     op.with_array_descr(|ad| (ad.item_size(), ad.is_item_signed()))
-        .unwrap_or((8, true))
+        .unwrap_or_else(|| missing_layout_descr("array descr (item size/sign)", op))
 }
 
 fn array_item_is_float_from_descr(op: &Op) -> bool {
     op.with_array_descr(|ad| ad.item_type() == Type::Float)
-        .unwrap_or(false)
+        .unwrap_or_else(|| missing_layout_descr("array descr (item is_float)", op))
 }
 
 /// Dense census of every non-constant Ref-typed value (input arg / op result),
@@ -3638,9 +3640,10 @@ fn build_function(
                 // llmodel.py:778-782: size, type_id, vtable from the size descr.
                 let descr = op.getdescr();
                 let sd = descr.as_ref().and_then(|d| d.as_size_descr());
-                let (size, type_id, vtable) = sd.map_or((16i64, 0i64, 0usize), |sd| {
-                    (sd.size() as i64, sd.type_id() as i64, sd.vtable())
-                });
+                let (size, type_id, vtable) = sd.map_or_else(
+                    || missing_layout_descr("size descr", op),
+                    |sd| (sd.size() as i64, sd.type_id() as i64, sd.vtable()),
+                );
 
                 // Inline nursery bump (rewrite.py malloc fast path, x86
                 // `malloc_cond`): total = align8(max(header+size, MIN)); if
@@ -3817,14 +3820,13 @@ fn build_function(
             OpCode::NewArray | OpCode::NewArrayClear => {
                 let vi = op.pos.get().raw();
                 let descr = op.getdescr();
-                let ad = descr.as_ref().and_then(|d| d.as_array_descr());
-                let (base_size, item_size) = ad.map_or((16i64, 8i64), |ad| {
-                    (ad.base_size() as i64, ad.item_size() as i64)
-                });
-                let len_offset = ad
-                    .and_then(|ad| ad.len_descr())
-                    .map_or(0i64, |ld| ld.offset() as i64);
-                let type_id = ad.map_or(0i64, |ad| ad.type_id() as i64);
+                let ad = descr
+                    .as_ref()
+                    .and_then(|d| d.as_array_descr())
+                    .unwrap_or_else(|| missing_layout_descr("array descr", op));
+                let (base_size, item_size) = (ad.base_size() as i64, ad.item_size() as i64);
+                let len_offset = ad.len_descr().map_or(0i64, |ld| ld.offset() as i64);
+                let type_id = ad.type_id() as i64;
 
                 // Inline nursery bump for arrays of a plain type under the
                 // large-object threshold (same fast path as the `New` arm).
@@ -4451,6 +4453,23 @@ fn missing_emit_const(opref: OpRef) -> ! {
     );
 }
 
+/// A memory-access or allocation op reached codegen without the layout descr it
+/// must carry (Field/Array/Size). Emitting a default offset/size/type_id would
+/// silently miscompile — on wasm, offset 0 is valid linear memory, so a bogus
+/// address reads/writes garbage instead of trapping. Fail loud instead. Dead on
+/// valid traces: every such op carries its descr (RPython invariant), and the
+/// native x86 backend defaults identically without ever hitting the default.
+#[cold]
+#[inline(never)]
+fn missing_layout_descr(what: &str, op: &Op) -> ! {
+    panic!(
+        "wasm codegen: {what} is absent for {:?} — a memory-access/allocation op \
+         must carry its layout descr; a default offset/size/type_id would \
+         silently miscompile.",
+        op.opcode
+    );
+}
+
 /// Resolve a constant operand's i64 bits: the inline `Const` value if the
 /// variant carries one (`history.py:227/268/314`), else the legacy pool entry.
 /// A pool miss panics via [`missing_emit_const`] rather than falling back to a
@@ -4515,7 +4534,7 @@ fn field_offset_from_descr(op: &Op) -> u64 {
             return fd.offset() as u64;
         }
     }
-    0
+    missing_layout_descr("field descr (offset)", op)
 }
 
 /// `(length-field offset, length-field size)` from an op's ArrayDescr length
@@ -4532,7 +4551,7 @@ fn array_len_layout_from_descr(op: &Op) -> (u64, usize) {
             .map(|ld| (ld.offset() as u64, ld.field_size()))
     })
     .flatten()
-    .unwrap_or((8, std::mem::size_of::<usize>()))
+    .unwrap_or_else(|| missing_layout_descr("array descr (len layout)", op))
 }
 
 /// Compute array element address: base + base_size + index * item_size.
@@ -4545,7 +4564,7 @@ fn emit_array_addr(
 ) {
     let (base_size, item_size) = op
         .with_array_descr(|ad| (ad.base_size() as u64, ad.item_size() as u64))
-        .unwrap_or((16, 8));
+        .unwrap_or_else(|| missing_layout_descr("array descr (base/item size)", op));
     emit_resolve(sink, constants, value_types, op.arg(0).to_opref()); // array ptr
     sink.i32_wrap_i64();
     // base + base_size + index * item_size

--- a/majit/majit-backend-wasm/src/codegen.rs
+++ b/majit/majit-backend-wasm/src/codegen.rs
@@ -1703,6 +1703,17 @@ fn build_function(
         sink.i64_store(mem64(frame.home_slot_base + h * SLOT_SIZE));
     }
 
+    // Bind the folded constants the optimizer left under a plain op position
+    // (see `unbound_pool_const_seeds`). Emitted before every block so the
+    // binding dominates the whole body, including a resume-at-LABEL entry.
+    for (raw, bits) in unbound_pool_const_seeds(inputargs, ops, constants, num_vars)? {
+        sink.i64_const(bits);
+        if value_types[raw as usize] == ValType::F64 {
+            sink.f64_reinterpret_i64();
+        }
+        sink.local_set(1 + raw);
+    }
+
     // A peeled loop arrives as `[preamble..][LABEL][body..][JUMP]`: the
     // preamble runs once on entry, the LABEL is the loop-back target, and
     // JUMP branches back to it. Emit the `loop` at the LABEL selected by the
@@ -4516,6 +4527,73 @@ fn emit_resolve_f64(
         debug_assert_eq!(value_types[opref.raw() as usize], ValType::F64);
         sink.local_get(1 + opref.raw());
     }
+}
+
+/// Values the optimizer left as plain (non-`Const`) OpRefs whose only
+/// definition is a constant-pool entry, paired with that entry's raw bits.
+///
+/// Constant folding and the short preamble both hand the backend a folded
+/// value under its original op position, with no producing op left in the
+/// trace. `RegisterManager::loc` (dynasm `regalloc.rs`) covers that case with
+/// a constants-map fallback taken once no register and no frame binding is
+/// found. wasm materializes every value in a local instead of a location, so
+/// the equivalent binding is a prologue store: without it the never-written
+/// local reads as the zero wasm initializes it to, silently substituting 0
+/// for the folded constant at every use.
+///
+/// Only positions actually read as a plain OpRef are returned, so a trace
+/// whose pool holds no such value emits no extra prologue instruction.
+fn unbound_pool_const_seeds(
+    inputargs: &[InputArg],
+    ops: &[Op],
+    constants: &indexmap::IndexMap<u32, i64>,
+    num_vars: u32,
+) -> Result<Vec<(u32, i64)>, BackendError> {
+    use std::collections::HashSet;
+    let mut defined: HashSet<u32> = inputargs.iter().map(|ia| ia.index).collect();
+    for op in ops {
+        let r = op.pos.get();
+        if r != OpRef::NONE && !r.is_constant() {
+            defined.insert(r.raw());
+        }
+    }
+    let mut seeds: Vec<(u32, i64)> = Vec::new();
+    let mut unresolved: Vec<u32> = Vec::new();
+    let mut seen: HashSet<u32> = HashSet::new();
+    let mut consider = |a: OpRef, seeds: &mut Vec<(u32, i64)>, seen: &mut HashSet<u32>| {
+        if a == OpRef::NONE || a.is_constant() {
+            return;
+        }
+        let raw = a.raw();
+        if raw >= num_vars || defined.contains(&raw) || !seen.insert(raw) {
+            return;
+        }
+        match constants.get(&raw) {
+            Some(&bits) => seeds.push((raw, bits)),
+            // No producer and no pool entry: the local would read as the zero
+            // wasm initializes it to, which is a wrong value, not a missing
+            // one. Decline the trace (the interpreter runs it correctly,
+            // unaccelerated) exactly as the unhandled-opcode arm does.
+            None => unresolved.push(raw),
+        }
+    };
+    for op in ops {
+        for a in op.getarglist().iter() {
+            consider(a.to_opref(), &mut seeds, &mut seen);
+        }
+        if let Some(fa) = op.getfailargs() {
+            for a in fa.iter() {
+                consider(a.to_opref(), &mut seeds, &mut seen);
+            }
+        }
+    }
+    if !unresolved.is_empty() {
+        return Err(BackendError::Unsupported(format!(
+            "wasm codegen: value{unresolved:?} read with no producing op and no \
+             constant-pool entry"
+        )));
+    }
+    Ok(seeds)
 }
 
 /// Compile-time value of a constant operand (what `emit_resolve` would push

--- a/majit/majit-backend-wasm/src/codegen.rs
+++ b/majit/majit-backend-wasm/src/codegen.rs
@@ -2349,15 +2349,19 @@ fn build_function(
                 let vi = op.pos.get().raw();
                 if !OpRef::raw_is_constant(vi) {
                     emit_resolve(&mut sink, constants, value_types, op.arg(0).to_opref());
-                    // num_bytes is arg(1), typically a constant
+                    // num_bytes (arg(1)) is always a compile-time constant;
+                    // resolve it like every other emit-time const so a genuine
+                    // pool miss panics via missing_emit_const instead of silently
+                    // defaulting to 8 (which zeroes the shift and skips the
+                    // narrowing, passing an un-truncated integer through).
                     let arg1 = op.arg(1).to_opref();
-                    let num_bytes = if arg1.is_constant() {
-                        arg1.inline_const_bits()
-                            .or_else(|| constants.get(&arg1.raw()).copied())
-                            .unwrap_or(8)
-                    } else {
-                        8 // default to no-op
-                    };
+                    let num_bytes = const_operand_value(constants, arg1).unwrap_or_else(|| {
+                        panic!(
+                            "wasm int_signext: num_bytes operand (raw={}) is not a \
+                             resolvable compile-time constant",
+                            arg1.raw()
+                        )
+                    });
                     let shift = 64 - num_bytes * 8;
                     if shift > 0 && shift < 64 {
                         sink.i64_const(shift);
@@ -2637,61 +2641,23 @@ fn build_function(
             }
 
             // ── Interior field access ──
-            OpCode::GetinteriorfieldGcI | OpCode::GetinteriorfieldGcR => {
-                let vi = op.pos.get().raw();
-                if !OpRef::raw_is_constant(vi) {
-                    // getinteriorfield(array, index, offset)
-                    emit_resolve(&mut sink, constants, value_types, op.arg(0).to_opref()); // array ptr
-                    sink.i32_wrap_i64();
-                    let field_offset = field_offset_from_descr(op);
-                    // Simplified: use field_offset directly (RPython computes base+index*itemsize+offset)
-                    let (size, signed) = field_size_sign_from_descr(op);
-                    emit_sized_int_load(&mut sink, field_offset, size, signed);
-                    sink.local_set(1 + vi);
-                }
-            }
-            OpCode::GetinteriorfieldGcF => {
-                let vi = op.pos.get().raw();
-                if !OpRef::raw_is_constant(vi) {
-                    emit_resolve(&mut sink, constants, value_types, op.arg(0).to_opref()); // array ptr
-                    sink.i32_wrap_i64();
-                    let field_offset = field_offset_from_descr(op);
-                    sink.f64_load(MemArg {
-                        offset: field_offset,
-                        align: 3,
-                        memory_index: 0,
-                    });
-                    sink.local_set(1 + vi);
-                }
-            }
-            OpCode::SetinteriorfieldGc => {
-                if let Some(base) = write_barrier_base(op, ref_values) {
-                    emit_write_barrier(
-                        &mut sink,
-                        constants,
-                        value_types,
-                        jit_call_idx,
-                        residual_type_base,
-                        wb_fn_ptr,
-                        base,
-                        frame,
-                    );
-                }
-                emit_resolve(&mut sink, constants, value_types, op.arg(0).to_opref());
-                sink.i32_wrap_i64();
-                let field_offset = field_offset_from_descr(op);
-                if field_is_float_from_descr(op) {
-                    emit_resolve_f64(&mut sink, constants, value_types, op.arg(2).to_opref());
-                    sink.f64_store(MemArg {
-                        offset: field_offset,
-                        align: 3,
-                        memory_index: 0,
-                    });
-                } else {
-                    emit_resolve(&mut sink, constants, value_types, op.arg(2).to_opref()); // value
-                    let (size, _signed) = field_size_sign_from_descr(op);
-                    emit_sized_int_store(&mut sink, field_offset, size);
-                }
+            // getinteriorfield/setinteriorfield address an interior field of an
+            // array element at `base + base_size + index*item_size + offset`. The
+            // prior lowering resolved only arg(0) (the array ptr) and applied
+            // field_offset_from_descr (which returns 0 for an InteriorFieldDescr),
+            // dropping arg(1) (the index) entirely, so it read/wrote element 0's
+            // field regardless of index — a silent wrong-memory access (wasm
+            // offset 0 is valid linear memory, so it does not trap). Decline and
+            // let the metainterp fall back to the interpreter, which addresses the
+            // interior field correctly.
+            OpCode::GetinteriorfieldGcI
+            | OpCode::GetinteriorfieldGcR
+            | OpCode::GetinteriorfieldGcF
+            | OpCode::SetinteriorfieldGc => {
+                return Err(BackendError::Unsupported(format!(
+                    "wasm codegen: interior-field op {:?} (index-aware addressing unimplemented)",
+                    op.opcode
+                )));
             }
 
             // ── String/Unicode ops (direct memory access) ──
@@ -2726,37 +2692,27 @@ fn build_function(
             }
 
             // ── GC memory ops ──
-            OpCode::GcLoadI => {
-                let vi = op.pos.get().raw();
-                if !OpRef::raw_is_constant(vi) {
-                    emit_resolve(&mut sink, constants, value_types, op.arg(0).to_opref());
-                    sink.i32_wrap_i64();
-                    let offset = field_offset_from_descr(op);
-                    sink.i64_load(mem64(offset));
-                    sink.local_set(1 + vi);
-                }
-            }
-            OpCode::GcLoadR => {
-                let vi = op.pos.get().raw();
-                if !OpRef::raw_is_constant(vi) {
-                    emit_resolve(&mut sink, constants, value_types, op.arg(0).to_opref());
-                    sink.i32_wrap_i64();
-                    let offset = field_offset_from_descr(op);
-                    sink.i32_load(MemArg {
-                        offset,
-                        align: 2,
-                        memory_index: 0,
-                    });
-                    sink.i64_extend_i32_u();
-                    sink.local_set(1 + vi);
-                }
-            }
-            OpCode::GcStore => {
-                emit_resolve(&mut sink, constants, value_types, op.arg(0).to_opref());
-                sink.i32_wrap_i64();
-                let offset = field_offset_from_descr(op);
-                emit_resolve(&mut sink, constants, value_types, op.arg(1).to_opref());
-                sink.i64_store(mem64(offset));
+            // GC_LOAD/GC_STORE and their indexed forms are produced only by the
+            // GC rewrite (majit-gc/src/rewrite.rs): the true semantics are
+            // offset=arg1, size=arg2 (load) / value=arg2, size=arg3 (store), with
+            // no FieldDescr attached. The wasm backend does not run the GC rewrite,
+            // so these never reach here. The prior lowering read a nonexistent
+            // field_offset_from_descr (→ 0) and, for GcStore, stored arg(1) (the
+            // offset operand) as the value — a silent miscompile. Panic loudly like
+            // LoadFromGcTable rather than emit a wrong memory access.
+            OpCode::GcLoadI
+            | OpCode::GcLoadR
+            | OpCode::GcLoadF
+            | OpCode::GcLoadIndexedI
+            | OpCode::GcLoadIndexedR
+            | OpCode::GcLoadIndexedF
+            | OpCode::GcStore
+            | OpCode::GcStoreIndexed => {
+                panic!(
+                    "wasm backend: {:?} is unsupported (GC_LOAD/GC_STORE); \
+                     the GC rewrite must not run for wasm",
+                    op.opcode
+                );
             }
 
             // ── Raw memory access ──

--- a/majit/majit-backend-wasm/src/codegen.rs
+++ b/majit/majit-backend-wasm/src/codegen.rs
@@ -1639,25 +1639,31 @@ fn build_function(
     // while `WASM_DIRECT_RESIDUAL_CALL` is enabled). Its `jit_call` fallback
     // branches are retained solely for the direct-family-disabled baseline.
     debug_assert!(!ca.emit_ca || residual_type_base.is_some());
-    // Value locals occupy `1 ..= num_vars`; reserve `UMULHI_SCRATCH` extra i64
-    // locals past them (`num_vars+1 ..= num_vars+UMULHI_SCRATCH`) as scratch for
-    // the `UintMulHigh` 32-bit-split expansion (`emit_umulhi`). One i32 local
-    // past those (`num_vars+UMULHI_SCRATCH+1`) holds the bridge table slot for
-    // the epilogue `call_indirect` dispatch (unused when `!bridge_dispatch`).
-    let bridge_slot_local = num_vars + UMULHI_SCRATCH + 1;
+    // Value locals occupy `1 ..= num_vars`; reserve `UMULHI_SCRATCH` i64 locals
+    // past them (`num_vars+1 ..= num_vars+UMULHI_SCRATCH`) for the `UintMulHigh`
+    // 32-bit-split expansion, plus one i64 local for the pending overflow flag.
+    // One i32 local past those holds the bridge table slot for the epilogue
+    // `call_indirect` dispatch (unused when `!bridge_dispatch`).
+    let ovf_flag_local = num_vars + UMULHI_SCRATCH + 1;
+    let bridge_slot_local = num_vars + UMULHI_SCRATCH + 2;
     // The self-recursive CALL_ASSEMBLER arm needs two more i32 scratch locals:
     // `ca_cfp_local` (the current callee frame pointer) and `ca_fi_local` (the
     // returned frame[0] fail index). Reserve them only under `emit_ca` so a
     // flag-off module keeps exactly one i32 local (byte-identical).
-    let ca_cfp_local = num_vars + UMULHI_SCRATCH + 2;
-    let ca_fi_local = num_vars + UMULHI_SCRATCH + 3;
+    let ca_cfp_local = num_vars + UMULHI_SCRATCH + 3;
+    let ca_fi_local = num_vars + UMULHI_SCRATCH + 4;
     // Extra i32 scratches when the inline nursery-bump fast path is armed:
     // one holds the loaded `nursery_free` across the bump/commit sequence;
     // runtime varsize array allocation also needs one for the computed
     // total/new-free word.
     let base_i32_locals: u32 = if ca.emit_ca { 3 } else { 1 };
-    let alloc_scratch_local = num_vars + UMULHI_SCRATCH + 1 + base_i32_locals;
+    let alloc_scratch_local = num_vars + UMULHI_SCRATCH + 2 + base_i32_locals;
     let alloc_size_local = alloc_scratch_local + 1;
+    debug_assert_eq!(bridge_slot_local, ovf_flag_local + 1);
+    debug_assert_eq!(ca_cfp_local, bridge_slot_local + 1);
+    debug_assert_eq!(ca_fi_local, ca_cfp_local + 1);
+    debug_assert_eq!(alloc_scratch_local, bridge_slot_local + base_i32_locals);
+    debug_assert_eq!(alloc_size_local, alloc_scratch_local + 1);
     debug_assert_eq!(value_types.len(), num_vars as usize);
     let mut locals = Vec::new();
     let mut start = 0;
@@ -1671,9 +1677,9 @@ fn build_function(
         start = end;
     }
     if let Some((count, ValType::I64)) = locals.last_mut() {
-        *count += UMULHI_SCRATCH;
+        *count += UMULHI_SCRATCH + 1;
     } else {
-        locals.push((UMULHI_SCRATCH, ValType::I64));
+        locals.push((UMULHI_SCRATCH + 1, ValType::I64));
     }
     locals.push((
         base_i32_locals
@@ -1807,6 +1813,7 @@ fn build_function(
     let mut guard_idx = fail_index_base;
     let mut in_loop_body = false;
     let mut labels_passed = 0usize;
+    let mut ovf_flag_live = false;
 
     for (op_idx, op) in ops.iter().enumerate() {
         if op.opcode == OpCode::Label && key_dispatch {
@@ -2093,23 +2100,39 @@ fn build_function(
             }
             OpCode::GuardNoOverflow => {
                 // RPython: 0 args — overflow flag implicit from preceding ovf op.
-                // Wasm MVP doesn't detect overflow, so always passes.
+                // If the optimizer proved the operation cannot overflow, the
+                // overflow op is absent and this guard is redundant.
+                if !ovf_flag_live {
+                    guard_idx += 1;
+                    continue;
+                }
+                ovf_flag_live = false;
+                sink.local_get(ovf_flag_local);
+                sink.i64_const(0);
+                sink.i64_ne();
+                emit_guard_if_exit(
+                    &mut sink,
+                    constants,
+                    value_types,
+                    guard_idx,
+                    op,
+                    block_exit_depth,
+                );
                 guard_idx += 1;
             }
             OpCode::GuardOverflow => {
-                // Always fails (no overflow detected in wasm MVP).
-                emit_guard_exit(&mut sink, constants, value_types, guard_idx, op);
-                match block_exit_depth {
-                    Some(d) => {
-                        sink.br(d);
-                    }
-                    // Straight-line: return directly so the following ops and
-                    // the terminal Finish do not overwrite this exit.
-                    None => {
-                        sink.local_get(0);
-                        sink.return_();
-                    }
-                }
+                assert!(ovf_flag_live, "GuardOverflow without preceding overflow op");
+                ovf_flag_live = false;
+                sink.local_get(ovf_flag_local);
+                sink.i64_eqz();
+                emit_guard_if_exit(
+                    &mut sink,
+                    constants,
+                    value_types,
+                    guard_idx,
+                    op,
+                    block_exit_depth,
+                );
                 guard_idx += 1;
             }
             OpCode::GuardNotInvalidated => {
@@ -2220,13 +2243,37 @@ fn build_function(
 
             // Overflow variants: compute result + overflow flag
             OpCode::IntAddOvf => {
-                emit_ovf_binop(&mut sink, constants, value_types, op, BinOp::I64Add)
+                ovf_flag_live = emit_ovf_binop(
+                    &mut sink,
+                    constants,
+                    value_types,
+                    op,
+                    BinOp::I64Add,
+                    num_vars,
+                    ovf_flag_local,
+                );
             }
             OpCode::IntSubOvf => {
-                emit_ovf_binop(&mut sink, constants, value_types, op, BinOp::I64Sub)
+                ovf_flag_live = emit_ovf_binop(
+                    &mut sink,
+                    constants,
+                    value_types,
+                    op,
+                    BinOp::I64Sub,
+                    num_vars,
+                    ovf_flag_local,
+                );
             }
             OpCode::IntMulOvf => {
-                emit_ovf_binop(&mut sink, constants, value_types, op, BinOp::I64Mul)
+                ovf_flag_live = emit_ovf_binop(
+                    &mut sink,
+                    constants,
+                    value_types,
+                    op,
+                    BinOp::I64Mul,
+                    num_vars,
+                    ovf_flag_local,
+                );
             }
 
             // ── Integer comparisons (signed) ──
@@ -4634,6 +4681,7 @@ fn emit_guard_exit(
 
 // ── Binary ops ──
 
+#[derive(Clone, Copy)]
 enum BinOp {
     I64Add,
     I64Sub,
@@ -4720,6 +4768,17 @@ fn emit_umulhi(
     if OpRef::raw_is_constant(vi) {
         return;
     }
+    emit_umulhi_to_local(sink, constants, value_types, op, num_vars, 1 + vi);
+}
+
+fn emit_umulhi_to_local(
+    sink: &mut InstructionSink<'_>,
+    constants: &indexmap::IndexMap<u32, i64>,
+    value_types: &[ValType],
+    op: &Op,
+    num_vars: u32,
+    output_local: u32,
+) {
     const MASK32: i64 = 0xFFFF_FFFF;
     let al = num_vars + 1;
     let ah = num_vars + 2;
@@ -4779,22 +4838,86 @@ fn emit_umulhi(
     sink.i64_shr_u();
     sink.i64_add();
 
-    sink.local_set(1 + vi);
+    sink.local_set(output_local);
 }
 
-/// Overflow binary op: stores result in pos, overflow flag convention.
-/// The overflow flag is not stored separately — GuardNoOverflow/GuardOverflow
-/// is handled by checking after the fact (simplified for wasm MVP).
+/// Overflow binary op: stores the wrapping result in pos and the signed
+/// overflow flag in the dedicated scratch local.
 fn emit_ovf_binop(
     sink: &mut InstructionSink<'_>,
     constants: &indexmap::IndexMap<u32, i64>,
     value_types: &[ValType],
     op: &Op,
     binop: BinOp,
-) {
-    // For wasm MVP, just compute the result without overflow detection.
-    // GuardNoOverflow/GuardOverflow are treated as always-pass.
-    emit_binop(sink, constants, value_types, op, binop);
+    num_vars: u32,
+    ovf_flag_local: u32,
+) -> bool {
+    let vi = op.pos.get().raw();
+    if OpRef::raw_is_constant(vi) {
+        return false;
+    }
+    let result_local = 1 + vi;
+
+    emit_resolve(sink, constants, value_types, op.arg(0).to_opref());
+    emit_resolve(sink, constants, value_types, op.arg(1).to_opref());
+    apply_binop(sink, binop);
+    sink.local_set(result_local);
+
+    match binop {
+        BinOp::I64Add => {
+            // ((a ^ result) & (b ^ result)) >>s 63
+            emit_resolve(sink, constants, value_types, op.arg(0).to_opref());
+            sink.local_get(result_local);
+            sink.i64_xor();
+            emit_resolve(sink, constants, value_types, op.arg(1).to_opref());
+            sink.local_get(result_local);
+            sink.i64_xor();
+            sink.i64_and();
+            sink.i64_const(63);
+            sink.i64_shr_s();
+            sink.local_set(ovf_flag_local);
+        }
+        BinOp::I64Sub => {
+            // ((a ^ b) & (a ^ result)) >>s 63
+            emit_resolve(sink, constants, value_types, op.arg(0).to_opref());
+            emit_resolve(sink, constants, value_types, op.arg(1).to_opref());
+            sink.i64_xor();
+            emit_resolve(sink, constants, value_types, op.arg(0).to_opref());
+            sink.local_get(result_local);
+            sink.i64_xor();
+            sink.i64_and();
+            sink.i64_const(63);
+            sink.i64_shr_s();
+            sink.local_set(ovf_flag_local);
+        }
+        BinOp::I64Mul => {
+            // Convert the unsigned high word to the signed high word:
+            // smulhi = umulhi - ((a >>s 63) & b) - ((b >>s 63) & a).
+            let high_local = num_vars + 1;
+            emit_umulhi_to_local(sink, constants, value_types, op, num_vars, high_local);
+            sink.local_get(high_local);
+            emit_resolve(sink, constants, value_types, op.arg(0).to_opref());
+            sink.i64_const(63);
+            sink.i64_shr_s();
+            emit_resolve(sink, constants, value_types, op.arg(1).to_opref());
+            sink.i64_and();
+            sink.i64_sub();
+            emit_resolve(sink, constants, value_types, op.arg(1).to_opref());
+            sink.i64_const(63);
+            sink.i64_shr_s();
+            emit_resolve(sink, constants, value_types, op.arg(0).to_opref());
+            sink.i64_and();
+            sink.i64_sub();
+            sink.local_get(result_local);
+            sink.i64_const(63);
+            sink.i64_shr_s();
+            sink.i64_ne();
+            sink.i64_extend_i32_u();
+            sink.local_set(ovf_flag_local);
+        }
+        _ => unreachable!("overflow emitter requires add, sub, or mul"),
+    }
+    true
 }
 
 // ── Comparison ops ──

--- a/majit/majit-backend-wasm/tests/codegen_test.rs
+++ b/majit/majit-backend-wasm/tests/codegen_test.rs
@@ -11,6 +11,7 @@ use majit_backend_wasm::codegen;
 use majit_ir::operand::Operand;
 use majit_ir::{InputArg, Op, OpCode, OpRef, Type};
 use smallvec::smallvec;
+use wasmi::{Engine, Linker, Memory, MemoryType, Module, Store};
 
 fn validate_wasm(bytes: &[u8]) {
     wasmparser::validate(bytes).expect("generated wasm should be valid");
@@ -235,6 +236,112 @@ fn build_module_default(
         Some(0),
         &codegen::GuardGcTypeInfo::default(),
     )
+}
+
+fn execute_ovf_trace_with_guard(
+    opcode: OpCode,
+    guard_opcode: OpCode,
+    a: i64,
+    b: i64,
+) -> (i64, i64) {
+    let inputargs = vec![
+        InputArg::from_type(Type::Int, 0),
+        InputArg::from_type(Type::Int, 1),
+    ];
+    let guard = Op::new(guard_opcode, &[]);
+    guard.setfailargs(smallvec![rb(OpRef::input_arg_int(0))]);
+    let finish = Op::new(OpCode::Finish, &[rb(OpRef::int_op(2))]);
+    finish.setfailargs(smallvec![rb(OpRef::int_op(2))]);
+    let ops = vec![
+        make_op(
+            opcode,
+            &[OpRef::input_arg_int(0), OpRef::input_arg_int(1)],
+            OpRef::int_op(2),
+        ),
+        guard,
+        finish,
+    ];
+    let (bytes, _) = build_module_default(&inputargs, &ops, &indexmap::IndexMap::new());
+
+    let engine = Engine::default();
+    let module = Module::new(&engine, &bytes).expect("generated trace should compile");
+    let mut store = Store::new(&engine, ());
+    let memory =
+        Memory::new(&mut store, MemoryType::new(1, None)).expect("test memory should allocate");
+    memory
+        .write(
+            &mut store,
+            codegen::FRAME_SLOT_BASE as usize,
+            &a.to_le_bytes(),
+        )
+        .unwrap();
+    memory
+        .write(
+            &mut store,
+            (codegen::FRAME_SLOT_BASE + 8) as usize,
+            &b.to_le_bytes(),
+        )
+        .unwrap();
+    let mut linker = Linker::new(&engine);
+    linker.define("env", "memory", memory).unwrap();
+    let instance = linker
+        .instantiate_and_start(&mut store, &module)
+        .expect("generated trace should instantiate");
+    instance
+        .get_typed_func::<i32, i32>(&store, "trace")
+        .unwrap()
+        .call(&mut store, 0)
+        .expect("generated trace should execute");
+
+    let mut fail_index = [0; 8];
+    let mut result = [0; 8];
+    memory.read(&store, 0, &mut fail_index).unwrap();
+    memory
+        .read(&store, codegen::FRAME_SLOT_BASE as usize, &mut result)
+        .unwrap();
+    (i64::from_le_bytes(fail_index), i64::from_le_bytes(result))
+}
+
+fn execute_ovf_trace(opcode: OpCode, a: i64, b: i64) -> (i64, i64) {
+    execute_ovf_trace_with_guard(opcode, OpCode::GuardNoOverflow, a, b)
+}
+
+#[test]
+fn test_int_add_ovf_guards_overflow() {
+    for (a, b, expected) in [(10, 20, 30), (i64::MIN, 1, i64::MIN + 1)] {
+        assert_eq!(execute_ovf_trace(OpCode::IntAddOvf, a, b), (1, expected));
+    }
+    assert_eq!(execute_ovf_trace(OpCode::IntAddOvf, i64::MAX, 1).0, 0);
+}
+
+#[test]
+fn test_int_sub_ovf_guards_overflow() {
+    for (a, b, expected) in [(100, 58, 42), (i64::MAX, 1, i64::MAX - 1)] {
+        assert_eq!(execute_ovf_trace(OpCode::IntSubOvf, a, b), (1, expected));
+    }
+    assert_eq!(execute_ovf_trace(OpCode::IntSubOvf, i64::MIN, 1).0, 0);
+}
+
+#[test]
+fn test_int_mul_ovf_guards_overflow() {
+    for (a, b, expected) in [(6, 7, 42), (i64::MIN, 1, i64::MIN), (-9, -7, 63)] {
+        assert_eq!(execute_ovf_trace(OpCode::IntMulOvf, a, b), (1, expected));
+    }
+    for (a, b) in [(i64::MIN, -1), (i64::MAX, 2), (1_i64 << 62, 3)] {
+        assert_eq!(execute_ovf_trace(OpCode::IntMulOvf, a, b).0, 0);
+    }
+}
+
+#[test]
+fn test_guard_overflow_uses_pending_flag() {
+    assert_eq!(
+        execute_ovf_trace_with_guard(OpCode::IntAddOvf, OpCode::GuardOverflow, i64::MAX, 1,).0,
+        1
+    );
+    assert_eq!(
+        execute_ovf_trace_with_guard(OpCode::IntAddOvf, OpCode::GuardOverflow, 1, 2).0,
+        0
+    );
 }
 
 #[test]

--- a/majit/majit-metainterp/src/optimizeopt/unroll.rs
+++ b/majit/majit-metainterp/src/optimizeopt/unroll.rs
@@ -1244,7 +1244,7 @@ impl UnrollOptimizer {
         }
 
         // ── unroll.py:140-175: finalize + jump_to_existing_trace ──
-        let imported_short_aliases = opt_p2.imported_short_aliases.clone();
+        let mut imported_short_aliases = opt_p2.imported_short_aliases.clone();
         // finalize_short_preamble: create TargetToken for this loop version
         // RPython parity: short preamble ops reference constant OpRefs from
         // the loop's constant pool. Pass consts_p1 so the ShortPreamble
@@ -1402,6 +1402,29 @@ impl UnrollOptimizer {
                                 .potential_extra_ops
                                 .iter()
                                 .any(|(k, _)| *k == arg || *k == resolved);
+                            if !needs_force {
+                                // RPython keeps the exported result and its
+                                // body use as one Box. A forwarded Phase-2
+                                // placeholder needs the preserved exported
+                                // Box to recover the same ownership path.
+                                if let Some((_, produced)) =
+                                    exported_short_boxes_produced.iter().find(|(_, produced)| {
+                                        let source = produced.res.to_opref();
+                                        source != arg
+                                            && final_ctx.get_replacement_opref(source) == arg
+                                    })
+                                {
+                                    let preamble_op = crate::optimizeopt::info::PreambleOp {
+                                        op: produced.res.clone(),
+                                        invented_name: produced.invented_name,
+                                        preamble_op: produced.preamble_op.clone(),
+                                        same_as_source: produced.same_as_source.clone(),
+                                    };
+                                    let source = final_ctx.force_op_from_preamble_op(&preamble_op);
+                                    let _ = opt_p2.force_box(source, &mut final_ctx);
+                                    continue;
+                                }
+                            }
                             if needs_force {
                                 let _ = opt_p2.force_box(arg, &mut final_ctx);
                             }
@@ -1410,6 +1433,7 @@ impl UnrollOptimizer {
                 }
                 let rebuilt = final_ctx.build_imported_short_preamble();
                 let builder = final_ctx.imported_short_preamble_builder.clone();
+                imported_short_aliases = final_ctx.used_imported_short_aliases();
                 opt_p2.final_ctx = Some(final_ctx);
                 (builder, rebuilt)
             } else {

--- a/pyre/bench/synth/binary_int_overflow_local_resume.py
+++ b/pyre/bench/synth/binary_int_overflow_local_resume.py
@@ -1,0 +1,56 @@
+# Overflowing integer operations must resume with the values that were loaded
+# from local slots, including values produced by recursive calls and unpacking.
+
+MODULUS = 1000000007
+
+
+def factorial_local(n):
+    if n <= 1:
+        return 1
+    a = factorial_local(n - 1)
+    return a * n
+
+
+def factorial_inline(n):
+    if n <= 1:
+        return 1
+    return factorial_inline(n - 1) * n
+
+
+def factorial_total(function, n, repetitions):
+    total = 0
+    for i in range(repetitions):
+        total = (total + function(n)) % MODULUS
+    return total
+
+
+def fibpair(n):
+    if n == 0:
+        return (0, 1)
+    a, b = fibpair(n - 1)
+    return (b, a + b)
+
+
+def fibpair_total(n, repetitions):
+    total = 0
+    for i in range(repetitions):
+        a, b = fibpair(n)
+        total = (total + b % MODULUS) % MODULUS
+    return total
+
+
+def plain_bignum_multiply(repetitions):
+    value = 1 << 62
+    total = 0
+    for i in range(repetitions):
+        product = value * (i % 5 + 2)
+        total = (total + product % MODULUS) % MODULUS
+    return total
+
+
+print(factorial_total(factorial_local, 21, 200))
+print(factorial_total(factorial_inline, 21, 200))
+print(factorial_total(factorial_local, 20, 200))
+print(fibpair_total(93, 8000))
+print(fibpair_total(40, 8000))
+print(plain_bignum_multiply(20000))

--- a/pyre/bench/synth/nested_for_outer_local_postread.py
+++ b/pyre/bench/synth/nested_for_outer_local_postread.py
@@ -1,0 +1,44 @@
+def variable_inner(n):
+    total = 0
+    for i in range(n):
+        outer = i % 5
+        for j in range(outer):
+            pass
+        total += outer
+    return total
+
+
+def constant_inner(n):
+    total = 0
+    for i in range(n):
+        outer = i % 5
+        for j in range(3):
+            pass
+        total += outer
+    return total
+
+
+def single_loop(n):
+    total = 0
+    for i in range(n):
+        local = i % 5
+        total += local
+    return total
+
+
+def three_levels(n):
+    total = 0
+    for i in range(n):
+        outer = i % 7
+        for j in range(outer):
+            middle = j % 3
+            for k in range(middle):
+                pass
+        total += outer
+    return total
+
+
+print(variable_inner(20000))
+print(constant_inner(20000))
+print(single_loop(20000))
+print(three_levels(12000))

--- a/pyre/bench/synth/unary_int_loop_carried.py
+++ b/pyre/bench/synth/unary_int_loop_carried.py
@@ -1,0 +1,37 @@
+# Unary operations must observe the current loop-carried integer. Exercise
+# both ordinary values and the large-integer boundary, plus neighboring
+# operations that serve as controls. Deterministic.
+
+
+def loop_carried_neg(n):
+    s = 1000
+    acc = 0
+    for i in range(n):
+        s -= 1
+        acc += -s
+    return s
+
+
+def large_neg(n):
+    t = 0
+    s = -(1 << 62)
+    for i in range(n):
+        s += i
+        t += -s
+    return t
+
+
+def controls(n):
+    s = 1000
+    acc = 0
+    for i in range(n):
+        s -= 1
+        acc += s
+        acc += 0 - s
+        acc += abs(i % 17)
+    return s, acc, -7
+
+
+print(loop_carried_neg(30000))
+print(large_neg(20000))
+print(controls(30000))

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -8621,13 +8621,17 @@ impl JitState for PyreJitState {
                 backend,
                 &mut virtuals_cache,
             );
-            // The Int bank is color-indexed (no slot overlay to defer to), and
-            // for a kept-stack branch guard the walk resumes at the guard's own
-            // coordinate where `reg_indices.int` colors are authoritative — so
-            // stamp the concrete directly here (the `seed_deferred_to_overlay`
-            // deferral only applies to the Ref slot-mirror). The guard's
-            // GUARD_TRUE/GUARD_FALSE needs this concrete to fold its direction.
-            if seed_bridge_locals && !matches!(concrete_val, majit_ir::Value::Void) {
+            // The Int bank is color-indexed and can be seeded directly only
+            // when the frame position names its exact liveness marker.  A
+            // resolved body coordinate can share a marker whose Int color is
+            // an earlier scratch value; treating that value as the current
+            // branch condition lets a nested FOR_ITER bridge take the wrong
+            // arm.  Leave such scratches symbolic, as RPython does when an
+            // unboxed temporary is absent from the exact resume position.
+            if seed_bridge_locals
+                && !seed_deferred_to_overlay
+                && !matches!(concrete_val, majit_ir::Value::Void)
+            {
                 ctx.try_set_opref_concrete(resolved, concrete_val);
             }
             let reg_idx = reg_idx as usize;

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -2751,6 +2751,12 @@ fn collect_loop_body_referenced_roots(
             return;
         };
         match instr {
+            I::LoadName { namei } => {
+                let name_idx = namei.get(op_arg) as usize;
+                if let Some(name) = code.names.get(name_idx) {
+                    global_names.insert(name.to_string());
+                }
+            }
             I::LoadGlobal { namei } => {
                 let name_idx = (namei.get(op_arg) as usize) >> 1;
                 if let Some(name) = code.names.get(name_idx) {
@@ -2848,7 +2854,7 @@ fn collect_loop_body_referenced_roots(
 /// The scan resolves candidate callees CONCRETELY from the live frame (the
 /// walk has not run yet, so no store has executed).  Two root seed sources,
 /// both scoped to identifiers the loop body or its in-loop handlers read:
-/// - module globals named by loop-body `LOAD_GLOBAL`;
+/// - module globals named by loop-body `LOAD_GLOBAL` or `LOAD_NAME`;
 /// - ROOT-frame fastlocals + closure cells whose slots are read by loop-body
 ///   local-load opcodes.
 ///
@@ -3075,6 +3081,49 @@ fn loop_inlines_abort_permanent_callee(
     None
 }
 
+/// True when the loop header is about to resume a generator whose body uses
+/// SEND delegation.
+///
+/// The full-body walker executes iterator advances while recording.  A SEND
+/// marker aborts that walk, but the delegated iterator is shared with the live
+/// generator frame, so replaying from the loop header would observe the
+/// already-advanced delegate and drop values.  The upstream blackhole path
+/// continues forward from the live generator frame.  Until that forward
+/// resume is available here, decline before the first shared-iterator advance.
+fn loop_iterates_send_generator(cf_addr: usize, start_pc: usize) -> bool {
+    if cf_addr == 0 {
+        return false;
+    }
+    unsafe {
+        let frame = &*(cf_addr as *const pyre_interpreter::pyframe::PyFrame);
+        let code = frame.code();
+        if !matches!(
+            pyre_interpreter::decode_instruction_at(code, start_pc),
+            Some((pyre_interpreter::Instruction::ForIter { .. }, _))
+        ) || frame.valuestackdepth <= frame.stack_base()
+        {
+            return false;
+        }
+
+        let iterator = frame.peek();
+        if !pyre_object::generator::is_generator_or_coroutine(iterator) {
+            return false;
+        }
+        let generator_frame = pyre_object::generator::w_generator_get_frame(iterator)
+            as *const pyre_interpreter::pyframe::PyFrame;
+        if generator_frame.is_null() {
+            return false;
+        }
+        let generator_code = (*generator_frame).code();
+        (0..generator_code.instructions.len()).any(|pc| {
+            matches!(
+                pyre_interpreter::decode_instruction_at(generator_code, pc),
+                Some((pyre_interpreter::Instruction::Send { .. }, _))
+            )
+        })
+    }
+}
+
 /// Whether [`full_body_walk_trace`] starts a fresh walk or continues one that
 /// has already applied eager stores.
 enum WalkJournals {
@@ -3125,6 +3174,16 @@ fn full_body_walk_trace<Sym: WalkSym>(
         crate::jitcode_dispatch::census_record("FullBodyWalk::LoopBodyAbortPermanent");
         if std::env::var_os("PYRE_FBW_DEBUG_ABORT").is_some() {
             eprintln!("[fbw-abort] start_pc={start_pc} abort_permanent_pc={abort_pc}");
+        }
+        fbw_decline(crate::driver::make_green_key(w_code, start_pc));
+        return TraceAction::Abort;
+    }
+    if loop_iterates_send_generator(cf_addr, start_pc) {
+        crate::jitcode_dispatch::census_record("FullBodyWalk::SendGeneratorIterator");
+        if crate::jitcode_dispatch::fbw_debug_abort_enabled() {
+            eprintln!(
+                "[fbw-abort] start_pc={start_pc} SEND generator iterator; declining before delegation"
+            );
         }
         fbw_decline(crate::driver::make_green_key(w_code, start_pc));
         return TraceAction::Abort;

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -11524,6 +11524,22 @@ impl CodeWriter {
                                 )
                             {
                                 emit_abort_permanent!(py_pc);
+                                // The bailout is a graph terminator even though
+                                // the runtime transfers control back to the
+                                // interpreter before reaching its successor.
+                                // Close it explicitly so `flatten.py make_link`
+                                // enters this block and emits the
+                                // bailout instead of treating its FrameState-
+                                // wide input arguments as a direct return.
+                                append_exit(
+                                    &current_block.block(),
+                                    super::flow::Link::new(
+                                        vec![super::flow::Constant::none().into()],
+                                        Some(graph.returnblock.clone()),
+                                        None,
+                                    )
+                                    .into_ref(),
+                                );
                                 continue;
                             }
                             let code_const: super::flow::FlowValue = super::flow::Constant::new(
@@ -16039,6 +16055,49 @@ def f(n):
                 .find_compiled_jitcode_arc(code_ptr)
                 .is_some(),
             "walker must close catch landings discovered while draining a handler"
+        );
+    }
+
+    #[test]
+    fn walker_delete_before_break_closes_unbound_load_bailout() {
+        let source = "\
+def f(n):
+    acc = 0
+    for i in range(n):
+        x = i
+        for j in range(10):
+            if j == 5:
+                del x
+                break
+        try:
+            acc += x
+        except UnboundLocalError:
+            acc += 7
+    return acc
+";
+        let code = first_nested_function_code(source);
+        let w_code = pyre_interpreter::box_code_constant(&code);
+        let code_ptr = unsafe {
+            pyre_interpreter::w_code_get_ptr(w_code) as *const pyre_interpreter::CodeObject
+        };
+        let writer = CodeWriter::new();
+        writer.setup_jitdriver(crate::jit::call::JitDriverStaticData {
+            portal_graph: code_ptr,
+            mainjitcode: None,
+        });
+
+        writer.make_jitcodes();
+
+        let pyjit = writer
+            .callcontrol()
+            .find_compiled_jitcode_arc(code_ptr)
+            .expect("DELETE_FAST break continuation must produce a jitcode");
+        let opnames: Vec<_> = pyre_jit_trace::jitcode_runtime::decoded_ops(&pyjit.jitcode.code)
+            .map(|op| op.opname)
+            .collect();
+        assert!(
+            opnames.contains(&"abort_permanent"),
+            "the undefined LOAD_FAST_CHECK must bail to the interpreter"
         );
     }
 

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -8148,6 +8148,31 @@ impl CodeWriter {
                             let _ = binary_op_tag(op_kind)
                                 .expect("unsupported binary op tag in jitcode lowering")
                                 as i64;
+                            let operands_are_local_loads = {
+                                let block = current_block.block();
+                                let block = block.borrow();
+                                current_state.stack.len() >= 2
+                                    && current_state.stack.iter().rev().take(2).all(|value| {
+                                        block.operations.iter().rev().any(|operation| {
+                                            operation.opname == "getarrayitem_vable_r"
+                                                && operation.result.as_ref() == Some(value)
+                                        })
+                                    })
+                            };
+                            // RPython puts a live marker immediately before
+                            // overflowing integer arithmetic.  Python bytecode
+                            // is dynamically typed, so preserve that boundary
+                            // for the local-load shape handled by the integer
+                            // fast path.
+                            if operands_are_local_loads {
+                                record_graph_op(
+                                    &current_block.block(),
+                                    "-live-",
+                                    Vec::new(),
+                                    None,
+                                    py_pc as i64,
+                                );
+                            }
                             // Pop rhs (blackhole will see vsd reflect this pop).
                             let _ = emit_popvalue_ref!(current_depth, py_pc);
                             let rhs_value = pop_ref_or_fresh(&mut current_state, &mut graph);


### PR DESCRIPTION
## Summary

JIT differential fuzz-hunt on `main`: run each program under the JIT and under `PYRE_NO_JIT=1`
on the same binary (objspace-immune — any output difference is unambiguously a JIT bug), then fix
each divergence. This branch closes seven miscompiles/crashes across both backends (dynasm and
cranelift).

## Fixes (one commit each)

| Commit | Symptom fixed |
|---|---|
| `Fix conditional DELETE_FAST walker merge` | conditional `del x` then reuse: walker merge produced an orphan flatten block (`make_return got N` panic / miscompile) |
| `close the LOAD_FAST_CHECK unbound-local bailout block` | `del x; …; del x` / unbound-local bailout left an exit-less block, panicking in flatten |
| `carry forwarded unary int inputs across loops` | `-s` / `abs(s)` of a loop-carried int froze the value at its compile-in point; large-magnitude unary was low-bits wrong. Forwarded unary int reads were missing from the short-preamble ownership contract |
| `Fix omitted slice step lowering` | `del seq[-3:]` (a negative-bound slice with an omitted step) crashed / deleted the wrong count — the omitted slice step used a null-ref sentinel instead of the `None` singleton, so the slice was never materialized before `DELETE_SUBSCR` |
| `Fix nested FOR_ITER bridge scratch seeding` | reading an outer local after an inner `for j in range(m)` loop returned a stale/garbage value (crash on dynasm, garbage int on cranelift) |
| `preserve local operands for binary overflow resume` | an integer `*`/`+` whose operand is loaded from a local (recursive-call result, tuple unpack) and overflows to a bignum was miscomputed; inlining or non-overflowing values were correct |
| `decline tracing before yield-from delegation` | `yield from <range>` in a hot-loop-consumed generator dropped a bounded number of delegated values at the compile-in transition; declines tracing before SEND delegation can mutate a shared iterator |

## Verification

- Each fix was reproduced (JIT vs `PYRE_NO_JIT` divergence) and confirmed resolved on **both**
  backends, with a full differential re-sweep after each commit showing no new regressions.
- Guard/effect-touching fixes (unary forwarding, binary-overflow resume) were A/B perf-checked: the
  affected hot loops still JIT-compile (unary loop ~34×, bignum loop ~3.7× over the interpreter).
- `pyre/check.py` green on dynasm and cranelift.

## Out of scope (deeper, tracked separately)

The hunt also surfaced three deep items left for follow-up:
- a `list += tuple` abort/replay double-count whose real root is a **nested-loop forward-resume**
  inconsistency (the decline settles the outer walk from an inconsistent resume point), not the
  in-place journaling — needs forward-resume/journal-lifetime rework;
- a select-kept-stack abort variant;
- a pre-existing **wasm32 bignum interpreter** defect (wasm JIT == wasm NOJIT, both wrong for
  bignum arithmetic — not a JIT-lowering bug).
