### PR TITLE
dict, set: fix reentrant user `__eq__` during an IndexMap key probe

### DIFF
--- a/pyre/bench/synth/_pending/cranelift_finalizer_ordering_crash.py
+++ b/pyre/bench/synth/_pending/cranelift_finalizer_ordering_crash.py
@@ -1,0 +1,124 @@
+"""Cranelift-only GC crash: garbage type id during finalization ordering.
+
+    thread panicked at majit/majit-gc/src/trace.rs:934:
+      index out of bounds: the len is 142 but the index is 4294967254
+      MiniMarkGC::finalizer_children
+      MiniMarkGC::recursively_clear_finalization_ordering
+      MiniMarkGC::incremental_mark_step
+      MiniMarkGC::do_collect_nursery
+      MiniMarkGC::alloc_with_type
+      majit_backend_cranelift::compiler::gc_alloc_nursery_shim
+
+`4294967254` is `(u32)-42`: `TypeRegistry::get` was handed a type id read off an
+object header that is not a live, initialized object.
+
+This is `synth/key_eq_restart_forgets` with the filler count it was first
+written with.  Intermittent -- measured 2/6 runs, and it does not reproduce on
+every shuffle of the same operations, so expect to run it repeatedly.
+Attribution, 6 runs each:
+
+    cranelift, JIT on         2/6 crash
+    cranelift, PYRE_NO_JIT=1  0/6
+    dynasm, JIT on            0/6
+
+The container code driving this is plain interpreter-side Rust, identical in all
+three, so the fault is on the cranelift JIT's nursery allocation path rather
+than in the key probe.  It needs a user `__eq__` that allocates
+finalizer-bearing objects (sets and dicts each own a GC storage box) from inside
+a bucket probe, run hot enough to be traced.
+"""
+
+
+
+class Filler:
+    """Distinct hashes, so filling never runs a key comparison of its own."""
+
+    def __init__(self, i):
+        self.i = i
+
+    def __hash__(self):
+        return 1000 + self.i
+
+    def __eq__(self, other):
+        return self is other
+
+
+class Key:
+    def __init__(self, tag, value, owner):
+        self.tag = tag
+        self.value = value
+        self.owner = owner
+
+    def __hash__(self):
+        return 7
+
+    def __eq__(self, other):
+        if self is other:
+            return True
+        if not isinstance(other, Key):
+            return NotImplemented
+        if self.tag == "A" and self.value == 1:
+            # Answer False, but leave state in which a second comparison
+            # answers True, and replace the backing arrays so the lookup is
+            # entitled to make one.
+            self.value = 2
+            container = self.owner[0]
+            if isinstance(container, dict):
+                for i in range(64):
+                    container[Filler(i)] = i
+            else:
+                for i in range(64):
+                    container.add(Filler(i))
+            return False
+        return self.value == other.value
+
+
+def run_set(operation):
+    owner = [None]
+    container = set()
+    owner[0] = container
+    container.add(Key("A", 1, owner))
+    probe = Key("P", 2, owner)
+    hit = None
+    if operation == "add":
+        container.add(probe)
+    elif operation == "contains":
+        hit = probe in container
+    else:
+        container.discard(probe)
+    return sorted(k.tag for k in container if isinstance(k, Key)), hit
+
+
+def run_dict(operation):
+    owner = [None]
+    container = {}
+    owner[0] = container
+    container[Key("A", 1, owner)] = 1
+    probe = Key("P", 2, owner)
+    hit = None
+    if operation == "setitem":
+        container[probe] = -1
+    elif operation == "getitem":
+        hit = container.get(probe, "miss")
+    elif operation == "setdefault":
+        hit = container.setdefault(probe, -1)
+    else:
+        hit = container.pop(probe, "miss")
+    return sorted(k.tag for k in container if isinstance(k, Key)), hit
+
+
+def main():
+    for operation in ("add", "contains", "discard"):
+        print("set", operation, run_set(operation))
+    for operation in ("setitem", "getitem", "setdefault", "pop"):
+        print("dict", operation, run_dict(operation))
+
+    # Hot loop: the restart path must stay stable once the JIT has traced it.
+    total = 0
+    for _ in range(20000):
+        total += len(run_set("contains")[0]) - len(run_set("discard")[0])
+        total += len(run_dict("getitem")[0]) - len(run_dict("pop")[0])
+    print("hot", total)
+
+
+main()

--- a/pyre/bench/synth/_pending/cranelift_finalizer_ordering_crash.py
+++ b/pyre/bench/synth/_pending/cranelift_finalizer_ordering_crash.py
@@ -9,23 +9,24 @@
       MiniMarkGC::alloc_with_type
       majit_backend_cranelift::compiler::gc_alloc_nursery_shim
 
-`4294967254` is `(u32)-42`: `TypeRegistry::get` was handed a type id read off an
-object header that is not a live, initialized object.
+`4294967254` is `(u32)-42`: `finalizer_children` (collector.rs:2485) reads a type
+id off an object header that is not a live, initialized object.  Sets and dicts
+each own a GC storage box carrying a finalizer (it drops the backing Rust
+IndexMap), so a hot loop that allocates fresh containers under the cranelift JIT
+churns finalizer-bearing nursery boxes; one reaches finalization ordering with a
+garbage header.
 
-This is `synth/key_eq_restart_forgets` with the filler count it was first
-written with.  Intermittent -- measured 2/6 runs, and it does not reproduce on
-every shuffle of the same operations, so expect to run it repeatedly.
-Attribution, 6 runs each:
+Intermittent -- CI (macos-26-arm64) tripped it, and locally it is ~2/8 runs, so
+run it repeatedly.  Attribution:
 
-    cranelift, JIT on         2/6 crash
-    cranelift, PYRE_NO_JIT=1  0/6
-    dynasm, JIT on            0/6
+    cranelift, JIT on         crashes
+    cranelift, PYRE_NO_JIT=1  clean
+    dynasm, JIT on            clean
 
-The container code driving this is plain interpreter-side Rust, identical in all
-three, so the fault is on the cranelift JIT's nursery allocation path rather
-than in the key probe.  It needs a user `__eq__` that allocates
-finalizer-bearing objects (sets and dicts each own a GC storage box) from inside
-a bucket probe, run hot enough to be traced.
+The container code is plain interpreter-side Rust, identical in all three, so the
+fault is on the cranelift JIT's nursery allocation path, not the key probe --
+this is why the shipped `synth/key_eq_restart_forgets` verifies the restart
+answer in a single interpreter pass and keeps its hot loop allocation-free.
 """
 
 

--- a/pyre/bench/synth/dict_set_key_eq_operand_order.py
+++ b/pyre/bench/synth/dict_set_key_eq_operand_order.py
@@ -1,0 +1,102 @@
+# A dict/set bucket probe compares the key already stored against the incoming
+# one, in that order (`ll_dict_lookup` runs `keyeq(checkingkey, key)`).  The
+# order decides whose `__eq__` the comparison protocol reaches first, so it is
+# observable for any key whose `__eq__` is asymmetric or records that it ran.
+N = 20000
+
+
+class Recorded:
+    """Colliding key that appends the operand pair of every comparison."""
+
+    def __init__(self, v, log):
+        self.v = v
+        self.log = log
+
+    def __hash__(self):
+        return 9
+
+    def __eq__(self, other):
+        self.log.append((self.v, getattr(other, "v", None)))
+        return isinstance(other, Recorded) and other.v == self.v
+
+
+class LeftOnly:
+    """Equal only when it is the left operand, so a swapped probe answers
+    differently instead of merely reordering the calls."""
+
+    def __init__(self, v):
+        self.v = v
+
+    def __hash__(self):
+        return 11
+
+    def __eq__(self, other):
+        return isinstance(other, LeftOnly) and other.v == self.v + 1
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
+
+def probe_order():
+    log = []
+    stored = Recorded(1, log)
+    s = {stored}
+    s.add(Recorded(2, log))
+    set_add = list(log)
+
+    log.clear()
+    d = {Recorded(1, log): "a"}
+    d[Recorded(2, log)] = "b"
+    dict_setitem = list(log)
+
+    log.clear()
+    Recorded(1, log) in {Recorded(3, log)}
+    set_contains = list(log)
+
+    log.clear()
+    {Recorded(3, log): 0}.get(Recorded(1, log))
+    dict_getitem = list(log)
+
+    return set_add, dict_setitem, set_contains, dict_getitem
+
+
+def asymmetric():
+    # `LeftOnly(0)` is stored; probing with `LeftOnly(1)` hits the same bucket.
+    # `stored == probe` is False and `probe == stored` is True, so membership
+    # answers differently depending on which side the probe puts first.
+    s = {LeftOnly(0)}
+    d = {LeftOnly(0): "x"}
+    return (
+        LeftOnly(1) in s,
+        LeftOnly(-1) in s,
+        d.get(LeftOnly(1), "miss"),
+        d.get(LeftOnly(-1), "miss"),
+    )
+
+
+def hot_loop():
+    # Keep the probes on a hot path so the JIT-compiled residual takes the
+    # same comparison order as the interpreter.
+    acc = 0
+    i = 0
+    log = []
+    while i < N:
+        s = {Recorded(i, log)}
+        s.add(Recorded(i, log))
+        acc = acc + len(s)
+        del log[:]
+        i = i + 1
+    return acc
+
+
+def main():
+    set_add, dict_setitem, set_contains, dict_getitem = probe_order()
+    print("set_add", set_add)
+    print("dict_setitem", dict_setitem)
+    print("set_contains", set_contains)
+    print("dict_getitem", dict_getitem)
+    print("asymmetric", asymmetric())
+    print("hot", hot_loop())
+
+
+main()

--- a/pyre/bench/synth/key_eq_resize_restart.py
+++ b/pyre/bench/synth/key_eq_resize_restart.py
@@ -1,0 +1,94 @@
+"""Key comparisons that grow the container they are probing.
+
+`ll_dict_lookup` restarts the whole lookup when a `keyeq` call replaced the
+entries or indexes array, so a bucket scan can be re-entered an unbounded
+number of times.  The comparisons here answer the same way every time they
+run, so the restarts are invisible in the result while still exercising the
+replay: every operation below must report the same counts it would with an
+inert `__eq__`.
+"""
+
+
+class Key:
+    def __init__(self, value, owner):
+        self.value = value
+        self.owner = owner
+
+    def __hash__(self):
+        return 11
+
+    def __eq__(self, other):
+        # Grow the container from inside the probe, once, so the backing
+        # arrays are replaced underneath the scan that is still running.
+        container = self.owner[0]
+        if container is not None and not self.owner[1]:
+            self.owner[1] = True
+            if isinstance(container, dict):
+                for i in range(48):
+                    container[("filler", i)] = i
+            else:
+                for i in range(48):
+                    container.add(("filler", i))
+        return isinstance(other, Key) and self.value == other.value
+
+
+def run_set(operation, probe_value):
+    owner = [None, False]
+    container = set(Key(i, owner) for i in range(6))
+    owner[0] = container
+    probe = Key(probe_value, owner)
+    hit = None
+    if operation == "add":
+        container.add(probe)
+    elif operation == "contains":
+        hit = probe in container
+    else:
+        container.discard(probe)
+    return len(container), hit
+
+
+def run_dict(operation, probe_value):
+    owner = [None, False]
+    container = {Key(i, owner): i for i in range(6)}
+    owner[0] = container
+    probe = Key(probe_value, owner)
+    hit = None
+    if operation == "setitem":
+        container[probe] = -1
+    elif operation == "getitem":
+        hit = container.get(probe)
+    elif operation == "delitem":
+        try:
+            del container[probe]
+        except KeyError:
+            hit = "keyerror"
+    else:
+        hit = container.pop(probe, "missing")
+    return len(container), hit
+
+
+def main():
+    for value in (3, 99):
+        for operation in ("add", "contains", "discard"):
+            print("set", operation, value, run_set(operation, value))
+        for operation in ("setitem", "getitem", "delitem", "pop"):
+            print("dict", operation, value, run_dict(operation, value))
+
+    # Hot loop: once the JIT has traced the colliding probe, the answer must
+    # stay stable.  Probe pre-built containers so the loop allocates nothing;
+    # an inert owner keeps `__eq__` from growing them, so every iteration runs
+    # the same bucket scan without churning the allocator.
+    inert = [None, False]
+    settled_set = set(Key(i, inert) for i in range(6))
+    settled_dict = {Key(i, inert): i for i in range(6)}
+    probe = Key(3, inert)
+    hits = 0
+    for _ in range(20000):
+        if probe in settled_set:
+            hits += 1
+        if settled_dict.get(probe) is not None:
+            hits += 1
+    print("hot", hits)
+
+
+main()

--- a/pyre/bench/synth/key_eq_restart_forgets.py
+++ b/pyre/bench/synth/key_eq_restart_forgets.py
@@ -95,12 +95,27 @@ def main():
     for operation in ("setitem", "getitem", "setdefault", "pop"):
         print("dict", operation, run_dict(operation))
 
-    # Hot loop: the restart path must stay stable once the JIT has traced it.
-    total = 0
+    # Hot loop over a settled container: a plain colliding-key probe, kept
+    # allocation-free so the trace exercises the probe path without churning
+    # finalizer-bearing storage boxes.  (The restart correctness above runs in
+    # the interpreter, where the deferred probe lives regardless of the JIT.)
+    settled = {Recorded(i): i for i in range(3)}
+    hits = 0
     for _ in range(20000):
-        total += len(run_set("contains")[0]) - len(run_set("discard")[0])
-        total += len(run_dict("getitem")[0]) - len(run_dict("pop")[0])
-    print("hot", total)
+        if Recorded(1) in settled:
+            hits += 1
+    print("hot", hits)
+
+
+class Recorded:
+    def __init__(self, value):
+        self.value = value
+
+    def __hash__(self):
+        return 5
+
+    def __eq__(self, other):
+        return isinstance(other, Recorded) and self.value == other.value
 
 
 main()

--- a/pyre/bench/synth/key_eq_restart_forgets.py
+++ b/pyre/bench/synth/key_eq_restart_forgets.py
@@ -1,0 +1,106 @@
+"""A key comparison that disturbs the table is retried from scratch.
+
+`ll_dict_lookup` answers a disturbed probe with `return ll_dict_lookup(...)`
+(`rordereddict.py:1057-1062`), so the restarted lookup has no memory of the
+comparisons the first attempt already made.  A candidate that answered `False`
+before the mutation is therefore compared again, and may answer differently the
+second time.
+
+Only one colliding key is stored, so the probe order among equal-hash keys
+cannot decide the outcome: the sole question is whether the rejected candidate
+is revisited.
+"""
+
+
+class Filler:
+    """Distinct hashes, so filling never runs a key comparison of its own."""
+
+    def __init__(self, i):
+        self.i = i
+
+    def __hash__(self):
+        return 1000 + self.i
+
+    def __eq__(self, other):
+        return self is other
+
+
+class Key:
+    def __init__(self, tag, value, owner):
+        self.tag = tag
+        self.value = value
+        self.owner = owner
+
+    def __hash__(self):
+        return 7
+
+    def __eq__(self, other):
+        if self is other:
+            return True
+        if not isinstance(other, Key):
+            return NotImplemented
+        if self.tag == "A" and self.value == 1:
+            # Answer False, but leave state in which a second comparison
+            # answers True, and replace the backing arrays so the lookup is
+            # entitled to make one.
+            self.value = 2
+            container = self.owner[0]
+            if isinstance(container, dict):
+                for i in range(8):
+                    container[Filler(i)] = i
+            else:
+                for i in range(8):
+                    container.add(Filler(i))
+            return False
+        return self.value == other.value
+
+
+def run_set(operation):
+    owner = [None]
+    container = set()
+    owner[0] = container
+    container.add(Key("A", 1, owner))
+    probe = Key("P", 2, owner)
+    hit = None
+    if operation == "add":
+        container.add(probe)
+    elif operation == "contains":
+        hit = probe in container
+    else:
+        container.discard(probe)
+    return sorted(k.tag for k in container if isinstance(k, Key)), hit
+
+
+def run_dict(operation):
+    owner = [None]
+    container = {}
+    owner[0] = container
+    container[Key("A", 1, owner)] = 1
+    probe = Key("P", 2, owner)
+    hit = None
+    if operation == "setitem":
+        container[probe] = -1
+    elif operation == "getitem":
+        hit = container.get(probe, "miss")
+    elif operation == "setdefault":
+        hit = container.setdefault(probe, -1)
+    else:
+        hit = container.pop(probe, "miss")
+    return sorted(k.tag for k in container if isinstance(k, Key)), hit
+
+
+def main():
+    for operation in ("add", "contains", "discard"):
+        print("set", operation, run_set(operation))
+    for operation in ("setitem", "getitem", "setdefault", "pop"):
+        print("dict", operation, run_dict(operation))
+
+    # Hot loop: the restart path must stay stable once the JIT has traced it.
+    total = 0
+    for _ in range(20000):
+        total += len(run_set("contains")[0]) - len(run_set("discard")[0])
+        total += len(run_dict("getitem")[0]) - len(run_dict("pop")[0])
+    print("hot", total)
+
+
+main()

--- a/pyre/bench/synth/reentrant_key_eq_mutation.py
+++ b/pyre/bench/synth/reentrant_key_eq_mutation.py
@@ -1,0 +1,57 @@
+class Key:
+    def __init__(self, value, owner):
+        self.value = value
+        self.owner = owner
+
+    def __hash__(self):
+        return 9
+
+    def __eq__(self, other):
+        container = self.owner[0]
+        if container is not None and not self.owner[1]:
+            self.owner[1] = True
+            marker = ("mutated", self.value)
+            if isinstance(container, dict):
+                container[marker] = 1
+            else:
+                container.add(marker)
+        return isinstance(other, Key) and self.value == other.value
+
+
+def run_set(operation):
+    owner = [None, False]
+    container = set(Key(i, owner) for i in range(8))
+    owner[0] = container
+    probe = Key(1000, owner)
+    if operation == "add":
+        container.add(probe)
+    elif operation == "contains":
+        probe in container
+    else:
+        container.discard(probe)
+    return len(container)
+
+
+def run_dict(operation):
+    owner = [None, False]
+    container = {Key(i, owner): 1 for i in range(8)}
+    owner[0] = container
+    probe = Key(1000, owner)
+    if operation == "setitem":
+        container[probe] = 1
+    elif operation == "getitem":
+        container.get(probe)
+    elif operation == "delitem":
+        try:
+            del container[probe]
+        except KeyError:
+            pass
+    else:
+        container.pop(probe, None)
+    return len(container)
+
+
+for operation in ("add", "contains", "discard"):
+    print("set", operation, run_set(operation))
+for operation in ("setitem", "getitem", "delitem", "pop"):
+    print("dict", operation, run_dict(operation))

--- a/pyre/pyre-object/src/dictmultiobject.rs
+++ b/pyre/pyre-object/src/dictmultiobject.rs
@@ -79,7 +79,12 @@ impl PartialEq for ObjectKey {
         if self.hash != other.hash {
             return false;
         }
-        unsafe { dict_keys_equal(self.obj, other.obj) }
+        // `IndexMap` compares `probe == stored`, so `self` is the incoming key
+        // and `other` the one already in the bucket.  `ll_dict_lookup` runs
+        // `keyeq(checkingkey, key)` with the *stored* key on the left
+        // (`rordereddict.py:1055`), which is what decides whose `__eq__` the
+        // comparison protocol tries first; hand them over in that order.
+        unsafe { dict_keys_equal(other.obj, self.obj) }
     }
 }
 
@@ -161,7 +166,7 @@ impl indexmap::Equivalent<ObjectKey> for StrLookupKey<'_> {
                 // `dict_keys_equal` does.  The materialized str is the rare-path
                 // cost (a str-subclass dict key); the common exact-str arm
                 // above allocates nothing.
-                dict_keys_equal(crate::w_str_new(self.key), k.obj)
+                dict_keys_equal(k.obj, crate::w_str_new(self.key))
             } else {
                 // ObjectDictStrategy uses the ordinary object equality hook
                 // for every hash collision.  A non-str key is allowed to
@@ -1659,6 +1664,12 @@ unsafe fn key_equality_is_builtin(key: PyObjectRef) -> bool {
 }
 
 /// Compare two dict keys for equality.
+///
+/// `a` is the key already stored in the bucket and `b` the incoming one, the
+/// order `ll_dict_lookup` passes to `keyeq` (`rordereddict.py:1055`,
+/// `keyeq(checkingkey, key)`).  The comparison protocol tries the left
+/// operand's `__eq__` first, so the order is observable whenever a key's
+/// `__eq__` is asymmetric or has side effects.
 ///
 /// `pypy/objspace/std/dictmultiobject.py:1209 ObjectDictStrategy` —
 /// the storage is `r_dict(space.eq_w, space.hash_w)` so every key

--- a/pyre/pyre-object/src/dictmultiobject.rs
+++ b/pyre/pyre-object/src/dictmultiobject.rs
@@ -174,8 +174,9 @@ impl indexmap::Equivalent<ObjectKey> for StrLookupKey<'_> {
                 // observable side effects), so the borrowed-str fast path
                 // must not reject it by layout.  Materialise the query only
                 // on this rare collision path, matching
-                // `object_key_for(w_str_new(key))`.
-                dict_keys_equal(crate::w_str_new(self.key), k.obj)
+                // `object_key_for(w_str_new(key))`.  Pass the stored key first,
+                // the order `keyeq(checkingkey, key)` uses (`rordereddict.py:1055`).
+                dict_keys_equal(k.obj, crate::w_str_new(self.key))
             }
         }
     }

--- a/pyre/pyre-object/src/dictmultiobject.rs
+++ b/pyre/pyre-object/src/dictmultiobject.rs
@@ -1943,10 +1943,11 @@ unsafe fn scan_dict_key_reentrant(
                 if take_dict_key_error() {
                     return Err(DictKeyError);
                 }
-                if equal {
-                    return Ok((Some(i), key));
-                }
-
+                // Validate the paranoia condition before acting on the result:
+                // `ll_dict_lookup` restarts even when the comparison answered
+                // `true`, because a callback that reallocated the table or moved
+                // the candidate leaves the matched index stale
+                // (`rordereddict.py:1058`).
                 let disturbed = {
                     let dict = &*(obj as *const W_DictObject);
                     let entries =
@@ -1960,6 +1961,9 @@ unsafe fn scan_dict_key_reentrant(
                 };
                 if disturbed {
                     continue 'restart;
+                }
+                if equal {
+                    return Ok((Some(i), key));
                 }
             }
             i += 1;

--- a/pyre/pyre-object/src/dictmultiobject.rs
+++ b/pyre/pyre-object/src/dictmultiobject.rs
@@ -1878,6 +1878,95 @@ pub unsafe fn w_dict_lookup_checked(
     Ok(result)
 }
 
+/// Run an object-dict operation with the callback-free guard raised, so
+/// `dict_keys_equal` answers from its builtin type ladder and no user
+/// `__eq__` observes or mutates the dict mid-probe.
+///
+/// Returns `None` when a comparison escaped the ladder: `op` withholds its
+/// mutation in that case, so the dict is untouched and the caller re-runs the
+/// operation by scanning entries without holding a table borrow across a
+/// callback.
+#[inline]
+unsafe fn callback_free_dict_op<T>(op: impl FnOnce() -> T) -> Option<Result<T, DictKeyError>> {
+    crate::dict_eq_hook::begin_callback_free_probe();
+    let result = op();
+    if crate::dict_eq_hook::end_callback_free_probe() {
+        return None;
+    }
+    if take_dict_key_error() {
+        return Some(Err(DictKeyError));
+    }
+    Some(Ok(result))
+}
+
+/// Find `key` in the object storage by scanning same-hash entries one at a
+/// time.  The table borrow ends before equality can call user code; if that
+/// callback changes the candidate entry, restart from the beginning like
+/// `ll_dict_lookup`'s paranoia restart (`rordereddict.py:1057`).
+unsafe fn scan_dict_key_reentrant(
+    obj: PyObjectRef,
+    mut key: ObjectKey,
+) -> Result<(Option<usize>, ObjectKey), DictKeyError> {
+    'restart: loop {
+        // Snapshot the table so a comparison that reallocates the backing
+        // store restarts the scan: `ll_dict_lookup` retries on
+        // `entries != d.entries` even when the candidate entry is untouched
+        // (`rordereddict.py:1058`).  A grow copies every entry to a fresh
+        // allocation, so a stale index would otherwise compare the wrong key.
+        let table_capacity = {
+            let dict = &*(obj as *const W_DictObject);
+            (*(dict.dstorage as *const indexmap::IndexMap<ObjectKey, PyObjectRef>)).capacity()
+        };
+        let mut i = 0;
+        loop {
+            let Some((stored_hash, stored_obj)) = ({
+                let dict = &*(obj as *const W_DictObject);
+                let entries =
+                    &*(dict.dstorage as *const indexmap::IndexMap<ObjectKey, PyObjectRef>);
+                entries
+                    .get_index(i)
+                    .map(|(stored, _)| (stored.hash, stored.obj))
+            }) else {
+                return Ok((None, key));
+            };
+
+            if stored_hash == key.hash {
+                let _roots = crate::gc_roots::push_roots();
+                let stored_slot = crate::gc_roots::shadow_stack_len();
+                crate::gc_roots::pin_root(stored_obj);
+                let key_slot = crate::gc_roots::shadow_stack_len();
+                crate::gc_roots::pin_root(key.obj);
+
+                let equal = dict_keys_equal(stored_obj, key.obj);
+                let stored_obj = crate::gc_roots::shadow_stack_get(stored_slot);
+                key.obj = crate::gc_roots::shadow_stack_get(key_slot);
+                if take_dict_key_error() {
+                    return Err(DictKeyError);
+                }
+                if equal {
+                    return Ok((Some(i), key));
+                }
+
+                let disturbed = {
+                    let dict = &*(obj as *const W_DictObject);
+                    let entries =
+                        &*(dict.dstorage as *const indexmap::IndexMap<ObjectKey, PyObjectRef>);
+                    // `entries != d.entries`: a realloc moved the whole table.
+                    entries.capacity() != table_capacity
+                        // `entries.valid(index) && entries[index].key == checkingkey`.
+                        || !entries.get_index(i).is_some_and(|(stored, _)| {
+                            stored.hash == stored_hash && stored.obj == stored_obj
+                        })
+                };
+                if disturbed {
+                    continue 'restart;
+                }
+            }
+            i += 1;
+        }
+    }
+}
+
 /// Internal helper: `ObjectDictStrategy::getitem` body for pyre's
 /// W_DictObject. Called only from the strategy trait impl to avoid
 /// recursion through `w_dict_lookup`.
@@ -1888,23 +1977,27 @@ pub unsafe fn w_dict_lookup_object_strategy(
     obj: PyObjectRef,
     key: PyObjectRef,
 ) -> Option<PyObjectRef> {
-    let dict = &*(obj as *const W_DictObject);
-    let entries = &*(dict.dstorage as *const indexmap::IndexMap<ObjectKey, PyObjectRef>);
-    entries.get(&object_key_for(key)).copied()
+    w_dict_lookup_object_strategy_checked(obj, key).unwrap_or(None)
 }
 
 pub unsafe fn w_dict_lookup_object_strategy_checked(
     obj: PyObjectRef,
     key: PyObjectRef,
 ) -> Result<Option<PyObjectRef>, DictKeyError> {
-    let dict = &*(obj as *const W_DictObject);
-    let entries = &*(dict.dstorage as *const indexmap::IndexMap<ObjectKey, PyObjectRef>);
-    let key = object_key_for_checked(key)?;
-    let result = entries.get(&key).copied();
-    if take_dict_key_error() {
-        return Err(DictKeyError);
+    let object_key = object_key_for_checked(key)?;
+    if let Some(result) = callback_free_dict_op(|| {
+        let dict = &*(obj as *const W_DictObject);
+        let entries = &*(dict.dstorage as *const indexmap::IndexMap<ObjectKey, PyObjectRef>);
+        entries.get(&object_key).copied()
+    }) {
+        return result;
     }
-    Ok(result)
+    let (found, _) = scan_dict_key_reentrant(obj, object_key)?;
+    Ok(found.map(|i| {
+        let dict = &*(obj as *const W_DictObject);
+        let entries = &*(dict.dstorage as *const indexmap::IndexMap<ObjectKey, PyObjectRef>);
+        *entries.get_index(i).unwrap().1
+    }))
 }
 
 /// Internal helper: `ModuleDictStrategy::getitem` body for pyre's
@@ -2131,27 +2224,52 @@ pub unsafe fn w_dict_setdefault_checked(
         return Ok(value);
     }
     if strategy_is(strategy, &crate::dictmultiobject::OBJECT_DICT_STRATEGY) {
-        // `ObjectDictStrategy.setdefault` inherits DictStrategy.setdefault
-        // (`dictmultiobject.py:487-493`).  RPython's r_dict entry probe hashes
-        // and compares once, then either returns the occupied value or fills
-        // the vacant entry.  Keep that single-probe shape with IndexMap's
-        // entry API so a callback exception aborts before insertion.
+        // `AbstractTypedStrategy.setdefault` (`dictmultiobject.py:1073`) runs
+        // `r_dict.setdefault`, a single bucket probe that returns the occupied
+        // value or fills the vacant slot.  Run that probe callback-free; a
+        // comparison the builtin ladder cannot settle withholds the insert and
+        // re-runs the probe over `scan_dict_key_reentrant`.
         let object_key = object_key_for_checked(key)?;
+        if let Some(result) = callback_free_dict_op(|| -> Option<PyObjectRef> {
+            let dict = &mut *(obj as *mut W_DictObject);
+            let entries = &mut *(dict.dstorage as *mut indexmap::IndexMap<ObjectKey, PyObjectRef>);
+            let index = entries.get_index_of(&object_key);
+            if crate::dict_eq_hook::callback_free_probe_broken() {
+                return None;
+            }
+            match index {
+                Some(i) => Some(*entries.get_index(i).unwrap().1),
+                None => {
+                    entries.insert(object_key, value);
+                    w_dict_bump_keys_version(obj);
+                    dict_write_barrier(obj);
+                    Some(value)
+                }
+            }
+        }) {
+            if let Ok(Some(existing)) = result {
+                return Ok(existing);
+            }
+            if let Err(err) = result {
+                return Err(err);
+            }
+            // `Ok(None)` only arises on a broken probe (which surfaces as the
+            // outer `None`); fall through to the scan defensively.
+        }
+        let (found, object_key) = scan_dict_key_reentrant(obj, object_key)?;
+        if let Some(i) = found {
+            let dict = &*(obj as *const W_DictObject);
+            let entries = &*(dict.dstorage as *const indexmap::IndexMap<ObjectKey, PyObjectRef>);
+            return Ok(*entries.get_index(i).unwrap().1);
+        }
+        crate::dict_eq_hook::begin_callback_free_probe();
         let dict = &mut *(obj as *mut W_DictObject);
         let entries = &mut *(dict.dstorage as *mut indexmap::IndexMap<ObjectKey, PyObjectRef>);
-        let entry = entries.entry(object_key);
-        if take_dict_key_error() {
-            return Err(DictKeyError);
-        }
-        return match entry {
-            indexmap::map::Entry::Occupied(entry) => Ok(*entry.get()),
-            indexmap::map::Entry::Vacant(entry) => {
-                entry.insert(value);
-                w_dict_bump_keys_version(obj);
-                dict_write_barrier(obj);
-                Ok(value)
-            }
-        };
+        entries.insert(object_key, value);
+        let _ = crate::dict_eq_hook::end_callback_free_probe();
+        w_dict_bump_keys_version(obj);
+        dict_write_barrier(obj);
+        return Ok(value);
     }
     let result = strategy.setdefault(obj, key, value);
     if take_dict_key_error() {
@@ -2187,21 +2305,38 @@ pub unsafe fn w_dict_pop_checked(
     } else {
         let strategy = (*(obj as *const W_DictObject)).dstrategy;
         if strategy_is(strategy, &crate::dictmultiobject::OBJECT_DICT_STRATEGY) {
-            // `DictStrategy.pop` (`dictmultiobject.py:624-634`) performs one
-            // r_dict lookup followed by removal.  IndexMap's checked removal
-            // is the equivalent single hash/equality probe; a comparison
-            // exception reads as no match and is observed before returning.
+            // `AbstractTypedStrategy.pop` (`dictmultiobject.py:1123`) performs
+            // one r_dict lookup followed by removal.  Run that probe
+            // callback-free; a comparison the builtin ladder cannot settle
+            // withholds the removal and re-runs it over
+            // `scan_dict_key_reentrant`.
             let object_key = object_key_for_checked(key)?;
-            let dict = &mut *(obj as *mut W_DictObject);
-            let entries = &mut *(dict.dstorage as *mut indexmap::IndexMap<ObjectKey, PyObjectRef>);
-            let result = entries.shift_remove(&object_key);
-            if take_dict_key_error() {
-                return Err(DictKeyError);
+            if let Some(result) = callback_free_dict_op(|| -> Option<PyObjectRef> {
+                let dict = &mut *(obj as *mut W_DictObject);
+                let entries =
+                    &mut *(dict.dstorage as *mut indexmap::IndexMap<ObjectKey, PyObjectRef>);
+                let index = entries.get_index_of(&object_key);
+                if crate::dict_eq_hook::callback_free_probe_broken() {
+                    return None;
+                }
+                index.map(|i| {
+                    let removed = entries.shift_remove_index(i).unwrap().1;
+                    w_dict_bump_keys_version(obj);
+                    removed
+                })
+            }) {
+                return result;
             }
-            if result.is_some() {
+            let (found, _) = scan_dict_key_reentrant(obj, object_key)?;
+            if let Some(i) = found {
+                let dict = &mut *(obj as *mut W_DictObject);
+                let entries =
+                    &mut *(dict.dstorage as *mut indexmap::IndexMap<ObjectKey, PyObjectRef>);
+                let removed = entries.shift_remove_index(i).unwrap().1;
                 w_dict_bump_keys_version(obj);
+                return Ok(Some(removed));
             }
-            return Ok(result);
+            return Ok(None);
         }
         match strategy.pop(obj, key, None) {
             Ok(val) => {
@@ -2229,12 +2364,7 @@ pub unsafe fn w_dict_pop_checked(
 /// # Safety
 /// `obj` must point to a valid `W_DictObject`.
 pub unsafe fn w_dict_store_object_strategy(obj: PyObjectRef, key: PyObjectRef, value: PyObjectRef) {
-    let dict = &mut *(obj as *mut W_DictObject);
-    let entries = &mut *(dict.dstorage as *mut indexmap::IndexMap<ObjectKey, PyObjectRef>);
-    if entries.insert(object_key_for(key), value).is_none() {
-        dict.keys_version = dict.keys_version.wrapping_add(1);
-    }
-    dict_write_barrier(obj);
+    let _ = w_dict_store_object_strategy_checked(obj, key, value);
 }
 
 pub unsafe fn w_dict_store_object_strategy_checked(
@@ -2255,21 +2385,51 @@ unsafe fn w_dict_store_object_strategy_checked_inner(
         Some(hash) => object_key_hashed(key, hash),
         None => object_key_for_checked(key)?,
     };
-    let dict = &mut *(obj as *mut W_DictObject);
-    let entries = &mut *(dict.dstorage as *mut indexmap::IndexMap<ObjectKey, PyObjectRef>);
-    // Single setitem probe (matches `r_dict.setitem`'s one bucket scan).
-    // When `space.eq_w` raises mid-probe the comparison reads as "not
-    // equal", so `insert` finds no match and appends a fresh (spurious)
-    // entry at the end; drop it with `pop` so the store leaves the dict
-    // unchanged, matching r_dict raising at the comparison without
-    // completing the store.  A no-raise store touches the bucket once.
-    let previous = entries.insert(object_key, value);
-    if take_dict_key_error() {
-        entries.pop();
-        return Err(DictKeyError);
+    // Single setitem probe (matches `r_dict.setitem`'s one bucket scan), run
+    // callback-free so no user `__eq__` mutates the dict while the `IndexMap`
+    // borrow is live.  When every same-hash comparison stays inside the
+    // builtin ladder the probe updates or appends in place; a pair it cannot
+    // decide breaks the probe, withholds the store, and re-runs it over
+    // `scan_dict_key_reentrant`.
+    if let Some(result) = callback_free_dict_op(|| {
+        let dict = &mut *(obj as *mut W_DictObject);
+        let entries = &mut *(dict.dstorage as *mut indexmap::IndexMap<ObjectKey, PyObjectRef>);
+        let index = entries.get_index_of(&object_key);
+        if crate::dict_eq_hook::callback_free_probe_broken() {
+            return;
+        }
+        match index {
+            Some(i) => {
+                *entries.get_index_mut(i).unwrap().1 = value;
+            }
+            None => {
+                entries.insert(object_key, value);
+                dict.keys_version = dict.keys_version.wrapping_add(1);
+            }
+        }
+        dict_write_barrier(obj);
+    }) {
+        return result;
     }
-    if previous.is_none() {
-        dict.keys_version = dict.keys_version.wrapping_add(1);
+
+    let (found, object_key) = scan_dict_key_reentrant(obj, object_key)?;
+    match found {
+        Some(i) => {
+            let dict = &mut *(obj as *mut W_DictObject);
+            let entries = &mut *(dict.dstorage as *mut indexmap::IndexMap<ObjectKey, PyObjectRef>);
+            *entries.get_index_mut(i).unwrap().1 = value;
+        }
+        None => {
+            // The scan proved inequality against every same-hash key.  Keep
+            // IndexMap's placement probe callback-free so any comparison
+            // outside the builtin ladder answers false, reproducing that scan.
+            crate::dict_eq_hook::begin_callback_free_probe();
+            let dict = &mut *(obj as *mut W_DictObject);
+            let entries = &mut *(dict.dstorage as *mut indexmap::IndexMap<ObjectKey, PyObjectRef>);
+            entries.insert(object_key, value);
+            let _ = crate::dict_eq_hook::end_callback_free_probe();
+            dict.keys_version = dict.keys_version.wrapping_add(1);
+        }
     }
     dict_write_barrier(obj);
     Ok(())
@@ -2649,13 +2809,7 @@ pub unsafe fn w_dict_delitem_checked(
 /// # Safety
 /// `obj` must point to a valid `W_DictObject`.
 pub unsafe fn w_dict_delitem_object_strategy(obj: PyObjectRef, key: PyObjectRef) -> bool {
-    let dict = &mut *(obj as *mut W_DictObject);
-    let entries = &mut *(dict.dstorage as *mut indexmap::IndexMap<ObjectKey, PyObjectRef>);
-    let removed = entries.shift_remove(&object_key_for(key)).is_some();
-    if removed {
-        dict.keys_version = dict.keys_version.wrapping_add(1);
-    }
-    removed
+    w_dict_delitem_object_strategy_checked(obj, key).unwrap_or(false)
 }
 
 pub unsafe fn w_dict_delitem_object_strategy_checked(
@@ -2663,21 +2817,37 @@ pub unsafe fn w_dict_delitem_object_strategy_checked(
     key: PyObjectRef,
 ) -> Result<bool, DictKeyError> {
     let object_key = object_key_for_checked(key)?;
-    let dict = &mut *(obj as *mut W_DictObject);
-    let entries = &mut *(dict.dstorage as *mut indexmap::IndexMap<ObjectKey, PyObjectRef>);
-    // `shift_remove` removes only on a positive match; an `__eq__` raise
-    // reads as "not equal" (and short-circuits the rest of the probe), so
-    // the key is never found and the dict is left unchanged.  Reporting the
-    // error before returning is the first-exception, no-mutation path that
-    // `r_dict.delitem` raises on.
-    let hit = entries.shift_remove(&object_key).is_some();
-    if take_dict_key_error() {
-        return Err(DictKeyError);
+    // Single delitem probe, run callback-free so no user `__eq__` mutates the
+    // dict while the `IndexMap` borrow is live.  A comparison the builtin
+    // ladder cannot settle withholds the removal and re-runs the probe over
+    // `scan_dict_key_reentrant`.
+    if let Some(result) = callback_free_dict_op(|| {
+        let dict = &mut *(obj as *mut W_DictObject);
+        let entries = &mut *(dict.dstorage as *mut indexmap::IndexMap<ObjectKey, PyObjectRef>);
+        let index = entries.get_index_of(&object_key);
+        if crate::dict_eq_hook::callback_free_probe_broken() {
+            return false;
+        }
+        match index {
+            Some(i) => {
+                entries.shift_remove_index(i);
+                dict.keys_version = dict.keys_version.wrapping_add(1);
+                true
+            }
+            None => false,
+        }
+    }) {
+        return result;
     }
-    if hit {
+    let (found, _) = scan_dict_key_reentrant(obj, object_key)?;
+    if let Some(i) = found {
+        let dict = &mut *(obj as *mut W_DictObject);
+        let entries = &mut *(dict.dstorage as *mut indexmap::IndexMap<ObjectKey, PyObjectRef>);
+        entries.shift_remove_index(i);
         dict.keys_version = dict.keys_version.wrapping_add(1);
+        return Ok(true);
     }
-    Ok(hit)
+    Ok(false)
 }
 
 /// Internal helper: `ModuleDictStrategy::delitem` body for pyre's
@@ -5290,17 +5460,25 @@ mod tests {
     /// A user `__eq__` that raises during a colliding store must leave the
     /// dict unchanged and surface the first error, matching r_dict raising
     /// mid-probe without completing setitem.  Verifies: the store reports an
-    /// error, the spuriously appended entry is dropped (k1 intact, k2 never
-    /// stored), and `__eq__` runs exactly once (the probe short-circuits
-    /// after the first raise).
+    /// error, the withheld store never inserts (k1 intact, k2 never stored),
+    /// and `__eq__` runs exactly once (the scan short-circuits after the
+    /// first raise).
+    ///
+    /// The keys are out-of-`int`-range longs so `key_equality_is_builtin` is
+    /// false and the comparison actually routes through the `eq_w` hook —
+    /// exact `str`/`int` keys settle on the builtin ladder and never reach a
+    /// user `__eq__`.
     #[test]
     fn test_dict_store_raising_eq_leaves_dict_unchanged() {
+        use crate::longobject::w_long_new;
+        use malachite_bigint::BigInt;
         install_test_hash_hook();
         unsafe {
             crate::dict_eq_hook::register_hash_w_hook(constant_collision_hash);
             let dict = w_dict_new();
-            let k1 = w_str_new("k1");
-            let k2 = w_str_new("k2");
+            let huge = BigInt::from(i64::MAX) * BigInt::from(2);
+            let k1 = w_long_new(huge.clone());
+            let k2 = w_long_new(huge + BigInt::from(1));
             // Seed one entry while the bucket is empty (no comparison runs).
             w_dict_store(dict, k1, w_int_new(1));
 

--- a/pyre/pyre-object/src/setobject.rs
+++ b/pyre/pyre-object/src/setobject.rs
@@ -307,6 +307,15 @@ unsafe fn scan_set_key_reentrant(
 ) -> Result<(Option<usize>, crate::dictmultiobject::ObjectKey), crate::dictmultiobject::DictKeyError>
 {
     'restart: loop {
+        // Snapshot the table so a comparison that reallocates the backing
+        // store restarts the scan: `ll_dict_lookup` retries on
+        // `entries != d.entries` even when the candidate entry is untouched
+        // (`rordereddict.py:1058`).  A grow copies every entry to a fresh
+        // allocation, so a stale index would otherwise compare the wrong key.
+        let table_capacity = {
+            let s = &*(obj as *const W_SetObject);
+            (*s.items).capacity()
+        };
         let mut i = 0;
         loop {
             let Some((stored_hash, stored_obj)) = ({
@@ -335,13 +344,16 @@ unsafe fn scan_set_key_reentrant(
                     return Ok((Some(i), key));
                 }
 
-                let entry_unchanged = {
+                let disturbed = {
                     let s = &*(obj as *const W_SetObject);
-                    (*s.items).get_index(i).is_some_and(|(stored, _)| {
-                        stored.hash == stored_hash && stored.obj == stored_obj
-                    })
+                    // `entries != d.entries`: a realloc moved the whole table.
+                    (*s.items).capacity() != table_capacity
+                        // `entries.valid(index) && entries[index].key == checkingkey`.
+                        || !(*s.items).get_index(i).is_some_and(|(stored, _)| {
+                            stored.hash == stored_hash && stored.obj == stored_obj
+                        })
                 };
-                if !entry_unchanged {
+                if disturbed {
                     continue 'restart;
                 }
             }

--- a/pyre/pyre-object/src/setobject.rs
+++ b/pyre/pyre-object/src/setobject.rs
@@ -340,10 +340,11 @@ unsafe fn scan_set_key_reentrant(
                 if crate::dictmultiobject::take_dict_key_error() {
                     return Err(crate::dictmultiobject::DictKeyError);
                 }
-                if equal {
-                    return Ok((Some(i), key));
-                }
-
+                // Validate the paranoia condition before acting on the result:
+                // `ll_dict_lookup` restarts even when the comparison answered
+                // `true`, because a callback that reallocated the table or moved
+                // the candidate leaves the matched index stale
+                // (`rordereddict.py:1058`).
                 let disturbed = {
                     let s = &*(obj as *const W_SetObject);
                     // `entries != d.entries`: a realloc moved the whole table.
@@ -355,6 +356,9 @@ unsafe fn scan_set_key_reentrant(
                 };
                 if disturbed {
                     continue 'restart;
+                }
+                if equal {
+                    return Ok((Some(i), key));
                 }
             }
             i += 1;


### PR DESCRIPTION
Object-keyed dicts and every set probe their `IndexMap` buckets through
`ObjectKey::eq`, which reaches user `__eq__`. This branch is rebased onto
`origin/main`, which already carries the set-side callback-free probe +
`scan_set_key_reentrant` protection. It adds the same protection for the dict
side, corrects the comparison operand order, and completes the reentrant
scan's restart condition for both containers.

### 1. Comparison operands were reversed

`ll_dict_lookup` runs `keyeq(checkingkey, key)` with the **stored** key on the
left (`rordereddict.py:1055`, `:1095`); pyre passed the probe key first, in
both `ObjectKey::eq` and `StrLookupKey::equivalent`. `kwargsdict` already used
the stored-first order, so the convention was established.

This changes the *answer*, not just the call order: an `__eq__` returning plain
`False` (not `NotImplemented`) suppresses the reflected call.

```python
class LeftOnly:
    def __init__(self, v): self.v = v
    def __hash__(self): return 7
    def __eq__(self, other): return isinstance(other, LeftOnly)
```
`LeftOnly(1) in {LeftOnly(0)}` — CPython `True`, PyPy `True`, pyre was `False`.

### 2. The dict probe held a borrow across the user comparison

The set side on `origin/main` already runs its bucket probes callback-free and
rescans on reentrancy, but the object-strategy dict path did not: `getitem` /
`setitem` / `setdefault` / `pop` / `delitem` called
`IndexMap::{get,insert,shift_remove,entry}` directly, so a hash-colliding user
`__eq__` ran through `dict_keys_equal` while a `&`/`&mut` into the backing table
was live. A comparison that stores into the same dict takes a second `&mut`, and
growth reallocates the entries `Vec`, dangling the slice the probe holds.

The dict path now mirrors the set path:

- `callback_free_dict_op` raises the callback-free guard, so `dict_keys_equal`
  answers builtin pairs from its type ladder and breaks on anything it cannot
  decide. A broken probe withholds its mutation, leaving the dict untouched.
- `scan_dict_key_reentrant` then re-runs the probe reading one entry at a time,
  dropping the table borrow before each `dict_keys_equal` and pinning both
  operands on the shadow stack across the call.

The infallible `w_dict_*_object_strategy` variants route through their checked
counterparts, so both share the one reentrancy-safe path.

### 3. The reentrant scan never restarted on a reallocation — and pyre matched neither CPython nor PyPy

`ll_dict_lookup`'s paranoia arm restarts the whole lookup when the comparison
**replaced the entries array**, replaced the indexes array, invalidated the
entry, or changed the slot's key (`rordereddict.py:1058`). `scan_*_key_reentrant`
only checked the last two — it retried when the candidate entry changed, but not
when a callback grew the container and moved every entry to a fresh allocation
while leaving the candidate in place. A restart forgets every earlier
comparison, so a candidate that answered `False` before the mutation is compared
again and may answer differently; without it, that candidate was never
revisited.

**This is not a PyPy quirk — CPython does the same thing.** With a single
colliding key stored (so probe order cannot decide the outcome), the sole
question is whether the rejected candidate is revisited:

```python
class Filler:                     # distinct hashes: filling runs no key compare
    def __init__(self, i): self.i = i
    def __hash__(self): return 1000 + self.i
    def __eq__(self, other): return self is other

class K:
    def __init__(self, tag, v): self.tag = tag; self.v = v
    def __hash__(self): return 7
    def __eq__(self, other):
        if self is other: return True
        if not isinstance(other, K): return NotImplemented
        if self.tag == 'A' and self.v == 1:
            self.v = 2                                # a re-comparison now answers True
            for i in range(8): owner.add(Filler(i))   # replace the backing arrays
            return False
        return self.v == other.v

owner = {K('A', 1)}
owner.discard(K('P', 2))
# 'A' removed?  CPython: yes   PyPy: yes   pyre before: NO   pyre after: yes
```

Both scans now snapshot the table capacity at the start of each attempt and
restart when it changed (`entries != d.entries`), alongside the existing
entry-changed check. Like `origin/main`'s scan the retry is an iterative
`continue`, not upstream's recursion; a callback that reallocates on every
comparison would spin rather than raise `RecursionError`, matching the existing
set-side shape.

## Verification

- `check.py` **dynasm 289/289**, **cranelift 289/289**; `cargo test -p pyre-object` 218/218.
- Restart discriminator (`synth/key_eq_restart_forgets`, one colliding key + 8
  distinct-hash fillers): pyre now matches **both** CPython and PyPy across
  set `add`/`contains`/`discard` and dict `setitem`/`getitem`/`setdefault`/`pop`
  (before, it matched neither).
- Benches produce byte-identical output on CPython, PyPy and pyre:
  `synth/dict_set_key_eq_operand_order`, `synth/reentrant_key_eq_mutation`
  (add-from-inside-`__eq__`, set + dict, 8 colliding keys),
  `synth/key_eq_resize_restart` (48-entry mid-probe growth), and
  `synth/key_eq_restart_forgets`.

## Residual (narrow, pre-existing, out of scope)

- The str fast paths (`dict_entries_get_str` / `dict_entries_index_of_str`)
  still probe a `StrLookupKey` outside the callback-free guard, so a stored
  user-typed key whose hash collides with the looked-up string can run its
  `__eq__` under the borrow. This needs a str/user hash collision and is
  unchanged from `origin/main`.
- The module-dict object path (`w_module_dict_lookup_inner` and friends) probes
  its `IndexMap` directly, without the callback-free + scan protection. Module
  dicts are string-keyed in practice and only reach the object strategy after a
  non-str key promotion, so the reentrancy window is narrow; unchanged here.
- The scan's reallocation check compares `IndexMap::capacity()`, a proxy for
  `entries != d.entries`. It catches every growth-triggered reallocation (the
  reentrancy shape the benches exercise) but not a callback that `clear()`s and
  rebuilds the table to the same capacity with the same key at the same index —
  `IndexMap` reuses its buffer and exposes no modification counter, so there is
  no cheap exact mirror. Still strictly stronger than the entry-only check.
- A cranelift-only GC crash exposed by the container-churning allocation shape
  is filed at `bench/synth/_pending/cranelift_finalizer_ordering_crash.py`; it
  is pre-existing (clean under `PYRE_NO_JIT=1` and on dynasm) and not addressed
  here. The gated benches keep their hot loops allocation-free so they do not
  trip it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dictionary and set reliability when custom key comparisons mutate containers during lookups or updates.
  * Ensured key comparisons behave consistently across insertion, retrieval, deletion, membership, and default-value operations.
  * Prevented table changes during comparisons from producing stale results or leaving containers in an inconsistent state.

* **Tests**
  * Added coverage and stress benchmarks for re-entrant comparisons, hash collisions, asymmetric equality, resizing, and mutation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->