### PR TITLE
jit: pin typed-array descr bases to the target word

### DIFF
--- a/majit/majit-translate/src/codewriter/assembler.rs
+++ b/majit/majit-translate/src/codewriter/assembler.rs
@@ -3500,7 +3500,9 @@ fn arraydescrof(
             crate::model::ValueType::Ref(_) => (
                 majit_ir::descr::ArrayFlag::Pointer,
                 majit_ir::value::Type::Ref,
-                8,
+                // Pointer elements stride by the target word, not the
+                // build host's.
+                crate::layout::target_word_size(),
             ),
             _ => (
                 majit_ir::descr::ArrayFlag::Unsigned,
@@ -3553,6 +3555,20 @@ fn vable_arraydescrof(
     is_item_signed: bool,
 ) -> crate::jitcode::BhDescr {
     let item_type = value_type_to_ir_type_for_descr(ty);
+    // The runtime block behind a vable array is `FixedObjectArray`: a length
+    // word with items flat at the target word (`FIXED_ARRAY_ITEMS_OFFSET`),
+    // holding word-wide `PyObjectRef` items. An element wider than the word
+    // would need an items-base decision this mint has never had to make
+    // (flat word vs element-aligned — the `TypedItemsBlock` /
+    // `GcTypedArray` split in `call.rs`); fail the build instead of
+    // silently picking a base.
+    assert!(
+        itemsize <= crate::layout::target_word_size(),
+        "vable array itemsize {itemsize} exceeds the target word \
+         {} — the flat-word items base below would under-align it; \
+         decide the items base against the runtime block before widening",
+        crate::layout::target_word_size(),
+    );
     crate::jitcode::BhDescr::Array {
         // A virtualizable frame array is length-prefixed by a single word
         // (`len_offset = Some(0)`), so its items start at the target word — the
@@ -4277,6 +4293,37 @@ mod tests {
     use super::*;
     use crate::flowspace::model::{ConstValue, HostObject};
     use crate::regalloc;
+
+    #[test]
+    fn vable_arraydescrof_pins_the_flat_word_base_for_pointer_items() {
+        // `FixedObjectArray`: length word at 0, word-wide pointer items flat
+        // at the word. On the host both words are `size_of::<usize>()`.
+        let word = crate::layout::target_word_size();
+        let descr = vable_arraydescrof(&crate::model::ValueType::Ref(None), word, false);
+        let crate::jitcode::BhDescr::Array {
+            base_size,
+            itemsize,
+            len_offset,
+            is_array_of_pointers,
+            ..
+        } = descr
+        else {
+            panic!("vable_arraydescrof must mint a BhDescr::Array");
+        };
+        assert_eq!(base_size, word);
+        assert_eq!(itemsize, word);
+        assert_eq!(len_offset, Some(0));
+        assert!(is_array_of_pointers);
+    }
+
+    #[test]
+    #[should_panic(expected = "exceeds the target word")]
+    fn vable_arraydescrof_rejects_items_wider_than_the_word() {
+        // A wider-than-word element would be under-aligned by the flat-word
+        // base; the mint must fail the build rather than pick a base.
+        let word = crate::layout::target_word_size();
+        let _ = vable_arraydescrof(&crate::model::ValueType::Int, word * 2, true);
+    }
 
     #[test]
     fn assembler_error_message_matches_exception_payload() {

--- a/majit/majit-translate/src/codewriter/assembler.rs
+++ b/majit/majit-translate/src/codewriter/assembler.rs
@@ -3554,7 +3554,10 @@ fn vable_arraydescrof(
 ) -> crate::jitcode::BhDescr {
     let item_type = value_type_to_ir_type_for_descr(ty);
     crate::jitcode::BhDescr::Array {
-        base_size: std::mem::size_of::<usize>(),
+        // A virtualizable frame array is length-prefixed by a single word
+        // (`len_offset = Some(0)`), so its items start at the target word — the
+        // build host's word would mis-stride the block on a narrower target.
+        base_size: crate::layout::target_word_size(),
         itemsize,
         len_offset: Some(0),
         type_id: 0,

--- a/majit/majit-translate/src/codewriter/assembler.rs
+++ b/majit/majit-translate/src/codewriter/assembler.rs
@@ -3512,9 +3512,15 @@ fn arraydescrof(
     // descr.py:354/359-362 + symbolic.get_array_token — basesize follows
     // the lltype's nolength flag: nolength → items at offset 0;
     // length-prefixed → items past the header at len_offset + WORD.
+    //
+    // This codewriter-less fallback is shape-only and serves GC arrays, whose
+    // items sit flat at the length word (`GcTypedArray`) — it does NOT
+    // element-align. The word must be the target's, not the host's, so a
+    // cross-target extraction (build host ≠ run target) bakes the right stride;
+    // the `CallControl` path above already routes through `array_items_base`.
     let base_size = match len_offset {
         None => 0,
-        Some(off) => off + std::mem::size_of::<usize>(),
+        Some(off) => off + crate::layout::target_word_size(),
     };
     crate::jitcode::BhDescr::Array {
         base_size,

--- a/majit/majit-translate/src/codewriter/call.rs
+++ b/majit/majit-translate/src/codewriter/call.rs
@@ -1451,6 +1451,21 @@ impl CallControl {
         }
     }
 
+    /// Byte offset of the first item of a `GcTypedArray` — the flat
+    /// `{ len: usize, items: [u8; 0] }` block the guard-resume / blackhole
+    /// materialiser (`allocate_array_struct`) produces and that interior-field
+    /// struct arrays address. Its items always begin at
+    /// `GC_TYPED_ARRAY_ITEMS_OFFSET`, the bare length word, regardless of the
+    /// element's alignment — the opposite of [`Self::array_items_base`], whose
+    /// unboxed `i64` / `f64` list storage (`TypedItemsBlock`) is element-aligned.
+    /// The two coincide on a 64-bit word and diverge on a 32-bit one, where an
+    /// 8-byte element rounds past the 4-byte word: routing a struct array
+    /// through the element-aligned rule would stride its materialised block a
+    /// half-word late.
+    fn gc_typed_array_items_base(&self) -> usize {
+        self.array_header_size
+    }
+
     /// RPython: resolve a struct field's type string.
     /// For `owner::field_name`, returns the full type of the field.
     pub fn field_type(&self, owner: &str, field_name: &str) -> Option<&str> {
@@ -2154,15 +2169,10 @@ impl CallControl {
         // `as Arc<dyn ArrayDescr>` matches the trait-object field type
         // on `SimpleInteriorFieldDescr.array_descr`.
         let item_size = compute_struct_size(self, &elem_name);
-        // Interior-field struct arrays address `GcTypedArray`, a flat
-        // `{ len: usize, items: [u8; 0] }` block whose items always begin at
-        // `GC_TYPED_ARRAY_ITEMS_OFFSET = WORD` regardless of the element's
-        // alignment (both the live block and the guard-resume materialiser
-        // `allocate_array_struct` use that offset). The base must match the
-        // block, so it is the bare word — NOT the element-aligned offset the
-        // list int/float storage (`TypedItemsBlock`, genuinely element-aligned)
-        // needs in `arraydescrof_concrete`.
-        let base_size = self.array_header_size;
+        // Interior-field struct arrays address `GcTypedArray`, whose items sit
+        // flat at the length word — NOT the element-aligned offset the list
+        // int/float storage (`TypedItemsBlock`) needs in `arraydescrof_concrete`.
+        let base_size = self.gc_typed_array_items_base();
         let array_key = majit_ir::descr::LLType::Array(majit_ir::descr::path_hash(array_str));
         let cached: majit_ir::descr::DescrRef = {
             let mut gc = majit_ir::descr::gc_cache().lock().unwrap();
@@ -7424,8 +7434,8 @@ mod tests {
     use super::*;
     use crate::model::{ExitSwitch, FunctionGraph, Link, LinkArg, ValueType, exception_exitcase};
 
-    /// A length-prefixed block puts its items at the length word rounded up to
-    /// the element's alignment. Only a target whose word is narrower than an
+    /// A `TypedItemsBlock` puts its items at the length word rounded up to the
+    /// element's alignment. Only a target whose word is narrower than an
     /// element can tell the two apart: with a 4-byte word, an `i64` item sits
     /// at 8, and addressing it at 4 strides the whole array one half-word
     /// early — every read then returns two packed 32-bit halves. A pointer
@@ -7441,6 +7451,45 @@ mod tests {
         // An unregistered struct element falls back to the word, which every
         // length-prefixed block already satisfies.
         assert_eq!(cc.array_items_base(word, Some("NoSuchStruct"), 24), word);
+
+        // The element-alignment rule is a pure function of `header_end` and the
+        // element, so a 32-bit word is reproducible on this 64-bit host by
+        // passing a 4-byte header_end directly (the scalar path never consults
+        // `target_word_size`). An `i64` / `f64` item rounds past the 4-byte
+        // word to 8; a word-wide pointer and a byte stay put.
+        assert_eq!(cc.array_items_base(4, Some("i64"), 8), 8);
+        assert_eq!(cc.array_items_base(4, Some("f64"), 8), 8);
+        assert_eq!(cc.array_items_base(4, Some("&PyObject"), 4), 4);
+        assert_eq!(cc.array_items_base(4, Some("u8"), 1), 4);
+    }
+
+    /// The two runtime typed-array blocks disagree on where items start, and a
+    /// descr's base must match the block it addresses. `TypedItemsBlock`
+    /// (unboxed list int/float storage) is element-aligned via
+    /// [`CallControl::array_items_base`]; `GcTypedArray` (the resume/blackhole
+    /// materialiser and interior-field struct arrays) is flat at the length
+    /// word via [`CallControl::gc_typed_array_items_base`]. The rules coincide
+    /// on a 64-bit word and part ways on a 32-bit one — the C5 regression was
+    /// routing a struct array through the element-aligned rule, invisible to a
+    /// host-only assertion because both land on 8 here.
+    #[test]
+    fn typed_block_and_gc_typed_array_bases_diverge_on_a_narrow_word() {
+        let cc = CallControl::new();
+        let word = crate::layout::target_word_size();
+
+        // GcTypedArray keeps items flat at the length word, whatever the element.
+        assert_eq!(cc.gc_typed_array_items_base(), word);
+
+        // On this 64-bit host the two rules agree for an 8-byte element…
+        assert_eq!(
+            cc.array_items_base(word, Some("i64"), 8),
+            cc.gc_typed_array_items_base(),
+        );
+        // …but on a 32-bit word (header_end / word = 4) they must not: the
+        // element-aligned block rounds the `i64` up to 8 while GcTypedArray
+        // stays flat at 4.
+        assert_eq!(cc.array_items_base(4, Some("i64"), 8), 8);
+        assert_ne!(cc.array_items_base(4, Some("i64"), 8), 4);
     }
 
     /// `getkind(SingleFloat) == 'int'` (history.py:53): `f32` banks to the

--- a/majit/majit-translate/src/codewriter/jtransform.rs
+++ b/majit/majit-translate/src/codewriter/jtransform.rs
@@ -2407,7 +2407,11 @@ impl<'a> Transformer<'a> {
                     OpKind::FieldRead { base, .. } => base.clone(),
                     _ => unreachable!("rewrite_op_getfield called on non-FieldRead op"),
                 };
-                let itemsize = array_field.array_itemsize.unwrap_or(8);
+                // Vable arrays hold word-wide `PyObjectRef` items; the
+                // default must be the target word, not the build host's.
+                let itemsize = array_field
+                    .array_itemsize
+                    .unwrap_or_else(crate::layout::target_word_size);
                 let is_signed = array_field.array_is_signed.unwrap_or(false);
                 self.vable_array_vars
                     .insert(result, (base_var, array_field.index, itemsize, is_signed));

--- a/pyre/pyre-jit-trace/build.rs
+++ b/pyre/pyre-jit-trace/build.rs
@@ -330,12 +330,14 @@ fn real_main() {
                     .map(|(name, idx)| {
                         // virtualizable.py:58 — VirtualizableInfo.array_descrs[i] =
                         // cpu.arraydescrof(getattr(VTYPE, name).TO). Python frame
-                        // locals are PyObjectRef pointers: itemsize=8, is_signed=false.
+                        // locals are PyObjectRef pointers: itemsize is one
+                        // target word (the build host's word would mis-stride
+                        // `FixedObjectArray` on a narrower target), is_signed=false.
                         majit_translate::VirtualizableFieldDescriptor::new_with_arraydescr(
                             *name,
                             Some(virtualizable_spec::PYFRAME_VABLE_OWNER_ROOT.to_string()),
                             *idx,
-                            8,     // itemsize: PyObjectRef is a pointer
+                            majit_translate::layout::target_word_size(),
                             false, // is_signed: pointers are unsigned
                         )
                     })

--- a/scripts/llbc_extract.py
+++ b/scripts/llbc_extract.py
@@ -151,6 +151,33 @@ def crate_layout_flags(
     return [expand_features(arg, cargo_features) for arg in spec.layout_cargo_args]
 
 
+def features_in_cargo_flags(crate: str, flags: list[str]) -> list[str]:
+    """Feature names a cargo arg list enables, workspace-qualified.
+
+    A bare name is crate-relative (the extraction passes run cargo inside the
+    crate directory) and must be spelled `crate/feature` for the
+    workspace-level `cargo metadata`. `--no-default-features` is ignored:
+    dropping it can only widen the graph, and the fingerprint may
+    over-approximate but must never miss an input.
+    """
+    features: list[str] = []
+    index = 0
+    while index < len(flags):
+        arg = flags[index]
+        if arg in ("--features", "-F") and index + 1 < len(flags):
+            value = flags[index + 1]
+            index += 2
+        elif arg.startswith(("--features=", "-F=")):
+            value = arg.split("=", 1)[1]
+            index += 1
+        else:
+            index += 1
+            continue
+        for feature in value.replace(",", " ").split():
+            features.append(feature if "/" in feature else f"{crate}/{feature}")
+    return features
+
+
 def run_capture(args: list[str], *, cwd: Path) -> str:
     return subprocess.run(
         args,
@@ -172,17 +199,33 @@ def host_triple(root: Path) -> str:
     raise SystemExit("extract-llbc.py: could not determine rustc host triple")
 
 
-_metadata_cache: dict[tuple[str, str], dict] = {}
+_metadata_cache: dict[tuple, dict] = {}
 
 
-def metadata(eng: Engine, cargo_features: str, platform: str) -> dict:
-    """`cargo metadata` filtered to `platform`, memoised per (features, platform).
+def metadata(
+    eng: Engine,
+    cargo_features: str,
+    platform: str,
+    extra_features: tuple[str, ...] = (),
+) -> dict:
+    """`cargo metadata` filtered to `platform`, memoised per full query.
 
     The platform matters: `--filter-platform` drops dependencies gated on other
     targets, so the host's graph does not see a `[target.'cfg(...)']` path dep
     that only the cross-target layout sidecar pass compiles.
+    `extra_features` carries workspace-qualified features a layout sidecar
+    pass enables beyond the host pass (`layout_cargo_args`), so the graph
+    sees the dependencies they pull in. The memo key spans every input that
+    shapes the result — including the engine's workspace root and feature
+    crates, which differ between engines sharing this module.
     """
-    key = (cargo_features, platform)
+    key = (
+        str(eng.root),
+        eng.metadata_feature_crates,
+        cargo_features,
+        platform,
+        extra_features,
+    )
     if key in _metadata_cache:
         return _metadata_cache[key]
 
@@ -193,6 +236,7 @@ def metadata(eng: Engine, cargo_features: str, platform: str) -> dict:
             metadata_features.extend(
                 f"{crate}/{feature}" for crate in eng.metadata_feature_crates
             )
+    metadata_features.extend(extra_features)
 
     args = [
         "cargo",
@@ -229,11 +273,25 @@ def fingerprint_inputs(eng: Engine, crates: list[str], cargo_features: str) -> l
         for name in target_names:
             platforms.update(crate_layout_targets(eng, eng.spec(name)))
 
+        # A layout sidecar pass may enable features the host pass does not
+        # (`layout_cargo_args`); fold them into every metadata query so the
+        # union closure sees the dependencies those features pull in.
+        layout_features: set[str] = set()
+        for name in target_names:
+            spec = eng.spec(name)
+            if spec.layout_cargo_args is not None:
+                layout_features.update(
+                    features_in_cargo_flags(
+                        name, crate_layout_flags(spec, cargo_features, [])
+                    )
+                )
+        extra_features = tuple(sorted(layout_features))
+
         # Never drop a requested target crate, only its excluded dependencies.
         exclude = excluded_packages(eng, crates) - set(target_names)
 
         for platform in sorted(platforms):
-            meta = metadata(eng, cargo_features, platform)
+            meta = metadata(eng, cargo_features, platform, extra_features)
             packages = meta["packages"]
             by_name = {package["name"]: package for package in packages}
             by_id = {package["id"]: package for package in packages}

--- a/scripts/llbc_extract.py
+++ b/scripts/llbc_extract.py
@@ -138,6 +138,19 @@ def charon_crate_flags(spec: CrateSpec, cargo_features: str) -> list[str]:
     return [expand_features(arg, cargo_features) for arg in spec.charon_args]
 
 
+def crate_layout_flags(
+    spec: CrateSpec, cargo_features: str, flags: list[str]
+) -> list[str]:
+    """Cargo args for this crate's layout sidecar passes.
+
+    `layout_cargo_args` when the spec declares them (a cross target usually
+    needs a different feature set), otherwise the host extraction `flags`.
+    """
+    if spec.layout_cargo_args is None:
+        return flags
+    return [expand_features(arg, cargo_features) for arg in spec.layout_cargo_args]
+
+
 def run_capture(args: list[str], *, cwd: Path) -> str:
     return subprocess.run(
         args,
@@ -159,7 +172,20 @@ def host_triple(root: Path) -> str:
     raise SystemExit("extract-llbc.py: could not determine rustc host triple")
 
 
-def metadata(eng: Engine, cargo_features: str) -> dict:
+_metadata_cache: dict[tuple[str, str], dict] = {}
+
+
+def metadata(eng: Engine, cargo_features: str, platform: str) -> dict:
+    """`cargo metadata` filtered to `platform`, memoised per (features, platform).
+
+    The platform matters: `--filter-platform` drops dependencies gated on other
+    targets, so the host's graph does not see a `[target.'cfg(...)']` path dep
+    that only the cross-target layout sidecar pass compiles.
+    """
+    key = (cargo_features, platform)
+    if key in _metadata_cache:
+        return _metadata_cache[key]
+
     metadata_features: list[str] = []
     for feature in cargo_features.split(","):
         feature = feature.strip()
@@ -173,11 +199,13 @@ def metadata(eng: Engine, cargo_features: str) -> dict:
         "metadata",
         "--format-version=1",
         "--filter-platform",
-        host_triple(eng.root),
+        platform,
     ]
     if metadata_features:
         args.extend(["--features", ",".join(metadata_features)])
-    return json.loads(run_capture(args, cwd=eng.root))
+    result = json.loads(run_capture(args, cwd=eng.root))
+    _metadata_cache[key] = result
+    return result
 
 
 def fingerprint_inputs(eng: Engine, crates: list[str], cargo_features: str) -> list[Path]:
@@ -193,61 +221,72 @@ def fingerprint_inputs(eng: Engine, crates: list[str], cargo_features: str) -> l
             target_names.append(crate)
 
     if target_names:
-        meta = metadata(eng, cargo_features)
-        packages = meta["packages"]
-        by_name = {package["name"]: package for package in packages}
-        by_id = {package["id"]: package for package in packages}
-        resolve_nodes = {
-            node["id"]: node for node in meta.get("resolve", {}).get("nodes", [])
-        }
-
-        missing = [name for name in target_names if name not in by_name]
-        if missing:
-            raise SystemExit(
-                "extract-llbc.py: unknown crate(s): " + ", ".join(sorted(missing))
-            )
+        # The stamp covers the host artefact AND every layout sidecar, so the
+        # fingerprint must hash the union of the closures those passes compile:
+        # a path dep gated on a cross target alone would otherwise change
+        # without invalidating the sidecar it shaped.
+        platforms = {host_triple(root)}
+        for name in target_names:
+            platforms.update(crate_layout_targets(eng, eng.spec(name)))
 
         # Never drop a requested target crate, only its excluded dependencies.
         exclude = excluded_packages(eng, crates) - set(target_names)
 
-        seen: set[str] = set()
-        stack = [by_name[name]["id"] for name in target_names]
-        closure = []
-        while stack:
-            package_id = stack.pop()
-            if package_id in seen:
-                continue
-            seen.add(package_id)
-            package = by_id[package_id]
-            closure.append(package)
+        for platform in sorted(platforms):
+            meta = metadata(eng, cargo_features, platform)
+            packages = meta["packages"]
+            by_name = {package["name"]: package for package in packages}
+            by_id = {package["id"]: package for package in packages}
+            resolve_nodes = {
+                node["id"]: node for node in meta.get("resolve", {}).get("nodes", [])
+            }
 
-            for dep in resolve_nodes.get(package_id, {}).get("deps", []):
-                dep_kinds = dep.get("dep_kinds", [])
-                # An empty `dep_kinds` is a normal (non-dev) edge; only
-                # drop deps whose every listed kind is `dev`.
-                if dep_kinds and all(kind.get("kind") == "dev" for kind in dep_kinds):
-                    continue
-                dep_package = by_id.get(dep["pkg"])
-                if dep_package is not None and dep_package.get("source") is None:
-                    stack.append(dep_package["id"])
+            missing = [name for name in target_names if name not in by_name]
+            if missing:
+                raise SystemExit(
+                    "extract-llbc.py: unknown crate(s): " + ", ".join(sorted(missing))
+                )
 
-        for package in closure:
-            if package["name"] in exclude:
-                continue
-            package_dir = Path(package["manifest_path"]).resolve().parent
-            if package_dir.is_relative_to(root):
-                rel_dir = package_dir.relative_to(root).as_posix()
-                pathspecs.append(f"{rel_dir}/Cargo.toml")
-            for target in package["targets"]:
-                kinds = set(target["kind"])
-                if not ({"lib", "bin", "custom-build"} & kinds):
+            seen: set[str] = set()
+            stack = [by_name[name]["id"] for name in target_names]
+            closure = []
+            while stack:
+                package_id = stack.pop()
+                if package_id in seen:
                     continue
-                src_path = Path(target["src_path"]).resolve()
-                if src_path.is_relative_to(root):
-                    rel_src = src_path.relative_to(root).as_posix()
-                    pathspecs.append(rel_src)
-                    if "custom-build" not in kinds:
-                        pathspecs.append(str(Path(rel_src).parent) + "/")
+                seen.add(package_id)
+                package = by_id[package_id]
+                closure.append(package)
+
+                for dep in resolve_nodes.get(package_id, {}).get("deps", []):
+                    dep_kinds = dep.get("dep_kinds", [])
+                    # An empty `dep_kinds` is a normal (non-dev) edge; only
+                    # drop deps whose every listed kind is `dev`.
+                    if dep_kinds and all(
+                        kind.get("kind") == "dev" for kind in dep_kinds
+                    ):
+                        continue
+                    dep_package = by_id.get(dep["pkg"])
+                    if dep_package is not None and dep_package.get("source") is None:
+                        stack.append(dep_package["id"])
+
+            for package in closure:
+                if package["name"] in exclude:
+                    continue
+                package_dir = Path(package["manifest_path"]).resolve().parent
+                if package_dir.is_relative_to(root):
+                    rel_dir = package_dir.relative_to(root).as_posix()
+                    pathspecs.append(f"{rel_dir}/Cargo.toml")
+                for target in package["targets"]:
+                    kinds = set(target["kind"])
+                    if not ({"lib", "bin", "custom-build"} & kinds):
+                        continue
+                    src_path = Path(target["src_path"]).resolve()
+                    if src_path.is_relative_to(root):
+                        rel_src = src_path.relative_to(root).as_posix()
+                        pathspecs.append(rel_src)
+                        if "custom-build" not in kinds:
+                            pathspecs.append(str(Path(rel_src).parent) + "/")
 
     result = subprocess.run(
         ["git", "ls-files", "-z", "--", *pathspecs],
@@ -359,6 +398,7 @@ def stamp_for(
     flags: list[str],
     charon_flags: list[str],
     layout_targets: list[str],
+    layout_flags: list[str],
 ) -> str:
     return "\n".join(
         [
@@ -369,6 +409,10 @@ def stamp_for(
             f"flags={' '.join(flags)}",
             f"charon_flags={' '.join(charon_flags)}",
             f"layout_targets={' '.join(layout_targets)}",
+            # The sidecar passes' own inputs: their cargo args and RUSTFLAGS
+            # shape the extracted layouts, so changing either must re-extract.
+            f"layout_flags={' '.join(layout_flags)}",
+            f"layout_rustflags={eng.layout_target_rustflags}",
             f"source={source_fingerprint(eng, [crate], cargo_features)}",
         ]
     )
@@ -522,6 +566,7 @@ def extract(eng: Engine, args: argparse.Namespace) -> None:
 
         dest = dest_dir / spec.output_name
         stamp_path = dest.with_suffix(dest.suffix + ".fingerprint")
+        layout_flags = crate_layout_flags(spec, cargo_features, flags)
         stamp = stamp_for(
             eng,
             crate=crate,
@@ -531,6 +576,7 @@ def extract(eng: Engine, args: argparse.Namespace) -> None:
             flags=flags,
             charon_flags=charon_flags,
             layout_targets=crate_layout_targets(eng, spec),
+            layout_flags=layout_flags,
         )
 
         sidecars = [
@@ -599,11 +645,6 @@ def extract(eng: Engine, args: argparse.Namespace) -> None:
                 prepared_std.add(target)
             sidecar = dest_dir / spec.layout_sidecar_name(target)
             print(f"=== extracting {crate} layouts for {target} -> {sidecar} ===")
-            layout_flags = (
-                flags
-                if spec.layout_cargo_args is None
-                else [expand_features(arg, cargo_features) for arg in spec.layout_cargo_args]
-            )
             layout_env = dict(env)
             if eng.layout_target_rustflags:
                 layout_env["RUSTFLAGS"] = (


### PR DESCRIPTION
Follow-ups to the target-aware layout work (#707), each keeping a build-time
descr base tied to the target word rather than the build host's.

## Name the `GcTypedArray` items-base rule and pin both typed-array descr bases to a 32-bit word

The two runtime typed-array blocks place their items differently, and a descr's
base must match the block it addresses:

- `TypedItemsBlock` (unboxed list int/float storage) — items **element-aligned**
  (`i64`/`f64` at 8), computed by `CallControl::array_items_base`.
- `GcTypedArray` (the resume/blackhole materialiser and interior-field struct
  arrays) — items **flat at the length word**.

The interior-field struct-array base was an inline `self.array_header_size` read
with a long comment. It is now a named `CallControl::gc_typed_array_items_base`
mirroring `array_items_base`, so routing a struct array through the
element-aligned rule (the earlier C5 regression) is a visible change to a named
method rather than an easily-"unified" inline expression.

Added regression tests that reproduce a 32-bit word on the 64-bit host by
passing an explicit 4-byte `header_end` to `array_items_base` (the scalar path
never consults `target_word_size`), asserting the element-aligned `i64`/`f64`
base (8) diverges from the flat word base (4) that the two rules coincide on at
word size 8 — the divergence a host-only assertion cannot otherwise see.

## Use the target word for the codewriter-less array-base fallback

The `arraydescrof` fallback taken when no `CallControl` is threaded computed its
length-prefixed base with the host `size_of::<usize>()`. Use `target_word_size()`,
matching the sweep the `CallControl` path already followed. This path is
shape-only for GC arrays (flat at the length word, no element alignment) and is
reached only by the codewriter-less `assemble()` test entry, so no generated
descr changes.

## Verification

`pyre/check.py` green on all three backends (dynasm 291/291, cranelift 291/291,
wasm 288/288) after a fresh LLBC extraction.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected typed-array memory layout calculations for different target word sizes.
  - Fixed offsets for fields within garbage-collected typed arrays.
  - Improved cross-platform handling of array descriptors, particularly on narrower-word architectures.
  - Added regression coverage to ensure typed array layouts use the correct item starting positions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->