### PR TITLE
jit: commit the frame-escape flush with the operand-stack mirror and resume past the abort

### DIFF
--- a/pyre/bench/getframe_escape_flush_writethrough_regression.py
+++ b/pyre/bench/getframe_escape_flush_writethrough_regression.py
@@ -1,0 +1,43 @@
+# Self-checking regression guard for the frame-escape flush that resumes past
+# the abort (registered via check.py run_selfcheck, NOT the synthetic suite).
+# A residual (may-force) callee stores its own frame; the loop body then reads
+# the caller's f_back.f_locals and mutates it through the 3.14 FrameLocalsProxy
+# write-through. Reading the redirected caller frame forces it mid-expression:
+# the escape flush must commit with the operand-stack mirror (the vable shadow's
+# stack region is NULL there) and resume forward AT the escaping opcode. The
+# legacy replay-from-loop-entry fallback (PYRE_FBW_ABORT_FLUSH=0) drops the
+# in-flight FOR_ITER iteration instead, so `total` comes up short -- the JIT-only
+# regression this guards.
+#
+# The write-through is a 3.14 FrameLocalsProxy behaviour PyPy 3.11 lacks (its
+# f_locals is a snapshot), so cpython and pypy disagree on the mutated value and
+# this cannot be a synthetic bench; the invariant is pyre-internal instead (a
+# correct JIT reproduces the no-JIT result) and is asserted here.
+import sys
+
+LOOPS = 20000
+box = [None]
+
+
+def bump(x):
+    box[0] = sys._getframe(0)
+    return x
+
+
+def main():
+    total = 0
+    marks = 0
+    for i in range(LOOPS):
+        total += bump(i)
+        f = box[0].f_back
+        f.f_locals['marks'] = f.f_locals['marks'] + (1 if f.f_lineno > 0 else 0)
+    if total != sum(range(LOOPS)):
+        print(f"FAIL dropped iteration: total={total} expected {sum(range(LOOPS))}")
+        raise SystemExit(1)
+    if marks != LOOPS:
+        print(f"FAIL write-through dropped: marks={marks} expected {LOOPS}")
+        raise SystemExit(1)
+    print(f"PASS total={total} marks={marks}")
+
+
+main()

--- a/pyre/bench/synth/getframe_force_cancel_journal.py
+++ b/pyre/bench/synth/getframe_force_cancel_journal.py
@@ -1,0 +1,32 @@
+# Regression guard: a frame-forcing user @property that forces FIRST (the
+# escape flush commits mid-property) and mutates SECOND (the commit is then
+# withdrawn because the callee entered a user frame). The withdrawal must
+# RESTORE the pre-flush frame before the legacy replay runs: replaying on the
+# flushed (mid-iteration) frame skipped the journal-rolled-back list append,
+# losing elements (len(seen) < loops, JIT-only).
+import sys
+
+
+class Obj:
+    hits = 0
+
+    @property
+    def peek(self):
+        _ = sys._getframe(1).f_locals  # forces the traced caller -> flush commits
+        Obj.hits += 1                  # user-frame effect AFTER the commit
+        return 1
+
+
+o = Obj()
+
+
+def main():
+    seen = []
+    total = 0
+    for i in range(20000):
+        seen.append(i)      # journaled append BEFORE the forcing read
+        total += o.peek
+    print(total, len(seen), sum(seen) % 1000003)
+
+
+main()

--- a/pyre/bench/synth/getframe_stored_fback_walk.py
+++ b/pyre/bench/synth/getframe_stored_fback_walk.py
@@ -1,0 +1,28 @@
+# Regression guard: a callee stores its OWN frame (sys._getframe(0)); the loop
+# body later walks .f_back.f_locals as a SEPARATE residual. That read forces
+# the traced caller mid-expression; the escape flush must commit with the
+# operand-stack mirror (the vable shadow's stack region is NULL there) and
+# resume forward AT the escaping opcode. Before the latched-stack escape
+# flush, the flush declined, the FOR_ITER inflight deliver was refused, and
+# the consumed iteration was DROPPED -- total came up short (JIT-only).
+import sys
+
+box = [None]
+
+
+def bump(x):
+    box[0] = sys._getframe(0)
+    return x
+
+
+def main():
+    total = 0
+    stale = 0
+    for i in range(20000):
+        total += bump(i)
+        if box[0].f_back.f_locals['total'] != total:
+            stale += 1
+    print(total, stale)
+
+
+main()

--- a/pyre/check.py
+++ b/pyre/check.py
@@ -1748,6 +1748,17 @@ def main():
             15,
             skip_backends=("wasm",),
         )
+        # The f_locals write-through it drives is a 3.14 FrameLocalsProxy
+        # behaviour PyPy 3.11 lacks (its f_locals is a snapshot), so cpython and
+        # pypy disagree on the mutated value and it cannot be a synthetic bench.
+        # The guard is pyre-internal: a forcing callee's escape flush must resume
+        # past the abort, else the in-flight FOR_ITER iteration drops and the
+        # loop total comes up short. Asserted inside the script.
+        chk.run_selfcheck(
+            "getframe_escape_flush_writethrough",
+            f"{B}/getframe_escape_flush_writethrough_regression.py",
+            15,
+        )
 
     if not args.no_synthetic:
         print()

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
@@ -4385,6 +4385,7 @@ struct FbwStoreJournalRootArea {
     foriter: *const std::cell::RefCell<Vec<InflightForiter>>,
     abort_resume: *const std::cell::RefCell<Option<InlineAbortCarrier>>,
     active_session: *const std::cell::Cell<*const std::cell::RefCell<WalkSession>>,
+    escape_flush_undo: *const std::cell::RefCell<Option<EscapeFlushUndo>>,
 }
 
 thread_local! {
@@ -4398,6 +4399,7 @@ thread_local! {
         foriter: FBW_FORITER_INFLIGHT.with(|value| value as *const _),
         abort_resume: FBW_ABORT_CALL_RESUME.with(|value| value as *const _),
         active_session: ACTIVE_WALK_SESSION.with(|value| value as *const _),
+        escape_flush_undo: escape_flush_undo_cell_ptr(),
     };
 }
 
@@ -4637,6 +4639,17 @@ pub unsafe fn fbw_store_journal_root_walker_area(
         // SAFETY: as above — only the `PyObjectRef` slot is a root; the
         // `usize` body pc and the bool flag are plain scalars.
         visitor(unsafe { &mut *(&mut entry.item as *mut pyre_object::PyObjectRef).cast() });
+    }
+    // The escape-flush undo snapshot stays armed from force time until the
+    // abort epilogue consumes it, and its slots can be the ONLY reference to
+    // pre-walk locals the flush displaced (the live-frame slots now hold
+    // walk-end values) — forward each so a minor collection on the abort
+    // unwind cannot move/free what `restore_escape_flush_undo` writes back.
+    let escape_undo = unsafe { &mut *(*area.escape_flush_undo).as_ptr() };
+    if let Some(undo) = escape_undo.as_mut() {
+        for slot in undo.slots.iter_mut() {
+            visitor(unsafe { &mut *(slot as *mut pyre_object::PyObjectRef).cast() });
+        }
     }
     // gh#467: the latched forward-flush operand stack (callable + args) is
     // nursery-resident across the abort unwind — the flush boxes Int/Float

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
@@ -20,23 +20,70 @@ use super::*;
 thread_local! {
     static ACTIVE_FRAME_ESCAPE: std::cell::Cell<Option<(usize, usize)>> =
         const { std::cell::Cell::new(None) };
+    static ACTIVE_FRAME_ESCAPE_STACK: std::cell::RefCell<Option<Vec<OpRef>>> =
+        const { std::cell::RefCell::new(None) };
     static COMMITTED_FRAME_ESCAPE_PC: std::cell::Cell<Option<usize>> =
+        const { std::cell::Cell::new(None) };
+    /// Pre-flush frame state captured by [`flush_active_frame_escape`] so a
+    /// post-call commit withdrawal can put the live frame back.  The legacy
+    /// replay's correctness contract is "the live frame still holds pre-walk
+    /// state"; a committed force-flush breaks it, so every path that does NOT
+    /// adopt the committed resume pc must restore this first.
+    static ESCAPE_FLUSH_UNDO: std::cell::RefCell<Option<EscapeFlushUndo>> =
+        const { std::cell::RefCell::new(None) };
+    /// Opcode-scoped effect window: `(py_pc, frame_entry_count,
+    /// executed_effect_count)` sampled at the FIRST residual of the Python
+    /// opcode currently being walked.  Re-executing a committed escape re-runs
+    /// the WHOLE opcode, so the latch gate must know whether any EARLIER
+    /// residual of the same opcode ran user bytecode or committed an effect —
+    /// not just the escaping one (rich-compare fallback chains run two
+    /// residuals in one opcode).  Reset at walk start; concrete effects only
+    /// happen through residuals, so anchoring the window at the first residual
+    /// loses nothing.
+    static ESCAPE_OPCODE_WINDOW: std::cell::Cell<Option<(usize, u64, usize)>> =
         const { std::cell::Cell::new(None) };
 }
 
-struct ActiveFrameEscapeGuard(Option<(usize, usize)>);
+pub(crate) struct EscapeFlushUndo {
+    frame: usize,
+    last_instr: isize,
+    valuestackdepth: usize,
+    pub(crate) slots: Vec<pyre_object::PyObjectRef>,
+}
+
+/// TLS cell pointer for the store-journal root area: the undo stays armed
+/// from force time until the abort epilogue consumes it, and its slots can be
+/// the ONLY reference to pre-walk locals the flush displaced — the area
+/// walker forwards them across any minor collection on that whole window
+/// (the resume-ref-roots stack cannot cover it: the residual's post-call
+/// `pop_resume_ref_roots_to` truncates past a force-time push).
+pub(crate) fn escape_flush_undo_cell_ptr() -> *const std::cell::RefCell<Option<EscapeFlushUndo>> {
+    ESCAPE_FLUSH_UNDO.with(|cell| cell as *const _)
+}
+
+struct ActiveFrameEscapeGuard {
+    prev: Option<(usize, usize)>,
+    prev_stack: Option<Vec<OpRef>>,
+}
 
 impl ActiveFrameEscapeGuard {
-    fn enter(frame: usize, py_pc: usize) -> Self {
+    fn enter(frame: usize, py_pc: usize, stack: Option<Vec<OpRef>>) -> Self {
         let current = (frame != 0).then_some((frame, py_pc));
         COMMITTED_FRAME_ESCAPE_PC.with(|slot| slot.set(None));
-        Self(ACTIVE_FRAME_ESCAPE.with(|slot| slot.replace(current)))
+        let latched = if current.is_some() { stack } else { None };
+        let prev_stack = ACTIVE_FRAME_ESCAPE_STACK
+            .with(|slot| std::mem::replace(&mut *slot.borrow_mut(), latched));
+        Self {
+            prev: ACTIVE_FRAME_ESCAPE.with(|slot| slot.replace(current)),
+            prev_stack,
+        }
     }
 }
 
 impl Drop for ActiveFrameEscapeGuard {
     fn drop(&mut self) {
-        ACTIVE_FRAME_ESCAPE.with(|slot| slot.set(self.0));
+        ACTIVE_FRAME_ESCAPE.with(|slot| slot.set(self.prev));
+        ACTIVE_FRAME_ESCAPE_STACK.with(|slot| *slot.borrow_mut() = self.prev_stack.take());
     }
 }
 
@@ -52,8 +99,27 @@ pub fn flush_active_frame_escape(ctx: &TraceCtx, frame: *mut pyre_interpreter::P
         if let Some((expected, py_pc)) = slot.get()
             && expected == frame as usize
         {
-            if crate::state::flush_walk_end_state_to_frame(ctx, expected, py_pc) {
+            // Force #2+ within this residual (`enter` resets the committed pc
+            // per residual): the live frame is already heap-authoritative
+            // from the first flush, and the callee may have legitimately
+            // mutated it since (an `f_locals` write-through) — re-flushing
+            // would overwrite that mutation with the same walk-end values.
+            // The token force is a no-op then too (`force_now` on
+            // TOKEN_NONE, virtualizable.py:248-260).
+            if COMMITTED_FRAME_ESCAPE_PC
+                .with(|committed| committed.get())
+                .is_some()
+            {
+                return true;
+            }
+            capture_escape_flush_undo(expected);
+            let flushed = flush_escape_state_with_latched_stack(ctx, expected, py_pc)
+                || crate::state::flush_walk_end_state_to_frame(ctx, expected, py_pc);
+            if flushed {
                 COMMITTED_FRAME_ESCAPE_PC.with(|committed| committed.set(Some(py_pc)));
+            } else {
+                // All-or-nothing decline: nothing was written, nothing to undo.
+                discard_escape_flush_undo();
             }
             return true;
         }
@@ -61,8 +127,141 @@ pub fn flush_active_frame_escape(ctx: &TraceCtx, frame: *mut pyre_interpreter::P
     })
 }
 
+/// Snapshot the frame region a successful escape flush overwrites (the whole
+/// `locals_cells_stack_w` array plus `last_instr`/`valuestackdepth`).  GC:
+/// the store-journal root area walks the armed capture's slots in place (see
+/// [`escape_flush_undo_cell_ptr`]).  A second force in the same residual
+/// keeps the OLDEST capture (the true pre-flush state); staleness across walk
+/// attempts is impossible — the walk-start reset discards any leftover.
+fn capture_escape_flush_undo(frame: usize) {
+    ESCAPE_FLUSH_UNDO.with(|slot| {
+        let mut slot = slot.borrow_mut();
+        match slot.as_ref() {
+            // Keep the oldest capture for the SAME frame (true pre-flush state).
+            Some(existing) if existing.frame == frame => return,
+            // A capture for a different frame is a stale leftover from an
+            // unwound path; its frame may be dead — drop without restoring.
+            Some(_) => *slot = None,
+            None => {}
+        }
+        let pf = unsafe { &*(frame as *const pyre_interpreter::PyFrame) };
+        *slot = Some(EscapeFlushUndo {
+            frame,
+            last_instr: pf.last_instr,
+            valuestackdepth: pf.valuestackdepth,
+            slots: pf.locals_w().as_slice().to_vec(),
+        });
+    });
+}
+
+/// Put the pre-flush frame state back.  Called on every path that does not
+/// adopt the committed escape pc (commit withdrawal, an unforced or
+/// rootless continuation, the `PYRE_FBW_ABORT_FLUSH=0` opt-out) so the
+/// legacy replay re-enters a pristine frame.
+pub(crate) fn restore_escape_flush_undo() {
+    ESCAPE_FLUSH_UNDO.with(|slot| {
+        let Some(undo) = slot.borrow_mut().take() else {
+            return;
+        };
+        unsafe {
+            let pf = &mut *(undo.frame as *mut pyre_interpreter::PyFrame);
+            let dst = pf.locals_w_mut();
+            let n = undo.slots.len().min(dst.as_slice().len());
+            for (i, &v) in undo.slots.iter().take(n).enumerate() {
+                dst[i] = v;
+            }
+            pf.last_instr = undo.last_instr;
+            pf.valuestackdepth = undo.valuestackdepth;
+        }
+    });
+}
+
+pub(crate) fn discard_escape_flush_undo() {
+    ESCAPE_FLUSH_UNDO.with(|slot| {
+        *slot.borrow_mut() = None;
+    });
+}
+
+/// Opcode-scoped effect window check (see [`ESCAPE_OPCODE_WINDOW`]): true iff
+/// no earlier residual of the CURRENT Python opcode entered a user frame or
+/// committed a concrete effect.  Opens the window on the first residual of
+/// each opcode.  Keyed on `py_pc` alone: an opcode revisited across walked
+/// inner-loop iterations compares against the FIRST visit's snapshot, so
+/// every revisit after any effect declines the latch — conservative (decline
+/// → legacy).  An unexplained latch-decline spike on nested-loop shapes is
+/// this; the refinement would reset the window on back-edge re-entry.
+fn escape_opcode_window_clean(py_pc: usize) -> bool {
+    let frames = pyre_interpreter::call::frame_entry_count();
+    let effects = fbw_executed_effect_count();
+    ESCAPE_OPCODE_WINDOW.with(|slot| match slot.get() {
+        Some((pc, f, e)) if pc == py_pc => f == frames && e == effects,
+        _ => {
+            slot.set(Some((py_pc, frames, effects)));
+            true
+        }
+    })
+}
+
+/// Reset the opcode window at walk start so a prior trace's sample cannot
+/// alias a same-pc opcode of the new walk.
+pub(crate) fn escape_opcode_window_reset() {
+    ESCAPE_OPCODE_WINDOW.with(|slot| slot.set(None));
+}
+
+/// Resolve the latched operand-stack mirror (`ActiveFrameEscapeGuard::enter`)
+/// to concrete refs and flush the walk-end state with the mid-expression
+/// stack the vable shadow cannot provide (its stack region is only valid at
+/// merge points).  The `_run_forever` continue-forward analog
+/// (`blackhole.py:1752`) for the escape abort: the resume state is the exact
+/// abort-point frame, so the walk's applied effects stand and nothing
+/// replays.  Returns false (no frame mutation) when no stack was latched or
+/// any slot lacks a concrete non-null Ref — the caller then falls back to the
+/// plain merge-point flush.
+fn flush_escape_state_with_latched_stack(ctx: &TraceCtx, frame: usize, py_pc: usize) -> bool {
+    ACTIVE_FRAME_ESCAPE_STACK.with(|slot| {
+        let latched = slot.borrow();
+        let Some(oprefs) = latched.as_ref() else {
+            return false;
+        };
+        let mut stack = Vec::with_capacity(oprefs.len());
+        for &opref in oprefs.iter() {
+            match ctx.concrete_of_opref(opref) {
+                Some(majit_ir::Value::Ref(r)) if r != majit_ir::GcRef::NO_CONCRETE => {
+                    let obj = r.as_usize() as pyre_object::PyObjectRef;
+                    if obj.is_null() {
+                        return false;
+                    }
+                    stack.push(obj);
+                }
+                _ => return false,
+            }
+        }
+        // The flush's Int/Float local boxing can trigger a minor collection;
+        // register the resolved refs as resume roots so they are forwarded in
+        // place across it (the same discipline as the vable root above).
+        let root_depth = majit_gc::shadow_stack::resume_ref_roots_depth();
+        unsafe {
+            majit_gc::shadow_stack::push_resume_ref_roots(std::slice::from_raw_parts_mut(
+                stack.as_mut_ptr() as *mut i64,
+                stack.len(),
+            ));
+        }
+        let committed =
+            crate::state::flush_walk_end_state_to_frame_with_full_stack(ctx, frame, py_pc, &stack);
+        majit_gc::shadow_stack::pop_resume_ref_roots_to(root_depth);
+        committed
+    })
+}
+
 pub fn take_committed_frame_escape_pc() -> Option<usize> {
     COMMITTED_FRAME_ESCAPE_PC.with(|slot| slot.take())
+}
+
+/// Withdraw a committed escape resume pc: the residual that escaped also ran
+/// user bytecode, so resuming AT its opcode would re-execute that user body —
+/// the legacy replay (whose journals roll back) is the never-double fallback.
+fn cancel_committed_frame_escape_pc() {
+    COMMITTED_FRAME_ESCAPE_PC.with(|slot| slot.set(None));
 }
 
 /// Reject a residual_call whose `allboxes` (funcbox + permuted args)
@@ -1098,8 +1297,39 @@ pub(crate) fn try_execute_residual_call_via_executor<Sym: WalkSym>(
         (!provably_side_effect_free).then(pyre_interpreter::call::frame_entry_count);
     let exec_result = {
         let escape_frame = if is_may_force { live_frame } else { 0 };
+        // Latch the operand-stack mirror for the escape flush: at force time
+        // the walk-end flush needs the caller's mid-expression stack, which
+        // the vable shadow cannot provide (`reconstructed_all_ref_call_stack`
+        // resolves the same mirror for the inline-abort Entry carrier).  Only
+        // a non-writing residual is latched — a committed escape resumes AT
+        // this opcode and re-executes it in the interpreter, which must not
+        // re-apply a heap write.  The write gate is load-bearing beyond the
+        // obvious setters: forcing is NOT limited to frame-introspection
+        // reads (`hook_access_field`, rvirtualizable.py:49-53, forces on
+        // every redirected-field access, reads AND writes), and the mutating
+        // forcers — the `f_lineno`/`f_trace` setters, `sys.settrace`,
+        // `_warnings.warn` (forces the caller frame for `__name__`, then
+        // mutates `__warningregistry__` with no user frame entered) — are
+        // excluded here only because every Python-visible frame MUTATOR is a
+        // Void-returning store or a CALL-shaped helper.  What survives the
+        // gates is attribute/item READS of frame-family objects, which are
+        // idempotently re-executable (re-execution reads the same flushed
+        // values the first execution saw; a token re-force is a no-op).
+        // A sub-walk's mirror describes the callee frame, not the escape
+        // frame, so it is never latched (the nested unjournaled-residual
+        // decline above already aborts before this).
+        // Not latched on a bridge walk: its abort path bypasses the
+        // run_perfn_walk epilogue that adopts (or restores) a committed
+        // escape flush, so a commit there would strand a moved frame.
+        let escape_stack = (escape_frame != 0
+            && !writes_live_heap
+            && !ctx.fbw_mode.inline_subwalk
+            && !ctx.trace_ctx.is_bridge_trace
+            && ctx.vstack_valid
+            && escape_opcode_window_clean(ctx.vstack_cur_pypc as usize))
+        .then(|| ctx.vstack_boxes.clone());
         let _frame_escape =
-            ActiveFrameEscapeGuard::enter(escape_frame, ctx.vstack_cur_pypc as usize);
+            ActiveFrameEscapeGuard::enter(escape_frame, ctx.vstack_cur_pypc as usize, escape_stack);
         let _suspend = majit_metainterp::TraceContinuationSuspendGuard::enter();
         majit_metainterp::executor::execute_residual_call(call_descr, func_ptr, &args)
     };
@@ -1133,10 +1363,34 @@ pub(crate) fn try_execute_residual_call_via_executor<Sym: WalkSym>(
             majit_gc::shadow_stack::pop_resume_ref_roots_to(depth);
         }
         if forced {
+            // The escaping residual also entered a user Python frame whose
+            // body may have committed irreversible effects; a committed
+            // escape resume would re-execute this opcode and re-run that
+            // body.  Withdraw the commit AND restore the pre-flush frame so
+            // the legacy replay re-enters pristine pre-walk state (the flush
+            // moved the live frame mid-iteration; replaying on top of it
+            // loses journal-rolled-back effects and re-runs partial state).
+            if heap_write_odometer_before
+                .is_some_and(|before| pyre_interpreter::call::frame_entry_count() != before)
+            {
+                cancel_committed_frame_escape_pc();
+                restore_escape_flush_undo();
+            }
+            // On a kept commit the undo stays armed: the abort epilogue
+            // consumes it — discard on adoption, restore when the flush is
+            // not adopted (`PYRE_FBW_ABORT_FLUSH=0`).
+            // On the cancel arm the restore above ran FIRST, so this refresh
+            // reloads PRE-walk values — the shadow then matches the frame the
+            // legacy replay will use, not walk-end state.  A future ladder
+            // leg must not assume walk-end shadow state after a cancelled
+            // commit.
             ctx.trace_ctx.refresh_virtualizable_shadow_from_heap();
             return Err(DispatchError::VableEscapedDuringResidualCall { pc: op_pc });
         }
     }
+    // A flush that ran without a forced abort (an unarmed token or a missing
+    // vable root) must not leak the moved frame into the continuing walk.
+    restore_escape_flush_undo();
     // #57 Option C (Finding #1, R1): a residual that is not provably
     // side-effect-free has now EXECUTED AFTER the in-flight FOR_ITER consume —
     // whether it returned a value (Ok) or raised (Err).  The store/append

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -3802,7 +3802,7 @@ pub(crate) fn flush_walk_end_state_to_frame(
     frame: usize,
     resume_py_pc: usize,
 ) -> bool {
-    flush_walk_end_state_to_frame_inner(ctx, frame, resume_py_pc, None, &[])
+    flush_walk_end_state_to_frame_inner(ctx, frame, resume_py_pc, None, &[], None)
 }
 
 /// `flush_walk_end_state_to_frame` plus an optional in-flight FOR_ITER item
@@ -3818,7 +3818,7 @@ pub(crate) fn flush_walk_end_state_to_frame_with_item(
     resume_py_pc: usize,
     push: Option<(PyObjectRef, usize)>,
 ) -> bool {
-    flush_walk_end_state_to_frame_inner(ctx, frame, resume_py_pc, push, &[])
+    flush_walk_end_state_to_frame_inner(ctx, frame, resume_py_pc, push, &[], None)
 }
 
 pub(crate) fn flush_walk_end_state_to_frame_with_stack_overrides(
@@ -3827,7 +3827,28 @@ pub(crate) fn flush_walk_end_state_to_frame_with_stack_overrides(
     resume_py_pc: usize,
     stack_overrides: &[(usize, PyObjectRef)],
 ) -> bool {
-    flush_walk_end_state_to_frame_inner(ctx, frame, resume_py_pc, None, stack_overrides)
+    flush_walk_end_state_to_frame_inner(ctx, frame, resume_py_pc, None, stack_overrides, None)
+}
+
+/// `flush_walk_end_state_to_frame` with the COMPLETE operand stack supplied by
+/// the caller as a contiguous slice for absolute slots
+/// `nlocals..nlocals + stack.len()`.  The mid-expression escape flush resolves
+/// the walk's operand-stack mirror to concrete refs, which the vable shadow
+/// cannot provide outside a merge point (its stack region reads NULL there).
+/// Declines (frame untouched) when the supplied height disagrees with the
+/// forward analysis's depth at `resume_py_pc`.
+///
+/// `stack` values are re-read per slot during the commit loop, whose Int/Float
+/// local boxing can trigger a minor collection — the caller must keep the
+/// slice registered as GC roots (`push_resume_ref_roots`) across the call so
+/// the slots are forwarded in place.
+pub(crate) fn flush_walk_end_state_to_frame_with_full_stack(
+    ctx: &TraceCtx,
+    frame: usize,
+    resume_py_pc: usize,
+    stack: &[PyObjectRef],
+) -> bool {
+    flush_walk_end_state_to_frame_inner(ctx, frame, resume_py_pc, None, &[], Some(stack))
 }
 
 fn flush_walk_end_state_to_frame_inner(
@@ -3836,15 +3857,22 @@ fn flush_walk_end_state_to_frame_inner(
     resume_py_pc: usize,
     push: Option<(PyObjectRef, usize)>,
     stack_overrides: &[(usize, PyObjectRef)],
+    full_stack: Option<&[PyObjectRef]>,
 ) -> bool {
+    let decline = |why: &str| {
+        if crate::jitcode_dispatch::fbw_debug_abort_enabled() {
+            eprintln!("[fbw-flush] DECLINE at py_pc={resume_py_pc}: {why}");
+        }
+        false
+    };
     if frame == 0 {
-        return false;
+        return decline("frame==0");
     }
     let Some(nlocals) = concrete_nlocals(frame) else {
-        return false;
+        return decline("no concrete_nlocals");
     };
     let Some(info) = ctx.virtualizable_info() else {
-        return false;
+        return decline("no virtualizable_info");
     };
     // Stack depth at the merge point from the cached forward analysis:
     // absolute vsd = stack_base + depth, stack_base = nlocals + ncells
@@ -3853,7 +3881,7 @@ fn flush_walk_end_state_to_frame_inner(
     let w_code =
         unsafe { *(frame_ptr.add(crate::frame_layout::PYFRAME_PYCODE_OFFSET) as *const *const ()) };
     if w_code.is_null() {
-        return false;
+        return decline("null w_code");
     }
     let raw_code = unsafe {
         pyre_interpreter::w_code_get_ptr(w_code as PyObjectRef)
@@ -3864,8 +3892,13 @@ fn flush_walk_end_state_to_frame_inner(
         .get(resume_py_pc)
         .copied()
     else {
-        return false;
+        return decline("no depth_at_py_pc");
     };
+    if let Some(full) = full_stack
+        && full.len() != depth as usize
+    {
+        return decline("full-stack height != analysis depth");
+    }
     let end_vsd = nlocals + depth as usize;
     let live = end_vsd.max(nlocals);
     let base = info.num_static_extra_boxes;
@@ -3878,36 +3911,40 @@ fn flush_walk_end_state_to_frame_inner(
         .iter()
         .position(|f| f.name == "lastblock");
     let Some(lastblock_idx) = lastblock_static else {
-        return false;
+        return decline("no lastblock static field");
     };
     let Some((_opref, shadow_lastblock)) = ctx.virtualizable_entry_at(lastblock_idx) else {
-        return false;
+        return decline("no shadow lastblock entry");
     };
     let frame_lastblock = unsafe { *(frame_ptr.add(PYFRAME_LASTBLOCK_OFFSET) as *const usize) };
     match shadow_lastblock {
         Value::Ref(r) => {
             if r.0 != frame_lastblock {
-                return false;
+                return decline("lastblock changed during walk");
             }
         }
-        _ => return false,
+        _ => return decline("shadow lastblock not a Ref"),
     }
     // Validation pass first: it allocates nothing, so entry presence
     // cannot change under it.  Commit only when every live slot resolves.
     let stack_override_at = |abs: usize| -> Option<PyObjectRef> {
+        if let Some(full) = full_stack {
+            return full.get(abs - nlocals).copied();
+        }
         stack_overrides
             .iter()
             .find_map(|&(slot, value)| (slot == abs).then_some(value))
     };
+    let have_overrides = full_stack.is_some() || !stack_overrides.is_empty();
     for abs in 0..live {
-        if abs >= nlocals && !stack_overrides.is_empty() {
+        if abs >= nlocals && have_overrides {
             if stack_override_at(abs).is_none() {
-                return false;
+                return decline("stack override missing for a live slot");
             }
             continue;
         }
         let Some((_opref, value)) = ctx.virtualizable_entry_at(base + abs) else {
-            return false;
+            return decline("no shadow entry for a live slot (validation)");
         };
         // An operand-STACK slot (`abs >= nlocals`) that resolves to a NULL Ref
         // is an UNPOPULATED shadow slot, not a live value: the virtualizable
@@ -3923,7 +3960,7 @@ fn flush_walk_end_state_to_frame_inner(
         // frame from its start state instead.  A local slot may legitimately
         // be NULL (an unbound local), so this only guards the stack region.
         if abs >= nlocals && matches!(value, Value::Ref(r) if r.0 == 0) {
-            return false;
+            return decline("NULL operand-stack shadow slot (mid-expression)");
         }
     }
     let arr_ptr = unsafe {
@@ -3935,7 +3972,7 @@ fn flush_walk_end_state_to_frame_inner(
     // frame mutation (all-or-nothing).
     let need = if push.is_some() { live + 1 } else { live };
     if arr_ptr.is_null() || unsafe { &*arr_ptr }.as_slice().len() < need {
-        return false;
+        return decline("frame stack array too small / null");
     }
     // Commit one slot at a time, re-reading the shadow entry per slot:
     // boxing an Int/Float slot allocates and may trigger a minor
@@ -3944,13 +3981,13 @@ fn flush_walk_end_state_to_frame_inner(
     // slot is reachable from the (rooted) frame, so neither side goes
     // stale across the loop.
     for abs in 0..live {
-        let boxed = if abs >= nlocals && !stack_overrides.is_empty() {
+        let boxed = if abs >= nlocals && have_overrides {
             // The override is the authoritative caller CALL stack.  Its
             // mid-opcode slots need not exist in the virtualizable shadow.
             stack_override_at(abs).expect("validated stack override")
         } else {
             let Some((_opref, value)) = ctx.virtualizable_entry_at(base + abs) else {
-                return false;
+                return decline("no shadow entry for a live slot (commit)");
             };
             boxed_slot_value_for_type(Type::Ref, &value)
         };

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -553,6 +553,14 @@ pub fn trace_bytecode<Sym: WalkSym>(
     WALK_END_PROPAGATE_ALLOWED.with(|c| c.set(allow_propagate_out));
     WALK_END_RESTART_PC.with(|c| c.set(None));
     FBW_BRIDGE_DECLINED.with(|c| c.set(false));
+    // A prior walk's opcode-effect-window sample must not alias a same-pc
+    // opcode of this walk (the escape-flush latch gate reads it).
+    crate::jitcode_dispatch::escape_opcode_window_reset();
+    // Likewise drop any escape-flush undo a prior attempt failed to consume:
+    // "oldest capture wins" is only correct WITHIN one walk attempt — a
+    // leftover here would restore wrong-generation locals onto a frame many
+    // iterations ahead.
+    crate::jitcode_dispatch::discard_escape_flush_undo();
     // `TraceCtx.reads_module_global` needs no reset here: a fresh TraceCtx is
     // built per trace (zero-init `false`), unlike the walk-end TLS flags above.
     // Likewise clear any no-replay finish payload a prior trace left
@@ -2253,13 +2261,42 @@ fn run_perfn_walk<Sym: WalkSym>(
         // predicate as the CloseLoop end-flush above.  A latched inline-callee
         // forward abort has already distinguished an outside mark from a mark
         // inside its discarded attempt.  `PYRE_FBW_ABORT_FLUSH=0` opts out.
-        if std::env::var_os("PYRE_FBW_ABORT_FLUSH").as_deref() != Some(std::ffi::OsStr::new("0")) {
+        if std::env::var_os("PYRE_FBW_ABORT_FLUSH").as_deref() == Some(std::ffi::OsStr::new("0")) {
+            // Opt-out: never adopt the escape flush — drop the commit and put
+            // the pre-flush frame back so the legacy replay sees pristine
+            // state.
+            if matches!(
+                &walk_result,
+                Err(crate::jitcode_dispatch::DispatchError::VableEscapedDuringResidualCall { .. })
+            ) {
+                let _ = crate::jitcode_dispatch::take_committed_frame_escape_pc();
+                crate::jitcode_dispatch::restore_escape_flush_undo();
+            }
+        } else {
             if matches!(
                 &walk_result,
                 Err(crate::jitcode_dispatch::DispatchError::VableEscapedDuringResidualCall { .. })
             ) && let Some(resume_py_pc) =
                 crate::jitcode_dispatch::take_committed_frame_escape_pc()
             {
+                crate::jitcode_dispatch::discard_escape_flush_undo();
+                // The force-time escape flush wrote the resume state into the
+                // LIVE frame (the frame the callee inspected).  The portal
+                // epilogue propagates `executed_frame` → live on a committed
+                // flush, so mirror the live frame's resume state into the walk
+                // snapshot to make that copy the identity.
+                let live = sym.live_vable_frame_addr();
+                if live != 0 && cf_addr != 0 && live != cf_addr {
+                    unsafe {
+                        (*(cf_addr as *mut pyre_interpreter::PyFrame)).restore_resume_state_from(
+                            &*(live as *const pyre_interpreter::PyFrame),
+                        );
+                    }
+                }
+                // The committed flush owns the iteration count (the resume pc
+                // is PAST the FOR_ITER consume); drop any in-flight item so
+                // the legacy deliver cannot re-apply one.
+                crate::jitcode_dispatch::fbw_foriter_inflight_clear();
                 WALK_END_RESTART_PC.with(|c| c.set(Some(resume_py_pc)));
                 WALK_END_FLUSH_COMMITTED.with(|c| c.set(true));
             }


### PR DESCRIPTION
## Problem

The orthodox force-gate (#719) unmasked a latent resume-past-abort defect: when a residual forces the traced frame mid-expression (a loop reading a stored frame's `f_back.f_locals`), the escape-pc walk-end flush always declined on "NULL operand-stack shadow slot" — the vable shadow's stack region is only valid at merge points. With no committed resume pc, the abort fell back to legacy replay, the FOR_ITER inflight deliver was refused, and the consumed iteration was **dropped**:

| repro | oracle | before | after |
|---|---|---|---|
| stored `getframe(0)` → `f_back.f_locals` walk in a hot for-loop | 199990000 | 199986990 (5 iterations dropped) | **199990000** |
| + non-journaled side effect in the callee | 199990000 / 20000 | 199986990 / 20005 | **199990000** / 20005¹ |

¹ the remaining +5 is the pre-existing own-frame entry-trace replay double (see Follow-up).

## Mechanism

Frame-level convergence of `run_blackhole_interp_to_cancel_tracing` (pyjitpl.py:2949) / `convert_and_run_from_pyjitpl` (blackhole.py:1799): resume forward from the abort point instead of replaying from loop entry.

- **Latch**: `ActiveFrameEscapeGuard` snapshots the walk's operand-stack OpRef mirror (`vstack_boxes`) per may-force residual — the same authoritative source `reconstructed_all_ref_call_stack` uses for the inline-abort Entry carrier.
- **Flush**: at force time the oprefs resolve through `concrete_of_opref` (GC-forwarded channel) and the walk-end flush commits with the mid-expression stack via a new full-stack variant, height-checked against the forward depth analysis.
- **Resume**: the committed pc adopts through the existing escape leg; the walk's applied effects stand exactly once (journals commit), the escaping opcode re-executes in the interpreter, and the in-flight FOR_ITER item is owned by the flush (no drop, no double).

## Safety gates (re-execution must be idempotent)

- `!writes_live_heap` — every Python-visible frame **mutator** is a Void store or CALL-shaped helper (an object-model invariant: the `f_lineno` setter, `sys.settrace`, `_warnings.warn` all force but are excluded by shape); what survives is frame-family attribute/item reads, which re-execute idempotently against the flushed values.
- **Opcode-scoped effect window** — frame-entry + executed-effect odometers sampled at the first residual of each opcode, so an earlier residual of a multi-residual opcode (rich-compare fallback chains) blocks the latch.
- **Post-call commit withdrawal** — if the forcing callee itself entered a user frame, the commit is cancelled and a **pre-flush undo snapshot** (rooted for its whole armed life through the store-journal root area) restores the frame, so legacy replay re-enters pristine pre-walk state. Discriminator: a journaled `seen.append(i)` before a forcing-then-mutating `@property` — without the restore, 5 appends were lost to the journal rollback.
- **Double-force skip** — after the first commit the frame is heap-authoritative; a second force in the same residual does not re-flush, so callee `f_locals` write-throughs survive adoption.
- Bridge walks and inline sub-walks never latch (their abort paths bypass the adoption epilogue); `PYRE_FBW_ABORT_FLUSH=0` restores byte-identical legacy behavior (verified: the old under-count reappears exactly).

## Verification

- check.py: **dynasm 293/293, cranelift 293/293, wasm 290/290**
- 47/47 foriter57 + getframe/inline_subwalk/mutate guard synth benches, JIT == NO_JIT
- 3 new synth guards: `getframe_stored_fback_walk`, `getframe_force_cancel_journal`, `getframe_force_write_between`
- Perf A/B vs main (same-epoch alternating): inline_helper / nbody / nested_loop / raise_catch — no regression
- Design cross-checked against rpython sources (pyjitpl.py `vable_after_residual_call` → `SwitchToBlackhole(ABORT_ESCAPE)` chain; virtualizable.py force semantics) including an adversarial review cycle that surfaced and closed two unsound holes (cancel-after-flush frame corruption, residual-scoped effect window) and three undo-lifecycle gaps (rooting window, double-force re-flush, cross-attempt staleness).

## Follow-up (not in this PR)

The orthodox endgame is jitcode-granularity blackhole conversion (`convert_and_run_from_walk`): build blackhole frames from the walk's register state and resume AFTER the residual with its result, feeding the existing production `BlackholeInterpreter`. That closes the two remaining bounded defects this PR does not cover — the own-frame `getframe(0)` entry-trace replay double (+5 above) and the while-loop inline-decline twin — and retires the FOR_ITER deliver/refuse machinery wholesale.

— *authored by Claude*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved execution reliability when frame inspection occurs during optimized code.
  * Preserved loop iterations, local-variable updates, and list mutations during frame transitions and resumed execution.
  * Improved handling of operand stacks and frame state during optimized execution fallbacks.

* **Tests**
  * Added regression checks covering frame access, caller-local updates, stored frame references, and repeated frame-forcing operations.
  * Integrated the new validation into the pre-merge benchmark checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->