### PR TITLE
import: get_frozen_object data, non-package parent rejection, sys.path[0] for -c/REPL, relative import head, __main__.__loader__

### DIFF
--- a/pyre/pyre-interpreter/src/importing.rs
+++ b/pyre/pyre-interpreter/src/importing.rs
@@ -1155,7 +1155,11 @@ fn canonical_startup_dir(dir: &Path) -> String {
     dir.to_string_lossy().into_owned()
 }
 
-pub fn init_sys_path(script_dir: &Path) {
+/// `script_dir` is the shadowing-check anchor (`config->sys_path_0`'s
+/// directory); `path0` is the literal entry `add_sys_path_0` later prepends to
+/// `sys.path` — `""` for `-c` / stdin / the REPL, the cwd for `-m`, the
+/// script's directory for a script.
+pub fn init_sys_path(script_dir: &Path, path0: &str) {
     // Register builtin modules (PyPy: make_builtins / setup_builtin_modules)
     install_builtin_modules();
 
@@ -1167,34 +1171,21 @@ pub fn init_sys_path(script_dir: &Path) {
         *p.borrow_mut() = Some(canonical_startup_dir(script_dir));
     });
 
+    // `pymain_run_python` prepends `sys.path[0]` only after `site` has run, so
+    // `site.removeduppaths()` never absolutizes the `-c` / REPL empty entry into
+    // the cwd.  Stage the entry here; `add_sys_path_0` performs the insert.
+    // `-P` (safe_path) suppresses it entirely.
+    SYS_PATH_0_PENDING.with(|p| {
+        *p.borrow_mut() = (!safe_path_flag()).then(|| path0.to_string());
+    });
+
     SYS_PATH.with(|p| {
         let mut path = p.borrow_mut();
         path.clear();
-        if !safe_path_flag() {
-            // Script directory first.
-            path.push(script_dir.to_path_buf());
-            // Current working directory as fallback. Under sandbox read it through
-            // the seam so it resolves to the controller's virtual cwd (`/tmp`)
-            // rather than leaking the trusted parent's real working directory.
-            #[cfg(feature = "sandbox")]
-            let cwd = {
-                use std::os::unix::ffi::OsStrExt;
-                crate::host_seam::ops::getcwd()
-                    .ok()
-                    .map(|b| PathBuf::from(std::ffi::OsStr::from_bytes(&b)))
-            };
-            #[cfg(not(feature = "sandbox"))]
-            let cwd = host_os::current_dir().ok();
-            if let Some(cwd) = cwd {
-                if cwd != script_dir {
-                    path.push(cwd);
-                }
-            }
-        }
-        // PYTHONPATH entries follow the script/cwd seed and precede the
-        // stdlib (pathconfig.c), split on the platform path-list separator.
-        // Honoured regardless of the safe-path flag, which only suppresses the
-        // script/cwd seed, but skipped under `-E` / `-I` (ignore_environment),
+        // PYTHONPATH entries head the seed and precede the stdlib
+        // (pathconfig.c), split on the platform path-list separator.  Honoured
+        // regardless of the safe-path flag, which only suppresses the
+        // `sys.path[0]` entry, but skipped under `-E` / `-I` (ignore_environment),
         // which ignore every `PYTHON*` variable. The sandbox interpreter takes
         // its search path from the controller, so it does not read the host
         // environment here.
@@ -1340,6 +1331,44 @@ pub fn add_sys_path(dir: &Path) {
         }
     }
     unsafe { pyre_object::listobject::w_list_append(w_path, shadow_stack_get(slot)) };
+}
+
+/// `pymain_sys_path_add_path0` — prepend the startup `sys.path[0]` entry staged
+/// by `init_sys_path`.  Called after `site` has run so `removeduppaths` cannot
+/// absolutize an empty entry into the cwd, and inserted unconditionally (no
+/// dedup).  The entry is taken, so a second call is a no-op.
+#[cfg(feature = "host_env")]
+pub fn add_sys_path_0() {
+    use pyre_object::gc_roots::{pin_root, push_roots, shadow_stack_get, shadow_stack_len};
+
+    let Some(entry) = SYS_PATH_0_PENDING.with(|p| p.borrow_mut().take()) else {
+        return;
+    };
+    // No `sys` yet (an embedder that never imports `site`): stage at the front
+    // of the seed instead, which `create_sys_path_list` flushes in order.
+    if get_sys_module("sys").is_none() {
+        SYS_PATH.with(|p| p.borrow_mut().insert(0, PathBuf::from(&entry)));
+        return;
+    }
+    // Pin the new entry before any further allocation (`get_sys_module` and the
+    // dict lookup allocate) can relocate it — `add_sys_path` parity.
+    let _roots = push_roots();
+    let slot = shadow_stack_len();
+    pin_root(pyre_object::w_str_new(&entry));
+    let Some(sys_mod) = get_sys_module("sys") else {
+        return;
+    };
+    let w_dict = unsafe { pyre_object::w_module_get_w_dict(sys_mod) };
+    if w_dict.is_null() {
+        return;
+    }
+    let Some(w_path) = (unsafe { pyre_object::w_dict_getitem_str(w_dict, "path") }) else {
+        return;
+    };
+    if !unsafe { pyre_object::is_list(w_path) } {
+        return;
+    }
+    unsafe { pyre_object::listobject::w_list_insert(w_path, 0, shadow_stack_get(slot)) };
 }
 
 // ── check_sys_modules ────────────────────────────────────────────────
@@ -1555,6 +1584,12 @@ thread_local! {
     /// `init_sys_path`; read by the shadowing check, which must not see later
     /// `sys.path` mutations.
     static SYS_PATH_0: RefCell<Option<String>> = const { RefCell::new(None) };
+    /// The literal `sys.path[0]` entry staged by `init_sys_path` and prepended
+    /// by `add_sys_path_0` once `site` has run (`pymain_sys_path_add_path0`):
+    /// `""` for `-c` / stdin / the REPL, the cwd for `-m`, the script's
+    /// directory for a script.  `None` under `-P`, and taken on first insert so
+    /// the `-i` REPL-after-script path does not prepend it twice.
+    static SYS_PATH_0_PENDING: RefCell<Option<String>> = const { RefCell::new(None) };
 }
 
 // The launcher flags belong to the interpreter, not to whichever thread

--- a/pyre/pyre-interpreter/src/importing.rs
+++ b/pyre/pyre-interpreter/src/importing.rs
@@ -2923,6 +2923,25 @@ pub fn dunder_import(
         {
             let import_slot = shadow_stack_len();
             pin_root(w_import);
+            // `PyImport_ImportModuleLevelObject`: a relative import with an
+            // empty fromlist hands back the head package named by the *resolved
+            // absolute name*, and the imported module itself when `name` carries
+            // no dot.  `_bootstrap.__import__` reaches the same slice through
+            // `module.__name__`, so a `sys.modules` entry that is not a module
+            // raises AttributeError there instead of the KeyError the
+            // interpreter entry point reports.
+            if level > 0
+                && !name.is_empty()
+                && !(!fromlist_missing
+                    && crate::baseobjspace::is_true(shadow_stack_get(fromlist_slot))?)
+            {
+                return relative_import_head(
+                    shadow_stack_get(bootstrap_slot),
+                    name,
+                    shadow_stack_get(globals_slot),
+                    level,
+                );
+            }
             let w_name = pyre_object::w_str_new(name);
             let name_slot = shadow_stack_len();
             pin_root(w_name);
@@ -2967,6 +2986,122 @@ pub fn dunder_import(
         level,
         execution_context,
     )
+}
+
+/// `PyImport_ImportModuleLevelObject`, the `level > 0` / empty-fromlist tail:
+/// import `name` relative to `globals`, then return the head package named by
+/// the absolute name the resolution produced.
+///
+/// `_bootstrap.__import__` spells the same slice as
+/// `sys.modules[module.__name__[:len(module.__name__) - cut_off]]`, which
+/// requires the loaded object to carry `__name__`.  A `sys.modules` entry that
+/// is not a module has none, so the interpreter entry point slices the name it
+/// resolved itself and reports a missing head as a KeyError.
+fn relative_import_head(
+    w_bootstrap: PyObjectRef,
+    name: &str,
+    w_globals: PyObjectRef,
+    level: i64,
+) -> Result<PyObjectRef, crate::PyError> {
+    use pyre_object::gc_roots::{pin_root, push_roots, shadow_stack_get, shadow_stack_len};
+
+    let _roots = push_roots();
+    let bootstrap_slot = shadow_stack_len();
+    pin_root(w_bootstrap);
+    // `_bootstrap.__import__` — `globals_ = globals if globals is not None else {}`.
+    let globals_slot = shadow_stack_len();
+    pin_root(if w_globals.is_null() || unsafe { is_none(w_globals) } {
+        pyre_object::w_dict_new()
+    } else {
+        w_globals
+    });
+    let name_slot = shadow_stack_len();
+    pin_root(pyre_object::w_str_new(name));
+    let level_slot = shadow_stack_len();
+    pin_root(pyre_object::w_int_new(level));
+
+    // `_bootstrap.__import__` — `package = _calc___package__(globals_)`.
+    let w_calc =
+        crate::baseobjspace::getattr_str(shadow_stack_get(bootstrap_slot), "_calc___package__")?;
+    let calc_slot = shadow_stack_len();
+    pin_root(w_calc);
+    let w_package = crate::call::call_function_impl_result(
+        shadow_stack_get(calc_slot),
+        &[shadow_stack_get(globals_slot)],
+    )
+    .map_err(strip_bootstrap_traceback_frames)?;
+    let package_slot = shadow_stack_len();
+    pin_root(w_package);
+
+    // `_bootstrap.__import__` — `module = _gcd_import(name, package, level)`.
+    // `_sanity_check` / `_resolve_name` validate `package` and `level` in there,
+    // so running it before the slice below keeps their diagnostics first.
+    let w_gcd = crate::baseobjspace::getattr_str(shadow_stack_get(bootstrap_slot), "_gcd_import")?;
+    let gcd_slot = shadow_stack_len();
+    pin_root(w_gcd);
+    let w_module = crate::call::call_function_impl_result(
+        shadow_stack_get(gcd_slot),
+        &[
+            shadow_stack_get(name_slot),
+            shadow_stack_get(package_slot),
+            shadow_stack_get(level_slot),
+        ],
+    )
+    .map_err(strip_bootstrap_traceback_frames)?;
+    let module_slot = shadow_stack_len();
+    pin_root(w_module);
+
+    // No dot in `name`: the imported module is already the head.
+    let Some(dot) = name.find('.') else {
+        return Ok(shadow_stack_get(module_slot));
+    };
+
+    // `_resolve_name(name, package, level)` is the absolute name just imported;
+    // it ends with `name`, so trimming from `name`'s first dot leaves the head.
+    let w_resolve =
+        crate::baseobjspace::getattr_str(shadow_stack_get(bootstrap_slot), "_resolve_name")?;
+    let resolve_slot = shadow_stack_len();
+    pin_root(w_resolve);
+    let w_abs_name = crate::call::call_function_impl_result(
+        shadow_stack_get(resolve_slot),
+        &[
+            shadow_stack_get(name_slot),
+            shadow_stack_get(package_slot),
+            shadow_stack_get(level_slot),
+        ],
+    )
+    .map_err(strip_bootstrap_traceback_frames)?;
+    let abs_slot = shadow_stack_len();
+    pin_root(w_abs_name);
+    // Owned: the slicing below outlives the allocations that follow it.
+    let abs_name = crate::baseobjspace::utf8_w(shadow_stack_get(abs_slot))?.to_string();
+    let cut_off = name.len() - dot;
+    let head = abs_name
+        .len()
+        .checked_sub(cut_off)
+        .and_then(|end| abs_name.get(..end))
+        .unwrap_or(abs_name.as_str());
+
+    let head_slot = shadow_stack_len();
+    pin_root(pyre_object::w_str_new(head));
+    // The raw `sys.modules` entry, `None` sentinel included: only a *missing*
+    // key is the KeyError.
+    let w_modules = sys_modules_dict();
+    let found = if w_modules.is_null() {
+        check_sys_modules(head)
+    } else {
+        unsafe {
+            pyre_object::dictmultiobject::w_dict_lookup(w_modules, shadow_stack_get(head_slot))
+        }
+        .filter(|w| !w.is_null())
+    };
+    if let Some(w_found) = found {
+        return Ok(w_found);
+    }
+    let head_repr = unsafe { crate::display::py_repr(shadow_stack_get(head_slot)) }?;
+    Err(crate::PyError::key_error(format!(
+        "{head_repr} not in sys.modules as expected"
+    )))
 }
 
 // ── importhook ───────────────────────────────────────────────────────

--- a/pyre/pyre-interpreter/src/importing.rs
+++ b/pyre/pyre-interpreter/src/importing.rs
@@ -1905,9 +1905,10 @@ pub(crate) fn create_sys_path_list() -> PyObjectRef {
 
 /// Extract a package module's `__path__` as filesystem directories.
 ///
-/// Returns `None` when the module is not a package (no `__path__` list), so
-/// the caller can fall back to the top-level (sys.path) search for the rare
-/// builtin packages that carry no on-disk `__path__`.
+/// Returns `None` when `__path__` is absent or is not a plain list of `str`.
+/// `absolute_import` rejects the absent case up front ("'<parent>' is not a
+/// package"), so a `None` reaching the caller means a package whose `__path__`
+/// yielded no usable directories.
 fn parent_package_path(parent: PyObjectRef) -> Option<Vec<PathBuf>> {
     let w_dict = unsafe { pyre_object::w_module_get_w_dict(parent) };
     if w_dict.is_null() || !unsafe { pyre_object::is_dict(w_dict) } {
@@ -2590,7 +2591,33 @@ fn absolute_import(
         let full_name = prefix.join(".");
         // A submodule is resolved against its parent package's `__path__`;
         // top-level names (level 0, no parent) search sys.path.
-        let parent_dirs = parent.and_then(parent_package_path);
+        //
+        // `_bootstrap._find_and_load_unlocked` fixes the order: a sys.modules
+        // hit for the full name wins first (`load_part` answers both the cached
+        // entry and the blocked-name sentinel), and only then must the parent be
+        // a package. Presence of `__path__` is the whole test — a PEP 420
+        // `_NamespacePath` (or any other non-list value) still marks a package
+        // even though `parent_package_path` cannot turn it into directories.
+        // Without the check a dotted name whose parent is a plain module falls
+        // back to the top-level search and can resolve to a same-leaf builtin.
+        let parent_dirs = match parent {
+            None => None,
+            Some(_)
+                if check_sys_modules(&full_name).is_some() || sys_modules_blocks(&full_name) =>
+            {
+                None
+            }
+            Some(parent_mod) => {
+                if crate::baseobjspace::findattr_result(parent_mod, "__path__")?.is_none() {
+                    let parent_name = parts[..level].join(".");
+                    return Err(crate::PyError::module_not_found_with_name(
+                        format!("No module named '{full_name}'; '{parent_name}' is not a package"),
+                        &full_name,
+                    ));
+                }
+                parent_package_path(parent_mod)
+            }
+        };
         let w_mod = load_part(&full_name, part, parent_dirs.as_deref(), execution_context)?;
         let Some(module) = w_mod else {
             // _bootstrap.py:1335 raises for the prefix that actually failed

--- a/pyre/pyre-interpreter/src/module/imp/interp_imp.rs
+++ b/pyre/pyre-interpreter/src/module/imp/interp_imp.rs
@@ -144,18 +144,54 @@ fn frozen_name(args: &[pyre_object::PyObjectRef], function: &str) -> Result<Stri
     };
     if !unsafe { pyre_object::is_str(name) } {
         return Err(crate::PyError::type_error(format!(
-            "{function}() argument 1 must be str"
+            "{function}() argument 1 must be str, not {}",
+            bad_argument_type_name(name)
         )));
     }
     Ok(unsafe { pyre_object::w_str_get_value(name) }.to_owned())
 }
 
-fn missing_frozen_error(name: &str) -> crate::PyError {
+/// `set_frozen_error` — both frozen diagnostics carry the module name as
+/// `.name` with no `.path`, and render it the way `%R` does.
+fn frozen_error(message: String, name: &str) -> crate::PyError {
     crate::PyError::import_error_name_path(
-        format!("No such frozen object named {name:?}"),
+        message,
         pyre_object::w_str_new(name),
         pyre_object::w_none(),
     )
+}
+
+/// `%R` on the module name: quote selection and escaping identical to
+/// `repr(str)`, which Rust's `{:?}` does not reproduce (it always
+/// double-quotes).
+fn frozen_name_repr(name: &str) -> String {
+    let w_name = pyre_object::w_str_new(name);
+    crate::display::format_wtf8_repr(unsafe { pyre_object::w_str_get_wtf8(w_name) })
+}
+
+fn missing_frozen_error(name: &str) -> crate::PyError {
+    frozen_error(
+        format!("No such frozen object named {}", frozen_name_repr(name)),
+        name,
+    )
+}
+
+/// `set_frozen_error(FROZEN_INVALID)` — the frozen data was supplied by the
+/// caller but does not unmarshal.
+fn invalid_frozen_error(name: &str) -> crate::PyError {
+    frozen_error(
+        format!("Frozen object named {} is invalid", frozen_name_repr(name)),
+        name,
+    )
+}
+
+/// The type name `_PyArg_BadArgument` prints for a rejected argument: `None`
+/// rather than `NoneType`.
+fn bad_argument_type_name(obj: pyre_object::PyObjectRef) -> String {
+    if unsafe { pyre_object::is_none(obj) } {
+        return "None".to_string();
+    }
+    type_name(obj)
 }
 
 /// The receiver's type name, for argument-type error messages.
@@ -336,7 +372,48 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
         crate::make_builtin_function_with_arity(
             "get_frozen_object",
             |args| {
-                let name = frozen_name(args, "get_frozen_object")?;
+                let (positional, kwargs) = crate::builtins::split_builtin_kwargs(args);
+                if crate::builtins::has_real_kwargs(kwargs) {
+                    return Err(crate::PyError::type_error(
+                        "_imp.get_frozen_object() takes no keyword arguments",
+                    ));
+                }
+                if positional.len() > 2 {
+                    return Err(crate::PyError::type_error(format!(
+                        "get_frozen_object expected at most 2 arguments, got {}",
+                        positional.len()
+                    )));
+                }
+                let name = frozen_name(positional, "get_frozen_object")?;
+                // `_imp_get_frozen_object_impl`: a `data` buffer stands in for
+                // the frozen table entry, so those bytes are unmarshalled
+                // directly and a stream that does not decode reports the object
+                // as invalid rather than as missing.
+                let data = positional
+                    .get(1)
+                    .copied()
+                    .filter(|&data| !unsafe { pyre_object::is_none(data) });
+                if let Some(data) = data {
+                    let Some(buffer) = crate::typedef::buffer_as_bytes_like(data)? else {
+                        return Err(crate::PyError::type_error(format!(
+                            "get_frozen_object() argument 2 must be bytes, not {}",
+                            bad_argument_type_name(data)
+                        )));
+                    };
+                    // Owned before the unmarshal allocates: the buffer may be a
+                    // freshly minted bytes that nothing roots.
+                    let bytes =
+                        unsafe { pyre_object::bytesobject::bytes_like_data(buffer) }.to_vec();
+                    let code = crate::module::marshal::loads_bytes(&bytes)
+                        .map_err(|_| invalid_frozen_error(&name))?;
+                    if !unsafe { crate::is_code(code) } {
+                        return Err(crate::PyError::type_error(format!(
+                            "frozen object {} is not a code object",
+                            frozen_name_repr(&name)
+                        )));
+                    }
+                    return Ok(code);
+                }
                 let entry =
                     served_frozen_module(&name).ok_or_else(|| missing_frozen_error(&name))?;
                 let (source, code_name) = frozen_source(entry)?;

--- a/pyre/pyre-interpreter/src/module/marshal/mod.rs
+++ b/pyre/pyre-interpreter/src/module/marshal/mod.rs
@@ -514,6 +514,16 @@ fn loads_impl(args: &[PyObjectRef]) -> PyResult {
     Ok(result)
 }
 
+/// `PyMarshal_ReadObjectFromString` — deserialize one object out of a raw byte
+/// buffer.  `_imp.get_frozen_object` unmarshals caller-supplied frozen data
+/// through this and rewrites any failure into its own diagnostic.
+pub(crate) fn loads_bytes(data: &[u8]) -> PyResult {
+    let _roots = pyre_object::gc_roots::push_roots();
+    let mut reader: &[u8] = data;
+    let result = wire::deserialize_value(&mut reader, PyreMarshalBag).map_err(marshal_error)?;
+    Ok(result.get())
+}
+
 fn dump_impl(args: &[PyObjectRef]) -> PyResult {
     let (positional, kwargs) = crate::builtins::split_builtin_kwargs(args);
     crate::builtins::kwarg_reject_unknown(kwargs, &["version", "allow_code"], "dump")?;

--- a/pyre/pyre-jit/tests/gc_stress.rs
+++ b/pyre/pyre-jit/tests/gc_stress.rs
@@ -50,7 +50,10 @@ fn run_harness(program: &str, name: &str, vacuity_label: &str) -> Result<(), Str
     reset_gc_fresh_for_test();
 
     let cwd = std::env::current_dir().map_err(|e| e.to_string())?;
-    importing::init_sys_path(&cwd);
+    importing::init_sys_path(&cwd, &cwd.to_string_lossy());
+    // This harness never imports `site`, so perform the post-site `sys.path[0]`
+    // insert directly.
+    importing::add_sys_path_0();
     importing::set_sys_argv(&[name.to_string()]);
 
     let code = compile_source_with_filename(program, Mode::Exec, name)

--- a/pyre/pyrex/src/lib.rs
+++ b/pyre/pyrex/src/lib.rs
@@ -544,9 +544,11 @@ fn real_main(binary_name: &str) {
 
     match mode {
         RunMode::Command(cmd) => {
-            // Initialize sys.path with CWD for -c mode.
+            // `_PyPathConfig_ComputeSysPath0` yields "" for a `-c` argv[0]. The
+            // cwd is still the anchor the shadowing check compares module
+            // origins against.
             let cwd = sys_path_cwd();
-            importing::init_sys_path(&cwd);
+            importing::init_sys_path(&cwd, "");
             let mut argv = vec!["-c".to_string()];
             argv.extend(args);
             importing::set_sys_argv(&argv);
@@ -559,7 +561,7 @@ fn real_main(binary_name: &str) {
             // `-m`: sys.path[0] is the cwd (runpy resets argv[0] to the
             // module's resolved origin via `_run_module_as_main`).
             let cwd = sys_path_cwd();
-            importing::init_sys_path(&cwd);
+            importing::init_sys_path(&cwd, &cwd.to_string_lossy());
             let mut argv = vec![module.clone()];
             argv.extend(args);
             importing::set_sys_argv(&argv);
@@ -593,12 +595,20 @@ fn real_main(binary_name: &str) {
                 .unwrap_or(Path::new("."))
                 .to_path_buf();
             #[cfg(not(feature = "sandbox"))]
-            let script_dir = Path::new(&path)
-                .parent()
-                .unwrap_or(Path::new("."))
-                .canonicalize()
-                .unwrap_or_else(|_| Path::new(".").to_path_buf());
-            importing::init_sys_path(&script_dir);
+            let script_dir = {
+                // `parent()` of a bare `x.py` is the empty path;
+                // `_PyPathConfig_ComputeSysPath0` absolutizes the script's
+                // directory, so resolve the empty case against the cwd rather
+                // than leaving a relative `.` on `sys.path`.
+                let parent = Path::new(&path).parent().unwrap_or(Path::new("."));
+                let parent = if parent.as_os_str().is_empty() {
+                    Path::new(".")
+                } else {
+                    parent
+                };
+                parent.canonicalize().unwrap_or_else(|_| sys_path_cwd())
+            };
+            importing::init_sys_path(&script_dir, &script_dir.to_string_lossy());
             // sys.argv[0] is the script path; remaining values go to argv[1:].
             let mut argv = vec![path.clone()];
             argv.extend(args);
@@ -609,9 +619,11 @@ fn real_main(binary_name: &str) {
             }
         }
         RunMode::Repl => {
-            // Initialize sys.path with CWD for REPL mode.
+            // The REPL and piped stdin both take "" for `sys.path[0]`
+            // (`_PyPathConfig_ComputeSysPath0` on an argv[0] of "" / "-"); the
+            // cwd stays the shadowing-check anchor.
             let cwd = sys_path_cwd();
-            importing::init_sys_path(&cwd);
+            importing::init_sys_path(&cwd, "");
             repl::run_repl(quiet, no_site);
         }
         RunMode::Interact {
@@ -746,22 +758,26 @@ fn setup_exec_context() -> Rc<PyExecutionContext> {
     execution_context
 }
 
-/// app_main.py:875-882 — unless `-S` (`no_site`) was given, `import site`
-/// once `__main__` is registered so the standard `site` initialization runs
-/// before user code (sys.path finalization, the `quit`/`exit`/`help`
-/// builtins). The import failing is non-fatal (the bare `except`): print
-/// "'import site' failed" to stderr and continue.
+/// app_main.py — unless `-S` (`no_site`) was given, `import site` once
+/// `__main__` is registered so the standard `site` initialization runs before
+/// user code (sys.path finalization, the `quit`/`exit`/`help` builtins). The
+/// import failing is non-fatal (the bare `except`): print "'import site'
+/// failed" to stderr and continue.
+///
+/// `pymain_run_python` then prepends the startup `sys.path[0]`, so that step
+/// happens here too — after `site`, whose `removeduppaths()` would otherwise
+/// rewrite the `-c` / REPL empty entry into the absolute cwd.
 pub(crate) fn import_site(
     no_site: bool,
     w_main_globals: pyre_object::PyObjectRef,
     ec_ptr: *const pyre_interpreter::PyExecutionContext,
 ) {
-    if no_site {
-        return;
-    }
-    if importing::importhook("site", w_main_globals, pyre_object::PY_NULL, 0, ec_ptr).is_err() {
+    if !no_site
+        && importing::importhook("site", w_main_globals, pyre_object::PY_NULL, 0, ec_ptr).is_err()
+    {
         eprintln!("'import site' failed");
     }
+    importing::add_sys_path_0();
 }
 
 /// Run the `init_importlib` / `init_importlib_external` sequence

--- a/pyre/pyrex/src/lib.rs
+++ b/pyre/pyrex/src/lib.rs
@@ -767,6 +767,46 @@ fn setup_exec_context() -> Rc<PyExecutionContext> {
 /// `pymain_run_python` then prepends the startup `sys.path[0]`, so that step
 /// happens here too — after `site`, whose `removeduppaths()` would otherwise
 /// rewrite the `-c` / REPL empty entry into the absolute cwd.
+/// `add_main_module` / `set_main_loader` — seed `__main__.__loader__`.
+///
+/// BuiltinImporter is the initial setting for every `__main__`; a script run by
+/// path replaces it with a `SourceFileLoader` bound to that file. `-m` is not
+/// covered here: `runpy._run_module_as_main` installs the module's own loader.
+/// Must run after the importlib bootstrap, which is what supplies both classes.
+pub(crate) fn seed_main_loader(
+    w_main_globals: pyre_object::PyObjectRef,
+    script_file: Option<&str>,
+    ec_ptr: *const pyre_interpreter::PyExecutionContext,
+) {
+    use pyre_interpreter::baseobjspace::getattr_str;
+
+    let load = |module: &str, attr: &str| -> Option<pyre_object::PyObjectRef> {
+        importing::importhook(module, w_main_globals, pyre_object::PY_NULL, 0, ec_ptr).ok()?;
+        let w_mod = importing::get_sys_module(module)?;
+        getattr_str(w_mod, attr).ok()
+    };
+
+    let loader = match script_file {
+        Some(path) => load("importlib._bootstrap_external", "SourceFileLoader").and_then(|ty| {
+            pyre_interpreter::call::call_function_impl_result(
+                ty,
+                &[
+                    pyre_object::w_str_new("__main__"),
+                    pyre_object::w_str_new(path),
+                ],
+            )
+            .ok()
+        }),
+        None => load("importlib._bootstrap", "BuiltinImporter"),
+    };
+    let Some(loader) = loader else {
+        return;
+    };
+    unsafe {
+        pyre_object::dictmultiobject::w_dict_setitem_str(w_main_globals, "__loader__", loader);
+    }
+}
+
 pub(crate) fn import_site(
     no_site: bool,
     w_main_globals: pyre_object::PyObjectRef,
@@ -926,7 +966,7 @@ fn run_source(source: &str, mode: Mode, filename: &str, no_site: bool) {
     // (pythonrun.c `_PyRun_SimpleFileObject`); the `-c "<string>"` command
     // path does not. `__file__` is absolutized (os.path.abspath, 3.9+) while
     // `sys.argv[0]` keeps the literal command-line path.
-    if filename != "<string>" {
+    let script_file = if filename != "<string>" {
         // Resolve a relative path against `sys_path_cwd()` — the seam-provided
         // virtual cwd under sandbox — before normalizing, so `std::path::absolute`
         // never consults (and leaks) the trusted process cwd. Off sandbox this is
@@ -951,7 +991,10 @@ fn run_source(source: &str, mode: Mode, filename: &str, no_site: bool) {
             "__cached__",
             pyre_object::w_none(),
         );
-    }
+        Some(abs_file)
+    } else {
+        None
+    };
 
     // Import `sys` up front so its creation flushes the native search-path seed
     // into `sys.path` before `site` and user code read it.
@@ -965,6 +1008,8 @@ fn run_source(source: &str, mode: Mode, filename: &str, no_site: bool) {
     if let Err(e) = init_importlib_bootstrap(canonical, ec_ptr) {
         eprintln!("pyre: importlib bootstrap failed: {}", e.message_text());
     }
+
+    seed_main_loader(canonical, script_file.as_deref(), ec_ptr);
 
     import_site(no_site, canonical, ec_ptr);
 

--- a/pyre/pyrex/src/repl.rs
+++ b/pyre/pyrex/src/repl.rs
@@ -92,6 +92,8 @@ pub fn run_repl(quiet: bool, no_site: bool) {
         eprintln!("pyre: importlib bootstrap failed: {}", e.message_text());
     }
 
+    crate::seed_main_loader(canonical, None, Rc::as_ptr(&execution_context));
+
     crate::import_site(no_site, canonical, Rc::as_ptr(&execution_context));
 
     let runtime = ReplRuntime {


### PR DESCRIPTION
Five `test_import` / `test_importlib` incompatibilities, each a separate commit.

## Changes

- **`_imp.get_frozen_object(name, data)`** — was arity-1 and dropped `data`
  entirely. Caller-supplied buffer data now unmarshals through a new
  `pub(crate) marshal::loads_bytes`; a marshal failure becomes
  `ImportError: Frozen object named %R is invalid`, a non-code result becomes
  `TypeError`. The name is rendered with `display::format_wtf8_repr` because
  Rust's `{:?}` always double-quotes while `%R` picks the quote character.
  Arity and keyword rejection follow `_PyArg_BadArgument`, including the
  `None`-not-`NoneType` type name. → `test_issue105979`

- **Dotted name whose parent is not a package** — `absolute_import` now raises
  `ModuleNotFoundError: No module named 'X.Y'; 'X' is not a package`. Before,
  `parent_package_path` returning `None` was indistinguishable from
  "top-level", so `find_module` matched the builtin table **by the leaf name**
  and `from numpy import array` bound the built-in `array` module as
  `sys.modules['numpy.array']`. The probe tests for `__path__` *presence*
  only — `parent_package_path` also returns `None` for a PEP 420
  `_NamespacePath`, which is a legitimate package.
  → `test_script_shadowing_third_party`

- **`sys.path[0]` for `-c`, stdin and the REPL** — was missing; these now get
  the empty entry. `pymain_run_python` prepends `path0` *after* `site` has
  run, so seeding it earlier is useless: `site.removeduppaths()` absolutizes
  an empty entry into the cwd. `init_sys_path(script_dir, path0)` therefore
  stages the entry (`None` under `-P`) and the new `add_sys_path_0()` performs
  the insert from `import_site`, which also runs under `-S`. Drops the extra
  cwd entry pyre used to push, and absolutizes a bare-filename script's
  directory. `SYS_PATH_0` still holds the canonical cwd, since the shadowing
  check compares against "`sys.path[0]` **or** `os.getcwd()`".
  → `test_script_shadowing_stdlib_cwd_failure`

- **Relative `__import__` head resolution** — new `relative_import_head` ports
  the `level > 0` empty-fromlist tail of `PyImport_ImportModuleLevelObject`.
  `_bootstrap.__import__` slices the head out of `module.__name__`, so a
  non-module planted in `sys.modules` raised `AttributeError`; the native path
  slices the absolute name it resolved itself and raises
  `KeyError: %R not in sys.modules as expected`.
  → `test_malicious_relative_import` ×2

- **`__main__.__loader__`** — was missing for `-c`, the REPL and script runs;
  only `-m` had one, by way of `runpy`. New `seed_main_loader` applies
  `add_main_module`'s `BuiltinImporter` default plus `set_main_loader`'s
  `SourceFileLoader("__main__", abs_file)` for a script, called after
  `init_importlib_bootstrap`. → `test_importlib.test_api.test_everyone_has___loader__` ×2

## Verification

- `check.py` **308/308 dynasm and 308/308 cranelift**, both binaries rebuilt at
  this branch tip and run serially.
- `test_importlib`: **1247 tests run, 1 bad**. That one
  (`extension.test_nonmodule_cases`) is a harness artifact — `run_test_script`
  spawns the child with `-E`, which drops `PYTHONPATH` and with it the C
  extension stubs the suite needs.
- `test_import`: the three real defects above are fixed; the remaining 11 are
  `SubinterpImportTests`, which need
  `_testinternalcapi.run_in_subinterp_with_config` and a real
  `ExtensionFileLoader`.
- 8/8 CPython oracle A/B runs identical; the 10 `get_frozen_object` error
  strings are byte-identical to the oracle. `-P` suppression, `-i` script
  `path0`, and "exactly one `''` under `-c`" all match.
- No regressions in the adjacent suites (`test_cmd_line`, `test_site`,
  `test_runpy`, `test_zipimport`, `test_module`, marshal/frozen/pkgutil), A/B'd
  against a pre-change binary.

## Note on the failure census

Most apparent `test_importlib` failures turned out **not** to be pyre defects:
isolated `-m unittest <leaf>` runs fail on the CPython 3.14.2 oracle too. The
13 `invalidate_caches` errors come from `PathFinder.invalidate_caches` doing a
runtime `from importlib.metadata import MetadataPathFinder` after the test has
emptied `sys.meta_path`/`sys.path`; the 6 hash-pyc failures come from
`test_file_loader.py` using `unittest.mock` without importing it. Both only
pass upstream because whole-package collection pre-warms `sys.modules`. Driving
the suite the way the collection mode actually runs it is what exposed the
`__main__.__loader__` gap, which the isolated driver had hidden.

— *commented by Claude*
