### PR TITLE
gh#346 frontier: unary/compare Result<Option> flip + Vec::index_mut ArrayWrite lift

### DIFF
--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -5634,12 +5634,26 @@ impl<'a> Lowering<'a> {
                 // read collapses to the bound element), and record the
                 // `(base, index)` pair so the paired `*p = v` write
                 // (`arr[i] = v` desugar) emits `ArrayWrite` from the
-                // `emit_projection_write` `Deref` arm.  `Vec<T>::index`
-                // ([`is_vec_index_call`]) lowers identically — the
-                // resized-list indirection is supplied downstream by the
-                // repr-dispatched `getitem`, not here.
+                // `emit_projection_write` `Deref` arm.  `Vec<T>::index` /
+                // `Vec<T>::index_mut` ([`is_vec_index_call`]) lower
+                // identically — the resized-list indirection is supplied
+                // downstream by the repr-dispatched `getitem` / `setitem`,
+                // not here.
+                //
+                // `Vec<T>::index_mut` yields a `&mut T`; binding
+                // `local_var[dest]` to the element value is sound only when
+                // that borrow is consumed by a single in-place deref
+                // (`*p` read or `*p = v` write) and never escapes as a
+                // pointer.  Unlike the `pyre_`-fenced workspace types, std
+                // `Vec::index_mut` matches any `Vec` in the crate, so the
+                // mutable leaf is gated on the [`add_dest_used_only_as_single_deref`]
+                // escape guard (a failing shape stays residual — safe).  The
+                // read leaf (`index`, a value copy) needs no such guard.
                 if args.len() == 2
-                    && (self.is_workspace_index_call(&reg) || self.is_vec_index_call(&reg))
+                    && (self.is_workspace_index_call(&reg)
+                        || (self.is_vec_index_call(&reg)
+                            && (!is_vec_index_mut_regular(&reg, self.llbc)
+                                || add_dest_used_only_as_single_deref(self.body, dest_local))))
                 {
                     let res = self
                         .graph
@@ -7241,47 +7255,20 @@ impl<'a> Lowering<'a> {
         is_workspace_index_regular(reg, self.llbc)
     }
 
-    /// `v[i]` on a `Vec<T>` — its `<Vec<T> as Index>::index` impl,
-    /// returning `&T`.  Unlike the workspace fixed arrays
-    /// ([`is_workspace_index_call`]), the receiver is a resized
-    /// `ListRepr` (`length` + `items` block), so the element load goes
-    /// through the rtyper's `getitem` (`AbstractBaseListRepr.rtype_getitem`,
-    /// which loads the `items` field before indexing).  The caller lowers
-    /// both to the same `ArrayRead`; the flowspace `getitem` it becomes is
-    /// repr-dispatched, so the resized indirection is added by
-    /// `rtype_getitem` rather than the front end.  Owner/leaf are derived
-    /// the same way [`call_target_segments`] derives the call key
-    /// (`impl_method_owner_for_fundecl`), so the match tracks the segment
-    /// spelling (`["vec", "Vec", "index"]`) the generic fallback would
-    /// otherwise leave unregistered.
-    ///
-    /// Restricted to the integer-index impl (`Index<usize>`, the element
-    /// load).  `Vec`'s `Index<Range<…>>` impls share the `index` leaf but
-    /// return a sub-`&[T]` slice, not an element — lowering those to a
-    /// scalar `ArrayRead` would mis-index, so the index type must be an
-    /// integer.  Charon runs `monomorphize:false`, so the `index`
-    /// signature keeps the generic index param `I` (a `TypeVar` typing as
-    /// `Ref`); the concrete index type is the callsite substitution
-    /// `types[1]` of the impl generics `[T, I, A]`.  `Index<usize>` types
-    /// as `Int`; `Index<Range<…>>` resolves to a `Range*` Adt (`Ref`) and
-    /// stays foreign.
+    /// `v[i]` / `v[i] = x` on a `Vec<T>` — its `<Vec<T> as Index>::index`
+    /// (read) or `<Vec<T> as IndexMut>::index_mut` (write) impl.  Unlike
+    /// the workspace fixed arrays ([`is_workspace_index_call`]), the
+    /// receiver is a resized `ListRepr` (`length` + `items` block), so the
+    /// element load goes through the rtyper's `getitem`
+    /// (`AbstractBaseListRepr.rtype_getitem`, which loads the `items` field
+    /// before indexing).  The caller lowers the read to `ArrayRead` and the
+    /// paired `*p = v` write to `ArrayWrite`; the flowspace `getitem` /
+    /// `setitem` they become are repr-dispatched, so the resized
+    /// indirection is added by `rtype_getitem` / `rtype_setitem` rather than
+    /// the front end.  Delegates to the free [`is_vec_index_regular`] so the
+    /// same gate is shared with the deferred-write liveness pre-pass.
     fn is_vec_index_call(&self, reg: &RegularCall) -> bool {
-        let CallKind::Fun(FunId::Regular { id }) = &reg.kind else {
-            return false;
-        };
-        let owner_leaf_ok = self.llbc.fn_by_id(*id).is_some_and(|fd| {
-            impl_method_owner_for_fundecl(self.llbc, fd)
-                .is_some_and(|(owner, leaf)| owner == "vec::Vec" && leaf == "index")
-        });
-        if !owner_leaf_ok {
-            return false;
-        }
-        reg.generics
-            .get("types")
-            .and_then(serde_json::Value::as_array)
-            .and_then(|tys| tys.get(1))
-            .and_then(|t| serde_json::from_value::<TyRef>(t.clone()).ok())
-            .is_some_and(|t| matches!(tyref_to_value_type(&t, self.llbc), ValueType::Int))
+        is_vec_index_regular(reg, self.llbc)
     }
 
     /// `<[T]>::swap(s, a, b)` (`core::slice::<Impl>::swap`) — an
@@ -10007,6 +9994,62 @@ fn is_workspace_index_regular(reg: &RegularCall, llbc: &Llbc) -> bool {
     (leaf == "index" || leaf == "index_mut") && path.starts_with("pyre_")
 }
 
+/// The `Vec<T>` index leaf a statically-resolved [`RegularCall`] resolves
+/// to — `"index"` (`<Vec<T> as Index>::index`, read) or `"index_mut"`
+/// (`<Vec<T> as IndexMut>::index_mut`, write) — restricted to the
+/// integer-index impl.  `Vec`'s `Index<Range<…>>` / `IndexMut<Range<…>>`
+/// impls share the same leaf but return a sub-`&[T]` slice, not an element;
+/// lowering those to a scalar `ArrayRead` / `ArrayWrite` would mis-index,
+/// so the index type must be an integer.  Charon runs `monomorphize:false`,
+/// so the signature keeps the generic index param `I` (a `TypeVar` typing
+/// as `Ref`); the concrete index type is the callsite substitution
+/// `types[1]` of the impl generics `[T, I, A]`.  `Index<usize>` types as
+/// `Int`; `Index<Range<…>>` resolves to a `Range*` Adt (`Ref`) and returns
+/// `None`.  Owner/leaf are derived the same way [`call_target_segments`]
+/// derives the call key (`impl_method_owner_for_fundecl`).  Free so the
+/// same gate is shared by the call-lowering intercept and the deferred-write
+/// liveness pre-pass.
+fn vec_index_regular_leaf(reg: &RegularCall, llbc: &Llbc) -> Option<&'static str> {
+    let CallKind::Fun(FunId::Regular { id }) = &reg.kind else {
+        return None;
+    };
+    let leaf = llbc.fn_by_id(*id).and_then(|fd| {
+        impl_method_owner_for_fundecl(llbc, fd).and_then(|(owner, leaf)| {
+            if owner != "vec::Vec" {
+                return None;
+            }
+            match leaf.as_str() {
+                "index" => Some("index"),
+                "index_mut" => Some("index_mut"),
+                _ => None,
+            }
+        })
+    })?;
+    let int_indexed = reg
+        .generics
+        .get("types")
+        .and_then(serde_json::Value::as_array)
+        .and_then(|tys| tys.get(1))
+        .and_then(|t| serde_json::from_value::<TyRef>(t.clone()).ok())
+        .is_some_and(|t| matches!(tyref_to_value_type(&t, llbc), ValueType::Int));
+    int_indexed.then_some(leaf)
+}
+
+/// Whether a [`RegularCall`] is a `Vec<T>` `index` **or** `index_mut` on an
+/// integer index (see [`vec_index_regular_leaf`]).
+fn is_vec_index_regular(reg: &RegularCall, llbc: &Llbc) -> bool {
+    vec_index_regular_leaf(reg, llbc).is_some()
+}
+
+/// Whether a [`RegularCall`] is specifically a `Vec<T>::index_mut` on an
+/// integer index — the write half, which yields a `&mut T` and so must pass
+/// the single-deref escape guard before it may be devirtualized to an
+/// `ArrayWrite` (the read leaf `index` yields a value copy and needs no
+/// guard).
+fn is_vec_index_mut_regular(reg: &RegularCall, llbc: &Llbc) -> bool {
+    vec_index_regular_leaf(reg, llbc) == Some("index_mut")
+}
+
 /// Whether a statically-resolved [`RegularCall`] is `<*mut T>::add` /
 /// `<*const T>::add` (`core::ptr::{mut_ptr,const_ptr}::<Impl>::add`) —
 /// the only `.add` spellings the items-base accessor collapse
@@ -10349,11 +10392,17 @@ fn compute_index_write_extra_live(body: &Unstructured, llbc: &Llbc) -> Vec<Vec<u
         let PlaceKind::Local(p) = call.dest.kind else {
             continue;
         };
-        // Both the workspace `index_mut` call and brick 3's
-        // `*base.add(idx)` defer their `*p = v` write to a later block,
-        // where the base / index operands are no longer spelled (the
-        // `ArrayWrite` is synthesised by `emit_projection_write`).
+        // The workspace `index_mut` call, `Vec<T>::index_mut`, and brick
+        // 3's `*base.add(idx)` all defer their `*p = v` write to a later
+        // block, where the base / index operands are no longer spelled (the
+        // `ArrayWrite` is synthesised by `emit_projection_write`).  The Vec
+        // arm must be gated on the identical escape guard the intercept
+        // applies, so the two stay in lockstep — threading a live-set entry
+        // for a write the intercept declined to lift would leave the base
+        // undefined.
         let is_deferred_write_producer = is_workspace_index_regular(reg, llbc)
+            || (is_vec_index_mut_regular(reg, llbc)
+                && add_dest_used_only_as_single_deref(body, p as usize))
             || is_list_items_elem_ptr_add_parts(
                 reg,
                 call.args.len(),
@@ -17665,6 +17714,52 @@ mod tests {
         assert_eq!(
             branch_calls, 0,
             "lookup: residual Try::branch Method-call after the recast-break-arm fold"
+        );
+    }
+
+    /// Real-LLBC anchor for the `Vec<T>::index_mut` write-lift: the
+    /// arg-fill path `fill_user_function_args` writes its `filled_args`
+    /// slots via `Vec::index_mut`; after the fold there must be no residual
+    /// `["vec","Vec","index_mut"]` call and at least one native `ArrayWrite`
+    /// (setarrayitem).  `#[ignore]`d (loads the ~440MB real LLBC); run with
+    /// `cargo test -p majit-translate --lib vec_index_mut_fill_user_function_args_real
+    /// -- --ignored`.
+    #[test]
+    #[ignore]
+    fn vec_index_mut_fill_user_function_args_real() {
+        use crate::model::{CallTarget, OpKind};
+        let path = concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../build/llbc/pyre-interpreter.ullbc"
+        );
+        let llbc = Llbc::load(path).expect("load real LLBC");
+        let graph = super::lower_function(&llbc, "fill_user_function_args")
+            .expect("lower fill_user_function_args");
+        let residual = graph
+            .blocks
+            .iter()
+            .flat_map(|b| b.operations.iter())
+            .filter(|op| {
+                matches!(
+                    &op.kind,
+                    OpKind::Call { target: CallTarget::FunctionPath { segments }, .. }
+                        if super::fmt_path_ends_with(segments, &["vec", "Vec", "index_mut"])
+                )
+            })
+            .count();
+        assert_eq!(
+            residual, 0,
+            "fill_user_function_args: residual vec::Vec::index_mut after the write-lift"
+        );
+        let array_writes = graph
+            .blocks
+            .iter()
+            .flat_map(|b| b.operations.iter())
+            .filter(|op| matches!(&op.kind, OpKind::ArrayWrite { .. }))
+            .count();
+        assert!(
+            array_writes >= 1,
+            "fill_user_function_args: expected at least one native ArrayWrite (setarrayitem)"
         );
     }
 }

--- a/pyre/pyre-interpreter/src/objspace/descroperation.rs
+++ b/pyre/pyre-interpreter/src/objspace/descroperation.rs
@@ -1753,7 +1753,11 @@ unsafe fn issubtype_cached(w_type: PyObjectRef, cls: PyObjectRef) -> bool {
 /// raises); `None` when neither side overrides — or every override returned
 /// `NotImplemented` — so the caller falls through to the by-layout fast paths
 /// / identity tail.
-unsafe fn try_compare_override(a: PyObjectRef, b: PyObjectRef, op: CompareOp) -> Option<PyResult> {
+unsafe fn try_compare_override(
+    a: PyObjectRef,
+    b: PyObjectRef,
+    op: CompareOp,
+) -> Result<Option<PyObjectRef>, PyError> {
     let dunder = match op {
         CompareOp::Lt => "__lt__",
         CompareOp::Le => "__le__",
@@ -1766,7 +1770,7 @@ unsafe fn try_compare_override(a: PyObjectRef, b: PyObjectRef, op: CompareOp) ->
     let a_ov = crate::baseobjspace::subclass_special_override(a, dunder);
     let b_ov = crate::baseobjspace::subclass_special_override(b, rdunder);
     if a_ov.is_none() && b_ov.is_none() {
-        return None;
+        return Ok(None);
     }
     // Python's "subclass reflected op takes priority": if `b`'s type is a
     // proper subclass of `a`'s type and `b` overrides the reflected op, run it
@@ -1783,14 +1787,13 @@ unsafe fn try_compare_override(a: PyObjectRef, b: PyObjectRef, op: CompareOp) ->
     };
     for (ov, recv, other) in order {
         if let Some((method, w_type)) = ov {
-            match crate::baseobjspace::get_and_call_function(method, recv, w_type, &[other]) {
-                Ok(result) if !is_not_implemented(result) => return Some(Ok(result)),
-                Ok(_) => {}
-                Err(e) => return Some(Err(e)),
+            let result = crate::baseobjspace::get_and_call_function(method, recv, w_type, &[other])?;
+            if !is_not_implemented(result) {
+                return Ok(Some(result));
             }
         }
     }
-    None
+    Ok(None)
 }
 
 /// Map forward dunder to reverse dunder.
@@ -1827,13 +1830,16 @@ fn reverse_dunder(dunder: &str) -> Option<&'static str> {
 /// PyPy: `ObjSpace.call_function(space.lookup(w_obj, dunder), w_obj)`
 /// The Python-level OperationError must propagate to the caller; use the
 /// Result-returning call path so PENDING_CALL_ERROR is consumed.
-unsafe fn try_instance_unaryop(a: PyObjectRef, dunder: &str) -> Option<PyResult> {
+unsafe fn try_instance_unaryop(
+    a: PyObjectRef,
+    dunder: &str,
+) -> Result<Option<PyObjectRef>, PyError> {
     if is_instance(a) {
         if let Some(method) = lookup(a, dunder) {
-            return Some(crate::call::call_function_impl_result(method, &[a]));
+            return Ok(Some(crate::call::call_function_impl_result(method, &[a])?));
         }
     }
-    None
+    Ok(None)
 }
 
 /// True when `obj`'s type defines `dunder` in a class other than the
@@ -2015,13 +2021,20 @@ unsafe fn needs_numeric_unaryop_dispatch(a: PyObjectRef, dunder: &str) -> bool {
 /// Call the overriding unary special on a numeric subclass operand before
 /// the Rust fast path.  Returns `None` when `a` is an exact builtin
 /// numeric or does not override `dunder`, so the caller falls through.
-unsafe fn try_numeric_unaryop_override(a: PyObjectRef, dunder: &str) -> Option<PyResult> {
+unsafe fn try_numeric_unaryop_override(
+    a: PyObjectRef,
+    dunder: &str,
+) -> Result<Option<PyObjectRef>, PyError> {
     if !needs_numeric_unaryop_dispatch(a, dunder) {
-        return None;
+        return Ok(None);
     }
-    let t = crate::typedef::r#type(a)?;
-    let method = lookup_in_type_where(t, dunder)?;
-    Some(crate::call::call_function_impl_result(method, &[a]))
+    let Some(t) = crate::typedef::r#type(a) else {
+        return Ok(None);
+    };
+    let Some(method) = lookup_in_type_where(t, dunder) else {
+        return Ok(None);
+    };
+    Ok(Some(crate::call::call_function_impl_result(method, &[a])?))
 }
 
 pub fn add(a: PyObjectRef, b: PyObjectRef) -> PyResult {
@@ -3335,8 +3348,8 @@ pub fn compare(a: PyObjectRef, b: PyObjectRef, op: CompareOp) -> PyResult {
     // non-overriding subclasses fall through to the by-layout comparison slot,
     // which gives the inherited builtin comparison.
     unsafe {
-        if let Some(result) = try_compare_override(a, b, op) {
-            return result;
+        if let Some(result) = try_compare_override(a, b, op)? {
+            return Ok(result);
         }
     }
     compare_slot(a, b, op)
@@ -3698,8 +3711,8 @@ impl CompareOp {
 
 pub fn pos(a: PyObjectRef) -> PyResult {
     unsafe {
-        if let Some(result) = try_numeric_unaryop_override(a, "__pos__") {
-            return result;
+        if let Some(result) = try_numeric_unaryop_override(a, "__pos__")? {
+            return Ok(result);
         }
         if is_int(a) || is_bool(a) {
             return Ok(w_int_new(int_value(a)));
@@ -3714,8 +3727,8 @@ pub fn pos(a: PyObjectRef) -> PyResult {
             let (ar, ai) = complex_val(a).unwrap();
             return Ok(w_complex_new(ar, ai));
         }
-        if let Some(result) = try_instance_unaryop(a, "__pos__") {
-            return result;
+        if let Some(result) = try_instance_unaryop(a, "__pos__")? {
+            return Ok(result);
         }
         if a.is_null() {
             return Err(PyError::type_error(
@@ -3733,8 +3746,8 @@ pub fn pos(a: PyObjectRef) -> PyResult {
 
 pub fn neg(a: PyObjectRef) -> PyResult {
     unsafe {
-        if let Some(result) = try_numeric_unaryop_override(a, "__neg__") {
-            return result;
+        if let Some(result) = try_numeric_unaryop_override(a, "__neg__")? {
+            return Ok(result);
         }
         if is_int(a) || is_bool(a) {
             let v = int_value(a);
@@ -3753,8 +3766,8 @@ pub fn neg(a: PyObjectRef) -> PyResult {
             return complex_neg(a);
         }
         // Instance __neg__
-        if let Some(result) = try_instance_unaryop(a, "__neg__") {
-            return result;
+        if let Some(result) = try_instance_unaryop(a, "__neg__")? {
+            return Ok(result);
         }
         if a.is_null() {
             return Err(PyError::type_error(
@@ -3772,8 +3785,8 @@ pub fn neg(a: PyObjectRef) -> PyResult {
 
 pub fn invert(a: PyObjectRef) -> PyResult {
     unsafe {
-        if let Some(result) = try_numeric_unaryop_override(a, "__invert__") {
-            return result;
+        if let Some(result) = try_numeric_unaryop_override(a, "__invert__")? {
+            return Ok(result);
         }
         if is_int(a) || is_bool(a) {
             return Ok(w_int_new(!int_value(a)));
@@ -3781,8 +3794,8 @@ pub fn invert(a: PyObjectRef) -> PyResult {
         if is_long(a) {
             return Ok(bigint_result(bigint_invert(w_long_get_value(a).clone())));
         }
-        if let Some(result) = try_instance_unaryop(a, "__invert__") {
-            return result;
+        if let Some(result) = try_instance_unaryop(a, "__invert__")? {
+            return Ok(result);
         }
         Err(PyError::type_error(format!(
             "unsupported operand type for unary ~: '{}'",

--- a/pyre/pyre-interpreter/src/objspace/descroperation.rs
+++ b/pyre/pyre-interpreter/src/objspace/descroperation.rs
@@ -1787,7 +1787,8 @@ unsafe fn try_compare_override(
     };
     for (ov, recv, other) in order {
         if let Some((method, w_type)) = ov {
-            let result = crate::baseobjspace::get_and_call_function(method, recv, w_type, &[other])?;
+            let result =
+                crate::baseobjspace::get_and_call_function(method, recv, w_type, &[other])?;
             if !is_not_implemented(result) {
                 return Ok(Some(result));
             }


### PR DESCRIPTION
Two gh#346 "rtyper legacy retirement" frontier slices — both reduce "PREPASS phaseA fail" census walls via orthodox, fail-safe changes.

## Commit 1 — descroperation: unary/compare override helpers → `Result<Option<PyObjectRef>, PyError>`

`try_numeric_unaryop_override`, `try_instance_unaryop`, `try_compare_override` returned
`Option<PyResult>` (= `Option<Result<*mut PyObject, PyError>>`), an inline `Result` whose `Err` arm
is the multi-word `PyError`. The prepass lowers the caller's `if let Some(result) = f()` to a
`Some.__pos_0` field read the annotator can't resolve (multi-word ADTs wildcard to one `Ref` word),
walling the whole unary-op dispatch chain on `getattr(__pos_0)`.

Returning `Result<Option<PyObjectRef>, PyError>` sends the error via `?` (layout-erased) and makes
the Ok payload `Option<*mut PyObject>` — a single GC word the existing option-residual-narrow path
lifts. Matches the sibling binop `try_dispatch_binary_special` and `descroperation.py`
`_make_unaryop_impl`. Eliminates the multi-word `__pos_0`/`__iter__`/`from_exc_object` walls across
the 10-head unary chain.

## Commit 2 — jit: lift `Vec<T>::index_mut` to `ArrayWrite` in the frontend index intercept

The frontend already devirtualizes `Vec<T>::index` (read) to `ArrayRead` + records the alias so a
paired `*p = v` becomes `ArrayWrite`. The `index_mut` leaf was unrecognized, so `v[i] = x`
residualized `["vec","Vec","index_mut"]` — an unregistered wall on the arg-fill path and from
`w_bytearray_setitem`. Widen the gate (extracted `vec_index_regular_leaf`, Int-index Range-excluded)
and the deferred-write liveness pre-pass to recognize `index_mut`, both gated on the existing
`add_dest_used_only_as_single_deref` escape guard (mutable leaf only — the read leaf's value copy
stays ungated). Mirrors RPython `rtype_setitem`/`ll_setitem_fast`.

## Verification
- Bit-exact vs python3.14 across unary/compare override paths and the arg-fill/bytearray write paths.
- `check.py`: dynasm 241/241, cranelift 241/241, wasm 239/240 (sole wasm fail = pre-existing
  `delete_negative_open_slice_hot`, unrelated list-slice-deletion — both native backends fully green
  on the hot arg-fill path, and a backend-agnostic frontend change cannot cause a wasm-only regression).
- Census (fresh LLBC): the unary flip eliminates the multi-word `__pos_0` walls across the unary
  chain; the index_mut lift takes the fresh census 288 → 285 (retiring `w_bytearray_setitem` +
  two downstream set heads). The slice sibling `[T]::index_mut` behind `w_list_setitem` is a distinct
  `core::slice` owner, out of scope — those move to that wall rather than retire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)