### PR TITLE
comments: strip internal AI-session tracking labels; fix Snapshot::extra_virtual_roots build break

### DIFF
--- a/majit/examples/tl/src/jit_interp.rs
+++ b/majit/examples/tl/src/jit_interp.rs
@@ -8,7 +8,7 @@
 /// Reds:   [inputarg, stackpos, stack]  (inputarg is a function parameter — red by nature)
 use majit_metainterp::jit::promote;
 
-// [SPIKE-S0/FR] throwaway compile counter to measure portal-call compile-through.
+// Throwaway compile counter to measure portal-call compile-through.
 pub static SPIKE_COMPILES: core::sync::atomic::AtomicU32 = core::sync::atomic::AtomicU32::new(0);
 
 /// Stack rotation — @dont_look_inside in RPython (tl.py:43).
@@ -117,7 +117,7 @@ const PUSHARG: u8 = 22;
 pub fn mainloop(program: &Bytecode, inputarg: i64, threshold: u32) -> i64 {
     let mut driver: majit_metainterp::JitDriver<TlState> =
         majit_metainterp::JitDriver::new(threshold);
-    // [SPIKE-S0/FR] count compiled loops.
+    // Count compiled loops.
     driver.set_on_compile_loop(|_gk, _b, _a| {
         SPIKE_COMPILES.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
     });
@@ -470,7 +470,7 @@ mod tests {
         ]
     }
 
-    /// [SPIKE-S0/FR] Measure whether a portal call inside a hot loop compiles
+    /// Measure whether a portal call inside a hot loop compiles
     /// through. Control = pure loop (no call). Probe = leaf call in loop body.
     #[test]
     fn spike_portal_call_compile_through() {

--- a/majit/majit-backend-wasm/src/codegen.rs
+++ b/majit/majit-backend-wasm/src/codegen.rs
@@ -3276,7 +3276,7 @@ fn build_function(
                 // own frame was the shadow-stack top. Now that the callee is
                 // pushed, reload local 0 from the entry beneath it before
                 // resolving inputs through local-0-relative homes. The
-                // trampoline path intentionally keeps the A0-era assumption:
+                // trampoline path intentionally keeps the earlier assumption:
                 // its scratch writes themselves dereference stale local 0.
                 if let (Some(_base), Some(inline)) = (residual_type_base, ca.inline) {
                     emit_ca_reload_caller(&mut sink, inline.jf_top_addr);
@@ -3380,7 +3380,7 @@ fn build_function(
                 // The recursive call or deopt helper may have collected and
                 // moved this invocation's own frame. Reload it before the pop
                 // trampoline and post-call home loads address local 0. As above,
-                // the trampoline-only configuration retains its A0-era stale-
+                // the trampoline-only configuration retains its earlier stale-
                 // local-0 limitation because its scratch writes cannot reload it
                 // safely.
                 if let (Some(_base), Some(inline)) = (residual_type_base, ca.inline) {

--- a/majit/majit-backend-wasm/src/lib.rs
+++ b/majit/majit-backend-wasm/src/lib.rs
@@ -598,7 +598,7 @@ pub extern "C" fn wasm_jit_ca_alloc_frame(frame_bytes: i64, gcmap_ptr: i64) -> i
     assert!(frame_bytes >= 0);
     assert_eq!(frame_bytes as usize % std::mem::size_of::<isize>(), 0);
     let depth = frame_bytes as usize / std::mem::size_of::<isize>();
-    // Slice A1: collecting nursery allocation, matching rewrite.py's
+    // Collecting nursery allocation, matching rewrite.py's
     // `gen_malloc_nursery_varsize_frame`. The caller frame remains rooted at
     // the shadow-stack top during a collection; wasm reloads it from there
     // after this call, then this freshly allocated callee is pushed below its
@@ -1344,7 +1344,7 @@ fn transfer_call_assembler_target_activity(
 /// Mark a CA target whose callee guard was structurally declined.  The host
 /// deopt helper calls this only after `MetaInterp` recorded the exact guard in
 /// `declined_bridge_guards`; invalidating the callers forces a retrace whose
-/// admission check above restores the pre-Slice-A call path.
+/// admission check above restores the plain call path.
 pub fn mark_call_assembler_terminal_decline(compiled_ptr: usize) {
     unsafe {
         let Some(loop_) = (compiled_ptr as *const CompiledWasmLoop).as_ref() else {

--- a/majit/majit-backend-wasm/src/lib.rs
+++ b/majit/majit-backend-wasm/src/lib.rs
@@ -2945,7 +2945,7 @@ mod tests {
         assert_eq!(unknown, None);
     }
 
-    /// S0 spike for the Option A wasm-JITFRAME refactor: prove the shared
+    /// Spike for the wasm-JITFRAME refactor: prove the shared
     /// `MiniMarkGC` forwards a JitFrame's interior Ref item through the
     /// `jf_gcmap` custom-trace when the frame is discovered via the jitframe
     /// shadow stack. This is the exact GC path the orthodox wasm loop would
@@ -2953,7 +2953,7 @@ mod tests {
     /// traced by `jf_gcmap` during a minor collection (`do_collect_nursery`
     /// Phase 1c → `trace_and_update_object` → `jitframe_custom_trace`). The
     /// wasm backend has none of the feeders yet; this confirms the collector
-    /// side works so the feeders can be built (S1–S3).
+    /// side works so the feeders can be built.
     #[test]
     fn jitframe_oldgen_gcmap_minor_forwards_ref_item() {
         use majit_backend::jitframe::{

--- a/majit/majit-ir/src/resumedata.rs
+++ b/majit/majit-ir/src/resumedata.rs
@@ -536,7 +536,7 @@ mod branch_orgpc_tag_tests {
 
     #[test]
     fn roundtrips_across_orgpc_and_flavor() {
-        // #73 S3.5: every (orgpc, flavor) in range tags into the negative space
+        // Every (orgpc, flavor) in range tags into the negative space
         // and decodes back exactly, including the two endpoints.
         for orgpc in [
             0usize,

--- a/majit/majit-ir/src/value.rs
+++ b/majit/majit-ir/src/value.rs
@@ -1152,7 +1152,7 @@ mod tests {
     /// the typed `GreenKey([pc, profiled, code], [Int, Int, Ref])` and
     /// calling `get_uhash` — that equivalence is what lets the legacy
     /// `make_green_key` u64 flow and the typed marker path agree on the
-    /// same cell (issue #203 gap-7 hash unification).
+    /// same cell.
     #[test]
     fn test_pypyjit_greenkey_uhash_matches_get_uhash() {
         let cases: &[(usize, bool, u64)] = &[

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/api.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/api.rs
@@ -58,7 +58,7 @@ pub(crate) struct CallerLocalLayout {
 ///
 /// Dispatch-arm lowering entry that pre-binds a list of caller-locals as
 /// portal-input bindings on the sub-Lowerer before lowering the body.
-/// The caller (slice 1.3 — dispatch arm emit at `lower_dispatch_chain`)
+/// The caller (dispatch arm emit at `lower_dispatch_chain`)
 /// collects them via
 /// [`collect_arm_caller_locals`] and threads the same list through
 /// `inline_call_<types>_v` as `(parent_reg, callee_reg)` pairs.

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/dispatch.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/dispatch.rs
@@ -78,7 +78,7 @@ mod find_dispatch_loop_body_tests {
 /// suppression set so subsequent `x` references in the same arm are NOT
 /// reported as caller-locals (the local shadows the caller scope).
 /// Scope tracking is intentionally flat — over-suppression in nested
-/// blocks is acceptable since the consumer (slice 2) just gets fewer
+/// blocks is acceptable since the consumer just gets fewer
 /// args, which is safe.  Under-suppression (let in inner block missed
 /// by outer scope) is fine — sub-Lowerer ignores extra portal inputs.
 /// Collect every identifier the pattern would bind, recursing into

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/lower_stmt.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/lower_stmt.rs
@@ -1324,11 +1324,11 @@ impl<'c> Lowerer<'c> {
                 crate::jit_interp::CallPolicyKind::ElidableInt
                 | crate::jit_interp::CallPolicyKind::ElidableIntCannotRaise
                 | crate::jit_interp::CallPolicyKind::ElidableIntOrMemerror => {
-                    // Parity #14 Slice C.4 + Parity #20: Pure flows through
+                    // Pure flows through
                     // the canonical `BC_RESIDUAL_CALL_*_I` family with the
                     // calldescr's `extra_info` set per `call.py:292-299
                     // _canraise(op)`'s 3-way pick.  The walker
-                    // (`pyjitpl/dispatch.rs` Slice C.1) reads
+                    // (`pyjitpl/dispatch.rs`) reads
                     // `effectinfo.check_is_elidable()` and routes through
                     // `record_result_of_call_pure` mirroring
                     // `pyjitpl.py:2111-2115`; the trailing

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/lower_value.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/lower_value.rs
@@ -761,7 +761,7 @@ impl<'c> Lowerer<'c> {
                 crate::jit_interp::CallPolicyKind::ElidableInt
                 | crate::jit_interp::CallPolicyKind::ElidableIntCannotRaise
                 | crate::jit_interp::CallPolicyKind::ElidableIntOrMemerror => {
-                    // Parity #14 Slice C.4 + Parity #20: see the stmt-form
+                    // See the stmt-form
                     // ElidableInt arm earlier in this file for the
                     // canonical migration rationale and the 3-way
                     // `_canraise(op)` pick from `call.py:292-299`.

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/lowerer.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/lowerer.rs
@@ -153,7 +153,7 @@ impl<'c> Lowerer<'c> {
 
     /// Emit an op token plus its parallel `OpMeta` entry, keeping
     /// `statements` and `op_metadata` index-aligned for the backward
-    /// liveness walker (Slice B.2.B).
+    /// liveness walker.
     pub(super) fn emit_op(&mut self, meta: OpMeta, tokens: TokenStream) {
         self.statements.push(tokens);
         self.op_metadata.push(meta);

--- a/majit/majit-macros/src/lib.rs
+++ b/majit/majit-macros/src/lib.rs
@@ -650,7 +650,7 @@ fn helper_policy_tokens_for_fn(
     // func._call_aroundstate_target_` — destructure the 2-tuple under
     // the upstream attribute name.  Pyre's `expand_call_surface_attr`
     // emits this const at module scope for `#[jit_release_gil]` callees
-    // (see slice 1); the policy fn body below mirrors the upstream
+    // the policy fn body below mirrors the upstream
     // destructure verbatim instead of threading the concrete target /
     // save_err through opaque tuple slots.
     let aroundstate_path = format_ident!("_call_aroundstate_target_{}", func.sig.ident);

--- a/majit/majit-metainterp/src/compile.rs
+++ b/majit/majit-metainterp/src/compile.rs
@@ -2379,7 +2379,7 @@ pub fn compile_tmp_callback(
     greenboxes: &[Value],
     red_arg_types: &[Type],
 ) -> Result<Arc<JitCellToken>, BackendError> {
-    // S2.1 invariant (wiggly-barto plan): every `JitDriverStaticData` reaching
+    // Invariant: every `JitDriverStaticData` reaching
     // `compile_tmp_callback` must have `portal_runner_adr` AND `portal_calldescr`
     // populated. `portal_runner_adr == 0` is the "attribute absent" sentinel
     // upstream (`warmspot.py:1010-1012` sets the address before any tmp_callback
@@ -2437,14 +2437,14 @@ pub fn compile_tmp_callback(
         nb_red_args,
         "compile_tmp_callback: red_arg_types length mismatch",
     );
-    // S2.4 contract (wiggly-barto plan): caller-passed `red_arg_types`
+    // Contract: caller-passed `red_arg_types`
     // must match `jd.red_args_types` — upstream's `compile.py:1107-1124`
     // reads `redargtypes` from `jitdriver_sd.red_args_types` directly so
     // the tmp-callback signature is owned by the jd, not by the call
     // site. Pyre still threads `red_arg_types` through the parameter
     // list while runtime callers derive kinds from CALL_ASSEMBLER args
-    // (see pyjitpl.rs:10444-10451); this assertion locks the
-    // invariant so the S2.4 cutover can drop the parameter without
+    // (see pyjitpl.rs); this assertion locks the invariant so a
+    // later cutover can drop the parameter without
     // a silent semantic shift.
     debug_assert_eq!(
         red_arg_types,

--- a/majit/majit-metainterp/src/history.rs
+++ b/majit/majit-metainterp/src/history.rs
@@ -2836,7 +2836,7 @@ impl TraceCtx {
     /// `build_state_field_snapshot(frames, …, virtualizable_boxes,
     /// virtualref_boxes)` for the state-field JIT guards.
     ///
-    /// Convergence (task #208): the only callers of this path are the
+    /// Convergence: the only callers of this path are the
     /// interpreter-side vable promotes — `get_arrayitem_vable_index`
     /// (`trace_ctx.rs`) and the `is_nonstandard_virtualizable` `isstandard`
     /// PTR_EQ (`trace_ctx.rs`, `pyjitpl.rs`). Both emit a `GUARD_VALUE`
@@ -2853,7 +2853,7 @@ impl TraceCtx {
     /// (`pyjitpl/dispatch.rs`), the full-framestack capture already at parity
     /// with `generate_guard`. Threading the live framestack into this recorder
     /// would only matter at framestack depth > 1 (inlined frames), which
-    /// cannot arise until the trace-into machinery (task #184) exists; a
+    /// cannot arise until the trace-into machinery exists; a
     /// partial box list would otherwise positionally misalign the resume
     /// reader's per-frame register layout, so the snapshot stays minimal.
     fn record_guard_with_snapshot(
@@ -3454,7 +3454,7 @@ impl TraceCtx {
         arg_types: &[Type],
         slot: EffectInfoSlot,
     ) -> OpRef {
-        // history.py:314 ConstPtr.value inline (Slice 7b op-graph walker
+        // history.py:314 ConstPtr.value inline (the op-graph walker
         // forwards `OpRef::ConstPtr(GcRef)` slots in `op.args`).
         let value_ref = OpRef::const_ptr(majit_ir::GcRef(value as usize));
         let func_ref = OpRef::const_int(func_ptr as usize as i64);
@@ -3513,7 +3513,7 @@ impl TraceCtx {
         // matching `history.py:307 ConstPtr` and preventing alias with
         // `ConstInt` slots of the same raw value.
         // history.py:227/268/314 Const{Int,Float,Ptr}.value inline.
-        // Slice 7b op-graph walker forwards Ref slots.
+        // The op-graph walker forwards Ref slots.
         let result_ref = match result_type {
             Type::Int => OpRef::const_int(result_value),
             Type::Float => OpRef::const_float(f64::from_bits(result_value as u64)),

--- a/majit/majit-metainterp/src/history.rs
+++ b/majit/majit-metainterp/src/history.rs
@@ -2407,6 +2407,10 @@ impl TraceCtx {
             frames: recorder_frames,
             vable_boxes: vable_boxes.to_vec(),
             vref_boxes: vref_boxes.to_vec(),
+            // The nested-list append fold resumes through the single-frame
+            // collapse, never this multi-frame path, so no extra virtual roots
+            // flow here.
+            extra_virtual_roots: Vec::new(),
         });
         self.set_last_guard_op_resume_position(snapshot_id);
     }

--- a/majit/majit-metainterp/src/jit_state.rs
+++ b/majit/majit-metainterp/src/jit_state.rs
@@ -636,7 +636,7 @@ pub trait JitState: Sized {
     /// `merge_point` / `force_finish_trace` where the generic `S::Sym`
     /// is not constrained to implement `JitCodeSym`.  Once
     /// `JitState::Sym: JitCodeSym` becomes the universal contract
-    /// (orth-9 step 4 reshape), this hook collapses into the
+    /// this hook collapses into the
     /// `JitCodeSym` method directly.
     fn populate_frame_for_guard(
         _sym: &Self::Sym,

--- a/majit/majit-metainterp/src/jitcode/assembler.rs
+++ b/majit/majit-metainterp/src/jitcode/assembler.rs
@@ -3771,12 +3771,12 @@ impl JitCodeBuilder {
         );
     }
 
-    /// Parity #14 Slice C.4: Pure sibling of
+    /// Pure sibling of
     /// [`Self::residual_call_int_canonical_via_target`].  Emits the
     /// canonical `BC_RESIDUAL_CALL_{R,IR,IRF}_I` opcode with the
     /// calldescr's `extra_info` set to `ELIDABLE_CAN_RAISE`
     /// (`call_descr::ELIDABLE_EFFECT_INFO`).  The canonical walker
-    /// (`majit-metainterp/src/pyjitpl/dispatch.rs` Slice C.1) reads
+    /// (`majit-metainterp/src/pyjitpl/dispatch.rs`) reads
     /// `effectinfo.check_is_elidable()` and routes the result through
     /// `record_result_of_call_pure` mirroring `pyjitpl.py:2111-2115`,
     /// retiring the legacy `BC_CALL_PURE_INT`-specific code path.
@@ -4072,7 +4072,7 @@ impl JitCodeBuilder {
         self.push_u8(dst as u8);
     }
 
-    /// Parity #14 Slice C.4: see
+    /// See
     /// [`Self::call_pure_int_canonical_via_target`] for the rationale.
     pub fn call_pure_ref_canonical_via_target(
         &mut self,
@@ -4185,7 +4185,7 @@ impl JitCodeBuilder {
         self.push_u8(dst as u8);
     }
 
-    /// Parity #14 Slice C.4: see
+    /// See
     /// [`Self::call_pure_int_canonical_via_target`] for the rationale.
     pub fn call_pure_float_canonical_via_target(
         &mut self,

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -491,7 +491,7 @@ pub struct JitDriverStaticData {
     /// `propagate_exception` post-loop branch.
     ///
     /// `0` mirrors upstream's "attribute absent" / "not yet wired" state
-    /// — populated by S2.1 alongside `portal_runner_adr`.
+    /// — populated alongside `portal_runner_adr`.
     pub assembler_helper_adr: i64,
     /// jitdriver.py:29 `self.vable_token_descr` (CALL_ASSEMBLER).
     ///
@@ -723,7 +723,7 @@ impl JitDriverStaticData {
     /// Pyre stores `red_args_types: Vec<char>` to mirror upstream's
     /// `'i' / 'r' / 'f'` representation; this helper bridges to the IR
     /// `Type` enum without the caller having to re-implement the
-    /// mapping. The S2.4 cutover will drop the explicit `red_arg_types`
+    /// mapping. A later cutover will drop the explicit `red_arg_types`
     /// argument from `compile_tmp_callback` and read from the jd
     /// directly via this helper.
     ///
@@ -1088,8 +1088,7 @@ impl<S: JitState> JitDriver<S> {
     /// `make_jitcodes() → finish_setup(codewriter)` for the narrow
     /// `pyjitpl.py:2264 self.liveness_info = "".join(asm.all_liveness)`
     /// slice — full `finish_setup` requires `CodeWriter` /
-    /// `CallControl` construction (orth-9 plan step 4) which
-    /// is not yet wired.
+    /// `CallControl` construction, which is not yet wired.
     ///
     /// Caller responsibility: build a fresh
     /// `majit_translate::codewriter::assembler::Assembler`,

--- a/majit/majit-metainterp/src/jitprof.rs
+++ b/majit/majit-metainterp/src/jitprof.rs
@@ -1143,7 +1143,7 @@ mod tests {
         // writes to that Arc must be visible to the profiler's
         // `get_counter` and freed-bump helpers.  Two independent
         // profilers bound to separate trackers must NOT share state —
-        // this is the regression Codex P2 flagged.
+        // this is the regression under test.
         let prof_a = JitProfiler::default();
         let prof_b = JitProfiler::default();
         let tracker_a = Arc::new(CpuTotalTracker::default());

--- a/majit/majit-metainterp/src/memmgr.rs
+++ b/majit/majit-metainterp/src/memmgr.rs
@@ -19,9 +19,8 @@
 //! Pyre currently has additional strong references in `BaseJitCell.
 //! loop_token` and embedded `JitCellToken` values inside
 //! `pyjitpl::compiled_loops`. Achieving "alive_loops is the SOLE
-//! strong owner" requires the slicing chain in
-//! `.claude/plans/memmgr-line-by-line-parity.md` (Slices 3.5–3.6),
-//! whose tail is blocked on (Arc lift of CompiledEntry.token).
+//! strong owner" requires further slicing whose tail is blocked on an
+//! Arc lift of `CompiledEntry.token`.
 //! Today `alive_loops` is a *third* strong owner; eviction tracking
 //! works for the warmstate side, but actual token frees only happen
 //! once Slices 3.5–3.6 prune the other strong owners.

--- a/majit/majit-metainterp/src/opencoder.rs
+++ b/majit/majit-metainterp/src/opencoder.rs
@@ -774,7 +774,7 @@ impl<'a> ByteTraceIter<'a> {
             }
             TAGCONSTPTR => {
                 // opencoder.py:328-329 ConstPtr(self.trace._refs[v]) —
-                // history.py:314 `ConstPtr.value` inline. Slice 7b
+                // history.py:314 `ConstPtr.value` inline. The
                 // op-graph walker forwards `OpRef::ConstPtr(GcRef)`
                 // slots across minor collection.
                 let addr = self.trace._refs[v as usize];
@@ -3402,7 +3402,7 @@ mod tests {
         assert!(it.done());
     }
 
-    /// M4 (post-Slice-7b): all `TAG{INT,CONSTPTR,CONSTOTHER}` args mint
+    /// All `TAG{INT,CONSTPTR,CONSTOTHER}` args mint
     /// inline-Const OpRefs (`history.py:227/268/314 Const{Int,Float,Ptr}.value`
     /// are inline) so the byte iterator no longer requires a
     /// ConstantPool to decode constant arguments. The op-graph GC walker

--- a/majit/majit-metainterp/src/optimizeopt/optimizer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/optimizer.rs
@@ -5061,7 +5061,7 @@ impl Optimizer {
         // copy here leaves the shared guard with `fail_arg_types=None`,
         // the bridge code falls back to the bridge tracer's (unboxed)
         // inputarg types, and the Ref count disagrees with the serializer
-        // → rd_numb over-read. See memory/fannkuch_reg20_root_cause.md.
+        // → rd_numb over-read.
         if let Some(types) = last.get_fail_arg_types() {
             op.set_fail_arg_types(types.to_vec());
         } else {

--- a/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
+++ b/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
@@ -1325,7 +1325,7 @@ fn imported_const_opref(
     }
     // history.py:227/268/314 Const{Int,Float,Ptr}.value inline — fresh
     // imported short-preamble constant lands inline in `op.args` rather
-    // than indexing the legacy pool. Slice 7b op-graph walker covers
+    // than indexing the legacy pool. The op-graph walker covers
     // ConstPtr slots across minor collection.
     let opref = match value {
         majit_ir::Value::Int(v) => OpRef::const_int(*v),

--- a/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
+++ b/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
@@ -1619,7 +1619,7 @@ impl ProducedShortOp {
         // phase boundary, so an eager `imported_short_aliases.push` here
         // would be a TODO dual write.
         //
-        // Path B parity (B.6.7): Heap/Array/LoopInvariant produce_* return
+        // Heap/Array/LoopInvariant produce_* return
         // `source` so successor short-op dependency args resolve through
         // `produced_results` to Phase 1 source-namespace (matching body
         // refs after `force_op_from_preamble_op` returns `preamble_source`).

--- a/majit/majit-metainterp/src/optimizeopt/unroll.rs
+++ b/majit/majit-metainterp/src/optimizeopt/unroll.rs
@@ -4351,7 +4351,7 @@ impl OptUnroll {
         //
         // `produced_results` accumulates `source pos -> replay identity` so
         // successor entries can resolve `Produced` arg classifications. After
-        // Path B (B.6.7) the producer-side `produce_*` methods return
+        // The producer-side `produce_*` methods return
         // `Some(source)` (Phase 1 OpRef = `self.res`); for invented Pure the
         // value is the body-visible OpRef per `replay_pos` in
         // `initialize_imported_short_preamble_builder_from_short_boxes`.
@@ -7319,7 +7319,7 @@ mod tests {
 
         import_short_preamble_state(&[OpRef::int_op(0)], &[phase2_result], &exported, &mut ctx);
 
-        // Path B (B.6.7-loopinv): imported_loop_invariant_results stores the
+        // imported_loop_invariant_results stores the
         // Phase 1 source directly (RPython `shortpreamble.py:120 op = self.res`).
         let _ = phase2_result;
         assert_eq!(
@@ -7462,7 +7462,7 @@ mod tests {
             .unwrap()
             .produced_short_op(&src19)
             .unwrap();
-        // Path B (B.6.7-heap-field): produce_heap_field no longer installs
+        // produce_heap_field no longer installs
         // make_equal_to, but the test still walks the get_box_replacement
         // chain inside force_box's add_preamble_op, so install a manual
         // forwarding to the body-visible OpRef to exercise that path.

--- a/majit/majit-metainterp/src/optimizeopt/unroll.rs
+++ b/majit/majit-metainterp/src/optimizeopt/unroll.rs
@@ -925,7 +925,7 @@ impl UnrollOptimizer {
         opt_p2.all_descrs = std::mem::take(&mut self.all_descrs);
         opt_p2.callinfocollection = self.callinfocollection.clone();
         opt_p2.cpu = self.cpu.clone();
-        // #217 Slice 3 — Phase 2 (peeled-loop pass) runtime value seed.
+        // Phase 2 (peeled-loop pass) runtime value seed.
         // The remap is deferred until after the Phase 2 `TraceIterator`
         // builds its `_cache`, because both inputargs AND body op results
         // are reminted to fresh OpRefs (opencoder.py:259-267 / :399-401).

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -1887,7 +1887,7 @@ impl<M: Clone> MetaInterp<M> {
             .map(|trace| (trace_id, trace))
     }
 
-    /// gh#73 S3.3: the OpCode of the guard op that produced this exit, resolved
+    /// The OpCode of the guard op that produced this exit, resolved
     /// from the `source_op_index` the fail descriptor / exit layout carries.
     /// Pure read of the retained compiled trace ops; None if the loop/trace is
     /// gone or the index is out of range.
@@ -6915,7 +6915,7 @@ impl<M: Clone> MetaInterp<M> {
         combined_ops.extend(body_ops);
         // history.py:227/268/314 parity: `op.args[j]` carries inline
         // `ConstX.value` directly; the retrace boundary no longer needs
-        // a separate `constants` side-table merge (Slice 7a).
+        // a separate `constants` side-table merge.
 
         // compile.py:1075-1085 + 379-393 parity: the partial trace saved by
         // compile_trace already owns the bridge inputarg contract
@@ -10003,7 +10003,7 @@ impl<M: Clone> MetaInterp<M> {
             .enumerate()
             .map(|(i, ia)| majit_ir::OpRef::input_arg_typed(i as u32, ia.tp))
             .collect();
-        // #217 Slice 4 — bridge inputarg `InputArg*.value` stamp.
+        // Bridge inputarg `InputArg*.value` stamp.
         //
         // bridgeopt.py:124 `deserialize_optimizer_knowledge` receives
         // `frontend_boxes` (the source guard's live boxes) alongside
@@ -19035,7 +19035,7 @@ mod tests {
     fn walk_partial_trace_refs_forwards_inline_const_ptr_in_op_args() {
         // history.py:314 `ConstPtr.value` parity: an inline-Const Ref
         // stored in `op.args[j]` is the canonical forwardable Ref site
-        // after Slice 2 producer cutover. A minor collection between
+        // after the producer cutover. A minor collection between
         // a failed bridge compile and `compile_retrace` must forward
         // it through the op-graph walker.
         let mut meta = MetaInterp::<()>::new(0);
@@ -19067,7 +19067,7 @@ mod tests {
     fn walk_partial_trace_refs_forwards_inline_const_ptr_in_fail_args() {
         // history.py:314 + resoperation.py guard fail_args parity:
         // guard ops carry `fail_args` (the resume-side live values).
-        // After Slice 2 cutover, an inline ConstPtr in fail_args must
+        // After the cutover, an inline ConstPtr in fail_args must
         // also forward across minor collection.
         let mut meta = MetaInterp::<()>::new(0);
         let guard = mk_op(OpCode::GuardTrue, &[OpRef::input_arg_int(0)], 11);
@@ -21196,7 +21196,7 @@ mod tests {
 
     #[test]
     fn on_back_edge_typed_installs_cell_with_typed_comparekey() {
-        // #203 gap-7 step-a cutover: a hot back-edge carrying a real
+        // A hot back-edge carrying a real
         // (code, pc) must install a warm-state cell with a typed
         // `comparekey`, so the marker-path lookup (`lookup_chain_with_key`)
         // resolves to the same cell as the legacy u64 hash flow. The cell
@@ -21229,7 +21229,7 @@ mod tests {
 
     #[test]
     fn bound_reached_force_starts_cell_with_typed_comparekey() {
-        // #203 gap-7 step-a: the can_enter_jit force-start path
+        // The can_enter_jit force-start path
         // (`bound_reached` → `force_start_tracing_for_key`) must also
         // install a cell with a typed comparekey, bypassing the counter.
         let mut meta = MetaInterp::<()>::new(1);

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -13488,11 +13488,11 @@ impl<M: Clone> MetaInterp<M> {
         );
         // pyjitpl.py:3597-3599 token = warmrunnerstate.get_assembler_token(greenargs).
         //
-        // S2.4 follow-up: pull `arg_types` from `target_sd.red_args_types`
+        // Pull `arg_types` from `target_sd.red_args_types`
         // (warmspot.py:664) — the static spec is the source of truth.
         // The previous shape recomputed types from runtime arg kinds
         // every call; the consistency assert at
-        // compile.rs::compile_tmp_callback (S2.4) already locks the
+        // compile.rs::compile_tmp_callback already locks the
         // contract that the runtime kinds match jd.red_args_types in
         // declaration order, so the two derivations are observationally
         // identical. Routing through the static spec removes the
@@ -14302,8 +14302,8 @@ impl<M: Clone> MetaInterp<M> {
         pc: usize,
         assembler_call: bool,
     ) -> Result<Option<(OpRef, i64)>, DoResidualCallAbort> {
-        // S2.1 invariant (wiggly-barto plan, mirrors `compile_tmp_callback`'s
-        // pre-check at compile.rs:2123): the recursive-call funcbox dereferences
+        // Invariant (mirrors `compile_tmp_callback`'s pre-check in
+        // compile.rs): the recursive-call funcbox dereferences
         // `portal_runner_adr` directly (line below), so a 0 address would jump
         // to NULL on the bh_call_r side. `warmspot.py:1010-1012` populates this
         // before any do_recursive_call can fire; `debug_assert!` catches a
@@ -15765,7 +15765,7 @@ impl MetaInterpStaticData {
     /// except pyre populates the table incrementally as drivers register
     /// instead of taking it wholesale from the codewriter's CallControl.
     ///
-    /// # S2.1 invariant (wiggly-barto plan)
+    /// # Invariant
     ///
     /// The caller must populate `jd.portal_runner_adr` to the host's
     /// `ll_portal_runner` address (`warmspot.py:1010-1012`) **before**
@@ -17447,7 +17447,7 @@ mod metainterp_static_data_tests {
         0xc0ffee
     }
 
-    /// S2.1 invariant (wiggly-barto plan): `do_recursive_call` requires
+    /// Invariant: `do_recursive_call` requires
     /// `portal_runner_adr != 0`. The default `with_virtualizable` /
     /// `JitDriverStaticData::new` constructor leaves the address at 0
     /// until the host runtime populates it (`warmspot.py:1010-1012`).
@@ -17475,7 +17475,7 @@ mod metainterp_static_data_tests {
             majit_ir::EffectInfo::default(),
         );
         // Deliberately do NOT set jd.portal_runner_adr — the default 0
-        // sentinel must trigger the S2.1 invariant assertion.
+        // sentinel must trigger the invariant assertion.
         let jd = crate::jitdriver::JitDriverStaticData::new(vec![], vec![]);
         let _ = meta.do_recursive_call(&jd, &[], descr_ref, &descr_view, 0, 0, false);
     }

--- a/majit/majit-metainterp/src/pyjitpl/dispatch.rs
+++ b/majit/majit-metainterp/src/pyjitpl/dispatch.rs
@@ -3098,7 +3098,7 @@ where
                     Some(Value::Float(f64::from_bits(concrete as u64))),
                 );
             }
-            // ── BC_GETARRAYITEM_GC_I (Slice C.2) ──
+            // ── BC_GETARRAYITEM_GC_I ──
             //
             // RPython parity: pyjitpl.py:1183-1199 `_opimpl_getarrayitem_gc_any`:
             //
@@ -4786,7 +4786,7 @@ where
                     action => return action,
                 }
             }
-            // ── Typed return arms (Slice C.1) ──
+            // ── Typed return arms ──
             //
             // RPython parity: pyjitpl.py:1620-1646 opimpl_int_return /
             // ref_return / float_return / void_return → MetaInterp.finishframe.
@@ -6342,9 +6342,8 @@ where
                 };
                 self.set_int_reg(dst, Some(OpRef::ConstInt(value)), Some(value));
             }
-            // Parity #14 Slice C.5 retired the Pure half of this arm —
-            // every Pure call site now emits canonical BC_RESIDUAL_CALL_*_I
-            // (Slices C.2/C.3/C.4); the canonical walker reads the
+            // The Pure half of this arm is retired — every Pure call site
+            // emits canonical BC_RESIDUAL_CALL_*_I; the canonical walker reads the
             // calldescr's `check_is_elidable()` and routes through
             // `record_result_of_call_pure`.  Only BC_CALL_ASSEMBLER_INT
             // survives here.
@@ -6417,7 +6416,7 @@ where
                 let (value, concrete) = self.read_ref_reg(src);
                 self.set_ref_reg(dst, Some(value), Some(concrete));
             }
-            // Parity #14 Slice C.5 retired the Pure half — see the Int
+            // The Pure half is retired — see the Int
             // sibling above for the full rationale.
             // pyjitpl.py:2007-2083 do_residual_call(assembler_call=True)
             // with tp == 'r'. See BC_CALL_ASSEMBLER_VOID for citation.
@@ -6487,7 +6486,7 @@ where
                 let (value, concrete) = self.read_float_reg(src);
                 self.set_float_reg(dst, Some(value), Some(concrete));
             }
-            // Parity #14 Slice C.5 retired the Pure half — see the Int
+            // The Pure half is retired — see the Int
             // sibling above for the full rationale.
             // pyjitpl.py:2007-2083 do_residual_call(assembler_call=True)
             // with tp == 'f'. See BC_CALL_ASSEMBLER_VOID for citation.

--- a/majit/majit-metainterp/src/pyjitpl/dispatch.rs
+++ b/majit/majit-metainterp/src/pyjitpl/dispatch.rs
@@ -417,7 +417,7 @@ pub trait JitCodeSym {
     /// `vec![0i64; program.len()]`).
     ///
     /// Convergence path: when the macro switches to RPython
-    /// MIFrame-regs storage (orth-9 step 4 reshape), this
+    /// MIFrame-regs storage, this
     /// method's default no-op impl matches RPython's "regs already
     /// populated by dispatch" semantics and the macro override drops
     /// out.  Until then, callers with a state-field JIT pass

--- a/majit/majit-metainterp/src/pyjitpl/frame.rs
+++ b/majit/majit-metainterp/src/pyjitpl/frame.rs
@@ -407,7 +407,7 @@ impl MIFrame {
     /// must satisfy [`OpRef::is_constant`] — the constant-namespace
     /// flag set by `OpRef::const_int` / `const_ptr` / `const_float`.
     ///
-    /// Production callers land with S2.3 follow-up (the metainterp-side
+    /// Production callers land with a follow-up (the metainterp-side
     /// `opimpl_jit_merge_point` port). For now the helper is dead code
     /// outside tests; it locks the contract upstream relies on so a
     /// future caller cannot silently accept a non-Const green.

--- a/majit/majit-metainterp/src/pyjitpl/frame.rs
+++ b/majit/majit-metainterp/src/pyjitpl/frame.rs
@@ -1550,7 +1550,7 @@ mod tests {
         use crate::JitCallArg;
         let mut builder = JitCodeBuilder::new();
         // Emit a canonical Pure residual_call that records 'i' at
-        // end-of-instr per `assembler.py:217-219` (Parity #14 Slice C.5).
+        // end-of-instr per `assembler.py`.
         let fn_idx = builder.add_fn_ptr(0x1usize as *const ());
         builder.call_pure_int_canonical_via_target(fn_idx, &[JitCallArg::int(0)], 0);
         let jitcode = Arc::new(builder.finish());

--- a/majit/majit-metainterp/src/trace_ctx.rs
+++ b/majit/majit-metainterp/src/trace_ctx.rs
@@ -1471,8 +1471,8 @@ impl TraceCtx {
     /// RPython parity: Ref constants preserve their type so guard
     /// fail_args are correctly typed during guard failure recovery.
     /// history.py:314 `ConstPtr.value` is inline on the Box; pyre
-    /// mirrors with `OpRef::ConstPtr(GcRef)`. The Slice 7b
-    /// op-graph walker forwards these slots across minor collection.
+    /// mirrors with `OpRef::ConstPtr(GcRef)`. The op-graph walker
+    /// forwards these slots across minor collection.
     pub fn const_ref(&mut self, value: i64) -> OpRef {
         OpRef::const_ptr(majit_ir::GcRef(value as usize))
     }

--- a/majit/majit-metainterp/src/trace_ctx.rs
+++ b/majit/majit-metainterp/src/trace_ctx.rs
@@ -142,9 +142,8 @@ fn concrete_shadow_value(value: Value) -> Option<Value> {
 /// RPython's `Box` carries type implicitly via Python class identity
 /// (`ConstInt`/`ConstFloat`/`InputArgRef` etc.).  Pyre's flat-OpRef
 /// encoding stores type as a separate `Type` tag, so `GreenBox` bundles
-/// the position + type tag into one struct — Phase A.4 step in
-/// `~/.claude/plans/ec-wiring-gentle-wave.md` folding away the
-/// previous parallel `Vec<OpRef>` + `Vec<Type>` adaptation.
+/// the position + type tag into one struct, folding away the previous
+/// parallel `Vec<OpRef>` + `Vec<Type>` adaptation.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct GreenBox {
     pub opref: OpRef,

--- a/majit/majit-metainterp/src/virtualref.rs
+++ b/majit/majit-metainterp/src/virtualref.rs
@@ -238,8 +238,7 @@ impl crate::resume::VRefInfo for VirtualRefInfo {
 // `cargo test` (RPython untranslated, pyre debug build).  Where
 // upstream uses `if not we_are_translated(): assert ...` the port is
 // `#[cfg(debug_assertions)] { assert!(...) }` (always-on under
-// debug_assertions, elided in release).  See `~/.claude/projects/.../
-// memory/feedback_rpython_assert_parity_always_on_2026_05_05.md`.
+// debug_assertions, elided in release).
 //
 // The `debug_assert!` calls below correspond to upstream `assert`
 // statements at:

--- a/majit/majit-metainterp/src/warmstate.rs
+++ b/majit/majit-metainterp/src/warmstate.rs
@@ -121,8 +121,8 @@ pub struct BaseJitCell {
     /// (`lookup_chain_with_key` / `ensure_cell_for_key` below) populate
     /// this on insert so chained cells distinguish hash collisions like
     /// upstream `JitCell.get_jitcell` (warmstate.py:596-604) does.
-    /// Migration of all callers from hash-only to typed keys is the
-    /// remaining S2.2 work.
+    /// Migration of all callers from hash-only to typed keys is
+    /// unfinished.
     pub comparekey: Option<GreenKey>,
 }
 
@@ -1901,7 +1901,7 @@ impl WarmEnterState {
     ///
     /// Currently a `&self` view: `WarmEnterState`'s mutable lookup
     /// helpers (`maybe_compile`, `should_start_dont_trace_here_trace`)
-    /// keep using the legacy hash-only path until S2.2 follow-up
+    /// keep using the legacy hash-only path until a follow-up
     /// migrates them.
     pub fn lookup_chain_with_key(&self, key: &GreenKey) -> Option<&BaseJitCell> {
         let hash = key.get_uhash();

--- a/majit/majit-translate/src/annotator/builtin.rs
+++ b/majit/majit-translate/src/annotator/builtin.rs
@@ -2433,7 +2433,7 @@ mod tests {
 
     #[test]
     fn builtin_list_on_iterator_routes_through_next() {
-        // Codex P1: `list(reversed(xs))` should keep the element type
+        // `list(reversed(xs))` should keep the element type
         // instead of collapsing to SomeImpossibleValue. Upstream chains
         // `s_iterable.iter().next()` which delegates to
         // `SomeIterator.next()` for SomeIterator inputs.
@@ -2463,7 +2463,7 @@ mod tests {
 
     #[test]
     fn builtin_max_keeps_nonneg_when_any_operand_is_nonneg() {
-        // Codex P2: upstream `nonneg |= s1.nonneg` is an OR-fold —
+        // upstream `nonneg |= s1.nonneg` is an OR-fold —
         // `max(nonneg, maybe_negative)` stays nonneg.
         use crate::annotator::model::SomeInteger;
         let bk = bk();
@@ -2481,7 +2481,7 @@ mod tests {
 
     #[test]
     fn builtin_int_rejects_out_of_range_float_constant() {
-        // Codex P2: `int(1e20)` would saturate to i64::MAX if we let the
+        // `int(1e20)` would saturate to i64::MAX if we let the
         // Rust cast do its default behaviour — upstream raises OverflowError
         // which constpropagate catches. Non-finite / out-of-range floats
         // must fall through to the conservative `s_result`.
@@ -2502,7 +2502,7 @@ mod tests {
 
     #[test]
     fn registered_class_backed_builtin_lifts_to_somebuiltin() {
-        // Codex P1: class-backed builtins (`range`, `int`, `list`, …)
+        // class-backed builtins (`range`, `int`, `list`, …)
         // are `HostObjectKind::Class` in HOST_ENV but still register
         // analysers. `immutablevalue` must route them to `SomeBuiltin`
         // so that `SomeBuiltin.call()` reaches the analyser, matching
@@ -2524,7 +2524,7 @@ mod tests {
 
     #[test]
     fn builtin_unichr_const_integer_returns_constant_unicode_cp() {
-        // Codex P2: `unichr(65)` must keep the constant via the
+        // `unichr(65)` must keep the constant via the
         // UnicodeCodePoint variant; constpropagate's re-annotation
         // through immutablevalue needs the explicit unicode tag.
         let bk = bk();
@@ -2543,7 +2543,7 @@ mod tests {
 
     #[test]
     fn builtin_unicode_const_string_returns_constant_unicode_string() {
-        // Codex P2: `unicode("abc")` must return a constant
+        // `unicode("abc")` must return a constant
         // SomeUnicodeString, not raise AnnotatorError.
         let bk = bk();
         let s_str = bk.immutablevalue(&ConstValue::byte_str("abc")).unwrap();
@@ -2561,7 +2561,7 @@ mod tests {
 
     #[test]
     fn builtin_hasattr_folds_constant_when_attr_exists_on_class() {
-        // Codex P2: for immutable constant receivers, `hasattr(C, "m")`
+        // for immutable constant receivers, `hasattr(C, "m")`
         // must fold to a constant SomeBool. The HOST_ENV `range` class
         // has no attribute members in this minimal env, so assert the
         // False branch — checks the folding mechanism regardless of
@@ -2585,7 +2585,7 @@ mod tests {
 
     #[test]
     fn builtin_bool_folds_constant_none_to_false() {
-        // Codex P2: `bool(None)` must pin `r.const = False` instead of
+        // `bool(None)` must pin `r.const = False` instead of
         // returning an unrefined SomeBool.
         let bk = bk();
         let s_none_val = bk.immutablevalue(&ConstValue::None).unwrap();
@@ -2615,7 +2615,7 @@ mod tests {
 
     #[test]
     fn call_builtin_rejects_unknown_keyword() {
-        // Codex P2: `list(xs, foo=1)` must raise instead of silently
+        // `list(xs, foo=1)` must raise instead of silently
         // ignoring `foo=1`. The dispatcher now rejects kwds outside
         // each analyser's allow-list.
         let bk = bk();
@@ -2656,7 +2656,7 @@ mod tests {
 
     #[test]
     fn builtin_int_rejects_positional_and_keyword_base() {
-        // Codex P2: `int(x, 10, base=16)` must raise the duplicate-arg
+        // `int(x, 10, base=16)` must raise the duplicate-arg
         // error that upstream's Python dispatch produces.
         let bk = bk();
         let s_str = bk.immutablevalue(&ConstValue::byte_str("1a")).unwrap();
@@ -2677,7 +2677,7 @@ mod tests {
 
     #[test]
     fn r_dict_helper_reads_force_non_null_from_keyword() {
-        // Codex P1: r_dict(eq, hash, force_non_null=True) must honour
+        // r_dict(eq, hash, force_non_null=True) must honour
         // the kwd. Previously ignored, leaving the DictDef flag false.
         //
         // Testing through call_builtin would trip
@@ -2716,7 +2716,7 @@ mod tests {
 
     #[test]
     fn builtin_enumerate_rejects_non_constant_start_keyword() {
-        // Codex P2: `enumerate(xs, start=<non-constant>)` must raise
+        // `enumerate(xs, start=<non-constant>)` must raise
         // the upstream "second argument to enumerate must be constant"
         // error instead of silently dropping the kwd.
         use crate::annotator::model::SomeInteger;
@@ -2766,7 +2766,7 @@ mod tests {
 
     #[test]
     fn builtin_hasattr_walks_class_mro_for_inherited_attr() {
-        // Codex P2: hasattr folding must resolve inherited attributes,
+        // hasattr folding must resolve inherited attributes,
         // not just the immediate class dict. Build base with `m`, then
         // subclass with empty dict — `hasattr(Subclass, "m")` must be
         // folded to True.

--- a/majit/majit-translate/src/annotator/unaryop.rs
+++ b/majit/majit-translate/src/annotator/unaryop.rs
@@ -1,8 +1,7 @@
 //! RPython `rpython/annotator/unaryop.py` — single-dispatch
 //! (`dispatch == 1`) operation handlers on the `SomeValue` lattice.
 //!
-//! Commit split (following the plan in
-//! `.claude/plans/0-warm-raccoon.md`):
+//! Commit split:
 //!
 //! * **Commit 6a (this file initial drop)** — `UNARY_OPERATIONS`
 //!   listing + `@op.type.register(SomeObject)` +

--- a/majit/majit-translate/src/codewriter/assembler.rs
+++ b/majit/majit-translate/src/codewriter/assembler.rs
@@ -2437,7 +2437,7 @@ impl Assembler {
     /// this because `rtyper` guarantees that every `Variable`'s
     /// `concretetype` produces exactly one `(kind, color)` via
     /// `getkind()` + `regalloc.py`.  Pyre's annotator / rtyper still
-    /// has known coverage gaps (tracked as task #71 / #74), and the
+    /// has known coverage gaps, and the
     /// `lookup_reg_with_kind` fallback silently emits a `(0, 'r')`
     /// default at write time — which masks how many distinct gaps
     /// exist per graph.  `MAJIT_COVERAGE_PANIC=1` aborts at the first

--- a/majit/majit-translate/src/codewriter/jtransform.rs
+++ b/majit/majit-translate/src/codewriter/jtransform.rs
@@ -1291,8 +1291,8 @@ impl<'a> Transformer<'a> {
             // Coverage covers all six
             // comparison ops (`eq`/`ne`/`lt`/`le`/`gt`/`ge`).  The
             // earlier "eq/ne only" restriction surfaced `int_le/r*`
-            // as unwired blackhole opnames, breaking the Task #85
-            // expected-empty snapshot.  RPython has no `ptr_lt` family,
+            // as unwired blackhole opnames, breaking the expected-empty
+            // snapshot.  RPython has no `ptr_lt` family,
             // but `cast_ptr_to_int` followed by `int_lt`/`int_le`
             // matches what `rpython/rtyper/rint.py` emits for any
             // comparison whose operands cross the ptr/int boundary —

--- a/majit/majit-translate/src/flowspace/mod.rs
+++ b/majit/majit-translate/src/flowspace/mod.rs
@@ -1,8 +1,7 @@
 //! `flowspace` — Rust port of `rpython/flowspace/`.
 //!
 //! Phase 1 of the five-year roadmap landing a line-by-line port of
-//! `rpython/{flowspace,annotator,rtyper}/` into majit-translate. See
-//! `.claude/plans/majestic-forging-meteor.md` for the full plan.
+//! `rpython/{flowspace,annotator,rtyper}/` into majit-translate.
 //!
 //! RPython upstream lives at
 //! `rpython/flowspace/`. The

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -6110,7 +6110,7 @@ impl<'a> Lowering<'a> {
                 // `newlist/r>r` — an opname with no blackhole handler —
                 // breaking `default_bh_builder_unwired_set_matches_task_85_snapshot`.
                 //
-                // Slice-C 7/18 measurement (base 4d3d6e290f6, assembler
+                // Measured (base 4d3d6e290f6, assembler
                 // `[ASM newlist DIAG]`): EXACTLY TWO graphs carry a vec! and
                 // still drop to the legacy walker, each behind an INDEPENDENT
                 // non-vec! wall the recognizer does not touch —

--- a/majit/majit-translate/src/lib.rs
+++ b/majit/majit-translate/src/lib.rs
@@ -1289,7 +1289,7 @@ fn analyze_pipeline_from_module_paths(
             },
         )
         .collect();
-    // Gated auto-population (issue #346, S2.3): with `PYRE_DYN_INDIRECT`
+    // Gated auto-population (issue #346): with `PYRE_DYN_INDIRECT`
     // on, register EVERY `>=2`-impl trait so its inline `dyn Trait`
     // receiver (lowered to `CallTarget::Indirect`) narrows to the family
     // base ClassDef.  Union with the config list (dedup by base_root),

--- a/majit/majit-translate/src/model.rs
+++ b/majit/majit-translate/src/model.rs
@@ -1161,7 +1161,7 @@ pub enum OpKind {
     /// fully-qualified path (`["module_path", "STATIC_NAME"]`)
     /// matching the upstream lookup key shape.
     ///
-    /// Slice C — `value` carries the literal-evaluated initializer
+    /// `value` carries the literal-evaluated initializer
     /// when `extract_static_decls` could fold the RHS to a
     /// `ConstValue` (bool/int/float/string literals, including the
     /// `-LIT` unary-neg shape and the `thread_local!` `const { LIT }`
@@ -4892,8 +4892,7 @@ impl FunctionGraph {
         // back through the predecessor chain to add `cond` as a
         // `block.inputargs` entry restores the
         // `flowspace/flowcontext.py:407-408 setstate(block.framestate)`
-        // shape that the AST walker doesn't produce eagerly (task #91
-        // prereq).
+        // shape that the AST walker doesn't produce eagerly.
         for arg in &outputargs {
             if let LinkArg::Value(var) = arg {
                 self.ensure_variable_at_block(block, var);
@@ -5000,7 +4999,7 @@ impl FunctionGraph {
     /// `flowspace/flowcontext.py:407-408 setstate(block.framestate)`
     /// populates `block.inputargs` with all carry-through Variables at
     /// block entry by walking top-down.  Pyre's AST walker doesn't do
-    /// this eagerly (task #91), so when a framestate-driven merge
+    /// this eagerly, so when a framestate-driven merge
     /// (`create_block_from_framestate`) surfaces an ancestor-defined
     /// Variable in `block.inputargs`, this helper backfills the
     /// predecessor chain bottom-up to the same final graph shape.
@@ -8016,7 +8015,7 @@ mod tests {
         assert_eq!(out, vec![LinkArg::Value(v_self)]);
     }
 
-    // ── annotator-monomorphization Slice C2 — CallTarget::Method ──
+    // ── annotator-monomorphization — CallTarget::Method ──
     // transient ClassDefKey transport invariants.
 
     #[test]

--- a/majit/majit-translate/src/rlib/jit.rs
+++ b/majit/majit-translate/src/rlib/jit.rs
@@ -94,7 +94,7 @@ pub const LOOP_HEADER_ANALYSER_NAME: &str = "rlib.jit.ExtLoopHeader.loop_header"
 /// The metadata is intentionally narrow: only fields that the
 /// annotator / codewriter pipeline reads. Runtime hooks captured on
 /// the pyre side (`PyPyJitDriver::get_*`) are mirrored as `HostObject`
-/// callables once the per-hook wiring lands in S1.3.
+/// callables once the per-hook wiring lands.
 #[derive(Clone, Debug)]
 pub struct JitDriverMeta {
     /// Identity of the driver instance — used as the
@@ -268,7 +268,7 @@ fn annotate_hooks(
 /// signature gains an `args_s_seed: &[SomeValue]` parameter without
 /// touching the variable-loop body.
 ///
-/// The dotted-green branch is held back to S1.3 alongside
+/// The dotted-green branch is held back alongside
 /// `ExtEnterLeaveMarker.specialize_call` (rlib/jit.py:965-993). Until
 /// then a dotted variable surfaces as an `AnnotatorError` so the gap
 /// fails closed instead of silently dropping the arg.
@@ -297,10 +297,10 @@ fn annotate_hook(
             // rlib/jit.py:941-948 dotted-green field path. Requires
             // `s_instance.classdef.find_attribute(fieldname)` plus
             // `bk.record_getattr(classdesc, fieldname)` — both land
-            // with `ExtEnterLeaveMarker.specialize_call` at S1.3.
+            // with `ExtEnterLeaveMarker.specialize_call`.
             return Err(AnnotatorError::new(format!(
                 "JitDriver dotted greenfield {name:?} reaches annotate_hook before \
-                 ExtEnterLeaveMarker.specialize_call port (S1.3, rlib/jit.py:965-993)",
+                 ExtEnterLeaveMarker.specialize_call port (rlib/jit.py:965-993)",
             )));
         }
         let key = format!("s_{name}");

--- a/majit/majit-translate/src/tool/algo/color.rs
+++ b/majit/majit-translate/src/tool/algo/color.rs
@@ -93,7 +93,7 @@ impl<N: Eq + std::hash::Hash + Clone> DependencyGraph<N> {
     ///
     /// O(n²): each of the n iterations re-partitions every remaining node
     /// across `sigma`, independent of edge density. This is the codewriter-side
-    /// super-linear compile cost identified as #203 gap-6 facet A. The O(V+E)
+    /// super-linear compile cost. The O(V+E)
     /// lex-BFS (partition-refinement) rewrite that would remove it is
     /// deliberately declined to keep this a line-by-line port of `color.py`,
     /// which is identically O(n²); the quadratic term only manifests on

--- a/majit/majit-translate/src/translator/backendopt/writeanalyze.rs
+++ b/majit/majit-translate/src/translator/backendopt/writeanalyze.rs
@@ -7,9 +7,9 @@
 //! Upstream's consumer is the JIT codewriter's `EffectInfo` construction
 //! (`jit/codewriter/call.py:38` builds a `ReadWriteAnalyzer`; `:320`
 //! `getcalldescr` queries it). Pyre's `getcalldescr` still uses the flat
-//! `analyze_readwrite` scanner at `codewriter/call.rs:4771`; wiring
-//! this flowspace analyzer in its place is the EffectInfo-analyzer epic
-//! (task #64). Until then this module is published as a parity sibling
+//! `analyze_readwrite` scanner in `codewriter/call.rs`; wiring this
+//! flowspace analyzer in its place is unported. Until then this module
+//! is published as a parity sibling
 //! alongside [`super::canraise`], [`super::collectanalyze`] and
 //! [`super::gilanalysis`].
 //!

--- a/majit/majit-translate/src/translator/rtyper/cutover.rs
+++ b/majit/majit-translate/src/translator/rtyper/cutover.rs
@@ -1439,7 +1439,7 @@ pub(crate) fn is_known_unported(msg: &str) -> bool {
         // and proceed; every other key repr (str, instance) hits this
         // TyperError instead of silently miscompiling dict getitem/contains
         // to pointer-identity comparison. Skip-classify until the
-        // call-based keyeq branch is ported (#140 DictRepr epic, Slice 2+).
+        // call-based keyeq branch is ported (#140 DictRepr epic).
         || msg.contains("dict key eq function not wired")
     // There is no `normalize_unary_op_name: pyre UnaryOp` Skip entry:
     // the 13 typed numeric / ptr / Unsigned casts route through

--- a/majit/majit-translate/src/translator/rtyper/extregistry.rs
+++ b/majit/majit-translate/src/translator/rtyper/extregistry.rs
@@ -1623,7 +1623,7 @@ mod tests {
         );
     }
 
-    /// Helpers for S1.3 marker specialize_call tests — build a hop
+    /// Helpers for the marker specialize_call tests — build a hop
     /// with int-typed greens / reds and a Signed args_r so the
     /// `inputarg(r, i)` path produces real Variables.
     fn signed_arg(name: &str) -> Hlvalue {
@@ -1789,7 +1789,7 @@ mod tests {
         let kwds_i: HashMap<String, usize> = [("i_frame".to_string(), 0)].into_iter().collect();
         let err = entry
             .specialize_marker_call(&hop, &kwds_i)
-            .expect_err("dotted greenfield must defer to S1.3 follow-up");
+            .expect_err("dotted greenfield must defer to the follow-up port");
         assert!(
             err.to_string().contains("dotted greenfield"),
             "expected dotted-greenfield diagnostic: {err}"

--- a/majit/majit-translate/src/translator/rtyper/lltypesystem/lltype.rs
+++ b/majit/majit-translate/src/translator/rtyper/lltypesystem/lltype.rs
@@ -1099,8 +1099,8 @@ impl _func {
 /// `_struct.clone()` → `_fields.clone()` (owned `Vec`), so two clones
 /// of the same prebuilt instance carry independent field storage and
 /// intra-class circular prebuilt instances (`a.b.back == a`) wire
-/// `back` to a stale snapshot rather than the in-progress `a`. See
-/// task #157 — this is the structural pre-requisite for
+/// `back` to a stale snapshot rather than the in-progress `a`. This
+/// is the structural pre-requisite for
 /// `InstanceRepr::convert_const_exact` byte-for-byte parity with
 /// `rclass.py:794-802`.
 ///
@@ -1150,7 +1150,7 @@ impl _struct {
 
 /// `_array.items` is wrapped in `Arc<Mutex<...>>` for the same shared-
 /// storage discipline as `_struct._fields` — see the `_struct` doc
-/// above for the parity rationale (task #157).
+/// above for the parity rationale.
 #[derive(Debug)]
 pub struct ArrayCore {
     pub TYPE: ArrayContainer,
@@ -3780,8 +3780,8 @@ impl _interior_ptr {
 
     /// Walks `_parent` by `_offsets` and returns the terminal element
     /// as an owned `LowLevelValue`. The shared-storage discipline of
-    /// `_struct._fields` and `_array.items` (`Arc<Mutex<...>>`, see
-    /// task #157) means owned clones still alias the underlying
+    /// `_struct._fields` and `_array.items` (`Arc<Mutex<...>>`) means
+    /// owned clones still alias the underlying
     /// container, so subsequent `_setattr` / `setitem` calls on the
     /// returned owned value mutate the same backing storage as the
     /// original `_parent` chain.

--- a/majit/majit-translate/src/translator/rtyper/lltypesystem/rordereddict.rs
+++ b/majit/majit-translate/src/translator/rtyper/lltypesystem/rordereddict.rs
@@ -405,7 +405,7 @@ impl OrderedDictRepr {
         let entries_array_ty = LowLevelType::Array(Box::new(self.DICTENTRYARRAY.clone()));
 
         // _ll_write_indexes(d, i, value) (rordereddict.py:558-563) — the real
-        // helper landed in Slice 2 for `build_ll_dict_lookup_helper_graph`'s
+        // helper exists for `build_ll_dict_lookup_helper_graph`'s
         // inlined store path; mint it here as a callable funcptr for the
         // non-inlined callers (`ll_dict_store_clean`).
         let write_indexes_fn = {
@@ -445,7 +445,7 @@ impl OrderedDictRepr {
 
         // ll_call_insert_clean_function(d, hash, i) (rordereddict.py:565-580)
         // — FUNC_* dispatch collapses to a single `ll_dict_store_clean` call,
-        // same shape as `ll_call_lookup_function` (Slice 2).
+        // same shape as `ll_call_lookup_function`.
         let insert_clean_fn = {
             let dict_ptr = dict_ptr.clone();
             let store_clean_const = store_clean_const.clone();
@@ -3048,7 +3048,7 @@ pub(crate) fn build_ll_malloc_indexes_and_choose_lookup_helper_graph(
 /// selector instead, and `ll_dict_remove_deleted_items` only clears the high
 /// bits (`&= FUNC_MASK`). So `ll_ensure_indexes` reaches this helper only while
 /// `num_live_items == 0`; the `num_live_items != 0` else arm stays unreachable.
-/// Re-verified after the Slice 3/4 write + delete paths landed. This builder
+/// Re-verified after the write + delete paths landed. This builder
 /// ports only the reachable `num_live_items == 0` branch straight-line (no
 /// runtime check), matching the "statically dead branch" precedent in
 /// [`build_ll_dict_lookup_helper_graph`]'s doc comment.
@@ -3602,7 +3602,7 @@ pub fn pair_ordereddict_repr_rtype_contains(
 /// (`i`/`perturb` are `r_uint`; the perturb shift is the *logical*
 /// `uint_rshift`). All `DICTINDEX_*` widths collapse to
 /// `Ptr(GcArray(Unsigned))` locally, so `T` is inert — this one graph serves
-/// every `FUNC_*` width (same collapse as `ll_call_lookup_function`, Slice 2).
+/// every `FUNC_*` width (same collapse as `ll_call_lookup_function`).
 /// Calls the real [`build_ll_write_indexes_helper_graph`] helper for the
 /// final store (not inlined) — that helper's own doc note already flagged
 /// it as reserved for "the non-inlined callers (`ll_dict_store_clean`,
@@ -3882,7 +3882,7 @@ pub(crate) fn build_ll_dict_store_clean_helper_graph(
 /// ```
 ///
 /// Same width-collapse rationale as `ll_call_lookup_function`'s FUNC_*
-/// dispatch (Slice 2): every `TYPE_*`/`DICTINDEX_*` width aliases the same
+/// dispatch: every `TYPE_*`/`DICTINDEX_*` width aliases the same
 /// `Ptr(GcArray(Unsigned))` shape locally, so the 4-way dispatch collapses
 /// to a single unconditional `ll_dict_store_clean` call. The `ll_assert`
 /// dead-fallthrough is debug-only and not modelled.
@@ -9926,7 +9926,7 @@ mod tests {
     }
 
     /// The eq-gate lets plain (non-`custom_eq_hash`) str keys through: the
-    /// direct-compare `ptr_eq` landmine from Slice 0 is now covered by the
+    /// direct-compare `ptr_eq` landmine is now covered by the
     /// `d.keyeq`-fallback wiring in `build_ll_dict_lookup_helper_graph`
     /// (`ll_streq`, via `key_repr.get_ll_eq_function()`), so
     /// `OrderedDictRepr::rtype_getitem` succeeds like the int-key case.

--- a/majit/majit-translate/src/translator/rtyper/lltypesystem/rstr.rs
+++ b/majit/majit-translate/src/translator/rtyper/lltypesystem/rstr.rs
@@ -29,8 +29,7 @@
 //!
 //! The full repr port (`AbstractStringRepr`/`AbstractUnicodeRepr`
 //! methods, `LLHelpers.ll_*` helpers, comparison, formatting,
-//! adtmeths) is deferred to its own follow-on slices — see
-//! `~/.claude/projects/.../memory/item3_abstractstringrepr_epic_plan.md`.
+//! adtmeths) is deferred to follow-on work.
 //!
 //! ## Why a separate module today
 //!

--- a/majit/majit-translate/src/translator/rtyper/pyre_call_registry.rs
+++ b/majit/majit-translate/src/translator/rtyper/pyre_call_registry.rs
@@ -127,7 +127,7 @@ impl PyreFunctionEntry {
     /// (`description.rs:1147-1169`) is skipped — pyre's synthetic
     /// `GraphFunc` has no `HostCode` and would fail there.
     ///
-    /// The producer (Slice A.4 follow-on, or a test fixture) is
+    /// The producer (a later follow-on, or a test fixture) is
     /// responsible for constructing `pygraph` from pyre's
     /// `model::FunctionGraph` for this callee — see
     /// `cutover::lift_callee_to_pygraph`.

--- a/majit/majit-translate/src/translator/rtyper/rclass.rs
+++ b/majit/majit-translate/src/translator/rtyper/rclass.rs
@@ -3149,7 +3149,7 @@ impl InstanceRepr {
         // Pyre clones `result` into the cache; both the cached clone
         // and the init target (`local`, the moved original) share
         // `_struct._fields` / `_array.items` via `Arc<Mutex<...>>`
-        // (lltype.rs:711-748, task #157), preserving the same
+        // (lltype.rs), preserving the same
         // mid-init aliasing semantics. The cache `borrow_mut` is
         // dropped before init runs so a recursive `convert_const_exact`
         // cache probe at the top of this function can re-acquire
@@ -3200,7 +3200,7 @@ impl InstanceRepr {
         // Pyre clones `result` into the cache; the cached clone and the
         // init target (`local`, the moved original) share
         // `_struct._fields` / `_array.items` via `Arc<Mutex<...>>`
-        // (lltype.rs:711-748, task #157), so mutations applied by
+        // (lltype.rs), so mutations applied by
         // `initialize_prebuilt_data` are visible through
         // `_reusable_prebuilt_instance` for the no-recursion case
         // (`get_standard_ll_exc_instance`). The cache `borrow_mut` is

--- a/majit/majit-translate/src/translator/rtyper/rmodel.rs
+++ b/majit/majit-translate/src/translator/rtyper/rmodel.rs
@@ -3099,8 +3099,7 @@ pub fn rtyper_makerepr(
         // `SomeUnicodeString.rtyper_makerepr` return the module-global
         // `string_repr` / `unicode_repr` (`lltypesystem/rstr.py:1255` /
         // `:1260`) unconditionally. Pyre's per-method `rtype_*` /
-        // `convert_const` overrides land slice-by-slice in the Item 3
-        // epic (`memory/item3_abstractstringrepr_epic_plan.md`). Until
+        // `convert_const` overrides land incrementally. Until
         // each one lands, `Repr`'s default impls surface a typed
         // `TyperError` from the per-method dispatch — same upstream
         // surface as `AbstractStringRepr` not yet defining the method.

--- a/majit/majit-translate/src/translator/rtyper/rstr.rs
+++ b/majit/majit-translate/src/translator/rtyper/rstr.rs
@@ -27,12 +27,11 @@
 //!   / `rtype_add` / `rtype_getitem`, `rtype_int` / `rtype_float`,
 //!   etc., rstr.py:119-449 + 651-737). The struct skeletons and
 //!   module-global singletons land here today; method bodies arrive
-//!   slice-by-slice — see the epic plan in
-//!   `~/.claude/projects/.../memory/item3_abstractstringrepr_epic_plan.md`.
+//!   incrementally.
 //! * `LLHelpers.ll_*` helper graphs (`ll_str2int` / `ll_str2float`,
 //!   `ll_startswith` / `ll_endswith` / `ll_find` / `ll_strip` /
 //!   `ll_lower` / `ll_upper` / `ll_split` / `ll_join` / `ll_replace`)
-//!   live in `lltypesystem/rstr.rs` and land slice-by-slice.
+//!   live in `lltypesystem/rstr.rs` and land incrementally.
 
 use std::sync::Arc;
 use std::sync::OnceLock;
@@ -148,11 +147,11 @@ impl AbstractLLHelpers {
 ///
 /// The `basetype` / `base` / `CACHE` attributes only matter for
 /// `BaseLLStringRepr.convert_const` (`lltypesystem/rstr.py:191-206`)
-/// which lands in a follow-up slice. Today the struct just carries
+/// which lands later. Today the struct just carries
 /// `lowleveltype = Ptr(STR)` so [`super::rmodel::rtyper_makerepr`]
 /// can return the singleton when `SomeString` shows up. Per-method
 /// `rtype_*` calls fall through `Repr`'s default `MissingRTypeOperation`
-/// stubs until each slice 4-12 method body lands.
+/// stubs until each method body lands.
 #[derive(Debug)]
 pub struct AbstractStringRepr {
     state: ReprState,
@@ -269,7 +268,7 @@ impl Repr for StringRepr {
     }
 
     /// RPython `AbstractStringRepr.rtype_method_*` dispatch table
-    /// (`rstr.py:134-449`). Pyre lands methods slice-by-slice; today
+    /// (`rstr.py:134-449`). Pyre lands methods incrementally; today
     /// `startswith` (rstr.py:134-145) and `endswith` (rstr.py:147-158)
     /// lower.
     fn rtype_method(&self, method_name: &str, hop: &HighLevelOp) -> RTypeResult {
@@ -563,7 +562,7 @@ impl Repr for UnicodeRepr {
 
     /// RPython `AbstractUnicodeRepr.rtype_method_*` dispatch table
     /// (`rstr.py:134-449` inherited via `AbstractUnicodeRepr(AbstractStringRepr)`).
-    /// Pyre lands methods slice-by-slice; today `startswith` and
+    /// Pyre lands methods incrementally; today `startswith` and
     /// `endswith` lower with helper-graph identities
     /// `ll_unicode_startswith` / `ll_unicode_endswith` (Ptr(UNICODE)).
     fn rtype_method(&self, method_name: &str, hop: &HighLevelOp) -> RTypeResult {
@@ -2457,7 +2456,7 @@ fn rtype_abstract_string_method_replace(
 
 // ____________________________________________________________
 // AbstractStringRepr / AbstractUnicodeRepr method dispatch
-// (`rstr.py:134-449`). Pyre lands the methods slice-by-slice; today
+// (`rstr.py:134-449`). Pyre lands the methods incrementally; today
 // only `startswith` (rstr.py:134-145) lowers in the
 // `args_r[1]` is-a-String/Unicode branch. The Char-side branch
 // (`ll_startswith_char` for char-keyed startswith) is deferred since

--- a/majit/majit-translate/src/translator/rtyper/unit_variant_fold.rs
+++ b/majit/majit-translate/src/translator/rtyper/unit_variant_fold.rs
@@ -15,8 +15,7 @@
 //! graphs registered directly through `register_function_graph` can
 //! take the Skip arm and bypass that fold.
 //! The residual `Call` op then survives into jtransform and is emitted
-//! as a `residual_call_r/d>r` wrapper, which blocks the JitCode walker
-//! (Task #333).
+//! as a `residual_call_r/d>r` wrapper, which blocks the JitCode walker.
 //!
 //! This pass operates directly on `model::FunctionGraph` after
 //! `lower_indirect_calls` and before `Transformer::transform`, so it

--- a/majit/majit-translate/src/translator/transform.rs
+++ b/majit/majit-translate/src/translator/transform.rs
@@ -1479,7 +1479,7 @@ mod tests {
 
     #[test]
     fn transform_list_contains_skips_when_nested_list_in_tuple() {
-        // Codex P2 (round 10): `[([True],)]` carries an unhashable
+        // `[([True],)]` carries an unhashable
         // list inside a tuple. Python would `TypeError` on
         // `items[tuple] = None`, so the rewrite must bail out and
         // leave the list-iteration semantics intact.
@@ -1708,7 +1708,7 @@ mod tests {
 
     #[test]
     fn transform_list_contains_canonicalises_nested_bool_in_tuple() {
-        // Codex P2 (round 7): `(True,)` and `(1,)` must collapse to
+        // `(True,)` and `(1,)` must collapse to
         // the same bucket under `canonical_dict_key` (recursive
         // numeric tower). Direct helper check — the end-to-end path
         // also needs a matching-typed needle to survive the
@@ -1732,7 +1732,7 @@ mod tests {
 
     #[test]
     fn transform_list_contains_keeps_first_inserted_key_on_numeric_collision() {
-        // Codex P2 (round 8): Python dict keeps the FIRST inserted
+        // Python dict keeps the FIRST inserted
         // key on hash collision — `{True: 1, 1: 2}` stays `{True: 2}`
         // with key type `bool`. The Rust rewrite must preserve the
         // caller's original `ConstValue` rather than canonicalising

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -4872,7 +4872,7 @@ fn exc_unicode_decode_error_init(args: &[PyObjectRef]) -> Result<PyObjectRef, cr
         // `w_bytes_from_bytes(...)` so `e.object` always holds a
         // canonical `bytes` regardless of the input shape.
         //
-        // Codex P1 (PR #89 round 2): `bytes_like_data` dispatches via
+        // `bytes_like_data` dispatches via
         // exact-type pointer identity (`is_bytes` → `py_type_check`)
         // and silently reads the operand through the `W_BytearrayObject`
         // layout for any non-exact-bytes input — including `bytes`

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -1450,7 +1450,7 @@ pub fn handle_exception(frame: &mut PyFrame, err: &mut PyError, next_instr: &mut
 
 /// Execute a frame — pure interpreter, no JIT.
 ///
-/// Crate-private since Slice C.3 (PyFrame Heap-Allocation Epic): canonical
+/// Crate-private: the canonical
 /// surface is `PyFrame::run` / `PyFrame::execute_frame` (PyPy
 /// `pyframe.py:268 run` / `pyframe.py:331 execute_frame`).  Retained as a
 /// free function because pyre's JIT override mechanism (call.rs

--- a/pyre/pyre-interpreter/src/function.rs
+++ b/pyre/pyre-interpreter/src/function.rs
@@ -254,7 +254,7 @@ pub const FUNCTION_OBJECT_SIZE: usize = std::mem::size_of::<Function>();
 /// closure / defs_w / w_kw_defs / w_module set.
 ///
 /// `can_change_code` is a `bool` and thus non-GC. `name` points at a
-/// GC-managed leaf storage box (`NameStorage`, off-GC storage epic S5) for a
+/// GC-managed leaf storage box (`NameStorage`, off-GC storage) for a
 /// mortal (user, `PyCode`) function, so its slot is forwarded here; the box tid's
 /// drop glue reclaims it on sweep. An immortal builtin function's `malloc_raw`
 /// name is not collector-owned, so the walker's `is_managed_heap_object` guard

--- a/pyre/pyre-interpreter/src/jit_fnaddr.rs
+++ b/pyre/pyre-interpreter/src/jit_fnaddr.rs
@@ -598,7 +598,7 @@ pub fn jit_trace_fnaddrs() -> Vec<(&'static str, i64)> {
     // each binds both the qualified module path and the glob-re-exported root
     // alias. `function_new_impl` lives in this crate so it binds through
     // `crate::`. The bytes/bytearray constructors allocate a GC-managed storage
-    // box (off-GC storage epic S4) that is not phaseA-liftable, so they
+    // box (off-GC storage) that is not phaseA-liftable, so they
     // residualise like the `malloc_typed` (`NewWithVtable`) roots below.
     push_alias_pair(
         &mut entries,

--- a/pyre/pyre-interpreter/src/module/_ctypes/stginfo.rs
+++ b/pyre/pyre-interpreter/src/module/_ctypes/stginfo.rs
@@ -210,7 +210,7 @@ pub(super) fn stginfo_set_pointer_type(info: PyObjectRef, ty: PyObjectRef) {
     unsafe { pyre_object::w_dict_setitem_str(dict_of(info), K_POINTER_TYPE, ty) };
 }
 
-// ── field size/align with the slice-1 `_type_` fallback ────────────────
+// ── field size/align with the `_type_` fallback ───────────────────────
 
 /// Byte size of a ctypes type `t`: its `StgInfo` size, else the simple-type
 /// size derived from `_type_`.

--- a/pyre/pyre-interpreter/src/objspace/std/mapdict.rs
+++ b/pyre/pyre-interpreter/src/objspace/std/mapdict.rs
@@ -894,7 +894,7 @@ pub unsafe fn find_map_attr(self_node: MapRef, name: &Wtf8, attrkind: u16) -> Op
 // the live value through `plain_direct_read` on every hit. The one movable
 // reference is the LOAD_METHOD `w_method` slot (mapdict.py:1418), forwarded
 // during collection by `pycode::walk_mapdict_method_cache_gc`. (Contingency:
-// were map nodes ever made movable — Task #197 — the raw pointers would
+// were map nodes ever made movable, the raw pointers would
 // dangle and the whole entry would have to switch to that forwarded design.)
 
 /// mapdict.py:1416-1422 `CacheEntry`. PyPy's shared `INVALID_CACHE_ENTRY`

--- a/pyre/pyre-interpreter/src/objspace/std/mapdict.rs
+++ b/pyre/pyre-interpreter/src/objspace/std/mapdict.rs
@@ -264,7 +264,7 @@ pub fn new_instance_terminator(w_cls: PyObjectRef, hasdict: bool, typedef_hasdic
 ///
 /// # Safety
 /// `obj` must be a live `W_ObjectObject` (the caller guards with
-/// `is_instance`). The instance is an immortal `Box` in Slice C, so the raw
+/// `is_instance`). The instance is an immortal `Box`, so the raw
 /// pointer is stable across this call.
 pub unsafe fn ensure_mapdict_initialized(obj: PyObjectRef) {
     let inst = &mut *(obj as *mut pyre_object::W_ObjectObject);
@@ -1717,7 +1717,7 @@ unsafe fn store_attr_slowpath(
 //
 // The map-node layer reads and writes attribute values through this trait.
 // PyPy mixes `MapdictStorageMixin` into the instance class; pyre's instance
-// (W_ObjectObject) implements this trait instead (Slice 2). Storage holds
+// (W_ObjectObject) implements this trait instead. Storage holds
 // `PyObjectRef`, so PyPy's `erase_item`/`unerase_item` (rerased boxing of a
 // W_Root into the untyped storage list) are the identity here.
 
@@ -3046,8 +3046,8 @@ pub unsafe fn mapdict_switch_to_text_strategy(w_dict: PyObjectRef) {
 /// mapdict.py:1123-1279 `MapDictStrategy` — the dict strategy a user instance's
 /// `__dict__` adopts. `dstorage` erases the backing `W_ObjectObject`
 /// (mapdict.py:1502), so every routed get/set/del/iter funnels into the
-/// instance's mapdict map+storage. Unwired in Slice C — the C5 `_obj_getdict`
-/// flip installs it; defined now so that flip is a one-line strategy swap.
+/// instance's mapdict map+storage. Unwired — the `_obj_getdict` flip
+/// installs it; defined now so that flip is a one-line strategy swap.
 pub struct MapDictStrategy;
 
 /// `space.fromcache(MapDictStrategy)` process-wide singleton — same `&'static`
@@ -4206,7 +4206,7 @@ mod tests {
     #[test]
     fn instance_dict_wrapper_in_special_slot_not_instance_dict() {
         use pyre_object::dictmultiobject::{DictStrategy, StrategyKind};
-        // Phase G slice 2: an instance's `__dict__` wrapper is stored in the
+        // An instance's `__dict__` wrapper is stored in the
         // mapdict "dict" SPECIAL slot (mapdict.py:826-840 _obj_getdict), not in
         // the INSTANCE_DICT side table. Repeated access returns the same wrapper,
         // and the SPECIAL slot is excluded from the `__dict__` view.

--- a/pyre/pyre-interpreter/src/pytraceback.rs
+++ b/pyre/pyre-interpreter/src/pytraceback.rs
@@ -16,8 +16,7 @@
 //! — frames are heap-allocated outside the nursery and walked by a
 //! custom GC walker).  Until `PyFrame` grows a W_Root header (which is
 //! itself a multi-file change), the descriptor `tb_frame` cannot
-//! return a Python-visible object directly; that gap is the
-//! convergence path documented at slice 3.
+//! return a Python-visible object directly.
 
 use pyre_object::pyobject::*;
 
@@ -34,7 +33,7 @@ pub static PYTRACEBACK_TYPE: PyType = new_pytype("traceback");
 ///
 /// Only `w_next` is GC-traced.  `frame` is a raw pointer to a
 /// custom-walked `PyFrame` allocation; the frame walker scans the
-/// traceback chain separately when wired up at slice 2.
+/// traceback chain separately once wired up.
 #[repr(C)]
 pub struct PyTraceback {
     pub ob_header: PyObject,

--- a/pyre/pyre-jit-trace/src/descr.rs
+++ b/pyre/pyre-jit-trace/src/descr.rs
@@ -1072,9 +1072,8 @@ static W_LIST_DESCR_GROUP: LazyLock<PyreObjectDescrGroup> = LazyLock::new(|| {
                 // incompatible item is stored. A trace that folded
                 // `strategy == Float` at trace-time into a constant would
                 // then read from `float_items.block` (empty after the
-                // switch) and dereference garbage — spectral_norm n=10
-                // SIGSEGV root cause diagnosed in
-                // memory/spectral_norm_small_n_crash_2026_04_17.md.
+                // switch) and dereference garbage — the spectral_norm n=10
+                // SIGSEGV root cause.
                 //
                 // Upstream PyPy handles this with a quasi-immutable flag
                 // + invalidate_compiled_code hook on strategy change;

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/branch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/branch.rs
@@ -70,7 +70,7 @@ pub(crate) fn resolve_branch_target_through_trampoline(code: &[u8], target: usiz
     resume
 }
 
-/// #73 S3.1 (approach C): re-derive a branch guard's resume `other_target` from
+/// Re-derive a branch guard's resume `other_target` from
 /// the guard's OWN `-live-` BEFORE anchor `orgpc` (== ctx.live_before_jit_pc at
 /// the goto_if_not) + the recorded flavor (GuardTrue/GuardFalse), WITHOUT the
 /// runtime condbox — mirroring PyPy generate_guard(resumepc=orgpc) (pyjitpl.py:520),
@@ -109,7 +109,7 @@ pub(crate) fn decode_side_other_target(
     Ok(resolve_branch_target_through_trampoline(code, raw))
 }
 
-/// #73 S4 decode: if `carried` is a tagged branch `orgpc` (negative-space
+/// Decode: if `carried` is a tagged branch `orgpc` (negative-space
 /// encoding, [`majit_ir::resumedata::encode_branch_orgpc`]), expand it to the
 /// genuine not-taken-arm jitcode offset (`derived` / other_target) DIRECTLY:
 /// `decode_side_other_target` picks the not-taken arm from `orgpc` + flavor and
@@ -223,11 +223,11 @@ pub(crate) fn branch_resume_target_stack_depth(
     if pjc.code_ptr.is_null() {
         return None;
     }
-    // #73 family(ii) Slice B: source the not-taken-arm depth off the genuine
-    // jitcode `target` through the compile-time `depth_trivia` twin, retiring
-    // the `python_pc_for_jitcode_pc` inversion + runtime
+    // Source the not-taken-arm depth off the genuine jitcode `target` through
+    // the compile-time `depth_trivia` twin, retiring the
+    // `python_pc_for_jitcode_pc` inversion + runtime
     // `skip_python_trivia_forward` + static-liveness read. The twin is built for
-    // every drained real-code jitcode (codewriter.rs), and the Slice A census
+    // every drained real-code jitcode (codewriter.rs), and the encode census
     // (`PYRE_M73_ENCODE_AUDIT`) proved the empty-twin fallback is never reached
     // here (0 fallback trips / 162 programs; this reader 1181 hits, all
     // populated). The `debug_assert` re-certifies the invariant in test builds.
@@ -541,8 +541,8 @@ pub(crate) fn branch_resume_target_stack_depth_any_leg(
     if pjc.code_ptr.is_null() {
         return None;
     }
-    // #73 family(ii) Slice B: twin-sourced leg-independent depth, py_pc inversion
-    // retired (see `branch_resume_target_stack_depth`). Slice A census: this
+    // Twin-sourced leg-independent depth, py_pc inversion retired (see
+    // `branch_resume_target_stack_depth`). Encode census: this
     // reader 1178 hits, all populated, 0 fallback trips — including at the
     // `outer_jitcode_index==0` coincidence that reads `jitcodes[0]`.
     debug_assert!(

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/fbw_state.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/fbw_state.rs
@@ -1246,7 +1246,7 @@ pub(crate) fn fbw_abort_nested_unjournaled_residual<Sym: WalkSym>(
     // nested-decline guard, which is for FOREIGN unjournaled residuals.
     let in_selfrec_fold = SELFREC_CA_FOLD_ACTIVE.with(|c| c.get());
     let in_exception_string_inline = EXCEPTION_STRING_INLINE_ACTIVE.with(|c| c.get());
-    // Narrowed decline (#73 Slice-1 payoff): the general depth-≥2 nested
+    // Narrowed decline: the general depth-≥2 nested
     // residual inline is sound now that the portal-runner ABI is correct — a
     // straight-line mutating callee inlines bit-exact.  Only two callee shapes
     // still miscompile, both masked by the old blanket decline and captured by

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/fbw_state.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/fbw_state.rs
@@ -142,7 +142,7 @@ pub(crate) fn fbw_rec_mutual_cutover_enabled() -> bool {
     })
 }
 
-/// `PYRE_FBW_LOOP_CALLEE_CA` (gap-10, general loop-bearing-callee →
+/// `PYRE_FBW_LOOP_CALLEE_CA` (general loop-bearing-callee →
 /// CALL_ASSEMBLER): when a multi-frame inlined callee sub-walk reaches the
 /// callee's own `jit_merge_point` and a compiled loop token already exists
 /// for that green key, emit a `CALL_ASSEMBLER` into it (mirror of
@@ -182,7 +182,7 @@ pub(crate) fn fbw_loop_callee_ca_enabled() -> bool {
 }
 
 /// `PYRE_FBW_VABLE_SCALAR_CA` (default OFF) — sub-mode of
-/// [`fbw_loop_callee_ca_enabled`]. When on, the gap-10 loop-callee
+/// [`fbw_loop_callee_ca_enabled`]. When on, the loop-callee
 /// CALL_ASSEMBLER passes the callee's loop-carried locals as scalar
 /// CALL_ASSEMBLER args plus a `VableExpansion` (`arg_overrides` mapping each
 /// scalar to a callee jitframe slot), so the optimizer can elide the per-call
@@ -206,7 +206,7 @@ pub(crate) fn fbw_vable_scalar_ca_enabled() -> bool {
 /// `PYRE_FBW_RAISE` (default ON) — the FBW walker owns the Python raise/except
 /// loop.  The twin NULL-ref guards exempt the trailing `cause` sentinel of a
 /// [`PyreHelperKind::RaiseVarargs`] residual so the walker records the raise.
-/// Now that the trait tracer is retired (gap-10), declining instead
+/// Now that the trait tracer is retired, declining instead
 /// re-interprets without JIT (a hot raise/except loop would time out), so the
 /// walker must own the raise path; `PYRE_FBW_RAISE=0` opts back to declining.
 pub(crate) fn fbw_raise_enabled() -> bool {
@@ -438,10 +438,10 @@ thread_local! {
         const { std::cell::Cell::new(false) };
 }
 
-/// Whether the slice-b Finish-portal compile route is enabled.  Cached so
+/// Whether the Finish-portal compile route is enabled.  Cached so
 /// the per-`*_return` read and the `full_body_walk_trace` read see a
-/// single consistent value.  Default ON since the Phase 5 production flip;
-/// `PYRE_FBW_CALL_ASSEMBLER=0` opts back into the pre-slice-b path (bare
+/// single consistent value.  Default ON; `PYRE_FBW_CALL_ASSEMBLER=0` opts
+/// back into the pre-Finish-portal path (bare
 /// `Terminate` -> `Abort`) as a transition escape hatch.
 pub(crate) fn fbw_call_assembler_enabled() -> bool {
     static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
@@ -1407,12 +1407,12 @@ pub(crate) fn fbw_store_token_in_vable<Sym: WalkSym>(
     Ok(())
 }
 
-/// Shared slice-b top-level finish path for the three value-returning arms
+/// Shared top-level finish path for the three value-returning arms
 /// (`ref_return` / `int_return` / `float_return`).  Re-boxes `result` to
 /// `Type::Ref`, records the vable store-back + `GUARD_NOT_FORCED_2`, and
 /// stashes the finish payload for `full_body_walk_trace`.  Deliberately
 /// does NOT record the `FINISH` op: under the gate the compile consumer
-/// (`finish_and_compile` -> `recorder.finish`, mod.rs:6427) records it from
+/// (`finish_and_compile` -> `recorder.finish`, mod.rs) records it from
 /// `finish_args`, so recording it here too would double it.
 pub(crate) fn fbw_terminate_with_finish<Sym: WalkSym>(
     ctx: &mut WalkContext<'_, '_, Sym>,

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
@@ -971,8 +971,8 @@ pub(crate) fn try_walker_call_assembler_self_recursive<Sym: WalkSym>(
     Ok(Some((DispatchOutcome::Continue, op.next_pc)))
 }
 
-/// gap-10 walker mirror of `opimpl_recursive_call_assembler`
-/// (`metainterp.rs:768`): a multi-frame inlined callee sub-walk reached its
+/// Walker mirror of `opimpl_recursive_call_assembler`
+/// (`metainterp.rs`): a multi-frame inlined callee sub-walk reached its
 /// OWN loop header (surfaced as `SubLoopCalleeCallAssembler`) and a compiled
 /// loop token already exists for it. The inlined prologue already populated
 /// the seeded virtual callee frame's locals via `setarrayitem_vable`, so this
@@ -1109,7 +1109,7 @@ pub(crate) fn emit_walker_loop_callee_call_assembler<Sym: WalkSym>(
 
 /// `PYRE_FBW_VABLE_SCALAR_CA` emission seam (S0 scaffolding).
 ///
-/// Emits the gap-10 loop-callee CALL_ASSEMBLER when the vable-scalar mode is
+/// Emits the loop-callee CALL_ASSEMBLER when the vable-scalar mode is
 /// on. S0: produces the identical red-only `[callee_frame, callee_ec]` CA as
 /// the default path, so flag-ON is byte-identical to flag-OFF. S2 replaces the
 /// body with `call_assembler_with_vable_expansion` — passing the callee's
@@ -1656,7 +1656,7 @@ pub(crate) fn try_walker_inline_resolved_user_call<Sym: WalkSym>(
     // an un-seedable strict shape never loses its inline.  Every bail below
     // precedes any IR recording, so a strict fall-through records no dead op.
     //
-    // gap-10 (`PYRE_FBW_LOOP_CALLEE_CA`): the seeded virtual callee frame /
+    // `PYRE_FBW_LOOP_CALLEE_CA`: the seeded virtual callee frame /
     // shared ec / local count are hoisted so the sub-walk return site can
     // emit a `CALL_ASSEMBLER` into the callee loop token when the sub-walk
     // surfaces `SubLoopCalleeCallAssembler` (the callee reached its own loop
@@ -1669,7 +1669,7 @@ pub(crate) fn try_walker_inline_resolved_user_call<Sym: WalkSym>(
     // way, so its in-callee guards route through the multi-frame snapshot.  A
     // deeper strict callee (`inline_depth >= fbw_max_multiframe_depth()`) keeps the
     // single-frame collapse — a 3-frame snapshot the resume path is sound for
-    // only one paused caller frame (task #126 multiframe depth).
+    // only one paused caller frame.
     let strict_seed = strict_inlinable && inline_depth < fbw_max_multiframe_depth();
     // True once the callee frame reds are actually seeded (all preconditions
     // below met).  For a strict callee this gates routing its guards through the
@@ -1785,7 +1785,7 @@ pub(crate) fn try_walker_inline_resolved_user_call<Sym: WalkSym>(
             callee_regs_r[ec_reg as usize] = callee_ec;
             callee_concrete_r[ec_reg as usize] = ConcreteValue::Null;
 
-            // gap-10: retain for a possible `SubLoopCalleeCallAssembler` emit.
+            // Retain for a possible `SubLoopCalleeCallAssembler` emit.
             ca_callee_frame = callee_frame;
             ca_callee_ec = callee_ec;
             ca_nlocals = nlocals;
@@ -1875,7 +1875,7 @@ pub(crate) fn try_walker_inline_resolved_user_call<Sym: WalkSym>(
     } else {
         // Single-frame collapse (resume at the CALL boundary, re-execute the
         // whole call on deopt): a nested strict callee
-        // (`inline_depth >= fbw_max_multiframe_depth()`, task #126), an un-seedable
+        // (`inline_depth >= fbw_max_multiframe_depth()`), an un-seedable
         // strict callee, or a callee neither seed served.  Sound for a pure
         // value-returning leaf (idempotent re-execute) and for a nested
         // straight-line callee (its pre-multiframe behavior).

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
@@ -1027,10 +1027,10 @@ pub(crate) fn emit_walker_loop_callee_call_assembler<Sym: WalkSym>(
     maybe_walker_vable_and_vrefs_before_residual_call(ctx);
 
     let ca_result = if fbw_vable_scalar_ca_enabled() {
-        // S1-S3 (`PYRE_FBW_VABLE_SCALAR_CA`): route through the vable-scalar
+        // `PYRE_FBW_VABLE_SCALAR_CA`: route through the vable-scalar
         // emitter so loop-carried locals become scalar CALL_ASSEMBLER args +
         // `VableExpansion` arg_overrides, letting the optimizer elide the
-        // per-call frame-array build. S0 scaffolding: the emitter currently
+        // per-call frame-array build. Scaffolding only: the emitter currently
         // produces the identical red-only CA; the vable_expansion routing lands
         // in S2.
         emit_loop_callee_ca_vable_scalar(ctx, callee_frame, callee_ec, token)
@@ -1107,16 +1107,16 @@ pub(crate) fn emit_walker_loop_callee_call_assembler<Sym: WalkSym>(
     Ok(Some((DispatchOutcome::Continue, op.next_pc)))
 }
 
-/// `PYRE_FBW_VABLE_SCALAR_CA` emission seam (S0 scaffolding).
+/// `PYRE_FBW_VABLE_SCALAR_CA` emission seam (scaffolding only).
 ///
 /// Emits the loop-callee CALL_ASSEMBLER when the vable-scalar mode is
-/// on. S0: produces the identical red-only `[callee_frame, callee_ec]` CA as
-/// the default path, so flag-ON is byte-identical to flag-OFF. S2 replaces the
-/// body with `call_assembler_with_vable_expansion` — passing the callee's
+/// on. Today it produces the identical red-only `[callee_frame, callee_ec]` CA
+/// as the default path, so flag-ON is byte-identical to flag-OFF. Wiring the
+/// body to `call_assembler_with_vable_expansion` — passing the callee's
 /// loop-carried locals as scalar args plus a `VableExpansion` whose
 /// `arg_overrides` map each scalar to a callee jitframe slot
-/// (`rewrite.py:665-695` handle_call_assembler parity) — so the optimizer can
-/// elide the per-call frame-array build.
+/// (`rewrite.py:665-695` handle_call_assembler parity) — would let the
+/// optimizer elide the per-call frame-array build.
 pub(crate) fn emit_loop_callee_ca_vable_scalar<Sym: WalkSym>(
     ctx: &mut WalkContext<'_, '_, Sym>,
     callee_frame: OpRef,

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
@@ -8,8 +8,7 @@
 //! `pyjitpl.py:1640-1660`). This module is the sole production tracer:
 //! it consumes the codewriter-emitted jitcode bytes directly, executing
 //! as it records (`is_authoritative_executor`). The trait-driven
-//! `MIFrame::execute_opcode_step` interpret loop is retired
-//! (#203 gap 10 / #73 Phase 6).
+//! `MIFrame::execute_opcode_step` interpret loop is retired.
 //!
 //! Module layout vs. RPython: because this FBW walker has no single
 //! `rpython/jit/metainterp/` file counterpart (the file-for-file parity
@@ -868,7 +867,7 @@ pub struct WalkContext<'frame, 'static_a: 'frame, Sym: WalkSym> {
     /// surfaces the `DispatchError` so a guard recorded without a resume
     /// snapshot aborts the walk instead of compiling.
     pub pending_guard_snapshot_error: Option<DispatchError>,
-    /// #73 PyPy-faithful kept-operand-stack snapshot: the walk-level
+    /// PyPy-faithful kept-operand-stack snapshot: the walk-level
     /// symbolic operand stack, indexed by ABSOLUTE operand-stack depth
     /// (slot `s`, `s in 0..vstack_depth`).  The Python operand stack is
     /// all-Ref (`W_Root`), so a single `Vec<OpRef>` (Ref bank) suffices.
@@ -1430,7 +1429,7 @@ pub enum DispatchError {
     /// `OpRef::ty()` invariant. The full-body walk surfaces a typed abort so
     /// the driver maps it to `TraceAction::Abort` and interpretation instead
     /// of panicking the tracer. Resuming such a guard needs the multi-frame
-    /// vable snapshot machinery (task #124).
+    /// vable snapshot machinery.
     GuardSnapshotVableUntyped { pc: usize },
     /// A guard capture had no decodable carried JitCode coordinate. Publishing
     /// a Python pc here would make a later side exit resume at a guessed
@@ -1496,7 +1495,7 @@ pub enum DispatchError {
     /// cyclic `*_push`/`*_pop` move, a truncated/under-sized color map, or a
     /// source that resolves to `OpRef::NONE` — i.e. when the deopt re-entry
     /// would otherwise restore a wrong value into a loop-carried slot
-    /// (task #124/#281 per-PC resume-value precision).  Plain `while` / `if`
+    /// (per-PC resume-value precision).  Plain `while` / `if`
     /// branches resume at depth 0 and are unaffected.  The walker surfaces a
     /// typed abort so the driver maps it to `TraceAction::Abort` →
     /// interpreter fallback (correct, untraced) instead of compiling a trace
@@ -1537,10 +1536,9 @@ pub enum DispatchError {
     /// callees via `push_inline_frame` + the `recursive-call-assembler` loop back-edge
     /// (`pyjitpl.rs` opimpl_recursive_call_assembler).  Surface a typed
     /// abort so the key interprets without JIT (`FBW_DECLINED_KEYS`) until
-    /// the walker itself covers loop-callee inlining (task #62, the Phase-6
-    /// convergence).
+    /// the walker itself covers loop-callee inlining.
     LoopBearingCalleeInlineUnsupported { pc: usize },
-    /// #57 (Finding #1): an in-flight FOR_ITER body executed a non-journalable
+    /// An in-flight FOR_ITER body executed a non-journalable
     /// in-place builtin-container mutation (`acc += delta` for an object-/float-
     /// strategy list, `bytearray`, `set`, `dict`, …).  The abort rollback cannot
     /// rewind it and a deliver re-run would double it, so the walk declines BEFORE
@@ -1781,7 +1779,7 @@ pub fn walk<Sym: WalkSym>(
             | DispatchOutcome::SwitchToBlackhole { .. }
             | DispatchOutcome::CloseLoop { .. }
             | DispatchOutcome::CompileTracePending { .. }
-            // gap-10: a multi-frame inlined callee reached its own loop
+            // A multi-frame inlined callee reached its own loop
             // header; propagate up to `try_walker_inline_user_call`, which
             // emits the recursive CALL_ASSEMBLER at the call boundary.
             | DispatchOutcome::SubLoopCalleeCallAssembler { .. } => {
@@ -3105,7 +3103,7 @@ pub fn bool_box_truth_reset() {
 /// non-elidable `residual_call_*` (`store_subscr_fn` /
 /// `set_current_exception` / etc.), the helper is never invoked → heap
 /// mutation never happens → next read derefs stale container → SIGBUS
-/// (M4 walker unactivated taxonomy: 5 STORE_SUBSCR-hot benches).  The
+/// (5 STORE_SUBSCR-hot benches).  The
 /// orthodox fix is to widen this function across `Call*` /
 /// `CallLoopinvariant*` / `CallMayForce*` shapes, mirroring PyPy's
 /// `_opimpl_residual_call*` which concrete-executes *every* residual
@@ -3120,8 +3118,7 @@ pub fn bool_box_truth_reset() {
 ///   * `CallPure*` is excluded — that's [`try_fold_pure_call_via_executor`]'s
 ///     job.
 ///   * `CallReleaseGil*` / `CallAssembler*` are excluded from THIS
-///     function's direct opcode set, but for distinct reasons (sub-slice 4
-///     audit outcome):
+///     function's direct opcode set, but for distinct reasons:
 ///     - `CallReleaseGil*` IS concrete-executed — `do_residual_call`
 ///       (`pyjitpl.py:2019-2044`) runs step 2 with `opnum1 =
 ///       CALL_MAY_FORCE_*` for the *whole* forces branch, and release-gil
@@ -3188,7 +3185,7 @@ pub fn bool_box_truth_reset() {
 ///   (pyjitpl.py:3365 ABORT_ESCAPE parity, see the token-protocol bullet
 ///   above).
 ///
-/// **Wire status** (Task #390 sub-slice 2.3): invoked from all three
+/// **Wire status**: invoked from all three
 /// dispatch entry points (`dispatch_residual_call_iRd_kind`,
 /// `dispatch_residual_call_iIRd_kind`, `dispatch_residual_call_iIRFd_kind`)
 /// alongside [`try_fold_pure_call_via_executor`].  The may-force /
@@ -3518,7 +3515,7 @@ fn collect_outer_active_boxes<Sym: WalkSym>(
         .iter()
         .map(|&(dst, v)| (dst as u32, v))
         .collect();
-    // #73 mirror-sourced kept operand-stack slots: at a branch guard the
+    // Mirror-sourced kept operand-stack slots: at a branch guard the
     // not-taken arm preserves the operand-stack bottom, so the live walk-level
     // box mirror (`ctx.vstack_boxes`, indexed by absolute operand-stack depth)
     // holds the exact kept value for resume operand slot `s`.  This replaces
@@ -4848,10 +4845,10 @@ fn direct_call_release_gil<Sym: WalkSym>(
     // branch, so it is executed identically to a `CALL_MAY_FORCE_*` — on
     // the **original** `allboxes` (`allboxes[0]` is the wrapper funcbox;
     // the recorded op above used the re-shaped `[savebox, funcbox_real,
-    // …]`).  Task #390 sub-slice 4: this removes the asymmetry where
-    // release-gil was the only forces sub-case that recorded without
-    // executing — the same un-executed-side-effect SIGBUS class sub-slice
-    // 3 closed for the may-force branch.
+    // …]`).  This removes the asymmetry where release-gil was the only
+    // forces sub-case that recorded without executing — the same
+    // un-executed-side-effect SIGBUS class already closed for the
+    // may-force branch.
     // `try_execute_residual_call_via_executor` self-gates (authoritative-
     // executor flag, const-funcbox, fnaddr ≥47-bit sanity) and degrades to
     // recording-only on decline; on success it stamps `recorded` with the
@@ -6884,7 +6881,7 @@ fn handle<Sym: WalkSym>(
                 };
                 let kept_stack = resume_depth.is_some_and(|d| d > 0);
                 let depth_gt_1 = resume_depth.is_some_and(|d| d > 1);
-                // #73 mirror-sourced kept-stack compile: a kept-stack guard
+                // Mirror-sourced kept-stack compile: a kept-stack guard
                 // COMPILES whenever the walk-level operand-stack mirror
                 // (`ctx.vstack_boxes`) covers EVERY kept resume slot
                 // `0..resume_depth` with a non-NONE, non-NULL box — i.e. the
@@ -7054,7 +7051,7 @@ fn handle<Sym: WalkSym>(
                     // `(dst, src)` trampoline against the guard-pc register file
                     // (`resolved_recovered`) — verified byte-exact against the
                     // declined-interpreter oracle across the 599-program
-                    // adversarial corpus (#73 kept-stack census, incl. the
+                    // adversarial corpus (kept-stack census, incl. the
                     // heap-int short-circuit / conditional-expression repros).
                     // The hazard remains only for an UNDERMODELED walk (invalid
                     // mirror: inline sub-walk / Unmodeled opcode), where those
@@ -8236,7 +8233,7 @@ fn handle<Sym: WalkSym>(
                 Some(Value::Int(v)) => v as usize,
                 _ => return Err(DispatchError::JitMergePointGreenKeyUnresolved { pc: op.pc }),
             };
-            // gap-10 (PYRE_FBW_LOOP_CALLEE_CA): an inlined callee's own loop
+            // `PYRE_FBW_LOOP_CALLEE_CA`: an inlined callee's own loop
             // header routes to a `CALL_ASSEMBLER` into its already-compiled loop
             // token EVEN WHEN its pycode green resolves.  nbody's `advance` has a
             // const-Ref code_green (resolves) plus an existing loop token, so the
@@ -8318,7 +8315,7 @@ fn handle<Sym: WalkSym>(
             let code_ptr = match ctx.trace_ctx.concrete_of_opref(code_green) {
                 Some(Value::Ref(gcref)) if gcref.0 != 0 => gcref.0 as *const (),
                 _ => {
-                    // gap-10 (PYRE_FBW_LOOP_CALLEE_CA, default-ON): inside a
+                    // `PYRE_FBW_LOOP_CALLEE_CA` (default-ON): inside a
                     // multi-frame inline sub-walk the callee's own
                     // `jit_merge_point` (its loop header) carries a pycode green
                     // with no live Ref shadow, so this resolution fails and the

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
@@ -2293,7 +2293,7 @@ fn write_ref_reg<Sym: WalkSym>(
     // `get_mut` defensively to tolerate sub-walk shadows that lag the
     // OpRef bank if a future caller mis-sizes them.
     //
-    // Codex P1 (PR #89): collapse non-Ref ConcreteValue (Int / Float)
+    // collapse non-Ref ConcreteValue (Int / Float)
     // to Null before storing into the Ref shadow.  `concrete_from_
     // recorded_opref` returns whatever kind the per-OpRef concrete
     // table holds; a kind mismatch (e.g. boxed Int returned through a
@@ -2400,7 +2400,7 @@ fn write_int_reg<Sym: WalkSym>(
     // an empty `concrete_registers_i` slice; production callers
     // (Concrete shadow seeding) size it to `registers_i.len()` at dispatch entry.
     //
-    // Codex P1 (PR #89) symmetry with `write_ref_reg`: collapse
+    // Symmetry with `write_ref_reg`: collapse
     // non-Int ConcreteValue to Null before storing into the Int
     // shadow so a kind-mismatched stamp can't leak Ref/Float bits
     // into `concrete_registers_i`.

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
@@ -57,7 +57,7 @@ pub(crate) fn ensure_residual_call_args_bound(
 /// `GUARD_NOT_FORCED` from the forces branch (`pyjitpl.py:2079`)
 /// should fire.
 ///
-/// ★ Task #390 sub-slice 1 — non-elidable concrete-execute inventory.
+/// Non-elidable concrete-execute inventory.
 ///
 /// PyPy `do_residual_call` (pyjitpl.py:1995-2126) concrete-executes
 /// the helper at trace-record time across the **forces** /
@@ -77,14 +77,14 @@ pub(crate) fn ensure_residual_call_args_bound(
 /// skipped via the two narrow branches above) before the trace op
 /// hits the recorder.
 ///
-/// Per-branch concrete-execute status (sub-slices 3 + 4 landed — every
-/// non-pure residual call now concrete-executes during the walk, matching
+/// Per-branch concrete-execute status (every non-pure residual call
+/// concrete-executes during the walk, matching
 /// PyPy `do_residual_call` which runs `executor.execute_varargs` for the
 /// whole forces branch regardless of EI):
 ///
 /// | EI branch | Selected op | Pyre walker concrete-execute |
 /// |---|---|---|
-/// | `is_call_release_gil()` | (early-routed to [`direct_call_release_gil`], records `CALL_RELEASE_GIL_*`) | executed as `CallMayForce*` on the **original** `allboxes` via [`try_execute_residual_call_via_executor`] (sub-slice 4) |
+/// | `is_call_release_gil()` | (early-routed to [`direct_call_release_gil`], records `CALL_RELEASE_GIL_*`) | executed as `CallMayForce*` on the **original** `allboxes` via [`try_execute_residual_call_via_executor`] |
 /// | `check_forces_virtual_or_virtualizable()` | `CallMayForce*` + `GuardNotForced` | executed via [`try_execute_residual_call_via_executor`] (active vable bracketed by the token protocol) |
 /// | `extraeffect == LoopInvariant` | `CallLoopinvariant*` | executed on cache miss; [`loopinvariant_lookup`] reuses the cached OpRef on hit (no execute, no record) |
 /// | `check_is_elidable()` | `CallPure*` | executed + cached via [`try_fold_pure_call_via_executor`] (elidable_cannot_raise only — see its caveats) |
@@ -99,11 +99,6 @@ pub(crate) fn ensure_residual_call_args_bound(
 /// self-gates and degrades to recording-only when a precondition fails
 /// (non-authoritative walk, non-const funcbox, unpatched symbolic fnaddr).
 ///
-/// **Priority order for sub-slice 2 (widen):** Call* (default — the
-/// store_subscr_fn / set_current_exception class, smallest blast
-/// radius, root cause of M4 SIGBUS) → CallLoopinvariant* (`pure=False
-/// exc=False` is safest) → CallMayForce* (riskiest — force-virtual
-/// audit precondition).
 pub(crate) fn select_residual_call_opcode(
     ei: &majit_ir::EffectInfo,
     dst_bank: char,
@@ -633,12 +628,12 @@ pub(crate) fn try_execute_residual_call_via_executor<Sym: WalkSym>(
         Some(majit_ir::Value::Int(addr)) => addr,
         _ => return Ok(ResidualExecOutcome::Declined(ResidualDecline::Symbolic)),
     };
-    // Sub-slice 4 safety gate — reject `symbolic_fnaddr_for_path`
+    // Safety gate — reject `symbolic_fnaddr_for_path`
     // placeholder values that escaped runtime patching.  Pyre's
     // codewriter mints a 64-bit hash of the helper's `CallPath` when
     // the build-time `pyre_interpreter::jit_trace_fnaddrs()` snapshot
-    // has no entry for it (`majit-translate/src/codewriter/call.rs:
-    // 4926 symbolic_fnaddr_for_path`).  `runtime_fnaddr_patch` rewrites
+    // has no entry for it (`symbolic_fnaddr_for_path` in
+    // `majit-translate/src/codewriter/call.rs`).  `runtime_fnaddr_patch` rewrites
     // these to real runtime addresses only when the path appears in
     // both the build-time and runtime registries; helpers absent from
     // the runtime registry retain the hash and dereferencing it as a
@@ -2189,17 +2184,17 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
         try_fold_pure_call_via_executor(ctx, call_opcode, &allboxes, call_descr, recorded);
 
         // pyjitpl.py:1346/1349/1354 `_opimpl_residual_call{1,2,3}` parity
-        // for the non-elidable shapes (Task #390 sub-slice 3).  PyPy
+        // for the non-elidable shapes.  PyPy
         // concrete-executes EVERY residual call regardless of EI — the
         // `exc` flag only selects the *guard* shape downstream
         // (`handle_possible_exception` → `GUARD_EXCEPTION` vs
         // `GUARD_NO_EXCEPTION`), not whether the helper runs.  Without
         // this, walker-recorded non-elidable helpers
         // (`store_subscr_fn`, `set_current_exception`, …) would skip
-        // their heap mutation because `eval.rs:3285-3308`'s walker-skip
+        // their heap mutation because `eval.rs`'s walker-skip
         // path bypasses `execute_opcode_step` → SIGBUS on the next read
-        // of the un-mutated container (M4 walker unactivated taxonomy).
-        // Task #390 sub-slice 4: PyPy-orthodox activation.  PyPy's
+        // of the un-mutated container.
+        // PyPy-orthodox activation.  PyPy's
         // `_opimpl_residual_call*` concrete-executes EVERY residual
         // call regardless of EI; the `exc` flag only selects the
         // post-call guard shape (`GUARD_EXCEPTION` vs `GUARD_NO_EXCEPTION`)
@@ -2991,9 +2986,9 @@ pub(crate) fn dispatch_residual_call_iIRd_kind<Sym: WalkSym>(
         // `dispatch_residual_call_iRd_kind` for the upstream walk.
         try_fold_pure_call_via_executor(ctx, call_opcode, &allboxes, call_descr, recorded);
 
-        // Non-elidable concrete-execute parity (Task #390 sub-slice 3)
-        // — see `dispatch_residual_call_iRd_kind` for the full citation.
-        // Task #390 sub-slice 4: PyPy-orthodox activation.  PyPy's
+        // Non-elidable concrete-execute parity — see
+        // `dispatch_residual_call_iRd_kind` for the full citation.
+        // PyPy-orthodox activation.  PyPy's
         // `_opimpl_residual_call*` concrete-executes EVERY residual
         // call regardless of EI; the `exc` flag only selects the
         // post-call guard shape (`GUARD_EXCEPTION` vs `GUARD_NO_EXCEPTION`)
@@ -3211,9 +3206,9 @@ pub(crate) fn dispatch_residual_call_iIRFd_kind<Sym: WalkSym>(
         // `result_type() == Void` arm and deferred (#61), so the compiled
         // loop's re-run does not double-apply the store.
 
-        // Non-elidable concrete-execute parity (Task #390 sub-slice 3)
-        // — see `dispatch_residual_call_iRd_kind` for the full citation.
-        // Task #390 sub-slice 4: PyPy-orthodox activation.  PyPy's
+        // Non-elidable concrete-execute parity — see
+        // `dispatch_residual_call_iRd_kind` for the full citation.
+        // PyPy-orthodox activation.  PyPy's
         // `_opimpl_residual_call*` concrete-executes EVERY residual
         // call regardless of EI; the `exc` flag only selects the
         // post-call guard shape (`GUARD_EXCEPTION` vs `GUARD_NO_EXCEPTION`)

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/resume_snapshot.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/resume_snapshot.rs
@@ -191,7 +191,7 @@ pub(crate) fn walker_capture_snapshot_for_last_guard_impl<Sym: WalkSym>(
     // box (including the identity at `[-1]`) to carry `OpRef::ty()`; a
     // deeper inlined / recursive frame can leave the identity untyped.
     // Surface a typed abort rather than tripping the
-    // invariant panic (the multi-frame vable snapshot is task #124).
+    // invariant panic (the multi-frame vable snapshot is unported).
     if !ctx.trace_ctx.vable_snapshot_buildable() {
         return Err(DispatchError::GuardSnapshotVableUntyped { pc: op_pc });
     }
@@ -729,8 +729,7 @@ pub(crate) fn walker_capture_snapshot_for_last_guard_impl<Sym: WalkSym>(
                         .payload
                         .resume_marker_for_jitcode_pc(op_pc)
                 };
-                // #73 S2: a
-                // specialization guard (`GuardValue`/`GuardClass`) sources its
+                // A specialization guard (`GuardValue`/`GuardClass`) sources its
                 // resume coordinate from the walk cursor's per-op `-live-`
                 // BEFORE anchor (`ctx.live_before_jit_pc`, `pyjitpl.py:198`)
                 // directly, dropping the py_pc-keyed block-head lookup.
@@ -740,8 +739,7 @@ pub(crate) fn walker_capture_snapshot_for_last_guard_impl<Sym: WalkSym>(
                 // decode identically for every consumer (banks + bridge maps +
                 // const refill) where the anchor coincides, and flags the
                 // divergent minority for the check.py output-equality gate.
-                // #73 S3.5: a depth-0
-                // branch guard (`GuardTrue`/`GuardFalse`) carries the walk's
+                // A depth-0 branch guard (`GuardTrue`/`GuardFalse`) carries the walk's
                 // arm-independent `-live-` BEFORE anchor (`ctx.live_before_jit_pc`,
                 // `orgpc`) TAGGED into the negative space of the word plus the
                 // guard flavor, instead of the py_pc-keyed block-head `marker`.
@@ -840,7 +838,7 @@ pub(crate) fn walker_capture_snapshot_for_last_guard_impl<Sym: WalkSym>(
                     None => majit_ir::resumedata::NO_JITCODE_PC,
                 }
             } else {
-                // #73 S5 p3-s1: the remaining nonbranch guards (outside the
+                // The remaining nonbranch guards (outside the
                 // arm-2 allow-list, not after-residual) carry the same
                 // block-head marker as arm-2, sourced from the jitcode-keyed
                 // twin at the guard's own `op_pc`.

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
@@ -4792,7 +4792,7 @@ pub(crate) fn try_walker_specialize_for_iter_next<Sym: WalkSym>(
     walker_emit_guard_with_snapshot(ctx, op_pc, OpCode::GuardTrue, &[continues])?;
 
     // The continue guard establishes `continues == 1` on the trace path. Keep
-    // Slice-1's wrapping IntAdd and live-iterator SetfieldGc updates intact.
+    // the wrapping IntAdd and live-iterator SetfieldGc updates intact.
     let delta = ctx.trace_ctx.record_op(OpCode::IntMul, &[step, continues]);
     ctx.trace_ctx.set_opref_concrete(
         delta,
@@ -5036,8 +5036,8 @@ pub(crate) fn try_walker_specialize_setslice<Sym: WalkSym>(
         .replace_box(src_len_box, src_len_const);
 
     // items[start + j] = source.items[j] for j in 0..slice_len, through the
-    // int_items blocks (`list_int_items_block_descr`, matching slice-1's
-    // `emit_typed_list_inline` `SetfieldGc`), so a virtual source temp's
+    // int_items blocks (`list_int_items_block_descr`, matching
+    // `emit_typed_list_inline`'s `SetfieldGc`), so a virtual source temp's
     // `SetarrayitemGc` stores fold against these reads.
     let src_block = crate::state::opimpl_getfield_gc_r(
         ctx.trace_ctx,

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/vable_ops.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/vable_ops.rs
@@ -39,7 +39,7 @@ pub(crate) fn getfield_vable_via_metainterp<Sym: WalkSym>(
     dst_bank: char,
 ) -> Result<(DispatchOutcome, usize), DispatchError> {
     let obj = read_ref_reg(code, op, 0, ctx)?;
-    // #68/gap-10: inside an inlined-callee sub-walk, a scalar getfield_vable_r
+    // Inside an inlined-callee sub-walk, a scalar getfield_vable_r
     // of the callee's namespace(idx5)/pycode(idx1) must resolve to the callee's
     // compile-time `InlineCalleeConsts` whether the callee frame is unseeded
     // (strict path, handled by the `obj.is_none()` branch below) OR a seeded

--- a/pyre/pyre-jit-trace/src/lib.rs
+++ b/pyre/pyre-jit-trace/src/lib.rs
@@ -58,10 +58,9 @@ pub(crate) fn trace_ctx_for_test(num_inputs: usize) -> majit_metainterp::TraceCt
 // exactly one extra red (ec, see `virtualizable_gen.rs:29-31` and
 // `pypy/module/pypyjit/interp_jit.py:67 reds = ['frame', 'ec']`).
 // `majit-macros::virtualizable!` itself is generic over `extra_reds.len()`
-// (mod.rs:515), so this assertion is *pyre-local*. Tracing-time helpers
+// (mod.rs), so this assertion is *pyre-local*. Tracing-time helpers
 // that seed/push the ec slot rely on this invariant; bumping it requires
-// re-auditing every ec wiring callsite — see the v3 plan at
-// `~/.claude/plans/ec-wiring-gentle-wave.md`.
+// re-auditing every ec wiring callsite.
 const _: () = assert!(
     virtualizable_gen::NUM_EXTRA_REDS == 1,
     "pyre's PyFrame virtualizable layout requires exactly one extra red (ec)",

--- a/pyre/pyre-jit-trace/src/pyjitcode.rs
+++ b/pyre/pyre-jit-trace/src/pyjitcode.rs
@@ -91,7 +91,7 @@ pub struct PyJitCodeMetadata {
     /// per materialized trace-entry green. Sorted ascending by green py_pc for
     /// binary search; empty for skeleton / fixture metadata.
     pub merge_entry_by_green: Vec<(u32, u32)>,
-    /// task#50 phase-1: predecessor-keyed jitcode-pc twin of `pcdep_color_slots`.
+    /// Predecessor-keyed jitcode-pc twin of `pcdep_color_slots`.
     /// Each entry `(off, colors)` maps a JitCode byte offset to the pcdep
     /// color→slot list of the py_pc that `python_pc_for_jitcode_pc(off)` returns
     /// (block-head marker precedence, else the predecessor op-start boundary).
@@ -103,14 +103,14 @@ pub struct PyJitCodeMetadata {
     /// equality holds by construction. Sorted ascending by offset; empty for
     /// skeleton / fixture.
     pub pcdep_by_jit_pc: Vec<(usize, Vec<(u8, u16, u16)>)>,
-    /// task#50 phase-1: predecessor-keyed jitcode-pc twin of `depth_at_py_pc`,
+    /// Predecessor-keyed jitcode-pc twin of `depth_at_py_pc`,
     /// built alongside `pcdep_by_jit_pc` with the same `python_pc_for_jitcode_pc`
     /// resolution (marker precedence + op-start predecessor). Predecessor-covers
     /// op offsets, so it agrees with the depth read at the decode seam for every
     /// carried coordinate: it equals
     /// `depth_at_py_pc[python_pc_for_jitcode_pc(jit_pc)]` by construction.
     pub depth_pred_by_jit_pc: Vec<(usize, u16)>,
-    /// task#50 #73-core: trivia-aware STATIC-liveness depth twin, split into the
+    /// Trivia-aware STATIC-liveness depth twin, split into the
     /// SAME two tiers as `python_pc_for_jitcode_pc` — an EXACT-match marker table
     /// (`depth_trivia_marker_by_jit_pc`, block-head precedence) and a PREDECESSOR
     /// op-start table (`depth_trivia_pred_by_jit_pc`, markers EXCLUDED). Each
@@ -134,14 +134,14 @@ pub struct PyJitCodeMetadata {
     pub const_ref_trivia_marker_by_jit_pc: Vec<(usize, Vec<(u16, i64)>)>,
     /// Predecessor-op-start tier of the trivia-aware const Ref slot twin.
     pub const_ref_trivia_pred_by_jit_pc: Vec<(usize, Vec<(u16, i64)>)>,
-    /// #73-core: trivia-aware twin of `result_color_at_pc`, split into the
+    /// Trivia-aware twin of `result_color_at_pc`, split into the
     /// SAME exact-marker / predecessor-op-start tiers as the depth-trivia
     /// twin. Each entry records
     /// `result_color_at_pc[skip_python_trivia_forward(py)]`, including an
     /// out-of-range trailing-trivia overshoot as `None`.
     pub result_color_trivia_marker_by_jit_pc: Vec<(usize, Option<u16>)>,
     pub result_color_trivia_pred_by_jit_pc: Vec<(usize, Option<u16>)>,
-    /// task#73 S5 phase-0: resume-marker twin split into the SAME two tiers as
+    /// Resume-marker twin split into the SAME two tiers as
     /// `python_pc_for_jitcode_pc` — an EXACT-match marker table
     /// (`resume_marker_marker_by_jit_pc`, block-head precedence) and a
     /// PREDECESSOR op-start table (`resume_marker_pred_by_jit_pc`, markers
@@ -151,7 +151,7 @@ pub struct PyJitCodeMetadata {
     /// the tiers stay separate. Empty for skeleton / fixture.
     pub resume_marker_marker_by_jit_pc: Vec<(usize, Option<usize>)>,
     pub resume_marker_pred_by_jit_pc: Vec<(usize, Option<usize>)>,
-    /// task#73 S5 phase-2: after-residual fallthrough-marker twin with the
+    /// After-residual fallthrough-marker twin with the
     /// same exact-marker / predecessor-op-start split as the resume-marker
     /// twin. Each value additionally applies the tracer's semantic
     /// fallthrough rule after skipping Python trivia. Empty for skeleton /
@@ -205,7 +205,7 @@ pub struct PyJitCodeMetadata {
     /// `nlocals + ncells + max_stackdepth`). Sized to the static peak, not
     /// `max(depth_at_pc)` — JIT-traced PCs may not reach `co_stacksize`.
     pub max_stackdepth: usize,
-    /// gh#73 S3.2: predecessor-keyed jitcode-pc const Ref operand-stack slots.
+    /// Predecessor-keyed jitcode-pc const Ref operand-stack slots.
     /// Each entry `(off, slots)` maps a JitCode byte offset to the const
     /// operand-stack slot list of the py_pc that `python_pc_for_jitcode_pc(off)`
     /// returns (block-head marker precedence, else the predecessor op-start
@@ -326,7 +326,7 @@ pub fn portal_red_pre_regalloc_slots(nlocals: usize, max_stackdepth: usize) -> (
     (portal_frame_reg, portal_ec_reg)
 }
 
-/// task#50 deletion-precondition: derive `pc_map[py_pc]` — the `-live-` resume
+/// Derive `pc_map[py_pc]` — the `-live-` resume
 /// marker byte offset — on-demand from the two surviving per-Python-PC tables,
 /// WITHOUT the retired dense `pc_map` Vec.
 ///
@@ -498,7 +498,7 @@ impl PyJitCode {
             .map(|i| table[i].1 as usize)
     }
 
-    /// task#50 phase-1: predecessor index into a jitcode-pc twin — the entry
+    /// Predecessor index into a jitcode-pc twin — the entry
     /// with the largest offset at-or-before `jit_pc`, reproducing
     /// `python_pc_for_jitcode_pc`'s marker-then-first_jit resolution baked into
     /// the twin at build time. `None` when the table is empty (skeleton /
@@ -511,7 +511,7 @@ impl PyJitCode {
         }
     }
 
-    /// task#50 phase-1: pcdep color→slot list keyed directly by a JitCode byte
+    /// The pcdep color→slot list keyed directly by a JitCode byte
     /// offset via the `pcdep_by_jit_pc` predecessor twin. Equals
     /// `pcdep_color_slots[python_pc_for_jitcode_pc(jit_pc)]` by construction for
     /// a carried resume coordinate; `None` when the twin is empty (skeleton /
@@ -525,7 +525,7 @@ impl PyJitCode {
         Self::predecessor_index(search).map(|i| table[i].1.clone())
     }
 
-    /// task#50 phase-1: value-stack depth keyed by a JitCode byte offset via the
+    /// Value-stack depth keyed by a JitCode byte offset via the
     /// `depth_pred_by_jit_pc` predecessor twin. Equals
     /// `depth_at_py_pc[python_pc_for_jitcode_pc(jit_pc)]` by construction for a
     /// carried resume coordinate; `None` when the twin is empty. Predecessor
@@ -539,7 +539,7 @@ impl PyJitCode {
         Self::predecessor_index(search).map(|i| table[i].1)
     }
 
-    /// gh#73 S3.2: const operand-stack slots keyed by a JitCode byte offset via
+    /// The const operand-stack slots keyed by a JitCode byte offset via
     /// the `const_ref_slots_by_jit_pc` predecessor twin. Returns the slots for
     /// a carried resume coordinate; `None` when the twin is empty (skeleton /
     /// fixture). Consumed on the decode-identity path of
@@ -553,7 +553,7 @@ impl PyJitCode {
         Self::predecessor_index(search).map(|i| table[i].1.clone())
     }
 
-    /// task#50 #73-core: trivia-aware STATIC-liveness depth keyed by a JitCode
+    /// Trivia-aware STATIC-liveness depth keyed by a JitCode
     /// byte offset, resolved with the SAME two tiers as
     /// `python_pc_for_jitcode_pc`: an EXACT marker match first (block-head
     /// precedence), else a PREDECESSOR scan of the op-start table (markers
@@ -610,7 +610,7 @@ impl PyJitCode {
         Self::predecessor_index(search).map(|i| pred[i].1.as_slice())
     }
 
-    /// #73-core: trivia-aware result color keyed by a JitCode byte offset,
+    /// Trivia-aware result color keyed by a JitCode byte offset,
     /// resolved with the SAME two tiers as `python_pc_for_jitcode_pc`.
     /// Equals
     /// `result_color_at_pc[skip_python_trivia_forward(python_pc_for_jitcode_pc(jit_pc))]`
@@ -630,7 +630,7 @@ impl PyJitCode {
         Self::predecessor_index(search).and_then(|i| pred[i].1)
     }
 
-    /// task#73 S5 phase-0: codewrite-time resume marker keyed by a JitCode byte
+    /// Codewrite-time resume marker keyed by a JitCode byte
     /// offset, resolved with the SAME two tiers as `python_pc_for_jitcode_pc`:
     /// an EXACT marker match first (block-head precedence), else a PREDECESSOR
     /// scan of the op-start table (markers excluded).
@@ -647,7 +647,7 @@ impl PyJitCode {
         Self::predecessor_index(search).and_then(|i| pred[i].1)
     }
 
-    /// task#73 S5 phase-2: codewrite-time after-residual fallthrough marker
+    /// Codewrite-time after-residual fallthrough marker
     /// keyed by a JitCode byte offset, resolved with the SAME two tiers as
     /// `python_pc_for_jitcode_pc`: an EXACT marker match first (block-head
     /// precedence), else a PREDECESSOR scan of the op-start table (markers
@@ -702,7 +702,7 @@ impl PyJitCode {
         Self::predecessor_index(search).and_then(|i| pred[i].1)
     }
 
-    /// task#50 #73-core: whether the trivia depth twin carries entries. `false`
+    /// Whether the trivia depth twin carries entries. `false`
     /// for skeleton / fixture installs where both tiers are
     /// empty. The audit uses this to distinguish an in-table `None` (overshoot,
     /// which must equal the raw reader's `None`) from an empty-twin `None` (where
@@ -736,7 +736,7 @@ impl PyJitCode {
     /// The carried word is preferred only when it is a `-live-`-anchored
     /// coordinate ([`JitCode::can_decode_live_vars`]).
     pub fn resolve_resume_pc_with_jitcode_pc(&self, carried: i32, op_live: u8) -> Option<usize> {
-        // #73 S3.5: a depth-0 branch guard may carry its `orgpc` tagged into the
+        // A depth-0 branch guard may carry its `orgpc` tagged into the
         // word's negative space; expand it to the block-head marker the baseline
         // would have carried before any offset use. No-op for offsets /
         // NO_JITCODE_PC (the flip-off case), so byte-identical when off.

--- a/pyre/pyre-jit-trace/src/pyjitpl.rs
+++ b/pyre/pyre-jit-trace/src/pyjitpl.rs
@@ -1,7 +1,7 @@
 //! `semantic_fallthrough_pc` — the tracer's auto-advance PC rule.
 //!
 //! The trait meta-interpreter (`PyreMetaInterp`, RPython MetaInterp
-//! pyjitpl.py:2371) is retired (gap-10 of issue #73 Phase 6); the FBW walker
+//! pyjitpl.py) is retired; the FBW walker
 //! (`jitcode_dispatch`) is the sole tracer.  Only the shared fallthrough-PC
 //! rule the codewriter and runtime both key off survives in this module.
 

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -1449,7 +1449,7 @@ pub(crate) fn bridge_semantic_maps_at_with_jitcode_pc(
             };
         };
         let payload = &jc.payload;
-        // #73 S3.5: expand a tagged branch `orgpc` word to the block-head marker
+        // Expand a tagged branch `orgpc` word to the block-head marker
         // BEFORE the `>= 0` / offset uses below — a tagged NEGATIVE word cast to
         // usize would otherwise be a huge OOB index. No-op for offsets /
         // NO_JITCODE_PC (flip-off), so byte-identical when off.
@@ -1529,14 +1529,14 @@ pub(crate) fn const_ref_slots_at_pc_at(jitcode_index: i32, jitcode_pc: i32) -> V
         let Some(jc) = sd.jitcodes.get(jitcode_index as usize) else {
             return Vec::new();
         };
-        // #73 S3.5: expand a tagged branch `orgpc` word to the block-head marker
+        // Expand a tagged branch `orgpc` word to the block-head marker
         // before the `>= 0` / offset uses below. No-op for offsets /
         // NO_JITCODE_PC (flip-off), so byte-identical when off.
         let jitcode_pc = crate::jitcode_dispatch::expand_branch_carried(&jc.payload, jitcode_pc);
         if jitcode_pc != majit_ir::resumedata::NO_JITCODE_PC && jitcode_pc >= 0 {
             let jp = jitcode_pc as usize;
             if jc.payload.jitcode.can_decode_live_vars(jp, sd.op_live) {
-                // gh#73 S3.2: source the const slots directly from the carried
+                // Source the const slots directly from the carried
                 // genuine `jitcode_pc` via the predecessor-keyed twin — the same
                 // decode-identity shape the pcdep/depth twins use at
                 // `bridge_semantic_maps_at_with_jitcode_pc`. A colored jitcode
@@ -8569,7 +8569,7 @@ impl JitState for PyreJitState {
             frame0.values.len(),
             frame0.pc,
         );
-        // gap-10 GotoIfNotValueNotConcrete (bridge sub-class): the resume
+        // GotoIfNotValueNotConcrete (bridge sub-class): the resume
         // data carries the concrete runtime value for every live frame
         // register, but the consume_boxes loops below keep only the OpRef
         // and DROP the concrete — so a bridge resume leaves loop-carried
@@ -8584,7 +8584,7 @@ impl JitState for PyreJitState {
         // the concrete is a trace-time shadow only, so the optimizer does
         // NOT const-fold the loop-variant value).  Default-ON (`=0` opts
         // out) once validated, mirroring the LoadGlobal-fold / multiframe
-        // gap-10 flips; the opt-out keeps the prior symbolic-bridge
+        // flips; the opt-out keeps the prior symbolic-bridge
         // behavior available for A/B.
         let seed_bridge_locals = std::env::var("PYRE_FBW_BRIDGE_LOCAL_SEED").as_deref() != Ok("0");
         // For kept-stack branch guards the body-internal marker's
@@ -8762,7 +8762,7 @@ impl JitState for PyreJitState {
                         // (`live_local_values`, not the off-heap decoded
                         // array) so the seeded bridge walk can fold a branch
                         // derived from it without risking a moved-pointer
-                        // stamp (gap-10 bridge sub-class; see seed note above).
+                        // stamp (bridge sub-class; see seed note above).
                         // Skip a NULL (`GcRef(0)`) source, matching the
                         // deferred-overlay seed below: a loop-carried local
                         // held in a register at an interior guard reads NULL

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -5,7 +5,7 @@
 //! JitCode body, combining symbolic IR recording
 //! with the per-step concrete frame snapshot.  Any location the walk declines
 //! re-interprets without JIT (the trait `PyreMetaInterp` interpret loop is
-//! retired, gap-10 of issue #73 Phase 6).
+//! retired).
 
 use majit_metainterp::{MetaInterp, TraceAction, TraceCtx};
 use pyre_interpreter::CodeObject;
@@ -530,7 +530,7 @@ fn start_pc_is_loop_header(code: &pyre_interpreter::CodeObject, start_pc: usize)
 /// walker walks the per-CodeObject JitCode body, recording symbolic IR against
 /// the per-step concrete frame snapshot.  A location the walk declines
 /// re-interprets without JIT (the trait `PyreMetaInterp` interpret loop is
-/// retired, gap-10 of issue #73 Phase 6).
+/// retired).
 pub fn trace_bytecode<Sym: WalkSym>(
     meta: &mut MetaInterp<PyreMeta>,
     sym: &mut Sym,
@@ -604,11 +604,9 @@ pub fn trace_bytecode<Sym: WalkSym>(
     // the interpreter resumes AFTER the walked region, not from its start.
     concrete_frame.set_last_instr_from_next_instr(lasti_pc);
     let w_code = concrete_frame.pycode;
-    // Issue #73 walker-as-tracer foundation probe (read-only).
-    // `PYRE_DUMP_PERFN_JITCODE=1` dumps the per-CodeObject JitCode body
-    // — the byte stream the walker-as-tracer must learn to walk so that
-    // `miframe.pc == jitcode_pc` and `pc_map` can retire.  See
-    // `project_issue73_architecture_walker_as_tracer_2026_05_28`.
+    // Read-only diagnostic: `PYRE_DUMP_PERFN_JITCODE=1` dumps the
+    // per-CodeObject JitCode body — the byte stream the walker-as-tracer walks
+    // so that `miframe.pc == jitcode_pc`.
     if std::env::var_os("PYRE_DUMP_PERFN_JITCODE").is_some() {
         dump_perfn_jitcode_for_trace(w_code, lasti_pc);
     }
@@ -652,15 +650,11 @@ pub fn trace_bytecode<Sym: WalkSym>(
         finish_trace_namespace_dependency(meta);
         return (action, concrete_frame);
     }
-    // Issue #73 walker-as-tracer foundation probe (slice #1, gated).
-    // `PYRE_WALK_PERFN_JITCODE=1` attempts to walk the per-CodeObject
-    // JitCode body via `dispatch_via_miframe` from the resume entry pc,
-    // logs how far the symbolic walk gets (terminator outcome vs first
-    // `DispatchError` stop), then aborts the trace.  Default-off → zero
-    // production change.  Produces the Path A (payload-seeding) gap
-    // inventory on a live bench now that walk-capability gaps #1/#2/#3
-    // are closed.  See
-    // `project_issue73_architecture_walker_as_tracer_2026_05_28`.
+    // Gated diagnostic: `PYRE_WALK_PERFN_JITCODE=1` attempts to walk the
+    // per-CodeObject JitCode body via `dispatch_via_miframe` from the resume
+    // entry pc, logs how far the symbolic walk gets (terminator outcome vs
+    // first `DispatchError` stop), then aborts the trace.  Default-off → zero
+    // production change.
     // The generic probe is gated on `carrier.is_none()` because multi-frame
     // bridge resumes are handled by the dedicated carrier walkers above.
     if carrier.is_none() && std::env::var_os("PYRE_WALK_PERFN_JITCODE").is_some() {
@@ -668,9 +662,9 @@ pub fn trace_bytecode<Sym: WalkSym>(
         finish_trace_namespace_dependency(meta);
         return (TraceAction::Abort, concrete_frame);
     }
-    // Issue #73 Phase 5 production flip: the per-CodeObject JitCode body is
-    // traced via the authoritative full-body walk — the walker-as-tracer
-    // path that makes `miframe.pc == jitcode_pc` and lets `pc_map` retire.
+    // The per-CodeObject JitCode body is traced via the authoritative
+    // full-body walk — the walker-as-tracer path that makes
+    // `miframe.pc == jitcode_pc`.
     //
     // A green key in `FBW_DECLINED_KEYS` had a prior walk fail on a
     // structural walker limitation (the recurring error classes in
@@ -694,7 +688,7 @@ pub fn trace_bytecode<Sym: WalkSym>(
     (TraceAction::Abort, concrete_frame)
 }
 
-/// Issue #73 walker-as-tracer foundation probe (slice #1).
+/// Read-only walker-as-tracer diagnostic probe.
 ///
 /// Attempts to walk the per-CodeObject JitCode body via
 /// [`crate::jitcode_dispatch::dispatch_via_miframe`] from the resume
@@ -721,7 +715,7 @@ pub fn trace_bytecode<Sym: WalkSym>(
 /// These name the jitcode register colors the loop body reads its
 /// loop-invariant pycode (`gr`) and frame/ec (`rr`) from.  A mid-loop walk
 /// entering PAST the merge point never executes it, so those colors are
-/// left `OpRef::NONE` unless explicitly seeded — the 51d.1 / B1 blocker.
+/// left `OpRef::NONE` unless explicitly seeded.
 ///
 /// Operand layout `cIRFIRF`: jdindex(`c`, 1 byte) followed by six
 /// count-prefixed register lists `gi, gr, gf, ri, rr, rf`.  Returns `None`
@@ -1724,7 +1718,7 @@ fn run_perfn_walk<Sym: WalkSym>(
     // read would fall through to the nonstandard GETFIELD_GC leg.  Falls back
     // to `const_ref` only when no virtualizable is bound.
     //
-    // NOTE (51d.1 root cause): seeding r0 is NECESSARY but not sufficient for
+    // NOTE: seeding r0 is NECESSARY but not sufficient for
     // the mid-loop resume entry (pc=107, after the loop-header
     // `jit_merge_point` @ pc=94).  The loop body reads its vable from a
     // post-merge LOOP-INPUT register (the merge-point reds), NOT from r0; that
@@ -1733,11 +1727,11 @@ fn run_perfn_walk<Sym: WalkSym>(
     // `GcRef(usize::MAX)` sentinel → `is_nonstandard_virtualizable` takes the
     // nonstandard leg → `getarrayitem_vable` returns `Value::Void` even though
     // the virtualizable SHADOW entry is correct.  Closing that needs the live
-    // loop-input registers seeded at walk entry (task #53), not just r0.
+    // loop-input registers seeded at walk entry, not just r0.
     let frame_box = ctx
         .standard_virtualizable_box()
         .unwrap_or_else(|| ctx.const_ref(cf_addr as i64));
-    // 51d.1 (B1 blocker): seed the loop's live INPUT registers so the
+    // Seed the loop's live INPUT registers so the
     // post-merge-point loop body resolves its loop-invariant reads.  The
     // walk enters PAST the loop-header `jit_merge_point`, which would
     // otherwise leave those colors `OpRef::NONE` (→ sentinel concrete →
@@ -2596,7 +2590,7 @@ fn run_perfn_walk<Sym: WalkSym>(
     Some((entry, code_len, walk_result))
 }
 
-/// Issue #73 walker-as-tracer foundation probe (slice #1, read-only).
+/// Read-only walker-as-tracer diagnostic probe, non-authoritative.
 ///
 /// Runs the per-CodeObject full-body walk via [`run_perfn_walk`] in
 /// non-authoritative mode, logs how far the symbolic walk got (terminator
@@ -3141,14 +3135,14 @@ enum WalkJournals {
     Keep,
 }
 
-/// Issue #73 production full-body tracer (Phase 5 flip).
+/// Production full-body tracer.
 ///
 /// Drives the per-CodeObject JitCode body via [`run_perfn_walk`] in
 /// authoritative mode AS the production trace — the walk IS the concrete
 /// execution, so unlike the probe it keeps the recorded trace.  Maps the
 /// walk outcome to a [`TraceAction`] for the caller to compile.
 ///
-/// Conservative mapping (first slice): only `CloseLoop` — the validated
+/// Conservative mapping: only `CloseLoop` — the validated
 /// end-to-end case (the four loop benches close under authoritative) — is
 /// mapped to a real `CloseLoopWithArgs`; every other outcome (`Terminate`
 /// finish-arg recovery, `SubReturn`/`SubRaise`, `SwitchToBlackhole`, any
@@ -3422,13 +3416,12 @@ fn full_body_walk_trace<Sym: WalkSym>(
     }
 }
 
-/// Issue #73 walker-as-tracer foundation probe.
+/// Walker-as-tracer diagnostic dump.
 ///
-/// Dumps the per-CodeObject JitCode body that the walker-as-tracer must
-/// walk for `miframe.pc == jitcode_pc` (the precondition for retiring
-/// `pc_map`).  The per-CodeObject JitCode is built BEFORE this point by
-/// `register_portal_jitdriver` → `make_jitcodes`
-/// (`pyre/pyre-jit/src/eval.rs:3924`), so it is available here.
+/// Dumps the per-CodeObject JitCode body the walker-as-tracer walks for
+/// `miframe.pc == jitcode_pc`.  The per-CodeObject JitCode is built BEFORE
+/// this point by `register_portal_jitdriver` → `make_jitcodes`
+/// (`pyre/pyre-jit/src/eval.rs`), so it is available here.
 ///
 /// Read-only: logs the body op stream + entry offset, mutates nothing.
 fn dump_perfn_jitcode_for_trace(w_code: *const (), start_pc: usize) {

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -706,8 +706,7 @@ pub fn trace_bytecode<Sym: WalkSym>(
 /// this surfaces the next blocker for the full-body walk — the Path A
 /// payload-seeding gap (an op reading a register slot the entry never
 /// seeded, e.g. a `goto_if_not` over a non-concrete Int produced by an
-/// unfolded `residual_call`).  See
-/// `project_issue73_architecture_walker_as_tracer_2026_05_28`.
+/// unfolded `residual_call`).
 ///
 /// Decode the loop-header `jit_merge_point` that governs a bridge resume
 /// coordinate and return its green-ref (`gr`) and red (`rr`) register lists.

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -2931,8 +2931,7 @@ impl MIFrame {
         // dual-write. Any divergence here means a code path updated one
         // shadow without the other — most likely load_local_value's lazy
         // fallback (trace_opcode.rs) which writes registers_r
-        // but does NOT call set_virtualizable_box_at. See
-        // memory/phase_1_4_cand_a_landed_raise_catch_diagnostic_2026_04_26.md.
+        // but does NOT call set_virtualizable_box_at.
         if std::env::var("PYRE_PROBE_SNAPSHOT").ok().as_deref() == Some("1") {
             let num_static = ctx
                 .virtualizable_info()

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -378,7 +378,7 @@ unsafe fn type_object_custom_trace(obj_addr: usize, f: &mut dyn FnMut(*mut majit
 
 /// Reclaim the Rust-owned, out-of-line `weak_subclasses` container of a swept
 /// heap type. `name` is a GC-managed leaf storage box (`NameStorage`, off-GC
-/// storage epic S5) reclaimed by its own box tid's drop glue — freeing it here
+/// storage) reclaimed by its own box tid's drop glue — freeing it here
 /// too would double-free a box swept before its owner. `mro_w` is a GC-managed
 /// `FixedObjectArray` reclaimed by the collector and must not be freed here. The
 /// managed namespace object is also reclaimed by the collector, while the
@@ -464,7 +464,7 @@ unsafe fn dict_object_custom_trace(obj_addr: usize, f: &mut dyn FnMut(*mut majit
     let w_dict = obj_addr as pyre_object::PyObjectRef;
     let strategy = unsafe { pyre_object::dictmultiobject::w_dict_get_strategy(w_dict) };
     // Keep the stable leaf storage box alive by forwarding its owning
-    // `dstorage` field slot (off-GC storage epic S2). The box has no walker
+    // `dstorage` field slot (off-GC storage). The box has no walker
     // of its own; `walk_gc_refs` below forwards the interior PyObjectRef
     // slots, matching the mapdict / set-items leaf-storage pattern. Only the
     // storage-box strategies own their `dstorage`: a MapDictStrategy
@@ -493,7 +493,7 @@ unsafe fn dict_object_custom_trace(obj_addr: usize, f: &mut dyn FnMut(*mut majit
 }
 
 /// Custom trace for `W_BytesObject`. `data` points at a GC-managed leaf storage
-/// box (`Vec<u8>`, no inner refs, off-GC storage epic S4). Forward the field
+/// box (`Vec<u8>`, no inner refs, off-GC storage). Forward the field
 /// slot so a major GC greys the box; the box tid's own drop glue reclaims the
 /// buffer on sweep. A no-GC-hook fallback allocation is not collector-owned, so
 /// the guard skips it.
@@ -509,7 +509,7 @@ unsafe fn bytes_object_custom_trace(obj_addr: usize, f: &mut dyn FnMut(*mut maji
 }
 
 /// Custom trace for `W_BytearrayObject`. Same GC-managed leaf storage box as
-/// `W_BytesObject` (off-GC storage epic S4).
+/// `W_BytesObject` (off-GC storage).
 unsafe fn bytearray_object_custom_trace(obj_addr: usize, f: &mut dyn FnMut(*mut majit_ir::GcRef)) {
     let ba = unsafe { &mut *(obj_addr as *mut pyre_object::bytearrayobject::W_BytearrayObject) };
     f(&mut ba.ob_header.w_class as *mut pyre_object::PyObjectRef as *mut majit_ir::GcRef);
@@ -586,7 +586,7 @@ unsafe fn object_object_custom_trace(obj_addr: usize, f: &mut dyn FnMut(*mut maj
 ///     Vec<(PyObjectRef, PyObjectRef)> — both halves of every entry
 ///
 /// Each of the three is now a GC-managed non-moving storage box (off-GC
-/// storage epic S3), so this trace does two things: it forwards each
+/// storage), so this trace does two things: it forwards each
 /// box-pointer field slot to grey the box (keeping it off the sweep list,
 /// as `object_object_custom_trace` does for `storage`), then walks the box
 /// interiors to forward their movable values.  The interior walk lives in
@@ -1462,7 +1462,7 @@ fn build_gc() -> Box<dyn majit_gc::GcAllocator> {
     // instances are the same Rust struct, so the vtable map sends
     // both PyTypes to `function_tid`. No `.with_destructor_fn`: a mortal
     // function's `name` box is reclaimed by its own tid's drop glue (off-GC
-    // storage epic S5); a holder destructor would double-free a box swept before
+    // storage); a holder destructor would double-free a box swept before
     // its owner.
     let function_tid = gc.register_type(TypeInfo::object_subclass_with_gc_ptrs(
         std::mem::size_of::<pyre_interpreter::function::Function>(),
@@ -1584,7 +1584,7 @@ fn build_gc() -> Box<dyn majit_gc::GcAllocator> {
         <pyre_object::typedef::W_MemberDescr as pyre_object::lltype::PyreClassPyTypeOf>::DESCRIPTOR,
     );
     // W_BytesObject (immutable byte sequence) carries `data`, a `*const Vec<u8>`
-    // GC-managed storage box (off-GC storage epic S4). The custom trace forwards
+    // GC-managed storage box (off-GC storage). The custom trace forwards
     // that field slot so the box stays live; no `.with_destructor_fn` — the box
     // tid's drop glue is the sole reclaimer, exactly as the set-items box owns
     // its reclamation. A sweep-time bytes destructor would put two reclaimers on
@@ -1626,7 +1626,7 @@ fn build_gc() -> Box<dyn majit_gc::GcAllocator> {
     // hook so the GC updates those indirect key/value slots just as it
     // updates inline object fields.
     // No `.with_destructor_fn`: a regular dict's `dstorage` is a GC-managed
-    // storage box (off-GC storage epic S2) whose own tid drop glue
+    // storage box (off-GC storage) whose own tid drop glue
     // (`storage_box_destructor`) is the sole reclaimer, exactly as the set
     // items box owns its reclamation. A sweep-time dict destructor would race
     // that box on the destructor list — freeing `dstorage` after the box was
@@ -2111,7 +2111,7 @@ fn build_gc() -> Box<dyn majit_gc::GcAllocator> {
     // hook so the GC walks all three indirect storages — matching
     // the W_DictObject pattern.
     // No `.with_destructor_fn`: all three storages are now GC-managed storage
-    // boxes (off-GC storage epic S3) whose own tid drop glue
+    // boxes (off-GC storage) whose own tid drop glue
     // (`storage_box_destructor`) is the sole reclaimer. A sweep-time module-dict
     // destructor would race those boxes on the destructor list and double-free —
     // exactly the regular-dict case above.
@@ -2909,7 +2909,7 @@ fn build_gc() -> Box<dyn majit_gc::GcAllocator> {
         pyre_object::gc_storage::storage_box_destructor::<pyre_object::setobject::SetItemsStorage>,
         pyre_object::setobject::set_set_items_gc_type_id,
     );
-    // Regular-dict `dstorage` storage boxes (off-GC storage epic S2).
+    // Regular-dict `dstorage` storage boxes (off-GC storage).
     // dictmultiobject.py:47 `dstorage` erases an `r_dict` = GcStruct("dicttable")
     // (rdict.py:210); each concrete strategy backs it with a native container
     // now living in a GC-managed leaf box. `dict_object_custom_trace` greys the
@@ -2966,7 +2966,7 @@ fn build_gc() -> Box<dyn majit_gc::GcAllocator> {
         pyre_object::gc_storage::storage_box_destructor::<pyre_object::celldict::ModuleDictStrategy>,
         pyre_object::celldict::set_module_dict_strategy_gc_type_id,
     );
-    // bytes / bytearray `data` storage box (off-GC storage epic S4). A leaf
+    // bytes / bytearray `data` storage box (off-GC storage). A leaf
     // `Vec<u8>` (no inner refs) shared by both types; `bytes_object_custom_trace`
     // / `bytearray_object_custom_trace` grey it through the `data` field slot and
     // the box tid's drop glue reclaims the buffer on sweep. Keep this id at the
@@ -2989,7 +2989,7 @@ fn build_gc() -> Box<dyn majit_gc::GcAllocator> {
         pyre_object::unicodeobject::set_unicode_value_gc_type_id,
     );
     // Mortal `name` string storage box shared by heap `W_TypeObject` and user
-    // `Function` (off-GC storage epic S5). A leaf `String` (no inner refs); the
+    // `Function` (off-GC storage). A leaf `String` (no inner refs); the
     // type's `type_object_custom_trace` name-slot greying and the function's
     // `FUNCTION_NAME_OFFSET` gc-pointer edge grey it, and the box tid's drop glue
     // reclaims the buffer on sweep. Only mortal holders box their name; immortal
@@ -3746,9 +3746,9 @@ pub struct PyPyJitDriver {
     /// rlib/jit.py:690 — `should_unroll_one_iteration` hook callable.
     pub should_unroll_one_iteration: Option<fn(usize, bool, pyre_object::PyObjectRef) -> bool>,
     /// rlib/jit.py:688 — `confirm_enter_jit` hook (concrete pyre signature
-    /// is wired alongside S1.3 specialize_call; until then, `None`).
+    /// is wired alongside specialize_call; until then, `None`).
     pub confirm_enter_jit: Option<fn() -> bool>,
-    /// rlib/jit.py:689 — `can_never_inline` hook (signature ported with S1.3).
+    /// rlib/jit.py:689 — `can_never_inline` hook (signature ported).
     pub can_never_inline: Option<fn() -> bool>,
 }
 
@@ -11685,8 +11685,7 @@ result = fib(12)
                   adds a native frame per recursive compiled entry. At the low JIT \
                   threshold used here, g(9)×2 runs enough compiled invocations to \
                   overflow the 2 MiB default cargo-test thread stack. Dynasm is \
-                  unaffected (jmp trampoline). See \
-                  memory/fib_recursive_sigbus_2026_04_19.md."
+                  unaffected (jmp trampoline)."
     )]
     fn test_recursive_global_reads_do_not_reuse_force_cache_across_global_mutation() {
         let _jit_params = TestJitParamsGuard::low_threshold();

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -4599,8 +4599,8 @@ fn unpack_merge_point_jit(
 /// each residual (`self.next`, `items.append`) concretely on the shared reds,
 /// so this advances the live iterator and grows the live list in place; the
 /// Rust caller loop then resumes from the advanced state (cooperative drain).
-/// Slice-1 discards the recorded trace — compiled-loop reuse and blackhole
-/// entry are later activation slices.
+/// The recorded trace is discarded — compiled-loop reuse and blackhole
+/// entry are not wired.
 fn drive_unpack_iterable_trace(
     green_key: u64,
     greenkey_raw: pyre_object::PyObjectRef,

--- a/pyre/pyre-jit/src/jit/assembler.rs
+++ b/pyre/pyre-jit/src/jit/assembler.rs
@@ -1630,14 +1630,14 @@ fn dispatch_residual_call(
     // `check_forces_virtual_or_virtualizable()` /
     // `extraeffect == LoopInvariant`.
     //
-    // Parity #14 Slice C.2+C.3: `CallFlavor::Pure*` now flows through
+    // `CallFlavor::Pure*` flows through
     // the canonical `residual_call_*_canonical_via_target_with_effect_info`
     // catchalls below.  `effect_info_for_call_flavor(Pure*)`
     // (`flatten.rs`) returns the matching `EF_ELIDABLE_*` per
     // `call.py:292-299`'s 3-way pick, which lands on the
     // calldescr's `extra_info`; the canonical
     // `BC_RESIDUAL_CALL_*_{I,R,F}` walker
-    // (`majit-metainterp/src/pyjitpl/dispatch.rs` Slice C.1) reads
+    // (`majit-metainterp/src/pyjitpl/dispatch.rs`) reads
     // `effectinfo.check_is_elidable()` and routes the result through
     // `record_result_of_call_pure` mirroring `pyjitpl.py:2111-2115`.
     // ReleaseGil + Ref still panics per `resoperation.py:1243-1244 # no
@@ -2727,10 +2727,10 @@ mod tests {
 
     #[test]
     fn assemble_residual_call_irf_f_supports_pure_float_flavor() {
-        // Parity #14 Slice C.2+C.3: CallFlavor::Pure now routes through
+        // CallFlavor::Pure routes through
         // the canonical `BC_RESIDUAL_CALL_IRF_F` (=161) with the
         // calldescr carrying ElidableCanRaise.  The walker
-        // (`pyjitpl/dispatch.rs` Slice C.1) reads
+        // (`pyjitpl/dispatch.rs`) reads
         // `effectinfo.check_is_elidable()` and runs
         // `record_result_of_call_pure` mirroring `pyjitpl.py:2111-2121`.
         let mut ssarepr = SSARepr::new("residual_call_irf_f");

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -4291,7 +4291,7 @@ fn filter_liveness_in_place(
             "filter_liveness_in_place: walker_tracked_pc_live_indices must be Some with one \
              entry per Python PC since label retirement retired per-PC label emission",
         );
-    // FOR_ITER body PCs: used to scope Slice B's per-PC frame-live
+    // FOR_ITER body PCs: used to scope the per-PC frame-live
     // re-add below. While-loop body PCs are excluded to prevent
     // perf regressions (wider liveness → more live-across-loop colors
     // → more spills).
@@ -13449,7 +13449,7 @@ impl CodeWriter {
             py_floor_by_jit_pc.insert(0, (0, 0));
         }
 
-        // task#50 sparse carry-forward sidecar: capture ONLY the py_pcs whose
+        // Sparse carry-forward sidecar: capture ONLY the py_pcs whose
         // dense marker the on-demand `derive_resume_marker` derivation cannot
         // reproduce from `first_jit_pc_by_py_pc` + `block_head_py_by_jit_pc`.
         // The derivation covers a py's own first op AND the trivia / next-op
@@ -13503,7 +13503,7 @@ impl CodeWriter {
             })
             .collect();
 
-        // task#50 phase-1: predecessor-keyed jitcode-pc twins of
+        // Predecessor-keyed jitcode-pc twins of
         // `pcdep_color_slots` and `depth_at_pc`, resolving a JitCode byte
         // offset the way `python_pc_for_jitcode_pc` does — the block-head marker
         // match first, else the largest `first_jit_pc_by_py_pc[py]` at-or-before
@@ -13521,9 +13521,9 @@ impl CodeWriter {
         let mut pcdep_by_jit_pc: Vec<(usize, Vec<(u8, u16, u16)>)> = Vec::new();
         let mut const_ref_slots_by_jit_pc: Vec<(usize, Vec<(u16, i64)>)> = Vec::new();
         let mut depth_pred_by_jit_pc: Vec<(usize, u16)> = Vec::new();
-        // task#50 #73-core: trivia-aware predecessor twin of the STATIC dense
+        // Trivia-aware predecessor twin of the STATIC dense
         // liveness depth.  The ENCODE-side branch-resume depth reader
-        // (`branch_resume_target_stack_depth`, jitcode_dispatch.rs:9329) does NOT
+        // (`branch_resume_target_stack_depth`) does NOT
         // read `depth_at_py_pc[inv(target)]` directly — it advances the inverted
         // py through `skip_python_trivia_forward` (a not-taken branch coordinate
         // can land on a `NOT_TAKEN`/`Cache` trivia op) BEFORE indexing the
@@ -13535,7 +13535,7 @@ impl CodeWriter {
         // `ExtendedArg`/`Resume`/`Nop`/`Cache`/`NotTaken` then record that opcode's
         // static depth.  A predecessor lookup then equals
         // `liveness_for(code).depth_at_py_pc()[skip_python_trivia_forward(inv(jit_pc))]`.
-        // task#50 #73-core: the trivia twin is split into the SAME two tiers as
+        // The trivia twin is split into the SAME two tiers as
         // `python_pc_for_jitcode_pc` — a marker table matched EXACTLY (the block
         // -head precedence tier, `block_head_py_by_jit_pc`'s depth analog) and an
         // op-start table matched by PREDECESSOR (`first_jit_pc_by_py_pc`'s depth

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -8156,8 +8156,7 @@ impl CodeWriter {
                         // registers inside the trace-tracked range (`registers_r`
                         // + `symbolic_stack`), so guards fired across the op (e.g.
                         // `GUARD_NOT_FORCED_2` after a helper call) capture the
-                        // lhs/rhs values in fail_args. See
-                        // `memory/pyre_trace_temp_reg_tracking_gap_2026_04_19.md`.
+                        // lhs/rhs values in fail_args.
                         Instruction::BinaryOp { op } => {
                             let op_kind = op.get(op_arg);
                             let _ = binary_op_tag(op_kind)

--- a/pyre/pyre-jit/src/jit/flatten.rs
+++ b/pyre/pyre-jit/src/jit/flatten.rs
@@ -3668,11 +3668,11 @@ where
 }
 
 /// Construct the BINARY_OP-family `residual_call_ir_r` Insn from
-/// raw register indices.  Production codewriter callsite (Slice
-/// micro-slice 3) bypasses the SpaceOperation→Insn round-trip and
+/// raw register indices.  The production codewriter callsite bypasses
+/// the SpaceOperation→Insn round-trip and
 /// emits this Insn directly into the SSARepr, replacing the prior
 /// `emit_residual_call(binary_op_fn_idx, ...)` + matching graph
-/// dual-write at codewriter.rs:5335-5378.
+/// dual-write in codewriter.rs.
 ///
 /// Mirrors [`lower_binary_op_hlop_to_insn`]'s output shape: the
 /// post-walker dispatcher and the walker-time direct push both produce
@@ -4937,12 +4937,12 @@ fn build_residual_call_r_i_insn_from_operands(
 /// Single HLOp opname `setitem`.  Returns `None` for non-`setitem`
 /// opnames or non-void-result HLOps.
 ///
-/// SETITEM retirement: same per-family
-/// pattern as micro-slices 3-5.  Differences vs the prior shapes:
+/// SETITEM retirement: same per-family pattern as the earlier
+/// families.  Differences vs the prior shapes:
 ///   * void Insn (no result Register).
 ///   * 3-element ListR (vs 2 for BINARY_OP/COMPARE_OP, 1 for BOOL).
 ///   * MayForce flavor (matches the prior dual-write at
-///     codewriter.rs:5274).
+///     codewriter.rs).
 pub fn lower_setitem_hlop_to_insn<F, LC>(
     op: &super::flow::SpaceOperation,
     ctx: &LoweringContext,
@@ -8902,8 +8902,7 @@ mod tests {
         // the Insn produced by feeding the equivalent dual-write
         // `residual_call_ir_r` SpaceOperation through
         // `flatten_op_to_insn`.  This is the foundational invariant
-        // for retiring the dual-write + inline emit in micro-slice 3
-        // of the epic.
+        // for retiring the dual-write + inline emit.
         let lhs = Variable::new(VariableId(0), Kind::Ref);
         let rhs = Variable::new(VariableId(1), Kind::Ref);
         let result = Variable::new(VariableId(2), Kind::Ref);

--- a/pyre/pyre-jit/src/jit/simplify.rs
+++ b/pyre/pyre-jit/src/jit/simplify.rs
@@ -1312,8 +1312,7 @@ mod tests {
 
     /// The faithful (operations-based) eliminate_empty_blocks collapses a
     /// NON-dead empty forwarding block that carries args — the shape
-    /// `remove_trivial_links` cannot (its incoming link has args).  Codex P2,
-    /// PR #127.
+    /// `remove_trivial_links` cannot (its incoming link has args).
     #[test]
     fn eliminate_empty_blocks_collapses_empty_forwarder_with_args() {
         // start -> empty(ve) -> next(vn);  empty has no operations and forwards

--- a/pyre/pyre-jit/tests/gc_stress.rs
+++ b/pyre/pyre-jit/tests/gc_stress.rs
@@ -626,7 +626,7 @@ assert result == 300, result
 }
 
 /// A `bytes` / `bytearray` object's `data` buffer is a GC-managed leaf storage
-/// box (off-GC storage epic S4): `bytes_object_custom_trace` /
+/// box (off-GC storage): `bytes_object_custom_trace` /
 /// `bytearray_object_custom_trace` grey it through the `data` field slot, and
 /// the box tid's drop glue reclaims it on sweep. Regression for two failure
 /// modes the migration off `malloc_typed`-immortal holders could introduce: a
@@ -692,7 +692,7 @@ assert result == 2325, result
 }
 
 /// A `str` SUBCLASS instance's WTF-8 `value` buffer is a GC-managed leaf storage
-/// box (off-GC storage epic S5): the mortal subclass holder is GC-swept and its
+/// box (off-GC storage): the mortal subclass holder is GC-swept and its
 /// `value` gc-pointer edge greys the box, whose tid drop glue reclaims the
 /// buffer on sweep. Regression for the migration off the per-type
 /// `unicode_object_destructor`: a subclass string reachable only through a list
@@ -747,7 +747,7 @@ assert result == 1428, result
 
 /// A mortal (user) `Function`'s `name` string and a heap `W_TypeObject`'s `name`
 /// string are GC-managed leaf storage boxes shared under one `NameStorage` tid
-/// (off-GC storage epic S5): the function's `FUNCTION_NAME_OFFSET` gc-pointer
+/// (off-GC storage): the function's `FUNCTION_NAME_OFFSET` gc-pointer
 /// edge and the type's `type_object_custom_trace` name-slot greying keep the box
 /// live, and the box tid's drop glue is the sole reclaimer. Regression for the
 /// migration off `function_object_destructor` / the type destructor's name-free:

--- a/pyre/pyre-object/src/bytesobject.rs
+++ b/pyre/pyre-object/src/bytesobject.rs
@@ -35,7 +35,7 @@ pub fn bytes_data_gc_type_id() -> u32 {
 ///
 /// PyPy: W_BytesObject stores `_value` (RPython string).
 /// pyre: stores a heap-allocated `Vec<u8>` in a GC-managed non-moving storage
-/// box (off-GC storage epic S4), same layout as W_BytearrayObject but without
+/// box (off-GC storage), same layout as W_BytearrayObject but without
 /// setitem/extend.
 #[repr(C)]
 pub struct W_BytesObject {

--- a/pyre/pyre-object/src/dictmultiobject.rs
+++ b/pyre/pyre-object/src/dictmultiobject.rs
@@ -1035,13 +1035,13 @@ pub static MODULE_DICT_TYPE: PyType = new_pytype("dict");
 pub struct W_ModuleDictObject {
     pub ob_header: PyObject,
     /// `dstorage` from `W_DictMultiObject.__slots__` (`dictmultiobject.py:47`).
-    /// A GC-managed non-moving storage box (off-GC storage epic S3);
+    /// A GC-managed non-moving storage box (off-GC storage);
     /// reassignment is a `setfield_gc`.  Authoritative while
     /// `object_storage` is null (ModuleDictStrategy mode); after
     /// `switch_to_object_strategy` it is cleared and not consulted.
     pub dstorage: *mut crate::celldict::ModuleDictStorage,
     /// `mstrategy` from `W_ModuleDictObject.__slots__` (`:331`).
-    /// A GC-managed non-moving storage box (off-GC storage epic S3).
+    /// A GC-managed non-moving storage box (off-GC storage).
     pub mstrategy: *mut crate::celldict::ModuleDictStrategy,
     /// `dstorage` after a `switch_to_object_strategy`
     /// (`celldict.py:173-186`).  Null while the dict is in


### PR DESCRIPTION
Three commits. The two comment sweeps are the bulk; the middle commit is an unrelated build fix that `origin/main` needs.

## `majit-metainterp: initialize Snapshot::extra_virtual_roots …`

`origin/main` at `57b01d0e8bd` **does not compile**:

```
error[E0063]: missing field `extra_virtual_roots` in initializer of `recorder::Snapshot`
    --> majit/majit-metainterp/src/history.rs:2406:51
```

`#661` added the field; `capture_snapshot_for_last_guard_op_multi_frame_with_vable_vref` was not updated. The value and comment are copied verbatim from the sibling `capture_snapshot_for_last_guard_multi_frame_with_vable_vref` — the same multi-frame path, where the nested-list append fold resumes through the single-frame collapse so no extra virtual roots reach it.

This is not caused by the comment sweeps: their diff to `history.rs` touches only lines 2836/2853/3454/3513, and the break reproduces on the base commit.

## The two comment sweeps

Removed identifiers invented in past AI sessions that no reader of the code can resolve:

| category | examples | sites |
|---|---|---|
| task/slice/phase tags | `task#50 phase-1`, `#73 S3.5`, `Parity #14 Slice C.4`, `Slice 7b`, `sub-slice 4`, `micro-slice 3` | ~155 |
| gap / stage tags | `gap-10`, `#203 gap-7`, `51d.1`, `M4`, `orth-9 step 4`, `S2.1 (wiggly-barto plan)`, `S1.3`, `Path B (B.6.7)`, `[SPIKE-S0/FR]`, `A0-era` | ~45 |
| AI-review labels | `Codex P1:`, `Codex P2 (round 8):`, `Codex P1 (PR #89):` | 21 |
| private file references | `.claude/plans/*.md`, `memory/*.md`, `project_issue73_…` | 12 |
| internal task numbers | `Task #85`, `Task #197`, `Task #333`, `task #157`, `task #124` | ~15 |

Each tag is replaced by the technical statement it prefixed; where the tag carried the sentence's subject, the sentence is reworded.

**Kept deliberately:**

- Real GitHub issue references (`#140`, `#203`, `#267`, `#346`, `#390`).
- `Finding #1`/`#2`/`#3` and `Option C` — these are defined by the `#57` issue cited next to them, so a reader can resolve them.
- `Slice A/B/C` inside `majit-translate/docs/design-346-*.md`, which is that document's own vocabulary.
- Algorithmic `Phase 1/2/3` (unroll passes, GC phases, annotator phases) — real domain vocabulary, not tracking labels.

## Method

No regex sweep. Every edit is a hand-authored exact `(old, new)` string pair that must match a stated number of times, or the file is left untouched and the pair is reported. A regex-gated attempt in an earlier session over-matched and destroyed unrelated `#420`/`#124`/`#171` issue provenance; this avoids that failure mode. False positives were checked and left alone (`slice-bound __index__` in `call_jit.rs` is real slicing, not a tracking tag).

## Verification

- `cargo check --workspace --all-targets --features dynasm` — passes. The only warning is the pre-existing `vstack_mirror.rs` `unreachable_patterns`.
- Diff is comment-only except three string literals, all named in the second commit message: two `S1.3` mentions in an `AnnotatorError` / `expect_err` message, and a `memory/*.md` citation inside an `#[ignore = "..."]` reason.

## Not included

The ~30,900 `file.py:NNN` / `file.rs:NNN` line-number citations across 518 files. Line numbers on file citations are the other half of the standing convention, but a sweep that size would conflict with essentially every one of the ~20 open PRs, so it needs a scheduling decision rather than being folded in here. Line numbers *were* dropped on the specific lines these commits already rewrote.