### PR TITLE
jit: fuse jd1 _unpackiterable_unknown_length drain-match into an exception-edge handler

### DIFF
--- a/majit/majit-metainterp/src/history.rs
+++ b/majit/majit-metainterp/src/history.rs
@@ -2382,10 +2382,6 @@ impl TraceCtx {
             frames: recorder_frames,
             vable_boxes: vable_boxes.to_vec(),
             vref_boxes: vref_boxes.to_vec(),
-            // The nested-list append fold resumes through the single-frame
-            // collapse, never this multi-frame path, so no extra virtual roots
-            // flow here.
-            extra_virtual_roots: Vec::new(),
         });
         self.set_last_guard_op_resume_position(snapshot_id);
     }

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -2544,6 +2544,30 @@ impl<M: Clone> MetaInterp<M> {
         staticdata.liveness_info = all_liveness.to_vec();
     }
 
+    /// Parts form of [`install_canonical_liveness`](Self::install_canonical_liveness)
+    /// for a driver whose jitcode carries build-time-baked `BC_LIVE`
+    /// offsets rather than a runtime-encoded `Assembler`.
+    ///
+    /// Installs the opcode-id table (`setup_insns` → `op_live`) and the
+    /// pre-built `all_liveness` byte stream directly, mirroring the
+    /// asm-derived slice of `finish_setup(codewriter)` (`setup_insns(asm.insns)`
+    /// at `pyjitpl.py:2260` + `liveness_info = "".join(asm.all_liveness)` at
+    /// `pyjitpl.py:2264`).  The same single-owner `Arc::get_mut` invariant
+    /// applies — call before any tracing path clones `staticdata`.
+    pub fn install_liveness_from_build_parts(
+        &mut self,
+        insns: &indexmap::IndexMap<String, u8>,
+        all_liveness: &[u8],
+    ) {
+        let staticdata = std::sync::Arc::get_mut(&mut self.staticdata).expect(
+            "MetaInterp::install_liveness_from_build_parts called after `staticdata` was \
+             cloned; RPython warmspot.py:289 invariant requires a single owner at \
+             finish_setup time",
+        );
+        staticdata.setup_insns(insns);
+        staticdata.liveness_info = all_liveness.to_vec();
+    }
+
     /// Install a fresh [`ActiveTraceSession`] seeded with the frontend
     /// trace metadata.  Called from `force_start_tracing` /
     /// `bound_reached` / `on_back_edge_typed` and the bridge-resume

--- a/majit/majit-metainterp/src/pyjitpl/dispatch.rs
+++ b/majit/majit-metainterp/src/pyjitpl/dispatch.rs
@@ -3098,6 +3098,42 @@ where
                     Some(Value::Float(f64::from_bits(concrete as u64))),
                 );
             }
+            // ── BC_ARRAYLEN_GC ──
+            //
+            // RPython parity: pyjitpl.py:754-763 `opimpl_arraylen_gc`
+            // (`execute_with_descr(rop.ARRAYLEN_GC, arraydescr, arraybox)`) and
+            // blackhole.py:1370 `bhimpl_arraylen_gc(cpu, r, d) -> i`.
+            //
+            // Encoding (`arraylen_gc/rd>i`): [array_reg u8][descr_idx u16][dst u8].
+            // Reads the GC array's length word at the descr's lendescr offset
+            // (`bh_arraylen_gc`: `sizeof(usize)` signed load), records
+            // `OpCode::ArraylenGc` so the optimizer can narrow the lenbound /
+            // virtualize, and stamps the result register with the concrete
+            // length.  Aborts (fail-loud) if the descr does not resolve to an
+            // array descr in the canonical pool.
+            jitcode::insns::BC_ARRAYLEN_GC => {
+                let (array_reg, descr_idx, dst) = {
+                    let frame = self.frames.current_mut();
+                    let array_reg = frame.next_u8() as usize;
+                    let descr_idx = frame.next_u16() as usize;
+                    let dst = frame.next_u8() as usize;
+                    (array_reg, descr_idx, dst)
+                };
+                let Some(descr) = self.dispatch_array_descr_ref(ctx, descr_idx) else {
+                    return TraceAction::Abort;
+                };
+                let (array_opref, array_addr) = self.read_ref_reg(array_reg);
+                // Concrete length via the lendescr (`bh_arraylen_gc`); `None`
+                // when the cpu is unwired or the descr lacks a lendescr, in
+                // which case the recorded op is left unstamped.
+                let concrete = ctx.arraylen_sanity_load(array_addr, &descr);
+                let reg_concrete = match &concrete {
+                    Some(majit_ir::Value::Int(n)) => Some(*n),
+                    _ => None,
+                };
+                let opref = ctx.opimpl_arraylen_gc(array_opref, descr, concrete);
+                self.set_int_reg(dst, Some(opref), reg_concrete);
+            }
             // ── BC_GETARRAYITEM_GC_I ──
             //
             // RPython parity: pyjitpl.py:1183-1199 `_opimpl_getarrayitem_gc_any`:

--- a/majit/majit-metainterp/src/trace_ctx.rs
+++ b/majit/majit-metainterp/src/trace_ctx.rs
@@ -3704,6 +3704,45 @@ impl TraceCtx {
         true
     }
 
+    /// pyjitpl.py:754-763 `opimpl_arraylen_gc(arraybox, arraydescr)`.
+    ///
+    /// ```text
+    ///  def opimpl_arraylen_gc(self, arraybox, arraydescr):
+    ///      lengthbox = self.metainterp.heapcache.arraylen(arraybox)
+    ///      if lengthbox is None:
+    ///          lengthbox = self.execute_with_descr(rop.ARRAYLEN_GC,
+    ///                                              arraydescr, arraybox)
+    ///          self.metainterp.heapcache.arraylen_now_known(arraybox, lengthbox)
+    ///      else:
+    ///          self.metainterp.staticdata.profiler.count_ops(
+    ///              rop.ARRAYLEN_GC, Counters.HEAPCACHED_OPS)
+    ///      return lengthbox
+    /// ```
+    ///
+    /// `concrete` is the runtime length the `execute_with_descr` box carries
+    /// (`arraylen_sanity_load`); `None` leaves the recorded OpRef unstamped
+    /// (the cpu is unwired or the descr lacks a lendescr).
+    pub fn opimpl_arraylen_gc(
+        &mut self,
+        array_opref: OpRef,
+        arraydescr: DescrRef,
+        concrete: Option<Value>,
+    ) -> OpRef {
+        if let Some(cached_len) = self.heap_cache().arraylen(array_opref) {
+            // pyjitpl.py:763 profiler.count_ops(rop.ARRAYLEN_GC, HEAPCACHED_OPS).
+            self.profiler()
+                .count_ops(OpCode::ArraylenGc, crate::pyjitpl::counters::HEAPCACHED_OPS);
+            return cached_len;
+        }
+        let len = self.record_op_with_descr(OpCode::ArraylenGc, &[array_opref], arraydescr);
+        if let Some(v) = concrete {
+            self.set_opref_concrete(len, v);
+        }
+        // pyjitpl.py:761 heapcache.arraylen_now_known(arraybox, lengthbox).
+        self.heap_cache_mut().arraylen_now_known(array_opref, len);
+        len
+    }
+
     /// pyjitpl.py:1253-1263 `opimpl_arraylen_vable(box, fdescr, adescr, pc)`.
     ///
     /// ```text
@@ -3780,17 +3819,11 @@ impl TraceCtx {
                 self.heapcache_getfield_now_known(vable_opref, f_index, op);
                 op
             };
-            // return self.opimpl_arraylen_gc(arraybox, adescr)
-            if let Some(cached_len) = self.heap_cache().arraylen(array_opref) {
-                // pyjitpl.py:763 profiler.count_ops(rop.ARRAYLEN_GC, HEAPCACHED_OPS).
-                self.profiler()
-                    .count_ops(OpCode::ArraylenGc, crate::pyjitpl::counters::HEAPCACHED_OPS);
-                return cached_len;
-            }
-            let len = self.record_op_with_descr(OpCode::ArraylenGc, &[array_opref], adescr);
-            // pyjitpl.py:761 heapcache.arraylen_now_known(arraybox, lengthbox).
-            self.heap_cache_mut().arraylen_now_known(array_opref, len);
-            return len;
+            // return self.opimpl_arraylen_gc(arraybox, adescr) — the
+            // nonstandard-virtualizable fallback reads the length through the GC
+            // array; no runtime concrete to stamp here (the vable read supplies
+            // the length on the standard path below).
+            return self.opimpl_arraylen_gc(array_opref, adescr, None);
         }
         // arrayindex = vinfo.array_field_by_descrs[fdescr]
         // result = vinfo.get_array_length(virtualizable, arrayindex)

--- a/majit/majit-trace/src/logger.rs
+++ b/majit/majit-trace/src/logger.rs
@@ -183,8 +183,11 @@ impl Logger {
     pub fn summary(&self) -> String {
         let total_before = self.total_ops_before();
         let total_after = self.total_ops_after();
+        // Signed in f64: optimization can raise the op count (guards/spills), so
+        // `total_after > total_before` is a legitimate negative reduction, not an
+        // unsigned-subtraction underflow.
         let reduction_pct = if total_before > 0 {
-            ((total_before - total_after) as f64 / total_before as f64) * 100.0
+            (total_before as f64 - total_after as f64) / total_before as f64 * 100.0
         } else {
             0.0
         };

--- a/majit/majit-translate/src/codegen.rs
+++ b/majit/majit-translate/src/codegen.rs
@@ -174,6 +174,7 @@ mod tests {
             jitcodes_by_path: indexmap::IndexMap::new(),
             insns: indexmap::IndexMap::new(),
             descrs: Vec::new(),
+            all_liveness: Vec::new(),
             total_blocks: 0,
             total_ops: 0,
             total_vable_rewrites: 0,

--- a/majit/majit-translate/src/front/iter_next.rs
+++ b/majit/majit-translate/src/front/iter_next.rs
@@ -168,7 +168,7 @@ fn originates_from_iter_op(graph: &FunctionGraph, var: &Variable) -> bool {
 /// prunable along its whole forward chain; removing a never-read inputarg
 /// slot drops only dead arguments from each predecessor link (the values
 /// stay defined and used wherever else they are live).
-fn collect_transitive_dead_slots(
+pub(crate) fn collect_transitive_dead_slots(
     graph: &FunctionGraph,
     start_block: usize,
     start_slot: usize,

--- a/majit/majit-translate/src/front/result_exc.rs
+++ b/majit/majit-translate/src/front/result_exc.rs
@@ -931,6 +931,12 @@ pub(crate) struct RewireOutcome {
     /// value-encoded `Result` the untouched downstream `match` keeps
     /// consuming.
     pub rewrapped: usize,
+    /// Drain-loop `match next()` sites fused by [`try_fuse_drain_match`]
+    /// into an exception-edge handler with a guest-KIND test, eliminating
+    /// the `Result` shell's `Ok`/`StopIteration` ctors + `PyErrorKind::eq`
+    /// residuals.  Counted separately from `rewrapped` and independent of
+    /// `tail_forwards` (which feeds `lower_result_exc_returns`).
+    pub fused: usize,
 }
 
 /// Per-site disposition for [`rewire_one_call_site`].
@@ -938,6 +944,7 @@ enum SiteOutcome {
     Diamond,
     TailForward,
     Rewrapped,
+    Fused,
 }
 
 /// Caller rule.  `results` are the result `Variable`s of calls to
@@ -954,12 +961,14 @@ pub(crate) fn rewire_result_exc_call_sites(
         diamonds: 0,
         tail_forwards: 0,
         rewrapped: 0,
+        fused: 0,
     };
     for (r, suffix) in results {
         match rewire_one_call_site(graph, r, suffix.as_deref().unwrap_or(""), enclosing_scoped)? {
             SiteOutcome::Diamond => outcome.diamonds += 1,
             SiteOutcome::TailForward => outcome.tail_forwards += 1,
             SiteOutcome::Rewrapped => outcome.rewrapped += 1,
+            SiteOutcome::Fused => outcome.fused += 1,
         }
     }
     Ok(outcome)
@@ -1004,6 +1013,17 @@ fn rewire_one_call_site(
         )
     });
     let Some(branch_op_idx) = branch_op_idx else {
+        // No `Result::branch` op → a hand-written `match` consumer.  The
+        // drain-loop `match next()` fusion recognises its exact shape and
+        // rewrites it into an exception-edge handler with a guest-KIND test;
+        // every other custom-match shape (and the drain shape when any
+        // hazard guard trips) falls through to `catch_and_rewrap`.  The
+        // fusion is fail-safe: an `Err` from `try_fuse_drain_match` MUST NOT
+        // propagate (that would decline the whole graph); it converts here
+        // into the existing rewrap path.
+        if try_fuse_drain_match(graph, a, r).is_ok() {
+            return Ok(SiteOutcome::Fused);
+        }
         catch_and_rewrap(graph, a, r, suffix)?;
         return Ok(SiteOutcome::Rewrapped);
     };
@@ -1312,6 +1332,736 @@ fn catch_and_rewrap(
         Some(ExitSwitch::LastException),
         vec![Link::new_mixed(value_args, n_id, None), exc_link],
     );
+    Ok(())
+}
+
+/// True iff `owner` names a `Result<T, PyError>` — the discriminant read's
+/// field owner for the drain loop's `next()` result (`result::Result<*mut
+/// PyObject,PyError>`).  Matched structurally (any `T` instantiation) so
+/// the recognizer keys on the exception carrier, not the payload type.
+fn owner_is_result_of_pyerror(owner: &str) -> bool {
+    owner.contains("Result<") && owner.ends_with(",PyError>")
+}
+
+/// True iff `owner` is the short `Result::Ok` / `Result::Err` variant owner
+/// a `__pos_0` payload read carries (`variant` = "Ok" / "Err").  Requires
+/// the `Result` qualifier so a `ControlFlow::Continue`/`Break` (the `?`
+/// diamond's ADT) is never mistaken for a `Result` arm.
+fn owner_is_result_variant(owner: &str, variant: &str) -> bool {
+    owner.contains("Result") && owner.ends_with(format!("::{variant}").as_str())
+}
+
+/// Follow `var` across one `link` (from `link`'s source block into
+/// `link.target`): the position `var` occupies among the link's `Value`
+/// args maps to `link.target`'s inputarg at that position.  `None` when the
+/// link does not carry `var` or the target lacks that inputarg slot — the
+/// single-successor alias hop the framestate-threaded lowering installs
+/// (a value binds to a fresh inputarg name per block).
+fn forward_alias(graph: &FunctionGraph, var: &Variable, link: &Link) -> Option<Variable> {
+    let pos = link
+        .args
+        .iter()
+        .position(|a| matches!(a, LinkArg::Value(v) if v == var))?;
+    graph.blocks[link.target.0].inputargs.get(pos).cloned()
+}
+
+/// The reraise (`else`) arm must be exactly `return Err(e)` reusing the
+/// payload `e` the Err arm already bound via `__pos_0[Result::Err]` — the
+/// RPython handler form `except OperationError as e: … raise` where `e` is
+/// bound once and consumed only on the re-raise path (NOT a fresh re-read in
+/// this block).  `e_payload` is that already-bound payload traced through the
+/// bool-switch and reraise links into this block; the block must build an
+/// `Err` shell, write `e_payload` into it, forward to the return block, and do
+/// nothing else.  Verifying this licenses block `R`'s `raise vb` substitution:
+/// `to_exc_object(e) == vb` (the caught exception value), so `raise vb`
+/// reproduces `return Err(e)` exactly.  Any extra effect fails loud → decline.
+fn verify_drain_reraise_returns_err_payload(
+    graph: &FunctionGraph,
+    reraise_target: usize,
+    e_payload: &Variable,
+    name: &str,
+) -> Result<(), String> {
+    let ops = &graph.blocks[reraise_target].operations;
+    // `outer = Result::Err()` shell ctor.
+    let ctor = ops.iter().enumerate().find_map(|(i, op)| match &op.kind {
+        OpKind::Call { target, .. } if result_ctor_kind(target) == Some(true) => {
+            op.result.clone().map(|outer| (i, outer))
+        }
+        _ => None,
+    });
+    let Some((ctor_idx, outer)) = ctor else {
+        return Err(format!(
+            "{name}: reraise arm block {reraise_target} lacks the Err shell ctor"
+        ));
+    };
+    // `outer.__pos_0 = e_payload` — the write must consume the exact
+    // already-bound Err payload, not some other value.
+    let write_idx = ops.iter().position(|op| {
+        matches!(
+            &op.kind,
+            OpKind::FieldWrite { base, field, value, .. }
+                if *base == outer
+                    && field.name == "__pos_0"
+                    && matches!(value, LinkArg::Value(v) if v == e_payload)
+        )
+    });
+    let Some(write_idx) = write_idx else {
+        return Err(format!(
+            "{name}: reraise arm block {reraise_target} does not write the already-bound Err payload"
+        ));
+    };
+    // Only these two ops may carry an effect; any other side-effecting op
+    // would be dropped when block `R` replaces this tail.
+    assert_block_pure_besides(
+        graph,
+        reraise_target,
+        &[ctor_idx, write_idx],
+        "reraise",
+        name,
+    )?;
+    // The shell flows to `returnblock` by a STRICT tail forward: block `R`
+    // deletes this whole reraise tail and substitutes an unconditional
+    // `raise vb`, so the arm must be an unconditional `return Err(e)` — a single
+    // exit, no exitswitch, only empty alias-hop blocks en route.  The tolerant
+    // forwarder would license a conditional tail (`if flag { return Err(e) }
+    // else { … }`) whose non-reraise branch the substitution silently drops.
+    if forwards_to_returnblock(graph, reraise_target, &outer) {
+        Ok(())
+    } else {
+        Err(format!(
+            "{name}: reraise arm block {reraise_target} does not forward the Err shell \
+             unconditionally to returnblock"
+        ))
+    }
+}
+
+/// Drain-loop `match next()` fusion — the hand-written `match` at
+/// `_unpackiterable_unknown_length`'s core:
+/// ```text
+///     match next(w_iterator) {
+///         Ok(w_item) => append(items, w_item),
+///         Err(e) if e.kind == PyErrorKind::StopIteration => break,
+///         Err(e) => return Err(e),
+///     }
+/// ```
+/// which lowers to a materialised `Result<*mut PyObject, PyError>` shell:
+/// a `__discriminant` switch whose arms build a `StopIteration`
+/// `SyntheticTransparentCtor`, read `__pos_0[Result::Err]`, and call
+/// `PyErrorKind::eq` — niladic ctors with no host symbol the jd1 walker
+/// SIGBUSes on.  This rewrites the `next()` block into `LastException`
+/// exits (normal → the `Ok` arm; exception → a handler `H`) whose handler
+/// runs the **guest-KIND** test `w_exception_get_kind(evalue) == 10`
+/// (`ExcKind::StopIteration`) — the exact source semantics
+/// `e.kind == PyErrorKind::StopIteration` through the
+/// `ExcKind ↔ PyErrorKind` bijection, NOT an MRO/subclass match.
+///
+/// Fail-safe: returns `Err` on ANY structural mismatch or hazard, and the
+/// caller ([`rewire_one_call_site`]) converts that into `catch_and_rewrap`
+/// — an `Err` must never propagate out (that would decline the whole
+/// graph).  Validate-before-mutate: every precondition and every rewired
+/// link arg is computed before the first graph mutation, so a decline
+/// leaves the graph byte-identical.  Detach-only: the bypassed
+/// discriminant / Err-arm / bool-switch / reraise blocks are left
+/// byte-intact for the post-rewrite `clear_unreachable_blocks` sweep.
+fn try_fuse_drain_match(
+    graph: &mut FunctionGraph,
+    a: usize,
+    r: &Variable,
+) -> Result<(), String> {
+    use crate::flowspace::model::{ConstValue, Constant};
+    use crate::model::{BlockId, ExitCase};
+    let name = graph.name.clone();
+
+    // --- (1) A: `r = next(iter)` is A's last op, closed by lower_call with
+    // a single no-exitcase forwarding exit.
+    let a_ops = &graph.blocks[a].operations;
+    let call_idx = a_ops.len().checked_sub(1).ok_or_else(|| {
+        format!("{name}: drain fuse: call block {a} is empty")
+    })?;
+    if a_ops[call_idx].result.as_ref() != Some(r) {
+        return Err(format!("{name}: drain fuse: next() is not the last op of block {a}"));
+    }
+    if graph.blocks[a].exitswitch.is_some() || graph.blocks[a].exits.len() != 1 {
+        return Err(format!(
+            "{name}: drain fuse: call block {a} is not the single forwarding-exit shape"
+        ));
+    }
+    if graph.blocks[a].exits[0].exitcase.is_some() {
+        return Err(format!("{name}: drain fuse: call block {a} exit carries an exitcase"));
+    }
+
+    // --- (2) A→B single exit; B holds `d = r.__discriminant[Result<..,PyError>]`,
+    // `exitswitch == Value(d)`, pure besides the read, single predecessor.
+    let (b, r_b) =
+        follow_single_exit(graph, a, r).map_err(|e| format!("{name}: drain fuse: {e}"))?;
+    assert_single_pred(graph, b, &name)?;
+    let (disc_idx, disc_var) = graph.blocks[b]
+        .operations
+        .iter()
+        .enumerate()
+        .find_map(|(i, op)| match &op.kind {
+            OpKind::FieldRead { base, field, .. }
+                if *base == r_b
+                    && field.name == "__discriminant"
+                    && field.owner_root.as_deref().is_some_and(owner_is_result_of_pyerror) =>
+            {
+                op.result.clone().map(|d| (i, d))
+            }
+            _ => None,
+        })
+        .ok_or_else(|| format!("{name}: drain fuse: block {b} lacks the Result __discriminant read"))?;
+    match &graph.blocks[b].exitswitch {
+        Some(ExitSwitch::Value(v)) if *v == disc_var => {}
+        other => {
+            return Err(format!(
+                "{name}: drain fuse: block {b} exitswitch {other:?} is not the Result discriminant"
+            ));
+        }
+    }
+    assert_block_pure_besides(graph, b, &[disc_idx], "discriminant", &name)?;
+
+    // --- (3) Split B's diamond; identify Ok/Err arms by the `__pos_0` owner
+    // of the read in each arm's target — NOT by discriminant 0/1.
+    let (case0, case1) = split_diamond_exits(&graph.blocks[b].exits, &name)?;
+    let reads_variant = |target: usize, variant: &str| -> bool {
+        graph.blocks[target].operations.iter().any(|op| {
+            matches!(&op.kind,
+                OpKind::FieldRead { field, .. }
+                    if field.name == "__pos_0"
+                        && field.owner_root.as_deref().is_some_and(|o| owner_is_result_variant(o, variant)))
+        })
+    };
+    let (ok_link, err_link) = if reads_variant(case0.target.0, "Ok")
+        && reads_variant(case1.target.0, "Err")
+    {
+        (case0, case1)
+    } else if reads_variant(case1.target.0, "Ok") && reads_variant(case0.target.0, "Err") {
+        // The Ok arm must be the discriminant-0 case (Result: Ok = 0); an
+        // inverted pairing is an unrecognised shape.
+        return Err(format!(
+            "{name}: drain fuse: Ok/Err arms inverted vs discriminant 0/1"
+        ));
+    } else {
+        return Err(format!(
+            "{name}: drain fuse: block {b} arms are not a Result Ok/Err __pos_0 pair"
+        ));
+    };
+    let ok_target = ok_link.target.0;
+    let err_target = err_link.target.0;
+
+    // --- (4) Ok arm: single predecessor; the `__pos_0[Result::Ok]` read is
+    // collapsed to `r` (the LastException normal edge carries the unwrapped
+    // payload directly).  Record its payload position on the Ok link.
+    assert_single_pred(graph, ok_target, &name)?;
+
+    // --- (5) Err arm: single predecessor, EXACTLY the four guard ops
+    // (StopIteration ctor, Err payload read, kind read, PyErrorKind::eq).
+    assert_single_pred(graph, err_target, &name)?;
+    let r_err = forward_alias(graph, &r_b, &err_link)
+        .ok_or_else(|| format!("{name}: drain fuse: Err link drops the Result value"))?;
+    let err_ops = &graph.blocks[err_target].operations;
+    let ctor_idx = err_ops
+        .iter()
+        .position(|op| matches!(&op.kind,
+            OpKind::Call { target: CallTarget::SyntheticTransparentCtor { name: n, owner_path }, .. }
+                if n == "StopIteration" && owner_path.last().is_some_and(|s| s == "PyErrorKind")))
+        .ok_or_else(|| format!("{name}: drain fuse: Err arm lacks the StopIteration ctor"))?;
+    let sc = err_ops[ctor_idx].result.clone().ok_or_else(|| {
+        format!("{name}: drain fuse: StopIteration ctor without result")
+    })?;
+    let (errpay_idx, err_payload) = err_ops
+        .iter()
+        .enumerate()
+        .find_map(|(i, op)| match &op.kind {
+            OpKind::FieldRead { base, field, .. }
+                if *base == r_err
+                    && field.name == "__pos_0"
+                    && field.owner_root.as_deref().is_some_and(|o| owner_is_result_variant(o, "Err")) =>
+            {
+                op.result.clone().map(|e| (i, e))
+            }
+            _ => None,
+        })
+        .ok_or_else(|| format!("{name}: drain fuse: Err arm lacks the Err __pos_0 read"))?;
+    let (kind_idx, kind_var) = err_ops
+        .iter()
+        .enumerate()
+        .find_map(|(i, op)| match &op.kind {
+            OpKind::FieldRead { base, field, .. }
+                if *base == err_payload
+                    && field.name == "kind"
+                    && field.owner_root.as_deref() == Some("PyError") =>
+            {
+                op.result.clone().map(|k| (i, k))
+            }
+            _ => None,
+        })
+        .ok_or_else(|| format!("{name}: drain fuse: Err arm lacks the PyError.kind read"))?;
+    let (eq_idx, eq_result) = err_ops
+        .iter()
+        .enumerate()
+        .find_map(|(i, op)| match &op.kind {
+            OpKind::Call { target: CallTarget::Method { name: m, receiver_root, .. }, args, .. }
+                if m == "eq"
+                    && receiver_root.as_deref() == Some("PyErrorKind")
+                    && args.len() == 2
+                    && args.contains(&kind_var)
+                    && args.contains(&sc) =>
+            {
+                op.result.clone().map(|m| (i, m))
+            }
+            _ => None,
+        })
+        .ok_or_else(|| format!("{name}: drain fuse: Err arm lacks the PyErrorKind::eq call"))?;
+    // The ctor and eq are Calls (not `is_pure_op`), so they must be among
+    // the recognized indices, not merely tolerated.
+    assert_block_pure_besides(
+        graph,
+        err_target,
+        &[ctor_idx, errpay_idx, kind_idx, eq_idx],
+        "Err arm",
+        &name,
+    )?;
+
+    // --- (6) Err arm → bool-switch block: `m2 = bool(eq)`, `exitswitch ==
+    // Value(m2)`, pure besides, single predecessor.
+    let (bswitch, eq_bs) = follow_single_exit(graph, err_target, &eq_result)
+        .map_err(|e| format!("{name}: drain fuse: Err arm exit: {e}"))?;
+    assert_single_pred(graph, bswitch, &name)?;
+    let (bool_idx, bool_temp) = graph.blocks[bswitch]
+        .operations
+        .iter()
+        .enumerate()
+        .find_map(|(i, op)| match &op.kind {
+            OpKind::UnaryOp { op: o, operand, .. } if o == "bool" && *operand == eq_bs => {
+                op.result.clone().map(|m| (i, m))
+            }
+            _ => None,
+        })
+        .ok_or_else(|| format!("{name}: drain fuse: bool-switch block {bswitch} lacks bool(eq)"))?;
+    match &graph.blocks[bswitch].exitswitch {
+        Some(ExitSwitch::Value(v)) if *v == bool_temp => {}
+        other => {
+            return Err(format!(
+                "{name}: drain fuse: block {bswitch} exitswitch {other:?} is not the eq bool switch"
+            ));
+        }
+    }
+    assert_block_pure_besides(graph, bswitch, &[bool_idx], "bool switch", &name)?;
+
+    // --- (7) Split the bool switch by exitcase: true → break arm, false →
+    // reraise arm.  Verify the reraise arm is a pure `return Err(e)` tail.
+    if graph.blocks[bswitch].exits.len() != 2 {
+        return Err(format!("{name}: drain fuse: bool switch has != 2 exits"));
+    }
+    let mut break_link: Option<Link> = None;
+    let mut reraise_link: Option<Link> = None;
+    for l in &graph.blocks[bswitch].exits {
+        match &l.exitcase {
+            Some(ExitCase::Bool(true)) => break_link = Some(l.clone()),
+            Some(ExitCase::Bool(false)) => reraise_link = Some(l.clone()),
+            other => {
+                return Err(format!(
+                    "{name}: drain fuse: bool switch exit case {other:?} is not Bool(true/false)"
+                ));
+            }
+        }
+    }
+    let (Some(break_link), Some(reraise_link)) = (break_link, reraise_link) else {
+        return Err(format!("{name}: drain fuse: bool switch lacks the true/false pair"));
+    };
+    let break_target = break_link.target.0;
+    let reraise_target = reraise_link.target.0;
+
+    // Err arm → bool-switch link (the Err arm's single exit, validated in
+    // step 6).  Used to trace the Result alias into the reraise block and to
+    // resolve break-edge args back through the Err arm.
+    let err_to_bswitch = graph.blocks[err_target].exits[0].clone();
+
+    // The already-bound Err payload `e` flowing into the reraise block.  The
+    // handler binds `e` once in the Err arm (`e = r.__pos_0[Result::Err]`) and
+    // the reraise arm re-emits `Err(e)` reusing that exact value — so trace
+    // `err_payload` (not the Result value) through the bool-switch into the
+    // reraise block and require the block to write it back into a fresh `Err`.
+    let e_bswitch = forward_alias(graph, &err_payload, &err_to_bswitch)
+        .ok_or_else(|| format!("{name}: drain fuse: bool-switch drops the Err payload"))?;
+    let e_reraise = forward_alias(graph, &e_bswitch, &reraise_link)
+        .ok_or_else(|| format!("{name}: drain fuse: reraise link drops the Err payload"))?;
+    verify_drain_reraise_returns_err_payload(graph, reraise_target, &e_reraise, &name)?;
+
+    // --- Build the normal (Ok) edge args (A scope), no mutation yet.
+    // Mirrors `rewire_one_call_site`'s continue-arm handling: r → payload,
+    // the Ok arm's discriminant temp → Const(0), loop-carried values
+    // back-substituted across the single A→B edge.
+    let mut normal_args: Vec<LinkArg> = Vec::with_capacity(ok_link.args.len());
+    let mut payload_positions: Vec<usize> = Vec::new();
+    for (i, arg) in ok_link.args.iter().enumerate() {
+        match arg {
+            LinkArg::Const(c) => normal_args.push(LinkArg::Const(c.clone())),
+            LinkArg::Value(v) if *v == r_b => {
+                normal_args.push(LinkArg::Value(r.clone()));
+                payload_positions.push(i);
+            }
+            LinkArg::Value(v) if *v == disc_var => {
+                normal_args.push(LinkArg::Const(Constant::new(ConstValue::Int(0))));
+            }
+            LinkArg::Value(v) => {
+                let v_a = back_substitute(graph, &[(a, b)], v, &name)?;
+                normal_args.push(LinkArg::Value(v_a));
+            }
+        }
+    }
+    if payload_positions.len() > 1 {
+        return Err(format!(
+            "{name}: drain fuse: Result threaded into {} Ok-arm slots — multi-slot collapse unsafe",
+            payload_positions.len()
+        ));
+    }
+
+    // GAP#3 + collapse precondition (hoisted pre-mutation).  The Ok arm's
+    // `__pos_0[Result::Ok]` read is rewritten to the raw element by the
+    // post-mutation `collapse_pos0_read` at the tail; that call is fallible, so
+    // its precondition is validated HERE, before any mutation, keeping a decline
+    // byte-identical.  The Result carrier must be consumed by EXACTLY the single
+    // `__pos_0[Result::Ok]` read (which must produce a value) and nothing else —
+    // a `__discriminant` read, a second `__pos_0` read, or an exit/switch that
+    // forwards the carrier would all survive the collapse pointing at the raw
+    // element read back as a Result (garbage).
+    if let Some(ok_carrier) = forward_alias(graph, &r_b, &ok_link) {
+        let op_uses: Vec<usize> = graph.blocks[ok_target]
+            .operations
+            .iter()
+            .enumerate()
+            .filter(|(_, op)| op_operand_vars(&op.kind).contains(&ok_carrier))
+            .map(|(i, _)| i)
+            .collect();
+        let [read_only] = op_uses.as_slice() else {
+            return Err(format!(
+                "{name}: drain fuse: Ok arm uses the Result carrier in {} ops — \
+                 collapse requires exactly the __pos_0[Result::Ok] read",
+                op_uses.len()
+            ));
+        };
+        let read_op = &graph.blocks[ok_target].operations[*read_only];
+        let is_pos0_read = matches!(&read_op.kind,
+            OpKind::FieldRead { base, field, .. }
+                if *base == ok_carrier
+                    && field.name == "__pos_0"
+                    && field.owner_root.as_deref().is_some_and(|o| owner_is_result_variant(o, "Ok")))
+            && read_op.result.is_some();
+        if !is_pos0_read {
+            return Err(format!(
+                "{name}: drain fuse: Ok arm carrier's sole use is not a value-producing \
+                 __pos_0[Result::Ok] read"
+            ));
+        }
+        // The collapse only rewrites the __pos_0 read; a carrier that also
+        // escapes on an exit or drives the exitswitch would keep pointing at the
+        // now-raw-element inputarg post-fusion.
+        let escapes = graph.blocks[ok_target].exits.iter().any(|l| {
+            l.args
+                .iter()
+                .any(|arg| matches!(arg, LinkArg::Value(v) if *v == ok_carrier))
+        }) || matches!(&graph.blocks[ok_target].exitswitch,
+            Some(ExitSwitch::Value(v)) if *v == ok_carrier);
+        if escapes {
+            return Err(format!(
+                "{name}: drain fuse: Ok arm forwards the Result carrier past the __pos_0 read"
+            ));
+        }
+    }
+
+    // --- Build the break edge (H → break-target) args, resolving each
+    // original break-link value back toward A scope.  Values defined in the
+    // detached B / Err-arm / bool-switch blocks decline unless they are a
+    // const-justifiable temp: the eq bool (true on the matched arm) and the
+    // Err-arm discriminant (1).  The Result value `r` and any other detached
+    // temp decline — they are not available on the exception edge.
+    // `forwarded` collects the DISTINCT A-scope loop-carried vars the break
+    // edge needs; each becomes a forwarded inputarg of H.
+    // A break-arg resolution: either a constant, or an A-scope var to forward.
+    enum BreakArg {
+        Const(LinkArg),
+        Forward(Variable),
+    }
+    let resolve_break = |x: &LinkArg| -> Result<BreakArg, String> {
+        // Constants ride through unchanged.
+        let LinkArg::Value(x) = x else {
+            let LinkArg::Const(c) = x else { unreachable!() };
+            return Ok(BreakArg::Const(LinkArg::Const(c.clone())));
+        };
+        // Hop bswitch → Err-arm.  The exitswitch bool temp is the only
+        // bswitch-defined value; the break arm never carries it, but guard
+        // it just in case (matched arm ⟹ eq true).
+        if *x == bool_temp {
+            return Ok(BreakArg::Const(LinkArg::Const(Constant::new(ConstValue::Bool(true)))));
+        }
+        let pos = graph.blocks[bswitch]
+            .inputargs
+            .iter()
+            .position(|v| v == x)
+            .ok_or_else(|| format!("{name}: drain fuse: break value defined in bool-switch block"))?;
+        let LinkArg::Value(y) = err_to_bswitch.args.get(pos).ok_or_else(|| {
+            format!("{name}: drain fuse: Err→bool-switch link lacks arg {pos}")
+        })? else {
+            // A const threaded through the bswitch inputarg.
+            let Some(LinkArg::Const(c)) = err_to_bswitch.args.get(pos) else { unreachable!() };
+            return Ok(BreakArg::Const(LinkArg::Const(c.clone())));
+        };
+        let y = y.clone();
+        // Hop Err-arm → B.  Err-arm-defined values (the four guard ops)
+        // decline, except the eq bool (matched arm ⟹ true).
+        if y == eq_result {
+            return Ok(BreakArg::Const(LinkArg::Const(Constant::new(ConstValue::Bool(true)))));
+        }
+        if y == sc || y == err_payload || y == kind_var {
+            return Err(format!(
+                "{name}: drain fuse: break edge carries a detached Err-arm temp (dead `Err(e)` re-bind)"
+            ));
+        }
+        let pos = graph.blocks[err_target]
+            .inputargs
+            .iter()
+            .position(|v| *v == y)
+            .ok_or_else(|| format!("{name}: drain fuse: break value defined in Err-arm block"))?;
+        let LinkArg::Value(z) = err_link.args.get(pos).ok_or_else(|| {
+            format!("{name}: drain fuse: B→Err link lacks arg {pos}")
+        })? else {
+            let Some(LinkArg::Const(c)) = err_link.args.get(pos) else { unreachable!() };
+            return Ok(BreakArg::Const(LinkArg::Const(c.clone())));
+        };
+        let z = z.clone();
+        // Hop B → A.  The Result value declines (invalid on the exception
+        // edge); the discriminant temp is Const(1) on the Err arm; a B
+        // inputarg forwards from the single A→B edge to an A-scope value.
+        if z == r_b {
+            return Err(format!(
+                "{name}: drain fuse: break edge needs the Result value (dead `Err(e)` re-bind reads it)"
+            ));
+        }
+        if z == disc_var {
+            return Ok(BreakArg::Const(LinkArg::Const(Constant::new(ConstValue::Int(1)))));
+        }
+        let pos = graph.blocks[b]
+            .inputargs
+            .iter()
+            .position(|v| *v == z)
+            .ok_or_else(|| format!("{name}: drain fuse: break value defined in discriminant block"))?;
+        match graph.blocks[a].exits[0].args.get(pos) {
+            Some(LinkArg::Const(c)) => Ok(BreakArg::Const(LinkArg::Const(c.clone()))),
+            Some(LinkArg::Value(av)) if *av == *r => Err(format!(
+                "{name}: drain fuse: break edge needs the Result value from A scope"
+            )),
+            Some(LinkArg::Value(av)) => Ok(BreakArg::Forward(av.clone())),
+            None => Err(format!("{name}: drain fuse: A→B link lacks arg {pos}")),
+        }
+    };
+    // --- Classify each break-target slot (MUST-ADD#1).  A transitively-dead
+    // slot — the loop's SSA merge-threads for the Result value, its
+    // discriminant, the caught `e` payload and the guard temps, none read past
+    // the break — is pruned from `break_target` and every predecessor link.  A
+    // live slot (the accumulator carried out of the loop) is resolved back to
+    // an A-scope loop var and forwarded onto the exception edge.
+    use std::collections::{BTreeMap, BTreeSet};
+    let mut dead: BTreeMap<usize, BTreeSet<usize>> = BTreeMap::new();
+    let mut live_slots: Vec<usize> = Vec::new();
+    for slot in 0..graph.blocks[break_target].inputargs.len() {
+        match crate::front::iter_next::collect_transitive_dead_slots(graph, break_target, slot) {
+            Ok(set) => {
+                for (bb, ss) in set {
+                    dead.entry(bb).or_default().insert(ss);
+                }
+            }
+            Err(_) => live_slots.push(slot),
+        }
+    }
+
+    // Arity guard: removing slot `s` from a block also drops arg `s` from every
+    // predecessor link, so every such link must carry the block's full
+    // pre-removal inputarg arity (mirrors the iter_next transitive prune).
+    for &bb in dead.keys() {
+        let arity = graph.blocks[bb].inputargs.len();
+        for blk in &graph.blocks {
+            for l in &blk.exits {
+                if l.target.0 == bb && l.args.len() != arity {
+                    return Err(format!(
+                        "{name}: drain fuse: predecessor link to block {bb} has arity {} != {arity} \
+                         — unsafe to prune the dead break-edge threads",
+                        l.args.len()
+                    ));
+                }
+            }
+        }
+    }
+
+    // Resolve the surviving (live) break slots back to A scope.  `forwarded`
+    // collects the DISTINCT A-scope loop vars the break edge still needs; each
+    // becomes a forwarded inputarg of H, carried on the exception edge.  A live
+    // const slot cannot be threaded as a Variable through `set_branch`'s
+    // arity-checked link, so decline it.
+    let mut forwarded: Vec<Variable> = Vec::new();
+    let mut break_vars_src: Vec<Variable> = Vec::with_capacity(live_slots.len());
+    for &slot in &live_slots {
+        match resolve_break(&break_link.args[slot])? {
+            BreakArg::Forward(av) => {
+                if !forwarded.contains(&av) {
+                    forwarded.push(av.clone());
+                }
+                break_vars_src.push(av);
+            }
+            BreakArg::Const(c) => {
+                return Err(format!(
+                    "{name}: drain fuse: live break slot carries a const {c:?} — cannot forward via set_branch"
+                ));
+            }
+        }
+    }
+
+    // --- All validation + arg-building passed; mutate. -----------------
+    // Block H's inputargs: [forwarded loop vars..., va(etype,unused), vb(evalue)].
+    let (h_id, h_inputs) = graph.create_block_with_arg_vars(forwarded.len() + 2);
+    // H's `etype` inputarg (slot `forwarded.len()`) is the int-kinded caught
+    // type — unused by the kind test; only `vb` (the evalue) is read.
+    let va_slot = h_inputs[forwarded.len()].clone();
+    let h_vb = h_inputs[forwarded.len() + 1].clone();
+    // Map each forwarded A-scope var to its H inputarg.
+    let h_of = |av: &Variable| -> Variable {
+        let idx = forwarded.iter().position(|v| v == av).expect("forwarded contains av");
+        h_inputs[idx].clone()
+    };
+    // Block R's inputarg: [vb].
+    let (r_id, r_inputs) = graph.create_block_with_arg_vars(1);
+    let r_vb = r_inputs[0].clone();
+
+    // H: `k = exc_kind_discriminant(vb)`; `cmp = (k == 10)`.  `set_branch`
+    // below wraps `cmp` in the `bool` hop the switch condition expects.
+    let k = graph
+        .push_op_var(
+            h_id,
+            OpKind::Call {
+                target: CallTarget::function_path([
+                    "pyre_object",
+                    "interp_exceptions",
+                    "exc_kind_discriminant",
+                ]),
+                args: vec![h_vb.clone()],
+                result_ty: ValueType::Int,
+            },
+            true,
+        )
+        .expect("exc_kind_discriminant produces a value");
+    // 10 == `ExcKind::StopIteration` (pyre-object interp_exceptions.rs); the two
+    // are coupled — renumbering that discriminant silently breaks this test.
+    let c10 = graph
+        .push_op_var(h_id, OpKind::ConstInt(10), true)
+        .expect("ConstInt produces a value");
+    let cmp = graph
+        .push_op_var(
+            h_id,
+            OpKind::BinOp {
+                op: "eq".to_string(),
+                lhs: k,
+                rhs: c10,
+                result_ty: ValueType::Int,
+            },
+            true,
+        )
+        .expect("BinOp eq produces a value");
+    // GAP#4: the kind test reads only `vb`; the `etype` slot must stay unused
+    // so the exception edge may thread the caught type in without a live
+    // consumer (H is freshly built here, so this is a construction invariant).
+    debug_assert!(
+        !graph.blocks[h_id.0]
+            .operations
+            .iter()
+            .any(|op| op_operand_vars(&op.kind).contains(&va_slot)),
+        "drain fuse: H references its unused etype inputarg"
+    );
+
+    // R: `v_type = type(vb)`; `goto exceptblock [v_type, vb]`.  DO NOT reuse
+    // `va` (the int-kinded etype); `type(evalue)` recomputes the ref-kind
+    // class the raise tail needs.
+    let v_type = graph
+        .push_op_var(
+            r_id,
+            OpKind::Call {
+                target: CallTarget::function_path(["type"]),
+                args: vec![r_vb.clone()],
+                result_ty: ValueType::Ref(None),
+            },
+            true,
+        )
+        .expect("type(evalue) produces a value");
+    graph.set_raise_values(r_id, v_type, r_vb);
+
+    // Break edge args in H scope (all forwarded Variables; the dead threads
+    // were pruned, so no const rides the surviving edge).
+    let break_vars: Vec<Variable> = break_vars_src.iter().map(|av| h_of(av)).collect();
+
+    // Drop every dead slot in the transitive chain from its block's inputargs
+    // and from every predecessor link feeding that block (descending indices so
+    // earlier positions stay valid), keeping link arity == target inputarg
+    // arity across the whole graph.  The old bswitch→break_target link is
+    // trimmed here too; H's fresh reduced-arity link is installed below.
+    for (&bb, slots) in dead.iter().rev() {
+        for &s in slots.iter().rev() {
+            graph.blocks[bb].inputargs.remove(s);
+            for blk in &mut graph.blocks {
+                for l in &mut blk.exits {
+                    if l.target.0 == bb {
+                        l.args.remove(s);
+                    }
+                }
+            }
+        }
+    }
+
+    // H: branch on the kind test — `cmp` true (kind == StopIteration) → break
+    // target; false → R (reraise `raise vb`).  `set_branch` wraps `cmp` in
+    // `bool` and installs arity-checked links (MUST-ADD#2).
+    graph.set_branch(
+        h_id,
+        cmp,
+        BlockId(break_target),
+        break_vars,
+        r_id,
+        vec![h_vb.clone()],
+    );
+
+    // A: LastException exits — normal → Ok arm; exception → H (catch-all).
+    // The exc link carries the loop-carried vars H's break edge needs (filling
+    // H's leading inputargs), then the caught `(va, vb)` pair into H's trailing
+    // `(etype, evalue)` slots, naming them as the `last_exception` /
+    // `last_exc_value` extravars (the `?`-diamond shape).
+    let va = graph.alloc_value_var();
+    let vb = graph.alloc_value_var();
+    let exc_vars: Vec<Variable> = forwarded
+        .iter()
+        .cloned()
+        .chain([va.clone(), vb.clone()])
+        .collect();
+    let mut exc_link =
+        Link::from_variables(graph, exc_vars, h_id, Some(crate::model::exception_exitcase()));
+    exc_link.last_exception = Some(LinkArg::Value(va));
+    exc_link.last_exc_value = Some(LinkArg::Value(vb));
+    assert_eq!(
+        normal_args.len(),
+        graph.block(ok_link.target).inputargs.len(),
+        "drain fuse: normal edge arity mismatch"
+    );
+    let normal_link = Link::new_mixed(normal_args, ok_link.target, None);
+    graph.set_control_flow_metadata(
+        BlockId(a),
+        Some(ExitSwitch::LastException),
+        vec![normal_link, exc_link],
+    );
+
+    // The Ok arm reads the payload via `r.__pos_0[Result::Ok]`; with the native
+    // call result flowing directly, that read collapses to `r`.
+    for pos in payload_positions {
+        collapse_pos0_read(graph, ok_link.target, pos, &name)?;
+    }
+
     Ok(())
 }
 

--- a/majit/majit-translate/src/front/result_exc.rs
+++ b/majit/majit-translate/src/front/result_exc.rs
@@ -1463,11 +1463,7 @@ fn verify_drain_reraise_returns_err_payload(
 /// leaves the graph byte-identical.  Detach-only: the bypassed
 /// discriminant / Err-arm / bool-switch / reraise blocks are left
 /// byte-intact for the post-rewrite `clear_unreachable_blocks` sweep.
-fn try_fuse_drain_match(
-    graph: &mut FunctionGraph,
-    a: usize,
-    r: &Variable,
-) -> Result<(), String> {
+fn try_fuse_drain_match(graph: &mut FunctionGraph, a: usize, r: &Variable) -> Result<(), String> {
     use crate::flowspace::model::{ConstValue, Constant};
     use crate::model::{BlockId, ExitCase};
     let name = graph.name.clone();
@@ -1475,11 +1471,14 @@ fn try_fuse_drain_match(
     // --- (1) A: `r = next(iter)` is A's last op, closed by lower_call with
     // a single no-exitcase forwarding exit.
     let a_ops = &graph.blocks[a].operations;
-    let call_idx = a_ops.len().checked_sub(1).ok_or_else(|| {
-        format!("{name}: drain fuse: call block {a} is empty")
-    })?;
+    let call_idx = a_ops
+        .len()
+        .checked_sub(1)
+        .ok_or_else(|| format!("{name}: drain fuse: call block {a} is empty"))?;
     if a_ops[call_idx].result.as_ref() != Some(r) {
-        return Err(format!("{name}: drain fuse: next() is not the last op of block {a}"));
+        return Err(format!(
+            "{name}: drain fuse: next() is not the last op of block {a}"
+        ));
     }
     if graph.blocks[a].exitswitch.is_some() || graph.blocks[a].exits.len() != 1 {
         return Err(format!(
@@ -1487,7 +1486,9 @@ fn try_fuse_drain_match(
         ));
     }
     if graph.blocks[a].exits[0].exitcase.is_some() {
-        return Err(format!("{name}: drain fuse: call block {a} exit carries an exitcase"));
+        return Err(format!(
+            "{name}: drain fuse: call block {a} exit carries an exitcase"
+        ));
     }
 
     // --- (2) A→B single exit; B holds `d = r.__discriminant[Result<..,PyError>]`,
@@ -1503,13 +1504,18 @@ fn try_fuse_drain_match(
             OpKind::FieldRead { base, field, .. }
                 if *base == r_b
                     && field.name == "__discriminant"
-                    && field.owner_root.as_deref().is_some_and(owner_is_result_of_pyerror) =>
+                    && field
+                        .owner_root
+                        .as_deref()
+                        .is_some_and(owner_is_result_of_pyerror) =>
             {
                 op.result.clone().map(|d| (i, d))
             }
             _ => None,
         })
-        .ok_or_else(|| format!("{name}: drain fuse: block {b} lacks the Result __discriminant read"))?;
+        .ok_or_else(|| {
+            format!("{name}: drain fuse: block {b} lacks the Result __discriminant read")
+        })?;
     match &graph.blocks[b].exitswitch {
         Some(ExitSwitch::Value(v)) if *v == disc_var => {}
         other => {
@@ -1531,21 +1537,20 @@ fn try_fuse_drain_match(
                         && field.owner_root.as_deref().is_some_and(|o| owner_is_result_variant(o, variant)))
         })
     };
-    let (ok_link, err_link) = if reads_variant(case0.target.0, "Ok")
-        && reads_variant(case1.target.0, "Err")
-    {
-        (case0, case1)
-    } else if reads_variant(case1.target.0, "Ok") && reads_variant(case0.target.0, "Err") {
-        // The Ok arm must be the discriminant-0 case (Result: Ok = 0); an
-        // inverted pairing is an unrecognised shape.
-        return Err(format!(
-            "{name}: drain fuse: Ok/Err arms inverted vs discriminant 0/1"
-        ));
-    } else {
-        return Err(format!(
-            "{name}: drain fuse: block {b} arms are not a Result Ok/Err __pos_0 pair"
-        ));
-    };
+    let (ok_link, err_link) =
+        if reads_variant(case0.target.0, "Ok") && reads_variant(case1.target.0, "Err") {
+            (case0, case1)
+        } else if reads_variant(case1.target.0, "Ok") && reads_variant(case0.target.0, "Err") {
+            // The Ok arm must be the discriminant-0 case (Result: Ok = 0); an
+            // inverted pairing is an unrecognised shape.
+            return Err(format!(
+                "{name}: drain fuse: Ok/Err arms inverted vs discriminant 0/1"
+            ));
+        } else {
+            return Err(format!(
+                "{name}: drain fuse: block {b} arms are not a Result Ok/Err __pos_0 pair"
+            ));
+        };
     let ok_target = ok_link.target.0;
     let err_target = err_link.target.0;
 
@@ -1566,9 +1571,10 @@ fn try_fuse_drain_match(
             OpKind::Call { target: CallTarget::SyntheticTransparentCtor { name: n, owner_path }, .. }
                 if n == "StopIteration" && owner_path.last().is_some_and(|s| s == "PyErrorKind")))
         .ok_or_else(|| format!("{name}: drain fuse: Err arm lacks the StopIteration ctor"))?;
-    let sc = err_ops[ctor_idx].result.clone().ok_or_else(|| {
-        format!("{name}: drain fuse: StopIteration ctor without result")
-    })?;
+    let sc = err_ops[ctor_idx]
+        .result
+        .clone()
+        .ok_or_else(|| format!("{name}: drain fuse: StopIteration ctor without result"))?;
     let (errpay_idx, err_payload) = err_ops
         .iter()
         .enumerate()
@@ -1576,7 +1582,10 @@ fn try_fuse_drain_match(
             OpKind::FieldRead { base, field, .. }
                 if *base == r_err
                     && field.name == "__pos_0"
-                    && field.owner_root.as_deref().is_some_and(|o| owner_is_result_variant(o, "Err")) =>
+                    && field
+                        .owner_root
+                        .as_deref()
+                        .is_some_and(|o| owner_is_result_variant(o, "Err")) =>
             {
                 op.result.clone().map(|e| (i, e))
             }
@@ -1601,12 +1610,20 @@ fn try_fuse_drain_match(
         .iter()
         .enumerate()
         .find_map(|(i, op)| match &op.kind {
-            OpKind::Call { target: CallTarget::Method { name: m, receiver_root, .. }, args, .. }
-                if m == "eq"
-                    && receiver_root.as_deref() == Some("PyErrorKind")
-                    && args.len() == 2
-                    && args.contains(&kind_var)
-                    && args.contains(&sc) =>
+            OpKind::Call {
+                target:
+                    CallTarget::Method {
+                        name: m,
+                        receiver_root,
+                        ..
+                    },
+                args,
+                ..
+            } if m == "eq"
+                && receiver_root.as_deref() == Some("PyErrorKind")
+                && args.len() == 2
+                && args.contains(&kind_var)
+                && args.contains(&sc) =>
             {
                 op.result.clone().map(|m| (i, m))
             }
@@ -1668,7 +1685,9 @@ fn try_fuse_drain_match(
         }
     }
     let (Some(break_link), Some(reraise_link)) = (break_link, reraise_link) else {
-        return Err(format!("{name}: drain fuse: bool switch lacks the true/false pair"));
+        return Err(format!(
+            "{name}: drain fuse: bool switch lacks the true/false pair"
+        ));
     };
     let break_target = break_link.target.0;
     let reraise_target = reraise_link.target.0;
@@ -1794,25 +1813,35 @@ fn try_fuse_drain_match(
         // bswitch-defined value; the break arm never carries it, but guard
         // it just in case (matched arm ⟹ eq true).
         if *x == bool_temp {
-            return Ok(BreakArg::Const(LinkArg::Const(Constant::new(ConstValue::Bool(true)))));
+            return Ok(BreakArg::Const(LinkArg::Const(Constant::new(
+                ConstValue::Bool(true),
+            ))));
         }
         let pos = graph.blocks[bswitch]
             .inputargs
             .iter()
             .position(|v| v == x)
-            .ok_or_else(|| format!("{name}: drain fuse: break value defined in bool-switch block"))?;
-        let LinkArg::Value(y) = err_to_bswitch.args.get(pos).ok_or_else(|| {
-            format!("{name}: drain fuse: Err→bool-switch link lacks arg {pos}")
-        })? else {
+            .ok_or_else(|| {
+                format!("{name}: drain fuse: break value defined in bool-switch block")
+            })?;
+        let LinkArg::Value(y) = err_to_bswitch
+            .args
+            .get(pos)
+            .ok_or_else(|| format!("{name}: drain fuse: Err→bool-switch link lacks arg {pos}"))?
+        else {
             // A const threaded through the bswitch inputarg.
-            let Some(LinkArg::Const(c)) = err_to_bswitch.args.get(pos) else { unreachable!() };
+            let Some(LinkArg::Const(c)) = err_to_bswitch.args.get(pos) else {
+                unreachable!()
+            };
             return Ok(BreakArg::Const(LinkArg::Const(c.clone())));
         };
         let y = y.clone();
         // Hop Err-arm → B.  Err-arm-defined values (the four guard ops)
         // decline, except the eq bool (matched arm ⟹ true).
         if y == eq_result {
-            return Ok(BreakArg::Const(LinkArg::Const(Constant::new(ConstValue::Bool(true)))));
+            return Ok(BreakArg::Const(LinkArg::Const(Constant::new(
+                ConstValue::Bool(true),
+            ))));
         }
         if y == sc || y == err_payload || y == kind_var {
             return Err(format!(
@@ -1824,10 +1853,14 @@ fn try_fuse_drain_match(
             .iter()
             .position(|v| *v == y)
             .ok_or_else(|| format!("{name}: drain fuse: break value defined in Err-arm block"))?;
-        let LinkArg::Value(z) = err_link.args.get(pos).ok_or_else(|| {
-            format!("{name}: drain fuse: B→Err link lacks arg {pos}")
-        })? else {
-            let Some(LinkArg::Const(c)) = err_link.args.get(pos) else { unreachable!() };
+        let LinkArg::Value(z) = err_link
+            .args
+            .get(pos)
+            .ok_or_else(|| format!("{name}: drain fuse: B→Err link lacks arg {pos}"))?
+        else {
+            let Some(LinkArg::Const(c)) = err_link.args.get(pos) else {
+                unreachable!()
+            };
             return Ok(BreakArg::Const(LinkArg::Const(c.clone())));
         };
         let z = z.clone();
@@ -1840,13 +1873,17 @@ fn try_fuse_drain_match(
             ));
         }
         if z == disc_var {
-            return Ok(BreakArg::Const(LinkArg::Const(Constant::new(ConstValue::Int(1)))));
+            return Ok(BreakArg::Const(LinkArg::Const(Constant::new(
+                ConstValue::Int(1),
+            ))));
         }
         let pos = graph.blocks[b]
             .inputargs
             .iter()
             .position(|v| *v == z)
-            .ok_or_else(|| format!("{name}: drain fuse: break value defined in discriminant block"))?;
+            .ok_or_else(|| {
+                format!("{name}: drain fuse: break value defined in discriminant block")
+            })?;
         match graph.blocks[a].exits[0].args.get(pos) {
             Some(LinkArg::Const(c)) => Ok(BreakArg::Const(LinkArg::Const(c.clone()))),
             Some(LinkArg::Value(av)) if *av == *r => Err(format!(
@@ -1926,7 +1963,10 @@ fn try_fuse_drain_match(
     let h_vb = h_inputs[forwarded.len() + 1].clone();
     // Map each forwarded A-scope var to its H inputarg.
     let h_of = |av: &Variable| -> Variable {
-        let idx = forwarded.iter().position(|v| v == av).expect("forwarded contains av");
+        let idx = forwarded
+            .iter()
+            .position(|v| v == av)
+            .expect("forwarded contains av");
         h_inputs[idx].clone()
     };
     // Block R's inputarg: [vb].
@@ -2040,8 +2080,12 @@ fn try_fuse_drain_match(
         .cloned()
         .chain([va.clone(), vb.clone()])
         .collect();
-    let mut exc_link =
-        Link::from_variables(graph, exc_vars, h_id, Some(crate::model::exception_exitcase()));
+    let mut exc_link = Link::from_variables(
+        graph,
+        exc_vars,
+        h_id,
+        Some(crate::model::exception_exitcase()),
+    );
     exc_link.last_exception = Some(LinkArg::Value(va));
     exc_link.last_exc_value = Some(LinkArg::Value(vb));
     assert_eq!(

--- a/majit/majit-translate/src/lib.rs
+++ b/majit/majit-translate/src/lib.rs
@@ -1579,13 +1579,15 @@ fn analyze_pipeline_from_module_paths(
         jitcodes_by_path: indexmap::IndexMap::new(),
         insns: indexmap::IndexMap::new(),
         descrs: Vec::new(),
+        all_liveness: Vec::new(),
         total_blocks: 0,
         total_ops: 0,
         total_vable_rewrites: 0,
     };
 
     mark_phase!("call_control + canonical_trait_impls + register graphs");
-    let (jitcodes, insns, descrs) = make_jitcodes(&config.pipeline, &mut call_control);
+    let (jitcodes, insns, descrs, all_liveness) =
+        make_jitcodes(&config.pipeline, &mut call_control);
     mark_phase!("make_jitcodes");
     pipeline.jit_drivers = call_control
         .jitdrivers_sd()
@@ -1607,6 +1609,11 @@ fn analyze_pipeline_from_module_paths(
     pipeline.jitcodes_by_path = call_control.jitcodes().clone();
     pipeline.insns = insns;
     pipeline.descrs = descrs;
+    // Snapshotted in `make_jitcodes` from the assembler's shared `all_liveness`
+    // table (the target of `pyjitpl.py:2264 self.liveness_info =
+    // "".join(asm.all_liveness)`) so the runtime can resolve the `BC_LIVE`
+    // offsets baked into `JitCode.code`.
+    pipeline.all_liveness = all_liveness;
 
     pipeline
 }
@@ -1683,6 +1690,7 @@ fn make_jitcodes(
     Vec<std::sync::Arc<jitcode::JitCode>>,
     indexmap::IndexMap<String, u8>,
     Vec<jitcode::BhDescr>,
+    Vec<u8>,
 ) {
     // RPython codewriter.py:74-89: make_jitcodes().
     //
@@ -1741,7 +1749,12 @@ fn make_jitcodes(
     // `insns`, mirroring RPython's single-store model.
     let descrs: Vec<jitcode::BhDescr> = codewriter.assembler.snapshot_descrs();
 
-    (jitcodes, insns, descrs)
+    // RPython `pyjitpl.py:2264 self.liveness_info = "".join(asm.all_liveness)`.
+    // Snapshot the assembler's shared `all_liveness` byte stream so the runtime
+    // can resolve the `BC_LIVE` offsets baked into `JitCode.code`.
+    let all_liveness = codewriter.assembler.all_liveness().to_vec();
+
+    (jitcodes, insns, descrs, all_liveness)
 }
 
 /// Generate tracing code directly from the canonical pipeline result.

--- a/majit/majit-translate/src/lib.rs
+++ b/majit/majit-translate/src/lib.rs
@@ -1839,7 +1839,7 @@ mod portal_driver_tests {
         let mut policy = policy::DefaultJitPolicy::new();
         call_control.find_all_graphs(&mut policy);
 
-        let (jitcodes, _, _) = make_jitcodes(&config, &mut call_control);
+        let (jitcodes, _, _, _) = make_jitcodes(&config, &mut call_control);
         assert_eq!(jitcodes.len(), 1);
         assert_eq!(jitcodes[0].index(), 0);
         assert!(call_control.jitcodes().contains_key(&portal));
@@ -1907,7 +1907,7 @@ mod portal_driver_tests {
         let mut policy = policy::DefaultJitPolicy::new();
         call_control.find_all_graphs(&mut policy);
 
-        let (jitcodes, _, _) = make_jitcodes(&config, &mut call_control);
+        let (jitcodes, _, _, _) = make_jitcodes(&config, &mut call_control);
         let merge = jitcodes[0]
             .body()
             ._ssarepr

--- a/majit/majit-translate/src/pipeline.rs
+++ b/majit/majit-translate/src/pipeline.rs
@@ -147,6 +147,17 @@ pub struct ProgramPipelineResult {
     /// single-store descr model.
     #[serde(default)]
     pub descrs: Vec<crate::jitcode::BhDescr>,
+    /// RPython: `Assembler.all_liveness` (assembler.py) — the shared,
+    /// deduplicated `(live_i, live_r, live_f)` byte stream that every
+    /// `BC_LIVE` op's baked 2-byte offset (in `JitCode.code`) indexes into.
+    ///
+    /// Persisted alongside `insns`/`descrs` so a runtime consumer re-tracing
+    /// a build-time jitcode (whose `BC_LIVE` liveness offsets are baked at
+    /// build time) can resolve those offsets through
+    /// `metainterp_sd.liveness_info` — the target of `pyjitpl.py:2264
+    /// self.liveness_info = "".join(asm.all_liveness)`.
+    #[serde(default)]
+    pub all_liveness: Vec<u8>,
     pub total_blocks: usize,
     pub total_ops: usize,
     pub total_vable_rewrites: usize,

--- a/majit/majit-translate/src/pipeline.rs
+++ b/majit/majit-translate/src/pipeline.rs
@@ -199,6 +199,7 @@ mod tests {
             jitcodes_by_path: indexmap::IndexMap::new(),
             insns: indexmap::IndexMap::new(),
             descrs: Vec::new(),
+            all_liveness: Vec::new(),
             total_blocks: 1,
             total_ops: 1,
             total_vable_rewrites: 0,

--- a/pyre/extra_tests/parity_tests/unpack_drain_exact_kind.py
+++ b/pyre/extra_tests/parity_tests/unpack_drain_exact_kind.py
@@ -1,0 +1,102 @@
+"""Facet A drain-loop exact-kind fusion regression guard.
+
+Guards pypy/interpreter/baseobjspace.py:1005-1015
+`_unpackiterable_unknown_length`.  The StopIteration drain loop's
+except handler is an EXACT per-kind test (`e.kind ==
+PyErrorKind::StopIteration`, the `e.match(space, w_StopIteration)`
+handler form): a StopIteration ends the drain, anything else
+re-raises.  The jd1 drain fusion lowers that handler to
+`exc_kind_discriminant(evalue) == ExcKind::StopIteration` on the
+`next()` LastException edge.  A wrong MRO/subclass-matching lowering
+would swallow, e.g., a `(ValueError, StopIteration)` multi-base
+exception the interpreter propagates — a silent miscompile.
+
+Self-check: each case captures the first (cold / interpreter) outcome,
+then repeats the same unpack in a hot loop; every hot iteration's
+outcome must equal the cold one.  A JIT that diverges from the
+interpreter on the same input makes a hot iteration disagree ->
+AssertionError.  CPython (no JIT) is trivially self-consistent, so this
+never false-reds against CPython's divergent MRO-match semantics for
+the multi-base case.
+
+Run under the jd1 walker to exercise the fusion:  PYRE_JD1=1
+"""
+
+N = 40000
+
+
+def drain(make_iter):
+    """Unpack an unknown-length iterator into a fixed 3-tuple, returning
+    a hashable signature of the outcome (ok tuple, or exception id)."""
+    try:
+        a, b, c = make_iter()
+    except BaseException as e:  # noqa: BLE001 - signature capture
+        return ("raised", type(e).__name__, str(e))
+    return ("ok", a, b, c)
+
+
+def gen_ok():
+    yield 1
+    yield 2
+    yield 3
+
+
+class RaiseIter:
+    """Iterator whose __next__ raises `exc` after the 1st element."""
+
+    def __init__(self, exc):
+        self._exc = exc
+        self._i = 0
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        self._i += 1
+        if self._i == 1:
+            return 10
+        raise self._exc
+
+
+class MyStop(StopIteration):
+    pass
+
+
+try:
+    class MultiStop(ValueError, StopIteration):
+        pass
+    HAVE_MULTI = True
+except TypeError:
+    # CPython rejects the multi-base layout; pyre may or may not.
+    HAVE_MULTI = False
+
+
+def run_case(name, make_iter):
+    first = drain(make_iter)
+    for _ in range(N):
+        sig = drain(make_iter)
+        assert sig == first, f"{name}: JIT diverged from interp {sig!r} != {first!r}"
+    return first
+
+
+# (i) normal StopIteration drain completes with the drained values.
+assert run_case("normal", gen_ok) == ("ok", 1, 2, 3)
+
+# (ii) a plain non-StopIteration error must PROPAGATE, not be swallowed
+#      into a 'not enough values to unpack' arity error.
+sig_ii = run_case("value_error", lambda: RaiseIter(ValueError("boom")))
+assert sig_ii[0] == "raised", sig_ii
+
+# (iii) a StopIteration subclass: the interpreter's exact-kind test decides
+#       whether it ends the drain or propagates.  Whatever it does, the JIT
+#       must match it (checked in-loop); no absolute assertion, so this stays
+#       CPython-safe.
+run_case("stop_subclass", lambda: RaiseIter(MyStop()))
+
+# (iv) multi-base (ValueError, StopIteration): the DISTINGUISHING case.
+#      Exact-kind (pyre) propagates; MRO-match would swallow.  We assert only
+#      that JIT == interpreter within this run, never which side wins.
+if HAVE_MULTI:
+    run_case("multi_base", lambda: RaiseIter(MultiStop()))
+
+print("OK")

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -9853,8 +9853,16 @@ fn _unpackiterable_unknown_length(
         unpackiterable_driver.jit_merge_point(greenkey, w_iterator, items);
         match next(w_iterator) {
             Ok(w_item) => unsafe { pyre_object::listobject::w_list_append(items, w_item) },
-            Err(e) if e.kind == crate::PyErrorKind::StopIteration => break,
-            Err(e) => return Err(e),
+            // `except OperationError as e: if not e.match(space,
+            // w_StopIteration): raise; break` — the StopIteration test rides
+            // inside the handler (`e` is bound once, consumed only on the
+            // re-raise path), not as a match guard.
+            Err(e) => {
+                if e.kind == crate::PyErrorKind::StopIteration {
+                    break;
+                }
+                return Err(e);
+            }
         }
     }
     let n = unsafe { pyre_object::listobject::w_list_len(items) };

--- a/pyre/pyre-interpreter/src/jit_fnaddr.rs
+++ b/pyre/pyre-interpreter/src/jit_fnaddr.rs
@@ -538,6 +538,17 @@ pub fn jit_trace_fnaddrs() -> Vec<(&'static str, i64)> {
         "pyre_object::lookup_exc_class_for_kind",
         crate::opcode_ops::bh_lookup_exc_class_for_kind as *const (),
     );
+    // `exc_kind_discriminant` reads the caught exception object's `kind`
+    // discriminant; its residual call rides a C-ABI bridge that returns the
+    // `ExcKind` discriminant in the integer result slot a residual result
+    // register wants.  Emitted by the `try_fuse_drain_match` recognizer
+    // (`front::result_exc`) for the drain loop's exception-edge kind test.
+    push_alias_pair(
+        &mut entries,
+        "pyre_object::interp_exceptions::exc_kind_discriminant",
+        "pyre_object::exc_kind_discriminant",
+        crate::opcode_ops::bh_w_exception_get_kind as *const (),
+    );
     // `pin_root` pushes onto the TLS `SHADOW_STACK` (the `shadow_stack_len`
     // twin), `dereference` reads the weakref `w_obj_weak` slot
     // (`@jit.dont_look_inside` upstream, the `proxy_type` twin), and

--- a/pyre/pyre-interpreter/src/opcode_ops.rs
+++ b/pyre/pyre-interpreter/src/opcode_ops.rs
@@ -766,6 +766,13 @@ pub extern "C" fn bh_lookup_exc_class_for_kind(kind_disc: i64) -> i64 {
     lookup_exc_class_for_kind(kind) as i64
 }
 
+/// C-ABI residual bridge for `exc_kind_discriminant`: the caught exception
+/// value rides in as a `PyObjectRef`; its `kind` discriminant rides back as `i64`.
+#[allow(improper_ctypes_definitions)]
+pub extern "C" fn bh_w_exception_get_kind(evalue: pyre_object::PyObjectRef) -> i64 {
+    pyre_object::interp_exceptions::exc_kind_discriminant(evalue)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/pyre/pyre-jit-trace/build.rs
+++ b/pyre/pyre-jit-trace/build.rs
@@ -13,6 +13,7 @@ const CODEGEN_OUTPUTS: &[&str] = &[
     "jit_drivers.bin",
     "insns.bin",
     "descrs.bin",
+    "liveness.bin",
     "fnaddr_bindings.bin",
     "static_pytype_bindings.bin",
     "static_ref_bindings.bin",
@@ -88,6 +89,11 @@ fn emit_llbc_extraction_placeholders() {
     std::fs::write(
         format!("{out_dir}/descrs.bin"),
         bincode::serialize(&Vec::<majit_translate::jitcode::BhDescr>::new()).unwrap(),
+    )
+    .unwrap();
+    std::fs::write(
+        format!("{out_dir}/liveness.bin"),
+        bincode::serialize(&Vec::<u8>::new()).unwrap(),
     )
     .unwrap();
     for name in [
@@ -461,6 +467,14 @@ fn real_main() {
     // by `acquire_interp`).
     let descrs_bin = bincode::serialize(&pipeline.descrs).unwrap();
     std::fs::write(format!("{out_dir}/descrs.bin"), &descrs_bin).unwrap();
+
+    // RPython `pyjitpl.py:2264 self.liveness_info = "".join(asm.all_liveness)`.
+    // Persist the build-time assembler's shared `all_liveness` byte stream so a
+    // runtime consumer re-tracing a build-time jitcode (whose `BC_LIVE` ops
+    // carry offsets baked against this table) can install it into
+    // `metainterp_sd.liveness_info` and resolve those offsets.
+    let liveness_bin = bincode::serialize(&pipeline.all_liveness).unwrap();
+    std::fs::write(format!("{out_dir}/liveness.bin"), &liveness_bin).unwrap();
 
     // RPython's translator AOT-compiles every helper into a single binary, so
     // `JitCode.fnaddr` / `constants_i` funcptrs are linker-resolved and stable

--- a/pyre/pyre-jit-trace/src/jitcode_runtime.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_runtime.rs
@@ -384,6 +384,32 @@ pub fn all_descrs() -> &'static [BhDescr] {
     &ALL_DESCRS
 }
 
+/// Deserialized `pipeline.all_liveness` — RPython `Assembler.all_liveness`
+/// (assembler.py), the target of `pyjitpl.py:2264 self.liveness_info =
+/// "".join(asm.all_liveness)`.
+///
+/// The build-time codewriter dedups every `(live_i, live_r, live_f)` triple
+/// into this single byte stream and bakes each `BC_LIVE` op's 2-byte offset
+/// into `JitCode.code`.  A runtime consumer re-tracing a build-time jitcode
+/// (jd1's `_unpackiterable_unknown_length` merge-point walk) resolves those
+/// baked offsets by installing this table into `metainterp_sd.liveness_info`.
+static ALL_LIVENESS: LazyLock<Vec<u8>> = LazyLock::new(|| {
+    const BYTES: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/liveness.bin"));
+    bincode::deserialize(BYTES).unwrap_or_else(|e| {
+        panic!(
+            "pyre-jit-trace: failed to deserialize liveness.bin \
+             ({} bytes): {e}",
+            BYTES.len(),
+        )
+    })
+});
+
+/// RPython: `metainterp_sd.liveness_info` — full shared `all_liveness`
+/// byte stream (see [`ALL_LIVENESS`]).
+pub fn all_liveness() -> &'static [u8] {
+    &ALL_LIVENESS
+}
+
 /// Pool of `DescrRef`s indexed alongside [`all_descrs`] so the
 /// trace-side jitcode walker
 /// ([`crate::jitcode_dispatch::dispatch_via_miframe`]) can resolve each

--- a/pyre/pyre-jit-trace/src/unpack_state.rs
+++ b/pyre/pyre-jit-trace/src/unpack_state.rs
@@ -74,10 +74,19 @@ impl UnpackJitState {
     /// `elect_active_jitdriver_sd`'s vinfo-scan keeps electing jd0. The driver
     /// yields the grown `items` list → `Type::Ref` (the `new` default).
     pub fn unpackiterable_driver_descriptor() -> JitDriverStaticData {
-        JitDriverStaticData::new(
+        let mut sd = JitDriverStaticData::new(
             vec![("greenkey", Type::Ref)],
             vec![("w_iterator", Type::Ref), ("items", Type::Ref)],
-        )
+        );
+        // baseobjspace.py:29-31 `unpackiterable_driver` = reds='auto', only a
+        // `jit_merge_point` in the `while True` drain (no `can_enter_jit`, no
+        // `loop_header`). warmspot.py:762-790 leaves `no_loop_header` at its
+        // `True` default for such a driver, so `opimpl_jit_merge_point`
+        // (pyjitpl.py:1550) auto-adds the loop header unconditionally — the
+        // first trace closes the loop on the `goto` back-edge instead of
+        // unrolling the whole drain to the StopIteration finish.
+        sd.no_loop_header = true;
+        sd
     }
 }
 

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -3412,6 +3412,24 @@ fn build_jit_driver_pair() -> JitDriverPair {
     // is traced in a later slice.
     let jd1 = pyre_jit_trace::unpack_state::UnpackJitState::unpackiterable_driver_descriptor();
     d.meta_interp_mut().register_jitdriver_sd(jd1);
+    // jd1's merge-point walk (`drive_unpack_iterable_trace`) re-traces the
+    // build-time `_unpackiterable_unknown_length` jitcode, whose `BC_LIVE` ops
+    // carry offsets baked against the build-time assembler's `all_liveness`
+    // table.  jd0 traces Python bytecode (PyFrame resume path) and never reads
+    // `metainterp_sd.op_live` / `liveness_info`, so pyre otherwise leaves them
+    // unset (`op_live = 255`).  Install the build-time opcode-id table
+    // (`op_live = insns["live/"]`) + `all_liveness` byte stream into the shared
+    // `staticdata` so the jd1 walk resolves its guard snapshots
+    // (`get_list_of_active_snapshot_boxes`).  Gated on the jd1 experiment so
+    // the default build leaves jd0's staticdata byte-identical; runs here,
+    // before any trace clones the `staticdata` Arc, to satisfy the single-owner
+    // `Arc::get_mut` invariant.
+    if jd1_experiment_enabled() {
+        d.meta_interp_mut().install_liveness_from_build_parts(
+            pyre_jit_trace::jitcode_runtime::insns_opname_to_byte(),
+            pyre_jit_trace::jitcode_runtime::all_liveness(),
+        );
+    }
     // rlib/jit.py:842 set_user_param — the translation-time `--jit STR`
     // option's analog. `PYRE_JIT="vec_all=1"` opts vectorization in the
     // PyPy way (parameter; the defaults stay off). `PYRE_JIT=0` keeps its
@@ -4797,17 +4815,72 @@ fn drive_unpack_iterable_trace(
                 &runtime,
                 green_ref,
                 &red_refs,
-            );
+            )
         },
     );
     if dbg {
-        eprintln!("[jd1] trace_jitcode drove={}", drove.is_some());
+        eprintln!("[jd1] trace_jitcode action={drove:?}");
     }
 
-    // The residual side effects already landed on the shared reds; drop the
-    // recorded trace (non-permanent so the cell's abort budget self-limits
-    // retrace storms) without compiling.
-    meta.abort_trace(false);
+    // P1 (compile): when the walk back-edges to the merge point it returns
+    // `CloseLoop`; assemble the recorded unpack loop and register it under the
+    // jd1 green key instead of dropping the trace.  jd1 is novable, so there
+    // are no virtualizable boxes and the jump args are the two loop-carried
+    // reds (`w_iterator`, `items`) in `collect_jump_args` order.  `PyreMeta`
+    // for the novable driver is fully static (no interpreter-frame
+    // projection).  No enter path yet: the loop is compiled and registered but
+    // the caller still drains it, so this only proves the recorded trace is
+    // compilable — the double-consumption fix is the later enter slice.
+    use majit_metainterp::{JitState, TraceAction};
+    let jump_args = match &drove {
+        Some(TraceAction::CloseLoop) => {
+            Some(pyre_jit_trace::unpack_state::UnpackJitState::collect_jump_args(&sym))
+        }
+        Some(TraceAction::CloseLoopWithArgs { jump_args, .. }) => Some(jump_args.clone()),
+        _ => None,
+    };
+    if let Some(jump_args) = jump_args {
+        let trace_meta = pyre_jit_trace::unpack_state::UnpackJitState {
+            greenkey: greenkey_raw,
+        }
+        .build_meta(JD1_LOOP_HEADER_PC, &pyre_jit_trace::state::PyreEnv);
+        let outcome = meta.compile_loop(&jump_args, trace_meta);
+        if dbg {
+            eprintln!("[jd1] compile_loop outcome={outcome:?}");
+        }
+    } else if let Some(TraceAction::Finish {
+        finish_args,
+        finish_arg_types,
+        exit_with_exception,
+    }) = drove
+    {
+        // A straight-line trace that closes by finishing rather than
+        // back-edging (the unpack loop's `StopIteration` exit reached before a
+        // full body + back-edge): route through the same finish-compile path
+        // jd0 uses so P1 still proves the recorded trace is assemblable.
+        match meta.compile_finish_from_active_session(
+            &finish_args,
+            finish_arg_types,
+            exit_with_exception,
+        ) {
+            Ok(()) => {
+                if dbg {
+                    eprintln!("[jd1] compile_finish ok exit_with_exception={exit_with_exception}");
+                }
+            }
+            Err(stb) => {
+                if dbg {
+                    eprintln!("[jd1] compile_finish aborted reason={}", stb.reason);
+                }
+                meta.aborted_tracing(stb.reason);
+            }
+        }
+    } else {
+        // The trace neither closed a loop nor reached a finish (aborted or
+        // still open); drop it non-permanently so the cell's abort budget
+        // self-limits retrace storms.
+        meta.abort_trace(false);
+    }
 }
 
 /// The single `jit_merge_point` pc in jd1's extracted

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -4818,13 +4818,7 @@ fn drive_unpack_iterable_trace(
                 recursive_exec_void,
             );
             majit_metainterp::trace_jitcode_from_merge_point(
-                ctx,
-                &mut sym,
-                &jitcode,
-                header_pc,
-                &runtime,
-                green_ref,
-                &red_refs,
+                ctx, &mut sym, &jitcode, header_pc, &runtime, green_ref, &red_refs,
             )
         },
     );

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -4781,13 +4781,23 @@ fn drive_unpack_iterable_trace(
         items: majit_ir::OpRef::input_arg_typed(1, majit_ir::Type::Ref),
     };
 
-    // Enter the trace AT the merge point (pc `0x5c`), not the jitcode entry:
-    // the extracted body's prologue (`length_hint`/`newlist`/
-    // `iterator_greenkey`) takes `w_iterable`, which the merge-point hook does
-    // not carry, so replaying from pc 0 would run `length_hint` on the wrong
-    // red. Drive through the production resolver runtime (the same closures
-    // jd0's live dispatch uses) so any CALL_ASSEMBLER / recursive-portal op
-    // resolves against real compiled-loop / warmstate state.
+    // The `jit_merge_point` opcode byte offset in the extracted body — the
+    // single source of truth is `UnpackSym::loop_header_pc()`.
+    // `trace_jitcode_from_merge_point` seeds `code_cursor` at this pc and
+    // decodes the merge-point register lists from `header_pc + 2`, so it must
+    // be the opcode byte, not one byte into the operands.
+    let header_pc = {
+        use majit_metainterp::JitCodeSym;
+        sym.loop_header_pc()
+    };
+
+    // Enter the trace AT the merge point, not the jitcode entry: the extracted
+    // body's prologue (`length_hint`/`newlist`/`iterator_greenkey`) takes
+    // `w_iterable`, which the merge-point hook does not carry, so replaying from
+    // pc 0 would run `length_hint` on the wrong red. Drive through the
+    // production resolver runtime (the same closures jd0's live dispatch uses)
+    // so any CALL_ASSEMBLER / recursive-portal op resolves against real
+    // compiled-loop / warmstate state.
     let drove = meta.with_trace_ctx_and_token_resolver(
         |ctx,
          resolve_token,
@@ -4811,7 +4821,7 @@ fn drive_unpack_iterable_trace(
                 ctx,
                 &mut sym,
                 &jitcode,
-                JD1_LOOP_HEADER_PC,
+                header_pc,
                 &runtime,
                 green_ref,
                 &red_refs,
@@ -4843,7 +4853,7 @@ fn drive_unpack_iterable_trace(
         let trace_meta = pyre_jit_trace::unpack_state::UnpackJitState {
             greenkey: greenkey_raw,
         }
-        .build_meta(JD1_LOOP_HEADER_PC, &pyre_jit_trace::state::PyreEnv);
+        .build_meta(header_pc, &pyre_jit_trace::state::PyreEnv);
         let outcome = meta.compile_loop(&jump_args, trace_meta);
         if dbg {
             eprintln!("[jd1] compile_loop outcome={outcome:?}");
@@ -4882,11 +4892,6 @@ fn drive_unpack_iterable_trace(
         meta.abort_trace(false);
     }
 }
-
-/// The single `jit_merge_point` pc in jd1's extracted
-/// `_unpackiterable_unknown_length` body — matches `UnpackSym::loop_header_pc`
-/// (asserted in `unpack_state::jd1_build_time_descrs_resolve_through_global_pool`).
-const JD1_LOOP_HEADER_PC: usize = 0x5c;
 
 /// Eagerly register pyre-jit's hooks into pyre-interpreter so callers
 /// like `sys.settrace` see the JIT side from the very first user call,

--- a/pyre/pyre-object/src/interp_exceptions.rs
+++ b/pyre/pyre-object/src/interp_exceptions.rs
@@ -130,6 +130,9 @@ pub enum ExcKind {
     KeyError = 7,
     AttributeError = 8,
     RuntimeError = 9,
+    // The jd1 drain-match fusion bakes this discriminant as a literal
+    // `ConstInt(10)` kind test (majit-translate front/result_exc.rs); keep the
+    // two in sync — renumbering silently miscompiles the fused break test.
     StopIteration = 10,
     OverflowError = 11,
     ArithmeticError = 12,
@@ -1316,6 +1319,18 @@ pub unsafe fn is_exception(obj: PyObjectRef) -> bool {
 #[inline]
 pub unsafe fn w_exception_get_kind(obj: PyObjectRef) -> ExcKind {
     unsafe { (*(obj as *const W_BaseException)).kind }
+}
+
+/// Reads the caught exception's `kind` discriminant as an integer, the
+/// residual-callable twin of `w_exception_get_kind`.  The tracer cannot
+/// model the raw pointer read, so the JIT residualises the call rather than
+/// tracing into it (`@dont_look_inside`); the residual resolves its address
+/// by qualified path in `jit_trace_fnaddrs`.  A non-inline standalone graph
+/// (unlike the `#[inline]` accessor) is what the census residualises.
+#[majit_macros::dont_look_inside]
+pub fn exc_kind_discriminant(evalue: PyObjectRef) -> i64 {
+    // Safety: `evalue` is a valid `W_BaseException` (the caught exception).
+    unsafe { w_exception_get_kind(evalue) as i64 }
 }
 
 /// Get the Python type name string for an ExcKind.


### PR DESCRIPTION
## Summary

Fuses the jd1 `_unpackiterable_unknown_length` drain-loop `match next()` into an
exception-edge handler, then unblocks the jd1 merge-point walk so the recorded
trace **compiles** (`Finish` / `compile_finish`) instead of aborting.

Before: the walk SIGBUSed on the materialized `Result<PyObjectRef, PyError>` shell
(`SyntheticTransparentCtor` + `PyErrorKind::eq` residuals with no host function),
and after the SIGBUS was removed it aborted. This PR removes the SIGBUS (Facet A
fusion) **and** fixes the abort — which turned out to be a merge-point entry
off-by-one, not a dispatch gap.

## Commits

1. `jd1: install build-time all_liveness into shared staticdata` (pre-existing on the branch)
2. `jit: fuse jd1 _unpackiterable_unknown_length drain-match into an exception-edge handler` — Facet A (+ 2 review fixes)
3. `majit-trace: compute the stats op-reduction percentage in f64` — pre-existing `MAJIT_STATS` underflow surfaced by this branch's op-count shift
4. `majit-metainterp: add BC_ARRAYLEN_GC trace-walk dispatch arm` — real `run_one_step` arm (used by `w_list_append`'s arraylen once the walk inlines append) + `TraceCtx::opimpl_arraylen_gc` extraction
5. `majit-translate: rustfmt result_exc.rs`
6. `jd1: enter the merge-point trace at the loop-header opcode byte` — **the abort fix**
7. `jd1: mark the unpackiterable driver as a no-loop-header driver` — RPython parity

## Facet A — drain-match fusion

- Restructured the interpreter source guard to the RPython handler form
  `Err(e) => { if e.kind == StopIteration { break } return Err(e) }`
  (mirrors `except OperationError as e: if not e.match(space, w_StopIteration): raise; break`),
  which yields clean MIR (no guard-desugared dead `Err(e)` re-bind on the break arm).
- Added caller rule `try_fuse_drain_match` (`front/result_exc.rs`) that rewrites the
  `next()` call block to `LastException` exits: normal → append the raw element; exception
  → a handler testing `exc_kind_discriminant(evalue) == ExcKind::StopIteration` (break) else
  reraise via `type(evalue)` to the exceptblock.
- The kind test is the **exact per-kind equality** the source performs (via a
  census-resolvable `#[dont_look_inside] exc_kind_discriminant` accessor + a
  `bh_w_exception_get_kind` C-ABI bridge) — **not** an MRO/subclass match, which would
  diverge from the interpreter for e.g. `class X(ValueError, StopIteration)`.
- Fail-safe: any structural mismatch declines to the existing `catch_and_rewrap` path.
  The two fallible tail rewrites are validated **before any graph mutation**, so a decline
  leaves the graph byte-identical (the Ok carrier must be consumed by exactly the
  value-producing `__pos_0[Result::Ok]` read; the reraise arm must forward its `Err`
  unconditionally to returnblock).

## jd1 walk unblock — abort was a phantom

After Facet A the walk still aborted. RCA: `drive_unpack_iterable_trace` seeded the walk at
`JD1_LOOP_HEADER_PC = 0x5c`, **one byte past** the `jit_merge_point` opcode at 0x5b
(`UnpackSym::loop_header_pc()` / the `merge_points[0].pc == 0x5b` test assertion).
`trace_jitcode_from_merge_point` uses that pc directly as `code_cursor` and decodes the
merge-point register lists from `header_pc + 2`, so starting at 0x5c dispatched the
merge-point's `jdindex` operand byte (`0x01`) as an opcode. That byte is `BC_ARRAYLEN_GC`,
so the walk read the following operand bytes as a bogus descr index (257) and aborted —
the "`unknown jitcode bytecode 1`" panic and the arraylen/descr-pool symptom were both this
one phantom. Fix: source `header_pc` from `UnpackSym::loop_header_pc()` so the duplicated
constant can't drift.

The commit-4 `BC_ARRAYLEN_GC` arm is kept as legit forward infrastructure: `w_list_append`
carries a real `arraylen_gc` (descr 38 → Array) that the walk reaches once it inlines
append on the element-yielded path.

`no_loop_header = true` matches RPython: `unpackiterable_driver` is `reds='auto'` with only a
`jit_merge_point` (no `can_enter_jit`/`loop_header`), so `warmspot.py:762-790` leaves
`no_loop_header` at its `True` default and `opimpl_jit_merge_point` auto-adds the loop header
on the back-edge.

## Verification

- `pyre/extra_tests/parity_tests/unpack_drain_exact_kind.py` (new): self-checking parity
  guard under `PYRE_JD1=1` — each case's hot/JIT outcome must equal its cold/interpreter
  outcome, including a multi-base `(ValueError, StopIteration)` that distinguishes the
  exact-kind lowering from a divergent MRO-match. **`OK`.**
- Boot smoke + census intact (no class-drop panic); `cargo check --workspace` clean.
- jd1 walk (`PYRE_JD1=1 PYRE_JD1_THRESHOLD=1`): `trace_jitcode action=Finish{…}` +
  `compile_finish ok` (was `Abort`).

## Scope note

The trace now **compiles as a `Finish`** (the StopIteration drain-exit). It does not yet
reach the `CloseLoop → compile_loop` north-star: the walk's residual `next()` takes the
exception edge on the first call (regardless of iterator length), so it never back-edges.
That points at the jd1 live-drive residual-call execution of `next()` and is the next
slice. No enter path yet — the caller still drains, so this is compile+register only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
