### PR TITLE
jit(fbw): multi-frame blackhole-resume build path + input-arg _resref seed (adoption gated)

### DIFF
--- a/majit/majit-metainterp/src/blackhole.rs
+++ b/majit/majit-metainterp/src/blackhole.rs
@@ -2411,23 +2411,48 @@ pub fn run_forever_with_portal(
 ///
 /// Get a chain of blackhole interpreters and fill them by copying
 /// 'metainterp.framestack'.
+pub struct PyjitplBlackholeFrameConfig<'a> {
+    pub state_field_layout: StateFieldLayout,
+    pub virtualizable_info: *const crate::virtualizable::VirtualizableInfo,
+    pub virtualizable_ptr: i64,
+    pub virtualizable_stack_base: usize,
+    pub jitdrivers_sd: &'a [BhJitDriverSd],
+}
+
 pub fn convert_and_run_from_pyjitpl(
     builder: &mut BlackholeInterpBuilder,
     framestack: &MIFrameStack,
     last_exc_value: i64,
     raising_exception: bool,
+    config: Option<PyjitplBlackholeFrameConfig<'_>>,
 ) -> JitException {
     // blackhole.py:1803-1810
     let mut next_bh: Option<Box<BlackholeInterpreter>> = None;
+    let roots_depth = majit_gc::shadow_stack::resume_ref_roots_depth();
 
     for frame in &framestack.frames {
         let mut cur_bh = builder.acquire_interp();
         cur_bh.copy_data_from_miframe(frame);
+        if let Some(config) = config.as_ref() {
+            cur_bh.state_field_layout = config.state_field_layout.clone();
+            cur_bh.virtualizable_info = config.virtualizable_info;
+            cur_bh.virtualizable_ptr = config.virtualizable_ptr;
+            cur_bh.virtualizable_stack_base = config.virtualizable_stack_base;
+            cur_bh.jitdrivers_sd = config.jitdrivers_sd.to_vec();
+        }
+        // Keep every completed interpreter bank rooted while later frames are
+        // acquired and throughout `run_forever`.  The chain is consumed and
+        // released there, so these banks cannot be recovered by moving them
+        // out after the run.
+        unsafe {
+            majit_gc::shadow_stack::push_resume_ref_roots(cur_bh.registers_r.as_mut_slice());
+        }
         cur_bh.nextblackholeinterp = next_bh;
         next_bh = Some(Box::new(cur_bh));
     }
 
     let Some(first_bh_box) = next_bh else {
+        majit_gc::shadow_stack::pop_resume_ref_roots_to(roots_depth);
         return JitException::DoneWithThisFrameVoid;
     };
     let mut first_bh = *first_bh_box;
@@ -2440,7 +2465,9 @@ pub fn convert_and_run_from_pyjitpl(
         0
     };
 
-    run_forever(builder, first_bh, current_exc)
+    let outcome = run_forever(builder, first_bh, current_exc);
+    majit_gc::shadow_stack::pop_resume_ref_roots_to(roots_depth);
+    outcome
 }
 
 /// blackhole.py:1782 resume_in_blackhole

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -199,6 +199,73 @@ pub fn drive_single_frame_blackhole(
     result
 }
 
+/// Run a tracing MIFrame chain through the structured multi-frame blackhole
+/// conversion.  Every frame shares the portal-level virtualizable layout, but
+/// retains its own jitcode, register banks, and blackhole interpreter.
+pub fn drive_multi_frame_blackhole(
+    builder: &mut crate::blackhole::BlackholeInterpBuilder,
+    framestack: &mut crate::pyjitpl::MIFrameStack,
+    state_field_layout: crate::blackhole::StateFieldLayout,
+    virtualizable_info: *const crate::virtualizable::VirtualizableInfo,
+    virtualizable_ptr: i64,
+    virtualizable_stack_base: usize,
+    metainterp_sd: &crate::pyjitpl::MetaInterpStaticData,
+    mut last_exc_value: i64,
+    raising_exception: bool,
+) -> crate::jitexc::JitException {
+    let mut ref_locations = Vec::new();
+    let mut packed_ref_roots = Vec::new();
+    for (frame_index, frame) in framestack.frames.iter().enumerate() {
+        for (color, value) in frame.ref_values.iter().enumerate() {
+            if let Some(value) = value {
+                ref_locations.push((frame_index, color));
+                packed_ref_roots.push(*value);
+            }
+        }
+    }
+    let exception_root = (last_exc_value != 0).then(|| {
+        let index = packed_ref_roots.len();
+        packed_ref_roots.push(last_exc_value);
+        index
+    });
+    let root_depth = majit_gc::shadow_stack::resume_ref_roots_depth();
+    unsafe {
+        majit_gc::shadow_stack::push_resume_ref_roots(packed_ref_roots.as_mut_slice());
+    }
+
+    builder.setup_cached_control_opcodes(
+        metainterp_sd.op_live as i32,
+        metainterp_sd.op_catch_exception as i32,
+        metainterp_sd.op_rvmprof_code as i32,
+    );
+    for ((frame_index, color), forwarded) in ref_locations
+        .into_iter()
+        .zip(packed_ref_roots.iter().copied())
+    {
+        framestack.frames[frame_index].ref_values[color] = Some(forwarded);
+    }
+    if let Some(index) = exception_root {
+        last_exc_value = packed_ref_roots[index];
+    }
+
+    let jitdrivers_sd = bh_jitdrivers_sd(metainterp_sd);
+    let outcome = crate::blackhole::convert_and_run_from_pyjitpl(
+        builder,
+        framestack,
+        last_exc_value,
+        raising_exception,
+        Some(crate::blackhole::PyjitplBlackholeFrameConfig {
+            state_field_layout,
+            virtualizable_info,
+            virtualizable_ptr,
+            virtualizable_stack_base,
+            jitdrivers_sd: &jitdrivers_sd,
+        }),
+    );
+    majit_gc::shadow_stack::pop_resume_ref_roots_to(root_depth);
+    outcome
+}
+
 fn writeback_live_state_scalars_from_blackhole<S: crate::JitState>(
     state: &mut S,
     layout: &crate::blackhole::StateFieldLayout,

--- a/majit/majit-metainterp/src/lib.rs
+++ b/majit/majit-metainterp/src/lib.rs
@@ -128,7 +128,8 @@ pub use jitcode::{
 };
 pub use jitdriver::{
     DeclarativeJitDriver, JitDriver, JitDriverStaticData, SingleFrameBlackholeResult,
-    TraceContinuationSuspendGuard, drive_single_frame_blackhole, trace_continuation_suspended,
+    TraceContinuationSuspendGuard, drive_multi_frame_blackhole, drive_single_frame_blackhole,
+    trace_continuation_suspended,
 };
 pub use majit_backend::CompiledTraceInfo;
 pub use pyjitpl::{eval_binop_f, eval_binop_i, eval_float_cmp, eval_unary_f, eval_unary_i};

--- a/majit/majit-metainterp/src/trace_ctx.rs
+++ b/majit/majit-metainterp/src/trace_ctx.rs
@@ -2309,6 +2309,39 @@ impl TraceCtx {
     ///      `None` as "never matches a real heap pointer", so PTR_EQ
     ///      comparisons with the standard vable resolve to "different" at
     ///      trace time.
+    /// Reconstruct a ref value whose recorder box carries no stamped concrete,
+    /// by re-executing its recorded producer against now-resolvable operands.
+    /// history.py:948 `resbox = execute_with_descr(...)` deferred to
+    /// resume-image build time: an inlined sub-walk that reads a loop-invariant
+    /// OUTER input arg records a `getfield_gc_r` while the obj is still symbolic
+    /// (its concrete lives only in the outer frame's register shadow), so
+    /// `concrete_of_opref` stays `None` until the seeded input arg lets the load
+    /// re-run here.  Follows a chain of `getfield_gc_r` ops down to a resolvable
+    /// root; `depth` bounds the walk.  Returns `None` when the chain roots at an
+    /// op that is neither stamped nor a ref getfield, or the obj is null.
+    pub fn recover_ref_value(&self, opref: OpRef, depth: u32) -> Option<Value> {
+        if let Some(v) = self.concrete_of_opref(opref) {
+            return Some(v);
+        }
+        if depth == 0 {
+            return None;
+        }
+        let op = self.recorder.get_op_by_raw_pos(opref.raw())?;
+        if !matches!(op.opcode, OpCode::GetfieldGcR | OpCode::GetfieldGcPureR) {
+            return None;
+        }
+        let descr = op.descr.borrow().clone()?;
+        let obj = op.args.borrow().first()?.to_opref();
+        let Value::Ref(obj_ref) = self.recover_ref_value(obj, depth - 1)? else {
+            return None;
+        };
+        let obj_ptr = obj_ref.0 as i64;
+        if obj_ptr == 0 || obj_ptr == usize::MAX as i64 {
+            return None;
+        }
+        self.field_sanity_load(obj_ptr, &descr, Type::Ref)
+    }
+
     pub fn concrete_of_opref(&self, opref: OpRef) -> Option<Value> {
         if opref.is_constant() {
             // history.py:220/261/307 box.type parity: the OpRef variant

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/bridge_subwalk.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/bridge_subwalk.rs
@@ -511,6 +511,7 @@ pub(crate) fn compute_bridge_root_parent_frame<Sym: WalkSym>(
         jitcode_index,
         call_jitcode_pc: None,
         call_stack_overrides: Vec::new(),
+        blackhole: None,
         resume_coord: ParentResumeCoord::Backxlat(root_pc),
         // Parent-frame words are never branch-tagged; negative tags belong to
         // a branch guard's own top-frame word.
@@ -661,6 +662,7 @@ pub(crate) fn recipe_parent_frame_from_recipe(
         jitcode_index: recipe.jitcode_index as u32,
         call_jitcode_pc: call_jit_pc,
         call_stack_overrides: Vec::new(),
+        blackhole: None,
         // The recipe's resolved word was `backxlat_py_pc(jitcode_index,
         // jitcode_pc)` by construction, exactly the bridge-root flavor.
         resume_coord: ParentResumeCoord::Backxlat(recipe.jitcode_pc as usize),

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
@@ -4240,6 +4240,11 @@ struct InlineParentFrame {
     /// Concrete operand-stack slots at the caller CALL, keyed by absolute
     /// `locals_cells_stack_w` index. Used only by the abort-point flush.
     call_stack_overrides: Vec<(usize, pyre_object::PyObjectRef)>,
+    /// Complete concrete image needed to turn this paused caller into an
+    /// `MIFrame` if a force aborts in a descendant residual call.  Captured
+    /// while the caller's register banks are still live; `None` is a
+    /// best-effort decline that leaves the existing guard snapshot usable.
+    blackhole: Option<InlineParentBlackhole>,
     /// Authoritative derivation of the caller's Python resume pc.  The
     /// Python-native consumers resolve this at their boundary; a CALL inside
     /// a try-block (catch marker) still declines multi-frame.
@@ -4252,6 +4257,21 @@ struct InlineParentFrame {
     /// at the return point with the not-yet-produced call-result slot nulled
     /// (`get_list_of_active_boxes(in_a_call=true)` parity, trace_opcode.rs).
     boxes: Vec<OpRef>,
+}
+
+#[derive(Clone)]
+struct InlineParentBlackhole {
+    /// Position immediately after the CALL.  The callee blackhole writes its
+    /// return value through `call_result_reg()` before this caller runs.
+    resume_pc: usize,
+    int_values: Vec<(usize, i64)>,
+    /// `(register color, semantic slot, value)`.  Keeping both indices makes
+    /// the semantic Ref shadow's source explicit while the MIFrame consumer
+    /// restores the color-indexed bank.
+    ref_values: Vec<(usize, usize, pyre_object::PyObjectRef)>,
+    /// Float values have no concrete shadow bank; retain their OpRefs and
+    /// resolve them at force time while the trace context is still live.
+    float_values: Vec<(usize, OpRef)>,
 }
 
 /// The derivation flavor of a paused caller frame's Python resume pc.
@@ -4651,6 +4671,7 @@ struct FbwStoreJournalRootArea {
     active_session: *const std::cell::Cell<*const std::cell::RefCell<WalkSession>>,
     escape_flush_undo: *const std::cell::RefCell<Option<EscapeFlushUndo>>,
     single_frame_blackhole: *const std::cell::RefCell<Option<LatchedSingleFrameBlackhole>>,
+    multi_frame_blackhole: *const std::cell::RefCell<Option<LatchedMultiFrameBlackhole>>,
 }
 
 thread_local! {
@@ -4666,6 +4687,7 @@ thread_local! {
         active_session: ACTIVE_WALK_SESSION.with(|value| value as *const _),
         escape_flush_undo: escape_flush_undo_cell_ptr(),
         single_frame_blackhole: single_frame_blackhole_cell_ptr(),
+        multi_frame_blackhole: multi_frame_blackhole_cell_ptr(),
     };
 }
 
@@ -4875,6 +4897,11 @@ pub unsafe fn fbw_store_journal_root_walker_area(
                 for (_slot, value) in parent.call_stack_overrides.iter_mut() {
                     visitor(unsafe { &mut *(value as *mut pyre_object::PyObjectRef).cast() });
                 }
+                if let Some(blackhole) = parent.blackhole.as_mut() {
+                    for (_color, _semantic_slot, value) in blackhole.ref_values.iter_mut() {
+                        visitor(unsafe { &mut *(value as *mut pyre_object::PyObjectRef).cast() });
+                    }
+                }
             }
         }
     }
@@ -4924,6 +4951,17 @@ pub unsafe fn fbw_store_journal_root_walker_area(
     if let Some(latched) = single_frame_blackhole.as_mut() {
         for value in latched.miframe.ref_values.iter_mut().flatten() {
             visitor(unsafe { &mut *(value as *mut i64).cast() });
+        }
+        if latched.last_exc_value != 0 {
+            visitor(unsafe { &mut *(&mut latched.last_exc_value as *mut i64).cast() });
+        }
+    }
+    let multi_frame_blackhole = unsafe { &mut *(*area.multi_frame_blackhole).as_ptr() };
+    if let Some(latched) = multi_frame_blackhole.as_mut() {
+        for frame in latched.framestack.frames.iter_mut() {
+            for value in frame.ref_values.iter_mut().flatten() {
+                visitor(unsafe { &mut *(value as *mut i64).cast() });
+            }
         }
         if latched.last_exc_value != 0 {
             visitor(unsafe { &mut *(&mut latched.last_exc_value as *mut i64).cast() });

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
@@ -48,6 +48,11 @@ thread_local! {
     /// carried to the walk-end VableEscaped leg.
     static FBW_SINGLE_FRAME_BLACKHOLE: std::cell::RefCell<Option<LatchedSingleFrameBlackhole>> =
         const { std::cell::RefCell::new(None) };
+    /// Force-time image of the paused caller chain plus the live innermost
+    /// tracing frame.  Like the single-frame latch, this outlives the walk
+    /// contexts whose concrete banks supplied it.
+    static FBW_MULTI_FRAME_BLACKHOLE: std::cell::RefCell<Option<LatchedMultiFrameBlackhole>> =
+        const { std::cell::RefCell::new(None) };
 }
 
 pub(crate) struct EscapeFlushUndo {
@@ -63,6 +68,12 @@ pub(crate) struct LatchedSingleFrameBlackhole {
     pub(crate) raising_exception: bool,
 }
 
+pub(crate) struct LatchedMultiFrameBlackhole {
+    pub(crate) framestack: majit_metainterp::MIFrameStack,
+    pub(crate) last_exc_value: i64,
+    pub(crate) raising_exception: bool,
+}
+
 pub(crate) fn single_frame_blackhole_cell_ptr()
 -> *const std::cell::RefCell<Option<LatchedSingleFrameBlackhole>> {
     FBW_SINGLE_FRAME_BLACKHOLE.with(|cell| cell as *const _)
@@ -72,14 +83,41 @@ pub(crate) fn take_single_frame_blackhole() -> Option<LatchedSingleFrameBlackhol
     FBW_SINGLE_FRAME_BLACKHOLE.with(|slot| slot.borrow_mut().take())
 }
 
+pub(crate) fn multi_frame_blackhole_cell_ptr()
+-> *const std::cell::RefCell<Option<LatchedMultiFrameBlackhole>> {
+    FBW_MULTI_FRAME_BLACKHOLE.with(|cell| cell as *const _)
+}
+
+pub(crate) fn take_multi_frame_blackhole() -> Option<LatchedMultiFrameBlackhole> {
+    FBW_MULTI_FRAME_BLACKHOLE.with(|slot| slot.borrow_mut().take())
+}
+
 pub(crate) fn reset_single_frame_blackhole() {
     FBW_SINGLE_FRAME_BLACKHOLE.with(|slot| {
+        *slot.borrow_mut() = None;
+    });
+    FBW_MULTI_FRAME_BLACKHOLE.with(|slot| {
         *slot.borrow_mut() = None;
     });
 }
 
 fn single_frame_blackhole_resume_enabled() -> bool {
     std::env::var_os("PYRE_FBW_BLACKHOLE_RESUME").as_deref() == Some(std::ffi::OsStr::new("1"))
+}
+
+/// Opt-in for adopting the MULTI-frame (inlined sub-walk) blackhole image.
+/// The build side (`build_multi_frame_miframe`, the input-arg `_resref` seed,
+/// and the getfield-chain `recover_ref_value`) reconstructs the frame stack
+/// correctly, but the resume side (`drive_multi_frame_blackhole` →
+/// `convert_and_run_from_pyjitpl`) does not yet materialize an OUTER frame's
+/// locals into its live frame before the innermost frame re-reads them (an
+/// inner `sys._getframe(1).f_locals[...]` runs first in the blackhole chain and
+/// sees the not-yet-restored caller frame).  Until that materialization lands,
+/// keep the multi-frame image from being latched so an inline-sub-walk force
+/// declines to the legacy escape/replay path (correct output) instead of
+/// resuming into an incomplete caller frame.
+fn multi_frame_blackhole_resume_enabled() -> bool {
+    std::env::var_os("PYRE_FBW_MULTIFRAME").as_deref() == Some(std::ffi::OsStr::new("1"))
 }
 
 fn build_single_frame_miframe<Sym: WalkSym>(
@@ -124,13 +162,23 @@ fn build_single_frame_miframe<Sym: WalkSym>(
         if miframe.ref_values.get(color).copied().flatten().is_some() {
             continue;
         }
-        let ConcreteValue::Ref(value) = ctx.concrete_registers_r.get(color).copied()? else {
+        let value = match ctx.concrete_registers_r.get(color).copied()? {
+            ConcreteValue::Ref(value) => value as i64,
             // ConcreteValue::Null is the walker's "unknown" sentinel, not a
-            // proven Python null.  S1 declines the whole image rather than
-            // manufacturing a hole in a live Ref color.
-            return None;
+            // proven Python null.  The register shadow never held this color's
+            // concrete — recover it from the recorded box's producer (a getfield
+            // chain rooted at a seeded input arg an inlined sub-walk read but
+            // never concretized in this frame's shadow); decline only when even
+            // that cannot resolve it.
+            _ => {
+                let opref = ctx.registers_r.get(color).copied()?;
+                match ctx.trace_ctx.recover_ref_value(opref, 8) {
+                    Some(majit_ir::Value::Ref(gc)) => gc.0 as i64,
+                    _ => return None,
+                }
+            }
         };
-        *miframe.ref_values.get_mut(color)? = Some(value as i64);
+        *miframe.ref_values.get_mut(color)? = Some(value);
     }
     for &color in &live.float {
         let color = color as usize;
@@ -145,6 +193,87 @@ fn build_single_frame_miframe<Sym: WalkSym>(
     }
 
     Some(miframe)
+}
+
+fn build_multi_frame_miframe<Sym: WalkSym>(
+    ctx: &WalkContext<'_, '_, Sym>,
+    resume_pc: usize,
+    lastop_result: Option<(char, usize, i64)>,
+) -> Option<majit_metainterp::MIFrameStack> {
+    let session = ctx.session.borrow();
+    if session.framestack.is_empty() {
+        return None;
+    }
+    macro_rules! s2dbg {
+        ($($a:tt)*) => {
+            if fbw_debug_abort_enabled() {
+                eprintln!("[s2-build-decline] {}", format!($($a)*));
+            }
+        };
+    }
+    let mut frames = majit_metainterp::MIFrameStack::empty();
+
+    for (index, inline) in session.framestack.iter().enumerate() {
+        let Some(parent) = inline.parent.as_ref() else {
+            s2dbg!("frame {index}: no parent");
+            return None;
+        };
+        let Some(concrete) = parent.blackhole.as_ref() else {
+            s2dbg!("frame {index}: parent.blackhole None (capture missing)");
+            return None;
+        };
+        let pjc = crate::state::pyjitcode_for_jitcode_index(parent.jitcode_index as i32)?;
+        let mut miframe = majit_metainterp::MIFrame::new(pjc.jitcode.clone(), concrete.resume_pc);
+        for &(color, value) in &concrete.int_values {
+            *miframe.int_values.get_mut(color)? = Some(value);
+        }
+        for &(color, _semantic_slot, value) in &concrete.ref_values {
+            *miframe.ref_values.get_mut(color)? = Some(value as i64);
+        }
+        for &(color, opref) in &concrete.float_values {
+            let Some(majit_ir::Value::Float(value)) = ctx.trace_ctx.concrete_of_opref(opref) else {
+                return None;
+            };
+            *miframe.float_values.get_mut(color)? = Some(value.to_bits() as i64);
+        }
+        if index != 0 {
+            miframe.last_caught_exception_value =
+                session.framestack[index - 1].last_caught_exception_value;
+        }
+        frames.push(miframe);
+    }
+
+    let current = session.framestack.last()?;
+    // The innermost frame is the callee `ctx` is actively sub-walking. In a
+    // sub-walk its identity lives in `inline_callee_consts` — the copied
+    // `snapshot_sym` still points at the outer portal, so resolving off it
+    // pins the OUTER jitcode while `resume_pc` and the concrete banks are the
+    // callee's, landing the resume mid-op in the wrong code. Resolve the
+    // callee's own jitcode so all three share its coordinate space; fall back
+    // to `snapshot_sym` for a top-level (non-sub-walk) abort.
+    let innermost_jitcode = if let Some(consts) = ctx.inline_callee_consts {
+        let jc = crate::state::pyjitcode_for_jitcode_index(consts.jitcode_index)?;
+        jc.jitcode.clone()
+    } else {
+        unsafe {
+            let sym = &*ctx.fbw_mode.snapshot_sym;
+            if sym.jitcode().is_null() {
+                s2dbg!("innermost snapshot_sym jitcode null");
+                return None;
+            }
+            (&(*sym.jitcode()).payload).jitcode.clone()
+        }
+    };
+    let Some(mut innermost) =
+        build_single_frame_miframe(ctx, innermost_jitcode, resume_pc, lastop_result)
+    else {
+        s2dbg!("innermost build_single_frame_miframe declined");
+        return None;
+    };
+    innermost.last_caught_exception_value = current.last_caught_exception_value;
+    frames.push(innermost);
+    s2dbg!("BUILT multi-frame depth={}", frames.frames.len());
+    Some(frames)
 }
 
 /// TLS cell pointer for the store-journal root area: the undo stays armed
@@ -1508,32 +1637,47 @@ pub(crate) fn try_execute_residual_call_via_executor<Sym: WalkSym>(
             // failure leaves the pre-existing escape/replay path untouched.
             let odometer_unchanged = heap_write_odometer_before
                 .is_some_and(|before| pyre_interpreter::call::frame_entry_count() == before);
+            if fbw_debug_abort_enabled() && ctx.fbw_mode.inline_subwalk {
+                eprintln!(
+                    "[s2-gate] inline_subwalk fs={} flag={} writes_live={} odo_unchanged={} \
+                     committed_none={} not_bridge={} bh_result_some={} sym_nonnull={}",
+                    ctx.session.borrow().framestack.len(),
+                    single_frame_blackhole_resume_enabled(),
+                    writes_live_heap,
+                    odometer_unchanged,
+                    committed_frame_escape_pc().is_none(),
+                    !ctx.trace_ctx.is_bridge_trace,
+                    blackhole_result.is_some(),
+                    !ctx.fbw_mode.snapshot_sym.is_null(),
+                );
+            }
             if single_frame_blackhole_resume_enabled()
                 && writes_live_heap
                 && odometer_unchanged
-                && committed_frame_escape_pc().is_none()
-                && !ctx.fbw_mode.inline_subwalk
                 && !ctx.trace_ctx.is_bridge_trace
-                && ctx.session.borrow().framestack.is_empty()
                 && let Some((resume_pc, result_bank, result_color)) = blackhole_result
                 && !ctx.fbw_mode.snapshot_sym.is_null()
             {
-                let jitcode = unsafe {
-                    let sym = &*ctx.fbw_mode.snapshot_sym;
-                    (!sym.jitcode().is_null()).then(|| (&(*sym.jitcode()).payload).jitcode.clone())
+                let (lastop_result, last_exc_value, raising_exception) = match exec_result {
+                    Ok(value) => (
+                        (result_bank != 'v').then_some((result_bank, result_color, value)),
+                        0,
+                        false,
+                    ),
+                    Err(exc) => (None, exc, true),
                 };
-                if let Some(jitcode) = jitcode {
-                    let (lastop_result, last_exc_value, raising_exception) = match exec_result {
-                        Ok(value) => (
-                            (result_bank != 'v').then_some((result_bank, result_color, value)),
-                            0,
-                            false,
-                        ),
-                        Err(exc) => (None, exc, true),
+                if ctx.session.borrow().framestack.is_empty()
+                    && !ctx.fbw_mode.inline_subwalk
+                    && committed_frame_escape_pc().is_none()
+                {
+                    let jitcode = unsafe {
+                        let sym = &*ctx.fbw_mode.snapshot_sym;
+                        (!sym.jitcode().is_null())
+                            .then(|| (&(*sym.jitcode()).payload).jitcode.clone())
                     };
-                    if let Some(miframe) =
+                    if let Some(miframe) = jitcode.and_then(|jitcode| {
                         build_single_frame_miframe(ctx, jitcode, resume_pc, lastop_result)
-                    {
+                    }) {
                         FBW_SINGLE_FRAME_BLACKHOLE.with(|slot| {
                             *slot.borrow_mut() = Some(LatchedSingleFrameBlackhole {
                                 miframe,
@@ -1542,6 +1686,18 @@ pub(crate) fn try_execute_residual_call_via_executor<Sym: WalkSym>(
                             });
                         });
                     }
+                } else if ctx.fbw_mode.inline_subwalk
+                    && multi_frame_blackhole_resume_enabled()
+                    && let Some(framestack) =
+                        build_multi_frame_miframe(ctx, resume_pc, lastop_result)
+                {
+                    FBW_MULTI_FRAME_BLACKHOLE.with(|slot| {
+                        *slot.borrow_mut() = Some(LatchedMultiFrameBlackhole {
+                            framestack,
+                            last_exc_value,
+                            raising_exception,
+                        });
+                    });
                 }
             }
             // On a kept commit the undo stays armed: the abort epilogue

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/resume_snapshot.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/resume_snapshot.rs
@@ -1235,6 +1235,88 @@ pub(crate) fn collect_call_stack_overrides<Sym: WalkSym>(
     overrides
 }
 
+fn capture_inline_parent_blackhole<Sym: WalkSym>(
+    ctx: &WalkContext<'_, '_, Sym>,
+    jitcode_index: u32,
+    call_jit_pc: usize,
+) -> Option<InlineParentBlackhole> {
+    let pjc = crate::state::pyjitcode_for_jitcode_index(jitcode_index as i32)?;
+    let call = decode_op_at(&pjc.jitcode.code, call_jit_pc)?;
+    let result_bank = call.argcodes.chars().last()?;
+    let result_color = (result_bank != 'v')
+        .then(|| pjc.jitcode.code.get(call.next_pc.checked_sub(1)?).copied())
+        .flatten()
+        .map(usize::from);
+    let live = crate::state::frame_liveness_reg_indices_by_bank_at(
+        jitcode_index as i32,
+        i32::try_from(call.next_pc).ok()?,
+    );
+    let depth = pjc
+        .depth_trivia_for_jitcode_pc(call.next_pc)
+        .or_else(|| pjc.depth_for_jitcode_pc_pred(call.next_pc))
+        .unwrap_or(0) as usize;
+    let nlocals = (!pjc.code_ptr.is_null())
+        .then(|| unsafe { &*pjc.code_ptr }.varnames.len())
+        .unwrap_or(0);
+    let pcdep = pjc
+        .pcdep_trivia_for_jitcode_pc(call.next_pc)
+        .map(ToOwned::to_owned)
+        .or_else(|| pjc.pcdep_for_jitcode_pc(call.next_pc))
+        .unwrap_or_default();
+
+    let mut int_values = Vec::with_capacity(live.int.len());
+    for &color in &live.int {
+        let color = color as usize;
+        if result_bank == 'i' && result_color == Some(color) {
+            continue;
+        }
+        let ConcreteValue::Int(value) = ctx.concrete_registers_i.get(color).copied()? else {
+            return None;
+        };
+        int_values.push((color, value));
+    }
+
+    let mut ref_values = Vec::with_capacity(live.ref_.len());
+    for &color in &live.ref_ {
+        let color = color as usize;
+        if result_bank == 'r' && result_color == Some(color) {
+            continue;
+        }
+        let semantic_slot =
+            crate::state::semantic_ref_slot_for_reg_color(nlocals, depth, &pcdep, color)
+                .unwrap_or(color);
+        let ConcreteValue::Ref(value) = ctx
+            .concrete_registers_r
+            .get(semantic_slot)
+            .copied()
+            .or_else(|| ctx.concrete_registers_r.get(color).copied())?
+        else {
+            return None;
+        };
+        ref_values.push((color, semantic_slot, value));
+    }
+
+    let mut float_values = Vec::with_capacity(live.float.len());
+    for &color in &live.float {
+        let color = color as usize;
+        if result_bank == 'f' && result_color == Some(color) {
+            continue;
+        }
+        let opref = ctx.registers_f.get(color).copied()?;
+        if opref == OpRef::NONE {
+            return None;
+        }
+        float_values.push((color, opref));
+    }
+
+    Some(InlineParentBlackhole {
+        resume_pc: call.next_pc,
+        int_values,
+        ref_values,
+        float_values,
+    })
+}
+
 pub(crate) fn compute_inline_caller_frame<Sym: WalkSym>(
     ctx: &mut WalkContext<'_, '_, Sym>,
     call_jit_pc: usize,
@@ -1396,6 +1478,7 @@ pub(crate) fn compute_inline_caller_frame<Sym: WalkSym>(
         jitcode_index,
         call_jitcode_pc: Some(call_jit_pc),
         call_stack_overrides,
+        blackhole: capture_inline_parent_blackhole(ctx, jitcode_index, call_jit_pc),
         resume_coord: ParentResumeCoord::CallFallthrough(call_jit_pc),
         resume_marker_jit_pc,
         boxes,
@@ -1607,6 +1690,7 @@ pub(crate) fn compute_nested_inline_caller_frame<Sym: WalkSym>(
         jitcode_index,
         call_jitcode_pc: Some(call_jit_pc),
         call_stack_overrides: Vec::new(),
+        blackhole: capture_inline_parent_blackhole(ctx, jitcode_index, call_jit_pc),
         resume_coord: ParentResumeCoord::CallFallthrough(call_jit_pc),
         resume_marker_jit_pc,
         boxes,

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -5206,6 +5206,32 @@ impl PyreSym {
                 &input_values,
                 concrete_frame as *const u8,
             );
+            // history.py:806-807 `*FrontendOp._resref` parity: give every ref
+            // input arg its runtime value on the recorder value channel (shared
+            // across the outer walk and every inlined sub-walk), not only in the
+            // per-frame register shadow / vable cache.  An inlined callee that
+            // reads a loop-invariant OUTER inputarg — e.g. `getfield_gc_r` off a
+            // portal-frame input reached through `sys._getframe` — records the
+            // load with `box_value(inputarg)` resolvable, so the load result is
+            // stamped and a blackhole-resume image can recover it.  Ref-only:
+            // int/float locals reconstruct through their own concrete shadows,
+            // and input args are never `is_constant()`, so folding gates are
+            // untouched.
+            for (i, opref) in scalar_oprefs.iter().enumerate() {
+                if let Some(majit_ir::Value::Ref(_)) = input_values.get(i).copied() {
+                    ctx.try_set_opref_concrete(*opref, input_values[i]);
+                }
+            }
+            for (j, opref) in array_items.iter().enumerate() {
+                if let Some(v @ majit_ir::Value::Ref(_)) =
+                    input_values.get(num_vable_scalars + j).copied()
+                {
+                    ctx.try_set_opref_concrete(*opref, v);
+                }
+            }
+            if let majit_ir::Value::Ref(_) = vable_ref_value {
+                ctx.try_set_opref_concrete(vable_ref, vable_ref_value);
+            }
         }
     }
 

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -1608,6 +1608,104 @@ fn try_adopt_single_frame_blackhole(ctx: &mut TraceCtx, cf_addr: usize) -> bool 
     adopted
 }
 
+fn try_adopt_multi_frame_blackhole(ctx: &mut TraceCtx, cf_addr: usize) -> bool {
+    let Some(mut latched) = crate::jitcode_dispatch::take_multi_frame_blackhole() else {
+        return false;
+    };
+    let depth = latched.framestack.len();
+    let virtualizable_info = ctx
+        .virtualizable_info()
+        .map(std::sync::Arc::as_ptr)
+        .unwrap_or(std::ptr::null());
+    if virtualizable_info.is_null() {
+        return false;
+    }
+    let Some(stack_base) = crate::state::concrete_nlocals(cf_addr) else {
+        return false;
+    };
+    // EXPERIMENT: multi-frame runs full outer-frame bodies, so it needs a
+    // full-coverage dispatch table, not the inline-call-only builder.
+    let (mut mf_builder, _unwired) =
+        crate::jitcode_runtime::build_default_bh_builder_with_unwired_report();
+    mf_builder.cpu = Some(majit_metainterp::blackhole::pyre_production_cpu());
+    let outcome = majit_metainterp::drive_multi_frame_blackhole(
+        &mut mf_builder,
+        &mut latched.framestack,
+        majit_metainterp::blackhole::StateFieldLayout::default(),
+        virtualizable_info,
+        cf_addr as i64,
+        stack_base,
+        ctx.metainterp_sd().as_ref(),
+        latched.last_exc_value,
+        latched.raising_exception,
+    );
+
+    let adopted = match outcome {
+        majit_metainterp::jitexc::JitException::ContinueRunningNormally {
+            ref green_int, ..
+        } => {
+            let Some(&resume_py_pc) = green_int.first() else {
+                return false;
+            };
+            let resume_py_pc = resume_py_pc as usize;
+            if cf_addr == 0 || resume_py_pc == 0 {
+                return false;
+            }
+            // Every frame in the chain uses the live portal virtualizable.
+            // Its setfield_vable operations have already committed the outer
+            // frame state; only the interpreter restart coordinate remains.
+            unsafe {
+                (*(cf_addr as *mut pyre_interpreter::PyFrame)).last_instr =
+                    resume_py_pc as isize - 1;
+            }
+            WALK_END_RESTART_PC.with(|slot| slot.set(Some(resume_py_pc)));
+            true
+        }
+        majit_metainterp::jitexc::JitException::DoneWithThisFrameVoid => {
+            crate::jitcode_dispatch::fbw_finish_concrete_set(crate::state::ConcreteValue::Null);
+            true
+        }
+        majit_metainterp::jitexc::JitException::DoneWithThisFrameInt(value) => {
+            crate::jitcode_dispatch::fbw_finish_concrete_set(crate::state::ConcreteValue::Int(
+                value,
+            ));
+            true
+        }
+        majit_metainterp::jitexc::JitException::DoneWithThisFrameRef(value) => {
+            crate::jitcode_dispatch::fbw_finish_concrete_set(crate::state::ConcreteValue::Ref(
+                value.as_usize() as pyre_object::PyObjectRef,
+            ));
+            true
+        }
+        majit_metainterp::jitexc::JitException::DoneWithThisFrameFloat(value) => {
+            crate::jitcode_dispatch::fbw_finish_concrete_set(crate::state::ConcreteValue::Float(
+                value,
+            ));
+            true
+        }
+        majit_metainterp::jitexc::JitException::ExitFrameWithExceptionRef(value) => {
+            crate::jitcode_dispatch::fbw_finish_raise_set(crate::state::ConcreteValue::Ref(
+                value.as_usize() as pyre_object::PyObjectRef,
+            ));
+            true
+        }
+    };
+    if adopted {
+        let _ = crate::jitcode_dispatch::take_committed_frame_escape_pc();
+        crate::jitcode_dispatch::discard_escape_flush_undo();
+        crate::jitcode_dispatch::fbw_foriter_inflight_clear();
+        WALK_END_FLUSH_COMMITTED.with(|slot| slot.set(true));
+        if crate::jitcode_dispatch::fbw_debug_abort_enabled() {
+            eprintln!("[fbw-blackhole] adopted multi-frame terminal depth={depth}");
+        }
+    }
+    adopted
+}
+
+fn try_adopt_force_blackhole(ctx: &mut TraceCtx, cf_addr: usize) -> bool {
+    try_adopt_multi_frame_blackhole(ctx, cf_addr) || try_adopt_single_frame_blackhole(ctx, cf_addr)
+}
+
 fn run_perfn_walk<Sym: WalkSym>(
     ctx: &mut TraceCtx,
     sym: &mut Sym,
@@ -2307,15 +2405,15 @@ fn run_perfn_walk<Sym: WalkSym>(
         // predicate as the CloseLoop end-flush above.  A latched inline-callee
         // forward abort has already distinguished an outside mark from a mark
         // inside its discarded attempt.  `PYRE_FBW_ABORT_FLUSH=0` opts out.
-        let single_frame_blackhole_adopted = matches!(
+        let force_blackhole_adopted = matches!(
             &walk_result,
             Err(crate::jitcode_dispatch::DispatchError::VableEscapedDuringResidualCall { .. })
-        ) && try_adopt_single_frame_blackhole(ctx, cf_addr);
+        ) && try_adopt_force_blackhole(ctx, cf_addr);
         if std::env::var_os("PYRE_FBW_ABORT_FLUSH").as_deref() == Some(std::ffi::OsStr::new("0")) {
             // Opt-out: never adopt the escape flush — drop the commit and put
             // the pre-flush frame back so the legacy replay sees pristine
             // state.
-            if !single_frame_blackhole_adopted
+            if !force_blackhole_adopted
                 && matches!(
                     &walk_result,
                     Err(
@@ -2327,7 +2425,7 @@ fn run_perfn_walk<Sym: WalkSym>(
                 crate::jitcode_dispatch::restore_escape_flush_undo();
             }
         } else {
-            if !single_frame_blackhole_adopted
+            if !force_blackhole_adopted
                 && matches!(
                     &walk_result,
                     Err(


### PR DESCRIPTION
## Summary

S2 of the C3 epic: reconstruct the inlined caller-frame stack for a
`VableEscaped` force that fires **inside an inline sub-walk**, so the residual
abort can converge through the ported blackhole (`convert_and_run_from_pyjitpl`)
instead of the legacy escape/replay path.

Follows S1 (#754, merged): opt-in single-frame blackhole resume.

## What's in this PR

**Build side (complete, validated):**
- `capture_inline_parent_blackhole` / `build_multi_frame_miframe` /
  `drive_multi_frame_blackhole` build the `[outer.., innermost]` `MIFrameStack`
  from the sub-walk `WalkContext`.
- The innermost frame's jitcode is resolved from
  `inline_callee_consts.jitcode_index` (not the copied outer-portal
  `snapshot_sym`, which pins the wrong code and lands the resume mid-op).
- **input-arg `_resref` seed** (`init_symbolic`): each ref input arg's concrete
  is stamped onto the recorder value channel (`history.py:806
  *FrontendOp._resref` parity). An inlined sub-walk that reads a loop-invariant
  OUTER input arg — a `getfield_gc_r` off a portal-frame input reached through
  `sys._getframe` — now resolves `box_value` at the load's record instead of
  seeing a symbolic ref.
- `build_single_frame_miframe` recovers an unstamped ref color through
  `recover_ref_value` (re-executes a getfield chain rooted at a now-resolvable
  seeded input arg).

## Validation

- **`check.py` 300/300 on `dynasm` AND `cranelift`** with the (unconditional)
  input-arg `_resref` seed active — no normal-JIT regression.
- Default behavior (multi-frame gate off): `s2_depth1`/`s2_depth2` →
  `199990000` via legacy replay; single-frame repros (`v1_single`,
  `while_twin`) → `199990000 20000` via the S1 blackhole. No crash, no
  regression.

## Known gap (gated off): multi-frame adoption resume

Multi-frame **adoption** is gated behind `PYRE_FBW_MULTIFRAME` (default **off**).
With the build side now producing a correct `MIFrameStack`, adoption exposes a
separate resume-side gap: `drive_multi_frame_blackhole` does not yet materialize
an **outer** frame's locals into its live frame before the **innermost** frame
re-reads them. In the blackhole chain the innermost interpreter runs first, so
an inner `sys._getframe(1).f_locals['total']` reads a not-yet-restored caller
frame and raises `KeyError`. Until that materialization lands, an inline
sub-walk force declines to the legacy replay path (correct output). Single-frame
resume (`PYRE_FBW_BLACKHOLE_RESUME`) is unchanged.

— *authored by Claude*
