### PR TITLE
stdlib: complete copy, enum, and weakref compatibility

### DIFF
--- a/pyre/extra_tests/snippets/stdlib_copy.py
+++ b/pyre/extra_tests/snippets/stdlib_copy.py
@@ -1,0 +1,43 @@
+import copy
+import gc
+import operator
+import weakref
+
+
+class Value:
+    pass
+
+
+a, b, c, d = [Value() for _ in range(4)]
+original = weakref.WeakValueDictionary({a: b, c: d})
+cloned = copy.copy(original)
+del c, d
+gc.collect()
+gc.collect()
+gc.collect()
+assert len(original) == 1
+assert len(cloned) == 1
+
+
+left = []
+left.append(left)
+right = copy.deepcopy(left)
+assert right is not left
+assert right[0] is right
+for comparison in (
+    operator.eq,
+    operator.ne,
+    operator.lt,
+    operator.le,
+    operator.gt,
+    operator.ge,
+):
+    try:
+        comparison(left, right)
+    except RecursionError:
+        pass
+    else:
+        raise AssertionError("recursive list comparison did not stop")
+
+
+print("stdlib copy ok")

--- a/pyre/extra_tests/snippets/stdlib_enum.py
+++ b/pyre/extra_tests/snippets/stdlib_enum.py
@@ -1,0 +1,96 @@
+from enum import Enum, IntEnum, IntFlag, auto
+
+
+class Color(Enum):
+    RED = 1
+    BLUE = 2
+
+
+class Number(IntEnum):
+    ONE = 1
+    TWO = 2
+
+
+class Permission(IntFlag):
+    READ = auto()
+    WRITE = auto()
+
+
+assert repr(Color) == "<enum 'Color'>"
+
+try:
+    delattr(Color, "RED")
+except AttributeError:
+    pass
+else:
+    raise AssertionError("Enum members must not be deletable")
+
+assert Color(1) is Color.RED
+assert list(Color) == [Color.RED, Color.BLUE]
+assert Number.ONE == 1
+assert Permission.READ | Permission.WRITE == 3
+assert ~Permission.READ is Permission.WRITE
+
+
+class BaseNumber(IntEnum):
+    @property
+    def one(self):
+        return self.name
+
+
+class DerivedNumber(BaseNumber):
+    one = auto()
+    two = auto()
+
+
+# EnumType installs a redirect descriptor and stores the member on it.  The
+# mapdict value must remain the IntEnum object, not be unboxed to a plain int.
+assert DerivedNumber.one is DerivedNumber._member_map_["one"]
+assert DerivedNumber.one.__class__ is DerivedNumber
+
+
+class FloatSubclass(float):
+    pass
+
+
+class Holder:
+    pass
+
+
+holder = Holder()
+holder.value = FloatSubclass(1.5)
+assert holder.value.__class__ is FloatSubclass
+holder_with_unboxed_slot = Holder()
+holder_with_unboxed_slot.value = 2.0
+holder_with_unboxed_slot.value = FloatSubclass(2.5)
+assert holder_with_unboxed_slot.value.__class__ is FloatSubclass
+
+
+class Meta(type):
+    def __repr__(cls):
+        return f"<custom {cls.__name__}>"
+
+
+class Custom(metaclass=Meta):
+    pass
+
+
+assert repr(Custom) == "<custom Custom>"
+
+# Type metadata is an object-valued getset, not a freshly boxed string on
+# every access.  `inspect.classify_class_attrs` relies on this identity when
+# locating `__name__` and `__qualname__` on the defining class.
+assert Custom.__name__ is Custom.__name__
+assert Custom.__qualname__ is Custom.__qualname__
+
+
+class Name(str):
+    pass
+
+
+custom_name = Name("Renamed")
+Custom.__name__ = custom_name
+assert Custom.__name__ is custom_name
+
+
+print("stdlib enum ok")

--- a/pyre/extra_tests/snippets/stdlib_weakref.py
+++ b/pyre/extra_tests/snippets/stdlib_weakref.py
@@ -5,6 +5,14 @@ from _weakref import getweakrefcount, getweakrefs, proxy, ref
 
 from testutils import assert_raises
 
+import weakref
+
+for type_name in ("ReferenceType", "ProxyType", "CallableProxyType"):
+    weak_type = getattr(weakref, type_name)
+    assert weak_type.__module__ == "weakref"
+    assert weak_type.__name__ == type_name
+    assert weak_type.__qualname__ == type_name
+
 
 class X:
     pass

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -5174,6 +5174,14 @@ unsafe fn delattr_surrogate(obj: PyObjectRef, w_name: PyObjectRef, name: &Wtf8) 
                 return crate::call::call_function_impl_result(da, &[obj, w_name])
                     .map(|_| w_none());
             }
+        } else if let Some(w_type) = crate::typedef::r#type(obj) {
+            // descroperation.py:254 dispatches through space.lookup for every
+            // receiver kind. A class is an instance of its metaclass, so its
+            // __delattr__ override precedes direct type-dict removal too.
+            if let Some(da) = lookup_in_type(w_type, "__delattr__") {
+                return crate::call::call_function_impl_result(da, &[obj, w_name])
+                    .map(|_| w_none());
+            }
         }
     }
     unsafe { object_delattr_surrogate(obj, w_name, name) }
@@ -5557,15 +5565,10 @@ fn object_getattr_miss(obj: PyObjectRef, name: &str, call_getattr: bool) -> PyRe
                 }
             }
             if name == "__name__" {
-                // `type.__name__` is the bare type name; a dotted tp_name
-                // (e.g. "types.UnionType") carries its module prefix only
-                // in repr, so strip to the final component here.
-                let full = w_type_get_name(obj);
-                let bare = full.rsplit('.').next().unwrap_or(full);
-                return Ok(w_str_new(bare));
+                return Ok(pyre_object::w_type_get_name_obj(obj));
             }
             if name == "__qualname__" {
-                return Ok(w_str_new(pyre_object::w_type_get_qualname(obj)));
+                return Ok(pyre_object::w_type_get_qualname_obj(obj));
             }
             if name == "__mro__" {
                 let mro_ptr = w_type_get_mro(obj);
@@ -5700,8 +5703,21 @@ fn object_getattr_miss(obj: PyObjectRef, name: &str, call_getattr: bool) -> PyRe
             {
                 return Ok(w_str_new(crate::typedef::METHOD_DOC));
             }
-            if name == "__doc__"
-                || name == "__code__"
+            // typeobject.py:1166-1179 descr__doc — a heap type reads only its
+            // own dict and returns None when absent; class docs are never
+            // inherited. EnumType may omit an explicit `__doc__ = None`, so an
+            // MRO lookup here would incorrectly surface Enum.__doc__.
+            if name == "__doc__" && pyre_object::w_type_is_heaptype(obj) {
+                if let Some(value) = crate::type_dict_lookup(obj, name) {
+                    return match get(value, PY_NULL, obj) {
+                        Ok(Some(result)) => Ok(result),
+                        Ok(None) => Ok(value),
+                        Err(e) => Err(e),
+                    };
+                }
+                return Ok(w_none());
+            }
+            if name == "__code__"
                 || name == "__func__"
                 || name == "__self__"
                 || name == "__globals__"
@@ -5867,6 +5883,22 @@ fn object_getattr_miss(obj: PyObjectRef, name: &str, call_getattr: bool) -> PyRe
     // methods pre-installed, matching PyPy's TypeDef interpleveldefs.
     if let Some(w_type) = crate::typedef::r#type(obj) {
         if let Some(method) = unsafe { lookup_in_type_where(w_type, name) } {
+            // descroperation.py:90-104 — a data descriptor wins, but a
+            // non-data descriptor or plain class value must wait until after
+            // the instance dict. This ordering matters for native-layout
+            // subclasses too: IntFlag stores `_inverted_` on the member while
+            // Flag carries a class-level `_inverted_ = None` default.
+            if unsafe { is_data_descr(method) }
+                && let Some(result) = unsafe { get(method, obj, w_type)? }
+            {
+                return Ok(result);
+            }
+            let w_dict = getdict_backing(obj);
+            if !w_dict.is_null()
+                && let Some(value) = finditem_str(w_dict, name)?
+            {
+                return Ok(value);
+            }
             if unsafe { crate::is_function(method) } {
                 return Ok(pyre_object::w_method_new(method, obj, w_type));
             }
@@ -6462,7 +6494,13 @@ fn object_getattr_miss(obj: PyObjectRef, name: &str, call_getattr: bool) -> PyRe
     // second half of the "hasdict instance dict" protocol.
     let w_dict = getdict_backing(obj);
     if !w_dict.is_null() {
-        if let Some(value) = unsafe { pyre_object::w_dict_getitem_str(w_dict, name) } {
+        // `w_dict` may use MapDictStrategy, whose storage is the backing
+        // instance rather than a native r_dict. PyPy calls
+        // `w_obj.getdictvalue`, which routes through that strategy; use the
+        // generic dict lookup here for the same reason. Reading the raw native
+        // storage skips MapDictStrategy and makes an int/str/etc. subclass's
+        // freshly stored attribute appear shadowed by an inherited class value.
+        if let Some(value) = finditem_str(w_dict, name)? {
             return Ok(value);
         }
     }
@@ -8581,7 +8619,7 @@ pub fn object_setattr(obj: PyObjectRef, name: &str, value: PyObjectRef) -> PyRes
                             object_functionstr_type_name(value),
                         )));
                     }
-                    pyre_object::w_type_set_qualname(obj, pyre_object::w_str_get_value(value));
+                    pyre_object::w_type_set_qualname(obj, value);
                     return Ok(w_none());
                 }
                 // typeobject.py:1258-1261 descr_set___abstractmethods__ —
@@ -9192,6 +9230,14 @@ pub fn delattr_str(obj: PyObjectRef, name: &str) -> PyResult {
     unsafe {
         if is_instance(obj) {
             let w_type = w_instance_get_type(obj);
+            if let Some(da) = lookup_in_type(w_type, "__delattr__") {
+                let w_name = w_str_new(name);
+                return crate::call::call_function_impl_result(da, &[obj, w_name])
+                    .map(|_| w_none());
+            }
+        } else if let Some(w_type) = crate::typedef::r#type(obj) {
+            // A class object's attribute operations dispatch through its
+            // metaclass in PyPy (`space.lookup(w_obj, '__delattr__')`).
             if let Some(da) = lookup_in_type(w_type, "__delattr__") {
                 let w_name = w_str_new(name);
                 return crate::call::call_function_impl_result(da, &[obj, w_name])

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -3620,6 +3620,34 @@ pub(crate) fn type_new_set_hash_if_eq(ns: PyObjectRef) {
     }
 }
 
+/// CPython `type_new_set_classdict`: every new class owns a `__doc__` entry,
+/// using None when its namespace has no docstring. A declared `__doc__` slot
+/// is the sole exception because the class variable would collide with its
+/// member descriptor.
+pub(crate) fn type_new_set_doc(ns: PyObjectRef) -> crate::PyResult {
+    if unsafe { pyre_object::w_dict_getitem_str(ns, "__doc__") }.is_some() {
+        return Ok(pyre_object::w_none());
+    }
+    let doc_is_slot = match unsafe { pyre_object::w_dict_getitem_str(ns, "__slots__") } {
+        Some(slots)
+            if unsafe {
+                pyre_object::is_str(slots)
+                    || pyre_object::is_tuple(slots)
+                    || pyre_object::is_list(slots)
+            } =>
+        {
+            crate::call::collect_slot_names(slots)?
+                .iter()
+                .any(|name| name == "__doc__")
+        }
+        _ => false,
+    };
+    if !doc_is_slot {
+        unsafe { pyre_object::w_dict_setitem_str_no_proxy(ns, "__doc__", pyre_object::w_none()) };
+    }
+    Ok(pyre_object::w_none())
+}
+
 /// PyPy `typeobject.py:223-235 W_TypeObject.__init__`: consume the compiler's
 /// `__qualname__` entry before slot setup and retain it on the type object.
 /// Keeping it in the namespace changes `cls.__dict__` and makes libraries
@@ -3635,7 +3663,7 @@ pub(crate) fn type_new_take_qualname(w_type: PyObjectRef, ns: PyObjectRef) -> cr
         )));
     }
     unsafe {
-        pyre_object::w_type_set_qualname(w_type, pyre_object::w_str_get_value(value));
+        pyre_object::w_type_set_qualname(w_type, value);
         pyre_object::w_dict_delitem_str_no_proxy(ns, "__qualname__");
     }
     Ok(pyre_object::w_none())
@@ -3759,6 +3787,8 @@ fn type_descr_new_with_metaclass(
                 unsafe { pyre_object::w_dict_setitem_wtf8_no_proxy(class_ns, &key, value) };
             }
         }
+        let class_ns = pyre_object::gc_roots::shadow_stack_get(class_ns_root);
+        type_new_set_doc(class_ns)?;
         let class_ns = pyre_object::gc_roots::shadow_stack_get(class_ns_root);
         type_new_set_hash_if_eq(class_ns);
         let class_ns = pyre_object::gc_roots::shadow_stack_get(class_ns_root);
@@ -6054,6 +6084,9 @@ unsafe fn py_repr_obj(obj: PyObjectRef) -> Result<PyObjectRef, crate::PyError> {
         if !obj.is_null() {
             let tp = (*obj).ob_type;
             if let Some(r) = crate::display::builtin_subclass_dunder_obj(obj, tp, "__repr__")? {
+                return Ok(r);
+            }
+            if let Some(r) = crate::display::type_metaclass_dunder_obj(obj, "__repr__")? {
                 return Ok(r);
             }
             if std::ptr::eq(tp, &INSTANCE_TYPE as *const PyType) {

--- a/pyre/pyre-interpreter/src/call.rs
+++ b/pyre/pyre-interpreter/src/call.rs
@@ -3569,34 +3569,7 @@ fn build_class_inner(
     // collide with the member descriptor (typing._SpecialForm).
     {
         let class_ns = pyre_object::gc_roots::shadow_stack_get(class_ns_root);
-        if unsafe { pyre_object::w_dict_getitem_str(class_ns, "__doc__") }.is_none() {
-            let class_ns = pyre_object::gc_roots::shadow_stack_get(class_ns_root);
-            let doc_is_slot =
-                match unsafe { pyre_object::w_dict_getitem_str(class_ns, "__slots__") } {
-                    Some(slots)
-                        if unsafe {
-                            pyre_object::is_str(slots)
-                                || pyre_object::is_tuple(slots)
-                                || pyre_object::is_list(slots)
-                        } =>
-                    {
-                        collect_slot_names(slots)
-                            .map(|names| names.iter().any(|n| n == "__doc__"))
-                            .unwrap_or(false)
-                    }
-                    _ => false,
-                };
-            if !doc_is_slot {
-                let class_ns = pyre_object::gc_roots::shadow_stack_get(class_ns_root);
-                unsafe {
-                    pyre_object::w_dict_setitem_str_no_proxy(
-                        class_ns,
-                        "__doc__",
-                        pyre_object::w_none(),
-                    )
-                };
-            }
-        }
+        crate::builtins::type_new_set_doc(class_ns)?;
     }
 
     // Create W_TypeObject from the class namespace
@@ -4036,7 +4009,9 @@ fn type_descr_call_with_mode(
 ///       slot_names_w = space.unpackiterable(w_slots)
 ///   for w_slot_name in slot_names_w:
 ///       slot_name = space.text_w(w_slot_name)
-fn collect_slot_names(w_slots: pyre_object::PyObjectRef) -> Result<Vec<String>, crate::PyError> {
+pub(crate) fn collect_slot_names(
+    w_slots: pyre_object::PyObjectRef,
+) -> Result<Vec<String>, crate::PyError> {
     unsafe {
         // typeobject.py:1158-1162: str → single-element list, else unpackiterable
         let slot_names_w = if pyre_object::is_str(w_slots) {

--- a/pyre/pyre-interpreter/src/display.rs
+++ b/pyre/pyre-interpreter/src/display.rs
@@ -352,17 +352,18 @@ pub(crate) unsafe fn builtin_subclass_dunder_obj(
         if w_class.is_null() || !pyre_object::is_type(w_class) {
             return Ok(None);
         }
-        let Some(found) = crate::baseobjspace::lookup_in_type_where(w_class, name) else {
+        let Some((src, found)) = crate::baseobjspace::lookup_where_pair(w_class, name) else {
             return Ok(None);
         };
         // `object`'s inherited default is not a leaf override — fall through
         // so the builtin formatting runs (and `object.__repr__` does not
-        // re-enter through this path).
+        // re-enter through this path). An explicit
+        // `Subclass.__str__ = object.__str__` is different: its owner is the
+        // subclass and the descriptor must run, allowing object.__str__ to
+        // delegate to the subclass's __repr__.
         let w_object = crate::typedef::w_object();
-        if let Some(default) = crate::baseobjspace::lookup_in_type_where(w_object, name) {
-            if std::ptr::eq(found, default) {
-                return Ok(None);
-            }
+        if std::ptr::eq(src, w_object) {
+            return Ok(None);
         }
         // A raising override propagates; a non-string return is a TypeError.
         let r = crate::builtins::call_and_check(found, &[obj])?;
@@ -370,6 +371,42 @@ pub(crate) unsafe fn builtin_subclass_dunder_obj(
             return Ok(Some(r));
         }
         Err(dunder_returned_non_string(name, r))
+    }
+}
+
+/// Resolve a class object's special method on its metaclass.
+///
+/// PyPy: `space.lookup(w_obj, name)` uses `space.type(w_obj)`, so a class
+/// receives an EnumType/user-metaclass override before the native `type`
+/// implementation. The builtin `type`/`object` definitions are terminals and
+/// deliberately left to the native formatting path to avoid re-entry.
+pub(crate) unsafe fn type_metaclass_dunder_obj(
+    obj: PyObjectRef,
+    name: &str,
+) -> Result<Option<PyObjectRef>, crate::PyError> {
+    unsafe {
+        if !pyre_object::is_type(obj) {
+            return Ok(None);
+        }
+        let Some(metaclass) = crate::typedef::r#type(obj) else {
+            return Ok(None);
+        };
+        if !pyre_object::is_type(metaclass) {
+            return Ok(None);
+        }
+        let Some((src, method)) = crate::baseobjspace::lookup_where_pair(metaclass, name) else {
+            return Ok(None);
+        };
+        if std::ptr::eq(src, crate::typedef::w_type())
+            || std::ptr::eq(src, crate::typedef::w_object())
+        {
+            return Ok(None);
+        }
+        let result = crate::builtins::call_and_check(method, &[obj])?;
+        if pyre_object::is_str(result) {
+            return Ok(Some(result));
+        }
+        Err(dunder_returned_non_string(name, result))
     }
 }
 
@@ -395,6 +432,9 @@ pub unsafe fn py_repr_wtf8(obj: PyObjectRef) -> Result<Wtf8Buf, crate::PyError> 
             // A builtin leaf subclass's `__repr__` override may return a
             // lone surrogate; read it as WTF-8 rather than folding to `&str`.
             if let Some(r) = builtin_subclass_dunder_obj(obj, tp, "__repr__")? {
+                return Ok(pyre_object::w_str_get_wtf8(r).to_wtf8_buf());
+            }
+            if let Some(r) = type_metaclass_dunder_obj(obj, "__repr__")? {
                 return Ok(pyre_object::w_str_get_wtf8(r).to_wtf8_buf());
             }
             if std::ptr::eq(tp, &INSTANCE_TYPE as *const PyType) {
@@ -477,6 +517,13 @@ pub unsafe fn py_repr(obj: PyObjectRef) -> Result<String, crate::PyError> {
         // `__repr__` override before the `ob_type`-keyed formatting below.
         if let Some(s) = builtin_subclass_dunder(obj, tp, "__repr__")? {
             return Ok(s);
+        }
+        // A class object is an instance of its metaclass.  PyPy's
+        // `space.repr` therefore resolves `__repr__` on that metaclass before
+        // `type`'s native `<class ...>` representation.  This is observable
+        // for EnumType and any user metaclass defining `__repr__`.
+        if let Some(result) = type_metaclass_dunder_obj(obj, "__repr__")? {
+            return Ok(pyre_object::w_str_get_value(result).to_string());
         }
         let formatted = if let Some(s) = builtin_leaf_repr_string(obj, tp) {
             s

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -4239,36 +4239,15 @@ impl OpcodeStepExecutor for PyFrame {
     // PyPy: LOAD_LOCALS; CPython: LOAD_LOCALS
     // Pushes the current namespace dict onto the stack.
     fn load_locals(&mut self) -> Result<(), PyError> {
-        let dict = pyre_object::w_dict_new();
-        unsafe {
-            let w_locals = self.get_w_locals();
-            if !w_locals.is_null() && pyre_object::is_dict(w_locals) {
-                for (key, value) in pyre_object::dictmultiobject::w_dict_items(w_locals) {
-                    if !value.is_null() {
-                        pyre_object::w_dict_store(dict, key, value);
-                    }
-                }
-            } else {
-                let code = &*crate::pyframe_get_pycode(self);
-                for (idx, name) in code.varnames.iter().enumerate() {
-                    let value = self.locals_w()[idx];
-                    if !value.is_null() {
-                        pyre_object::w_dict_store(dict, pyre_object::w_str_new(name), value);
-                    }
-                }
-                let w_globals = self.get_w_globals();
-                if self.nlocals() == 0 && !w_globals.is_null() {
-                    for (key, value) in
-                        unsafe { pyre_object::dictmultiobject::w_dict_items(w_globals) }
-                    {
-                        if !value.is_null() {
-                            pyre_object::w_dict_store(dict, key, value);
-                        }
-                    }
-                }
-            }
-        }
-        self.push(dict);
+        // pyopcode.py:793-794:
+        //   self.pushvalue(self.getorcreatedebug().w_locals)
+        // In particular this must preserve a metaclass's custom `__prepare__`
+        // mapping.  Rebuilding a plain dict loses mapping-subclass semantics;
+        // treating a dict subclass as a non-dict can also accidentally copy
+        // globals into the class namespace and make LOAD_FROM_DICT_OR_DEREF
+        // select a global over its closure cell.
+        let w_locals = self.get_or_create_w_locals();
+        self.push(w_locals);
         Ok(())
     }
 

--- a/pyre/pyre-interpreter/src/module/_weakref/interp__weakref.rs
+++ b/pyre/pyre-interpreter/src/module/_weakref/interp__weakref.rs
@@ -206,7 +206,10 @@ fn init_weakref_type(ns: PyObjectRef) {
 
 pub fn weakref_type() -> PyObjectRef {
     *WEAKREF_TYPE.get_or_init(|| {
-        let tp = crate::typedef::make_builtin_type("weakref", init_weakref_type);
+        // CPython exposes `_weakref.ref` as `weakref.ReferenceType`.
+        // The dotted builtin name supplies the public module while the type
+        // metadata getters expose the final component as the bare name.
+        let tp = crate::typedef::make_builtin_type("weakref.ReferenceType", init_weakref_type);
         unsafe { pyre_object::w_type_set_hasdict(tp, true) };
         tp as usize
     }) as PyObjectRef
@@ -254,7 +257,7 @@ fn init_proxy_type(ns: PyObjectRef) {
 #[majit_macros::dont_look_inside]
 pub fn proxy_type() -> PyObjectRef {
     *PROXY_TYPE.get_or_init(|| {
-        let tp = crate::typedef::make_builtin_type("weakproxy", init_proxy_type);
+        let tp = crate::typedef::make_builtin_type("weakref.ProxyType", init_proxy_type);
         unsafe {
             pyre_object::w_type_set_hasdict(tp, true);
             pyre_object::w_type_set_acceptable_as_base_class(tp, false);
@@ -313,7 +316,10 @@ fn init_callable_proxy_type(ns: PyObjectRef) {
 #[majit_macros::dont_look_inside]
 pub fn callable_proxy_type() -> PyObjectRef {
     *CALLABLE_PROXY_TYPE.get_or_init(|| {
-        let tp = crate::typedef::make_builtin_type("weakcallableproxy", init_callable_proxy_type);
+        let tp = crate::typedef::make_builtin_type(
+            "weakref.CallableProxyType",
+            init_callable_proxy_type,
+        );
         unsafe {
             pyre_object::w_type_set_hasdict(tp, true);
             pyre_object::w_type_set_acceptable_as_base_class(tp, false);
@@ -834,10 +840,39 @@ fn is_w_weakref(obj: PyObjectRef) -> bool {
     if obj.is_null() {
         return false;
     }
-    match crate::typedef::r#type(obj) {
-        Some(tp) => std::ptr::eq(tp, weakref_type()),
-        None => false,
+    unsafe { crate::baseobjspace::isinstance_w(obj, weakref_type()) }
+}
+
+/// PyPy `app_weakref._remove_dead_weakref`, backed by
+/// `W_DictMultiObject.nondescr_delitem_if_value_is`.
+///
+/// The lookup and deletion operate on the intrinsic dict backing so dict
+/// subclass hooks are bypassed.  Rechecking pointer identity immediately
+/// before deletion preserves the upstream atomic "delete only this weakref"
+/// contract if key comparison mutates the dictionary.
+pub fn remove_dead_weakref(args: &[PyObjectRef]) -> Result<PyObjectRef, PyError> {
+    let dict = args[0];
+    let key = args[1];
+    let backing = crate::type_methods::resolve_dict_backing(dict);
+    if backing.is_null() {
+        return Err(PyError::type_error(format!(
+            "_remove_dead_weakref() argument 1 must be dict, not {}",
+            crate::baseobjspace::object_functionstr_type_name(dict),
+        )));
     }
+    let Some(stored) = crate::baseobjspace::finditem(backing, key)? else {
+        return Ok(pyre_object::w_none());
+    };
+    if !is_w_weakref(stored) {
+        return Err(PyError::type_error("not a weakref"));
+    }
+    if !dereference(stored).is_null() {
+        return Ok(pyre_object::w_none());
+    }
+    if crate::baseobjspace::finditem(backing, key)? == Some(stored) {
+        crate::baseobjspace::delitem_slot(backing, key)?;
+    }
+    Ok(pyre_object::w_none())
 }
 
 fn is_callable(obj: PyObjectRef) -> bool {

--- a/pyre/pyre-interpreter/src/module/_weakref/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_weakref/mod.rs
@@ -12,8 +12,8 @@
 //! }
 //! ```
 //!
-//! `_remove_dead_weakref` is CPython-only and is stubbed as a no-op for
-//! cleanup-driven users like weakref.py's WeakValueDictionary.
+//! CPython exposes `_remove_dead_weakref`; PyPy implements the same operation
+//! in `app_weakref.py` through its atomic `delitem_if_value_is` helper.
 
 pub mod interp__weakref;
 
@@ -31,6 +31,6 @@ crate::py_module! {
     module_functions: {
         "getweakrefcount"      / 1 = interp__weakref::getweakrefcount,
         "getweakrefs"          / 1 = interp__weakref::getweakrefs,
-        "_remove_dead_weakref" / 2 = |_| Ok(pyre_object::w_none()),
+        "_remove_dead_weakref" / 2 = interp__weakref::remove_dead_weakref,
     },
 }

--- a/pyre/pyre-interpreter/src/objspace/descroperation.rs
+++ b/pyre/pyre-interpreter/src/objspace/descroperation.rs
@@ -3347,6 +3347,12 @@ pub fn xor(a: PyObjectRef, b: PyObjectRef) -> PyResult {
 /// Comparison operation dispatch.
 
 pub fn compare(a: PyObjectRef, b: PyObjectRef, op: CompareOp) -> PyResult {
+    // RPython inserts a stack check on this recursive object-space call.
+    // Container comparisons recurse without pushing a Python frame (for
+    // example two distinct self-referential lists), so keep the same guard
+    // explicitly in the Rust port and raise RecursionError before exhausting
+    // the native stack.
+    crate::stack_check::stack_check()?;
     // A builtin subclass overriding the comparison dunder dispatches the
     // override first (with reflected-subclass priority); exact builtins and
     // non-overriding subclasses fall through to the by-layout comparison slot,

--- a/pyre/pyre-interpreter/src/objspace/std/mapdict.rs
+++ b/pyre/pyre-interpreter/src/objspace/std/mapdict.rs
@@ -2001,20 +2001,53 @@ fn box_value(typ: UnboxType, val: i64) -> PyObjectRef {
     }
 }
 
-/// `type(w_value) is space.IntObjectCls` (mapdict.py:574,615). `is_int` matches
-/// `bool` too (bool subclasses int), but bool's impl class is not the int
-/// class, so a bool must not be unboxed — `w_int_new` boxing would discard its
-/// bool identity.
+/// `type(w_value) is space.IntObjectCls` (mapdict.py:198,574,615).
+///
+/// Pyre gives an int subclass the same native storage layout as W_IntObject
+/// and carries its app-level identity in `w_class`. Testing only the layout
+/// (`is_int`) would unbox IntEnum/user-int instances and reconstruct them as
+/// builtin ints, losing `w_class`. Compare the exact app-level type just as
+/// PyPy compares the exact implementation class.
 ///
 /// # Safety
 /// `w_value` must point to a live object.
 unsafe fn is_unboxable_int(w_value: PyObjectRef) -> bool {
-    // Early-return control flow rather than `if c { false } else { x }`, which
-    // can become a `!c && x` (a `bool_not`) that majit-translate cannot lower.
-    if unsafe { pyre_object::is_bool(w_value) } {
+    if !unsafe { pyre_object::is_int(w_value) } {
         return false;
     }
-    unsafe { pyre_object::is_int(w_value) }
+    let exact = crate::typedef::gettypeobject(&pyre_object::INT_TYPE);
+    if exact.is_null() {
+        // Interpreter-only unit tests may exercise mapdict before the app-level
+        // type registry is initialized. A native int with no class stamp is
+        // the bootstrap representation of that same exact type.
+        if pyre_object::tagged_int::CAN_BE_TAGGED
+            && unsafe { pyre_object::tagged_int::is_tagged_int(w_value) }
+        {
+            return true;
+        }
+        return unsafe { (*w_value).w_class.is_null() };
+    }
+    let Some(actual) = crate::typedef::r#type(w_value) else {
+        return false;
+    };
+    std::ptr::eq(actual, exact)
+}
+
+/// Float half of `_pick_unbox_type`: PyPy uses
+/// `type(w_value) is space.FloatObjectCls`, so a float subclass must retain
+/// its boxed object and `w_class` too.
+unsafe fn is_unboxable_float(w_value: PyObjectRef) -> bool {
+    if !unsafe { pyre_object::is_float(w_value) } {
+        return false;
+    }
+    let exact = crate::typedef::gettypeobject(&pyre_object::FLOAT_TYPE);
+    if exact.is_null() {
+        return unsafe { (*w_value).w_class.is_null() };
+    }
+    let Some(actual) = crate::typedef::r#type(w_value) else {
+        return false;
+    };
+    std::ptr::eq(actual, exact)
 }
 
 /// mapdict.py:586-590 `UnboxedPlainAttribute._convert_to_boxed` — rebuild the
@@ -2058,7 +2091,7 @@ unsafe fn convert_to_boxed_and_write<O: MapdictObject>(
 unsafe fn value_has_unbox_type(typ: UnboxType, w_value: PyObjectRef) -> bool {
     match typ {
         UnboxType::Int => unsafe { is_unboxable_int(w_value) },
-        UnboxType::Float => unsafe { pyre_object::is_float(w_value) },
+        UnboxType::Float => unsafe { is_unboxable_float(w_value) },
     }
 }
 
@@ -2595,7 +2628,7 @@ unsafe fn pick_unbox_type(self_node: MapRef, w_value: PyObjectRef) -> Option<Unb
     if term.allow_unboxing.get() {
         if ALLOW_UNBOXING_INTS && unsafe { is_unboxable_int(w_value) } {
             return Some(UnboxType::Int);
-        } else if unsafe { pyre_object::is_float(w_value) } {
+        } else if unsafe { is_unboxable_float(w_value) } {
             return Some(UnboxType::Float);
         }
     }

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -9155,10 +9155,7 @@ fn init_type_type(ns: PyObjectRef) {
 
     let name_getter = make_builtin_function_with_arity(
         "__name__",
-        |args| unsafe {
-            let name = pyre_object::w_type_get_name(args[1]);
-            Ok(pyre_object::w_str_new(name))
-        },
+        |args| unsafe { Ok(pyre_object::w_type_get_name_obj(args[1])) },
         2,
     );
     // typeobject.py:1046 descr_set__name__
@@ -9199,8 +9196,7 @@ fn init_type_type(ns: PyObjectRef) {
             crate::builtins::check_surrogate(w_value)?;
             // typeobject.py:1058 `w_type.name = name` — surrogate-free, so
             // the str view is valid UTF-8.
-            let name = unsafe { pyre_object::w_str_get_value(w_value) };
-            unsafe { pyre_object::w_type_set_name(w_type, name) };
+            unsafe { pyre_object::w_type_set_name(w_type, w_value) };
             Ok(pyre_object::w_none())
         },
         3,
@@ -15172,23 +15168,26 @@ fn init_object_type(ns: PyObjectRef) {
         pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
             ns,
             "__init_subclass__",
-            make_builtin_function("__init_subclass__", |args| {
-                let (_, kwargs) = crate::builtins::split_builtin_kwargs(args);
-                if let Some(kw) = kwargs {
-                    let has_real_kw = unsafe {
-                        pyre_object::w_dict_items(kw).into_iter().any(|(k, _)| {
-                            pyre_object::is_str(k)
-                                && pyre_object::w_str_get_wtf8(k).as_str() != Ok("__pyre_kw__")
-                        })
-                    };
-                    if has_real_kw {
-                        return Err(crate::PyError::type_error(
-                            "__init_subclass__() takes no keyword arguments",
-                        ));
+            pyre_object::function::w_classmethod_new(make_builtin_function(
+                "__init_subclass__",
+                |args| {
+                    let (_, kwargs) = crate::builtins::split_builtin_kwargs(args);
+                    if let Some(kw) = kwargs {
+                        let has_real_kw = unsafe {
+                            pyre_object::w_dict_items(kw).into_iter().any(|(k, _)| {
+                                pyre_object::is_str(k)
+                                    && pyre_object::w_str_get_wtf8(k).as_str() != Ok("__pyre_kw__")
+                            })
+                        };
+                        if has_real_kw {
+                            return Err(crate::PyError::type_error(
+                                "__init_subclass__() takes no keyword arguments",
+                            ));
+                        }
                     }
-                }
-                Ok(pyre_object::w_none())
-            }),
+                    Ok(pyre_object::w_none())
+                },
+            )),
         )
     };
     unsafe {

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -340,6 +340,8 @@ unsafe fn type_object_custom_trace(obj_addr: usize, f: &mut dyn FnMut(*mut majit
     let t = unsafe { &mut *(obj_addr as *mut pyre_object::typeobject::W_TypeObject) };
     f(&mut t.ob_header.w_class as *mut pyre_object::PyObjectRef as *mut majit_ir::GcRef);
     f(&mut t.bases as *mut pyre_object::PyObjectRef as *mut majit_ir::GcRef);
+    f(&mut t.w_name as *mut pyre_object::PyObjectRef as *mut majit_ir::GcRef);
+    f(&mut t.w_qualname as *mut pyre_object::PyObjectRef as *mut majit_ir::GcRef);
     // `name` points at a GC-managed leaf storage box (`String`, off-GC storage
     // epic S5) for a mortal heap type; forward the field slot so a major GC greys
     // the box, and the box tid's drop glue reclaims the buffer on sweep. An

--- a/pyre/pyre-object/src/typeobject.rs
+++ b/pyre/pyre-object/src/typeobject.rs
@@ -101,9 +101,16 @@ pub struct W_TypeObject {
     pub ob_header: PyObject,
     /// Class name (heap-allocated, leaked).
     pub name: *mut String,
+    /// App-level `__name__` object.  CPython preserves this object's identity
+    /// (including a str subclass assigned to a heap type); null means the
+    /// initial exact string has not been materialised yet.
+    pub w_name: PyObjectRef,
     /// Qualified class name.  PyPy `W_TypeObject.qualname` is populated by
     /// consuming `__qualname__` from the class namespace at construction.
     pub qualname: *mut String,
+    /// App-level `__qualname__` object, with the same lazy/identity semantics
+    /// as `w_name`.
+    pub w_qualname: PyObjectRef,
     /// Tuple of base type objects (PyObjectRef → W_TupleObject or PY_NULL).
     pub bases: PyObjectRef,
     /// Raw pointer to the class dict backing storage (`dict_w` analogue).
@@ -344,7 +351,9 @@ pub fn w_type_new(name: &str, bases: PyObjectRef, dict_ptr: *mut u8) -> PyObject
         },
         mro_w: std::ptr::null_mut(),
         name,
+        w_name: PY_NULL,
         qualname,
+        w_qualname: PY_NULL,
         bases,
         dict: dict_ptr,
         flag_heaptype: true,
@@ -458,7 +467,9 @@ pub fn w_type_new_builtin(
         },
         mro_w: std::ptr::null_mut(),
         name,
+        w_name: PY_NULL,
         qualname,
+        w_qualname: PY_NULL,
         bases,
         dict: dict_ptr,
         flag_heaptype: false,
@@ -793,12 +804,30 @@ pub unsafe fn w_type_get_name(obj: PyObjectRef) -> &'static str {
     &*(*(obj as *const W_TypeObject)).name
 }
 
+/// Return the stable app-level `type.__name__` object.
+pub unsafe fn w_type_get_name_obj(obj: PyObjectRef) -> PyObjectRef {
+    let t = &mut *(obj as *mut W_TypeObject);
+    if t.w_name.is_null() {
+        let full = &*t.name;
+        let bare = if t.flag_heaptype {
+            full.as_str()
+        } else {
+            full.rsplit('.').next().unwrap_or(full)
+        };
+        t.w_name = crate::w_str_new(bare);
+    }
+    t.w_name
+}
+
 /// Replace the class name (`descr_set__name__`, typeobject.py:1058
 /// `w_type.name = name`).  `name` is an owned `String` behind a raw
 /// pointer (`malloc_raw` = boxed); assigning through it drops the old
 /// name and installs the new one, leaving the slot itself unchanged.
-pub unsafe fn w_type_set_name(obj: PyObjectRef, name: &str) {
-    *(*(obj as *mut W_TypeObject)).name = name.to_string();
+pub unsafe fn w_type_set_name(obj: PyObjectRef, w_name: PyObjectRef) {
+    let t = &mut *(obj as *mut W_TypeObject);
+    *t.name = crate::w_str_get_value(w_name).to_string();
+    t.w_name = w_name;
+    crate::gc_hook::try_gc_write_barrier(obj as *mut u8);
 }
 
 /// `typeobject.py:223-235` / `getqualname`: the class qualified name lives
@@ -807,8 +836,20 @@ pub unsafe fn w_type_get_qualname(obj: PyObjectRef) -> &'static str {
     &*(*(obj as *const W_TypeObject)).qualname
 }
 
-pub unsafe fn w_type_set_qualname(obj: PyObjectRef, qualname: &str) {
-    *(*(obj as *mut W_TypeObject)).qualname = qualname.to_string();
+/// Return the stable app-level `type.__qualname__` object.
+pub unsafe fn w_type_get_qualname_obj(obj: PyObjectRef) -> PyObjectRef {
+    let t = &mut *(obj as *mut W_TypeObject);
+    if t.w_qualname.is_null() {
+        t.w_qualname = crate::w_str_new(&*t.qualname);
+    }
+    t.w_qualname
+}
+
+pub unsafe fn w_type_set_qualname(obj: PyObjectRef, w_qualname: PyObjectRef) {
+    let t = &mut *(obj as *mut W_TypeObject);
+    *t.qualname = crate::w_str_get_value(w_qualname).to_string();
+    t.w_qualname = w_qualname;
+    crate::gc_hook::try_gc_write_barrier(obj as *mut u8);
 }
 
 /// Get the bases tuple.


### PR DESCRIPTION
## Summary

- implement `_weakref._remove_dead_weakref` and public weakref type metadata
- preserve recursive comparison safety and metaclass repr/delattr semantics needed by `copy` and `enum`
- preserve builtin-subclass attribute identity and stable type `__name__`/`__qualname__` objects
- make `LOAD_LOCALS` retain custom metaclass `__prepare__` mappings, matching PyPy
- add focused copy and enum stdlib regression snippets

## Validation

- `PYRE_JIT=0 target/debug/pyre-dynasm -m test test_enum` — 1,081 tests successful
- `test_copy.py` — 81 passed
- weakref mapping/module groups — 29 passed
- stdlib copy/enum/weakref snippets passed
- `cargo check --features dynasm`
- `cargo test --features dynasm`
- `python pyre/check.py`: cranelift 248/248, wasm 247/247; dynasm 247/248 with the existing `nested_loop` performance gate exceeding 2x PyPy (all correctness runs passed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility for class attributes, including `__doc__`, `__name__`, and `__qualname__`.
  * Corrected descriptor precedence and custom namespace handling during class creation.
  * Improved metaclass-controlled `repr()` and `str()` behavior.
  * Fixed weak-reference type names and cleanup behavior.
  * Corrected integer and float handling for subclasses.
  * Added safer recursion handling for comparisons involving recursive objects.

* **Tests**
  * Added coverage for standard-library `copy`, `enum`, and `weakref` behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->