### PR TITLE
jit: exception traceback recording and handler-entry state parity

### DIFF
--- a/majit/majit-metainterp/src/lib.rs
+++ b/majit/majit-metainterp/src/lib.rs
@@ -146,7 +146,8 @@ pub use pyjitpl::{
     JitCodeSym, JitHooks, JitStats, MIFrame, MIFrameStack, MetaInterp, MetaInterpGlobalData,
     MetaInterpStaticData, RawCompileResult, StandaloneFrameStack, build_state_field_snapshot,
     call_int_function, call_ref_function, call_void_function, counters,
-    record_application_traceback_for_recording, set_record_application_traceback_hook,
+    record_application_traceback_for_recording, record_inline_application_traceback_for_recording,
+    set_record_application_traceback_hook, set_record_inline_application_traceback_hook,
     struct_fields_write_effect_info, trace_jitcode, trace_jitcode_from_merge_point,
     trace_jitcode_with_args, trace_jitcode_with_args_and_runtime,
 };

--- a/majit/majit-metainterp/src/lib.rs
+++ b/majit/majit-metainterp/src/lib.rs
@@ -146,6 +146,7 @@ pub use pyjitpl::{
     JitCodeSym, JitHooks, JitStats, MIFrame, MIFrameStack, MetaInterp, MetaInterpGlobalData,
     MetaInterpStaticData, RawCompileResult, StandaloneFrameStack, build_state_field_snapshot,
     call_int_function, call_ref_function, call_void_function, counters,
+    record_application_traceback_for_recording, set_record_application_traceback_hook,
     struct_fields_write_effect_info, trace_jitcode, trace_jitcode_from_merge_point,
     trace_jitcode_with_args, trace_jitcode_with_args_and_runtime,
 };

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -1513,12 +1513,24 @@ pub struct JitHooks {
 /// owns the application frame and the jitcode-to-source-position mapping, so
 /// majit keeps only this crate-neutral ABI hook.
 pub type RecordApplicationTraceback = extern "C" fn(i64, i64, i32, i32);
+pub type RecordInlineApplicationTraceback = extern "C" fn(i64, i64, i64, i32, i32);
 
 static RECORD_APPLICATION_TRACEBACK: std::sync::atomic::AtomicUsize =
+    std::sync::atomic::AtomicUsize::new(0);
+static RECORD_INLINE_APPLICATION_TRACEBACK: std::sync::atomic::AtomicUsize =
     std::sync::atomic::AtomicUsize::new(0);
 
 pub fn set_record_application_traceback_hook(hook: Option<RecordApplicationTraceback>) {
     RECORD_APPLICATION_TRACEBACK.store(
+        hook.map_or(0, |callback| callback as usize),
+        std::sync::atomic::Ordering::Release,
+    );
+}
+
+pub fn set_record_inline_application_traceback_hook(
+    hook: Option<RecordInlineApplicationTraceback>,
+) {
+    RECORD_INLINE_APPLICATION_TRACEBACK.store(
         hook.map_or(0, |callback| callback as usize),
         std::sync::atomic::Ordering::Release,
     );
@@ -1537,8 +1549,7 @@ fn record_application_traceback(exc_value: i64, frame_ptr: *const u8, frame: &MI
 }
 
 /// Invoke the host traceback callback for a recording frame represented by a
-/// crate-external walker.  The caller must supply the concrete frame identity;
-/// inline frames without one must not call this function.
+/// crate-external walker. The caller must supply the concrete frame identity.
 pub fn record_application_traceback_for_recording(
     exc_value: i64,
     frame_ptr: i64,
@@ -1556,6 +1567,28 @@ pub fn record_application_traceback_for_recording(
     // function pointer in set_record_application_traceback_hook.
     let callback: RecordApplicationTraceback = unsafe { std::mem::transmute(callback) };
     callback(exc_value, frame_ptr, jitcode_index, opcode_position);
+}
+
+/// Invoke the host callback for an inlined recording frame represented by its
+/// own promoted code/globals metadata rather than a concrete frame pointer.
+pub fn record_inline_application_traceback_for_recording(
+    exc_value: i64,
+    w_code: i64,
+    w_globals: i64,
+    jitcode_index: i32,
+    opcode_position: i32,
+) {
+    if exc_value == 0 || w_code == 0 {
+        return;
+    }
+    let callback = RECORD_INLINE_APPLICATION_TRACEBACK.load(std::sync::atomic::Ordering::Acquire);
+    if callback == 0 {
+        return;
+    }
+    // Safety: the only stored values come from a
+    // RecordInlineApplicationTraceback function pointer.
+    let callback: RecordInlineApplicationTraceback = unsafe { std::mem::transmute(callback) };
+    callback(exc_value, w_code, w_globals, jitcode_index, opcode_position);
 }
 
 /// framework.py `root_walker.walk_roots` per-op helper: visit every

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -1508,6 +1508,56 @@ pub struct JitHooks {
     pub on_compile_error: Option<Box<dyn Fn(u64, &str) + Send>>,
 }
 
+/// Runtime callback used to attach an application traceback while the
+/// metainterpreter is executing the one-shot recording iteration.  The host
+/// owns the application frame and the jitcode-to-source-position mapping, so
+/// majit keeps only this crate-neutral ABI hook.
+pub type RecordApplicationTraceback = extern "C" fn(i64, i64, i32, i32);
+
+static RECORD_APPLICATION_TRACEBACK: std::sync::atomic::AtomicUsize =
+    std::sync::atomic::AtomicUsize::new(0);
+
+pub fn set_record_application_traceback_hook(hook: Option<RecordApplicationTraceback>) {
+    RECORD_APPLICATION_TRACEBACK.store(
+        hook.map_or(0, |callback| callback as usize),
+        std::sync::atomic::Ordering::Release,
+    );
+}
+
+fn record_application_traceback(exc_value: i64, frame_ptr: *const u8, frame: &MIFrame) {
+    if exc_value == 0 || frame_ptr.is_null() || frame.inline_frame {
+        return;
+    }
+    record_application_traceback_for_recording(
+        exc_value,
+        frame_ptr as usize as i64,
+        frame.jitcode.try_index().map_or(-1, |index| index as i32),
+        frame.last_opcode_position as i32,
+    );
+}
+
+/// Invoke the host traceback callback for a recording frame represented by a
+/// crate-external walker.  The caller must supply the concrete frame identity;
+/// inline frames without one must not call this function.
+pub fn record_application_traceback_for_recording(
+    exc_value: i64,
+    frame_ptr: i64,
+    jitcode_index: i32,
+    opcode_position: i32,
+) {
+    if exc_value == 0 || frame_ptr == 0 {
+        return;
+    }
+    let callback = RECORD_APPLICATION_TRACEBACK.load(std::sync::atomic::Ordering::Acquire);
+    if callback == 0 {
+        return;
+    }
+    // Safety: the only stored values come from a RecordApplicationTraceback
+    // function pointer in set_record_application_traceback_hook.
+    let callback: RecordApplicationTraceback = unsafe { std::mem::transmute(callback) };
+    callback(exc_value, frame_ptr, jitcode_index, opcode_position);
+}
+
 /// framework.py `root_walker.walk_roots` per-op helper: visit every
 /// inline `ConstPtr.value` slot stored in `op.args` and `op.fail_args`.
 /// history.py:314 `ConstPtr.value` is inline on the Box object; pyre
@@ -12437,8 +12487,17 @@ impl<M: Clone> MetaInterp<M> {
                 }
             }
             if handled {
+                let frame = self.framestack.current_mut();
+                record_application_traceback(excvalue, self.vable_ptr, frame);
+                frame.last_caught_exception_value = excvalue;
                 // pyjitpl.py:2522: raise ChangeFrame
                 return Err(FinishframeExceptionSignal::ChangeFrame);
+            }
+            {
+                let frame = self.framestack.current_mut();
+                if frame.last_caught_exception_value != excvalue {
+                    record_application_traceback(excvalue, self.vable_ptr, frame);
+                }
             }
             self.popframe(true);
         }

--- a/majit/majit-metainterp/src/pyjitpl/dispatch.rs
+++ b/majit/majit-metainterp/src/pyjitpl/dispatch.rs
@@ -1690,7 +1690,24 @@ where
                 }
             }
             if handled {
+                let frame = self.frames.current_mut();
+                super::record_application_traceback(
+                    self.last_exception_value,
+                    ctx.virtualizable_heap_ptr().unwrap_or(std::ptr::null()),
+                    frame,
+                );
+                frame.last_caught_exception_value = self.last_exception_value;
                 return TraceAction::Continue;
+            }
+            {
+                let frame = self.frames.current_mut();
+                if frame.last_caught_exception_value != self.last_exception_value {
+                    super::record_application_traceback(
+                        self.last_exception_value,
+                        ctx.virtualizable_heap_ptr().unwrap_or(std::ptr::null()),
+                        frame,
+                    );
+                }
             }
             self.pop_exception_frame(ctx);
         }
@@ -2599,7 +2616,11 @@ where
             return TraceAction::Continue;
         }
 
-        let bytecode = self.frames.current_mut().next_u8();
+        let bytecode = {
+            let frame = self.frames.current_mut();
+            frame.last_opcode_position = frame.code_cursor;
+            frame.next_u8()
+        };
         match bytecode {
             // RPython `blackhole.py:950 bhimpl_live` — no-op marker
             // emitted by the codewriter ahead of every guard-bearing
@@ -6736,12 +6757,32 @@ where
                 self.last_exception_box = Some(opref);
                 self.last_exception_value = concrete;
                 self.class_of_last_exc_is_const = true;
+                {
+                    let frame = self.frames.current_mut();
+                    if frame.last_caught_exception_value != concrete {
+                        super::record_application_traceback(
+                            concrete,
+                            ctx.virtualizable_heap_ptr().unwrap_or(std::ptr::null()),
+                            frame,
+                        );
+                    }
+                }
                 self.pop_exception_frame(ctx);
                 return self.unwind_to_exception_handler(ctx);
             }
             jitcode::insns::BC_RERAISE => {
                 if self.last_exception_value == 0 {
                     return TraceAction::Abort;
+                }
+                {
+                    let frame = self.frames.current_mut();
+                    if frame.last_caught_exception_value != self.last_exception_value {
+                        super::record_application_traceback(
+                            self.last_exception_value,
+                            ctx.virtualizable_heap_ptr().unwrap_or(std::ptr::null()),
+                            frame,
+                        );
+                    }
                 }
                 self.pop_exception_frame(ctx);
                 return self.unwind_to_exception_handler(ctx);

--- a/majit/majit-metainterp/src/pyjitpl/frame.rs
+++ b/majit/majit-metainterp/src/pyjitpl/frame.rs
@@ -77,6 +77,14 @@ pub struct MIFrame {
     pub jitcode: Arc<JitCode>,
     pub pc: usize,
     pub code_cursor: usize,
+    /// Bytecode position of the operation currently being executed.
+    /// Exception unwinding uses this instead of the post-decode cursor when
+    /// the host records the Python traceback for this frame.
+    pub last_opcode_position: usize,
+    /// Exception already recorded when this frame entered a catch handler.
+    /// A later bare re-raise of the same object must not prepend this frame a
+    /// second time.
+    pub last_caught_exception_value: i64,
     pub int_regs: Vec<Option<OpRef>>,
     pub int_values: Vec<Option<i64>>,
     pub ref_regs: Vec<Option<OpRef>>,
@@ -175,6 +183,8 @@ impl MIFrame {
             jitcode,
             pc,
             code_cursor: 0,
+            last_opcode_position: pc,
+            last_caught_exception_value: 0,
             int_regs: vec![None; regs_and_consts_i],
             int_values: vec![None; regs_and_consts_i],
             ref_regs: vec![None; regs_and_consts_r],

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/bridge_subwalk.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/bridge_subwalk.rs
@@ -57,6 +57,17 @@ pub fn dispatch_via_miframe<Sym: WalkSym>(
 ) -> Result<(DispatchOutcome, usize), DispatchError> {
     let sym_ptr = sym as *mut Sym;
     let entry_py_pc = EntryPyPc::Py(orgpc as u32);
+    if is_top_level {
+        let mut walk_session = session.borrow_mut();
+        walk_session.recording_frame_ptr = sym.live_vable_frame_addr();
+        walk_session.recording_jitcode_index = if sym.jitcode().is_null() {
+            -1
+        } else {
+            unsafe { (*sym.jitcode()).index as i32 }
+        };
+        walk_session.recording_opcode_position = position;
+        walk_session.last_caught_exception_value = 0;
+    }
 
     // Phase 7: this IS the full-body walk over the outer `sym.jitcode`,
     // so guard snapshots can resolve a per-guard resume coordinate from

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/bridge_subwalk.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/bridge_subwalk.rs
@@ -780,6 +780,7 @@ pub(crate) fn drive_bridge_frame_subwalk<Sym: WalkSym>(
     let consts = InlineCalleeConsts {
         w_globals: callee_w_globals,
         w_code: callee_code_key,
+        jitcode_index: jc.try_index().map_or(-1, |index| index as i32),
     };
 
     // Install the ROOT sym as the snapshot sym (NOT the callee's) so in-callee
@@ -1144,6 +1145,7 @@ pub(crate) fn drive_outer_frame_continuation<Sym: WalkSym>(
     let consts = InlineCalleeConsts {
         w_globals: root_w_globals,
         w_code: root_code_key,
+        jitcode_index: jc.try_index().map_or(-1, |index| index as i32),
     };
 
     let root_sym_ptr = root_sym as *const Sym;

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
@@ -1600,6 +1600,8 @@ pub(crate) fn try_walker_inline_resolved_user_call<Sym: WalkSym>(
     let inline_consts = InlineCalleeConsts {
         w_globals: unsafe { pyre_interpreter::function_get_globals_obj(callable) } as usize,
         w_code: callee_code_key,
+        jitcode_index: crate::state::ensure_jitcode_index(callee_code_key as *const ())
+            .map_or(-1, |index| index as i32),
     };
 
     // Specialize the inlined body on this exact callable: a later
@@ -2474,6 +2476,7 @@ pub(crate) fn try_walker_inline_resolved_user_call<Sym: WalkSym>(
         }
         DispatchOutcome::SubRaise { exc, exc_concrete } => {
             if let Some(target) = try_catch_exception_at(code, op.next_pc) {
+                record_inline_application_traceback(ctx, exc_concrete, op.pc, true);
                 record_top_level_application_traceback(ctx, exc_concrete, op.pc, true);
                 ctx.last_exc_value = Some(exc);
                 ctx.last_exc_value_concrete = exc_concrete;
@@ -3241,6 +3244,7 @@ pub(crate) fn dispatch_inline_call_dr_kind<Sym: WalkSym>(
         }
         DispatchOutcome::SubRaise { exc, exc_concrete } => {
             if let Some(target) = try_catch_exception_at(code, op.next_pc) {
+                record_inline_application_traceback(ctx, exc_concrete, op.pc, true);
                 record_top_level_application_traceback(ctx, exc_concrete, op.pc, true);
                 ctx.last_exc_value = Some(exc);
                 // Thread the callee's concrete
@@ -3384,6 +3388,7 @@ pub(crate) fn dispatch_inline_call_dir_kind<Sym: WalkSym>(
         }
         DispatchOutcome::SubRaise { exc, exc_concrete } => {
             if let Some(target) = try_catch_exception_at(code, op.next_pc) {
+                record_inline_application_traceback(ctx, exc_concrete, op.pc, true);
                 record_top_level_application_traceback(ctx, exc_concrete, op.pc, true);
                 ctx.last_exc_value = Some(exc);
                 // Thread the callee's concrete
@@ -3539,6 +3544,7 @@ pub(crate) fn dispatch_inline_call_dirf_kind<Sym: WalkSym>(
         }
         DispatchOutcome::SubRaise { exc, exc_concrete } => {
             if let Some(target) = try_catch_exception_at(code, op.next_pc) {
+                record_inline_application_traceback(ctx, exc_concrete, op.pc, true);
                 record_top_level_application_traceback(ctx, exc_concrete, op.pc, true);
                 ctx.last_exc_value = Some(exc);
                 // Thread the callee's concrete

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
@@ -2474,6 +2474,7 @@ pub(crate) fn try_walker_inline_resolved_user_call<Sym: WalkSym>(
         }
         DispatchOutcome::SubRaise { exc, exc_concrete } => {
             if let Some(target) = try_catch_exception_at(code, op.next_pc) {
+                record_top_level_application_traceback(ctx, exc_concrete, op.pc, true);
                 ctx.last_exc_value = Some(exc);
                 ctx.last_exc_value_concrete = exc_concrete;
                 Ok(Some((DispatchOutcome::Continue, target)))
@@ -3240,6 +3241,7 @@ pub(crate) fn dispatch_inline_call_dr_kind<Sym: WalkSym>(
         }
         DispatchOutcome::SubRaise { exc, exc_concrete } => {
             if let Some(target) = try_catch_exception_at(code, op.next_pc) {
+                record_top_level_application_traceback(ctx, exc_concrete, op.pc, true);
                 ctx.last_exc_value = Some(exc);
                 // Thread the callee's concrete
                 // exception across the frame boundary.  Without this a
@@ -3382,6 +3384,7 @@ pub(crate) fn dispatch_inline_call_dir_kind<Sym: WalkSym>(
         }
         DispatchOutcome::SubRaise { exc, exc_concrete } => {
             if let Some(target) = try_catch_exception_at(code, op.next_pc) {
+                record_top_level_application_traceback(ctx, exc_concrete, op.pc, true);
                 ctx.last_exc_value = Some(exc);
                 // Thread the callee's concrete
                 // exception across the frame boundary.  Without this a
@@ -3536,6 +3539,7 @@ pub(crate) fn dispatch_inline_call_dirf_kind<Sym: WalkSym>(
         }
         DispatchOutcome::SubRaise { exc, exc_concrete } => {
             if let Some(target) = try_catch_exception_at(code, op.next_pc) {
+                record_top_level_application_traceback(ctx, exc_concrete, op.pc, true);
                 ctx.last_exc_value = Some(exc);
                 // Thread the callee's concrete
                 // exception across the frame boundary.  Without this a

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
@@ -453,6 +453,10 @@ pub struct InlineFrame {
     /// reaches [`FBW_MAX_INLINE_RECURSION`], the call folds to a residual
     /// instead of unrolling its call tree (`pyjitpl.py`).
     pub w_code: usize,
+    /// Exception most recently caught by this frame. Matching
+    /// `MIFrame.last_caught_exception_value`, this suppresses a second
+    /// traceback node when the same exception later leaves via bare re-raise.
+    pub last_caught_exception_value: i64,
     /// Paused caller snapshot for the multi-frame path. `None` preserves the
     /// straight-line single-frame collapse while retaining the callee level.
     pub parent: Option<InlineParentFrame>,
@@ -490,7 +494,8 @@ pub struct WalkSession {
     pub tmpreg_i_concrete: ConcreteValue,
     pub tmpreg_f: OpRef,
     /// Concrete root frame and jitcode identity for application traceback
-    /// recording. Inlined callees have no concrete frame here and are skipped.
+    /// recording. Inlined callees carry their own identity separately in
+    /// `InlineCalleeConsts`.
     pub recording_frame_ptr: usize,
     pub recording_jitcode_index: i32,
     /// Last opcode executed by the root recording frame.
@@ -551,6 +556,46 @@ fn record_top_level_application_traceback<Sym: WalkSym>(
     );
 }
 
+fn record_inline_application_traceback<Sym: WalkSym>(
+    ctx: &mut WalkContext<'_, '_, Sym>,
+    exc_concrete: ConcreteValue,
+    opcode_position: usize,
+    caught: bool,
+) {
+    if ctx.is_top_level {
+        return;
+    }
+    let Some(consts) = ctx.inline_callee_consts else {
+        return;
+    };
+    let ConcreteValue::Ref(exc_ptr) = exc_concrete else {
+        return;
+    };
+    if exc_ptr.is_null() {
+        return;
+    }
+    let exc_value = exc_ptr as usize as i64;
+    {
+        let mut session = ctx.session.borrow_mut();
+        let Some(frame) = session.framestack.last_mut() else {
+            return;
+        };
+        if !caught && frame.last_caught_exception_value == exc_value {
+            return;
+        }
+        if caught {
+            frame.last_caught_exception_value = exc_value;
+        }
+    }
+    majit_metainterp::record_inline_application_traceback_for_recording(
+        exc_value,
+        consts.w_code as i64,
+        consts.w_globals as i64,
+        consts.jitcode_index,
+        opcode_position as i32,
+    );
+}
+
 /// Compile-time-constant frame fields of an inlined callee.
 #[derive(Clone, Copy)]
 pub struct InlineCalleeConsts {
@@ -560,6 +605,9 @@ pub struct InlineCalleeConsts {
     /// `frame.pycode` (`VABLE_CODE_FIELD_IDX` = 1): the callee's `W_Code`
     /// pointer.
     w_code: usize,
+    /// Jitcode identity used to translate a callee opcode to its Python
+    /// instruction coordinate when constructing `PyTraceback` metadata.
+    jitcode_index: i32,
 }
 
 /// Walk-scoped FBW modes inherited parent-to-child across sub-walk
@@ -1832,6 +1880,7 @@ pub fn walk<Sym: WalkSym>(
 ) -> Result<(DispatchOutcome, usize), DispatchError> {
     let mut pc = start_pc;
     loop {
+        let opcode_position = pc;
         let (outcome, next_pc) = step(code, pc, ctx)?;
         pc = next_pc;
         match outcome {
@@ -1863,6 +1912,7 @@ pub fn walk<Sym: WalkSym>(
                 // `exit_frame_with_exception`, letting the exception escape a
                 // frame that actually catches it.
                 if let Some(target) = try_catch_exception_at(code, pc) {
+                    record_inline_application_traceback(ctx, exc_concrete, opcode_position, true);
                     let opcode_position = ctx.session.borrow().recording_opcode_position;
                     record_top_level_application_traceback(
                         ctx,
@@ -1919,6 +1969,16 @@ pub fn walk<Sym: WalkSym>(
                     fbw_terminate_with_raise(exc, exc_concrete);
                     return Ok((DispatchOutcome::Terminate, pc));
                 } else {
+                    let is_bare_reraise = decode_op_at(code, opcode_position)
+                        .is_some_and(|op| op.opname == "reraise/");
+                    if !is_bare_reraise {
+                        record_inline_application_traceback(
+                            ctx,
+                            exc_concrete,
+                            opcode_position,
+                            false,
+                        );
+                    }
                     return Ok((DispatchOutcome::SubRaise { exc, exc_concrete }, pc));
                 }
             }
@@ -4100,10 +4160,11 @@ impl<'a> InlineFrameGuard<'a> {
         w_code: usize,
         parent: Option<InlineParentFrame>,
     ) -> Self {
-        session
-            .borrow_mut()
-            .framestack
-            .push(InlineFrame { w_code, parent });
+        session.borrow_mut().framestack.push(InlineFrame {
+            w_code,
+            last_caught_exception_value: 0,
+            parent,
+        });
         ACTIVE_WALK_SESSION.with(|c| c.set(session as *const _));
         InlineFrameGuard(session)
     }

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
@@ -489,6 +489,14 @@ pub struct WalkSession {
     pub tmpreg_i: OpRef,
     pub tmpreg_i_concrete: ConcreteValue,
     pub tmpreg_f: OpRef,
+    /// Concrete root frame and jitcode identity for application traceback
+    /// recording. Inlined callees have no concrete frame here and are skipped.
+    pub recording_frame_ptr: usize,
+    pub recording_jitcode_index: i32,
+    /// Last opcode executed by the root recording frame.
+    pub recording_opcode_position: usize,
+    /// Exception already recorded when the root frame entered its handler.
+    pub last_caught_exception_value: i64,
 }
 
 impl Default for WalkSession {
@@ -501,8 +509,46 @@ impl Default for WalkSession {
             tmpreg_i: OpRef::NONE,
             tmpreg_i_concrete: ConcreteValue::Null,
             tmpreg_f: OpRef::NONE,
+            recording_frame_ptr: 0,
+            recording_jitcode_index: -1,
+            recording_opcode_position: 0,
+            last_caught_exception_value: 0,
         }
     }
+}
+
+fn record_top_level_application_traceback<Sym: WalkSym>(
+    ctx: &mut WalkContext<'_, '_, Sym>,
+    exc_concrete: ConcreteValue,
+    opcode_position: usize,
+    caught: bool,
+) {
+    if !ctx.is_top_level {
+        return;
+    }
+    let ConcreteValue::Ref(exc_ptr) = exc_concrete else {
+        return;
+    };
+    if exc_ptr.is_null() {
+        return;
+    }
+    let exc_value = exc_ptr as usize as i64;
+    let (frame_ptr, jitcode_index) = {
+        let mut session = ctx.session.borrow_mut();
+        if !caught && session.last_caught_exception_value == exc_value {
+            return;
+        }
+        if caught {
+            session.last_caught_exception_value = exc_value;
+        }
+        (session.recording_frame_ptr, session.recording_jitcode_index)
+    };
+    majit_metainterp::record_application_traceback_for_recording(
+        exc_value,
+        frame_ptr as i64,
+        jitcode_index,
+        opcode_position as i32,
+    );
 }
 
 /// Compile-time-constant frame fields of an inlined callee.
@@ -1724,6 +1770,9 @@ pub fn step<Sym: WalkSym>(
     ctx: &mut WalkContext<'_, '_, Sym>,
 ) -> Result<(DispatchOutcome, usize), DispatchError> {
     let op: DecodedOp = decode_op_at(code, pc).ok_or(DispatchError::UndecodableOpcode { pc })?;
+    if ctx.is_top_level {
+        ctx.session.borrow_mut().recording_opcode_position = op.pc;
+    }
     // #73: maintain the `-live-` BEFORE anchor.  Every
     // `-live-` byte the walk decodes becomes the resume point preceding the
     // NEXT guard (`pyjitpl.py`, normal guard resume reads at
@@ -1814,6 +1863,13 @@ pub fn walk<Sym: WalkSym>(
                 // `exit_frame_with_exception`, letting the exception escape a
                 // frame that actually catches it.
                 if let Some(target) = try_catch_exception_at(code, pc) {
+                    let opcode_position = ctx.session.borrow().recording_opcode_position;
+                    record_top_level_application_traceback(
+                        ctx,
+                        exc_concrete,
+                        opcode_position,
+                        true,
+                    );
                     ctx.last_exc_value = Some(exc);
                     ctx.last_exc_value_concrete = exc_concrete;
                     // pyjitpl.py:2530-2558 `finishframe_exception` only
@@ -1844,6 +1900,13 @@ pub fn walk<Sym: WalkSym>(
                     continue;
                 }
                 if ctx.is_top_level {
+                    let opcode_position = ctx.session.borrow().recording_opcode_position;
+                    record_top_level_application_traceback(
+                        ctx,
+                        exc_concrete,
+                        opcode_position,
+                        false,
+                    );
                     // RPython parity: framestack exhausted with no handler
                     // match → `compile_exit_frame_with_exception(last_exc_box)`.
                     // Stash the exception the same way the value-return arms
@@ -8577,6 +8640,7 @@ fn handle<Sym: WalkSym>(
             // exit-frame finish (which escapes a try/except as a no-payload
             // Terminate abort).
             if ctx.is_top_level && !fbw_raise_enabled() {
+                record_top_level_application_traceback(ctx, concrete_exc, op.pc, false);
                 ctx.trace_ctx
                     .finish(&[exc], ctx.exit_frame_with_exception_descr_ref.clone());
                 if let ConcreteValue::Ref(p) = concrete_exc {
@@ -8716,6 +8780,12 @@ fn handle<Sym: WalkSym>(
                 .ok_or(DispatchError::ReraiseWithoutLastExcValue { pc: op.pc })?;
             // Gated `PYRE_FBW_RAISE`: symmetric with `raise/r`.
             if ctx.is_top_level && !fbw_raise_enabled() {
+                record_top_level_application_traceback(
+                    ctx,
+                    ctx.last_exc_value_concrete,
+                    op.pc,
+                    false,
+                );
                 ctx.trace_ctx
                     .finish(&[exc], ctx.exit_frame_with_exception_descr_ref.clone());
                 if let ConcreteValue::Ref(p) = ctx.last_exc_value_concrete {

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -647,6 +647,53 @@ pub(crate) extern "C" fn record_caught_blackhole_traceback(
     }
 }
 
+pub(crate) extern "C" fn record_inline_traceback_for_recording(
+    exc_value: i64,
+    w_code_value: i64,
+    w_globals_value: i64,
+    jitcode_index: i32,
+    opcode_position: i32,
+) {
+    if exc_value == 0 || w_code_value == 0 {
+        return;
+    }
+    let Some(last_instruction) =
+        pyre_jit_trace::state::python_pc_for_jitcode_pc_public(jitcode_index, opcode_position)
+            .map(i64::from)
+    else {
+        return;
+    };
+    let w_exc = exc_value as PyObjectRef;
+    let w_code = w_code_value as PyObjectRef;
+    let w_globals = w_globals_value as PyObjectRef;
+    let _roots = pyre_object::gc_roots::push_roots();
+    pyre_object::gc_roots::pin_root(w_exc);
+    pyre_object::gc_roots::pin_root(w_code);
+    pyre_object::gc_roots::pin_root(w_globals);
+    // `record_application_traceback` requires the traceback's own frame
+    // identity. The recording walker cannot force the optimizer's virtual
+    // locals, so materialize a traceback-only frame from the promoted callee
+    // metadata instead of substituting the caller's frame.
+    let Ok(mut frame) = pyre_interpreter::createframe_obj(
+        w_code as *const (),
+        w_globals,
+        pyre_interpreter::call::getexecutioncontext(),
+        None,
+    ) else {
+        return;
+    };
+    frame.last_instr = last_instruction as isize;
+    let frame_ptr = frame.into_raw();
+    pyre_object::gc_roots::pin_root(frame_ptr as PyObjectRef);
+    unsafe {
+        pyre_interpreter::pytraceback::record_application_traceback(
+            w_exc,
+            frame_ptr,
+            last_instruction,
+        );
+    }
+}
+
 #[majit_macros::jit_may_force]
 pub extern "C" fn jit_force_callee_frame(frame_ptr: i64) -> i64 {
     #[cfg(feature = "cranelift")]

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -625,7 +625,7 @@ pub(crate) fn drain_backend_jit_exc() {
     majit_backend_wasm::jit_exc_clear();
 }
 
-extern "C" fn record_caught_blackhole_traceback(
+pub(crate) extern "C" fn record_caught_blackhole_traceback(
     exc_value: i64,
     frame_value: i64,
     jitcode_index: i32,

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -3402,6 +3402,9 @@ thread_local! {
 }
 
 fn build_jit_driver_pair() -> JitDriverPair {
+    majit_metainterp::set_record_application_traceback_hook(Some(
+        crate::call_jit::record_caught_blackhole_traceback,
+    ));
     let info = build_pyframe_virtualizable_info();
     let mut d = JitDriver::new(JIT_THRESHOLD);
     d.set_virtualizable_info(info.clone());

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -3405,6 +3405,9 @@ fn build_jit_driver_pair() -> JitDriverPair {
     majit_metainterp::set_record_application_traceback_hook(Some(
         crate::call_jit::record_caught_blackhole_traceback,
     ));
+    majit_metainterp::set_record_inline_application_traceback_hook(Some(
+        crate::call_jit::record_inline_traceback_for_recording,
+    ));
     let info = build_pyframe_virtualizable_info();
     let mut d = JitDriver::new(JIT_THRESHOLD);
     d.set_virtualizable_info(info.clone());

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -692,6 +692,10 @@ struct SpamBlock {
     /// `EggBlock` has one incoming edge; pyre coalesces those eggs by handler
     /// PC, so widening the shared FrameState must rewrite every earlier edge.
     incoming_exception_links: Vec<super::flow::LinkRef>,
+    /// Whether this exception EggBlock receives a `raise value` edge.
+    /// Kept on the edge block so handler-entry policy follows link
+    /// provenance rather than scanning the surrounding code object.
+    explicit_raise_operand_edge: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -704,6 +708,7 @@ impl SpamBlockRef {
             framestate,
             dead: false,
             incoming_exception_links: Vec::new(),
+            explicit_raise_operand_edge: false,
         })))
     }
 
@@ -725,6 +730,14 @@ impl SpamBlockRef {
 
     fn incoming_exception_links(&self) -> Vec<super::flow::LinkRef> {
         self.0.borrow().incoming_exception_links.clone()
+    }
+
+    fn mark_explicit_raise_operand_edge(&self) {
+        self.0.borrow_mut().explicit_raise_operand_edge = true;
+    }
+
+    fn has_explicit_raise_operand_edge(&self) -> bool {
+        self.0.borrow().explicit_raise_operand_edge
     }
 
     fn mark_dead(&self) {
@@ -5210,6 +5223,13 @@ fn decode_exception_catch_sites(
         let landing_label = assembler.new_label();
         catch_for_pc[py_pc] = Some(landing_label);
         let landing = SpamBlockRef::new(graph.new_block(Vec::new()), None);
+        if matches!(
+            pyre_interpreter::decode_instruction_at(code, py_pc),
+            Some((Instruction::RaiseVarargs { argc }, op_arg))
+                if argc.get(op_arg) as i64 >= 1
+        ) {
+            landing.mark_explicit_raise_operand_edge();
+        }
         catch_sites.push(ExceptionCatchSite {
             landing_label,
             handler_py_pc,
@@ -6157,6 +6177,16 @@ impl CodeWriter {
         let mut graph = new_shadow_graph_with_portal_inputs(code, frame_inputs);
         let (catch_for_pc, catch_sites, handler_depth_at) =
             decode_exception_catch_sites(&mut assembler, &mut graph, code, num_instrs);
+        // A graph with a caught `raise value` edge needs the EggBlock
+        // link-argument path throughout its exception handlers: cleanup
+        // reraises can carry that same operand across several exception-table
+        // components before POP_EXCEPT restores the previous exception.
+        // Graphs whose exception edges are all implicit/bare retain the
+        // established reconstruction; there is no explicit operand identity
+        // for it to discard.
+        let preserve_exception_edge_states = catch_sites
+            .iter()
+            .any(|site| site.landing.has_explicit_raise_operand_edge());
         // `flowcontext.py:293 self.joinpoints = {}` — sparse-by-PC dict
         // keyed by `next_offset`, populated via `setdefault(...)` per
         // `flowcontext.py:426`.  Vec-of-Vec value preserves the candidate
@@ -7576,12 +7606,28 @@ impl CodeWriter {
                         if start_pc != py_pc {
                             break;
                         }
-                        if let Some(handler_state) = handler_entry_state_from_catch_sites(
+                        if preserve_exception_edge_states {
+                            // Each catch landing is the exception edge's
+                            // EggBlock: it constructs the handler stack from
+                            // its own link inputs, then `mergeblock` joins
+                            // those states through ordinary link arguments.
+                            // Keep that joined pending state while a caught
+                            // `raise value` can flow through this exception
+                            // graph, so PUSH_EXC_INFO retains the edge's
+                            // previous-exception identity.
+                            current_depth = current_state.stack.len() as u16;
+                            needs_fallthrough = false;
+                        } else if let Some(handler_state) = handler_entry_state_from_catch_sites(
                             code,
                             &mut graph,
                             &catch_sites,
                             py_pc,
                         ) {
+                            // Non-explicit edges do not carry a raised
+                            // operand whose identity must survive the handler
+                            // cleanup. Their reconstructed state is equivalent
+                            // to the incoming EggBlock values and preserves
+                            // the established bare-reraise graph shape.
                             current_depth = handler_state.stack.len() as u16;
                             current_state = handler_state;
                             needs_fallthrough = false;


### PR DESCRIPTION
Three commits aligning JIT exception traceback/state handling with PyPy's recording structure.

## 1. `jit: record frame traceback on recording exc unwind`

The trace-recording path never called `record_application_traceback` for the recording frame, so the one iteration that records a trace produced an exception with a missing traceback entry. Wasm `exception_metadata_hot` reported wrong `same_frame_tb` output; now byte-identical to pypy on all backends.

## 2. `jit: record inlined-callee traceback on recording unwind`

Nested `a→b→raise` with `b` inlined into the trace lost `b`'s traceback frame on the recording iteration. Adds a crate-neutral `RecordInlineApplicationTraceback` hook that builds a metadata frame from the inlined callee's promoted `w_code`/`w_globals`, with per-inline-frame `last_caught_exception_value` and a re-raise gate. Verified: unconditional nested raises (depth 3/4), bare re-raise, GC churn with retained tracebacks.

## 3. `jit: keep catch-edge frame state for caught explicit raises`

Root cause of the stale-`sys_exc_value` family: handler-entry construction replaced the pending edge-specific `FrameState` (joined from catch landings via mergeblock link arguments) with a cross-catch-site union minting fresh variables, severing `PUSH_EXC_INFO`'s saved previous-exception identity. After a mid-handler resume, `POP_EXCEPT` consumed the caught exception instead of the saved one — a loop whose except handler exits via `raise e` (or a new exception) chained prior-iteration exceptions into `__context__` (maxctx 399 vs pypy 0, beginning exactly at loop compile).

Each catch landing now records whether its protected PC decodes to `RAISE_VARARGS` with an operand; graphs containing such a caught edge keep the pending mergeblock-joined state at handler entry (`flowcontext.py guessexception`/EggBlock link-argument discipline). Implicit/bare-only graphs keep the reconstructed state.

Known residual (documented in the commit): a code object mixing a call-edge bare-reraise handler with a separately caught explicit raise duplicates one tb frame on re-recording iterations (~1/1700). Removing the graph-wide gate needs per-edge handler dispatch; investigated and parked with the blocker localized (exception-value materialization identity between `link.last_exc_value` and the landing result).

## Verification

- Repro battery (both backends, oracle pypy3): nested-reraise `__context__` shapes (maxctx 0), new-object raise (1), blackhole inner/outer branches (0), multi-site handlers (0), mixed bare/ctx shapes, nested tb depth 3/4, GC churn — all matching pypy.
- `exception_metadata_hot` byte-identical to pypy3 on dynasm/cranelift.
- `cargo test` (pyre-jit-trace, pyre-jit, majit-metainterp dynasm+cranelift): pass.
- `pyre/check.py` dynasm 293/293, cranelift 293/293.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved exception traceback recording during JIT execution and inline calls.
  * Tracebacks now include more accurate source locations for raised and re-raised exceptions.
  * Reduced duplicate traceback entries when the same exception is handled repeatedly.
  * Improved traceback accuracy for explicitly raised exceptions and exception propagation across inline frames.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->