### PR TITLE
jit: loop-perf follow-ups + decline REC_CA fold for loop-bearing self-recursion

### DIFF
--- a/pyre/bench/synth/for_iter_conditional_store_bridge.py
+++ b/pyre/bench/synth/for_iter_conditional_store_bridge.py
@@ -1,0 +1,13 @@
+def loop_with_two_backedges(n):
+    high = 0
+    for i in range(n):
+        value = i % 7
+        high = value if value > high else high
+        if i % 45 == 0:
+            high = 0
+    return high
+
+
+result = loop_with_two_backedges(4000)
+assert result == 6
+print(result)

--- a/pyre/bench/synth/recursive_call_frame_relocation.py
+++ b/pyre/bench/synth/recursive_call_frame_relocation.py
@@ -1,0 +1,26 @@
+# Deep self-recursion whose caller frame is relocated by a minor collection
+# while the recursive callee runs.  The bytecode CALL fast path drops the
+# arguments, runs the callee, then pushes its result onto the caller's value
+# stack.  The callee allocates enough to trigger a minor collection that moves
+# the caller frame, so the raw pointer captured before the call goes stale; the
+# result push and its valuestackdepth bump must land on the forwarded live
+# frame.  When they hit the abandoned copy the live frame keeps a stack depth
+# one slot short, the following BINARY_OP reads the range iterator instead of
+# the recursion result ("unsupported operand type(s) for +: 'range_iterator'
+# and 'int'"), and the dropped exception segfaults.  cat(5) sums to 5! per
+# call; 1000 outer iterations warm the JIT and sustain the allocation pressure
+# that forces the relocation.  No max-pypy-ratio: branchy recursion is the
+# architectural JIT gap, so this is a correctness/crash guard only.
+def cat(n):
+    if n <= 1:
+        return 1
+    r = 0
+    for k in range(n):
+        r += cat(n - 1)
+    return r
+
+
+total = 0
+for i in range(1000):
+    total += cat(5)
+print(total)

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -159,6 +159,41 @@ pub fn install_current_frame_tls_only(frame: &mut PyFrame) -> CurrentFrameGuard 
     push_current_frame_previous_root(previous, std::ptr::null_mut(), std::ptr::null_mut())
 }
 
+/// Re-anchor a caller frame across a callee call that may run a moving minor
+/// collection.
+///
+/// The interpreter holds the running frame as a raw `&mut PyFrame`, which the
+/// GC does not treat as a managed reference.  When the callee allocates enough
+/// to trigger a minor collection, the caller frame is relocated and that raw
+/// pointer is left aimed at the abandoned nursery copy.  A field write through
+/// it afterwards — the `CALL` result push and its `valuestackdepth` bump —
+/// then lands on dead memory, so the live frame keeps a stack depth one slot
+/// short and the next opcode reads the wrong operands.
+///
+/// Pushing the frame onto the shadow stack lets the root walker forward it in
+/// place during the collection; `live()` reads the forwarded pointer back.
+/// This mirrors the JIT eval layer's `FrameRoot`.
+pub(crate) struct FrameAnchor {
+    depth: usize,
+}
+
+impl FrameAnchor {
+    pub(crate) fn new(frame: &mut PyFrame) -> Self {
+        let depth = majit_gc::shadow_stack::push(majit_ir::GcRef(frame as *mut PyFrame as usize));
+        Self { depth }
+    }
+
+    pub(crate) fn live(&self) -> *mut PyFrame {
+        majit_gc::shadow_stack::get(self.depth).0 as *mut PyFrame
+    }
+}
+
+impl Drop for FrameAnchor {
+    fn drop(&mut self) {
+        majit_gc::shadow_stack::try_pop_to(self.depth);
+    }
+}
+
 /// rpython/memory/gctransform/framework.py `root_walker.walk_roots` parity:
 /// expose every live slot of `PyFrame.locals_cells_stack_w` on the active
 /// f_backref chain as a GC root.
@@ -4012,6 +4047,7 @@ impl OpcodeStepExecutor for PyFrame {
                 && !callable.is_null()
                 && unsafe { crate::is_function(callable) }
             {
+                let anchor = FrameAnchor::new(self);
                 let result =
                     crate::function::funccall_valuestack(callable, nargs, self, nargs + 2, false);
                 if result.is_null() {
@@ -4019,7 +4055,10 @@ impl OpcodeStepExecutor for PyFrame {
                         .unwrap_or_else(|| crate::PyError::type_error("call failed"))
                         .into());
                 }
-                self.push(result);
+                // baseobjspace.py:1256 self.pushvalue(w_result). The callee may
+                // have relocated this frame via a minor collection, so push
+                // onto the forwarded live frame, not the pre-call pointer.
+                unsafe { &mut *anchor.live() }.push(result);
                 return Ok(());
             }
         }
@@ -4034,6 +4073,7 @@ impl OpcodeStepExecutor for PyFrame {
         let null_or_self = self.pop();
         let callable = self.pop();
 
+        let anchor = FrameAnchor::new(self);
         let result = if null_or_self.is_null() {
             call_callable(self, callable, &args)?
         } else {
@@ -4042,7 +4082,9 @@ impl OpcodeStepExecutor for PyFrame {
             full_args.extend_from_slice(&args);
             call_callable(self, callable, &full_args)?
         };
-        self.push(result);
+        // The callee may have relocated this frame via a minor collection;
+        // push onto the forwarded live frame, not the pre-call pointer.
+        unsafe { &mut *anchor.live() }.push(result);
         Ok(())
     }
 
@@ -4066,9 +4108,12 @@ impl OpcodeStepExecutor for PyFrame {
         let args_obj = self.pop();
         let self_or_null = self.pop();
         let callable = self.pop();
+        let anchor = FrameAnchor::new(self);
         let result =
             crate::call::call_function_ex(self, callable, self_or_null, args_obj, kwargs_or_null)?;
-        self.push(result);
+        // The callee may have relocated this frame via a minor collection;
+        // push onto the forwarded live frame, not the pre-call pointer.
+        unsafe { &mut *anchor.live() }.push(result);
         Ok(())
     }
 
@@ -4094,8 +4139,11 @@ impl OpcodeStepExecutor for PyFrame {
         let self_or_null = self.pop();
         let callable = self.pop();
 
+        let anchor = FrameAnchor::new(self);
         let result = crate::call::call_kw(self, callable, self_or_null, &args, kwarg_names)?;
-        self.push(result);
+        // The callee may have relocated this frame via a minor collection;
+        // push onto the forwarded live frame, not the pre-call pointer.
+        unsafe { &mut *anchor.live() }.push(result);
         Ok(())
     }
 

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
@@ -628,6 +628,26 @@ pub(crate) fn try_walker_call_assembler_self_recursive(
             return Ok(None);
         }
     }
+    // Loopless self-call shape only: the operand stack below the call's own
+    // operands (`r_args = [callable, null_or_self, arg0..]`) must hold no
+    // loop-carried input arg.  A self-call inside a `for`/`while` body keeps
+    // the loop's InputArg operands (the `FOR_ITER` iterator, an accumulator
+    // reloaded for `+=`) on the caller stack under the call; the concrete
+    // CALL_ASSEMBLER fold cannot carry them across the assembler call, so the
+    // loop-back-edge guard resumes the loop-carried iterator as NULL and the
+    // blackhole faults on the next `FOR_ITER`.  The residual path keeps those
+    // operands live, so decline the loop-bearing shape to it.  The loopless
+    // `fib` shape keeps only within-iteration temps (a prior call result), no
+    // InputArg, and stays foldable.
+    if ctx.vstack_valid {
+        let kept_below = ctx.vstack_boxes.len().saturating_sub(r_args.len());
+        if ctx.vstack_boxes[..kept_below]
+            .iter()
+            .any(|slot| slot.is_input_arg())
+        {
+            return Ok(None);
+        }
+    }
     // The outer portal sym (the only materialized frame across sub-walks)
     // via the FBW thread-local — the same read mechanism
     // `walker_capture_snapshot_for_last_guard` uses.  Null outside a

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/vstack_mirror.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/vstack_mirror.rs
@@ -261,26 +261,36 @@ pub(crate) fn reconcile_vstack_at_boundary(
         return;
     };
     let class = classify_vstack_opcode(&instr, op_arg);
-    // #389(b): the py3.14 inlined comprehension emits a
-    // `SWAP`/`BUILD_LIST`/`SWAP` preamble before its `FOR_ITER`, which the
-    // codewriter lowers NON-MONOTONICALLY in jitcode — the JitCode-PC floor
-    // pivot maps a later jit_pc back to an EARLIER py_pc, so the walk re-visits
-    // those preamble py_pcs OUT OF ORDER (a backward py transition, then a
-    // forward re-walk of the just-visited py_pcs).  A `SWAP`/`COPY` never
-    // branches, so a backward py transition whose PREDECESSOR is a permutation
-    // op is unambiguously this lowering artifact, not real re-execution (a
-    // genuine loop back-edge leaves a `JUMP`/branch as the predecessor, class
-    // `PopOnlyOrSideStore`).  In the region the per-op replay is WRONG: it
-    // re-applies the `SWAP` effect and reuses a stale `vstack_last_ref`,
-    // dropping the just-built list from the mirror.  Reseed the whole mirror
-    // from the authoritative virtualizable shadow (kept current by the portal
-    // `setarrayitem_vable_r` pushes) instead, until the walk advances PAST the
-    // py_pc it backed off from (py order monotonic again).
-    if matches!(class, VstackOpClass::Swap(_) | VstackOpClass::Copy(_))
-        && (new_pypc as usize) < prev_pypc
-        && ctx.vstack_reorder_ceiling == u32::MAX
-    {
-        ctx.vstack_reorder_ceiling = prev_pypc as u32;
+    // RPython's MIFrame follows one flow-graph link at a time; the target
+    // block receives its register state from that link's inputargs
+    // (pyjitpl.py:2371-2387 `interpret` / `run_one_step`).  The full-body
+    // walk instead traverses flattened JitCode whose layout can switch to a
+    // different source block without the Python PCs forming a CFG edge.  Do
+    // not replay the previous Python opcode across such a layout switch: its
+    // `vstack_last_ref` belongs to the other block.  Doing so at the two arms
+    // of a conditional expression overwrote the loop-carried FOR_ITER slot
+    // with the selected local, and a later branch guard serialized that
+    // foreign box into the virtualizable resume image.
+    //
+    // Enter a shadow-reseed region until the walk passes both endpoints of
+    // the out-of-order transition.  This subsumes the former SWAP/COPY-only
+    // detection for non-monotonic comprehension lowering and applies the
+    // same block-input rule to ordinary conditional-expression arms.
+    let fallthrough = crate::pyjitpl::semantic_fallthrough_pc(code, prev_pypc);
+    use pyre_interpreter::Instruction;
+    let has_fallthrough = !matches!(
+        instr,
+        Instruction::JumpForward { .. }
+            | Instruction::JumpBackward { .. }
+            | Instruction::JumpBackwardNoInterrupt { .. }
+            | Instruction::ReturnValue
+            | Instruction::Reraise { .. }
+            | Instruction::RaiseVarargs { .. }
+    );
+    let cfg_successor = (has_fallthrough && new_pypc as usize == fallthrough)
+        || crate::liveness::target_pc(code, &instr, prev_pypc, op_arg) == Some(new_pypc as usize);
+    if !cfg_successor && ctx.vstack_reorder_ceiling == u32::MAX {
+        ctx.vstack_reorder_ceiling = (new_pypc as usize).max(prev_pypc) as u32;
     }
     let in_reorder_region = ctx.vstack_reorder_ceiling != u32::MAX;
     let (fallthrough_depth, branch_depth) =

--- a/pyre/pyre-jit-trace/src/liveness.rs
+++ b/pyre/pyre-jit-trace/src/liveness.rs
@@ -843,7 +843,7 @@ fn is_unconditional_jump(instr: &pyre_interpreter::bytecode::Instruction) -> boo
 /// Branch target PC for branching instructions.
 /// Uses skip_caches to account for cache slots after the instruction,
 /// matching the codewriter's target calculation.
-fn target_pc(
+pub(crate) fn target_pc(
     code: &CodeObject,
     instr: &pyre_interpreter::bytecode::Instruction,
     pc: usize,

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -7418,14 +7418,17 @@ impl CodeWriter {
         // flowcontext.py:402-405 `while self.pendingblocks: block =
         // self.pendingblocks.popleft(); if not block.dead: self.record_block(block)`.
         //
-        // Outer loop: outer loop wraps main drain + catch landings
-        // emit so handler-entry blocks queued by
-        // `emit_goto!(handler_py_pc)` in catch landings get drained by
-        // a second main-drain pass.  Without this, handler-entry blocks
-        // would be orphans with 0 ops + 0 exits + framestate-wide
-        // inputargs, tripping `make_return`'s 1-or-2-arg invariant in
-        // canonical `flatten_graph` (`flatten.py:107-109`).
-        let mut catch_landings_processed = false;
+        // Outer loop interleaves the ordinary pending-block drain with
+        // newly reachable catch landings.  Upstream's
+        // `flowcontext.py:124-153 guessexception` puts every exception
+        // EggBlock directly on `pendingblocks`, and `build_flow` keeps
+        // draining that queue to a fixed point (`flowcontext.py:399-405`).
+        // Pyre emits its synthetic catch-landing sequence separately, so
+        // mirror the same fixed point with one processed bit per site.
+        // A handler block drained after the first landing pass can itself
+        // expose a nested cleanup landing; a one-shot pass leaves that
+        // regular block live with inputargs but no exits.
+        let mut catch_landings_processed = vec![false; catch_sites.len()];
         loop {
             while let Some(pending_block) = pendingblocks.pop_front() {
                 if pending_block.dead() {
@@ -11349,10 +11352,12 @@ impl CodeWriter {
                         // resolves the variable name with.
                         Instruction::LoadFastCheck { var_num } => {
                             let idx = var_num.get(op_arg).as_usize() as u16;
-                            // A local proven unbound at compile time (a
-                            // `ConstantValue::None` slot, e.g. after a preceding
-                            // DELETE_FAST) makes LOAD_FAST_CHECK unconditionally
-                            // raise UnboundLocalError.  Emitting the
+                            // An absent `locals_w` slot means the local is
+                            // undefined on at least one predecessor
+                            // (`framestate.py:105-114 union`); the legacy
+                            // `ConstantValue::None` sentinel represents the
+                            // statically-unbound form.  The walker has no SSA
+                            // value for either shape.  Emitting the
                             // `load_fast_check` residual + `GuardNoException` +
                             // push leaves a normal-return `Finish` continuation;
                             // a later guard-failure bridge resolves into that
@@ -11360,11 +11365,14 @@ impl CodeWriter {
                             // the interpreter so it raises, mirroring the
                             // constant-folded `if w_value is None` failure arm
                             // (matches the DeleteFast known-unbound handling).
-                            if matches!(
-                                current_state.local_value_at(idx as usize),
-                                Some(super::flow::FlowValue::Constant(c))
-                                    if c.value == super::flow::ConstantValue::None
-                            ) {
+                            let local_value = current_state.local_value_at(idx as usize);
+                            if local_value.is_none()
+                                || matches!(
+                                    local_value,
+                                    Some(super::flow::FlowValue::Constant(c))
+                                        if c.value == super::flow::ConstantValue::None
+                                )
+                            {
                                 emit_abort_permanent!(py_pc);
                                 continue;
                             }
@@ -11735,10 +11743,7 @@ impl CodeWriter {
                                     ),
                                 );
                                 set_last_bool_exitcase(&current_block.block(), true);
-                                let mut bound_state = current_state.clone();
-                                bound_state.next_offset = py_pc + 1;
-                                bound_state.blocklist =
-                                    frame_blocks_for_offset(code, bound_state.next_offset);
+                                let bound_state = current_state.clone();
                                 let bound_block = SpamBlockRef::new(
                                     graph.new_block(Vec::new()),
                                     Some(bound_state.clone()),
@@ -11751,15 +11756,6 @@ impl CodeWriter {
                                     output_link(&current_state, &bound_state, bound_block.block()),
                                 );
                                 set_last_bool_exitcase(&current_block.block(), false);
-                                // The successful check continues at the next
-                                // bytecode in this block. Register that block
-                                // as the next-PC candidate so a handler or
-                                // exception-table joinpoint at the same PC
-                                // cannot replace the DELETE_FAST continuation.
-                                joinpoints
-                                    .entry(py_pc + 1)
-                                    .or_insert_with(Vec::new)
-                                    .insert(0, bound_block.clone());
 
                                 // The unbound arm raises before any clear,
                                 // matching pyopcode.py:998 DELETE_FAST. Keep
@@ -11830,8 +11826,36 @@ impl CodeWriter {
                                     None,
                                     py_pc as i64,
                                 );
-                                current_state
-                                    .store_local_value(idx, super::flow::Constant::none().into());
+                                // `framestate.py:105-114 union`: an undefined
+                                // local is `None`, not a Constant(None).  The
+                                // graph-side vable write above still carries
+                                // the runtime PY_NULL sentinel.
+                                current_state.clear_local_value(idx);
+                                // The successful branch egg has now executed
+                                // the clear.  Close it into the next bytecode
+                                // through the ordinary joinpoint machinery,
+                                // exactly as `flowcontext.py:424-475
+                                // mergeblock` closes every branch arrival.
+                                // Directly inserting this block into the
+                                // candidate list strands an older candidate
+                                // at the same PC when conditional control flow
+                                // already reaches the continuation.
+                                let next_py_pc = py_pc + 1;
+                                let mut continuation_state = current_state.clone();
+                                continuation_state.next_offset = next_py_pc;
+                                continuation_state.blocklist =
+                                    frame_blocks_for_offset(code, next_py_pc);
+                                let _ = mergeblock(
+                                    code,
+                                    &mut graph,
+                                    &mut joinpoints,
+                                    &current_block,
+                                    &continuation_state,
+                                    next_py_pc,
+                                    &mut pendingblocks,
+                                    &mut all_walker_blocks,
+                                );
+                                needs_fallthrough = false;
                             } else {
                                 emit_abort_permanent!(py_pc);
                             }
@@ -12068,19 +12092,18 @@ impl CodeWriter {
                 }
             } // end inner while-let pendingblocks
 
-            // Outer loop outer loop logic.  After main drain
-            // exhausts pendingblocks, catch landings emit (below) runs
-            // ONCE (gated on `catch_landings_processed`).  `emit_goto!`
-            // in catch landings queues handler-entry blocks onto
-            // pendingblocks; the next outer-loop iteration's inner
-            // while-let drains them so they don't end up as orphan
-            // empty-exits blocks with framestate-wide inputargs.
-            if catch_landings_processed {
-                break;
-            }
-            catch_landings_processed = true;
-
-            for site in &catch_sites {
+            // Match `build_flow`'s queue fixed point: emit each newly
+            // reachable landing once, then return to the pending-block
+            // drain.  Handler code can discover another exception edge,
+            // making a later site's landing reachable only after an
+            // earlier landing has been processed.
+            let mut emitted_catch_landing = false;
+            for (site_index, site) in catch_sites.iter().enumerate() {
+                if catch_landings_processed[site_index] || site.landing.framestate().is_none() {
+                    continue;
+                }
+                catch_landings_processed[site_index] = true;
+                emitted_catch_landing = true;
                 emit_mark_label_catch_landing!(site.landing_label);
                 // `emit_mark_label_catch_landing!` reassigns
                 // `current_block` to the pre-allocated catch landing
@@ -12284,6 +12307,9 @@ impl CodeWriter {
                 depth += 1;
                 emit_vsd!(depth, site.handler_py_pc);
                 emit_goto!(site.handler_py_pc);
+            }
+            if !emitted_catch_landing {
+                break;
             }
         } // end outer drain loop
 
@@ -15594,6 +15620,47 @@ def run(iters):
                 .is_some(),
             "walker must produce a jitcode for the with/exception loop \
              without tripping the make_return empty-exits invariant"
+        );
+    }
+
+    #[test]
+    fn walker_conditional_delete_closes_merge_and_nested_catch_landings() {
+        let source = "\
+def f(n):
+    for i in range(n):
+        x = 1
+        if i & 1:
+            del x
+        try:
+            y = x
+        except NameError:
+            pass
+    return i
+";
+        let code = first_nested_function_code(source);
+        let w_code = pyre_interpreter::box_code_constant(&code);
+        let code_ptr = unsafe {
+            pyre_interpreter::w_code_get_ptr(w_code) as *const pyre_interpreter::CodeObject
+        };
+        let writer = CodeWriter::new();
+        writer.setup_jitdriver(crate::jit::call::JitDriverStaticData {
+            portal_graph: code_ptr,
+            mainjitcode: None,
+        });
+
+        // DELETE_FAST's successful branch must merge into the pre-existing
+        // fall-through candidate at the following NOP.  The NameError handler
+        // is then drained after its catch landing is emitted, and its protected
+        // POP_EXCEPT path exposes a nested cleanup landing.  Both stages must
+        // follow flowcontext.py:399-475's queue/merge fixed point.
+        writer.make_jitcodes();
+
+        assert!(
+            writer
+                .callcontrol()
+                .find_compiled_jitcode_arc(code_ptr)
+                .is_some(),
+            "walker must close catch landings discovered while draining a handler"
         );
     }
 


### PR DESCRIPTION
Stacks four commits on `main` (rebased clean, 0 behind):

- **Fix conditional DELETE_FAST walker merge** (`0db9c9c2f3`)
- **Fix FOR_ITER state across flattened block switches** (`b50970857b`)
- **interp: re-anchor caller frame across the CALL result push** (`935820158f`) — the bytecode `CALL`/`CALL_KW`/`CALL_FUNCTION_EX` paths held the running frame as a raw `&mut PyFrame` across the callee call; a minor collection triggered by the callee relocates the caller frame, so the result push landed on the abandoned copy. Adds a shadow-stack `FrameAnchor` and pushes each result onto the forwarded live frame. Guard bench `synth/recursive_call_frame_relocation.py` added.
- **jit: decline the self-recursive CALL_ASSEMBLER fold for loop-bearing callers** (`e76871358c`) — the `FrameAnchor` fix exposed a JIT-only crash on the same bench: `try_walker_call_assembler_self_recursive` folded a self-recursive call inside a `for` body, but the loop-carried `FOR_ITER` iterator (an `InputArg` kept on the caller stack below the call) resolves to NULL at the loop-back-edge guard's blackhole resume, so the deopt re-enters `FOR_ITER` on a null iterator and segfaults. The fold now declines when the operand stack below the call's own operands holds an `InputArg`, routing the loop-bearing shape to the residual path; the loopless `fib` shape stays foldable.

## Verification
- `synth/recursive_call_frame_relocation.py` (cat pattern → 120000): correct on both backends, was SIGSEGV.
- `fib` still folds to `CALL_ASSEMBLER` (perf preserved); a loopless 2-param accumulator recursion also stays foldable (no over-decline).
- `check.py`: **dynasm 227/227, cranelift 227/227** green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)