### PR TITLE
jit: decline the list-append sub-walk when the build-time descr layout does not match the target

### DIFF
--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
@@ -3191,6 +3191,19 @@ unsafe fn orthodox_list_append_recognize(
 pub(crate) fn orthodox_list_append_body_and_sym<Sym: WalkSym>(
     ctx: &WalkContext<'_, '_, Sym>,
 ) -> Option<(SubJitCodeBody, *const Sym)> {
+    // The sub-walk resolves `w_list_append`'s `d`/`j` operands through the
+    // build-time global descr pool, whose field offsets assume 8-byte pointers
+    // (`build_descr_layout_matches_target`).  On a 32-bit target they name the
+    // wrong bytes, so the body's `is_plain_int1` subclass test folds on
+    // garbage, the walk descends the dead `switch_to_object_strategy` leg and
+    // concretely executes its residuals against the live list before declining
+    // at the leg's un-lowered `ListStrategy::Object` ctor.  That abort leaves an
+    // unrollbackable body effect, which makes `fbw_foriter_inflight_take` refuse
+    // delivery and drop the in-flight FOR_ITER iteration.  Decline here instead,
+    // before any IR or side effect: the generic residual append handles the call.
+    if !crate::jitcode_runtime::build_descr_layout_matches_target() {
+        return None;
+    }
     let jc_arc = crate::jitcode_runtime::list_append_jitcode()?;
     let sub_body = sub_jitcode_body_by_index(jc_arc.index())?;
     let sym_ptr = ctx.fbw_mode.snapshot_sym;

--- a/pyre/pyre-jit-trace/src/jitcode_runtime.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_runtime.rs
@@ -429,6 +429,26 @@ pub fn all_descr_refs() -> &'static [DescrRef] {
     &ALL_DESCR_REFS
 }
 
+/// Whether the build-time descr pool's field offsets describe the struct
+/// layout this binary actually runs on.
+///
+/// [`all_descrs`] is serialised by `build.rs` from the layout model in
+/// `majit-translate` (`codewriter::call::StructLayout::from_type_strings` /
+/// `get_type_flag`), which sizes every pointer-typed field at 8 bytes and
+/// aligns to an 8-byte word.  The exact per-field offsets the Charon LLBC
+/// carries (`front::semantic`'s `field_offsets`) come from the same 64-bit
+/// extraction.  On a 32-bit target the real structs pack pointers at 4
+/// (`PyObject.w_class` sits at 4, not 8; `PyType.instantiate` at 24, not 32),
+/// so every offset past the first pointer field names the wrong bytes and a
+/// concrete read through one of those descrs returns garbage.
+///
+/// The per-site descrs the walker builds itself (`crate::descr`) use
+/// `offset_of!` and are always right, so only consumers that resolve their
+/// `d` operands through the build-time pool need this gate.
+pub fn build_descr_layout_matches_target() -> bool {
+    std::mem::size_of::<usize>() == 8
+}
+
 /// Build the metainterp-side `RuntimeBhDescr` pool from the shared
 /// build-time `ALL_DESCRS` and install it into `majit-metainterp` as the
 /// process-global build-time descr pool (`JitCode::descr_at`'s fallback for


### PR DESCRIPTION
Fixes the standing `main` CI red on `pyre/check.py (ubuntu-24.04)`:

```
FAIL wasm synth/delete_negative_open_slice_hot  wrong output
FAILED: wasm 1 failed, 239 passed
```

## Symptom

Only the `del items[:-2]` case of the bench diverged, and only under wasm.
Bisecting `N` showed `N=200` correct and `N=201` wrong, with
`wasm(N) == cpython(N-1)` holding for every larger `N` — the loop ran exactly
one iteration short, once, at the point the JIT started tracing.

## Root cause

The build-time global descr pool (`jitcode_runtime::all_descrs`, serialised by
`pyre-jit-trace/build.rs`) carries field offsets computed with an 8-byte
pointer: `majit-translate`'s `codewriter::call::get_type_flag` sizes every
Ref/usize field at 8 and `StructLayout::from_type_strings` aligns to the
build-script process's `size_of::<usize>()`, and the Charon LLBC
`field_offsets` come from the same x86_64 extraction. On wasm32 the real
structs pack pointers at 4 — `PyObject.w_class` sits at 4, not 8;
`PyType.instantiate` at 24, not 32 — so a concrete read through one of those
descrs returns garbage. The per-site descrs the walker builds itself
(`crate::descr`) use `offset_of!` and are correct on every target.

The orthodox `w_list_append` inline sub-walk is the only production consumer of
that pool (`RawDescrPool::Global`), which is why wasm otherwise looks healthy.
Under wasm32 its `is_plain_int1` subclass test folded on garbage —
`ptr_eq(16, 119)` where native sees the pinned `w_class` on both sides — so the
walk descended the dead `switch_to_object_strategy` leg, executed that leg's
residuals concretely against the live list, and then declined at the leg's
un-lowered `ListStrategy::Object` ctor (`OrthodoxSubWalkTraceUnsupported`).
The resulting abort left an unrollbackable body effect, so
`fbw_foriter_inflight_take` refused delivery and dropped the in-flight
`FOR_ITER` item.

The walker code itself is identical across targets; the split was purely the
descr offsets.

## Fix

Add `jitcode_runtime::build_descr_layout_matches_target()` documenting the
8-byte-pointer assumption, and consult it in
`orthodox_list_append_body_and_sym`, which declines before any IR is recorded
and before any side effect; the generic residual append handles the call.
Constant-true on 64-bit, so the native backends are byte-for-byte unchanged.
Any future consumer of the build-time pool must consult the same gate.

The real fix — target-aware layouts (thread a word size through
`get_type_flag` / `from_type_strings` and re-extract LLBC for wasm32) — would
change every wasm jitcode offset and is left as follow-up work.

## Verification

`pyre/check.py`, all three backends:

| backend | result |
| --- | --- |
| dynasm | ALL PASSED 241/241 |
| cranelift | ALL PASSED 241/241 |
| wasm | ALL PASSED 240/240 |

`cargo fmt --check` clean. `synth/delete_negative_open_slice_hot` now prints
`242981142` on wasm, matching CPython.

## Not addressed here

The same CI run's `cargo test (ubuntu-24.04)` is also red, for an unrelated
reason: `mapdict.rs:2497 panicked: RefCell already mutably borrowed` in the
`module::_weakref::interp__weakref::tests::*` set, with the number of failing
tests varying run to run (2 vs 10).
