### PR TITLE
jit: register _collections deque iterators as GC roots

### DIFF
--- a/pyre/pyre-interpreter/src/module/_collections/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_collections/mod.rs
@@ -113,7 +113,13 @@ fn maxlen_obj(self_obj: PyObjectRef) -> PyObjectRef {
     }
 }
 
-// PyPy `W_DequeIter`: the iterator owns the deque, current position, number
+// The two deque iterators are `.allocate()`-immortal `#[pyre_class]` wrappers
+// holding a traced `deque` edge the marker never scans; re-export so `build_gc`
+// can register their offsets with the immortal-root walker.
+pub use deque_iter::W_DequeIter;
+pub use deque_rev_iter::W_DequeRevIter;
+
+// `W_DequeIter`: the iterator owns the deque, current position, number
 // of remaining entries, and a snapshot of the deque mutation lock.
 mod deque_iter {
     use super::{W_Deque, checklock, data, getlock};

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -1855,6 +1855,10 @@ fn build_gc() -> Box<dyn majit_gc::GcAllocator> {
             as pyre_object::lltype::PyreClassPyTypeOf>::DESCRIPTOR,
         <pyre_interpreter::module::r#struct::unpack_iter::W_UnpackIter
             as pyre_object::lltype::PyreClassPyTypeOf>::DESCRIPTOR,
+        <pyre_interpreter::module::_collections::W_DequeIter
+            as pyre_object::lltype::PyreClassPyTypeOf>::DESCRIPTOR,
+        <pyre_interpreter::module::_collections::W_DequeRevIter
+            as pyre_object::lltype::PyreClassPyTypeOf>::DESCRIPTOR,
     ] {
         pyre_object::gc_hook::register_pyre_class_offsets(
             descr.pytype_ptr as usize,


### PR DESCRIPTION
## Problem

`_collections._deque_iterator` (`W_DequeIter`) and `_collections._deque_reverse_iterator`
(`W_DequeRevIter`) are `#[pyre_class]` wrappers that each hold a traced `deque: PyObjectRef`
managed child, but they were never wired into `build_gc`. On the native backends the GC-root
completeness oracle (`eval.rs`, `#[cfg(not(target_arch = "wasm32"))]`, unconditional) therefore
aborts at GC init:

```
GC-root registration gap: #[pyre_class] type(s) with managed children were never wired into
build_gc ... Register each in build_gc:
["_collections._deque_iterator", "_collections._deque_reverse_iterator"]
```

This fires before any user code runs, so **every** native JIT program panics — even a trivial
`while` loop. `main` (`014bc0fae6b`) is affected.

## Fix

Both iterators are `.allocate()`-**immortal**: `allocate` lowers to `malloc_typed`, and the GC
marker skips malloc_typed objects. So they must be registered on the **immortal-root** path,
`register_pyre_class_offsets`, alongside `W_Enumerate` / `W_UnpackIter` — the immortal-root walker
force-forwards the `deque` child on every collection. Re-export the two types from `_collections`
(they live in private submodules) so `build_gc` can name them.

> **Correction (force-pushed):** the first revision of this branch used `register_pyre_class` (the
> marker-tid path, like `W_Deque`). That satisfies the completeness oracle's tid check, but the
> marker never scans a malloc_typed object, so the `deque` child would still be swept while the
> iterator is live — a latent use-after-free that only surfaces under a major collection. The
> current revision uses `register_pyre_class_offsets`.

## Validation

- Distinguishing test: a module-global deque reachable only through a live iterator, then a
  `gc.collect()` (major collection). With `register_pyre_class_offsets` the sum matches CPython;
  the earlier `register_pyre_class` dropped the deque (swept), so this is the test that separates
  the two paths — a light/minor-GC or churn workload passes either way.
- Full `check.py`: **dynasm 241/241, cranelift 241/241** green. One unrelated pre-existing
  wasm-only failure (`selfrec_tail_exception_unwind`, tracked separately) passes on both natives
  and is not touched by this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved garbage collection handling for forward and reverse `collections.deque` iterators.
  * Prevented active deque iterators and their underlying data from being incorrectly removed during garbage collection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
