### PR TITLE
jit(fbw): multi-frame blackhole resume, jit.virtual_ref frame-chain wiring, JIT parameter-name validation

### DIFF
--- a/majit/majit-metainterp/src/blackhole.rs
+++ b/majit/majit-metainterp/src/blackhole.rs
@@ -2251,6 +2251,37 @@ fn handle_jitexception_in_portal(
     }
 }
 
+/// Register-bank image of the blackhole frame whose `JitException` propagated
+/// out of `_run_forever`.
+///
+/// `_run_forever` releases that frame back to the pool before the exception
+/// leaves, so a `ContinueRunningNormally` handoff that has to materialize the
+/// resumed frame's live operand-stack slots cannot read the banks afterwards.
+/// The three banks are moved out (not copied) before the release, matching
+/// [`crate::jitdriver::SingleFrameBlackholeResult`], which keeps the terminal
+/// interpreter of the single-frame path logically alive the same way.
+pub struct BlackholeTerminalImage {
+    pub jitcode_index: usize,
+    pub registers_i: Vec<i64>,
+    pub registers_r: Vec<i64>,
+    pub registers_f: Vec<i64>,
+    pub position: usize,
+    pub last_opcode_position: usize,
+}
+
+impl BlackholeTerminalImage {
+    fn take_from(bh: &mut BlackholeInterpreter) -> Self {
+        Self {
+            jitcode_index: bh.jitcode.index(),
+            registers_i: std::mem::take(&mut bh.registers_i),
+            registers_r: std::mem::take(&mut bh.registers_r),
+            registers_f: std::mem::take(&mut bh.registers_f),
+            position: bh.position,
+            last_opcode_position: bh.last_opcode_position,
+        }
+    }
+}
+
 /// blackhole.py:1762 _handle_jitexception
 ///
 /// Route a JitException through the blackhole frame chain.
@@ -2262,6 +2293,7 @@ fn handle_jitexception(
     mut bh: BlackholeInterpreter,
     exc: JitException,
     portal_runner: Option<&dyn Fn(&JitException) -> Result<(BhReturnType, i64), JitException>>,
+    terminal_out: Option<&mut Option<BlackholeTerminalImage>>,
 ) -> Result<(BlackholeInterpreter, i64), JitException> {
     // blackhole.py:1764: while blackholeinterp.jitcode.jitdriver_sd is None
     while bh.jitcode.jitdriver_sd().is_none() {
@@ -2276,6 +2308,9 @@ fn handle_jitexception(
     // blackhole.py:1767-1769
     if bh.nextblackholeinterp.is_none() {
         // Bottommost entry: exception goes through
+        if let Some(terminal_out) = terminal_out {
+            *terminal_out = Some(BlackholeTerminalImage::take_from(&mut bh));
+        }
         builder.release_interp(bh);
         return Err(exc);
     }
@@ -2312,7 +2347,7 @@ pub fn run_forever(
     bh: BlackholeInterpreter,
     current_exc: i64,
 ) -> JitException {
-    run_forever_with_portal(builder, bh, current_exc, None)
+    run_forever_with_portal(builder, bh, current_exc, None, None, None)
 }
 
 /// blackhole.py:1752 _run_forever with optional portal runner callback.
@@ -2321,13 +2356,26 @@ pub fn run_forever(
 /// when ContinueRunningNormally is raised at a recursive portal level,
 /// this callback re-enters the portal function with the exception's
 /// green/red args and returns the result.
+///
+/// `terminal_out` receives the [`BlackholeTerminalImage`] of the bottommost
+/// frame when its exception propagates out, so the caller can read the banks
+/// the release would otherwise recycle.
 pub fn run_forever_with_portal(
     builder: &mut BlackholeInterpBuilder,
     mut bh: BlackholeInterpreter,
     mut current_exc: i64,
     portal_runner: Option<&dyn Fn(&JitException) -> Result<(BhReturnType, i64), JitException>>,
+    on_enter_level: Option<&dyn Fn(i64)>,
+    mut terminal_out: Option<&mut Option<BlackholeTerminalImage>>,
 ) -> JitException {
     loop {
+        // executioncontext.py enter: publish this level's frame as
+        // `ec.topframeref` before its residuals run (pyjitpl multi-frame
+        // resume only; None on the guard-failure path where the chain is
+        // already correct via the compiled trace's real stores).
+        if let Some(on_enter_level) = on_enter_level {
+            on_enter_level(bh.virtualizable_ptr);
+        }
         // blackhole.py:1754-1755
         match bh.resume_mainloop(current_exc) {
             Ok(exc) => {
@@ -2335,7 +2383,13 @@ pub fn run_forever_with_portal(
             }
             Err(jit_exc) => {
                 // blackhole.py:1756-1758
-                match handle_jitexception(builder, bh, jit_exc, portal_runner) {
+                match handle_jitexception(
+                    builder,
+                    bh,
+                    jit_exc,
+                    portal_runner,
+                    terminal_out.as_deref_mut(),
+                ) {
                     Ok((new_bh, exc)) => {
                         // Handled at recursive portal level — continue
                         bh = new_bh;
@@ -2373,6 +2427,16 @@ pub struct PyjitplBlackholeFrameConfig<'a> {
     pub virtualizable_ptr: i64,
     pub virtualizable_stack_base: usize,
     pub jitdrivers_sd: &'a [BhJitDriverSd],
+    /// Per-frame concrete frame ptr + its own stack_base, aligned to
+    /// `framestack.frames` (outermost-first).  When present, each blackhole
+    /// level uses ITS OWN frame as the virtualizable instead of sharing the
+    /// portal's, and `on_enter_level` publishes it as `ec.topframeref`.
+    pub per_frame: Option<&'a [(i64, usize)]>,
+    /// `executioncontext.py enter`: publish `ec.topframeref = <this level's
+    /// frame>` before each frame runs so a re-executed `sys._getframe` observes
+    /// the resumed frame chain.  Threaded from the interpreter side because
+    /// majit-metainterp cannot reference `ExecutionContext`.
+    pub on_enter_level: Option<&'a dyn Fn(i64)>,
 }
 
 pub fn convert_and_run_from_pyjitpl(
@@ -2381,12 +2445,14 @@ pub fn convert_and_run_from_pyjitpl(
     last_exc_value: i64,
     raising_exception: bool,
     config: Option<PyjitplBlackholeFrameConfig<'_>>,
+    terminal_out: Option<&mut Option<BlackholeTerminalImage>>,
 ) -> JitException {
     // blackhole.py:1803-1810
     let mut next_bh: Option<Box<BlackholeInterpreter>> = None;
     let roots_depth = majit_gc::shadow_stack::resume_ref_roots_depth();
+    let on_enter_level = config.as_ref().and_then(|config| config.on_enter_level);
 
-    for frame in &framestack.frames {
+    for (frame_index, frame) in framestack.frames.iter().enumerate() {
         let mut cur_bh = builder.acquire_interp();
         cur_bh.copy_data_from_miframe(frame);
         if let Some(config) = config.as_ref() {
@@ -2394,6 +2460,11 @@ pub fn convert_and_run_from_pyjitpl(
             cur_bh.virtualizable_info = config.virtualizable_info;
             cur_bh.virtualizable_ptr = config.virtualizable_ptr;
             cur_bh.virtualizable_stack_base = config.virtualizable_stack_base;
+            if let Some(per_frame) = config.per_frame {
+                let (frame_ptr, frame_stack_base) = per_frame[frame_index];
+                cur_bh.virtualizable_ptr = frame_ptr;
+                cur_bh.virtualizable_stack_base = frame_stack_base;
+            }
             cur_bh.jitdrivers_sd = config.jitdrivers_sd.to_vec();
         }
         // Keep every completed interpreter bank rooted while later frames are
@@ -2421,7 +2492,14 @@ pub fn convert_and_run_from_pyjitpl(
         0
     };
 
-    let outcome = run_forever(builder, first_bh, current_exc);
+    let outcome = run_forever_with_portal(
+        builder,
+        first_bh,
+        current_exc,
+        None,
+        on_enter_level,
+        terminal_out,
+    );
     majit_gc::shadow_stack::pop_resume_ref_roots_to(roots_depth);
     outcome
 }

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -221,6 +221,18 @@ pub fn drive_single_frame_blackhole(
     result
 }
 
+/// Terminal state from a multi-frame tracing-abort blackhole run.
+///
+/// `terminal` is the bottommost (portal-level) frame's register image, present
+/// whenever its exception propagated out of `_run_forever`.  A
+/// ContinueRunningNormally handoff needs it to materialize that frame's live
+/// operand-stack slots, exactly as the single-frame path uses
+/// [`SingleFrameBlackholeResult`].
+pub struct MultiFrameBlackholeResult {
+    pub outcome: crate::jitexc::JitException,
+    pub terminal: Option<crate::blackhole::BlackholeTerminalImage>,
+}
+
 /// Run a tracing MIFrame chain through the structured multi-frame blackhole
 /// conversion.  Every frame shares the portal-level virtualizable layout, but
 /// retains its own jitcode, register banks, and blackhole interpreter.
@@ -234,7 +246,9 @@ pub fn drive_multi_frame_blackhole(
     metainterp_sd: &crate::pyjitpl::MetaInterpStaticData,
     mut last_exc_value: i64,
     raising_exception: bool,
-) -> crate::jitexc::JitException {
+    per_frame: Option<&[(i64, usize)]>,
+    on_enter_level: Option<&dyn Fn(i64)>,
+) -> MultiFrameBlackholeResult {
     let mut ref_locations = Vec::new();
     let mut packed_ref_roots = Vec::new();
     for (frame_index, frame) in framestack.frames.iter().enumerate() {
@@ -271,6 +285,7 @@ pub fn drive_multi_frame_blackhole(
     }
 
     let jitdrivers_sd = bh_jitdrivers_sd(metainterp_sd);
+    let mut terminal = None;
     let outcome = crate::blackhole::convert_and_run_from_pyjitpl(
         builder,
         framestack,
@@ -282,10 +297,13 @@ pub fn drive_multi_frame_blackhole(
             virtualizable_ptr,
             virtualizable_stack_base,
             jitdrivers_sd: &jitdrivers_sd,
+            per_frame,
+            on_enter_level,
         }),
+        Some(&mut terminal),
     );
     majit_gc::shadow_stack::pop_resume_ref_roots_to(root_depth);
-    outcome
+    MultiFrameBlackholeResult { outcome, terminal }
 }
 
 fn writeback_live_state_scalars_from_blackhole<S: crate::JitState>(
@@ -5884,6 +5902,8 @@ impl<S: JitState> JitDriver<S> {
                                     crate::jitexc::JitException,
                                 >
                         }),
+                        None,
+                        None,
                     );
                     // compile.py:716 assert 0, "unreachable"
                     if crate::majit_log_enabled() {

--- a/majit/majit-metainterp/src/lib.rs
+++ b/majit/majit-metainterp/src/lib.rs
@@ -127,9 +127,9 @@ pub use jitcode::{
     live_slots_for_state_field_jit, set_global_build_descr_pool,
 };
 pub use jitdriver::{
-    DeclarativeJitDriver, JitDriver, JitDriverStaticData, SingleFrameBlackholeResult,
-    TraceContinuationSuspendGuard, drive_multi_frame_blackhole, drive_single_frame_blackhole,
-    trace_continuation_suspended,
+    DeclarativeJitDriver, JitDriver, JitDriverStaticData, MultiFrameBlackholeResult,
+    SingleFrameBlackholeResult, TraceContinuationSuspendGuard, drive_multi_frame_blackhole,
+    drive_single_frame_blackhole, trace_continuation_suspended,
 };
 pub use majit_backend::CompiledTraceInfo;
 pub use pyjitpl::{eval_binop_f, eval_binop_i, eval_float_cmp, eval_unary_f, eval_unary_i};

--- a/majit/majit-metainterp/src/virtualref.rs
+++ b/majit/majit-metainterp/src/virtualref.rs
@@ -102,6 +102,26 @@ pub struct JitVirtualRef {
 /// upstream's `inst.typeptr == self.jit_virtual_ref_vtable`.
 pub const JIT_VIRTUAL_REF_VTABLE: u64 = 0x4A49_5456_5245_4621; // "JITVREF!"
 
+/// Free-function form of [`VirtualRefInfo::is_virtual_ref`] for callers that
+/// don't hold a `VirtualRefInfo` — e.g. the interpreter's frame-chain force
+/// path (`ExecutionContext::force_vref`).  The check reads only the module
+/// constant `JIT_VIRTUAL_REF_VTABLE`, so no receiver state is needed.
+/// `virtualref.py:94-98 is_virtual_ref(gcref)`.
+///
+/// # Safety
+/// `ptr` must be null or point to a valid object whose first 8 bytes are the
+/// `('super', rclass.OBJECT)` typeptr word.
+#[inline]
+pub unsafe fn ptr_is_virtual_ref(ptr: *const u8) -> bool {
+    unsafe {
+        if ptr.is_null() {
+            return false;
+        }
+        let header = ptr as *const ObjectHeader;
+        (*header).typeptr == JIT_VIRTUAL_REF_VTABLE
+    }
+}
+
 /// `rpython/rlib/jit.py:487 class InvalidVirtualRef(Exception)` —
 /// `force_virtual` raises this when `virtual_token == TOKEN_NONE`
 /// but `forced` is null (`virtualref.py:174-176`).  Pyre's single
@@ -462,13 +482,7 @@ impl VirtualRefInfo {
     /// `ptr` must point to a valid GCREF object whose first 8 bytes
     /// are the typeptr word, or be null.
     pub unsafe fn is_virtual_ref(&self, ptr: *const u8) -> bool {
-        unsafe {
-            if ptr.is_null() {
-                return false;
-            }
-            let header = ptr as *const ObjectHeader;
-            (*header).typeptr == JIT_VIRTUAL_REF_VTABLE
-        }
+        unsafe { ptr_is_virtual_ref(ptr) }
     }
 }
 

--- a/pyre/bench/synth/getframe_inlined_callee_own_frame.py
+++ b/pyre/bench/synth/getframe_inlined_callee_own_frame.py
@@ -1,0 +1,27 @@
+# Regression guard: an INLINED callee that inspects its own frame via
+# sys._getframe(0) must still see ITS OWN frame, not its caller's. The walker
+# executes residuals concretely while an inline push never runs the
+# interpreter's call sequence, so ec.topframeref still names the caller unless
+# the inline declines or materialises the callee's frame. Publishing a frame
+# for only the inline levels that have one shifts every _getframe up a level
+# instead of fixing it, and the shift is invisible to a JIT-vs-JIT comparison
+# -- both pyre paths move together. Hence the assert against the literal
+# expected chain rather than a self-consistency check.
+import sys
+
+
+def leaf(x):
+    frame = sys._getframe(0)
+    return (frame.f_code.co_name, frame.f_back.f_code.co_name)
+
+
+def main():
+    seen = set()
+    total = 0
+    for i in range(20000):
+        seen.add(leaf(i))
+        total += i
+    print(total, sorted(seen))
+
+
+main()

--- a/pyre/pyre-interpreter/src/executioncontext.rs
+++ b/pyre/pyre-interpreter/src/executioncontext.rs
@@ -17,6 +17,39 @@ fn force_frame(frame: *mut PyFrame) {
     }
 }
 
+/// `_jit_vref.py:48-52` `vref()` = `jit_force_virtual`.
+///
+/// `topframeref` and every frame's `f_backref` hold a `jit.virtual_ref` — at
+/// interpreter level (`_jit_vref.py:40 VRefRepr.lowleveltype = OBJECTPTR`) that
+/// is just the frame pointer itself, so forcing is the identity.  Once the JIT
+/// virtualizes an inlined callee, the slot instead holds a `JitVirtualRef`
+/// whose `virtualref.py:135 force_virtual_if_necessary` materializes the real
+/// frame.  The JIT installs that materialization via
+/// [`register_force_vref_hook`]; interp-level code never stores a
+/// `JitVirtualRef`, so `is_virtual_ref` is always false and this stays the
+/// identity fast path.
+pub type ForceVRefFn = unsafe extern "C" fn(*mut PyFrame) -> *mut PyFrame;
+static FORCE_VREF_HOOK: OnceLock<ForceVRefFn> = OnceLock::new();
+
+pub fn register_force_vref_hook(f: ForceVRefFn) {
+    let _ = FORCE_VREF_HOOK.set(f);
+}
+
+/// Force a vref stored in the frame chain (`topframeref` / `f_backref`).
+/// `virtualref.py:135`: `if inst.typeptr != jit_virtual_ref_vtable: return inst`
+/// (the pointer already *is* the frame) else materialize via `force_virtual`.
+#[inline]
+pub(crate) fn force_vref(ptr: *mut PyFrame) -> *mut PyFrame {
+    if unsafe { majit_metainterp::virtualref::ptr_is_virtual_ref(ptr as *const u8) } {
+        match FORCE_VREF_HOOK.get() {
+            Some(f) => unsafe { f(ptr) },
+            None => ptr,
+        }
+    } else {
+        ptr
+    }
+}
+
 /// Return the live `PyFrame` as the Python-visible `frame` object passed
 /// to a trace / profile callback.
 ///
@@ -301,8 +334,11 @@ impl ExecutionContext {
 
     #[inline]
     pub fn gettopframe(&self) -> *mut PyFrame {
-        force_frame(self.topframeref);
-        self.topframeref
+        // `executioncontext.py:_gettopframe` → `self.topframeref()` (vref
+        // force), then the virtualizable force materializes the fastlocals.
+        let frame = force_vref(self.topframeref);
+        force_frame(frame);
+        frame
     }
 
     #[inline]
@@ -311,7 +347,7 @@ impl ExecutionContext {
     }
 
     pub fn gettopframe_nohidden(&self) -> *mut PyFrame {
-        let mut frame = self.topframeref;
+        let mut frame = force_vref(self.topframeref);
         while !frame.is_null() {
             force_frame(frame);
             // SAFETY: frame pointers are owned by interpreter call stack and can be
@@ -355,8 +391,10 @@ impl ExecutionContext {
         unsafe {
             (*frame).f_backref = self.topframeref;
         }
-        // `jit.virtual_ref(frame)` — vref allocation, no-op until
-        // jit.virtual_ref is ported.
+        // `self.topframeref = jit.virtual_ref(frame)`.  At interp level
+        // `virtual_ref(frame)` is the frame pointer itself
+        // (`_jit_vref.py:40 lowleveltype = OBJECTPTR`, no allocation); the
+        // JIT rewrites it to a `JitVirtualRef` when it virtualizes the frame.
         self.topframeref = frame;
     }
 
@@ -377,19 +415,26 @@ impl ExecutionContext {
         } else {
             Ok(())
         };
-        let _frame_vref = self.topframeref;
+        let frame_vref = self.topframeref;
         unsafe {
+            // `self.topframeref = frame.f_backref` (no parens — move the raw
+            // caller vref back, do not force it).
             self.topframeref = (*frame).f_backref;
             if (*frame).escaped() || got_exception {
+                // `f_back = frame.f_backref()` — forced (get_f_back forces).
                 let f_back = (*frame).get_f_back();
                 if !f_back.is_null() {
                     (*f_back).mark_as_escaped();
                 }
-                // `frame_vref()` — vref force, no-op until jit.virtual_ref is ported.
+                // `frame_vref()` — force the leaving frame's own vref so it
+                // stays reachable after the JIT frame is gone (identity at
+                // interp level).
+                force_vref(frame_vref);
             }
         }
-        // `jit.virtual_ref_finish(frame_vref, frame)` — no-op until
-        // jit.virtual_ref is ported.
+        // `jit.virtual_ref_finish(frame_vref, frame)` — keepalives only at
+        // interp level (both operands are already live in Rust); the JIT
+        // records VIRTUAL_REF_FINISH during tracing.
         self._revdb_leave(got_exception);
         trace_result
     }

--- a/pyre/pyre-interpreter/src/module/pypyjit/mod.rs
+++ b/pyre/pyre-interpreter/src/module/pypyjit/mod.rs
@@ -16,7 +16,9 @@
 ///   * `set_param(name=value, ...)` — keyword arguments.
 ///
 /// Both forms funnel through the JIT's authoritative `set_user_param` parser
-/// (`call::set_jit_param_string`) so no parameter table is duplicated here.
+/// (`call::set_jit_param_string`); the keyword form additionally validates each
+/// name against `unroll_parameters`, reading the JIT's own table rather than
+/// duplicating it.
 fn set_param(
     args: &[pyre_object::PyObjectRef],
 ) -> Result<pyre_object::PyObjectRef, crate::PyError> {
@@ -41,10 +43,12 @@ fn set_param(
         }
     }
 
-    // interp_jit.py:157-167 — keyword arguments. Re-serialize each `name=value`
+    // interp_jit.py:159-170 — keyword arguments. Re-serialize each `name=value`
     // pair into one parameter string so the JIT-side parser stays the single
     // source of truth. `enable_opts` carries a string value; every other
-    // parameter is an integer (`space.int_w` rejects a non-int value here).
+    // parameter is an integer (`space.int_w` rejects a non-int value here) whose
+    // name is looked up in `unroll_parameters` (rlib/jit.py:606) before it is
+    // accepted.
     if let Some(kw_dict) = kwds {
         let mut parts: Vec<String> = Vec::new();
         for (k, v) in unsafe { pyre_object::dictmultiobject::w_dict_items(kw_dict) } {
@@ -60,6 +64,14 @@ fn set_param(
                 parts.push(format!("{key}={value}"));
             } else {
                 let value = crate::baseobjspace::int_w(v)?;
+                let known = majit_metainterp::jit::UNROLL_PARAMETERS
+                    .iter()
+                    .any(|&(name, _)| name == key && name != "enable_opts");
+                if !known {
+                    return Err(crate::PyError::type_error(format!(
+                        "no JIT parameter '{key}'"
+                    )));
+                }
                 parts.push(format!("{key}={value}"));
             }
         }

--- a/pyre/pyre-interpreter/src/pyframe.rs
+++ b/pyre/pyre-interpreter/src/pyframe.rs
@@ -505,8 +505,11 @@ unsafe fn alloc_frame_locals_array(
     unsafe { alloc_fixed_array_with_header(len, fill) }
 }
 
+/// Write barrier for a batch of stores into a frame's
+/// `locals_cells_stack_w`: the array is its own GC object, so an old array
+/// receiving young values must join the remembered set.
 #[inline]
-fn remember_frame_locals_array(array: *mut FixedObjectArray) {
+pub fn remember_frame_locals_array(array: *mut FixedObjectArray) {
     if pyre_object::gc_hook::try_gc_owns_object(array as *mut u8) {
         pyre_object::gc_hook::try_gc_write_barrier(array as *mut u8);
     }
@@ -2942,10 +2945,15 @@ impl PyFrame {
         unsafe { (*self.execution_context).get_builtin() }
     }
 
-    /// PyPy-compatible `get_f_back`.
+    /// `frame.f_backref()` — force the caller vref.  `f_backref` holds a
+    /// `jit.virtual_ref`; calling it materializes the caller frame (identity
+    /// at interp level, `force_virtual` once the JIT virtualized it).  Callers
+    /// that need the raw unforced vref (e.g. `ExecutionContext::leave`'s
+    /// `topframeref = frame.f_backref` restore, no parens) read the field
+    /// directly instead.
     #[inline]
     pub fn get_f_back(&self) -> *mut PyFrame {
-        self.f_backref
+        crate::executioncontext::force_vref(self.f_backref)
     }
 
     /// pyframe.py:768-771 `fget_f_builtins` — `self.get_builtin()

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -1720,8 +1720,11 @@ fn try_adopt_multi_frame_blackhole(ctx: &mut TraceCtx, cf_addr: usize) -> bool {
     unsafe {
         for i in 0..per_frame.len() {
             let callee = per_frame[i].0 as *mut pyre_interpreter::PyFrame;
-            let f_back = if i == 0 { cf_addr as i64 } else { per_frame[i - 1].0 }
-                as *mut pyre_interpreter::PyFrame;
+            let f_back = if i == 0 {
+                cf_addr as i64
+            } else {
+                per_frame[i - 1].0
+            } as *mut pyre_interpreter::PyFrame;
             if std::ptr::eq(callee, f_back) {
                 continue;
             }

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -1454,10 +1454,23 @@ fn seed_loop_entry_ref_slots(
     }
 }
 
-fn apply_single_frame_blackhole_crn(
+/// Materialize a blackhole `ContinueRunningNormally` handoff into the live
+/// interpreter frame: write every live local / operand-stack slot from the
+/// terminal register banks, then move the frame to the resume coordinate.
+///
+/// Shared by the single-frame and multi-frame adopt paths — the multi-frame
+/// chain's terminal frame is the portal level, so it needs the exact same
+/// treatment (a chain whose inner levels committed through their own
+/// virtualizable still leaves the portal's `valuestackdepth` at the aborted
+/// mid-expression value).
+fn apply_blackhole_crn(
     frame: usize,
     jitcode_index: i32,
-    terminal: &mut majit_metainterp::SingleFrameBlackholeResult,
+    position: usize,
+    last_opcode_position: usize,
+    registers_i: &[i64],
+    registers_r: &mut [i64],
+    registers_f: &[i64],
     resume_py_pc: usize,
 ) -> bool {
     if frame == 0 {
@@ -1486,8 +1499,8 @@ fn apply_single_frame_blackhole_crn(
     if pf.locals_w().as_slice().len() < live_end {
         return false;
     }
-    let pcdep = crate::state::pcdep_trivia_at(jitcode_index, terminal.last_opcode_position as i32)
-        .or_else(|| crate::state::pcdep_trivia_at(jitcode_index, terminal.position as i32));
+    let pcdep = crate::state::pcdep_trivia_at(jitcode_index, last_opcode_position as i32)
+        .or_else(|| crate::state::pcdep_trivia_at(jitcode_index, position as i32));
     let Some(pcdep) = pcdep else {
         return false;
     };
@@ -1503,9 +1516,9 @@ fn apply_single_frame_blackhole_crn(
         }
         let color = color as usize;
         let present = match bank {
-            0 => color < terminal.registers_i.len(),
-            1 => color < terminal.registers_r.len(),
-            2 => color < terminal.registers_f.len(),
+            0 => color < registers_i.len(),
+            1 => color < registers_r.len(),
+            2 => color < registers_f.len(),
             _ => false,
         };
         if !present {
@@ -1521,16 +1534,19 @@ fn apply_single_frame_blackhole_crn(
 
     let root_depth = majit_gc::shadow_stack::resume_ref_roots_depth();
     unsafe {
-        majit_gc::shadow_stack::push_resume_ref_roots(terminal.registers_r.as_mut_slice());
+        majit_gc::shadow_stack::push_resume_ref_roots(registers_r);
     }
     for (slot, bank, color) in writes {
         let value = match bank {
-            0 => majit_ir::Value::Int(terminal.registers_i[color]),
-            1 => majit_ir::Value::Ref(majit_ir::GcRef(terminal.registers_r[color] as usize)),
-            2 => majit_ir::Value::Float(f64::from_bits(terminal.registers_f[color] as u64)),
+            0 => majit_ir::Value::Int(registers_i[color]),
+            1 => majit_ir::Value::Ref(majit_ir::GcRef(registers_r[color] as usize)),
+            2 => majit_ir::Value::Float(f64::from_bits(registers_f[color] as u64)),
             _ => unreachable!("validated blackhole register bank"),
         };
         pf.locals_w_mut()[slot] = crate::state::boxed_slot_value_for_type(value.get_type(), &value);
+        // Per store, not once after the loop: boxing the next slot can collect,
+        // which re-arms the array's write barrier.
+        pyre_interpreter::remember_frame_locals_array(pf.locals_cells_stack_w);
     }
     majit_gc::shadow_stack::pop_resume_ref_roots_to(root_depth);
     pf.valuestackdepth = live_end;
@@ -1575,10 +1591,14 @@ fn try_adopt_single_frame_blackhole(ctx: &mut TraceCtx, cf_addr: usize) -> bool 
                 return false;
             };
             let resume_py_pc = resume_py_pc as usize;
-            if !apply_single_frame_blackhole_crn(
+            if !apply_blackhole_crn(
                 cf_addr,
                 jitcode_index,
-                &mut terminal,
+                terminal.position,
+                terminal.last_opcode_position,
+                &terminal.registers_i,
+                terminal.registers_r.as_mut_slice(),
+                &terminal.registers_f,
                 resume_py_pc,
             ) {
                 return false;
@@ -1646,12 +1666,92 @@ fn try_adopt_multi_frame_blackhole(ctx: &mut TraceCtx, cf_addr: usize) -> bool {
     let Some(stack_base) = crate::state::concrete_nlocals(cf_addr) else {
         return false;
     };
+    // Recover each level's concrete PyFrame ptr and its own fastlocals base.
+    // `build_multi_frame_miframe` emits one frame per inline level's CALLER
+    // plus the innermost callee, so `frames.last()` is the frame being
+    // sub-walked and `frames[0]` is either the walked frame `cf_addr` itself
+    // or — when the inline sits inside a residual call the walk descended
+    // into — that intermediate frame.  Any level whose frame register is not
+    // a concrete PyFrame declines the adopt (legacy replay handles it).
+    let mut per_frame: Vec<(i64, usize)> = Vec::with_capacity(latched.framestack.frames.len());
+    for frame in &latched.framestack.frames {
+        let Ok(jitcode_index) = i32::try_from(frame.jitcode.index()) else {
+            return false;
+        };
+        let frame_reg = crate::state::portal_red_regs_at(jitcode_index).0;
+        if frame_reg == u16::MAX {
+            return false;
+        }
+        let Some(frame_ptr) = frame.ref_values.get(frame_reg as usize).copied().flatten() else {
+            return false;
+        };
+        if frame_ptr == 0 {
+            return false;
+        }
+        let Some(frame_stack_base) = crate::state::concrete_nlocals(frame_ptr as usize) else {
+            return false;
+        };
+        per_frame.push((frame_ptr, frame_stack_base));
+    }
+    // A chain rooted at an intermediate frame means the walk descended into a
+    // residual call and inlined inside it.  Two things then do not hold:
+    // `resume_py_pc` is a coordinate in `frames[0]`'s code while the restart
+    // moves `cf_addr`, and — because the walker executes residuals CONCRETELY
+    // while an inline push never runs the interpreter's call sequence — a
+    // `sys._getframe()` inside the inlined body already read `ec.topframeref`
+    // as the CALLER and committed the wrong frame object, which the adopt
+    // would then publish.  Bracketing each inline level's concrete frame with
+    // an `enter`/`leave` does not fix it: levels that run without a
+    // materialized frame have nothing to publish, so the chain stays short by
+    // one and shifts every `_getframe` result up a level.  Closing this needs
+    // the `jit.virtual_ref` emit at the inline push, so decline to legacy
+    // replay until then.
+    if per_frame.first().map(|&(frame_ptr, _)| frame_ptr) != Some(cf_addr as i64) {
+        return false;
+    }
+    // `ExecutionContext::enter` parity for the resumed chain:
+    // `frames[0].f_backref = cf_addr`, `frames[i].f_backref = frames[i - 1]`.
+    // The blackhole re-executes each level's residual `sys._getframe` against
+    // `ec.topframeref`/`f_backref`, so the chain must be live before the run;
+    // it also stays live afterwards for a frame the residual captured.  When
+    // `frames[0]` IS the walked frame it was already entered by its own
+    // caller — linking it would overwrite its `f_backref` with itself and
+    // orphan the frame above it.
+    unsafe {
+        for i in 0..per_frame.len() {
+            let callee = per_frame[i].0 as *mut pyre_interpreter::PyFrame;
+            let f_back = if i == 0 { cf_addr as i64 } else { per_frame[i - 1].0 }
+                as *mut pyre_interpreter::PyFrame;
+            if std::ptr::eq(callee, f_back) {
+                continue;
+            }
+            (*callee).f_backref = f_back;
+            // `enter` stores into a frame whose allocation barrier is still in
+            // effect; these frames were built many collections ago, so each
+            // store needs its own remembered-set entry.
+            if pyre_object::gc_hook::try_gc_owns_object(callee as *mut u8) {
+                pyre_object::gc_hook::try_gc_write_barrier(callee as *mut u8);
+            }
+        }
+    }
+    let ec = unsafe {
+        (*(cf_addr as *mut pyre_interpreter::PyFrame)).execution_context
+            as *mut pyre_interpreter::PyExecutionContext
+    };
+    let saved_topframeref = unsafe { (*ec).topframeref };
+    // `enter`: publish `ec.topframeref = <this level's frame>` before it runs.
+    let set_topframeref = |frame_ptr: i64| unsafe {
+        (*ec).topframeref = frame_ptr as *mut pyre_interpreter::PyFrame;
+    };
     // EXPERIMENT: multi-frame runs full outer-frame bodies, so it needs a
     // full-coverage dispatch table, not the inline-call-only builder.
     let (mut mf_builder, _unwired) =
         crate::jitcode_runtime::build_default_bh_builder_with_unwired_report();
     mf_builder.cpu = Some(majit_metainterp::blackhole::pyre_production_cpu());
-    let outcome = majit_metainterp::drive_multi_frame_blackhole(
+    let majit_metainterp::MultiFrameBlackholeResult {
+        outcome,
+        terminal: mut mf_terminal,
+    } = majit_metainterp::drive_multi_frame_blackhole(
         &mut mf_builder,
         &mut latched.framestack,
         majit_metainterp::blackhole::StateFieldLayout::default(),
@@ -1661,8 +1761,13 @@ fn try_adopt_multi_frame_blackhole(ctx: &mut TraceCtx, cf_addr: usize) -> bool {
         ctx.metainterp_sd().as_ref(),
         latched.last_exc_value,
         latched.raising_exception,
+        Some(per_frame.as_slice()),
+        Some(&set_topframeref as &dyn Fn(i64)),
     );
-
+    // `leave`: restore `ec.topframeref` to the portal after the inline chain.
+    unsafe {
+        (*ec).topframeref = saved_topframeref;
+    }
     let adopted = match outcome {
         majit_metainterp::jitexc::JitException::ContinueRunningNormally {
             ref green_int, ..
@@ -1674,12 +1779,28 @@ fn try_adopt_multi_frame_blackhole(ctx: &mut TraceCtx, cf_addr: usize) -> bool {
             if cf_addr == 0 || resume_py_pc == 0 {
                 return false;
             }
-            // Every frame in the chain uses the live portal virtualizable.
-            // Its setfield_vable operations have already committed the outer
-            // frame state; only the interpreter restart coordinate remains.
-            unsafe {
-                (*(cf_addr as *mut pyre_interpreter::PyFrame)).last_instr =
-                    resume_py_pc as isize - 1;
+            // The terminal frame's own `setfield_vable` operations committed
+            // the frame fields they wrote, but the aborted mid-expression
+            // operand stack is still in place, so the resume coordinate needs
+            // the same live-slot materialization the single-frame path
+            // performs.
+            let Some(terminal) = mf_terminal.as_mut() else {
+                return false;
+            };
+            let Ok(terminal_jitcode_index) = i32::try_from(terminal.jitcode_index) else {
+                return false;
+            };
+            if !apply_blackhole_crn(
+                cf_addr,
+                terminal_jitcode_index,
+                terminal.position,
+                terminal.last_opcode_position,
+                &terminal.registers_i,
+                terminal.registers_r.as_mut_slice(),
+                &terminal.registers_f,
+                resume_py_pc,
+            ) {
+                return false;
             }
             WALK_END_RESTART_PC.with(|slot| slot.set(Some(resume_py_pc)));
             true

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -4474,24 +4474,35 @@ fn apply_jit_param_string(
     } else if text == "default" {
         ws.set_default_params();
     } else {
-        // rlib/jit.py:850-862 — "name=value,name=value"
+        // rlib/jit.py:850-874 — "name=value,name=value"
         for s in text.split(',') {
             let s = s.trim();
             if s.is_empty() {
                 continue;
             }
-            // rlib/jit.py:853 — len(parts) != 2 → raise ValueError
-            let Some((name, value)) = s.split_once('=') else {
-                return Err(());
-            };
-            let value = value.trim();
-            if name == "enable_opts" {
-                ws.set_param_enable_opts(value);
-            } else if let Ok(parsed) = value.parse::<i64>() {
-                ws.set_param(name, parsed);
-            } else {
+            // rlib/jit.py:852-856 — len(parts) != 2 → raise ValueError
+            let parts: Vec<&str> = s.split('=').collect();
+            if parts.len() != 2 {
                 return Err(());
             }
+            let name = parts[0];
+            let value = parts[1].trim();
+            if name == "enable_opts" {
+                ws.set_param_enable_opts(value);
+                continue;
+            }
+            // rlib/jit.py:860-874 — the name must be one of unroll_parameters;
+            // anything else falls through to the loop's `else: raise ValueError`.
+            let known = majit_metainterp::jit::UNROLL_PARAMETERS
+                .iter()
+                .any(|&(name1, _)| name1 == name && name1 != "enable_opts");
+            if !known {
+                return Err(());
+            }
+            let Ok(parsed) = value.parse::<i64>() else {
+                return Err(());
+            };
+            ws.set_param(name, parsed);
         }
     }
     Ok(())


### PR DESCRIPTION
Three stacked slices on the way to retiring the FBW replay-from-entry path.

## 1. `virtualref`, `executioncontext`, `pyframe`: route the frame chain through `force_vref`

`topframeref` and every frame's `f_backref` hold a `jit.virtual_ref`. `_jit_vref.py:40` gives that vref `lowleveltype = OBJECTPTR`, so at interpreter level it is the frame pointer itself and forcing is the identity; `virtualref.py:135 force_virtual_if_necessary` only materializes when the typeptr word is the `JitVirtualRef` vtable.

- `ptr_is_virtual_ref` extracted as a free function so a caller holding no `VirtualRefInfo` can run the typeptr check (`virtualref.py:94-98`).
- `force_vref` + a `FORCE_VREF_HOOK` for the materializing arm, called where PyPy writes `self.topframeref()` / `frame.f_backref()` **with parens** — `gettopframe`, `gettopframe_nohidden`, `leave`'s `frame_vref()` keepalive. `leave`'s `topframeref = frame.f_backref` restore stays unforced (no parens upstream).

## 2. `jit(fbw)`: multi-frame blackhole resume

The multi-frame adopt path drove the blackhole chain but restored only the restart coordinate, and it linked the reconstructed frame chain from the wrong end.

- `BlackholeTerminalImage`, taken from the bottommost frame in `handle_jitexception` before `release_interp` recycles it, so a ContinueRunningNormally handoff can still read that frame's register banks. `drive_multi_frame_blackhole` now returns `MultiFrameBlackholeResult`.
- `apply_single_frame_blackhole_crn` → `apply_blackhole_crn`, called from the multi-frame arm too: the terminal frame is the portal level, whose `valuestackdepth` was left at the aborted mid-expression value, so its operand-stack slots need the same materialization. Plus a remembered-set re-arm after every slot store, since boxing the next slot can collect.
- `build_multi_frame_miframe` emits one frame per inline level's **CALLER**, so `frames[0]` is the walked frame itself; linking it would set `f_backref` to itself and orphan the frame above. Link `frames[i]` → `frames[i-1]` with `frames[0].f_backref = cf_addr`, skipping the self-link, and publish each level as `ec.topframeref` while it runs.
- Decline the adopt when `frames[0]` is not the walked frame. That shape means the walk descended into a residual call and inlined inside it, where `resume_py_pc` is a coordinate in another frame's code and a `sys._getframe()` in the inlined body already committed the caller's frame object. Legacy replay handles it correctly; closing it needs the `jit.virtual_ref` emit at the inline push.
- `synth/getframe_inlined_callee_own_frame` asserts the literal frame chain an inlined leaf sees. Publishing a frame for only the inline levels that have one shifts every `_getframe` up a level, and that shift is invisible to a JIT-vs-JIT comparison — hence the literal expectation rather than a self-consistency check.

## 3. `pypyjit`, `jit`: reject unknown JIT parameter names

`pypyjit.set_param(no_such_param=1)` serialized the unknown name into the general parameter string, and the string parser handed it to `WarmEnterState::set_param`, whose fallthrough arm dropped it. Both the keyword and the positional-string form silently accepted any name.

- Keyword form: look each non-`enable_opts` name up in `UNROLL_PARAMETERS` (`rlib/jit.py:606`) and raise `TypeError("no JIT parameter '<key>'")` (`interp_jit.py:163-170`). The int conversion still runs first, matching upstream ordering.
- String form: port `set_user_param`'s `for name1, _ in unroll_parameters: … else: raise ValueError` loop (`rlib/jit.py:860-874`), and split on `=` requiring exactly two parts (`rlib/jit.py:852-856`) rather than `splitn(2)`, which accepted `enable_opts=a=b`.

Verified against the PyPy oracle: `TypeError: no JIT parameter 'no_such_param'`, `ValueError: error in JIT parameters string`, and the too-many-positional `TypeError` all match verbatim.

## Verification

`python ./pyre/check.py` — **dynasm 309/309, cranelift 309/309, wasm 306/306, 3/3 backend runs**, on `c38f0f2dc8` with LLBC re-extracted for the current source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved frame introspection when accessing the current frame and caller frames during optimized execution.
  - Added support for preserving frame state when resuming multi-level optimized execution.
  - Added validation for JIT parameters supplied through `pypyjit.set_param`.

- **Bug Fixes**
  - Fixed virtualized frame references so frame chains remain accessible and correctly materialized.
  - Improved restoration of local values and execution positions after optimized code exits or resumes.
  - Invalid JIT parameter names now raise a clear `TypeError` instead of being silently accepted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->