### PR TITLE
jit: record the save/restore-exception pair on a no-exception bridge entry

### DIFF
--- a/pyre/bench/synth/exc_bridge_entry_guard_not_removed.py
+++ b/pyre/bench/synth/exc_bridge_entry_guard_not_removed.py
@@ -1,0 +1,55 @@
+# A residual callee raises for the extremes of a hot descending loop and
+# returns in the middle, so the loop trace's exception guard chronically fails
+# WITHOUT a pending exception and a no-exception bridge gets compiled.  That
+# bridge's entry GUARD_NO_EXCEPTION is what makes the rare pending-exception
+# entry deopt instead of running the no-exception continuation on a NULL
+# raised-call result.
+#
+# The `str(i) + str(i)` ahead of the try is the point of the shape: it lands a
+# removable call in the bridge's resume data, right before the entry guard.
+# `optimize_GUARD_NO_EXCEPTION` (rewrite.py, pure.py) drops a
+# GUARD_NO_EXCEPTION whose predecessor was removed, so without the
+# SAVE_EXC_CLASS / SAVE_EXCEPTION + RESTORE_EXCEPTION pair around it the entry
+# guard is deleted and the final IndexError escapes uncaught -- upstream issue
+# #2132, pinned there by test_guard_no_exception_incorrectly_removed_from_bridge.
+R = 4000
+START = 14
+
+
+def do(n):
+    if n > 7:
+        raise ValueError(n)
+    if n > 1:
+        return n
+    raise IndexError(n)
+
+
+def one_pass(start):
+    caught_value = 0
+    caught_index = 0
+    i = start
+    while i > 0:
+        s = str(i) + str(i)
+        try:
+            do(i)
+        except ValueError:
+            caught_value += 1
+        except IndexError:
+            caught_index += 1
+        if len(s) == 0:
+            return -1, -1
+        i -= 1
+    return caught_value, caught_index
+
+
+def run():
+    total_value = 0
+    total_index = 0
+    for _ in range(R):
+        v, x = one_pass(START)
+        total_value += v
+        total_index += x
+    return total_value, total_index
+
+
+print(run())

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/bridge_subwalk.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/bridge_subwalk.rs
@@ -417,17 +417,36 @@ pub fn dispatch_via_miframe<Sym: WalkSym>(
             vstack_enter_exception_handler(&mut wc, seed.catch_target, seed.exc);
             seed.catch_target
         } else {
-            // `_prepare_exception_resumption` null-exception arm
-            // (pyjitpl.py:3152-3154) + `prepare_resume_from_failure`
-            // (pyjitpl.py:3156-3171): every exception-guard bridge re-checks
-            // its entry flavor.  With no pending exception at walk time,
-            // `clear_exception()` + `handle_possible_exception()` record
-            // GUARD_NO_EXCEPTION at the bridge start, so the OTHER failure
-            // flavor — a pending exception whose class the source guard's
-            // expected class does not match — deopts to the blackhole at
-            // bridge entry instead of running the recorded no-exception
+            // `_prepare_exception_resumption` null-exception arm +
+            // `prepare_resume_from_failure` (pyjitpl.py): every exception-guard
+            // bridge re-checks its entry flavor.  With no pending exception at
+            // walk time, `clear_exception()` + `handle_possible_exception()`
+            // record GUARD_NO_EXCEPTION at the bridge start, so the OTHER
+            // failure flavor — a pending exception whose class the source
+            // guard's expected class does not match — deopts to the blackhole
+            // at bridge entry instead of running the recorded no-exception
             // continuation on a NULL raised-call result.
             if wc.trace_ctx.is_bridge_trace && wc.trace_ctx.bridge_source_is_exception_guard() {
+                // `_prepare_exception_resumption` records SAVE_EXC_CLASS +
+                // SAVE_EXCEPTION for the exception-guard descr flavor whether or
+                // not the deadframe carried an exception — `exc_class = 0` and a
+                // null value on this arm — and `prepare_resume_from_failure`
+                // records RESTORE_EXCEPTION just before the guard.  That pair is
+                // what keeps the optimizer from deleting the guard: resume data
+                // can put a removable op ahead of it (here
+                // `seed_execution_context_for_walk`'s GetfieldGcR, a heap-CSE
+                // candidate), and both `optimize_GUARD_NO_EXCEPTION` ports
+                // (rewrite.rs, pure.rs) drop a GUARD_NO_EXCEPTION whose
+                // predecessor was removed.  RESTORE_EXCEPTION is never folded, so
+                // it holds that flag clear.  `remove_bridge_exception` strips the
+                // trio again once it is consecutive and unused, so keeping the
+                // guard costs nothing at runtime.  Without it the bridge is
+                // entered with a pending exception at the same source guard and
+                // runs the no-exception continuation on a NULL raised-call
+                // result — the shape upstream issue #2132 describes.
+                let class_op = wc.trace_ctx.save_exc_class();
+                let value_op = wc.trace_ctx.save_exception();
+                wc.trace_ctx.restore_exception(class_op, value_op);
                 wc.trace_ctx.record_guard(OpCode::GuardNoException, &[], 0);
                 // `position` is already the post-call resume coordinate —
                 // capture without the after-residual advance and carry it


### PR DESCRIPTION
## What

`_prepare_exception_resumption` records `SAVE_EXC_CLASS` + `SAVE_EXCEPTION` for the exception-guard descr flavor whether or not the deadframe carried an exception (`exc_class = 0` and a null value when it did not), and `prepare_resume_from_failure` records `RESTORE_EXCEPTION` just before the entry guard (`pyjitpl.py`).

That pair is not decoration — it is what keeps the optimizer from deleting the entry guard. Resume data can place a removable operation ahead of the guard, and `optimize_GUARD_NO_EXCEPTION` (`rewrite.py`, `pure.py`) drops a `GUARD_NO_EXCEPTION` whose predecessor was removed. Upstream pins the hazard with `test_guard_no_exception_incorrectly_removed_from_bridge` (issue #2132).

The bridge sub-walk emitted the trio only on the routed pending-exception arm; the no-exception arm recorded a bare `GuardNoException`. This records the same trio on that arm.

## Why it matters here

The removal shape is structurally present in this tree, not hypothetical:

- both `optimize_GUARD_NO_EXCEPTION` ports exist — `rewrite.rs` keys on `ctx.last_op_removed`, `pure.rs` on `last_emitted_was_removed`;
- `seed_execution_context_for_walk` records a heap-CSE-eligible `GetfieldGcR` immediately ahead of the entry guard.

If that guard is removed, the bridge is entered with a pending exception at the same source guard and runs the recorded no-exception continuation on a NULL raised-call result.

## Scope — this closes a window, it does not fix an observed miscompile

Stated plainly: the guard survives today. A control build with this change reverted produces identical output on the added bench, so nothing observable changes. `RestoreException` is never folded by any pass, so it holds `last_op_removed` clear; `remove_bridge_exception` strips the trio again once it is consecutive with its results unused, which is the case on this arm — so the protection costs nothing at runtime.

Also drops stale upstream line-number suffixes from the surrounding comment.

## Verification

- `check.py` dynasm 308/308 + cranelift 308/308 on the parent commit.
- New bench `exc_bridge_entry_guard_not_removed` → `(28000, 4000)` on dynasm, cranelift, no-JIT, pypy3 and cpython; `MAJIT_STATS` confirms it really compiles a bridge (`bridges_compiled=1`), so it is not a vacuous shape.
- `exc_mixed_classes_bridge_flavor` unchanged at `2399980000`, matching pypy3 on both backends.
- No jitstats baseline drifts.

A `check.py` run taken while this machine was at load average ~118 (several sibling worktrees building concurrently) showed three chronic boundary perf gate-sitters failing — `raise_catch`, `const_arg_call_resume`, `residual_raise_except_resume`. Correctness was 306/306 non-perf and no jitstats drifted, so those are load artifacts rather than an effect of this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of exception-guard scenarios during JIT execution.
  * Added coverage for repeated exception handling across loop iterations.

* **Documentation**
  * Expanded internal explanations for exception restoration and guard behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->