### PR TITLE
str: collectable managed exact-string constructor + dynamic-producer routing (#171)

### DIFF
--- a/majit/majit-gc/src/trace.rs
+++ b/majit/majit-gc/src/trace.rs
@@ -806,6 +806,16 @@ impl TypeRegistry {
         id as u32
     }
 
+    /// Attach a sweep-time destructor to an already-registered type.
+    /// For `#[pyre_class]` types registered through the generic
+    /// `object_subclass_with_gc_ptrs` path (which sets no destructor) that
+    /// nonetheless own Rust heap needing drop glue when the collector
+    /// reclaims a dead instance. Reads back through `get(type_id).destructor`
+    /// in the sweep, so mutating the `entries` slot is sufficient.
+    pub fn set_destructor(&mut self, type_id: u32, destructor: DestructorFn) {
+        self.entries[type_id as usize].destructor = Some(destructor);
+    }
+
     /// `gctypelayout.encode_type_shapes_now` parity
     /// (gctypelayout.py:393-398): freezes the registry so subsequent
     /// `register_type` calls panic and assigns each `is_object`

--- a/pyre/pyre-interpreter/src/module/_codecs/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_codecs/mod.rs
@@ -988,7 +988,7 @@ fn charmap_decode_impl(
         }
     }
     Ok(w_tuple_new(vec![
-        w_str_from_wtf8(out),
+        w_str_from_wtf8_managed(out),
         w_int_new(orig_len as i64),
     ]))
 }
@@ -1334,7 +1334,7 @@ fn utf7_decode_impl(
         out.truncate(shift_out_start);
     }
     Ok(w_tuple_new(vec![
-        w_str_from_wtf8(out),
+        w_str_from_wtf8_managed(out),
         w_int_new(consumed as i64),
     ]))
 }
@@ -1604,7 +1604,7 @@ fn unicode_escape_decode_impl(
         }
     }
     Ok(w_tuple_new(vec![
-        w_str_from_wtf8(out),
+        w_str_from_wtf8_managed(out),
         w_int_new(pos as i64 + pos_delta),
     ]))
 }

--- a/pyre/pyre-interpreter/src/module/_tokenize/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_tokenize/mod.rs
@@ -89,6 +89,18 @@ pub struct W_TokenizerIter {
     pending_empty_fstring_middle: Option<(u8, usize, usize, String)>,
 }
 
+/// Sweep-time cleanup for a GC-reclaimed `W_TokenizerIter`: run its Drop glue
+/// so the owned Rust heap (source `String`, token / error `Vec`s, the line
+/// table) is freed instead of leaked. The only managed child, `readline`, is a
+/// raw `PyObjectRef` (Copy), and `Token` / `ParseError` carry no GC pointers,
+/// so this touches no GC memory and is safe to run at sweep time.
+///
+/// # Safety
+/// `obj` must point to a valid, GC-dead `W_TokenizerIter`.
+pub unsafe fn w_tokenizer_iter_dealloc(obj: PyObjectRef) {
+    unsafe { std::ptr::drop_in_place(obj as *mut W_TokenizerIter) }
+}
+
 fn read_line(self_obj: PyObjectRef) -> Result<String, crate::PyError> {
     let (readline, encoding) = {
         let this = W_TokenizerIter::from_obj(self_obj)

--- a/pyre/pyre-interpreter/src/objspace/descroperation.rs
+++ b/pyre/pyre-interpreter/src/objspace/descroperation.rs
@@ -1086,7 +1086,9 @@ pub(crate) unsafe fn str_concat(a: PyObjectRef, b: PyObjectRef) -> PyResult {
     let mut result = Wtf8Buf::with_capacity(sa.len() + sb.len());
     result.push_wtf8(sa);
     result.push_wtf8(sb);
-    Ok(w_str_from_wtf8(result))
+    // Concatenation is a dominant dynamic-churn producer; its result lives in
+    // GC-traced slots (locals, list/dict/set members), so make it collectable.
+    Ok(w_str_from_wtf8_managed(result))
 }
 
 /// Extract a non-negative repeat count from an int or long.
@@ -1139,7 +1141,8 @@ pub(crate) unsafe fn str_repeat(s: PyObjectRef, n: PyObjectRef) -> PyResult {
         out.extend_from_slice(bytes);
     }
     let buf = Wtf8Buf::from_bytes(out).expect("repetition of WTF-8 is WTF-8");
-    Ok(w_str_from_wtf8(buf))
+    // Repetition churns fresh dynamic strings; make the result collectable.
+    Ok(w_str_from_wtf8_managed(buf))
 }
 
 pub(crate) unsafe fn bytes_concat(a: PyObjectRef, b: PyObjectRef) -> PyResult {

--- a/pyre/pyre-interpreter/src/objspace/std/formatting.rs
+++ b/pyre/pyre-interpreter/src/objspace/std/formatting.rs
@@ -105,7 +105,8 @@ pub(crate) unsafe fn str_format_percent(fmt: PyObjectRef, args: PyObjectRef) -> 
         ));
     }
 
-    Ok(w_str_from_wtf8(result))
+    // `str % args` printf formatting is a dominant dynamic-churn producer.
+    Ok(w_str_from_wtf8_managed(result))
 }
 
 pub(crate) unsafe fn bytes_format_percent(fmt: PyObjectRef, args: PyObjectRef) -> PyResult {

--- a/pyre/pyre-interpreter/src/runtime_ops.rs
+++ b/pyre/pyre-interpreter/src/runtime_ops.rs
@@ -615,7 +615,8 @@ pub fn build_string_from_refs(parts: &[PyObjectRef]) -> PyObjectRef {
             }
         }
     }
-    pyre_object::w_str_from_wtf8(result)
+    // BUILD_STRING / f-string result is a fresh dynamic string; make it collectable.
+    pyre_object::w_str_from_wtf8_managed(result)
 }
 
 /// CONVERT_VALUE conversion code, shared by the interpreter and the JIT
@@ -640,14 +641,14 @@ pub fn convert_value_code(conv: ConvertValueOparg) -> i64 {
 pub fn convert_value(value: PyObjectRef, conv: i64) -> Result<PyObjectRef, crate::PyError> {
     if conv == 0 || conv == 3 {
         let w = unsafe { crate::py_str_wtf8(value)? };
-        return Ok(pyre_object::w_str_from_wtf8(w));
+        return Ok(pyre_object::w_str_from_wtf8_managed(w));
     }
     let s = match conv {
         1 => unsafe { crate::py_repr(value)? },
         2 => crate::builtins::py_ascii(value)?,
         _ => unsafe { crate::py_str(value)? },
     };
-    Ok(pyre_object::w_str_new(&s))
+    Ok(pyre_object::w_str_new_managed(&s))
 }
 
 /// FORMAT_SIMPLE / FORMAT_WITH_SPEC evaluation, shared by the interpreter
@@ -668,7 +669,7 @@ pub fn format_value(value: PyObjectRef, spec: PyObjectRef) -> Result<PyObjectRef
         }
     };
     let s = crate::type_methods::format_value_dispatch(value, &spec_str)?;
-    Ok(pyre_object::w_str_from_wtf8(s))
+    Ok(pyre_object::w_str_from_wtf8_managed(s))
 }
 
 /// STORE_SLICE evaluation (`obj[start:stop] = value`): builds a `slice`
@@ -740,7 +741,8 @@ pub fn binary_slice_values(
             let e = (if e < 0 { (len + e).max(0) } else { e.min(len) } as usize).max(s);
             let part = rustpython_wtf8::Wtf8::from_bytes(&full.as_bytes()[offsets[s]..offsets[e]])
                 .expect("code-point-aligned slice is WTF-8");
-            return Ok(pyre_object::w_str_from_wtf8(part.to_wtf8_buf()));
+            // Substring slicing churns fresh dynamic strings; make it collectable.
+            return Ok(pyre_object::w_str_from_wtf8_managed(part.to_wtf8_buf()));
         }
         if pyre_object::is_tuple(obj) {
             let len = pyre_object::w_tuple_len(obj) as i64;

--- a/pyre/pyre-interpreter/src/type_methods.rs
+++ b/pyre/pyre-interpreter/src/type_methods.rs
@@ -2247,11 +2247,13 @@ pub fn builtin_value_format(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::
                 crate::display::py_str_wtf8(args[0])?
             }));
         }
-        return Ok(pyre_object::w_str_new_managed(&unsafe { crate::py_str(args[0])? }));
+        return Ok(pyre_object::w_str_new_managed(&unsafe {
+            crate::py_str(args[0])?
+        }));
     }
-    Ok(pyre_object::w_str_from_wtf8_managed(format_with_spec_public(
-        args[0], &spec,
-    )?))
+    Ok(pyre_object::w_str_from_wtf8_managed(
+        format_with_spec_public(args[0], &spec)?,
+    ))
 }
 
 fn format_with_spec(val: PyObjectRef, spec: &str) -> Result<Wtf8Buf, crate::PyError> {

--- a/pyre/pyre-interpreter/src/type_methods.rs
+++ b/pyre/pyre-interpreter/src/type_methods.rs
@@ -737,7 +737,8 @@ pub fn str_method_join(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyErr
         }
         out.push_wtf8(unsafe { pyre_object::w_str_get_wtf8(*item) });
     }
-    Ok(pyre_object::w_str_from_wtf8(out))
+    // `str.join` is a dominant dynamic-churn producer; make the result collectable.
+    Ok(pyre_object::w_str_from_wtf8_managed(out))
 }
 
 /// `str.split` / `str.rsplit` take `sep` and `maxsplit` positionally or by
@@ -1372,7 +1373,8 @@ fn str_method_format_core(
         &mut numbering,
         2,
     )?;
-    Ok(pyre_object::w_str_from_wtf8(rendered))
+    // `str.format` / `%` rendering is a dominant dynamic-churn producer.
+    Ok(pyre_object::w_str_from_wtf8_managed(rendered))
 }
 
 /// `newformat.py Formatter.format` rendering pass.  Renders the
@@ -2238,15 +2240,16 @@ pub fn builtin_value_format(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::
         String::new()
     };
     if spec.is_empty() {
-        // `str(self)` — a str self passes through as WTF-8.
+        // `str(self)` — a str self passes through as WTF-8. Dynamic result:
+        // collectable.
         if unsafe { pyre_object::is_str(args[0]) } {
-            return Ok(pyre_object::w_str_from_wtf8(unsafe {
+            return Ok(pyre_object::w_str_from_wtf8_managed(unsafe {
                 crate::display::py_str_wtf8(args[0])?
             }));
         }
-        return Ok(pyre_object::w_str_new(&unsafe { crate::py_str(args[0])? }));
+        return Ok(pyre_object::w_str_new_managed(&unsafe { crate::py_str(args[0])? }));
     }
-    Ok(pyre_object::w_str_from_wtf8(format_with_spec_public(
+    Ok(pyre_object::w_str_from_wtf8_managed(format_with_spec_public(
         args[0], &spec,
     )?))
 }

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -17756,7 +17756,7 @@ fn invalid_byte_2_of_4(ch1: u8, ch2: u8) -> bool {
 pub(crate) fn charp2uni(data: &[u8]) -> PyObjectRef {
     let decoded = decode_utf8_with_errors(data, "surrogateescape")
         .expect("surrogateescape rescues every byte, so the decode never fails");
-    pyre_object::w_str_from_wtf8(decoded)
+    pyre_object::w_str_from_wtf8_managed(decoded)
 }
 
 /// unicodehelper.py:377-537 _str_decode_utf8_slowpath
@@ -17964,7 +17964,7 @@ pub(crate) fn bytes_method_decode(args: &[PyObjectRef]) -> Result<PyObjectRef, c
         _ => "strict".to_string(),
     };
     let s = decode_bytes_to_wtf8(data, &encoding, errors.as_str())?;
-    Ok(pyre_object::w_str_from_wtf8(s))
+    Ok(pyre_object::w_str_from_wtf8_managed(s))
 }
 
 /// Decode `data` under `encoding`/`errors` into a WTF-8 string, dispatching on

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -526,6 +526,14 @@ unsafe fn bytearray_object_custom_trace(obj_addr: usize, f: &mut dyn FnMut(*mut 
     f(&mut ba.w_weakreflifeline as *mut pyre_object::PyObjectRef as *mut majit_ir::GcRef);
 }
 
+/// Reclaim the owned Rust heap (source string, token / error vectors, line
+/// table) of a swept tokenizer iterator, which `register_pyre_class` registers
+/// through the generic no-destructor path.
+unsafe fn tokenizer_iter_destructor(obj_addr: usize) {
+    let obj = obj_addr as pyre_object::PyObjectRef;
+    unsafe { pyre_interpreter::module::_tokenize::w_tokenizer_iter_dealloc(obj) };
+}
+
 /// Custom trace for `W_ObjectObject` (instance `map`+`storage`,
 /// `mapdict.py:907-910`).  The `storage` list is an off-GC
 /// `Box<Vec<PyObjectRef>>`, so — exactly as `dict_object_custom_trace`
@@ -2825,12 +2833,18 @@ fn build_gc() -> Box<dyn majit_gc::GcAllocator> {
         <pyre_interpreter::module::_collections::W_DequeRevIter
             as pyre_object::lltype::PyreClassPyTypeOf>::DESCRIPTOR,
     );
-    register_pyre_class(
+    let tokenizer_iter_tid = register_pyre_class(
         &mut gc,
         &mut pytype_to_tid,
         <pyre_interpreter::module::_tokenize::W_TokenizerIter
             as pyre_object::lltype::PyreClassPyTypeOf>::DESCRIPTOR,
     );
+    // W_TokenizerIter owns Rust heap (source string, token / error vectors, the
+    // line table); as an immortal it was never swept, but now that it is
+    // GC-managed the marker reclaims dead instances, so attach a destructor to
+    // run its Drop glue and free that heap instead of leaking it.
+    gc.types
+        .set_destructor(tokenizer_iter_tid, tokenizer_iter_destructor);
     // A Block is GC-managed but is not an rclass.OBJECT subclass and has no
     // Python-visible vtable.  Registering it through `register_pyre_class`
     // would add a spurious subclass-range alias and shift W_Deque's canonical

--- a/pyre/pyre-object/src/unicodeobject.rs
+++ b/pyre/pyre-object/src/unicodeobject.rs
@@ -181,10 +181,12 @@ pub fn w_str_from_wtf8_managed(value: Wtf8Buf) -> PyObjectRef {
     };
     let raw = crate::gc_hook::try_gc_alloc_stable_raw(W_UNICODE_GC_TYPE_ID, W_UNICODE_OBJECT_SIZE);
     if raw.is_null() {
-        // Hook vanished after the value box: `value` is a GC box that only a
-        // GC-managed header can keep alive, so recover the bytes and rebuild a
-        // fully immortal string rather than pair it with a `malloc_typed` header.
-        let recovered = unsafe { *Box::from_raw(value) };
+        // Header alloc failed after the value box: rebuild a fully immortal
+        // string rather than pair a `malloc_typed` header with a GC value box it
+        // cannot grey. `gc_alloc_storage_box` may have returned a GC-owned
+        // pointer (its doc forbids `Box::from_raw` on that — the sweep reclaims
+        // it), so copy the bytes out and abandon the box instead of freeing it.
+        let recovered = unsafe { (*value).clone() };
         return w_str_from_wtf8_immortal(recovered);
     }
     crate::gc_interp::note_alloc();

--- a/pyre/pyre-object/src/unicodeobject.rs
+++ b/pyre/pyre-object/src/unicodeobject.rs
@@ -81,12 +81,18 @@ impl crate::lltype::GcType for W_UnicodeObject {
     const SIZE: usize = W_UNICODE_OBJECT_SIZE;
 }
 
-/// Allocate a new W_UnicodeObject on the heap.
+/// Allocate a new exact `str` W_UnicodeObject from a Rust `&str`.
 ///
-/// Uses `Box::leak` for simplicity (objects are never freed).
-/// The inner `Wtf8Buf` is also `Box::into_raw`'d so it can be recovered.
-/// `from_string` takes ownership of the bytes with no copy or
-/// re-validation (every `&str` is already valid WTF-8).
+/// Exact strings are **immortal** by default: the header is `malloc_typed`
+/// (off-GC, never swept) and the inner `Wtf8Buf` is `malloc_raw`
+/// (`Box::into_raw`), so nothing reclaims them — the safe, structural-string
+/// default (dict keys, code constants, names all flow through here and must not
+/// be collectable, or the first collection would sweep them under the still-live
+/// immortal structures that hold them off the GC root graph).  Dynamic,
+/// short-lived strings that live only in GC-traced slots go through
+/// [`w_str_new_managed`] instead, which returns a collectable
+/// (`try_gc_alloc_stable`) header + GC value box.  `from_string` takes ownership
+/// of the bytes with no copy or re-validation (every `&str` is valid WTF-8).
 ///
 /// `#[dont_look_inside]` (`@jit.dont_look_inside`, `rlib/jit.py:139`), the
 /// `box_str_constant` twin: the body runs a `str::chars` count plus an
@@ -110,11 +116,92 @@ pub fn w_str_new(s: &str) -> PyObjectRef {
     }) as PyObjectRef
 }
 
+/// Collectable exact-`str` constructor for **dynamic, short-lived** strings
+/// (`str(int)`, concatenation, `%`/`format`, `join`, decode results) that live
+/// only in GC-traced slots (list/dict values, frame locals, instance attrs).
+///
+/// Config (b) of the exact-str split: the header is `try_gc_alloc_stable`
+/// (born-old, collectable) and the value is a GC-managed [`UnicodeValueStorage`]
+/// box greyed by the header's `value` gc-pointer edge and reclaimed by the box
+/// tid's drop glue on sweep (tid 34 carries **no** header destructor — the box
+/// is the sole reclaimer).  Gated on `gc_interp::enabled()`; when off (native
+/// default) or the alloc hook is absent it falls back to the immortal
+/// [`w_str_from_wtf8_immortal`] so a managed header never pairs with a
+/// non-greyable value.  Mirrors [`w_str_subclass_from_wtf8`]'s value handling.
+pub fn w_str_new_managed(s: &str) -> PyObjectRef {
+    w_str_from_wtf8_managed(Wtf8Buf::from_string(s.to_string()))
+}
+
 /// Allocate a new W_UnicodeObject from a WTF-8 buffer that may carry lone
 /// surrogate code points (produced by surrogateescape / surrogatepass
 /// decoding).  `byte_len` is the WTF-8 byte count, `len` the code point
 /// count (which counts each surrogate as one code point).
 pub fn w_str_from_wtf8(value: Wtf8Buf) -> PyObjectRef {
+    let byte_len = value.len();
+    let char_len = value.code_points().count();
+    let value = crate::lltype::malloc_raw(value);
+    crate::lltype::malloc_typed(W_UnicodeObject {
+        ob_header: PyObject {
+            ob_type: &STR_TYPE as *const PyType,
+            w_class: get_instantiate(&STR_TYPE),
+        },
+        value,
+        byte_len,
+        len: char_len,
+    }) as PyObjectRef
+}
+
+/// Collectable `w_str_from_wtf8` for dynamic strings — see [`w_str_new_managed`].
+///
+/// Builds config (b): a GC value box (greyed by the header `value` edge, tid 34
+/// has no destructor) under a `try_gc_alloc_stable` header.  Value box is
+/// allocated **before** the header (matching [`w_str_subclass_from_wtf8`]) so a
+/// header-alloc minor collection cannot observe a half-initialised header.
+/// Falls back to fully immortal when `gc_interp` is off or the hook is absent,
+/// keeping the header/value ownership consistent (a `malloc_typed` header must
+/// not hold a GC value box it cannot grey).
+pub fn w_str_from_wtf8_managed(value: Wtf8Buf) -> PyObjectRef {
+    // Config (b) needs a registered value-box tid so the header greys a GC box,
+    // not a `malloc_raw` buffer it can never reclaim; fall back to immortal until
+    // both the collector path and the value tid are live.
+    if !crate::gc_interp::enabled() || unicode_value_gc_type_id() == 0 {
+        return w_str_from_wtf8_immortal(value);
+    }
+    let byte_len = value.len();
+    let char_len = value.code_points().count();
+    let value = crate::gc_storage::gc_alloc_storage_box(value, unicode_value_gc_type_id());
+    let unicode = W_UnicodeObject {
+        ob_header: PyObject {
+            ob_type: &STR_TYPE as *const PyType,
+            w_class: get_instantiate(&STR_TYPE),
+        },
+        value,
+        byte_len,
+        len: char_len,
+    };
+    let raw = crate::gc_hook::try_gc_alloc_stable_raw(W_UNICODE_GC_TYPE_ID, W_UNICODE_OBJECT_SIZE);
+    if raw.is_null() {
+        // Hook vanished after the value box: `value` is a GC box that only a
+        // GC-managed header can keep alive, so recover the bytes and rebuild a
+        // fully immortal string rather than pair it with a `malloc_typed` header.
+        let recovered = unsafe { *Box::from_raw(value) };
+        return w_str_from_wtf8_immortal(recovered);
+    }
+    crate::gc_interp::note_alloc();
+    unsafe {
+        std::ptr::write(raw as *mut W_UnicodeObject, unicode);
+        raw as PyObjectRef
+    }
+}
+
+/// Immortal `w_str_from_wtf8`: always allocates through `malloc_typed`,
+/// bypassing the `gc_interp` gate so the result is never collected.
+///
+/// `box_str_constant` stores its result as a bare `usize` in the thread-local
+/// `STRING_CONSTANT_CACHE`, which is not a GC root; a collectable interned
+/// constant would be swept out from under the cache (use-after-free).  Interned
+/// constants are bounded, so keeping them immortal is the intended split.
+pub fn w_str_from_wtf8_immortal(value: Wtf8Buf) -> PyObjectRef {
     let byte_len = value.len();
     let char_len = value.code_points().count();
     let value = crate::lltype::malloc_raw(value);
@@ -183,7 +270,7 @@ pub fn box_str_constant(value: &Wtf8) -> PyObjectRef {
         if let Some(&cached) = cache.borrow().get(value) {
             return cached as PyObjectRef;
         }
-        let obj = w_str_from_wtf8(value.to_owned());
+        let obj = w_str_from_wtf8_immortal(value.to_owned());
         cache.borrow_mut().insert(value.to_owned(), obj as usize);
         obj
     })
@@ -271,7 +358,9 @@ pub extern "C" fn jit_str_concat(a: i64, b: i64) -> i64 {
         let mut result = Wtf8Buf::with_capacity(sa.len() + sb.len());
         result.push_wtf8(sa);
         result.push_wtf8(sb);
-        w_str_from_wtf8(result) as i64
+        // Concatenation result is a dynamic, short-lived string (the `a + b`
+        // churn the RSS leak is dominated by); make it collectable.
+        w_str_from_wtf8_managed(result) as i64
     }
 }
 
@@ -285,7 +374,7 @@ pub extern "C" fn jit_str_repeat(s: i64, n: i64) -> i64 {
         for _ in 0..count {
             result.push_wtf8(sv);
         }
-        w_str_from_wtf8(result) as i64
+        w_str_from_wtf8_managed(result) as i64
     }
 }
 
@@ -324,7 +413,7 @@ pub extern "C" fn jit_str_is_true(s: i64) -> i64 {
 /// identity, mirroring `ll_str` on a string).
 #[majit_macros::elidable]
 pub extern "C" fn jit_int_str(v: i64) -> i64 {
-    w_str_new(&v.to_string()) as i64
+    w_str_new_managed(&v.to_string()) as i64
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Adds a collectable "managed" exact-`str` constructor (config (b) of the exact-`str`
GC split) and routes the dynamic, short-lived string producers through it, so
churn-heavy `str` outputs that live in GC-traced slots (list/dict values, frame
locals) are reclaimed instead of allocated immortal. Structural strings
(constants, dict keys, interned) stay immortal by default, so a missed producer
leaks (bounded) rather than crashing.

Scope: the managed path is gated on `gc_interp::enabled()` — **off by default on
native** (opt-in `PYRE_GC_INTERP=1`, immortal fallback keeps native behavior
unchanged) and **on by default on wasm**, where the routing is active from
startup.

## Commits

- `_tokenize: free swept W_TokenizerIter Rust heap with a sweep-time destructor`
  — reclaims the tokenizer iterator's owned Rust heap when the GC sweeps it.
- `str: add managed exact-str constructors and route dynamic producers through them`
  — `w_str_new_managed` / `w_str_from_wtf8_managed`: a GC value box under a
  born-old collectable header, greyed by the header's `value` edge and reclaimed
  by the box tid's drop glue. Routes concat, repeat, `BUILD_STRING`/f-string,
  `CONVERT_VALUE`/`FORMAT_VALUE`, `str` slice, `str.join`, `str.format`, and
  `%` formatting.
- `str: route bytes.decode results through the managed constructor`
  — routes `bytes_method_decode`, `charp2uni`, and the charmap / utf-7 /
  unicode-escape decode results.
- `unicodeobject: copy bytes instead of Box::from_raw in the managed-str header-alloc fallback`
  — the header-alloc-failure recovery cloned the buffer instead of
  `Box::from_raw`-ing a pointer `gc_alloc_storage_box` may own through the GC
  (which would double-free against the sweep).

## Validation

- `pyre/check.py`: dynasm 246/246, cranelift 246/246, **wasm 245/245** — wasm runs
  `gc_interp` on by default, so its suite actively exercises the managed routing.
- Decode churn RSS (native, `PYRE_GC_INTERP=1`): **48 MB managed vs 305 MB
  immortal (6.3×)**; mixed-op churn 167 MB vs 1296 MB (7.7×).
- Correctness: managed results held as dict key/value, list, and set elements
  survive `gc.collect` with the JIT on and off.

## Codex parity review

Reviewed against `main` over the 10 changed files. §1 (parity regressions to
PyPy): none. §2 (introduced mismatches): the `Box::from_raw` double-free above,
fixed in this branch. §3/§4: the exact-`str` immortal baseline (the deliberate
safe-split boundary) and the value-box split / tokenizer drop-glue /
`TokenizerIter` 3.14 structural adaptations, all documented in-code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
