### PR TITLE
jit: reactive setup-abort bridge decline + pending-field prologue heapcache fixes

### DIFF
--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -2582,11 +2582,11 @@ impl<S: JitState> JitDriver<S> {
                         let current_ops = ctx.num_ops();
                         current_ops == start_ops
                             || (current_ops == start_ops + 1
-                                && ctx.ops().get(start_ops).is_some_and(|op| {
-                                    op.opcode == majit_ir::OpCode::GetfieldRawI
-                                }))
-                    })
-                {
+                                && ctx
+                                    .ops()
+                                    .get(start_ops)
+                                    .is_some_and(|op| op.opcode == majit_ir::OpCode::GetfieldRawI))
+                    }) {
                     self.meta
                         .bridge_info_cloned()
                         .map(|bridge| bridge.source_descr)

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -860,6 +860,10 @@ pub struct JitDriver<S: JitState> {
     /// traces from an exception guard (GUARD_EXCEPTION / GUARD_NO_EXCEPTION).
     /// The caller should emit SAVE_EXC_CLASS + SAVE_EXCEPTION at trace start.
     pub last_bridge_is_exception_guard: bool,
+    /// Recorded op count after bridge setup prologue materialization and
+    /// before the bridge body walk starts. Used to distinguish deterministic
+    /// setup aborts from transient mid-trace aborts.
+    bridge_body_start_op_count: Option<usize>,
     /// Additional entry points sharing this driver's compiled loops.
     entry_points: Vec<EntryPoint>,
     /// PyPy JitDriver(is_recursive=True): enables max_unroll_recursion
@@ -1041,6 +1045,7 @@ impl<S: JitState> JitDriver<S> {
             descriptor: None,
             resume_data_result: None,
             last_bridge_is_exception_guard: false,
+            bridge_body_start_op_count: None,
             entry_points: Vec::new(),
             is_recursive: false,
             epoch_qmut,
@@ -2568,6 +2573,34 @@ impl<S: JitState> JitDriver<S> {
                 if self.meta.bridge_info().is_some() {
                     crate::debug::log_one("jit-abort", "Abort during bridge tracing");
                 }
+                let setup_aborted_bridge_descr = if matches!(action, TraceAction::Abort)
+                    && self.meta.bridge_info().is_some()
+                    && self.meta.tracing.as_ref().is_some_and(|ctx| {
+                        let Some(start_ops) = self.bridge_body_start_op_count else {
+                            return false;
+                        };
+                        let current_ops = ctx.num_ops();
+                        current_ops == start_ops
+                            || (current_ops == start_ops + 1
+                                && ctx.ops().get(start_ops).is_some_and(|op| {
+                                    op.opcode == majit_ir::OpCode::GetfieldRawI
+                                }))
+                    })
+                {
+                    self.meta
+                        .bridge_info_cloned()
+                        .map(|bridge| bridge.source_descr)
+                } else {
+                    None
+                };
+                if let Some(source_descr) = setup_aborted_bridge_descr {
+                    // pyjitpl.rs:9527-9532 structural-decline contract:
+                    // a bridge abort before bytecode-body ops is deterministic
+                    // setup failure from the fixed guard resume shape, so it
+                    // must not refire. The lone GetfieldRawI case is emitted
+                    // by bridge symbolic init before the body walker runs.
+                    self.meta.record_declined_bridge_guard(&source_descr);
+                }
                 // `pyjitpl.py:2491` `except SwitchToBlackhole as stb:
                 // self.aborted_tracing(stb.reason)` — the
                 // `aborted_tracing(reason)` accounting half of RPython's
@@ -2657,6 +2690,7 @@ impl<S: JitState> JitDriver<S> {
                     self.meta.aborted_tracing(reason_int);
                 }
                 self.sym = None;
+                self.bridge_body_start_op_count = None;
                 self.meta.clear_trace_session();
             }
             TraceAction::AbortPermanent => {
@@ -2693,6 +2727,7 @@ impl<S: JitState> JitDriver<S> {
     #[inline(never)]
     fn clear_tracing_session_state(&mut self) {
         self.sym = None;
+        self.bridge_body_start_op_count = None;
         self.meta.clear_trace_session();
     }
 
@@ -3137,26 +3172,11 @@ impl<S: JitState> JitDriver<S> {
             // guard failure resumes via blackhole — isolates bridge-record
             // resume defects from the blackhole path.
             //
-            // Guard resume virtuals ARE bridgeable: the bridge trace emits a
-            // materialization prologue (`setup_bridge_sym` -> NEW_WITH_VTABLE /
-            // SETFIELD_GC, resume.py:1042-1057 ResumeDataBoxReader._prepare), so
-            // `rd_virtuals` alone must NOT decline — declining it strands the hot
-            // loop on blackhole deopt (recursive fib etc. lose all JIT speedup).
-            // `rd_pendingfields` still declines: the bridge path only seeds the
-            // exception channel, not the general SETFIELD_GC pending-field
-            // prologue (resume.py:993-1007 _prepare_pendingfields), which is the
-            // remaining orthodox gap tracked separately.
-            let bridge_needs_materialization = exit_layout
-                .storage
-                .as_deref()
-                .is_some_and(|storage| !storage.rd_pendingfields.is_empty());
-            if bridge_needs_materialization {
-                self.meta.record_declined_bridge_guard(&descr_arc);
-            }
+            // Pending-field guards bridge through setup_bridge_sym's
+            // pending-field prologue (resume.py:993-1007).
             let should_bridge = must_compile
                 && !majit_metainterp::MetaInterp::<S::Meta>::stack_almost_full()
-                && !no_bridge_enabled()
-                && !bridge_needs_materialization;
+                && !no_bridge_enabled();
 
             // compile.py:710 recovery_layout header_pc parity:
             // guard resume_pc comes from the guard's recovery metadata.
@@ -4881,6 +4901,7 @@ impl<S: JitState> JitDriver<S> {
         resume_pc: usize,
     ) -> bool {
         majit_metainterp::mc_diag_bump(12); // start_bridge_tracing entered
+        self.bridge_body_start_op_count = None;
         // compile.py:725-729 `_trace_and_compile_from_bridge` raises
         // `compile.giveup()` when the descr's owning JitCellToken weakref
         // is dead (memmgr-evicted).  Pyre signals the same outcome by
@@ -4901,20 +4922,6 @@ impl<S: JitState> JitDriver<S> {
             majit_metainterp::mc_diag_bump(15); // sbt early: no compiled_meta
             return false;
         };
-
-        if self
-            .meta
-            .get_compiled_exit_layout_in_trace(green_key, trace_id, fail_index)
-            .and_then(|layout| layout.storage)
-            .is_some_and(|storage| !storage.rd_pendingfields.is_empty())
-        {
-            // resume.py:993-1007 _prepare_pendingfields: the general SETFIELD_GC
-            // pending-field prologue is not yet emitted on the bridge path, so a
-            // guard carrying pending fields still declines. `rd_virtuals` alone
-            // is bridgeable via the `setup_bridge_sym` materialization prologue
-            // and must NOT gate here (see the handle_fail decline site).
-            return false;
-        }
 
         if !state.can_trace() {
             majit_metainterp::mc_diag_bump(16); // sbt early: !can_trace
@@ -5141,6 +5148,7 @@ impl<S: JitState> JitDriver<S> {
                 &retrace.fail_types,
             );
         }
+        self.bridge_body_start_op_count = self.meta.tracing.as_ref().map(|ctx| ctx.num_ops());
         self.meta.begin_trace_session(trace_meta);
         // resume.py:1047-1055 parity:
         //   ResumeDataBoxReader.consume_boxes() rebuilds the frame state,

--- a/pyre/bench/synth/nested_for_int_scratch_bridge.py
+++ b/pyre/bench/synth/nested_for_int_scratch_bridge.py
@@ -1,0 +1,22 @@
+# Nested FOR_ITER with a branch-local Int condition and a kept stack at the
+# bridge resume point. The resolved-offset bridge decodes a non-empty Int bank,
+# so the Int register bank is reconstructed concretely at bridge resume and the
+# nested-loop branch guard folds instead of aborting GotoIfNotValueNotConcrete.
+def run(n):
+    total = 0
+    marker = None
+    other = object()
+    for i in range(n):
+        limit = (i & 3) + 1
+        for j in range(limit):
+            scratch = j + i
+            obj = marker if (j & 1) else other
+            if obj is None:
+                total += scratch
+            else:
+                total += j
+        total += limit
+    return total
+
+
+print(run(20000))

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -6547,11 +6547,17 @@ fn prepare_bridge_pending_fields(
             );
             if pending.item_index < 0 {
                 ctx.record_op_with_descr(OpCode::SetfieldGc, &[target_op, value_op], descr.clone());
-                // No walker field-heapcache seed: the replayed SETFIELD_GC runs at
-                // bridge entry, but the prologue does not mutate the live heap, so a
-                // getfield that hit a seeded entry would resolve against the stale
-                // pre-write field. (The array branch below can seed because its
-                // getarrayitem hit returns the cached value without a sanity load.)
+                // resume.py:1004 _prepare_pendingfields replays through
+                // execute_setfield_gc, which seeds heapcache.setfield after
+                // recording so a later same-field getfield folds against this
+                // write. Key on descr.index() (not index_in_parent) to match the
+                // trace-time get/setfield paths. The pending target is always
+                // non-virtual (resume.py:441 asserts only the fieldbox is virtual;
+                // the target is registered as a plain box), so the bridge-body read
+                // hits the regular getfield heapcache path with no on-hit sanity
+                // load, and the replayed SETFIELD_GC runs at bridge entry before
+                // any body op so the folded value matches the post-write field.
+                ctx.heapcache_setfield_cached(target_op, descr.index(), value_op);
             } else {
                 let index_op = ctx.const_int(pending.item_index as i64);
                 ctx.record_op_with_descr(

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -6459,8 +6459,7 @@ fn prepare_bridge_pending_fields(
         let Some(descr) = pending.descr.as_ref() else {
             continue;
         };
-        let is_exc_channel =
-            pending.item_index < 0 && std::sync::Arc::ptr_eq(descr, &target_descr);
+        let is_exc_channel = pending.item_index < 0 && std::sync::Arc::ptr_eq(descr, &target_descr);
 
         // resume.py:1002-1005: both operands use the same tagged decoder as
         // frame boxes.  Decode the target as well as the fieldbox so virtual

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -6548,13 +6548,11 @@ fn prepare_bridge_pending_fields(
             );
             if pending.item_index < 0 {
                 ctx.record_op_with_descr(OpCode::SetfieldGc, &[target_op, value_op], descr.clone());
-                if let Some(field_descr) = descr.as_field_descr() {
-                    ctx.heapcache_setfield_cached(
-                        target_op,
-                        field_descr.index_in_parent() as u32,
-                        value_op,
-                    );
-                }
+                // No walker field-heapcache seed: the replayed SETFIELD_GC runs at
+                // bridge entry, but the prologue does not mutate the live heap, so a
+                // getfield that hit a seeded entry would resolve against the stale
+                // pre-write field. (The array branch below can seed because its
+                // getarrayitem hit returns the cached value without a sanity load.)
             } else {
                 let index_op = ctx.const_int(pending.item_index as i64);
                 ctx.record_op_with_descr(
@@ -6562,6 +6560,13 @@ fn prepare_bridge_pending_fields(
                     &[target_op, index_op, value_op],
                     descr.clone(),
                 );
+                // resume.py:1211-1223 _setarrayitem replays through
+                // execute_setarrayitem_gc, which seeds the heapcache after
+                // recording (pyjitpl.py:2741-2744) so a later same-element
+                // getarrayitem folds against this write. The pending array
+                // container is always non-virtual, so the read hits the plain
+                // getarrayitem path (no on-hit sanity load).
+                ctx.heapcache_setarrayitem(target_op, index_op, descr.index(), value_op);
             }
         }
     }

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -6435,13 +6435,13 @@ fn bridge_decode_box(
     }
 }
 
-/// Seed the bridge walk's current-exception channel from the guard-owned
-/// pending field stream.  `resume.py:_prepare_pendingfields` decodes these
-/// tagged values only after virtual preparation; bridge tracing must decode
-/// the same fieldbox without applying the write to the live execution
-/// context, because the walk may still be abandoned.
+/// Prepare the guard-owned pending field stream for bridge tracing.
+/// `resume.py:_prepare_pendingfields` decodes these tagged values only after
+/// virtual preparation; the exception-channel entry seeds the bridge walk's
+/// current exception, while ordinary entries are re-emitted as trace ops
+/// instead of being applied directly to the live execution context.
 #[allow(clippy::too_many_arguments)]
-fn seed_bridge_pending_current_exception(
+fn prepare_bridge_pending_fields(
     sym: &mut PyreSym,
     ctx: &mut majit_metainterp::TraceCtx,
     resume_data: &majit_metainterp::ResumeDataResult,
@@ -6459,9 +6459,8 @@ fn seed_bridge_pending_current_exception(
         let Some(descr) = pending.descr.as_ref() else {
             continue;
         };
-        if pending.item_index >= 0 || !std::sync::Arc::ptr_eq(descr, &target_descr) {
-            continue;
-        }
+        let is_exc_channel =
+            pending.item_index < 0 && std::sync::Arc::ptr_eq(descr, &target_descr);
 
         // resume.py:1002-1005: both operands use the same tagged decoder as
         // frame boxes.  Decode the target as well as the fieldbox so virtual
@@ -6481,34 +6480,90 @@ fn seed_bridge_pending_current_exception(
             &resume_data.fail_arg_types,
             storage.rd_virtuals.len(),
         );
-        let _ = bridge_decode_box(
-            ctx,
-            &target,
-            Type::Ref,
-            rd_virtuals,
-            resume_data,
-            fail_values,
-            fail_types,
-            backend,
-            cache,
-        );
-        let (value_box, value_concrete) = bridge_decode_box(
-            ctx,
-            &value,
-            Type::Ref,
-            rd_virtuals,
-            resume_data,
-            fail_values,
-            fail_types,
-            backend,
-            cache,
-        );
-        let majit_ir::Value::Ref(value_ref) = value_concrete else {
-            continue;
-        };
-        sym.last_exc_box = value_box;
-        sym.last_exc_value = value_ref.as_usize() as pyre_object::PyObjectRef;
-        sym.class_of_last_exc_is_const = false;
+
+        if is_exc_channel {
+            let _ = bridge_decode_box(
+                ctx,
+                &target,
+                Type::Ref,
+                rd_virtuals,
+                resume_data,
+                fail_values,
+                fail_types,
+                backend,
+                cache,
+            );
+            let (value_box, value_concrete) = bridge_decode_box(
+                ctx,
+                &value,
+                Type::Ref,
+                rd_virtuals,
+                resume_data,
+                fail_values,
+                fail_types,
+                backend,
+                cache,
+            );
+            let majit_ir::Value::Ref(value_ref) = value_concrete else {
+                continue;
+            };
+            sym.last_exc_box = value_box;
+            sym.last_exc_value = value_ref.as_usize() as pyre_object::PyObjectRef;
+            sym.class_of_last_exc_is_const = false;
+        } else {
+            // resume.py:993-1007 `_prepare_pendingfields`: replay ordinary
+            // pending writes as bridge-entry SETFIELD_GC / SETARRAYITEM_GC ops.
+            let (target_op, _) = bridge_decode_box(
+                ctx,
+                &target,
+                Type::Ref,
+                rd_virtuals,
+                resume_data,
+                fail_values,
+                fail_types,
+                backend,
+                cache,
+            );
+            let value_kind = if pending.item_index < 0 {
+                descr
+                    .as_field_descr()
+                    .map(|fd| fd.field_type())
+                    .unwrap_or(Type::Ref)
+            } else {
+                descr
+                    .as_array_descr()
+                    .map(|ad| ad.item_type())
+                    .unwrap_or(Type::Ref)
+            };
+            let (value_op, _) = bridge_decode_box(
+                ctx,
+                &value,
+                value_kind,
+                rd_virtuals,
+                resume_data,
+                fail_values,
+                fail_types,
+                backend,
+                cache,
+            );
+            if pending.item_index < 0 {
+                ctx.record_op_with_descr(OpCode::SetfieldGc, &[target_op, value_op], descr.clone());
+                if let Some(field_descr) = descr.as_field_descr() {
+                    ctx.heapcache_setfield_cached(
+                        target_op,
+                        field_descr.index_in_parent() as u32,
+                        value_op,
+                    );
+                }
+            } else {
+                let index_op = ctx.const_int(pending.item_index as i64);
+                ctx.record_op_with_descr(
+                    OpCode::SetarrayitemGc,
+                    &[target_op, index_op, value_op],
+                    descr.clone(),
+                );
+            }
+        }
     }
 }
 
@@ -9457,7 +9512,7 @@ impl JitState for PyreJitState {
             });
         }
 
-        seed_bridge_pending_current_exception(
+        prepare_bridge_pending_fields(
             sym,
             ctx,
             resume_data,

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -2891,6 +2891,23 @@ pub fn trace_and_compile_from_bridge(
         if driver.is_tracing() {
             driver.meta_interp_mut().abort_trace(false);
         }
+        // This pre-walk decline returns before the `trace_bytecode` walk, so the
+        // walk-time `TraceAction::Abort` recorder below never runs for it. Record
+        // the guard here so `must_compile_with_values` does not re-enter this
+        // structurally-undecidable bridge every ~`trace_eagerness` failures. Gate
+        // to the guard-invariant subset: an exception guard always carries the
+        // exception (a deterministic decline while the exc-edge bridge is off),
+        // and a pending-field guard is exactly the subset the removed eager
+        // decline suppressed. A `GUARD_NOT_FORCED` whose `pending_exc` is
+        // runtime-conditional and carries no pending fields could still bridge on
+        // a non-raising failure, so it is left unrecorded.
+        let has_pending_fields = exit_layout
+            .storage
+            .as_deref()
+            .is_some_and(|storage| !storage.rd_pendingfields.is_empty());
+        if last_bridge_is_exception_guard || has_pending_fields {
+            driver.meta_interp_mut().record_declined_bridge_guard(descr_arc);
+        }
         return BridgeResolution::ResumeBlackhole;
     }
 

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -2894,18 +2894,14 @@ pub fn trace_and_compile_from_bridge(
         // This pre-walk decline returns before the `trace_bytecode` walk, so the
         // walk-time `TraceAction::Abort` recorder below never runs for it. Record
         // the guard here so `must_compile_with_values` does not re-enter this
-        // structurally-undecidable bridge every ~`trace_eagerness` failures. Gate
-        // to the guard-invariant subset: an exception guard always carries the
-        // exception (a deterministic decline while the exc-edge bridge is off),
-        // and a pending-field guard is exactly the subset the removed eager
-        // decline suppressed. A `GUARD_NOT_FORCED` whose `pending_exc` is
-        // runtime-conditional and carries no pending fields could still bridge on
-        // a non-raising failure, so it is left unrecorded.
-        let has_pending_fields = exit_layout
-            .storage
-            .as_deref()
-            .is_some_and(|storage| !storage.rd_pendingfields.is_empty());
-        if last_bridge_is_exception_guard || has_pending_fields {
+        // structurally-undecidable bridge every ~`trace_eagerness` failures. Only
+        // an exception guard is recorded: its `pending_exc` is guard-invariant, so
+        // the decline is deterministic while the exc-edge bridge is off. A
+        // `GUARD_NOT_FORCED` (even one carrying pending fields) has a
+        // runtime-conditional `pending_exc` and can still bridge on a later
+        // non-raising failure via the pending-field prologue, so blacklisting it
+        // after one raising failure would defeat that; leave it unrecorded.
+        if last_bridge_is_exception_guard {
             driver
                 .meta_interp_mut()
                 .record_declined_bridge_guard(descr_arc);

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -2906,7 +2906,9 @@ pub fn trace_and_compile_from_bridge(
             .as_deref()
             .is_some_and(|storage| !storage.rd_pendingfields.is_empty());
         if last_bridge_is_exception_guard || has_pending_fields {
-            driver.meta_interp_mut().record_declined_bridge_guard(descr_arc);
+            driver
+                .meta_interp_mut()
+                .record_declined_bridge_guard(descr_arc);
         }
         return BridgeResolution::ResumeBlackhole;
     }


### PR DESCRIPTION
Bridge-path changes on the reactive setup-abort decline, plus prologue heapcache fixes and a regression bench.

> The resolved-offset Int/Float register-bank reconstruction originally in this PR is **subsumed by #715**, which shipped the same reconstruction via an unconditional consume-stage stamp. A fable-advised adjudication found #715's unconditional stamp #675-safe (RPython `consume_boxes` fills every color; a fold-extra color is dead at the guard so stamping its true value can't affect a fold; `clear_unboxed_banks` strips scalars so the marker superset never materializes) and the guard-exact liveness gate here fully redundant (255/255 gate events `exact_member=true` — it never excluded a color). That work (bridge Int/Float pipeline + its dedup follow-up) is dropped; this PR keeps only the parts independent of #715.

## 1. Reactively decline setup-aborting pending-field bridges

Remove the eager `rd_pendingfields` bridge-materialization decline and add the general pending-field prologue (`prepare_bridge_pending_fields` emits `SETFIELD_GC` / `SETARRAYITEM_GC` for non-exception entries, `resume.py:993-1007` `_prepare_pendingfields`). A guard whose bridge aborts during setup (no bytecode-body ops recorded, tracked via `bridge_body_start_op_count`) is a deterministic structural failure, so `record_declined_bridge_guard` marks it once instead of re-tracing every ~`trace_eagerness` guard failures. Transient mid-trace aborts (body ops recorded) are unaffected.

Also close the pre-walk coverage gap (Codex review): a guard resuming with a pending exception and no exc-edge route declines *before* the walk (the pre-walk `ResumeBlackhole` in `trace_and_compile_from_bridge`), which the walk-time `TraceAction::Abort` recorder never reaches, so `must_compile_with_values` re-entered the same undecidable bridge every ~`trace_eagerness` failures. Record the guard there too, gated to **exception guards only** — an exception guard's `pending_exc` is guard-invariant, so the decline is deterministic while the exc-edge bridge is off. A `GUARD_NOT_FORCED` (even one carrying pending fields) has a runtime-conditional `pending_exc` and can still bridge on a later non-raising failure via the pending-field prologue, so blacklisting it after one raising failure would defeat that; it is left unrecorded.

## 2. Bridge pending-field prologue heapcache seeding (Codex review)

- **Seed the field heapcache correctly-keyed**: the prior seed keyed on `index_in_parent()` while every trace-time getfield/setfield path keys on `descr.index()` (they differ for `PyreFieldDescr`), so it was inert. Re-key it on `descr.index()`, mirroring `execute_setfield_gc` → `heapcache.setfield` (`resume.py:1004`), so a bridge body reading a just-replayed pending field folds against the write. The pending target is always non-virtual (`resume.py:441` asserts only the fieldbox is virtual; the target is registered as a plain box), so the read takes the regular getfield path with no on-hit sanity load, and the replayed `SETFIELD_GC` runs at bridge entry before any body op.
- **Add the missing array-item heapcache seed** after `SETARRAYITEM_GC`, keyed on `descr.index()` (mirroring `execute_setarrayitem_gc`, `pyjitpl.py:2741-2744`), so a later same-element getarrayitem folds against the write. The pending array container is always non-virtual, so the read hits the plain getarrayitem path with no on-hit sanity load.

## bench

`nested_for_int_scratch_bridge` covers a resolved-offset kept-stack bridge with a non-empty Int register bank — the path #715 reconstructs concretely.

`python3 pyre/check.py --backend dynasm` — 294/294.
