### PR TITLE
jit: warm-entry runnable-loop gate at JIT_THRESHOLD=1039; MOST_GENERAL for un-analyzed callees

### DIFF
--- a/majit/majit-macros/src/jit_interp/codegen_state.rs
+++ b/majit/majit-macros/src/jit_interp/codegen_state.rs
@@ -1806,11 +1806,13 @@ fn generate_state_fields_jit_state(config: &JitInterpConfig, func: &ItemFn) -> T
             fn __build_virtualizable_info()
             -> Option<::std::sync::Arc<majit_metainterp::virtualizable::VirtualizableInfo>> {
                 use majit_metainterp::virtualizable::VirtualizableInfo;
-                // token_offset=0: the stack-local state struct is non-GC and
-                // never moved, so the vable_token protocol is inert — the
+                // No `vable_token` field: the stack-local state struct is
+                // non-GC and never moved, so the token protocol is inert — the
                 // identity value (a `&state` pointer) is recovered straight
-                // from the resume snapshot, not via a heap token.
-                let mut __info = VirtualizableInfo::new(0);
+                // from the resume snapshot, not via a heap token. The struct's
+                // offset 0 is a live user field, so every token read/write must
+                // no-op rather than land there.
+                let mut __info = VirtualizableInfo::without_vable_token();
                 __info.name = "state".to_string();
                 // The dispatch lowering binds the green ref `program` to ref
                 // register 0 (it is the base for `program[pc]` reads) and the

--- a/majit/majit-metainterp/src/call_descr.rs
+++ b/majit/majit-metainterp/src/call_descr.rs
@@ -462,8 +462,11 @@ pub fn effect_info_for_slot(slot: EffectInfoSlot) -> EffectInfo {
 /// opcode at codewriter time, so reverse the mapping here so the descr
 /// the optimizer reads carries the matching effect class.
 ///
-/// `CALL_MAY_FORCE` maps to [`forces_virtual_or_virtualizable_effect_info`]
-/// (`effectinfo.py:23 EF_FORCES_VIRTUAL_OR_VIRTUALIZABLE`).
+/// `CALL_MAY_FORCE` maps to [`default_effect_info()`]: the opcode alone
+/// only proves `check_forces_virtual_or_virtualizable()` held
+/// (`pyjitpl.py:2007-2008`), which `EF_RANDOM_EFFECTS` satisfies via the
+/// `>=` at `effectinfo.py:249-250`. It does NOT prove the write analyzer
+/// ran, so the reconstruction cannot invent an empty write set.
 /// `CALL_RELEASE_GIL` cannot be reconstructed from the opcode alone —
 /// upstream `effectinfo.py:271-273 MOST_GENERAL` pairs `EF_RANDOM_EFFECTS`
 /// with a `call_release_gil_target` funcptr that this helper does not
@@ -476,7 +479,7 @@ pub fn default_effect_for_opcode(opcode: majit_ir::OpCode) -> EffectInfo {
     } else if opcode.is_call_loopinvariant() {
         LOOPINVARIANT_EFFECT_INFO
     } else if opcode.is_call_may_force() {
-        forces_virtual_or_virtualizable_effect_info()
+        default_effect_info()
     } else if opcode.is_call_release_gil() {
         unreachable!(
             "default_effect_for_opcode: CALL_RELEASE_GIL (`{opcode:?}`) requires \

--- a/majit/majit-metainterp/src/call_descr.rs
+++ b/majit/majit-metainterp/src/call_descr.rs
@@ -154,45 +154,48 @@ impl majit_ir::descr::LoopTokenDescr for MetaCallAssemblerDescr {
     }
 }
 
-/// Default EffectInfo for an external residual call without per-callee
-/// heap analyzer output — the `EF_CAN_RAISE` row of `call.py:300-301
-/// elif self._canraise(op):` selected through
-/// `effectinfo_from_writeanalyze` with the
-/// `graphanalyze.py:60 analyze_external_call` default
-/// (`bottom_result()` = empty set).
+/// EffectInfo for a residual call whose callee has no heap-analyzer
+/// output — `EffectInfo::MOST_GENERAL`.
 ///
-/// Shape: `extraeffect=CanRaise`, every `_*_descrs_*` raw set =
-/// `Some(Vec::new())`, every `*_descrs_*` bitstring = `Some(Vec::new())`,
-/// `can_collect=true` (PyPy `effectinfo.py:283` default).
-/// `effectinfo.py:293-299` else-branch: when the analyzer returns
-/// non-`top_set` effects, raw sets START at `[]` and grow with actual
-/// effects; for an empty effects set they stay `[]`. The matching
-/// invariant `effectinfo.py:149-162` `RandomEffects ⇔ raw=None`
-/// keeps this distinct from `MOST_GENERAL` (`extraeffect=RandomEffects
-/// ⇔ raw=None ⇔ bitstring=None`).
+/// `graphanalyze.py:105-116 analyze` splits the direct-call case three
+/// ways, and only ONE of them is the empty-set bottom:
 ///
-/// **Why not `MOST_GENERAL`**: `EF_RANDOM_EFFECTS` is reserved for
-/// callees the `RandomEffectsAnalyzer` (`effectinfo.py:410-415`)
-/// flags via `funcobj.random_effects_on_gcobjs`; collapsing the
-/// plain "no-analyzer" case onto it routes every residual call
-/// through `OptHeap.call_has_random_effects → clean_caches` (full
-/// heap invalidation) and `check_forces_virtual_or_virtualizable()`
-/// → `GUARD_NOT_FORCED`, both of which PyPy reserves for genuinely
-/// random callees. The empty-frozenset shape lets
-/// `compute_bitstrings` produce zero-length bitstrings so
-/// `bitcheck` short-circuits to false; cached heap state survives
-/// across these calls per PyPy.
+/// * `:104-108` the callee is `external` → `analyze_external_call`,
+///   whose `graphanalyze.py:60` default is `bottom_result()`;
+/// * `:109-112` the callee has no `funcobj.graph` (nothing to analyze)
+///   → `top_result()`;
+/// * `:117-122 indirect_call` with `graphs is None` → `top_result()`.
+///
+/// `effectinfo.py:285-292` then turns a `top_set` result into
+/// `EF_RANDOM_EFFECTS` with all six raw sets and all six bitstrings set
+/// to `None`, which is exactly `EffectInfo.MOST_GENERAL`
+/// (`effectinfo.py:271-273`). `call.py:174-187 get_jitcode_calldescr`
+/// uses the same constant for the calldescr it attaches to a JitCode.
+///
+/// A pyre residual callee reaching this function is the second case,
+/// not the first: it is a Rust helper the codewriter pipeline never
+/// analyzed, so its write set is unknown rather than empty. Handing out
+/// the `bottom_result()` shape here would assert "writes nothing",
+/// which `heap.rs force_from_effectinfo` would believe.
+///
+/// Callers that HAVE proved something about the callee must not use
+/// this: `cannot_raise_effect_info()`,
+/// `CANNOT_RAISE_NO_HEAP_EFFECT_INFO`, the `ELIDABLE_*` constants and
+/// the analyzer-built EIs from `codewriter::call::getcalldescr` all
+/// carry concrete (possibly empty) raw sets.
 pub fn default_effect_info() -> EffectInfo {
-    EffectInfo::const_new(ExtraEffect::CanRaise, OopSpecIndex::None)
+    EffectInfo::MOST_GENERAL
 }
 
-/// aheui nursery-alloc residual: identical optimizer treatment to
-/// [`default_effect_info`] (CanRaise, empty write-sets, can_collect=true)
-/// but stamped with [`PyreHelperKind::NurseryAlloc`] so the dynasm CallR
-/// genop emits an inline nursery bump. The tag does not change effect
-/// analysis — the op is forced/fenced exactly like the current residual.
+/// aheui nursery-alloc residual: `EF_CAN_RAISE` with empty write sets —
+/// an allocation publishes a fresh object and writes no field of any
+/// object the trace already cached, so `graphanalyze.py:60
+/// analyze_external_call`'s `bottom_result()` is the honest answer.
+/// Stamped with [`PyreHelperKind::NurseryAlloc`] so the dynasm CallR
+/// genop emits an inline nursery bump; the tag does not change effect
+/// analysis.
 pub fn nursery_alloc_effect_info() -> EffectInfo {
-    let mut ei = default_effect_info();
+    let mut ei = EffectInfo::const_new(ExtraEffect::CanRaise, OopSpecIndex::None);
     ei.pyre_helper = PyreHelperKind::NurseryAlloc;
     ei
 }
@@ -402,21 +405,19 @@ pub const LOOPINVARIANT_EFFECT_INFO: EffectInfo =
 /// which is out of scope for the slot enum.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
 pub enum EffectInfoSlot {
-    /// `EF_CAN_RAISE` — `call.py:300-301 elif self._canraise(op):`
-    /// branch of `getcalldescr`. Maps to [`default_effect_info()`]:
-    /// `CanRaise + Some(empty)` raw sets + `Some(empty)` bitstrings,
-    /// matching the writeanalyzer-empty external-call shape
-    /// (`graphanalyze.py:60` `bottom_result()` + `effectinfo.py:293-299`
-    /// else-branch). Default slot for producers without per-callee
-    /// heap analysis.
+    /// Default slot for producers without per-callee heap analysis.
+    /// Maps to [`default_effect_info()`] = `EffectInfo::MOST_GENERAL`
+    /// (`EF_RANDOM_EFFECTS`, all raw sets and bitstrings `None`), the
+    /// `graphanalyze.py:109-112` "callee has no analyzable graph" →
+    /// `top_result()` outcome promoted by `effectinfo.py:285-292`.
     ///
-    /// **Distinct from `RandomEffects`**: `EF_RANDOM_EFFECTS` is the
-    /// `RandomEffectsAnalyzer` (`effectinfo.py:410-415`) outcome for
-    /// callees flagged `random_effects_on_gcobjs`; collapsing the
-    /// plain "no-analyzer" path onto it triggers `clean_caches` +
-    /// `GUARD_NOT_FORCED` PyPy reserves for genuinely-random callees.
-    /// No pyre producer constructs a true `RandomEffects` slot today
-    /// (none of the registered helpers are `random_effects_on_gcobjs`).
+    /// The name records the `call.py:300-301 elif self._canraise(op):`
+    /// row it stands in for; the `EF_CAN_RAISE` + empty-write-set shape
+    /// that row produces requires analyzer output pyre does not have at
+    /// these sites, so it is not what this slot resolves to. A producer
+    /// that HAS proved the callee cannot raise picks
+    /// [`EffectInfoSlot::CannotRaise`] or
+    /// [`EffectInfoSlot::CannotRaiseNoHeap`] instead.
     #[default]
     CanRaise,
     /// `EF_CANNOT_RAISE` — `call.py:303` `else` branch.
@@ -488,15 +489,8 @@ pub fn default_effect_for_opcode(opcode: majit_ir::OpCode) -> EffectInfo {
 }
 
 /// Create a CallDescr with the conservative
-/// [`default_effect_info()`] (`EF_CAN_RAISE` + `Some(Vec::new())`
-/// raw sets + `Some(Vec::new())` bitstrings + `can_collect=true`).
-/// This is the analyzer-absent fallback mirroring
-/// `call.py:300-301 elif self._canraise(op):` fed through
-/// `effectinfo_from_writeanalyze` with the
-/// `graphanalyze.py:60 analyze_external_call` default
-/// (`bottom_result()` = empty set) — the
-/// `effectinfo.py:293-299` else-branch shape, distinct from
-/// `MOST_GENERAL`.
+/// [`default_effect_info()`] (`EffectInfo::MOST_GENERAL`), the
+/// analyzer-absent fallback described there.
 ///
 /// Production producers should prefer one of the more specific factories
 /// so the per-callee classification reaches the trace IR:

--- a/majit/majit-metainterp/src/call_descr.rs
+++ b/majit/majit-metainterp/src/call_descr.rs
@@ -187,6 +187,27 @@ pub fn default_effect_info() -> EffectInfo {
     EffectInfo::MOST_GENERAL
 }
 
+/// `call.py:300-301 elif self._canraise(op):` — `EF_CAN_RAISE` built
+/// through `effectinfo_from_writeanalyze` with an empty analyzer result.
+///
+/// Shape: `extraeffect=CanRaise`, every `_*_descrs_*` raw set =
+/// `Some(Vec::new())`, every `*_descrs_*` bitstring = `Some(Vec::new())`,
+/// `can_collect=true` (`effectinfo.py:283` default).
+/// `effectinfo.py:293-299`'s else-branch starts the raw sets at `[]` and
+/// grows them with the analyzer's actual effects, so an analyzer that
+/// reported nothing leaves them `[]` — distinct from `MOST_GENERAL`,
+/// which the `effectinfo.py:149-162` invariant ties to raw = `None`.
+///
+/// This is the row for a callee the producer classified by hand: an
+/// opaque leaf helper the author marked `#[dont_look_inside]`
+/// (`rlib/jit.py:132`), whose upstream counterpart still has a graph for
+/// the write analyzer to walk. It asserts "writes no field of any object
+/// the trace already cached", which
+/// [`default_effect_info`] deliberately does not.
+pub fn can_raise_effect_info() -> EffectInfo {
+    EffectInfo::const_new(ExtraEffect::CanRaise, OopSpecIndex::None)
+}
+
 /// aheui nursery-alloc residual: `EF_CAN_RAISE` with empty write sets —
 /// an allocation publishes a fresh object and writes no field of any
 /// object the trace already cached, so `graphanalyze.py:60
@@ -405,21 +426,31 @@ pub const LOOPINVARIANT_EFFECT_INFO: EffectInfo =
 /// which is out of scope for the slot enum.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
 pub enum EffectInfoSlot {
-    /// Default slot for producers without per-callee heap analysis.
-    /// Maps to [`default_effect_info()`] = `EffectInfo::MOST_GENERAL`
-    /// (`EF_RANDOM_EFFECTS`, all raw sets and bitstrings `None`), the
-    /// `graphanalyze.py:109-112` "callee has no analyzable graph" →
-    /// `top_result()` outcome promoted by `effectinfo.py:285-292`.
+    /// `EF_CAN_RAISE` — `call.py:300-301 elif self._canraise(op):`
+    /// branch of `getcalldescr`, resolved through
+    /// [`can_raise_effect_info()`]: `CanRaise` + `Some(empty)` raw sets
+    /// and bitstrings.
     ///
-    /// The name records the `call.py:300-301 elif self._canraise(op):`
-    /// row it stands in for; the `EF_CAN_RAISE` + empty-write-set shape
-    /// that row produces requires analyzer output pyre does not have at
-    /// these sites, so it is not what this slot resolves to. A producer
-    /// that HAS proved the callee cannot raise picks
-    /// [`EffectInfoSlot::CannotRaise`] or
-    /// [`EffectInfoSlot::CannotRaiseNoHeap`] instead.
+    /// Picked by producers that classified the callee by hand — the
+    /// `#[dont_look_inside]` policy bytes, whose upstream counterpart is
+    /// a `@dont_look_inside` function the write analyzer still walks. It
+    /// is not the "nothing was analyzed" answer: that one is
+    /// [`EffectInfoSlot::Unanalyzed`].
     #[default]
     CanRaise,
+    /// `EF_RANDOM_EFFECTS` / [`EffectInfo::MOST_GENERAL`] — the
+    /// `graphanalyze.py:109-112` "callee has no analyzable graph" →
+    /// `top_result()` outcome, promoted by `effectinfo.py:285-292`.
+    /// Resolved through [`default_effect_info()`].
+    ///
+    /// Picked by producers that classified nothing: a helper binding
+    /// arbitrary interpreter execution, with no graph for a write
+    /// analyzer to walk. `check_forces_virtual_or_virtualizable()` holds
+    /// for this row (`effectinfo.py:249-250`, `7 >= 6`), so a callee
+    /// registered with it must not be dispatched through `cond_call` /
+    /// `record_known_result` (`jtransform.py:1677`,
+    /// `pyjitpl.py:2128-2132` assert the opposite).
+    Unanalyzed,
     /// `EF_CANNOT_RAISE` — `call.py:303` `else` branch.
     CannotRaise,
     /// `EF_CANNOT_RAISE` + analyzer-confirmed empty heap. Maps to
@@ -443,7 +474,8 @@ pub enum EffectInfoSlot {
 /// const captures the analyzer-absent fallback for that `extraeffect`.
 pub fn effect_info_for_slot(slot: EffectInfoSlot) -> EffectInfo {
     match slot {
-        EffectInfoSlot::CanRaise => default_effect_info(),
+        EffectInfoSlot::CanRaise => can_raise_effect_info(),
+        EffectInfoSlot::Unanalyzed => default_effect_info(),
         EffectInfoSlot::CannotRaise => cannot_raise_effect_info(),
         EffectInfoSlot::CannotRaiseNoHeap => CANNOT_RAISE_NO_HEAP_EFFECT_INFO.clone(),
         EffectInfoSlot::ElidableCanRaise => ELIDABLE_EFFECT_INFO,
@@ -984,5 +1016,28 @@ mod set_effect_bitstrings_tests {
         assert!(!ei.has_random_effects());
         assert!(!ei.has_oopspec());
         assert!(!ei.check_can_invalidate());
+    }
+
+    /// `effectinfo.py:149-162` ties `EF_RANDOM_EFFECTS` to raw sets =
+    /// `None`, so the hand-classified `call.py:300-301` row and the
+    /// `graphanalyze.py:109-112` no-graph row are not interchangeable.
+    /// A slot resolving `CanRaise` to `MOST_GENERAL` would make every
+    /// `cond_call` / `record_known_result` target force the
+    /// virtualizable, which `jtransform.py:1677` and
+    /// `pyjitpl.py:2128-2132` assert can never happen.
+    #[test]
+    fn can_raise_slot_is_the_analyzed_row_and_unanalyzed_is_most_general() {
+        let can_raise = effect_info_for_slot(EffectInfoSlot::CanRaise);
+        assert_eq!(can_raise.extraeffect, ExtraEffect::CanRaise);
+        assert!(!can_raise.has_random_effects());
+        assert!(!can_raise.check_forces_virtual_or_virtualizable());
+        assert!(can_raise._write_descrs_fields.is_some());
+
+        let unanalyzed = effect_info_for_slot(EffectInfoSlot::Unanalyzed);
+        assert_eq!(unanalyzed.extraeffect, ExtraEffect::RandomEffects);
+        assert!(unanalyzed.has_random_effects());
+        assert!(unanalyzed._write_descrs_fields.is_none());
+        assert_eq!(unanalyzed, default_effect_info());
+        assert_ne!(can_raise, unanalyzed);
     }
 }

--- a/majit/majit-metainterp/src/jitcode/assembler.rs
+++ b/majit/majit-metainterp/src/jitcode/assembler.rs
@@ -2944,13 +2944,10 @@ impl JitCodeBuilder {
     ) {
         // pyjitpl.py:2655 do_residual_call invalidates the heapcache from
         // descriptor effects before recording the call. `default_effect_info()`
-        // returns the PyPy `call.py:300-301` `EF_CAN_RAISE` shape with empty
-        // raw sets (`effectinfo.py:293-299` else-branch) + empty bitstrings +
-        // `can_collect=true`, matching the analyzer-empty external-call
-        // outcome (`graphanalyze.py:60 bottom_result()`). Using
-        // `EffectInfo::default()` (also empty) would drop the `CanRaise`
-        // extraeffect, suppressing the `GUARD_NO_EXCEPTION` the walker emits
-        // per `effectinfo.py:236 check_can_raise()`.
+        // returns `EffectInfo::MOST_GENERAL`, the `graphanalyze.py:109-112`
+        // no-analyzed-graph outcome; `check_can_raise()`
+        // (`effectinfo.py:236 extraeffect > EF_CANNOT_RAISE`) stays true so
+        // the walker keeps emitting `GUARD_NO_EXCEPTION`.
         self.residual_call_void_canonical_via_target_with_effect_info(
             fn_ptr_idx,
             arg_regs,
@@ -3614,8 +3611,8 @@ impl JitCodeBuilder {
             majit_ir::descr::EffectInfo {
                 // effectinfo.py:149-155: `EF_RANDOM_EFFECTS` keeps every
                 // readonly/write descr set as `None`; spread MOST_GENERAL
-                // for the wildcard rather than `default_effect_info()`'s
-                // saturated `Some(vec![0xff; 8])` bitstrings.
+                // directly so the `call_release_gil_target` sentinel below
+                // rides on the same constant.
                 // `(1, 0)` is the unresolved sentinel — the inner
                 // `emit_canonical_call_*_via_target` helper looks up the
                 // `JitCallTarget` from `descrs[fn_ptr_idx]` and calls
@@ -3743,8 +3740,8 @@ impl JitCodeBuilder {
             majit_ir::descr::EffectInfo {
                 // effectinfo.py:149-155: `EF_RANDOM_EFFECTS` keeps every
                 // readonly/write descr set as `None`; spread MOST_GENERAL
-                // for the wildcard rather than `default_effect_info()`'s
-                // saturated `Some(vec![0xff; 8])` bitstrings.
+                // directly so the `call_release_gil_target` sentinel below
+                // rides on the same constant.
                 // `(1, 0)` is the unresolved sentinel — the inner
                 // `emit_canonical_call_*_via_target` helper looks up the
                 // `JitCallTarget` from `descrs[fn_ptr_idx]` and calls

--- a/majit/majit-metainterp/src/jitcode/assembler.rs
+++ b/majit/majit-metainterp/src/jitcode/assembler.rs
@@ -2937,21 +2937,43 @@ impl JitCodeBuilder {
     /// ()
     /// route through this adapter so callers do not have to thread
     /// `concrete_ptr` and `BhCallDescr` separately.
+    /// `call.py:282-303 getcalldescr`'s per-callee `extraeffect` for the
+    /// target at `fn_ptr_idx`.
+    ///
+    /// The producer already stamped its classification onto the
+    /// `JitCallTarget` (`add_call_target_with_save_err` /
+    /// `add_fn_ptr_with_slot`), so the residual descr reads that slot
+    /// instead of inventing a row here: a hand-classified
+    /// `#[dont_look_inside]` helper keeps `EF_CAN_RAISE`, while a helper
+    /// registered as [`crate::call_descr::EffectInfoSlot::Unanalyzed`]
+    /// keeps `MOST_GENERAL`. A `fn_ptr_idx` that is not a call target is
+    /// left to the `_with_effect_info` sibling's own panic.
+    fn effect_info_for_target(&self, fn_ptr_idx: u16) -> majit_ir::descr::EffectInfo {
+        match self.descrs.get(fn_ptr_idx as usize) {
+            Some(RuntimeBhDescr::Call(target)) => {
+                crate::call_descr::effect_info_for_slot(target.effect_info_slot)
+            }
+            _ => crate::call_descr::default_effect_info(),
+        }
+    }
+
     pub fn residual_call_void_canonical_via_target(
         &mut self,
         fn_ptr_idx: u16,
         arg_regs: &[JitCallArg],
     ) {
         // pyjitpl.py:2655 do_residual_call invalidates the heapcache from
-        // descriptor effects before recording the call. `default_effect_info()`
-        // returns `EffectInfo::MOST_GENERAL`, the `graphanalyze.py:109-112`
-        // no-analyzed-graph outcome; `check_can_raise()`
-        // (`effectinfo.py:236 extraeffect > EF_CANNOT_RAISE`) stays true so
-        // the walker keeps emitting `GUARD_NO_EXCEPTION`.
+        // descriptor effects before recording the call, so the descr must
+        // carry the callee's own classification —
+        // `effect_info_for_target`. `check_can_raise()`
+        // (`effectinfo.py:236 extraeffect > EF_CANNOT_RAISE`) holds for
+        // every row it can return, so the walker keeps emitting
+        // `GUARD_NO_EXCEPTION`.
+        let effect_info = self.effect_info_for_target(fn_ptr_idx);
         self.residual_call_void_canonical_via_target_with_effect_info(
             fn_ptr_idx,
             arg_regs,
-            crate::call_descr::default_effect_info(),
+            effect_info,
         );
     }
 
@@ -3359,11 +3381,12 @@ impl JitCodeBuilder {
         arg_regs: &[JitCallArg],
         dst: u16,
     ) {
+        let effect_info = self.effect_info_for_target(fn_ptr_idx);
         self.residual_call_int_canonical_via_target_with_effect_info(
             fn_ptr_idx,
             arg_regs,
             dst,
-            crate::call_descr::default_effect_info(),
+            effect_info,
         );
     }
 
@@ -3400,11 +3423,12 @@ impl JitCodeBuilder {
         arg_regs: &[JitCallArg],
         dst: u16,
     ) {
+        let effect_info = self.effect_info_for_target(fn_ptr_idx);
         self.residual_call_ref_canonical_via_target_with_effect_info(
             fn_ptr_idx,
             arg_regs,
             dst,
-            crate::call_descr::default_effect_info(),
+            effect_info,
         );
     }
 
@@ -3511,11 +3535,12 @@ impl JitCodeBuilder {
         arg_regs: &[JitCallArg],
         dst: u16,
     ) {
+        let effect_info = self.effect_info_for_target(fn_ptr_idx);
         self.residual_call_float_canonical_via_target_with_effect_info(
             fn_ptr_idx,
             arg_regs,
             dst,
-            crate::call_descr::default_effect_info(),
+            effect_info,
         );
     }
 

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -4839,6 +4839,34 @@ impl<S: JitState> JitDriver<S> {
         self.meta.has_compiled_loop(green_key)
     }
 
+    /// Whether the warm-entry runner can actually execute the code at this
+    /// green key. Stronger than `has_compiled_loop`: it also requires a
+    /// frontend `compiled_loops` meta (`get_compiled_meta`).
+    ///
+    /// `has_compiled_loop` is true whenever the cell's procedure token has a
+    /// compiled backend body (`warmstate.py:482-511` gates entry on code
+    /// presence). That includes a `compile_tmp_callback` token
+    /// (`compile.py:1101-1150`): a CALL_ASSEMBLER fallback stub with a real
+    /// body but NO frontend meta, since MetaInterp never inserts it into
+    /// `compiled_loops`. RPython's `execute_assembler` can enter such a token
+    /// directly — the stub bounces control back to the interpreter
+    /// (ContinueRunningNormally). Pyre's warm-entry runner instead needs the
+    /// `compiled_loops` meta to interpret guard-failure exit layouts, so
+    /// entering a bare tmp callback here has no meta and aborts.
+    ///
+    /// Gating warm-entry dispatch on this predicate lets a tmp-only cell fall
+    /// through to the counter tick / trace-start, which is the pyre-orthodox
+    /// realization of the tmp-callback → resume-interp semantics: the back-edge
+    /// counter keeps ticking until the real loop compiles (a `compiled_loops`
+    /// entry appears) and `redirect_call_assembler` takes over. Entry bridges
+    /// (`ResumeFromInterpDescr`, `compile.py:1079-1083`) DO get a
+    /// `compiled_loops` entry despite carrying 0 target tokens, so they remain
+    /// dispatchable — this predicate only excludes bare tmp callbacks.
+    #[inline]
+    pub fn has_runnable_compiled_loop(&self, green_key: u64) -> bool {
+        self.has_compiled_loop(green_key) && self.meta.get_compiled_meta(green_key).is_some()
+    }
+
     /// Actual key the last compile_loop stored under.
     pub fn last_compiled_key(&self) -> Option<u64> {
         self.meta.last_compiled_key()

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -114,17 +114,17 @@ fn bh_jitdrivers_sd(
 /// null to leave it unset. A non-null vinfo lets the blackhole run a mid-body
 /// vable-array op (e.g. the `int_*_jump_if_ovf` overflow guard on a `[int; virt]`
 /// state field). Seed when either the portal-inline experiment is on, or the
-/// machine is a state-field one (`token_offset == 0`) whose `bh_clear_vable_token`
-/// is inert so a non-null vinfo cannot corrupt its non-GC `state` struct. A real
-/// heap virtualizable (`token_offset > 0`, e.g. PyFrame) is left with null vinfo
-/// to preserve its existing resume contract.
+/// machine is a state-field one (no `vable_token` field) whose
+/// `bh_clear_vable_token` is inert so a non-null vinfo cannot corrupt its non-GC
+/// `state` struct. A real heap virtualizable (e.g. PyFrame) is left with null
+/// vinfo to preserve its existing resume contract.
 fn seed_deopt_vinfo_ptr(
     vinfo: Option<&std::sync::Arc<crate::virtualizable::VirtualizableInfo>>,
 ) -> *const crate::virtualizable::VirtualizableInfo {
     match vinfo {
         Some(info)
             if crate::pyjitpl::dispatch::portal_inline_experiment_enabled()
-                || info.token_offset == 0 =>
+                || !info.has_vable_token() =>
         {
             std::sync::Arc::as_ptr(info)
         }
@@ -3641,7 +3641,7 @@ impl<S: JitState> JitDriver<S> {
                     // `setarrayitem_vable`) can resolve its vinfo during resume.
                     // Two sources:
                     //   * the portal-inline experiment (gated), OR
-                    //   * a state-field machine (`token_offset == 0`), whose
+                    //   * a state-field machine (no `vable_token` field), whose
                     //     `bh_clear_vable_token` is inert (the `state` struct has
                     //     no heap token), so a non-null vinfo cannot corrupt it.
                     //     The overflow-guard deopt (`int_*_jump_if_ovf` on the
@@ -6070,22 +6070,22 @@ mod tests {
     use majit_ir::{GcRef, OpCode, OpRef, Type, Value};
 
     // `seed_deopt_vinfo_ptr` decides which guard-failure deopts hand the blackhole
-    // a non-null `bh.virtualizable_info`. A state-field machine (`token_offset == 0`)
+    // a non-null `bh.virtualizable_info`. A state-field machine (no `vable_token`)
     // must be seeded so a mid-body vable-array op — the `int_*_jump_if_ovf` overflow
     // guard on a `[int; virt]` field — resolves its vinfo during resume instead of
-    // panicking. A real heap virtualizable (`token_offset > 0`, e.g. PyFrame) keeps
-    // the prior null-vinfo resume contract unless the portal-inline experiment is on.
+    // panicking. A real heap virtualizable (e.g. PyFrame) keeps the prior
+    // null-vinfo resume contract unless the portal-inline experiment is on.
     #[test]
     fn seed_deopt_vinfo_ptr_seeds_state_field_and_skips_heap_virtualizable() {
         use crate::virtualizable::VirtualizableInfo;
 
-        // token_offset == 0 → seed the reconstructed vinfo pointer (always, since
+        // no vable_token → seed the reconstructed vinfo pointer (always, since
         // its `bh_clear_vable_token` is inert and cannot corrupt the state struct).
-        let state_field = std::sync::Arc::new(VirtualizableInfo::new(0));
+        let state_field = std::sync::Arc::new(VirtualizableInfo::without_vable_token());
         assert_eq!(
             seed_deopt_vinfo_ptr(Some(&state_field)),
             std::sync::Arc::as_ptr(&state_field),
-            "a token_offset==0 state-field machine must seed a non-null vinfo",
+            "a state-field machine with no vable_token must seed a non-null vinfo",
         );
 
         // No vinfo available → null.

--- a/majit/majit-metainterp/src/optimizeopt/heap.rs
+++ b/majit/majit-metainterp/src/optimizeopt/heap.rs
@@ -1939,26 +1939,23 @@ impl OptHeap {
             // `!compute_bitstrings_has_run()` so the translated interpreter's
             // bitstring path is unchanged.
             //
-            // STRUCTURAL ADAPTATION (no heap.py analog): upstream every
-            // cached descr is inside the `compute_bitstrings` universe, so
-            // the bitcheck is total.  Pyre also caches RUNTIME-minted
-            // descrs (`ei_index` unset even after bitstrings ran — e.g.
-            // the module-global cell fold's mutable
-            // `ObjectMutableCell.w_value`).  No call's write bitstring can
-            // ever name such a descr, so a bitcheck miss proves nothing;
-            // treating it as "not written" let a namespace-store residual
-            // (analyzed write set, which cannot include the runtime descr)
-            // keep the getfield cache and re-read a stale global
-            // (`acc = acc + a; acc = acc + b` at module level dropped the
-            // first term).  A mutable out-of-universe descr is therefore
-            // conservatively invalidated by every non-elidable call — but
-            // only once bitstrings have run: before that, a u32::MAX
-            // `effect_idx` just means the fixture never stamped the slot, so
-            // the identity fallback below is the correct arbiter.
+            // A descr whose `ei_index` is still the sentinel is NOT special-
+            // cased here, matching `heap.py:537-553`. Upstream leaves the
+            // sentinel on any descr that no EffectInfo's raw set names —
+            // `effectinfo.py:495-496` stamps `sys.maxint` on every descr in
+            // `all_descrs` and only `:524-526` renumbers the ones that appear
+            // in some `_readonly_descrs_*` / `_write_descrs_*`, which
+            // `test_effectinfo.py:172,176` pins with `f3descr`. A sentinel
+            // descr therefore bitchecks false upstream too. That is sound
+            // because of the OTHER half of the contract: a call whose write
+            // set was never computed is `EF_RANDOM_EFFECTS`
+            // (`graphanalyze.py:109-112 top_result()` →
+            // `effectinfo.py:285-292`) and never reaches this function at all
+            // — `heap.py:460` routes it to `clean_caches`. pyre upholds the
+            // same contract at `call_descr.rs default_effect_info()`; keeping
+            // a descr-side guard here instead would be papering over any call
+            // that still asserts an empty write set it did not earn.
             let writes_field = ei.check_write_descr_field(effect_idx)
-                || (majit_ir::effectinfo::compute_bitstrings_has_run()
-                    && effect_idx == u32::MAX
-                    && !descr.is_always_pure())
                 || (!majit_ir::effectinfo::compute_bitstrings_has_run()
                     && ei.writes_field_descr_by_identity(&descr));
             if writes_field {
@@ -1986,14 +1983,9 @@ impl OptHeap {
             .collect();
         for (descr_idx, descr, effect_idx) in array_descrs {
             let read = ei.check_readonly_descr_array(effect_idx);
-            // See the field loop above: a RUNTIME-minted array descr
-            // (`ei_index` unset) is outside the bitstring universe, so no
-            // call's write bitstring can name it — conservatively treat
-            // every non-elidable call as writing it.
-            let write = ei.check_write_descr_array(effect_idx)
-                || (majit_ir::effectinfo::compute_bitstrings_has_run()
-                    && effect_idx == u32::MAX
-                    && !descr.is_always_pure());
+            // heap.py:556 — no sentinel special case, for the reason given
+            // in the field loop above.
+            let write = ei.check_write_descr_array(effect_idx);
             if !read && !write {
                 continue;
             }
@@ -3502,14 +3494,27 @@ impl Optimization for OptHeap {
             .collect();
         sort_descr_item_refs_untranslated(&mut field_entries);
         for (descr, (field_idx, cf)) in field_entries {
+            // NOT heap.py:370-372, which has no filter here.
+            //
+            // Hoisting a cached MUTABLE field into the peeled loop's label is
+            // only sound if the back-edge re-supplies it. `shortpreamble.py:465-476
+            // ExtendedShortPreambleBuilder.add_preamble_op` appends
+            // `preamble_op.op` to the label args and `preamble_op.preamble_op` —
+            // the RE-EXECUTED operation — to the jump args, so upstream re-reads
+            // the field each iteration. pyre's peeled body currently passes the
+            // ENTRY value straight back: with this filter removed,
+            // `pyre/bench/synth/callee_store_global_read_after_call.py` emits
+            // `v245 = SameAsI(<preamble getfield IntMutableCell.intvalue>)` and
+            // `Jump(..., v245)`, so a global a residual call mutates every
+            // iteration is treated as loop-invariant (316836 vs 240008).
+            // `is_always_pure()` descrs are exempt because re-reading them cannot
+            // observe a change. Remove this once the back-edge supplies the
+            // re-executed op.
             let effect_idx = Self::field_effect_index(descr);
             if majit_ir::effectinfo::compute_bitstrings_has_run()
                 && effect_idx == u32::MAX
                 && !descr.is_always_pure()
             {
-                // Match force_from_effectinfo's conservatism for mutable
-                // descrs outside the bitstring universe: a residual call may
-                // write them, so they must be read live in each peeled body.
                 continue;
             }
             cf.produce_potential_short_preamble_ops(sb, descr, field_idx, ctx);
@@ -3519,12 +3524,12 @@ impl Optimization for OptHeap {
         //         for index, d in submap.const_indexes.items():
         //             d.produce_potential_short_preamble_ops(self.optimizer, sb, descr, index)
         for (_, descr, submap) in &self.cached_arrayitems {
+            // Same back-edge gap as the field loop above, for array items.
             let effect_idx = Self::array_effect_index(descr);
             if majit_ir::effectinfo::compute_bitstrings_has_run()
                 && effect_idx == u32::MAX
                 && !descr.is_always_pure()
             {
-                // Same rule for runtime-minted mutable array descrs.
                 continue;
             }
             for (_, cai) in &submap.const_indexes {

--- a/majit/majit-metainterp/src/optimizeopt/virtualize.rs
+++ b/majit/majit-metainterp/src/optimizeopt/virtualize.rs
@@ -4425,8 +4425,9 @@ mod tests {
         // call_has_random_effects` then routes through `clean_caches`,
         // so the per-cached-field flush runs and `setfield_gc` survives
         // in front of the call. The test threads `MOST_GENERAL` directly
-        // to exercise the analyzer-absent path orthogonally to the
-        // production `default_effect_info()` shape.
+        // rather than through `default_effect_info()`, which returns the
+        // same constant, so the assertion stays pinned to the shape
+        // under test.
         let sd = size_descr(2);
         let fd = field_descr(11);
         let call_descr = crate::call_descr::make_call_descr_with_effect(

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -13926,6 +13926,13 @@ impl<M: Clone> MetaInterp<M> {
             Some(info) => info,
             None => return,
         };
+        // A machine with no `vable_token` field (`has_vable_token`) has nowhere
+        // to publish the force token: its `token_field_descr` resolves to offset
+        // 0, the struct's first live field, so recording the SETFIELD would make
+        // the compiled loop overwrite that field on every residual call.
+        if !vinfo.has_vable_token() {
+            return;
+        }
         let vable_ptr = self.vable_ptr;
         let ctx = match self.tracing.as_mut() {
             Some(ctx) => ctx,

--- a/majit/majit-metainterp/src/virtualizable.rs
+++ b/majit/majit-metainterp/src/virtualizable.rs
@@ -146,8 +146,19 @@ pub struct VirtualizableInfo {
     pub static_fields: Vec<VableFieldInfo>,
     /// Array fields on the virtualizable (e.g., `locals_w`).
     pub array_fields: Vec<VableArrayInfo>,
-    /// Offset of the `vable_token` field in the heap object.
+    /// Offset of the `vable_token` field in the heap object. Meaningless
+    /// unless `has_vable_token` — see [`VirtualizableInfo::has_vable_token`].
     pub token_offset: usize,
+    /// Whether the host object actually carries a `vable_token` field.
+    ///
+    /// `virtualizable.py:28` reads `vable_token` off every VTYPE, so
+    /// upstream has no false case. Pyre's state-field machines do: the
+    /// `#[jit_interp]` `state` struct is a non-GC, stack-resident struct
+    /// the interpreter author declares, with no slot to spare for a token
+    /// — its identity is recovered from the resume snapshot instead. Every
+    /// token read/write must stay inert for those, or it lands on the
+    /// struct's first live field.
+    has_vable_token: bool,
     /// Total number of "boxes" (field slots + array element slots)
     /// that the JIT needs to save/restore for this virtualizable.
     ///
@@ -228,6 +239,7 @@ impl Clone for VirtualizableInfo {
             static_fields: self.static_fields.clone(),
             array_fields: self.array_fields.clone(),
             token_offset: self.token_offset,
+            has_vable_token: self.has_vable_token,
             num_static_extra_boxes: self.num_static_extra_boxes,
             parent_descr: self.parent_descr.clone(),
             array_descrs: self.array_descrs.clone(),
@@ -271,11 +283,25 @@ impl majit_ir::descr::VinfoMarker for VirtualizableInfo {
 impl VirtualizableInfo {
     /// Create a new VirtualizableInfo.
     pub fn new(token_offset: usize) -> Self {
+        Self::with_token(token_offset, true)
+    }
+
+    /// Create a `VirtualizableInfo` for a machine with no `vable_token`
+    /// field — see [`VirtualizableInfo::has_vable_token`]. Its token
+    /// protocol is inert: `tracing_before/after_residual_call`,
+    /// `force_now` and the token read/write pair all no-op instead of
+    /// landing on offset 0.
+    pub fn without_vable_token() -> Self {
+        Self::with_token(0, false)
+    }
+
+    fn with_token(token_offset: usize, has_vable_token: bool) -> Self {
         VirtualizableInfo {
             name: String::new(),
             static_fields: Vec::new(),
             array_fields: Vec::new(),
             token_offset,
+            has_vable_token,
             num_static_extra_boxes: 0,
             parent_descr: None,
             array_descrs: Vec::new(),
@@ -671,6 +697,12 @@ impl VirtualizableInfo {
         self.array_fields.len()
     }
 
+    /// Whether this machine has a real `vable_token` field to operate on.
+    /// False only for [`VirtualizableInfo::without_vable_token`] machines.
+    pub fn has_vable_token(&self) -> bool {
+        self.has_vable_token
+    }
+
     /// Set token to TOKEN_TRACING_RESCALL before a residual call.
     ///
     /// The token tells the runtime that JIT tracing is active and a
@@ -680,6 +712,9 @@ impl VirtualizableInfo {
     /// # Safety
     /// `obj_ptr` must point to a valid virtualizable object.
     pub unsafe fn tracing_before_residual_call(&self, obj_ptr: *mut u8) {
+        if !self.has_vable_token() {
+            return;
+        }
         unsafe {
             // The token is a word-sized (`Signed`) field: 4 bytes on wasm32.
             // The all-ones sentinel truncates to `usize::MAX` at that width.
@@ -697,6 +732,11 @@ impl VirtualizableInfo {
     /// # Safety
     /// `obj_ptr` must point to a valid virtualizable object.
     pub unsafe fn tracing_after_residual_call(&self, obj_ptr: *mut u8) -> bool {
+        // No token to consult: the callee had no way to force this machine's
+        // state, so it is never reported as escaped.
+        if !self.has_vable_token() {
+            return false;
+        }
         unsafe {
             let token_ptr = obj_ptr.add(self.token_offset) as *mut usize;
             if *token_ptr != 0 {
@@ -720,6 +760,9 @@ impl VirtualizableInfo {
     /// # Safety
     /// `obj_ptr` must point to a valid virtualizable object.
     pub unsafe fn force_now(&self, obj_ptr: *mut u8, force_fn: impl FnOnce(u64)) {
+        if !self.has_vable_token() {
+            return;
+        }
         unsafe {
             let token_ptr = obj_ptr.add(self.token_offset) as *mut usize;
             let token = *token_ptr;
@@ -739,6 +782,9 @@ impl VirtualizableInfo {
     /// # Safety
     /// `obj_ptr` must point to a valid virtualizable object.
     pub unsafe fn read_token(&self, obj_ptr: *const u8) -> VableToken {
+        if !self.has_vable_token() {
+            return VableToken::None;
+        }
         unsafe {
             let token_ptr = obj_ptr.add(self.token_offset) as *const usize;
             let raw = *token_ptr;
@@ -759,6 +805,9 @@ impl VirtualizableInfo {
     /// # Safety
     /// `obj_ptr` must point to a valid virtualizable object.
     pub unsafe fn write_token(&self, obj_ptr: *mut u8, token: VableToken) {
+        if !self.has_vable_token() {
+            return;
+        }
         unsafe {
             let token_ptr = obj_ptr.add(self.token_offset) as *mut usize;
             *token_ptr = token.to_raw() as usize;
@@ -2906,15 +2955,10 @@ pub(crate) unsafe fn vable_write_array_item(
 /// # Safety
 /// `obj_ptr` must point to a valid virtualizable object.
 pub(crate) unsafe fn bh_clear_vable_token(vinfo: &VirtualizableInfo, obj_ptr: *mut u8) {
-    // `token_offset == 0` marks a machine with no real `vable_token` field: a
-    // non-GC, stack-resident `state` struct whose identity is recovered straight
-    // from the resume snapshot rather than via a heap token (see the state-field
-    // `VirtualizableInfo::new(0)` in the `#[jit_interp]` codegen). Offset 0 on a
-    // GC virtualizable is always the type pointer, so a real `vable_token` never
-    // lands there (`PYFRAME_VABLE_TOKEN_OFFSET > 0`). Writing to offset 0 here
-    // would clobber the struct's first field (e.g. a `Vec`'s data pointer), so
-    // honor the documented "inert token protocol" and do nothing.
-    if vinfo.token_offset == 0 {
+    // A machine with no real `vable_token` field (`has_vable_token`) keeps an
+    // inert token protocol: writing to offset 0 would clobber the struct's
+    // first live field (e.g. a `Vec`'s data pointer).
+    if !vinfo.has_vable_token() {
         return;
     }
     unsafe {
@@ -3021,18 +3065,18 @@ mod bh_clear_vable_token_inert_token_protocol {
         token: usize,
     }
 
-    // A state-field machine builds `VirtualizableInfo::new(0)`: there is no heap
-    // `vable_token`, so `token_offset == 0`. Clearing must be inert — writing to
-    // offset 0 would clobber the live first field. This is the guard that lets
+    // A state-field machine builds `VirtualizableInfo::without_vable_token()`:
+    // there is no heap `vable_token` to clear. Clearing must be inert — writing
+    // to offset 0 would clobber the live first field. This is the guard that lets
     // the overflow-deopt blackhole run a `[int; virt]` vable op without corrupting
     // the state struct.
     #[test]
-    fn clear_is_inert_when_token_offset_is_zero() {
+    fn clear_is_inert_when_the_machine_has_no_vable_token() {
         let mut probe = TokenProbe {
             first: 0xDEAD_BEEF,
             token: 0x1234,
         };
-        let info = VirtualizableInfo::new(0);
+        let info = VirtualizableInfo::without_vable_token();
         let p = (&mut probe as *mut TokenProbe) as *mut u8;
         unsafe { bh_clear_vable_token(&info, p) };
         assert_eq!(probe.first, 0xDEAD_BEEF, "offset-0 field must be untouched");

--- a/pyre/pyre-jit-trace/src/descr.rs
+++ b/pyre/pyre-jit-trace/src/descr.rs
@@ -704,7 +704,7 @@ fn build_object_descr_group_with_def_path(
             .iter()
             .any(|fd| fd.offset() == pyre_object::pyobject::W_CLASS_OFFSET)
         {
-            gc_fielddescrs.push(new_w_class_field_descr());
+            gc_fielddescrs.push(W_CLASS_FIELD_DESCR.clone());
         }
         // `descr.py:108-118 get_size_descr` cache key — `path_hash`로
         // 만들어진 lltype-object identity.  Prefer the canonical
@@ -1774,8 +1774,19 @@ fn new_w_class_field_descr() -> Arc<dyn FieldDescr> {
     })
 }
 
+/// The single `w_class` field descriptor for the shared `PyObject` header.
+///
+/// `descr.py:218-239 get_field_descr` caches on `(STRUCT, fieldname)`, so a
+/// given field is one object for the whole run and every consumer compares it
+/// by identity: `heap.py` keys `cached_fields` by the descriptor itself
+/// (`heap.rs:860 cached_field_pos_for_descr` matches on `descr_identity`), and
+/// so do the short-preamble export and `force_from_effectinfo`. Minting a
+/// fresh `Arc` per call gave each `w_class` read in a trace its own identity,
+/// so two reads of the same header could never share a cache entry.
+static W_CLASS_FIELD_DESCR: LazyLock<Arc<dyn FieldDescr>> = LazyLock::new(new_w_class_field_descr);
+
 pub fn w_class_descr() -> DescrRef {
-    new_w_class_field_descr()
+    W_CLASS_FIELD_DESCR.clone() as DescrRef
 }
 
 /// Alias for backward compatibility — same as w_class_descr().
@@ -2160,7 +2171,16 @@ pub fn str_len_descr() -> DescrRef {
 
 /// Field descriptor for ob_type (PyObject.ob_type pointer) — immutable.
 /// heaptracker.py:66: `if name == 'typeptr': continue`
+///
+/// One object per run, for the identity reason documented on
+/// [`W_CLASS_FIELD_DESCR`].
+static OB_TYPE_FIELD_DESCR: LazyLock<Arc<dyn FieldDescr>> = LazyLock::new(new_ob_type_field_descr);
+
 pub fn ob_type_descr() -> DescrRef {
+    OB_TYPE_FIELD_DESCR.clone() as DescrRef
+}
+
+fn new_ob_type_field_descr() -> Arc<dyn FieldDescr> {
     Arc::new(PyreFieldDescr {
         offset: OB_TYPE_OFFSET,
         field_size: 8,

--- a/pyre/pyre-jit-trace/src/helpers.rs
+++ b/pyre/pyre-jit-trace/src/helpers.rs
@@ -41,10 +41,9 @@ pub fn emit_trace_call_int_typed(
     // virtualizable / quasi-immut analyzers; the gap is the trace-side
     // plumbing — pyre-jit-trace helpers live outside the codewriter
     // pipeline so the analyzer's per-callee EI never reaches this
-    // emit site. Until per-helper EI registration lands,
-    // fall back to the conservative `default_effect_info()`
-    // (≡ `effectinfo.MOST_GENERAL` for unanalyzed callees: CanRaise +
-    // all-writes-set bitmasks).
+    // emit site. Until per-helper EI registration lands, the callee is
+    // `graphanalyze.py:109-112`'s no-graph case, so
+    // `default_effect_info()` hands out `effectinfo.MOST_GENERAL`.
     ctx.call_int_typed_with_effect(helper, args, arg_types, default_effect_info())
 }
 
@@ -65,9 +64,8 @@ pub fn emit_trace_call_float_typed(
 /// exc=False, pure=True)` parity for direct trace emit paths.
 ///
 /// `emit_trace_call_int_typed` calls into the tracer with
-/// `default_effect_info()` (`effectinfo.MOST_GENERAL`, CanRaise +
-/// all-writes-set), so even an `#[elidable_cannot_raise]` callee is
-/// recorded as a plain `CallI`.  This wrapper threads an explicit
+/// `default_effect_info()` (`effectinfo.MOST_GENERAL`), so even an
+/// `#[elidable_cannot_raise]` callee is recorded as a plain `CallI`.  This wrapper threads an explicit
 /// `ElidableCannotRaise` `EffectInfo` through
 /// `record_result_of_call_pure` (`pyjitpl.py:3553-3579`) and patches the
 /// trace to `CallPureI`.

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
@@ -1940,8 +1940,21 @@ pub(crate) fn try_walker_specialize_store_attr<Sym: WalkSym>(
         };
         let helper = ctx.trace_ctx.const_int(helper_fn as usize as i64);
 
-        let mut effect = original_effect.clone();
-        effect.extraeffect = majit_ir::ExtraEffect::CannotRaise;
+        // `original_effect` is the generic setattr residual's
+        // `EF_RANDOM_EFFECTS`, whose six raw sets and six bitstrings are
+        // all `None` (`effectinfo.py:149-155`). Cloning it and lowering
+        // only `extraeffect` would build the "non-random + raw=None"
+        // shape `effectinfo.py:149-162` asserts against, and
+        // `check_write_descr_field` would then unwrap a `None`
+        // bitstring. Build the downgraded effect from scratch so the
+        // sets match the extraeffect: the raw slot write cannot raise,
+        // and it touches no field or array descr the heap cache holds
+        // (the storage is reached only through this helper pair, never
+        // through `getfield_gc` / `getarrayitem_gc`).
+        let mut effect = majit_ir::EffectInfo::const_new(
+            majit_ir::ExtraEffect::CannotRaise,
+            majit_ir::OopSpecIndex::None,
+        );
         effect.pyre_helper = majit_ir::PyreHelperKind::StoreAttr;
         let descr = majit_metainterp::make_call_descr_with_effect(
             &[

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -2937,14 +2937,17 @@ fn run_perfn_walk<Sym: WalkSym>(
     // rather than rewinding the live frame to the guard pc and re-running the
     // region through the `ContinueRunningNormally` re-entry — which would
     // execute every residual a second time and double-apply any
-    // callee-internal side effect (#177).  The tracer arms it for any
-    // single-frame resume: the general guard path consumes the kept stash as
-    // a terminal `BridgeResolution`, and the CALL_ASSEMBLER callback hands it
-    // to its back-to-back blackhole hook, so a committed journal never
-    // strands into a guard-state re-run; the three decisions (this
-    // predicate, the journal commit below, and the caller's
-    // consume-vs-rewind) stay in agreement.  A multiframe resume is never
-    // armed, so it stays on the legacy rewind-and-replay path.
+    // callee-internal side effect (#177).  The general guard path consumes
+    // the kept stash as a terminal `BridgeResolution` and so arms any resume,
+    // single- or multi-frame — `Terminate` is always the LIVE frame's return
+    // (an inlined callee's return is a `SubReturn` inside the walk), so its
+    // concrete result is what that frame hands its caller either way.  The
+    // CALL_ASSEMBLER callback routes the stash through a back-to-back
+    // blackhole hook that reconstructs a single live frame, so it arms only
+    // single-frame resumes and leaves multiframe ones on the rewind-and-replay
+    // path.  Either way a committed journal never strands into a guard-state
+    // re-run: the three decisions (this predicate, the journal commit below,
+    // and the caller's consume-vs-rewind) stay in agreement.
     let terminate_no_replay = (!is_bridge_trace
         || crate::jitcode_dispatch::fbw_bridge_noreplay_armed())
         && matches!(

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -3097,17 +3097,30 @@ pub fn trace_and_compile_from_bridge(
     let trace_frame = frame.snapshot_for_tracing();
     let live_frame_addr = frame as *const PyFrame as usize;
     let mut adopted_walk_end_state = false;
-    // Arm the bridge `Terminate` no-replay shortcut for this walk whenever
-    // the resume is single-frame.  The walk epilogue (`run_perfn_walk` in
-    // trace.rs) reads this flag: only when armed does a bridge `Terminate`
-    // walk keep its finish-concrete stash + commit the store journal, so the
-    // three decisions (epilogue predicate, journal commit, the
-    // consume-vs-rewind below) stay in agreement and a committed journal
-    // never strands into a blackhole re-run.  Both callers can consume the
-    // kept stash: the general guard path returns it as a terminal
-    // `BridgeResolution`, and the CALL_ASSEMBLER callback hands it to the
-    // back-to-back blackhole hook via `CA_WALK_FINISHED_FRAME`.
-    let bridge_noreplay_armed = !is_multiframe_resume;
+    // Arm the bridge `Terminate` no-replay shortcut for this walk.  The walk
+    // epilogue (`run_perfn_walk` in trace.rs) reads this flag: only when armed
+    // does a bridge `Terminate` walk keep its finish-concrete stash + commit
+    // the store journal, so the three decisions (epilogue predicate, journal
+    // commit, the consume-vs-rewind below) stay in agreement and a committed
+    // journal never strands into a blackhole re-run.
+    //
+    // `pyjitpl.py:2947` `interpret()` "should always raise": a resumed trace
+    // that runs its frames forward to a return raises `DoneWithThisFrame`
+    // from the POST-walk state, whatever the resume's frame count — there is
+    // no rewind-to-the-deadframe re-run upstream.  A multi-frame resume walks
+    // the inlined callees to `SubReturn` and only the LIVE frame's return
+    // raises `Terminate`, so its finish-concrete is that frame's result, the
+    // same value the blackhole rebuild would produce.  Replaying instead
+    // re-executes every residual the walk already ran concretely and
+    // double-applies its callee-internal side effects (`Counter.bump()`'s
+    // `self.pos += 1` counted twice in
+    // `bench/synth/nested_callee_chain_mutation_abort.py`).
+    //
+    // The CALL_ASSEMBLER callback (`allow_finish_direct_return == false`)
+    // hands a kept stash to its back-to-back blackhole hook through
+    // `CA_WALK_FINISHED_FRAME`, which reconstructs one live frame; keep that
+    // caller on the single-frame arming it already had.
+    let bridge_noreplay_armed = allow_finish_direct_return || !is_multiframe_resume;
     pyre_jit_trace::jitcode_dispatch::fbw_bridge_noreplay_arm(bridge_noreplay_armed);
     let outcome = {
         let (driver, _) = crate::eval::driver_pair();
@@ -3200,15 +3213,10 @@ pub fn trace_and_compile_from_bridge(
     }
     match pyre_jit_trace::jitcode_dispatch::fbw_finish_concrete_take() {
         Some(pyre_jit_trace::jitcode_dispatch::FinishConcrete::Return(cv)) => {
-            // `bridge_noreplay_armed` folds in `!is_multiframe_resume`, so a kept
-            // stash implies a single real live PyFrame: the `Terminate` is the
-            // live frame's function return, about to be popped by its caller with
-            // `cv`.  No rewind, no blackhole.
-            debug_assert!(
-                !is_multiframe_resume,
-                "bridge Terminate no-replay stash kept for a multiframe resume \
-                 (frames={num_resume_frames})"
-            );
+            // `Terminate` is the LIVE frame's function return, about to be
+            // popped by its caller with `cv`; any inlined callee the resume
+            // reconstructed already returned inside the walk.  No rewind, no
+            // blackhole.
             if majit_metainterp::majit_log_enabled() {
                 eprintln!(
                     "[jit][bridge-trace] finish-noreplay at resume_pc={} key={}",
@@ -3218,11 +3226,6 @@ pub fn trace_and_compile_from_bridge(
             return BridgeResolution::Finished(cv);
         }
         Some(pyre_jit_trace::jitcode_dispatch::FinishConcrete::Raise(cv)) => {
-            debug_assert!(
-                !is_multiframe_resume,
-                "bridge Terminate no-replay raise kept for a multiframe resume \
-                 (frames={num_resume_frames})"
-            );
             // jitexc.py:44: hand the walk's uncaught exception to the
             // guard's portal as ExitFrameWithExceptionRef.
             return BridgeResolution::FinishedException(cv);
@@ -3244,9 +3247,11 @@ pub fn trace_and_compile_from_bridge(
     // THIS iteration through the blackhole, which rebuilds the full inlined
     // framestack and runs it — exactly as a cold multi-frame guard does.
     // Signalled by returning `false` (→ `handle_fail` ResumeInBlackhole) even
-    // though the bridge compiled. The walk took the non-flush path, so it
-    // committed no side effects; the blackhole re-running the resumed region
-    // applies them exactly once.
+    // though the bridge compiled. The walk took the non-flush path, so its
+    // store journal was rolled back; a residual it executed concretely is not
+    // in that journal, so the blackhole re-run applies such an effect twice —
+    // the `Terminate` no-replay shortcut above is what keeps a returning walk
+    // off this path.
     // The non-flush path applies to single-frame guards too: without the
     // committed walk-end state the live frame's last_instr / operand stack
     // were never advanced through the guard's resume region (only the

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -6613,8 +6613,13 @@ fn maybe_compile_and_run(
     }
     // warmstate.py:503-511: procedure_token exists → EnterJitAssembler.
     // RPython enters assembler unconditionally when a compiled loop is
-    // available for this green_key.
-    if driver.has_compiled_loop(green_key) {
+    // available for this green_key. Pyre gates on `has_runnable_compiled_loop`
+    // (not `has_compiled_loop`) so a bare `compile_tmp_callback` token — which
+    // has a compiled body but no `compiled_loops` meta — falls through to the
+    // counter tick below instead of entering `execute_assembler` with no meta
+    // to interpret its exit (which aborts). The tmp cell then re-ticks until
+    // the real loop compiles.
+    if driver.has_runnable_compiled_loop(green_key) {
         return execute_assembler(frame, green_key, loop_header_pc, driver, info, env);
     }
     // Pyre-local deviation: this short-circuit treats `DONT_TRACE_HERE` as a
@@ -7511,7 +7516,7 @@ fn bound_reached(
     {
         return None;
     }
-    if !driver.has_compiled_loop(green_key) && !driver.is_tracing() {
+    if !driver.has_runnable_compiled_loop(green_key) && !driver.is_tracing() {
         return compile_and_run_once(
             frame_root.frame(),
             green_key,
@@ -7523,7 +7528,7 @@ fn bound_reached(
         );
     }
     // warmstate.py:503-511: procedure_token → EnterJitAssembler.
-    let outcome = if driver.has_compiled_loop(green_key) {
+    let outcome = if driver.has_runnable_compiled_loop(green_key) {
         let _frame_locals_root = FrameLocalsRoot::new(frame_root.frame());
         Some(driver.run_compiled_detailed_with_bridge_keyed(
             green_key,
@@ -7653,8 +7658,11 @@ pub fn try_function_entry_jit(frame: &mut PyFrame) -> Option<PyResult> {
     let (driver, info) = driver_pair();
 
     // RPython warmstate.py maybe_compile_and_run fast path:
-    // if no compiled loop and not tracing, just tick the counter.
-    if !driver.has_compiled_loop(green_key) && !driver.is_tracing() {
+    // if no runnable compiled loop and not tracing, just tick the counter.
+    // A bare `compile_tmp_callback` token (has_compiled_loop true, no
+    // `compiled_loops` meta) is treated as not-yet-runnable so the counter
+    // keeps ticking toward compiling the real loop.
+    if !driver.has_runnable_compiled_loop(green_key) && !driver.is_tracing() {
         let should_trace = driver
             .meta_interp_mut()
             .warm_state_mut()
@@ -7671,9 +7679,10 @@ pub fn try_function_entry_jit(frame: &mut PyFrame) -> Option<PyResult> {
     )) {
         return None;
     }
-    if driver.has_compiled_loop(green_key) {
+    if driver.has_runnable_compiled_loop(green_key) {
         // Same gate as maybe_compile_and_run: only enter compiled code
-        // when a compiled loop exists for this green_key.
+        // when a runnable compiled loop (frontend meta present, not a bare
+        // tmp callback) exists for this green_key.
         // warmstate.py:503-511: procedure_token → enter unconditionally.
         if majit_metainterp::majit_log_enabled() {
             eprintln!(

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -6160,32 +6160,23 @@ fn trace_jit_bytecode(_pc: usize, _instruction_name: &str) {
     // Debug logging disabled — per-bytecode eprintln causes O(n) slowdown.
 }
 
-thread_local! {
-    /// Memoizes `find_loop_header_pcs` per code object.  The loop-header set
-    /// depends only on `code.instructions` (immutable) and the `CodeObject`
-    /// behind `code_ptr` is `Box`-immortal — a stable, never-freed address —
-    /// so the raw pointer is a sound stable key.  Recomputing it on every
-    /// `eval_loop_jit` entry re-scans the whole bytecode and rebuilds the
-    /// successor map for each called function / module-body frame; the loop
-    /// headers are code-invariant (fixed once the codewriter has seen the
-    /// code), so that per-frame O(code) work is pure waste on cold, run-once
-    /// startup code where no frame is entered twice through this loop.
-    static LOOP_HEADER_MEMO: RefCell<HashMap<usize, Rc<VecSet<usize>>>> =
-        RefCell::new(HashMap::new());
-}
-
-/// Cached form of [`crate::jit::codewriter::find_loop_header_pcs`], keyed by
-/// the immortal `CodeObject` address.
-fn cached_loop_header_pcs(code: &pyre_interpreter::CodeObject) -> Rc<VecSet<usize>> {
-    let key = code as *const pyre_interpreter::CodeObject as usize;
-    LOOP_HEADER_MEMO.with(|memo| {
-        if let Some(hit) = memo.borrow().get(&key) {
-            return hit.clone();
-        }
-        let computed = Rc::new(crate::jit::codewriter::find_loop_header_pcs(code));
-        memo.borrow_mut().insert(key, computed.clone());
-        computed
-    })
+/// Loop-header PC set for `code`, from the `CallControl` that owns the
+/// per-graph codewriter caches (call.py:29 `self.jitcodes = {}`).
+///
+/// The set is scanned once per graph and kept there, matching the point in
+/// upstream where loop headers are fixed: `jtransform.py:1714-1723`
+/// rewrites `can_enter_jit` into a `loop_header` operation while the
+/// codewriter builds that graph's `JitCode`, so the running interpreter
+/// only ever reads an already-derived answer. Recomputing the scan per
+/// back-edge would re-walk the whole bytecode and rebuild the successor
+/// map on every loop iteration of every interpreted frame.
+fn cached_loop_header_pcs(code: &pyre_interpreter::CodeObject) -> std::sync::Arc<VecSet<usize>> {
+    // The `&mut CallControl` borrow ends with this statement — the set is
+    // handed back as a shared `Arc`, so no caller holds it across a
+    // re-entry into `callcontrol()`.
+    crate::jit::codewriter::CodeWriter::instance()
+        .callcontrol()
+        .get_loop_header_pcs(code)
 }
 
 /// warmspot.py portal_runner parity: execute a frame through the JIT-enabled
@@ -6214,7 +6205,7 @@ fn eval_loop_jit(frame: &mut PyFrame) -> LoopResult {
     // runs once and never takes a back-edge — never reach it, so computing it
     // eagerly here scanned the whole bytecode and built a successor map for
     // every frame entry to produce a set no one read.  Compute it lazily at
-    // the first back-edge instead (memoized per code object).
+    // the first back-edge instead (kept per graph on `CallControl`).
     let env = PyreEnv;
     let (driver, info) = driver_pair();
     // interp_jit.py:66 — next_instr, pycode are greens (managed by jit_merge_point).

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -1095,7 +1095,8 @@ use pyre_object::floatobject::{FLOAT_FLOATVAL_OFFSET, W_FloatObject};
 use pyre_object::intobject::{INT_INTVAL_OFFSET, W_IntObject};
 use pyre_object::{w_bool_from, w_int_new, w_none, w_str_new, w_tuple_new};
 
-const JIT_THRESHOLD: u32 = 200;
+// rlib/jit.py PARAMETERS default: loop hot-count threshold.
+const JIT_THRESHOLD: u32 = 1039;
 type JitDriverPair = (
     JitDriver<PyreJitState>,
     std::sync::Arc<majit_metainterp::virtualizable::VirtualizableInfo>,

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -16,8 +16,11 @@ use pyre_interpreter::pyframe::PyFrame;
 use pyre_interpreter::{
     PyError, PyResult, StepResult, decode_instruction_forward, execute_opcode_step,
 };
-use std::cell::{Cell, UnsafeCell};
+use std::cell::{Cell, RefCell, UnsafeCell};
 use std::collections::HashMap;
+use std::rc::Rc;
+
+use vecset::VecSet;
 
 use majit_backend::Backend;
 use majit_gc::GcAllocator;
@@ -6156,6 +6159,34 @@ fn trace_jit_bytecode(_pc: usize, _instruction_name: &str) {
     // Debug logging disabled — per-bytecode eprintln causes O(n) slowdown.
 }
 
+thread_local! {
+    /// Memoizes `find_loop_header_pcs` per code object.  The loop-header set
+    /// depends only on `code.instructions` (immutable) and the `CodeObject`
+    /// behind `code_ptr` is `Box`-immortal — a stable, never-freed address —
+    /// so the raw pointer is a sound stable key.  Recomputing it on every
+    /// `eval_loop_jit` entry re-scans the whole bytecode and rebuilds the
+    /// successor map for each called function / module-body frame; the loop
+    /// headers are code-invariant (fixed once the codewriter has seen the
+    /// code), so that per-frame O(code) work is pure waste on cold, run-once
+    /// startup code where no frame is entered twice through this loop.
+    static LOOP_HEADER_MEMO: RefCell<HashMap<usize, Rc<VecSet<usize>>>> =
+        RefCell::new(HashMap::new());
+}
+
+/// Cached form of [`crate::jit::codewriter::find_loop_header_pcs`], keyed by
+/// the immortal `CodeObject` address.
+fn cached_loop_header_pcs(code: &pyre_interpreter::CodeObject) -> Rc<VecSet<usize>> {
+    let key = code as *const pyre_interpreter::CodeObject as usize;
+    LOOP_HEADER_MEMO.with(|memo| {
+        if let Some(hit) = memo.borrow().get(&key) {
+            return hit.clone();
+        }
+        let computed = Rc::new(crate::jit::codewriter::find_loop_header_pcs(code));
+        memo.borrow_mut().insert(key, computed.clone());
+        computed
+    })
+}
+
 /// warmspot.py portal_runner parity: execute a frame through the JIT-enabled
 /// interpreter. Used by bhimpl_recursive_call (blackhole.py:1074-1093) for
 /// recursive portal depth. Returns PyObjectRef (NULL on void/exception).
@@ -6176,7 +6207,13 @@ fn eval_loop_jit(frame: &mut PyFrame) -> LoopResult {
     // on the Rust stack that walk_pyframe_roots cannot reach).
     let _eval_activation = pyre_object::gc_interp::EvalActivationGuard::enter();
     let code = unsafe { &*pyre_interpreter::pyframe_get_pycode(frame_root.frame()) };
-    let semantic_loop_headers = crate::jit::codewriter::find_loop_header_pcs(code);
+    // `semantic_loop_headers` is consumed only on the `CloseLoop` arm below (a
+    // back-edge event).  Loopless frames — the overwhelming majority during
+    // cold startup, where every called helper / class body / module top level
+    // runs once and never takes a back-edge — never reach it, so computing it
+    // eagerly here scanned the whole bytecode and built a successor map for
+    // every frame entry to produce a set no one read.  Compute it lazily at
+    // the first back-edge instead (memoized per code object).
     let env = PyreEnv;
     let (driver, info) = driver_pair();
     // interp_jit.py:66 — next_instr, pycode are greens (managed by jit_merge_point).
@@ -6343,7 +6380,7 @@ fn eval_loop_jit(frame: &mut PyFrame) -> LoopResult {
                 driver.blackhole_if_trace_too_long();
             }
             Ok(StepResult::CloseLoop { loop_header_pc, .. }) => {
-                if !semantic_loop_headers.contains(&loop_header_pc) {
+                if !cached_loop_header_pcs(code).contains(&loop_header_pc) {
                     driver.blackhole_if_trace_too_long();
                     continue;
                 }

--- a/pyre/pyre-jit/src/jit/call.rs
+++ b/pyre/pyre-jit/src/jit/call.rs
@@ -22,6 +22,8 @@
 //! | `grab_initial_jitcodes()`   | `grab_initial_jitcodes()`   |
 //! | `enum_pending_graphs()`     | `enum_pending_graphs()`     |
 //! | (n/a — pure-lookup helper)  | `find_jitcode()`            |
+//! | (baked into `JitCode` at    | `loop_header_pcs` +         |
+//! |  translation time)          | `get_loop_header_pcs()`     |
 //!
 //! Note: RPython's CallControl is owned by a single
 //! `CodeWriter` instance (`warmspot.py:245`) for the lifetime of the JIT.
@@ -34,6 +36,7 @@ use std::collections::HashMap;
 use majit_translate::jitcode::BhCallDescr;
 use pyre_interpreter::CodeObject;
 use pyre_jit_trace::PyJitCode;
+use vecset::VecSet;
 
 use super::cpu::Cpu;
 
@@ -182,6 +185,29 @@ pub struct CallControl {
     /// `CodeWriter::make_jitcodes` (codewriter.py:85). See
     /// [`CallInfoCollection`] for the pyre-side shell rationale.
     pub callinfocollection: CallInfoCollection,
+
+    /// Per-graph loop-header PC set — the scan result of
+    /// [`super::codewriter::find_loop_header_pcs`].
+    ///
+    /// Loop headers are translation-time information upstream. A
+    /// `can_enter_jit` marker in the source graph becomes a `loop_header`
+    /// operation while the graph is transformed
+    /// (`jtransform.py:1714-1723 handle_jit_marker__loop_header`), and
+    /// the marker scan over all graphs — `warmspot.py:143-156
+    /// _find_jit_marker` / `:172-173 find_loop_headers` — likewise runs
+    /// once, inside `WarmRunnerDesc.__init__`. The running interpreter
+    /// only ever reads an already-derived answer.
+    ///
+    /// pyre's graph is raw 3.14 bytecode, which carries no markers, so
+    /// the equivalent set has to be scanned from `code.instructions`
+    /// (`find_loop_header_pcs`); it also has to exclude the backward
+    /// jumps 3.14 emits for a `break` inside an `except` handler, which
+    /// are a layout artifact rather than a loop back-edge. Keeping the
+    /// result here gives that scan upstream's computed-once, per-graph
+    /// lifetime, under the same owner and key as the jitcodes it belongs
+    /// with (call.py:29 `self.jitcodes = {}` is a plain instance dict on
+    /// `CallControl`, filled on miss by call.py:155-172 `get_jitcode`).
+    pub loop_header_pcs: HashMap<usize, std::sync::Arc<VecSet<usize>>>,
 }
 
 impl CallControl {
@@ -198,7 +224,28 @@ impl CallControl {
             jitcodes: HashMap::new(),
             unfinished_graphs: Vec::new(),
             callinfocollection: CallInfoCollection::new(),
+            loop_header_pcs: HashMap::new(),
         }
+    }
+
+    /// Loop-header PC set for `code`, computed on first request and kept
+    /// on this `CallControl` afterwards.
+    ///
+    /// Same memoize-on-miss shape as `get_jitcode` (call.py:155-172:
+    /// `try: return self.jitcodes[graph] / except KeyError: ... ;
+    /// self.jitcodes[graph] = jitcode; return jitcode`) and keyed by the
+    /// same canonical `CodeObject*` graph identity. The scan reads only
+    /// `code.instructions`, which is fixed for a given graph, so the
+    /// cached set never goes stale.
+    pub fn get_loop_header_pcs(&mut self, code: &CodeObject) -> std::sync::Arc<VecSet<usize>> {
+        let key = code as *const CodeObject as usize;
+        if let Some(hit) = self.loop_header_pcs.get(&key) {
+            return std::sync::Arc::clone(hit);
+        }
+        let computed = std::sync::Arc::new(super::codewriter::find_loop_header_pcs(code));
+        self.loop_header_pcs
+            .insert(key, std::sync::Arc::clone(&computed));
+        computed
     }
 
     /// RPython: `CallControl.grab_initial_jitcodes()` (call.py:145-148).

--- a/pyre/pyre-jit/src/jit/flatten.rs
+++ b/pyre/pyre-jit/src/jit/flatten.rs
@@ -623,8 +623,12 @@ pub fn intern_call_descr_stub(
 pub fn slot_for_call_flavor(flavor: CallFlavor) -> majit_metainterp::EffectInfoSlot {
     use majit_metainterp::EffectInfoSlot;
     match flavor {
-        // `call.py:301 getcalldescr` — `EF_CAN_RAISE`.
-        CallFlavor::Plain => EffectInfoSlot::CanRaise,
+        // `graphanalyze.py:109-112` — every `Plain` helper binds an
+        // interpreter entry point with no graph for a write analyzer to
+        // walk, so its row is `top_result()` → `MOST_GENERAL`, not the
+        // `call.py:301` analyzed `EF_CAN_RAISE`. Matches the EI
+        // `effect_info_for_call_flavor` hands the same flavor.
+        CallFlavor::Plain => EffectInfoSlot::Unanalyzed,
         // `call.py:303 getcalldescr` — `EF_CANNOT_RAISE` (`else` branch).
         // RPython has a single `EF_CANNOT_RAISE` constant; the "no heap
         // touched" property of `PlainCannotRaiseNoHeap` is captured in
@@ -7051,6 +7055,23 @@ mod tests {
         // both resolve to `MOST_GENERAL`.
         let ei = effect_info_for_call_flavor(CallFlavor::Plain);
         assert_eq!(dispatch_kind_for_effect_info(&ei), CallFlavor::MayForce);
+    }
+
+    /// The two producer-side classifiers for one flavor must agree: the
+    /// slot a helper is registered with (`add_fn_ptr_with_slot`, read back
+    /// by the residual-call adapters) and the EI the walker records must
+    /// name the same `call.py:282-303` row. A `Plain` helper registered as
+    /// the analyzed `EF_CAN_RAISE` row while its recorded EI says
+    /// `MOST_GENERAL` would let one path assert an empty write set the
+    /// other refuses to.
+    #[test]
+    fn plain_flavor_slot_and_effect_info_name_the_same_row() {
+        let slot = slot_for_call_flavor(CallFlavor::Plain);
+        assert_eq!(slot, majit_metainterp::EffectInfoSlot::Unanalyzed);
+        assert_eq!(
+            majit_metainterp::effect_info_for_slot(slot),
+            effect_info_for_call_flavor(CallFlavor::Plain)
+        );
     }
 
     #[test]

--- a/pyre/pyre-jit/src/jit/flatten.rs
+++ b/pyre/pyre-jit/src/jit/flatten.rs
@@ -724,21 +724,26 @@ pub fn effect_info_for_call_flavor(flavor: CallFlavor) -> majit_ir::EffectInfo {
         // clean_caches), and `force_from_effectinfo` finds no descr
         // bits set so no per-cached-descr flush either.
         CallFlavor::PlainCannotRaiseNoHeap => majit_metainterp::CANNOT_RAISE_NO_HEAP_EFFECT_INFO,
-        // `EF_FORCES_VIRTUAL_OR_VIRTUALIZABLE` —
-        // `call.py:288-289 if self.virtualizable_analyzer.analyze(op):`
-        // row of `getcalldescr`, fed through
-        // `effectinfo_from_writeanalyze` with the
-        // `graphanalyze.py:60` analyzer default (empty set). Distinct
-        // from `EF_RANDOM_EFFECTS` (`call.py:282-283
-        // randomeffects_analyzer` branch): both pass
-        // `check_forces_virtual_or_virtualizable()` via `>=` ordering at
-        // `effectinfo.py:249-250`, but only RandomEffects trips
-        // `has_random_effects()` (`effectinfo.py:252`) → routes
-        // OptHeap through `clean_caches`. Collapsing MayForce onto
-        // `MOST_GENERAL` would over-invalidate heap state PyPy keeps
-        // live for virtualizable-forcing callees with an empty heap
-        // effects analysis.
-        CallFlavor::MayForce => majit_metainterp::forces_virtual_or_virtualizable_effect_info(),
+        // Also `EffectInfo::MOST_GENERAL`. Upstream reaches
+        // `EF_FORCES_VIRTUAL_OR_VIRTUALIZABLE` at
+        // `call.py:287-289 if extraeffect is None: if
+        // self.virtualizable_analyzer.analyze(op):`, i.e. only after
+        // `call.py:282-284 randomeffects_analyzer` declined AND the write
+        // analyzer produced a concrete set for the callee's graph. Every
+        // pyre producer of this flavor binds an interpreter entry point
+        // that runs arbitrary Python code (`cpu.call_fn`, `compare_fn`,
+        // `truth_fn`, `call_fn_0..8`, `setattr_fn`, …), so no write set
+        // was ever computed and an empty one asserts something false.
+        //
+        // Nothing is lost by the promotion: `EF_RANDOM_EFFECTS` (7) is
+        // `>=` `EF_FORCES_VIRTUAL_OR_VIRTUALIZABLE` (6) at
+        // `effectinfo.py:249-250`, so `check_forces_virtual_or_
+        // virtualizable()` still holds and `pyjitpl.py:2007-2008` still
+        // selects the `CALL_MAY_FORCE_*` opcode with its vable/vref
+        // preparation. The added effect is `heap.py:460`'s
+        // `has_random_effects()` route into `clean_caches`, which is what
+        // an unknown write set means.
+        CallFlavor::MayForce => majit_metainterp::default_effect_info(),
         // EF_LOOPINVARIANT — `effectinfo.py:18`.
         // `optimize_CALL_LOOPINVARIANT_*` branch.
         CallFlavor::LoopInvariant => EffectInfo {
@@ -6997,13 +7002,10 @@ mod tests {
         // ReleaseGil is excluded because it needs the real
         // `(target_fn_addr, save_err)` seed.
         //
-        // `Plain` → `EF_CAN_RAISE` (`call.py:300-301`, fed through
-        // `effectinfo_from_writeanalyze` with the
-        // `graphanalyze.py:60 analyze_external_call` default
-        // `bottom_result()` = empty set; the `effectinfo.py:285`
-        // top_set force-promotion only fires when `effects is top_set`,
-        // not when the producer simply omits an analyzer). dispatch
-        // reverses via the `_ => Plain` arm.
+        // `Plain` is excluded — with no analyzer output it resolves to
+        // `EffectInfo::MOST_GENERAL`, sharing `ExtraEffect::RandomEffects`
+        // with `MayForce`, so the reverse mapping collapses to `MayForce`
+        // (asserted separately below).
         //
         // `PlainCannotRaise` → `EF_CANNOT_RAISE` (`call.py:303`),
         // dispatch reverses via the `ExtraEffect::CannotRaise =>
@@ -7017,7 +7019,6 @@ mod tests {
         // not the extraeffect discriminant, so the round-trip correctly
         // collapses to PlainCannotRaise.
         for flavor in [
-            CallFlavor::Plain,
             CallFlavor::PlainCannotRaise,
             CallFlavor::MayForce,
             CallFlavor::LoopInvariant,
@@ -7045,6 +7046,11 @@ mod tests {
             "PlainCannotRaiseNoHeap shares extraeffect=CannotRaise with \
              PlainCannotRaise; dispatch reverse-maps both to PlainCannotRaise"
         );
+
+        // Same collapse on the RandomEffects side: `Plain` and `MayForce`
+        // both resolve to `MOST_GENERAL`.
+        let ei = effect_info_for_call_flavor(CallFlavor::Plain);
+        assert_eq!(dispatch_kind_for_effect_info(&ei), CallFlavor::MayForce);
     }
 
     #[test]
@@ -7055,28 +7061,33 @@ mod tests {
     }
 
     #[test]
-    fn analyzer_absent_plain_and_may_force_carry_distinct_extra_effects() {
-        // `call.py:288-303 getcalldescr` keeps `EF_CAN_RAISE`
-        // (plain raising callees) and `EF_FORCES_VIRTUAL_OR_VIRTUALIZABLE`
-        // (virtualizable forcing callees) as distinct extraeffect
-        // values.  Collapsing them both onto `EF_RANDOM_EFFECTS = 7`
-        // (`MOST_GENERAL`) would over-claim random-effects semantics on
-        // plain calls, routing them through
-        // `check_forces_virtual_or_virtualizable()` (`pyjitpl.py:2007`,
-        // `effectinfo.py:250`) and tripping `has_random_effects()`
-        // cache invalidation that `EF_CAN_RAISE` / `EF_FORCES` leave
-        // intact.
+    fn analyzer_absent_plain_and_may_force_both_resolve_to_most_general() {
+        // `call.py:282-303 getcalldescr` reaches `EF_CAN_RAISE` and
+        // `EF_FORCES_VIRTUAL_OR_VIRTUALIZABLE` only with write-analyzer
+        // output in hand; both rows carry the callee's concrete write set.
+        // Neither pyre flavor has one — `Plain` means "nothing is known
+        // about the callee" and every `MayForce` producer binds an
+        // interpreter entry point that runs arbitrary Python code — so
+        // both take `graphanalyze.py:109-112`'s `top_result()` and land on
+        // `EF_RANDOM_EFFECTS` (`effectinfo.py:285-292`).
+        //
+        // The `MayForce` semantics survive the merge: `EF_RANDOM_EFFECTS`
+        // (7) `>=` `EF_FORCES_VIRTUAL_OR_VIRTUALIZABLE` (6) at
+        // `effectinfo.py:249-250`, so `pyjitpl.py:2007-2008` still selects
+        // `CALL_MAY_FORCE_*` with its vable/vref preparation.
         let plain_ei = effect_info_for_call_flavor(CallFlavor::Plain);
         let may_force_ei = effect_info_for_call_flavor(CallFlavor::MayForce);
-        assert_ne!(plain_ei, may_force_ei);
-        assert_eq!(plain_ei.extraeffect, majit_ir::ExtraEffect::CanRaise);
+        assert_eq!(plain_ei, may_force_ei);
+        assert_eq!(plain_ei.extraeffect, majit_ir::ExtraEffect::RandomEffects);
+        assert!(plain_ei.has_random_effects());
+        assert!(plain_ei.check_forces_virtual_or_virtualizable());
+        // `effectinfo.py:149-155`: `EF_RANDOM_EFFECTS` keeps every raw set
+        // and every bitstring at `None`, so no `check_*_descr_*` query can
+        // read an invented empty set.
+        assert!(plain_ei._write_descrs_fields.is_none());
+        assert!(plain_ei.write_descrs_fields.is_none());
         assert_eq!(
-            may_force_ei.extraeffect,
-            majit_ir::ExtraEffect::ForcesVirtualOrVirtualizable
-        );
-        assert_eq!(dispatch_kind_for_effect_info(&plain_ei), CallFlavor::Plain);
-        assert_eq!(
-            dispatch_kind_for_effect_info(&may_force_ei),
+            dispatch_kind_for_effect_info(&plain_ei),
             CallFlavor::MayForce
         );
     }
@@ -10069,19 +10080,12 @@ mod tests {
 
     #[test]
     fn build_load_global_helper_carries_distinct_effect_info_from_binary_op_helper() {
-        // BINARY_OP records `MayForce` → ForcesVirtualOrVirtualizable;
-        // LoadGlobal records `Plain` → CanRaise. PyPy `call.py:288-303
-        // getcalldescr` keeps these as distinct `extraeffect` values:
-        // the `virtualizable_analyzer` branch (`:288-289`) routes to
-        // `EF_FORCES_VIRTUAL_OR_VIRTUALIZABLE`, the `_canraise`
-        // raising-callee branch (`:300-301`) routes to `EF_CAN_RAISE`.
-        // `effectinfo.py:285` force-promotion to `EF_RANDOM_EFFECTS`
-        // only fires when the analyzer literally returns `top_set`; the
-        // analyzer-absent external-call default is `bottom_result()` =
-        // empty set per `graphanalyze.py:60`, so the supplied
-        // `extraeffect` survives the empty-effects else-branch
-        // (`:293-299`). Both EIs therefore carry distinct shapes and
-        // round-trip through `dispatch_kind_for_effect_info`.
+        // BINARY_OP records `MayForce`, LoadGlobal records `Plain`.
+        // Neither callee was write-analyzed, so both resolve to
+        // `EffectInfo::MOST_GENERAL` (`graphanalyze.py:109-112`
+        // `top_result()` → `effectinfo.py:285-292`) and share
+        // `ExtraEffect::RandomEffects`. What still separates the two
+        // descrs is the `pyre_helper` tag the walker dispatches on.
         let bin = build_binary_op_residual_call_ir_r_insn(7, 0, 1, 2, 3);
         let glob = build_load_global_fn_residual_call_ir_r_insn(7, 0, 1, 2, 4, 3);
         let bin_descr = match &bin {
@@ -10104,25 +10108,28 @@ mod tests {
             },
             _ => panic!("LoadGlobal Insn is not Op"),
         };
-        assert_eq!(
-            bin_descr.extraeffect,
-            majit_ir::ExtraEffect::ForcesVirtualOrVirtualizable,
-            "MayForce flavor produces EF_FORCES_VIRTUAL_OR_VIRTUALIZABLE \
-             per `call.py:288-289 virtualizable_analyzer` branch"
-        );
-        assert_eq!(
-            glob_descr.extraeffect,
-            majit_ir::ExtraEffect::CanRaise,
-            "Plain flavor produces EF_CAN_RAISE per `call.py:300-301 \
-             _canraise` branch"
-        );
+        for (name, ei) in [("BINARY_OP", &bin_descr), ("LoadGlobal", &glob_descr)] {
+            assert_eq!(
+                ei.extraeffect,
+                majit_ir::ExtraEffect::RandomEffects,
+                "{name}: an un-analyzed callee is `graphanalyze.py:109-112` \
+                 `top_result()`, promoted to EF_RANDOM_EFFECTS at \
+                 `effectinfo.py:285-292`"
+            );
+            assert!(
+                ei.check_forces_virtual_or_virtualizable(),
+                "{name}: EF_RANDOM_EFFECTS (7) >= \
+                 EF_FORCES_VIRTUAL_OR_VIRTUALIZABLE (6) at \
+                 `effectinfo.py:249-250`, so `pyjitpl.py:2007-2008` still \
+                 selects CALL_MAY_FORCE"
+            );
+        }
         assert_ne!(
             bin_descr, glob_descr,
-            "MayForce and Plain carry distinct EffectInfo shapes; \
-             collapsing them onto MOST_GENERAL would over-claim \
-             random-effects semantics and trip `has_random_effects` \
-             cache invalidation (`effectinfo.py:252`)"
+            "the two descrs stay distinguishable through `pyre_helper`, \
+             which is what the walker's fold recognisers dispatch on"
         );
+        assert_ne!(bin_descr.pyre_helper, glob_descr.pyre_helper);
     }
 
     #[test]

--- a/pyre/pyre-jit/src/jit/flatten.rs
+++ b/pyre/pyre-jit/src/jit/flatten.rs
@@ -700,15 +700,11 @@ fn is_pyre_canonical_elidable_hlop(opname: &str) -> bool {
 pub fn effect_info_for_call_flavor(flavor: CallFlavor) -> majit_ir::EffectInfo {
     use majit_ir::{EffectInfo, ExtraEffect};
     match flavor {
-        // `EF_CAN_RAISE` — `call.py:300-301 elif self._canraise(op):`
-        // row of `getcalldescr`, fed through
-        // `effectinfo_from_writeanalyze` with the
-        // `graphanalyze.py:60 analyze_external_call` default
-        // (`bottom_result()` = empty set). `effectinfo.py:285` only
-        // force-promotes to `EF_RANDOM_EFFECTS` when
-        // `effects is top_set`; the no-analyzer-output case takes the
-        // `else` branch at `:293-299` and lands at
-        // `extraeffect=CanRaise + Some([])` raw sets.
+        // `EffectInfo::MOST_GENERAL` — the callee has no analyzed
+        // graph, which is `graphanalyze.py:109-112`'s `top_result()`
+        // and `effectinfo.py:285-292`'s `EF_RANDOM_EFFECTS` promotion,
+        // not the `graphanalyze.py:60 analyze_external_call`
+        // `bottom_result()` reserved for external C functions.
         CallFlavor::Plain => majit_metainterp::default_effect_info(),
         // `EF_CANNOT_RAISE` — `call.py:303 else:` row of `getcalldescr`
         // (non-elidable + `_canraise(op) == False`). Same
@@ -865,10 +861,11 @@ pub fn dispatch_kind_for_effect_info(ei: &majit_ir::EffectInfo) -> CallFlavor {
 /// would push the wrong path back into the residual_call shape.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CallFlavor {
-    /// Plain residual call, conservative `EF_CAN_RAISE` default
-    /// (`rpython/jit/codewriter/effectinfo.py:22`). `call.py:301
-    /// getcalldescr` picks this when the analyzer reports the callee
-    /// can raise but is not elidable / loop-invariant / forces.
+    /// Plain residual call to a callee no analyzer has looked at.
+    /// Resolves to `EffectInfo::MOST_GENERAL` (`EF_RANDOM_EFFECTS`,
+    /// `effectinfo.py:271-273`), the `graphanalyze.py:109-112`
+    /// no-graph `top_result()` outcome. Producers that know more pick
+    /// one of the flavors below.
     Plain,
     /// `EF_CANNOT_RAISE` (`effectinfo.py:19`). `call.py:303 getcalldescr`
     /// picks this on the non-elidable `else` branch when


### PR DESCRIPTION
## nbody warm-entry gate + EffectInfo honesty for un-analyzed callees

Two independent lines of work on the nbody trace shape.

### 1. Warm-entry dispatch gate (`5909016798c`, `db089f4bc20`, `0038ee8ad36`)

`JIT_THRESHOLD` was 200, a workaround for a divergence introduced at `08f7f169`.
At the rlib default of 1039 the warm-entry path gated on
`has_compiled_loop(procedure_token)` but then read `get_compiled_meta(compiled_loops)`;
the two diverge through the tmp-callback, producing a `missing-compiled-meta`
abort at pc14. Gating five sites on `has_runnable_compiled_loop` fixes it, so
`JIT_THRESHOLD` is restored to 1039. The `eval_loop_jit` loop-header PC set is
now computed lazily at the back-edge, and its memo moved off a `thread_local!`
onto `CallControl` next to `jitcodes` (`call.py:29`, `call.py:155-172`) —
upstream's TLS surface is per-thread runtime state only, never a per-graph
derived cache.

### 2. EffectInfo honesty (`b52d91b5b33`, `6556d9eb8bb`, `6c6b0d98daf`)

`OptHeap::force_from_effectinfo` treated any cached mutable descr whose
`ei_index` was still the `u32::MAX` sentinel as written by every non-elidable
call, on the premise that upstream's bitcheck is total. **That premise is
wrong.** `effectinfo.py:495-496` stamps `sys.maxint` on every descr in
`all_descrs`; only `:524-526` renumbers those some EffectInfo's
`_readonly_descrs_*` / `_write_descrs_*` names. `test_effectinfo.py:172,176`
pins it — `f3descr` is passed to `compute_bitstrings` and still ends at
`sys.maxint`. Upstream sentinel descrs bitcheck false too.

What makes that sound upstream is the **call** side: a callee whose write set
was never computed is `EF_RANDOM_EFFECTS`
(`graphanalyze.py:109-112 top_result()` → `effectinfo.py:285-292`) and
`heap.py:460` routes it to `clean_caches` without reaching
`force_from_effectinfo`. Two pyre call classes were not upholding that:

- `default_effect_info()` returned the *external-C* `bottom_result()` shape
  (`EF_CAN_RAISE` + `Some(empty)` sets). Its every caller is the
  no-analyzed-graph case. Now `MOST_GENERAL`.
- `CallFlavor::MayForce` returned `EF_FORCES_VIRTUAL_OR_VIRTUALIZABLE` +
  `Some(empty)` sets. Upstream reaches that row at `call.py:287-289` only after
  `call.py:282-284 randomeffects_analyzer` declined *and* the write analyzer
  produced a set; every pyre producer binds an interpreter entry point that runs
  arbitrary Python (`cpu.call_fn`, `compare_fn`, `truth_fn`, `call_fn_0..8`,
  `setattr_fn`, …). Now `MOST_GENERAL`. Nothing is lost — `EF_RANDOM_EFFECTS`
  (7) `>=` (6) at `effectinfo.py:249-250`, so `pyjitpl.py:2007-2008` still
  selects `CALL_MAY_FORCE_*` with its vable/vref preparation.

With both fixed, the field and array sentinel clauses in
`force_from_effectinfo` are removed.

Separately, `w_class_descr()` / `ob_type_descr()` minted a fresh `Arc` per call
while `cached_field_pos_for_descr` matches on pointer identity
(`descr.py:218-239` caches on `(STRUCT, fieldname)`), so two reads of the same
object header could never share a cache entry. Both are now `LazyLock`
singletons.

### Deliberately kept

The two `produce_potential_short_preamble_ops` clauses stay. They mask a
different defect: `shortpreamble.py:465-476
ExtendedShortPreambleBuilder.add_preamble_op` puts the re-executed
`preamble_op.preamble_op` in the jump args, so upstream re-reads the field each
iteration and `heap.py:360-377` needs no filter — pyre's peeled body passes the
entry value back instead. Without the clauses,
`pyre/bench/synth/callee_store_global_read_after_call.py` emits
`Jump(..., v245)` for a global that a residual call mutates every iteration and
prints 316836 instead of 240008. Their comments now state that reason rather
than citing the descr universe.

### Verification

- `python3 ./pyre/check.py --backend dynasm` — 308/308 at every commit.
- `cargo test --features dynasm` on `majit-ir`, `majit-metainterp`,
  `pyre-jit-trace`, `pyre-jit` — green. Three `flatten` tests that pinned the
  old `Plain` / `MayForce` extraeffect split were updated to the new invariant.
- nbody optimized traces: pairwise loop **998 → 754 ops**, first loop 305 → 277;
  output unchanged (`-0.03512397269476283`).
- Wall-clock A/B is not reported for the last commit: the machine was running
  unrelated builds at load average 24, which inflated every benchmark ~30%
  including untouched ones. The trace-op counts above are the deterministic
  measure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
