### PR TITLE
GC-manage immortal iterator wrappers that hold managed children

### DIFF
--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -11296,9 +11296,11 @@ pub fn next(obj: PyObjectRef) -> PyResult {
                 w_prev = next(it.w_iterator)?;
                 // set before fetching w_next to handle reentrancy
                 it.w_prev = w_prev;
+                pyre_object::gc_hook::try_gc_write_barrier(obj as *mut u8);
             }
             let w_next = next(it.w_iterator)?;
             it.w_prev = w_next;
+            pyre_object::gc_hook::try_gc_write_barrier(obj as *mut u8);
             return Ok(pyre_object::w_tuple_new(vec![w_prev, w_next]));
         }
         // itertools.cycle — interp_itertools.py W_Cycle.next_w

--- a/pyre/pyre-interpreter/src/lib.rs
+++ b/pyre/pyre-interpreter/src/lib.rs
@@ -886,6 +886,17 @@ pub fn all_subclass_range_aliases() -> Vec<pyre_object::pyobject::SubclassRangeA
         // GC type chain (`build_gc`), after the coroutine / dict-view-iterator
         // slots, so its vtable alias lands at the current max tid.
         subclass_range_alias(116, typed::<crate::module::_collections::W_Deque>()),
+        // Formerly-immortal iterators converted to `allocate_stable` (managed),
+        // registered at the tail of the JIT `register_pyre_class` chain after
+        // the pyre-object iterators (W_Struct = 125 .. W_TokenizerIter = 129).
+        subclass_range_alias(125, typed::<crate::module::r#struct::W_Struct>()),
+        subclass_range_alias(
+            126,
+            typed::<crate::module::r#struct::unpack_iter::W_UnpackIter>(),
+        ),
+        subclass_range_alias(127, typed::<crate::module::_collections::W_DequeIter>()),
+        subclass_range_alias(128, typed::<crate::module::_collections::W_DequeRevIter>()),
+        subclass_range_alias(129, typed::<crate::module::_tokenize::W_TokenizerIter>()),
     ]
 }
 

--- a/pyre/pyre-interpreter/src/module/_collections/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_collections/mod.rs
@@ -208,7 +208,7 @@ mod deque_iter {
         let index = requested.max(0);
         let _roots = pyre_object::gc_roots::push_roots();
         pyre_object::gc_roots::pin_root(deque);
-        W_DequeIter::allocate(W_DequeIter {
+        W_DequeIter::allocate_stable(W_DequeIter {
             ob: PyObject {
                 ob_type: std::ptr::null(),
                 w_class: std::ptr::null_mut(),
@@ -310,7 +310,7 @@ mod deque_rev_iter {
         let offset = requested.max(0);
         let _roots = pyre_object::gc_roots::push_roots();
         pyre_object::gc_roots::pin_root(deque);
-        W_DequeRevIter::allocate(W_DequeRevIter {
+        W_DequeRevIter::allocate_stable(W_DequeRevIter {
             ob: PyObject {
                 ob_type: std::ptr::null(),
                 w_class: std::ptr::null_mut(),

--- a/pyre/pyre-interpreter/src/module/_tokenize/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_tokenize/mod.rs
@@ -213,7 +213,7 @@ impl W_TokenizerIter {
             None => None,
         };
         let _ = type_object();
-        Ok(W_TokenizerIter::allocate(W_TokenizerIter {
+        Ok(W_TokenizerIter::allocate_stable(W_TokenizerIter {
             ob: PyObject {
                 ob_type: std::ptr::null(),
                 w_class: std::ptr::null_mut(),

--- a/pyre/pyre-interpreter/src/module/struct/mod.rs
+++ b/pyre/pyre-interpreter/src/module/struct/mod.rs
@@ -965,7 +965,7 @@ pub struct W_Struct {
 impl W_Struct {
     #[staticmethod]
     fn __new__(_cls: PyObjectRef) -> PyObjectRef {
-        W_Struct::allocate(W_Struct {
+        W_Struct::allocate_stable(W_Struct {
             ob: pyre_object::PyObject {
                 ob_type: std::ptr::null(),
                 w_class: std::ptr::null_mut(),
@@ -981,6 +981,7 @@ impl W_Struct {
         let format = format_to_string(w_format)?;
         self.size = parse_format(&format)?.calcsize()?;
         self.format = w_str_new(&format);
+        pyre_object::gc_hook::try_gc_write_barrier(self as *mut Self as *mut u8);
         Ok(())
     }
 
@@ -1151,7 +1152,7 @@ pub mod unpack_iter {
                 "iterative unpacking requires a buffer of a multiple of {size} bytes"
             )));
         }
-        Ok(W_UnpackIter::allocate(W_UnpackIter {
+        Ok(W_UnpackIter::allocate_stable(W_UnpackIter {
             ob: pyre_object::PyObject {
                 ob_type: std::ptr::null(),
                 w_class: std::ptr::null_mut(),

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -1831,59 +1831,15 @@ fn build_gc() -> Box<dyn majit_gc::GcAllocator> {
             &pyre_object::dictmultiobject::W_DICT_VIEW_GC_PTR_OFFSETS,
         );
     }
-    // Immortal `#[pyre_class]` iterator / sequence wrappers whose managed
-    // children are held SOLELY through the immortal object.  The marker never
-    // scans a `malloc_typed`-immortal, so without a registered offset set the
-    // generic immortal-root walker (`walk_raw_immortal_roots`) cannot forward
-    // the child, and a collection reachable only through the wrapper frees it —
-    // e.g. `enumerate(list)` whose source list-iterator sits on a caller frame
-    // across a hot inner loop's collection, surfacing as
-    // `TypeError: not an iterator` on the next `__next__`.  These have no GC
-    // vtable site (immortal, keyed by `pytype_ptr`), so register the
-    // descriptor's `ptr_offsets` directly like the dict-view offsets above.
-    // The explicit `type_id`s never reach a GC arena, so no `register_type` /
-    // drift-check is involved.  This is the complete set of immortal
-    // `#[pyre_class]` wrappers with managed children that the
-    // `register_pyre_class` list above does not already cover; every other
-    // iterator family (map/filter/zip/cycle/chain/count/repeat, the four
-    // seq/list/tuple/set iterators, reversed, the SRE scanner) is registered
-    // there, and `W_Deque` is `allocate_stable` (GC-managed, not immortal).
-    for descr in [
-        <pyre_object::functional::W_Enumerate
-            as pyre_object::lltype::PyreClassPyTypeOf>::DESCRIPTOR,
-        <pyre_object::functional::W_Range
-            as pyre_object::lltype::PyreClassPyTypeOf>::DESCRIPTOR,
-        <pyre_object::functional::W_LongRangeIterator
-            as pyre_object::lltype::PyreClassPyTypeOf>::DESCRIPTOR,
-        <pyre_object::interp_itertools::W_TakeWhile
-            as pyre_object::lltype::PyreClassPyTypeOf>::DESCRIPTOR,
-        <pyre_object::interp_itertools::W_DropWhile
-            as pyre_object::lltype::PyreClassPyTypeOf>::DESCRIPTOR,
-        <pyre_object::interp_itertools::W_FilterFalse
-            as pyre_object::lltype::PyreClassPyTypeOf>::DESCRIPTOR,
-        <pyre_object::interp_itertools::W_Pairwise
-            as pyre_object::lltype::PyreClassPyTypeOf>::DESCRIPTOR,
-        <pyre_object::operation::_CallableIterator
-            as pyre_object::lltype::PyreClassPyTypeOf>::DESCRIPTOR,
-        <pyre_interpreter::module::r#struct::W_Struct
-            as pyre_object::lltype::PyreClassPyTypeOf>::DESCRIPTOR,
-        <pyre_interpreter::module::r#struct::unpack_iter::W_UnpackIter
-            as pyre_object::lltype::PyreClassPyTypeOf>::DESCRIPTOR,
-        <pyre_interpreter::module::_collections::W_DequeIter
-            as pyre_object::lltype::PyreClassPyTypeOf>::DESCRIPTOR,
-        <pyre_interpreter::module::_collections::W_DequeRevIter
-            as pyre_object::lltype::PyreClassPyTypeOf>::DESCRIPTOR,
-        // `_tokenize.TokenizerIter` holds the callable source in an inline
-        // `readline` field and is `allocate`-immortal, so its offsets are
-        // registered here rather than through the managed marker.
-        <pyre_interpreter::module::_tokenize::W_TokenizerIter
-            as pyre_object::lltype::PyreClassPyTypeOf>::DESCRIPTOR,
-    ] {
-        pyre_object::gc_hook::register_pyre_class_offsets(
-            descr.pytype_ptr as usize,
-            descr.ptr_offsets,
-        );
-    }
+    // Formerly-immortal `#[pyre_class]` iterator / sequence wrappers with
+    // managed children (`range`, the long-range iterator, takewhile / dropwhile
+    // / filterfalse / pairwise, the callable-sentinel iterator, `struct.Struct`
+    // and its unpack iterator, the two deque iterators, the tokenizer iterator)
+    // are now `allocate_stable` (GC-managed old-gen) and registered through
+    // `register_pyre_class` at the tail of the tid chain below.  The marker
+    // scans them and forwards their `ptr_offsets` on both the interpreter and
+    // JIT paths, so the separate immortal-root offset registration these types
+    // used to need is gone.
     // `pypy/interpreter/typedef.py:312-326 class GetSetProperty`
     // — fget/fset/fdel/doc/reqcls/name are W_Root references.
     // Pyre's `GetSetProperty` ports them as inline fields; the
@@ -2669,6 +2625,99 @@ fn build_gc() -> Box<dyn majit_gc::GcAllocator> {
         &mut gc,
         &mut pytype_to_tid,
         <pyre_interpreter::module::_collections::W_Deque
+            as pyre_object::lltype::PyreClassPyTypeOf>::DESCRIPTOR,
+    );
+    // `enumerate` W_Enumerate — AUTO-ID `allocate_stable` (GC-managed old-gen),
+    // like W_Deque above.  Its source iterator (`w_iter_or_list`) is a managed
+    // child held solely through the enumerate; as an immortal the marker skipped
+    // it and only the interpreter-side immortal-root walker forwarded the child,
+    // so under JIT (no immortal walk over jitframe slots) a collection reachable
+    // only through the enumerate freed the source iterator.  Managed + registered
+    // tid/offsets lets the marker forward the child uniformly on both paths.
+    register_pyre_class(
+        &mut gc,
+        &mut pytype_to_tid,
+        <pyre_object::functional::W_Enumerate
+            as pyre_object::lltype::PyreClassPyTypeOf>::DESCRIPTOR,
+    );
+    // Formerly-immortal iterator / sequence wrappers converted to
+    // `allocate_stable` (GC-managed).  Each holds managed children solely
+    // through the wrapper, so as immortals only the interpreter-side
+    // immortal-root walker forwarded them and the JIT (no immortal walk over
+    // jitframe slots) dropped them on a collection reachable only through the
+    // wrapper.  Managed + registered tid/offsets lets the marker forward the
+    // children uniformly on both paths.  Registered at the absolute tail of the
+    // tid chain — in this fixed order — so no earlier explicit-id / hardcoded
+    // slot shifts.
+    register_pyre_class(
+        &mut gc,
+        &mut pytype_to_tid,
+        <pyre_object::functional::W_Range as pyre_object::lltype::PyreClassPyTypeOf>::DESCRIPTOR,
+    );
+    register_pyre_class(
+        &mut gc,
+        &mut pytype_to_tid,
+        <pyre_object::functional::W_LongRangeIterator
+            as pyre_object::lltype::PyreClassPyTypeOf>::DESCRIPTOR,
+    );
+    register_pyre_class(
+        &mut gc,
+        &mut pytype_to_tid,
+        <pyre_object::interp_itertools::W_TakeWhile
+            as pyre_object::lltype::PyreClassPyTypeOf>::DESCRIPTOR,
+    );
+    register_pyre_class(
+        &mut gc,
+        &mut pytype_to_tid,
+        <pyre_object::interp_itertools::W_DropWhile
+            as pyre_object::lltype::PyreClassPyTypeOf>::DESCRIPTOR,
+    );
+    register_pyre_class(
+        &mut gc,
+        &mut pytype_to_tid,
+        <pyre_object::interp_itertools::W_FilterFalse
+            as pyre_object::lltype::PyreClassPyTypeOf>::DESCRIPTOR,
+    );
+    register_pyre_class(
+        &mut gc,
+        &mut pytype_to_tid,
+        <pyre_object::interp_itertools::W_Pairwise
+            as pyre_object::lltype::PyreClassPyTypeOf>::DESCRIPTOR,
+    );
+    register_pyre_class(
+        &mut gc,
+        &mut pytype_to_tid,
+        <pyre_object::operation::_CallableIterator
+            as pyre_object::lltype::PyreClassPyTypeOf>::DESCRIPTOR,
+    );
+    register_pyre_class(
+        &mut gc,
+        &mut pytype_to_tid,
+        <pyre_interpreter::module::r#struct::W_Struct
+            as pyre_object::lltype::PyreClassPyTypeOf>::DESCRIPTOR,
+    );
+    register_pyre_class(
+        &mut gc,
+        &mut pytype_to_tid,
+        <pyre_interpreter::module::r#struct::unpack_iter::W_UnpackIter
+            as pyre_object::lltype::PyreClassPyTypeOf>::DESCRIPTOR,
+    );
+    register_pyre_class(
+        &mut gc,
+        &mut pytype_to_tid,
+        <pyre_interpreter::module::_collections::W_DequeIter
+            as pyre_object::lltype::PyreClassPyTypeOf>::DESCRIPTOR,
+    );
+    register_pyre_class(
+        &mut gc,
+        &mut pytype_to_tid,
+        <pyre_interpreter::module::_collections::W_DequeRevIter
+            as pyre_object::lltype::PyreClassPyTypeOf>::DESCRIPTOR,
+    );
+    register_pyre_class(
+        &mut gc,
+        &mut pytype_to_tid,
+        <pyre_interpreter::module::_tokenize::W_TokenizerIter
             as pyre_object::lltype::PyreClassPyTypeOf>::DESCRIPTOR,
     );
     // ── GC-root registration completeness oracle ─────────────────────────

--- a/pyre/pyre-object/src/functional.rs
+++ b/pyre/pyre-object/src/functional.rs
@@ -27,7 +27,7 @@ use pyre_macros::pyre_class;
 // carries the bigint value (PyPy line 297-303
 // `space.add(w_index, space.newint(1))` after `rarithmetic.ovfcheck`).
 
-#[pyre_class("enumerate", type_id = 41, static_name = "ENUMERATE")]
+#[pyre_class("enumerate", static_name = "ENUMERATE")]
 pub struct W_Enumerate {
     /// `functional.py:225 self.w_iter_or_list` — either the source
     /// iterator (general case) or the source list itself
@@ -54,7 +54,7 @@ pub fn w_enumerate_new(
     let _roots = crate::gc_roots::push_roots();
     crate::gc_roots::pin_root(w_iter_or_list);
     crate::gc_roots::pin_root(w_index);
-    W_Enumerate::allocate(W_Enumerate {
+    W_Enumerate::allocate_stable(W_Enumerate {
         ob: PyObject {
             ob_type: std::ptr::null(),
             w_class: std::ptr::null_mut(),
@@ -127,12 +127,9 @@ mod enumerate_tests {
     use super::*;
 
     #[test]
-    fn w_enumerate_gc_type_id_matches_descr() {
-        assert_eq!(W_ENUMERATE_GC_TYPE_ID, 41);
-        assert_eq!(
-            <W_Enumerate as crate::lltype::GcType>::type_id(),
-            W_ENUMERATE_GC_TYPE_ID
-        );
+    fn w_enumerate_object_size_matches_descr() {
+        // Auto-id `allocate_stable` (GC-managed): the tid is assigned at JIT
+        // init, so there is no compile-time `W_ENUMERATE_GC_TYPE_ID` to check.
         assert_eq!(
             <W_Enumerate as crate::lltype::GcType>::SIZE,
             W_ENUMERATE_OBJECT_SIZE
@@ -178,7 +175,7 @@ pub struct W_ReversedIterator {
 pub fn w_reversed_new(w_sequence: PyObjectRef, remaining: i64) -> PyObjectRef {
     let _roots = crate::gc_roots::push_roots();
     crate::gc_roots::pin_root(w_sequence);
-    W_ReversedIterator::allocate(W_ReversedIterator {
+    W_ReversedIterator::allocate_stable(W_ReversedIterator {
         ob: PyObject {
             ob_type: std::ptr::null(),
             w_class: std::ptr::null_mut(),
@@ -262,7 +259,7 @@ pub fn w_map_new(w_fun: PyObjectRef, w_iterators: PyObjectRef, strict: bool) -> 
     let _roots = crate::gc_roots::push_roots();
     crate::gc_roots::pin_root(w_fun);
     crate::gc_roots::pin_root(w_iterators);
-    W_Map::allocate(W_Map {
+    W_Map::allocate_stable(W_Map {
         ob: PyObject {
             ob_type: std::ptr::null(),
             w_class: std::ptr::null_mut(),
@@ -348,7 +345,7 @@ pub fn w_filter_new(w_predicate: PyObjectRef, w_iterable: PyObjectRef) -> PyObje
         crate::gc_roots::pin_root(w_predicate);
     }
     crate::gc_roots::pin_root(w_iterable);
-    W_Filter::allocate(W_Filter {
+    W_Filter::allocate_stable(W_Filter {
         ob: PyObject {
             ob_type: std::ptr::null(),
             w_class: std::ptr::null_mut(),
@@ -414,7 +411,7 @@ pub struct W_Zip {
 pub fn w_zip_new(w_iterators: PyObjectRef, strict: bool) -> PyObjectRef {
     let _roots = crate::gc_roots::push_roots();
     crate::gc_roots::pin_root(w_iterators);
-    W_Zip::allocate(W_Zip {
+    W_Zip::allocate_stable(W_Zip {
         ob: PyObject {
             ob_type: std::ptr::null(),
             w_class: std::ptr::null_mut(),
@@ -681,7 +678,12 @@ mod range_iter_tests {
 ///
 /// `w_length` is precomputed once at construction (`descr_new` →
 /// `compute_range_length`) and read back by `descr_len` / `descr_bool`.
-#[pyre_class("range", type_id = 7, static_name = "RANGE")]
+// Explicit `type_id` (not auto): `RANGE_DESCR_GROUP` in pyre-jit-trace bakes
+// `W_RANGE_GC_TYPE_ID` at compile time to virtualize range GET_ITER/FOR_ITER,
+// so the tid must be a const. 118 is the tail registration slot (right after
+// W_Enumerate = 117); register_pyre_class drift-checks it against the runtime
+// assignment order.
+#[pyre_class("range", type_id = 118, static_name = "RANGE")]
 pub struct W_Range {
     pub start: PyObjectRef,
     pub stop: PyObjectRef,
@@ -711,7 +713,7 @@ pub fn w_range_new(start: PyObjectRef, stop: PyObjectRef, step: PyObjectRef) -> 
         range_bigint_to_obj(len_big)
     };
     crate::gc_roots::pin_root(length);
-    W_Range::allocate(W_Range {
+    W_Range::allocate_stable(W_Range {
         ob: PyObject {
             ob_type: std::ptr::null(),
             w_class: std::ptr::null_mut(),
@@ -1051,7 +1053,7 @@ pub fn range_length_big(start: &BigInt, stop: &BigInt, step: &BigInt) -> BigInt 
 // advances by one each step (`self.w_index`), so the cursor keeps arbitrary
 // precision and never overflows for a range longer than a machine word.
 
-#[pyre_class("longrange_iterator", type_id = 8, static_name = "LONG_RANGE_ITER")]
+#[pyre_class("longrange_iterator", static_name = "LONG_RANGE_ITER")]
 pub struct W_LongRangeIterator {
     pub start: PyObjectRef,
     pub step: PyObjectRef,
@@ -1071,7 +1073,7 @@ pub fn w_long_range_iter_new(
     crate::gc_roots::pin_root(len);
     let index = crate::intobject::w_int_new(0);
     crate::gc_roots::pin_root(index);
-    W_LongRangeIterator::allocate(W_LongRangeIterator {
+    W_LongRangeIterator::allocate_stable(W_LongRangeIterator {
         ob: PyObject {
             ob_type: std::ptr::null(),
             w_class: std::ptr::null_mut(),
@@ -1128,6 +1130,7 @@ pub unsafe fn w_long_range_iter_set_index(obj: PyObjectRef, index: PyObjectRef) 
     let it = obj as *mut W_LongRangeIterator;
     unsafe {
         (*it).index = index;
+        crate::gc_hook::try_gc_write_barrier(it as *mut u8);
     }
 }
 
@@ -1167,6 +1170,7 @@ pub unsafe fn w_long_range_iter_next(obj: PyObjectRef) -> Option<PyObjectRef> {
         crate::gc_roots::pin_root(next_index);
         let it = crate::gc_roots::shadow_stack_get(iter_slot) as *mut W_LongRangeIterator;
         (*it).index = next_index;
+        crate::gc_hook::try_gc_write_barrier(it as *mut u8);
         Some(range_bigint_to_obj(value))
     }
 }
@@ -1176,12 +1180,9 @@ mod range_obj_tests {
     use super::*;
 
     #[test]
-    fn w_range_gc_type_id_matches_descr() {
-        assert_eq!(W_RANGE_GC_TYPE_ID, 7);
-        assert_eq!(
-            <W_Range as crate::lltype::GcType>::type_id(),
-            W_RANGE_GC_TYPE_ID
-        );
+    fn w_range_object_size_matches_descr() {
+        // Auto-id `allocate_stable` (GC-managed): the tid is assigned at JIT
+        // init, so there is no compile-time `W_RANGE_GC_TYPE_ID` to check.
         assert_eq!(
             <W_Range as crate::lltype::GcType>::SIZE,
             W_RANGE_OBJECT_SIZE

--- a/pyre/pyre-object/src/interp_itertools.rs
+++ b/pyre/pyre-object/src/interp_itertools.rs
@@ -40,7 +40,7 @@ pub fn w_count_new(w_firstval: PyObjectRef, w_step: PyObjectRef) -> PyObjectRef 
     let _roots = crate::gc_roots::push_roots();
     crate::gc_roots::pin_root(w_firstval);
     crate::gc_roots::pin_root(w_step);
-    W_Count::allocate(W_Count {
+    W_Count::allocate_stable(W_Count {
         ob: PyObject {
             ob_type: std::ptr::null(),
             w_class: std::ptr::null_mut(),
@@ -74,6 +74,7 @@ pub unsafe fn w_count_get_c(obj: PyObjectRef) -> PyObjectRef {
 pub unsafe fn w_count_set_c(obj: PyObjectRef, v: PyObjectRef) {
     unsafe {
         (*(obj as *mut W_Count)).w_c = v;
+        crate::gc_hook::try_gc_write_barrier(obj as *mut u8);
     }
 }
 
@@ -122,7 +123,7 @@ pub fn w_repeat_new(w_obj: PyObjectRef, w_times: Option<i64>) -> PyObjectRef {
     // `gct_fv_gc_malloc` bracket pattern (`framework.py:853-856`).
     let _roots = crate::gc_roots::push_roots();
     crate::gc_roots::pin_root(w_obj);
-    W_Repeat::allocate(W_Repeat {
+    W_Repeat::allocate_stable(W_Repeat {
         ob: PyObject {
             ob_type: std::ptr::null(),
             w_class: std::ptr::null_mut(),
@@ -190,7 +191,7 @@ pub unsafe fn w_repeat_dec_count(obj: PyObjectRef) {
 // `next_w` lives in the interpreter (`baseobjspace::next`) because it
 // calls the predicate.
 
-#[pyre_class("itertools.takewhile", type_id = 54, static_name = "TAKEWHILE")]
+#[pyre_class("itertools.takewhile", static_name = "TAKEWHILE")]
 pub struct W_TakeWhile {
     pub w_predicate: PyObjectRef,
     pub w_iterable: PyObjectRef,
@@ -204,7 +205,7 @@ pub fn w_takewhile_new(w_predicate: PyObjectRef, w_iterable: PyObjectRef) -> PyO
     let _roots = crate::gc_roots::push_roots();
     crate::gc_roots::pin_root(w_predicate);
     crate::gc_roots::pin_root(w_iterable);
-    W_TakeWhile::allocate(W_TakeWhile {
+    W_TakeWhile::allocate_stable(W_TakeWhile {
         ob: PyObject {
             ob_type: std::ptr::null(),
             w_class: std::ptr::null_mut(),
@@ -235,7 +236,7 @@ pub unsafe fn is_takewhile(obj: PyObjectRef) -> bool {
 //         self.started = False
 // ```
 
-#[pyre_class("itertools.dropwhile", type_id = 55, static_name = "DROPWHILE")]
+#[pyre_class("itertools.dropwhile", static_name = "DROPWHILE")]
 pub struct W_DropWhile {
     pub w_predicate: PyObjectRef,
     pub w_iterable: PyObjectRef,
@@ -249,7 +250,7 @@ pub fn w_dropwhile_new(w_predicate: PyObjectRef, w_iterable: PyObjectRef) -> PyO
     let _roots = crate::gc_roots::push_roots();
     crate::gc_roots::pin_root(w_predicate);
     crate::gc_roots::pin_root(w_iterable);
-    W_DropWhile::allocate(W_DropWhile {
+    W_DropWhile::allocate_stable(W_DropWhile {
         ob: PyObject {
             ob_type: std::ptr::null(),
             w_class: std::ptr::null_mut(),
@@ -288,7 +289,7 @@ pub unsafe fn is_dropwhile(obj: PyObjectRef) -> bool {
 //
 // `w_predicate` is PY_NULL when the Python-level predicate was None.
 
-#[pyre_class("itertools.filterfalse", type_id = 56, static_name = "FILTERFALSE")]
+#[pyre_class("itertools.filterfalse", static_name = "FILTERFALSE")]
 pub struct W_FilterFalse {
     pub w_predicate: PyObjectRef,
     pub w_iterable: PyObjectRef,
@@ -303,7 +304,7 @@ pub fn w_filterfalse_new(w_predicate: PyObjectRef, w_iterable: PyObjectRef) -> P
         crate::gc_roots::pin_root(w_predicate);
     }
     crate::gc_roots::pin_root(w_iterable);
-    W_FilterFalse::allocate(W_FilterFalse {
+    W_FilterFalse::allocate_stable(W_FilterFalse {
         ob: PyObject {
             ob_type: std::ptr::null(),
             w_class: std::ptr::null_mut(),
@@ -347,7 +348,7 @@ pub fn w_compress_new(w_data: PyObjectRef, w_selectors: PyObjectRef) -> PyObject
     let _roots = crate::gc_roots::push_roots();
     crate::gc_roots::pin_root(w_data);
     crate::gc_roots::pin_root(w_selectors);
-    W_Compress::allocate(W_Compress {
+    W_Compress::allocate_stable(W_Compress {
         ob: PyObject {
             ob_type: std::ptr::null(),
             w_class: std::ptr::null_mut(),
@@ -390,7 +391,7 @@ pub fn w_starmap_new(w_fun: PyObjectRef, w_iterable: PyObjectRef) -> PyObjectRef
     let _roots = crate::gc_roots::push_roots();
     crate::gc_roots::pin_root(w_fun);
     crate::gc_roots::pin_root(w_iterable);
-    W_StarMap::allocate(W_StarMap {
+    W_StarMap::allocate_stable(W_StarMap {
         ob: PyObject {
             ob_type: std::ptr::null(),
             w_class: std::ptr::null_mut(),
@@ -435,7 +436,7 @@ pub fn w_accumulate_new(
         crate::gc_roots::pin_root(w_func);
     }
     crate::gc_roots::pin_root(w_initial);
-    W_Accumulate::allocate(W_Accumulate {
+    W_Accumulate::allocate_stable(W_Accumulate {
         ob: PyObject {
             ob_type: std::ptr::null(),
             w_class: std::ptr::null_mut(),
@@ -486,7 +487,7 @@ pub fn w_zip_longest_new(
     let _roots = crate::gc_roots::push_roots();
     crate::gc_roots::pin_root(w_iterators);
     crate::gc_roots::pin_root(w_fillvalue);
-    W_ZipLongest::allocate(W_ZipLongest {
+    W_ZipLongest::allocate_stable(W_ZipLongest {
         ob: PyObject {
             ob_type: std::ptr::null(),
             w_class: std::ptr::null_mut(),
@@ -514,7 +515,7 @@ pub unsafe fn is_zip_longest(obj: PyObjectRef) -> bool {
 //
 // `w_prev` is PY_NULL until the first `next_w`.
 
-#[pyre_class("itertools.pairwise", type_id = 57, static_name = "PAIRWISE")]
+#[pyre_class("itertools.pairwise", static_name = "PAIRWISE")]
 pub struct W_Pairwise {
     pub w_iterator: PyObjectRef,
     pub w_prev: PyObjectRef,
@@ -526,7 +527,7 @@ pub fn w_pairwise_new(w_iterator: PyObjectRef) -> PyObjectRef {
     // `gct_fv_gc_malloc` bracket pattern (`framework.py:853-856`).
     let _roots = crate::gc_roots::push_roots();
     crate::gc_roots::pin_root(w_iterator);
-    W_Pairwise::allocate(W_Pairwise {
+    W_Pairwise::allocate_stable(W_Pairwise {
         ob: PyObject {
             ob_type: std::ptr::null(),
             w_class: std::ptr::null_mut(),
@@ -578,7 +579,7 @@ pub fn w_cycle_new(w_iterable: PyObjectRef) -> PyObjectRef {
     crate::gc_roots::pin_root(w_iterable);
     let saved = crate::listobject::w_list_new(Vec::new());
     crate::gc_roots::pin_root(saved);
-    W_Cycle::allocate(W_Cycle {
+    W_Cycle::allocate_stable(W_Cycle {
         ob: PyObject {
             ob_type: std::ptr::null(),
             w_class: std::ptr::null_mut(),
@@ -643,7 +644,7 @@ pub fn w_chain_new(w_iterables: PyObjectRef) -> PyObjectRef {
     // `gct_fv_gc_malloc` bracket pattern (`framework.py:853-856`).
     let _roots = crate::gc_roots::push_roots();
     crate::gc_roots::pin_root(w_iterables);
-    W_Chain::allocate(W_Chain {
+    W_Chain::allocate_stable(W_Chain {
         ob: PyObject {
             ob_type: std::ptr::null(),
             w_class: std::ptr::null_mut(),
@@ -737,12 +738,8 @@ mod tests {
     }
 
     #[test]
-    fn w_takewhile_gc_type_id_matches_descr() {
-        assert_eq!(W_TAKEWHILE_GC_TYPE_ID, 54);
-        assert_eq!(
-            <W_TakeWhile as crate::lltype::GcType>::type_id(),
-            W_TAKEWHILE_GC_TYPE_ID
-        );
+    fn w_takewhile_object_size_matches_descr() {
+        // Auto-id `allocate_stable` (GC-managed): tid assigned at JIT init.
         assert_eq!(
             <W_TakeWhile as crate::lltype::GcType>::SIZE,
             W_TAKEWHILE_OBJECT_SIZE
@@ -750,12 +747,8 @@ mod tests {
     }
 
     #[test]
-    fn w_dropwhile_gc_type_id_matches_descr() {
-        assert_eq!(W_DROPWHILE_GC_TYPE_ID, 55);
-        assert_eq!(
-            <W_DropWhile as crate::lltype::GcType>::type_id(),
-            W_DROPWHILE_GC_TYPE_ID
-        );
+    fn w_dropwhile_object_size_matches_descr() {
+        // Auto-id `allocate_stable` (GC-managed): tid assigned at JIT init.
         assert_eq!(
             <W_DropWhile as crate::lltype::GcType>::SIZE,
             W_DROPWHILE_OBJECT_SIZE
@@ -763,12 +756,8 @@ mod tests {
     }
 
     #[test]
-    fn w_filterfalse_gc_type_id_matches_descr() {
-        assert_eq!(W_FILTERFALSE_GC_TYPE_ID, 56);
-        assert_eq!(
-            <W_FilterFalse as crate::lltype::GcType>::type_id(),
-            W_FILTERFALSE_GC_TYPE_ID
-        );
+    fn w_filterfalse_object_size_matches_descr() {
+        // Auto-id `allocate_stable` (GC-managed): tid assigned at JIT init.
         assert_eq!(
             <W_FilterFalse as crate::lltype::GcType>::SIZE,
             W_FILTERFALSE_OBJECT_SIZE
@@ -844,12 +833,8 @@ mod tests {
     }
 
     #[test]
-    fn w_pairwise_gc_type_id_matches_descr() {
-        assert_eq!(W_PAIRWISE_GC_TYPE_ID, 57);
-        assert_eq!(
-            <W_Pairwise as crate::lltype::GcType>::type_id(),
-            W_PAIRWISE_GC_TYPE_ID
-        );
+    fn w_pairwise_object_size_matches_descr() {
+        // Auto-id `allocate_stable` (GC-managed): tid assigned at JIT init.
         assert_eq!(
             <W_Pairwise as crate::lltype::GcType>::SIZE,
             W_PAIRWISE_OBJECT_SIZE

--- a/pyre/pyre-object/src/interp_sre.rs
+++ b/pyre/pyre-object/src/interp_sre.rs
@@ -168,7 +168,7 @@ pub fn w_sre_match_new(
     crate::gc_roots::pin_root(w_srepat);
     crate::gc_roots::pin_root(w_string);
     crate::gc_roots::pin_root(w_buffer);
-    W_SRE_Match::allocate(W_SRE_Match {
+    W_SRE_Match::allocate_stable(W_SRE_Match {
         ob: PyObject {
             ob_type: std::ptr::null(),
             w_class: std::ptr::null_mut(),
@@ -254,7 +254,7 @@ pub fn w_sre_scanner_new(
     crate::gc_roots::pin_root(w_srepat);
     crate::gc_roots::pin_root(w_string);
     crate::gc_roots::pin_root(w_buffer);
-    W_SRE_Scanner::allocate(W_SRE_Scanner {
+    W_SRE_Scanner::allocate_stable(W_SRE_Scanner {
         ob: PyObject {
             ob_type: std::ptr::null(),
             w_class: std::ptr::null_mut(),

--- a/pyre/pyre-object/src/iterobject.rs
+++ b/pyre/pyre-object/src/iterobject.rs
@@ -44,7 +44,7 @@ pub fn w_seq_iter_new(seq: PyObjectRef, length: usize) -> PyObjectRef {
     // `gct_fv_gc_malloc` bracket pattern (`framework.py:853-856`).
     let _roots = crate::gc_roots::push_roots();
     crate::gc_roots::pin_root(seq);
-    W_SeqIterObject::allocate(W_SeqIterObject {
+    W_SeqIterObject::allocate_stable(W_SeqIterObject {
         ob: PyObject {
             ob_type: std::ptr::null(),
             w_class: std::ptr::null_mut(),
@@ -58,7 +58,7 @@ pub fn w_seq_iter_new(seq: PyObjectRef, length: usize) -> PyObjectRef {
 pub fn w_list_iter_new(seq: PyObjectRef) -> PyObjectRef {
     let _roots = crate::gc_roots::push_roots();
     crate::gc_roots::pin_root(seq);
-    W_ListIterObject::allocate(W_ListIterObject {
+    W_ListIterObject::allocate_stable(W_ListIterObject {
         ob: PyObject {
             ob_type: std::ptr::null(),
             w_class: std::ptr::null_mut(),
@@ -71,7 +71,7 @@ pub fn w_list_iter_new(seq: PyObjectRef) -> PyObjectRef {
 pub fn w_list_reverse_iter_new(seq: PyObjectRef, index: i64) -> PyObjectRef {
     let _roots = crate::gc_roots::push_roots();
     crate::gc_roots::pin_root(seq);
-    W_ListReverseIterObject::allocate(W_ListReverseIterObject {
+    W_ListReverseIterObject::allocate_stable(W_ListReverseIterObject {
         ob: PyObject {
             ob_type: std::ptr::null(),
             w_class: std::ptr::null_mut(),
@@ -84,7 +84,7 @@ pub fn w_list_reverse_iter_new(seq: PyObjectRef, index: i64) -> PyObjectRef {
 pub fn w_tuple_iter_new(seq: PyObjectRef) -> PyObjectRef {
     let _roots = crate::gc_roots::push_roots();
     crate::gc_roots::pin_root(seq);
-    W_TupleIterObject::allocate(W_TupleIterObject {
+    W_TupleIterObject::allocate_stable(W_TupleIterObject {
         ob: PyObject {
             ob_type: std::ptr::null(),
             w_class: std::ptr::null_mut(),
@@ -141,6 +141,7 @@ pub unsafe fn w_list_iter_index(obj: PyObjectRef) -> i64 {
 #[inline]
 pub unsafe fn w_list_iter_set_seq(obj: PyObjectRef, seq: PyObjectRef) {
     (*(obj as *mut W_ListIterObject)).seq = seq;
+    crate::gc_hook::try_gc_write_barrier(obj as *mut u8);
 }
 
 #[inline]
@@ -161,6 +162,7 @@ pub unsafe fn w_list_reverse_iter_index(obj: PyObjectRef) -> i64 {
 #[inline]
 pub unsafe fn w_list_reverse_iter_set_seq(obj: PyObjectRef, seq: PyObjectRef) {
     (*(obj as *mut W_ListReverseIterObject)).seq = seq;
+    crate::gc_hook::try_gc_write_barrier(obj as *mut u8);
 }
 
 #[inline]
@@ -181,6 +183,7 @@ pub unsafe fn w_tuple_iter_index(obj: PyObjectRef) -> i64 {
 #[inline]
 pub unsafe fn w_tuple_iter_set_seq(obj: PyObjectRef, seq: PyObjectRef) {
     (*(obj as *mut W_TupleIterObject)).seq = seq;
+    crate::gc_hook::try_gc_write_barrier(obj as *mut u8);
 }
 
 #[inline]

--- a/pyre/pyre-object/src/operation.rs
+++ b/pyre/pyre-object/src/operation.rs
@@ -30,7 +30,7 @@
 use crate::pyobject::*;
 use pyre_macros::pyre_class;
 
-#[pyre_class("_CallableIterator", type_id = 42, static_name = "CALLABLE_ITERATOR")]
+#[pyre_class("_CallableIterator", static_name = "CALLABLE_ITERATOR")]
 pub struct _CallableIterator {
     /// The zero-argument callable invoked on each `__next__`.  Set to
     /// `PY_NULL` once the sentinel has been returned, latching the
@@ -46,7 +46,7 @@ pub fn w_callable_iterator_new(callable: PyObjectRef, sentinel: PyObjectRef) -> 
     let _roots = crate::gc_roots::push_roots();
     crate::gc_roots::pin_root(callable);
     crate::gc_roots::pin_root(sentinel);
-    _CallableIterator::allocate(_CallableIterator {
+    _CallableIterator::allocate_stable(_CallableIterator {
         ob: PyObject {
             ob_type: std::ptr::null(),
             w_class: std::ptr::null_mut(),
@@ -76,6 +76,7 @@ pub unsafe fn w_callable_iterator_get_callable(obj: PyObjectRef) -> PyObjectRef 
 pub unsafe fn w_callable_iterator_set_callable(obj: PyObjectRef, value: PyObjectRef) {
     unsafe {
         (*(obj as *mut _CallableIterator)).callable = value;
+        crate::gc_hook::try_gc_write_barrier(obj as *mut u8);
     }
 }
 
@@ -91,12 +92,8 @@ mod tests {
     use super::*;
 
     #[test]
-    fn w_callable_iterator_gc_type_id_matches_descr() {
-        assert_eq!(W_CALLABLE_ITERATOR_GC_TYPE_ID, 42);
-        assert_eq!(
-            <_CallableIterator as crate::lltype::GcType>::type_id(),
-            W_CALLABLE_ITERATOR_GC_TYPE_ID
-        );
+    fn w_callable_iterator_object_size_matches_descr() {
+        // Auto-id `allocate_stable` (GC-managed): tid assigned at JIT init.
         assert_eq!(
             <_CallableIterator as crate::lltype::GcType>::SIZE,
             W_CALLABLE_ITERATOR_OBJECT_SIZE

--- a/pyre/pyre-object/src/pyobject.rs
+++ b/pyre/pyre-object/src/pyobject.rs
@@ -569,6 +569,19 @@ pub const SUBCLASS_RANGE_HIERARCHY: &[(u32, Option<u32>)] = &[
     (114, Some(0)),
     (115, Some(0)),
     (116, Some(0)),
+    (117, Some(0)),
+    (118, Some(0)),
+    (119, Some(0)),
+    (120, Some(0)),
+    (121, Some(0)),
+    (122, Some(0)),
+    (123, Some(0)),
+    (124, Some(0)),
+    (125, Some(0)),
+    (126, Some(0)),
+    (127, Some(0)),
+    (128, Some(0)),
+    (129, Some(0)),
 ];
 
 /// Compute subclass IDs from [`SUBCLASS_RANGE_HIERARCHY`] and write every
@@ -962,6 +975,19 @@ pub fn all_subclass_range_aliases() -> Vec<SubclassRangeAlias> {
         subclass_range_alias(23, &crate::iterobject::SEQ_ITER_TYPE),
         subclass_range_alias(24, typed::<crate::interp_itertools::W_Count>()),
         subclass_range_alias(25, typed::<crate::interp_itertools::W_Repeat>()),
+        // `enumerate` W_Enumerate — auto-id `allocate_stable` registered at the
+        // tail of the JIT `register_pyre_class` chain (after W_Deque = 116).
+        subclass_range_alias(117, typed::<crate::functional::W_Enumerate>()),
+        // Formerly-immortal iterators converted to `allocate_stable` (managed),
+        // registered at the tail of the JIT `register_pyre_class` chain in this
+        // exact order (after W_Enumerate = 117).
+        subclass_range_alias(118, typed::<crate::functional::W_Range>()),
+        subclass_range_alias(119, typed::<crate::functional::W_LongRangeIterator>()),
+        subclass_range_alias(120, typed::<crate::interp_itertools::W_TakeWhile>()),
+        subclass_range_alias(121, typed::<crate::interp_itertools::W_DropWhile>()),
+        subclass_range_alias(122, typed::<crate::interp_itertools::W_FilterFalse>()),
+        subclass_range_alias(123, typed::<crate::interp_itertools::W_Pairwise>()),
+        subclass_range_alias(124, typed::<crate::operation::_CallableIterator>()),
         subclass_range_alias(26, &crate::typedef::MEMBER_TYPE),
         subclass_range_alias(27, &crate::bytesobject::BYTES_TYPE),
         subclass_range_alias(28, &crate::bytearrayobject::BYTEARRAY_TYPE),

--- a/pyre/pyre-object/src/setobject.rs
+++ b/pyre/pyre-object/src/setobject.rs
@@ -28,7 +28,7 @@ pub fn w_set_iter_new(w_set: PyObjectRef) -> PyObjectRef {
     let _roots = crate::gc_roots::push_roots();
     crate::gc_roots::pin_root(w_set);
     let startlen = unsafe { w_set_len(w_set) };
-    W_SetIterObject::allocate(W_SetIterObject {
+    W_SetIterObject::allocate_stable(W_SetIterObject {
         ob: PyObject {
             ob_type: std::ptr::null(),
             w_class: std::ptr::null_mut(),
@@ -55,6 +55,7 @@ pub unsafe fn w_set_iter_get_set(obj: PyObjectRef) -> PyObjectRef {
 #[inline]
 pub unsafe fn w_set_iter_set_set(obj: PyObjectRef, w_set: PyObjectRef) {
     (*(obj as *mut W_SetIterObject)).w_set = w_set;
+    crate::gc_hook::try_gc_write_barrier(obj as *mut u8);
 }
 
 #[inline]


### PR DESCRIPTION
## Problem

The precise collector roots interpreter frames through `walk_pyframe_roots` +
`walk_raw_immortal_roots`, which recursively forwards the inline `PyObjectRef`
children of *immortal* (`allocate`) `#[pyre_class]` wrappers. JIT frames are
rooted through `jitframe_trace` (the gcmap), which has **no** immortal walk. So
for an iterator / sequence wrapper allocated immortal, a managed child reachable
*solely* through that wrapper (e.g. an enumerate's inner iterator, a deque
iterator's backing deque) was scanned on the interpreter path but **dropped on a
moving collection while the wrapper sat in a jitframe slot** — a use-after-free
under the JIT.

## Fix

Convert every `#[pyre_class]` iterator / sequence wrapper whose managed children
are held solely through the wrapper from immortal (`allocate`) to GC-managed
(`allocate_stable`). Managed wrappers are scanned by the marker via their tid's
`ptr_offsets`, so their children are forwarded on **both** paths.

- **pyre-object**: seq / list-reverse / tuple / set iterators, `reversed`,
  `map` / `filter` / `zip`, `count` / `repeat` / `compress` / `starmap` /
  `accumulate` / `zip_longest` / `cycle` / `chain`, the SRE scanner **and match
  result**, `range`, the long-range iterator, `takewhile` / `dropwhile` /
  `filterfalse` / `pairwise`, and the callable-sentinel iterator.
- **pyre-interpreter**: `struct.Struct` and its unpack iterator, the two deque
  iterators, and the tokenizer iterator.

The wrappers that were previously registered only through the immortal-root
offset loop (`range`, long-range, `takewhile`, `dropwhile`, `filterfalse`,
`pairwise`, `_CallableIterator`, struct/unpack-iter, deque iterators, tokenizer
iterator) are moved into `register_pyre_class` at the tail of the GC type-id
chain (tids 118..129), with matching subclass-range hierarchy + alias census
entries; the offset loop is removed. Most drop the vestigial `type_id = N` for
an auto-assigned tail tid; **`range` keeps an explicit `type_id = 118`** pinned
to its tail slot, because `RANGE_DESCR_GROUP` (added by #683) bakes
`W_RANGE_GC_TYPE_ID` at compile time to virtualize range `GET_ITER`/`FOR_ITER`.
The SRE match result and scanner were already registered through
`register_pyre_class`, so converting them needs no census change.

Write barriers are added to the managed-field setters / next paths that store a
child after construction: the long-range index, the count value, the list-iter /
list-reverse / tuple / set seq, the callable, the struct format, and the
pairwise prev.

`W_IntRangeIterator` stays immortal — it holds only scalar counters.

## Completeness audit

An adversarial audit (four independent lenses — missed conversion, missing
barrier, census consistency, descr-group tid / Rust-heap leak — each finding
verified by a skeptic) swept every `#[pyre_class]` struct for the same latent
class. Results:

- **W_SRE_Match** — confirmed missed conversion (sibling of the converted
  scanner, holds `w_string`/`w_buffer` reachable solely through the match).
  **Folded into this PR.**
- **CoroutineWrapper** — audited and **refuted**: its async drive opcodes
  (`GET_AWAITABLE`, `SEND`) permanently abort the JIT tracer, so it never lands
  in a jitframe slot; the immortal-with-registered-offsets gap is inert. Left
  immortal (correct).
- **W_TokenizerIter Rust-heap leak** (low) — the now-collectable tokenizer
  iterator owns Rust heap (source `String`, token `Vec`s) with no destructor, so
  its buffers leak on collection. Pre-existing in nature (as an immortal it was
  never freed either) and a separate mechanism (destructor plumbing); **deferred
  to a follow-up**, not a UAF.
- Barrier, census, and descr-tid lenses: no findings.

## Validation

- **Boot**: census (`pytype_to_tid` ↔ subclass-range aliases) + subclass-range
  hierarchy + GC-root completeness oracle all green.
- **gcroot battery** (`converted_smoke.py`: every converted type under 200×
  `gc.collect()`): JIT output **identical** to NO_JIT, and identical under a
  forced 16 KB nursery.
- **W_SRE_Match** (`sre_match_gc.py`: str + bytes match whose subject is solely
  reachable through the match, `gc.collect()` between): JIT == NO_JIT == tiny
  nursery.
- **#683 interaction** (`range_virt_gc.py` + a big-int `range` tid check holding
  the range live across `gc.collect()`): correct under JIT, GC-stress, and tiny
  nursery — confirming the real managed tid equals the descr-baked
  `W_RANGE_GC_TYPE_ID`.
- **Perf**: neutral-to-faster on the iterator microbenchmarks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
