### PR TITLE
import: __main__ identity, circular-import diagnostics, module getattr precedence, imp completeness

### DIFF
--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -5454,10 +5454,12 @@ unsafe fn module_getattr_hook_or_err(
         Some(w) if !w.is_null() && pyre_object::is_str(w) => {
             pyre_object::w_str_get_wtf8(w).to_string()
         }
-        _ => return Err(PyError::new(
-            PyErrorKind::AttributeError,
-            format!("module has no attribute '{name}'"),
-        )),
+        _ => {
+            return Err(PyError::new(
+                PyErrorKind::AttributeError,
+                format!("module has no attribute '{name}'"),
+            ));
+        }
     };
     // module.py:148-159 — a module still executing (`__spec__._initializing`)
     // or naming an as-yet-unset submodule reports the circular-import cause.

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -5450,10 +5450,8 @@ unsafe fn module_getattr_hook_or_err(
     // when it is a string, falling back to the bare form otherwise
     // (module.py:143-162).  Own the name up front so the `__spec__` lookups
     // below, which allocate, cannot dangle the dict-borrowed slice.
-    let nm = match finditem_str(w_dict, "__name__")? {
-        Some(w) if !w.is_null() && pyre_object::is_str(w) => {
-            pyre_object::w_str_get_wtf8(w).to_string()
-        }
+    let w_name = match finditem_str(w_dict, "__name__")? {
+        Some(w) if !w.is_null() && pyre_object::is_str(w) => w,
         _ => {
             return Err(PyError::new(
                 PyErrorKind::AttributeError,
@@ -5461,22 +5459,61 @@ unsafe fn module_getattr_hook_or_err(
             ));
         }
     };
-    // module.py:148-159 — a module still executing (`__spec__._initializing`)
-    // or naming an as-yet-unset submodule reports the circular-import cause.
+    // Pin the name across the `__spec__` / shadowing lookups below, which
+    // allocate, then read the display form back from its slot.
+    let _scope = pyre_object::gc_roots::push_roots();
+    let name_slot = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(w_name);
+    let nm = pyre_object::w_str_get_wtf8(w_name).to_string();
+    // Classify the miss through `__spec__`: a same-named file shadowing a
+    // search-path module is flagged first (the stdlib hint takes priority over
+    // the circular-import cause), then a module still executing, then an unset
+    // submodule slot.
     let w_spec = finditem_str(w_dict, "__spec__")?.filter(|w| !w.is_null());
     let msg = if let Some(w_spec) = w_spec {
-        if crate::importing::is_spec_initializing(w_spec)? {
+        let spec_slot = pyre_object::gc_roots::shadow_stack_len();
+        pyre_object::gc_roots::pin_root(w_spec);
+        let w_name = pyre_object::gc_roots::shadow_stack_get(name_slot);
+        let (origin, is_shadowing, is_shadowing_stdlib) =
+            crate::importing::module_shadow_info(w_spec, w_name)?;
+        let w_spec = pyre_object::gc_roots::shadow_stack_get(spec_slot);
+        if is_shadowing_stdlib {
+            let origin = origin.as_deref().unwrap_or("");
             format!(
-                "partially initialized module '{nm}' has no attribute '{name}' \
-                 (most likely due to a circular import)"
+                "module '{nm}' has no attribute '{name}' (consider renaming \
+                 '{origin}' since it has the same name as the standard library \
+                 module named '{nm}' and prevents importing that standard \
+                 library module)"
             )
-        } else if crate::importing::is_spec_uninitialized_submodule(w_spec, name)? {
-            format!(
-                "cannot access submodule '{name}' of module '{nm}' \
-                 (most likely due to a circular import)"
-            )
+        } else if crate::importing::is_spec_initializing(w_spec)? {
+            if is_shadowing {
+                let origin = origin.as_deref().unwrap_or("");
+                format!(
+                    "module '{nm}' has no attribute '{name}' (consider renaming \
+                     '{origin}' if it has the same name as a library you \
+                     intended to import)"
+                )
+            } else if let Some(origin) = origin.as_deref() {
+                format!(
+                    "partially initialized module '{nm}' from '{origin}' has no \
+                     attribute '{name}' (most likely due to a circular import)"
+                )
+            } else {
+                format!(
+                    "partially initialized module '{nm}' has no attribute \
+                     '{name}' (most likely due to a circular import)"
+                )
+            }
         } else {
-            format!("module '{nm}' has no attribute '{name}'")
+            let w_spec = pyre_object::gc_roots::shadow_stack_get(spec_slot);
+            if crate::importing::is_spec_uninitialized_submodule(w_spec, name)? {
+                format!(
+                    "cannot access submodule '{name}' of module '{nm}' \
+                     (most likely due to a circular import)"
+                )
+            } else {
+                format!("module '{nm}' has no attribute '{name}'")
+            }
         }
     } else {
         format!("module '{nm}' has no attribute '{name}'")

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -5464,18 +5464,22 @@ unsafe fn module_getattr_hook_or_err(
     // module.py:148-159 — a module still executing (`__spec__._initializing`)
     // or naming an as-yet-unset submodule reports the circular-import cause.
     let w_spec = finditem_str(w_dict, "__spec__")?.filter(|w| !w.is_null());
-    let msg = match w_spec {
-        Some(w_spec) if crate::importing::is_spec_initializing(w_spec) => format!(
-            "partially initialized module '{nm}' has no attribute '{name}' \
-             (most likely due to a circular import)"
-        ),
-        Some(w_spec) if crate::importing::is_spec_uninitialized_submodule(w_spec, name) => {
+    let msg = if let Some(w_spec) = w_spec {
+        if crate::importing::is_spec_initializing(w_spec)? {
+            format!(
+                "partially initialized module '{nm}' has no attribute '{name}' \
+                 (most likely due to a circular import)"
+            )
+        } else if crate::importing::is_spec_uninitialized_submodule(w_spec, name)? {
             format!(
                 "cannot access submodule '{name}' of module '{nm}' \
                  (most likely due to a circular import)"
             )
+        } else {
+            format!("module '{nm}' has no attribute '{name}'")
         }
-        _ => format!("module '{nm}' has no attribute '{name}'"),
+    } else {
+        format!("module '{nm}' has no attribute '{name}'")
     };
     Err(PyError::new(PyErrorKind::AttributeError, msg))
 }

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -4908,17 +4908,35 @@ fn getattr_str_impl(obj: PyObjectRef, name: &str, call_getattr: bool) -> PyResul
         }
     }
 
+    // module.py:130-162 `Module.descr_getattribute` — a module receiver runs
+    // the generic lookup with the `__getattr__` fallback suppressed, then
+    // consults its own dict's PEP 562 `__getattr__`, and only then the receiver
+    // type's class-level `__getattr__` (descroperation.py:242-245).  Ordering
+    // the module-dict hook before the class hook — and giving the class hook the
+    // final say — matches `slot_tp_getattr_hook`: a class-level `__getattr__`'s
+    // own AttributeError must reach the caller rather than be overwritten by the
+    // generic module-miss message.
+    if call_getattr && unsafe { is_module(obj) } {
+        let err = match object_getattr_miss(obj, name, false) {
+            Ok(value) => return Ok(value),
+            Err(e) => e,
+        };
+        if err.kind != PyErrorKind::AttributeError {
+            return Err(err);
+        }
+        let err = match unsafe { module_getattr_hook_or_err(obj, name, err, true) } {
+            Ok(value) => return Ok(value),
+            Err(e) if e.kind == PyErrorKind::AttributeError => e,
+            Err(e) => return Err(e),
+        };
+        let w_type = crate::typedef::r#type(obj).unwrap_or(PY_NULL);
+        return unsafe { instance_getattr_hook_or_err(w_type, obj, name, err) };
+    }
+
     let err = match object_getattr_miss(obj, name, call_getattr) {
         Ok(value) => return Ok(value),
         Err(e) => e,
     };
-    // module.py:130-142 `Module.descr_getattribute` — PEP 562: after the
-    // normal lookup misses with AttributeError, a module-level `__getattr__`
-    // stored in the module's own dict gets the final say, called with just the
-    // attribute name.  Only `space.getattr` consults it.
-    if err.kind == PyErrorKind::AttributeError && unsafe { is_module(obj) } {
-        return unsafe { module_getattr_hook_or_err(obj, name, err, call_getattr) };
-    }
     Err(err)
 }
 
@@ -5429,14 +5447,33 @@ unsafe fn module_getattr_hook_or_err(
         }
     }
     // No module `__getattr__`: phrase the miss with the module's `__name__`
-    // when it is a string, falling back to the bare form otherwise.  The
-    // `__spec__`-based circular-import diagnostics are not ported.
-    let msg = match finditem_str(w_dict, "__name__")? {
+    // when it is a string, falling back to the bare form otherwise
+    // (module.py:143-162).  Own the name up front so the `__spec__` lookups
+    // below, which allocate, cannot dangle the dict-borrowed slice.
+    let nm = match finditem_str(w_dict, "__name__")? {
         Some(w) if !w.is_null() && pyre_object::is_str(w) => {
-            let nm = pyre_object::w_str_get_wtf8(w);
-            format!("module '{nm}' has no attribute '{name}'")
+            pyre_object::w_str_get_wtf8(w).to_string()
         }
-        _ => format!("module has no attribute '{name}'"),
+        _ => return Err(PyError::new(
+            PyErrorKind::AttributeError,
+            format!("module has no attribute '{name}'"),
+        )),
+    };
+    // module.py:148-159 — a module still executing (`__spec__._initializing`)
+    // or naming an as-yet-unset submodule reports the circular-import cause.
+    let w_spec = finditem_str(w_dict, "__spec__")?.filter(|w| !w.is_null());
+    let msg = match w_spec {
+        Some(w_spec) if crate::importing::is_spec_initializing(w_spec) => format!(
+            "partially initialized module '{nm}' has no attribute '{name}' \
+             (most likely due to a circular import)"
+        ),
+        Some(w_spec) if crate::importing::is_spec_uninitialized_submodule(w_spec, name) => {
+            format!(
+                "cannot access submodule '{name}' of module '{nm}' \
+                 (most likely due to a circular import)"
+            )
+        }
+        _ => format!("module '{nm}' has no attribute '{name}'"),
     };
     Err(PyError::new(PyErrorKind::AttributeError, msg))
 }

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -7730,8 +7730,8 @@ fn builtin_compile(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> 
         ));
     }
     if optimize == -1 {
-        // sys.flags.optimize default.
-        optimize = 0;
+        // pycompiler.py `compile_ast`: -1 resolves to sys.flags.optimize.
+        optimize = i64::from(crate::importing::optimize_flag());
     }
 
     let source_str = unsafe {

--- a/pyre/pyre-interpreter/src/compile.rs
+++ b/pyre/pyre-interpreter/src/compile.rs
@@ -17,7 +17,17 @@ pub use rustpython_compiler_core::bytecode::{
 /// The `CompileError` is returned unflattened so the SyntaxError builders
 /// can read its `python_location` / `python_end_location` / `source_path`.
 pub fn compile_source(source: &str, mode: Mode) -> Result<CodeObject, CompileError> {
-    rp_compile(source, mode, "<string>".into(), Default::default())
+    rp_compile(source, mode, "<string>".into(), default_compile_opts())
+}
+
+/// The `CompileOpts` for an implicit compile (script / `-c` / import): the
+/// `optimize` level tracks `-O` / `-OO` / PYTHONOPTIMIZE via the runtime flag,
+/// the rest default (pycompiler.py `compile_ast` resolving `optimize == -1`).
+fn default_compile_opts() -> CompileOpts {
+    CompileOpts {
+        optimize: crate::importing::optimize_flag(),
+        ..Default::default()
+    }
 }
 
 /// Compile Python source code with a custom filename.
@@ -28,7 +38,7 @@ pub fn compile_source_with_filename(
     mode: Mode,
     filename: &str,
 ) -> Result<CodeObject, CompileError> {
-    compile_source_with_opts(source, mode, filename, Default::default())
+    compile_source_with_opts(source, mode, filename, default_compile_opts())
 }
 
 /// Compile Python source with an explicit `CompileOpts`, carrying the

--- a/pyre/pyre-interpreter/src/display.rs
+++ b/pyre/pyre-interpreter/src/display.rs
@@ -494,6 +494,43 @@ pub(crate) unsafe fn exc_user_dunder_obj(
     }
 }
 
+/// Dispatch a user-defined `__repr__` / `__str__` override on a
+/// `types.ModuleType` subclass. A module instance keeps `ob_type` at the
+/// canonical module type and carries its Python class in `w_class`, so the
+/// `ob_type`-keyed formatting in `py_repr` / `py_str` would otherwise bypass a
+/// subclass override. Returns `None` when the method resolves to the base
+/// `module` registration or `object` (no override); a raising override
+/// propagates and a non-string result raises `TypeError`.
+unsafe fn module_user_dunder_obj(
+    obj: PyObjectRef,
+    name: &str,
+) -> Result<Option<PyObjectRef>, crate::PyError> {
+    unsafe {
+        let w_class = (*obj).w_class;
+        if w_class.is_null() || !pyre_object::is_type(w_class) {
+            return Ok(None);
+        }
+        let module_class = crate::typedef::gettypeobject(&MODULE_TYPE);
+        if std::ptr::eq(w_class, module_class) {
+            return Ok(None);
+        }
+        let Some((src, method)) = crate::baseobjspace::lookup_where_pair(w_class, name) else {
+            return Ok(None);
+        };
+        if method.is_null()
+            || std::ptr::eq(src, module_class)
+            || std::ptr::eq(src, crate::typedef::w_object())
+        {
+            return Ok(None);
+        }
+        let r = crate::builtins::call_and_check(method, &[obj])?;
+        if pyre_object::is_str(r) {
+            return Ok(Some(r));
+        }
+        Err(dunder_returned_non_string(name, r))
+    }
+}
+
 pub unsafe fn py_repr(obj: PyObjectRef) -> Result<String, crate::PyError> {
     // A tagged immediate must be formatted before `ob_type` touches it as a
     // pointer; `repr` of a plain `int` is its
@@ -759,7 +796,14 @@ pub unsafe fn py_repr(obj: PyObjectRef) -> Result<String, crate::PyError> {
             // GenericAlias.__repr__ (`_pypy_generic_alias.py:57`).
             return crate::_pypy_generic_alias::repr(obj);
         } else if std::ptr::eq(tp, &MODULE_TYPE as *const PyType) {
-            crate::typedef::module_repr_string(obj)?
+            // A `types.ModuleType` subclass carries its class in `w_class`; a
+            // subclass `__repr__` override wins over the native module
+            // formatting.
+            if let Some(r) = module_user_dunder_obj(obj, "__repr__")? {
+                pyre_object::w_str_get_value(r).to_string()
+            } else {
+                crate::typedef::module_repr_string(obj)?
+            }
         } else if std::ptr::eq(
             tp,
             &pyre_object::pyobject::MAPPING_PROXY_TYPE as *const PyType,
@@ -1066,6 +1110,13 @@ pub unsafe fn py_str(obj: PyObjectRef) -> Result<String, crate::PyError> {
         // above, so this fallthrough never reaches a bare-`str` subclass.
         if let Some(s) = builtin_subclass_dunder(obj, tp, "__str__")? {
             return Ok(s);
+        }
+        // A `types.ModuleType` subclass `__str__` override wins; without one,
+        // `str` falls back to `__repr__` through `py_repr`.
+        if pyre_object::is_module(obj) {
+            if let Some(r) = module_user_dunder_obj(obj, "__str__")? {
+                return Ok(pyre_object::w_str_get_value(r).to_string());
+            }
         }
         py_repr(obj)
     }

--- a/pyre/pyre-interpreter/src/display.rs
+++ b/pyre/pyre-interpreter/src/display.rs
@@ -442,6 +442,15 @@ pub unsafe fn py_repr_wtf8(obj: PyObjectRef) -> Result<Wtf8Buf, crate::PyError> 
                     return Ok(w);
                 }
             }
+            // A `types.ModuleType` subclass `__repr__` override may likewise
+            // return a lone surrogate; read it as WTF-8 rather than folding to
+            // `&str`. Without an override, the native module repr is plain and
+            // delegates to `py_repr` below.
+            if std::ptr::eq(tp, &MODULE_TYPE as *const PyType) {
+                if let Some(r) = module_user_dunder_obj(obj, "__repr__")? {
+                    return Ok(pyre_object::w_str_get_wtf8(r).to_wtf8_buf());
+                }
+            }
         }
         Ok(Wtf8Buf::from_string(py_repr(obj)?))
     }
@@ -1171,6 +1180,16 @@ pub unsafe fn py_str_wtf8(obj: PyObjectRef) -> Result<Wtf8Buf, crate::PyError> {
                 if let Some(w) = try_call_dunder_wtf8(obj, "__repr__")? {
                     return Ok(w);
                 }
+            }
+            // A `types.ModuleType` subclass `__str__` override may likewise
+            // return a lone surrogate; read it as WTF-8. Without one, `str`
+            // falls back to `__repr__`, kept on the WTF-8 path so a
+            // surrogate-bearing module `__repr__` is preserved too.
+            if pyre_object::is_module(obj) {
+                if let Some(r) = module_user_dunder_obj(obj, "__str__")? {
+                    return Ok(pyre_object::w_str_get_wtf8(r).to_wtf8_buf());
+                }
+                return py_repr_wtf8(obj);
             }
         }
         Ok(Wtf8Buf::from_string(py_str(obj)?))

--- a/pyre/pyre-interpreter/src/importing.rs
+++ b/pyre/pyre-interpreter/src/importing.rs
@@ -2106,6 +2106,23 @@ fn load_source_module(
     let module = pyre_object::w_module_new_aliasing_dict(modulename, canonical);
     set_sys_module(modulename, module);
 
+    // `_frozen_importlib`'s install() (moduledef.py:17-49) executes the two
+    // bootstrap sources under their frozen names, so classes defined in them
+    // capture `__module__` = the frozen name; importlib/__init__.py then renames
+    // the modules to `importlib._bootstrap{,_external}` afterward.  Mirror that:
+    // exec under the frozen `__name__`, restore it after (before install, whose
+    // `sys.modules[__name__]` lookups need the real name).
+    let frozen_exec_name = match modulename {
+        "importlib._bootstrap" => Some("_frozen_importlib"),
+        "importlib._bootstrap_external" => Some("_frozen_importlib_external"),
+        _ => None,
+    };
+    if let Some(frozen) = frozen_exec_name {
+        unsafe {
+            pyre_object::w_dict_setitem_str(w_globals, "__name__", pyre_object::w_str_new(frozen));
+        }
+    }
+
     // PyPy `importing.py:300` passes `pathname`/`cpathname` to
     // `exec_code_module`; pyre has no .pyc cache today so cpathname is
     // always None, matching the PyPy `cpathname is None` arm at line
@@ -2123,6 +2140,18 @@ fn load_source_module(
     ) {
         remove_sys_module(modulename);
         return Err(e);
+    }
+
+    // Restore the public name now that class bodies have captured the frozen
+    // `__module__`; `module.__name__` resolves from this dict entry.
+    if frozen_exec_name.is_some() {
+        unsafe {
+            pyre_object::w_dict_setitem_str(
+                w_globals,
+                "__name__",
+                pyre_object::w_str_new(modulename),
+            );
+        }
     }
 
     // Module-level code may have rewritten `sys.modules[name]` (the

--- a/pyre/pyre-interpreter/src/importing.rs
+++ b/pyre/pyre-interpreter/src/importing.rs
@@ -3024,37 +3024,48 @@ fn resolve_package_name(w_globals: PyObjectRef) -> Result<Option<String>, crate:
 // Get an attribute from the module on TOS. Like `space.getattr(w_module, w_name)`.
 
 /// `importing.py:430 get_spec` — `space.getattr(w_module, '__spec__')`,
-/// returning None when the module carries no spec.
-pub(crate) fn get_spec(module: PyObjectRef) -> PyObjectRef {
+/// returning None when the module carries no `__spec__`.  Only a missing
+/// attribute is suppressed; any other lookup error propagates.
+pub(crate) fn get_spec(module: PyObjectRef) -> Result<PyObjectRef, crate::PyError> {
     match crate::baseobjspace::getattr_str(module, "__spec__") {
-        Ok(v) => v,
-        Err(_) => pyre_object::w_none(),
+        Ok(v) => Ok(v),
+        Err(e) if e.kind == crate::PyErrorKind::AttributeError => Ok(pyre_object::w_none()),
+        Err(e) => Err(e),
     }
 }
 
 /// `importing.py:438 is_spec_initializing` — a spec whose `_initializing`
 /// flag is truthy marks a module still executing, the circular-import signal.
-pub(crate) fn is_spec_initializing(w_spec: PyObjectRef) -> bool {
+/// A missing `_initializing` reads as not initializing; any other lookup error,
+/// and the truth test itself, propagate.
+pub(crate) fn is_spec_initializing(w_spec: PyObjectRef) -> Result<bool, crate::PyError> {
     if unsafe { pyre_object::is_none(w_spec) } {
-        return false;
+        return Ok(false);
     }
-    match crate::baseobjspace::getattr_str(w_spec, "_initializing") {
-        Ok(v) => crate::baseobjspace::is_true(v).unwrap_or(false),
-        Err(_) => false,
-    }
+    let w_initializing = match crate::baseobjspace::getattr_str(w_spec, "_initializing") {
+        Ok(v) => v,
+        Err(e) if e.kind == crate::PyErrorKind::AttributeError => return Ok(false),
+        Err(e) => return Err(e),
+    };
+    crate::baseobjspace::is_true(w_initializing)
 }
 
 /// `importing.py:452 is_spec_uninitialized_submodule` — the name appears in the
-/// spec's `_uninitialized_submodules` list.
-pub(crate) fn is_spec_uninitialized_submodule(w_spec: PyObjectRef, name: &str) -> bool {
+/// spec's `_uninitialized_submodules` list.  A missing attribute reads as not a
+/// submodule; any other lookup error, and the containment test, propagate.
+pub(crate) fn is_spec_uninitialized_submodule(
+    w_spec: PyObjectRef,
+    name: &str,
+) -> Result<bool, crate::PyError> {
     if unsafe { pyre_object::is_none(w_spec) } {
-        return false;
+        return Ok(false);
     }
     let w_value = match crate::baseobjspace::getattr_str(w_spec, "_uninitialized_submodules") {
         Ok(v) => v,
-        Err(_) => return false,
+        Err(e) if e.kind == crate::PyErrorKind::AttributeError => return Ok(false),
+        Err(e) => return Err(e),
     };
-    crate::baseobjspace::contains(w_value, pyre_object::w_str_new(name)).unwrap_or(false)
+    crate::baseobjspace::contains(w_value, pyre_object::w_str_new(name))
 }
 
 pub fn import_from(
@@ -3159,9 +3170,9 @@ pub fn import_from(
     // pyopcode.py:1165-1177 — classify the failure through `__spec__` before
     // reading the path buffer: a module still executing reports the
     // circular-import cause, as does one whose submodule slot is unset.
-    let w_spec = get_spec(module);
-    let initializing = is_spec_initializing(w_spec);
-    let uninit_submodule = !initializing && is_spec_uninitialized_submodule(w_spec, &pkgname);
+    let w_spec = get_spec(module)?;
+    let initializing = is_spec_initializing(w_spec)?;
+    let uninit_submodule = !initializing && is_spec_uninitialized_submodule(w_spec, &pkgname)?;
     let pkgpath = crate::baseobjspace::utf8_w(w_pkgpath)?;
     let msg = if initializing {
         format!(

--- a/pyre/pyre-interpreter/src/importing.rs
+++ b/pyre/pyre-interpreter/src/importing.rs
@@ -1135,9 +1135,33 @@ fn startup_builtin_module(
 /// PyPy equivalent: sys.path is populated at startup with the script
 /// directory, then PYTHONPATH entries, then the stdlib.
 #[cfg(feature = "host_env")]
+/// The canonical absolute form of a startup `sys.path[0]` directory, for the
+/// shadowing check to compare against absolute module origins.  Under the
+/// sandbox the path is left as given (a virtual path the controller mediates);
+/// `canonicalize` would issue raw host syscalls past the seccomp lockdown.
+fn canonical_startup_dir(dir: &Path) -> String {
+    #[cfg(not(feature = "sandbox"))]
+    if let Ok(abs) = std::path::absolute(dir) {
+        return abs
+            .canonicalize()
+            .unwrap_or(abs)
+            .to_string_lossy()
+            .into_owned();
+    }
+    dir.to_string_lossy().into_owned()
+}
+
 pub fn init_sys_path(script_dir: &Path) {
     // Register builtin modules (PyPy: make_builtins / setup_builtin_modules)
     install_builtin_modules();
+
+    // Record the startup `sys.path[0]` for the shadowing check before any user
+    // code can mutate `sys.path`.  Module origins are absolute canonical paths,
+    // so store the canonical absolute form here for the directory comparison to
+    // hold for a relative script argument or a symlinked working directory.
+    SYS_PATH_0.with(|p| {
+        *p.borrow_mut() = Some(canonical_startup_dir(script_dir));
+    });
 
     SYS_PATH.with(|p| {
         let mut path = p.borrow_mut();
@@ -1531,6 +1555,11 @@ thread_local! {
     static SYS_SAFE_PATH: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
     static SYS_OPTIMIZE: std::cell::Cell<i64> = const { std::cell::Cell::new(0) };
     static SYS_DONT_WRITE_BYTECODE: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+    /// The directory prepended to `sys.path` at startup (`config->sys_path_0`):
+    /// the script's directory, or the cwd for `-c` / `-m`.  Captured once by
+    /// `init_sys_path`; read by the shadowing check, which must not see later
+    /// `sys.path` mutations.
+    static SYS_PATH_0: RefCell<Option<String>> = const { RefCell::new(None) };
 }
 
 /// Record whether the launcher was given `-S` (no `site` import), so the
@@ -3078,6 +3107,108 @@ pub(crate) fn is_spec_uninitialized_submodule(
     crate::baseobjspace::contains(w_value, pyre_object::w_str_new(name))
 }
 
+/// `_PyModuleSpec_GetFileOrigin` — the spec's file origin: its `origin` string
+/// when `has_location` is truthy and `origin` is a string, otherwise None.  A
+/// missing `has_location` / `origin`, or a falsey `has_location`, yields None;
+/// other lookup errors and the truth test propagate.
+pub(crate) fn spec_file_origin(
+    w_spec: PyObjectRef,
+) -> Result<Option<PyObjectRef>, crate::PyError> {
+    if unsafe { pyre_object::is_none(w_spec) } {
+        return Ok(None);
+    }
+    // `has_location` is a property whose getter runs Python and allocates, so
+    // pin the spec and read it back before the `origin` lookup.
+    let _scope = pyre_object::gc_roots::push_roots();
+    let spec_slot = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(w_spec);
+    let w_has_location = match crate::baseobjspace::getattr_str(w_spec, "has_location") {
+        Ok(v) => v,
+        Err(e) if e.kind == crate::PyErrorKind::AttributeError => return Ok(None),
+        Err(e) => return Err(e),
+    };
+    if !crate::baseobjspace::is_true(w_has_location)? {
+        return Ok(None);
+    }
+    let w_spec = pyre_object::gc_roots::shadow_stack_get(spec_slot);
+    let w_origin = match crate::baseobjspace::getattr_str(w_spec, "origin") {
+        Ok(v) => v,
+        Err(e) if e.kind == crate::PyErrorKind::AttributeError => return Ok(None),
+        Err(e) => return Err(e),
+    };
+    if !unsafe { pyre_object::is_str(w_origin) } {
+        return Ok(None);
+    }
+    Ok(Some(w_origin))
+}
+
+/// `_PyModule_IsPossiblyShadowing` — whether a module loaded from `origin` could
+/// be shadowing a same-named module later on the search path.  True when `-P`
+/// is off and the file's directory equals the startup `sys.path[0]`; a package
+/// `__init__.py` compares its parent directory instead.
+pub(crate) fn is_possibly_shadowing(origin: &str) -> bool {
+    if safe_path_flag() {
+        return false;
+    }
+    let Some(sys_path_0) = SYS_PATH_0.with(|p| p.borrow().clone()) else {
+        return false;
+    };
+    let sep = std::path::MAIN_SEPARATOR;
+    // root = os.path.dirname(origin.removesuffix(os.sep + "__init__.py"))
+    let mut root = origin.to_string();
+    let Some(idx) = root.rfind(sep) else {
+        return false;
+    };
+    if root[idx + 1..] == *"__init__.py" {
+        root.truncate(idx);
+        let Some(idx2) = root.rfind(sep) else {
+            return false;
+        };
+        root.truncate(idx2);
+    } else {
+        root.truncate(idx);
+    }
+    root == sys_path_0
+}
+
+/// The shadowing classification for a module: its spec file origin (a path
+/// string, when it has one), whether it is possibly shadowing a same-named
+/// search-path module, and whether that shadowed module is a standard-library
+/// one.  `w_name` is the module's `__name__` object, tested against
+/// `sys.stdlib_module_names`.
+pub(crate) fn module_shadow_info(
+    w_spec: PyObjectRef,
+    w_name: PyObjectRef,
+) -> Result<(Option<String>, bool, bool), crate::PyError> {
+    let origin = match spec_file_origin(w_spec)? {
+        Some(o) => unsafe { pyre_object::w_str_get_value(o) }.to_string(),
+        None => return Ok((None, false, false)),
+    };
+    if !is_possibly_shadowing(&origin) {
+        return Ok((Some(origin), false, false));
+    }
+    // Shadowing a same-named search-path module; a standard-library name gets
+    // the stronger hint.  `sys.stdlib_module_names` may be replaced or deleted
+    // by user code — only a real set participates, and its membership test
+    // (which hashes `__name__`) propagates.
+    let mut shadowing_stdlib = false;
+    if let Some(sys_mod) = get_sys_module("sys") {
+        let _scope = pyre_object::gc_roots::push_roots();
+        let name_slot = pyre_object::gc_roots::shadow_stack_len();
+        pyre_object::gc_roots::pin_root(w_name);
+        let w_names = match crate::baseobjspace::getattr_str(sys_mod, "stdlib_module_names") {
+            Ok(v) => v,
+            Err(e) if e.kind == crate::PyErrorKind::AttributeError => pyre_object::w_none(),
+            Err(e) => return Err(e),
+        };
+        if unsafe { pyre_object::is_set_or_frozenset(w_names) } {
+            let w_name = pyre_object::gc_roots::shadow_stack_get(name_slot);
+            shadowing_stdlib = crate::baseobjspace::contains(w_names, w_name)?;
+        }
+    }
+    Ok((Some(origin), true, shadowing_stdlib))
+}
+
 pub fn import_from(
     module: PyObjectRef,
     name: &str,
@@ -3165,30 +3296,57 @@ pub fn import_from(
     // collect; the name string is young and movable, so pin it and read it
     // back from the slot afterwards.
     pyre_object::gc_roots::pin_root(w_pkgname);
-    // pypy/module/imp/importing.py:460 get_path
+    // pypy/module/imp/importing.py:460 get_path — a non-str `__file__`
+    // (including None) reports the location as unknown.
     let w_pkgpath = match crate::baseobjspace::getattr_str(module, "__file__") {
-        Ok(v) if unsafe { pyre_object::is_none(v) } => pyre_object::w_str_new("unknown location"),
-        Ok(v) => v,
+        Ok(v) if unsafe { pyre_object::is_str(v) } => v,
+        Ok(_) => pyre_object::w_str_new("unknown location"),
         Err(e) if e.kind == crate::PyErrorKind::AttributeError => {
             pyre_object::w_str_new("unknown location")
         }
         Err(e) => return Err(e),
     };
+    // Pin the path string across the spec lookups below (which allocate) too.
+    let pkgpath_slot = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(w_pkgpath);
     let w_pkgname = pyre_object::gc_roots::shadow_stack_get(pkgname_slot);
     // Own the name so the spec lookups below (which allocate) cannot dangle it.
     let pkgname = unsafe { pyre_object::w_str_get_value(w_pkgname) }.to_string();
-    // pyopcode.py:1165-1177 — classify the failure through `__spec__` before
-    // reading the path buffer: a module still executing reports the
-    // circular-import cause, as does one whose submodule slot is unset.
+    // Classify the failure through `__spec__`: a same-named file shadowing a
+    // search-path module is flagged first, then a module still executing
+    // reports the circular-import cause, then an unset submodule slot.
     let w_spec = get_spec(module)?;
+    let spec_slot = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(w_spec);
+    let w_pkgname = pyre_object::gc_roots::shadow_stack_get(pkgname_slot);
+    let (origin, is_shadowing, is_shadowing_stdlib) = module_shadow_info(w_spec, w_pkgname)?;
+    let w_spec = pyre_object::gc_roots::shadow_stack_get(spec_slot);
     let initializing = is_spec_initializing(w_spec)?;
+    let w_spec = pyre_object::gc_roots::shadow_stack_get(spec_slot);
     let uninit_submodule = !initializing && is_spec_uninitialized_submodule(w_spec, &pkgname)?;
-    let pkgpath = crate::baseobjspace::utf8_w(w_pkgpath)?;
-    let msg = if initializing {
+    let pkgpath =
+        crate::baseobjspace::utf8_w(pyre_object::gc_roots::shadow_stack_get(pkgpath_slot))?;
+    let origin = origin.as_deref().unwrap_or("");
+    let msg = if is_shadowing_stdlib {
         format!(
-            "cannot import name '{name}' from partially initialized module \
-             '{pkgname}' (most likely due to a circular import) ({pkgpath})"
+            "cannot import name '{name}' from '{pkgname}' (consider renaming \
+             '{origin}' since it has the same name as the standard library \
+             module named '{pkgname}' and prevents importing that standard \
+             library module)"
         )
+    } else if initializing {
+        if is_shadowing {
+            format!(
+                "cannot import name '{name}' from '{pkgname}' (consider renaming \
+                 '{origin}' if it has the same name as a library you intended \
+                 to import)"
+            )
+        } else {
+            format!(
+                "cannot import name '{name}' from partially initialized module \
+                 '{pkgname}' (most likely due to a circular import) ({pkgpath})"
+            )
+        }
     } else if uninit_submodule {
         format!(
             "cannot access submodule '{pkgname}' of module '{name}' \
@@ -3197,6 +3355,8 @@ pub fn import_from(
     } else {
         format!("cannot import name '{name}' from '{pkgname}' ({pkgpath})")
     };
+    let w_pkgname = pyre_object::gc_roots::shadow_stack_get(pkgname_slot);
+    let w_pkgpath = pyre_object::gc_roots::shadow_stack_get(pkgpath_slot);
     Err(crate::PyError::import_error_name_path(
         msg, w_pkgname, w_pkgpath,
     ))

--- a/pyre/pyre-interpreter/src/importing.rs
+++ b/pyre/pyre-interpreter/src/importing.rs
@@ -1529,6 +1529,8 @@ thread_local! {
     static SYS_DEV_MODE: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
     static SYS_UTF8_MODE: std::cell::Cell<i64> = const { std::cell::Cell::new(0) };
     static SYS_SAFE_PATH: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+    static SYS_OPTIMIZE: std::cell::Cell<u8> = const { std::cell::Cell::new(0) };
+    static SYS_DONT_WRITE_BYTECODE: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
 }
 
 /// Record whether the launcher was given `-S` (no `site` import), so the
@@ -1546,6 +1548,7 @@ pub fn no_site_flag() -> bool {
 /// Record the command-line flags consumed by `app_main.py` before `sys` is
 /// initialized.  The codec paths also read `dev_mode` directly, matching
 /// `space.sys.get_flag('dev_mode')` in `unicodeobject.py`.
+#[allow(clippy::too_many_arguments)]
 pub fn set_runtime_flags(
     no_user_site: bool,
     ignore_environment: bool,
@@ -1553,6 +1556,8 @@ pub fn set_runtime_flags(
     dev_mode: bool,
     utf8_mode: i64,
     safe_path: bool,
+    optimize: u8,
+    dont_write_bytecode: bool,
 ) {
     SYS_NO_USER_SITE.with(|p| p.set(no_user_site));
     SYS_IGNORE_ENVIRONMENT.with(|p| p.set(ignore_environment));
@@ -1560,6 +1565,8 @@ pub fn set_runtime_flags(
     SYS_DEV_MODE.with(|p| p.set(dev_mode));
     SYS_UTF8_MODE.with(|p| p.set(utf8_mode));
     SYS_SAFE_PATH.with(|p| p.set(safe_path));
+    SYS_OPTIMIZE.with(|p| p.set(optimize));
+    SYS_DONT_WRITE_BYTECODE.with(|p| p.set(dont_write_bytecode));
 }
 
 pub fn no_user_site_flag() -> bool {
@@ -1584,6 +1591,19 @@ pub fn utf8_mode_flag() -> i64 {
 
 pub fn safe_path_flag() -> bool {
     SYS_SAFE_PATH.with(|p| p.get())
+}
+
+/// `-O` / `-OO` / PYTHONOPTIMIZE level, driving `sys.flags.optimize` and the
+/// default compile `optimize` (stripped asserts, `__debug__` = False, and at
+/// level 2 discarded docstrings).
+pub fn optimize_flag() -> u8 {
+    SYS_OPTIMIZE.with(|p| p.get())
+}
+
+/// `-B` / PYTHONDONTWRITEBYTECODE, driving `sys.flags.dont_write_bytecode` and
+/// `sys.dont_write_bytecode`.
+pub fn dont_write_bytecode_flag() -> bool {
+    SYS_DONT_WRITE_BYTECODE.with(|p| p.get())
 }
 
 /// Called from sys module init to pick up any pending argv.

--- a/pyre/pyre-interpreter/src/importing.rs
+++ b/pyre/pyre-interpreter/src/importing.rs
@@ -1529,7 +1529,7 @@ thread_local! {
     static SYS_DEV_MODE: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
     static SYS_UTF8_MODE: std::cell::Cell<i64> = const { std::cell::Cell::new(0) };
     static SYS_SAFE_PATH: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
-    static SYS_OPTIMIZE: std::cell::Cell<u8> = const { std::cell::Cell::new(0) };
+    static SYS_OPTIMIZE: std::cell::Cell<i64> = const { std::cell::Cell::new(0) };
     static SYS_DONT_WRITE_BYTECODE: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
 }
 
@@ -1556,7 +1556,7 @@ pub fn set_runtime_flags(
     dev_mode: bool,
     utf8_mode: i64,
     safe_path: bool,
-    optimize: u8,
+    optimize: i64,
     dont_write_bytecode: bool,
 ) {
     SYS_NO_USER_SITE.with(|p| p.set(no_user_site));
@@ -1593,10 +1593,20 @@ pub fn safe_path_flag() -> bool {
     SYS_SAFE_PATH.with(|p| p.get())
 }
 
-/// `-O` / `-OO` / PYTHONOPTIMIZE level, driving `sys.flags.optimize` and the
-/// default compile `optimize` (stripped asserts, `__debug__` = False, and at
-/// level 2 discarded docstrings).
+/// `-O` / `-OO` / PYTHONOPTIMIZE level for the default compile `optimize`
+/// (stripped asserts, `__debug__` = False, and at level 2 discarded
+/// docstrings), clamped into the compiler's byte-wide field.  Levels above 2
+/// behave as 2.
 pub fn optimize_flag() -> u8 {
+    SYS_OPTIMIZE
+        .with(|p| p.get())
+        .clamp(0, i64::from(u8::MAX)) as u8
+}
+
+/// The raw optimization level for `sys.flags.optimize`, mirroring a large
+/// `PYTHONOPTIMIZE` value verbatim; `optimize_flag` clamps this for the
+/// compiler.
+pub fn optimize_level() -> i64 {
     SYS_OPTIMIZE.with(|p| p.get())
 }
 

--- a/pyre/pyre-interpreter/src/importing.rs
+++ b/pyre/pyre-interpreter/src/importing.rs
@@ -1317,7 +1317,7 @@ pub fn add_sys_path(dir: &Path) {
 // ── check_sys_modules ────────────────────────────────────────────────
 // PyPy equivalent: importing.py `check_sys_modules(space, w_modulename)`
 
-fn check_sys_modules(name: &str) -> Option<PyObjectRef> {
+pub(crate) fn check_sys_modules(name: &str) -> Option<PyObjectRef> {
     // Consult the Python-visible sys.modules dict first so that user code
     // writing `sys.modules['foo'] = mod` is immediately visible to imports.
     // PyPy: importing.py check_sys_modules reads space.sys.get('modules').
@@ -2974,6 +2974,40 @@ fn resolve_package_name(w_globals: PyObjectRef) -> Result<Option<String>, crate:
 //
 // Get an attribute from the module on TOS. Like `space.getattr(w_module, w_name)`.
 
+/// `importing.py:430 get_spec` — `space.getattr(w_module, '__spec__')`,
+/// returning None when the module carries no spec.
+pub(crate) fn get_spec(module: PyObjectRef) -> PyObjectRef {
+    match crate::baseobjspace::getattr_str(module, "__spec__") {
+        Ok(v) => v,
+        Err(_) => pyre_object::w_none(),
+    }
+}
+
+/// `importing.py:438 is_spec_initializing` — a spec whose `_initializing`
+/// flag is truthy marks a module still executing, the circular-import signal.
+pub(crate) fn is_spec_initializing(w_spec: PyObjectRef) -> bool {
+    if unsafe { pyre_object::is_none(w_spec) } {
+        return false;
+    }
+    match crate::baseobjspace::getattr_str(w_spec, "_initializing") {
+        Ok(v) => crate::baseobjspace::is_true(v).unwrap_or(false),
+        Err(_) => false,
+    }
+}
+
+/// `importing.py:452 is_spec_uninitialized_submodule` — the name appears in the
+/// spec's `_uninitialized_submodules` list.
+pub(crate) fn is_spec_uninitialized_submodule(w_spec: PyObjectRef, name: &str) -> bool {
+    if unsafe { pyre_object::is_none(w_spec) } {
+        return false;
+    }
+    let w_value = match crate::baseobjspace::getattr_str(w_spec, "_uninitialized_submodules") {
+        Ok(v) => v,
+        Err(_) => return false,
+    };
+    crate::baseobjspace::contains(w_value, pyre_object::w_str_new(name)).unwrap_or(false)
+}
+
 pub fn import_from(
     module: PyObjectRef,
     name: &str,
@@ -3071,9 +3105,28 @@ pub fn import_from(
         Err(e) => return Err(e),
     };
     let w_pkgname = pyre_object::gc_roots::shadow_stack_get(pkgname_slot);
-    let pkgname = unsafe { pyre_object::w_str_get_value(w_pkgname) };
+    // Own the name so the spec lookups below (which allocate) cannot dangle it.
+    let pkgname = unsafe { pyre_object::w_str_get_value(w_pkgname) }.to_string();
+    // pyopcode.py:1165-1177 — classify the failure through `__spec__` before
+    // reading the path buffer: a module still executing reports the
+    // circular-import cause, as does one whose submodule slot is unset.
+    let w_spec = get_spec(module);
+    let initializing = is_spec_initializing(w_spec);
+    let uninit_submodule = !initializing && is_spec_uninitialized_submodule(w_spec, &pkgname);
     let pkgpath = crate::baseobjspace::utf8_w(w_pkgpath)?;
-    let msg = format!("cannot import name '{name}' from '{pkgname}' ({pkgpath})");
+    let msg = if initializing {
+        format!(
+            "cannot import name '{name}' from partially initialized module \
+             '{pkgname}' (most likely due to a circular import) ({pkgpath})"
+        )
+    } else if uninit_submodule {
+        format!(
+            "cannot access submodule '{pkgname}' of module '{name}' \
+             (most likely due to a circular import)"
+        )
+    } else {
+        format!("cannot import name '{name}' from '{pkgname}' ({pkgpath})")
+    };
     Err(crate::PyError::import_error_name_path(
         msg, w_pkgname, w_pkgpath,
     ))

--- a/pyre/pyre-interpreter/src/importing.rs
+++ b/pyre/pyre-interpreter/src/importing.rs
@@ -1627,9 +1627,7 @@ pub fn safe_path_flag() -> bool {
 /// docstrings), clamped into the compiler's byte-wide field.  Levels above 2
 /// behave as 2.
 pub fn optimize_flag() -> u8 {
-    SYS_OPTIMIZE
-        .with(|p| p.get())
-        .clamp(0, i64::from(u8::MAX)) as u8
+    SYS_OPTIMIZE.with(|p| p.get()).clamp(0, i64::from(u8::MAX)) as u8
 }
 
 /// The raw optimization level for `sys.flags.optimize`, mirroring a large
@@ -3111,9 +3109,7 @@ pub(crate) fn is_spec_uninitialized_submodule(
 /// when `has_location` is truthy and `origin` is a string, otherwise None.  A
 /// missing `has_location` / `origin`, or a falsey `has_location`, yields None;
 /// other lookup errors and the truth test propagate.
-pub(crate) fn spec_file_origin(
-    w_spec: PyObjectRef,
-) -> Result<Option<PyObjectRef>, crate::PyError> {
+pub(crate) fn spec_file_origin(w_spec: PyObjectRef) -> Result<Option<PyObjectRef>, crate::PyError> {
     if unsafe { pyre_object::is_none(w_spec) } {
         return Ok(None);
     }
@@ -3273,6 +3269,21 @@ pub fn import_from(
                         }
                     }
                 }
+            }
+        }
+    }
+
+    // import_from Issue #17636 — a submodule already bound in sys.modules under
+    // `<__name__>.<name>` is returned even when the parent object rejected the
+    // attribute (e.g. a non-module stand-in with restrictive slots that
+    // `_handle_fromlist` could not setattr onto). Read `__name__` off the object
+    // rather than requiring it to be a module.
+    if let Ok(w_name) = crate::baseobjspace::getattr_str(module, "__name__") {
+        if unsafe { pyre_object::is_str(w_name) } {
+            let modname = unsafe { pyre_object::w_str_get_value(w_name) };
+            let fullname = format!("{modname}.{name}");
+            if let Some(submod) = check_sys_modules(&fullname) {
+                return Ok(submod);
             }
         }
     }

--- a/pyre/pyre-interpreter/src/module/imp/interp_imp.rs
+++ b/pyre/pyre-interpreter/src/module/imp/interp_imp.rs
@@ -413,12 +413,22 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
         ns,
         "create_dynamic",
         // interp_imp.py:49 create_dynamic — no C-extension support, the
-        // `has_so_extension() == False` branch. Raising ImportError (rather
-        // than being absent) matches the meta-path `hasattr` probe while still
-        // letting `except ImportError` fall back to a pure-Python module.
+        // `has_so_extension() == False` branch. The spec's `name` and `origin`
+        // are read and rejected for an embedded null before reporting the
+        // unsupported load, matching `_imp_create_dynamic_impl`. Raising
+        // ImportError (rather than being absent) matches the meta-path
+        // `hasattr` probe while still letting `except ImportError` fall back to
+        // a pure-Python module.
         crate::make_builtin_function_with_arity(
             "create_dynamic",
-            |_| {
+            |args| {
+                let Some(&spec) = args.first() else {
+                    return Err(crate::PyError::type_error(
+                        "create_dynamic() missing required argument 'spec'",
+                    ));
+                };
+                crate::baseobjspace::text0_w(crate::baseobjspace::getattr_str(spec, "name")?)?;
+                crate::baseobjspace::text0_w(crate::baseobjspace::getattr_str(spec, "origin")?)?;
                 Err(crate::PyError::new(
                     crate::PyErrorKind::ImportError,
                     "Not implemented".to_string(),

--- a/pyre/pyre-interpreter/src/module/imp/interp_imp.rs
+++ b/pyre/pyre-interpreter/src/module/imp/interp_imp.rs
@@ -106,6 +106,12 @@ static FROZEN_MODULES: &[FrozenModule] = &[
 
 static FROZEN_OVERRIDE: AtomicI64 = AtomicI64::new(0);
 
+/// `importing.py:159 ImportRLock` reentrant depth. With one execution context
+/// the owner collapses to held/not-held and the real lock never blocks, so the
+/// recursion counter is the whole observable state; it is per-interpreter
+/// (shared across threads), so a global — not thread-local — is correct.
+static IMPORT_LOCK_COUNT: AtomicI64 = AtomicI64::new(0);
+
 fn frozen_module(name: &str) -> Option<&'static FrozenModule> {
     FROZEN_MODULES.iter().find(|entry| entry.name == name)
 }
@@ -150,6 +156,14 @@ fn missing_frozen_error(name: &str) -> crate::PyError {
         pyre_object::w_str_new(name),
         pyre_object::w_none(),
     )
+}
+
+/// The receiver's type name, for argument-type error messages.
+fn type_name(obj: pyre_object::PyObjectRef) -> String {
+    match crate::typedef::r#type(obj) {
+        Some(tp) => unsafe { pyre_object::w_type_get_name(tp) }.to_string(),
+        None => "object".to_string(),
+    }
 }
 
 fn frozen_source(entry: &FrozenModule) -> Result<(String, String), crate::PyError> {
@@ -397,30 +411,85 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
     );
     crate::module_ns_store(
         ns,
+        "create_dynamic",
+        // interp_imp.py:49 create_dynamic — no C-extension support, the
+        // `has_so_extension() == False` branch. Raising ImportError (rather
+        // than being absent) matches the meta-path `hasattr` probe while still
+        // letting `except ImportError` fall back to a pure-Python module.
+        crate::make_builtin_function_with_arity(
+            "create_dynamic",
+            |_| {
+                Err(crate::PyError::new(
+                    crate::PyErrorKind::ImportError,
+                    "Not implemented".to_string(),
+                ))
+            },
+            1,
+        ),
+    );
+    crate::module_ns_store(
+        ns,
         "acquire_lock",
-        crate::make_builtin_function_with_arity("acquire_lock", |_| Ok(pyre_object::w_none()), 0),
+        // importing.py:174 acquire_lock — reentrant; bump the depth.
+        crate::make_builtin_function_with_arity(
+            "acquire_lock",
+            |_| {
+                IMPORT_LOCK_COUNT.fetch_add(1, Ordering::Relaxed);
+                Ok(pyre_object::w_none())
+            },
+            0,
+        ),
     );
     crate::module_ns_store(
         ns,
         "release_lock",
-        crate::make_builtin_function_with_arity("release_lock", |_| Ok(pyre_object::w_none()), 0),
+        // importing.py:192 release_lock — releasing an unheld lock is an error.
+        crate::make_builtin_function_with_arity(
+            "release_lock",
+            |_| {
+                if IMPORT_LOCK_COUNT.load(Ordering::Relaxed) <= 0 {
+                    return Err(crate::PyError::runtime_error("not holding the import lock"));
+                }
+                IMPORT_LOCK_COUNT.fetch_sub(1, Ordering::Relaxed);
+                Ok(pyre_object::w_none())
+            },
+            0,
+        ),
     );
     crate::module_ns_store(
         ns,
         "lock_held",
+        // importing.py:171 lock_held_by_anyone.
         crate::make_builtin_function_with_arity(
             "lock_held",
-            |_| Ok(pyre_object::w_bool_from(false)),
+            |_| Ok(pyre_object::w_bool_from(IMPORT_LOCK_COUNT.load(Ordering::Relaxed) > 0)),
             0,
         ),
     );
     crate::module_ns_store(
         ns,
         "_fix_co_filename",
+        // interp_imp.py:157 fix_co_filename(code, pathname).
         crate::make_builtin_function_with_arity(
             "_fix_co_filename",
-            |_| Ok(pyre_object::w_none()),
-            0,
+            |args| {
+                if !unsafe { crate::is_code(args[0]) } {
+                    return Err(crate::PyError::type_error(format!(
+                        "_fix_co_filename() argument 1 must be code, not {}",
+                        type_name(args[0])
+                    )));
+                }
+                if !unsafe { pyre_object::is_str(args[1]) } {
+                    return Err(crate::PyError::type_error(format!(
+                        "_fix_co_filename() argument 2 must be str, not {}",
+                        type_name(args[1])
+                    )));
+                }
+                let newname = unsafe { pyre_object::w_str_get_value(args[1]) }.to_owned();
+                unsafe { crate::pycode::fix_co_filename(args[0], &newname) };
+                Ok(pyre_object::w_none())
+            },
+            2,
         ),
     );
     crate::module_ns_store(

--- a/pyre/pyre-interpreter/src/module/imp/interp_imp.rs
+++ b/pyre/pyre-interpreter/src/module/imp/interp_imp.rs
@@ -207,8 +207,19 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                         return Ok(pyre_object::w_int_new(0));
                     }
                 };
+                // `interp_imp.is_builtin`: 0 = not a builtin, 1 = a builtin
+                // not yet imported, -1 = a builtin already in sys.modules and
+                // thus not re-initializable (sys/builtins and any other
+                // already-imported builtin).
                 let is_builtin = BUILTIN_MODULES.with(|m| m.borrow().contains_key(name));
-                Ok(pyre_object::w_int_new(if is_builtin { 1 } else { 0 }))
+                let result = if !is_builtin {
+                    0
+                } else if crate::importing::check_sys_modules(name).is_some() {
+                    -1
+                } else {
+                    1
+                };
+                Ok(pyre_object::w_int_new(result))
             },
             1,
         ),
@@ -237,6 +248,20 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                 let entry =
                     served_frozen_module(&name).ok_or_else(|| missing_frozen_error(&name))?;
                 Ok(pyre_object::w_bool_from(entry.is_package))
+            },
+            1,
+        ),
+    );
+    crate::module_ns_store(
+        ns,
+        "init_frozen",
+        crate::make_builtin_function_with_arity(
+            "init_frozen",
+            // interp_imp.py:74 — frozen modules are served through the meta
+            // path, never re-initialized by this legacy entry point.
+            |args| {
+                let _ = frozen_name(args, "init_frozen")?;
+                Ok(pyre_object::w_none())
             },
             1,
         ),

--- a/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
+++ b/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
@@ -2762,7 +2762,9 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                         return Err(crate::PyError::type_error("chmod() requires 2 arguments"));
                     }
                     let path = extract_path(args[0])?;
-                    let mode = (unsafe { pyre_object::w_int_get_value(args[1]) }) as u32;
+                    // `posix.chmod` unwraps `mode` as `c_int`, so a non-integer
+                    // raises TypeError instead of reinterpreting its layout.
+                    let mode = crate::baseobjspace::c_int_w(args[1])? as u32;
                     let c_path = std::ffi::CString::new(path.as_bytes())
                         .map_err(|_| crate::PyError::value_error("embedded null in path"))?;
                     let ret = unsafe { libc::chmod(c_path.as_ptr(), mode as libc::mode_t) };

--- a/pyre/pyre-interpreter/src/module/sys/vm.rs
+++ b/pyre/pyre-interpreter/src/module/sys/vm.rs
@@ -1478,8 +1478,10 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
     module_ns_store(ns, "path_importer_cache", w_dict_new());
     // sys.meta_path — empty
     module_ns_store(ns, "meta_path", w_list_new(vec![]));
-    // sys.dont_write_bytecode
-    module_ns_store(ns, "dont_write_bytecode", w_bool_from(true));
+    // sys.dont_write_bytecode — mirrors `sys.flags.dont_write_bytecode` (0
+    // unless `-B` / PYTHONDONTWRITEBYTECODE); no bytecode cache is written
+    // regardless, but the reported default stays False for compatibility.
+    module_ns_store(ns, "dont_write_bytecode", w_bool_from(false));
     // sys.pycache_prefix — None unless -X pycache_prefix / PYTHONPYCACHEPREFIX.
     // `importlib._bootstrap_external.cache_from_source` reads it to compute the
     // bytecode path before `dont_write_bytecode` is consulted.

--- a/pyre/pyre-interpreter/src/module/sys/vm.rs
+++ b/pyre/pyre-interpreter/src/module/sys/vm.rs
@@ -1247,35 +1247,66 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
         "builtin_module_names",
         w_tuple_new(builtin_names.into_iter().map(w_str_new).collect()),
     );
-    // sys.stdlib_module_names — frozenset of stdlib module names, read by
-    // `traceback.TracebackException` (`wrong_name in sys.stdlib_module_names`)
-    // to offer "did you forget to import" hints.  Seeded from the
-    // compiled-in builtin module names; the full pure-Python stdlib set is
-    // not enumerated yet, so a name absent here simply yields no hint
-    // rather than a crash.
+    // sys.stdlib_module_names — frozenset of every top-level standard-library
+    // module name (`Python/stdlib_module_names.h`).  Read by
+    // `traceback.TracebackException` for "did you forget to import" hints and
+    // by the module shadowing check for the stronger stdlib rename hint.  The
+    // list is the full set regardless of platform, as upstream ships it.
+    const STDLIB_MODULE_NAMES: &[&str] = &[
+        "__future__", "_abc", "_aix_support", "_android_support", "_apple_support", "_ast",
+        "_ast_unparse", "_asyncio", "_bisect", "_blake2", "_bz2", "_codecs", "_codecs_cn",
+        "_codecs_hk", "_codecs_iso2022", "_codecs_jp", "_codecs_kr", "_codecs_tw",
+        "_collections", "_collections_abc", "_colorize", "_compat_pickle", "_contextvars",
+        "_csv", "_ctypes", "_curses", "_curses_panel", "_datetime", "_dbm", "_decimal",
+        "_elementtree", "_frozen_importlib", "_frozen_importlib_external", "_functools",
+        "_gdbm", "_hashlib", "_heapq", "_hmac", "_imp", "_interpchannels", "_interpqueues",
+        "_interpreters", "_io", "_ios_support", "_json", "_locale", "_lsprof", "_lzma",
+        "_markupbase", "_md5", "_multibytecodec", "_multiprocessing", "_opcode",
+        "_opcode_metadata", "_operator", "_osx_support", "_overlapped", "_pickle",
+        "_posixshmem", "_posixsubprocess", "_py_abc", "_py_warnings", "_pydatetime",
+        "_pydecimal", "_pyio", "_pylong", "_pyrepl", "_queue", "_random",
+        "_remote_debugging", "_scproxy", "_sha1", "_sha2", "_sha3", "_signal",
+        "_sitebuiltins", "_socket", "_sqlite3", "_sre", "_ssl", "_stat", "_statistics",
+        "_string", "_strptime", "_struct", "_suggestions", "_symtable", "_sysconfig",
+        "_thread", "_threading_local", "_tkinter", "_tokenize", "_tracemalloc", "_types",
+        "_typing", "_uuid", "_warnings", "_weakref", "_weakrefset", "_winapi", "_wmi",
+        "_zoneinfo", "_zstd", "abc", "annotationlib", "antigravity", "argparse", "array",
+        "ast", "asyncio", "atexit", "base64", "bdb", "binascii", "bisect", "builtins",
+        "bz2", "cProfile", "calendar", "cmath", "cmd", "code", "codecs", "codeop",
+        "collections", "colorsys", "compileall", "compression", "concurrent",
+        "configparser", "contextlib", "contextvars", "copy", "copyreg", "csv", "ctypes",
+        "curses", "dataclasses", "datetime", "dbm", "decimal", "difflib", "dis", "doctest",
+        "email", "encodings", "ensurepip", "enum", "errno", "faulthandler", "fcntl",
+        "filecmp", "fileinput", "fnmatch", "fractions", "ftplib", "functools", "gc",
+        "genericpath", "getopt", "getpass", "gettext", "glob", "graphlib", "grp", "gzip",
+        "hashlib", "heapq", "hmac", "html", "http", "idlelib", "imaplib", "importlib",
+        "inspect", "io", "ipaddress", "itertools", "json", "keyword", "linecache", "locale",
+        "logging", "lzma", "mailbox", "marshal", "math", "mimetypes", "mmap",
+        "modulefinder", "msvcrt", "multiprocessing", "netrc", "nt", "ntpath", "nturl2path",
+        "numbers", "opcode", "operator", "optparse", "os", "pathlib", "pdb", "pickle",
+        "pickletools", "pkgutil", "platform", "plistlib", "poplib", "posix", "posixpath",
+        "pprint", "profile", "pstats", "pty", "pwd", "py_compile", "pyclbr", "pydoc",
+        "pydoc_data", "pyexpat", "queue", "quopri", "random", "re", "readline", "reprlib",
+        "resource", "rlcompleter", "runpy", "sched", "secrets", "select", "selectors",
+        "shelve", "shlex", "shutil", "signal", "site", "smtplib", "socket", "socketserver",
+        "sqlite3", "sre_compile", "sre_constants", "sre_parse", "ssl", "stat", "statistics",
+        "string", "stringprep", "struct", "subprocess", "symtable", "sys", "sysconfig",
+        "syslog", "tabnanny", "tarfile", "tempfile", "termios", "textwrap", "this",
+        "threading", "time", "timeit", "tkinter", "token", "tokenize", "tomllib", "trace",
+        "traceback", "tracemalloc", "tty", "turtle", "turtledemo", "types", "typing",
+        "unicodedata", "unittest", "urllib", "uuid", "venv", "warnings", "wave", "weakref",
+        "webbrowser", "winreg", "winsound", "wsgiref", "xml", "xmlrpc", "zipapp", "zipfile",
+        "zipimport", "zlib", "zoneinfo",
+    ];
     module_ns_store(
         ns,
         "stdlib_module_names",
-        pyre_object::setobject::w_frozenset_from_items(&[
-            w_str_new("sys"),
-            w_str_new("builtins"),
-            w_str_new("_thread"),
-            w_str_new("time"),
-            w_str_new("errno"),
-            w_str_new("_io"),
-            w_str_new("marshal"),
-            w_str_new("_imp"),
-            w_str_new("gc"),
-            w_str_new("_warnings"),
-            w_str_new("_string"),
-            w_str_new("_codecs"),
-            w_str_new("_weakref"),
-            w_str_new("_operator"),
-            w_str_new("_collections"),
-            w_str_new("_functools"),
-            w_str_new("itertools"),
-            w_str_new("atexit"),
-        ]),
+        pyre_object::setobject::w_frozenset_from_items(
+            &STDLIB_MODULE_NAMES
+                .iter()
+                .map(|&n| w_str_new(n))
+                .collect::<Vec<_>>(),
+        ),
     );
     // sys.exception() — the value half of `sys.exc_info()`: the exception
     // instance currently being handled, or None outside an `except` block.

--- a/pyre/pyre-interpreter/src/module/sys/vm.rs
+++ b/pyre/pyre-interpreter/src/module/sys/vm.rs
@@ -746,7 +746,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                 pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
                     fns,
                     "optimize",
-                    w_int_new(i64::from(crate::importing::optimize_flag())),
+                    w_int_new(crate::importing::optimize_level()),
                 )
             };
             unsafe {

--- a/pyre/pyre-interpreter/src/module/sys/vm.rs
+++ b/pyre/pyre-interpreter/src/module/sys/vm.rs
@@ -746,14 +746,14 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                 pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
                     fns,
                     "optimize",
-                    w_int_new(0),
+                    w_int_new(i64::from(crate::importing::optimize_flag())),
                 )
             };
             unsafe {
                 pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
                     fns,
                     "dont_write_bytecode",
-                    w_int_new(0),
+                    w_int_new(i64::from(crate::importing::dont_write_bytecode_flag())),
                 )
             };
             unsafe {
@@ -1478,10 +1478,14 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
     module_ns_store(ns, "path_importer_cache", w_dict_new());
     // sys.meta_path — empty
     module_ns_store(ns, "meta_path", w_list_new(vec![]));
-    // sys.dont_write_bytecode — mirrors `sys.flags.dont_write_bytecode` (0
-    // unless `-B` / PYTHONDONTWRITEBYTECODE); no bytecode cache is written
-    // regardless, but the reported default stays False for compatibility.
-    module_ns_store(ns, "dont_write_bytecode", w_bool_from(false));
+    // sys.dont_write_bytecode — mirrors `sys.flags.dont_write_bytecode`
+    // (`-B` / PYTHONDONTWRITEBYTECODE); no bytecode cache is written regardless,
+    // but the reported value tracks the flag for compatibility.
+    module_ns_store(
+        ns,
+        "dont_write_bytecode",
+        w_bool_from(crate::importing::dont_write_bytecode_flag()),
+    );
     // sys.pycache_prefix — None unless -X pycache_prefix / PYTHONPYCACHEPREFIX.
     // `importlib._bootstrap_external.cache_from_source` reads it to compute the
     // bytecode path before `dont_write_bytecode` is consulted.

--- a/pyre/pyre-interpreter/src/pycode.rs
+++ b/pyre/pyre-interpreter/src/pycode.rs
@@ -1406,6 +1406,48 @@ pub unsafe fn w_code_get_ptr(obj: PyObjectRef) -> *const () {
     unsafe { (*(obj as *const PyCode)).code_ptr }
 }
 
+/// `importing.py:379 update_code_filenames`: set `source_path` on `code` and,
+/// recursively, on every nested code constant whose filename still matches the
+/// root's *original* name (leaving unrelated inlined filenames untouched).
+/// `Constants` exposes no in-place mutation, so the table is rebuilt.
+fn fix_code_filenames(code: &mut crate::CodeObject, oldname: &str, newname: &str) {
+    code.source_path = newname.to_owned();
+    let new_consts: crate::bytecode::Constants<crate::bytecode::ConstantData> = code
+        .constants
+        .iter()
+        .map(|c| match c {
+            crate::bytecode::ConstantData::Code { code: nested }
+                if nested.source_path == oldname =>
+            {
+                let mut nested = (**nested).clone();
+                fix_code_filenames(&mut nested, oldname, newname);
+                crate::bytecode::ConstantData::Code {
+                    code: Box::new(nested),
+                }
+            }
+            other => other.clone(),
+        })
+        .collect();
+    code.constants = new_consts;
+}
+
+/// `_imp._fix_co_filename(code, path)` (importing.py:158 fix_co_filename):
+/// replace `co_filename` on the code object in place, recursing through its
+/// nested code constants.  Only valid because the code object is owned
+/// (`Box::into_raw`), single-threaded, and not executing when import machinery
+/// calls this right after compilation.
+///
+/// # Safety
+/// `w_code` must point to a valid `PyCode` whose body is not currently running.
+pub unsafe fn fix_co_filename(w_code: PyObjectRef, newname: &str) {
+    let code_ptr = unsafe { w_code_get_ptr(w_code) } as *mut crate::CodeObject;
+    if code_ptr.is_null() {
+        return;
+    }
+    let oldname = unsafe { (*code_ptr).source_path.clone() };
+    unsafe { fix_code_filenames(&mut *code_ptr, &oldname, newname) };
+}
+
 /// Cached [`crate::pyframe::npure_cellvars`] for the code wrapper `obj`,
 /// or `None` for a null/stub wrapper (sentinel `u32::MAX`) so the caller
 /// falls back to recomputation.

--- a/pyre/pyrex/src/lib.rs
+++ b/pyre/pyrex/src/lib.rs
@@ -824,15 +824,42 @@ fn run_source(source: &str, mode: Mode, filename: &str, no_site: bool) {
     let main_module = pyre_object::module::w_module_new_aliasing_dict("__main__", canonical);
     importing::set_sys_module("__main__", main_module);
 
+    // Seed the module-identity attributes every `__main__` namespace carries
+    // (pythonrun.c seeds these; `runpy` does the `-m` case). Without them a
+    // bare `__spec__` / `__package__` / `__doc__` reference falls through to
+    // the `builtins` module and returns its values, so `if __spec__ is None`
+    // main-detection (multiprocessing spawn, runpy, pytest) inverts.
+    unsafe {
+        pyre_object::dictmultiobject::w_dict_setitem_str(
+            canonical,
+            "__spec__",
+            pyre_object::w_none(),
+        );
+        pyre_object::dictmultiobject::w_dict_setitem_str(
+            canonical,
+            "__package__",
+            pyre_object::w_none(),
+        );
+        pyre_object::dictmultiobject::w_dict_setitem_str(
+            canonical,
+            "__doc__",
+            pyre_object::w_none(),
+        );
+    }
+
     // A script run by path gets `__file__` / `__cached__` in `__main__`
     // (pythonrun.c `_PyRun_SimpleFileObject`); the `-c "<string>"` command
-    // path does not. `__file__` is the literal command-line path, not a
-    // canonicalized one.
+    // path does not. `__file__` is absolutized (os.path.abspath, 3.9+) while
+    // `sys.argv[0]` keeps the literal command-line path.
     if filename != "<string>" {
+        let abs_file = match std::path::absolute(filename) {
+            Ok(p) => p.to_string_lossy().into_owned(),
+            Err(_) => filename.to_string(),
+        };
         let _ = pyre_interpreter::baseobjspace::setattr_str(
             main_module,
             "__file__",
-            pyre_object::w_str_new(filename),
+            pyre_object::w_str_new(&abs_file),
         );
         let _ = pyre_interpreter::baseobjspace::setattr_str(
             main_module,

--- a/pyre/pyrex/src/lib.rs
+++ b/pyre/pyrex/src/lib.rs
@@ -909,7 +909,17 @@ fn run_source(source: &str, mode: Mode, filename: &str, no_site: bool) {
     // path does not. `__file__` is absolutized (os.path.abspath, 3.9+) while
     // `sys.argv[0]` keeps the literal command-line path.
     if filename != "<string>" {
-        let abs_file = match std::path::absolute(filename) {
+        // Resolve a relative path against `sys_path_cwd()` — the seam-provided
+        // virtual cwd under sandbox — before normalizing, so `std::path::absolute`
+        // never consults (and leaks) the trusted process cwd. Off sandbox this is
+        // identical to `absolute(filename)`.
+        let path = Path::new(filename);
+        let to_absolutize = if path.is_absolute() {
+            path.to_path_buf()
+        } else {
+            sys_path_cwd().join(path)
+        };
+        let abs_file = match std::path::absolute(&to_absolutize) {
             Ok(p) => p.to_string_lossy().into_owned(),
             Err(_) => filename.to_string(),
         };

--- a/pyre/pyrex/src/lib.rs
+++ b/pyre/pyrex/src/lib.rs
@@ -48,7 +48,7 @@ struct LaunchFlags {
     utf8_mode: Option<i64>,
     safe_path: bool,
     // `-O` count on the command line; PYTHONOPTIMIZE folds in during finalize.
-    optimize: u8,
+    optimize: i64,
     dont_write_bytecode: bool,
 }
 
@@ -169,15 +169,17 @@ fn env_int_flag(name: &str) -> Option<u32> {
 }
 
 /// `-O` count folded with PYTHONOPTIMIZE (`config_init_optimization_level`):
-/// the effective level is the larger of the two.
-fn resolve_optimize(flags: &LaunchFlags) -> u8 {
-    let mut level = u32::from(flags.optimize);
+/// the effective level is the larger of the two.  The level is kept as a wide
+/// integer so `sys.flags.optimize` mirrors a large `PYTHONOPTIMIZE` verbatim;
+/// the compiler clamps it into a byte at read time.
+fn resolve_optimize(flags: &LaunchFlags) -> i64 {
+    let mut level = flags.optimize;
     if !flags.ignore_environment {
         if let Some(v) = env_int_flag("PYTHONOPTIMIZE") {
-            level = level.max(v);
+            level = level.max(i64::from(v));
         }
     }
-    level.min(u32::from(u8::MAX)) as u8
+    level
 }
 
 /// `-B` folded with PYTHONDONTWRITEBYTECODE: either disables bytecode caches.

--- a/pyre/pyrex/src/lib.rs
+++ b/pyre/pyrex/src/lib.rs
@@ -47,6 +47,9 @@ struct LaunchFlags {
     dev_mode: bool,
     utf8_mode: Option<i64>,
     safe_path: bool,
+    // `-O` count on the command line; PYTHONOPTIMIZE folds in during finalize.
+    optimize: u8,
+    dont_write_bytecode: bool,
 }
 
 impl Default for LaunchFlags {
@@ -61,6 +64,8 @@ impl Default for LaunchFlags {
             dev_mode: false,
             utf8_mode: None,
             safe_path: false,
+            optimize: 0,
+            dont_write_bytecode: false,
         }
     }
 }
@@ -76,7 +81,9 @@ Options:
 -i     : inspect interactively after running script
 -E     : ignore PYTHON* environment variables
 -I     : isolate Python from the user's environment
--O     : optimize (no-op, reserved for compatibility)
+-B     : don't write .pyc files on import (also PYTHONDONTWRITEBYTECODE=x)
+-O     : remove assert and __debug__-dependent statements (also PYTHONOPTIMIZE=x)
+-OO    : do -O changes and also discard docstrings
 -q     : don't print version on interactive startup
 -s     : don't add user site directory to sys.path
 -S     : don't imply 'import site' on initialization
@@ -146,8 +153,50 @@ fn resolve_utf8_mode(flags: &LaunchFlags) -> i64 {
     if locale_implies_utf8_mode() { 1 } else { 0 }
 }
 
+/// `_Py_get_env_flag`: an integer environment flag. An unset or empty value is
+/// absent; a clean non-negative integer is used as-is; anything else (trailing
+/// junk, negative, overflow) counts as 1.
+fn env_int_flag(name: &str) -> Option<u32> {
+    let raw = std::env::var(name).ok()?;
+    if raw.is_empty() {
+        return None;
+    }
+    let value = match raw.parse::<i64>() {
+        Ok(v) if (0..=i64::from(u32::MAX)).contains(&v) => v as u32,
+        _ => 1,
+    };
+    Some(value)
+}
+
+/// `-O` count folded with PYTHONOPTIMIZE (`config_init_optimization_level`):
+/// the effective level is the larger of the two.
+fn resolve_optimize(flags: &LaunchFlags) -> u8 {
+    let mut level = u32::from(flags.optimize);
+    if !flags.ignore_environment {
+        if let Some(v) = env_int_flag("PYTHONOPTIMIZE") {
+            level = level.max(v);
+        }
+    }
+    level.min(u32::from(u8::MAX)) as u8
+}
+
+/// `-B` folded with PYTHONDONTWRITEBYTECODE: either disables bytecode caches.
+fn resolve_dont_write_bytecode(flags: &LaunchFlags) -> bool {
+    if flags.dont_write_bytecode {
+        return true;
+    }
+    if !flags.ignore_environment {
+        if let Some(v) = env_int_flag("PYTHONDONTWRITEBYTECODE") {
+            return v != 0;
+        }
+    }
+    false
+}
+
 fn finalize_flags(mut flags: LaunchFlags) -> LaunchFlags {
     flags.utf8_mode = Some(resolve_utf8_mode(&flags));
+    flags.optimize = resolve_optimize(&flags);
+    flags.dont_write_bytecode = resolve_dont_write_bytecode(&flags);
     flags
 }
 
@@ -193,7 +242,11 @@ fn parse_args(binary_name: &str) -> Result<(RunMode, LaunchFlags, Vec<String>), 
                     _ => {}
                 }
             }
-            Short('O') => {} // no-op
+            // `-O` / `-OO` raise the optimization level; each occurrence counts
+            // (app_main.py `optimize`). PYTHONOPTIMIZE folds in during finalize.
+            Short('O') => flags.optimize = flags.optimize.saturating_add(1),
+            // `-B` disables writing bytecode caches (PYTHONDONTWRITEBYTECODE).
+            Short('B') => flags.dont_write_bytecode = true,
             // Unbuffered stdio: pyre's stdout/stderr wrappers already write
             // through to the fd on every call, so the flag has nothing left
             // to disable; accepting it keeps `script_helper`-style spawns
@@ -415,6 +468,8 @@ fn real_main(binary_name: &str) {
         dev_mode,
         utf8_mode,
         safe_path,
+        optimize,
+        dont_write_bytecode,
     } = flags;
 
     // The `interact` controller does not run the embedded interpreter; it only
@@ -456,6 +511,8 @@ fn real_main(binary_name: &str) {
         dev_mode,
         utf8_mode.unwrap_or(0),
         safe_path,
+        optimize,
+        dont_write_bytecode,
     );
 
     // OS-level hardening (default-on in any Linux `sandbox` build): lock the


### PR DESCRIPTION
Continues the import-compatibility work. Each change was verified against
PyPy3 (the compat oracle) and CPython 3.14; every case below now matches
PyPy3 exactly.

## Changes

- **`__main__` identity attributes** — seed `__spec__` / `__package__` /
  `__doc__` = `None` on the `__main__` namespace before user code runs, so a
  bare reference no longer falls through to `builtins`. Set `__file__`
  (absolutized) / `__cached__` = `None` for a script run by path. Fixes
  `if __spec__ is None` main-detection (multiprocessing spawn, runpy, pytest)
  and `NameError: __doc__`.

- **Circular-import diagnostics** — `from a import x` and `a.x` on a module
  still executing now report *"partially initialized module 'a' ... (most
  likely due to a circular import)"*, and an unset submodule reports *"cannot
  access submodule ..."*, driven by `__spec__._initializing` /
  `_uninitialized_submodules`.

- **Module `__getattr__` precedence** — a module consults its own dict's PEP
  562 `__getattr__` before the receiver type's class-level `__getattr__`, and
  a class-level `__getattr__`'s own `AttributeError` reaches the caller
  instead of being overwritten by the generic module-miss message.

- **`_imp.is_builtin`** — returns `-1` for a builtin already in `sys.modules`
  (not re-initializable), `1` for a not-yet-imported builtin, `0` otherwise.

- **`_imp.init_frozen`** — added as the legacy no-op returning `None`.

- **`sys.dont_write_bytecode`** — defaults to `False`, consistent with
  `sys.flags.dont_write_bytecode` (no bytecode cache is written regardless).

Also included (earlier on this branch): module subclass `__repr__`/`__str__`
override dispatch in `repr`/`str`, and `chmod` mode validation as `c_int`.

## Verification

- Each case matches PyPy3 (and CPython where they agree; circular-import
  wording follows PyPy3 per the faithful-error-message convention).
- `check.py` dynasm 300/300 ×2 and cranelift 300/300 ×2, all green.

— *commented by Claude*