### PR TITLE
time: implement strptime

### DIFF
--- a/pyre/pyre-interpreter/src/module/time/mod.rs
+++ b/pyre/pyre-interpreter/src/module/time/mod.rs
@@ -21,6 +21,15 @@ crate::py_module! {
             pyre_object::w_str_new("UTC"),
         ]),
     },
+    // PyPy: pypy/module/time/app_time.py:26-34.  Keep strptime at app
+    // level and delegate to the shared CPython `_strptime` module.
+    inline_app: {
+        r#"
+def strptime(string, format="%a %b %d %H:%M:%S %Y"):
+    import _strptime
+    return _strptime._strptime_time(string, format)
+"# => ["strptime"],
+    },
     functions: {
         "time"         / 0 = t::time,
         "time_ns"      / 0 = t::time_ns,


### PR DESCRIPTION
## Summary

- expose `time.strptime` as an app-level function
- port PyPy `pypy/module/time/app_time.py:26-34` directly
- delegate parsing to the shared stdlib `_strptime._strptime_time` implementation

## Impact

The `time` stdlib snippet now passes and callers can parse formatted time strings into `struct_time`.

## Validation

- `target/release/pyre-dynasm pyre/extra_tests/snippets/stdlib_time.py`
- `python3 scripts/extract-llbc.py pyre-interpreter`
- `PYRE_RTYPER_VERBOSE=1 cargo build --release -p pyre-jit-trace`
- `cargo check --workspace --features dynasm`
- `cargo test --workspace --features dynasm`