### PR TITLE
jit: mint a fresh GUARD_NOT_INVALIDATED flag per compiled bridge

### DIFF
--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -15673,7 +15673,7 @@ impl majit_backend::Backend for CraneliftBackend {
         }
         let ops_owned: Vec<Op> = ops.iter().map(|rc| (**rc).clone()).collect();
         let ops: &[Op] = &ops_owned;
-        let invalidated_arc = original_token.invalidated.clone();
+        let invalidated_arc = original_token.mint_bridge_invalidation_flag();
         let flag_ptr =
             Arc::as_ptr(&invalidated_arc) as *const std::sync::atomic::AtomicBool as usize;
         let original_compiled = original_token
@@ -15726,7 +15726,7 @@ impl majit_backend::Backend for CraneliftBackend {
         let compiled = self.do_compile(
             inputargs,
             ops,
-            Some(flag_ptr), // compile.py:186: bridges share parent's invalidation flag
+            Some(flag_ptr),
             Some((source_trace_id, fail_descr.fail_index_per_trace())),
             caller_layout.as_ref(),
         );

--- a/majit/majit-backend-dynasm/src/runner.rs
+++ b/majit/majit-backend-dynasm/src/runner.rs
@@ -2264,7 +2264,8 @@ impl Backend for DynasmBackend {
         if let Some(table) = gc_table.as_ref() {
             asm.set_gc_table_base(table.base_addr());
         }
-        asm.set_invalidated_flag_addr(std::sync::Arc::as_ptr(&original_token.invalidated) as usize);
+        let bridge_flag = original_token.mint_bridge_invalidation_flag();
+        asm.set_invalidated_flag_addr(std::sync::Arc::as_ptr(&bridge_flag) as usize);
 
         let _orig_compiled = Self::get_compiled(original_token);
 

--- a/majit/majit-backend-wasm/src/lib.rs
+++ b/majit/majit-backend-wasm/src/lib.rs
@@ -1264,14 +1264,20 @@ fn ca_max_frame_bytes(targets: &[(u64, CallAssemblerTarget)]) -> u32 {
         .expect("admitted CALL_ASSEMBLER targets must be non-empty")
 }
 
-fn mark_call_assembler_target_active(target: &CallAssemblerTarget, caller: &JitCellToken) {
+fn mark_call_assembler_target_active(
+    target: &CallAssemblerTarget,
+    caller_flag: std::sync::Arc<std::sync::atomic::AtomicBool>,
+) {
+    // `caller_flag` is the invalidation flag the calling artifact's
+    // `GUARD_NOT_INVALIDATED` reads — the token flag for a loop, the
+    // bridge-generation flag for a bridge — so a terminal decline of the
+    // callee invalidates exactly the artifact embedding the CA edge.
     // The target metadata is removed by `CompiledWasmLoop::drop`; compilation
     // is single-threaded, and callers only retain the pointer while the token
     // remains compiled. This is the same lifetime used by the deopt helper.
     let force_terminal_decline = unsafe {
         if let Some(loop_) = (target.compiled_ptr as *const CompiledWasmLoop).as_ref() {
             loop_.ca_active.set(true);
-            let caller_flag = caller.invalidation_flag();
             {
                 let mut callers = loop_.ca_callers.borrow_mut();
                 if !callers
@@ -1859,7 +1865,7 @@ impl majit_backend::Backend for WasmBackend {
         );
         if let Some(targets) = ca_targets.as_ref() {
             for (_, target) in targets {
-                mark_call_assembler_target_active(target, token);
+                mark_call_assembler_target_active(target, token.invalidation_flag());
             }
         }
 
@@ -1904,19 +1910,6 @@ impl majit_backend::Backend for WasmBackend {
         let ops_owned: Vec<Op> = normalize_ops_for_codegen(inputargs, ops);
         let ops: &[Op] = &ops_owned;
         diag_bump(0); // compile_bridge entered
-
-        // PyPy patches every GUARD_NOT_INVALIDATED in a loop and its already
-        // attached bridges to their recovery stubs at invalidation time. A
-        // wasm guard reads the equivalent live token flag instead. Never add
-        // a new in-module bridge after that transition: in particular, a
-        // bridge attached to the newly failing invalidation guard could jump
-        // back into the same permanently-invalidated loop and form a closed
-        // loop↔bridge cycle without returning to the blackhole interpreter.
-        if original_token.is_invalidated() {
-            return Err(BackendError::Unsupported(
-                "wasm backend: cannot attach a bridge to an invalidated loop".into(),
-            ));
-        }
 
         // is_loop=false: a bridge's terminal JUMP with no LABEL is a loop-closing
         // bridge whose re-entry target is plumbed via `external_jump_slot`.
@@ -2304,6 +2297,10 @@ impl majit_backend::Backend for WasmBackend {
         // This bridge's exit indices come from the global fail-index space,
         // like every trace's (`failguard::FAIL_DESCR_REGISTRY`).
         let base = fail_descr_base();
+        // `rpython/jit/backend/model.py:145`: a bridge compiled after an
+        // invalidation starts valid; only a later invalidation may kill its
+        // `GUARD_NOT_INVALIDATED` operations.
+        let bridge_flag = original_token.mint_bridge_invalidation_flag();
         let (wasm_bytes, guard_exits, _num_ref_homes, bridge_cells_base, bridge_cells_owner) =
             codegen::build_wasm_module(
                 inputargs,
@@ -2316,7 +2313,7 @@ impl majit_backend::Backend for WasmBackend {
                 alloc_array_fn_ptr,
                 wb_fn_ptr,
                 nursery_alloc_params(ops).as_ref(),
-                Arc::as_ptr(&original_token.invalidated) as usize as u32,
+                Arc::as_ptr(&bridge_flag) as usize as u32,
                 base,
                 // A loop-closing bridge's terminal JUMP re-enters the target
                 // loop (own or sibling, resolved via `LABEL_TARGETS`) through
@@ -2412,7 +2409,7 @@ impl majit_backend::Backend for WasmBackend {
                 // Freeze this recursion to the CA mechanism: no further bridge
                 // chains here (see the decline above the codegen call).
                 for (_, target) in targets {
-                    mark_call_assembler_target_active(target, original_token);
+                    mark_call_assembler_target_active(target, bridge_flag.clone());
                 }
             }
         }

--- a/majit/majit-backend/src/lib.rs
+++ b/majit/majit-backend/src/lib.rs
@@ -1177,6 +1177,14 @@ pub struct JitCellToken {
     /// When set to `true`, any `GUARD_NOT_INVALIDATED` in the compiled
     /// code will fail, causing execution to bail out to the interpreter.
     pub invalidated: Arc<AtomicBool>,
+    /// Invalidation flags minted for bridges attached to this token. Each
+    /// bridge's `GUARD_NOT_INVALIDATED` reads its own generation's flag, so a
+    /// bridge compiled after an invalidation starts valid and only a later
+    /// invalidation can fail it. `rpython/jit/backend/model.py:145` requires a
+    /// repeated `invalidate_loop()` to invalidate newer guards, but not an old
+    /// guard that already has a bridge attached. The token owns the Arcs so
+    /// addresses baked into compiled artifacts remain valid for its lifetime.
+    bridge_invalidation_flags: parking_lot::Mutex<Vec<Arc<AtomicBool>>>,
     /// Alternative loop versions to compile immediately after the main loop.
     pub version_info: Option<LoopVersionInfo>,
     /// history.py:449: _keepalive_jitcell_tokens — set of other tokens
@@ -1341,6 +1349,7 @@ impl JitCellToken {
             outermost_jitdriver_index: None,
             compiled: OnceLock::new(),
             invalidated: Arc::new(AtomicBool::new(false)),
+            bridge_invalidation_flags: parking_lot::Mutex::new(Vec::new()),
             version_info: None,
             keepalive_tokens: parking_lot::Mutex::new(Vec::new()),
             // `rpython/jit/backend/x86/assembler.py:514` creates the
@@ -1516,6 +1525,27 @@ impl JitCellToken {
     /// Get a clone of the invalidated flag (for registering with QuasiImmut).
     pub fn invalidation_flag(&self) -> Arc<AtomicBool> {
         self.invalidated.clone()
+    }
+
+    /// Mint the clear invalidation flag owned by a newly compiled bridge.
+    pub fn mint_bridge_invalidation_flag(&self) -> Arc<AtomicBool> {
+        let flag = Arc::new(AtomicBool::new(false));
+        self.bridge_invalidation_flags.lock().push(flag.clone());
+        flag
+    }
+
+    /// Return the root and all bridge-generation invalidation flags.
+    pub fn all_invalidation_flags(&self) -> Vec<Arc<AtomicBool>> {
+        let bridge_flags = self.bridge_invalidation_flags.lock();
+        let mut flags = Vec::with_capacity(1 + bridge_flags.len());
+        flags.push(self.invalidated.clone());
+        flags.extend(bridge_flags.iter().cloned());
+        flags
+    }
+
+    /// Return the most recently minted bridge-generation flag.
+    pub fn latest_bridge_invalidation_flag(&self) -> Option<Arc<AtomicBool>> {
+        self.bridge_invalidation_flags.lock().last().cloned()
     }
 
     /// `pyjitpl.py:3898` `has_compiled_targets(token)` —
@@ -3286,6 +3316,25 @@ mod tests {
         // Reset
         token.reset_compiled();
         assert!(!token.has_compiled_code());
+    }
+
+    #[test]
+    fn bridge_invalidation_flags_are_independent_generations() {
+        let token = JitCellToken::new(42);
+        token.invalidate();
+
+        let bridge_flag = token.mint_bridge_invalidation_flag();
+        assert!(token.is_invalidated());
+        assert!(!bridge_flag.load(std::sync::atomic::Ordering::Acquire));
+
+        let flags = token.all_invalidation_flags();
+        assert_eq!(flags.len(), 2);
+        assert!(Arc::ptr_eq(&flags[0], &token.invalidation_flag()));
+        assert!(Arc::ptr_eq(&flags[1], &bridge_flag));
+        assert!(Arc::ptr_eq(
+            &token.latest_bridge_invalidation_flag().unwrap(),
+            &bridge_flag
+        ));
     }
 
     #[test]

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -4480,6 +4480,13 @@ impl<S: JitState> JitDriver<S> {
         self.meta.last_compiled_key()
     }
 
+    /// Flag read by `GUARD_NOT_INVALIDATED` in the last successful artifact.
+    pub fn last_compiled_artifact_invalidation_flag(
+        &self,
+    ) -> Option<std::sync::Arc<std::sync::atomic::AtomicBool>> {
+        self.meta.last_compiled_artifact_invalidation_flag()
+    }
+
     /// warmstate.py:437-444 starting cell's green_key (the cell on which
     /// TRACING must be cleared in the finally block). Returns None when
     /// no trace is in progress.
@@ -5305,7 +5312,9 @@ impl<S: JitState> JitDriver<S> {
         // can force GUARD_NOT_INVALIDATED exits periodically.
         if let Some(token) = self.meta.get_loop_token(key_hash) {
             if let Ok(mut qmut) = self.epoch_qmut.lock() {
-                qmut.register(&token.invalidation_flag());
+                for flag in token.all_invalidation_flags() {
+                    qmut.register(&flag);
+                }
             }
         }
 

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -1199,6 +1199,10 @@ pub struct MetaInterp<M: Clone> {
     /// from the tracing green_key when cross-loop cut retargets to the
     /// inner loop's key (compile.py:269).
     pub(crate) last_compiled_key: Option<u64>,
+    /// Invalidation flag read by the most recently compiled loop or bridge.
+    /// Dependency registration uses the artifact generation rather than
+    /// always registering the root token's flag.
+    pub(crate) last_compiled_artifact_invalidation_flag: Option<Arc<std::sync::atomic::AtomicBool>>,
     /// virtualizable.py:86 NUM_SCALAR_INPUTARGS: number of scalar inputargs
     /// (frame + static fields). Set by the interpreter at JIT init.
     pub num_scalar_inputargs: usize,
@@ -2355,6 +2359,7 @@ impl<M: Clone> MetaInterp<M> {
             cancel_count: 0,
             internal_compile_panics: 0,
             last_compiled_key: None,
+            last_compiled_artifact_invalidation_flag: None,
             num_scalar_inputargs: 0,
             potential_retrace_position: None,
             last_quasi_immutable_deps: Vec::new(),
@@ -3588,6 +3593,7 @@ impl<M: Clone> MetaInterp<M> {
 
     fn prepare_trace_start_runtime(&mut self) {
         self.last_compiled_key = None;
+        self.last_compiled_artifact_invalidation_flag = None;
         // pyjitpl.py:2884-2892 `compile_and_run_once` body, line-by-line:
         //   debug_start('jit-tracing')                  # OUTER open
         //   self.staticdata._setup_once()
@@ -6118,6 +6124,7 @@ impl<M: Clone> MetaInterp<M> {
         };
         match compile_result {
             Ok(_) => {
+                self.last_compiled_artifact_invalidation_flag = Some(token.invalidation_flag());
                 // compile.py:826-830 store_hash: assign jitcounter hashes.
                 self.assign_guard_hashes(token.as_ref());
                 // compile.py:566-567 send_loop_to_backend registers the token
@@ -7023,6 +7030,7 @@ impl<M: Clone> MetaInterp<M> {
         };
         match compile_result {
             Ok(_) => {
+                self.last_compiled_artifact_invalidation_flag = Some(token.invalidation_flag());
                 self.assign_guard_hashes(token.as_ref());
                 // `compile.py:237` / `compile.py:289` — every TargetToken
                 // whose LABEL or JUMP appears in `combined_ops` carries
@@ -7592,6 +7600,7 @@ impl<M: Clone> MetaInterp<M> {
         };
         match compile_loop_result {
             Ok(_) => {
+                self.last_compiled_artifact_invalidation_flag = Some(token.invalidation_flag());
                 self.assign_guard_hashes(token.as_ref());
                 self.warm_state.memory_manager.keep_loop_alive(&token);
                 // compile.py:213 record_loop_or_bridge.
@@ -8088,6 +8097,13 @@ impl<M: Clone> MetaInterp<M> {
     /// for cross-loop cuts, otherwise the tracing key.
     pub fn last_compiled_key(&self) -> Option<u64> {
         self.last_compiled_key
+    }
+
+    /// Flag read by `GUARD_NOT_INVALIDATED` in the last successful artifact.
+    pub fn last_compiled_artifact_invalidation_flag(
+        &self,
+    ) -> Option<Arc<std::sync::atomic::AtomicBool>> {
+        self.last_compiled_artifact_invalidation_flag.clone()
     }
 
     /// Cranelift direct body-entry selector for the first compiled loop LABEL.
@@ -10358,6 +10374,7 @@ impl<M: Clone> MetaInterp<M> {
         snapshot_frame_pcs: SnapshotFramePcs,
         call_pure_results: indexmap::IndexMap<Vec<Value>, Value>,
     ) -> bool {
+        self.last_compiled_artifact_invalidation_flag = None;
         crate::mc_diag_bump(8); // compile_bridge entered
         if !self.compiled_loops.contains_key(&green_key) {
             return false;
@@ -10863,6 +10880,8 @@ impl<M: Clone> MetaInterp<M> {
 
         match result {
             Ok(_) => {
+                self.last_compiled_artifact_invalidation_flag =
+                    source_jct.latest_bridge_invalidation_flag();
                 if crate::majit_log_enabled() {
                     eprintln!(
                         "[jit] compiled bridge at key={}, guard={}",

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -4596,23 +4596,22 @@ pub fn make_green_key(code_ptr: *const (), pc: usize) -> u64 {
 // source of truth. call_depth() reads it. No more Box<dyn Any> allocation.
 
 /// RPython compile.py:204-207 (record_loop_or_bridge) parity:
-/// Register the compiled loop's invalidation flag with all quasi-immutable
+/// Register the compiled artifact's invalidation flag with all quasi-immutable
 /// dependencies collected during optimization. The optimizer records
 /// namespace pointers in quasi_immutable_deps when processing
 /// QUASIIMMUT_FIELD ops. After compilation, this function reads them
 /// from MetaInterp and registers watchers so GUARD_NOT_INVALIDATED
 /// fails when the namespace mutates.
-fn register_quasi_immutable_deps(green_key: u64) {
+fn register_quasi_immutable_deps(_green_key: u64) {
     let (driver, _) = driver_pair();
     let deps: Vec<(u64, u32)> =
         std::mem::take(&mut driver.meta_interp_mut().last_quasi_immutable_deps);
     if deps.is_empty() {
         return;
     }
-    let Some(token) = driver.get_loop_token(green_key) else {
+    let Some(flag) = driver.last_compiled_artifact_invalidation_flag() else {
         return;
     };
-    let flag = token.invalidation_flag();
     // `celldict.py:34 _immutable_fields_ = ["version?"]`: the global cell
     // fast path's `QUASIIMMUT_FIELD(ns, slot)` is keyed on the module
     // dict's `ModuleDictStrategy.version`, not a per-slot index, so every


### PR DESCRIPTION
## Problem

`synth/global_quasiimmut_invalidation` ran at **79.4x pypy**: a module global rebound inside a hot nested loop triggered a storm of **203 bridges / 40709 guard failures**, after which the outer loop was abandoned to the interpreter (~40x steady state).

Root cause — a **stillborn-bridge cascade**: `GUARD_NOT_INVALIDATED` compiles to a load of an `Arc<AtomicBool>` baked by address, and bridges baked the **parent token's flag** (dynasm `runner.rs`, cranelift `compiler.rs`, wasm `codegen` wiring). The flag is never reset, so after a real quasi-immutable invalidation permanently set it, every recovery bridge died on its own guard at first execution. Each stillborn bridge cost `trace_eagerness=200` guard failures before the next attached (cascade rate: bridges ≈ guard_failures/200, verified at multiple N).

This violates the `backend/model.py:145 invalidate_loop` contract: a repeated `invalidate_loop()` must invalidate *newer* `guard_not_invalidated`, but **not** an old one that already has a bridge attached — i.e. a bridge compiled after an invalidation starts valid.

## Fix

One invalidation flag per compiled artifact:

- `JitCellToken` owns bridge-generation flags (`mint_bridge_invalidation_flag` / `all_invalidation_flags` / `latest_bridge_invalidation_flag`); each backend's `compile_bridge` mints a fresh flag instead of baking the root flag.
- `MetaInterp` records the last compiled artifact's flag; `register_quasi_immutable_deps` registers **that** flag with the module-dict version watchers, so a bridge is killed only by future mutations.
- Per-entry epoch registration covers root + all bridge flags, so the periodic forced exit still reaches a loop whose recovered steady state runs inside a bridge.
- wasm: the invalidated-token bridge decline is removed (the loop↔bridge cycle it guarded against is now the valid recovered steady state, and the epoch flags bound it); `ca_callers` records the calling artifact's flag so a callee terminal decline invalidates exactly the artifact embedding the CA edge.

Root `is_invalidated()` semantics and the warmstate invalidated-token filter are unchanged; loops without bridges behave identically.

## Verification

| | before | after |
|---|---|---|
| repro (rebind + nested loop, N=1M) | 203 bridges / 40709 gf / 0.47s | **3 bridges / 710 gf / 0.07s** |
| control (no rebind) | 0 bridges / 108 gf / 0.05s | unchanged |
| `synth/global_quasiimmut_invalidation` | 79.4x | **3.0x** (dynasm), 4.3x (cranelift), 4.9x (wasm) |

- `check.py` all backends: **dynasm 293/293, cranelift 293/293, wasm 290/290 — ALL PASSED**
- `cargo test -p majit-backend -p majit-metainterp --features dynasm`: pass (includes a new generation-independence unit test)
- Perf controls: `fannkuch`, `synth/kept_stack_depth_gt1` — no regression from the extra per-entry registration

🤖 Generated with [Claude Code](https://claude.com/claude-code)