### PR TITLE
jit: bridge a depth-2 inlined-callee raise to the root except handler

### DIFF
--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -6480,8 +6480,14 @@ mod tests {
         let descr_arc = std::sync::Arc::clone(&failure.descr_arc);
         drop(failure);
 
-        let started =
-            driver.start_bridge_tracing(&descr_arc, &mut NonTraceableState, &(), &fail_values, 0);
+        let started = driver.start_bridge_tracing(
+            &descr_arc,
+            &mut NonTraceableState,
+            &(),
+            &fail_values,
+            0,
+            0,
+        );
         assert!(!started);
         assert!(!driver.meta.is_tracing());
     }

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -3534,8 +3534,14 @@ impl<S: JitState> JitDriver<S> {
                         // already recovered `state` to the resume point, so the
                         // bridge sees the post-guard-failure values.
                         if should_bridge && !portal_crn_handled && pc != usize::MAX {
-                            let bridge_ok =
-                                self.start_bridge_tracing(&descr_arc, state, env, &raw_values, pc);
+                            let bridge_ok = self.start_bridge_tracing(
+                                &descr_arc,
+                                state,
+                                env,
+                                &raw_values,
+                                pc,
+                                guard_exc,
+                            );
                             if crate::majit_log_enabled() {
                                 eprintln!(
                                     "[bridge] start_bridge_tracing (green resume) key={} trace={} fail={} resume_pc={} ok={}",
@@ -4906,6 +4912,11 @@ impl<S: JitState> JitDriver<S> {
         env: &S::Env,
         raw_fail_values: &[i64],
         resume_pc: usize,
+        // llmodel.py:240 `cpu.grab_exc_value(deadframe)`: the pending exception
+        // grabbed at the guard failure, threaded so `setup_bridge_sym` seeds the
+        // bridge sym's standing exception (pyjitpl.py:3125). 0 when the guard
+        // carried no exception.
+        guard_exc: i64,
     ) -> bool {
         majit_metainterp::mc_diag_bump(12); // start_bridge_tracing entered
         self.bridge_body_start_op_count = None;
@@ -5074,6 +5085,11 @@ impl<S: JitState> JitDriver<S> {
         // `has_compiled_targets_fn` presence.
         ctx.is_bridge_trace = true;
         ctx.set_bridge_source_is_exception_guard(retrace.is_exception_guard);
+        // pyjitpl.py:3125 `_prepare_exception_resumption` grabs the exception
+        // BEFORE frame reconstruction; thread it onto the ctx so the pyre
+        // `setup_bridge_sym` override can seed the standing exception before it
+        // drains the inline-callee carrier.
+        ctx.set_bridge_guard_exc(guard_exc);
         ctx.bridge_target_header_pc = parent_header_pc;
         ctx.has_compiled_targets_fn = Some(Box::new(move |gk: u64| -> bool {
             let meta = unsafe { &*(meta_ptr as *const crate::pyjitpl::MetaInterp<S::Meta>) };
@@ -5481,8 +5497,14 @@ impl<S: JitState> JitDriver<S> {
                 let resume_pc = resume_pc.unwrap_or(guard_resume_pc);
                 self.sync_after(state, &result_meta, descriptor.as_ref());
 
-                let bridge_ok =
-                    self.start_bridge_tracing(&descr_arc, state, env, &raw_values, resume_pc);
+                let bridge_ok = self.start_bridge_tracing(
+                    &descr_arc,
+                    state,
+                    env,
+                    &raw_values,
+                    resume_pc,
+                    result_exc,
+                );
                 if crate::majit_log_enabled() {
                     eprintln!(
                         "[bridge] start_bridge_tracing key={} trace={} fail={} resume_pc={} ok={}",

--- a/majit/majit-metainterp/src/trace_ctx.rs
+++ b/majit/majit-metainterp/src/trace_ctx.rs
@@ -523,6 +523,13 @@ pub struct TraceCtx {
     /// `descr_arc.is_guard_exc()` and read by static bridge setup/walkers
     /// that only receive `TraceCtx`.
     pub(crate) bridge_source_is_exception_guard: bool,
+    /// llmodel.py:240 `cpu.grab_exc_value(deadframe)`: the pending exception
+    /// value grabbed at the guard failure that triggered this bridge, threaded
+    /// from `start_bridge_tracing` so `setup_bridge_sym` can seed the bridge
+    /// sym's standing exception (pyjitpl.py:3125 `_prepare_exception_resumption`
+    /// grabs BEFORE frame reconstruction). Raw `PyObjectRef as i64`; 0 when the
+    /// guard carried no exception. Class is re-derived from the value's typeptr.
+    pub(crate) bridge_guard_exc: i64,
 }
 
 /// A decoded-but-not-yet-built description of one inlined
@@ -1223,6 +1230,7 @@ impl TraceCtx {
             bridge_inline_carrier: None,
             bridge_reg_indices: None,
             bridge_source_is_exception_guard: false,
+            bridge_guard_exc: 0,
         }
     }
 
@@ -1299,6 +1307,7 @@ impl TraceCtx {
             bridge_inline_carrier: None,
             bridge_reg_indices: None,
             bridge_source_is_exception_guard: false,
+            bridge_guard_exc: 0,
         }
     }
 
@@ -1337,6 +1346,16 @@ impl TraceCtx {
     }
 
     /// True only for bridge traces sourced from an exception guard descr.
+    pub fn set_bridge_guard_exc(&mut self, guard_exc: i64) {
+        self.bridge_guard_exc = guard_exc;
+    }
+
+    /// The exception value grabbed at the guard failure that triggered this
+    /// bridge (0 when none). See `bridge_guard_exc`.
+    pub fn bridge_guard_exc(&self) -> i64 {
+        self.bridge_guard_exc
+    }
+
     pub fn bridge_source_is_exception_guard(&self) -> bool {
         self.bridge_source_is_exception_guard
     }

--- a/pyre/pyre-interpreter/src/executioncontext.rs
+++ b/pyre/pyre-interpreter/src/executioncontext.rs
@@ -721,7 +721,6 @@ impl ExecutionContext {
     }
 
     pub fn sys_exc_info(&self, _for_hidden: bool) -> PyObjectRef {
-        let _ = self.gettopframe();
         let _ = _for_hidden;
         if !self.sys_exc_value.is_null() {
             return self.sys_exc_value;

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/bridge_subwalk.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/bridge_subwalk.rs
@@ -326,6 +326,10 @@ pub fn dispatch_via_miframe<Sym: WalkSym>(
         // last_exc_value` is already the standing exception box, so the handler's
         // `last_exc_value/>r` reads it.  On the normal path, seed the mirror at
         // the first-walked pc as before.
+        // Carrier-boundary raise seed (`finishframe_exception`): a depth-2
+        // inlined callee's sub-walk raised and the root frame's handler covers
+        // the CALL (set by `drive_bridge_carrier_walk`).  Consumed once here.
+        let carrier_raise_seed = crate::jitcode_dispatch::take_carrier_raise_seed();
         let walk_position = if let Some(catch_target) = exc_edge_catch_target {
             // RPython `pyjitpl.py:3125-3173` exception-guard resumption, emitted
             // at the bridge-entry frame state so the GUARD_EXCEPTION captures a
@@ -373,6 +377,20 @@ pub fn dispatch_via_miframe<Sym: WalkSym>(
             // already-caught exception (mirrors `blackhole.rs route_to_catch`).
             majit_metainterp::blackhole::BH_LAST_EXC_VALUE.with(|c| c.set(0));
             catch_target
+        } else if let Some(seed) = carrier_raise_seed {
+            // Carrier-boundary raise: the inlined callee's sub-walk already
+            // RECORDED the exception (a NewWithVtable of a known const class from
+            // its inline RAISE), so `seed.exc` is a live trace box carrying its
+            // own class — no SAVE/RESTORE/GUARD_EXCEPTION is needed (that path
+            // exists for a runtime exception restored from the pending cell).
+            // Mirror the walk-level SubRaise routing (mod.rs `finishframe_
+            // exception`): seed `last_exc_value` + the handler-entry operand
+            // stack (exc on TOS), then enter at the handler.
+            wc.last_exc_value = Some(seed.exc);
+            wc.last_exc_value_concrete = seed.exc_concrete;
+            majit_metainterp::blackhole::BH_LAST_EXC_VALUE.with(|c| c.set(0));
+            vstack_enter_exception_handler(&mut wc, seed.catch_target, seed.exc);
+            seed.catch_target
         } else {
             seed_vstack_mirror(&mut wc, sym, position);
             position

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/fbw_state.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/fbw_state.rs
@@ -112,6 +112,27 @@ pub(crate) fn fbw_inline_multiframe_enabled() -> bool {
     })
 }
 
+/// `PYRE_FBW_TRYBLOCK_INLINE`: multi-frame-inline a branch-bearing callee
+/// CALLed inside a try-block when its `except` handler REJOINS the CALL's own
+/// loop (`exc_handler_rejoins_specific_loop`).  The paused caller frame resumes
+/// at the CALL fallthrough on the no-raise path, and on a raise the caller's
+/// `lastblock` (a static box in its virtualizable image) unwinds to the handler
+/// in the blackhole — bit-exact.  A handler that BREAKS / RETURNS out of that
+/// loop is not routed (a hot raise there cannot be bridged and would
+/// deopt-storm), so it keeps declining to the residual path.  Default-on;
+/// `PYRE_FBW_TRYBLOCK_INLINE=0` (or `false`) restores the blanket try-block
+/// decline as the rollback escape hatch.
+pub(crate) fn fbw_tryblock_inline_enabled() -> bool {
+    static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ENABLED.get_or_init(|| match std::env::var_os("PYRE_FBW_TRYBLOCK_INLINE") {
+        Some(v) => {
+            let v = v.to_string_lossy();
+            v != "0" && !v.eq_ignore_ascii_case("false")
+        }
+        None => true,
+    })
+}
+
 /// `PYRE_FBW_NSVABLE_MULTIFRAME` (#73): publish the `_nonstandard_virtualizable`
 /// promote guard through the full multi-frame resume chain (each paused caller
 /// plus the callee's own coordinate) instead of the single-frame sentinel
@@ -1378,7 +1399,7 @@ pub(crate) fn fbw_abort_nested_unjournaled_residual<Sym: WalkSym>(
         FBW_ABORT_OUTER_STACK_OVERRIDES.with(|c| {
             *c.borrow_mut() = stack_overrides;
         });
-        return Err(DispatchError::LoopBearingCalleeInlineUnsupported { pc });
+        return Err(DispatchError::callee_inline_unsupported(pc));
     }
     Ok(())
 }

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/fbw_state.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/fbw_state.rs
@@ -133,6 +133,30 @@ pub(crate) fn fbw_tryblock_inline_enabled() -> bool {
     })
 }
 
+/// `PYRE_FBW_CARRIER_RAISE`: deliver a depth-2 inlined-callee raise to the ROOT
+/// frame's `except` handler at the bridge-carrier boundary
+/// (`finishframe_exception`), so the raise compiles a bridge into the enclosing
+/// loop instead of aborting the carrier and deopt-storming.  Without it, a
+/// carrier sub-walk that ends in `SubRaise` is dropped (the consumer only
+/// continues a value-`SubReturn`), and every raise iteration re-interprets.
+///
+/// This also gates the try-block inline gate WIDENING: when on, a handler that
+/// breaks/returns to an ENCLOSING loop is inline-eligible (its hot raise bridges
+/// via this delivery); when off, only a handler rejoining the CALL's own loop
+/// inlines (`exc_handler_rejoins_specific_loop`), so the widened shape declines
+/// to the residual path instead of deopt-storming.  Default-on;
+/// `PYRE_FBW_CARRIER_RAISE=0` (or `false`) is the rollback escape hatch.
+pub(crate) fn fbw_carrier_raise_enabled() -> bool {
+    static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ENABLED.get_or_init(|| match std::env::var_os("PYRE_FBW_CARRIER_RAISE") {
+        Some(v) => {
+            let v = v.to_string_lossy();
+            v != "0" && !v.eq_ignore_ascii_case("false")
+        }
+        None => true,
+    })
+}
+
 /// `PYRE_FBW_NSVABLE_MULTIFRAME` (#73): publish the `_nonstandard_virtualizable`
 /// promote guard through the full multi-frame resume chain (each paused caller
 /// plus the callee's own coordinate) instead of the single-frame sentinel

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
@@ -502,7 +502,7 @@ pub(crate) fn collect_callee_active_boxes(
     // frame's box section from, and the decoder would resume on one anyway;
     // decline the inline rather than encode against an empty window.
     if carried_jitcode_pc == majit_ir::resumedata::NO_JITCODE_PC {
-        return Err(DispatchError::LoopBearingCalleeInlineUnsupported { pc: callee_op_pc });
+        return Err(DispatchError::callee_inline_unsupported(callee_op_pc));
     }
     // The resume decoder consumes this frame's section per the liveness at the
     // carried `jitcode_pc` (`setposition` → `get_current_position_info`), not
@@ -536,7 +536,7 @@ pub(crate) fn collect_callee_active_boxes(
                         banks.float,
                     );
                 }
-                Err(DispatchError::LoopBearingCalleeInlineUnsupported { pc: callee_op_pc })
+                Err(DispatchError::callee_inline_unsupported(callee_op_pc))
             }
         }
     };
@@ -1641,7 +1641,7 @@ pub(crate) fn try_walker_inline_resolved_user_call<Sym: WalkSym>(
         if fbw_rec_mutual_cutover_enabled() {
             return Ok(None);
         }
-        return Err(DispatchError::LoopBearingCalleeInlineUnsupported { pc: op.pc });
+        return Err(DispatchError::callee_inline_unsupported(op.pc));
     }
 
     // Path-1 (#68): the inlined callee's compile-time-constant frame fields,
@@ -1830,14 +1830,14 @@ pub(crate) fn try_walker_inline_resolved_user_call<Sym: WalkSym>(
             };
             if raw.is_null() {
                 if try_multiframe {
-                    return Err(DispatchError::LoopBearingCalleeInlineUnsupported { pc: op.pc });
+                    return Err(DispatchError::callee_inline_unsupported(op.pc));
                 }
                 break 'seed;
             }
             let callee_code = unsafe { &*raw };
             if pyre_interpreter::ncells(callee_code) != 0 {
                 if try_multiframe {
-                    return Err(DispatchError::LoopBearingCalleeInlineUnsupported { pc: op.pc });
+                    return Err(DispatchError::callee_inline_unsupported(op.pc));
                 }
                 break 'seed;
             }
@@ -1865,7 +1865,7 @@ pub(crate) fn try_walker_inline_resolved_user_call<Sym: WalkSym>(
                 )
             }) {
                 if try_multiframe {
-                    return Err(DispatchError::LoopBearingCalleeInlineUnsupported { pc: op.pc });
+                    return Err(DispatchError::callee_inline_unsupported(op.pc));
                 }
                 break 'seed;
             }
@@ -1876,7 +1876,7 @@ pub(crate) fn try_walker_inline_resolved_user_call<Sym: WalkSym>(
                 crate::state::ensure_jitcode_index(callee_code_key as *const ())
             else {
                 if try_multiframe {
-                    return Err(DispatchError::LoopBearingCalleeInlineUnsupported { pc: op.pc });
+                    return Err(DispatchError::callee_inline_unsupported(op.pc));
                 }
                 break 'seed;
             };
@@ -1887,7 +1887,7 @@ pub(crate) fn try_walker_inline_resolved_user_call<Sym: WalkSym>(
                 || ec_reg as usize >= callee_regs_r.len()
             {
                 if try_multiframe {
-                    return Err(DispatchError::LoopBearingCalleeInlineUnsupported { pc: op.pc });
+                    return Err(DispatchError::callee_inline_unsupported(op.pc));
                 }
                 break 'seed;
             }
@@ -1902,7 +1902,7 @@ pub(crate) fn try_walker_inline_resolved_user_call<Sym: WalkSym>(
             let sym_ptr = ctx.fbw_mode.snapshot_sym;
             if sym_ptr.is_null() {
                 if try_multiframe {
-                    return Err(DispatchError::LoopBearingCalleeInlineUnsupported { pc: op.pc });
+                    return Err(DispatchError::callee_inline_unsupported(op.pc));
                 }
                 break 'seed;
             }
@@ -2031,10 +2031,10 @@ pub(crate) fn try_walker_inline_resolved_user_call<Sym: WalkSym>(
                         fbw_set_abort_call_resume(outer_jitcode_index, call_jitcode_pc, stack);
                     }
                 }
-                return Err(DispatchError::LoopBearingCalleeInlineUnsupported { pc: op.pc });
+                return Err(DispatchError::callee_inline_unsupported(op.pc));
             }
             Err(InlineCallerFrameDecline::Unavailable) => {
-                return Err(DispatchError::LoopBearingCalleeInlineUnsupported { pc: op.pc });
+                return Err(DispatchError::callee_inline_unsupported(op.pc));
             }
         }
     } else if callee_frame_seeded {
@@ -2517,7 +2517,7 @@ pub(crate) fn try_walker_inline_resolved_user_call<Sym: WalkSym>(
                         }
                     }
                 }
-                return Err(DispatchError::LoopBearingCalleeInlineUnsupported { pc: op.pc });
+                return Err(DispatchError::callee_inline_unsupported(op.pc));
             }
             match dst_bank {
                 'r' => write_ref_reg(ctx, op.pc, dst, value, concrete_for_shadow)?,
@@ -2558,7 +2558,7 @@ pub(crate) fn try_walker_inline_resolved_user_call<Sym: WalkSym>(
             if fbw_store_journal_len() > prologue_journal_before
                 || (!unjournaled_before_subwalk && fbw_has_unjournaled_effect())
             {
-                return Err(DispatchError::LoopBearingCalleeInlineUnsupported { pc: op.pc });
+                return Err(DispatchError::callee_inline_unsupported(op.pc));
             }
             emit_walker_loop_callee_call_assembler(
                 ctx,
@@ -2860,7 +2860,7 @@ pub(crate) fn try_walker_inline_user_binop<Sym: WalkSym>(
             ConcreteValue::Ref(obj)
                 if std::ptr::eq(obj, pyre_object::special::w_not_implemented())
         ) {
-            return Err(DispatchError::LoopBearingCalleeInlineUnsupported { pc: op.pc });
+            return Err(DispatchError::callee_inline_unsupported(op.pc));
         }
         if !result.is_constant() {
             let not_implemented = ctx
@@ -3004,7 +3004,7 @@ pub(crate) fn try_walker_inline_user_compareop<Sym: WalkSym>(
             ConcreteValue::Ref(obj)
                 if std::ptr::eq(obj, pyre_object::special::w_not_implemented())
         ) {
-            return Err(DispatchError::LoopBearingCalleeInlineUnsupported { pc: op.pc });
+            return Err(DispatchError::callee_inline_unsupported(op.pc));
         }
         if !result.is_constant() {
             let not_implemented = ctx

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
@@ -2221,6 +2221,16 @@ pub fn exc_edge_bridge_enabled() -> bool {
     *ENABLED.get_or_init(|| std::env::var_os("PYRE_EXC_EDGE_BRIDGE").is_some())
 }
 
+/// `PYRE_CARRIER_EXC_RESUME=1` enables the multi-frame (carrier) exception
+/// resume: seed the grabbed guard exception onto the bridge sym and route the
+/// inlined callee's carrier sub-walk into its own `catch_exception` handler
+/// (`finishframe_exception` parity, pyjitpl.py:2530).  Default-off while the
+/// #343/#126 depth-2 exception-resume slice is validated bit-exact.
+pub fn carrier_exc_resume_enabled() -> bool {
+    static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ENABLED.get_or_init(|| std::env::var_os("PYRE_CARRIER_EXC_RESUME").is_some())
+}
+
 /// Mirror of `blackhole.rs BlackholeInterpreter::find_catch_before_resume_live`
 /// for the walker.  An after-residual-call exception guard resumes at the
 /// no-exception fallthrough `-live-` (the next opcode after the call); the

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
@@ -1819,6 +1819,34 @@ pub(crate) fn census_dump() {
     });
 }
 
+/// Carrier-boundary raise seed (`finishframe_exception` at the bridge carrier):
+/// set by [`crate::trace::drive_bridge_carrier_walk`] when a depth-2 inlined
+/// callee's sub-walk ended in `SubRaise` and the ROOT frame's `except` handler
+/// covers the CALL.  [`crate::jitcode_dispatch::dispatch_via_miframe`] reads it
+/// once when it sets up the root walk and enters at `catch_target` with the
+/// caught exception seeded — the same handler-entry reconstruction the
+/// walk-level SubRaise routing performs, but at the carrier boundary the
+/// sub-walk crossed on its own.
+#[derive(Clone, Copy)]
+pub(crate) struct CarrierRaiseSeed {
+    pub exc: OpRef,
+    pub exc_concrete: crate::state::ConcreteValue,
+    pub catch_target: usize,
+}
+
+thread_local! {
+    static FBW_CARRIER_RAISE_SEED: std::cell::Cell<Option<CarrierRaiseSeed>> =
+        const { std::cell::Cell::new(None) };
+}
+
+pub(crate) fn set_carrier_raise_seed(seed: CarrierRaiseSeed) {
+    FBW_CARRIER_RAISE_SEED.with(|c| c.set(Some(seed)));
+}
+
+pub(crate) fn take_carrier_raise_seed() -> Option<CarrierRaiseSeed> {
+    FBW_CARRIER_RAISE_SEED.with(|c| c.take())
+}
+
 /// Walk one opcode at `pc` and return the dispatch outcome plus the
 /// next pc. Side effects reach `ctx.trace_ctx` only for opnames whose
 /// handler explicitly records (e.g. `ref_return/r` calls

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
@@ -1731,6 +1731,21 @@ impl DispatchError {
             Self::ExcEdgeCrossFrameReturnUnsupported { .. } => "ExcEdgeCrossFrameReturnUnsupported",
         }
     }
+
+    /// Construct the callee-inline decline.  The
+    /// `LoopBearingCalleeInlineUnsupported` variant is emitted from ~20 sites
+    /// (multi-frame seed preconditions, snapshot capture, hazard scan), so
+    /// route them through one constructor that records the source location
+    /// under `PYRE_LB_SITE` to tell the decline reasons apart in a census.
+    #[track_caller]
+    #[inline]
+    pub(crate) fn callee_inline_unsupported(pc: usize) -> Self {
+        if std::env::var_os("PYRE_LB_SITE").is_some() {
+            let loc = std::panic::Location::caller();
+            eprintln!("[lb-site] {}:{} pc={pc}", loc.file(), loc.line());
+        }
+        Self::LoopBearingCalleeInlineUnsupported { pc }
+    }
 }
 
 /// Per-process census of full-body-walk decline classes, keyed by
@@ -2161,7 +2176,7 @@ fn finishframe_lookahead_at(code: &[u8], position: usize) -> FinishframeLookahea
 /// (both cases continue unwinding from the caller's POV — the
 /// instrumentation side effect is dropped today, matching RPython's
 /// non-trace-recorded `cintf` call).
-fn try_catch_exception_at(code: &[u8], position: usize) -> Option<usize> {
+pub(crate) fn try_catch_exception_at(code: &[u8], position: usize) -> Option<usize> {
     match finishframe_lookahead_at(code, position) {
         FinishframeLookahead::CatchTarget(target) => Some(target),
         FinishframeLookahead::RvmprofCode { .. } | FinishframeLookahead::NoMatch => None,
@@ -2286,6 +2301,75 @@ pub(crate) fn exc_handler_rejoins_loop(code: &[u8], catch_target: usize) -> bool
                 // Multi-target dispatch not followed; leave this path un-proven
                 // (routing declines unless another path rejoins the loop).
             }
+            _ => work.push(op.next_pc),
+        }
+    }
+    false
+}
+
+/// The CALL's own loop header: the `jit_merge_point` op with the greatest pc at
+/// or before `call_jit_pc`.  Loop headers precede their body in the jitcode
+/// (outermost first), so among the merge points before the CALL the last one is
+/// the INNERMOST enclosing loop.  `None` when the CALL sits under no loop.
+pub(crate) fn enclosing_loop_header_jit_pc(code: &[u8], call_jit_pc: usize) -> Option<usize> {
+    crate::jitcode_runtime::decoded_ops(code)
+        .filter(|op| op.pc <= call_jit_pc && op.key.starts_with("jit_merge_point"))
+        .map(|op| op.pc)
+        .max()
+}
+
+/// Whether the `except` handler at `catch_target` rejoins the SPECIFIC loop
+/// whose header is `loop_header_pc` (the CALL's own loop), as opposed to
+/// breaking / returning out to an ENCLOSING loop or out of the frame.
+///
+/// [`exc_handler_rejoins_loop`] answers "reaches ANY `jit_merge_point`", which
+/// is too weak at the inline gate: a `break` out of the CALL's loop still
+/// reaches the ENCLOSING loop's merge point and would read as a rejoin.  Here a
+/// path is a rejoin ONLY if it reaches `loop_header_pc` itself; reaching a
+/// DIFFERENT merge point (broke out to an outer loop) or a `*_return` (out of
+/// frame) is a non-rejoin terminal.  Only the exact-loop rejoin is the
+/// exc-edge-bridgeable shape whose hot raise avoids a deopt-storm.
+pub(crate) fn exc_handler_rejoins_specific_loop(
+    code: &[u8],
+    catch_target: usize,
+    loop_header_pc: usize,
+) -> bool {
+    let mut visited = std::collections::HashSet::new();
+    let mut work = vec![catch_target];
+    let mut budget = 4096usize;
+    while let Some(pc) = work.pop() {
+        if budget == 0 {
+            return false;
+        }
+        budget -= 1;
+        if !visited.insert(pc) {
+            continue;
+        }
+        if pc == loop_header_pc {
+            // Rejoined the CALL's own loop header.
+            return true;
+        }
+        let Some(op) = decode_op_at(code, pc) else {
+            continue;
+        };
+        if op.key.starts_with("jit_merge_point") {
+            // A DIFFERENT loop's header: the handler broke out of the CALL's
+            // loop into an enclosing one.  Non-rejoin terminal.
+            continue;
+        }
+        if matches!(
+            op.key,
+            "ref_return/r" | "int_return/i" | "float_return/f" | "void_return/"
+        ) {
+            continue;
+        }
+        match op.key {
+            "goto/L" => work.push(read_label(code, &op, 0)),
+            "goto_if_not/iL" => {
+                work.push(read_label(code, &op, 1));
+                work.push(op.next_pc);
+            }
+            key if key.starts_with("switch") => {}
             _ => work.push(op.next_pc),
         }
     }

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
@@ -568,6 +568,20 @@ fn record_inline_application_traceback<Sym: WalkSym>(
     let Some(consts) = ctx.inline_callee_consts else {
         return;
     };
+    // A non-standard virtualizable frame in a bridge sub-walk carries the
+    // `GcRef(usize::MAX)` sentinel (or null) as `w_code` instead of a real
+    // `PyCode` — a synthetic frame with no Python code to anchor a node on.
+    // The host adapter (`record_inline_traceback_for_recording`) dereferences
+    // `w_code` through `createframe_obj`, so a sentinel / garbage pointer would
+    // SIGSEGV.  Skip null / sentinel / non-code; the null + sentinel checks run
+    // before `is_code`, whose `py_type_check` would deref the raw sentinel
+    // (`CAN_BE_TAGGED` is off).
+    if consts.w_code == 0 || consts.w_code == usize::MAX {
+        return;
+    }
+    if !unsafe { pyre_interpreter::pycode::is_code(consts.w_code as pyre_object::PyObjectRef) } {
+        return;
+    }
     let ConcreteValue::Ref(exc_ptr) = exc_concrete else {
         return;
     };

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/resume_snapshot.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/resume_snapshot.rs
@@ -1078,18 +1078,33 @@ pub(crate) fn decline_inline_caller_frame_for_catch_marker(
         // for the enclosing try sits right after it (`finishframe_exception`
         // lookahead), so read the handler target forward from there, then test
         // it rejoins the CALL's own loop header specifically.
-        let rejoins = crate::jitcode_dispatch::enclosing_loop_header_jit_pc(
-            caller_jitcode,
-            call_jit_pc,
-        )
-        .zip(crate::jitcode_dispatch::try_catch_exception_at(caller_jitcode, resume_pos))
-        .is_some_and(|(loop_header, catch_target)| {
-            crate::jitcode_dispatch::exc_handler_rejoins_specific_loop(
-                caller_jitcode,
-                catch_target,
-                loop_header,
-            )
-        });
+        let rejoins =
+            crate::jitcode_dispatch::enclosing_loop_header_jit_pc(caller_jitcode, call_jit_pc)
+                .zip(crate::jitcode_dispatch::try_catch_exception_at(
+                    caller_jitcode,
+                    resume_pos,
+                ))
+                .is_some_and(|(loop_header, catch_target)| {
+                    if fbw_carrier_raise_enabled() {
+                        // The carrier-boundary raise delivery bridges an inlined callee's
+                        // hot raise into whatever loop the handler rejoins, so a handler
+                        // that BREAKS/RETURNS to an ENCLOSING loop no longer deopt-storms
+                        // — widen the gate to ANY-loop rejoin.
+                        crate::jitcode_dispatch::exc_handler_rejoins_loop(
+                            caller_jitcode,
+                            catch_target,
+                        )
+                    } else {
+                        // Without the delivery, only a handler rejoining the CALL's OWN
+                        // loop is exc-edge-bridgeable; a break/return-to-outer handler's
+                        // hot raise would deopt-storm, so keep it on the residual path.
+                        crate::jitcode_dispatch::exc_handler_rejoins_specific_loop(
+                            caller_jitcode,
+                            catch_target,
+                            loop_header,
+                        )
+                    }
+                });
         if rejoins {
             return Ok(());
         }

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/resume_snapshot.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/resume_snapshot.rs
@@ -1038,9 +1038,11 @@ pub(crate) fn walker_capture_snapshot_for_last_guard_impl<Sym: WalkSym>(
 /// (`ctx.registers_*`) are still in scope.  `call_jit_pc` is the CALL op's
 /// jitcode pc in the caller.  Returns a named decline reason
 /// when the caller frame is not snapshot-able for this first slice: missing
-/// liveness / resume tables, a CALL inside a try-block whose catch-marker
-/// resume is not representable in this py_pc-only multi-frame capture, or no
-/// result on the operand stack at the return point.
+/// liveness / resume tables, a CALL inside a try-block whose `except` handler
+/// does NOT rejoin the CALL's own loop (a `break` / `return` out of it — its hot
+/// raise cannot be bridged, so it stays on the residual path, see
+/// [`decline_inline_caller_frame_for_catch_marker`]), or no result on the
+/// operand stack at the return point.
 ///
 /// The caller resumes at the CALL's return point (fallthrough) with the
 /// not-yet-produced call-result slot nulled — `get_list_of_active_boxes(
@@ -1055,12 +1057,44 @@ pub(crate) enum InlineCallerFrameDecline {
 
 pub(crate) fn decline_inline_caller_frame_for_catch_marker(
     after_residual_call_resume: Option<usize>,
+    caller_jitcode: &[u8],
+    call_jit_pc: usize,
 ) -> Result<(), InlineCallerFrameDecline> {
-    if after_residual_call_resume.is_some() {
-        Err(InlineCallerFrameDecline::TryBlockCatchMarker)
-    } else {
-        Ok(())
+    let Some(resume_pos) = after_residual_call_resume else {
+        // Not a try-block CALL — nothing to route on a raise.
+        return Ok(());
+    };
+    // The CALL is inside a try-block.  Inline it when its exception handler
+    // REJOINS the CALL's own loop (the exc-edge-bridgeable shape): the paused
+    // caller frame resumes at the CALL fallthrough on the no-raise path, and on
+    // a raise the caller's `lastblock` (a static box in its virtualizable image)
+    // unwinds to the catch handler in the blackhole — bit-exact, and a HOT raise
+    // can later be bridged.  A handler that BREAKS/RETURNS out of that loop
+    // cannot be bridged, so a hot raise would deopt-storm; keep declining to the
+    // residual path, whose after-residual catch marker handles the raise without
+    // a per-iteration deopt.
+    if fbw_tryblock_inline_enabled() {
+        // `resume_pos` is the CALL's post-call `live/`; the `catch_exception/L`
+        // for the enclosing try sits right after it (`finishframe_exception`
+        // lookahead), so read the handler target forward from there, then test
+        // it rejoins the CALL's own loop header specifically.
+        let rejoins = crate::jitcode_dispatch::enclosing_loop_header_jit_pc(
+            caller_jitcode,
+            call_jit_pc,
+        )
+        .zip(crate::jitcode_dispatch::try_catch_exception_at(caller_jitcode, resume_pos))
+        .is_some_and(|(loop_header, catch_target)| {
+            crate::jitcode_dispatch::exc_handler_rejoins_specific_loop(
+                caller_jitcode,
+                catch_target,
+                loop_header,
+            )
+        });
+        if rejoins {
+            return Ok(());
+        }
     }
+    Err(InlineCallerFrameDecline::TryBlockCatchMarker)
 }
 
 pub(crate) fn concrete_ref_for_color<Sym: WalkSym>(
@@ -1224,11 +1258,15 @@ pub(crate) fn compute_inline_caller_frame<Sym: WalkSym>(
             return Err(InlineCallerFrameDecline::Unavailable);
         }
         let call_py = python_pc_for_jitcode_pc(&jc.payload.metadata, call_jit_pc) as usize;
-        // A CALL inside a try-block resumes at its own catch marker, which this
-        // py_pc-only multi-frame capture cannot represent — decline this slice.
+        // A CALL inside a try-block: inline it only when its exception handler
+        // rejoins the loop (the exc-edge-bridgeable shape); otherwise decline so
+        // the residual path handles the raise via its after-residual catch
+        // marker without a per-iteration deopt.
         decline_inline_caller_frame_for_catch_marker(
             jc.payload
                 .after_residual_call_resume_for_jitcode_pc(call_jit_pc),
+            jc.payload.jitcode.code.as_slice(),
+            call_jit_pc,
         )?;
         let code = &*jc.payload.code_ptr;
         let fallthrough = crate::pyjitpl::semantic_fallthrough_pc(code, call_py) as u32;
@@ -1370,9 +1408,11 @@ pub(crate) fn compute_nested_inline_caller_frame<Sym: WalkSym>(
     }
     let resume_marker_jit_pc = pjc.after_residual_marker_for_jitcode_pc(call_jit_pc);
     let after_residual_call_resume = pjc.after_residual_call_resume_for_jitcode_pc(call_jit_pc);
-    // A CALL inside a try-block resumes at its own catch marker, which this
-    // py_pc-only multi-frame capture cannot represent.
-    decline_inline_caller_frame_for_catch_marker(after_residual_call_resume)?;
+    // A CALL inside a try-block at inline depth ≥2: the rejoin-loop lift is
+    // scoped to the top-level caller (`compute_inline_caller_frame`) for now, so
+    // pass an empty jitcode here — a nested try-block CALL keeps declining
+    // (its catch-marker resume is not yet routed through the deeper snapshot).
+    decline_inline_caller_frame_for_catch_marker(after_residual_call_resume, &[], call_jit_pc)?;
     let legacy_fallthrough_py_pc = || unsafe {
         let call_py = python_pc_for_jitcode_pc(&pjc.metadata, call_jit_pc) as usize;
         let code = &*pjc.code_ptr;
@@ -1589,17 +1629,17 @@ pub(crate) fn walker_capture_multi_frame_inline_snapshot<Sym: WalkSym>(
         .last()
         .map(|frame| frame.w_code);
     let Some(callee_w_code) = callee_w_code else {
-        return Err(DispatchError::LoopBearingCalleeInlineUnsupported { pc: callee_op_pc });
+        return Err(DispatchError::callee_inline_unsupported(callee_op_pc));
     };
     let Some(callee_jitcode_index) = crate::state::ensure_jitcode_index(callee_w_code as *const ())
     else {
-        return Err(DispatchError::LoopBearingCalleeInlineUnsupported { pc: callee_op_pc });
+        return Err(DispatchError::callee_inline_unsupported(callee_op_pc));
     };
     let Some(callee_pjc) = crate::state::pyjitcode_for_jitcode_index(callee_jitcode_index) else {
-        return Err(DispatchError::LoopBearingCalleeInlineUnsupported { pc: callee_op_pc });
+        return Err(DispatchError::callee_inline_unsupported(callee_op_pc));
     };
     if !callee_pjc.is_populated() || callee_pjc.code_ptr.is_null() {
-        return Err(DispatchError::LoopBearingCalleeInlineUnsupported { pc: callee_op_pc });
+        return Err(DispatchError::callee_inline_unsupported(callee_op_pc));
     }
     let mf_diag = std::env::var_os("PYRE_FBW_MF_DIAG").is_some();
     let recipe_resultcolor_audit = pcmap_recipe_resultcolor_audit_enabled();

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/tests.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/tests.rs
@@ -71,11 +71,17 @@ fn done_descr_ref_for_tests() -> DescrRef {
 
 #[test]
 fn inline_caller_frame_distinguishes_try_block_catch_marker_decline() {
+    // No after-residual catch resume → not a try-block CALL → accept.
     assert_eq!(
-        decline_inline_caller_frame_for_catch_marker(Some(42)),
+        decline_inline_caller_frame_for_catch_marker(None, &[], 0),
+        Ok(()),
+    );
+    // A try-block CALL with no resolvable loop header / catch (empty jitcode)
+    // cannot prove its handler rejoins the CALL's loop → decline.
+    assert_eq!(
+        decline_inline_caller_frame_for_catch_marker(Some(42), &[], 0),
         Err(InlineCallerFrameDecline::TryBlockCatchMarker),
     );
-    assert_eq!(decline_inline_caller_frame_for_catch_marker(None), Ok(()));
 }
 
 /// `ensure_residual_call_args_bound` backs the unbound-arg abort path

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -8584,6 +8584,24 @@ impl JitState for PyreJitState {
             return;
         }
 
+        // pyjitpl.py:3125-3165 `_prepare_exception_resumption` + `execute_ll_raised`:
+        // the exception grabbed at guard failure (`cpu.grab_exc_value`, threaded
+        // via `ctx.bridge_guard_exc`) becomes the bridge's standing exception.
+        // Seed `current_exc_value` here so `seed_bridge_standing_exception_from_current`
+        // below promotes it into `last_exc_value` / `last_exc_box` (the
+        // `dispatch_via_miframe` / carrier exc-edge precondition reads these).
+        // Without this seed the sym only sees `get_current_exception()`, which the
+        // blackhole has already cleared by carrier re-trace time.  Gated while the
+        // #343/#126 depth-2 exception-resume slice is validated.
+        if crate::jitcode_dispatch::carrier_exc_resume_enabled()
+            && ctx.bridge_source_is_exception_guard()
+        {
+            let guard_exc = ctx.bridge_guard_exc();
+            if guard_exc != 0 && sym.current_exc_value.is_null() {
+                sym.current_exc_value = guard_exc as pyre_object::PyObjectRef;
+            }
+        }
+
         // virtualizable.py:139 load_list_of_boxes parity: decode each
         // RebuiltValue in the resume stream into a typed Value. The type
         // is the fixed Box kind the encoder recorded at numbering time

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -1029,6 +1029,34 @@ fn inject_root_call_result<Sym: WalkSym>(
     true
 }
 
+/// The ROOT frame's `except` handler jitcode pc covering the CALL paused at
+/// `root_pc`, for the carrier-boundary `finishframe_exception` (a depth-2
+/// inlined callee raised).  `root_pc` is the CALL's post-call resume `-live-`,
+/// with the enclosing try's `catch_exception/L` sitting BEHIND it (the same
+/// shape the single-frame exception-edge router scans), so read backward.
+/// Accept the handler only when it rejoins a loop (`exc_handler_rejoins_loop`)
+/// so the bridge closes with a `Jump` into the enclosing loop instead of a
+/// cross-frame return the carrier cannot reconstruct.
+fn carrier_root_catch_target<Sym: WalkSym>(sym: &Sym, root_pc: usize) -> Option<usize> {
+    if sym.jitcode().is_null() {
+        return None;
+    }
+    let payload = unsafe { &(*sym.jitcode()).payload };
+    let code = payload.jitcode.code.as_slice();
+    // The paused caller's resume pc is the CALL's post-call `-live-`; the
+    // `catch_exception/L` for the enclosing try sits BEHIND it (between the
+    // CALL's post-call `-live-` and the next op), so scan backward — the same
+    // lookup the single-frame exception-edge router uses.
+    let candidate = crate::jitcode_dispatch::find_catch_before_resume_live(code, root_pc);
+    if std::env::var_os("PYRE_P2_DIAG").is_some() {
+        eprintln!(
+            "[p2-raise] root_pc={root_pc} catch_before={candidate:?} rejoins={:?}",
+            candidate.map(|t| crate::jitcode_dispatch::exc_handler_rejoins_loop(code, t)),
+        );
+    }
+    candidate.filter(|&t| crate::jitcode_dispatch::exc_handler_rejoins_loop(code, t))
+}
+
 fn drive_bridge_carrier_walk<Sym: WalkSym>(
     ctx: &mut TraceCtx,
     sym: &mut Sym,
@@ -1189,6 +1217,47 @@ fn drive_bridge_carrier_walk<Sym: WalkSym>(
                 );
             }
             crate::jitcode_dispatch::census_record("P2Drain::ResultSlotUnresolved");
+        }
+    }
+
+    // `finishframe_exception` at the carrier boundary: the inlined callee's
+    // sub-walk raised and had no local handler, so it surfaced `SubRaise`.  The
+    // ROOT frame paused at the CALL; if its `except` handler covers the CALL and
+    // rejoins a loop, deliver the exception to that handler and continue the
+    // root walk from it (the same handler-entry reconstruction the walk-level
+    // SubRaise routing performs, threaded across the carrier the sub-walk
+    // crossed on its own).  Without this the raise is dropped and re-interpreted
+    // every iteration (deopt-storm).
+    let subwalk_raise = match &walk {
+        Some(Ok((crate::jitcode_dispatch::DispatchOutcome::SubRaise { exc, exc_concrete }, _))) => {
+            Some((*exc, *exc_concrete))
+        }
+        _ => None,
+    };
+    if let Some((exc, exc_concrete)) = subwalk_raise {
+        if carrier.recipes.len() == 1 && crate::jitcode_dispatch::fbw_carrier_raise_enabled() {
+            if let Some(catch_target) = carrier_root_catch_target(sym, root_pc) {
+                crate::jitcode_dispatch::set_carrier_raise_seed(
+                    crate::jitcode_dispatch::CarrierRaiseSeed {
+                        exc,
+                        exc_concrete,
+                        catch_target,
+                    },
+                );
+                crate::jitcode_dispatch::census_record("P2Drain::CompileRootRaise");
+                let root_py_pc =
+                    crate::state::backxlat_py_pc(carrier.root_jitcode_index, root_pc as i32)
+                        as usize;
+                let action =
+                    full_body_walk_trace(ctx, sym, w_code, root_py_pc, cf_addr, WalkJournals::Keep);
+                // Defensive: `dispatch_via_miframe` consumes the seed, but a
+                // walk that early-declines before reaching it would leave the
+                // seed standing and leak it into a later unrelated walk. Clear
+                // any residual seed so exactly this walk can observe it.
+                let _ = crate::jitcode_dispatch::take_carrier_raise_seed();
+                return action;
+            }
+            crate::jitcode_dispatch::census_record("P2Drain::RaiseNoRootCatch");
         }
     }
 

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -2754,7 +2754,14 @@ pub fn trace_and_compile_from_bridge(
     // compile.py:714: start_retrace_from_guard + set bridge_info.
     let started = {
         let (driver, _) = crate::eval::driver_pair();
-        driver.start_bridge_tracing(descr_arc, &mut jit_state, &env, raw_values, resume_pc)
+        driver.start_bridge_tracing(
+            descr_arc,
+            &mut jit_state,
+            &env,
+            raw_values,
+            resume_pc,
+            guard_exc,
+        )
     };
     if !started {
         if majit_metainterp::majit_log_enabled() {


### PR DESCRIPTION
## What

Compile a **bridge** for a raise that fires inside an **inlined try-block callee**, instead of aborting the trace and deopt-storming.

When a try-block callee inlines (previous commit on this branch), its raise fails a guard *inside* the inlined body, so the guard-failure bridge is a **depth-2 multi-frame kept-stack bridge**. The carrier machinery (`drive_bridge_carrier_walk`) drove the callee sub-walk correctly and it ended in `SubRaise`, but the consumer only continued a value-`SubReturn` — the `SubRaise` was dropped, the trace aborted, and every raise iteration re-interpreted.

This delivers the sub-walk's raise to the **root frame's `except` handler** at the carrier boundary — the `finishframe_exception` the walk-level SubRaise routing already performs one frame down:

- `carrier_root_catch_target` reads the root handler covering the CALL (`find_catch_before_resume_live` from the CALL's post-call `-live-`), accepted only when it rejoins a loop, so the bridge closes with a `Jump` into the enclosing loop.
- On `SubRaise`, a `CarrierRaiseSeed { exc, exc_concrete, catch_target }` is stashed and the root walk re-entered; `dispatch_via_miframe` consumes the seed and enters at the handler with `last_exc_value` + the handler-entry operand stack seeded. The callee sub-walk already recorded the exception (a known const class from its inline RAISE), so no `SAVE`/`RESTORE`/`GUARD_EXCEPTION` is emitted.

Gated `PYRE_FBW_CARRIER_RAISE` (default-on, `=0` opt-out). The same flag widens the try-block inline gate: with the delivery, a handler that **breaks/returns to an enclosing loop** is inline-eligible; with it off, only a handler rejoining the CALL's own loop inlines (`exc_handler_rejoins_specific_loop`), so the widened shape declines to the residual path instead of deopt-storming.

## Why it was blocked before

`exceptions.py` (already a winner) has the *same* depth-2 abort (`bridges=0`, `guard_failures=7808`) — it won only because its raise is rare (1/32). `break_except_live_local`'s raise is ~1/4, so its deopt cost dominated. Neither witness bridged its raise; the routing predicate was never the wall — the dropped `SubRaise` was.

## Results (dynasm)

| bench | bridges | guard_failures | speedup |
|---|---|---|---|
| `exceptions` | 0 → 1 | 7808 → 202 | **3.5×** |
| `exception_args_virtual` | 0 → 1 | 7808 → 2104 | **2.2×** |
| `break_except_live_local` | 0 → 1 | 21715 → 202 | **1.82×** |

First time a depth-2 inlined-callee raise compiles a bridge.

## Verification

- Full synth corpus **237/237 bit-exact** default-on vs opt-out; only the 3 witnesses change jit-stats (all wins, no new deopt-storm/abort anywhere).
- `check.py` **3-backend green**: dynasm 248/248, cranelift 248/248, wasm 247/247.
- GC-stress (tiny nursery + poison) bit-exact on all witnesses.
- `cargo test -p pyre-jit-trace` clean apart from the pre-existing, unrelated `jd1_build_time_descrs_...` charon-less-env failure (untouched by this change).

## Branch contents

This branch (`nbody`) is 3 commits ahead of `main`, all part of the callee-inline / exception-edge line:
1. reconstruct Int/Float register banks concretely at bridge resume
2. multi-frame-inline try-block CALLs whose except handler rejoins the loop
3. deliver a depth-2 inlined-callee raise to the root except handler (this PR's headline)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
