### PR TITLE
jit: const-fold all-Const operands at record time in the FBW walker

### DIFF
--- a/majit/majit-backend-wasm/src/lib.rs
+++ b/majit/majit-backend-wasm/src/lib.rs
@@ -1445,6 +1445,26 @@ impl majit_backend::Backend for WasmBackend {
         register_pending_call_assembler_target(token_number, input_types);
     }
 
+    /// model.py:254 bh_arraylen_gc(array, arraydescr): read the length
+    /// prefix at `lendescr.offset` (llmodel.py:585-588
+    /// `read_int_at_mem(array, ofs, WORD, 1)`), mirroring the native
+    /// backends' overrides.  The trait default is a stub returning 0,
+    /// which would feed a wrong length into trace-time concrete stamps
+    /// and `arraylen` const folds.
+    fn bh_arraylen_gc(
+        &self,
+        array_ptr: i64,
+        arraydescr: &majit_translate::jitcode::BhDescr,
+    ) -> i64 {
+        let ofs = arraydescr
+            .array_len_offset()
+            .expect("bh_arraylen_gc requires ArrayDescr.lendescr");
+        // SAFETY: `array_ptr` is a GC-managed array pointer threaded
+        // through from the trace recorder / blackhole; `ofs` is the
+        // length-prefix offset its allocation wrote (see `bh_new_array`).
+        unsafe { *((array_ptr as *const u8).add(ofs) as *const usize) as i64 }
+    }
+
     // ── Blackhole allocation (llmodel.py:775-790) ──
     //
     // The blackhole interpreter materializes virtuals (e.g. a virtualized

--- a/majit/majit-backend-wasm/src/lib.rs
+++ b/majit/majit-backend-wasm/src/lib.rs
@@ -1445,26 +1445,6 @@ impl majit_backend::Backend for WasmBackend {
         register_pending_call_assembler_target(token_number, input_types);
     }
 
-    /// model.py:254 bh_arraylen_gc(array, arraydescr): read the length
-    /// prefix at `lendescr.offset` (llmodel.py:585-588
-    /// `read_int_at_mem(array, ofs, WORD, 1)`), mirroring the native
-    /// backends' overrides.  The trait default is a stub returning 0,
-    /// which would feed a wrong length into trace-time concrete stamps
-    /// and `arraylen` const folds.
-    fn bh_arraylen_gc(
-        &self,
-        array_ptr: i64,
-        arraydescr: &majit_translate::jitcode::BhDescr,
-    ) -> i64 {
-        let ofs = arraydescr
-            .array_len_offset()
-            .expect("bh_arraylen_gc requires ArrayDescr.lendescr");
-        // SAFETY: `array_ptr` is a GC-managed array pointer threaded
-        // through from the trace recorder / blackhole; `ofs` is the
-        // length-prefix offset its allocation wrote (see `bh_new_array`).
-        unsafe { *((array_ptr as *const u8).add(ofs) as *const usize) as i64 }
-    }
-
     // ── Blackhole allocation (llmodel.py:775-790) ──
     //
     // The blackhole interpreter materializes virtuals (e.g. a virtualized

--- a/majit/majit-metainterp/src/jitprof.rs
+++ b/majit/majit-metainterp/src/jitprof.rs
@@ -130,6 +130,12 @@ impl EmptyProfiler {
 /// [`owner_thread`]: TimingState::owner_thread
 #[derive(Default, Debug)]
 struct TimingState {
+    /// `self.starttime` (`jitprof.py:64`) — fixed profile start mark;
+    /// `_print_stats`'s TOTAL line is `tk - starttime`.
+    starttime: Option<Instant>,
+    /// `self.tk` (`jitprof.py:71`) — set by `finish()` just before
+    /// `print_stats()`.
+    tk: Option<Instant>,
     /// `self.t1` (`jitprof.py:56`) — timer baseline for the next
     /// `_start`/`_end` to charge time against.
     t1: Option<Instant>,
@@ -303,10 +309,111 @@ impl JitProfiler {
         //   self.t1 = self.starttime
         //   ...
         //   self.current = []
+        let now = Instant::now();
         let mut state = self.timing.lock().expect("JitProfiler timing poisoned");
-        state.t1 = Some(Instant::now());
+        state.starttime = Some(now);
+        state.tk = None;
+        state.t1 = Some(now);
         state.current.clear();
         state.owner_thread = None;
+    }
+
+    /// jitprof.py:71-73 `Profiler.finish`.
+    ///
+    /// ```text
+    ///  def finish(self):
+    ///      self.tk = self.timer()
+    ///      self.print_stats()
+    /// ```
+    pub fn finish(&self) {
+        {
+            let mut state = self.timing.lock().expect("JitProfiler timing poisoned");
+            state.tk = Some(Instant::now());
+        }
+        self.print_stats();
+    }
+
+    /// jitprof.py:124-128 `Profiler.print_stats` — emit the
+    /// `jit-summary` section (visible under `MAJIT_LOG`).
+    pub fn print_stats(&self) {
+        crate::debug::debug_start("jit-summary");
+        if crate::debug::have_debug_prints() {
+            self._print_stats();
+        }
+        crate::debug::debug_stop("jit-summary");
+    }
+
+    /// jitprof.py:130-174 `Profiler._print_stats` — line set, order,
+    /// and layout are upstream's.
+    fn _print_stats(&self) {
+        let snap = self.snapshot();
+        let (starttime, tk) = {
+            let state = self.timing.lock().expect("JitProfiler timing poisoned");
+            (state.starttime, state.tk)
+        };
+        let ns_to_secs = |ns: u64| ns as f64 / 1e9;
+        crate::debug::debug_print(&fmt_line_time(
+            "Tracing",
+            snap.tracing,
+            ns_to_secs(self.tracing_time_ns.load(Ordering::Relaxed)),
+        ));
+        crate::debug::debug_print(&fmt_line_time(
+            "Backend",
+            snap.backend,
+            ns_to_secs(self.backend_time_ns.load(Ordering::Relaxed)),
+        ));
+        let total = match (starttime, tk) {
+            (Some(start), Some(end)) => end.saturating_duration_since(start).as_secs_f64(),
+            _ => 0.0,
+        };
+        crate::debug::debug_print(&format!("TOTAL:      \t\t{total:.6}"));
+        let mut intline = |label: &str, value: usize| {
+            crate::debug::debug_print(&fmt_intline(label, value));
+        };
+        intline("ops", snap.ops);
+        intline("heapcached ops", snap.heapcached_ops);
+        intline("recorded ops", snap.recorded_ops);
+        intline("  calls", snap.calls);
+        intline("guards", snap.guards);
+        intline("opt ops", snap.opt_ops);
+        intline("opt guards", snap.opt_guards);
+        intline("opt guards shared", snap.opt_guards_shared);
+        intline("forcings", snap.opt_forcings);
+        intline("abort: trace too long", snap.abort_too_long);
+        intline("abort: compiling", snap.abort_bridge);
+        intline("abort: vable escape", snap.abort_escape);
+        intline("abort: bad loop", snap.abort_bad_loop);
+        intline("abort: force quasi-immut", snap.abort_force_quasiimmut);
+        intline("abort: segmenting trace", snap.abort_segmented_trace);
+        intline("virtualizables forced", snap.force_virtualizables);
+        intline("nvirtuals", snap.nvirtuals);
+        intline("nvholes", snap.nvholes);
+        intline("nvreused", snap.nvreused);
+        intline("vecopt tried", snap.opt_vectorize_try);
+        intline("vecopt success", snap.opt_vectorized);
+        // jitprof.py:166-174 `if cpu is not None:` — pyre's tracker Arc
+        // is always bound (a fresh one before `set_cpu_tracker`).
+        let tracker = self
+            .cpu_tracker
+            .lock()
+            .expect("JitProfiler cpu_tracker poisoned")
+            .clone();
+        intline(
+            "Total # of loops",
+            tracker.total_compiled_loops.load(Ordering::Relaxed),
+        );
+        intline(
+            "Total # of bridges",
+            tracker.total_compiled_bridges.load(Ordering::Relaxed),
+        );
+        intline(
+            "Freed # of loops",
+            tracker.total_freed_loops.load(Ordering::Relaxed),
+        );
+        intline(
+            "Freed # of bridges",
+            tracker.total_freed_bridges.load(Ordering::Relaxed),
+        );
     }
 
     /// jitprof.py:95 `Profiler.start_tracing`.
@@ -844,6 +951,20 @@ fn debug_channel_for_event(event: i32) -> Option<&'static str> {
     }
 }
 
+/// jitprof.py:176-178 `Profiler._print_line_time` layout:
+/// `"%s:%s\t%d\t%f" % (string, " " * max(0, 13-len(string)), i, tim)`.
+fn fmt_line_time(string: &str, i: usize, tim: f64) -> String {
+    let pad = " ".repeat(13usize.saturating_sub(string.len()));
+    format!("{string}:{pad}\t{i}\t{tim:.6}")
+}
+
+/// jitprof.py:180-182 `Profiler._print_intline` layout:
+/// `"%s:%s\t%d" % (string, " " * max(0, 13-len(string)), i)`.
+fn fmt_intline(string: &str, i: usize) -> String {
+    let pad = " ".repeat(13usize.saturating_sub(string.len()));
+    format!("{string}:{pad}\t{i}")
+}
+
 /// Plain-old-data snapshot of [`JitProfiler`].
 ///
 /// Used by debug printers, tests, and the `JitStats` view. Field order
@@ -1188,6 +1309,36 @@ mod tests {
         // observes the bump (no shadowing into a separate counter).
         sd.profiler.count_ops(OpCode::IntAdd, counters::OPS);
         assert_eq!(sd.profiler.ops.load(Ordering::Relaxed), 1);
+    }
+
+    #[test]
+    fn print_line_layouts_match_print_stats() {
+        // `"%s:%s\t%d\t%f"` with `" " * max(0, 13-len(string))`.
+        assert_eq!(
+            fmt_line_time("Tracing", 2, 0.5),
+            "Tracing:      \t2\t0.500000"
+        );
+        assert_eq!(fmt_intline("ops", 42), "ops:          \t42");
+        // A label longer than 13 chars gets no padding (max(0, ..)).
+        assert_eq!(
+            fmt_intline("abort: trace too long", 1),
+            "abort: trace too long:\t1"
+        );
+        // The calls line keeps its two-space indent inside the label.
+        assert_eq!(fmt_intline("  calls", 7), "  calls:      \t7");
+    }
+
+    #[test]
+    fn finish_marks_tk_and_prints_without_panicking() {
+        let prof = JitProfiler::default();
+        prof.start();
+        prof.count_ops(OpCode::IntAdd, counters::OPS);
+        // `finish()` = `self.tk = timer(); print_stats()`; with MAJIT_LOG
+        // unset the print side is a no-op, the tk mark still lands.
+        prof.finish();
+        let state = prof.timing.lock().unwrap();
+        assert!(state.starttime.is_some());
+        assert!(state.tk.is_some());
     }
 
     #[test]

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/arith.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/arith.rs
@@ -487,7 +487,9 @@ pub(crate) fn record_ptr_cmp<Sym: WalkSym>(
 /// same `b1 is b2` short-circuit at `pyjitpl.py` for
 /// `opimpl_ptr_eq` but the nullity test against `CONST_NULL` cannot
 /// short-circuit because `box` is never the literal `CONST_NULL`
-/// constant (codewriter would have folded that).
+/// constant (codewriter would have folded that).  A `Const` box still
+/// folds through `execute_and_record`'s `_all_constants` short-circuit —
+/// `CONST_NULL` is itself a `Const`, so both operands are constant.
 pub(crate) fn ptr_nullity_record<Sym: WalkSym>(
     code: &[u8],
     op: &DecodedOp,
@@ -495,6 +497,16 @@ pub(crate) fn ptr_nullity_record<Sym: WalkSym>(
     nonzero: bool,
 ) -> Result<(DispatchOutcome, usize), DispatchError> {
     let box_ = read_ref_reg(code, op, 0, ctx)?;
+    // A `Const` box folds without recording: `CONST_NULL` is a `Const`, so
+    // `_all_constants` holds and `execute_and_record` answers the nullity
+    // from the constant's own address.
+    if let Some(majit_ir::Value::Ref(r)) = box_.inline_const_to_value() {
+        let folded = ((r.0 != 0) == nonzero) as i64;
+        let result = ctx.trace_ctx.const_int(folded);
+        let dst = code[op.pc + 2] as usize;
+        write_int_reg(ctx, op.pc, dst, result, ConcreteValue::Int(folded))?;
+        return Ok((DispatchOutcome::Continue, op.next_pc));
+    }
     let null_const = ctx.trace_ctx.const_null();
     let opcode = if nonzero {
         OpCode::PtrNe
@@ -728,11 +740,19 @@ pub(crate) fn unop_cast_record<Sym: WalkSym>(
         // `box_value(result)` callers see the live value.
         OpCode::CastIntToFloat => {
             let a = read_int_reg(code, op, 0, ctx)?;
-            let result = ctx.trace_ctx.record_op(opcode, &[a]);
-            if let Some(majit_ir::Value::Int(n)) = ctx.trace_ctx.box_value(a) {
-                ctx.trace_ctx
-                    .set_opref_concrete(result, majit_ir::Value::Float(n as f64));
-            }
+            // A `Const` operand folds without recording
+            // (`execute_and_record`'s `_all_constants` short-circuit;
+            // CAST_INT_TO_FLOAT is ALWAYS_PURE).
+            let result = if let Some(majit_ir::Value::Int(n)) = a.inline_const_to_value() {
+                ctx.trace_ctx.const_float((n as f64).to_bits() as i64)
+            } else {
+                let result = ctx.trace_ctx.record_op(opcode, &[a]);
+                if let Some(majit_ir::Value::Int(n)) = ctx.trace_ctx.box_value(a) {
+                    ctx.trace_ctx
+                        .set_opref_concrete(result, majit_ir::Value::Float(n as f64));
+                }
+                result
+            };
             let len = ctx.registers_f.len();
             let slot = ctx
                 .registers_f
@@ -747,6 +767,14 @@ pub(crate) fn unop_cast_record<Sym: WalkSym>(
         }
         // `cast_int_to_ptr/i>r`: Int-bank → Ref-bank. Bit-cast the
         // operand's Box.value (`BoxInt(n)` → `BoxRef(n as ptr)`).
+        //
+        // No `_all_constants` fold for the two ptr casts: upstream's fold
+        // executes via `bhimpl_cast_int_to_ptr` / `bhimpl_cast_ptr_to_int`,
+        // which assert an odd (tagged) int the GC ignores.  Pyre's casts
+        // serve untagged pointer round-trips, so folding would bake a raw
+        // address into the trace as a `ConstPtr` the gcreftracer forwards
+        // as an object — or as an int a moving collection silently
+        // invalidates.  Keep recording both.
         OpCode::CastIntToPtr => {
             let a = read_int_reg(code, op, 0, ctx)?;
             let result = ctx.trace_ctx.record_op(opcode, &[a]);

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/arith.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/arith.rs
@@ -333,6 +333,24 @@ pub(crate) fn binop_ref_to_int_record<Sym: WalkSym>(
         write_int_reg(ctx, op.pc, dst, result, ConcreteValue::Int(folded))?;
         return Ok((DispatchOutcome::Continue, op.next_pc));
     }
+    // Distinct all-`Const` ref operands fold to a result constant without
+    // recording — `execute_and_record` const-folds any pure op whose operands
+    // are all `Const`, and the sibling `record_ptr_cmp` already does this. Two
+    // constant refs have a GC-stable identity relation, so the `is`/`is not`
+    // outcome is known at trace time.
+    if let (Some(majit_ir::Value::Ref(la)), Some(majit_ir::Value::Ref(rb))) =
+        (a.inline_const_to_value(), b.inline_const_to_value())
+    {
+        let folded = match opcode {
+            OpCode::PtrEq | OpCode::InstancePtrEq => (la == rb) as i64,
+            OpCode::PtrNe | OpCode::InstancePtrNe => (la != rb) as i64,
+            _ => unreachable!("binop_ref_to_int_record: unsupported opcode {opcode:?}"),
+        };
+        let result = ctx.trace_ctx.const_int(folded);
+        let dst = code[op.pc + 3] as usize;
+        write_int_reg(ctx, op.pc, dst, result, ConcreteValue::Int(folded))?;
+        return Ok((DispatchOutcome::Continue, op.next_pc));
+    }
     let result = ctx.trace_ctx.record_op(opcode, &[a, b]);
     // Stamp the bool result from the operands' concrete carriers: the
     // `box_value` carrier first, then the `concrete_registers_r` shadow. The

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/arith.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/arith.rs
@@ -12,6 +12,24 @@
 
 use super::*;
 
+/// `execute_and_record` profiler entry — `profiler.count_ops(opnum)` fires
+/// before the `_all_constants` fold check, so a folded op still lands in the
+/// base `OPS` bucket.  The `b1 is b2` fast paths return from the opimpl
+/// before `self.execute` runs and count nothing.
+fn count_ops_executed<Sym: WalkSym>(ctx: &WalkContext<'_, '_, Sym>, opcode: OpCode) {
+    ctx.trace_ctx
+        .profiler()
+        .count_ops(opcode, majit_metainterp::counters::OPS);
+}
+
+/// `_record_helper` profiler half — `count_ops(opnum, Counters.RECORDED_OPS)`
+/// fires exactly when the op is recorded.
+fn count_ops_recorded<Sym: WalkSym>(ctx: &WalkContext<'_, '_, Sym>, opcode: OpCode) {
+    ctx.trace_ctx
+        .profiler()
+        .count_ops(opcode, majit_metainterp::counters::RECORDED_OPS);
+}
+
 /// Generic int-bank binop handler. Reads `registers_i[src1]` and
 /// `registers_i[src2]`, records `record_op(opcode, [a, b])`, writes
 /// the recorder's result OpRef into `registers_i[dst]`. Operand
@@ -44,6 +62,7 @@ pub(crate) fn binop_int_record<Sym: WalkSym>(
             return Ok((DispatchOutcome::Continue, op.next_pc));
         }
     }
+    count_ops_executed(ctx, opcode);
     // All-`Const` operands fold to a result constant without recording —
     // `execute_and_record` short-circuits `_record_helper` via
     // `executor.wrap_constant(resvalue)` when `_all_constants(*argboxes)`
@@ -57,6 +76,7 @@ pub(crate) fn binop_int_record<Sym: WalkSym>(
         write_int_reg(ctx, op.pc, dst, result, ConcreteValue::Int(folded))?;
         return Ok((DispatchOutcome::Continue, op.next_pc));
     }
+    count_ops_recorded(ctx, opcode);
     let result = ctx.trace_ctx.record_op(opcode, &[a, b]);
     // Box(value) parity: stamp the result from the operands' Box.value
     // carriers (BoxInt(value) — matches dispatch.rs trace_binop_i).
@@ -111,6 +131,7 @@ pub(crate) fn record_int_cmp<Sym: WalkSym>(
         });
         return ctx.trace_ctx.const_int(folded);
     }
+    count_ops_executed(ctx, opcode);
     if let (Some(Value::Int(la)), Some(Value::Int(rb))) =
         (a.inline_const_to_value(), b.inline_const_to_value())
     {
@@ -118,6 +139,7 @@ pub(crate) fn record_int_cmp<Sym: WalkSym>(
             .trace_ctx
             .const_int(majit_metainterp::eval_binop_i(opcode, la, rb));
     }
+    count_ops_recorded(ctx, opcode);
     let result = ctx.trace_ctx.record_op(opcode, &[a, b]);
     if let (Some(majit_ir::Value::Int(la)), Some(majit_ir::Value::Int(rb))) =
         (ctx.trace_ctx.box_value(a), ctx.trace_ctx.box_value(b))
@@ -137,11 +159,13 @@ pub(crate) fn record_int_unary<Sym: WalkSym>(
     opcode: OpCode,
     a: OpRef,
 ) -> OpRef {
+    count_ops_executed(ctx, opcode);
     if let Some(Value::Int(la)) = a.inline_const_to_value() {
         return ctx
             .trace_ctx
             .const_int(majit_metainterp::eval_unary_i(opcode, la));
     }
+    count_ops_recorded(ctx, opcode);
     let result = ctx.trace_ctx.record_op(opcode, &[a]);
     if let Some(majit_ir::Value::Int(la)) = ctx.trace_ctx.box_value(a) {
         let folded = majit_metainterp::eval_unary_i(opcode, la);
@@ -181,9 +205,11 @@ pub(crate) fn record_int_ovf<Sym: WalkSym>(
         OpCode::IntMulOvf => (v1.wrapping_mul(v2), v1.checked_mul(v2).is_none()),
         _ => unreachable!("record_int_ovf requires an IntAddOvf/IntSubOvf/IntMulOvf opcode"),
     };
+    count_ops_executed(ctx, opcode);
     if b1.is_constant() && b2.is_constant() {
         return Ok((ctx.trace_ctx.const_int(wrapping_result), overflow));
     }
+    count_ops_recorded(ctx, opcode);
     let resbox = ctx.trace_ctx.record_op(opcode, &[b1, b2]);
     ctx.trace_ctx
         .set_opref_concrete(resbox, Value::Int(wrapping_result));
@@ -275,6 +301,7 @@ pub(crate) fn execute_pure_binop_i<Sym: WalkSym>(
     a: OpRef,
     b: OpRef,
 ) -> OpRef {
+    count_ops_executed(ctx, opcode);
     if let (Some(majit_ir::Value::Int(va)), Some(majit_ir::Value::Int(vb))) =
         (a.inline_const_to_value(), b.inline_const_to_value())
     {
@@ -282,6 +309,7 @@ pub(crate) fn execute_pure_binop_i<Sym: WalkSym>(
         return ctx.trace_ctx.const_int(folded);
     }
 
+    count_ops_recorded(ctx, opcode);
     let result = ctx.trace_ctx.record_op(opcode, &[a, b]);
     if let (Some(majit_ir::Value::Int(va)), Some(majit_ir::Value::Int(vb))) =
         (ctx.trace_ctx.box_value(a), ctx.trace_ctx.box_value(b))
@@ -309,8 +337,10 @@ pub(crate) fn unop_int_record<Sym: WalkSym>(
     // A `Const` operand folds without recording (`execute_and_record`'s
     // `_all_constants` short-circuit) — except `int_same_as`, whose
     // `opimpl_int_same_as` calls `_record_helper` unconditionally to
-    // force the result into a Box.
+    // force the result into a Box (bypassing `execute_and_record`, so it
+    // skips the base `OPS` count too).
     if opcode != OpCode::SameAsI {
+        count_ops_executed(ctx, opcode);
         if let Some(majit_ir::Value::Int(n)) = a.inline_const_to_value() {
             let folded = majit_metainterp::eval_unary_i(opcode, n);
             let result = ctx.trace_ctx.const_int(folded);
@@ -319,6 +349,7 @@ pub(crate) fn unop_int_record<Sym: WalkSym>(
             return Ok((DispatchOutcome::Continue, op.next_pc));
         }
     }
+    count_ops_recorded(ctx, opcode);
     let result = ctx.trace_ctx.record_op(opcode, &[a]);
     // Box(value) parity: stamp the unary result from the operand's
     // Box.value carrier (matches dispatch.rs trace_unary_i).  The
@@ -364,6 +395,7 @@ pub(crate) fn binop_ref_to_int_record<Sym: WalkSym>(
         write_int_reg(ctx, op.pc, dst, result, ConcreteValue::Int(folded))?;
         return Ok((DispatchOutcome::Continue, op.next_pc));
     }
+    count_ops_executed(ctx, opcode);
     // Distinct all-`Const` ref operands fold to a result constant without
     // recording — `execute_and_record` const-folds any pure op whose operands
     // are all `Const`, and the sibling `record_ptr_cmp` already does this. Two
@@ -382,6 +414,7 @@ pub(crate) fn binop_ref_to_int_record<Sym: WalkSym>(
         write_int_reg(ctx, op.pc, dst, result, ConcreteValue::Int(folded))?;
         return Ok((DispatchOutcome::Continue, op.next_pc));
     }
+    count_ops_recorded(ctx, opcode);
     let result = ctx.trace_ctx.record_op(opcode, &[a, b]);
     // Stamp the bool result from the operands' concrete carriers: the
     // `box_value` carrier first, then the `concrete_registers_r` shadow. The
@@ -434,6 +467,7 @@ pub(crate) fn record_ptr_cmp<Sym: WalkSym>(
             .unwrap_or_else(|| unreachable!("record_ptr_cmp requires PtrEq or PtrNe"));
         return ctx.trace_ctx.const_int(folded);
     }
+    count_ops_executed(ctx, opcode);
     if let (Some(Value::Ref(la)), Some(Value::Ref(rb))) =
         (a.inline_const_to_value(), b.inline_const_to_value())
     {
@@ -443,6 +477,7 @@ pub(crate) fn record_ptr_cmp<Sym: WalkSym>(
             _ => unreachable!("record_ptr_cmp requires PtrEq or PtrNe"),
         });
     }
+    count_ops_recorded(ctx, opcode);
     let result = ctx.trace_ctx.record_op(opcode, &[a, b]);
     let folded = if let (Some(majit_ir::Value::Ref(la)), Some(majit_ir::Value::Ref(rb))) =
         (ctx.trace_ctx.box_value(a), ctx.trace_ctx.box_value(b))
@@ -497,6 +532,12 @@ pub(crate) fn ptr_nullity_record<Sym: WalkSym>(
     nonzero: bool,
 ) -> Result<(DispatchOutcome, usize), DispatchError> {
     let box_ = read_ref_reg(code, op, 0, ctx)?;
+    let opcode = if nonzero {
+        OpCode::PtrNe
+    } else {
+        OpCode::PtrEq
+    };
+    count_ops_executed(ctx, opcode);
     // A `Const` box folds without recording: `CONST_NULL` is a `Const`, so
     // `_all_constants` holds and `execute_and_record` answers the nullity
     // from the constant's own address.
@@ -508,11 +549,7 @@ pub(crate) fn ptr_nullity_record<Sym: WalkSym>(
         return Ok((DispatchOutcome::Continue, op.next_pc));
     }
     let null_const = ctx.trace_ctx.const_null();
-    let opcode = if nonzero {
-        OpCode::PtrNe
-    } else {
-        OpCode::PtrEq
-    };
+    count_ops_recorded(ctx, opcode);
     let result = ctx.trace_ctx.record_op(opcode, &[box_, null_const]);
     // Concrete stamp: prefer the box's own value carrier (constant pool /
     // standard-virtualizable shadow / `set_opref_concrete` stamp).  When the
@@ -658,6 +695,7 @@ pub(crate) fn binop_float_to_int_record<Sym: WalkSym>(
 ) -> Result<(DispatchOutcome, usize), DispatchError> {
     let a = read_float_reg(code, op, 0, ctx)?;
     let b = read_float_reg(code, op, 1, ctx)?;
+    count_ops_executed(ctx, opcode);
     // All-`Const` operands fold without recording (`execute_and_record`'s
     // `_all_constants` short-circuit; FLOAT_LT..FLOAT_GE are ALWAYS_PURE).
     // No `a == b` fast path: float compares are not `FASTPATHS_SAME_BOXES`
@@ -672,6 +710,7 @@ pub(crate) fn binop_float_to_int_record<Sym: WalkSym>(
         write_int_reg(ctx, op.pc, dst, result, ConcreteValue::Int(folded))?;
         return Ok((DispatchOutcome::Continue, op.next_pc));
     }
+    count_ops_recorded(ctx, opcode);
     let result = ctx.trace_ctx.record_op(opcode, &[a, b]);
     // Box(value) parity: stamp the bool result from the operands' Box.value
     // carriers (matches dispatch.rs GOTO_IF_NOT_FLOAT_* + trace_float_compare).
@@ -700,6 +739,7 @@ pub(crate) fn record_float_cmp<Sym: WalkSym>(
     // short-circuit), and `opimpl_goto_if_not` emits no guard for a `Const`
     // condbox.  No `b1 is b2` fast path: the fused float compares are
     // generated with `if False and b1 is b2` (`x == x` is false for a NaN).
+    count_ops_executed(ctx, opcode);
     if let (Some(Value::Float(fa)), Some(Value::Float(fb))) =
         (a.inline_const_to_value(), b.inline_const_to_value())
     {
@@ -707,6 +747,7 @@ pub(crate) fn record_float_cmp<Sym: WalkSym>(
             majit_metainterp::eval_float_cmp(opcode, fa.to_bits() as i64, fb.to_bits() as i64);
         return ctx.trace_ctx.const_int(folded);
     }
+    count_ops_recorded(ctx, opcode);
     let result = ctx.trace_ctx.record_op(opcode, &[a, b]);
     if let (Some(majit_ir::Value::Float(fa)), Some(majit_ir::Value::Float(fb))) =
         (ctx.trace_ctx.box_value(a), ctx.trace_ctx.box_value(b))
@@ -734,6 +775,7 @@ pub(crate) fn unop_cast_record<Sym: WalkSym>(
     opcode: OpCode,
 ) -> Result<(DispatchOutcome, usize), DispatchError> {
     let dst = code[op.pc + 2] as usize;
+    count_ops_executed(ctx, opcode);
     match opcode {
         // `cast_int_to_float/i>f`: Int-bank → Float-bank. Stamp the
         // result with the operand's Box.value as an f64 so downstream
@@ -746,6 +788,7 @@ pub(crate) fn unop_cast_record<Sym: WalkSym>(
             let result = if let Some(majit_ir::Value::Int(n)) = a.inline_const_to_value() {
                 ctx.trace_ctx.const_float((n as f64).to_bits() as i64)
             } else {
+                count_ops_recorded(ctx, opcode);
                 let result = ctx.trace_ctx.record_op(opcode, &[a]);
                 if let Some(majit_ir::Value::Int(n)) = ctx.trace_ctx.box_value(a) {
                     ctx.trace_ctx
@@ -777,6 +820,7 @@ pub(crate) fn unop_cast_record<Sym: WalkSym>(
         // invalidates.  Keep recording both.
         OpCode::CastIntToPtr => {
             let a = read_int_reg(code, op, 0, ctx)?;
+            count_ops_recorded(ctx, opcode);
             let result = ctx.trace_ctx.record_op(opcode, &[a]);
             if let Some(majit_ir::Value::Int(n)) = ctx.trace_ctx.box_value(a) {
                 ctx.trace_ctx
@@ -788,6 +832,7 @@ pub(crate) fn unop_cast_record<Sym: WalkSym>(
         // operand's Box.value (`BoxRef(p)` → `BoxInt(p as i64)`).
         OpCode::CastPtrToInt => {
             let a = read_ref_reg(code, op, 0, ctx)?;
+            count_ops_recorded(ctx, opcode);
             let result = ctx.trace_ctx.record_op(opcode, &[a]);
             if let Some(majit_ir::Value::Ref(r)) = ctx.trace_ctx.box_value(a) {
                 ctx.trace_ctx
@@ -815,6 +860,7 @@ pub(crate) fn binop_float_record<Sym: WalkSym>(
 ) -> Result<(DispatchOutcome, usize), DispatchError> {
     let a = read_float_reg(code, op, 0, ctx)?;
     let b = read_float_reg(code, op, 1, ctx)?;
+    count_ops_executed(ctx, opcode);
     // All-`Const` operands fold without recording (`execute_and_record`'s
     // `_all_constants` short-circuit; FLOAT_ADD..FLOAT_TRUEDIV are
     // ALWAYS_PURE).
@@ -837,6 +883,7 @@ pub(crate) fn binop_float_record<Sym: WalkSym>(
         *slot = result;
         return Ok((DispatchOutcome::Continue, op.next_pc));
     }
+    count_ops_recorded(ctx, opcode);
     let result = ctx.trace_ctx.record_op(opcode, &[a, b]);
     // Box(value) parity: stamp the result from the operands' Box.value
     // carriers (matches dispatch.rs trace_binop_f).
@@ -873,6 +920,7 @@ pub(crate) fn unop_float_record<Sym: WalkSym>(
     opcode: OpCode,
 ) -> Result<(DispatchOutcome, usize), DispatchError> {
     let a = read_float_reg(code, op, 0, ctx)?;
+    count_ops_executed(ctx, opcode);
     // A `Const` operand folds without recording (`execute_and_record`'s
     // `_all_constants` short-circuit; FLOAT_NEG / FLOAT_ABS are
     // ALWAYS_PURE).
@@ -893,6 +941,7 @@ pub(crate) fn unop_float_record<Sym: WalkSym>(
         *slot = result;
         return Ok((DispatchOutcome::Continue, op.next_pc));
     }
+    count_ops_recorded(ctx, opcode);
     let result = ctx.trace_ctx.record_op(opcode, &[a]);
     // Box(value) parity: stamp the unary float result (matches dispatch.rs
     // trace_unary_f — FloatNeg / FloatAbs).

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/arith.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/arith.rs
@@ -646,6 +646,20 @@ pub(crate) fn binop_float_to_int_record<Sym: WalkSym>(
 ) -> Result<(DispatchOutcome, usize), DispatchError> {
     let a = read_float_reg(code, op, 0, ctx)?;
     let b = read_float_reg(code, op, 1, ctx)?;
+    // All-`Const` operands fold without recording (`execute_and_record`'s
+    // `_all_constants` short-circuit; FLOAT_LT..FLOAT_GE are ALWAYS_PURE).
+    // No `a == b` fast path: float compares are not `FASTPATHS_SAME_BOXES`
+    // members (`x == x` is false for a NaN).
+    if let (Some(majit_ir::Value::Float(fa)), Some(majit_ir::Value::Float(fb))) =
+        (a.inline_const_to_value(), b.inline_const_to_value())
+    {
+        let folded =
+            majit_metainterp::eval_float_cmp(opcode, fa.to_bits() as i64, fb.to_bits() as i64);
+        let result = ctx.trace_ctx.const_int(folded);
+        let dst = code[op.pc + 3] as usize;
+        write_int_reg(ctx, op.pc, dst, result, ConcreteValue::Int(folded))?;
+        return Ok((DispatchOutcome::Continue, op.next_pc));
+    }
     let result = ctx.trace_ctx.record_op(opcode, &[a, b]);
     // Box(value) parity: stamp the bool result from the operands' Box.value
     // carriers (matches dispatch.rs GOTO_IF_NOT_FLOAT_* + trace_float_compare).
@@ -669,9 +683,18 @@ pub(crate) fn record_float_cmp<Sym: WalkSym>(
     a: OpRef,
     b: OpRef,
 ) -> OpRef {
-    // Mirrors `self.execute(rop.<CMP>, b1, b2)` but does not pre-fold
-    // `_all_constants` / `b1 is b2` (`pyjitpl.py`);
-    // the recorded compare and downstream guard are optimizer-folded/strengthened.
+    // Mirrors `self.execute(rop.<CMP>, b1, b2)`: all-`Const` operands fold
+    // without recording (`execute_and_record`'s `_all_constants`
+    // short-circuit), and `opimpl_goto_if_not` emits no guard for a `Const`
+    // condbox.  No `b1 is b2` fast path: the fused float compares are
+    // generated with `if False and b1 is b2` (`x == x` is false for a NaN).
+    if let (Some(Value::Float(fa)), Some(Value::Float(fb))) =
+        (a.inline_const_to_value(), b.inline_const_to_value())
+    {
+        let folded =
+            majit_metainterp::eval_float_cmp(opcode, fa.to_bits() as i64, fb.to_bits() as i64);
+        return ctx.trace_ctx.const_int(folded);
+    }
     let result = ctx.trace_ctx.record_op(opcode, &[a, b]);
     if let (Some(majit_ir::Value::Float(fa)), Some(majit_ir::Value::Float(fb))) =
         (ctx.trace_ctx.box_value(a), ctx.trace_ctx.box_value(b))
@@ -764,6 +787,28 @@ pub(crate) fn binop_float_record<Sym: WalkSym>(
 ) -> Result<(DispatchOutcome, usize), DispatchError> {
     let a = read_float_reg(code, op, 0, ctx)?;
     let b = read_float_reg(code, op, 1, ctx)?;
+    // All-`Const` operands fold without recording (`execute_and_record`'s
+    // `_all_constants` short-circuit; FLOAT_ADD..FLOAT_TRUEDIV are
+    // ALWAYS_PURE).
+    if let (Some(majit_ir::Value::Float(fa)), Some(majit_ir::Value::Float(fb))) =
+        (a.inline_const_to_value(), b.inline_const_to_value())
+    {
+        let bits = majit_metainterp::eval_binop_f(opcode, fa.to_bits() as i64, fb.to_bits() as i64);
+        let result = ctx.trace_ctx.const_float(bits);
+        let dst = code[op.pc + 3] as usize;
+        let len = ctx.registers_f.len();
+        let slot = ctx
+            .registers_f
+            .get_mut(dst)
+            .ok_or(DispatchError::RegisterOutOfRange {
+                pc: op.pc,
+                reg: dst,
+                len,
+                bank: "f",
+            })?;
+        *slot = result;
+        return Ok((DispatchOutcome::Continue, op.next_pc));
+    }
     let result = ctx.trace_ctx.record_op(opcode, &[a, b]);
     // Box(value) parity: stamp the result from the operands' Box.value
     // carriers (matches dispatch.rs trace_binop_f).
@@ -800,6 +845,26 @@ pub(crate) fn unop_float_record<Sym: WalkSym>(
     opcode: OpCode,
 ) -> Result<(DispatchOutcome, usize), DispatchError> {
     let a = read_float_reg(code, op, 0, ctx)?;
+    // A `Const` operand folds without recording (`execute_and_record`'s
+    // `_all_constants` short-circuit; FLOAT_NEG / FLOAT_ABS are
+    // ALWAYS_PURE).
+    if let Some(majit_ir::Value::Float(fa)) = a.inline_const_to_value() {
+        let bits = majit_metainterp::eval_unary_f(opcode, fa.to_bits() as i64);
+        let result = ctx.trace_ctx.const_float(bits);
+        let dst = code[op.pc + 2] as usize;
+        let len = ctx.registers_f.len();
+        let slot = ctx
+            .registers_f
+            .get_mut(dst)
+            .ok_or(DispatchError::RegisterOutOfRange {
+                pc: op.pc,
+                reg: dst,
+                len,
+                bank: "f",
+            })?;
+        *slot = result;
+        return Ok((DispatchOutcome::Continue, op.next_pc));
+    }
     let result = ctx.trace_ctx.record_op(opcode, &[a]);
     // Box(value) parity: stamp the unary float result (matches dispatch.rs
     // trace_unary_f — FloatNeg / FloatAbs).

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/arith.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/arith.rs
@@ -44,6 +44,19 @@ pub(crate) fn binop_int_record<Sym: WalkSym>(
             return Ok((DispatchOutcome::Continue, op.next_pc));
         }
     }
+    // All-`Const` operands fold to a result constant without recording —
+    // `execute_and_record` short-circuits `_record_helper` via
+    // `executor.wrap_constant(resvalue)` when `_all_constants(*argboxes)`
+    // holds for a pure op, and every opname routed here is ALWAYS_PURE.
+    if let (Some(majit_ir::Value::Int(la)), Some(majit_ir::Value::Int(rb))) =
+        (a.inline_const_to_value(), b.inline_const_to_value())
+    {
+        let folded = majit_metainterp::eval_binop_i(opcode, la, rb);
+        let result = ctx.trace_ctx.const_int(folded);
+        let dst = code[op.pc + 3] as usize;
+        write_int_reg(ctx, op.pc, dst, result, ConcreteValue::Int(folded))?;
+        return Ok((DispatchOutcome::Continue, op.next_pc));
+    }
     let result = ctx.trace_ctx.record_op(opcode, &[a, b]);
     // Box(value) parity: stamp the result from the operands' Box.value
     // carriers (BoxInt(value) — matches dispatch.rs trace_binop_i).
@@ -124,6 +137,11 @@ pub(crate) fn record_int_unary<Sym: WalkSym>(
     opcode: OpCode,
     a: OpRef,
 ) -> OpRef {
+    if let Some(Value::Int(la)) = a.inline_const_to_value() {
+        return ctx
+            .trace_ctx
+            .const_int(majit_metainterp::eval_unary_i(opcode, la));
+    }
     let result = ctx.trace_ctx.record_op(opcode, &[a]);
     if let Some(majit_ir::Value::Int(la)) = ctx.trace_ctx.box_value(a) {
         let folded = majit_metainterp::eval_unary_i(opcode, la);
@@ -288,6 +306,19 @@ pub(crate) fn unop_int_record<Sym: WalkSym>(
     opcode: OpCode,
 ) -> Result<(DispatchOutcome, usize), DispatchError> {
     let a = read_int_reg(code, op, 0, ctx)?;
+    // A `Const` operand folds without recording (`execute_and_record`'s
+    // `_all_constants` short-circuit) — except `int_same_as`, whose
+    // `opimpl_int_same_as` calls `_record_helper` unconditionally to
+    // force the result into a Box.
+    if opcode != OpCode::SameAsI {
+        if let Some(majit_ir::Value::Int(n)) = a.inline_const_to_value() {
+            let folded = majit_metainterp::eval_unary_i(opcode, n);
+            let result = ctx.trace_ctx.const_int(folded);
+            let dst = code[op.pc + 2] as usize;
+            write_int_reg(ctx, op.pc, dst, result, ConcreteValue::Int(folded))?;
+            return Ok((DispatchOutcome::Continue, op.next_pc));
+        }
+    }
     let result = ctx.trace_ctx.record_op(opcode, &[a]);
     // Box(value) parity: stamp the unary result from the operand's
     // Box.value carrier (matches dispatch.rs trace_unary_i).  The

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/heapcache_ops.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/heapcache_ops.rs
@@ -56,6 +56,12 @@ pub(crate) fn getarrayitem_gc_via_heapcache<Sym: WalkSym>(
         );
         cached
     } else {
+        ctx.trace_ctx
+            .profiler()
+            .count_ops(opcode, majit_metainterp::counters::OPS);
+        ctx.trace_ctx
+            .profiler()
+            .count_ops(opcode, majit_metainterp::counters::RECORDED_OPS);
         let resbox = ctx
             .trace_ctx
             .record_op_with_descr(opcode, &[array, index], descr.clone());
@@ -177,6 +183,13 @@ pub(crate) fn setarrayitem_gc_via_heapcache<Sym: WalkSym>(
     let descr = read_descr(code, op, 3, ctx)?;
     let descr_index = descr.index();
 
+    ctx.trace_ctx
+        .profiler()
+        .count_ops(OpCode::SetarrayitemGc, majit_metainterp::counters::OPS);
+    ctx.trace_ctx.profiler().count_ops(
+        OpCode::SetarrayitemGc,
+        majit_metainterp::counters::RECORDED_OPS,
+    );
     ctx.trace_ctx
         .record_op_with_descr(OpCode::SetarrayitemGc, &[array, index, value], descr);
     // `upd.setarrayitem(valuebox)` (heapcache.py) parity — the
@@ -332,6 +345,12 @@ pub(crate) fn setfield_gc_via_heapcache<Sym: WalkSym>(
             majit_metainterp::counters::HEAPCACHED_OPS,
         );
     } else {
+        ctx.trace_ctx
+            .profiler()
+            .count_ops(OpCode::SetfieldGc, majit_metainterp::counters::OPS);
+        ctx.trace_ctx
+            .profiler()
+            .count_ops(OpCode::SetfieldGc, majit_metainterp::counters::RECORDED_OPS);
         ctx.trace_ctx
             .record_op_with_descr(OpCode::SetfieldGc, &[obj, valuebox], descr);
         // Write-through with alias-clearing semantics
@@ -492,6 +511,12 @@ pub(crate) fn getfield_gc_via_heapcache<Sym: WalkSym>(
         // struct pointer is known (Const, vable shadow, or stamped),
         // mirroring `pyjitpl.py resbox = execute_with_descr(...);
         // upd.getfield_now_known(resbox)`.
+        ctx.trace_ctx
+            .profiler()
+            .count_ops(opcode, majit_metainterp::counters::OPS);
+        ctx.trace_ctx
+            .profiler()
+            .count_ops(opcode, majit_metainterp::counters::RECORDED_OPS);
         let resbox = ctx
             .trace_ctx
             .record_op_with_descr(opcode, &[obj], descr.clone());

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/heapcache_ops.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/heapcache_ops.rs
@@ -38,6 +38,63 @@ pub(crate) fn getarrayitem_gc_via_heapcache<Sym: WalkSym>(
     let descr = read_descr(code, op, 2, ctx)?;
     let descr_index = descr.index();
 
+    // `_opimpl_getarrayitem_gc_pure_any`: directly-constant array and
+    // index operands bypass the heapcache completely — execute the load
+    // now and substitute a `Const`, with no profiler counts (the bypass
+    // calls `executor.execute`, not `execute_and_record`).
+    let is_pure = matches!(
+        opcode,
+        OpCode::GetarrayitemGcPureI | OpCode::GetarrayitemGcPureR | OpCode::GetarrayitemGcPureF
+    );
+    if is_pure && array.is_constant() && index.is_constant() {
+        let load_type = match opcode {
+            OpCode::GetarrayitemGcPureI => majit_ir::Type::Int,
+            OpCode::GetarrayitemGcPureR => majit_ir::Type::Ref,
+            _ => majit_ir::Type::Float,
+        };
+        if let (Some(majit_ir::Value::Ref(array_ref)), Some(majit_ir::Value::Int(index_value))) = (
+            ctx.trace_ctx.box_value(array),
+            ctx.trace_ctx.box_value(index),
+        ) {
+            let array_ptr = array_ref.0 as i64;
+            if array_ptr != 0 && array_ptr != usize::MAX as i64 {
+                let folded =
+                    match ctx
+                        .trace_ctx
+                        .array_sanity_load(array_ptr, index_value, &descr, load_type)
+                    {
+                        Some(majit_ir::Value::Int(n)) => Some(ctx.trace_ctx.const_int(n)),
+                        Some(majit_ir::Value::Ref(r)) => Some(ctx.trace_ctx.const_ref(r.0 as i64)),
+                        Some(majit_ir::Value::Float(f)) => {
+                            Some(ctx.trace_ctx.const_float(f.to_bits() as i64))
+                        }
+                        Some(majit_ir::Value::Void) | None => None,
+                    };
+                if let Some(folded) = folded {
+                    let dst = code[op.pc + 5] as usize;
+                    let concrete = concrete_from_recorded_opref(ctx, folded);
+                    match dst_bank {
+                        'i' => write_int_reg(ctx, op.pc, dst, folded, concrete)?,
+                        'r' => write_ref_reg(ctx, op.pc, dst, folded, concrete)?,
+                        _ => {
+                            let len = ctx.registers_f.len();
+                            let slot = ctx.registers_f.get_mut(dst).ok_or(
+                                DispatchError::RegisterOutOfRange {
+                                    pc: op.pc,
+                                    reg: dst,
+                                    len,
+                                    bank: "f",
+                                },
+                            )?;
+                            *slot = folded;
+                        }
+                    }
+                    return Ok((DispatchOutcome::Continue, op.next_pc));
+                }
+            }
+        }
+    }
+
     let result = if let Some(cached) =
         ctx.trace_ctx
             .heapcache_getarrayitem(array, index, descr_index)
@@ -511,12 +568,21 @@ pub(crate) fn getfield_gc_via_heapcache<Sym: WalkSym>(
         // struct pointer is known (Const, vable shadow, or stamped),
         // mirroring `pyjitpl.py resbox = execute_with_descr(...);
         // upd.getfield_now_known(resbox)`.
+        // The `_pure` jitcode spellings alias `opimpl_getfield_gc_*`
+        // upstream, so the profiler always sees the plain opnum even
+        // when the pure opcode is what gets recorded.
+        let profiled_opcode = match opcode {
+            OpCode::GetfieldGcPureI => OpCode::GetfieldGcI,
+            OpCode::GetfieldGcPureR => OpCode::GetfieldGcR,
+            OpCode::GetfieldGcPureF => OpCode::GetfieldGcF,
+            other => other,
+        };
         ctx.trace_ctx
             .profiler()
-            .count_ops(opcode, majit_metainterp::counters::OPS);
+            .count_ops(profiled_opcode, majit_metainterp::counters::OPS);
         ctx.trace_ctx
             .profiler()
-            .count_ops(opcode, majit_metainterp::counters::RECORDED_OPS);
+            .count_ops(profiled_opcode, majit_metainterp::counters::RECORDED_OPS);
         let resbox = ctx
             .trace_ctx
             .record_op_with_descr(opcode, &[obj], descr.clone());

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/tests.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/tests.rs
@@ -6094,11 +6094,11 @@ fn ptr_nonzero_records_ptrne_with_box_and_null() {
         .unwrap_or_else(|| panic!("`{opname}` must be in insns table"));
     // Operand encoding `r>i`: 1B r-reg + 1B i-reg-dst = 2B
     let code = [byte, 0, 0];
-    let mut tc = fresh_trace_ctx();
+    // A `Const` box folds (`_all_constants` — CONST_NULL is a `Const`), so
+    // the record path needs a genuinely non-const InputArg operand.
+    let mut tc = TraceCtx::for_test_types(&[Type::Ref]);
     let descr = done_descr_ref_for_tests();
-    // Seed `registers_r[0]` with a placeholder OpRef so the
-    // handler has something to read.
-    let box_opref = tc.const_ref(0xdeadbeef);
+    let box_opref = OpRef::input_arg_ref(0);
     let mut regs_r = [box_opref];
     let mut regs_i = [OpRef::None];
     let session = std::cell::RefCell::new(WalkSession::default());
@@ -6174,6 +6174,71 @@ fn ptr_nonzero_records_ptrne_with_box_and_null() {
         Some(Type::Ref)
     );
     assert_ne!(wc.registers_i[0], OpRef::None);
+}
+
+#[test]
+fn ptr_nullity_folds_a_const_box_without_recording() {
+    // `execute(PTR_NE, box, CONST_NULL)` has all-`Const` operands when
+    // `box` is a `Const` — `_all_constants` folds the nullity answer
+    // without recording.
+    let byte = *insns_opname_to_byte()
+        .get("ptr_nonzero/r>i")
+        .expect("`ptr_nonzero/r>i` must be in insns table");
+    let code = [byte, 0, 0];
+
+    let mut tc = fresh_trace_ctx();
+    let nonnull = tc.const_ref(0xdeadbeef);
+    let mut regs_r = [nonnull];
+    let mut regs_i = [OpRef::None];
+    let (_, next_pc) = run_hint_step(&code, &mut tc, &mut regs_r, &mut [], &mut regs_i)
+        .expect("ptr_nonzero on a const ref must fold");
+    assert_eq!(next_pc, 3);
+    assert_eq!(tc.num_ops(), 0, "a const box folds without recording");
+    assert_eq!(
+        regs_i[0].inline_const_to_value(),
+        Some(majit_ir::Value::Int(1)),
+        "a non-null const ref folds ptr_nonzero to 1",
+    );
+
+    let mut null_tc = fresh_trace_ctx();
+    let null = null_tc.const_null();
+    let mut null_regs_r = [null];
+    let mut null_regs_i = [OpRef::None];
+    let (_, _) = run_hint_step(
+        &code,
+        &mut null_tc,
+        &mut null_regs_r,
+        &mut [],
+        &mut null_regs_i,
+    )
+    .expect("ptr_nonzero on the null const must fold");
+    assert_eq!(null_tc.num_ops(), 0);
+    assert_eq!(
+        null_regs_i[0].inline_const_to_value(),
+        Some(majit_ir::Value::Int(0)),
+        "the null const folds ptr_nonzero to 0",
+    );
+}
+
+#[test]
+fn cast_int_to_float_folds_a_const_int_without_recording() {
+    let byte = *insns_opname_to_byte()
+        .get("cast_int_to_float/i>f")
+        .expect("`cast_int_to_float/i>f` must be in insns table");
+    let code = [byte, 0x00, 0x00]; // `i>f`: i-src=0, f-dst=0
+    let mut tc = fresh_trace_ctx();
+    let operand = tc.const_int(42);
+    let mut regs_i = [operand];
+    let mut regs_f = [OpRef::None];
+    let (_, next_pc) = run_float_step(&code, &mut tc, &mut regs_f, &mut regs_i)
+        .expect("cast_int_to_float on a const int must fold");
+    assert_eq!(next_pc, 3);
+    assert_eq!(tc.num_ops(), 0, "a const operand folds without recording");
+    assert_eq!(
+        regs_f[0].inline_const_to_value(),
+        Some(majit_ir::Value::Float(42.0)),
+        "dst must hold the folded ConstFloat",
+    );
 }
 
 /// `abort/>r` is a pyre-only no-op result marker — the walker

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/tests.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/tests.rs
@@ -10309,6 +10309,151 @@ fn getarrayitem_gc_r_cache_miss_records_op_and_writes_dst() {
     assert_eq!(dst_post, last.pos.get());
 }
 
+/// Backend stub for the pure-getarrayitem bypass test: the required
+/// methods are unreachable; `bh_getarrayitem_gc_*` trait defaults read
+/// the real backing memory.
+struct PureArrayTestCpu;
+impl majit_backend::Backend for PureArrayTestCpu {
+    fn compile_loop(
+        &mut self,
+        _inputargs: &[majit_ir::InputArg],
+        _ops: &[majit_ir::OpRc],
+        _token: &majit_backend::JitCellToken,
+    ) -> Result<majit_backend::AsmInfo, majit_backend::BackendError> {
+        unimplemented!("PureArrayTestCpu::compile_loop")
+    }
+    fn compile_bridge(
+        &mut self,
+        _fail_descr: &dyn majit_ir::FailDescr,
+        _inputargs: &[majit_ir::InputArg],
+        _ops: &[majit_ir::OpRc],
+        _original_token: &majit_backend::JitCellToken,
+        _previous_tokens: &[std::sync::Arc<majit_backend::JitCellToken>],
+        _caller_recovery_layout: Option<&majit_backend::ExitRecoveryLayout>,
+    ) -> Result<majit_backend::AsmInfo, majit_backend::BackendError> {
+        unimplemented!("PureArrayTestCpu::compile_bridge")
+    }
+    fn execute_token(
+        &self,
+        _token: &majit_backend::JitCellToken,
+        _args: &[majit_ir::Value],
+    ) -> majit_backend::DeadFrame {
+        unimplemented!("PureArrayTestCpu::execute_token")
+    }
+    fn get_latest_descr<'a>(
+        &'a self,
+        _frame: &'a majit_backend::DeadFrame,
+    ) -> &'a dyn majit_ir::FailDescr {
+        unimplemented!("PureArrayTestCpu::get_latest_descr")
+    }
+    fn get_latest_descr_arc(
+        &self,
+        _frame: &majit_backend::DeadFrame,
+    ) -> std::sync::Arc<dyn majit_ir::descr::Descr> {
+        unimplemented!("PureArrayTestCpu::get_latest_descr_arc")
+    }
+    fn get_int_value(&self, _frame: &majit_backend::DeadFrame, _index: usize) -> i64 {
+        unimplemented!("PureArrayTestCpu::get_int_value")
+    }
+    fn get_float_value(&self, _frame: &majit_backend::DeadFrame, _index: usize) -> f64 {
+        unimplemented!("PureArrayTestCpu::get_float_value")
+    }
+    fn get_ref_value(&self, _frame: &majit_backend::DeadFrame, _index: usize) -> majit_ir::GcRef {
+        unimplemented!("PureArrayTestCpu::get_ref_value")
+    }
+    fn invalidate_loop(&self, _token: &majit_backend::JitCellToken) {
+        unimplemented!("PureArrayTestCpu::invalidate_loop")
+    }
+}
+
+/// `_opimpl_getarrayitem_gc_pure_any`: directly-constant array and index
+/// operands bypass the heapcache — the load executes now, the result is
+/// a `Const`, nothing is recorded, and no profiler bucket counts (the
+/// bypass calls `executor.execute`, not `execute_and_record`).
+#[test]
+fn getarrayitem_gc_pure_const_operands_fold_without_recording_or_counting() {
+    let byte = *insns_opname_to_byte()
+        .get("getarrayitem_gc_i_pure/rid>i")
+        .expect("`getarrayitem_gc_i_pure/rid>i` must be in insns table");
+    let code = [byte, 0x02, 0x03, 0x01, 0x00, 0x05];
+    let cpu = PureArrayTestCpu;
+    let mut tc = fresh_trace_ctx();
+    tc.set_cpu(Some(&cpu));
+    // Fake GcArray block: length prefix at offset 0, items from
+    // base_size 8 → item[1] == 9.
+    let storage: Box<[usize; 3]> = Box::new([2, 7, 9]);
+    let ptr = storage.as_ref().as_ptr() as i64;
+    let mut regs_r = distinct_const_refs(&mut tc, 8);
+    let mut regs_i = distinct_const_ints(&mut tc, 8);
+    regs_r[2] = tc.const_ref(ptr);
+    regs_i[3] = tc.const_int(1);
+    let descr = crate::descr::make_array_descr(8, 8, Some(0), majit_ir::Type::Int, true);
+    let descr_pool: Vec<DescrRef> = vec![make_fail_descr(0), descr];
+    let frame_done = done_descr_ref_for_tests();
+    let ops_before = tc.num_ops();
+    let prof_before = tc.profiler().snapshot();
+    let session = std::cell::RefCell::new(WalkSession::default());
+    let mut wc = WalkContext {
+        callee_shadow: None,
+        inline_callee_consts: None,
+        fbw_mode: test_fbw_mode(),
+        session: &session,
+        registers_r: &mut regs_r,
+        registers_i: &mut regs_i,
+        registers_f: &mut [],
+        concrete_registers_r: &mut [],
+        concrete_registers_i: &mut [],
+        descr_refs: &descr_pool,
+        raw_descrs: RawDescrPool::Global,
+        is_authoritative_executor: false,
+        trace_ctx: &mut tc,
+        done_with_this_frame_descr_ref: frame_done,
+        done_with_this_frame_descr_int: make_fail_descr(101),
+        done_with_this_frame_descr_float: make_fail_descr(102),
+        done_with_this_frame_descr_void: make_fail_descr(103),
+        exit_frame_with_exception_descr_ref: make_fail_descr(2),
+        is_top_level: true,
+        sub_jitcode_lookup: &no_sub_jitcodes,
+        last_exc_value: None,
+        last_exc_value_concrete: ConcreteValue::Null,
+        entry_py_pc: EntryPyPc::Py(0),
+        outer_resume_marker_jit_pc: None,
+        outer_jitcode_index: 0,
+        outer_active_boxes: Vec::new(),
+        store_subscr_fn_addr: None,
+        pending_guard_snapshot_error: None,
+        vstack_boxes: Vec::new(),
+        vstack_depth: 0,
+        vstack_cur_pypc: 0,
+        vstack_valid: false,
+        vstack_last_ref: OpRef::NONE,
+        vstack_reorder_ceiling: u32::MAX,
+        live_before_jit_pc: usize::MAX,
+        live_after_jit_pc: usize::MAX,
+    };
+    let (outcome, next_pc) = step(&code, 0, &mut wc).expect("getarrayitem_gc_i_pure must dispatch");
+    assert_eq!(outcome, DispatchOutcome::Continue);
+    assert_eq!(next_pc, 6);
+    let dst_post = wc.registers_i[5];
+    drop(wc);
+    assert!(dst_post.is_constant(), "the bypass substitutes a Const");
+    assert_eq!(
+        dst_post.inline_const_to_value(),
+        Some(majit_ir::Value::Int(9)),
+        "item[1] of the backing array"
+    );
+    assert_eq!(
+        tc.num_ops(),
+        ops_before,
+        "the bypass records no ArrayitemGc op"
+    );
+    let prof_after = tc.profiler().snapshot();
+    assert_eq!(prof_after.ops, prof_before.ops);
+    assert_eq!(prof_after.recorded_ops, prof_before.recorded_ops);
+    assert_eq!(prof_after.heapcached_ops, prof_before.heapcached_ops);
+    drop(storage);
+}
+
 #[test]
 fn getarrayitem_gc_r_cache_hit_returns_cached_box() {
     // Pre-cache (array, index, descr) →

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/tests.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/tests.rs
@@ -5687,6 +5687,159 @@ fn int_unop_folds_a_const_int_operand_without_recording() {
     );
 }
 
+/// [`run_hint_step`] companion for float-bank steps: same lean harness
+/// with caller-supplied `registers_f` (and `registers_i` for the
+/// `ff>i` compares).
+fn run_float_step(
+    code: &[u8],
+    tc: &mut TraceCtx,
+    regs_f: &mut [OpRef],
+    regs_i: &mut [OpRef],
+) -> Result<(DispatchOutcome, usize), DispatchError> {
+    let outer_jitcode_index = test_outer_resume_jitcode_index();
+    let session = std::cell::RefCell::new(WalkSession::default());
+    let mut wc = WalkContext {
+        callee_shadow: None,
+        inline_callee_consts: None,
+        fbw_mode: test_fbw_mode(),
+        session: &session,
+        registers_r: &mut [],
+        registers_i: regs_i,
+        registers_f: regs_f,
+        concrete_registers_r: &mut [],
+        concrete_registers_i: &mut [],
+        descr_refs: &[],
+        raw_descrs: RawDescrPool::Global,
+        is_authoritative_executor: false,
+        trace_ctx: tc,
+        done_with_this_frame_descr_ref: done_descr_ref_for_tests(),
+        done_with_this_frame_descr_int: make_fail_descr(101),
+        done_with_this_frame_descr_float: make_fail_descr(102),
+        done_with_this_frame_descr_void: make_fail_descr(103),
+        exit_frame_with_exception_descr_ref: make_fail_descr(2),
+        is_top_level: true,
+        sub_jitcode_lookup: &no_sub_jitcodes,
+        last_exc_value: None,
+        last_exc_value_concrete: ConcreteValue::Null,
+        entry_py_pc: EntryPyPc::Py(0),
+        outer_resume_marker_jit_pc: Some(0),
+        outer_jitcode_index,
+        outer_active_boxes: Vec::new(),
+        store_subscr_fn_addr: None,
+        pending_guard_snapshot_error: None,
+        vstack_boxes: Vec::new(),
+        vstack_depth: 0,
+        vstack_cur_pypc: 0,
+        vstack_valid: false,
+        vstack_last_ref: OpRef::NONE,
+        vstack_reorder_ceiling: u32::MAX,
+        live_before_jit_pc: usize::MAX,
+        live_after_jit_pc: usize::MAX,
+    };
+    step(code, 0, &mut wc)
+}
+
+#[test]
+fn float_binop_folds_two_const_float_operands_without_recording() {
+    let byte = *insns_opname_to_byte()
+        .get("float_add/ff>f")
+        .expect("`float_add/ff>f` must be in insns table");
+    let code = [byte, 0x00, 0x01, 0x02]; // `ff>f`: src1=0, src2=1, dst=2
+    let mut tc = fresh_trace_ctx();
+    let lhs = tc.const_float((40.0f64).to_bits() as i64);
+    let rhs = tc.const_float((2.0f64).to_bits() as i64);
+    let mut regs_f = [lhs, rhs, OpRef::None];
+    let ops_before = tc.num_ops();
+    let (_, next_pc) = run_float_step(&code, &mut tc, &mut regs_f, &mut [])
+        .expect("float_add on two const floats must fold");
+    assert_eq!(next_pc, 4);
+    assert_eq!(
+        tc.num_ops(),
+        ops_before,
+        "all-const operands fold without recording a FloatAdd",
+    );
+    assert_eq!(
+        regs_f[2].inline_const_to_value(),
+        Some(majit_ir::Value::Float(42.0)),
+        "dst must hold the folded ConstFloat",
+    );
+}
+
+#[test]
+fn float_unop_folds_a_const_float_operand_without_recording() {
+    let byte = *insns_opname_to_byte()
+        .get("float_neg/f>f")
+        .expect("`float_neg/f>f` must be in insns table");
+    let code = [byte, 0x00, 0x01]; // `f>f`: src=0, dst=1
+    let mut tc = fresh_trace_ctx();
+    let operand = tc.const_float((1.5f64).to_bits() as i64);
+    let mut regs_f = [operand, OpRef::None];
+    let ops_before = tc.num_ops();
+    let (_, next_pc) = run_float_step(&code, &mut tc, &mut regs_f, &mut [])
+        .expect("float_neg on a const float must fold");
+    assert_eq!(next_pc, 3);
+    assert_eq!(
+        tc.num_ops(),
+        ops_before,
+        "a const operand folds without recording a FloatNeg",
+    );
+    assert_eq!(
+        regs_f[1].inline_const_to_value(),
+        Some(majit_ir::Value::Float(-1.5)),
+        "dst must hold the folded ConstFloat",
+    );
+}
+
+#[test]
+fn float_compare_folds_two_const_float_operands_without_recording() {
+    let byte = *insns_opname_to_byte()
+        .get("float_lt/ff>i")
+        .expect("`float_lt/ff>i` must be in insns table");
+    let code = [byte, 0x00, 0x01, 0x00]; // `ff>i`: f-src1=0, f-src2=1, i-dst=0
+    let mut tc = fresh_trace_ctx();
+    let lhs = tc.const_float((1.0f64).to_bits() as i64);
+    let rhs = tc.const_float((2.0f64).to_bits() as i64);
+    let mut regs_f = [lhs, rhs];
+    let mut regs_i = [OpRef::None];
+    let ops_before = tc.num_ops();
+    let (_, next_pc) = run_float_step(&code, &mut tc, &mut regs_f, &mut regs_i)
+        .expect("float_lt on two const floats must fold");
+    assert_eq!(next_pc, 4);
+    assert_eq!(
+        tc.num_ops(),
+        ops_before,
+        "all-const operands fold without recording a FloatLt",
+    );
+    assert_eq!(
+        regs_i[0].inline_const_to_value(),
+        Some(majit_ir::Value::Int(1)),
+        "1.0 < 2.0 folds to ConstInt(1)",
+    );
+}
+
+#[test]
+fn fused_float_compare_folds_const_operands_without_guards() {
+    // The fused float compares route their condbox through
+    // `self.execute(rop.FLOAT_*, b1, b2)` — all-const operands fold and the
+    // `Const` condbox emits no guard.
+    let byte = *insns_opname_to_byte()
+        .get("goto_if_not_float_lt/ffL")
+        .expect("`goto_if_not_float_lt/ffL` must be in insns table");
+    let code = [byte, 0x00, 0x01, 0x09, 0x00];
+    let mut tc = fresh_trace_ctx();
+    let lhs = tc.const_float((1.0f64).to_bits() as i64);
+    let rhs = tc.const_float((2.0f64).to_bits() as i64);
+    let mut regs_f = [lhs, rhs];
+    let (_, next_pc) = run_float_step(&code, &mut tc, &mut regs_f, &mut [])
+        .expect("a const float compare has a static direction");
+    assert_eq!(next_pc, code.len(), "1.0 < 2.0 falls through");
+    assert_eq!(
+        tc.num_ops(),
+        0,
+        "const float compare records no FloatLt and no guard"
+    );
+}
+
 #[test]
 fn float_add_with_out_of_range_src_register_surfaces_typed_error() {
     let byte = *insns_opname_to_byte()

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/tests.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/tests.rs
@@ -5841,6 +5841,54 @@ fn fused_float_compare_folds_const_operands_without_guards() {
 }
 
 #[test]
+fn profiler_counts_ops_and_recorded_ops_like_execute_and_record() {
+    // `execute_and_record` counts `OPS` before the `_all_constants` fold
+    // and `_record_helper` adds `RECORDED_OPS` only when the op records;
+    // the `b1 is b2` fast path returns before `self.execute` and counts
+    // neither.
+    let byte = *insns_opname_to_byte()
+        .get("int_add/ii>i")
+        .expect("`int_add/ii>i` must be in insns table");
+    let code = [byte, 0x00, 0x01, 0x02];
+
+    // Record path: non-const operands -> OPS + RECORDED_OPS.
+    let mut tc = TraceCtx::for_test_types(&[Type::Int, Type::Int]);
+    let mut regs_i = [
+        OpRef::input_arg_int(0),
+        OpRef::input_arg_int(1),
+        OpRef::None,
+    ];
+    run_hint_step(&code, &mut tc, &mut [], &mut [], &mut regs_i).expect("int_add must record");
+    let snap = tc.profiler().snapshot();
+    assert_eq!(snap.ops, 1, "recorded int_add lands in the OPS bucket");
+    assert_eq!(snap.recorded_ops, 1, "recorded int_add adds RECORDED_OPS");
+
+    // Fold path: all-const operands -> OPS only.
+    let mut fold_tc = fresh_trace_ctx();
+    let lhs = fold_tc.const_int(1);
+    let rhs = fold_tc.const_int(2);
+    let mut fold_regs = [lhs, rhs, OpRef::None];
+    run_hint_step(&code, &mut fold_tc, &mut [], &mut [], &mut fold_regs)
+        .expect("int_add must fold");
+    let snap = fold_tc.profiler().snapshot();
+    assert_eq!(snap.ops, 1, "a folded op still lands in the OPS bucket");
+    assert_eq!(snap.recorded_ops, 0, "a folded op is not RECORDED_OPS");
+
+    // Same-box fast path: neither counter.
+    let eq_byte = *insns_opname_to_byte()
+        .get("int_eq/ii>i")
+        .expect("`int_eq/ii>i` must be in insns table");
+    let eq_code = [eq_byte, 0x00, 0x00, 0x01];
+    let mut same_tc = TraceCtx::for_test_types(&[Type::Int]);
+    let mut same_regs = [OpRef::input_arg_int(0), OpRef::None];
+    run_hint_step(&eq_code, &mut same_tc, &mut [], &mut [], &mut same_regs)
+        .expect("same-box int_eq must fold");
+    let snap = same_tc.profiler().snapshot();
+    assert_eq!(snap.ops, 0, "the same-box fast path skips self.execute");
+    assert_eq!(snap.recorded_ops, 0);
+}
+
+#[test]
 fn float_add_with_out_of_range_src_register_surfaces_typed_error() {
     let byte = *insns_opname_to_byte()
         .get("float_add/ff>f")

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/tests.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/tests.rs
@@ -5484,8 +5484,14 @@ fn drive_ptr_compare(opname: &str, expected_opcode: majit_ir::OpCode) {
         .get(opname)
         .unwrap_or_else(|| panic!("`{opname}` must be in insns table"));
     let code = [byte, 0x02, 0x04, 0x06]; // r-src1=2, r-src2=4, i-dst=6
-    let mut tc = fresh_trace_ctx();
+    let mut tc = TraceCtx::for_test_types(&[Type::Ref, Type::Ref]);
     let mut regs_r = distinct_const_refs(&mut tc, 8);
+    // Non-const operands so the compare records: PyPy folds a ptr compare only
+    // when both operands are `Const`; the distinct-const fold is covered by
+    // `ptr_eq_folds_two_distinct_const_refs_without_recording`. InputArg refs
+    // (declared by `for_test_types`) are the recordable non-const operand.
+    regs_r[2] = OpRef::input_arg_ref(0);
+    regs_r[4] = OpRef::input_arg_ref(1);
     let mut regs_i = distinct_const_refs(&mut tc, 8);
     let arg0 = regs_r[2];
     let arg1 = regs_r[4];
@@ -5569,6 +5575,37 @@ fn instance_ptr_eq_records_instanceptreq() {
 #[test]
 fn instance_ptr_ne_records_instanceptrne() {
     drive_ptr_compare("instance_ptr_ne/rr>i", majit_ir::OpCode::InstancePtrNe);
+}
+
+#[test]
+fn ptr_eq_folds_two_distinct_const_refs_without_recording() {
+    // `execute_and_record` const-folds a pure op whose operands are all
+    // `Const`; two distinct const refs answer `is` (PtrEq -> false) at trace
+    // time without a recorded PTR_EQ.
+    let byte = *insns_opname_to_byte()
+        .get("ptr_eq/rr>i")
+        .expect("`ptr_eq/rr>i` must be in insns table");
+    let code = [byte, 0x00, 0x01, 0x00]; // `rr>i`: r-src1=0, r-src2=1, i-dst=0
+    let mut tc = fresh_trace_ctx();
+    let a = tc.const_ref(0xC0DE_0000);
+    let b = tc.const_ref(0xC0DE_0001);
+    let mut regs_r = [a, b];
+    let mut regs_i = [OpRef::None];
+    let mut concrete_r = [ConcreteValue::Null, ConcreteValue::Null];
+    let ops_before = tc.num_ops();
+    let (_, next_pc) = run_hint_step(&code, &mut tc, &mut regs_r, &mut concrete_r, &mut regs_i)
+        .expect("ptr_eq on two const refs must fold");
+    assert_eq!(next_pc, 4);
+    assert_eq!(
+        tc.num_ops(),
+        ops_before,
+        "distinct const-ref operands fold without recording a PtrEq",
+    );
+    assert_eq!(
+        tc.concrete_of_opref(regs_i[0]),
+        Some(majit_ir::Value::Int(0)),
+        "distinct const refs are not identical -> PtrEq folds to 0",
+    );
 }
 
 #[test]

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/tests.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/tests.rs
@@ -1054,6 +1054,29 @@ fn fused_int_compare_folds_same_box_and_constant_operands_without_guards() {
 }
 
 #[test]
+fn fused_int_is_zero_folds_a_const_operand_without_recording() {
+    // `opimpl_goto_if_not_int_is_zero`'s condbox comes from
+    // `self.execute(rop.INT_IS_ZERO, box)` — a `Const` operand folds the
+    // condition without recording, and `opimpl_goto_if_not` emits no guard
+    // for a `Const` condbox.
+    let byte = *insns_opname_to_byte()
+        .get("goto_if_not_int_is_zero/iL")
+        .expect("`goto_if_not_int_is_zero/iL` must be in insns table");
+    let code = [byte, 0x00, 0x09, 0x00];
+    let mut tc = fresh_trace_ctx();
+    let operand = tc.const_int(5);
+    let mut regs_i = [operand];
+    let (_, next_pc) = run_hint_step(&code, &mut tc, &mut [], &mut [], &mut regs_i)
+        .expect("a const int_is_zero condition has a static direction");
+    assert_eq!(next_pc, 9, "is_zero(5) = 0 takes the not-taken label");
+    assert_eq!(
+        tc.num_ops(),
+        0,
+        "const int_is_zero records no IntIsZero and no guard"
+    );
+}
+
+#[test]
 fn fused_ptr_compare_uses_ref_shadows_for_the_runtime_direction() {
     let byte = *insns_opname_to_byte()
         .get("goto_if_not_ptr_eq/rrL")
@@ -5605,6 +5628,62 @@ fn ptr_eq_folds_two_distinct_const_refs_without_recording() {
         tc.concrete_of_opref(regs_i[0]),
         Some(majit_ir::Value::Int(0)),
         "distinct const refs are not identical -> PtrEq folds to 0",
+    );
+}
+
+#[test]
+fn int_binop_folds_two_const_int_operands_without_recording() {
+    // `execute_and_record` const-folds a pure op whose operands are all
+    // `Const` (`_all_constants` short-circuit) — the int binop loop routes
+    // through `self.execute`, so an all-const `int_add` never records.
+    let byte = *insns_opname_to_byte()
+        .get("int_add/ii>i")
+        .expect("`int_add/ii>i` must be in insns table");
+    let code = [byte, 0x00, 0x01, 0x02]; // `ii>i`: src1=0, src2=1, dst=2
+    let mut tc = fresh_trace_ctx();
+    let lhs = tc.const_int(40);
+    let rhs = tc.const_int(2);
+    let mut regs_i = [lhs, rhs, OpRef::None];
+    let ops_before = tc.num_ops();
+    let (_, next_pc) = run_hint_step(&code, &mut tc, &mut [], &mut [], &mut regs_i)
+        .expect("int_add on two const ints must fold");
+    assert_eq!(next_pc, 4);
+    assert_eq!(
+        tc.num_ops(),
+        ops_before,
+        "all-const operands fold without recording an IntAdd",
+    );
+    assert_eq!(
+        regs_i[2].inline_const_to_value(),
+        Some(majit_ir::Value::Int(42)),
+        "dst must hold the folded ConstInt",
+    );
+}
+
+#[test]
+fn int_unop_folds_a_const_int_operand_without_recording() {
+    // The unary loop (`int_neg` / `int_invert` / `int_is_true`) also routes
+    // through `self.execute`, so a `Const` operand folds without recording.
+    let byte = *insns_opname_to_byte()
+        .get("int_neg/i>i")
+        .expect("`int_neg/i>i` must be in insns table");
+    let code = [byte, 0x00, 0x01]; // `i>i`: src=0, dst=1
+    let mut tc = fresh_trace_ctx();
+    let operand = tc.const_int(7);
+    let mut regs_i = [operand, OpRef::None];
+    let ops_before = tc.num_ops();
+    let (_, next_pc) = run_hint_step(&code, &mut tc, &mut [], &mut [], &mut regs_i)
+        .expect("int_neg on a const int must fold");
+    assert_eq!(next_pc, 3);
+    assert_eq!(
+        tc.num_ops(),
+        ops_before,
+        "a const operand folds without recording an IntNeg",
+    );
+    assert_eq!(
+        regs_i[1].inline_const_to_value(),
+        Some(majit_ir::Value::Int(-7)),
+        "dst must hold the folded ConstInt",
     );
 }
 

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -3023,10 +3023,14 @@ pub(crate) fn opimpl_getfield_gc_i(ctx: &mut TraceCtx, obj: OpRef, descr: DescrR
     } else {
         OpCode::GetfieldGcI
     };
+    // The `_pure` spelling aliases this opimpl upstream, so the
+    // profiler always sees the plain GETFIELD_GC_I opnum.
     ctx.profiler()
-        .count_ops(opcode, majit_metainterp::counters::OPS);
-    ctx.profiler()
-        .count_ops(opcode, majit_metainterp::counters::RECORDED_OPS);
+        .count_ops(OpCode::GetfieldGcI, majit_metainterp::counters::OPS);
+    ctx.profiler().count_ops(
+        OpCode::GetfieldGcI,
+        majit_metainterp::counters::RECORDED_OPS,
+    );
     let result = ctx.record_op_with_descr(opcode, &[obj], descr.clone());
     // pyjitpl.py:948-949 `resbox = execute_with_descr(...); upd.getfield_now_known(resbox)`.
     // `resbox` carries the loaded value; pair the recorded opref with
@@ -3125,10 +3129,14 @@ pub(crate) fn opimpl_getfield_gc_r(ctx: &mut TraceCtx, obj: OpRef, descr: DescrR
     } else {
         OpCode::GetfieldGcR
     };
+    // The `_pure` spelling aliases this opimpl upstream, so the
+    // profiler always sees the plain GETFIELD_GC_R opnum.
     ctx.profiler()
-        .count_ops(opcode, majit_metainterp::counters::OPS);
-    ctx.profiler()
-        .count_ops(opcode, majit_metainterp::counters::RECORDED_OPS);
+        .count_ops(OpCode::GetfieldGcR, majit_metainterp::counters::OPS);
+    ctx.profiler().count_ops(
+        OpCode::GetfieldGcR,
+        majit_metainterp::counters::RECORDED_OPS,
+    );
     let result = ctx.record_op_with_descr(opcode, &[obj], descr.clone());
     // pyjitpl.py:948-949 `resbox = execute_with_descr(...); upd.getfield_now_known(resbox)`.
     // Pair the recorded opref with the live ref so subsequent

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -3023,6 +3023,10 @@ pub(crate) fn opimpl_getfield_gc_i(ctx: &mut TraceCtx, obj: OpRef, descr: DescrR
     } else {
         OpCode::GetfieldGcI
     };
+    ctx.profiler()
+        .count_ops(opcode, majit_metainterp::counters::OPS);
+    ctx.profiler()
+        .count_ops(opcode, majit_metainterp::counters::RECORDED_OPS);
     let result = ctx.record_op_with_descr(opcode, &[obj], descr.clone());
     // pyjitpl.py:948-949 `resbox = execute_with_descr(...); upd.getfield_now_known(resbox)`.
     // `resbox` carries the loaded value; pair the recorded opref with
@@ -3121,6 +3125,10 @@ pub(crate) fn opimpl_getfield_gc_r(ctx: &mut TraceCtx, obj: OpRef, descr: DescrR
     } else {
         OpCode::GetfieldGcR
     };
+    ctx.profiler()
+        .count_ops(opcode, majit_metainterp::counters::OPS);
+    ctx.profiler()
+        .count_ops(opcode, majit_metainterp::counters::RECORDED_OPS);
     let result = ctx.record_op_with_descr(opcode, &[obj], descr.clone());
     // pyjitpl.py:948-949 `resbox = execute_with_descr(...); upd.getfield_now_known(resbox)`.
     // Pair the recorded opref with the live ref so subsequent
@@ -10580,6 +10588,9 @@ mod tests {
             Some(majit_ir::Value::Int(77)),
             "the fold substitutes the loaded value as a Const"
         );
+        let prof_folded = ctx.profiler().snapshot();
+        assert_eq!(prof_folded.ops, 0);
+        assert_eq!(prof_folded.recorded_ops, 0);
 
         // Control: a non-pure descr on the same const receiver records.
         let mutable_descr = crate::descr::make_field_descr(8, 8, majit_ir::Type::Int, true);
@@ -10590,6 +10601,9 @@ mod tests {
             "a non-pure field read on a const receiver still records"
         );
         assert!(!recorded.is_constant());
+        let prof_recorded = ctx.profiler().snapshot();
+        assert_eq!(prof_recorded.ops, 1);
+        assert_eq!(prof_recorded.recorded_ops, 1);
     }
 
     /// `opimpl_arraylen_gc` + `execute_and_record`: ARRAYLEN_GC is

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -2872,7 +2872,15 @@ pub(crate) fn opimpl_arraylen_gc(ctx: &mut TraceCtx, array: OpRef, descr: DescrR
     // (`_all_constants` — a GcArray block's length is fixed at
     // allocation).  The folded box still feeds `arraylen_now_known`,
     // matching `opimpl_arraylen_gc`'s unconditional cache write.
-    if array.is_constant() {
+    //
+    // Not on wasm32: `WasmBackend` inherits the `bh_arraylen_gc` trait
+    // stub (returns 0), so the fold would bake a wrong `ConstInt(0)`
+    // length.  Overriding the stub to read the real length was tried and
+    // exposes a latent wasm-JIT defect (real arraylen concrete stamps
+    // change trace shapes: `synth/comprehension_object_append_hot` GC
+    // crash at `copy_nursery_object` + 2 wrong outputs), so the stub —
+    // and this gate — stay until that defect is fixed.
+    if !cfg!(target_arch = "wasm32") && array.is_constant() {
         if let Some(majit_ir::Value::Ref(struct_ref)) = ctx.box_value(array) {
             let struct_ptr = struct_ref.0 as i64;
             if struct_ptr != 0 && struct_ptr != usize::MAX as i64 {

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -2867,6 +2867,25 @@ pub(crate) fn opimpl_arraylen_gc(ctx: &mut TraceCtx, array: OpRef, descr: DescrR
         );
         return cached;
     }
+    // ARRAYLEN_GC is ALWAYS_PURE, so `execute_and_record` folds a `Const`
+    // array operand to the loaded length without recording
+    // (`_all_constants` — a GcArray block's length is fixed at
+    // allocation).  The folded box still feeds `arraylen_now_known`,
+    // matching `opimpl_arraylen_gc`'s unconditional cache write.
+    if array.is_constant() {
+        if let Some(majit_ir::Value::Ref(struct_ref)) = ctx.box_value(array) {
+            let struct_ptr = struct_ref.0 as i64;
+            if struct_ptr != 0 && struct_ptr != usize::MAX as i64 {
+                if let Some(majit_ir::Value::Int(len)) =
+                    ctx.arraylen_sanity_load(struct_ptr, &descr)
+                {
+                    let folded = ctx.const_int(len);
+                    ctx.heap_cache_mut().arraylen_now_known(array, folded);
+                    return folded;
+                }
+            }
+        }
+    }
     let result = ctx.record_op_with_descr(OpCode::ArraylenGc, &[array], descr.clone());
     // Box(value) parity: executor.py:188 do_arraylen_gc returns
     // BoxInt(cpu.bh_arraylen_gc(array, arraydescr)). Stamp the result
@@ -2885,12 +2904,26 @@ pub(crate) fn opimpl_arraylen_gc(ctx: &mut TraceCtx, array: OpRef, descr: DescrR
 }
 
 pub(crate) fn opimpl_getfield_gc_i(ctx: &mut TraceCtx, obj: OpRef, descr: DescrRef) -> OpRef {
-    // pyjitpl.py:opimpl_getfield_gc_i parity: the tracer does NOT fold
-    // pure field reads on constant objects. Folding happens in the
-    // optimizer (heap.py:optimize_GETFIELD_GC_I → optimizer.constant_fold),
-    // which pyre ports in OptContext::execute_nonspec_const with correct
-    // type dispatch (Int/Float/Ref). The tracer only records the GC op.
-    //
+    // `_opimpl_getfield_gc_any_pureornot`: a `ConstPtr` receiver through an
+    // always-pure descr bypasses the heapcache completely — execute the
+    // load now and substitute the value as a `Const`, recording no op (the
+    // jitcode-dispatch twin `getfield_gc_via_heapcache` carries the same
+    // fast path).  For a non-pure descr the tracer only records; folding a
+    // constant object's mutable field read is the optimizer's job
+    // (heap.py:optimize_GETFIELD_GC_I → optimizer.constant_fold, ported in
+    // OptContext::execute_nonspec_const).
+    if obj.is_constant() && descr.is_always_pure() {
+        if let Some(majit_ir::Value::Ref(struct_ref)) = ctx.box_value(obj) {
+            let struct_ptr = struct_ref.0 as i64;
+            if struct_ptr != 0 && struct_ptr != usize::MAX as i64 {
+                if let Some(majit_ir::Value::Int(n)) =
+                    ctx.field_sanity_load(struct_ptr, &descr, majit_ir::Type::Int)
+                {
+                    return ctx.const_int(n);
+                }
+            }
+        }
+    }
     // heapcache.py: check if this field was already read/written in this trace
     let field_index = descr.index();
     if let Some(cached) = ctx.heapcache_getfield_cached(obj, field_index) {
@@ -2997,10 +3030,23 @@ pub(crate) fn opimpl_getfield_gc_i(ctx: &mut TraceCtx, obj: OpRef, descr: DescrR
 }
 
 /// pyjitpl.py:874-882 `opimpl_getfield_gc_r`. Same shape as `_i`
-/// modulo the rop variant — folding lives in the optimizer
-/// (`optimize_GETFIELD_GC_R = optimize_GETFIELD_GC_I` per RPython's
-/// alias), so the tracer only records the GC op.
+/// modulo the rop variant: the `ConstPtr` + always-pure bypass folds to
+/// a `Const` without recording, and for non-pure descrs folding lives in
+/// the optimizer (`optimize_GETFIELD_GC_R = optimize_GETFIELD_GC_I` per
+/// RPython's alias).
 pub(crate) fn opimpl_getfield_gc_r(ctx: &mut TraceCtx, obj: OpRef, descr: DescrRef) -> OpRef {
+    if obj.is_constant() && descr.is_always_pure() {
+        if let Some(majit_ir::Value::Ref(struct_ref)) = ctx.box_value(obj) {
+            let struct_ptr = struct_ref.0 as i64;
+            if struct_ptr != 0 && struct_ptr != usize::MAX as i64 {
+                if let Some(majit_ir::Value::Ref(loaded)) =
+                    ctx.field_sanity_load(struct_ptr, &descr, majit_ir::Type::Ref)
+                {
+                    return ctx.const_ref(loaded.0 as i64);
+                }
+            }
+        }
+    }
     let field_index = descr.index();
     if let Some(cached) = ctx.heapcache_getfield_cached(obj, field_index) {
         // pyjitpl.py:934-945 cache-hit sanity check (ref arm).
@@ -10417,6 +10463,145 @@ mod tests {
         }
 
         assert_eq!(ConcreteValue::from_pyobj(obj), ConcreteValue::Ref(obj));
+    }
+
+    /// Minimal Backend for `field_sanity_load` / `arraylen_sanity_load`:
+    /// the default `bh_getfield_gc_*` trait methods read raw memory, and
+    /// `bh_arraylen_gc` mirrors the production overrides (the trait
+    /// default is a stub returning 0).  Compilation/execution entry
+    /// points are unreachable in these tests.
+    struct FieldLoadTestCpu;
+    impl majit_backend::Backend for FieldLoadTestCpu {
+        fn compile_loop(
+            &mut self,
+            _inputargs: &[majit_ir::InputArg],
+            _ops: &[majit_ir::OpRc],
+            _token: &majit_backend::JitCellToken,
+        ) -> Result<majit_backend::AsmInfo, majit_backend::BackendError> {
+            unimplemented!("FieldLoadTestCpu::compile_loop")
+        }
+        fn compile_bridge(
+            &mut self,
+            _fail_descr: &dyn majit_ir::FailDescr,
+            _inputargs: &[majit_ir::InputArg],
+            _ops: &[majit_ir::OpRc],
+            _original_token: &majit_backend::JitCellToken,
+            _previous_tokens: &[std::sync::Arc<majit_backend::JitCellToken>],
+            _caller_recovery_layout: Option<&majit_backend::ExitRecoveryLayout>,
+        ) -> Result<majit_backend::AsmInfo, majit_backend::BackendError> {
+            unimplemented!("FieldLoadTestCpu::compile_bridge")
+        }
+        fn execute_token(
+            &self,
+            _token: &majit_backend::JitCellToken,
+            _args: &[majit_ir::Value],
+        ) -> majit_backend::DeadFrame {
+            unimplemented!("FieldLoadTestCpu::execute_token")
+        }
+        fn get_latest_descr<'a>(
+            &'a self,
+            _frame: &'a majit_backend::DeadFrame,
+        ) -> &'a dyn majit_ir::FailDescr {
+            unimplemented!("FieldLoadTestCpu::get_latest_descr")
+        }
+        fn get_latest_descr_arc(
+            &self,
+            _frame: &majit_backend::DeadFrame,
+        ) -> std::sync::Arc<dyn majit_ir::descr::Descr> {
+            unimplemented!("FieldLoadTestCpu::get_latest_descr_arc")
+        }
+        fn get_int_value(&self, _frame: &majit_backend::DeadFrame, _index: usize) -> i64 {
+            unimplemented!("FieldLoadTestCpu::get_int_value")
+        }
+        fn get_float_value(&self, _frame: &majit_backend::DeadFrame, _index: usize) -> f64 {
+            unimplemented!("FieldLoadTestCpu::get_float_value")
+        }
+        fn get_ref_value(
+            &self,
+            _frame: &majit_backend::DeadFrame,
+            _index: usize,
+        ) -> majit_ir::GcRef {
+            unimplemented!("FieldLoadTestCpu::get_ref_value")
+        }
+        fn invalidate_loop(&self, _token: &majit_backend::JitCellToken) {
+            unimplemented!("FieldLoadTestCpu::invalidate_loop")
+        }
+        fn bh_arraylen_gc(
+            &self,
+            array_ptr: i64,
+            arraydescr: &majit_translate::jitcode::BhDescr,
+        ) -> i64 {
+            let ofs = arraydescr
+                .array_len_offset()
+                .expect("bh_arraylen_gc requires ArrayDescr.lendescr");
+            unsafe { *((array_ptr as *const u8).add(ofs) as *const usize) as i64 }
+        }
+    }
+
+    /// `_opimpl_getfield_gc_any_pureornot`: a `ConstPtr` receiver through
+    /// an always-pure descr bypasses the heapcache and folds to the loaded
+    /// value with no recorded op; a non-pure descr still records.
+    #[test]
+    fn getfield_gc_const_receiver_through_pure_descr_folds_without_recording() {
+        let cpu = FieldLoadTestCpu;
+        let mut ctx = TraceCtx::for_test(0);
+        ctx.set_cpu(Some(&cpu));
+        // Fake two-word struct: the field at offset 8 holds 77.
+        let storage: Box<[i64; 2]> = Box::new([0, 77]);
+        let ptr = storage.as_ref().as_ptr() as i64;
+        let obj = ctx.const_ref(ptr);
+
+        let pure_descr = crate::descr::make_immutable_field_descr(8, 8, majit_ir::Type::Int, true);
+        let ops_before = ctx.num_ops();
+        let result = opimpl_getfield_gc_i(&mut ctx, obj, pure_descr);
+        assert_eq!(
+            ctx.num_ops(),
+            ops_before,
+            "const receiver + always-pure descr records nothing"
+        );
+        assert_eq!(
+            result.inline_const_to_value(),
+            Some(majit_ir::Value::Int(77)),
+            "the fold substitutes the loaded value as a Const"
+        );
+
+        // Control: a non-pure descr on the same const receiver records.
+        let mutable_descr = crate::descr::make_field_descr(8, 8, majit_ir::Type::Int, true);
+        let recorded = opimpl_getfield_gc_i(&mut ctx, obj, mutable_descr);
+        assert_eq!(
+            ctx.num_ops(),
+            ops_before + 1,
+            "a non-pure field read on a const receiver still records"
+        );
+        assert!(!recorded.is_constant());
+    }
+
+    /// `opimpl_arraylen_gc` + `execute_and_record`: ARRAYLEN_GC is
+    /// ALWAYS_PURE, so a `Const` array operand folds to the loaded length
+    /// without recording.
+    #[test]
+    fn arraylen_gc_const_array_folds_to_the_loaded_length_without_recording() {
+        let cpu = FieldLoadTestCpu;
+        let mut ctx = TraceCtx::for_test(0);
+        ctx.set_cpu(Some(&cpu));
+        // Fake GcArray block: the length prefix at offset 0 holds 5.
+        let storage: Box<[usize; 2]> = Box::new([5, 0]);
+        let ptr = storage.as_ref().as_ptr() as i64;
+        let array = ctx.const_ref(ptr);
+        let descr = crate::descr::make_array_descr(8, 8, Some(0), majit_ir::Type::Int, true);
+
+        let ops_before = ctx.num_ops();
+        let result = opimpl_arraylen_gc(&mut ctx, array, descr);
+        assert_eq!(
+            ctx.num_ops(),
+            ops_before,
+            "a const array operand folds without recording an ArraylenGc"
+        );
+        assert_eq!(
+            result.inline_const_to_value(),
+            Some(majit_ir::Value::Int(5)),
+            "the fold substitutes the loaded length as a ConstInt"
+        );
     }
 
     fn ensure_test_callbacks() {

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -2867,6 +2867,11 @@ pub(crate) fn opimpl_arraylen_gc(ctx: &mut TraceCtx, array: OpRef, descr: DescrR
         );
         return cached;
     }
+    // The cache miss routes through `execute_and_record`, which counts
+    // the base OPS bucket at entry — before the `_all_constants` fold
+    // check — so the fold and record paths below both count OPS.
+    ctx.profiler()
+        .count_ops(OpCode::ArraylenGc, majit_metainterp::counters::OPS);
     // ARRAYLEN_GC is ALWAYS_PURE, so `execute_and_record` folds a `Const`
     // array operand to the loaded length without recording
     // (`_all_constants` — a GcArray block's length is fixed at
@@ -2894,6 +2899,9 @@ pub(crate) fn opimpl_arraylen_gc(ctx: &mut TraceCtx, array: OpRef, descr: DescrR
             }
         }
     }
+    // `_record_helper` adds RECORDED_OPS exactly when the op is recorded.
+    ctx.profiler()
+        .count_ops(OpCode::ArraylenGc, majit_metainterp::counters::RECORDED_OPS);
     let result = ctx.record_op_with_descr(OpCode::ArraylenGc, &[array], descr.clone());
     // Box(value) parity: executor.py:188 do_arraylen_gc returns
     // BoxInt(cpu.bh_arraylen_gc(array, arraydescr)). Stamp the result
@@ -10599,7 +10607,8 @@ mod tests {
         let descr = crate::descr::make_array_descr(8, 8, Some(0), majit_ir::Type::Int, true);
 
         let ops_before = ctx.num_ops();
-        let result = opimpl_arraylen_gc(&mut ctx, array, descr);
+        let prof_before = ctx.profiler().snapshot();
+        let result = opimpl_arraylen_gc(&mut ctx, array, descr.clone());
         assert_eq!(
             ctx.num_ops(),
             ops_before,
@@ -10610,6 +10619,41 @@ mod tests {
             Some(majit_ir::Value::Int(5)),
             "the fold substitutes the loaded length as a ConstInt"
         );
+        // execute_and_record counts OPS at entry even when `_all_constants`
+        // folds; RECORDED_OPS only accompanies an actual record.
+        let prof_folded = ctx.profiler().snapshot();
+        assert_eq!(prof_folded.ops, prof_before.ops + 1);
+        assert_eq!(prof_folded.recorded_ops, prof_before.recorded_ops);
+
+        // The heapcache skips Const keys both ways (`arraylen` /
+        // `arraylen_now_known`), so a repeat call re-folds: OPS counts
+        // again, still nothing recorded or heapcached.
+        let refolded = opimpl_arraylen_gc(&mut ctx, array, descr);
+        assert_eq!(refolded, result);
+        let prof_refolded = ctx.profiler().snapshot();
+        assert_eq!(prof_refolded.ops, prof_folded.ops + 1);
+        assert_eq!(prof_refolded.recorded_ops, prof_folded.recorded_ops);
+        assert_eq!(prof_refolded.heapcached_ops, prof_folded.heapcached_ops);
+    }
+
+    #[test]
+    fn arraylen_gc_nonconst_array_records_and_counts_ops() {
+        let mut ctx = TraceCtx::for_test_types(&[majit_ir::Type::Ref]);
+        let array = OpRef::input_arg_ref(0);
+        let descr = crate::descr::make_array_descr(8, 8, Some(0), majit_ir::Type::Int, true);
+
+        let ops_before = ctx.num_ops();
+        let prof_before = ctx.profiler().snapshot();
+        let result = opimpl_arraylen_gc(&mut ctx, array, descr);
+        assert!(!result.is_constant());
+        assert_eq!(
+            ctx.num_ops(),
+            ops_before + 1,
+            "a non-const array operand records an ArraylenGc"
+        );
+        let prof_after = ctx.profiler().snapshot();
+        assert_eq!(prof_after.ops, prof_before.ops + 1);
+        assert_eq!(prof_after.recorded_ops, prof_before.recorded_ops + 1);
     }
 
     fn ensure_test_callbacks() {

--- a/pyre/pyrex/src/lib.rs
+++ b/pyre/pyrex/src/lib.rs
@@ -632,6 +632,23 @@ fn run_interact(
 /// `check.py` asserts it stays 0. Must be called before any `process::exit`
 /// since exits skip destructors.
 fn maybe_print_jit_stats() {
+    // warmspot.py finish helper: `if profiler.initialized:
+    // profiler.finish()` — emits the PYPYLOG `jit-summary` section on
+    // stderr, visible under `MAJIT_LOG` (the `[jit-stats]` line below
+    // stays the `MAJIT_STATS` machine-readable summary).
+    if majit_metainterp::majit_log_enabled() {
+        let profiler = &pyre_jit::eval::driver_pair()
+            .0
+            .meta_interp()
+            .staticdata
+            .profiler;
+        if profiler
+            .initialized
+            .load(std::sync::atomic::Ordering::Relaxed)
+        {
+            profiler.finish();
+        }
+    }
     if std::env::var_os("MAJIT_STATS").is_none() {
         return;
     }


### PR DESCRIPTION
Applies `execute_and_record`'s `_all_constants` short-circuit (fold a pure op whose operands are all `Const` to `wrap_constant(resvalue)` without recording) across the FBW walker's record handlers. Follow-up to #729's Codex review, which flagged the first instance in `binop_ref_to_int_record`.

## Commits

1. **binop_ref_to_int**: distinct all-const ref operands fold the `ptr_eq`/`ptr_ne`/`instance_ptr_*` answer from GC-stable const identity.
2. **int bank**: `binop_int_record` (all 20 routed opnames are ALWAYS_PURE), `unop_int_record` (excluding `int_same_as` — `opimpl_int_same_as` calls `_record_helper` unconditionally to force a Box), and `record_int_unary` (fused `goto_if_not_int_is_*` condboxes; `opimpl_goto_if_not` emits no guard for a `Const` condbox).
3. **float bank**: `binop_float_record`, `unop_float_record`, `binop_float_to_int_record`, `record_float_cmp`. The last one previously documented the missing pre-fold as deferred to the optimizer; the fused float compares route their condbox through `self.execute`, which folds at record time. The absent `b1 is b2` fast path stays absent: float compares are not `FASTPATHS_SAME_BOXES` members (`x == x` is false for a NaN) and the fused loop generates them with `if False and b1 is b2`.
4. **ptr nullity + casts**: `ptr_nullity_record` folds a `Const` box (`CONST_NULL` is itself a `Const`, so `_all_constants` holds); `cast_int_to_float` folds a `Const` int. The two ptr casts deliberately keep recording: upstream's fold executes via `bhimpl_cast_int_to_ptr`/`bhimpl_cast_ptr_to_int`, which assert an odd (tagged) int the GC ignores — pyre's casts serve untagged pointer round-trips, so a folded const would bake a raw address into the trace (a `ConstPtr` the gcreftracer forwards as an object, or an int a moving collection invalidates).

Surface audit: `dispatch_switch_id` already gates on `!valuebox.is_constant()`; the remaining direct `record_op` sites in `mod.rs`/`specialize.rs`/`inline_call.rs` feed operands from freshly recorded ops (structurally non-const), so this completes the `_all_constants` family at the opimpl surface.

## Validation

- `cargo test -p pyre-jit-trace` default + `--features dynasm`: 288 passed / 0 failed each (9 new fold tests)
- `check.py --backend dynasm`: ALL PASSED 293/293
- `check.py --backend cranelift`: ALL PASSED 293/293

🤖 Generated with [Claude Code](https://claude.com/claude-code)