### PR TITLE
jit: reconstruct Int/Float register banks concretely at bridge resume

### DIFF
--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -8587,14 +8587,20 @@ impl JitState for PyreJitState {
         // flips; the opt-out keeps the prior symbolic-bridge
         // behavior available for A/B.
         let seed_bridge_locals = std::env::var("PYRE_FBW_BRIDGE_LOCAL_SEED").as_deref() != Ok("0");
-        // For kept-stack branch guards the body-internal marker's
-        // liveness colors do not 1:1-correspond to semantic slots — a
-        // color that lives a temp at the body marker may name a different
-        // slot at the guard PC.  Seeding concrete values at the
-        // consume_boxes stage (color-indexed) stamps the wrong value onto
-        // the OpRef, causing downstream branch folds to take the wrong
-        // direction.  Defer seeding to the post-overlay stage where the
-        // mirror is slot-indexed and values are authoritative.
+        // `seed_deferred_to_overlay` is Ref-specific.  The Ref overlay below
+        // rebuilds a SLOT-indexed mirror from the color-indexed resume decode
+        // (via `pcdep_entries`).  At a kept-stack branch guard the body-internal
+        // marker's Ref colors do not 1:1-correspond to semantic slots — a color
+        // that lives a temp at the marker may name a different slot at the guard
+        // PC — so seeding the Ref concrete at the color-indexed consume stage
+        // stamps the wrong value; defer it to the post-overlay stage where the
+        // mirror is slot-indexed and authoritative.  The Int and Float banks
+        // (`sym.registers_i` / `sym.registers_f`) are pure scalar register reds
+        // with no operand-stack slot mirror, so they reconstruct concrete at the
+        // consume stage directly — matching `resume.py:1052-1055
+        // rebuild_from_resumedata` → `consume_boxes(f.get_current_position_info(),
+        // registers_i, registers_r, registers_f)`, which fills all three banks
+        // uniformly at the guard's resume position.
         let seed_deferred_to_overlay =
             crate::state::frame_pc_is_resolved_offset_at(frame0.jitcode_index, frame0.pc);
         let mut bridge_stamp_orphans =
@@ -8613,17 +8619,16 @@ impl JitState for PyreJitState {
                 backend,
                 &mut virtuals_cache,
             );
-            // The Int bank is color-indexed and can be seeded directly only
-            // when the frame position names its exact liveness marker.  A
-            // resolved body coordinate can share a marker whose Int color is
-            // an earlier scratch value; treating that value as the current
-            // branch condition lets a nested FOR_ITER bridge take the wrong
-            // arm.  Leave such scratches symbolic, as RPython does when an
-            // unboxed temporary is absent from the exact resume position.
-            if seed_bridge_locals
-                && !seed_deferred_to_overlay
-                && !matches!(concrete_val, majit_ir::Value::Void)
-            {
+            // The Int bank is a scalar register red: the decoded value is paired
+            // with `reg_indices.int` by `value_cursor` and read from this guard's
+            // `fail_values`, so it is guard-accurate.  Stamp it as the trace-time
+            // concrete unconditionally (not gated on `seed_deferred_to_overlay`,
+            // which is Ref-only) so a loop-carried Int red feeding an
+            // `(i % k) == 0` kept-stack branch guard folds its `goto_if_not`
+            // instead of declining the bridge with `GotoIfNotValueNotConcrete`.
+            // Mirrors `consume_boxes(..., f.registers_i, ...)` filling the Int
+            // bank at the guard's resume position.
+            if seed_bridge_locals && !matches!(concrete_val, majit_ir::Value::Void) {
                 ctx.try_set_opref_concrete(resolved, concrete_val);
             }
             let reg_idx = reg_idx as usize;
@@ -8675,10 +8680,11 @@ impl JitState for PyreJitState {
                 backend,
                 &mut virtuals_cache,
             );
-            if seed_bridge_locals
-                && !seed_deferred_to_overlay
-                && !matches!(concrete_val, majit_ir::Value::Void)
-            {
+            // Float bank: a scalar register red, guard-accurate like the Int
+            // bank above; stamp its concrete unconditionally (the Ref-only
+            // `seed_deferred_to_overlay` deferral does not apply), mirroring
+            // `consume_boxes(..., f.registers_f)`.
+            if seed_bridge_locals && !matches!(concrete_val, majit_ir::Value::Void) {
                 ctx.try_set_opref_concrete(resolved, concrete_val);
             }
             let reg_idx = reg_idx as usize;


### PR DESCRIPTION
## Summary

`setup_bridge_sym` reconstructs a bridge frame from guard resume data, mirroring `resume.py:1052-1055` `rebuild_from_resumedata` → `consume_boxes(f.get_current_position_info(), registers_i, registers_r, registers_f)`, which fills **all three register banks uniformly** at the guard's resume position.

pyre deferred the concrete seed of *every* bank to the Ref operand-stack overlay stage (`seed_deferred_to_overlay`), but that overlay rebuilds the slot-indexed mirror only for the **Ref** bank (`pcdep_entries`, all `bank==1`). The **Int and Float** banks (`sym.registers_i` / `sym.registers_f`) are pure scalar register reds with no operand-stack slot mirror, so their concrete was dropped for kept-stack branch guards.

Consequence: a loop-carried Int red — e.g. a `range` index feeding an `(i % k) == 0` kept-stack branch guard — stayed symbolic, so its `goto_if_not` could not fold a direction and the branch-guard bridge declined with `GotoIfNotValueNotConcrete`, falling back to the interpreter (bit-exact but no compiled bridge).

## Fix

Stamp the Int and Float concrete at the consume stage unconditionally; the `seed_deferred_to_overlay` deferral is Ref-specific (only the Ref bank feeds the slot-mirror overlay). `reg_indices` is read from the guard's resolved `-live-` marker (pyre's `get_current_position_info()` analog), so the `value_cursor`-paired resume value is guard-accurate. `try_set_opref_concrete` sets a trace-time shadow only — the IR keeps the symbolic `InputArg`, so no loop-variant value is const-folded (orthodox meta-tracing: trace the concrete path, guard it).

## Verification

- `kept_stack_deep_var_condexpr` / `_shortcircuit`: the repeated `GotoIfNotValueNotConcrete` abort is gone and the branch-guard bridge now compiles (census `bridge=true`, abort 66→0), with bit-exact output.
- Float un-defer bit-exact vs CPython (`nbody` / `spectral_norm` / `float_loop` identical).
- `pyre/check.py` all three backends green: **dynasm 246/246, cranelift 246/246, wasm 245/245**; no jit-stats regression floor fire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
