### PR TITLE
jit: #73 jitcode-blackhole — backxlat consumer-family twin cutover + midbody py forward-carry (P1)

### DIFF
--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/diag.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/diag.rs
@@ -59,10 +59,17 @@ pub(crate) fn pcmap_recipe_resultcolor_audit_probe(site: &'static str, verdict: 
 /// paths; it is never a panic.
 pub(crate) fn resolve_parent_resume_py_pc(parent: &InlineParentFrame) -> Option<u32> {
     match parent.resume_coord {
-        ParentResumeCoord::Backxlat(jitcode_pc) => Some(crate::state::backxlat_py_pc(
-            parent.jitcode_index as i32,
-            jitcode_pc as i32,
-        ) as u32),
+        ParentResumeCoord::Backxlat(jitcode_pc) => {
+            // #73: read the forward py_pc twin (a codewriter-built,
+            // trivia-normalized twin of `backxlat_py_pc`'s result — proven equal
+            // corpus-wide in Slice 3'). The inversion survives only for the
+            // empty-twin class (skeleton / fixture jitcodes).
+            let twin = crate::state::pyjitcode_for_jitcode_index(parent.jitcode_index as i32)
+                .and_then(|pjc| pjc.forward_py_pc_for_jitcode_pc(jitcode_pc));
+            Some(twin.unwrap_or_else(|| {
+                crate::state::backxlat_py_pc(parent.jitcode_index as i32, jitcode_pc as i32) as u32
+            }))
+        }
         ParentResumeCoord::CallFallthrough(call_jit_pc) => {
             let Some(pjc) = crate::state::pyjitcode_for_jitcode_index(parent.jitcode_index as i32)
             else {

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
@@ -2428,6 +2428,7 @@ pub(crate) fn try_walker_inline_resolved_user_call<Sym: WalkSym>(
                         call_stack_len: arg_concretes.len(),
                         callee_jitcode_index: callee_pjc.jitcode.index() as u32,
                         abort_jitcode_pc: abort_pc,
+                        callee_py_pc,
                         w_code: w_code as pyre_object::PyObjectRef,
                         w_globals: unsafe { pyre_interpreter::function_get_globals_obj(callable) },
                         x_arg,

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
@@ -1038,10 +1038,10 @@ impl<Sym: WalkSym> WalkContext<'_, '_, Sym> {
     fn entry_py_pc(&self) -> u32 {
         match self.entry_py_pc {
             EntryPyPc::Py(py_pc) => py_pc,
-            EntryPyPc::Jit(jitcode_pc) => {
-                crate::state::backxlat_py_pc(self.outer_jitcode_index as i32, jitcode_pc as i32)
-                    as u32
-            }
+            EntryPyPc::Jit(jitcode_pc) => crate::state::forward_py_pc_or_backxlat(
+                self.outer_jitcode_index as i32,
+                jitcode_pc as i32,
+            ) as u32,
         }
     }
 }

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
@@ -4491,6 +4491,10 @@ pub(crate) struct MidBodyPayload {
     /// interpreter flush boundary.
     pub callee_jitcode_index: u32,
     pub abort_jitcode_pc: usize,
+    /// Forward-carried Python instruction PC for `abort_jitcode_pc`, stamped
+    /// once at capture so the flush reads a scalar instead of re-inverting the
+    /// coordinate through the jitcode->py tables.
+    pub callee_py_pc: usize,
     pub w_code: pyre_object::PyObjectRef,
     pub w_globals: pyre_object::PyObjectRef,
     pub x_arg: pyre_object::PyObjectRef,

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -857,18 +857,24 @@ fn m73_backxlat_twin_audit_enabled() -> bool {
 /// predecessor entry, so they are delegated straight to `backxlat_py_pc`, which
 /// resolves them identically to the pre-cutover call.
 pub fn forward_py_pc_or_backxlat(jitcode_index: i32, pc_word: i32) -> i32 {
-    let live = backxlat_py_pc(jitcode_index, pc_word);
-    if pc_word >= 0 && m73_backxlat_twin_audit_enabled() {
-        if let Some(twin) = pyjitcode_for_jitcode_index(jitcode_index)
-            .and_then(|pjc| pjc.forward_py_pc_for_jitcode_pc(pc_word as usize))
-        {
-            assert_eq!(
-                twin as i32, live,
-                "PYRE_M73_BACKXLAT_TWIN_AUDIT: forward py_pc twin diverged at jitcode {jitcode_index} pc {pc_word}"
-            );
-        }
+    if pc_word < 0 {
+        return backxlat_py_pc(jitcode_index, pc_word);
     }
-    live
+    match pyjitcode_for_jitcode_index(jitcode_index)
+        .and_then(|pjc| pjc.forward_py_pc_for_jitcode_pc(pc_word as usize))
+    {
+        Some(twin) => {
+            if m73_backxlat_twin_audit_enabled() {
+                assert_eq!(
+                    twin as i32,
+                    backxlat_py_pc(jitcode_index, pc_word),
+                    "PYRE_M73_BACKXLAT_TWIN_AUDIT: forward py_pc twin diverged at jitcode {jitcode_index} pc {pc_word}"
+                );
+            }
+            twin as i32
+        }
+        None => backxlat_py_pc(jitcode_index, pc_word),
+    }
 }
 
 /// `framework.py` `root_walker.walk_roots` hook for the boxed `Ref`

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -836,6 +836,41 @@ pub fn backxlat_py_pc(jitcode_index: i32, pc_word: i32) -> i32 {
     }
 }
 
+/// `PYRE_M73_BACKXLAT_TWIN_AUDIT` asserts the codewriter-built forward py_pc
+/// twin equals the [`backxlat_py_pc`] inversion at every non-negative resume
+/// word before [`forward_py_pc_or_backxlat`] trusts the twin. Off in
+/// production; the gated assert is the only added work.
+fn m73_backxlat_twin_audit_enabled() -> bool {
+    static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ENABLED.get_or_init(|| std::env::var_os("PYRE_M73_BACKXLAT_TWIN_AUDIT").is_some())
+}
+
+/// Forward Python instruction coordinate for a carried resume JitCode word.
+///
+/// Reads the codewriter-built `forward_py_pc` twin — a by-construction mirror
+/// of [`backxlat_py_pc`]'s block-head/floor resolution plus its
+/// `skip_python_trivia_forward` normalization — keeping the inversion only for
+/// the empty-twin class (skeleton / fixture jitcodes) and for negative words.
+///
+/// Negative words (`NO_JITCODE_PC` `-1`, tagged branch-orgpc words `<= -2`)
+/// cast to a huge `usize` twin key and would floor-resolve to a bogus
+/// predecessor entry, so they are delegated straight to `backxlat_py_pc`, which
+/// resolves them identically to the pre-cutover call.
+pub fn forward_py_pc_or_backxlat(jitcode_index: i32, pc_word: i32) -> i32 {
+    let live = backxlat_py_pc(jitcode_index, pc_word);
+    if pc_word >= 0 && m73_backxlat_twin_audit_enabled() {
+        if let Some(twin) = pyjitcode_for_jitcode_index(jitcode_index)
+            .and_then(|pjc| pjc.forward_py_pc_for_jitcode_pc(pc_word as usize))
+        {
+            assert_eq!(
+                twin as i32, live,
+                "PYRE_M73_BACKXLAT_TWIN_AUDIT: forward py_pc twin diverged at jitcode {jitcode_index} pc {pc_word}"
+            );
+        }
+    }
+    live
+}
+
 /// `framework.py` `root_walker.walk_roots` hook for the boxed `Ref`
 /// constants embedded in every live jitcode's `constants_r` pool.
 ///
@@ -6009,7 +6044,7 @@ fn reconstruct_inline_recipe(
     if frame.pc < 0 {
         return None;
     }
-    let py_pc = backxlat_py_pc(frame.jitcode_index, frame.pc) as usize;
+    let py_pc = forward_py_pc_or_backxlat(frame.jitcode_index, frame.pc) as usize;
     let w_code = code_for_jitcode_index(frame.jitcode_index)?;
     if w_code.is_null() {
         return None;
@@ -12329,10 +12364,10 @@ pub(crate) fn assemble_bridge_inline_pending(
         concrete_frame.push(recipe_slot_to_pyobj(recipe.concrete_r[k]));
     }
     // last_instr is one before the recipe's Python pc so next_instr() resumes there.
-    concrete_frame
-        .set_last_instr_from_next_instr(
-            backxlat_py_pc(recipe.jitcode_index, recipe.jitcode_pc) as usize
-        );
+    concrete_frame.set_last_instr_from_next_instr(forward_py_pc_or_backxlat(
+        recipe.jitcode_index,
+        recipe.jitcode_pc,
+    ) as usize);
 
     // Symbolic side: mirror the FAST branch field-for-field.
     let mut sym = PyreSym::new_uninit(OpRef::NONE);

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -593,7 +593,7 @@ pub fn trace_bytecode<Sym: WalkSym>(
         start_pc
     };
     let lasti_pc = if let Some(ref c) = carrier {
-        crate::state::backxlat_py_pc(c.root_jitcode_index, c.root_pc as i32) as usize
+        crate::state::forward_py_pc_or_backxlat(c.root_jitcode_index, c.root_pc as i32) as usize
     } else {
         start_pc
     };
@@ -1047,7 +1047,9 @@ fn drive_bridge_carrier_walk<Sym: WalkSym>(
         let pcs: Vec<usize> = carrier
             .recipes
             .iter()
-            .map(|r| crate::state::backxlat_py_pc(r.jitcode_index, r.jitcode_pc) as usize)
+            .map(|r| {
+                crate::state::forward_py_pc_or_backxlat(r.jitcode_index, r.jitcode_pc) as usize
+            })
             .collect();
         eprintln!(
             "[p2-shape] root_pc={root_pc} n_recipes={} recipe_pcs={pcs:?}",
@@ -1173,9 +1175,10 @@ fn drive_bridge_carrier_walk<Sym: WalkSym>(
         if want_compile && middles_ok {
             if inject_root_call_result(sym, root_pc, result) {
                 crate::jitcode_dispatch::census_record("P2Drain::CompileRoot");
-                let root_py_pc =
-                    crate::state::backxlat_py_pc(carrier.root_jitcode_index, root_pc as i32)
-                        as usize;
+                let root_py_pc = crate::state::forward_py_pc_or_backxlat(
+                    carrier.root_jitcode_index,
+                    root_pc as i32,
+                ) as usize;
                 // The sub-walks above already applied each frame's eager stores
                 // and journaled them; hand those journals to the root walk so its
                 // epilogue settles them exactly once.
@@ -1198,7 +1201,10 @@ fn drive_bridge_carrier_walk<Sym: WalkSym>(
             if p2_diag {
                 eprintln!(
                     "[p2-drain] callee sub-walk OK recipe_py_pc={} entry={entry} end_pc={end_pc} outcome={outcome:?}",
-                    crate::state::backxlat_py_pc(recipe.jitcode_index, recipe.jitcode_pc)
+                    crate::state::forward_py_pc_or_backxlat(
+                        recipe.jitcode_index,
+                        recipe.jitcode_pc
+                    )
                 );
             }
             crate::jitcode_dispatch::census_record("P2Drain::SubWalkOk");
@@ -1207,7 +1213,10 @@ fn drive_bridge_carrier_walk<Sym: WalkSym>(
             if p2_diag {
                 eprintln!(
                     "[p2-drain] callee sub-walk STOP recipe_py_pc={} entry={entry} err={e:?}",
-                    crate::state::backxlat_py_pc(recipe.jitcode_index, recipe.jitcode_pc)
+                    crate::state::forward_py_pc_or_backxlat(
+                        recipe.jitcode_index,
+                        recipe.jitcode_pc
+                    )
                 );
             }
             crate::jitcode_dispatch::census_record("P2Drain::SubWalkStop");

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -304,6 +304,15 @@ struct MidBodyFlushWords {
     callee_py_pc: usize,
 }
 
+/// `PYRE_M73_MIDBODY_CARRY_AUDIT` asserts the forward-carried
+/// `MidBodyPayload.callee_py_pc` equals the jitcode->py inversion at the
+/// midbody flush boundary before the carry is trusted. Off in production; the
+/// gated branch is the only added work.
+fn midbody_carry_audit_enabled() -> bool {
+    static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ENABLED.get_or_init(|| std::env::var_os("PYRE_M73_MIDBODY_CARRY_AUDIT").is_some())
+}
+
 fn resolve_midbody_flush_words(
     payload: &crate::jitcode_dispatch::MidBodyPayload,
 ) -> Option<MidBodyFlushWords> {
@@ -318,16 +327,40 @@ fn resolve_midbody_flush_words(
         unsafe { &*outer.code_ptr },
         call_py_pc,
     );
+    // #73 walker-as-tracer P1: the callee resume py is read from the scalar
+    // forward-carried on the MidBodyPayload (`callee_py_pc`, stamped at capture
+    // from the same jitcode->py inversion this once performed). The `callee`
+    // pjc lookup above stays for its null-code decline (`?`) and feeds the
+    // gated audit, which asserts the carry still equals the live inversion.
+    // The midbody callee-rebuild resume path is corpus-cold, so byte-parity
+    // rests on encode/resume input identity (same immutable metadata + pc), not
+    // on an exercised audit; the gate remains a permanent tripwire.
+    if midbody_carry_audit_enabled() {
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static HITS: AtomicU64 = AtomicU64::new(0);
+        let callee_py_pc_convert = crate::jitcode_dispatch::python_pc_for_jitcode_pc(
+            &callee.metadata,
+            payload.abort_jitcode_pc,
+        ) as usize;
+        if HITS.fetch_add(1, Ordering::Relaxed) == 0 {
+            eprintln!(
+                "[m73-midbody-carry-audit] first callee_py_pc comparison (carry={} convert={callee_py_pc_convert})",
+                payload.callee_py_pc
+            );
+        }
+        assert_eq!(
+            payload.callee_py_pc, callee_py_pc_convert,
+            "PYRE_M73_MIDBODY_CARRY_AUDIT: callee_py_pc carry diverged at jitcode {} pc {}",
+            payload.callee_jitcode_index, payload.abort_jitcode_pc
+        );
+    }
     Some(MidBodyFlushWords {
         call_py_pc,
         post_call_py_pc: crate::jitcode_dispatch::skip_python_trivia_forward(
             unsafe { &*outer.code_ptr },
             call_py_pc + 1,
         ),
-        callee_py_pc: crate::jitcode_dispatch::python_pc_for_jitcode_pc(
-            &callee.metadata,
-            payload.abort_jitcode_pc,
-        ) as usize,
+        callee_py_pc: payload.callee_py_pc,
     })
 }
 

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -625,6 +625,60 @@ pub(crate) fn drain_backend_jit_exc() {
     majit_backend_wasm::jit_exc_clear();
 }
 
+/// #73 measurement gate. When `PYRE_M73_LASTINSTR_AUDIT` is set, the three
+/// blackhole traceback sites compare the production inversion
+/// `python_pc_for_jitcode_pc_public(last_opcode_position)` (= `orgpc`, the
+/// raising op's python pc) against the forward candidate `frame.last_instr + 1`
+/// (the JIT-vable resume convention normalized to `orgpc`). Divergence means the
+/// forward datum is stale/off-by-one and cannot yet replace the inversion; a
+/// clean corpus (zero divergences) would mean the forward carry is already
+/// exact. Pure telemetry — never changes production output.
+fn m73_lastinstr_audit_enabled() -> bool {
+    static E: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *E.get_or_init(|| std::env::var_os("PYRE_M73_LASTINSTR_AUDIT").is_some())
+}
+
+fn m73_lastinstr_audit(
+    site: &str,
+    jitcode_index: Option<i32>,
+    opcode_position: i32,
+    frame_ptr: *const PyFrame,
+) {
+    if !m73_lastinstr_audit_enabled() || frame_ptr.is_null() {
+        return;
+    }
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static HITS: AtomicU64 = AtomicU64::new(0);
+    static DIVERGE: AtomicU64 = AtomicU64::new(0);
+    static NONE: AtomicU64 = AtomicU64::new(0);
+    let inv = jitcode_index.and_then(|index| {
+        pyre_jit_trace::state::python_pc_for_jitcode_pc_public(index, opcode_position)
+    });
+    let fwd = unsafe { (*frame_ptr).last_instr as i64 } + 1;
+    let hits = HITS.fetch_add(1, Ordering::Relaxed) + 1;
+    if hits == 1 {
+        // Per-process heartbeat: confirms the site was exercised even when no
+        // divergence prints (each check.py test is a fresh process).
+        eprintln!("[M73-LASTINSTR] first-hit site={site}");
+    }
+    match inv {
+        Some(iv) => {
+            let iv = iv as i64;
+            if iv != fwd {
+                let d = DIVERGE.fetch_add(1, Ordering::Relaxed) + 1;
+                eprintln!(
+                    "[M73-LASTINSTR] diverge site={site} inv={iv} fwd={fwd} delta={} (proc hits={hits} diverge={d} none={})",
+                    iv - fwd,
+                    NONE.load(Ordering::Relaxed)
+                );
+            }
+        }
+        None => {
+            NONE.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+}
+
 pub(crate) extern "C" fn record_caught_blackhole_traceback(
     exc_value: i64,
     frame_value: i64,
@@ -638,6 +692,7 @@ pub(crate) extern "C" fn record_caught_blackhole_traceback(
     let last_instruction =
         pyre_jit_trace::state::python_pc_for_jitcode_pc_public(jitcode_index, opcode_position)
             .map_or(unsafe { (*frame_ptr).last_instr as i64 }, i64::from);
+    m73_lastinstr_audit("caught", Some(jitcode_index), opcode_position, frame_ptr);
     unsafe {
         pyre_interpreter::pytraceback::record_application_traceback(
             exc_value as PyObjectRef,
@@ -2226,6 +2281,12 @@ pub fn blackhole_resume_via_rd_numb(
                                 )
                             })
                             .map_or(unsafe { (*frame_ptr).last_instr as i64 }, i64::from);
+                        m73_lastinstr_audit(
+                            "exit_guard_exc",
+                            jitcode_index,
+                            last_opcode_position as i32,
+                            frame_ptr,
+                        );
                         unsafe {
                             pyre_interpreter::pytraceback::record_application_traceback(
                                 err.exc_object,
@@ -2366,6 +2427,12 @@ pub fn blackhole_resume_via_rd_numb(
                             )
                         })
                         .map_or(unsafe { (*frame_ptr).last_instr as i64 }, i64::from);
+                    m73_lastinstr_audit(
+                        "exit_got_exc",
+                        jitcode_index,
+                        last_opcode_position as i32,
+                        frame_ptr,
+                    );
                     unsafe {
                         pyre_interpreter::pytraceback::record_application_traceback(
                             err.exc_object,


### PR DESCRIPTION
Continues the jitcode-blackhole epic (#73) on top of #727 (Slice 3'), retiring
runtime consumers of the `py_pc ↔ jitcode_pc` translation tables by reading the
codewriter-built forward py_pc twin instead of inverting `jitcode_pc → py_pc`.

## Commits

1. **`d977ab8` — cut the `Backxlat` parent-resume coordinate to the forward
   py_pc twin.** `resolve_parent_resume_py_pc`'s `Backxlat` arm reads the
   codewriter-built `forward_py_pc_for_jitcode_pc` twin, keeping the inversion
   only for the empty-twin (skeleton / fixture) class.

2. **`cabe2c8` — `PYRE_M73_LASTINSTR_AUDIT` blackhole-traceback divergence
   census.** A gated census over the blackhole traceback-delivery sites,
   comparing the `jitcode_pc → py_pc` inversion against `frame.last_instr + 1`.
   Measured large, varied divergence (not ±1) across the synth corpus, proving
   `last_instr` is many opcodes stale at the raising op — the inversion is
   load-bearing for `tb_lasti` / `tb_lineno`, so a naive forward-carry here is a
   NO-GO. Census retained as a tripwire.

3. **`2003cdf` + `e032ddd` — route the `backxlat_py_pc` resume-word consumer
   family through `state::forward_py_pc_or_backxlat`** (two phases: audit, then
   cutover). One helper with a negative-guard (`NO_JITCODE_PC` / tagged
   branch-orgpc words delegate to `backxlat_py_pc`), a `forward_py_pc` twin read
   for non-negative words, and an empty-twin fallback. All `backxlat_py_pc`
   resume-word call sites converted; the inversion is now reached only via the
   helper and the diagnostic fallback. A 3-lens adversarial pass proved
   `twin == backxlat` by construction (marker tier iterates the same
   `block_head_py_by_jit_pc` + `skip_python_trivia_forward`; pred tier mirrors
   floor resolution). `PYRE_M73_BACKXLAT_TWIN_AUDIT` sweep over 280 synth
   tests × both backends: 0 divergence.

4. **`972f566` — #73 P1: forward-carry the midbody callee resume py on
   `MidBodyPayload`.** Adds `MidBodyPayload.callee_py_pc`, stamped at capture
   from the value already computed for the abort anchor, so the midbody flush
   reads a scalar instead of re-inverting `abort_jitcode_pc` through
   `block_head_py_by_jit_pc` + `py_floor_by_jit_pc`. Removes one runtime reader
   of both tables. Byte-parity rests on encode/resume input identity;
   `PYRE_M73_MIDBODY_CARRY_AUDIT` is a permanent tripwire (the midbody
   callee-rebuild commit path is not exercised by the synth corpus, so the
   certificate here is by-construction).

## Scoping note (recorded for follow-up)

A map + decompose + adversary scoping of the walker-as-tracer epic found the
byte-preserving forward-carry lever is **exhausted after P1**: the walk itself is
py-free (`op.pc` is a jitcode offset; `InlineParentFrame` carries jitcode coords,
no py scalar), so a forward-carry reduces table readers only where the encode
already converts py for another reason — P1 is the unique such site. The
remaining warm consumers (Entry / outer abort carriers) are pure relocations,
and the true remaining progress is the structural reentry-in-jitcode-coords
change (byte-changing, design-bearing). No `pc_map` / table deletion lands here.

## Verification

- `python3 pyre/check.py --backend dynasm,cranelift` = 294/294 each, byte-identical.
- `PYRE_M73_BACKXLAT_TWIN_AUDIT` sweep: 280 synth × 2 backends, 0 divergence.

— *authored by Claude*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy when translating JIT execution positions back to Python source positions.
  * Improved handling of inline calls and mid-execution interruptions, preserving the correct callee location.
  * Improved diagnostic and traceback reporting across JIT execution paths.

* **Diagnostics**
  * Added optional runtime checks to detect inconsistencies in position tracking and report detailed information for troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->