### PR TITLE
jit: FBW tracer robustness follow-ups (establish_nullity, vable stack-slot writes, binop_ref fold)

### DIFF
--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/arith.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/arith.rs
@@ -311,8 +311,8 @@ pub(crate) fn unop_int_record<Sym: WalkSym>(
 /// `pyjitpl.py` exec-generated `opimpl_ptr_eq` /
 /// `opimpl_ptr_ne` (and instance variants) follow `self.execute(rop.<OPNUM>,
 /// b1, b2)` — both `b1`/`b2` are ref boxes, result is an int box. The
-/// `b1 is b2` fast path is omitted (same rationale as `binop_int_record`'s
-/// comparison family — pyre's recorder shares constants by value).
+/// `b1 is b2` fast path folds via `FASTPATHS_SAME_BOXES`; distinct operands
+/// record and then stamp the bool from the operands' concrete carriers.
 pub(crate) fn binop_ref_to_int_record<Sym: WalkSym>(
     code: &[u8],
     op: &DecodedOp,
@@ -334,16 +334,35 @@ pub(crate) fn binop_ref_to_int_record<Sym: WalkSym>(
         return Ok((DispatchOutcome::Continue, op.next_pc));
     }
     let result = ctx.trace_ctx.record_op(opcode, &[a, b]);
-    // Box(value) parity: stamp the bool result from the operands' Box.value
-    // carriers (matches dispatch.rs trace_binop_r_to_i).
-    if let (Some(majit_ir::Value::Ref(la)), Some(majit_ir::Value::Ref(rb))) =
+    // Stamp the bool result from the operands' concrete carriers: the
+    // `box_value` carrier first, then the `concrete_registers_r` shadow. The
+    // shadow is a distinct channel from `box_value` and the primary carrier
+    // for inline-callee params (whose OpRef has no `set_opref_concrete`
+    // stamp), so without this fallback a materialized `is`/`is not` on a
+    // shadow-only ref operand left the bool symbolic and a downstream
+    // `goto_if_not` declined. Matches the sibling fallbacks in
+    // `record_ptr_cmp` and `ptr_nullity_record`.
+    let folded = if let (Some(majit_ir::Value::Ref(la)), Some(majit_ir::Value::Ref(rb))) =
         (ctx.trace_ctx.box_value(a), ctx.trace_ctx.box_value(b))
     {
-        let folded = match opcode {
+        Some(match opcode {
             OpCode::PtrEq | OpCode::InstancePtrEq => (la == rb) as i64,
             OpCode::PtrNe | OpCode::InstancePtrNe => (la != rb) as i64,
             _ => panic!("binop_ref_to_int_record: unsupported opcode {opcode:?}"),
-        };
+        })
+    } else if let (ConcreteValue::Ref(la), ConcreteValue::Ref(rb)) = (
+        read_ref_reg_concrete(code, op, 0, ctx),
+        read_ref_reg_concrete(code, op, 1, ctx),
+    ) {
+        Some(match opcode {
+            OpCode::PtrEq | OpCode::InstancePtrEq => (la == rb) as i64,
+            OpCode::PtrNe | OpCode::InstancePtrNe => (la != rb) as i64,
+            _ => panic!("binop_ref_to_int_record: unsupported opcode {opcode:?}"),
+        })
+    } else {
+        None
+    };
+    if let Some(folded) = folded {
         ctx.trace_ctx
             .set_opref_concrete(result, majit_ir::Value::Int(folded));
     }

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
@@ -7273,6 +7273,13 @@ fn fused_goto_if_not_int<Sym: WalkSym>(
 /// stays walker-side because resume snapshots are —
 /// `walker_emit_guard_with_snapshot` is the walk's `generate_guard`.
 ///
+/// The heapcache check runs before `box.nonnull()`: upstream reads the
+/// concrete pointer unconditionally, but the walker knows it only through
+/// the concrete shadow, which may be absent even when a prior guard already
+/// proved the box's nullity. Consulting the cache first keeps the known
+/// answer from being lost to a missing shadow (the value is read lazily only
+/// on a cache miss).
+///
 /// Returns `box.nonnull()`.
 fn establish_nullity<Sym: WalkSym>(
     code: &[u8],
@@ -7280,19 +7287,13 @@ fn establish_nullity<Sym: WalkSym>(
     ctx: &mut WalkContext<'_, '_, Sym>,
     boxref: OpRef,
 ) -> Result<bool, DispatchError> {
-    // `box.nonnull()` reads the pointer itself. The walker knows it only
-    // through the concrete shadow, and an absent shadow is not evidence of
-    // either nullity, so decline rather than guess the branch direction.
-    let ConcreteValue::Ref(ptr) = read_ref_reg_concrete(code, op, 0, ctx) else {
-        return Err(DispatchError::UnsupportedOpname {
-            pc: op.pc,
-            key: op.key,
-        });
-    };
-    let value = !ptr.is_null();
     // Pyre's `is_nullity_known` splits upstream's boolean into which side is
-    // known (`Some(true)` non-null, `Some(false)` null, `None` unknown), so
-    // upstream's "is it known at all" test is `is_some`.
+    // known (`Some(true)` non-null, `Some(false)` null, `None` unknown). When
+    // the nullity is already known, the stored side *is* `box.nonnull()` — an
+    // SSA box's nullity is immutable — so the heapcache answers the branch
+    // without reading the pointer. This is consulted before the concrete
+    // shadow so a box whose nullity a prior guard proved still resolves even
+    // when its Ref shadow is absent.
     let known = ctx.trace_ctx.heap_cache().is_nullity_known(boxref, |op| {
         op.inline_const_to_value().and_then(|v| match v {
             Value::Int(n) => Some(n),
@@ -7300,13 +7301,24 @@ fn establish_nullity<Sym: WalkSym>(
             _ => None,
         })
     });
-    if known.is_some() {
+    if let Some(value) = known {
         ctx.trace_ctx.profiler().count_ops(
             OpCode::GuardNonnull,
             majit_metainterp::counters::HEAPCACHED_OPS,
         );
         return Ok(value);
     }
+    // Nullity not yet known: `box.nonnull()` reads the pointer itself. The
+    // walker knows it only through the concrete shadow, and an absent shadow
+    // is not evidence of either nullity, so decline rather than guess the
+    // branch direction.
+    let ConcreteValue::Ref(ptr) = read_ref_reg_concrete(code, op, 0, ctx) else {
+        return Err(DispatchError::UnsupportedOpname {
+            pc: op.pc,
+            key: op.key,
+        });
+    };
+    let value = !ptr.is_null();
     if value {
         // A known class already implies non-null, so the guard is redundant.
         if !ctx.trace_ctx.heap_cache().is_class_known(boxref) {

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/tests.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/tests.rs
@@ -1069,6 +1069,41 @@ fn fused_ptr_compare_uses_ref_shadows_for_the_runtime_direction() {
 }
 
 #[test]
+fn ptr_eq_folds_from_the_ref_shadow_when_box_value_is_absent() {
+    // A non-fused `ptr_eq/rr>i` whose operands carry a concrete only in the
+    // ref-register shadow (box_value absent — the inline-callee-param case)
+    // must still fold the bool result, matching the fused twin and
+    // ptr_nullity. Without the shadow fallback the bool stayed symbolic and a
+    // downstream goto_if_not declined.
+    let byte = *insns_opname_to_byte()
+        .get("ptr_eq/rr>i")
+        .expect("`ptr_eq/rr>i` must be in insns table");
+    // `rr>i`: 1B r-src1 + 1B r-src2 + 1B i-dst.
+    let code = [byte, 0x00, 0x01, 0x00];
+    let mut tc = TraceCtx::for_test_types(&[Type::Ref, Type::Ref]);
+    let a = OpRef::input_arg_ref(0);
+    let b = OpRef::input_arg_ref(1);
+    assert_eq!(
+        tc.box_value(a),
+        None,
+        "an input-arg ref has no box_value carrier"
+    );
+    let mut regs_r = [a, b];
+    let mut regs_i = [OpRef::None];
+    let pa = 0xdead_0000_usize as *mut pyre_object::pyobject::PyObject;
+    let pb = 0xbeef_0000_usize as *mut pyre_object::pyobject::PyObject;
+    let mut concrete_r = [ConcreteValue::Ref(pa), ConcreteValue::Ref(pb)];
+    let (_, next_pc) = run_hint_step(&code, &mut tc, &mut regs_r, &mut concrete_r, &mut regs_i)
+        .expect("ptr_eq must record from the ref shadow");
+    assert_eq!(next_pc, 4);
+    assert_eq!(
+        tc.concrete_of_opref(regs_i[0]),
+        Some(majit_ir::Value::Int(0)),
+        "distinct shadow pointers fold PtrEq to false without a box_value carrier",
+    );
+}
+
+#[test]
 fn hint_force_virtualizable_is_a_noop_without_virtualizable_info() {
     let byte = *insns_opname_to_byte()
         .get("hint_force_virtualizable/r")

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/tests.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/tests.rs
@@ -1185,6 +1185,35 @@ fn goto_if_not_ptr_nonzero_declines_without_a_concrete() {
 }
 
 #[test]
+fn goto_if_not_ptr_nonzero_uses_known_nonnull_heapcache_without_a_ref_shadow() {
+    let byte = *insns_opname_to_byte()
+        .get("goto_if_not_ptr_nonzero/rL")
+        .expect("`goto_if_not_ptr_nonzero/rL` must be in insns table");
+    // `rL`: 1B ref reg + 2B label (target 9).
+    let code = [byte, 0x00, 0x09, 0x00];
+    let mut tc = fresh_trace_ctx();
+    let operand = tc.record_op(majit_ir::OpCode::New, &[]);
+    tc.heap_cache_mut().new_object(operand);
+    let ops_before = tc.num_ops();
+    let mut regs_r = [operand];
+    // The Ref shadow is absent, yet the heapcache already proved non-nullness.
+    // `_establish_nullity` answers from the cache before demanding a pointer.
+    let mut concrete_r = [ConcreteValue::Null];
+    let (outcome, next_pc) = run_hint_step(&code, &mut tc, &mut regs_r, &mut concrete_r, &mut [])
+        .expect("a heapcache-known non-null box needs no ref shadow");
+    assert_eq!(outcome, DispatchOutcome::Continue);
+    assert_eq!(
+        next_pc, 4,
+        "a known non-null pointer falls through without reading a shadow"
+    );
+    assert_eq!(
+        tc.num_ops(),
+        ops_before,
+        "the heapcache-known fast path emits no nullity guard"
+    );
+}
+
+#[test]
 fn raw_load_i_records_the_load_against_the_descr() {
     let byte = *insns_opname_to_byte()
         .get("raw_load_i/iid>i")

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -664,11 +664,20 @@ pub(crate) fn write_stack_slot(
         // wrapint/wrapfloat emitted a NewWithVtable OpRef without
         // allocating yet — update only the OpRef half so
         // synchronize_virtualizable keeps writing the existing W_Root.
+        //
+        // The `has_virtualizable_shadow()` guard is a shadow-ownership
+        // safeguard: an owner (`owns_virtualizable_shadow()`) normally seeds
+        // both halves, but the disabled-concrete-shadow state (owner seeded
+        // with no live values — the init-before-run path) leaves
+        // `virtualizable_values` absent. Writing only the OpRef half there
+        // matches that state's contract (`virtualizable_entry_at` returns
+        // None, readers use the zero placeholder) and mirrors the #699 guard
+        // on `mirror_vable_static_to_boxes`.
         match concrete.to_ir_ref_value() {
-            Some(v) => {
+            Some(v) if ctx.has_virtualizable_shadow() => {
                 ctx.set_virtualizable_entry_at(flat_idx, boxed, v);
             }
-            None => {
+            _ => {
                 ctx.set_virtualizable_box_at(flat_idx, boxed);
             }
         }
@@ -860,6 +869,18 @@ pub(crate) fn swap_stack_slots(
         ) {
             ctx.set_virtualizable_entry_at(flat_top, op_other, val_other);
             ctx.set_virtualizable_entry_at(flat_other, op_top, val_top);
+        } else if let (Some(op_top), Some(op_other)) = (
+            ctx.virtualizable_box_at(flat_top),
+            ctx.virtualizable_box_at(flat_other),
+        ) {
+            // Disabled-concrete-shadow owner (seeded with no live values):
+            // `virtualizable_entry_at` returns None because
+            // `virtualizable_values` is absent, so the pair-read above fails
+            // even though the boxes exist. Swap only the OpRef halves, the
+            // sole readers in that state, matching the disabled-shadow
+            // contract (see `write_stack_slot`).
+            ctx.set_virtualizable_box_at(flat_top, op_other);
+            ctx.set_virtualizable_box_at(flat_other, op_top);
         } else {
             panic!(
                 "swap_stack_slots: missing virtualizable_boxes entries for stack slots {top_idx} and {other_idx}"
@@ -3569,6 +3590,51 @@ mod tests {
         }
 
         assert_eq!(unsafe { &*frame.ctx }.num_ops(), before);
+    }
+
+    #[test]
+    fn stack_slot_writers_degrade_to_opref_only_when_concrete_shadow_disabled() {
+        // A disabled-concrete-shadow owner (`owns_virtualizable_shadow()` true
+        // but `virtualizable_values` absent — the init-before-run seed state)
+        // must update only the OpRef half of the vable shadow instead of
+        // panicking in `set_virtualizable_entry_at`. Production never reaches
+        // this state; the guard hardens the incidental owns/values coupling.
+        let nvs = crate::virtualizable_gen::NUM_VABLE_SCALARS;
+        let mut ctx = TraceCtx::for_test_types(&[Type::Ref]);
+        let info = crate::frame_layout::build_pyframe_virtualizable_info();
+        let placeholder = ctx.const_ref(0);
+        // Boxes cover stack slots 0 and 1 at `nlocals == 0`; the empty values
+        // slice disables the concrete shadow.
+        let boxes = vec![placeholder; nvs + 4];
+        ctx.set_virtualizable_boxes_with_info(boxes, Vec::new(), &info, &[4]);
+        assert!(
+            !ctx.has_virtualizable_shadow(),
+            "empty values must disable the concrete shadow",
+        );
+
+        let mut sym = PyreSym::new_uninit(OpRef::NONE);
+        sym.bridge_local_oprefs = Some(Vec::new()); // owns via the bridge half
+        sym.nlocals = 0;
+        sym.registers_r = vec![OpRef::NONE; 2]; // swap's semantic mirror needs both slots
+        assert!(sym.owns_virtualizable_shadow());
+
+        let ptr = 0xdead_beef_usize as *mut pyre_object::pyobject::PyObject;
+        let boxed0 = ctx.const_ref(0x1111);
+        let boxed1 = ctx.const_ref(0x2222);
+        // Ref concrete + disabled shadow: OpRef-only write, no panic.
+        write_stack_slot(&mut sym, &mut ctx, 0, boxed0, ConcreteValue::Ref(ptr));
+        write_stack_slot(&mut sym, &mut ctx, 1, boxed1, ConcreteValue::Ref(ptr));
+        assert_eq!(ctx.virtualizable_box_at(nvs), Some(boxed0));
+        assert_eq!(ctx.virtualizable_box_at(nvs + 1), Some(boxed1));
+        assert!(
+            !ctx.has_virtualizable_shadow(),
+            "the values half stays disabled after a Ref push",
+        );
+
+        // Swap degrades to an OpRef-only exchange rather than the entry-pair panic.
+        swap_stack_slots(&mut sym, &mut ctx, 0, 1);
+        assert_eq!(ctx.virtualizable_box_at(nvs), Some(boxed1));
+        assert_eq!(ctx.virtualizable_box_at(nvs + 1), Some(boxed0));
     }
 
     #[test]


### PR DESCRIPTION
Three follow-up robustness fixes on the FBW tracer, stacked on `main`.

### `establish_nullity`: consult heapcache nullity before the ref shadow
`establish_nullity` read the concrete ref shadow before `is_nullity_known`, so a box whose nullity a prior guard already proved declined the `goto_if_not_ptr_nonzero`/`goto_if_not_ptr_iszero` branch whenever its ref shadow was absent. Hoist the `is_nullity_known` check above the shadow demand: on a known side count `HEAPCACHED_OPS` and return `box.nonnull()` (immutable for an SSA box), reading the pointer lazily only when nullity is unknown. Matches `_establish_nullity` and the sibling `assert_not_none/r` arm.

### `trace_opcode`: degrade vable stack-slot writes to the OpRef half when the concrete shadow is absent
`write_stack_slot` and `swap_stack_slots` gate on the sym-level `owns_virtualizable_shadow()`, but the `set_virtualizable_entry_at` path they take needs the ctx-level concrete `virtualizable_values`; when that concrete shadow is disabled they panicked. Degrade to the OpRef half (`set_virtualizable_box_at`) instead, honoring the disabled-shadow contract. Not reachable in production today; defensive, with a regression test.

### `binop_ref_to_int`: fold from the ref-register shadow when `box_value` is absent
`binop_ref_to_int_record` folded a `ptr_eq`/`ptr_ne`/`instance_ptr_eq`/`instance_ptr_ne` only from `box_value`. When both operands carry a concrete ref shadow but no `box_value`, fall back to the ref-register shadow so the compare still folds to a concrete Int.

Tests: `cargo test -p pyre-jit-trace` — 278 passed / 0 failed on both default and `--features dynasm`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
