### PR TITLE
jit: remove dead S2c extra_virtual_roots resume pipe

### DIFF
--- a/majit/majit-metainterp/src/history.rs
+++ b/majit/majit-metainterp/src/history.rs
@@ -1019,23 +1019,6 @@ impl TreeLoop {
                         .collect(),
                     vable_boxes: snap.vable_boxes.iter().map(&remap_tagged).collect(),
                     vref_boxes: snap.vref_boxes.iter().map(&remap_tagged).collect(),
-                    // Extra virtual roots are raw OpRefs (not tagged): remap each
-                    // to the post-cut namespace, mirroring `remap_tagged`'s Box
-                    // arm — unmapped runtime OpRefs drop to NONE, constants/NONE
-                    // pass through.
-                    extra_virtual_roots: snap
-                        .extra_virtual_roots
-                        .iter()
-                        .map(|old_ref| {
-                            if let Some(&new_ref) = remap.get(old_ref) {
-                                new_ref
-                            } else if !Self::is_runtime_opref(*old_ref) {
-                                *old_ref
-                            } else {
-                                OpRef::NONE
-                            }
-                        })
-                        .collect(),
                 }
             })
             .collect();
@@ -2248,7 +2231,6 @@ impl TraceCtx {
             pc,
             &[],
             &[],
-            &[],
         );
     }
 
@@ -2274,7 +2256,6 @@ impl TraceCtx {
         pc: u32,
         vable_boxes: &[crate::recorder::SnapshotTagged],
         vref_boxes: &[crate::recorder::SnapshotTagged],
-        extra_virtual_roots: &[OpRef],
     ) {
         // The pc word is a raw JitCode offset.
         let boxes = self.encode_snapshot_boxes(active_boxes);
@@ -2286,7 +2267,6 @@ impl TraceCtx {
             }],
             vable_boxes: vable_boxes.to_vec(),
             vref_boxes: vref_boxes.to_vec(),
-            extra_virtual_roots: extra_virtual_roots.to_vec(),
         });
         self.set_last_guard_resume_position(snapshot_id);
     }
@@ -2313,7 +2293,6 @@ impl TraceCtx {
             }],
             vable_boxes: vable_boxes.to_vec(),
             vref_boxes: vref_boxes.to_vec(),
-            extra_virtual_roots: Vec::new(),
         });
         self.set_last_guard_op_resume_position(snapshot_id);
     }
@@ -2369,10 +2348,6 @@ impl TraceCtx {
             frames: recorder_frames,
             vable_boxes: vable_boxes.to_vec(),
             vref_boxes: vref_boxes.to_vec(),
-            // The nested-list append fold resumes through the single-frame
-            // collapse, never this multi-frame path, so no extra virtual roots
-            // flow here.
-            extra_virtual_roots: Vec::new(),
         });
         self.set_last_guard_resume_position(snapshot_id);
     }
@@ -2407,10 +2382,6 @@ impl TraceCtx {
             frames: recorder_frames,
             vable_boxes: vable_boxes.to_vec(),
             vref_boxes: vref_boxes.to_vec(),
-            // The nested-list append fold resumes through the single-frame
-            // collapse, never this multi-frame path, so no extra virtual roots
-            // flow here.
-            extra_virtual_roots: Vec::new(),
         });
         self.set_last_guard_op_resume_position(snapshot_id);
     }
@@ -2875,7 +2846,6 @@ impl TraceCtx {
             }],
             vable_boxes: Vec::new(),
             vref_boxes: Vec::new(),
-            extra_virtual_roots: Vec::new(),
         });
         let opref = self.record_guard(opcode, args, num_live);
         self.recorder.set_last_op_resume_position(snapshot_idx);

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -754,12 +754,6 @@ pub struct OptContext {
     /// resume.py:243-247 _number_boxes consumes vref_array as a section
     /// after vable_array. opencoder.py:767 records vref_boxes here.
     pub snapshot_vref_boxes: SnapshotBoxes,
-    /// Per-guard extra virtual roots (nested-list append fold's inner-list
-    /// wrapper) from tracing-time snapshots. Seeded into finish()'s virtual
-    /// worklist off the frame section. Empty except behind
-    /// `PYRE_NESTED_LIST_FOLD_VIRT`. Stored as `SnapshotBoxes` so they ride the
-    /// same unroll/bridge OpRef remap as the vable/vref sections.
-    pub snapshot_extra_virtual_roots: SnapshotBoxes,
     /// Per-guard per-frame (jitcode_index, pc) from tracing-time snapshots.
     pub snapshot_frame_pcs: SnapshotFramePcs,
     /// optimizer.py:34 `self.inputargs = inputargs` parity.
@@ -1697,7 +1691,6 @@ impl OptContext {
             snapshot_frame_sizes: Vec::new(),
             snapshot_vable_boxes: Vec::new(),
             snapshot_vref_boxes: Vec::new(),
-            snapshot_extra_virtual_roots: Vec::new(),
             snapshot_frame_pcs: Vec::new(),
 
             inputargs: Vec::new(),
@@ -2283,7 +2276,6 @@ impl OptContext {
             snapshot_frame_sizes: Vec::new(),
             snapshot_vable_boxes: Vec::new(),
             snapshot_vref_boxes: Vec::new(),
-            snapshot_extra_virtual_roots: Vec::new(),
             snapshot_frame_pcs: Vec::new(),
 
             inputargs: Vec::new(),
@@ -6340,28 +6332,10 @@ impl OptContext {
             return;
         };
 
-        // Extra virtual roots for this guard position — the nested-list append
-        // fold's inner-list wrapper, reachable only as a field of the outer
-        // virtual. Seeded into finish()'s virtual worklist off the frame section
-        // (empty except behind PYRE_NESTED_LIST_FOLD_VIRT). Stored as untyped
-        // SnapshotBoxes so they ride the same unroll/bridge OpRef remap as the
-        // vable/vref sections; finish() only reads their position OpRef.
-        let extra_virtual_roots: Vec<OpRef> = snapshot_get(
-            &self.snapshot_extra_virtual_roots,
-            op.rd_resume_position.get(),
-        )
-        .map(|boxes| boxes.iter().map(|b| b.opref()).collect())
-        .unwrap_or_default();
-
         // resume.py:428-445, 520-558: pending_setfields are passed to finish()
         // which handles register_box, visitor_walk_recursive, and tagging.
-        let (rd_numb, rd_consts, rd_virtuals, liveboxes, livebox_types) = memo.finish(
-            numb_state,
-            &env,
-            &mut pending_setfields,
-            knowledge.as_ref(),
-            &extra_virtual_roots,
-        );
+        let (rd_numb, rd_consts, rd_virtuals, liveboxes, livebox_types) =
+            memo.finish(numb_state, &env, &mut pending_setfields, knowledge.as_ref());
 
         if crate::callee_rca_enabled() {
             let vable_items = if rd_numb.len() >= 3 {

--- a/majit/majit-metainterp/src/optimizeopt/optimizer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/optimizer.rs
@@ -438,10 +438,6 @@ pub struct Optimizer {
     /// section. opencoder.py:767 create_top_snapshot records vref_boxes
     /// alongside vable_boxes.
     pub snapshot_vref_boxes: SnapshotBoxes,
-    /// Per-guard extra virtual roots (nested-list append fold's inner-list
-    /// wrapper) from tracing-time snapshots. Empty except behind
-    /// `PYRE_NESTED_LIST_FOLD_VIRT`.
-    pub snapshot_extra_virtual_roots: SnapshotBoxes,
     /// Per-guard per-frame (jitcode_index, pc) from tracing-time snapshots.
     pub snapshot_frame_pcs: SnapshotFramePcs,
     /// Phase 1 emit ops carried into Phase 2's lookup surface (6).
@@ -1409,7 +1405,6 @@ impl Optimizer {
             snapshot_frame_sizes: Vec::new(),
             snapshot_vable_boxes: Vec::new(),
             snapshot_vref_boxes: Vec::new(),
-            snapshot_extra_virtual_roots: Vec::new(),
             snapshot_frame_pcs: Vec::new(),
             phase1_emit_ops: Vec::new(),
             opt_ops_emitted: 0,
@@ -2464,7 +2459,6 @@ impl Optimizer {
             .iter()
             .chain(self.snapshot_vable_boxes.iter())
             .chain(self.snapshot_vref_boxes.iter())
-            .chain(self.snapshot_extra_virtual_roots.iter())
             .flatten()
             .flat_map(|boxes| boxes.iter().map(|boxref| boxref.opref()))
             .filter(|opref| !opref.is_none() && !opref.is_constant())
@@ -2491,7 +2485,6 @@ impl Optimizer {
         ctx.snapshot_frame_sizes = std::mem::take(&mut self.snapshot_frame_sizes);
         ctx.snapshot_vable_boxes = std::mem::take(&mut self.snapshot_vable_boxes);
         ctx.snapshot_vref_boxes = std::mem::take(&mut self.snapshot_vref_boxes);
-        ctx.snapshot_extra_virtual_roots = std::mem::take(&mut self.snapshot_extra_virtual_roots);
         ctx.snapshot_frame_pcs = std::mem::take(&mut self.snapshot_frame_pcs);
 
         sanitize_backend_constants_for_ops(ops.iter().map(|op| &**op), constants);

--- a/majit/majit-metainterp/src/optimizeopt/unroll.rs
+++ b/majit/majit-metainterp/src/optimizeopt/unroll.rs
@@ -294,10 +294,6 @@ pub struct UnrollOptimizer {
     /// (resume.py:243-247 vref_array — _number_boxes consumes them
     /// after the virtualizable array).
     pub snapshot_vref_boxes: SnapshotBoxes,
-    /// Per-guard extra virtual roots (nested-list append fold's inner-list
-    /// wrapper) from tracing-time snapshots. Empty except behind
-    /// `PYRE_NESTED_LIST_FOLD_VIRT`.
-    pub snapshot_extra_virtual_roots: SnapshotBoxes,
     /// Per-guard per-frame (jitcode_index, pc) from tracing-time snapshots.
     pub snapshot_frame_pcs: SnapshotFramePcs,
     /// pyjitpl.py:2289 all_descrs: dense list indexed by descr_index.
@@ -388,7 +384,6 @@ impl UnrollOptimizer {
             snapshot_frame_sizes: Vec::new(),
             snapshot_vable_boxes: Vec::new(),
             snapshot_vref_boxes: Vec::new(),
-            snapshot_extra_virtual_roots: Vec::new(),
             snapshot_frame_pcs: Vec::new(),
             all_descrs: Vec::new(),
             quasi_immutable_deps: Vec::new(),
@@ -632,13 +627,11 @@ impl UnrollOptimizer {
             opt_p1.snapshot_frame_sizes = self.snapshot_frame_sizes.clone();
             opt_p1.snapshot_vable_boxes = self.snapshot_vable_boxes.clone();
             opt_p1.snapshot_vref_boxes = self.snapshot_vref_boxes.clone();
-            opt_p1.snapshot_extra_virtual_roots = self.snapshot_extra_virtual_roots.clone();
             opt_p1.snapshot_frame_pcs = self.snapshot_frame_pcs.clone();
             self.replace_compile_snapshot_roots(Self::collect_snapshot_const_ptr_slots(&mut [
                 &mut opt_p1.snapshot_boxes,
                 &mut opt_p1.snapshot_vable_boxes,
                 &mut opt_p1.snapshot_vref_boxes,
-                &mut opt_p1.snapshot_extra_virtual_roots,
             ]));
             opt_p1.call_pure_results = self.call_pure_results.clone();
             // RPython optimize_preamble (unroll.py:101-103): flush=False.
@@ -956,8 +949,6 @@ impl UnrollOptimizer {
         opt_p2.snapshot_frame_sizes = std::mem::take(&mut self.snapshot_frame_sizes);
         opt_p2.snapshot_vable_boxes = std::mem::take(&mut self.snapshot_vable_boxes);
         opt_p2.snapshot_vref_boxes = std::mem::take(&mut self.snapshot_vref_boxes);
-        opt_p2.snapshot_extra_virtual_roots =
-            std::mem::take(&mut self.snapshot_extra_virtual_roots);
         opt_p2.snapshot_frame_pcs = std::mem::take(&mut self.snapshot_frame_pcs);
         opt_p2.call_pure_results = std::mem::take(&mut self.call_pure_results);
         // RPython: same Optimizer instance keeps patchguardop across phases.
@@ -1114,16 +1105,10 @@ impl UnrollOptimizer {
                 *r = r.map_opref(translate_opref);
             }
         }
-        for boxes in opt_p2.snapshot_extra_virtual_roots.iter_mut().flatten() {
-            for r in boxes.iter_mut() {
-                *r = r.map_opref(translate_opref);
-            }
-        }
         self.replace_compile_snapshot_roots(Self::collect_snapshot_const_ptr_slots(&mut [
             &mut opt_p2.snapshot_boxes,
             &mut opt_p2.snapshot_vable_boxes,
             &mut opt_p2.snapshot_vref_boxes,
-            &mut opt_p2.snapshot_extra_virtual_roots,
         ]));
         // Phase 1's emitted ops are already in Phase 1's emitted
         // namespace `[num_inputs..next_global_opref)`. Phase 2 body may
@@ -5781,15 +5766,6 @@ fn clone_guard_snapshot_remapped(
             &mut ctx.snapshot_vref_boxes,
             new_pos,
             remap_snapshot_boxes(&vref_boxes, ref_map),
-        );
-    }
-    if let Some(extra_virtual_roots) =
-        snapshot_get(&ctx.snapshot_extra_virtual_roots, old_pos).cloned()
-    {
-        snapshot_insert(
-            &mut ctx.snapshot_extra_virtual_roots,
-            new_pos,
-            remap_snapshot_boxes(&extra_virtual_roots, ref_map),
         );
     }
     if let Some(frame_pcs) = snapshot_get(&ctx.snapshot_frame_pcs, old_pos).cloned() {

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -494,7 +494,6 @@ fn snapshot_map_from_trace_snapshots(
     SnapshotFrameSizes,
     SnapshotBoxes,
     SnapshotBoxes,
-    SnapshotBoxes,
     SnapshotFramePcs,
 ) {
     let _ = constants; // legacy idx-Const pool no longer populated here; see SnapshotTagged::Const arm
@@ -502,7 +501,6 @@ fn snapshot_map_from_trace_snapshots(
     let mut size_map = Vec::new();
     let mut vable_map = Vec::new();
     let mut vref_map = Vec::new();
-    let mut evr_map = Vec::new();
     let mut pc_map = Vec::new();
     // opencoder.py:603 _encode: trace snapshot recorder only emits Box
     // (live deadframe slot) and Const (compile-time pool) payloads.
@@ -554,14 +552,6 @@ fn snapshot_map_from_trace_snapshots(
         // AND vref_array. resume.py:243-247 _number_boxes consumes
         // vref_array as a separate section after vable_array.
         let vref_boxes: Vec<SnapshotBox> = snap.vref_boxes.iter().map(&tagged_to_box).collect();
-        // Extra virtual roots are raw OpRefs (not SnapshotTagged): wrap each as
-        // an untyped SnapshotBox so it rides the same unroll/bridge OpRef remap
-        // as the vable/vref sections. finish() reads only their position OpRef.
-        let extra_virtual_roots: Vec<SnapshotBox> = snap
-            .extra_virtual_roots
-            .iter()
-            .map(|opref| SnapshotBox::from(*opref))
-            .collect();
         let frame_pcs: Vec<(i32, i32)> = snap
             .frames
             .iter()
@@ -572,10 +562,9 @@ fn snapshot_map_from_trace_snapshots(
         snapshot_insert(&mut size_map, id, frame_sizes);
         snapshot_insert(&mut vable_map, id, vable_boxes);
         snapshot_insert(&mut vref_map, id, vref_boxes);
-        snapshot_insert(&mut evr_map, id, extra_virtual_roots);
         snapshot_insert(&mut pc_map, id, frame_pcs);
     }
-    (box_map, size_map, vable_map, vref_map, evr_map, pc_map)
+    (box_map, size_map, vable_map, vref_map, pc_map)
 }
 
 struct PreparedBridgeTrace {
@@ -585,7 +574,6 @@ struct PreparedBridgeTrace {
     snapshot_frame_sizes: SnapshotFrameSizes,
     snapshot_vable_boxes: SnapshotBoxes,
     snapshot_vref_boxes: SnapshotBoxes,
-    snapshot_extra_virtual_roots: SnapshotBoxes,
     snapshot_frame_pcs: SnapshotFramePcs,
     pending_bridge_rd: Option<PendingBridgeRd>,
     runtime_boxes: Vec<OpRef>,
@@ -672,7 +660,6 @@ fn prepare_bridge_trace_for_optimizer(
     snapshot_frame_sizes: SnapshotFrameSizes,
     snapshot_vable_boxes: SnapshotBoxes,
     snapshot_vref_boxes: SnapshotBoxes,
-    snapshot_extra_virtual_roots: SnapshotBoxes,
     snapshot_frame_pcs: SnapshotFramePcs,
     pending_bridge_rd: Option<PendingBridgeRd>,
     runtime_boxes: Vec<OpRef>,
@@ -721,8 +708,6 @@ fn prepare_bridge_trace_for_optimizer(
     let snapshot_boxes = translate_trace_iter_box_map(snapshot_boxes, &cache);
     let snapshot_vable_boxes = translate_trace_iter_box_map(snapshot_vable_boxes, &cache);
     let snapshot_vref_boxes = translate_trace_iter_box_map(snapshot_vref_boxes, &cache);
-    let snapshot_extra_virtual_roots =
-        translate_trace_iter_box_map(snapshot_extra_virtual_roots, &cache);
     let pending_bridge_rd = pending_bridge_rd.map(|mut prd| {
         prd.liveboxes = prd
             .liveboxes
@@ -747,7 +732,6 @@ fn prepare_bridge_trace_for_optimizer(
         snapshot_frame_sizes,
         snapshot_vable_boxes,
         snapshot_vref_boxes,
-        snapshot_extra_virtual_roots,
         snapshot_frame_pcs,
         pending_bridge_rd,
         runtime_boxes,
@@ -5467,7 +5451,6 @@ impl<M: Clone> MetaInterp<M> {
             snapshot_frame_size_map,
             mut snapshot_vable_map,
             mut snapshot_vref_map,
-            snapshot_evr_map,
             snapshot_pc_map,
         ) = snapshot_map_from_trace_snapshots(&trace_snapshots, &mut constants);
         // history.py:220/261/307 — `Const{Int,Float,Ptr}.type` is an
@@ -5478,7 +5461,6 @@ impl<M: Clone> MetaInterp<M> {
         unroll_opt.snapshot_frame_sizes = snapshot_frame_size_map.clone();
         unroll_opt.snapshot_vable_boxes = snapshot_vable_map.clone();
         unroll_opt.snapshot_vref_boxes = snapshot_vref_map.clone();
-        unroll_opt.snapshot_extra_virtual_roots = snapshot_evr_map.clone();
         unroll_opt.snapshot_frame_pcs = snapshot_pc_map.clone();
         // The original snapshot maps are re-cloned into `simple_opt` on the
         // InvalidLoop retry below, so they must stay rooted across the WHOLE
@@ -5604,10 +5586,6 @@ impl<M: Clone> MetaInterp<M> {
                         simple_opt.snapshot_frame_sizes = snapshot_frame_size_map;
                         simple_opt.snapshot_vable_boxes = snapshot_vable_map;
                         simple_opt.snapshot_vref_boxes = snapshot_vref_map;
-                        // Extra virtual roots carry only non-const virtual OpRefs
-                        // (no inline ConstPtr gcrefs), so they are not part of the
-                        // const-ptr root-slot set above; move the map through.
-                        simple_opt.snapshot_extra_virtual_roots = snapshot_evr_map;
                         simple_opt.snapshot_frame_pcs = snapshot_pc_map;
                         simple_opt.call_pure_results = call_pure_results.clone();
                         // Forward the recorder's operand pool — the retry path
@@ -6519,7 +6497,6 @@ impl<M: Clone> MetaInterp<M> {
             snapshot_frame_sizes,
             mut snapshot_vable_boxes,
             mut snapshot_vref_boxes,
-            snapshot_extra_virtual_roots,
             snapshot_frame_pcs,
         ) = snapshot_map_from_trace_snapshots(&trace_snapshots, &mut constants);
         self.compile_snapshot_refs = collect_snapshot_const_ptr_slots(&mut [
@@ -6606,7 +6583,6 @@ impl<M: Clone> MetaInterp<M> {
                     snapshot_frame_sizes,
                     snapshot_vable_boxes,
                     snapshot_vref_boxes,
-                    snapshot_extra_virtual_roots,
                     snapshot_frame_pcs,
                     call_pure_results,
                 );
@@ -6640,7 +6616,6 @@ impl<M: Clone> MetaInterp<M> {
                     snapshot_frame_sizes,
                     snapshot_vable_boxes,
                     snapshot_vref_boxes,
-                    snapshot_extra_virtual_roots,
                     snapshot_frame_pcs,
                 );
                 if success {
@@ -6861,7 +6836,6 @@ impl<M: Clone> MetaInterp<M> {
             retrace_snapshot_frame_sizes,
             mut retrace_snapshot_vable_boxes,
             mut retrace_snapshot_vref_boxes,
-            retrace_snapshot_extra_virtual_roots,
             retrace_snapshot_frame_pcs,
         ) = snapshot_map_from_trace_snapshots(&trace.snapshots, &mut constants);
         self.compile_snapshot_refs = collect_snapshot_const_ptr_slots(&mut [
@@ -6875,7 +6849,6 @@ impl<M: Clone> MetaInterp<M> {
         unroll_opt.snapshot_frame_sizes = retrace_snapshot_frame_sizes;
         unroll_opt.snapshot_vable_boxes = retrace_snapshot_vable_boxes;
         unroll_opt.snapshot_vref_boxes = retrace_snapshot_vref_boxes;
-        unroll_opt.snapshot_extra_virtual_roots = retrace_snapshot_extra_virtual_roots;
         unroll_opt.snapshot_frame_pcs = retrace_snapshot_frame_pcs;
         // Import the exported state from the first (failed) attempt so the
         // optimizer can continue from where it left off.
@@ -7406,7 +7379,6 @@ impl<M: Clone> MetaInterp<M> {
             snapshot_frame_size_map,
             mut snapshot_vable_map,
             mut snapshot_vref_map,
-            snapshot_evr_map,
             snapshot_pc_map,
         ) = snapshot_map_from_trace_snapshots(&trace_snapshots, &mut constants);
         self.compile_snapshot_refs = collect_snapshot_const_ptr_slots(&mut [
@@ -7426,7 +7398,6 @@ impl<M: Clone> MetaInterp<M> {
         optimizer.snapshot_frame_sizes = snapshot_frame_size_map;
         optimizer.snapshot_vable_boxes = snapshot_vable_map;
         optimizer.snapshot_vref_boxes = snapshot_vref_map;
-        optimizer.snapshot_extra_virtual_roots = snapshot_evr_map;
         optimizer.snapshot_frame_pcs = snapshot_pc_map;
 
         // InvalidLoop during optimization should abort the trace, not crash
@@ -7819,7 +7790,6 @@ impl<M: Clone> MetaInterp<M> {
             snapshot_frame_size_map,
             mut snapshot_vable_map,
             mut snapshot_vref_map,
-            snapshot_evr_map,
             snapshot_pc_map,
         ) = snapshot_map_from_trace_snapshots(&trace_snapshots, &mut constants);
         self.compile_snapshot_refs = collect_snapshot_const_ptr_slots(&mut [
@@ -7831,7 +7801,6 @@ impl<M: Clone> MetaInterp<M> {
         optimizer.snapshot_frame_sizes = snapshot_frame_size_map;
         optimizer.snapshot_vable_boxes = snapshot_vable_map;
         optimizer.snapshot_vref_boxes = snapshot_vref_map;
-        optimizer.snapshot_extra_virtual_roots = snapshot_evr_map;
         optimizer.snapshot_frame_pcs = snapshot_pc_map;
 
         let optimize_result = optimizer.optimize_with_constants_and_inputs_oprc(
@@ -9921,7 +9890,6 @@ impl<M: Clone> MetaInterp<M> {
         snapshot_frame_sizes: SnapshotFrameSizes,
         snapshot_vable_boxes: SnapshotBoxes,
         snapshot_vref_boxes: SnapshotBoxes,
-        snapshot_extra_virtual_roots: SnapshotBoxes,
         snapshot_frame_pcs: SnapshotFramePcs,
     ) -> bool {
         if !self.compiled_loops.contains_key(&green_key) {
@@ -9966,7 +9934,6 @@ impl<M: Clone> MetaInterp<M> {
             snapshot_frame_sizes,
             snapshot_vable_boxes,
             snapshot_vref_boxes,
-            snapshot_extra_virtual_roots,
             snapshot_frame_pcs,
             None,
             bridge_runtime_boxes,
@@ -9996,7 +9963,6 @@ impl<M: Clone> MetaInterp<M> {
         optimizer.snapshot_frame_sizes = prepared.snapshot_frame_sizes;
         optimizer.snapshot_vable_boxes = prepared.snapshot_vable_boxes;
         optimizer.snapshot_vref_boxes = prepared.snapshot_vref_boxes;
-        optimizer.snapshot_extra_virtual_roots = prepared.snapshot_extra_virtual_roots;
         optimizer.snapshot_frame_pcs = prepared.snapshot_frame_pcs;
         optimizer.trace_inputargs = bridge_inputargs
             .iter()
@@ -10365,7 +10331,6 @@ impl<M: Clone> MetaInterp<M> {
         snapshot_frame_sizes: SnapshotFrameSizes,
         snapshot_vable_boxes: SnapshotBoxes,
         snapshot_vref_boxes: SnapshotBoxes,
-        snapshot_extra_virtual_roots: SnapshotBoxes,
         snapshot_frame_pcs: SnapshotFramePcs,
         call_pure_results: indexmap::IndexMap<Vec<Value>, Value>,
     ) -> bool {
@@ -10557,7 +10522,6 @@ impl<M: Clone> MetaInterp<M> {
             snapshot_frame_sizes,
             snapshot_vable_boxes,
             snapshot_vref_boxes,
-            snapshot_extra_virtual_roots,
             snapshot_frame_pcs,
             pending_bridge_rd,
             bridge_runtime_boxes,
@@ -10612,7 +10576,6 @@ impl<M: Clone> MetaInterp<M> {
         optimizer.snapshot_frame_sizes = prepared.snapshot_frame_sizes;
         optimizer.snapshot_vable_boxes = prepared.snapshot_vable_boxes;
         optimizer.snapshot_vref_boxes = prepared.snapshot_vref_boxes;
-        optimizer.snapshot_extra_virtual_roots = prepared.snapshot_extra_virtual_roots;
         optimizer.snapshot_frame_pcs = prepared.snapshot_frame_pcs;
         // Store bridge inputarg types so export_state can mint typed
         // `renamed_inputargs` OpRefs that carry their type intrinsically
@@ -19290,7 +19253,6 @@ mod tests {
             snapshot_vable_boxes,
             Vec::new(),
             Vec::new(),
-            Vec::new(),
             Some(pending_bridge_rd),
             bridge_runtime_boxes,
             10,
@@ -20453,7 +20415,6 @@ mod tests {
                 }],
                 vable_boxes: Vec::new(),
                 vref_boxes: Vec::new(),
-                extra_virtual_roots: Vec::new(),
             })
         };
         assert_eq!(snapshot_id, 0);

--- a/majit/majit-metainterp/src/pyjitpl/dispatch.rs
+++ b/majit/majit-metainterp/src/pyjitpl/dispatch.rs
@@ -8031,7 +8031,6 @@ pub fn build_state_field_snapshot(
         frames: snapshot_frames,
         vable_boxes: vable_boxes_snap,
         vref_boxes: vref_boxes_snap,
-        extra_virtual_roots: Vec::new(),
     }
 }
 

--- a/majit/majit-metainterp/src/recorder.rs
+++ b/majit/majit-metainterp/src/recorder.rs
@@ -59,18 +59,6 @@ pub struct Snapshot {
     pub vable_boxes: Vec<SnapshotTagged>,
     /// VirtualRef box references (tagged).
     pub vref_boxes: Vec<SnapshotTagged>,
-    /// Extra virtual roots to seed into the resume-data virtual worklist
-    /// beyond the frame's liveness boxes and the vable/vref prefixes — virtual
-    /// op-results reachable only as a field of another walker-minted virtual,
-    /// with no frame-liveness slot of their own.  Each entry is numbered
-    /// `TAGVIRTUAL` (off the liveness-counted frame section), so
-    /// `_number_boxes` / `finish` descends into it via
-    /// `get_virtual_fields` exactly as it does for a live TAGVIRTUAL box
-    /// (`_visitor_walk_recursive`).  Empty on every path except the
-    /// nested-list append fold behind `PYRE_NESTED_LIST_FOLD_VIRT`; the inner
-    /// `[[i] …]` wrapper enters here so its separately allocated backing block
-    /// is rooted in resume data.
-    pub extra_virtual_roots: Vec<OpRef>,
 }
 
 /// One frame in a snapshot — corresponds to one MIFrame/JitCode position.

--- a/majit/majit-metainterp/src/resume.rs
+++ b/majit/majit-metainterp/src/resume.rs
@@ -3933,13 +3933,6 @@ impl ResumeDataLoopMemo {
     ///   target_tagged/value_tagged are filled in-place.
     /// `optimizer_knowledge`: bridgeopt.py:63 serialize_optimizer_knowledge.
     ///   Heap field triples and known-class info for bridge compilation.
-    /// `extra_virtual_roots`: virtual op-results reachable only as a field of
-    ///   another walker-minted virtual (no frame-liveness slot of their own).
-    ///   Seeded into the virtual worklist as `register_virtual_box` roots — the
-    ///   `_visitor_walk_recursive` analog descends into each via
-    ///   `get_virtual_fields`, so a nested `[[i] …]` inner-list wrapper roots its
-    ///   separately allocated backing block. Empty on every path except the
-    ///   nested-list append fold behind `PYRE_NESTED_LIST_FOLD_VIRT`.
     ///
     /// Returns `(rd_numb, rd_consts, rd_virtuals, liveboxes, livebox_types)`.
     /// `livebox_types` maps typed OpRef → Type, captured at numbering time
@@ -3950,7 +3943,6 @@ impl ResumeDataLoopMemo {
         env: &dyn majit_ir::BoxEnv,
         pending_setfields: &mut [majit_ir::GuardPendingFieldEntry],
         optimizer_knowledge: Option<&OptimizerKnowledgeForResume>,
-        extra_virtual_roots: &[majit_ir::OpRef],
     ) -> (
         Vec<u8>,
         Vec<majit_ir::Const>,
@@ -4006,30 +3998,6 @@ impl ResumeDataLoopMemo {
                 debug_assert_eq!(tagbits, TAGVIRTUAL);
                 virtual_worklist.push(opref);
             }
-        }
-
-        // Seed the walker-minted extra virtual roots (the nested-list append
-        // fold's inner-list wrapper) into the same worklist. These carry no
-        // frame-liveness slot — they are reachable only as a field of another
-        // virtual — so they are numbered off the frame section: `register_
-        // virtual_box` stamps them UNASSIGNEDVIRTUAL (resume.py:359-368
-        // register_virtual_fields default) so `_number_virtuals` gives them an
-        // `rd_virtuals` slot without ever making them a fail-arg, and the drain
-        // below descends into each via `get_virtual_fields` — the pyre analog of
-        // `_visitor_walk_recursive` reaching the wrapper's backing block.
-        for &root in extra_virtual_roots {
-            if root.is_none() {
-                continue;
-            }
-            let resolved = env.get_box_replacement(root);
-            if resolved.is_none()
-                || virtual_fields.contains_key(&resolved)
-                || !(env.is_virtual_ref(resolved) || env.is_virtual_raw(resolved))
-            {
-                continue;
-            }
-            self.register_virtual_box(resolved, env, &numb_state.liveboxes, &mut new_liveboxes);
-            virtual_worklist.push(resolved);
         }
 
         // Worklist-based recursive virtual discovery (RPython visitor_walk_recursive).
@@ -5023,7 +4991,7 @@ mod tests {
         );
         let numb_state = memo.number(&snapshot, &env, -1).unwrap();
         let (rd_numb, rd_consts, _rd_virtuals, liveboxes, _livebox_types) =
-            memo.finish(numb_state, &env, &mut [], None, &[]);
+            memo.finish(numb_state, &env, &mut [], None);
 
         // liveboxes should contain only TAGBOX entries: OpRef::int_op(1) and OpRef::int_op(3)
         assert_eq!(liveboxes.len(), 2);

--- a/majit/majit-metainterp/tests/jit_driver_runtime_parity.rs
+++ b/majit/majit-metainterp/tests/jit_driver_runtime_parity.rs
@@ -34,7 +34,6 @@ fn attach_single_frame_snapshot(ctx: &mut TraceCtx, pc: u32, boxes: &[(OpRef, Ty
         }],
         vable_boxes: Vec::new(),
         vref_boxes: Vec::new(),
-        extra_virtual_roots: Vec::new(),
     });
     ctx.set_last_guard_resume_position(snapshot_id);
 }

--- a/pyre/bench/synth/nested_list_comprehension_hot.py
+++ b/pyre/bench/synth/nested_list_comprehension_hot.py
@@ -1,15 +1,15 @@
 # An inlined list comprehension whose LIST_APPEND element is a non-empty nested
 # list (`[[i] …]` / `[[i, i + 1] …]`). The #171 fold virtualizes the inner list,
-# but its separately allocated backing block (NewArray / NewArrayClear) carries
-# no jitcode-liveness color, so it is not rooted in the append commit sub-walk's
-# guard-exit resume data and a deopt resolves it to a null OpRef.
+# whose separately allocated backing block (NewArray / NewArrayClear) carries no
+# jitcode-liveness color. Once the trace-time single-executor forks were retired
+# the append body no longer runs under a speculative-replay sub-walk, so the
+# backing block is bound at every guard-exit deopt without an extra resume-data
+# root; the shape is admitted by default (PYRE_NESTED_LIST_FOLD_VIRT, default-on).
 #
-# Held back behind the DEFAULT-OFF PYRE_NESTED_LIST_FOLD_VIRT gate: while the
-# gate is off `for_iter_bodies_all_jit_safe` declines the shape, so this runs in
-# the interpreter and prints the correct total. It is the acceptance repro for
-# the recursive virtual-list-forcing rooting work — with the gate on it must
-# still print the same total on all three backends (dynasm / cranelift / wasm)
-# once the rooting lands.
+# Acceptance repro for that fold: it must print the same total on all three
+# backends (dynasm / cranelift / wasm). Set PYRE_NESTED_LIST_FOLD_VIRT=0 to fall
+# back to the `for_iter_bodies_all_jit_safe` interpreter decline (native only —
+# the wasm guest cannot read the env var).
 
 
 def single_comp(n):

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
@@ -3828,21 +3828,6 @@ pub(crate) struct GuardCaptureScope<'a> {
     /// with the exact, depth-independent edge resolution. Empty outside the
     /// gated kept-stack path.
     pub branch_guard_kept_recovered: &'a [(u16, OpRef)],
-
-    /// Extra virtual roots to seed into the guard snapshot beyond the outer
-    /// Python frame's jitcode-liveness boxes — walker-minted virtual op-results
-    /// that carry no liveness color yet must survive a deopt as fail-arg roots.
-    /// The motivating case is the `w_list_append` commit sub-walk over a
-    /// non-empty nested list element (`[[i] for i in range(n)]`): the appended
-    /// inner-list wrapper is passed to the sub-walk as a register arg but is not
-    /// named by any live outer color, so without an explicit root the resume
-    /// recursion never descends into it and its backing block resolves to a null
-    /// `OpRef`. Each entry is the `(OpRef, Type)` of a root the snapshot builder
-    /// must append to the top frame's boxes so the ported
-    /// `_visitor_walk_recursive` registers the nested virtual (wrapper + backing
-    /// block) in resume data. Empty on every path today: only populated behind
-    /// the DEFAULT-OFF `PYRE_NESTED_LIST_FOLD_VIRT` gate, so this is dormant.
-    pub sub_walk_extra_virtual_roots: &'a [(OpRef, majit_ir::Type)],
 }
 
 /// `rlib/jit.py:601` `max_unroll_recursion` default (= warmstate

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/resume_snapshot.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/resume_snapshot.rs
@@ -980,16 +980,6 @@ pub(crate) fn walker_capture_snapshot_for_last_guard_impl<Sym: WalkSym>(
                 scope.branch_guard_kept_recovered,
             );
             let pc_word = resolved_offset as u32;
-            // S2b: the walker-minted extra virtual roots (the nested-list append
-            // fold's inner-list wrapper) ride the snapshot as TAGVIRTUAL worklist
-            // seeds, NOT frame-liveness boxes — they must never enter `active`
-            // (which is liveness-counted, `state.rs` setup_bridge_sym assert) nor
-            // `vable_boxes` (size-exact, `resume.rs` consume_vable_info assert).
-            let extra_virtual_roots: Vec<majit_ir::OpRef> = scope
-                .sub_walk_extra_virtual_roots
-                .iter()
-                .map(|(opref, _ty)| *opref)
-                .collect();
             ctx.trace_ctx
                 .capture_snapshot_for_last_guard_with_vable_vref(
                     &active,
@@ -997,7 +987,6 @@ pub(crate) fn walker_capture_snapshot_for_last_guard_impl<Sym: WalkSym>(
                     pc_word,
                     &vable_boxes,
                     &vref_boxes,
-                    &extra_virtual_roots,
                 );
             return Ok(());
         }
@@ -1029,8 +1018,6 @@ pub(crate) fn walker_capture_snapshot_for_last_guard_impl<Sym: WalkSym>(
             arm_pc_word,
             &vable_boxes,
             &vref_boxes,
-            // Per-opcode arm path: not the nested-list append fold, no extra roots.
-            &[],
         );
     Ok(())
 }

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -2971,9 +2971,6 @@ impl MIFrame {
             frames,
             vable_boxes,
             vref_boxes,
-            // Trait-leg (MIFrame) snapshot: the nested-list append fold is a
-            // full-body-walk-only path, so no extra virtual roots here.
-            extra_virtual_roots: Vec::new(),
         }
     }
 


### PR DESCRIPTION
## Summary

Removes the `extra_virtual_roots` resume-data channel end-to-end. It was the deferred "S2c" slice of the gh#389(b) nested-list-fold epic — machinery to root a nested comprehension's inner-list backing block across a deopt.

The channel is dead code: its **only writer would have been** `GuardCaptureScope::sub_walk_extra_virtual_roots`, which is never assigned on any path. So every `Snapshot::extra_virtual_roots` was an empty `Vec`, `ResumeDataLoopMemo::finish()`'s param was always `&[]`, and its seed loop never iterated. #344 (retiring the trace-time single-executor forks) removed the speculative-replay sub-walk this channel was built to serve, so the epic closed with the gate flipped default-on (already on `main`) — never needing the roots.

## What was deleted

- `recorder::Snapshot::extra_virtual_roots` field
- `ResumeDataLoopMemo::finish()` `extra_virtual_roots` parameter + its worklist seed loop (`resume.rs`)
- `snapshot_extra_virtual_roots` threading across `Optimizer` / `UnrollOptimizer` / `OptContext` / bridge (`optimizer.rs`, `unroll.rs`, `optimizeopt/mod.rs`, `pyjitpl.rs`) — field decls, inits, `mem::take`, remap loops, the `snapshot_map_from_trace_snapshots` tuple slot, `PreparedBridgeTrace` field, and the `compile_bridge`/`compile_entry_bridge` signatures
- consumer `GuardCaptureScope::sub_walk_extra_virtual_roots` + its reader (`resume_snapshot.rs`)

Also refreshes the `nested_list_comprehension_hot` bench header (was describing the retired default-off premise).

Since the removed code provably never executed, this is behavior-neutral.

## Verification

- `cargo test -p majit-metainterp --lib`: 1401 passed, 0 failed
- `pyre/check.py`: dynasm 246/246, cranelift 246/246, wasm 245/245, `internal_compile_panics=0`; `nested_list_comprehension_hot` green on all three
- `cargo fmt --check`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)