### PR TITLE
jit: preserve CompareOp guard resumes and speed JitCode interference

### DIFF
--- a/pyre/bench/synth/math_isqrt_compare_bridge_resume.py
+++ b/pyre/bench/synth/math_isqrt_compare_bridge_resume.py
@@ -1,0 +1,31 @@
+# pyre-check: max-pypy-ratio=35
+# A comparison helper (like test_math.testIsqrt's assertLessEqual/assertLess)
+# runs first on exact ints and then on bignums. The `<=`/`<` inside the helper
+# callee has CompareOp class/value guards that must attach a bridge at the
+# comparison's opcode-start resume point instead of deopting every later call.
+# unittest is unavailable on the wasm backend (no os module), so the helper is
+# a plain class rather than unittest.TestCase.
+
+import math
+
+
+class Cmp:
+    def le(self, a, b):
+        assert a <= b
+
+    def lt(self, a, b):
+        assert a < b
+
+
+cmp = Cmp()
+BIG = 10**100
+checksum = 0
+
+for value in list(range(5000)) + [BIG] * 80000:
+    root = math.isqrt(value)
+    assert type(root) is int
+    cmp.le(root * root, value)
+    cmp.lt(value, (root + 1) * (root + 1))
+    checksum = (checksum + (root & 65535)) % 1000000007
+
+print(checksum)

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -8256,6 +8256,20 @@ impl CodeWriter {
                             // Same stack-direct pattern as BinaryOp — see its comment.
                             let op_kind = opname.get(op_arg);
                             let _ = compare_op_tag(op_kind);
+                            // `MIFrame.generate_guard()` captures resumedata at
+                            // the current jitcode pc (`pyjitpl.py:188-195`).
+                            // CompareOp specialization emits class/value guards
+                            // after consuming both Python operands, so retain
+                            // the opcode-start `-live-`; the pre-dispatch pcdep
+                            // snapshot supplies those operands on guard failure,
+                            // matching PyPy's per-frame register snapshot.
+                            record_graph_op(
+                                &current_block.block(),
+                                "-live-",
+                                Vec::new(),
+                                None,
+                                py_pc as i64,
+                            );
                             let _ = emit_popvalue_ref!(current_depth, py_pc);
                             let rhs_value = pop_ref_or_fresh(&mut current_state, &mut graph);
                             let _ = emit_popvalue_ref!(current_depth, py_pc);


### PR DESCRIPTION
## Summary

This change removes two independent costs exposed by running the CPython `test_math` suite under pyre:

1. `CompareOp` guards now retain the Python opcode-start resume snapshot before consuming their operands.
2. JitCode resume-interference construction now uses the existing RPython-style weighted/path-compressed `UnionFind`, freezes representatives into a dense table, and resolves each live variable's representative once per snapshot.

It also adds focused synth coverage for the `math.isqrt` comparison/bridge path and for large regex-compiler JitCodes.

## Problem 1: `CompareOp` guards resumed from post-pop liveness

The generated `CompareOp` handler popped both Python operands before specialized comparison dispatch emitted class/value guards. Unlike PyPy's `MIFrame.generate_guard()` path, there was no opcode-start `-live-` marker preserving the frame snapshot at the guard's resume PC.

When exact-int comparisons warmed into bignum comparisons in `test_math.testIsqrt`, guard failures therefore did not receive the comparison operands from the opcode-start snapshot. This prevented the expected resident bridge behavior and produced a large guard-failure storm.

The codewriter now records `-live-` immediately before the two operand pops. Guard resumedata consequently uses the pre-dispatch per-frame snapshot, matching the PyPy `MIFrame.generate_guard(resumepc)` shape.

## Problem 2: resume-interference construction repeatedly walked union-find chains

`build_value_parent` used a custom `HashMap<u32, u32>` union-find with neither weighted union nor path compression. `build_colive_interference` then called `find` for both sides of every pair in its `O(live^2)` loop. Large JitCodes such as `re._compiler._compile` and `_optimize_charset` repeatedly walked the same parent chains and made source-to-JitCode translation dominate startup.

This change:

- builds value equivalence with `majit_translate::tool::algo::unionfind::UnionFind`, the existing line-by-line RPython port;
- freezes the resulting representatives in a dense `Vec<u32>` because graph-local variable IDs are dense;
- caches `(variable, representative)` once per live variable before constructing pairwise interference.

The interference semantics and coalescing partition are unchanged. #371 still tracks the larger RPython-parity refactor that can eventually delete this compensating co-live pass; this PR only removes the pathological cost while that pass remains live.

## Impact

On the original investigation base (`a1de59b9fb2`), using the exact command from the report:

```console
MAJIT_STATS=1 /usr/bin/time -p ./target/release/pyre -m test test_math -v
```

| metric | before | after | change |
|---|---:|---:|---:|
| test body | 10.259 s | 8.815 s | -14% |
| wall time | 13.39 s | 10.03 s | -25% |
| guard failures | 35,041 | 11,836 | -66% |

Temporary phase instrumentation, not included in the patch, measured codewriter time falling from about 3.683 s to 0.495 s and resume-interference time from about 2.997 s to 0.099 s. The co-live pair-building portion fell to about 0.014 s.

After rebasing onto current `main` (`4d652c2dfa6`), the same command completes 89 tests successfully with:

```text
test body:       8.313 s
wall time:       9.39 s
guard failures:  11,575
loops/bridges:   52 / 37
```

The remaining `test_math` gap is largely present with the JIT disabled as well, so this PR does not claim to eliminate the interpreter/object/call overhead that remains.

## Regression coverage

- `math_isqrt_compare_bridge_resume.py` exercises exact-int comparisons followed by bignum comparisons in the shape used by `testIsqrt`.
- `regex_large_jitcode_resume_interference.py` repeatedly compiles distinct regexes to exercise resume interference for the large stdlib regex compiler JitCodes.

Current two-backend results:

| synth | PyPy | dynasm | Cranelift |
|---|---:|---:|---:|
| `math_isqrt_compare_bridge_resume` | 0.08 s | 1.93 s (26.2x) | 2.17 s (29.4x) |
| `regex_large_jitcode_resume_interference` | 0.08 s | 0.81 s (11.0x) | 0.90 s (12.3x) |

## Validation

- `python3 scripts/extract-llbc.py pyre-jit`
- `cargo check --features dynasm`
- `cargo test --features dynasm` — 5 passed
- `cargo build --release`
- `python3 pyre/check.py --backend dynasm,cranelift --synthetic-timeout 20`
  - dynasm: 296/296 passed
  - Cranelift: 296/296 passed

Refs #152.
Refs #371.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved JIT handling of equivalent values and guard failure state, supporting more reliable execution and recovery.
  * Improved performance of internal liveness and interference analysis.

* **Tests**
  * Added a comprehensive integer square-root benchmark and verification scenario, including large values and correctness checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->