### PR TITLE
jit: fix two exception-path compile defects (last-exc lookahead, except-tuple pin)

### DIFF
--- a/majit/majit-metainterp/src/history.rs
+++ b/majit/majit-metainterp/src/history.rs
@@ -2407,6 +2407,10 @@ impl TraceCtx {
             frames: recorder_frames,
             vable_boxes: vable_boxes.to_vec(),
             vref_boxes: vref_boxes.to_vec(),
+            // The nested-list append fold resumes through the single-frame
+            // collapse, never this multi-frame path, so no extra virtual roots
+            // flow here.
+            extra_virtual_roots: Vec::new(),
         });
         self.set_last_guard_op_resume_position(snapshot_id);
     }

--- a/pyre/bench/synth/except_tuple_clause_hot.py
+++ b/pyre/bench/synth/except_tuple_clause_hot.py
@@ -1,0 +1,42 @@
+# An `except (A, B):` clause builds its match target with `BUILD_TUPLE` on
+# every visit, so the tuple is a fresh object each time the handler runs. The
+# `CHECK_EXC_MATCH` fold pins the match target it saw while tracing; pinning
+# the container rather than its elements makes that guard unsatisfiable on a
+# re-allocated tuple, and the handler then side-exits once per visit. The
+# elements are `LOAD_GLOBAL` constants already covered by the quasi-immutable
+# invalidation guard, so the clause must stay on the compiled path.
+#
+# The single-class `except A:` loop below is the control: same raise rate, a
+# match target that is loaded rather than built. Both loops must agree with the
+# interpreter and neither may accumulate side exits. Output verified against
+# CPython/PyPy.
+N = 60000
+
+
+def tuple_clause(n):
+    acc = 0
+    i = 0
+    while i < n:
+        try:
+            if i > 2:
+                raise TypeError("x")
+        except (TypeError, ValueError):
+            acc += 9
+        i += 1
+    return acc
+
+
+def single_clause(n):
+    acc = 0
+    i = 0
+    while i < n:
+        try:
+            if i > 2:
+                raise TypeError("x")
+        except TypeError:
+            acc += 9
+        i += 1
+    return acc
+
+
+print(tuple_clause(N), single_clause(N))

--- a/pyre/bench/synth/except_tuple_clause_hot.py
+++ b/pyre/bench/synth/except_tuple_clause_hot.py
@@ -8,8 +8,7 @@
 #
 # The single-class `except A:` loop below is the control: same raise rate, a
 # match target that is loaded rather than built. Both loops must agree with the
-# interpreter and neither may accumulate side exits. Output verified against
-# CPython/PyPy.
+# interpreter and neither may accumulate side exits.
 N = 60000
 
 

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
@@ -2134,18 +2134,77 @@ pub(crate) fn exc_handler_rejoins_loop(code: &[u8], catch_target: usize) -> bool
     false
 }
 
+/// True when a path reachable from `position` reads the walker's active
+/// exception (`last_exception/>i` / `last_exc_value/>r`) before reaching the
+/// `catch_exception/L` that would replace it.
+///
+/// The jitcode is one flat byte stream whose blocks are stitched together by
+/// `goto/L` labels, so the block that physically follows an op is frequently
+/// not its successor. Advancing by `op.next_pc` alone therefore walks out of
+/// the current block and answers from whatever block the assembler happened to
+/// place next — reporting that block's `catch_exception/L` while the real
+/// successor reads the exception. The residual-call sites act on that answer by
+/// clearing `last_exc_value`, so the read then finds no active exception and
+/// the walk aborts (`LastExcValueWithoutActiveException`) for the whole run.
+///
+/// Labels are followed instead: `goto/L` continues at its target,
+/// `goto_if_not/iL` queues its taken arm and continues on the fall-through, and
+/// ops that end a path stop it — `catch_exception/L` because the handler it
+/// introduces installs a fresh exception, `raise`/`reraise` because they
+/// replace the current one, and the `*_return` family because the frame is
+/// gone. Targets are visited once, which bounds the walk across back edges.
+///
+/// Both answers are recoverable: a spurious `false` clears an exception a later
+/// read wants, a spurious `true` leaves one live for a later
+/// `catch_exception/L` to reject. Each ends the walk in a typed
+/// [`DispatchError`] and falls back to the interpreter, so neither can produce
+/// a wrong result.
 fn reads_last_exc_before_next_catch(code: &[u8], position: usize) -> bool {
+    // Arms queued by a conditional branch, and the jump targets already
+    // started from. Both stay empty on a straight-line answer.
+    let mut pending: Vec<usize> = Vec::new();
+    let mut started: Vec<usize> = Vec::new();
     let mut pc = position;
-    while let Some(op) = decode_op_at(code, pc) {
-        if op.key == "catch_exception/L" {
-            return false;
+    loop {
+        let path_continues = match decode_op_at(code, pc) {
+            None => false,
+            Some(op) => match op.key {
+                "last_exception/>i" | "last_exc_value/>r" => return true,
+                "catch_exception/L" | "raise/r" | "reraise/" | "int_return/i" | "int_return/c"
+                | "ref_return/r" | "float_return/f" | "void_return/" => false,
+                "goto/L" => {
+                    let target = read_label(code, &op, 0);
+                    let fresh = !started.contains(&target);
+                    if fresh {
+                        started.push(target);
+                        pc = target;
+                    }
+                    fresh
+                }
+                "goto_if_not/iL" => {
+                    // Operand layout `iL`: the label sits after the 1-byte
+                    // Int register.
+                    let target = read_label(code, &op, 1);
+                    if !started.contains(&target) {
+                        started.push(target);
+                        pending.push(target);
+                    }
+                    pc = op.next_pc;
+                    true
+                }
+                _ => {
+                    pc = op.next_pc;
+                    true
+                }
+            },
+        };
+        if !path_continues {
+            match pending.pop() {
+                Some(next) => pc = next,
+                None => return false,
+            }
         }
-        if matches!(op.key, "last_exception/>i" | "last_exc_value/>r") {
-            return true;
-        }
-        pc = op.next_pc;
     }
-    false
 }
 
 /// Read a 2-byte little-endian descr index operand and resolve to

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
@@ -2072,6 +2072,26 @@ pub(crate) fn find_catch_before_resume_live(code: &[u8], resume_live_pos: usize)
     None
 }
 
+/// Byte offset of the 2-byte label operand inside an op's operand block,
+/// derived from the operand signature in `key` (the part after `/`, up to the
+/// `>` that introduces the result). Register operands (`i` / `r` / `f`) are one
+/// byte each, so the offset is the number of them preceding the `L`.
+///
+/// `None` when the op carries no label, or when an operand whose width this
+/// decode does not model (a var-list, a descr) sits in front of it.
+fn label_operand_offset(key: &str) -> Option<usize> {
+    let signature = key.split('/').nth(1)?.split('>').next()?;
+    let mut offset = 0usize;
+    for operand in signature.chars() {
+        match operand {
+            'L' => return Some(offset),
+            'i' | 'r' | 'f' => offset += 1,
+            _ => return None,
+        }
+    }
+    None
+}
+
 /// Does the `except` handler at `catch_target` flow back into this frame's loop
 /// (reaching a `jit_merge_point` back-edge), rather than returning out of the
 /// frame (`*_return`)?
@@ -2147,18 +2167,20 @@ pub(crate) fn exc_handler_rejoins_loop(code: &[u8], catch_target: usize) -> bool
 /// clearing `last_exc_value`, so the read then finds no active exception and
 /// the walk aborts (`LastExcValueWithoutActiveException`) for the whole run.
 ///
-/// Labels are followed instead: `goto/L` continues at its target,
-/// `goto_if_not/iL` queues its taken arm and continues on the fall-through, and
-/// ops that end a path stop it — `catch_exception/L` because the handler it
-/// introduces installs a fresh exception, `raise`/`reraise` because they
-/// replace the current one, and the `*_return` family because the frame is
-/// gone. Targets are visited once, which bounds the walk across back edges.
+/// Labels are followed instead: `goto/L` continues at its target, a
+/// conditional branch queues its taken arm and continues on the fall-through,
+/// and ops that end a path stop it — `catch_exception/L` because the handler it
+/// introduces installs a fresh exception, `raise/r` because it replaces the
+/// current one, `unreachable/` because it has no successor, and the `*_return`
+/// family because the frame is gone. Targets are visited once, which bounds the
+/// walk across back edges.
 ///
-/// Both answers are recoverable: a spurious `false` clears an exception a later
-/// read wants, a spurious `true` leaves one live for a later
-/// `catch_exception/L` to reject. Each ends the walk in a typed
-/// [`DispatchError`] and falls back to the interpreter, so neither can produce
-/// a wrong result.
+/// The answer is an over-approximation of the reads: whenever the successor set
+/// is not decodable — `switch/id`, whose targets live in a descr this scan
+/// cannot read, or any other label-carrying op whose shape is not modelled —
+/// the exception is reported as read. Over-reporting only leaves a recorded
+/// exception standing for the caller, whereas under-reporting drops one a later
+/// read still needs.
 fn reads_last_exc_before_next_catch(code: &[u8], position: usize) -> bool {
     // Arms queued by a conditional branch, and the jump targets already
     // started from. Both stay empty on a straight-line answer.
@@ -2169,9 +2191,11 @@ fn reads_last_exc_before_next_catch(code: &[u8], position: usize) -> bool {
         let path_continues = match decode_op_at(code, pc) {
             None => false,
             Some(op) => match op.key {
-                "last_exception/>i" | "last_exc_value/>r" => return true,
-                "catch_exception/L" | "raise/r" | "reraise/" | "int_return/i" | "int_return/c"
-                | "ref_return/r" | "float_return/f" | "void_return/" => false,
+                // `opimpl_reraise` re-raises `last_exc_value`, so it reads the
+                // exception exactly like `last_exc_value/>r`.
+                "last_exception/>i" | "last_exc_value/>r" | "reraise/" => return true,
+                "catch_exception/L" | "raise/r" | "unreachable/" | "int_return/i"
+                | "int_return/c" | "ref_return/r" | "float_return/f" | "void_return/" => false,
                 "goto/L" => {
                     let target = read_label(code, &op, 0);
                     let fresh = !started.contains(&target);
@@ -2181,10 +2205,11 @@ fn reads_last_exc_before_next_catch(code: &[u8], position: usize) -> bool {
                     }
                     fresh
                 }
-                "goto_if_not/iL" => {
-                    // Operand layout `iL`: the label sits after the 1-byte
-                    // Int register.
-                    let target = read_label(code, &op, 1);
+                key if key.starts_with("goto_if") || key.contains("jump_if_ovf") => {
+                    let Some(offset) = label_operand_offset(key) else {
+                        return true;
+                    };
+                    let target = read_label(code, &op, offset);
                     if !started.contains(&target) {
                         started.push(target);
                         pending.push(target);
@@ -2192,7 +2217,10 @@ fn reads_last_exc_before_next_catch(code: &[u8], position: usize) -> bool {
                     pc = op.next_pc;
                     true
                 }
-                _ => {
+                key => {
+                    if key == "switch/id" || label_operand_offset(key).is_some() {
+                        return true;
+                    }
                     pc = op.next_pc;
                     true
                 }

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
@@ -2178,9 +2178,9 @@ pub(crate) fn exc_handler_rejoins_loop(code: &[u8], catch_target: usize) -> bool
 /// The answer is an over-approximation of the reads: whenever the successor set
 /// is not decodable — `switch/id`, whose targets live in a descr this scan
 /// cannot read, or any other label-carrying op whose shape is not modelled —
-/// the exception is reported as read. Over-reporting only leaves a recorded
-/// exception standing for the caller, whereas under-reporting drops one a later
-/// read still needs.
+/// the exception is reported as read, as it is for an op the decode cannot read
+/// at all. Over-reporting only leaves a recorded exception standing for the
+/// caller, whereas under-reporting drops one a later read still needs.
 fn reads_last_exc_before_next_catch(code: &[u8], position: usize) -> bool {
     // Arms queued by a conditional branch, and the jump targets already
     // started from. Both stay empty on a straight-line answer.
@@ -2189,11 +2189,19 @@ fn reads_last_exc_before_next_catch(code: &[u8], position: usize) -> bool {
     let mut pc = position;
     loop {
         let path_continues = match decode_op_at(code, pc) {
-            None => false,
+            // The decode fails on an opcode byte outside the instruction table
+            // and on a payload the stream is too short to hold, not only at the
+            // end of the code — the ops beyond it are unknown either way.
+            None => return true,
             Some(op) => match op.key {
-                // `opimpl_reraise` re-raises `last_exc_value`, so it reads the
-                // exception exactly like `last_exc_value/>r`.
-                "last_exception/>i" | "last_exc_value/>r" | "reraise/" => return true,
+                // `opimpl_reraise` re-raises `last_exc_value`, and
+                // `opimpl_goto_if_exception_mismatch` asserts it before testing
+                // the class, so both read the exception exactly like
+                // `last_exc_value/>r`.
+                "last_exception/>i"
+                | "last_exc_value/>r"
+                | "reraise/"
+                | "goto_if_exception_mismatch/iL" => return true,
                 "catch_exception/L" | "raise/r" | "unreachable/" | "int_return/i"
                 | "int_return/c" | "ref_return/r" | "float_return/f" | "void_return/" => false,
                 "goto/L" => {

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
@@ -2109,6 +2109,19 @@ fn walker_guard_exc_match_tuple_items<Sym: WalkSym>(
         ) {
             return Ok(false);
         }
+        // Read every element before recording anything: a bail-out after a
+        // guard has been emitted would leave the target's class pinned, and the
+        // caller reads that as "already guarded" and drops its own pin.
+        let len = unsafe { pyre_object::w_tuple_len(match_type) };
+        let mut concretes: Vec<pyre_object::PyObjectRef> = Vec::with_capacity(len);
+        for index in 0..len {
+            let Some(concrete) =
+                (unsafe { pyre_object::w_tuple_getitem(match_type, index as i64) })
+            else {
+                return Ok(false);
+            };
+            concretes.push(concrete);
+        }
         walker_guard_exc_match_tuple_class(ctx, op_pc, match_op, tuple_type as i64)?;
         walker_guard_exact_w_class(ctx, op_pc, match_op, canonical_tuple_class)?;
         let block = crate::state::opimpl_getfield_gc_r(
@@ -2116,7 +2129,6 @@ fn walker_guard_exc_match_tuple_items<Sym: WalkSym>(
             match_op,
             crate::descr::tuple_wrappeditems_descr(),
         );
-        let len = unsafe { pyre_object::w_tuple_len(match_type) };
         let length = crate::state::opimpl_arraylen_gc(
             ctx.trace_ctx,
             block,
@@ -2124,15 +2136,10 @@ fn walker_guard_exc_match_tuple_items<Sym: WalkSym>(
         );
         let len_const = ctx.trace_ctx.const_int(len as i64);
         walker_emit_fold_guard_with_snapshot(ctx, op_pc, OpCode::GuardValue, &[length, len_const])?;
-        for index in 0..len {
+        for (index, concrete) in concretes.into_iter().enumerate() {
             let index_op = ctx.trace_ctx.const_int(index as i64);
             let item =
                 crate::state::trace_items_block_getitem_value(ctx.trace_ctx, block, index_op);
-            let Some(concrete) =
-                (unsafe { pyre_object::w_tuple_getitem(match_type, index as i64) })
-            else {
-                return Ok(false);
-            };
             items.push((item, concrete));
         }
     } else {

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
@@ -2084,6 +2084,16 @@ fn walker_guard_exc_match_tuple_items<Sym: WalkSym>(
         as *const pyre_object::pyobject::PyType;
     let tuple_type = &pyre_object::TUPLE_TYPE as *const pyre_object::pyobject::PyType;
 
+    // Either layout may carry a subclass `w_class`, and the element reads below
+    // are only the whole target when it is a plain tuple.
+    let canonical_tuple_class = pyre_object::get_instantiate(&pyre_object::TUPLE_TYPE);
+    if !std::ptr::eq(
+        unsafe { (*(match_type as *const pyre_object::pyobject::PyObject)).w_class },
+        canonical_tuple_class,
+    ) {
+        return Ok(false);
+    }
+
     let mut items: Vec<(OpRef, pyre_object::PyObjectRef)> = Vec::new();
     if std::ptr::eq(ob_type, spec_oo) {
         walker_guard_exc_match_tuple_class(ctx, op_pc, match_op, spec_oo as i64)?;
@@ -2102,13 +2112,6 @@ fn walker_guard_exc_match_tuple_items<Sym: WalkSym>(
             items.push((item, concrete));
         }
     } else if std::ptr::eq(ob_type, tuple_type) {
-        let canonical_tuple_class = pyre_object::get_instantiate(&pyre_object::TUPLE_TYPE);
-        if !std::ptr::eq(
-            unsafe { (*(match_type as *const pyre_object::pyobject::PyObject)).w_class },
-            canonical_tuple_class,
-        ) {
-            return Ok(false);
-        }
         // Read every element before recording anything: a bail-out after a
         // guard has been emitted would leave the target's class pinned, and the
         // caller reads that as "already guarded" and drops its own pin.

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
@@ -2057,6 +2057,118 @@ pub(crate) fn try_walker_specialize_compare_op_int<Sym: WalkSym>(
 /// Declines (`None` → generic residual) when either operand lacks a
 /// concrete shadow, or `match_type` is not a valid exception class /
 /// tuple (the residual then raises the correct `TypeError`).
+/// Pin the elements of a tuple `except` clause's match target, returning
+/// whether the target was a tuple layout this could read through.
+///
+/// `w_tuple_new` picks the layout by arity: two object elements become a
+/// `W_SpecialisedTupleObject_oo` holding them in inline immutable `value0` /
+/// `value1` slots, everything else an array-backed `W_TupleObject` behind
+/// `wrappeditems`. Both are read here with the same guarded-load shape the
+/// other tuple folds use, and each element is pinned to the class seen while
+/// tracing. The `_oo` loads are pure (immutable fields), so a tuple built from
+/// constants leaves nothing behind after optimization.
+///
+/// A match target that is neither layout — a bare class, the int/float
+/// specialisations, or a tuple subclass whose `w_class` diverges — returns
+/// `false` so the caller pins the object identity instead. That is correct for
+/// a target that is loaded rather than built, which is the only case where the
+/// identity can hold across iterations.
+fn walker_guard_exc_match_tuple_items<Sym: WalkSym>(
+    ctx: &mut WalkContext<'_, '_, Sym>,
+    op_pc: usize,
+    match_op: OpRef,
+    match_type: pyre_object::PyObjectRef,
+) -> Result<bool, DispatchError> {
+    let ob_type = unsafe { (*(match_type as *const pyre_object::pyobject::PyObject)).ob_type };
+    let spec_oo = &pyre_object::specialisedtupleobject::SPECIALISED_TUPLE_OO_TYPE
+        as *const pyre_object::pyobject::PyType;
+    let tuple_type = &pyre_object::TUPLE_TYPE as *const pyre_object::pyobject::PyType;
+
+    let mut items: Vec<(OpRef, pyre_object::PyObjectRef)> = Vec::new();
+    if std::ptr::eq(ob_type, spec_oo) {
+        walker_guard_exc_match_tuple_class(ctx, op_pc, match_op, spec_oo as i64)?;
+        for index in 0..2usize {
+            let descr = if index == 0 {
+                crate::descr::specialised_tuple_oo_value0_descr()
+            } else {
+                crate::descr::specialised_tuple_oo_value1_descr()
+            };
+            let item = crate::state::opimpl_getfield_gc_r(ctx.trace_ctx, match_op, descr);
+            let concrete = unsafe {
+                pyre_object::specialisedtupleobject::w_specialised_tuple_oo_getvalue(
+                    match_type, index,
+                )
+            };
+            items.push((item, concrete));
+        }
+    } else if std::ptr::eq(ob_type, tuple_type) {
+        let canonical_tuple_class = pyre_object::get_instantiate(&pyre_object::TUPLE_TYPE);
+        if !std::ptr::eq(
+            unsafe { (*(match_type as *const pyre_object::pyobject::PyObject)).w_class },
+            canonical_tuple_class,
+        ) {
+            return Ok(false);
+        }
+        walker_guard_exc_match_tuple_class(ctx, op_pc, match_op, tuple_type as i64)?;
+        walker_guard_exact_w_class(ctx, op_pc, match_op, canonical_tuple_class)?;
+        let block = crate::state::opimpl_getfield_gc_r(
+            ctx.trace_ctx,
+            match_op,
+            crate::descr::tuple_wrappeditems_descr(),
+        );
+        let len = unsafe { pyre_object::w_tuple_len(match_type) };
+        let length = crate::state::opimpl_arraylen_gc(
+            ctx.trace_ctx,
+            block,
+            crate::state::pyobject_gcarray_descr(),
+        );
+        let len_const = ctx.trace_ctx.const_int(len as i64);
+        walker_emit_fold_guard_with_snapshot(ctx, op_pc, OpCode::GuardValue, &[length, len_const])?;
+        for index in 0..len {
+            let index_op = ctx.trace_ctx.const_int(index as i64);
+            let item =
+                crate::state::trace_items_block_getitem_value(ctx.trace_ctx, block, index_op);
+            let Some(concrete) =
+                (unsafe { pyre_object::w_tuple_getitem(match_type, index as i64) })
+            else {
+                return Ok(false);
+            };
+            items.push((item, concrete));
+        }
+    } else {
+        return Ok(false);
+    }
+
+    for (item, concrete) in items {
+        if item.is_constant() {
+            continue;
+        }
+        let expected = ctx.trace_ctx.const_ref(concrete as i64);
+        walker_emit_fold_guard_with_snapshot(ctx, op_pc, OpCode::GuardValue, &[item, expected])?;
+        ctx.trace_ctx.heap_cache_mut().replace_box(item, expected);
+    }
+    Ok(true)
+}
+
+/// `GuardClass` on a match target's layout, skipped when the class is already
+/// pinned.
+fn walker_guard_exc_match_tuple_class<Sym: WalkSym>(
+    ctx: &mut WalkContext<'_, '_, Sym>,
+    op_pc: usize,
+    match_op: OpRef,
+    type_addr: i64,
+) -> Result<(), DispatchError> {
+    if ctx.trace_ctx.heap_cache().is_class_known(match_op) {
+        return Ok(());
+    }
+    let type_const = ctx.trace_ctx.const_int(type_addr);
+    walker_emit_fold_guard_with_snapshot(ctx, op_pc, OpCode::GuardClass, &[match_op, type_const])?;
+    ctx.trace_ctx
+        .heap_cache_mut()
+        .class_now_known(match_op, type_addr);
+    Ok(())
+}
+
 pub(crate) fn try_walker_fold_check_exc_match<Sym: WalkSym>(
     ctx: &mut WalkContext<'_, '_, Sym>,
     op_pc: usize,
@@ -2087,9 +2199,20 @@ pub(crate) fn try_walker_fold_check_exc_match<Sym: WalkSym>(
     let matched = pyre_interpreter::eval::check_exc_match_against(exc, match_type);
 
     // --- commit to the fold: emit IR (no further declines) ---
-    // Pin `match_type` identity so a runtime divergence (a reassigned
-    // handler global) side-exits rather than running the wrong handler.
-    if !match_op.is_constant() && !ctx.trace_ctx.heap_cache().is_class_known(match_op) {
+    // Pin `match_type` so a runtime divergence (a reassigned handler global)
+    // side-exits rather than running the wrong handler.
+    //
+    // A tuple clause is pinned through its ELEMENTS. `except (A, B):` lowers to
+    // `BUILD_TUPLE`, which allocates a fresh tuple on every visit, so an
+    // identity guard on the container is unsatisfiable — it fails once per
+    // visit and the loop collapses into side exits and bridge churn. The
+    // elements are what the match actually reads and what a rebinding would
+    // change, so guarding them is both sound and stable across the
+    // re-allocation.
+    if !match_op.is_constant()
+        && !walker_guard_exc_match_tuple_items(ctx, op_pc, match_op, match_type)?
+        && !ctx.trace_ctx.heap_cache().is_class_known(match_op)
+    {
         let expected = ctx.trace_ctx.const_ref(match_type as i64);
         ctx.trace_ctx
             .record_guard(OpCode::GuardValue, &[match_op, expected], 0);


### PR DESCRIPTION
Two defects made ordinary `try`/`except` shapes fall off the compiled path, plus two follow-up fixes from review.

## 1. The last-exc lookahead was control-flow-blind

`reads_last_exc_before_next_catch` decides whether a residual call may clear the walker's recorded exception. It advanced by `op.next_pc` only, but jitcode is one flat byte stream whose blocks are stitched by `goto/L` — the physically next op is frequently not the successor.

Instrumented on a `raise`/`except E as e:`/`raise e` frame: the scan from the residual call at jitcode pc=2040 ran past `pc=2077 goto/L → 1017` into the unrelated block at 2080, found *that* block's `catch_exception/L`, and answered "no read". The exception was cleared; the real successor `1017 → 1020` is `last_exc_value/>r`, so every trace died with `LastExcValueWithoutActiveException`. `permanent=false`, so the frame retraced and re-aborted for the whole run — `loops_compiled=0`.

Following labels: **3.3x @80k, 8.8x @200k, 18.0x @400k**.

## 2. `except (A, B):` pinned a rebuilt tuple by identity

The clause builds its match target with `BUILD_TUPLE` on every visit, so the tuple is a fresh object each time. `try_walker_fold_check_exc_match` pinned it with `GuardValue(match_op, const_ref(<the traced tuple's address>))` — unsatisfiable. Guard failures came in at roughly N/2 (the nursery bump sometimes hands back the same address, which is what made it look intermittent).

Discriminator: hoisting `EXC = (TypeError, ValueError)` out of the loop took guard failures 49900 → 1; `except (TypeError,)` with a single element was equally slow, so it was never about tuple length or multi-class matching.

Fix pins the **elements** instead. Two object elements land in `W_SpecialisedTupleObject_oo`, whose inline `value0`/`value1` are immutable → `GetfieldGcPureR` → folded away entirely; other arities go through `wrappeditems` behind an `arraylen` guard. Non-tuple targets keep the identity pin, which does hold for a loaded target.

dynasm **0.627 → 0.067s (9.4x)**, cranelift 0.484 → 0.072s, guard failures 29901 → 2, bridges 149 → 0 (pypy 0.059s). 46/79 corpus programs improved, none regressed. The inline tuple-except form appears at **510 sites across 200 files** of the bundled `lib-python`.

Bench added: `pyre/bench/synth/except_tuple_clause_hot.py`.

## 3–4. Review follow-ups

- The lookahead followed only `goto/L` and `goto_if_not/iL`; the other 23 label-bearing ops fell through to the physically next op, `switch/id` successors were never considered, and `reraise/` was classified as not reading the exception although `opimpl_reraise` re-raises `last_exc_value`. The label offset is now derived from the key's operand signature, and an un-decodable successor set answers "read" — over-reporting leaves a recorded exception standing, under-reporting drops one a later read needs.
- `walker_guard_exc_match_tuple_items` emitted the layout `GuardClass` before reading each element, so an element bail-out returned false with the class already pinned; the caller gates its own identity pin on `is_class_known`, which dropped every value guard from the fold. Elements are now read before anything is recorded.

## Not included, deliberately

Removing the `for_iter_frame_has_raising_named_handler` gate was tried on top of these fixes. It measured 2.5–4.9x faster with zero aborts and passed 1088 differential checks on both backends — and it is still **wrong**. The gate blocks *every* abort, not only the one fixed here, and any abort in a FOR_ITER frame drops the in-flight item. A handler body that mutates a container hits `InplaceContainerMutationUnsupported` and the loop returns 3999 items instead of 4000 on both backends; a second shape aborts the process. The differential corpus missed it because no generated handler body mutated a container. The gate stays.

## Verification

check.py **245/245 dynasm + 245/245 cranelift**; pyre-jit-trace 321, pyre-jit 241, majit-metainterp 1401 (dynasm) / 1399 (cranelift); 688 differential checks across 348 generated exception shapes on both backends, 0 wrong.

## Known, pre-existing, out of scope

A JIT-compiled same-frame raise/except never attaches `__traceback__`, so `e.__traceback__` reads `None` inside the handler once the loop compiles (4000 → 201 on both backends; `e.args` and `type(e)` are unaffected). Confirmed pre-existing by rebuilding with `origin/main`'s `jitcode_dispatch/mod.rs` — same result. Filed as follow-up work, untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved exception handling across branching code paths, preventing incorrect exception state tracking.
  - Improved support for matching exceptions against tuples of exception classes.

- **Performance**
  - Refined exception-match optimization to reduce unnecessary runtime checks while preserving correct behavior.

- **Benchmarks**
  - Added coverage to compare tuple-based and single-class exception handling performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->