### PR TITLE
jit: resolve struct layouts for the target being built, not the extraction host

### DIFF
--- a/.github/workflows/pyre-ci.yml
+++ b/.github/workflows/pyre-ci.yml
@@ -124,6 +124,13 @@ jobs:
     # unchanged crates restore while only the changed crate re-extracts; the
     # Extract step below refills any missed crate, so the downstream artefact
     # always carries all three ullbc files.
+    #
+    # Each crate's entry also carries its `*.layouts.ullbc` sidecars — the
+    # same crate re-extracted for a cross target and reduced to its type
+    # declarations, so a wasm32 build reads wasm32 field offsets rather than
+    # the extraction host's. They must restore alongside the artefact they
+    # accompany: a cache hit skips extraction, and `pyre-jit-trace`'s build
+    # script refuses a cross-target build whose sidecars are absent.
     - name: Cache LLBC (pyre-object)
       id: llbc-cache-object
       uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
@@ -131,6 +138,7 @@ jobs:
         path: |
           build/llbc/pyre-object.ullbc
           build/llbc/pyre-object.ullbc.fingerprint
+          build/llbc/pyre-object.*.layouts.ullbc
         key: llbc-pyre-object-${{ runner.os }}-${{ runner.arch }}-${{ env.CHARON_VERSION }}-${{ steps.llbc-fingerprint.outputs.pyre_object }}
     - name: Cache LLBC (pyre-interpreter)
       id: llbc-cache-interpreter
@@ -139,6 +147,7 @@ jobs:
         path: |
           build/llbc/pyre-interpreter.ullbc
           build/llbc/pyre-interpreter.ullbc.fingerprint
+          build/llbc/pyre-interpreter.*.layouts.ullbc
         key: llbc-pyre-interpreter-${{ runner.os }}-${{ runner.arch }}-${{ env.CHARON_VERSION }}-${{ steps.llbc-fingerprint.outputs.pyre_interpreter }}
     - name: Cache LLBC (pyre-jit)
       id: llbc-cache-jit

--- a/majit/majit-metainterp/src/optimizeopt/intbounds.rs
+++ b/majit/majit-metainterp/src/optimizeopt/intbounds.rs
@@ -1636,12 +1636,6 @@ impl Optimization for OptIntBounds {
                 | OpCode::GetfieldRawI
                 | OpCode::GetfieldGcI
                 | OpCode::GetinteriorfieldGcI
-                | OpCode::GetfieldRawR
-                | OpCode::GetfieldGcR
-                | OpCode::GetinteriorfieldGcR
-                | OpCode::GetfieldRawF
-                | OpCode::GetfieldGcF
-                | OpCode::GetinteriorfieldGcF
                 | OpCode::GetarrayitemRawI
                 | OpCode::GetarrayitemGcI
                 | OpCode::CallPureI

--- a/majit/majit-metainterp/src/optimizeopt/intbounds.rs
+++ b/majit/majit-metainterp/src/optimizeopt/intbounds.rs
@@ -1715,15 +1715,14 @@ impl Optimization for OptIntBounds {
             }
 
             // ── Field accesses ──
-            OpCode::GetfieldRawI
-            | OpCode::GetfieldGcI
-            | OpCode::GetinteriorfieldGcI
-            | OpCode::GetfieldRawR
-            | OpCode::GetfieldGcR
-            | OpCode::GetinteriorfieldGcR
-            | OpCode::GetfieldRawF
-            | OpCode::GetfieldGcF
-            | OpCode::GetinteriorfieldGcF => {
+            // `postprocess_GETFIELD_GC_I` and friends: only the int-typed
+            // reads narrow, because the bound this installs is an integer
+            // range and `setintbound` asserts an `'i'` operand.  The `_R` /
+            // `_F` variants have no postprocess of their own.  Their absence
+            // matters on a 32-bit target: a pointer field is 4 bytes wide
+            // there, so it satisfies the sub-word test below and would ask
+            // for an integer bound on a `Ref` box.
+            OpCode::GetfieldRawI | OpCode::GetfieldGcI | OpCode::GetinteriorfieldGcI => {
                 let __descr_arc_d = op.getdescr();
                 if let Some(ref d) = __descr_arc_d.as_ref() {
                     let (field_size, signed) = d.field_size_and_sign();

--- a/majit/majit-translate/src/codewriter/call.rs
+++ b/majit/majit-translate/src/codewriter/call.rs
@@ -1011,12 +1011,12 @@ impl StructLayout {
                     known_struct_sizes
                         .get(type_str.as_str())
                         .copied()
-                        .unwrap_or(std::mem::size_of::<usize>())
+                        .unwrap_or(crate::layout::target_word_size())
                 } else {
                     get_type_flag(type_str).2
                 };
                 if sz > 0 {
-                    let align = sz.min(std::mem::size_of::<usize>());
+                    let align = sz.min(crate::layout::target_word_size());
                     offset = (offset + align - 1) & !(align - 1);
                     offset += sz;
                 }
@@ -1028,7 +1028,7 @@ impl StructLayout {
                 continue;
             }
             // RPython: alignment is typically min(field_size, WORD).
-            let align = field_size.min(std::mem::size_of::<usize>());
+            let align = field_size.min(crate::layout::target_word_size());
             offset = (offset + align - 1) & !(align - 1);
             let rank = immutable_field_ranks.get(name).copied();
             layout_fields.push(StructFieldLayout {
@@ -1056,8 +1056,8 @@ impl StructLayout {
                     known_struct_sizes
                         .get(ty.as_str())
                         .copied()
-                        .unwrap_or(std::mem::size_of::<usize>())
-                        .min(std::mem::size_of::<usize>())
+                        .unwrap_or(crate::layout::target_word_size())
+                        .min(crate::layout::target_word_size())
                 } else {
                     get_type_flag(ty).2
                 }
@@ -1287,7 +1287,7 @@ impl CallControl {
             // RPython: symbolic.get_array_token(GcArray(T))[0] = carray.items.offset
             // = sizeof(Signed) = WORD. Standard GcArray has a length field before items.
             //
-            array_header_size: std::mem::size_of::<usize>(),
+            array_header_size: crate::layout::target_word_size(),
             struct_layouts: HashMap::new(),
             immutable_fields_by_struct: HashMap::new(),
             immutable_array_types: HashSet::new(),
@@ -1645,7 +1645,7 @@ impl CallControl {
                     use majit_ir::descr::SimpleFieldDescr;
                     // `descr.py:264 get_field_arraylen_descr` shape:
                     // `FieldDescr("len", ofs, WORD, FLAG_SIGNED)`.
-                    let word_size = std::mem::size_of::<usize>();
+                    let word_size = crate::layout::target_word_size();
                     std::sync::Arc::new(SimpleFieldDescr::new_with_name(
                         u32::MAX,
                         off,
@@ -6640,7 +6640,7 @@ fn all_interiorfielddescrs(
         if field_name == "typeptr" {
             continue;
         }
-        let align = field_size.min(std::mem::size_of::<usize>());
+        let align = field_size.min(crate::layout::target_word_size());
         if align > 0 {
             offset = (offset + align - 1) & !(align - 1);
         }
@@ -6755,7 +6755,7 @@ fn compute_struct_size(cc: &CallControl, struct_name: &str) -> usize {
             // RPython: symbolic.get_field_token() uses actual nested struct size.
             cc.struct_layout_for(field_type_str)
                 .map(|l| l.size)
-                .unwrap_or(std::mem::size_of::<usize>())
+                .unwrap_or(crate::layout::target_word_size())
         } else {
             let (_, field_type, s) = get_type_flag(field_type_str);
             if field_type == majit_ir::value::Type::Void || s == 0 {
@@ -6763,7 +6763,7 @@ fn compute_struct_size(cc: &CallControl, struct_name: &str) -> usize {
             }
             s
         };
-        let align = field_size.min(std::mem::size_of::<usize>());
+        let align = field_size.min(crate::layout::target_word_size());
         offset = (offset + align - 1) & !(align - 1);
         offset += field_size;
     }
@@ -6773,8 +6773,8 @@ fn compute_struct_size(cc: &CallControl, struct_name: &str) -> usize {
             if cc.is_known_struct(ty) {
                 cc.struct_layout_for(ty)
                     .map(|l| l.size)
-                    .unwrap_or(std::mem::size_of::<usize>())
-                    .min(std::mem::size_of::<usize>())
+                    .unwrap_or(crate::layout::target_word_size())
+                    .min(crate::layout::target_word_size())
             } else {
                 get_type_flag(ty).2
             }
@@ -6810,7 +6810,7 @@ fn field_metadata(
         let nested_size = known_struct_sizes
             .get(type_str)
             .copied()
-            .unwrap_or(std::mem::size_of::<usize>());
+            .unwrap_or(crate::layout::target_word_size());
         (
             majit_ir::descr::ArrayFlag::Struct,
             majit_ir::value::Type::Ref,
@@ -6835,7 +6835,11 @@ pub(crate) fn get_type_flag(
             || s.starts_with("Option<")
             || s == "String" =>
         {
-            (ArrayFlag::Pointer, majit_ir::value::Type::Ref, 8)
+            (
+                ArrayFlag::Pointer,
+                majit_ir::value::Type::Ref,
+                crate::layout::target_word_size(),
+            )
         }
         // RPython: TYPE is lltype.Float → FLAG_FLOAT
         "f64" => (ArrayFlag::Float, majit_ir::value::Type::Float, 8),
@@ -6846,12 +6850,22 @@ pub(crate) fn get_type_flag(
         // `get_array_descr`.
         "f32" => (ArrayFlag::Unsigned, majit_ir::value::Type::Int, 4),
         // RPython: rffi.cast(TYPE, -1) == -1 → FLAG_SIGNED
-        "i64" | "isize" => (ArrayFlag::Signed, majit_ir::value::Type::Int, 8),
+        "i64" => (ArrayFlag::Signed, majit_ir::value::Type::Int, 8),
+        "isize" => (
+            ArrayFlag::Signed,
+            majit_ir::value::Type::Int,
+            crate::layout::target_word_size(),
+        ),
         "i32" => (ArrayFlag::Signed, majit_ir::value::Type::Int, 4),
         "i16" => (ArrayFlag::Signed, majit_ir::value::Type::Int, 2),
         "i8" => (ArrayFlag::Signed, majit_ir::value::Type::Int, 1),
         // RPython: Bool → FLAG_UNSIGNED; unsigned number → FLAG_UNSIGNED
-        "u64" | "usize" => (ArrayFlag::Unsigned, majit_ir::value::Type::Int, 8),
+        "u64" => (ArrayFlag::Unsigned, majit_ir::value::Type::Int, 8),
+        "usize" => (
+            ArrayFlag::Unsigned,
+            majit_ir::value::Type::Int,
+            crate::layout::target_word_size(),
+        ),
         "u32" => (ArrayFlag::Unsigned, majit_ir::value::Type::Int, 4),
         "u16" => (ArrayFlag::Unsigned, majit_ir::value::Type::Int, 2),
         "u8" => (ArrayFlag::Unsigned, majit_ir::value::Type::Int, 1),
@@ -6859,7 +6873,11 @@ pub(crate) fn get_type_flag(
         // RPython: Void fields are skipped
         "()" => (ArrayFlag::Void, majit_ir::value::Type::Void, 0),
         // Unknown type — treat as GC pointer (conservative)
-        _ => (ArrayFlag::Pointer, majit_ir::value::Type::Ref, 8),
+        _ => (
+            ArrayFlag::Pointer,
+            majit_ir::value::Type::Ref,
+            crate::layout::target_word_size(),
+        ),
     }
 }
 

--- a/majit/majit-translate/src/codewriter/call.rs
+++ b/majit/majit-translate/src/codewriter/call.rs
@@ -1418,6 +1418,39 @@ impl CallControl {
         self.struct_layouts.get(&sid)
     }
 
+    /// Byte offset of the first item of a length-prefixed array whose length
+    /// word ends at `header_end` and whose elements are `elem` (`item_size`
+    /// bytes wide).
+    ///
+    /// The blocks these descrs address are `#[repr(C)] { length: usize, items:
+    /// [T; 0] }`, so the items begin at the length word rounded UP to `T`'s
+    /// alignment — not at the word itself. The two coincide whenever the word
+    /// is at least as wide as every element, which is why a 64-bit target sees
+    /// `header_end` unchanged; on a 32-bit target an 8-byte element (`i64` /
+    /// `f64` unboxed list storage) is aligned past the 4-byte length word, and
+    /// addressing it at the word would stride the array 4 bytes early.
+    fn array_items_base(&self, header_end: usize, elem: Option<&str>, item_size: usize) -> usize {
+        let align = self.element_align(elem, item_size);
+        header_end.next_multiple_of(align)
+    }
+
+    /// Alignment of an array element. A scalar or pointer aligns to its own
+    /// width, capped at the 8 bytes of the widest one (`i64` / `f64` / a
+    /// pointer); a struct aligns to its widest field, which its total size
+    /// does not report. An unregistered struct falls back to the length word,
+    /// the alignment every length-prefixed block already satisfies.
+    fn element_align(&self, elem: Option<&str>, item_size: usize) -> usize {
+        let word = crate::layout::target_word_size();
+        let scalar_align = |size: usize| size.clamp(1, 8).next_power_of_two();
+        match elem.filter(|name| self.is_known_struct(name)) {
+            Some(name) => self
+                .struct_layout_for(name)
+                .and_then(|layout| layout.fields.iter().map(|f| scalar_align(f.size)).max())
+                .unwrap_or(word),
+            None => scalar_align(item_size),
+        }
+    }
+
     /// RPython: resolve a struct field's type string.
     /// For `owner::field_name`, returns the full type of the field.
     pub fn field_type(&self, owner: &str, field_name: &str) -> Option<&str> {
@@ -1548,10 +1581,11 @@ impl CallControl {
         //   `nolength=False` → length at lendescr.offset → items past header
         // pyre's CallControl uses a single-word array header
         // (`array_header_size = WORD`), so the length-prefixed shape places
-        // items immediately after the length word at `len_offset + WORD`.
+        // items at the first element-aligned offset past the length word
+        // ([`Self::array_items_base`]).
         let base_size = match len_offset {
             None => 0,
-            Some(off) => off + self.array_header_size,
+            Some(off) => self.array_items_base(off + self.array_header_size, elem_ref, item_size),
         };
         // `descr.py:348-378 get_array_descr(gccache, ARRAY_OR_STRUCT)`:
         // PyPy keys `cache[ARRAY_OR_STRUCT]` on the ARRAY lltype's
@@ -2120,7 +2154,7 @@ impl CallControl {
         // `as Arc<dyn ArrayDescr>` matches the trait-object field type
         // on `SimpleInteriorFieldDescr.array_descr`.
         let item_size = compute_struct_size(self, &elem_name);
-        let base_size = self.array_header_size;
+        let base_size = self.array_items_base(self.array_header_size, Some(&elem_name), item_size);
         let array_key = majit_ir::descr::LLType::Array(majit_ir::descr::path_hash(array_str));
         let cached: majit_ir::descr::DescrRef = {
             let mut gc = majit_ir::descr::gc_cache().lock().unwrap();
@@ -7381,6 +7415,25 @@ pub(crate) fn describe_call(target: &CallTarget) -> Option<CallDescriptor> {
 mod tests {
     use super::*;
     use crate::model::{ExitSwitch, FunctionGraph, Link, LinkArg, ValueType, exception_exitcase};
+
+    /// A length-prefixed block puts its items at the length word rounded up to
+    /// the element's alignment. Only a target whose word is narrower than an
+    /// element can tell the two apart: with a 4-byte word, an `i64` item sits
+    /// at 8, and addressing it at 4 strides the whole array one half-word
+    /// early — every read then returns two packed 32-bit halves. A pointer
+    /// item, being word-wide, stays at the word.
+    #[test]
+    fn array_items_base_rounds_up_to_the_element_alignment() {
+        let cc = CallControl::new();
+        let word = crate::layout::target_word_size();
+        assert_eq!(cc.array_items_base(word, Some("i64"), 8), 8);
+        assert_eq!(cc.array_items_base(word, Some("f64"), 8), 8);
+        assert_eq!(cc.array_items_base(word, Some("&PyObject"), word), word);
+        assert_eq!(cc.array_items_base(word, Some("u8"), 1), word);
+        // An unregistered struct element falls back to the word, which every
+        // length-prefixed block already satisfies.
+        assert_eq!(cc.array_items_base(word, Some("NoSuchStruct"), 24), word);
+    }
 
     /// `getkind(SingleFloat) == 'int'` (history.py:53): `f32` banks to the
     /// int kind across the field/return classifiers (FLAG_UNSIGNED,

--- a/majit/majit-translate/src/codewriter/call.rs
+++ b/majit/majit-translate/src/codewriter/call.rs
@@ -2154,7 +2154,15 @@ impl CallControl {
         // `as Arc<dyn ArrayDescr>` matches the trait-object field type
         // on `SimpleInteriorFieldDescr.array_descr`.
         let item_size = compute_struct_size(self, &elem_name);
-        let base_size = self.array_items_base(self.array_header_size, Some(&elem_name), item_size);
+        // Interior-field struct arrays address `GcTypedArray`, a flat
+        // `{ len: usize, items: [u8; 0] }` block whose items always begin at
+        // `GC_TYPED_ARRAY_ITEMS_OFFSET = WORD` regardless of the element's
+        // alignment (both the live block and the guard-resume materialiser
+        // `allocate_array_struct` use that offset). The base must match the
+        // block, so it is the bare word — NOT the element-aligned offset the
+        // list int/float storage (`TypedItemsBlock`, genuinely element-aligned)
+        // needs in `arraydescrof_concrete`.
+        let base_size = self.array_header_size;
         let array_key = majit_ir::descr::LLType::Array(majit_ir::descr::path_hash(array_str));
         let cached: majit_ir::descr::DescrRef = {
             let mut gc = majit_ir::descr::gc_cache().lock().unwrap();

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -221,8 +221,16 @@ fn build_semantic_program_from_llbcs_with_static_addrs_filtered(
                 for (key, rows) in prog.struct_field_attrs {
                     acc.struct_field_attrs.entry(key).or_insert(rows);
                 }
+                // Last-writer-wins, unlike the first-writer merges around it:
+                // a cross-target layout sidecar is appended after the host
+                // artefacts (`auto_discover_workspace_llbc_paths`) precisely so
+                // its target field offsets overwrite the host's here, while its
+                // (body-stripped, so partly unresolvable) per-type-string
+                // tables lose to the host above.  Among the host artefacts this
+                // is a no-op: they describe one target, so a shared struct's
+                // layout is identical in each.
                 for (key, layout) in prog.exact_layouts {
-                    acc.exact_layouts.entry(key).or_insert(layout);
+                    acc.exact_layouts.insert(key, layout);
                 }
                 // Merge the name → StructId resolver, collapsing a key to
                 // `None` when two crates disagree on the identity (a

--- a/majit/majit-translate/src/layout.rs
+++ b/majit/majit-translate/src/layout.rs
@@ -38,6 +38,25 @@ pub fn target_word_size() -> usize {
     })
 }
 
+/// Whether `target` is a real cross target — non-empty and distinct from the
+/// build `host` — so its layout sidecars apply. Native builds share the host's
+/// struct layouts and need no sidecar.
+pub fn is_cross_target(target: &str, host: &str) -> bool {
+    !target.is_empty() && target != host
+}
+
+/// Filename of the cross-target layout sidecar for `crate_stem` (an `.ullbc`
+/// stem such as `pyre-object`) and `target`, e.g.
+/// `pyre-object.wasm32-unknown-unknown.layouts.ullbc`.
+///
+/// The single home for this naming convention: `pyre-jit-trace/build.rs`
+/// (preflight, rerun tracking, the codegen cache key) and
+/// [`crate::auto_discover_workspace_llbc_paths`] both derive sidecar names
+/// through here, so the convention cannot drift between them.
+pub fn layout_sidecar_filename(crate_stem: &str, target: &str) -> String {
+    format!("{crate_stem}.{target}.layouts.ullbc")
+}
+
 /// RPython: `symbolic.get_field_token` + `symbolic.get_size` provider.
 ///
 /// Supplies struct layouts for the codewriter pipeline. Each struct is

--- a/majit/majit-translate/src/layout.rs
+++ b/majit/majit-translate/src/layout.rs
@@ -16,6 +16,28 @@ use std::collections::{HashMap, HashSet};
 use crate::call::StructLayout;
 use crate::model::ImmutableRank;
 
+/// Byte width of a pointer on the target these layouts describe — RPython's
+/// `WORD`.
+///
+/// The layouts computed here are baked into build-time artefacts (the descr
+/// pool `pyre-jit-trace/build.rs` serialises) that the *target* binary reads
+/// back, so they must describe the target's structs, not the build host's.
+/// Cargo exports the target's pointer width to build scripts as
+/// `CARGO_CFG_TARGET_POINTER_WIDTH`; the layout model also runs in-process
+/// (where the host *is* the target), and there the host width applies.
+///
+/// Read once: neither the environment nor the target changes within a run.
+pub fn target_word_size() -> usize {
+    static WORD: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
+    *WORD.get_or_init(|| {
+        std::env::var("CARGO_CFG_TARGET_POINTER_WIDTH")
+            .ok()
+            .and_then(|bits| bits.parse::<usize>().ok())
+            .map(|bits| bits / 8)
+            .unwrap_or(std::mem::size_of::<usize>())
+    })
+}
+
 /// RPython: `symbolic.get_field_token` + `symbolic.get_size` provider.
 ///
 /// Supplies struct layouts for the codewriter pipeline. Each struct is

--- a/majit/majit-translate/src/lib.rs
+++ b/majit/majit-translate/src/lib.rs
@@ -294,26 +294,7 @@ fn auto_discover_workspace_llbc_paths(module_paths: &[&str]) -> Option<Vec<Strin
     // Pyre build requires all three artifacts; generic consumers whose portal
     // lives in the mandatory pair may still use the two-artifact result.
     const MANDATORY: &[&str] = &["pyre-object.ullbc", "pyre-interpreter.ullbc"];
-    // Cross-target layout sidecars first.  Charon resolves struct layouts
-    // per target, and the artefacts above carry the extraction host's;
-    // building for a target with a different pointer width would otherwise
-    // read every field past the first pointer at the wrong offset.  A
-    // sidecar is the same crate re-extracted for that target and reduced to
-    // its `type_decls`, so it contributes layouts and nothing else — and
-    // because `build_semantic_program_from_llbcs` merges `exact_layouts`
-    // first-writer-wins, being first is what makes those layouts the ones
-    // that apply.
-    let target = std::env::var("TARGET").unwrap_or_default();
     let mut paths = Vec::with_capacity(3);
-    if !target.is_empty() && target != std::env::var("HOST").unwrap_or_default() {
-        for name in MANDATORY {
-            let stem = name.trim_end_matches(".ullbc");
-            let sidecar = llbc_dir.join(format!("{stem}.{target}.layouts.ullbc"));
-            if sidecar.exists() {
-                paths.push(sidecar.to_string_lossy().into_owned());
-            }
-        }
-    }
     for name in MANDATORY {
         let p = llbc_dir.join(name);
         if !p.exists() {
@@ -330,6 +311,37 @@ fn auto_discover_workspace_llbc_paths(module_paths: &[&str]) -> Option<Vec<Strin
              front-end. A configured eval::eval_loop_jit driver will fail \
              exact portal resolution; run scripts/extract-llbc.py first."
         );
+    }
+    // Cross-target layout sidecars LAST.  Charon resolves struct layouts per
+    // target, and the artefacts above carry the extraction host's; building
+    // for a target with a different pointer width would otherwise read every
+    // field past the first pointer at the wrong offset.  A sidecar is the same
+    // crate re-extracted for that target, reduced to `type_decls`.  It must
+    // contribute *only* its `exact_layouts` (the target field offsets): its
+    // `type_decls` were extracted without the function bodies, so any field
+    // type first hash-consed in a dropped body resolves to nothing, and the
+    // host artefacts — where those types are target-independent and fully
+    // resolvable — are the authority for everything but offsets.  So the
+    // sidecar goes last, and `build_semantic_program_from_llbcs` seeds every
+    // per-type-string table from the host (first-writer) while overwriting
+    // `exact_layouts` from the sidecar (last-writer).
+    let target = std::env::var("TARGET").unwrap_or_default();
+    let host = std::env::var("HOST").unwrap_or_default();
+    if layout::is_cross_target(&target, &host) {
+        for name in MANDATORY {
+            let stem = name.trim_end_matches(".ullbc");
+            let sidecar = llbc_dir.join(layout::layout_sidecar_filename(stem, &target));
+            if sidecar.exists() {
+                paths.push(sidecar.to_string_lossy().into_owned());
+            } else {
+                eprintln!(
+                    "[majit-translate] {stem}.{target}.layouts.ullbc absent — \
+                     cross-target build will read {stem}'s host-extracted field \
+                     offsets, which may be wrong for {target}; run \
+                     scripts/extract-llbc.py to produce it."
+                );
+            }
+        }
     }
     Some(paths)
 }

--- a/majit/majit-translate/src/lib.rs
+++ b/majit/majit-translate/src/lib.rs
@@ -294,7 +294,26 @@ fn auto_discover_workspace_llbc_paths(module_paths: &[&str]) -> Option<Vec<Strin
     // Pyre build requires all three artifacts; generic consumers whose portal
     // lives in the mandatory pair may still use the two-artifact result.
     const MANDATORY: &[&str] = &["pyre-object.ullbc", "pyre-interpreter.ullbc"];
+    // Cross-target layout sidecars first.  Charon resolves struct layouts
+    // per target, and the artefacts above carry the extraction host's;
+    // building for a target with a different pointer width would otherwise
+    // read every field past the first pointer at the wrong offset.  A
+    // sidecar is the same crate re-extracted for that target and reduced to
+    // its `type_decls`, so it contributes layouts and nothing else — and
+    // because `build_semantic_program_from_llbcs` merges `exact_layouts`
+    // first-writer-wins, being first is what makes those layouts the ones
+    // that apply.
+    let target = std::env::var("TARGET").unwrap_or_default();
     let mut paths = Vec::with_capacity(3);
+    if !target.is_empty() && target != std::env::var("HOST").unwrap_or_default() {
+        for name in MANDATORY {
+            let stem = name.trim_end_matches(".ullbc");
+            let sidecar = llbc_dir.join(format!("{stem}.{target}.layouts.ullbc"));
+            if sidecar.exists() {
+                paths.push(sidecar.to_string_lossy().into_owned());
+            }
+        }
+    }
     for name in MANDATORY {
         let p = llbc_dir.join(name);
         if !p.exists() {

--- a/pyre/pyre-jit-trace/build.rs
+++ b/pyre/pyre-jit-trace/build.rs
@@ -181,7 +181,26 @@ fn preflight_llbc_or_fail() {
     if !charon_present {
         println!("cargo::error=Install charon (one-time): scripts/install-charon.py");
     }
-    println!("cargo::error=Extract the LLBC: scripts/extract-llbc.py");
+    // Cross-compiling: the driver's default `LAYOUT_TARGETS` only covers
+    // wasm32, so any other target's sidecars are produced only when the
+    // extraction is told this target explicitly.  Advertise it (harmless but
+    // redundant for wasm32).  The override must also list the sidecar paths,
+    // since `PYRE_MIR_FRONTEND_LLBC` is treated as the complete input set and
+    // returns before the sidecar check above.
+    let sidecars = llbc_layout_sidecars();
+    let (extract_cmd, override_extra) = if sidecars.is_empty() {
+        ("scripts/extract-llbc.py".to_string(), String::new())
+    } else {
+        let target = std::env::var("TARGET").unwrap_or_default();
+        (
+            format!("LLBC_LAYOUT_TARGETS={target} scripts/extract-llbc.py"),
+            sidecars
+                .iter()
+                .map(|name| format!(":/abs/{name}"))
+                .collect::<String>(),
+        )
+    };
+    println!("cargo::error=Extract the LLBC: {extract_cmd}");
 
     // The install step is only needed when the charon binary is absent;
     // with it present the fix is the single extract command.
@@ -199,10 +218,10 @@ fn preflight_llbc_or_fail() {
 {}\n\
  Bootstrap (run from the repo root):\n\
 {}\
-   scripts/extract-llbc.py\n\
+   {}\n\
 \n\
  …or point the build at existing artefacts:\n\
-   export PYRE_MIR_FRONTEND_LLBC=/abs/pyre-object.ullbc:/abs/pyre-interpreter.ullbc:/abs/pyre-jit.ullbc\n\
+   export PYRE_MIR_FRONTEND_LLBC=/abs/pyre-object.ullbc:/abs/pyre-interpreter.ullbc:/abs/pyre-jit.ullbc{}\n\
 ========================================================================\n",
         missing
             .iter()
@@ -210,6 +229,8 @@ fn preflight_llbc_or_fail() {
             .collect::<Vec<_>>()
             .join("\n"),
         install_line,
+        extract_cmd,
+        override_extra,
     );
 
     std::process::exit(1);
@@ -616,14 +637,17 @@ fn emit_rerun_directives(repo_root: &str, source_paths: &[String]) {
 /// artefacts so their Charon-resolved field offsets win.
 fn llbc_layout_sidecars() -> Vec<String> {
     let target = std::env::var("TARGET").unwrap_or_default();
-    if target.is_empty() || target == std::env::var("HOST").unwrap_or_default() {
+    let host = std::env::var("HOST").unwrap_or_default();
+    if !majit_translate::layout::is_cross_target(&target, &host) {
         return Vec::new();
     }
     // `pyre-jit` is absent: it has no sidecar (see the extraction driver's
     // spec for why), so only the object model gets cross-target layouts.
+    // The naming convention lives in `majit_translate::layout` so it stays in
+    // lockstep with `auto_discover_workspace_llbc_paths`.
     ["pyre-object", "pyre-interpreter"]
         .iter()
-        .map(|crate_name| format!("{crate_name}.{target}.layouts.ullbc"))
+        .map(|crate_name| majit_translate::layout::layout_sidecar_filename(crate_name, &target))
         .collect()
 }
 
@@ -787,6 +811,21 @@ fn hash_llbc_inputs(h: &mut CacheHasher, repo_root: &str) {
                 .join("build")
                 .join("llbc")
                 .join(llbc),
+        );
+    }
+    // Cross-target sidecars are build inputs too: they supply the target field
+    // offsets `auto_discover_workspace_llbc_paths` merges in.  Without them in
+    // the key, regenerating a sidecar (same Rust sources, same target — e.g.
+    // after fixing the extraction flags) leaves the key unchanged, so
+    // `restore_codegen_cache` would serve the descrs built from the old
+    // offsets.  Empty on a native build.
+    for sidecar in llbc_layout_sidecars() {
+        hash_file_content(
+            h,
+            &std::path::Path::new(repo_root)
+                .join("build")
+                .join("llbc")
+                .join(&sidecar),
         );
     }
 }

--- a/pyre/pyre-jit-trace/build.rs
+++ b/pyre/pyre-jit-trace/build.rs
@@ -144,11 +144,21 @@ fn preflight_llbc_or_fail() {
         "pyre-interpreter.ullbc",
         "pyre-jit.ullbc",
     ];
-    let missing: Vec<&str> = REQUIRED
+    let mut missing: Vec<String> = REQUIRED
         .iter()
-        .copied()
         .filter(|name| !llbc_dir.join(name).exists())
+        .map(|name| (*name).to_string())
         .collect();
+    // Cross-compiling additionally needs this target's layout sidecars:
+    // Charon resolves struct layouts per target, and the artefacts above
+    // carry the extraction host's.  Without them every descr field past the
+    // first pointer names the wrong bytes on a target whose pointers are a
+    // different width, which corrupts reads instead of failing.
+    for name in llbc_layout_sidecars() {
+        if !llbc_dir.join(&name).exists() {
+            missing.push(name);
+        }
+    }
     if missing.is_empty() {
         return;
     }
@@ -592,6 +602,29 @@ fn emit_rerun_directives(repo_root: &str, source_paths: &[String]) {
     ] {
         println!("cargo::rerun-if-changed={repo_root}/build/llbc/{llbc}");
     }
+    for sidecar in llbc_layout_sidecars() {
+        println!("cargo::rerun-if-changed={repo_root}/build/llbc/{sidecar}");
+    }
+}
+
+/// Layout-sidecar artefact names this build consumes, empty for a native
+/// build.
+///
+/// `scripts/extract-llbc.py` re-extracts each crate for every cross target
+/// and reduces the result to its `type_decls`; `majit-translate`'s
+/// `auto_discover_workspace_llbc_paths` merges them ahead of the host
+/// artefacts so their Charon-resolved field offsets win.
+fn llbc_layout_sidecars() -> Vec<String> {
+    let target = std::env::var("TARGET").unwrap_or_default();
+    if target.is_empty() || target == std::env::var("HOST").unwrap_or_default() {
+        return Vec::new();
+    }
+    // `pyre-jit` is absent: it has no sidecar (see the extraction driver's
+    // spec for why), so only the object model gets cross-target layouts.
+    ["pyre-object", "pyre-interpreter"]
+        .iter()
+        .map(|crate_name| format!("{crate_name}.{target}.layouts.ullbc"))
+        .collect()
 }
 
 fn codegen_cache_dir(repo_root: &str, cache_key: &str) -> std::path::PathBuf {

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
@@ -6250,33 +6250,6 @@ pub fn nested_list_fold_virt_enabled() -> bool {
     *ENABLED
 }
 
-/// `PYRE_WASM_UNBOXED_APPEND_FOLD` gate (read once) — admits the unboxed
-/// (Integer/Float storage) `w_list_append` fold on the wasm backend. The fold
-/// records the spare-capacity fast path guarded by `GuardTrue(length <
-/// arraylen(items))`; when the comprehension result escapes the enclosing frame
-/// and a later append crosses the backing block's realloc boundary, the wasm
-/// backend mis-resumes that capacity-guard deopt — the reallocating append's
-/// iteration is lost (list one element short) or, when the partially built list
-/// is a kept operand-stack temp, the whole list resolves to NULL ("call
-/// failed"). dynasm / cranelift resume the identical guard IR correctly, so this
-/// is a wasm-backend deopt/resume defect. Until it is root-fixed, decline the
-/// unboxed arm on wasm so the append runs as the plain residual `jit_list_append`
-/// (interpreter fallback, correct if unaccelerated). DEFAULT-ON for wasm32 (the
-/// backend that mis-resumes); a strict no-op on native (the fold always folds
-/// there). Set `PYRE_WASM_UNBOXED_APPEND_FOLD=1` to force the fold back on for
-/// bisecting the root fix. The Object-storage arm is unaffected — it resumes
-/// correctly and stays folded.
-fn wasm_unboxed_append_fold_declined() -> bool {
-    static DECLINED: std::sync::LazyLock<bool> = std::sync::LazyLock::new(|| {
-        if cfg!(target_arch = "wasm32") {
-            std::env::var("PYRE_WASM_UNBOXED_APPEND_FOLD").map_or(true, |v| v != "1")
-        } else {
-            false
-        }
-    });
-    *DECLINED
-}
-
 /// #62 dead-`box_bool` proof for [`try_walker_specialize_compare_op_int`] /
 /// `_float`.  Returns `true` only when a forward JitCode lookahead proves
 /// the compare's boxed Ref dst register (`dst_reg`) is consumed *solely*

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
@@ -3320,6 +3320,19 @@ unsafe fn orthodox_list_append_recognize(
 pub(crate) fn orthodox_list_append_body_and_sym<Sym: WalkSym>(
     ctx: &WalkContext<'_, '_, Sym>,
 ) -> Option<(SubJitCodeBody, *const Sym)> {
+    // The sub-walk resolves `w_list_append`'s `d`/`j` operands through the
+    // build-time global descr pool, whose field offsets assume 8-byte pointers
+    // (`build_descr_layout_matches_target`).  On a 32-bit target they name the
+    // wrong bytes, so the body's `is_plain_int1` subclass test folds on
+    // garbage, the walk descends the dead `switch_to_object_strategy` leg and
+    // concretely executes its residuals against the live list before declining
+    // at the leg's un-lowered `ListStrategy::Object` ctor.  That abort leaves an
+    // unrollbackable body effect, which makes `fbw_foriter_inflight_take` refuse
+    // delivery and drop the in-flight FOR_ITER iteration.  Decline here instead,
+    // before any IR or side effect: the generic residual append handles the call.
+    if !crate::jitcode_runtime::build_descr_layout_matches_target() {
+        return None;
+    }
     let jc_arc = crate::jitcode_runtime::list_append_jitcode()?;
     let sub_body = sub_jitcode_body_by_index(jc_arc.index())?;
     let sym_ptr = ctx.fbw_mode.snapshot_sym;

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
@@ -3257,14 +3257,11 @@ unsafe fn orthodox_list_append_recognize(
             // Gate off: preserve the prior behavior (Empty always declined).
             return None;
         }
-        let unboxed_declined = wasm_unboxed_append_fold_declined();
-        let int_ok = !unboxed_declined
-            && pyre_object::is_plain_int1(value)
+        let int_ok = pyre_object::is_plain_int1(value)
             && !pyre_object::pyobject::is_long(value)
             && !(pyre_object::tagged_int::CAN_BE_TAGGED
                 && pyre_object::tagged_int::is_tagged_int(value));
-        let float_ok =
-            !unboxed_declined && !value.is_null() && pyre_object::is_plain_float_strict(value);
+        let float_ok = !value.is_null() && pyre_object::is_plain_float_strict(value);
         // switch_to_correct_strategy routes `is_plain_int1` -> Integer with no
         // tagged exclusion. Exclude any plain-int / float from the object
         // fallback so a tagged-int / fits-int `W_LongObject` DECLINES (generic
@@ -3286,9 +3283,7 @@ unsafe fn orthodox_list_append_recognize(
     // fits-int `W_LongObject` is declined, see note above).
     // A tagged-immediate value would need a tag-aware unboxed store and no
     // `w_class` pin; decline to the generic residual append instead.
-    let unboxed_declined = wasm_unboxed_append_fold_declined();
-    let int_ok = !unboxed_declined
-        && pyre_object::w_list_uses_int_storage(inner_self)
+    let int_ok = pyre_object::w_list_uses_int_storage(inner_self)
         && pyre_object::is_plain_int1(value)
         && !pyre_object::pyobject::is_long(value)
         && !(pyre_object::tagged_int::CAN_BE_TAGGED
@@ -3302,8 +3297,7 @@ unsafe fn orthodox_list_append_recognize(
     // `type(w_obj) is W_FloatObject`, the strict predicate the body's Float
     // arm also uses. No fits-* long analogue (a float is never re-boxed
     // across arithmetic, unlike a fits-int W_LongObject).
-    let float_ok = !unboxed_declined
-        && pyre_object::w_list_uses_float_storage(inner_self)
+    let float_ok = pyre_object::w_list_uses_float_storage(inner_self)
         && !value.is_null()
         && pyre_object::is_plain_float_strict(value);
     if !int_ok && !obj_ok && !float_ok {
@@ -3318,9 +3312,9 @@ unsafe fn orthodox_list_append_recognize(
 /// compiled or the snapshot sym is absent.  The returned `sym_ptr` is
 /// non-null with a set `jitcode` field.  Word size does not enter here: the
 /// `d` operands resolve through a descr pool built from the target's own
-/// Charon layouts (`jitcode_runtime::build_time_field_offset`), and the one
-/// storage arm wasm still mis-resumes is declined upstream at recognition
-/// ([`wasm_unboxed_append_fold_declined`]).
+/// Charon layouts (`jitcode_runtime::build_time_field_offset`), whose array
+/// descrs place the items at the first element-aligned offset past the length
+/// word — the offset a 4-byte word and an 8-byte item disagree on.
 pub(crate) fn orthodox_list_append_body_and_sym<Sym: WalkSym>(
     ctx: &WalkContext<'_, '_, Sym>,
 ) -> Option<(SubJitCodeBody, *const Sym)> {

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
@@ -3317,20 +3317,21 @@ unsafe fn orthodox_list_append_recognize(
 /// Returns `None` (decline — no IR emitted yet) when the body jitcode is not
 /// compiled or the snapshot sym is absent.  The returned `sym_ptr` is
 /// non-null with a set `jitcode` field.
+/// 32-bit targets additionally decline: the sub-walk still miscompiles
+/// there.  Its `d` operands now resolve through a descr pool built from the
+/// target's own Charon layouts (`jitcode_runtime::build_time_field_offset`),
+/// so the reads land on the right bytes — but with the walk reaching the end
+/// instead of aborting, six `bench/synth` list programs
+/// (`list_ops`, `list_reverse`, `list_bound_method_mutation`,
+/// `list_append_funcentry_helper`, `inlined_helper_mutation`,
+/// `inlined_mutation_before_abort`) produce wrong output under the wasm
+/// backend while every native backend stays green.  The remaining defect is
+/// in the fold, not in the layouts; until it is found, the generic residual
+/// append handles the call on a 32-bit target.
 pub(crate) fn orthodox_list_append_body_and_sym<Sym: WalkSym>(
     ctx: &WalkContext<'_, '_, Sym>,
 ) -> Option<(SubJitCodeBody, *const Sym)> {
-    // The sub-walk resolves `w_list_append`'s `d`/`j` operands through the
-    // build-time global descr pool, whose field offsets assume 8-byte pointers
-    // (`build_descr_layout_matches_target`).  On a 32-bit target they name the
-    // wrong bytes, so the body's `is_plain_int1` subclass test folds on
-    // garbage, the walk descends the dead `switch_to_object_strategy` leg and
-    // concretely executes its residuals against the live list before declining
-    // at the leg's un-lowered `ListStrategy::Object` ctor.  That abort leaves an
-    // unrollbackable body effect, which makes `fbw_foriter_inflight_take` refuse
-    // delivery and drop the in-flight FOR_ITER iteration.  Decline here instead,
-    // before any IR or side effect: the generic residual append handles the call.
-    if !crate::jitcode_runtime::build_descr_layout_matches_target() {
+    if std::mem::size_of::<usize>() != 8 {
         return None;
     }
     let jc_arc = crate::jitcode_runtime::list_append_jitcode()?;

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
@@ -3316,24 +3316,14 @@ unsafe fn orthodox_list_append_recognize(
 /// (the resume-coordinate source) shared by both list-append fold forms.
 /// Returns `None` (decline — no IR emitted yet) when the body jitcode is not
 /// compiled or the snapshot sym is absent.  The returned `sym_ptr` is
-/// non-null with a set `jitcode` field.
-/// 32-bit targets additionally decline: the sub-walk still miscompiles
-/// there.  Its `d` operands now resolve through a descr pool built from the
-/// target's own Charon layouts (`jitcode_runtime::build_time_field_offset`),
-/// so the reads land on the right bytes — but with the walk reaching the end
-/// instead of aborting, six `bench/synth` list programs
-/// (`list_ops`, `list_reverse`, `list_bound_method_mutation`,
-/// `list_append_funcentry_helper`, `inlined_helper_mutation`,
-/// `inlined_mutation_before_abort`) produce wrong output under the wasm
-/// backend while every native backend stays green.  The remaining defect is
-/// in the fold, not in the layouts; until it is found, the generic residual
-/// append handles the call on a 32-bit target.
+/// non-null with a set `jitcode` field.  Word size does not enter here: the
+/// `d` operands resolve through a descr pool built from the target's own
+/// Charon layouts (`jitcode_runtime::build_time_field_offset`), and the one
+/// storage arm wasm still mis-resumes is declined upstream at recognition
+/// ([`wasm_unboxed_append_fold_declined`]).
 pub(crate) fn orthodox_list_append_body_and_sym<Sym: WalkSym>(
     ctx: &WalkContext<'_, '_, Sym>,
 ) -> Option<(SubJitCodeBody, *const Sym)> {
-    if std::mem::size_of::<usize>() != 8 {
-        return None;
-    }
     let jc_arc = crate::jitcode_runtime::list_append_jitcode()?;
     let sub_body = sub_jitcode_body_by_index(jc_arc.index())?;
     let sym_ptr = ctx.fbw_mode.snapshot_sym;

--- a/pyre/pyre-jit-trace/src/jitcode_runtime.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_runtime.rs
@@ -455,24 +455,25 @@ pub fn all_descr_refs() -> &'static [DescrRef] {
     &ALL_DESCR_REFS
 }
 
-/// Whether the build-time descr pool's field offsets describe the struct
-/// layout this binary actually runs on.
+/// Byte offset the build-time descr pool records for `{owner}.{name}`, or
+/// `None` when no `Field` slot names that field.
 ///
-/// [`all_descrs`] is serialised by `build.rs` from the layout model in
-/// `majit-translate` (`codewriter::call::StructLayout::from_type_strings` /
-/// `get_type_flag`), which sizes every pointer-typed field at 8 bytes and
-/// aligns to an 8-byte word.  The exact per-field offsets the Charon LLBC
-/// carries (`front::semantic`'s `field_offsets`) come from the same 64-bit
-/// extraction.  On a 32-bit target the real structs pack pointers at 4
-/// (`PyObject.w_class` sits at 4, not 8; `PyType.instantiate` at 24, not 32),
-/// so every offset past the first pointer field names the wrong bytes and a
-/// concrete read through one of those descrs returns garbage.
-///
-/// The per-site descrs the walker builds itself (`crate::descr`) use
-/// `offset_of!` and are always right, so only consumers that resolve their
-/// `d` operands through the build-time pool need this gate.
-pub fn build_descr_layout_matches_target() -> bool {
-    std::mem::size_of::<usize>() == 8
+/// [`all_descrs`] is serialised by `build.rs` from `majit-translate`'s layout
+/// model, whose word size and Charon-resolved field offsets both follow the
+/// target being compiled. A consumer that resolves `d` operands through this
+/// pool therefore reads the same bytes `offset_of!` names — the
+/// `build_time_offset_matches_runtime_layout` test pins that agreement for the
+/// structs the orthodox sub-walk reads.
+pub fn build_time_field_offset(owner: &str, name: &str) -> Option<usize> {
+    all_descrs().iter().find_map(|d| match d {
+        BhDescr::Field {
+            owner: o,
+            name: n,
+            offset,
+            ..
+        } if o == owner && n == name => Some(*offset),
+        _ => None,
+    })
 }
 
 /// Build the metainterp-side `RuntimeBhDescr` pool from the shared
@@ -984,6 +985,48 @@ pub fn resolve_op_at(code: &[u8], pc: usize, regs: RegisterFileView<'_>) -> Opti
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The build-time descr pool must name the same bytes `offset_of!` does.
+    ///
+    /// The pool is serialised by `build.rs` from `majit-translate`'s layout
+    /// model, which sizes a pointer from `CARGO_CFG_TARGET_POINTER_WIDTH` and
+    /// takes exact offsets from the Charon layout Charon resolved for the
+    /// build's `TARGET`.  Both used to be fixed to the extraction host's
+    /// 64-bit layout, so on a 32-bit target every offset past the first
+    /// pointer field named the wrong bytes: the orthodox `w_list_append`
+    /// sub-walk, the one production consumer that resolves its `d` operands
+    /// through this pool, folded its subclass test on garbage, walked the
+    /// dead `switch_to_object_strategy` leg, executed that leg's residuals
+    /// against the live list, and aborted — dropping the in-flight `FOR_ITER`
+    /// item with it (`bench/synth/delete_negative_open_slice_hot.py` then
+    /// ran one loop iteration short).
+    ///
+    /// These two fields are exactly the ones that sub-walk reads, and both
+    /// sit past a pointer, so they move between 64- and 32-bit targets.
+    #[test]
+    fn build_time_offset_matches_runtime_layout() {
+        for (owner, name, runtime) in [
+            (
+                "PyObject",
+                "w_class",
+                std::mem::offset_of!(pyre_object::pyobject::PyObject, w_class),
+            ),
+            (
+                "PyType",
+                "instantiate",
+                std::mem::offset_of!(pyre_object::pyobject::PyType, instantiate),
+            ),
+        ] {
+            let Some(built) = build_time_field_offset(owner, name) else {
+                panic!("build-time descr pool carries no `{owner}.{name}` field slot");
+            };
+            assert_eq!(
+                built, runtime,
+                "build-time descr pool places `{owner}.{name}` at {built}, \
+                 but this target's layout puts it at {runtime}",
+            );
+        }
+    }
 
     /// Every key in build-observed `pipeline.insns` that ALSO appears in
     /// the canonical universe (`majit_translate::insns::

--- a/pyre/pyre-jit-trace/src/jitcode_runtime.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_runtime.rs
@@ -455,6 +455,26 @@ pub fn all_descr_refs() -> &'static [DescrRef] {
     &ALL_DESCR_REFS
 }
 
+/// Whether the build-time descr pool's field offsets describe the struct
+/// layout this binary actually runs on.
+///
+/// [`all_descrs`] is serialised by `build.rs` from the layout model in
+/// `majit-translate` (`codewriter::call::StructLayout::from_type_strings` /
+/// `get_type_flag`), which sizes every pointer-typed field at 8 bytes and
+/// aligns to an 8-byte word.  The exact per-field offsets the Charon LLBC
+/// carries (`front::semantic`'s `field_offsets`) come from the same 64-bit
+/// extraction.  On a 32-bit target the real structs pack pointers at 4
+/// (`PyObject.w_class` sits at 4, not 8; `PyType.instantiate` at 24, not 32),
+/// so every offset past the first pointer field names the wrong bytes and a
+/// concrete read through one of those descrs returns garbage.
+///
+/// The per-site descrs the walker builds itself (`crate::descr`) use
+/// `offset_of!` and are always right, so only consumers that resolve their
+/// `d` operands through the build-time pool need this gate.
+pub fn build_descr_layout_matches_target() -> bool {
+    std::mem::size_of::<usize>() == 8
+}
+
 /// Build the metainterp-side `RuntimeBhDescr` pool from the shared
 /// build-time `ALL_DESCRS` and install it into `majit-metainterp` as the
 /// process-global build-time descr pool (`JitCode::descr_at`'s fallback for

--- a/pyre/scripts/extract-llbc.py
+++ b/pyre/scripts/extract-llbc.py
@@ -34,6 +34,9 @@ SPECS: dict[str, CrateSpec] = {
             "majit/charon-corpus/Cargo.toml",
             "majit/charon-corpus/src/",
         ],
+        # A reader fixture, not a build input: nothing consumes its layouts
+        # for a cross target.
+        layout_targets=(),
     ),
     "pyre-object": CrateSpec(
         name="pyre-object",
@@ -59,10 +62,39 @@ SPECS: dict[str, CrateSpec] = {
         crate_dir=ROOT / "pyre" / "pyre-jit",
         output_name="pyre-jit.ullbc",
         cargo_args=["--features", "{features}"],
+        # No layout sidecar. A cross-target pass has to pass cargo
+        # `--target`, and cargo then stops applying `RUSTFLAGS` to host
+        # units — including `pyre-jit-trace`'s build script, which
+        # build-depends on `pyre-interpreter` and so drags in
+        # `rustpython-host_env`. That crate uses `cfg_select!`, still
+        # unstable on Charon's pinned nightly, and the
+        # `-Zcrate-attr=feature(cfg_select)` that enables it can only reach
+        # host units through `-Zhost-config`, which cargo panics on when
+        # `--target` is set. The stock build never hits this: its toolchain
+        # has `cfg_select` stable.
+        #
+        # The gap this leaves is the 588 layout-carrying types declared
+        # only here — `jit::{flow,codewriter,flatten,regalloc}`,
+        # `majit_*`, and closure environments, i.e. the compiler's own
+        # data structures rather than the object model traced bytecode
+        # reads. Every runtime type reached through a descr comes from
+        # pyre-object or pyre-interpreter, both of which do get sidecars.
+        layout_targets=(),
     ),
 }
 
 DEFAULT_CRATES = ["pyre-object", "pyre-interpreter", "pyre-jit"]
+
+# Targets, besides the extraction host, that get a layout sidecar. The
+# wasm32 build reads the same `build/llbc` set as the native build, and its
+# pointers are 4 bytes wide: without its own field offsets every descr field
+# past the first pointer names the wrong bytes.
+LAYOUT_TARGETS = ("wasm32-unknown-unknown",)
+
+# The wasm32 compiler pass needs the same `getrandom` backend selection the
+# wasm build itself uses (`check.py`'s `WASM_RUSTFLAGS`) — the default
+# backend refuses to build for `wasm32-unknown-unknown`.
+LAYOUT_TARGET_RUSTFLAGS = '--cfg getrandom_backend="custom"'
 
 # Base fingerprint inputs shared by every pyre crate: workspace manifests plus
 # the extraction tooling itself, so an edit to the engine/driver busts caches.
@@ -84,6 +116,8 @@ def main() -> None:
         out_dir=ROOT / "build" / "llbc",
         base_pathspecs=BASE_PATHSPECS,
         metadata_feature_crates=("pyre-interpreter", "pyre-jit"),
+        layout_targets=LAYOUT_TARGETS,
+        layout_target_rustflags=LAYOUT_TARGET_RUSTFLAGS,
     )
 
 

--- a/scripts/llbc_extract.py
+++ b/scripts/llbc_extract.py
@@ -40,6 +40,14 @@ class CrateSpec:
     - `excluded_deps`: path-dependency package names dropped from this crate's
       fingerprint because the artefact holds zero references to them; the
       extraction guard re-checks the artefact and fails loud if that drifts.
+    - `layout_targets`: target triples, besides the extraction host, this
+      crate also emits a layout sidecar for (see `layout_sidecar_name`).
+      `None` takes the driver's default; `()` opts out. Every listed target
+      must compile under `layout_cargo_args`.
+    - `layout_cargo_args`: `cargo_args` replacement for the sidecar passes.
+      A cross target usually needs a different feature set than the host
+      (a native code generator does not build for wasm32). `None` reuses
+      `cargo_args`.
     """
 
     name: str
@@ -49,6 +57,12 @@ class CrateSpec:
     charon_args: list[str] = field(default_factory=list)
     fingerprint_pathspecs: list[str] | None = None
     excluded_deps: set[str] = field(default_factory=set)
+    layout_targets: tuple[str, ...] | None = None
+    layout_cargo_args: list[str] | None = None
+
+    def layout_sidecar_name(self, target: str) -> str:
+        """Artefact name of this crate's `target` layout sidecar."""
+        return f"{Path(self.output_name).stem}.{target}.layouts.ullbc"
 
 
 @dataclass
@@ -63,6 +77,8 @@ class Engine:
     charon_root: Path
     cargo_features: str
     metadata_feature_crates: tuple[str, ...] = ()
+    layout_targets: tuple[str, ...] = ()
+    layout_target_rustflags: str = ""
 
     def spec(self, crate: str) -> CrateSpec:
         try:
@@ -342,6 +358,7 @@ def stamp_for(
     cargo_features: str,
     flags: list[str],
     charon_flags: list[str],
+    layout_targets: list[str],
 ) -> str:
     return "\n".join(
         [
@@ -351,9 +368,84 @@ def stamp_for(
             f"features={cargo_features}",
             f"flags={' '.join(flags)}",
             f"charon_flags={' '.join(charon_flags)}",
+            f"layout_targets={' '.join(layout_targets)}",
             f"source={source_fingerprint(eng, [crate], cargo_features)}",
         ]
     )
+
+
+def crate_layout_targets(eng: Engine, spec: CrateSpec) -> list[str]:
+    """Cross targets this crate emits a layout sidecar for.
+
+    The extraction host is never in the list: its layouts already live in
+    the crate's own artefact.
+    """
+    extra = eng.layout_targets if spec.layout_targets is None else spec.layout_targets
+    host = host_triple(eng.root)
+    return [t for t in extra if t != host]
+
+
+def write_layout_sidecar(source: Path, dest: Path) -> None:
+    """Reduce a full `.ullbc` to its type declarations.
+
+    A cross-target extraction is only wanted for the struct layouts Charon
+    resolved for that target; its function bodies are compiled under
+    different `cfg`s and must not displace the host's. Dropping every
+    declaration list but `type_decls` keeps the artefact a loadable
+    `.ullbc` — the reader needs no special case, and the consumer merges
+    it ahead of the host artefacts so its layouts win.
+
+    Only the fields kept are decoded, not the whole file: bodies dominate
+    the input (the interpreter's are ~94% of it), and parsing them costs an
+    order of magnitude more memory than the text itself.
+    """
+    text = source.read_text(encoding="utf-8")
+    decoder = json.JSONDecoder()
+
+    def field(name: str):
+        key = f'"{name}":'
+        at = text.find(key)
+        if at < 0:
+            raise SystemExit(f"extract-llbc.py: {source.name} has no `{name}` field")
+        # `raw_decode` does not skip leading whitespace of its own.
+        start = at + len(key)
+        while text[start] in " \t\r\n":
+            start += 1
+        value, _ = decoder.raw_decode(text, start)
+        return value
+
+    slim = {
+        "charon_version": field("charon_version"),
+        "has_errors": field("has_errors"),
+        "translated": {
+            "crate_name": field("crate_name"),
+            "type_decls": field("type_decls"),
+            "fun_decls": [],
+        },
+    }
+    del text
+    dest.write_text(json.dumps(slim), encoding="utf-8")
+
+
+def ensure_charon_std(charon_bin: Path, targets: list[str], root: Path) -> None:
+    """Install the target `std` Charon's pinned toolchain needs.
+
+    Charon drives its own nightly rustc, so a target installed for the
+    build toolchain is not necessarily installed for Charon's. Adding it is
+    idempotent and fast when already present.
+    """
+    toolchain_name = Path(run_capture([str(charon_bin), "toolchain-path"], cwd=root).strip()).name
+    for target in targets:
+        command = ["rustup", "target", "add", target, "--toolchain", toolchain_name]
+        if subprocess.run(command).returncode != 0:
+            raise SystemExit(
+                f"extract-llbc.py: could not install '{target}' std for Charon's "
+                f"toolchain '{toolchain_name}'.\n"
+                f"  run: {' '.join(command)}\n"
+                "  or drop the target from LLBC_LAYOUT_TARGETS to extract host "
+                "layouts only (a cross-target build then reads the host's field "
+                "offsets)."
+            )
 
 
 def extract(eng: Engine, args: argparse.Namespace) -> None:
@@ -381,8 +473,6 @@ def extract(eng: Engine, args: argparse.Namespace) -> None:
     # rustc), so this never thrashes the runtime build's cache, and the LLBC is
     # independent of debuginfo so the artefact is byte-identical.
     env.setdefault("CARGO_PROFILE_DEV_DEBUG", "0")
-    env["CARGO_UNSTABLE_HOST_CONFIG"] = "true"
-    env["CARGO_UNSTABLE_TARGET_APPLIES_TO_HOST"] = "true"
     # Dependency build scripts run while Charon extracts a target crate. They
     # must not recursively demand the very LLBC artefact currently being
     # produced (pyre-jit -> pyre-jit-trace -> pyre-jit.ullbc). Consumers may
@@ -390,12 +480,18 @@ def extract(eng: Engine, args: argparse.Namespace) -> None:
     # `rerun-if-env-changed` ensures the following normal build regenerates
     # production artifacts from the completed LLBC set.
     env["MAJIT_LLBC_EXTRACTION"] = "1"
+    host_config_env = {
+        "CARGO_UNSTABLE_HOST_CONFIG": "true",
+        "CARGO_UNSTABLE_TARGET_APPLIES_TO_HOST": "true",
+    }
     host_config = [
         "--config",
         "target-applies-to-host=false",
         "--config",
         f'host.rustflags=["{crate_attr}"]',
     ]
+
+    prepared_std: set[str] = set()
 
     for crate in args.crates or eng.default_crates:
         spec = eng.spec(crate)
@@ -415,12 +511,17 @@ def extract(eng: Engine, args: argparse.Namespace) -> None:
             cargo_features=cargo_features,
             flags=flags,
             charon_flags=charon_flags,
+            layout_targets=crate_layout_targets(eng, spec),
         )
 
+        sidecars = [
+            dest_dir / spec.layout_sidecar_name(t) for t in crate_layout_targets(eng, spec)
+        ]
         if (
             not args.force
             and dest.exists()
             and dest.stat().st_size > 0
+            and all(s.exists() and s.stat().st_size > 0 for s in sidecars)
             and stamp_path.exists()
             and stamp_path.read_text() == stamp + "\n"
         ):
@@ -442,6 +543,7 @@ def extract(eng: Engine, args: argparse.Namespace) -> None:
             crate_root = path / "src" / "main.rs"
         crate_root.touch()
 
+        host_env = {**env, **host_config_env}
         command = [
             str(charon_bin),
             "cargo",
@@ -453,7 +555,7 @@ def extract(eng: Engine, args: argparse.Namespace) -> None:
             *flags,
             *host_config,
         ]
-        subprocess.run(command, cwd=path, env=env, check=True)
+        subprocess.run(command, cwd=path, env=host_env, check=True)
         # Fail loud rather than letting a missing artefact surface later
         # as an opaque build.rs panic ("build/llbc/ is missing …").
         if not dest.exists() or dest.stat().st_size == 0:
@@ -462,6 +564,58 @@ def extract(eng: Engine, args: argparse.Namespace) -> None:
                 "  the crate compiled but produced no MIR — "
                 "inspect the Charon output above"
             )
+
+        # One extra extraction per cross target, reduced to its type
+        # declarations. Charon's own `--targets` aggregation would fold
+        # every target's layouts into this one artefact, but it aggregates
+        # the *bodies* too: a `cfg`-differing function lands two or three
+        # times over, and a portal that must resolve to an exact graph no
+        # longer does. Extracting each target separately keeps the host
+        # artefact's bodies untouched, and dropping everything but
+        # `type_decls` from the cross-target one leaves only what a
+        # cross-target build actually lacks — its own field offsets.
+        for target in crate_layout_targets(eng, spec):
+            if target not in prepared_std:
+                ensure_charon_std(charon_bin, [target], eng.root)
+                prepared_std.add(target)
+            sidecar = dest_dir / spec.layout_sidecar_name(target)
+            print(f"=== extracting {crate} layouts for {target} -> {sidecar} ===")
+            layout_flags = (
+                flags
+                if spec.layout_cargo_args is None
+                else [expand_features(arg, cargo_features) for arg in spec.layout_cargo_args]
+            )
+            layout_env = dict(env)
+            if eng.layout_target_rustflags:
+                layout_env["RUSTFLAGS"] = (
+                    layout_env.get("RUSTFLAGS", "") + " " + eng.layout_target_rustflags
+                ).strip()
+            full = sidecar.with_suffix(sidecar.suffix + ".full")
+            crate_root.touch()
+            subprocess.run(
+                [
+                    str(charon_bin),
+                    "cargo",
+                    "--ullbc",
+                    "--dest-file",
+                    str(full),
+                    "--targets",
+                    target,
+                    *charon_flags,
+                    "--",
+                    *layout_flags,
+                ],
+                cwd=path,
+                env=layout_env,
+                check=True,
+            )
+            if not full.exists() or full.stat().st_size == 0:
+                raise SystemExit(
+                    f"extract-llbc.py: Charon emitted no {target} artefact at {full}"
+                )
+            write_layout_sidecar(full, sidecar)
+            full.unlink()
+            print(f"    wrote {sidecar} ({sidecar.stat().st_size} bytes)")
         # Guard the fingerprint exclusion (CrateSpec.excluded_deps): a package
         # dropped from this crate's fingerprint must not appear in its artefact,
         # else a later edit to that package would silently serve a stale cache.
@@ -492,6 +646,8 @@ def run_cli(
     base_pathspecs: list[str] | None = None,
     charon_root: Path | None = None,
     metadata_feature_crates: tuple[str, ...] = (),
+    layout_targets: tuple[str, ...] = (),
+    layout_target_rustflags: str = "",
 ) -> None:
     """Argparse UX shared by every driver (positional crates, --force, …)."""
     all_crates = " ".join(specs)
@@ -515,6 +671,11 @@ def run_cli(
     # the dynasm build never needs. A driver whose crates ignore `{features}`
     # is unaffected by this default. Override with `CARGO_FEATURES`.
     cargo_features = os.environ.get("CARGO_FEATURES", "dynasm")
+    # `LLBC_LAYOUT_TARGETS` overrides the driver's cross-target layout set
+    # (comma-separated); the empty string extracts host layouts only.
+    layout_override = os.environ.get("LLBC_LAYOUT_TARGETS")
+    if layout_override is not None:
+        layout_targets = tuple(t.strip() for t in layout_override.split(",") if t.strip())
     eng = Engine(
         specs=specs,
         default_crates=default_crates,
@@ -524,6 +685,8 @@ def run_cli(
         charon_root=charon_root or root,
         cargo_features=cargo_features,
         metadata_feature_crates=metadata_feature_crates,
+        layout_targets=layout_targets,
+        layout_target_rustflags=layout_target_rustflags,
     )
 
     crates = args.crates or default_crates

--- a/scripts/llbc_extract.py
+++ b/scripts/llbc_extract.py
@@ -402,7 +402,7 @@ def write_layout_sidecar(source: Path, dest: Path) -> None:
     text = source.read_text(encoding="utf-8")
     decoder = json.JSONDecoder()
 
-    def field(name: str):
+    def field(name: str, *, want: type):
         key = f'"{name}":'
         at = text.find(key)
         if at < 0:
@@ -411,15 +411,34 @@ def write_layout_sidecar(source: Path, dest: Path) -> None:
         start = at + len(key)
         while text[start] in " \t\r\n":
             start += 1
-        value, _ = decoder.raw_decode(text, start)
+        try:
+            value, _ = decoder.raw_decode(text, start)
+        except json.JSONDecodeError as exc:
+            # The substring scan is unscoped, so `"{name}":` could match inside
+            # a string literal before the real key; then `start` points at
+            # non-JSON and decoding fails.  Report it the same way the rest of
+            # this file does instead of surfacing a bare traceback.
+            raise SystemExit(
+                f"extract-llbc.py: {source.name} `{name}` did not decode as JSON "
+                f"({exc}); the reducer's key scan matched a non-field occurrence."
+            ) from exc
+        # Shape guard: a wrong (earlier) match can still decode as valid JSON of
+        # the wrong type.  `type_decls` in particular must reach the sidecar
+        # intact — it is the sole source of the target field offsets.
+        if not isinstance(value, want):
+            raise SystemExit(
+                f"extract-llbc.py: {source.name} `{name}` decoded as "
+                f"{type(value).__name__}, expected {want.__name__}; the reducer's "
+                f"key scan matched a non-field occurrence."
+            )
         return value
 
     slim = {
-        "charon_version": field("charon_version"),
-        "has_errors": field("has_errors"),
+        "charon_version": field("charon_version", want=str),
+        "has_errors": field("has_errors", want=bool),
         "translated": {
-            "crate_name": field("crate_name"),
-            "type_decls": field("type_decls"),
+            "crate_name": field("crate_name", want=str),
+            "type_decls": field("type_decls", want=list),
             "fun_decls": [],
         },
     }


### PR DESCRIPTION
The build-time descr pool that `pyre-jit-trace/build.rs` serialises is read back
by the target binary, but every offset in it came from a single host extraction
of Charon LLBC plus a hardcoded 8-byte pointer in the layout model. On a 32-bit
target both are wrong — `PyObject.w_class` sits at 4, not 8; `PyType.instantiate`
at 24, not 32 — so the orthodox `w_list_append` sub-walk, the one production
consumer that resolves `d` operands through the pool, read the wrong bytes on
wasm32. #697 papered over this by gating the fold on a runtime layout check.

Three layers, all fixed here:

1. **Extraction was host-only.** A layout sidecar is now produced per configured
   cross target: charon re-runs with `--targets <triple>` and the result is
   reduced to its `type_decls`, written as `<crate>.<target>.layouts.ullbc`
   (1.1 MB / 6.9 MB vs the 46 MB / 383 MB host artefacts). `majit-translate`
   prepends them when `TARGET != HOST`, so their `exact_layouts` win the
   first-writer-wins merge. Reader code is untouched. Passing `--targets` with
   several triples in one pass was tried first and rejected: it aggregates
   *bodies* too, which breaks portal resolution.
2. **The layout model assumed a 64-bit pointer.** `layout::target_word_size()`
   reads `CARGO_CFG_TARGET_POINTER_WIDTH` and replaces `size_of::<usize>()`
   throughout `codewriter::call`; `usize`/`isize` split off `u64`/`i64`. On a
   64-bit target the word is still 8, so native codegen is bit-identical.
3. **A latent 32-bit-only optimizer bug.** `intbounds::propagate_postprocess`
   grouped `Getfield*{I,R,F}` into one arm gated on `field_size < 8`. Only the
   `_I` opcodes have a postprocess, and a 4-byte pointer field satisfies the
   sub-word test — so with correct layouts wasm hit
   `setintbound: expected 'i'-typed operand, got Ref`. Narrowed to `_I`.

`build_descr_layout_matches_target()` is replaced by
`build_time_field_offset(owner, name)` plus a test pinning the pool's offsets to
`offset_of!` for the structs the sub-walk reads.

`pyre-jit` gets no sidecar: with `--target` set, cargo stops applying RUSTFLAGS
to host units, and `pyre-jit-trace`'s build script drags in `rustpython-host_env`,
which uses `cfg_select!` — still unstable on Charon's pinned nightly, and the
`-Zhost-config` that would reach host units panics cargo. The 588 types this
leaves out are all compiler-internal; every runtime type reached through a descr
comes from `pyre-object` or `pyre-interpreter`, which do get sidecars.

## Verification

- `check.py`: dynasm 244/244, cranelift 244/244, wasm 243/243
- `cargo test -p majit-metainterp --lib`: 1401 passed
- `cargo fmt --all -- --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for target-specific layout metadata during cross-compilation.
  - Improved build preparation for cross-target and WebAssembly environments.
  - Added validation to detect missing layout artifacts before compilation.

- **Bug Fixes**
  - Improved structure, array, and field layout calculations across different target word sizes.
  - Corrected integer-bound propagation for applicable field operations.
  - Removed an unnecessary WebAssembly restriction affecting list-append optimizations.

- **Tests**
  - Added checks confirming build-time and runtime field layouts remain consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->