### PR TITLE
jit: assert list slice-delete removal count and non-null delete residual operands

### DIFF
--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -13691,6 +13691,20 @@ pub(crate) fn delitem_slot(obj: PyObjectRef, index: PyObjectRef) -> Result<(), P
                     crate::sliceobject::slice_adjust_indices(raw_start, raw_stop, step, len);
                 if step == 1 {
                     w_list_delslice(obj, start.max(0) as usize, stop.max(start) as usize);
+                    // Diagnostic (#24 wasm-Linux miscompile, root cause unpinned):
+                    // a correct `del list[a:b]` removes exactly `slicelength`
+                    // elements, leaving `len - slicelength`. The null-Ref operand
+                    // class was refuted on Linux CI (eval_slice_index's is_null
+                    // assert sits on this exact path and never fired), so a
+                    // stale/moved `items` backing or a length read desynced from
+                    // the mutated backing is the surviving hypothesis; trap loudly
+                    // with the counts so a wasm Linux run pins the divergence.
+                    let after = w_list_len(obj) as i64;
+                    assert!(
+                        after == len - slicelength,
+                        "delitem_slot step-1 slice-delete count mismatch (#24): after={after} expected={} len={len} slicelength={slicelength} start={start} stop={stop} raw_start={raw_start} raw_stop={raw_stop}",
+                        len - slicelength
+                    );
                     return Ok(());
                 }
                 // Extended-slice delete: gather the selected indices, then

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -5152,6 +5152,15 @@ pub extern "C" fn bh_store_slice_fn(obj: i64, start: i64, stop: i64, value: i64)
 /// `BH_LAST_EXC_VALUE` for the trailing `GuardNoException`, matching
 /// `bh_store_subscr_fn`.
 pub extern "C" fn bh_delete_subscr_fn(obj: i64, index: i64) -> i64 {
+    // Diagnostic (#24 wasm-Linux miscompile): the delete target and index Refs
+    // must be non-null at the residual boundary. A null `items` on the wasm
+    // resume path would silently mis-route — `is_list(null)` is false without a
+    // deref, so the slice branch is skipped and the operand reads guest offset 0.
+    // Trap loudly to pin a null `items`/`index` at the residual entry.
+    assert!(
+        obj != 0 && index != 0,
+        "bh_delete_subscr_fn: null residual operand (#24 wasm): obj={obj:#x} index={index:#x}"
+    );
     if let Err(mut err) = pyre_interpreter::baseobjspace::delitem(
         obj as pyre_object::PyObjectRef,
         index as pyre_object::PyObjectRef,


### PR DESCRIPTION
## Status update (CI on this PR)

The wasm `delete_negative_open_slice_hot` miscompile is **already resolved on
current `main` (877a4393)**: this PR's `check.py (ubuntu-24.04)` reports
`wasm 245/245 ALL PASSED` (the bench now returns the correct value, no longer
`WRONG`), and neither assert below fires. The bug was fixed by an intervening
`main` commit between `#698` (last observed `WRONG`) and `877a4393` — most
likely the wasm codegen fixes in `#661` and/or the `extra_virtual_roots`
threading in `#708` (exact fixer not bisected: wasm-Linux is CI-only). The lone
red check is an **unrelated** `cranelift synth/global_quasiimmut_invalidation`
x150.0 perf-ratio flake on a congested runner, not a correctness failure.

So these two asserts now stand as **regression guards** rather than a live
probe. They are universal invariants of a correct list slice-delete (verified
zero false-fire: `check.py --backend dynasm` 246/246 locally and wasm 245/245 on
CI), release-active so they also fire under `check.py`'s release builds.
**Landing vs closing is your call.**

## Background — how the null class was refuted first

The earlier null-Ref asserts (in `normalize_slice` / `eval_slice_index`) ran on
wasm-Linux CI and never fired while the bench was still wrong. That was
conclusive: list slice-delete goes `DELETE_SUBSCR` → residual `delete_subscr` →
`bh_delete_subscr_fn(obj, index)` → `delitem` → `delitem_slot` →
`slice_unpack(w_slice_get_start/stop/step)` → `eval_slice_index` per non-None
bound, so `eval_slice_index`'s `is_null` assert sat on the executed path — the
non-null result meant the divergence was a non-null wrong value, not a null.

## The two guards

- `delitem_slot` step-1 branch asserts `post-delete len == len - slicelength`
  (a stale/moved `items` backing or a desynced length read breaks this and names
  the counts).
- `bh_delete_subscr_fn` asserts its `obj`/`index` residual operands are non-null
  (the residual boundary the earlier asserts did not cover).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
