### PR TITLE
jit: read the append-site resume depth off the jitcode-pc trivia twin

### DIFF
--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
@@ -3367,8 +3367,19 @@ pub(crate) fn orthodox_list_append_commit<Sym: WalkSym>(
         } else {
             let codeobj = &*jc.payload.code_ptr;
             py = skip_python_trivia_forward(codeobj, py as usize) as u32;
-            let lv = crate::liveness::liveness_for(jc.payload.code_ptr);
-            let vsd = match lv.depth_at_py_pc().get(py as usize).copied() {
+            // Read the depth off the jitcode-pc-keyed trivia twin, which equals
+            // `depth_at_py_pc()[skip_python_trivia_forward(python_pc_for_jitcode_pc(op.pc))]`
+            // by construction; fall back to the py_pc-keyed static-liveness read
+            // where the twin is unpopulated (skeleton / fixture install).
+            let depth = if jc.payload.depth_trivia_populated() {
+                jc.payload.depth_trivia_for_jitcode_pc(op.pc)
+            } else {
+                crate::liveness::liveness_for(jc.payload.code_ptr)
+                    .depth_at_py_pc()
+                    .get(py as usize)
+                    .copied()
+            };
+            let vsd = match depth {
                 Some(d) => (sym.nlocals() + d as usize) as i64,
                 None => sym.valuestackdepth() as i64,
             };


### PR DESCRIPTION
## pc_map read-cutover — slice A: append-site resume depth

First read-cutover slice toward retiring the py_pc-keyed metadata reads
(the `op.pc → python_pc_for_jitcode_pc → skip_python_trivia_forward →
depth_at_py_pc[py]` inversion chain) in favour of the jitcode-pc-keyed
twins already built at `finalize_jitcode`. One seam per slice, each
byte-identical where the twin is populated.

### This slice

`specialize.rs`'s sub-walk pre-publishes the single append-site resume
coordinate its guards collapse to (the `list.append` fold — the CALL for
the method form, the LIST_APPEND for the opcode form). It read the
value-stack depth by inverting the append op's `op.pc` back to a python
pc and indexing the py_pc-keyed `depth_at_py_pc` static-liveness table.

That read is cut over to `PyJitCode::depth_trivia_for_jitcode_pc(op.pc)`,
the jitcode-pc-keyed trivia twin. By construction it equals

```
depth_at_py_pc[skip_python_trivia_forward(python_pc_for_jitcode_pc(op.pc))]
```

— marker-then-predecessor resolution with trivia, baking the same `None`
on a trailing-trivia overshoot past the last opcode. The read is gated on
`depth_trivia_populated()`; where the twin is empty (skeleton / fixture
installs) it falls back to the prior py_pc-keyed static-liveness read.
Production carries a populated twin, so the depth is byte-identical.

Single seam, existing twin, no new table — the lowest-risk cutover of the
17 live `depth_at_py_pc(` call sites, chosen as the pattern-setter.

### Verification

- `cargo check -p pyre-jit-trace --features dynasm` — 0 errors.
- `python3 pyre/check.py --backend dynasm,cranelift` — 241/241 ×2,
  byte-identical (the twin reproduces the py_pc-derived depth exactly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
