### PR TITLE
stdlib: complete copy, enum, weakref, and opcode compatibility

### DIFF
--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -8247,7 +8247,13 @@ impl<M: Clone> MetaInterp<M> {
         live_values: &[Value],
     ) -> Option<RawCompileResult<'_, M>> {
         let compiled = self.compiled_loops.get(&green_key)?;
-        let token = compiled.live_token()?;
+        // warmstate.py:398 `loop_token = cell.get_procedure_token()`:
+        // execution must use the cell's current, invalidation-filtered token.
+        // `compiled_loops` is a metadata index and can still retain a weak
+        // predecessor while a recompile/redirect has installed a newer token
+        // on the JitCell.  Executing that predecessor re-enters invalidated
+        // machine code and repeatedly fails GUARD_NOT_INVALIDATED.
+        let token = self.warm_state.get_procedure_token(green_key)?;
 
         Self::prepare_compiled_run_io();
         let result = self.backend.execute_token_raw(&token, live_values);
@@ -8368,7 +8374,9 @@ impl<M: Clone> MetaInterp<M> {
         live_values: &[i64],
     ) -> Option<CompileResult<'_, M>> {
         let compiled = self.compiled_loops.get(&green_key)?;
-        let token = compiled.live_token()?;
+        // warmstate.py:398: the JitCell is the canonical current-token
+        // owner and filters invalidated predecessors.
+        let token = self.warm_state.get_procedure_token(green_key)?;
 
         Self::prepare_compiled_run_io();
         let frame = self.backend.execute_token_ints(&token, live_values);
@@ -8538,7 +8546,9 @@ impl<M: Clone> MetaInterp<M> {
         dispatch_key: u32,
     ) -> Option<CompileResult<'_, M>> {
         let compiled = self.compiled_loops.get(&green_key)?;
-        let token = compiled.live_token()?;
+        // warmstate.py:398: execute the token returned by the JitCell, not
+        // the compiled-metadata index's possibly retired predecessor.
+        let token = self.warm_state.get_procedure_token(green_key)?;
 
         Self::prepare_compiled_run_io();
         let frame = self
@@ -9517,6 +9527,23 @@ impl<M: Clone> MetaInterp<M> {
             .expect("must_compile_with_values: descr_arc must be a FailDescr");
         let trace_id = descr_fd.trace_id();
         let fail_index = descr_fd.fail_index_per_trace();
+        // quasiimmut.py:97-100 `QuasiImmut.invalidate()` marks the owning
+        // JitCellToken invalid before `cpu.invalidate_loop()` patches every
+        // GUARD_NOT_INVALIDATED.  The failed guard remains usable only as
+        // resume data; warmstate.py:191-196 no longer returns that token as a
+        // procedure token, and PyPy never traces a bridge onto it.  Preserve
+        // that object ownership here: a stale machine-code activation may
+        // still report the descr, but it must go straight to blackhole
+        // resume instead of ticking the bridge counter and repeatedly
+        // attaching bridges to the permanently invalidated loop.
+        let owning_jct = majit_backend::descr_owning_jct(descr_fd);
+        let owning_key = owning_jct
+            .as_ref()
+            .map(|jct| jct.green_key())
+            .unwrap_or(fallback_green_key);
+        if owning_jct.as_ref().is_some_and(|jct| jct.is_invalidated()) {
+            return (false, owning_key);
+        }
         // A guard whose bridge was refused by a terminal-declining backend
         // (`bridge_decline_is_terminal()`, currently wasm) or by a structural
         // full-body-walk decline must not re-fire: re-tracing rebuilds the same
@@ -9528,9 +9555,6 @@ impl<M: Clone> MetaInterp<M> {
             .contains(&(trace_id, fail_index))
         {
             crate::mc_diag_bump(1); // declined_bridge_guards short-circuit
-            let owning_key = majit_backend::descr_owning_jct(descr_fd)
-                .map(|jct| jct.green_key())
-                .unwrap_or(fallback_green_key);
             return (false, owning_key);
         }
         // compile.py:725 `_trace_and_compile_from_bridge` walks
@@ -9541,9 +9565,6 @@ impl<M: Clone> MetaInterp<M> {
         // outer entry key.  RPython doesn't have this fallback because
         // its identity is descr-pointer-based, never indirected through
         // a numeric `green_key`.
-        let owning_key = majit_backend::descr_owning_jct(descr_fd)
-            .map(|jct| jct.green_key())
-            .unwrap_or(fallback_green_key);
         if descr_addr == 0 {
             crate::mc_diag_bump(2); // descr_addr==0 skip
             crate::debug::log_one("jit-tracing", "must_compile: descr_addr=0, skip");

--- a/pyre/extra_tests/parity_tests/dict_str_subclass_keys.py
+++ b/pyre/extra_tests/parity_tests/dict_str_subclass_keys.py
@@ -48,4 +48,31 @@ stored = next(iter(holder.__dict__))
 assert stored is instance_key
 assert type(stored) is MyStr
 
+# The non-str MapDictStrategy leg devolves to ObjectDictStrategy and must keep
+# the checked insertion contract across that transition.  Protocol-0 pickle's
+# BUILD opcode exposes this by hashing a state key once in the state dict and
+# again while assigning it into the new instance's __dict__.
+class HashError(Exception):
+    pass
+
+
+class RaisingKey:
+    remaining = 1
+
+    def __hash__(self):
+        if not self.remaining:
+            raise HashError
+        self.remaining -= 1
+        return 42
+
+
+raising_key = RaisingKey()
+state = {raising_key: None}
+try:
+    Holder().__dict__[raising_key] = state[raising_key]
+except HashError:
+    pass
+else:
+    raise AssertionError("MapDictStrategy swallowed the key's __hash__ error")
+
 print("OK")

--- a/pyre/extra_tests/snippets/jit_inline_raise_frame_identity.py
+++ b/pyre/extra_tests/snippets/jit_inline_raise_frame_identity.py
@@ -1,0 +1,37 @@
+"""An inlined raising callee must retain its own concrete frame identity."""
+
+
+class StopDispatch(Exception):
+    pass
+
+
+class Dispatcher:
+    def __init__(self):
+        self.position = 0
+        self.stack = []
+
+    def push(self):
+        self.stack.append(42)
+
+    def stop(self):
+        raise StopDispatch(self.stack.pop())
+
+    dispatch = {0: push, 1: stop}
+
+    def load(self):
+        try:
+            while True:
+                if self.position >= 2:
+                    raise EOFError((self.position, self.stack))
+                key = self.position
+                self.position += 1
+                self.dispatch[key](self)
+        except StopDispatch as exc:
+            return exc.args[0]
+
+
+# This is the pure-Python pickle Unpickler dispatch shape: a hot caller loop
+# invokes unbound methods from a table, and the STOP handler mutates a stack
+# immediately before raising the exception caught by the caller.
+for iteration in range(10_000):
+    assert Dispatcher().load() == 42, iteration

--- a/pyre/extra_tests/snippets/stdlib_codecs_escape.py
+++ b/pyre/extra_tests/snippets/stdlib_codecs_escape.py
@@ -1,0 +1,37 @@
+"""PyPy _codecs.escape_decode parity used by protocol-0 pickle."""
+
+import _codecs
+import codecs
+
+
+cases = {
+    b"a\\n\\\\b\\x00c\\td": b"a\n\\b\x00c\td",
+    b"\\077": b"?",
+    b"\\100": b"@",
+    b"\\253": bytes([0o253]),
+    b"\\312": bytes([0o312]),
+    b"\\400": b"\0",
+    b"\\9": b"\\9",
+    b"\\01": b"\x01",
+    b"\\0f": b"\0f",
+    b"\\08": b"\08",
+}
+for encoded, expected in cases.items():
+    decoded, consumed = _codecs.escape_decode(encoded)
+    assert decoded == expected, (encoded, decoded, expected)
+    assert consumed == len(encoded)
+
+raw = b"a\n\\b\x00c\td\xe5"
+assert _codecs.escape_encode(raw) == (b"a\\n\\\\b\\x00c\\td\\xe5", len(raw))
+
+assert codecs.escape_decode(b"a\\x00\\n") == (b"a\x00\n", 7)
+assert _codecs.escape_decode(b"[\\x]\\x", "ignore") == (b"[]", 6)
+assert _codecs.escape_decode(b"[\\x]\\x", "replace") == (b"[?]?", 6)
+
+for malformed in (b"\\x", b"[\\x]", b"\\x0", b"[\\x0]", b"trailing\\"):
+    try:
+        _codecs.escape_decode(malformed)
+    except ValueError:
+        pass
+    else:
+        raise AssertionError(malformed)

--- a/pyre/extra_tests/snippets/stdlib_copy.py
+++ b/pyre/extra_tests/snippets/stdlib_copy.py
@@ -1,0 +1,43 @@
+import copy
+import gc
+import operator
+import weakref
+
+
+class Value:
+    pass
+
+
+a, b, c, d = [Value() for _ in range(4)]
+original = weakref.WeakValueDictionary({a: b, c: d})
+cloned = copy.copy(original)
+del c, d
+gc.collect()
+gc.collect()
+gc.collect()
+assert len(original) == 1
+assert len(cloned) == 1
+
+
+left = []
+left.append(left)
+right = copy.deepcopy(left)
+assert right is not left
+assert right[0] is right
+for comparison in (
+    operator.eq,
+    operator.ne,
+    operator.lt,
+    operator.le,
+    operator.gt,
+    operator.ge,
+):
+    try:
+        comparison(left, right)
+    except RecursionError:
+        pass
+    else:
+        raise AssertionError("recursive list comparison did not stop")
+
+
+print("stdlib copy ok")

--- a/pyre/extra_tests/snippets/stdlib_enum.py
+++ b/pyre/extra_tests/snippets/stdlib_enum.py
@@ -93,4 +93,19 @@ Custom.__name__ = custom_name
 assert Custom.__name__ is custom_name
 
 
+# `__slots__` accepts any iterable.  A `__doc__` slot suppresses the default
+# class-level None entry, while another slot iterable still gets that default.
+DocSlotSet = type("DocSlotSet", (), {"__slots__": {"__doc__"}})
+assert type(DocSlotSet.__dict__["__doc__"]).__name__ == "member_descriptor"
+
+doc_slots = iter(["__doc__"])
+DocSlotIterator = type("DocSlotIterator", (), {"__slots__": doc_slots})
+assert DocSlotIterator.__slots__ is doc_slots
+assert list(doc_slots) == []
+assert type(DocSlotIterator.__dict__["__doc__"]).__name__ == "member_descriptor"
+
+PlainSlotSet = type("PlainSlotSet", (), {"__slots__": {"value"}})
+assert PlainSlotSet.__dict__["__doc__"] is None
+
+
 print("stdlib enum ok")

--- a/pyre/extra_tests/snippets/stdlib_enum.py
+++ b/pyre/extra_tests/snippets/stdlib_enum.py
@@ -1,0 +1,96 @@
+from enum import Enum, IntEnum, IntFlag, auto
+
+
+class Color(Enum):
+    RED = 1
+    BLUE = 2
+
+
+class Number(IntEnum):
+    ONE = 1
+    TWO = 2
+
+
+class Permission(IntFlag):
+    READ = auto()
+    WRITE = auto()
+
+
+assert repr(Color) == "<enum 'Color'>"
+
+try:
+    delattr(Color, "RED")
+except AttributeError:
+    pass
+else:
+    raise AssertionError("Enum members must not be deletable")
+
+assert Color(1) is Color.RED
+assert list(Color) == [Color.RED, Color.BLUE]
+assert Number.ONE == 1
+assert Permission.READ | Permission.WRITE == 3
+assert ~Permission.READ is Permission.WRITE
+
+
+class BaseNumber(IntEnum):
+    @property
+    def one(self):
+        return self.name
+
+
+class DerivedNumber(BaseNumber):
+    one = auto()
+    two = auto()
+
+
+# EnumType installs a redirect descriptor and stores the member on it.  The
+# mapdict value must remain the IntEnum object, not be unboxed to a plain int.
+assert DerivedNumber.one is DerivedNumber._member_map_["one"]
+assert DerivedNumber.one.__class__ is DerivedNumber
+
+
+class FloatSubclass(float):
+    pass
+
+
+class Holder:
+    pass
+
+
+holder = Holder()
+holder.value = FloatSubclass(1.5)
+assert holder.value.__class__ is FloatSubclass
+holder_with_unboxed_slot = Holder()
+holder_with_unboxed_slot.value = 2.0
+holder_with_unboxed_slot.value = FloatSubclass(2.5)
+assert holder_with_unboxed_slot.value.__class__ is FloatSubclass
+
+
+class Meta(type):
+    def __repr__(cls):
+        return f"<custom {cls.__name__}>"
+
+
+class Custom(metaclass=Meta):
+    pass
+
+
+assert repr(Custom) == "<custom Custom>"
+
+# Type metadata is an object-valued getset, not a freshly boxed string on
+# every access.  `inspect.classify_class_attrs` relies on this identity when
+# locating `__name__` and `__qualname__` on the defining class.
+assert Custom.__name__ is Custom.__name__
+assert Custom.__qualname__ is Custom.__qualname__
+
+
+class Name(str):
+    pass
+
+
+custom_name = Name("Renamed")
+Custom.__name__ = custom_name
+assert Custom.__name__ is custom_name
+
+
+print("stdlib enum ok")

--- a/pyre/extra_tests/snippets/stdlib_inspect.py
+++ b/pyre/extra_tests/snippets/stdlib_inspect.py
@@ -1,0 +1,35 @@
+import _opcode
+import dis
+import inspect
+
+
+global_value = 42
+
+
+def closure_target():
+    return len([global_value])
+
+
+instructions = list(dis.get_instructions(closure_target))
+assert any(instruction.argval == "global_value" for instruction in instructions)
+variables = inspect.getclosurevars(closure_target)
+assert variables.globals == {"global_value": 42}
+assert variables.builtins["len"] is len
+
+for predicate in (
+    _opcode.has_arg,
+    _opcode.has_const,
+    _opcode.has_name,
+    _opcode.has_jump,
+    _opcode.has_free,
+    _opcode.has_local,
+    _opcode.has_exc,
+):
+    try:
+        predicate()
+    except TypeError:
+        pass
+    else:
+        raise AssertionError("opcode predicate accepted a missing opcode")
+
+print("stdlib inspect ok")

--- a/pyre/extra_tests/snippets/stdlib_inspect.py
+++ b/pyre/extra_tests/snippets/stdlib_inspect.py
@@ -1,6 +1,7 @@
 import _opcode
 import dis
 import inspect
+import opcode
 import typing
 
 
@@ -80,5 +81,15 @@ for predicate in (
         pass
     else:
         raise AssertionError("opcode predicate accepted a missing opcode")
+
+assert _opcode.stack_effect(dis.opmap["NOP"], None) == 0
+try:
+    _opcode.stack_effect(dis.opmap["NOP"], 0, True)
+except TypeError:
+    pass
+else:
+    raise AssertionError("_opcode.stack_effect accepted positional jump")
+assert opcode._intrinsic_1_descs[0] == "INTRINSIC_1_INVALID"
+assert opcode._intrinsic_2_descs[0] == "INTRINSIC_2_INVALID"
 
 print("stdlib inspect ok")

--- a/pyre/extra_tests/snippets/stdlib_inspect.py
+++ b/pyre/extra_tests/snippets/stdlib_inspect.py
@@ -1,6 +1,7 @@
 import _opcode
 import dis
 import inspect
+import typing
 
 
 global_value = 42
@@ -15,6 +16,54 @@ assert any(instruction.argval == "global_value" for instruction in instructions)
 variables = inspect.getclosurevars(closure_target)
 assert variables.globals == {"global_value": 42}
 assert variables.builtins["len"] is len
+
+parameter = inspect.Parameter("value", inspect.Parameter.POSITIONAL_ONLY)
+same_parameter = inspect.Parameter("value", inspect.Parameter.POSITIONAL_ONLY)
+assert parameter == same_parameter
+assert not parameter != same_parameter
+
+signature = inspect.Signature([parameter])
+bound = signature.bind(1)
+same_bound = signature.bind(1)
+assert bound == same_bound
+assert not bound != same_bound
+
+
+class EqualOnly:
+    def __eq__(self, other):
+        return isinstance(other, EqualOnly)
+
+
+assert EqualOnly() == EqualOnly()
+assert not EqualOnly() != EqualOnly()
+
+comparison_calls = []
+
+
+class ComparisonBase:
+    def __eq__(self, other):
+        comparison_calls.append("base")
+        return NotImplemented
+
+
+class ComparisonSubclass(ComparisonBase):
+    def __eq__(self, other):
+        comparison_calls.append("subclass")
+        return True
+
+
+assert ComparisonBase() == ComparisonSubclass()
+assert comparison_calls == ["subclass"]
+
+assert inspect.formatannotation(typing.List[str] | int) == "List[str] | int"
+assert typing.Union[int] is int
+assert repr(typing.Union[typing.List[str], int]) == "typing.List[str] | int"
+try:
+    object() | int
+except TypeError:
+    pass
+else:
+    raise AssertionError("an arbitrary object participated in union syntax")
 
 for predicate in (
     _opcode.has_arg,

--- a/pyre/extra_tests/snippets/stdlib_weakref.py
+++ b/pyre/extra_tests/snippets/stdlib_weakref.py
@@ -23,6 +23,16 @@ b = ref(a)
 
 assert callable(b)
 assert b() is a
+assert repr(b).startswith("<weakref at ")
+proxy_repr_target = X()
+assert repr(proxy(proxy_repr_target)).startswith("<weakproxy at ")
+
+try:
+    weakref._remove_dead_weakref(X.__dict__, "missing")
+except TypeError:
+    pass
+else:
+    raise AssertionError("_remove_dead_weakref accepted a mappingproxy")
 
 # Test __callback__ property
 assert b.__callback__ is None, (

--- a/pyre/extra_tests/snippets/stdlib_weakref.py
+++ b/pyre/extra_tests/snippets/stdlib_weakref.py
@@ -5,6 +5,14 @@ from _weakref import getweakrefcount, getweakrefs, proxy, ref
 
 from testutils import assert_raises
 
+import weakref
+
+for type_name in ("ReferenceType", "ProxyType", "CallableProxyType"):
+    weak_type = getattr(weakref, type_name)
+    assert weak_type.__module__ == "weakref"
+    assert weak_type.__name__ == type_name
+    assert weak_type.__qualname__ == type_name
+
 
 class X:
     pass

--- a/pyre/pyre-interpreter/src/_pypy_generic_alias.rs
+++ b/pyre/pyre-interpreter/src/_pypy_generic_alias.rs
@@ -632,6 +632,30 @@ pub(crate) fn create_union(x: PyObjectRef, y: PyObjectRef) -> crate::PyResult {
     Ok(w_union_from_members(members, parameters))
 }
 
+/// `UnionType(items)` construction used by `typing.Union[items]`.
+///
+/// Unlike `_create_union(x, y)`, the constructor does not apply the
+/// operator-level `_unionable` gate: typing's Python-level `_GenericAlias`
+/// instances are valid members even though a generic arbitrary object must
+/// still make the direct `obj | type` operator return `NotImplemented`.
+/// The remaining body is `UnionType.__init__`: collect parameters from the
+/// raw items, recursively flatten nested unions, and deduplicate by equality.
+pub(crate) fn union_from_items(items: &[PyObjectRef]) -> crate::PyResult {
+    if items.len() == 1 {
+        return Ok(normalize_none(items[0]));
+    }
+    let parameters = collect_parameters(w_tuple_new(items.to_vec()))?;
+    let mut members: Vec<PyObjectRef> = Vec::new();
+    for &item in items {
+        add_recurse(item, &mut members)?;
+    }
+    if members.len() == 1 {
+        Ok(members[0])
+    } else {
+        Ok(w_union_from_members(members, parameters))
+    }
+}
+
 /// `add_recurse(arg)` (`_pypy_generic_alias.py:253-262`) — the deduplicating
 /// flatten body of `UnionType.__init__`.  `None` becomes `NoneType`, a nested
 /// `UnionType` is spliced member-by-member, and a member is appended only when

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -5240,6 +5240,14 @@ unsafe fn delattr_surrogate(obj: PyObjectRef, w_name: PyObjectRef, name: &Wtf8) 
                 return crate::call::call_function_impl_result(da, &[obj, w_name])
                     .map(|_| w_none());
             }
+        } else if let Some(w_type) = crate::typedef::r#type(obj) {
+            // descroperation.py:254 dispatches through space.lookup for every
+            // receiver kind. A class is an instance of its metaclass, so its
+            // __delattr__ override precedes direct type-dict removal too.
+            if let Some(da) = lookup_in_type(w_type, "__delattr__") {
+                return crate::call::call_function_impl_result(da, &[obj, w_name])
+                    .map(|_| w_none());
+            }
         }
     }
     unsafe { object_delattr_surrogate(obj, w_name, name) }
@@ -5623,25 +5631,10 @@ fn object_getattr_miss(obj: PyObjectRef, name: &str, call_getattr: bool) -> PyRe
                 }
             }
             if name == "__name__" {
-                // typeobject.py:626 getname — a heap type keeps its stored
-                // name verbatim (it may legitimately contain a dot when built
-                // via `type('a.b', (), {})`); a static type's dotted tp_name
-                // (e.g. "types.UnionType") carries its module prefix only in
-                // repr, so strip to the final component.
-                let full = w_type_get_name(obj);
-                let bare = if pyre_object::w_type_is_heaptype(obj) {
-                    full
-                } else {
-                    full.rsplit('.').next().unwrap_or(full)
-                };
-                return Ok(w_str_new(bare));
+                return Ok(pyre_object::w_type_get_name_obj(obj));
             }
             if name == "__qualname__" {
-                // typeobject.py:637 getqualname returns the stored qualname;
-                // `type_new_take_qualname` popped an explicit class-body
-                // `__qualname__` into it at creation, and the heap/static name
-                // split is already baked into the field.
-                return Ok(w_str_new(pyre_object::w_type_get_qualname(obj)));
+                return Ok(pyre_object::w_type_get_qualname_obj(obj));
             }
             if name == "__mro__" {
                 let mro_ptr = w_type_get_mro(obj);
@@ -5776,8 +5769,21 @@ fn object_getattr_miss(obj: PyObjectRef, name: &str, call_getattr: bool) -> PyRe
             {
                 return Ok(w_str_new(crate::typedef::METHOD_DOC));
             }
-            if name == "__doc__"
-                || name == "__code__"
+            // typeobject.py:1166-1179 descr__doc — a heap type reads only its
+            // own dict and returns None when absent; class docs are never
+            // inherited. EnumType may omit an explicit `__doc__ = None`, so an
+            // MRO lookup here would incorrectly surface Enum.__doc__.
+            if name == "__doc__" && pyre_object::w_type_is_heaptype(obj) {
+                if let Some(value) = crate::type_dict_lookup(obj, name) {
+                    return match get(value, PY_NULL, obj) {
+                        Ok(Some(result)) => Ok(result),
+                        Ok(None) => Ok(value),
+                        Err(e) => Err(e),
+                    };
+                }
+                return Ok(w_none());
+            }
+            if name == "__code__"
                 || name == "__func__"
                 || name == "__self__"
                 || name == "__globals__"
@@ -6592,7 +6598,13 @@ fn object_getattr_miss(obj: PyObjectRef, name: &str, call_getattr: bool) -> PyRe
     // second half of the "hasdict instance dict" protocol.
     let w_dict = getdict_backing(obj);
     if !w_dict.is_null() {
-        if let Some(value) = unsafe { pyre_object::w_dict_getitem_str(w_dict, name) } {
+        // `w_dict` may use MapDictStrategy, whose storage is the backing
+        // instance rather than a native r_dict. PyPy calls
+        // `w_obj.getdictvalue`, which routes through that strategy; use the
+        // generic dict lookup here for the same reason. Reading the raw native
+        // storage skips MapDictStrategy and makes an int/str/etc. subclass's
+        // freshly stored attribute appear shadowed by an inherited class value.
+        if let Some(value) = finditem_str(w_dict, name)? {
             return Ok(value);
         }
     }
@@ -8746,7 +8758,7 @@ pub fn object_setattr(obj: PyObjectRef, name: &str, value: PyObjectRef) -> PyRes
                             object_functionstr_type_name(value),
                         )));
                     }
-                    pyre_object::w_type_set_qualname(obj, pyre_object::w_str_get_value(value));
+                    pyre_object::w_type_set_qualname(obj, value);
                     return Ok(w_none());
                 }
                 // typeobject.py:1258-1261 descr_set___abstractmethods__ —
@@ -9381,6 +9393,14 @@ pub fn delattr_str(obj: PyObjectRef, name: &str) -> PyResult {
                             .map(|_| w_none());
                     }
                 }
+            }
+        } else if let Some(w_type) = crate::typedef::r#type(obj) {
+            // A class object's attribute operations dispatch through its
+            // metaclass in PyPy (`space.lookup(w_obj, '__delattr__')`).
+            if let Some(da) = lookup_in_type(w_type, "__delattr__") {
+                let w_name = w_str_new(name);
+                return crate::call::call_function_impl_result(da, &[obj, w_name])
+                    .map(|_| w_none());
             }
         }
     }

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -8722,7 +8722,7 @@ pub fn object_setattr(obj: PyObjectRef, name: &str, value: PyObjectRef) -> PyRes
                         pyre_object::type_name_of(value)
                     )));
                 }
-                pyre_object::w_type_set_qualname(obj, pyre_object::w_str_get_value(value));
+                pyre_object::w_type_set_qualname(obj, value);
                 mutated(obj, Some(name));
                 return Ok(w_none());
             }

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -8722,6 +8722,7 @@ pub fn object_setattr(obj: PyObjectRef, name: &str, value: PyObjectRef) -> PyRes
                         pyre_object::type_name_of(value)
                     )));
                 }
+                crate::builtins::check_surrogate(value)?;
                 pyre_object::w_type_set_qualname(obj, value);
                 mutated(obj, Some(name));
                 return Ok(w_none());
@@ -8754,6 +8755,7 @@ pub fn object_setattr(obj: PyObjectRef, name: &str, value: PyObjectRef) -> PyRes
                             object_functionstr_type_name(value),
                         )));
                     }
+                    crate::builtins::check_surrogate(value)?;
                     pyre_object::w_type_set_qualname(obj, value);
                     return Ok(w_none());
                 }
@@ -14724,6 +14726,21 @@ fn dict_delitem(obj: PyObjectRef, key: PyObjectRef) -> Result<(), PyError> {
         match pyre_object::dictmultiobject::w_dict_delitem_checked(obj, key) {
             Ok(true) => Ok(()),
             Ok(false) => Err(PyError::key_error_with_key(key)),
+            Err(_) => Err(take_pending_dict_key_error(key)),
+        }
+    }
+}
+
+/// PyPy `W_DictMultiObject.nondescr_delitem_if_value_is`: bypass subclass
+/// hooks and preserve the single-probe identity-checked deletion primitive.
+pub fn dict_delitem_if_value_is(
+    obj: PyObjectRef,
+    key: PyObjectRef,
+    value: PyObjectRef,
+) -> Result<bool, PyError> {
+    unsafe {
+        match pyre_object::dictmultiobject::w_dict_delitem_if_value_is_checked(obj, key, value) {
+            Ok(removed) => Ok(removed),
             Err(_) => Err(take_pending_dict_key_error(key)),
         }
     }

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -5565,7 +5565,6 @@ fn object_getattr_miss(obj: PyObjectRef, name: &str, call_getattr: bool) -> PyRe
         if is_type(obj) {
             // baseobjspace.py:76 — the metaclass is type(C), read from w_class.
             let w_type_type = crate::typedef::w_type();
-            let w_object = crate::typedef::w_object();
             let w_metaclass = {
                 let w_class = (*obj).w_class;
                 if !w_class.is_null() && !std::ptr::eq(w_class, w_type_type) {
@@ -5576,20 +5575,17 @@ fn object_getattr_miss(obj: PyObjectRef, name: &str, call_getattr: bool) -> PyRe
             };
             let w_metaclasses: [Option<PyObjectRef>; 2] =
                 [w_metaclass, crate::typedef::gettypefor((*obj).ob_type)];
-            // typeobject.py:811-819 — a metatype DATA descriptor is consulted
-            // before anything else, including the hardcoded type attributes
-            // below.  Only honor one defined on a user metaclass (its owner is
-            // neither `type` nor `object`): the builtin getsets those bases
-            // carry are served by the dedicated short-circuits below, so
-            // letting them through here would re-enter this lookup.
+            // typeobject.py:811-819 — `space.lookup(self, name)` searches the
+            // complete metaclass MRO, and any data descriptor found there is
+            // consulted before the class's own MRO.  This includes getsets
+            // defined by `type` itself: for example `type.__module__` must
+            // invoke type's descriptor with `type` as its receiver rather
+            // than return the raw descriptor from type's own dictionary.
             for w_metaclass in w_metaclasses.iter().flatten() {
                 let w_metaclass = *w_metaclass;
                 if is_type(w_metaclass) {
-                    if let Some((src, descr)) = lookup_where_pair(w_metaclass, name) {
-                        if !std::ptr::eq(src, w_type_type)
-                            && !std::ptr::eq(src, w_object)
-                            && is_data_descr(descr)
-                        {
+                    if let Some(descr) = lookup_in_type_where(w_metaclass, name) {
+                        if is_data_descr(descr) {
                             match get(descr, obj, w_metaclass) {
                                 Ok(Some(result)) => return Ok(result),
                                 Ok(None) => {}

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -3778,6 +3778,7 @@ pub(crate) fn type_new_take_qualname(w_type: PyObjectRef, ns: PyObjectRef) -> cr
             crate::type_methods::arg_type_name(value),
         )));
     }
+    check_surrogate(value)?;
     unsafe {
         pyre_object::w_type_set_qualname(w_type, value);
         pyre_object::w_dict_delitem_str_no_proxy(ns, "__qualname__");

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -3753,21 +3753,12 @@ pub(crate) fn type_new_set_doc(ns: PyObjectRef) -> crate::PyResult {
     if unsafe { pyre_object::w_dict_getitem_str(ns, "__doc__") }.is_some() {
         return Ok(pyre_object::w_none());
     }
-    let doc_is_slot = match unsafe { pyre_object::w_dict_getitem_str(ns, "__slots__") } {
-        Some(slots)
-            if unsafe {
-                pyre_object::is_str(slots)
-                    || pyre_object::is_tuple(slots)
-                    || pyre_object::is_list(slots)
-            } =>
-        {
-            crate::call::collect_slot_names(slots)?
-                .iter()
-                .any(|name| name == "__doc__")
-        }
-        _ => false,
-    };
-    if !doc_is_slot {
+    // `create_all_slots` owns iteration of `__slots__`.  In particular, it
+    // must consume a one-shot iterator exactly once.  Defer the default doc
+    // entry whenever slots are present; `create_all_slots` installs it after
+    // collecting the complete slot-name sequence if `__doc__` was not among
+    // those names.
+    if unsafe { pyre_object::w_dict_getitem_str(ns, "__slots__") }.is_none() {
         unsafe { pyre_object::w_dict_setitem_str_no_proxy(ns, "__doc__", pyre_object::w_none()) };
     }
     Ok(pyre_object::w_none())

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -3745,6 +3745,34 @@ pub(crate) fn type_new_set_hash_if_eq(ns: PyObjectRef) {
     }
 }
 
+/// CPython `type_new_set_classdict`: every new class owns a `__doc__` entry,
+/// using None when its namespace has no docstring. A declared `__doc__` slot
+/// is the sole exception because the class variable would collide with its
+/// member descriptor.
+pub(crate) fn type_new_set_doc(ns: PyObjectRef) -> crate::PyResult {
+    if unsafe { pyre_object::w_dict_getitem_str(ns, "__doc__") }.is_some() {
+        return Ok(pyre_object::w_none());
+    }
+    let doc_is_slot = match unsafe { pyre_object::w_dict_getitem_str(ns, "__slots__") } {
+        Some(slots)
+            if unsafe {
+                pyre_object::is_str(slots)
+                    || pyre_object::is_tuple(slots)
+                    || pyre_object::is_list(slots)
+            } =>
+        {
+            crate::call::collect_slot_names(slots)?
+                .iter()
+                .any(|name| name == "__doc__")
+        }
+        _ => false,
+    };
+    if !doc_is_slot {
+        unsafe { pyre_object::w_dict_setitem_str_no_proxy(ns, "__doc__", pyre_object::w_none()) };
+    }
+    Ok(pyre_object::w_none())
+}
+
 /// PyPy `typeobject.py:223-235 W_TypeObject.__init__`: consume the compiler's
 /// `__qualname__` entry before slot setup and retain it on the type object.
 /// Keeping it in the namespace changes `cls.__dict__` and makes libraries
@@ -3760,7 +3788,7 @@ pub(crate) fn type_new_take_qualname(w_type: PyObjectRef, ns: PyObjectRef) -> cr
         )));
     }
     unsafe {
-        pyre_object::w_type_set_qualname(w_type, pyre_object::w_str_get_value(value));
+        pyre_object::w_type_set_qualname(w_type, value);
         pyre_object::w_dict_delitem_str_no_proxy(ns, "__qualname__");
     }
     Ok(pyre_object::w_none())
@@ -3976,6 +4004,8 @@ fn type_descr_new_with_metaclass(
                 pyre_object::w_dict_setitem_str_no_proxy(class_ns, "__doc__", pyre_object::w_none())
             };
         }
+        let class_ns = pyre_object::gc_roots::shadow_stack_get(class_ns_root);
+        type_new_set_doc(class_ns)?;
         let class_ns = pyre_object::gc_roots::shadow_stack_get(class_ns_root);
         type_new_set_hash_if_eq(class_ns);
         let class_ns = pyre_object::gc_roots::shadow_stack_get(class_ns_root);
@@ -6312,6 +6342,9 @@ unsafe fn py_repr_obj(obj: PyObjectRef) -> Result<PyObjectRef, crate::PyError> {
         if !obj.is_null() {
             let tp = (*obj).ob_type;
             if let Some(r) = crate::display::builtin_subclass_dunder_obj(obj, tp, "__repr__")? {
+                return Ok(r);
+            }
+            if let Some(r) = crate::display::type_metaclass_dunder_obj(obj, "__repr__")? {
                 return Ok(r);
             }
             if std::ptr::eq(tp, &INSTANCE_TYPE as *const PyType) {

--- a/pyre/pyre-interpreter/src/call.rs
+++ b/pyre/pyre-interpreter/src/call.rs
@@ -3584,34 +3584,7 @@ fn build_class_inner(
     // collide with the member descriptor (typing._SpecialForm).
     {
         let class_ns = pyre_object::gc_roots::shadow_stack_get(class_ns_root);
-        if unsafe { pyre_object::w_dict_getitem_str(class_ns, "__doc__") }.is_none() {
-            let class_ns = pyre_object::gc_roots::shadow_stack_get(class_ns_root);
-            let doc_is_slot =
-                match unsafe { pyre_object::w_dict_getitem_str(class_ns, "__slots__") } {
-                    Some(slots)
-                        if unsafe {
-                            pyre_object::is_str(slots)
-                                || pyre_object::is_tuple(slots)
-                                || pyre_object::is_list(slots)
-                        } =>
-                    {
-                        collect_slot_names(slots)
-                            .map(|names| names.iter().any(|n| n == "__doc__"))
-                            .unwrap_or(false)
-                    }
-                    _ => false,
-                };
-            if !doc_is_slot {
-                let class_ns = pyre_object::gc_roots::shadow_stack_get(class_ns_root);
-                unsafe {
-                    pyre_object::w_dict_setitem_str_no_proxy(
-                        class_ns,
-                        "__doc__",
-                        pyre_object::w_none(),
-                    )
-                };
-            }
-        }
+        crate::builtins::type_new_set_doc(class_ns)?;
     }
 
     // Create W_TypeObject from the class namespace
@@ -4051,7 +4024,9 @@ fn type_descr_call_with_mode(
 ///       slot_names_w = space.unpackiterable(w_slots)
 ///   for w_slot_name in slot_names_w:
 ///       slot_name = space.text_w(w_slot_name)
-fn collect_slot_names(w_slots: pyre_object::PyObjectRef) -> Result<Vec<String>, crate::PyError> {
+pub(crate) fn collect_slot_names(
+    w_slots: pyre_object::PyObjectRef,
+) -> Result<Vec<String>, crate::PyError> {
     unsafe {
         // typeobject.py:1158-1162: str → single-element list, else unpackiterable
         let slot_names_w = if pyre_object::is_str(w_slots) {

--- a/pyre/pyre-interpreter/src/call.rs
+++ b/pyre/pyre-interpreter/src/call.rs
@@ -4193,6 +4193,11 @@ pub unsafe fn create_all_slots(
             wantdict = false;
             wantweakref = false;
             let all_names = collect_slot_names(w_slots)?;
+            if !all_names.iter().any(|name| name == "__doc__")
+                && !crate::type_dict_contains(w_type, "__doc__")
+            {
+                crate::runtime_ops::type_dict_store(w_type, "__doc__", pyre_object::w_none());
+            }
             for slot_name in &all_names {
                 match slot_name.as_str() {
                     // typeobject.py:1165-1169: __dict__ slot

--- a/pyre/pyre-interpreter/src/display.rs
+++ b/pyre/pyre-interpreter/src/display.rs
@@ -352,17 +352,18 @@ pub(crate) unsafe fn builtin_subclass_dunder_obj(
         if w_class.is_null() || !pyre_object::is_type(w_class) {
             return Ok(None);
         }
-        let Some(found) = crate::baseobjspace::lookup_in_type_where(w_class, name) else {
+        let Some((src, found)) = crate::baseobjspace::lookup_where_pair(w_class, name) else {
             return Ok(None);
         };
         // `object`'s inherited default is not a leaf override — fall through
         // so the builtin formatting runs (and `object.__repr__` does not
-        // re-enter through this path).
+        // re-enter through this path). An explicit
+        // `Subclass.__str__ = object.__str__` is different: its owner is the
+        // subclass and the descriptor must run, allowing object.__str__ to
+        // delegate to the subclass's __repr__.
         let w_object = crate::typedef::w_object();
-        if let Some(default) = crate::baseobjspace::lookup_in_type_where(w_object, name) {
-            if std::ptr::eq(found, default) {
-                return Ok(None);
-            }
+        if std::ptr::eq(src, w_object) {
+            return Ok(None);
         }
         // A raising override propagates; a non-string return is a TypeError.
         let r = crate::builtins::call_and_check(found, &[obj])?;
@@ -370,6 +371,42 @@ pub(crate) unsafe fn builtin_subclass_dunder_obj(
             return Ok(Some(r));
         }
         Err(dunder_returned_non_string(name, r))
+    }
+}
+
+/// Resolve a class object's special method on its metaclass.
+///
+/// PyPy: `space.lookup(w_obj, name)` uses `space.type(w_obj)`, so a class
+/// receives an EnumType/user-metaclass override before the native `type`
+/// implementation. The builtin `type`/`object` definitions are terminals and
+/// deliberately left to the native formatting path to avoid re-entry.
+pub(crate) unsafe fn type_metaclass_dunder_obj(
+    obj: PyObjectRef,
+    name: &str,
+) -> Result<Option<PyObjectRef>, crate::PyError> {
+    unsafe {
+        if !pyre_object::is_type(obj) {
+            return Ok(None);
+        }
+        let Some(metaclass) = crate::typedef::r#type(obj) else {
+            return Ok(None);
+        };
+        if !pyre_object::is_type(metaclass) {
+            return Ok(None);
+        }
+        let Some((src, method)) = crate::baseobjspace::lookup_where_pair(metaclass, name) else {
+            return Ok(None);
+        };
+        if std::ptr::eq(src, crate::typedef::w_type())
+            || std::ptr::eq(src, crate::typedef::w_object())
+        {
+            return Ok(None);
+        }
+        let result = crate::builtins::call_and_check(method, &[obj])?;
+        if pyre_object::is_str(result) {
+            return Ok(Some(result));
+        }
+        Err(dunder_returned_non_string(name, result))
     }
 }
 
@@ -395,6 +432,9 @@ pub unsafe fn py_repr_wtf8(obj: PyObjectRef) -> Result<Wtf8Buf, crate::PyError> 
             // A builtin leaf subclass's `__repr__` override may return a
             // lone surrogate; read it as WTF-8 rather than folding to `&str`.
             if let Some(r) = builtin_subclass_dunder_obj(obj, tp, "__repr__")? {
+                return Ok(pyre_object::w_str_get_wtf8(r).to_wtf8_buf());
+            }
+            if let Some(r) = type_metaclass_dunder_obj(obj, "__repr__")? {
                 return Ok(pyre_object::w_str_get_wtf8(r).to_wtf8_buf());
             }
             if std::ptr::eq(tp, &INSTANCE_TYPE as *const PyType) {
@@ -477,6 +517,13 @@ pub unsafe fn py_repr(obj: PyObjectRef) -> Result<String, crate::PyError> {
         // `__repr__` override before the `ob_type`-keyed formatting below.
         if let Some(s) = builtin_subclass_dunder(obj, tp, "__repr__")? {
             return Ok(s);
+        }
+        // A class object is an instance of its metaclass.  PyPy's
+        // `space.repr` therefore resolves `__repr__` on that metaclass before
+        // `type`'s native `<class ...>` representation.  This is observable
+        // for EnumType and any user metaclass defining `__repr__`.
+        if let Some(result) = type_metaclass_dunder_obj(obj, "__repr__")? {
+            return Ok(pyre_object::w_str_get_value(result).to_string());
         }
         let formatted = if let Some(s) = builtin_leaf_repr_string(obj, tp) {
             s

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -4400,36 +4400,15 @@ impl OpcodeStepExecutor for PyFrame {
     // PyPy: LOAD_LOCALS; CPython: LOAD_LOCALS
     // Pushes the current namespace dict onto the stack.
     fn load_locals(&mut self) -> Result<(), PyError> {
-        let dict = pyre_object::w_dict_new();
-        unsafe {
-            let w_locals = self.get_w_locals();
-            if !w_locals.is_null() && pyre_object::is_dict(w_locals) {
-                for (key, value) in pyre_object::dictmultiobject::w_dict_items(w_locals) {
-                    if !value.is_null() {
-                        pyre_object::w_dict_store(dict, key, value);
-                    }
-                }
-            } else {
-                let code = &*crate::pyframe_get_pycode(self);
-                for (idx, name) in code.varnames.iter().enumerate() {
-                    let value = self.locals_w()[idx];
-                    if !value.is_null() {
-                        pyre_object::w_dict_store(dict, pyre_object::w_str_new(name), value);
-                    }
-                }
-                let w_globals = self.get_w_globals();
-                if self.nlocals() == 0 && !w_globals.is_null() {
-                    for (key, value) in
-                        unsafe { pyre_object::dictmultiobject::w_dict_items(w_globals) }
-                    {
-                        if !value.is_null() {
-                            pyre_object::w_dict_store(dict, key, value);
-                        }
-                    }
-                }
-            }
-        }
-        self.push(dict);
+        // pyopcode.py:793-794:
+        //   self.pushvalue(self.getorcreatedebug().w_locals)
+        // In particular this must preserve a metaclass's custom `__prepare__`
+        // mapping.  Rebuilding a plain dict loses mapping-subclass semantics;
+        // treating a dict subclass as a non-dict can also accidentally copy
+        // globals into the class namespace and make LOAD_FROM_DICT_OR_DEREF
+        // select a global over its closure cell.
+        let w_locals = self.get_or_create_w_locals();
+        self.push(w_locals);
         Ok(())
     }
 

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -469,6 +469,8 @@ unsafe fn walk_builtin_type_dicts_gc(forward: &mut dyn FnMut(&mut PyObjectRef)) 
                     &mut (*(w_type as *mut pyre_object::typeobject::W_TypeObject)).bases;
                 forward(bases_slot);
                 let t = &mut *(w_type as *mut pyre_object::typeobject::W_TypeObject);
+                forward(&mut t.w_name);
+                forward(&mut t.w_qualname);
                 // Heap and builtin types both hold a managed W_DictObject.
                 // Forward the field itself; the dict's custom trace walks its
                 // keys and values.

--- a/pyre/pyre-interpreter/src/executioncontext.rs
+++ b/pyre/pyre-interpreter/src/executioncontext.rs
@@ -213,6 +213,10 @@ pub struct ExecutionContext {
     /// per-thread EC pointer and the optimizer can dead-store-eliminate a
     /// balanced save/restore.  GC-rooted via `walk_pyframe_roots`.
     pub sys_exc_value: PyObjectRef,
+    /// Per-execution-context coroutine origin tracking depth. CPython keeps
+    /// the corresponding setting in the thread state; pyre keeps all such
+    /// execution state on the PyPy-style ExecutionContext.
+    pub coroutine_origin_tracking_depth: i64,
     /// `executioncontext.py:55` — linked-list head for running generators and
     /// coroutines.  Each node owns the suspended exception state of its
     /// caller through `GeneratorOrCoroutine.previous_gen_or_coroutine`.
@@ -270,6 +274,7 @@ impl ExecutionContext {
             builtin_dict_cache: std::cell::Cell::new(pyre_object::PY_NULL),
             check_signal_action: None,
             sys_exc_value: pyre_object::PY_NULL,
+            coroutine_origin_tracking_depth: 0,
             current_gen_or_coroutine: pyre_object::PY_NULL,
             w_asyncgen_firstiter_fn: pyre_object::PY_NULL,
             w_asyncgen_finalizer_fn: pyre_object::PY_NULL,

--- a/pyre/pyre-interpreter/src/module/_codecs/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_codecs/mod.rs
@@ -1609,6 +1609,154 @@ fn unicode_escape_decode_impl(
     ]))
 }
 
+/// `interp_codecs.py:1101 escape_decode` / `_PyString_DecodeEscape` — the
+/// bytes-to-bytes Python string-literal escape transform used by protocol-0
+/// pickle.
+fn escape_decode_impl(
+    w_obj: PyObjectRef,
+    errors: PyObjectRef,
+) -> Result<PyObjectRef, crate::PyError> {
+    let data = if unsafe { is_str(w_obj) } {
+        unsafe { w_str_get_wtf8(w_obj) }.as_bytes().to_vec()
+    } else if let Some(src) = crate::typedef::buffer_as_bytes_like(w_obj)? {
+        unsafe { pyre_object::bytesobject::bytes_like_data(src) }.to_vec()
+    } else {
+        return Err(crate::PyError::type_error(
+            "escape_decode() argument must be bytes-like or str",
+        ));
+    };
+    let errors_s = if unsafe { is_str(errors) } {
+        unsafe { w_str_get_value(errors) }
+    } else if unsafe { pyre_object::is_none(errors) } {
+        "strict"
+    } else {
+        return Err(crate::PyError::type_error("errors must be str or None"));
+    };
+
+    let mut out = Vec::with_capacity(data.len());
+    let mut pos = 0usize;
+    let mut first_escape_warning: Option<String> = None;
+    while pos < data.len() {
+        if data[pos] != b'\\' {
+            out.push(data[pos]);
+            pos += 1;
+            continue;
+        }
+
+        let escape_start = pos;
+        pos += 1;
+        if pos == data.len() {
+            return Err(crate::PyError::value_error("Trailing \\ in string"));
+        }
+        let ch = data[pos];
+        pos += 1;
+        match ch {
+            b'\n' => {}
+            b'\\' => out.push(b'\\'),
+            b'\'' => out.push(b'\''),
+            b'"' => out.push(b'"'),
+            b'b' => out.push(0x08),
+            b'f' => out.push(0x0c),
+            b't' => out.push(b'\t'),
+            b'n' => out.push(b'\n'),
+            b'r' => out.push(b'\r'),
+            b'v' => out.push(0x0b),
+            b'a' => out.push(0x07),
+            b'0'..=b'7' => {
+                let octal_start = pos - 1;
+                while pos < data.len()
+                    && pos < octal_start + 3
+                    && (b'0'..=b'7').contains(&data[pos])
+                {
+                    pos += 1;
+                }
+                let raw = data[octal_start..pos]
+                    .iter()
+                    .fold(0u16, |value, digit| value * 8 + (digit - b'0') as u16);
+                if raw >= 256 && first_escape_warning.is_none() {
+                    first_escape_warning = Some(format!(
+                        "invalid octal escape sequence '\\{}'",
+                        String::from_utf8_lossy(&data[octal_start..pos])
+                    ));
+                }
+                out.push(raw as u8);
+            }
+            b'x' => {
+                let hi = data.get(pos).and_then(|byte| (*byte as char).to_digit(16));
+                let lo = data
+                    .get(pos + 1)
+                    .and_then(|byte| (*byte as char).to_digit(16));
+                if let (Some(hi), Some(lo)) = (hi, lo) {
+                    out.push((hi * 16 + lo) as u8);
+                    pos += 2;
+                } else {
+                    match errors_s {
+                        "strict" => {
+                            return Err(crate::PyError::value_error(format!(
+                                "invalid \\x escape at position {escape_start}"
+                            )));
+                        }
+                        "replace" => out.push(b'?'),
+                        "ignore" => {}
+                        other => {
+                            return Err(crate::PyError::value_error(format!(
+                                "decoding error; unknown error handling code: {other}"
+                            )));
+                        }
+                    }
+                    if data.get(pos).is_some_and(u8::is_ascii_hexdigit) {
+                        pos += 1;
+                    }
+                }
+            }
+            other => {
+                out.push(b'\\');
+                pos -= 1;
+                if first_escape_warning.is_none() {
+                    first_escape_warning =
+                        Some(format!("invalid escape sequence '\\{}'", char::from(other)));
+                }
+            }
+        }
+    }
+
+    if let Some(message) = first_escape_warning {
+        crate::warn::warn_deprecation(&message)?;
+    }
+    Ok(w_tuple_new(vec![
+        w_bytes_from_bytes(&out),
+        w_int_new(data.len() as i64),
+    ]))
+}
+
+/// `interp_codecs.py:1092 escape_encode` / `string_escape_encode(data,
+/// quote=False)` — the inverse bytes transform.
+fn escape_encode_impl(w_obj: PyObjectRef) -> Result<PyObjectRef, crate::PyError> {
+    if !unsafe { is_bytes(w_obj) } {
+        return Err(crate::PyError::type_error(format!(
+            "escape_encode() argument 1 must be bytes, not {}",
+            crate::type_methods::arg_type_name(w_obj)
+        )));
+    }
+    let data = unsafe { pyre_object::bytesobject::w_bytes_data(w_obj) };
+    let mut out = Vec::with_capacity(data.len());
+    for byte in data {
+        match *byte {
+            b'\t' => out.extend_from_slice(b"\\t"),
+            b'\n' => out.extend_from_slice(b"\\n"),
+            b'\r' => out.extend_from_slice(b"\\r"),
+            b'\\' => out.extend_from_slice(b"\\\\"),
+            b'\'' => out.extend_from_slice(b"\\'"),
+            0x20..=0x7e => out.push(*byte),
+            value => out.extend_from_slice(format!("\\x{value:02x}").as_bytes()),
+        }
+    }
+    Ok(w_tuple_new(vec![
+        w_bytes_from_bytes(&out),
+        w_int_new(data.len() as i64),
+    ]))
+}
+
 fn charmap_build(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     let Some(chars) = args.first().copied() else {
         return Err(crate::PyError::type_error(
@@ -1794,6 +1942,18 @@ crate::py_module! {
             #[default(w_bool_from(false))] _final: PyObjectRef,
         ) -> Result<PyObjectRef, crate::PyError> {
             unicode_escape_decode_impl(obj, errors)
+        }
+        fn escape_decode(
+            obj: PyObjectRef,
+            #[default(w_str_new("strict"))] errors: PyObjectRef,
+        ) -> Result<PyObjectRef, crate::PyError> {
+            escape_decode_impl(obj, errors)
+        }
+        fn escape_encode(
+            obj: PyObjectRef,
+            #[default(w_str_new("strict"))] _errors: PyObjectRef,
+        ) -> Result<PyObjectRef, crate::PyError> {
+            escape_encode_impl(obj)
         }
         fn charmap_encode(
             obj: PyObjectRef,

--- a/pyre/pyre-interpreter/src/module/_opcode/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_opcode/mod.rs
@@ -55,6 +55,12 @@ fn has_exc(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
 
 fn stack_effect(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     let (positional, kwargs) = crate::builtins::split_builtin_kwargs(args);
+    if positional.len() > 2 {
+        return Err(crate::PyError::type_error(format!(
+            "stack_effect() takes at most 2 positional arguments ({} given)",
+            positional.len(),
+        )));
+    }
     let raw = positional
         .first()
         .copied()
@@ -64,16 +70,14 @@ fn stack_effect(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
         .filter(|op| op.real().is_none_or(|real| real.deopt().is_none()))
         .ok_or_else(|| crate::PyError::value_error("invalid opcode or oparg"))?;
 
-    let oparg = positional
-        .get(1)
-        .copied()
-        .map(crate::baseobjspace::int_w)
-        .transpose()?
-        .unwrap_or(0);
+    let oparg = match positional.get(1).copied() {
+        Some(value) if unsafe { !is_none(value) } => crate::baseobjspace::int_w(value)?,
+        _ => 0,
+    };
     let oparg =
         u32::try_from(oparg).map_err(|_| crate::PyError::value_error("invalid opcode or oparg"))?;
 
-    let jump = crate::builtins::kwarg_get(kwargs, "jump").or_else(|| positional.get(2).copied());
+    let jump = crate::builtins::kwarg_get(kwargs, "jump");
     let effect = match jump {
         Some(value) if unsafe { !is_none(value) } => {
             if crate::baseobjspace::is_true(value)? {
@@ -90,19 +94,15 @@ fn stack_effect(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
 }
 
 fn get_intrinsic1_descs(_: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    Ok(w_list_new(
-        oparg::IntrinsicFunction1::iter()
-            .map(|value| w_str_new(value.desc()))
-            .collect(),
-    ))
+    let mut descriptions = vec![w_str_new("INTRINSIC_1_INVALID")];
+    descriptions.extend(oparg::IntrinsicFunction1::iter().map(|value| w_str_new(value.desc())));
+    Ok(w_list_new(descriptions))
 }
 
 fn get_intrinsic2_descs(_: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    Ok(w_list_new(
-        oparg::IntrinsicFunction2::iter()
-            .map(|value| w_str_new(value.desc()))
-            .collect(),
-    ))
+    let mut descriptions = vec![w_str_new("INTRINSIC_2_INVALID")];
+    descriptions.extend(oparg::IntrinsicFunction2::iter().map(|value| w_str_new(value.desc())));
+    Ok(w_list_new(descriptions))
 }
 
 fn get_nb_ops(_: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {

--- a/pyre/pyre-interpreter/src/module/_opcode/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_opcode/mod.rs
@@ -1,12 +1,121 @@
 //! _opcode module — PyPy: `pypy/module/_opcode/`.
 //!
-//! Stub providing stack_effect + has_arg / has_const / has_name /
-//! has_jump and related classifiers — enough for opcode.py to import.
-//! Returns neutral values (0 for stack_effect, False for has_*, empty
-//! lists / dicts for the rest).  Full implementations would mirror
-//! Python/compile.c.
+//! Opcode metadata used by `opcode.py` and `dis.py`.
 
 use pyre_object::*;
+use rustpython_compiler_core::bytecode::{AnyOpcode, oparg};
+
+fn try_opcode(raw: i64) -> Option<AnyOpcode> {
+    u16::try_from(raw).ok()?.try_into().ok()
+}
+
+fn opcode_predicate(
+    args: &[PyObjectRef],
+    predicate: impl FnOnce(AnyOpcode) -> bool,
+) -> Result<PyObjectRef, crate::PyError> {
+    let raw = crate::baseobjspace::int_w(args[0])?;
+    Ok(w_bool_from(try_opcode(raw).is_some_and(predicate)))
+}
+
+fn is_valid(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    opcode_predicate(args, |_| true)
+}
+
+fn has_arg(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    opcode_predicate(args, |op| op.has_arg())
+}
+
+fn has_const(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    opcode_predicate(args, |op| op.has_const())
+}
+
+fn has_name(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    opcode_predicate(args, |op| op.has_name())
+}
+
+fn has_jump(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    opcode_predicate(args, |op| op.has_jump())
+}
+
+fn has_free(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    opcode_predicate(args, |op| op.has_free())
+}
+
+fn has_local(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    opcode_predicate(args, |op| op.has_local())
+}
+
+fn has_exc(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    opcode_predicate(args, |op| op.is_block_push())
+}
+
+fn stack_effect(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    let (positional, kwargs) = crate::builtins::split_builtin_kwargs(args);
+    let raw = positional
+        .first()
+        .copied()
+        .ok_or_else(|| crate::PyError::type_error("stack_effect() missing opcode"))?;
+    let raw = crate::baseobjspace::int_w(raw)?;
+    let opcode = try_opcode(raw)
+        .filter(|op| op.real().is_none_or(|real| real.deopt().is_none()))
+        .ok_or_else(|| crate::PyError::value_error("invalid opcode or oparg"))?;
+
+    let oparg = positional
+        .get(1)
+        .copied()
+        .map(crate::baseobjspace::int_w)
+        .transpose()?
+        .unwrap_or(0);
+    let oparg =
+        u32::try_from(oparg).map_err(|_| crate::PyError::value_error("invalid opcode or oparg"))?;
+
+    let jump = crate::builtins::kwarg_get(kwargs, "jump").or_else(|| positional.get(2).copied());
+    let effect = match jump {
+        Some(value) if unsafe { !is_none(value) } => {
+            if crate::baseobjspace::is_true(value)? {
+                opcode.stack_effect_jump(oparg)
+            } else {
+                opcode.stack_effect(oparg)
+            }
+        }
+        _ => opcode
+            .stack_effect(oparg)
+            .max(opcode.stack_effect_jump(oparg)),
+    };
+    Ok(w_int_new(effect as i64))
+}
+
+fn get_intrinsic1_descs(_: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    Ok(w_list_new(
+        oparg::IntrinsicFunction1::iter()
+            .map(|value| w_str_new(value.desc()))
+            .collect(),
+    ))
+}
+
+fn get_intrinsic2_descs(_: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    Ok(w_list_new(
+        oparg::IntrinsicFunction2::iter()
+            .map(|value| w_str_new(value.desc()))
+            .collect(),
+    ))
+}
+
+fn get_nb_ops(_: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    Ok(w_list_new(
+        oparg::BinaryOperator::iter()
+            .map(|value| w_tuple_new(vec![w_str_new(value.desc()), w_str_new(&value.to_string())]))
+            .collect(),
+    ))
+}
+
+fn special_method_names_impl() -> PyObjectRef {
+    w_list_new(
+        oparg::SpecialMethod::iter()
+            .map(|value| w_str_new(&value.to_string()))
+            .collect(),
+    )
+}
 
 crate::py_module! {
     "_opcode",
@@ -15,21 +124,16 @@ crate::py_module! {
             format!("<{opcode}>")
         }
         fn get_special_method_names() -> PyObjectRef {
-            w_list_new(vec![
-                w_str_new("__enter__"),
-                w_str_new("__exit__"),
-                w_str_new("__aenter__"),
-                w_str_new("__aexit__"),
-            ])
+            crate::module::_opcode::special_method_names_impl()
         }
     },
     functions: {
-        "stack_effect"             / 3 = |_| Ok(w_int_new(0)),
+        "stack_effect"             / 3 = stack_effect,
         "get_executor"             / 0 = |_| Ok(w_none()),
-        "get_specialization_stats" / 0 = |_| Ok(w_dict_new()),
-        "get_intrinsic1_descs"     / 0 = |_| Ok(w_list_new(vec![])),
-        "get_intrinsic2_descs"     / 0 = |_| Ok(w_list_new(vec![])),
-        "get_nb_ops"               / 0 = |_| Ok(w_list_new(vec![])),
+        "get_specialization_stats" / 0 = |_| Ok(w_none()),
+        "get_intrinsic1_descs"     / 0 = get_intrinsic1_descs,
+        "get_intrinsic2_descs"     / 0 = get_intrinsic2_descs,
+        "get_nb_ops"               / 0 = get_nb_ops,
         "get_executor_count"       / 0 = |_| Ok(w_int_new(0)),
         "get_hot_code"             / 0 = |_| Ok(w_list_new(vec![])),
     },
@@ -39,14 +143,17 @@ crate::py_module! {
         // gated on `@requires_specialization` then skip.
         crate::module_ns_store(ns, "ENABLE_SPECIALIZATION", w_bool_from(false));
         crate::module_ns_store(ns, "ENABLE_SPECIALIZATION_FT", w_bool_from(false));
-        for name in [
-            "has_arg", "has_const", "has_name", "has_jump", "has_jrel",
-            "has_jabs", "has_free", "has_local", "has_exc",
+        for (name, function) in [
+            ("is_valid", is_valid as crate::BuiltinCodeFn),
+            ("has_arg", has_arg as crate::BuiltinCodeFn),
+            ("has_const", has_const as crate::BuiltinCodeFn),
+            ("has_name", has_name as crate::BuiltinCodeFn),
+            ("has_jump", has_jump as crate::BuiltinCodeFn),
+            ("has_free", has_free as crate::BuiltinCodeFn),
+            ("has_local", has_local as crate::BuiltinCodeFn),
+            ("has_exc", has_exc as crate::BuiltinCodeFn),
         ] {
-            crate::module_ns_store(
-                ns, name,
-                crate::make_builtin_function_with_arity(name, |_| Ok(w_bool_from(false)), 0),
-            );
+            crate::module_ns_store(ns, name, crate::make_builtin_function_with_arity(name, function, 1));
         }
     }
 }

--- a/pyre/pyre-interpreter/src/module/_opcode/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_opcode/mod.rs
@@ -13,7 +13,11 @@ fn opcode_predicate(
     args: &[PyObjectRef],
     predicate: impl FnOnce(AnyOpcode) -> bool,
 ) -> Result<PyObjectRef, crate::PyError> {
-    let raw = crate::baseobjspace::int_w(args[0])?;
+    let opcode = args
+        .first()
+        .copied()
+        .ok_or_else(|| crate::PyError::type_error("opcode argument is required"))?;
+    let raw = crate::baseobjspace::int_w(opcode)?;
     Ok(w_bool_from(try_opcode(raw).is_some_and(predicate)))
 }
 

--- a/pyre/pyre-interpreter/src/module/_random/macro_smoke.rs
+++ b/pyre/pyre-interpreter/src/module/_random/macro_smoke.rs
@@ -151,4 +151,30 @@ mod tests {
         assert!(unsafe { is_list(result) });
         assert_eq!(unsafe { w_list_len(result) }, 2);
     }
+
+    /// PyPy's `generic_new_descr` accepts the constructor arguments and
+    /// leaves them for `__init__`; the synthesized allocator must do the same.
+    #[test]
+    fn synthesized_new_accepts_init_arguments() {
+        crate::typedef::init_typeobjects();
+        let cls = type_object();
+        let seed = w_int_new(37);
+        let obj = __pyre_wrap___new__(&[cls, seed]).expect("synthesized __new__");
+        let demo = Demo::from_obj(obj).expect("Demo allocation");
+        assert_eq!(demo.state, 0);
+        __pyre_wrap___init__(&[obj, seed]).expect("Demo.__init__");
+        assert_eq!(Demo::from_obj(obj).expect("initialized Demo").state, 37);
+    }
+
+    /// TypeDef ownership is process-global: another OS thread must observe
+    /// the exact same Python type object, not a fresh TLS allocation.
+    #[test]
+    fn generated_type_object_is_process_global() {
+        crate::typedef::init_typeobjects();
+        let expected = type_object() as usize;
+        let observed = std::thread::spawn(|| type_object() as usize)
+            .join()
+            .expect("type lookup thread");
+        assert_eq!(observed, expected);
+    }
 }

--- a/pyre/pyre-interpreter/src/module/_weakref/interp__weakref.rs
+++ b/pyre/pyre-interpreter/src/module/_weakref/interp__weakref.rs
@@ -206,7 +206,10 @@ fn init_weakref_type(ns: PyObjectRef) {
 
 pub fn weakref_type() -> PyObjectRef {
     *WEAKREF_TYPE.get_or_init(|| {
-        let tp = crate::typedef::make_builtin_type("weakref", init_weakref_type);
+        // CPython exposes `_weakref.ref` as `weakref.ReferenceType`.
+        // The dotted builtin name supplies the public module while the type
+        // metadata getters expose the final component as the bare name.
+        let tp = crate::typedef::make_builtin_type("weakref.ReferenceType", init_weakref_type);
         unsafe { pyre_object::w_type_set_hasdict(tp, true) };
         tp as usize
     }) as PyObjectRef
@@ -254,7 +257,7 @@ fn init_proxy_type(ns: PyObjectRef) {
 #[majit_macros::dont_look_inside]
 pub fn proxy_type() -> PyObjectRef {
     *PROXY_TYPE.get_or_init(|| {
-        let tp = crate::typedef::make_builtin_type("weakproxy", init_proxy_type);
+        let tp = crate::typedef::make_builtin_type("weakref.ProxyType", init_proxy_type);
         unsafe {
             pyre_object::w_type_set_hasdict(tp, true);
             pyre_object::w_type_set_acceptable_as_base_class(tp, false);
@@ -313,7 +316,10 @@ fn init_callable_proxy_type(ns: PyObjectRef) {
 #[majit_macros::dont_look_inside]
 pub fn callable_proxy_type() -> PyObjectRef {
     *CALLABLE_PROXY_TYPE.get_or_init(|| {
-        let tp = crate::typedef::make_builtin_type("weakcallableproxy", init_callable_proxy_type);
+        let tp = crate::typedef::make_builtin_type(
+            "weakref.CallableProxyType",
+            init_callable_proxy_type,
+        );
         unsafe {
             pyre_object::w_type_set_hasdict(tp, true);
             pyre_object::w_type_set_acceptable_as_base_class(tp, false);
@@ -834,10 +840,39 @@ fn is_w_weakref(obj: PyObjectRef) -> bool {
     if obj.is_null() {
         return false;
     }
-    match crate::typedef::r#type(obj) {
-        Some(tp) => std::ptr::eq(tp, weakref_type()),
-        None => false,
+    unsafe { crate::baseobjspace::isinstance_w(obj, weakref_type()) }
+}
+
+/// PyPy `app_weakref._remove_dead_weakref`, backed by
+/// `W_DictMultiObject.nondescr_delitem_if_value_is`.
+///
+/// The lookup and deletion operate on the intrinsic dict backing so dict
+/// subclass hooks are bypassed.  Rechecking pointer identity immediately
+/// before deletion preserves the upstream atomic "delete only this weakref"
+/// contract if key comparison mutates the dictionary.
+pub fn remove_dead_weakref(args: &[PyObjectRef]) -> Result<PyObjectRef, PyError> {
+    let dict = args[0];
+    let key = args[1];
+    let backing = crate::type_methods::resolve_dict_backing(dict);
+    if backing.is_null() {
+        return Err(PyError::type_error(format!(
+            "_remove_dead_weakref() argument 1 must be dict, not {}",
+            crate::baseobjspace::object_functionstr_type_name(dict),
+        )));
     }
+    let Some(stored) = crate::baseobjspace::finditem(backing, key)? else {
+        return Ok(pyre_object::w_none());
+    };
+    if !is_w_weakref(stored) {
+        return Err(PyError::type_error("not a weakref"));
+    }
+    if !dereference(stored).is_null() {
+        return Ok(pyre_object::w_none());
+    }
+    if crate::baseobjspace::finditem(backing, key)? == Some(stored) {
+        crate::baseobjspace::delitem_slot(backing, key)?;
+    }
+    Ok(pyre_object::w_none())
 }
 
 fn is_callable(obj: PyObjectRef) -> bool {

--- a/pyre/pyre-interpreter/src/module/_weakref/interp__weakref.rs
+++ b/pyre/pyre-interpreter/src/module/_weakref/interp__weakref.rs
@@ -681,8 +681,11 @@ pub fn descr__repr__(args: &[PyObjectRef]) -> Result<PyObjectRef, PyError> {
     let w_obj = dereference(w_self);
     let type_name = unsafe {
         match crate::typedef::r#type(w_self) {
-            Some(tp) => pyre_object::w_type_get_name(tp).to_string(),
-            None => "weakref".to_string(),
+            Some(tp) if std::ptr::eq(tp, weakref_type()) => "weakref",
+            Some(tp) if std::ptr::eq(tp, proxy_type()) => "weakproxy",
+            Some(tp) if std::ptr::eq(tp, callable_proxy_type()) => "weakcallableproxy",
+            Some(tp) => pyre_object::w_type_get_name(tp),
+            None => "weakref",
         }
     };
     let state = if w_obj.is_null() || unsafe { pyre_object::is_none(w_obj) } {
@@ -851,8 +854,20 @@ fn is_w_weakref(obj: PyObjectRef) -> bool {
 /// before deletion preserves the upstream atomic "delete only this weakref"
 /// contract if key comparison mutates the dictionary.
 pub fn remove_dead_weakref(args: &[PyObjectRef]) -> Result<PyObjectRef, PyError> {
-    let dict = args[0];
-    let key = args[1];
+    let dict = args
+        .first()
+        .copied()
+        .ok_or_else(|| PyError::type_error("_remove_dead_weakref() missing dict argument"))?;
+    let key = args
+        .get(1)
+        .copied()
+        .ok_or_else(|| PyError::type_error("_remove_dead_weakref() missing key argument"))?;
+    if !unsafe { pyre_object::is_dict(dict) } {
+        return Err(PyError::type_error(format!(
+            "_remove_dead_weakref() argument 1 must be dict, not {}",
+            crate::baseobjspace::object_functionstr_type_name(dict),
+        )));
+    }
     let backing = crate::type_methods::resolve_dict_backing(dict);
     if backing.is_null() {
         return Err(PyError::type_error(format!(
@@ -869,9 +884,7 @@ pub fn remove_dead_weakref(args: &[PyObjectRef]) -> Result<PyObjectRef, PyError>
     if !dereference(stored).is_null() {
         return Ok(pyre_object::w_none());
     }
-    if crate::baseobjspace::finditem(backing, key)? == Some(stored) {
-        crate::baseobjspace::delitem_slot(backing, key)?;
-    }
+    crate::baseobjspace::dict_delitem_if_value_is(backing, key, stored)?;
     Ok(pyre_object::w_none())
 }
 

--- a/pyre/pyre-interpreter/src/module/_weakref/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_weakref/mod.rs
@@ -12,8 +12,8 @@
 //! }
 //! ```
 //!
-//! `_remove_dead_weakref` is CPython-only and is stubbed as a no-op for
-//! cleanup-driven users like weakref.py's WeakValueDictionary.
+//! CPython exposes `_remove_dead_weakref`; PyPy implements the same operation
+//! in `app_weakref.py` through its atomic `delitem_if_value_is` helper.
 
 pub mod interp__weakref;
 
@@ -31,6 +31,6 @@ crate::py_module! {
     module_functions: {
         "getweakrefcount"      / 1 = interp__weakref::getweakrefcount,
         "getweakrefs"          / 1 = interp__weakref::getweakrefs,
-        "_remove_dead_weakref" / 2 = |_| Ok(pyre_object::w_none()),
+        "_remove_dead_weakref" / 2 = interp__weakref::remove_dead_weakref,
     },
 }

--- a/pyre/pyre-interpreter/src/module/sys/vm.rs
+++ b/pyre/pyre-interpreter/src/module/sys/vm.rs
@@ -332,6 +332,34 @@ fn sys_setprofile_impl(args: &[PyObjectRef]) -> crate::PyResult {
     Ok(w_none())
 }
 
+fn sys_get_coroutine_origin_tracking_depth(_args: &[PyObjectRef]) -> crate::PyResult {
+    let ec = current_execution_context();
+    let depth = if ec.is_null() {
+        0
+    } else {
+        unsafe { (*ec).coroutine_origin_tracking_depth }
+    };
+    Ok(pyre_object::w_int_new(depth))
+}
+
+fn sys_set_coroutine_origin_tracking_depth(args: &[PyObjectRef]) -> crate::PyResult {
+    let w_depth = *args.first().ok_or_else(|| {
+        crate::PyError::type_error(
+            "set_coroutine_origin_tracking_depth() missing required argument 'depth'",
+        )
+    })?;
+    let indexed = crate::baseobjspace::space_index(w_depth)?;
+    let depth = crate::baseobjspace::int_w(indexed)?;
+    if depth < 0 {
+        return Err(crate::PyError::value_error("depth must be >= 0"));
+    }
+    let ec = current_execution_context();
+    if !ec.is_null() {
+        unsafe { (*ec).coroutine_origin_tracking_depth = depth };
+    }
+    Ok(w_none())
+}
+
 fn asyncgen_hooks_type() -> PyObjectRef {
     static TYPE: OnceLock<usize> = OnceLock::new();
     *TYPE.get_or_init(|| {
@@ -1328,6 +1356,24 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
         ns,
         "setprofile",
         make_builtin_function_with_arity("setprofile", sys_setprofile_impl, 1),
+    );
+    module_ns_store(
+        ns,
+        "get_coroutine_origin_tracking_depth",
+        make_builtin_function_with_arity(
+            "get_coroutine_origin_tracking_depth",
+            sys_get_coroutine_origin_tracking_depth,
+            0,
+        ),
+    );
+    module_ns_store(
+        ns,
+        "set_coroutine_origin_tracking_depth",
+        make_builtin_function_with_arity(
+            "set_coroutine_origin_tracking_depth",
+            sys_set_coroutine_origin_tracking_depth,
+            1,
+        ),
     );
     module_ns_store(
         ns,

--- a/pyre/pyre-interpreter/src/objspace/descroperation.rs
+++ b/pyre/pyre-interpreter/src/objspace/descroperation.rs
@@ -1792,8 +1792,7 @@ unsafe fn try_compare_override(
     let b_type = crate::typedef::r#type(b);
     let a_ov = comparison_method(a, dunder);
     let mut b_ov = comparison_method(b, rdunder);
-    if dunder == rdunder
-        && matches!((a_type, b_type), (Some(at), Some(bt)) if std::ptr::eq(at, bt))
+    if dunder == rdunder && matches!((a_type, b_type), (Some(at), Some(bt)) if std::ptr::eq(at, bt))
     {
         // descroperation.py: for __eq__ and __ne__, objects of the same
         // class resolve the same method, so do not invoke it twice.

--- a/pyre/pyre-interpreter/src/objspace/descroperation.rs
+++ b/pyre/pyre-interpreter/src/objspace/descroperation.rs
@@ -3356,6 +3356,12 @@ pub fn xor(a: PyObjectRef, b: PyObjectRef) -> PyResult {
 /// Comparison operation dispatch.
 
 pub fn compare(a: PyObjectRef, b: PyObjectRef, op: CompareOp) -> PyResult {
+    // RPython inserts a stack check on this recursive object-space call.
+    // Container comparisons recurse without pushing a Python frame (for
+    // example two distinct self-referential lists), so keep the same guard
+    // explicitly in the Rust port and raise RecursionError before exhausting
+    // the native stack.
+    crate::stack_check::stack_check()?;
     // A builtin subclass overriding the comparison dunder dispatches the
     // override first (with reflected-subclass priority); exact builtins and
     // non-overriding subclasses fall through to the by-layout comparison slot,

--- a/pyre/pyre-interpreter/src/objspace/descroperation.rs
+++ b/pyre/pyre-interpreter/src/objspace/descroperation.rs
@@ -1756,16 +1756,15 @@ unsafe fn issubtype_cached(w_type: PyObjectRef, cls: PyObjectRef) -> bool {
     pyre_object::w_type_issubtype(w_type, cls)
 }
 
-/// Builtin-subclass comparison override dispatch.
+/// Comparison special-method dispatch.
 ///
-/// When either operand is a builtin subclass that *overrides* the comparison
-/// dunder, dispatch it with Python's reflected-subclass priority, calling
-/// only genuine overrides — never the inherited builtin slot, which delegates
-/// straight back into [`compare`] and would recurse forever.  Returns
-/// `Some(result)` once an override yields a non-`NotImplemented` value (or
-/// raises); `None` when neither side overrides — or every override returned
-/// `NotImplemented` — so the caller falls through to the by-layout fast paths
-/// / identity tail.
+/// PyPy: `descroperation.py:_make_comparison_impl`.  Generic instances use
+/// the complete MRO lookup, including inherited `object.__eq__` /
+/// `object.__ne__`; the latter deliberately calls the receiver's live
+/// `__eq__`.  Builtin layouts retain the override-only lookup because their
+/// inherited slots delegate straight back into [`compare`] and would recurse
+/// forever.  The reflected method of a proper subclass has priority, and
+/// equal types only invoke the shared `__eq__` / `__ne__` implementation once.
 unsafe fn try_compare_override(
     a: PyObjectRef,
     b: PyObjectRef,
@@ -1780,8 +1779,26 @@ unsafe fn try_compare_override(
         CompareOp::Ne => "__ne__",
     };
     let rdunder = reverse_dunder(dunder).unwrap_or(dunder);
-    let a_ov = crate::baseobjspace::subclass_special_override(a, dunder);
-    let b_ov = crate::baseobjspace::subclass_special_override(b, rdunder);
+    let comparison_method = |obj: PyObjectRef, name: &str| {
+        if is_instance(obj) {
+            let w_type = crate::typedef::r#type(obj)?;
+            let method = lookup_in_type_where(w_type, name)?;
+            Some((method, w_type))
+        } else {
+            crate::baseobjspace::subclass_special_override(obj, name)
+        }
+    };
+    let a_type = crate::typedef::r#type(a);
+    let b_type = crate::typedef::r#type(b);
+    let a_ov = comparison_method(a, dunder);
+    let mut b_ov = comparison_method(b, rdunder);
+    if dunder == rdunder
+        && matches!((a_type, b_type), (Some(at), Some(bt)) if std::ptr::eq(at, bt))
+    {
+        // descroperation.py: for __eq__ and __ne__, objects of the same
+        // class resolve the same method, so do not invoke it twice.
+        b_ov = None;
+    }
     if a_ov.is_none() && b_ov.is_none() {
         return Ok(None);
     }
@@ -1789,7 +1806,7 @@ unsafe fn try_compare_override(
     // proper subclass of `a`'s type and `b` overrides the reflected op, run it
     // first.
     let b_first = b_ov.is_some()
-        && match (crate::typedef::r#type(a), crate::typedef::r#type(b)) {
+        && match (a_type, b_type) {
             (Some(at), Some(bt)) => !std::ptr::eq(at, bt) && issubtype_cached(bt, at),
             _ => false,
         };

--- a/pyre/pyre-interpreter/src/objspace/std/mapdict.rs
+++ b/pyre/pyre-interpreter/src/objspace/std/mapdict.rs
@@ -2009,20 +2009,53 @@ fn box_value(typ: UnboxType, val: i64) -> PyObjectRef {
     }
 }
 
-/// `type(w_value) is space.IntObjectCls` (mapdict.py:574,615). `is_int` matches
-/// `bool` too (bool subclasses int), but bool's impl class is not the int
-/// class, so a bool must not be unboxed — `w_int_new` boxing would discard its
-/// bool identity.
+/// `type(w_value) is space.IntObjectCls` (mapdict.py:198,574,615).
+///
+/// Pyre gives an int subclass the same native storage layout as W_IntObject
+/// and carries its app-level identity in `w_class`. Testing only the layout
+/// (`is_int`) would unbox IntEnum/user-int instances and reconstruct them as
+/// builtin ints, losing `w_class`. Compare the exact app-level type just as
+/// PyPy compares the exact implementation class.
 ///
 /// # Safety
 /// `w_value` must point to a live object.
 unsafe fn is_unboxable_int(w_value: PyObjectRef) -> bool {
-    // Early-return control flow rather than `if c { false } else { x }`, which
-    // can become a `!c && x` (a `bool_not`) that majit-translate cannot lower.
-    if unsafe { pyre_object::is_bool(w_value) } {
+    if !unsafe { pyre_object::is_int(w_value) } {
         return false;
     }
-    unsafe { pyre_object::is_int(w_value) }
+    let exact = crate::typedef::gettypeobject(&pyre_object::INT_TYPE);
+    if exact.is_null() {
+        // Interpreter-only unit tests may exercise mapdict before the app-level
+        // type registry is initialized. A native int with no class stamp is
+        // the bootstrap representation of that same exact type.
+        if pyre_object::tagged_int::CAN_BE_TAGGED
+            && unsafe { pyre_object::tagged_int::is_tagged_int(w_value) }
+        {
+            return true;
+        }
+        return unsafe { (*w_value).w_class.is_null() };
+    }
+    let Some(actual) = crate::typedef::r#type(w_value) else {
+        return false;
+    };
+    std::ptr::eq(actual, exact)
+}
+
+/// Float half of `_pick_unbox_type`: PyPy uses
+/// `type(w_value) is space.FloatObjectCls`, so a float subclass must retain
+/// its boxed object and `w_class` too.
+unsafe fn is_unboxable_float(w_value: PyObjectRef) -> bool {
+    if !unsafe { pyre_object::is_float(w_value) } {
+        return false;
+    }
+    let exact = crate::typedef::gettypeobject(&pyre_object::FLOAT_TYPE);
+    if exact.is_null() {
+        return unsafe { (*w_value).w_class.is_null() };
+    }
+    let Some(actual) = crate::typedef::r#type(w_value) else {
+        return false;
+    };
+    std::ptr::eq(actual, exact)
 }
 
 /// mapdict.py:586-590 `UnboxedPlainAttribute._convert_to_boxed` — rebuild the
@@ -2066,7 +2099,7 @@ unsafe fn convert_to_boxed_and_write<O: MapdictObject>(
 unsafe fn value_has_unbox_type(typ: UnboxType, w_value: PyObjectRef) -> bool {
     match typ {
         UnboxType::Int => unsafe { is_unboxable_int(w_value) },
-        UnboxType::Float => unsafe { pyre_object::is_float(w_value) },
+        UnboxType::Float => unsafe { is_unboxable_float(w_value) },
     }
 }
 
@@ -2603,7 +2636,7 @@ unsafe fn pick_unbox_type(self_node: MapRef, w_value: PyObjectRef) -> Option<Unb
     if term.allow_unboxing.get() {
         if ALLOW_UNBOXING_INTS && unsafe { is_unboxable_int(w_value) } {
             return Some(UnboxType::Int);
-        } else if unsafe { pyre_object::is_float(w_value) } {
+        } else if unsafe { is_unboxable_float(w_value) } {
             return Some(UnboxType::Float);
         }
     }

--- a/pyre/pyre-interpreter/src/objspace/std/mapdict.rs
+++ b/pyre/pyre-interpreter/src/objspace/std/mapdict.rs
@@ -2020,7 +2020,7 @@ fn box_value(typ: UnboxType, val: i64) -> PyObjectRef {
 /// # Safety
 /// `w_value` must point to a live object.
 unsafe fn is_unboxable_int(w_value: PyObjectRef) -> bool {
-    if !unsafe { pyre_object::is_int(w_value) } {
+    if unsafe { pyre_object::is_bool(w_value) } || !unsafe { pyre_object::is_int(w_value) } {
         return false;
     }
     let exact = crate::typedef::gettypeobject(&pyre_object::INT_TYPE);

--- a/pyre/pyre-interpreter/src/pyframe.rs
+++ b/pyre/pyre-interpreter/src/pyframe.rs
@@ -686,6 +686,15 @@ impl FrameBox {
     ) -> crate::PyResult {
         self.fix_array_ptrs();
         let register_final = !self.code().exceptiontable.is_empty();
+        let is_coroutine = self.code().flags.contains(crate::CodeFlags::COROUTINE);
+        let _origin_roots = pyre_object::gc_roots::push_roots();
+        let coroutine_origin_slot = if is_coroutine {
+            let origin = capture_coroutine_origin(self.execution_context);
+            pyre_object::gc_roots::pin_root(origin);
+            Some(pyre_object::gc_roots::shadow_stack_len() - 1)
+        } else {
+            None
+        };
         // A suspended generator frame is off the call chain — `f_back` is
         // None until a resume re-links it (`executioncontext.py enter`
         // rebinds `f_backref = topframeref`; pyre does the same at
@@ -717,16 +726,19 @@ impl FrameBox {
                 .contains(crate::CodeFlags::ASYNC_GENERATOR)
         } {
             pyre_object::generator::w_async_generator_new(frame_ptr as *mut u8, pycode)
-        } else if unsafe {
-            (*frame_ptr)
-                .code()
-                .flags
-                .contains(crate::CodeFlags::COROUTINE)
-        } {
+        } else if is_coroutine {
             pyre_object::generator::w_coroutine_new(frame_ptr as *mut u8, pycode)
         } else {
             pyre_object::generator::w_generator_new(frame_ptr as *mut u8, pycode)
         };
+        if let Some(slot) = coroutine_origin_slot {
+            unsafe {
+                pyre_object::generator::w_coroutine_set_origin(
+                    generator,
+                    pyre_object::gc_roots::shadow_stack_get(slot),
+                );
+            }
+        }
         // GeneratorOrCoroutine.__init__ stores `_name` / `_qualname` on the
         // generator.  Root the new owner while allocating the two wrapped
         // strings, then publish them through the normal GC write barrier.
@@ -748,6 +760,52 @@ impl FrameBox {
         }
         Ok(generator)
     }
+}
+
+/// Capture `coroutine.cr_origin` from the visible caller chain.
+///
+/// The coroutine frame has not executed yet, so its `f_backref` is empty.
+/// Creation therefore walks the live ExecutionContext from its current top
+/// frame, using the PyPy no-hidden-frame traversal, and records summaries in
+/// most-recent-first order.
+fn capture_coroutine_origin(ec: *const PyExecutionContext) -> PyObjectRef {
+    if ec.is_null() {
+        return w_none();
+    }
+    let depth = unsafe { (*ec).coroutine_origin_tracking_depth };
+    if depth <= 0 {
+        return w_none();
+    }
+
+    let _roots = pyre_object::gc_roots::push_roots();
+    let mut summary_slots = Vec::new();
+    let mut frame = unsafe { (*ec).gettopframe_nohidden() };
+    for _ in 0..depth {
+        if frame.is_null() {
+            break;
+        }
+        let code = unsafe { (*frame).code() };
+        let filename_slot = pyre_object::gc_roots::shadow_stack_len();
+        pyre_object::gc_roots::pin_root(w_str_new(&code.source_path));
+        let lineno_slot = pyre_object::gc_roots::shadow_stack_len();
+        pyre_object::gc_roots::pin_root(w_int_new(unsafe { (*frame).fget_f_lineno() } as i64));
+        let funcname_slot = pyre_object::gc_roots::shadow_stack_len();
+        pyre_object::gc_roots::pin_root(w_str_new(&code.obj_name));
+        let summary = w_tuple_new(vec![
+            pyre_object::gc_roots::shadow_stack_get(filename_slot),
+            pyre_object::gc_roots::shadow_stack_get(lineno_slot),
+            pyre_object::gc_roots::shadow_stack_get(funcname_slot),
+        ]);
+        pyre_object::gc_roots::pin_root(summary);
+        summary_slots.push(pyre_object::gc_roots::shadow_stack_len() - 1);
+        frame = crate::executioncontext::ExecutionContext::getnextframe_nohidden(frame);
+    }
+    w_tuple_new(
+        summary_slots
+            .into_iter()
+            .map(pyre_object::gc_roots::shadow_stack_get)
+            .collect(),
+    )
 }
 
 impl std::ops::Deref for FrameBox {

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -9301,10 +9301,7 @@ fn init_type_type(ns: PyObjectRef) {
 
     let name_getter = make_builtin_function_with_arity(
         "__name__",
-        |args| unsafe {
-            let name = pyre_object::w_type_get_name(args[1]);
-            Ok(pyre_object::w_str_new(name))
-        },
+        |args| unsafe { Ok(pyre_object::w_type_get_name_obj(args[1])) },
         2,
     );
     // typeobject.py:1046 descr_set__name__
@@ -9345,8 +9342,7 @@ fn init_type_type(ns: PyObjectRef) {
             crate::builtins::check_surrogate(w_value)?;
             // typeobject.py:1058 `w_type.name = name` — surrogate-free, so
             // the str view is valid UTF-8.
-            let name = unsafe { pyre_object::w_str_get_value(w_value) };
-            unsafe { pyre_object::w_type_set_name(w_type, name) };
+            unsafe { pyre_object::w_type_set_name(w_type, w_value) };
             Ok(pyre_object::w_none())
         },
         3,
@@ -15360,23 +15356,26 @@ fn init_object_type(ns: PyObjectRef) {
         pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
             ns,
             "__init_subclass__",
-            make_builtin_function("__init_subclass__", |args| {
-                let (_, kwargs) = crate::builtins::split_builtin_kwargs(args);
-                if let Some(kw) = kwargs {
-                    let has_real_kw = unsafe {
-                        pyre_object::w_dict_items(kw).into_iter().any(|(k, _)| {
-                            pyre_object::is_str(k)
-                                && pyre_object::w_str_get_wtf8(k).as_str() != Ok("__pyre_kw__")
-                        })
-                    };
-                    if has_real_kw {
-                        return Err(crate::PyError::type_error(
-                            "__init_subclass__() takes no keyword arguments",
-                        ));
+            pyre_object::function::w_classmethod_new(make_builtin_function(
+                "__init_subclass__",
+                |args| {
+                    let (_, kwargs) = crate::builtins::split_builtin_kwargs(args);
+                    if let Some(kw) = kwargs {
+                        let has_real_kw = unsafe {
+                            pyre_object::w_dict_items(kw).into_iter().any(|(k, _)| {
+                                pyre_object::is_str(k)
+                                    && pyre_object::w_str_get_wtf8(k).as_str() != Ok("__pyre_kw__")
+                            })
+                        };
+                        if has_real_kw {
+                            return Err(crate::PyError::type_error(
+                                "__init_subclass__() takes no keyword arguments",
+                            ));
+                        }
                     }
-                }
-                Ok(pyre_object::w_none())
-            }),
+                    Ok(pyre_object::w_none())
+                },
+            )),
         )
     };
     unsafe {

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -636,10 +636,13 @@ pub fn init_typeobjects() {
             notimplemented_type as usize,
         );
 
-        // types.UnionType — PyPy: _pypy_generic_alias.py UnionType, bases=(object,)
+        // typing.Union — exported by `types` as `UnionType`; Python 3.14
+        // gives the shared runtime type the canonical name/module
+        // `typing.Union`. PyPy: _pypy_generic_alias.py UnionType,
+        // bases=(object,).
         // `__slots__` includes `__weakref__` (`_pypy_generic_alias.py:247`),
         // so a union is weak-referenceable.
-        let union_type = new_typeobject_with_base("types.UnionType", init_union_type, object_type);
+        let union_type = new_typeobject_with_base("typing.Union", init_union_type, object_type);
         unsafe { pyre_object::w_type_set_weakrefable(union_type, true) };
         reg.insert(
             &pyre_object::UNION_TYPE as *const PyType as usize,
@@ -8229,14 +8232,22 @@ fn union_class_getitem(args: &[PyObjectRef]) -> crate::PyResult {
             "Cannot take a Union of no types.",
         ));
     }
-    let mut curr = items[0];
-    for &next in &items[1..] {
-        curr = crate::_pypy_generic_alias::create_union(curr, next)?;
-    }
-    Ok(curr)
+    crate::_pypy_generic_alias::union_from_items(&items)
 }
 
 fn init_union_type(ns: PyObjectRef) {
+    // Python 3.14's shared `types.UnionType` / `typing.Union` runtime type
+    // exposes `__module__` on union *instances* as well as on the type.  Keep
+    // the value in the typedef namespace so generic object attribute lookup
+    // reaches it (the metatype's type-name-derived module alone is not an
+    // instance attribute).
+    unsafe {
+        pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
+            ns,
+            "__module__",
+            pyre_object::w_str_new("typing"),
+        )
+    };
     // UnionType.__args__ — returns the tuple of union member types
     let args_getter = make_builtin_function_with_arity(
         "__args__",

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -9388,7 +9388,7 @@ fn init_type_type(ns: PyObjectRef) {
                 )));
             }
             unsafe {
-                pyre_object::w_type_set_qualname(w_type, pyre_object::w_str_get_value(value));
+                pyre_object::w_type_set_qualname(w_type, value);
                 crate::baseobjspace::mutated(w_type, Some("__qualname__"));
             }
             Ok(pyre_object::w_none())

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
@@ -1651,6 +1651,21 @@ pub(crate) fn try_walker_inline_resolved_user_call<Sym: WalkSym>(
     // (`pcdep_color_slots[0]`), not `r{i}`; an empty fixture map is identity.
     let entry_colors = crate::state::sub_jitcode_entry_param_colors(w_code);
     for i in 0..nparams {
+        // RPython passes the same RefFrontendOp into the callee MIFrame, so
+        // the Box keeps its recording-time pointer across the frame boundary.
+        // Pyre also carries a register-local concrete shadow; mirror that
+        // value back onto the canonical OpRef before constructing the callee
+        // register file.  Loop-sidecar locals in particular can have a live
+        // register concrete even when an intervening vable load returned a
+        // fresh, previously unstamped OpRef.
+        if let ConcreteValue::Ref(value) = callee_arg_concretes[i]
+            && !value.is_null()
+        {
+            ctx.trace_ctx.try_set_opref_concrete(
+                callee_args[i],
+                majit_ir::Value::Ref(majit_ir::GcRef(value as usize)),
+            );
+        }
         let reg = match &entry_colors {
             // Colored jitcode: seed param `i` at the register it occupies at
             // the callee entry PC.  A param dead at entry carries no entry
@@ -1828,7 +1843,48 @@ pub(crate) fn try_walker_inline_resolved_user_call<Sym: WalkSym>(
             );
 
             callee_regs_r[frame_reg as usize] = callee_frame;
-            callee_concrete_r[frame_reg as usize] = ConcreteValue::Null;
+            // `perform_call` creates one concrete frame per MIFrame before
+            // `setup_call` installs the argument boxes (pyjitpl.py:2445-2476,
+            // 1862-1874).  Mirror that recording-time object.  Root each
+            // freshly boxed argument immediately: `ConcreteValue::to_pyobj`
+            // can allocate, and a later argument must not collect an earlier
+            // one before the frame constructor takes ownership of the slice.
+            let arg_roots = pyre_object::gc_roots::push_roots();
+            let arg_root_base = pyre_object::gc_roots::shadow_stack_len();
+            for concrete in callee_arg_concretes.iter().take(nparams).copied() {
+                pyre_object::gc_roots::pin_root(concrete.to_pyobj());
+            }
+            let concrete_args: Vec<pyre_object::PyObjectRef> = (0..nparams)
+                .map(|i| pyre_object::gc_roots::shadow_stack_get(arg_root_base + i))
+                .collect();
+            let concrete_ec = sym.concrete_execution_context();
+            // Use a GC-managed frame, not `new_boxed`: the concrete pointer is
+            // stamped onto the active trace's frontend op below, and
+            // `MetaInterp::walk_active_trace_refs` is then its RPython-style
+            // GC root through optimization.  A scope-owned tracer snapshot
+            // would be freed when this function returns while the Box value
+            // still exists, leaving a dangling recording-time pointer.
+            let mut frame = pyre_interpreter::pyframe::FrameBox::new(
+                pyre_interpreter::pyframe::PyFrame::new_for_call_with_closure_and_globals_obj(
+                    w_code,
+                    &concrete_args,
+                    inline_consts.w_globals as pyre_object::PyObjectRef,
+                    concrete_ec,
+                    pyre_object::PY_NULL,
+                    pyre_interpreter::pyframe::FrameLocalsArrayAllocation::OldGenGc,
+                ),
+            );
+            drop(arg_roots);
+            let concrete_frame_ptr = frame.as_mut_ptr();
+            callee_concrete_r[frame_reg as usize] =
+                ConcreteValue::Ref(concrete_frame_ptr as pyre_object::PyObjectRef);
+            ctx.trace_ctx.set_opref_concrete(
+                callee_frame,
+                majit_ir::Value::Ref(majit_ir::GcRef(concrete_frame_ptr as usize)),
+            );
+            // GC-managed FrameBox::drop intentionally relinquishes only the
+            // host handle; the frontend op above keeps the frame reachable.
+            drop(frame);
             callee_regs_r[ec_reg as usize] = callee_ec;
             callee_concrete_r[ec_reg as usize] = ConcreteValue::Null;
 

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
@@ -417,6 +417,24 @@ pub(crate) fn try_walker_specialize_binary_op_int<Sym: WalkSym>(
         return Ok(None);
     };
 
+    // intobject.py `_make_generic_descr_binop`: the machine-int fast path
+    // exits through `_make_ovf2long` when `ovfcheck(op(x, y))` raises.
+    // This walker specialization represents only the no-overflow arm.  When
+    // the concrete walk is already on the overflow arm, defer before emitting
+    // any IR so the generic residual records the authentic W_Long result.
+    // Emitting INT_*_OVF + GUARD_NO_OVERFLOW here would contradict that
+    // result: the bridge would immediately try to prove the freshly boxed
+    // W_IntObject is a W_LongObject and abort on every retry.
+    let overflowed = match op_code {
+        OpCode::IntAddOvf => la.checked_add(rb).is_none(),
+        OpCode::IntSubOvf => la.checked_sub(rb).is_none(),
+        OpCode::IntMulOvf => la.checked_mul(rb).is_none(),
+        _ => false,
+    };
+    if overflowed {
+        return Ok(None);
+    }
+
     // intobject.py range validation (mirror the former int fast path's
     // needs_concrete_check): bail to the generic leg when the bare-IR-op
     // emission would be unsound (zero / INT_MIN-overflow divisor, oversized

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -1605,7 +1605,7 @@ fn seed_loop_entry_ref_slots(
     pcdep: &[(u8, u16, u16)],
     num_vable_scalars: usize,
     mut box_at: impl FnMut(usize) -> Option<majit_ir::OpRef>,
-    mut seed: impl FnMut(u8, majit_ir::OpRef),
+    mut seed: impl FnMut(u8, u16, majit_ir::OpRef),
 ) {
     for &(bank, color, slot) in pcdep {
         if bank != 1 {
@@ -1614,7 +1614,7 @@ fn seed_loop_entry_ref_slots(
         if let Some(opref) = box_at(num_vable_scalars + slot as usize)
             && !opref.is_none()
         {
-            seed(color as u8, opref);
+            seed(color as u8, slot, opref);
         }
     }
 }
@@ -1885,12 +1885,38 @@ fn run_perfn_walk<Sym: WalkSym>(
             if let Some(pcdep) =
                 crate::state::pcdep_trivia_at(pjc.jitcode.index() as i32, entry as i32)
             {
+                let mut live_slot_seeds = Vec::new();
                 seed_loop_entry_ref_slots(
                     &pcdep,
                     nvs,
                     |index| ctx.virtualizable_box_at(index),
-                    &mut seed,
+                    |color, slot, opref| live_slot_seeds.push((color, slot, opref)),
                 );
+                for (color, slot, opref) in live_slot_seeds {
+                    seed(color, opref);
+                    // RPython's MIFrame register is a Box carrying both its
+                    // symbolic identity and recording-time value.  The
+                    // sidecar reconstruction above restores the first half;
+                    // stamp the live PyFrame slot onto the same OpRef so an
+                    // inlined callee receives its concrete argument identity.
+                    // Without this, a dynamic call such as pickle's
+                    // dispatch[key](self) loses `self` at the loop header;
+                    // a raising callee then mutates concrete state but cannot
+                    // recover the exception class, aborting and replaying the
+                    // already-applied mutation.
+                    if cf_addr != 0 {
+                        let frame =
+                            unsafe { &*(cf_addr as *const pyre_interpreter::pyframe::PyFrame) };
+                        if let Some(&value) = frame.locals_w().as_slice().get(slot as usize)
+                            && !value.is_null()
+                        {
+                            ctx.set_opref_concrete(
+                                opref,
+                                majit_ir::Value::Ref(majit_ir::GcRef(value as usize)),
+                            );
+                        }
+                    }
+                }
             }
         }
         // The pcdep inversion above is the complete loop-entry seed.  FOR_ITER
@@ -3702,7 +3728,7 @@ mod tests {
                     .checked_sub(crate::virtualizable_gen::NUM_VABLE_SCALARS)
                     .and_then(|slot| frame_boxes.get(slot).copied())
             },
-            |color, opref| seeded.push((color, opref)),
+            |color, _slot, opref| seeded.push((color, opref)),
         );
 
         assert_eq!(seeded, vec![(7, slot0), (4, slot2)]);

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -1601,6 +1601,24 @@ fn drive_outer_continuation_and_map<Sym: WalkSym>(
     }
 }
 
+fn seed_loop_entry_ref_slots(
+    pcdep: &[(u8, u16, u16)],
+    num_vable_scalars: usize,
+    mut box_at: impl FnMut(usize) -> Option<majit_ir::OpRef>,
+    mut seed: impl FnMut(u8, majit_ir::OpRef),
+) {
+    for &(bank, color, slot) in pcdep {
+        if bank != 1 {
+            continue;
+        }
+        if let Some(opref) = box_at(num_vable_scalars + slot as usize)
+            && !opref.is_none()
+        {
+            seed(color as u8, opref);
+        }
+    }
+}
+
 fn run_perfn_walk<Sym: WalkSym>(
     ctx: &mut TraceCtx,
     sym: &mut Sym,
@@ -1853,10 +1871,31 @@ fn run_perfn_walk<Sym: WalkSym>(
                 }
             }
         }
-        // Loop-trace entry seeds no operand-stack colors.  The codewriter's
-        // `Instruction::ForIter` handler emits `getarrayitem_vable_r` to reload
-        // the iterator from the virtualizable on every iteration, so the
-        // residual consumes that in-loop read rather than an entry register.
+        // A loop trace starts at the per-CodeObject sidecar coordinate near
+        // the loop header, not at the function entry that originally defined
+        // every live MIFrame register.  RPython reaches that header with the
+        // same MIFrame and therefore retains all live register contents.  The
+        // sidecar walk creates a fresh register bank, so reconstruct each
+        // per-PC Ref color from its authoritative slot in the red frame's
+        // virtualizable array before dispatching the header.  This is the
+        // non-bridge counterpart of `setup_bridge_sym`'s color/slot inversion;
+        // without it loop-carried collection operands remain `OpRef::NONE`.
+        if !is_bridge_trace {
+            let nvs = crate::virtualizable_gen::NUM_VABLE_SCALARS;
+            if let Some(pcdep) =
+                crate::state::pcdep_trivia_at(pjc.jitcode.index() as i32, entry as i32)
+            {
+                seed_loop_entry_ref_slots(
+                    &pcdep,
+                    nvs,
+                    |index| ctx.virtualizable_box_at(index),
+                    &mut seed,
+                );
+            }
+        }
+        // The pcdep inversion above is the complete loop-entry seed.  FOR_ITER
+        // also emits an in-loop `getarrayitem_vable_r`, so its iterator is
+        // refreshed from the same frame owner on every iteration.
         //
         // #124: a bridge enters mid-body, where the loop-header merge-point
         // colors seeded above (the loop's green pycode / red frame+ec) are
@@ -3639,6 +3678,34 @@ mod tests {
             None,
             "a sidecar after the marker must not bind an earlier sibling marker"
         );
+    }
+
+    #[test]
+    fn loop_sidecar_seeds_ref_colors_from_live_frame_slots() {
+        let slot0 = majit_ir::OpRef::input_arg_typed(3, majit_ir::Type::Ref);
+        let slot2 = majit_ir::OpRef::input_arg_typed(4, majit_ir::Type::Ref);
+        let none = majit_ir::OpRef::NONE;
+        let frame_boxes = [slot0, none, slot2];
+        let pcdep = [
+            (1, 7, 0),
+            (0, 8, 1), // Int bank is not a Ref seed.
+            (1, 9, 1), // An absent frame slot stays absent.
+            (1, 4, 2),
+        ];
+        let mut seeded = Vec::new();
+
+        super::seed_loop_entry_ref_slots(
+            &pcdep,
+            crate::virtualizable_gen::NUM_VABLE_SCALARS,
+            |index| {
+                index
+                    .checked_sub(crate::virtualizable_gen::NUM_VABLE_SCALARS)
+                    .and_then(|slot| frame_boxes.get(slot).copied())
+            },
+            |color, opref| seeded.push((color, opref)),
+        );
+
+        assert_eq!(seeded, vec![(7, slot0), (4, slot2)]);
     }
 
     #[test]

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -340,6 +340,8 @@ unsafe fn type_object_custom_trace(obj_addr: usize, f: &mut dyn FnMut(*mut majit
     let t = unsafe { &mut *(obj_addr as *mut pyre_object::typeobject::W_TypeObject) };
     f(&mut t.ob_header.w_class as *mut pyre_object::PyObjectRef as *mut majit_ir::GcRef);
     f(&mut t.bases as *mut pyre_object::PyObjectRef as *mut majit_ir::GcRef);
+    f(&mut t.w_name as *mut pyre_object::PyObjectRef as *mut majit_ir::GcRef);
+    f(&mut t.w_qualname as *mut pyre_object::PyObjectRef as *mut majit_ir::GcRef);
     // `name` points at a GC-managed leaf storage box (`String`, off-GC storage
     // epic S5) for a mortal heap type; forward the field slot so a major GC greys
     // the box, and the box tid's drop glue reclaims the buffer on sweep. An

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -6629,6 +6629,23 @@ fn handle_fail(
     guard_exc: i64,
     _info: &majit_metainterp::virtualizable::VirtualizableInfo,
 ) -> HandleFailOutcome {
+    // A failure reported through a retired/inlined source descr can belong to
+    // an invalidated JitCellToken even while the outer entry token is still
+    // installed.  PyPy cannot make that namespace mistake: the live
+    // MIFrame/looptoken path that contains GUARD_NOT_INVALIDATED is itself
+    // revoked from warm entry.  Revoke the actual entry token as well before
+    // resuming, so the next back-edge warms and compiles against the new
+    // quasi-immutable value instead of re-entering the stale containing
+    // machine trace on every iteration.
+    if descr_arc
+        .as_fail_descr()
+        .and_then(majit_backend::descr_owning_jct)
+        .is_some_and(|token| token.is_invalidated())
+    {
+        let (driver, _) = driver_pair();
+        driver.invalidate_loop(green_key);
+    }
+
     // The range FOR_ITER `GuardClass(RANGE_ITER)` proves its own site
     // polymorphic on the first failure.  The failing descr carries the
     // FOR_ITER green key it protects (`range_foriter_green_key`), stamped

--- a/pyre/pyre-macros/src/lib.rs
+++ b/pyre/pyre-macros/src/lib.rs
@@ -1529,7 +1529,10 @@ fn expand_pyre_methods(
     if has_init && !has_new {
         let synth: ImplItem = parse_quote! {
             #[staticmethod]
-            fn __new__(_cls: ::pyre_object::PyObjectRef) -> ::pyre_object::PyObjectRef {
+            fn __new__(
+                _cls: ::pyre_object::PyObjectRef,
+                _args: &[::pyre_object::PyObjectRef],
+            ) -> ::pyre_object::PyObjectRef {
                 <#self_ty>::allocate(<#self_ty as ::std::default::Default>::default())
             }
         };
@@ -1975,12 +1978,12 @@ fn expand_pyre_methods(
 
     let type_object_fn = quote! {
         pub fn type_object() -> ::pyre_object::PyObjectRef {
-            thread_local! {
-                static CELL: ::std::cell::OnceCell<::pyre_object::PyObjectRef>
-                    = const { ::std::cell::OnceCell::new() };
-            }
-            CELL.with(|c| {
-                *c.get_or_init(|| {
+            // PyPy TypeDef objects are interpreter/process-owned, never
+            // execution-context or thread-local.  Store the immortal pointer
+            // as usize so the process-global cache remains Sync without
+            // duplicating Python type identity per thread.
+            static CELL: ::std::sync::OnceLock<usize> = ::std::sync::OnceLock::new();
+            *CELL.get_or_init(|| {
                     let tp = crate::typedef::make_builtin_type_with_layout(
                         <#self_ty as ::pyre_object::lltype::PyreClassPyTypeOf>::PYNAME,
                         |ns| { #(#registrations)* },
@@ -1993,9 +1996,8 @@ fn expand_pyre_methods(
                         },
                         tp,
                     );
-                    tp
-                })
-            })
+                    tp as usize
+                }) as ::pyre_object::PyObjectRef
         }
     };
 

--- a/pyre/pyre-object/src/dictmultiobject.rs
+++ b/pyre/pyre-object/src/dictmultiobject.rs
@@ -2167,6 +2167,21 @@ unsafe fn w_dict_store_checked_inner(
         strategy.switch_to_object_strategy(obj);
         return w_dict_store_object_strategy_checked_inner(obj, key, value, hash);
     }
+    if strategy.strategy_kind() == StrategyKind::Map {
+        // mapdict.py:1177-1183 MapDictStrategy.setitem — exact str keys stay
+        // as map nodes; every other key first devolves the instance __dict__
+        // to ObjectDictStrategy and then performs the ordinary fallible dict
+        // insertion.  Calling the trait's infallible `setitem` here would make
+        // that second leg use `object_key_for`, which deliberately consumes a
+        // `__hash__` exception.  Keep the checked W_DictMultiObject.setitem
+        // path checked across the strategy transition instead.
+        if crate::is_exact_type(key, &crate::STR_TYPE) {
+            strategy.setitem(obj, key, value);
+            return Ok(());
+        }
+        strategy.switch_to_object_strategy(obj);
+        return w_dict_store_object_strategy_checked_inner(obj, key, value, hash);
+    }
     strategy.setitem(obj, key, value);
     if take_dict_key_error() {
         return Err(DictKeyError);
@@ -2805,6 +2820,82 @@ pub unsafe fn w_dict_delitem_checked(
         return Err(DictKeyError);
     }
     Ok(removed)
+}
+
+/// `dictmultiobject.py:213-219 W_DictMultiObject.nondescr_delitem_if_value_is`
+/// / `rordereddict.py:863 ll_dict_delitem_if_value_is`: perform one key probe
+/// and remove the matched entry only when its current value is pointer-identical
+/// to `value`.
+pub unsafe fn w_dict_delitem_if_value_is_checked(
+    obj: PyObjectRef,
+    key: PyObjectRef,
+    value: PyObjectRef,
+) -> Result<bool, DictKeyError> {
+    if is_module_dict(obj) {
+        if !w_module_dict_is_object_strategy(obj) {
+            w_module_dict_switch_to_object_strategy(obj);
+        }
+        let object_key = object_key_for_checked(key)?;
+        if let Some(result) = callback_free_dict_op(|| {
+            let entries = w_module_dict_object_storage_mut(obj);
+            let Some(index) = entries.get_index_of(&object_key) else {
+                return false;
+            };
+            if entries
+                .get_index(index)
+                .is_none_or(|(_, stored)| *stored != value)
+            {
+                return false;
+            }
+            entries.shift_remove_index(index);
+            let strategy = &mut *(*(obj as *mut W_ModuleDictObject)).mstrategy;
+            strategy.mutated();
+            w_dict_bump_keys_version(obj);
+            true
+        }) {
+            return result;
+        }
+        return Err(DictKeyError);
+    }
+
+    let strategy = (*(obj as *const W_DictObject)).dstrategy;
+    if strategy.strategy_kind() != StrategyKind::Object {
+        strategy.switch_to_object_strategy(obj);
+    }
+    let object_key = object_key_for_checked(key)?;
+    if let Some(result) = callback_free_dict_op(|| {
+        let dict = &mut *(obj as *mut W_DictObject);
+        let entries = &mut *(dict.dstorage as *mut indexmap::IndexMap<ObjectKey, PyObjectRef>);
+        let Some(index) = entries.get_index_of(&object_key) else {
+            return false;
+        };
+        if entries
+            .get_index(index)
+            .is_none_or(|(_, stored)| *stored != value)
+        {
+            return false;
+        }
+        entries.shift_remove_index(index);
+        dict.keys_version = dict.keys_version.wrapping_add(1);
+        true
+    }) {
+        return result;
+    }
+    let (found, _) = scan_dict_key_reentrant(obj, object_key)?;
+    let Some(index) = found else {
+        return Ok(false);
+    };
+    let dict = &mut *(obj as *mut W_DictObject);
+    let entries = &mut *(dict.dstorage as *mut indexmap::IndexMap<ObjectKey, PyObjectRef>);
+    if entries
+        .get_index(index)
+        .is_none_or(|(_, stored)| *stored != value)
+    {
+        return Ok(false);
+    }
+    entries.shift_remove_index(index);
+    dict.keys_version = dict.keys_version.wrapping_add(1);
+    Ok(true)
 }
 
 /// Internal helper: `ObjectDictStrategy::delitem` body for pyre's

--- a/pyre/pyre-object/src/generator.rs
+++ b/pyre/pyre-object/src/generator.rs
@@ -382,6 +382,12 @@ pub unsafe fn w_coroutine_get_origin(obj: PyObjectRef) -> PyObjectRef {
 }
 
 #[inline]
+pub unsafe fn w_coroutine_set_origin(obj: PyObjectRef, origin: PyObjectRef) {
+    unsafe { (*(obj as *mut GeneratorIterator)).cr_origin = origin };
+    crate::gc_hook::try_gc_write_barrier(obj as *mut u8);
+}
+
+#[inline]
 pub unsafe fn w_async_generator_hooks_inited(obj: PyObjectRef) -> bool {
     unsafe { (*(obj as *const GeneratorIterator)).hooks_inited }
 }

--- a/pyre/pyre-object/src/typeobject.rs
+++ b/pyre/pyre-object/src/typeobject.rs
@@ -101,9 +101,16 @@ pub struct W_TypeObject {
     pub ob_header: PyObject,
     /// Class name (heap-allocated, leaked).
     pub name: *mut String,
+    /// App-level `__name__` object.  CPython preserves this object's identity
+    /// (including a str subclass assigned to a heap type); null means the
+    /// initial exact string has not been materialised yet.
+    pub w_name: PyObjectRef,
     /// Qualified class name.  PyPy `W_TypeObject.qualname` is populated by
     /// consuming `__qualname__` from the class namespace at construction.
     pub qualname: *mut String,
+    /// App-level `__qualname__` object, with the same lazy/identity semantics
+    /// as `w_name`.
+    pub w_qualname: PyObjectRef,
     /// Tuple of base type objects (PyObjectRef → W_TupleObject or PY_NULL).
     pub bases: PyObjectRef,
     /// Raw pointer to the class dict backing storage (`dict_w` analogue).
@@ -344,7 +351,9 @@ pub fn w_type_new(name: &str, bases: PyObjectRef, dict_ptr: *mut u8) -> PyObject
         },
         mro_w: std::ptr::null_mut(),
         name,
+        w_name: PY_NULL,
         qualname,
+        w_qualname: PY_NULL,
         bases,
         dict: dict_ptr,
         flag_heaptype: true,
@@ -458,7 +467,9 @@ pub fn w_type_new_builtin(
         },
         mro_w: std::ptr::null_mut(),
         name,
+        w_name: PY_NULL,
         qualname,
+        w_qualname: PY_NULL,
         bases,
         dict: dict_ptr,
         flag_heaptype: false,
@@ -793,12 +804,30 @@ pub unsafe fn w_type_get_name(obj: PyObjectRef) -> &'static str {
     &*(*(obj as *const W_TypeObject)).name
 }
 
+/// Return the stable app-level `type.__name__` object.
+pub unsafe fn w_type_get_name_obj(obj: PyObjectRef) -> PyObjectRef {
+    let t = &mut *(obj as *mut W_TypeObject);
+    if t.w_name.is_null() {
+        let full = &*t.name;
+        let bare = if t.flag_heaptype {
+            full.as_str()
+        } else {
+            full.rsplit('.').next().unwrap_or(full)
+        };
+        t.w_name = crate::w_str_new(bare);
+    }
+    t.w_name
+}
+
 /// Replace the class name (`descr_set__name__`, typeobject.py:1058
 /// `w_type.name = name`).  `name` is an owned `String` behind a raw
 /// pointer (`malloc_raw` = boxed); assigning through it drops the old
 /// name and installs the new one, leaving the slot itself unchanged.
-pub unsafe fn w_type_set_name(obj: PyObjectRef, name: &str) {
-    *(*(obj as *mut W_TypeObject)).name = name.to_string();
+pub unsafe fn w_type_set_name(obj: PyObjectRef, w_name: PyObjectRef) {
+    let t = &mut *(obj as *mut W_TypeObject);
+    *t.name = crate::w_str_get_value(w_name).to_string();
+    t.w_name = w_name;
+    crate::gc_hook::try_gc_write_barrier(obj as *mut u8);
 }
 
 /// `typeobject.py:223-235` / `getqualname`: the class qualified name lives
@@ -807,8 +836,20 @@ pub unsafe fn w_type_get_qualname(obj: PyObjectRef) -> &'static str {
     &*(*(obj as *const W_TypeObject)).qualname
 }
 
-pub unsafe fn w_type_set_qualname(obj: PyObjectRef, qualname: &str) {
-    *(*(obj as *mut W_TypeObject)).qualname = qualname.to_string();
+/// Return the stable app-level `type.__qualname__` object.
+pub unsafe fn w_type_get_qualname_obj(obj: PyObjectRef) -> PyObjectRef {
+    let t = &mut *(obj as *mut W_TypeObject);
+    if t.w_qualname.is_null() {
+        t.w_qualname = crate::w_str_new(&*t.qualname);
+    }
+    t.w_qualname
+}
+
+pub unsafe fn w_type_set_qualname(obj: PyObjectRef, w_qualname: PyObjectRef) {
+    let t = &mut *(obj as *mut W_TypeObject);
+    *t.qualname = crate::w_str_get_value(w_qualname).to_string();
+    t.w_qualname = w_qualname;
+    crate::gc_hook::try_gc_write_barrier(obj as *mut u8);
 }
 
 /// Get the bases tuple.

--- a/pyre/pyre-object/src/typeobject.rs
+++ b/pyre/pyre-object/src/typeobject.rs
@@ -279,32 +279,36 @@ pub fn leak_layout(layout: Layout) -> *const Layout {
     crate::lltype::malloc_raw(layout)
 }
 
-thread_local! {
-    /// Builtin types (`w_type_new_builtin`) are created before the GC is
-    /// built and remain `malloc_typed` Box-immortal, so the collector never
-    /// fires their `W_TYPE_GC_TYPE_ID` custom trace.  Their namespaces can
-    /// still acquire young GC children after boot, including type-dict values
-    /// and subclass weakrefs. This registry
-    /// roots those children on each collection.  It also covers the rare
-    /// pre-GC immortal fallback from `w_type_new` when no GC hook is installed.
-    /// Heap types allocated after GC startup are GC-managed instead and are
-    /// rooted through their own `W_TYPE_GC_TYPE_ID` custom trace.
-    static BUILTIN_TYPE_NAMESPACE_ROOTS: std::cell::RefCell<Vec<usize>> =
-        std::cell::RefCell::new(Vec::new());
+/// Builtin types (`w_type_new_builtin`) are process-global, so their root
+/// registry must have the same owner.  A TLS registry loses types first made
+/// on a worker and makes a collection on another thread miss their children.
+static BUILTIN_TYPE_NAMESPACE_ROOTS: std::sync::OnceLock<std::sync::Mutex<Vec<usize>>> =
+    std::sync::OnceLock::new();
+
+fn builtin_type_namespace_roots() -> &'static std::sync::Mutex<Vec<usize>> {
+    BUILTIN_TYPE_NAMESPACE_ROOTS.get_or_init(|| std::sync::Mutex::new(Vec::new()))
 }
 
 /// Record an immortal type for the collection-time namespace root walk.
+#[majit_macros::dont_look_inside]
 fn register_builtin_type_roots(addr: usize) {
     // Record the prebuilt-family store so the next minor collection scans it
     // (gc_roots.rs prebuilt-root write tracking).
     crate::gc_roots::mark_prebuilt_roots_dirty();
-    BUILTIN_TYPE_NAMESPACE_ROOTS.with(|reg| reg.borrow_mut().push(addr));
+    builtin_type_namespace_roots()
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .push(addr);
 }
 
 /// Snapshot the registered immortal-type addresses for the root walker
 /// (`pyre_interpreter::eval::walk_builtin_type_dicts_gc`).
+#[majit_macros::dont_look_inside]
 pub fn snapshot_builtin_type_roots() -> Vec<usize> {
-    BUILTIN_TYPE_NAMESPACE_ROOTS.with(|reg| reg.borrow().clone())
+    builtin_type_namespace_roots()
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .clone()
 }
 
 /// Allocate a new W_TypeObject with `flag_heaptype = true`.
@@ -815,6 +819,7 @@ pub unsafe fn w_type_get_name_obj(obj: PyObjectRef) -> PyObjectRef {
             full.rsplit('.').next().unwrap_or(full)
         };
         t.w_name = crate::w_str_new(bare);
+        crate::gc_hook::try_gc_write_barrier(obj as *mut u8);
     }
     t.w_name
 }
@@ -841,6 +846,7 @@ pub unsafe fn w_type_get_qualname_obj(obj: PyObjectRef) -> PyObjectRef {
     let t = &mut *(obj as *mut W_TypeObject);
     if t.w_qualname.is_null() {
         t.w_qualname = crate::w_str_new(&*t.qualname);
+        crate::gc_hook::try_gc_write_barrier(obj as *mut u8);
     }
     t.w_qualname
 }


### PR DESCRIPTION
## Summary
- complete copy and enum compatibility paths
- finish weakref behavior and type metadata
- implement `_opcode` classifiers, metadata tables, and stack effects
- restore `dis` argument decoding and `inspect.getclosurevars`

## Validation
- `_opcode` unittest: 7 passed
- `inspect.getclosurevars`: 10 passed
- copy/enum/weakref regression snippets passed
- LLBC re-extracted for pyre-object, pyre-interpreter, and pyre-jit
- dynasm JIT prepass/build passed
- cargo check/test and CI follow on this branch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for coroutine origin tracking and asynchronous generator hooks through `sys`.
  * Improved `typing.Union` construction and introspection, including nested union handling.
  * Implemented opcode metadata, validation, stack-effect calculations, and special-method listings.
  * Added functional weak-reference cleanup and standard CPython-compatible weak-reference type names.

* **Bug Fixes**
  * Improved class names, qualified names, documentation, representations, slots, and metaclass behavior.
  * Corrected cyclic comparisons, frame locals handling, float subclass storage, and garbage-collection tracking.
  * Expanded compatibility with `copy`, `enum`, `inspect`, and `weakref` standard-library behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->