### PR TITLE
jit(fbw): opt-in single-frame blackhole resume for VableEscaped residual aborts

### DIFF
--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -62,6 +62,143 @@ impl std::ops::DerefMut for BackEdgeBhBuilder {
     }
 }
 
+/// Terminal state from a single-frame tracing-abort blackhole run.
+///
+/// The terminal interpreter is kept logically alive by moving out its three
+/// register banks, matching the back-edge resume path below: a
+/// ContinueRunningNormally handoff needs the full color-indexed bank, not only
+/// the declared red subset carried by the exception.
+pub struct SingleFrameBlackholeResult {
+    pub outcome: crate::jitexc::JitException,
+    pub registers_i: Vec<i64>,
+    pub registers_r: Vec<i64>,
+    pub registers_f: Vec<i64>,
+    pub position: usize,
+    pub last_opcode_position: usize,
+}
+
+fn bh_jitdrivers_sd(
+    metainterp_sd: &crate::pyjitpl::MetaInterpStaticData,
+) -> Vec<crate::blackhole::BhJitDriverSd> {
+    metainterp_sd
+        .jitdrivers_sd
+        .iter()
+        .map(|jd| {
+            let result_type = match jd.result_type {
+                majit_ir::Type::Int => crate::blackhole::BhReturnType::Int,
+                majit_ir::Type::Ref => crate::blackhole::BhReturnType::Ref,
+                majit_ir::Type::Float => crate::blackhole::BhReturnType::Float,
+                majit_ir::Type::Void => crate::blackhole::BhReturnType::Void,
+            };
+            let portal_runner_ptr = (jd.portal_runner_adr != 0).then(|| unsafe {
+                std::mem::transmute::<usize, extern "C" fn(i64, i64, i64, i64, i64) -> i64>(
+                    jd.portal_runner_adr as usize,
+                )
+            });
+            let mainjitcode_calldescr = jd
+                .portal_calldescr
+                .as_ref()
+                .and_then(|descr| descr.as_call_descr())
+                .map(majit_translate::jitcode::BhCallDescr::from_call_descr)
+                .unwrap_or_default();
+            crate::blackhole::BhJitDriverSd {
+                result_type,
+                portal_runner_ptr,
+                mainjitcode_calldescr,
+            }
+        })
+        .collect()
+}
+
+/// Run one tracing MIFrame forward in the already-ported blackhole.
+///
+/// This is the single-frame counterpart of the structured back-edge template
+/// at the call site below.  `copy_data_from_miframe` deliberately copies only
+/// the typed register values and pc, so all interpreter-global / frame-global
+/// state is supplied explicitly here.
+pub fn drive_single_frame_blackhole(
+    miframe: &mut crate::pyjitpl::MIFrame,
+    state_field_layout: crate::blackhole::StateFieldLayout,
+    virtualizable_info: *const crate::virtualizable::VirtualizableInfo,
+    virtualizable_ptr: i64,
+    virtualizable_stack_base: usize,
+    metainterp_sd: &crate::pyjitpl::MetaInterpStaticData,
+    last_exc_value: i64,
+    raising_exception: bool,
+) -> SingleFrameBlackholeResult {
+    // The MIFrame is handed here from a force-time TLS latch.  Publish its Ref
+    // values before leasing/building the interpreter because first use of the
+    // pooled builder may allocate.  Option<i64> is not a contiguous root area,
+    // so keep an index-parallel packed root vector and copy forwarding updates
+    // back before copy_data_from_miframe reads the MIFrame.
+    let mut ref_roots: Vec<(usize, i64)> = miframe
+        .ref_values
+        .iter()
+        .enumerate()
+        .filter_map(|(index, value)| value.map(|value| (index, value)))
+        .collect();
+    let root_depth = majit_gc::shadow_stack::resume_ref_roots_depth();
+    let mut packed_ref_roots: Vec<i64> = ref_roots.iter().map(|(_, value)| *value).collect();
+    unsafe {
+        majit_gc::shadow_stack::push_resume_ref_roots(packed_ref_roots.as_mut_slice());
+    }
+
+    let mut builder = BackEdgeBhBuilder::lease();
+    builder.setup_cached_control_opcodes(
+        metainterp_sd.op_live as i32,
+        metainterp_sd.op_catch_exception as i32,
+        metainterp_sd.op_rvmprof_code as i32,
+    );
+    for ((index, value), forwarded) in ref_roots.iter_mut().zip(&packed_ref_roots) {
+        *value = *forwarded;
+        miframe.ref_values[*index] = Some(*forwarded);
+    }
+
+    let mut bh = builder.acquire_interp();
+    bh.copy_data_from_miframe(miframe);
+    bh.state_field_layout = state_field_layout;
+    bh.virtualizable_info = virtualizable_info;
+    bh.virtualizable_ptr = virtualizable_ptr;
+    bh.virtualizable_stack_base = virtualizable_stack_base;
+    bh.jitdrivers_sd = bh_jitdrivers_sd(metainterp_sd);
+
+    // The blackhole may allocate/collect while executing.  Its Ref bank is the
+    // authoritative live register file and must be forwarded in place.
+    unsafe {
+        majit_gc::shadow_stack::push_resume_ref_roots(bh.registers_r.as_mut_slice());
+    }
+    let current_exc = if raising_exception {
+        last_exc_value
+    } else {
+        bh.exception_last_value = last_exc_value;
+        0
+    };
+    let outcome = match bh.resume_mainloop(current_exc) {
+        Err(jit_exc) => jit_exc,
+        Ok(propagated) => {
+            debug_assert!(
+                bh.nextblackholeinterp.is_some(),
+                "single-frame bottom blackhole returned to a missing caller"
+            );
+            crate::jitexc::JitException::ExitFrameWithExceptionRef(majit_ir::GcRef(
+                propagated as usize,
+            ))
+        }
+    };
+    majit_gc::shadow_stack::pop_resume_ref_roots_to(root_depth);
+
+    let result = SingleFrameBlackholeResult {
+        outcome,
+        registers_i: std::mem::take(&mut bh.registers_i),
+        registers_r: std::mem::take(&mut bh.registers_r),
+        registers_f: std::mem::take(&mut bh.registers_f),
+        position: bh.position,
+        last_opcode_position: bh.last_opcode_position,
+    };
+    builder.release_interp(bh);
+    result
+}
+
 fn writeback_live_state_scalars_from_blackhole<S: crate::JitState>(
     state: &mut S,
     layout: &crate::blackhole::StateFieldLayout,

--- a/majit/majit-metainterp/src/lib.rs
+++ b/majit/majit-metainterp/src/lib.rs
@@ -127,8 +127,8 @@ pub use jitcode::{
     live_slots_for_state_field_jit, set_global_build_descr_pool,
 };
 pub use jitdriver::{
-    DeclarativeJitDriver, JitDriver, JitDriverStaticData, TraceContinuationSuspendGuard,
-    trace_continuation_suspended,
+    DeclarativeJitDriver, JitDriver, JitDriverStaticData, SingleFrameBlackholeResult,
+    TraceContinuationSuspendGuard, drive_single_frame_blackhole, trace_continuation_suspended,
 };
 pub use majit_backend::CompiledTraceInfo;
 pub use pyjitpl::{eval_binop_f, eval_binop_i, eval_float_cmp, eval_unary_f, eval_unary_i};

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
@@ -877,6 +877,7 @@ pub(crate) fn try_walker_call_assembler_self_recursive<Sym: WalkSym>(
             call_descr,
             ca_result,
             op.pc,
+            None,
         )?
     };
     // A decline leaves the CALL_ASSEMBLER recorded symbolically WITHOUT
@@ -1122,6 +1123,7 @@ pub(crate) fn emit_walker_loop_callee_call_assembler<Sym: WalkSym>(
         call_descr,
         ca_result,
         op.pc,
+        None,
     )?;
     let exec_raised = match exec {
         ResidualExecOutcome::Executed(result) => result.is_err(),

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
@@ -4510,6 +4510,7 @@ struct FbwStoreJournalRootArea {
     abort_resume: *const std::cell::RefCell<Option<InlineAbortCarrier>>,
     active_session: *const std::cell::Cell<*const std::cell::RefCell<WalkSession>>,
     escape_flush_undo: *const std::cell::RefCell<Option<EscapeFlushUndo>>,
+    single_frame_blackhole: *const std::cell::RefCell<Option<LatchedSingleFrameBlackhole>>,
 }
 
 thread_local! {
@@ -4524,6 +4525,7 @@ thread_local! {
         abort_resume: FBW_ABORT_CALL_RESUME.with(|value| value as *const _),
         active_session: ACTIVE_WALK_SESSION.with(|value| value as *const _),
         escape_flush_undo: escape_flush_undo_cell_ptr(),
+        single_frame_blackhole: single_frame_blackhole_cell_ptr(),
     };
 }
 
@@ -4773,6 +4775,18 @@ pub unsafe fn fbw_store_journal_root_walker_area(
     if let Some(undo) = escape_undo.as_mut() {
         for slot in undo.slots.iter_mut() {
             visitor(unsafe { &mut *(slot as *mut pyre_object::PyObjectRef).cast() });
+        }
+    }
+    // C3 S1: the force-time MIFrame survives the dispatch unwind in TLS.
+    // Its Option<i64> Ref bank is not visible to the collector, so forward
+    // every populated color until the walk-end handler takes the latch.
+    let single_frame_blackhole = unsafe { &mut *(*area.single_frame_blackhole).as_ptr() };
+    if let Some(latched) = single_frame_blackhole.as_mut() {
+        for value in latched.miframe.ref_values.iter_mut().flatten() {
+            visitor(unsafe { &mut *(value as *mut i64).cast() });
+        }
+        if latched.last_exc_value != 0 {
+            visitor(unsafe { &mut *(&mut latched.last_exc_value as *mut i64).cast() });
         }
     }
     // gh#467: the latched forward-flush operand stack (callable + args) is
@@ -5139,6 +5153,7 @@ fn direct_call_release_gil<Sym: WalkSym>(
         call_descr,
         recorded,
         pc,
+        None,
     )?;
     // A decline leaves the call recorded symbolically WITHOUT running it, so
     // the walk-end no-replay commit must stay off for this trace.

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
@@ -42,6 +42,12 @@ thread_local! {
     /// loses nothing.
     static ESCAPE_OPCODE_WINDOW: std::cell::Cell<Option<(usize, u64, usize)>> =
         const { std::cell::Cell::new(None) };
+    /// C3 S1 force-time image of the single live tracing frame.  The
+    /// color-indexed concrete banks cease to exist when dispatch unwinds, so
+    /// the MIFrame must be assembled beside `tracing_after_residual_call` and
+    /// carried to the walk-end VableEscaped leg.
+    static FBW_SINGLE_FRAME_BLACKHOLE: std::cell::RefCell<Option<LatchedSingleFrameBlackhole>> =
+        const { std::cell::RefCell::new(None) };
 }
 
 pub(crate) struct EscapeFlushUndo {
@@ -49,6 +55,96 @@ pub(crate) struct EscapeFlushUndo {
     last_instr: isize,
     valuestackdepth: usize,
     pub(crate) slots: Vec<pyre_object::PyObjectRef>,
+}
+
+pub(crate) struct LatchedSingleFrameBlackhole {
+    pub(crate) miframe: majit_metainterp::MIFrame,
+    pub(crate) last_exc_value: i64,
+    pub(crate) raising_exception: bool,
+}
+
+pub(crate) fn single_frame_blackhole_cell_ptr()
+-> *const std::cell::RefCell<Option<LatchedSingleFrameBlackhole>> {
+    FBW_SINGLE_FRAME_BLACKHOLE.with(|cell| cell as *const _)
+}
+
+pub(crate) fn take_single_frame_blackhole() -> Option<LatchedSingleFrameBlackhole> {
+    FBW_SINGLE_FRAME_BLACKHOLE.with(|slot| slot.borrow_mut().take())
+}
+
+pub(crate) fn reset_single_frame_blackhole() {
+    FBW_SINGLE_FRAME_BLACKHOLE.with(|slot| {
+        *slot.borrow_mut() = None;
+    });
+}
+
+fn single_frame_blackhole_resume_enabled() -> bool {
+    std::env::var_os("PYRE_FBW_BLACKHOLE_RESUME").as_deref() == Some(std::ffi::OsStr::new("1"))
+}
+
+fn build_single_frame_miframe<Sym: WalkSym>(
+    ctx: &WalkContext<'_, '_, Sym>,
+    jitcode: std::sync::Arc<majit_metainterp::jitcode::JitCode>,
+    resume_pc: usize,
+    lastop_result: Option<(char, usize, i64)>,
+) -> Option<majit_metainterp::MIFrame> {
+    let live = crate::state::frame_liveness_reg_indices_by_bank_at(
+        i32::try_from(jitcode.index()).ok()?,
+        i32::try_from(resume_pc).ok()?,
+    );
+    let mut miframe = majit_metainterp::MIFrame::new(jitcode.clone(), resume_pc);
+
+    // pyjitpl.py make_result_of_lastop: the residual returned before its
+    // ordinary dispatcher writeback, while `resume_pc` already points past
+    // the call.  Stamp the just-produced value first: its destination is
+    // normally live at `resume_pc`, but the concrete shadow still contains
+    // Null/old data and must not make the all-live-color pass decline.
+    if let Some((bank, color, value)) = lastop_result {
+        match bank {
+            'i' => *miframe.int_values.get_mut(color)? = Some(value),
+            'r' => *miframe.ref_values.get_mut(color)? = Some(value),
+            'f' => *miframe.float_values.get_mut(color)? = Some(value),
+            'v' => {}
+            _ => return None,
+        }
+    }
+
+    for &color in &live.int {
+        let color = color as usize;
+        if miframe.int_values.get(color).copied().flatten().is_some() {
+            continue;
+        }
+        let ConcreteValue::Int(value) = ctx.concrete_registers_i.get(color).copied()? else {
+            return None;
+        };
+        *miframe.int_values.get_mut(color)? = Some(value);
+    }
+    for &color in &live.ref_ {
+        let color = color as usize;
+        if miframe.ref_values.get(color).copied().flatten().is_some() {
+            continue;
+        }
+        let ConcreteValue::Ref(value) = ctx.concrete_registers_r.get(color).copied()? else {
+            // ConcreteValue::Null is the walker's "unknown" sentinel, not a
+            // proven Python null.  S1 declines the whole image rather than
+            // manufacturing a hole in a live Ref color.
+            return None;
+        };
+        *miframe.ref_values.get_mut(color)? = Some(value as i64);
+    }
+    for &color in &live.float {
+        let color = color as usize;
+        if miframe.float_values.get(color).copied().flatten().is_some() {
+            continue;
+        }
+        let opref = ctx.registers_f.get(color).copied()?;
+        let Some(majit_ir::Value::Float(value)) = ctx.trace_ctx.concrete_of_opref(opref) else {
+            return None;
+        };
+        *miframe.float_values.get_mut(color)? = Some(value.to_bits() as i64);
+    }
+
+    Some(miframe)
 }
 
 /// TLS cell pointer for the store-journal root area: the undo stays armed
@@ -255,6 +351,10 @@ fn flush_escape_state_with_latched_stack(ctx: &TraceCtx, frame: usize, py_pc: us
 
 pub fn take_committed_frame_escape_pc() -> Option<usize> {
     COMMITTED_FRAME_ESCAPE_PC.with(|slot| slot.take())
+}
+
+fn committed_frame_escape_pc() -> Option<usize> {
+    COMMITTED_FRAME_ESCAPE_PC.with(|slot| slot.get())
 }
 
 /// Withdraw a committed escape resume pc: the residual that escaped also ran
@@ -782,6 +882,7 @@ pub(crate) fn try_execute_residual_call_via_executor<Sym: WalkSym>(
     call_descr: &dyn majit_ir::descr::CallDescr,
     recorded: OpRef,
     op_pc: usize,
+    blackhole_result: Option<(usize, char, usize)>,
 ) -> Result<ResidualExecOutcome, DispatchError> {
     // `execute_varargs` clears the metainterp exception slot at residual-call
     // entry, before the helper can either run or leave the call recorded
@@ -1375,6 +1476,51 @@ pub(crate) fn try_execute_residual_call_via_executor<Sym: WalkSym>(
             {
                 cancel_committed_frame_escape_pc();
                 restore_escape_flush_undo();
+            }
+            // C3 S1: the writes-live-heap force shape cannot safely resume AT
+            // this opcode, but a top-level one-frame walk can resume PAST it
+            // through the existing blackhole when every live color has a
+            // concrete value.  Build here, before WalkContext's concrete banks
+            // disappear, and consume only in run_perfn_walk's VableEscaped
+            // epilogue.  Every condition is additive under an exact opt-in;
+            // failure leaves the pre-existing escape/replay path untouched.
+            let odometer_unchanged = heap_write_odometer_before
+                .is_some_and(|before| pyre_interpreter::call::frame_entry_count() == before);
+            if single_frame_blackhole_resume_enabled()
+                && writes_live_heap
+                && odometer_unchanged
+                && committed_frame_escape_pc().is_none()
+                && !ctx.fbw_mode.inline_subwalk
+                && !ctx.trace_ctx.is_bridge_trace
+                && ctx.session.borrow().framestack.is_empty()
+                && let Some((resume_pc, result_bank, result_color)) = blackhole_result
+                && !ctx.fbw_mode.snapshot_sym.is_null()
+            {
+                let jitcode = unsafe {
+                    let sym = &*ctx.fbw_mode.snapshot_sym;
+                    (!sym.jitcode().is_null()).then(|| (&(*sym.jitcode()).payload).jitcode.clone())
+                };
+                if let Some(jitcode) = jitcode {
+                    let (lastop_result, last_exc_value, raising_exception) = match exec_result {
+                        Ok(value) => (
+                            (result_bank != 'v').then_some((result_bank, result_color, value)),
+                            0,
+                            false,
+                        ),
+                        Err(exc) => (None, exc, true),
+                    };
+                    if let Some(miframe) =
+                        build_single_frame_miframe(ctx, jitcode, resume_pc, lastop_result)
+                    {
+                        FBW_SINGLE_FRAME_BLACKHOLE.with(|slot| {
+                            *slot.borrow_mut() = Some(LatchedSingleFrameBlackhole {
+                                miframe,
+                                last_exc_value,
+                                raising_exception,
+                            });
+                        });
+                    }
+                }
             }
             // On a kept commit the undo stays armed: the abort epilogue
             // consumes it — discard on adoption, restore when the flush is
@@ -2529,6 +2675,7 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
             call_descr,
             recorded,
             op.pc,
+            Some((op.next_pc, dst_bank, dst)),
         )?;
         // A decline leaves the call recorded symbolically WITHOUT running
         // it — a side effect only the legacy replay applies, so the
@@ -3323,6 +3470,7 @@ pub(crate) fn dispatch_residual_call_iIRd_kind<Sym: WalkSym>(
             call_descr,
             recorded,
             op.pc,
+            Some((op.next_pc, dst_bank, dst)),
         )?;
         // A decline leaves the call recorded symbolically WITHOUT running
         // it — a side effect only the legacy replay applies, so the
@@ -3543,6 +3691,7 @@ pub(crate) fn dispatch_residual_call_iIRFd_kind<Sym: WalkSym>(
             call_descr,
             recorded,
             op.pc,
+            Some((op.next_pc, dst_bank, dst)),
         )?;
         // A decline leaves the call recorded symbolically WITHOUT running
         // it — a side effect only the legacy replay applies, so the

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/tests.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/tests.rs
@@ -6582,6 +6582,7 @@ fn authoritative_walker_executes_may_force_call_and_stamps_result() {
         call_descr,
         recorded,
         0,
+        None,
     );
     drop(wc);
     assert_eq!(
@@ -6644,6 +6645,7 @@ fn non_authoritative_walker_does_not_execute_may_force_call() {
         call_descr,
         recorded,
         0,
+        None,
     );
     drop(wc);
     assert_eq!(
@@ -6721,6 +6723,7 @@ fn authoritative_walker_transcribes_may_force_raise_to_last_exc() {
         call_descr,
         recorded,
         0,
+        None,
     );
     let captured_exc = wc.last_exc_value;
     let captured_concrete = wc.last_exc_value_concrete;
@@ -6822,6 +6825,7 @@ fn may_force_with_active_vable_executes_and_clears_token() {
         call_descr,
         recorded,
         0,
+        None,
     );
     drop(wc);
     assert!(
@@ -6927,6 +6931,7 @@ fn may_force_vable_escape_surfaces_typed_abort() {
         call_descr,
         recorded,
         7,
+        None,
     );
     drop(wc);
     assert!(

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -1627,6 +1627,183 @@ fn seed_loop_entry_ref_slots(
     }
 }
 
+fn apply_single_frame_blackhole_crn(
+    frame: usize,
+    jitcode_index: i32,
+    terminal: &mut majit_metainterp::SingleFrameBlackholeResult,
+    resume_py_pc: usize,
+) -> bool {
+    if frame == 0 {
+        return false;
+    }
+    let Some(stack_base) = crate::state::concrete_nlocals(frame) else {
+        return false;
+    };
+    let pf = unsafe { &mut *(frame as *mut pyre_interpreter::PyFrame) };
+    let w_code = pf.pycode;
+    if w_code.is_null() {
+        return false;
+    }
+    let raw_code = unsafe {
+        pyre_interpreter::w_code_get_ptr(w_code as pyre_object::PyObjectRef)
+            as *const pyre_interpreter::CodeObject
+    };
+    let Some(stack_depth) = crate::liveness::liveness_for(raw_code)
+        .depth_at_py_pc()
+        .get(resume_py_pc)
+        .copied()
+    else {
+        return false;
+    };
+    let live_end = stack_base + stack_depth as usize;
+    if pf.locals_w().as_slice().len() < live_end {
+        return false;
+    }
+    let pcdep = crate::state::pcdep_trivia_at(jitcode_index, terminal.last_opcode_position as i32)
+        .or_else(|| crate::state::pcdep_trivia_at(jitcode_index, terminal.position as i32));
+    let Some(pcdep) = pcdep else {
+        return false;
+    };
+
+    // Validate every mapped color and every live operand-stack slot before
+    // writing anything.  Dead locals may retain their old heap value; each
+    // stack slot at the merge point must have an authoritative color.
+    let mut writes: Vec<(usize, u8, usize)> = Vec::new();
+    for &(bank, color, slot) in &pcdep {
+        let slot = slot as usize;
+        if slot >= live_end {
+            continue;
+        }
+        let color = color as usize;
+        let present = match bank {
+            0 => color < terminal.registers_i.len(),
+            1 => color < terminal.registers_r.len(),
+            2 => color < terminal.registers_f.len(),
+            _ => false,
+        };
+        if !present {
+            return false;
+        }
+        if !writes.iter().any(|(existing, _, _)| *existing == slot) {
+            writes.push((slot, bank, color));
+        }
+    }
+    if (stack_base..live_end).any(|slot| !writes.iter().any(|(s, _, _)| *s == slot)) {
+        return false;
+    }
+
+    let root_depth = majit_gc::shadow_stack::resume_ref_roots_depth();
+    unsafe {
+        majit_gc::shadow_stack::push_resume_ref_roots(terminal.registers_r.as_mut_slice());
+    }
+    for (slot, bank, color) in writes {
+        let value = match bank {
+            0 => majit_ir::Value::Int(terminal.registers_i[color]),
+            1 => majit_ir::Value::Ref(majit_ir::GcRef(terminal.registers_r[color] as usize)),
+            2 => majit_ir::Value::Float(f64::from_bits(terminal.registers_f[color] as u64)),
+            _ => unreachable!("validated blackhole register bank"),
+        };
+        pf.locals_w_mut()[slot] = crate::state::boxed_slot_value_for_type(value.get_type(), &value);
+    }
+    majit_gc::shadow_stack::pop_resume_ref_roots_to(root_depth);
+    pf.valuestackdepth = live_end;
+    pf.last_instr = resume_py_pc as isize - 1;
+    true
+}
+
+fn try_adopt_single_frame_blackhole(ctx: &mut TraceCtx, cf_addr: usize) -> bool {
+    let Some(mut latched) = crate::jitcode_dispatch::take_single_frame_blackhole() else {
+        return false;
+    };
+    let jitcode_index = match i32::try_from(latched.miframe.jitcode.index()) {
+        Ok(index) => index,
+        Err(_) => return false,
+    };
+    let virtualizable_info = ctx
+        .virtualizable_info()
+        .map(std::sync::Arc::as_ptr)
+        .unwrap_or(std::ptr::null());
+    if virtualizable_info.is_null() {
+        return false;
+    }
+    let Some(stack_base) = crate::state::concrete_nlocals(cf_addr) else {
+        return false;
+    };
+    let mut terminal = majit_metainterp::drive_single_frame_blackhole(
+        &mut latched.miframe,
+        majit_metainterp::blackhole::StateFieldLayout::default(),
+        virtualizable_info,
+        cf_addr as i64,
+        stack_base,
+        ctx.metainterp_sd().as_ref(),
+        latched.last_exc_value,
+        latched.raising_exception,
+    );
+
+    let adopted = match terminal.outcome {
+        majit_metainterp::jitexc::JitException::ContinueRunningNormally {
+            ref green_int, ..
+        } => {
+            let Some(&resume_py_pc) = green_int.first() else {
+                return false;
+            };
+            let resume_py_pc = resume_py_pc as usize;
+            if !apply_single_frame_blackhole_crn(
+                cf_addr,
+                jitcode_index,
+                &mut terminal,
+                resume_py_pc,
+            ) {
+                return false;
+            }
+            WALK_END_RESTART_PC.with(|slot| slot.set(Some(resume_py_pc)));
+            true
+        }
+        majit_metainterp::jitexc::JitException::DoneWithThisFrameVoid => {
+            crate::jitcode_dispatch::fbw_finish_concrete_set(crate::state::ConcreteValue::Null);
+            true
+        }
+        majit_metainterp::jitexc::JitException::DoneWithThisFrameInt(value) => {
+            crate::jitcode_dispatch::fbw_finish_concrete_set(crate::state::ConcreteValue::Int(
+                value,
+            ));
+            true
+        }
+        majit_metainterp::jitexc::JitException::DoneWithThisFrameRef(value) => {
+            crate::jitcode_dispatch::fbw_finish_concrete_set(crate::state::ConcreteValue::Ref(
+                value.as_usize() as pyre_object::PyObjectRef,
+            ));
+            true
+        }
+        majit_metainterp::jitexc::JitException::DoneWithThisFrameFloat(value) => {
+            crate::jitcode_dispatch::fbw_finish_concrete_set(crate::state::ConcreteValue::Float(
+                value,
+            ));
+            true
+        }
+        majit_metainterp::jitexc::JitException::ExitFrameWithExceptionRef(value) => {
+            crate::jitcode_dispatch::fbw_finish_raise_set(crate::state::ConcreteValue::Ref(
+                value.as_usize() as pyre_object::PyObjectRef,
+            ));
+            true
+        }
+    };
+    if adopted {
+        let _ = crate::jitcode_dispatch::take_committed_frame_escape_pc();
+        crate::jitcode_dispatch::discard_escape_flush_undo();
+        crate::jitcode_dispatch::fbw_foriter_inflight_clear();
+        WALK_END_FLUSH_COMMITTED.with(|slot| slot.set(true));
+        if crate::jitcode_dispatch::fbw_debug_abort_enabled() {
+            eprintln!(
+                "[fbw-blackhole] adopted single-frame terminal at jitcode_index={} \
+                 position={} last_opcode_position={}",
+                jitcode_index, terminal.position, terminal.last_opcode_position,
+            );
+        }
+    }
+    adopted
+}
+
 fn run_perfn_walk<Sym: WalkSym>(
     ctx: &mut TraceCtx,
     sym: &mut Sym,
@@ -2326,23 +2503,35 @@ fn run_perfn_walk<Sym: WalkSym>(
         // predicate as the CloseLoop end-flush above.  A latched inline-callee
         // forward abort has already distinguished an outside mark from a mark
         // inside its discarded attempt.  `PYRE_FBW_ABORT_FLUSH=0` opts out.
+        let single_frame_blackhole_adopted = matches!(
+            &walk_result,
+            Err(crate::jitcode_dispatch::DispatchError::VableEscapedDuringResidualCall { .. })
+        ) && try_adopt_single_frame_blackhole(ctx, cf_addr);
         if std::env::var_os("PYRE_FBW_ABORT_FLUSH").as_deref() == Some(std::ffi::OsStr::new("0")) {
             // Opt-out: never adopt the escape flush — drop the commit and put
             // the pre-flush frame back so the legacy replay sees pristine
             // state.
-            if matches!(
-                &walk_result,
-                Err(crate::jitcode_dispatch::DispatchError::VableEscapedDuringResidualCall { .. })
-            ) {
+            if !single_frame_blackhole_adopted
+                && matches!(
+                    &walk_result,
+                    Err(
+                        crate::jitcode_dispatch::DispatchError::VableEscapedDuringResidualCall { .. }
+                    )
+                )
+            {
                 let _ = crate::jitcode_dispatch::take_committed_frame_escape_pc();
                 crate::jitcode_dispatch::restore_escape_flush_undo();
             }
         } else {
-            if matches!(
-                &walk_result,
-                Err(crate::jitcode_dispatch::DispatchError::VableEscapedDuringResidualCall { .. })
-            ) && let Some(resume_py_pc) =
-                crate::jitcode_dispatch::take_committed_frame_escape_pc()
+            if !single_frame_blackhole_adopted
+                && matches!(
+                    &walk_result,
+                    Err(
+                        crate::jitcode_dispatch::DispatchError::VableEscapedDuringResidualCall { .. }
+                    )
+                )
+                && let Some(resume_py_pc) =
+                    crate::jitcode_dispatch::take_committed_frame_escape_pc()
             {
                 crate::jitcode_dispatch::discard_escape_flush_undo();
                 // The force-time escape flush wrote the resume state into the
@@ -2750,7 +2939,12 @@ fn run_perfn_walk<Sym: WalkSym>(
         )
         && crate::jitcode_dispatch::fbw_finish_concrete_peek().is_some()
         && !crate::jitcode_dispatch::fbw_has_unjournaled_effect();
-    if !terminate_no_replay {
+    let blackhole_terminal_no_replay = matches!(
+        &walk_result,
+        Err(crate::jitcode_dispatch::DispatchError::VableEscapedDuringResidualCall { .. })
+    ) && WALK_END_FLUSH_COMMITTED.with(|slot| slot.get())
+        && crate::jitcode_dispatch::fbw_finish_concrete_peek().is_some();
+    if !terminate_no_replay && !blackhole_terminal_no_replay {
         crate::jitcode_dispatch::fbw_finish_concrete_reset();
     }
 
@@ -3434,6 +3628,7 @@ fn full_body_walk_trace<Sym: WalkSym>(
     // aborted walk's top-level `*_return` arm may have stashed, so a stale
     // value cannot leak into this walk's `Terminate` handling.
     crate::jitcode_dispatch::fbw_finish_payload_reset();
+    crate::jitcode_dispatch::reset_single_frame_blackhole();
     crate::jitcode_dispatch::fbw_executed_nonpure_residual_reset();
     crate::jitcode_dispatch::fbw_executed_body_residual_reset();
     crate::jitcode_dispatch::fbw_abort_outer_resume_reset();


### PR DESCRIPTION
## Summary

Behind `PYRE_FBW_BLACKHOLE_RESUME` (default off). When a residual call forces the
traced frame's virtualizable and the FBW walk aborts with
`VableEscapedDuringResidualCall`, this builds a single-frame `MIFrame` from the
`WalkContext` concrete registers and runs the blackhole interpreter to resume
*after* the forcing op, in place of the escape-flush replay.

The residual returns before stamping its own result, so the MIFrame build places
that result into the last op's result register (`make_result_of_lastop`) and
advances the position past the forcing op — resume-after-with-result. This is the
orthodox abort→blackhole convergence direction (`convert_and_run_from_pyjitpl`
machinery), applied to the single-frame top-level abort.

## Defect fixed

The escape-flush replay re-applies the forcing op's side effect, so a
self-`sys._getframe()` bump inside a hot loop double-applies. Both the V1 and the
while-twin repros exhibit the same single-frame `VableEscaped` at the bump's own
trace: they print `199990000 20005` under the JIT versus the oracle `20000`. With
the flag on, both print `20000`.

(The while-twin's `LoopBearing` decline is main's inline *seed* decline that never
runs the bump body, so this single-frame resume closes both repros; there is no
multi-frame defect in the current corpus.)

## Shape

- **Opt-in / additive.** Flag default off ⇒ codegen byte-identical. When on, the
  blackhole adopt *replaces* the legacy escape-flush replay for the single-frame
  `VableEscaped` case, so there is no added steady-state cost.
- **Perf-neutral.** Alternating A/B across the synth corpus: only
  `getframe_stored_fback_walk` adopts blackhole; all deltas within ±1% noise, at
  identical wall time to the buggy legacy path.

## Files

- `residual_call.rs`: force-time latch `FBW_SINGLE_FRAME_BLACKHOLE` and
  `build_single_frame_miframe` with live-color masking and an all-or-nothing
  decline.
- `jitdriver.rs`: `drive_single_frame_blackhole` / `SingleFrameBlackholeResult`,
  mirroring the back-edge driver template with GC rooting of the MIFrame ref
  values and registers.
- `trace.rs`: `try_adopt_single_frame_blackhole` and
  `apply_single_frame_blackhole_crn` at the `VableEscaped` leg, plus latch reset
  at walk start.
- `mod.rs`: latch in the FBW root area and reftracer forwarding of the latched
  MIFrame refs and exception.

## Verification

- `check.py` **297/297** on both backends in both flag states: dynasm off / on,
  cranelift off / on.
- V1 and while-twin repros: `20005` (flag off) → `20000` (flag on) on both
  backends; the for-loop twin stays green.

Branch base is one commit behind `main` (only #752, an unrelated dict rooting
fix); the merge is clean.

— *commented by Claude*
