### PR TITLE
importing, _codecs: hold launcher flags and the codec registry in interpreter-global state

### DIFF
--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -49,7 +49,6 @@ thread_local! {
         import_roots: crate::importing::capture_import_root_area(),
         method_cache: crate::baseobjspace::capture_method_cache_root_area(),
         mapdict_method_cache: crate::pycode::capture_mapdict_method_cache_root_area(),
-        codec_state: crate::module::_codecs::capture_codec_state_root_area(),
     };
 }
 
@@ -59,7 +58,6 @@ struct PyFrameRootArea {
     import_roots: *const (),
     method_cache: *const (),
     mapdict_method_cache: *const (),
-    codec_state: *const (),
 }
 use crate::pyframe::PyFrame;
 
@@ -852,9 +850,9 @@ pub unsafe fn walk_pyframe_roots_area(
                     &mut forward,
                 );
                 // _codecs.CodecState is a space-cache object in PyPy; pyre
-                // keeps the same list/dict state in module-local storage, so
-                // its Python objects must be forwarded explicitly.
-                crate::module::_codecs::walk_codec_state_root_area(area.codec_state, &mut forward);
+                // keeps the same list/dict state in an interpreter-global
+                // slot, so its Python objects must be forwarded explicitly.
+                crate::module::_codecs::walk_codec_state_gc(&mut forward);
             }
         }
     }

--- a/pyre/pyre-interpreter/src/importing.rs
+++ b/pyre/pyre-interpreter/src/importing.rs
@@ -10,6 +10,7 @@
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, AtomicI64, Ordering};
 // `Path` is used only by the host_env source/package loaders; keep it gated
 // so an host_env-off build does not warn on an unused import. `PathBuf`
 // appears in the host_env-independent module-search surface
@@ -1549,15 +1550,6 @@ pub fn set_sys_argv(args: &[String]) {
 thread_local! {
     static SYS_ARGV_PENDING: std::cell::Cell<pyre_object::PyObjectRef> =
         const { std::cell::Cell::new(pyre_object::PY_NULL) };
-    static SYS_NO_SITE: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
-    static SYS_NO_USER_SITE: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
-    static SYS_IGNORE_ENVIRONMENT: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
-    static SYS_ISOLATED: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
-    static SYS_DEV_MODE: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
-    static SYS_UTF8_MODE: std::cell::Cell<i64> = const { std::cell::Cell::new(0) };
-    static SYS_SAFE_PATH: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
-    static SYS_OPTIMIZE: std::cell::Cell<i64> = const { std::cell::Cell::new(0) };
-    static SYS_DONT_WRITE_BYTECODE: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
     /// The directory prepended to `sys.path` at startup (`config->sys_path_0`):
     /// the script's directory, or the cwd for `-c` / `-m`.  Captured once by
     /// `init_sys_path`; read by the shadowing check, which must not see later
@@ -1565,16 +1557,31 @@ thread_local! {
     static SYS_PATH_0: RefCell<Option<String>> = const { RefCell::new(None) };
 }
 
+// The launcher flags belong to the interpreter, not to whichever thread
+// happened to parse the command line: `space.sys.get_flag(...)` reads them
+// off the one `space`.  Keeping them process-global means a reader on any
+// thread — a codec lookup, `sys.flags`, an embedder calling in — observes
+// the values the launcher recorded instead of the per-thread default.
+static SYS_NO_SITE: AtomicBool = AtomicBool::new(false);
+static SYS_NO_USER_SITE: AtomicBool = AtomicBool::new(false);
+static SYS_IGNORE_ENVIRONMENT: AtomicBool = AtomicBool::new(false);
+static SYS_ISOLATED: AtomicBool = AtomicBool::new(false);
+static SYS_DEV_MODE: AtomicBool = AtomicBool::new(false);
+static SYS_UTF8_MODE: AtomicI64 = AtomicI64::new(0);
+static SYS_SAFE_PATH: AtomicBool = AtomicBool::new(false);
+static SYS_OPTIMIZE: AtomicI64 = AtomicI64::new(0);
+static SYS_DONT_WRITE_BYTECODE: AtomicBool = AtomicBool::new(false);
+
 /// Record whether the launcher was given `-S` (no `site` import), so the
 /// `sys.flags.no_site` field built during sys module init reflects it. Set
 /// before the first `import sys`.
 pub fn set_no_site(no_site: bool) {
-    SYS_NO_SITE.with(|p| p.set(no_site));
+    SYS_NO_SITE.store(no_site, Ordering::Relaxed);
 }
 
 /// Read the `-S` flag for `sys.flags.no_site`.
 pub fn no_site_flag() -> bool {
-    SYS_NO_SITE.with(|p| p.get())
+    SYS_NO_SITE.load(Ordering::Relaxed)
 }
 
 /// Record the command-line flags consumed by `app_main.py` before `sys` is
@@ -1591,38 +1598,38 @@ pub fn set_runtime_flags(
     optimize: i64,
     dont_write_bytecode: bool,
 ) {
-    SYS_NO_USER_SITE.with(|p| p.set(no_user_site));
-    SYS_IGNORE_ENVIRONMENT.with(|p| p.set(ignore_environment));
-    SYS_ISOLATED.with(|p| p.set(isolated));
-    SYS_DEV_MODE.with(|p| p.set(dev_mode));
-    SYS_UTF8_MODE.with(|p| p.set(utf8_mode));
-    SYS_SAFE_PATH.with(|p| p.set(safe_path));
-    SYS_OPTIMIZE.with(|p| p.set(optimize));
-    SYS_DONT_WRITE_BYTECODE.with(|p| p.set(dont_write_bytecode));
+    SYS_NO_USER_SITE.store(no_user_site, Ordering::Relaxed);
+    SYS_IGNORE_ENVIRONMENT.store(ignore_environment, Ordering::Relaxed);
+    SYS_ISOLATED.store(isolated, Ordering::Relaxed);
+    SYS_DEV_MODE.store(dev_mode, Ordering::Relaxed);
+    SYS_UTF8_MODE.store(utf8_mode, Ordering::Relaxed);
+    SYS_SAFE_PATH.store(safe_path, Ordering::Relaxed);
+    SYS_OPTIMIZE.store(optimize, Ordering::Relaxed);
+    SYS_DONT_WRITE_BYTECODE.store(dont_write_bytecode, Ordering::Relaxed);
 }
 
 pub fn no_user_site_flag() -> bool {
-    SYS_NO_USER_SITE.with(|p| p.get())
+    SYS_NO_USER_SITE.load(Ordering::Relaxed)
 }
 
 pub fn ignore_environment_flag() -> bool {
-    SYS_IGNORE_ENVIRONMENT.with(|p| p.get())
+    SYS_IGNORE_ENVIRONMENT.load(Ordering::Relaxed)
 }
 
 pub fn isolated_flag() -> bool {
-    SYS_ISOLATED.with(|p| p.get())
+    SYS_ISOLATED.load(Ordering::Relaxed)
 }
 
 pub fn dev_mode_flag() -> bool {
-    SYS_DEV_MODE.with(|p| p.get())
+    SYS_DEV_MODE.load(Ordering::Relaxed)
 }
 
 pub fn utf8_mode_flag() -> i64 {
-    SYS_UTF8_MODE.with(|p| p.get())
+    SYS_UTF8_MODE.load(Ordering::Relaxed)
 }
 
 pub fn safe_path_flag() -> bool {
-    SYS_SAFE_PATH.with(|p| p.get())
+    SYS_SAFE_PATH.load(Ordering::Relaxed)
 }
 
 /// `-O` / `-OO` / PYTHONOPTIMIZE level for the default compile `optimize`
@@ -1630,20 +1637,22 @@ pub fn safe_path_flag() -> bool {
 /// docstrings), clamped into the compiler's byte-wide field.  Levels above 2
 /// behave as 2.
 pub fn optimize_flag() -> u8 {
-    SYS_OPTIMIZE.with(|p| p.get()).clamp(0, i64::from(u8::MAX)) as u8
+    SYS_OPTIMIZE
+        .load(Ordering::Relaxed)
+        .clamp(0, i64::from(u8::MAX)) as u8
 }
 
 /// The raw optimization level for `sys.flags.optimize`, mirroring a large
 /// `PYTHONOPTIMIZE` value verbatim; `optimize_flag` clamps this for the
 /// compiler.
 pub fn optimize_level() -> i64 {
-    SYS_OPTIMIZE.with(|p| p.get())
+    SYS_OPTIMIZE.load(Ordering::Relaxed)
 }
 
 /// `-B` / PYTHONDONTWRITEBYTECODE, driving `sys.flags.dont_write_bytecode` and
 /// `sys.dont_write_bytecode`.
 pub fn dont_write_bytecode_flag() -> bool {
-    SYS_DONT_WRITE_BYTECODE.with(|p| p.get())
+    SYS_DONT_WRITE_BYTECODE.load(Ordering::Relaxed)
 }
 
 /// Called from sys module init to pick up any pending argv.

--- a/pyre/pyre-interpreter/src/module/_codecs/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_codecs/mod.rs
@@ -5,7 +5,7 @@
 //! text path. The codec registry (`register` / `lookup`) and error
 //! handlers remain stubs; binary transform codecs are not modelled.
 
-use std::cell::Cell;
+use std::sync::atomic::{AtomicPtr, Ordering};
 
 use pyre_object::*;
 use rustpython_wtf8::{CodePoint, Wtf8Buf};
@@ -30,54 +30,50 @@ impl CodecState {
     }
 }
 
-thread_local! {
-    static CODEC_STATE: Cell<*mut CodecState> = const { Cell::new(std::ptr::null_mut()) };
-}
+/// The registry is `space.fromcache(CodecState)` upstream — one instance per
+/// interpreter, not per thread — so `codecs.register` / `register_error` and
+/// the search cache stay visible to every reader.  Published once and never
+/// replaced, which is what lets the collector read the slot without
+/// coordinating with a mutator that is inside `with_codec_state`.
+static CODEC_STATE: AtomicPtr<CodecState> = AtomicPtr::new(std::ptr::null_mut());
 
 fn with_codec_state<R>(f: impl FnOnce(&mut CodecState) -> R) -> R {
-    CODEC_STATE.with(|slot| {
-        let mut ptr = slot.get();
-        if ptr.is_null() {
-            ptr = Box::into_raw(Box::new(CodecState::new()));
-            slot.set(ptr);
-        }
-        f(unsafe { &mut *ptr })
-    })
+    let mut ptr = CODEC_STATE.load(Ordering::Acquire);
+    if ptr.is_null() {
+        // `CodecState::new` allocates the registry objects and registers the
+        // builtin error handlers, so build it before publishing the slot.
+        let created = Box::into_raw(Box::new(CodecState::new()));
+        ptr = match CODEC_STATE.compare_exchange(
+            std::ptr::null_mut(),
+            created,
+            Ordering::AcqRel,
+            Ordering::Acquire,
+        ) {
+            Ok(_) => created,
+            Err(existing) => {
+                drop(unsafe { Box::from_raw(created) });
+                existing
+            }
+        };
+    }
+    f(unsafe { &mut *ptr })
 }
 
-pub(crate) unsafe fn walk_codec_state_gc(visitor: &mut dyn FnMut(&mut PyObjectRef)) {
-    CODEC_STATE.with(|slot| {
-        let ptr = slot.get();
-        if ptr.is_null() {
-            return;
-        }
-        let state = unsafe { &mut *ptr };
-        visitor(&mut state.codec_search_path);
-        visitor(&mut state.codec_search_cache);
-        visitor(&mut state.codec_error_registry);
-    });
-}
-
-pub(crate) fn capture_codec_state_root_area() -> *const () {
-    CODEC_STATE.with(|state| state as *const _ as *const ())
-}
-
-/// # Safety
-/// `data` must come from [`capture_codec_state_root_area`], and the owning
-/// thread must be quiesced.
-pub(crate) unsafe fn walk_codec_state_root_area(
-    data: *const (),
-    visitor: &mut dyn FnMut(&mut PyObjectRef),
-) {
-    let state = unsafe { &*(data as *const Cell<*mut CodecState>) };
-    let ptr = state.get();
+/// Forward the registry's Python objects.  Upstream reaches the same list and
+/// dicts through the space's object graph; pyre holds them off-heap, so the
+/// collector has to be handed them.
+pub(crate) fn walk_codec_state_gc(visitor: &mut dyn FnMut(&mut PyObjectRef)) {
+    let ptr = CODEC_STATE.load(Ordering::Acquire);
     if ptr.is_null() {
         return;
     }
-    let state = unsafe { &mut *ptr };
-    visitor(&mut state.codec_search_path);
-    visitor(&mut state.codec_search_cache);
-    visitor(&mut state.codec_error_registry);
+    // A collection can run while the mutator is inside `with_codec_state`, so
+    // reach the slots through raw pointers instead of a second `&mut`.
+    unsafe {
+        visitor(&mut *std::ptr::addr_of_mut!((*ptr).codec_search_path));
+        visitor(&mut *std::ptr::addr_of_mut!((*ptr).codec_search_cache));
+        visitor(&mut *std::ptr::addr_of_mut!((*ptr).codec_error_registry));
+    }
 }
 
 // PyPy `interp_codecs.py:166-190 normalize`.


### PR DESCRIPTION
Follow-up to the #766 review thread arguing that `TextIOWrapper`'s dev-mode error-handler validation should not depend on thread-local state. Both halves of that complaint are addressed here.

## `importing`: launcher config flags

The nine scalar flags the launcher records were parked in `thread_local!` cells but written once from the interpreter thread, so a reader on any other thread saw the per-thread default instead of the recorded value — `dev_mode` in particular gates the codec error-handler validation `TextIOWrapper.__init__` / `reconfigure` run.

Moved `no_site`, `no_user_site`, `ignore_environment`, `isolated`, `dev_mode`, `utf8_mode`, `safe_path`, `optimize` and `dont_write_bytecode` to `AtomicBool` / `AtomicI64`.

Left alone deliberately: `SYS_ARGV_PENDING` holds a GC-managed object registered with the per-thread root area, and `SYS_PATH_0` stores a `String`.

## `_codecs`: the codec registry

`CodecState` is `space.fromcache(CodecState)` upstream — one instance per interpreter — but pyre kept it thread-local, so the search path, search cache and error registry were per-thread: a `codecs.register_error()` on one thread was invisible to a lookup on another.

It is now published once through an `AtomicPtr`. Since the slot is written once and never replaced, the collector can read it without coordinating with a mutator inside `with_codec_state`, so the per-thread root-area plumbing (`capture_codec_state_root_area` / `walk_codec_state_root_area` and the `PyFrameRootArea` field) drops out in favour of walking the global slot directly, alongside the other process-global off-GC root slots (`reduce_protocol::walk_handle_roots`, `async_operation::walk_handle_roots`).

## Why interpreter-global is the orthodox home

- PyPy keeps every one of these flags in the space-global `sys` module dict (`pypy/module/sys/app.py:156-176`), rebound by the launcher at app level (`pypy/interpreter/app_main.py:802-803`) and read through `space.sys.get_flag()` (`pypy/module/sys/moduledef.py:233-235`). `space.sys` is a plain instance field (`pypy/interpreter/baseobjspace.py:642-643`), one per translated binary.
- PyPy's only per-thread storage is the `ExecutionContext` (`pypy/module/thread/threadlocals.py:53-54`); no launcher or config scalar is thread-local anywhere in `pypy/` or `rpython/`. cpyext even mirrors these to process-global C ints (`pypy/module/cpyext/api.py:682-698`).
- CPython keeps them in `PyInterpreterState.config` — per-interpreter, never per-thread.
- The codebase already keeps comparable configuration in process-global atomics: `GC_ENABLED`, `FAULTHANDLER_ENABLED`, `FROZEN_OVERRIDE`, `FIELD_LIMIT`, `DEFAULT_SOCKET_TIMEOUT`.

## Not changed (verified, not assumed)

`dev_mode_flag()` still reads pyre's own storage rather than doing a live `sys.flags` lookup. Rebinding `sys.flags` from Python and re-running the validation discriminates the two: PyPy follows the live object (its `get_flag` is a dict lookup), CPython 3.14 follows the startup snapshot because it reads `PyConfig`. pyre matches CPython here, so this is a PyPy/CPython divergence rather than a defect, and a live lookup would also put a dict+attribute lookup on every check.

## Verification

- `check.py --synthetic-only` 294/294 on dynasm.
- Codec registry GC stress (custom search function + custom error handler + `TextIOWrapper` carrying that handler, across 12 rounds of heap churn and `gc.collect()`): identical output on pyre, PyPy and CPython.
- `-X dev` behaviour unchanged; full CLI flag matrix (`-O`, `-OO`, `-B`, `-S`, `-I`, `-E`, `-P`, `-X utf8`) verified against CPython.

🤖 Generated with [Claude Code](https://claude.com/claude-code)