### PR TITLE
jit: gh#394 warmup follow-ons — cache FrameRoot shadow-stack cell + correct walk-end handback vsd

### DIFF
--- a/majit/majit-gc/src/shadow_stack.rs
+++ b/majit/majit-gc/src/shadow_stack.rs
@@ -212,7 +212,7 @@ thread_local! {
     static MAX_SHADOW_STACK_DEPTH: Cell<usize> = const { Cell::new(DEFAULT_SHADOW_STACK_DEPTH) };
 
     /// Thread-local shadow stack for individual GcRef roots.
-    static SHADOW_STACK: RefCell<ShadowStack> = RefCell::new(ShadowStack::new());
+    static SHADOW_STACK: RefCell<ShadowStack> = const { RefCell::new(ShadowStack::new()) };
 
     /// Thread-local flat jitframe root stack. Rust tests run multiple
     /// JIT/GC tests in parallel, so using one process-global root stack lets
@@ -372,9 +372,9 @@ struct ShadowStack {
 }
 
 impl ShadowStack {
-    fn new() -> Self {
+    const fn new() -> Self {
         ShadowStack {
-            entries: Vec::with_capacity(64),
+            entries: Vec::new(),
         }
     }
 }
@@ -428,6 +428,37 @@ pub fn get(index: usize) -> GcRef {
         let ss = ss.borrow();
         ss.entries[index]
     })
+}
+
+/// An opaque handle to this thread's `SHADOW_STACK` cell.
+///
+/// The pointer is stable for the life of the owning thread (the same
+/// invariant `MutatorEntry` relies on for STW walks): the thread-local cell is
+/// never reallocated once created. Resolving it once and reusing it lets a hot
+/// caller re-read roots without paying the thread-local resolution
+/// (`_tlv_get_addr` on macOS) on every access — the root-stack base is held in
+/// a fixed location and re-read cheaply, matching the C backend's
+/// once-per-function `gc_enter_roots_frame` resolution and the x86 JIT's
+/// register-cached root-stack top.
+#[derive(Clone, Copy)]
+pub struct ShadowStackSlot(*const RefCell<ShadowStack>);
+
+/// Resolve this thread's `SHADOW_STACK` cell once, for reuse by [`slot_get`].
+pub fn shadow_stack_slot() -> ShadowStackSlot {
+    ShadowStackSlot(SHADOW_STACK.with(|ss| ss as *const _))
+}
+
+/// Get a GcRef at `index` through a previously resolved [`ShadowStackSlot`].
+///
+/// # Safety
+///
+/// `slot` must have been produced by [`shadow_stack_slot`] on the current
+/// thread and the thread must still be alive (its `SHADOW_STACK` not yet torn
+/// down). No `&mut` borrow of the cell may be held across this call.
+pub unsafe fn slot_get(slot: ShadowStackSlot, index: usize) -> GcRef {
+    // SAFETY: per the contract, `slot.0` points at the live owning-thread cell.
+    let ss = unsafe { &*slot.0 }.borrow();
+    ss.entries[index]
 }
 
 /// Walk all entries on the GcRef shadow stack.

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -190,8 +190,8 @@ impl FrameRoot {
     fn frame(&mut self) -> &mut PyFrame {
         // SAFETY: `slot` was resolved on this thread in `new` and the thread is
         // still running; no `&mut` borrow of the cell is held here.
-        let frame = unsafe { majit_gc::shadow_stack::slot_get(self.slot, self.depth) }.0
-            as *mut PyFrame;
+        let frame =
+            unsafe { majit_gc::shadow_stack::slot_get(self.slot, self.depth) }.0 as *mut PyFrame;
         unsafe { &mut *frame }
     }
 

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -5753,33 +5753,9 @@ fn eval_loop_jit(frame: &mut PyFrame) -> LoopResult {
         }
         // The ec block above may have run bytecode_trace / perform_actions
         // (collection points) on a fall-through path; re-seed before the
-        // stack-effect reads and the opcode dispatch.
+        // opcode dispatch.
         let f: *mut PyFrame = frame_root.frame() as *mut PyFrame;
         let mut next_instr = unsafe { &*f }.next_instr();
-        let raw_arg: u32 = op_arg.into();
-        let delta = instruction.stack_effect(raw_arg);
-        if delta > 0 {
-            // `frame` is a shared reborrow used only in this block's reads and
-            // the `if` condition below; its last use ends before the `&mut *f`
-            // reborrow in the taken branch, so the two never alias. Keep any
-            // future `frame` use above that write — the raw pointer means the
-            // borrow checker will not catch an overlap introduced here.
-            let frame = unsafe { &*f };
-            let pushed_top = frame.valuestackdepth.saturating_add(delta as usize);
-            let next_pc = opcode_pc + 1;
-            // A JIT handoff can arrive with the stack depth for the point just
-            // after a super-instruction while `last_instr` still names the
-            // super-instruction itself. If metadata proves the current depth
-            // belongs to the next opcode, advance the pc instead of re-running
-            // pushes that are already reflected in the frame stack.
-            if pushed_top > frame.locals_w().len()
-                && pyre_jit_trace::state::depth_based_vsd_for_wcode(frame.pycode as usize, next_pc)
-                    == Some(frame.valuestackdepth)
-            {
-                unsafe { &mut *f }.set_last_instr_from_next_instr(next_pc);
-                continue;
-            }
-        }
         let step_result =
             execute_opcode_step(unsafe { &mut *f }, code, instruction, op_arg, next_instr);
         match step_result {
@@ -6764,9 +6740,15 @@ fn compile_and_run_once(
                     .frame()
                     .restore_resume_state_from(&executed_frame);
             } else if let Some(restart_pc) = walk_end_restart_pc {
-                frame_root
-                    .frame()
-                    .set_last_instr_from_next_instr(restart_pc);
+                // A marker inside a super-instruction closes the loop at
+                // `loop_header_pc + 1`, and the walk already advanced
+                // `valuestackdepth` through the super-instruction. Set both the
+                // resume pc and its operand depth so the handed-back frame is
+                // self-consistent, mirroring the flush leg above and the
+                // blackhole legs (`apply_blackhole_crn_handoff`).
+                let frame = frame_root.frame();
+                frame.set_last_instr_from_next_instr(restart_pc);
+                correct_resume_vsd(frame, restart_pc);
             }
             propagated_exception = pyre_jit_trace::trace::take_walk_end_propagated_exception();
             action

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -172,18 +172,26 @@ struct FrameLocalsRoot {
 /// collection.
 struct FrameRoot {
     depth: usize,
+    slot: majit_gc::shadow_stack::ShadowStackSlot,
 }
 
 impl FrameRoot {
     #[majit_macros::dont_look_inside]
     fn new(frame: &mut PyFrame) -> Self {
         let depth = majit_gc::shadow_stack::push(majit_ir::GcRef(frame as *mut PyFrame as usize));
-        Self { depth }
+        // Resolve the thread-local shadow-stack cell once; `frame()` re-reads
+        // the root through this cached slot instead of paying the thread-local
+        // resolution on every access.
+        let slot = majit_gc::shadow_stack::shadow_stack_slot();
+        Self { depth, slot }
     }
 
     #[majit_macros::dont_look_inside]
     fn frame(&mut self) -> &mut PyFrame {
-        let frame = majit_gc::shadow_stack::get(self.depth).0 as *mut PyFrame;
+        // SAFETY: `slot` was resolved on this thread in `new` and the thread is
+        // still running; no `&mut` borrow of the cell is held here.
+        let frame = unsafe { majit_gc::shadow_stack::slot_get(self.slot, self.depth) }.0
+            as *mut PyFrame;
         unsafe { &mut *frame }
     }
 


### PR DESCRIPTION
Follow-on to #692, carrying two independent gh#394 warmup cleanups that a re-profile of the #692 result surfaced. Each is separately gated and A/B-measured.

---

## Commit 1 — cache the shadow-stack cell in `FrameRoot`; const-init `SHADOW_STACK`

#692 cut the per-opcode-step `FrameRoot::frame()` reload count in `eval_loop_jit` (gh#394 driver residual); a re-profile showed `majit_gc::shadow_stack::get` still the #1 non-idle warmup self-time frame — the remaining ~3 seeds/step each pay a thread-local resolution (`_tlv_get_addr` on macOS) because `SHADOW_STACK.with()` runs on every access.

- **majit-gc**: add `ShadowStackSlot` (a cached `*const RefCell<ShadowStack>`) plus `shadow_stack_slot()` / `unsafe slot_get()`. The cell address is stable for the owning thread's life — the same invariant `MutatorEntry` already relies on for STW walks.
- **pyre-jit**: `FrameRoot::new` resolves the thread-local cell once and stores the slot; `frame()` re-reads `entries[depth]` through the cached slot instead of resolving the thread-local on every call. `FrameRoot` is a same-thread stack local, so the cached pointer can neither outlive nor cross its thread. `slot_get` takes the same transient borrow the old `get()` did, and re-reads still index the live `entries` Vec, so a Vec realloc between reads is unaffected.
- Also `const`-initialize the `SHADOW_STACK` thread-local (`ShadowStack::new` is now `const` with an empty Vec instead of `Vec::with_capacity(64)`), dropping the per-access lazy-init guard.

**Orthodoxy.** RPython does not re-resolve the root-stack base per access: it lives in a plain global (`gcdata` singleton, `framework.py`), the C backend resolves it once per function (`gc_enter_roots_frame`, `funcgen.py`), the x86 JIT caches the root-stack top in a register across call boundaries (`assembler.py:_load_shadowstack_top_in_ebx`), and `shadowcolor.py` even hoists root saves out of loops. pyre's per-access `SHADOW_STACK.with()` is the divergence; caching the resolution once per activation and reusing it between GC safepoints brings the access cost back in line with upstream. The cache never spans a thread-switch/GIL boundary (single stack-local `FrameRoot` per activation).

**Perf (A/B, interleaved best-of-N, EPOCHREALTIME):** run 1 (15 rounds) +3.66% best-of-N / +3.85% median, bands disjoint; run 2 (12 rounds) +3.71% / +3.52%, disjoint. Every round faster.

---

## Commit 2 — correct `valuestackdepth` on the super-instruction walk-end handback

The non-flush walk-end handback in `compile_and_run_once` set the resume pc but **not** `valuestackdepth`: when a loop-header marker sits inside a super-instruction, the walk closes the loop at `loop_header_pc + 1` and leaves `valuestackdepth` advanced through the super-instruction, while the handback wrote only `last_instr`/`next_instr`. The frame was handed back with pc and operand depth inconsistent, and `eval_loop_jit` patched it downstream by recomputing `instruction.stack_effect` **every opcode step** and, when the projected push overflowed the frame array and the depth table agreed, advancing the pc instead of dispatching. That per-step `stack_effect` was the #2 non-idle warmup self-time frame.

- Make the handback symmetric with the flush leg (`restore_resume_state_from`) and the blackhole legs (`apply_blackhole_crn_handoff`): after `set_last_instr_from_next_instr(restart_pc)`, call `correct_resume_vsd(frame, restart_pc)` to re-derive the operand depth from the resume pc via the depth table.
- The handed-back frame is then self-consistent, so the per-step reconciliation block and its `stack_effect` recompute are **removed**. `valuestackdepth` is now only ever *compared* against the precomputed depth table (`depth_based_vsd_for_wcode` / liveness), never re-derived per dispatch step — the depth table is the single source of truth, and rustpython's `stack_effect_info` leaves the hot path.

**Orthodoxy.** PyPy's dispatch loop never computes a per-step stack effect: `valuestackdepth` is an incrementally-maintained counter (`pyframe.py` push/popvalue), `stack_effect` is compile-time only (co_stacksize, `astcompiler/assemble.py`), and the JIT frame is a virtualizable restored *positionally* from resume data in one shot (`rpython/jit/metainterp/virtualizable.py`), so pc and vsd are never mutually inconsistent at a merge point. Fixing the seam so the frame is self-consistent — rather than patching the inconsistency downstream — is the orthodox shape.

**Perf (A/B, interleaved best-of-N, 21 rounds):** +1.39% best-of-N / +0.17% median, bands overlap. Perf-neutral-to-slightly-positive; this commit lands as a correctness/orthodoxy cleanup that *removes* machinery (the per-step reconciliation), with the A/B confirming no regression.

---

## Correctness (whole branch)

- `check.py --backend dynasm,cranelift`: **241/241 dynasm + 241/241 cranelift, byte-identical** both backends (measured on both the pre- and post-commit-2 base).
- `MAJIT_GC_STRESS=1` gc_stress **12/12** — the UAF gate: a moving collection at every allocation window.
- `cargo test -p majit-gc` 191, `cargo test -p pyre-jit` 320+12 (both eval-loop twins).
- Golden warmup output byte-identical (`3004320000`) for both commits.

— *opened by Claude*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved garbage-collection root tracking during JIT execution.
  - Fixed frame and operand-stack state restoration when execution resumes inside optimized instruction sequences.
  - Improved consistency after garbage-collection points, reducing the risk of incorrect execution state.

- **Performance**
  - Reduced repeated overhead when accessing per-thread garbage-collection state during JIT operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->