### PR TITLE
jit: FBW profiler-counter parity + remove GetfieldGcPure* opcodes

### DIFF
--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -4486,9 +4486,6 @@ fn op_dereferences_first_arg(opcode: majit_ir::OpCode) -> bool {
             | OpCode::GetfieldGcI
             | OpCode::GetfieldGcR
             | OpCode::GetfieldGcF
-            | OpCode::GetfieldGcPureI
-            | OpCode::GetfieldGcPureR
-            | OpCode::GetfieldGcPureF
             // SetfieldGc: store to [loc_ptr + offset]
             | OpCode::SetfieldGc
             // GetArrayItemGc / SetArrayItemGc: load/store from arrays
@@ -12667,10 +12664,7 @@ impl CraneliftBackend {
                 | OpCode::GetfieldGcF
                 | OpCode::GetfieldRawI
                 | OpCode::GetfieldRawR
-                | OpCode::GetfieldRawF
-                | OpCode::GetfieldGcPureI
-                | OpCode::GetfieldGcPureR
-                | OpCode::GetfieldGcPureF => {
+                | OpCode::GetfieldRawF => {
                     let descr = op.getdescr().expect("getfield op must have a descriptor");
                     let fd = descr
                         .as_field_descr()
@@ -21045,7 +21039,7 @@ mod tests {
         let inputargs = vec![InputArg::new_ref(0)];
         let ops = vec![
             mk_op(OpCode::Label, &[OpRef::input_arg_ref(0)], OpRef::NONE.raw()),
-            mk_op_with_descr(OpCode::GetfieldGcPureR, &[OpRef::input_arg_ref(0)], 1, fd),
+            mk_op_with_descr(OpCode::GetfieldGcR, &[OpRef::input_arg_ref(0)], 1, fd),
             mk_op(OpCode::Finish, &[OpRef::ref_op(1)], OpRef::NONE.raw()),
         ];
 
@@ -22911,7 +22905,7 @@ mod tests {
                 loop_descr.clone(),
             ),
             mk_op_with_descr(
-                OpCode::GetfieldGcPureI,
+                OpCode::GetfieldGcI,
                 &[OpRef::input_arg_ref(2)],
                 3,
                 int_field.clone(),

--- a/majit/majit-backend-dynasm/src/aarch64/assembler.rs
+++ b/majit/majit-backend-dynasm/src/aarch64/assembler.rs
@@ -2549,9 +2549,6 @@ impl<'a> AssemblerARM64<'a> {
             OpCode::GetfieldGcI
             | OpCode::GetfieldGcR
             | OpCode::GetfieldGcF
-            | OpCode::GetfieldGcPureI
-            | OpCode::GetfieldGcPureR
-            | OpCode::GetfieldGcPureF
             | OpCode::GetfieldRawI
             | OpCode::GetfieldRawR
             | OpCode::GetfieldRawF

--- a/majit/majit-backend-dynasm/src/regalloc.rs
+++ b/majit/majit-backend-dynasm/src/regalloc.rs
@@ -2971,9 +2971,6 @@ impl<'a> RegAlloc<'a> {
             OpCode::GetfieldGcI
             | OpCode::GetfieldGcR
             | OpCode::GetfieldGcF
-            | OpCode::GetfieldGcPureI
-            | OpCode::GetfieldGcPureR
-            | OpCode::GetfieldGcPureF
             | OpCode::GetfieldRawI
             | OpCode::GetfieldRawR
             | OpCode::GetfieldRawF
@@ -3226,9 +3223,6 @@ impl<'a> RegAlloc<'a> {
             OpCode::GetfieldGcI
             | OpCode::GetfieldGcR
             | OpCode::GetfieldGcF
-            | OpCode::GetfieldGcPureI
-            | OpCode::GetfieldGcPureR
-            | OpCode::GetfieldGcPureF
             | OpCode::GetfieldRawI
             | OpCode::GetfieldRawR
             | OpCode::GetfieldRawF => {

--- a/majit/majit-backend-dynasm/src/x86/assembler.rs
+++ b/majit/majit-backend-dynasm/src/x86/assembler.rs
@@ -3392,9 +3392,6 @@ impl<'a> Assembler386<'a> {
             OpCode::GetfieldGcI
             | OpCode::GetfieldGcR
             | OpCode::GetfieldGcF
-            | OpCode::GetfieldGcPureI
-            | OpCode::GetfieldGcPureR
-            | OpCode::GetfieldGcPureF
             | OpCode::GetfieldRawI
             | OpCode::GetfieldRawR
             | OpCode::GetfieldRawF

--- a/majit/majit-backend-wasm/src/codegen.rs
+++ b/majit/majit-backend-wasm/src/codegen.rs
@@ -2502,7 +2502,7 @@ fn build_function(
             }
 
             // ── Field access (direct memory operations) ──
-            OpCode::GetfieldGcI | OpCode::GetfieldGcPureI | OpCode::GetfieldRawI => {
+            OpCode::GetfieldGcI | OpCode::GetfieldRawI => {
                 let vi = op.pos.get().raw();
                 if !OpRef::raw_is_constant(vi) {
                     emit_resolve(&mut sink, constants, value_types, op.arg(0).to_opref()); // struct ptr (i64)
@@ -2513,7 +2513,7 @@ fn build_function(
                     sink.local_set(1 + vi);
                 }
             }
-            OpCode::GetfieldGcR | OpCode::GetfieldGcPureR | OpCode::GetfieldRawR => {
+            OpCode::GetfieldGcR | OpCode::GetfieldRawR => {
                 let vi = op.pos.get().raw();
                 if !OpRef::raw_is_constant(vi) {
                     emit_resolve(&mut sink, constants, value_types, op.arg(0).to_opref());
@@ -2560,7 +2560,7 @@ fn build_function(
             }
 
             // ── Float field access ──
-            OpCode::GetfieldGcF | OpCode::GetfieldGcPureF | OpCode::GetfieldRawF => {
+            OpCode::GetfieldGcF | OpCode::GetfieldRawF => {
                 let vi = op.pos.get().raw();
                 if !OpRef::raw_is_constant(vi) {
                     emit_resolve(&mut sink, constants, value_types, op.arg(0).to_opref());

--- a/majit/majit-gc/src/rewrite.rs
+++ b/majit/majit-gc/src/rewrite.rs
@@ -2281,13 +2281,6 @@ impl GcRewriterImpl {
             return false;
         }
         // rewrite.py:246-247 GETFIELD_{GC,RAW}_{I,R,F}.
-        // Upstream excludes GETFIELD_GC_PURE_{I,R,F}: the pure variants
-        // are `is_always_pure` at `resoperation.rs:1228` and must retain
-        // their pure-op identity; lowering them to GC_LOAD_* would drop
-        // purity and let the optimizer CSE-fold them differently from
-        // their upstream siblings.  So the pure arm is intentionally
-        // not handled here and falls through to the main loop's default
-        // arm (which emits the op unchanged).
         if matches!(
             opnum,
             OpCode::GetfieldGcI
@@ -3709,36 +3702,6 @@ mod tests {
         assert_eq!(result[0].opcode, OpCode::CondCallGcWb);
         assert_eq!(result[0].arg(0).to_opref(), obj);
         assert_eq!(result[1].opcode, OpCode::GcStore);
-    }
-
-    // ── Parity guards against `transform_to_gc_load` over-reaching ──
-
-    #[test]
-    fn test_getfield_gc_pure_not_lowered() {
-        // rewrite.py:246-247 excludes GETFIELD_GC_PURE_{I,R,F} from the
-        // lowering arm — upstream only handles GETFIELD_GC_{I,R,F} and
-        // GETFIELD_RAW_{I,R,F}.  The pure variant is `is_always_pure`
-        // at `resoperation.rs:1228` and must retain that identity; a
-        // stray lowering to GC_LOAD_R would drop purity semantics.
-        let rw = make_rewriter();
-        let obj = OpRef::ref_op(0);
-        let ops = vec![Op::with_descr(
-            OpCode::GetfieldGcPureR,
-            &[ro(obj)],
-            ref_field_descr(),
-        )];
-
-        let result = rw.rewrite_for_gc(&ops);
-
-        assert_eq!(result.len(), 1);
-        assert_eq!(result[0].opcode, OpCode::GetfieldGcPureR);
-        assert!(
-            !result.iter().any(|op| matches!(
-                op.opcode,
-                OpCode::GcLoadR | OpCode::GcLoadI | OpCode::GcLoadF
-            )),
-            "GETFIELD_GC_PURE_R must not be lowered to GC_LOAD_*"
-        );
     }
 
     #[test]

--- a/majit/majit-ir/src/resoperation.rs
+++ b/majit/majit-ir/src/resoperation.rs
@@ -2005,11 +2005,6 @@ pub enum OpCode {
     GetfieldRawR,
     GetfieldRawF,
 
-    // ── No side effect: pure field access (immutable) ──
-    GetfieldGcPureI,
-    GetfieldGcPureR,
-    GetfieldGcPureF,
-
     // ── Allocation ──
     New,
     NewWithVtable,
@@ -2201,20 +2196,12 @@ impl OpCode {
 
     pub fn is_always_pure(self) -> bool {
         let n = self.as_u16();
-        (ALWAYS_PURE_FIRST <= n && n <= ALWAYS_PURE_LAST)
-            || matches!(
-                self,
-                OpCode::GetfieldGcPureI | OpCode::GetfieldGcPureR | OpCode::GetfieldGcPureF
-            )
+        ALWAYS_PURE_FIRST <= n && n <= ALWAYS_PURE_LAST
     }
 
     pub fn has_no_side_effect(self) -> bool {
         let n = self.as_u16();
-        (NOSIDEEFFECT_FIRST <= n && n <= NOSIDEEFFECT_LAST)
-            || matches!(
-                self,
-                OpCode::GetfieldGcPureI | OpCode::GetfieldGcPureR | OpCode::GetfieldGcPureF
-            )
+        NOSIDEEFFECT_FIRST <= n && n <= NOSIDEEFFECT_LAST
     }
 
     pub fn is_malloc(self) -> bool {
@@ -2371,12 +2358,7 @@ impl OpCode {
     pub fn is_getfield(self) -> bool {
         matches!(
             self,
-            OpCode::GetfieldGcI
-                | OpCode::GetfieldGcR
-                | OpCode::GetfieldGcF
-                | OpCode::GetfieldGcPureI
-                | OpCode::GetfieldGcPureR
-                | OpCode::GetfieldGcPureF
+            OpCode::GetfieldGcI | OpCode::GetfieldGcR | OpCode::GetfieldGcF
         )
     }
 
@@ -2746,9 +2728,6 @@ impl OpCode {
                 | OpCode::GetfieldRawI
                 | OpCode::GetfieldRawR
                 | OpCode::GetfieldRawF
-                | OpCode::GetfieldGcPureI
-                | OpCode::GetfieldGcPureR
-                | OpCode::GetfieldGcPureF
                 // Untyped setfield
                 | OpCode::SetfieldGc
                 | OpCode::SetfieldRaw
@@ -3021,9 +3000,6 @@ static OPARITY: [Option<u8>; OPCODE_COUNT] = {
     set!(GetfieldRawI, 1);
     set!(GetfieldRawR, 1);
     set!(GetfieldRawF, 1);
-    set!(GetfieldGcPureI, 1);
-    set!(GetfieldGcPureR, 1);
-    set!(GetfieldGcPureF, 1);
     // Allocation
     set!(New, 0);
     set!(NewWithVtable, 0);
@@ -3145,9 +3121,6 @@ static OPWITHDESCR: [bool; OPCODE_COUNT] = {
         GetfieldRawI,
         GetfieldRawR,
         GetfieldRawF,
-        GetfieldGcPureI,
-        GetfieldGcPureR,
-        GetfieldGcPureF,
         // Allocation
         New,
         NewWithVtable,
@@ -3343,7 +3316,6 @@ static OPRESTYPE: [Type; OPCODE_COUNT] = {
         GetinteriorfieldGcI,
         GetfieldGcI,
         GetfieldRawI,
-        GetfieldGcPureI,
         Strhash,
         Unicodehash,
         CondCallValueI,
@@ -3391,7 +3363,6 @@ static OPRESTYPE: [Type; OPCODE_COUNT] = {
         GetinteriorfieldGcF,
         GetfieldGcF,
         GetfieldRawF,
-        GetfieldGcPureF,
         CallF,
         CallPureF,
         CallMayForceF,
@@ -3414,7 +3385,6 @@ static OPRESTYPE: [Type; OPCODE_COUNT] = {
         GetinteriorfieldGcR,
         GetfieldGcR,
         GetfieldRawR,
-        GetfieldGcPureR,
         New,
         NewWithVtable,
         NewArray,
@@ -3607,9 +3577,6 @@ static OPNAME: [&str; OPCODE_COUNT] = {
         GetfieldRawI,
         GetfieldRawR,
         GetfieldRawF,
-        GetfieldGcPureI,
-        GetfieldGcPureR,
-        GetfieldGcPureF,
         New,
         NewWithVtable,
         NewArray,
@@ -3852,9 +3819,6 @@ mod tests {
             OpCode::GetfieldRawI,
             OpCode::GetfieldRawR,
             OpCode::GetfieldRawF,
-            OpCode::GetfieldGcPureI,
-            OpCode::GetfieldGcPureR,
-            OpCode::GetfieldGcPureF,
             OpCode::NewArray,
             OpCode::NewArrayClear,
             OpCode::Newstr,
@@ -4043,7 +4007,6 @@ mod tests {
             OpCode::IntMulOvf,
             OpCode::GetfieldGcI,
             OpCode::GetfieldRawI,
-            OpCode::GetfieldGcPureI,
             OpCode::GetarrayitemGcI,
             OpCode::GetarrayitemRawI,
             OpCode::GetarrayitemGcPureI,
@@ -4076,7 +4039,6 @@ mod tests {
             OpCode::SameAsF,
             OpCode::GetfieldGcF,
             OpCode::GetfieldRawF,
-            OpCode::GetfieldGcPureF,
             OpCode::GetarrayitemGcF,
             OpCode::GetarrayitemRawF,
             OpCode::GetarrayitemGcPureF,
@@ -4116,7 +4078,6 @@ mod tests {
             OpCode::GuardException,
             OpCode::GetfieldGcR,
             OpCode::GetfieldRawR,
-            OpCode::GetfieldGcPureR,
             OpCode::GetarrayitemGcR,
             OpCode::GetarrayitemRawR,
             OpCode::GetarrayitemGcPureR,
@@ -4200,7 +4161,6 @@ mod tests {
 
         assert!(OpCode::IntAdd.is_always_pure());
         assert!(OpCode::FloatMul.is_always_pure());
-        assert!(OpCode::GetfieldGcPureI.is_always_pure());
         assert!(!OpCode::SetfieldGc.is_always_pure());
 
         assert!(OpCode::IntAddOvf.is_ovf());
@@ -4650,9 +4610,6 @@ mod tests {
         assert!(OpCode::GetfieldGcI.is_getfield());
         assert!(OpCode::GetfieldGcR.is_getfield());
         assert!(OpCode::GetfieldGcF.is_getfield());
-        assert!(OpCode::GetfieldGcPureI.is_getfield());
-        assert!(OpCode::GetfieldGcPureR.is_getfield());
-        assert!(OpCode::GetfieldGcPureF.is_getfield());
         assert!(!OpCode::GetfieldRawI.is_getfield());
         assert!(!OpCode::IntAdd.is_getfield());
     }

--- a/majit/majit-metainterp/src/box_trace.rs
+++ b/majit/majit-metainterp/src/box_trace.rs
@@ -62,6 +62,12 @@ fn getfield_gc_i_pureornot(
     // Record the plain GETFIELD_GC_I opnum regardless of
     // `descr.is_always_pure()`; purity is re-derived from the descr by
     // OptHeap. There is no pure getfield opnum.
+    // pyjitpl.py:948 cache-miss `execute_with_descr` routes through
+    // `execute_and_record`, which counts OPS and RECORDED_OPS.
+    ctx.profiler()
+        .count_ops(OpCode::GetfieldGcI, crate::counters::OPS);
+    ctx.profiler()
+        .count_ops(OpCode::GetfieldGcI, crate::counters::RECORDED_OPS);
     let result = ctx.record_op_with_descr(OpCode::GetfieldGcI, &[obj], descr.clone());
     // pyjitpl.py:948-949 — pair the recorded opref with the live int
     // payload so subsequent `box_value(result)` mirrors RPython's
@@ -335,6 +341,12 @@ fn getfield_gc_f_pureornot(
     // Record the plain GETFIELD_GC_F opnum regardless of
     // `descr.is_always_pure()`; purity is re-derived from the descr by
     // OptHeap. There is no pure getfield opnum.
+    // pyjitpl.py:948 cache-miss `execute_with_descr` routes through
+    // `execute_and_record`, which counts OPS and RECORDED_OPS.
+    ctx.profiler()
+        .count_ops(OpCode::GetfieldGcF, crate::counters::OPS);
+    ctx.profiler()
+        .count_ops(OpCode::GetfieldGcF, crate::counters::RECORDED_OPS);
     let result = ctx.record_op_with_descr(OpCode::GetfieldGcF, &[obj], descr.clone());
     // Pair the recorded opref with the live float payload — RPython's
     // executor returns a BoxFloat with both identity and value.

--- a/majit/majit-metainterp/src/box_trace.rs
+++ b/majit/majit-metainterp/src/box_trace.rs
@@ -59,12 +59,10 @@ fn getfield_gc_i_pureornot(
             .count_ops(OpCode::GetfieldGcI, crate::counters::HEAPCACHED_OPS);
         return cached;
     }
-    let opcode = if descr.is_always_pure() {
-        OpCode::GetfieldGcPureI
-    } else {
-        OpCode::GetfieldGcI
-    };
-    let result = ctx.record_op_with_descr(opcode, &[obj], descr.clone());
+    // Record the plain GETFIELD_GC_I opnum regardless of
+    // `descr.is_always_pure()`; purity is re-derived from the descr by
+    // OptHeap. There is no pure getfield opnum.
+    let result = ctx.record_op_with_descr(OpCode::GetfieldGcI, &[obj], descr.clone());
     // pyjitpl.py:948-949 — pair the recorded opref with the live int
     // payload so subsequent `box_value(result)` mirrors RPython's
     // executor-returned Box (history.py BoxInt(value=...)).
@@ -334,12 +332,10 @@ fn getfield_gc_f_pureornot(
             .count_ops(OpCode::GetfieldGcI, crate::counters::HEAPCACHED_OPS);
         return cached;
     }
-    let opcode = if descr.is_always_pure() {
-        OpCode::GetfieldGcPureF
-    } else {
-        OpCode::GetfieldGcF
-    };
-    let result = ctx.record_op_with_descr(opcode, &[obj], descr.clone());
+    // Record the plain GETFIELD_GC_F opnum regardless of
+    // `descr.is_always_pure()`; purity is re-derived from the descr by
+    // OptHeap. There is no pure getfield opnum.
+    let result = ctx.record_op_with_descr(OpCode::GetfieldGcF, &[obj], descr.clone());
     // Pair the recorded opref with the live float payload — RPython's
     // executor returns a BoxFloat with both identity and value.
     let live_value = if let Some(Value::Ref(struct_ref)) = ctx.box_value(obj) {

--- a/majit/majit-metainterp/src/compile.rs
+++ b/majit/majit-metainterp/src/compile.rs
@@ -2727,7 +2727,7 @@ mod tests {
             &[rooted_inputarg_operand(Type::Ref, 0), op0_result.clone()],
         ));
         let op2: majit_ir::OpRc = {
-            let mut op = Op::new(OpCode::GetfieldGcPureI, &[op0_result]);
+            let mut op = Op::new(OpCode::GetfieldGcI, &[op0_result]);
             op.pos.set(OpRef::int_op(11));
             op.setdescr(majit_ir::descr::make_field_descr(
                 16,
@@ -2778,7 +2778,7 @@ mod tests {
             vec![OpRef::input_arg_ref(0), forwarded_same_as]
         );
 
-        assert_eq!(ops[3].opcode, OpCode::GetfieldGcPureI);
+        assert_eq!(ops[3].opcode, OpCode::GetfieldGcI);
         assert_eq!(
             ops[3]
                 .getarglist()

--- a/majit/majit-metainterp/src/executor.rs
+++ b/majit/majit-metainterp/src/executor.rs
@@ -549,7 +549,14 @@ pub fn execute_nonspec_const(
         if let Some(folded) = execute_cast_const(opnum, a) {
             return Ok(Some(folded));
         }
-        // GETFIELD_GC_PURE_I/R/F — withdescr arity-1.
+        // GETFIELD_GC_{I,R,F} — withdescr arity-1, both spellings.
+        // The executor helper is registered under the plain opnum
+        // (resoperation.py's table has no PURE getfield opnums; the
+        // fold decision is the caller's, gated on
+        // `descr.is_always_pure()` at `heap.py:641
+        // optimize_GETFIELD_GC_I`), so the fold must accept the plain
+        // spelling too — pyre additionally records GetfieldGcPure*
+        // at trace time and both shapes reach `constant_fold`.
         // `optimizer.py:829-832 protect_speculative_operation` has
         // validated the gcref is non-null and of a valid type for
         // `fielddescr.parent_descr` (`llmodel.py:555-567`); the
@@ -560,16 +567,20 @@ pub fn execute_nonspec_const(
         if let (Value::Ref(struct_ref), Some(d)) = (a, descr) {
             if let Some(fd) = d.as_field_descr() {
                 return Ok(Some(match opnum {
-                    OpCode::GetfieldGcPureI => match fd.field_size() {
+                    OpCode::GetfieldGcPureI | OpCode::GetfieldGcI => match fd.field_size() {
                         1 | 2 | 4 | 8 => Value::Int(cpu.bh_getfield_gc_i(struct_ref.0, fd)),
                         sz => unreachable!(
-                            "GETFIELD_GC_PURE_I: unsupported field_size {} \
+                            "GETFIELD_GC_I: unsupported field_size {} \
                              (llmodel.py:478 raises NotImplementedError)",
                             sz
                         ),
                     },
-                    OpCode::GetfieldGcPureR => Value::Ref(cpu.bh_getfield_gc_r(struct_ref.0, fd)),
-                    OpCode::GetfieldGcPureF => Value::Float(cpu.bh_getfield_gc_f(struct_ref.0, fd)),
+                    OpCode::GetfieldGcPureR | OpCode::GetfieldGcR => {
+                        Value::Ref(cpu.bh_getfield_gc_r(struct_ref.0, fd))
+                    }
+                    OpCode::GetfieldGcPureF | OpCode::GetfieldGcF => {
+                        Value::Float(cpu.bh_getfield_gc_f(struct_ref.0, fd))
+                    }
                     _ => return Err(()),
                 }));
             }
@@ -1026,5 +1037,41 @@ mod execute_pure_call_tests {
         effect.extraeffect = ExtraEffect::ElidableCanRaise;
         let descr = SimpleCallDescr::new(0, vec![Type::Int], Type::Int, false, 8, effect);
         let _ = execute_pure_call(&descr, double_i64 as *const () as i64, &[1]);
+    }
+}
+
+#[cfg(test)]
+mod execute_nonspec_const_tests {
+    use super::*;
+    use majit_ir::descr::{DescrRef, SimpleFieldDescr};
+    use majit_ir::{Type, Value};
+    use std::sync::Arc;
+
+    /// The getfield fold arm must accept the plain spelling: the
+    /// executor helper is registered under the plain opnum upstream,
+    /// and `heap.py:641 optimize_GETFIELD_GC_I` folds a plain-spelled
+    /// op whenever `descr.is_always_pure()` holds and the base becomes
+    /// constant. A plain-only miss here surfaces as the
+    /// `constant_fold` "no helper registered" panic.
+    #[test]
+    fn getfield_gc_fold_accepts_plain_and_pure_spellings() {
+        let cpu = crate::cpu::default_cpu();
+        // One-field struct layout: header word + i64 payload at offset 8.
+        let storage: Box<[i64; 2]> = Box::new([0, 42]);
+        let base = storage.as_ref().as_ptr() as usize;
+        let descr: DescrRef = Arc::new(SimpleFieldDescr::new(0, 8, 8, Type::Int, true));
+        for opnum in [OpCode::GetfieldGcI, OpCode::GetfieldGcPureI] {
+            let folded = execute_nonspec_const(
+                cpu.as_ref(),
+                opnum,
+                &[Value::Ref(majit_ir::GcRef(base))],
+                Some(&descr),
+                Type::Int,
+            );
+            match folded {
+                Ok(Some(Value::Int(42))) => {}
+                other => panic!("{opnum:?} must fold to Ok(Some(Int(42))), got {other:?}"),
+            }
+        }
     }
 }

--- a/majit/majit-metainterp/src/executor.rs
+++ b/majit/majit-metainterp/src/executor.rs
@@ -549,14 +549,13 @@ pub fn execute_nonspec_const(
         if let Some(folded) = execute_cast_const(opnum, a) {
             return Ok(Some(folded));
         }
-        // GETFIELD_GC_{I,R,F} — withdescr arity-1, both spellings.
+        // GETFIELD_GC_{I,R,F} — withdescr arity-1.
         // The executor helper is registered under the plain opnum
         // (resoperation.py's table has no PURE getfield opnums; the
         // fold decision is the caller's, gated on
         // `descr.is_always_pure()` at `heap.py:641
         // optimize_GETFIELD_GC_I`), so the fold must accept the plain
-        // spelling too — pyre additionally records GetfieldGcPure*
-        // at trace time and both shapes reach `constant_fold`.
+        // spelling used for immutable fields.
         // `optimizer.py:829-832 protect_speculative_operation` has
         // validated the gcref is non-null and of a valid type for
         // `fielddescr.parent_descr` (`llmodel.py:555-567`); the
@@ -567,7 +566,7 @@ pub fn execute_nonspec_const(
         if let (Value::Ref(struct_ref), Some(d)) = (a, descr) {
             if let Some(fd) = d.as_field_descr() {
                 return Ok(Some(match opnum {
-                    OpCode::GetfieldGcPureI | OpCode::GetfieldGcI => match fd.field_size() {
+                    OpCode::GetfieldGcI => match fd.field_size() {
                         1 | 2 | 4 | 8 => Value::Int(cpu.bh_getfield_gc_i(struct_ref.0, fd)),
                         sz => unreachable!(
                             "GETFIELD_GC_I: unsupported field_size {} \
@@ -575,12 +574,8 @@ pub fn execute_nonspec_const(
                             sz
                         ),
                     },
-                    OpCode::GetfieldGcPureR | OpCode::GetfieldGcR => {
-                        Value::Ref(cpu.bh_getfield_gc_r(struct_ref.0, fd))
-                    }
-                    OpCode::GetfieldGcPureF | OpCode::GetfieldGcF => {
-                        Value::Float(cpu.bh_getfield_gc_f(struct_ref.0, fd))
-                    }
+                    OpCode::GetfieldGcR => Value::Ref(cpu.bh_getfield_gc_r(struct_ref.0, fd)),
+                    OpCode::GetfieldGcF => Value::Float(cpu.bh_getfield_gc_f(struct_ref.0, fd)),
                     _ => return Err(()),
                 }));
             }
@@ -1054,24 +1049,23 @@ mod execute_nonspec_const_tests {
     /// constant. A plain-only miss here surfaces as the
     /// `constant_fold` "no helper registered" panic.
     #[test]
-    fn getfield_gc_fold_accepts_plain_and_pure_spellings() {
+    fn getfield_gc_fold_accepts_plain_spelling() {
         let cpu = crate::cpu::default_cpu();
         // One-field struct layout: header word + i64 payload at offset 8.
         let storage: Box<[i64; 2]> = Box::new([0, 42]);
         let base = storage.as_ref().as_ptr() as usize;
         let descr: DescrRef = Arc::new(SimpleFieldDescr::new(0, 8, 8, Type::Int, true));
-        for opnum in [OpCode::GetfieldGcI, OpCode::GetfieldGcPureI] {
-            let folded = execute_nonspec_const(
-                cpu.as_ref(),
-                opnum,
-                &[Value::Ref(majit_ir::GcRef(base))],
-                Some(&descr),
-                Type::Int,
-            );
-            match folded {
-                Ok(Some(Value::Int(42))) => {}
-                other => panic!("{opnum:?} must fold to Ok(Some(Int(42))), got {other:?}"),
-            }
+        let opnum = OpCode::GetfieldGcI;
+        let folded = execute_nonspec_const(
+            cpu.as_ref(),
+            opnum,
+            &[Value::Ref(majit_ir::GcRef(base))],
+            Some(&descr),
+            Type::Int,
+        );
+        match folded {
+            Ok(Some(Value::Int(42))) => {}
+            other => panic!("{opnum:?} must fold to Ok(Some(Int(42))), got {other:?}"),
         }
     }
 }

--- a/majit/majit-metainterp/src/history.rs
+++ b/majit/majit-metainterp/src/history.rs
@@ -2479,7 +2479,15 @@ impl TraceCtx {
     /// no longer used.
     pub fn record_guard(&mut self, opcode: OpCode, args: &[OpRef], num_live: usize) -> OpRef {
         let _ = num_live;
-        Self::do_record_guard(&mut self.recorder, opcode, args, None)
+        let opref = Self::do_record_guard(&mut self.recorder, opcode, args, None);
+        // pyjitpl.py:2581 `count_ops(opnum, Counters.GUARDS)` — counted
+        // here at the record chokepoint so every recording call site
+        // bumps the bucket exactly once. generate_guard's Const-box
+        // early return records nothing (pyjitpl.py:2559), and callers
+        // here likewise fold instead of calling record_guard, so
+        // "count once per recorded guard" matches upstream.
+        self.profiler().count_ops(opcode, crate::counters::GUARDS);
+        opref
     }
 
     /// Record a guard carrying a pre-minted `ResumeGuardDescr`.
@@ -2494,7 +2502,10 @@ impl TraceCtx {
         args: &[OpRef],
         descr: DescrRef,
     ) -> OpRef {
-        Self::do_record_guard(&mut self.recorder, opcode, args, Some(descr))
+        let opref = Self::do_record_guard(&mut self.recorder, opcode, args, Some(descr));
+        // pyjitpl.py:2581 — see record_guard.
+        self.profiler().count_ops(opcode, crate::counters::GUARDS);
+        opref
     }
 
     /// `pyjitpl.py:2548 generate_guard()` parity: tracer-stage typed
@@ -2520,6 +2531,8 @@ impl TraceCtx {
     ) -> OpRef {
         let opref = Self::do_record_guard(&mut self.recorder, opcode, args, None);
         self.recorder.set_last_op_fail_arg_types(fail_arg_types);
+        // pyjitpl.py:2581 — see record_guard.
+        self.profiler().count_ops(opcode, crate::counters::GUARDS);
         opref
     }
 

--- a/majit/majit-metainterp/src/optimizeopt/heap.rs
+++ b/majit/majit-metainterp/src/optimizeopt/heap.rs
@@ -2280,8 +2280,7 @@ impl OptHeap {
             ctx.structinfo_setfield(op, field_idx, op.pos.get());
         }
         // Virtualizable Ref fields (linked list head) need a null guard.
-        let is_vable_ref =
-            is_vable_field && matches!(op.opcode, OpCode::GetfieldGcR | OpCode::GetfieldGcPureR);
+        let is_vable_ref = is_vable_field && matches!(op.opcode, OpCode::GetfieldGcR);
         if is_vable_ref {
             ctx.emit(op.clone());
             let zero_ref = ctx.make_constant_int(0);
@@ -3021,12 +3020,9 @@ impl OptHeap {
     ) -> OptimizationResult {
         match op.opcode {
             // ── Field reads ──
-            OpCode::GetfieldGcI
-            | OpCode::GetfieldGcR
-            | OpCode::GetfieldGcF
-            | OpCode::GetfieldGcPureI
-            | OpCode::GetfieldGcPureR
-            | OpCode::GetfieldGcPureF => self.optimize_getfield(op, op_rc, ctx),
+            OpCode::GetfieldGcI | OpCode::GetfieldGcR | OpCode::GetfieldGcF => {
+                self.optimize_getfield(op, op_rc, ctx)
+            }
 
             // ── Raw field reads/writes ──
             // Keep these conservative. The standard heap.py cache/postprocess

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -840,7 +840,7 @@ pub struct OptContext {
     /// upstream keys producers on `box._forwarded`, not a positional map).
     pub(crate) phase1_emit_ops_index: FxHashMap<OpRef, majit_ir::OpRc>,
     /// Recorder trace ops that carry the input operands' producer `Op`
-    /// (e.g. the `IntLt`/`GetfieldGcPureI` operands of a recorded loop),
+    /// (e.g. the `IntLt`/immutable `GetfieldGcI` operands of a recorded loop),
     /// shared by `Rc` with the canonical stores but absent from
     /// `new_operations` / `phase1_emit_ops` / `resop_refs`. Seeded at
     /// optimizer setup from the recorder's `Rc<Op>` slice (`TreeLoop.ops`

--- a/majit/majit-metainterp/src/optimizeopt/optimizer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/optimizer.rs
@@ -5776,7 +5776,25 @@ mod tests {
 
     #[test]
     fn test_default_pipeline_keeps_call_may_force_pairs_alive_when_results_are_used() {
-        let field_descr = Arc::new(TestDescr(91));
+        let field_group = majit_ir::descr::make_simple_descr_group(
+            91,
+            16,
+            1,
+            0,
+            &[majit_ir::descr::SimpleFieldDescrSpec {
+                index: 91,
+                name: "CallResult.field".to_string(),
+                offset: 0,
+                field_size: 8,
+                field_type: Type::Int,
+                is_immutable: true,
+                is_quasi_immutable: false,
+                flag: majit_ir::ArrayFlag::Signed,
+                virtualizable: false,
+                index_in_parent: 0,
+            }],
+        );
+        let field_descr = field_group.field_descrs[0].clone() as DescrRef;
         let call_descr_a = call_may_force_descr(81, majit_ir::Type::Ref);
         let call_descr_b = call_may_force_descr(82, majit_ir::Type::Ref);
         let mut ops = vec![
@@ -5790,7 +5808,7 @@ mod tests {
             ),
             Op::new(OpCode::GuardNotForced, &[]),
             Op::with_descr(
-                OpCode::GetfieldGcPureI,
+                OpCode::GetfieldGcI,
                 &[rooted_resop_operand(Type::Ref, 3)],
                 field_descr.clone(),
             ),
@@ -5804,7 +5822,7 @@ mod tests {
             ),
             Op::new(OpCode::GuardNotForced, &[]),
             Op::with_descr(
-                OpCode::GetfieldGcPureI,
+                OpCode::GetfieldGcI,
                 &[rooted_resop_operand(Type::Ref, 6)],
                 field_descr,
             ),
@@ -5848,7 +5866,39 @@ mod tests {
 
     #[test]
     fn test_default_pipeline_keeps_call_may_force_when_guard_fail_args_reference_results() {
-        let field_descr = Arc::new(TestDescr(101));
+        let field_group = majit_ir::descr::make_simple_descr_group(
+            101,
+            24,
+            2,
+            0,
+            &[
+                majit_ir::descr::SimpleFieldDescrSpec {
+                    index: 101,
+                    name: "CallResult.type".to_string(),
+                    offset: 0,
+                    field_size: 8,
+                    field_type: Type::Int,
+                    is_immutable: true,
+                    is_quasi_immutable: false,
+                    flag: majit_ir::ArrayFlag::Signed,
+                    virtualizable: false,
+                    index_in_parent: 0,
+                },
+                majit_ir::descr::SimpleFieldDescrSpec {
+                    index: 102,
+                    name: "CallResult.value".to_string(),
+                    offset: 8,
+                    field_size: 8,
+                    field_type: Type::Int,
+                    is_immutable: true,
+                    is_quasi_immutable: false,
+                    flag: majit_ir::ArrayFlag::Signed,
+                    virtualizable: false,
+                    index_in_parent: 1,
+                },
+            ],
+        );
+        let field_descr = field_group.field_descrs[0].clone() as DescrRef;
         // Distinct field so `get_a_val` is not CSE-folded into `get_a_type`:
         // it stays a live producer at its own position, which guard_b's fail
         // args reference (a fail arg pointing at a *folded* getfield would make
@@ -5856,7 +5906,7 @@ mod tests {
         // forwards to the survivor — the resolve_box_box divergence tripwire,
         // mod.rs:4750; binding to the real folded producer needs the oprc
         // driver, blocked here by CallMayForceR's void result position).
-        let field_descr_b = Arc::new(TestDescr(102));
+        let field_descr_b = field_group.field_descrs[1].clone() as DescrRef;
         let call_descr_a = call_may_force_descr(83, majit_ir::Type::Ref);
         let call_descr_b = call_may_force_descr(84, majit_ir::Type::Ref);
         let guard_types_a = vec![
@@ -5916,12 +5966,12 @@ mod tests {
         );
         guard_a.set_fail_arg_types(guard_types_a);
         let get_a_type = Op::with_descr(
-            OpCode::GetfieldGcPureI,
+            OpCode::GetfieldGcI,
             &[rooted_resop_operand(Type::Ref, 3)],
             field_descr.clone(),
         );
         let get_a_val = Op::with_descr(
-            OpCode::GetfieldGcPureI,
+            OpCode::GetfieldGcI,
             &[rooted_resop_operand(Type::Ref, 3)],
             field_descr_b.clone(),
         );
@@ -5953,12 +6003,12 @@ mod tests {
         );
         guard_b.set_fail_arg_types(guard_types_b);
         let get_b_type = Op::with_descr(
-            OpCode::GetfieldGcPureI,
+            OpCode::GetfieldGcI,
             &[rooted_resop_operand(Type::Ref, 7)],
             field_descr.clone(),
         );
         let get_b_val = Op::with_descr(
-            OpCode::GetfieldGcPureI,
+            OpCode::GetfieldGcI,
             &[rooted_resop_operand(Type::Ref, 7)],
             field_descr,
         );

--- a/majit/majit-metainterp/src/optimizeopt/pure.rs
+++ b/majit/majit-metainterp/src/optimizeopt/pure.rs
@@ -214,7 +214,7 @@ impl RecentPureOpTable {
     }
 
     fn bucket_count() -> usize {
-        (OpCode::LoadEffectiveAddress as usize - OpCode::IntAdd as usize + 1) + 3
+        OpCode::LoadEffectiveAddress as usize - OpCode::IntAdd as usize + 1
     }
 
     fn bucket_index(opcode: OpCode) -> Option<usize> {
@@ -222,15 +222,6 @@ impl RecentPureOpTable {
             return Some(opcode as usize - OpCode::IntAddOvf as usize);
         }
         match opcode {
-            OpCode::GetfieldGcPureI => {
-                Some(OpCode::LoadEffectiveAddress as usize - OpCode::IntAdd as usize + 1)
-            }
-            OpCode::GetfieldGcPureR => {
-                Some(OpCode::LoadEffectiveAddress as usize - OpCode::IntAdd as usize + 2)
-            }
-            OpCode::GetfieldGcPureF => {
-                Some(OpCode::LoadEffectiveAddress as usize - OpCode::IntAdd as usize + 3)
-            }
             _ if opcode.is_always_pure() => Some(opcode as usize - OpCode::IntAdd as usize),
             _ => None,
         }
@@ -1302,21 +1293,6 @@ impl Optimization for OptPure {
     /// then this method transfers them into OptPure's preamble caches.
     fn install_preamble_pure_ops(&mut self, ctx: &OptContext) {
         for entry in &ctx.imported_short_pure_ops {
-            // heap.py:640-643: GetfieldGcPure on constant objects are
-            // handled by constant_fold in the heap optimizer. Skip these
-            // to avoid conflicting with the heap path. Non-constant
-            // GetfieldGcPure ops go through the pure cache normally.
-            if matches!(
-                entry.opcode,
-                OpCode::GetfieldGcPureI | OpCode::GetfieldGcPureR | OpCode::GetfieldGcPureF
-            ) {
-                let arg0_is_const = entry.args.first().map_or(false, |a| {
-                    matches!(a, crate::optimizeopt::ImportedShortPureArg::Const(..))
-                });
-                if arg0_is_const {
-                    continue;
-                }
-            }
             // The replay `preamble_op` was built by `ImportedShortPureOp::new`
             // from the same arg list with producer-bound operands
             // (shortpreamble.py:425 — the replay op carries the same Box
@@ -2269,147 +2245,85 @@ mod tests {
         assert_eq!(ovf_count, 0, "OVF(3,4) should be constant-folded");
     }
 
-    #[repr(C)]
-    struct TestIntFieldObject {
-        value: i64,
-    }
-
-    #[repr(C)]
-    struct TestFloatFieldObject {
-        value: f64,
-    }
-
-    #[repr(C)]
-    struct TestRefFieldObject {
-        value: usize,
+    fn run_immutable_getfield_cse(opcode: OpCode, index: u32, field_type: Type) -> Vec<Op> {
+        let flag = match field_type {
+            Type::Int => majit_ir::ArrayFlag::Signed,
+            Type::Float => majit_ir::ArrayFlag::Float,
+            Type::Ref => majit_ir::ArrayFlag::Unsigned,
+            _ => unreachable!("getfield CSE test requires a typed field"),
+        };
+        let group = majit_ir::descr::make_simple_descr_group(
+            index,
+            16,
+            1,
+            0,
+            &[majit_ir::descr::SimpleFieldDescrSpec {
+                index,
+                name: format!("CseField{index}"),
+                offset: 0,
+                field_size: 8,
+                field_type,
+                is_immutable: true,
+                is_quasi_immutable: false,
+                flag,
+                virtualizable: false,
+                index_in_parent: 0,
+            }],
+        );
+        let descr = group.field_descrs[0].clone() as majit_ir::DescrRef;
+        let base = crate::history::test_support::rooted_inputarg_operand(Type::Ref, 100);
+        let mut ops = vec![
+            Op::with_descr(opcode, &[base.clone()], descr.clone()),
+            Op::with_descr(opcode, &[base], descr),
+            Op::new(OpCode::Jump, &[]),
+        ];
+        assign_positions(&mut ops);
+        let mut opt = Optimizer::new();
+        opt.add_pass(Box::new(crate::optimizeopt::heap::OptHeap::new()));
+        opt.trace_inputargs = OpRef::inputarg_refs(&vec![Type::Ref; 1024]);
+        let (ops, snapshots) = super::super::seed_empty_guard_snapshots(&ops);
+        opt.snapshot_boxes = snapshots;
+        opt.optimize_with_constants_and_inputs(&ops, &mut majit_ir::ConstMap::new(), 1024)
     }
 
     #[test]
-    fn test_constant_fold_getfield_gc_pure_i_from_constant_object() {
-        let object = Box::new(TestIntFieldObject { value: 123 });
-        let ptr = Box::into_raw(object) as usize;
-
-        let descr = make_field_descr_full(1, 0, 8, Type::Int, true);
-        let mut pass = OptPure::new();
-        let mut ctx = OptContext::with_num_inputs(4, 0);
-        // The struct operand is the canonical box materialized in ctx and made
-        // a Ref constant; the op carries that same box (no position-only mint).
-        let struct_box = ctx.materialize_operand_at(OpRef::ref_op(10));
-        ctx.make_constant_box(&struct_box, Value::Ref(GcRef(ptr)));
-        let mut op = Op::with_descr(OpCode::GetfieldGcPureI, &[struct_box.clone()], descr);
-        op.pos.set(OpRef::int_op(0));
-        pass.setup();
-
-        // Resolve forwarded args (mirrors propagate_from_pass_range) so the op
-        // carries the canonical const box the pass reads via get_constant_box.
-        let resolved = ctx
-            .resolve_operand_operand_opt(&op.arg(0))
-            .expect("constant arg resolves");
-        op.setarg(0, resolved);
-
-        assert_eq!(ctx.constant_fold(&op), Some(Value::Int(123)));
-        let result = pass.propagate_forward(&op, &std::rc::Rc::new(op.clone()), &mut ctx);
-        assert!(matches!(result, OptimizationResult::Remove));
-        assert_eq!(
-            ctx.get_box_replacement_operand_opt(OpRef::int_op(0))
-                .and_then(|cb| cb.const_int()),
-            Some(123)
-        );
-
-        unsafe {
-            drop(Box::from_raw(ptr as *mut TestIntFieldObject));
-        }
+    fn test_immutable_getfield_gc_i_cse_uses_heap_cache() {
+        let result = run_immutable_getfield_cse(OpCode::GetfieldGcI, 1, Type::Int);
+        assert_eq!(result.len(), 2);
+        assert_eq!(result[0].opcode, OpCode::GetfieldGcI);
+        assert_eq!(result[1].opcode, OpCode::Jump);
     }
 
     #[test]
-    fn test_constant_fold_getfield_gc_pure_f_from_constant_object() {
-        let object = Box::new(TestFloatFieldObject { value: 3.5 });
-        let ptr = Box::into_raw(object) as usize;
-
-        let descr = make_field_descr_full(2, 0, 8, Type::Float, true);
-        let mut pass = OptPure::new();
-        let mut ctx = OptContext::with_num_inputs(4, 0);
-        let struct_box = ctx.materialize_operand_at(OpRef::ref_op(10));
-        ctx.make_constant_box(&struct_box, Value::Ref(GcRef(ptr)));
-        let mut op = Op::with_descr(OpCode::GetfieldGcPureF, &[struct_box.clone()], descr);
-        op.pos.set(OpRef::float_op(0));
-        pass.setup();
-
-        // Resolve forwarded args (mirrors propagate_from_pass_range) so the op
-        // carries the canonical const box the pass reads via get_constant_box.
-        let resolved = ctx
-            .resolve_operand_operand_opt(&op.arg(0))
-            .expect("constant arg resolves");
-        op.setarg(0, resolved);
-
-        assert_eq!(ctx.constant_fold(&op), Some(Value::Float(3.5)));
-        let result = pass.propagate_forward(&op, &std::rc::Rc::new(op.clone()), &mut ctx);
-        assert!(matches!(result, OptimizationResult::Remove));
-        assert_eq!(
-            ctx.get_box_replacement_operand_opt(OpRef::float_op(0))
-                .and_then(|b| ctx.get_constant_float_box(&b)),
-            Some(3.5)
-        );
-
-        unsafe {
-            drop(Box::from_raw(ptr as *mut TestFloatFieldObject));
-        }
+    fn test_immutable_getfield_gc_f_cse_uses_heap_cache() {
+        let result = run_immutable_getfield_cse(OpCode::GetfieldGcF, 2, Type::Float);
+        assert_eq!(result.len(), 2);
+        assert_eq!(result[0].opcode, OpCode::GetfieldGcF);
+        assert_eq!(result[1].opcode, OpCode::Jump);
     }
 
     #[test]
-    fn test_constant_fold_getfield_gc_pure_r_from_constant_object() {
-        let object = Box::new(TestRefFieldObject {
-            value: 0x1234_5678usize,
-        });
-        let ptr = Box::into_raw(object) as usize;
-
-        let descr = make_field_descr_full(3, 0, std::mem::size_of::<usize>(), Type::Ref, true);
-        let mut pass = OptPure::new();
-        let mut ctx = OptContext::with_num_inputs(4, 0);
-        let struct_box = ctx.materialize_operand_at(OpRef::ref_op(10));
-        ctx.make_constant_box(&struct_box, Value::Ref(GcRef(ptr)));
-        let mut op = Op::with_descr(OpCode::GetfieldGcPureR, &[struct_box.clone()], descr);
-        op.pos.set(OpRef::ref_op(0));
-        pass.setup();
-
-        // Resolve forwarded args (mirrors propagate_from_pass_range) so the op
-        // carries the canonical const box the pass reads via get_constant_box.
-        let resolved = ctx
-            .resolve_operand_operand_opt(&op.arg(0))
-            .expect("constant arg resolves");
-        op.setarg(0, resolved);
-
-        assert_eq!(
-            ctx.constant_fold(&op),
-            Some(Value::Ref(GcRef(0x1234_5678usize)))
-        );
-        let result = pass.propagate_forward(&op, &std::rc::Rc::new(op.clone()), &mut ctx);
-        assert!(matches!(result, OptimizationResult::Remove));
-        assert_eq!(
-            ctx.get_box_replacement_operand_opt(OpRef::ref_op(0))
-                .and_then(|cb| cb.const_value()),
-            Some(Value::Ref(GcRef(0x1234_5678usize)))
-        );
-
-        unsafe {
-            drop(Box::from_raw(ptr as *mut TestRefFieldObject));
-        }
+    fn test_immutable_getfield_gc_r_cse_uses_heap_cache() {
+        let result = run_immutable_getfield_cse(OpCode::GetfieldGcR, 3, Type::Ref);
+        assert_eq!(result.len(), 2);
+        assert_eq!(result[0].opcode, OpCode::GetfieldGcR);
+        assert_eq!(result[1].opcode, OpCode::Jump);
     }
 
     #[test]
     #[should_panic(expected = "must be a gcref")]
-    fn test_constant_fold_getfield_gc_pure_does_not_treat_int_constant_as_gc_pointer() {
+    fn test_constant_fold_getfield_gc_does_not_treat_int_constant_as_gc_pointer() {
         // Upstream `optimizer.py:829-832 protect_speculative_operation`
         // derefs `op.getarg(0)` via `getref_base()` — only `ConstPtr`
-        // supports that.  RPython's type system makes a `GETFIELD_GC_
-        // PURE_I` with `ConstInt` arg0 unconstructible.  Pyre's
+        // supports that. RPython's type system makes a `GETFIELD_GC_I`
+        // with `ConstInt` arg0 unconstructible. Pyre's
         // strict-orthodoxy port panics on the variant mismatch instead
         // of returning `None`; this test pins that behavior.
         let descr = make_field_descr_full(4, 0, 8, Type::Int, true);
         let mut ctx = OptContext::with_num_inputs(4, 0);
         let arg_box = ctx.materialize_operand_at(OpRef::int_op(10));
         ctx.make_constant_box(&arg_box, Value::Int(2));
-        let mut op = Op::with_descr(OpCode::GetfieldGcPureI, &[arg_box.clone()], descr);
+        let mut op = Op::with_descr(OpCode::GetfieldGcI, &[arg_box.clone()], descr);
         op.pos.set(OpRef::int_op(0));
 
         // Resolve forwarded args (mirrors propagate_from_pass_range) so the op

--- a/majit/majit-metainterp/src/optimizeopt/unroll.rs
+++ b/majit/majit-metainterp/src/optimizeopt/unroll.rs
@@ -3788,7 +3788,7 @@ impl OptUnroll {
         // NOT in `inputargs` (= originals there), so THIS leg is the sole mapper
         // that resolves them to jump_args. Measured LOAD-BEARING: 176 consumptions
         // across the check.py corpus on both backends, all GuardNonnullClass /
-        // GetfieldGcPure over ref inputargs (the redundant-guard / pure-getfield
+        // Immutable GetfieldGc over ref inputargs (the redundant-guard / field-read
         // elimination on loop-carried references). Dropping this leg routes those
         // args to the None → InvalidLoop arm below — correct, but it loses the loop
         // inlining for those traces. (The originals-domain seeding from the import
@@ -3989,11 +3989,11 @@ impl OptUnroll {
                 // already carries it). Overwriting the seed for such an op would
                 // make every later short op that reads the input resolve to this
                 // fresh, field-less allocation instead of the loop-carried box, so
-                // a `GetfieldGcPureI` over the aliased input reads an uninitialized
+                // a `GetfieldGcI` over the aliased input reads an uninitialized
                 // field. Skip the insert ONLY for those allocation ops
                 // (`is_malloc`: New..Newunicode) to preserve the seed. A colliding
                 // NON-allocation op (a pure read/compute whose result pos happens
-                // to alias a seed, e.g. `GetfieldGcPureI` producing an Int loop
+                // to alias a seed, e.g. `GetfieldGcI` producing an Int loop
                 // slot) is a genuine recomputation whose fresh result IS the
                 // correct binding — skipping it would strand the slot on the seed's
                 // Ref box and feed a Ref into an Int consumer (getintbound_handle
@@ -7127,7 +7127,7 @@ mod tests {
         let mut optimizer = crate::optimizeopt::optimizer::Optimizer::new();
         let mut ctx = crate::optimizeopt::OptContext::with_num_inputs(8, 0);
         let ptr = GcRef(0x1234_5678);
-        let field_descr = majit_ir::descr::make_field_descr_full(88, 0, 8, Type::Int, false);
+        let field_descr = majit_ir::descr::make_field_descr_full(88, 0, 8, Type::Int, true);
         // ConstPtr.value inline (history.py:314): the producer seeds the
         // inline variant that carries the pointer directly; the consumer
         // reads it back without any pool lookup.
@@ -7137,7 +7137,7 @@ mod tests {
             .push(crate::optimizeopt::shortpreamble::PreambleOp {
                 op: {
                     let mut op = Op::with_descr(
-                        OpCode::GetfieldGcPureI,
+                        OpCode::GetfieldGcI,
                         &[Operand::from_opref(OpRef::const_ptr(ptr))],
                         field_descr.clone(),
                     );
@@ -7163,7 +7163,7 @@ mod tests {
             &mut ctx,
             None,
         );
-        // Both label args resolve to Int op slots (12 / 11 = GetfieldGcPureI base / result).
+        // Both label args resolve to Int op slots (12 / 11 = GetfieldGcI base / result).
         let mut ctx2 =
             crate::optimizeopt::OptContext::with_inputarg_types(8, &[Type::Int, Type::Int]);
         let targetargs = [OpRef::input_arg_int(0), OpRef::input_arg_int(1)];
@@ -7177,7 +7177,7 @@ mod tests {
         assert_eq!(ctx2.get_constant(fresh_const), Some(Value::Ref(ptr)));
         let expected = crate::optimizeopt::ImportedShortPureOp::new(
             &mut ctx2,
-            OpCode::GetfieldGcPureI,
+            OpCode::GetfieldGcI,
             Some(field_descr.clone()),
             vec![crate::optimizeopt::ImportedShortPureArg::Const(
                 Value::Ref(ptr),
@@ -7975,16 +7975,14 @@ mod tests {
         // pre-replaced with OpRef::int_op(10) (the corresponding label_arg).
         let p2_ops = vec![
             {
-                let mut op = Op::new(
-                    OpCode::GetfieldGcPureI,
-                    &[rooted_resop_operand(Type::Int, 50)],
-                );
+                let mut op = Op::new(OpCode::GetfieldGcI, &[rooted_resop_operand(Type::Int, 50)]);
                 op.pos.set(OpRef::int_op(1));
-                op.setdescr(majit_ir::make_field_descr(
+                op.setdescr(majit_ir::descr::make_field_descr_full(
+                    0,
                     0,
                     8,
                     majit_ir::Type::Int,
-                    majit_ir::ArrayFlag::Signed,
+                    true,
                 ));
                 op
             },
@@ -8030,7 +8028,7 @@ mod tests {
             &[OpRef::int_op(10), extra_label_arg.to_opref()]
         );
         let body_getfield = &combined[label_idx + 1];
-        assert_eq!(body_getfield.opcode, OpCode::GetfieldGcPureI);
+        assert_eq!(body_getfield.opcode, OpCode::GetfieldGcI);
         assert_eq!(
             body_getfield
                 .getarglist()

--- a/majit/majit-metainterp/src/optimizeopt/virtualize.rs
+++ b/majit/majit-metainterp/src/optimizeopt/virtualize.rs
@@ -915,13 +915,8 @@ impl OptVirtualize {
             // heaptracker.py:66 typeptr exclusion: typeptr is excluded from
             // virtual fields but can be resolved from the SizeDescr vtable.
             // RPython doesn't need this because GUARD_CLASS reads the class
-            // directly from the object, not via a separate GetfieldGcPure.
-            if field_val.is_none()
-                && matches!(
-                    op.opcode,
-                    majit_ir::OpCode::GetfieldGcPureI | majit_ir::OpCode::GetfieldGcI
-                )
-            {
+            // directly from the object, not via a separate field read.
+            if field_val.is_none() && matches!(op.opcode, majit_ir::OpCode::GetfieldGcI) {
                 let is_typeptr = op.with_field_descr(|fd| fd.is_typeptr()).unwrap_or(false);
                 if is_typeptr {
                     let vtable = match &info {
@@ -1964,9 +1959,6 @@ impl Optimization for OptVirtualize {
             OpCode::GetfieldGcI
             | OpCode::GetfieldGcR
             | OpCode::GetfieldGcF
-            | OpCode::GetfieldGcPureI
-            | OpCode::GetfieldGcPureR
-            | OpCode::GetfieldGcPureF
             | OpCode::GetfieldRawI
             | OpCode::GetfieldRawR
             | OpCode::GetfieldRawF => self.optimize_getfield_gc(op, op_rc, ctx),
@@ -5343,7 +5335,7 @@ mod tests {
     }
 
     #[test]
-    fn test_call_forced_virtual_pure_getfield() {
+    fn test_call_forced_virtual_immutable_getfield() {
         // RPython test_optimizeopt.py:test_forced_virtual_pure_getfield
         //
         // [p0]

--- a/majit/majit-metainterp/src/trace_ctx.rs
+++ b/majit/majit-metainterp/src/trace_ctx.rs
@@ -2327,7 +2327,7 @@ impl TraceCtx {
             return None;
         }
         let op = self.recorder.get_op_by_raw_pos(opref.raw())?;
-        if !matches!(op.opcode, OpCode::GetfieldGcR | OpCode::GetfieldGcPureR) {
+        if !matches!(op.opcode, OpCode::GetfieldGcR) {
             return None;
         }
         let descr = op.descr.borrow().clone()?;

--- a/majit/majit-metainterp/src/trace_ctx.rs
+++ b/majit/majit-metainterp/src/trace_ctx.rs
@@ -2573,6 +2573,11 @@ impl TraceCtx {
         for field_index in 0..info.static_fields.len() {
             if let Some(&value) = boxes.get(field_index) {
                 let descr = info.static_field_descr(field_index);
+                // pyjitpl.py:3489-3521 `gen_store_back_in_vable`.
+                self.profiler()
+                    .count_ops(OpCode::SetfieldGc, crate::counters::OPS);
+                self.profiler()
+                    .count_ops(OpCode::SetfieldGc, crate::counters::RECORDED_OPS);
                 self.vable_setfield_descr(vable_opref, value, descr);
             }
         }
@@ -2586,6 +2591,10 @@ impl TraceCtx {
             for item_index in 0..len {
                 if let Some(&value) = boxes.get(flat_box_index) {
                     let index = self.const_int(item_index as i64);
+                    self.profiler()
+                        .count_ops(OpCode::SetarrayitemGc, crate::counters::OPS);
+                    self.profiler()
+                        .count_ops(OpCode::SetarrayitemGc, crate::counters::RECORDED_OPS);
                     self.vable_setarrayitem_descr(array_ref, index, value, array_descr.clone());
                 }
                 flat_box_index += 1;
@@ -2593,7 +2602,13 @@ impl TraceCtx {
         }
 
         let null = self.const_int(0);
-        self.vable_setfield_descr(vable_opref, null, info.token_field_descr());
+        // pyjitpl.py:3521 final token-null store uses `record2`, so it
+        // contributes no profiler counters.
+        self.record_op_with_descr(
+            OpCode::SetfieldGc,
+            &[vable_opref, null],
+            info.token_field_descr(),
+        );
     }
 
     /// `compile.py:425-461 patch_new_loop_to_load_virtualizable_fields`
@@ -2721,13 +2736,26 @@ impl TraceCtx {
             (token_descr, clear_ptr, clear_descr)
         };
         //     tokenbox = mi.execute_and_record(rop.GETFIELD_GC_R, token_descr, box)
+        // pyjitpl.py:1148-1158 `emit_force_virtualizable`.
+        self.profiler()
+            .count_ops(OpCode::GetfieldGcR, crate::counters::OPS);
+        self.profiler()
+            .count_ops(OpCode::GetfieldGcR, crate::counters::RECORDED_OPS);
         let tokenbox = self.record_op_with_descr(OpCode::GetfieldGcR, &[vable_opref], token_descr);
         //     condbox = mi.execute_and_record(rop.PTR_NE, None, tokenbox, CONST_NULL)
         let null_ref = self.const_null();
+        self.profiler()
+            .count_ops(OpCode::PtrNe, crate::counters::OPS);
+        self.profiler()
+            .count_ops(OpCode::PtrNe, crate::counters::RECORDED_OPS);
         let condbox = self.record_op(OpCode::PtrNe, &[tokenbox, null_ref]);
         let funcbox = self.const_int(clear_ptr as i64);
         //     self.execute_varargs(rop.COND_CALL, [condbox, funcbox, box],
         //                          calldescr, False, False)
+        self.profiler()
+            .count_ops(OpCode::CondCallN, crate::counters::OPS);
+        self.profiler()
+            .count_ops(OpCode::CondCallN, crate::counters::RECORDED_OPS);
         Self::do_record_op_with_descr(
             &mut self.recorder,
             OpCode::CondCallN,
@@ -2866,6 +2894,11 @@ impl TraceCtx {
             // guard descr via `num_live` (live-var count), not pc, so the
             // parameter is documented here but not consumed at this layer.
             let _ = pc;
+            // pyjitpl.py:1135-1138 `_nonstandard_virtualizable` execute leg.
+            self.profiler()
+                .count_ops(OpCode::PtrEq, crate::counters::OPS);
+            self.profiler()
+                .count_ops(OpCode::PtrEq, crate::counters::RECORDED_OPS);
             let eqbox = self.record_op(OpCode::PtrEq, &[vable_opref, standard_box]);
             let isstandard: i64 = if concrete_ptrs_eq(concrete.as_ref(), standard_concrete.as_ref())
             {
@@ -3051,6 +3084,12 @@ impl TraceCtx {
                 return (cached, cached_value);
             }
             let record_descr = self.vable_static_record_descr(&fielddescr);
+            // pyjitpl.py:1173-1199 nonstandard vable miss delegates to
+            // the standard heap operation.
+            self.profiler()
+                .count_ops(OpCode::GetfieldGcI, crate::counters::OPS);
+            self.profiler()
+                .count_ops(OpCode::GetfieldGcI, crate::counters::RECORDED_OPS);
             let op = self.record_op_with_descr(OpCode::GetfieldGcI, &[vable_opref], record_descr);
             // pyjitpl.py:949 upd.getfield_now_known(resbox).  `resbox`
             // in RPython carries the loaded value via `BoxInt.value`;
@@ -3082,6 +3121,10 @@ impl TraceCtx {
             }
         }
         // Fallback for tests/missing layout
+        self.profiler()
+            .count_ops(OpCode::GetfieldGcI, crate::counters::OPS);
+        self.profiler()
+            .count_ops(OpCode::GetfieldGcI, crate::counters::RECORDED_OPS);
         let op = self.record_op_with_descr(OpCode::GetfieldGcI, &[vable_opref], fielddescr);
         (op, None)
     }
@@ -3145,6 +3188,11 @@ impl TraceCtx {
             concrete != 0,
             "do_assert_not_none: ref operand {opref:?} is null at trace time"
         );
+        // pyjitpl.py:390 `execute(ASSERT_NOT_NONE, ...)`.
+        self.profiler()
+            .count_ops(OpCode::AssertNotNone, crate::counters::OPS);
+        self.profiler()
+            .count_ops(OpCode::AssertNotNone, crate::counters::RECORDED_OPS);
         self.record_op(OpCode::AssertNotNone, &[opref]);
         // pyjitpl.py:391 `self.metainterp.heapcache.nullity_now_known(box)`.
         self.heap_cache.nullity_now_known(opref, true);
@@ -3185,6 +3233,11 @@ impl TraceCtx {
             // class argument silently skips the record in RPython.
             return;
         }
+        // pyjitpl.py:399-402 `execute(RECORD_EXACT_CLASS, ...)`.
+        self.profiler()
+            .count_ops(OpCode::RecordExactClass, crate::counters::OPS);
+        self.profiler()
+            .count_ops(OpCode::RecordExactClass, crate::counters::RECORDED_OPS);
         self.record_op(OpCode::RecordExactClass, &[opref, cls_const]);
         let cls_value = match self.constants_get_value(cls_const) {
             Some(Value::Int(vtable)) => vtable,
@@ -3247,6 +3300,12 @@ impl TraceCtx {
                     return;
                 }
             }
+            // pyjitpl.py:1173-1199 nonstandard vable miss delegates to
+            // the standard heap operation.
+            self.profiler()
+                .count_ops(OpCode::SetfieldGc, crate::counters::OPS);
+            self.profiler()
+                .count_ops(OpCode::SetfieldGc, crate::counters::RECORDED_OPS);
             self.record_op_with_descr(OpCode::SetfieldGc, &[vable_opref, value], record_descr);
             // pyjitpl.py:980 upd.setfield(valuebox).  Cache stores the
             // Box identity (`value` OpRef); the intrinsic concrete
@@ -3348,6 +3407,10 @@ impl TraceCtx {
                 return (cached, cached_value);
             }
             let record_descr = self.vable_static_record_descr(&fielddescr);
+            self.profiler()
+                .count_ops(OpCode::GetfieldGcR, crate::counters::OPS);
+            self.profiler()
+                .count_ops(OpCode::GetfieldGcR, crate::counters::RECORDED_OPS);
             let op = self.record_op_with_descr(OpCode::GetfieldGcR, &[vable_opref], record_descr);
             // pyjitpl.py:949 upd.getfield_now_known(resbox) — `resbox`
             // carries `.getref_base()` payload; pair it with the
@@ -3373,12 +3436,21 @@ impl TraceCtx {
                 return (op, concrete_shadow_value(value));
             }
         }
+        self.profiler()
+            .count_ops(OpCode::GetfieldGcR, crate::counters::OPS);
+        self.profiler()
+            .count_ops(OpCode::GetfieldGcR, crate::counters::RECORDED_OPS);
         let op = self.record_op_with_descr(OpCode::GetfieldGcR, &[vable_opref], fielddescr);
         (op, None)
     }
 
     /// Record a virtualizable ref field read with an explicit field descriptor.
     pub fn vable_getfield_ref_descr(&mut self, vable_opref: OpRef, descr: DescrRef) -> OpRef {
+        // pyjitpl.py:3489-3521 `gen_store_back_in_vable`.
+        self.profiler()
+            .count_ops(OpCode::GetfieldGcR, crate::counters::OPS);
+        self.profiler()
+            .count_ops(OpCode::GetfieldGcR, crate::counters::RECORDED_OPS);
         self.record_op_with_descr(OpCode::GetfieldGcR, &[vable_opref], descr)
     }
 
@@ -3442,6 +3514,10 @@ impl TraceCtx {
                 return (cached, cached_value);
             }
             let record_descr = self.vable_static_record_descr(&fielddescr);
+            self.profiler()
+                .count_ops(OpCode::GetfieldGcF, crate::counters::OPS);
+            self.profiler()
+                .count_ops(OpCode::GetfieldGcF, crate::counters::RECORDED_OPS);
             let op = self.record_op_with_descr(OpCode::GetfieldGcF, &[vable_opref], record_descr);
             // pyjitpl.py:949 upd.getfield_now_known(resbox) — pair the
             // float payload with the recorded opref so subsequent
@@ -3466,6 +3542,10 @@ impl TraceCtx {
                 return (op, concrete_shadow_value(value));
             }
         }
+        self.profiler()
+            .count_ops(OpCode::GetfieldGcF, crate::counters::OPS);
+        self.profiler()
+            .count_ops(OpCode::GetfieldGcF, crate::counters::RECORDED_OPS);
         let op = self.record_op_with_descr(OpCode::GetfieldGcF, &[vable_opref], fielddescr);
         (op, None)
     }
@@ -3486,6 +3566,11 @@ impl TraceCtx {
             }
         }
         let index = self.const_int(item_index as i64);
+        // pyjitpl.py:1218-1230 vable fallback uses standard array access.
+        self.profiler()
+            .count_ops(OpCode::GetarrayitemGcI, crate::counters::OPS);
+        self.profiler()
+            .count_ops(OpCode::GetarrayitemGcI, crate::counters::RECORDED_OPS);
         let op = self.record_op_with_descr(OpCode::GetarrayitemGcI, &[array_opref, index], adescr);
         (op, None)
     }
@@ -3551,6 +3636,10 @@ impl TraceCtx {
             // arraybox = self.opimpl_getfield_gc_r(box, fdescr)
             // return self.opimpl_getarrayitem_gc_i(arraybox, indexbox, adescr)
             let record_descr = self.vable_array_record_descr(&fdescr);
+            self.profiler()
+                .count_ops(OpCode::GetfieldGcR, crate::counters::OPS);
+            self.profiler()
+                .count_ops(OpCode::GetfieldGcR, crate::counters::RECORDED_OPS);
             let array_opref =
                 self.record_op_with_descr(OpCode::GetfieldGcR, &[vable_opref], record_descr);
             return (
@@ -3568,6 +3657,10 @@ impl TraceCtx {
             }
         }
         // Fallback: vable layout missing — go through getfield + arrayitem.
+        self.profiler()
+            .count_ops(OpCode::GetfieldGcR, crate::counters::OPS);
+        self.profiler()
+            .count_ops(OpCode::GetfieldGcR, crate::counters::RECORDED_OPS);
         let array_opref =
             self.record_op_with_descr(OpCode::GetfieldGcR, &[vable_opref], fdescr.clone());
         if let Ok(item_index) = usize::try_from(index_runtime_value) {
@@ -3594,6 +3687,10 @@ impl TraceCtx {
             }
         }
         let index = self.const_int(item_index as i64);
+        self.profiler()
+            .count_ops(OpCode::GetarrayitemGcR, crate::counters::OPS);
+        self.profiler()
+            .count_ops(OpCode::GetarrayitemGcR, crate::counters::RECORDED_OPS);
         let op = self.record_op_with_descr(OpCode::GetarrayitemGcR, &[array_opref, index], adescr);
         (op, None)
     }
@@ -3617,6 +3714,10 @@ impl TraceCtx {
                 adescr.index(),
             );
             let record_descr = self.vable_array_record_descr(&fdescr);
+            self.profiler()
+                .count_ops(OpCode::GetfieldGcR, crate::counters::OPS);
+            self.profiler()
+                .count_ops(OpCode::GetfieldGcR, crate::counters::RECORDED_OPS);
             let array_opref =
                 self.record_op_with_descr(OpCode::GetfieldGcR, &[vable_opref], record_descr);
             let item = self.vable_getarrayitem_ref_descr(array_opref, index, adescr);
@@ -3633,6 +3734,10 @@ impl TraceCtx {
                 return (op, concrete_shadow_value(value));
             }
         }
+        self.profiler()
+            .count_ops(OpCode::GetfieldGcR, crate::counters::OPS);
+        self.profiler()
+            .count_ops(OpCode::GetfieldGcR, crate::counters::RECORDED_OPS);
         let array_opref =
             self.record_op_with_descr(OpCode::GetfieldGcR, &[vable_opref], fdescr.clone());
         if let Ok(item_index) = usize::try_from(index_runtime_value) {
@@ -3659,6 +3764,10 @@ impl TraceCtx {
             }
         }
         let index = self.const_int(item_index as i64);
+        self.profiler()
+            .count_ops(OpCode::GetarrayitemGcF, crate::counters::OPS);
+        self.profiler()
+            .count_ops(OpCode::GetarrayitemGcF, crate::counters::RECORDED_OPS);
         let op = self.record_op_with_descr(OpCode::GetarrayitemGcF, &[array_opref, index], adescr);
         (op, None)
     }
@@ -3676,6 +3785,10 @@ impl TraceCtx {
         let concrete = self.concrete_of_opref(vable_opref);
         if self.is_nonstandard_virtualizable(pc, vable_opref, &fdescr, concrete) {
             let record_descr = self.vable_array_record_descr(&fdescr);
+            self.profiler()
+                .count_ops(OpCode::GetfieldGcR, crate::counters::OPS);
+            self.profiler()
+                .count_ops(OpCode::GetfieldGcR, crate::counters::RECORDED_OPS);
             let array_opref =
                 self.record_op_with_descr(OpCode::GetfieldGcR, &[vable_opref], record_descr);
             return (
@@ -3690,6 +3803,10 @@ impl TraceCtx {
                 return (op, concrete_shadow_value(value));
             }
         }
+        self.profiler()
+            .count_ops(OpCode::GetfieldGcR, crate::counters::OPS);
+        self.profiler()
+            .count_ops(OpCode::GetfieldGcR, crate::counters::RECORDED_OPS);
         let array_opref =
             self.record_op_with_descr(OpCode::GetfieldGcR, &[vable_opref], fdescr.clone());
         if let Ok(item_index) = usize::try_from(index_runtime_value) {
@@ -3738,8 +3855,16 @@ impl TraceCtx {
         let vable_concrete = self.concrete_of_opref(vable_opref);
         if self.is_nonstandard_virtualizable(pc, vable_opref, &fdescr, vable_concrete) {
             let record_descr = self.vable_array_record_descr(&fdescr);
+            self.profiler()
+                .count_ops(OpCode::GetfieldGcR, crate::counters::OPS);
+            self.profiler()
+                .count_ops(OpCode::GetfieldGcR, crate::counters::RECORDED_OPS);
             let array_opref =
                 self.record_op_with_descr(OpCode::GetfieldGcR, &[vable_opref], record_descr);
+            self.profiler()
+                .count_ops(OpCode::SetarrayitemGc, crate::counters::OPS);
+            self.profiler()
+                .count_ops(OpCode::SetarrayitemGc, crate::counters::RECORDED_OPS);
             self.vable_setarrayitem_descr(array_opref, index, value, adescr);
             return true;
         }
@@ -3786,6 +3911,11 @@ impl TraceCtx {
                 .count_ops(OpCode::ArraylenGc, crate::pyjitpl::counters::HEAPCACHED_OPS);
             return cached_len;
         }
+        // pyjitpl.py:754-763 `opimpl_arraylen_gc` miss.
+        self.profiler()
+            .count_ops(OpCode::ArraylenGc, crate::counters::OPS);
+        self.profiler()
+            .count_ops(OpCode::ArraylenGc, crate::counters::RECORDED_OPS);
         let len = self.record_op_with_descr(OpCode::ArraylenGc, &[array_opref], arraydescr);
         if let Some(v) = concrete {
             self.set_opref_concrete(len, v);
@@ -3858,6 +3988,11 @@ impl TraceCtx {
                 cached
             } else {
                 let record_descr = self.vable_array_record_descr(&fdescr);
+                // pyjitpl.py:1253-1263 nonstandard vable getfield miss.
+                self.profiler()
+                    .count_ops(OpCode::GetfieldGcR, crate::counters::OPS);
+                self.profiler()
+                    .count_ops(OpCode::GetfieldGcR, crate::counters::RECORDED_OPS);
                 let op =
                     self.record_op_with_descr(OpCode::GetfieldGcR, &[vable_opref], record_descr);
                 let live = if vable_struct_ptr != 0 {
@@ -3890,7 +4025,15 @@ impl TraceCtx {
             }
         }
         // Fallback when the layout is unavailable.
+        self.profiler()
+            .count_ops(OpCode::GetfieldGcR, crate::counters::OPS);
+        self.profiler()
+            .count_ops(OpCode::GetfieldGcR, crate::counters::RECORDED_OPS);
         let array_opref = self.record_op_with_descr(OpCode::GetfieldGcR, &[vable_opref], fdescr);
+        self.profiler()
+            .count_ops(OpCode::ArraylenGc, crate::counters::OPS);
+        self.profiler()
+            .count_ops(OpCode::ArraylenGc, crate::counters::RECORDED_OPS);
         self.record_op_with_descr(OpCode::ArraylenGc, &[array_opref], adescr)
     }
 
@@ -3910,6 +4053,10 @@ impl TraceCtx {
         index: OpRef,
         descr: DescrRef,
     ) -> OpRef {
+        self.profiler()
+            .count_ops(OpCode::GetarrayitemGcI, crate::counters::OPS);
+        self.profiler()
+            .count_ops(OpCode::GetarrayitemGcI, crate::counters::RECORDED_OPS);
         self.record_op_with_descr(OpCode::GetarrayitemGcI, &[array_opref, index], descr)
     }
 
@@ -3920,6 +4067,10 @@ impl TraceCtx {
         index: OpRef,
         descr: DescrRef,
     ) -> OpRef {
+        self.profiler()
+            .count_ops(OpCode::GetarrayitemGcR, crate::counters::OPS);
+        self.profiler()
+            .count_ops(OpCode::GetarrayitemGcR, crate::counters::RECORDED_OPS);
         self.record_op_with_descr(OpCode::GetarrayitemGcR, &[array_opref, index], descr)
     }
 
@@ -3930,6 +4081,10 @@ impl TraceCtx {
         index: OpRef,
         descr: DescrRef,
     ) -> OpRef {
+        self.profiler()
+            .count_ops(OpCode::GetarrayitemGcF, crate::counters::OPS);
+        self.profiler()
+            .count_ops(OpCode::GetarrayitemGcF, crate::counters::RECORDED_OPS);
         self.record_op_with_descr(OpCode::GetarrayitemGcF, &[array_opref, index], descr)
     }
 

--- a/majit/majit-metainterp/src/trace_ctx.rs
+++ b/majit/majit-metainterp/src/trace_ctx.rs
@@ -2601,9 +2601,14 @@ impl TraceCtx {
             }
         }
 
+        // Final token-null store (`record2`, so it records no profiler
+        // counters). The token slot holds a raw force marker, and this
+        // store resets it to zero. Use an integer-zero null rather than a
+        // Ref `const_null`: introducing a Ref constant here routes the
+        // store through the ref-const path, which miscompiles on backends
+        // that bake ref consts as raw addresses (wasm) or emit a GC write
+        // barrier under a differing calling convention.
         let null = self.const_int(0);
-        // pyjitpl.py:3521 final token-null store uses `record2`, so it
-        // contributes no profiler counters.
         self.record_op_with_descr(
             OpCode::SetfieldGc,
             &[vable_opref, null],

--- a/majit/majit-trace/src/heapcache.rs
+++ b/majit/majit-trace/src/heapcache.rs
@@ -1166,9 +1166,6 @@ impl HeapCache {
             OpCode::GetfieldGcI
                 | OpCode::GetfieldGcR
                 | OpCode::GetfieldGcF
-                | OpCode::GetfieldGcPureI
-                | OpCode::GetfieldGcPureR
-                | OpCode::GetfieldGcPureF
                 | OpCode::PtrEq
                 | OpCode::PtrNe
                 | OpCode::InstancePtrEq

--- a/pyre/pyre-interpreter/src/objspace/descroperation.rs
+++ b/pyre/pyre-interpreter/src/objspace/descroperation.rs
@@ -671,7 +671,7 @@ fn bigint_rshift_core(a: &BigInt, b: &BigInt, collecting: bool) -> i64 {
 
 /// `rbigint.floordiv`/`mod`/`lshift`/`rshift` payload halves on bare
 /// `*const BigInt` operands — the divmod/shift the walker emits after reading
-/// each `W_LongObject` operand's immutable `value` via `GetfieldGcPure`. Taking
+/// each `W_LongObject` operand's immutable `value` via `GetfieldGc`. Taking
 /// the payloads (not the wrappers) keeps these elidable calls pure on the
 /// immutable bigints so the optimizer never reorders them ahead of the boxing
 /// `setfield_gc`. Allocates the result via the COLLECTING nursery (the call is a

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/heapcache_ops.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/heapcache_ops.rs
@@ -437,13 +437,13 @@ pub(crate) fn setfield_gc_via_heapcache<Sym: WalkSym>(
 ///
 /// Walker behaviour mirrors `_opimpl_getfield_gc_any_pureornot`
 /// uniformly: heapcache hit returns the cached box (no IR op);
-/// heapcache miss records `GetfieldGc<I|R>` (non-pure variant) +
-/// writes through. The optimizer's always-pure pass later folds the
-/// non-pure read into `GetfieldGcPure*` based on `descr.is_always_pure()`,
-/// which is `OpHelpers.getfield_pure_for_descr` (resoperation.py)
-/// parity. Walker emitting Pure variants directly would be
-/// a TODO since RPython's opimpl_* never emits the Pure
-/// opcodes; they're an optimizer-rewrite artifact.
+/// heapcache miss records the opcode the dispatch selected +
+/// writes through. RPython aliases the `_pure` jitcode spelling to
+/// the plain opimpl (`pyjitpl.py:884`), so both spellings record the
+/// plain opnum here; the optimizer re-derives purity from
+/// `descr.is_always_pure()` (`heap.py:641` const fold +
+/// invalidation-exempt field cache). There is no post-trace rewrite
+/// to the Pure opcodes.
 ///
 /// `dst_bank` selects the result bank: `'i'` writes `registers_i[dst]`,
 /// `'r'` writes `registers_r[dst]`.

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/heapcache_ops.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/heapcache_ops.rs
@@ -464,9 +464,9 @@ pub(crate) fn getfield_gc_via_heapcache<Sym: WalkSym>(
     // substitutes the value as a Const literal, recording no op.
     let const_pure_result = if obj.is_constant() && descr.is_always_pure() {
         let load_type = match opcode {
-            OpCode::GetfieldGcI | OpCode::GetfieldGcPureI => Some(majit_ir::Type::Int),
-            OpCode::GetfieldGcR | OpCode::GetfieldGcPureR => Some(majit_ir::Type::Ref),
-            OpCode::GetfieldGcF | OpCode::GetfieldGcPureF => Some(majit_ir::Type::Float),
+            OpCode::GetfieldGcI => Some(majit_ir::Type::Int),
+            OpCode::GetfieldGcR => Some(majit_ir::Type::Ref),
+            OpCode::GetfieldGcF => Some(majit_ir::Type::Float),
             _ => None,
         };
         let struct_ptr = match ctx.trace_ctx.box_value(obj) {
@@ -507,12 +507,8 @@ pub(crate) fn getfield_gc_via_heapcache<Sym: WalkSym>(
     let typeptr_const = if ctx.fbw_mode.inline_subwalk && !obj.is_constant() && is_typeptr_field {
         let known = ctx.trace_ctx.heap_cache().get_known_class(obj);
         match (known, opcode) {
-            (Some(cls), OpCode::GetfieldGcI | OpCode::GetfieldGcPureI) => {
-                Some(ctx.trace_ctx.const_int(cls))
-            }
-            (Some(cls), OpCode::GetfieldGcR | OpCode::GetfieldGcPureR) => {
-                Some(ctx.trace_ctx.const_ref(cls))
-            }
+            (Some(cls), OpCode::GetfieldGcI) => Some(ctx.trace_ctx.const_int(cls)),
+            (Some(cls), OpCode::GetfieldGcR) => Some(ctx.trace_ctx.const_ref(cls)),
             _ => None,
         }
     } else {
@@ -548,12 +544,7 @@ pub(crate) fn getfield_gc_via_heapcache<Sym: WalkSym>(
         if ctx.fbw_mode.inline_subwalk
             && matches!(
                 opcode,
-                OpCode::GetfieldGcI
-                    | OpCode::GetfieldGcR
-                    | OpCode::GetfieldGcF
-                    | OpCode::GetfieldGcPureI
-                    | OpCode::GetfieldGcPureR
-                    | OpCode::GetfieldGcPureF
+                OpCode::GetfieldGcI | OpCode::GetfieldGcR | OpCode::GetfieldGcF
             )
             && descr
                 .as_field_descr()
@@ -568,15 +559,9 @@ pub(crate) fn getfield_gc_via_heapcache<Sym: WalkSym>(
         // struct pointer is known (Const, vable shadow, or stamped),
         // mirroring `pyjitpl.py resbox = execute_with_descr(...);
         // upd.getfield_now_known(resbox)`.
-        // The `_pure` jitcode spellings alias `opimpl_getfield_gc_*`
-        // upstream, so the profiler always sees the plain opnum even
-        // when the pure opcode is what gets recorded.
-        let profiled_opcode = match opcode {
-            OpCode::GetfieldGcPureI => OpCode::GetfieldGcI,
-            OpCode::GetfieldGcPureR => OpCode::GetfieldGcR,
-            OpCode::GetfieldGcPureF => OpCode::GetfieldGcF,
-            other => other,
-        };
+        // The immutable jitcode spellings alias `opimpl_getfield_gc_*`
+        // upstream, so the profiler sees the plain opnum.
+        let profiled_opcode = opcode;
         ctx.trace_ctx
             .profiler()
             .count_ops(profiled_opcode, majit_metainterp::counters::OPS);
@@ -587,9 +572,9 @@ pub(crate) fn getfield_gc_via_heapcache<Sym: WalkSym>(
             .trace_ctx
             .record_op_with_descr(opcode, &[obj], descr.clone());
         let load_type = match opcode {
-            OpCode::GetfieldGcI | OpCode::GetfieldGcPureI => Some(majit_ir::Type::Int),
-            OpCode::GetfieldGcR | OpCode::GetfieldGcPureR => Some(majit_ir::Type::Ref),
-            OpCode::GetfieldGcF | OpCode::GetfieldGcPureF => Some(majit_ir::Type::Float),
+            OpCode::GetfieldGcI => Some(majit_ir::Type::Int),
+            OpCode::GetfieldGcR => Some(majit_ir::Type::Ref),
+            OpCode::GetfieldGcF => Some(majit_ir::Type::Float),
             _ => None,
         };
         let live_value = if let (Some(ty), Some(majit_ir::Value::Ref(struct_ref))) =

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
@@ -6577,12 +6577,10 @@ fn walker_record_getfield_gc_i_uncached<Sym: WalkSym>(
     obj: OpRef,
     descr: DescrRef,
 ) -> OpRef {
-    let opcode = if descr.is_always_pure() {
-        OpCode::GetfieldGcPureI
-    } else {
-        OpCode::GetfieldGcI
-    };
-    ctx.trace_ctx.record_op_with_descr(opcode, &[obj], descr)
+    // Plain GETFIELD_GC_I regardless of purity; OptHeap re-derives
+    // purity from the descr. There is no pure getfield opnum.
+    ctx.trace_ctx
+        .record_op_with_descr(OpCode::GetfieldGcI, &[obj], descr)
 }
 
 fn walker_record_getfield_gc_r_uncached<Sym: WalkSym>(
@@ -6590,12 +6588,10 @@ fn walker_record_getfield_gc_r_uncached<Sym: WalkSym>(
     obj: OpRef,
     descr: DescrRef,
 ) -> OpRef {
-    let opcode = if descr.is_always_pure() {
-        OpCode::GetfieldGcPureR
-    } else {
-        OpCode::GetfieldGcR
-    };
-    ctx.trace_ctx.record_op_with_descr(opcode, &[obj], descr)
+    // Plain GETFIELD_GC_R regardless of purity; OptHeap re-derives
+    // purity from the descr. There is no pure getfield opnum.
+    ctx.trace_ctx
+        .record_op_with_descr(OpCode::GetfieldGcR, &[obj], descr)
 }
 
 /// True only when this `LoadAttr` residual is immediately consumed by the

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
@@ -3138,6 +3138,14 @@ fn dispatch_switch_id<Sym: WalkSym>(
         };
         for &key in switchdict.const_keys_in_order() {
             let keybox = ctx.trace_ctx.const_int(key);
+            // pyjitpl.py:609-613 `opimpl_switch` miss uses
+            // `execute(INT_EQ, ...)` for each key.
+            ctx.trace_ctx
+                .profiler()
+                .count_ops(OpCode::IntEq, majit_metainterp::counters::OPS);
+            ctx.trace_ctx
+                .profiler()
+                .count_ops(OpCode::IntEq, majit_metainterp::counters::RECORDED_OPS);
             let eqbox = ctx.trace_ctx.record_op(OpCode::IntEq, &[valuebox, keybox]);
             if let Some(v) = valuebox_concrete {
                 ctx.trace_ctx
@@ -7183,6 +7191,15 @@ fn emit_namespace_cell_store_fold<Sym: WalkSym>(
             majit_metainterp::counters::HEAPCACHED_OPS,
         );
     } else {
+        // pyjitpl.py:974-988 `_opimpl_setfield_gc_any` record leg.
+        ctx.trace_ctx.profiler().count_ops(
+            majit_ir::OpCode::SetfieldGc,
+            majit_metainterp::counters::OPS,
+        );
+        ctx.trace_ctx.profiler().count_ops(
+            majit_ir::OpCode::SetfieldGc,
+            majit_metainterp::counters::RECORDED_OPS,
+        );
         ctx.trace_ctx.record_op_with_descr(
             majit_ir::OpCode::SetfieldGc,
             &[cell_opref, raw_int],
@@ -8309,6 +8326,13 @@ fn handle<Sym: WalkSym>(
             let base = read_int_reg(code, op, 0, ctx)?;
             let offset = read_int_reg(code, op, 1, ctx)?;
             let descr = read_descr(code, op, 2, ctx)?;
+            // pyjitpl.py:1025-1027 `opimpl_raw_load_i`.
+            ctx.trace_ctx
+                .profiler()
+                .count_ops(OpCode::RawLoadI, majit_metainterp::counters::OPS);
+            ctx.trace_ctx
+                .profiler()
+                .count_ops(OpCode::RawLoadI, majit_metainterp::counters::RECORDED_OPS);
             let result =
                 ctx.trace_ctx
                     .record_op_with_descr(OpCode::RawLoadI, &[base, offset], descr);
@@ -8331,6 +8355,13 @@ fn handle<Sym: WalkSym>(
             let offset = read_int_reg(code, op, 1, ctx)?;
             let value = read_int_reg(code, op, 2, ctx)?;
             let descr = read_descr(code, op, 3, ctx)?;
+            // pyjitpl.py:1018-1022 `_opimpl_raw_store`.
+            ctx.trace_ctx
+                .profiler()
+                .count_ops(OpCode::RawStore, majit_metainterp::counters::OPS);
+            ctx.trace_ctx
+                .profiler()
+                .count_ops(OpCode::RawStore, majit_metainterp::counters::RECORDED_OPS);
             ctx.trace_ctx
                 .record_op_with_descr(OpCode::RawStore, &[base, offset, value], descr);
             Ok((DispatchOutcome::Continue, op.next_pc))
@@ -8384,6 +8415,14 @@ fn handle<Sym: WalkSym>(
             let value = read_ref_reg(code, op, 2, ctx)?;
             let descr = read_descr(code, op, 3, ctx)?;
             let descr_index = descr.index();
+            // pyjitpl.py:736-744 `_opimpl_setarrayitem_gc_any`.
+            ctx.trace_ctx
+                .profiler()
+                .count_ops(OpCode::SetarrayitemGc, majit_metainterp::counters::OPS);
+            ctx.trace_ctx.profiler().count_ops(
+                OpCode::SetarrayitemGc,
+                majit_metainterp::counters::RECORDED_OPS,
+            );
             ctx.trace_ctx.record_op_with_descr(
                 OpCode::SetarrayitemGc,
                 &[array, index, value],
@@ -8462,6 +8501,13 @@ fn handle<Sym: WalkSym>(
         // vtable word, so nothing is known about its class.
         "new/d>r" => {
             let descr = read_descr(code, op, 0, ctx)?;
+            // pyjitpl.py:624-629 `execute_new`.
+            ctx.trace_ctx
+                .profiler()
+                .count_ops(OpCode::New, majit_metainterp::counters::OPS);
+            ctx.trace_ctx
+                .profiler()
+                .count_ops(OpCode::New, majit_metainterp::counters::RECORDED_OPS);
             let resbox = ctx.trace_ctx.record_op_with_descr(OpCode::New, &[], descr);
             ctx.trace_ctx.heap_cache_mut().new_object(resbox);
             let dst = code[op.pc + 3] as usize;
@@ -8483,6 +8529,14 @@ fn handle<Sym: WalkSym>(
             // `class_now_known` takes the vtable address: pyre tracks the
             // concrete class pointer where upstream only raises HF_KNOWN_CLASS.
             let known_class = descr.as_size_descr().map(|size| size.vtable() as i64);
+            // pyjitpl.py:624-629 `execute_new_with_vtable`.
+            ctx.trace_ctx
+                .profiler()
+                .count_ops(OpCode::NewWithVtable, majit_metainterp::counters::OPS);
+            ctx.trace_ctx.profiler().count_ops(
+                OpCode::NewWithVtable,
+                majit_metainterp::counters::RECORDED_OPS,
+            );
             let resbox = ctx
                 .trace_ctx
                 .record_op_with_descr(OpCode::NewWithVtable, &[], descr);
@@ -8519,6 +8573,14 @@ fn handle<Sym: WalkSym>(
             let is_ref_array = descr
                 .as_array_descr()
                 .map_or(false, |a| a.is_array_of_pointers());
+            // pyjitpl.py:631-637 `_opimpl_new_array`.
+            ctx.trace_ctx
+                .profiler()
+                .count_ops(OpCode::NewArrayClear, majit_metainterp::counters::OPS);
+            ctx.trace_ctx.profiler().count_ops(
+                OpCode::NewArrayClear,
+                majit_metainterp::counters::RECORDED_OPS,
+            );
             let resbox =
                 ctx.trace_ctx
                     .record_op_with_descr(OpCode::NewArrayClear, &[length], descr);

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
@@ -8220,12 +8220,12 @@ fn handle<Sym: WalkSym>(
         "getfield_gc_i/rd>i" => getfield_gc_via_heapcache(code, op, ctx, OpCode::GetfieldGcI, 'i'),
         "getfield_gc_r/rd>r" => getfield_gc_via_heapcache(code, op, ctx, OpCode::GetfieldGcR, 'r'),
         "getfield_gc_f/rd>f" => getfield_gc_via_heapcache(code, op, ctx, OpCode::GetfieldGcF, 'f'),
-        // RPython `blackhole.py` aliases
-        // `bhimpl_getfield_gc_{i,r,f}_pure = bhimpl_getfield_gc_{i,r,f}` —
-        // pure-getter shape on quasi-immutable descrs.  Walker emits
-        // the non-pure opcode; the optimizer rewrites to the Pure form
-        // post-trace based on `descr.is_always_pure()`
-        // (`resoperation.py OpHelpers.getfield_pure_for_descr`).
+        // RPython aliases the `_pure` jitcode spelling to the plain
+        // handler (`pyjitpl.py:884 opimpl_getfield_gc_i_pure =
+        // opimpl_getfield_gc_i`), so the recorded opcode stays plain
+        // and purity is re-derived from `descr.is_always_pure()` by
+        // the optimizer (`heap.py:641` const fold + invalidation-exempt
+        // field cache).
         "getfield_gc_i_pure/rd>i" => {
             getfield_gc_via_heapcache(code, op, ctx, OpCode::GetfieldGcI, 'i')
         }

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
@@ -6051,7 +6051,7 @@ fn walker_unbox_int_typed<Sym: WalkSym>(
             // `GuardFalse` does not forward through the loop-close `SetfieldGc`,
             // so it would survive the unroll and pin a per-iteration rebox in the
             // steady loop. Skipping it yields the flag-false `GuardClass`+
-            // `GetfieldGcPure` shape (raw carry).
+            // immutable `GetfieldGc` shape (raw carry).
         }
     }
     if !ctx.trace_ctx.heap_cache().is_class_known(obj) {

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
@@ -2826,6 +2826,30 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
             maybe_walker_vable_and_vrefs_before_residual_call(ctx);
         }
 
+        // pyjitpl.py:2669-2682 `execute_and_record_varargs`; may-force
+        // calls use `history.record_nospec` and therefore count nothing.
+        if matches!(
+            call_opcode,
+            OpCode::CallI
+                | OpCode::CallR
+                | OpCode::CallF
+                | OpCode::CallN
+                | OpCode::CallPureI
+                | OpCode::CallPureR
+                | OpCode::CallPureF
+                | OpCode::CallPureN
+                | OpCode::CallLoopinvariantI
+                | OpCode::CallLoopinvariantR
+                | OpCode::CallLoopinvariantF
+                | OpCode::CallLoopinvariantN
+        ) {
+            ctx.trace_ctx
+                .profiler()
+                .count_ops(call_opcode, majit_metainterp::counters::OPS);
+            ctx.trace_ctx
+                .profiler()
+                .count_ops(call_opcode, majit_metainterp::counters::RECORDED_OPS);
+        }
         let recorded = ctx
             .trace_ctx
             .record_op_with_descr(call_opcode, &allboxes, descr.clone());
@@ -3635,6 +3659,28 @@ pub(crate) fn dispatch_residual_call_iIRd_kind<Sym: WalkSym>(
             maybe_walker_vable_and_vrefs_before_residual_call(ctx);
         }
 
+        if matches!(
+            call_opcode,
+            OpCode::CallI
+                | OpCode::CallR
+                | OpCode::CallF
+                | OpCode::CallN
+                | OpCode::CallPureI
+                | OpCode::CallPureR
+                | OpCode::CallPureF
+                | OpCode::CallPureN
+                | OpCode::CallLoopinvariantI
+                | OpCode::CallLoopinvariantR
+                | OpCode::CallLoopinvariantF
+                | OpCode::CallLoopinvariantN
+        ) {
+            ctx.trace_ctx
+                .profiler()
+                .count_ops(call_opcode, majit_metainterp::counters::OPS);
+            ctx.trace_ctx
+                .profiler()
+                .count_ops(call_opcode, majit_metainterp::counters::RECORDED_OPS);
+        }
         let recorded = ctx
             .trace_ctx
             .record_op_with_descr(call_opcode, &allboxes, descr.clone());
@@ -3845,6 +3891,28 @@ pub(crate) fn dispatch_residual_call_iIRFd_kind<Sym: WalkSym>(
             maybe_walker_vable_and_vrefs_before_residual_call(ctx);
         }
 
+        if matches!(
+            call_opcode,
+            OpCode::CallI
+                | OpCode::CallR
+                | OpCode::CallF
+                | OpCode::CallN
+                | OpCode::CallPureI
+                | OpCode::CallPureR
+                | OpCode::CallPureF
+                | OpCode::CallPureN
+                | OpCode::CallLoopinvariantI
+                | OpCode::CallLoopinvariantR
+                | OpCode::CallLoopinvariantF
+                | OpCode::CallLoopinvariantN
+        ) {
+            ctx.trace_ctx
+                .profiler()
+                .count_ops(call_opcode, majit_metainterp::counters::OPS);
+            ctx.trace_ctx
+                .profiler()
+                .count_ops(call_opcode, majit_metainterp::counters::RECORDED_OPS);
+        }
         let recorded = ctx
             .trace_ctx
             .record_op_with_descr(call_opcode, &allboxes, descr.clone());

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/resume_snapshot.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/resume_snapshot.rs
@@ -1671,6 +1671,15 @@ pub(crate) fn compute_nested_inline_caller_frame<Sym: WalkSym>(
                         continue;
                     }
                     let idx = ctx.trace_ctx.const_int(slot as i64);
+                    // pyjitpl.py:3489-3521 `gen_store_back_in_vable`
+                    // escape flush uses the standard recorded store path.
+                    ctx.trace_ctx
+                        .profiler()
+                        .count_ops(OpCode::SetarrayitemGc, majit_metainterp::counters::OPS);
+                    ctx.trace_ctx.profiler().count_ops(
+                        OpCode::SetarrayitemGc,
+                        majit_metainterp::counters::RECORDED_OPS,
+                    );
                     ctx.trace_ctx.record_op_with_descr(
                         OpCode::SetarrayitemGc,
                         &[locals_array, idx, operand],

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
@@ -653,22 +653,25 @@ pub(crate) fn try_walker_specialize_binary_op_long<Sym: WalkSym>(
     let long_type_addr = &pyre_object::pyobject::LONG_TYPE as *const _ as i64;
     walker_guard_class(ctx, op_pc, lhs, long_type_addr)?;
     walker_guard_class(ctx, op_pc, rhs, long_type_addr)?;
-    // Read each operand's immutable `value` payload (`GetfieldGcPure`), then call
-    // the elidable `rbigint` op on the bare `*const BigInt` payloads. Passing the
-    // payloads (not the wrappers) keeps the call pure on the immutable bigints, so
-    // the optimizer forwards the field read and never reorders this elidable call
-    // ahead of the boxing `setfield_gc` below — which would otherwise read the
-    // freshly-allocated result wrapper's uninitialized `value` (the function-loop
-    // unroll exposed exactly that reorder). The result is a GC-managed
-    // `*mut BigInt`, Ref-typed so the JIT gcmap roots it across the collecting
-    // boxing NEW. Every op allocates (`EF_ELIDABLE_OR_MEMORYERROR`) or divides
-    // (`EF_ELIDABLE_CAN_RAISE`), so a trailing `GuardNoException` follows
-    // (`pyjitpl.py`).
+    // Read each operand's immutable `value` payload, then call the
+    // elidable `rbigint` op on the bare `*const BigInt` payloads. Passing
+    // the payloads (not the wrappers) keeps the call pure on the immutable
+    // bigints, so the optimizer forwards the field read and never reorders
+    // this elidable call ahead of the boxing `setfield_gc` below — which
+    // would otherwise read the freshly-allocated result wrapper's
+    // uninitialized `value` (the function-loop unroll exposed exactly that
+    // reorder). The forwarding is descr-keyed (`long_value_descr()` is
+    // immutable), so the plain `GETFIELD_GC_R` opnum gets identical OptHeap
+    // treatment — there is no pure getfield opnum. The result is a
+    // GC-managed `*mut BigInt`, Ref-typed so the JIT gcmap roots it across
+    // the collecting boxing NEW. Every op allocates
+    // (`EF_ELIDABLE_OR_MEMORYERROR`) or divides (`EF_ELIDABLE_CAN_RAISE`),
+    // so a trailing `GuardNoException` follows (`pyjitpl.py`).
     let off = pyre_object::longobject::LONG_VALUE_OFFSET;
     let lhs_payload = unsafe { *((lhs_obj as *const u8).add(off) as *const i64) };
     let rhs_payload = unsafe { *((rhs_obj as *const u8).add(off) as *const i64) };
     let lhs_pl = ctx.trace_ctx.record_op_with_descr(
-        OpCode::GetfieldGcPureR,
+        OpCode::GetfieldGcR,
         &[lhs],
         crate::descr::long_value_descr(),
     );
@@ -677,7 +680,7 @@ pub(crate) fn try_walker_specialize_binary_op_long<Sym: WalkSym>(
         majit_ir::Value::Ref(majit_ir::GcRef(lhs_payload as usize)),
     );
     let rhs_pl = ctx.trace_ctx.record_op_with_descr(
-        OpCode::GetfieldGcPureR,
+        OpCode::GetfieldGcR,
         &[rhs],
         crate::descr::long_value_descr(),
     );

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -3076,20 +3076,17 @@ pub(crate) fn opimpl_getfield_gc_i(ctx: &mut TraceCtx, obj: OpRef, descr: DescrR
             }
         }
     }
-    let opcode = if descr.is_always_pure() {
-        OpCode::GetfieldGcPureI
-    } else {
-        OpCode::GetfieldGcI
-    };
-    // The `_pure` spelling aliases this opimpl upstream, so the
-    // profiler always sees the plain GETFIELD_GC_I opnum.
+    // `opimpl_getfield_gc_i` records the plain GETFIELD_GC_I opnum
+    // regardless of `descr.is_always_pure()`; purity is re-derived from
+    // the descr by OptHeap (const fold + invalidation-exempt field
+    // cache). There is no pure getfield opnum.
     ctx.profiler()
         .count_ops(OpCode::GetfieldGcI, majit_metainterp::counters::OPS);
     ctx.profiler().count_ops(
         OpCode::GetfieldGcI,
         majit_metainterp::counters::RECORDED_OPS,
     );
-    let result = ctx.record_op_with_descr(opcode, &[obj], descr.clone());
+    let result = ctx.record_op_with_descr(OpCode::GetfieldGcI, &[obj], descr.clone());
     // pyjitpl.py:948-949 `resbox = execute_with_descr(...); upd.getfield_now_known(resbox)`.
     // `resbox` carries the loaded value; pair the recorded opref with
     // the live int from `field_sanity_load` so subsequent
@@ -3182,20 +3179,16 @@ pub(crate) fn opimpl_getfield_gc_r(ctx: &mut TraceCtx, obj: OpRef, descr: DescrR
             }
         }
     }
-    let opcode = if descr.is_always_pure() {
-        OpCode::GetfieldGcPureR
-    } else {
-        OpCode::GetfieldGcR
-    };
-    // The `_pure` spelling aliases this opimpl upstream, so the
-    // profiler always sees the plain GETFIELD_GC_R opnum.
+    // `opimpl_getfield_gc_r` records the plain GETFIELD_GC_R opnum
+    // regardless of `descr.is_always_pure()`; purity is re-derived from
+    // the descr by OptHeap. There is no pure getfield opnum.
     ctx.profiler()
         .count_ops(OpCode::GetfieldGcR, majit_metainterp::counters::OPS);
     ctx.profiler().count_ops(
         OpCode::GetfieldGcR,
         majit_metainterp::counters::RECORDED_OPS,
     );
-    let result = ctx.record_op_with_descr(opcode, &[obj], descr.clone());
+    let result = ctx.record_op_with_descr(OpCode::GetfieldGcR, &[obj], descr.clone());
     // pyjitpl.py:948-949 `resbox = execute_with_descr(...); upd.getfield_now_known(resbox)`.
     // Pair the recorded opref with the live ref so subsequent
     // `box_value(result)` mirrors RPython's executor-returned Box.
@@ -11827,7 +11820,7 @@ mod tests {
             if op.opcode == OpCode::GuardClass {
                 saw_guard_nonnull_class = true;
             }
-            if op.opcode == OpCode::GetfieldGcPureI
+            if op.opcode == OpCode::GetfieldGcI
                 && op
                     .getarglist()
                     .iter()
@@ -11844,7 +11837,7 @@ mod tests {
         );
         assert!(
             saw_pure_payload,
-            "int payload fast path should read the immutable payload with GetfieldGcPureI"
+            "int payload fast path should read the immutable payload with GetfieldGcI"
         );
     }
 
@@ -11873,14 +11866,15 @@ mod tests {
         };
 
         let recorder = ctx.into_recorder();
-        // A boxed W_Int reads its immutable payload with GetfieldGcPureI. The
+        // A boxed W_Int reads its immutable payload with the plain
+        // GetfieldGcI (purity re-derived from the descr by OptHeap). The
         // lowbit tag-discrimination guard (rtagged.py:155) is elided because
         // `obj` is a Const (pyjitpl.py:2583 generate_guard const-skip), so no
         // guard is emitted at all.
         let payload_op = recorder
             .get_op_by_pos(payload)
             .expect("payload op should be present");
-        assert_eq!(payload_op.opcode, OpCode::GetfieldGcPureI);
+        assert_eq!(payload_op.opcode, OpCode::GetfieldGcI);
         for pos in 1..(1 + recorder.num_ops() as u32) {
             let Some(op) = recorder.get_op_by_raw_pos(pos) else {
                 continue;

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -3518,8 +3518,19 @@ pub(crate) fn trace_array_getitem_value(ctx: &mut TraceCtx, array: OpRef, index:
     let descr = pyobject_gcarray_descr();
     let descr_idx = descr.index();
     if let Some(cached) = ctx.heapcache_getarrayitem(array, index, descr_idx) {
+        // pyjitpl.py:640-663 `_do_getarrayitem_gc_any` cache hit.
+        ctx.profiler().count_ops(
+            OpCode::GetarrayitemGcR,
+            majit_metainterp::counters::HEAPCACHED_OPS,
+        );
         return cached;
     }
+    ctx.profiler()
+        .count_ops(OpCode::GetarrayitemGcR, majit_metainterp::counters::OPS);
+    ctx.profiler().count_ops(
+        OpCode::GetarrayitemGcR,
+        majit_metainterp::counters::RECORDED_OPS,
+    );
     let result = ctx.record_op_with_descr(OpCode::GetarrayitemGcR, &[array, index], descr.clone());
     if let Some(live_value) = array_load_for_cache(ctx, array, index, &descr, majit_ir::Type::Ref) {
         ctx.set_opref_concrete(result, live_value);
@@ -3568,6 +3579,13 @@ pub(crate) fn trace_raw_array_getitem_value(
     if let Some(cached) = ctx.heapcache_getarrayitem(array, index, descr_idx) {
         return cached;
     }
+    // pyjitpl.py:640-663 `_do_getarrayitem_gc_any` record leg.
+    ctx.profiler()
+        .count_ops(OpCode::GetarrayitemGcR, majit_metainterp::counters::OPS);
+    ctx.profiler().count_ops(
+        OpCode::GetarrayitemGcR,
+        majit_metainterp::counters::RECORDED_OPS,
+    );
     let result = ctx.record_op_with_descr(OpCode::GetarrayitemGcR, &[array, index], descr.clone());
     if let Some(live_value) = array_load_for_cache(ctx, array, index, &descr, majit_ir::Type::Ref) {
         ctx.set_opref_concrete(result, live_value);
@@ -3599,6 +3617,12 @@ pub(crate) fn trace_items_block_getitem_value(
     if let Some(cached) = ctx.heapcache_getarrayitem(block, index, descr_idx) {
         return cached;
     }
+    ctx.profiler()
+        .count_ops(OpCode::GetarrayitemGcR, majit_metainterp::counters::OPS);
+    ctx.profiler().count_ops(
+        OpCode::GetarrayitemGcR,
+        majit_metainterp::counters::RECORDED_OPS,
+    );
     let result = ctx.record_op_with_descr(OpCode::GetarrayitemGcR, &[block, index], descr.clone());
     if let Some(live_value) = array_load_for_cache(ctx, block, index, &descr, majit_ir::Type::Ref) {
         ctx.set_opref_concrete(result, live_value);
@@ -3630,6 +3654,13 @@ pub(crate) fn trace_items_block_getitem_value_pure(
     index: OpRef,
 ) -> OpRef {
     let descr = pyobject_gcarray_descr();
+    // Pure jitcode spellings alias the plain opimpl for profiling.
+    ctx.profiler()
+        .count_ops(OpCode::GetarrayitemGcR, majit_metainterp::counters::OPS);
+    ctx.profiler().count_ops(
+        OpCode::GetarrayitemGcR,
+        majit_metainterp::counters::RECORDED_OPS,
+    );
     let result =
         ctx.record_op_with_descr(OpCode::GetarrayitemGcPureR, &[block, index], descr.clone());
     if let Some(live_value) = array_load_for_cache(ctx, block, index, &descr, majit_ir::Type::Ref) {
@@ -3648,6 +3679,12 @@ pub(crate) fn trace_items_block_setitem_value(
 ) {
     let descr = pyobject_gcarray_descr();
     let descr_idx = descr.index();
+    ctx.profiler()
+        .count_ops(OpCode::SetarrayitemGc, majit_metainterp::counters::OPS);
+    ctx.profiler().count_ops(
+        OpCode::SetarrayitemGc,
+        majit_metainterp::counters::RECORDED_OPS,
+    );
     ctx.record_op_with_descr(OpCode::SetarrayitemGc, &[block, index, value], descr);
     // pyjitpl.py:980 `upd.setarrayitem(valuebox)` — cache stores the
     // Box identity (`value` OpRef); cache-hit readers resolve the
@@ -3665,6 +3702,12 @@ pub(crate) fn trace_raw_array_setitem_value(
 ) {
     let descr = pyobject_array_descr();
     let descr_idx = descr.index();
+    ctx.profiler()
+        .count_ops(OpCode::SetarrayitemGc, majit_metainterp::counters::OPS);
+    ctx.profiler().count_ops(
+        OpCode::SetarrayitemGc,
+        majit_metainterp::counters::RECORDED_OPS,
+    );
     ctx.record_op_with_descr(OpCode::SetarrayitemGc, &[array, index, value], descr);
     // pyjitpl.py:980 `upd.setarrayitem(valuebox)` parity — cache
     // stores the Box identity (`value` OpRef); cache-hit readers
@@ -3687,6 +3730,12 @@ pub(crate) fn trace_int_block_getitem_value(
     if let Some(cached) = ctx.heapcache_getarrayitem(block, index, descr_idx) {
         return cached;
     }
+    ctx.profiler()
+        .count_ops(OpCode::GetarrayitemGcI, majit_metainterp::counters::OPS);
+    ctx.profiler().count_ops(
+        OpCode::GetarrayitemGcI,
+        majit_metainterp::counters::RECORDED_OPS,
+    );
     let result = ctx.record_op_with_descr(OpCode::GetarrayitemGcI, &[block, index], descr.clone());
     if let Some(live_value) = array_load_for_cache(ctx, block, index, &descr, majit_ir::Type::Int) {
         ctx.set_opref_concrete(result, live_value);
@@ -3706,6 +3755,12 @@ pub(crate) fn trace_int_block_setitem_value(
 ) {
     let descr = int_gcarray_descr();
     let descr_idx = descr.index();
+    ctx.profiler()
+        .count_ops(OpCode::SetarrayitemGc, majit_metainterp::counters::OPS);
+    ctx.profiler().count_ops(
+        OpCode::SetarrayitemGc,
+        majit_metainterp::counters::RECORDED_OPS,
+    );
     ctx.record_op_with_descr(OpCode::SetarrayitemGc, &[block, index, value], descr);
     ctx.heapcache_setarrayitem(block, index, descr_idx, value);
 }
@@ -3723,6 +3778,12 @@ pub(crate) fn trace_float_block_getitem_value(
     if let Some(cached) = ctx.heapcache_getarrayitem(block, index, descr_idx) {
         return cached;
     }
+    ctx.profiler()
+        .count_ops(OpCode::GetarrayitemGcF, majit_metainterp::counters::OPS);
+    ctx.profiler().count_ops(
+        OpCode::GetarrayitemGcF,
+        majit_metainterp::counters::RECORDED_OPS,
+    );
     let result = ctx.record_op_with_descr(OpCode::GetarrayitemGcF, &[block, index], descr.clone());
     if let Some(live_value) = array_load_for_cache(ctx, block, index, &descr, majit_ir::Type::Float)
     {
@@ -3742,6 +3803,12 @@ pub(crate) fn trace_float_block_setitem_value(
 ) {
     let descr = float_gcarray_descr();
     let descr_idx = descr.index();
+    ctx.profiler()
+        .count_ops(OpCode::SetarrayitemGc, majit_metainterp::counters::OPS);
+    ctx.profiler().count_ops(
+        OpCode::SetarrayitemGc,
+        majit_metainterp::counters::RECORDED_OPS,
+    );
     ctx.record_op_with_descr(OpCode::SetarrayitemGc, &[block, index, value], descr);
     ctx.heapcache_setarrayitem(block, index, descr_idx, value);
 }
@@ -6066,6 +6133,13 @@ fn emit_stroruni_oopspec_call(
     let mut call_args = Vec::with_capacity(1 + args.len());
     call_args.push(func_const);
     call_args.extend_from_slice(args);
+    // resume.py:1143-1160 `execute_and_record_varargs(CALL_R, ...)`.
+    ctx.profiler()
+        .count_ops(majit_ir::OpCode::CallR, majit_metainterp::counters::OPS);
+    ctx.profiler().count_ops(
+        majit_ir::OpCode::CallR,
+        majit_metainterp::counters::RECORDED_OPS,
+    );
     ctx.record_op_with_descr(majit_ir::OpCode::CallR, &call_args, calldescr.clone())
 }
 
@@ -6812,6 +6886,12 @@ fn prepare_bridge_pending_fields(
                 cache,
             );
             if pending.item_index < 0 {
+                // resume.py `_prepare_pendingfields` replays through
+                // `execute_and_record`.
+                ctx.profiler()
+                    .count_ops(OpCode::SetfieldGc, majit_metainterp::counters::OPS);
+                ctx.profiler()
+                    .count_ops(OpCode::SetfieldGc, majit_metainterp::counters::RECORDED_OPS);
                 ctx.record_op_with_descr(OpCode::SetfieldGc, &[target_op, value_op], descr.clone());
                 // resume.py:1004 _prepare_pendingfields replays through
                 // execute_setfield_gc, which seeds heapcache.setfield after
@@ -6826,6 +6906,12 @@ fn prepare_bridge_pending_fields(
                 ctx.heapcache_setfield_cached(target_op, descr.index(), value_op);
             } else {
                 let index_op = ctx.const_int(pending.item_index as i64);
+                ctx.profiler()
+                    .count_ops(OpCode::SetarrayitemGc, majit_metainterp::counters::OPS);
+                ctx.profiler().count_ops(
+                    OpCode::SetarrayitemGc,
+                    majit_metainterp::counters::RECORDED_OPS,
+                );
                 ctx.record_op_with_descr(
                     OpCode::SetarrayitemGc,
                     &[target_op, index_op, value_op],
@@ -7940,6 +8026,12 @@ fn materialize_bridge_virtual(
             // stable_field_index.
             let field_descr =
                 crate::descr::make_field_descr_with_parent(parent_descr.clone(), fd_info.offset);
+            // resume.py:1111-1122 materializer operations use
+            // `execute_and_record`.
+            ctx.profiler()
+                .count_ops(OpCode::SetfieldGc, majit_metainterp::counters::OPS);
+            ctx.profiler()
+                .count_ops(OpCode::SetfieldGc, majit_metainterp::counters::RECORDED_OPS);
             ctx.record_op_with_descr(OpCode::SetfieldGc, &[struct_op, value], field_descr.clone());
             // Bridge virtual rematerialisation — `upd.setfield(valuebox)`
             // parity: cache stores the Box identity (`value` OpRef).
@@ -7967,6 +8059,12 @@ fn materialize_bridge_virtual(
                 return OpRef::NONE;
             };
             // resume.py:619 decoder.allocate_with_vtable(descr=self.descr)
+            ctx.profiler()
+                .count_ops(OpCode::NewWithVtable, majit_metainterp::counters::OPS);
+            ctx.profiler().count_ops(
+                OpCode::NewWithVtable,
+                majit_metainterp::counters::RECORDED_OPS,
+            );
             let new_op = ctx.record_op_with_descr(OpCode::NewWithVtable, &[], size_descr.clone());
             ctx.heap_cache_mut().new_object(new_op);
             // resume.py:620 decoder.virtuals_cache.set_ptr(index, struct)
@@ -8002,6 +8100,10 @@ fn materialize_bridge_virtual(
                 return OpRef::NONE;
             };
             // resume.py:635 decoder.allocate_struct(self.typedescr)
+            ctx.profiler()
+                .count_ops(OpCode::New, majit_metainterp::counters::OPS);
+            ctx.profiler()
+                .count_ops(OpCode::New, majit_metainterp::counters::RECORDED_OPS);
             let new_op = ctx.record_op_with_descr(OpCode::New, &[], struct_descr.clone());
             ctx.heap_cache_mut().new_object(new_op);
             // resume.py:636 decoder.virtuals_cache.set_ptr(index, struct)
@@ -8055,6 +8157,10 @@ fn materialize_bridge_virtual(
             // resume.py:645 AbstractVArrayInfo.__init__ asserts arraydescr is
             // not None; resume.py:652 allocate reads self.arraydescr directly.
             let array_descr = arraydescr.clone().expect("VArrayInfo: arraydescr is None");
+            ctx.profiler()
+                .count_ops(alloc_opcode, majit_metainterp::counters::OPS);
+            ctx.profiler()
+                .count_ops(alloc_opcode, majit_metainterp::counters::RECORDED_OPS);
             let new_op = ctx.record_op_with_descr(alloc_opcode, &[len_ref], array_descr.clone());
             ctx.heap_cache_mut().new_object(new_op);
             // resume.py:654 decoder.virtuals_cache.set_ptr(index, array)
@@ -8076,6 +8182,10 @@ fn materialize_bridge_virtual(
                 }
                 let idx_ref = ctx.const_int(i as i64);
                 // resume.py:660/665/670 setarrayitem_{ref,float,int}
+                ctx.profiler()
+                    .count_ops(set_opcode, majit_metainterp::counters::OPS);
+                ctx.profiler()
+                    .count_ops(set_opcode, majit_metainterp::counters::RECORDED_OPS);
                 ctx.record_op_with_descr(
                     set_opcode,
                     &[new_op, idx_ref, value],
@@ -8107,6 +8217,12 @@ fn materialize_bridge_virtual(
             let array_descr = arraydescr
                 .as_ref()
                 .expect("VArrayStructInfo: arraydescr is None");
+            ctx.profiler()
+                .count_ops(OpCode::NewArrayClear, majit_metainterp::counters::OPS);
+            ctx.profiler().count_ops(
+                OpCode::NewArrayClear,
+                majit_metainterp::counters::RECORDED_OPS,
+            );
             let new_op =
                 ctx.record_op_with_descr(OpCode::NewArrayClear, &[len_ref], array_descr.clone());
             ctx.heap_cache_mut().new_object(new_op);
@@ -8192,6 +8308,10 @@ fn materialize_bridge_virtual(
             //   [func, size], calldescr). A missing entry surfaces here, as the
             // calldescr is consumed by the CALL_I op, not as a separate lookup
             // assertion.
+            ctx.profiler()
+                .count_ops(OpCode::CallI, majit_metainterp::counters::OPS);
+            ctx.profiler()
+                .count_ops(OpCode::CallI, majit_metainterp::counters::RECORDED_OPS);
             let buffer = ctx.record_op_with_descr(
                 OpCode::CallI,
                 &[func_ref, size_ref],
@@ -8232,6 +8352,10 @@ fn materialize_bridge_virtual(
                     di.is_signed,
                 );
                 let offset_ref = ctx.const_int(off as i64);
+                ctx.profiler()
+                    .count_ops(OpCode::RawStore, majit_metainterp::counters::OPS);
+                ctx.profiler()
+                    .count_ops(OpCode::RawStore, majit_metainterp::counters::RECORDED_OPS);
                 ctx.record_op_with_descr(
                     OpCode::RawStore,
                     &[buffer, offset_ref, item],
@@ -8260,6 +8384,10 @@ fn materialize_bridge_virtual(
             let base_buffer = decode_fieldnum(ctx, fieldnums[0], rd_virtuals, resume_data, cache);
             // resume.py:726: buffer = decoder.int_add_const(base_buffer, self.offset)
             let offset_ref = ctx.const_int(*offset as i64);
+            ctx.profiler()
+                .count_ops(OpCode::IntAdd, majit_metainterp::counters::OPS);
+            ctx.profiler()
+                .count_ops(OpCode::IntAdd, majit_metainterp::counters::RECORDED_OPS);
             let buffer = ctx.record_op(OpCode::IntAdd, &[base_buffer, offset_ref]);
             // resume.py:727: decoder.virtuals_cache.set_int(index, buffer)
             cache.set_int(vidx, buffer);
@@ -8300,6 +8428,10 @@ fn materialize_bridge_virtual(
                 (OpCode::Newstr, OpCode::Strsetitem)
             };
             // resume.py:769: string = decoder.allocate_string(length)
+            ctx.profiler()
+                .count_ops(alloc_opcode, majit_metainterp::counters::OPS);
+            ctx.profiler()
+                .count_ops(alloc_opcode, majit_metainterp::counters::RECORDED_OPS);
             let string = ctx.record_op(alloc_opcode, &[length_ref]);
             // resume.py:770: decoder.virtuals_cache.set_ptr(index, string)
             cache.set_ptr(vidx, string);
@@ -8316,6 +8448,10 @@ fn materialize_bridge_virtual(
                     continue;
                 }
                 let idx_ref = ctx.const_int(i as i64);
+                ctx.profiler()
+                    .count_ops(set_opcode, majit_metainterp::counters::OPS);
+                ctx.profiler()
+                    .count_ops(set_opcode, majit_metainterp::counters::RECORDED_OPS);
                 ctx.record_op(set_opcode, &[string, idx_ref, charbox]);
             }
             if majit_metainterp::majit_log_enabled() {
@@ -8406,6 +8542,10 @@ fn materialize_bridge_virtual(
             let start = decode_fieldnum(ctx, fieldnums[1], rd_virtuals, resume_data, cache);
             let length = decode_fieldnum(ctx, fieldnums[2], rd_virtuals, resume_data, cache);
             // resume.py:1157-1158 / :1185-1186: stopbox = INT_ADD(startbox, lengthbox)
+            ctx.profiler()
+                .count_ops(OpCode::IntAdd, majit_metainterp::counters::OPS);
+            ctx.profiler()
+                .count_ops(OpCode::IntAdd, majit_metainterp::counters::RECORDED_OPS);
             let stop = ctx.record_op(OpCode::IntAdd, &[start, length]);
             let oopspec = if is_unicode {
                 majit_ir::effectinfo::OopSpecIndex::UniSlice

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -3209,7 +3209,7 @@ pub(crate) fn opimpl_getfield_gc_r(ctx: &mut TraceCtx, obj: OpRef, descr: DescrR
     result
 }
 
-// Note: pyre does not currently route GetfieldGcF/GetfieldGcPureF through
+// Note: pyre does not currently route GetfieldGcF through
 // state.rs. Float field unboxing goes via the codewriter-generated
 // `getfield_gc_f_pureornot` (majit-translate/src/codegen.rs),
 // which — matching RPython's pyjitpl.py opimpl_getfield_gc_f — records
@@ -5257,7 +5257,7 @@ impl PyreSym {
                     for (item_idx, bits) in items.iter().enumerate() {
                         // Seed a tagged-immediate local as the heap `W_IntObject`
                         // it stands for, so the recorded body reads it through the
-                        // flag-false `GuardClass`+`GetfieldGcPure` arm rather than
+                        // flag-false `GuardClass`+immutable `GetfieldGc` arm rather than
                         // the tagged `CastPtrToInt`+`IntAnd` arm. The runtime
                         // (`execute_assembler`) converts the live frame's local
                         // slots to heap boxes before the compiled loop reads them;

--- a/pyre/pyre-jit-trace/src/trace_helpers/typed_trace.rs
+++ b/pyre/pyre-jit-trace/src/trace_helpers/typed_trace.rs
@@ -374,7 +374,7 @@ fn unbox_int_or_long_for_int_strategy<F: pyre_jit_trace::walker_frame_ops::Walke
 /// variants (`Cls_ii / Cls_ff / Cls_oo` per
 /// `pypy/objspace/std/specialisedtupleobject.py`) the trace dispatches
 /// on the runtime `ob_type` and emits a direct inline-field load —
-/// `value0` / `value1` are immutable so the `GetfieldGcPureI/F/R` op
+/// `value0` / `value1` are immutable so the `GetfieldGcI/F/R` op
 /// is constant-foldable.
 
 /// pyjitpl.py:767-776 opimpl_check_neg_index:

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -268,7 +268,7 @@ fn trace_abort_error(reason: &'static str) -> PyError {
 pub(crate) struct LongBinopSpec {
     /// Pure `rbigint` op over the two bare `*const BigInt` *payloads*
     /// `[Ref, Ref] -> Ref`. The walker emits this after a
-    /// `GetfieldGcPure(value)` on each operand, so the elidable call is pure on
+    /// immutable `GetfieldGc(value)` on each operand, so the elidable call is pure on
     /// the immutable bigints (not the wrappers) and the optimizer never
     /// reorders it ahead of the boxing `setfield_gc` that initializes a fresh
     /// result wrapper.

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -2844,12 +2844,9 @@ impl MIFrame {
             &active_boxes,
             &snapshot_full_types,
         );
-        // pyjitpl.py:2581: self.staticdata.profiler.count_ops(opnum, Counters.GUARDS).
-        // Atomic fetch_add through the shared `Arc<MetaInterpStaticData>`
-        // — `&self` access is enough because `JitProfiler::count_ops`
-        // bumps an `AtomicUsize`.
-        ctx.profiler()
-            .count_ops(opcode, majit_metainterp::counters::GUARDS);
+        // pyjitpl.py:2581 `count_ops(opnum, Counters.GUARDS)` is bumped
+        // inside `TraceCtx::record_guard_typed` (the record chokepoint),
+        // so no explicit count here.
     }
 
     /// pyjitpl.py:2586-2602 capture_resumedata parity.

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -6899,7 +6899,7 @@ pub(crate) fn resume_in_blackhole_from_exit_layout(
 /// `GuardTrue(lowbit)` fails on every back-edge → deopt storm / hang. Converting
 /// the slot to a heap box here — at the concrete boundary, recording no IR —
 /// makes the compiled loop read heap `W_IntObject`, so the trace is the
-/// flag-false `GuardClass`+`GetfieldGcPure` shape that virtualizes to a raw
+/// flag-false `GuardClass`+immutable `GetfieldGc` shape that virtualizes to a raw
 /// carry with zero in-loop tag ops.
 ///
 /// Only the locals region (`0..nlocals`) is scanned; cell/free vars and stack
@@ -7549,7 +7549,7 @@ pub fn try_function_entry_jit(frame: &mut PyFrame) -> Option<PyResult> {
         let env = PyreEnv;
         // Same concrete boundary as `execute_assembler`: a function-entry
         // compiled trace reads its arg locals as heap `W_IntObject`
-        // (`GuardClass`+`GetfieldGcPure`, entry-local tag test omitted), but
+        // (`GuardClass`+immutable `GetfieldGc`, entry-local tag test omitted), but
         // this path never runs `execute_assembler`, so convert here too. A
         // recursive callee (`fib(n-1)`) arrives with a tagged-immediate arg
         // local; without this the compiled `GuardClass(n)` derefs the tag.
@@ -11935,7 +11935,7 @@ r = acc",
     /// RPython portal return type is always REF (warmspot.py:449).
     /// The self-recursive call uses CALL_ASSEMBLER_R, FINISH records with
     /// done_with_this_frame_descr_ref, and the caller unboxes via
-    /// GuardClass + GetfieldGcPureI (pyjitpl.py:3198-3220).
+    /// GuardClass + immutable GetfieldGcI (pyjitpl.py:3198-3220).
     ///
     /// A previous bug used CALL_ASSEMBLER_I + FINISH(Int) + forced unbox
     /// at the blackhole boundary, causing pointer-like-integer corruption

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -11431,7 +11431,7 @@ mod tests {
             if op.opcode == OpCode::GuardClass {
                 saw_guard_nonnull_class = true;
             }
-            if op.opcode == OpCode::GetfieldGcPureI
+            if op.opcode == OpCode::GetfieldGcI
                 && op
                     .getarglist()
                     .iter()
@@ -11449,7 +11449,7 @@ mod tests {
         );
         assert!(
             saw_pure_payload,
-            "int payload fast path should read the immutable payload with GetfieldGcPureI: {:?}",
+            "int payload fast path should read the immutable payload with GetfieldGcI: {:?}",
             recorded_ops
         );
     }

--- a/pyre/pyre-jit/src/trace_verify.rs
+++ b/pyre/pyre-jit/src/trace_verify.rs
@@ -134,7 +134,7 @@ mod tests {
     }
 
     #[test]
-    fn test_unbox_int_ops_use_pure_reads_for_immutable_descrs() {
+    fn test_unbox_int_ops_read_immutable_descrs_as_plain_getfield() {
         let mut ctx = TraceCtx::for_test(1);
         let obj = OpRef::input_arg_ref(0);
         let _intval = crate::trace_unbox_int(
@@ -145,13 +145,14 @@ mod tests {
             immutable_intval_descr(),
         );
         let ops = get_ops(ctx);
-        // Immutable intval descr → GetfieldGcPureI for the value read.
-        // GuardClass takes the object directly (no pre-read of ob_type).
-        assert_eq!(ops, vec![OpCode::GuardClass, OpCode::GetfieldGcPureI]);
+        // The tracer records the plain GetfieldGcI even for an immutable
+        // descr; OptHeap re-derives purity from the descr. GuardClass takes
+        // the object directly (no pre-read of ob_type).
+        assert_eq!(ops, vec![OpCode::GuardClass, OpCode::GetfieldGcI]);
     }
 
     #[test]
-    fn test_unbox_float_ops_use_pure_reads_for_immutable_descrs() {
+    fn test_unbox_float_ops_read_immutable_descrs_as_plain_getfield() {
         let mut ctx = TraceCtx::for_test(1);
         let obj = OpRef::input_arg_ref(0);
         let _floatval = crate::trace_unbox_float(
@@ -162,7 +163,7 @@ mod tests {
             immutable_floatval_descr(),
         );
         let ops = get_ops(ctx);
-        assert_eq!(ops, vec![OpCode::GuardClass, OpCode::GetfieldGcPureF]);
+        assert_eq!(ops, vec![OpCode::GuardClass, OpCode::GetfieldGcF]);
     }
 
     #[test]

--- a/pyre/pyre-object/src/longobject.rs
+++ b/pyre/pyre-object/src/longobject.rs
@@ -505,7 +505,7 @@ pub extern "C" fn jit_w_long_xor_raw(a: i64, b: i64) -> i64 {
 /// `rbigint.add`/`sub`/`mul`/`and_`/`or_`/`xor_` (`rpython/rlib/rbigint.py`,
 /// each `@jit.elidable`) on bare `*const BigInt` payloads — the elidable
 /// arithmetic the walker emits after reading each operand's immutable `value`
-/// via `GetfieldGcPure`. Taking the payloads (not the `W_LongObject` wrappers)
+/// via an immutable `GetfieldGc`. Taking the payloads (not the `W_LongObject` wrappers)
 /// keeps the call's inputs the immutable bigints, so the optimizer forwards the
 /// field read and never reorders this elidable call ahead of the boxing
 /// `setfield_gc` that initializes the fresh result wrapper. Allocates the result


### PR DESCRIPTION
FBW tracer/profiler parity follow-ups, culminating in the removal of the pure-getfield IR opcodes.

## Stack

**(a) Count `OPS`/`RECORDED_OPS` across the remaining FBW record paths.**
`execute_and_record` counts `OPS` at entry (before the all-const fold) and `RECORDED_OPS` on `_record_helper`; several producers that recorded ops directly via `history.record*` were bypassing the profiler. Added the two counters across the record families that were still uncounted (`new`/`new_with_vtable`/`new_array_clear`, raw load/store, `setarrayitem` c-form, `switch`/`IntEq` folds, namespace fold, residual-call dispatchers, vable legs / force / store-back, bridge remat, pending-fields, str/unicode, raw-buffer and frame-array helpers, escape-flush `setarrayitem`).

**(b) Count `Counters.GUARDS` at the `TraceCtx` guard-record chokepoint.**
Guard counting was scattered at a single emit site. Moved it to the `record_guard` / `record_guard_typed` / `record_guard_with_descr` chokepoint so every recorded guard is counted once, and removed the ad-hoc count in `generate_guard_core`.

**(c) Fold plain-spelled getfield in `execute_nonspec_const`.**
Widened the `execute_nonspec_const` getfield fold to accept the plain `GETFIELD_GC_*` opcodes (purity comes from the descr, not the opnum), so const-fold works once the tracer stops emitting the pure spelling. Corrects the stale pure-getfield comments.

**(d) Remove the `GetfieldGcPure{I,R,F}` IR opcodes entirely.**
Upstream has no pure-getfield opnum: `GETFIELD_GC` sits outside the `_ALWAYS_PURE` range, `opimpl_getfield_gc_i_pure` records the plain opnum, and purity is re-derived from `descr.is_always_pure()` at each optimizer stage. The loop-invariant hoist that the pure opcode appeared to provide is actually produced by the HEAP channel (`CachedField::produce_potential_short_preamble_ops` → `AbstractStructPtrInfo` short-preamble ops mint a plain `GETFIELD_GC`, survival gated by `descr.is_always_pure()`); `OptPure` never touches getfields.

- Every tracer producer now records the plain `GetfieldGc{I,R,F}` (int/float/ref unbox, bignum `W_LongObject.value` reads, the uncached walker record paths).
- Deleted the three opcodes: enum variants, metadata tables (arity / OPWITHDESCR / RESULT_TYPE / OPNAME), predicate arms (`is_always_pure` / `has_no_side_effect` / `is_getfield` / `is_memory_access`), the `RecentPureOpTable` buckets, and every consumer/backend load arm (dynasm regalloc + x86 + aarch64, cranelift, wasm, heap/virtualize/heapcache).
- Optimizer CSE/hoist tests converted to plain getfield + immutable descr — they still pass, which is the A/B proof that the heap channel reproduces the CSE and the loop-invariant short-preamble hoist.
- `GetarrayitemGcPure` is **kept**: upstream legitimately retains the array pure opnum (`GETARRAYITEM_GC_PURE` is inside the always-pure range). Out of scope here.

## Gates
- `check.py` green on both backends (dynasm 300/300, cranelift 300/300).
- `GetfieldGcPure` census across `majit/` + `pyre/` = 0.
- Unit suites green on both backends; wasm backend crate compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Unified immutable and regular garbage-collected field reads under the standard field-access operations across JIT tracing, optimization, and compilation.
  * Updated native and WebAssembly backends to generate the appropriate loads consistently.

* **Bug Fixes**
  * Improved constant folding and immutable-field optimization behavior.
  * Corrected handling of field and array operations during trace recording.

* **Monitoring**
  * Expanded operation and guard profiling so recorded and executed operations are counted more accurately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->