### PR TITLE
jit(gh#346): retire the complex-division prepass walls via float-`/`→truediv lowering

### DIFF
--- a/majit/majit-translate/src/codewriter/jtransform.rs
+++ b/majit/majit-translate/src/codewriter/jtransform.rs
@@ -5262,9 +5262,13 @@ fn canonical_float_arith_binop(op: &str) -> Option<&'static str> {
         // `front::mir::canonical_binop_label` collapses Rust `/`
         // (MIR `Div`) to "floordiv"; over floats that operator is
         // true division, so both labels land on `float_truediv`.
+        // The front end re-labels a float-result `/` to "truediv"
+        // (mirroring RPython's flowspace opname) before the prepass
+        // annotator, so this arm also accepts the already-canonical
+        // "truediv" / "inplace_truediv" spellings.
         // Integer "floordiv" never reaches this arm — the guard
         // requires a float operand or a Float result.
-        "div" | "div_assign" | "floordiv" => Some("div"),
+        "div" | "div_assign" | "floordiv" | "truediv" | "inplace_truediv" => Some("div"),
         _ => None,
     }
 }

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -3515,7 +3515,7 @@ impl<'a> Lowering<'a> {
             Rvalue::BinaryOp(op_json, lhs, rhs) => {
                 let lhs_v = self.resolve_operand(mir_bb, lhs)?;
                 let rhs_v = self.resolve_operand(mir_bb, rhs)?;
-                let op_label = binop_label(&op_json)?;
+                let mut op_label = binop_label(&op_json)?;
                 let res = self
                     .graph
                     .alloc_value_var_with_type(crate::model::ConcreteType::Unknown);
@@ -3527,6 +3527,23 @@ impl<'a> Lowering<'a> {
                     ValueType::Float => ValueType::Float,
                     _ => ValueType::Int,
                 };
+                // Rust `/` (MIR `Div`) lowers to the `floordiv` opname
+                // (`canonical_binop_label`) — the correct label for
+                // integer truncating division. Over floats `/` is true
+                // division; `pairtype(SomeFloat, SomeFloat)` registers
+                // `truediv` but not `floordiv` (`binaryop.py:440-443`),
+                // the same distinction RPython's flowspace makes by
+                // emitting the `truediv` opname for `/` at graph
+                // construction. Re-label the float result so the prepass
+                // annotator dispatches `truediv(SomeFloat, SomeFloat)`
+                // instead of walling on the unregistered `floordiv`.
+                // Downstream is unchanged: `codewriter::jtransform` funnels
+                // both labels to `float_truediv` and the rtyper maps
+                // `(FloatRepr, "truediv")` / `(FloatRepr, "div")` to the
+                // same `rtype_template("truediv")`.
+                if result_ty == ValueType::Float && op_label == "floordiv" {
+                    op_label = "truediv".to_string();
+                }
                 Ok((
                     Some(OpKind::BinOp {
                         op: op_label,

--- a/majit/majit-translate/src/translator/rtyper/cutover.rs
+++ b/majit/majit-translate/src/translator/rtyper/cutover.rs
@@ -1614,6 +1614,20 @@ pub(crate) fn populate_call_registry_from_call_graphs(
         };
         pending.push((key, graph, entry));
     }
+    // Lift `pending` in a deterministic order.  `function_graphs.iter()`
+    // (`GraphStore` over `path_to_key: HashMap<CallPath, _>`) yields entries
+    // in `std::HashMap` order, which varies run-to-run.  Pass 2's lift order
+    // is observable: the fail-closed transitive gate (`flowspace_adapter.rs`
+    // `translate_op`) rejects a caller whose callee has ALREADY recorded a
+    // `record_lift_error`, so whether a caller inherits a callee's recorded
+    // error — and which transitive error surfaces — depends on which of the
+    // two lifted first.  Sorting by the path key makes the lift order (and
+    // thus the recorded-error attribution) reproducible, mirroring the
+    // Phase-A subject sort (`run_two_phase_prepass_inner`).  The lift itself
+    // is per-entry isolated (`Rc::as_ptr` dedup below) and aliases of one
+    // entry share the same graph, so ordering changes neither which entries
+    // fail nor what each computes — only the attribution determinism.
+    pending.sort_by(|a, b| a.0.segments().cmp(b.0.segments()));
     // Register `unsafe fn` stubs between Pass 1 (alias explosion) and
     // Pass 2 (callee lift).  `build_flow.rs:215` rejects unsafe bodies so
     // they never enter `function_graphs`; without a stub a safe-fn body

--- a/majit/majit-translate/src/translator/rtyper/cutover.rs
+++ b/majit/majit-translate/src/translator/rtyper/cutover.rs
@@ -2151,10 +2151,15 @@ pub(crate) fn register_unsafe_fn_stubs(
 ///   `Void` result.
 /// - `core::cell::Cell::<T>::set(&self, val)` returns `()` — an
 ///   in-place store into the cell, `Void` result.
-/// - `core::f64::<Impl>::is_infinite` / `core::slice::<Impl>::is_empty`
-///   return `bool` — `Bool` result.
-/// - `std::f64::<Impl>::floor` / `std::f64::<Impl>::powf` return `f64` —
-///   `Float` result.
+/// - `core::f64::<Impl>::is_infinite` / `core::f64::<Impl>::is_nan` /
+///   `core::slice::<Impl>::is_empty` return `bool` — `Bool` result.
+/// - `std::f64::<Impl>::floor` / `std::f64::<Impl>::powf` /
+///   `core::f64::<Impl>::abs` return `f64` — `Float` result.
+/// - `core::f64::<Impl>::NAN` / `core::f64::<Impl>::INFINITY` are the
+///   associated `f64` constants, reached as zero-arg `FunctionPath`
+///   accessors — `Float` result, empty arg list. These plus the `f64`
+///   predicates above close the complex-division (`_Py_c_quot` /
+///   `_Py_c_prod`) foreign-leaf cluster.
 /// - `core::f64::<Impl>::to_bits` returns `u64` reinterpreted as `i64` —
 ///   `Signed` result.
 ///
@@ -2198,6 +2203,22 @@ const FOREIGN_STDLIB_EXTERNALS: &[(&[&str], &[&str], LowLevelType)] = &[
         &["core", "f64", "<Impl>", "to_bits"],
         &["self"],
         LowLevelType::Signed,
+    ),
+    (
+        &["core", "f64", "<Impl>", "abs"],
+        &["self"],
+        LowLevelType::Float,
+    ),
+    (
+        &["core", "f64", "<Impl>", "is_nan"],
+        &["self"],
+        LowLevelType::Bool,
+    ),
+    (&["core", "f64", "<Impl>", "NAN"], &[], LowLevelType::Float),
+    (
+        &["core", "f64", "<Impl>", "INFINITY"],
+        &[],
+        LowLevelType::Float,
     ),
 ];
 


### PR DESCRIPTION
## Summary

Retires the last foreign-frontier cluster in the two-phase-rtyper `[PREPASS phaseA fail]` census — the complex-division graphs in `descroperation.rs` — plus a determinism fix for the census itself.

Three commits:

1. **`rtyper: sort two-phase Pass-2 pending by path key`** — Pass-2 `populate_call_registry_from_call_graphs` lifted `pending` in `GraphStore::iter()` (`HashMap` order), so last-write-wins error recording + the fail-closed transitive gate made the census head count flicker run-to-run. Sorting `pending` by path key before the lift loop makes it deterministic. Bit-exact (no behavior change).

2. **`front/rtyper: register the f64 complex-division foreign leaves`** — adds `core::f64::<Impl>::abs` / `is_nan` and the `NAN` / `INFINITY` associated-constant accessors to `FOREIGN_STDLIB_EXTERNALS`. These were the remaining unresolved foreign leaves in `_Py_c_quot` / `_Py_c_prod` / `_Py_rc_quot`; `is_infinite` was already present and `is_finite` is front-recognized (`(x-x)==0.0`). Net-neutral alone — prerequisite for #3.

3. **`front, codewriter: lower a float-result \`/\` to the truediv opname`** — the root cause. `canonical_binop_label` maps every Rust MIR `Div` to the `floordiv` opname, correct for integer truncating division but wrong for `f64 /` (true division). The prepass annotator then dispatches `floordiv(SomeFloat, SomeFloat)`, which `pairtype(SomeFloat, SomeFloat)` does not register (add/sub/mul/div/truediv, no floordiv — `binaryop.py:428-447`; RPython's flowspace emits the `truediv` opname for `/` at graph construction so it never sees float floordiv). The fix re-labels a float-result `Div` to `truediv` at the `Rvalue::BinaryOp` lowering. Bit-exact downstream: `jtransform` funnels both `floordiv` and `truediv` over floats to `float_truediv`, and the rtyper maps `(FloatRepr, "truediv")` / `(FloatRepr, "div")` to the same `rtype_template("truediv")`. `canonical_float_arith_binop` is extended to accept `truediv` / `inplace_truediv` on the legacy-walker path too.

## Effect

Retires `complex_quot` / `complex_truediv` / `real_complex_quot` / `float_truediv` prepass-fail heads: **census 309 → 305, no staircase** (the added-head set is empty). Remaining floordiv/mod walls are unrelated: `float_divmod_w`/`float_floordiv` wall on `mod(SomeFloat, SomeFloat)` (`%` on floats → `math.fmod` residual, a separate pre-existing concern), and `int_floordiv` on `checked_div` (integer path).

## Verification

- `cargo test -p majit-translate` — 3004+ tests green.
- `check.py --backend dynasm,cranelift` — **dynasm 297/297, cranelift 297/297**.
- Complex/float division bit-exact vs python3.14, including JIT-traced hot loops (`100.0/x` and `(3+4j)/z` over 100k iterations).
- No LLBC re-extract needed (all edits in `majit-translate`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved floating-point division handling to consistently distinguish true division from integer-style division.
  * Added support for floating-point operations involving absolute values, `NaN`, and infinity.
  * Made translation error reporting more consistent and repeatable across runs.

* **Compatibility**
  * Recognizes additional division operation spellings during translation, improving support for supported Rust and Flowspace code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->