### PR TITLE
jit: instruction-keyed, per-frame, and loop-close exception traceback recording

### DIFF
--- a/majit/majit-metainterp/src/blackhole.rs
+++ b/majit/majit-metainterp/src/blackhole.rs
@@ -260,12 +260,7 @@ pub struct BlackholeInterpreter {
     /// an exception-table handler is entered.  The generic blackhole carries
     /// only raw frame/exception references; portal integrations install the
     /// callback that understands their frame and JitCode-PC layouts.
-    pub record_caught_exception: Option<extern "C" fn(i64, i64, i32, i32)>,
-    /// Exception most recently delivered to an in-frame handler.  If that same
-    /// object later leaves through the handler cleanup's `reraise`, its frame
-    /// traceback was already recorded on handler entry and must not be added a
-    /// second time at the bottommost blackhole exit.
-    pub last_caught_exception_value: i64,
+    pub record_caught_exception: Option<extern "C" fn(i64, i64, i64, i64)>,
     /// blackhole.py bhimpl_getfield_vable_*: pointer to the virtualizable
     /// object (e.g. PyFrame). Used by jitcode::BC_GETFIELD_VABLE_* bytecodes.
     /// Set during blackhole setup from the guard failure's virtualizable ptr.
@@ -353,7 +348,6 @@ impl Default for BlackholeInterpreter {
             last_opcode_position: 0,
             exception_last_value: 0,
             record_caught_exception: None,
-            last_caught_exception_value: 0,
             virtualizable_ptr: 0,
             virtualizable_info: std::ptr::null(),
             jitdrivers_sd: Vec::new(),
@@ -371,7 +365,6 @@ impl BlackholeInterpreter {
         self.got_exception = false;
         self.last_opcode_position = position;
         self.exception_last_value = 0;
-        self.last_caught_exception_value = 0;
     }
 
     fn init_register_file_from_i64s(
@@ -1169,16 +1162,20 @@ impl BlackholeInterpreter {
             return false;
         }
         let target = (code[catch_pos + 1] as usize) | ((code[catch_pos + 2] as usize) << 8);
-        if let Some(record) = self.record_caught_exception {
+        // pyopcode.py raise_varargs records the raising instruction before
+        // handler lookup; RaiseWithExplicitTraceback skips it for bare
+        // reraise.
+        if self.jitcode.code[self.last_opcode_position] != jitcode::insns::BC_RERAISE
+            && let Some(record) = self.record_caught_exception
+        {
             record(
                 exc_value,
                 self.virtualizable_ptr,
-                self.jitcode.try_index().map_or(-1, |index| index as i32),
-                self.last_opcode_position as i32,
+                self.jitcode.try_index().map_or(-1, |index| index as i64),
+                self.last_opcode_position as i64,
             );
         }
         self.exception_last_value = exc_value;
-        self.last_caught_exception_value = exc_value;
         self.position = target;
         BH_LAST_EXC_VALUE.with(|c| c.set(0));
         // A residual `bh_call` that raised published the exception into BOTH

--- a/majit/majit-metainterp/src/lib.rs
+++ b/majit/majit-metainterp/src/lib.rs
@@ -146,10 +146,11 @@ pub use pyjitpl::{
     JitCodeSym, JitHooks, JitStats, MIFrame, MIFrameStack, MetaInterp, MetaInterpGlobalData,
     MetaInterpStaticData, RawCompileResult, StandaloneFrameStack, build_state_field_snapshot,
     call_int_function, call_ref_function, call_void_function, counters,
-    record_application_traceback_for_recording, record_inline_application_traceback_for_recording,
-    set_record_application_traceback_hook, set_record_inline_application_traceback_hook,
-    struct_fields_write_effect_info, trace_jitcode, trace_jitcode_from_merge_point,
-    trace_jitcode_with_args, trace_jitcode_with_args_and_runtime,
+    record_application_traceback_for_recording, record_application_traceback_hook_address,
+    record_inline_application_traceback_for_recording,
+    record_inline_application_traceback_hook_address, set_record_application_traceback_hook,
+    set_record_inline_application_traceback_hook, struct_fields_write_effect_info, trace_jitcode,
+    trace_jitcode_from_merge_point, trace_jitcode_with_args, trace_jitcode_with_args_and_runtime,
 };
 pub use quasiimmut::QuasiImmut;
 pub use trace_ctx::BridgeInlineCarrier;

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -1512,8 +1512,8 @@ pub struct JitHooks {
 /// metainterpreter is executing the one-shot recording iteration.  The host
 /// owns the application frame and the jitcode-to-source-position mapping, so
 /// majit keeps only this crate-neutral ABI hook.
-pub type RecordApplicationTraceback = extern "C" fn(i64, i64, i32, i32);
-pub type RecordInlineApplicationTraceback = extern "C" fn(i64, i64, i64, i32, i32);
+pub type RecordApplicationTraceback = extern "C" fn(i64, i64, i64, i64);
+pub type RecordInlineApplicationTraceback = extern "C" fn(i64, i64, i64, i64, i64);
 
 static RECORD_APPLICATION_TRACEBACK: std::sync::atomic::AtomicUsize =
     std::sync::atomic::AtomicUsize::new(0);
@@ -1534,6 +1534,14 @@ pub fn set_record_inline_application_traceback_hook(
         hook.map_or(0, |callback| callback as usize),
         std::sync::atomic::Ordering::Release,
     );
+}
+
+pub fn record_application_traceback_hook_address() -> *const () {
+    RECORD_APPLICATION_TRACEBACK.load(std::sync::atomic::Ordering::Acquire) as *const ()
+}
+
+pub fn record_inline_application_traceback_hook_address() -> *const () {
+    RECORD_INLINE_APPLICATION_TRACEBACK.load(std::sync::atomic::Ordering::Acquire) as *const ()
 }
 
 fn record_application_traceback(exc_value: i64, frame_ptr: *const u8, frame: &MIFrame) {
@@ -1566,7 +1574,12 @@ pub fn record_application_traceback_for_recording(
     // Safety: the only stored values come from a RecordApplicationTraceback
     // function pointer in set_record_application_traceback_hook.
     let callback: RecordApplicationTraceback = unsafe { std::mem::transmute(callback) };
-    callback(exc_value, frame_ptr, jitcode_index, opcode_position);
+    callback(
+        exc_value,
+        frame_ptr,
+        i64::from(jitcode_index),
+        i64::from(opcode_position),
+    );
 }
 
 /// Invoke the host callback for an inlined recording frame represented by its
@@ -1588,7 +1601,13 @@ pub fn record_inline_application_traceback_for_recording(
     // Safety: the only stored values come from a
     // RecordInlineApplicationTraceback function pointer.
     let callback: RecordInlineApplicationTraceback = unsafe { std::mem::transmute(callback) };
-    callback(exc_value, w_code, w_globals, jitcode_index, opcode_position);
+    callback(
+        exc_value,
+        w_code,
+        w_globals,
+        i64::from(jitcode_index),
+        i64::from(opcode_position),
+    );
 }
 
 /// framework.py `root_walker.walk_roots` per-op helper: visit every
@@ -12521,16 +12540,16 @@ impl<M: Clone> MetaInterp<M> {
             }
             if handled {
                 let frame = self.framestack.current_mut();
-                record_application_traceback(excvalue, self.vable_ptr, frame);
-                frame.last_caught_exception_value = excvalue;
-                // pyjitpl.py:2522: raise ChangeFrame
+                if frame.jitcode.code[frame.last_opcode_position]
+                    != crate::jitcode::insns::BC_RERAISE
+                {
+                    record_application_traceback(excvalue, self.vable_ptr, frame);
+                }
                 return Err(FinishframeExceptionSignal::ChangeFrame);
             }
             {
                 let frame = self.framestack.current_mut();
-                if frame.last_caught_exception_value != excvalue {
-                    record_application_traceback(excvalue, self.vable_ptr, frame);
-                }
+                record_application_traceback(excvalue, self.vable_ptr, frame);
             }
             self.popframe(true);
         }

--- a/majit/majit-metainterp/src/pyjitpl/dispatch.rs
+++ b/majit/majit-metainterp/src/pyjitpl/dispatch.rs
@@ -1720,23 +1720,22 @@ where
             }
             if handled {
                 let frame = self.frames.current_mut();
-                super::record_application_traceback(
-                    self.last_exception_value,
-                    ctx.virtualizable_heap_ptr().unwrap_or(std::ptr::null()),
-                    frame,
-                );
-                frame.last_caught_exception_value = self.last_exception_value;
-                return TraceAction::Continue;
-            }
-            {
-                let frame = self.frames.current_mut();
-                if frame.last_caught_exception_value != self.last_exception_value {
+                if frame.jitcode.code[frame.last_opcode_position] != jitcode::insns::BC_RERAISE {
                     super::record_application_traceback(
                         self.last_exception_value,
                         ctx.virtualizable_heap_ptr().unwrap_or(std::ptr::null()),
                         frame,
                     );
                 }
+                return TraceAction::Continue;
+            }
+            {
+                let frame = self.frames.current_mut();
+                super::record_application_traceback(
+                    self.last_exception_value,
+                    ctx.virtualizable_heap_ptr().unwrap_or(std::ptr::null()),
+                    frame,
+                );
             }
             self.pop_exception_frame(ctx);
         }
@@ -6896,13 +6895,13 @@ where
                 self.class_of_last_exc_is_const = true;
                 {
                     let frame = self.frames.current_mut();
-                    if frame.last_caught_exception_value != concrete {
-                        super::record_application_traceback(
-                            concrete,
-                            ctx.virtualizable_heap_ptr().unwrap_or(std::ptr::null()),
-                            frame,
-                        );
-                    }
+                    // pyopcode.py raise_varargs: RAISE_VARARGS with an
+                    // explicit value records at the raising instruction.
+                    super::record_application_traceback(
+                        concrete,
+                        ctx.virtualizable_heap_ptr().unwrap_or(std::ptr::null()),
+                        frame,
+                    );
                 }
                 self.pop_exception_frame(ctx);
                 return self.unwind_to_exception_handler(ctx);
@@ -6911,16 +6910,8 @@ where
                 if self.last_exception_value == 0 {
                     return TraceAction::Abort;
                 }
-                {
-                    let frame = self.frames.current_mut();
-                    if frame.last_caught_exception_value != self.last_exception_value {
-                        super::record_application_traceback(
-                            self.last_exception_value,
-                            ctx.virtualizable_heap_ptr().unwrap_or(std::ptr::null()),
-                            frame,
-                        );
-                    }
-                }
+                // RaiseWithExplicitTraceback is the bare-reraise path and
+                // deliberately skips record_application_traceback.
                 self.pop_exception_frame(ctx);
                 return self.unwind_to_exception_handler(ctx);
             }

--- a/majit/majit-metainterp/src/pyjitpl/frame.rs
+++ b/majit/majit-metainterp/src/pyjitpl/frame.rs
@@ -81,10 +81,6 @@ pub struct MIFrame {
     /// Exception unwinding uses this instead of the post-decode cursor when
     /// the host records the Python traceback for this frame.
     pub last_opcode_position: usize,
-    /// Exception already recorded when this frame entered a catch handler.
-    /// A later bare re-raise of the same object must not prepend this frame a
-    /// second time.
-    pub last_caught_exception_value: i64,
     pub int_regs: Vec<Option<OpRef>>,
     pub int_values: Vec<Option<i64>>,
     pub ref_regs: Vec<Option<OpRef>>,
@@ -184,7 +180,6 @@ impl MIFrame {
             pc,
             code_cursor: 0,
             last_opcode_position: pc,
-            last_caught_exception_value: 0,
             int_regs: vec![None; regs_and_consts_i],
             int_values: vec![None; regs_and_consts_i],
             ref_regs: vec![None; regs_and_consts_r],

--- a/pyre/pyre-jit-trace/src/descr.rs
+++ b/pyre/pyre-jit-trace/src/descr.rs
@@ -2474,6 +2474,97 @@ pub fn w_exception_context_descr(kind: ExcKind) -> DescrRef {
     field_descr_from_group(group, 3)
 }
 
+/// Field descriptor for `W_BaseException.w_traceback`, sharing the
+/// per-kind exception allocation descriptor with the other exception slots.
+pub fn w_exception_traceback_descr(kind: ExcKind) -> DescrRef {
+    let idx = kind as u8 as usize;
+    let mut cache = W_BASE_EXCEPTION_DESCR_CACHE.lock().unwrap();
+    if cache[idx].is_none() {
+        cache[idx] = Some(build_w_exception_group(kind));
+    }
+    field_descr_from_group(cache[idx].as_ref().unwrap(), 5)
+}
+
+static PYTRACEBACK_DESCR_GROUP: LazyLock<PyreObjectDescrGroup> = LazyLock::new(|| {
+    use pyre_interpreter::pytraceback::{
+        PYTRACEBACK_FRAME_OFFSET, PYTRACEBACK_GC_TYPE_ID, PYTRACEBACK_LASTI_OFFSET,
+        PYTRACEBACK_LINENO_OFFSET, PYTRACEBACK_OBJECT_SIZE, PYTRACEBACK_TYPE,
+        PYTRACEBACK_W_CODE_OFFSET, PYTRACEBACK_W_NEXT_OFFSET,
+    };
+
+    build_object_descr_group_with_def_path(
+        PYTRACEBACK_OBJECT_SIZE,
+        PYTRACEBACK_GC_TYPE_ID,
+        &PYTRACEBACK_TYPE as *const _ as usize,
+        &[
+            (
+                "PyTraceback.w_class",
+                W_CLASS_OFFSET,
+                8,
+                Type::Ref,
+                false,
+                false,
+                false,
+            ),
+            (
+                "PyTraceback.frame",
+                PYTRACEBACK_FRAME_OFFSET,
+                8,
+                Type::Ref,
+                false,
+                false,
+                false,
+            ),
+            (
+                "PyTraceback.lasti",
+                PYTRACEBACK_LASTI_OFFSET,
+                8,
+                Type::Int,
+                true,
+                false,
+                false,
+            ),
+            (
+                "PyTraceback.w_next",
+                PYTRACEBACK_W_NEXT_OFFSET,
+                8,
+                Type::Ref,
+                false,
+                false,
+                false,
+            ),
+            (
+                "PyTraceback.lineno",
+                PYTRACEBACK_LINENO_OFFSET,
+                8,
+                Type::Int,
+                true,
+                false,
+                false,
+            ),
+            (
+                "PyTraceback.w_code",
+                PYTRACEBACK_W_CODE_OFFSET,
+                8,
+                Type::Ref,
+                false,
+                false,
+                false,
+            ),
+        ],
+        "",
+        "",
+    )
+});
+
+pub fn pytraceback_size_descr() -> DescrRef {
+    PYTRACEBACK_DESCR_GROUP.size_descr.clone()
+}
+
+pub fn pytraceback_field_descr(index: usize) -> DescrRef {
+    field_descr_from_group(&PYTRACEBACK_DESCR_GROUP, index)
+}
+
 /// Cached field descriptor for a raw reference slot selected by the
 /// exception attribute fold.  Indices are those of `build_w_exception_group`;
 /// no parallel descriptor is constructed.

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/bridge_subwalk.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/bridge_subwalk.rs
@@ -66,7 +66,6 @@ pub fn dispatch_via_miframe<Sym: WalkSym>(
             unsafe { (*sym.jitcode()).index as i32 }
         };
         walk_session.recording_opcode_position = position;
-        walk_session.last_caught_exception_value = 0;
     }
 
     // Phase 7: this IS the full-body walk over the outer `sym.jitcode`,

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
@@ -2539,8 +2539,8 @@ pub(crate) fn try_walker_inline_resolved_user_call<Sym: WalkSym>(
         }
         DispatchOutcome::SubRaise { exc, exc_concrete } => {
             if let Some(target) = try_catch_exception_at(code, op.next_pc) {
-                record_inline_application_traceback(ctx, exc_concrete, op.pc, true);
-                record_top_level_application_traceback(ctx, exc_concrete, op.pc, true);
+                record_inline_application_traceback(ctx, exc, exc_concrete, op.pc, true, false);
+                record_top_level_application_traceback(ctx, exc, exc_concrete, op.pc, true, false);
                 ctx.last_exc_value = Some(exc);
                 ctx.last_exc_value_concrete = exc_concrete;
                 Ok(Some((DispatchOutcome::Continue, target)))
@@ -3307,8 +3307,8 @@ pub(crate) fn dispatch_inline_call_dr_kind<Sym: WalkSym>(
         }
         DispatchOutcome::SubRaise { exc, exc_concrete } => {
             if let Some(target) = try_catch_exception_at(code, op.next_pc) {
-                record_inline_application_traceback(ctx, exc_concrete, op.pc, true);
-                record_top_level_application_traceback(ctx, exc_concrete, op.pc, true);
+                record_inline_application_traceback(ctx, exc, exc_concrete, op.pc, true, false);
+                record_top_level_application_traceback(ctx, exc, exc_concrete, op.pc, true, false);
                 ctx.last_exc_value = Some(exc);
                 // Thread the callee's concrete
                 // exception across the frame boundary.  Without this a
@@ -3451,8 +3451,8 @@ pub(crate) fn dispatch_inline_call_dir_kind<Sym: WalkSym>(
         }
         DispatchOutcome::SubRaise { exc, exc_concrete } => {
             if let Some(target) = try_catch_exception_at(code, op.next_pc) {
-                record_inline_application_traceback(ctx, exc_concrete, op.pc, true);
-                record_top_level_application_traceback(ctx, exc_concrete, op.pc, true);
+                record_inline_application_traceback(ctx, exc, exc_concrete, op.pc, true, false);
+                record_top_level_application_traceback(ctx, exc, exc_concrete, op.pc, true, false);
                 ctx.last_exc_value = Some(exc);
                 // Thread the callee's concrete
                 // exception across the frame boundary.  Without this a
@@ -3607,8 +3607,8 @@ pub(crate) fn dispatch_inline_call_dirf_kind<Sym: WalkSym>(
         }
         DispatchOutcome::SubRaise { exc, exc_concrete } => {
             if let Some(target) = try_catch_exception_at(code, op.next_pc) {
-                record_inline_application_traceback(ctx, exc_concrete, op.pc, true);
-                record_top_level_application_traceback(ctx, exc_concrete, op.pc, true);
+                record_inline_application_traceback(ctx, exc, exc_concrete, op.pc, true, false);
+                record_top_level_application_traceback(ctx, exc, exc_concrete, op.pc, true, false);
                 ctx.last_exc_value = Some(exc);
                 // Thread the callee's concrete
                 // exception across the frame boundary.  Without this a

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
@@ -453,10 +453,6 @@ pub struct InlineFrame {
     /// reaches [`FBW_MAX_INLINE_RECURSION`], the call folds to a residual
     /// instead of unrolling its call tree (`pyjitpl.py`).
     pub w_code: usize,
-    /// Exception most recently caught by this frame. Matching
-    /// `MIFrame.last_caught_exception_value`, this suppresses a second
-    /// traceback node when the same exception later leaves via bare re-raise.
-    pub last_caught_exception_value: i64,
     /// Paused caller snapshot for the multi-frame path. `None` preserves the
     /// straight-line single-frame collapse while retaining the callee level.
     pub parent: Option<InlineParentFrame>,
@@ -500,8 +496,6 @@ pub struct WalkSession {
     pub recording_jitcode_index: i32,
     /// Last opcode executed by the root recording frame.
     pub recording_opcode_position: usize,
-    /// Exception already recorded when the root frame entered its handler.
-    pub last_caught_exception_value: i64,
 }
 
 impl Default for WalkSession {
@@ -517,16 +511,17 @@ impl Default for WalkSession {
             recording_frame_ptr: 0,
             recording_jitcode_index: -1,
             recording_opcode_position: 0,
-            last_caught_exception_value: 0,
         }
     }
 }
 
 fn record_top_level_application_traceback<Sym: WalkSym>(
     ctx: &mut WalkContext<'_, '_, Sym>,
+    exc: OpRef,
     exc_concrete: ConcreteValue,
     opcode_position: usize,
-    caught: bool,
+    execute_concrete: bool,
+    emit_runtime: bool,
 ) {
     if !ctx.is_top_level {
         return;
@@ -537,30 +532,45 @@ fn record_top_level_application_traceback<Sym: WalkSym>(
     if exc_ptr.is_null() {
         return;
     }
-    let exc_value = exc_ptr as usize as i64;
     let (frame_ptr, jitcode_index) = {
-        let mut session = ctx.session.borrow_mut();
-        if !caught && session.last_caught_exception_value == exc_value {
-            return;
-        }
-        if caught {
-            session.last_caught_exception_value = exc_value;
-        }
+        let session = ctx.session.borrow();
         (session.recording_frame_ptr, session.recording_jitcode_index)
     };
-    majit_metainterp::record_application_traceback_for_recording(
-        exc_value,
-        frame_ptr as i64,
-        jitcode_index,
-        opcode_position as i32,
-    );
+    if execute_concrete {
+        majit_metainterp::record_application_traceback_for_recording(
+            exc_ptr as usize as i64,
+            frame_ptr as i64,
+            jitcode_index,
+            opcode_position as i32,
+        );
+    }
+    let hook = majit_metainterp::record_application_traceback_hook_address();
+    let frame = crate::state::pyjitcode_for_jitcode_index(jitcode_index)
+        .and_then(|jitcode| {
+            ctx.registers_r
+                .get(jitcode.metadata.portal_frame_reg as usize)
+                .copied()
+        })
+        .unwrap_or(OpRef::NONE);
+    if emit_runtime && !hook.is_null() && !exc.is_none() && !frame.is_none() {
+        let jitcode = ctx.trace_ctx.const_int(i64::from(jitcode_index));
+        let opcode = ctx.trace_ctx.const_int(opcode_position as i64);
+        ctx.trace_ctx.call_void_typed_with_effect(
+            hook,
+            &[exc, frame, jitcode, opcode],
+            &[Type::Ref, Type::Ref, Type::Int, Type::Int],
+            default_effect_info(),
+        );
+    }
 }
 
 fn record_inline_application_traceback<Sym: WalkSym>(
     ctx: &mut WalkContext<'_, '_, Sym>,
+    exc: OpRef,
     exc_concrete: ConcreteValue,
     opcode_position: usize,
-    caught: bool,
+    execute_concrete: bool,
+    emit_runtime: bool,
 ) {
     if ctx.is_top_level {
         return;
@@ -588,26 +598,127 @@ fn record_inline_application_traceback<Sym: WalkSym>(
     if exc_ptr.is_null() {
         return;
     }
-    let exc_value = exc_ptr as usize as i64;
-    {
-        let mut session = ctx.session.borrow_mut();
-        let Some(frame) = session.framestack.last_mut() else {
-            return;
-        };
-        if !caught && frame.last_caught_exception_value == exc_value {
-            return;
-        }
-        if caught {
-            frame.last_caught_exception_value = exc_value;
-        }
+    if execute_concrete {
+        majit_metainterp::record_inline_application_traceback_for_recording(
+            exc_ptr as usize as i64,
+            consts.w_code as i64,
+            consts.w_globals as i64,
+            consts.jitcode_index,
+            opcode_position as i32,
+        );
     }
-    majit_metainterp::record_inline_application_traceback_for_recording(
-        exc_value,
-        consts.w_code as i64,
-        consts.w_globals as i64,
-        consts.jitcode_index,
-        opcode_position as i32,
+    let hook = majit_metainterp::record_inline_application_traceback_hook_address();
+    if emit_runtime && !hook.is_null() && !exc.is_none() {
+        let w_code = ctx.trace_ctx.const_ref(consts.w_code as i64);
+        let w_globals = ctx.trace_ctx.const_ref(consts.w_globals as i64);
+        let jitcode = ctx.trace_ctx.const_int(i64::from(consts.jitcode_index));
+        let opcode = ctx.trace_ctx.const_int(opcode_position as i64);
+        ctx.trace_ctx.call_void_typed_with_effect(
+            hook,
+            &[exc, w_code, w_globals, jitcode, opcode],
+            &[Type::Ref, Type::Ref, Type::Ref, Type::Int, Type::Int],
+            default_effect_info(),
+        );
+    }
+}
+
+fn recording_instruction_is_bare_reraise<Sym: WalkSym>(
+    ctx: &WalkContext<'_, '_, Sym>,
+    opcode_position: usize,
+) -> bool {
+    let jitcode_index = if ctx.is_top_level {
+        ctx.session.borrow().recording_jitcode_index
+    } else {
+        ctx.inline_callee_consts
+            .map_or(-1, |consts| consts.jitcode_index)
+    };
+    crate::state::jitcode_pc_is_bare_reraise(jitcode_index, opcode_position as i32)
+}
+
+fn record_fresh_application_traceback<Sym: WalkSym>(
+    ctx: &mut WalkContext<'_, '_, Sym>,
+    exc: OpRef,
+    exc_concrete: ConcreteValue,
+    opcode_position: usize,
+) {
+    let ConcreteValue::Ref(exc_ptr) = exc_concrete else {
+        return;
+    };
+    if exc_ptr.is_null() || unsafe { !pyre_object::is_exception(exc_ptr) } {
+        return;
+    }
+    let kind = unsafe { pyre_object::interp_exceptions::w_exception_get_kind(exc_ptr) };
+    let (jitcode_index, w_code) = if ctx.is_top_level {
+        let session = ctx.session.borrow();
+        let frame = session.recording_frame_ptr as *const pyre_interpreter::PyFrame;
+        let w_code = if frame.is_null() {
+            0
+        } else {
+            unsafe { (*frame).pycode as usize }
+        };
+        (session.recording_jitcode_index, w_code)
+    } else {
+        ctx.inline_callee_consts
+            .map_or((-1, 0), |consts| (consts.jitcode_index, consts.w_code))
+    };
+    let Some(jitcode) = crate::state::pyjitcode_for_jitcode_index(jitcode_index) else {
+        return;
+    };
+    let Some(frame) = ctx
+        .registers_r
+        .get(jitcode.metadata.portal_frame_reg as usize)
+        .copied()
+    else {
+        return;
+    };
+    let Some(last_instruction) =
+        crate::state::python_pc_for_jitcode_pc_public(jitcode_index, opcode_position as i32)
+    else {
+        return;
+    };
+    let Some(raw_code) = crate::state::raw_code_for_jitcode_index(jitcode_index) else {
+        return;
+    };
+    let lineno =
+        unsafe { pyre_interpreter::pyframe::offset2lineno(&*raw_code, last_instruction as isize) }
+            as i64;
+
+    let traceback = ctx.trace_ctx.record_op_with_descr(
+        OpCode::NewWithVtable,
+        &[],
+        crate::descr::pytraceback_size_descr(),
     );
+    ctx.trace_ctx.heap_cache_mut().new_object(traceback);
+    let fields = [
+        (
+            ctx.trace_ctx
+                .const_ref(pyre_object::pyobject::get_instantiate(
+                    &pyre_interpreter::pytraceback::PYTRACEBACK_TYPE,
+                ) as i64),
+            0,
+        ),
+        (frame, 1),
+        (ctx.trace_ctx.const_int(i64::from(last_instruction)), 2),
+        (ctx.trace_ctx.const_ref(0), 3),
+        (ctx.trace_ctx.const_int(lineno), 4),
+        (ctx.trace_ctx.const_ref(w_code as i64), 5),
+    ];
+    for (value, index) in fields {
+        let descr = crate::descr::pytraceback_field_descr(index);
+        ctx.trace_ctx
+            .record_op_with_descr(OpCode::SetfieldGc, &[traceback, value], descr.clone());
+        ctx.trace_ctx
+            .heapcache_setfield_cached(traceback, descr.index(), value);
+    }
+
+    let traceback_descr = crate::descr::w_exception_traceback_descr(kind);
+    ctx.trace_ctx.record_op_with_descr(
+        OpCode::SetfieldGc,
+        &[exc, traceback],
+        traceback_descr.clone(),
+    );
+    ctx.trace_ctx
+        .heapcache_setfield_cached(exc, traceback_descr.index(), traceback);
 }
 
 /// Compile-time-constant frame fields of an inlined callee.
@@ -1969,14 +2080,32 @@ pub fn walk<Sym: WalkSym>(
                 // `exit_frame_with_exception`, letting the exception escape a
                 // frame that actually catches it.
                 if let Some(target) = try_catch_exception_at(code, pc) {
-                    record_inline_application_traceback(ctx, exc_concrete, opcode_position, true);
-                    let opcode_position = ctx.session.borrow().recording_opcode_position;
-                    record_top_level_application_traceback(
-                        ctx,
-                        exc_concrete,
-                        opcode_position,
-                        true,
-                    );
+                    let raised_in_this_frame = decode_op_at(code, opcode_position)
+                        .is_some_and(|op| matches!(op.opname, "raise/r" | "reraise/"));
+                    if !raised_in_this_frame {
+                        // finishframe_exception propagates into this frame
+                        // before catch_exception/L enters its handler. Record
+                        // that frame-boundary step once; handler entry itself
+                        // does not add a traceback node.
+                        record_inline_application_traceback(
+                            ctx,
+                            exc,
+                            exc_concrete,
+                            opcode_position,
+                            true,
+                            false,
+                        );
+                        let recording_opcode_position =
+                            ctx.session.borrow().recording_opcode_position;
+                        record_top_level_application_traceback(
+                            ctx,
+                            exc,
+                            exc_concrete,
+                            recording_opcode_position,
+                            true,
+                            false,
+                        );
+                    }
                     ctx.last_exc_value = Some(exc);
                     ctx.last_exc_value_concrete = exc_concrete;
                     // pyjitpl.py:2530-2558 `finishframe_exception` only
@@ -2007,13 +2136,18 @@ pub fn walk<Sym: WalkSym>(
                     continue;
                 }
                 if ctx.is_top_level {
-                    let opcode_position = ctx.session.borrow().recording_opcode_position;
-                    record_top_level_application_traceback(
-                        ctx,
-                        exc_concrete,
-                        opcode_position,
-                        false,
-                    );
+                    if !recording_instruction_is_bare_reraise(ctx, opcode_position) {
+                        let recording_opcode_position =
+                            ctx.session.borrow().recording_opcode_position;
+                        record_top_level_application_traceback(
+                            ctx,
+                            exc,
+                            exc_concrete,
+                            recording_opcode_position,
+                            true,
+                            false,
+                        );
+                    }
                     // RPython parity: framestack exhausted with no handler
                     // match → `compile_exit_frame_with_exception(last_exc_box)`.
                     // Stash the exception the same way the value-return arms
@@ -2026,13 +2160,13 @@ pub fn walk<Sym: WalkSym>(
                     fbw_terminate_with_raise(exc, exc_concrete);
                     return Ok((DispatchOutcome::Terminate, pc));
                 } else {
-                    let is_bare_reraise = decode_op_at(code, opcode_position)
-                        .is_some_and(|op| op.opname == "reraise/");
-                    if !is_bare_reraise {
+                    if !recording_instruction_is_bare_reraise(ctx, opcode_position) {
                         record_inline_application_traceback(
                             ctx,
+                            exc,
                             exc_concrete,
                             opcode_position,
+                            true,
                             false,
                         );
                     }
@@ -4296,11 +4430,10 @@ impl<'a> InlineFrameGuard<'a> {
         w_code: usize,
         parent: Option<InlineParentFrame>,
     ) -> Self {
-        session.borrow_mut().framestack.push(InlineFrame {
-            w_code,
-            last_caught_exception_value: 0,
-            parent,
-        });
+        session
+            .borrow_mut()
+            .framestack
+            .push(InlineFrame { w_code, parent });
         ACTIVE_WALK_SESSION.with(|c| c.set(session as *const _));
         InlineFrameGuard(session)
     }
@@ -8849,6 +8982,32 @@ fn handle<Sym: WalkSym>(
             ctx.last_exc_value = Some(exc);
             ctx.last_exc_value_concrete = concrete_exc;
             ctx.fbw_mode.class_of_last_exc_is_const = true;
+            let freshly_normalized = fbw_built_exc_take(exc);
+            if !recording_instruction_is_bare_reraise(ctx, op.pc) {
+                let caught_in_frame = try_catch_exception_at(code, op.next_pc).is_some();
+                if caught_in_frame {
+                    if freshly_normalized {
+                        record_fresh_application_traceback(ctx, exc, concrete_exc, op.pc);
+                    } else {
+                        record_inline_application_traceback(
+                            ctx,
+                            exc,
+                            concrete_exc,
+                            op.pc,
+                            false,
+                            true,
+                        );
+                        record_top_level_application_traceback(
+                            ctx,
+                            exc,
+                            concrete_exc,
+                            op.pc,
+                            false,
+                            true,
+                        );
+                    }
+                }
+            }
             // Gated `PYRE_FBW_RAISE`: route the top-level raise through
             // `SubRaise` so walk()'s SubRaise arm runs the in-frame
             // `catch_exception/L` lookahead (`finishframe_lookahead_at`) and
@@ -8856,7 +9015,6 @@ fn handle<Sym: WalkSym>(
             // exit-frame finish (which escapes a try/except as a no-payload
             // Terminate abort).
             if ctx.is_top_level && !fbw_raise_enabled() {
-                record_top_level_application_traceback(ctx, concrete_exc, op.pc, false);
                 ctx.trace_ctx
                     .finish(&[exc], ctx.exit_frame_with_exception_descr_ref.clone());
                 if let ConcreteValue::Ref(p) = concrete_exc {
@@ -8996,12 +9154,6 @@ fn handle<Sym: WalkSym>(
                 .ok_or(DispatchError::ReraiseWithoutLastExcValue { pc: op.pc })?;
             // Gated `PYRE_FBW_RAISE`: symmetric with `raise/r`.
             if ctx.is_top_level && !fbw_raise_enabled() {
-                record_top_level_application_traceback(
-                    ctx,
-                    ctx.last_exc_value_concrete,
-                    op.pc,
-                    false,
-                );
                 ctx.trace_ctx
                     .finish(&[exc], ctx.exit_frame_with_exception_descr_ref.clone());
                 if let ConcreteValue::Ref(p) = ctx.last_exc_value_concrete {

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
@@ -4294,6 +4294,7 @@ pub(crate) fn try_walker_trace_raise_builtin<Sym: WalkSym>(
     // The normalized publish result is the same flat builtin instance;
     // forward the inline-built exc OpRef (carrying its concrete shadow)
     // to the dst that feeds the following `raise/r`.
+    fbw_built_exc_insert(exc_op);
     write_residual_call_result_to_dst(ctx, op.pc, dst, 'r', exc_op)?;
     Ok(Some(()))
 }

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -3985,7 +3985,21 @@ pub(crate) fn flush_walk_end_state_to_frame(
     frame: usize,
     resume_py_pc: usize,
 ) -> bool {
-    flush_walk_end_state_to_frame_inner(ctx, frame, resume_py_pc, None, &[], None)
+    flush_walk_end_state_to_frame_inner(ctx, frame, resume_py_pc, None, &[], None, false)
+}
+
+/// Merge-point handoff for `raise_continue_running_normally`.
+///
+/// A handler loop can carry a null saved-exception sentinel as a real live
+/// operand.  Accept it only when the recorded box independently resolves to
+/// that same concrete null; abort-point handoffs keep rejecting null shadow
+/// slots because their mid-expression operands may be unavailable.
+pub(crate) fn flush_walk_loop_end_state_to_frame(
+    ctx: &TraceCtx,
+    frame: usize,
+    resume_py_pc: usize,
+) -> bool {
+    flush_walk_end_state_to_frame_inner(ctx, frame, resume_py_pc, None, &[], None, true)
 }
 
 /// `flush_walk_end_state_to_frame` plus an optional in-flight FOR_ITER item
@@ -4001,7 +4015,7 @@ pub(crate) fn flush_walk_end_state_to_frame_with_item(
     resume_py_pc: usize,
     push: Option<(PyObjectRef, usize)>,
 ) -> bool {
-    flush_walk_end_state_to_frame_inner(ctx, frame, resume_py_pc, push, &[], None)
+    flush_walk_end_state_to_frame_inner(ctx, frame, resume_py_pc, push, &[], None, false)
 }
 
 pub(crate) fn flush_walk_end_state_to_frame_with_stack_overrides(
@@ -4010,7 +4024,15 @@ pub(crate) fn flush_walk_end_state_to_frame_with_stack_overrides(
     resume_py_pc: usize,
     stack_overrides: &[(usize, PyObjectRef)],
 ) -> bool {
-    flush_walk_end_state_to_frame_inner(ctx, frame, resume_py_pc, None, stack_overrides, None)
+    flush_walk_end_state_to_frame_inner(
+        ctx,
+        frame,
+        resume_py_pc,
+        None,
+        stack_overrides,
+        None,
+        false,
+    )
 }
 
 /// `flush_walk_end_state_to_frame` with the COMPLETE operand stack supplied by
@@ -4031,7 +4053,7 @@ pub(crate) fn flush_walk_end_state_to_frame_with_full_stack(
     resume_py_pc: usize,
     stack: &[PyObjectRef],
 ) -> bool {
-    flush_walk_end_state_to_frame_inner(ctx, frame, resume_py_pc, None, &[], Some(stack))
+    flush_walk_end_state_to_frame_inner(ctx, frame, resume_py_pc, None, &[], Some(stack), false)
 }
 
 fn flush_walk_end_state_to_frame_inner(
@@ -4041,6 +4063,7 @@ fn flush_walk_end_state_to_frame_inner(
     push: Option<(PyObjectRef, usize)>,
     stack_overrides: &[(usize, PyObjectRef)],
     full_stack: Option<&[PyObjectRef]>,
+    allow_known_null_stack: bool,
 ) -> bool {
     let decline = |why: &str| {
         if crate::jitcode_dispatch::fbw_debug_abort_enabled() {
@@ -4126,14 +4149,16 @@ fn flush_walk_end_state_to_frame_inner(
             }
             continue;
         }
-        let Some((_opref, value)) = ctx.virtualizable_entry_at(base + abs) else {
+        let Some((opref, value)) = ctx.virtualizable_entry_at(base + abs) else {
             return decline("no shadow entry for a live slot (validation)");
         };
         // An operand-STACK slot (`abs >= nlocals`) that resolves to a NULL Ref
-        // is an UNPOPULATED shadow slot, not a live value: the virtualizable
-        // shadow tracks locals/cells faithfully but its stack region is only
-        // valid at a merge point (loop header) where the walk's stack effects
-        // have settled.  At an arbitrary mid-opcode resume pc (an
+        // is normally an UNPOPULATED shadow slot, not a live value: the
+        // virtualizable shadow tracks locals/cells faithfully but its stack
+        // region is only generally valid at a merge point where the walk's
+        // stack effects have settled.  A merge-point handoff can also carry a
+        // real null sentinel when its recorded box proves the same concrete
+        // value.  At an arbitrary mid-opcode resume pc (an
         // `abort_permanent` marker reached partway through an opcode's stack
         // build — e.g. a MAKE_FUNCTION whose LOAD_CONST'd code object the walk
         // tracked symbolically, never writing it to the shadow) those slots
@@ -4143,7 +4168,13 @@ fn flush_walk_end_state_to_frame_inner(
         // frame from its start state instead.  A local slot may legitimately
         // be NULL (an unbound local), so this only guards the stack region.
         if abs >= nlocals && matches!(value, Value::Ref(r) if r.0 == 0) {
-            return decline("NULL operand-stack shadow slot (mid-expression)");
+            let recorded_null = matches!(
+                ctx.concrete_of_opref(opref),
+                Some(Value::Ref(r)) if r.0 == 0
+            );
+            if !allow_known_null_stack || !recorded_null {
+                return decline("NULL operand-stack shadow slot (mid-expression)");
+            }
         }
     }
     let arr_ptr = unsafe {

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -803,6 +803,23 @@ pub fn python_pc_for_jitcode_pc_public(jitcode_index: i32, offset: i32) -> Optio
     )
 }
 
+/// Whether a JitCode exception exit came from the Python bare-reraise
+/// instruction path. `RAISE_VARARGS 0` and `RERAISE` both use
+/// RaiseWithExplicitTraceback and skip record_application_traceback.
+pub fn jitcode_pc_is_bare_reraise(jitcode_index: i32, offset: i32) -> bool {
+    let Some(raw_code) = raw_code_for_jitcode_index(jitcode_index) else {
+        return false;
+    };
+    let Some(py_pc) = python_pc_for_jitcode_pc_public(jitcode_index, offset) else {
+        return false;
+    };
+    match unsafe { pyre_interpreter::decode_instruction_at(&*raw_code, py_pc as usize) } {
+        Some((Instruction::RaiseVarargs { .. }, op_arg)) => u32::from(op_arg) == 0,
+        Some((Instruction::Reraise { .. }, _)) => true,
+        _ => false,
+    }
+}
+
 /// Advance a Python instruction coordinate past resume trivia when code is available.
 pub fn skip_python_trivia_forward_public(
     jitcode_index: i32,

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -2271,7 +2271,9 @@ fn run_perfn_walk<Sym: WalkSym>(
                                  (unjournaled effect) — legacy replay kept"
                             );
                         }
-                    } else if crate::state::flush_walk_end_state_to_frame(ctx, cf_addr, header_pc) {
+                    } else if crate::state::flush_walk_loop_end_state_to_frame(
+                        ctx, cf_addr, header_pc,
+                    ) {
                         if crate::jitcode_dispatch::fbw_debug_abort_enabled() {
                             eprintln!(
                                 "[fbw-end-flush] COMMIT header_pc={header_pc} bridge={} \

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -682,9 +682,18 @@ fn m73_lastinstr_audit(
 pub(crate) extern "C" fn record_caught_blackhole_traceback(
     exc_value: i64,
     frame_value: i64,
-    jitcode_index: i32,
-    opcode_position: i32,
+    jitcode_index: i64,
+    opcode_position: i64,
 ) {
+    let Ok(jitcode_index) = i32::try_from(jitcode_index) else {
+        return;
+    };
+    let Ok(opcode_position) = i32::try_from(opcode_position) else {
+        return;
+    };
+    if pyre_jit_trace::state::jitcode_pc_is_bare_reraise(jitcode_index, opcode_position) {
+        return;
+    }
     let frame_ptr = frame_value as *mut PyFrame;
     if frame_ptr.is_null() || exc_value == 0 {
         return;
@@ -706,9 +715,15 @@ pub(crate) extern "C" fn record_inline_traceback_for_recording(
     exc_value: i64,
     w_code_value: i64,
     w_globals_value: i64,
-    jitcode_index: i32,
-    opcode_position: i32,
+    jitcode_index: i64,
+    opcode_position: i64,
 ) {
+    let Ok(jitcode_index) = i32::try_from(jitcode_index) else {
+        return;
+    };
+    let Ok(opcode_position) = i32::try_from(opcode_position) else {
+        return;
+    };
     if exc_value == 0 || w_code_value == 0 {
         return;
     }
@@ -2397,7 +2412,17 @@ pub fn blackhole_resume_via_rd_numb(
             let frame_ptr = bh.virtualizable_ptr as *mut PyFrame;
             let jitcode_index = bh.jitcode.try_index().map(|v| v as i32);
             let last_opcode_position = bh.last_opcode_position;
-            let last_caught_exception_value = bh.last_caught_exception_value;
+            let bare_reraise = bh
+                .jitcode
+                .code
+                .get(last_opcode_position)
+                .is_some_and(|opcode| *opcode == majit_metainterp::jitcode::insns::BC_RERAISE)
+                || jitcode_index.is_some_and(|index| {
+                    pyre_jit_trace::state::jitcode_pc_is_bare_reraise(
+                        index,
+                        last_opcode_position as i32,
+                    )
+                });
             release_bh_rd(bh);
             let Some(mut caller_bh) = next.map(|b| *b) else {
                 // blackhole.py:1679-1682 _exit_frame_with_exception:
@@ -2415,8 +2440,7 @@ pub fn blackhole_resume_via_rd_numb(
                         "blackhole exception (null exc_value)",
                     )
                 };
-                let caught_reraise = exc_value != 0 && last_caught_exception_value == exc_value;
-                if caught_reraise {
+                if bare_reraise {
                     err.attach_tb = false;
                 } else if !frame_ptr.is_null() {
                     let last_instruction = jitcode_index

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -724,6 +724,12 @@ pub(crate) extern "C" fn record_inline_traceback_for_recording(
     let Ok(opcode_position) = i32::try_from(opcode_position) else {
         return;
     };
+    // Inline frames follow the same RaiseWithExplicitTraceback rule as
+    // concrete blackhole frames: a bare reraise preserves the traceback
+    // already attached by the original raising instruction.
+    if pyre_jit_trace::state::jitcode_pc_is_bare_reraise(jitcode_index, opcode_position) {
+        return;
+    }
     if exc_value == 0 || w_code_value == 0 {
         return;
     }
@@ -2423,6 +2429,29 @@ pub fn blackhole_resume_via_rd_numb(
                         last_opcode_position as i32,
                     )
                 });
+            // blackhole.py _run_forever propagates an unhandled exception one
+            // BlackholeInterpreter frame at a time. Record each exiting
+            // frame before advancing to nextblackholeinterp, matching
+            // pytraceback.py record_application_traceback at every Python
+            // frame boundary. A bare reraise preserves the existing chain.
+            if !bare_reraise && !frame_ptr.is_null() {
+                if let Some(jitcode_index) = jitcode_index {
+                    record_caught_blackhole_traceback(
+                        exc_value,
+                        frame_ptr as i64,
+                        i64::from(jitcode_index),
+                        last_opcode_position as i64,
+                    );
+                } else {
+                    unsafe {
+                        pyre_interpreter::pytraceback::record_application_traceback(
+                            exc_value as PyObjectRef,
+                            frame_ptr,
+                            (*frame_ptr).last_instr as i64,
+                        );
+                    }
+                }
+            }
             release_bh_rd(bh);
             let Some(mut caller_bh) = next.map(|b| *b) else {
                 // blackhole.py:1679-1682 _exit_frame_with_exception:
@@ -2442,28 +2471,6 @@ pub fn blackhole_resume_via_rd_numb(
                 };
                 if bare_reraise {
                     err.attach_tb = false;
-                } else if !frame_ptr.is_null() {
-                    let last_instruction = jitcode_index
-                        .and_then(|index| {
-                            pyre_jit_trace::state::python_pc_for_jitcode_pc_public(
-                                index,
-                                last_opcode_position as i32,
-                            )
-                        })
-                        .map_or(unsafe { (*frame_ptr).last_instr as i64 }, i64::from);
-                    m73_lastinstr_audit(
-                        "exit_got_exc",
-                        jitcode_index,
-                        last_opcode_position as i32,
-                        frame_ptr,
-                    );
-                    unsafe {
-                        pyre_interpreter::pytraceback::record_application_traceback(
-                            err.exc_object,
-                            frame_ptr,
-                            last_instruction,
-                        );
-                    }
                 }
                 // A residual helper can publish a raise to both exception
                 // channels.  Blackhole propagation has consumed its own


### PR DESCRIPTION
Follow-up to #743. Three commits closing the remaining exception-traceback correctness gaps surfaced by that PR's review and by fixture verification. Rebased onto current main (#745).

## 1. `jit: key traceback recording on the raising instruction`

`record_application_traceback` (recording path, blackhole, and the FBW walker) previously suppressed a traceback node whenever the raised object was pointer-equal to `last_caught_exception_value`. That conflated an explicit re-raise of the caught object (`except E as e: raise e`) with a bare re-raise:

- compiled traces for `raise e` attached **no** traceback at all (steady-state depth 0), and
- a recording pass over a bare `raise` appended extra nodes at the re-raise and handler coordinates.

Decide by instruction instead: `RAISE_VARARGS` with an operand always records; the bare-reraise path (`RAISE_VARARGS 0` / `RERAISE`, `RaiseWithExplicitTraceback` upstream) never records; handler entry in the same frame records nothing; frame-boundary propagation records once per frame. `jitcode_pc_is_bare_reraise` maps a JitCode coordinate back to the Python instruction for the walker/blackhole paths, and a fresh locally-caught exception gets an optimizer-visible virtual `PyTraceback` so unobserved allocations still fold away. `last_caught_exception_value` is removed from `MIFrame`, `BlackholeInterpreter`, `InlineFrame`, and `WalkSession`; no traceback decision keys on object identity.

Addresses the codex-review §2/§3 findings on #743 (identity-based suppression of `raise e`).

## 2. `jit: record every unhandled blackhole frame's traceback`

`blackhole_resume_via_rd_numb` attached the application traceback only at the bottommost `_exit_frame_with_exception` arm. When an exception propagated through several reconstructed `BlackholeInterpreter` frames the intermediate frames were never recorded — a one-frame resume whose residual call raised (a compiled trace's first guard-failure replay calling a callee) produced a traceback missing the callee's frame.

Record each exiting frame before advancing to `nextblackholeinterp`, matching `_run_forever` propagating one frame at a time and `record_application_traceback` attaching at every Python frame boundary; the bottommost frame is covered by the same call and still recorded once. Also applies `jitcode_pc_is_bare_reraise` in `record_inline_traceback_for_recording` so an inlined bare reraise adds no duplicate node.

## 3. `jit(fbw): accept a proven-null saved-exc sentinel at loop-close flush`

A handler loop carries the saved-previous-exception null sentinel as a real live operand across its loop-close merge point. `flush_walk_end_state_to_frame` rejected any null `Ref` in the operand-stack region as an unpopulated mid-expression shadow, so `run_perfn_walk` declined the merge-point handoff and fell back to the legacy replay; the replay re-executed the trailing residual (e.g. a `StoreSubscr`) once, producing one extra side effect at the trace-compile boundary while traceback depths stayed correct.

Add `flush_walk_loop_end_state_to_frame` for the `raise_continue_running_normally` handoff: a null operand-stack slot is accepted only when its recorded box independently resolves to the same concrete null. The abort-point, item, stack-override, and full-stack callers keep the strict rejection, since their arbitrary resume coordinate can hold an unavailable mid-expression shadow slot.

## Verification (both backends, oracle pypy3)

Traceback battery — nested reraise `__context__` (maxctx 0), new-object raise (1), blackhole inner/outer (0), multi-site (0), mixed bare/ctx (maxtbdepth 1), nested3/4/reraise (0), conditional-raise bridge `nested_cond`/`cond_d4` (0), mixed call-reraise (0), `raise_e_tb` (`{2: 4000}`), an adversarial null-sentinel stress (accumulator + caught-identity checks exact) — all matching pypy. `exception_metadata_hot` byte-identical to pypy3.

`cargo test` (pyre-jit 325, pyre-jit-trace 294, gc 12, majit-metainterp dynasm 1403 / cranelift 1401): pass. `pyre/check.py` dynasm 300/300 and cranelift 300/300.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
