### PR TITLE
jit: narrow the remaining u16 register operands to the canonical 1-byte encoding

### DIFF
--- a/majit/majit-metainterp/src/blackhole.rs
+++ b/majit/majit-metainterp/src/blackhole.rs
@@ -913,54 +913,6 @@ impl BlackholeInterpreter {
         }
     }
 
-    fn bh_binop_i(&mut self, opcode: OpCode) {
-        let dst = self.next_u16() as usize;
-        let lhs_idx = self.next_u16() as usize;
-        let rhs_idx = self.next_u16() as usize;
-        let lhs = self.registers_i[lhs_idx];
-        let rhs = self.registers_i[rhs_idx];
-        self.registers_i[dst] = eval_binop_i(opcode, lhs, rhs);
-    }
-
-    /// Per-opname ref binop helper returning int. Mirrors
-    /// `bhimpl_{ptr_eq,ptr_ne,instance_ptr_eq,instance_ptr_ne}`.
-    fn bh_binop_r_to_i(&mut self, opcode: OpCode) {
-        let dst = self.next_u16() as usize;
-        let lhs_idx = self.next_u16() as usize;
-        let rhs_idx = self.next_u16() as usize;
-        let lhs = self.registers_r[lhs_idx];
-        let rhs = self.registers_r[rhs_idx];
-        self.registers_i[dst] = match opcode {
-            OpCode::PtrEq | OpCode::InstancePtrEq => (lhs == rhs) as i64,
-            OpCode::PtrNe | OpCode::InstancePtrNe => (lhs != rhs) as i64,
-            other => panic!("bh_binop_r_to_i: unsupported opcode {other:?}"),
-        };
-    }
-
-    /// Per-opname float binop helper. See `bh_binop_i` for the pattern.
-    /// RPython equivalents: `bhimpl_float_{add,sub,mul,truediv}`
-    /// (`blackhole.py:663-687`).
-    fn bh_binop_f(&mut self, opcode: OpCode) {
-        let dst = self.next_u16() as usize;
-        let lhs_idx = self.next_u16() as usize;
-        let rhs_idx = self.next_u16() as usize;
-        let lhs = self.registers_f[lhs_idx];
-        let rhs = self.registers_f[rhs_idx];
-        self.registers_f[dst] = eval_binop_f(opcode, lhs, rhs);
-    }
-
-    /// Unary ptr nullity helpers — `bhimpl_ptr_iszero` / `bhimpl_ptr_nonzero`.
-    fn bh_ptr_nullity(&mut self, nonzero: bool) {
-        let dst = self.next_u16() as usize;
-        let src_idx = self.next_u16() as usize;
-        let value = self.registers_r[src_idx];
-        self.registers_i[dst] = if nonzero {
-            (value != 0) as i64
-        } else {
-            (value == 0) as i64
-        };
-    }
-
     /// blackhole.py:1732-1748 _get_list_of_values parity.
     ///
     /// Decodes a bytecode-encoded register list: [length:u8][indices:u8...].
@@ -1419,16 +1371,16 @@ impl BlackholeInterpreter {
         Ok(())
     }
 
-    /// Read call arguments from bytecode (kind:u8, reg:u16 per arg).
+    /// Read call arguments from bytecode (kind:u8, reg:u8 per arg).
     fn read_call_args(&mut self, num_args: usize) -> Vec<i64> {
         let mut args = Vec::with_capacity(num_args);
-        let mut metas: Vec<(u8, u16)> = Vec::with_capacity(num_args);
+        let mut metas: Vec<(u8, u8)> = Vec::with_capacity(num_args);
         for _ in 0..num_args {
             let kind_byte = self.next_u8();
             let kind = JitArgKind::decode(kind_byte);
-            let reg = self.next_u16();
+            let reg = self.next_u8();
             metas.push((kind_byte, reg));
-            args.push(self.read_call_arg(kind, reg));
+            args.push(self.read_call_arg(kind, reg as u16));
         }
         if crate::majit_log_enabled() {
             // Heuristic: for Ref args, peek intval at +0x10 (W_IntObject layout).
@@ -5307,7 +5259,7 @@ fn bhimpl_uint_ge(a: i64, b: i64) -> i64 {
 
 /// `blackhole.py:471 bhimpl_uint_mul_high` — high 64 bits of unsigned
 /// 128-bit product.  Extracted from the inline body of
-/// `handler_uint_mul_high` so the pyre-u16 macro can target a named
+/// `handler_uint_mul_high` so the bhhandler macro can target a named
 /// bhimpl uniformly with the rest of the binop family.
 fn bhimpl_uint_mul_high(a: i64, b: i64) -> i64 {
     let a = a as u64 as u128;
@@ -6673,7 +6625,7 @@ pub fn pyre_production_cpu() -> &'static dyn majit_backend::Backend {
 /// shapes.  This builder's `setup_insns` registers every opcode key
 /// the production producers (`pyjitpl/dispatch.rs`, `majit-macros`
 /// DSL lowerer, `pyre-jit/src/jit/assembler.rs`) can emit: byte-
-/// identical canonical keys, pyre-u16 register-width adapters,
+/// identical canonical keys, single-byte register operands,
 /// audited residual_call / vable / state-field families, the pyre
 /// nested inline-call handler, and the `_pyre/P` adapters for
 /// `BC_CALL_ASSEMBLER_*`, `BC_COND_CALL_*`, and
@@ -6889,7 +6841,7 @@ pub fn build_inline_call_only_bh_builder() -> BlackholeInterpBuilder {
     ] {
         insns.insert(key.to_string(), byte);
     }
-    // P5 — int unary + float arithmetic + ref/ptr pyre-u16 family.
+    // P5 — int unary + float arithmetic + ref/ptr family.
     // 14 keys covering record_unary_i/f, record_binop_f, record_binop_r,
     // and ptr_iszero/nonzero (`assembler.rs:784,817,825,2956,2974,799`).
     for (key, byte) in [
@@ -6998,8 +6950,8 @@ pub fn build_inline_call_only_bh_builder() -> BlackholeInterpBuilder {
     ] {
         insns.insert(key.to_string(), byte);
     }
-    // P7 — state_field family (byte-identical canonical: u16 descr +
-    // u8 register), push/pop/guard_value pyre-u16 (u16 register), and
+    // P7 — state_field family (u16 descr + u8 register),
+    // push/pop/guard_value (canonical 1-byte register), and
     // misc operand-less (reraise, unreachable) + jit_merge_point/iIRFIRF
     // (already wired canonically).
     for (key, byte) in [
@@ -7139,7 +7091,7 @@ pub fn build_inline_call_only_bh_builder() -> BlackholeInterpBuilder {
     // canonical RPython argcode contract (`blackhole.py:1224-1276`)
     // byte-for-byte, so the wired `handler_residual_call_*` decode
     // straight via `read_list_{i,r,f}` + `read_descr` without needing
-    // pyre-u16 variants.
+    // width adapters.
     insns.insert(
         "residual_call_r_v/iRd".to_string(),
         majit_translate::insns::BC_RESIDUAL_CALL_R_V,
@@ -9396,8 +9348,8 @@ fn handler_inline_call_r_v(
 /// `JitCodeBuilder::call_assembler_{int,ref,float,void}_like`
 /// (`assembler.rs:3370,3429,3451,3489`) emits a pyre-only flat payload
 /// for `BC_CALL_ASSEMBLER_{INT,REF,FLOAT,VOID}`:
-///   typed: `[target_idx: u16, dst: u16, num_args: u16, (kind: u8, reg: u16) × num_args]`
-///   void:  `[target_idx: u16, num_args: u16, (kind: u8, reg: u16) × num_args]`
+///   typed: `[target_idx: u16, dst: u8, num_args: u16, (kind: u8, reg: u8) × num_args]`
+///   void:  `[target_idx: u16, num_args: u16, (kind: u8, reg: u8) × num_args]`
 /// RPython has no `bhimpl_call_assembler_*`; pyre re-interprets the
 /// recorded operation by direct-calling `target.concrete_ptr` via the
 /// shared `call_int_function` / `call_void_function` C-ABI helpers.
@@ -9411,13 +9363,13 @@ fn handler_call_assembler_int_pyre(
 ) -> Result<usize, DispatchError> {
     let mut p = p;
     let fn_ptr_idx = jitcode::read_u16(code, &mut p) as usize;
-    let dst = jitcode::read_u16(code, &mut p) as usize;
+    let dst = jitcode::read_u8(code, &mut p) as usize;
     let num_args = jitcode::read_u16(code, &mut p) as usize;
     let mut args = Vec::with_capacity(num_args);
     for _ in 0..num_args {
         let kind = JitArgKind::decode(jitcode::read_u8(code, &mut p));
-        let reg = jitcode::read_u16(code, &mut p);
-        args.push(bh.read_call_arg(kind, reg));
+        let reg = jitcode::read_u8(code, &mut p);
+        args.push(bh.read_call_arg(kind, reg as u16));
     }
     let target = bh.jitcode.call_target(fn_ptr_idx);
     BH_LAST_EXC_VALUE.with(|c| c.set(0));
@@ -9443,13 +9395,13 @@ fn handler_call_assembler_ref_pyre(
 ) -> Result<usize, DispatchError> {
     let mut p = p;
     let fn_ptr_idx = jitcode::read_u16(code, &mut p) as usize;
-    let dst = jitcode::read_u16(code, &mut p) as usize;
+    let dst = jitcode::read_u8(code, &mut p) as usize;
     let num_args = jitcode::read_u16(code, &mut p) as usize;
     let mut args = Vec::with_capacity(num_args);
     for _ in 0..num_args {
         let kind = JitArgKind::decode(jitcode::read_u8(code, &mut p));
-        let reg = jitcode::read_u16(code, &mut p);
-        args.push(bh.read_call_arg(kind, reg));
+        let reg = jitcode::read_u8(code, &mut p);
+        args.push(bh.read_call_arg(kind, reg as u16));
     }
     let target = bh.jitcode.call_target(fn_ptr_idx);
     BH_LAST_EXC_VALUE.with(|c| c.set(0));
@@ -9489,13 +9441,13 @@ fn handler_call_assembler_float_pyre(
 ) -> Result<usize, DispatchError> {
     let mut p = p;
     let fn_ptr_idx = jitcode::read_u16(code, &mut p) as usize;
-    let dst = jitcode::read_u16(code, &mut p) as usize;
+    let dst = jitcode::read_u8(code, &mut p) as usize;
     let num_args = jitcode::read_u16(code, &mut p) as usize;
     let mut args = Vec::with_capacity(num_args);
     for _ in 0..num_args {
         let kind = JitArgKind::decode(jitcode::read_u8(code, &mut p));
-        let reg = jitcode::read_u16(code, &mut p);
-        args.push(bh.read_call_arg(kind, reg));
+        let reg = jitcode::read_u8(code, &mut p);
+        args.push(bh.read_call_arg(kind, reg as u16));
     }
     let target = bh.jitcode.call_target(fn_ptr_idx);
     BH_LAST_EXC_VALUE.with(|c| c.set(0));
@@ -9525,8 +9477,8 @@ fn handler_call_assembler_void_pyre(
     let mut args = Vec::with_capacity(num_args);
     for _ in 0..num_args {
         let kind = JitArgKind::decode(jitcode::read_u8(code, &mut p));
-        let reg = jitcode::read_u16(code, &mut p);
-        args.push(bh.read_call_arg(kind, reg));
+        let reg = jitcode::read_u8(code, &mut p);
+        args.push(bh.read_call_arg(kind, reg as u16));
     }
     let target = bh.jitcode.call_target(fn_ptr_idx);
     BH_LAST_EXC_VALUE.with(|c| c.set(0));
@@ -9549,8 +9501,8 @@ fn handler_call_assembler_void_pyre(
 ///
 /// `JitCodeBuilder::call_cond_like` / `call_cond_value_like`
 /// (`assembler.rs:2642,2660`) emit a pyre-only flat payload:
-///   `cond_call_*`:    `[first_reg: u16, fn_ptr_idx: u16, arg_count: u8, kind × arg_count: u8, reg × arg_count: u16]`
-///   `cond_call_value`: `[value_reg: u16, fn_ptr_idx: u16, arg_count: u8, kind × arg_count: u8, reg × arg_count: u16, dst: u16]`
+///   `cond_call_*`:    `[first_reg: u8, fn_ptr_idx: u16, arg_count: u8, kind × arg_count: u8, reg × arg_count: u8]`
+///   `cond_call_value`: `[value_reg: u8, fn_ptr_idx: u16, arg_count: u8, kind × arg_count: u8, reg × arg_count: u8, dst: u8]`
 ///   `record_known_result_*`: same shape as `cond_call_*` (no dst).
 ///
 /// Producers: `majit-macros/src/jit_interp/jitcode_lower.rs:2166-2458`,
@@ -9574,10 +9526,10 @@ fn read_cond_call_args(
     let regs_start = kinds_start + arg_count;
     for i in 0..arg_count {
         let kind = JitArgKind::decode(code[kinds_start + i]);
-        let reg = u16::from_le_bytes([code[regs_start + 2 * i], code[regs_start + 2 * i + 1]]);
-        args.push(bh.read_call_arg(kind, reg));
+        let reg = code[regs_start + i];
+        args.push(bh.read_call_arg(kind, reg as u16));
     }
-    (args, regs_start + 2 * arg_count)
+    (args, regs_start + arg_count)
 }
 
 fn handler_cond_call_void_pyre(
@@ -9586,7 +9538,7 @@ fn handler_cond_call_void_pyre(
     p: usize,
 ) -> Result<usize, DispatchError> {
     let mut p = p;
-    let cond_reg = jitcode::read_u16(code, &mut p) as usize;
+    let cond_reg = jitcode::read_u8(code, &mut p) as usize;
     let fn_ptr_idx = jitcode::read_u16(code, &mut p) as usize;
     let arg_count = jitcode::read_u8(code, &mut p) as usize;
     let condition = bh.registers_i[cond_reg];
@@ -9615,19 +9567,19 @@ fn handler_cond_call_value_int_pyre(
     p: usize,
 ) -> Result<usize, DispatchError> {
     let mut p = p;
-    let value_reg = jitcode::read_u16(code, &mut p) as usize;
+    let value_reg = jitcode::read_u8(code, &mut p) as usize;
     let fn_ptr_idx = jitcode::read_u16(code, &mut p) as usize;
     let arg_count = jitcode::read_u8(code, &mut p) as usize;
     let value = bh.registers_i[value_reg];
     let (args, p_end) = read_cond_call_args(bh, code, p, arg_count);
-    let dst = u16::from_le_bytes([code[p_end], code[p_end + 1]]) as usize;
+    let dst = code[p_end] as usize;
     let result = if value == 0 {
         let target = bh.jitcode.call_target(fn_ptr_idx);
         BH_LAST_EXC_VALUE.with(|c| c.set(0));
         let r = call_int_function(target.concrete_ptr, &args);
         let exc_val = BH_LAST_EXC_VALUE.with(|c| c.get());
         if exc_val != 0 {
-            bh.position = p_end + 2;
+            bh.position = p_end + 1;
             if bh.handle_exception_in_frame(exc_val) {
                 return Ok(bh.position);
             }
@@ -9640,7 +9592,7 @@ fn handler_cond_call_value_int_pyre(
         value
     };
     bh.registers_i[dst] = result;
-    Ok(p_end + 2)
+    Ok(p_end + 1)
 }
 
 fn handler_cond_call_value_ref_pyre(
@@ -9649,12 +9601,12 @@ fn handler_cond_call_value_ref_pyre(
     p: usize,
 ) -> Result<usize, DispatchError> {
     let mut p = p;
-    let value_reg = jitcode::read_u16(code, &mut p) as usize;
+    let value_reg = jitcode::read_u8(code, &mut p) as usize;
     let fn_ptr_idx = jitcode::read_u16(code, &mut p) as usize;
     let arg_count = jitcode::read_u8(code, &mut p) as usize;
     let value = bh.registers_r[value_reg];
     let (args, p_end) = read_cond_call_args(bh, code, p, arg_count);
-    let dst = u16::from_le_bytes([code[p_end], code[p_end + 1]]) as usize;
+    let dst = code[p_end] as usize;
     let result = if value == 0 {
         let target = bh.jitcode.call_target(fn_ptr_idx);
         BH_LAST_EXC_VALUE.with(|c| c.set(0));
@@ -9664,7 +9616,7 @@ fn handler_cond_call_value_ref_pyre(
         let r = call_ref_function(target.concrete_ptr, &args);
         let exc_val = BH_LAST_EXC_VALUE.with(|c| c.get());
         if exc_val != 0 {
-            bh.position = p_end + 2;
+            bh.position = p_end + 1;
             if bh.handle_exception_in_frame(exc_val) {
                 return Ok(bh.position);
             }
@@ -9677,7 +9629,7 @@ fn handler_cond_call_value_ref_pyre(
         value
     };
     bh.registers_r[dst] = result;
-    Ok(p_end + 2)
+    Ok(p_end + 1)
 }
 
 /// `bhimpl_record_known_result_*` body is `pass` — pure marker for
@@ -9689,14 +9641,14 @@ fn handler_record_known_result_int_pyre(
     p: usize,
 ) -> Result<usize, DispatchError> {
     let mut p = p;
-    // first_reg : u16 + fn_ptr_idx : u16
-    p += 4;
+    // first_reg : u8 + fn_ptr_idx : u16
+    p += 3;
     let arg_count = jitcode::read_u8(code, &mut p) as usize;
     let _ = bh;
     // kinds: arg_count × u8
     p += arg_count;
-    // regs: arg_count × u16
-    p += arg_count * 2;
+    // regs: arg_count × u8
+    p += arg_count;
     Ok(p)
 }
 
@@ -9722,9 +9674,9 @@ fn handler_record_known_result_ref_pyre(
 /// the `(bh, code, position) -> Result<usize, _>` signature.  Operand
 /// payload (pyre-only):
 ///   `sub_idx: u16`, `num_args: u16`,
-///   `num_args × (kind: u8, caller_src: u16, callee_dst: u16)`,
-///   `return_i: u16`, `return_r: u16`, `return_f: u16`
-/// `u16::MAX` in any return slot encodes "no caller destination".
+///   `num_args × (kind: u8, caller_src: u8, callee_dst: u8)`,
+///   `return_i: u8`, `return_r: u8`, `return_f: u8`
+/// `u8::MAX` in any return slot encodes "no caller destination".
 ///
 /// Registered via the pyre-only opname `inline_call_pyre_nested/P`
 /// in `pyre_extension_insns()`.  Canonical `inline_call_{r,ir,irf}_*`
@@ -9744,8 +9696,8 @@ fn handler_inline_call_pyre_nested(
     let mut arg_triples = Vec::with_capacity(num_args);
     for _ in 0..num_args {
         let kind = JitArgKind::decode(jitcode::read_u8(code, &mut p));
-        let caller_src = jitcode::read_u16(code, &mut p) as usize;
-        let callee_dst = jitcode::read_u16(code, &mut p) as usize;
+        let caller_src = jitcode::read_u8(code, &mut p) as usize;
+        let callee_dst = jitcode::read_u8(code, &mut p) as usize;
         arg_triples.push((kind, caller_src, callee_dst));
     }
     let return_i = decode_return_slot_at(code, &mut p);
@@ -9858,11 +9810,11 @@ fn handler_inline_call_pyre_nested(
 
 /// Mirror of `BlackholeInterpreter::decode_return_slot` for handler
 /// callsites that thread a local cursor instead of mutating
-/// `self.position`.  `u16::MAX` encodes the "no caller destination"
+/// `self.position`.  `u8::MAX` encodes the "no caller destination"
 /// sentinel.
 fn decode_return_slot_at(code: &[u8], cursor: &mut usize) -> Option<usize> {
-    let dst = jitcode::read_u16(code, cursor) as usize;
-    if dst == u16::MAX as usize {
+    let dst = jitcode::read_u8(code, cursor) as usize;
+    if dst == u8::MAX as usize {
         None
     } else {
         Some(dst)

--- a/majit/majit-metainterp/src/blackhole.rs
+++ b/majit/majit-metainterp/src/blackhole.rs
@@ -856,6 +856,13 @@ impl BlackholeInterpreter {
         jitcode::read_u8(&self.jitcode.code, &mut self.position)
     }
 
+    /// Read one register operand ([`jitcode::JitcodeReg`]); register operands
+    /// are always one byte. Use this at register reads instead of `next_u8`
+    /// so the 1-byte register width stays enforced in one place.
+    fn next_reg(&mut self) -> jitcode::JitcodeReg {
+        self.next_u8()
+    }
+
     fn next_u16(&mut self) -> u16 {
         jitcode::read_u16(&self.jitcode.code, &mut self.position)
     }
@@ -922,7 +929,7 @@ impl BlackholeInterpreter {
         let length = self.next_u8() as usize;
         let mut values = Vec::with_capacity(length);
         for _ in 0..length {
-            let index = self.next_u8() as usize;
+            let index = self.next_reg() as usize;
             if crate::bh_debug_enabled() {
                 eprintln!(
                     "[bh-getlist] i{index} -> {}",
@@ -939,7 +946,7 @@ impl BlackholeInterpreter {
         let length = self.next_u8() as usize;
         let mut values = Vec::with_capacity(length);
         for _ in 0..length {
-            let index = self.next_u8() as usize;
+            let index = self.next_reg() as usize;
             values.push(self.registers_r.get(index).copied().unwrap_or(0));
         }
         values
@@ -949,7 +956,7 @@ impl BlackholeInterpreter {
         let length = self.next_u8() as usize;
         let mut values = Vec::with_capacity(length);
         for _ in 0..length {
-            let index = self.next_u8() as usize;
+            let index = self.next_reg() as usize;
             values.push(self.registers_f.get(index).copied().unwrap_or(0));
         }
         values
@@ -969,7 +976,7 @@ impl BlackholeInterpreter {
     /// `USE_C_FORM`).
     pub(crate) fn bhimpl_jit_merge_point(&mut self, opcode: u8) -> Result<(), DispatchError> {
         let nbody_debug = crate::nbody_debug_enabled();
-        let jdindex_byte = self.next_u8();
+        let jdindex_byte = self.next_reg();
         let jdindex = if opcode == jitcode::insns::BC_JIT_MERGE_POINT_C {
             (jdindex_byte as i8) as usize
         } else {
@@ -1378,7 +1385,7 @@ impl BlackholeInterpreter {
         for _ in 0..num_args {
             let kind_byte = self.next_u8();
             let kind = JitArgKind::decode(kind_byte);
-            let reg = self.next_u8();
+            let reg = self.next_reg();
             metas.push((kind_byte, reg));
             args.push(self.read_call_arg(kind, reg as u16));
         }
@@ -9363,12 +9370,12 @@ fn handler_call_assembler_int_pyre(
 ) -> Result<usize, DispatchError> {
     let mut p = p;
     let fn_ptr_idx = jitcode::read_u16(code, &mut p) as usize;
-    let dst = jitcode::read_u8(code, &mut p) as usize;
+    let dst = jitcode::read_reg(code, &mut p) as usize;
     let num_args = jitcode::read_u16(code, &mut p) as usize;
     let mut args = Vec::with_capacity(num_args);
     for _ in 0..num_args {
         let kind = JitArgKind::decode(jitcode::read_u8(code, &mut p));
-        let reg = jitcode::read_u8(code, &mut p);
+        let reg = jitcode::read_reg(code, &mut p);
         args.push(bh.read_call_arg(kind, reg as u16));
     }
     let target = bh.jitcode.call_target(fn_ptr_idx);
@@ -9395,12 +9402,12 @@ fn handler_call_assembler_ref_pyre(
 ) -> Result<usize, DispatchError> {
     let mut p = p;
     let fn_ptr_idx = jitcode::read_u16(code, &mut p) as usize;
-    let dst = jitcode::read_u8(code, &mut p) as usize;
+    let dst = jitcode::read_reg(code, &mut p) as usize;
     let num_args = jitcode::read_u16(code, &mut p) as usize;
     let mut args = Vec::with_capacity(num_args);
     for _ in 0..num_args {
         let kind = JitArgKind::decode(jitcode::read_u8(code, &mut p));
-        let reg = jitcode::read_u8(code, &mut p);
+        let reg = jitcode::read_reg(code, &mut p);
         args.push(bh.read_call_arg(kind, reg as u16));
     }
     let target = bh.jitcode.call_target(fn_ptr_idx);
@@ -9441,12 +9448,12 @@ fn handler_call_assembler_float_pyre(
 ) -> Result<usize, DispatchError> {
     let mut p = p;
     let fn_ptr_idx = jitcode::read_u16(code, &mut p) as usize;
-    let dst = jitcode::read_u8(code, &mut p) as usize;
+    let dst = jitcode::read_reg(code, &mut p) as usize;
     let num_args = jitcode::read_u16(code, &mut p) as usize;
     let mut args = Vec::with_capacity(num_args);
     for _ in 0..num_args {
         let kind = JitArgKind::decode(jitcode::read_u8(code, &mut p));
-        let reg = jitcode::read_u8(code, &mut p);
+        let reg = jitcode::read_reg(code, &mut p);
         args.push(bh.read_call_arg(kind, reg as u16));
     }
     let target = bh.jitcode.call_target(fn_ptr_idx);
@@ -9477,7 +9484,7 @@ fn handler_call_assembler_void_pyre(
     let mut args = Vec::with_capacity(num_args);
     for _ in 0..num_args {
         let kind = JitArgKind::decode(jitcode::read_u8(code, &mut p));
-        let reg = jitcode::read_u8(code, &mut p);
+        let reg = jitcode::read_reg(code, &mut p);
         args.push(bh.read_call_arg(kind, reg as u16));
     }
     let target = bh.jitcode.call_target(fn_ptr_idx);
@@ -9538,7 +9545,7 @@ fn handler_cond_call_void_pyre(
     p: usize,
 ) -> Result<usize, DispatchError> {
     let mut p = p;
-    let cond_reg = jitcode::read_u8(code, &mut p) as usize;
+    let cond_reg = jitcode::read_reg(code, &mut p) as usize;
     let fn_ptr_idx = jitcode::read_u16(code, &mut p) as usize;
     let arg_count = jitcode::read_u8(code, &mut p) as usize;
     let condition = bh.registers_i[cond_reg];
@@ -9567,7 +9574,7 @@ fn handler_cond_call_value_int_pyre(
     p: usize,
 ) -> Result<usize, DispatchError> {
     let mut p = p;
-    let value_reg = jitcode::read_u8(code, &mut p) as usize;
+    let value_reg = jitcode::read_reg(code, &mut p) as usize;
     let fn_ptr_idx = jitcode::read_u16(code, &mut p) as usize;
     let arg_count = jitcode::read_u8(code, &mut p) as usize;
     let value = bh.registers_i[value_reg];
@@ -9601,7 +9608,7 @@ fn handler_cond_call_value_ref_pyre(
     p: usize,
 ) -> Result<usize, DispatchError> {
     let mut p = p;
-    let value_reg = jitcode::read_u8(code, &mut p) as usize;
+    let value_reg = jitcode::read_reg(code, &mut p) as usize;
     let fn_ptr_idx = jitcode::read_u16(code, &mut p) as usize;
     let arg_count = jitcode::read_u8(code, &mut p) as usize;
     let value = bh.registers_r[value_reg];
@@ -9676,7 +9683,7 @@ fn handler_record_known_result_ref_pyre(
 ///   `sub_idx: u16`, `num_args: u16`,
 ///   `num_args × (kind: u8, caller_src: u8, callee_dst: u8)`,
 ///   `return_i: u8`, `return_r: u8`, `return_f: u8`
-/// `u8::MAX` in any return slot encodes "no caller destination".
+/// `NO_RETURN_REG` in any return slot encodes "no caller destination".
 ///
 /// Registered via the pyre-only opname `inline_call_pyre_nested/P`
 /// in `pyre_extension_insns()`.  Canonical `inline_call_{r,ir,irf}_*`
@@ -9696,8 +9703,8 @@ fn handler_inline_call_pyre_nested(
     let mut arg_triples = Vec::with_capacity(num_args);
     for _ in 0..num_args {
         let kind = JitArgKind::decode(jitcode::read_u8(code, &mut p));
-        let caller_src = jitcode::read_u8(code, &mut p) as usize;
-        let callee_dst = jitcode::read_u8(code, &mut p) as usize;
+        let caller_src = jitcode::read_reg(code, &mut p) as usize;
+        let callee_dst = jitcode::read_reg(code, &mut p) as usize;
         arg_triples.push((kind, caller_src, callee_dst));
     }
     let return_i = decode_return_slot_at(code, &mut p);
@@ -9810,11 +9817,11 @@ fn handler_inline_call_pyre_nested(
 
 /// Mirror of `BlackholeInterpreter::decode_return_slot` for handler
 /// callsites that thread a local cursor instead of mutating
-/// `self.position`.  `u8::MAX` encodes the "no caller destination"
+/// `self.position`.  `NO_RETURN_REG` encodes the "no caller destination"
 /// sentinel.
 fn decode_return_slot_at(code: &[u8], cursor: &mut usize) -> Option<usize> {
-    let dst = jitcode::read_u8(code, cursor) as usize;
-    if dst == u8::MAX as usize {
+    let dst = jitcode::read_reg(code, cursor) as usize;
+    if dst == jitcode::NO_RETURN_REG as usize {
         None
     } else {
         Some(dst)

--- a/majit/majit-metainterp/src/jitcode/assembler.rs
+++ b/majit/majit-metainterp/src/jitcode/assembler.rs
@@ -2457,8 +2457,8 @@ impl JitCodeBuilder {
 
     /// Void-result sibling of [`Self::recursive_call_int`]
     /// (`opimpl_recursive_call_v`).  Carries no result register — the
-    /// `result_dst` slot is emitted as the `u8::MAX` "no result" sentinel the
-    /// dispatcher decodes to `None`.
+    /// `result_dst` slot is emitted as the [`jitcode::NO_RETURN_REG`] "no
+    /// result" sentinel the dispatcher decodes to `None`.
     pub fn recursive_call_void(
         &mut self,
         jd_index: u16,
@@ -2480,7 +2480,7 @@ impl JitCodeBuilder {
         }
         self.start_instr(jitcode::insns::BC_RECURSIVE_CALL_VOID);
         self.push_u16(jd_index);
-        self.push_u8(u8::MAX);
+        self.push_u8(jitcode::NO_RETURN_REG);
         self.push_u16(greens.len() as u16);
         for &(kind, src) in greens {
             self.push_u8(kind.encode());
@@ -2821,7 +2821,7 @@ impl JitCodeBuilder {
     fn push_return_slot(&mut self, ret: Option<u16>) {
         match ret {
             Some(caller_dst) => self.push_reg_u8(caller_dst, "inline_call return"),
-            None => self.push_u8(u8::MAX),
+            None => self.push_u8(jitcode::NO_RETURN_REG),
         }
     }
 
@@ -4671,14 +4671,18 @@ impl JitCodeBuilder {
         self.code.push(value);
     }
 
+    /// Emit a single register operand ([`jitcode::JitcodeReg`], one byte).
+    /// A register index that does not fit a byte latches the overflow flag so
+    /// `try_finish` declines the JitCode. See [`jitcode::JitcodeReg`] — the
+    /// register width is deliberately fixed at `u8`.
     fn push_reg_u8(&mut self, reg: u16, _context: &'static str) {
-        if reg > u8::MAX as u16 {
+        if reg > jitcode::JitcodeReg::MAX as u16 {
             // The placeholder exists only in the transient builder;
             // `try_finish` observes the latch and declines the JitCode.
             self.encoding_overflow = true;
             self.push_u8(0);
         } else {
-            self.push_u8(reg as u8);
+            self.push_u8(reg as jitcode::JitcodeReg);
         }
     }
 
@@ -5156,10 +5160,10 @@ impl JitCodeBuilder {
             };
             let slot = base + pool_idx;
             assert!(
-                slot <= u8::MAX as u16,
+                slot <= jitcode::JitcodeReg::MAX as u16,
                 "patch_const_u8_refs: slot {slot} (base={base} + pool_idx={pool_idx}) overflows u8"
             );
-            self.code[offset] = slot as u8;
+            self.code[offset] = slot as jitcode::JitcodeReg;
         }
     }
 }

--- a/majit/majit-metainterp/src/jitcode/assembler.rs
+++ b/majit/majit-metainterp/src/jitcode/assembler.rs
@@ -2323,9 +2323,9 @@ impl JitCodeBuilder {
     /// Emit a recursive portal call returning an int (pyjitpl.py:1376
     /// `opimpl_recursive_call`).  The payload is consumed by
     /// `JitCodeMachine::exec_recursive_call`:
-    ///   jd_index:u16, result_dst:u16, num_green:u16,
-    ///   (green_kind:u8, green_src:u16) × num_green, num_args:u16,
-    ///   (kind:u8, caller_src:u16, callee_dst:u16) × num_args.
+    ///   jd_index:u16, result_dst:u8, num_green:u16,
+    ///   (green_kind:u8, green_src:u8) × num_green, num_args:u16,
+    ///   (kind:u8, caller_src:u8, callee_dst:u8) × num_args.
     /// The portal is self-recursive, so the opcode carries the jitdriver
     /// index rather than a compiled target.  `greens` are the caller
     /// registers holding the portal green key, in the jitdriver's green
@@ -2358,17 +2358,17 @@ impl JitCodeBuilder {
         }
         self.start_instr(jitcode::insns::BC_RECURSIVE_CALL_INT);
         self.push_u16(jd_index);
-        self.push_u16(result_dst);
+        self.push_reg_u8(result_dst, "recursive_call_int result");
         self.push_u16(greens.len() as u16);
         for &(kind, src) in greens {
             self.push_u8(kind.encode());
-            self.push_u16(src);
+            self.push_reg_u8(src, "recursive_call_int green");
         }
         self.push_u16(args.len() as u16);
         for &(kind, caller_src, callee_dst) in args {
             self.push_u8(kind.encode());
-            self.push_u16(caller_src);
-            self.push_u16(callee_dst);
+            self.push_reg_u8(caller_src, "recursive_call_int caller argument");
+            self.push_reg_u8(callee_dst, "recursive_call_int callee argument");
         }
         self.record_resulttype('i');
     }
@@ -2399,17 +2399,17 @@ impl JitCodeBuilder {
         }
         self.start_instr(jitcode::insns::BC_RECURSIVE_CALL_REF);
         self.push_u16(jd_index);
-        self.push_u16(result_dst);
+        self.push_reg_u8(result_dst, "recursive_call_ref result");
         self.push_u16(greens.len() as u16);
         for &(kind, src) in greens {
             self.push_u8(kind.encode());
-            self.push_u16(src);
+            self.push_reg_u8(src, "recursive_call_ref green");
         }
         self.push_u16(args.len() as u16);
         for &(kind, caller_src, callee_dst) in args {
             self.push_u8(kind.encode());
-            self.push_u16(caller_src);
-            self.push_u16(callee_dst);
+            self.push_reg_u8(caller_src, "recursive_call_ref caller argument");
+            self.push_reg_u8(callee_dst, "recursive_call_ref callee argument");
         }
         self.record_resulttype('r');
     }
@@ -2440,24 +2440,24 @@ impl JitCodeBuilder {
         }
         self.start_instr(jitcode::insns::BC_RECURSIVE_CALL_FLOAT);
         self.push_u16(jd_index);
-        self.push_u16(result_dst);
+        self.push_reg_u8(result_dst, "recursive_call_float result");
         self.push_u16(greens.len() as u16);
         for &(kind, src) in greens {
             self.push_u8(kind.encode());
-            self.push_u16(src);
+            self.push_reg_u8(src, "recursive_call_float green");
         }
         self.push_u16(args.len() as u16);
         for &(kind, caller_src, callee_dst) in args {
             self.push_u8(kind.encode());
-            self.push_u16(caller_src);
-            self.push_u16(callee_dst);
+            self.push_reg_u8(caller_src, "recursive_call_float caller argument");
+            self.push_reg_u8(callee_dst, "recursive_call_float callee argument");
         }
         self.record_resulttype('f');
     }
 
     /// Void-result sibling of [`Self::recursive_call_int`]
     /// (`opimpl_recursive_call_v`).  Carries no result register — the
-    /// `result_dst` slot is emitted as the `u16::MAX` "no result" sentinel the
+    /// `result_dst` slot is emitted as the `u8::MAX` "no result" sentinel the
     /// dispatcher decodes to `None`.
     pub fn recursive_call_void(
         &mut self,
@@ -2480,17 +2480,17 @@ impl JitCodeBuilder {
         }
         self.start_instr(jitcode::insns::BC_RECURSIVE_CALL_VOID);
         self.push_u16(jd_index);
-        self.push_u16(u16::MAX);
+        self.push_u8(u8::MAX);
         self.push_u16(greens.len() as u16);
         for &(kind, src) in greens {
             self.push_u8(kind.encode());
-            self.push_u16(src);
+            self.push_reg_u8(src, "recursive_call_void green");
         }
         self.push_u16(args.len() as u16);
         for &(kind, caller_src, callee_dst) in args {
             self.push_u8(kind.encode());
-            self.push_u16(caller_src);
-            self.push_u16(callee_dst);
+            self.push_reg_u8(caller_src, "recursive_call_void caller argument");
+            self.push_reg_u8(callee_dst, "recursive_call_void callee argument");
         }
     }
 
@@ -2793,8 +2793,8 @@ impl JitCodeBuilder {
         self.push_u16(args.len() as u16);
         for &(kind, caller_src, callee_dst) in args {
             self.push_u8(kind.encode());
-            self.push_u16(caller_src);
-            self.push_u16(callee_dst);
+            self.push_reg_u8(caller_src, "inline_call caller argument");
+            self.push_reg_u8(callee_dst, "inline_call callee argument");
         }
         self.push_return_slot(return_i);
         self.push_return_slot(return_r);
@@ -2820,8 +2820,8 @@ impl JitCodeBuilder {
 
     fn push_return_slot(&mut self, ret: Option<u16>) {
         match ret {
-            Some(caller_dst) => self.push_u16(caller_dst),
-            None => self.push_u16(u16::MAX),
+            Some(caller_dst) => self.push_reg_u8(caller_dst, "inline_call return"),
+            None => self.push_u8(u8::MAX),
         }
     }
 
@@ -3934,7 +3934,7 @@ impl JitCodeBuilder {
 
     fn call_cond_like(&mut self, bc: u8, fn_ptr_idx: u16, first_reg: u16, args: &[JitCallArg]) {
         self.start_instr(bc);
-        self.push_u16(first_reg);
+        self.push_reg_u8(first_reg, "conditional_call first register");
         self.push_u16(fn_ptr_idx);
         let arg_count = args.len();
         assert!(
@@ -3946,7 +3946,7 @@ impl JitCodeBuilder {
             self.push_u8(arg.kind as u8);
         }
         for arg in args {
-            self.push_u16(arg.reg);
+            self.push_reg_u8(arg.reg, "conditional_call argument");
         }
     }
 
@@ -3960,7 +3960,7 @@ impl JitCodeBuilder {
         result_kind: char,
     ) {
         self.start_instr(bc);
-        self.push_u16(value_reg);
+        self.push_reg_u8(value_reg, "conditional_call_value first register");
         self.push_u16(fn_ptr_idx);
         let arg_count = args.len();
         assert!(
@@ -3972,9 +3972,9 @@ impl JitCodeBuilder {
             self.push_u8(arg.kind as u8);
         }
         for arg in args {
-            self.push_u16(arg.reg);
+            self.push_reg_u8(arg.reg, "conditional_call_value argument");
         }
-        self.push_u16(dst);
+        self.push_reg_u8(dst, "conditional_call_value result");
         self.record_resulttype(result_kind);
     }
 
@@ -4761,7 +4761,7 @@ impl JitCodeBuilder {
         self.push_u16(arg_regs.len() as u16);
         for &arg in arg_regs {
             self.push_u8(arg.kind.encode());
-            self.push_u16(arg.reg);
+            self.push_reg_u8(arg.reg, "call_assembler_void argument");
         }
     }
 
@@ -4930,11 +4930,11 @@ impl JitCodeBuilder {
         }
         self.start_instr(opcode);
         self.push_u16(target_idx);
-        self.push_u16(dst);
+        self.push_reg_u8(dst, "call_assembler_int result");
         self.push_u16(arg_regs.len() as u16);
         for &arg in arg_regs {
             self.push_u8(arg.kind.encode());
-            self.push_u16(arg.reg);
+            self.push_reg_u8(arg.reg, "call_assembler_int argument");
         }
         self.record_resulttype('i');
     }
@@ -4952,11 +4952,11 @@ impl JitCodeBuilder {
         }
         self.start_instr(opcode);
         self.push_u16(target_idx);
-        self.push_u16(dst);
+        self.push_reg_u8(dst, "call_assembler_ref result");
         self.push_u16(arg_regs.len() as u16);
         for &arg in arg_regs {
             self.push_u8(arg.kind.encode());
-            self.push_u16(arg.reg);
+            self.push_reg_u8(arg.reg, "call_assembler_ref argument");
         }
         self.record_resulttype('r');
     }
@@ -4990,11 +4990,11 @@ impl JitCodeBuilder {
         }
         self.start_instr(opcode);
         self.push_u16(target_idx);
-        self.push_u16(dst);
+        self.push_reg_u8(dst, "call_assembler_float result");
         self.push_u16(arg_regs.len() as u16);
         for &arg in arg_regs {
             self.push_u8(arg.kind.encode());
-            self.push_u16(arg.reg);
+            self.push_reg_u8(arg.reg, "call_assembler_float argument");
         }
         self.record_resulttype('f');
     }

--- a/majit/majit-metainterp/src/jitcode/mod.rs
+++ b/majit/majit-metainterp/src/jitcode/mod.rs
@@ -615,10 +615,42 @@ impl JitCodeRuntimeExt for JitCode {
     }
 }
 
+/// The encoded width of a jitcode **register operand**: exactly one byte.
+///
+/// A register operand occupies a single byte in the jitcode stream — the
+/// canonical encoding (`chr(reg.index)` when assembling, `ord(code[position])`
+/// when decoding). The 256-per-kind register limit, the `num_regs < 256`
+/// assemble-time decline, and every register decode site all rest on this
+/// width. Encode register operands with `JitCodeBuilder::push_reg_u8` and
+/// decode them with [`read_reg`] / `next_reg`, so the width lives in one place.
+///
+/// ⚠️ This MUST remain `u8`. Do NOT widen it to `u16` (or any wider type):
+/// doing so silently desyncs the encoder from the 1-byte register decoders and
+/// reintroduces exactly the register-width divergence this alias exists to
+/// prevent. Non-register operands (descr / field / array indexes) are `u16`
+/// and are deliberately NOT covered by this alias.
+pub type JitcodeReg = u8;
+
+/// The register-operand value that encodes "no register" / "no return slot"
+/// (e.g. a `recursive_call_void` result slot, or an `inline_call` with no
+/// caller destination). It is [`JitcodeReg::MAX`], safe as a sentinel because
+/// `try_finish` declines any JitCode with `num_regs >= 256`, so every real
+/// register index is `<= 254`. Encode and decode both reference this constant
+/// so the sentinel never drifts.
+pub(crate) const NO_RETURN_REG: JitcodeReg = JitcodeReg::MAX;
+
 pub(crate) fn read_u8(code: &[u8], cursor: &mut usize) -> u8 {
     let value = *code.get(*cursor).expect("truncated jitcode");
     *cursor += 1;
     value
+}
+
+/// Read one register operand ([`JitcodeReg`]) from `code` at `*cursor`,
+/// advancing past it. Use this — never a bare `read_u8` — wherever the byte
+/// is a register index, so the 1-byte register width stays enforced in one
+/// place. See [`JitcodeReg`].
+pub(crate) fn read_reg(code: &[u8], cursor: &mut usize) -> JitcodeReg {
+    read_u8(code, cursor)
 }
 
 pub(crate) fn read_u16(code: &[u8], cursor: &mut usize) -> u16 {

--- a/majit/majit-metainterp/src/pyjitpl/dispatch.rs
+++ b/majit/majit-metainterp/src/pyjitpl/dispatch.rs
@@ -2139,7 +2139,7 @@ where
     ///
     /// Payload (little-endian, emitted by
     /// `JitCodeBuilder::recursive_call_int` and siblings):
-    ///   jd_index:u16, result_dst:u8 (`u8::MAX` = no result / void),
+    ///   jd_index:u16, result_dst:u8 (`NO_RETURN_REG` = no result / void),
     ///   num_green:u16, (green_kind:u8, green_src:u8) × num_green,
     ///   num_args:u16, (kind:u8, caller_src:u8, callee_dst:u8) × num_args.
     ///
@@ -2175,8 +2175,8 @@ where
         let (jd_index, result_dst, green_srcs, arg_triples) = {
             let frame = self.frames.current_mut();
             let jd_index = frame.next_u16() as usize;
-            let result_dst_raw = frame.next_u8() as usize;
-            let result_dst = if result_dst_raw == u8::MAX as usize {
+            let result_dst_raw = frame.next_reg() as usize;
+            let result_dst = if result_dst_raw == crate::jitcode::NO_RETURN_REG as usize {
                 None
             } else {
                 Some(result_dst_raw)
@@ -2185,15 +2185,15 @@ where
             let mut green_srcs = Vec::with_capacity(num_green);
             for _ in 0..num_green {
                 let kind = JitArgKind::decode(frame.next_u8());
-                let src = frame.next_u8() as usize;
+                let src = frame.next_reg() as usize;
                 green_srcs.push((kind, src));
             }
             let num_args = frame.next_u16() as usize;
             let mut arg_triples = Vec::with_capacity(num_args);
             for _ in 0..num_args {
                 let kind = JitArgKind::decode(frame.next_u8());
-                let caller_src = frame.next_u8() as usize;
-                let callee_dst = frame.next_u8() as usize;
+                let caller_src = frame.next_reg() as usize;
+                let callee_dst = frame.next_reg() as usize;
                 arg_triples.push((kind, caller_src, callee_dst));
             }
             // Caller-side result-slot bookkeeping (BC_INLINE_CALL:3298-3300).
@@ -2665,7 +2665,7 @@ where
             // `i` = u8 register index (`assembler.py:165-167`).
             jitcode::insns::BC_LOAD_STATE_FIELD => {
                 let field_idx = self.frames.current_mut().next_u16() as usize;
-                let dest = self.frames.current_mut().next_u8() as usize;
+                let dest = self.frames.current_mut().next_reg() as usize;
                 let opref = sym
                     .state_field_ref(field_idx)
                     .expect("state field not initialized");
@@ -2676,7 +2676,7 @@ where
             }
             jitcode::insns::BC_STORE_STATE_FIELD => {
                 let field_idx = self.frames.current_mut().next_u16() as usize;
-                let src = self.frames.current_mut().next_u8() as usize;
+                let src = self.frames.current_mut().next_reg() as usize;
                 let (opref, value) = self.read_int_reg(src);
                 sym.set_state_field_ref(field_idx, opref);
                 sym.set_state_field_value(field_idx, value);
@@ -2687,7 +2687,7 @@ where
             // real ref base. Argcodes: `d` = u16 field index, `r` = ref reg.
             jitcode::insns::BC_LOAD_STATE_FIELD_REF => {
                 let field_idx = self.frames.current_mut().next_u16() as usize;
-                let dest = self.frames.current_mut().next_u8() as usize;
+                let dest = self.frames.current_mut().next_reg() as usize;
                 let opref = sym
                     .state_ref_field_ref(field_idx)
                     .expect("ref state field not initialized");
@@ -2698,15 +2698,15 @@ where
             }
             jitcode::insns::BC_STORE_STATE_FIELD_REF => {
                 let field_idx = self.frames.current_mut().next_u16() as usize;
-                let src = self.frames.current_mut().next_u8() as usize;
+                let src = self.frames.current_mut().next_reg() as usize;
                 let (opref, value) = self.read_ref_reg(src);
                 sym.set_state_ref_field_ref(field_idx, opref);
                 sym.set_state_ref_field_value(field_idx, value);
             }
             jitcode::insns::BC_LOAD_STATE_ARRAY => {
                 let array_idx = self.frames.current_mut().next_u16() as usize;
-                let index_reg = self.frames.current_mut().next_u8() as usize;
-                let dest = self.frames.current_mut().next_u8() as usize;
+                let index_reg = self.frames.current_mut().next_reg() as usize;
+                let dest = self.frames.current_mut().next_reg() as usize;
                 let (_, index_concrete) = self.read_int_reg(index_reg);
                 let elem_idx = index_concrete as usize;
                 let opref = sym.state_array_ref(array_idx, elem_idx);
@@ -2723,8 +2723,8 @@ where
             }
             jitcode::insns::BC_STORE_STATE_ARRAY => {
                 let array_idx = self.frames.current_mut().next_u16() as usize;
-                let index_reg = self.frames.current_mut().next_u8() as usize;
-                let src = self.frames.current_mut().next_u8() as usize;
+                let index_reg = self.frames.current_mut().next_reg() as usize;
+                let src = self.frames.current_mut().next_reg() as usize;
                 let (_, index_concrete) = self.read_int_reg(index_reg);
                 let elem_idx = index_concrete as usize;
                 let (opref, value) = self.read_int_reg(src);
@@ -2894,9 +2894,9 @@ where
                 //   [descr_idx u16]
                 let (base_reg, ea_reg, value_reg, descr_idx) = {
                     let frame = self.frames.current_mut();
-                    let base_reg = frame.next_u8() as usize;
-                    let ea_reg = frame.next_u8() as usize;
-                    let value_reg = frame.next_u8() as usize;
+                    let base_reg = frame.next_reg() as usize;
+                    let ea_reg = frame.next_reg() as usize;
+                    let value_reg = frame.next_reg() as usize;
                     let descr_idx = frame.next_u16() as usize;
                     (base_reg, ea_reg, value_reg, descr_idx)
                 };
@@ -2956,10 +2956,10 @@ where
                 //   [BC_RAW_LOAD_I][base_reg u8][ea_reg u8][descr_idx u16][dst u8]
                 let (base_reg, ea_reg, descr_idx, dst) = {
                     let frame = self.frames.current_mut();
-                    let base_reg = frame.next_u8() as usize;
-                    let ea_reg = frame.next_u8() as usize;
+                    let base_reg = frame.next_reg() as usize;
+                    let ea_reg = frame.next_reg() as usize;
                     let descr_idx = frame.next_u16() as usize;
-                    let dst = frame.next_u8() as usize;
+                    let dst = frame.next_reg() as usize;
                     (base_reg, ea_reg, descr_idx, dst)
                 };
                 let Some(descr) = self.dispatch_array_descr_ref(ctx, descr_idx) else {
@@ -3193,9 +3193,9 @@ where
             jitcode::insns::BC_ARRAYLEN_GC => {
                 let (array_reg, descr_idx, dst) = {
                     let frame = self.frames.current_mut();
-                    let array_reg = frame.next_u8() as usize;
+                    let array_reg = frame.next_reg() as usize;
                     let descr_idx = frame.next_u16() as usize;
-                    let dst = frame.next_u8() as usize;
+                    let dst = frame.next_reg() as usize;
                     (array_reg, descr_idx, dst)
                 };
                 let Some(descr) = self.dispatch_array_descr_ref(ctx, descr_idx) else {
@@ -3236,10 +3236,10 @@ where
             jitcode::insns::BC_GETARRAYITEM_GC_I => {
                 let (array_reg, index_reg, descr_idx, dst) = {
                     let frame = self.frames.current_mut();
-                    let array_reg = frame.next_u8() as usize;
-                    let index_reg = frame.next_u8() as usize;
+                    let array_reg = frame.next_reg() as usize;
+                    let index_reg = frame.next_reg() as usize;
                     let descr_idx = frame.next_u16() as usize;
-                    let dst = frame.next_u8() as usize;
+                    let dst = frame.next_reg() as usize;
                     (array_reg, index_reg, descr_idx, dst)
                 };
                 let Some(descr) = self.dispatch_array_descr_ref(ctx, descr_idx) else {
@@ -3428,10 +3428,10 @@ where
             jitcode::insns::BC_GETARRAYITEM_GC_R_RID => {
                 let (array_reg, index_reg, descr_idx, dst) = {
                     let frame = self.frames.current_mut();
-                    let array_reg = frame.next_u8() as usize;
-                    let index_reg = frame.next_u8() as usize;
+                    let array_reg = frame.next_reg() as usize;
+                    let index_reg = frame.next_reg() as usize;
                     let descr_idx = frame.next_u16() as usize;
-                    let dst = frame.next_u8() as usize;
+                    let dst = frame.next_reg() as usize;
                     (array_reg, index_reg, descr_idx, dst)
                 };
                 let Some(descr) = self.dispatch_array_descr_ref(ctx, descr_idx) else {
@@ -3487,9 +3487,9 @@ where
             | jitcode::insns::BC_SETARRAYITEM_GC_F => {
                 let (array_reg, index_reg, value_reg, descr_idx) = {
                     let frame = self.frames.current_mut();
-                    let array_reg = frame.next_u8() as usize;
-                    let index_reg = frame.next_u8() as usize;
-                    let value_reg = frame.next_u8() as usize;
+                    let array_reg = frame.next_reg() as usize;
+                    let index_reg = frame.next_reg() as usize;
+                    let value_reg = frame.next_reg() as usize;
                     let descr_idx = frame.next_u16() as usize;
                     (array_reg, index_reg, value_reg, descr_idx)
                 };
@@ -3724,7 +3724,7 @@ where
                 self.set_int_reg(dest, Some(result), Some(len as i64));
             }
             jitcode::insns::BC_HINT_FORCE_VIRTUALIZABLE => {
-                let vable_reg = self.frames.current_mut().next_u8() as usize;
+                let vable_reg = self.frames.current_mut().next_reg() as usize;
                 let vable_opref = self.resolve_vable_box(vable_reg);
                 ctx.gen_store_back_in_vable(vable_opref);
             }
@@ -3786,7 +3786,7 @@ where
                     let opcode_pc = frame.code_cursor - 1;
                     (
                         opcode_pc,
-                        frame.next_u8() as usize,
+                        frame.next_reg() as usize,
                         frame.next_u16() as usize,
                     )
                 };
@@ -3814,7 +3814,7 @@ where
                     let opcode_pc = frame.code_cursor - 1;
                     (
                         opcode_pc,
-                        frame.next_u8() as usize,
+                        frame.next_reg() as usize,
                         frame.next_u16() as usize,
                     )
                 };
@@ -3844,8 +3844,8 @@ where
                     let opcode_pc = frame.code_cursor - 1;
                     (
                         opcode_pc,
-                        frame.next_u8() as usize,
-                        frame.next_u8() as usize,
+                        frame.next_reg() as usize,
+                        frame.next_reg() as usize,
                         frame.next_u16() as usize,
                     )
                 };
@@ -3884,8 +3884,8 @@ where
                     let opcode_pc = frame.code_cursor - 1;
                     (
                         opcode_pc,
-                        frame.next_u8() as usize,
-                        frame.next_u8() as usize,
+                        frame.next_reg() as usize,
+                        frame.next_reg() as usize,
                         frame.next_u16() as usize,
                     )
                 };
@@ -3913,8 +3913,8 @@ where
                     let opcode_pc = frame.code_cursor - 1;
                     (
                         opcode_pc,
-                        frame.next_u8() as usize,
-                        frame.next_u8() as usize,
+                        frame.next_reg() as usize,
+                        frame.next_reg() as usize,
                         frame.next_u16() as usize,
                     )
                 };
@@ -3945,7 +3945,7 @@ where
                     let opcode_pc = frame.code_cursor - 1;
                     (
                         opcode_pc,
-                        frame.next_u8() as usize,
+                        frame.next_reg() as usize,
                         frame.next_u16() as usize,
                     )
                 };
@@ -3994,7 +3994,7 @@ where
                     let opcode_pc = frame.code_cursor - 1;
                     (
                         opcode_pc,
-                        frame.next_u8() as usize,
+                        frame.next_reg() as usize,
                         frame.next_u16() as usize,
                     )
                 };
@@ -4025,7 +4025,7 @@ where
                 let _target = self.frames.current_mut().next_u16();
             }
             jitcode::insns::BC_LAST_EXCEPTION => {
-                let dst = self.frames.current_mut().next_u8() as usize;
+                let dst = self.frames.current_mut().next_reg() as usize;
                 let exc_value = self.last_exception_value;
                 // pyjitpl.py:1707-1714 opimpl_last_exception:
                 //     exc_value = self.metainterp.last_exc_value
@@ -4046,7 +4046,7 @@ where
                 self.set_int_reg(dst, Some(ctx.const_int(typeptr)), Some(typeptr));
             }
             jitcode::insns::BC_LAST_EXC_VALUE => {
-                let dst = self.frames.current_mut().next_u8() as usize;
+                let dst = self.frames.current_mut().next_reg() as usize;
                 // pyjitpl.py:1716-1719 opimpl_last_exc_value:
                 //     exc_value = self.metainterp.last_exc_value
                 //     assert exc_value
@@ -4082,7 +4082,7 @@ where
                 // Canonical `iL` encoding: [vtable:u8][target:u16].
                 let (vtable_idx, target) = {
                     let frame = self.frames.current_mut();
-                    (frame.next_u8() as usize, frame.next_u16() as usize)
+                    (frame.next_reg() as usize, frame.next_u16() as usize)
                 };
                 let exc_value = self.last_exception_value;
                 assert!(
@@ -4111,7 +4111,7 @@ where
             jitcode::insns::BC_RVMPROF_CODE => {
                 let (leaving_idx, unique_id_idx) = {
                     let frame = self.frames.current_mut();
-                    (frame.next_u8() as usize, frame.next_u8() as usize)
+                    (frame.next_reg() as usize, frame.next_reg() as usize)
                 };
                 let leaving = self.frames.current_mut().int_values[leaving_idx].unwrap_or(0);
                 let unique_id = self.frames.current_mut().int_values[unique_id_idx].unwrap_or(0);
@@ -4138,7 +4138,7 @@ where
                 // swap (dispatch.rs:850) finds that `-live-` at
                 // `mp_opcode_pc - SIZE_LIVE_OP`.
                 let mp_opcode_pc = frame.code_cursor - 1;
-                let jdindex_byte = frame.next_u8();
+                let jdindex_byte = frame.next_reg();
                 // RPython `blackhole.py:112-123` argcode discrimination:
                 //
                 //     if argcode == 'i':
@@ -4253,7 +4253,7 @@ where
                     let max = max_regs[slot];
                     let is_green_slot = slot < 3;
                     for _ in 0..count {
-                        let reg = frame.next_u8();
+                        let reg = frame.next_reg();
                         let reg_idx = reg as usize;
                         if capture_walk_reds && slot >= 3 {
                             match slot {
@@ -4824,7 +4824,7 @@ where
                 // rather than reading the slot byte as the index directly,
                 // mirroring `blackhole.py:120 self.registers_i[ord(code[pos])]`.
                 let frame = self.frames.current_mut();
-                let jdindex_byte = frame.next_u8();
+                let jdindex_byte = frame.next_reg();
                 let slot = jdindex_byte as usize;
                 let jdindex = frame.int_values.get(slot).copied().flatten().expect(
                     "BC_LOOP_HEADER (i form): jdindex register slot \
@@ -4858,13 +4858,13 @@ where
                     let mut arg_triples = Vec::with_capacity(num_args);
                     for _ in 0..num_args {
                         let kind = JitArgKind::decode(frame.next_u8());
-                        let caller_src = frame.next_u8() as usize;
-                        let callee_dst = frame.next_u8() as usize;
+                        let caller_src = frame.next_reg() as usize;
+                        let callee_dst = frame.next_reg() as usize;
                         arg_triples.push((kind, caller_src, callee_dst));
                     }
                     let decode_return_slot = |f: &mut MIFrame| {
-                        let dst = f.next_u8() as usize;
-                        if dst == u8::MAX as usize {
+                        let dst = f.next_reg() as usize;
+                        if dst == crate::jitcode::NO_RETURN_REG as usize {
                             None
                         } else {
                             Some(dst)
@@ -5005,7 +5005,7 @@ where
             // RPython `self.last_exc_value = lltype.nullptr(...)`).
             jitcode::insns::BC_INT_RETURN => {
                 self.clear_exception();
-                let src = self.frames.current_mut().next_u8() as usize;
+                let src = self.frames.current_mut().next_reg() as usize;
                 let (opref, concrete) = self.read_int_reg(src);
                 let target = self.frames.current_mut().return_i;
                 if target.is_none() {
@@ -5069,7 +5069,7 @@ where
             }
             jitcode::insns::BC_REF_RETURN => {
                 self.clear_exception();
-                let src = self.frames.current_mut().next_u8() as usize;
+                let src = self.frames.current_mut().next_reg() as usize;
                 let (opref, concrete) = self.read_ref_reg(src);
                 let target = self.frames.current_mut().return_r;
                 if target.is_none() {
@@ -5099,7 +5099,7 @@ where
             }
             jitcode::insns::BC_FLOAT_RETURN => {
                 self.clear_exception();
-                let src = self.frames.current_mut().next_u8() as usize;
+                let src = self.frames.current_mut().next_reg() as usize;
                 let (opref, concrete) = self.read_float_reg(src);
                 let target = self.frames.current_mut().return_f;
                 if target.is_none() {
@@ -5169,24 +5169,24 @@ where
 
                 let (target, args_i, args_r, args_f, calldescr) = {
                     let frame = self.frames.current_mut();
-                    let funcptr_reg = frame.next_u8() as u16;
+                    let funcptr_reg = frame.next_reg() as u16;
                     let mut args_i: Vec<JitCallArg> = Vec::new();
                     if has_int {
                         let count = frame.next_u8() as usize;
                         for _ in 0..count {
-                            args_i.push(JitCallArg::int(frame.next_u8() as u16));
+                            args_i.push(JitCallArg::int(frame.next_reg() as u16));
                         }
                     }
                     let mut args_r: Vec<JitCallArg> = Vec::new();
                     let count_r = frame.next_u8() as usize;
                     for _ in 0..count_r {
-                        args_r.push(JitCallArg::reference(frame.next_u8() as u16));
+                        args_r.push(JitCallArg::reference(frame.next_reg() as u16));
                     }
                     let mut args_f: Vec<JitCallArg> = Vec::new();
                     if has_float {
                         let count = frame.next_u8() as usize;
                         for _ in 0..count {
-                            args_f.push(JitCallArg::float(frame.next_u8() as u16));
+                            args_f.push(JitCallArg::float(frame.next_reg() as u16));
                         }
                     }
                     let calldescr_idx = frame.next_u16();
@@ -5488,28 +5488,28 @@ where
 
                 let (target, args_i, args_r, args_f, calldescr, dst) = {
                     let frame = self.frames.current_mut();
-                    let funcptr_reg = frame.next_u8() as u16;
+                    let funcptr_reg = frame.next_reg() as u16;
                     let mut args_i: Vec<JitCallArg> = Vec::new();
                     if has_int {
                         let count = frame.next_u8() as usize;
                         for _ in 0..count {
-                            args_i.push(JitCallArg::int(frame.next_u8() as u16));
+                            args_i.push(JitCallArg::int(frame.next_reg() as u16));
                         }
                     }
                     let mut args_r: Vec<JitCallArg> = Vec::new();
                     let count_r = frame.next_u8() as usize;
                     for _ in 0..count_r {
-                        args_r.push(JitCallArg::reference(frame.next_u8() as u16));
+                        args_r.push(JitCallArg::reference(frame.next_reg() as u16));
                     }
                     let mut args_f: Vec<JitCallArg> = Vec::new();
                     if has_float {
                         let count = frame.next_u8() as usize;
                         for _ in 0..count {
-                            args_f.push(JitCallArg::float(frame.next_u8() as u16));
+                            args_f.push(JitCallArg::float(frame.next_reg() as u16));
                         }
                     }
                     let calldescr_idx = frame.next_u16();
-                    let dst = frame.next_u8() as usize;
+                    let dst = frame.next_reg() as usize;
                     let calldescr = frame
                         .jitcode
                         .descr_at(calldescr_idx as usize)
@@ -5787,28 +5787,28 @@ where
 
                 let (target, args_i, args_r, args_f, calldescr, dst) = {
                     let frame = self.frames.current_mut();
-                    let funcptr_reg = frame.next_u8() as u16;
+                    let funcptr_reg = frame.next_reg() as u16;
                     let mut args_i: Vec<JitCallArg> = Vec::new();
                     if has_int {
                         let count = frame.next_u8() as usize;
                         for _ in 0..count {
-                            args_i.push(JitCallArg::int(frame.next_u8() as u16));
+                            args_i.push(JitCallArg::int(frame.next_reg() as u16));
                         }
                     }
                     let mut args_r: Vec<JitCallArg> = Vec::new();
                     let count_r = frame.next_u8() as usize;
                     for _ in 0..count_r {
-                        args_r.push(JitCallArg::reference(frame.next_u8() as u16));
+                        args_r.push(JitCallArg::reference(frame.next_reg() as u16));
                     }
                     let mut args_f: Vec<JitCallArg> = Vec::new();
                     if has_float {
                         let count = frame.next_u8() as usize;
                         for _ in 0..count {
-                            args_f.push(JitCallArg::float(frame.next_u8() as u16));
+                            args_f.push(JitCallArg::float(frame.next_reg() as u16));
                         }
                     }
                     let calldescr_idx = frame.next_u16();
-                    let dst = frame.next_u8() as usize;
+                    let dst = frame.next_reg() as usize;
                     let calldescr = frame
                         .jitcode
                         .descr_at(calldescr_idx as usize)
@@ -6040,24 +6040,24 @@ where
             jitcode::insns::BC_RESIDUAL_CALL_IRF_F => {
                 let (target, args_i, args_r, args_f, calldescr, dst) = {
                     let frame = self.frames.current_mut();
-                    let funcptr_reg = frame.next_u8() as u16;
+                    let funcptr_reg = frame.next_reg() as u16;
                     let mut args_i: Vec<JitCallArg> = Vec::new();
                     let count_i = frame.next_u8() as usize;
                     for _ in 0..count_i {
-                        args_i.push(JitCallArg::int(frame.next_u8() as u16));
+                        args_i.push(JitCallArg::int(frame.next_reg() as u16));
                     }
                     let mut args_r: Vec<JitCallArg> = Vec::new();
                     let count_r = frame.next_u8() as usize;
                     for _ in 0..count_r {
-                        args_r.push(JitCallArg::reference(frame.next_u8() as u16));
+                        args_r.push(JitCallArg::reference(frame.next_reg() as u16));
                     }
                     let mut args_f: Vec<JitCallArg> = Vec::new();
                     let count_f = frame.next_u8() as usize;
                     for _ in 0..count_f {
-                        args_f.push(JitCallArg::float(frame.next_u8() as u16));
+                        args_f.push(JitCallArg::float(frame.next_reg() as u16));
                     }
                     let calldescr_idx = frame.next_u16();
-                    let dst = frame.next_u8() as usize;
+                    let dst = frame.next_reg() as usize;
                     let calldescr = frame
                         .jitcode
                         .descr_at(calldescr_idx as usize)
@@ -6306,7 +6306,7 @@ where
                     let mut arg_regs = Vec::with_capacity(num_args);
                     for _ in 0..num_args {
                         let kind = JitArgKind::decode(frame.next_u8());
-                        let reg = frame.next_u8();
+                        let reg = frame.next_reg();
                         arg_regs.push(JitCallArg {
                             kind,
                             reg: reg as u16,
@@ -6384,13 +6384,13 @@ where
             | jitcode::insns::BC_RECORD_KNOWN_RESULT_REF => {
                 let (first_reg, fn_ptr_idx, arg_regs, dst) = {
                     let frame = self.frames.current_mut();
-                    let first_reg = frame.next_u8() as u16;
+                    let first_reg = frame.next_reg() as u16;
                     let fn_ptr_idx = frame.next_u16() as usize;
                     let num_args = frame.next_u8() as usize;
                     let mut arg_regs = Vec::with_capacity(num_args);
                     for _ in 0..num_args {
                         let kind = JitArgKind::decode(frame.next_u8());
-                        let reg = frame.next_u8();
+                        let reg = frame.next_reg();
                         arg_regs.push(JitCallArg {
                             kind,
                             reg: reg as u16,
@@ -6401,7 +6401,7 @@ where
                         jitcode::insns::BC_COND_CALL_VALUE_INT
                             | jitcode::insns::BC_COND_CALL_VALUE_REF
                     ) {
-                        Some(frame.next_u8() as u16)
+                        Some(frame.next_reg() as u16)
                     } else {
                         None
                     };
@@ -6522,7 +6522,7 @@ where
             jitcode::insns::BC_MOVE_I => {
                 let (src, dst) = {
                     let frame = self.frames.current_mut();
-                    (frame.next_u8() as usize, frame.next_u8() as usize)
+                    (frame.next_reg() as usize, frame.next_reg() as usize)
                 };
                 let (value, concrete) = self.read_int_reg(src);
                 self.set_int_reg(dst, Some(value), Some(concrete));
@@ -6534,7 +6534,7 @@ where
             jitcode::insns::BC_MOVE_I_C => {
                 let (value, dst) = {
                     let frame = self.frames.current_mut();
-                    (frame.next_u8() as i8 as i64, frame.next_u8() as usize)
+                    (frame.next_u8() as i8 as i64, frame.next_reg() as usize)
                 };
                 self.set_int_reg(dst, Some(OpRef::ConstInt(value)), Some(value));
             }
@@ -6550,12 +6550,12 @@ where
                 let (fn_ptr_idx, dst, arg_regs) = {
                     let frame = self.frames.current_mut();
                     let fn_ptr_idx = frame.next_u16() as usize;
-                    let dst = frame.next_u8() as usize;
+                    let dst = frame.next_reg() as usize;
                     let num_args = frame.next_u16() as usize;
                     let mut arg_regs = Vec::with_capacity(num_args);
                     for _ in 0..num_args {
                         let kind = JitArgKind::decode(frame.next_u8());
-                        let reg = frame.next_u8();
+                        let reg = frame.next_reg();
                         arg_regs.push(JitCallArg {
                             kind,
                             reg: reg as u16,
@@ -6610,7 +6610,7 @@ where
             jitcode::insns::BC_MOVE_R => {
                 let (src, dst) = {
                     let frame = self.frames.current_mut();
-                    (frame.next_u8() as usize, frame.next_u8() as usize)
+                    (frame.next_reg() as usize, frame.next_reg() as usize)
                 };
                 let (value, concrete) = self.read_ref_reg(src);
                 self.set_ref_reg(dst, Some(value), Some(concrete));
@@ -6623,12 +6623,12 @@ where
                 let (fn_ptr_idx, dst, arg_regs) = {
                     let frame = self.frames.current_mut();
                     let fn_ptr_idx = frame.next_u16() as usize;
-                    let dst = frame.next_u8() as usize;
+                    let dst = frame.next_reg() as usize;
                     let num_args = frame.next_u16() as usize;
                     let mut arg_regs = Vec::with_capacity(num_args);
                     for _ in 0..num_args {
                         let kind = JitArgKind::decode(frame.next_u8());
-                        let reg = frame.next_u8();
+                        let reg = frame.next_reg();
                         arg_regs.push(JitCallArg {
                             kind,
                             reg: reg as u16,
@@ -6683,7 +6683,7 @@ where
             jitcode::insns::BC_MOVE_F => {
                 let (src, dst) = {
                     let frame = self.frames.current_mut();
-                    (frame.next_u8() as usize, frame.next_u8() as usize)
+                    (frame.next_reg() as usize, frame.next_reg() as usize)
                 };
                 let (value, concrete) = self.read_float_reg(src);
                 self.set_float_reg(dst, Some(value), Some(concrete));
@@ -6696,12 +6696,12 @@ where
                 let (fn_ptr_idx, dst, arg_regs) = {
                     let frame = self.frames.current_mut();
                     let fn_ptr_idx = frame.next_u16() as usize;
-                    let dst = frame.next_u8() as usize;
+                    let dst = frame.next_reg() as usize;
                     let num_args = frame.next_u16() as usize;
                     let mut arg_regs = Vec::with_capacity(num_args);
                     for _ in 0..num_args {
                         let kind = JitArgKind::decode(frame.next_u8());
-                        let reg = frame.next_u8();
+                        let reg = frame.next_reg();
                         arg_regs.push(JitCallArg {
                             kind,
                             reg: reg as u16,
@@ -6774,7 +6774,7 @@ where
                 let (src, opcode_pc) = {
                     let frame = self.frames.current_mut();
                     let opcode_pc = frame.code_cursor - 1;
-                    (frame.next_u8() as usize, opcode_pc)
+                    (frame.next_reg() as usize, opcode_pc)
                 };
                 let (opref, concrete) = self.read_int_reg(src);
                 let const_ref = ctx.const_int(concrete);
@@ -6795,7 +6795,7 @@ where
             // `heap_cache.is_nullity_known` + bumps `HEAPCACHED_OPS`
             // on cache hit per pyjitpl.py:387-388.
             jitcode::insns::BC_ASSERT_NOT_NONE => {
-                let src = self.frames.current_mut().next_u8() as usize;
+                let src = self.frames.current_mut().next_reg() as usize;
                 let (opref, concrete) = self.read_ref_reg(src);
                 ctx.trace_assert_not_none(opref, concrete);
             }
@@ -6808,8 +6808,8 @@ where
             // blackhole.py:616 `@arguments("r", "i")` and remains the
             // ConstInt vtable address that RPython passes as `clsbox`.
             jitcode::insns::BC_RECORD_EXACT_CLASS => {
-                let src = self.frames.current_mut().next_u8() as usize;
-                let cls = self.frames.current_mut().next_u8() as usize;
+                let src = self.frames.current_mut().next_reg() as usize;
+                let cls = self.frames.current_mut().next_reg() as usize;
                 let (box_opref, _) = self.read_ref_reg(src);
                 let (cls_opref, _) = self.read_int_reg(cls);
                 ctx.trace_record_exact_class(box_opref, cls_opref);
@@ -6819,7 +6819,7 @@ where
                 let (src, opcode_pc) = {
                     let frame = self.frames.current_mut();
                     let opcode_pc = frame.code_cursor - 1;
-                    (frame.next_u8() as usize, opcode_pc)
+                    (frame.next_reg() as usize, opcode_pc)
                 };
                 let (opref, concrete) = self.read_ref_reg(src);
                 let const_ref = ctx.const_ref(concrete);
@@ -6838,7 +6838,7 @@ where
                 let (src, opcode_pc) = {
                     let frame = self.frames.current_mut();
                     let opcode_pc = frame.code_cursor - 1;
-                    (frame.next_u8() as usize, opcode_pc)
+                    (frame.next_reg() as usize, opcode_pc)
                 };
                 let (opref, concrete) = self.read_float_reg(src);
                 let const_ref = ctx.const_float(concrete);
@@ -6871,7 +6871,7 @@ where
                 // of opimpl_raise itself — what `generate_guard(...,
                 // resumepc=orgpc)` records.
                 let opcode_pc = self.frames.current_mut().code_cursor - 1;
-                let src = self.frames.current_mut().next_u8() as usize;
+                let src = self.frames.current_mut().next_reg() as usize;
                 let (opref, concrete) = self.read_ref_reg(src);
                 if concrete == 0 {
                     return TraceAction::Abort;
@@ -6976,14 +6976,14 @@ where
                 let count = frame.next_u8() as usize;
                 let mut regs = Vec::with_capacity(count);
                 for _ in 0..count {
-                    regs.push(frame.next_u8() as usize);
+                    regs.push(frame.next_reg() as usize);
                 }
                 regs
             };
             let args_i = has_i_list.then(|| read_list(frame)).unwrap_or_default();
             let args_r = read_list(frame);
             let args_f = has_f_list.then(|| read_list(frame)).unwrap_or_default();
-            let result_dst = return_kind.map(|_| frame.next_u8() as usize);
+            let result_dst = return_kind.map(|_| frame.next_reg() as usize);
             frame._result_argcode = match return_kind {
                 Some(JitArgKind::Int) => b'i',
                 Some(JitArgKind::Ref) => b'r',
@@ -7224,9 +7224,9 @@ where
         // `bhhandler_ii_i!` blackhole decoder.
         let (lhs_idx, rhs_idx, dst) = {
             let frame = self.frames.current_mut();
-            let lhs_idx = frame.next_u8() as usize;
-            let rhs_idx = frame.next_u8() as usize;
-            let dst = frame.next_u8() as usize;
+            let lhs_idx = frame.next_reg() as usize;
+            let rhs_idx = frame.next_reg() as usize;
+            let dst = frame.next_reg() as usize;
             (lhs_idx, rhs_idx, dst)
         };
         let (lhs, lhs_value) = self.read_int_reg(lhs_idx);
@@ -7261,8 +7261,8 @@ where
         // `code[position+1]=dst`).
         let (src_idx, dst) = {
             let frame = self.frames.current_mut();
-            let src_idx = frame.next_u8() as usize;
-            let dst = frame.next_u8() as usize;
+            let src_idx = frame.next_reg() as usize;
+            let dst = frame.next_reg() as usize;
             (src_idx, dst)
         };
         let (src, src_value) = self.read_int_reg(src_idx);
@@ -7283,9 +7283,9 @@ where
     fn trace_binop_r_to_i(&mut self, ctx: &mut TraceCtx, opcode: OpCode) {
         let (lhs_idx, rhs_idx, dst) = {
             let frame = self.frames.current_mut();
-            let lhs_idx = frame.next_u8() as usize;
-            let rhs_idx = frame.next_u8() as usize;
-            let dst = frame.next_u8() as usize;
+            let lhs_idx = frame.next_reg() as usize;
+            let rhs_idx = frame.next_reg() as usize;
+            let dst = frame.next_reg() as usize;
             (lhs_idx, rhs_idx, dst)
         };
         let (lhs, lhs_value) = self.read_ref_reg(lhs_idx);
@@ -7312,8 +7312,8 @@ where
     fn trace_ptr_nullity(&mut self, ctx: &mut TraceCtx, nonzero: bool) {
         let (src_idx, dst) = {
             let frame = self.frames.current_mut();
-            let src_idx = frame.next_u8() as usize;
-            let dst = frame.next_u8() as usize;
+            let src_idx = frame.next_reg() as usize;
+            let dst = frame.next_reg() as usize;
             (src_idx, dst)
         };
         let (src, src_value) = self.read_ref_reg(src_idx);
@@ -7339,9 +7339,9 @@ where
     fn trace_binop_f(&mut self, ctx: &mut TraceCtx, opcode: OpCode) {
         let (lhs_idx, rhs_idx, dst) = {
             let frame = self.frames.current_mut();
-            let lhs_idx = frame.next_u8() as usize;
-            let rhs_idx = frame.next_u8() as usize;
-            let dst = frame.next_u8() as usize;
+            let lhs_idx = frame.next_reg() as usize;
+            let rhs_idx = frame.next_reg() as usize;
+            let dst = frame.next_reg() as usize;
             (lhs_idx, rhs_idx, dst)
         };
         let (lhs, lhs_value) = self.read_float_reg(lhs_idx);
@@ -7357,8 +7357,8 @@ where
         // `bhhandler_f_f!` blackhole decoder.
         let (src_idx, dst) = {
             let frame = self.frames.current_mut();
-            let src_idx = frame.next_u8() as usize;
-            let dst = frame.next_u8() as usize;
+            let src_idx = frame.next_reg() as usize;
+            let dst = frame.next_reg() as usize;
             (src_idx, dst)
         };
         let (src, src_value) = self.read_float_reg(src_idx);

--- a/majit/majit-metainterp/src/pyjitpl/dispatch.rs
+++ b/majit/majit-metainterp/src/pyjitpl/dispatch.rs
@@ -2139,9 +2139,9 @@ where
     ///
     /// Payload (little-endian, emitted by
     /// `JitCodeBuilder::recursive_call_int` and siblings):
-    ///   jd_index:u16, result_dst:u16 (`u16::MAX` = no result / void),
-    ///   num_green:u16, (green_kind:u8, green_src:u16) × num_green,
-    ///   num_args:u16, (kind:u8, caller_src:u16, callee_dst:u16) × num_args.
+    ///   jd_index:u16, result_dst:u8 (`u8::MAX` = no result / void),
+    ///   num_green:u16, (green_kind:u8, green_src:u8) × num_green,
+    ///   num_args:u16, (kind:u8, caller_src:u8, callee_dst:u8) × num_args.
     ///
     /// `result_kind` is `Some(Int/Ref/Float)` for the typed opcodes and
     /// `None` for the void opcode.  The green register sources carry the
@@ -2175,8 +2175,8 @@ where
         let (jd_index, result_dst, green_srcs, arg_triples) = {
             let frame = self.frames.current_mut();
             let jd_index = frame.next_u16() as usize;
-            let result_dst_raw = frame.next_u16() as usize;
-            let result_dst = if result_dst_raw == u16::MAX as usize {
+            let result_dst_raw = frame.next_u8() as usize;
+            let result_dst = if result_dst_raw == u8::MAX as usize {
                 None
             } else {
                 Some(result_dst_raw)
@@ -2185,15 +2185,15 @@ where
             let mut green_srcs = Vec::with_capacity(num_green);
             for _ in 0..num_green {
                 let kind = JitArgKind::decode(frame.next_u8());
-                let src = frame.next_u16() as usize;
+                let src = frame.next_u8() as usize;
                 green_srcs.push((kind, src));
             }
             let num_args = frame.next_u16() as usize;
             let mut arg_triples = Vec::with_capacity(num_args);
             for _ in 0..num_args {
                 let kind = JitArgKind::decode(frame.next_u8());
-                let caller_src = frame.next_u16() as usize;
-                let callee_dst = frame.next_u16() as usize;
+                let caller_src = frame.next_u8() as usize;
+                let callee_dst = frame.next_u8() as usize;
                 arg_triples.push((kind, caller_src, callee_dst));
             }
             // Caller-side result-slot bookkeeping (BC_INLINE_CALL:3298-3300).
@@ -4858,13 +4858,13 @@ where
                     let mut arg_triples = Vec::with_capacity(num_args);
                     for _ in 0..num_args {
                         let kind = JitArgKind::decode(frame.next_u8());
-                        let caller_src = frame.next_u16() as usize;
-                        let callee_dst = frame.next_u16() as usize;
+                        let caller_src = frame.next_u8() as usize;
+                        let callee_dst = frame.next_u8() as usize;
                         arg_triples.push((kind, caller_src, callee_dst));
                     }
                     let decode_return_slot = |f: &mut MIFrame| {
-                        let dst = f.next_u16() as usize;
-                        if dst == u16::MAX as usize {
+                        let dst = f.next_u8() as usize;
+                        if dst == u8::MAX as usize {
                             None
                         } else {
                             Some(dst)
@@ -4999,9 +4999,6 @@ where
             //     TraceAction::Finish so the outer `finish_and_compile`
             //     (jitdriver.rs::merge_point) drives the compile path —
             //     same precedent as the exception unwind at :935-942.
-            //
-            // Operand width: typed-return src is u16 (assembler.rs:1341
-            // `push_reg_u16`; blackhole.rs:2243 `next_u16`), not u8.
             //
             // last_exc_value clearing mirrors pyjitpl.py:2481 finishframe
             // (Pyre `clear_exception` is the JitCodeMachine equivalent of
@@ -6284,8 +6281,8 @@ where
                     }
                 }
             }
-            // BC_CALL_ASSEMBLER_VOID retains the legacy `(fn_ptr_idx:u16,
-            // num_args:u16, [(kind:u8, reg:u16)]...)` layout — the
+            // BC_CALL_ASSEMBLER_VOID uses `(fn_ptr_idx:u16,
+            // num_args:u16, [(kind:u8, reg:u8)]...)` — the
             // assembler-token path is not in the canonical *_v family
             // and of pyre-call-family-canonical-migration.md
             // owns its migration.
@@ -6309,8 +6306,11 @@ where
                     let mut arg_regs = Vec::with_capacity(num_args);
                     for _ in 0..num_args {
                         let kind = JitArgKind::decode(frame.next_u8());
-                        let reg = frame.next_u16();
-                        arg_regs.push(JitCallArg { kind, reg });
+                        let reg = frame.next_u8();
+                        arg_regs.push(JitCallArg {
+                            kind,
+                            reg: reg as u16,
+                        });
                     }
                     (fn_ptr_idx, arg_regs)
                 };
@@ -6384,21 +6384,24 @@ where
             | jitcode::insns::BC_RECORD_KNOWN_RESULT_REF => {
                 let (first_reg, fn_ptr_idx, arg_regs, dst) = {
                     let frame = self.frames.current_mut();
-                    let first_reg = frame.next_u16();
+                    let first_reg = frame.next_u8() as u16;
                     let fn_ptr_idx = frame.next_u16() as usize;
                     let num_args = frame.next_u8() as usize;
                     let mut arg_regs = Vec::with_capacity(num_args);
                     for _ in 0..num_args {
                         let kind = JitArgKind::decode(frame.next_u8());
-                        let reg = frame.next_u16();
-                        arg_regs.push(JitCallArg { kind, reg });
+                        let reg = frame.next_u8();
+                        arg_regs.push(JitCallArg {
+                            kind,
+                            reg: reg as u16,
+                        });
                     }
                     let dst = if matches!(
                         bytecode,
                         jitcode::insns::BC_COND_CALL_VALUE_INT
                             | jitcode::insns::BC_COND_CALL_VALUE_REF
                     ) {
-                        Some(frame.next_u16())
+                        Some(frame.next_u8() as u16)
                     } else {
                         None
                     };
@@ -6547,13 +6550,16 @@ where
                 let (fn_ptr_idx, dst, arg_regs) = {
                     let frame = self.frames.current_mut();
                     let fn_ptr_idx = frame.next_u16() as usize;
-                    let dst = frame.next_u16() as usize;
+                    let dst = frame.next_u8() as usize;
                     let num_args = frame.next_u16() as usize;
                     let mut arg_regs = Vec::with_capacity(num_args);
                     for _ in 0..num_args {
                         let kind = JitArgKind::decode(frame.next_u8());
-                        let reg = frame.next_u16();
-                        arg_regs.push(JitCallArg { kind, reg });
+                        let reg = frame.next_u8();
+                        arg_regs.push(JitCallArg {
+                            kind,
+                            reg: reg as u16,
+                        });
                     }
                     (fn_ptr_idx, dst, arg_regs)
                 };
@@ -6617,13 +6623,16 @@ where
                 let (fn_ptr_idx, dst, arg_regs) = {
                     let frame = self.frames.current_mut();
                     let fn_ptr_idx = frame.next_u16() as usize;
-                    let dst = frame.next_u16() as usize;
+                    let dst = frame.next_u8() as usize;
                     let num_args = frame.next_u16() as usize;
                     let mut arg_regs = Vec::with_capacity(num_args);
                     for _ in 0..num_args {
                         let kind = JitArgKind::decode(frame.next_u8());
-                        let reg = frame.next_u16();
-                        arg_regs.push(JitCallArg { kind, reg });
+                        let reg = frame.next_u8();
+                        arg_regs.push(JitCallArg {
+                            kind,
+                            reg: reg as u16,
+                        });
                     }
                     (fn_ptr_idx, dst, arg_regs)
                 };
@@ -6687,13 +6696,16 @@ where
                 let (fn_ptr_idx, dst, arg_regs) = {
                     let frame = self.frames.current_mut();
                     let fn_ptr_idx = frame.next_u16() as usize;
-                    let dst = frame.next_u16() as usize;
+                    let dst = frame.next_u8() as usize;
                     let num_args = frame.next_u16() as usize;
                     let mut arg_regs = Vec::with_capacity(num_args);
                     for _ in 0..num_args {
                         let kind = JitArgKind::decode(frame.next_u8());
-                        let reg = frame.next_u16();
-                        arg_regs.push(JitCallArg { kind, reg });
+                        let reg = frame.next_u8();
+                        arg_regs.push(JitCallArg {
+                            kind,
+                            reg: reg as u16,
+                        });
                     }
                     (fn_ptr_idx, dst, arg_regs)
                 };

--- a/majit/majit-metainterp/src/pyjitpl/frame.rs
+++ b/majit/majit-metainterp/src/pyjitpl/frame.rs
@@ -232,6 +232,13 @@ impl MIFrame {
         read_u8(&self.jitcode.code, &mut self.code_cursor)
     }
 
+    /// Read one register operand ([`crate::jitcode::JitcodeReg`]); register
+    /// operands are always one byte. Use this at register reads instead of
+    /// `next_u8` so the 1-byte register width stays enforced in one place.
+    pub fn next_reg(&mut self) -> crate::jitcode::JitcodeReg {
+        self.next_u8()
+    }
+
     pub fn next_u16(&mut self) -> u16 {
         read_u16(&self.jitcode.code, &mut self.code_cursor)
     }

--- a/pyre/pyre-jit-trace/src/jitcode_runtime.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_runtime.rs
@@ -617,46 +617,46 @@ pub struct DecodedOp {
 ///
 /// | opname                              | producer (`assembler.rs`)             | payload bytes |
 /// |-------------------------------------|---------------------------------------|---------------|
-/// | `inline_call_pyre_nested`           | `:nested_inline_call_*_typed_args`    | `4 + num_args*5 + 6`  (`sub_idx u16 + num_args u16 + num_args × (kind u8, caller_src u16, callee_dst u16) + return_i u16 + return_r u16 + return_f u16`) |
-/// | `call_assembler_int_pyre`           | `:3429 call_assembler_int_like`       | `6 + num_args*3`  (`target_idx u16 + dst u16 + num_args u16 + num_args × (kind u8, reg u16)`) |
+/// | `inline_call_pyre_nested`           | `:nested_inline_call_*_typed_args`    | `4 + num_args*3 + 3`  (`sub_idx u16 + num_args u16 + num_args × (kind u8, caller_src u8, callee_dst u8) + return_i u8 + return_r u8 + return_f u8`) |
+/// | `call_assembler_int_pyre`           | `:3429 call_assembler_int_like`       | `5 + num_args*2`  (`target_idx u16 + dst u8 + num_args u16 + num_args × (kind u8, reg u8)`) |
 /// | `call_assembler_ref_pyre`           | `:3451 call_assembler_ref_like`       | same as int |
 /// | `call_assembler_float_pyre`         | `:3489 call_assembler_float_like`     | same as int |
-/// | `call_assembler_void_pyre`          | `:3370 call_assembler_void_like`      | `4 + num_args*3`  (omits `dst u16`) |
-/// | `cond_call_void_pyre`               | `:2642 call_cond_like`                | `5 + arg_count*3`  (`first_reg u16 + fn_ptr_idx u16 + arg_count u8 + arg_count × (kind u8) + arg_count × (reg u16)`) |
+/// | `call_assembler_void_pyre`          | `:3370 call_assembler_void_like`      | `4 + num_args*2`  (omits `dst u8`) |
+/// | `cond_call_void_pyre`               | `:2642 call_cond_like`                | `4 + arg_count*2`  (`first_reg u8 + fn_ptr_idx u16 + arg_count u8 + arg_count × (kind u8) + arg_count × (reg u8)`) |
 /// | `record_known_result_int_pyre`      | `:2618 call_cond_like`                | same as cond_call |
 /// | `record_known_result_ref_pyre`      | `:2630 call_cond_like`                | same as cond_call |
-/// | `cond_call_value_int_pyre`          | `:2660 call_cond_value_like`          | `7 + arg_count*3`  (cond_call layout + trailing `dst u16`) |
+/// | `cond_call_value_int_pyre`          | `:2660 call_cond_value_like`          | `5 + arg_count*2`  (cond_call layout + trailing `dst u8`) |
 /// | `cond_call_value_ref_pyre`          | `:2660 call_cond_value_like`          | same as int variant |
 fn pyre_p_payload_len(opname: &str, code: &[u8], cursor: usize) -> Option<usize> {
     match opname {
         "inline_call_pyre_nested" => {
             // sub_idx u16 + num_args u16 + num_args × (kind u8, caller_src
-            // u16, callee_dst u16) + return_i u16 + return_r u16 + return_f u16
+            // u8, callee_dst u8) + return_i u8 + return_r u8 + return_f u8
             let num_args =
                 u16::from_le_bytes([*code.get(cursor + 2)?, *code.get(cursor + 3)?]) as usize;
-            Some(4 + num_args * 5 + 6)
+            Some(4 + num_args * 3 + 3)
         }
         "call_assembler_int_pyre" | "call_assembler_ref_pyre" | "call_assembler_float_pyre" => {
-            // target_idx u16 + dst u16 + num_args u16 + num_args × (kind u8, reg u16)
+            // target_idx u16 + dst u8 + num_args u16 + num_args × (kind u8, reg u8)
             let num_args =
-                u16::from_le_bytes([*code.get(cursor + 4)?, *code.get(cursor + 5)?]) as usize;
-            Some(6 + num_args * 3)
+                u16::from_le_bytes([*code.get(cursor + 3)?, *code.get(cursor + 4)?]) as usize;
+            Some(5 + num_args * 2)
         }
         "call_assembler_void_pyre" => {
-            // target_idx u16 + num_args u16 + num_args × (kind u8, reg u16)
+            // target_idx u16 + num_args u16 + num_args × (kind u8, reg u8)
             let num_args =
                 u16::from_le_bytes([*code.get(cursor + 2)?, *code.get(cursor + 3)?]) as usize;
-            Some(4 + num_args * 3)
+            Some(4 + num_args * 2)
         }
         "cond_call_void_pyre" | "record_known_result_int_pyre" | "record_known_result_ref_pyre" => {
-            // first_reg u16 + fn_ptr_idx u16 + arg_count u8 + arg_count × (kind u8) + arg_count × (reg u16)
-            let arg_count = *code.get(cursor + 4)? as usize;
-            Some(5 + arg_count * 3)
+            // first_reg u8 + fn_ptr_idx u16 + arg_count u8 + arg_count × (kind u8) + arg_count × (reg u8)
+            let arg_count = *code.get(cursor + 3)? as usize;
+            Some(4 + arg_count * 2)
         }
         "cond_call_value_int_pyre" | "cond_call_value_ref_pyre" => {
-            // cond_call shape + trailing dst u16
-            let arg_count = *code.get(cursor + 4)? as usize;
-            Some(7 + arg_count * 3)
+            // cond_call shape + trailing dst u8
+            let arg_count = *code.get(cursor + 3)? as usize;
+            Some(5 + arg_count * 2)
         }
         _ => None,
     }


### PR DESCRIPTION
## What

The `/P` payload family (`inline_call_pyre_nested`, `call_assembler_*_pyre`,
`cond_call_*` / `record_known_result_*_pyre`) and the recursive-call payload
were the last opcodes that still encoded their **register** operands as `u16`.
Every other opcode already follows the canonical 1-byte register contract
(`assembler.py:74` `chr(reg.index)`, `blackhole.py:107` `ord(code[position])`).
This narrows those remaining families to the canonical 1-byte encoding so the
whole jitcode register stream is uniform.

## Change

- **Encoder** (`JitCodeBuilder`, `jitcode/assembler.rs`): the six emit families
  (`recursive_call_{int,ref,float,void}`, `inline_call`, `cond_call`/`_value`,
  `call_int`/`call_assembler`) switch `push_u16` → `push_reg_u8` for register
  operands. The remaining `push_u16` sites are `field_idx`/`array_idx`/`descr`
  only — which stay `u16` upstream too.
- **Decoders flipped in lockstep** (three surfaces): the `pyre_p_payload_len`
  layout table (`jitcode_runtime.rs`), the `JitCodeMachine` payload reads
  (`pyjitpl/dispatch.rs`), and the blackhole `/P` handlers + `read_call_args`
  (`blackhole.rs`).
- **Sentinel** `u16::MAX` ("no return slot") → `u8::MAX`. Safe because
  `try_assemble` declines any jitcode with `num_regs >= 256`, so every valid
  register index is `<= 254`.
- **Dead code removed**: `bh_binop_i` / `bh_binop_r_to_i` / `bh_binop_f` /
  `bh_ptr_nullity` (no callers). Stale `pyre-u16` comments refreshed.
- `call_result_reg`'s backward walk was audited: it assumes only the canonical
  residual-call and `setfield_vable_i` widths, both untouched — no change needed.

## Why it fits without a register allocator

Register demand (`co_nlocals + co_stacksize` + the fixed portal registers) was
censused over the `pypy` + `rpython` + `bench` + `extra_tests` corpus
(66,028 code objects): p50=6, p99=24, p99.9=38, p100≈106. Nothing approaches
the 244 headroom, so the existing direct slot mapping fits `u8` for every real
code object with no graph-coloring compression prerequisite; the pre-existing
`num_regs >= 256` decline never fires in practice.

## Verification

- `cargo test --all --features dynasm` — green.
- `check.py` cranelift 297/297; dynasm 296/297 — the sole miss is `nested_loop`
  at its chronic x2 perf boundary (quiet re-measure ~1.9x, under the gate).
  Register-operand width cannot reach compiled-loop IR, so it is unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
