### PR TITLE
jit(fbw): fix broken main — drop #763's residual last_caught_exception_value propagation (removed in #756)

### DIFF
--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
@@ -236,14 +236,9 @@ fn build_multi_frame_miframe<Sym: WalkSym>(
             };
             *miframe.float_values.get_mut(color)? = Some(value.to_bits() as i64);
         }
-        if index != 0 {
-            miframe.last_caught_exception_value =
-                session.framestack[index - 1].last_caught_exception_value;
-        }
         frames.push(miframe);
     }
 
-    let current = session.framestack.last()?;
     // The innermost frame is the callee `ctx` is actively sub-walking. In a
     // sub-walk its identity lives in `inline_callee_consts` — the copied
     // `snapshot_sym` still points at the outer portal, so resolving off it
@@ -264,13 +259,12 @@ fn build_multi_frame_miframe<Sym: WalkSym>(
             (&(*sym.jitcode()).payload).jitcode.clone()
         }
     };
-    let Some(mut innermost) =
+    let Some(innermost) =
         build_single_frame_miframe(ctx, innermost_jitcode, resume_pc, lastop_result)
     else {
         s2dbg!("innermost build_single_frame_miframe declined");
         return None;
     };
-    innermost.last_caught_exception_value = current.last_caught_exception_value;
     frames.push(innermost);
     s2dbg!("BUILT multi-frame depth={}", frames.frames.len());
     Some(frames)


### PR DESCRIPTION
## Problem

`origin/main` does not compile. `pyre-jit-trace` fails with 4× `E0609`:

```
error[E0609]: no field `last_caught_exception_value` on type `majit_metainterp::MIFrame`
  --> pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs:240
error[E0609]: no field `last_caught_exception_value` on type `InlineFrame`
  --> pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs:241
  (same at :273 for MIFrame and &InlineFrame)
```

Because PR CI builds `merge(PR, main)`, this reddens **every** open PR, not just the one that introduced it.

## Root cause

Stale-branch merge:

- **#756** (`dc3559c94aa`, "instruction-keyed, per-frame, and loop-close exception traceback recording") deliberately **removed** `last_caught_exception_value` from `MIFrame`, `BlackholeInterpreter`, `InlineFrame`, and `WalkSession`. Its commit body: *"no traceback decision keys on object identity."* Traceback recording is now keyed on the raising instruction.
- **#763** (`80d590b0f6d`, "multi-frame blackhole-resume build path") was developed on a **pre-#756 base** and still reads/writes that field in `build_multi_frame_miframe`. It merged 4 commits after #756 (`#756 → #753 → #748 → #735 → #763`), so the field references no longer resolve.

## Fix

Drop #763's vestigial per-frame `last_caught_exception_value` propagation to match #756's instruction-keyed model — **not** restore the field (that would undo #756's design). The removed lines only copied the field between reconstructed frames; the multi-frame build path is `PYRE_FBW_MULTIFRAME`-gated (default off), so there is no behavior change.

## Verification

`python3 ./pyre/check.py` on the fix:

```
ALL PASSED: dynasm 303/303
ALL PASSED: cranelift 303/303
ALL PASSED: wasm 300/300
```

— *commented by Claude*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected exception state handling when resuming execution after a residual call.
  * Prevented exception-catch information from being incorrectly carried over between nested execution frames.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->