### PR TITLE
wasm: stamp w_class on NEW_WITH_VTABLE; drop the wasm-only LIST_APPEND residual decline

### DIFF
--- a/majit/majit-backend-wasm/src/codegen.rs
+++ b/majit/majit-backend-wasm/src/codegen.rs
@@ -3659,6 +3659,20 @@ fn build_function(
                     || missing_layout_descr("size descr", op),
                     |sd| (sd.size() as i64, sd.type_id() as i64, sd.vtable()),
                 );
+                // `(w_class_offset, w_class)` — the `PyObject.w_class` field
+                // and the class pointer instances of this type carry
+                // (`get_instantiate(vtable_type)`). `fuse_boxing_alloc` drops
+                // the boxing ctor's `ob_header` stores expecting the runtime to
+                // stamp both `ob_type` and `w_class` from the size descr; the
+                // vtable write above covers `ob_type`, this covers `w_class`.
+                let w_class_init = sd.and_then(|sd| {
+                    sd.w_class_obj().and_then(|w_class| {
+                        sd.gc_fielddescrs()
+                            .iter()
+                            .find(|fd| fd.is_w_class())
+                            .map(|fd| (fd.offset() as u64, w_class))
+                    })
+                });
 
                 // Inline nursery bump (rewrite.py malloc fast path, x86
                 // `malloc_cond`): total = align8(max(header+size, MIN)); if
@@ -3811,6 +3825,28 @@ fn build_function(
                             align: 2,
                             memory_index: 0,
                         });
+                    }
+                    // Stamp `w_class = get_instantiate(vtable_type)` so the
+                    // materialized builtin box carries the class pointer
+                    // OptVirtualize folded its `w_class` header reads to. Mirrors
+                    // dynasm `genop_new_with_vtable` (aarch64/assembler.rs).
+                    // Pointer-width (4 bytes on wasm32): store the low 32 bits.
+                    // Without it the nursery-zeroed `w_class` stays 0 and the
+                    // promoted-`w_class` GuardValue fails every iteration on any
+                    // escaping-builtin loop (e.g. `while: lst.append(i)`).
+                    if op.opcode == OpCode::NewWithVtable {
+                        if let Some((w_class_offset, w_class)) = w_class_init {
+                            if w_class != 0 {
+                                sink.local_get(1 + vi);
+                                sink.i32_wrap_i64();
+                                sink.i32_const(w_class as i32);
+                                sink.i32_store(MemArg {
+                                    offset: w_class_offset,
+                                    align: 2,
+                                    memory_index: 0,
+                                });
+                            }
+                        }
                     }
                 }
                 // The collecting allocation may have moved every other live

--- a/pyre/.gitignore
+++ b/pyre/.gitignore
@@ -5,3 +5,11 @@ Cargo.lock
 # The committed benchmark baselines live at pyre/bench/*.jitstats.
 /check.snap/
 /bench/synth/*.jitstats
+# Exceptions: synthetic benches whose structural counters are a committed gate.
+# check.py's regression floor reads loops_aborted/internal_compile_panics from
+# these on every run, which is the only gate wasm has — run_synthetic_bench
+# passes vs_pypy=None for wasm, so no perf ratio can catch a wasm-only trace
+# abort storm there.
+!/bench/synth/comprehension_object_append_hot.*.jitstats
+!/bench/synth/const_arg_call_resume.*.jitstats
+!/bench/synth/nested_list_comprehension_hot.*.jitstats

--- a/pyre/bench/synth/comprehension_object_append_hot.cranelift.jitstats
+++ b/pyre/bench/synth/comprehension_object_append_hot.cranelift.jitstats
@@ -1,0 +1,5 @@
+bridges_compiled=18
+guard_failures=3700
+internal_compile_panics=0
+loops_aborted=2
+loops_compiled=7

--- a/pyre/bench/synth/comprehension_object_append_hot.dynasm.jitstats
+++ b/pyre/bench/synth/comprehension_object_append_hot.dynasm.jitstats
@@ -1,0 +1,5 @@
+bridges_compiled=18
+guard_failures=3700
+internal_compile_panics=0
+loops_aborted=2
+loops_compiled=7

--- a/pyre/bench/synth/comprehension_object_append_hot.wasm.jitstats
+++ b/pyre/bench/synth/comprehension_object_append_hot.wasm.jitstats
@@ -1,0 +1,2 @@
+internal_compile_panics=0
+loops_aborted=2

--- a/pyre/bench/synth/const_arg_call_resume.cranelift.jitstats
+++ b/pyre/bench/synth/const_arg_call_resume.cranelift.jitstats
@@ -1,0 +1,5 @@
+bridges_compiled=9
+guard_failures=1846
+internal_compile_panics=0
+loops_aborted=1
+loops_compiled=5

--- a/pyre/bench/synth/const_arg_call_resume.dynasm.jitstats
+++ b/pyre/bench/synth/const_arg_call_resume.dynasm.jitstats
@@ -1,0 +1,5 @@
+bridges_compiled=9
+guard_failures=1846
+internal_compile_panics=0
+loops_aborted=1
+loops_compiled=5

--- a/pyre/bench/synth/const_arg_call_resume.wasm.jitstats
+++ b/pyre/bench/synth/const_arg_call_resume.wasm.jitstats
@@ -1,0 +1,2 @@
+internal_compile_panics=0
+loops_aborted=1

--- a/pyre/bench/synth/exc_info_module_loop_hot.py
+++ b/pyre/bench/synth/exc_info_module_loop_hot.py
@@ -1,0 +1,26 @@
+# Module-scope `for i in range(N)` whose body raises, catches, and reads
+# sys.exc_info() both inside and after the handler.  At module scope the loop
+# variable `i` is a STORE_NAME (a global-dict residual), not a STORE_FAST frame
+# local.  When an escaping residual in the handler body aborts the recording
+# walk, the in-flight FOR_ITER item must still be re-delivered so the iteration
+# runs exactly once: the loop-variable store re-binds the SAME re-delivered
+# item, so it is not an accumulating body effect and must not refuse-drop the
+# iteration.  A drop loses that iteration's `exc_info_inside` / `exc_info_after`
+# increments (both would read N-k instead of N).
+
+import sys
+
+N = 3000
+
+exc_info_inside = 0
+exc_info_after_none = 0
+for i in range(N):
+    try:
+        raise ValueError(i)
+    except ValueError:
+        info = sys.exc_info()
+        exc_info_inside += info[0] is ValueError and info[1].args == (i,) and info[2] is not None
+    exc_info_after_none += sys.exc_info() == (None, None, None)
+
+print("exc_info_inside", exc_info_inside)
+print("exc_info_after_none", exc_info_after_none)

--- a/pyre/bench/synth/nested_list_comprehension_hot.cranelift.jitstats
+++ b/pyre/bench/synth/nested_list_comprehension_hot.cranelift.jitstats
@@ -1,0 +1,5 @@
+bridges_compiled=6
+guard_failures=1228
+internal_compile_panics=0
+loops_aborted=2
+loops_compiled=3

--- a/pyre/bench/synth/nested_list_comprehension_hot.dynasm.jitstats
+++ b/pyre/bench/synth/nested_list_comprehension_hot.dynasm.jitstats
@@ -1,0 +1,5 @@
+bridges_compiled=6
+guard_failures=1228
+internal_compile_panics=0
+loops_aborted=2
+loops_compiled=3

--- a/pyre/bench/synth/nested_list_comprehension_hot.wasm.jitstats
+++ b/pyre/bench/synth/nested_list_comprehension_hot.wasm.jitstats
@@ -1,0 +1,2 @@
+internal_compile_panics=0
+loops_aborted=2

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/fbw_state.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/fbw_state.rs
@@ -682,6 +682,18 @@ pub(crate) fn fbw_foriter_body_effect_since_consume() -> bool {
         .unwrap_or(false)
 }
 
+/// Resolved `body_pc` of the most-recent (top) in-flight FOR_ITER entry — the
+/// FOR_ITER continue-arm fallthrough, i.e. the pc of the loop-variable store
+/// that binds the just-consumed item.  `None` when no item is in flight or its
+/// coordinate is an unresolvable native pc.
+pub(crate) fn fbw_foriter_inflight_top_body_pc() -> Option<usize> {
+    FBW_FORITER_INFLIGHT.with(|c| {
+        c.borrow()
+            .last()
+            .and_then(|e| inflight_foriter_body_pc(e.body))
+    })
+}
+
 /// Whether ANY of the three R1 body-effect signals is currently present:
 /// the body-effect-since-consume flag, either journal non-empty, or the
 /// unjournaled-effect flag.  These are the exact signals

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
@@ -1502,8 +1502,29 @@ pub(crate) fn try_execute_residual_call_via_executor<Sym: WalkSym>(
     } else {
         None
     };
+    // The loop-variable binding store is the op at the in-flight FOR_ITER's
+    // `body_pc` (the FOR_ITER continue-arm fallthrough), a STORE_NAME/
+    // STORE_GLOBAL that writes the just-consumed item to the loop target (a
+    // module/global-scope `for i in …`; a function-scope loop var is a
+    // STORE_FAST frame local that never becomes a residual).  Re-delivery
+    // re-runs the body from `body_pc`, re-storing the SAME re-delivered item to
+    // the SAME name — an idempotent write, never an accumulating double.  Like
+    // the `is_idempotent_gc_barrier` write barrier it still EXECUTES concretely
+    // (the module dict must hold the binding for the walk's remaining reads) but
+    // it is not a body effect: keep it out of the R1 in-flight-FOR_ITER
+    // accounting so an escaping residual later in the same body does not
+    // refuse-drop the whole iteration.
+    // `vstack_cur_pypc` points one past the executing op (next-instr
+    // convention), while `body_pc` is the store's own py_pc, so the loop-var
+    // store satisfies `vstack_cur_pypc == body_pc + 1`.
+    let is_loop_var_binding_store = matches!(
+        helper,
+        majit_ir::PyreHelperKind::StoreName | majit_ir::PyreHelperKind::StoreGlobal
+    ) && fbw_foriter_inflight_top_body_pc()
+        .is_some_and(|body_pc| body_pc + 1 == ctx.vstack_cur_pypc as usize);
     let body_effect_candidate = !provably_side_effect_free
         && !is_idempotent_gc_barrier
+        && !is_loop_var_binding_store
         && writes_live_heap
         && fbw_foriter_inflight_active();
     // #57 Option C (Finding #1, user-frame signal): the Void/helper-tag write

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
@@ -2686,15 +2686,6 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
         if try_walker_orthodox_list_append_opcode(ctx, code, op, &r_args, dst)?.is_some() {
             return Ok((DispatchOutcome::Continue, op.next_pc));
         }
-        // The wasm backend miscompiles the resulting resize/append bridge
-        // (#389b-class element drop, wasm-only — `comprehension_object_append_hot`
-        // / `nested_list_comprehension_hot` return short), the same wasm-append
-        // codegen hazard `wasm_unboxed_append_fold_declined` guards the unboxed
-        // fold against. Keep the safeguard abort on wasm so the loop falls back
-        // to correct interpretation; only native backends take the fall-through.
-        if cfg!(target_arch = "wasm32") {
-            return Err(DispatchError::UnfoldableListAppendResidualUnsupported { pc: op.pc });
-        }
     }
 
     // `len(x)` on an exact canonical list: inline the strategy-guarded


### PR DESCRIPTION
Four commits on top of `main`, all found by chasing the largest wasm-vs-dynasm
runtime gaps in `pyre/check.py --synthetic-only`.

## `wasm: stamp w_class on NEW_WITH_VTABLE`

`fuse_boxing_alloc` lowers `malloc_typed(W_IntObject { .. })` to
`NewWithVtable` + a payload store, dropping the boxing ctor's `ob_header`
subtree on the contract that the backend stamps **both** `ob_type` (the vtable)
and `w_class` (`get_instantiate(vtable_type)`) from the size descr. dynasm's
`genop_new_with_vtable` does this; the wasm backend wrote only the vtable.

wasm also zero-fills the nursery on reset, so the missing store left
`w_class == 0`, and the promoted `GuardValue(w_class, int_typeobj)` that
`OptVirtualize` folds those header reads to failed on **every** iteration of any
loop that escapes a freshly boxed builtin.

`synth/list_reverse` on wasm: `executes=233267`, `decl_shortcircuit=233065` →
`executes=13`, `decl_shortcircuit=0`; 52.8x → 4.7x vs CPython.

cranelift's `NewWithVtable` has the same omission. It is latent there only
because that nursery is not zeroed on reset, so recycled memory usually still
holds a plausible `w_class`; not fixed here.

## `jit: drop the wasm-only LIST_APPEND residual-fallthrough safeguard`

The top three wasm-vs-dynasm gaps were all one arm in
`jitcode_dispatch/residual_call.rs`. #749 let a declined `LIST_APPEND` fold fall
through to the generic `jit_list_append` residual, but kept
`if cfg!(target_arch = "wasm32") { return Err(UnfoldableListAppendResidualUnsupported) }`
because wasm miscompiled the resulting resize/append bridge. That aborted the
bridge on every guard failure, forever: `FIRED=4984`, `sbt_entered=4984`,
`cb_entered=0`, `bridge_diag entered=0` — nothing ever compiled.

Removing it (9 deleted lines, no replacement — the backend split disappears):

| bench | before | after | wasm/dynasm |
|---|---|---|---|
| `synth/nested_list_comprehension_hot` | 19.70s | 1.42s | 59.8x → 2.4x |
| `synth/comprehension_object_append_hot` | 7.78s | 0.36s | 34.0x → 2.3x |
| `synth/const_arg_call_resume` | 3.16s | 0.29s | 21.1x → 1.9x |

⚠️ The element drop that safeguard guarded against is the wasm offset-0
silent-null class: wasm32 linear-memory offset 0 is valid memory, so a null
`Ref` is a layout-dependent wrong answer rather than a trap, and it does not
reproduce on macOS aarch64 in principle. An ablation (safeguard off **and** the
`w_class` stamp above reverted) still passed locally, so the `w_class` fix is
not proven to be what cured it — #737's bridge-iter journal root is the likelier
fixer. **Linux CI is the real gate for this commit.** If it reddens, hunt the
null `Ref` in the append-residual bridge rather than restoring the arm.

## `bench: commit jit-stats baselines for the three append-residual synth benches`

Nothing caught the above: `run_synthetic_bench` passes `vs_pypy=None` for wasm,
so the `max-pypy-ratio` header is not read there and the per-bench timeout alone
let the pre-fix 8.58s run pass. `check.py`'s `loops_aborted` /
`internal_compile_panics` regression floor would have caught it, but
`pyre/.gitignore` treated every `bench/synth/*.jitstats` as local scratch.

Records and commits the baselines for these three benches (`loops_aborted` =
2 / 2 / 1, byte-identical on dynasm and cranelift; the residual aborts are
`LoopBearingCalleeInlineUnsupported { pc: 116 }` on the module-level trace) with
matching `!` exceptions in `pyre/.gitignore`. Verified by writing
`loops_aborted=0` into the wasm baseline: `SNAPDIFF jit-stats regression:
loops_aborted 0 -> 2`.

## `jit: exempt the FOR_ITER loop-variable store from the in-flight body-effect guard`

Pre-existing commit carried on this branch; a module-level loop-variable
`STORE_NAME` was classified as a body effect and aborted the trace with
`VableEscaped`.

## Verification

`pyre/check.py` locally (macOS aarch64): dynasm 309/309, cranelift 309/309,
wasm 306/306.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved WebAssembly object creation so runtime type information is initialized correctly.
  - Fixed loop tracing behavior to preserve accurate loop-variable handling and exception state observation.
  - Improved WebAssembly list-append tracing behavior, reducing unnecessary tracing aborts.

- **Tests**
  - Added a benchmark covering `sys.exc_info()` behavior inside and after repeated exception handlers.
  - Added and updated JIT benchmark statistics for WebAssembly and native execution paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->