### PR TITLE
jit: plain-root-bridge self-recursive inline lift + consume_boxes-parity bridge resume

### DIFF
--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -2649,6 +2649,10 @@ impl<S: JitState> JitDriver<S> {
                     }
                 }
                 self.meta.abort_trace_live(false);
+                // `pyjitpl.py:2785-2789` counts every SwitchToBlackhole abort,
+                // including a bridge whose greenkey is None. `Decline` is a
+                // pyre pre-trace coverage fallback, not a traced abort, so it
+                // deliberately remains outside `aborted_tracing` accounting.
                 if !matches!(action, TraceAction::Decline) {
                     self.meta.aborted_tracing(reason_int);
                 }

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -2562,7 +2562,9 @@ impl<S: JitState> JitDriver<S> {
             // (PyreMetaInterp::step_inline_frame pops the inline frame and
             // records the CALL_ASSEMBLER); it never reaches the jitdriver.
             // Defensive: treat an escaped instance as a plain Abort.
-            action @ (TraceAction::RecursiveCallAssembler { .. } | TraceAction::Abort) => {
+            action @ (TraceAction::RecursiveCallAssembler { .. }
+            | TraceAction::Abort
+            | TraceAction::Decline) => {
                 if self.meta.bridge_info().is_some() {
                     crate::debug::log_one("jit-abort", "Abort during bridge tracing");
                 }
@@ -2647,7 +2649,9 @@ impl<S: JitState> JitDriver<S> {
                     }
                 }
                 self.meta.abort_trace_live(false);
-                self.meta.aborted_tracing(reason_int);
+                if !matches!(action, TraceAction::Decline) {
+                    self.meta.aborted_tracing(reason_int);
+                }
                 self.sym = None;
                 self.meta.clear_trace_session();
             }

--- a/majit/majit-metainterp/src/lib.rs
+++ b/majit/majit-metainterp/src/lib.rs
@@ -367,6 +367,9 @@ pub enum TraceAction {
     SegmentedLoop,
     /// Abort the current trace (recoverable — may retry later).
     Abort,
+    /// Decline the current trace before compilation and return to residual
+    /// execution without charging a trace abort.
+    Decline,
     /// Abort the current trace permanently (never trace this location again).
     AbortPermanent,
     /// A loop back-edge was reached inside an inline callee frame whose

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/fbw_state.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/fbw_state.rs
@@ -124,6 +124,29 @@ pub(crate) fn fbw_rec_multiframe_enabled() -> bool {
     })
 }
 
+/// `PYRE_FBW_BRIDGE_REC_INLINE` (default OFF) — on a plain root bridge walk,
+/// lift the bridge-trace decline that keeps an exact-integer arithmetic callee a
+/// single residual call, letting the bridge inline one self-recursive level
+/// exactly as a primary trace does: the call falls through to the self-recursive
+/// unroll gate and the multiframe seed instead of returning a residual.
+/// Experimental de-risk lever for bridge-served self-recursive inline;
+/// default-off pending A/B measurement and badness-floor gating.  The miscompile
+/// hazard it admits — a bridge-inlined int-binop callee's second virtual frame
+/// operand stack has no red bridge input, so an overflow/exception resume path
+/// can leave a NULL vable stack slot — is contained by the seed-success
+/// precondition plus the `n_parents == n_callees` snapshot valve fallbacks.
+/// `=1`/`true` turns it on.
+pub(crate) fn fbw_bridge_rec_inline_enabled() -> bool {
+    static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ENABLED.get_or_init(|| match std::env::var_os("PYRE_FBW_BRIDGE_REC_INLINE") {
+        Some(v) => {
+            let v = v.to_string_lossy();
+            v != "0" && !v.eq_ignore_ascii_case("false")
+        }
+        None => false,
+    })
+}
+
 /// Full-portal recursive-call cutover (`PYRE_FBW_REC_MUTUAL_CUTOVER`): at the
 /// inline-unroll cap, route a recursive callee (self OR mutual) through
 /// `get_assembler_token` → `compile_tmp_callback` (warmstate.py,

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/fbw_state.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/fbw_state.rs
@@ -124,18 +124,19 @@ pub(crate) fn fbw_rec_multiframe_enabled() -> bool {
     })
 }
 
-/// `PYRE_FBW_BRIDGE_REC_INLINE` (default OFF) — on a plain root bridge walk,
+/// `PYRE_FBW_BRIDGE_REC_INLINE` (default ON) — on a plain root bridge walk,
 /// lift the bridge-trace decline that keeps an exact-integer arithmetic callee a
 /// single residual call, letting the bridge inline one self-recursive level
 /// exactly as a primary trace does: the call falls through to the self-recursive
-/// unroll gate and the multiframe seed instead of returning a residual.
-/// Experimental de-risk lever for bridge-served self-recursive inline;
-/// default-off pending A/B measurement and badness-floor gating.  The miscompile
-/// hazard it admits — a bridge-inlined int-binop callee's second virtual frame
-/// operand stack has no red bridge input, so an overflow/exception resume path
-/// can leave a NULL vable stack slot — is contained by the seed-success
-/// precondition plus the `n_parents == n_callees` snapshot valve fallbacks.
-/// `=1`/`true` turns it on.
+/// unroll gate and the multiframe seed instead of returning a residual.  The
+/// miscompile hazard it admits — a bridge-inlined int-binop callee's second
+/// virtual frame operand stack has no red bridge input, so an overflow/exception
+/// resume path can leave a NULL vable stack slot — is contained by the
+/// seed-success precondition plus the `n_parents == n_callees` snapshot valve
+/// fallbacks.  A/B across the bench corpus is byte-parity clean and adds no
+/// `loops_aborted` or `internal_compile_panics`; fib_recursive gains one inlined
+/// bridge (guard_failures 407 -> 406, bridges_compiled 2 -> 3) for a ~10% win.
+/// `=0`/`false` opts back out.
 pub(crate) fn fbw_bridge_rec_inline_enabled() -> bool {
     static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
     *ENABLED.get_or_init(|| match std::env::var_os("PYRE_FBW_BRIDGE_REC_INLINE") {
@@ -143,7 +144,7 @@ pub(crate) fn fbw_bridge_rec_inline_enabled() -> bool {
             let v = v.to_string_lossy();
             v != "0" && !v.eq_ignore_ascii_case("false")
         }
-        None => false,
+        None => true,
     })
 }
 

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
@@ -1378,7 +1378,7 @@ pub(crate) fn try_walker_inline_resolved_user_call<Sym: WalkSym>(
     // The primary loop still inlines the callee, and non-integer/user-
     // overridable calls continue through the ordinary inline/abort policy.
     //
-    // Exception (`PYRE_FBW_BRIDGE_REC_INLINE`, default off): a plain ROOT bridge
+    // Exception (`PYRE_FBW_BRIDGE_REC_INLINE`, default on): a plain ROOT bridge
     // walk — no carrier resume, not an inline sub-walk, an empty framestack, and
     // a live root portal — is uniform with a primary trace, so its second
     // virtual frame is seeded and snapshot-covered exactly as the loop's is.

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
@@ -1377,11 +1377,24 @@ pub(crate) fn try_walker_inline_resolved_user_call<Sym: WalkSym>(
     // overflow path can then compile NULL vable stack slots into the bridge.
     // The primary loop still inlines the callee, and non-integer/user-
     // overridable calls continue through the ordinary inline/abort policy.
+    //
+    // Exception (`PYRE_FBW_BRIDGE_REC_INLINE`, default off): a plain ROOT bridge
+    // walk — no carrier resume, not an inline sub-walk, an empty framestack, and
+    // a live root portal — is uniform with a primary trace, so its second
+    // virtual frame is seeded and snapshot-covered exactly as the loop's is.
+    // There the decline is lifted: the call falls through to the self-recursive
+    // unroll gate and multiframe seed as if walked from a primary trace.
     if ctx.trace_ctx.is_bridge_trace
         && args_all_builtin_integer
         && fbw_callee_body_has_binary_op_residual(body.code, callee_descr_refs)
     {
-        return Ok(None);
+        let safe_root_bridge = !ctx.fbw_mode.carrier_resume
+            && !ctx.fbw_mode.inline_subwalk
+            && !ctx.fbw_mode.snapshot_sym.is_null()
+            && ctx.session.borrow().framestack.is_empty();
+        if !(fbw_bridge_rec_inline_enabled() && safe_root_bridge) {
+            return Ok(None);
+        }
     }
     // An inline sub-walk inside a FOR_ITER body resumes a guard at the
     // caller's CALL boundary, so deopt re-executes the whole callee.  Replaying

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -6018,8 +6018,9 @@ fn reconstruct_inline_recipe(
     }
 
     // Virtualizable-callee shape (pyre's "every function is its own portal"
-    // model): the callee's only live ref registers are the portal reds
-    // [frame, ec], and its locals live in the `frame` red's own
+    // model): the callee's live ref registers are the portal reds [frame, ec]
+    // (and, at a mid-expression pause, operands kept live across a CALL), while
+    // its locals live in the `frame` red's own
     // `locals_cells_stack_w` virtual array — the same place the ROOT frame keeps
     // its locals — NOT in the register section. Recover them into REGISTER-
     // SECTION slots so the bridge rebuilds the callee as a plain MIFrame
@@ -6041,14 +6042,42 @@ fn reconstruct_inline_recipe(
     let (pframe_reg, pec_reg) = portal_red_regs_at(frame.jitcode_index);
     let (pframe_reg, pec_reg) = (pframe_reg as u32, pec_reg as u32);
     let has_frame = reg_indices.ref_.contains(&pframe_reg);
-    let full_portal =
-        reg_indices.ref_.len() == 2 && has_frame && reg_indices.ref_.contains(&pec_reg);
-    let in_call_portal =
-        in_a_call && pending_value_index.is_some() && reg_indices.ref_.len() == 1 && has_frame;
-    if pframe_reg != u32::from(u16::MAX)
-        && pec_reg != u32::from(u16::MAX)
-        && (full_portal || in_call_portal)
-    {
+    let maps = bridge_semantic_maps_from_pc(frame.jitcode_index, frame.pc);
+    // resume.py:1042-1057 `rebuild_from_resumedata` / `consume_boxes` rebuilds
+    // every paused frame and fills EVERY live register from the resume stream
+    // with no shape classifier. Pyre recovers a portal callee's locals from the
+    // `frame` red's own `locals_cells_stack_w` virtual array (below) rather than
+    // the register section, so accept any paused portal callee whose every live
+    // non-red color names a semantic slot at this pc (the `pcdep` inversion the
+    // encoder used): the reds are recovered through the `frame`, and each live
+    // operand kept across a CALL — e.g. `result1` in `f(a) + g(b)` at the second
+    // CALL — is decoded semantic-ordered from the flushed array. This single
+    // predicate subsumes the canonical `[frame, ec]` and the reduced `[frame]`
+    // in-a-call shapes; a slot the pause-time flush did not cover still declines
+    // at the mandatory-operand check below.
+    let portal_callee = has_frame
+        && reg_indices.ref_.iter().all(|&c| {
+            c == pframe_reg
+                || c == pec_reg
+                || semantic_ref_slot_for_reg_color(
+                    nlocals,
+                    stack_only,
+                    &maps.pcdep_entries,
+                    c as usize,
+                )
+                .is_some()
+        });
+    if pframe_reg != u32::from(u16::MAX) && pec_reg != u32::from(u16::MAX) && portal_callee {
+        // Distinguish the sibling-operand admission (a live color beyond the
+        // portal reds) from the canonical reds-only shape so the corpus shows
+        // what exercises the widened acceptance.
+        if reg_indices
+            .ref_
+            .iter()
+            .any(|&c| c != pframe_reg && c != pec_reg)
+        {
+            crate::jitcode_dispatch::census_record("P2Recipe::PortalSiblingAdmit");
+        }
         use majit_ir::resumedata::{RebuiltValue, TAGVIRTUAL, UNINITIALIZED_TAG, untag};
         let frame_pos = reg_indices.ref_.iter().position(|&c| c == pframe_reg)?;
         let RebuiltValue::Virtual(frame_vidx) = values[frame_pos] else {
@@ -6121,6 +6150,7 @@ fn reconstruct_inline_recipe(
                 continue;
             }
             if registers_r[s] == OpRef::NONE {
+                crate::jitcode_dispatch::census_record("P2Recipe::MandatoryOperandMissing");
                 return None;
             }
         }
@@ -6155,8 +6185,8 @@ fn reconstruct_inline_recipe(
     // resume pc there is no per-pc map to faithfully rebuild the frame, so
     // decline to the single-frame bridge (whose vable payload IS semantic-
     // ordered) rather than rebuild the frame with mis-slotted boxes.
-    let maps = bridge_semantic_maps_from_pc(frame.jitcode_index, frame.pc);
     if maps.pcdep_entries.is_empty() {
+        crate::jitcode_dispatch::census_record("P2Recipe::PortalShapeRejected");
         return None;
     }
     for &color in &reg_indices.ref_ {
@@ -6171,7 +6201,10 @@ fn reconstruct_inline_recipe(
             Some(semantic_idx) if semantic_idx == color as usize => {}
             // A live color whose semantic slot differs (or is unmappable):
             // the color-indexed recipe would mis-slot it. Decline.
-            _ => return None,
+            _ => {
+                crate::jitcode_dispatch::census_record("P2Recipe::PortalShapeRejected");
+                return None;
+            }
         }
     }
 

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -1996,6 +1996,11 @@ pub struct PyreSym {
     /// `None` for a non-branch-guard resume, where the walk
     /// keeps the opcode-entry offset for `py_pc`.
     pub(crate) bridge_walk_entry_pc: Option<usize>,
+    /// JitCode body that owns `bridge_walk_entry_pc`. `resume.py:1049-1056`
+    /// constructs the resumed frame and applies its PC from the same resume
+    /// section; retain that body identity so the walker never interprets the
+    /// offset in another installed body for this code object.
+    pub(crate) bridge_walk_entry_jitcode_index: i32,
     /// The color-indexed Ref register bank as `consume_boxes`
     /// (resume.py:1055) fills `f.registers_r` — one box per abstract
     /// register color the guard's resume numbering named. This is the
@@ -2185,6 +2190,7 @@ pub trait WalkSym {
     fn live_vable_frame_addr(&self) -> usize;
     fn set_live_vable_frame_addr(&mut self, value: usize);
     fn bridge_walk_entry_pc(&self) -> Option<usize>;
+    fn bridge_walk_entry_jitcode_index(&self) -> i32;
     fn bridge_registers_r(&self) -> Option<&Vec<OpRef>>;
     fn bridge_registers_r_mut(&mut self) -> &mut Option<Vec<OpRef>>;
     fn bridge_stack_oprefs(&self) -> Option<&Vec<OpRef>>;
@@ -2304,6 +2310,11 @@ impl WalkSym for PyreSym {
     #[inline]
     fn bridge_walk_entry_pc(&self) -> Option<usize> {
         self.bridge_walk_entry_pc
+    }
+
+    #[inline]
+    fn bridge_walk_entry_jitcode_index(&self) -> i32 {
+        self.bridge_walk_entry_jitcode_index
     }
 
     #[inline]
@@ -4477,6 +4488,7 @@ impl PyreSym {
             bridge_local_oprefs: None,
             bridge_stack_oprefs: None,
             bridge_walk_entry_pc: None,
+            bridge_walk_entry_jitcode_index: -1,
             bridge_registers_r: None,
             bridge_local_types: None,
             vable_last_instr: OpRef::NONE,
@@ -9267,6 +9279,7 @@ impl JitState for PyreJitState {
         sym.bridge_walk_entry_pc =
             crate::state::frame_pc_is_resolved_offset_at(frame0.jitcode_index, frame0.pc)
                 .then_some(frame0.pc as usize);
+        sym.bridge_walk_entry_jitcode_index = frame0.jitcode_index;
         sym.bridge_local_types = Some(bridge_local_types);
         // consume_boxes (resume.py:1055) fills `f.registers_r` by abstract
         // register color; keep that color-indexed decode so a cross-frame

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -1990,6 +1990,58 @@ fn run_perfn_walk<Sym: WalkSym>(
         Vec::new()
     };
 
+    // resume.py:1042-1057 `consume_boxes` fills every register named by the
+    // resume marker's `live/` stream.  A bridge whose carried coordinate names
+    // such a marker starts this walk from the input banks above, so reject the
+    // walk when those banks cannot provide one of the marker's live colors.
+    //
+    // A null Ref in `argboxes_r` is also uncovered here.  For this bridge
+    // shape, positional Ref seeds come from the restored stack-slot mirror;
+    // a live register receiving its mirror's null is not a valid replacement
+    // for the register value `consume_boxes` would have restored.  This is
+    // deliberately a decline-only soundness gate: later color-indexed seeding
+    // may make the value available, but must prove this coverage first.
+    // `Some` is the actual resume-marker discriminator: setup_bridge_sym sets
+    // it only when the carried frame pc is a decodable `live/` offset.
+    if is_bridge_trace && sym.bridge_walk_entry_pc().is_some() {
+        let live = crate::state::frame_liveness_reg_indices_by_bank_from_pc(
+            pjc.jitcode.index() as i32,
+            entry as i32,
+        );
+        let missing_ref = live.ref_.iter().copied().find(|&color| {
+            !matches!(
+                argboxes_r.get(color as usize),
+                Some(opref)
+                    if !opref.is_none()
+                        && !matches!(opref, majit_ir::OpRef::ConstPtr(gcref) if gcref.0 == 0)
+            )
+        });
+        let missing_int = live.int.iter().copied().find(|&color| {
+            argboxes_i
+                .get(color as usize)
+                .is_none_or(|opref| opref.is_none())
+        });
+        // `dispatch_via_miframe` has no Float bridge-input bank; therefore any
+        // Float color live at a resume marker is
+        // necessarily uncovered.
+        let missing_float = live.float.first().copied();
+        if missing_ref.is_some() || missing_int.is_some() || missing_float.is_some() {
+            crate::jitcode_dispatch::census_record("Fbw::BridgeEntryLiveRegUnseeded");
+            if crate::jitcode_dispatch::fbw_debug_abort_enabled() {
+                eprintln!(
+                    "[fbw-bridge-decline] uncovered resume-marker live register: \
+                     jitcode_index={} entry={} ref={missing_ref:?} int={missing_int:?} \
+                     float={missing_float:?}",
+                    pjc.jitcode.index(),
+                    entry,
+                );
+            }
+            fbw_bridge_decline(ctx);
+            fbw_decline(crate::driver::make_green_key(w_code, start_pc));
+            return None;
+        }
+    }
+
     let Some((code_len, mut walk_result)) = dispatch_perfn_frame(
         ctx,
         sym,
@@ -3411,7 +3463,11 @@ fn full_body_walk_trace<Sym: WalkSym>(
             if crate::jitcode_dispatch::fbw_debug_abort_enabled() {
                 eprintln!("[fbw-abort] start_pc={start_pc} run_perfn_walk returned None");
             }
-            TraceAction::Abort
+            if ctx.is_bridge_trace && FBW_BRIDGE_DECLINED.with(|c| c.get()) {
+                TraceAction::Decline
+            } else {
+                TraceAction::Abort
+            }
         }
     }
 }

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -2026,51 +2026,73 @@ fn run_perfn_walk<Sym: WalkSym>(
         return None;
     }
 
-    // resume.py:1042-1057 `consume_boxes` fills every register named by the
-    // resume marker's `live/` stream.  A bridge whose carried coordinate names
-    // such a marker starts this walk from the input banks above, so reject the
-    // walk when those banks cannot provide one of the marker's live colors.
+    // The foreign-JitCode check above is a first-class runtime decline. Below,
+    // resume.py:1017-1057 `consume_boxes` / `enumerate_vars` fills every live
+    // Ref, Int, and Float register from the marker's stream. With the total
+    // bridge seed above, an uncovered color is a codewriter/seed defect.
     // `_callback_r` writes `next_ref()` directly (resume.py:1032-1034), so a
-    // restored null Ref is a covered value; only `OpRef::NONE` is absent.
-    // `Some` is the actual resume-marker discriminator: setup_bridge_sym sets
-    // it only when the carried frame pc is a decodable `live/` offset.
+    // restored null Ref is covered; only `OpRef::NONE` is absent. `Some` is
+    // the resume-marker discriminator: setup_bridge_sym sets it only when the
+    // carried frame pc is a decodable `live/` offset.
     if is_bridge_trace && sym.bridge_walk_entry_pc().is_some() {
         let live = crate::state::frame_liveness_reg_indices_by_bank_from_pc(
             pjc.jitcode.index() as i32,
             entry as i32,
         );
-        let missing_ref = live.ref_.iter().copied().find(|&color| {
-            argboxes_r
-                .get(color as usize)
-                .is_none_or(|opref| opref.is_none())
-        });
-        let missing_int = live.int.iter().copied().find(|&color| {
-            argboxes_i
-                .get(color as usize)
-                .is_none_or(|opref| opref.is_none())
-        });
-        // resume.py:1036-1038 `_callback_f` fills each Float color named by
-        // the resume marker, and the Float input bank above seeds it by color.
-        let missing_float = live.float.iter().copied().find(|&color| {
-            argboxes_f
-                .get(color as usize)
-                .is_none_or(|opref| opref.is_none())
-        });
-        if missing_ref.is_some() || missing_int.is_some() || missing_float.is_some() {
-            if missing_ref.is_some() {
-                crate::jitcode_dispatch::census_record("Fbw::BridgeEntryLiveRegUnseeded::Ref");
-            }
-            if missing_int.is_some() {
-                crate::jitcode_dispatch::census_record("Fbw::BridgeEntryLiveRegUnseeded::Int");
-            }
-            if missing_float.is_some() {
-                crate::jitcode_dispatch::census_record("Fbw::BridgeEntryLiveRegUnseeded::Float");
-            }
+        let uncovered = live
+            .ref_
+            .iter()
+            .copied()
+            .find(|&color| {
+                argboxes_r
+                    .get(color as usize)
+                    .is_none_or(|opref| opref.is_none())
+            })
+            .map(|color| ("Ref", color))
+            .or_else(|| {
+                live.int
+                    .iter()
+                    .copied()
+                    .find(|&color| {
+                        argboxes_i
+                            .get(color as usize)
+                            .is_none_or(|opref| opref.is_none())
+                    })
+                    .map(|color| ("Int", color))
+            })
+            .or_else(|| {
+                live.float
+                    .iter()
+                    .copied()
+                    .find(|&color| {
+                        argboxes_f
+                            .get(color as usize)
+                            .is_none_or(|opref| opref.is_none())
+                    })
+                    .map(|color| ("Float", color))
+            });
+        debug_assert!(
+            uncovered.is_none(),
+            "consume_boxes totality violated: jitcode_index={} entry={} uncovered={uncovered:?}",
+            pjc.jitcode.index(),
+            entry,
+        );
+        if let Some((bank, color)) = uncovered {
+            // read_int_reg/read_float_reg (jitcode_dispatch/mod.rs:1907-1936)
+            // only bounds-check. An uncovered color would record OpRef::NONE
+            // into an operation and can become a SIGSEGV or miscompile; retain
+            // this cold decline as the release airbag.
+            let census_key = match bank {
+                "Ref" => "Fbw::BridgeEntryLiveRegUnseeded::Ref",
+                "Int" => "Fbw::BridgeEntryLiveRegUnseeded::Int",
+                "Float" => "Fbw::BridgeEntryLiveRegUnseeded::Float",
+                _ => unreachable!("unknown bridge register bank"),
+            };
+            crate::jitcode_dispatch::census_record(census_key);
             if crate::jitcode_dispatch::fbw_debug_abort_enabled() {
                 eprintln!(
                     "[fbw-bridge-decline] uncovered resume-marker live register: \
-                     jitcode_index={} entry={} ref={missing_ref:?} int={missing_int:?} \
-                     float={missing_float:?}",
+                     jitcode_index={} entry={} bank={bank} color={color}",
                     pjc.jitcode.index(),
                     entry,
                 );

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -2003,6 +2003,29 @@ fn run_perfn_walk<Sym: WalkSym>(
         Vec::new()
     };
 
+    // resume.py:1049-1056 constructs a frame and consumes its register stream
+    // against that frame's JitCode body. Do not interpret a carried offset in
+    // another installed body for the same code object: its register colors are
+    // a foreign coordinate space. This is a runtime decline, not a green-key
+    // disable, because a later bridge may carry a matching body identity.
+    if is_bridge_trace
+        && sym.bridge_walk_entry_pc().is_some()
+        && pjc.jitcode.index() as i32 != sym.bridge_walk_entry_jitcode_index()
+    {
+        crate::jitcode_dispatch::census_record("Fbw::BridgeEntryForeignJitcode");
+        if crate::jitcode_dispatch::fbw_debug_abort_enabled() {
+            eprintln!(
+                "[fbw-bridge-decline] foreign resume-marker jitcode: body_index={} \\
+                 bridge_jitcode_index={} entry={}",
+                pjc.jitcode.index(),
+                sym.bridge_walk_entry_jitcode_index(),
+                entry,
+            );
+        }
+        fbw_bridge_decline(ctx);
+        return None;
+    }
+
     // resume.py:1042-1057 `consume_boxes` fills every register named by the
     // resume marker's `live/` stream.  A bridge whose carried coordinate names
     // such a marker starts this walk from the input banks above, so reject the
@@ -2034,7 +2057,15 @@ fn run_perfn_walk<Sym: WalkSym>(
                 .is_none_or(|opref| opref.is_none())
         });
         if missing_ref.is_some() || missing_int.is_some() || missing_float.is_some() {
-            crate::jitcode_dispatch::census_record("Fbw::BridgeEntryLiveRegUnseeded");
+            if missing_ref.is_some() {
+                crate::jitcode_dispatch::census_record("Fbw::BridgeEntryLiveRegUnseeded::Ref");
+            }
+            if missing_int.is_some() {
+                crate::jitcode_dispatch::census_record("Fbw::BridgeEntryLiveRegUnseeded::Int");
+            }
+            if missing_float.is_some() {
+                crate::jitcode_dispatch::census_record("Fbw::BridgeEntryLiveRegUnseeded::Float");
+            }
             if crate::jitcode_dispatch::fbw_debug_abort_enabled() {
                 eprintln!(
                     "[fbw-bridge-decline] uncovered resume-marker live register: \

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -1994,13 +1994,8 @@ fn run_perfn_walk<Sym: WalkSym>(
     // resume marker's `live/` stream.  A bridge whose carried coordinate names
     // such a marker starts this walk from the input banks above, so reject the
     // walk when those banks cannot provide one of the marker's live colors.
-    //
-    // A null Ref in `argboxes_r` is also uncovered here.  For this bridge
-    // shape, positional Ref seeds come from the restored stack-slot mirror;
-    // a live register receiving its mirror's null is not a valid replacement
-    // for the register value `consume_boxes` would have restored.  This is
-    // deliberately a decline-only soundness gate: later color-indexed seeding
-    // may make the value available, but must prove this coverage first.
+    // `_callback_r` writes `next_ref()` directly (resume.py:1032-1034), so a
+    // restored null Ref is a covered value; only `OpRef::NONE` is absent.
     // `Some` is the actual resume-marker discriminator: setup_bridge_sym sets
     // it only when the carried frame pc is a decodable `live/` offset.
     if is_bridge_trace && sym.bridge_walk_entry_pc().is_some() {
@@ -2009,12 +2004,9 @@ fn run_perfn_walk<Sym: WalkSym>(
             entry as i32,
         );
         let missing_ref = live.ref_.iter().copied().find(|&color| {
-            !matches!(
-                argboxes_r.get(color as usize),
-                Some(opref)
-                    if !opref.is_none()
-                        && !matches!(opref, majit_ir::OpRef::ConstPtr(gcref) if gcref.0 == 0)
-            )
+            argboxes_r
+                .get(color as usize)
+                .is_none_or(|opref| opref.is_none())
         });
         let missing_int = live.int.iter().copied().find(|&color| {
             argboxes_i
@@ -2037,7 +2029,6 @@ fn run_perfn_walk<Sym: WalkSym>(
                 );
             }
             fbw_bridge_decline(ctx);
-            fbw_decline(crate::driver::make_green_key(w_code, start_pc));
             return None;
         }
     }

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -802,7 +802,7 @@ type PerfnWalkResult = Result<
 /// ([`drive_bridge_carrier_walk`]).  Resolves the five terminal descrs off
 /// `MetaInterpStaticData`, builds the per-CodeObject descr pool + sub-jitcode
 /// lookup off `pjc.jitcode.exec.descrs`, and runs `dispatch_via_miframe` from
-/// `entry` with the caller-seeded `argboxes_r`.  Returns
+/// `entry` with the caller-seeded register banks.  Returns
 /// `(code_len, walk_result)`; `None` when the terminal descrs are unwired.
 fn dispatch_perfn_frame<Sym: WalkSym>(
     ctx: &mut TraceCtx,
@@ -814,6 +814,7 @@ fn dispatch_perfn_frame<Sym: WalkSym>(
     entry: usize,
     argboxes_r: &[majit_ir::OpRef],
     argboxes_i: &[majit_ir::OpRef],
+    argboxes_f: &[majit_ir::OpRef],
     authoritative: bool,
 ) -> Option<(usize, PerfnWalkResult)> {
     // Resolve the five terminal descrs off MetaInterpStaticData so the
@@ -918,7 +919,7 @@ fn dispatch_perfn_frame<Sym: WalkSym>(
         pjc.jitcode.constants_f.as_slice(),
         argboxes_r,
         argboxes_i,
-        &[],
+        argboxes_f,
     );
     Some((code_len, walk_result))
 }
@@ -1990,6 +1991,18 @@ fn run_perfn_walk<Sym: WalkSym>(
         Vec::new()
     };
 
+    // resume.py:1036-1038 `_callback_f` parity: seed the Float bank the same
+    // way as argboxes_i. Empty for a non-marker resume; `truncate(num_regs_f)`
+    // strips the copy_constants tail exactly as the Int build does.
+    let argboxes_f: Vec<majit_ir::OpRef> = if sym.bridge_walk_entry_pc().is_some() {
+        let num_regs_f = pjc.jitcode.num_regs_f() as usize;
+        let mut v = sym.registers_f().to_vec();
+        v.truncate(num_regs_f);
+        v
+    } else {
+        Vec::new()
+    };
+
     // resume.py:1042-1057 `consume_boxes` fills every register named by the
     // resume marker's `live/` stream.  A bridge whose carried coordinate names
     // such a marker starts this walk from the input banks above, so reject the
@@ -2013,10 +2026,13 @@ fn run_perfn_walk<Sym: WalkSym>(
                 .get(color as usize)
                 .is_none_or(|opref| opref.is_none())
         });
-        // `dispatch_via_miframe` has no Float bridge-input bank; therefore any
-        // Float color live at a resume marker is
-        // necessarily uncovered.
-        let missing_float = live.float.first().copied();
+        // resume.py:1036-1038 `_callback_f` fills each Float color named by
+        // the resume marker, and the Float input bank above seeds it by color.
+        let missing_float = live.float.iter().copied().find(|&color| {
+            argboxes_f
+                .get(color as usize)
+                .is_none_or(|opref| opref.is_none())
+        });
         if missing_ref.is_some() || missing_int.is_some() || missing_float.is_some() {
             crate::jitcode_dispatch::census_record("Fbw::BridgeEntryLiveRegUnseeded");
             if crate::jitcode_dispatch::fbw_debug_abort_enabled() {
@@ -2043,6 +2059,7 @@ fn run_perfn_walk<Sym: WalkSym>(
         entry,
         &argboxes_r,
         &argboxes_i,
+        &argboxes_f,
         authoritative,
     ) else {
         return None;


### PR DESCRIPTION
## Summary

Lands the depth-1 self-recursive inline lift for exact-integer arithmetic
callees (`fib`-shaped recursion), plus the guard-failure bridge resume path
brought to `consume_boxes` totality parity. Eight commits in two arcs.

The depth-2 recursive inline this line of work originally targeted has since
landed on main (#674); what remains here is the depth-1 inline lift (measured
~6% on fib) and the resume-path orthodoxy the depth-2 shape motivated, now
carried to its endpoint: the bridge-entry seed is total (all three register
banks) so the coverage decline degrades to a `debug_assert` with a retained
cold airbag.

## Arc 1 — depth-1 inline lift + resume-path orthodoxy (commits 1–5)

1. `gate a plain-root-bridge self-recursive inline behind PYRE_FBW_BRIDGE_REC_INLINE`
2. `default PYRE_FBW_BRIDGE_REC_INLINE on`
3. `Decline uncovered bridge-entry live registers`
4. `generalize the inline-recipe portal-callee shape toward consume_boxes totality`
5. `preserve null bridge refs and per-guard declines`

### 1–2. Plain-root-bridge self-recursive inline lift

On a guard-failure bridge walk, an exact-integer arithmetic callee
(`args_all_builtin_integer` + a `BinaryOp` residual body) was unconditionally
kept as one residual call, because re-inlining it would create a second virtual
frame whose operand stack is not a red bridge input (an overflow path could
compile NULL vable stack slots into the bridge).

This admits that inline only on a **plain root bridge** — `!carrier_resume &&
!inline_subwalk && snapshot_sym non-null && framestack empty` — uniform with a
primary trace: its second virtual frame is seeded and snapshot-covered exactly
as the loop's is, and the call falls through to the existing self-recursive
unroll gate and multiframe seed. The NULL-vable hazard is contained by the
seed-success precondition plus the `n_parents == n_callees` snapshot valve
fallbacks. Behind `PYRE_FBW_BRIDGE_REC_INLINE` (default-on; `=0` opts out).

Measured: fib36 ~6.4% faster with the lift on vs `PYRE_FBW_BRIDGE_REC_INLINE=0`.

### 3 + 5. Bridge-entry live-register soundness net (consume_boxes parity)

`run_perfn_walk` decodes the codewriter `live/` set at a bridge entry pc and
declines the walk — a non-abort `TraceAction::Decline` that falls back to
residual without charging `loops_aborted` — when a live register the resume
marker names cannot be seeded from the bridge input banks. This mirrors the
`consume_boxes` totality contract (`resume.py:1042-1057`): every live register
must be fillable. Refined to upstream parity:

- declines only on an **absent** register (`OpRef::NONE`); a seeded
  `ConstPtr(NULL)` is a restored null value, not "uncovered" (`_callback_r`,
  `resume.py:1032-1034`);
- **per-guard** decline (`declined_bridge_guards`), not a whole-greenkey
  permanent disable — blackhole-once-retryable (`compile.py:701-717`);
- `Decline` is a pre-trace coverage fallback, documented stats-neutral against
  `pyjitpl.py:2785-2789`.

### 4. Inline-recipe portal-callee generalization

`reconstruct_inline_recipe` classified a paused portal callee with two
enumerated shapes: the canonical `[frame, ec]` reds-only form and the reduced
`[frame]` in-a-call form. A middle frame paused mid-expression keeps operands
live on the stack beside the reds, a wider live-ref set both shapes reject,
collapsing the carrier to a zero-recipe plain bridge.

Replace the two shapes with one predicate: accept any paused portal callee
whose every live non-red color maps to a semantic `locals_cells_stack_w` slot
through the per-pc pcdep inversion. The portal arm reconstructs each slot
semantic-ordered from the frame virtual's array; the mandatory-operand NONE
check still declines an uncovered slot. This subsumes both prior shapes and
narrows the gap to `consume_boxes`, which fills every live register with no
classifier.

## Arc 2 — S1 endpoint: total bridge seed (commits 6–8)

6. `Thread Float bridge input bank`
7. `Decline foreign bridge JitCode bodies`
8. `Assert bridge register seed totality`

Brings the bridge-entry seed to full `consume_boxes` totality
(`resume.py:1017-1057` — `enumerate_vars` fires `_callback_i/_r/_f` over every
live register of all three banks), so the arc-1 coverage decline degrades to an
assertion:

- **6.** `dispatch_via_miframe` already accepts a Float bridge-input bank
  (`bridge_subwalk.rs:56`, seeded `top_regs_f`) and `setup_bridge_sym` already
  decodes Float colors into `registers_f`; the sole caller passed `&[]`. Thread
  the Float bank through `dispatch_perfn_frame` and seed it exactly like
  `argboxes_i` (`_callback_f`, `resume.py:1036-1038`). The categorical
  "any live Float is uncovered" leg becomes the same per-color probe as Int/Ref.
- **7.** `resume.py:1049-1056` constructs the resumed frame against its own
  JitCode body and applies the PC from that body's resume section. A guard from
  a different installed body for the same code object carries a foreign
  coordinate space; persist `frame0.jitcode_index` on the sym and decline
  (first-class runtime `Decline`, retryable — never a green-key disable) when it
  does not match `pjc.jitcode.index()`. Census `Fbw::BridgeEntryForeignJitcode`.
- **8.** With the total seed, an uncovered live color is a codewriter/seed
  defect: `debug_assert!("consume_boxes totality violated")` enforces the
  endpoint in CI. The cold decline is retained as the release airbag
  (`read_int_reg`/`read_float_reg` do not NONE-check, so an uncovered color
  would record `OpRef::NONE` into an op → SIGSEGV/miscompile), with the
  coverage census split per bank (`…Unseeded::{Ref,Int,Float}`) for zero-fire
  evidence.

## Verification

- `check.py --backend dynasm`: 285/285 ALL PASSED.
- Byte-parity: fib 20/24/28 default-JIT vs `PYRE_JIT=0` (6765 / 46368 / 317811).
- Float workloads (`float_loop`, `spectral_norm`, `nbody`): JIT vs `PYRE_JIT=0`
  byte-identical, `loops_aborted=0`, `internal_compile_panics=0`, every
  `Fbw::BridgeEntry*` census leg zero-fire.
- Assert-armed debug build (fib 20/24/28, `fib_recursive`, `inline_helper`, the
  three float workloads, `PYRE_FBW_BRIDGE_REC_INLINE=1
  PYRE_FBW_MULTIFRAME_DEPTH=2` stress): the totality `debug_assert` does not
  trip; all outputs correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
