### PR TITLE
builtins: advance Python 3.14 type and protocol parity

### DIFF
--- a/pyre/extra_tests/snippets/builtin_memoryview.py
+++ b/pyre/extra_tests/snippets/builtin_memoryview.py
@@ -126,6 +126,32 @@ def test_bytesio_readinto():
 test_bytesio_readinto()
 
 
+def test_struct_iter_unpack_holds_export():
+    # PyPy W_UnpackIter keeps the acquired Py_buffer until the iterator is
+    # exhausted (including the terminal next()) or finalized.
+    source = bytearray(struct.pack("II", 10, 20))
+    view = memoryview(source)
+    unpacked = struct.iter_unpack("I", view)
+    assert_raises(BufferError, view.release)
+    assert_raises(BufferError, lambda: source.append(0))
+    assert next(unpacked) == (10,)
+    assert list(unpacked) == [(20,)]
+    view.release()
+    source.append(0)
+
+    # A direct mutable export is likewise released by the native finalizer
+    # when an iterator is abandoned before exhaustion.
+    source = bytearray(struct.pack("I", 30))
+    unpacked = struct.iter_unpack("I", source)
+    assert_raises(BufferError, lambda: source.append(0))
+    del unpacked
+    gc.collect()
+    source.append(0)
+
+
+test_struct_iter_unpack_holds_export()
+
+
 # PyPy interp_buffer.py descr_new_picklebuffer acquires the buffer in
 # __new__, and its typedef is explicitly final.  CPython 3.14 exposes the
 # same constructor and final-type behavior through pickle.PickleBuffer.
@@ -140,6 +166,38 @@ assert_raises(TypeError, lambda: pickle.PickleBuffer(1))
 released_pickle_buffer_source = memoryview(b"released")
 released_pickle_buffer_source.release()
 assert_raises(ValueError, lambda: pickle.PickleBuffer(released_pickle_buffer_source))
+
+
+def test_pickle_buffer_holds_export():
+    source = bytearray(b"abc")
+    wrapped = pickle.PickleBuffer(source)
+    assert_raises(BufferError, lambda: source.append(0))
+    wrapped.release()
+    wrapped.release()  # `_release_buf` is idempotent.
+    source.append(0)
+
+    source = bytearray(b"abc")
+    view = memoryview(source)
+    wrapped = pickle.PickleBuffer(view)
+    assert_raises(BufferError, view.release)
+    wrapped.release()
+    view.release()
+
+    source = bytearray(b"abc")
+    wrapped = pickle.PickleBuffer(source)
+    assert_raises(BufferError, lambda: source.append(0))
+    del wrapped
+    gc.collect()
+    source.append(0)
+
+    wrapped = pickle.PickleBuffer(b"immutable")
+    wrapped_ref = weakref.ref(wrapped)
+    del wrapped
+    gc.collect()
+    assert wrapped_ref() is None
+
+
+test_pickle_buffer_holds_export()
 
 
 def subclass_pickle_buffer():

--- a/pyre/extra_tests/snippets/builtin_memoryview.py
+++ b/pyre/extra_tests/snippets/builtin_memoryview.py
@@ -196,6 +196,34 @@ def test_pickle_buffer_holds_export():
     gc.collect()
     assert wrapped_ref() is None
 
+    class Exporter:
+        def __init__(self):
+            self.data = bytearray(b"pep688")
+            self.flags = []
+            self.released = []
+
+        def __buffer__(self, flags):
+            self.flags.append(flags)
+            return memoryview(self.data)
+
+        def __release_buffer__(self, view):
+            self.released.append(view)
+
+    exporter = Exporter()
+    wrapped = pickle.PickleBuffer(exporter)
+    assert exporter.flags == [0x011C]  # PyBUF_FULL_RO
+    assert bytes(wrapped) == b"pep688"
+    assert_raises(BufferError, lambda: exporter.data.append(0))
+    wrapped.release()
+    assert len(exporter.released) == 1
+    exporter.data.append(0)
+
+    class BadExporter:
+        def __buffer__(self, flags):
+            return b"not a memoryview"
+
+    assert_raises(TypeError, lambda: pickle.PickleBuffer(BadExporter()))
+
 
 test_pickle_buffer_holds_export()
 

--- a/pyre/extra_tests/snippets/stdlib_os.py
+++ b/pyre/extra_tests/snippets/stdlib_os.py
@@ -137,6 +137,16 @@ with TestWithTempDir() as tmpdir:
     assert os.read(fd, len(CONTENT3)) == CONTENT3
     os.close(fd)
 
+    # Python 3.14 os.readinto holds a writable-buffer export for the syscall
+    # and writes into the exact memoryview window supplied by the caller.
+    fd = os.open(fname, os.O_RDONLY)
+    target = bytearray(b"..............")
+    assert os.readinto(fd, memoryview(target)[2 : 2 + len(CONTENT2)]) == len(CONTENT2)
+    assert target == b".." + CONTENT2 + b".."
+    assert os.readinto(fd, bytearray()) == 0
+    assert_raises(TypeError, lambda: os.readinto(fd, b"readonly"))
+    os.close(fd)
+
     fname3 = os.path.join(tmpdir, FILE_NAME3)
     os.rename(fname, fname3)
     assert os.path.exists(fname) is False

--- a/pyre/extra_tests/snippets/stdlib_struct.py
+++ b/pyre/extra_tests/snippets/stdlib_struct.py
@@ -92,3 +92,13 @@ with assert_raises(UnicodeEncodeError):
 
 with assert_raises(struct.error):
     struct.Struct(b"\xff")
+
+# CPython 3.14 accepts a zero-width Pascal field.  It consumes one pack
+# argument and contributes one empty bytes result while occupying no bytes.
+assert struct.calcsize("0p") == 0
+assert struct.pack("0p", b"payload") == b""
+assert struct.unpack("0p", b"") == (b"",)
+
+unpack_iterator_type = type(struct.iter_unpack("B", b""))
+with assert_raises(TypeError):
+    unpack_iterator_type()

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -9986,31 +9986,17 @@ fn generator_unpack_into(
             // resume value (e.g. `x = yield`) would observe stale
             // stack on the second iteration.
             w_generator_set_started(gen_obj);
-            w_generator_set_running(gen_obj, true);
-            let result = frame.execute_frame(Some(pyre_object::w_none()), None);
-            w_generator_set_running(gen_obj, false);
+            let result = generator_invoke_execute_frame(
+                gen_obj,
+                frame,
+                Some(pyre_object::w_none()),
+                None,
+                None,
+            );
             match result {
-                // generator.py:132-138 `_invoke_execute_frame`'s
-                // `finally: self.frame_is_finished()` runs before the
-                // OperationError reaches the unpack_into try/except,
-                // so by the time PyPy's `if e.match(StopIteration):
-                // break` fires the generator is already marked
-                // finished.  Pyre's inline `frame.execute_frame` path
-                // skips that finally block, so mirror it explicitly.
-                Err(e) if e.kind == crate::PyErrorKind::StopIteration => {
-                    // generator.py:131-138 — `_invoke_execute_frame` applies
-                    // `_leak_stopiteration` (PEP 479) BEFORE unpack_into's
-                    // `if e.match(StopIteration): break`, so a StopIteration
-                    // leaked from the body becomes RuntimeError and propagates;
-                    // it is not the normal-exhaustion path (which is the
-                    // `Ok`/`frame_finished_execution` arm below).
-                    generator_frame_is_finished(gen_obj, frame);
-                    return Err(leak_stopiteration(e));
-                }
-                Err(e) => {
-                    generator_frame_is_finished(gen_obj, frame);
-                    return Err(e);
-                }
+                // `_invoke_execute_frame` has already applied PEP 479 and
+                // finalized the frame for any escaping error.
+                Err(e) => return Err(e),
                 Ok(w_result) => {
                     // generator.py:339-341 — frame finished ⇒ RETURNed,
                     // mark exhausted and stop without appending.
@@ -12744,6 +12730,46 @@ unsafe fn generator_frame_is_finished(gen_obj: PyObjectRef, frame: &mut crate::p
     unsafe { w_generator_set_frame(gen_obj, std::ptr::null_mut()) };
 }
 
+/// generator.py:121-145 `_invoke_execute_frame`: install the generator's
+/// exception state, execute its already-entered frame resume, finish the frame
+/// on errors, and perform the common frame/running/EC cleanup in `finally`.
+unsafe fn generator_invoke_execute_frame(
+    gen_obj: PyObjectRef,
+    frame: &mut crate::pyframe::PyFrame,
+    w_inputvalue: Option<PyObjectRef>,
+    operr: Option<PyError>,
+    throw_args: Option<([PyObjectRef; 3], usize)>,
+) -> PyResult {
+    use pyre_object::generator::*;
+    if w_generator_is_running(gen_obj) {
+        return Err(PyError::value_error("generator already executing"));
+    }
+    w_generator_set_running(gen_obj, true);
+    let ec = crate::call::getexecutioncontext() as *mut crate::executioncontext::ExecutionContext;
+    if !ec.is_null() {
+        (*ec).push_gen_or_coroutine(gen_obj);
+    }
+    let result = frame.execute_generator_frame(w_inputvalue, operr, throw_args);
+    let result = match result {
+        Err(e) => {
+            generator_frame_is_finished(gen_obj, frame);
+            if e.kind == crate::PyErrorKind::StopIteration {
+                Err(leak_stopiteration(e))
+            } else {
+                Err(e)
+            }
+        }
+        result => result,
+    };
+    // generator.py:142-145 `finally`.
+    frame.f_backref = std::ptr::null_mut();
+    w_generator_set_running(gen_obj, false);
+    if !ec.is_null() {
+        (*ec).pop_gen_or_coroutine(gen_obj);
+    }
+    result
+}
+
 /// PyPy: GeneratorIterator._send_ex(w_arg, operr)
 ///
 /// Resume a generator frame: push w_arg (for send/next) or inject operr
@@ -12756,10 +12782,6 @@ fn generator_send_ex(
 ) -> PyResult {
     use pyre_object::generator::*;
     unsafe {
-        if w_generator_is_running(gen_obj) {
-            return Err(PyError::value_error("generator already executing"));
-        }
-
         if w_generator_is_exhausted(gen_obj) {
             if let Some(err) = operr {
                 return Err(err);
@@ -12786,72 +12808,30 @@ fn generator_send_ex(
             }
         }
         w_generator_set_started(gen_obj);
-        w_generator_set_running(gen_obj, true);
-
-        // generator.py:127 `ec.push_gen_or_coroutine(self)`: make the
-        // exception suspended on this generator current for the whole resume,
-        // including a delegated `yield from` call.
-        let ec =
-            crate::call::getexecutioncontext() as *mut crate::executioncontext::ExecutionContext;
-        if !ec.is_null() {
-            (*ec).push_gen_or_coroutine(gen_obj);
-        }
-        let invoke_result = (|| -> PyResult {
-            // A suspended `yield from` owns the next resume operation.  Keep
-            // the outer frame parked until its delegate either yields again or
-            // is exhausted, so a value or exception never takes the bytecode
-            // path intended for an awaitable resume.
-            let mut pending_operr = operr;
-            let mut delegated_completion = false;
-            if already_started && !frame.w_yielding_from.is_null() {
-                match resume_yield_from(frame, w_arg, pending_operr.take(), throw_args) {
-                    Ok(Some(value)) => return Ok(value),
-                    Ok(None) => delegated_completion = true,
-                    Err(err) => pending_operr = Some(err),
-                }
-            }
-
-            // generator.py:104 — w_result = frame.execute_frame(w_arg, operr)
-            let w_inputvalue =
-                if already_started && pending_operr.is_none() && !delegated_completion {
-                    Some(w_arg)
-                } else {
-                    None
-                };
-            let result = frame.execute_frame(w_inputvalue, pending_operr);
-
-            match result {
-                Ok(value) => {
-                    // generator.py:109-114 — if the frame marked itself
-                    // finished, it was RETURNed from; otherwise it YIELDed.
-                    if frame.frame_finished_execution() {
-                        generator_frame_is_finished(gen_obj, frame);
-                        // generator.py:117-119 / pyopcode.py RETURN_VALUE in
-                        // generator frames — `raise StopIteration(returnvalue)`
-                        // so callers can pull the return value off `.value`.
-                        Err(stop_iteration_with_value(value))
-                    } else {
-                        Ok(value)
-                    }
-                }
-                Err(e) => {
+        // generator.py:104 `_invoke_execute_frame` delegates the complete
+        // resume to `frame.execute_frame(w_arg_or_err)`.  In particular,
+        // `PyFrame.resume_execute_frame` handles `w_yielding_from` only after
+        // the outer frame has entered the execution context.
+        let w_inputvalue = if already_started && operr.is_none() {
+            Some(w_arg)
+        } else {
+            None
+        };
+        match generator_invoke_execute_frame(gen_obj, frame, w_inputvalue, operr, throw_args) {
+            Ok(value) => {
+                // generator.py:109-114 — if the frame marked itself finished,
+                // it was RETURNed from; otherwise it YIELDed.
+                if frame.frame_finished_execution() {
                     generator_frame_is_finished(gen_obj, frame);
-                    // generator.py `_leak_stopiteration` (PEP 479).
-                    if e.kind == crate::PyErrorKind::StopIteration {
-                        Err(leak_stopiteration(e))
-                    } else {
-                        Err(e)
-                    }
+                    // generator.py:117-119 / pyopcode.py RETURN_VALUE in
+                    // generator frames — `raise StopIteration(returnvalue)`.
+                    Err(stop_iteration_with_value(value))
+                } else {
+                    Ok(value)
                 }
             }
-        })();
-        // generator.py:142-145 `finally`: always clear the running flag and
-        // restore the caller's exception state after this resume.
-        w_generator_set_running(gen_obj, false);
-        if !ec.is_null() {
-            (*ec).pop_gen_or_coroutine(gen_obj);
+            Err(e) => Err(e),
         }
-        invoke_result
     }
 }
 
@@ -12860,13 +12840,13 @@ fn generator_send_ex(
 /// `Some` is a value yielded by the delegate and is therefore also the
 /// outer generator's result.  `None` means the delegate completed and the
 /// outer frame has been positioned at the completion path.
-fn resume_yield_from(
+pub(crate) fn resume_yield_from(
     frame: &mut crate::pyframe::PyFrame,
+    w_yf: PyObjectRef,
     w_arg: PyObjectRef,
     operr: Option<PyError>,
     throw_args: Option<([PyObjectRef; 3], usize)>,
 ) -> Result<Option<PyObjectRef>, PyError> {
-    let w_yf = frame.w_yielding_from;
     debug_assert!(!w_yf.is_null());
 
     let result = match operr {
@@ -12890,7 +12870,20 @@ fn resume_yield_from(
     };
 
     match result {
-        Ok(value) => Ok(Some(value)),
+        Ok(value) => {
+            // pyopcode.py:1225-1227 `next_yield_from`: publish the delegate
+            // only after its call has yielded.  While the delegate is
+            // executing, `gi_yieldfrom` must therefore remain None.
+            frame.w_yielding_from = w_yf;
+            if pyre_object::gc_hook::try_gc_owns_object(
+                frame as *mut crate::pyframe::PyFrame as *mut u8,
+            ) {
+                pyre_object::gc_hook::try_gc_write_barrier(
+                    frame as *mut crate::pyframe::PyFrame as *mut u8,
+                );
+            }
+            Ok(Some(value))
+        }
         Err(err) if err.kind == PyErrorKind::StopIteration => {
             frame.w_yielding_from = pyre_object::PY_NULL;
             finish_yield_from(frame, err)?;

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -10004,18 +10004,18 @@ fn generator_unpack_into(
                     // leaked from the body becomes RuntimeError and propagates;
                     // it is not the normal-exhaustion path (which is the
                     // `Ok`/`frame_finished_execution` arm below).
-                    w_generator_set_exhausted(gen_obj);
+                    generator_frame_is_finished(gen_obj, frame);
                     return Err(leak_stopiteration(e));
                 }
                 Err(e) => {
-                    w_generator_set_exhausted(gen_obj);
+                    generator_frame_is_finished(gen_obj, frame);
                     return Err(e);
                 }
                 Ok(w_result) => {
                     // generator.py:339-341 — frame finished ⇒ RETURNed,
                     // mark exhausted and stop without appending.
                     if frame.frame_finished_execution() {
-                        w_generator_set_exhausted(gen_obj);
+                        generator_frame_is_finished(gen_obj, frame);
                         break;
                     }
                     // generator.py:342 `results.append(w_result)`.
@@ -12728,6 +12728,22 @@ pub(crate) fn property_descr_delete_impl(args: &[PyObjectRef]) -> PyResult {
 // - throw(t,v) → send_ex(None, OperationError(t,v))
 // - close()    → throw(GeneratorExit) then check result
 
+/// generator.py:313-315 `frame_is_finished` plus Python 3.14's eager frame
+/// clearing on `close()`.  Dropping the generator's frame edge releases all
+/// suspended locals; an escaped `gi_frame` remains a valid, cleared frame.
+unsafe fn generator_frame_is_finished(gen_obj: PyObjectRef, frame: &mut crate::pyframe::PyFrame) {
+    use pyre_object::generator::*;
+    unsafe { w_generator_set_exhausted(gen_obj) };
+    frame.set_frame_finished_execution(true);
+    frame.w_yielding_from = PY_NULL;
+    // The exhausted flag makes `descr_clear` take its permitted finalized
+    // branch.  It has no semantic failure path after that state transition.
+    let _ = frame.descr_clear();
+    frame.f_backref = std::ptr::null_mut();
+    frame.f_generator_nowref = PY_NULL;
+    unsafe { w_generator_set_frame(gen_obj, std::ptr::null_mut()) };
+}
+
 /// PyPy: GeneratorIterator._send_ex(w_arg, operr)
 ///
 /// Resume a generator frame: push w_arg (for send/next) or inject operr
@@ -12804,7 +12820,7 @@ fn generator_send_ex(
                 // generator.py:109-114 — if the frame marked itself finished,
                 // it was RETURNed from; otherwise it YIELDed.
                 if frame.frame_finished_execution() {
-                    w_generator_set_exhausted(gen_obj);
+                    generator_frame_is_finished(gen_obj, frame);
                     // generator.py:117-119 / pyopcode.py RETURN_VALUE in
                     // generator frames — `raise StopIteration(returnvalue)`
                     // so callers can pull the return value off `.value`.
@@ -12817,7 +12833,7 @@ fn generator_send_ex(
                 }
             }
             Err(e) => {
-                w_generator_set_exhausted(gen_obj);
+                generator_frame_is_finished(gen_obj, frame);
                 // generator.py `_leak_stopiteration` (PEP 479) — a
                 // StopIteration that escaped the body becomes RuntimeError;
                 // any other error propagates unchanged.  The normal-return
@@ -13273,7 +13289,12 @@ pub(crate) fn generator_close_method(args: &[PyObjectRef]) -> PyResult {
             return Ok(w_none());
         }
         if !w_generator_is_started(gen_obj) {
-            w_generator_set_exhausted(gen_obj);
+            let frame_ptr = w_generator_get_frame(gen_obj) as *mut crate::pyframe::PyFrame;
+            if frame_ptr.is_null() {
+                w_generator_set_exhausted(gen_obj);
+            } else {
+                generator_frame_is_finished(gen_obj, &mut *frame_ptr);
+            }
             return Ok(w_none());
         }
     }
@@ -13283,9 +13304,15 @@ pub(crate) fn generator_close_method(args: &[PyObjectRef]) -> PyResult {
             // Generator yielded after GeneratorExit — RuntimeError
             Err(PyError::runtime_error("generator ignored GeneratorExit"))
         }
-        Err(e) if e.kind == PyErrorKind::StopIteration || e.kind == PyErrorKind::GeneratorExit => {
-            Ok(w_none())
+        Err(mut e) if e.kind == PyErrorKind::StopIteration => {
+            // Python 3.13+ / 3.14: close() returns the value produced when
+            // GeneratorExit is caught and the generator executes `return x`.
+            let w_exc = e.to_exc_object();
+            let _roots = pyre_object::gc_roots::push_roots();
+            pyre_object::gc_roots::pin_root(w_exc);
+            getattr_str(w_exc, "value").or_else(|_| Ok(w_none()))
         }
+        Err(e) if e.kind == PyErrorKind::GeneratorExit => Ok(w_none()),
         Err(e) => Err(e),
     }
 }

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -12754,7 +12754,19 @@ unsafe fn generator_invoke_execute_frame(
         Err(e) => {
             generator_frame_is_finished(gen_obj, frame);
             if e.kind == crate::PyErrorKind::StopIteration {
-                Err(leak_stopiteration(e))
+                let message = if is_async_generator(gen_obj) {
+                    "async generator raised StopIteration"
+                } else {
+                    "generator raised StopIteration"
+                };
+                Err(leak_generator_iteration(e, message))
+            } else if is_async_generator(gen_obj)
+                && e.kind == crate::PyErrorKind::StopAsyncIteration
+            {
+                Err(leak_generator_iteration(
+                    e,
+                    "async generator raised StopAsyncIteration",
+                ))
             } else {
                 Err(e)
             }
@@ -12786,7 +12798,11 @@ fn generator_send_ex(
             if let Some(err) = operr {
                 return Err(err);
             }
-            return Err(PyError::stop_iteration());
+            return Err(if is_async_generator(gen_obj) {
+                PyError::stop_async_iteration()
+            } else {
+                PyError::stop_iteration()
+            });
         }
 
         let frame_ptr = w_generator_get_frame(gen_obj) as *mut crate::pyframe::PyFrame;
@@ -12795,16 +12811,27 @@ fn generator_send_ex(
             if let Some(err) = operr {
                 return Err(err);
             }
-            return Err(PyError::stop_iteration());
+            return Err(if is_async_generator(gen_obj) {
+                PyError::stop_async_iteration()
+            } else {
+                PyError::stop_iteration()
+            });
         }
         let frame = &mut *frame_ptr;
         let already_started = w_generator_is_started(gen_obj);
 
         if !already_started {
             if operr.is_none() && !w_arg.is_null() && !is_none(w_arg) {
-                return Err(PyError::type_error(
-                    "can't send non-None value to a just-started generator",
-                ));
+                return Err(PyError::type_error(format!(
+                    "can't send non-None value to a just-started {}",
+                    if is_async_generator(gen_obj) {
+                        "async generator"
+                    } else if is_coroutine(gen_obj) {
+                        "coroutine"
+                    } else {
+                        "generator"
+                    }
+                )));
             }
         }
         w_generator_set_started(gen_obj);
@@ -12823,6 +12850,9 @@ fn generator_send_ex(
                 // it was RETURNed from; otherwise it YIELDed.
                 if frame.frame_finished_execution() {
                     generator_frame_is_finished(gen_obj, frame);
+                    if is_async_generator(gen_obj) {
+                        return Err(PyError::stop_async_iteration());
+                    }
                     // generator.py:117-119 / pyopcode.py RETURN_VALUE in
                     // generator frames — `raise StopIteration(returnvalue)`.
                     Err(stop_iteration_with_value(value))
@@ -13008,7 +13038,7 @@ fn stop_iteration_with_value(value: PyObjectRef) -> PyError {
 /// cause suppresses the context in display, mirroring
 /// `chain_exceptions_from_cause`).  This is distinct from a normal generator
 /// return, which surfaces through the `Ok`/`frame_finished_execution` path.
-unsafe fn leak_stopiteration(mut e: PyError) -> PyError {
+unsafe fn leak_generator_iteration(mut e: PyError, message: &str) -> PyError {
     use pyre_object::interp_exceptions::*;
     let w_stopiter = e.to_exc_object();
     // Root the leaked StopIteration across the RuntimeError allocation below:
@@ -13019,7 +13049,7 @@ unsafe fn leak_stopiteration(mut e: PyError) -> PyError {
     if !w_stopiter.is_null() {
         pyre_object::gc_roots::pin_root(w_stopiter);
     }
-    let rt = w_exception_new(ExcKind::RuntimeError, "generator raised StopIteration");
+    let rt = w_exception_new(ExcKind::RuntimeError, message);
     if pyre_object::is_exception(rt) && !w_stopiter.is_null() {
         w_exception_set_context(rt, w_stopiter);
         w_exception_set_cause(rt, w_stopiter);
@@ -13195,6 +13225,10 @@ pub(crate) fn generator_send_method(args: &[PyObjectRef]) -> PyResult {
 
 /// PyPy: GeneratorIterator.descr_throw(w_type, w_val=None, w_tb=None)
 pub(crate) fn generator_throw_method(args: &[PyObjectRef]) -> PyResult {
+    generator_throw_impl(args, true)
+}
+
+fn generator_throw_impl(args: &[PyObjectRef], warn_legacy_signature: bool) -> PyResult {
     let given = args.len().saturating_sub(1);
     if given == 0 {
         return Err(PyError::type_error(
@@ -13214,7 +13248,7 @@ pub(crate) fn generator_throw_method(args: &[PyObjectRef]) -> PyResult {
 
     // Python 3.14 deprecates only the legacy three-argument spelling; the
     // one- and two-argument forms retain their existing semantics.
-    if argc == 3 {
+    if warn_legacy_signature && argc == 3 {
         crate::warn::warn_category(
             "the (type, exc, tb) signature of throw() is deprecated, use the single-arg signature instead.",
             "DeprecationWarning",
@@ -13351,6 +13385,415 @@ pub(crate) fn coroutine_wrapper_close_method(args: &[PyObjectRef]) -> PyResult {
     generator_close_method(&[coroutine])
 }
 
+/// PyPy `AsyncGenerator.init_hooks`.
+fn async_generator_init_hooks(async_gen: PyObjectRef) -> PyResult {
+    unsafe {
+        use pyre_object::generator::*;
+        if w_async_generator_hooks_inited(async_gen) {
+            return Ok(w_none());
+        }
+        w_async_generator_set_hooks_inited(async_gen);
+        let ec = crate::call::getexecutioncontext() as *mut crate::PyExecutionContext;
+        if ec.is_null() {
+            w_async_generator_set_finalizer(async_gen, PY_NULL);
+            return Ok(w_none());
+        }
+        w_async_generator_set_finalizer(async_gen, (*ec).w_asyncgen_finalizer_fn);
+        let firstiter = (*ec).w_asyncgen_firstiter_fn;
+        if !firstiter.is_null() {
+            let _roots = pyre_object::gc_roots::push_roots();
+            pyre_object::gc_roots::pin_root(async_gen);
+            pyre_object::gc_roots::pin_root(firstiter);
+            crate::call::call_function_impl_result(firstiter, &[async_gen])?;
+        }
+    }
+    Ok(w_none())
+}
+
+pub(crate) fn async_generator_anext_method(args: &[PyObjectRef]) -> PyResult {
+    let async_gen = args.first().copied().unwrap_or(PY_NULL);
+    async_generator_init_hooks(async_gen)?;
+    Ok(pyre_object::generator::w_async_gen_asend_new(
+        async_gen,
+        w_none(),
+    ))
+}
+
+pub(crate) fn async_generator_asend_method(args: &[PyObjectRef]) -> PyResult {
+    let async_gen = args.first().copied().unwrap_or(PY_NULL);
+    let value = args.get(1).copied().unwrap_or_else(w_none);
+    async_generator_init_hooks(async_gen)?;
+    Ok(pyre_object::generator::w_async_gen_asend_new(
+        async_gen, value,
+    ))
+}
+
+pub(crate) fn async_generator_athrow_method(args: &[PyObjectRef]) -> PyResult {
+    let given = args.len().saturating_sub(1);
+    if given == 0 {
+        return Err(PyError::type_error(
+            "athrow expected at least 1 argument, got 0",
+        ));
+    }
+    if given > 3 {
+        return Err(PyError::type_error(format!(
+            "athrow expected at most 3 arguments, got {given}"
+        )));
+    }
+    // CPython 3.14: match generator.throw() and deprecate the legacy
+    // (type, value, traceback) spelling while retaining PyPy's state machine.
+    if given == 3 {
+        crate::warn::warn_category(
+            "the (type, exc, tb) signature of athrow() is deprecated, use the single-arg signature instead.",
+            "DeprecationWarning",
+            2,
+        )?;
+    }
+    let async_gen = args[0];
+    async_generator_init_hooks(async_gen)?;
+    Ok(pyre_object::generator::w_async_gen_athrow_new(
+        async_gen,
+        args[1],
+        args.get(2).copied().unwrap_or_else(w_none),
+        args.get(3).copied().unwrap_or_else(w_none),
+    ))
+}
+
+pub(crate) fn async_generator_aclose_method(args: &[PyObjectRef]) -> PyResult {
+    let async_gen = args.first().copied().unwrap_or(PY_NULL);
+    async_generator_init_hooks(async_gen)?;
+    Ok(pyre_object::generator::w_async_gen_athrow_new(
+        async_gen,
+        PY_NULL,
+        w_none(),
+        w_none(),
+    ))
+}
+
+fn async_gen_unwrap_value(async_gen: PyObjectRef, value: PyObjectRef) -> PyResult {
+    if let Some(wrapper) = pyre_object::generator::AsyncGenValueWrapper::from_obj(value) {
+        let yielded = wrapper.w_value;
+        unsafe {
+            pyre_object::generator::w_async_generator_set_running(async_gen, false);
+        }
+        Err(stop_iteration_with_value(yielded))
+    } else {
+        Ok(value)
+    }
+}
+
+fn async_gen_asend_do_send(awaitable: PyObjectRef, mut arg: PyObjectRef) -> PyResult {
+    use pyre_object::generator::*;
+    let (async_gen, initial_value, state) = {
+        let payload = AsyncGenASend::from_obj(awaitable)
+            .ok_or_else(|| PyError::type_error("invalid async_generator_asend receiver"))?;
+        (payload.async_gen, payload.w_value_to_send, payload.state)
+    };
+    if state == ASYNC_GEN_STATE_CLOSED {
+        return Err(PyError::runtime_error(
+            "cannot reuse already awaited __anext__()/asend()",
+        ));
+    }
+    if state == ASYNC_GEN_STATE_INIT {
+        if unsafe { is_none(arg) } {
+            arg = initial_value;
+        }
+        AsyncGenASend::from_obj(awaitable)
+            .expect("validated async_generator_asend")
+            .state = ASYNC_GEN_STATE_ITER;
+        if unsafe { w_async_generator_is_running(async_gen) } {
+            AsyncGenASend::from_obj(awaitable)
+                .expect("validated async_generator_asend")
+                .state = ASYNC_GEN_STATE_CLOSED;
+            return Err(PyError::runtime_error(
+                "anext(): asynchronous generator is already running",
+            ));
+        }
+        unsafe { w_async_generator_set_running(async_gen, true) };
+    }
+    let result = generator_send_ex(async_gen, arg, None, None)
+        .and_then(|value| async_gen_unwrap_value(async_gen, value));
+    if result.is_err() {
+        unsafe { w_async_generator_set_running(async_gen, false) };
+        AsyncGenASend::from_obj(awaitable)
+            .expect("validated async_generator_asend")
+            .state = ASYNC_GEN_STATE_CLOSED;
+    }
+    result
+}
+
+pub(crate) fn async_gen_asend_next_method(args: &[PyObjectRef]) -> PyResult {
+    async_gen_asend_do_send(args.first().copied().unwrap_or(PY_NULL), w_none())
+}
+
+pub(crate) fn async_gen_asend_send_method(args: &[PyObjectRef]) -> PyResult {
+    async_gen_asend_do_send(
+        args.first().copied().unwrap_or(PY_NULL),
+        args.get(1).copied().unwrap_or_else(w_none),
+    )
+}
+
+pub(crate) fn async_gen_asend_close_method(args: &[PyObjectRef]) -> PyResult {
+    let awaitable = args.first().copied().unwrap_or(PY_NULL);
+    let (async_gen, state) = {
+        let payload = pyre_object::generator::AsyncGenASend::from_obj(awaitable)
+            .ok_or_else(|| PyError::type_error("invalid async_generator_asend receiver"))?;
+        (payload.async_gen, payload.state)
+    };
+    pyre_object::generator::AsyncGenASend::from_obj(awaitable)
+        .expect("validated async_generator_asend")
+        .state = pyre_object::generator::ASYNC_GEN_STATE_CLOSED;
+    if state != pyre_object::generator::ASYNC_GEN_STATE_ITER {
+        return Ok(w_none());
+    }
+    let result = generator_send_ex(
+        async_gen,
+        w_none(),
+        Some(PyError::new(PyErrorKind::GeneratorExit, String::new())),
+        None,
+    );
+    unsafe { pyre_object::generator::w_async_generator_set_running(async_gen, false) };
+    match result {
+        Ok(_) => Err(PyError::runtime_error("coroutine ignored GeneratorExit")),
+        Err(err)
+            if matches!(
+                err.kind,
+                PyErrorKind::GeneratorExit
+                    | PyErrorKind::StopIteration
+                    | PyErrorKind::StopAsyncIteration
+            ) =>
+        {
+            Ok(w_none())
+        }
+        Err(err) => Err(err),
+    }
+}
+
+pub(crate) fn async_gen_asend_throw_method(args: &[PyObjectRef]) -> PyResult {
+    let awaitable = args.first().copied().unwrap_or(PY_NULL);
+    let (async_gen, state) = {
+        let payload = pyre_object::generator::AsyncGenASend::from_obj(awaitable)
+            .ok_or_else(|| PyError::type_error("invalid async_generator_asend receiver"))?;
+        (payload.async_gen, payload.state)
+    };
+    if state == pyre_object::generator::ASYNC_GEN_STATE_CLOSED {
+        return Err(PyError::runtime_error(
+            "cannot reuse already awaited __anext__()/asend()",
+        ));
+    }
+    if state == pyre_object::generator::ASYNC_GEN_STATE_INIT {
+        pyre_object::generator::AsyncGenASend::from_obj(awaitable)
+            .expect("validated async_generator_asend")
+            .state = pyre_object::generator::ASYNC_GEN_STATE_ITER;
+        if unsafe { pyre_object::generator::w_async_generator_is_running(async_gen) } {
+            pyre_object::generator::AsyncGenASend::from_obj(awaitable)
+                .expect("validated async_generator_asend")
+                .state = pyre_object::generator::ASYNC_GEN_STATE_CLOSED;
+            return Err(PyError::runtime_error(
+                "anext(): asynchronous generator is already running",
+            ));
+        }
+        unsafe { pyre_object::generator::w_async_generator_set_running(async_gen, true) };
+    }
+    let mut forwarded = Vec::with_capacity(args.len());
+    forwarded.push(async_gen);
+    forwarded.extend_from_slice(args.get(1..).unwrap_or(&[]));
+    let result = generator_throw_method(&forwarded)
+        .and_then(|value| async_gen_unwrap_value(async_gen, value));
+    if result.is_err() {
+        unsafe { pyre_object::generator::w_async_generator_set_running(async_gen, false) };
+        pyre_object::generator::AsyncGenASend::from_obj(awaitable)
+            .expect("validated async_generator_asend")
+            .state = pyre_object::generator::ASYNC_GEN_STATE_CLOSED;
+    }
+    result
+}
+
+fn async_gen_athrow_handle_error(closing: bool, err: PyError) -> PyResult {
+    if closing
+        && matches!(
+            err.kind,
+            PyErrorKind::StopAsyncIteration
+                | PyErrorKind::StopIteration
+                | PyErrorKind::GeneratorExit
+        )
+    {
+        Err(PyError::stop_iteration())
+    } else {
+        Err(err)
+    }
+}
+
+fn async_gen_athrow_do_send(awaitable: PyObjectRef, arg: PyObjectRef) -> PyResult {
+    use pyre_object::generator::*;
+    let (async_gen, exc_type, exc_value, exc_tb, state) = {
+        let payload = AsyncGenAThrow::from_obj(awaitable)
+            .ok_or_else(|| PyError::type_error("invalid async_generator_athrow receiver"))?;
+        (
+            payload.async_gen,
+            payload.w_exc_type,
+            payload.w_exc_value,
+            payload.w_exc_tb,
+            payload.state,
+        )
+    };
+    if state == ASYNC_GEN_STATE_CLOSED {
+        return Err(PyError::runtime_error(
+            "cannot reuse already awaited aclose()/athrow()",
+        ));
+    }
+    let throwing = state == ASYNC_GEN_STATE_INIT;
+    if throwing {
+        if unsafe { !is_none(arg) } {
+            return Err(PyError::runtime_error(
+                "can't send non-None value to a just-started coroutine",
+            ));
+        }
+        AsyncGenAThrow::from_obj(awaitable)
+            .expect("validated async_generator_athrow")
+            .state = ASYNC_GEN_STATE_ITER;
+        if unsafe { w_async_generator_is_running(async_gen) } {
+            AsyncGenAThrow::from_obj(awaitable)
+                .expect("validated async_generator_athrow")
+                .state = ASYNC_GEN_STATE_CLOSED;
+            return Err(PyError::runtime_error(
+                "athrow(): asynchronous generator is already running",
+            ));
+        }
+        unsafe { w_async_generator_set_running(async_gen, true) };
+    }
+    let closing = exc_type.is_null();
+    let result = if throwing {
+        if closing {
+            generator_send_ex(
+                async_gen,
+                w_none(),
+                Some(PyError::new(PyErrorKind::GeneratorExit, String::new())),
+                None,
+            )
+        } else {
+            // `AsyncGenerator.athrow` already warned from the caller-visible
+            // argument count.  Its awaitable stores normalized optional
+            // slots, so this internal three-slot resume must not warn again.
+            generator_throw_impl(&[async_gen, exc_type, exc_value, exc_tb], false)
+        }
+    } else {
+        generator_send_ex(async_gen, arg, None, None)
+    };
+    let result = match result {
+        Ok(value) => {
+            if closing && AsyncGenValueWrapper::from_obj(value).is_some() {
+                Err(PyError::runtime_error(
+                    "async generator ignored GeneratorExit",
+                ))
+            } else {
+                async_gen_unwrap_value(async_gen, value)
+            }
+        }
+        Err(err) => async_gen_athrow_handle_error(closing, err),
+    };
+    if result.is_err() {
+        unsafe { w_async_generator_set_running(async_gen, false) };
+        AsyncGenAThrow::from_obj(awaitable)
+            .expect("validated async_generator_athrow")
+            .state = ASYNC_GEN_STATE_CLOSED;
+    }
+    result
+}
+
+pub(crate) fn async_gen_athrow_next_method(args: &[PyObjectRef]) -> PyResult {
+    async_gen_athrow_do_send(args.first().copied().unwrap_or(PY_NULL), w_none())
+}
+
+pub(crate) fn async_gen_athrow_send_method(args: &[PyObjectRef]) -> PyResult {
+    async_gen_athrow_do_send(
+        args.first().copied().unwrap_or(PY_NULL),
+        args.get(1).copied().unwrap_or_else(w_none),
+    )
+}
+
+pub(crate) fn async_gen_athrow_close_method(args: &[PyObjectRef]) -> PyResult {
+    let awaitable = args.first().copied().unwrap_or(PY_NULL);
+    let (async_gen, state) = {
+        let payload = pyre_object::generator::AsyncGenAThrow::from_obj(awaitable)
+            .ok_or_else(|| PyError::type_error("invalid async_generator_athrow receiver"))?;
+        (payload.async_gen, payload.state)
+    };
+    pyre_object::generator::AsyncGenAThrow::from_obj(awaitable)
+        .expect("validated async_generator_athrow")
+        .state = pyre_object::generator::ASYNC_GEN_STATE_CLOSED;
+    if state != pyre_object::generator::ASYNC_GEN_STATE_ITER {
+        return Ok(w_none());
+    }
+    let result = generator_send_ex(
+        async_gen,
+        w_none(),
+        Some(PyError::new(PyErrorKind::GeneratorExit, String::new())),
+        None,
+    );
+    unsafe { pyre_object::generator::w_async_generator_set_running(async_gen, false) };
+    match result {
+        Ok(_) => Err(PyError::runtime_error("coroutine ignored GeneratorExit")),
+        Err(err)
+            if matches!(
+                err.kind,
+                PyErrorKind::GeneratorExit
+                    | PyErrorKind::StopIteration
+                    | PyErrorKind::StopAsyncIteration
+            ) =>
+        {
+            Ok(w_none())
+        }
+        Err(err) => Err(err),
+    }
+}
+
+pub(crate) fn async_gen_athrow_throw_method(args: &[PyObjectRef]) -> PyResult {
+    let awaitable = args.first().copied().unwrap_or(PY_NULL);
+    let (async_gen, closing, state) = {
+        let payload = pyre_object::generator::AsyncGenAThrow::from_obj(awaitable)
+            .ok_or_else(|| PyError::type_error("invalid async_generator_athrow receiver"))?;
+        (
+            payload.async_gen,
+            payload.w_exc_type.is_null(),
+            payload.state,
+        )
+    };
+    if state == pyre_object::generator::ASYNC_GEN_STATE_CLOSED {
+        return Err(PyError::runtime_error(
+            "cannot reuse already awaited aclose()/athrow()",
+        ));
+    }
+    if state == pyre_object::generator::ASYNC_GEN_STATE_INIT {
+        pyre_object::generator::AsyncGenAThrow::from_obj(awaitable)
+            .expect("validated async_generator_athrow")
+            .state = pyre_object::generator::ASYNC_GEN_STATE_ITER;
+        if unsafe { pyre_object::generator::w_async_generator_is_running(async_gen) } {
+            pyre_object::generator::AsyncGenAThrow::from_obj(awaitable)
+                .expect("validated async_generator_athrow")
+                .state = pyre_object::generator::ASYNC_GEN_STATE_CLOSED;
+            return Err(PyError::runtime_error(
+                "athrow(): asynchronous generator is already running",
+            ));
+        }
+        unsafe { pyre_object::generator::w_async_generator_set_running(async_gen, true) };
+    }
+    let mut forwarded = Vec::with_capacity(args.len());
+    forwarded.push(async_gen);
+    forwarded.extend_from_slice(args.get(1..).unwrap_or(&[]));
+    let result = match generator_throw_method(&forwarded) {
+        Ok(value) => async_gen_unwrap_value(async_gen, value),
+        Err(err) => async_gen_athrow_handle_error(closing, err),
+    };
+    if result.is_err() {
+        unsafe { pyre_object::generator::w_async_generator_set_running(async_gen, false) };
+        pyre_object::generator::AsyncGenAThrow::from_obj(awaitable)
+            .expect("validated async_generator_athrow")
+            .state = pyre_object::generator::ASYNC_GEN_STATE_CLOSED;
+    }
+    result
+}
+
 /// generator.py:302 `_finalize_` — called by the GC finalizer when a suspended generator
 /// is collected. If the suspended frame is still live and its current instruction is
 /// covered by an exception-table handler (a `finally`/`except`/`with` cleanup), raise
@@ -13370,6 +13813,18 @@ pub fn generator_finalize(gen_obj: PyObjectRef) -> PyResult {
         let code = frame.code();
         let pc_bytes = (last_instr as u32) * 2; // last_instr is a word index; table is byte offsets
         if crate::pycode::lookup_exceptiontable(&code.exceptiontable, pc_bytes).is_some() {
+            if is_async_generator(gen_obj) {
+                let finalizer = w_async_generator_get_finalizer(gen_obj);
+                if !finalizer.is_null() {
+                    return match crate::call::call_function_impl_result(finalizer, &[gen_obj]) {
+                        Ok(_) => Ok(w_none()),
+                        Err(mut err) => {
+                            err.write_unraisable(w_none(), "async generator finalizer", gen_obj);
+                            Ok(w_none())
+                        }
+                    };
+                }
+            }
             return generator_close_method(&[gen_obj]);
         }
     }

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -12788,64 +12788,70 @@ fn generator_send_ex(
         w_generator_set_started(gen_obj);
         w_generator_set_running(gen_obj, true);
 
-        // A suspended `yield from` owns the next resume operation.  Keep the
-        // outer frame parked until its delegate either yields again or is
-        // exhausted, so a value or exception never takes the bytecode path
-        // intended for an awaitable resume.
-        let mut pending_operr = operr;
-        let mut delegated_completion = false;
-        if already_started && !frame.w_yielding_from.is_null() {
-            match resume_yield_from(frame, w_arg, pending_operr.take(), throw_args) {
-                Ok(Some(value)) => {
-                    w_generator_set_running(gen_obj, false);
-                    return Ok(value);
-                }
-                Ok(None) => delegated_completion = true,
-                Err(err) => pending_operr = Some(err),
-            }
+        // generator.py:127 `ec.push_gen_or_coroutine(self)`: make the
+        // exception suspended on this generator current for the whole resume,
+        // including a delegated `yield from` call.
+        let ec =
+            crate::call::getexecutioncontext() as *mut crate::executioncontext::ExecutionContext;
+        if !ec.is_null() {
+            (*ec).push_gen_or_coroutine(gen_obj);
         }
+        let invoke_result = (|| -> PyResult {
+            // A suspended `yield from` owns the next resume operation.  Keep
+            // the outer frame parked until its delegate either yields again or
+            // is exhausted, so a value or exception never takes the bytecode
+            // path intended for an awaitable resume.
+            let mut pending_operr = operr;
+            let mut delegated_completion = false;
+            if already_started && !frame.w_yielding_from.is_null() {
+                match resume_yield_from(frame, w_arg, pending_operr.take(), throw_args) {
+                    Ok(Some(value)) => return Ok(value),
+                    Ok(None) => delegated_completion = true,
+                    Err(err) => pending_operr = Some(err),
+                }
+            }
 
-        // generator.py:104 — w_result = frame.execute_frame(w_arg, operr)
-        let w_inputvalue = if already_started && pending_operr.is_none() && !delegated_completion {
-            Some(w_arg)
-        } else {
-            None
-        };
-        let result = frame.execute_frame(w_inputvalue, pending_operr);
+            // generator.py:104 — w_result = frame.execute_frame(w_arg, operr)
+            let w_inputvalue =
+                if already_started && pending_operr.is_none() && !delegated_completion {
+                    Some(w_arg)
+                } else {
+                    None
+                };
+            let result = frame.execute_frame(w_inputvalue, pending_operr);
 
-        w_generator_set_running(gen_obj, false);
-
-        match result {
-            Ok(value) => {
-                // generator.py:109-114 — if the frame marked itself finished,
-                // it was RETURNed from; otherwise it YIELDed.
-                if frame.frame_finished_execution() {
+            match result {
+                Ok(value) => {
+                    // generator.py:109-114 — if the frame marked itself
+                    // finished, it was RETURNed from; otherwise it YIELDed.
+                    if frame.frame_finished_execution() {
+                        generator_frame_is_finished(gen_obj, frame);
+                        // generator.py:117-119 / pyopcode.py RETURN_VALUE in
+                        // generator frames — `raise StopIteration(returnvalue)`
+                        // so callers can pull the return value off `.value`.
+                        Err(stop_iteration_with_value(value))
+                    } else {
+                        Ok(value)
+                    }
+                }
+                Err(e) => {
                     generator_frame_is_finished(gen_obj, frame);
-                    // generator.py:117-119 / pyopcode.py RETURN_VALUE in
-                    // generator frames — `raise StopIteration(returnvalue)`
-                    // so callers can pull the return value off `.value`.
-                    // Wrap any non-None return into the exception's args
-                    // tuple; bare `return` (or fallthrough → None) keeps
-                    // an empty args tuple.
-                    Err(stop_iteration_with_value(value))
-                } else {
-                    Ok(value)
+                    // generator.py `_leak_stopiteration` (PEP 479).
+                    if e.kind == crate::PyErrorKind::StopIteration {
+                        Err(leak_stopiteration(e))
+                    } else {
+                        Err(e)
+                    }
                 }
             }
-            Err(e) => {
-                generator_frame_is_finished(gen_obj, frame);
-                // generator.py `_leak_stopiteration` (PEP 479) — a
-                // StopIteration that escaped the body becomes RuntimeError;
-                // any other error propagates unchanged.  The normal-return
-                // StopIteration is built in the `Ok`/`frame_finished_execution`
-                // arm above and never reaches here.
-                if e.kind == crate::PyErrorKind::StopIteration {
-                    Err(leak_stopiteration(e))
-                } else {
-                    Err(e)
-                }
-            }
+        })();
+        // generator.py:142-145 `finally`: always clear the running flag and
+        // restore the caller's exception state after this resume.
+        w_generator_set_running(gen_obj, false);
+        if !ec.is_null() {
+            (*ec).pop_gen_or_coroutine(gen_obj);
         }
+        invoke_result
     }
 }
 

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -3745,8 +3745,11 @@ pub fn exception_match(exc_type: PyObjectRef, check_class: PyObjectRef) -> bool 
     mro.iter().any(|&klass| is_w(klass, check_class))
 }
 
-/// Get the length of a container: `len(obj)`.
-pub fn len(obj: PyObjectRef) -> PyResult {
+/// `pypy/objspace/descroperation.py:294-298 _len` — invoke the concrete
+/// `__len__` descriptor and return its still-wrapped result.  The public
+/// [`len`] and [`len_w`] operations below perform the mandatory index,
+/// nonnegative, and machine-word checks around this primitive.
+fn _len(obj: PyObjectRef) -> PyResult {
     // descroperation.py:294-298 `_len` — a builtin subclass overriding
     // `__len__` dispatches the override (bound via `get_and_call_function`);
     // exact builtins and non-overriding subclasses fall through to the
@@ -3758,6 +3761,16 @@ pub fn len(obj: PyObjectRef) -> PyResult {
         }
     }
     len_slot(obj)
+}
+
+/// `pypy/objspace/descroperation.py:304-308 len` — preserve the wrapped
+/// integer returned by `space.index`, but validate negativity and overflow
+/// before exposing it to app-level `len()`.
+pub fn len(obj: PyObjectRef) -> PyResult {
+    let w_res = _len(obj)?;
+    let w_index = space_index(w_res)?;
+    _check_len_result(w_index)?;
+    Ok(w_index)
 }
 
 /// The builtin `__len__` slot body: length dispatch by concrete layout.
@@ -4638,31 +4651,27 @@ fn getattr_str_impl(obj: PyObjectRef, name: &str, call_getattr: bool) -> PyResul
         }
     }
 
-    // Module objects: look up in module namespace.
-    // PyPy `space.getattr(w_module, w_name) → Module.getdictvalue(space,
-    // name)` (`pypy/interpreter/module.py:Module.getdictvalue`
-    // inherited from `baseobjspace.py:45-48 W_Root.getdictvalue`):
-    //
-    //     w_dict = self.getdict(space)        # module.py:77 → self.w_dict
-    //     if w_dict is not None:
-    //         return space.finditem_str(w_dict, attr)
-    //     return None
-    //
-    // Routing through `space.finditem_str` (rather than reading the
-    // backing storage directly) gives dict subclass `__getitem__`
-    // overrides their PyPy chance to fire on the user-supplied
-    // `__builtins__` aliasing case (`moduledef.py:102-103
-    // Module(space, None, w_builtin)`), and routes through the
-    // storage-authoritative read path so transient W_DictObject
-    // snapshots can't shadow the live storage state.  The Result-
-    // bearing variant propagates non-KeyError errors from subclass
-    // overrides (`baseobjspace.py:870 finditem` re-raise).
+    // Module objects use `object_getattribute` first (`module.py:130-134`),
+    // so their class descriptors and namespace follow the normal descriptor
+    // precedence.  This matters for a ModuleType subclass that shadows the
+    // base `__dict__` member: `class M(ModuleType): __dict__ = 8` must expose
+    // 8, and `module.__dir__` then rejects it as a non-dict.  Only after the
+    // complete normal lookup misses does module.py consult PEP 562
+    // `__getattr__` (the tail below).
     unsafe {
         if is_module(obj) {
-            if name == "__dict__" {
-                // module.py:20 — `Module.getdict(space)` returns
-                // `self.w_dict`.  Always non-null after construction.
-                return Ok(pyre_object::w_module_get_w_dict(obj));
+            let w_type = crate::typedef::r#type(obj).unwrap_or(PY_NULL);
+            let w_descr = if w_type.is_null() {
+                None
+            } else {
+                lookup_in_type_where(w_type, name)
+            };
+            if let Some(descr) = w_descr {
+                if is_data_descr(descr) {
+                    if let Some(value) = get(descr, obj, w_type)? {
+                        return Ok(value);
+                    }
+                }
             }
             let w_dict = pyre_object::w_module_get_w_dict(obj);
             if !w_dict.is_null() {
@@ -4671,6 +4680,9 @@ fn getattr_str_impl(obj: PyObjectRef, name: &str, call_getattr: bool) -> PyResul
                         return Ok(value);
                     }
                 }
+            }
+            if let Some(descr) = w_descr {
+                return Ok(get(descr, obj, w_type)?.unwrap_or(descr));
             }
         }
     }
@@ -10178,7 +10190,7 @@ fn _check_len_result(w_int: PyObjectRef) -> Result<i64, crate::PyError> {
 /// before `_check_len_result` so `__index__` is consulted but `__int__`
 /// is NOT — matching PyPy's stricter contract.
 pub fn len_w(w_obj: PyObjectRef) -> Result<i64, crate::PyError> {
-    let w_res = len(w_obj)?;
+    let w_res = _len(w_obj)?;
     let w_index = space_index(w_res)?;
     _check_len_result(w_index)
 }

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -13180,23 +13180,78 @@ pub(crate) fn generator_send_method(args: &[PyObjectRef]) -> PyResult {
 
 /// PyPy: GeneratorIterator.descr_throw(w_type, w_val=None, w_tb=None)
 pub(crate) fn generator_throw_method(args: &[PyObjectRef]) -> PyResult {
-    let gen_obj = if args.is_empty() {
-        pyre_object::PY_NULL
-    } else {
-        args[0]
-    };
-    let w_type = if args.len() > 1 {
-        args[1]
-    } else {
-        pyre_object::PY_NULL
-    };
+    let given = args.len().saturating_sub(1);
+    if given == 0 {
+        return Err(PyError::type_error(
+            "throw expected at least 1 argument, got 0",
+        ));
+    }
+    if given > 3 {
+        return Err(PyError::type_error(format!(
+            "throw expected at most 3 arguments, got {given}"
+        )));
+    }
+    let gen_obj = args[0];
+    let w_type = args[1];
     let w_val = args.get(2).copied().unwrap_or_else(w_none);
     let w_tb = args.get(3).copied().unwrap_or_else(w_none);
-    let argc = (args.len() - 1).clamp(1, 3);
+    let argc = given;
 
-    // A non-exception argument or a normalization failure is raised to the
-    // caller; the generator is not resumed.
-    let err = normalize_throw_args(w_type, w_val)?;
+    // Python 3.14 deprecates only the legacy three-argument spelling; the
+    // one- and two-argument forms retain their existing semantics.
+    if argc == 3 {
+        crate::warn::warn_category(
+            "the (type, exc, tb) signature of throw() is deprecated, use the single-arg signature instead.",
+            "DeprecationWarning",
+            2,
+        )?;
+    }
+
+    // generator.py:185-216 `throw` — validate the traceback before the
+    // exception class/instance, then normalize an OperationError.  Usage
+    // errors are raised to the caller; failures produced while constructing
+    // an exception class are thrown into the generator itself.
+    let traceback = if unsafe { is_none(w_tb) } {
+        None
+    } else if unsafe { crate::pytraceback::is_pytraceback(w_tb) } {
+        Some(w_tb)
+    } else {
+        return Err(PyError::type_error(
+            "throw() third argument must be a traceback object",
+        ));
+    };
+    let is_class = unsafe { exception_is_valid_obj_as_class_w(w_type) };
+    let is_instance = if is_class {
+        false
+    } else {
+        let w_class = exception_getclass(w_type);
+        !w_class.is_null() && unsafe { exception_is_valid_class_w(w_class) }
+    };
+    if !is_class && !is_instance {
+        return Err(PyError::type_error(format!(
+            "exceptions must be classes or instances deriving from BaseException, not {}",
+            crate::type_methods::arg_type_name(w_type),
+        )));
+    }
+    if is_instance && unsafe { !is_none(w_val) } {
+        return Err(PyError::type_error(
+            "instance exception may not have a separate value",
+        ));
+    }
+
+    let mut operr = crate::error::OperationError::new(w_type, w_val);
+    operr._application_traceback = traceback;
+    let err = match operr.normalize_exception(w_none()) {
+        Ok(w_value) => unsafe { PyError::from_exc_object(w_value) },
+        Err(err) => {
+            return generator_send_ex(
+                gen_obj,
+                w_none(),
+                Some(err),
+                Some(([w_type, w_val, w_tb], argc)),
+            );
+        }
+    };
     generator_send_ex(
         gen_obj,
         w_none(),
@@ -13293,41 +13348,6 @@ pub fn generator_finalize(gen_obj: PyObjectRef) -> PyResult {
         }
     }
     Ok(w_none())
-}
-
-/// Normalize throw() arguments into a PyError.
-///
-/// PyPy: generator.py throw() → OperationError(w_type, w_val, tb) + normalize
-///
-/// Handles:
-///   throw(TypeError)         — type → creates instance
-///   throw(TypeError("msg"))  — instance → derives type
-///   throw(TypeError, "msg")  — type + value → creates instance
-fn normalize_throw_args(w_type: PyObjectRef, w_val: PyObjectRef) -> Result<PyError, PyError> {
-    unsafe {
-        // If w_type is an exception instance, use it directly
-        if !w_type.is_null() && pyre_object::interp_exceptions::is_exception(w_type) {
-            return Ok(PyError::from_exc_object(w_type));
-        }
-
-        // generator.py throw(): a valid exception class is called to make
-        // the exception instance, including user-defined subclasses.
-        if !w_type.is_null() && exception_is_valid_obj_as_class_w(w_type) {
-            let w_exc = if w_val.is_null() || pyre_object::is_none(w_val) {
-                crate::call::call_function_impl_result(w_type, &[])?
-            } else {
-                crate::call::call_function_impl_result(w_type, &[w_val])?
-            };
-            if pyre_object::interp_exceptions::is_exception(w_exc) {
-                return Ok(PyError::from_exc_object(w_exc));
-            }
-        }
-
-        // Fallback: TypeError
-        Err(PyError::type_error(
-            "exceptions must be classes or instances deriving from BaseException",
-        ))
-    }
 }
 
 #[cfg(test)]

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -8704,6 +8704,26 @@ pub fn object_setattr(obj: PyObjectRef, name: &str, value: PyObjectRef) -> PyRes
                     w_type_get_name(obj)
                 )));
             }
+            // typeobject.py's metadata setters update the heap type itself;
+            // they are not ordinary inherited class attributes.
+            if name == "__qualname__" {
+                if !crate::baseobjspace::isinstance_str_w(value) {
+                    return Err(PyError::type_error(format!(
+                        "can only assign string to {}.__qualname__, not '{}'",
+                        w_type_get_name(obj),
+                        pyre_object::type_name_of(value)
+                    )));
+                }
+                pyre_object::w_type_set_qualname(obj, pyre_object::w_str_get_value(value));
+                mutated(obj, Some(name));
+                return Ok(w_none());
+            }
+            if name == "__module__" {
+                crate::type_dict_store(obj, name, value);
+                crate::type_dict_delete(obj, "__firstlineno__");
+                mutated(obj, Some(name));
+                return Ok(w_none());
+            }
             if crate::type_dict_has_storage(obj) {
                 // CPython 3.14 type_set_annotations stores assignments in
                 // the per-type cache and disables the lazy annotate
@@ -9448,6 +9468,15 @@ pub fn object_delattr(obj: PyObjectRef, name: &str) -> PyResult {
             if !pyre_object::w_type_is_heaptype(obj) {
                 return Err(PyError::type_error(format!(
                     "cannot delete attributes on immutable type object '{}'",
+                    w_type_get_name(obj)
+                )));
+            }
+            // CPython 3.14 exposes these as non-deletable type metadata.
+            // Their values may be assigned, but deletion must not fall
+            // through to raw namespace removal.
+            if name == "__name__" || name == "__qualname__" || name == "__type_params__" {
+                return Err(PyError::type_error(format!(
+                    "cannot delete '{name}' attribute of type '{}'",
                     w_type_get_name(obj)
                 )));
             }

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -64,6 +64,17 @@ pub fn take_pending_hash_error() -> PyError {
     })
 }
 
+/// Convert the two failure modes of a checked set-table operation back into
+/// the Python exception carried by PyPy's `r_dict` operation.
+pub fn map_set_update_error(err: pyre_object::setobject::SetUpdateError) -> PyError {
+    match err {
+        pyre_object::setobject::SetUpdateError::Key(_) => take_pending_hash_error(),
+        pyre_object::setobject::SetUpdateError::ChangedSize => {
+            PyError::runtime_error("Set changed size during iteration")
+        }
+    }
+}
+
 /// Root the exception parked in `PENDING_HASH_ERROR` while a raising
 /// `__hash__`/`__eq__` propagates across a dict probe. Its `PyError` holds GC
 /// refs the precise collector does not reach through the raw `Cell`; forward
@@ -136,11 +147,23 @@ pub fn wrap_dict_key_hash_error(key: PyObjectRef, err: PyError) -> PyError {
     ))
 }
 
-/// The set-element counterpart of [`wrap_dict_key_hash_error`]: a bad element
-/// raises the bare `unhashable type: '<type>'` TypeError from hashing, so the
-/// error passes through unchanged.
-pub fn wrap_set_element_hash_error(_item: PyObjectRef, err: PyError) -> PyError {
-    err
+/// Python 3.14's set-element counterpart of [`wrap_dict_key_hash_error`].
+pub fn wrap_set_element_hash_error(item: PyObjectRef, err: PyError) -> PyError {
+    if err.kind != PyErrorKind::TypeError {
+        return err;
+    }
+    if !err.exc_object.is_null() {
+        let exact_type_error = crate::builtins::lookup_exc_class("TypeError");
+        let raised_type = crate::typedef::r#type(err.exc_object).unwrap_or(PY_NULL);
+        if exact_type_error.is_none_or(|expected| !std::ptr::eq(raised_type, expected)) {
+            return err;
+        }
+    }
+    PyError::type_error(format!(
+        "cannot use '{}' as a set element ({})",
+        object_functionstr_type_name(item),
+        err.message,
+    ))
 }
 
 /// Compatibility alias for PyPy's base-object type.

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -6704,6 +6704,31 @@ fn parse_int_from_str(
             c.to_digit(radix).is_some()
         }
     };
+
+    // RPython `NumberStringParser.__init__` checks the configured digit
+    // limit immediately after whitespace/sign/base-prefix handling and
+    // before it allocates or parses the digit stream.  Preserve that order:
+    // malformed underscore placement is diagnosed later by `next_digit`,
+    // except for an empty input or a leading underscore before a base prefix,
+    // which the parser rejects ahead of the limit check.
+    if digits.is_empty() || (!had_base_prefix && digits.starts_with('_')) {
+        return Err(invalid_int_literal(w_source, base));
+    }
+    if radix & (radix - 1) != 0 {
+        let maxdigits = crate::module::sys::state::int_max_str_digits();
+        if maxdigits != 0 {
+            let digit_count = digits.chars().filter(|&c| c != '_').count();
+            if digit_count > maxdigits as usize {
+                return Err(crate::PyError::new(
+                    crate::PyErrorKind::ValueError,
+                    format!(
+                        "Exceeds the limit ({maxdigits} digits) for integer string conversion: value has {digit_count} digits; use sys.set_int_max_str_digits() to increase the limit"
+                    ),
+                ));
+            }
+        }
+    }
+
     let digit_chars: Vec<char> = digits.chars().collect();
     let mut cleaned = String::with_capacity(digits.len());
     for (i, &c) in digit_chars.iter().enumerate() {
@@ -6720,21 +6745,6 @@ fn parse_int_from_str(
             return Err(invalid_int_literal(w_source, base));
         }
         cleaned.push(c);
-    }
-    // PyPy `pypy/objspace/std/intobject.py:_string_to_int_or_long` applies
-    // the configurable limit to every non-binary base. Underscores are not
-    // digits and have already been removed from `cleaned`.
-    if radix & (radix - 1) != 0 {
-        let maxdigits = crate::module::sys::state::int_max_str_digits();
-        if maxdigits != 0 && cleaned.len() > maxdigits as usize {
-            return Err(crate::PyError::new(
-                crate::PyErrorKind::ValueError,
-                format!(
-                    "Exceeds the limit ({maxdigits}) for integer string conversion: value has {} digits",
-                    cleaned.len()
-                ),
-            ));
-        }
     }
     if let Ok(v) = i64::from_str_radix(&cleaned, radix) {
         return Ok(w_int_new(sign * v));
@@ -11985,6 +11995,35 @@ mod tests {
         let err = builtin_hash(&[value]).expect_err("tuple hash should reject list element");
 
         assert_eq!(err.kind, crate::PyErrorKind::TypeError);
+    }
+
+    #[test]
+    fn int_string_digit_limit_precedes_digit_buffer_allocation() {
+        crate::typedef::init_typeobjects();
+        let text = "7".repeat(crate::module::sys::state::DEFAULT_MAX_STR_DIGITS as usize + 1);
+        let source = w_str_new(&text);
+        let err = parse_int_from_str(source, &text, 10).unwrap_err();
+        assert_eq!(err.kind, crate::PyErrorKind::ValueError);
+        assert_eq!(
+            err.message,
+            "Exceeds the limit (4300 digits) for integer string conversion: value has 4301 digits; use sys.set_int_max_str_digits() to increase the limit"
+        );
+    }
+
+    #[test]
+    fn int_string_leading_underscore_error_precedes_digit_limit() {
+        crate::typedef::init_typeobjects();
+        let text = format!(
+            "_{}",
+            "7".repeat(crate::module::sys::state::DEFAULT_MAX_STR_DIGITS as usize + 1)
+        );
+        let source = w_str_new(&text);
+        let err = parse_int_from_str(source, &text, 10).unwrap_err();
+        assert_eq!(err.kind, crate::PyErrorKind::ValueError);
+        assert!(
+            err.message
+                .starts_with("invalid literal for int() with base 10:")
+        );
     }
 
     #[test]

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -11729,29 +11729,24 @@ fn builtin_format(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
 /// `__import__(name, globals=None, locals=None, fromlist=(), level=0)`
 /// — PyPy: `pypy/module/imp/importing.py:importhook`.
 fn builtin_import_stub(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    // `__import__(name, globals, locals, fromlist, level)` — every parameter
-    // may be passed by keyword (`__import__("a.b", fromlist=["c"])`), so the
-    // positional slots fall back to the matching kwarg.
-    let (pos, kwargs) = split_builtin_kwargs(args);
-    let arg = |idx: usize, key: &str| -> PyObjectRef {
-        pos.get(idx)
-            .copied()
-            .or_else(|| kwarg_get(kwargs, key))
-            .unwrap_or(pyre_object::PY_NULL)
-    };
-    let name_obj = arg(0, "name");
-    if name_obj.is_null() {
-        return Err(crate::PyError::type_error(
-            "__import__() missing required argument 'name' (pos 1)",
-        ));
-    }
+    // `__import__(name, globals, locals, fromlist, level)` — PyPy's gateway
+    // binds the five named slots before `importhook` runs.  Use the shared
+    // flat-ABI equivalent so duplicate positional/keyword values, unknown
+    // keywords, and surplus positionals raise at the same boundary.
+    let scope = bind_builtin_kwargs(
+        args,
+        &["name", "globals", "locals", "fromlist", "level"],
+        &[true, false, false, false, false],
+        "__import__",
+    )?;
+    let name_obj = scope[0];
     if !unsafe { pyre_object::is_str(name_obj) } {
         return Err(crate::PyError::type_error("module name must be a string"));
     }
     let name = unsafe { pyre_object::w_str_get_value(name_obj) };
-    let globals = arg(1, "globals");
-    let fromlist = arg(3, "fromlist");
-    let level_obj = arg(4, "level");
+    let globals = scope[1];
+    let fromlist = scope[3];
+    let level_obj = scope[4];
     // `@unwrap_spec(level=int)` — an omitted level defaults to 0; a supplied
     // non-integer raises through the index protocol rather than defaulting.
     let level = if level_obj.is_null() {

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -7127,7 +7127,7 @@ pub fn builtin_set_add_items(
             let set = pyre_object::gc_roots::shadow_stack_get(sp);
             let item = pyre_object::gc_roots::shadow_stack_get(item_base + i);
             pyre_object::w_set_add_hashed_checked(set, item, hash)
-                .map_err(|_| crate::baseobjspace::take_pending_hash_error())?;
+                .map_err(crate::baseobjspace::map_set_update_error)?;
         }
         Ok(())
     }

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -9941,6 +9941,24 @@ pub(crate) fn init_file_wrapper_type(ns: PyObjectRef) {
                     .get(2)
                     .map(|&o| unsafe { pyre_object::w_int_get_value(o) })
                     .unwrap_or(0) as i32;
+                // CPython 3.14 TextIOWrapper only permits the opaque-cookie
+                // forms for current/end-relative seeks; FileIO remains free
+                // to use ordinary non-zero offsets.
+                if !file_is_binary(args[0]) && offset != 0 {
+                    // POSIX/Python's public SEEK_CUR and SEEK_END values are
+                    // 1 and 2.  Keep this semantic validation target-neutral;
+                    // wasm libc intentionally does not expose lseek constants.
+                    if whence == 1 {
+                        return Err(crate::module::_io::unsupported(
+                            "can't do nonzero cur-relative seeks",
+                        ));
+                    }
+                    if whence == 2 {
+                        return Err(crate::module::_io::unsupported(
+                            "can't do nonzero end-relative seeks",
+                        ));
+                    }
+                }
                 if let Some(fd) = file_get_fd(args[0]) {
                     #[cfg(all(feature = "host_env", not(target_arch = "wasm32")))]
                     {
@@ -10337,10 +10355,7 @@ fn file_check_readable(self_obj: PyObjectRef) -> Result<(), crate::PyError> {
     if mode.contains('r') || mode.contains('+') {
         Ok(())
     } else {
-        // `UnsupportedOperation` derives from ValueError; until exception
-        // instances carry that multiple-inheritance class here, preserve the
-        // observable ValueError branch and PyPy's exact message.
-        Err(crate::PyError::value_error("File not open for reading"))
+        Err(crate::module::_io::unsupported("File not open for reading"))
     }
 }
 
@@ -10349,14 +10364,15 @@ fn file_check_writable(self_obj: PyObjectRef) -> Result<(), crate::PyError> {
     if mode.contains('w') || mode.contains('a') || mode.contains('x') || mode.contains('+') {
         Ok(())
     } else {
-        Err(crate::PyError::value_error("File not open for writing"))
+        Err(crate::module::_io::unsupported("File not open for writing"))
     }
 }
 
 /// One `space.acquire_writebuf` export held for a FileIO `readinto` call.
 /// PyPy's `with view:` keeps this lock until after `output_slice`/`c_read`.
 pub(crate) struct WritableBuffer {
-    obj: PyObjectRef,
+    _roots: pyre_object::gc_roots::RootScope,
+    owner_slot: usize,
     held: bool,
     address: *mut u8,
     length: usize,
@@ -10364,16 +10380,26 @@ pub(crate) struct WritableBuffer {
 
 impl WritableBuffer {
     pub(crate) unsafe fn acquire(obj: PyObjectRef) -> Result<Self, crate::PyError> {
-        let mut acquired = Self {
-            obj,
-            held: unsafe { buffer_export_incref(obj) },
-            address: std::ptr::null_mut(),
-            length: 0,
-        };
-        let data = unsafe { fileio_writebuf(obj) }?;
-        acquired.address = data.as_mut_ptr();
-        acquired.length = data.len();
-        Ok(acquired)
+        // `space.acquire_writebuf` owns a traced exporter for the complete
+        // `with view:` extent.  Root both the requested object and the
+        // concrete storage owner so Python called while the buffer is live
+        // cannot leave Drop with a pre-GC address.
+        let roots = pyre_object::gc_roots::push_roots();
+        pyre_object::gc_roots::pin_root(obj);
+        let obj_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+        let (data, owner) =
+            unsafe { fileio_writebuf(pyre_object::gc_roots::shadow_stack_get(obj_slot))? };
+        pyre_object::gc_roots::pin_root(owner);
+        let owner_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+        let owner = pyre_object::gc_roots::shadow_stack_get(owner_slot);
+        let held = unsafe { buffer_export_incref(owner) };
+        Ok(Self {
+            _roots: roots,
+            owner_slot,
+            held,
+            address: data.as_mut_ptr(),
+            length: data.len(),
+        })
     }
 
     pub(crate) unsafe fn as_mut_slice(&mut self) -> &mut [u8] {
@@ -10384,26 +10410,44 @@ impl WritableBuffer {
 impl Drop for WritableBuffer {
     fn drop(&mut self) {
         if self.held {
-            unsafe { buffer_export_decref(self.obj) };
+            let owner = pyre_object::gc_roots::shadow_stack_get(self.owner_slot);
+            unsafe { buffer_export_decref(owner) };
         }
     }
 }
 
 /// `space.acquire_writebuf` for FileIO.readinto.  These are pyre's native
 /// writable exporters; a memoryview contributes its exact contiguous window.
-unsafe fn fileio_writebuf(obj: PyObjectRef) -> Result<&'static mut [u8], crate::PyError> {
+unsafe fn fileio_writebuf(
+    obj: PyObjectRef,
+) -> Result<(&'static mut [u8], PyObjectRef), crate::PyError> {
     unsafe {
         if pyre_object::bytearrayobject::is_bytearray(obj) {
-            return Ok(pyre_object::bytearrayobject::w_bytearray_data_mut(obj));
+            return Ok((pyre_object::bytearrayobject::w_bytearray_data_mut(obj), obj));
         }
         if pyre_object::interp_array::is_array(obj) {
-            return Ok(pyre_object::interp_array::w_array_vec_mut(obj).as_mut_slice());
+            return Ok((
+                pyre_object::interp_array::w_array_vec_mut(obj).as_mut_slice(),
+                obj,
+            ));
         }
         #[cfg(all(unix, not(feature = "sandbox")))]
         if let Some(view) = crate::module::mmap::interp_mmap::mmap_buffer_view(obj) {
             let (address, length, readonly) = view?;
             if !readonly {
-                return Ok(std::slice::from_raw_parts_mut(address as *mut u8, length));
+                return Ok((
+                    std::slice::from_raw_parts_mut(address as *mut u8, length),
+                    obj,
+                ));
+            }
+        }
+        #[cfg(all(unix, feature = "host_env", not(feature = "sandbox")))]
+        if let Some((backing, offset, length, _format, _itemsize, _shape)) =
+            crate::module::_ctypes::cdata::cdata_buffer_view(obj)
+        {
+            let full = pyre_object::bytearrayobject::w_bytearray_data_mut(backing);
+            if offset <= full.len() && length <= full.len() - offset {
+                return Ok((&mut full[offset..offset + length], backing));
             }
         }
         if pyre_object::memoryview::is_w_memoryview(obj) {
@@ -10427,7 +10471,7 @@ unsafe fn fileio_writebuf(obj: PyObjectRef) -> Result<&'static mut [u8], crate::
                     "memoryview buffer is no longer valid",
                 ));
             }
-            return Ok(&mut full[offset..offset + length]);
+            return Ok((&mut full[offset..offset + length], obj));
         }
         Err(crate::PyError::type_error(
             "readinto() argument must be read-write bytes-like object",
@@ -10737,15 +10781,16 @@ fn file_method_read(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError>
         return Err(crate::PyError::type_error("read() requires self"));
     }
     file_check_closed(args[0])?;
+    file_check_readable(args[0])?;
     if let Some(fd) = file_get_fd(args[0]) {
-        let n = args.get(1).and_then(|&o| unsafe {
-            if pyre_object::is_int(o) {
-                let v = pyre_object::w_int_get_value(o);
-                if v < 0 { None } else { Some(v as usize) }
-            } else {
-                None
+        let n = match args.get(1).copied() {
+            None => None,
+            Some(value) if unsafe { pyre_object::is_none(value) } => None,
+            Some(value) => {
+                let value = crate::baseobjspace::int_w(crate::baseobjspace::space_index(value)?)?;
+                (value >= 0).then_some(value as usize)
             }
-        });
+        };
         #[cfg(all(feature = "host_env", not(target_arch = "wasm32")))]
         {
             let data = fd_read(fd, n).map_err(fd_io_err)?;
@@ -10784,16 +10829,17 @@ fn file_method_readline(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyEr
         return Err(crate::PyError::type_error("readline() requires self"));
     }
     file_check_closed(args[0])?;
+    file_check_readable(args[0])?;
     // Optional size cap (`readline(size)`): stop after `size` bytes even
     // before a newline. A missing or negative size means no cap.
-    let max = args.get(1).and_then(|&o| unsafe {
-        if pyre_object::is_int(o) {
-            let v = pyre_object::w_int_get_value(o);
-            if v < 0 { None } else { Some(v as usize) }
-        } else {
-            None
+    let max = match args.get(1).copied() {
+        None => None,
+        Some(value) if unsafe { pyre_object::is_none(value) } => None,
+        Some(value) => {
+            let value = crate::baseobjspace::int_w(crate::baseobjspace::space_index(value)?)?;
+            (value >= 0).then_some(value as usize)
         }
-    });
+    };
     if let Some(fd) = file_get_fd(args[0]) {
         #[cfg(all(feature = "host_env", not(target_arch = "wasm32")))]
         {
@@ -10896,6 +10942,7 @@ fn file_method_write(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError
         return Err(crate::PyError::type_error("write() requires (self, data)"));
     }
     file_check_closed(args[0])?;
+    file_check_writable(args[0])?;
     if let Some(fd) = file_get_fd(args[0]) {
         let bytes: Vec<u8> = unsafe {
             if pyre_object::is_str(args[1]) {

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -3504,7 +3504,7 @@ fn min_max_dispatch(
     // functional.py:216-218 — empty positional → TypeError, not panic.
     if positional.is_empty() {
         return Err(crate::PyError::type_error(format!(
-            "{fn_name}() expected at least one argument, got 0"
+            "{fn_name} expected at least 1 argument, got 0"
         )));
     }
     // functional.py:206-210 — `default=` is only meaningful for the
@@ -8306,23 +8306,33 @@ pub(crate) fn builtin_dir(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::Py
             // base, recursively.
             classdir_into(obj, &mut names)?;
         } else if pyre_object::is_instance(obj) {
-            // util.py:80 `_objectdir` (`object.__dir__`) — the instance
-            // `__dict__` keys plus `_classdir(type(obj))`.  The instance dict
-            // for hasdict objects is the live W_DictObject returned by
-            // `w_obj.getdict(space)`; `__slots__` Member descriptor names live
-            // in the class namespaces walked by `classdir_into`, so every slot
-            // is listed regardless of whether it currently holds a value.
-            let w_dict = crate::baseobjspace::getdict(obj);
-            if !w_dict.is_null() {
+            // util.py:80 `_objectdir` (`object.__dir__`) — use ordinary
+            // `getattr(obj, '__dict__'/'__class__', None)`, not raw layout
+            // fields.  A class may shadow either name with a slot/descriptor;
+            // in particular an uninitialised `__class__` slot suppresses the
+            // recursive class namespace while the live `__dict__` remains.
+            let w_dict = match crate::baseobjspace::getattr_str(obj, "__dict__") {
+                Ok(w_dict) if pyre_object::is_dict(w_dict) => Some(w_dict),
+                Ok(_) => None,
+                Err(e) if e.kind == crate::PyErrorKind::AttributeError => None,
+                Err(e) => return Err(e),
+            };
+            if let Some(w_dict) = w_dict {
                 for (k, _) in pyre_object::w_dict_items(w_dict) {
                     if pyre_object::is_str(k) {
                         names.push(pyre_object::w_str_get_wtf8(k).to_owned());
                     }
                 }
             }
-            let w_type = pyre_object::w_instance_get_type(obj);
-            if !w_type.is_null() && pyre_object::is_type(w_type) {
-                classdir_into(w_type, &mut names)?;
+            let w_class = match crate::baseobjspace::getattr_str(obj, "__class__") {
+                Ok(w_class) => Some(w_class),
+                Err(e) if e.kind == crate::PyErrorKind::AttributeError => None,
+                Err(e) => return Err(e),
+            };
+            if let Some(w_class) = w_class {
+                if pyre_object::is_type(w_class) {
+                    classdir_into(w_class, &mut names)?;
+                }
             }
         } else {
             // Fallback `_objectdir` (util.py:80) for builtin W_Root types
@@ -8946,27 +8956,20 @@ fn builtin_chr(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
             args.len()
         )));
     }
-    let obj = args[0];
-    // operation.py:28 — space.int_w unwraps to int
-    let val = if unsafe { is_int(obj) } {
-        unsafe { w_int_get_value(obj) }
-    } else {
-        // int subclass instance — check __int_value__ via builtin_int
-        match builtin_int(args) {
-            Ok(v) if unsafe { is_int(v) } => unsafe { w_int_get_value(v) },
-            _ => {
-                return Err(crate::PyError::type_error(
-                    "an integer is required (got type non-int)",
-                ));
-            }
-        }
-    };
-    if val < 0 || val > 0x10ffff {
-        // `pypy/module/__builtin__/operation.py:31-32 chr` — out-of-range
-        // raises ValueError, message "chr() arg out of range".
-        return Err(crate::PyError::value_error("chr() arg out of range"));
+    // Python 3.14 `builtin_chr` uses the index protocol: `__int__` alone is
+    // insufficient, floats are rejected, and an arbitrarily large int reaches
+    // the range check rather than overflowing a host machine word.  This is
+    // the target-version difference from PyPy's `@unwrap_spec(code=int)`.
+    let val = index_to_bigint(args[0])?;
+    if val < BigInt::from(0) || val > BigInt::from(0x10ffff_u32) {
+        return Err(crate::PyError::value_error(
+            "chr() arg not in range(0x110000)",
+        ));
     }
-    match char::from_u32(val as u32) {
+    let val = val
+        .to_u32()
+        .expect("chr range check guarantees a value fitting u32");
+    match char::from_u32(val) {
         Some(c) => Ok(w_str_new(&c.to_string())),
         // Surrogate code points (0xD800-0xDFFF) are valid chr() arguments and
         // produce a lone-surrogate string; char::from_u32 rejects them, so
@@ -9517,13 +9520,19 @@ pub fn builtin_any_fn(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyErro
     builtin_any(args)
 }
 fn builtin_any(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    if args.is_empty() {
+    let (positional, kwargs) = split_builtin_kwargs(args);
+    if has_real_kwargs(kwargs) {
+        return Err(crate::PyError::type_error(
+            "any() takes no keyword arguments",
+        ));
+    }
+    if positional.len() != 1 {
         return Err(crate::PyError::type_error(format!(
             "any() takes exactly one argument ({} given)",
-            args.len()
+            positional.len()
         )));
     }
-    let it = crate::baseobjspace::iter(args[0])?;
+    let it = crate::baseobjspace::iter(positional[0])?;
     loop {
         match crate::baseobjspace::next(it) {
             Ok(item) if crate::baseobjspace::is_true(item)? => return Ok(w_bool_from(true)),
@@ -11055,13 +11064,19 @@ pub fn builtin_all_fn(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyErro
     builtin_all(args)
 }
 fn builtin_all(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    if args.is_empty() {
+    let (positional, kwargs) = split_builtin_kwargs(args);
+    if has_real_kwargs(kwargs) {
+        return Err(crate::PyError::type_error(
+            "all() takes no keyword arguments",
+        ));
+    }
+    if positional.len() != 1 {
         return Err(crate::PyError::type_error(format!(
             "all() takes exactly one argument ({} given)",
-            args.len()
+            positional.len()
         )));
     }
-    let it = crate::baseobjspace::iter(args[0])?;
+    let it = crate::baseobjspace::iter(positional[0])?;
     loop {
         match crate::baseobjspace::next(it) {
             Ok(item) if !crate::baseobjspace::is_true(item)? => return Ok(w_bool_from(false)),

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -11420,7 +11420,7 @@ fn parse_complex_str(raw: &str) -> Option<(f64, f64)> {
 ///
 /// `int`/`bool`/`float` become a real-only pair; a `complex` keeps both
 /// components; an instance is asked for `__complex__` then `__float__`.
-fn complex_coerce(obj: PyObjectRef) -> Result<(f64, f64), crate::PyError> {
+pub(crate) fn complex_coerce(obj: PyObjectRef) -> Result<(f64, f64), crate::PyError> {
     use pyre_object::*;
     unsafe {
         if is_exact_type(obj, &COMPLEX_TYPE) {

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -143,6 +143,16 @@ pub(crate) unsafe fn buffer_export_decref(obj: PyObjectRef) {
 /// buffer export (a live memoryview) is outstanding.
 pub(crate) unsafe fn bytearray_check_exports(obj: PyObjectRef) -> Result<(), crate::PyError> {
     if unsafe { pyre_object::bytearrayobject::w_bytearray_exports(obj) } > 0 {
+        // A tracing collector does not reclaim an expression-temporary
+        // `memoryview` at the end of the statement as CPython's refcounting
+        // does.  Make non-moving major progress before rejecting the resize:
+        // dead stable-allocated views run `memoryview_object_destructor` and
+        // release their backing export, while a live view remains counted.
+        // `collect_oldgen` is essential here: callers still hold `obj` in a
+        // by-value interpreter local, so this check must not move it.
+        pyre_object::gc_hook::try_gc_collect_oldgen();
+    }
+    if unsafe { pyre_object::bytearrayobject::w_bytearray_exports(obj) } > 0 {
         return Err(crate::PyError::new(
             crate::PyErrorKind::BufferError,
             "Existing exports of data: object cannot be re-sized",
@@ -9821,11 +9831,15 @@ pub(crate) fn init_file_wrapper_type(ns: PyObjectRef) {
             "fileno",
             make_builtin_function_with_arity(
                 "fileno",
-                |args| match args.first().copied().and_then(file_get_fd) {
-                    Some(fd) => Ok(w_int_new(fd as i64)),
-                    None => Err(crate::PyError::os_error(
-                        "fileno() on a file without a descriptor",
-                    )),
+                |args| {
+                    let self_obj = args[0];
+                    file_check_closed(self_obj)?;
+                    match file_get_fd(self_obj) {
+                        Some(fd) => Ok(w_int_new(fd as i64)),
+                        None => Err(crate::PyError::os_error(
+                            "fileno() on a file without a descriptor",
+                        )),
+                    }
                 },
                 1,
             ),
@@ -9912,6 +9926,12 @@ pub(crate) fn init_file_wrapper_type(ns: PyObjectRef) {
             ns,
             "seek",
             make_builtin_function("seek", |args| {
+                if args.len() < 2 || args.len() > 3 {
+                    return Err(crate::PyError::type_error(format!(
+                        "seek() takes from 1 to 2 arguments ({} given)",
+                        args.len().saturating_sub(1)
+                    )));
+                }
                 file_check_closed(args[0])?;
                 let offset = args
                     .get(1)
@@ -10008,6 +10028,131 @@ pub(crate) fn init_file_wrapper_type(ns: PyObjectRef) {
     };
 }
 
+/// PyPy `W_FileIO.typedef` — raw-stream methods override the shared
+/// TextIOWrapper-shaped helpers installed by [`init_file_wrapper_type`].
+/// Keeping this as a separate initializer mirrors FileIO's distinct typedef
+/// instead of teaching the text wrapper about raw-only operations.
+pub(crate) fn init_fileio_type(ns: PyObjectRef) {
+    for (name, function) in [
+        ("read", make_builtin_function("read", fileio_method_read)),
+        (
+            "readinto",
+            make_builtin_function_with_arity("readinto", fileio_method_readinto, 2),
+        ),
+        (
+            "readall",
+            make_builtin_function_with_arity("readall", fileio_method_readall, 1),
+        ),
+        (
+            "write",
+            make_builtin_function_with_arity("write", fileio_method_write, 2),
+        ),
+        (
+            "truncate",
+            make_builtin_function("truncate", fileio_method_truncate),
+        ),
+    ] {
+        unsafe { pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(ns, name, function) };
+    }
+    for (name, getter) in [
+        ("closed", fileio_get_closed as crate::gateway::BuiltinCodeFn),
+        (
+            "closefd",
+            fileio_get_closefd as crate::gateway::BuiltinCodeFn,
+        ),
+        ("mode", fileio_get_mode as crate::gateway::BuiltinCodeFn),
+        (
+            "_blksize",
+            fileio_get_blksize as crate::gateway::BuiltinCodeFn,
+        ),
+    ] {
+        let getter = make_builtin_function_with_arity(name, getter, 2);
+        unsafe {
+            pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
+                ns,
+                name,
+                crate::typedef::make_getset_descriptor_named(getter, name),
+            )
+        };
+    }
+    unsafe {
+        pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
+            ns,
+            "__repr__",
+            make_builtin_function_with_arity("__repr__", fileio_method_repr, 1),
+        )
+    };
+}
+
+fn fileio_get_slot(args: &[PyObjectRef], storage: &str) -> Result<PyObjectRef, crate::PyError> {
+    let self_obj = args
+        .get(1)
+        .copied()
+        .ok_or_else(|| crate::PyError::type_error("descriptor requires an instance"))?;
+    crate::baseobjspace::getattr_str(self_obj, storage)
+}
+
+fn fileio_get_closed(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    fileio_get_slot(args, "__file_closed__")
+}
+
+fn fileio_get_closefd(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    fileio_get_slot(args, "__file_closefd__")
+}
+
+fn fileio_get_mode(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    fileio_get_slot(args, "__file_public_mode__")
+}
+
+fn fileio_get_blksize(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    fileio_get_slot(args, "__file_blksize__")
+}
+
+/// PyPy `W_FileIO.repr_w`.
+fn fileio_method_repr(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    let self_obj = args
+        .first()
+        .copied()
+        .ok_or_else(|| crate::PyError::type_error("__repr__ requires self"))?;
+    let type_name = unsafe {
+        crate::typedef::r#type(self_obj)
+            .map(|tp| pyre_object::w_type_get_name(tp).to_string())
+            .unwrap_or_else(|| "FileIO".to_string())
+    };
+    // CPython 3.14's subclass repr names the concrete subclass; the builtin
+    // itself retains its public `_io.FileIO` spelling.
+    let repr_type = if type_name == "FileIO" {
+        "_io.FileIO"
+    } else {
+        type_name.as_str()
+    };
+    if file_is_closed(self_obj) {
+        return Ok(w_str_new(&format!("<{repr_type} [closed]>")));
+    }
+    let closefd = if file_closefd(self_obj) {
+        "True"
+    } else {
+        "False"
+    };
+    let mode = crate::baseobjspace::getattr_str(self_obj, "__file_public_mode__")
+        .ok()
+        .and_then(|value| unsafe {
+            pyre_object::is_str(value).then(|| pyre_object::w_str_get_value(value).to_string())
+        })
+        .unwrap_or_default();
+    let body = if let Ok(name) = crate::baseobjspace::getattr_str(self_obj, "name") {
+        format!("name={} mode='{mode}' closefd={closefd}", unsafe {
+            crate::display::py_repr(name)?
+        })
+    } else {
+        format!(
+            "fd={} mode='{mode}' closefd={closefd}",
+            file_get_fd(self_obj).unwrap_or(-1)
+        )
+    };
+    Ok(w_str_new(&format!("<{repr_type} {body}>")))
+}
+
 /// `_io.FileIO.__init__` — PyPy `W_FileIO.descr_init`.
 ///
 /// The existing file helpers keep their state in reserved instance slots; a
@@ -10029,27 +10174,57 @@ pub(crate) fn fileio_init(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::Py
         ));
     }
     let mode = unsafe { pyre_object::w_str_get_value(mode_obj) };
+    // PyPy `decode_mode`: exactly one r/w/x/a flag, at most one '+', and
+    // optional 'b'.  Keep the individual booleans because `_mode()` derives
+    // the public canonical mode from capabilities, not from input spelling
+    // (`wb+` is reported as `rb+`).
     let mut primary = None;
     let mut updating = false;
-    let mut binary_seen = false;
     for ch in mode.chars() {
         match ch {
             'r' | 'w' | 'a' | 'x' => {
-                if primary.replace(ch).is_some() {
-                    return Err(crate::PyError::value_error("invalid mode"));
+                if primary.is_some() {
+                    return Err(crate::PyError::value_error(
+                        "Must have exactly one of read/write/create/append mode",
+                    ));
                 }
+                primary = Some(ch);
             }
-            '+' if !updating => updating = true,
-            'b' if !binary_seen => binary_seen = true,
-            _ => return Err(crate::PyError::value_error("invalid mode")),
+            '+' => {
+                if updating {
+                    return Err(crate::PyError::value_error(
+                        "Must have exactly one of read/write/create/append mode",
+                    ));
+                }
+                updating = true;
+            }
+            'b' => {}
+            _ => {
+                return Err(crate::PyError::value_error(format!("invalid mode: {mode}")));
+            }
         }
     }
-    let primary = primary.ok_or_else(|| crate::PyError::value_error("invalid mode"))?;
-    let binary_mode = format!("{primary}b{}", if updating { "+" } else { "" });
+    let primary = primary.ok_or_else(|| {
+        crate::PyError::value_error("Must have exactly one of read/write/create/append mode")
+    })?;
+    let raw_mode = format!("{primary}b{}", if updating { "+" } else { "" });
+    let binary_mode = match (primary, updating) {
+        ('x', false) => "xb",
+        ('x', true) => "xb+",
+        ('a', false) => "ab",
+        ('a', true) => "ab+",
+        ('r', false) => "rb",
+        ('r', true) | ('w', true) => "rb+",
+        ('w', false) => "wb",
+        _ => unreachable!(),
+    };
 
     let closefd_obj = bind_pos_or_kw(pos, kwargs, 3, "closefd", "FileIO", 3)?
         .unwrap_or_else(|| w_bool_from(true));
     let closefd = crate::baseobjspace::is_true(closefd_obj)?;
+    if unsafe { pyre_object::is_bool(file) } {
+        crate::warn::warn_category("bool is used as a file descriptor", "RuntimeWarning", 1)?;
+    }
     if !unsafe { pyre_object::is_int(file) } && !closefd {
         return Err(crate::PyError::value_error(
             "Cannot use closefd=False with file name",
@@ -10058,7 +10233,7 @@ pub(crate) fn fileio_init(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::Py
     let opener = bind_pos_or_kw(pos, kwargs, 4, "opener", "FileIO", 4)?.unwrap_or_else(w_none);
     let opened = builtin_open(&[
         file,
-        w_str_new(&binary_mode),
+        w_str_new(&raw_mode),
         w_int_new(-1),
         w_none(),
         w_none(),
@@ -10085,22 +10260,319 @@ pub(crate) fn fileio_init(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::Py
             crate::baseobjspace::setattr_str(self_obj, name, value)?;
         }
     }
-    crate::baseobjspace::setattr_str(self_obj, "mode", w_str_new(&binary_mode))?;
-    crate::baseobjspace::setattr_str(self_obj, "closefd", w_bool_from(closefd))?;
-    crate::baseobjspace::setattr_str(self_obj, "closed", w_bool_from(false))?;
+    // PyPy keeps these on W_FileIO fields and exposes them through typedef
+    // descriptors.  Our generic instance layout stores the corresponding
+    // fields under private mapdict names so descriptor writes cannot be
+    // shadowed by user attributes.
+    if !crate::baseobjspace::setdictvalue(self_obj, "__file_public_mode__", w_str_new(binary_mode))
+        || !crate::baseobjspace::setdictvalue(self_obj, "__file_closefd__", w_bool_from(closefd))
+        || !crate::baseobjspace::setdictvalue(self_obj, "__file_closed__", w_bool_from(false))
+    {
+        return Err(crate::PyError::runtime_error(
+            "FileIO instance has no state dictionary",
+        ));
+    }
+    #[cfg(not(unix))]
+    let blksize = 8192;
+    #[cfg(unix)]
+    let blksize = file_get_fd(self_obj)
+        .and_then(|fd| crate::host_seam::ops::fstat(fd).ok())
+        .map(|st| if st.blksize > 1 { st.blksize } else { 8192 })
+        .unwrap_or(8192);
+    if !crate::baseobjspace::setdictvalue(self_obj, "__file_blksize__", w_int_new(blksize as i64)) {
+        return Err(crate::PyError::runtime_error(
+            "FileIO instance has no state dictionary",
+        ));
+    }
     Ok(w_none())
 }
 
+fn file_is_closed(self_obj: PyObjectRef) -> bool {
+    for name in ["__file_closed__", "closed"] {
+        if let Ok(value) = crate::baseobjspace::getattr_str(self_obj, name) {
+            return unsafe { pyre_object::is_bool(value) && pyre_object::w_bool_get_value(value) };
+        }
+    }
+    false
+}
+
+fn file_set_closed(self_obj: PyObjectRef, closed: bool) -> Result<(), crate::PyError> {
+    if crate::baseobjspace::getattr_str(self_obj, "__file_closed__").is_ok() {
+        if crate::baseobjspace::setdictvalue(self_obj, "__file_closed__", w_bool_from(closed)) {
+            return Ok(());
+        }
+    }
+    crate::baseobjspace::setattr_str(self_obj, "closed", w_bool_from(closed)).map(|_| ())
+}
+
+fn file_closefd(self_obj: PyObjectRef) -> bool {
+    for name in ["__file_closefd__", "closefd"] {
+        if let Ok(value) = crate::baseobjspace::getattr_str(self_obj, name) {
+            return unsafe { !pyre_object::is_bool(value) || pyre_object::w_bool_get_value(value) };
+        }
+    }
+    true
+}
+
 fn file_check_closed(self_obj: PyObjectRef) -> Result<(), crate::PyError> {
-    let closed = crate::baseobjspace::getattr_str(self_obj, "closed")
-        .ok()
-        .map(|value| unsafe { pyre_object::is_bool(value) && pyre_object::w_bool_get_value(value) })
-        .unwrap_or(false);
-    if closed {
+    if file_is_closed(self_obj) {
         Err(crate::PyError::value_error("I/O operation on closed file"))
     } else {
         Ok(())
     }
+}
+
+fn file_mode_string(self_obj: PyObjectRef) -> String {
+    crate::baseobjspace::getattr_str(self_obj, "__file_mode__")
+        .ok()
+        .and_then(|mode| unsafe {
+            pyre_object::is_str(mode).then(|| pyre_object::w_str_get_value(mode).to_string())
+        })
+        .unwrap_or_default()
+}
+
+/// PyPy `W_FileIO._check_readable` / `_check_writable`.
+fn file_check_readable(self_obj: PyObjectRef) -> Result<(), crate::PyError> {
+    let mode = file_mode_string(self_obj);
+    if mode.contains('r') || mode.contains('+') {
+        Ok(())
+    } else {
+        // `UnsupportedOperation` derives from ValueError; until exception
+        // instances carry that multiple-inheritance class here, preserve the
+        // observable ValueError branch and PyPy's exact message.
+        Err(crate::PyError::value_error("File not open for reading"))
+    }
+}
+
+fn file_check_writable(self_obj: PyObjectRef) -> Result<(), crate::PyError> {
+    let mode = file_mode_string(self_obj);
+    if mode.contains('w') || mode.contains('a') || mode.contains('x') || mode.contains('+') {
+        Ok(())
+    } else {
+        Err(crate::PyError::value_error("File not open for writing"))
+    }
+}
+
+/// One `space.acquire_writebuf` export held for a FileIO `readinto` call.
+/// PyPy's `with view:` keeps this lock until after `output_slice`/`c_read`.
+pub(crate) struct WritableBuffer {
+    obj: PyObjectRef,
+    held: bool,
+    address: *mut u8,
+    length: usize,
+}
+
+impl WritableBuffer {
+    pub(crate) unsafe fn acquire(obj: PyObjectRef) -> Result<Self, crate::PyError> {
+        let mut acquired = Self {
+            obj,
+            held: unsafe { buffer_export_incref(obj) },
+            address: std::ptr::null_mut(),
+            length: 0,
+        };
+        let data = unsafe { fileio_writebuf(obj) }?;
+        acquired.address = data.as_mut_ptr();
+        acquired.length = data.len();
+        Ok(acquired)
+    }
+
+    pub(crate) unsafe fn as_mut_slice(&mut self) -> &mut [u8] {
+        unsafe { std::slice::from_raw_parts_mut(self.address, self.length) }
+    }
+}
+
+impl Drop for WritableBuffer {
+    fn drop(&mut self) {
+        if self.held {
+            unsafe { buffer_export_decref(self.obj) };
+        }
+    }
+}
+
+/// `space.acquire_writebuf` for FileIO.readinto.  These are pyre's native
+/// writable exporters; a memoryview contributes its exact contiguous window.
+unsafe fn fileio_writebuf(obj: PyObjectRef) -> Result<&'static mut [u8], crate::PyError> {
+    unsafe {
+        if pyre_object::bytearrayobject::is_bytearray(obj) {
+            return Ok(pyre_object::bytearrayobject::w_bytearray_data_mut(obj));
+        }
+        if pyre_object::interp_array::is_array(obj) {
+            return Ok(pyre_object::interp_array::w_array_vec_mut(obj).as_mut_slice());
+        }
+        #[cfg(all(unix, not(feature = "sandbox")))]
+        if let Some(view) = crate::module::mmap::interp_mmap::mmap_buffer_view(obj) {
+            let (address, length, readonly) = view?;
+            if !readonly {
+                return Ok(std::slice::from_raw_parts_mut(address as *mut u8, length));
+            }
+        }
+        if pyre_object::memoryview::is_w_memoryview(obj) {
+            memoryview_check_released(obj)?;
+            if pyre_object::memoryview::w_memoryview_readonly(obj) || !memoryview_contiguity(obj).0
+            {
+                return Err(crate::PyError::type_error(
+                    "readinto() argument must be read-write bytes-like object",
+                ));
+            }
+            let view = pyre_object::memoryview::w_memoryview_view(obj);
+            let Some(full) = view.backing().as_bytes_mut() else {
+                return Err(crate::PyError::type_error(
+                    "readinto() argument must be read-write bytes-like object",
+                ));
+            };
+            let offset = view.offset() as usize;
+            let length = pyre_object::memoryview::w_memoryview_length(obj) as usize;
+            if offset > full.len() || length > full.len() - offset {
+                return Err(crate::PyError::value_error(
+                    "memoryview buffer is no longer valid",
+                ));
+            }
+            return Ok(&mut full[offset..offset + length]);
+        }
+        Err(crate::PyError::type_error(
+            "readinto() argument must be read-write bytes-like object",
+        ))
+    }
+}
+
+/// PyPy `W_FileIO.read_w` / `readall_w` / `readinto_w` / `write_w`.
+fn fileio_method_read(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    let self_obj = args
+        .first()
+        .copied()
+        .ok_or_else(|| crate::PyError::type_error("read() requires self"))?;
+    file_check_closed(self_obj)?;
+    file_check_readable(self_obj)?;
+    file_method_read(args)
+}
+
+fn fileio_method_readall(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    if args.len() != 1 {
+        return Err(crate::PyError::type_error("readall() takes no arguments"));
+    }
+    fileio_method_read(args)
+}
+
+fn fileio_method_readinto(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    if args.len() != 2 {
+        return Err(crate::PyError::type_error(format!(
+            "readinto() takes exactly one argument ({} given)",
+            args.len().saturating_sub(1)
+        )));
+    }
+    let self_obj = args[0];
+    let buffer_obj = args[1];
+    file_check_closed(self_obj)?;
+    file_check_readable(self_obj)?;
+    let mut buffer = unsafe { WritableBuffer::acquire(buffer_obj) }?;
+    let target = unsafe { buffer.as_mut_slice() };
+
+    if let Some(fd) = file_get_fd(self_obj) {
+        #[cfg(all(feature = "host_env", not(target_arch = "wasm32")))]
+        {
+            match fd_read_into(fd, target) {
+                Ok(n) => return Ok(w_int_new(n as i64)),
+                Err(err)
+                    if err.raw_os_error().is_some_and(|errno| {
+                        errno == libc::EAGAIN || errno == libc::EWOULDBLOCK
+                    }) =>
+                {
+                    return Ok(w_none());
+                }
+                Err(err) => return Err(fd_io_err(err)),
+            }
+        }
+        #[cfg(any(not(feature = "host_env"), target_arch = "wasm32"))]
+        {
+            let _ = (fd, target);
+            return Err(crate::PyError::not_implemented(
+                "fd readinto requires host_env feature",
+            ));
+        }
+    }
+
+    let data = file_get_data(self_obj);
+    let pos = file_get_pos(self_obj).min(data.len());
+    let count = target.len().min(data.len() - pos);
+    target[..count].copy_from_slice(&data[pos..pos + count]);
+    file_set_pos(self_obj, pos + count);
+    Ok(w_int_new(count as i64))
+}
+
+fn fileio_method_write(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    if args.len() != 2 {
+        return Err(crate::PyError::type_error(format!(
+            "write() takes exactly one argument ({} given)",
+            args.len().saturating_sub(1)
+        )));
+    }
+    file_check_closed(args[0])?;
+    file_check_writable(args[0])?;
+    // `space.bufferstr_w`, unlike TextIOWrapper.write, rejects str.
+    unsafe { file_write_buffer_bytes(args[1]) }?;
+    file_method_write(args)
+}
+
+fn fileio_method_truncate(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    if args.is_empty() || args.len() > 2 {
+        return Err(crate::PyError::type_error(format!(
+            "truncate() takes at most one argument ({} given)",
+            args.len().saturating_sub(1)
+        )));
+    }
+    let self_obj = args[0];
+    file_check_closed(self_obj)?;
+    file_check_writable(self_obj)?;
+    let size_obj = match args.get(1).copied() {
+        Some(value) if !unsafe { pyre_object::is_none(value) } => value,
+        _ => {
+            let value = crate::baseobjspace::call_method(self_obj, "tell", &[]);
+            if value.is_null() {
+                return Err(crate::call::take_call_error()
+                    .unwrap_or_else(|| crate::PyError::runtime_error("tell failed")));
+            }
+            value
+        }
+    };
+    let index = crate::baseobjspace::space_index(size_obj)?;
+    let size = crate::baseobjspace::int_w(index)?;
+    if size < 0 {
+        #[cfg(unix)]
+        let invalid_argument = libc::EINVAL;
+        #[cfg(not(unix))]
+        let invalid_argument = 22;
+        return Err(crate::PyError::os_error_with_errno(
+            invalid_argument,
+            "Invalid argument",
+        ));
+    }
+
+    if let Some(fd) = file_get_fd(self_obj) {
+        #[cfg(all(unix, not(feature = "sandbox")))]
+        {
+            if unsafe { libc::ftruncate(fd, size as libc::off_t) } < 0 {
+                return Err(fd_io_err(std::io::Error::last_os_error()));
+            }
+            return Ok(index);
+        }
+        #[cfg(any(not(unix), feature = "sandbox"))]
+        {
+            let _ = (fd, size);
+            return Err(crate::PyError::not_implemented(
+                "fd truncate is unavailable on this target",
+            ));
+        }
+    }
+
+    let mut data = file_get_data(self_obj);
+    data.resize(size as usize, 0);
+    crate::baseobjspace::setattr_str(
+        self_obj,
+        "__file_data__",
+        pyre_object::bytesobject::w_bytes_from_bytes(&data),
+    )?;
+    crate::baseobjspace::setattr_str(self_obj, "__file_dirty__", w_bool_from(true))?;
+    Ok(index)
 }
 
 fn file_method_isatty(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
@@ -10397,7 +10869,7 @@ fn file_method_readlines(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyE
 
 /// `_io/interp_fileio.py:write_w` — `space.getarg_w('s*', w_data).as_str()`.
 /// The `s*` converter accepts readable buffer exporters, not only bytes.
-unsafe fn file_write_buffer_bytes(obj: PyObjectRef) -> Result<Vec<u8>, crate::PyError> {
+pub(crate) unsafe fn file_write_buffer_bytes(obj: PyObjectRef) -> Result<Vec<u8>, crate::PyError> {
     unsafe {
         if pyre_object::bytesobject::is_bytes_like(obj) {
             return Ok(pyre_object::bytesobject::bytes_like_data(obj).to_vec());
@@ -10501,21 +10973,13 @@ fn file_method_close(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError
         return Ok(w_none());
     }
     if let Some(fd) = file_get_fd(args[0]) {
-        let already = crate::baseobjspace::getattr_str(args[0], "closed")
-            .ok()
-            .map(|v| unsafe { pyre_object::is_bool(v) && pyre_object::w_bool_get_value(v) })
-            .unwrap_or(false);
+        let already = file_is_closed(args[0]);
         if !already {
             // Mark closed first so the fd is not reusable even if the underlying
             // close reports an error, then surface that error (matching
             // _io.FileIO.close).
-            let _ = crate::baseobjspace::setattr_str(args[0], "closed", w_bool_from(true));
-            let closefd = crate::baseobjspace::getattr_str(args[0], "closefd")
-                .ok()
-                .map(|value| unsafe {
-                    !pyre_object::is_bool(value) || pyre_object::w_bool_get_value(value)
-                })
-                .unwrap_or(true);
+            file_set_closed(args[0], true)?;
+            let closefd = file_closefd(args[0]);
             if !closefd {
                 return Ok(w_none());
             }
@@ -10542,7 +11006,7 @@ fn file_method_close(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError
     // If the file was opened in a writable mode, flush the in-memory
     // buffer to disk.
     file_flush_dirty(args[0])?;
-    crate::baseobjspace::setattr_str(args[0], "closed", w_bool_from(true))?;
+    file_set_closed(args[0], true)?;
     Ok(w_none())
 }
 
@@ -10601,6 +11065,7 @@ fn file_method_flush(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError
     if args.is_empty() {
         return Ok(w_none());
     }
+    file_check_closed(args[0])?;
     if file_get_fd(args[0]).is_some() {
         return Ok(w_none());
     }
@@ -10642,6 +11107,27 @@ fn open_flags_for_mode(_mode: &str) -> i32 {
     0
 }
 
+/// PyPy `W_FileIO.descr_init`: immediately fstat every supplied/opened fd and
+/// reject directory descriptors before publishing the FileIO object.
+#[cfg(unix)]
+fn fileio_validate_fd(
+    fd: i32,
+    w_name: PyObjectRef,
+) -> Result<crate::host_seam::StatBuf, crate::PyError> {
+    let st = crate::host_seam::ops::fstat(fd)
+        .map_err(|error| crate::host_seam::seam_os_err(error, ""))?;
+    #[cfg(unix)]
+    if st.mode & libc::S_IFMT as u32 == libc::S_IFDIR as u32 {
+        return Err(crate::PyError::os_error_syscall(libc::EISDIR, w_name));
+    }
+    Ok(st)
+}
+
+#[cfg(unix)]
+fn fileio_close_owned_fd(fd: i32) {
+    let _ = crate::host_seam::ops::close(fd);
+}
+
 pub fn builtin_open(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     if args.is_empty() {
         return Err(crate::PyError::type_error("open() missing 'file' argument"));
@@ -10667,6 +11153,8 @@ pub fn builtin_open(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError>
     let encoding_obj =
         resolve_pos_or_kw(open_pos.get(3).copied(), open_kwargs, "encoding", "open", 4)?;
     let errors_obj = resolve_pos_or_kw(open_pos.get(4).copied(), open_kwargs, "errors", "open", 5)?;
+    let closefd_obj =
+        resolve_pos_or_kw(open_pos.get(6).copied(), open_kwargs, "closefd", "open", 7)?;
     let opener_obj = resolve_pos_or_kw(open_pos.get(7).copied(), open_kwargs, "opener", "open", 8)?;
     let str_or_none =
         |obj: Option<PyObjectRef>, name: &str| -> Result<Option<String>, crate::PyError> {
@@ -10704,7 +11192,19 @@ pub fn builtin_open(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError>
     // through the descriptor directly (io.open(fd, ...) — used by
     // subprocess pipe handling).
     if unsafe { pyre_object::is_int(path_obj) } {
-        let fd = unsafe { pyre_object::w_int_get_value(path_obj) } as i32;
+        let fd_value = unsafe { pyre_object::w_int_get_value(path_obj) };
+        let fd = i32::try_from(fd_value).map_err(|_| {
+            crate::PyError::overflow_error("Python int too large to convert to C int")
+        })?;
+        if fd < 0 {
+            return Err(crate::PyError::value_error("negative file descriptor"));
+        }
+        #[cfg(unix)]
+        fileio_validate_fd(fd, path_obj)?;
+        let closefd = match closefd_obj {
+            Some(value) => crate::baseobjspace::is_true(value)?,
+            None => true,
+        };
         let binary = mode.contains('b');
         let wrapper = pyre_object::w_instance_new(file_wrapper_type());
         let _ = crate::baseobjspace::setattr_str(wrapper, "__file_fd__", w_int_new(fd as i64));
@@ -10714,8 +11214,15 @@ pub fn builtin_open(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError>
         let _ = crate::baseobjspace::setattr_str(wrapper, "errors", w_str_new(&errors));
         let _ = crate::baseobjspace::setattr_str(wrapper, "name", w_int_new(fd as i64));
         let _ = crate::baseobjspace::setattr_str(wrapper, "mode", w_str_new(&mode));
+        let _ = crate::baseobjspace::setattr_str(wrapper, "closefd", w_bool_from(closefd));
         let _ = crate::baseobjspace::setattr_str(wrapper, "closed", w_bool_from(false));
         return Ok(wrapper);
+    }
+
+    if closefd_obj.map(crate::baseobjspace::is_true).transpose()? == Some(false) {
+        return Err(crate::PyError::value_error(
+            "Cannot use closefd=False with file name",
+        ));
     }
 
     let path = unsafe {
@@ -10760,7 +11267,21 @@ pub fn builtin_open(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError>
                 opener,
                 &[path_obj, w_int_new(flags as i64)],
             )?;
-            let fd = unsafe { pyre_object::w_int_get_value(fd_obj) } as i32;
+            if !unsafe { pyre_object::is_int(fd_obj) } {
+                return Err(crate::PyError::type_error("expected integer from opener"));
+            }
+            let fd_value = unsafe { pyre_object::w_int_get_value(fd_obj) };
+            let fd = i32::try_from(fd_value).map_err(|_| {
+                crate::PyError::overflow_error("Python int too large to convert to C int")
+            })?;
+            if fd < 0 {
+                return Err(crate::PyError::value_error(format!("opener returned {fd}")));
+            }
+            #[cfg(unix)]
+            if let Err(error) = fileio_validate_fd(fd, path_obj) {
+                fileio_close_owned_fd(fd);
+                return Err(error);
+            }
             let wrapper = pyre_object::w_instance_new(file_wrapper_type());
             let _ = crate::baseobjspace::setattr_str(wrapper, "__file_fd__", w_int_new(fd as i64));
             let _ =
@@ -10785,6 +11306,10 @@ pub fn builtin_open(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError>
         let flags = open_flags_for_mode(&mode);
         let fd = crate::host_seam::ops::open(path.as_bytes(), flags, 0o666)
             .map_err(|e| crate::host_seam::seam_os_err(e, &path))?;
+        if let Err(error) = fileio_validate_fd(fd, path_obj) {
+            fileio_close_owned_fd(fd);
+            return Err(error);
+        }
         let wrapper = pyre_object::w_instance_new(file_wrapper_type());
         let _ = crate::baseobjspace::setattr_str(wrapper, "__file_fd__", w_int_new(fd as i64));
         let _ = crate::baseobjspace::setattr_str(wrapper, "__file_binary__", w_bool_from(binary));
@@ -10809,6 +11334,10 @@ pub fn builtin_open(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError>
         let flags = open_flags_for_mode(&mode);
         let fd = crate::host_seam::ops::open(path.as_bytes(), flags, 0o666)
             .map_err(|e| crate::host_seam::seam_os_err(e, &path))?;
+        if let Err(error) = fileio_validate_fd(fd, path_obj) {
+            fileio_close_owned_fd(fd);
+            return Err(error);
+        }
         let wrapper = pyre_object::w_instance_new(file_wrapper_type());
         let _ = crate::baseobjspace::setattr_str(wrapper, "__file_fd__", w_int_new(fd as i64));
         let _ = crate::baseobjspace::setattr_str(wrapper, "__file_binary__", w_bool_from(binary));

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -10793,10 +10793,35 @@ pub fn builtin_open(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError>
         let _ = crate::baseobjspace::setattr_str(wrapper, "errors", w_str_new(&errors));
         let _ = crate::baseobjspace::setattr_str(wrapper, "name", path_obj);
         let _ = crate::baseobjspace::setattr_str(wrapper, "mode", w_str_new(&mode));
+        let _ = crate::baseobjspace::setattr_str(wrapper, "closefd", w_bool_from(true));
         let _ = crate::baseobjspace::setattr_str(wrapper, "closed", w_bool_from(false));
         Ok(wrapper)
     }
-    #[cfg(not(feature = "sandbox"))]
+    #[cfg(all(not(feature = "sandbox"), unix))]
+    {
+        // PyPy: interp_io._open constructs W_FileIO, whose descr_init opens a
+        // pathname immediately through _open_fd.  In particular, `w` creates
+        // and truncates before open() returns, `x` reports EEXIST here, and
+        // `a` owns an O_APPEND descriptor.  Keeping pathname-backed streams in
+        // an in-memory side buffer postpones all three observable effects until
+        // close(), which is not the W_FileIO storage shape.
+        let _ = (reading, writing);
+        let flags = open_flags_for_mode(&mode);
+        let fd = crate::host_seam::ops::open(path.as_bytes(), flags, 0o666)
+            .map_err(|e| crate::host_seam::seam_os_err(e, &path))?;
+        let wrapper = pyre_object::w_instance_new(file_wrapper_type());
+        let _ = crate::baseobjspace::setattr_str(wrapper, "__file_fd__", w_int_new(fd as i64));
+        let _ = crate::baseobjspace::setattr_str(wrapper, "__file_binary__", w_bool_from(binary));
+        let _ = crate::baseobjspace::setattr_str(wrapper, "__file_mode__", w_str_new(&mode));
+        let _ = crate::baseobjspace::setattr_str(wrapper, "encoding", w_str_new(&encoding));
+        let _ = crate::baseobjspace::setattr_str(wrapper, "errors", w_str_new(&errors));
+        let _ = crate::baseobjspace::setattr_str(wrapper, "name", path_obj);
+        let _ = crate::baseobjspace::setattr_str(wrapper, "mode", w_str_new(&mode));
+        let _ = crate::baseobjspace::setattr_str(wrapper, "closefd", w_bool_from(true));
+        let _ = crate::baseobjspace::setattr_str(wrapper, "closed", w_bool_from(false));
+        Ok(wrapper)
+    }
+    #[cfg(all(not(feature = "sandbox"), not(unix)))]
     {
         let data: Vec<u8> = if reading && !mode.contains('w') && !mode.contains('x') {
             #[cfg(any(not(feature = "host_env"), target_arch = "wasm32"))]
@@ -12024,6 +12049,31 @@ mod tests {
             err.message
                 .starts_with("invalid literal for int() with base 10:")
         );
+    }
+
+    /// PyPy `interp_io._open` constructs `W_FileIO`, and
+    /// `W_FileIO.descr_init` calls `_open_fd` before returning.  A writable
+    /// pathname must therefore be created/truncated while the stream is still
+    /// open, rather than when our wrapper is later flushed or closed.
+    #[cfg(unix)]
+    #[test]
+    fn open_write_path_opens_and_truncates_immediately() {
+        crate::typedef::init_typeobjects();
+        static NEXT_PATH: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
+        let serial = NEXT_PATH.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        let path =
+            std::env::temp_dir().join(format!("pyre-open-write-{}-{serial}-æ", std::process::id()));
+        std::fs::write(&path, b"old contents").unwrap();
+
+        let path_text = path.to_str().unwrap();
+        let file = builtin_open(&[w_str_new(path_text), w_str_new("w")]).unwrap();
+        assert_eq!(std::fs::metadata(&path).unwrap().len(), 0);
+        assert!(!unsafe {
+            pyre_object::w_bool_get_value(crate::baseobjspace::getattr_str(file, "closed").unwrap())
+        });
+
+        file_method_close(&[file]).unwrap();
+        std::fs::remove_file(path).unwrap();
     }
 
     #[test]

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -293,6 +293,10 @@ unsafe fn w_memoryview_new_mmap(
         };
         let view_ptr = pyre_object::memoryview::bufferview_alloc(view);
         pyre_object::memoryview::w_memoryview_set_view(mv, view_ptr);
+        // Unlike the GC-owned exporters, the mapping is foreign memory that
+        // `close`/`resize` hand straight back to the kernel, so the window
+        // must keep it from being unmapped while this view can still read it.
+        crate::module::mmap::interp_mmap::mmap_exports_incref(r_obj);
         mv
     }
 }

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -335,7 +335,7 @@ unsafe fn w_memoryview_new_plain(
 
 /// Build the `W_MMap.readbuf_w`/`writebuf_w` view: one contiguous external
 /// byte window whose owner remains the mmap object.
-#[cfg(unix)]
+#[cfg(all(unix, not(feature = "sandbox")))]
 unsafe fn w_memoryview_new_mmap(
     w_obj: PyObjectRef,
     address: usize,
@@ -7225,6 +7225,24 @@ pub fn builtin_set_add_items(
     set: PyObjectRef,
     items: &[PyObjectRef],
 ) -> Result<(), crate::PyError> {
+    builtin_set_add_items_impl(set, items, true)
+}
+
+/// Intersection materializes an operand through PyPy's internal `_newobj`
+/// path.  Unlike the public set constructor/mutators, CPython 3.14 and PyPy
+/// let the original `unhashable type` escape from this path unchanged.
+pub(crate) fn builtin_set_add_items_intersection(
+    set: PyObjectRef,
+    items: &[PyObjectRef],
+) -> Result<(), crate::PyError> {
+    builtin_set_add_items_impl(set, items, false)
+}
+
+fn builtin_set_add_items_impl(
+    set: PyObjectRef,
+    items: &[PyObjectRef],
+    wrap_hash_error: bool,
+) -> Result<(), crate::PyError> {
     unsafe {
         // `try_hash_value` may run a user `__hash__` that allocates and
         // triggers a moving minor collection; `set` and every not-yet-added
@@ -7241,10 +7259,14 @@ pub fn builtin_set_add_items(
         for i in 0..item_len {
             let item = pyre_object::gc_roots::shadow_stack_get(item_base + i);
             let hash = try_hash_value(item).map_err(|err| {
-                crate::baseobjspace::wrap_set_element_hash_error(
-                    pyre_object::gc_roots::shadow_stack_get(item_base + i),
-                    err,
-                )
+                if wrap_hash_error {
+                    crate::baseobjspace::wrap_set_element_hash_error(
+                        pyre_object::gc_roots::shadow_stack_get(item_base + i),
+                        err,
+                    )
+                } else {
+                    err
+                }
             })?;
             let set = pyre_object::gc_roots::shadow_stack_get(sp);
             let item = pyre_object::gc_roots::shadow_stack_get(item_base + i);

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -67,6 +67,18 @@ pub(crate) unsafe fn backing_exports_incref(buffer: &pyre_object::buffer::Buffer
                 pyre_object::bytearrayobject::w_bytearray_exports_incref(*w_obj)
             }
             Buffer::Array { w_obj } => pyre_object::interp_array::w_array_exports_incref(*w_obj),
+            Buffer::External { w_obj, .. } => {
+                // The only counted external exporter is `mmap` (ctypes'
+                // `memoryview_at` stores `None` and keeps no count), so a
+                // derived mmap view takes its own count here — otherwise
+                // releasing the view it came from would let `close`/`resize`
+                // unmap while this one still reads the mapping.
+                let _ = w_obj;
+                #[cfg(all(unix, not(feature = "sandbox")))]
+                if crate::module::mmap::interp_mmap::is_mmap(*w_obj) {
+                    crate::module::mmap::interp_mmap::mmap_exports_incref(*w_obj);
+                }
+            }
             _ => {}
         }
     }
@@ -1473,6 +1485,22 @@ fn memoryview_repr(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> 
     Ok(w_str_new(&format!("<{label} at {mv:?}>")))
 }
 
+/// Drop an mmap-backed view's export directly, bypassing any Python-callable
+/// release.  Returns `true` when it handled an mmap backing.
+#[cfg(all(unix, not(feature = "sandbox")))]
+unsafe fn release_external_backing(backing: PyObjectRef) -> bool {
+    if crate::module::mmap::interp_mmap::is_mmap(backing) {
+        unsafe { crate::module::mmap::interp_mmap::mmap_exports_decref(backing) };
+        return true;
+    }
+    false
+}
+
+#[cfg(not(all(unix, not(feature = "sandbox"))))]
+unsafe fn release_external_backing(_backing: PyObjectRef) -> bool {
+    false
+}
+
 /// `memoryview.release` — drop the view; subsequent access raises ValueError.
 /// Idempotent (a second `release` on an already-released view is a no-op),
 /// matching `descr_release`.
@@ -1504,9 +1532,15 @@ pub(crate) fn memoryview_release(args: &[PyObjectRef]) -> Result<PyObjectRef, cr
                 // Clear the view before invoking the exporter hook so a
                 // re-entrant release is a no-op.
                 pyre_object::memoryview::w_memoryview_set_released(mv);
-                if let Some(release_fn) = crate::baseobjspace::lookup(backing, "__release_buffer__")
-                {
-                    crate::call::call_function_impl_result(release_fn, &[backing, mv])?;
+                // An `mmap` mapping keeps its count internally — it exposes no
+                // Python-callable release, so the drop cannot be forged from
+                // user code.  Every other exporter runs `__release_buffer__`.
+                if !release_external_backing(backing) {
+                    if let Some(release_fn) =
+                        crate::baseobjspace::lookup(backing, "__release_buffer__")
+                    {
+                        crate::call::call_function_impl_result(release_fn, &[backing, mv])?;
+                    }
                 }
             } else {
                 pyre_object::memoryview::w_memoryview_set_released(mv);

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -1476,7 +1476,7 @@ fn memoryview_repr(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> 
 /// `memoryview.release` — drop the view; subsequent access raises ValueError.
 /// Idempotent (a second `release` on an already-released view is a no-op),
 /// matching `descr_release`.
-fn memoryview_release(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+pub(crate) fn memoryview_release(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     let mv = args.first().copied().unwrap_or(w_none());
     unsafe {
         if !pyre_object::memoryview::w_memoryview_released(mv) {

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -3732,10 +3732,37 @@ fn type_descr_new_with_metaclass(
         let name_obj = args[0];
         let bases = args[1];
         let w_namespace_dict = args[2];
+        // typeobject.py:_check_new_args — validate the three public
+        // arguments before attempting to copy or normalise any of them.
+        if !unsafe { crate::baseobjspace::isinstance_str_w(name_obj) } {
+            return Err(crate::PyError::type_error(format!(
+                "type() argument 1 must be str, not {}",
+                unsafe { pyre_object::type_name_of(name_obj) }
+            )));
+        }
+        if !unsafe { is_tuple(bases) } {
+            return Err(crate::PyError::type_error(format!(
+                "type() argument 2 must be tuple, not {}",
+                unsafe { pyre_object::type_name_of(bases) }
+            )));
+        }
+        let w_dict_type = crate::typedef::gettypeobject(&pyre_object::pyobject::DICT_TYPE);
+        if !unsafe { crate::baseobjspace::isinstance_w(w_namespace_dict, w_dict_type) } {
+            return Err(crate::PyError::type_error(format!(
+                "type() argument 3 must be dict, not {}",
+                unsafe { pyre_object::type_name_of(w_namespace_dict) }
+            )));
+        }
+        let w_ns_backing = unsafe { crate::type_methods::resolve_dict_backing(w_namespace_dict) };
         // typeobject.py:953 `_check_surrogate(space, name)` — reject a lone
         // surrogate in the name before it is read as UTF-8 below.
-        if unsafe { pyre_object::is_str(name_obj) } {
-            check_surrogate(name_obj)?;
+        check_surrogate(name_obj)?;
+        for cp in unsafe { pyre_object::w_str_get_wtf8(name_obj) }.code_points() {
+            if cp.to_u32() == 0 {
+                return Err(crate::PyError::value_error(
+                    "type name must not contain null characters",
+                ));
+            }
         }
         // typeobject.py `type.__new__` — `isinstance_w(w_bases, w_tuple)` and
         // `isinstance_w(w_dict, w_dict)`: bases must be a tuple and the
@@ -3808,7 +3835,6 @@ fn type_descr_new_with_metaclass(
         // the dict backing so e.g. an `enum._EnumDict` class body is
         // walked instead of dropped.
         let w_namespace_dict = pyre_object::gc_roots::shadow_stack_get(namespace_root);
-        let w_ns_backing = unsafe { crate::type_methods::resolve_dict_backing(w_namespace_dict) };
         if !w_ns_backing.is_null() {
             let backing_root = pyre_object::gc_roots::shadow_stack_len();
             pyre_object::gc_roots::pin_root(w_ns_backing);
@@ -3853,6 +3879,54 @@ fn type_descr_new_with_metaclass(
                 let class_ns = pyre_object::gc_roots::shadow_stack_get(class_ns_root);
                 unsafe { pyre_object::w_dict_setitem_wtf8_no_proxy(class_ns, &key, value) };
             }
+        }
+        // typeobject.py:ensure_common_attributes / ensure_module_attr.  Direct
+        // three-argument type() calls do not pass through __build_class__, so
+        // fill __module__ from the live caller frame when the namespace did
+        // not supply it.
+        let class_ns = pyre_object::gc_roots::shadow_stack_get(class_ns_root);
+        if unsafe { pyre_object::w_dict_getitem_str(class_ns, "__module__") }.is_none() {
+            let frame = crate::eval::CURRENT_FRAME.with(|current| current.get());
+            if !frame.is_null() {
+                let globals = unsafe { (*frame).get_w_globals() };
+                if !globals.is_null() {
+                    if let Some(module) = crate::baseobjspace::finditem_str(globals, "__name__")? {
+                        let class_ns = pyre_object::gc_roots::shadow_stack_get(class_ns_root);
+                        unsafe {
+                            pyre_object::w_dict_setitem_str_no_proxy(class_ns, "__module__", module)
+                        };
+                    }
+                }
+            }
+        }
+        // CPython 3.14 rejects lone surrogates in the initial type doc while
+        // retaining the historical freedom to assign arbitrary objects later.
+        let class_ns = pyre_object::gc_roots::shadow_stack_get(class_ns_root);
+        if let Some(doc) = unsafe { pyre_object::w_dict_getitem_str(class_ns, "__doc__") } {
+            if unsafe { pyre_object::is_str(doc) } {
+                check_surrogate(doc)?;
+            }
+        }
+        // W_TypeObject.__init__: pop and validate __qualname__ before slot
+        // construction.  Pyre keeps it in the canonical namespace because it
+        // has no separate qualname field, but preserves the same validation.
+        let class_ns = pyre_object::gc_roots::shadow_stack_get(class_ns_root);
+        if let Some(qualname) = unsafe { pyre_object::w_dict_getitem_str(class_ns, "__qualname__") }
+        {
+            if !unsafe { crate::baseobjspace::isinstance_str_w(qualname) } {
+                return Err(crate::PyError::type_error(format!(
+                    "type __qualname__ must be a str, not {}",
+                    unsafe { pyre_object::type_name_of(qualname) }
+                )));
+            }
+        }
+        // typeobject.py:ensure_common_attributes always installs __doc__;
+        // user heap types use None when no class-body docstring was supplied.
+        let class_ns = pyre_object::gc_roots::shadow_stack_get(class_ns_root);
+        if unsafe { pyre_object::w_dict_getitem_str(class_ns, "__doc__") }.is_none() {
+            unsafe {
+                pyre_object::w_dict_setitem_str_no_proxy(class_ns, "__doc__", pyre_object::w_none())
+            };
         }
         let class_ns = pyre_object::gc_roots::shadow_stack_get(class_ns_root);
         type_new_set_hash_if_eq(class_ns);

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -2441,7 +2441,11 @@ pub fn install_default_builtins(ns: PyObjectRef) {
     crate::module_ns_store(
         ns,
         "StopAsyncIteration",
-        make_exc_type("StopAsyncIteration", exc_exception_new, exception),
+        make_exc_type(
+            "StopAsyncIteration",
+            exc_stop_async_iteration_new,
+            exception,
+        ),
     );
     crate::module_ns_store(
         ns,
@@ -4263,6 +4267,10 @@ exc_constructor!(
     pyre_object::interp_exceptions::ExcKind::StopIteration
 );
 exc_constructor!(
+    exc_stop_async_iteration,
+    pyre_object::interp_exceptions::ExcKind::StopAsyncIteration
+);
+exc_constructor!(
     exc_overflow_error,
     pyre_object::interp_exceptions::ExcKind::OverflowError
 );
@@ -5272,6 +5280,7 @@ exc_new_wrapper!(exc_attribute_error_new, exc_attribute_error);
 exc_new_wrapper!(exc_name_error_new, exc_name_error);
 exc_new_wrapper!(exc_runtime_error_new, exc_runtime_error);
 exc_new_wrapper!(exc_stop_iteration_new, exc_stop_iteration);
+exc_new_wrapper!(exc_stop_async_iteration_new, exc_stop_async_iteration);
 exc_new_wrapper!(exc_overflow_error_new, exc_overflow_error);
 exc_new_wrapper!(exc_import_error_new, exc_import_error);
 exc_new_wrapper!(exc_not_implemented_error_new, exc_not_implemented_error);

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -63,9 +63,66 @@ pub(crate) unsafe fn backing_exports_incref(buffer: &pyre_object::buffer::Buffer
     };
     unsafe {
         match root {
-            Buffer::Byte { w_obj } => pyre_object::bytearrayobject::w_bytearray_exports_incref(*w_obj),
+            Buffer::Byte { w_obj } => {
+                pyre_object::bytearrayobject::w_bytearray_exports_incref(*w_obj)
+            }
             Buffer::Array { w_obj } => pyre_object::interp_array::w_array_exports_incref(*w_obj),
             _ => {}
+        }
+    }
+}
+
+/// Acquire one live buffer export directly from a Python exporter.
+///
+/// This is the object-level half of `space.acquire_py_buffer`: callers keep
+/// the exporter itself in a traced field and this function accounts for the
+/// matching `bf_releasebuffer` obligation.  Immutable `bytes` needs no
+/// release and returns `false`; the mutable/runtime-owned exporters return
+/// `true` and must later be paired with [`buffer_export_decref`].
+///
+/// PyPy keeps this state on the acquired `Py_buffer`/`Buffer` object.  Until
+/// pyre's generic `Py_buffer` carrier is shared by every consumer, keeping the
+/// boolean beside the owning object field preserves the same single-owner
+/// shape without an address-keyed side table.
+pub(crate) unsafe fn buffer_export_incref(obj: PyObjectRef) -> bool {
+    unsafe {
+        if pyre_object::bytearrayobject::is_bytearray(obj) {
+            pyre_object::bytearrayobject::w_bytearray_exports_incref(obj);
+            return true;
+        }
+        if pyre_object::interp_array::is_array(obj) {
+            pyre_object::interp_array::w_array_exports_incref(obj);
+            return true;
+        }
+        if pyre_object::memoryview::is_w_memoryview(obj) {
+            pyre_object::memoryview::w_memoryview_exports_incref(obj);
+            return true;
+        }
+        #[cfg(all(unix, not(feature = "sandbox")))]
+        if crate::module::mmap::interp_mmap::is_mmap(obj) {
+            crate::module::mmap::interp_mmap::mmap_exports_incref(obj);
+            return true;
+        }
+    }
+    false
+}
+
+/// Release one export acquired by [`buffer_export_incref`].
+///
+/// # Safety
+/// `obj` must still be the exporter paired with a successful (`true`)
+/// acquisition, and the pair must be released exactly once.
+pub(crate) unsafe fn buffer_export_decref(obj: PyObjectRef) {
+    unsafe {
+        if pyre_object::bytearrayobject::is_bytearray(obj) {
+            pyre_object::bytearrayobject::w_bytearray_exports_decref(obj);
+        } else if pyre_object::interp_array::is_array(obj) {
+            pyre_object::interp_array::w_array_exports_decref(obj);
+        } else if pyre_object::memoryview::is_w_memoryview(obj) {
+            pyre_object::memoryview::w_memoryview_exports_decref(obj);
+        } else {
+            #[cfg(all(unix, not(feature = "sandbox")))]
+            crate::module::mmap::interp_mmap::mmap_exports_decref(obj);
         }
     }
 }

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -51,6 +51,25 @@ unsafe fn backing_is_bytearray(obj: PyObjectRef) -> bool {
     }
 }
 
+/// Take one `_exports` count on whichever resizable exporter ultimately backs
+/// `buffer`, so the storage cannot be reallocated while a view over it is
+/// alive.  `Buffer::sub` never nests, so one parent peel is sufficient.  The
+/// matching release runs through the backing's `__release_buffer__`.
+pub(crate) unsafe fn backing_exports_incref(buffer: &pyre_object::buffer::Buffer) {
+    use pyre_object::buffer::Buffer;
+    let root = match buffer {
+        Buffer::Sub { parent, .. } => parent.as_ref(),
+        other => other,
+    };
+    unsafe {
+        match root {
+            Buffer::Byte { w_obj } => pyre_object::bytearrayobject::w_bytearray_exports_incref(*w_obj),
+            Buffer::Array { w_obj } => pyre_object::interp_array::w_array_exports_incref(*w_obj),
+            _ => {}
+        }
+    }
+}
+
 /// `_check_exports` — reject a size-changing mutation of a bytearray while a
 /// buffer export (a live memoryview) is outstanding.
 pub(crate) unsafe fn bytearray_check_exports(obj: PyObjectRef) -> Result<(), crate::PyError> {
@@ -98,13 +117,16 @@ unsafe fn w_memoryview_new_derived(
         let _roots = pyre_object::gc_roots::push_roots();
         let sp = pyre_object::gc_roots::shadow_stack_len();
         pyre_object::gc_roots::pin_root(mv_src);
-        // A derived view (copy / slice / cast) shares — never owns — the
-        // backing's export.
-        let mv = pyre_object::memoryview::w_memoryview_alloc_header(false, false);
+        // A derived view stays alive independently of the view it came from,
+        // so it takes its own `_exports` count on the backing rather than
+        // relying on the source's: releasing the source must not leave this
+        // view pointing at storage the exporter is then free to reallocate.
+        let mv = pyre_object::memoryview::w_memoryview_alloc_header(false, true);
         let r_src = pyre_object::gc_roots::shadow_stack_get(sp);
         let view = derive(pyre_object::memoryview::w_memoryview_view(r_src));
         let view_ptr = pyre_object::memoryview::bufferview_alloc(view);
         pyre_object::memoryview::w_memoryview_set_view(mv, view_ptr);
+        backing_exports_incref(pyre_object::memoryview::w_memoryview_view(mv).backing());
         mv
     }
 }
@@ -120,7 +142,7 @@ unsafe fn w_memoryview_cast_1d(mv_src: PyObjectRef, fmt: &str, itemsize: i64) ->
         let sp = pyre_object::gc_roots::shadow_stack_len();
         pyre_object::gc_roots::pin_root(mv_src);
         pyre_object::gc_roots::pin_root(w_str_new(fmt));
-        let mv = pyre_object::memoryview::w_memoryview_alloc_header(false, false);
+        let mv = pyre_object::memoryview::w_memoryview_alloc_header(false, true);
         let r_src = pyre_object::gc_roots::shadow_stack_get(sp);
         let r_fmt = pyre_object::gc_roots::shadow_stack_get(sp + 1);
         let src_view = pyre_object::memoryview::w_memoryview_view(r_src);
@@ -132,6 +154,7 @@ unsafe fn w_memoryview_cast_1d(mv_src: PyObjectRef, fmt: &str, itemsize: i64) ->
         };
         let view_ptr = pyre_object::memoryview::bufferview_alloc(view);
         pyre_object::memoryview::w_memoryview_set_view(mv, view_ptr);
+        backing_exports_incref(pyre_object::memoryview::w_memoryview_view(mv).backing());
         mv
     }
 }
@@ -157,7 +180,7 @@ unsafe fn w_memoryview_cast_nd(
         pyre_object::gc_roots::pin_root(w_str_new(fmt));
         pyre_object::gc_roots::pin_root(memoryview_wrap_dims(shape));
         pyre_object::gc_roots::pin_root(memoryview_wrap_dims(strides));
-        let mv = pyre_object::memoryview::w_memoryview_alloc_header(false, false);
+        let mv = pyre_object::memoryview::w_memoryview_alloc_header(false, true);
         let r_src = pyre_object::gc_roots::shadow_stack_get(sp);
         let r_fmt = pyre_object::gc_roots::shadow_stack_get(sp + 1);
         let r_shape = pyre_object::gc_roots::shadow_stack_get(sp + 2);
@@ -177,6 +200,7 @@ unsafe fn w_memoryview_cast_nd(
         };
         let view_ptr = pyre_object::memoryview::bufferview_alloc(view);
         pyre_object::memoryview::w_memoryview_set_view(mv, view_ptr);
+        backing_exports_incref(pyre_object::memoryview::w_memoryview_view(mv).backing());
         mv
     }
 }
@@ -664,25 +688,7 @@ unsafe fn memoryview_slice_view(
         // The root `Buffer` tag was fixed by `buffer_w`; follow it directly
         // instead of repeating an objspace isinstance lookup in this hot/JIT
         // path.  `Buffer::sub` never nests, so one parent peel is sufficient.
-        let backing = snapshot.backing();
-        match backing {
-            pyre_object::buffer::Buffer::Byte { w_obj } => {
-                pyre_object::bytearrayobject::w_bytearray_exports_incref(*w_obj)
-            }
-            pyre_object::buffer::Buffer::Array { w_obj } => {
-                pyre_object::interp_array::w_array_exports_incref(*w_obj)
-            }
-            pyre_object::buffer::Buffer::Sub { parent, .. } => match parent.as_ref() {
-                pyre_object::buffer::Buffer::Byte { w_obj } => {
-                    pyre_object::bytearrayobject::w_bytearray_exports_incref(*w_obj)
-                }
-                pyre_object::buffer::Buffer::Array { w_obj } => {
-                    pyre_object::interp_array::w_array_exports_incref(*w_obj)
-                }
-                _ => {}
-            },
-            _ => {}
-        }
+        backing_exports_incref(snapshot.backing());
         w_memoryview_set_view(sliced, bufferview_alloc(snapshot));
         pyre_object::gc_roots::pin_root(sliced);
 

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -7017,6 +7017,11 @@ pub(crate) fn builtin_list_ctor(args: &[PyObjectRef]) -> Result<PyObjectRef, cra
             return Ok(w_list_new(items));
         }
     }
+    // listobject.py:1049-1053 `_extend_from_iterable` asks for the source's
+    // length hint before obtaining/consuming its iterator.  The hint is only a
+    // preallocation aid, but RuntimeError and other non-TypeError failures
+    // from `__len__` / `__length_hint__` are observable and must propagate.
+    let _ = crate::baseobjspace::length_hint(obj, 0)?;
     // Consume iterator — PyPy: listobject.py W_ListObject(iterable)
     Ok(w_list_new(collect_iterable(obj)?))
 }

--- a/pyre/pyre-interpreter/src/call.rs
+++ b/pyre/pyre-interpreter/src/call.rs
@@ -10,8 +10,20 @@ use rustpython_wtf8::Wtf8Buf;
 
 use crate::{
     PyError, PyResult, builtin_code_get, dispatch_callable, function_get_closure,
-    function_get_globals_obj,
+    function_get_globals_obj, function_get_name, function_get_qualname,
 };
+
+/// `function.py:131/214/231 new_frame.run(self.name, self.qualname)`.
+/// Generator creation must capture the function's writable metadata rather
+/// than lazily rereading the immutable code object's names.
+pub(crate) fn frame_into_generator_for_function(
+    frame: crate::pyframe::FrameBox,
+    function: PyObjectRef,
+) -> PyResult {
+    let name = unsafe { function_get_name(function) }.to_string();
+    let qualname = unsafe { function_get_qualname(function) };
+    frame.into_generator_named(Some(&name), Some(&qualname))
+}
 
 struct FrameLocalsRoot {
     slot: *mut *mut u8,
@@ -577,7 +589,7 @@ fn call_user_function_with_eval(
                 closure,
                 crate::pyframe::FrameLocalsArrayAllocation::OldGenGc,
             )?);
-        return gen_frame.into_generator();
+        return frame_into_generator_for_function(gen_frame, callable);
     }
 
     let mut func_frame =
@@ -625,7 +637,7 @@ pub fn call_user_function_resolved(
                 closure,
                 crate::pyframe::FrameLocalsArrayAllocation::OldGenGc,
             )?);
-        return gen_frame.into_generator();
+        return frame_into_generator_for_function(gen_frame, callable);
     }
 
     let eval_fn = get_eval_fn();
@@ -1262,7 +1274,7 @@ pub fn call_user_function_plain_with_ctx(
                 closure,
                 crate::pyframe::FrameLocalsArrayAllocation::OldGenGc,
             )?);
-        return gen_frame.into_generator();
+        return frame_into_generator_for_function(gen_frame, callable);
     }
 
     let mut func_frame =
@@ -2199,7 +2211,7 @@ pub fn call_with_kwargs(
             // `func(*args, **kwds)` from `contextlib.contextmanager`) would
             // execute eagerly and surface the first yielded value.
             if crate::pyframe::code_flags_make_generator(code.flags) {
-                return func_frame.into_generator();
+                return frame_into_generator_for_function(func_frame, callable);
             }
             let plain_mode = FORCE_PLAIN_EVAL.with(|c| c.get() > 0);
             let eval_fn = if plain_mode {
@@ -2738,7 +2750,7 @@ fn call_user_function_with_args(func: PyObjectRef, args: &[PyObjectRef]) -> PyOb
                 }
             },
         );
-        return match gen_frame.into_generator() {
+        return match frame_into_generator_for_function(gen_frame, func) {
             Ok(v) => v,
             Err(e) => {
                 set_call_error(e);
@@ -2800,7 +2812,7 @@ fn call_user_function_resolved_frameless(func: PyObjectRef, args: &[PyObjectRef]
         ));
     frame.fix_array_ptrs();
     if crate::pyframe::code_flags_make_generator(code_ref.flags) {
-        return match frame.into_generator() {
+        return match frame_into_generator_for_function(frame, func) {
             Ok(v) => v,
             Err(e) => {
                 set_call_error(e);

--- a/pyre/pyre-interpreter/src/call.rs
+++ b/pyre/pyre-interpreter/src/call.rs
@@ -4242,6 +4242,22 @@ pub unsafe fn create_all_slots(
             // typeobject.py:1178: string_sort(newslotnames)
             newslotnames.sort();
 
+            // CPython 3.14 rejects additional instance slots on variable-size
+            // builtin layouts (the Py_TPFLAGS_ITEMS_AT_END families).
+            if !newslotnames.is_empty() && !base_layout.is_null() {
+                let typedef = (*base_layout).typedef;
+                if std::ptr::eq(typedef, &pyre_object::INT_TYPE)
+                    || std::ptr::eq(typedef, &pyre_object::STR_TYPE)
+                    || std::ptr::eq(typedef, &pyre_object::TUPLE_TYPE)
+                    || std::ptr::eq(typedef, &pyre_object::bytesobject::BYTES_TYPE)
+                {
+                    return Err(crate::PyError::type_error(format!(
+                        "nonempty __slots__ not supported for subtype of '{}'",
+                        pyre_object::w_type_get_name(w_bestbase)
+                    )));
+                }
+            }
+
             // typeobject.py:1183-1189: create_slot loop
             let type_name = pyre_object::w_type_get_name(w_type);
             let mut slot_index = base_nslots;

--- a/pyre/pyre-interpreter/src/error.rs
+++ b/pyre/pyre-interpreter/src/error.rs
@@ -426,6 +426,7 @@ pub enum PyErrorKind {
     AttributeError,
     RuntimeError,
     StopIteration,
+    StopAsyncIteration,
     OverflowError,
     ArithmeticError,
     ImportError,
@@ -994,6 +995,10 @@ impl PyError {
         Self::new(PyErrorKind::StopIteration, String::new())
     }
 
+    pub fn stop_async_iteration() -> Self {
+        Self::new(PyErrorKind::StopAsyncIteration, String::new())
+    }
+
     /// Convert to a W_BaseException for pushing onto the value stack.
     /// Reuses the cached object from from_exc_object() if available, otherwise
     /// materialises it once and memoises it into `self.exc_object` so repeat
@@ -1256,6 +1261,7 @@ impl PyError {
             PyErrorKind::AttributeError => ExcKind::AttributeError,
             PyErrorKind::RuntimeError => ExcKind::RuntimeError,
             PyErrorKind::StopIteration => ExcKind::StopIteration,
+            PyErrorKind::StopAsyncIteration => ExcKind::StopAsyncIteration,
             PyErrorKind::OverflowError => ExcKind::OverflowError,
             PyErrorKind::ArithmeticError => ExcKind::ArithmeticError,
             PyErrorKind::ImportError => ExcKind::ImportError,
@@ -1326,6 +1332,7 @@ impl PyError {
             ExcKind::AttributeError => PyErrorKind::AttributeError,
             ExcKind::RuntimeError => PyErrorKind::RuntimeError,
             ExcKind::StopIteration => PyErrorKind::StopIteration,
+            ExcKind::StopAsyncIteration => PyErrorKind::StopAsyncIteration,
             ExcKind::OverflowError => PyErrorKind::OverflowError,
             ExcKind::ArithmeticError => PyErrorKind::ArithmeticError,
             ExcKind::ImportError => PyErrorKind::ImportError,

--- a/pyre/pyre-interpreter/src/error.rs
+++ b/pyre/pyre-interpreter/src/error.rs
@@ -97,7 +97,7 @@ impl OperationError {
                         return Err(crate::call::take_call_error()
                             .unwrap_or_else(|| PyError::type_error("constructor failed")));
                     }
-                    w_type = self._exception_getclass(w_value)?;
+                    w_type = self._exception_getclass_from_call(w_type, w_value)?;
                 } else {
                     // error.py:212 w_valuetype = space.exception_getclass(w_value)
                     let w_valuetype = crate::baseobjspace::exception_getclass(w_value);
@@ -124,7 +124,7 @@ impl OperationError {
                             return Err(crate::call::take_call_error()
                                 .unwrap_or_else(|| PyError::type_error("constructor failed")));
                         }
-                        w_type = self._exception_getclass(w_value)?;
+                        w_type = self._exception_getclass_from_call(w_type, w_value)?;
                     }
                 }
                 // error.py:225-236 traceback attach — fast path writes
@@ -171,6 +171,32 @@ impl OperationError {
             return Err(PyError::type_error(
                 "exceptions must derive from BaseException",
             ));
+        }
+        Ok(w_type)
+    }
+
+    /// Python 3.14 exception normalization diagnostic for a class call whose
+    /// `__new__` returned a non-exception.  This is the class-construction
+    /// counterpart of `_exception_getclass`; direct `raise non_exception`
+    /// retains the ordinary "exceptions must derive" wording.
+    fn _exception_getclass_from_call(
+        &self,
+        w_constructor: PyObjectRef,
+        w_inst: PyObjectRef,
+    ) -> Result<PyObjectRef, PyError> {
+        let w_type = crate::baseobjspace::exception_getclass(w_inst);
+        if w_type.is_null() || !unsafe { crate::baseobjspace::exception_is_valid_class_w(w_type) } {
+            let constructor = unsafe { crate::display::py_repr(w_constructor) }
+                .unwrap_or_else(|_| "<exception class>".to_string());
+            let returned_type = if w_type.is_null() {
+                "<unknown type>".to_string()
+            } else {
+                unsafe { crate::display::py_repr(w_type) }
+                    .unwrap_or_else(|_| "<unknown type>".to_string())
+            };
+            return Err(PyError::type_error(format!(
+                "calling {constructor} should have returned an instance of BaseException, not {returned_type}"
+            )));
         }
         Ok(w_type)
     }

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -626,6 +626,14 @@ pub unsafe fn walk_pyframe_roots_area(
             let current_gen_slot =
                 unsafe { &mut (*ec).current_gen_or_coroutine as *mut PyObjectRef };
             visitor(unsafe { &mut *(current_gen_slot as *mut majit_ir::GcRef) });
+            for hook in unsafe {
+                [
+                    &mut (*ec).w_asyncgen_firstiter_fn as *mut PyObjectRef,
+                    &mut (*ec).w_asyncgen_finalizer_fn as *mut PyObjectRef,
+                ]
+            } {
+                visitor(unsafe { &mut *(hook as *mut majit_ir::GcRef) });
+            }
             // pending_with_disabled_del is a GC-visible list upstream
             // (executioncontext.py:652); pyre's Vec lives in the boxed
             // UserDelAction, so its element slots are visited here.
@@ -3873,6 +3881,10 @@ impl OpcodeStepExecutor for PyFrame {
         crate::opcode_ops::list_to_tuple_value(val)
     }
 
+    fn async_gen_wrap(&mut self, val: PyObjectRef) -> Result<PyObjectRef, PyError> {
+        Ok(pyre_object::generator::w_async_gen_value_wrapper_new(val))
+    }
+
     // ── print_expr ──
     // PRINT_EXPR → sys.displayhook(value). Routing through the live hook lets
     // a rebound displayhook (doctest, IDLE) and a redirected sys.stdout take
@@ -4050,6 +4062,64 @@ impl OpcodeStepExecutor for PyFrame {
         // `running` flag.
         self.push(w_iter);
         Ok(())
+    }
+
+    fn get_aiter(&mut self) -> Result<(), PyError> {
+        let obj = self.pop();
+        let method =
+            unsafe { crate::baseobjspace::lookup_special(obj, "__aiter__")? }.ok_or_else(|| {
+                crate::PyError::type_error(format!(
+                    "'async for' requires an object with __aiter__ method, got {}",
+                    crate::type_methods::arg_type_name(obj)
+                ))
+            })?;
+        let iter = crate::call::call_function_impl_result(method, &[])?;
+        if unsafe { crate::baseobjspace::lookup_special(iter, "__anext__")? }.is_none() {
+            return Err(crate::PyError::type_error(format!(
+                "'async for' received an object from __aiter__ that does not implement __anext__: {}",
+                crate::type_methods::arg_type_name(iter)
+            )));
+        }
+        self.push(iter);
+        Ok(())
+    }
+
+    fn get_anext(&mut self) -> Result<(), PyError> {
+        let iter = self.peek();
+        let method = unsafe { crate::baseobjspace::lookup_special(iter, "__anext__")? }
+            .ok_or_else(|| {
+                crate::PyError::type_error(format!(
+                    "'async for' requires an iterator with __anext__ method, got {}",
+                    crate::type_methods::arg_type_name(iter)
+                ))
+            })?;
+        let next = crate::call::call_function_impl_result(method, &[])?;
+        let awaitable = crate::baseobjspace::get_awaitable_iter(next, 0).map_err(|err| {
+            if err.kind == crate::PyErrorKind::TypeError {
+                crate::PyError::type_error(format!(
+                    "'async for' received an invalid object from __anext__: {}",
+                    crate::type_methods::arg_type_name(next)
+                ))
+            } else {
+                err
+            }
+        })?;
+        self.push(awaitable);
+        Ok(())
+    }
+
+    fn end_async_for(&mut self) -> Result<(), PyError> {
+        let exc = self.pop();
+        let err = unsafe { crate::PyError::from_exc_object(exc) };
+        if err.kind == crate::PyErrorKind::StopAsyncIteration {
+            // The 3.14 exception table preserves the surrounding handler's
+            // previous-exception entry below the asynchronous iterator; the
+            // StopAsyncIteration edge itself pushes only `exc`.
+            self.pop(); // asynchronous iterator
+            Ok(())
+        } else {
+            Err(err)
+        }
     }
 
     // ── load_method ──
@@ -5603,6 +5673,126 @@ while i < 3000:
         unsafe {
             let result = w_dict_getitem_str(frame.w_globals, "result").unwrap();
             assert_eq!(w_int_get_value(result), 42);
+        }
+    }
+
+    #[test]
+    fn test_async_generator_asend_yield_and_exhaustion() {
+        let source = r#"
+async def agen():
+    yield 42
+
+g = agen()
+frame_visible = g.ag_frame is not None
+code_visible = g.ag_code is not None
+initially_suspended = g.ag_suspended
+a = g.__anext__()
+try:
+    a.send(None)
+except StopIteration as e:
+    yielded = e.value
+try:
+    g.__anext__().send(None)
+except StopAsyncIteration:
+    exhausted = True
+"#;
+        let (result, frame) = run_exec_frame(source);
+        result.expect("async generator program failed");
+        unsafe {
+            let yielded = w_dict_getitem_str(frame.w_globals, "yielded").unwrap();
+            assert_eq!(w_int_get_value(yielded), 42);
+            let exhausted = w_dict_getitem_str(frame.w_globals, "exhausted").unwrap();
+            assert!(is_true(exhausted).unwrap());
+            for name in ["frame_visible", "code_visible"] {
+                assert!(is_true(w_dict_getitem_str(frame.w_globals, name).unwrap()).unwrap());
+            }
+            assert!(
+                !is_true(w_dict_getitem_str(frame.w_globals, "initially_suspended").unwrap())
+                    .unwrap()
+            );
+        }
+    }
+
+    #[test]
+    fn test_async_generator_asend_value_and_aclose() {
+        let source = r#"
+closed = False
+async def agen():
+    global closed
+    try:
+        value = yield 1
+        yield value
+    finally:
+        closed = True
+
+g = agen()
+try:
+    g.__anext__().send(None)
+except StopIteration as e:
+    first = e.value
+try:
+    g.asend(42).send(None)
+except StopIteration as e:
+    second = e.value
+try:
+    g.aclose().send(None)
+except StopIteration:
+    close_done = True
+"#;
+        let (result, frame) = run_exec_frame(source);
+        result.expect("async generator asend/aclose program failed");
+        unsafe {
+            for (name, expected) in [("first", 1), ("second", 42)] {
+                assert_eq!(
+                    w_int_get_value(w_dict_getitem_str(frame.w_globals, name).unwrap()),
+                    expected
+                );
+            }
+            for name in ["closed", "close_done"] {
+                assert!(is_true(w_dict_getitem_str(frame.w_globals, name).unwrap()).unwrap());
+            }
+        }
+    }
+
+    #[test]
+    fn test_async_for_consumes_async_generator() {
+        let source = r#"
+async def agen():
+    yield 2
+    yield 3
+
+preserved_exception = False
+async def consume():
+    global preserved_exception
+    result = []
+    try:
+        raise ValueError('outer')
+    except ValueError:
+        async for value in agen():
+            result.append(value)
+        try:
+            raise
+        except ValueError:
+            preserved_exception = True
+    return result
+
+coro = consume()
+try:
+    coro.send(None)
+except StopIteration as e:
+    result = e.value
+"#;
+        let (result, frame) = run_exec_frame(source);
+        result.expect("async-for program failed");
+        unsafe {
+            let result = w_dict_getitem_str(frame.w_globals, "result").unwrap();
+            assert_eq!(w_list_len(result), 2);
+            assert_eq!(w_int_get_value(w_list_getitem(result, 0).unwrap()), 2);
+            assert_eq!(w_int_get_value(w_list_getitem(result, 1).unwrap()), 3);
+            assert!(
+                is_true(w_dict_getitem_str(frame.w_globals, "preserved_exception").unwrap())
+                    .unwrap()
+            );
         }
     }
 

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -1094,6 +1094,7 @@ pub fn get_current_exception() -> PyObjectRef {
 /// The bytecode PUSH_EXC_INFO machinery deliberately continues to use
 /// [`get_current_exception`] for the direct EC slot; app-level `sys.exception`
 /// and bare raise use this logical view instead.
+#[majit_macros::dont_look_inside]
 pub fn get_sys_exception() -> PyObjectRef {
     let ec = crate::call::getexecutioncontext();
     if ec.is_null() {
@@ -1172,7 +1173,11 @@ pub fn attach_raise_cause(exc: PyObjectRef, cause: Option<PyObjectRef>) -> Resul
     // `__context__` and `__cause__`/`__suppress_context__` writes land
     // in the typed slots on `W_BaseException` per
     // `interp_exceptions.py:113-117`.
-    crate::error::chain_context(exc, get_sys_exception());
+    // A running generator swaps its suspended exception into this flat EC
+    // slot before entering the frame.  Keep the hot raise path on the same
+    // residual leaf as PyPy's live frame state; walking the outer generator
+    // chain here would expose the virtualizable frame during tracing.
+    crate::error::chain_context(exc, get_current_exception());
     if let Some(cause_obj) = cause {
         if !cause_obj.is_null() && unsafe { pyre_object::is_exception(exc) } {
             // `interp_exceptions.py:166-174 descr_setcause` — writes
@@ -1338,7 +1343,7 @@ pub fn handle_exception(frame: &mut PyFrame, err: &mut PyError, next_instr: &mut
     // handled records that active exception as its __context__, not only an
     // explicit `raise`.  Recorded once (skipped when a __context__ is already
     // stamped), so it lands at the frame where the exception first surfaces.
-    crate::error::chain_context(err.exc_object, get_sys_exception());
+    crate::error::chain_context(err.exc_object, get_current_exception());
     if err.attach_tb {
         if !ec.is_null() && unsafe { !(*ec).gettrace().is_null() } {
             // The materialized exception is old-gen managed but lives only in the

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -255,7 +255,10 @@ unsafe fn walk_raw_function_roots(
 /// never recurses into it; visit the slot as a root the same way
 /// `walk_raw_function_roots` forwards `w_func_globals_obj`.  No-op for non-code
 /// values and inert when the cached dict is non-moving.
-unsafe fn walk_raw_code_roots(value: PyObjectRef, visitor: &mut dyn FnMut(&mut majit_ir::GcRef)) {
+pub unsafe fn walk_raw_code_roots(
+    value: PyObjectRef,
+    visitor: &mut dyn FnMut(&mut majit_ir::GcRef),
+) {
     unsafe {
         if value.is_null() || !crate::pycode::is_code(value) {
             return;

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -1487,7 +1487,7 @@ pub fn handle_exception(frame: &mut PyFrame, err: &mut PyError, next_instr: &mut
 /// `EVAL_OVERRIDE.unwrap_or(eval_frame_plain)` fallback (call.rs:328 etc.)
 /// continues to reference it directly.
 pub(crate) fn eval_frame_plain(frame: &mut PyFrame) -> PyResult {
-    eval_frame_plain_with_operr(frame, None)
+    eval_frame_plain_with_resume(frame, None, None, None)
 }
 
 /// pyframe.py:270-299 execute_frame body — enter/call_trace/eval_loop/
@@ -1495,14 +1495,69 @@ pub(crate) fn eval_frame_plain(frame: &mut PyFrame) -> PyResult {
 /// throw() path routes it through handle_operation_error and sets
 /// last_instr = next_instr - 1 before resuming (pyframe.py:273-277).
 pub(crate) fn eval_frame_plain_with_operr(frame: &mut PyFrame, operr: Option<PyError>) -> PyResult {
+    eval_frame_plain_with_resume(frame, None, operr, None)
+}
+
+enum FrameResume {
+    Yielded(PyObjectRef),
+    Dispatch(Option<PyError>),
+}
+
+/// pyframe.py:285-315 `resume_execute_frame`.  A suspended `yield from` is
+/// resumed only after `execute_frame` has entered the outer frame.  Clearing
+/// `w_yielding_from` before the delegate call gives the running generator the
+/// same transient `gi_yieldfrom is None` state as PyPy.
+fn prepare_frame_resume(
+    frame: &mut PyFrame,
+    w_inputvalue: Option<PyObjectRef>,
+    operr: Option<PyError>,
+    throw_args: Option<([PyObjectRef; 3], usize)>,
+) -> Result<FrameResume, PyError> {
+    let mut pending_operr = operr;
+    if !frame.w_yielding_from.is_null() {
+        let w_yf = frame.w_yielding_from;
+        frame.w_yielding_from = pyre_object::PY_NULL;
+        let w_arg = w_inputvalue.unwrap_or_else(pyre_object::w_none);
+        match crate::baseobjspace::resume_yield_from(
+            frame,
+            w_yf,
+            w_arg,
+            pending_operr.take(),
+            throw_args,
+        ) {
+            Ok(Some(value)) => return Ok(FrameResume::Yielded(value)),
+            // The delegate's StopIteration value is already on the outer
+            // frame stack and its SEND completion target is installed.
+            Ok(None) => return Ok(FrameResume::Dispatch(None)),
+            Err(err) => pending_operr = Some(err),
+        }
+    }
+    if pending_operr.is_none() {
+        if let Some(w_arg_or_err) = w_inputvalue {
+            let _ = frame.resume_execute_frame(w_arg_or_err)?;
+        }
+    }
+    Ok(FrameResume::Dispatch(pending_operr))
+}
+
+pub(crate) fn eval_frame_plain_with_resume(
+    frame: &mut PyFrame,
+    w_inputvalue: Option<PyObjectRef>,
+    operr: Option<PyError>,
+    throw_args: Option<([PyObjectRef; 3], usize)>,
+) -> PyResult {
     frame.fix_array_ptrs();
     if frame.execution_context.is_null() {
-        if let Some(mut err) = operr {
-            let mut next_instr = frame.next_instr();
-            if !handle_exception(frame, &mut err, &mut next_instr) {
-                return Err(err);
+        match prepare_frame_resume(frame, w_inputvalue, operr, throw_args)? {
+            FrameResume::Yielded(value) => return Ok(value),
+            FrameResume::Dispatch(Some(mut err)) => {
+                let mut next_instr = frame.next_instr();
+                if !handle_exception(frame, &mut err, &mut next_instr) {
+                    return Err(err);
+                }
+                frame.last_instr = next_instr as isize - 1;
             }
-            frame.last_instr = next_instr as isize - 1;
+            FrameResume::Dispatch(None) => {}
         }
         return eval_loop(frame);
     }
@@ -1531,12 +1586,19 @@ pub(crate) fn eval_frame_plain_with_operr(frame: &mut PyFrame, operr: Option<PyE
     let outer_result = (|| -> PyResult {
         execution_context.call_trace(frame as *mut PyFrame)?;
         let inner_result = (|| -> PyResult {
-            if let Some(mut err) = operr {
-                let mut next_instr = frame.next_instr();
-                if !handle_exception(frame, &mut err, &mut next_instr) {
-                    return Err(err);
+            match prepare_frame_resume(frame, w_inputvalue, operr, throw_args)? {
+                FrameResume::Yielded(value) => {
+                    w_exitvalue = value;
+                    return Ok(value);
                 }
-                frame.last_instr = next_instr as isize - 1;
+                FrameResume::Dispatch(Some(mut err)) => {
+                    let mut next_instr = frame.next_instr();
+                    if !handle_exception(frame, &mut err, &mut next_instr) {
+                        return Err(err);
+                    }
+                    frame.last_instr = next_instr as isize - 1;
+                }
+                FrameResume::Dispatch(None) => {}
             }
             let result = eval_loop(frame)?;
             w_exitvalue = result;

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -279,7 +279,7 @@ unsafe fn walk_raw_code_roots(value: PyObjectRef, visitor: &mut dyn FnMut(&mut m
 /// `W_BASE_EXCEPTION_GC_PTR_OFFSETS` slot in place, the same shape
 /// `walk_raw_function_roots` / `walk_raw_getset_roots` use for Box/`malloc_typed`
 /// -held children. No-op for non-exception values.
-unsafe fn walk_raw_exception_roots(
+pub unsafe fn walk_raw_exception_roots(
     value: PyObjectRef,
     visitor: &mut dyn FnMut(&mut majit_ir::GcRef),
 ) {
@@ -617,6 +617,12 @@ pub unsafe fn walk_pyframe_roots_area(
             // This is the post-PUSH_EXC_INFO owner of the same exception and
             // must preserve its traceback/frame graph identically.
             unsafe { walk_raw_exception_roots((*ec).sys_exc_value, visitor) };
+            // `executioncontext.py:55` current_gen_or_coroutine is the head
+            // of the running-generator chain.  The generator custom trace
+            // follows each node's `previous_gen_or_coroutine` edge.
+            let current_gen_slot =
+                unsafe { &mut (*ec).current_gen_or_coroutine as *mut PyObjectRef };
+            visitor(unsafe { &mut *(current_gen_slot as *mut majit_ir::GcRef) });
             // pending_with_disabled_del is a GC-visible list upstream
             // (executioncontext.py:652); pyre's Vec lives in the boxed
             // UserDelAction, so its element slots are visited here.
@@ -1072,6 +1078,19 @@ pub fn get_current_exception() -> PyObjectRef {
     unsafe { (*ec).sys_exc_value }
 }
 
+/// `executioncontext.py:219-233 sys_exc_info` — return the topmost handled
+/// exception, including one parked on the running generator/coroutine chain.
+/// The bytecode PUSH_EXC_INFO machinery deliberately continues to use
+/// [`get_current_exception`] for the direct EC slot; app-level `sys.exception`
+/// and bare raise use this logical view instead.
+pub fn get_sys_exception() -> PyObjectRef {
+    let ec = crate::call::getexecutioncontext();
+    if ec.is_null() {
+        return PY_NULL;
+    }
+    unsafe { (*ec).sys_exc_info(false) }
+}
+
 /// Flat TLS write of the per-thread `CURRENT_EXCEPTION` slot — same
 /// residual-leaf contract as [`get_current_exception`].
 #[majit_macros::dont_look_inside]
@@ -1142,7 +1161,7 @@ pub fn attach_raise_cause(exc: PyObjectRef, cause: Option<PyObjectRef>) -> Resul
     // `__context__` and `__cause__`/`__suppress_context__` writes land
     // in the typed slots on `W_BaseException` per
     // `interp_exceptions.py:113-117`.
-    crate::error::chain_context(exc, get_current_exception());
+    crate::error::chain_context(exc, get_sys_exception());
     if let Some(cause_obj) = cause {
         if !cause_obj.is_null() && unsafe { pyre_object::is_exception(exc) } {
             // `interp_exceptions.py:166-174 descr_setcause` — writes
@@ -1308,7 +1327,7 @@ pub fn handle_exception(frame: &mut PyFrame, err: &mut PyError, next_instr: &mut
     // handled records that active exception as its __context__, not only an
     // explicit `raise`.  Recorded once (skipped when a __context__ is already
     // stamped), so it lands at the frame where the exception first surfaces.
-    crate::error::chain_context(err.exc_object, get_current_exception());
+    crate::error::chain_context(err.exc_object, get_sys_exception());
     if err.attach_tb {
         if !ec.is_null() && unsafe { !(*ec).gettrace().is_null() } {
             // The materialized exception is old-gen managed but lives only in the
@@ -2949,7 +2968,7 @@ impl OpcodeStepExecutor for PyFrame {
             0 => {
                 // Bare `raise` — re-raise current exception
                 // PyPy: executioncontext.py sys_exc_info
-                let exc = get_current_exception();
+                let exc = get_sys_exception();
                 if exc.is_null() || unsafe { pyre_object::is_none(exc) } {
                     Err(PyError::runtime_error("No active exception to reraise"))
                 } else if unsafe { pyre_object::is_exception(exc) } {

--- a/pyre/pyre-interpreter/src/executioncontext.rs
+++ b/pyre/pyre-interpreter/src/executioncontext.rs
@@ -217,6 +217,10 @@ pub struct ExecutionContext {
     /// coroutines.  Each node owns the suspended exception state of its
     /// caller through `GeneratorOrCoroutine.previous_gen_or_coroutine`.
     pub current_gen_or_coroutine: PyObjectRef,
+    /// `executioncontext.py:53-54` — PEP 525 hooks, owned by the execution
+    /// context (thread-specific), never by a process-global side table.
+    pub w_asyncgen_firstiter_fn: PyObjectRef,
+    pub w_asyncgen_finalizer_fn: PyObjectRef,
 }
 
 pub type PyExecutionContext = ExecutionContext;
@@ -267,6 +271,8 @@ impl ExecutionContext {
             check_signal_action: None,
             sys_exc_value: pyre_object::PY_NULL,
             current_gen_or_coroutine: pyre_object::PY_NULL,
+            w_asyncgen_firstiter_fn: pyre_object::PY_NULL,
+            w_asyncgen_finalizer_fn: pyre_object::PY_NULL,
         }
     }
 

--- a/pyre/pyre-interpreter/src/executioncontext.rs
+++ b/pyre/pyre-interpreter/src/executioncontext.rs
@@ -213,6 +213,10 @@ pub struct ExecutionContext {
     /// per-thread EC pointer and the optimizer can dead-store-eliminate a
     /// balanced save/restore.  GC-rooted via `walk_pyframe_roots`.
     pub sys_exc_value: PyObjectRef,
+    /// `executioncontext.py:55` — linked-list head for running generators and
+    /// coroutines.  Each node owns the suspended exception state of its
+    /// caller through `GeneratorOrCoroutine.previous_gen_or_coroutine`.
+    pub current_gen_or_coroutine: PyObjectRef,
 }
 
 pub type PyExecutionContext = ExecutionContext;
@@ -262,6 +266,7 @@ impl ExecutionContext {
             builtin_dict_cache: std::cell::Cell::new(pyre_object::PY_NULL),
             check_signal_action: None,
             sys_exc_value: pyre_object::PY_NULL,
+            current_gen_or_coroutine: pyre_object::PY_NULL,
         }
     }
 
@@ -707,23 +712,64 @@ impl ExecutionContext {
     pub fn sys_exc_info(&self, _for_hidden: bool) -> PyObjectRef {
         let _ = self.gettopframe();
         let _ = _for_hidden;
+        if !self.sys_exc_value.is_null() {
+            return self.sys_exc_value;
+        }
+        let mut generator = self.current_gen_or_coroutine;
+        while !generator.is_null() {
+            let saved =
+                unsafe { pyre_object::generator::w_generator_get_saved_exc_value(generator) };
+            if !saved.is_null() {
+                return saved;
+            }
+            generator = unsafe { pyre_object::generator::w_generator_get_previous(generator) };
+        }
         pyre_object::PY_NULL
     }
 
-    pub fn set_sys_exc_info(&mut self, _operror: PyObjectRef) {
-        let _ = _operror;
-        let frame = self.gettopframe_nohidden();
-        if !frame.is_null() {
-            // Real PyPy stores OperationError in frame.last_exception.
-            let _ = frame;
-        }
+    pub fn current_exception(&self) -> PyObjectRef {
+        self.sys_exc_value
+    }
+
+    pub fn set_sys_exc_info(&mut self, operror: PyObjectRef) {
+        self.sys_exc_value = operror;
     }
 
     pub fn clear_sys_exc_info(&mut self) {
-        let mut frame = self.gettopframe_nohidden();
-        while !frame.is_null() {
-            frame = Self::getnextframe_nohidden(frame);
+        self.sys_exc_value = pyre_object::PY_NULL;
+    }
+
+    /// `executioncontext.py:254-259` — exchange the caller's active handler
+    /// exception with the exception suspended on `gen`, then link `gen` as
+    /// the current generator/coroutine.
+    pub fn push_gen_or_coroutine(&mut self, generator: PyObjectRef) {
+        let current_exc = self.sys_exc_value;
+        let saved_exc =
+            unsafe { pyre_object::generator::w_generator_get_saved_exc_value(generator) };
+        self.sys_exc_value = saved_exc;
+        unsafe {
+            pyre_object::generator::w_generator_set_saved_exc_value(generator, current_exc);
+            pyre_object::generator::w_generator_set_previous(
+                generator,
+                self.current_gen_or_coroutine,
+            );
         }
+        self.current_gen_or_coroutine = generator;
+    }
+
+    /// `executioncontext.py:261-267` — unlink `gen`, park the exception state
+    /// produced by its frame on the generator, and restore its caller's state.
+    pub fn pop_gen_or_coroutine(&mut self, generator: PyObjectRef) {
+        debug_assert_eq!(self.current_gen_or_coroutine, generator);
+        let caller_exc =
+            unsafe { pyre_object::generator::w_generator_get_saved_exc_value(generator) };
+        self.current_gen_or_coroutine =
+            unsafe { pyre_object::generator::w_generator_get_previous(generator) };
+        unsafe {
+            pyre_object::generator::w_generator_set_previous(generator, pyre_object::PY_NULL);
+            pyre_object::generator::w_generator_set_saved_exc_value(generator, self.sys_exc_value);
+        }
+        self.sys_exc_value = caller_exc;
     }
 
     pub fn settrace(&mut self, w_func: PyObjectRef) {

--- a/pyre/pyre-interpreter/src/executioncontext.rs
+++ b/pyre/pyre-interpreter/src/executioncontext.rs
@@ -136,6 +136,14 @@ pub fn register_generator_finalizer(obj: PyObjectRef) {
     pyre_object::gc_hook::try_gc_register_finalizer(0, obj, finalizer_queue_trigger);
 }
 
+/// Register an interp-level object whose PyPy counterpart implements
+/// `_finalize_` solely to release an acquired buffer.  The ownership bit
+/// lives on the object itself; this queue supplies the unreachable-object
+/// callback corresponding to `register_finalizer(space)`.
+pub fn register_native_buffer_finalizer(obj: PyObjectRef) {
+    pyre_object::gc_hook::try_gc_register_finalizer(0, obj, finalizer_queue_trigger);
+}
+
 /// Register an object that owns a `WeakrefLifeline`. PyPy's GC invalidates the
 /// rweakrefs and registers callback-bearing lifelines themselves; until pyre's
 /// mapdict weakref SPECIAL slot is inline, the address-keyed slot keeps that
@@ -146,7 +154,9 @@ pub fn register_weakref_finalizer(obj: PyObjectRef) {
     let already_registered = crate::typedef::r#type(obj)
         .map(|w_type| unsafe { pyre_object::w_type_get_hasuserdel(w_type) })
         .unwrap_or(false);
-    if !already_registered {
+    let native_buffer_finalizer = crate::module::__pypy__::W_PickleBuffer::from_obj(obj).is_some()
+        || crate::module::r#struct::unpack_iter::W_UnpackIter::from_obj(obj).is_some();
+    if !already_registered && !native_buffer_finalizer {
         pyre_object::gc_hook::try_gc_register_finalizer(0, obj, finalizer_queue_trigger);
     }
 }
@@ -1953,6 +1963,14 @@ impl UserDelAction {
 
     pub fn _call_finalizer(&mut self, w_obj: PyObjectRef) {
         crate::module::_weakref::interp__weakref::finalize_weakrefs(w_obj);
+        if let Some(pb) = crate::module::__pypy__::W_PickleBuffer::from_obj(w_obj) {
+            pb.release_export();
+            return;
+        }
+        if let Some(iter) = crate::module::r#struct::unpack_iter::W_UnpackIter::from_obj(w_obj) {
+            iter.release_export();
+            return;
+        }
         if unsafe { pyre_object::generator::is_generator_or_coroutine(w_obj) } {
             if self.gc_disabled(w_obj) {
                 return;

--- a/pyre/pyre-interpreter/src/function.rs
+++ b/pyre/pyre-interpreter/src/function.rs
@@ -2700,7 +2700,7 @@ fn _flat_pycall(
     // ownership (no execution). Normal functions execute through the JIT-aware
     // eval, which needs the locals roots registered for the duration.
     if new_frame._is_generator_or_coroutine() {
-        match new_frame.into_generator() {
+        match crate::call::frame_into_generator_for_function(new_frame, func) {
             Ok(v) => v,
             Err(e) => {
                 crate::call::set_call_error(e);
@@ -2781,7 +2781,7 @@ fn _flat_pycall_defaults(
 
     // function.py:231 — return new_frame.run(self.name, self.qualname)
     if new_frame._is_generator_or_coroutine() {
-        match new_frame.into_generator() {
+        match crate::call::frame_into_generator_for_function(new_frame, func) {
             Ok(v) => v,
             Err(e) => {
                 crate::call::set_call_error(e);

--- a/pyre/pyre-interpreter/src/host_seam.rs
+++ b/pyre/pyre-interpreter/src/host_seam.rs
@@ -110,9 +110,8 @@ pub type SeamResult<T> = Result<T, SeamError>;
 /// Map a [`SeamError`] onto the interpreter's `PyError`, mirroring the
 /// `io_err`/`fd_io_err` conversions the real-syscall call sites use. `context`
 /// is the path that becomes the `OSError`'s `filename` (empty = omit, matching
-/// the `""` the fd call sites pass). Only the sandbox build routes errors
-/// through here; the real build keeps its own inline `io_err`.
-#[cfg(feature = "sandbox")]
+/// the `""` the fd call sites pass). Both real and trampoline-backed opens
+/// use this conversion so they expose the same Python exception shape.
 pub fn seam_os_err(e: SeamError, context: &str) -> crate::PyError {
     match e {
         SeamError::Os(errno) => {

--- a/pyre/pyre-interpreter/src/importing.rs
+++ b/pyre/pyre-interpreter/src/importing.rs
@@ -2241,7 +2241,16 @@ pub fn importhook(
     level: i64,
     execution_context: *const PyExecutionContext,
 ) -> Result<PyObjectRef, crate::PyError> {
-    if name.is_empty() && level < 0 {
+    // CPython 3.14 import.c / PyPy's import-level validation: negative
+    // levels are rejected independently of the module name.  An empty name
+    // is valid only for an actual relative import (`from . import x`).
+    if level < 0 {
+        return Err(crate::PyError::new(
+            crate::PyErrorKind::ValueError,
+            "level must be >= 0",
+        ));
+    }
+    if name.is_empty() && level == 0 {
         return Err(crate::PyError::new(
             crate::PyErrorKind::ValueError,
             "Empty module name",
@@ -2275,6 +2284,14 @@ fn relative_import(
             "attempted relative import with no known parent package",
         )
     })?;
+    // importlib._bootstrap._resolve_name: an empty fallback package (the
+    // `__main__` case) has no parent to anchor even a level-1 import.
+    if package.is_empty() {
+        return Err(crate::PyError::new(
+            crate::PyErrorKind::ImportError,
+            "attempted relative import with no known parent package",
+        ));
+    }
 
     // Strip (level - 1) trailing components from package
     // PyPy: for dotted name "a.b.c" with level=2, strip "c" → "a.b", then strip "b" → "a"
@@ -2316,15 +2333,44 @@ fn resolve_package_name(w_globals: PyObjectRef) -> Result<Option<String>, crate:
     // missing entry; any other `__getitem__` error (a dict-subclass globals
     // raising) must propagate.  `?` re-raises it; `if let Some(..)` consumes
     // the present case.
-    // Try __package__ first (PyPy: space.finditem_str(w_globals, '__package__'))
-    if let Some(pkg) = crate::baseobjspace::finditem_str(w_globals, "__package__")? {
-        if !pkg.is_null() && unsafe { pyre_object::is_str(pkg) } {
-            let s = unsafe { pyre_object::w_str_get_value(pkg) };
-            if !s.is_empty() {
-                return Ok(Some(s.to_string()));
+    // Python 3.14 importlib._bootstrap._calc___package__: an explicit
+    // non-None __package__ wins; otherwise __spec__.parent is authoritative.
+    let package = crate::baseobjspace::finditem_str(w_globals, "__package__")?;
+    let spec = crate::baseobjspace::finditem_str(w_globals, "__spec__")?;
+    if let Some(pkg) = package {
+        if !unsafe { pyre_object::is_none(pkg) } {
+            if !unsafe { pyre_object::is_str(pkg) } {
+                return Err(crate::PyError::type_error(
+                    "__package__ not set to a string",
+                ));
             }
+            return Ok(Some(
+                unsafe { pyre_object::w_str_get_value(pkg) }.to_string(),
+            ));
         }
     }
+    if let Some(spec) = spec {
+        if !unsafe { pyre_object::is_none(spec) } {
+            let parent = crate::baseobjspace::getattr_str(spec, "parent")?;
+            if !unsafe { pyre_object::is_str(parent) } {
+                return Err(crate::PyError::type_error(
+                    "__spec__.parent is not a string",
+                ));
+            }
+            return Ok(Some(
+                unsafe { pyre_object::w_str_get_value(parent) }.to_string(),
+            ));
+        }
+    }
+
+    // _calc___package__ emits ImportWarning before the legacy __name__ /
+    // __path__ fallback.  Route it through warnings.warn so assertWarns and
+    // user warning filters see the event.
+    crate::warn::warn_category(
+        "can't resolve package from __spec__ or __package__, falling back on __name__ and __path__",
+        "ImportWarning",
+        3,
+    )?;
 
     // Fallback: __name__ (for modules inside packages)
     if let Some(name_obj) = crate::baseobjspace::finditem_str(w_globals, "__name__")? {
@@ -2334,10 +2380,11 @@ fn resolve_package_name(w_globals: PyObjectRef) -> Result<Option<String>, crate:
             if crate::baseobjspace::finditem_str(w_globals, "__path__")?.is_some() {
                 return Ok(Some(name.to_string()));
             }
-            // Otherwise strip the last component (module name within package)
-            if let Some(dot) = name.rfind('.') {
-                return Ok(Some(name[..dot].to_string()));
-            }
+            // Otherwise `rpartition('.')[0]` is also the empty string for a
+            // top-level module such as __main__.
+            return Ok(Some(
+                name.rfind('.').map_or("", |dot| &name[..dot]).to_string(),
+            ));
         }
     }
 
@@ -2596,6 +2643,29 @@ pub fn import_all_from_w(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn importhook_rejects_invalid_absolute_name_and_level() {
+        crate::test_hooks::install_hash_hook();
+        let empty = importhook("", PY_NULL, PY_NULL, 0, std::ptr::null()).unwrap_err();
+        assert_eq!(empty.kind, crate::PyErrorKind::ValueError);
+        assert_eq!(empty.message, "Empty module name");
+
+        let negative = importhook("sys", PY_NULL, PY_NULL, -1, std::ptr::null()).unwrap_err();
+        assert_eq!(negative.kind, crate::PyErrorKind::ValueError);
+        assert_eq!(negative.message, "level must be >= 0");
+
+        let globals = pyre_object::w_dict_new();
+        unsafe {
+            pyre_object::w_dict_setitem_str(globals, "__package__", pyre_object::w_str_new(""));
+        }
+        let no_parent = importhook("", globals, PY_NULL, 1, std::ptr::null()).unwrap_err();
+        assert_eq!(no_parent.kind, crate::PyErrorKind::ImportError);
+        assert_eq!(
+            no_parent.message,
+            "attempted relative import with no known parent package"
+        );
+    }
 
     #[test]
     fn test_sys_modules_cache() {

--- a/pyre/pyre-interpreter/src/jit_fnaddr.rs
+++ b/pyre/pyre-interpreter/src/jit_fnaddr.rs
@@ -1366,6 +1366,16 @@ pub fn jit_trace_fnaddrs() -> Vec<(&'static str, i64)> {
         "pyre_interpreter::get_current_exception",
         get_current_exc as *const (),
     );
+    // `get_sys_exception` is the PyPy `ExecutionContext.sys_exc_info` leaf:
+    // it may walk the running-generator chain, but that execution-context
+    // state is runtime data and must not be folded into a trace.
+    let get_sys_exc: fn() -> pyre_object::PyObjectRef = crate::eval::get_sys_exception;
+    push_alias_pair(
+        &mut entries,
+        "pyre_interpreter::eval::get_sys_exception",
+        "pyre_interpreter::get_sys_exception",
+        get_sys_exc as *const (),
+    );
     let set_current_exc: fn(pyre_object::PyObjectRef) = crate::eval::set_current_exception;
     push_alias_pair(
         &mut entries,
@@ -2517,6 +2527,14 @@ mod tests {
             get_exc
         );
         assert_eq!(bindings["pyre_interpreter::get_current_exception"], get_exc);
+
+        let get_sys_exc: fn() -> pyre_object::PyObjectRef = crate::eval::get_sys_exception;
+        let get_sys_exc = get_sys_exc as *const () as usize as i64;
+        assert_eq!(
+            bindings["pyre_interpreter::eval::get_sys_exception"],
+            get_sys_exc
+        );
+        assert_eq!(bindings["pyre_interpreter::get_sys_exception"], get_sys_exc);
 
         let set_exc: fn(pyre_object::PyObjectRef) = crate::eval::set_current_exception;
         let set_exc = set_exc as *const () as usize as i64;

--- a/pyre/pyre-interpreter/src/jit_fnaddr.rs
+++ b/pyre/pyre-interpreter/src/jit_fnaddr.rs
@@ -2102,11 +2102,31 @@ pub fn jit_static_pytype_addrs() -> Vec<(&'static str, i64)> {
             "interp_exceptions::EXC_SYNTAX_ERROR_TYPE",
             interp_exceptions::EXC_SYNTAX_ERROR_TYPE
         ),
+        pytype_addr!(
+            "interp_exceptions::EXC_STOP_ASYNC_ITERATION_TYPE",
+            interp_exceptions::EXC_STOP_ASYNC_ITERATION_TYPE
+        ),
         pytype_addr!("generator::GENERATOR_TYPE", generator::GENERATOR_TYPE),
         pytype_addr!("generator::COROUTINE_TYPE", generator::COROUTINE_TYPE),
         pytype_addr!(
+            "generator::ASYNC_GENERATOR_TYPE",
+            generator::ASYNC_GENERATOR_TYPE
+        ),
+        pytype_addr!(
             "generator::COROUTINE_WRAPPER_TYPE",
             generator::COROUTINE_WRAPPER_TYPE
+        ),
+        pytype_addr!(
+            "generator::ASYNC_GEN_VALUE_WRAPPER_TYPE",
+            generator::ASYNC_GEN_VALUE_WRAPPER_TYPE
+        ),
+        pytype_addr!(
+            "generator::ASYNC_GEN_ASEND_TYPE",
+            generator::ASYNC_GEN_ASEND_TYPE
+        ),
+        pytype_addr!(
+            "generator::ASYNC_GEN_ATHROW_TYPE",
+            generator::ASYNC_GEN_ATHROW_TYPE
         ),
         pytype_addr!("pyobject::INT_TYPE", pyobject::INT_TYPE),
         pytype_addr!("pyobject::BOOL_TYPE", pyobject::BOOL_TYPE),

--- a/pyre/pyre-interpreter/src/lib.rs
+++ b/pyre/pyre-interpreter/src/lib.rs
@@ -898,6 +898,10 @@ pub fn all_subclass_range_aliases() -> Vec<pyre_object::pyobject::SubclassRangeA
         subclass_range_alias(127, typed::<crate::module::_collections::W_DequeIter>()),
         subclass_range_alias(128, typed::<crate::module::_collections::W_DequeRevIter>()),
         subclass_range_alias(129, typed::<crate::module::_tokenize::W_TokenizerIter>()),
+        subclass_range_alias(
+            130,
+            typed::<crate::pyframe::frame_locals_proxy::FrameLocalsProxy>(),
+        ),
     ]
 }
 

--- a/pyre/pyre-interpreter/src/module/__pypy__/interp_buffer.rs
+++ b/pyre/pyre-interpreter/src/module/__pypy__/interp_buffer.rs
@@ -12,6 +12,9 @@ use crate::PyError;
 pub struct W_PickleBuffer {
     /// The wrapped buffer-supporting object, or `None` after `release()`.
     w_obj: PyObjectRef,
+    /// `self.buf is not None and self.buf.needs_release()`: owns exactly one
+    /// exporter release until `release()` or `_finalize_` takes it.
+    export_active: bool,
 }
 
 #[crate::pyre_methods(
@@ -41,13 +44,27 @@ impl W_PickleBuffer {
         pyre_object::gc_roots::pin_root(w_obj);
         // `allocate` may collect; store the post-collection exporter rather
         // than the stale Rust-stack copy.
-        Ok(W_PickleBuffer::allocate(W_PickleBuffer {
+        let r_obj = pyre_object::gc_roots::shadow_stack_get(sp);
+        let export_active = unsafe { crate::builtins::buffer_export_incref(r_obj) };
+        // Like the other self-mutating interp-level payloads, keep the
+        // wrapper stationary.  More importantly for `register_finalizer`, an
+        // acquired export must enter the old-object finalizer queue at its
+        // definitive address; a nursery registration is first promoted as a
+        // finalizer root and otherwise delays `_release_buf` by a collection.
+        let w_pickle_buffer = W_PickleBuffer::allocate_stable(W_PickleBuffer {
             ob: pyre_object::PyObject {
                 ob_type: std::ptr::null(),
                 w_class: std::ptr::null_mut(),
             },
-            w_obj: pyre_object::gc_roots::shadow_stack_get(sp),
-        }))
+            w_obj: r_obj,
+            export_active,
+        });
+        // Pyre also routes weakref invalidation through this finalizer queue,
+        // so register immutable-buffer wrappers too: PyPy's collector handles
+        // their weakrefs independently even when `buf.needs_release()` is
+        // false.  The idempotent release body is a no-op for that export.
+        crate::executioncontext::register_native_buffer_finalizer(w_pickle_buffer);
+        Ok(w_pickle_buffer)
     }
 
     /// `raw()` — a memoryview of the raw bytes underlying the wrapped buffer.
@@ -78,6 +95,19 @@ impl W_PickleBuffer {
 
     /// `release()` — drop the reference to the underlying buffer.
     fn release(&mut self) {
+        self.release_export();
+    }
+}
+
+impl W_PickleBuffer {
+    /// `_release_buf` (`interp_buffer.py:146-150`) — clear ownership before
+    /// calling the exporter release, making repeated explicit/finalizer calls
+    /// idempotent.
+    pub(crate) fn release_export(&mut self) {
+        if self.export_active {
+            self.export_active = false;
+            unsafe { crate::builtins::buffer_export_decref(self.w_obj) };
+        }
         self.w_obj = pyre_object::w_none();
     }
 }

--- a/pyre/pyre-interpreter/src/module/__pypy__/interp_buffer.rs
+++ b/pyre/pyre-interpreter/src/module/__pypy__/interp_buffer.rs
@@ -15,6 +15,14 @@ pub struct W_PickleBuffer {
     /// `self.buf is not None and self.buf.needs_release()`: owns exactly one
     /// exporter release until `release()` or `_finalize_` takes it.
     export_active: bool,
+    /// The generic `W_Root.__buffer_w` path returns a temporary memoryview.
+    /// Keep and release that carrier as part of `self.buf`; a concrete
+    /// exporter supplied directly by the caller is borrowed instead.
+    release_memoryview: bool,
+    /// The PEP 688 exporter paired with the temporary memoryview, or `None`
+    /// for a native exporter.  This is the inline owner corresponding to the
+    /// buffer protocol's `__release_buffer__(view)` obligation.
+    w_release_exporter: PyObjectRef,
 }
 
 #[crate::pyre_methods(
@@ -28,20 +36,11 @@ impl W_PickleBuffer {
         // interp_buffer.py:201-203 descr_new_picklebuffer — acquire the
         // export while constructing the object; PickleBuffer has no separate
         // __init__ phase.
-        if !is_buffer_like(w_obj) {
-            let name = type_name(w_obj);
-            return Err(PyError::type_error(format!(
-                "a bytes-like object is required, not '{name}'"
-            )));
-        }
-        // `space.buffer_w(w_obj, BUF_FULL_RO)` rejects a released
-        // memoryview at construction time, before the PickleBuffer exists.
-        if is_memoryview(w_obj) {
-            unsafe { crate::builtins::memoryview_check_released(w_obj) }?;
-        }
+        let (w_buffer, release_memoryview, w_release_exporter) = acquire_pickle_buffer(w_obj)?;
         let _roots = pyre_object::gc_roots::push_roots();
         let sp = pyre_object::gc_roots::shadow_stack_len();
-        pyre_object::gc_roots::pin_root(w_obj);
+        pyre_object::gc_roots::pin_root(w_buffer);
+        pyre_object::gc_roots::pin_root(w_release_exporter);
         // `allocate` may collect; store the post-collection exporter rather
         // than the stale Rust-stack copy.
         let r_obj = pyre_object::gc_roots::shadow_stack_get(sp);
@@ -58,6 +57,8 @@ impl W_PickleBuffer {
             },
             w_obj: r_obj,
             export_active,
+            release_memoryview,
+            w_release_exporter: pyre_object::gc_roots::shadow_stack_get(sp + 1),
         });
         // Pyre also routes weakref invalidation through this finalizer queue,
         // so register immutable-buffer wrappers too: PyPy's collector handles
@@ -94,8 +95,8 @@ impl W_PickleBuffer {
     }
 
     /// `release()` — drop the reference to the underlying buffer.
-    fn release(&mut self) {
-        self.release_export();
+    fn release(&mut self) -> Result<(), PyError> {
+        self.release_export_result()
     }
 }
 
@@ -104,11 +105,53 @@ impl W_PickleBuffer {
     /// calling the exporter release, making repeated explicit/finalizer calls
     /// idempotent.
     pub(crate) fn release_export(&mut self) {
+        let _ = self.release_export_result();
+    }
+
+    fn release_export_result(&mut self) -> Result<(), PyError> {
+        if unsafe { pyre_object::is_none(self.w_obj) } {
+            return Ok(());
+        }
+        let _roots = pyre_object::gc_roots::push_roots();
+        let sp = pyre_object::gc_roots::shadow_stack_len();
+        pyre_object::gc_roots::pin_root(self.w_obj);
+        pyre_object::gc_roots::pin_root(self.w_release_exporter);
+        let w_obj = pyre_object::gc_roots::shadow_stack_get(sp);
         if self.export_active {
             self.export_active = false;
-            unsafe { crate::builtins::buffer_export_decref(self.w_obj) };
+            unsafe { crate::builtins::buffer_export_decref(w_obj) };
         }
         self.w_obj = pyre_object::w_none();
+        self.w_release_exporter = pyre_object::w_none();
+        if self.release_memoryview {
+            self.release_memoryview = false;
+            let w_exporter = pyre_object::gc_roots::shadow_stack_get(sp + 1);
+            let callback_result = if let Some(w_release) =
+                unsafe { crate::baseobjspace::lookup(w_exporter, "__release_buffer__") }
+            {
+                let w_type = crate::typedef::r#type(w_exporter).unwrap_or(w_exporter);
+                unsafe {
+                    crate::baseobjspace::get_and_call_function(
+                        w_release,
+                        w_exporter,
+                        w_type,
+                        &[pyre_object::gc_roots::shadow_stack_get(sp)],
+                    )
+                }
+                .map(|_| ())
+            } else {
+                Ok(())
+            };
+            // The callback is advisory cleanup; the temporary carrier still
+            // has to be released if it raises, matching a try/finally around
+            // the acquired Py_buffer.
+            let release_result =
+                crate::builtins::memoryview_release(&[pyre_object::gc_roots::shadow_stack_get(sp)])
+                    .map(|_| ());
+            callback_result?;
+            release_result?;
+        }
+        Ok(())
     }
 }
 
@@ -157,14 +200,56 @@ fn type_name(obj: PyObjectRef) -> String {
     }
 }
 
-/// Any buffer exporter is accepted: `bytes`, `bytearray`, `array`, and
-/// `memoryview` (`buffer_w(w_obj, BUF_FULL_RO)`).
-fn is_buffer_like(obj: PyObjectRef) -> bool {
+/// `space.buffer_w(w_obj, BUF_FULL_RO)` for PickleBuffer construction.
+///
+/// Concrete native exporters keep their identity.  The W_Root fallback is
+/// the Python 3.14/PyPy PEP 688 path: look up and descriptor-bind
+/// `__buffer__`, pass `BUF_FULL_RO`, and require a memoryview result.  The
+/// returned boolean says that the result is the temporary carrier owned by
+/// this acquisition and must be released with the PickleBuffer.
+fn acquire_pickle_buffer(obj: PyObjectRef) -> Result<(PyObjectRef, bool, PyObjectRef), PyError> {
     unsafe {
-        pyre_object::is_bytes(obj)
+        if pyre_object::is_bytes(obj)
             || pyre_object::is_bytearray(obj)
             || pyre_object::interp_array::is_array(obj)
             || is_memoryview(obj)
+        {
+            if is_memoryview(obj) {
+                crate::builtins::memoryview_check_released(obj)?;
+            }
+            return Ok((obj, false, pyre_object::w_none()));
+        }
+
+        const BUF_FULL_RO: i64 = 0x011c;
+        let _roots = pyre_object::gc_roots::push_roots();
+        let sp = pyre_object::gc_roots::shadow_stack_len();
+        pyre_object::gc_roots::pin_root(obj);
+        pyre_object::gc_roots::pin_root(pyre_object::w_int_new(BUF_FULL_RO));
+        let r_obj = pyre_object::gc_roots::shadow_stack_get(sp);
+        if let Some(w_impl) = crate::baseobjspace::lookup(r_obj, "__buffer__") {
+            pyre_object::gc_roots::pin_root(w_impl);
+            let w_type = crate::typedef::r#type(r_obj).unwrap_or(r_obj);
+            let w_result = crate::baseobjspace::get_and_call_function(
+                pyre_object::gc_roots::shadow_stack_get(sp + 2),
+                r_obj,
+                w_type,
+                &[pyre_object::gc_roots::shadow_stack_get(sp + 1)],
+            )?;
+            if is_memoryview(w_result) {
+                crate::builtins::memoryview_check_released(w_result)?;
+                return Ok((w_result, true, pyre_object::gc_roots::shadow_stack_get(sp)));
+            }
+            return Err(PyError::type_error(format!(
+                "a bytes-like object is required, not '{}'",
+                type_name(pyre_object::gc_roots::shadow_stack_get(sp))
+            )));
+        }
+        // Interp-level exporters such as mmap / ctypes expose their native
+        // `buffer_w` implementation without a Python-visible `__buffer__`
+        // descriptor.  Normalize those to the same owned memoryview carrier.
+        let w_result =
+            crate::builtins::w_memoryview_new(pyre_object::gc_roots::shadow_stack_get(sp))?;
+        return Ok((w_result, true, pyre_object::w_none()));
     }
 }
 

--- a/pyre/pyre-interpreter/src/module/_io/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_io/mod.rs
@@ -7,6 +7,11 @@
 
 use pyre_object::*;
 
+// The module-local exception class is process-global, like PyPy's module
+// definition object.  Keep the immortal type pointer shared across threads;
+// runtime semantic state must not be duplicated in TLS.
+static UNSUPPORTED_OPERATION_TYPE: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
+
 fn type_method(ns: PyObjectRef, name: &str, function: PyObjectRef) {
     unsafe {
         pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(ns, name, function);
@@ -22,11 +27,187 @@ fn io_closed(obj: PyObjectRef) -> bool {
         .unwrap_or(false)
 }
 
+fn iobase_internal_closed(obj: PyObjectRef) -> bool {
+    crate::baseobjspace::getattr_str(obj, "__iobase_closed__")
+        .ok()
+        .is_some_and(|value| unsafe {
+            pyre_object::is_bool(value) && pyre_object::w_bool_get_value(value)
+        })
+}
+
+fn iobase_set_internal_closed(obj: PyObjectRef, closed: bool) -> Result<(), crate::PyError> {
+    if crate::baseobjspace::setdictvalue(obj, "__iobase_closed__", w_bool_from(closed)) {
+        Ok(())
+    } else {
+        Err(crate::PyError::runtime_error(
+            "_IOBase instance has no state dictionary",
+        ))
+    }
+}
+
+/// `interp_iobase.py:unsupported` — construct the module-local
+/// `UnsupportedOperation`, preserving its OSError + ValueError MRO.
+pub(crate) fn unsupported(message: &str) -> crate::PyError {
+    let Some(&type_addr) = UNSUPPORTED_OPERATION_TYPE.get() else {
+        return crate::PyError::value_error(message);
+    };
+    let _roots = pyre_object::gc_roots::push_roots();
+    let sp = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(w_str_new(message));
+    match crate::call::call_function_impl_result(
+        type_addr as PyObjectRef,
+        &[pyre_object::gc_roots::shadow_stack_get(sp)],
+    ) {
+        Ok(exc) => unsafe { crate::PyError::from_exc_object(exc) },
+        Err(error) => error,
+    }
+}
+
 fn iobase_close(args: &[PyObjectRef]) -> crate::PyResult {
-    if let Some(&self_obj) = args.first() {
-        crate::baseobjspace::setattr_str(self_obj, "closed", w_bool_from(true))?;
+    let self_obj = args
+        .first()
+        .copied()
+        .ok_or_else(|| crate::PyError::type_error("close() requires self"))?;
+    if iobase_internal_closed(self_obj) {
+        return Ok(w_none());
+    }
+    // PyPy `close_w`: `flush()` runs while `closed` is still false, and the
+    // internal flag is set in `finally`, even when the virtual flush raises.
+    let flushed = call_method_result(self_obj, "flush", &[]);
+    iobase_set_internal_closed(self_obj, true)?;
+    flushed.map(|_| w_none())
+}
+
+fn iobase_flush(args: &[PyObjectRef]) -> crate::PyResult {
+    let self_obj = args
+        .first()
+        .copied()
+        .ok_or_else(|| crate::PyError::type_error("flush() requires self"))?;
+    if iobase_internal_closed(self_obj) {
+        return Err(crate::PyError::value_error("I/O operation on closed file"));
     }
     Ok(w_none())
+}
+
+fn iobase_closed_get(args: &[PyObjectRef]) -> crate::PyResult {
+    let self_obj = args
+        .get(1)
+        .copied()
+        .ok_or_else(|| crate::PyError::type_error("descriptor requires an instance"))?;
+    Ok(w_bool_from(iobase_internal_closed(self_obj)))
+}
+
+fn iobase_check_closed(args: &[PyObjectRef]) -> crate::PyResult {
+    let self_obj = args
+        .first()
+        .copied()
+        .ok_or_else(|| crate::PyError::type_error("_checkClosed() requires self"))?;
+    let message = args
+        .get(1)
+        .copied()
+        .filter(|value| !unsafe { pyre_object::is_none(*value) })
+        .map(|value| unsafe { pyre_object::w_str_get_value(value).to_string() })
+        .unwrap_or_else(|| "I/O operation on closed file".to_string());
+    if io_closed(self_obj) {
+        Err(crate::PyError::value_error(message))
+    } else {
+        Ok(w_none())
+    }
+}
+
+fn iobase_check_capability(args: &[PyObjectRef], method: &str, message: &str) -> crate::PyResult {
+    let self_obj = args
+        .first()
+        .copied()
+        .ok_or_else(|| crate::PyError::type_error(format!("{method}() requires self")))?;
+    let capable = call_method_result(self_obj, method, &[])?;
+    if crate::baseobjspace::is_true(capable)? {
+        Ok(w_none())
+    } else {
+        Err(unsupported(message))
+    }
+}
+
+fn iobase_unsupported(args: &[PyObjectRef], operation: &str) -> crate::PyResult {
+    if args.is_empty() {
+        return Err(crate::PyError::type_error(format!(
+            "{operation}() requires self"
+        )));
+    }
+    Err(unsupported(operation))
+}
+
+fn iobase_seek(args: &[PyObjectRef]) -> crate::PyResult {
+    iobase_unsupported(args, "seek")
+}
+
+fn iobase_truncate(args: &[PyObjectRef]) -> crate::PyResult {
+    iobase_unsupported(args, "truncate")
+}
+
+fn iobase_fileno(args: &[PyObjectRef]) -> crate::PyResult {
+    iobase_unsupported(args, "fileno")
+}
+
+fn iobase_tell(args: &[PyObjectRef]) -> crate::PyResult {
+    let self_obj = args
+        .first()
+        .copied()
+        .ok_or_else(|| crate::PyError::type_error("tell() requires self"))?;
+    call_method_result(self_obj, "seek", &[w_int_new(0), w_int_new(1)])
+}
+
+fn iobase_enter(args: &[PyObjectRef]) -> crate::PyResult {
+    let self_obj = args
+        .first()
+        .copied()
+        .ok_or_else(|| crate::PyError::type_error("__enter__() requires self"))?;
+    iobase_check_closed(&[self_obj])?;
+    Ok(self_obj)
+}
+
+fn iobase_iter(args: &[PyObjectRef]) -> crate::PyResult {
+    let self_obj = args
+        .first()
+        .copied()
+        .ok_or_else(|| crate::PyError::type_error("__iter__() requires self"))?;
+    iobase_check_closed(&[self_obj])?;
+    Ok(self_obj)
+}
+
+fn iobase_next(args: &[PyObjectRef]) -> crate::PyResult {
+    let self_obj = args
+        .first()
+        .copied()
+        .ok_or_else(|| crate::PyError::type_error("__next__() requires self"))?;
+    let line = call_method_result(self_obj, "readline", &[])?;
+    if crate::baseobjspace::len_w(line)? == 0 {
+        Err(crate::PyError::stop_iteration())
+    } else {
+        Ok(line)
+    }
+}
+
+fn iobase_del(args: &[PyObjectRef]) -> crate::PyResult {
+    let Some(&self_obj) = args.first() else {
+        return Ok(w_none());
+    };
+    // PyPy `descr_del` deliberately suppresses failures while finalizing.
+    if !io_closed(self_obj) {
+        let _ = call_method_result(self_obj, "close", &[]);
+    }
+    Ok(w_none())
+}
+
+fn iobase_getstate(args: &[PyObjectRef]) -> crate::PyResult {
+    let self_obj = args
+        .first()
+        .copied()
+        .ok_or_else(|| crate::PyError::type_error("__getstate__() requires self"))?;
+    Err(crate::PyError::type_error(format!(
+        "cannot serialize '{}' object",
+        crate::type_methods::arg_type_name(self_obj)
+    )))
 }
 
 fn iobase_isatty(args: &[PyObjectRef]) -> crate::PyResult {
@@ -91,8 +272,140 @@ pub(crate) fn iobase_writelines(args: &[PyObjectRef]) -> crate::PyResult {
     Ok(w_none())
 }
 
+fn iobase_convert_size(value: Option<PyObjectRef>) -> Result<i64, crate::PyError> {
+    match value {
+        None => Ok(-1),
+        Some(value) if unsafe { pyre_object::is_none(value) } => Ok(-1),
+        Some(value) => crate::baseobjspace::int_w(crate::baseobjspace::space_index(value)?),
+    }
+}
+
+/// `interp_iobase.py:W_IOBase.readline_w` — backwards-compatible mixin over
+/// virtual `peek` and `read`, including the one-byte fallback.
+fn iobase_readline(args: &[PyObjectRef]) -> crate::PyResult {
+    let self_obj = args
+        .first()
+        .copied()
+        .ok_or_else(|| crate::PyError::type_error("readline() requires self"))?;
+    if args.len() > 2 {
+        return Err(crate::PyError::type_error(format!(
+            "readline() takes at most one argument ({} given)",
+            args.len().saturating_sub(1)
+        )));
+    }
+    let limit = iobase_convert_size(args.get(1).copied())?;
+    let peek = match crate::baseobjspace::getattr_str(self_obj, "peek") {
+        Ok(method) => Some(method),
+        Err(error) if error.kind == crate::PyErrorKind::AttributeError => None,
+        Err(error) => return Err(error),
+    };
+
+    let _roots = pyre_object::gc_roots::push_roots();
+    let sp = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(self_obj);
+    pyre_object::gc_roots::pin_root(peek.unwrap_or(PY_NULL));
+    let mut output = Vec::new();
+    while limit < 0 || output.len() < limit as usize {
+        let mut nreadahead = 1usize;
+        let peek = pyre_object::gc_roots::shadow_stack_get(sp + 1);
+        if !peek.is_null() {
+            let readahead = crate::call::call_function_impl_result(peek, &[w_int_new(1)])?;
+            if !unsafe { pyre_object::bytesobject::is_bytes_like(readahead) } {
+                return Err(crate::PyError::os_error(format!(
+                    "peek() should have returned a bytes object, not '{}'",
+                    crate::type_methods::arg_type_name(readahead)
+                )));
+            }
+            let bytes = unsafe { pyre_object::bytesobject::bytes_like_data(readahead) };
+            if !bytes.is_empty() {
+                let remaining = if limit < 0 {
+                    bytes.len()
+                } else {
+                    (limit as usize - output.len()).min(bytes.len())
+                };
+                nreadahead = bytes[..remaining]
+                    .iter()
+                    .position(|byte| *byte == b'\n')
+                    .map_or(remaining, |index| index + 1);
+            }
+        }
+
+        let read = call_method_result(
+            pyre_object::gc_roots::shadow_stack_get(sp),
+            "read",
+            &[w_int_new(nreadahead as i64)],
+        )?;
+        if !unsafe { pyre_object::bytesobject::is_bytes_like(read) } {
+            return Err(crate::PyError::os_error(format!(
+                "peek() should have returned a bytes object, not '{}'",
+                crate::type_methods::arg_type_name(read)
+            )));
+        }
+        let bytes = unsafe { pyre_object::bytesobject::bytes_like_data(read) };
+        if bytes.is_empty() {
+            break;
+        }
+        output.extend_from_slice(bytes);
+        if bytes.last() == Some(&b'\n') {
+            break;
+        }
+    }
+    Ok(pyre_object::bytesobject::w_bytes_from_bytes(&output))
+}
+
+/// `interp_iobase.py:W_IOBase.readlines_w` — consume the stream iterator,
+/// stopping after the accumulated line lengths exceed a positive hint.
+fn iobase_readlines(args: &[PyObjectRef]) -> crate::PyResult {
+    let self_obj = args
+        .first()
+        .copied()
+        .ok_or_else(|| crate::PyError::type_error("readlines() requires self"))?;
+    if args.len() > 2 {
+        return Err(crate::PyError::type_error(format!(
+            "readlines() takes at most one argument ({} given)",
+            args.len().saturating_sub(1)
+        )));
+    }
+    let hint = iobase_convert_size(args.get(1).copied())?;
+    let iterator = crate::baseobjspace::iter(self_obj)?;
+    let _roots = pyre_object::gc_roots::push_roots();
+    let sp = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(iterator);
+    let lines_sp = pyre_object::gc_roots::shadow_stack_len();
+    let mut count = 0usize;
+    let mut length = 0i64;
+    loop {
+        let line = match crate::baseobjspace::next(pyre_object::gc_roots::shadow_stack_get(sp)) {
+            Ok(line) => line,
+            Err(error) if error.kind == crate::PyErrorKind::StopIteration => break,
+            Err(error) => return Err(error),
+        };
+        length = length.saturating_add(crate::baseobjspace::len_w(line)?);
+        pyre_object::gc_roots::pin_root(line);
+        count += 1;
+        if hint > 0 && length > hint {
+            break;
+        }
+    }
+    let lines = (0..count)
+        .map(|index| pyre_object::gc_roots::shadow_stack_get(lines_sp + index))
+        .collect();
+    Ok(w_list_new(lines))
+}
+
 fn init_iobase_type(ns: PyObjectRef) {
-    type_method(ns, "closed", w_bool_from(false));
+    // interp_iobase.py:333-358 W_IOBase.typedef declares both descriptors
+    // in the raw typedef.  They must be present before the type/layout is
+    // built: setting only the hasdict/weakrefable flags afterwards leaves
+    // `_IOBase()` without the observable `__dict__` descriptor.
+    type_method(ns, "__dict__", crate::typedef::dict_descr());
+    type_method(ns, "__weakref__", crate::typedef::weakref_descr());
+    let closed_getter = crate::make_builtin_function_with_arity("closed", iobase_closed_get, 2);
+    type_method(
+        ns,
+        "closed",
+        crate::typedef::make_getset_descriptor_named(closed_getter, "closed"),
+    );
     type_method(
         ns,
         "close",
@@ -100,8 +413,74 @@ fn init_iobase_type(ns: PyObjectRef) {
     );
     type_method(
         ns,
+        "flush",
+        crate::make_builtin_function_with_arity("flush", iobase_flush, 1),
+    );
+    for (name, function) in [
+        ("seek", iobase_seek as crate::gateway::BuiltinCodeFn),
+        ("truncate", iobase_truncate as crate::gateway::BuiltinCodeFn),
+        ("fileno", iobase_fileno as crate::gateway::BuiltinCodeFn),
+    ] {
+        type_method(ns, name, crate::make_builtin_function(name, function));
+    }
+    type_method(
+        ns,
+        "tell",
+        crate::make_builtin_function_with_arity("tell", iobase_tell, 1),
+    );
+    for name in ["readable", "writable", "seekable"] {
+        type_method(
+            ns,
+            name,
+            crate::make_builtin_function_with_arity(name, |_| Ok(w_bool_from(false)), 1),
+        );
+    }
+    type_method(
+        ns,
+        "_checkReadable",
+        crate::make_builtin_function_with_arity(
+            "_checkReadable",
+            |args| iobase_check_capability(args, "readable", "File or stream is not readable"),
+            1,
+        ),
+    );
+    type_method(
+        ns,
+        "_checkWritable",
+        crate::make_builtin_function_with_arity(
+            "_checkWritable",
+            |args| iobase_check_capability(args, "writable", "File or stream is not writable"),
+            1,
+        ),
+    );
+    type_method(
+        ns,
+        "_checkSeekable",
+        crate::make_builtin_function_with_arity(
+            "_checkSeekable",
+            |args| iobase_check_capability(args, "seekable", "File or stream is not seekable"),
+            1,
+        ),
+    );
+    type_method(
+        ns,
+        "_checkClosed",
+        crate::make_builtin_function("_checkClosed", iobase_check_closed),
+    );
+    type_method(
+        ns,
         "isatty",
         crate::make_builtin_function_with_arity("isatty", iobase_isatty, 1),
+    );
+    type_method(
+        ns,
+        "readline",
+        crate::make_builtin_function("readline", iobase_readline),
+    );
+    type_method(
+        ns,
+        "readlines",
+        crate::make_builtin_function("readlines", iobase_readlines),
     );
     type_method(
         ns,
@@ -111,7 +490,7 @@ fn init_iobase_type(ns: PyObjectRef) {
     type_method(
         ns,
         "__enter__",
-        crate::make_builtin_function_with_arity("__enter__", |args| Ok(args[0]), 1),
+        crate::make_builtin_function_with_arity("__enter__", iobase_enter, 1),
     );
     type_method(
         ns,
@@ -121,6 +500,273 @@ fn init_iobase_type(ns: PyObjectRef) {
             Ok(w_none())
         }),
     );
+    type_method(
+        ns,
+        "__iter__",
+        crate::make_builtin_function_with_arity("__iter__", iobase_iter, 1),
+    );
+    type_method(
+        ns,
+        "__next__",
+        crate::make_builtin_function_with_arity("__next__", iobase_next, 1),
+    );
+    type_method(
+        ns,
+        "__del__",
+        crate::make_builtin_function_with_arity("__del__", iobase_del, 1),
+    );
+    type_method(
+        ns,
+        "__getstate__",
+        crate::make_builtin_function_with_arity("__getstate__", iobase_getstate, 1),
+    );
+}
+
+/// `interp_iobase.py:rawiobase_read_w` — the default raw `read` is a
+/// one-shot `readinto` over a freshly allocated bytearray.  A negative or
+/// omitted size delegates to the virtual `readall` method.
+fn rawiobase_read(args: &[PyObjectRef]) -> crate::PyResult {
+    let self_obj = args
+        .first()
+        .copied()
+        .ok_or_else(|| crate::PyError::type_error("read() requires self"))?;
+    if args.len() > 2 {
+        return Err(crate::PyError::type_error(format!(
+            "read() takes at most one argument ({} given)",
+            args.len().saturating_sub(1)
+        )));
+    }
+    let size = match args.get(1).copied() {
+        None => -1,
+        Some(value) if unsafe { pyre_object::is_none(value) } => -1,
+        Some(value) => crate::baseobjspace::int_w(crate::baseobjspace::space_index(value)?)?,
+    };
+    if size < 0 {
+        return call_method_result(self_obj, "readall", &[]);
+    }
+    let size = usize::try_from(size).map_err(|_| {
+        crate::PyError::overflow_error("Python int too large to convert to C ssize_t")
+    })?;
+
+    let _roots = pyre_object::gc_roots::push_roots();
+    let sp = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(self_obj);
+    pyre_object::gc_roots::pin_root(pyre_object::bytearrayobject::w_bytearray_new(size));
+    let length = call_method_result(
+        pyre_object::gc_roots::shadow_stack_get(sp),
+        "readinto",
+        &[pyre_object::gc_roots::shadow_stack_get(sp + 1)],
+    )?;
+    if unsafe { pyre_object::is_none(length) } {
+        return Ok(length);
+    }
+    let length = crate::baseobjspace::int_w(length)?;
+    if length < 0 || length as u128 > size as u128 {
+        return Err(crate::PyError::value_error(format!(
+            "readinto returned {length} outside buffer size {size}"
+        )));
+    }
+    let buffer = pyre_object::gc_roots::shadow_stack_get(sp + 1);
+    let data = unsafe { pyre_object::bytearrayobject::w_bytearray_data(buffer) };
+    Ok(pyre_object::bytesobject::w_bytes_from_bytes(
+        &data[..length as usize],
+    ))
+}
+
+/// `interp_iobase.py:rawiobase_readall_w` — repeatedly invoke the virtual
+/// limited `read(DEFAULT_BUFFER_SIZE)` until EOF.  `None` is propagated only
+/// when no bytes have yet been accumulated.
+fn rawiobase_readall(args: &[PyObjectRef]) -> crate::PyResult {
+    let self_obj = args
+        .first()
+        .copied()
+        .ok_or_else(|| crate::PyError::type_error("readall() requires self"))?;
+    if args.len() != 1 {
+        return Err(crate::PyError::type_error(format!(
+            "readall() takes no arguments ({} given)",
+            args.len().saturating_sub(1)
+        )));
+    }
+
+    let _roots = pyre_object::gc_roots::push_roots();
+    let sp = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(self_obj);
+    let mut output = Vec::new();
+    loop {
+        let data = call_method_result(
+            pyre_object::gc_roots::shadow_stack_get(sp),
+            "read",
+            &[w_int_new(8192)],
+        )?;
+        if unsafe { pyre_object::is_none(data) } {
+            if output.is_empty() {
+                return Ok(data);
+            }
+            break;
+        }
+        if !unsafe { pyre_object::bytesobject::is_bytes_like(data) } {
+            return Err(crate::PyError::type_error("read() should return bytes"));
+        }
+        let chunk = unsafe { pyre_object::bytesobject::bytes_like_data(data) };
+        if chunk.is_empty() {
+            break;
+        }
+        output.extend_from_slice(chunk);
+    }
+    Ok(pyre_object::bytesobject::w_bytes_from_bytes(&output))
+}
+
+fn init_rawiobase_type(ns: PyObjectRef) {
+    type_method(
+        ns,
+        "read",
+        crate::make_builtin_function("read", rawiobase_read),
+    );
+    type_method(
+        ns,
+        "readall",
+        crate::make_builtin_function_with_arity("readall", rawiobase_readall, 1),
+    );
+}
+
+fn buffered_iobase_read(args: &[PyObjectRef]) -> crate::PyResult {
+    iobase_unsupported(args, "read")
+}
+
+fn buffered_iobase_read1(args: &[PyObjectRef]) -> crate::PyResult {
+    iobase_unsupported(args, "read1")
+}
+
+fn buffered_iobase_write(args: &[PyObjectRef]) -> crate::PyResult {
+    iobase_unsupported(args, "write")
+}
+
+fn buffered_iobase_detach(args: &[PyObjectRef]) -> crate::PyResult {
+    iobase_unsupported(args, "detach")
+}
+
+/// `interp_bufferedio.py:W_BufferedIOBase._readinto` — acquire one writable
+/// view, call the virtual `read`/`read1` once, bounds-check the returned bytes,
+/// then copy them into the exact exported window.
+fn buffered_iobase_readinto_impl(args: &[PyObjectRef], read_once: bool) -> crate::PyResult {
+    if args.len() != 2 {
+        return Err(crate::PyError::type_error(format!(
+            "{}() takes exactly one argument ({} given)",
+            if read_once { "readinto1" } else { "readinto" },
+            args.len().saturating_sub(1)
+        )));
+    }
+    let self_obj = args[0];
+    let mut buffer = unsafe { crate::builtins::WritableBuffer::acquire(args[1]) }?;
+    let target = unsafe { buffer.as_mut_slice() };
+    let method = if read_once { "read1" } else { "read" };
+    let data = call_method_result(self_obj, method, &[w_int_new(target.len() as i64)])?;
+    if !unsafe { pyre_object::bytesobject::is_bytes_like(data) } {
+        return Err(crate::PyError::type_error(format!(
+            "{method}() should return bytes"
+        )));
+    }
+    let data = unsafe { pyre_object::bytesobject::bytes_like_data(data) };
+    if data.len() > target.len() {
+        return Err(crate::PyError::value_error(format!(
+            "{method}() returned too much data: {} bytes requested, {} returned",
+            target.len(),
+            data.len()
+        )));
+    }
+    target[..data.len()].copy_from_slice(data);
+    Ok(w_int_new(data.len() as i64))
+}
+
+fn buffered_iobase_readinto(args: &[PyObjectRef]) -> crate::PyResult {
+    buffered_iobase_readinto_impl(args, false)
+}
+
+fn buffered_iobase_readinto1(args: &[PyObjectRef]) -> crate::PyResult {
+    buffered_iobase_readinto_impl(args, true)
+}
+
+fn init_buffered_iobase_type(ns: PyObjectRef) {
+    for (name, function) in [
+        (
+            "read",
+            buffered_iobase_read as crate::gateway::BuiltinCodeFn,
+        ),
+        (
+            "read1",
+            buffered_iobase_read1 as crate::gateway::BuiltinCodeFn,
+        ),
+        (
+            "write",
+            buffered_iobase_write as crate::gateway::BuiltinCodeFn,
+        ),
+        (
+            "detach",
+            buffered_iobase_detach as crate::gateway::BuiltinCodeFn,
+        ),
+    ] {
+        type_method(ns, name, crate::make_builtin_function(name, function));
+    }
+    type_method(
+        ns,
+        "readinto",
+        crate::make_builtin_function_with_arity("readinto", buffered_iobase_readinto, 2),
+    );
+    type_method(
+        ns,
+        "readinto1",
+        crate::make_builtin_function_with_arity("readinto1", buffered_iobase_readinto1, 2),
+    );
+}
+
+fn text_iobase_read(args: &[PyObjectRef]) -> crate::PyResult {
+    iobase_unsupported(args, "read")
+}
+
+fn text_iobase_readline(args: &[PyObjectRef]) -> crate::PyResult {
+    iobase_unsupported(args, "readline")
+}
+
+fn text_iobase_write(args: &[PyObjectRef]) -> crate::PyResult {
+    iobase_unsupported(args, "write")
+}
+
+fn text_iobase_detach(args: &[PyObjectRef]) -> crate::PyResult {
+    iobase_unsupported(args, "detach")
+}
+
+fn text_iobase_none_get(args: &[PyObjectRef]) -> crate::PyResult {
+    if args.get(1).is_none() {
+        return Err(crate::PyError::type_error(
+            "descriptor requires an instance",
+        ));
+    }
+    Ok(w_none())
+}
+
+fn init_text_iobase_type(ns: PyObjectRef) {
+    for (name, function) in [
+        ("read", text_iobase_read as crate::gateway::BuiltinCodeFn),
+        (
+            "readline",
+            text_iobase_readline as crate::gateway::BuiltinCodeFn,
+        ),
+        ("write", text_iobase_write as crate::gateway::BuiltinCodeFn),
+        (
+            "detach",
+            text_iobase_detach as crate::gateway::BuiltinCodeFn,
+        ),
+    ] {
+        type_method(ns, name, crate::make_builtin_function(name, function));
+    }
+    for name in ["encoding", "newlines", "errors"] {
+        let getter = crate::make_builtin_function_with_arity(name, text_iobase_none_get, 2);
+        type_method(
+            ns,
+            name,
+            crate::typedef::make_getset_descriptor_named(getter, name),
+        );
+    }
 }
 
 fn call_method_result(obj: PyObjectRef, name: &str, args: &[PyObjectRef]) -> crate::PyResult {
@@ -241,6 +887,7 @@ crate::py_module! {
             crate::builtins::exc_exception_new,
             bases,
         );
+        let _ = UNSUPPORTED_OPERATION_TYPE.set(unsupported as usize);
         crate::module_ns_store(ns, "UnsupportedOperation", unsupported);
 
         // `_io.BlockingIOError` aliases the builtin BlockingIOError.
@@ -257,20 +904,36 @@ crate::py_module! {
             obj_type,
         );
         unsafe { pyre_object::w_type_set_acceptable_as_base_class(io_base, true) };
-        let raw_base = crate::typedef::make_builtin_type_with_base("_RawIOBase", |_| {}, io_base);
-        let buffered_base = crate::typedef::make_builtin_type_with_base(
-            "_BufferedIOBase",
-            |_| {},
+        unsafe {
+            pyre_object::w_type_set_weakrefable(io_base, true);
+            pyre_object::typeobject::w_type_set_hasdict(io_base, true);
+        }
+        let raw_base = crate::typedef::make_builtin_type_with_base(
+            "_RawIOBase",
+            init_rawiobase_type,
             io_base,
         );
-        let text_base = crate::typedef::make_builtin_type_with_base("_TextIOBase", |_| {}, io_base);
+        let buffered_base = crate::typedef::make_builtin_type_with_base(
+            "_BufferedIOBase",
+            init_buffered_iobase_type,
+            io_base,
+        );
+        let text_base = crate::typedef::make_builtin_type_with_base(
+            "_TextIOBase",
+            init_text_iobase_type,
+            io_base,
+        );
         for (name, typ) in [
             ("_IOBase", io_base),
             ("_RawIOBase", raw_base),
             ("_BufferedIOBase", buffered_base),
             ("_TextIOBase", text_base),
         ] {
-            unsafe { pyre_object::w_type_set_acceptable_as_base_class(typ, true) };
+            unsafe {
+                pyre_object::w_type_set_acceptable_as_base_class(typ, true);
+                pyre_object::w_type_set_weakrefable(typ, true);
+                pyre_object::typeobject::w_type_set_hasdict(typ, true);
+            };
             crate::module_ns_store(ns, name, typ);
         }
 

--- a/pyre/pyre-interpreter/src/module/_io/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_io/mod.rs
@@ -284,6 +284,7 @@ crate::py_module! {
             "FileIO",
             |type_ns| {
                 crate::builtins::init_file_wrapper_type(type_ns);
+                crate::builtins::init_fileio_type(type_ns);
                 type_method(
                     type_ns,
                     "__init__",
@@ -292,6 +293,9 @@ crate::py_module! {
             },
             raw_base,
         );
+        // W_IOBase carries a weakref lifeline; W_FileIO instances therefore
+        // accept weak references just like PyPy's concrete raw stream.
+        unsafe { pyre_object::w_type_set_weakrefable(file_io, true) };
         let buffered_reader = crate::typedef::make_builtin_type_with_base(
             "BufferedReader",
             init_buffered_reader_type,

--- a/pyre/pyre-interpreter/src/module/_random/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_random/mod.rs
@@ -128,11 +128,34 @@ pub struct W_Random {
     weakrefable
 )]
 impl W_Random {
-    fn __init__(
-        &mut self,
-        #[default(pyre_object::w_none())] w_anything: PyObjectRef,
-    ) -> Result<(), crate::PyError> {
-        self.seed(w_anything)
+    /// PyPy `interp_random.py:descr_new__`: allocate the requested subtype and
+    /// initialise it from the first constructor argument (or `None`).
+    ///
+    /// `__args__.firstarg()` deliberately leaves surplus-argument reporting to
+    /// the gateway.  Pyre's flat builtin ABI performs that gateway check here.
+    #[staticmethod]
+    fn __new__(_cls: PyObjectRef, args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+        let (positional, kwargs) = crate::builtins::split_builtin_kwargs(args);
+        if crate::builtins::has_real_kwargs(kwargs) {
+            return Err(crate::PyError::type_error(
+                "Random() takes no keyword arguments",
+            ));
+        }
+        let user_args = positional.get(1..).unwrap_or(&[]);
+        if user_args.len() > 1 {
+            return Err(crate::PyError::type_error(
+                "Random() requires 0 or 1 argument",
+            ));
+        }
+        let w_anything = user_args.first().copied().unwrap_or_else(w_none);
+        let _roots = pyre_object::gc_roots::push_roots();
+        pyre_object::gc_roots::pin_root(w_anything);
+        let seed_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+        let obj = W_Random::allocate_stable(W_Random::default());
+        let random = W_Random::from_obj(obj)
+            .expect("a freshly allocated _random.Random has the Random layout");
+        random.seed(pyre_object::gc_roots::shadow_stack_get(seed_slot))?;
+        Ok(obj)
     }
 
     fn random(&mut self) -> f64 {

--- a/pyre/pyre-interpreter/src/module/mmap/interp_mmap.rs
+++ b/pyre/pyre-interpreter/src/module/mmap/interp_mmap.rs
@@ -284,22 +284,6 @@ fn init_mmap_type(ns: pyre_object::PyObjectRef) {
         }),
     ) };
 
-    // `__release_buffer__` — the explicit `memoryview.release()` path; the
-    // collector-driven one goes through the buffer layer's external hook.
-    unsafe { pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
-        ns,
-        "__release_buffer__",
-        crate::make_builtin_function_with_arity(
-            "__release_buffer__",
-            |args| {
-                let obj = args.first().copied().unwrap_or(pyre_object::PY_NULL);
-                unsafe { mmap_exports_decref(obj) };
-                Ok(pyre_object::w_none())
-            },
-            2,
-        ),
-    ) };
-
     // close() — munmap and zero the pointer.
     unsafe { pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
         ns,
@@ -775,6 +759,7 @@ fn init_mmap_type(ns: pyre_object::PyObjectRef) {
             if let Some(&obj) = args.first() {
                 let p = mmap_get_attr_i64(obj, "_ptr") as usize;
                 if p != 0 {
+                    mmap_check_exports(obj, "cannot close exported pointers exist")?;
                     mmap_registry_remove(mmap_get_attr_i64(obj, "_id") as u64);
                     mmap_set_attr(obj, "_ptr", pyre_object::w_int_new(0));
                     mmap_set_attr(obj, "_len", pyre_object::w_int_new(0));

--- a/pyre/pyre-interpreter/src/module/mmap/interp_mmap.rs
+++ b/pyre/pyre-interpreter/src/module/mmap/interp_mmap.rs
@@ -97,6 +97,9 @@ fn mmap_type() -> pyre_object::PyObjectRef {
         *c.get_or_init(|| {
             let tp = crate::typedef::make_builtin_type("mmap", init_mmap_type);
             unsafe { pyre_object::typeobject::w_type_set_hasdict(tp, true) };
+            // A view dropped by the collector never reaches `__release_buffer__`,
+            // so the buffer layer needs a way back here to drop the count.
+            unsafe { pyre_object::buffer::set_external_release_hook(mmap_exports_decref) };
             tp
         })
     })
@@ -135,6 +138,42 @@ fn mmap_ptr(obj: pyre_object::PyObjectRef) -> Result<(*mut u8, usize), crate::Py
         return Err(crate::PyError::value_error("mmap closed or invalid"));
     }
     Ok((p, len))
+}
+
+/// True when `obj` is an `mmap` instance.
+#[cfg(unix)]
+pub(crate) fn is_mmap(obj: pyre_object::PyObjectRef) -> bool {
+    crate::typedef::r#type(obj).is_some_and(|tp| std::ptr::eq(tp, mmap_type()))
+}
+
+/// `_exports` — how many buffers are currently exported from the mapping.
+/// The mapping is raw foreign memory, so unmapping it under a live view is a
+/// use-after-free rather than a stale-but-owned read; `close` and `resize`
+/// refuse while this is non-zero.
+#[cfg(unix)]
+pub(crate) fn mmap_exports_incref(obj: pyre_object::PyObjectRef) {
+    let n = mmap_get_attr_i64(obj, "_exports");
+    mmap_set_attr(obj, "_exports", pyre_object::w_int_new(n + 1));
+}
+
+/// Paired with [`mmap_exports_incref`]; saturates at zero so a double release
+/// cannot wrap the count and strand the mapping.
+#[cfg(unix)]
+pub(crate) unsafe fn mmap_exports_decref(obj: pyre_object::PyObjectRef) {
+    if !is_mmap(obj) {
+        return;
+    }
+    let n = mmap_get_attr_i64(obj, "_exports");
+    mmap_set_attr(obj, "_exports", pyre_object::w_int_new((n - 1).max(0)));
+}
+
+/// Reject unmapping while a view still points into the mapping.
+#[cfg(unix)]
+fn mmap_check_exports(obj: pyre_object::PyObjectRef, message: &str) -> Result<(), crate::PyError> {
+    if mmap_get_attr_i64(obj, "_exports") > 0 {
+        return Err(crate::PyError::new(crate::PyErrorKind::BufferError, message));
+    }
+    Ok(())
 }
 
 /// `W_MMap.readbuf_w` / `writebuf_w` — expose the live mapping to the
@@ -245,6 +284,22 @@ fn init_mmap_type(ns: pyre_object::PyObjectRef) {
         }),
     ) };
 
+    // `__release_buffer__` — the explicit `memoryview.release()` path; the
+    // collector-driven one goes through the buffer layer's external hook.
+    unsafe { pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
+        ns,
+        "__release_buffer__",
+        crate::make_builtin_function_with_arity(
+            "__release_buffer__",
+            |args| {
+                let obj = args.first().copied().unwrap_or(pyre_object::PY_NULL);
+                unsafe { mmap_exports_decref(obj) };
+                Ok(pyre_object::w_none())
+            },
+            2,
+        ),
+    ) };
+
     // close() — munmap and zero the pointer.
     unsafe { pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
         ns,
@@ -255,6 +310,7 @@ fn init_mmap_type(ns: pyre_object::PyObjectRef) {
                 let obj = args.first().copied().unwrap_or(pyre_object::PY_NULL);
                 let p = mmap_get_attr_i64(obj, "_ptr") as usize;
                 if p != 0 {
+                    mmap_check_exports(obj, "cannot close exported pointers exist")?;
                     mmap_registry_remove(mmap_get_attr_i64(obj, "_id") as u64);
                     mmap_set_attr(obj, "_ptr", pyre_object::w_int_new(0));
                     mmap_set_attr(obj, "_len", pyre_object::w_int_new(0));
@@ -1051,6 +1107,7 @@ fn init_mmap_type(ns: pyre_object::PyObjectRef) {
                         "mmap can't resize a readonly or copy-on-write memory map.",
                     ));
                 }
+                mmap_check_exports(obj, "mmap can't resize with extant buffers exported.")?;
                 let (p, old_len) = mmap_ptr(obj)?;
                 let newsize = unsafe { pyre_object::w_int_get_value(args[1]) };
                 if newsize < 0 {

--- a/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
+++ b/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
@@ -639,6 +639,54 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
         ),
     );
 
+    // Python 3.14 `os.readinto`: acquire one writable buffer export for the
+    // complete `_Py_read(fd, buffer->buf, buffer->len)` call and return the
+    // number of bytes transferred without allocating an intermediate bytes
+    // object on the real-host path.
+    crate::module_ns_store(
+        ns,
+        "readinto",
+        crate::make_builtin_function_with_arity(
+            "readinto",
+            |args| {
+                let fd_value = unsafe { pyre_object::w_int_get_value(args[0]) };
+                let fd = libc::c_int::try_from(fd_value).map_err(|_| {
+                    crate::PyError::overflow_error("fd is greater than maximum")
+                })?;
+                let mut buffer = unsafe { crate::builtins::WritableBuffer::acquire(args[1]) }?;
+                let target = unsafe { buffer.as_mut_slice() };
+                #[cfg(not(feature = "sandbox"))]
+                let result = loop {
+                    let result = unsafe {
+                        libc::read(
+                            fd,
+                            target.as_mut_ptr() as *mut libc::c_void,
+                            target.len() as _,
+                        )
+                    };
+                    if result >= 0 {
+                        break result as i64;
+                    }
+                    let error = std::io::Error::last_os_error();
+                    if error.raw_os_error() == Some(libc::EINTR) {
+                        continue;
+                    }
+                    return Err(io_err(error, ""));
+                };
+                #[cfg(feature = "sandbox")]
+                let result = {
+                    let data = crate::host_seam::ops::read(fd, target.len() as i64)
+                        .map_err(|error| crate::host_seam::seam_os_err(error, ""))?;
+                    let length = data.len().min(target.len());
+                    target[..length].copy_from_slice(&data[..length]);
+                    length as i64
+                };
+                Ok(pyre_object::w_int_new(result))
+            },
+            2,
+        ),
+    );
+
     // ── posix.write(fd, data) → nbytes ──
     crate::module_ns_store(
         ns,
@@ -650,17 +698,10 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                     return Err(crate::PyError::type_error("write() requires 2 arguments"));
                 }
                 let fd = (unsafe { pyre_object::w_int_get_value(args[0]) }) as libc::c_int;
-                let data = unsafe {
-                    if pyre_object::bytesobject::is_bytes_like(args[1]) {
-                        pyre_object::bytesobject::bytes_like_data(args[1]).to_vec()
-                    } else if pyre_object::is_str(args[1]) {
-                        pyre_object::w_str_get_value(args[1]).as_bytes().to_vec()
-                    } else {
-                        return Err(crate::PyError::type_error(
-                            "write() arg 2 must be bytes-like",
-                        ));
-                    }
-                };
+                // CPython `os_write_impl` receives a `Py_buffer`: text is not
+                // accepted, while every contiguous readable exporter is.
+                let data = unsafe { crate::builtins::file_write_buffer_bytes(args[1]) }
+                    .map_err(|_| crate::PyError::type_error("write() arg 2 must be bytes-like"))?;
                 #[cfg(not(feature = "sandbox"))]
                 let ret = {
                     let ret = unsafe {

--- a/pyre/pyre-interpreter/src/module/struct/mod.rs
+++ b/pyre/pyre-interpreter/src/module/struct/mod.rs
@@ -652,39 +652,16 @@ unsafe fn writebuf<'a>(obj: PyObjectRef) -> Result<&'a mut [u8], crate::PyError>
 struct PackIntoExport(PyObjectRef);
 
 impl PackIntoExport {
-    /// Returns `None` for a target that carries no export count; `writebuf`
-    /// rejects everything except the two kinds handled here.
+    /// Returns `None` for an immutable target that carries no export count;
+    /// `writebuf` rejects every unsupported exporter before use.
     unsafe fn acquire(obj: PyObjectRef) -> Option<Self> {
-        unsafe {
-            if bytearrayobject::is_bytearray(obj) {
-                bytearrayobject::w_bytearray_exports_incref(obj);
-            } else if memoryview::is_w_memoryview(obj) {
-                memoryview::w_memoryview_exports_incref(obj);
-            } else {
-                #[cfg(all(unix, not(feature = "sandbox")))]
-                if crate::module::mmap::interp_mmap::is_mmap(obj) {
-                    crate::module::mmap::interp_mmap::mmap_exports_incref(obj);
-                    return Some(Self(obj));
-                }
-                return None;
-            }
-        }
-        Some(Self(obj))
+        unsafe { crate::builtins::buffer_export_incref(obj).then_some(Self(obj)) }
     }
 }
 
 impl Drop for PackIntoExport {
     fn drop(&mut self) {
-        unsafe {
-            if bytearrayobject::is_bytearray(self.0) {
-                bytearrayobject::w_bytearray_exports_decref(self.0);
-            } else if memoryview::is_w_memoryview(self.0) {
-                memoryview::w_memoryview_exports_decref(self.0);
-            } else {
-                #[cfg(all(unix, not(feature = "sandbox")))]
-                crate::module::mmap::interp_mmap::mmap_exports_decref(self.0);
-            }
-        }
+        unsafe { crate::builtins::buffer_export_decref(self.0) }
     }
 }
 
@@ -716,12 +693,14 @@ fn do_pack_into(
         offset += buflen;
     }
     if buflen - offset < size {
+        // `r_uint(s_size + offset)` in PyPy: the diagnostic deliberately
+        // represents `sys.maxsize + size` above the signed machine range.
+        // Add in the unsigned domain so CPython 3.14's boundary message does
+        // not turn into a Rust debug-overflow panic.
+        let required = (offset as u64) + (size as u64);
         return Err(struct_error(format!(
             "pack_into requires a buffer of at least {} bytes for packing {} bytes at offset {} (actual buffer size is {})",
-            size + offset,
-            size,
-            offset,
-            buflen
+            required, size, offset, buflen
         )));
     }
     let packed = pack_values(&parsed, values)?;
@@ -884,12 +863,12 @@ fn do_unpack_from(format: &str, buf: &[u8], offset: i64) -> Result<PyObjectRef, 
         offset += buflen;
     }
     if buflen - offset < size as i64 {
+        // Same `r_uint(s_size + offset)` boundary calculation as
+        // `do_pack_into`; `sys.maxsize + size` is a valid diagnostic value.
+        let required = (offset as u64) + (size as u64);
         return Err(struct_error(format!(
             "unpack_from requires a buffer of at least {} bytes for unpacking {} bytes at offset {} (actual buffer size is {})",
-            size as i64 + offset,
-            size,
-            offset,
-            buflen
+            required, size, offset, buflen
         )));
     }
     let start = offset as usize;
@@ -1150,6 +1129,10 @@ pub mod unpack_iter {
         buffer: PyObjectRef,
         size: i64,
         index: i64,
+        /// `self.view is not None` (`interp_struct.py:212-224`).  A true
+        /// value owns exactly one exporter count and is cleared on normal
+        /// exhaustion or from the native finalizer.
+        export_active: bool,
     }
 
     #[crate::pyre_methods]
@@ -1161,8 +1144,14 @@ pub mod unpack_iter {
         /// `descr_next` — unpack the next record, raising `StopIteration`
         /// at the end of the buffer.
         fn __next__(&mut self) -> Result<PyObjectRef, crate::PyError> {
+            if self.buffer.is_null() {
+                return Err(crate::PyError::new(crate::PyErrorKind::StopIteration, ""));
+            }
             let buf = unsafe { readbuf(self.buffer)? };
             if self.index >= buf.len() as i64 {
+                // CPython/PyPy release the inline Py_buffer eagerly at the
+                // first exhausted `next()`, rather than waiting for GC.
+                self.release_export();
                 return Err(crate::PyError::new(crate::PyErrorKind::StopIteration, ""));
             }
             let start = self.index as usize;
@@ -1175,11 +1164,28 @@ pub mod unpack_iter {
 
         /// `descr_length_hint` — records remaining.
         fn __length_hint__(&self) -> PyObjectRef {
+            if self.buffer.is_null() {
+                return w_int_new(0);
+            }
             let remaining = match unsafe { readbuf(self.buffer) } {
                 Ok(buf) => (buf.len() as i64 - self.index) / self.size,
                 Err(_) => 0,
             };
             w_int_new(remaining)
+        }
+
+        /// `_finalize_` / the exhausted branch share `_release_buf`'s
+        /// idempotent take-then-release shape.
+        pub(crate) fn release_export(&mut self) {
+            if self.buffer.is_null() {
+                return;
+            }
+            if self.export_active {
+                self.export_active = false;
+                unsafe { crate::builtins::buffer_export_decref(self.buffer) };
+            }
+            self.buffer = PY_NULL;
+            self.format = PY_NULL;
         }
     }
 
@@ -1206,7 +1212,8 @@ pub mod unpack_iter {
                 "iterative unpacking requires a buffer of a multiple of {size} bytes"
             )));
         }
-        Ok(W_UnpackIter::allocate_stable(W_UnpackIter {
+        let export_active = unsafe { crate::builtins::buffer_export_incref(buffer) };
+        let w_iter = W_UnpackIter::allocate_stable(W_UnpackIter {
             ob: pyre_object::PyObject {
                 ob_type: std::ptr::null(),
                 w_class: std::ptr::null_mut(),
@@ -1215,7 +1222,12 @@ pub mod unpack_iter {
             buffer,
             size,
             index: 0,
-        }))
+            export_active,
+        });
+        if export_active {
+            crate::executioncontext::register_native_buffer_finalizer(w_iter);
+        }
+        Ok(w_iter)
     }
 }
 

--- a/pyre/pyre-interpreter/src/module/struct/mod.rs
+++ b/pyre/pyre-interpreter/src/module/struct/mod.rs
@@ -4,8 +4,9 @@
 //! `FormatIterator.interpret`) plus the standard and native format tables
 //! (`standardfmttable.py`, `nativefmttable.py`): byte-order/size/alignment
 //! decoding from the leading char, repetition counts, `needcount` codes
-//! (`x`/`s`/`p`), per-code range checks, and the `s`/`c`/`x`/`p`/`?`/`e`
-//! string, char, pad, pascal, bool and half-float codes.  `struct.error`
+//! (`x`/`s`/`p`), per-code range checks, and the `s`/`c`/`x`/`p`/`?`/`e`/
+//! `F`/`D` string, char, pad, pascal, bool, half-float and complex codes.
+//! `struct.error`
 //! is `space.new_exception_class("struct.error", space.w_Exception)`
 //! (`interp_struct.py:20 Cache`).
 
@@ -73,6 +74,8 @@ enum Code {
     HalfFloat,
     Float,
     Double,
+    FloatComplex,
+    DoubleComplex,
     Int { signed: bool },
 }
 
@@ -156,6 +159,11 @@ fn lookup_fmt(c: char, native: bool) -> Option<Fmt> {
             'e' => (Code::HalfFloat, 2),
             'f' => (Code::Float, 4),
             'd' => (Code::Double, 8),
+            // CPython 3.14 native_table: complex storage is two adjacent
+            // component values, aligned like one component rather than like
+            // the full 8/16-byte field.
+            'F' => (Code::FloatComplex, 8),
+            'D' => (Code::DoubleComplex, 16),
             _ => return None,
         }
     } else {
@@ -172,13 +180,23 @@ fn lookup_fmt(c: char, native: bool) -> Option<Fmt> {
             'e' => (Code::HalfFloat, 2),
             'f' => (Code::Float, 4),
             'd' => (Code::Double, 8),
+            'F' => (Code::FloatComplex, 8),
+            'D' => (Code::DoubleComplex, 16),
             // `n`/`N`/`P` do not exist in standard sizes.
             _ => return None,
         }
     };
     // Scalar types are naturally aligned on the targets pyre builds for;
     // in standard mode all alignments collapse to 1.
-    let alignment = if native { size.max(1) } else { 1 };
+    let alignment = if native {
+        match code {
+            Code::FloatComplex => std::mem::align_of::<f32>(),
+            Code::DoubleComplex => std::mem::align_of::<f64>(),
+            _ => size.max(1),
+        }
+    } else {
+        1
+    };
     Some(Fmt {
         code,
         size,
@@ -479,6 +497,44 @@ unsafe fn pack_float_code(
     Ok(())
 }
 
+/// CPython 3.14 `np_*_complex` / `bp_*_complex` / `lp_*_complex` — coerce
+/// one Python value with `PyComplex_AsCComplex`, then encode the real and
+/// imaginary components independently in that order.
+unsafe fn pack_complex_code(
+    out: &mut Vec<u8>,
+    arg: PyObjectRef,
+    code: Code,
+    bigendian: bool,
+) -> Result<(), crate::PyError> {
+    let (real, imag) = crate::builtins::complex_coerce(arg)
+        .map_err(|_| struct_error("required argument is not a complex"))?;
+    match code {
+        Code::FloatComplex => {
+            for component in [real, imag] {
+                let value = component as f32;
+                // CPython 3.14 `init_endian_tables` replaces the host-endian
+                // standard F row with `np_float_complex`, whose C float cast
+                // permits infinity.  The opposite-endian `PyFloat_Pack4`
+                // rows retain their overflow check.
+                if bigendian != native_is_bigendian()
+                    && component.is_finite()
+                    && value.is_infinite()
+                {
+                    return Err(struct_overflow("float too large to pack with f format"));
+                }
+                push_endian(out, &value.to_bits().to_le_bytes(), bigendian);
+            }
+        }
+        Code::DoubleComplex => {
+            for component in [real, imag] {
+                push_endian(out, &component.to_bits().to_le_bytes(), bigendian);
+            }
+        }
+        _ => unreachable!(),
+    }
+    Ok(())
+}
+
 fn push_endian(out: &mut Vec<u8>, le: &[u8], bigendian: bool) {
     if bigendian {
         out.extend(le.iter().rev());
@@ -605,6 +661,13 @@ fn pack_values(parsed: &Parsed, values: &[PyObjectRef]) -> Result<Vec<u8>, crate
                     unsafe { pack_float_code(&mut out, arg, fmt.code, parsed.bigendian)? };
                 }
             }
+            Code::FloatComplex | Code::DoubleComplex => {
+                for _ in 0..rep {
+                    let arg = values[ai];
+                    ai += 1;
+                    unsafe { pack_complex_code(&mut out, arg, fmt.code, parsed.bigendian)? };
+                }
+            }
         }
     }
     Ok(out)
@@ -616,6 +679,9 @@ unsafe fn writebuf<'a>(obj: PyObjectRef) -> Result<&'a mut [u8], crate::PyError>
     unsafe {
         if bytearrayobject::is_bytearray(obj) {
             return Ok(bytearrayobject::w_bytearray_data_mut(obj));
+        }
+        if interp_array::is_array(obj) {
+            return Ok(interp_array::w_array_vec_mut(obj).as_mut_slice());
         }
         // `W_MMap.writebuf_w` — the live mapping, unless it was opened
         // read-only.
@@ -762,6 +828,35 @@ fn unpack_float(raw: &[u8], code: Code, bigendian: bool) -> PyObjectRef {
     }
 }
 
+/// CPython 3.14 `nu_*_complex` / `bu_*_complex` / `lu_*_complex` — decode
+/// two adjacent components and preserve their exact zero/NaN/Inf bit signs.
+fn unpack_complex(raw: &[u8], code: Code, bigendian: bool) -> PyObjectRef {
+    let (real, imag) = match code {
+        Code::FloatComplex => {
+            let mut real = [0u8; 4];
+            let mut imag = [0u8; 4];
+            copy_endian(&raw[..4], &mut real, bigendian);
+            copy_endian(&raw[4..8], &mut imag, bigendian);
+            (
+                f32::from_bits(u32::from_le_bytes(real)) as f64,
+                f32::from_bits(u32::from_le_bytes(imag)) as f64,
+            )
+        }
+        Code::DoubleComplex => {
+            let mut real = [0u8; 8];
+            let mut imag = [0u8; 8];
+            copy_endian(&raw[..8], &mut real, bigendian);
+            copy_endian(&raw[8..16], &mut imag, bigendian);
+            (
+                f64::from_bits(u64::from_le_bytes(real)),
+                f64::from_bits(u64::from_le_bytes(imag)),
+            )
+        }
+        _ => unreachable!(),
+    };
+    w_complex_new(real, imag)
+}
+
 fn copy_endian(raw: &[u8], out: &mut [u8], bigendian: bool) {
     let n = out.len();
     for i in 0..n {
@@ -837,6 +932,16 @@ fn unpack_units(parsed: &Parsed, buf: &[u8]) -> Result<PyObjectRef, crate::PyErr
             Code::Float | Code::Double | Code::HalfFloat => {
                 for _ in 0..rep {
                     out.push(unpack_float(
+                        &buf[pos..pos + fmt.size],
+                        fmt.code,
+                        parsed.bigendian,
+                    ));
+                    pos += fmt.size;
+                }
+            }
+            Code::FloatComplex | Code::DoubleComplex => {
+                for _ in 0..rep {
+                    out.push(unpack_complex(
                         &buf[pos..pos + fmt.size],
                         fmt.code,
                         parsed.bigendian,
@@ -998,6 +1103,21 @@ pub struct W_Struct {
     size: i64,
 }
 
+impl W_Struct {
+    /// CPython 3.14 `ENSURE_STRUCT_IS_READY` — every operation other than the
+    /// `size` getter rejects an object allocated with `Struct.__new__` but not
+    /// initialized yet.
+    fn ensure_ready(&self) -> Result<(), crate::PyError> {
+        if self.size < 0 {
+            Err(crate::PyError::runtime_error(
+                "Struct object is not initialized",
+            ))
+        } else {
+            Ok(())
+        }
+    }
+}
+
 #[crate::pyre_methods(doc = "Struct(fmt) --> compiled struct object")]
 impl W_Struct {
     /// `interp_struct.py:256 descr__new__` — the format string is consumed by
@@ -1026,8 +1146,9 @@ impl W_Struct {
     }
 
     #[getter]
-    fn format(&self) -> PyObjectRef {
-        self.format
+    fn format(&self) -> Result<PyObjectRef, crate::PyError> {
+        self.ensure_ready()?;
+        Ok(self.format)
     }
 
     #[getter]
@@ -1040,6 +1161,7 @@ impl W_Struct {
     /// The whole-args-slice ABI hands `args[0]` = self; the packed values
     /// are `args[1..]`.
     fn pack(&self, args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+        self.ensure_ready()?;
         let format = majit_metainterp::jit::promote_string(self.format);
         let fmt = unsafe { w_str_get_value(format) };
         do_pack(fmt, &args[1..])
@@ -1048,6 +1170,7 @@ impl W_Struct {
     /// `interp_struct.py:234 descr_unpack` —
     /// `do_unpack(space, jit.promote_string(self.format), w_str)`.
     fn unpack(&self, w_str: PyObjectRef) -> Result<PyObjectRef, crate::PyError> {
+        self.ensure_ready()?;
         let format = majit_metainterp::jit::promote_string(self.format);
         let fmt = unsafe { w_str_get_value(format) };
         let buf = unsafe { readbuf(w_str)? };
@@ -1059,6 +1182,7 @@ impl W_Struct {
     /// Whole-args ABI: `args[0]` = self, `args[1]` = buffer, `args[2]` =
     /// offset, `args[3..]` = the packed values.
     fn pack_into(&self, args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+        self.ensure_ready()?;
         let format = majit_metainterp::jit::promote_string(self.format);
         let fmt = unsafe { w_str_get_value(format) };
         let (pos, _) = crate::builtins::split_builtin_kwargs(&args[1..]);
@@ -1075,6 +1199,7 @@ impl W_Struct {
     /// `do_unpack_from(space, jit.promote_string(self.format), buffer, offset)`.
     /// `buffer` / `offset` are accepted positionally or by keyword.
     fn unpack_from(&self, args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+        self.ensure_ready()?;
         let format = majit_metainterp::jit::promote_string(self.format);
         let fmt = unsafe { w_str_get_value(format) };
         let (buffer, offset) = resolve_buffer_offset(&args[1..])?;
@@ -1085,6 +1210,7 @@ impl W_Struct {
     /// `interp_struct.py:241 descr_iter_unpack` — a `W_UnpackIter` over
     /// `buffer`.  Whole-args ABI: `args[0]` = self, `args[1]` = buffer.
     fn iter_unpack(&self, args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+        self.ensure_ready()?;
         let buffer = args
             .get(1)
             .copied()
@@ -1093,9 +1219,17 @@ impl W_Struct {
     }
 
     /// `_struct.Struct.__repr__` — `Struct('<format>')`.
-    fn __repr__(&self) -> PyObjectRef {
+    fn __repr__(&self) -> Result<String, crate::PyError> {
+        self.ensure_ready()?;
         let fmt = unsafe { w_str_get_value(self.format) };
-        w_str_new(&format!("Struct('{fmt}')"))
+        Ok(format!("Struct('{fmt}')"))
+    }
+
+    /// CPython exposes a dedicated `Struct.__sizeof__` and applies the same
+    /// readiness guard before consulting the compiled format allocation.
+    fn __sizeof__(&self) -> Result<i64, crate::PyError> {
+        self.ensure_ready()?;
+        Ok(std::mem::size_of::<W_Struct>() as i64)
     }
 }
 
@@ -1300,8 +1434,9 @@ crate::py_module! {
             let fmt = format_to_string(fmt_obj)?;
             parse_format(&fmt)?.calcsize()
         }
-        fn unpack(fmt_obj: PyObjectRef, buf: &[u8]) -> Result<PyObjectRef, crate::PyError> {
+        fn unpack(fmt_obj: PyObjectRef, buffer: PyObjectRef) -> Result<PyObjectRef, crate::PyError> {
             let fmt = format_to_string(fmt_obj)?;
+            let buf = unsafe { readbuf(buffer)? };
             do_unpack(&fmt, buf)
         }
     },

--- a/pyre/pyre-interpreter/src/module/struct/mod.rs
+++ b/pyre/pyre-interpreter/src/module/struct/mod.rs
@@ -612,6 +612,15 @@ unsafe fn writebuf<'a>(obj: PyObjectRef) -> Result<&'a mut [u8], crate::PyError>
         if bytearrayobject::is_bytearray(obj) {
             return Ok(bytearrayobject::w_bytearray_data_mut(obj));
         }
+        // `W_MMap.writebuf_w` — the live mapping, unless it was opened
+        // read-only.
+        #[cfg(all(unix, not(feature = "sandbox")))]
+        if let Some(view) = crate::module::mmap::interp_mmap::mmap_buffer_view(obj) {
+            let (address, length, readonly) = view?;
+            if !readonly {
+                return Ok(std::slice::from_raw_parts_mut(address as *mut u8, length));
+            }
+        }
         if memoryview::is_w_memoryview(obj) {
             crate::builtins::memoryview_check_released(obj)?;
             if memoryview::w_memoryview_readonly(obj) {
@@ -652,6 +661,11 @@ impl PackIntoExport {
             } else if memoryview::is_w_memoryview(obj) {
                 memoryview::w_memoryview_exports_incref(obj);
             } else {
+                #[cfg(all(unix, not(feature = "sandbox")))]
+                if crate::module::mmap::interp_mmap::is_mmap(obj) {
+                    crate::module::mmap::interp_mmap::mmap_exports_incref(obj);
+                    return Some(Self(obj));
+                }
                 return None;
             }
         }
@@ -664,8 +678,11 @@ impl Drop for PackIntoExport {
         unsafe {
             if bytearrayobject::is_bytearray(self.0) {
                 bytearrayobject::w_bytearray_exports_decref(self.0);
-            } else {
+            } else if memoryview::is_w_memoryview(self.0) {
                 memoryview::w_memoryview_exports_decref(self.0);
+            } else {
+                #[cfg(all(unix, not(feature = "sandbox")))]
+                crate::module::mmap::interp_mmap::mmap_exports_decref(self.0);
             }
         }
     }
@@ -1216,6 +1233,12 @@ unsafe fn readbuf<'a>(obj: PyObjectRef) -> Result<&'a [u8], crate::PyError> {
     unsafe {
         if bytesobject::is_bytes_like(obj) {
             return Ok(bytesobject::bytes_like_data(obj));
+        }
+        // `W_MMap.readbuf_w` — the live mapping.
+        #[cfg(all(unix, not(feature = "sandbox")))]
+        if let Some(view) = crate::module::mmap::interp_mmap::mmap_buffer_view(obj) {
+            let (address, length, _readonly) = view?;
+            return Ok(std::slice::from_raw_parts(address as *const u8, length));
         }
         if interp_array::is_array(obj) {
             return Ok(interp_array::w_array_bytes(obj));

--- a/pyre/pyre-interpreter/src/module/struct/mod.rs
+++ b/pyre/pyre-interpreter/src/module/struct/mod.rs
@@ -550,21 +550,26 @@ fn pack_values(parsed: &Parsed, values: &[PyObjectRef]) -> Result<Vec<u8>, crate
                 let arg = values[ai];
                 ai += 1;
                 let data = unsafe { accept_bytes(arg, "argument for 'p' must be a bytes object")? };
+                // CPython 3.14 accepts `0p`: it still consumes one argument,
+                // but the zero-width field has no prefix or payload bytes.
+                // Older PyPy raises `bad '0p'`; pyre follows the 3.14 target.
+                if rep == 0 {
+                    continue;
+                }
                 // `pack_pascal` — length prefix byte (clamped to count-1 and
-                // 255) then the string, padded to `count` bytes total.  A
-                // `0p` field has no room for even the length byte.
+                // 255) then the string, padded to `count` bytes total.
                 let mut prefix = data.len();
                 if prefix >= rep {
-                    if rep == 0 {
-                        return Err(struct_error("bad '0p' in struct format"));
-                    }
                     prefix = rep - 1;
                 }
                 if prefix > 255 {
                     prefix = 255;
                 }
                 out.push(prefix as u8);
-                pack_string_bytes(&mut out, &data[..prefix], rep - 1);
+                // PyPy `_pack_string(fmtiter, string, count-1)`: only the
+                // one-byte length prefix is capped at 255.  The field still
+                // stores as much payload as its full `count - 1` width.
+                pack_string_bytes(&mut out, data, rep - 1);
             }
             Code::Bool => {
                 for _ in 0..rep {
@@ -801,9 +806,11 @@ fn unpack_units(parsed: &Parsed, buf: &[u8]) -> Result<PyObjectRef, crate::PyErr
             }
             Code::Pascal => {
                 // `unpack_pascal` — first byte is the length, clamped to the
-                // field width; the value is the following bytes.
+                // field width; the value is the following bytes.  CPython
+                // 3.14's zero-width form contributes one empty bytes value.
                 if rep == 0 {
-                    return Err(struct_error("bad '0p' in struct format"));
+                    out.push(w_bytes_from_bytes(&[]));
+                    continue;
                 }
                 let data = &buf[pos..pos + rep];
                 let end = (1 + data[0] as usize).min(rep);
@@ -1173,7 +1180,9 @@ pub mod unpack_iter {
             };
             w_int_new(remaining)
         }
+    }
 
+    impl W_UnpackIter {
         /// `_finalize_` / the exhausted branch share `_release_buf`'s
         /// idempotent take-then-release shape.
         pub(crate) fn release_export(&mut self) {
@@ -1200,7 +1209,14 @@ pub mod unpack_iter {
         // Force the type's method table to be built before allocating (the
         // `unpack_iterator` type is not exposed as a module attribute, so
         // nothing else triggers `type_object()`).
-        let _ = type_object();
+        let iter_type = type_object();
+        // W_UnpackIter.typedef has no `__new__` in PyPy.  Preserve that
+        // TypeDef shape: the implementation type is returned by `type(it)`
+        // but cannot be instantiated or used as a base class.
+        unsafe {
+            pyre_object::w_type_set_acceptable_as_base_class(iter_type, false);
+            pyre_object::w_type_set_disallow_instantiation(iter_type);
+        }
         let buf = unsafe { readbuf(buffer)? };
         if size <= 0 {
             return Err(struct_error(format!(

--- a/pyre/pyre-interpreter/src/module/struct/mod.rs
+++ b/pyre/pyre-interpreter/src/module/struct/mod.rs
@@ -636,6 +636,41 @@ unsafe fn writebuf<'a>(obj: PyObjectRef) -> Result<&'a mut [u8], crate::PyError>
     }
 }
 
+/// One export held on a `pack_into` target for as long as the writable slice
+/// is live.  `s_pack_into` keeps the buffer exported across `s_pack_internal`,
+/// so a value coercion that re-enters Python and calls `release()` — or
+/// resizes the exporter — raises instead of leaving the saved slice stale.
+struct PackIntoExport(PyObjectRef);
+
+impl PackIntoExport {
+    /// Returns `None` for a target that carries no export count; `writebuf`
+    /// rejects everything except the two kinds handled here.
+    unsafe fn acquire(obj: PyObjectRef) -> Option<Self> {
+        unsafe {
+            if bytearrayobject::is_bytearray(obj) {
+                bytearrayobject::w_bytearray_exports_incref(obj);
+            } else if memoryview::is_w_memoryview(obj) {
+                memoryview::w_memoryview_exports_incref(obj);
+            } else {
+                return None;
+            }
+        }
+        Some(Self(obj))
+    }
+}
+
+impl Drop for PackIntoExport {
+    fn drop(&mut self) {
+        unsafe {
+            if bytearrayobject::is_bytearray(self.0) {
+                bytearrayobject::w_bytearray_exports_decref(self.0);
+            } else {
+                memoryview::w_memoryview_exports_decref(self.0);
+            }
+        }
+    }
+}
+
 /// `do_pack_into` — pack `values` into `buffer` starting at `offset`,
 /// resolving a negative offset against the buffer end.
 fn do_pack_into(
@@ -646,6 +681,7 @@ fn do_pack_into(
 ) -> Result<PyObjectRef, crate::PyError> {
     let parsed = parse_format(format)?;
     let size = parsed.calcsize()?;
+    let _export = unsafe { PackIntoExport::acquire(buffer) };
     let buf = unsafe { writebuf(buffer)? };
     let buflen = buf.len() as i64;
     let mut offset = offset;

--- a/pyre/pyre-interpreter/src/module/sys/vm.rs
+++ b/pyre/pyre-interpreter/src/module/sys/vm.rs
@@ -370,7 +370,7 @@ fn sys_unraisablehook(args: &[PyObjectRef]) -> crate::PyResult {
 /// out lets the JIT bypass invoke the same logic without going through the
 /// builtin call dispatch.
 pub fn exc_info_direct() -> PyObjectRef {
-    let exc = crate::eval::get_current_exception();
+    let exc = crate::eval::get_sys_exception();
     unsafe {
         if exc.is_null() || pyre_object::is_none(exc) || !pyre_object::is_exception(exc) {
             w_tuple_new(vec![w_none(), w_none(), w_none()])
@@ -1131,7 +1131,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
         make_builtin_function_with_arity(
             "exception",
             |_| {
-                let exc = crate::eval::get_current_exception();
+                let exc = crate::eval::get_sys_exception();
                 Ok(unsafe {
                     if exc.is_null() || !pyre_object::is_exception(exc) {
                         w_none()

--- a/pyre/pyre-interpreter/src/module/sys/vm.rs
+++ b/pyre/pyre-interpreter/src/module/sys/vm.rs
@@ -332,6 +332,101 @@ fn sys_setprofile_impl(args: &[PyObjectRef]) -> crate::PyResult {
     Ok(w_none())
 }
 
+fn asyncgen_hooks_type() -> PyObjectRef {
+    static TYPE: OnceLock<usize> = OnceLock::new();
+    *TYPE.get_or_init(|| {
+        crate::_structseq::make_struct_seq("asyncgen_hooks", &["firstiter", "finalizer"]) as usize
+    }) as PyObjectRef
+}
+
+fn sys_get_asyncgen_hooks_impl(_args: &[PyObjectRef]) -> crate::PyResult {
+    let ec = current_execution_context();
+    let (firstiter, finalizer) = if ec.is_null() {
+        (w_none(), w_none())
+    } else {
+        unsafe {
+            (
+                if (*ec).w_asyncgen_firstiter_fn.is_null() {
+                    w_none()
+                } else {
+                    (*ec).w_asyncgen_firstiter_fn
+                },
+                if (*ec).w_asyncgen_finalizer_fn.is_null() {
+                    w_none()
+                } else {
+                    (*ec).w_asyncgen_finalizer_fn
+                },
+            )
+        }
+    };
+    Ok(crate::_structseq::new_instance(
+        asyncgen_hooks_type(),
+        vec![firstiter, finalizer],
+    ))
+}
+
+fn sys_set_asyncgen_hooks_impl(args: &[PyObjectRef]) -> crate::PyResult {
+    let (positional, kwargs) = crate::builtins::split_builtin_kwargs(args);
+    crate::builtins::kwarg_reject_unknown(
+        kwargs,
+        &["firstiter", "finalizer"],
+        "set_asyncgen_hooks",
+    )?;
+    if positional.len() > 2 {
+        return Err(crate::PyError::type_error(format!(
+            "set_asyncgen_hooks() takes at most 2 arguments ({} given)",
+            positional.len()
+        )));
+    }
+    let kw_firstiter = crate::builtins::kwarg_get(kwargs, "firstiter");
+    let kw_finalizer = crate::builtins::kwarg_get(kwargs, "finalizer");
+    if !positional.is_empty() && kw_firstiter.is_some() {
+        return Err(crate::PyError::type_error(
+            "set_asyncgen_hooks() got multiple values for argument 'firstiter'",
+        ));
+    }
+    if positional.len() > 1 && kw_finalizer.is_some() {
+        return Err(crate::PyError::type_error(
+            "set_asyncgen_hooks() got multiple values for argument 'finalizer'",
+        ));
+    }
+    let firstiter = positional.first().copied().or(kw_firstiter);
+    let finalizer = positional.get(1).copied().or(kw_finalizer);
+    let ec = current_execution_context();
+    if !ec.is_null() {
+        unsafe {
+            // PyPy vm.py:set_asyncgen_hooks updates and validates finalizer
+            // first, then firstiter.  Preserve that observable ordering when
+            // the second argument is invalid.
+            if let Some(value) = finalizer {
+                if is_none(value) {
+                    (*ec).w_asyncgen_finalizer_fn = PY_NULL;
+                } else if crate::baseobjspace::callable_w(value) {
+                    (*ec).w_asyncgen_finalizer_fn = value;
+                } else {
+                    return Err(crate::PyError::type_error(format!(
+                        "callable finalizer expected, got {}",
+                        crate::type_methods::arg_type_name(value)
+                    )));
+                }
+            }
+            if let Some(value) = firstiter {
+                if is_none(value) {
+                    (*ec).w_asyncgen_firstiter_fn = PY_NULL;
+                } else if crate::baseobjspace::callable_w(value) {
+                    (*ec).w_asyncgen_firstiter_fn = value;
+                } else {
+                    return Err(crate::PyError::type_error(format!(
+                        "callable firstiter expected, got {}",
+                        crate::type_methods::arg_type_name(value)
+                    )));
+                }
+            }
+        }
+    }
+    Ok(w_none())
+}
+
 fn sys_unraisablehook(args: &[PyObjectRef]) -> crate::PyResult {
     let Some(&w_hookargs) = args.first() else {
         return Err(crate::PyError::type_error(
@@ -792,7 +887,9 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                         if args.len() == 1 { "was" } else { "were" },
                     )));
                 }
-                Ok(w_int_new(crate::module::sys::state::int_max_str_digits() as i64))
+                Ok(w_int_new(
+                    crate::module::sys::state::int_max_str_digits() as i64
+                ))
             },
             0,
         ),
@@ -1232,6 +1329,16 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
         "setprofile",
         make_builtin_function_with_arity("setprofile", sys_setprofile_impl, 1),
     );
+    module_ns_store(
+        ns,
+        "get_asyncgen_hooks",
+        make_builtin_function_with_arity("get_asyncgen_hooks", sys_get_asyncgen_hooks_impl, 0),
+    );
+    module_ns_store(
+        ns,
+        "set_asyncgen_hooks",
+        crate::make_builtin_function("set_asyncgen_hooks", sys_set_asyncgen_hooks_impl),
+    );
     // sys.getfilesystemencoding
     module_ns_store(
         ns,
@@ -1259,11 +1366,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
     module_ns_store(
         ns,
         "_clear_type_descriptors",
-        make_builtin_function_with_arity(
-            "_clear_type_descriptors",
-            sys_clear_type_descriptors,
-            1,
-        ),
+        make_builtin_function_with_arity("_clear_type_descriptors", sys_clear_type_descriptors, 1),
     );
     // sys.is_finalizing
     module_ns_store(

--- a/pyre/pyre-interpreter/src/objspace/descroperation.rs
+++ b/pyre/pyre-interpreter/src/objspace/descroperation.rs
@@ -2605,11 +2605,11 @@ pub(crate) fn divmod_builtin(a: PyObjectRef, b: PyObjectRef) -> PyResult {
         let lhs_num = is_int(a) || is_long(a) || is_float(a);
         let rhs_num = is_int(b) || is_long(b) || is_float(b);
         if lhs_num && rhs_num {
-            // intobject.py:356-360 `_divmod` — a zero integer divisor reports
-            // divmod's own "integer divmod by zero"; a float operand instead
-            // falls through to floordiv/mod (which report "float modulo").
-            if is_int_or_long(a) && is_int_or_long(b) && !is_true(b)? {
-                return Err(PyError::zero_division("integer divmod by zero"));
+            // Python 3.14 reports the builtin operation's uniform spelling for
+            // every numeric zero divisor.  This intentionally differs from
+            // PyPy 3.11's int/float-specific divmod and modulo messages.
+            if !is_true(b)? {
+                return Err(PyError::zero_division("division by zero"));
             }
             let q = floordiv(a, b)?;
             let r = mod_(a, b)?;
@@ -2977,11 +2977,10 @@ pub fn divmod(a: PyObjectRef, b: PyObjectRef) -> PyResult {
         let lhs_num = is_int(a) || is_long(a) || is_float(a);
         let rhs_num = is_int(b) || is_long(b) || is_float(b);
         if lhs_num && rhs_num {
-            // intobject.py:356-360 `_divmod` — a zero integer divisor reports
-            // divmod's own "integer divmod by zero"; a float operand instead
-            // falls through to floordiv/mod (which report "float modulo").
-            if is_int_or_long(a) && is_int_or_long(b) && !is_true(b)? {
-                return Err(PyError::zero_division("integer divmod by zero"));
+            // Python 3.14 target-version spelling; see `divmod_builtin` above
+            // for the PyPy 3.11 difference.
+            if !is_true(b)? {
+                return Err(PyError::zero_division("division by zero"));
             }
             let q = floordiv(a, b)?;
             let r = mod_(a, b)?;

--- a/pyre/pyre-interpreter/src/objspace/std/mapdict.rs
+++ b/pyre/pyre-interpreter/src/objspace/std/mapdict.rs
@@ -969,7 +969,15 @@ impl MapdictCacheEntry {
 /// # Safety
 /// `w_obj` must be a live object.
 unsafe fn mapdict_map_or_null(w_obj: PyObjectRef) -> MapRef {
-    if w_obj.is_null() || !unsafe { pyre_object::is_instance(w_obj) } {
+    // W_TypeObject is represented with the broad INSTANCE_TYPE family for
+    // parts of the object-space dispatch, but PyPy's W_TypeObject does not
+    // mix in MapdictStorageMixin.  Let type attribute stores reach the
+    // metatype data descriptors (__name__, __qualname__, __module__, ...)
+    // instead of treating the type object's header as mapdict storage.
+    if w_obj.is_null()
+        || unsafe { pyre_object::is_type(w_obj) }
+        || !unsafe { pyre_object::is_instance(w_obj) }
+    {
         return std::ptr::null();
     }
     unsafe { ensure_mapdict_initialized(w_obj) };

--- a/pyre/pyre-interpreter/src/opcode_ops.rs
+++ b/pyre/pyre-interpreter/src/opcode_ops.rs
@@ -293,7 +293,7 @@ pub fn set_add_value(set: PyObjectRef, value: PyObjectRef) -> Result<(), PyError
             let set = pyre_object::gc_roots::shadow_stack_get(sp);
             let value = pyre_object::gc_roots::shadow_stack_get(sp + 1);
             pyre_object::w_set_add_hashed_checked(set, value, hash)
-                .map_err(|_| crate::baseobjspace::take_pending_hash_error())?;
+                .map_err(crate::baseobjspace::map_set_update_error)?;
         } else if pyre_object::is_list(set) {
             pyre_object::w_list_append(set, value);
         }
@@ -333,7 +333,7 @@ pub fn set_update_value(set: PyObjectRef, iterable: PyObjectRef) -> Result<(), P
                 let set = pyre_object::gc_roots::shadow_stack_get(sp);
                 let item = pyre_object::gc_roots::shadow_stack_get(item_base + i);
                 pyre_object::w_set_add_hashed_checked(set, item, hash)
-                    .map_err(|_| crate::baseobjspace::take_pending_hash_error())?;
+                    .map_err(crate::baseobjspace::map_set_update_error)?;
             }
         } else if pyre_object::is_list(set) {
             if pyre_object::is_list(iterable) {

--- a/pyre/pyre-interpreter/src/pyframe.rs
+++ b/pyre/pyre-interpreter/src/pyframe.rs
@@ -714,6 +714,13 @@ impl FrameBox {
             (*frame_ptr)
                 .code()
                 .flags
+                .contains(crate::CodeFlags::ASYNC_GENERATOR)
+        } {
+            pyre_object::generator::w_async_generator_new(frame_ptr as *mut u8, pycode)
+        } else if unsafe {
+            (*frame_ptr)
+                .code()
+                .flags
                 .contains(crate::CodeFlags::COROUTINE)
         } {
             pyre_object::generator::w_coroutine_new(frame_ptr as *mut u8, pycode)

--- a/pyre/pyre-interpreter/src/pyframe.rs
+++ b/pyre/pyre-interpreter/src/pyframe.rs
@@ -431,7 +431,18 @@ impl FrameBox {
     /// the heap, header-bearing frame, so ownership transfers straight through
     /// `into_raw` without the snapshot copy `PyFrame::initialize_as_generator`
     /// needs for the borrowed-`&mut self` case.
-    pub fn into_generator(mut self) -> crate::PyResult {
+    pub fn into_generator(self) -> crate::PyResult {
+        self.into_generator_named(None, None)
+    }
+
+    /// `pyframe.py:259 initialize_as_generator(name, qualname)` — function
+    /// calls pass the function's current writable metadata so each newly
+    /// created generator freezes it independently of the code object.
+    pub fn into_generator_named(
+        mut self,
+        name: Option<&str>,
+        qualname: Option<&str>,
+    ) -> crate::PyResult {
         self.fix_array_ptrs();
         let register_final = !self.code().exceptiontable.is_empty();
         // A suspended generator frame is off the call chain — `f_back` is
@@ -464,6 +475,19 @@ impl FrameBox {
         } else {
             pyre_object::generator::w_generator_new(frame_ptr as *mut u8)
         };
+        // GeneratorOrCoroutine.__init__ stores `_name` / `_qualname` on the
+        // generator.  Root the new owner while allocating the two wrapped
+        // strings, then publish them through the normal GC write barrier.
+        let _roots = pyre_object::gc_roots::push_roots();
+        pyre_object::gc_roots::pin_root(generator);
+        if let Some(name) = name {
+            let w_name = pyre_object::w_str_new(name);
+            unsafe { pyre_object::generator::w_generator_set_name(generator, w_name) };
+        }
+        if let Some(qualname) = qualname {
+            let w_qualname = pyre_object::w_str_new(qualname);
+            unsafe { pyre_object::generator::w_generator_set_qualname(generator, w_qualname) };
+        }
         unsafe {
             (*frame_ptr).f_generator_nowref = generator;
         }

--- a/pyre/pyre-interpreter/src/pyframe.rs
+++ b/pyre/pyre-interpreter/src/pyframe.rs
@@ -27,6 +27,247 @@ const _: () = assert!(
 /// W_Root (mirrors `pytraceback::PYTRACEBACK_TYPE`).
 pub static FRAME_TYPE: PyType = new_pytype("frame");
 
+/// CPython 3.14 `FrameLocalsProxy` — the write-through mapping exposed by
+/// `frame.f_locals` for optimized frames.  PyPy's older `getdictscope` keeps
+/// the canonical locals mapping on `FrameDebugData.w_locals`; retain that
+/// owner and make the proxy synchronize through `fast2locals` / `locals2fast`
+/// rather than inventing a second per-frame store.
+pub mod frame_locals_proxy {
+    use super::*;
+
+    #[crate::pyre_class("FrameLocalsProxy")]
+    pub struct FrameLocalsProxy {
+        w_frame: PyObjectRef,
+    }
+
+    impl FrameLocalsProxy {
+        #[inline]
+        fn frame(&self) -> &mut PyFrame {
+            unsafe { &mut *(self.w_frame as *mut PyFrame) }
+        }
+
+        #[inline]
+        fn mapping(&self) -> Result<PyObjectRef, crate::PyError> {
+            self.frame().getdictscope()
+        }
+
+        fn call_mapping_method(
+            &self,
+            name: &str,
+            args: &[PyObjectRef],
+        ) -> Result<PyObjectRef, crate::PyError> {
+            let result = crate::baseobjspace::call_method(self.mapping()?, name, args);
+            if result.is_null() {
+                Err(crate::call::take_call_error()
+                    .unwrap_or_else(|| crate::PyError::runtime_error("method call failed")))
+            } else {
+                Ok(result)
+            }
+        }
+
+        fn key_is_fast_local(&self, key: PyObjectRef) -> Result<bool, crate::PyError> {
+            let frame = self.frame();
+            let code = frame.code();
+            for (index, name) in code.varnames.iter().enumerate() {
+                if hidden_local(code, index) {
+                    continue;
+                }
+                if crate::baseobjspace::eq_w(pyre_object::w_str_new(name.as_ref()), key)? {
+                    return Ok(true);
+                }
+            }
+            Ok(false)
+        }
+    }
+
+    #[crate::pyre_methods(doc = "A write-through view of a frame's optimized locals.")]
+    impl FrameLocalsProxy {
+        #[staticmethod]
+        fn __new__(_cls: PyObjectRef, args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+            // The gateway includes the type object in the raw argument slice
+            // passed to a static __new__ wrapper.
+            if args.len() != 2 {
+                return Err(crate::PyError::type_error(format!(
+                    "FrameLocalsProxy expected 1 argument, got {}",
+                    args.len().saturating_sub(1)
+                )));
+            }
+            let w_frame = args[1];
+            if !unsafe { pyre_object::py_type_check(w_frame, &FRAME_TYPE) } {
+                return Err(crate::PyError::type_error(
+                    "FrameLocalsProxy() argument must be a frame",
+                ));
+            }
+            let _roots = pyre_object::gc_roots::push_roots();
+            pyre_object::gc_roots::pin_root(w_frame);
+            let slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+            let proxy = FrameLocalsProxy::allocate_stable(FrameLocalsProxy {
+                ob: PyObject {
+                    ob_type: std::ptr::null(),
+                    w_class: std::ptr::null_mut(),
+                },
+                w_frame: pyre_object::gc_roots::shadow_stack_get(slot),
+            });
+            Ok(proxy)
+        }
+
+        fn __getitem__(&self, key: PyObjectRef) -> Result<PyObjectRef, crate::PyError> {
+            crate::baseobjspace::getitem(self.mapping()?, key)
+        }
+
+        fn __setitem__(
+            &mut self,
+            key: PyObjectRef,
+            value: PyObjectRef,
+        ) -> Result<(), crate::PyError> {
+            let mapping = self.mapping()?;
+            crate::baseobjspace::setitem(mapping, key, value)?;
+            self.frame().locals2fast(false)
+        }
+
+        fn __delitem__(&mut self, key: PyObjectRef) -> Result<(), crate::PyError> {
+            let mapping = self.mapping()?;
+            // Perform the lookup first so absent/unhashable keys retain the
+            // underlying mapping's KeyError/TypeError.
+            crate::baseobjspace::getitem(mapping, key)?;
+            if self.key_is_fast_local(key)? {
+                return Err(crate::PyError::value_error(
+                    "cannot remove local variables from FrameLocalsProxy",
+                ));
+            }
+            crate::baseobjspace::delitem(mapping, key)
+        }
+
+        fn __len__(&self) -> Result<i64, crate::PyError> {
+            crate::baseobjspace::len_w(self.mapping()?)
+        }
+
+        fn __iter__(&self) -> Result<PyObjectRef, crate::PyError> {
+            crate::baseobjspace::iter(self.mapping()?)
+        }
+
+        fn __reversed__(&self) -> Result<PyObjectRef, crate::PyError> {
+            let mut keys: Vec<_> =
+                unsafe { pyre_object::dictmultiobject::w_dict_items(self.mapping()?) }
+                    .into_iter()
+                    .map(|(key, _)| key)
+                    .collect();
+            keys.reverse();
+            Ok(pyre_object::w_list_new(keys))
+        }
+
+        fn __contains__(&self, key: PyObjectRef) -> Result<bool, crate::PyError> {
+            crate::baseobjspace::contains(self.mapping()?, key)
+        }
+
+        fn keys(&self) -> Result<PyObjectRef, crate::PyError> {
+            let keys = unsafe { pyre_object::dictmultiobject::w_dict_items(self.mapping()?) }
+                .into_iter()
+                .map(|(key, _)| key)
+                .collect();
+            Ok(pyre_object::w_list_new(keys))
+        }
+
+        fn values(&self) -> Result<PyObjectRef, crate::PyError> {
+            let values = unsafe { pyre_object::dictmultiobject::w_dict_items(self.mapping()?) }
+                .into_iter()
+                .map(|(_, value)| value)
+                .collect();
+            Ok(pyre_object::w_list_new(values))
+        }
+
+        fn items(&self) -> Result<PyObjectRef, crate::PyError> {
+            let items = unsafe { pyre_object::dictmultiobject::w_dict_items(self.mapping()?) };
+            Ok(pyre_object::w_list_new(
+                items
+                    .into_iter()
+                    .map(|(key, value)| pyre_object::w_tuple_new(vec![key, value]))
+                    .collect(),
+            ))
+        }
+
+        fn copy(&self) -> Result<PyObjectRef, crate::PyError> {
+            self.call_mapping_method("copy", &[])
+        }
+
+        fn get(
+            &self,
+            key: PyObjectRef,
+            #[default(pyre_object::w_none())] default: PyObjectRef,
+        ) -> Result<PyObjectRef, crate::PyError> {
+            self.call_mapping_method("get", &[key, default])
+        }
+
+        fn update(&mut self, other: PyObjectRef) -> Result<(), crate::PyError> {
+            self.call_mapping_method("update", &[other])?;
+            self.frame().locals2fast(false)
+        }
+
+        fn setdefault(
+            &mut self,
+            key: PyObjectRef,
+            #[default(pyre_object::w_none())] default: PyObjectRef,
+        ) -> Result<PyObjectRef, crate::PyError> {
+            let result = self.call_mapping_method("setdefault", &[key, default])?;
+            self.frame().locals2fast(false)?;
+            Ok(result)
+        }
+
+        fn pop(&mut self, args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+            // Raw slice methods receive the bound receiver in args[0].
+            if args.len() < 2 || args.len() > 3 {
+                return Err(crate::PyError::type_error("pop expected 1 or 2 arguments"));
+            }
+            let call_args = &args[1..];
+            let mapping = self.mapping()?;
+            if crate::baseobjspace::getitem(mapping, call_args[0]).is_ok()
+                && self.key_is_fast_local(call_args[0])?
+            {
+                return Err(crate::PyError::value_error(
+                    "cannot remove local variables from FrameLocalsProxy",
+                ));
+            }
+            self.call_mapping_method("pop", call_args)
+        }
+
+        fn __or__(&self, other: PyObjectRef) -> Result<PyObjectRef, crate::PyError> {
+            self.call_mapping_method("__or__", &[other])
+        }
+
+        fn __ror__(&self, other: PyObjectRef) -> Result<PyObjectRef, crate::PyError> {
+            self.call_mapping_method("__ror__", &[other])
+        }
+
+        fn __ior__(&mut self, other: PyObjectRef) -> Result<PyObjectRef, crate::PyError> {
+            self.update(other)?;
+            Ok(self as *mut FrameLocalsProxy as PyObjectRef)
+        }
+
+        fn __eq__(&self, other: PyObjectRef) -> Result<bool, crate::PyError> {
+            crate::baseobjspace::eq_w(self.mapping()?, other)
+        }
+
+        fn __repr__(&self) -> Result<String, crate::PyError> {
+            unsafe { crate::display::py_repr(self.mapping()?) }
+        }
+    }
+
+    pub fn new(w_frame: PyObjectRef) -> PyObjectRef {
+        let _roots = pyre_object::gc_roots::push_roots();
+        pyre_object::gc_roots::pin_root(w_frame);
+        let slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+        let w_type = type_object();
+        unsafe { pyre_object::typeobject::w_type_set_flag_map_or_seq(w_type, b'M') };
+        FrameLocalsProxy::allocate_stable(FrameLocalsProxy {
+            ob: PyObject {
+                ob_type: std::ptr::null(),
+                w_class: std::ptr::null_mut(),
+            },
+            w_frame: pyre_object::gc_roots::shadow_stack_get(slot),
+        })
+    }
+}
+
 /// Build the `ob_header` for a freshly-created `PyFrame` — `ob_type`
 /// pinned to [`FRAME_TYPE`], `w_class` the cached `W_TypeObject`
 /// (null during bootstrap before `init_typeobjects`). Mirrors

--- a/pyre/pyre-interpreter/src/pyframe.rs
+++ b/pyre/pyre-interpreter/src/pyframe.rs
@@ -461,6 +461,10 @@ impl FrameBox {
         // block is non-moving (old-gen when GC-managed, `std::alloc`
         // otherwise), so only the locals array needs protecting.
         let _root = FrameLocalsRoot::new(frame_ptr);
+        // generator.py:21 `self.pycode = frame.pycode`: preserve the exact
+        // code object independently of the frame, which is cleared when the
+        // generator finishes.
+        let pycode = unsafe { (*frame_ptr).pycode as pyre_object::PyObjectRef };
         // generator.py: GeneratorIterator / Coroutine — native `async def`
         // frames have their own object type.  In particular, a Coroutine is
         // awaitable but is not itself an iterator; `__await__` supplies the
@@ -471,9 +475,9 @@ impl FrameBox {
                 .flags
                 .contains(crate::CodeFlags::COROUTINE)
         } {
-            pyre_object::generator::w_coroutine_new(frame_ptr as *mut u8)
+            pyre_object::generator::w_coroutine_new(frame_ptr as *mut u8, pycode)
         } else {
-            pyre_object::generator::w_generator_new(frame_ptr as *mut u8)
+            pyre_object::generator::w_generator_new(frame_ptr as *mut u8, pycode)
         };
         // GeneratorOrCoroutine.__init__ stores `_name` / `_qualname` on the
         // generator.  Root the new owner while allocating the two wrapped

--- a/pyre/pyre-interpreter/src/pyframe.rs
+++ b/pyre/pyre-interpreter/src/pyframe.rs
@@ -2511,11 +2511,8 @@ impl PyFrame {
         }
     }
 
-    /// pyframe.py:300 resume_execute_frame (send-path only).
-    ///
-    /// A suspended delegate is resumed by `generator_send_ex` before this
-    /// method runs.  Once that delegate completes, this path receives the
-    /// normal outer-frame input again.
+    /// pyframe.py:300 resume_execute_frame, after any suspended delegate has
+    /// either yielded or completed in `eval_frame_plain_with_resume`.
     #[inline]
     pub fn resume_execute_frame(
         &mut self,
@@ -2537,12 +2534,21 @@ impl PyFrame {
         w_inputvalue: Option<PyObjectRef>,
         operr: Option<crate::PyError>,
     ) -> crate::PyResult {
-        if operr.is_none() {
-            if let Some(w_arg_or_err) = w_inputvalue {
-                let _ = self.resume_execute_frame(w_arg_or_err)?;
-            }
-        }
-        crate::eval::eval_frame_plain_with_operr(self, operr)
+        crate::eval::eval_frame_plain_with_resume(self, w_inputvalue, operr, None)
+    }
+
+    /// Generator/coroutine execution entry carrying the original throw
+    /// arguments for non-generator delegates.  This is the Rust representation
+    /// of PyPy's `SApplicationException` payload passed through
+    /// `PyFrame.execute_frame(w_arg_or_err)`.
+    #[inline]
+    pub fn execute_generator_frame(
+        &mut self,
+        w_inputvalue: Option<PyObjectRef>,
+        operr: Option<crate::PyError>,
+        throw_args: Option<([PyObjectRef; 3], usize)>,
+    ) -> crate::PyResult {
+        crate::eval::eval_frame_plain_with_resume(self, w_inputvalue, operr, throw_args)
     }
 
     /// pyframe.py:521-522 `hide(self): return self.pycode.hidden_applevel`.

--- a/pyre/pyre-interpreter/src/pyopcode.rs
+++ b/pyre/pyre-interpreter/src/pyopcode.rs
@@ -1381,6 +1381,15 @@ pub trait OpcodeStepExecutor: SharedOpcodeHandler {
     fn get_awaitable(&mut self, _context: u32) -> Result<(), PyError> {
         Err(crate::PyError::type_error("get_awaitable not implemented").into())
     }
+    fn get_aiter(&mut self) -> Result<(), PyError> {
+        Err(crate::PyError::type_error("get_aiter not implemented").into())
+    }
+    fn get_anext(&mut self) -> Result<(), PyError> {
+        Err(crate::PyError::type_error("get_anext not implemented").into())
+    }
+    fn end_async_for(&mut self) -> Result<(), PyError> {
+        Err(crate::PyError::type_error("end_async_for not implemented").into())
+    }
 
     // Class
     fn load_build_class(&mut self) -> Result<(), PyError> {
@@ -1551,10 +1560,11 @@ pub trait OpcodeStepExecutor: SharedOpcodeHandler {
                 Ok(())
             }
             IntrinsicFunction1::AsyncGenWrap => {
-                // Wraps a value yielded from an async generator. pyre conflates
-                // generators / coroutines / async generators into a single
-                // suspended-frame object, so the wrapper type is not modeled —
-                // the value passes through unchanged.
+                // PyPy `YIELD_VALUE`: an async-generator yield is wrapped so
+                // AsyncGenASend can distinguish it from an await suspension.
+                let value = self.pop_value()?;
+                let wrapped = self.async_gen_wrap(value)?;
+                self.push_value(wrapped)?;
                 Ok(())
             }
             // PEP 695 type-parameter construction (`class C[T]:`, `def f[T]()`).
@@ -1622,6 +1632,12 @@ pub trait OpcodeStepExecutor: SharedOpcodeHandler {
         _val: <Self as SharedOpcodeHandler>::Value,
     ) -> Result<<Self as SharedOpcodeHandler>::Value, PyError> {
         Err(crate::PyError::type_error("list_to_tuple not implemented").into())
+    }
+    fn async_gen_wrap(
+        &mut self,
+        _val: <Self as SharedOpcodeHandler>::Value,
+    ) -> Result<<Self as SharedOpcodeHandler>::Value, PyError> {
+        Err(crate::PyError::type_error("async_gen_wrap not implemented").into())
     }
     fn print_expr(&mut self, _val: <Self as SharedOpcodeHandler>::Value) -> Result<(), PyError> {
         Err(crate::PyError::type_error("print_expr not implemented").into())
@@ -2456,6 +2472,27 @@ pub fn execute_get_awaitable<E: OpcodeStepExecutor>(
         unreachable!()
     };
     executor.get_awaitable(r#where.get(op_arg))?;
+    Ok(StepResult::Continue)
+}
+
+pub fn execute_get_aiter<E: OpcodeStepExecutor>(
+    executor: &mut E,
+) -> Result<StepResult<E::Value>, PyError> {
+    executor.get_aiter()?;
+    Ok(StepResult::Continue)
+}
+
+pub fn execute_get_anext<E: OpcodeStepExecutor>(
+    executor: &mut E,
+) -> Result<StepResult<E::Value>, PyError> {
+    executor.get_anext()?;
+    Ok(StepResult::Continue)
+}
+
+pub fn execute_end_async_for<E: OpcodeStepExecutor>(
+    executor: &mut E,
+) -> Result<StepResult<E::Value>, PyError> {
+    executor.end_async_for()?;
     Ok(StepResult::Continue)
 }
 
@@ -3641,10 +3678,9 @@ where
         // ── Await ──
         Instruction::GetAwaitable { .. } => execute_get_awaitable(executor, instruction, op_arg),
 
-        // ── Async stubs ──
-        Instruction::GetAiter | Instruction::GetAnext | Instruction::EndAsyncFor => {
-            Err(crate::PyError::type_error("async not yet implemented").into())
-        }
+        Instruction::GetAiter => execute_get_aiter(executor),
+        Instruction::GetAnext => execute_get_anext(executor),
+        Instruction::EndAsyncFor => execute_end_async_for(executor),
 
         // yield from: handled by PyFrame override in eval.rs
         Instruction::GetYieldFromIter => execute_get_yield_from_iter(executor),

--- a/pyre/pyre-interpreter/src/stack_check.rs
+++ b/pyre/pyre-interpreter/src/stack_check.rs
@@ -422,11 +422,11 @@ pub extern "C" fn pyre_stack_criticalcode_stop() {
     TL_REPORT_ERROR.with(|c| c.set(1));
 }
 
-/// pypy/module/sys/vm.py:63 `setrecursionlimit` parity. Tentatively
-/// applies the new stack budget, probes `stack_check` at the current
-/// depth, and rolls the budget back on failure before raising
-/// `RecursionError`. Only on success does the visible recursion
-/// limit get committed and the shadow-stack depth grown.
+/// pypy/module/sys/vm.py:63 `setrecursionlimit`, with Python 3.14's
+/// logical-depth rejection before PyPy's byte-budget update.  The check must
+/// use Python call depth: native Rust frame size is unrelated to CPython's
+/// `py_recursion_remaining` and cannot decide whether a Python limit is below
+/// the current interpreter depth.
 pub fn set_recursion_limit(new_limit: i32) -> Result<(), PyError> {
     if new_limit <= 0 {
         return Err(PyError::value_error("recursion limit must be positive"));
@@ -434,18 +434,21 @@ pub fn set_recursion_limit(new_limit: i32) -> Result<(), PyError> {
     // pypy/module/sys/vm.py:86-87 silent upper bound.
     let limit = new_limit.min(MAX_RECURSION_LIMIT);
     let old_limit = get_recursion_limit();
-
-    // pypy/module/sys/vm.py:88-90 try: _stack_set_length_fraction + stack_check
-    pyre_stack_set_length_fraction(limit as f64 * 0.001);
-    if stack_check().is_err() {
-        // pypy/module/sys/vm.py:91-95 rollback on StackOverflow.
-        pyre_stack_set_length_fraction(old_limit as f64 * 0.001);
+    // CPython 3.14 Python/sysmodule.c `sys_setrecursionlimit_impl`: reject
+    // when the current Python recursion depth has already reached the limit.
+    let depth = crate::call::call_depth();
+    if depth >= limit as u32 {
         return Err(PyError::recursion_error(format!(
-            "cannot set the recursion limit to {limit} at the recursion depth: the limit is too low"
+            "cannot set the recursion limit to {limit} at the recursion depth {depth}: the limit is too low"
         )));
     }
 
-    // pypy/module/sys/vm.py:96-97 commit + grow shadow stack.
+    // CPython 3.14 keeps Python recursion accounting separate from native
+    // stack protection.  Preserve PyPy's native byte guard as a high-water
+    // allocation: lowering the Python limit must not shrink it underneath
+    // the already-running Rust interpreter stack.  Logical depth below is
+    // what enforces the newly lowered Python limit.
+    pyre_stack_set_length_fraction(old_limit.max(limit) as f64 * 0.001);
     crate::module::sys::state::set_recursion_limit(limit);
     majit_gc::shadow_stack::increase_root_stack_depth((limit as f64 * 0.001 * 163840.0) as usize);
     Ok(())
@@ -466,6 +469,12 @@ pub fn get_recursion_limit() -> i32 {
 #[inline]
 #[majit_macros::dont_look_inside]
 pub fn stack_check() -> Result<(), PyError> {
+    // CPython 3.14 checks `py_recursion_remaining`, i.e. Python interpreter
+    // depth, independently of native stack protection.  pyre's matching
+    // counter is bumped around every user-function call.
+    if crate::call::call_depth() >= get_recursion_limit() as u32 {
+        return Err(PyError::recursion_error("maximum recursion depth exceeded"));
+    }
     let current = current_sp();
     let end = PYRE_STACKTOOBIG.stack_end.load(Ordering::Relaxed);
     let length = PYRE_STACKTOOBIG.stack_length.load(Ordering::Relaxed);
@@ -605,16 +614,16 @@ mod tests {
     }
 
     #[test]
-    fn set_recursion_limit_scales_stack_budget() {
+    fn set_recursion_limit_keeps_native_stack_budget_high_water_mark() {
         let _g = lock_tests();
         reset_all();
-        // Halving the recursion limit halves the stack budget.
+        // Lowering the Python logical limit must not shrink native protection
+        // underneath the currently-running interpreter stack.
         set_recursion_limit(500).expect("500 is positive");
         assert_eq!(get_recursion_limit(), 500);
-        assert!(pyre_stack_get_length() < MAX_STACK_SIZE);
-        assert!(pyre_stack_get_length() >= MAX_STACK_SIZE / 2 - 4096);
+        assert_eq!(pyre_stack_get_length(), MAX_STACK_SIZE);
 
-        // Doubling it doubles the budget.
+        // Raising the limit grows both the logical limit and native budget.
         set_recursion_limit(2000).expect("2000 is positive");
         assert_eq!(get_recursion_limit(), 2000);
         assert!(pyre_stack_get_length() > MAX_STACK_SIZE);

--- a/pyre/pyre-interpreter/src/type_methods.rs
+++ b/pyre/pyre-interpreter/src/type_methods.rs
@@ -442,10 +442,13 @@ pub fn list_method_extend(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::Py
                 }
             }
         } else {
-            // listobject.py:1019 _extend_from_iterable: append each yielded
-            // value before asking the iterator for the next one.  In
-            // particular, an exception from a later `next()` must not roll
-            // back the prefix already appended to the receiver.
+            // listobject.py:1052 `_extend_from_iterable` asks for a length
+            // hint before `_do_extend_from_iterable` obtains and consumes the
+            // iterator.  Hint failures other than TypeError/AttributeError are
+            // observable and propagate without appending a prefix.
+            let _ = crate::baseobjspace::length_hint(other, 0)?;
+            // Append each yielded value before asking for the next one.  An
+            // exception from a later `next()` does not roll back the prefix.
             let _roots = pyre_object::gc_roots::push_roots();
             let root_base = pyre_object::gc_roots::shadow_stack_len();
             pyre_object::gc_roots::pin_root(list);

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -1963,7 +1963,10 @@ fn module_descr_getattribute(args: &[PyObjectRef]) -> Result<PyObjectRef, crate:
 /// module.py:164-173 `Module.descr_module__dir__`.
 fn module_descr_dir(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     let module = module_require(args.first().copied().unwrap_or(PY_NULL), "__dir__")?;
-    let w_dict = unsafe { pyre_object::w_module_get_w_dict(module) };
+    // module.py:164 — deliberately perform ordinary attribute lookup rather
+    // than reading `self.w_dict`: a ModuleType subclass may shadow
+    // `__dict__`, in which case the resulting non-dict is a TypeError.
+    let w_dict = crate::baseobjspace::getattr_str(module, "__dict__")?;
     if w_dict.is_null()
         || (!unsafe { pyre_object::is_dict(w_dict) }
             && !unsafe { pyre_object::dictmultiobject::is_module_dict(w_dict) }
@@ -16686,37 +16689,48 @@ fn bytes_method_join(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError
             args.len().saturating_sub(1)
         )));
     }
-    let sep = unsafe { pyre_object::bytesobject::bytes_like_data(args[0]) };
-    let iterable = args[1];
-    let items: Vec<PyObjectRef> = unsafe {
-        if pyre_object::is_list(iterable) {
-            let n = pyre_object::w_list_len(iterable);
-            (0..n)
-                .filter_map(|i| pyre_object::w_list_getitem(iterable, i as i64))
-                .collect()
-        } else if pyre_object::is_tuple(iterable) {
-            let n = pyre_object::w_tuple_len(iterable);
-            (0..n)
-                .filter_map(|i| pyre_object::w_tuple_getitem(iterable, i as i64))
-                .collect()
-        } else {
-            crate::builtins::collect_iterable(iterable)?
-        }
-    };
-    let mut out: Vec<u8> = Vec::new();
-    for (i, &item) in items.iter().enumerate() {
-        if i > 0 {
-            out.extend_from_slice(sep);
-        }
-        let Some(src) = buffer_as_bytes_like(item)? else {
-            return Err(crate::PyError::type_error(format!(
-                "sequence item {i}: expected a bytes-like object, {} found",
-                type_name_of(item)
-            )));
+    // Python 3.14's bytearray join holds a buffer export on the separator
+    // while materialising the iterable and copying its items (GH-112625).
+    // A re-entrant iterator therefore cannot resize/clear the separator out
+    // from under the borrowed bytes.  Immutable bytes acquires no export.
+    let acquired_export = unsafe { crate::builtins::buffer_export_incref(args[0]) };
+    let result = (|| {
+        let sep = unsafe { pyre_object::bytesobject::bytes_like_data(args[0]) };
+        let iterable = args[1];
+        let items: Vec<PyObjectRef> = unsafe {
+            if pyre_object::is_list(iterable) {
+                let n = pyre_object::w_list_len(iterable);
+                (0..n)
+                    .filter_map(|i| pyre_object::w_list_getitem(iterable, i as i64))
+                    .collect()
+            } else if pyre_object::is_tuple(iterable) {
+                let n = pyre_object::w_tuple_len(iterable);
+                (0..n)
+                    .filter_map(|i| pyre_object::w_tuple_getitem(iterable, i as i64))
+                    .collect()
+            } else {
+                crate::builtins::collect_iterable(iterable)?
+            }
         };
-        out.extend_from_slice(unsafe { pyre_object::bytesobject::bytes_like_data(src) });
+        let mut out: Vec<u8> = Vec::new();
+        for (i, &item) in items.iter().enumerate() {
+            if i > 0 {
+                out.extend_from_slice(sep);
+            }
+            let Some(src) = buffer_as_bytes_like(item)? else {
+                return Err(crate::PyError::type_error(format!(
+                    "sequence item {i}: expected a bytes-like object, {} found",
+                    type_name_of(item)
+                )));
+            };
+            out.extend_from_slice(unsafe { pyre_object::bytesobject::bytes_like_data(src) });
+        }
+        Ok(new_bytes_like(args[0], &out))
+    })();
+    if acquired_export {
+        unsafe { crate::builtins::buffer_export_decref(args[0]) };
     }
-    Ok(new_bytes_like(args[0], &out))
+    result
 }
 
 /// `stringmethods.py:descr_partition` / `descr_rpartition` — split once

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -18483,6 +18483,11 @@ fn bytearray_method_extend(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::P
                     e
                 }
             })?;
+            // bytesobject.py:855-860 `_from_byte_sequence`: after obtaining
+            // the iterator, query the original source's length hint to size
+            // the builder.  RuntimeError and other real hint failures must
+            // propagate before any bytearray mutation.
+            let _ = crate::baseobjspace::length_hint(other, 0)?;
             let is_str = pyre_object::is_str(other);
             let mut appended = Vec::new();
             loop {

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -21079,16 +21079,18 @@ fn generator_name_value(obj: PyObjectRef, qualname: bool) -> crate::PyResult {
     if !override_value.is_null() {
         return Ok(override_value);
     }
-    let frame = generator_frame(obj);
-    if frame.is_null() {
-        return Ok(w_str_new("<generator>"));
+    // generator.py:32-43 `get_name` / `get_qualname`: both fallback paths
+    // read the immutable generator-owned `pycode`, never the frame (which is
+    // cleared on exhaustion).  `_qualname is None` delegates to `get_name`.
+    let pycode = unsafe { pyre_object::generator::w_generator_get_pycode(obj) };
+    if pycode.is_null() || unsafe { pyre_object::is_none(pycode) } {
+        return Ok(w_str_new("<finished>"));
     }
-    let code = unsafe { (*frame).code() };
-    Ok(w_str_new(if qualname {
-        &code.qualname
-    } else {
-        &code.obj_name
-    }))
+    let code_ptr = unsafe { crate::pycode::w_code_get_ptr(pycode) } as *const crate::CodeObject;
+    if code_ptr.is_null() {
+        return Ok(w_str_new("<finished>"));
+    }
+    Ok(w_str_new(unsafe { &(*code_ptr).obj_name }))
 }
 
 fn generator_getter_for(args: &[PyObjectRef], field: usize, coroutine: bool) -> crate::PyResult {

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -6329,8 +6329,10 @@ fn init_frame_type(ns: PyObjectRef) {
         )
     };
 
-    // f_locals — read-only; runs `fast2locals` (pyframe.py:644
-    // fget_getdictscope), so it needs `&mut` and can raise.
+    // f_locals — read-only.  Python 3.14 exposes a fresh write-through
+    // FrameLocalsProxy for optimized frames; module/class frames retain their
+    // actual locals mapping.  The proxy itself routes through the frame-owned
+    // getdictscope/locals2fast machinery.
     let locals_getter = make_builtin_function_with_arity(
         "f_locals",
         |args| {
@@ -6338,7 +6340,11 @@ fn init_frame_type(ns: PyObjectRef) {
             if f.is_null() {
                 return Ok(pyre_object::w_none());
             }
-            let w = unsafe { &mut *f }.getdictscope()?;
+            let frame = unsafe { &mut *f };
+            if frame.code().flags.contains(crate::CodeFlags::OPTIMIZED) {
+                return Ok(crate::pyframe::frame_locals_proxy::new(args[1]));
+            }
+            let w = frame.getdictscope()?;
             Ok(if w.is_null() {
                 pyre_object::w_dict_new()
             } else {

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -21121,13 +21121,9 @@ fn generator_getter_for(args: &[PyObjectRef], field: usize, coroutine: bool) -> 
                 frame as PyObjectRef
             }
         }
-        3 => {
-            if frame.is_null() {
-                w_none()
-            } else {
-                unsafe { (*frame).pycode as PyObjectRef }
-            }
-        }
+        // generator.py:387 / :464 `interp_attrproperty_w('pycode')` reads the
+        // generator-owned immutable field, not the possibly-cleared frame.
+        3 => unsafe { pyre_object::generator::w_generator_get_pycode(obj) },
         4 => {
             if frame.is_null() {
                 w_none()

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -366,7 +366,12 @@ pub fn init_typeobjects() {
         // str — PyPy: unicodeobject.py, bases=(object,)
         reg.insert(
             &STR_TYPE as *const PyType as usize,
-            new_typeobject_with_base("str", init_str_type, object_type) as usize,
+            new_typeobject_with_base_and_layout(
+                "str",
+                init_str_type,
+                object_type,
+                &STR_TYPE as *const PyType,
+            ) as usize,
         );
 
         // list — PyPy: listobject.py, bases=(object,)
@@ -9157,7 +9162,7 @@ fn init_type_type(ns: PyObjectRef) {
             // filters out null entries but preserves `w_none()`, matching
             // PyPy's "value present even if it's None" semantic.
             if unsafe { pyre_object::w_type_is_heaptype(cls) } {
-                if let Some(v) = unsafe { crate::baseobjspace::lookup_in_type(cls, "__module__") } {
+                if let Some(v) = crate::type_dict_lookup(cls, "__module__") {
                     if !v.is_null() {
                         return Ok(v);
                     }
@@ -9186,6 +9191,10 @@ fn init_type_type(ns: PyObjectRef) {
             unsafe {
                 if pyre_object::is_type(cls) {
                     crate::type_dict_store(cls, "__module__", value);
+                    // CPython 3.14 type_set_module clears the compiler's
+                    // source-location metadata when the owning module changes.
+                    crate::type_dict_delete(cls, "__firstlineno__");
+                    crate::baseobjspace::mutated(cls, Some("__module__"));
                 }
             }
             Ok(pyre_object::w_none())
@@ -9288,6 +9297,48 @@ fn init_type_type(ns: PyObjectRef) {
             ns,
             "__name__",
             make_getset_property_named(name_getter, name_setter, pyre_object::PY_NULL, "__name__"),
+        )
+    };
+
+    let qualname_getter = make_builtin_function_with_arity(
+        "__qualname__",
+        |args| unsafe {
+            Ok(pyre_object::w_str_new(pyre_object::w_type_get_qualname(
+                args[1],
+            )))
+        },
+        2,
+    );
+    let qualname_setter = make_builtin_function_with_arity(
+        "__qualname__",
+        |args| {
+            let w_type = args[1];
+            let value = args[2];
+            if !unsafe { crate::baseobjspace::isinstance_str_w(value) } {
+                return Err(crate::PyError::type_error(format!(
+                    "can only assign string to {}.__qualname__, not '{}'",
+                    unsafe { pyre_object::w_type_get_name(w_type) },
+                    unsafe { pyre_object::type_name_of(value) }
+                )));
+            }
+            unsafe {
+                pyre_object::w_type_set_qualname(w_type, pyre_object::w_str_get_value(value));
+                crate::baseobjspace::mutated(w_type, Some("__qualname__"));
+            }
+            Ok(pyre_object::w_none())
+        },
+        3,
+    );
+    unsafe {
+        pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
+            ns,
+            "__qualname__",
+            make_getset_property_named(
+                qualname_getter,
+                qualname_setter,
+                pyre_object::PY_NULL,
+                "__qualname__",
+            ),
         )
     };
 

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -3749,6 +3749,14 @@ fn set_init_from_iterable(
     w_set: PyObjectRef,
     w_iterable: PyObjectRef,
 ) -> Result<(), crate::PyError> {
+    set_init_from_iterable_impl(w_set, w_iterable, true)
+}
+
+fn set_init_from_iterable_impl(
+    w_set: PyObjectRef,
+    w_iterable: PyObjectRef,
+    wrap_hash_error: bool,
+) -> Result<(), crate::PyError> {
     if unsafe { pyre_object::is_set_or_frozenset(w_iterable) } {
         unsafe { pyre_object::w_set_copy_storage_from(w_set, w_iterable) };
         return Ok(());
@@ -3814,7 +3822,11 @@ fn set_init_from_iterable(
     let items =
         crate::builtins::collect_iterable(pyre_object::gc_roots::shadow_stack_get(iterable_slot))?;
     let w_set = pyre_object::gc_roots::shadow_stack_get(set_slot);
-    crate::builtins::builtin_set_add_items(w_set, &items)
+    if wrap_hash_error {
+        crate::builtins::builtin_set_add_items(w_set, &items)
+    } else {
+        crate::builtins::builtin_set_add_items_intersection(w_set, &items)
+    }
 }
 
 /// `set.__init__(self, [iterable])` — PyPy: setobject.py W_SetObject.descr_init.
@@ -6812,8 +6824,14 @@ fn dict_view_as_set_op(
     rhs: pyre_object::PyObjectRef,
     methname: &str,
 ) -> Result<pyre_object::PyObjectRef, crate::PyError> {
-    let w_set_type = crate::typedef::gettypeobject(&pyre_object::setobject::SET_TYPE);
-    let w_set = crate::call::call_function_impl_result(w_set_type, &[lhs])?;
+    let w_set = if methname == "intersection_update" {
+        let w_set = pyre_object::w_set_new();
+        set_init_from_iterable_impl(w_set, lhs, false)?;
+        w_set
+    } else {
+        let w_set_type = crate::typedef::gettypeobject(&pyre_object::setobject::SET_TYPE);
+        crate::call::call_function_impl_result(w_set_type, &[lhs])?
+    };
     let method = crate::baseobjspace::getattr_str(w_set, methname)?;
     crate::call::call_function_impl_result(method, &[rhs])?;
     Ok(w_set)
@@ -20219,6 +20237,14 @@ fn set_newobj(
     Ok(w_set)
 }
 
+fn set_newobj_intersection(
+    w_iterable: pyre_object::PyObjectRef,
+) -> Result<pyre_object::PyObjectRef, crate::PyError> {
+    let w_set = pyre_object::w_set_new();
+    set_init_from_iterable_impl(w_set, w_iterable, false)?;
+    Ok(w_set)
+}
+
 /// The operand as a set: itself when it already is one, otherwise a set built
 /// from it.
 ///
@@ -20317,12 +20343,12 @@ pub(crate) fn set_method_intersection(
 
     // `setobject.py` — the seed and every operand become sets, and a
     // set operand is intersected as it stands rather than rebuilt.
-    let mut result = set_newobj(others_w[0])?;
+    let mut result = set_newobj_intersection(others_w[0])?;
     for &w_other in &others_w[1..] {
         let w_other_as_set = if unsafe { pyre_object::is_set_or_frozenset(w_other) } {
             w_other
         } else {
-            set_newobj(w_other)?
+            set_newobj_intersection(w_other)?
         };
         result = set_intersect_update(result, w_other_as_set)?;
     }

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -3747,7 +3747,7 @@ fn set_init_from_iterable(
                     key,
                 )
             }
-            .map_err(|_| crate::baseobjspace::take_pending_hash_error())?;
+            .map_err(crate::baseobjspace::map_set_update_error)?;
             copied_hashed_key = true;
             index += 1;
         }
@@ -20065,7 +20065,7 @@ pub(crate) fn set_method_union(
     for other in &args[1..] {
         if unsafe { pyre_object::is_set_or_frozenset(*other) } {
             unsafe { pyre_object::w_set_update_from_set(result, *other) }
-                .map_err(|_| crate::baseobjspace::take_pending_hash_error())?;
+                .map_err(crate::baseobjspace::map_set_update_error)?;
         } else {
             let other_items = crate::builtins::collect_iterable(*other)?;
             crate::builtins::builtin_set_add_items(result, &other_items)?;
@@ -20160,7 +20160,7 @@ fn set_intersect_update(
                     break;
                 };
                 pyre_object::w_set_insert_key_checked(result, key)
-                    .map_err(|_| crate::baseobjspace::take_pending_hash_error())?;
+                    .map_err(crate::baseobjspace::map_set_update_error)?;
             }
             i += 1;
         }
@@ -20472,7 +20472,7 @@ fn set_method_update(
     for other in &args[1..] {
         if unsafe { pyre_object::is_set_or_frozenset(*other) } {
             unsafe { pyre_object::w_set_update_from_set(args[0], *other) }
-                .map_err(|_| crate::baseobjspace::take_pending_hash_error())?;
+                .map_err(crate::baseobjspace::map_set_update_error)?;
         } else {
             let other_items = crate::builtins::collect_iterable(*other)?;
             crate::builtins::builtin_set_add_items(args[0], &other_items)?;
@@ -20494,7 +20494,7 @@ fn set_method_difference_update(
     for other in &args[1..] {
         let w_other_as_set = set_operand_as_set(*other)?;
         unsafe { pyre_object::w_set_difference_update_from_set(args[0], w_other_as_set) }
-            .map_err(|_| crate::baseobjspace::take_pending_hash_error())?;
+            .map_err(crate::baseobjspace::map_set_update_error)?;
     }
     Ok(pyre_object::w_none())
 }
@@ -20561,7 +20561,7 @@ fn set_symmetric_difference_storage(
                         break;
                     };
                     pyre_object::w_set_insert_key_checked(w_new, key)
-                        .map_err(|_| crate::baseobjspace::take_pending_hash_error())?;
+                        .map_err(crate::baseobjspace::map_set_update_error)?;
                 }
                 i += 1;
             }
@@ -20686,7 +20686,7 @@ fn init_set_type(ns: PyObjectRef) {
                         let set = pyre_object::gc_roots::shadow_stack_get(sp);
                         let item = pyre_object::gc_roots::shadow_stack_get(sp + 1);
                         pyre_object::w_set_add_hashed_checked(set, item, hash)
-                            .map_err(|_| crate::baseobjspace::take_pending_hash_error())?;
+                            .map_err(crate::baseobjspace::map_set_update_error)?;
                     }
                     Ok(pyre_object::w_none())
                 },

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -21245,6 +21245,20 @@ fn generator_set_name(args: &[PyObjectRef]) -> crate::PyResult {
 fn generator_set_qualname(args: &[PyObjectRef]) -> crate::PyResult {
     generator_set_name_common(args, true, false)
 }
+fn generator_delete_name(_args: &[PyObjectRef]) -> crate::PyResult {
+    // CPython 3.14 routes deletion through the same string-only member
+    // setter, so `del gen.__name__` is a TypeError (the bundled 3.14
+    // GeneratorTest requires the exception class), not PyPy's older
+    // null-fdel AttributeError.
+    Err(crate::PyError::type_error(
+        "__name__ must be set to a string object",
+    ))
+}
+fn generator_delete_qualname(_args: &[PyObjectRef]) -> crate::PyResult {
+    Err(crate::PyError::type_error(
+        "__qualname__ must be set to a string object",
+    ))
+}
 fn coroutine_set_name(args: &[PyObjectRef]) -> crate::PyResult {
     generator_set_name_common(args, false, true)
 }
@@ -21313,25 +21327,28 @@ fn init_generator_type(ns: PyObjectRef) {
             )
         };
     }
-    for (name, getter, setter) in [
+    for (name, getter, setter, deleter) in [
         (
             "__name__",
             generator_get_name as DunderFn,
             generator_set_name as DunderFn,
+            generator_delete_name as DunderFn,
         ),
         (
             "__qualname__",
             generator_get_qualname as DunderFn,
             generator_set_qualname as DunderFn,
+            generator_delete_qualname as DunderFn,
         ),
     ] {
         let get = make_builtin_function_with_arity(name, getter, 2);
         let set = make_builtin_function_with_arity(name, setter, 3);
+        let delete = make_builtin_function_with_arity(name, deleter, 2);
         unsafe {
             pyre_object::w_dict_setitem_str_no_proxy(
                 ns,
                 name,
-                make_getset_property_full(get, set, PY_NULL, PY_NULL, PY_NULL, Some(name)),
+                make_getset_property_full(get, set, delete, PY_NULL, PY_NULL, Some(name)),
             )
         };
     }
@@ -21382,25 +21399,28 @@ fn init_coroutine_type(ns: PyObjectRef) {
             )
         };
     }
-    for (name, getter, setter) in [
+    for (name, getter, setter, deleter) in [
         (
             "__name__",
             coroutine_get_name as DunderFn,
             coroutine_set_name as DunderFn,
+            generator_delete_name as DunderFn,
         ),
         (
             "__qualname__",
             coroutine_get_qualname as DunderFn,
             coroutine_set_qualname as DunderFn,
+            generator_delete_qualname as DunderFn,
         ),
     ] {
         let get = make_builtin_function_with_arity(name, getter, 2);
         let set = make_builtin_function_with_arity(name, setter, 3);
+        let delete = make_builtin_function_with_arity(name, deleter, 2);
         unsafe {
             pyre_object::w_dict_setitem_str_no_proxy(
                 ns,
                 name,
-                make_getset_property_full(get, set, PY_NULL, PY_NULL, PY_NULL, Some(name)),
+                make_getset_property_full(get, set, delete, PY_NULL, PY_NULL, Some(name)),
             )
         };
     }

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -16394,6 +16394,15 @@ pub(crate) fn buffer_as_bytes_like(
     if let Some(data) = crate::module::_ctypes::cdata::cdata_bytes(obj) {
         return Ok(Some(pyre_object::bytesobject::w_bytes_from_bytes(data)));
     }
+    // `W_MMap.readbuf_w` — the mapping is a bytes-like source in its own
+    // right, so `bytes(m)` / `bytearray(m)` copy it here instead of falling
+    // through to the iterable path.
+    #[cfg(all(unix, not(feature = "sandbox")))]
+    if let Some(view) = crate::module::mmap::interp_mmap::mmap_buffer_view(obj) {
+        let (address, length, _readonly) = view?;
+        let data = unsafe { std::slice::from_raw_parts(address as *const u8, length) };
+        return Ok(Some(pyre_object::bytesobject::w_bytes_from_bytes(data)));
+    }
     if unsafe { pyre_object::bytesobject::is_bytes_like(obj) } {
         return Ok(Some(obj));
     }

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -788,6 +788,17 @@ pub fn init_typeobjects() {
             &pyre_object::generator::COROUTINE_TYPE as *const PyType as usize,
             coroutine_type as usize,
         );
+        let async_generator_type =
+            new_typeobject_with_base("async_generator", init_async_generator_type, object_type);
+        unsafe {
+            pyre_object::w_type_set_disallow_instantiation(async_generator_type);
+            pyre_object::w_type_set_acceptable_as_base_class(async_generator_type, false);
+            pyre_object::w_type_set_weakrefable(async_generator_type, true);
+        }
+        reg.insert(
+            &pyre_object::generator::ASYNC_GENERATOR_TYPE as *const PyType as usize,
+            async_generator_type as usize,
+        );
         let coroutine_wrapper_type = new_typeobject_with_base(
             "coroutine_wrapper",
             init_coroutine_wrapper_type,
@@ -801,6 +812,30 @@ pub fn init_typeobjects() {
             &pyre_object::generator::COROUTINE_WRAPPER_TYPE as *const PyType as usize,
             coroutine_wrapper_type as usize,
         );
+        for (pytype, name, init) in [
+            (
+                &pyre_object::generator::ASYNC_GEN_VALUE_WRAPPER_TYPE,
+                "async_generator_wrapped_value",
+                init_async_gen_value_wrapper_type as fn(PyObjectRef),
+            ),
+            (
+                &pyre_object::generator::ASYNC_GEN_ASEND_TYPE,
+                "async_generator_asend",
+                init_async_gen_asend_type as fn(PyObjectRef),
+            ),
+            (
+                &pyre_object::generator::ASYNC_GEN_ATHROW_TYPE,
+                "async_generator_athrow",
+                init_async_gen_athrow_type as fn(PyObjectRef),
+            ),
+        ] {
+            let ty = new_typeobject_with_base(name, init, object_type);
+            unsafe {
+                pyre_object::w_type_set_disallow_instantiation(ty);
+                pyre_object::w_type_set_acceptable_as_base_class(ty, false);
+            }
+            reg.insert(pytype as *const PyType as usize, ty as usize);
+        }
         let range_iterator_type =
             new_typeobject_with_base("range_iterator", init_range_iterator_type, object_type);
         unsafe {
@@ -21074,6 +21109,15 @@ fn coroutine_descr_repr(args: &[PyObjectRef]) -> crate::PyResult {
     )))
 }
 
+fn async_generator_descr_repr(args: &[PyObjectRef]) -> crate::PyResult {
+    let name = generator_name_value(args[0], true)?;
+    Ok(w_str_new(&format!(
+        "<async_generator object {} at {:p}>",
+        unsafe { pyre_object::w_str_get_value(name) },
+        args[0]
+    )))
+}
+
 fn generator_name_value(obj: PyObjectRef, qualname: bool) -> crate::PyResult {
     let override_value = unsafe {
         if qualname {
@@ -21099,19 +21143,23 @@ fn generator_name_value(obj: PyObjectRef, qualname: bool) -> crate::PyResult {
     Ok(w_str_new(unsafe { &(*code_ptr).obj_name }))
 }
 
-fn generator_getter_for(args: &[PyObjectRef], field: usize, coroutine: bool) -> crate::PyResult {
+fn generator_getter_for(args: &[PyObjectRef], field: usize, kind: u8) -> crate::PyResult {
     let obj = args.get(1).copied().unwrap_or(PY_NULL);
     let matches = unsafe {
-        if coroutine {
-            pyre_object::generator::is_coroutine(obj)
-        } else {
-            pyre_object::generator::is_generator(obj)
+        match kind {
+            0 => pyre_object::generator::is_generator(obj),
+            1 => pyre_object::generator::is_coroutine(obj),
+            _ => pyre_object::generator::is_async_generator(obj),
         }
     };
     if !matches {
         return Err(crate::PyError::type_error(format!(
             "descriptor is for '{}'",
-            if coroutine { "coroutine" } else { "generator" }
+            match kind {
+                0 => "generator",
+                1 => "coroutine",
+                _ => "async_generator",
+            }
         )));
     }
     let frame = generator_frame(obj);
@@ -21150,11 +21198,15 @@ fn generator_getter_for(args: &[PyObjectRef], field: usize, coroutine: bool) -> 
 }
 
 fn generator_getter(args: &[PyObjectRef], field: usize) -> crate::PyResult {
-    generator_getter_for(args, field, false)
+    generator_getter_for(args, field, 0)
 }
 
 fn coroutine_getter(args: &[PyObjectRef], field: usize) -> crate::PyResult {
-    generator_getter_for(args, field, true)
+    generator_getter_for(args, field, 1)
+}
+
+fn async_generator_getter(args: &[PyObjectRef], field: usize) -> crate::PyResult {
+    generator_getter_for(args, field, 2)
 }
 
 fn generator_get_running(args: &[PyObjectRef]) -> crate::PyResult {
@@ -21206,25 +21258,54 @@ fn coroutine_get_name(args: &[PyObjectRef]) -> crate::PyResult {
 fn coroutine_get_qualname(args: &[PyObjectRef]) -> crate::PyResult {
     coroutine_getter(args, 6)
 }
+fn async_generator_get_running(args: &[PyObjectRef]) -> crate::PyResult {
+    let obj = args.get(1).copied().unwrap_or(PY_NULL);
+    if !unsafe { pyre_object::generator::is_async_generator(obj) } {
+        return Err(crate::PyError::type_error(
+            "descriptor is for 'async_generator'",
+        ));
+    }
+    Ok(w_bool_from(unsafe {
+        pyre_object::generator::w_async_generator_is_running(obj)
+    }))
+}
+fn async_generator_get_suspended(args: &[PyObjectRef]) -> crate::PyResult {
+    async_generator_getter(args, 1)
+}
+fn async_generator_get_frame(args: &[PyObjectRef]) -> crate::PyResult {
+    async_generator_getter(args, 2)
+}
+fn async_generator_get_code(args: &[PyObjectRef]) -> crate::PyResult {
+    async_generator_getter(args, 3)
+}
+fn async_generator_get_await(args: &[PyObjectRef]) -> crate::PyResult {
+    async_generator_getter(args, 4)
+}
+fn async_generator_get_name(args: &[PyObjectRef]) -> crate::PyResult {
+    async_generator_getter(args, 5)
+}
+fn async_generator_get_qualname(args: &[PyObjectRef]) -> crate::PyResult {
+    async_generator_getter(args, 6)
+}
 
-fn generator_set_name_common(
-    args: &[PyObjectRef],
-    qualname: bool,
-    coroutine: bool,
-) -> crate::PyResult {
+fn generator_set_name_common(args: &[PyObjectRef], qualname: bool, kind: u8) -> crate::PyResult {
     let obj = args[1];
     let value = args[2];
     let matches = unsafe {
-        if coroutine {
-            pyre_object::generator::is_coroutine(obj)
-        } else {
-            pyre_object::generator::is_generator(obj)
+        match kind {
+            0 => pyre_object::generator::is_generator(obj),
+            1 => pyre_object::generator::is_coroutine(obj),
+            _ => pyre_object::generator::is_async_generator(obj),
         }
     };
     if !matches {
         return Err(crate::PyError::type_error(format!(
             "descriptor is for '{}'",
-            if coroutine { "coroutine" } else { "generator" }
+            match kind {
+                0 => "generator",
+                1 => "coroutine",
+                _ => "async_generator",
+            }
         )));
     }
     if !unsafe { pyre_object::is_str(value) } {
@@ -21244,10 +21325,10 @@ fn generator_set_name_common(
 }
 
 fn generator_set_name(args: &[PyObjectRef]) -> crate::PyResult {
-    generator_set_name_common(args, false, false)
+    generator_set_name_common(args, false, 0)
 }
 fn generator_set_qualname(args: &[PyObjectRef]) -> crate::PyResult {
-    generator_set_name_common(args, true, false)
+    generator_set_name_common(args, true, 0)
 }
 fn generator_delete_name(_args: &[PyObjectRef]) -> crate::PyResult {
     // CPython 3.14 routes deletion through the same string-only member
@@ -21264,10 +21345,16 @@ fn generator_delete_qualname(_args: &[PyObjectRef]) -> crate::PyResult {
     ))
 }
 fn coroutine_set_name(args: &[PyObjectRef]) -> crate::PyResult {
-    generator_set_name_common(args, false, true)
+    generator_set_name_common(args, false, 1)
 }
 fn coroutine_set_qualname(args: &[PyObjectRef]) -> crate::PyResult {
-    generator_set_name_common(args, true, true)
+    generator_set_name_common(args, true, 1)
+}
+fn async_generator_set_name(args: &[PyObjectRef]) -> crate::PyResult {
+    generator_set_name_common(args, false, 2)
+}
+fn async_generator_set_qualname(args: &[PyObjectRef]) -> crate::PyResult {
+    generator_set_name_common(args, true, 2)
 }
 
 fn generator_descr_sizeof(_args: &[PyObjectRef]) -> crate::PyResult {
@@ -21428,6 +21515,156 @@ fn init_coroutine_type(ns: PyObjectRef) {
             )
         };
     }
+}
+
+/// PyPy `generator.py AsyncGenerator.typedef`.
+fn init_async_generator_type(ns: PyObjectRef) {
+    unsafe { pyre_object::w_dict_setitem_str(ns, "__doc__", w_none()) };
+    for (name, function, arity) in [
+        ("__repr__", async_generator_descr_repr as DunderFn, 1),
+        (
+            "asend",
+            crate::baseobjspace::async_generator_asend_method,
+            2,
+        ),
+        (
+            "aclose",
+            crate::baseobjspace::async_generator_aclose_method,
+            1,
+        ),
+        ("__aiter__", crate::baseobjspace::iter_self_method, 1),
+        (
+            "__anext__",
+            crate::baseobjspace::async_generator_anext_method,
+            1,
+        ),
+        ("__sizeof__", generator_descr_sizeof, 1),
+    ] {
+        unsafe {
+            pyre_object::w_dict_setitem_str_no_proxy(
+                ns,
+                name,
+                make_builtin_function_with_arity(name, function, arity),
+            )
+        };
+    }
+    unsafe {
+        pyre_object::w_dict_setitem_str(
+            ns,
+            "athrow",
+            make_builtin_function("athrow", crate::baseobjspace::async_generator_athrow_method),
+        );
+        pyre_object::w_dict_setitem_str(
+            ns,
+            "__class_getitem__",
+            pyre_object::function::w_classmethod_new(make_builtin_function(
+                "__class_getitem__",
+                crate::_pypy_generic_alias::generic_alias_class_getitem,
+            )),
+        );
+    }
+    for (name, getter) in [
+        ("ag_running", async_generator_get_running as DunderFn),
+        ("ag_suspended", async_generator_get_suspended as DunderFn),
+        ("ag_frame", async_generator_get_frame as DunderFn),
+        ("ag_code", async_generator_get_code as DunderFn),
+        ("ag_await", async_generator_get_await as DunderFn),
+    ] {
+        unsafe {
+            pyre_object::w_dict_setitem_str_no_proxy(
+                ns,
+                name,
+                make_getset_descriptor_named(
+                    make_builtin_function_with_arity(name, getter, 2),
+                    name,
+                ),
+            )
+        };
+    }
+    for (name, getter, setter, deleter) in [
+        (
+            "__name__",
+            async_generator_get_name as DunderFn,
+            async_generator_set_name as DunderFn,
+            generator_delete_name as DunderFn,
+        ),
+        (
+            "__qualname__",
+            async_generator_get_qualname as DunderFn,
+            async_generator_set_qualname as DunderFn,
+            generator_delete_qualname as DunderFn,
+        ),
+    ] {
+        unsafe {
+            pyre_object::w_dict_setitem_str_no_proxy(
+                ns,
+                name,
+                make_getset_property_full(
+                    make_builtin_function_with_arity(name, getter, 2),
+                    make_builtin_function_with_arity(name, setter, 3),
+                    make_builtin_function_with_arity(name, deleter, 2),
+                    PY_NULL,
+                    PY_NULL,
+                    Some(name),
+                ),
+            )
+        };
+    }
+}
+
+fn init_async_gen_value_wrapper_type(ns: PyObjectRef) {
+    unsafe { pyre_object::w_dict_setitem_str(ns, "__doc__", w_none()) };
+}
+
+fn init_async_gen_awaitable_type(ns: PyObjectRef, athrow: bool) {
+    unsafe { pyre_object::w_dict_setitem_str(ns, "__doc__", w_none()) };
+    let (next, send, throw, close) = if athrow {
+        (
+            crate::baseobjspace::async_gen_athrow_next_method as DunderFn,
+            crate::baseobjspace::async_gen_athrow_send_method as DunderFn,
+            crate::baseobjspace::async_gen_athrow_throw_method as DunderFn,
+            crate::baseobjspace::async_gen_athrow_close_method as DunderFn,
+        )
+    } else {
+        (
+            crate::baseobjspace::async_gen_asend_next_method as DunderFn,
+            crate::baseobjspace::async_gen_asend_send_method as DunderFn,
+            crate::baseobjspace::async_gen_asend_throw_method as DunderFn,
+            crate::baseobjspace::async_gen_asend_close_method as DunderFn,
+        )
+    };
+    for (name, function, arity) in [
+        (
+            "__await__",
+            crate::baseobjspace::iter_self_method as DunderFn,
+            1,
+        ),
+        (
+            "__iter__",
+            crate::baseobjspace::iter_self_method as DunderFn,
+            1,
+        ),
+        ("__next__", next, 1),
+        ("send", send, 2),
+        ("close", close, 1),
+    ] {
+        unsafe {
+            pyre_object::w_dict_setitem_str_no_proxy(
+                ns,
+                name,
+                make_builtin_function_with_arity(name, function, arity),
+            )
+        };
+    }
+    unsafe { pyre_object::w_dict_setitem_str(ns, "throw", make_builtin_function("throw", throw)) };
+}
+
+fn init_async_gen_asend_type(ns: PyObjectRef) {
+    init_async_gen_awaitable_type(ns, false)
+}
+
+fn init_async_gen_athrow_type(ns: PyObjectRef) {
+    init_async_gen_awaitable_type(ns, true)
 }
 
 /// PyPy `generator.py CoroutineWrapper.typedef`.

--- a/pyre/pyre-interpreter/src/warn.rs
+++ b/pyre/pyre-interpreter/src/warn.rs
@@ -9,9 +9,19 @@
 
 /// baseobjspace.py:2087: space.warn(space.newtext(msg), space.w_DeprecationWarning)
 pub fn warn_deprecation(msg: &str) -> Result<(), crate::PyError> {
+    warn_category(msg, "DeprecationWarning", 2)
+}
+
+/// Route an interpreter warning through Python's warnings machinery so
+/// filters and `warnings.catch_warnings(record=True)` observe it.
+pub fn warn_category(
+    msg: &str,
+    category_name: &str,
+    stacklevel: i64,
+) -> Result<(), crate::PyError> {
     if let (Some(warnings), Some(category)) = (
         crate::importing::get_sys_module("warnings"),
-        crate::builtins::lookup_exc_class("DeprecationWarning"),
+        crate::builtins::lookup_exc_class(category_name),
     ) {
         if let Ok(warn_fn) = crate::baseobjspace::getattr_str(warnings, "warn") {
             crate::call::call_function_impl_result(
@@ -19,14 +29,14 @@ pub fn warn_deprecation(msg: &str) -> Result<(), crate::PyError> {
                 &[
                     pyre_object::w_str_new(msg),
                     category,
-                    pyre_object::w_int_new(2),
+                    pyre_object::w_int_new(stacklevel),
                 ],
             )
             .map(|_| ())?;
             return Ok(());
         }
     }
-    warn(msg, "DeprecationWarning");
+    warn(msg, category_name);
     Ok(())
 }
 

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -409,6 +409,7 @@ unsafe fn type_object_destructor(obj_addr: usize) {
 /// `gc.collect()` runs) is not reclaimed.
 unsafe fn generator_object_custom_trace(obj_addr: usize, f: &mut dyn FnMut(*mut majit_ir::GcRef)) {
     let gen_obj = unsafe { &mut *(obj_addr as *mut pyre_object::generator::GeneratorIterator) };
+    f(&mut gen_obj.pycode as *mut pyre_object::PyObjectRef as *mut majit_ir::GcRef);
     f(&mut gen_obj.name as *mut pyre_object::PyObjectRef as *mut majit_ir::GcRef);
     f(&mut gen_obj.qualname as *mut pyre_object::PyObjectRef as *mut majit_ir::GcRef);
     f(&mut gen_obj.cr_origin as *mut pyre_object::PyObjectRef as *mut majit_ir::GcRef);
@@ -424,6 +425,7 @@ unsafe fn generator_object_custom_trace(obj_addr: usize, f: &mut dyn FnMut(*mut 
     // for its active `sys_exc_value` slot.
     let mut exception_adapter = |slot: &mut majit_ir::GcRef| f(slot as *mut majit_ir::GcRef);
     unsafe {
+        pyre_interpreter::eval::walk_raw_code_roots(gen_obj.pycode, &mut exception_adapter);
         pyre_interpreter::eval::walk_raw_exception_roots(
             gen_obj.saved_exc_value,
             &mut exception_adapter,

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -412,6 +412,23 @@ unsafe fn generator_object_custom_trace(obj_addr: usize, f: &mut dyn FnMut(*mut 
     f(&mut gen_obj.name as *mut pyre_object::PyObjectRef as *mut majit_ir::GcRef);
     f(&mut gen_obj.qualname as *mut pyre_object::PyObjectRef as *mut majit_ir::GcRef);
     f(&mut gen_obj.cr_origin as *mut pyre_object::PyObjectRef as *mut majit_ir::GcRef);
+    f(&mut gen_obj.saved_exc_value as *mut pyre_object::PyObjectRef as *mut majit_ir::GcRef);
+    f(
+        &mut gen_obj.previous_gen_or_coroutine as *mut pyre_object::PyObjectRef
+            as *mut majit_ir::GcRef,
+    );
+    // W_BaseException is currently malloc_typed-immortal, so forwarding its
+    // carrier above does not make the collector visit traceback/context/args.
+    // Preserve the children of the exception parked by
+    // `ExecutionContext.pop_gen_or_coroutine`, just as the EC root walker does
+    // for its active `sys_exc_value` slot.
+    let mut exception_adapter = |slot: &mut majit_ir::GcRef| f(slot as *mut majit_ir::GcRef);
+    unsafe {
+        pyre_interpreter::eval::walk_raw_exception_roots(
+            gen_obj.saved_exc_value,
+            &mut exception_adapter,
+        )
+    };
     if !gen_obj.frame_ptr.is_null() {
         let frame = gen_obj.frame_ptr as *mut PyFrame;
         if pyre_object::gc_hook::try_gc_owns_object(gen_obj.frame_ptr) {

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -409,6 +409,7 @@ unsafe fn type_object_destructor(obj_addr: usize) {
 /// `gc.collect()` runs) is not reclaimed.
 unsafe fn generator_object_custom_trace(obj_addr: usize, f: &mut dyn FnMut(*mut majit_ir::GcRef)) {
     let gen_obj = unsafe { &mut *(obj_addr as *mut pyre_object::generator::GeneratorIterator) };
+    f(&mut gen_obj.ob.w_class as *mut pyre_object::PyObjectRef as *mut majit_ir::GcRef);
     f(&mut gen_obj.pycode as *mut pyre_object::PyObjectRef as *mut majit_ir::GcRef);
     f(&mut gen_obj.name as *mut pyre_object::PyObjectRef as *mut majit_ir::GcRef);
     f(&mut gen_obj.qualname as *mut pyre_object::PyObjectRef as *mut majit_ir::GcRef);
@@ -477,6 +478,7 @@ unsafe fn pytraceback_object_custom_trace(
     f: &mut dyn FnMut(*mut majit_ir::GcRef),
 ) {
     let tb = unsafe { &mut *(obj_addr as *mut pyre_interpreter::pytraceback::PyTraceback) };
+    f(&mut tb.ob_header.w_class as *mut pyre_object::PyObjectRef as *mut majit_ir::GcRef);
     f(&mut tb.w_next as *mut pyre_object::PyObjectRef as *mut majit_ir::GcRef);
     f(&mut tb.w_code as *mut pyre_object::PyObjectRef as *mut majit_ir::GcRef);
     if !tb.frame.is_null() && pyre_object::gc_hook::try_gc_owns_object(tb.frame as *mut u8) {
@@ -486,6 +488,8 @@ unsafe fn pytraceback_object_custom_trace(
 
 unsafe fn dict_object_custom_trace(obj_addr: usize, f: &mut dyn FnMut(*mut majit_ir::GcRef)) {
     let w_dict = obj_addr as pyre_object::PyObjectRef;
+    let dict = unsafe { &mut *(obj_addr as *mut pyre_object::dictmultiobject::W_DictObject) };
+    f(&mut dict.ob_header.w_class as *mut pyre_object::PyObjectRef as *mut majit_ir::GcRef);
     let strategy = unsafe { pyre_object::dictmultiobject::w_dict_get_strategy(w_dict) };
     // Keep the stable leaf storage box alive by forwarding its owning
     // `dstorage` field slot (off-GC storage). The box has no walker
@@ -497,7 +501,6 @@ unsafe fn dict_object_custom_trace(obj_addr: usize, f: &mut dyn FnMut(*mut majit
     // (`w_dict_new_unmanaged_side_table_value`) is not collector-owned —
     // both are skipped (Map by kind, the side table by `try_gc_owns_object`).
     if strategy.strategy_kind() != pyre_object::dictmultiobject::StrategyKind::Map {
-        let dict = unsafe { &mut *(obj_addr as *mut pyre_object::dictmultiobject::W_DictObject) };
         if !dict.dstorage.is_null() && pyre_object::gc_hook::try_gc_owns_object(dict.dstorage) {
             let dstorage_slot = std::ptr::addr_of_mut!(dict.dstorage);
             f(dstorage_slot as *mut majit_ir::GcRef);
@@ -633,13 +636,14 @@ unsafe fn module_dict_object_custom_trace(
     f: &mut dyn FnMut(*mut majit_ir::GcRef),
 ) {
     let obj = obj_addr as pyre_object::PyObjectRef;
+    let md = unsafe { &mut *(obj_addr as *mut pyre_object::dictmultiobject::W_ModuleDictObject) };
+    f(&mut md.ob_header.w_class as *mut pyre_object::PyObjectRef as *mut majit_ir::GcRef);
     // Grey each GC-managed storage box through its field slot so a major GC
     // keeps it live; the box interiors are GC leaves, so the walk below is
     // the only thing that forwards their element slots.  Non-moving, so the
     // minor-GC forward is a no-op.  Guard on GC ownership: a `tid == 0`
     // `malloc_raw` fallback box (unit tests / pre-init) has no GC hook.
     if pyre_object::dictmultiobject::is_module_dict(obj) {
-        let md = &mut *(obj as *mut pyre_object::dictmultiobject::W_ModuleDictObject);
         for field in [
             std::ptr::addr_of_mut!(md.dstorage) as *mut *mut u8,
             std::ptr::addr_of_mut!(md.object_storage) as *mut *mut u8,
@@ -666,6 +670,13 @@ unsafe fn module_dict_object_custom_trace(
 
 unsafe fn set_object_custom_trace(obj_addr: usize, f: &mut dyn FnMut(*mut majit_ir::GcRef)) {
     let set = unsafe { &mut *(obj_addr as *mut pyre_object::setobject::W_SetObject) };
+    // A builtin-layout instance can carry a mortal heap subclass in the
+    // inline `w_class` header word.  This is the instance -> class edge that
+    // PyPy obtains from the W_Root object's runtime class.  Keep it on the
+    // set itself: in `check_free_after_iterating`, exhausting the iterator
+    // releases the last other reference to a frozenset subclass immediately
+    // before its instance finalizer resolves `__del__` through that class.
+    f(&mut set.ob_header.w_class as *mut pyre_object::PyObjectRef as *mut majit_ir::GcRef);
     // Keep the stable leaf storage box alive by forwarding its owning field
     // slot. The box has no walker of its own; this trace also walks its inner
     // ObjectKey slots below, matching the mapdict leaf-storage pattern.
@@ -698,7 +709,8 @@ unsafe fn set_object_custom_trace(obj_addr: usize, f: &mut dyn FnMut(*mut majit_
 /// (`capacity == len`, every slot written by `alloc_tuple_items_block`).
 unsafe fn tuple_object_custom_trace(obj_addr: usize, f: &mut dyn FnMut(*mut majit_ir::GcRef)) {
     let tuple_ptr = obj_addr as *mut pyre_object::tupleobject::W_TupleObject;
-    let tuple = unsafe { &*tuple_ptr };
+    let tuple = unsafe { &mut *tuple_ptr };
+    f(&mut tuple.ob_header.w_class as *mut pyre_object::PyObjectRef as *mut majit_ir::GcRef);
     let block = tuple.wrappeditems;
     if block.is_null() {
         return;
@@ -733,7 +745,8 @@ unsafe fn tuple_object_custom_trace(obj_addr: usize, f: &mut dyn FnMut(*mut maji
 /// behind.
 unsafe fn list_object_custom_trace(obj_addr: usize, f: &mut dyn FnMut(*mut majit_ir::GcRef)) {
     let list_ptr = obj_addr as *mut pyre_object::listobject::W_ListObject;
-    let list = unsafe { &*list_ptr };
+    let list = unsafe { &mut *list_ptr };
+    f(&mut list.ob_header.w_class as *mut pyre_object::PyObjectRef as *mut majit_ir::GcRef);
     if list.strategy == pyre_object::listobject::ListStrategy::Object && !list.items.is_null() {
         if pyre_object::gc_hook::try_gc_owns_object(list.items as *mut u8) {
             // Phase L2: a GC-managed (moving) block is forwarded by handing the
@@ -918,6 +931,7 @@ unsafe fn memoryview_object_destructor(obj_addr: usize) {
 unsafe fn pyframe_object_custom_trace(obj_addr: usize, f: &mut dyn FnMut(*mut majit_ir::GcRef)) {
     let frame = unsafe { &mut *(obj_addr as *mut PyFrame) };
 
+    f(&mut frame.ob_header.w_class as *mut pyre_object::PyObjectRef as *mut majit_ir::GcRef);
     f(&mut frame.f_backref as *mut *mut PyFrame as *mut majit_ir::GcRef);
     f(&mut frame.pycode as *mut *const () as *mut majit_ir::GcRef);
 

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -2878,6 +2878,16 @@ fn build_gc() -> Box<dyn majit_gc::GcAllocator> {
     // run its Drop glue and free that heap instead of leaking it.
     gc.types
         .set_destructor(tokenizer_iter_tid, tokenizer_iter_destructor);
+    // Python 3.14 FrameLocalsProxy — its sole managed edge owns the live
+    // PyFrame whose fast locals it exposes.  Keep the proxy in the ordinary
+    // AUTO-ID class chain so the generated offset walker forwards that frame
+    // for as long as user code retains the proxy.
+    register_pyre_class(
+        &mut gc,
+        &mut pytype_to_tid,
+        <pyre_interpreter::pyframe::frame_locals_proxy::FrameLocalsProxy
+            as pyre_object::lltype::PyreClassPyTypeOf>::DESCRIPTOR,
+    );
     // A Block is GC-managed but is not an rclass.OBJECT subclass and has no
     // Python-visible vtable.  Registering it through `register_pyre_class`
     // would add a spurious subclass-range alias and shift W_Deque's canonical

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -414,6 +414,7 @@ unsafe fn generator_object_custom_trace(obj_addr: usize, f: &mut dyn FnMut(*mut 
     f(&mut gen_obj.name as *mut pyre_object::PyObjectRef as *mut majit_ir::GcRef);
     f(&mut gen_obj.qualname as *mut pyre_object::PyObjectRef as *mut majit_ir::GcRef);
     f(&mut gen_obj.cr_origin as *mut pyre_object::PyObjectRef as *mut majit_ir::GcRef);
+    f(&mut gen_obj.w_finalizer as *mut pyre_object::PyObjectRef as *mut majit_ir::GcRef);
     f(&mut gen_obj.saved_exc_value as *mut pyre_object::PyObjectRef as *mut majit_ir::GcRef);
     f(
         &mut gen_obj.previous_gen_or_coroutine as *mut pyre_object::PyObjectRef
@@ -1740,7 +1741,7 @@ fn build_gc() -> Box<dyn majit_gc::GcAllocator> {
     // `pytype_to_tid`, so this pre-registration wins over its
     // generic `object_subclass(sizeof(PyObject), parent_tid)`
     // default which would underallocate `W_BaseException`.
-    for kind_idx in 0u8..=(pyre_object::interp_exceptions::ExcKind::UnboundLocalError as u8) {
+    for kind_idx in 0u8..=(pyre_object::interp_exceptions::ExcKind::StopAsyncIteration as u8) {
         // Round-trip the byte through the enum so we don't depend
         // on unsafe transmute; every value in [0, UnboundLocalError]
         // is a valid `ExcKind` variant by construction.
@@ -1778,6 +1779,7 @@ fn build_gc() -> Box<dyn majit_gc::GcAllocator> {
             30 => pyre_object::interp_exceptions::ExcKind::SyntaxError,
             31 => pyre_object::interp_exceptions::ExcKind::BufferError,
             32 => pyre_object::interp_exceptions::ExcKind::UnboundLocalError,
+            33 => pyre_object::interp_exceptions::ExcKind::StopAsyncIteration,
             _ => unreachable!(),
         };
         let pytype_ptr =
@@ -2888,6 +2890,34 @@ fn build_gc() -> Box<dyn majit_gc::GcAllocator> {
         <pyre_interpreter::pyframe::frame_locals_proxy::FrameLocalsProxy
             as pyre_object::lltype::PyreClassPyTypeOf>::DESCRIPTOR,
     );
+    // AsyncGenerator shares GeneratorOrCoroutine's suspended-frame payload
+    // and custom trace, but keeps a distinct vtable identity.  Its helper
+    // awaitables are appended at the absolute AUTO-ID tail so existing type
+    // ids remain stable.
+    let async_generator_vtable_tid = gc.register_type(TypeInfo::object_subclass_with_custom_trace(
+        std::mem::size_of::<pyre_object::generator::GeneratorIterator>(),
+        object_tid,
+        generator_object_custom_trace,
+    ));
+    majit_gc::GcAllocator::register_vtable_for_type(
+        &mut gc,
+        &pyre_object::generator::ASYNC_GENERATOR_TYPE as *const _ as usize,
+        async_generator_vtable_tid,
+    );
+    pytype_to_tid.insert(
+        &pyre_object::generator::ASYNC_GENERATOR_TYPE as *const _ as usize,
+        async_generator_vtable_tid,
+    );
+    for descriptor in [
+        <pyre_object::generator::AsyncGenValueWrapper
+            as pyre_object::lltype::PyreClassPyTypeOf>::DESCRIPTOR,
+        <pyre_object::generator::AsyncGenASend
+            as pyre_object::lltype::PyreClassPyTypeOf>::DESCRIPTOR,
+        <pyre_object::generator::AsyncGenAThrow
+            as pyre_object::lltype::PyreClassPyTypeOf>::DESCRIPTOR,
+    ] {
+        register_pyre_class(&mut gc, &mut pytype_to_tid, descriptor);
+    }
     // A Block is GC-managed but is not an rclass.OBJECT subclass and has no
     // Python-visible vtable.  Registering it through `register_pyre_class`
     // would add a spurious subclass-range alias and shift W_Deque's canonical

--- a/pyre/pyre-object/src/buffer.rs
+++ b/pyre/pyre-object/src/buffer.rs
@@ -46,6 +46,27 @@ pub enum Buffer {
     },
 }
 
+/// Drop the export an `External` window holds on its owner.  The owners that
+/// keep a count (`mmap`) live above this crate, so the interpreter installs
+/// the callback at start-up; until then, and for owners that keep no count
+/// (`ctypes.memoryview_at`, whose `w_obj` is `None`), releasing is a no-op.
+static EXTERNAL_RELEASE: core::sync::atomic::AtomicUsize =
+    core::sync::atomic::AtomicUsize::new(0);
+
+/// # Safety
+/// `f` must stay valid for the process lifetime and accept any `w_obj` that
+/// was stored in an `External` buffer.
+pub unsafe fn set_external_release_hook(f: unsafe fn(PyObjectRef)) {
+    EXTERNAL_RELEASE.store(f as usize, core::sync::atomic::Ordering::Release);
+}
+
+unsafe fn external_release(w_obj: PyObjectRef) {
+    let f = EXTERNAL_RELEASE.load(core::sync::atomic::Ordering::Acquire);
+    if f != 0 && !w_obj.is_null() {
+        unsafe { core::mem::transmute::<usize, unsafe fn(PyObjectRef)>(f)(w_obj) }
+    }
+}
+
 impl Buffer {
     /// Release the single exporter lock owned by a root memoryview.
     /// Derived/sub views do not call this; their root view owns the count.
@@ -57,7 +78,7 @@ impl Buffer {
                 }
                 Buffer::Array { w_obj } => crate::interp_array::w_array_exports_decref(*w_obj),
                 Buffer::String { .. } => {}
-                Buffer::External { .. } => {}
+                Buffer::External { w_obj, .. } => external_release(*w_obj),
                 Buffer::Sub { parent, .. } => parent.release_export(),
             }
         }

--- a/pyre/pyre-object/src/buffer.rs
+++ b/pyre/pyre-object/src/buffer.rs
@@ -50,8 +50,7 @@ pub enum Buffer {
 /// keep a count (`mmap`) live above this crate, so the interpreter installs
 /// the callback at start-up; until then, and for owners that keep no count
 /// (`ctypes.memoryview_at`, whose `w_obj` is `None`), releasing is a no-op.
-static EXTERNAL_RELEASE: core::sync::atomic::AtomicUsize =
-    core::sync::atomic::AtomicUsize::new(0);
+static EXTERNAL_RELEASE: core::sync::atomic::AtomicUsize = core::sync::atomic::AtomicUsize::new(0);
 
 /// # Safety
 /// `f` must stay valid for the process lifetime and accept any `w_obj` that

--- a/pyre/pyre-object/src/bufferview.rs
+++ b/pyre/pyre-object/src/bufferview.rs
@@ -340,7 +340,20 @@ impl BufferView {
                 BufferView::View1D { parent, .. } => parent.length(),
                 BufferView::ViewND {
                     parent, w_shape, ..
-                } => read_dims(*w_shape).iter().product::<i64>() * parent.itemsize(),
+                } => {
+                    let shape = read_dims(*w_shape);
+                    // CPython 3.14 exposes a resized zero-field ctypes
+                    // Structure as a 0-D, itemsize-zero buffer whose nbytes
+                    // is nevertheless the full resized backing.  Preserve
+                    // that parent's byte extent so `view.cast("B")` can
+                    // flatten it; ordinary BufferViewND follows PyPy's
+                    // product(shape) * itemsize calculation below.
+                    if shape.is_empty() && parent.itemsize() == 0 {
+                        parent.length()
+                    } else {
+                        shape.iter().product::<i64>() * parent.itemsize()
+                    }
+                }
                 BufferView::Readonly { view, .. } => view.length(),
             }
         }

--- a/pyre/pyre-object/src/generator.rs
+++ b/pyre/pyre-object/src/generator.rs
@@ -8,6 +8,7 @@ use pyre_macros::pyre_class;
 
 pub static GENERATOR_TYPE: PyType = crate::pyobject::new_pytype("generator");
 pub static COROUTINE_TYPE: PyType = crate::pyobject::new_pytype("coroutine");
+pub static ASYNC_GENERATOR_TYPE: PyType = crate::pyobject::new_pytype("async_generator");
 
 /// Generator object: holds a boxed frame that can be resumed.
 ///
@@ -48,6 +49,11 @@ pub struct GeneratorIterator {
     /// `generator.py:30` `previous_gen_or_coroutine`: the execution-context
     /// linked-list edge while this generator is running.
     pub previous_gen_or_coroutine: PyObjectRef,
+    /// `AsyncGenerator.hooks_inited` / `ag_running` / `w_finalizer`.
+    /// Generator and coroutine instances keep the neutral values.
+    pub hooks_inited: bool,
+    pub ag_running: bool,
+    pub w_finalizer: PyObjectRef,
 }
 
 /// PyPy `generator.py CoroutineWrapper`: the iterator returned by
@@ -55,6 +61,39 @@ pub struct GeneratorIterator {
 #[pyre_class("coroutine_wrapper", static_name = "COROUTINE_WRAPPER")]
 pub struct CoroutineWrapper {
     pub coroutine: PyObjectRef,
+}
+
+/// PyPy `generator.py AsyncGenValueWrapper`: distinguishes a value yielded
+/// by an async generator from a value yielded by an await inside its body.
+#[pyre_class(
+    "async_generator_wrapped_value",
+    static_name = "ASYNC_GEN_VALUE_WRAPPER"
+)]
+pub struct AsyncGenValueWrapper {
+    pub w_value: PyObjectRef,
+}
+
+/// Shared state values from PyPy `AsyncGenABase`.
+pub const ASYNC_GEN_STATE_INIT: u8 = 0;
+pub const ASYNC_GEN_STATE_ITER: u8 = 1;
+pub const ASYNC_GEN_STATE_CLOSED: u8 = 2;
+
+#[pyre_class("async_generator_asend", static_name = "ASYNC_GEN_ASEND")]
+pub struct AsyncGenASend {
+    pub async_gen: PyObjectRef,
+    pub w_value_to_send: PyObjectRef,
+    pub state: u8,
+}
+
+#[pyre_class("async_generator_athrow", static_name = "ASYNC_GEN_ATHROW")]
+pub struct AsyncGenAThrow {
+    pub async_gen: PyObjectRef,
+    /// `PY_NULL` identifies `aclose()`; otherwise these are the arguments to
+    /// `athrow()` and optional values use Python `None`.
+    pub w_exc_type: PyObjectRef,
+    pub w_exc_value: PyObjectRef,
+    pub w_exc_tb: PyObjectRef,
+    pub state: u8,
 }
 
 /// GC type id assigned to `GeneratorIterator` at JitDriver init time.
@@ -73,21 +112,21 @@ impl crate::lltype::GcType for GeneratorIterator {
 fn w_generator_or_coroutine_new(
     frame_ptr: *mut u8,
     pycode: PyObjectRef,
-    coroutine: bool,
+    kind: GeneratorKind,
 ) -> PyObjectRef {
     let _roots = crate::gc_roots::push_roots();
     crate::gc_roots::pin_root(pycode);
     let value = GeneratorIterator {
         ob: PyObject {
-            ob_type: if coroutine {
-                &COROUTINE_TYPE as *const PyType
-            } else {
-                &GENERATOR_TYPE as *const PyType
+            ob_type: match kind {
+                GeneratorKind::Generator => &GENERATOR_TYPE as *const PyType,
+                GeneratorKind::Coroutine => &COROUTINE_TYPE as *const PyType,
+                GeneratorKind::AsyncGenerator => &ASYNC_GENERATOR_TYPE as *const PyType,
             },
-            w_class: if coroutine {
-                get_instantiate(&COROUTINE_TYPE)
-            } else {
-                get_instantiate(&GENERATOR_TYPE)
+            w_class: match kind {
+                GeneratorKind::Generator => get_instantiate(&GENERATOR_TYPE),
+                GeneratorKind::Coroutine => get_instantiate(&COROUTINE_TYPE),
+                GeneratorKind::AsyncGenerator => get_instantiate(&ASYNC_GENERATOR_TYPE),
             },
         },
         frame_ptr,
@@ -97,10 +136,17 @@ fn w_generator_or_coroutine_new(
         running: false,
         name: PY_NULL,
         qualname: PY_NULL,
-        cr_origin: if coroutine { crate::w_none() } else { PY_NULL },
+        cr_origin: if kind == GeneratorKind::Coroutine {
+            crate::w_none()
+        } else {
+            PY_NULL
+        },
         warned_unawaited: false,
         saved_exc_value: PY_NULL,
         previous_gen_or_coroutine: PY_NULL,
+        hooks_inited: false,
+        ag_running: false,
+        w_finalizer: PY_NULL,
     };
     // A generator must be GC-managed, not immortal `malloc_typed`: the
     // collector never reaches an immortal object, so the registered
@@ -126,12 +172,23 @@ fn w_generator_or_coroutine_new(
     crate::lltype::malloc_typed(value) as PyObjectRef
 }
 
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum GeneratorKind {
+    Generator,
+    Coroutine,
+    AsyncGenerator,
+}
+
 pub fn w_generator_new(frame_ptr: *mut u8, pycode: PyObjectRef) -> PyObjectRef {
-    w_generator_or_coroutine_new(frame_ptr, pycode, false)
+    w_generator_or_coroutine_new(frame_ptr, pycode, GeneratorKind::Generator)
 }
 
 pub fn w_coroutine_new(frame_ptr: *mut u8, pycode: PyObjectRef) -> PyObjectRef {
-    w_generator_or_coroutine_new(frame_ptr, pycode, true)
+    w_generator_or_coroutine_new(frame_ptr, pycode, GeneratorKind::Coroutine)
+}
+
+pub fn w_async_generator_new(frame_ptr: *mut u8, pycode: PyObjectRef) -> PyObjectRef {
+    w_generator_or_coroutine_new(frame_ptr, pycode, GeneratorKind::AsyncGenerator)
 }
 
 pub fn w_coroutine_wrapper_new(coroutine: PyObjectRef) -> PyObjectRef {
@@ -157,8 +214,65 @@ pub unsafe fn is_coroutine(obj: PyObjectRef) -> bool {
 }
 
 #[inline]
+pub unsafe fn is_async_generator(obj: PyObjectRef) -> bool {
+    unsafe { py_type_check(obj, &ASYNC_GENERATOR_TYPE) }
+}
+
+#[inline]
 pub unsafe fn is_generator_or_coroutine(obj: PyObjectRef) -> bool {
-    unsafe { is_generator(obj) || is_coroutine(obj) }
+    unsafe { is_generator(obj) || is_coroutine(obj) || is_async_generator(obj) }
+}
+
+pub fn w_async_gen_value_wrapper_new(w_value: PyObjectRef) -> PyObjectRef {
+    let _roots = crate::gc_roots::push_roots();
+    crate::gc_roots::pin_root(w_value);
+    AsyncGenValueWrapper::allocate(AsyncGenValueWrapper {
+        ob: PyObject {
+            ob_type: std::ptr::null(),
+            w_class: std::ptr::null_mut(),
+        },
+        w_value,
+    })
+}
+
+pub fn w_async_gen_asend_new(async_gen: PyObjectRef, w_value_to_send: PyObjectRef) -> PyObjectRef {
+    let _roots = crate::gc_roots::push_roots();
+    crate::gc_roots::pin_root(async_gen);
+    crate::gc_roots::pin_root(w_value_to_send);
+    AsyncGenASend::allocate(AsyncGenASend {
+        ob: PyObject {
+            ob_type: std::ptr::null(),
+            w_class: std::ptr::null_mut(),
+        },
+        async_gen,
+        w_value_to_send,
+        state: ASYNC_GEN_STATE_INIT,
+    })
+}
+
+pub fn w_async_gen_athrow_new(
+    async_gen: PyObjectRef,
+    w_exc_type: PyObjectRef,
+    w_exc_value: PyObjectRef,
+    w_exc_tb: PyObjectRef,
+) -> PyObjectRef {
+    let _roots = crate::gc_roots::push_roots();
+    for value in [async_gen, w_exc_type, w_exc_value, w_exc_tb] {
+        if !value.is_null() {
+            crate::gc_roots::pin_root(value);
+        }
+    }
+    AsyncGenAThrow::allocate(AsyncGenAThrow {
+        ob: PyObject {
+            ob_type: std::ptr::null(),
+            w_class: std::ptr::null_mut(),
+        },
+        async_gen,
+        w_exc_type,
+        w_exc_value,
+        w_exc_tb,
+        state: ASYNC_GEN_STATE_INIT,
+    })
 }
 
 #[inline]
@@ -265,6 +379,37 @@ pub unsafe fn w_generator_set_qualname(obj: PyObjectRef, value: PyObjectRef) {
 #[inline]
 pub unsafe fn w_coroutine_get_origin(obj: PyObjectRef) -> PyObjectRef {
     unsafe { (*(obj as *const GeneratorIterator)).cr_origin }
+}
+
+#[inline]
+pub unsafe fn w_async_generator_hooks_inited(obj: PyObjectRef) -> bool {
+    unsafe { (*(obj as *const GeneratorIterator)).hooks_inited }
+}
+
+#[inline]
+pub unsafe fn w_async_generator_set_hooks_inited(obj: PyObjectRef) {
+    unsafe { (*(obj as *mut GeneratorIterator)).hooks_inited = true };
+}
+
+#[inline]
+pub unsafe fn w_async_generator_is_running(obj: PyObjectRef) -> bool {
+    unsafe { (*(obj as *const GeneratorIterator)).ag_running }
+}
+
+#[inline]
+pub unsafe fn w_async_generator_set_running(obj: PyObjectRef, value: bool) {
+    unsafe { (*(obj as *mut GeneratorIterator)).ag_running = value };
+}
+
+#[inline]
+pub unsafe fn w_async_generator_get_finalizer(obj: PyObjectRef) -> PyObjectRef {
+    unsafe { (*(obj as *const GeneratorIterator)).w_finalizer }
+}
+
+#[inline]
+pub unsafe fn w_async_generator_set_finalizer(obj: PyObjectRef, value: PyObjectRef) {
+    unsafe { (*(obj as *mut GeneratorIterator)).w_finalizer = value };
+    crate::gc_hook::try_gc_write_barrier(obj as *mut u8);
 }
 
 #[cfg(test)]

--- a/pyre/pyre-object/src/generator.rs
+++ b/pyre/pyre-object/src/generator.rs
@@ -156,6 +156,14 @@ pub unsafe fn w_generator_get_frame(obj: PyObjectRef) -> *mut u8 {
     unsafe { (*(obj as *const GeneratorIterator)).frame_ptr }
 }
 
+#[inline]
+pub unsafe fn w_generator_set_frame(obj: PyObjectRef, frame_ptr: *mut u8) {
+    unsafe { (*(obj as *mut GeneratorIterator)).frame_ptr = frame_ptr };
+    if !frame_ptr.is_null() {
+        crate::gc_hook::try_gc_write_barrier(obj as *mut u8);
+    }
+}
+
 pub unsafe fn w_generator_is_exhausted(obj: PyObjectRef) -> bool {
     unsafe { (*(obj as *const GeneratorIterator)).exhausted }
 }

--- a/pyre/pyre-object/src/generator.rs
+++ b/pyre/pyre-object/src/generator.rs
@@ -38,6 +38,13 @@ pub struct GeneratorIterator {
     pub cr_origin: PyObjectRef,
     /// PyPy: `Coroutine._warned_unawaited`.
     pub warned_unawaited: bool,
+    /// `generator.py:29` `GeneratorOrCoroutine.saved_operr`.  Pyre stores
+    /// the materialized exception value carried by `ExecutionContext` rather
+    /// than an `OperationError`, but preserves the same per-generator owner.
+    pub saved_exc_value: PyObjectRef,
+    /// `generator.py:30` `previous_gen_or_coroutine`: the execution-context
+    /// linked-list edge while this generator is running.
+    pub previous_gen_or_coroutine: PyObjectRef,
 }
 
 /// PyPy `generator.py CoroutineWrapper`: the iterator returned by
@@ -82,6 +89,8 @@ fn w_generator_or_coroutine_new(frame_ptr: *mut u8, coroutine: bool) -> PyObject
         qualname: PY_NULL,
         cr_origin: if coroutine { crate::w_none() } else { PY_NULL },
         warned_unawaited: false,
+        saved_exc_value: PY_NULL,
+        previous_gen_or_coroutine: PY_NULL,
     };
     // A generator must be GC-managed, not immortal `malloc_typed`: the
     // collector never reaches an immortal object, so the registered
@@ -192,6 +201,28 @@ pub unsafe fn w_generator_set_running(obj: PyObjectRef, val: bool) {
     unsafe {
         (*(obj as *mut GeneratorIterator)).running = val;
     }
+}
+
+#[inline]
+pub unsafe fn w_generator_get_saved_exc_value(obj: PyObjectRef) -> PyObjectRef {
+    unsafe { (*(obj as *const GeneratorIterator)).saved_exc_value }
+}
+
+#[inline]
+pub unsafe fn w_generator_set_saved_exc_value(obj: PyObjectRef, value: PyObjectRef) {
+    unsafe { (*(obj as *mut GeneratorIterator)).saved_exc_value = value };
+    crate::gc_hook::try_gc_write_barrier(obj as *mut u8);
+}
+
+#[inline]
+pub unsafe fn w_generator_get_previous(obj: PyObjectRef) -> PyObjectRef {
+    unsafe { (*(obj as *const GeneratorIterator)).previous_gen_or_coroutine }
+}
+
+#[inline]
+pub unsafe fn w_generator_set_previous(obj: PyObjectRef, value: PyObjectRef) {
+    unsafe { (*(obj as *mut GeneratorIterator)).previous_gen_or_coroutine = value };
+    crate::gc_hook::try_gc_write_barrier(obj as *mut u8);
 }
 
 #[inline]

--- a/pyre/pyre-object/src/generator.rs
+++ b/pyre/pyre-object/src/generator.rs
@@ -19,6 +19,9 @@ pub struct GeneratorIterator {
     /// Opaque pointer to the suspended PyFrame (Box<PyFrame>).
     /// NULL when the generator is exhausted.
     pub frame_ptr: *mut u8,
+    /// `generator.py:21` `self.pycode = frame.pycode`.  This remains owned by
+    /// the generator after `frame` is cleared on exhaustion.
+    pub pycode: PyObjectRef,
     /// Whether the generator has been started (first __next__ called).
     pub started: bool,
     /// Whether the generator is exhausted.
@@ -67,7 +70,13 @@ impl crate::lltype::GcType for GeneratorIterator {
     const SIZE: usize = W_GENERATOR_OBJECT_SIZE;
 }
 
-fn w_generator_or_coroutine_new(frame_ptr: *mut u8, coroutine: bool) -> PyObjectRef {
+fn w_generator_or_coroutine_new(
+    frame_ptr: *mut u8,
+    pycode: PyObjectRef,
+    coroutine: bool,
+) -> PyObjectRef {
+    let _roots = crate::gc_roots::push_roots();
+    crate::gc_roots::pin_root(pycode);
     let value = GeneratorIterator {
         ob: PyObject {
             ob_type: if coroutine {
@@ -82,6 +91,7 @@ fn w_generator_or_coroutine_new(frame_ptr: *mut u8, coroutine: bool) -> PyObject
             },
         },
         frame_ptr,
+        pycode,
         started: false,
         exhausted: false,
         running: false,
@@ -116,12 +126,12 @@ fn w_generator_or_coroutine_new(frame_ptr: *mut u8, coroutine: bool) -> PyObject
     crate::lltype::malloc_typed(value) as PyObjectRef
 }
 
-pub fn w_generator_new(frame_ptr: *mut u8) -> PyObjectRef {
-    w_generator_or_coroutine_new(frame_ptr, false)
+pub fn w_generator_new(frame_ptr: *mut u8, pycode: PyObjectRef) -> PyObjectRef {
+    w_generator_or_coroutine_new(frame_ptr, pycode, false)
 }
 
-pub fn w_coroutine_new(frame_ptr: *mut u8) -> PyObjectRef {
-    w_generator_or_coroutine_new(frame_ptr, true)
+pub fn w_coroutine_new(frame_ptr: *mut u8, pycode: PyObjectRef) -> PyObjectRef {
+    w_generator_or_coroutine_new(frame_ptr, pycode, true)
 }
 
 pub fn w_coroutine_wrapper_new(coroutine: PyObjectRef) -> PyObjectRef {
@@ -163,6 +173,11 @@ pub unsafe fn w_coroutine_wrapper_get_coroutine(obj: PyObjectRef) -> PyObjectRef
 
 pub unsafe fn w_generator_get_frame(obj: PyObjectRef) -> *mut u8 {
     unsafe { (*(obj as *const GeneratorIterator)).frame_ptr }
+}
+
+#[inline]
+pub unsafe fn w_generator_get_pycode(obj: PyObjectRef) -> PyObjectRef {
+    unsafe { (*(obj as *const GeneratorIterator)).pycode }
 }
 
 #[inline]

--- a/pyre/pyre-object/src/interp_exceptions.rs
+++ b/pyre/pyre-object/src/interp_exceptions.rs
@@ -28,6 +28,8 @@ pub static EXC_KEY_ERROR_TYPE: PyType = crate::pyobject::new_pytype("KeyError");
 pub static EXC_ATTRIBUTE_ERROR_TYPE: PyType = crate::pyobject::new_pytype("AttributeError");
 pub static EXC_RUNTIME_ERROR_TYPE: PyType = crate::pyobject::new_pytype("RuntimeError");
 pub static EXC_STOP_ITERATION_TYPE: PyType = crate::pyobject::new_pytype("StopIteration");
+pub static EXC_STOP_ASYNC_ITERATION_TYPE: PyType =
+    crate::pyobject::new_pytype("StopAsyncIteration");
 pub static EXC_IMPORT_ERROR_TYPE: PyType = crate::pyobject::new_pytype("ImportError");
 pub static EXC_MODULE_NOT_FOUND_ERROR_TYPE: PyType =
     crate::pyobject::new_pytype("ModuleNotFoundError");
@@ -94,6 +96,7 @@ pub fn exc_kind_to_pytype(kind: ExcKind) -> &'static PyType {
         ExcKind::AttributeError => &EXC_ATTRIBUTE_ERROR_TYPE,
         ExcKind::RuntimeError => &EXC_RUNTIME_ERROR_TYPE,
         ExcKind::StopIteration => &EXC_STOP_ITERATION_TYPE,
+        ExcKind::StopAsyncIteration => &EXC_STOP_ASYNC_ITERATION_TYPE,
         ExcKind::ImportError => &EXC_IMPORT_ERROR_TYPE,
         ExcKind::ModuleNotFoundError => &EXC_MODULE_NOT_FOUND_ERROR_TYPE,
         ExcKind::NotImplementedError => &EXC_NOT_IMPLEMENTED_ERROR_TYPE,
@@ -213,6 +216,9 @@ pub enum ExcKind {
     BufferError = 31,
     /// Subclass of NameError raised when a fast local is read while unbound.
     UnboundLocalError = 32,
+    /// Signals exhaustion of an asynchronous iterator.  Appended so the
+    /// existing discriminants embedded by the JIT remain stable.
+    StopAsyncIteration = 33,
 }
 
 impl ExcKind {
@@ -621,7 +627,7 @@ fn w_exception_new_empty_impl(kind: ExcKind, immortal: bool) -> PyObjectRef {
 /// arrays against the same authoritative bound.  Anchored on the
 /// highest-numbered variant so adding new ExcKinds at the end of the
 /// enum extends the bound automatically.
-pub const EXC_KIND_COUNT: usize = (ExcKind::UnboundLocalError as u8 as usize) + 1;
+pub const EXC_KIND_COUNT: usize = (ExcKind::StopAsyncIteration as u8 as usize) + 1;
 
 thread_local! {
     static EXC_CLASS_BY_KIND: std::cell::Cell<[PyObjectRef; EXC_KIND_COUNT]> =
@@ -1348,6 +1354,7 @@ pub fn exc_kind_name(kind: ExcKind) -> &'static str {
         ExcKind::AttributeError => "AttributeError",
         ExcKind::RuntimeError => "RuntimeError",
         ExcKind::StopIteration => "StopIteration",
+        ExcKind::StopAsyncIteration => "StopAsyncIteration",
         ExcKind::OverflowError => "OverflowError",
         ExcKind::ArithmeticError => "ArithmeticError",
         ExcKind::ImportError => "ImportError",
@@ -1454,6 +1461,7 @@ pub fn exc_kind_from_name(name: &str) -> Option<ExcKind> {
         "AttributeError" => Some(ExcKind::AttributeError),
         "RuntimeError" => Some(ExcKind::RuntimeError),
         "StopIteration" => Some(ExcKind::StopIteration),
+        "StopAsyncIteration" => Some(ExcKind::StopAsyncIteration),
         "OverflowError" => Some(ExcKind::OverflowError),
         "ArithmeticError" => Some(ExcKind::ArithmeticError),
         "ImportError" => Some(ExcKind::ImportError),
@@ -1565,6 +1573,7 @@ mod tests {
             ExcKind::AttributeError,
             ExcKind::RuntimeError,
             ExcKind::StopIteration,
+            ExcKind::StopAsyncIteration,
             ExcKind::OverflowError,
             ExcKind::ArithmeticError,
             ExcKind::ImportError,

--- a/pyre/pyre-object/src/pyobject.rs
+++ b/pyre/pyre-object/src/pyobject.rs
@@ -582,6 +582,7 @@ pub const SUBCLASS_RANGE_HIERARCHY: &[(u32, Option<u32>)] = &[
     (127, Some(0)),
     (128, Some(0)),
     (129, Some(0)),
+    (130, Some(0)),
 ];
 
 /// Compute subclass IDs from [`SUBCLASS_RANGE_HIERARCHY`] and write every

--- a/pyre/pyre-object/src/pyobject.rs
+++ b/pyre/pyre-object/src/pyobject.rs
@@ -583,6 +583,10 @@ pub const SUBCLASS_RANGE_HIERARCHY: &[(u32, Option<u32>)] = &[
     (128, Some(0)),
     (129, Some(0)),
     (130, Some(0)),
+    (131, Some(0)),
+    (132, Some(0)),
+    (133, Some(0)),
+    (134, Some(0)),
 ];
 
 /// Compute subclass IDs from [`SUBCLASS_RANGE_HIERARCHY`] and write every
@@ -769,6 +773,10 @@ pub fn all_foreign_pytypes() -> &'static [(&'static PyType, &'static PyType)] {
         (
             &crate::interp_exceptions::EXC_EXCEPTION_TYPE,
             &crate::interp_exceptions::EXCEPTION_TYPE,
+        ),
+        (
+            &crate::interp_exceptions::EXC_STOP_ASYNC_ITERATION_TYPE,
+            &crate::interp_exceptions::EXC_EXCEPTION_TYPE,
         ),
         (
             &crate::interp_exceptions::EXC_ARITHMETIC_ERROR_TYPE,
@@ -1003,6 +1011,7 @@ pub fn all_subclass_range_aliases() -> Vec<SubclassRangeAlias> {
         ),
         subclass_range_alias(31, &crate::interp_exceptions::EXC_UNBOUND_LOCAL_ERROR_TYPE),
         subclass_range_alias(31, &crate::interp_exceptions::EXC_BUFFER_ERROR_TYPE),
+        subclass_range_alias(31, &crate::interp_exceptions::EXC_STOP_ASYNC_ITERATION_TYPE),
         subclass_range_alias(32, &crate::generator::GENERATOR_TYPE),
         subclass_range_alias(33, &TYPE_TYPE),
         subclass_range_alias(34, &STR_TYPE),
@@ -1083,6 +1092,13 @@ pub fn all_subclass_range_aliases() -> Vec<SubclassRangeAlias> {
         subclass_range_alias(115, &crate::dictmultiobject::DICT_REVERSEKEYITERATOR_TYPE),
         subclass_range_alias(115, &crate::dictmultiobject::DICT_REVERSEVALUEITERATOR_TYPE),
         subclass_range_alias(115, &crate::dictmultiobject::DICT_REVERSEITEMITERATOR_TYPE),
+        // Async-generator support is appended after the interpreter-owned
+        // FrameLocalsProxy (130) in build_gc: the shared generator payload
+        // gets 131, followed by the three pyre_class helper awaitables.
+        subclass_range_alias(131, &crate::generator::ASYNC_GENERATOR_TYPE),
+        subclass_range_alias(132, typed::<crate::generator::AsyncGenValueWrapper>()),
+        subclass_range_alias(133, typed::<crate::generator::AsyncGenASend>()),
+        subclass_range_alias(134, typed::<crate::generator::AsyncGenAThrow>()),
     ]
 }
 

--- a/pyre/pyre-object/src/setobject.rs
+++ b/pyre/pyre-object/src/setobject.rs
@@ -10,7 +10,9 @@
 #![allow(unsafe_op_in_unsafe_fn)]
 
 use crate::pyobject::*;
+use indexmap::map::{RawEntryApiV1, raw_entry_v1::RawEntryMut};
 use pyre_macros::pyre_class;
+use std::hash::BuildHasher;
 
 pub static SET_TYPE: PyType = crate::pyobject::new_pytype("set");
 pub static FROZENSET_TYPE: PyType = crate::pyobject::new_pytype("frozenset");
@@ -270,7 +272,7 @@ pub unsafe fn w_set_add_hashed_checked(
     obj: PyObjectRef,
     item: PyObjectRef,
     hash: i64,
-) -> Result<(), crate::dictmultiobject::DictKeyError> {
+) -> Result<(), SetUpdateError> {
     w_set_insert_key_checked(obj, crate::dictmultiobject::object_key_hashed(item, hash))
 }
 
@@ -363,34 +365,8 @@ unsafe fn scan_set_key_reentrant(
 pub unsafe fn w_set_insert_key_checked(
     obj: PyObjectRef,
     key: crate::dictmultiobject::ObjectKey,
-) -> Result<(), crate::dictmultiobject::DictKeyError> {
-    if let Some(result) = callback_free_set_op(|| {
-        let s = &mut *(obj as *mut W_SetObject);
-        let present = (*s.items).get_index_of(&key).is_some();
-        if !crate::dict_eq_hook::callback_free_probe_broken() && !present {
-            (*s.items).insert(key, ());
-            s.len = (*s.items).len();
-            s.hash = -1;
-            set_write_barrier(obj);
-        }
-    }) {
-        return result;
-    }
-
-    let (found, key) = scan_set_key_reentrant(obj, key)?;
-    if found.is_none() {
-        // The scan established inequality against every same-hash key.  Keep
-        // IndexMap's placement probe callback-free; any comparison outside
-        // the builtin ladder therefore answers false, reproducing that scan.
-        crate::dict_eq_hook::begin_callback_free_probe();
-        let s = &mut *(obj as *mut W_SetObject);
-        (*s.items).insert(key, ());
-        let _ = crate::dict_eq_hook::end_callback_free_probe();
-        s.len = (*s.items).len();
-        s.hash = -1;
-        set_write_barrier(obj);
-    }
-    Ok(())
+) -> Result<(), SetUpdateError> {
+    w_set_insert_key_reentrant(obj, key)
 }
 
 /// Membership test for a key that carries its own digest, propagating an
@@ -577,7 +553,7 @@ pub unsafe fn w_set_copy_storage_from(dst: PyObjectRef, src: PyObjectRef) {
 pub unsafe fn w_set_difference_update_from_set(
     dst: PyObjectRef,
     src: PyObjectRef,
-) -> Result<(), crate::dictmultiobject::DictKeyError> {
+) -> Result<(), SetUpdateError> {
     if std::ptr::eq(
         (*(dst as *const W_SetObject)).items,
         (*(src as *const W_SetObject)).items,
@@ -592,15 +568,25 @@ pub unsafe fn w_set_difference_update_from_set(
     // exact contains-with-hash callback direction of the upstream strategy.
     if w_set_len(dst) < w_set_len(src) {
         let result = w_set_new();
+        let dst_items = (*(dst as *const W_SetObject)).items;
+        let dst_len = (*dst_items).len();
         let mut i = 0;
-        while let Some(key) = w_set_key_at(dst, i) {
-            if !w_set_contains_key_checked(src, key)? {
+        while i < dst_len {
+            let Some(key) = w_set_key_at(dst, i) else {
+                return Err(SetUpdateError::ChangedSize);
+            };
+            if !w_set_contains_key_for_update(src, key)? {
+                if (*(dst as *const W_SetObject)).items != dst_items
+                    || (*dst_items).len() != dst_len
+                {
+                    return Err(SetUpdateError::ChangedSize);
+                }
                 // The comparison may clear or otherwise shorten `dst`.
                 // CPython's set probe restarts when `entry->key` changes;
                 // once this live index disappeared there is no surviving
                 // entry to copy into the difference result.
                 let Some(key) = w_set_key_at(dst, i) else {
-                    break;
+                    return Err(SetUpdateError::ChangedSize);
                 };
                 w_set_insert_key_checked(result, key)?;
             }
@@ -610,9 +596,17 @@ pub unsafe fn w_set_difference_update_from_set(
         return Ok(());
     }
     // `src` is a distinct storage, so removing from `dst` cannot renumber it.
+    let src_items = (*(src as *const W_SetObject)).items;
+    let src_len = (*src_items).len();
     let mut i = 0;
-    while let Some(key) = w_set_key_at(src, i) {
-        w_set_discard_key_checked(dst, key)?;
+    while i < src_len {
+        let Some(key) = w_set_key_at(src, i) else {
+            return Err(SetUpdateError::ChangedSize);
+        };
+        w_set_remove_key_for_update(dst, key)?;
+        if (*(src as *const W_SetObject)).items != src_items || (*src_items).len() != src_len {
+            return Err(SetUpdateError::ChangedSize);
+        }
         i += 1;
     }
     Ok(())
@@ -631,7 +625,7 @@ pub unsafe fn w_set_difference_update_from_set(
 pub unsafe fn w_set_update_from_set(
     dst: PyObjectRef,
     src: PyObjectRef,
-) -> Result<(), crate::dictmultiobject::DictKeyError> {
+) -> Result<(), SetUpdateError> {
     if std::ptr::eq(
         (*(dst as *const W_SetObject)).items,
         (*(src as *const W_SetObject)).items,
@@ -644,12 +638,153 @@ pub unsafe fn w_set_update_from_set(
     // (`set_object_custom_trace`) — a `Vec` of keys lifted out of them would
     // not be walked and would be left holding stale pointers.
     let mut i = 0;
-    while i < (*(*(src as *const W_SetObject)).items).len() {
-        let Some((&key, _)) = (*(*(src as *const W_SetObject)).items).get_index(i) else {
+    loop {
+        let src_items = (*(src as *const W_SetObject)).items;
+        let Some((&key, _)) = (*src_items).get_index(i) else {
             break;
         };
         w_set_insert_key_checked(dst, key)?;
         i += 1;
+    }
+    Ok(())
+}
+
+/// Failure modes of the PyPy `ObjectSetStrategy.update` table merge.
+pub enum SetUpdateError {
+    /// An equality callback raised; its concrete exception is parked in the
+    /// interpreter's pending dict-key error slot.
+    Key(crate::dictmultiobject::DictKeyError),
+    /// A callback changed one of the tables while it was being traversed.
+    ChangedSize,
+}
+
+/// Insert one cached-hash key during `ObjectSetStrategy.update` without
+/// holding an IndexMap borrow across user `eq_w`.
+///
+/// RPython's `r_dict.update` detects a table size change during a comparison
+/// and raises instead of continuing through invalidated buckets.  IndexMap's
+/// ordinary `insert` owns a mutable table borrow while `ObjectKey::eq` calls
+/// Python; re-entering `set.clear()` through that callback invalidates its
+/// internal insertion index.  Read each candidate by value, release the Rust
+/// borrow before `eq_w`, verify the table shape, then use the already-proven
+/// vacant raw entry so insertion performs no second user comparison.
+unsafe fn w_set_insert_key_reentrant(
+    dst: PyObjectRef,
+    key: crate::dictmultiobject::ObjectKey,
+) -> Result<(), SetUpdateError> {
+    // CPython 3.14's set probe restarts when a comparison mutates the table;
+    // PyPy's r_dict likewise resumes from a valid table state rather than
+    // retaining a bucket index across the callback.
+    'restart: loop {
+        let dst_items = (*(dst as *const W_SetObject)).items;
+        let dst_len = (*dst_items).len();
+        let mut i = 0;
+        while i < dst_len {
+            let Some((&stored, _)) = (*dst_items).get_index(i) else {
+                continue 'restart;
+            };
+            if stored.hash == key.hash {
+                let equal = crate::dictmultiobject::dict_keys_equal(stored.obj, key.obj);
+                if crate::dictmultiobject::take_dict_key_error() {
+                    return Err(SetUpdateError::Key(crate::dictmultiobject::DictKeyError));
+                }
+                if (*(dst as *const W_SetObject)).items != dst_items
+                    || (*dst_items).len() != dst_len
+                {
+                    continue 'restart;
+                }
+                if equal {
+                    return Ok(());
+                }
+            }
+            i += 1;
+        }
+
+        if (*(dst as *const W_SetObject)).items != dst_items || (*dst_items).len() != dst_len {
+            continue;
+        }
+        let entries = &mut *dst_items;
+        let hash = entries.hasher().hash_one(&key);
+        match entries.raw_entry_mut_v1().from_hash(hash, |_| false) {
+            RawEntryMut::Vacant(entry) => {
+                entry.insert_hashed_nocheck(hash, key, ());
+            }
+            RawEntryMut::Occupied(_) => unreachable!("a never-matching raw probe is vacant"),
+        }
+        let set = &mut *(dst as *mut W_SetObject);
+        set.len += 1;
+        set.hash = -1;
+        set_write_barrier(dst);
+        return Ok(());
+    }
+}
+
+/// Membership half of `contains_with_hash` for a mutation-sensitive set
+/// operation.  As with the update inserter above, no IndexMap borrow crosses
+/// `eq_w`; a size-changing callback invalidates the traversal explicitly.
+unsafe fn w_set_contains_key_for_update(
+    probe: PyObjectRef,
+    key: crate::dictmultiobject::ObjectKey,
+) -> Result<bool, SetUpdateError> {
+    let items = (*(probe as *const W_SetObject)).items;
+    let len = (*items).len();
+    let mut i = 0;
+    while i < len {
+        let Some((&stored, _)) = (*items).get_index(i) else {
+            return Err(SetUpdateError::ChangedSize);
+        };
+        if stored.hash == key.hash {
+            let equal = crate::dictmultiobject::dict_keys_equal(stored.obj, key.obj);
+            if crate::dictmultiobject::take_dict_key_error() {
+                return Err(SetUpdateError::Key(crate::dictmultiobject::DictKeyError));
+            }
+            if (*(probe as *const W_SetObject)).items != items || (*items).len() != len {
+                return Err(SetUpdateError::ChangedSize);
+            }
+            if equal {
+                return Ok(true);
+            }
+        }
+        i += 1;
+    }
+    Ok(false)
+}
+
+/// `delitem_with_hash` for a mutation-sensitive difference update.  Find the
+/// matching bucket without lending IndexMap across Python code, then delete
+/// the proven index without another equality callback.
+unsafe fn w_set_remove_key_for_update(
+    dst: PyObjectRef,
+    key: crate::dictmultiobject::ObjectKey,
+) -> Result<(), SetUpdateError> {
+    let items = (*(dst as *const W_SetObject)).items;
+    let len = (*items).len();
+    let mut found = None;
+    let mut i = 0;
+    while i < len {
+        let Some((&stored, _)) = (*items).get_index(i) else {
+            return Err(SetUpdateError::ChangedSize);
+        };
+        if stored.hash == key.hash {
+            let equal = crate::dictmultiobject::dict_keys_equal(stored.obj, key.obj);
+            if crate::dictmultiobject::take_dict_key_error() {
+                return Err(SetUpdateError::Key(crate::dictmultiobject::DictKeyError));
+            }
+            if (*(dst as *const W_SetObject)).items != items || (*items).len() != len {
+                return Err(SetUpdateError::ChangedSize);
+            }
+            if equal {
+                found = Some(i);
+                break;
+            }
+        }
+        i += 1;
+    }
+    if let Some(index) = found {
+        (*items).shift_remove_index(index);
+        let set = &mut *(dst as *mut W_SetObject);
+        set.len -= 1;
+        set.hash = -1;
     }
     Ok(())
 }

--- a/pyre/pyre-object/src/typeobject.rs
+++ b/pyre/pyre-object/src/typeobject.rs
@@ -333,15 +333,6 @@ pub fn w_type_new(name: &str, bases: PyObjectRef, dict_ptr: *mut u8) -> PyObject
         let name = crate::gc_roots::shadow_stack_get(save_point + 2) as *mut String;
         (name, qualname)
     };
-    crate::gc_roots::pin_root(name as PyObjectRef);
-    let qualname = if raw.is_null() {
-        crate::lltype::malloc_raw(unsafe { (&*name).clone() })
-    } else {
-        crate::gc_storage::gc_alloc_storage_box(
-            unsafe { (&*name).clone() },
-            name_storage_gc_type_id(),
-        )
-    };
     // Install the forwarded bases and managed namespace addresses rather than the
     // pre-collection arguments (the pins survive any collection the alloc forces).
     let bases = crate::gc_roots::shadow_stack_get(save_point);

--- a/pyre/pyre-object/src/typeobject.rs
+++ b/pyre/pyre-object/src/typeobject.rs
@@ -333,6 +333,15 @@ pub fn w_type_new(name: &str, bases: PyObjectRef, dict_ptr: *mut u8) -> PyObject
         let name = crate::gc_roots::shadow_stack_get(save_point + 2) as *mut String;
         (name, qualname)
     };
+    crate::gc_roots::pin_root(name as PyObjectRef);
+    let qualname = if raw.is_null() {
+        crate::lltype::malloc_raw(unsafe { (&*name).clone() })
+    } else {
+        crate::gc_storage::gc_alloc_storage_box(
+            unsafe { (&*name).clone() },
+            name_storage_gc_type_id(),
+        )
+    };
     // Install the forwarded bases and managed namespace addresses rather than the
     // pre-collection arguments (the pins survive any collection the alloc forces).
     let bases = crate::gc_roots::shadow_stack_get(save_point);


### PR DESCRIPTION
## Summary
- preserve buffer exports across memoryview, mmap, struct iterators, and PickleBuffer
- complete Python 3.14 struct, core protocol, type metadata, and iterable error parity
- capture generator and coroutine names at creation and enforce 3.14 metadata setters/deletion
- align generator.throw argument normalization and legacy-call deprecation behavior with Python 3.14
- release finalized generator frames and return close() values with Python 3.14 semantics
- align __import__ argument binding, relative-package resolution, and ImportWarning delivery
- repair the rebased stale Snapshot field initializer left on main

## Verification
- cargo check --features dynasm
- cargo test --features dynasm
- GeneratorCloseTest: 8/8 with JIT enabled and 8/8 with PYRE_NO_JIT=1
- focused Python 3.14 generator throw/import tests with JIT enabled and PYRE_NO_JIT=1
- pyre-object and pyre-interpreter LLBC re-extraction plus release prepass rebuild
- python3 pyre/check.py --backend dynasm --no-synthetic: 11/11 passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added write-through `frame.f_locals` support for optimized frames.
  * Improved generator and coroutine naming, exception handling, `throw()`, and `close()` compatibility.
  * Added support for complex `struct` formats and zero-width Pascal strings.
  * Improved buffer and memoryview lifetime handling, including safer `mmap` resizing and closing.

* **Bug Fixes**
  * Aligned numerous built-in behaviors, validation rules, error messages, imports, and `__slots__` handling with Python 3.14.
  * Improved set mutation safety and buffer-related error handling.

* **Tests**
  * Expanded coverage for generators, buffers, `struct`, imports, and built-in behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->