### PR TITLE
fix: address stdlib compatibility reviews

### DIFF
--- a/majit/majit-metainterp/src/history.rs
+++ b/majit/majit-metainterp/src/history.rs
@@ -2382,10 +2382,6 @@ impl TraceCtx {
             frames: recorder_frames,
             vable_boxes: vable_boxes.to_vec(),
             vref_boxes: vref_boxes.to_vec(),
-            // The nested-list append fold resumes through the single-frame
-            // collapse, never this multi-frame path, so no extra virtual roots
-            // flow here.
-            extra_virtual_roots: Vec::new(),
         });
         self.set_last_guard_op_resume_position(snapshot_id);
     }

--- a/pyre/extra_tests/parity_tests/exec_globals_dict.py
+++ b/pyre/extra_tests/parity_tests/exec_globals_dict.py
@@ -53,4 +53,18 @@ assert g["y"] == 3
 assert "__builtins__" in g
 
 
+# DELETE_GLOBAL must use the live globals dict-subclass backing, while dict's
+# intrinsic deletion semantics bypass the Python-level override.
+class DeletingGlobals(dict):
+    def __delitem__(self, key):
+        self.deleted = key
+        return super().__delitem__(key)
+
+
+g = DeletingGlobals(x=1)
+exec("global x\ndel x", g)
+assert not hasattr(g, "deleted")
+assert "x" not in g
+
+
 print("OK")

--- a/pyre/extra_tests/parity_tests/exec_globals_dict.py
+++ b/pyre/extra_tests/parity_tests/exec_globals_dict.py
@@ -67,4 +67,16 @@ assert not hasattr(g, "deleted")
 assert "x" not in g
 
 
+class GetattributeGlobals(dict):
+    def __getattribute__(self, name):
+        if name == "__dict_data__":
+            raise AssertionError("DELETE_GLOBAL exposed its intrinsic backing")
+        return super().__getattribute__(name)
+
+
+g = GetattributeGlobals(x=1)
+exec("global x\ndel x", g)
+assert "x" not in g
+
+
 print("OK")

--- a/pyre/extra_tests/snippets/_pickle.py
+++ b/pyre/extra_tests/snippets/_pickle.py
@@ -949,6 +949,32 @@ if HAVE_PICKLE:
     finally:
         globals()["Shadow"] = _real_shadow
 
+    # Import/sys.modules failures become PicklingError, but exceptions from a
+    # real module's PEP 562 __getattr__ remain user exceptions.
+    import sys
+    import types
+
+    dynamic_module = types.ModuleType("pickle_dynamic_keyerror")
+
+    def dynamic_getattr(name):
+        raise KeyError(name)
+
+    dynamic_module.__getattr__ = dynamic_getattr
+    sys.modules[dynamic_module.__name__] = dynamic_module
+
+    def dynamic_target():
+        pass
+
+    dynamic_target.__module__ = dynamic_module.__name__
+    dynamic_target.__qualname__ = "dynamic_target"
+    try:
+        dumps(dynamic_target, 4)
+        raise AssertionError("module __getattr__ KeyError was masked")
+    except KeyError as exc:
+        assert exc.args == ("dynamic_target",), exc
+    finally:
+        del sys.modules[dynamic_module.__name__]
+
     # ── persistent_id / persistent_load: the external-object hook ──
     class Ref:
         def __init__(self, name):

--- a/pyre/extra_tests/snippets/jit.py
+++ b/pyre/extra_tests/snippets/jit.py
@@ -12,11 +12,25 @@ def baz(a: int, b: int):
     return a + b + 12
 
 
+def many_args(*args):
+    return len(args)
+
+
+def two_unsupported_calls():
+    # The JIT helper ABI intentionally tops out at 14 explicit arguments.
+    # Two consecutive larger calls must produce one clean interpreter bailout,
+    # not two exits attached to the same flow-graph block.
+    first = many_args(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14)
+    second = many_args(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14)
+    return first + second
+
+
 def tests():
     assert foo() == 15
     assert bar() == 2e5
     assert baz(17, 20) == 49
     assert baz(17, 22.5) == 51.5
+    assert two_unsupported_calls() == 30
 
 
 tests()
@@ -26,4 +40,5 @@ if hasattr(foo, "__jit__"):
     foo.__jit__()
     bar.__jit__()
     baz.__jit__()
+    two_unsupported_calls.__jit__()
     tests()

--- a/pyre/extra_tests/snippets/stdlib_typing.py
+++ b/pyre/extra_tests/snippets/stdlib_typing.py
@@ -167,6 +167,18 @@ assert NonCallableExplicitAnnotate.__annotate__ == 42
 assert NonCallableExplicitAnnotate.__annotations__ == {}
 
 
+class ResetAnnotationsThenAnnotate:
+    pass
+
+
+ResetAnnotationsThenAnnotate.__annotations__ = {"old": int}
+ResetAnnotationsThenAnnotate.__annotate__ = lambda format: {"new": format}
+assert ResetAnnotationsThenAnnotate.__annotations__ == {"new": 1}
+del ResetAnnotationsThenAnnotate.__annotations__
+ResetAnnotationsThenAnnotate.__annotate__ = lambda format: {"again": format}
+assert ResetAnnotationsThenAnnotate.__annotations__ == {"again": 1}
+
+
 class AnnotationReader:
     def __set_name__(self, owner, name):
         owner.InjectedBySetName = int

--- a/pyre/extra_tests/snippets/stdlib_typing.py
+++ b/pyre/extra_tests/snippets/stdlib_typing.py
@@ -44,6 +44,10 @@ class AnnotatedCoordinate:
     x: int
 
 
+if hasattr(AnnotatedCoordinate.__annotate__, "__jit__"):
+    # Force the annotation thunk through the LOAD_FROM_DICT_OR_GLOBALS JIT
+    # residual before materializing its cache.
+    AnnotatedCoordinate.__annotate__.__jit__()
 assert AnnotatedCoordinate.__annotations__ == {"x": int}
 
 
@@ -121,6 +125,64 @@ assert LazyAnnotatedChild.__annotate__ is None
 assert LazyAnnotatedBase.__annotations__ == {"value": int}
 LazyAnnotatedBase.__annotate__ = lambda _: {}
 assert LazyAnnotatedBase.__annotations__ == {}
+
+# Clearing __annotate__ preserves an already materialized cache, while a new
+# callable replaces both the compiler-facing and public slots.
+LazyAnnotatedBase.__annotate__ = lambda format: {"cached": format}
+assert LazyAnnotatedBase.__annotations__ == {"cached": 1}
+LazyAnnotatedBase.__annotate__ = None
+assert LazyAnnotatedBase.__annotations__ == {"cached": 1}
+LazyAnnotatedBase.__annotate__ = lambda format: {"new": format}
+assert LazyAnnotatedBase.__annotate__(1) == {"new": 1}
+assert LazyAnnotatedBase.__annotations__ == {"new": 1}
+
+
+class ExplicitAnnotations:
+    __annotations__ = {"old": int}
+
+
+ExplicitAnnotations.__annotations__ = {"new": str}
+assert ExplicitAnnotations.__annotations__ == {"new": str}
+assert ExplicitAnnotations.__dict__["__annotations__"] == {"new": str}
+del ExplicitAnnotations.__annotations__
+assert ExplicitAnnotations.__annotations__ == {}
+
+
+class ExplicitAnnotate:
+    def __annotate__(format):
+        return {"old": format}
+
+
+old_explicit_annotate = ExplicitAnnotate.__annotate__
+ExplicitAnnotate.__annotate__ = lambda format: {"new": format}
+assert ExplicitAnnotate.__annotate__ is old_explicit_annotate
+assert ExplicitAnnotate.__annotations__ == {"old": 1}
+
+
+class AnnotationReader:
+    def __set_name__(self, owner, name):
+        owner.InjectedBySetName = int
+        self.seen = owner.__annotations__
+
+
+class SetNameAnnotations:
+    value: InjectedBySetName
+    reader = AnnotationReader()
+
+
+assert SetNameAnnotations.reader.seen == {"value": int}
+
+
+class AnnotationMeta(type):
+    pass
+
+
+class MetaSetNameAnnotations(metaclass=AnnotationMeta):
+    value: InjectedBySetName
+    reader = AnnotationReader()
+
+
+assert MetaSetNameAnnotations.reader.seen == {"value": int}
 
 try:
     LazyAnnotatedBase.__annotate__ = 42

--- a/pyre/extra_tests/snippets/stdlib_typing.py
+++ b/pyre/extra_tests/snippets/stdlib_typing.py
@@ -159,6 +159,14 @@ assert ExplicitAnnotate.__annotate__ is old_explicit_annotate
 assert ExplicitAnnotate.__annotations__ == {"old": 1}
 
 
+class NonCallableExplicitAnnotate:
+    __annotate__ = 42
+
+
+assert NonCallableExplicitAnnotate.__annotate__ == 42
+assert NonCallableExplicitAnnotate.__annotations__ == {}
+
+
 class AnnotationReader:
     def __set_name__(self, owner, name):
         owner.InjectedBySetName = int

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -5396,7 +5396,9 @@ pub(crate) fn type_get_annotations(obj: PyObjectRef) -> PyResult {
     let annotate_fn = crate::type_dict_lookup(obj, "__annotate__")
         .or_else(|| crate::type_dict_lookup(obj, "__annotate_func__"));
     let annotations = match annotate_fn {
-        Some(callable) if !callable.is_null() && !unsafe { is_none(callable) } => {
+        Some(callable)
+            if !callable.is_null() && !unsafe { is_none(callable) } && callable_w(callable) =>
+        {
             let value = crate::call::call_function_impl_result(callable, &[w_int_new(1)])?;
             if !unsafe { is_dict(value) } {
                 return Err(PyError::type_error(format!(

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -5391,8 +5391,10 @@ pub(crate) fn type_get_annotations(obj: PyObjectRef) -> PyResult {
         )));
     }
 
-    let annotate_fn = crate::type_dict_lookup(obj, "__annotate_func__")
-        .or_else(|| crate::type_dict_lookup(obj, "__annotate__"));
+    // An explicit class-body __annotate__ is an ordinary visible class-dict
+    // entry and takes precedence over the compiler-facing descriptor slot.
+    let annotate_fn = crate::type_dict_lookup(obj, "__annotate__")
+        .or_else(|| crate::type_dict_lookup(obj, "__annotate_func__"));
     let annotations = match annotate_fn {
         Some(callable) if !callable.is_null() && !unsafe { is_none(callable) } => {
             let value = crate::call::call_function_impl_result(callable, &[w_int_new(1)])?;
@@ -5418,7 +5420,14 @@ pub(crate) fn type_set_annotations(obj: PyObjectRef, value: PyObjectRef) -> PyRe
             unsafe { w_type_get_name(obj) },
         )));
     }
-    crate::type_dict_store(obj, "__annotations_cache__", value);
+    // CPython updates an explicit class-body __annotations__ key in place;
+    // otherwise the descriptor stores through __annotations_cache__.
+    if crate::type_dict_lookup(obj, "__annotations__").is_some() {
+        crate::type_dict_store(obj, "__annotations__", value);
+        crate::type_dict_delete(obj, "__annotations_cache__");
+    } else {
+        crate::type_dict_store(obj, "__annotations_cache__", value);
+    }
     crate::type_dict_store(obj, "__annotate_func__", w_none());
     crate::type_dict_store(obj, "__annotate__", w_none());
     pyre_object::gc_hook::try_gc_write_barrier(obj as *mut u8);
@@ -5439,8 +5448,15 @@ pub(crate) fn type_set_annotate(obj: PyObjectRef, value: PyObjectRef) -> PyResul
     if !unsafe { is_none(value) } && !callable_w(value) {
         return Err(PyError::type_error("__annotate__ must be callable or None"));
     }
+    // CPython stores descriptor assignments in the compiler-facing slot.
+    // An explicit class-body __annotate__ key remains an ordinary visible
+    // class attribute and intentionally shadows this internal slot.
     crate::type_dict_store(obj, "__annotate_func__", value);
-    crate::type_dict_delete(obj, "__annotations_cache__");
+    // Setting None preserves an already materialized annotations cache;
+    // installing a new callable invalidates it.
+    if !unsafe { is_none(value) } {
+        crate::type_dict_delete(obj, "__annotations_cache__");
+    }
     pyre_object::gc_hook::try_gc_write_barrier(obj as *mut u8);
     unsafe { mutated(obj, Some("__annotate__")) };
     Ok(w_none())
@@ -5453,8 +5469,9 @@ pub(crate) fn type_del_annotations(obj: PyObjectRef) -> PyResult {
             unsafe { w_type_get_name(obj) },
         )));
     }
-    let removed = crate::type_dict_delete(obj, "__annotations_cache__")
-        || crate::type_dict_delete(obj, "__annotations__");
+    let removed_cache = crate::type_dict_delete(obj, "__annotations_cache__");
+    let removed_explicit = crate::type_dict_delete(obj, "__annotations__");
+    let removed = removed_cache || removed_explicit;
     if !removed {
         return Err(raiseattrerror(obj, "__annotations__", None));
     }

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -5431,7 +5431,7 @@ pub(crate) fn type_set_annotations(obj: PyObjectRef, value: PyObjectRef) -> PyRe
         crate::type_dict_store(obj, "__annotations_cache__", value);
     }
     crate::type_dict_store(obj, "__annotate_func__", w_none());
-    crate::type_dict_store(obj, "__annotate__", w_none());
+    crate::type_dict_delete(obj, "__annotate__");
     pyre_object::gc_hook::try_gc_write_barrier(obj as *mut u8);
     unsafe { mutated(obj, Some("__annotations__")) };
     Ok(w_none())
@@ -5478,7 +5478,7 @@ pub(crate) fn type_del_annotations(obj: PyObjectRef) -> PyResult {
         return Err(raiseattrerror(obj, "__annotations__", None));
     }
     crate::type_dict_store(obj, "__annotate_func__", w_none());
-    crate::type_dict_store(obj, "__annotate__", w_none());
+    crate::type_dict_delete(obj, "__annotate__");
     pyre_object::gc_hook::try_gc_write_barrier(obj as *mut u8);
     unsafe { mutated(obj, Some("__annotations__")) };
     Ok(w_none())

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -3707,6 +3707,7 @@ fn type_descr_new_with_metaclass(
         // both explicit class cells out of the new type's `__dict__`
         // (CPython consumes them here rather than storing them).
         let mut classcell_root = None;
+        let mut classdictcell_root = None;
         // `type.__new__` accepts any `dict` subclass as the namespace
         // (the check is `PyDict_Check`, not `PyDict_CheckExact`); resolve
         // the dict backing so e.g. an `enum._EnumDict` class body is
@@ -3747,6 +3748,11 @@ fn type_descr_new_with_metaclass(
                     continue;
                 }
                 if key.as_str() == Ok("__classdictcell__") {
+                    if unsafe { pyre_object::is_cell(value) } {
+                        let root = pyre_object::gc_roots::shadow_stack_len();
+                        pyre_object::gc_roots::pin_root(value);
+                        classdictcell_root = Some(root);
+                    }
                     continue;
                 }
                 let class_ns = pyre_object::gc_roots::shadow_stack_get(class_ns_root);
@@ -3863,6 +3869,17 @@ fn type_descr_new_with_metaclass(
         // `weak_subclasses` so `mutated()` and `__subclasses__()`
         // observe this class.
         unsafe { pyre_object::typeobject::w_type_ready(w_type) };
+
+        // CPython type_new_set_classdict precedes type_new_set_names: lazy
+        // annotation thunks invoked by __set_name__ must resolve class-local
+        // names through the completed type dictionary.
+        if let Some(classdictcell_root) = classdictcell_root {
+            let classdictcell = pyre_object::gc_roots::shadow_stack_get(classdictcell_root);
+            let type_dict = unsafe { pyre_object::w_type_get_dict_ptr(w_type) as PyObjectRef };
+            if !type_dict.is_null() {
+                unsafe { pyre_object::w_cell_set(classdictcell, type_dict) };
+            }
+        }
 
         // _set_names (typeobject.py:1006) — call `__set_name__(owner, name)`
         // on each descriptor in the type's FINAL `__dict__` (`w_type.dict_w`),

--- a/pyre/pyre-interpreter/src/call.rs
+++ b/pyre/pyre-interpreter/src/call.rs
@@ -3784,6 +3784,18 @@ fn build_class_inner(
         // `weak_subclasses` so cross-subclass invalidation in
         // `mutated()` and `__subclasses__()` see this class.
         unsafe { pyre_object::typeobject::w_type_ready(w) };
+        // CPython type_new_set_classdict binds __classdict__ before
+        // type_new_set_names.  A descriptor's __set_name__ may mutate the
+        // completed type dict and immediately materialize lazy annotations;
+        // the annotation thunk must observe that final dict, not the
+        // provisional class-body namespace.
+        if let Some(classdictcell_root) = classdictcell_root {
+            let classdictcell = pyre_object::gc_roots::shadow_stack_get(classdictcell_root);
+            let type_dict = unsafe { pyre_object::w_type_get_dict_ptr(w) as PyObjectRef };
+            if !type_dict.is_null() {
+                unsafe { pyre_object::w_cell_set(classdictcell, type_dict) };
+            }
+        }
         // __set_name__ protocol — type_new_set_names
         // Only needed here because w_type_new is a raw Rust call that
         // bypasses the type() builtin (builtins.rs) which already calls
@@ -3842,6 +3854,9 @@ fn build_class_inner(
         }
     }
 
+    // The default path bound this before __set_name__; the metaclass path
+    // normally binds it inside type.__new__.  Retain this final validation/
+    // fallback for a custom metaclass returning a type without delegating.
     if let Some(classdictcell_root) = classdictcell_root {
         if unsafe { pyre_object::is_type(w_type) } {
             let classdictcell = pyre_object::gc_roots::shadow_stack_get(classdictcell_root);

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -3834,13 +3834,13 @@ impl OpcodeStepExecutor for PyFrame {
     // ── delete_global ──
     // pypy/interpreter/pyopcode.py:901-903 DELETE_GLOBAL —
     //   `self.space.delitem(self.get_w_globals_storage(), w_varname)`.
-    // `space.delitem` on a dict raises `KeyError(w_varname)` when the
-    // key is missing; pyre routes through `w_dict_delitem_str` on the
-    // canonical W_DictObject so the W_ModuleDictObject's strategy is updated.
+    // CPython/PyPy dict deletion uses the dict's intrinsic strategy and does
+    // not invoke a dict subclass's Python-level __delitem__.  Resolve pyre's
+    // composed dict-subclass backing first, then use that same strategy path.
     fn delete_global(&mut self, name: &str) -> Result<(), PyError> {
         let w_globals = self.get_w_globals();
-        let found =
-            !w_globals.is_null() && unsafe { pyre_object::w_dict_delitem_str(w_globals, name) };
+        let backing = unsafe { crate::type_methods::resolve_dict_backing(w_globals) };
+        let found = !backing.is_null() && unsafe { pyre_object::w_dict_delitem_str(backing, name) };
         if !found {
             return Err(PyError::key_error(format!("'{name}'")));
         }

--- a/pyre/pyre-interpreter/src/module/_pickle/pickler.rs
+++ b/pyre/pyre-interpreter/src/module/_pickle/pickler.rs
@@ -1895,8 +1895,8 @@ fn whichmodule(w_obj: PyObjectRef, name: &str) -> Result<PyObjectRef, PyError> {
     // ModuleNotFoundError subclass), an invalid module name, and a missing
     // sys.modules entry into PicklingError.  Other exceptions raised by a
     // module's dynamic attribute machinery still propagate unchanged.
-    let resolved = match crate::module::_pickle::try_resolve_global(&module_name, name, true) {
-        Ok(value) => value,
+    let module = match import_module(&module_name) {
+        Ok(module) => module,
         Err(error)
             if matches!(
                 error.kind,
@@ -1911,6 +1911,14 @@ fn whichmodule(w_obj: PyObjectRef, name: &str) -> Result<PyObjectRef, PyError> {
                 error.message
             )));
         }
+        Err(error) => return Err(error),
+    };
+    // Attribute traversal is deliberately outside the import-error
+    // conversion above.  A module's PEP 562 __getattr__ may raise KeyError,
+    // and that user exception must propagate rather than become PicklingError.
+    let resolved = match getattribute_dotted(module, name) {
+        Ok((value, _)) => Some(value),
+        Err(error) if matches!(error.kind, crate::PyErrorKind::AttributeError) => None,
         Err(error) => return Err(error),
     };
     match resolved {

--- a/pyre/pyre-interpreter/src/type_methods.rs
+++ b/pyre/pyre-interpreter/src/type_methods.rs
@@ -5124,9 +5124,35 @@ pub fn resolve_dict_backing(obj: PyObjectRef) -> PyObjectRef {
             }
         }
         if is_instance(obj) {
-            if let Ok(backing) = crate::baseobjspace::getattr_str(obj, "__dict_data__") {
-                if is_dict(backing) {
-                    return backing;
+            // `__dict_data__` is pyre's object-resident stand-in for the
+            // intrinsic W_DictMultiObject payload of a PyPy dict subclass.
+            // Read that reserved layout slot directly: going through
+            // `getattr_str` would incorrectly expose internal dict operations
+            // to a subclass's Python-level `__getattribute__` hook.
+            let w_type = crate::typedef::r#type(obj).unwrap_or(PY_NULL);
+            if !w_type.is_null() {
+                let mut layout = pyre_object::w_type_get_layout_ptr(w_type);
+                while !layout.is_null() {
+                    let current = &*layout;
+                    let first_slot = current
+                        .nslots
+                        .saturating_sub(current.newslotnames.len() as u32);
+                    if let Some(offset) = current
+                        .newslotnames
+                        .iter()
+                        .position(|name| name == "__dict_data__")
+                    {
+                        if let Some(backing) = crate::objspace::std::mapdict::getslotvalue(
+                            obj,
+                            first_slot + offset as u32,
+                        ) {
+                            if is_dict(backing) {
+                                return backing;
+                            }
+                        }
+                        break;
+                    }
+                    layout = current.base_layout;
                 }
             }
         }

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -1935,11 +1935,7 @@ fn module_annotations_get(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::Py
                     "__annotate__ returned non-dict of type '{received}'"
                 )));
             }
-            // Module annotation functions consult the mutable
-            // `__conditional_annotations__` set.  A partially executed
-            // module may therefore produce a larger dict on a later read;
-            // do not freeze the intermediate result in `__annotations__`.
-            return Ok(result);
+            result
         }
         _ => pyre_object::w_dict_new(),
     };

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -4731,7 +4731,7 @@ pub extern "C" fn bh_load_global_fn(
 
 /// LOAD_FROM_DICT_OR_GLOBALS residual (`load_from_dict_or_globals` HLOp →
 /// `residual_call_ir_r`).  Mirrors `eval.rs::load_from_dict_or_globals`:
-/// try `getattr_str(dict, name)` on the popped mapping first, then fall
+/// try `getitem(dict, name)` on the popped mapping first, then fall
 /// back to the live frame's globals, else NameError.  `namei` is a direct
 /// `code.names` index (no LOAD_GLOBAL push-null low-bit shift).
 ///
@@ -4757,11 +4757,17 @@ pub extern "C" fn bh_load_from_dict_or_globals_fn(
     let varname = code.names[idx].as_ref();
     let dict = dict_ptr as pyre_object::PyObjectRef;
 
-    // Try the popped mapping first (`getattr_str`), matching the
-    // interpreter's `if let Ok(val) = getattr_str(dict, name)` fast path.
-    match pyre_interpreter::baseobjspace::getattr_str(dict, varname) {
+    // CPython/PyPy LOAD_FROM_DICT_OR_GLOBALS uses mapping subscription, not
+    // attribute lookup.  Preserve __getitem__/__missing__ and propagate every
+    // exception except the KeyError that selects the globals fallback.
+    let key = pyre_object::w_str_new(varname);
+    match pyre_interpreter::baseobjspace::getitem(dict, key) {
         Ok(val) => return val as i64,
-        Err(_) => {}
+        Err(err) if matches!(err.kind, pyre_interpreter::PyErrorKind::KeyError) => {}
+        Err(mut err) => {
+            publish_residual_call_exception(err.to_exc_object() as i64);
+            return 0;
+        }
     }
 
     // Fall back to the live frame's globals (GC-safe when the frame owns
@@ -4775,10 +4781,13 @@ pub extern "C" fn bh_load_from_dict_or_globals_fn(
         unsafe { pyre_interpreter::w_code_get_w_globals(w_code_ptr as pyre_object::PyObjectRef) }
     };
     if !w_globals.is_null() {
-        if let Some(val) =
-            unsafe { pyre_object::dictmultiobject::w_dict_getitem_str(w_globals, varname) }
-        {
-            return val as i64;
+        match pyre_interpreter::baseobjspace::finditem_str(w_globals, varname) {
+            Ok(Some(val)) => return val as i64,
+            Ok(None) => {}
+            Err(mut err) => {
+                publish_residual_call_exception(err.to_exc_object() as i64);
+                return 0;
+            }
         }
     }
 

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -8821,6 +8821,10 @@ impl CodeWriter {
                             };
                             if nargs > 14 {
                                 emit_abort_permanent!(py_pc);
+                                // `abort_permanent` closes this graph block.
+                                // Do not record the synthetic call result or
+                                // any later operation on the closed block.
+                                continue;
                             }
                             push_and_bump!(call_result_value, py_pc);
                         }


### PR DESCRIPTION
Follow-up to #702 addressing its unresolved review findings.

- mirror `LOAD_FROM_DICT_OR_GLOBALS` mapping semantics in the JIT residual
- preserve CPython 3.14 type/module annotation cache and explicit-slot behavior
- bind `__classdict__` before `__set_name__`
- delete globals through dict-subclass backing storage without invoking Python `__delitem__`
- preserve module `__getattr__` exceptions during pickle global verification
- stop the walker immediately after a large-call `abort_permanent`

Validation:
- `cargo fmt --all -- --check`
- `cargo check --features dynasm`
- `cargo test --features dynasm`
- `cargo test -p pyre-jit-trace --features dynasm` (241 passed, 6 ignored)
- `cargo test -p pyre-jit --features dynasm` (322 passed, 1 ignored; GC stress 12 passed)
- `test_type_annotations` and `test_module` with pyre-dynasm
- modified regression snippets with pyre-dynasm, including forced-JIT annotation thunk
- `python3 pyre/check.py target/release/pyre-dynasm --backend dynasm --no-synthetic` (11/11 passed)
