### PR TITLE
bench: record the finalizer-ordering crash root cause; add a deterministic gc-stress repro phase

### DIFF
--- a/majit/majit-gc/src/collector.rs
+++ b/majit/majit-gc/src/collector.rs
@@ -1425,13 +1425,36 @@ impl MiniMarkGC {
         }
     }
 
+    /// incminimark.py:1259 `get_possibly_forwarded_tid`: header access that
+    /// follows the forwarding pointer when a young object was already moved
+    /// by this collection. A forwarded nursery header holds FORWARDED_MARKER,
+    /// whose all-ones flag region fakes every flag (IGNORE_FINALIZER
+    /// included), so a raw read there would silently drop a finalizer entry.
+    ///
+    /// Latent today: every finalizer-queue registrant (instances, generators)
+    /// is stable-allocated, so a queued object is never in the nursery. It
+    /// becomes load-bearing when instance allocation converges back to the
+    /// movable nursery (see `alloc_instance_object`).
+    fn get_possibly_forwarded_header(&self, obj_addr: usize) -> *const GcHeader {
+        let hdr = unsafe { header_of(obj_addr) };
+        if self.is_nursery_object_start(obj_addr) && unsafe { (*hdr).is_forwarded() } {
+            let fwd_addr = unsafe { GcHeader::forwarding_address(hdr) };
+            unsafe { header_of(fwd_addr) }
+        } else {
+            hdr
+        }
+    }
+
     /// incminimark.py:2914-2926 `deal_with_young_objects_with_finalizers`.
     fn deal_with_young_objects_with_finalizers(&mut self) {
         while let Some((obj_addr, fq_index)) =
             self.probably_young_objects_with_finalizers.pop_front()
         {
             let current = if self.is_nursery_object_start(obj_addr) {
-                let hdr = unsafe { header_of(obj_addr) };
+                // incminimark.py:2918: the IGNORE_FINALIZER read must go
+                // through `get_possibly_forwarded_tid` — the object may have
+                // been forwarded by an earlier root walk this collection.
+                let hdr = self.get_possibly_forwarded_header(obj_addr);
                 if unsafe { (*hdr).has_flag(flags::IGNORE_FINALIZER) } {
                     continue;
                 }

--- a/pyre/bench/synth/_pending/cranelift_finalizer_ordering_crash.py
+++ b/pyre/bench/synth/_pending/cranelift_finalizer_ordering_crash.py
@@ -13,7 +13,8 @@
 `finalizer_children` was dereferencing an already-moved object.
 
 Root cause (confirmed by deterministic bisection): the generator resume paths
-skipped `generator.py` `send_ex`'s `finally: frame.f_backref = jit.vref_None`,
+skipped `generator.py` `_invoke_execute_frame`'s
+`finally: frame.f_backref = jit.vref_None`,
 so the exhausted genexp that `sorted(...)` below fully consumes kept its last
 resumer's dead frame reachable through the finalizer graph (the genexp carries
 a finalizer via its exception table).  A later minor collection that moved one

--- a/pyre/bench/synth/_pending/cranelift_finalizer_ordering_crash.py
+++ b/pyre/bench/synth/_pending/cranelift_finalizer_ordering_crash.py
@@ -1,6 +1,6 @@
-"""Cranelift-only GC crash: garbage type id during finalization ordering.
+"""Regression repro: garbage type id during finalization ordering (FIXED).
 
-    thread panicked at majit/majit-gc/src/trace.rs:934:
+    thread panicked at majit/majit-gc/src/trace.rs:
       index out of bounds: the len is 142 but the index is 4294967254
       MiniMarkGC::finalizer_children
       MiniMarkGC::recursively_clear_finalization_ordering
@@ -9,24 +9,29 @@
       MiniMarkGC::alloc_with_type
       majit_backend_cranelift::compiler::gc_alloc_nursery_shim
 
-`4294967254` is `(u32)-42`: `finalizer_children` (collector.rs:2485) reads a type
-id off an object header that is not a live, initialized object.  Sets and dicts
-each own a GC storage box carrying a finalizer (it drops the backing Rust
-IndexMap), so a hot loop that allocates fresh containers under the cranelift JIT
-churns finalizer-bearing nursery boxes; one reaches finalization ordering with a
-garbage header.
+`4294967254` is `(u32)-42`, the low half of the header FORWARDED_MARKER:
+`finalizer_children` was dereferencing an already-moved object.
 
-Intermittent -- CI (macos-26-arm64) tripped it, and locally it is ~2/8 runs, so
-run it repeatedly.  Attribution:
+Root cause (confirmed by deterministic bisection): the generator resume paths
+skipped `generator.py` `send_ex`'s `finally: frame.f_backref = jit.vref_None`,
+so the exhausted genexp that `sorted(...)` below fully consumes kept its last
+resumer's dead frame reachable through the finalizer graph (the genexp carries
+a finalizer via its exception table).  A later minor collection that moved one
+of that dead frame's young locals -- the container itself, forwarded through
+the live owner while the dead frame is neither a root nor remembered -- left
+the frame slot stale, and the major finalization-ordering walk read the
+forwarding marker as a type id.  The cranelift-only attribution was a
+promotion-timing artifact, not a distinct JIT store bug.  Fixed by the
+`generator_invoke_execute_frame` port in baseobjspace.rs, whose `finally`
+drops `f_backref` (and `generator_frame_is_finished` clears finished frames).
 
-    cranelift, JIT on         crashes
-    cranelift, PYRE_NO_JIT=1  clean
-    dynasm, JIT on            clean
-
-The container code is plain interpreter-side Rust, identical in all three, so the
-fault is on the cranelift JIT's nursery allocation path, not the key probe --
-this is why the shipped `synth/key_eq_restart_forgets` verifies the restart
-answer in a single interpreter pass and keeps its hot loop allocation-free.
+The natural phases below are intermittent (CI macos-26-arm64 tripped it, ~2/8
+locally).  The `run_del_probe` phase reproduces the pre-fix crash
+deterministically: an object with `__del__` and a fully-consumed genexp both
+sit on the finalizer queue holding the same container.  Build with the pyrex
+`gc_stress` feature (see the commented passthrough in pyrex/Cargo.toml) and
+run under `MAJIT_GC_STRESS=1` -- every allocation then forces a full
+collection and the pre-fix binary panics on the first finalization walk.
 """
 
 
@@ -108,7 +113,47 @@ def run_dict(operation):
     return sorted(k.tag for k in container if isinstance(k, Key)), hit
 
 
+class Owner:
+    """Has __del__, so it joins the FinalizerQueue; owns the probed container."""
+
+    def __init__(self):
+        self.box = [None]
+        self.container = None
+
+    def __del__(self):
+        pass
+
+
+def run_del_probe(kind):
+    o = Owner()
+    if kind == "set":
+        c = set()
+        o.container = c
+        o.box[0] = c
+        c.add(Key("A", 1, o.box))
+        probe = Key("P", 2, o.box)
+        _ = probe in c
+    else:
+        c = {}
+        o.container = c
+        o.box[0] = c
+        c[Key("A", 1, o.box)] = 1
+        probe = Key("P", 2, o.box)
+        _ = c.get(probe, None)
+    # `o` (with __del__) dies at return; the genexp the sum consumes is also
+    # queued as a finalizer, and pre-fix its frame still linked the resumer.
+    return sum(1 for k in c if isinstance(k, Key))
+
+
 def main():
+    # Deterministic phase first (see docstring): panics the pre-fix binary
+    # under MAJIT_GC_STRESS=1 with the gc_stress feature built in.  Runs
+    # before the hot loop because every phase crawls under GC stress.
+    total = 0
+    for i in range(5000):
+        total += run_del_probe("set" if i % 2 == 0 else "dict")
+    print("del_probe", total)
+
     for operation in ("add", "contains", "discard"):
         print("set", operation, run_set(operation))
     for operation in ("setitem", "getitem", "setdefault", "pop"):

--- a/pyre/pyrex/Cargo.toml
+++ b/pyre/pyrex/Cargo.toml
@@ -33,6 +33,11 @@ dynasm = ["jit", "pyre-jit/dynasm"]
 # so mimalloc roughly halves bignum-heavy workloads (fib_loop beats PyPy).
 # Enable with e.g. `--features dynasm,mimalloc`.
 mimalloc = ["dep:mimalloc"]
+# Deterministic GC stress: forces a full collection at the start of every
+# allocation (opt in at runtime via MAJIT_GC_STRESS). Test/diagnostic only —
+# uncomment to build a GC-repro binary (see
+# bench/synth/_pending/cranelift_finalizer_ordering_crash.py).
+# gc_stress = ["pyre-jit/gc_stress"]
 # Build the interpreter as an RPython-style sandbox client: every mediated OS
 # call routes through host_seam's marshalling trampoline (see pyre-interpreter).
 sandbox = ["pyre-interpreter/sandbox"]


### PR DESCRIPTION
## Summary

The `_pending` finalizer-ordering crash repro (`index out of bounds: ... 4294967254` in `MiniMarkGC::finalizer_children`, tripped once on CI macos-26-arm64) is root-caused and — as of the current `main` — fixed. This PR updates the repro to match the facts and makes the crash deterministically reproducible.

- **Root cause** (was misattributed to the cranelift nursery-allocation path): `4294967254 = (u32)-42` is the low half of the header `FORWARDED_MARKER` — the finalization-ordering walk dereferenced an already-moved object. The generator resume paths skipped `generator.py` `send_ex`'s `finally: frame.f_backref = jit.vref_None`, so an exhausted genexp kept its last resumer's dead frame reachable through the finalizer graph; a minor collection that moved one of that dead frame's young locals (the container, forwarded through its live owner while the dead frame is neither a root nor remembered) left the frame slot stale for the walk to read. The cranelift-only signature was a promotion-timing artifact, not a distinct JIT store bug.
- **Fixed on main** by the `generator_invoke_execute_frame` port (its `finally` drops `f_backref`; `generator_frame_is_finished` eagerly clears finished frames).

## Changes

- `bench/synth/_pending/cranelift_finalizer_ordering_crash.py`: rewrite the docstring with the confirmed root cause and add a `run_del_probe` phase — an object with `__del__` and a fully-consumed genexp queued as finalizers holding the same container — which reproduces the pre-fix crash deterministically under `MAJIT_GC_STRESS=1`.
- `pyre/pyrex/Cargo.toml`: commented-out `gc_stress` feature passthrough (test/diagnostic only) documenting how to build such a repro binary.

## Verification

- Pre-fix control (pristine collector, before the resume-path drop): deterministic crash `index out of bounds ... 4294967254` in `finalizer_children` under `MAJIT_GC_STRESS=1`.
- Same repro with the `f_backref` drop (equivalent to what landed on main): clean, 4/4 runs; an instrumented forwarded-child detector in the walk counted 28 stale reaches before the drop, 0 after.
- Current `main` binary (cranelift + gc_stress): clean 3/3 on the deterministic repro.
- `pyre/check.py --backend dynasm,cranelift` with the equivalent drop: dynasm 285/285, cranelift 285/285 ALL PASSED.
- The updated `_pending` file runs clean with deterministic output (`del_probe 5000`, `hot 40000`) on the current main binary.
## Follow-ups (same PR)

- `4b37a4be953` — codex parity review (section 2) fix: the `finally` that clears `frame.f_backref` belongs to `_invoke_execute_frame` (generator.py:108-146), not `send_ex` which merely delegates; docstring attribution corrected.
- `bc9a6bac88e` — port `get_possibly_forwarded_tid` (incminimark.py:1259) for the `IGNORE_FINALIZER` read in `deal_with_young_objects_with_finalizers` (incminimark.py:2918 parity). A forwarded nursery header holds `FORWARDED_MARKER`, whose all-ones flag region fakes the flag and would silently drop the finalizer entry. Latent today — finalizer-queue registrants (instances via `alloc_instance_object`, generators) are stable-allocated, so a queued object is never in the nursery; it becomes load-bearing when instance allocation converges back to the movable nursery per that adaptation's stated path. Verified: `del_drop` discriminators match pypy3; `pyre/check.py --backend dynasm,cranelift` ALL PASSED 293/293 + 293/293.

🤖 Generated with [Claude Code](https://claude.com/claude-code)