### PR TITLE
jit: gate the tracing-frame force on the escaping frame being the traced one

### DIFF
--- a/pyre/bench/synth/getframe_residual_callee_own_frame.py
+++ b/pyre/bench/synth/getframe_residual_callee_own_frame.py
@@ -1,0 +1,30 @@
+# Regression guard: a residual (may-force) callee that inspects its OWN frame
+# via sys._getframe() must not clear the traced CALLER's virtualizable tracing
+# token. Clearing it raised a spurious frame-escape with no committed resume pc,
+# replaying the loop body from entry and double-applying the callee's
+# non-journaled STORE_ATTR side effect -- a JIT-only wrong answer (c.n > loops).
+import sys
+
+
+class Counter:
+    pass
+
+
+c = Counter()
+c.n = 0
+
+
+def bump(x):
+    c.n += 1                  # STORE_ATTR: non-journaled body effect
+    frame = sys._getframe(0)  # may-force residual inspecting the callee's own frame
+    return x if frame is not None else -1
+
+
+def main():
+    total = 0
+    for i in range(20000):
+        total += bump(i)
+    print(total, c.n)
+
+
+main()

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
@@ -40,7 +40,14 @@ impl Drop for ActiveFrameEscapeGuard {
     }
 }
 
-pub fn flush_active_frame_escape(ctx: &TraceCtx, frame: *mut pyre_interpreter::PyFrame) {
+/// Returns whether `frame` is the one recorded as escaping this residual call
+/// (`expected == frame`) — i.e. the traced virtualizable itself was handed to
+/// Python, so its tracing token must be forced. A residual callee inspecting
+/// its own frame passes a different `frame` and returns false. Independently,
+/// the walk-end resume pc is committed only when the state flush succeeds (a
+/// merge point with cached depth); a matched frame that cannot flush still
+/// escaped and must be forced, so the two signals are decoupled.
+pub fn flush_active_frame_escape(ctx: &TraceCtx, frame: *mut pyre_interpreter::PyFrame) -> bool {
     ACTIVE_FRAME_ESCAPE.with(|slot| {
         if let Some((expected, py_pc)) = slot.get()
             && expected == frame as usize
@@ -48,8 +55,10 @@ pub fn flush_active_frame_escape(ctx: &TraceCtx, frame: *mut pyre_interpreter::P
             if crate::state::flush_walk_end_state_to_frame(ctx, expected, py_pc) {
                 COMMITTED_FRAME_ESCAPE_PC.with(|committed| committed.set(Some(py_pc)));
             }
+            return true;
         }
-    });
+        false
+    })
 }
 
 pub fn take_committed_frame_escape_pc() -> Option<usize> {

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -3477,8 +3477,10 @@ unsafe extern "C" fn force_pyframe(frame: *mut pyre_interpreter::PyFrame) {
     }
     let (driver, info) = driver_pair();
     unsafe {
+        let mut traced_frame_escaped = false;
         let tracing_frame = driver.meta_interp_mut().trace_ctx().and_then(|ctx| {
-            pyre_jit_trace::jitcode_dispatch::flush_active_frame_escape(ctx, frame);
+            traced_frame_escaped =
+                pyre_jit_trace::jitcode_dispatch::flush_active_frame_escape(ctx, frame);
             ctx.virtualizable_heap_ptr()
         });
         let tracing_frame = tracing_frame.map(|ptr| ptr as *mut u8).filter(|ptr| {
@@ -3498,14 +3500,17 @@ unsafe extern "C" fn force_pyframe(frame: *mut pyre_interpreter::PyFrame) {
                 driver.meta_interp_mut().force_virtualizable_token(token);
             });
         };
-        // Force the traced frame even when it IS the escaping one: clearing
+        // Force the traced frame only when the frame handed to Python IS the
+        // traced virtualizable (it was the one recorded as escaping). Clearing
         // TOKEN_TRACING_RESCALL is what `tracing_after_residual_call` reads as
-        // "the callee forced the virtualizable", which raises
-        // `VableEscapedDuringResidualCall` and lets the walk resume forward
-        // from the pc `flush_active_frame_escape` just committed.  Skipping it
-        // would leave the walk tracing against a shadow whose frame has already
-        // been handed to Python code.
-        if let Some(ptr) = tracing_frame {
+        // "the callee forced the virtualizable", raising
+        // `VableEscapedDuringResidualCall` so the walk resumes forward.  A
+        // residual callee inspecting its own frame escapes a DIFFERENT frame;
+        // clearing the token there raises a spurious escape with no committed
+        // resume pc, so the walk replays from entry — double-applying the
+        // residual's non-journaled body effects.  Skipping the force there
+        // leaves the callee frame (which is not the traced shadow) untouched.
+        if traced_frame_escaped && let Some(ptr) = tracing_frame {
             force(ptr);
         }
         if live_frame_armed {


### PR DESCRIPTION
## Problem

A residual (may-force) callee that inspects **its own frame** via `sys._getframe()` in a hot loop makes the JIT produce a wrong answer: a non-journaled `STORE_ATTR` in the callee body is applied one extra time per compiled iteration.

Discriminator (JIT-only; `PYRE_NO_JIT=1`, CPython and PyPy all print `199990000 20000`):

```python
import sys

class Counter:
    pass

c = Counter()
c.n = 0

def bump(x):
    c.n += 1                  # STORE_ATTR: non-journaled body effect
    frame = sys._getframe(0)  # forcing residual inspecting the callee's own frame
    return x if frame is not None else -1

def main():
    total = 0
    for i in range(20000):
        total += bump(i)
    print(total, c.n)         # JIT (for-loop): 199990000 20010 — c.n over-counted

main()
```

This is the P1 left unanswered by the #699 review ("Avoid forcing unrelated tracing frames").

## Cause

`force_pyframe` fires from `gettopframe` / `getnextframe_nohidden` when Python asks for a frame during a residual call. The `sys._getframe(0)` above hands Python the **callee's own** frame — not the caller's traced virtualizable — yet the force path unconditionally forced the traced vable whenever its token was `TOKEN_TRACING_RESCALL`. Forcing a frame that did not actually escape clears the caller's tracing token, which `tracing_after_residual_call` then reads as a real escape and raises `VableEscapedDuringResidualCall`. The abort replays `ContinueRunningNormally` from loop entry, re-running the already-executed non-journaled `STORE_ATTR` → double-apply.

## Fix

Force the traced virtualizable only when the frame handed to Python **is** the traced one (i.e. it was recorded as escaping):

- `flush_active_frame_escape` now returns a `bool` — `true` only when the active escape's `expected` frame matches the frame being forced. The committed-pc write is **decoupled** from flush success (flushing legitimately declines when there is no merge-point depth, and that must not suppress the escape signal).
- `force_pyframe` gates the traced-frame force on that returned flag; the caller's `live_frame_armed` force path is unchanged.

`for i in range(20000): total += bump(i)` moves `c.n` 20010 → **20000**.

## Verification

- `pyre/bench/synth/getframe_residual_callee_own_frame.py` (added) — for-loop regression guard, oracle-matched (CPython == PyPy == pyre == `199990000 20000`).
- `check.py`: **dynasm 286/286, cranelift 286/286, wasm 283/283**, 3/3 backend runs green on the rebased HEAD.
- `inline_helper` and the other inline benches unchanged (no inline-path regression).
- An adversarial static review confirmed the force-target change is a **non-issue** (post-fix force is a strict subset of pre-fix force — it only ever forces *less*).

## Known limitation (tracked, not fixed here)

The **while-loop** twin of the discriminator (`while i < N: total += bump(i)`) still over-counts (`c.n = 20005`). This is **independent** of the fix above (A/B-proven: the count is identical before and after — the fix is monotone and only ever forces less) and is a separate, pre-existing bug.

It is an instance of the known **resume-past-abort** limitation: a side-effecting user function in a hot loop that the JIT keeps aborting re-applies its non-journaled effect `+K` times. In the while shape `bump` is taken down the multiframe-inline seeding path, which declines (`LoopBearingCalleeInlineUnsupported`) after the body already ran concretely; the gh#467 abort-flush then sees an unjournaled effect and keeps the legacy replay from loop entry instead of resuming past the abort.

A perf-safe static fix was **attempted and refuted**: the only available static signal (`extraeffect >= ForcesVirtualOrVirtualizable`) also covers generic Python-to-Python calls, so declining inline on it regresses `inline_helper`/`nbody` to timeouts; and declining inline does not close the class anyway (the residual path double-applies too, for a callee escaping the *traced* frame via `sys._getframe(1)`/`f_back`). The real fix is the resume-past-abort piece in gh#467/#343 territory, tracked separately. No while-loop bench is added here because it would be red.

— *authored by Claude*
