### PR TITLE
object: pin value across the reentrant scan in delitem_if_value_is

### DIFF
--- a/pyre/pyre-object/src/dictmultiobject.rs
+++ b/pyre/pyre-object/src/dictmultiobject.rs
@@ -2923,7 +2923,14 @@ pub unsafe fn w_dict_delitem_if_value_is_checked(
     }) {
         return result;
     }
+    // `value` is a native local held across the scan; a mid-scan GC in a
+    // probing `__eq__` could move it before the identity check below, so pin
+    // and reload it alongside the container the scan returns.
+    let _value_root = crate::gc_roots::push_roots();
+    let value_slot = crate::gc_roots::shadow_stack_len();
+    crate::gc_roots::pin_root(value);
     let (found, _, obj) = scan_dict_key_reentrant(obj, object_key)?;
+    let value = crate::gc_roots::shadow_stack_get(value_slot);
     let Some(index) = found else {
         return Ok(false);
     };


### PR DESCRIPTION
## Summary

Follow-up to the Codex P1 review on #747: in `w_dict_delitem_if_value_is_checked`'s reentrant-scan fallback, `scan_dict_key_reentrant` can run user `__eq__` and trigger a moving GC — the returned dict pointer is reloaded, but the raw `value` argument was still the pre-move pointer, so the identity check could compare a stale address and incorrectly skip the atomic deletion. Pin `value` before the scan and reload it after, matching the setitem/setdefault sibling paths.

## Verification

- `cargo test -p pyre-object`: 218 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)