### PR TITLE
jit: fold the LOAD_ATTR bound-builtin-method getattr into a traced Method

### DIFF
--- a/pyre/bench/synth/bound_method_builtin_fold.py
+++ b/pyre/bench/synth/bound_method_builtin_fold.py
@@ -8,8 +8,9 @@
 # that fold depends on: a __slots__ subclass whose method is replaced mid-loop
 # (version tag), an instance-dict entry shadowing the method name (the fold
 # must decline for a dict-bearing receiver), alternating receiver types at one
-# call site (class guard), and a bound method that outlives its CALL (the
-# virtual must materialize). Output verified against CPython/PyPy.
+# call site (class guard), `__`-names that bind through the same shape, and a
+# bound method that outlives its CALL (the virtual must materialize). Output
+# verified against CPython/PyPy.
 N = 20000
 
 
@@ -67,6 +68,17 @@ def polymorphic(n):
     return len(a), len(b)
 
 
+def dunder_names(n):
+    # `__`-names bind through the same `function` + builtin-code shape as
+    # `append`, so the fold applies to them too.
+    lst = [0] * 8
+    total = 0
+    for i in range(n):
+        total += lst.__len__() + (i,).__len__()
+        lst.__setitem__(i & 7, i)
+    return total, lst[3]
+
+
 def escaping_bound_method(n):
     r = []
     keep = []
@@ -83,4 +95,5 @@ print(dict_and_set(N))
 print(slots_subclass_override(N))
 print(shadowed(N))
 print(polymorphic(N))
+print(dunder_names(N))
 print(escaping_bound_method(N))

--- a/pyre/bench/synth/bound_method_builtin_fold.py
+++ b/pyre/bench/synth/bound_method_builtin_fold.py
@@ -1,0 +1,86 @@
+# `lst.append(x)` on a builtin receiver: the name resolves to a builtin-code
+# function on the type, so LOAD_ATTR's method fast path declines (it only
+# pushes `[descr, self]` for `flag_method_descriptor` types) and `getattr`
+# materialises a bound method. The tracer folds that construction to
+# guard_class + guard_value(w_class) + guard_value(version_tag) +
+# new_with_vtable(Method) so it virtualizes into the following CALL, instead of
+# leaving an opaque getattr residual in the loop. These cases pin the guards
+# that fold depends on: a __slots__ subclass whose method is replaced mid-loop
+# (version tag), an instance-dict entry shadowing the method name (the fold
+# must decline for a dict-bearing receiver), alternating receiver types at one
+# call site (class guard), and a bound method that outlives its CALL (the
+# virtual must materialize). Output verified against CPython/PyPy.
+N = 20000
+
+
+def build(n):
+    r = []
+    for i in range(n):
+        r.append(i)
+    return r
+
+
+def dict_and_set(n):
+    d = {}
+    s = set()
+    for i in range(n):
+        d.setdefault(i & 7, i)
+        s.add(i & 15)
+    return len(d), len(s)
+
+
+class L(list):
+    __slots__ = ()
+
+
+def slots_subclass_override(n):
+    lst = L()
+    seen = []
+    for i in range(n):
+        lst.append(i)
+        if i == n // 2:
+            L.append = lambda self, v, _old=list.append: _old(self, v * 100)
+            seen.append("patched")
+    total = sum(lst)
+    del L.append
+    return total, seen
+
+
+class Shadow(list):
+    pass
+
+
+def shadowed(n):
+    obj = Shadow()
+    calls = []
+    obj.append = calls.append
+    for i in range(n):
+        obj.append(i)
+    return len(obj), len(calls)
+
+
+def polymorphic(n):
+    a, b = [], bytearray()
+    for i in range(n):
+        target = a if (i & 1) else b
+        target.append(i & 127)
+    return len(a), len(b)
+
+
+def escaping_bound_method(n):
+    r = []
+    keep = []
+    for i in range(n):
+        m = r.append
+        keep.append(m)
+        m(i)
+    keep[0](-1)
+    return len(r), r[-1], len(keep)
+
+
+print(len(build(N)), sum(build(N // 8)))
+print(dict_and_set(N))
+print(slots_subclass_override(N))
+print(shadowed(N))
+print(polymorphic(N))
+print(escaping_bound_method(N))

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -7900,7 +7900,11 @@ pub unsafe fn bound_method_attr_fast_path(
     }
     // No instance dict => the type lookup cannot be shadowed, so the
     // non-data-descriptor branch of `object.__getattribute__` is the only
-    // reachable one.
+    // reachable one.  This is stricter than `callmethod.py:60-64`, which
+    // admits a dict-bearing receiver and merely checks that `name` is absent
+    // from it: the emitted fold carries no dict-shape guard, so a later store
+    // of `name` into the dict would not side-exit.  Admitting those receivers
+    // means emitting that guard first.
     if !getdict_backing(w_obj).is_null() {
         return None;
     }

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -7848,6 +7848,79 @@ pub unsafe fn load_method_fast_path(
     Some((w_type, version_tag, w_descr))
 }
 
+/// The `getattr(w_obj, name)` shape that reduces, purely, to
+/// `w_method_new(w_descr, w_obj, w_type)` — the bound method
+/// `object.__getattribute__` builds when the name resolves to a plain
+/// builtin-code function on the type and nothing shadows it.
+///
+/// This is the case [`load_method_fast_path`] deliberately does NOT take:
+/// upstream restricts the `[w_descr, w_obj]` push to `flag_method_descriptor`
+/// types (only `Function.typedef`, typedef.py:807), so `lst.append` falls
+/// through to `space.getattr` and materialises a `Method` in both engines.
+/// PyPy's tracer then sees through that `getattr` — it is ordinary RPython —
+/// and the resulting `Method` virtualizes away, leaving LOAD_METHOD with zero
+/// ops in a steady-state loop. pyre's `getattr` is an opaque residual instead,
+/// so the tracer needs this predicate to reproduce the same fold.
+///
+/// Returns `(w_type, version_tag, w_descr)` when the reduction holds, `None`
+/// otherwise. Every ingredient is a pure read: the caller pins `w_type` on
+/// the receiver and `version_tag` on the type, which together make the
+/// `lookup_in_type` result a constant. The receiver must have no instance
+/// dict at all (not merely no entry for `name`) — a dict the guards do not
+/// cover could grow a shadowing entry between trace and execution.
+///
+/// # Safety
+/// `w_obj` must be a valid object pointer (null tolerated).
+pub unsafe fn bound_method_attr_fast_path(
+    w_obj: PyObjectRef,
+    name: &str,
+) -> Option<(PyObjectRef, u64, PyObjectRef)> {
+    if w_obj.is_null() {
+        return None;
+    }
+    let w_type = crate::typedef::r#type(w_obj)?;
+    if w_type.is_null() {
+        return None;
+    }
+    // The tracer pins the class by guarding the receiver's `w_class` slot, so
+    // only a receiver whose class IS that slot can be reproduced.  Exception
+    // instances carrying the generic stub resolve their class through the
+    // kind registry instead and are declined here.
+    if !std::ptr::eq(w_type, (*w_obj).w_class) {
+        return None;
+    }
+    // typeobject.py:56-58: an uncacheable type cannot pin the lookup.
+    let version_tag = pyre_object::typeobject::w_type_get_version_tag(w_type);
+    if version_tag == 0 {
+        return None;
+    }
+    // Only the default `__getattribute__` is sound to reproduce.
+    if !has_object_getattribute(w_type) {
+        return None;
+    }
+    // No instance dict => the type lookup cannot be shadowed, so the
+    // non-data-descriptor branch of `object.__getattribute__` is the only
+    // reachable one.
+    if !getdict_backing(w_obj).is_null() {
+        return None;
+    }
+    let w_descr = lookup_in_type(w_type, name)?;
+    // `get()` binds exactly this shape: a `function` whose code is builtin
+    // (a `BuiltinFunction` returns itself unbound; every other descriptor
+    // kind takes a different arm).  A function is never a data descriptor,
+    // so the data-descriptor arm above it cannot fire either.
+    if !crate::is_function(w_descr) {
+        return None;
+    }
+    if !std::ptr::eq((*w_descr).ob_type, &crate::FUNCTION_TYPE as *const _) {
+        return None;
+    }
+    if !crate::is_builtin_code(crate::function_get_code(w_descr) as PyObjectRef) {
+        return None;
+    }
+    Some((w_type, version_tag, w_descr))
+}
+
 /// descroperation.py:12-15 `object_getattribute(space)` — the canonical
 /// `object.__getattribute__` descriptor used as the identity anchor for
 /// the `uses_object_getattribute` fast path.  Returns true iff `w_descr`

--- a/pyre/pyre-jit-trace/src/descr.rs
+++ b/pyre/pyre-jit-trace/src/descr.rs
@@ -988,6 +988,19 @@ static W_METHOD_DESCR_GROUP: LazyLock<PyreObjectDescrGroup> = LazyLock::new(|| {
                 false,
                 false,
             ),
+            // The inline bound-method emit (`emit_bound_method_inline`) can
+            // escape a guard and be materialized, so the inherited Python
+            // class needs to be a proper virtual field of this group — same
+            // reasoning as the `PyObject.w_class` entry on W_ListObject.
+            (
+                "PyObject.w_class",
+                pyre_object::pyobject::W_CLASS_OFFSET,
+                8,
+                Type::Ref,
+                false,
+                false,
+                false,
+            ),
         ],
         "Method",
         "function::Method",
@@ -1833,6 +1846,28 @@ pub fn method_w_function_descr() -> DescrRef {
 /// `_Method._immutable_fields_`.
 pub fn method_w_self_descr() -> DescrRef {
     field_descr_from_group(&W_METHOD_DESCR_GROUP, 1)
+}
+
+/// `Method.w_class` — the class the bound function was found on
+/// (`function.py` `Method.w_class`), distinct from the inherited
+/// `PyObject.w_class` naming the Method's own type.
+pub fn method_w_class_descr() -> DescrRef {
+    field_descr_from_group(&W_METHOD_DESCR_GROUP, 2)
+}
+
+/// Inherited `PyObject.w_class` on a `Method` — the Python-level `method`
+/// class stamped by `w_method_new`'s header. Kept in the Method group (not
+/// the standalone `w_class_descr`) so an inline emit's store is a virtual
+/// field of the same size descr and materialization reproduces the header.
+pub fn method_header_w_class_descr() -> DescrRef {
+    field_descr_from_group(&W_METHOD_DESCR_GROUP, 3)
+}
+
+/// Size descriptor for `Method` allocation via `NewWithVtable`
+/// (vtable = `&METHOD_TYPE`); `w_function` / `w_self` / `w_class` and the
+/// inherited header `w_class` are `SetfieldGc`'d after.
+pub fn w_method_size_descr() -> DescrRef {
+    W_METHOD_DESCR_GROUP.size_descr.clone()
 }
 
 /// `typeobject.py:26-34 ObjectMutableCell.w_value` — the boxed payload of

--- a/pyre/pyre-jit-trace/src/helpers.rs
+++ b/pyre/pyre-jit-trace/src/helpers.rs
@@ -523,6 +523,43 @@ pub fn emit_exception_new_inline(
     new_op
 }
 
+/// Emit inline `Method` creation (NewWithVtable + SetfieldGc for
+/// `w_function` / `w_self` / `w_class` and the inherited header
+/// `PyObject.w_class`), mirroring `function.rs w_method_new`.
+///
+/// This is the traced form of the bound method `getattr(obj, name)` builds
+/// for a `LOAD_ATTR`-method whose descriptor lives on the type. Emitting it
+/// as New+SetField instead of the opaque `bh_load_attr_fn` residual lets the
+/// optimizer virtualize the method away when it is immediately consumed by
+/// the following `CALL` — the shape PyPy gets for free by tracing through
+/// `space.getattr` (its LOAD_METHOD emits no ops at all in a steady-state
+/// loop; `pypy/objspace/std/callmethod.py:25-80`).
+pub fn emit_bound_method_inline(
+    ctx: &mut TraceCtx,
+    w_function: OpRef,
+    w_self: OpRef,
+    w_class: OpRef,
+    header_w_class: OpRef,
+) -> OpRef {
+    let new_op = ctx.record_op_with_descr(
+        OpCode::NewWithVtable,
+        &[],
+        crate::descr::w_method_size_descr(),
+    );
+    ctx.heap_cache_mut().new_object(new_op);
+    for (descr, value) in [
+        (crate::descr::method_w_function_descr(), w_function),
+        (crate::descr::method_w_self_descr(), w_self),
+        (crate::descr::method_w_class_descr(), w_class),
+        (crate::descr::method_header_w_class_descr(), header_w_class),
+    ] {
+        let index = descr.index();
+        ctx.record_op_with_descr(OpCode::SetfieldGc, &[new_op, value], descr);
+        ctx.heapcache_setfield_cached(new_op, index, value);
+    }
+    new_op
+}
+
 /// Emit inline Object-strategy `W_ListObject` creation as traced
 /// `NewArrayClear` + `SetarrayitemGc` + `NewWithVtable` + `SetfieldGc`
 /// ops the optimizer can virtualize when the list never escapes — instead

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
@@ -3395,6 +3395,24 @@ pub(crate) fn dispatch_residual_call_iIRd_kind<Sym: WalkSym>(
                 {
                     return Ok((DispatchOutcome::Continue, op.next_pc));
                 }
+                // The `[w_descr, w_obj]` push above is restricted to
+                // `flag_method_descriptor` types, so a builtin method on a
+                // builtin receiver (`lst.append`) leaves `getattr` to build a
+                // `Method`.  Emit that construction instead of the opaque
+                // residual so it virtualizes into the following CALL.
+                if try_walker_specialize_load_bound_method_attr(
+                    ctx,
+                    op.pc,
+                    obj_opref,
+                    w_code_ptr,
+                    namei as usize,
+                    dst,
+                    dst_bank,
+                )?
+                .is_some()
+                {
+                    return Ok((DispatchOutcome::Continue, op.next_pc));
+                }
             }
         }
     }

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
@@ -1666,6 +1666,133 @@ pub(crate) fn try_walker_specialize_load_method_attr<Sym: WalkSym>(
     Ok(Some(()))
 }
 
+/// Fold the `LOAD_ATTR`-method `getattr` residual for a receiver whose name
+/// resolves to a plain builtin-code function on its type — the `lst.append`
+/// shape [`try_walker_specialize_load_method_attr`] declines because upstream
+/// restricts its `[w_descr, w_obj]` push to `flag_method_descriptor` types.
+///
+/// Both engines materialise a `Method` here (`space.getattr`), but PyPy traces
+/// *through* that `getattr` — it is ordinary RPython — so the type lookup folds
+/// to a constant under `guard_class` + the version pin and the `Method` itself
+/// virtualizes away: its optimized LOAD_METHOD emits no ops at all in a
+/// steady-state loop (`pypy/objspace/std/callmethod.py:25-80`). pyre's `getattr`
+/// is an opaque `CALL_MAY_FORCE` residual, which additionally drags a
+/// `GUARD_NOT_FORCED` (forcing the virtualizable frame) and a `GUARD_NO_EXCEPTION`
+/// through every iteration. This fold reproduces PyPy's shape directly:
+///
+///   guard_class(obj, ob_type)
+///   guard_value(getfield(obj, w_class), the type)
+///   guard_value(getfield(the type, version_tag), the tag)
+///   new_with_vtable(Method) + setfield(w_function/w_self/w_class/header)
+///
+/// The guards make `lookup_in_type` constant exactly as the version-tag promote
+/// does upstream, and the emitted `Method` is dead once the following `CALL`
+/// folds — the append fold reads `w_function` / `w_self` straight back off it.
+///
+/// Returns `None` (fall through to the residual, SAFE) for every shape
+/// [`pyre_interpreter::baseobjspace::bound_method_attr_fast_path`] declines.
+///
+/// Restricted to the top full-body frame for the reason
+/// [`try_walker_orthodox_list_append`] documents: inside an inlined callee
+/// sub-walk a fold's guards collapse their resume to the caller's CALL
+/// boundary, so a guard failure re-runs the callee from its entry and doubles
+/// any side effect it sequenced before this `LOAD_ATTR`. The residual resumes
+/// past the call instead, so declining here re-runs nothing extra.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn try_walker_specialize_load_bound_method_attr<Sym: WalkSym>(
+    ctx: &mut WalkContext<'_, '_, Sym>,
+    op_pc: usize,
+    obj: OpRef,
+    w_code_ptr: usize,
+    name_idx: usize,
+    dst: usize,
+    dst_bank: char,
+) -> Result<Option<()>, DispatchError> {
+    if !ctx.is_authoritative_executor || dst_bank != 'r' || ctx.fbw_mode.inline_subwalk {
+        return Ok(None);
+    }
+    let Some(concrete_obj) = walker_concrete_ref_object(ctx, obj) else {
+        return Ok(None);
+    };
+    let Some(name) = walker_load_name_from_code(w_code_ptr, name_idx) else {
+        return Ok(None);
+    };
+    // `__`-names reach `getattr` through slots the fold does not model, the
+    // same carve-out `try_walker_specialize_load_method_attr` applies.
+    if name.contains("__") {
+        return Ok(None);
+    }
+    let Some((w_type, version_tag, w_descr)) = (unsafe {
+        pyre_interpreter::baseobjspace::bound_method_attr_fast_path(concrete_obj, &name)
+    }) else {
+        return Ok(None);
+    };
+
+    // guard_class(obj, ob_type): the physical layout the `w_class` read below
+    // needs, and what pins the receiver's builtin kind.
+    let phys_type = unsafe { (*concrete_obj).ob_type } as i64;
+    if !ctx.trace_ctx.heap_cache().is_class_known(obj) {
+        let type_const = ctx.trace_ctx.const_int(phys_type);
+        walker_emit_fold_guard_with_snapshot(ctx, op_pc, OpCode::GuardClass, &[obj, type_const])?;
+        ctx.trace_ctx
+            .heap_cache_mut()
+            .class_now_known(obj, phys_type);
+    }
+
+    // Pin the Python-level class exactly: a subclass reaching the same
+    // physical layout can define its own `name` and must side-exit.
+    let w_class_op = walker_record_getfield_gc_r_uncached(ctx, obj, crate::descr::w_class_descr());
+    let w_type_const = ctx.trace_ctx.const_ref(w_type as i64);
+    walker_emit_fold_guard_with_snapshot(
+        ctx,
+        op_pc,
+        OpCode::GuardValue,
+        &[w_class_op, w_type_const],
+    )?;
+    ctx.trace_ctx
+        .heap_cache_mut()
+        .replace_box(w_class_op, w_type_const);
+
+    // typeobject.py `promote(self.version_tag())`: reassigning the method on
+    // the type bumps the tag, so the constant `w_descr` side-exits.
+    let vt_op = walker_record_getfield_gc_i_uncached(
+        ctx,
+        w_type_const,
+        crate::descr::type_version_tag_descr(),
+    );
+    let vt_const = ctx.trace_ctx.const_int(version_tag as i64);
+    walker_emit_fold_guard_with_snapshot(ctx, op_pc, OpCode::GuardValue, &[vt_op, vt_const])?;
+    ctx.trace_ctx.heap_cache_mut().replace_box(vt_op, vt_const);
+
+    // `w_method_new(w_descr, obj, w_type)` + the header stamp its allocation
+    // performs (`ob_type` comes from the NewWithVtable's size descr).
+    let func_const = ctx.trace_ctx.const_ref(w_descr as i64);
+    let header_w_class = ctx
+        .trace_ctx
+        .const_ref(pyre_object::get_instantiate(&pyre_object::function::METHOD_TYPE) as i64);
+    let method_op = crate::helpers::emit_bound_method_inline(
+        ctx.trace_ctx,
+        func_const,
+        obj,
+        w_type_const,
+        header_w_class,
+    );
+    let method_type_addr = &pyre_object::function::METHOD_TYPE as *const _ as i64;
+    ctx.trace_ctx
+        .heap_cache_mut()
+        .class_now_known(method_op, method_type_addr);
+    // The concrete bound method the walker's own execution must observe; a
+    // fresh `Method` per evaluation is what `getattr` produces anyway, so the
+    // trace allocating its own is not an identity divergence.
+    let bound = pyre_object::w_method_new(w_descr, concrete_obj, w_type);
+    ctx.trace_ctx.set_opref_concrete(
+        method_op,
+        majit_ir::Value::Ref(majit_ir::GcRef(bound as usize)),
+    );
+    write_residual_call_result_to_dst(ctx, op_pc, dst, dst_bank, method_op)?;
+    Ok(Some(()))
+}
+
 /// Fold `bh_load_method_self_fn(obj, attr, code, name_idx)` once both the
 /// receiver and the attribute are concrete.  The method-attribute fold above
 /// already guards class, type version, and instance map; this second residual
@@ -1693,9 +1820,35 @@ pub(crate) fn try_walker_fold_load_method_self<Sym: WalkSym>(
     let Some(concrete_attr) = walker_concrete_ref_object(ctx, attr) else {
         return Ok(None);
     };
+    // `compute_load_method_bound` answers PY_NULL for an already-bound method
+    // without inspecting anything else, so pinning the attribute's class is
+    // the whole precondition.  Left as a residual this is a second per-iteration
+    // call on top of the `getattr` one (`lst.append(x)` pays both).
     if unsafe { pyre_object::is_method(concrete_attr) } {
-        return Ok(None);
-    };
+        let method_type_addr = &pyre_object::function::METHOD_TYPE as *const _ as i64;
+        let class_pinned = attr.is_constant() || ctx.trace_ctx.heap_cache().is_class_known(attr);
+        if !class_pinned {
+            // A guard here would resume at the caller's CALL inside an inlined
+            // callee sub-walk, re-running whatever that callee already did;
+            // leave those to the residual (which resumes past the call).
+            if ctx.fbw_mode.inline_subwalk {
+                return Ok(None);
+            }
+            let type_const = ctx.trace_ctx.const_int(method_type_addr);
+            walker_emit_fold_guard_with_snapshot(
+                ctx,
+                op_pc,
+                OpCode::GuardClass,
+                &[attr, type_const],
+            )?;
+            ctx.trace_ctx
+                .heap_cache_mut()
+                .class_now_known(attr, method_type_addr);
+        }
+        let null_const = ctx.trace_ctx.const_ref(pyre_object::PY_NULL as i64);
+        write_residual_call_result_to_dst(ctx, op_pc, dst, dst_bank, null_const)?;
+        return Ok(Some(()));
+    }
     let Some(name) = walker_load_name_from_code(w_code_ptr, name_idx) else {
         return Ok(None);
     };

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
@@ -1717,11 +1717,6 @@ pub(crate) fn try_walker_specialize_load_bound_method_attr<Sym: WalkSym>(
     let Some(name) = walker_load_name_from_code(w_code_ptr, name_idx) else {
         return Ok(None);
     };
-    // `__`-names reach `getattr` through slots the fold does not model, the
-    // same carve-out `try_walker_specialize_load_method_attr` applies.
-    if name.contains("__") {
-        return Ok(None);
-    }
     let Some((w_type, version_tag, w_descr)) = (unsafe {
         pyre_interpreter::baseobjspace::bound_method_attr_fast_path(concrete_obj, &name)
     }) else {


### PR DESCRIPTION
`lst.append(x)` in a hot loop kept an opaque `getattr` residual in the
compiled trace, so every iteration ran an MRO walk, allocated a fresh
`Method`, and paid a `GUARD_NOT_FORCED` / `GUARD_NO_EXCEPTION` pair plus a
second `bh_load_method_self_fn` call.

## Why the interpreter gate is not the bug

`load_method_fast_path` declines for `lst.append` because
`flag_method_descriptor` is set only on `Function.typedef`
(`pypy/interpreter/typedef.py:807`). `pypy/objspace/std/callmethod.py:25-80`
restricts its `[w_descr, w_obj]` push the same way, so PyPy also falls
through to `space.getattr` and materialises a `Method`. The port is
faithful and is left alone.

## The gap is at trace level

`PYPYLOG=jit-log-opt` on the same loop shows PyPy's `#18 LOAD_METHOD` merge
point emitting **zero** operations: `space.getattr` is ordinary RPython, so
the meta-tracer traces through it, the MRO lookup constant-folds under
`guard_class` + `guard_not_invalidated`, and the `Method` virtualizes away.
pyre's `getattr` is an opaque residual, so the tracer has to fold it — the
same role `try_walker_specialize_load_attr` / `..._load_method_attr`
already play.

## Change

* `bound_method_attr_fast_path` (beside `load_method_fast_path`) names the
  shape `getattr` reduces to `w_method_new(w_descr, obj, w_type)` purely:
  default `__getattribute__`, cacheable version tag, receiver class
  identical to its `w_class` slot, no instance dict at all, and a
  `FUNCTION_TYPE` descriptor with builtin code.
* `try_walker_specialize_load_bound_method_attr` emits `guard_class` +
  `guard_value(w_class)` + `guard_value(version_tag)` +
  `NewWithVtable(Method)`, so the following CALL reads `w_function` /
  `w_self` back off it and the allocation dies. Restricted to the top
  full-body frame for the reason `try_walker_orthodox_list_append`
  documents (a fold's guards inside an inlined callee collapse resume to
  the caller's CALL and would re-run the callee's earlier side effects).
* `try_walker_fold_load_method_self` answers the companion residual with a
  `PY_NULL` constant under a Method class guard instead of declining —
  `compute_load_method_bound` returns PY_NULL for any `is_method(attr)`.
* `Method`'s descr group gains the inherited `PyObject.w_class` so the
  inline emit's header store is a virtual field of the same size descr.

## Numbers

`synth/const_arg_call_resume`, check.py's own execution-only ratio against
pypy (header gate is x30):

| | before | after |
| --- | --- | --- |
| dynasm | x22.7 | x9.5 |
| cranelift | x28.1 | x12.5 |

The `r.append(i)` loop alone goes x32.2 -> x5.0, and its compiled loop drops
from 50 ops with one `call_may_force` to 45 with none. Against CPython the
whole fixture goes from x4.95 (slower than the interpreter) to x2.4.

The measurement is check.py's metric — user CPU minus an empty-program run
(`_run_timed_unix` + `_exec_time`), not wall clock.

## Verification

`python3 ./pyre/check.py --backend dynasm,cranelift`: 309/309 on both.
`cargo test --all --no-default-features --features dynasm`: green.
`cargo fmt --all --check`: clean.

New fixture `pyre/bench/synth/bound_method_builtin_fold.py` pins the guards:
a `__slots__` subclass whose method is replaced mid-loop (version tag), an
instance-dict entry shadowing the method name (the fold must decline), a
polymorphic receiver at one call site (class guard), and a bound method that
outlives its CALL (materialization). Output matches CPython 3.14 and PyPy.

Not specific to this fixture: it covers `obj.method()` on any dict-less
builtin receiver (list / dict / set / str / ...).

— *commented by Claude*
