### PR TITLE
stdlib: address PR 726 review parity gaps

### DIFF
--- a/pyre/check.py
+++ b/pyre/check.py
@@ -5,6 +5,7 @@ Cross-platform Python translation of pyre/check.sh.
 """
 
 import argparse
+import difflib
 import math
 import os
 import shutil
@@ -334,6 +335,30 @@ def _dump_failed_run(output, stderr, limit=40):
             print(dim(f"... {len(lines) - len(clipped)} earlier line(s) omitted"))
         for line in clipped:
             print(line)
+    print("────────────────────")
+
+
+def _dump_output_mismatch(actual, expected, limit=80):
+    """Print a bounded unified diff for a backend stdout mismatch."""
+    diff = list(
+        difflib.unified_diff(
+            expected.splitlines(),
+            actual.splitlines(),
+            fromfile="expected (pypy)",
+            tofile="actual",
+            lineterm="",
+        )
+    )
+    if not diff:
+        # Preserve otherwise-invisible trailing-newline/line-ending details.
+        print(f"    expected repr: {expected!r}")
+        print(f"    actual repr:   {actual!r}")
+        return
+    print("─── output diff ───")
+    for line in diff[:limit]:
+        print(line)
+    if len(diff) > limit:
+        print(dim(f"... {len(diff) - limit} later diff line(s) omitted"))
     print("────────────────────")
 
 
@@ -1152,10 +1177,9 @@ class Check:
         else:
             matched = output == pypy_output
         if not matched:
-            exp = pypy_output[:60]
-            act = output[:60]
             self._record(backend, False, name, "wrong output")
-            print(f"{red('WRONG')}  got: {act} expected(pypy): {exp}")
+            print(f"{red('WRONG')}")
+            _dump_output_mismatch(output, pypy_output)
             self._append_comparison(backend, name, t_cpython, t_pypy, "WRONG")
             return
 

--- a/pyre/extra_tests/snippets/stdlib_codecs_escape.py
+++ b/pyre/extra_tests/snippets/stdlib_codecs_escape.py
@@ -23,6 +23,7 @@ for encoded, expected in cases.items():
 
 raw = b"a\n\\b\x00c\td\xe5"
 assert _codecs.escape_encode(raw) == (b"a\\n\\\\b\\x00c\\td\\xe5", len(raw))
+assert _codecs.escape_encode(b"'") == (b"'", 1)
 
 assert codecs.escape_decode(b"a\\x00\\n") == (b"a\x00\n", 7)
 assert _codecs.escape_decode(b"[\\x]\\x", "ignore") == (b"[]", 6)

--- a/pyre/extra_tests/snippets/stdlib_inspect.py
+++ b/pyre/extra_tests/snippets/stdlib_inspect.py
@@ -2,6 +2,7 @@ import _opcode
 import dis
 import inspect
 import opcode
+import sys
 import typing
 
 
@@ -83,6 +84,11 @@ for predicate in (
         raise AssertionError("opcode predicate accepted a missing opcode")
 
 assert _opcode.stack_effect(dis.opmap["NOP"], None) == 0
+
+old_origin_depth = sys.get_coroutine_origin_tracking_depth()
+sys.set_coroutine_origin_tracking_depth(depth=1)
+assert sys.get_coroutine_origin_tracking_depth() == 1
+sys.set_coroutine_origin_tracking_depth(old_origin_depth)
 try:
     _opcode.stack_effect(dis.opmap["NOP"], 0, True)
 except TypeError:

--- a/pyre/extra_tests/snippets/stdlib_weakref.py
+++ b/pyre/extra_tests/snippets/stdlib_weakref.py
@@ -34,6 +34,13 @@ except TypeError:
 else:
     raise AssertionError("_remove_dead_weakref accepted a mappingproxy")
 
+# PyPy's app-level helper calls the current value and deletes it only when
+# that call returns None; it deliberately accepts arbitrary callables.
+callable_entries = {"dead": lambda: None, "live": lambda: 1}
+weakref._remove_dead_weakref(callable_entries, "dead")
+weakref._remove_dead_weakref(callable_entries, "live")
+assert callable_entries == {"live": callable_entries["live"]}
+
 # Test __callback__ property
 assert b.__callback__ is None, (
     "weakref without callback should have __callback__ == None"
@@ -66,6 +73,10 @@ gc.collect()
 assert seen == [(2, None), (1, None)]
 assert w1.__callback__ is None
 assert w2.__callback__ is None
+
+dead_entries = {"x": w1}
+weakref._remove_dead_weakref(dead_entries, "x")
+assert dead_entries == {}
 
 
 class G:

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -3988,14 +3988,6 @@ fn type_descr_new_with_metaclass(
                 )));
             }
         }
-        // typeobject.py:ensure_common_attributes always installs __doc__;
-        // user heap types use None when no class-body docstring was supplied.
-        let class_ns = pyre_object::gc_roots::shadow_stack_get(class_ns_root);
-        if unsafe { pyre_object::w_dict_getitem_str(class_ns, "__doc__") }.is_none() {
-            unsafe {
-                pyre_object::w_dict_setitem_str_no_proxy(class_ns, "__doc__", pyre_object::w_none())
-            };
-        }
         let class_ns = pyre_object::gc_roots::shadow_stack_get(class_ns_root);
         type_new_set_doc(class_ns)?;
         let class_ns = pyre_object::gc_roots::shadow_stack_get(class_ns_root);

--- a/pyre/pyre-interpreter/src/module/_codecs/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_codecs/mod.rs
@@ -1746,7 +1746,6 @@ fn escape_encode_impl(w_obj: PyObjectRef) -> Result<PyObjectRef, crate::PyError>
             b'\n' => out.extend_from_slice(b"\\n"),
             b'\r' => out.extend_from_slice(b"\\r"),
             b'\\' => out.extend_from_slice(b"\\\\"),
-            b'\'' => out.extend_from_slice(b"\\'"),
             0x20..=0x7e => out.push(*byte),
             value => out.extend_from_slice(format!("\\x{value:02x}").as_bytes()),
         }

--- a/pyre/pyre-interpreter/src/module/_weakref/interp__weakref.rs
+++ b/pyre/pyre-interpreter/src/module/_weakref/interp__weakref.rs
@@ -878,12 +878,24 @@ pub fn remove_dead_weakref(args: &[PyObjectRef]) -> Result<PyObjectRef, PyError>
     let Some(stored) = crate::baseobjspace::finditem(backing, key)? else {
         return Ok(pyre_object::w_none());
     };
-    if !is_w_weakref(stored) {
-        return Err(PyError::type_error("not a weakref"));
-    }
-    if !dereference(stored).is_null() {
+    // app_weakref.py calls the retrieved value directly (`wr()`) rather than
+    // requiring a weakref instance.  Keep backing/key/stored rooted across
+    // that arbitrary call, then use the native identity-checked deletion
+    // primitive exactly as `delitem_if_value_is(d, key, wr)` does upstream.
+    let _roots = pyre_object::gc_roots::push_roots();
+    let backing_root = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(backing);
+    let key_root = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(key);
+    let stored_root = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(stored);
+    let result = crate::call::call_function_impl_result(stored, &[])?;
+    if !unsafe { pyre_object::is_none(result) } {
         return Ok(pyre_object::w_none());
     }
+    let backing = pyre_object::gc_roots::shadow_stack_get(backing_root);
+    let key = pyre_object::gc_roots::shadow_stack_get(key_root);
+    let stored = pyre_object::gc_roots::shadow_stack_get(stored_root);
     crate::baseobjspace::dict_delitem_if_value_is(backing, key, stored)?;
     Ok(pyre_object::w_none())
 }

--- a/pyre/pyre-interpreter/src/module/sys/vm.rs
+++ b/pyre/pyre-interpreter/src/module/sys/vm.rs
@@ -343,7 +343,25 @@ fn sys_get_coroutine_origin_tracking_depth(_args: &[PyObjectRef]) -> crate::PyRe
 }
 
 fn sys_set_coroutine_origin_tracking_depth(args: &[PyObjectRef]) -> crate::PyResult {
-    let w_depth = *args.first().ok_or_else(|| {
+    let (positional, kwargs) = crate::builtins::split_builtin_kwargs(args);
+    crate::builtins::kwarg_reject_unknown(
+        kwargs,
+        &["depth"],
+        "set_coroutine_origin_tracking_depth",
+    )?;
+    if positional.len() > 1 {
+        return Err(crate::PyError::type_error(format!(
+            "set_coroutine_origin_tracking_depth() takes exactly one argument ({} given)",
+            positional.len(),
+        )));
+    }
+    let kw_depth = crate::builtins::kwarg_get(kwargs, "depth");
+    if !positional.is_empty() && kw_depth.is_some() {
+        return Err(crate::PyError::type_error(
+            "set_coroutine_origin_tracking_depth() got multiple values for argument 'depth'",
+        ));
+    }
+    let w_depth = positional.first().copied().or(kw_depth).ok_or_else(|| {
         crate::PyError::type_error(
             "set_coroutine_origin_tracking_depth() missing required argument 'depth'",
         )


### PR DESCRIPTION
Follow-up to #726 after it merged while review feedback was being addressed.

- match PyPy `_remove_dead_weakref` callable and identity-checked deletion semantics
- preserve apostrophes in `_codecs.escape_encode(..., quote=False)`
- bind `depth=` for coroutine origin tracking
- defer default `__doc__` until after `__slots__` handling
- add regression coverage for each behavior

Validation:
- re-extracted `pyre-interpreter` LLBC and wasm layouts
- rebuilt the rtyper prepass
- `cargo check --features dynasm`
- `cargo test --features dynasm`
- stdlib codecs/inspect/weakref snippets
- direct `__doc__` member-slot reproduction