### PR TITLE
interpreter: improve stdlib compatibility

### DIFF
--- a/lib-python/3/functools.py
+++ b/lib-python/3/functools.py
@@ -377,6 +377,14 @@ class partial:
     __new__ = _partial_new
     __repr__ = recursive_repr()(_partial_repr)
 
+    def __delattr__(self, name):
+        # The C accelerator exposes __dict__ as a non-deletable getset
+        # descriptor.  Keep the Python fallback behavior identical when
+        # _functools.partial is unavailable.
+        if name == "__dict__":
+            raise TypeError("cannot delete __dict__")
+        object.__delattr__(self, name)
+
     def __call__(self, /, *args, **keywords):
         phcount = self._phcount
         if phcount:

--- a/pyre/extra_tests/snippets/stdlib_ast.py
+++ b/pyre/extra_tests/snippets/stdlib_ast.py
@@ -39,6 +39,20 @@ assert i.names[0].name == "a"
 assert i.names[0].asname is None
 
 
+# compile() accepts a tree returned by ast.parse(), including ordinary
+# expression, assignment, call, attribute, list, and tuple nodes.
+compiled_tree = ast.parse("result = helper.value(40 + 2, items=[1, 2], pair=(3, 4))")
+namespace = {
+    "helper": type(
+        "Helper",
+        (),
+        {"value": staticmethod(lambda value, **kw: (value, kw["items"], kw["pair"]))},
+    )
+}
+exec(compile(compiled_tree, "<ast-object>", "exec"), namespace)
+assert namespace["result"] == (42, [1, 2], (3, 4))
+
+
 # Regression test for issue #4862:
 # A cyclic AST fed to compile() used to overflow the Rust stack and SIGSEGV.
 # After the fix, the recursion guard in ast_from_object raises RecursionError,

--- a/pyre/extra_tests/snippets/stdlib_marshal.py
+++ b/pyre/extra_tests/snippets/stdlib_marshal.py
@@ -66,6 +66,28 @@ class MarshalTests(unittest.TestCase):
             bytearray(b"\x01\x02"),
         )
 
+    def test_marshal_additional_atoms(self):
+        self._test_marshal(None)
+        self._test_marshal(Ellipsis)
+        self._test_marshal(StopIteration)
+        self._test_marshal(2**100)
+        self._test_marshal(-(2**100))
+        self._test_marshal(1 + 2j)
+        self._test_marshal(b"marshal")
+
+    def test_shared_reference(self):
+        shared = [1, 2]
+        loaded = self.dump_then_load([shared, shared])
+        self.assertIs(loaded[0], loaded[1])
+
+    def test_file_api(self):
+        from io import BytesIO
+
+        stream = BytesIO()
+        self.assertIsNone(marshal.dump({"answer": 42}, stream))
+        stream.seek(0)
+        self.assertEqual(marshal.load(stream), {"answer": 42})
+
     def test_roundtrip(self):
         orig = compile("1 + 1", "", "eval")
 
@@ -73,6 +95,9 @@ class MarshalTests(unittest.TestCase):
         loaded = marshal.loads(dumped)
 
         assert eval(loaded) == eval(orig)
+
+        with self.assertRaises(ValueError):
+            marshal.dumps([orig], allow_code=False)
 
 
 if __name__ == "__main__":

--- a/pyre/extra_tests/snippets/stdlib_weakref.py
+++ b/pyre/extra_tests/snippets/stdlib_weakref.py
@@ -1,4 +1,6 @@
-from _weakref import proxy, ref
+import gc
+
+from _weakref import getweakrefcount, getweakrefs, proxy, ref
 
 from testutils import assert_raises
 
@@ -21,6 +23,8 @@ assert b.__callback__ is None, (
 callback = lambda r: None
 c = ref(a, callback)
 assert c.__callback__ is callback, "weakref with callback should return the callback"
+assert getweakrefcount(a) == 2
+assert set(getweakrefs(a)) == {b, c}
 
 # Test __callback__ is read-only
 try:
@@ -31,11 +35,18 @@ except AttributeError:
 
 # Test __callback__ after referent deletion
 x = X()
-cb = lambda r: None
-w = ref(x, cb)
-assert w.__callback__ is cb
+seen = []
+cb1 = lambda r: seen.append((1, r()))
+cb2 = lambda r: seen.append((2, r()))
+w1 = ref(x, cb1)
+w2 = ref(x, cb2)
+assert w1.__callback__ is cb1
+assert w2.__callback__ is cb2
 del x
-assert w.__callback__ is None, "__callback__ should be None after referent is collected"
+gc.collect()
+assert seen == [(2, None), (1, None)]
+assert w1.__callback__ is None
+assert w2.__callback__ is None
 
 
 class G:
@@ -49,5 +60,6 @@ p = proxy(g)
 assert p.h == 5
 
 del g
+gc.collect()
 
 assert_raises(ReferenceError, lambda: p.h)

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -11611,6 +11611,17 @@ pub fn next(obj: PyObjectRef) -> PyResult {
                 return crate::call::call_function_impl_result(method, &[obj]);
             }
         }
+        // PyPy `space.next(w_obj)` performs a type-MRO `__next__` lookup for
+        // every W_Root object.  Typed-payload builtins are not INSTANCE_TYPE
+        // layouts, so give them the same generic dispatch used by `iter`
+        // above instead of requiring one hardcoded branch per iterator type.
+        if !is_instance(obj) {
+            if let Some(w_type) = crate::typedef::r#type(obj) {
+                if let Some(method) = lookup_in_type_where(w_type, "__next__") {
+                    return crate::call::call_function_impl_result(method, &[obj]);
+                }
+            }
+        }
     }
     Err(PyError::type_error(format!(
         "'{}' object is not an iterator",

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -7149,15 +7149,15 @@ fn builtin_compile(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> 
             // surrogate raises `UnicodeEncodeError` (strict) rather than
             // panicking in `w_str_get_value`.
             let bytes = crate::type_methods::encode_object(source, "utf-8", "strict")?;
-            String::from_utf8(bytes).expect("strict utf-8 encode yields valid utf-8")
+            Some(String::from_utf8(bytes).expect("strict utf-8 encode yields valid utf-8"))
         } else if pyre_object::bytesobject::is_bytes_like(source) {
             // A bytes-like source honours the PEP 263 coding cookie and raises
             // SyntaxError on undecodable bytes rather than lossily replacing.
-            crate::compile::decode_source_bytes(
+            Some(crate::compile::decode_source_bytes(
                 pyre_object::bytesobject::bytes_like_data(source),
                 &filename,
                 false,
-            )?
+            )?)
         } else {
             // PyPy returns an AST input unchanged when ONLY_AST is requested.
             // Keep this check at the public `_ast.AST` boundary so subclasses
@@ -7174,13 +7174,12 @@ fn builtin_compile(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> 
                 if flags & PYCF_ONLY_AST != 0 {
                     return Ok(source);
                 }
-                return Err(crate::PyError::not_implemented(
-                    "compiling an AST object is not implemented",
+                None
+            } else {
+                return Err(crate::PyError::type_error(
+                    "compile() arg 1 must be a string, bytes or AST object",
                 ));
             }
-            return Err(crate::PyError::type_error(
-                "compile() arg 1 must be a string, bytes or AST object",
-            ));
         }
     };
 
@@ -7194,10 +7193,25 @@ fn builtin_compile(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> 
         ..Default::default()
     };
     if flags & PYCF_ONLY_AST != 0 {
-        return crate::module::_ast::convert::parse_to_object(&source_str, mode);
+        return crate::module::_ast::convert::parse_to_object(
+            source_str
+                .as_deref()
+                .expect("AST input returned above for ONLY_AST"),
+            mode,
+        );
     }
-    let code = crate::compile::compile_source_with_opts(&source_str, mode, &filename, opts)
-        .map_err(compile_err_to_syntax_error)?;
+    if source_str.is_none() {
+        let code = crate::module::_ast::convert::compile_object(source, &filename, mode, opts)?;
+        let code_ptr = Box::into_raw(Box::new(code)) as *const ();
+        return Ok(crate::w_code_new(code_ptr));
+    }
+    let code = crate::compile::compile_source_with_opts(
+        source_str.as_deref().expect("non-AST source"),
+        mode,
+        &filename,
+        opts,
+    )
+    .map_err(compile_err_to_syntax_error)?;
     let code_ptr = Box::into_raw(Box::new(code)) as *const ();
     Ok(crate::w_code_new(code_ptr))
 }

--- a/pyre/pyre-interpreter/src/call.rs
+++ b/pyre/pyre-interpreter/src/call.rs
@@ -2151,25 +2151,6 @@ pub fn call_with_kwargs(
     // For type objects: allocate via __new__ then call __init__ with kwargs.
     // PyPy: typeobject.py descr_call → __new__ + __init__
     if unsafe { pyre_object::is_type(callable) } {
-        // Types with acceptable_as_base_class=false (bool, NoneType) reject kwargs.
-        // PyPy: boolobject.py descr_new uses @unwrap_spec (positional only).
-        // The `function` type is non-acceptable-as-base too, but its
-        // `tp_new` (`FunctionType(code, globals, ..., kwdefaults=...)`)
-        // does take keyword arguments, so route those through `__new__`.
-        let is_function_type = std::ptr::eq(
-            callable,
-            crate::typedef::gettypeobject(&crate::FUNCTION_TYPE),
-        );
-        if !kwargs.is_empty()
-            && !is_function_type
-            && !unsafe { pyre_object::w_type_get_acceptable_as_base_class(callable) }
-        {
-            let type_name = unsafe { pyre_object::w_type_get_name(callable) };
-            return Err(crate::PyError::type_error(format!(
-                "{}() takes no keyword arguments",
-                type_name,
-            )));
-        }
         // Calculate the winning metaclass from bases.
         // type(name, bases, dict, **kw) needs to find the correct metaclass
         // and call its __new__ with the kwargs.

--- a/pyre/pyre-interpreter/src/executioncontext.rs
+++ b/pyre/pyre-interpreter/src/executioncontext.rs
@@ -122,6 +122,21 @@ pub fn register_generator_finalizer(obj: PyObjectRef) {
     pyre_object::gc_hook::try_gc_register_finalizer(0, obj, finalizer_queue_trigger);
 }
 
+/// Register an object that owns a `WeakrefLifeline`. PyPy's GC invalidates the
+/// rweakrefs and registers callback-bearing lifelines themselves; until pyre's
+/// mapdict weakref SPECIAL slot is inline, the address-keyed slot keeps that
+/// lifeline rooted, so the equivalent death notification is registered on its
+/// owner. Objects with `__del__` are already in this queue and must not be
+/// registered twice.
+pub fn register_weakref_finalizer(obj: PyObjectRef) {
+    let already_registered = crate::typedef::r#type(obj)
+        .map(|w_type| unsafe { pyre_object::w_type_get_hasuserdel(w_type) })
+        .unwrap_or(false);
+    if !already_registered {
+        pyre_object::gc_hook::try_gc_register_finalizer(0, obj, finalizer_queue_trigger);
+    }
+}
+
 /// Shared execution context for all frames in one interpreter run.
 ///
 /// Holds the builtin module dict used by module-level frames.
@@ -1914,6 +1929,7 @@ impl UserDelAction {
     }
 
     pub fn _call_finalizer(&mut self, w_obj: PyObjectRef) {
+        crate::module::_weakref::interp__weakref::finalize_weakrefs(w_obj);
         if unsafe { pyre_object::generator::is_generator_or_coroutine(w_obj) } {
             if self.gc_disabled(w_obj) {
                 return;

--- a/pyre/pyre-interpreter/src/importing.rs
+++ b/pyre/pyre-interpreter/src/importing.rs
@@ -572,6 +572,7 @@ pub fn install_builtin_modules() {
     pyre_install_module!(_pickle);
     pyre_install_module!("_struct"(r#struct));
     pyre_install_module!(binascii);
+    pyre_install_module!(marshal);
     pyre_install_module!(zlib);
     pyre_install_module!(_typing);
     pyre_install_module!(_template);
@@ -610,7 +611,6 @@ pub fn install_builtin_modules() {
         "_heapq",
         "_tokenize",
         "_bisect",
-        "marshal",
         "_stat",
         "_queue",
         "_zoneinfo",

--- a/pyre/pyre-interpreter/src/module/_ast/convert.rs
+++ b/pyre/pyre-interpreter/src/module/_ast/convert.rs
@@ -7,6 +7,483 @@
 use pyre_object::{PY_NULL, PyObjectRef};
 use rustpython_compiler::{ast, parser};
 
+type AstResult<T> = Result<T, crate::PyError>;
+
+/// Convert an interpreter-level `_ast` tree back into Ruff's compiler AST and
+/// compile it.  This is the reverse of `Converter`, corresponding to PyPy's
+/// generated `ast_from_object` boundary.
+pub fn compile_object(
+    object: PyObjectRef,
+    filename: &str,
+    mode: crate::compile::Mode,
+    opts: crate::compile::CompileOpts,
+) -> AstResult<crate::compile::CodeObject> {
+    let ast_module = crate::importing::importhook(
+        "_ast",
+        PY_NULL,
+        PY_NULL,
+        0,
+        crate::call::take_last_exec_ctx(),
+    )?;
+    let mut converter = ObjectConverter {
+        ast_module,
+        depth: 0,
+    };
+    let module = converter.module(object)?;
+    let source_file = rustpython_compiler::core::SourceFileBuilder::new(filename, "").finish();
+    rustpython_compiler::codegen::compile::compile_top(module, source_file, mode, opts)
+        .map_err(|error| crate::PyError::syntax_error(error.to_string()))
+}
+
+struct ObjectConverter {
+    ast_module: PyObjectRef,
+    depth: usize,
+}
+
+impl ObjectConverter {
+    fn recurse<T>(&mut self, f: impl FnOnce(&mut Self) -> AstResult<T>) -> AstResult<T> {
+        // PyPy's generated ast_from_object calls space.getexecutioncontext()
+        // recursion guards around nested ASDL nodes.  Keep the state on this
+        // conversion, never in TLS or a global side table.
+        if self.depth >= 200 {
+            return Err(crate::PyError::recursion_error(
+                "maximum recursion depth exceeded while traversing AST node",
+            ));
+        }
+        self.depth += 1;
+        let result = f(self);
+        self.depth -= 1;
+        result
+    }
+
+    fn is_node(&self, object: PyObjectRef, name: &str) -> AstResult<bool> {
+        let ty = crate::baseobjspace::getattr_str(self.ast_module, name)?;
+        Ok(unsafe { crate::baseobjspace::isinstance_w(object, ty) })
+    }
+
+    fn field(&self, object: PyObjectRef, field: &str, node: &str) -> AstResult<PyObjectRef> {
+        crate::baseobjspace::getattr_str(object, field).map_err(|_| {
+            crate::PyError::type_error(format!("required field {field:?} missing from {node}"))
+        })
+    }
+
+    fn optional_field(&self, object: PyObjectRef, field: &str) -> AstResult<Option<PyObjectRef>> {
+        match crate::baseobjspace::getattr_str(object, field) {
+            Ok(value) if unsafe { pyre_object::is_none(value) } => Ok(None),
+            Ok(value) => Ok(Some(value)),
+            Err(error) if error.kind == crate::PyErrorKind::AttributeError => Ok(None),
+            Err(error) => Err(error),
+        }
+    }
+
+    fn list(&self, object: PyObjectRef, field: &str, node: &str) -> AstResult<Vec<PyObjectRef>> {
+        let value = self.field(object, field, node)?;
+        if !unsafe { pyre_object::is_list(value) } {
+            return Err(crate::PyError::type_error(format!(
+                "AST list field must be a list, not {}",
+                unsafe { pyre_object::type_name_of(value) }
+            )));
+        }
+        Ok(unsafe { pyre_object::w_list_items_copy_as_vec(value) })
+    }
+
+    fn string(&self, object: PyObjectRef, field: &str, node: &str) -> AstResult<String> {
+        let value = self.field(object, field, node)?;
+        if !unsafe { pyre_object::is_str(value) } {
+            return Err(crate::PyError::type_error(
+                "AST identifier must be of type str",
+            ));
+        }
+        Ok(unsafe { pyre_object::w_str_get_value(value).to_string() })
+    }
+
+    fn module(&mut self, object: PyObjectRef) -> AstResult<ast::Mod> {
+        if self.is_node(object, "Module")? {
+            let values = self.list(object, "body", "Module")?;
+            let body = values
+                .into_iter()
+                .map(|value| self.recurse(|this| this.stmt(value)))
+                .collect::<Result<Vec<_>, _>>()?;
+            Ok(ast::Mod::Module(ast::ModModule {
+                node_index: Default::default(),
+                range: Default::default(),
+                body,
+                runtime_body: None,
+            }))
+        } else if self.is_node(object, "Interactive")? {
+            let values = self.list(object, "body", "Interactive")?;
+            let body = values
+                .into_iter()
+                .map(|value| self.recurse(|this| this.stmt(value)))
+                .collect::<Result<Vec<_>, _>>()?;
+            Ok(ast::Mod::Module(ast::ModModule {
+                node_index: Default::default(),
+                range: Default::default(),
+                body,
+                runtime_body: None,
+            }))
+        } else if self.is_node(object, "Expression")? {
+            let body = self.field(object, "body", "Expression")?;
+            Ok(ast::Mod::Expression(ast::ModExpression {
+                node_index: Default::default(),
+                range: Default::default(),
+                body: Box::new(self.recurse(|this| this.expr(body))?),
+            }))
+        } else {
+            Err(crate::PyError::type_error(format!(
+                "expected some sort of mod, but got {}",
+                unsafe { pyre_object::type_name_of(object) }
+            )))
+        }
+    }
+
+    fn stmt(&mut self, object: PyObjectRef) -> AstResult<ast::Stmt> {
+        if self.is_node(object, "FunctionDef")? || self.is_node(object, "AsyncFunctionDef")? {
+            let is_async = self.is_node(object, "AsyncFunctionDef")?;
+            let name = ast::Identifier::new(
+                self.string(
+                    object,
+                    "name",
+                    if is_async {
+                        "AsyncFunctionDef"
+                    } else {
+                        "FunctionDef"
+                    },
+                )?,
+                Default::default(),
+            );
+            let args = self.field(object, "args", "FunctionDef")?;
+            let parameters = Box::new(self.recurse(|this| this.parameters(args))?);
+            let body = self
+                .list(object, "body", "FunctionDef")?
+                .into_iter()
+                .map(|value| self.recurse(|this| this.stmt(value)))
+                .collect::<Result<Vec<_>, _>>()?;
+            // `type_params` was added after the original positional
+            // FunctionDef constructor.  Like RustPython/PyPy, a missing field
+            // on a manually constructed legacy node means an empty list.
+            let _type_params = self.optional_field(object, "type_params")?;
+            Ok(ast::Stmt::FunctionDef(ast::StmtFunctionDef {
+                node_index: Default::default(),
+                range: Default::default(),
+                is_async,
+                decorator_list: Vec::new(),
+                name,
+                type_params: None,
+                parameters,
+                returns: None,
+                body,
+                runtime_decorator_list: None,
+                runtime_type_comment: None,
+                runtime_type_comment_bytes: None,
+                runtime_body: None,
+            }))
+        } else if self.is_node(object, "Pass")? {
+            Ok(ast::Stmt::Pass(ast::StmtPass {
+                node_index: Default::default(),
+                range: Default::default(),
+            }))
+        } else if self.is_node(object, "Expr")? {
+            let value = self.field(object, "value", "Expr")?;
+            Ok(ast::Stmt::Expr(ast::StmtExpr {
+                node_index: Default::default(),
+                range: Default::default(),
+                value: Box::new(self.recurse(|this| this.expr(value))?),
+            }))
+        } else if self.is_node(object, "Return")? {
+            let value = self.optional_field(object, "value")?;
+            Ok(ast::Stmt::Return(ast::StmtReturn {
+                node_index: Default::default(),
+                range: Default::default(),
+                value: value
+                    .map(|value| self.recurse(|this| this.expr(value)).map(Box::new))
+                    .transpose()?,
+            }))
+        } else if self.is_node(object, "Assign")? {
+            let targets = self
+                .list(object, "targets", "Assign")?
+                .into_iter()
+                .map(|value| self.recurse(|this| this.expr(value)))
+                .collect::<Result<Vec<_>, _>>()?;
+            let value = self.field(object, "value", "Assign")?;
+            Ok(ast::Stmt::Assign(ast::StmtAssign {
+                node_index: Default::default(),
+                range: Default::default(),
+                targets,
+                value: Box::new(self.recurse(|this| this.expr(value))?),
+                runtime_targets: None,
+                runtime_type_comment: None,
+                runtime_type_comment_bytes: None,
+            }))
+        } else {
+            Err(crate::PyError::type_error(format!(
+                "expected some sort of stmt, but got {}",
+                unsafe { pyre_object::type_name_of(object) }
+            )))
+        }
+    }
+
+    fn parameters(&mut self, object: PyObjectRef) -> AstResult<ast::Parameters> {
+        // Preserve the ASDL field reads even for empty argument lists.  Defaults
+        // are paired with parameters in source order by the complete converter.
+        for field in [
+            "posonlyargs",
+            "args",
+            "kwonlyargs",
+            "kw_defaults",
+            "defaults",
+        ] {
+            if !self.list(object, field, "arguments")?.is_empty() {
+                return Err(crate::PyError::not_implemented(
+                    "compiling AST functions with parameters is not implemented",
+                ));
+            }
+        }
+        if self.optional_field(object, "vararg")?.is_some()
+            || self.optional_field(object, "kwarg")?.is_some()
+        {
+            return Err(crate::PyError::not_implemented(
+                "compiling AST functions with variadic parameters is not implemented",
+            ));
+        }
+        Ok(ast::Parameters::default())
+    }
+
+    fn expr(&mut self, object: PyObjectRef) -> AstResult<ast::Expr> {
+        if self.is_node(object, "UnaryOp")? {
+            let operand = self.field(object, "operand", "UnaryOp")?;
+            let op = self.field(object, "op", "UnaryOp")?;
+            Ok(ast::Expr::UnaryOp(ast::ExprUnaryOp {
+                node_index: Default::default(),
+                range: Default::default(),
+                op: self.unaryop(op)?,
+                operand: Box::new(self.recurse(|this| this.expr(operand))?),
+            }))
+        } else if self.is_node(object, "BinOp")? {
+            let left = self.field(object, "left", "BinOp")?;
+            let right = self.field(object, "right", "BinOp")?;
+            let op = self.field(object, "op", "BinOp")?;
+            Ok(ast::Expr::BinOp(ast::ExprBinOp {
+                node_index: Default::default(),
+                range: Default::default(),
+                left: Box::new(self.recurse(|this| this.expr(left))?),
+                op: self.operator(op)?,
+                right: Box::new(self.recurse(|this| this.expr(right))?),
+            }))
+        } else if self.is_node(object, "Call")? {
+            let func = self.field(object, "func", "Call")?;
+            let args = self
+                .list(object, "args", "Call")?
+                .into_iter()
+                .map(|arg| self.recurse(|this| this.expr(arg)))
+                .collect::<Result<Vec<_>, _>>()?;
+            let keywords = self
+                .list(object, "keywords", "Call")?
+                .into_iter()
+                .map(|keyword| self.recurse(|this| this.keyword(keyword)))
+                .collect::<Result<Vec<_>, _>>()?;
+            Ok(ast::Expr::Call(ast::ExprCall {
+                node_index: Default::default(),
+                range: Default::default(),
+                func: Box::new(self.recurse(|this| this.expr(func))?),
+                arguments: ast::Arguments {
+                    node_index: Default::default(),
+                    range: Default::default(),
+                    args: args.into_boxed_slice(),
+                    keywords: keywords.into_boxed_slice(),
+                    runtime_args: None,
+                    runtime_bases: None,
+                },
+            }))
+        } else if self.is_node(object, "Attribute")? {
+            let value = self.field(object, "value", "Attribute")?;
+            let ctx = self.field(object, "ctx", "Attribute")?;
+            Ok(ast::Expr::Attribute(ast::ExprAttribute {
+                node_index: Default::default(),
+                range: Default::default(),
+                value: Box::new(self.recurse(|this| this.expr(value))?),
+                attr: ast::Identifier::new(
+                    self.string(object, "attr", "Attribute")?,
+                    Default::default(),
+                ),
+                ctx: self.context(ctx)?,
+            }))
+        } else if self.is_node(object, "List")? || self.is_node(object, "Tuple")? {
+            let is_tuple = self.is_node(object, "Tuple")?;
+            let elements = self
+                .list(object, "elts", if is_tuple { "Tuple" } else { "List" })?
+                .into_iter()
+                .map(|element| self.recurse(|this| this.expr(element)))
+                .collect::<Result<Vec<_>, _>>()?;
+            let ctx = self.context(self.field(object, "ctx", "sequence")?)?;
+            if is_tuple {
+                Ok(ast::Expr::Tuple(ast::ExprTuple {
+                    node_index: Default::default(),
+                    range: Default::default(),
+                    elts: elements,
+                    ctx,
+                    parenthesized: true,
+                    runtime_elts: None,
+                }))
+            } else {
+                Ok(ast::Expr::List(ast::ExprList {
+                    node_index: Default::default(),
+                    range: Default::default(),
+                    elts: elements,
+                    ctx,
+                    runtime_elts: None,
+                }))
+            }
+        } else if self.is_node(object, "Name")? {
+            let ctx = self.context(self.field(object, "ctx", "Name")?)?;
+            Ok(ast::Expr::Name(ast::ExprName {
+                node_index: Default::default(),
+                range: Default::default(),
+                id: ast::name::Name::new(self.string(object, "id", "Name")?),
+                ctx,
+            }))
+        } else if self.is_node(object, "Constant")? {
+            let value = self.field(object, "value", "Constant")?;
+            Ok(ast::Expr::Constant(ast::ExprConstant {
+                node_index: Default::default(),
+                range: Default::default(),
+                value: self.constant_value(value)?,
+                kind: None,
+                invalid_type: None,
+            }))
+        } else {
+            Err(crate::PyError::type_error(format!(
+                "expected some sort of expr, but got {}",
+                unsafe { pyre_object::type_name_of(object) }
+            )))
+        }
+    }
+
+    fn keyword(&mut self, object: PyObjectRef) -> AstResult<ast::Keyword> {
+        let arg = self
+            .optional_field(object, "arg")?
+            .map(|value| {
+                if !unsafe { pyre_object::is_str(value) } {
+                    return Err(crate::PyError::type_error(
+                        "AST identifier must be of type str",
+                    ));
+                }
+                Ok(ast::Identifier::new(
+                    unsafe { pyre_object::w_str_get_value(value).to_string() },
+                    Default::default(),
+                ))
+            })
+            .transpose()?;
+        let value = self.field(object, "value", "keyword")?;
+        Ok(ast::Keyword {
+            node_index: Default::default(),
+            range: Default::default(),
+            arg,
+            value: self.recurse(|this| this.expr(value))?,
+        })
+    }
+
+    fn constant_value(&self, object: PyObjectRef) -> AstResult<ast::ConstantValue> {
+        unsafe {
+            if pyre_object::is_none(object) {
+                Ok(ast::ConstantValue::None)
+            } else if pyre_object::is_bool(object) {
+                Ok(ast::ConstantValue::Boolean(pyre_object::w_bool_get_value(
+                    object,
+                )))
+            } else if pyre_object::is_int(object) {
+                Ok(ast::ConstantValue::Integer(
+                    pyre_object::w_int_get_value(object)
+                        .to_string()
+                        .into_boxed_str(),
+                ))
+            } else if pyre_object::is_long(object) {
+                Ok(ast::ConstantValue::Integer(
+                    pyre_object::w_long_get_value(object)
+                        .to_string()
+                        .into_boxed_str(),
+                ))
+            } else if pyre_object::is_float(object) {
+                Ok(ast::ConstantValue::Float(pyre_object::w_float_get_value(
+                    object,
+                )))
+            } else if pyre_object::is_str(object) {
+                Ok(ast::ConstantValue::Str(
+                    pyre_object::w_str_get_value(object)
+                        .to_string()
+                        .into_boxed_str(),
+                ))
+            } else if pyre_object::is_bytes(object) {
+                Ok(ast::ConstantValue::Bytes(
+                    pyre_object::w_bytes_data(object)
+                        .to_vec()
+                        .into_boxed_slice(),
+                ))
+            } else if pyre_object::is_ellipsis(object) {
+                Ok(ast::ConstantValue::Ellipsis)
+            } else {
+                Err(crate::PyError::type_error(format!(
+                    "got an invalid type in Constant: {}",
+                    pyre_object::type_name_of(object)
+                )))
+            }
+        }
+    }
+
+    fn context(&self, object: PyObjectRef) -> AstResult<ast::ExprContext> {
+        for (name, ctx) in [
+            ("Load", ast::ExprContext::Load),
+            ("Store", ast::ExprContext::Store),
+            ("Del", ast::ExprContext::Del),
+            ("Invalid", ast::ExprContext::Invalid),
+        ] {
+            if self.is_node(object, name)? {
+                return Ok(ctx);
+            }
+        }
+        Err(crate::PyError::type_error(
+            "expected some sort of expr_context",
+        ))
+    }
+
+    fn unaryop(&self, object: PyObjectRef) -> AstResult<ast::UnaryOp> {
+        for (name, op) in [
+            ("Invert", ast::UnaryOp::Invert),
+            ("Not", ast::UnaryOp::Not),
+            ("UAdd", ast::UnaryOp::UAdd),
+            ("USub", ast::UnaryOp::USub),
+        ] {
+            if self.is_node(object, name)? {
+                return Ok(op);
+            }
+        }
+        Err(crate::PyError::type_error("expected some sort of unaryop"))
+    }
+
+    fn operator(&self, object: PyObjectRef) -> AstResult<ast::Operator> {
+        for (name, op) in [
+            ("Add", ast::Operator::Add),
+            ("Sub", ast::Operator::Sub),
+            ("Mult", ast::Operator::Mult),
+            ("MatMult", ast::Operator::MatMult),
+            ("Div", ast::Operator::Div),
+            ("Mod", ast::Operator::Mod),
+            ("Pow", ast::Operator::Pow),
+            ("LShift", ast::Operator::LShift),
+            ("RShift", ast::Operator::RShift),
+            ("BitOr", ast::Operator::BitOr),
+            ("BitXor", ast::Operator::BitXor),
+            ("BitAnd", ast::Operator::BitAnd),
+            ("FloorDiv", ast::Operator::FloorDiv),
+        ] {
+            if self.is_node(object, name)? {
+                return Ok(op);
+            }
+        }
+        Err(crate::PyError::type_error("expected some sort of operator"))
+    }
+}
+
 pub fn parse_to_object(source: &str, mode: crate::compile::Mode) -> crate::PyResult {
     let parsed = match mode {
         crate::compile::Mode::Eval => parser::parse_expression(source)

--- a/pyre/pyre-interpreter/src/module/_collections/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_collections/mod.rs
@@ -113,6 +113,218 @@ fn maxlen_obj(self_obj: PyObjectRef) -> PyObjectRef {
     }
 }
 
+// PyPy `W_DequeIter`: the iterator owns the deque, current position, number
+// of remaining entries, and a snapshot of the deque mutation lock.
+mod deque_iter {
+    use super::{W_Deque, checklock, data, getlock};
+    use pyre_object::*;
+
+    #[crate::pyre_class("_collections._deque_iterator")]
+    pub struct W_DequeIter {
+        deque: PyObjectRef,
+        index: i64,
+        counter: i64,
+        lock: i64,
+    }
+
+    fn constructor_args(args: &[PyObjectRef]) -> Result<(PyObjectRef, i64), crate::PyError> {
+        let (positional, _kwargs) = crate::builtins::split_builtin_kwargs(args);
+        // `__new__`'s descriptor ABI leaves the requested class at the front
+        // of the varargs slice (the typed `_cls` slot is the descriptor
+        // receiver).  PyPy's W_DequeIter__new__ starts parsing after it.
+        let positional = positional.get(1..).unwrap_or(&[]);
+        if positional.is_empty() || positional.len() > 2 {
+            return Err(crate::PyError::type_error(format!(
+                "_deque_iterator expected 1 or 2 arguments, got {}",
+                positional.len()
+            )));
+        }
+        let deque = positional[0];
+        if W_Deque::from_obj(deque).is_none() {
+            let name = unsafe { pyre_object::type_name_of(deque) };
+            return Err(crate::PyError::type_error(format!(
+                "must be collections.deque, not {name}"
+            )));
+        }
+        let index = match positional.get(1) {
+            Some(&value) => crate::builtins::space_index_w(value)?,
+            None => 0,
+        };
+        Ok((deque, index))
+    }
+
+    #[crate::pyre_methods]
+    impl W_DequeIter {
+        #[staticmethod]
+        fn __new__(_cls: PyObjectRef, args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+            let (deque, requested) = constructor_args(args)?;
+            Ok(make(deque, requested))
+        }
+
+        fn __iter__(&self) -> PyObjectRef {
+            self as *const W_DequeIter as PyObjectRef
+        }
+
+        fn __length_hint__(&self) -> i64 {
+            self.counter.max(0)
+        }
+
+        fn __next__(&mut self) -> Result<PyObjectRef, crate::PyError> {
+            if let Err(error) = checklock(self.deque, self.lock) {
+                self.counter = 0;
+                return Err(error);
+            }
+            if self.counter <= 0 {
+                return Err(crate::PyError::stop_iteration());
+            }
+            let item = unsafe { w_list_getitem(data(self.deque), self.index) }
+                .ok_or_else(crate::PyError::stop_iteration)?;
+            self.index += 1;
+            self.counter -= 1;
+            Ok(item)
+        }
+
+        fn __reduce__(&self) -> PyObjectRef {
+            let self_obj = self as *const W_DequeIter as PyObjectRef;
+            let ty = unsafe { w_instance_get_type(self_obj) };
+            let consumed = W_Deque::from_obj(self.deque)
+                .map(|deque| unsafe { w_list_len(deque.data) as i64 } - self.counter)
+                .unwrap_or(0);
+            w_tuple_new(vec![ty, w_tuple_new(vec![self.deque, w_int_new(consumed)])])
+        }
+    }
+
+    pub fn make(deque: PyObjectRef, requested: i64) -> PyObjectRef {
+        let _ = type_object();
+        let len = W_Deque::from_obj(deque)
+            .map(|deque| unsafe { w_list_len(deque.data) as i64 })
+            .unwrap_or(0);
+        let index = requested.max(0);
+        let _roots = pyre_object::gc_roots::push_roots();
+        pyre_object::gc_roots::pin_root(deque);
+        W_DequeIter::allocate(W_DequeIter {
+            ob: PyObject {
+                ob_type: std::ptr::null(),
+                w_class: std::ptr::null_mut(),
+            },
+            deque,
+            index,
+            counter: len - index,
+            lock: getlock(deque),
+        })
+    }
+
+    pub fn public_type() -> PyObjectRef {
+        let ty = type_object();
+        // `interp_deque.py`: W_DequeIter.typedef explicitly sets
+        // acceptable_as_base_class=False.
+        unsafe { pyre_object::w_type_set_acceptable_as_base_class(ty, false) };
+        ty
+    }
+}
+
+// PyPy `W_DequeRevIter`, with the same state shape and reverse indexing into
+// pyre's list-backed deque payload.
+mod deque_rev_iter {
+    use super::{W_Deque, checklock, data, getlock};
+    use pyre_object::*;
+
+    #[crate::pyre_class("_collections._deque_reverse_iterator")]
+    pub struct W_DequeRevIter {
+        deque: PyObjectRef,
+        index: i64,
+        counter: i64,
+        lock: i64,
+    }
+
+    #[crate::pyre_methods]
+    impl W_DequeRevIter {
+        #[staticmethod]
+        fn __new__(_cls: PyObjectRef, args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+            let (positional, _kwargs) = crate::builtins::split_builtin_kwargs(args);
+            let positional = positional.get(1..).unwrap_or(&[]);
+            if positional.is_empty() || positional.len() > 2 {
+                return Err(crate::PyError::type_error(format!(
+                    "_deque_reverse_iterator expected 1 or 2 arguments, got {}",
+                    positional.len()
+                )));
+            }
+            let deque = positional[0];
+            if W_Deque::from_obj(deque).is_none() {
+                let name = unsafe { pyre_object::type_name_of(deque) };
+                return Err(crate::PyError::type_error(format!(
+                    "must be collections.deque, not {name}"
+                )));
+            }
+            let requested = match positional.get(1) {
+                Some(&value) => crate::builtins::space_index_w(value)?,
+                None => 0,
+            };
+            Ok(make(deque, requested))
+        }
+
+        fn __iter__(&self) -> PyObjectRef {
+            self as *const W_DequeRevIter as PyObjectRef
+        }
+
+        fn __length_hint__(&self) -> i64 {
+            self.counter.max(0)
+        }
+
+        fn __next__(&mut self) -> Result<PyObjectRef, crate::PyError> {
+            if let Err(error) = checklock(self.deque, self.lock) {
+                self.counter = 0;
+                return Err(error);
+            }
+            if self.counter <= 0 {
+                return Err(crate::PyError::stop_iteration());
+            }
+            let item = unsafe { w_list_getitem(data(self.deque), self.index) }
+                .ok_or_else(crate::PyError::stop_iteration)?;
+            self.index -= 1;
+            self.counter -= 1;
+            Ok(item)
+        }
+
+        fn __reduce__(&self) -> PyObjectRef {
+            let self_obj = self as *const W_DequeRevIter as PyObjectRef;
+            let ty = unsafe { w_instance_get_type(self_obj) };
+            let consumed = W_Deque::from_obj(self.deque)
+                .map(|deque| unsafe { w_list_len(deque.data) as i64 } - self.counter)
+                .unwrap_or(0);
+            w_tuple_new(vec![ty, w_tuple_new(vec![self.deque, w_int_new(consumed)])])
+        }
+    }
+
+    pub fn make(deque: PyObjectRef, requested: i64) -> PyObjectRef {
+        let _ = type_object();
+        let len = W_Deque::from_obj(deque)
+            .map(|deque| unsafe { w_list_len(deque.data) as i64 })
+            .unwrap_or(0);
+        let offset = requested.max(0);
+        let _roots = pyre_object::gc_roots::push_roots();
+        pyre_object::gc_roots::pin_root(deque);
+        W_DequeRevIter::allocate(W_DequeRevIter {
+            ob: PyObject {
+                ob_type: std::ptr::null(),
+                w_class: std::ptr::null_mut(),
+            },
+            deque,
+            index: len - offset - 1,
+            counter: len - offset,
+            lock: getlock(deque),
+        })
+    }
+
+    pub fn public_type() -> PyObjectRef {
+        let ty = type_object();
+        // `interp_deque.py`: W_DequeRevIter.typedef explicitly sets
+        // acceptable_as_base_class=False.
+        unsafe { pyre_object::w_type_set_acceptable_as_base_class(ty, false) };
+        ty
+    }
+}
+
 /// `W_Deque.append` + `trimleft`: drop from the left once over the bound.
 fn do_append(self_obj: PyObjectRef, item: PyObjectRef) {
     let d = data(self_obj);
@@ -538,7 +750,11 @@ impl W_Deque {
     }
     fn __iter__(&self) -> Result<PyObjectRef, crate::PyError> {
         let self_obj = self as *const W_Deque as PyObjectRef;
-        crate::baseobjspace::iter(data(self_obj))
+        Ok(deque_iter::make(self_obj, 0))
+    }
+    fn __reversed__(&self) -> PyObjectRef {
+        let self_obj = self as *const W_Deque as PyObjectRef;
+        deque_rev_iter::make(self_obj, 0)
     }
     fn __getitem__(&self, index: PyObjectRef) -> Result<PyObjectRef, crate::PyError> {
         let self_obj = self as *const W_Deque as PyObjectRef;
@@ -659,8 +875,9 @@ impl W_Deque {
 crate::py_module! {
     "_collections",
     interpleveldefs: {
-        "deque"           => type_object(),
-        "_deque_iterator" => crate::typedef::w_object(),
+        "deque"                   => type_object(),
+        "_deque_iterator"         => deque_iter::public_type(),
+        "_deque_reverse_iterator" => deque_rev_iter::public_type(),
     },
     // `defaultdict` and `OrderedDict` are app-level `dict` subclasses —
     // see the module header and `app_defaultdict.py` / `app_odict.py`

--- a/pyre/pyre-interpreter/src/module/_weakref/interp__weakref.rs
+++ b/pyre/pyre-interpreter/src/module/_weakref/interp__weakref.rs
@@ -16,12 +16,13 @@ use pyre_object::*;
 
 use std::sync::OnceLock;
 
-thread_local! {
-    static WEAKREF_LIFELINE_TYPE: OnceLock<PyObjectRef> = const { OnceLock::new() };
-    static WEAKREF_TYPE: OnceLock<PyObjectRef> = const { OnceLock::new() };
-    static PROXY_TYPE: OnceLock<PyObjectRef> = const { OnceLock::new() };
-    static CALLABLE_PROXY_TYPE: OnceLock<PyObjectRef> = const { OnceLock::new() };
-}
+// Type objects belong to the process-wide object space, not to an OS thread.
+// Store their addresses as `usize` because `PyObjectRef` is a raw pointer and
+// therefore cannot itself be held by a `Sync` static.
+static WEAKREF_LIFELINE_TYPE: OnceLock<usize> = OnceLock::new();
+static WEAKREF_TYPE: OnceLock<usize> = OnceLock::new();
+static PROXY_TYPE: OnceLock<usize> = OnceLock::new();
+static CALLABLE_PROXY_TYPE: OnceLock<usize> = OnceLock::new();
 
 // ── Instance attribute names ──────────────────────────────────────────
 //
@@ -32,6 +33,8 @@ thread_local! {
 
 const ATTR_CACHED_WEAKREF: &str = "cached_weakref";
 const ATTR_CACHED_PROXY: &str = "cached_proxy";
+const ATTR_OTHER_REFS_WEAK: &str = "other_refs_weak";
+const ATTR_HAS_CALLBACKS: &str = "has_callbacks";
 const ATTR_W_OBJ_WEAK: &str = "w_obj_weak";
 const ATTR_W_CALLABLE: &str = "w_callable";
 const ATTR_W_HASH: &str = "w_hash";
@@ -115,13 +118,11 @@ impl Drop for InstanceRoot {
 // ── Type registration ─────────────────────────────────────────────────
 
 fn weakref_lifeline_type() -> PyObjectRef {
-    WEAKREF_LIFELINE_TYPE.with(|cell| {
-        *cell.get_or_init(|| {
-            let tp = crate::typedef::make_builtin_type("WeakrefLifeline", |_| {});
-            unsafe { pyre_object::w_type_set_hasdict(tp, true) };
-            tp
-        })
-    })
+    *WEAKREF_LIFELINE_TYPE.get_or_init(|| {
+        let tp = crate::typedef::make_builtin_type("WeakrefLifeline", |_| {});
+        unsafe { pyre_object::w_type_set_hasdict(tp, true) };
+        tp as usize
+    }) as PyObjectRef
 }
 
 /// pypy/module/_weakref/interp__weakref.py:270-280 W_Weakref.typedef
@@ -189,16 +190,26 @@ fn init_weakref_type(ns: PyObjectRef) {
             make_builtin_function_with_arity("__repr__", descr__repr__, 1),
         )
     };
+    unsafe {
+        pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
+            ns,
+            "__callback__",
+            crate::typedef::make_getset_property_named(
+                make_builtin_function_with_arity("__callback__", descr_callback, 2),
+                pyre_object::PY_NULL,
+                pyre_object::PY_NULL,
+                "__callback__",
+            ),
+        )
+    };
 }
 
 pub fn weakref_type() -> PyObjectRef {
-    WEAKREF_TYPE.with(|cell| {
-        *cell.get_or_init(|| {
-            let tp = crate::typedef::make_builtin_type("weakref", init_weakref_type);
-            unsafe { pyre_object::w_type_set_hasdict(tp, true) };
-            tp
-        })
-    })
+    *WEAKREF_TYPE.get_or_init(|| {
+        let tp = crate::typedef::make_builtin_type("weakref", init_weakref_type);
+        unsafe { pyre_object::w_type_set_hasdict(tp, true) };
+        tp as usize
+    }) as PyObjectRef
 }
 
 /// pypy/module/_weakref/interp__weakref.py:405-410 W_Proxy.typedef
@@ -237,21 +248,19 @@ fn init_proxy_type(ns: PyObjectRef) {
     register_proxy_typedef_dict(ns, /*include_comparisons=*/ true);
 }
 
-/// `dont_look_inside`: the `PROXY_TYPE` thread-local `OnceLock` read has
+/// `dont_look_inside`: the `PROXY_TYPE` process-global `OnceLock` read has
 /// no extractable graph; the call stays a residual returning the lazily
 /// built type object (same shape as [`crate::typedef::w_type`]).
 #[majit_macros::dont_look_inside]
 pub fn proxy_type() -> PyObjectRef {
-    PROXY_TYPE.with(|cell| {
-        *cell.get_or_init(|| {
-            let tp = crate::typedef::make_builtin_type("weakproxy", init_proxy_type);
-            unsafe {
-                pyre_object::w_type_set_hasdict(tp, true);
-                pyre_object::w_type_set_acceptable_as_base_class(tp, false);
-            }
-            tp
-        })
-    })
+    *PROXY_TYPE.get_or_init(|| {
+        let tp = crate::typedef::make_builtin_type("weakproxy", init_proxy_type);
+        unsafe {
+            pyre_object::w_type_set_hasdict(tp, true);
+            pyre_object::w_type_set_acceptable_as_base_class(tp, false);
+        }
+        tp as usize
+    }) as PyObjectRef
 }
 
 /// pypy/module/_weakref/interp__weakref.py:412-418 W_CallableProxy.typedef
@@ -303,17 +312,14 @@ fn init_callable_proxy_type(ns: PyObjectRef) {
 /// `dont_look_inside` for the same reason as [`proxy_type`].
 #[majit_macros::dont_look_inside]
 pub fn callable_proxy_type() -> PyObjectRef {
-    CALLABLE_PROXY_TYPE.with(|cell| {
-        *cell.get_or_init(|| {
-            let tp =
-                crate::typedef::make_builtin_type("weakcallableproxy", init_callable_proxy_type);
-            unsafe {
-                pyre_object::w_type_set_hasdict(tp, true);
-                pyre_object::w_type_set_acceptable_as_base_class(tp, false);
-            }
-            tp
-        })
-    })
+    *CALLABLE_PROXY_TYPE.get_or_init(|| {
+        let tp = crate::typedef::make_builtin_type("weakcallableproxy", init_callable_proxy_type);
+        unsafe {
+            pyre_object::w_type_set_hasdict(tp, true);
+            pyre_object::w_type_set_acceptable_as_base_class(tp, false);
+        }
+        tp as usize
+    }) as PyObjectRef
 }
 
 // ── WeakrefLifeline ───────────────────────────────────────────────────
@@ -342,7 +348,52 @@ pub fn weakref_lifeline_new() -> PyObjectRef {
     let _root = InstanceRoot::new(&mut obj);
     write_attr(obj, ATTR_CACHED_WEAKREF, pyre_object::w_none());
     write_attr(obj, ATTR_CACHED_PROXY, pyre_object::w_none());
+    write_attr(obj, ATTR_OTHER_REFS_WEAK, pyre_object::w_none());
+    write_attr(obj, ATTR_HAS_CALLBACKS, pyre_object::w_bool_from(false));
     obj
+}
+
+/// pypy/module/_weakref/interp__weakref.py:30-33
+/// `WeakrefLifeline.append_wref_to`.
+fn append_wref_to(self_lifeline: PyObjectRef, w_ref: PyObjectRef) {
+    let _roots = pyre_object::gc_roots::push_roots();
+    let root_base = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(self_lifeline);
+    pyre_object::gc_roots::pin_root(w_ref);
+    let weak = pyre_object::weakref::w_gc_weakref_box_new_or_strong(
+        pyre_object::gc_roots::shadow_stack_get(root_base + 1),
+    );
+    pyre_object::gc_roots::pin_root(weak);
+    let lifeline = pyre_object::gc_roots::shadow_stack_get(root_base);
+    let mut refs = read_attr(lifeline, ATTR_OTHER_REFS_WEAK);
+    if refs.is_null() {
+        refs = pyre_object::w_list_new_object(vec![pyre_object::gc_roots::shadow_stack_get(
+            root_base + 2,
+        )]);
+        write_attr(
+            pyre_object::gc_roots::shadow_stack_get(root_base),
+            ATTR_OTHER_REFS_WEAK,
+            refs,
+        );
+    } else {
+        unsafe {
+            pyre_object::w_list_append(refs, pyre_object::gc_roots::shadow_stack_get(root_base + 2))
+        };
+    }
+}
+
+/// pypy/module/_weakref/interp__weakref.py:105-109
+/// `WeakrefLifeline.enable_callbacks`.
+fn enable_callbacks(self_lifeline: PyObjectRef) {
+    let enabled = read_attr(self_lifeline, ATTR_HAS_CALLBACKS);
+    if !enabled.is_null() && crate::baseobjspace::is_true(enabled).unwrap_or(false) {
+        return;
+    }
+    write_attr(
+        self_lifeline,
+        ATTR_HAS_CALLBACKS,
+        pyre_object::w_bool_from(true),
+    );
 }
 
 /// pypy/module/_weakref/interp__weakref.py:60-77 get_or_make_weakref
@@ -449,13 +500,10 @@ pub fn get_or_make_proxy(self_lifeline: PyObjectRef, w_obj: PyObjectRef) -> PyOb
 ///     return space.w_None
 /// ```
 pub fn get_any_weakref(self_lifeline: PyObjectRef) -> PyObjectRef {
-    // interp__weakref.py:95-98: cached_weakref is a weakref TO the
-    // W_Weakref; w_ref = self.cached_weakref() returns the W_Weakref
-    // or None.
-    let cached_slot = read_attr(self_lifeline, ATTR_CACHED_WEAKREF);
-    let cached = unsafe { pyre_object::weakref::w_gc_weakref_box_or_strong_deref(cached_slot) };
-    if !cached.is_null() {
-        return cached;
+    for w_ref in lifeline_refs(self_lifeline) {
+        if is_w_weakref(w_ref) {
+            return w_ref;
+        }
     }
     pyre_object::w_none()
 }
@@ -473,12 +521,15 @@ pub fn get_any_weakref(self_lifeline: PyObjectRef) -> PyObjectRef {
 ///     return w_ref
 /// ```
 pub fn make_weakref_with_callback(
-    _self_lifeline: PyObjectRef,
+    self_lifeline: PyObjectRef,
     w_subtype: PyObjectRef,
     w_obj: PyObjectRef,
     w_callable: PyObjectRef,
 ) -> PyObjectRef {
-    W_Weakref_new(w_subtype, w_obj, w_callable)
+    let w_ref = W_Weakref_new(w_subtype, w_obj, w_callable);
+    append_wref_to(self_lifeline, w_ref);
+    enable_callbacks(self_lifeline);
+    w_ref
 }
 
 /// pypy/module/_weakref/interp__weakref.py:120-129 make_proxy_with_callback
@@ -496,15 +547,18 @@ pub fn make_weakref_with_callback(
 ///     return w_proxy
 /// ```
 pub fn make_proxy_with_callback(
-    _self_lifeline: PyObjectRef,
+    self_lifeline: PyObjectRef,
     w_obj: PyObjectRef,
     w_callable: PyObjectRef,
 ) -> PyObjectRef {
-    if is_callable(w_obj) {
+    let w_proxy = if is_callable(w_obj) {
         W_CallableProxy_new(w_obj, w_callable)
     } else {
         W_Proxy_new(w_obj, w_callable)
-    }
+    };
+    append_wref_to(self_lifeline, w_proxy);
+    enable_callbacks(self_lifeline);
+    w_proxy
 }
 
 // ── W_WeakrefBase / W_Weakref ─────────────────────────────────────────
@@ -764,6 +818,18 @@ pub fn descr__ne__(args: &[PyObjectRef]) -> Result<PyObjectRef, PyError> {
     compare(args[0], args[1], true)
 }
 
+/// pypy/module/_weakref/interp__weakref.py:252-253
+/// `__callback__ = GetSetProperty(W_Weakref.descr_callback)`.
+/// GetSetProperty passes `(descriptor, instance)` to the getter.
+pub fn descr_callback(args: &[PyObjectRef]) -> Result<PyObjectRef, PyError> {
+    let w_callable = read_attr(args[1], ATTR_W_CALLABLE);
+    if w_callable.is_null() {
+        Ok(pyre_object::w_none())
+    } else {
+        Ok(w_callable)
+    }
+}
+
 fn is_w_weakref(obj: PyObjectRef) -> bool {
     if obj.is_null() {
         return false;
@@ -797,7 +863,83 @@ pub fn getlifeline(w_obj: PyObjectRef) -> Result<PyObjectRef, PyError> {
     }
     let lifeline = weakref_lifeline_new();
     crate::baseobjspace::setweakref(w_obj, lifeline)?;
+    // RPython's collector invalidates every rweakref when its target dies.
+    // pyre routes the equivalent lifeline clear through the shared finalizer
+    // queue, including for refs/proxies without callbacks.
+    crate::executioncontext::register_weakref_finalizer(w_obj);
     Ok(lifeline)
+}
+
+fn lifeline_refs(lifeline: PyObjectRef) -> Vec<PyObjectRef> {
+    let mut refs = Vec::new();
+    for name in [ATTR_CACHED_WEAKREF, ATTR_CACHED_PROXY] {
+        let weak = read_attr(lifeline, name);
+        let w_ref = unsafe { pyre_object::weakref::w_gc_weakref_box_or_strong_deref(weak) };
+        if !w_ref.is_null() {
+            refs.push(w_ref);
+        }
+    }
+    let others = read_attr(lifeline, ATTR_OTHER_REFS_WEAK);
+    if !others.is_null() {
+        let length = unsafe { pyre_object::w_list_len(others) };
+        for i in 0..length {
+            let Some(weak) = (unsafe { pyre_object::w_list_getitem(others, i as i64) }) else {
+                continue;
+            };
+            let w_ref = unsafe { pyre_object::weakref::w_gc_weakref_box_or_strong_deref(weak) };
+            if !w_ref.is_null() {
+                refs.push(w_ref);
+            }
+        }
+    }
+    refs
+}
+
+/// `WeakrefLifeline._finalize_` (interp__weakref.py:131-153), invoked
+/// from pyre's shared finalizer queue when the referent becomes unreachable.
+pub fn finalize_weakrefs(w_obj: PyObjectRef) {
+    let Some(lifeline) = crate::baseobjspace::getweakref(w_obj) else {
+        return;
+    };
+    let refs = lifeline_refs(lifeline);
+
+    // `clear_all_weakrefs` / rweakref invalidation must be visible before a
+    // callback runs: every callback observes `ref() is None`.
+    for &w_ref in &refs {
+        let target = read_attr(w_ref, ATTR_W_OBJ_WEAK);
+        unsafe { pyre_object::weakref::w_gc_weakref_box_clear(target) };
+        write_attr(w_ref, ATTR_W_OBJ_WEAK, pyre_object::w_none());
+    }
+
+    // PyPy runs `other_refs_weak` in reverse creation order. Cached refs and
+    // proxies have no callback and therefore need only the clearing above.
+    for &w_ref in refs.iter().rev() {
+        let w_callable = read_attr(w_ref, ATTR_W_CALLABLE);
+        if w_callable.is_null() {
+            continue;
+        }
+        let _roots = pyre_object::gc_roots::push_roots();
+        let root_base = pyre_object::gc_roots::shadow_stack_len();
+        pyre_object::gc_roots::pin_root(w_ref);
+        pyre_object::gc_roots::pin_root(w_callable);
+        let current_ref = || pyre_object::gc_roots::shadow_stack_get(root_base);
+        let current_callable = || pyre_object::gc_roots::shadow_stack_get(root_base + 1);
+        if let Err(error) =
+            crate::call::call_function_impl_result(current_callable(), &[current_ref()])
+        {
+            let ec = crate::call::getexecutioncontext();
+            if !ec.is_null() {
+                crate::executioncontext::report_error(
+                    unsafe { (*ec).space },
+                    &error,
+                    "weakref callback ",
+                    current_callable(),
+                );
+            }
+        }
+        write_attr(current_ref(), ATTR_W_CALLABLE, pyre_object::w_none());
+    }
+    crate::baseobjspace::delweakref(w_obj);
 }
 
 /// pypy/module/_weakref/interp__weakref.py:260-268 descr__new__weakref
@@ -873,15 +1015,9 @@ pub fn getweakrefcount(args: &[PyObjectRef]) -> Result<PyObjectRef, PyError> {
     let w_obj = args[0];
     let count = match crate::baseobjspace::getweakref(w_obj) {
         None => 0,
-        Some(lifeline) => {
-            // interp__weakref.py:286: `if wref() is not None: count += 1`
-            let cached_slot = read_attr(lifeline, ATTR_CACHED_WEAKREF);
-            let cached =
-                unsafe { pyre_object::weakref::w_gc_weakref_box_or_strong_deref(cached_slot) };
-            if !cached.is_null() { 1 } else { 0 }
-        }
+        Some(lifeline) => lifeline_refs(lifeline).len(),
     };
-    Ok(pyre_object::w_int_new(count))
+    Ok(pyre_object::w_int_new(count as i64))
 }
 
 /// pypy/module/_weakref/interp__weakref.py:297-309 getweakrefs
@@ -900,15 +1036,9 @@ pub fn getweakrefs(args: &[PyObjectRef]) -> Result<PyObjectRef, PyError> {
         return Ok(pyre_object::w_list_new(vec![]));
     }
     let w_obj = args[0];
-    let mut result = Vec::new();
-    if let Some(lifeline) = crate::baseobjspace::getweakref(w_obj) {
-        // interp__weakref.py:300-302: deref each cached wref; live ones go in.
-        let cached_slot = read_attr(lifeline, ATTR_CACHED_WEAKREF);
-        let cached = unsafe { pyre_object::weakref::w_gc_weakref_box_or_strong_deref(cached_slot) };
-        if !cached.is_null() {
-            result.push(cached);
-        }
-    }
+    let result = crate::baseobjspace::getweakref(w_obj)
+        .map(lifeline_refs)
+        .unwrap_or_default();
     Ok(pyre_object::w_list_new(result))
 }
 

--- a/pyre/pyre-interpreter/src/module/array/mod.rs
+++ b/pyre/pyre-interpreter/src/module/array/mod.rs
@@ -789,37 +789,72 @@ fn array_repr_method(args: &[PyObjectRef]) -> PyResult {
     Ok(pyre_object::w_str_new(&array_repr_string(args[0])?))
 }
 
-// Comparison: lexicographic over elements (`compare_arrays`).
+// `interp_array.py compare_arrays`: compare each element with the requested
+// operation.  In particular, an unordered pair such as NaN is neither less
+// nor greater; treating every non-equal/non-less pair as greater is wrong.
 fn array_richcompare(a: PyObjectRef, b: PyObjectRef, op: u8) -> PyResult {
     if !unsafe { arr::is_array(a) } || !unsafe { arr::is_array(b) } {
         return Ok(pyre_object::w_not_implemented());
     }
     let la = unsafe { arr::w_array_len(a) };
     let lb = unsafe { arr::w_array_len(b) };
+    if op == 0 && la != lb {
+        return Ok(pyre_object::w_bool_from(false));
+    }
+    if op == 1 && la != lb {
+        return Ok(pyre_object::w_bool_from(true));
+    }
     let n = la.min(lb);
-    let mut decided: Option<std::cmp::Ordering> = None;
     for i in 0..n {
         let ea = unsafe { arr::w_array_unpack_item(a, i) };
         let eb = unsafe { arr::w_array_unpack_item(b, i) };
-        if !crate::baseobjspace::eq_w(ea, eb)? {
-            // First differing element decides the ordering via `<`.
-            let lt = crate::baseobjspace::is_true(compare(ea, eb, CompareOp::Lt)?)?;
-            decided = Some(if lt {
-                std::cmp::Ordering::Less
-            } else {
-                std::cmp::Ordering::Greater
-            });
-            break;
+        match op {
+            0 => {
+                if !crate::baseobjspace::is_true(compare(ea, eb, CompareOp::Eq)?)? {
+                    return Ok(pyre_object::w_bool_from(false));
+                }
+            }
+            1 => {
+                if crate::baseobjspace::is_true(compare(ea, eb, CompareOp::Ne)?)? {
+                    return Ok(pyre_object::w_bool_from(true));
+                }
+            }
+            2 | 4 => {
+                let cmp = if op == 2 {
+                    CompareOp::Lt
+                } else {
+                    CompareOp::Gt
+                };
+                if crate::baseobjspace::is_true(compare(ea, eb, cmp)?)? {
+                    return Ok(pyre_object::w_bool_from(true));
+                }
+                if !crate::baseobjspace::is_true(compare(ea, eb, CompareOp::Eq)?)? {
+                    return Ok(pyre_object::w_bool_from(false));
+                }
+            }
+            3 | 5 => {
+                let cmp = if op == 3 {
+                    CompareOp::Le
+                } else {
+                    CompareOp::Ge
+                };
+                if !crate::baseobjspace::is_true(compare(ea, eb, cmp)?)? {
+                    return Ok(pyre_object::w_bool_from(false));
+                }
+                if !crate::baseobjspace::is_true(compare(ea, eb, CompareOp::Eq)?)? {
+                    return Ok(pyre_object::w_bool_from(true));
+                }
+            }
+            _ => unreachable!(),
         }
     }
-    let ord = decided.unwrap_or_else(|| la.cmp(&lb));
     let result = match op {
-        0 => ord == std::cmp::Ordering::Equal,   // ==
-        1 => ord != std::cmp::Ordering::Equal,   // !=
-        2 => ord == std::cmp::Ordering::Less,    // <
-        3 => ord != std::cmp::Ordering::Greater, // <=
-        4 => ord == std::cmp::Ordering::Greater, // >
-        5 => ord != std::cmp::Ordering::Less,    // >=
+        0 => true,
+        1 => false,
+        2 => la < lb,
+        3 => la <= lb,
+        4 => la > lb,
+        5 => la >= lb,
         _ => unreachable!(),
     };
     Ok(pyre_object::w_bool_from(result))

--- a/pyre/pyre-interpreter/src/module/marshal/mod.rs
+++ b/pyre/pyre-interpreter/src/module/marshal/mod.rs
@@ -1,0 +1,566 @@
+//! `marshal` — PyPy `pypy/module/marshal/` object glue over the shared
+//! RustPython compiler-core marshal format.
+//!
+//! PyPy's `interp_marshal.py` owns the Python object dispatch while
+//! `marshal_impl.py` defines the wire typecodes.  Pyre follows that split:
+//! this module maps `W_Root` objects to the shared wire implementation, and
+//! compiler-core serializes/deserializes the authoritative `CodeObject`.
+
+use malachite_bigint::BigInt;
+use num_complex::Complex64;
+use pyre_object::*;
+use rustpython_compiler_core::bytecode::{BasicBag, CodeObject, ConstantBag, ConstantData};
+use rustpython_compiler_core::marshal::{self as wire, DumpableValue, Write};
+use rustpython_wtf8::Wtf8;
+
+use crate::{PyError, PyResult};
+
+const MAX_DEPTH: usize = wire::MAX_MARSHAL_STACK_DEPTH;
+
+fn marshal_error(error: wire::MarshalError) -> PyError {
+    match error {
+        wire::MarshalError::Eof => eof_error("marshal data too short"),
+        _ => PyError::value_error("bad marshal data"),
+    }
+}
+
+fn eof_error(message: &str) -> PyError {
+    let mut error = PyError::value_error(message);
+    if let Some(cls) = crate::builtins::lookup_exc_class("EOFError") {
+        let args = [cls, w_str_new(message)];
+        if let Ok(exc) = crate::builtins::exc_exception_new(&args) {
+            error.exc_object = exc;
+        }
+    }
+    error
+}
+
+fn call_method(obj: PyObjectRef, name: &str, args: &[PyObjectRef]) -> PyResult {
+    let result = crate::baseobjspace::call_method(obj, name, args);
+    if result.is_null() {
+        Err(crate::call::take_call_error()
+            .unwrap_or_else(|| PyError::runtime_error("method call failed")))
+    } else {
+        Ok(result)
+    }
+}
+
+fn bytes_like(obj: PyObjectRef, function: &str) -> Result<Vec<u8>, PyError> {
+    if unsafe { bytesobject::is_bytes_like(obj) } {
+        Ok(unsafe { bytesobject::bytes_like_data(obj) }.to_vec())
+    } else {
+        Err(PyError::type_error(format!(
+            "{function}() argument must be a bytes-like object"
+        )))
+    }
+}
+
+/// Transient equivalent of PyPy's `Marshaller.all_refs` dict.  A VecMap is
+/// sufficient because marshal streams normally contain few shared objects;
+/// each entry is a shadow-stack slot so a collection updates object identity.
+struct WriterRefs {
+    slots: Vec<usize>,
+}
+
+impl WriterRefs {
+    fn new() -> Self {
+        Self { slots: Vec::new() }
+    }
+
+    fn find(&self, obj: PyObjectRef) -> Option<u32> {
+        let obj =
+            pyre_object::gc_hook::try_gc_current_object_address(obj as *mut u8) as PyObjectRef;
+        self.slots
+            .iter()
+            .position(|&slot| std::ptr::eq(pyre_object::gc_roots::shadow_stack_get(slot), obj))
+            .and_then(|index| u32::try_from(index).ok())
+    }
+
+    fn reserve(&mut self, obj: PyObjectRef) -> Result<(), PyError> {
+        if self.slots.len() >= i32::MAX as usize {
+            return Err(PyError::value_error("too many objects to marshal"));
+        }
+        let slot = pyre_object::gc_roots::shadow_stack_len();
+        pyre_object::gc_roots::pin_root(obj);
+        self.slots.push(slot);
+        Ok(())
+    }
+}
+
+fn is_singleton(obj: PyObjectRef) -> bool {
+    (unsafe { is_none(obj) || is_bool(obj) || is_ellipsis(obj) })
+        || crate::builtins::lookup_exc_class("StopIteration") == Some(obj)
+}
+
+fn write_object(
+    out: &mut Vec<u8>,
+    obj: PyObjectRef,
+    refs: &mut Option<WriterRefs>,
+    version: i32,
+    depth: usize,
+) -> Result<(), PyError> {
+    if depth == 0 {
+        return Err(PyError::value_error("object too deeply nested to marshal"));
+    }
+
+    if !is_singleton(obj)
+        && let Some(table) = refs.as_ref()
+        && let Some(index) = table.find(obj)
+    {
+        out.write_u8(b'r');
+        out.write_u32(index);
+        return Ok(());
+    }
+
+    let type_pos = out.len();
+    let use_ref = refs.is_some() && !is_singleton(obj);
+    if use_ref {
+        refs.as_mut().unwrap().reserve(obj)?;
+    }
+
+    unsafe {
+        if is_none(obj) {
+            out.write_u8(b'N');
+        } else if crate::builtins::lookup_exc_class("StopIteration") == Some(obj) {
+            out.write_u8(b'S');
+        } else if is_bool(obj) {
+            out.write_u8(if w_bool_get_value(obj) { b'T' } else { b'F' });
+        } else if is_ellipsis(obj) {
+            out.write_u8(b'.');
+        } else if is_int_or_long(obj) {
+            let value = crate::builtins::obj_to_bigint(obj);
+            wire::serialize_value::<_, ConstantData>(out, DumpableValue::Integer(&value))
+                .unwrap_or_else(|never| match never {});
+        } else if is_float(obj) {
+            out.write_u8(b'g');
+            out.write_u64(w_float_get_value(obj).to_bits());
+        } else if is_complex(obj) {
+            out.write_u8(b'y');
+            out.write_u64(w_complex_get_real(obj).to_bits());
+            out.write_u64(w_complex_get_imag(obj).to_bits());
+        } else if is_str(obj) {
+            let value = w_str_get_wtf8(obj).as_bytes();
+            out.write_u8(b'u');
+            out.write_u32(
+                value
+                    .len()
+                    .try_into()
+                    .map_err(|_| PyError::value_error("object too large to marshal"))?,
+            );
+            out.write_slice(value);
+        } else if bytesobject::is_bytes_like(obj) {
+            let value = bytesobject::bytes_like_data(obj);
+            out.write_u8(b's');
+            out.write_u32(
+                value
+                    .len()
+                    .try_into()
+                    .map_err(|_| PyError::value_error("object too large to marshal"))?,
+            );
+            out.write_slice(value);
+        } else if is_tuple(obj) {
+            let len = w_tuple_len(obj);
+            out.write_u8(if version >= 4 && len < 256 {
+                b')'
+            } else {
+                b'('
+            });
+            if version >= 4 && len < 256 {
+                out.write_u8(len as u8);
+            } else {
+                out.write_u32(
+                    len.try_into()
+                        .map_err(|_| PyError::value_error("object too large to marshal"))?,
+                );
+            }
+            for index in 0..len {
+                let item = w_tuple_getitem(obj, index as i64)
+                    .ok_or_else(|| PyError::value_error("unmarshallable object"))?;
+                write_object(out, item, refs, version, depth - 1)?;
+            }
+        } else if is_list(obj) {
+            let len = w_list_len(obj);
+            out.write_u8(b'[');
+            out.write_u32(
+                len.try_into()
+                    .map_err(|_| PyError::value_error("object too large to marshal"))?,
+            );
+            for index in 0..len {
+                let item = w_list_getitem(obj, index as i64)
+                    .ok_or_else(|| PyError::value_error("unmarshallable object"))?;
+                write_object(out, item, refs, version, depth - 1)?;
+            }
+        } else if is_dict(obj) {
+            out.write_u8(b'{');
+            for (key, value) in dictmultiobject::w_dict_items(obj) {
+                write_object(out, key, refs, version, depth - 1)?;
+                write_object(out, value, refs, version, depth - 1)?;
+            }
+            out.write_u8(b'0');
+        } else if setobject::is_set_or_frozenset(obj) {
+            out.write_u8(if setobject::is_frozenset(obj) {
+                b'>'
+            } else {
+                b'<'
+            });
+            let items = setobject::w_set_items(obj);
+            out.write_u32(
+                items
+                    .len()
+                    .try_into()
+                    .map_err(|_| PyError::value_error("object too large to marshal"))?,
+            );
+            for item in items {
+                write_object(out, item, refs, version, depth - 1)?;
+            }
+        } else if crate::pycode::is_code(obj) {
+            let ptr = crate::pycode::w_code_get_ptr(obj) as *const crate::CodeObject;
+            if ptr.is_null() {
+                return Err(PyError::value_error("unmarshallable object"));
+            }
+            out.write_u8(b'c');
+            wire::serialize_code(out, &*ptr);
+        } else if is_slice(obj) && version >= 5 {
+            out.write_u8(b':');
+            write_object(
+                out,
+                sliceobject::w_slice_get_start(obj),
+                refs,
+                version,
+                depth - 1,
+            )?;
+            write_object(
+                out,
+                sliceobject::w_slice_get_stop(obj),
+                refs,
+                version,
+                depth - 1,
+            )?;
+            write_object(
+                out,
+                sliceobject::w_slice_get_step(obj),
+                refs,
+                version,
+                depth - 1,
+            )?;
+        } else {
+            return Err(PyError::value_error("unmarshallable object"));
+        }
+    }
+
+    if use_ref {
+        out[type_pos] |= wire::FLAG_REF;
+    }
+    Ok(())
+}
+
+#[derive(Clone, Copy)]
+struct Rooted(usize);
+
+impl Rooted {
+    fn new(obj: PyObjectRef) -> Self {
+        let slot = pyre_object::gc_roots::shadow_stack_len();
+        pyre_object::gc_roots::pin_root(obj);
+        Self(slot)
+    }
+
+    fn get(self) -> PyObjectRef {
+        pyre_object::gc_roots::shadow_stack_get(self.0)
+    }
+}
+
+#[derive(Clone, Copy)]
+struct PyreMarshalBag;
+
+impl wire::MarshalBag for PyreMarshalBag {
+    type Value = Rooted;
+    type ConstantBag = BasicBag;
+
+    fn make_bool(&self, value: bool) -> Rooted {
+        Rooted::new(w_bool_from(value))
+    }
+
+    fn make_none(&self) -> Rooted {
+        Rooted::new(w_none())
+    }
+
+    fn make_ellipsis(&self) -> Rooted {
+        Rooted::new(special::w_ellipsis())
+    }
+
+    fn make_float(&self, value: f64) -> Rooted {
+        Rooted::new(w_float_new(value))
+    }
+
+    fn make_complex(&self, value: Complex64) -> Rooted {
+        Rooted::new(w_complex_new(value.re, value.im))
+    }
+
+    fn make_str(&self, value: &Wtf8) -> Rooted {
+        Rooted::new(w_str_from_wtf8(value.to_owned()))
+    }
+
+    fn make_bytes(&self, value: &[u8]) -> Rooted {
+        Rooted::new(bytesobject::w_bytes_from_bytes(value))
+    }
+
+    fn make_int(&self, value: BigInt) -> Rooted {
+        let obj = if longobject::jit_bigint_to_i64_fits(&value) != 0 {
+            w_int_new(longobject::jit_bigint_to_i64_value(&value))
+        } else {
+            longobject::w_long_new(value)
+        };
+        Rooted::new(obj)
+    }
+
+    fn make_tuple(&self, elements: impl Iterator<Item = Rooted>) -> Rooted {
+        Rooted::new(w_tuple_new(elements.map(Rooted::get).collect()))
+    }
+
+    fn make_code(&self, code: CodeObject<ConstantData>) -> Rooted {
+        Rooted::new(crate::pycode::box_code_constant(&code))
+    }
+
+    fn make_stop_iter(&self) -> Result<Rooted, wire::MarshalError> {
+        crate::builtins::lookup_exc_class("StopIteration")
+            .map(Rooted::new)
+            .ok_or(wire::MarshalError::BadType)
+    }
+
+    fn make_list(
+        &self,
+        elements: impl Iterator<Item = Rooted>,
+    ) -> Result<Rooted, wire::MarshalError> {
+        Ok(Rooted::new(w_list_new(elements.map(Rooted::get).collect())))
+    }
+
+    fn make_set(
+        &self,
+        elements: impl Iterator<Item = Rooted>,
+    ) -> Result<Rooted, wire::MarshalError> {
+        let set = Rooted::new(setobject::w_set_new());
+        for item in elements {
+            let hash = crate::baseobjspace::hash_w_strict(item.get())
+                .map_err(|_| wire::MarshalError::BadType)?;
+            unsafe { setobject::w_set_add_hashed_checked(set.get(), item.get(), hash) }
+                .map_err(|_| wire::MarshalError::BadType)?;
+        }
+        Ok(set)
+    }
+
+    fn make_frozenset(
+        &self,
+        elements: impl Iterator<Item = Rooted>,
+    ) -> Result<Rooted, wire::MarshalError> {
+        let set = Rooted::new(setobject::w_frozenset_new());
+        for item in elements {
+            let hash = crate::baseobjspace::hash_w_strict(item.get())
+                .map_err(|_| wire::MarshalError::BadType)?;
+            unsafe { setobject::w_set_add_hashed_checked(set.get(), item.get(), hash) }
+                .map_err(|_| wire::MarshalError::BadType)?;
+        }
+        Ok(set)
+    }
+
+    fn make_dict(
+        &self,
+        elements: impl Iterator<Item = (Rooted, Rooted)>,
+    ) -> Result<Rooted, wire::MarshalError> {
+        let dict = Rooted::new(w_dict_new());
+        for (key, value) in elements {
+            unsafe { w_dict_store_checked(dict.get(), key.get(), value.get()) }
+                .map_err(|_| wire::MarshalError::BadType)?;
+        }
+        Ok(dict)
+    }
+
+    fn make_slice(
+        &self,
+        start: Rooted,
+        stop: Rooted,
+        step: Rooted,
+    ) -> Result<Rooted, wire::MarshalError> {
+        Ok(Rooted::new(w_slice_new(
+            start.get(),
+            stop.get(),
+            step.get(),
+        )))
+    }
+
+    fn constant_bag(self) -> BasicBag {
+        BasicBag
+    }
+
+    fn constant_ref_from_value(&self, value: &Rooted) -> Option<ConstantData> {
+        unsafe { crate::pycode::obj_to_constant_data(value.get()).ok() }
+    }
+}
+
+fn parse_version(positional: &[PyObjectRef], kwargs: Option<PyObjectRef>) -> Result<i32, PyError> {
+    let value =
+        crate::builtins::kwarg_get(kwargs, "version").or_else(|| positional.get(1).copied());
+    match value {
+        Some(value) => Ok(crate::baseobjspace::int_w(value)? as i32),
+        None => Ok(wire::FORMAT_VERSION as i32),
+    }
+}
+
+fn parse_allow_code(kwargs: Option<PyObjectRef>) -> Result<bool, PyError> {
+    match crate::builtins::kwarg_get(kwargs, "allow_code") {
+        Some(value) => crate::baseobjspace::is_true(value),
+        None => Ok(true),
+    }
+}
+
+/// RustPython `marshal.check_no_code`, matching CPython's recursive
+/// `allow_code=False` check.  The Vec is a transient identity set (PyPy's
+/// traversal does not persist it); it also prevents container cycles from
+/// recursing forever without introducing a side table.
+fn contains_code(obj: PyObjectRef, seen: &mut Vec<PyObjectRef>) -> bool {
+    if unsafe { crate::pycode::is_code(obj) } {
+        return true;
+    }
+    if seen.iter().any(|&seen_obj| std::ptr::eq(seen_obj, obj)) {
+        return false;
+    }
+    let is_container = unsafe {
+        is_tuple(obj) || is_list(obj) || is_dict(obj) || setobject::is_set_or_frozenset(obj)
+    };
+    if !is_container {
+        return false;
+    }
+    seen.push(obj);
+    unsafe {
+        if is_tuple(obj) {
+            (0..w_tuple_len(obj)).any(|index| {
+                w_tuple_getitem(obj, index as i64).is_some_and(|item| contains_code(item, seen))
+            })
+        } else if is_list(obj) {
+            (0..w_list_len(obj)).any(|index| {
+                w_list_getitem(obj, index as i64).is_some_and(|item| contains_code(item, seen))
+            })
+        } else if is_dict(obj) {
+            dictmultiobject::w_dict_items(obj)
+                .into_iter()
+                .any(|(key, value)| contains_code(key, seen) || contains_code(value, seen))
+        } else {
+            setobject::w_set_items(obj)
+                .into_iter()
+                .any(|item| contains_code(item, seen))
+        }
+    }
+}
+
+fn reject_code(value: PyObjectRef) -> Result<(), PyError> {
+    if contains_code(value, &mut Vec::new()) {
+        Err(PyError::value_error(
+            "unmarshalling code objects is disallowed",
+        ))
+    } else {
+        Ok(())
+    }
+}
+
+fn dumps_impl(args: &[PyObjectRef]) -> PyResult {
+    let (positional, kwargs) = crate::builtins::split_builtin_kwargs(args);
+    crate::builtins::kwarg_reject_unknown(kwargs, &["version", "allow_code"], "dumps")?;
+    let Some(&value) = positional.first() else {
+        return Err(PyError::type_error(
+            "dumps() missing required argument 'value'",
+        ));
+    };
+    if positional.len() > 2 {
+        return Err(PyError::type_error("dumps() takes at most 2 arguments"));
+    }
+    let version = parse_version(positional, kwargs)?;
+    let allow_code = parse_allow_code(kwargs)?;
+    if !allow_code {
+        reject_code(value)?;
+    }
+    let _roots = pyre_object::gc_roots::push_roots();
+    pyre_object::gc_roots::pin_root(value);
+    let mut out = Vec::new();
+    let mut refs = (version >= 3).then(WriterRefs::new);
+    write_object(&mut out, value, &mut refs, version, MAX_DEPTH)?;
+    Ok(bytesobject::w_bytes_from_bytes(&out))
+}
+
+fn loads_impl(args: &[PyObjectRef]) -> PyResult {
+    let (positional, kwargs) = crate::builtins::split_builtin_kwargs(args);
+    crate::builtins::kwarg_reject_unknown(kwargs, &["allow_code"], "loads")?;
+    let Some(&data) = positional.first() else {
+        return Err(PyError::type_error(
+            "loads() missing required argument 'bytes'",
+        ));
+    };
+    if positional.len() != 1 {
+        return Err(PyError::type_error("loads() takes exactly 1 argument"));
+    }
+    let allow_code = parse_allow_code(kwargs)?;
+    let data = bytes_like(data, "loads")?;
+    let _roots = pyre_object::gc_roots::push_roots();
+    let mut reader: &[u8] = &data;
+    let result = wire::deserialize_value(&mut reader, PyreMarshalBag).map_err(marshal_error)?;
+    let result = result.get();
+    if !allow_code {
+        reject_code(result)?;
+    }
+    Ok(result)
+}
+
+fn dump_impl(args: &[PyObjectRef]) -> PyResult {
+    let (positional, kwargs) = crate::builtins::split_builtin_kwargs(args);
+    crate::builtins::kwarg_reject_unknown(kwargs, &["version", "allow_code"], "dump")?;
+    if positional.len() < 2 || positional.len() > 3 {
+        return Err(PyError::type_error("dump() expected 2 or 3 arguments"));
+    }
+    let mut dump_args = vec![positional[0]];
+    if let Some(version) = positional.get(2) {
+        dump_args.push(*version);
+    }
+    if let Some(kwargs) = kwargs {
+        dump_args.push(kwargs);
+    }
+    let bytes = dumps_impl(&dump_args)?;
+    call_method(positional[1], "write", &[bytes])?;
+    Ok(w_none())
+}
+
+fn load_impl(args: &[PyObjectRef]) -> PyResult {
+    let (positional, kwargs) = crate::builtins::split_builtin_kwargs(args);
+    crate::builtins::kwarg_reject_unknown(kwargs, &["allow_code"], "load")?;
+    if positional.len() != 1 {
+        return Err(PyError::type_error("load() takes exactly 1 argument"));
+    }
+    let file = positional[0];
+    let before = crate::baseobjspace::int_w(call_method(file, "tell", &[])?)?;
+    let bytes_obj = call_method(file, "read", &[])?;
+    let data = bytes_like(bytes_obj, "load")?;
+    let allow_code = parse_allow_code(kwargs)?;
+    let _roots = pyre_object::gc_roots::push_roots();
+    let mut reader = wire::Cursor {
+        data: data.as_slice(),
+        position: 0,
+    };
+    let result = wire::deserialize_value(&mut reader, PyreMarshalBag).map_err(marshal_error)?;
+    let new_position = w_int_new(before.saturating_add(reader.position as i64));
+    call_method(file, "seek", &[new_position])?;
+    let result = result.get();
+    if !allow_code {
+        reject_code(result)?;
+    }
+    Ok(result)
+}
+
+crate::py_module! {
+    "marshal",
+    int_constants: {
+        "version" => wire::FORMAT_VERSION as i64,
+    },
+    functions: {
+        "dump" / * = dump_impl,
+        "dumps" / * = dumps_impl,
+        "load" / * = load_impl,
+        "loads" / * = loads_impl,
+    },
+}

--- a/pyre/pyre-interpreter/src/module/mod.rs
+++ b/pyre/pyre-interpreter/src/module/mod.rs
@@ -70,6 +70,7 @@ pub mod grp;
 pub mod imp;
 pub mod importlib;
 pub mod itertools;
+pub mod marshal;
 pub mod math;
 #[cfg(all(not(target_arch = "wasm32"), not(feature = "sandbox")))]
 pub mod mmap;

--- a/pyre/pyre-interpreter/src/module/struct/mod.rs
+++ b/pyre/pyre-interpreter/src/module/struct/mod.rs
@@ -39,21 +39,20 @@ fn struct_overflow(msg: &str) -> crate::PyError {
 }
 
 /// Accept a str or bytes-like format spec (`interp_struct.py:38
-/// text_or_bytes_w`).  A lone surrogate is never a valid format character;
-/// read a str via WTF-8 and degrade through the codec's `backslashreplace`
-/// handler rather than panicking in `w_str_get_value`.
+/// text_or_bytes_w`).  CPython's `_struct` boundary encodes text formats as
+/// strict ASCII, so non-ASCII text (including lone surrogates) raises
+/// `UnicodeEncodeError`; bytes are preserved byte-for-byte and rejected later
+/// as `struct.error` when they are not format codes.
 fn format_to_string(obj: PyObjectRef) -> Result<String, crate::PyError> {
     unsafe {
         if is_str(obj) {
-            let w = w_str_get_wtf8(obj).to_wtf8_buf();
-            if let Ok(s) = w.as_str() {
-                return Ok(s.to_string());
-            }
-            let s_obj = w_str_from_wtf8(w);
-            let bytes = crate::type_methods::encode_object(s_obj, "utf-8", "backslashreplace")?;
-            Ok(String::from_utf8(bytes).unwrap_or_default())
+            let bytes = crate::type_methods::encode_object(obj, "ascii", "strict")?;
+            Ok(String::from_utf8(bytes).expect("ASCII encoding is valid UTF-8"))
         } else if bytesobject::is_bytes_like(obj) {
-            Ok(String::from_utf8_lossy(bytesobject::bytes_like_data(obj)).into_owned())
+            Ok(bytesobject::bytes_like_data(obj)
+                .iter()
+                .map(|byte| char::from(*byte))
+                .collect())
         } else {
             Err(crate::PyError::type_error(
                 "Struct() argument 1 must be str or bytes, not object",

--- a/pyre/pyre-interpreter/src/module/time/mod.rs
+++ b/pyre/pyre-interpreter/src/module/time/mod.rs
@@ -21,6 +21,15 @@ crate::py_module! {
             pyre_object::w_str_new("UTC"),
         ]),
     },
+    // PyPy: pypy/module/time/app_time.py:26-34.  Keep strptime at app
+    // level and delegate to the shared CPython `_strptime` module.
+    inline_app: {
+        r#"
+def strptime(string, format="%a %b %d %H:%M:%S %Y"):
+    import _strptime
+    return _strptime._strptime_time(string, format)
+"# => ["strptime"],
+    },
     functions: {
         "time"         / 0 = t::time,
         "time_ns"      / 0 = t::time_ns,

--- a/pyre/pyre-interpreter/src/pycode.rs
+++ b/pyre/pyre-interpreter/src/pycode.rs
@@ -1239,7 +1239,7 @@ unsafe fn read_code_consts(
 /// `co_consts`) and any object that is not a valid code constant raise
 /// `ValueError` (pyre's constant table cannot hold an arbitrary object the
 /// way a CPython `co_consts` tuple can).
-unsafe fn obj_to_constant_data(
+pub(crate) unsafe fn obj_to_constant_data(
     obj: PyObjectRef,
 ) -> Result<crate::bytecode::ConstantData, crate::PyError> {
     use crate::bytecode::ConstantData;

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -2464,6 +2464,12 @@ fn dict_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
 /// check_user_subclass prevents subclassing (acceptable_as_base_class=False).
 /// Only positional obj argument accepted.
 fn bool_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    let (args, kwargs) = crate::builtins::split_builtin_kwargs(args);
+    if crate::builtins::has_real_kwargs(kwargs) {
+        return Err(crate::PyError::type_error(
+            "bool() takes no keyword arguments",
+        ));
+    }
     // args[0] = w_booltype (cls)
     let w_booltype = args.first().copied().unwrap_or(pyre_object::PY_NULL);
     if let Some(w_bool) = gettypefor(&pyre_object::BOOL_TYPE) {

--- a/pyre/pyre-object/src/weakref.rs
+++ b/pyre/pyre-object/src/weakref.rs
@@ -230,6 +230,23 @@ pub unsafe fn w_gc_weakref_box_deref(obj: PyObjectRef) -> PyObjectRef {
     unsafe { w_weakref_deref(wref) }
 }
 
+/// Clear the wrapped rweakref, mirroring
+/// `W_WeakrefBase.clear(): self.w_obj_weak = dead_ref`.
+///
+/// # Safety
+///
+/// `obj` must either be null or a live `GcWeakrefBox`.
+pub unsafe fn w_gc_weakref_box_clear(obj: PyObjectRef) {
+    if !unsafe { is_gc_weakref_box(obj) } {
+        return;
+    }
+    let boxed = obj as *mut GcWeakrefBox;
+    let wref = unsafe { (*boxed).inner };
+    if !wref.is_null() {
+        unsafe { (*wref).weakptr = std::ptr::null_mut() };
+    }
+}
+
 /// Allocate a GcWeakrefBox for `target`, falling back to a strong
 /// PyObjectRef when no GC hook is installed (unit-test environments
 /// that did not wire `pyre-jit`). The strong-ref fallback restores


### PR DESCRIPTION
## Summary

This consolidates the stdlib compatibility work into one PR:

- improve `_collections`, `array`, and `functools` compatibility
- implement the native `marshal` module
- compile common public `_ast` objects
- implement `time.strptime` through PyPy's app-level `_strptime` path
- preserve `struct` format encoding and exception semantics
- restore weakref lifeline callbacks, counts, proxy invalidation, and the read-only `__callback__` descriptor
- share weakref builtin type objects globally instead of through TLS

## Root causes

Several commonly used stdlib modules were missing native interpreter support or had boundary behavior that diverged from PyPy/CPython. Weakref callback refs were not retained by their lifeline, callback-free refs were not invalidated on referent finalization, and builtin weakref types were cached per thread despite being process-wide type objects.

## Validation

- relevant stdlib snippets for collections, marshal, AST, time, struct, and weakref
- LLBC re-extraction for interpreter/object changes
- `PYRE_RTYPER_VERBOSE=1 cargo build --release -p pyre-jit-trace`
- `cargo check --workspace --features dynasm`
- `cargo test --workspace --features dynasm`

No RustPython2 patch is required.