### PR TITLE
jit: locally decline the orthodox list-append fold, and force the virtualizable on frame escape

### DIFF
--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -16514,6 +16514,14 @@ impl majit_backend::Backend for CraneliftBackend {
         Some(force_token_to_dead_frame(force_token))
     }
 
+    fn is_force_token_armed(&self, force_token: GcRef) -> bool {
+        if force_token.0 == 0 {
+            return false;
+        }
+        let jf_ptr = jitframe_resolve(force_token.0 as *mut i64);
+        unsafe { *jf_ptr.add(JF_FORCE_DESCR_OFS as usize / 8) != 0 }
+    }
+
     fn get_latest_descr<'a>(&'a self, frame: &'a DeadFrame) -> &'a dyn FailDescr {
         get_latest_descr_from_deadframe(frame).expect("get_latest_descr_from_deadframe failed")
     }

--- a/majit/majit-backend-dynasm/src/aarch64/assembler.rs
+++ b/majit/majit-backend-dynasm/src/aarch64/assembler.rs
@@ -3135,6 +3135,18 @@ impl<'a> AssemblerARM64<'a> {
             | OpCode::CallReleaseGilI
             | OpCode::CallReleaseGilF
             | OpCode::CallReleaseGilN => {
+                if matches!(
+                    op.opcode,
+                    OpCode::CallMayForceI
+                        | OpCode::CallMayForceR
+                        | OpCode::CallMayForceF
+                        | OpCode::CallMayForceN
+                        | OpCode::CallReleaseGilI
+                        | OpCode::CallReleaseGilF
+                        | OpCode::CallReleaseGilN
+                ) {
+                    self._store_force_index_if_next_guard(ops, op_index, fail_index);
+                }
                 self.genop_call_with_arglocs(op, arglocs);
             }
             OpCode::CallR => {

--- a/majit/majit-backend-dynasm/src/runner.rs
+++ b/majit/majit-backend-dynasm/src/runner.rs
@@ -2701,6 +2701,43 @@ impl Backend for DynasmBackend {
             .expect("FrameData::fail_descr must implement FailDescr")
     }
 
+    fn force(&self, force_token: GcRef) -> Option<DeadFrame> {
+        if force_token.is_null() {
+            return None;
+        }
+        let frame = unsafe { JitFrame::resolve(force_token.0 as *mut JitFrame) };
+        let force_descr = unsafe { (*frame).jf_force_descr };
+        assert_ne!(force_descr, 0, "force: jf_force_descr is null");
+        unsafe { (*frame).jf_descr = force_descr };
+
+        let descr = self.fail_descr_arc_from_addr(force_descr);
+        let fail_descr = descr
+            .as_fail_descr()
+            .expect("force descriptor must implement FailDescr");
+        let raw_values = fail_descr
+            .fail_arg_types()
+            .iter()
+            .enumerate()
+            .map(|(index, _)| {
+                crate::guard::decode_rd_loc_slot(fail_descr, index)
+                    .map(|slot| unsafe { crate::llmodel::get_int_value_direct(frame, slot) as i64 })
+                    .unwrap_or(0)
+            })
+            .collect();
+        let exc_value = GcRef(unsafe { (*frame).jf_guard_exc });
+        Some(DeadFrame {
+            data: Box::new(FrameData::new(raw_values, descr, None, exc_value)),
+        })
+    }
+
+    fn is_force_token_armed(&self, force_token: GcRef) -> bool {
+        if force_token.is_null() {
+            return false;
+        }
+        let frame = unsafe { JitFrame::resolve(force_token.0 as *mut JitFrame) };
+        unsafe { (*frame).jf_force_descr != 0 }
+    }
+
     fn get_latest_descr_arc(&self, frame: &DeadFrame) -> Arc<dyn majit_ir::Descr> {
         // `history.py:125` `cpu.get_latest_descr(deadframe)` returns the
         // metainterp `AbstractFailDescr` object op.descr stamped.  After

--- a/majit/majit-backend-dynasm/src/x86/assembler.rs
+++ b/majit/majit-backend-dynasm/src/x86/assembler.rs
@@ -4282,6 +4282,18 @@ impl<'a> Assembler386<'a> {
             | OpCode::CallReleaseGilI
             | OpCode::CallReleaseGilF
             | OpCode::CallReleaseGilN => {
+                if matches!(
+                    op.opcode,
+                    OpCode::CallMayForceI
+                        | OpCode::CallMayForceR
+                        | OpCode::CallMayForceF
+                        | OpCode::CallMayForceN
+                        | OpCode::CallReleaseGilI
+                        | OpCode::CallReleaseGilF
+                        | OpCode::CallReleaseGilN
+                ) {
+                    self._store_force_index_if_next_guard(ops, op_index, fail_index);
+                }
                 self.genop_call_with_arglocs(op, arglocs);
             }
             OpCode::CallR => {

--- a/majit/majit-backend-dynasm/src/x86/assembler.rs
+++ b/majit/majit-backend-dynasm/src/x86/assembler.rs
@@ -6048,10 +6048,17 @@ impl<'a> Assembler386<'a> {
         self.pending_force_cell = Some(cell);
 
         // x86/assembler.py:2210-2222: store descr to jf_force_descr,
-        // zero jf_descr.
+        // zero jf_descr.  The 64-bit descr pointer needs a register to reach
+        // memory; route it through `X86_64_SCRATCH_REG` as
+        // assembler.py:2219-2223 does, never through an allocatable one.
+        // This runs just before the call it guards, and that call's arguments
+        // are still sitting in their allocated registers — EAX is in
+        // `ALL_CORE_REGS`, so materializing the pointer there would overwrite
+        // an argument.  R11 is reserved as the scratch and holds nothing live.
+        let scratch = crate::regloc::X86_64_SCRATCH_REG.value;
         dynasm!(self.mc ; .arch x64
-            ; mov rax, QWORD descr_ptr
-            ; mov QWORD [rbp + JF_FORCE_DESCR_OFS], rax
+            ; mov Rq(scratch), QWORD descr_ptr
+            ; mov QWORD [rbp + JF_FORCE_DESCR_OFS], Rq(scratch)
             ; mov QWORD [rbp + JF_DESCR_OFS], 0
         );
     }

--- a/majit/majit-backend/src/lib.rs
+++ b/majit/majit-backend/src/lib.rs
@@ -2140,6 +2140,11 @@ pub trait Backend: Send {
         None
     }
 
+    /// Whether a force token is inside a call bracket with recovery data.
+    fn is_force_token_armed(&self, _force_token: GcRef) -> bool {
+        false
+    }
+
     /// Store a saved-data GC ref on a dead frame.
     fn set_savedata_ref(&self, _frame: &mut DeadFrame, _data: GcRef) {
         // No-op: backend doesn't support savedata

--- a/majit/majit-metainterp/src/history.rs
+++ b/majit/majit-metainterp/src/history.rs
@@ -2407,6 +2407,10 @@ impl TraceCtx {
             frames: recorder_frames,
             vable_boxes: vable_boxes.to_vec(),
             vref_boxes: vref_boxes.to_vec(),
+            // The nested-list append fold resumes through the single-frame
+            // collapse, never this multi-frame path, so no extra virtual roots
+            // flow here.
+            extra_virtual_roots: Vec::new(),
         });
         self.set_last_guard_op_resume_position(snapshot_id);
     }

--- a/majit/majit-metainterp/src/jitcode/assembler.rs
+++ b/majit/majit-metainterp/src/jitcode/assembler.rs
@@ -4532,6 +4532,12 @@ impl JitCodeBuilder {
             || total_i > 256
             || total_r > 256
             || total_f > 256
+            // A resume frame records its jitcode `pc` as a single SHORT
+            // (`resumecode.py:90` `append_int` casts through `rffi.SHORT`), so
+            // a jitcode whose byte length cannot be addressed by an i16 pc
+            // would overflow the resume numbering.  Decline it like the
+            // register/const ceilings above; the interpreter keeps running it.
+            || self.code.len() > i16::MAX as usize
         {
             return None;
         }
@@ -4651,6 +4657,14 @@ impl JitCodeBuilder {
     pub fn finish(self) -> JitCode {
         self.try_finish()
             .expect("JitCodeBuilder::finish called for an unencodable JitCode")
+    }
+
+    /// Latch the single-byte-operand overflow flag so `try_finish` declines
+    /// the JitCode.  Used by front-ends that compute a pool-backed operand
+    /// index outside the builder's `push_reg_u8` seam and would otherwise have
+    /// to panic when the index exceeds a single byte.
+    pub fn note_encoding_overflow(&mut self) {
+        self.encoding_overflow = true;
     }
 
     fn push_u8(&mut self, value: u8) {

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -11280,6 +11280,39 @@ impl<M: Clone> MetaInterp<M> {
         Some((all_virtuals_ptr, all_virtuals_int))
     }
 
+    /// Force a running virtualizable identified by its backend force token.
+    pub fn force_virtualizable_token(&mut self, token: u64) {
+        let deadframe = self
+            .backend
+            .force(GcRef(token as usize))
+            .expect("active virtualizable must have a backend deadframe");
+        let descr_arc = self.backend.get_latest_descr_arc(&deadframe);
+        let descr = descr_arc
+            .as_fail_descr()
+            .expect("forced virtualizable must have a fail descriptor");
+        let green_key = majit_backend::descr_owning_jct(descr)
+            .expect("forced virtualizable must belong to a compiled loop")
+            .green_key();
+        let trace_id = descr.trace_id();
+        let fail_index = descr.fail_index();
+        let fail_values = descr
+            .fail_arg_types()
+            .iter()
+            .enumerate()
+            .map(|(index, tp)| match tp {
+                Type::Int => self.backend.get_int_value(&deadframe, index),
+                Type::Ref => self.backend.get_ref_value(&deadframe, index).0 as i64,
+                Type::Float => self.backend.get_float_value(&deadframe, index).to_bits() as i64,
+                Type::Void => 0,
+            })
+            .collect::<Vec<_>>();
+        let _ = self.handle_async_forcing(green_key, trace_id, fail_index, &fail_values);
+    }
+
+    pub fn is_force_token_armed(&self, token: u64) -> bool {
+        self.backend.is_force_token_armed(GcRef(token as usize))
+    }
+
     /// RPython pyjitpl.py:3101 _prepare_exception_resumption +
     /// pyjitpl.py:3132 prepare_resume_from_failure parity.
     ///

--- a/majit/majit-metainterp/src/trace_ctx.rs
+++ b/majit/majit-metainterp/src/trace_ctx.rs
@@ -1944,7 +1944,7 @@ impl TraceCtx {
     /// stops at `self.num_arrays + self.static_fields.len()` and leaves the
     /// identity untouched. No-op when the heap pointer, `virtualizable_info`,
     /// or `virtualizable_values` is unavailable.
-    pub(crate) fn synchronize_virtualizable(&self) {
+    pub fn synchronize_virtualizable(&self) {
         let Some(heap_ptr) = self.virtualizable_heap_ptr else {
             return;
         };

--- a/majit/majit-metainterp/src/trace_ctx.rs
+++ b/majit/majit-metainterp/src/trace_ctx.rs
@@ -2314,6 +2314,19 @@ impl TraceCtx {
         self.virtualizable_boxes.is_some()
     }
 
+    /// Whether BOTH halves of the standard virtualizable shadow are active.
+    ///
+    /// `init_virtualizable_boxes` seeds the OpRef half alone when the caller
+    /// has no live concrete values (the bridge-entry rebuild in
+    /// `seed_virtualizable_boxes`, test fixtures), leaving
+    /// `virtualizable_values` disabled so readers fall back to the zero
+    /// placeholder. `set_virtualizable_entry_at` writes both halves and
+    /// panics without the concrete one, so its callers must gate on this
+    /// rather than on `has_virtualizable_boxes`.
+    pub fn has_virtualizable_shadow(&self) -> bool {
+        self.virtualizable_boxes.is_some() && self.virtualizable_values.is_some()
+    }
+
     /// Drop the tracing-time virtualizable_boxes mirror.
     ///
     /// Used at bridge entry: `init_symbolic` seeds the cache with OpRefs

--- a/pyre/pyre-interpreter/src/call.rs
+++ b/pyre/pyre-interpreter/src/call.rs
@@ -2822,7 +2822,7 @@ fn call_metaclass_with_kwargs(
             if stored.is_null() {
                 std::ptr::null_mut()
             } else {
-                unsafe { (*stored).gettopframe() }
+                unsafe { (*stored).gettopframe_raw() }
             }
         };
         if !kwds.is_empty() && !frame.is_null() {
@@ -3188,7 +3188,7 @@ fn build_class_inner(
                     if stored.is_null() {
                         std::ptr::null_mut()
                     } else {
-                        unsafe { (*stored).gettopframe() }
+                        unsafe { (*stored).gettopframe_raw() }
                     }
                 };
                 let ns_obj = if !prepare_kwds.is_empty() && !prepare_frame.is_null() {
@@ -3908,7 +3908,7 @@ pub(crate) fn call_init_subclass_on_bases(
         if stored.is_null() {
             std::ptr::null_mut()
         } else {
-            unsafe { (*stored).gettopframe() }
+            unsafe { (*stored).gettopframe_raw() }
         }
     };
     if !frame.is_null() {

--- a/pyre/pyre-interpreter/src/executioncontext.rs
+++ b/pyre/pyre-interpreter/src/executioncontext.rs
@@ -3,6 +3,20 @@ use std::sync::OnceLock;
 
 use crate::PyFrame;
 
+pub type ForceFrameFn = unsafe extern "C" fn(*mut PyFrame);
+static FORCE_FRAME_HOOK: OnceLock<ForceFrameFn> = OnceLock::new();
+
+pub fn register_force_frame_hook(f: ForceFrameFn) {
+    let _ = FORCE_FRAME_HOOK.set(f);
+}
+
+#[inline]
+fn force_frame(frame: *mut PyFrame) {
+    if let Some(f) = FORCE_FRAME_HOOK.get() {
+        unsafe { f(frame) };
+    }
+}
+
 /// Return the live `PyFrame` as the Python-visible `frame` object passed
 /// to a trace / profile callback.
 ///
@@ -261,12 +275,19 @@ impl ExecutionContext {
 
     #[inline]
     pub fn gettopframe(&self) -> *mut PyFrame {
+        force_frame(self.topframeref);
+        self.topframeref
+    }
+
+    #[inline]
+    pub fn gettopframe_raw(&self) -> *mut PyFrame {
         self.topframeref
     }
 
     pub fn gettopframe_nohidden(&self) -> *mut PyFrame {
         let mut frame = self.topframeref;
         while !frame.is_null() {
+            force_frame(frame);
             // SAFETY: frame pointers are owned by interpreter call stack and can be
             // null-checked before dereference.
             unsafe {
@@ -282,6 +303,7 @@ impl ExecutionContext {
 
     pub fn getnextframe_nohidden(mut frame: *mut PyFrame) -> *mut PyFrame {
         while !frame.is_null() {
+            force_frame(frame);
             // SAFETY: caller provides a valid frame chain or null.
             unsafe {
                 let current = &*frame;
@@ -289,6 +311,7 @@ impl ExecutionContext {
                 if next.is_null() {
                     return std::ptr::null_mut();
                 }
+                force_frame(next);
                 if !(&*next).hide() {
                     return next;
                 }

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/fbw_state.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/fbw_state.rs
@@ -665,6 +665,16 @@ pub(crate) fn fbw_append_promote_journal_push(list: pyre_object::PyObjectRef) {
     FBW_APPEND_PROMOTE_JOURNAL.with(|j| j.borrow_mut().push(list));
 }
 
+/// Undo the most recent Empty-to-typed list promotion when its speculative
+/// append fold is locally declined.
+pub(crate) fn fbw_append_promote_journal_rollback_last(list: pyre_object::PyObjectRef) {
+    FBW_APPEND_PROMOTE_JOURNAL.with(|j| {
+        let popped = j.borrow_mut().pop();
+        assert_eq!(popped, Some(list));
+    });
+    unsafe { pyre_object::listobject::w_list_clear(list) };
+}
+
 /// Record the `intvalue` a walked eager `IntMutableCell` store displaces,
 /// for the in-place restore when the walk does not commit its end state.
 // Consumed by the StoreName/StoreGlobal cell fold

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
@@ -17,6 +17,45 @@
 
 use super::*;
 
+thread_local! {
+    static ACTIVE_FRAME_ESCAPE: std::cell::Cell<Option<(usize, usize)>> =
+        const { std::cell::Cell::new(None) };
+    static COMMITTED_FRAME_ESCAPE_PC: std::cell::Cell<Option<usize>> =
+        const { std::cell::Cell::new(None) };
+}
+
+struct ActiveFrameEscapeGuard(Option<(usize, usize)>);
+
+impl ActiveFrameEscapeGuard {
+    fn enter(frame: usize, py_pc: usize) -> Self {
+        let current = (frame != 0).then_some((frame, py_pc));
+        COMMITTED_FRAME_ESCAPE_PC.with(|slot| slot.set(None));
+        Self(ACTIVE_FRAME_ESCAPE.with(|slot| slot.replace(current)))
+    }
+}
+
+impl Drop for ActiveFrameEscapeGuard {
+    fn drop(&mut self) {
+        ACTIVE_FRAME_ESCAPE.with(|slot| slot.set(self.0));
+    }
+}
+
+pub fn flush_active_frame_escape(ctx: &TraceCtx, frame: *mut pyre_interpreter::PyFrame) {
+    ACTIVE_FRAME_ESCAPE.with(|slot| {
+        if let Some((expected, py_pc)) = slot.get()
+            && expected == frame as usize
+        {
+            if crate::state::flush_walk_end_state_to_frame(ctx, expected, py_pc) {
+                COMMITTED_FRAME_ESCAPE_PC.with(|committed| committed.set(Some(py_pc)));
+            }
+        }
+    });
+}
+
+pub fn take_committed_frame_escape_pc() -> Option<usize> {
+    COMMITTED_FRAME_ESCAPE_PC.with(|slot| slot.take())
+}
+
 /// Reject a residual_call whose `allboxes` (funcbox + permuted args)
 /// contains an `OpRef::NONE`.  RPython's `do_residual_call` resolves
 /// each argbox through `env[box]`, where an unbound box is a `KeyError`;
@@ -988,9 +1027,26 @@ pub(crate) fn try_execute_residual_call_via_executor<Sym: WalkSym>(
     // `vable_and_vrefs_before_residual_call` (pyjitpl.py:2017) runs only past
     // the OS_NOT_IN_TRACE / force-virtual short-circuits. RPython mirror:
     // `pyjitpl.py:3318-3330`.
+    let live_frame = if ctx.fbw_mode.snapshot_sym.is_null() {
+        0
+    } else {
+        unsafe { (*ctx.fbw_mode.snapshot_sym).live_vable_frame_addr() }
+    };
     let vable_root_depth = if let Some(obj) = vable_obj_root.as_mut() {
         let info = crate::frame_layout::build_pyframe_virtualizable_info();
         let root_depth = majit_gc::shadow_stack::resume_ref_roots_depth();
+        if let Some(last_instr_index) = info
+            .static_fields
+            .iter()
+            .position(|field| field.name == "last_instr")
+        {
+            let last_instr = ctx.trace_ctx.const_int(ctx.vstack_cur_pypc as i64);
+            ctx.trace_ctx.set_virtualizable_entry_at(
+                last_instr_index,
+                last_instr,
+                majit_ir::Value::Int(ctx.vstack_cur_pypc as i64),
+            );
+        }
         unsafe {
             majit_gc::shadow_stack::push_resume_ref_roots(std::slice::from_mut(&mut **obj));
             info.tracing_before_residual_call(**obj as usize as *mut u8);
@@ -1039,6 +1095,9 @@ pub(crate) fn try_execute_residual_call_via_executor<Sym: WalkSym>(
     let heap_write_odometer_before =
         (!provably_side_effect_free).then(pyre_interpreter::call::frame_entry_count);
     let exec_result = {
+        let escape_frame = if is_may_force { live_frame } else { 0 };
+        let _frame_escape =
+            ActiveFrameEscapeGuard::enter(escape_frame, ctx.vstack_cur_pypc as usize);
         let _suspend = majit_metainterp::TraceContinuationSuspendGuard::enter();
         majit_metainterp::executor::execute_residual_call(call_descr, func_ptr, &args)
     };
@@ -1061,11 +1120,10 @@ pub(crate) fn try_execute_residual_call_via_executor<Sym: WalkSym>(
     // heap half: a cleared token means the callee forced the virtualizable —
     // the frame escaped, the trace must abort (pyjitpl.py:3365
     // `SwitchToBlackhole(Counters.ABORT_ESCAPE, raising_exception=True)`).
-    // The interpreter resumes from the live frame,
-    // which the callee's force path made heap-authoritative — no
-    // `load_fields_from_virtualizable` analogue is needed because the FBW
-    // abort discards the walk shadow instead of handing it to a blackhole
-    // leg.  An intact token is cleared back to TOKEN_NONE.
+    // The interpreter resumes from the live frame, which the callee's force
+    // path made heap-authoritative. Reload the walk shadow before aborting so
+    // later cleanup cannot restore pre-force fields.  An intact token is
+    // cleared back to TOKEN_NONE.
     if let Some(obj) = vable_obj_root.as_ref() {
         let info = crate::frame_layout::build_pyframe_virtualizable_info();
         let forced = unsafe { info.tracing_after_residual_call(**obj as usize as *mut u8) };
@@ -1073,6 +1131,7 @@ pub(crate) fn try_execute_residual_call_via_executor<Sym: WalkSym>(
             majit_gc::shadow_stack::pop_resume_ref_roots_to(depth);
         }
         if forced {
+            ctx.trace_ctx.refresh_virtualizable_shadow_from_heap();
             return Err(DispatchError::VableEscapedDuringResidualCall { pc: op_pc });
         }
     }

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
@@ -1986,9 +1986,8 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     // parity suite folding function-entry helper appends on both backends.
     // #171 ORTHODOX descent: descend the real `w_list_append` body,
     // recording its array ops native.
-    // A decline (`None`) falls through to the generic residual below; an
-    // un-lowered in-body helper aborts the trace (graceful interpreter
-    // fallback).  Gated to top full-body frames, not inside a sub-walk.
+    // A recognition or body-sub-walk decline falls through to the generic
+    // residual below. Gated to top full-body frames, not inside a sub-walk.
     if ctx.is_authoritative_executor
         && !ctx.fbw_mode.inline_subwalk
         && dst_bank == 'r'

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
@@ -1035,18 +1035,16 @@ pub(crate) fn try_execute_residual_call_via_executor<Sym: WalkSym>(
     let vable_root_depth = if let Some(obj) = vable_obj_root.as_mut() {
         let info = crate::frame_layout::build_pyframe_virtualizable_info();
         let root_depth = majit_gc::shadow_stack::resume_ref_roots_depth();
-        if let Some(last_instr_index) = info
-            .static_fields
-            .iter()
-            .position(|field| field.name == "last_instr")
-        {
-            let last_instr = ctx.trace_ctx.const_int(ctx.vstack_cur_pypc as i64);
-            ctx.trace_ctx.set_virtualizable_entry_at(
-                last_instr_index,
-                last_instr,
-                majit_ir::Value::Int(ctx.vstack_cur_pypc as i64),
-            );
-        }
+        // Publish the current Python pc so a force inside the callee reports
+        // the executing line rather than the one the last resume point left
+        // behind.
+        let last_instr = ctx.trace_ctx.const_int(ctx.vstack_cur_pypc as i64);
+        crate::trace_opcode::mirror_vable_static_to_boxes(
+            ctx.trace_ctx,
+            "last_instr",
+            last_instr,
+            majit_ir::Value::Int(ctx.vstack_cur_pypc as i64),
+        );
         unsafe {
             majit_gc::shadow_stack::push_resume_ref_roots(std::slice::from_mut(&mut **obj));
             info.tracing_before_residual_call(**obj as usize as *mut u8);

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
@@ -2953,9 +2953,9 @@ pub(crate) fn try_walker_specialize_builtin_len<Sym: WalkSym>(
 /// the sub-walk with inline-subwalk mode enabled.
 ///
 /// Like the fold, the walker only RECORDS the array-op IR; this applies the
-/// append to the concrete list + journals the rewind.  Declines (`Ok(None)`)
-/// BEFORE emitting any IR for a non-matching shape (SAFE fallback to the fold
-/// / residual).
+/// append to the concrete list + journals the rewind. Recognition declines
+/// before emitting IR; an unsupported body sub-walk rolls its tentative IR
+/// back before falling through to the residual call.
 ///
 /// STATUS: the descr-pool
 /// wiring, the host-static const relocation, and the list header field
@@ -2968,8 +2968,8 @@ pub(crate) fn try_walker_specialize_builtin_len<Sym: WalkSym>(
 /// at build time (`jtransform.rs`), so the descent completes and commits a
 /// working trace.  Safety net: if a stale build-time jitcode kept that ctor as
 /// a symbolic (`>>47`) fnaddr, `try_execute_residual_call_via_executor`
-/// declines it (`OrthodoxSubWalkTraceUnsupported`) and the descent aborts
-/// gracefully (interpreter fallback) instead of baking the hash as a code
+/// declines it (`OrthodoxSubWalkTraceUnsupported`) and the method-call form
+/// records the append as a residual call instead of baking the hash as a code
 /// address and branching to garbage.
 pub(crate) fn try_walker_orthodox_list_append<Sym: WalkSym>(
     ctx: &mut WalkContext<'_, '_, Sym>,
@@ -3022,7 +3022,14 @@ pub(crate) fn try_walker_orthodox_list_append<Sym: WalkSym>(
     // resolver) and stays live for the enclosing full-body walk.
     let sym = unsafe { &*sym_ptr };
 
-    // ── commit (record IR; no further declines) ──
+    let pre_fold_pos = ctx.trace_ctx.get_trace_position();
+    // Mirror the commit's own promotion predicate exactly: a rollback must
+    // undo a promotion only when one was performed, or it would pop another
+    // list's journal entry.
+    let promoted_empty = empty_append_virt_enabled()
+        && unsafe { pyre_object::w_list_uses_empty_storage(inner_self) };
+
+    // ── tentative commit ──
     let callable_op = r_args[0];
     let value_op = r_args[2];
 
@@ -3060,9 +3067,22 @@ pub(crate) fn try_walker_orthodox_list_append<Sym: WalkSym>(
         crate::descr::method_w_self_descr(),
     );
 
-    orthodox_list_append_commit(
+    let commit_result = orthodox_list_append_commit(
         ctx, op, sym, &sub_body, self_ref, value_op, inner_self, value, len_before,
-    )?;
+    );
+    match commit_result {
+        Ok(()) => {}
+        Err(DispatchError::OrthodoxSubWalkTraceUnsupported { .. }) => {
+            ctx.trace_ctx.cut_trace(pre_fold_pos);
+            ctx.trace_ctx.heap_cache_mut().reset();
+            bool_box_truth_reset();
+            if promoted_empty {
+                fbw_append_promote_journal_rollback_last(inner_self);
+            }
+            return Ok(None);
+        }
+        Err(error) => return Err(error),
+    }
 
     // The `list.append(x)` call's `None` return (the residual's Ref dst).
     let none_ref = ctx.trace_ctx.const_ref(pyre_object::w_none() as i64);

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
@@ -3509,7 +3509,9 @@ pub(crate) fn orthodox_list_append_commit<Sym: WalkSym>(
 /// gate and descends the same `w_list_append` body as the method-call form
 /// ([`try_walker_orthodox_list_append`]).  Returns `None` (fall through to the
 /// generic residual, SAFE — identical to the retired MIFrame tracer's `jit_list_append`)
-/// for any non-matching shape; the residual is void so no result is written.
+/// for any non-matching shape, and likewise after rolling the tentative IR back
+/// when the body sub-walk hits an un-lowered helper; the residual is void so no
+/// result is written.
 pub(crate) fn try_walker_orthodox_list_append_opcode<Sym: WalkSym>(
     ctx: &mut WalkContext<'_, '_, Sym>,
     code: &[u8],
@@ -3546,11 +3548,31 @@ pub(crate) fn try_walker_orthodox_list_append_opcode<Sym: WalkSym>(
     // resolver) and stays live for the enclosing full-body walk.
     let sym = unsafe { &*sym_ptr };
 
-    // ── commit (record IR; no further declines) ──
+    let pre_fold_pos = ctx.trace_ctx.get_trace_position();
+    // Mirror the commit's own promotion predicate exactly: a rollback must
+    // undo a promotion only when one was performed, or it would pop another
+    // list's journal entry.
+    let promoted_empty =
+        empty_append_virt_enabled() && unsafe { pyre_object::w_list_uses_empty_storage(list) };
+
+    // ── tentative commit ──
     // The receiver list OpRef + value OpRef are the residual's Ref operands.
-    orthodox_list_append_commit(
+    let commit_result = orthodox_list_append_commit(
         ctx, op, sym, &sub_body, r_args[0], r_args[1], list, value, len_before,
-    )?;
+    );
+    match commit_result {
+        Ok(()) => {}
+        Err(DispatchError::OrthodoxSubWalkTraceUnsupported { .. }) => {
+            ctx.trace_ctx.cut_trace(pre_fold_pos);
+            ctx.trace_ctx.heap_cache_mut().reset();
+            bool_box_truth_reset();
+            if promoted_empty {
+                fbw_append_promote_journal_rollback_last(list);
+            }
+            return Ok(None);
+        }
+        Err(error) => return Err(error),
+    }
     Ok(Some(()))
 }
 

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -2148,6 +2148,15 @@ fn run_perfn_walk<Sym: WalkSym>(
         // forward abort has already distinguished an outside mark from a mark
         // inside its discarded attempt.  `PYRE_FBW_ABORT_FLUSH=0` opts out.
         if std::env::var_os("PYRE_FBW_ABORT_FLUSH").as_deref() != Some(std::ffi::OsStr::new("0")) {
+            if matches!(
+                &walk_result,
+                Err(crate::jitcode_dispatch::DispatchError::VableEscapedDuringResidualCall { .. })
+            ) && let Some(resume_py_pc) =
+                crate::jitcode_dispatch::take_committed_frame_escape_pc()
+            {
+                WALK_END_RESTART_PC.with(|c| c.set(Some(resume_py_pc)));
+                WALK_END_FLUSH_COMMITTED.with(|c| c.set(true));
+            }
             let call_forward_abort = match &walk_result {
                 Err(crate::jitcode_dispatch::DispatchError::AbortPermanentMarkerReached { pc }) => {
                     Some((*pc, true))

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -548,15 +548,17 @@ use crate::frame_layout::{
 /// (`last_instr`, `pycode`, `valuestackdepth`, `debugdata`,
 /// `lastblock`, `w_globals`).
 ///
-/// No-op when `virtualizable_boxes` is not yet seeded
-/// (non-virtualizable trace, or before `init_virtualizable_boxes`).
+/// No-op when the virtualizable shadow is not seeded (non-virtualizable
+/// trace, or before `init_virtualizable_boxes`) and when only its OpRef
+/// half is live — a bridge-entry rebuild seeds no concrete values, and
+/// there is no concrete slot to mirror into.
 pub(crate) fn mirror_vable_static_to_boxes(
     ctx: &mut TraceCtx,
     static_field_name: &str,
     opref: OpRef,
     concrete: Value,
 ) {
-    if !ctx.has_virtualizable_boxes() {
+    if !ctx.has_virtualizable_shadow() {
         return;
     }
     let idx = ctx

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -4363,12 +4363,12 @@ fn bh_call_kw_impl(
     let parent_frame_ptr: *const PyFrame = if ec.is_null() {
         std::ptr::null()
     } else {
-        unsafe { (*ec).gettopframe() as *const PyFrame }
+        unsafe { (*ec).gettopframe_raw() as *const PyFrame }
     };
     assert!(
         !parent_frame_ptr.is_null(),
         "bh_call_kw_impl requires a live parent PyFrame from \
-         getexecutioncontext().gettopframe(); the eval loop must pin the \
+         getexecutioncontext().gettopframe_raw(); the eval loop must pin the \
          execution context before any residual call"
     );
     let saved_ctx = pyre_interpreter::call::take_last_exec_ctx();
@@ -4468,7 +4468,7 @@ fn bh_call_fn_impl(callable: PyObjectRef, null_or_self: PyObjectRef, args: &[PyO
         values
     };
     // `space.getexecutioncontext()` (call.rs:198 → TLS-pinned EC the eval
-    // loop stamps on entry) `.gettopframe()` is the active caller frame —
+    // loop stamps on entry) `.gettopframe_raw()` is the active caller frame —
     // `executioncontext.py:85-89 enter` / `:91-109 leave` keep
     // `topframeref` pointing at the running frame.  A null here means the
     // EC was never pinned before a residual call, which is a wiring bug, so
@@ -4477,12 +4477,12 @@ fn bh_call_fn_impl(callable: PyObjectRef, null_or_self: PyObjectRef, args: &[PyO
     let parent_frame_ptr: *const PyFrame = if ec.is_null() {
         std::ptr::null()
     } else {
-        unsafe { (*ec).gettopframe() as *const PyFrame }
+        unsafe { (*ec).gettopframe_raw() as *const PyFrame }
     };
     assert!(
         !parent_frame_ptr.is_null(),
         "bh_call_fn_impl requires a live parent PyFrame from \
-         getexecutioncontext().gettopframe(); the eval loop must pin the \
+         getexecutioncontext().gettopframe_raw(); the eval loop must pin the \
          execution context before any residual call"
     );
     if pyre_object::gc_roots::shadow_stack_get(root_base).is_null() {
@@ -4593,12 +4593,12 @@ pub extern "C" fn bh_call_function_ex_fn(
     let parent_frame_ptr: *const PyFrame = if ec.is_null() {
         std::ptr::null()
     } else {
-        unsafe { (*ec).gettopframe() as *const PyFrame }
+        unsafe { (*ec).gettopframe_raw() as *const PyFrame }
     };
     assert!(
         !parent_frame_ptr.is_null(),
         "bh_call_function_ex_fn requires a live parent PyFrame from \
-         getexecutioncontext().gettopframe(); the eval loop must pin the \
+         getexecutioncontext().gettopframe_raw(); the eval loop must pin the \
          execution context before any residual call"
     );
     let saved_ctx = pyre_interpreter::call::take_last_exec_ctx();

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -3430,7 +3430,44 @@ fn build_jit_driver_pair() -> JitDriverPair {
     majit_backend_wasm::set_ca_deopt_helper_slot(
         crate::call_jit::wasm_ca_resume_deopt as *const () as usize as u32,
     );
+    pyre_interpreter::executioncontext::register_force_frame_hook(force_pyframe);
     (d, info)
+}
+
+unsafe extern "C" fn force_pyframe(frame: *mut pyre_interpreter::PyFrame) {
+    if frame.is_null() {
+        return;
+    }
+    let (driver, info) = driver_pair();
+    unsafe {
+        let tracing_frame = driver.meta_interp_mut().trace_ctx().and_then(|ctx| {
+            pyre_jit_trace::jitcode_dispatch::flush_active_frame_escape(ctx, frame);
+            ctx.virtualizable_heap_ptr()
+        });
+        let tracing_frame = tracing_frame.map(|ptr| ptr as *mut u8).filter(|ptr| {
+            matches!(
+                info.read_token(*ptr),
+                majit_metainterp::virtualizable::VableToken::TracingRescall
+            )
+        });
+        let live_frame_armed = match info.read_token(frame.cast()) {
+            majit_metainterp::virtualizable::VableToken::Active(token) => {
+                driver.meta_interp_mut().is_force_token_armed(token)
+            }
+            _ => false,
+        };
+        let mut force = |ptr: *mut u8| {
+            info.force_virtualizable_if_necessary(ptr, |token| {
+                driver.meta_interp_mut().force_virtualizable_token(token);
+            });
+        };
+        if let Some(ptr) = tracing_frame.filter(|ptr| *ptr != frame.cast()) {
+            force(ptr);
+        }
+        if live_frame_armed {
+            force(frame.cast());
+        }
+    }
 }
 
 // dont_look_inside: JIT-driver global accessor (JIT_DRIVER TLS).

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -3461,7 +3461,14 @@ unsafe extern "C" fn force_pyframe(frame: *mut pyre_interpreter::PyFrame) {
                 driver.meta_interp_mut().force_virtualizable_token(token);
             });
         };
-        if let Some(ptr) = tracing_frame.filter(|ptr| *ptr != frame.cast()) {
+        // Force the traced frame even when it IS the escaping one: clearing
+        // TOKEN_TRACING_RESCALL is what `tracing_after_residual_call` reads as
+        // "the callee forced the virtualizable", which raises
+        // `VableEscapedDuringResidualCall` and lets the walk resume forward
+        // from the pc `flush_active_frame_escape` just committed.  Skipping it
+        // would leave the walk tracing against a shadow whose frame has already
+        // been handed to Python code.
+        if let Some(ptr) = tracing_frame {
             force(ptr);
         }
         if live_frame_armed {

--- a/pyre/pyre-jit/src/jit/assembler.rs
+++ b/pyre/pyre-jit/src/jit/assembler.rs
@@ -2068,7 +2068,18 @@ fn expect_list_regs_or_pool(state: &mut AssemblyState, op: &Operand, expected: K
                      got {other:?}"
                 ),
             };
-            u8::try_from(reg_idx).expect("register index exceeds u8")
+            // A pool-backed index (`num_regs_kind + pool_idx`) can exceed a
+            // single operand byte even though `num_regs_kind` itself stays
+            // under the ceiling.  Latch the builder's overflow flag and emit a
+            // placeholder rather than panicking; `try_finish` then declines the
+            // JitCode and the interpreter keeps running the trace's function.
+            match u8::try_from(reg_idx) {
+                Ok(byte) => byte,
+                Err(_) => {
+                    state.builder.note_encoding_overflow();
+                    0
+                }
+            }
         })
         .collect()
 }


### PR DESCRIPTION
Three JIT correctness fixes. `pyre/check.py` is green on all three backends: **dynasm 241/241, cranelift 241/241, wasm 240/240**.

## 1–2. Orthodox list-append fold: local decline instead of a whole-trace abort

Fixes the wasm-only `synth/delete_negative_open_slice_hot` failure (`242980541` → **`242981142`**, the oracle value).

The orthodox `w_list_append` sub-walk descends the compiled body. When it reached a residual call whose funcbox is a symbolic fnaddr, `try_execute_residual_call_via_executor` returned `OrthodoxSubWalkTraceUnsupported`, which propagated out and aborted the **whole enclosing trace** — 5 aborts, `loops_compiled=0`. One of those aborts had its in-flight FOR_ITER delivery refused (a body effect had committed since the consume), falling back to the legacy drop-on-abort and losing exactly one loop iteration.

The aborting helper was identified by instrumenting the symbolic-fnaddr minting functions: it is `Method { name: "object_push", receiver_root: Some("W_ListObject") }`, **not** the `ListStrategy::Object` unit-variant constructor the surrounding comment predicted (that one is also symbolic but hashes differently and is never the one hit). Since it is an unresolved method rather than a unit enum-variant constructor, lowering unit-variant ctors at build time would not have removed it.

Both fold forms now take a trace position before the tentative commit and, on that error, cut the trace back, reset the heap cache and bool-box truth state, undo an Empty-to-typed promotion when the commit performed one, and fall through to the generic residual append. `get_trace_position`/`cut_trace` already existed in `history.rs`.

This is sound because the concrete `w_list_append` runs only *after* a successful sub-walk, so the rollback path leaves the list untouched and the residual applies the append exactly once. It also keeps the orthodox-append optimization on every target where the sub-walk succeeds — a blanket "decline if the body has any symbolic constant" would have disabled it everywhere.

## 3. Force the virtualizable when a frame escapes the execution-context chain

Fixes stale frame state under JIT.

In PyPy, `ExecutionContext.topframeref` is a `jit.virtual_ref`, so every read forces the vref and writes the virtualizable back. In pyre it is a raw `PyFrame` pointer with no force point, so a frame handed to Python from inside a compiled loop still carried its locals and `last_instr` in JIT registers.

```python
for i in range(2000):
    fr = sys._getframe()
    fr.f_locals['i']   # disagreed with the running `i` on 1799 iterations
    fr.f_lineno        # reported the loop header line, not the current line
```

| | `f_locals` mismatches | `f_lineno` |
|---|---|---|
| CPython | 0 | `{5: 2000}` |
| pyre `PYRE_NO_JIT=1` | 0 | `{5: 2000}` |
| pyre JIT (before) | **1799** | `{5: 201, 4: 1799}` |
| pyre JIT (after) | **0** | `{5: 2000}` |

A force hook on `ExecutionContext` is registered by `pyre-jit` and called from `gettopframe`, `gettopframe_nohidden` and `getnextframe_nohidden`, so this covers `f_back` walks and traceback construction too, not just `sys._getframe`. Internal callers that only need the caller frame pointer keep a non-forcing `gettopframe_raw`.

`force_virtualizable_if_necessary` already no-ops without an attached token, and the live-frame path additionally requires the backend to report the token armed, so frames outside a call bracket are untouched.

### Known limitations

- `is_force_token_armed` is implemented for dynasm and cranelift. The **wasm** backend keeps the default `false`, so it retains the previous behavior there (no regression, but the frame-escape staleness is not yet fixed on wasm).
- `f_lineno` is now near-exact but not perfect: in a loop body with a preceding statement, ~1% of iterations still report the previous line (a deterministic `last_instr` publication-granularity effect, since `last_instr` is published at resume points rather than per opcode). This is a large improvement over reporting the loop header, but not full parity.

## Note on a related latent gap (deliberately not changed)

The FOR_ITER resume-past-abort gap — Option C refusing delivery once an un-journaled body effect has committed — was investigated and left alone. A general forward-flush already exists (`flush_walk_end_state_to_frame`), and the path is unreachable in practice: sweeping all 230 synth benches with `PYRE_FBW_DEBUG_ABORT=1` produced **zero** deliveries and **zero** refusals. Widening the R1 guard is what prevents a silent double-apply, so changing it without a reproducing case would be unverifiable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)