### PR TITLE
Add a bridge-recursion overflow parity fixture

### DIFF
--- a/pyre/bench/synth/bridge_recursion_overflow.py
+++ b/pyre/bench/synth/bridge_recursion_overflow.py
@@ -1,0 +1,20 @@
+# Parity fixture for the depth-1 bridge self-recursive inline lift
+# (PYRE_FBW_BRIDGE_REC_INLINE, default on, #704). `f` is a tail-recursive
+# exact-integer callee whose `acc * 2 + 1` crosses the machine-int boundary
+# partway down the recursion, so an overflow guard fires inside the frame the
+# lift inlines on a guard-failure bridge. #704's A/B ran on `fib`, which never
+# overflows, so this shape — an overflow-guard resume in a bridge-inlined
+# recursive frame — was unexercised. Byte-parity against CPython/PyPy here
+# guards its resume against a silent wrong-answer regression. No max-pypy-ratio
+# gate: with the lift on this shape admits an abort that folds back to residual
+# (perf-neutral-to-negative), so the signal is correctness, not speed.
+def f(n, acc):
+    if n == 0:
+        return acc
+    return f(n - 1, acc * 2 + 1)
+
+
+out = []
+for i in range(300):
+    out.append(f(64, i) % 1000000007)
+print(out[0], out[-1], sum(out) % 1000000007)


### PR DESCRIPTION
## Summary

Adds a synthetic parity fixture for the depth-1 bridge self-recursive inline
lift (`PYRE_FBW_BRIDGE_REC_INLINE`, default on) landed in #704.

#704's A/B was validated on `fib`, which never overflows the machine int, so it
never exercised an overflow guard inside the bridge-inlined recursive frame.
This fixture closes that gap: a tail-recursive exact-integer callee whose
`acc * 2 + 1` crosses the machine-int boundary partway down the recursion, so a
`GuardNoOverflow` resumes inside the frame the lift inlines on a guard-failure
bridge. The synthetic parity suite runs it byte-exact against CPython/PyPy on
each backend, so a silent overflow-guard resume miscompile on that shape fails
the check.

No `# pyre-check: max-pypy-ratio=` gate: with the lift on, this exact shape
admits an abort that folds back to residual (`loops_aborted` 0→6 vs the residual
path's single clean bridge), so it is perf-neutral-to-negative — a correctness
fixture, not a timing gate.

## Verification

- `check.py --backend dynasm --synthetic-pattern bridge_recursion_overflow.py`:
  PASS.
- `check.py --backend cranelift ...`: PASS.
- CPython == PyPy == backend output (byte-exact); dynasm 286-suite unaffected.
- Non-vacuous + lift-sensitive: `loops_aborted=6` with the lift on vs `1` with
  `PYRE_FBW_BRIDGE_REC_INLINE=0` — the fixture exercises exactly the shape the
  lift admits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
