### PR TITLE
perf-exc: exception JIT perf (attr fold + loop-header dominance)

### DIFF
--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -8464,6 +8464,8 @@ pub fn object_setattr(obj: PyObjectRef, name: &str, value: PyObjectRef) -> PyRes
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum ExceptionAttrSlot {
     Args,
+    Context,
+    Cause,
     Code,
     Errno,
     Strerror,
@@ -8508,6 +8510,8 @@ pub unsafe fn exception_attr_slot_fold(
     let kind = unsafe { pyre_object::w_exception_get_kind(obj) };
     let slot = match name {
         "args" => ExceptionAttrSlot::Args,
+        "__context__" => ExceptionAttrSlot::Context,
+        "__cause__" => ExceptionAttrSlot::Cause,
         "code" if kind == pyre_object::interp_exceptions::ExcKind::SystemExit => {
             ExceptionAttrSlot::Code
         }
@@ -8549,6 +8553,18 @@ pub unsafe fn exception_attr_slot_fold(
         }
         _ => return None,
     };
+    // Only loads of `__context__`/`__cause__` fold to a raw slot read.
+    // `descr_setcontext` (`interp_exceptions.py:183-190`) type-validates and
+    // `descr_setcause` (`:166-174`) also flips `suppress_context` to True, so a
+    // direct slot write would drop those effects.
+    if is_store
+        && matches!(
+            slot,
+            ExceptionAttrSlot::Context | ExceptionAttrSlot::Cause
+        )
+    {
+        return None;
+    }
     let w_type = crate::typedef::r#type(obj)?;
     // Any hit precedes the hard-coded exception arm.  The version-tag guard
     // below pins this miss across later heap-subclass mutations.
@@ -8564,6 +8580,10 @@ pub unsafe fn exception_attr_slot_fold(
             ExceptionAttrSlot::Args => {
                 pyre_object::interp_exceptions::w_exception_get_args_storage(obj)
             }
+            ExceptionAttrSlot::Context => {
+                pyre_object::interp_exceptions::w_exception_get_context(obj)
+            }
+            ExceptionAttrSlot::Cause => pyre_object::interp_exceptions::w_exception_get_cause(obj),
             ExceptionAttrSlot::Code => pyre_object::interp_exceptions::w_exception_get_code(obj),
             ExceptionAttrSlot::Errno => pyre_object::interp_exceptions::w_exception_get_errno(obj),
             ExceptionAttrSlot::Strerror => {

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -8557,12 +8557,7 @@ pub unsafe fn exception_attr_slot_fold(
     // `descr_setcontext` (`interp_exceptions.py:183-190`) type-validates and
     // `descr_setcause` (`:166-174`) also flips `suppress_context` to True, so a
     // direct slot write would drop those effects.
-    if is_store
-        && matches!(
-            slot,
-            ExceptionAttrSlot::Context | ExceptionAttrSlot::Cause
-        )
-    {
+    if is_store && matches!(slot, ExceptionAttrSlot::Context | ExceptionAttrSlot::Cause) {
         return None;
     }
     let w_type = crate::typedef::r#type(obj)?;

--- a/pyre/pyre-jit-trace/src/descr.rs
+++ b/pyre/pyre-jit-trace/src/descr.rs
@@ -2489,6 +2489,8 @@ pub fn w_exception_slot_descr(
     }
     let field_index = match slot {
         pyre_interpreter::baseobjspace::ExceptionAttrSlot::Args => 2,
+        pyre_interpreter::baseobjspace::ExceptionAttrSlot::Context => 3,
+        pyre_interpreter::baseobjspace::ExceptionAttrSlot::Cause => 4,
         pyre_interpreter::baseobjspace::ExceptionAttrSlot::Errno => 11,
         pyre_interpreter::baseobjspace::ExceptionAttrSlot::Strerror => 12,
         pyre_interpreter::baseobjspace::ExceptionAttrSlot::Filename => 13,

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
@@ -414,6 +414,38 @@ pub(crate) fn exception_string_override_straight_line(body_code: &[u8]) -> bool 
     true
 }
 
+/// Whether an exception string-override body issues a nested Python call.  The
+/// bounded string-override route inlines the override as a leaf; a nested call
+/// (`CallFn` residual, or a `cond_call`/`call_assembler`/`inline_call`) forces a
+/// multi-frame guard-resume snapshot the sub-walk cannot build, aborting
+/// mid-recording (`LoopBearingCalleeInlineUnsupported`) and discarding the whole
+/// loop.  Such a body must stay on the residual dispatch path.
+pub(crate) fn exception_string_override_has_nested_call(
+    body_code: &[u8],
+    callee_descr_refs: &[DescrRef],
+) -> bool {
+    let mut pc = 0usize;
+    while pc < body_code.len() {
+        let Some(d) = crate::jitcode_runtime::decode_op_at(body_code, pc) else {
+            return true;
+        };
+        if d.opname.starts_with("cond_call")
+            || d.opname.starts_with("call_assembler")
+            || d.opname.starts_with("inline_call")
+        {
+            return true;
+        }
+        if d.opname.starts_with("residual_call")
+            && residual_call_helper_kind_in_body(body_code, &d, callee_descr_refs)
+                == Some(majit_ir::PyreHelperKind::CallFn)
+        {
+            return true;
+        }
+        pc = d.next_pc;
+    }
+    false
+}
+
 /// Active boxes for an inlined callee's OWN frame in a multi-frame snapshot
 /// (#68).  The fast-path inline predicate guarantees the callee does not own a
 /// virtualizable (any vable op declines the inline), so the owns_vable /
@@ -2405,6 +2437,18 @@ pub(crate) fn try_walker_inline_exception_string_override<Sym: WalkSym>(
         return Ok(None);
     };
     if !exception_string_override_straight_line(body.code) {
+        return Ok(None);
+    }
+    // A nested Python call in the override body (e.g. `return repr(self.args)`)
+    // cannot be inlined on this bounded route: recording the callee's own
+    // residual and its guard-resume snapshot aborts mid-trace, discarding the
+    // whole loop instead of declining.  Keep such a body on the residual
+    // dispatch path where the interpreter owns the nested frame.
+    let Some((override_descr_refs, _, _)) = crate::state::sub_jitcode_descr_pool_for_code(w_code)
+    else {
+        return Ok(None);
+    };
+    if exception_string_override_has_nested_call(body.code, override_descr_refs) {
         return Ok(None);
     }
 

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
@@ -1267,7 +1267,7 @@ pub(crate) fn try_walker_inline_resolved_user_call<Sym: WalkSym>(
     nparams: usize,
     has_closure: bool,
     exception_receiver_guard: Option<ExceptionInlineReceiverGuard>,
-    arg_class_guard: Option<(OpRef, i64)>,
+    arg_class_guard: Option<ArgClassGuard>,
     allow_method_load_attr: bool,
     require_str_result: bool,
 ) -> Result<Option<(DispatchOutcome, usize)>, DispatchError> {
@@ -1518,8 +1518,39 @@ pub(crate) fn try_walker_inline_resolved_user_call<Sym: WalkSym>(
             version_tag,
         )?;
     }
-    if let Some((arg, w_class)) = arg_class_guard {
-        walker_guard_class(ctx, op.pc, arg, w_class)?;
+    if let Some((arg, concrete_arg, w_type)) = arg_class_guard {
+        // `GuardClass` compares the object's physical `ob_type`, not its Python
+        // `W_TypeObject`.  Pin the physical type: a boxed builtin whose
+        // `ob_type` the optimizer already knows would make a `GuardClass`
+        // against the heap type object provably fail, discarding the loop
+        // (`InvalidLoop`).  `walker_guard_class` also emits the tagged-int
+        // low-bit test, needed when `arg` may arrive as a tagged int.
+        let physical_type = unsafe { (*concrete_arg).ob_type } as i64;
+        walker_guard_class(ctx, op.pc, arg, physical_type)?;
+        // A builtin subclass / user instance shares its `ob_type` with the base
+        // layout, so `ob_type` alone does not pin the class the reflected-op
+        // decline (`w_type_issubtype`) was computed against.  Guard the live
+        // `w_class` too so an arg of a distinct class deopts.  Singletons with a
+        // null `w_class` (`Ellipsis`/`NotImplemented`) are pinned exactly by
+        // `ob_type`, and guarding their null slot against `w_type` would itself
+        // be provably false — so guard `w_class` only when it is populated.
+        if !unsafe { (*concrete_arg).w_class }.is_null() {
+            let live_w_class = crate::state::opimpl_getfield_gc_r(
+                ctx.trace_ctx,
+                arg,
+                crate::descr::w_class_descr(),
+            );
+            let w_class_const = ctx.trace_ctx.const_ref(w_type as i64);
+            walker_emit_fold_guard_with_snapshot(
+                ctx,
+                op.pc,
+                OpCode::GuardValue,
+                &[live_w_class, w_class_const],
+            )?;
+            ctx.trace_ctx
+                .heap_cache_mut()
+                .replace_box(live_w_class, w_class_const);
+        }
     }
 
     let callable_expected = ctx
@@ -2544,7 +2575,7 @@ pub(crate) fn try_walker_inline_user_binop<Sym: WalkSym>(
         nparams,
         has_closure,
         Some((lhs, concrete_lhs, w_class, version_tag)),
-        Some((rhs, w_typ_r as i64)),
+        Some((rhs, concrete_rhs, w_typ_r)),
         false,
         false,
     )?
@@ -2680,7 +2711,7 @@ pub(crate) fn try_walker_inline_user_compareop<Sym: WalkSym>(
         nparams,
         has_closure,
         Some((lhs, concrete_lhs, w_class, version_tag)),
-        Some((rhs, w_typ_r as i64)),
+        Some((rhs, concrete_rhs, w_typ_r)),
         false,
         false,
     )?

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
@@ -2560,6 +2560,18 @@ pub(crate) fn try_walker_inline_user_binop<Sym: WalkSym>(
         return Ok(None);
     };
 
+    // A tagged immediate is an exact builtin `int` with C-level operator slots:
+    // it has no heap `ob_type`/`w_class` to pin, and its dunder is not inlinable
+    // Python code.  Decline before the concrete derefs below, which would fault
+    // on the immediate (`typedef::r#type` stays the tagged-safe typing path).
+    // Inert behind `CAN_BE_TAGGED` (default false).
+    if pyre_object::tagged_int::CAN_BE_TAGGED
+        && (pyre_object::tagged_int::is_tagged_int(concrete_lhs)
+            || pyre_object::tagged_int::is_tagged_int(concrete_rhs))
+    {
+        return Ok(None);
+    }
+
     let w_class = unsafe { (*concrete_lhs).w_class };
     if w_class.is_null() || !unsafe { pyre_object::is_type(w_class) } {
         return Ok(None);
@@ -2695,6 +2707,18 @@ pub(crate) fn try_walker_inline_user_compareop<Sym: WalkSym>(
     let Some(concrete_rhs) = walker_concrete_ref_object(ctx, rhs) else {
         return Ok(None);
     };
+
+    // A tagged immediate is an exact builtin `int` with C-level operator slots:
+    // it has no heap `ob_type`/`w_class` to pin, and its dunder is not inlinable
+    // Python code.  Decline before the concrete derefs below, which would fault
+    // on the immediate (`typedef::r#type` stays the tagged-safe typing path).
+    // Inert behind `CAN_BE_TAGGED` (default false).
+    if pyre_object::tagged_int::CAN_BE_TAGGED
+        && (pyre_object::tagged_int::is_tagged_int(concrete_lhs)
+            || pyre_object::tagged_int::is_tagged_int(concrete_rhs))
+    {
+        return Ok(None);
+    }
 
     let w_class = unsafe { (*concrete_lhs).w_class };
     if w_class.is_null() || !unsafe { pyre_object::is_type(w_class) } {

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
@@ -4908,6 +4908,12 @@ type ExceptionInlineReceiverGuard = (
     u64,
 );
 
+/// `(arg, concrete_arg, w_type)` for an inlined operator's non-receiver
+/// argument: the operand op to guard, its record-time concrete object (for the
+/// physical `ob_type`), and the Python `W_TypeObject` the reflected-op decline
+/// was computed against (pinned via the live `w_class`).
+type ArgClassGuard = (OpRef, pyre_object::PyObjectRef, pyre_object::PyObjectRef);
+
 /// `residual_call` shape `iIRd>X` dispatcher — `_ir_*` arglist with
 /// both an int-bank list and a ref-bank list before the descr. RPython
 /// parity: `pyjitpl.py:1338-1340 _opimpl_residual_call2` (`@arguments`

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
@@ -1514,6 +1514,12 @@ pub(crate) fn try_walker_specialize_store_attr<Sym: WalkSym>(
                         concrete_stored,
                     )
                 }
+                pyre_interpreter::baseobjspace::ExceptionAttrSlot::Context
+                | pyre_interpreter::baseobjspace::ExceptionAttrSlot::Cause => {
+                    // `exception_attr_slot_fold` declines these for stores, so
+                    // the store fold never reaches here.
+                    unreachable!("__context__/__cause__ slots fold on load only")
+                }
                 pyre_interpreter::baseobjspace::ExceptionAttrSlot::Code => {
                     pyre_object::interp_exceptions::w_exception_set_code(
                         concrete_obj,

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -4835,6 +4835,75 @@ fn for_iter_frame_is_finally_duplicated(code: &pyre_interpreter::CodeObject) -> 
     for_iter_count > 1 && any_in_handler
 }
 
+/// True when `code` holds an `except ... as name:` handler whose own body can
+/// raise. Binding the caught exception to a name emits an exceptional cleanup
+/// tail — `STORE_FAST name; DELETE_FAST name; RERAISE 1` — reached only when the
+/// handler body itself raises (`raise name`, `raise Other(...)`, a bare `raise`).
+///
+/// That tail lowers to a `last_exc_value` jitcode op, and on a bridge walk the
+/// walker holds no active exception to answer it with, so the walk aborts with
+/// `LastExcValueWithoutActiveException` (`jitcode_dispatch` `last_exc_value/>r`;
+/// the value RPython asserts on in `pyjitpl.py opimpl_last_exc_value`). The
+/// abort is not permanent, so the loop is retraced and re-aborts for its whole
+/// run — the abort count scales with the iteration count rather than settling.
+///
+/// The abort itself is survivable: a frame without a `FOR_ITER` keeps producing
+/// the right answer, it merely retraces. With a `FOR_ITER` in the frame the abort
+/// can land while an item is in flight, and that item's iteration is dropped
+/// (#57) — the result is short by exactly one handler visit per abort. Such a
+/// frame must run in the interpreter. The caller applies this only to frames that
+/// hold a `FOR_ITER`.
+///
+/// A handler that binds no name (`except E:`) emits no cleanup tail, and a
+/// binding handler that cannot raise never reaches its own tail; both keep
+/// JITting, as does a raise sitting in the `try` block rather than the handler.
+fn for_iter_frame_has_raising_named_handler(code: &pyre_interpreter::CodeObject) -> bool {
+    use pyre_interpreter::Instruction as I;
+    let num_instrs = code.instructions.len();
+    for pc in 0..num_instrs {
+        if !matches!(
+            pyre_interpreter::decode_instruction_at(code, pc),
+            Some((I::CheckExcMatch, _))
+        ) {
+            continue;
+        }
+        // The match test is followed by the no-match branch and, for an
+        // `as name` handler, the `STORE_FAST name` binding the caught value.
+        // `except E:` pops it instead and binds nothing.
+        let mut bound = None;
+        let mut scan = pc + 1;
+        while scan < num_instrs {
+            match pyre_interpreter::decode_instruction_at(code, scan) {
+                Some((I::PopJumpIfFalse { .. } | I::NotTaken | I::ExtendedArg | I::Cache, _)) => {
+                    scan += 1;
+                }
+                Some((I::StoreFast { var_num }, op_arg)) => {
+                    bound = Some(var_num.get(op_arg).as_usize());
+                    break;
+                }
+                _ => break,
+            }
+        }
+        let Some(bound) = bound else {
+            continue;
+        };
+        // The handler body runs until the cleanup that clears the bound name.
+        // A `RAISE_VARARGS` before that point reaches the exceptional tail.
+        for body_pc in (scan + 1)..num_instrs {
+            match pyre_interpreter::decode_instruction_at(code, body_pc) {
+                Some((I::DeleteFast { var_num }, op_arg))
+                    if var_num.get(op_arg).as_usize() == bound =>
+                {
+                    break;
+                }
+                Some((I::RaiseVarargs { .. }, _)) => return true,
+                _ => {}
+            }
+        }
+    }
+    false
+}
+
 /// A nested inner `for` loop `break` — a `POP_TOP` that pops the inner iterator
 /// then a `JUMP_BACKWARD` to the enclosing `FOR_ITER` — miscompiles when the
 /// break lands on the secondary edge of a conditional in the inner-loop guard:
@@ -5082,8 +5151,14 @@ fn unsupported_jit_shape(code: &pyre_interpreter::CodeObject) -> UnsupportedJitS
         // A `finally`-duplicated loop stays interpreted: its exhaustion
         // side-exit resumes through the lossy carry-forward `pc_map` and lands
         // at the exceptional copy with an empty stack (see
-        // `for_iter_frame_is_finally_duplicated`).
-        if !for_iter_bodies_all_jit_safe(code) || for_iter_frame_is_finally_duplicated(code) {
+        // `for_iter_frame_is_finally_duplicated`). A handler that binds the
+        // caught exception and then raises re-aborts the walk for the whole run,
+        // and an abort with an item in flight drops that iteration (see
+        // `for_iter_frame_has_raising_named_handler`).
+        if !for_iter_bodies_all_jit_safe(code)
+            || for_iter_frame_is_finally_duplicated(code)
+            || for_iter_frame_has_raising_named_handler(code)
+        {
             return UnsupportedJitShape::CurrentFrameOnly;
         }
     }
@@ -9966,6 +10041,59 @@ mod tests {
         .expect("test code should compile");
         let code = function_code_from_module(&module, "r");
         assert!(for_iter_bodies_all_jit_safe(&code));
+        assert!(!for_iter_frame_has_raising_named_handler(&code));
+        assert_eq!(unsupported_jit_shape(&code), UnsupportedJitShape::None);
+    }
+
+    #[test]
+    fn for_iter_frame_with_raising_named_handler_is_declined() {
+        // `except ValueError as e:` whose body re-raises reaches the `as`
+        // cleanup tail (`DELETE_FAST e; RERAISE 1`) on every visit. Tracing that
+        // tail re-aborts for the whole run, and an abort with a `FOR_ITER` item
+        // in flight drops that iteration, so the frame must stay interpreted.
+        use pyre_interpreter::compile_exec;
+        let module = compile_exec(
+            "def r(n):\n    acc = 0\n    for i in range(n):\n        try:\n            try:\n                if i % 3 == 0:\n                    raise ValueError\n            except ValueError as e:\n                raise e\n        except ValueError:\n            acc += 9\n    return acc\n",
+        )
+        .expect("test code should compile");
+        let code = function_code_from_module(&module, "r");
+        // The body opcodes themselves stay admissible; only the frame-level
+        // handler shape declines.
+        assert!(for_iter_bodies_all_jit_safe(&code));
+        assert!(for_iter_frame_has_raising_named_handler(&code));
+        assert_eq!(
+            unsupported_jit_shape(&code),
+            UnsupportedJitShape::CurrentFrameOnly
+        );
+    }
+
+    #[test]
+    fn for_iter_frame_with_nonraising_named_handler_still_jits() {
+        // The same `as` binding, but the handler only reads the exception. Its
+        // cleanup tail is never reached, so the frame keeps tracing. This is the
+        // common `except E as e:` idiom and must not be caught by the decline
+        // above — the `raise` here sits in the `try` block, not the handler.
+        use pyre_interpreter::compile_exec;
+        let module = compile_exec(
+            "def r(n):\n    acc = 0\n    for i in range(n):\n        try:\n            if i % 3 == 0:\n                raise ValueError(i)\n        except ValueError as e:\n            acc += len(e.args)\n    return acc\n",
+        )
+        .expect("test code should compile");
+        let code = function_code_from_module(&module, "r");
+        assert!(!for_iter_frame_has_raising_named_handler(&code));
+        assert_eq!(unsupported_jit_shape(&code), UnsupportedJitShape::None);
+    }
+
+    #[test]
+    fn for_iter_frame_with_raising_unbound_handler_still_jits() {
+        // `except ValueError:` binds no name, so there is no cleanup tail to
+        // re-abort on even though the handler raises.
+        use pyre_interpreter::compile_exec;
+        let module = compile_exec(
+            "def r(n):\n    acc = 0\n    for i in range(n):\n        try:\n            try:\n                raise ValueError\n            except ValueError:\n                raise KeyError\n        except KeyError:\n            acc += 1\n    return acc\n",
+        )
+        .expect("test code should compile");
+        let code = function_code_from_module(&module, "r");
+        assert!(!for_iter_frame_has_raising_named_handler(&code));
         assert_eq!(unsupported_jit_shape(&code), UnsupportedJitShape::None);
     }
 

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -4666,6 +4666,16 @@ fn for_iter_body_op_is_jit_safe(instr: pyre_interpreter::Instruction) -> bool {
             | I::BuildList { .. }
             | I::BuildSet { .. }
             | I::BuildMap { .. }
+            // In-frame exception raise / handling. These opcodes already trace
+            // in the while-loop form (whose body bypasses this FOR_ITER-only
+            // scan): the raised exception is virtualized and a walk abort
+            // rewinds partial trace state. The finally-duplicated FOR_ITER
+            // hazard is gated separately by for_iter_frame_is_finally_duplicated.
+            | I::RaiseVarargs { .. }
+            | I::PushExcInfo
+            | I::CheckExcMatch
+            | I::PopExcept
+            | I::Reraise { .. }
             // oparg prefix + inline-cache padding (no-ops in the body scan)
             | I::ExtendedArg
             | I::Cache
@@ -9939,6 +9949,22 @@ mod tests {
         )
         .expect("test code should compile");
         let code = function_code_from_module(&module, "w");
+        assert!(for_iter_bodies_all_jit_safe(&code));
+        assert_eq!(unsupported_jit_shape(&code), UnsupportedJitShape::None);
+    }
+
+    #[test]
+    fn for_iter_try_except_body_is_jit_safe() {
+        // A `for` loop whose body raises and catches in-frame: the exception
+        // opcodes (RAISE_VARARGS / CHECK_EXC_MATCH / PUSH_EXC_INFO / POP_EXCEPT)
+        // are allow-listed, so the frame is admitted for tracing. The FOR_ITER
+        // is not inside the try range, so it is not finally-duplicated.
+        use pyre_interpreter::compile_exec;
+        let module = compile_exec(
+            "def r(n):\n    acc = 0\n    for i in range(n):\n        try:\n            if i % 3 == 0:\n                raise ValueError\n            acc += i\n        except ValueError:\n            acc += 1\n    return acc\n",
+        )
+        .expect("test code should compile");
+        let code = function_code_from_module(&module, "r");
         assert!(for_iter_bodies_all_jit_safe(&code));
         assert_eq!(unsupported_jit_shape(&code), UnsupportedJitShape::None);
     }

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -13887,34 +13887,111 @@ fn backward_jump_target(
     }
 }
 
+/// Control-flow successors of every code-unit index: fall-through (except
+/// after an unconditional transfer), forward and backward jump targets, and
+/// the exception edge from each protected pc to its handler landing.  Built in
+/// one sequential decode pass so an `EXTENDED_ARG` prefix folds into the
+/// following opcode's argument, matching the edge model of
+/// `find_branch_target_pcs`.
+fn code_successors(code: &CodeObject) -> Vec<Vec<usize>> {
+    let num_instrs = code.instructions.len();
+    let mut succ: Vec<Vec<usize>> = vec![Vec::new(); num_instrs];
+    let mut scan_state = OpArgState::default();
+    for pc in 0..num_instrs {
+        let (instr, op_arg) = scan_state.get(code.instructions[pc]);
+        if let Some(target) = backward_jump_target(code, pc, instr, op_arg) {
+            if target < num_instrs {
+                succ[pc].push(target);
+            }
+        }
+        let forward_delta = match instr {
+            Instruction::PopJumpIfFalse { delta }
+            | Instruction::PopJumpIfTrue { delta }
+            | Instruction::PopJumpIfNone { delta }
+            | Instruction::PopJumpIfNotNone { delta }
+            | Instruction::JumpForward { delta }
+            | Instruction::ForIter { delta } => Some(delta.get(op_arg).as_usize()),
+            _ => None,
+        };
+        if let Some(delta) = forward_delta {
+            let target = jump_target_forward(code, num_instrs, pc + 1, delta);
+            if target < num_instrs {
+                succ[pc].push(target);
+            }
+        }
+        let terminates = matches!(
+            instr,
+            Instruction::JumpForward { .. }
+                | Instruction::JumpBackward { .. }
+                | Instruction::JumpBackwardNoInterrupt { .. }
+                | Instruction::ReturnValue
+                | Instruction::RaiseVarargs { .. }
+                | Instruction::Reraise { .. }
+        );
+        if !terminates {
+            let fallthrough = pc + 1;
+            if fallthrough < num_instrs {
+                succ[pc].push(fallthrough);
+            }
+        }
+    }
+    for entry in pyre_interpreter::pycode::decode_exceptiontable(&code.exceptiontable) {
+        let start = entry.start as usize / 2;
+        let end = (entry.end as usize / 2).min(num_instrs);
+        let handler = entry.target as usize / 2;
+        if handler < num_instrs {
+            for pc in start..end {
+                succ[pc].push(handler);
+            }
+        }
+    }
+    succ
+}
+
+/// True when `target_pc` dominates `source_pc`: every control-flow path from
+/// the code entry (pc 0) to `source_pc` passes through `target_pc`.  Answered
+/// by a forward reachability from the entry that never enters `target_pc` — if
+/// `source_pc` stays unreachable, `target_pc` dominates it.
+fn target_dominates(succ: &[Vec<usize>], target_pc: usize, source_pc: usize) -> bool {
+    let num_instrs = succ.len();
+    if target_pc == source_pc || target_pc == 0 {
+        return true;
+    }
+    if source_pc >= num_instrs {
+        return false;
+    }
+    let mut seen = vec![false; num_instrs];
+    let mut stack = vec![0usize];
+    seen[0] = true;
+    while let Some(pc) = stack.pop() {
+        for &next in &succ[pc] {
+            if next == target_pc || seen[next] {
+                continue;
+            }
+            seen[next] = true;
+            stack.push(next);
+        }
+    }
+    !seen[source_pc]
+}
+
 /// True when a backward bytecode jump is only a control-flow return from an
-/// out-of-line exception handler to earlier mainline code, rather than a loop
-/// backedge.  Python 3.14 lays handler cleanup blocks after the protected
-/// body, so a `break` in a handler can be encoded as `JUMP_BACKWARD` even
-/// though its landing is after the source loop.  `interp_jit.py:103-114`
+/// exception handler to earlier code, rather than a loop backedge.  Python
+/// 3.14 lays handler blocks after the protected body, so a `break` / handler
+/// rejoin can be encoded as `JUMP_BACKWARD` even though its target is not a
+/// loop header.  A genuine loop backedge's target dominates the jump (every
+/// path to the jump enters through the loop header); a handler-return target
+/// does not, because the handler is reached from the protected body through
+/// the exception edge, bypassing that target.  `interp_jit.py:103-114`
 /// attaches `loop_header` / `can_enter_jit` to semantic loop backedges; do not
-/// manufacture a JIT loop header for this layout-only backward coordinate.
+/// manufacture a JIT loop header for a non-dominating backward coordinate.
 fn backward_jump_is_handler_only_target(
     code: &CodeObject,
     source_pc: usize,
     target_pc: usize,
 ) -> bool {
-    let handler_boundary = pyre_interpreter::pycode::decode_exceptiontable(&code.exceptiontable)
-        .map(|entry| entry.target as usize / 2)
-        .filter(|&handler_pc| target_pc < handler_pc && handler_pc <= source_pc)
-        .min();
-    let Some(handler_boundary) = handler_boundary else {
-        return false;
-    };
-
-    let mut arg_state = OpArgState::default();
-    for pc in 0..handler_boundary.min(code.instructions.len()) {
-        let (instruction, op_arg) = arg_state.get(code.instructions[pc]);
-        if backward_jump_target(code, pc, instruction, op_arg) == Some(target_pc) {
-            return false;
-        }
-    }
-    true
+    let succ = code_successors(code);
+    !target_dominates(&succ, target_pc, source_pc)
 }
 
 /// Match pyre-interpreter/pyopcode.rs:skip_caches.
@@ -14190,12 +14267,13 @@ fn compile_jitcode_via_raw_code(
 /// `CallControl.jitdrivers_sd`, matching codewriter.py:37.
 pub fn find_loop_header_pcs(code: &pyre_interpreter::CodeObject) -> VecSet<usize> {
     let num_instrs = code.instructions.len();
+    let succ = code_successors(code);
     let mut loop_header_pcs: VecSet<usize> = VecSet::new();
     let mut scan_state = OpArgState::default();
     for scan_pc in 0..num_instrs {
         let (scan_instr, scan_arg) = scan_state.get(code.instructions[scan_pc]);
         if let Some(target) = backward_jump_target(code, scan_pc, scan_instr, scan_arg) {
-            if target < num_instrs && !backward_jump_is_handler_only_target(code, scan_pc, target) {
+            if target < num_instrs && target_dominates(&succ, target, scan_pc) {
                 loop_header_pcs.insert(target);
             }
         }
@@ -15641,9 +15719,15 @@ mod tests {
     }
 
     #[test]
-    fn handler_break_backward_jump_is_not_a_loop_header() {
+    fn handler_rejoin_backward_jump_is_not_a_loop_header() {
+        // Nested try/except inside a `while`: each handler ends in a backward
+        // jump that rejoins the loop body after the protected region.  Its
+        // target does not dominate the jump (the handler is entered from the
+        // protected body via the exception edge), so it is a handler return,
+        // not a loop backedge — excluded from the loop headers — while the
+        // `while` backedge dominates its source and stays.
         let code = first_nested_function_code(
-            "def f():\n    total = 0\n    for _ in range(3):\n        value = 0\n        while True:\n            try:\n                value = may_raise()\n            except Exception as exc:\n                value = exc.value\n                break\n        total += value\n    return total\n",
+            "def k(n):\n    s = 0\n    while n > 0:\n        try:\n            try:\n                s += 1\n            except KeyError:\n                s += 2\n        except ValueError:\n            s += 3\n        n -= 1\n    return s\n",
         );
         let mut arg_state = OpArgState::default();
         let mut handler_only_targets = Vec::new();
@@ -15660,15 +15744,42 @@ mod tests {
             }
         }
 
-        assert_eq!(handler_only_targets.len(), 1);
+        assert!(!handler_only_targets.is_empty());
         assert!(!ordinary_targets.is_empty());
         let loop_headers = find_loop_header_pcs(&code);
-        assert!(!loop_headers.contains(&handler_only_targets[0]));
+        assert!(
+            handler_only_targets
+                .iter()
+                .all(|target| !loop_headers.contains(target))
+        );
         assert!(
             ordinary_targets
                 .iter()
                 .all(|target| loop_headers.contains(target))
         );
+    }
+
+    #[test]
+    fn loop_with_try_except_body_keeps_its_loop_header() {
+        // A `while`/`for` whose body contains a try/except still registers its
+        // backedge target as a loop header.  The loop backedge sits after the
+        // handler block, so its target dominates the jump even though a handler
+        // landing lies between the header and the backedge.
+        let code = first_nested_function_code(
+            "def run(n):\n    acc = 0\n    i = 0\n    while i < n:\n        try:\n            raise ValueError\n        except ValueError:\n            acc += 1\n        i += 1\n    return acc\n",
+        );
+        let mut arg_state = OpArgState::default();
+        let mut backedge_targets = Vec::new();
+        for pc in 0..code.instructions.len() {
+            let (instruction, op_arg) = arg_state.get(code.instructions[pc]);
+            if let Some(target) = backward_jump_target(&code, pc, instruction, op_arg) {
+                backedge_targets.push(target);
+            }
+        }
+        // The sole backward jump is the `while` backedge.
+        assert_eq!(backedge_targets.len(), 1);
+        let loop_headers = find_loop_header_pcs(&code);
+        assert!(loop_headers.contains(&backedge_targets[0]));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Exception-handling JIT performance work, stacked on `perf-exc`.

### Commits

1. **guard inlined-op arg by ob_type + w_class** — a P1 rhs-guard passed a
   `W_TypeObject` to `GuardClass` (which needs a physical `ob_type`); a
   builtin-int RHS was then provably-false and the loop never compiled. Emit a
   physical `ob_type` `GuardClass` plus a conditional `w_class` `GuardValue`.

2. **decline str-override inline on nested call** — a str `__str__`-override
   inline admitted nested-call bodies, whose abort poisoned the whole loop. Add
   `exception_string_override_has_nested_call` so only the single-invoke body
   inlines.

3. **fold `__context__`/`__cause__` exception attr reads** — extend
   `exception_attr_slot_fold` so `LOAD_ATTR` of `__context__`/`__cause__` on an
   exception folds to a guarded field read (`GetfieldGcR`) instead of a residual
   getset-descriptor call. Stores decline (`descr_setcause` sets
   `suppress_context`; `descr_setcontext` type-validates). Removes ~3 residual
   calls/iter from raising-in-`except` loops.

4. **classify loop backedges by target dominance** — the loop-header predicate
   excluded a genuine loop header whenever a loop body contained a `try/except`:
   the loop's own backedge is laid out after the handler block, so the prior
   landing-pad heuristic never saw it, and same-frame raise-catch loops stayed
   uncompiled. Decide by dominance instead — build a CFG (fall-through, forward/
   backward jumps, exception-table edges); a backward jump is a loop backedge
   iff its target dominates its source. Validated against an iterative-dominator
   oracle across 8 try/except-in-loop shapes.

### Effect

Same-frame raise-catch loops now compile: `vbase_big` @3M JIT **0.04s** vs
interp **12.86s** (was JIT slower than interp); `context_chain` compiles. This
also unblocks commit 3's benefit (a set `__context__` requires raise-in-`except`
= the previously non-compiling shape).

### Verification

`pyre/check.py` **241/241** on both backends (dynasm + cranelift). Two new
`codewriter` unit tests (`loop_with_try_except_body_keeps_its_loop_header`,
`handler_rejoin_backward_jump_is_not_a_loop_header`).

— *commented by Claude*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Correctly handle `__context__` and `__cause__` exception attributes, preserving expected setter side effects.
  * Prevent unsafe specialization for exception attribute stores and avoid incorrect folding during execution.
  * Improved JIT loop detection in the presence of nested try/except handlers.
  * Avoid inlining exception-string overrides when they contain nested calls.
* **Performance**
  * Faster exception attribute reads and broader safe `for`-loop tracing when try/except appears in the loop body.
  * More targeted operator inlining with improved type/guard handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->