### PR TITLE
jit(fbw): exception-object virtualization perf + polymorphic-raise resume fix

### DIFF
--- a/pyre/bench/synth/exception_traceback_loop_forms.py
+++ b/pyre/bench/synth/exception_traceback_loop_forms.py
@@ -1,0 +1,169 @@
+# Traceback nodes recorded by a compiled loop, driven by BOTH loop forms.
+#
+# The sibling exception-traceback fixtures all drive their workload with
+# `for i in range(N)`. The two loop forms compile through different paths and
+# have failed independently: the same callee raising into a `while` loop lost
+# every node while the `for` twin lost exactly one, so a `for`-only fixture
+# reports the milder symptom or none at all.
+#
+# Each shape reports the SET of chain depths it observed rather than one
+# sample, so a compiled iteration that disagrees with the interpreted ones
+# shows up as a second element instead of being averaged away. A node built on
+# both sides of a frame boundary shows up the same way.
+#
+# The traceback walk is repeated inline in each shape on purpose: moving it
+# into a helper adds a call to the loop body and changes what the body traces,
+# which is enough to hide the divergence.
+
+N = 20000
+
+
+def out(key, value):
+    print(f"{key} = {value}")
+
+
+def thrower(i):
+    raise KeyError(i)
+
+
+def while_callee(n):
+    depths, missing, i = set(), 0, 0
+    while i < n:
+        try:
+            thrower(i)
+        except KeyError as e:
+            tb = e.__traceback__
+            if tb is None:
+                missing += 1
+            else:
+                d = 0
+                while tb is not None:
+                    d += 1
+                    tb = tb.tb_next
+                depths.add(d)
+        i += 1
+    return sorted(depths), missing
+
+
+def for_callee(n):
+    depths, missing = set(), 0
+    for i in range(n):
+        try:
+            thrower(i)
+        except KeyError as e:
+            tb = e.__traceback__
+            if tb is None:
+                missing += 1
+            else:
+                d = 0
+                while tb is not None:
+                    d += 1
+                    tb = tb.tb_next
+                depths.add(d)
+    return sorted(depths), missing
+
+
+def while_same_frame(n):
+    depths, missing, i = set(), 0, 0
+    while i < n:
+        try:
+            raise ValueError(i)
+        except ValueError as e:
+            tb = e.__traceback__
+            if tb is None:
+                missing += 1
+            else:
+                d = 0
+                while tb is not None:
+                    d += 1
+                    tb = tb.tb_next
+                depths.add(d)
+        i += 1
+    return sorted(depths), missing
+
+
+def for_same_frame(n):
+    depths, missing = set(), 0
+    for i in range(n):
+        try:
+            raise ValueError(i)
+        except ValueError as e:
+            tb = e.__traceback__
+            if tb is None:
+                missing += 1
+            else:
+                d = 0
+                while tb is not None:
+                    d += 1
+                    tb = tb.tb_next
+                depths.add(d)
+    return sorted(depths), missing
+
+
+def while_residual_raise(n):
+    """A builtin operation raises for the frame -- no `raise` statement."""
+    depths, missing, i, zero = set(), 0, 0, 0
+    while i < n:
+        try:
+            _ = i // zero
+        except ZeroDivisionError as e:
+            tb = e.__traceback__
+            if tb is None:
+                missing += 1
+            else:
+                d = 0
+                while tb is not None:
+                    d += 1
+                    tb = tb.tb_next
+                depths.add(d)
+        i += 1
+    return sorted(depths), missing
+
+
+def while_bare_reraise(n):
+    depths, missing, i = set(), 0, 0
+    while i < n:
+        try:
+            try:
+                raise ValueError(i)
+            except ValueError:
+                raise
+        except ValueError as e:
+            tb = e.__traceback__
+            if tb is None:
+                missing += 1
+            else:
+                d = 0
+                while tb is not None:
+                    d += 1
+                    tb = tb.tb_next
+                depths.add(d)
+        i += 1
+    return sorted(depths), missing
+
+
+def while_innermost_lineno(n):
+    """The innermost node's line is the raising line, not the helper's `def`."""
+    linenos, missing, i = set(), 0, 0
+    while i < n:
+        try:
+            thrower(i)
+        except KeyError as e:
+            tb = e.__traceback__
+            if tb is None:
+                missing += 1
+            else:
+                while tb.tb_next is not None:
+                    tb = tb.tb_next
+                linenos.add(tb.tb_lineno)
+        i += 1
+    return sorted(linenos), missing
+
+
+out("while_callee_tb", while_callee(N))
+out("for_callee_tb", for_callee(N))
+out("while_same_frame_tb", while_same_frame(N))
+out("for_same_frame_tb", for_same_frame(N))
+out("while_residual_raise_tb", while_residual_raise(N))
+out("while_bare_reraise_tb", while_bare_reraise(N))
+out("while_innermost_lineno", while_innermost_lineno(N))

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -9606,6 +9606,10 @@ pub unsafe fn exception_attr_slot_fold(
             ExceptionAttrSlot::Filename2
         }
         // `__traceback__` is a `W_BaseException` slot on every exception kind.
+        // `descr_gettraceback` also calls `tb.frame.mark_as_escaped()`, which
+        // `w_exception_get_traceback` omits while the `ExecutionContext::leave`
+        // vref force it feeds is unported; the fold tracks that getter, so both
+        // sides gain the mark together.
         "__traceback__" => ExceptionAttrSlot::Traceback,
         // `name` shares the `w_exc_name` slot across the four kinds whose getattr
         // arm reads it; other kinds keep the regular attribute fall-through.

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -6726,10 +6726,12 @@ fn object_getattr_miss(obj: PyObjectRef, name: &str, call_getattr: bool) -> PyRe
                 }
             }
             // Shared `name` attribute for the kinds that expose it —
-            // `W_ImportError` (and `W_ModuleNotFoundError`), `W_NameError`,
-            // and `W_AttributeError` (Python 3.10+).  Read from the shared
-            // `w_exc_name` slot (default `None`); falls through to normal
-            // attribute lookup on every other exception kind.
+            // `W_ImportError` (and `W_ModuleNotFoundError`), `W_NameError`
+            // (and `W_UnboundLocalError`, which subclasses it and so inherits
+            // the descriptor), and `W_AttributeError` (Python 3.10+).  Read
+            // from the shared `w_exc_name` slot (default `None`); falls
+            // through to normal attribute lookup on every other exception
+            // kind.
             "name" => {
                 let kind = unsafe { pyre_object::w_exception_get_kind(obj) };
                 if matches!(
@@ -6737,6 +6739,7 @@ fn object_getattr_miss(obj: PyObjectRef, name: &str, call_getattr: bool) -> PyRe
                     pyre_object::interp_exceptions::ExcKind::ImportError
                         | pyre_object::interp_exceptions::ExcKind::ModuleNotFoundError
                         | pyre_object::interp_exceptions::ExcKind::NameError
+                        | pyre_object::interp_exceptions::ExcKind::UnboundLocalError
                         | pyre_object::interp_exceptions::ExcKind::AttributeError
                 ) {
                     let stored =
@@ -9469,8 +9472,8 @@ pub fn object_setattr(obj: PyObjectRef, name: &str, value: PyObjectRef) -> PyRes
                 }
             }
             // Shared writable `name` slot for ImportError / ModuleNotFoundError
-            // / NameError / AttributeError; the matching getattr arm reads it
-            // back.
+            // / NameError (and its UnboundLocalError subclass) / AttributeError;
+            // the matching getattr arm reads it back.
             "name" => {
                 let kind = unsafe { pyre_object::w_exception_get_kind(obj) };
                 if matches!(
@@ -9478,6 +9481,7 @@ pub fn object_setattr(obj: PyObjectRef, name: &str, value: PyObjectRef) -> PyRes
                     pyre_object::interp_exceptions::ExcKind::ImportError
                         | pyre_object::interp_exceptions::ExcKind::ModuleNotFoundError
                         | pyre_object::interp_exceptions::ExcKind::NameError
+                        | pyre_object::interp_exceptions::ExcKind::UnboundLocalError
                         | pyre_object::interp_exceptions::ExcKind::AttributeError
                 ) {
                     unsafe { pyre_object::interp_exceptions::w_exception_set_name(obj, value) };
@@ -9611,7 +9615,7 @@ pub unsafe fn exception_attr_slot_fold(
         // vref force it feeds is unported; the fold tracks that getter, so both
         // sides gain the mark together.
         "__traceback__" => ExceptionAttrSlot::Traceback,
-        // `name` shares the `w_exc_name` slot across the four kinds whose getattr
+        // `name` shares the `w_exc_name` slot across the kinds whose getattr
         // arm reads it; other kinds keep the regular attribute fall-through.
         "name"
             if matches!(
@@ -9619,6 +9623,7 @@ pub unsafe fn exception_attr_slot_fold(
                 pyre_object::interp_exceptions::ExcKind::ImportError
                     | pyre_object::interp_exceptions::ExcKind::ModuleNotFoundError
                     | pyre_object::interp_exceptions::ExcKind::NameError
+                    | pyre_object::interp_exceptions::ExcKind::UnboundLocalError
                     | pyre_object::interp_exceptions::ExcKind::AttributeError
             ) =>
         {

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -9517,6 +9517,14 @@ pub enum ExceptionAttrSlot {
     Strerror,
     Filename,
     Filename2,
+    Traceback,
+    Name,
+    AttrObj,
+    UnicodeObject,
+    UnicodeStart,
+    UnicodeEnd,
+    UnicodeReason,
+    UnicodeEncoding,
 }
 
 /// Ingredients for the full-body walker's mirror of the typed exception-slot
@@ -9597,13 +9605,99 @@ pub unsafe fn exception_attr_slot_fold(
         {
             ExceptionAttrSlot::Filename2
         }
+        // `__traceback__` is a `W_BaseException` slot on every exception kind.
+        "__traceback__" => ExceptionAttrSlot::Traceback,
+        // `name` shares the `w_exc_name` slot across the four kinds whose getattr
+        // arm reads it; other kinds keep the regular attribute fall-through.
+        "name"
+            if matches!(
+                kind,
+                pyre_object::interp_exceptions::ExcKind::ImportError
+                    | pyre_object::interp_exceptions::ExcKind::ModuleNotFoundError
+                    | pyre_object::interp_exceptions::ExcKind::NameError
+                    | pyre_object::interp_exceptions::ExcKind::AttributeError
+            ) =>
+        {
+            ExceptionAttrSlot::Name
+        }
+        "obj" if kind == pyre_object::interp_exceptions::ExcKind::AttributeError => {
+            ExceptionAttrSlot::AttrObj
+        }
+        "object"
+            if matches!(
+                kind,
+                pyre_object::interp_exceptions::ExcKind::UnicodeTranslateError
+                    | pyre_object::interp_exceptions::ExcKind::UnicodeDecodeError
+                    | pyre_object::interp_exceptions::ExcKind::UnicodeEncodeError
+            ) =>
+        {
+            ExceptionAttrSlot::UnicodeObject
+        }
+        "start"
+            if matches!(
+                kind,
+                pyre_object::interp_exceptions::ExcKind::UnicodeTranslateError
+                    | pyre_object::interp_exceptions::ExcKind::UnicodeDecodeError
+                    | pyre_object::interp_exceptions::ExcKind::UnicodeEncodeError
+            ) =>
+        {
+            ExceptionAttrSlot::UnicodeStart
+        }
+        "end"
+            if matches!(
+                kind,
+                pyre_object::interp_exceptions::ExcKind::UnicodeTranslateError
+                    | pyre_object::interp_exceptions::ExcKind::UnicodeDecodeError
+                    | pyre_object::interp_exceptions::ExcKind::UnicodeEncodeError
+            ) =>
+        {
+            ExceptionAttrSlot::UnicodeEnd
+        }
+        "reason"
+            if matches!(
+                kind,
+                pyre_object::interp_exceptions::ExcKind::UnicodeTranslateError
+                    | pyre_object::interp_exceptions::ExcKind::UnicodeDecodeError
+                    | pyre_object::interp_exceptions::ExcKind::UnicodeEncodeError
+            ) =>
+        {
+            ExceptionAttrSlot::UnicodeReason
+        }
+        // `encoding` is absent on `UnicodeTranslateError`, so its getattr arm
+        // excludes that kind.
+        "encoding"
+            if matches!(
+                kind,
+                pyre_object::interp_exceptions::ExcKind::UnicodeDecodeError
+                    | pyre_object::interp_exceptions::ExcKind::UnicodeEncodeError
+            ) =>
+        {
+            ExceptionAttrSlot::UnicodeEncoding
+        }
         _ => return None,
     };
-    // Only loads of `__context__`/`__cause__` fold to a raw slot read.
-    // `descr_setcontext` (`interp_exceptions.py:183-190`) type-validates and
-    // `descr_setcause` (`:166-174`) also flips `suppress_context` to True, so a
-    // direct slot write would drop those effects.
-    if is_store && matches!(slot, ExceptionAttrSlot::Context | ExceptionAttrSlot::Cause) {
+    // This folds LOADS only.  `__context__`/`__cause__` stores are
+    // side-effecting: `descr_setcontext` (`interp_exceptions.py:183-190`)
+    // type-validates and `descr_setcause` (`:166-174`) also flips
+    // `suppress_context` to True, so a direct slot write would drop those
+    // effects; `descr_settraceback` likewise type-validates its store.  The
+    // `name`/`obj`/Unicode* setters are plain slot writes, but they are still
+    // left residual here — only the read side of every listed slot is folded.
+    if is_store
+        && matches!(
+            slot,
+            ExceptionAttrSlot::Context
+                | ExceptionAttrSlot::Cause
+                | ExceptionAttrSlot::Traceback
+                | ExceptionAttrSlot::Name
+                | ExceptionAttrSlot::AttrObj
+                | ExceptionAttrSlot::UnicodeObject
+                | ExceptionAttrSlot::UnicodeStart
+                | ExceptionAttrSlot::UnicodeEnd
+                | ExceptionAttrSlot::UnicodeReason
+                | ExceptionAttrSlot::UnicodeEncoding
+        )
+    {
         return None;
     }
     let w_type = crate::typedef::r#type(obj)?;
@@ -9635,6 +9729,28 @@ pub unsafe fn exception_attr_slot_fold(
             }
             ExceptionAttrSlot::Filename2 => {
                 pyre_object::interp_exceptions::w_exception_get_filename2(obj)
+            }
+            ExceptionAttrSlot::Traceback => {
+                pyre_object::interp_exceptions::w_exception_get_traceback(obj)
+            }
+            ExceptionAttrSlot::Name => pyre_object::interp_exceptions::w_exception_get_name(obj),
+            ExceptionAttrSlot::AttrObj => {
+                pyre_object::interp_exceptions::w_exception_get_attr_obj(obj)
+            }
+            ExceptionAttrSlot::UnicodeObject => {
+                pyre_object::interp_exceptions::w_exception_get_object(obj)
+            }
+            ExceptionAttrSlot::UnicodeStart => {
+                pyre_object::interp_exceptions::w_exception_get_start(obj)
+            }
+            ExceptionAttrSlot::UnicodeEnd => {
+                pyre_object::interp_exceptions::w_exception_get_end(obj)
+            }
+            ExceptionAttrSlot::UnicodeReason => {
+                pyre_object::interp_exceptions::w_exception_get_reason(obj)
+            }
+            ExceptionAttrSlot::UnicodeEncoding => {
+                pyre_object::interp_exceptions::w_exception_get_encoding(obj)
             }
         }
     };

--- a/pyre/pyre-interpreter/src/error.rs
+++ b/pyre/pyre-interpreter/src/error.rs
@@ -666,11 +666,12 @@ impl PyError {
         err
     }
 
-    /// UnboundLocalError(NameError) carrying the undefined local name.
-    pub fn unbound_local_error_with_name(msg: impl Into<String>, name: &str) -> Self {
-        let mut err = Self::new(PyErrorKind::UnboundLocalError, msg);
-        err.w_name_context = pyre_object::w_str_new(name);
-        err
+    /// UnboundLocalError(NameError) for an unbound local.  The undefined name
+    /// rides only in the message: `format_exc_check_arg` stamps the `name`
+    /// slot when the raised class is exactly `NameError`, so an
+    /// `UnboundLocalError` reaches Python with `name` still `None`.
+    pub fn unbound_local_error(msg: impl Into<String>) -> Self {
+        Self::new(PyErrorKind::UnboundLocalError, msg)
     }
 
     /// A ModuleNotFoundError carrying the unresolved module `name` so

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -1925,12 +1925,9 @@ impl LocalOpcodeHandler for PyFrame {
     fn load_local_checked_value(&mut self, idx: usize, name: &str) -> Result<Self::Value, PyError> {
         let value = self.locals_w()[idx];
         if value.is_null() {
-            return Err(PyError::unbound_local_error_with_name(
-                format!(
-                    "cannot access local variable '{name}' where it is not associated with a value"
-                ),
-                name,
-            ));
+            return Err(PyError::unbound_local_error(format!(
+                "cannot access local variable '{name}' where it is not associated with a value"
+            )));
         }
         // Cell objects are valid even if their contents are PY_NULL
         // (needed for __class__ cell during class body execution).
@@ -3329,12 +3326,9 @@ impl OpcodeStepExecutor for PyFrame {
             } else {
                 ""
             };
-            return Err(PyError::unbound_local_error_with_name(
-                format!(
-                    "cannot access local variable '{name}' where it is not associated with a value"
-                ),
-                name,
-            ));
+            return Err(PyError::unbound_local_error(format!(
+                "cannot access local variable '{name}' where it is not associated with a value"
+            )));
         }
         self.locals_w_mut()[idx] = PY_NULL;
         Ok(())

--- a/pyre/pyre-interpreter/src/pyframe.rs
+++ b/pyre/pyre-interpreter/src/pyframe.rs
@@ -1843,7 +1843,7 @@ pub fn deref_unbound_error(code: &CodeObject, idx: usize) -> crate::PyError {
     if is_free {
         crate::PyError::name_error_with_name(message, name)
     } else {
-        crate::PyError::unbound_local_error_with_name(message, name)
+        crate::PyError::unbound_local_error(message)
     }
 }
 

--- a/pyre/pyre-jit-trace/src/descr.rs
+++ b/pyre/pyre-jit-trace/src/descr.rs
@@ -2624,6 +2624,14 @@ pub fn w_exception_slot_descr(
         pyre_interpreter::baseobjspace::ExceptionAttrSlot::Filename => 13,
         pyre_interpreter::baseobjspace::ExceptionAttrSlot::Filename2 => 14,
         pyre_interpreter::baseobjspace::ExceptionAttrSlot::Code => 15,
+        pyre_interpreter::baseobjspace::ExceptionAttrSlot::Traceback => 5,
+        pyre_interpreter::baseobjspace::ExceptionAttrSlot::UnicodeObject => 6,
+        pyre_interpreter::baseobjspace::ExceptionAttrSlot::UnicodeStart => 7,
+        pyre_interpreter::baseobjspace::ExceptionAttrSlot::UnicodeEnd => 8,
+        pyre_interpreter::baseobjspace::ExceptionAttrSlot::UnicodeReason => 9,
+        pyre_interpreter::baseobjspace::ExceptionAttrSlot::UnicodeEncoding => 10,
+        pyre_interpreter::baseobjspace::ExceptionAttrSlot::Name => 16,
+        pyre_interpreter::baseobjspace::ExceptionAttrSlot::AttrObj => 17,
     };
     field_descr_from_group(cache[idx].as_ref().unwrap(), field_index)
 }

--- a/pyre/pyre-jit-trace/src/helpers.rs
+++ b/pyre/pyre-jit-trace/src/helpers.rs
@@ -630,6 +630,33 @@ pub fn emit_object_list_inline(ctx: &mut TraceCtx, items: &[OpRef]) -> OpRef {
     list
 }
 
+/// Emit inline Empty-strategy `W_ListObject` creation — the `args_w` of a
+/// zero-argument exception (`raise ValueError()`) — as a bare `NewWithVtable`
+/// wrapper plus the `strategy` store, mirroring `w_list_new(vec![])` /
+/// `w_list_new_with_strategy(vec![], Empty)`.
+///
+/// `length` (0) and `items` (null) stay zero-filled by `NewWithVtable`, as the
+/// non-Object strategies leave them.  The typed `int_items` / `float_items`
+/// blocks also stay null: the Empty strategy reads neither (its first append
+/// installs fresh typed storage via `switch_to_correct_strategy`), and
+/// `list_object_custom_trace` forwards a typed block only when the GC owns it,
+/// so a null slot is inert.  OptVirtualize folds the whole wrapper when the
+/// list never escapes.
+pub fn emit_empty_list_inline(ctx: &mut TraceCtx) -> OpRef {
+    use crate::descr::{list_strategy_descr, w_list_size_descr};
+
+    let list = ctx.record_op_with_descr(OpCode::NewWithVtable, &[], w_list_size_descr());
+    ctx.heap_cache_mut().new_object(list);
+
+    let strategy_const = ctx.const_int(pyre_object::listobject::ListStrategy::Empty as i64);
+    let strategy_descr = list_strategy_descr();
+    let strategy_idx = strategy_descr.index();
+    ctx.record_op_with_descr(OpCode::SetfieldGc, &[list, strategy_const], strategy_descr);
+    ctx.heapcache_setfield_cached(list, strategy_idx, strategy_const);
+
+    list
+}
+
 /// Trace-visible canonical `W_TupleObject` construction from boxed items.
 /// This is the allocation half of `W_BaseException.descr_getargs`: the raw
 /// `args_w` list is copied into a fresh tuple on every public attribute read.

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
@@ -1766,13 +1766,6 @@ pub(crate) fn try_walker_inline_resolved_user_call<Sym: WalkSym>(
     // reads from the unseeded frame box; inlining it would abort the
     // *whole* enclosing trace with `VableBoxNotSeeded`.
     //
-    // A zero-param callee has no positional argument to seed, so the
-    // convention holds vacuously and the strict path serves it like any other
-    // straight-line leaf.  The residual it used to fall back to is not cheap:
-    // `def f0(): return 1` called from a `while` loop measured 569 ns/iter
-    // against 1.16 ns for the same call with one parameter.  Keep the decline
-    // for a zero-param callee the strict path cannot serve, so such a body
-    // still takes the residual rather than the decline-to-interpretation below.
     // A param-bearing Python callee that is otherwise inline-eligible but
     // whose body is not a straight-line leaf (loop / branch / non-static
     // vable) cannot be served by the fast-path register seeding.  Emitting
@@ -1794,6 +1787,14 @@ pub(crate) fn try_walker_inline_resolved_user_call<Sym: WalkSym>(
         .unwrap_or(u16::MAX);
     let strict_inlinable =
         callee_fast_path_inlinable(body.code, callee_descr_refs, ctx, callee_portal_frame_reg);
+    // A zero-param callee has no positional argument to seed, so the register
+    // convention above holds vacuously and the strict path serves it like any
+    // other straight-line leaf.  The residual it would otherwise fall back to
+    // is not cheap: `def f0(): return 1` called from a `while` loop measured
+    // 569 ns/iter against 1.16 ns for the same call with one parameter.  Only a
+    // zero-param callee the strict path cannot serve declines here, so such a
+    // body still takes the residual rather than the decline-to-interpretation
+    // below.
     if nparams == 0 && !strict_inlinable {
         return Ok(None);
     }

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
@@ -1766,12 +1766,13 @@ pub(crate) fn try_walker_inline_resolved_user_call<Sym: WalkSym>(
     // reads from the unseeded frame box; inlining it would abort the
     // *whole* enclosing trace with `VableBoxNotSeeded`.
     //
-    // The zero-param case lowers to an ordinary residual call (orthodox
-    // non-inlinable path); a residual zero-arg call is cheap and has no
-    // positional-arg inline win to recover.
-    if nparams == 0 {
-        return Ok(None);
-    }
+    // A zero-param callee has no positional argument to seed, so the
+    // convention holds vacuously and the strict path serves it like any other
+    // straight-line leaf.  The residual it used to fall back to is not cheap:
+    // `def f0(): return 1` called from a `while` loop measured 569 ns/iter
+    // against 1.16 ns for the same call with one parameter.  Keep the decline
+    // for a zero-param callee the strict path cannot serve, so such a body
+    // still takes the residual rather than the decline-to-interpretation below.
     // A param-bearing Python callee that is otherwise inline-eligible but
     // whose body is not a straight-line leaf (loop / branch / non-static
     // vable) cannot be served by the fast-path register seeding.  Emitting
@@ -1793,6 +1794,9 @@ pub(crate) fn try_walker_inline_resolved_user_call<Sym: WalkSym>(
         .unwrap_or(u16::MAX);
     let strict_inlinable =
         callee_fast_path_inlinable(body.code, callee_descr_refs, ctx, callee_portal_frame_reg);
+    if nparams == 0 && !strict_inlinable {
+        return Ok(None);
+    }
 
     // A self-recursive callee routes to the direct `CALL_ASSEMBLER` arm
     // (`try_walker_call_assembler_self_recursive`, reached when this inline

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
@@ -2843,6 +2843,16 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     {
         return Ok((DispatchOutcome::Continue, op.next_pc));
     }
+    // A bare-class `raise Type` has no construct residual to fold; synthesize
+    // the zero-argument instance at the raise itself when the operand is a
+    // canonical builtin exception class.
+    if ctx.is_authoritative_executor
+        && dst_bank == 'r'
+        && ei.pyre_helper == majit_ir::PyreHelperKind::RaiseVarargs
+        && try_walker_trace_raise_bare_class(ctx, code, op, &r_args, dst)?.is_some()
+    {
+        return Ok((DispatchOutcome::Continue, op.next_pc));
+    }
     // B3 piece 3: lower the PUSH_EXC_INFO / POP_EXCEPT
     // exc-info-stack residuals to GETFIELD_GC_R / SETFIELD_GC on the EC's
     // `sys_exc_value` slot. Recognised by the

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
@@ -4815,9 +4815,10 @@ pub(crate) fn try_walker_trace_exception_new<Sym: WalkSym>(
             ArgsEmit::Int(values)
         }
         pyre_object::listobject::ListStrategy::Float => {
-            // `all_floats` is strict `type(w) is W_FloatObject`, so every
-            // element is an exact `W_FloatObject` and `walker_unbox_float`'s
-            // `&FLOAT_TYPE` guard holds.
+            // `all_floats` is strict `type(w) is W_FloatObject`, which reads
+            // `w_class`, so every element is an exact `W_FloatObject` here.
+            // The emit side pins that `w_class` as well: `walker_unbox_float`
+            // guards only the payload `ob_type`, which a subclass shares.
             let mut values = Vec::with_capacity(final_concrete_args.len());
             for &arg in final_concrete_args {
                 values.push(unsafe { pyre_object::w_float_get_value(arg) });
@@ -4922,8 +4923,21 @@ pub(crate) fn try_walker_trace_exception_new<Sym: WalkSym>(
         ArgsEmit::Empty => crate::helpers::emit_empty_list_inline(ctx.trace_ctx),
         ArgsEmit::Float(values) => {
             let float_type_addr = &pyre_object::pyobject::FLOAT_TYPE as *const _ as i64;
+            let float_typeobj = pyre_object::get_instantiate(&pyre_object::pyobject::FLOAT_TYPE);
             let mut raws = Vec::with_capacity(final_args.len());
             for (&arg, value) in final_args.iter().zip(values) {
+                // A float subclass instance carries the same payload
+                // `ob_type` and only retags `w_class`, so `walker_unbox_float`
+                // alone would let a later subclass argument stay on this trace
+                // and be unboxed into Float-strategy storage — `e.args[0]`
+                // would come back a plain float.  `FloatListStrategy.
+                // is_correct_type` rejects it, so pin the exact `w_class` and
+                // let such an argument side-exit to the residual.  A constant
+                // operand is the same object on every iteration, so its
+                // trace-time `w_class` already holds.
+                if !arg.is_constant() {
+                    walker_guard_exact_w_class(ctx, op.pc, arg, float_typeobj)?;
+                }
                 let raw = walker_unbox_float(ctx, op.pc, arg, float_type_addr)?;
                 ctx.trace_ctx
                     .set_opref_concrete(raw, majit_ir::Value::Float(value));
@@ -4940,8 +4954,15 @@ pub(crate) fn try_walker_trace_exception_new<Sym: WalkSym>(
         }
         ArgsEmit::Int(values) => {
             let int_type_addr = &pyre_object::pyobject::INT_TYPE as *const _ as i64;
+            let int_typeobj = pyre_object::get_instantiate(&pyre_object::pyobject::INT_TYPE);
             let mut raws = Vec::with_capacity(final_args.len());
             for (&arg, value) in final_args.iter().zip(values) {
+                // Same subclass hole as the Float arm: `is_plain_int1` rejects
+                // an int subclass on `w_class`, but `walker_unbox_int` guards
+                // the shared payload `ob_type`.
+                if !arg.is_constant() {
+                    walker_guard_exact_w_class(ctx, op.pc, arg, int_typeobj)?;
+                }
                 let raw = walker_unbox_int(ctx, op.pc, arg, int_type_addr)?;
                 ctx.trace_ctx
                     .set_opref_concrete(raw, majit_ir::Value::Int(value));
@@ -5260,6 +5281,17 @@ pub(crate) fn try_walker_trace_raise_bare_class<Sym: WalkSym>(
         return Ok(None);
     }
 
+    // Resolve the EC while declining is still free.  `walker_ensure_execution_
+    // context` returns `None` on a null snapshot sym or a frameless walk, and
+    // its recovery records a `GETFIELD_GC_R` that must not land after a guard
+    // referencing it — `ensure_execution_context` recovers eagerly at walk
+    // entry for that reason.  A decline past the commit below would also leave
+    // the construction ops orphaned and the heap-cache shadows describing an
+    // object the caller's generic-residual fall-through never built.
+    let Some(ec) = walker_ensure_execution_context(ctx) else {
+        return Ok(None);
+    };
+
     // --- commit: pin the class identity, emit the construction + raise ---
     // Guard the class operand so the trace-time kind / vtable stay valid
     // across iterations (`implement_guard_value`).
@@ -5298,12 +5330,9 @@ pub(crate) fn try_walker_trace_raise_bare_class<Sym: WalkSym>(
 
     // `__context__` chaining on the still-virtual exception, mirroring the
     // `try_walker_trace_raise_builtin` tail: `active = GETFIELD_GC_R(ec,
-    // sys_exc_value)` then `SETFIELD_GC(exc, active, w_context)`.  The EC is
-    // routed through `walker_ensure_execution_context` so the read shares the
-    // one seeded EC OpRef the PUSH_EXC_INFO / POP_EXCEPT lowering consumes.
-    let Some(ec) = walker_ensure_execution_context(ctx) else {
-        return Ok(None);
-    };
+    // sys_exc_value)` then `SETFIELD_GC(exc, active, w_context)`.  `ec` came
+    // from `walker_ensure_execution_context` above, so the read shares the one
+    // seeded EC OpRef the PUSH_EXC_INFO / POP_EXCEPT lowering consumes.
     let active = ctx.trace_ctx.record_op_with_descr(
         OpCode::GetfieldGcR,
         &[ec],

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
@@ -4620,11 +4620,14 @@ pub(crate) fn try_walker_trace_exception_new<Sym: WalkSym>(
     // final slice is selected below after the concrete constructor exposes the
     // value-dependent branch result.  The shared typed-list emitter reproduces
     // `w_list_new`'s Integer layout, allowing the common `SystemExit(i)` shape
-    // to virtualize alongside message-bearing Object lists.  Other strategies
-    // retain the safe residual fallback.
+    // to virtualize alongside message-bearing Object lists.  The Empty strategy
+    // (zero-argument `raise ValueError()` / `raise StopIteration()`, the most
+    // common raise shape) reproduces `w_list_new(vec![])`'s empty list.  The
+    // Float strategy retains the safe residual fallback.
     enum ArgsEmit {
         Object,
         Int(Vec<i64>),
+        Empty,
     }
 
     let is_canonical = pyre_object::interp_exceptions::is_canonical_exc_class(concrete_callable);
@@ -4802,8 +4805,8 @@ pub(crate) fn try_walker_trace_exception_new<Sym: WalkSym>(
             }
             ArgsEmit::Int(values)
         }
-        pyre_object::listobject::ListStrategy::Empty
-        | pyre_object::listobject::ListStrategy::Float => return Ok(None),
+        pyre_object::listobject::ListStrategy::Empty => ArgsEmit::Empty,
+        pyre_object::listobject::ListStrategy::Float => return Ok(None),
     };
 
     // GuardClass pins each None-sensitive `_init_error` branch.  A tagged
@@ -4898,6 +4901,7 @@ pub(crate) fn try_walker_trace_exception_new<Sym: WalkSym>(
     // alongside the exception.
     let args_list = match args_emit {
         ArgsEmit::Object => crate::helpers::emit_object_list_inline(ctx.trace_ctx, final_args),
+        ArgsEmit::Empty => crate::helpers::emit_empty_list_inline(ctx.trace_ctx),
         ArgsEmit::Int(values) => {
             let int_type_addr = &pyre_object::pyobject::INT_TYPE as *const _ as i64;
             let mut raws = Vec::with_capacity(final_args.len());

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
@@ -5154,6 +5154,178 @@ pub(crate) fn try_walker_trace_raise_builtin<Sym: WalkSym>(
     Ok(Some(()))
 }
 
+/// B3: walker-native fold for a bare-class `raise Type`
+/// (no call parentheses).  Unlike `raise Type()`, a bare class has no
+/// preceding `CallFn` construct residual — `normalize_raise_varargs_jit`
+/// instantiates the class itself — so no virtualizable `NewWithVtable`
+/// exists and `try_walker_trace_raise_builtin` declines it to the residual
+/// (a per-iteration heap alloc + may-force).
+///
+/// `do_raise` instantiates a raised class with no arguments, so a bare
+/// `raise ValueError` is `raise ValueError()`.  When the operand is a
+/// canonical builtin exception class with a trivial-args constructor and no
+/// explicit `from` cause, build the zero-argument instance inline (the
+/// `try_walker_trace_exception_new` Empty-args shape) and chain
+/// `__context__` (the `try_walker_trace_raise_builtin` tail), so the whole
+/// exception virtualizes and DCEs when it never escapes.  A subclass or a
+/// non-trivial-args kind (OSError / Unicode) declines to the residual.
+///
+/// Returns `None` (fall through to the generic residual) for any
+/// non-matching shape.
+pub(crate) fn try_walker_trace_raise_bare_class<Sym: WalkSym>(
+    ctx: &mut WalkContext<'_, '_, Sym>,
+    code: &[u8],
+    op: &DecodedOp,
+    r_args: &[OpRef],
+    dst: usize,
+) -> Result<Option<()>, DispatchError> {
+    if r_args.len() != 3 {
+        return Ok(None);
+    }
+    let class_op = r_args[1];
+    // The residual arg concretes are `[frame, exc, cause]`.  Recover the live
+    // exception operand (index 1) from the residual list rather than the opref
+    // shadow: a bare class comes straight from `LOAD_GLOBAL`, not the inline
+    // construct fold, so its shadow is not stamped.
+    let arg_concretes = read_ref_var_list_concrete(code, op, 1, ctx);
+    let Some(ConcreteValue::Ref(concrete_class)) = arg_concretes.get(1).copied() else {
+        return Ok(None);
+    };
+    // The operand must be a canonical builtin exception CLASS.  An already
+    // built instance (`raise ValueError()`) is not in the class registry and
+    // is handled by `try_walker_trace_raise_builtin`; a non-exception operand
+    // (`raise obj`) also declines here.
+    if concrete_class.is_null()
+        || !pyre_object::interp_exceptions::is_canonical_exc_class(concrete_class)
+    {
+        return Ok(None);
+    }
+
+    // Explicit `raise X from Y` keeps the residual: `attach_raise_cause` sets
+    // `__cause__` and `__suppress_context__`, which the inline `__context__`
+    // store alone does not reproduce.  The cause operand is a const `PY_NULL`
+    // (or a `Null` / `Ref(null)` shadow) when there is no cause; any concrete
+    // non-null Ref is an explicit cause.
+    let cause_op = r_args[2];
+    let cause_is_null = match arg_concretes.get(2) {
+        Some(ConcreteValue::Ref(p)) => p.is_null(),
+        Some(ConcreteValue::Null) | None => matches!(
+            ctx.trace_ctx.box_value(cause_op),
+            Some(majit_ir::Value::Ref(majit_ir::GcRef(0)))
+        ),
+        _ => false,
+    };
+    if !cause_is_null {
+        return Ok(None);
+    }
+
+    // Build the exception concretely on the plain eval loop (no tracer
+    // re-entry) to read its kind and confirm a flat builtin instance.  A
+    // canonical class has the builtin `descr_new` / `descr_init`, so a
+    // zero-argument construction runs no user code.  Trace-time only.
+    let exc = {
+        let _plain_guard = pyre_interpreter::call::force_plain_eval();
+        pyre_interpreter::call::call_function_impl_result(concrete_class, &[])
+    };
+    let Ok(exc) = exc else { return Ok(None) };
+    let kind = unsafe {
+        if !pyre_object::is_exception(exc) {
+            return Ok(None);
+        }
+        pyre_object::interp_exceptions::w_exception_get_kind(exc)
+    };
+    if pyre_object::interp_exceptions::lookup_exc_class_for_kind(kind) != concrete_class {
+        return Ok(None);
+    }
+    if !kind.has_trivial_args_constructor() {
+        return Ok(None);
+    }
+    let exc_type_ptr = unsafe {
+        (*(exc as *const pyre_object::interp_exceptions::W_BaseException))
+            .ob_header
+            .ob_type
+    };
+    if !std::ptr::eq(
+        exc_type_ptr,
+        pyre_object::interp_exceptions::exc_kind_to_pytype(kind),
+    ) {
+        return Ok(None);
+    }
+
+    // --- commit: pin the class identity, emit the construction + raise ---
+    // Guard the class operand so the trace-time kind / vtable stay valid
+    // across iterations (`implement_guard_value`).
+    if !class_op.is_constant() {
+        let expected = ctx.trace_ctx.const_ref(concrete_class as i64);
+        ctx.trace_ctx
+            .record_guard(OpCode::GuardValue, &[class_op, expected], 0);
+        walker_capture_snapshot_for_last_guard(ctx, op.pc)?;
+        ctx.trace_ctx.heap_cache_mut().replace_box(class_op, expected);
+    }
+
+    // Empty `args_w` list (zero-argument construction), stamped with the
+    // canonical list class exactly as `w_list_new` does.
+    let args_list = crate::helpers::emit_empty_list_inline(ctx.trace_ctx);
+    let list_w_class = pyre_object::get_instantiate(&pyre_object::pyobject::LIST_TYPE);
+    let list_w_class = ctx.trace_ctx.const_ref(list_w_class as i64);
+    let list_w_class_descr = crate::descr::list_w_class_descr();
+    let list_w_class_index = list_w_class_descr.index();
+    ctx.trace_ctx.record_op_with_descr(
+        OpCode::SetfieldGc,
+        &[args_list, list_w_class],
+        list_w_class_descr,
+    );
+    ctx.trace_ctx
+        .heapcache_setfield_cached(args_list, list_w_class_index, list_w_class);
+
+    let new_op =
+        crate::helpers::emit_exception_new_inline(ctx.trace_ctx, kind, class_op, args_list);
+    ctx.trace_ctx
+        .heap_cache_mut()
+        .class_now_known(new_op, exc_type_ptr as usize as i64);
+    ctx.trace_ctx
+        .set_opref_concrete(new_op, majit_ir::Value::Ref(majit_ir::GcRef(exc as usize)));
+
+    // `__context__` chaining on the still-virtual exception, mirroring the
+    // `try_walker_trace_raise_builtin` tail: `active = GETFIELD_GC_R(ec,
+    // sys_exc_value)` then `SETFIELD_GC(exc, active, w_context)`.  The EC is
+    // routed through `walker_ensure_execution_context` so the read shares the
+    // one seeded EC OpRef the PUSH_EXC_INFO / POP_EXCEPT lowering consumes.
+    let Some(ec) = walker_ensure_execution_context(ctx) else {
+        return Ok(None);
+    };
+    let active = ctx.trace_ctx.record_op_with_descr(
+        OpCode::GetfieldGcR,
+        &[ec],
+        crate::descr::ec_sys_exc_value_descr(),
+    );
+    ctx.trace_ctx.record_op_with_descr(
+        OpCode::SetfieldGc,
+        &[new_op, active],
+        crate::descr::w_exception_context_descr(kind),
+    );
+    // Apply the same context write to the concrete, freshly-built exception so
+    // Python code reached later in this authoritative walk observes the
+    // `__context__` the recorded SETFIELD performs on compiled iterations.
+    let active_concrete = pyre_interpreter::eval::get_current_exception();
+    if !active_concrete.is_null() {
+        unsafe {
+            pyre_object::interp_exceptions::w_exception_set_context(exc, active_concrete);
+        }
+    }
+
+    // Mark the inline-built instance FBW-built so the following `raise/r`
+    // records its frame node via the virtual `record_fresh_application_
+    // traceback` (an inline PyTraceback `NewWithVtable` + SETFIELDs on the
+    // exception) rather than `record_top_level_application_traceback`, whose
+    // runtime hook passes the exception to a `CallN` and forces it to
+    // materialize — defeating the save/restore DCE that virtualizes a
+    // locally-caught raise.  Mirrors `try_walker_trace_raise_builtin`.
+    fbw_built_exc_insert(new_op);
+    write_residual_call_result_to_dst(ctx, op.pc, dst, 'r', new_op)?;
+    Ok(Some(()))
+}
+
 /// B3 piece 3: lower the PUSH_EXC_INFO / POP_EXCEPT
 /// exc-info-stack residuals to GETFIELD_GC_R / SETFIELD_GC on the EC's
 /// `sys_exc_value` slot (`ec_sys_exc_value_descr`).

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
@@ -2083,10 +2083,18 @@ pub(crate) fn try_walker_specialize_store_attr<Sym: WalkSym>(
                     )
                 }
                 pyre_interpreter::baseobjspace::ExceptionAttrSlot::Context
-                | pyre_interpreter::baseobjspace::ExceptionAttrSlot::Cause => {
+                | pyre_interpreter::baseobjspace::ExceptionAttrSlot::Cause
+                | pyre_interpreter::baseobjspace::ExceptionAttrSlot::Traceback
+                | pyre_interpreter::baseobjspace::ExceptionAttrSlot::Name
+                | pyre_interpreter::baseobjspace::ExceptionAttrSlot::AttrObj
+                | pyre_interpreter::baseobjspace::ExceptionAttrSlot::UnicodeObject
+                | pyre_interpreter::baseobjspace::ExceptionAttrSlot::UnicodeStart
+                | pyre_interpreter::baseobjspace::ExceptionAttrSlot::UnicodeEnd
+                | pyre_interpreter::baseobjspace::ExceptionAttrSlot::UnicodeReason
+                | pyre_interpreter::baseobjspace::ExceptionAttrSlot::UnicodeEncoding => {
                     // `exception_attr_slot_fold` declines these for stores, so
                     // the store fold never reaches here.
-                    unreachable!("__context__/__cause__ slots fold on load only")
+                    unreachable!("load-only exception slots fold on load only")
                 }
                 pyre_interpreter::baseobjspace::ExceptionAttrSlot::Code => {
                     pyre_object::interp_exceptions::w_exception_set_code(
@@ -5260,7 +5268,9 @@ pub(crate) fn try_walker_trace_raise_bare_class<Sym: WalkSym>(
         ctx.trace_ctx
             .record_guard(OpCode::GuardValue, &[class_op, expected], 0);
         walker_capture_snapshot_for_last_guard(ctx, op.pc)?;
-        ctx.trace_ctx.heap_cache_mut().replace_box(class_op, expected);
+        ctx.trace_ctx
+            .heap_cache_mut()
+            .replace_box(class_op, expected);
     }
 
     // Empty `args_w` list (zero-argument construction), stamped with the

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
@@ -4622,11 +4622,12 @@ pub(crate) fn try_walker_trace_exception_new<Sym: WalkSym>(
     // `w_list_new`'s Integer layout, allowing the common `SystemExit(i)` shape
     // to virtualize alongside message-bearing Object lists.  The Empty strategy
     // (zero-argument `raise ValueError()` / `raise StopIteration()`, the most
-    // common raise shape) reproduces `w_list_new(vec![])`'s empty list.  The
-    // Float strategy retains the safe residual fallback.
+    // common raise shape) reproduces `w_list_new(vec![])`'s empty list, and the
+    // Float strategy reproduces its Float layout.
     enum ArgsEmit {
         Object,
         Int(Vec<i64>),
+        Float(Vec<f64>),
         Empty,
     }
 
@@ -4805,8 +4806,17 @@ pub(crate) fn try_walker_trace_exception_new<Sym: WalkSym>(
             }
             ArgsEmit::Int(values)
         }
+        pyre_object::listobject::ListStrategy::Float => {
+            // `all_floats` is strict `type(w) is W_FloatObject`, so every
+            // element is an exact `W_FloatObject` and `walker_unbox_float`'s
+            // `&FLOAT_TYPE` guard holds.
+            let mut values = Vec::with_capacity(final_concrete_args.len());
+            for &arg in final_concrete_args {
+                values.push(unsafe { pyre_object::w_float_get_value(arg) });
+            }
+            ArgsEmit::Float(values)
+        }
         pyre_object::listobject::ListStrategy::Empty => ArgsEmit::Empty,
-        pyre_object::listobject::ListStrategy::Float => return Ok(None),
     };
 
     // GuardClass pins each None-sensitive `_init_error` branch.  A tagged
@@ -4902,6 +4912,24 @@ pub(crate) fn try_walker_trace_exception_new<Sym: WalkSym>(
     let args_list = match args_emit {
         ArgsEmit::Object => crate::helpers::emit_object_list_inline(ctx.trace_ctx, final_args),
         ArgsEmit::Empty => crate::helpers::emit_empty_list_inline(ctx.trace_ctx),
+        ArgsEmit::Float(values) => {
+            let float_type_addr = &pyre_object::pyobject::FLOAT_TYPE as *const _ as i64;
+            let mut raws = Vec::with_capacity(final_args.len());
+            for (&arg, value) in final_args.iter().zip(values) {
+                let raw = walker_unbox_float(ctx, op.pc, arg, float_type_addr)?;
+                ctx.trace_ctx
+                    .set_opref_concrete(raw, majit_ir::Value::Float(value));
+                raws.push(raw);
+            }
+            crate::helpers::emit_typed_list_inline(
+                ctx.trace_ctx,
+                &raws,
+                crate::state::float_gcarray_descr(),
+                crate::descr::list_float_items_len_descr(),
+                crate::descr::list_float_items_block_descr(),
+                pyre_object::listobject::ListStrategy::Float,
+            )
+        }
         ArgsEmit::Int(values) => {
             let int_type_addr = &pyre_object::pyobject::INT_TYPE as *const _ as i64;
             let mut raws = Vec::with_capacity(final_args.len());

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -6282,10 +6282,9 @@ pub extern "C" fn bh_unbound_local_error_fn(w_code_ptr: i64, name_idx: i64) -> i
     } else {
         "<cell>"
     };
-    pyre_interpreter::PyError::unbound_local_error_with_name(
-        format!("cannot access local variable '{name}' where it is not associated with a value"),
-        name,
-    )
+    pyre_interpreter::PyError::unbound_local_error(format!(
+        "cannot access local variable '{name}' where it is not associated with a value"
+    ))
     .to_exc_object() as i64
 }
 

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -5861,9 +5861,12 @@ pub extern "C" fn bh_compare_fn(lhs: i64, rhs: i64, op_code: i64) -> i64 {
     }
 
     // op_code 8 = IS_OP `is`, 9 = `is not` (from compare_op_tag).
-    // Pointer identity, infallible — never publishes BH_LAST_EXC_VALUE.
+    // `space.is_w`, not raw pointer identity: `W_AbstractIntObject.is_w`
+    // (`intobject.py:44`) and `W_FloatObject.is_w` (`floatobject.py:196`)
+    // compare two plain `int`s / `float`s by value, so a freshly boxed equal
+    // value is identical.  Infallible — never publishes BH_LAST_EXC_VALUE.
     if op_code == 8 || op_code == 9 {
-        let same = std::ptr::eq(lhs, rhs);
+        let same = pyre_interpreter::baseobjspace::is_w(lhs, rhs);
         let result = if op_code == 9 { !same } else { same };
         return pyre_object::w_bool_from(result) as i64;
     }

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -4579,13 +4579,31 @@ fn filter_liveness_in_place(
                 break;
             }
             let super::flatten::Insn::Op {
-                opname: _,
+                opname,
                 args,
                 result,
             } = next
             else {
                 continue;
             };
+            // A `raise/r <reg>` op reads its exception operand — the residual
+            // `normalize_raise_varargs` result the tracer populated via
+            // `make_result_of_lastop`. It is a live operand read by the raise,
+            // not disposable scratch, so `get_list_of_active_boxes` keeps it in
+            // the resume `-live-`; the frame-slot retain above drops it (an
+            // operand-stack temp with no Python-local slot). Re-add its Ref
+            // register so the after-residual `GUARD_NO_EXCEPTION` /
+            // `GUARD_NOT_FORCED` and the raise's `GUARD_CLASS` all resume with
+            // the exception seeded (blackhole `bhimpl_raise` asserts non-null).
+            if opname == "raise" {
+                for arg in args {
+                    if let SsaOperand::Register(reg) = arg
+                        && reg.kind == SsaKind::Ref
+                    {
+                        union_r.insert(reg.index);
+                    }
+                }
+            }
             // A sparse opcode-start marker can also precede the residual op
             // that consumes the prior opcode's result (for example
             // LOAD_NAME(r) followed by LOAD_ATTR). Those Ref arguments are

--- a/pyre/pyre-object/src/interp_exceptions.rs
+++ b/pyre/pyre-object/src/interp_exceptions.rs
@@ -810,10 +810,15 @@ pub unsafe fn w_exception_set_context(obj: PyObjectRef, value: PyObjectRef) {
     }
 }
 
-/// `interp_exceptions.py:196-201 descr_gettraceback` parity (minus
-/// the `PyTraceback.frame.mark_as_escaped()` callback, which pyre
-/// does not have yet — see TODO on
-/// `baseobjspace::getattr_str`'s `__traceback__` arm).
+/// `interp_exceptions.py:196-201 descr_gettraceback` parity, minus the
+/// `tb.frame.mark_as_escaped()` side effect.  `PyFrame::mark_as_escaped`
+/// exists, but the flag's only consumer is `ExecutionContext::leave`, whose
+/// `frame_vref()` force stays a no-op until `jit.virtual_ref` is ported —
+/// and a frame a traceback can reach has already left, with `got_exception`
+/// set, so `leave` marked its `f_back` either way.  The mark belongs with
+/// that force, together with the `__traceback__` arm of
+/// `baseobjspace::exception_attr_slot_fold`, which folds this read to a raw
+/// slot load in traced code.
 ///
 /// # Safety
 /// `obj` must point to a valid `W_BaseException`.


### PR DESCRIPTION
Extends the FBW walker's exception virtualization and closes a pre-existing
blackhole resume-liveness crash on polymorphic `raise <expr>` loops.

## Perf: virtualize more exception raises + fold more attributes

- **Zero-argument construction** (`raise ValueError()`): the args-list
  `ListStrategy::Empty` build is emitted inline (`NewWithVtable` +
  `SetfieldGc(strategy=Empty)`), mirroring `w_list_new_with_strategy(vec![],
  Empty)`, so the constructor no longer falls to a residual heap alloc.
  ~4900ns → ~1ns.
- **Float-argument construction** (`raise ValueError(1.5)`): the Integer arm's
  mirror via `walker_unbox_float` + `emit_typed_list_inline(Float)`. Float
  subclasses stay Object-strategy (identity preserved). ~4750ns → ~1ns.
- **Bare-class raise** (`raise ValueError`): `try_walker_trace_raise_bare_class`
  synthesizes the zero-arg instance inline and marks it FBW-built so the raise
  records its traceback through the virtual `record_fresh_application_traceback`
  path (staying virtual and DCE-able) instead of the escaping runtime hook.
  ~2644ns → ~1ns.
- **Widen the exception attribute slot fold** to eight more `W_BaseException`
  attributes (`__traceback__`, `name`, `obj`, and the Unicode `object`/`start`/
  `end`/`reason`/`encoding`), load-fold only. Keeps a `__traceback__`-reading
  handler on an otherwise-virtualized exception from escaping.

## Correctness: keep the raise operand in the filtered resume liveness

Fixes a pre-existing crash: a polymorphic `raise <expr>` loop (where the
exception is a per-iteration residual-call result) panics on the type-change
deopt with `bhimpl_raise: excvalue must be non-null`.

`filter_liveness_in_place` narrows the codewriter `-live-` records to the Ref
colors that map to a Python local/stack slot, dropping operand-stack
temporaries. A `raise/r <reg>` reads its exception operand from such a
temporary — the residual `normalize_raise_varargs` result the tracer stored via
`make_result_of_lastop` — so the filter dropped it from the `-live-` preceding
the raise. On the deopt the guard (`GUARD_CLASS`, or the after-residual
`GUARD_NO_EXCEPTION` / `GUARD_NOT_FORCED`) resumed at that marker and the
blackhole seeded `registers_r` without the exception → assert.

The fix re-adds the `raise` op's Ref operand register to the retained set,
extending the existing precedent that re-adds LOAD_ATTR's tracer-populated
residual operand. It mirrors `get_list_of_active_boxes` keeping every register
read after the marker, closing the deferred `num_live`-aware
`capture_resumedata(after_residual_call=True)` gap for the raise operand.

## Verification

- `check.py`: dynasm 303/303, cranelift 303/303.
- Exception attribute reads byte-identical to pypy3 across all folded attributes.
- A 17-shape polymorphic-`raise` corpus (both backends) is crash-free and
  byte-identical to pypy3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved JIT handling of exception attributes and traceback-related fields, including more precise slot-to-field mapping.
  * Optimized canonical bare-class `raise Type` paths to reduce unnecessary residual exception work.
  * Enhanced exception construction to better support float and empty argument list strategies.
* **Bug Fixes**
  * Improved preservation of exception state during optimized raise/resume flows.
  * Improved Unicode error and attribute-error details for exception attribute access.
  * Unified unbound-local error construction across load and delete cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->